### PR TITLE
fix(blocklist): bound how long a stale list can serve

### DIFF
--- a/apps/moderator/src/lib/server/blocklist.service.ts
+++ b/apps/moderator/src/lib/server/blocklist.service.ts
@@ -11,20 +11,29 @@ import { getRedis } from './redis';
 
 export type BlocklistDTO = { id?: number; type: string; data: string[] };
 
-const MONTH_TTL = 60 * 60 * 24 * 30; // matches the main app's CacheTTL.month
+/**
+ * A CEILING on staleness, not a cache lifetime — writers delete this key, so an edit normally takes
+ * effect on the next read. The populate below is read-then-write, so a reader that read the row
+ * before a write commits can land its pre-write snapshot after that write's delete, and only
+ * another write to the same type clears it. Three of the eight lists in production had gone 8, 46
+ * and 676 days without a write (measured 2026-08-25), so the expiry was the only bound there was.
+ *
+ * The main app and the auth hub populate this same key with the same value; they have to agree.
+ */
+const CACHE_TTL = 5 * 60;
 
 const blocklistKey = (type: string) =>
   `${REDIS_KEYS.SYSTEM.BLOCKLIST}:${type}` as RedisKeyTemplateCache;
 
 /** The cache-aside populate, and the ONLY `set` in this file — see `bustCache` for why writers never. */
 async function setCache(data: BlocklistDTO) {
-  await getRedis().set(blocklistKey(data.type), JSON.stringify(data), { EX: MONTH_TTL });
+  await getRedis().set(blocklistKey(data.type), JSON.stringify(data), { EX: CACHE_TTL });
 }
 
 /**
  * 🔴 DELETE, never a re-read written back. Writing a snapshot is itself a read-modify-write with no
  * lock over it, so two WRITERS the row lock correctly serialised could still land their cache
- * writes in the other order and leave the LOSER's list under a month TTL. Deletes commute with each
+ * writes in the other order and leave the LOSER's list cached until it expires. Deletes commute with each
  * other, so that ordering no longer decides anything.
  *
  * ⚠️ What this does NOT close, stated because the obvious reading of "deletes commute" is that it
@@ -36,8 +45,7 @@ async function setCache(data: BlocklistDTO) {
  * and the page reloads through `load` on every submit, so a reader is typically mid-fill when the
  * write AFTER this one commits — two moderators submitting seconds apart is enough. This write's
  * own bust cannot put a reader into this write's window, because a miss it caused reads a row that
- * is already updated. Closing it needs a lease, a version, or a TTL short enough that the staleness
- * is bounded; none of those is in this change.
+ * is already updated. `CACHE_TTL` is the TTL-short-enough option: it bounds that window rather than closing it.
  *
  * Returns false rather than throwing. The row is already committed by the time this runs, and a
  * throw here reports failure for a write that succeeded — on the remove path the operator's retry
@@ -76,8 +84,8 @@ async function bustCache(type: string): Promise<boolean> {
 async function readBlocklistRow(type: string): Promise<BlocklistDTO> {
   // `dbWrite`, not `dbRead`, and this is MORE load-bearing since the writers stopped calling this:
   // its one caller is the cache-aside populate in `getBlocklistDTO`, and a write busts the key, so
-  // the very next read is a post-write read that pins a value for a MONTH. Off the replica that
-  // read races replication and caches the PRE-EDIT row for 30 days — a moderator's change silently
+  // the very next read is a post-write read whose value then serves every pod until it expires. Off
+  // the replica that read races replication and caches the PRE-EDIT row — a moderator's change silently
   // undone. Do not "optimise" this to `dbRead` because no write path reaches it any more.
   const rows = await dbWrite
     .selectFrom('Blocklist')

--- a/src/server/services/__tests__/blocklist.service.test.ts
+++ b/src/server/services/__tests__/blocklist.service.test.ts
@@ -211,6 +211,27 @@ describe('a type with more than one Blocklist row', () => {
     const result = await getBlocklistDTO({ type: BlocklistType.EmailDomain });
     expect(result.data).toEqual([]);
   });
+
+  /**
+   * The populate is read-then-write, so a reader that read the row before a write commits can land
+   * its pre-write snapshot after that write's DELETE. Only another write to the same type clears
+   * it, and three of the eight lists in production had gone 8, 46 and 676 days without one — so
+   * this expiry is the only bound on how long a moderator's edit can go unenforced.
+   *
+   * A ceiling rather than an exact number: tuning the value should not need a test edit, restoring
+   * the month it used to be should.
+   */
+  it('caches for minutes, not a month — the expiry bounds how long a stale copy serves', async () => {
+    respectOrderBy([{ id: 1, type: BlocklistType.EmailDomain, data: ['a.example'] }]);
+
+    await getBlocklistDTO({ type: BlocklistType.EmailDomain });
+
+    const options = redisMock.redis.set.mock.calls.at(-1)?.[2] as { EX?: number } | undefined;
+    expect(options?.EX, 'the populate must set an expiry').toBeGreaterThan(0);
+    expect(options?.EX, 'a stale copy must not be able to serve for hours').toBeLessThanOrEqual(
+      15 * 60
+    );
+  });
 });
 
 describe('what an edit does to the shared cache key', () => {
@@ -228,7 +249,7 @@ describe('what an edit does to the shared cache key', () => {
    * This used to cache a re-read of the winning row, which fixed one bug and left another: the
    * re-read and the `SET` are themselves an unserialised read-modify-write over the key, so two
    * edits the row lock correctly serialised could still land their cache writes in the other
-   * order and leave the LOSER's list under a month TTL. Every enforcement path reads this key
+   * order and leave the LOSER's list cached until it expires. Every enforcement path reads this key
    * first, so that is the lost update the row lock exists to prevent, moved to the artifact that
    * actually gates. A delete commutes; the next read repopulates from the table.
    *

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -21,29 +21,44 @@ function getBlocklistKey(type: string) {
   return `${REDIS_KEYS.SYSTEM.BLOCKLIST}:${type}` as RedisKeyTemplateCache;
 }
 
+/**
+ * A CEILING on staleness, not a cache lifetime. Writers delete this key, so an edit normally takes
+ * effect on the next read; this bounds the case the delete cannot reach. The populate below is
+ * read-then-write, so a reader that read the row before a write commits can land its pre-write
+ * snapshot after that write's delete, and only another write to the same type clears it. Measured
+ * 2026-08-25: three of the eight lists in production had gone 8, 46 and 676 days without a write,
+ * so "the next write" is not a bound at all and the expiry was the only one.
+ *
+ * The moderator spoke and the auth hub populate this same key and carry the same value. They have
+ * to agree — a shorter one anywhere is harmless, a longer one reinstates the window for whichever
+ * app wrote it.
+ */
+const BLOCKLIST_CACHE_TTL = 5 * 60;
+
 // No in-process cache: pod-local copies can't be invalidated cross-pod on upsert.
 async function setCache({ type, data }: { type: string; data: BlocklistDTO }) {
   await redis.set(getBlocklistKey(type), JSON.stringify(data), {
-    EX: CacheTTL.month,
+    EX: BLOCKLIST_CACHE_TTL,
   });
 }
 
 /**
  * 🔴 DELETE, never a re-read written back. Writing a snapshot is itself a read-modify-write with no
  * lock over it, so two WRITERS the row lock correctly serialised could still land their cache writes
- * in the other order, leaving the LOSER's list under a month TTL. Deletes commute with each other,
+ * in the other order, leaving the LOSER's list cached until it expires. Deletes commute with each other,
  * so that ordering no longer decides anything.
  *
  * ⚠️ What this does NOT close: a DELETE does not commute with the POPULATE in `getBlocklistDTO`,
  * which is plain cache-aside. A reader that missed and read the row before the commit can `set` its
- * pre-write snapshot AFTER the bust, pinning it for the month TTL.
+ * pre-write snapshot AFTER the bust, pinning it until the key expires.
  *
  * The causation runs to the NEXT write, not this one: a bust guarantees the following read misses,
  * so a reader is typically mid-fill when the write AFTER this one commits — and back-to-back writes
  * are ordinary here, a moderator removing chips one at a time. This write's own bust cannot put a
  * reader into this write's window, because a miss it caused reads a row that is already updated.
- * Closing it needs a lease, a version, or a TTL short enough to bound the staleness; none of those
- * is in this change.
+ * `BLOCKLIST_CACHE_TTL` is the TTL-short-enough option: it bounds that window rather than closing
+ * it. A lease or a version would close it outright, at the cost of the same rule existing in three
+ * separately-released apps.
  *
  * The moderator spoke busts the same key the same way. The two must agree.
  *
@@ -138,7 +153,7 @@ export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSc
       // Unreachable while the locking read above holds: a row it returned is locked to commit,
       // so nothing can delete or re-type it underneath. Asserted anyway so the guarantee is
       // local — anyone who later moves either statement out of this transaction gets a failure
-      // instead of a silent zero-row success that then caches a stale row for a month.
+      // instead of a silent zero-row success that then caches a stale row.
       if (count !== 1) throw new Error(`blocklist update matched ${count} rows under a row lock`);
       return next;
     },
@@ -162,7 +177,7 @@ export async function upsertBlocklist({ id, type, blocklist }: UpsertBlocklistSc
  *
  * No writer calls this any more. Its one caller is the cache-aside populate in `getBlocklistDTO` —
  * so this is what decides which row the whole system enforces, and a write busts the key, making
- * the next read a post-write read that pins a value for a month.
+ * the next read a post-write read whose value then serves every pod until it expires.
  *
  * This picks the lowest id, always, and reports the duplicate. It deliberately does NOT
  * union the rows: for a deny-list a union blocks more, but for the benign lists a union


### PR DESCRIPTION
Writers already delete the shared cache key, so a moderator's blocklist edit normally takes effect on the next read. This bounds the case the delete cannot reach.

The populate is read-then-write: a reader that read the row *before* a write commits can land its pre-write snapshot *after* that write's delete. The delete already happened, so nothing clears the stale copy but another write to the same type — and the expiry was a month.

## Measured before designing anything

`Blocklist` on production, 2026-08-25, eight rows, one per type:

| list | last written | gap |
|---|---|---|
| EmailDomain, MessagePattern, LinkDomain | that day | ~2 hours |
| ProfanityBenignWord, PromptBenignPhrase | 2026-08-21 | 4 days |
| UsernamePartial | 2026-08-17 | 7.9 days |
| NegativeBenignPhrase | 2026-07-10 | 45.8 days |
| Link | 2024-10-19 | 675.7 days |

On the three lists being worked that day a stale copy is cleared within hours by the next edit. On the bottom three nothing clears it early, so the month was the only bound. `EmailDomain` also has a weekly cron writer, so its worst case is about a week regardless of moderator activity.

The live cache was also read, through a replica that serves the slot after `READONLY`: every key was populated at or after its row's last write, and the three edited that day were reloaded **within one second** of the write that busted them. So the bust works; nothing stale was standing. Two of the eight (`Link`, `NegativeBenignPhrase`) sit on masters the bastion does not forward and could not be read — and they are the two with the longest write gaps, so the lists where a pin would last longest are the ones that measurement says nothing about.

## What this changes

Five minutes, in the main app and the moderator spoke, which populate the same key. `apps/auth` carries the same constant and ships separately, so it follows as its own PR.

This **bounds** the window rather than closing it. Closing it outright needs a lease or a version stamp, which would mean the same rule living identically in three separately-released apps, where a mismatch is a new quiet failure. Justin chose the bound.

## Test

Asserts a **ceiling** (≤ 15 min) rather than the digits, so tuning the value needs no test edit while restoring the month fails.

Mutation control: setting it back to `60 * 60 * 24 * 30` fails with
`a stale copy must not be able to serve for hours: expected 2592000 to be less than or equal to 900`.

## Suite

`Test Files 1 failed | 1422 passed | 1 skipped (1424)` at `0e1710dbdd`, rebased on `origin/main` at `9b133c2258`.

The one failure is `pageRunScrollContract.test.ts > the header height has ONE declaration under src/` — `868kwbbfa`, the Windows path-separator guard, fixed by #4397 which is open and not yet merged. Not this change: it touches no CSS, no header constant, and no test in that file.

Also run: `test:apps:run` 85 files / 891 passed, and `apps/moderator` `svelte-check` 9354 files / 0 errors — the moderator spoke is the second writer of this key and is not covered by the main app's typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MkJyhc4BdEnHTHBZyvxqx
