### PR TITLE
fix(challenges): one failed group must not abandon the whole Swiss tick

### DIFF
--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -40,7 +40,14 @@ vi.mock('~/server/logging/client', () => ({
 }));
 
 import { rollingSwissEngine } from '~/server/games/daily-challenge/challenge-engine-rolling-swiss';
-import { GROUP_SIZE, RELATIONS_PER_CALL } from '~/server/games/daily-challenge/challenge-swiss';
+import {
+  DEFAULT_BOUT_BUDGET,
+  GROUP_SIZE,
+  RELATIONS_PER_CALL,
+} from '~/server/games/daily-challenge/challenge-swiss';
+
+/** Mirrors the engine's own private backstop, so the close tests can assert they did not hit it. */
+const MAX_SETTLE_PASSES = DEFAULT_BOUT_BUDGET + 2;
 
 const ctx = {
   challengeId: 1,
@@ -76,6 +83,50 @@ function stubQueries(imageCount: number) {
     );
   });
 }
+
+/**
+ * 🔴 `getSwissState` returning a CONSTANT makes the close loop untestable: the engine's view of the
+ * field never changes, `planGroups` re-plans the same groups every pass, and the settle loop can
+ * only exit by exhausting `MAX_SETTLE_PASSES`. A test then reaches pass 11 while reading as though
+ * it reached pass 2, and "the field is measured" and "the field is not" are the same fixture — which
+ * is exactly the distinction the close-time money guard turns on.
+ *
+ * This derives the tallies from what `recordComparison` was actually given, so the loop terminates
+ * the way production's does: entries reach their budget and stop being planned.
+ */
+function useAccumulatingState() {
+  getSwissState.mockImplementation(() => {
+    const wins = new Map<number, number>();
+    const games = new Map<number, number>();
+    const played = new Set<string>();
+    for (const [arg] of recordComparison.mock.calls) {
+      const { imageIdA, imageIdB, winnerImageId } = (
+        arg as { verdict: { imageIdA: number; imageIdB: number; winnerImageId: number } }
+      ).verdict;
+      // Mirrors the engine's own `pairKey`, which is module-private.
+      played.add(imageIdA < imageIdB ? `${imageIdA}:${imageIdB}` : `${imageIdB}:${imageIdA}`);
+      games.set(imageIdA, (games.get(imageIdA) ?? 0) + 1);
+      games.set(imageIdB, (games.get(imageIdB) ?? 0) + 1);
+      wins.set(winnerImageId, (wins.get(winnerImageId) ?? 0) + 1);
+    }
+    return Promise.resolve({ wins, games, played });
+  });
+}
+
+/** The one `challenge-swiss-close` event a close emits. */
+function closeEvent(): { passes: number; shortOfBudget: number } | undefined {
+  return logToAxiom.mock.calls
+    .map(([arg]) => arg as { name: string; passes: number; shortOfBudget: number })
+    .find((arg) => arg.name === 'challenge-swiss-close');
+}
+
+const closeField = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    imageId: i + 1,
+    userId: i + 1,
+    username: `u${i}`,
+    weightedRating: 0,
+  }));
 
 /** The `failedGroups` payload of the one `challenge-swiss-group-failed` event a tick emits. */
 function failedGroupsFrom(log: typeof logToAxiom): string[] {
@@ -198,7 +249,9 @@ describe('advance and rankField', () => {
     // Attribution is the whole point of logging membership, and with four groups "the right group"
     // is a claim that can be wrong. The failed group must be exactly the entries that recorded
     // nothing — logging `groups[0]`, or every planned group, makes the field actively misleading.
-    const failedIds = failedGroupsFrom(logToAxiom)[0].split(',').sort();
+    const failedIds = failedGroupsFrom(logToAxiom)[0]
+      .split(',')
+      .sort((a, b) => Number(a) - Number(b));
     const recordedIds = new Set(
       recordComparison.mock.calls.flatMap(([arg]) => {
         const { imageIdA, imageIdB } = (arg as { verdict: { imageIdA: number; imageIdB: number } })
@@ -291,6 +344,28 @@ describe('advance and rankField', () => {
     );
   });
 
+  /**
+   * The id list is capped, so on a field-wide outage it stops being the count. Without
+   * `failedGroupsTruncated` beside it a reader takes 20 as the number of failed groups.
+   */
+  it('caps the logged ids on a field-wide outage and SAYS the list was cut', async () => {
+    const field = GROUP_SIZE * 21;
+    getStandings.mockResolvedValue(standings(field));
+    stubQueries(field);
+    compareGroup.mockRejectedValue(new Error('Provider returned error'));
+
+    await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(0);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-group-failed',
+        planned: 21,
+        failed: 21,
+        failedGroupsTruncated: true,
+      })
+    );
+    expect(failedGroupsFrom(logToAxiom)).toHaveLength(20);
+  });
+
   it('reports a group skipped for missing images under its OWN name, not as a failure', async () => {
     getStandings.mockResolvedValue(standings(GROUP_SIZE * 4));
     // One image of the sixteen does not load, so exactly one group is short whichever band it lands
@@ -358,7 +433,11 @@ describe('advance and rankField', () => {
     // A group fails as a UNIT, and its membership is what makes attribution possible across ticks.
     // Compared as a set: the entries are logged in PRESENTATION order, which the band shuffle
     // deliberately varies, so asserting the literal order would pin the shuffle rather than the log.
-    expect(failedGroupsFrom(logToAxiom)[0].split(',').sort()).toEqual(['1', '2', '3', '4']);
+    expect(
+      failedGroupsFrom(logToAxiom)[0]
+        .split(',')
+        .sort((a, b) => Number(a) - Number(b))
+    ).toEqual(['1', '2', '3', '4']);
     // Nothing was billed: the provider never returned a usage figure to bill from.
     expect(incrementOperationSpent).not.toHaveBeenCalled();
   });
@@ -366,6 +445,34 @@ describe('advance and rankField', () => {
   // Passes against the UNFIXED engine too — it is not a revert control, it is the third arm of the
   // three-way distinction: success emits neither warning. It fails if either log is ever moved out
   // of its `if`, which is the edit it exists to stop.
+  /**
+   * The guards exist because `isContentRefusal` and the message read both touch properties of a
+   * thrown value, INSIDE the catch that stops a failure escaping. A throwing accessor there escapes
+   * `runPool` and abandons the tick — the exact bug this file was changed to remove, re-entering
+   * through the recovery path. Without the wrappers this test rejects instead of resolving.
+   */
+  it('survives an error whose own message THROWS when read', async () => {
+    getStandings.mockResolvedValue(standings(GROUP_SIZE));
+    stubQueries(GROUP_SIZE);
+    const hostile = new Error('unused');
+    Object.defineProperty(hostile, 'message', {
+      get() {
+        throw new Error('boom');
+      },
+    });
+    compareGroup.mockRejectedValue(hostile);
+
+    await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(0);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-group-failed',
+        failed: 1,
+        refused: 0,
+        message: 'unserializable error',
+      })
+    );
+  });
+
   it('reports NEITHER warning on a clean tick', async () => {
     getStandings.mockResolvedValue(standings(GROUP_SIZE));
     stubQueries(GROUP_SIZE);
@@ -462,25 +569,92 @@ describe('advance and rankField', () => {
     stubQueries(field);
     compareGroup.mockRejectedValue(new Error('Provider returned error'));
 
-    await expect(
-      rollingSwissEngine.rankField(
-        ctx,
-        Array.from({ length: field }, (_, i) => ({
-          imageId: i + 1,
-          userId: i + 1,
-          username: `u${i}`,
-          weightedRating: 0,
-        }))
-      )
-    ).rejects.toThrow(/none succeeded/);
+    await expect(rollingSwissEngine.rankField(ctx, closeField(field))).rejects.toThrow(
+      /field unmeasured/
+    );
 
     // No standings written means no ranking for the caller to pay out against.
     expect(replaceStandings).not.toHaveBeenCalled();
   });
 
-  it('still finalizes at close when SOME groups succeeded', async () => {
+  /**
+   * The same payout as the test above, reached by a different door. A call that RESOLVED and then
+   * failed to write leaves the field exactly as unmeasured as a call that never happened — and it
+   * increments `calls`, not `failed`. A guard keyed on calls waves it through, bills eleven settle
+   * passes on the way, and ranks on nothing. Keyed on rows recorded, it stops on the first pass.
+   */
+  it('REFUSES to finalize when every close-time relation WRITE failed', async () => {
     const field = GROUP_SIZE * 4;
     stubQueries(field);
+    compareGroup.mockImplementation((input: unknown) => {
+      const { group } = input as { group: { imageId: number }[] };
+      return Promise.resolve({
+        order: group.map((image) => image.imageId),
+        malformed: false,
+        model: 'openai/gpt-5.6-luna',
+        usage: {},
+        buzzCost: 12,
+      });
+    });
+    recordComparison.mockRejectedValue(new Error('no unique constraint matching ON CONFLICT'));
+
+    await expect(rollingSwissEngine.rankField(ctx, closeField(field))).rejects.toThrow(
+      /field unmeasured/
+    );
+    expect(replaceStandings).not.toHaveBeenCalled();
+  });
+
+  /** The third door: the provider answers every group, and every answer is unparseable. */
+  it('REFUSES to finalize when every close-time ranking was malformed', async () => {
+    const field = GROUP_SIZE * 4;
+    stubQueries(field);
+    compareGroup.mockResolvedValue({
+      order: null,
+      malformed: true,
+      model: 'openai/gpt-5.6-luna',
+      usage: {},
+      buzzCost: 12,
+    });
+
+    await expect(rollingSwissEngine.rankField(ctx, closeField(field))).rejects.toThrow(
+      /field unmeasured/
+    );
+    expect(replaceStandings).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 🔴 The other half of the decision, and the reason the guard reads the FIELD rather than the
+   * pass. A settled challenge's last pass plans one group; 37% of ticks see a provider failure. If
+   * one transient group could abort the close, a fully measured challenge would sit in 'Completing'
+   * for up to ~70 minutes waiting on the hourly recovery job, for nothing.
+   */
+  it('still finalizes when a last group fails but the field IS measured', async () => {
+    const field = GROUP_SIZE * 4;
+    stubQueries(field);
+    // Twelve entries have their full budget and are filtered out of planning; four are untouched,
+    // so exactly one group is planned — and the tallies prove the field was measured.
+    const games = new Map<number, number>(
+      Array.from({ length: field }, (_, i) => [i + 1, i < 12 ? 9 : 0])
+    );
+    getSwissState.mockResolvedValue({ wins: new Map(), games, played: new Set() });
+    compareGroup.mockRejectedValue(new Error('Provider returned error'));
+
+    const ranked = await rollingSwissEngine.rankField(ctx, closeField(field));
+
+    expect(ranked).toHaveLength(field);
+    expect(replaceStandings).toHaveBeenCalledTimes(1);
+    // Exactly one pass: it planned, recorded nothing, found the field measured and stopped. The
+    // close stage is deliberately unbounded by wall clock, so `passes` and `settleMs` on this event
+    // are the only record of how long it took.
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-swiss-close', passes: 1 })
+    );
+  });
+
+  it('still finalizes at close when SOME groups succeeded, and settles by running OUT of work', async () => {
+    const field = GROUP_SIZE * 4;
+    stubQueries(field);
+    useAccumulatingState();
     let call = 0;
     compareGroup.mockImplementation((input: unknown) => {
       call++;
@@ -496,17 +670,13 @@ describe('advance and rankField', () => {
     });
 
     // The guard above must not have made close brittle: a partially-failing provider still settles.
-    const ranked = await rollingSwissEngine.rankField(
-      ctx,
-      Array.from({ length: field }, (_, i) => ({
-        imageId: i + 1,
-        userId: i + 1,
-        username: `u${i}`,
-        weightedRating: 0,
-      }))
-    );
+    const ranked = await rollingSwissEngine.rankField(ctx, closeField(field));
     expect(ranked).toHaveLength(field);
     expect(replaceStandings).toHaveBeenCalledTimes(1);
+    // The loop ended because the field ran out of work, NOT because it hit its backstop. Against a
+    // frozen state fake this reads identically while actually reaching pass 11, and the one failed
+    // group would be silently re-attempted ten more times.
+    expect(closeEvent()?.passes).toBeLessThan(MAX_SETTLE_PASSES);
   });
 
   it('applies the spend ceiling at close too, not only on ticks', async () => {

--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -171,7 +171,7 @@ describe('advance and rankField', () => {
     expect(incrementOperationSpent).toHaveBeenCalledExactlyOnceWith(1, 12);
   });
 
-  it('counts a malformed ranking as a failure and records nothing for it', async () => {
+  it('bills a malformed ranking as a CALL and records nothing for it', async () => {
     getStandings.mockResolvedValue(standings(GROUP_SIZE));
     stubQueries(GROUP_SIZE);
     compareGroup.mockResolvedValue({
@@ -649,6 +649,43 @@ describe('advance and rankField', () => {
     expect(logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'challenge-swiss-close', passes: 1 })
     );
+  });
+
+  /**
+   * 🔴 A DELIBERATE decision, pinned here because the argument for undoing it is a good one.
+   *
+   * A close where every group's images fail to load throws like any other unmeasured field — and a
+   * review correctly pointed out that this arm has NO path to success: a deleted image does not come
+   * back, so the hourly recovery re-plans the same groups and fails identically, forever. The
+   * suggested fix was to exempt the pure-unloadable case from the throw.
+   *
+   * Not taken. Exempting it means finalizing on a field with no comparison rows, which is the payout
+   * on `imageId` order this whole branch exists to prevent — and the entries' authors are still paid
+   * even though their images are gone. A challenge that never finalizes pays nobody and warns on
+   * every cycle; a challenge that finalizes wrongly pays the wrong creators, irreversibly. The
+   * throw message names `unloadable`, so the two are distinguishable in Axiom.
+   *
+   * If this ever needs revisiting, the fix is an attempt cap on the hourly recovery, NOT an
+   * exemption here.
+   */
+  it('REFUSES to finalize when the whole field failed to LOAD', async () => {
+    const field = GROUP_SIZE * 4;
+    // The images query returns nothing, so no group can be assembled.
+    queryRaw.mockImplementation((strings: TemplateStringsArray) => {
+      const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+      if (sql.includes('startsAt'))
+        return Promise.resolve([
+          { startsAt: new Date(Date.now() - 60_000), endsAt: new Date(Date.now() + 60_000) },
+        ]);
+      if (sql.includes('COUNT(*)')) return Promise.resolve([{ relations: BigInt(0) }]);
+      return Promise.resolve([]);
+    });
+
+    await expect(rollingSwissEngine.rankField(ctx, closeField(field))).rejects.toThrow(
+      /field unmeasured/
+    );
+    expect(compareGroup).not.toHaveBeenCalled();
+    expect(replaceStandings).not.toHaveBeenCalled();
   });
 
   it('still finalizes at close when SOME groups succeeded, and settles by running OUT of work', async () => {

--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -40,14 +40,7 @@ vi.mock('~/server/logging/client', () => ({
 }));
 
 import { rollingSwissEngine } from '~/server/games/daily-challenge/challenge-engine-rolling-swiss';
-import {
-  DEFAULT_BOUT_BUDGET,
-  GROUP_SIZE,
-  RELATIONS_PER_CALL,
-} from '~/server/games/daily-challenge/challenge-swiss';
-
-/** Mirrors the engine's own private backstop, so the close tests can assert they did not hit it. */
-const MAX_SETTLE_PASSES = DEFAULT_BOUT_BUDGET + 2;
+import { GROUP_SIZE, RELATIONS_PER_CALL } from '~/server/games/daily-challenge/challenge-swiss';
 
 const ctx = {
   challengeId: 1,
@@ -99,7 +92,12 @@ function useAccumulatingState() {
     const wins = new Map<number, number>();
     const games = new Map<number, number>();
     const played = new Set<string>();
-    for (const [arg] of recordComparison.mock.calls) {
+    for (const [index, [arg]] of recordComparison.mock.calls.entries()) {
+      // 🔴 Committed rows ONLY. `mock.calls` includes writes that REJECTED, and a fixture built from
+      // those reports a field measured by rows that never landed — which is the exact property the
+      // close-time guard turns on, inverted. A write-failure test using this helper would then stop
+      // the guard firing and read as though the guard were wrong.
+      if (recordComparison.mock.settledResults[index]?.type !== 'fulfilled') continue;
       const { imageIdA, imageIdB, winnerImageId } = (
         arg as { verdict: { imageIdA: number; imageIdB: number; winnerImageId: number } }
       ).verdict;
@@ -337,6 +335,13 @@ describe('advance and rankField', () => {
         message: 'write conflict',
       })
     );
+    // The ids are the point of this event: they name the groups now holding some of their six rows,
+    // and finding those rows to clean them needs the membership.
+    const written = logToAxiom.mock.calls
+      .map(([arg]) => arg as { name: string; writeFailedGroups?: string[] })
+      .find((arg) => arg.name === 'challenge-swiss-write-failed');
+    expect(written?.writeFailedGroups).toHaveLength(1);
+    expect(written?.writeFailedGroups?.[0].split(',')).toHaveLength(GROUP_SIZE);
     // A database failure must not be filed as a provider failure. They point at different systems,
     // and `refused` — the count of provider content refusals — must never be fed a Postgres error.
     expect(logToAxiom).not.toHaveBeenCalledWith(
@@ -442,9 +447,6 @@ describe('advance and rankField', () => {
     expect(incrementOperationSpent).not.toHaveBeenCalled();
   });
 
-  // Passes against the UNFIXED engine too — it is not a revert control, it is the third arm of the
-  // three-way distinction: success emits neither warning. It fails if either log is ever moved out
-  // of its `if`, which is the edit it exists to stop.
   /**
    * The guards exist because `isContentRefusal` and the message read both touch properties of a
    * thrown value, INSIDE the catch that stops a failure escaping. A throwing accessor there escapes
@@ -473,6 +475,9 @@ describe('advance and rankField', () => {
     );
   });
 
+  // Passes against the UNFIXED engine too — it is not a revert control, it is the third arm of the
+  // three-way distinction: success emits neither warning. It fails if either log is ever moved out
+  // of its `if`, which is the edit it exists to stop.
   it('reports NEITHER warning on a clean tick', async () => {
     getStandings.mockResolvedValue(standings(GROUP_SIZE));
     stubQueries(GROUP_SIZE);
@@ -586,6 +591,10 @@ describe('advance and rankField', () => {
   it('REFUSES to finalize when every close-time relation WRITE failed', async () => {
     const field = GROUP_SIZE * 4;
     stubQueries(field);
+    // Deliberately the ACCUMULATING fake, not the frozen one: this is the fixture that would let a
+    // rejected write count as measurement, so it is the one that proves the helper counts committed
+    // rows only. With the filter removed, the guard stops firing and this test resolves.
+    useAccumulatingState();
     compareGroup.mockImplementation((input: unknown) => {
       const { group } = input as { group: { imageId: number }[] };
       return Promise.resolve({
@@ -713,7 +722,11 @@ describe('advance and rankField', () => {
     // The loop ended because the field ran out of work, NOT because it hit its backstop. Against a
     // frozen state fake this reads identically while actually reaching pass 11, and the one failed
     // group would be silently re-attempted ten more times.
-    expect(closeEvent()?.passes).toBeLessThan(MAX_SETTLE_PASSES);
+    // The exact count, not `< MAX_SETTLE_PASSES`. The bound is module-private in the engine, so a
+    // copy of it here would go vacuous and SILENTLY if the engine's ever dropped — and a run that
+    // doubled its passes would still satisfy the inequality. Against a frozen state fake this reads
+    // 11, the backstop, which is the artifact this fixture exists to rule out.
+    expect(closeEvent()?.passes).toBe(6);
   });
 
   it('applies the spend ceiling at close too, not only on ticks', async () => {

--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -690,8 +690,10 @@ describe('advance and rankField', () => {
       return Promise.resolve([]);
     });
 
+    // Matches the ARM, not just the refusal: every arm of that throw says "field unmeasured", so a
+    // future edit routing the unloadable case through a different counter would still satisfy it.
     await expect(rollingSwissEngine.rankField(ctx, closeField(field))).rejects.toThrow(
-      /field unmeasured/
+      /unloadable 4/
     );
     expect(compareGroup).not.toHaveBeenCalled();
     expect(replaceStandings).not.toHaveBeenCalled();

--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -135,6 +135,149 @@ describe('advance and rankField', () => {
     );
   });
 
+  /**
+   * 🔴 What this establishes, and what it does not. `runPool`'s concurrency is 16 and only four
+   * groups are planned, so all four are dispatched before any resolves — the rejection is pinned to
+   * the second INVOCATION, which is deterministic, but the order in which the other three finish is
+   * not, so nothing here asserts an ordering. What it pins is that one provider failure costs one
+   * group: the tick still returns, the other three groups still record, and the spend is still
+   * billed. Before the per-group catch this threw out of `advance()` — 49 of 133 ticks on
+   * challenge 438 did exactly that in production.
+   */
+  it('loses ONE group to a provider failure, not the tick', async () => {
+    getStandings.mockResolvedValue(standings(GROUP_SIZE * 4));
+    stubQueries(GROUP_SIZE * 4);
+    const verdict = {
+      order: [1, 2, 3, 4],
+      malformed: false,
+      model: 'openai/gpt-5.6-luna',
+      usage: {},
+      buzzCost: 12,
+    };
+    let call = 0;
+    compareGroup.mockImplementation(() => {
+      call++;
+      return call === 2
+        ? Promise.reject(new Error('Provider returned error'))
+        : Promise.resolve(verdict);
+    });
+
+    const calls = await rollingSwissEngine.advance!(ctx, Date.now() + 60_000);
+
+    expect(compareGroup).toHaveBeenCalledTimes(4);
+    expect(calls).toBe(3);
+    expect(recordComparison).toHaveBeenCalledTimes(3 * RELATIONS_PER_CALL);
+    // A tick that threw billed NOTHING for the calls it had already paid the provider for.
+    expect(incrementOperationSpent).toHaveBeenCalledExactlyOnceWith(1, 36);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-group-failed',
+        type: 'warning',
+        failed: 1,
+        calls: 3,
+        message: 'Provider returned error',
+      })
+    );
+    expect(logToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-swiss-group-unloadable' })
+    );
+  });
+
+  it('reports a group skipped for missing images under its OWN name, not as a failure', async () => {
+    getStandings.mockResolvedValue(standings(GROUP_SIZE * 4));
+    // One image of the sixteen does not load, so exactly one group is short whichever band it lands
+    // in. A group we cannot assemble is not a group that failed, and a dashboard that cannot tell a
+    // deleted image from a provider outage sends the next reader to the wrong system.
+    queryRaw.mockImplementation((strings: TemplateStringsArray) => {
+      const sql = Array.isArray(strings) ? strings.join('') : String(strings);
+      if (sql.includes('startsAt'))
+        return Promise.resolve([
+          { startsAt: new Date(Date.now() - 60_000), endsAt: new Date(Date.now() + 60_000) },
+        ]);
+      if (sql.includes('COUNT(*)')) return Promise.resolve([{ relations: BigInt(0) }]);
+      return Promise.resolve(
+        Array.from({ length: GROUP_SIZE * 4 }, (_, i) => ({
+          id: i + 1,
+          url: `uuid-${i + 1}`,
+          nsfwLevel: 1,
+        })).filter((row) => row.id !== 7)
+      );
+    });
+    compareGroup.mockResolvedValue({
+      order: [1, 2, 3, 4],
+      malformed: false,
+      model: 'openai/gpt-5.6-luna',
+      usage: {},
+      buzzCost: 12,
+    });
+
+    await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(3);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-group-unloadable',
+        type: 'warning',
+        unloadable: 1,
+      })
+    );
+    expect(logToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-swiss-group-failed' })
+    );
+  });
+
+  /**
+   * The envelope message is generic for BOTH a refusal and a 5xx — production shows 49 identical
+   * `Provider returned error` lines and nothing to tell them apart. `isContentRefusal` reads the raw
+   * body, so the counter answers "why" where the message cannot. Nothing acts on it: excluding an
+   * entry is Justin's call and he chose not to, on the grounds that a transient provider error would
+   * silently drop a legitimate creator's entry.
+   */
+  it('classifies a content refusal apart from any other provider failure', async () => {
+    getStandings.mockResolvedValue(standings(GROUP_SIZE));
+    stubQueries(GROUP_SIZE);
+    const refusal = Object.assign(new Error('Provider returned error'), {
+      body: '{"error":{"metadata":{"reasons":["data_inspection_failed"]}}}',
+    });
+    compareGroup.mockRejectedValue(refusal);
+
+    await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(0);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-group-failed',
+        failed: 1,
+        refused: 1,
+      })
+    );
+    // A group fails as a UNIT, and its membership is what makes attribution possible across ticks.
+    // Compared as a set: the entries are logged in PRESENTATION order, which the band shuffle
+    // deliberately varies, so asserting the literal order would pin the shuffle rather than the log.
+    const logged = logToAxiom.mock.calls
+      .map(([arg]) => arg as { name: string; failedGroups?: string[] })
+      .find((arg) => arg.name === 'challenge-swiss-group-failed');
+    expect(logged?.failedGroups?.[0].split(',').sort()).toEqual(['1', '2', '3', '4']);
+    // Nothing was billed: the provider never returned a usage figure to bill from.
+    expect(incrementOperationSpent).not.toHaveBeenCalled();
+  });
+
+  // Passes against the UNFIXED engine too — it is not a revert control, it is the third arm of the
+  // three-way distinction: success emits neither warning. It fails if either log is ever moved out
+  // of its `if`, which is the edit it exists to stop.
+  it('reports NEITHER warning on a clean tick', async () => {
+    getStandings.mockResolvedValue(standings(GROUP_SIZE));
+    stubQueries(GROUP_SIZE);
+    compareGroup.mockResolvedValue({
+      order: [1, 2, 3, 4],
+      malformed: false,
+      model: 'openai/gpt-5.6-luna',
+      usage: {},
+      buzzCost: 12,
+    });
+
+    await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(1);
+    const names = logToAxiom.mock.calls.map(([arg]) => (arg as { name: string }).name);
+    expect(names).not.toContain('challenge-swiss-group-failed');
+    expect(names).not.toContain('challenge-swiss-group-unloadable');
+  });
+
   it('does nothing when the field is smaller than one group', async () => {
     getStandings.mockResolvedValue(standings(GROUP_SIZE - 1));
     await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(0);

--- a/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-engine-rolling-swiss.test.ts
@@ -77,6 +77,14 @@ function stubQueries(imageCount: number) {
   });
 }
 
+/** The `failedGroups` payload of the one `challenge-swiss-group-failed` event a tick emits. */
+function failedGroupsFrom(log: typeof logToAxiom): string[] {
+  const event = log.mock.calls
+    .map(([arg]) => arg as { name: string; failedGroups?: string[] })
+    .find((arg) => arg.name === 'challenge-swiss-group-failed');
+  return event?.failedGroups ?? [];
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   operationBudgetRemaining.mockResolvedValue({ remaining: null, spent: 0 });
@@ -147,19 +155,21 @@ describe('advance and rankField', () => {
   it('loses ONE group to a provider failure, not the tick', async () => {
     getStandings.mockResolvedValue(standings(GROUP_SIZE * 4));
     stubQueries(GROUP_SIZE * 4);
-    const verdict = {
-      order: [1, 2, 3, 4],
-      malformed: false,
-      model: 'openai/gpt-5.6-luna',
-      usage: {},
-      buzzCost: 12,
-    };
+    // The ranking is derived from the group it was ASKED about, as the real one is — a fixed
+    // `[1, 2, 3, 4]` would have every group record relations among the same four images, and the
+    // attribution assertion below would then be reading the mock rather than the engine.
     let call = 0;
-    compareGroup.mockImplementation(() => {
+    compareGroup.mockImplementation((input: unknown) => {
       call++;
-      return call === 2
-        ? Promise.reject(new Error('Provider returned error'))
-        : Promise.resolve(verdict);
+      if (call === 2) return Promise.reject(new Error('Provider returned error'));
+      const { group } = input as { group: { imageId: number }[] };
+      return Promise.resolve({
+        order: group.map((image) => image.imageId),
+        malformed: false,
+        model: 'openai/gpt-5.6-luna',
+        usage: {},
+        buzzCost: 12,
+      });
     });
 
     const calls = await rollingSwissEngine.advance!(ctx, Date.now() + 60_000);
@@ -175,11 +185,109 @@ describe('advance and rankField', () => {
         type: 'warning',
         failed: 1,
         calls: 3,
+        // The NEGATIVE arm of the refusal classification. Without it `refused` is pinned in one
+        // direction only, and `if (isContentRefusal(error)) refused++` reduced to `refused++` passes.
+        refused: 0,
         message: 'Provider returned error',
       })
     );
     expect(logToAxiom).not.toHaveBeenCalledWith(
       expect.objectContaining({ name: 'challenge-swiss-group-unloadable' })
+    );
+
+    // Attribution is the whole point of logging membership, and with four groups "the right group"
+    // is a claim that can be wrong. The failed group must be exactly the entries that recorded
+    // nothing — logging `groups[0]`, or every planned group, makes the field actively misleading.
+    const failedIds = failedGroupsFrom(logToAxiom)[0].split(',').sort();
+    const recordedIds = new Set(
+      recordComparison.mock.calls.flatMap(([arg]) => {
+        const { imageIdA, imageIdB } = (arg as { verdict: { imageIdA: number; imageIdB: number } })
+          .verdict;
+        return [String(imageIdA), String(imageIdB)];
+      })
+    );
+    expect(failedIds).toHaveLength(GROUP_SIZE);
+    expect(failedIds.filter((id) => recordedIds.has(id))).toEqual([]);
+  });
+
+  /**
+   * The failure mode the fix is NAMED for, which a four-group fixture cannot reach: `runPool`'s
+   * concurrency is 16, so with four groups every one is dispatched before any rejection is seen and
+   * the old code made the same four calls. Only past the lane count does `runPool`'s `failed` flag
+   * have a next item to refuse — 17 groups, a rejection on the first, and group 17 is the one
+   * production was losing. 68 standings at the stubbed progress plan 17 groups: `tickCallBudget` is
+   * ceil(68*9/2/6)=51 due, halved to 26 by progress, and `planGroups` cuts floor(68/4)=17 from them.
+   *
+   * The second rejection is not decoration: it is what pins `firstError ??=` as FIRST rather than
+   * last, and gives `failedGroups` more than one entry to get wrong.
+   */
+  it('still dispatches the groups a failure used to abandon', async () => {
+    const field = 68;
+    getStandings.mockResolvedValue(standings(field));
+    stubQueries(field);
+    let call = 0;
+    compareGroup.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.reject(new Error('first failure'));
+      if (call === 5) return Promise.reject(new Error('second failure'));
+      return Promise.resolve({
+        order: [1, 2, 3, 4],
+        malformed: false,
+        model: 'openai/gpt-5.6-luna',
+        usage: {},
+        buzzCost: 12,
+      });
+    });
+
+    const calls = await rollingSwissEngine.advance!(ctx, Date.now() + 60_000);
+
+    // 17, not 16. Under the old code the 17th group was never dispatched — `runPool` stops taking
+    // items once a worker has rejected — and the tick threw on top of it.
+    expect(compareGroup).toHaveBeenCalledTimes(17);
+    expect(calls).toBe(15);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-group-failed',
+        planned: 17,
+        failed: 2,
+        calls: 15,
+        message: 'first failure',
+      })
+    );
+    expect(failedGroupsFrom(logToAxiom)).toHaveLength(2);
+  });
+
+  /**
+   * The catch covers the relation WRITES as well as the comparison. A dropped connection on the
+   * write is at least as likely as a provider 5xx, and under the old code it abandoned the tick the
+   * same way. The call is still counted and still billed: the provider was already paid.
+   */
+  it('loses one group to a failed relation write, and still bills the call', async () => {
+    getStandings.mockResolvedValue(standings(GROUP_SIZE * 4));
+    stubQueries(GROUP_SIZE * 4);
+    compareGroup.mockResolvedValue({
+      order: [1, 2, 3, 4],
+      malformed: false,
+      model: 'openai/gpt-5.6-luna',
+      usage: {},
+      buzzCost: 12,
+    });
+    recordComparison.mockRejectedValueOnce(new Error('write conflict'));
+
+    await expect(rollingSwissEngine.advance!(ctx, Date.now() + 60_000)).resolves.toBe(4);
+    expect(incrementOperationSpent).toHaveBeenCalledExactlyOnceWith(1, 48);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-swiss-write-failed',
+        writeFailed: 1,
+        calls: 4,
+        message: 'write conflict',
+      })
+    );
+    // A database failure must not be filed as a provider failure. They point at different systems,
+    // and `refused` — the count of provider content refusals — must never be fed a Postgres error.
+    expect(logToAxiom).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-swiss-group-failed' })
     );
   });
 
@@ -250,10 +358,7 @@ describe('advance and rankField', () => {
     // A group fails as a UNIT, and its membership is what makes attribution possible across ticks.
     // Compared as a set: the entries are logged in PRESENTATION order, which the band shuffle
     // deliberately varies, so asserting the literal order would pin the shuffle rather than the log.
-    const logged = logToAxiom.mock.calls
-      .map(([arg]) => arg as { name: string; failedGroups?: string[] })
-      .find((arg) => arg.name === 'challenge-swiss-group-failed');
-    expect(logged?.failedGroups?.[0].split(',').sort()).toEqual(['1', '2', '3', '4']);
+    expect(failedGroupsFrom(logToAxiom)[0].split(',').sort()).toEqual(['1', '2', '3', '4']);
     // Nothing was billed: the provider never returned a usage figure to bill from.
     expect(incrementOperationSpent).not.toHaveBeenCalled();
   });
@@ -339,6 +444,69 @@ describe('advance and rankField', () => {
     expect(logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'challenge-swiss-budget-exhausted', type: 'warning' })
     );
+  });
+
+  /**
+   * 🔴 THE MONEY CASE. Do not relax this into a `break` without reading why it is a `throw`.
+   *
+   * Per-group catching means a close-time pass where EVERY group fails returns 0 calls, which is
+   * the same number a settled field returns. If those two end the loop the same way, `rankField`
+   * ranks a field nothing measured: with no comparison rows every entry scores 0.5 in `strength`,
+   * so `swissStandings` falls through to its `imageId` tiebreak and the caller pays real prizes on
+   * upload order. Before groups were caught individually the provider error propagated and left the
+   * challenge in 'Completing' for a later run to judge properly; this keeps that behaviour for the
+   * close path only.
+   */
+  it('REFUSES to finalize a field when every close-time group failed', async () => {
+    const field = GROUP_SIZE * 4;
+    stubQueries(field);
+    compareGroup.mockRejectedValue(new Error('Provider returned error'));
+
+    await expect(
+      rollingSwissEngine.rankField(
+        ctx,
+        Array.from({ length: field }, (_, i) => ({
+          imageId: i + 1,
+          userId: i + 1,
+          username: `u${i}`,
+          weightedRating: 0,
+        }))
+      )
+    ).rejects.toThrow(/none succeeded/);
+
+    // No standings written means no ranking for the caller to pay out against.
+    expect(replaceStandings).not.toHaveBeenCalled();
+  });
+
+  it('still finalizes at close when SOME groups succeeded', async () => {
+    const field = GROUP_SIZE * 4;
+    stubQueries(field);
+    let call = 0;
+    compareGroup.mockImplementation((input: unknown) => {
+      call++;
+      if (call === 2) return Promise.reject(new Error('Provider returned error'));
+      const { group } = input as { group: { imageId: number }[] };
+      return Promise.resolve({
+        order: group.map((image) => image.imageId),
+        malformed: false,
+        model: 'openai/gpt-5.6-luna',
+        usage: {},
+        buzzCost: 12,
+      });
+    });
+
+    // The guard above must not have made close brittle: a partially-failing provider still settles.
+    const ranked = await rollingSwissEngine.rankField(
+      ctx,
+      Array.from({ length: field }, (_, i) => ({
+        imageId: i + 1,
+        userId: i + 1,
+        username: `u${i}`,
+        weightedRating: 0,
+      }))
+    );
+    expect(ranked).toHaveLength(field);
+    expect(replaceStandings).toHaveBeenCalledTimes(1);
   });
 
   it('applies the spend ceiling at close too, not only on ticks', async () => {

--- a/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
+++ b/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
@@ -17,6 +17,7 @@ import {
   PODIUM_SIZE,
   runPool,
 } from '~/server/games/daily-challenge/challenge-ladder';
+import { isContentRefusal } from '~/server/games/daily-challenge/challenge-judge-routes';
 import {
   buildGroupComparisonPrompt,
   compareGroup,
@@ -243,61 +244,114 @@ async function runGroups(
 
   let calls = 0;
   let malformed = 0;
+  let unloadable = 0;
+  let failed = 0;
+  let refused = 0;
+  const failedGroups: string[] = [];
+  let firstError: string | undefined;
   let buzz = 0;
 
-  await runPool(groups, LADDER_CONCURRENCY, async (group) => {
-    // Checked per group rather than once up front: the deadline is what holds when the provider is
-    // slower than we assumed, and a limit that is only tested before the work starts cannot do that.
-    // The SPEND ceiling is deliberately not here — it is applied when groups are planned, because a
-    // check inside concurrent lanes all read zero before any lane has paid for anything.
-    if (deadlineMs != null && Date.now() >= deadlineMs) return;
+  try {
+    await runPool(groups, LADDER_CONCURRENCY, async (group) => {
+      // Checked per group rather than once up front: the deadline is what holds when the provider is
+      // slower than we assumed, and a limit that is only tested before the work starts cannot do that.
+      // The SPEND ceiling is deliberately not here — it is applied when groups are planned, because a
+      // check inside concurrent lanes all read zero before any lane has paid for anything.
+      if (deadlineMs != null && Date.now() >= deadlineMs) return;
 
-    const groupImages = group
-      .map((entry) => images.get(entry.imageId))
-      .filter((image): image is ComparisonImage => !!image);
-    // A group we cannot fully load is not a group. Comparing the remainder would silently change
-    // the question from "rank four" to "rank three" and bill for it.
-    if (groupImages.length !== group.length) return;
+      const groupImages = group
+        .map((entry) => images.get(entry.imageId))
+        .filter((image): image is ComparisonImage => !!image);
+      // A group we cannot fully load is not a group. Comparing the remainder would silently change
+      // the question from "rank four" to "rank three" and bill for it.
+      if (groupImages.length !== group.length) {
+        unloadable++;
+        return;
+      }
 
-    const verdict = await compareGroup({ systemPrompt, group: groupImages });
-    calls++;
-    buzz += verdict.buzzCost;
+      // One group's failure must cost one group. `runPool` stops dispatching on the first rejection
+      // and rethrows it, so an error escaping here abandoned every group not yet started AND the
+      // whole review tick around it.
+      try {
+        const verdict = await compareGroup({ systemPrompt, group: groupImages });
+        calls++;
+        buzz += verdict.buzzCost;
 
-    if (!verdict.order) {
-      malformed++;
-      return;
-    }
+        if (!verdict.order) {
+          malformed++;
+          return;
+        }
 
-    // Written against the SNAPSHOT's played set, so a pair another lane recorded in the meantime is
-    // still attempted here and lands on the conflict clause rather than being skipped by a read
-    // that raced. Cheap either way: it is one row, not one call.
-    const relations = relationsFromRanking(verdict.order, state.played);
-    for (const [index, relation] of relations.entries()) {
-      await store.recordComparison({
-        challengeId: ctx.challengeId,
-        phase: 'swiss',
-        verdict: {
-          imageIdA: relation.winnerImageId,
-          imageIdB: relation.loserImageId,
-          firstSeatImageId: groupImages[0].imageId,
-          winnerImageId: relation.winnerImageId,
-          margin: null,
-          perCategory: {},
-          reason: null,
-          model: verdict.model,
-          rerouted: false,
-          usage: verdict.usage,
-          // One CALL produced all of these rows, so its cost belongs to the group once. Spreading
-          // it across six rows would make each look a sixth as expensive as it was; repeating it
-          // would sextuple the challenge's recorded spend. The first row carries it.
-          buzzCost: index === 0 ? verdict.buzzCost : 0,
-        },
-      });
-    }
-  });
+        // Written against the SNAPSHOT's played set, so a pair another lane recorded in the meantime
+        // is still attempted here and lands on the conflict clause rather than being skipped by a
+        // read that raced. Cheap either way: it is one row, not one call.
+        const relations = relationsFromRanking(verdict.order, state.played);
+        for (const [index, relation] of relations.entries()) {
+          await store.recordComparison({
+            challengeId: ctx.challengeId,
+            phase: 'swiss',
+            verdict: {
+              imageIdA: relation.winnerImageId,
+              imageIdB: relation.loserImageId,
+              firstSeatImageId: groupImages[0].imageId,
+              winnerImageId: relation.winnerImageId,
+              margin: null,
+              perCategory: {},
+              reason: null,
+              model: verdict.model,
+              rerouted: false,
+              usage: verdict.usage,
+              // One CALL produced all of these rows, so its cost belongs to the group once. Spreading
+              // it across six rows would make each look a sixth as expensive as it was; repeating it
+              // would sextuple the challenge's recorded spend. The first row carries it.
+              buzzCost: index === 0 ? verdict.buzzCost : 0,
+            },
+          });
+        }
+      } catch (error) {
+        failed++;
+        if (isContentRefusal(error)) refused++;
+        // A group of four fails as a UNIT, so no single failure attributes to an entry. The
+        // membership is logged so attribution can be done across ticks by intersection — an image in
+        // every failed group and no successful one is the suspect.
+        failedGroups.push(groupImages.map((image) => image.imageId).join(','));
+        firstError ??= error instanceof Error ? error.message : String(error);
+      }
+    });
+  } finally {
+    // Billed whatever happens to the pool: `buzz` grows the moment a call returns, so anything
+    // already paid for is in it even on a path that throws past this point.
+    const spend = Math.ceil(buzz);
+    if (spend > 0) await incrementOperationSpent(ctx.challengeId, spend);
+  }
 
-  const spend = Math.ceil(buzz);
-  if (spend > 0) await incrementOperationSpent(ctx.challengeId, spend);
+  if (failed) {
+    logToAxiom({
+      type: 'warning',
+      name: 'challenge-swiss-group-failed',
+      challengeId: ctx.challengeId,
+      planned: groups.length,
+      calls,
+      failed,
+      // `message` is the OpenRouter envelope and is generic for a refusal; `refused` is the
+      // classified answer, read out of the raw body by `isContentRefusal`.
+      refused,
+      failedGroups,
+      message: firstError,
+    }).catch(() => undefined);
+  }
+  if (unloadable) {
+    // A group whose images would not load is NOT a group that failed and not one that succeeded.
+    // Three names rather than one counter, so a provider outage and a deleted image do not read as
+    // the same event.
+    logToAxiom({
+      type: 'warning',
+      name: 'challenge-swiss-group-unloadable',
+      challengeId: ctx.challengeId,
+      planned: groups.length,
+      unloadable,
+    }).catch(() => undefined);
+  }
   if (malformed) {
     logToAxiom({
       type: 'warning',

--- a/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
+++ b/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
@@ -141,7 +141,14 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
     if (eligible.length < 2) return eligible;
 
     let calls = 0;
+    let passes = 0;
+    // The close stage has NO wall-clock bound, only `MAX_SETTLE_PASSES`, and it can outlast the
+    // 10-minute completion claim (see `pickWinnersForChallenge`). Leaving it unbounded is a
+    // deliberate call — a timeout trades a measured podium for a faster one — so the duration is
+    // measured instead of capped, and it is on the close event below.
+    const settleStartedAt = Date.now();
     for (let pass = 0; pass < MAX_SETTLE_PASSES; pass++) {
+      passes++;
       // The spend ceiling has to be re-read each pass and applied here too. Settling at close was
       // originally unbounded, which would have made the budget a limit on ticks only — the one
       // moment a runaway is most likely is the moment it was exempt.
@@ -166,20 +173,34 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
 
       const pass = await runGroups(ctx, eligible, affordable, 1);
       calls += pass.calls;
-      // 🔴 A pass that PLANNED work and completed none of it is a provider outage, not a settled
-      // field, and the two must not both end the loop. Ranking an unmeasured field is not a
-      // degraded ranking: with no comparison rows every entry scores the same 0.5 in `strength`,
-      // so `swissStandings` falls through to its `imageId` tiebreak and the caller pays prizes on
-      // upload order. Throwing leaves the challenge in 'Completing' for a later run to judge
-      // properly — which is what the whole tick did before groups were caught individually.
-      // `advance` deliberately keeps the tolerant behaviour; it is only at close that giving up
-      // quietly costs money.
-      if (pass.calls === 0 && pass.failed > 0) {
+      // Nothing left to compare. The only clean way out of this loop.
+      if (pass.planned === 0) break;
+      // 🔴 Keyed on ROWS RECORDED, never on calls made. A call that resolved and then failed to
+      // write, and a call that came back unparseable, both leave the field exactly as unmeasured as
+      // a call that never happened — and neither increments `failed`. Keying on calls let those two
+      // run the loop to its bound, billing every pass, and then rank on nothing.
+      if (pass.recorded > 0) continue;
+
+      // A pass planned work and recorded none of it. Whether that is fatal depends on the FIELD,
+      // not on this pass: refusing whenever one last transient group fails would abort the close of
+      // a fully measured challenge, and 37% of ticks see a provider failure.
+      //
+      // The bar is not a threshold anyone picked. With no comparison rows at all, every entry
+      // scores the same 0.5 in `strength` and `swissStandings` falls through to its `imageId`
+      // tiebreak — so the podium is upload order, carrying no information, and the caller pays real
+      // prizes on it. Throwing leaves the challenge in 'Completing' for a later run to judge
+      // properly, which is what the whole tick did before groups were caught individually. With any
+      // rows, the ranking is evidence-based but short, which is what `shortOfBudget` below reports.
+      // `advance` keeps the tolerant behaviour throughout; only at close does giving up cost money.
+      const measured = await store.getSwissState(ctx.challengeId);
+      if (measured.games.size === 0) {
         throw new Error(
-          `swiss close: ${pass.failed} of ${pass.planned} groups failed and none succeeded`
+          `swiss close: ${pass.planned} groups planned, no comparison recorded, field unmeasured ` +
+            `(failed ${pass.failed}, malformed ${pass.malformed}, writeFailed ${pass.writeFailed}, ` +
+            `unloadable ${pass.unloadable})`
         );
       }
-      if (pass.calls === 0) break;
+      break;
     }
 
     const state = await store.getSwissState(ctx.challengeId);
@@ -196,6 +217,8 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
       challengeId: ctx.challengeId,
       field: eligible.length,
       closeCalls: calls,
+      passes,
+      settleMs: Date.now() - settleStartedAt,
       shortOfBudget,
       minGames: Math.min(...eligible.map((e) => state.games.get(e.imageId) ?? 0)),
     }).catch(() => undefined);
@@ -228,7 +251,16 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
  * mid-flight would let two lanes pick the same pair before either had recorded it, which is the
  * third concurrency race this subsystem has had.
  */
-type GroupPass = { calls: number; planned: number; failed: number };
+type GroupPass = {
+  /** Relation ROWS actually inserted. The only counter that says the field got measured. */
+  recorded: number;
+  calls: number;
+  planned: number;
+  failed: number;
+  malformed: number;
+  writeFailed: number;
+  unloadable: number;
+};
 
 async function runGroups(
   ctx: JudgingEngineContext,
@@ -247,7 +279,16 @@ async function runGroups(
     budget: DEFAULT_BOUT_BUDGET,
     maxGroups: maxCalls,
   });
-  if (!groups.length) return { calls: 0, planned: 0, failed: 0 };
+  if (!groups.length)
+    return {
+      recorded: 0,
+      calls: 0,
+      planned: 0,
+      failed: 0,
+      malformed: 0,
+      writeFailed: 0,
+      unloadable: 0,
+    };
 
   const images = await loadComparisonImages(groups.flat().map((entry) => entry.imageId));
   const systemPrompt = buildGroupComparisonPrompt({
@@ -259,12 +300,14 @@ async function runGroups(
   });
 
   let calls = 0;
+  let recorded = 0;
   let malformed = 0;
   let unloadable = 0;
   let failed = 0;
   let refused = 0;
   let writeFailed = 0;
   const failedGroups: string[] = [];
+  const writeFailedGroups: string[] = [];
   let firstError: string | undefined;
   let firstWriteError: string | undefined;
   let buzz = 0;
@@ -343,9 +386,14 @@ async function runGroups(
               buzzCost: index === 0 ? verdict.buzzCost : 0,
             },
           });
+          recorded++;
         }
       } catch (error) {
         writeFailed++;
+        // The ids go on THIS event, not only on the provider one: these are the groups left with
+        // some of their six rows committed, and finding those rows needs their membership.
+        if (writeFailedGroups.length < MAX_LOGGED_FAILED_GROUPS)
+          writeFailedGroups.push(groupImages.map((image) => image.imageId).join(','));
         firstWriteError ??= describeError(error);
       }
     });
@@ -384,7 +432,9 @@ async function runGroups(
       challengeId: ctx.challengeId,
       planned: groups.length,
       calls,
+      recorded,
       writeFailed,
+      writeFailedGroups,
       message: firstWriteError,
     }).catch(() => undefined);
   }
@@ -409,7 +459,7 @@ async function runGroups(
       malformed,
     }).catch(() => undefined);
   }
-  return { calls, planned: groups.length, failed };
+  return { recorded, calls, planned: groups.length, failed, malformed, writeFailed, unloadable };
 }
 
 /**

--- a/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
+++ b/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
@@ -173,7 +173,7 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
 
       const pass = await runGroups(ctx, eligible, affordable, 1);
       calls += pass.calls;
-      // Nothing left to compare. The only clean way out of this loop.
+      // Nothing left to compare — the field is settled.
       if (pass.planned === 0) break;
       // 🔴 Keyed on ROWS RECORDED, never on calls made. A call that resolved and then failed to
       // write, and a call that came back unparseable, both leave the field exactly as unmeasured as
@@ -192,6 +192,9 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
       // properly, which is what the whole tick did before groups were caught individually. With any
       // rows, the ranking is evidence-based but short, which is what `shortOfBudget` below reports.
       // `advance` keeps the tolerant behaviour throughout; only at close does giving up cost money.
+      // Strictly fresher than the snapshot the pass planned from, so it can only ever hold MORE
+      // rows — which makes the guard more permissive, the safe direction for one that refuses to
+      // finalize. Reached only when a pass recorded nothing, so at most once per close.
       const measured = await store.getSwissState(ctx.challengeId);
       if (measured.games.size === 0) {
         throw new Error(

--- a/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
+++ b/src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts
@@ -121,13 +121,14 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
       return 0;
     }
 
-    return runGroups(
+    const pass = await runGroups(
       ctx,
       standings.map((row) => ({ imageId: row.imageId })),
       maxCalls,
       progress,
       deadlineMs
     );
+    return pass.calls;
   },
 
   /**
@@ -163,9 +164,22 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
         break;
       }
 
-      const spentCalls = await runGroups(ctx, eligible, affordable, 1);
-      calls += spentCalls;
-      if (spentCalls === 0) break;
+      const pass = await runGroups(ctx, eligible, affordable, 1);
+      calls += pass.calls;
+      // 🔴 A pass that PLANNED work and completed none of it is a provider outage, not a settled
+      // field, and the two must not both end the loop. Ranking an unmeasured field is not a
+      // degraded ranking: with no comparison rows every entry scores the same 0.5 in `strength`,
+      // so `swissStandings` falls through to its `imageId` tiebreak and the caller pays prizes on
+      // upload order. Throwing leaves the challenge in 'Completing' for a later run to judge
+      // properly — which is what the whole tick did before groups were caught individually.
+      // `advance` deliberately keeps the tolerant behaviour; it is only at close that giving up
+      // quietly costs money.
+      if (pass.calls === 0 && pass.failed > 0) {
+        throw new Error(
+          `swiss close: ${pass.failed} of ${pass.planned} groups failed and none succeeded`
+        );
+      }
+      if (pass.calls === 0) break;
     }
 
     const state = await store.getSwissState(ctx.challengeId);
@@ -214,13 +228,15 @@ export const rollingSwissEngine: ChallengeJudgingEngine = {
  * mid-flight would let two lanes pick the same pair before either had recorded it, which is the
  * third concurrency race this subsystem has had.
  */
+type GroupPass = { calls: number; planned: number; failed: number };
+
 async function runGroups(
   ctx: JudgingEngineContext,
   pool: { imageId: number }[],
   maxCalls: number,
   progress: number,
   deadlineMs?: number
-): Promise<number> {
+): Promise<GroupPass> {
   const state = await store.getSwissState(ctx.challengeId);
   const groups = planGroups({
     pool,
@@ -231,7 +247,7 @@ async function runGroups(
     budget: DEFAULT_BOUT_BUDGET,
     maxGroups: maxCalls,
   });
-  if (!groups.length) return 0;
+  if (!groups.length) return { calls: 0, planned: 0, failed: 0 };
 
   const images = await loadComparisonImages(groups.flat().map((entry) => entry.imageId));
   const systemPrompt = buildGroupComparisonPrompt({
@@ -247,8 +263,10 @@ async function runGroups(
   let unloadable = 0;
   let failed = 0;
   let refused = 0;
+  let writeFailed = 0;
   const failedGroups: string[] = [];
   let firstError: string | undefined;
+  let firstWriteError: string | undefined;
   let buzz = 0;
 
   try {
@@ -272,16 +290,34 @@ async function runGroups(
       // One group's failure must cost one group. `runPool` stops dispatching on the first rejection
       // and rethrows it, so an error escaping here abandoned every group not yet started AND the
       // whole review tick around it.
+      //
+      // The comparison and the writes are caught SEPARATELY. They are not one failure: a provider
+      // that never answered cost nothing and wrote nothing, while a failed write means the call was
+      // made, was billed, and left some of its six rows behind. They point at different systems and
+      // one counter cannot say which happened.
+      let verdict: Awaited<ReturnType<typeof compareGroup>>;
       try {
-        const verdict = await compareGroup({ systemPrompt, group: groupImages });
-        calls++;
-        buzz += verdict.buzzCost;
+        verdict = await compareGroup({ systemPrompt, group: groupImages });
+      } catch (error) {
+        failed++;
+        if (isRefusal(error)) refused++;
+        // A group of four fails as a UNIT, so no single failure attributes to an entry. The
+        // membership is logged so attribution can be done across ticks by intersection — an image in
+        // every failed group and no successful one is the suspect.
+        if (failedGroups.length < MAX_LOGGED_FAILED_GROUPS)
+          failedGroups.push(groupImages.map((image) => image.imageId).join(','));
+        firstError ??= describeError(error);
+        return;
+      }
 
-        if (!verdict.order) {
-          malformed++;
-          return;
-        }
+      calls++;
+      buzz += verdict.buzzCost;
+      if (!verdict.order) {
+        malformed++;
+        return;
+      }
 
+      try {
         // Written against the SNAPSHOT's played set, so a pair another lane recorded in the meantime
         // is still attempted here and lands on the conflict clause rather than being skipped by a
         // read that raced. Cheap either way: it is one row, not one call.
@@ -309,13 +345,8 @@ async function runGroups(
           });
         }
       } catch (error) {
-        failed++;
-        if (isContentRefusal(error)) refused++;
-        // A group of four fails as a UNIT, so no single failure attributes to an entry. The
-        // membership is logged so attribution can be done across ticks by intersection — an image in
-        // every failed group and no successful one is the suspect.
-        failedGroups.push(groupImages.map((image) => image.imageId).join(','));
-        firstError ??= error instanceof Error ? error.message : String(error);
+        writeFailed++;
+        firstWriteError ??= describeError(error);
       }
     });
   } finally {
@@ -337,7 +368,24 @@ async function runGroups(
       // classified answer, read out of the raw body by `isContentRefusal`.
       refused,
       failedGroups,
+      // The list is capped, so it stops being the count as soon as a whole field fails.
+      failedGroupsTruncated: failed > failedGroups.length,
       message: firstError,
+    }).catch(() => undefined);
+  }
+  if (writeFailed) {
+    // Points at the DATABASE, not the provider: the call was made and billed, and some of the
+    // group's six relation rows landed. `recordComparison` is one statement per row with no
+    // transaction around them, so a partial group is biased — `relationsFromRanking` emits pairs in
+    // ranking order, so the rows that land first are the ones the group's leader wins.
+    logToAxiom({
+      type: 'warning',
+      name: 'challenge-swiss-write-failed',
+      challengeId: ctx.challengeId,
+      planned: groups.length,
+      calls,
+      writeFailed,
+      message: firstWriteError,
     }).catch(() => undefined);
   }
   if (unloadable) {
@@ -361,7 +409,35 @@ async function runGroups(
       malformed,
     }).catch(() => undefined);
   }
-  return calls;
+  return { calls, planned: groups.length, failed };
+}
+
+/**
+ * A cap on the ids one tick reports. Attribution wants membership, not a transcript, and a field-
+ * wide outage at close can plan hundreds of groups against an unset `operationBudget`.
+ */
+const MAX_LOGGED_FAILED_GROUPS = 20;
+
+/**
+ * 🔴 Both of these run INSIDE the catch that exists to stop a failure escaping. `isContentRefusal`
+ * reads `.message`, `.body` and `.data$.body$` off the thrown value unguarded, and `String(error)`
+ * calls `toString` — a throwing accessor on either would escape `runPool` and abandon the tick,
+ * which is the exact bug this file was changed to remove.
+ */
+function isRefusal(error: unknown): boolean {
+  try {
+    return isContentRefusal(error);
+  } catch {
+    return false;
+  }
+}
+
+function describeError(error: unknown): string {
+  try {
+    return error instanceof Error ? error.message : String(error);
+  } catch {
+    return 'unserializable error';
+  }
 }
 
 /**


### PR DESCRIPTION
## The defect

`src/server/games/daily-challenge/challenge-engine-rolling-swiss.ts`, in `runGroups`: the `runPool` callback called `compareGroup` with **no try/catch**. `runPool` (`challenge-ladder.ts:225-252`) deliberately stops dispatching on the first rejection and rethrows it — so one provider failure dropped every group not yet started **and** the review tick around it.

Found in production by @sky on challenge 438, the first public daily on this engine.

## Evidence

Re-measured independently before touching anything, last 24h on `civitai-prod`:

| `challenge-engine-advance` | count |
|---|---|
| `info` | 84 |
| `error` | 49 |

36.8% of ticks abandoning their remaining work. All 49 errors carry the same message, `Provider returned error` — the OpenRouter envelope, which is generic for a refusal *and* for a 5xx. Both types returned rows, so the window was populated and the query could have seen a result either way.

## Five commits, and the second and third are the important ones

**`71818289c6`** — the containment fix: catch per group, separate telemetry names, billing into a `finally`.

**`4fcd33231b`** — a money-path blocker the first commit introduced. Per-group catching makes a close-time pass where **every** group failed return 0 calls, the same number a settled field returns. `rankField` broke on both, so a provider outage at close ranked a field with no comparison rows:

- `challenge-swiss.ts:231-236` — with no rows every entry scores 0.5 in `strength`, so `swissStandings` falls through to its `a.imageId - b.imageId` tiebreak
- `daily-challenge-processing.ts:1618-1621` — `rankField`'s output becomes `rankedEntries`, then winners, then prizes

Real Buzz paid on upload order. Before this PR the error propagated and left the challenge in `Completing` for a later run.

**`0d81b48c2e`** — the guard was still asking the wrong question. It asked whether a pass made *calls*, not whether it *measured* anything, and two states answered wrongly: a call that resolved and then failed to write its relations, and a call that came back unparseable. Neither increments `failed`, both increment `calls`. So both walked past the guard, ran the settle loop to its 11-pass bound **billing every pass**, and ranked on nothing. It now keys on `recorded` — rows actually inserted — closing the provider, write, malformed and unloadable doors in one condition.

That commit also gave the guard proportion. `failed > 0 && calls === 0` fires on the healthiest challenge there is — one so settled its last pass plans a single group — if that group hits a transient 5xx, and 37% of ticks see one. It would have discarded a fully measured close. It now refuses only when the field has **no comparison rows at all**, which is not a threshold anyone picked: it is exactly the condition under which the podium is upload order.

**`d3e9e831ac`** and **`d41e0a10c7`** — review follow-ups: pinning a declined recommendation, and correcting the test fixture.

## Everything else in the diff

- **Comparison and relation writes are caught separately.** They pointed at two different systems under one counter: a provider that never answered cost nothing and wrote nothing, while a failed write means the call was made, was billed, and left some of its six rows behind (`recordComparison` is one statement per row, no transaction). New `challenge-swiss-write-failed`, carrying the group membership — those are the groups holding partial rows, and finding them needs the ids. This also stops a Postgres error being counted in `refused`, the *content refusal* counter.
- **Four distinct telemetry names**, so a provider failure, a write failure, a missing-image skip and an unparseable ranking never read as each other. A clean tick emits none.
- **Refusals classified** with the existing, already-tested `isContentRefusal`, which reads the raw provider body rather than the generic envelope message.
- **Failed group membership logged**, capped at 20 with `failedGroupsTruncated`. A group of four fails as a unit, so no single failure attributes to an entry; membership across ticks makes attribution possible by intersection. Nothing acts on it.
- **`isContentRefusal` and the message read are guarded.** Both run inside the catch that exists to stop a failure escaping, and both touch properties of a thrown value — a throwing accessor would have escaped `runPool` and abandoned the tick, re-creating the exact bug.
- **`challenge-swiss-close` carries `passes` and `settleMs`.** The close stage has no wall-clock bound and can outlast the completion claim. Justin's call is to leave it unbounded and measure it rather than cap it, since a timeout trades a measured podium for a faster one.

## Decisions taken deliberately, each pinned by a test

**A wholly unloadable close still refuses to finalize.** Review correctly noted this arm has no path to success — a deleted image does not come back, so the hourly recovery re-plans the same groups forever — and proposed exempting it. Not taken: the exemption means finalizing on a field with no comparison rows, and paying the authors of images that are gone. A challenge that never finalizes pays nobody and warns every cycle; one that finalizes wrongly pays the wrong creators, irreversibly. Pinned by `REFUSES to finalize when the whole field failed to LOAD`, with the argument in its doc comment.

**Excluding a repeatedly-failing entry after N attempts.** Raised with Justin as a product decision; he chose not to. `Provider returned error` cannot currently be classified, and dropping an entry on a transient error would silently remove a legitimate creator from the ranking.

## Known, and deliberately not changed

**A failed call is never billed**, because a rejection carries no usage figure. The per-tick ceiling on unbilled calls therefore rises from ~1 to the planned group count, so `operationSpent` tracks a smaller fraction of real provider spend during an outage than it did. Stated rather than fixed: writing an estimated price into `operationSpent` would be inventing spend data.

**A challenge stuck in `Completing` retries hourly, unbounded, and re-bills each cycle.** `resetStuckCompletingChallenges` runs from an hourly cron with a 10-minute threshold, and there is no attempt counter on the path. A permanently unjudgeable challenge loops forever with one error line per cycle. An attempt cap belongs in `challengeCompletionJob`, a different subsystem, and is not in this PR.

**`challenge-engine-pairwise.ts:178`** has the same unguarded-pool shape. Different engine, out of scope — noted so it is not mistaken for something missed.

**Challenge 438** — live until 2026-08-26 00:00 UTC. Its `judgingEngine`, `operationBudget` and description are untouched.

## Verification

13 tests added, 22 in the file. **Reverting the engine to the base commit `b6aa4449b3`:**

```
Tests  13 failed | 9 passed (22)
```

All 13 fail.

**Targeted mutants, each reverted after:**

| mutant | result |
|---|---|
| delete the close-path guard | `promise resolved "[ …(16) ]" instead of rejecting` — the bug itself: a full ranking returned where it must refuse |
| key the guard on `calls` instead of `recorded` | the WRITE-failed and MALFORMED close tests |
| always throw (drop the measured-field term) | `still finalizes when a last group fails but the field IS measured` |
| exempt the pure-unloadable case, as review proposed | `REFUSES to finalize when the whole field failed to LOAD`, and nothing else |
| count attempted rather than committed writes in the state fake | `REFUSES to finalize when every close-time relation WRITE failed` |
| freeze `getSwissState` (drop the accumulating fake) | `expected 11 to be less than 11` — the settle loop reaching its backstop |
| drop the `isRefusal` / `describeError` wrappers | `survives an error whose own message THROWS when read` |
| `if (isContentRefusal(error)) refused++` to `refused++` | 2 tests |
| `firstError ??=` to `firstError =` | the 17-group test |
| attribute `groups[0]` instead of the failed group | the attribution assertion |
| never record write membership | `loses one group to a failed relation write` |
| `MAX_LOGGED_FAILED_GROUPS` to 1000 | the truncation test |
| never increment `passes` | `passes: 1` |

What the tests do **not** establish: `runPool`'s concurrency is 16, so in the four-group fixtures the rejection is pinned to the second *invocation* (deterministic — no `await` precedes `compareGroup` in the worker) while completion order is not, and nothing asserts an ordering. The 17-group test exists precisely because a four-group fixture cannot reach the "groups never dispatched" half of the bug. One test, `reports NEITHER warning on a clean tick`, passes against the unfixed engine and says so in its own comment.

Defects in this work caught by the tests and the two reviewers rather than by me: a string-replace that silently matched nothing (so `isContentRefusal` was never called); an assertion pinning the band shuffle's presentation order; a `compareGroup` mock returning a fixed ranking regardless of which group it was asked about; a state fake frozen across settle passes, which made "field measured" and "field unmeasured" the same fixture; and that same fake counting writes that had rejected.

**And two controls that could not fail.** After committing, `git checkout HEAD -- <engine>` restores the *fixed* file — that revert control printed `14 passed` and read as clean. And `HEAD~3` is the containment commit, not the base, so a control against it printed 9 instead of 13. Both were caught by asking what a failure should have looked like.

```
pnpm run typecheck   -> OK, 0 type errors
eslint <both files>  -> exit 0
pnpm exec vitest run --project 'unit*' <the suite> -> Test Files 1 passed (1) / Tests 22 passed (22)
pnpm run test:unit:run -> Test Files 1 failed | 1415 passed | 1 skipped (1417), exit 1
```

The one full-suite failure is `src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts`, a Windows-only path-separator guard. **Control:** with this diff stashed it still fails, `Tests 1 failed | 9 passed (10)` — pre-existing, unrelated. `blocks.router.workflow.test.ts` collected **358** tests, so the submodule is initialised and the run is meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEL2pqMTdhreopbNVgXkNH
