### PR TITLE
fix(auth): bound how long a stale email blocklist can serve

### DIFF
--- a/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
@@ -27,7 +27,9 @@ function makeRedis() {
   return {
     _store: store,
     get: vi.fn(async (k: string) => store.get(k) ?? null),
-    set: vi.fn(async (k: string, v: string) => {
+    // The options argument is modelled because the EXPIRY is now part of what this file asserts.
+    // A fake narrower than the real client is a ceiling on what any test here can see.
+    set: vi.fn(async (k: string, v: string, _options?: { EX: number }) => {
       store.set(k, v);
       return 'OK';
     }),
@@ -61,11 +63,34 @@ describe('getBlockedEmailDomains', () => {
 
     expect(await getBlockedEmailDomains()).toEqual(['db1.com', 'db2.com']);
     expect(h.executeTakeFirst).toHaveBeenCalledTimes(1);
-    // best-effort repopulate with a 30d TTL
     expect(redis.set).toHaveBeenCalledWith(
       BLOCKLIST_KEY,
       JSON.stringify({ type: 'EmailDomain', data: ['db1.com', 'db2.com'] }),
-      { EX: 60 * 60 * 24 * 30 }
+      { EX: expect.any(Number) }
+    );
+  });
+
+  /**
+   * This repopulate is what a moderator's edit has to outlive. The writers DELETE the key, so an
+   * edit normally lands on the next read; what the delete cannot reach is a read that started
+   * before the write and finishes after it, writing its pre-write copy back. The expiry is the
+   * only bound on that, and it used to be a month.
+   *
+   * A ceiling rather than the exact number, so tuning the value needs no test edit while restoring
+   * the month fails. The main app and the moderator spoke populate this same key and carry the
+   * same bound.
+   */
+  it('repopulates with a bound of minutes, not a month', async () => {
+    const redis = makeRedis();
+    h.getRedis.mockReturnValue(redis);
+    h.executeTakeFirst.mockResolvedValue({ data: ['db1.com'] });
+
+    await getBlockedEmailDomains();
+
+    const options = redis.set.mock.calls.at(-1)?.[2] as { EX?: number } | undefined;
+    expect(options?.EX, 'the repopulate must set an expiry').toBeGreaterThan(0);
+    expect(options?.EX, 'a stale copy must not be able to serve for hours').toBeLessThanOrEqual(
+      15 * 60
     );
   });
 

--- a/apps/auth/src/lib/server/auth/blocklist.ts
+++ b/apps/auth/src/lib/server/auth/blocklist.ts
@@ -3,11 +3,22 @@ import { getRedis } from '../redis';
 import { db } from '../db/db';
 
 // Blocked email domains — mirrors the main app's getBlockedEmailDomains (blocklist.service.ts).
-// The main app keeps `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain` warm (a JSON {type, data[]} with a
-// ~1-month TTL, refreshed on read). We read that shared cache first, then fall back to the
-// Blocklist table on a cold cache (and best-effort repopulate). Same redis + same DB = same list.
+// The main app keeps `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain` warm (a JSON {type, data[]},
+// refreshed on read). We read that shared cache first, then fall back to the Blocklist table on a
+// cold cache (and best-effort repopulate). Same redis + same DB = same list.
 const BLOCKLIST_KEY = `${REDIS_KEYS.SYSTEM.BLOCKLIST}:EmailDomain`;
-const TTL_SECONDS = 60 * 60 * 24 * 30; // 30d, matches the main app
+
+/**
+ * A CEILING on staleness, not a cache lifetime. The moderator writers DELETE this key, so an edit
+ * normally takes effect on the next read. What the delete cannot reach is the repopulate below: it
+ * reads the row and then writes, so a read that happened before a write commits can land its
+ * pre-write copy after that write's delete. Only another write to the same type clears it, and on
+ * production three of the eight lists had gone 8, 46 and 676 days without one.
+ *
+ * Must match the main app and the moderator spoke, which populate this same key. A shorter value
+ * anywhere is harmless; a longer one reinstates the window for whichever app wrote it.
+ */
+const TTL_SECONDS = 5 * 60;
 
 type StringGet = { get(k: string): Promise<string | null | undefined> };
 type StringSet = { set(k: string, v: string, o: { EX: number }): Promise<unknown> };


### PR DESCRIPTION
Third and last of the blocklist-cache set. `apps/auth` releases separately from the main app, so it is its own PR — the main app and the moderator spoke are in #4398.

The auth hub repopulates the shared `system:blocklist:EmailDomain` key on a cold cache, with the same expiry the main app used: a month.

The moderator writers **delete** this key, so an edit normally takes effect on the next read. What the delete cannot reach is this repopulate — it reads the row and *then* writes, so a read that began before a write commits can land its pre-write copy *after* that write's delete. The delete has already happened. Only another write to the same type clears it.

Measured on production 2026-08-25: three of the eight lists had gone **8, 46 and 676 days** without a write, so for those the expiry was the only bound there was.

Five minutes, matching #4398. The three apps ship separately, so a window where they disagree is expected and harmless in one direction only: a shorter value anywhere costs nothing, a longer one reinstates the window for whichever app wrote the key.

## Tests

The existing test asserted the exact 30-day value and failed loudly on this change, which is what it was for. It now asserts a **ceiling** (≤ 15 min) instead, so tuning the value needs no test edit while restoring the month fails.

Mutation control: setting it back to `60 * 60 * 24 * 30` fails with
`a stale copy must not be able to serve for hours: expected 2592000 to be less than or equal to 900`.

⚠️ **The redis fake did not model `set`'s options argument at all** — its signature stopped at `(k, v)`. That is why nothing in this file could pin the expiry before: the fake was a ceiling on what any test here could see. `svelte-check` is what surfaced it, as a type error on the new assertion rather than a silent pass. The fake now takes the options.

## Verification

- `apps/auth` `svelte-check`: **8043 files, 0 errors**
- `test:apps:run`: **86 files / 914 passed | 35 skipped (949)**

⚠️ One pre-existing `svelte-check` WARNING, untouched by this change and reported because the repo's guidance says these are read rather than filtered: `src/routes/login/+page.svelte:28` — `state_referenced_locally` on `form`, i.e. only the initial value is captured. Not in this diff; flagging, not fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MkJyhc4BdEnHTHBZyvxqx
