### PR TITLE
fix(sales): only offer, and only accept, versions a sale can discount

### DIFF
--- a/apps/creator-studio/src/lib/components/monetization/SaleFields.svelte
+++ b/apps/creator-studio/src/lib/components/monetization/SaleFields.svelte
@@ -180,9 +180,16 @@
         <IconAlertTriangle />
         <Alert.Title>Applies to {n.applies} of {selectedCount} selected</Alert.Title>
         <Alert.Description>
-          {n.skipped}
-          {n.skipped === 1 ? 'is' : 'are'} in early access, which already prices itself out when the window
-          closes — a sale can't run on top of one.
+          {#if n.earlyAccess > 0}
+            {n.earlyAccess}
+            {n.earlyAccess === 1 ? 'is' : 'are'} in early access, which already prices itself out when
+            the window closes — a sale can't run on top of one.
+          {/if}
+          {#if n.unpriced > 0}
+            {n.unpriced}
+            {n.unpriced === 1 ? 'has' : 'have'} no permanent access price, so there is nothing for a sale
+            to take Buzz off.
+          {/if}
         </Alert.Description>
       </Alert.Root>
     {/if}

--- a/apps/creator-studio/src/lib/monetization/__tests__/sales.test.ts
+++ b/apps/creator-studio/src/lib/monetization/__tests__/sales.test.ts
@@ -7,6 +7,7 @@ import {
   resolveSaleEligibility,
   maxSaleLeadDays,
   minCreatorScoreForSale,
+  parseSalePreview,
   resolveSaleUndercut,
   saleLengthInDays,
   shortenBounds,
@@ -157,13 +158,48 @@ describe('resolveSaleEligibility', () => {
 
     const partial = resolveSaleEligibility({ ...base, earlyAccessCount: 1, unpricedCount: 1 });
     expect(partial.canSchedule).toBe(true);
-    expect(partial.partialNotice).toEqual({ skipped: 2, applies: 3 });
+    // Kept APART, not summed. The notice names one reason per count, and a single `skipped` forced it to
+    // pick one — it told the creator three unpriced versions were in early access.
+    expect(partial.partialNotice).toEqual({ earlyAccess: 1, unpriced: 1, applies: 3 });
+  });
+
+  // The two arms are one keystroke apart and every count stays correct when they are swapped, so the
+  // MESSAGE is what has to be asserted.
+  it('names the reason that actually applies, including when both do', () => {
+    const allEarly = resolveSaleEligibility({ ...base, earlyAccessCount: 5, unpricedCount: 0 });
+    expect(allEarly.blockedReason).toMatch(/early access/);
+    expect(allEarly.blockedReason).not.toMatch(/permanent access price/);
+
+    const allUnpriced = resolveSaleEligibility({ ...base, earlyAccessCount: 0, unpricedCount: 5 });
+    expect(allUnpriced.blockedReason).toMatch(/permanent access price/);
+    expect(allUnpriced.blockedReason).not.toMatch(/early access/);
+
+    const mixed = resolveSaleEligibility({ ...base, earlyAccessCount: 2, unpricedCount: 3 });
+    expect(mixed.blockedReason).toMatch(/early access/);
+    expect(mixed.blockedReason).toMatch(/permanent access price/);
+  });
+
+  // 🔴 A preview that FAILED is not a preview that found nothing in the way. Resetting the counts to 0
+  // on failure read as "all 5 selected versions are covered", offered Apply, and the write then refused
+  // it — and for a Percent sale the floor check that guards the other unknown never runs.
+  it('blocks when the coverage check did not come back', () => {
+    const unknown = resolveSaleEligibility({
+      ...base,
+      type: 'Percent',
+      amount: 20,
+      earlyAccessCount: undefined,
+      unpricedCount: undefined,
+    });
+    expect(unknown.canSchedule).toBe(false);
+    expect(unknown.blockedReason).toMatch(/Couldn't check which versions can go on sale/);
+    expect(unknown.eligibleVersions).toBe(0);
+    expect(unknown.partialNotice).toBeUndefined();
   });
 
   it('still schedules a partly-early-access selection and reports the shortfall', () => {
     const r = resolveSaleEligibility({ ...base, earlyAccessCount: 2 });
     expect(r.canSchedule).toBe(true);
-    expect(r.partialNotice).toEqual({ skipped: 2, applies: 3 });
+    expect(r.partialNotice).toEqual({ earlyAccess: 2, unpriced: 0, applies: 3 });
   });
 
   it('carries no partial notice once it is blocked outright — the reason says it', () => {
@@ -545,5 +581,32 @@ describe('shortenBounds', () => {
 
   it('reports a sale on its final day as unshortenable', () => {
     expect(shortenBounds(sale, new Date('2026-03-13T06:00:00Z')).possible).toBe(false);
+  });
+});
+
+// The `?/salePreview` wire is string-keyed and nothing type-checks it. The page used to read
+// `Number(data?.unpriced ?? 0)`, so renaming the key on the server silently produced zeroes — which
+// resolveSaleEligibility reads as "everything you selected is covered".
+describe('parseSalePreview', () => {
+  const payload = { eligible: 3, earlyAccess: 1, unpriced: 1, minCoveredPrice: 500 };
+
+  it('reads a well-formed payload', () => {
+    expect(parseSalePreview(payload)).toEqual(payload);
+  });
+
+  it('treats a null floor as "none priced", not as missing', () => {
+    expect(parseSalePreview({ ...payload, minCoveredPrice: null })?.minCoveredPrice).toBeNull();
+  });
+
+  // 🔴 undefined, never zeroes. A renamed or dropped key is an answer we did not get, and the form
+  // blocks on that — the whole point of the type on the other side of this wire.
+  it('returns undefined when a count is missing or the wrong shape', () => {
+    const missing: Record<string, unknown> = { ...payload };
+    delete missing.unpriced;
+    expect(parseSalePreview(missing)).toBeUndefined();
+    expect(parseSalePreview({ ...payload, unpriced: '1' })).toBeUndefined();
+    expect(parseSalePreview({ ...payload, eligible: NaN })).toBeUndefined();
+    expect(parseSalePreview(undefined)).toBeUndefined();
+    expect(parseSalePreview(null)).toBeUndefined();
   });
 });

--- a/apps/creator-studio/src/lib/monetization/__tests__/sales.test.ts
+++ b/apps/creator-studio/src/lib/monetization/__tests__/sales.test.ts
@@ -21,6 +21,7 @@ const days = (n: number) => new Date(NOW.getTime() + n * 24 * 60 * 60 * 1000);
 const base = {
   selectedCount: 5,
   earlyAccessCount: 0,
+  unpricedCount: 0,
   creatorScore: 25_000,
   tier: 'bronze',
   daysUsedInMonth: 0,
@@ -124,6 +125,39 @@ describe('resolveSaleEligibility', () => {
       earlyAccessCount: 1,
     });
     expect(one.blockedReason).toMatch(/This version is in early access/);
+  });
+
+  // CU 868kwp6cx. A sale composes over a permanent access price and nothing else, so one scheduled over
+  // versions that have no such price is created, reports itself as covering them, and then discounts
+  // nothing on the card, the model page or the charge. This is the exact shape of the sale a creator
+  // scheduled on 2026-08-25 — 20% off, five versions, no gate on any of them.
+  //
+  // 🔴 If you are removing this because the picker already filters the list: the picker is a list, and
+  // the ids reach this form through the URL. A bookmark, a back button or a price cleared between
+  // picking and submitting all arrive here with a selection the list would no longer show.
+  it('blocks a sale over versions with no access price to discount', () => {
+    const all = resolveSaleEligibility({ ...base, type: 'Percent', amount: 20, unpricedCount: 5 });
+    expect(all.canSchedule).toBe(false);
+    expect(all.blockedReason).toMatch(/None of the selected versions has a permanent access price/);
+
+    const one = resolveSaleEligibility({
+      ...base,
+      selectedCount: 1,
+      unpricedCount: 1,
+    });
+    expect(one.blockedReason).toMatch(/This version has no permanent access price/);
+  });
+
+  // Both counts come off the same total, so adding them rather than taking the larger is what keeps a
+  // selection that is entirely unschedulable from reporting versions it would cover.
+  it('counts unpriced and early-access versions as separate shortfalls', () => {
+    const mixed = resolveSaleEligibility({ ...base, earlyAccessCount: 2, unpricedCount: 3 });
+    expect(mixed.canSchedule).toBe(false);
+    expect(mixed.eligibleVersions).toBe(0);
+
+    const partial = resolveSaleEligibility({ ...base, earlyAccessCount: 1, unpricedCount: 1 });
+    expect(partial.canSchedule).toBe(true);
+    expect(partial.partialNotice).toEqual({ skipped: 2, applies: 3 });
   });
 
   it('still schedules a partly-early-access selection and reports the shortfall', () => {
@@ -237,6 +271,7 @@ describe('resolveSaleDraft', () => {
   const ctx = {
     selectedCount: 5,
     earlyAccessCount: 0,
+    unpricedCount: 0,
     minCoveredPrice: 500,
     creatorScore: 25_000,
     tier: 'bronze',
@@ -426,6 +461,7 @@ describe('the offered last day and the budget agree', () => {
   const ctx = {
     selectedCount: 1,
     earlyAccessCount: 0,
+    unpricedCount: 0,
     minCoveredPrice: 500,
     creatorScore: 25_000,
     tier: 'bronze',

--- a/apps/creator-studio/src/lib/monetization/__tests__/sales.test.ts
+++ b/apps/creator-studio/src/lib/monetization/__tests__/sales.test.ts
@@ -21,6 +21,7 @@ const days = (n: number) => new Date(NOW.getTime() + n * 24 * 60 * 60 * 1000);
 
 const base = {
   selectedCount: 5,
+  eligibleCount: 5,
   earlyAccessCount: 0,
   unpricedCount: 0,
   creatorScore: 25_000,
@@ -116,13 +117,14 @@ describe('resolveSaleEligibility', () => {
   });
 
   it('blocks when every selected version is early access, and speaks in the singular for one', () => {
-    const all = resolveSaleEligibility({ ...base, earlyAccessCount: 5 });
+    const all = resolveSaleEligibility({ ...base, eligibleCount: 0, earlyAccessCount: 5 });
     expect(all.canSchedule).toBe(false);
     expect(all.blockedReason).toMatch(/Every selected version is in early access/);
 
     const one = resolveSaleEligibility({
       ...base,
       selectedCount: 1,
+      eligibleCount: 0,
       earlyAccessCount: 1,
     });
     expect(one.blockedReason).toMatch(/This version is in early access/);
@@ -137,13 +139,20 @@ describe('resolveSaleEligibility', () => {
   // the ids reach this form through the URL. A bookmark, a back button or a price cleared between
   // picking and submitting all arrive here with a selection the list would no longer show.
   it('blocks a sale over versions with no access price to discount', () => {
-    const all = resolveSaleEligibility({ ...base, type: 'Percent', amount: 20, unpricedCount: 5 });
+    const all = resolveSaleEligibility({
+      ...base,
+      type: 'Percent',
+      amount: 20,
+      eligibleCount: 0,
+      unpricedCount: 5,
+    });
     expect(all.canSchedule).toBe(false);
     expect(all.blockedReason).toMatch(/None of the selected versions has a permanent access price/);
 
     const one = resolveSaleEligibility({
       ...base,
       selectedCount: 1,
+      eligibleCount: 0,
       unpricedCount: 1,
     });
     expect(one.blockedReason).toMatch(/This version has no permanent access price/);
@@ -152,11 +161,21 @@ describe('resolveSaleEligibility', () => {
   // Both counts come off the same total, so adding them rather than taking the larger is what keeps a
   // selection that is entirely unschedulable from reporting versions it would cover.
   it('counts unpriced and early-access versions as separate shortfalls', () => {
-    const mixed = resolveSaleEligibility({ ...base, earlyAccessCount: 2, unpricedCount: 3 });
+    const mixed = resolveSaleEligibility({
+      ...base,
+      eligibleCount: 0,
+      earlyAccessCount: 2,
+      unpricedCount: 3,
+    });
     expect(mixed.canSchedule).toBe(false);
     expect(mixed.eligibleVersions).toBe(0);
 
-    const partial = resolveSaleEligibility({ ...base, earlyAccessCount: 1, unpricedCount: 1 });
+    const partial = resolveSaleEligibility({
+      ...base,
+      eligibleCount: 3,
+      earlyAccessCount: 1,
+      unpricedCount: 1,
+    });
     expect(partial.canSchedule).toBe(true);
     // Kept APART, not summed. The notice names one reason per count, and a single `skipped` forced it to
     // pick one — it told the creator three unpriced versions were in early access.
@@ -166,17 +185,47 @@ describe('resolveSaleEligibility', () => {
   // The two arms are one keystroke apart and every count stays correct when they are swapped, so the
   // MESSAGE is what has to be asserted.
   it('names the reason that actually applies, including when both do', () => {
-    const allEarly = resolveSaleEligibility({ ...base, earlyAccessCount: 5, unpricedCount: 0 });
+    const allEarly = resolveSaleEligibility({
+      ...base,
+      eligibleCount: 0,
+      earlyAccessCount: 5,
+      unpricedCount: 0,
+    });
     expect(allEarly.blockedReason).toMatch(/early access/);
     expect(allEarly.blockedReason).not.toMatch(/permanent access price/);
 
-    const allUnpriced = resolveSaleEligibility({ ...base, earlyAccessCount: 0, unpricedCount: 5 });
+    const allUnpriced = resolveSaleEligibility({
+      ...base,
+      eligibleCount: 0,
+      earlyAccessCount: 0,
+      unpricedCount: 5,
+    });
     expect(allUnpriced.blockedReason).toMatch(/permanent access price/);
     expect(allUnpriced.blockedReason).not.toMatch(/early access/);
 
-    const mixed = resolveSaleEligibility({ ...base, earlyAccessCount: 2, unpricedCount: 3 });
+    const mixed = resolveSaleEligibility({
+      ...base,
+      eligibleCount: 0,
+      earlyAccessCount: 2,
+      unpricedCount: 3,
+    });
     expect(mixed.blockedReason).toMatch(/early access/);
     expect(mixed.blockedReason).toMatch(/permanent access price/);
+  });
+
+  // 🔴 The server's own count, never `selected - skipped`. A selected id the creator no longer owns —
+  // deleted, transferred, never theirs — is in neither skip count, so subtracting reports it as covered
+  // and the form names a coverage the write does not deliver.
+  it('takes the covered count from the server rather than subtracting', () => {
+    const stale = resolveSaleEligibility({
+      ...base,
+      selectedCount: 3,
+      eligibleCount: 1,
+      earlyAccessCount: 0,
+      unpricedCount: 1,
+    });
+    expect(stale.eligibleVersions).toBe(1);
+    expect(stale.partialNotice).toEqual({ earlyAccess: 0, unpriced: 1, applies: 1 });
   });
 
   // 🔴 A preview that FAILED is not a preview that found nothing in the way. Resetting the counts to 0
@@ -187,6 +236,7 @@ describe('resolveSaleEligibility', () => {
       ...base,
       type: 'Percent',
       amount: 20,
+      eligibleCount: undefined,
       earlyAccessCount: undefined,
       unpricedCount: undefined,
     });
@@ -197,13 +247,13 @@ describe('resolveSaleEligibility', () => {
   });
 
   it('still schedules a partly-early-access selection and reports the shortfall', () => {
-    const r = resolveSaleEligibility({ ...base, earlyAccessCount: 2 });
+    const r = resolveSaleEligibility({ ...base, eligibleCount: 3, earlyAccessCount: 2 });
     expect(r.canSchedule).toBe(true);
     expect(r.partialNotice).toEqual({ earlyAccess: 2, unpriced: 0, applies: 3 });
   });
 
   it('carries no partial notice once it is blocked outright — the reason says it', () => {
-    const r = resolveSaleEligibility({ ...base, earlyAccessCount: 5 });
+    const r = resolveSaleEligibility({ ...base, eligibleCount: 0, earlyAccessCount: 5 });
     expect(r.partialNotice).toBeUndefined();
   });
 
@@ -306,6 +356,7 @@ describe('resolveSaleEligibility — a sale may never take a version to zero', (
 describe('resolveSaleDraft', () => {
   const ctx = {
     selectedCount: 5,
+    eligibleCount: 5,
     earlyAccessCount: 0,
     unpricedCount: 0,
     minCoveredPrice: 500,
@@ -496,6 +547,7 @@ describe('the offered last day and the budget agree', () => {
   // because the picker told them it was allowed.
   const ctx = {
     selectedCount: 1,
+    eligibleCount: 1,
     earlyAccessCount: 0,
     unpricedCount: 0,
     minCoveredPrice: 500,
@@ -596,6 +648,15 @@ describe('parseSalePreview', () => {
 
   it('treats a null floor as "none priced", not as missing', () => {
     expect(parseSalePreview({ ...payload, minCoveredPrice: null })?.minCoveredPrice).toBeNull();
+  });
+
+  // 🔴 `null` is the value that SKIPS the Fixed zero-floor check, so a garbage floor must not degrade
+  // into it — that waves through any fixed discount rather than blocking on an unknown.
+  it('refuses a floor that is neither a number nor null', () => {
+    expect(parseSalePreview({ ...payload, minCoveredPrice: '500' })).toBeUndefined();
+    const dropped: Record<string, unknown> = { ...payload };
+    delete dropped.minCoveredPrice;
+    expect(parseSalePreview(dropped)).toBeUndefined();
   });
 
   // 🔴 undefined, never zeroes. A renamed or dropped key is an answer we did not get, and the form

--- a/apps/creator-studio/src/lib/monetization/sales.ts
+++ b/apps/creator-studio/src/lib/monetization/sales.ts
@@ -53,6 +53,11 @@ export type SaleEligibilityInput = {
   selectedCount: number;
   /** Selected versions gated as Early Access — a sale can't cover those. */
   earlyAccessCount: number;
+  /**
+   * Selected versions with no permanent access price. A sale composes over that price and nothing else,
+   * so one laid over these covers a version and then discounts nothing anywhere (CU 868kwp6cx).
+   */
+  unpricedCount: number;
   creatorScore: number;
   tier: string | null | undefined;
   /** Sale-days already committed in the budget month the draft starts in. */
@@ -86,9 +91,22 @@ export type SaleEligibility = {
   partialNotice?: { skipped: number; applies: number };
 };
 
+// Named by what is wrong with the SELECTION, not by what the creator did: "nothing here is priced" is
+// actionable, "sales need paid access" is a rule they then have to apply themselves.
+const nothingPricedReason = (selectedCount: number) =>
+  selectedCount === 1
+    ? 'This version has no permanent access price, so a sale has nothing to take Buzz off.'
+    : 'None of the selected versions has a permanent access price, so a sale has nothing to take Buzz off.';
+
+const allEarlyAccessReason = (selectedCount: number) =>
+  selectedCount === 1
+    ? "This version is in early access, and a sale can't run on early access."
+    : "Every selected version is in early access, and a sale can't run on early access.";
+
 export function resolveSaleEligibility({
   selectedCount,
   earlyAccessCount,
+  unpricedCount,
   creatorScore,
   tier,
   daysUsedInMonth,
@@ -101,7 +119,7 @@ export function resolveSaleEligibility({
   now,
   resolving,
 }: SaleEligibilityInput): SaleEligibility {
-  const eligibleVersions = Math.max(0, selectedCount - earlyAccessCount);
+  const eligibleVersions = Math.max(0, selectedCount - earlyAccessCount - unpricedCount);
   const daysAllowed = maxSaleDays(tier, overrides);
   const daysLeft = Math.max(0, daysAllowed - daysUsedInMonth);
   const leadDays = (startsAt.getTime() - now.getTime()) / DAY_MS;
@@ -122,9 +140,7 @@ export function resolveSaleEligibility({
   else if (draftDays <= 0) blockedReason = 'Choose the days the sale runs.';
   else if (eligibleVersions <= 0)
     blockedReason =
-      selectedCount === 1
-        ? "This version is in early access, and a sale can't run on early access."
-        : "Every selected version is in early access, and a sale can't run on early access.";
+      unpricedCount > 0 ? nothingPricedReason(selectedCount) : allEarlyAccessReason(selectedCount);
   else if (leadDays > maxLead) blockedReason = `A sale can start at most ${maxLead} days from now.`;
   // Backdating is not a cosmetic problem: the budget buckets by START month, so a sale backdated into a
   // past month spends an untouched budget and runs concurrently with this month's.
@@ -155,8 +171,8 @@ export function resolveSaleEligibility({
     daysLeft,
     blockedReason,
     partialNotice:
-      !blockedReason && earlyAccessCount > 0
-        ? { skipped: earlyAccessCount, applies: eligibleVersions }
+      !blockedReason && earlyAccessCount + unpricedCount > 0
+        ? { skipped: earlyAccessCount + unpricedCount, applies: eligibleVersions }
         : undefined,
   };
 }
@@ -197,6 +213,7 @@ export function resolveSaleDraft(
   ctx: {
     selectedCount: number;
     earlyAccessCount: number;
+    unpricedCount: number;
     /** Cheapest buyer-facing price; null = none priced, undefined = not known (blocks). */
     minCoveredPrice: number | null | undefined;
     overrides?: SaleLimitOverrides;
@@ -226,6 +243,7 @@ export function resolveSaleDraft(
     eligibility: resolveSaleEligibility({
       selectedCount: ctx.selectedCount,
       earlyAccessCount: ctx.earlyAccessCount,
+      unpricedCount: ctx.unpricedCount,
       creatorScore: ctx.creatorScore,
       tier: ctx.tier,
       daysUsedInMonth,

--- a/apps/creator-studio/src/lib/monetization/sales.ts
+++ b/apps/creator-studio/src/lib/monetization/sales.ts
@@ -49,15 +49,50 @@ export function budgetMonthOf(startsAt: Date): Date {
   return new Date(Date.UTC(startsAt.getUTCFullYear(), startsAt.getUTCMonth(), 1));
 }
 
+/**
+ * What `?/salePreview` answers. Both sides of that action go through this module — the route builds the
+ * payload with `salePreviewPayload` and the page reads it with `parseSalePreview` — because the wire is
+ * string-keyed and untyped: renaming a key on the server left the page reading `undefined ?? 0`, which
+ * says "everything you selected is covered" and offers a sale the write refuses.
+ */
+export type SalePreview = {
+  /** Versions a sale would actually cover. */
+  eligible: number;
+  earlyAccess: number;
+  unpriced: number;
+  /** Cheapest buyer-facing price among the covered ones; null = none priced. */
+  minCoveredPrice: number | null;
+};
+
+export const salePreviewPayload = (p: SalePreview): SalePreview => p;
+
+/** `undefined` when the action did not answer — never coerced to zeroes, which read as full coverage. */
+export function parseSalePreview(data: unknown): SalePreview | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const d = data as Record<string, unknown>;
+  const count = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+  const eligible = count(d.eligible);
+  const earlyAccess = count(d.earlyAccess);
+  const unpriced = count(d.unpriced);
+  if (eligible === undefined || earlyAccess === undefined || unpriced === undefined)
+    return undefined;
+  const min = count(d.minCoveredPrice);
+  return { eligible, earlyAccess, unpriced, minCoveredPrice: min ?? null };
+}
+
 export type SaleEligibilityInput = {
   selectedCount: number;
-  /** Selected versions gated as Early Access — a sale can't cover those. */
-  earlyAccessCount: number;
+  /**
+   * Selected versions gated as Early Access — a sale can't cover those. `undefined` = NOT KNOWN, which
+   * blocks: the preview can fail, and a failure that reset the counts to 0 read as "everything you
+   * selected is covered" and offered Apply on a sale the server would refuse.
+   */
+  earlyAccessCount: number | undefined;
   /**
    * Selected versions with no permanent access price. A sale composes over that price and nothing else,
    * so one laid over these covers a version and then discounts nothing anywhere (CU 868kwp6cx).
    */
-  unpricedCount: number;
+  unpricedCount: number | undefined;
   creatorScore: number;
   tier: string | null | undefined;
   /** Sale-days already committed in the budget month the draft starts in. */
@@ -87,12 +122,19 @@ export type SaleEligibility = {
   daysLeft: number;
   /** Why the creator can't schedule this at all. Absent when they can. */
   blockedReason?: string;
-  /** Set when the sale is schedulable but won't reach the whole selection. */
-  partialNotice?: { skipped: number; applies: number };
+  /**
+   * Set when the sale is schedulable but won't reach the whole selection. The two reasons stay
+   * SEPARATE: a summed count forces the notice to name one of them, and it named the wrong one for
+   * every selection that mixed them (CU 868kwp6mp).
+   */
+  partialNotice?: { earlyAccess: number; unpriced: number; applies: number };
 };
 
 // Named by what is wrong with the SELECTION, not by what the creator did: "nothing here is priced" is
 // actionable, "sales need paid access" is a rule they then have to apply themselves.
+const mixedBlockedReason =
+  'None of the selected versions can go on sale — some are in early access, and the rest have no permanent access price.';
+
 const nothingPricedReason = (selectedCount: number) =>
   selectedCount === 1
     ? 'This version has no permanent access price, so a sale has nothing to take Buzz off.'
@@ -119,7 +161,10 @@ export function resolveSaleEligibility({
   now,
   resolving,
 }: SaleEligibilityInput): SaleEligibility {
-  const eligibleVersions = Math.max(0, selectedCount - earlyAccessCount - unpricedCount);
+  const coverageKnown = earlyAccessCount != null && unpricedCount != null;
+  const eligibleVersions = coverageKnown
+    ? Math.max(0, selectedCount - earlyAccessCount - unpricedCount)
+    : 0;
   const daysAllowed = maxSaleDays(tier, overrides);
   const daysLeft = Math.max(0, daysAllowed - daysUsedInMonth);
   const leadDays = (startsAt.getTime() - now.getTime()) / DAY_MS;
@@ -131,6 +176,10 @@ export function resolveSaleEligibility({
   if (creatorScore < minScore)
     blockedReason = `Sales unlock at a creator score of ${minScore.toLocaleString()}.`;
   else if (resolving) blockedReason = 'Checking which versions can go on sale…';
+  // Distinct from `resolving`: the check finished and failed. Same rule the floor below applies — an
+  // answer we could not get is never "nothing is in the way".
+  else if (!coverageKnown)
+    blockedReason = "Couldn't check which versions can go on sale. Try again.";
   // A floor we could not resolve is NOT "no floor". The preview can fail, and treating an unknown as
   // "nothing to clear" would offer Apply on a discount nothing has evaluated.
   else if (type === 'Fixed' && amount != null && minCoveredPrice === undefined)
@@ -140,7 +189,11 @@ export function resolveSaleEligibility({
   else if (draftDays <= 0) blockedReason = 'Choose the days the sale runs.';
   else if (eligibleVersions <= 0)
     blockedReason =
-      unpricedCount > 0 ? nothingPricedReason(selectedCount) : allEarlyAccessReason(selectedCount);
+      unpricedCount && earlyAccessCount
+        ? mixedBlockedReason
+        : unpricedCount
+          ? nothingPricedReason(selectedCount)
+          : allEarlyAccessReason(selectedCount);
   else if (leadDays > maxLead) blockedReason = `A sale can start at most ${maxLead} days from now.`;
   // Backdating is not a cosmetic problem: the budget buckets by START month, so a sale backdated into a
   // past month spends an untouched budget and runs concurrently with this month's.
@@ -171,8 +224,8 @@ export function resolveSaleEligibility({
     daysLeft,
     blockedReason,
     partialNotice:
-      !blockedReason && earlyAccessCount + unpricedCount > 0
-        ? { skipped: earlyAccessCount + unpricedCount, applies: eligibleVersions }
+      !blockedReason && coverageKnown && earlyAccessCount + unpricedCount > 0
+        ? { earlyAccess: earlyAccessCount, unpriced: unpricedCount, applies: eligibleVersions }
         : undefined,
   };
 }
@@ -212,8 +265,8 @@ export function resolveSaleDraft(
   input: SaleDraftInput,
   ctx: {
     selectedCount: number;
-    earlyAccessCount: number;
-    unpricedCount: number;
+    earlyAccessCount: number | undefined;
+    unpricedCount: number | undefined;
     /** Cheapest buyer-facing price; null = none priced, undefined = not known (blocks). */
     minCoveredPrice: number | null | undefined;
     overrides?: SaleLimitOverrides;

--- a/apps/creator-studio/src/lib/monetization/sales.ts
+++ b/apps/creator-studio/src/lib/monetization/sales.ts
@@ -76,17 +76,30 @@ export function parseSalePreview(data: unknown): SalePreview | undefined {
   const unpriced = count(d.unpriced);
   if (eligible === undefined || earlyAccess === undefined || unpriced === undefined)
     return undefined;
-  const min = count(d.minCoveredPrice);
-  return { eligible, earlyAccess, unpriced, minCoveredPrice: min ?? null };
+  // `null` is an answer — "nothing in the selection is priced". Anything else non-numeric is not, and
+  // must not degrade to it: `null` is the value that SKIPS the Fixed zero-floor check entirely.
+  if (d.minCoveredPrice !== null && count(d.minCoveredPrice) === undefined) return undefined;
+  return {
+    eligible,
+    earlyAccess,
+    unpriced,
+    minCoveredPrice: d.minCoveredPrice === null ? null : (count(d.minCoveredPrice) as number),
+  };
 }
 
 export type SaleEligibilityInput = {
   selectedCount: number;
   /**
-   * Selected versions gated as Early Access — a sale can't cover those. `undefined` = NOT KNOWN, which
-   * blocks: the preview can fail, and a failure that reset the counts to 0 read as "everything you
-   * selected is covered" and offered Apply on a sale the server would refuse.
+   * Versions the WRITE would cover, as the server counted them. `undefined` = NOT KNOWN, which blocks:
+   * the preview can fail, and a failure that reset this to a number read as "everything you selected is
+   * covered" and offered Apply on a sale the server would refuse.
+   *
+   * 🔴 Not `selectedCount - skipped`. A selected id the creator no longer owns — deleted, transferred,
+   * never theirs — is in neither skip count, so subtracting counts it as covered and the form names a
+   * coverage the write does not deliver.
    */
+  eligibleCount: number | undefined;
+  /** Selected versions gated as Early Access — a sale can't cover those. */
   earlyAccessCount: number | undefined;
   /**
    * Selected versions with no permanent access price. A sale composes over that price and nothing else,
@@ -147,6 +160,7 @@ const allEarlyAccessReason = (selectedCount: number) =>
 
 export function resolveSaleEligibility({
   selectedCount,
+  eligibleCount,
   earlyAccessCount,
   unpricedCount,
   creatorScore,
@@ -161,10 +175,8 @@ export function resolveSaleEligibility({
   now,
   resolving,
 }: SaleEligibilityInput): SaleEligibility {
-  const coverageKnown = earlyAccessCount != null && unpricedCount != null;
-  const eligibleVersions = coverageKnown
-    ? Math.max(0, selectedCount - earlyAccessCount - unpricedCount)
-    : 0;
+  const coverageKnown = eligibleCount != null && earlyAccessCount != null && unpricedCount != null;
+  const eligibleVersions = coverageKnown ? eligibleCount : 0;
   const daysAllowed = maxSaleDays(tier, overrides);
   const daysLeft = Math.max(0, daysAllowed - daysUsedInMonth);
   const leadDays = (startsAt.getTime() - now.getTime()) / DAY_MS;
@@ -265,6 +277,7 @@ export function resolveSaleDraft(
   input: SaleDraftInput,
   ctx: {
     selectedCount: number;
+    eligibleCount: number | undefined;
     earlyAccessCount: number | undefined;
     unpricedCount: number | undefined;
     /** Cheapest buyer-facing price; null = none priced, undefined = not known (blocks). */
@@ -295,6 +308,7 @@ export function resolveSaleDraft(
     daysUsedInMonth,
     eligibility: resolveSaleEligibility({
       selectedCount: ctx.selectedCount,
+      eligibleCount: ctx.eligibleCount,
       earlyAccessCount: ctx.earlyAccessCount,
       unpricedCount: ctx.unpricedCount,
       creatorScore: ctx.creatorScore,

--- a/apps/creator-studio/src/lib/server/__tests__/sale-eligibility.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/sale-eligibility.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { isSaleEligibleGate, saleEligibleSqlText } from '../monetization/sale-eligibility';
+import {
+  classifyGate,
+  isSaleEligibleGate,
+  saleEligibleSqlText,
+} from '../monetization/sale-eligibility';
 
 const permanent = (terms: unknown) => ({ timeframeDays: null, endsAt: null, terms });
+const earlyAccess = (terms: unknown) => ({ timeframeDays: 14, endsAt: null, terms });
 
 describe('isSaleEligibleGate', () => {
   it('accepts a permanent gate with a download price', () => {
@@ -26,12 +31,23 @@ describe('isSaleEligibleGate', () => {
     expect(isSaleEligibleGate(permanent(null))).toBe(false);
   });
 
+  // `terms` is jsonb, so the type says nothing about what is in it. `'500' > 0` is true in JS, which
+  // would make the picker (SQL, type-guarded) and the write (this) disagree about the same version.
+  it('rejects a price that is not a number', () => {
+    expect(isSaleEligibleGate(permanent({ download: { price: '500' } }))).toBe(false);
+    expect(isSaleEligibleGate(permanent({ generation: { price: true } }))).toBe(false);
+  });
+
+  // gatePrices drops the generation tier wholesale when the grant is a free one, so a price beside
+  // `free` is not chargeable. The SQL half has to agree, or the picker lists what the write skips.
+  it('rejects a free generation grant even when it carries a price', () => {
+    expect(isSaleEligibleGate(permanent({ generation: { free: true, price: 300 } }))).toBe(false);
+  });
+
   // `timeframeDays`, not `endsAt`: an unpublished timed gate also has a null endsAt, so endsAt cannot
   // tell a timed gate from a permanent one.
   it('rejects early access however it is priced', () => {
-    expect(
-      isSaleEligibleGate({ timeframeDays: 14, endsAt: null, terms: { download: { price: 500 } } })
-    ).toBe(false);
+    expect(isSaleEligibleGate(earlyAccess({ download: { price: 500 } }))).toBe(false);
     expect(
       isSaleEligibleGate({
         timeframeDays: 14,
@@ -52,29 +68,45 @@ describe('isSaleEligibleGate', () => {
   });
 });
 
-// The SQL half of the same rule — it filters the picker's list, which pages, so `isSaleEligibleGate`
-// cannot answer for it. Asserted as text because a predicate that silently stops constraining something
-// still returns rows, and a list that is merely too WIDE is the bug being fixed rather than a red test.
+// The creator is told WHICH reason applies, and the two arms are one keystroke apart — swapping them
+// leaves every count correct and every message wrong.
+describe('classifyGate', () => {
+  it('separates the two reasons a version is skipped', () => {
+    expect(classifyGate(permanent({ download: { price: 500 } }))).toBe('eligible');
+    expect(classifyGate(earlyAccess({ download: { price: 500 } }))).toBe('earlyAccess');
+    expect(classifyGate(permanent({ download: { price: 0 } }))).toBe('unpriced');
+    expect(classifyGate(null)).toBe('unpriced');
+  });
+
+  // An early-access gate that is ALSO unpriced is still early access — the creator's next move is
+  // different for each, and "price it" is the wrong instruction for a timed window.
+  it('calls an unpriced early-access gate early access', () => {
+    expect(classifyGate(earlyAccess({ download: { price: 0 } }))).toBe('earlyAccess');
+  });
+});
+
+// The SQL half filters the picker's list, which pages — `isSaleEligibleGate` cannot answer for it.
+//
+// Asserted as one whole string rather than as substrings, because the mutations that matter most are
+// STRUCTURAL and leave every substring in place: `exists` → `not exists` inverts the list to exactly the
+// versions a sale cannot discount, and `and (priced…)` → `or (priced…)` decouples the subquery from the
+// version entirely. Both passed a `toContain`-based version of this test.
 describe('saleEligibleSqlText', () => {
-  const text = saleEligibleSqlText('mv');
-
-  it('constrains the gate to a permanent, still-open one on the aliased version', () => {
-    expect(text).toContain('pa."entityId" = mv."id"');
-    expect(text).toContain('pa."timeframeDays" is null');
-    expect(text).toContain('pa."endsAt" is null or pa."endsAt" > now()');
+  it('emits exactly this predicate', () => {
+    expect(saleEligibleSqlText('mv', 77)).toBe(
+      `exists (select 1 from "PaidAccess" pa where pa."entityType" = 'ModelVersion' and pa."entityId" = mv."id" and pa."ownerId" = 77 and pa."timeframeDays" is null and (pa."endsAt" is null or pa."endsAt" > now()) and ((jsonb_typeof(pa."terms"->'download'->'price') = 'number' and (pa."terms"->'download'->>'price')::numeric > 0) or (not (pa."terms"->'generation' ? 'free') and (jsonb_typeof(pa."terms"->'generation'->'price') = 'number' and (pa."terms"->'generation'->>'price')::numeric > 0))))`
+    );
   });
 
-  it('requires a price on either chargeable tier', () => {
-    expect(text).toContain(`(pa."terms"->'download'->>'price')::numeric > 0`);
-    expect(text).toContain(`(pa."terms"->'generation'->>'price')::numeric > 0`);
+  it('scopes to the alias and the owner it is given', () => {
+    const text = saleEligibleSqlText('v', 12);
+    expect(text).toContain('pa."entityId" = v."id"');
+    expect(text).toContain('pa."ownerId" = 12');
   });
 
-  // Without the type guard, `::numeric` over a non-numeric price hard-errors the whole query rather than
-  // skipping the row — every creator's list 500s off one malformed gate. `int` would do the same to a
-  // fractional price, which nothing on the write path rejects.
-  it('guards the cast and does not narrow it to int', () => {
-    expect(text).toContain(`jsonb_typeof(pa."terms"->'download'->'price') = 'number'`);
-    expect(text).toContain(`jsonb_typeof(pa."terms"->'generation'->'price') = 'number'`);
-    expect(text).not.toContain('::int');
+  // The owner id is interpolated into raw SQL, so nothing downstream parameterises it.
+  it('refuses an owner id that is not an integer', () => {
+    expect(() => saleEligibleSqlText('mv', 1.5)).toThrow();
+    expect(() => saleEligibleSqlText('mv', Number('abc'))).toThrow();
   });
 });

--- a/apps/creator-studio/src/lib/server/__tests__/sale-eligibility.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/sale-eligibility.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { isSaleEligibleGate, saleEligibleSqlText } from '../monetization/sale-eligibility';
+
+const permanent = (terms: unknown) => ({ timeframeDays: null, endsAt: null, terms });
+
+describe('isSaleEligibleGate', () => {
+  it('accepts a permanent gate with a download price', () => {
+    expect(isSaleEligibleGate(permanent({ download: { price: 500 } }))).toBe(true);
+  });
+
+  // A generation-only version carries no download tier, so reading only `download` would call every one
+  // of them unsaleable.
+  it('accepts a permanent gate priced on generation alone', () => {
+    expect(isSaleEligibleGate(permanent({ generation: { price: 200, trialLimit: 0 } }))).toBe(true);
+  });
+
+  // The defect in CU 868kwp6cx. A sale over one of these is created, reports itself as covering the
+  // version, and then discounts nothing anywhere — there is no price for discountedTerms to compose over.
+  it('rejects a version with no gate at all', () => {
+    expect(isSaleEligibleGate(null)).toBe(false);
+  });
+
+  it('rejects a permanent gate carrying no price', () => {
+    expect(isSaleEligibleGate(permanent({ generation: { free: true } }))).toBe(false);
+    expect(isSaleEligibleGate(permanent({ download: { price: 0 } }))).toBe(false);
+    expect(isSaleEligibleGate(permanent(null))).toBe(false);
+  });
+
+  // `timeframeDays`, not `endsAt`: an unpublished timed gate also has a null endsAt, so endsAt cannot
+  // tell a timed gate from a permanent one.
+  it('rejects early access however it is priced', () => {
+    expect(
+      isSaleEligibleGate({ timeframeDays: 14, endsAt: null, terms: { download: { price: 500 } } })
+    ).toBe(false);
+    expect(
+      isSaleEligibleGate({
+        timeframeDays: 14,
+        endsAt: new Date('2099-01-01'),
+        terms: { download: { price: 500 } },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects a gate whose window has closed', () => {
+    expect(
+      isSaleEligibleGate({
+        timeframeDays: null,
+        endsAt: new Date('2020-01-01'),
+        terms: { download: { price: 500 } },
+      })
+    ).toBe(false);
+  });
+});
+
+// The SQL half of the same rule — it filters the picker's list, which pages, so `isSaleEligibleGate`
+// cannot answer for it. Asserted as text because a predicate that silently stops constraining something
+// still returns rows, and a list that is merely too WIDE is the bug being fixed rather than a red test.
+describe('saleEligibleSqlText', () => {
+  const text = saleEligibleSqlText('mv');
+
+  it('constrains the gate to a permanent, still-open one on the aliased version', () => {
+    expect(text).toContain('pa."entityId" = mv."id"');
+    expect(text).toContain('pa."timeframeDays" is null');
+    expect(text).toContain('pa."endsAt" is null or pa."endsAt" > now()');
+  });
+
+  it('requires a price on either chargeable tier', () => {
+    expect(text).toContain(`(pa."terms"->'download'->>'price')::numeric > 0`);
+    expect(text).toContain(`(pa."terms"->'generation'->>'price')::numeric > 0`);
+  });
+
+  // Without the type guard, `::numeric` over a non-numeric price hard-errors the whole query rather than
+  // skipping the row — every creator's list 500s off one malformed gate. `int` would do the same to a
+  // fractional price, which nothing on the write path rejects.
+  it('guards the cast and does not narrow it to int', () => {
+    expect(text).toContain(`jsonb_typeof(pa."terms"->'download'->'price') = 'number'`);
+    expect(text).toContain(`jsonb_typeof(pa."terms"->'generation'->'price') = 'number'`);
+    expect(text).not.toContain('::int');
+  });
+});

--- a/apps/creator-studio/src/lib/server/models-view.ts
+++ b/apps/creator-studio/src/lib/server/models-view.ts
@@ -20,6 +20,8 @@ const modelsQuerySchema = z.object({
   status: z.enum(['all', 'published', 'draft']).optional().catch(undefined),
   access: z.enum(['1']).optional().catch(undefined),
   usage: z.enum(['download', 'generation']).optional().catch(undefined),
+  // Set by "New sale", which sends the creator here to pick what the sale covers.
+  for: z.enum(['sale']).optional().catch(undefined),
   sort: z.enum(['recent', 'name']).catch('recent'),
   page: z.coerce.number().int().min(1).catch(1),
   // Page-size selector value (868ke493p); persisted to a cookie so it applies on later loads.
@@ -49,6 +51,8 @@ export type ModelsView = CreatorModelsResult & {
     access: boolean;
     usage: string;
     sort: 'recent' | 'name';
+    /** Picking versions for a sale: the list is narrowed to what a sale could discount. */
+    saleOnly: boolean;
   };
 };
 
@@ -70,6 +74,11 @@ export async function getModelsView(
   const baseModel = parsed.bm?.trim() || undefined;
   const type = parsed.mt?.trim() || undefined;
   const access = parsed.access === '1';
+  // The list a sale is picked from must only offer versions a sale can actually discount — a version
+  // with no permanent paid-access price takes the sale and shows nothing anywhere (CU 868kwp6mp).
+  // Independent of the flag on purpose: narrowing a list is safe, and pairing it with the flag would
+  // serialise the two queries below for no gain.
+  const saleOnly = parsed.for === 'sale';
 
   // Page size: an explicit ?ps= updates the shared cookie; otherwise fall back to the cookie, then the default.
   const perPage = resolvePageSize(parsed.ps, cookies.get(PAGE_SIZE_COOKIE));
@@ -87,6 +96,7 @@ export async function getModelsView(
       status: parsed.status,
       access,
       usage: parsed.usage,
+      saleEligible: saleOnly,
       sort: parsed.sort,
       page: parsed.page,
       perPage,
@@ -122,6 +132,7 @@ export async function getModelsView(
       access,
       usage: parsed.usage ?? '',
       sort: parsed.sort,
+      saleOnly,
     },
   };
 }

--- a/apps/creator-studio/src/lib/server/models-view.ts
+++ b/apps/creator-studio/src/lib/server/models-view.ts
@@ -76,9 +76,18 @@ export async function getModelsView(
   const access = parsed.access === '1';
   // The list a sale is picked from must only offer versions a sale can actually discount — a version
   // with no permanent paid-access price takes the sale and shows nothing anywhere (CU 868kwp6mp).
-  // Independent of the flag on purpose: narrowing a list is safe, and pairing it with the flag would
-  // serialise the two queries below for no gain.
-  const saleOnly = parsed.for === 'sale';
+  //
+  // Gated on the flag, which costs a serial await before the models query: the page keys its whole
+  // sale-preparation mode off `saleOnly`, so leaving it flag-independent meant a creator without the
+  // feature could land on `?for=sale` from a link, get the banner and a narrowed list, and be walked to
+  // a Continue button into a page that tells them the feature is off. `isEnabled` memoises, so the cost
+  // is a cached read, not a round trip per load.
+  const salesEnabled = await getFlipt().isEnabled(
+    'scheduled-model-sales',
+    String(user.id),
+    fliptContext(user)
+  );
+  const saleOnly = parsed.for === 'sale' && salesEnabled;
 
   // Page size: an explicit ?ps= updates the shared cookie; otherwise fall back to the cookie, then the default.
   const perPage = resolvePageSize(parsed.ps, cookies.get(PAGE_SIZE_COOKIE));
@@ -86,27 +95,22 @@ export async function getModelsView(
     cookies.set(PAGE_SIZE_COOKIE, String(perPage), { path: '/', maxAge: PAGE_SIZE_MAX_AGE });
   }
 
-  const [result, salesEnabled] = await Promise.all([
-    getCreatorModels({
-      userId: user.id,
-      q,
-      fee: parsed.fee,
-      baseModel,
-      type,
-      status: parsed.status,
-      access,
-      usage: parsed.usage,
-      saleEligible: saleOnly,
-      sort: parsed.sort,
-      page: parsed.page,
-      perPage,
-      // Selection is always available, so "select all matching filters" always needs the full id set.
-      withMatchingVersionIds: true,
-    }),
-    // Per-user entityId so the feature can open to a few creators before everyone. `isEnabled` rather
-    // than `getBoolean`: only the former honours FLIPT_LOCAL_OVERRIDES, so this is togglable locally.
-    getFlipt().isEnabled('scheduled-model-sales', String(user.id), fliptContext(user)),
-  ]);
+  const result = await getCreatorModels({
+    userId: user.id,
+    q,
+    fee: parsed.fee,
+    baseModel,
+    type,
+    status: parsed.status,
+    access,
+    usage: parsed.usage,
+    saleEligible: saleOnly,
+    sort: parsed.sort,
+    page: parsed.page,
+    perPage,
+    // Selection is always available, so "select all matching filters" always needs the full id set.
+    withMatchingVersionIds: true,
+  });
 
   // Sales are read ONLY when the feature is on. Migrations here are applied by hand, so on any
   // environment where the sale tables have not been created yet an unconditional read makes /models

--- a/apps/creator-studio/src/lib/server/models.ts
+++ b/apps/creator-studio/src/lib/server/models.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_GENERATION_TRIAL_LIMIT,
   type PaidAccessConfig,
 } from '$lib/monetization/paid-access';
+import { saleEligibleFilter } from '$lib/server/monetization/sale-eligibility';
 
 // "Sold in any form": an active PaidAccess row — a timed window still open OR a permanent (no end date) gate.
 function paidAccessFilter(alias: string) {
@@ -94,6 +95,8 @@ export type ModelsQuery = {
   access?: boolean; // has early / paid access on a version
   /** Usage-control filter (bulk paid-access scoping): 'download' or 'generation'. */
   usage?: 'download' | 'generation';
+  /** Only versions a sale could actually discount — the sale picker's list (868kwp6mp). */
+  saleEligible?: boolean;
   sort?: ModelsSort;
   page?: number;
   /** Rows per page (defaults to MODELS_PER_PAGE); the page's cookie-backed size selector sets it. */
@@ -238,7 +241,18 @@ export const PAGE_SIZE_COOKIE = 'cs-page-size';
 // sort + pagination. Version-level filters (fee/baseModel/access) both narrow the model list (models with ≥1
 // matching version) AND restrict the versions shown, so "select all" selects exactly what's on screen.
 export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModelsResult> {
-  const { userId, q, fee, baseModel, type, status, access, usage, sort = 'recent' } = query;
+  const {
+    userId,
+    q,
+    fee,
+    baseModel,
+    type,
+    status,
+    access,
+    usage,
+    saleEligible,
+    sort = 'recent',
+  } = query;
   const page = Math.max(1, query.page ?? 1);
   const perPage = query.perPage ?? MODELS_PER_PAGE;
   const usageValue =
@@ -254,7 +268,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
   if (status === 'published') filtered = filtered.where('status', '=', 'Published');
   else if (status === 'draft') filtered = filtered.where('status', '=', 'Draft');
   else if (status !== 'all') filtered = filtered.where('status', '!=', 'Draft'); // default: hide drafts
-  const hasVersionFilter = !!baseModel || !!access || !!fee || !!usageValue;
+  const hasVersionFilter = !!baseModel || !!access || !!fee || !!usageValue || !!saleEligible;
   if (hasVersionFilter)
     filtered = filtered.where((eb) =>
       eb.exists(
@@ -267,6 +281,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
           .$if(!!usageValue, (b) => b.where('mv.usageControl', '=', usageValue!))
           .$if(fee === 'set', (b) => b.where(feeFilter('mv', 'set')))
           .$if(fee === 'off', (b) => b.where(feeFilter('mv', 'off')))
+          .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv')))
       )
     );
 
@@ -360,6 +375,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
     .$if(!!usageValue, (b) => b.where('mv.usageControl', '=', usageValue!))
     .$if(fee === 'set', (b) => b.where(feeFilter('mv', 'set')))
     .$if(fee === 'off', (b) => b.where(feeFilter('mv', 'off')))
+    .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv')))
     .orderBy('mv.index', 'asc')
     .execute();
 
@@ -383,6 +399,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
       .$if(!!usageValue, (b) => b.where('mv.usageControl', '=', usageValue!))
       .$if(fee === 'set', (b) => b.where(feeFilter('mv', 'set')))
       .$if(fee === 'off', (b) => b.where(feeFilter('mv', 'off')))
+      .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv')))
       .select('mv.id')
       .execute();
     matchingVersionIds = idRows.map((r) => r.id);

--- a/apps/creator-studio/src/lib/server/models.ts
+++ b/apps/creator-studio/src/lib/server/models.ts
@@ -281,7 +281,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
           .$if(!!usageValue, (b) => b.where('mv.usageControl', '=', usageValue!))
           .$if(fee === 'set', (b) => b.where(feeFilter('mv', 'set')))
           .$if(fee === 'off', (b) => b.where(feeFilter('mv', 'off')))
-          .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv')))
+          .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv', userId)))
       )
     );
 
@@ -375,7 +375,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
     .$if(!!usageValue, (b) => b.where('mv.usageControl', '=', usageValue!))
     .$if(fee === 'set', (b) => b.where(feeFilter('mv', 'set')))
     .$if(fee === 'off', (b) => b.where(feeFilter('mv', 'off')))
-    .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv')))
+    .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv', userId)))
     .orderBy('mv.index', 'asc')
     .execute();
 
@@ -399,7 +399,7 @@ export async function getCreatorModels(query: ModelsQuery): Promise<CreatorModel
       .$if(!!usageValue, (b) => b.where('mv.usageControl', '=', usageValue!))
       .$if(fee === 'set', (b) => b.where(feeFilter('mv', 'set')))
       .$if(fee === 'off', (b) => b.where(feeFilter('mv', 'off')))
-      .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv')))
+      .$if(!!saleEligible, (b) => b.where(saleEligibleFilter('mv', userId)))
       .select('mv.id')
       .execute();
     matchingVersionIds = idRows.map((r) => r.id);

--- a/apps/creator-studio/src/lib/server/monetization/sale-eligibility.ts
+++ b/apps/creator-studio/src/lib/server/monetization/sale-eligibility.ts
@@ -14,6 +14,11 @@ type EligibleRow = {
   terms: unknown;
 };
 
+/** Why a selected version is not covered — the two reasons a creator is told apart. */
+export type GateVerdict = 'eligible' | 'earlyAccess' | 'unpriced';
+
+const isPositivePrice = (price: unknown): boolean => typeof price === 'number' && price > 0;
+
 /**
  * True when a sale laid over this gate would take Buzz off something.
  *
@@ -26,31 +31,54 @@ export function isSaleEligibleGate(row: EligibleRow | null | undefined): boolean
   if (!row) return false;
   if (!isPermanentGate(row) || !isPaidAccessActive(row)) return false;
   const { download, generation } = gatePrices(row.terms as ModelVersionTerms | null);
-  return download > 0 || generation > 0;
+  // `typeof`, not just `> 0`: `terms` is jsonb the type system says nothing about, and `'500' > 0` is
+  // true in JS while the SQL half's `jsonb_typeof` guard calls the same row ineligible. Guarding one
+  // side only is how the picker and the write come to disagree about a version.
+  return isPositivePrice(download) || isPositivePrice(generation);
+}
+
+/**
+ * The verdict on one selected version, given its gate row (`null` when it has none).
+ *
+ * Separate from `isSaleEligibleGate` because the creator is told WHICH reason applies, and the two arms
+ * are trivially swappable — the error message and the toast then name the wrong one with every test
+ * still green.
+ */
+export function classifyGate(row: EligibleRow | null | undefined): GateVerdict {
+  if (isSaleEligibleGate(row)) return 'eligible';
+  return row && row.timeframeDays != null ? 'earlyAccess' : 'unpriced';
 }
 
 /**
  * The same rule as SQL, for the queries that page and count rather than fetch rows —
  * `isSaleEligibleGate` cannot filter a list the caller has not loaded.
  *
+ * 🔴 Scoped by `ownerId`, which is not redundant with the caller's own `Model.userId` join. Without it
+ * the planner reads the subquery as the cheap driver, scans every permanent priced gate on the site and
+ * PK-probes its way back — measured on production at 41.9 ms / 29,985 buffers for a creator with no
+ * gates at all, against 0.28 ms / ~46 buffers with the clause, and it grows with the table rather than
+ * with the creator. `PaidAccess.ownerId` and `Model.userId` agree on all 5,071 production rows, and the
+ * ownership-transfer path maintains both.
+ *
  * `jsonb_typeof(...) = 'number'` guards the cast rather than decorating it: `->>'price'` on a string or
  * an object is still text, and `::numeric` over that hard-errors the whole batch instead of skipping the
  * row. `numeric` rather than `int` for the same reason — the write path has never rejected a fractional
  * price.
+ *
+ * The `'free'` test mirrors `gatePrices`, which drops the generation tier wholesale when the grant is a
+ * free one. Without it a `{ free: true, price: N }` row is eligible here and ineligible in JS.
  */
-export function saleEligibleSqlText(alias: string): string {
+export function saleEligibleSqlText(alias: string, userId: number): string {
+  // This is `sql.raw`, so nothing downstream parameterises `userId`. Refuse rather than interpolate
+  // anything that is not an integer.
+  if (!Number.isInteger(userId)) throw new Error('saleEligibleSqlText: userId must be an integer');
   const priced = (tier: 'download' | 'generation') =>
     `(jsonb_typeof(pa."terms"->'${tier}'->'price') = 'number' and (pa."terms"->'${tier}'->>'price')::numeric > 0)`;
-  return `exists (
-    select 1 from "PaidAccess" pa
-    where pa."entityType" = 'ModelVersion'
-      and pa."entityId" = ${alias}."id"
-      and pa."timeframeDays" is null
-      and (pa."endsAt" is null or pa."endsAt" > now())
-      and (${priced('download')} or ${priced('generation')})
-  )`;
+  return `exists (select 1 from "PaidAccess" pa where pa."entityType" = 'ModelVersion' and pa."entityId" = ${alias}."id" and pa."ownerId" = ${userId} and pa."timeframeDays" is null and (pa."endsAt" is null or pa."endsAt" > now()) and (${priced(
+    'download'
+  )} or (not (pa."terms"->'generation' ? 'free') and ${priced('generation')})))`;
 }
 
-export function saleEligibleFilter(alias: string) {
-  return sql.raw<boolean>(saleEligibleSqlText(alias));
+export function saleEligibleFilter(alias: string, userId: number) {
+  return sql.raw<boolean>(saleEligibleSqlText(alias, userId));
 }

--- a/apps/creator-studio/src/lib/server/monetization/sale-eligibility.ts
+++ b/apps/creator-studio/src/lib/server/monetization/sale-eligibility.ts
@@ -1,0 +1,56 @@
+import { sql } from '@civitai/db/kysely';
+import { gatePrices, isPaidAccessActive, isPermanentGate } from '@civitai/buzz';
+import type { ModelVersionTerms } from '@civitai/buzz';
+
+// What a sale can actually discount. One definition, read by the picker's filter, by the sale form's
+// preview and by the schedule write, because the three disagreeing is the bug this exists to close:
+// eligibility used to mean "owned and not early access", so a version with no price at all was
+// selectable, schedulable, and then discounted nothing. All 13 sale items in production on 2026-08-25
+// covered a version in exactly that state (CU 868kwp6cx).
+
+type EligibleRow = {
+  timeframeDays: number | null;
+  endsAt: Date | null;
+  terms: unknown;
+};
+
+/**
+ * True when a sale laid over this gate would take Buzz off something.
+ *
+ * Permanent only — a sale never covers a timed early-access window, and the main app re-checks the same
+ * rule when it prices, since the gate type stays mutable after a sale exists. Priced only —
+ * `discountedTerms` composes over the download and generation prices and nothing else, so a gate
+ * carrying neither resolves to no discount on the card, the model page or the charge.
+ */
+export function isSaleEligibleGate(row: EligibleRow | null | undefined): boolean {
+  if (!row) return false;
+  if (!isPermanentGate(row) || !isPaidAccessActive(row)) return false;
+  const { download, generation } = gatePrices(row.terms as ModelVersionTerms | null);
+  return download > 0 || generation > 0;
+}
+
+/**
+ * The same rule as SQL, for the queries that page and count rather than fetch rows —
+ * `isSaleEligibleGate` cannot filter a list the caller has not loaded.
+ *
+ * `jsonb_typeof(...) = 'number'` guards the cast rather than decorating it: `->>'price'` on a string or
+ * an object is still text, and `::numeric` over that hard-errors the whole batch instead of skipping the
+ * row. `numeric` rather than `int` for the same reason — the write path has never rejected a fractional
+ * price.
+ */
+export function saleEligibleSqlText(alias: string): string {
+  const priced = (tier: 'download' | 'generation') =>
+    `(jsonb_typeof(pa."terms"->'${tier}'->'price') = 'number' and (pa."terms"->'${tier}'->>'price')::numeric > 0)`;
+  return `exists (
+    select 1 from "PaidAccess" pa
+    where pa."entityType" = 'ModelVersion'
+      and pa."entityId" = ${alias}."id"
+      and pa."timeframeDays" is null
+      and (pa."endsAt" is null or pa."endsAt" > now())
+      and (${priced('download')} or ${priced('generation')})
+  )`;
+}
+
+export function saleEligibleFilter(alias: string) {
+  return sql.raw<boolean>(saleEligibleSqlText(alias));
+}

--- a/apps/creator-studio/src/lib/server/monetization/sales.ts
+++ b/apps/creator-studio/src/lib/server/monetization/sales.ts
@@ -190,10 +190,15 @@ export async function scheduleSale(
     if (!eligible.length)
       return {
         ok: false as const,
+        // Three arms, matching resolveSaleEligibility's. Reachable only by a forged POST or by the
+        // selection changing between preview and submit — but a refusal that names the wrong reason is
+        // worse than the generic one, and the client already had the mixed case.
         error:
-          skippedUnpriced > 0
-            ? 'None of the selected versions can go on sale — a sale discounts a permanent access price, and none of them has one.'
-            : "None of the selected versions can go on sale — a sale can't run on early access.",
+          skippedUnpriced > 0 && skippedEarlyAccess > 0
+            ? 'None of the selected versions can go on sale — some are in early access, and the rest have no permanent access price.'
+            : skippedUnpriced > 0
+              ? 'None of the selected versions can go on sale — a sale discounts a permanent access price, and none of them has one.'
+              : "None of the selected versions can go on sale — a sale can't run on early access.",
       };
 
     const refusal = await zeroFloorRefusal(

--- a/apps/creator-studio/src/lib/server/monetization/sales.ts
+++ b/apps/creator-studio/src/lib/server/monetization/sales.ts
@@ -11,8 +11,17 @@ import {
   type SaleLimitOverrides,
 } from '@civitai/buzz';
 import { dbRead, dbWrite } from '$lib/server/db';
-import { isSaleEligibleGate } from '$lib/server/monetization/sale-eligibility';
+import { classifyGate } from '$lib/server/monetization/sale-eligibility';
 import { saleLengthInDays } from '$lib/monetization/sales';
+
+/** One selected version the creator owns, with everything the eligibility rule and the floor need. */
+type EligibleVersion = {
+  id: number;
+  baseModel: string | null;
+  timeframeDays: number | null;
+  endsAt: Date | null;
+  terms: unknown;
+};
 
 // Scheduled sales — server reads and every write that changes a sale. Spec: CU 868ktk1ku.
 //
@@ -41,9 +50,16 @@ const SALE_BUDGET_LOCK_CLASS = 4109;
  */
 export async function summarizeSaleSelection(
   userId: number,
-  versionIds: number[]
-): Promise<{ eligible: number; earlyAccess: number; unpriced: number }> {
-  if (!versionIds.length) return { eligible: 0, earlyAccess: 0, unpriced: 0 };
+  versionIds: number[],
+  tier: string | null
+): Promise<{
+  eligible: number;
+  earlyAccess: number;
+  unpriced: number;
+  minCoveredPrice: number | null;
+}> {
+  if (!versionIds.length)
+    return { eligible: 0, earlyAccess: 0, unpriced: 0, minCoveredPrice: null };
   const { eligible, skippedEarlyAccess, skippedUnpriced } = await classifySelection(
     dbRead,
     userId,
@@ -53,12 +69,13 @@ export async function summarizeSaleSelection(
     eligible: eligible.length,
     earlyAccess: skippedEarlyAccess,
     unpriced: skippedUnpriced,
+    minCoveredPrice: lowestBuyerPrice(eligible, tier),
   };
 }
 
 /**
- * The cheapest price a BUYER would actually be charged across versions a sale would cover. Null when
- * nothing in the selection is priced.
+ * The floor a Fixed discount must stay under: the cheapest price a BUYER would actually be charged
+ * across the versions a sale WOULD cover.
  *
  * 🔴 Capped, not stored. A sale composes over `cappedTerms`, so the price it discounts is the stored
  * price lowered to the owner's current tier ceiling. Measuring the stored price instead lets a fixed
@@ -68,45 +85,17 @@ export async function summarizeSaleSelection(
  *
  * Both chargeable prices count, since a sale discounts the download price and any separate generation
  * price alike.
+ *
+ * 🔴 Measured over the ELIGIBLE rows, not over every permanent gate in the selection. A second query
+ * with its own idea of "covered" is how the floor comes to be priced against a version the sale does
+ * not cover — it already had no `endsAt` test while eligibility did.
  */
-export async function cheapestCoveredPrice(
-  userId: number,
-  versionIds: number[],
-  tier: string | null
-): Promise<number | null> {
-  if (!versionIds.length) return null;
-  return lowestBuyerPrice(await coveredPriceRows(dbRead, userId, versionIds), tier);
-}
-
-type CoveredPriceRow = { terms: unknown; baseModel: string | null };
-
-function coveredPriceRows(
-  db: typeof dbRead | typeof dbWrite,
-  userId: number,
-  versionIds: number[]
-) {
-  return (
-    db
-      .selectFrom('PaidAccess as pa')
-      .innerJoin('ModelVersion as mv', 'mv.id', 'pa.entityId')
-      .innerJoin('Model as m', 'm.id', 'mv.modelId')
-      .select(['pa.terms', 'mv.baseModel'])
-      .where('pa.entityType', '=', 'ModelVersion')
-      .where('pa.entityId', 'in', versionIds)
-      // A sale can't cover early access, so an early-access price must not drag the floor down.
-      .where('pa.timeframeDays', 'is', null)
-      .where('m.userId', '=', userId)
-      .execute()
-  );
-}
-
-/** Lowest non-zero buyer-facing price across the rows. 0 means "not charged for", not "free". */
-function lowestBuyerPrice(rows: CoveredPriceRow[], tier: string | null): number | null {
+function lowestBuyerPrice(rows: EligibleVersion[], tier: string | null): number | null {
   let lowest: number | null = null;
   for (const row of rows) {
     const { download, generation } = gatePrices(row.terms as ModelVersionTerms | null);
-    // Permanent by construction: the query keeps only `timeframeDays IS NULL` rows, and the ceiling
-    // governs permanent gates only.
+    // Permanent by construction: `isSaleEligibleGate` kept only permanent rows, and the ceiling governs
+    // permanent gates only.
     const gate = { permanent: true, mediaType: capMediaType(row.baseModel ?? undefined) };
     for (const stored of [download, generation]) {
       if (stored <= 0) continue;
@@ -207,10 +196,16 @@ export async function scheduleSale(
             : "None of the selected versions can go on sale — a sale can't run on early access.",
       };
 
-    const refusal = await zeroFloorRefusal(trx, userId, eligible, tier, {
-      discountType: input.discountType,
-      discountAmount: input.discountAmount,
-    });
+    const refusal = await zeroFloorRefusal(
+      trx,
+      userId,
+      eligible.map((v) => v.id),
+      tier,
+      {
+        discountType: input.discountType,
+        discountAmount: input.discountAmount,
+      }
+    );
     if (refusal) return { ok: false as const, error: refusal };
 
     const month = new Date(
@@ -246,7 +241,7 @@ export async function scheduleSale(
 
     await trx
       .insertInto('ModelVersionSaleItem')
-      .values(eligible.map((modelVersionId) => ({ saleId: sale.id, modelVersionId })))
+      .values(eligible.map((v) => ({ saleId: sale.id, modelVersionId: v.id })))
       .execute();
 
     return {
@@ -257,7 +252,7 @@ export async function scheduleSale(
       skippedUnpriced,
       // Returned rather than re-read after the commit: these are the rows just written, and a fresh
       // lookup for the cache bust is a replica read that can come back empty.
-      versionIds: eligible,
+      versionIds: eligible.map((v) => v.id),
     };
   });
 }
@@ -281,7 +276,8 @@ async function zeroFloorRefusal(
   // No ids means we cannot price a floor, which is not the same as there being none to clear.
   if (!versionIds.length) return 'Could not check the prices on this sale. Try again.';
 
-  const floor = lowestBuyerPrice(await coveredPriceRows(trx, userId, versionIds), tier);
+  const { eligible } = await classifySelection(trx, userId, versionIds);
+  const floor = lowestBuyerPrice(eligible, tier);
   if (floor === null || discount.discountAmount < floor) return null;
   return `That discount would take the cheapest covered version (${floor} Buzz) to zero. Lower it, or clear the gate to give the model away.`;
 }
@@ -415,27 +411,31 @@ async function classifySelection(
   trx: typeof dbRead | typeof dbWrite,
   userId: number,
   versionIds: number[]
-): Promise<{ eligible: number[]; skippedEarlyAccess: number; skippedUnpriced: number }> {
+): Promise<{
+  eligible: EligibleVersion[];
+  skippedEarlyAccess: number;
+  skippedUnpriced: number;
+}> {
   const rows = await trx
     .selectFrom('ModelVersion as mv')
     .innerJoin('Model as m', 'm.id', 'mv.modelId')
     .leftJoin('PaidAccess as pa', (join) =>
       join.onRef('pa.entityId', '=', 'mv.id').on('pa.entityType', '=', 'ModelVersion')
     )
-    .select(['mv.id', 'pa.timeframeDays', 'pa.endsAt', 'pa.terms'])
+    .select(['mv.id', 'mv.baseModel', 'pa.timeframeDays', 'pa.endsAt', 'pa.terms'])
     .where('mv.id', 'in', versionIds)
     .where('m.userId', '=', userId)
     .execute();
 
-  const eligible: number[] = [];
+  const eligible: EligibleVersion[] = [];
   let skippedEarlyAccess = 0;
   let skippedUnpriced = 0;
   for (const row of rows) {
     // A LEFT JOIN miss and a permanent gate both leave `timeframeDays` null, so the row is only a gate
     // when `terms` came back — otherwise every ungated version reads as permanent.
-    const gate = row.terms == null ? null : row;
-    if (isSaleEligibleGate(gate)) eligible.push(row.id);
-    else if (gate && gate.timeframeDays != null) skippedEarlyAccess++;
+    const verdict = classifyGate(row.terms == null ? null : row);
+    if (verdict === 'eligible') eligible.push(row);
+    else if (verdict === 'earlyAccess') skippedEarlyAccess++;
     else skippedUnpriced++;
   }
   return { eligible, skippedEarlyAccess, skippedUnpriced };

--- a/apps/creator-studio/src/lib/server/monetization/sales.ts
+++ b/apps/creator-studio/src/lib/server/monetization/sales.ts
@@ -11,6 +11,7 @@ import {
   type SaleLimitOverrides,
 } from '@civitai/buzz';
 import { dbRead, dbWrite } from '$lib/server/db';
+import { isSaleEligibleGate } from '$lib/server/monetization/sale-eligibility';
 import { saleLengthInDays } from '$lib/monetization/sales';
 
 // Scheduled sales — server reads and every write that changes a sale. Spec: CU 868ktk1ku.
@@ -34,29 +35,25 @@ const BUDGET_LOOKBACK_MONTHS = 2;
 const SALE_BUDGET_LOCK_CLASS = 4109;
 
 /**
- * Selected versions gated as Early Access, which a sale can't cover. `timeframeDays IS NOT NULL` is the
- * test, NOT `endsAt`: an unpublished timed gate also carries a null `endsAt` until publish materializes
- * it, so `endsAt` cannot tell a timed gate from a permanent one.
- *
- * Ownership-scoped like its siblings — an unscoped read would let the count report on versions the
- * caller doesn't own.
+ * What the sale form needs about a selection it can't see: how much of it a sale would actually cover,
+ * and why the rest is out. Same classification the write applies, so the form cannot offer a sale the
+ * write is going to refuse.
  */
-export async function countEarlyAccessVersions(
+export async function summarizeSaleSelection(
   userId: number,
   versionIds: number[]
-): Promise<number> {
-  if (!versionIds.length) return 0;
-  const row = await dbRead
-    .selectFrom('PaidAccess as pa')
-    .innerJoin('ModelVersion as mv', 'mv.id', 'pa.entityId')
-    .innerJoin('Model as m', 'm.id', 'mv.modelId')
-    .select(({ fn }) => fn.countAll<string>().as('count'))
-    .where('pa.entityType', '=', 'ModelVersion')
-    .where('pa.entityId', 'in', versionIds)
-    .where('pa.timeframeDays', 'is not', null)
-    .where('m.userId', '=', userId)
-    .executeTakeFirst();
-  return Number(row?.count ?? 0);
+): Promise<{ eligible: number; earlyAccess: number; unpriced: number }> {
+  if (!versionIds.length) return { eligible: 0, earlyAccess: 0, unpriced: 0 };
+  const { eligible, skippedEarlyAccess, skippedUnpriced } = await classifySelection(
+    dbRead,
+    userId,
+    versionIds
+  );
+  return {
+    eligible: eligible.length,
+    earlyAccess: skippedEarlyAccess,
+    unpriced: skippedUnpriced,
+  };
 }
 
 /**
@@ -144,7 +141,14 @@ export type ScheduleSaleInput = {
 };
 
 export type ScheduleSaleResult =
-  | { ok: true; saleId: number; covered: number; skippedEarlyAccess: number; versionIds: number[] }
+  | {
+      ok: true;
+      saleId: number;
+      covered: number;
+      skippedEarlyAccess: number;
+      skippedUnpriced: number;
+      versionIds: number[];
+    }
   | { ok: false; error: string };
 
 /** UTC midnight today — the earliest a sale may start. */
@@ -189,11 +193,18 @@ export async function scheduleSale(
 
     // Ownership and eligibility resolved on the primary too: a version that just changed hands or just
     // took an early-access gate must not slip in behind a stale replica.
-    const eligible = await eligibleVersionIds(trx, userId, versionIds);
+    const { eligible, skippedEarlyAccess, skippedUnpriced } = await classifySelection(
+      trx,
+      userId,
+      versionIds
+    );
     if (!eligible.length)
       return {
         ok: false as const,
-        error: "None of the selected versions can go on sale — a sale can't run on early access.",
+        error:
+          skippedUnpriced > 0
+            ? 'None of the selected versions can go on sale — a sale discounts a permanent access price, and none of them has one.'
+            : "None of the selected versions can go on sale — a sale can't run on early access.",
       };
 
     const refusal = await zeroFloorRefusal(trx, userId, eligible, tier, {
@@ -242,7 +253,8 @@ export async function scheduleSale(
       ok: true as const,
       saleId: sale.id,
       covered: eligible.length,
-      skippedEarlyAccess: versionIds.length - eligible.length,
+      skippedEarlyAccess,
+      skippedUnpriced,
       // Returned rather than re-read after the commit: these are the rows just written, and a fresh
       // lookup for the cache bust is a replica read that can come back empty.
       versionIds: eligible,
@@ -389,30 +401,44 @@ export async function deepenSale(
 }
 
 /**
- * Versions of `versionIds` the creator owns that are NOT early access. A version with no `PaidAccess`
- * row at all is included: it is ungated today, and a sale on it simply has nothing to discount until
- * they price it — refusing here would make "select all, schedule a sale" fail on a mixed selection.
+ * Splits a selection into the versions a sale can actually discount and the reasons the rest can't.
+ *
+ * A version with no permanent access price used to be eligible, on the reasoning that a sale over it
+ * simply discounts nothing until the creator prices it. That is the bug in CU 868kwp6cx: the sale is
+ * created, reports itself as covering the version, and then shows nothing on the card, the model page
+ * or the charge — because there is no price for `discountedTerms` to compose over. Every one of the 13
+ * sale items in production on 2026-08-25 was in that state.
+ *
+ * Versions the creator does not own are absent from the rows and silently dropped, as before.
  */
-async function eligibleVersionIds(
-  trx: typeof dbWrite,
+async function classifySelection(
+  trx: typeof dbRead | typeof dbWrite,
   userId: number,
   versionIds: number[]
-): Promise<number[]> {
+): Promise<{ eligible: number[]; skippedEarlyAccess: number; skippedUnpriced: number }> {
   const rows = await trx
     .selectFrom('ModelVersion as mv')
     .innerJoin('Model as m', 'm.id', 'mv.modelId')
     .leftJoin('PaidAccess as pa', (join) =>
-      join
-        .onRef('pa.entityId', '=', 'mv.id')
-        .on('pa.entityType', '=', 'ModelVersion')
-        .on('pa.timeframeDays', 'is not', null)
+      join.onRef('pa.entityId', '=', 'mv.id').on('pa.entityType', '=', 'ModelVersion')
     )
-    .select('mv.id')
+    .select(['mv.id', 'pa.timeframeDays', 'pa.endsAt', 'pa.terms'])
     .where('mv.id', 'in', versionIds)
     .where('m.userId', '=', userId)
-    .where('pa.entityId', 'is', null)
     .execute();
-  return rows.map((r) => r.id);
+
+  const eligible: number[] = [];
+  let skippedEarlyAccess = 0;
+  let skippedUnpriced = 0;
+  for (const row of rows) {
+    // A LEFT JOIN miss and a permanent gate both leave `timeframeDays` null, so the row is only a gate
+    // when `terms` came back — otherwise every ungated version reads as permanent.
+    const gate = row.terms == null ? null : row;
+    if (isSaleEligibleGate(gate)) eligible.push(row.id);
+    else if (gate && gate.timeframeDays != null) skippedEarlyAccess++;
+    else skippedUnpriced++;
+  }
+  return { eligible, skippedEarlyAccess, skippedUnpriced };
 }
 
 async function salesInMonth(

--- a/apps/creator-studio/src/routes/(app)/models/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/models/+page.svelte
@@ -74,7 +74,9 @@
   });
 
   // Arrived from Sales via "New sale": the page is here to collect a selection and hand it back.
-  const pickingForSale = $derived(page.url.searchParams.get('for') === 'sale' && data.salesEnabled);
+  // Read from the view rather than the URL so the banner cannot be absent while the list is narrowed —
+  // the server narrows on `for=sale` alone, and an unexplained short list is worse than an early prompt.
+  const pickingForSale = $derived(view.query.saleOnly);
 
   // The tier every cap on this page resolves against (a lapse falls back to free, never to "no access").
   const tier = $derived(data.caps.capTier);
@@ -422,10 +424,14 @@
     const qs = params.toString();
     return `/models/export${qs ? `?${qs}` : ''}`;
   });
+  // Every filter the empty state offers to clear. `mt` and `usage` were missing, so filtering to a type
+  // with no matches reported "you have no models" — and, under `for=sale`, "none of these can go on sale".
   const filterActive = $derived(
     !!view.query.q ||
       !!view.query.fee ||
       !!view.query.bm ||
+      !!view.query.mt ||
+      !!view.query.usage ||
       !!view.query.status ||
       view.query.access
   );
@@ -781,25 +787,25 @@
 <div aria-busy={searching} class={searching ? 'opacity-60 transition-opacity' : undefined}>
   {#if view.models.length === 0}
     <div class="placeholder">
-      {#if view.query.saleOnly}
-        Nothing here can go on sale. A sale discounts a permanent access price, so price a version
-        first — early access and licensing fees aren't what a sale takes Buzz off.
-        {#if filterActive}
-          <button
-            class="underline"
-            onclick={() =>
-              navigate({ q: null, fee: null, bm: null, status: null, access: null, page: null })}
-            >Clear filters</button
-          >
-        {/if}
-        <a href="/models">Set a price</a>
-      {:else if filterActive}
+      {#if filterActive}
         No models match your filters. <button
           class="underline"
           onclick={() =>
-            navigate({ q: null, fee: null, bm: null, status: null, access: null, page: null })}
-          >Clear</button
+            navigate({
+              q: null,
+              fee: null,
+              bm: null,
+              mt: null,
+              usage: null,
+              status: null,
+              access: null,
+              page: null,
+            })}>Clear</button
         >
+      {:else if view.query.saleOnly}
+        Nothing here can go on sale. A sale discounts a permanent access price, so price a version
+        first — early access and licensing fees aren't what a sale takes Buzz off.
+        <a href="/models">Set a price</a>
       {:else}
         You have no models yet. <a href="https://civitai.com/models/create"
           >Upload one on civitai.com</a

--- a/apps/creator-studio/src/routes/(app)/models/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/models/+page.svelte
@@ -478,6 +478,10 @@
         <p class="text-sm text-dark-1">
           Choose the versions to put on sale, then continue to set the discount and dates.
         </p>
+        <p class="text-sm text-dark-2">
+          Only versions sold with a permanent access price are listed — a sale takes Buzz off that
+          price, so there is nothing for it to discount anywhere else.
+        </p>
       </div>
       <div class="flex items-center gap-2">
         <span
@@ -777,7 +781,19 @@
 <div aria-busy={searching} class={searching ? 'opacity-60 transition-opacity' : undefined}>
   {#if view.models.length === 0}
     <div class="placeholder">
-      {#if filterActive}
+      {#if view.query.saleOnly}
+        Nothing here can go on sale. A sale discounts a permanent access price, so price a version
+        first — early access and licensing fees aren't what a sale takes Buzz off.
+        {#if filterActive}
+          <button
+            class="underline"
+            onclick={() =>
+              navigate({ q: null, fee: null, bm: null, status: null, access: null, page: null })}
+            >Clear filters</button
+          >
+        {/if}
+        <a href="/models">Set a price</a>
+      {:else if filterActive}
         No models match your filters. <button
           class="underline"
           onclick={() =>

--- a/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
@@ -6,7 +6,6 @@ import { bustVersionCache } from '$lib/server/monetization/bust-cache';
 import { getSaleLimitOverrides } from '$lib/server/monetization/sale-limits';
 import {
   cancelSale,
-  cheapestCoveredPrice,
   deepenSale,
   getCreatorSales,
   getManageableSales,
@@ -17,6 +16,7 @@ import {
 } from '$lib/server/monetization/sales';
 import { resolveCreatorScore, TEST_CREATOR_SCORE_COOKIE } from '$lib/server/creator-score';
 import { minCreatorScoreForSale } from '@civitai/buzz';
+import { salePreviewPayload } from '$lib/monetization/sales';
 import type { SessionUser } from '@civitai/auth';
 import { getFlipt, fliptContext } from '$lib/server/flipt';
 
@@ -124,20 +124,14 @@ export const actions: Actions = {
     const form = await request.formData();
     const parsed = versionIdsSchema.safeParse(form.get('versionIds'));
     if (!parsed.success) return fail(400, { error: firstError(parsed.error) });
-    const [selection, minCoveredPrice] = await Promise.all([
-      summarizeSaleSelection(locals.user.id, parsed.data),
-      cheapestCoveredPrice(
-        locals.user.id,
-        parsed.data,
-        cappedTier(resolveMembership(locals.user, cookies.get(TEST_MEMBERSHIP_COOKIE)))
-      ),
-    ]);
-    return {
-      earlyAccess: selection.earlyAccess,
-      unpriced: selection.unpriced,
-      eligible: selection.eligible,
-      minCoveredPrice,
-    };
+    // cappedTier, not the display label: the floor is measured against what a buyer is charged, and a
+    // lapsed membership keeps its name but is capped at free.
+    const selection = await summarizeSaleSelection(
+      locals.user.id,
+      parsed.data,
+      cappedTier(resolveMembership(locals.user, cookies.get(TEST_MEMBERSHIP_COOKIE)))
+    );
+    return salePreviewPayload(selection);
   },
 
   scheduleSale: async ({ request, locals, cookies }) => {

--- a/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
@@ -7,13 +7,13 @@ import { getSaleLimitOverrides } from '$lib/server/monetization/sale-limits';
 import {
   cancelSale,
   cheapestCoveredPrice,
-  countEarlyAccessVersions,
   deepenSale,
   getCreatorSales,
   getManageableSales,
   getSaleVersionsBySale,
   scheduleSale,
   shortenSale,
+  summarizeSaleSelection,
 } from '$lib/server/monetization/sales';
 import { resolveCreatorScore, TEST_CREATOR_SCORE_COOKIE } from '$lib/server/creator-score';
 import { minCreatorScoreForSale } from '@civitai/buzz';
@@ -116,23 +116,28 @@ export const load: PageServerLoad = async ({ locals, parent, cookies }) => {
 };
 
 export const actions: Actions = {
-  // What the sale form needs about a selection it can't see: how much of it is early access (a sale
-  // can't cover that) and the cheapest price among the rest (a fixed discount must stay under it).
+  // What the sale form needs about a selection it can't see: how much of it a sale would cover, why
+  // the rest is out, and the cheapest price among the covered ones (a fixed discount must stay under it).
   salePreview: async ({ request, locals, cookies }) => {
     if (await salesOff(locals.user))
       return fail(403, { error: 'Scheduled sales are not available yet.' });
     const form = await request.formData();
     const parsed = versionIdsSchema.safeParse(form.get('versionIds'));
     if (!parsed.success) return fail(400, { error: firstError(parsed.error) });
-    const [earlyAccess, minCoveredPrice] = await Promise.all([
-      countEarlyAccessVersions(locals.user.id, parsed.data),
+    const [selection, minCoveredPrice] = await Promise.all([
+      summarizeSaleSelection(locals.user.id, parsed.data),
       cheapestCoveredPrice(
         locals.user.id,
         parsed.data,
         cappedTier(resolveMembership(locals.user, cookies.get(TEST_MEMBERSHIP_COOKIE)))
       ),
     ]);
-    return { earlyAccess, minCoveredPrice };
+    return {
+      earlyAccess: selection.earlyAccess,
+      unpriced: selection.unpriced,
+      eligible: selection.eligible,
+      minCoveredPrice,
+    };
   },
 
   scheduleSale: async ({ request, locals, cookies }) => {
@@ -183,6 +188,7 @@ export const actions: Actions = {
       scheduled: true,
       covered: result.covered,
       skippedEarlyAccess: result.skippedEarlyAccess,
+      skippedUnpriced: result.skippedUnpriced,
     };
   },
 

--- a/apps/creator-studio/src/routes/(app)/sales/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.svelte
@@ -19,7 +19,12 @@
   import SaleFields from '$lib/components/monetization/SaleFields.svelte';
   import { resolveSaleDraft, type SaleDraftInput } from '$lib/monetization/sales';
   import { isSaleActive, remainingSaleDays, type ModelVersionSaleWindow } from '@civitai/buzz';
-  import { budgetMonthOf, minCreatorScoreForSale, shortenBounds } from '$lib/monetization/sales';
+  import {
+    budgetMonthOf,
+    minCreatorScoreForSale,
+    parseSalePreview,
+    shortenBounds,
+  } from '$lib/monetization/sales';
   import type { PageData } from './$types';
 
   // Scheduled sales, listed and managed. Starting one lives on the Models tab, where the selection is;
@@ -104,6 +109,9 @@
       .map((v) => Number(v.trim()))
       .filter((n) => Number.isInteger(n) && n > 0)
   );
+  // The preview depends on WHICH versions, not on the array's identity. `draftVersionIds` rebuilds on
+  // every `page.url` change, so depending on it re-POSTed the preview for an unchanged selection.
+  const draftVersionKey = $derived(draftVersionIds.join(','));
   // Flag-gated as well as URL-driven: a ?versions= link must not open a form whose submit would be
   // refused with a 403 the creator can do nothing about.
   const creating = $derived(draftVersionIds.length > 0 && data.salesEnabled);
@@ -135,15 +143,19 @@
 
   // What the form can't see about a selection this page never listed: how much of it a sale would
   // cover, why the rest is out, and the cheapest price among the covered ones. undefined = not known,
-  // which blocks rather than waves through.
-  let earlyAccessCount = $state(0);
-  let unpricedCount = $state(0);
+  // which blocks rather than waves through — a failed preview must not read as full coverage.
+  let earlyAccessCount = $state<number | undefined>(undefined);
+  let unpricedCount = $state<number | undefined>(undefined);
   let minCoveredPrice = $state<number | null | undefined>(undefined);
   let loadingPreview = $state(false);
   let previewRequest = 0;
   $effect(() => {
-    const ids = draftVersionIds;
+    const key = draftVersionKey;
+    const ids = key ? key.split(',') : [];
     if (ids.length === 0) {
+      // Bump first: an in-flight preview for the previous selection would otherwise still pass the
+      // sequence guard and write its counts back over this reset.
+      previewRequest++;
       earlyAccessCount = 0;
       unpricedCount = 0;
       minCoveredPrice = undefined;
@@ -151,28 +163,28 @@
     }
     const seq = ++previewRequest;
     const body = new FormData();
-    body.set('versionIds', ids.join(','));
+    body.set('versionIds', key);
     loadingPreview = true;
     fetch('?/salePreview', { method: 'POST', body })
       .then((r) => r.text())
       .then((r) => {
         if (seq !== previewRequest) return;
         const parsed = deserialize(r);
-        if (parsed.type !== 'success') {
-          earlyAccessCount = 0;
-          unpricedCount = 0;
+        const preview = parsed.type === 'success' ? parseSalePreview(parsed.data) : undefined;
+        if (!preview) {
+          earlyAccessCount = undefined;
+          unpricedCount = undefined;
           minCoveredPrice = undefined;
           return;
         }
-        earlyAccessCount = Number(parsed.data?.earlyAccess ?? 0);
-        unpricedCount = Number(parsed.data?.unpriced ?? 0);
-        const min = parsed.data?.minCoveredPrice;
-        minCoveredPrice = min == null ? null : Number(min);
+        earlyAccessCount = preview.earlyAccess;
+        unpricedCount = preview.unpriced;
+        minCoveredPrice = preview.minCoveredPrice;
       })
       .catch(() => {
         if (seq !== previewRequest) return;
-        earlyAccessCount = 0;
-        unpricedCount = 0;
+        earlyAccessCount = undefined;
+        unpricedCount = undefined;
         minCoveredPrice = undefined;
       })
       .finally(() => {

--- a/apps/creator-studio/src/routes/(app)/sales/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.svelte
@@ -144,6 +144,7 @@
   // What the form can't see about a selection this page never listed: how much of it a sale would
   // cover, why the rest is out, and the cheapest price among the covered ones. undefined = not known,
   // which blocks rather than waves through — a failed preview must not read as full coverage.
+  let eligibleCount = $state<number | undefined>(undefined);
   let earlyAccessCount = $state<number | undefined>(undefined);
   let unpricedCount = $state<number | undefined>(undefined);
   let minCoveredPrice = $state<number | null | undefined>(undefined);
@@ -156,6 +157,9 @@
       // Bump first: an in-flight preview for the previous selection would otherwise still pass the
       // sequence guard and write its counts back over this reset.
       previewRequest++;
+      // The bump orphans any in-flight request, so its `finally` will not clear this.
+      loadingPreview = false;
+      eligibleCount = 0;
       earlyAccessCount = 0;
       unpricedCount = 0;
       minCoveredPrice = undefined;
@@ -172,17 +176,20 @@
         const parsed = deserialize(r);
         const preview = parsed.type === 'success' ? parseSalePreview(parsed.data) : undefined;
         if (!preview) {
+          eligibleCount = undefined;
           earlyAccessCount = undefined;
           unpricedCount = undefined;
           minCoveredPrice = undefined;
           return;
         }
+        eligibleCount = preview.eligible;
         earlyAccessCount = preview.earlyAccess;
         unpricedCount = preview.unpriced;
         minCoveredPrice = preview.minCoveredPrice;
       })
       .catch(() => {
         if (seq !== previewRequest) return;
+        eligibleCount = undefined;
         earlyAccessCount = undefined;
         unpricedCount = undefined;
         minCoveredPrice = undefined;
@@ -201,6 +208,7 @@
       sale,
       {
         selectedCount: draftVersionIds.length,
+        eligibleCount,
         earlyAccessCount,
         unpricedCount,
         minCoveredPrice,

--- a/apps/creator-studio/src/routes/(app)/sales/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.svelte
@@ -69,10 +69,16 @@
         await invalidateAll();
         if (result.data?.cancelled) selectedId = null;
         if (result.data?.scheduled) {
-          const skipped = Number(result.data?.skippedEarlyAccess ?? 0);
+          const earlyAccess = Number(result.data?.skippedEarlyAccess ?? 0);
+          const unpriced = Number(result.data?.skippedUnpriced ?? 0);
+          const covered = Number(result.data?.covered ?? 0);
+          const reasons = [
+            earlyAccess > 0 ? `${earlyAccess} already in early access` : null,
+            unpriced > 0 ? `${unpriced} with no access price` : null,
+          ].filter(Boolean);
           toast.success(
-            skipped > 0
-              ? `Sale scheduled on ${result.data?.covered} version${result.data?.covered === 1 ? '' : 's'} — ${skipped} skipped, already in early access.`
+            reasons.length > 0
+              ? `Sale scheduled on ${covered} version${covered === 1 ? '' : 's'} — skipped ${reasons.join(' and ')}.`
               : 'Sale scheduled.'
           );
           await closeCreate();
@@ -127,9 +133,11 @@
     sale.endDate = isoDay(new Date(start.getTime() + (span - 1) * 86_400_000));
   });
 
-  // What the form can't see about a selection this page never listed: how much of it is early access,
-  // and the cheapest price among the rest. undefined = not known, which blocks rather than waves through.
+  // What the form can't see about a selection this page never listed: how much of it a sale would
+  // cover, why the rest is out, and the cheapest price among the covered ones. undefined = not known,
+  // which blocks rather than waves through.
   let earlyAccessCount = $state(0);
+  let unpricedCount = $state(0);
   let minCoveredPrice = $state<number | null | undefined>(undefined);
   let loadingPreview = $state(false);
   let previewRequest = 0;
@@ -137,6 +145,7 @@
     const ids = draftVersionIds;
     if (ids.length === 0) {
       earlyAccessCount = 0;
+      unpricedCount = 0;
       minCoveredPrice = undefined;
       return;
     }
@@ -151,16 +160,19 @@
         const parsed = deserialize(r);
         if (parsed.type !== 'success') {
           earlyAccessCount = 0;
+          unpricedCount = 0;
           minCoveredPrice = undefined;
           return;
         }
         earlyAccessCount = Number(parsed.data?.earlyAccess ?? 0);
+        unpricedCount = Number(parsed.data?.unpriced ?? 0);
         const min = parsed.data?.minCoveredPrice;
         minCoveredPrice = min == null ? null : Number(min);
       })
       .catch(() => {
         if (seq !== previewRequest) return;
         earlyAccessCount = 0;
+        unpricedCount = 0;
         minCoveredPrice = undefined;
       })
       .finally(() => {
@@ -178,6 +190,7 @@
       {
         selectedCount: draftVersionIds.length,
         earlyAccessCount,
+        unpricedCount,
         minCoveredPrice,
         creatorScore: data.creatorScore,
         tier: data.capTier,

--- a/src/server/services/__tests__/model-version.bust-sale-caches.service.test.ts
+++ b/src/server/services/__tests__/model-version.bust-sale-caches.service.test.ts
@@ -97,9 +97,9 @@ describe('bustMvCache', () => {
     expect(bustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', [11]);
   });
 
-  // And the other direction. The search-index enqueue at the end of this function is the one leg that
-  // does NOT self-heal — every cache here expires on a TTL, the Meilisearch document does not — so a
-  // Redis fault on the cheapest bust must not be what stops it running.
+  // And the other direction. Note what this does NOT establish: the five busts between this one and the
+  // enqueue are unguarded, so any of them throwing still loses it. This pins only that the two sale
+  // busts are not what stops it.
   it('still reaches the search-index enqueue when the gate-row bust throws', async () => {
     vi.mocked(bustPaidAccessCache).mockRejectedValueOnce(new Error('redis down'));
 

--- a/src/server/services/__tests__/model-version.bust-sale-caches.service.test.ts
+++ b/src/server/services/__tests__/model-version.bust-sale-caches.service.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// bustMvCache is the ONLY invalidation Creator Studio can reach: scheduling, cancelling, shortening and
+// deepening a sale all POST /api/v1/model-versions/bust-cache, which calls it. A sale write moves two
+// cached things — the per-model badge window AND the per-version gate row, which carries the sale
+// windows the model page prices from — and only the first was busted, so for the rest of the hour the
+// card and the page disagreed about the same sale. This pins both.
+//
+// The mock wall mirrors bust-public-model-response-cache.service.test.ts: model-version.service pulls
+// the search-index / meili / prom graph at load.
+
+const { envBox } = vi.hoisted(() => ({
+  envBox: {
+    IS_DATAPACKET: true,
+    LOGGING: '',
+    MEILI_CALL_CONCURRENCY: 50,
+    SIGNALS_CALL_CONCURRENCY: 30,
+    S3_UPLOAD_ENDPOINT: 'http://localhost:9000',
+    S3_IMAGE_UPLOAD_ENDPOINT: 'http://localhost:9000',
+  } as Record<string, unknown>,
+}));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy(envBox, { get: (t, p: string) => (p in t ? t[p] : undefined) }),
+}));
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, dbReadFallbackCounter: { inc: vi.fn() } };
+});
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { refresh: vi.fn() },
+  modelVersionAccessCache: { refresh: vi.fn() },
+}));
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: { bust: vi.fn() } }));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: { queueUpdate: vi.fn() } }));
+vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({}));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/donation-goal.service', () => ({ checkDonationGoalComplete: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({
+  imagesForModelVersionsCache: { refresh: vi.fn() },
+  uploadImageFromUrl: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
+vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({ updateModelLastVersionAt: vi.fn() }));
+vi.mock('~/server/services/model-file.service', () => ({
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
+// Spread the real module: hand-listing its exports couples this file to model-version.service's whole
+// import graph, and the next export it reaches for would fail to load here rather than fail a test.
+vi.mock('~/server/services/paid-access.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  bustModelSaleCache: vi.fn(),
+  bustPaidAccessCache: vi.fn(),
+}));
+
+import { bustMvCache } from '~/server/services/model-version.service';
+import { bustModelSaleCache, bustPaidAccessCache } from '~/server/services/paid-access.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bustMvCache', () => {
+  // 🔴 Do not delete either assertion because "the badge bust covers it". They are different caches with
+  // different keys: the badge is per MODEL, the gate row is per VERSION, and the model page reads the
+  // price from the gate row. Dropping the second one restores a sale that badges on the card and shows
+  // full price on the page for up to an hour (CU 868kwp6ne).
+  it('busts the sale-window caches on both sides of the display path', async () => {
+    await bustMvCache([11, 22], [7]);
+
+    expect(bustModelSaleCache).toHaveBeenCalledWith([11, 22]);
+    expect(bustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', [11, 22]);
+  });
+
+  it('busts them for a single id passed unwrapped', async () => {
+    await bustMvCache(11);
+
+    expect(bustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', [11]);
+  });
+
+  // The badge bust is deliberately swallowed — a stale badge must not fail an unpublish. That must not
+  // take the gate-row bust down with it, which is what putting them in one try block would do.
+  it('still busts the gate row when the badge bust throws', async () => {
+    vi.mocked(bustModelSaleCache).mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(bustMvCache([11])).resolves.toBeUndefined();
+    expect(bustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', [11]);
+  });
+});

--- a/src/server/services/__tests__/model-version.bust-sale-caches.service.test.ts
+++ b/src/server/services/__tests__/model-version.bust-sale-caches.service.test.ts
@@ -61,6 +61,7 @@ vi.mock('~/server/services/paid-access.service', async (importOriginal) => ({
 
 import { bustMvCache } from '~/server/services/model-version.service';
 import { bustModelSaleCache, bustPaidAccessCache } from '~/server/services/paid-access.service';
+import { modelsSearchIndex } from '~/server/search-index';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -76,6 +77,9 @@ describe('bustMvCache', () => {
 
     expect(bustModelSaleCache).toHaveBeenCalledWith([11, 22]);
     expect(bustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', [11, 22]);
+    // Once each. A consolidation that folds a second bust in at a caller is otherwise invisible here.
+    expect(bustModelSaleCache).toHaveBeenCalledTimes(1);
+    expect(bustPaidAccessCache).toHaveBeenCalledTimes(1);
   });
 
   it('busts them for a single id passed unwrapped', async () => {
@@ -91,5 +95,15 @@ describe('bustMvCache', () => {
 
     await expect(bustMvCache([11])).resolves.toBeUndefined();
     expect(bustPaidAccessCache).toHaveBeenCalledWith('ModelVersion', [11]);
+  });
+
+  // And the other direction. The search-index enqueue at the end of this function is the one leg that
+  // does NOT self-heal — every cache here expires on a TTL, the Meilisearch document does not — so a
+  // Redis fault on the cheapest bust must not be what stops it running.
+  it('still reaches the search-index enqueue when the gate-row bust throws', async () => {
+    vi.mocked(bustPaidAccessCache).mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(bustMvCache([11], [7])).resolves.toBeUndefined();
+    expect(modelsSearchIndex.queueUpdate).toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
@@ -52,6 +52,7 @@ vi.mock('~/server/services/paid-access.service', () => ({
   assertPaidAccessInput: vi.fn(),
   getFreshSalesForPermanentGate: vi.fn().mockResolvedValue([]),
   bustModelSaleCache: vi.fn(),
+  bustPaidAccessCache: vi.fn(),
 }));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));

--- a/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
+++ b/src/server/services/__tests__/model-version.unpublish-refund.service.test.ts
@@ -45,7 +45,12 @@ vi.mock('~/server/search-index', () => ({
   imagesSearchIndex: { queueUpdate: vi.fn() },
   imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
 }));
-vi.mock('~/server/services/paid-access.service', () => ({
+// Spread the real module rather than listing its exports: a hand-listed mock couples this file to
+// model-version.service's whole import graph, and the next export it reaches for fails to LOAD here
+// rather than failing an assertion. That is what happened when `bustPaidAccessCache` was added — only a
+// full-suite run found it, hours later.
+vi.mock('~/server/services/paid-access.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   materializePaidAccessEndsAt: vi.fn(),
   writePaidAccessForModelVersion: vi.fn(),
   getPaidAccess: vi.fn(),

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -2568,8 +2568,11 @@ export const bustMvCache = async (
   // endpoint that calls this, so without it a cancelled sale stayed advertised for the whole TTL.
   try {
     await bustModelSaleCache(versionIds);
-  } catch {
+  } catch (error) {
     // Best-effort, like the busts around it: a stale badge is not worth failing an unpublish over.
+    // Logged rather than silent — a sustained Redis fault otherwise advertises stale sales for a full
+    // TTL with nothing recorded anywhere.
+    logToAxiom({ type: 'error', name: 'bust-model-sale-cache', message: 'sale badge', error });
   }
   // Not covered by the badge bust above: the gate row caches the sale windows too, and it is what the
   // model page prices from. Busting one and not the other left the card and the page disagreeing about
@@ -2578,8 +2581,9 @@ export const bustMvCache = async (
   // search-index enqueue at the end of this function does not.
   try {
     await bustPaidAccessCache('ModelVersion', versionIds);
-  } catch {
+  } catch (error) {
     // Best-effort: a stale price on the model page is not worth failing an unpublish over.
+    logToAxiom({ type: 'error', name: 'bust-paid-access-cache', message: 'gate row', error });
   }
   await bustOrchestratorModelCache(versionIds, userId);
   await modelVersionAccessCache.refresh(versionIds);

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -2573,8 +2573,14 @@ export const bustMvCache = async (
   }
   // Not covered by the badge bust above: the gate row caches the sale windows too, and it is what the
   // model page prices from. Busting one and not the other left the card and the page disagreeing about
-  // the same sale for the rest of the hour (868kwp6ne).
-  await bustPaidAccessCache('ModelVersion', versionIds);
+  // the same sale for the rest of the hour (868kwp6ne). Guarded like the badge for the same reason, and
+  // separately from it so one Redis fault cannot take both — this row self-heals on its TTL, while the
+  // search-index enqueue at the end of this function does not.
+  try {
+    await bustPaidAccessCache('ModelVersion', versionIds);
+  } catch {
+    // Best-effort: a stale price on the model page is not worth failing an unpublish over.
+  }
   await bustOrchestratorModelCache(versionIds, userId);
   await modelVersionAccessCache.refresh(versionIds);
   // Refresh imagesForModelVersionsCache too — TTL is up to 1 day on Datapacket,

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -83,6 +83,7 @@ import {
   getPaidAccess,
   getFreshSalesForPermanentGate,
   bustModelSaleCache,
+  bustPaidAccessCache,
   materializePaidAccessEndsAt,
   writePaidAccessForModelVersion,
 } from '~/server/services/paid-access.service';
@@ -2570,6 +2571,10 @@ export const bustMvCache = async (
   } catch {
     // Best-effort, like the busts around it: a stale badge is not worth failing an unpublish over.
   }
+  // Not covered by the badge bust above: the gate row caches the sale windows too, and it is what the
+  // model page prices from. Busting one and not the other left the card and the page disagreeing about
+  // the same sale for the rest of the hour (868kwp6ne).
+  await bustPaidAccessCache('ModelVersion', versionIds);
   await bustOrchestratorModelCache(versionIds, userId);
   await modelVersionAccessCache.refresh(versionIds);
   // Refresh imagesForModelVersionsCache too — TTL is up to 1 day on Datapacket,

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -4872,7 +4872,9 @@ export async function transferModelOwnership({
         modelIds.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
       )
     ),
-    // Not covered by bustMvCache: the gate row carries ownerId, the public donation goal carries userId.
+    // The gate row carries ownerId and the public donation goal carries userId, so both have to go.
+    // bustMvCache busts the gate row too as of 868kwp6ne — this stays as the deliberate duplicate that
+    // keeps the pair together, and a second bust of an already-busted key costs one SET.
     invalidation('bustPaidAccessCache', bustPaidAccessCache('ModelVersion', affectedVersionIds)),
     invalidation(
       'bustPublicDonationGoals',


### PR DESCRIPTION
From the 2026-08-25 sync with Ellie: she set a 20% sale on a model with no license fee and nothing appeared anywhere. The display side was right — there was no price to discount. She should never have been able to pick it.

## What was wrong

A sale composes over a **permanent paid-access price** and nothing else (`discountedTerms` in `@civitai/buzz`). Eligibility only asked *"is this early access?"* — so a version with no price at all was selectable, schedulable, and then discounted nothing on the card, the model page or the charge.

This is not one creator's mistake. Every `ModelVersionSaleItem` row in production is in that state:

```
sale_items: 13   sale_items_covering_nothing: 13   sales_with_items: 2
```

Ellie's is sale 2. Neither sale can ever have shown anything.

## What changed

**One predicate decides eligibility** — `apps/creator-studio/src/lib/server/monetization/sale-eligibility.ts`: an *active, permanent* gate with a download or generation price above zero, scoped to the owner. Three surfaces read it, so they cannot drift:

| Surface | Half it uses |
|---|---|
| The picker's list on `/models?for=sale` | SQL (`saleEligibleFilter`) — it pages, so JS can't answer for it |
| The sale form's preview (`summarizeSaleSelection`) | JS (`classifyGate` / `isSaleEligibleGate`) |
| `scheduleSale` on the primary, inside the transaction | the same JS |

The filter reaches **all three** queries in `getCreatorModels` — the model-list `EXISTS`, the versions query, and `matchingVersionIds` — so "select all" cannot select what the list does not show. `for=sale` rides `buildParams`, so filter-as-you-type through `/models/search` keeps the narrowing.

The floor a Fixed discount must clear is now measured over the same rows, in the same query. Unpriced versions are reported as skipped **separately** from early-access ones, in the form and in the post-schedule toast.

**Early access stays out.** Confirmed with @JustMaier — a sale cannot discount it, and the feature brief said so before any of this code existed.

## The caching half (CU 868kwp6ne)

Justin suspected caching. Measured on a dev server on this branch, dev DB, key read before each removal:

- **Card badge — fine, and never the problem.** `modelSaleCache`, TTL 60s, *and* busted by `bustMvCache`. A sale inserted in raw SQL with **no bust at all** came back from `model.getActiveSales` on the next request.
- **Model page price and sale card — stale, up to an hour.** `paidAccessCache` carries the sale windows beside the terms, TTL 1h, SWR off, and `bustMvCache` did not bust it. With the sale live the page read `sale: null` at 300 Buzz; after removing the key, 240 (20% off). Then the percent sale was ended and a Fixed 100 one started: the page went on serving the **ended** sale until the same removal, then 200. Both shapes correct, units are Buzz.
- **The charge is unaffected** — `getFreshSalesForPermanentGate` reads the primary, never the cache. A display divergence, not a billing one. (Read in code, not measured.)

So `bustMvCache` busts the gate row too, guarded like the badge bust beside it and separately from it.

## Review round (second commit)

Eight lanes over the first commit — three Svelte, five main-app, all prompted to refute. Six real defects, four introduced by that commit, all fixed in `5a7ec260`:

- **The pre-schedule notice stated something false.** Summing the two skip reasons left `SaleFields.svelte` telling a creator that three unpriced versions were in early access. The test asserting the sum was pinning the bug.
- **A failed preview read as full coverage** — counts reset to 0, Apply offered, write refused. They are `undefined` on failure now and block, the rule the floor check already applied one field over.
- **Two definitions of "the covered set"**, so a Fixed discount's floor could be priced against a version the sale would not cover. One query, one definition.
- **The `EXISTS` was not owner-scoped.** Production `EXPLAIN`: **41.9 ms / 29,985 buffers** for a creator with *no* gates, ×3 per page load, scaling with the table rather than the creator. With `pa."ownerId" = <userId>`: **0.043 ms**. Positive control: 570 rows still match for the largest gate owner.
- **JS and SQL disagreed on a string price and on a free generation grant.** Both closed, both tested.
- **`filterActive` was missing `mt`/`usage`**, so a type filter with no matches was diagnosed as "nothing here can go on sale".

Test lane findings acted on: the SQL predicate is asserted as one whole string (`exists` → `not exists` passed the substring version), `classifyGate` is extracted and tested so its two arms can't be swapped silently, `?/salePreview` is a typed contract both sides go through, and the hand-listed `paid-access.service` mock is now `importOriginal` — hand-listing is what let the first commit break that file.

## Verification

`pnpm run typecheck` 0 errors · `svelte-check` 8,978 files, 0 errors 0 warnings · lint unchanged against the baseline on every changed file · prettier clean (Creator Studio formats its own tree) · `test:apps:run` 86 files / 911 passed · `test:lint-rules` 21 files / 347 passed · `test:unit:run` **1 failed | 22,113 passed**, and `blocks.router.workflow.test.ts` collected **358**.

The one red is `src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts`, pre-existing and unrelated — a path guard comparing `src\pages\...` to `src/pages/...`, i.e. Windows separators. This branch touches no file under `AppBlocks`.

Every claim above that says "measured" has a positive control behind it: each revert control was run and named its failure, and the production predicate was checked both ways — 570 matching rows for a real creator, 0 of the 13 existing sale-covered versions.

## No migration, and the existing rows stay

Nothing to apply. The 13 dead `ModelVersionSaleItem` rows stay as they are — **@JustMaier's call**, asked and answered. They discount nothing and both sales end 2026-09-01.

Worth knowing when this is reported as fixed: it prevents recurrence, it does not repair Ellie's sale. Hers still shows as running, still reports itself as covering versions, and still discounts nothing until it expires.

Closes CU [868kwp6mp](https://app.clickup.com/t/868kwp6mp), [868kwp6ne](https://app.clickup.com/t/868kwp6ne)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLcLCqeC97jyU5iKqfmWbd
