### PR TITLE
fix(test): route every path in the scroll-contract guard through one normaliser

### DIFF
--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -60,11 +60,19 @@ const RUN_PAGE = path.join(REPO_ROOT, 'src/pages/apps/run/[slug]/[[...path]].tsx
 const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/PageBlockHost.tsx');
 const APP_LAYOUT = path.join(REPO_ROOT, 'src/components/AppLayout/AppLayout.tsx');
 
+/**
+ * A repo-relative path with forward slashes, on every platform. `path.relative` returns the
+ * platform separator, so on Windows a raw result compares unequal to the `src/...` literals below
+ * and the guard fails for the platform rather than for the thing it guards. Every assertion here
+ * that names a file goes through this.
+ */
+const repoPath = (file: string) => path.relative(REPO_ROOT, file).split(path.sep).join('/');
+
 function read(file: string): string {
   // Prove the path before trusting a "no match": a comparison against an absent
   // operand reports SAME, not MISSING, and a renamed route would otherwise turn
   // every assertion below into a vacuous pass on an empty string.
-  expect(fs.existsSync(file), `${path.relative(REPO_ROOT, file)} does not exist`).toBe(true);
+  expect(fs.existsSync(file), `${repoPath(file)} does not exist`).toBe(true);
   return fs.readFileSync(file, 'utf8');
 }
 
@@ -239,7 +247,7 @@ describe('the run page and its host agree on who owns the height', () => {
             // Posix separators, so the expectation below reads the same on every
             // platform. Without this the walk yields `src\pages\…` on Windows and
             // the guard fails there while staying green on Linux CI.
-            offenders.push(path.relative(REPO_ROOT, full).split(path.sep).join('/'));
+            offenders.push(repoPath(full));
         }
       }
     };
@@ -362,14 +370,14 @@ describe('the run page and its host agree on who owns the height', () => {
       for (const re of patterns) {
         for (const m of src.matchAll(re)) {
           cssDecls.push({
-            file: path.relative(REPO_ROOT, file),
+            file: repoPath(file),
             value: m[1].trim().replace(/^['"`]|['"`]$/g, ''),
           });
         }
       }
       if (/\.tsx?$/.test(file)) {
         for (const m of src.matchAll(/(?:const|let|var)\s+(HEADER_HEIGHT(?:_PX)?)\s*=/g)) {
-          tsDecls.push({ file: path.relative(REPO_ROOT, file), text: m[1] });
+          tsDecls.push({ file: repoPath(file), text: m[1] });
         }
       }
     }


### PR DESCRIPTION
`path.relative` returns the platform separator, so on Windows this guard compared `src\styles\globals.css` against the `src/styles/globals.css` literal and failed for the platform rather than for the thing it guards.

#4387 fixed one of the four call sites. The other three were untouched, and one of them feeds the assertion that has been red on `main` since #4379 added it — which is why the box went straight back to a permanent `1 failed` after `868kwbbfa` was closed.

All four now go through a single `repoPath` helper, so a fifth site cannot reintroduce it.

## Mutation control

Moving the `--header-height` declaration into another file fails the guard **naming the file it moved to**, in forward slashes:

```
AssertionError: the `--header-height` declaration moved out of globals.css:
expected 'src/components/AppBlocks/mutation-control.css' to be 'src/styles/globals.css'
```

That is the check that matters. A comparison that passes on both separators *and* on a wrong path is a disabled guard reporting green, which is worse than the red it replaces.

**What the control could NOT reach, stated rather than implied:** the sibling assertion on `tsDecls[0].file` is shadowed by the `HEADER_HEIGHT_PX` read above it, which fails first on any mutation that would move the constant. It was wrong for the same reason and is corrected, but it has no reddening control and is closer to dead weight than to a guard.

## Sweep

Every `path.relative` call site in the test tree, classified per call site rather than per file — a file-level scan misfiles `no-agent-ground-truth-write.test.ts`, which has four un-normalised calls and is still safe.

| category | n |
|---|---|
| normalised inline | 30 |
| un-normalised, compared only against `[]` | 7 |
| un-normalised, both sides built the same way | 3 |
| un-normalised, message text only — never asserted | 3 |
| **un-normalised AND compared to a forward-slash literal** | **2** |

Both dangerous sites are the two fixed here. The earlier sweep's "exactly one dangerous member" was true when it ran; the second arrived with #4379.

## Suite

`Test Files 1422 passed | 1 skipped (1423)`, `Tests 22216 passed | 27 skipped (22243)` — **0 failed**, run against `5c1e8566c2` rebased on `origin/main` at `798d0893a9`.

⚠️ `main` reached `9b133c2258` while that suite ran. It moves faster than a full suite takes, so "the suite ran against the tip" is not a state anyone can hold — what this line means is that no failure survives on a base six commits newer than the one the ticket was closed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MkJyhc4BdEnHTHBZyvxqx
