### PR TITLE
feat(app-blocks): a moderator-initiated free-text message to an app's owner

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260824120000_app_listing_mod_action_message_owner/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260824120000_app_listing_mod_action_message_owner/migration.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- Moderator → app-developer messaging: widen the app_listing_moderation_events action CHECK
+-- ============================================================
+-- Adds ONE moderation action:
+--   * 'message-owner' — a moderator sent the app's canonical owner (and, on
+--     request, its accepted collaborators) a free-text message. Unlike every other
+--     action in this taxonomy it changes NO listing state: the row exists to make
+--     the message attributable and reviewable. `reason` carries the SUBJECT and
+--     `detail` the BODY, so the moderation history renders what was actually said;
+--     `after` records the delivery decision (`recipientUserIds`,
+--     `includeCollaborators`), which is the part that cannot be reconstructed later
+--     because the canonical owner can change after the fact.
+--
+-- The current CHECK (20260713120000_w13_post_approval_mod_actions) allows
+-- delist|relist|claim|purge|report-resolve|report-dismiss|reset-to-pending|
+-- owner-unpublish|owner-republish, so `messageAppOwner` would be REJECTED with 23514
+-- without this widen. Postgres cannot modify a CHECK in place -> DROP then ADD.
+-- ADDITIVE: the new IN-list is a strict SUPERSET of the old one, so no existing row
+-- can violate it (nothing to backfill / re-validate).
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy). This
+-- file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
+-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
+--
+-- 🔴 ORDERING: timing-sharp, exactly like the widen it follows. Existing code paths
+-- are unaffected, but the NEW proc's first write fails without it:
+--   * Apply to the DEV CLONE **before** a PR preview exercises `messageAppOwner`, or
+--     the preview 500s on the constraint (preview-DB-drift → smoke-500 trap).
+--   * Apply to PROD nvme0 **before** this ships (main -> release), or the first live
+--     moderator message hits 23514 — and note the failure mode is the GOOD one: the
+--     audit row is written BEFORE delivery, so a missing CHECK widen means the
+--     message is never sent, not that it is sent unrecorded.
+--
+-- The migration-agreement unit test
+-- (src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts)
+-- parses the LATEST action-CHECK migration `.sql` (this file, by sorted dir name)
+-- and asserts its IN-list equals the code tuple APP_LISTING_MODERATION_ACTIONS,
+-- catching code/DDL drift at CI time — but it does NOT apply the DDL. The human
+-- apply above is still required.
+--
+-- Idempotent: DROP IF EXISTS then ADD, so a manual re-run is a no-op.
+--
+-- Wrapped in a single transaction so the DROP+ADD swap is ATOMIC: without it there
+-- is a sub-ms window between DROP and ADD where the table has NO action CHECK and a
+-- concurrent bad write could slip through.
+BEGIN;
+ALTER TABLE "app_listing_moderation_events"
+  DROP CONSTRAINT IF EXISTS "app_listing_mod_events_action_check";
+ALTER TABLE "app_listing_moderation_events"
+  ADD  CONSTRAINT "app_listing_mod_events_action_check"
+  CHECK ("action" IN (
+    'delist',
+    'relist',
+    'claim',
+    'purge',
+    'report-resolve',
+    'report-dismiss',
+    'reset-to-pending',
+    'owner-unpublish',
+    'owner-republish',
+    'message-owner'
+  ));
+COMMIT;

--- a/src/components/Apps/appListingModerationView.ts
+++ b/src/components/Apps/appListingModerationView.ts
@@ -104,6 +104,14 @@ const MOD_ACTION_CHIPS: Record<string, Chip> = {
   'reset-to-pending': { label: 'Reset to pending', color: 'yellow' },
   'owner-unpublish': { label: 'Unpublished by you', color: 'gray' },
   'owner-republish': { label: 'Republished by you', color: 'green' },
+  // 🔴 The one action that changed NO listing state — it records that a moderator sent
+  // the owner a free-text message. The label must read correctly in BOTH views this map
+  // serves: the mod queue (`OffsiteReviewQueue`) and the OWNER's own history
+  // (`ownerListingModals`, via `listMyListingModerationEvents`). "Message from
+  // moderation" is true from either side; "Messaged the owner" would be wrong in the
+  // owner's own view, and every `owner-*` label above shows the map is already read
+  // second-person there. Blue, matching `claim` — informational, not a takedown.
+  'message-owner': { label: 'Message from moderation', color: 'blue' },
 };
 
 /** Chip for a moderation-event action, for the per-listing history view. */

--- a/src/server/notifications/__tests__/app-moderator-message.notifications.test.ts
+++ b/src/server/notifications/__tests__/app-moderator-message.notifications.test.ts
@@ -51,9 +51,7 @@ describe('registration shape', () => {
     // send would succeed, the row would exist, and the developer would see nothing —
     // a silent failure that no test of this module alone can see.
     expect(notificationProcessors).toHaveProperty('app-moderator-message');
-    expect(
-      (notificationProcessors as Record<string, unknown>)['app-moderator-message']
-    ).toBe(def);
+    expect((notificationProcessors as Record<string, unknown>)['app-moderator-message']).toBe(def);
   });
 });
 

--- a/src/server/notifications/__tests__/app-moderator-message.notifications.test.ts
+++ b/src/server/notifications/__tests__/app-moderator-message.notifications.test.ts
@@ -93,12 +93,20 @@ describe('prepareMessage', () => {
     expect(m!.message).toContain(MODERATION_REPLY_URL);
   });
 
-  it('does NOT name the acting moderator — nothing in details can', () => {
-    // Attribution lives in `AppListingModerationEvent.actorUserId`. Naming the
-    // individual on the wire would make "who acted on my app" answerable by the
-    // developer, which is a retaliation vector the rest of the moderation surface
-    // declines to open. Asserted on the TYPE's own field set, so adding a
-    // `moderatorUsername` field later fails here rather than shipping quietly.
+  it('renders nothing beyond the four details fields', () => {
+    // ⚠️ SCOPE, corrected: this asserts the shape of the LOCAL fixture, not the
+    // exported TYPE. TypeScript types are erased at runtime, so adding a
+    // `moderatorUsername` field to `AppModeratorMessageNotificationDetails` would NOT
+    // fail this — an earlier version of this comment claimed it would, and that claim
+    // was the kind of "reads as coverage while providing none" that stops the next
+    // person looking.
+    //
+    // 🔴 THE REAL GUARD ON "the moderator is not named to the recipient" IS
+    // `app-moderator-message.service.test.ts` → "the moderator is recorded in the audit
+    // row and ABSENT from what the recipient gets", which inspects the details object
+    // the SERVICE actually builds and is confirmed by mutation. What this case is worth
+    // keeping for is narrower: the fixture that feeds the whole-string pin below has
+    // exactly these four fields, so the pinned copy cannot be silently fed a fifth.
     expect(Object.keys(DETAILS).sort()).toEqual(['body', 'listingId', 'slug', 'subject']);
   });
 

--- a/src/server/notifications/__tests__/app-moderator-message.notifications.test.ts
+++ b/src/server/notifications/__tests__/app-moderator-message.notifications.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appModeratorMessageNotifications,
+  MODERATION_REPLY_URL,
+  type AppModeratorMessageNotificationDetails,
+} from '~/server/notifications/app-moderator-message.notifications';
+import { notificationProcessors } from '~/server/notifications/utils.notifications';
+import { OWNER_SUBMISSIONS_URL } from '~/server/notifications/app-listing.notifications';
+
+/**
+ * The twelfth app notification type — the moderator's free-text message (pure: no DB,
+ * no client).
+ *
+ * 🔴 THE COPY IS PINNED AS A WHOLE NORMALISED STRING, not by keyword. The artifact
+ * under test IS prose, and a guard on WORDS is walkable by REWORDING: a `toContain`
+ * on "not delivered" stays green through a rewrite that drops the reply route
+ * entirely, or that renders the subject and silently drops the body. A cosmetic reword
+ * will now fail this test — that is the price of a machine-readable claim about what a
+ * developer actually receives, and it is worth paying for the one notification type
+ * whose entire payload is text a human wrote.
+ */
+
+type Def = (typeof appModeratorMessageNotifications)['app-moderator-message'];
+const def = (appModeratorMessageNotifications as Record<string, Def>)['app-moderator-message'];
+
+function msg(details: AppModeratorMessageNotificationDetails) {
+  return def.prepareMessage({ details } as Parameters<Def['prepareMessage']>[0]);
+}
+
+const DETAILS: AppModeratorMessageNotificationDetails = {
+  slug: 'prompt-vault',
+  listingId: 'apl_live',
+  subject: 'Your listing describes a spend confirmation that does not exist',
+  body: 'It says it asks before it spends. It has never shown a confirmation.',
+};
+
+describe('registration shape', () => {
+  it('is a non-toggleable System notification with no prepareQuery', () => {
+    expect(def).toBeTruthy();
+    // Not toggleable, for the same reason the moderation-decision types are not: a
+    // developer must not be able to opt out of being told their app has a problem.
+    expect(def.toggleable).toBe(false);
+    expect(def.category).toBe('System');
+    // Imperative — emitted from the service, never scanned by the scheduled job.
+    expect((def as { prepareQuery?: unknown }).prepareQuery).toBeUndefined();
+  });
+
+  it('🔴 is REGISTERED in the shared processor map', () => {
+    // Without this the type renders as `null` in the drawer: `getNotificationMessage`
+    // looks the type up in `notificationProcessors` and returns null on a miss. The
+    // send would succeed, the row would exist, and the developer would see nothing —
+    // a silent failure that no test of this module alone can see.
+    expect(notificationProcessors).toHaveProperty('app-moderator-message');
+    expect(
+      (notificationProcessors as Record<string, unknown>)['app-moderator-message']
+    ).toBe(def);
+  });
+});
+
+describe('prepareMessage', () => {
+  it('🔴 renders the EXACT string a developer receives', () => {
+    const m = msg(DETAILS);
+    expect(m).toBeTruthy();
+    expect(m!.message).toBe(
+      'Civitai moderation sent you a message about your app "prompt-vault" — ' +
+        'Your listing describes a spend confirmation that does not exist: ' +
+        'It says it asks before it spends. It has never shown a confirmation. ' +
+        '(Replies to this notification are not delivered; contact the team at civitai.com/support.)'
+    );
+  });
+
+  it('carries BOTH halves of what the moderator wrote, verbatim', () => {
+    // Independently of the whole-string pin above, because the failure mode this
+    // guards — rendering the subject and dropping the body — is the one that turns a
+    // message into a notification with no content, and it is a one-line edit.
+    const m = msg(DETAILS);
+    expect(m!.message).toContain(DETAILS.subject);
+    expect(m!.message).toContain(DETAILS.body);
+  });
+
+  it('identifies the app by SLUG, which is never null', () => {
+    // The sibling families fall back to a terse label when `name` is absent. Here the
+    // recipient may own several apps, and one of the two listings that motivated this
+    // feature has an entirely empty listing — i.e. a null name — so a fallback would
+    // fire exactly where identification matters most.
+    const m = msg({ ...DETAILS, slug: 'df-qwen-canvas' });
+    expect(m!.message).toContain('your app "df-qwen-canvas"');
+    expect(m!.message).not.toContain('prompt-vault');
+  });
+
+  it('🔴 always states that replies are not delivered, and where to go instead', () => {
+    // A one-way channel that does not say so strands a developer who wants to answer.
+    const m = msg(DETAILS);
+    expect(m!.message).toContain('not delivered');
+    expect(m!.message).toContain(MODERATION_REPLY_URL);
+  });
+
+  it('does NOT name the acting moderator — nothing in details can', () => {
+    // Attribution lives in `AppListingModerationEvent.actorUserId`. Naming the
+    // individual on the wire would make "who acted on my app" answerable by the
+    // developer, which is a retaliation vector the rest of the moderation surface
+    // declines to open. Asserted on the TYPE's own field set, so adding a
+    // `moderatorUsername` field later fails here rather than shipping quietly.
+    expect(Object.keys(DETAILS).sort()).toEqual(['body', 'listingId', 'slug', 'subject']);
+  });
+
+  it('links to the owner submissions view, the one URL the recipient can always open', () => {
+    // `/apps/mine` gates on `appBlocksAuthor` — the cohort a listing owner is in by
+    // construction — whereas the public detail page gates on `hasAppsStoreAccess` and
+    // 404s for owners outside it. Pinned against the shared constant so a route rename
+    // moves this with its five siblings rather than stranding it.
+    expect(msg(DETAILS)!.url).toBe(OWNER_SUBMISSIONS_URL);
+    expect(OWNER_SUBMISSIONS_URL).toBe('/apps/mine');
+  });
+});

--- a/src/server/notifications/app-moderator-message.notifications.ts
+++ b/src/server/notifications/app-moderator-message.notifications.ts
@@ -1,0 +1,100 @@
+import { NotificationCategory } from '~/server/common/enums';
+import { createNotificationProcessor } from '~/server/notifications/base.notifications';
+import { OWNER_SUBMISSIONS_URL } from '~/server/notifications/app-listing.notifications';
+
+/**
+ * App Store Listings — the MODERATOR-INITIATED, FREE-TEXT message to an app's owner.
+ *
+ * 🔴 HOW THIS DIFFERS FROM THE OTHER ELEVEN APP NOTIFICATIONS, and why it needed a
+ * twelfth type rather than a reused one. All eleven existing app types
+ * (`app-block-*`, `app-listing-*`, `app-collaborator-*`, `app-ownership-transfer-*`)
+ * are EVENT-TRIGGERED with FIXED copy: a state transition happened, and
+ * `prepareMessage` renders a sentence the platform wrote. Four of them additionally
+ * splice a moderator-supplied `reason` into that fixed sentence — but the sentence,
+ * and therefore the SUBJECT of the message, is chosen by the code path, not by the
+ * moderator. There was no way for a moderator to say a thing the platform has no
+ * event for ("your listing claims it asks before spending; it does not"), which left
+ * the only routes as editing a third party's app or contacting them off-platform.
+ *
+ * This type carries the moderator's own SUBJECT and BODY and renders them verbatim.
+ *
+ * 🔴 IT IS NOT AN INBOX, AND THE COPY SAYS SO. A notification is one-way — there is
+ * no thread, no reply affordance, and nothing on the recipient's side that would
+ * route a reply anywhere. Leaving that implicit would strand a developer who WANTS to
+ * answer ("we shipped the estimate last week"), so {@link MODERATION_REPLY_URL} is
+ * appended to every rendered message. If a real two-way channel is ever built, this
+ * clause is the thing to delete — deliberately part of the string rather than a
+ * separate optional field, so it cannot be forgotten on one code path.
+ *
+ * 🔴 THE ACTING MODERATOR IS NOT NAMED TO THE RECIPIENT. Attribution lives in
+ * `AppListingModerationEvent.actorUserId` (durable, mod-visible, survives an account
+ * delete), which is where accountability belongs. Naming the individual on the wire
+ * would make "who delisted my app" answerable by a developer, which is a retaliation
+ * vector the rest of the moderation surface already declines to open: `delistListing`
+ * / `rejectRequest` both carry the mod's REASON to the user and never the mod's
+ * identity. This type matches that posture rather than inventing a second one.
+ *
+ * Imperative like its siblings: emitted directly via `createNotification`, so NO
+ * `prepareQuery` and no notifications-DB migration (`type` is free-form text).
+ * Registered in `utils.notifications.ts`.
+ *
+ * DARK on arrival: the only emitter is a `moderatorProcedure`, so nothing reaches a
+ * developer until a moderator sends one.
+ */
+
+export type AppModeratorMessageNotificationDetails = {
+  /**
+   * The public store slug — the app's identity in the rendered message.
+   *
+   * 🔴 THE SLUG, NOT THE DISPLAY NAME, and that is a decision rather than an
+   * omission. The sibling families carry `name` with a `'Your app'` fallback because
+   * they are emitted from paths that already hold the row. Here the recipient may own
+   * several apps, so a terse fallback is genuinely ambiguous — and one of the two
+   * listings that motivated this feature has an ENTIRELY EMPTY listing, i.e. a null
+   * name, which is precisely the case where a fallback would fire. The slug is NOT
+   * NULL, is the app's public identity (`<slug>.civit.ai`), and is already resolved
+   * by the owner lookup — so it identifies the app in every case at no extra read.
+   */
+  slug: string;
+  /** The PARENT listing id (`apl_<ULID>`) for a future deep-link. */
+  listingId?: string | null;
+  /** The moderator's free-text subject line. Rendered VERBATIM. */
+  subject: string;
+  /** The moderator's free-text body. Rendered VERBATIM. */
+  body: string;
+};
+
+/**
+ * Where a recipient who wants to answer should actually go.
+ *
+ * A bare path would be ambiguous inside a sentence that already contains a slug and a
+ * quoted app name, so this is written host-first. It is TEXT, not the notification's
+ * `url` — that stays {@link OWNER_SUBMISSIONS_URL}, because the developer's first move
+ * on a message about their listing is to open the listing.
+ */
+export const MODERATION_REPLY_URL = 'civitai.com/support';
+
+/** `your app "<slug>"`. */
+function appLabel(details: AppModeratorMessageNotificationDetails): string {
+  return `your app "${details.slug}"`;
+}
+
+export const appModeratorMessageNotifications = createNotificationProcessor({
+  'app-moderator-message': {
+    displayName: 'Message from Civitai moderation',
+    category: NotificationCategory.System,
+    // Not toggleable, for the same reason the moderation-decision types are not: a
+    // developer must not be able to opt out of being told their app has a problem.
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppModeratorMessageNotificationDetails;
+      return {
+        message:
+          `Civitai moderation sent you a message about ${appLabel(details)} — ` +
+          `${details.subject}: ${details.body} ` +
+          `(Replies to this notification are not delivered; contact the team at ${MODERATION_REPLY_URL}.)`,
+        url: OWNER_SUBMISSIONS_URL,
+      };
+    },
+  },
+});

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -5,6 +5,7 @@ import { articleUnpublishNotifications } from '~/server/notifications/article-un
 import { appBlockNotifications } from '~/server/notifications/app-block.notifications';
 import { appCollaboratorNotifications } from '~/server/notifications/app-collaborator.notifications';
 import { appListingNotifications } from '~/server/notifications/app-listing.notifications';
+import { appModeratorMessageNotifications } from '~/server/notifications/app-moderator-message.notifications';
 import { auctionNotifications } from '~/server/notifications/auction.notifications';
 import type { BareNotification } from '~/server/notifications/base.notifications';
 import { bountyNotifications } from '~/server/notifications/bounty.notifications';
@@ -50,6 +51,7 @@ export const notificationProcessors = {
   ...appListingNotifications,
   ...appBlockNotifications,
   ...appCollaboratorNotifications,
+  ...appModeratorMessageNotifications,
   ...articleRatingReviewNotifications,
   ...reportNotifications,
   ...featuredNotifications,

--- a/src/server/routers/__tests__/app-listings.router.messageAppOwner.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.messageAppOwner.test.ts
@@ -13,14 +13,34 @@ import type { TRPCError } from '@trpc/server';
  * "It rejected" is satisfied by a proc that sends the message and then throws on the
  * way out; only the un-called mock says the refusal happened BEFORE any write or send.
  *
- * 🔴 WHICH CASES ACTUALLY TEST THE MOD GATE — stated rather than assumed, because
- * getting this wrong is how an authz matrix reads as coverage while providing none.
- * `moderatorProcedure` is `protectedProcedure.use(isMod)`, so an ANONYMOUS caller is
- * refused by `isAuthed` with UNAUTHORIZED before `isMod` is ever reached — and that is
- * equally true if the gate is downgraded to `protectedProcedure`. The anonymous case is
- * therefore STRUCTURALLY incapable of discriminating mod-gated from
- * merely-authenticated: it is an AUTH guard, labelled as one. The TESTER case is the
- * mod guard, and it is the one that dies to the downgrade mutant.
+ * 🔴 WHICH CASES ACTUALLY TEST WHICH GATE — stated rather than assumed, because getting
+ * this wrong is how an authz matrix reads as coverage while providing none. There are
+ * TWO gates on this proc and the difference between them is not cosmetic:
+ *
+ *   1. `moderatorProcedure` = `protectedProcedure.use(isMod)`. `isMod` throws
+ *      **FORBIDDEN** on `!user.isModerator`. This is the gate the TESTER and DEVELOPER
+ *      cases below pin.
+ *   2. the inner `if (!ctx.user?.isModerator) throw throwAuthorizationError(...)`, which
+ *      throws **UNAUTHORIZED**. Every sibling mod action in this router carries the same
+ *      belt.
+ *
+ * 🔴 GATE 2 IS UNREACHABLE TODAY, AND IS LABELLED RATHER THAN COUNTED. It tests the
+ * IDENTICAL predicate to `isMod` (`trpc.ts`: `if (!user.isModerator) throw FORBIDDEN`),
+ * so no context can reach the proc body with a non-moderator — deleting its throw leaves
+ * the whole suite green. It is defence-in-depth against a future downgrade of gate 1,
+ * which is worth keeping, but no BEHAVIOURAL test here proves it does anything. The
+ * "both gates are present" case at the end is a STRUCTURAL guard covering that, and is
+ * described as one.
+ *
+ * ⚠️ A consequence worth naming, because it was mis-stated in review: mutating
+ * `moderatorProcedure` → `protectedProcedure` does NOT grant a user access — gate 2 then
+ * refuses, with UNAUTHORIZED. That mutant dies on the CODE MISMATCH below, not on the
+ * service being reached, and `mockMessageAppOwner` is never called under it either.
+ * Pinning the exact code is what makes the mutant die at all.
+ *
+ * The ANONYMOUS case is a third thing again: `isAuthed` refuses it before `isMod` runs,
+ * and would do so under either gate, so it discriminates nothing about moderator-only.
+ * It is an AUTH guard, labelled as one.
  */
 
 const { mockMessageAppOwner, mockIsAppBlocksEnabled, mockIsAppBlocksAuthorEnabled } = vi.hoisted(
@@ -100,12 +120,16 @@ beforeEach(() => {
 });
 
 describe('authorization — one case per role, and the service never runs on a refusal', () => {
-  it('🔴 MOD GATE: a non-moderator is FORBIDDEN and the service is NOT called', async () => {
+  it('🔴 GATE 1 (moderatorProcedure): a non-moderator is FORBIDDEN, service NOT called', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
-    // FORBIDDEN specifically, not `instanceof TRPCError` — a caller invoking a proc
-    // that does not exist ALSO rejects with a TRPCError (NOT_FOUND, "No procedure found
-    // on path"), so the loose assertion would be green on a branch where
-    // `messageAppOwner` was never added, i.e. it would prove the gate without the gate.
+    // 🔴 FORBIDDEN specifically, for TWO independent reasons:
+    //   (a) a caller invoking a proc that does not exist ALSO rejects with a TRPCError
+    //       (NOT_FOUND, "No procedure found on path"), so a loose `instanceof` would be
+    //       green on a branch where `messageAppOwner` was never added; and
+    //   (b) FORBIDDEN is `isMod`'s code, while the inner recheck's is UNAUTHORIZED — so
+    //       this assertion is what distinguishes gate 1 from gate 2, and the only reason
+    //       a `moderatorProcedure → protectedProcedure` mutant dies at all. A test that
+    //       accepted either code would pass with gate 1 removed.
     await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'FORBIDDEN' });
     expect(mockMessageAppOwner).not.toHaveBeenCalled();
   });
@@ -268,20 +292,70 @@ describe('schema bounds — rejected at the boundary, service NEVER called', () 
   });
 });
 
-describe('the mod-only limiter is not the inert middleware', () => {
-  it('🔴 the proc does NOT rely on the tRPC rateLimit middleware', () => {
-    // `rateLimit` short-circuits for moderators, so wiring it here would cap nothing
-    // while reading as a limit. This asserts the SOURCE, because the behaviour is
-    // unobservable: an inert middleware and no middleware are indistinguishable from
-    // outside, which is precisely what makes the mistake survivable in review.
+describe('source-level guards on the proc', () => {
+  /**
+   * 🔴 THE EXTRACTOR IS THE INSTRUMENT, SO IT IS CONTROLLED BEFORE IT IS READ.
+   *
+   * The first version of these guards sliced to `'\n  }),'` — TWO spaces. The real
+   * terminator is FOUR (`    }),`), so `indexOf` returned -1, `slice(0, -1)` kept
+   * nearly the whole 3k-line router, and every assertion below was answered by some
+   * OTHER procedure's source. Measured: deleting this proc's inner `isModerator`
+   * recheck left the "both gates are present" case GREEN, because a sibling's identical
+   * line was in scope. A guard reading as coverage while providing none.
+   *
+   * It fails loudly now, and `the extractor is BOUNDED` below is the positive control
+   * that keeps it honest — without it, a future terminator change silently restores the
+   * whole-file scan and every assertion here goes vacuous again in exactly the same way.
+   */
+  function procBody(): string {
     const src = readFileSync(
       path.join(process.cwd(), 'src/server/routers/app-listings.router.ts'),
       'utf8'
     );
-    const proc = src.slice(src.indexOf('messageAppOwner: moderatorProcedure'));
-    const body = proc.slice(0, proc.indexOf('\n  }),'));
-    expect(body).toContain('moderatorProcedure');
-    expect(body).not.toContain('.use(rateLimit(');
+    const start = src.indexOf('  messageAppOwner: moderatorProcedure');
+    if (start === -1) throw new Error('messageAppOwner proc not found in the router');
+    const rest = src.slice(start);
+    const end = rest.indexOf('\n    }),');
+    if (end === -1) throw new Error('messageAppOwner proc terminator not found');
+    return rest.slice(0, end);
+  }
+
+  it('🔴 POSITIVE CONTROL: the extractor is BOUNDED to this one procedure', () => {
+    const body = procBody();
+    // Small enough to be one proc, and — the load-bearing half — containing NO
+    // neighbouring procedure. Both siblings named here carry their own
+    // `if (!ctx.user?.isModerator)` recheck, which is precisely what the broken
+    // extractor was reading.
+    expect(body).toContain('messageAppOwner');
+    expect(body.length).toBeLessThan(1200);
+    for (const sibling of ['delistListing:', 'relistListing:', 'claimListing:', 'purgeListing:']) {
+      expect(body, `the slice must not reach ${sibling}`).not.toContain(sibling);
+    }
+  });
+
+  it('🔴 STRUCTURAL: both authorization gates are present on the proc', () => {
+    // Structural, and labelled as such: gate 2 (the inner recheck) is unreachable while
+    // gate 1 stands — see the file header — so no behavioural case can pin it. Deleting
+    // it leaves every behavioural test green, which is exactly why the ledger has to be
+    // written down somewhere. This is that somewhere: removing EITHER gate fails here,
+    // while the tester/developer cases above fail only if gate 1 goes.
+    const body = procBody();
+    expect(body).toContain('messageAppOwner: moderatorProcedure');
+    expect(body).toContain('if (!ctx.user?.isModerator)');
+    expect(body).toContain('throwAuthorizationError');
+  });
+
+  it('🔴 the proc does NOT rely on the tRPC rateLimit middleware', () => {
+    // `rateLimit` short-circuits for moderators, so wiring it here would cap nothing
+    // while reading as a limit. This asserts the SOURCE, because the behaviour is
+    // unobservable: an inert middleware and no middleware are indistinguishable from
+    // outside, which is what makes the mistake survivable in review.
+    //
+    // ⚠️ The pattern is `rateLimit(`, NOT `.use(rateLimit(`. This router never spells
+    // the latter — it writes `.use(\n      rateLimit({` across lines — so the original
+    // `not.toContain('.use(rateLimit(')` was VACUOUSLY TRUE and would have passed with
+    // a rate limit sitting on the proc. Matching the call itself is what can fail.
+    expect(procBody()).not.toContain('rateLimit(');
     // …and the real ceilings exist and are reached from the service.
     const svc = readFileSync(
       path.join(process.cwd(), 'src/server/services/blocks/app-moderator-message.service.ts'),

--- a/src/server/routers/__tests__/app-listings.router.messageAppOwner.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.messageAppOwner.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TRPCError } from '@trpc/server';
+import type { TRPCError } from '@trpc/server';
 
 /**
  * `appListings.messageAppOwner` — the moderator → app-developer message proc.

--- a/src/server/routers/__tests__/app-listings.router.messageAppOwner.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.messageAppOwner.test.ts
@@ -1,0 +1,293 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * `appListings.messageAppOwner` — the moderator → app-developer message proc.
+ *
+ * Drives the REAL `appListingsRouter` via `createCaller`, so the middleware wiring is
+ * what decides rather than a re-statement of it.
+ *
+ * 🔴 EVERY REFUSAL ASSERTS THE SERVICE WAS NOT CALLED, not merely that the call threw.
+ * "It rejected" is satisfied by a proc that sends the message and then throws on the
+ * way out; only the un-called mock says the refusal happened BEFORE any write or send.
+ *
+ * 🔴 WHICH CASES ACTUALLY TEST THE MOD GATE — stated rather than assumed, because
+ * getting this wrong is how an authz matrix reads as coverage while providing none.
+ * `moderatorProcedure` is `protectedProcedure.use(isMod)`, so an ANONYMOUS caller is
+ * refused by `isAuthed` with UNAUTHORIZED before `isMod` is ever reached — and that is
+ * equally true if the gate is downgraded to `protectedProcedure`. The anonymous case is
+ * therefore STRUCTURALLY incapable of discriminating mod-gated from
+ * merely-authenticated: it is an AUTH guard, labelled as one. The TESTER case is the
+ * mod guard, and it is the one that dies to the downgrade mutant.
+ */
+
+const { mockMessageAppOwner, mockIsAppBlocksEnabled, mockIsAppBlocksAuthorEnabled } = vi.hoisted(
+  () => ({
+    mockMessageAppOwner: vi.fn(async () => ({
+      appListingId: 'apl_1',
+      eventId: 'alme_1',
+      recipientCount: 1,
+    })),
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
+  })
+);
+
+vi.mock('~/server/services/blocks/app-moderator-message.service', () => ({
+  messageAppOwner: mockMessageAppOwner,
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+
+function modMessageErr(code: string, message: string): Error {
+  return Object.assign(new Error(message), { name: 'AppModeratorMessageError', code });
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
+const tester = { id: 2, isModerator: false, tier: 'free', username: 'tester', onboarding: 0x1f };
+// An app DEVELOPER is still just a logged-in user here — the load-bearing negative: the
+// person this feature messages must not be able to use it.
+const developer = { id: 3, isModerator: false, tier: 'free', username: 'dev', onboarding: 0x1f };
+
+const INPUT = {
+  appListingId: 'apl_1',
+  subject: 'Your listing describes a spend confirmation that does not exist',
+  body: 'It says it asks before it spends. It has never shown a confirmation to a user.',
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMessageAppOwner.mockResolvedValue({
+    appListingId: 'apl_1',
+    eventId: 'alme_1',
+    recipientCount: 1,
+  });
+  mockIsAppBlocksEnabled.mockImplementation((opts?: { user?: { isModerator?: boolean } }) =>
+    Promise.resolve(!!opts?.user?.isModerator)
+  );
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+});
+
+describe('authorization — one case per role, and the service never runs on a refusal', () => {
+  it('🔴 MOD GATE: a non-moderator is FORBIDDEN and the service is NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+    // FORBIDDEN specifically, not `instanceof TRPCError` — a caller invoking a proc
+    // that does not exist ALSO rejects with a TRPCError (NOT_FOUND, "No procedure found
+    // on path"), so the loose assertion would be green on a branch where
+    // `messageAppOwner` was never added, i.e. it would prove the gate without the gate.
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockMessageAppOwner).not.toHaveBeenCalled();
+  });
+
+  it('🔴 MOD GATE: an app DEVELOPER cannot message anyone, including themselves', async () => {
+    // The population this feature acts ON. A developer with access to it could send a
+    // "Civitai moderation" notification to any app owner — the platform's own framing,
+    // wielded by an untrusted party.
+    const caller = appListingsRouter.createCaller(fakeCtx(developer) as never);
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockMessageAppOwner).not.toHaveBeenCalled();
+  });
+
+  it('AUTH GUARD (not the mod gate): anonymous is UNAUTHORIZED; service NOT called', async () => {
+    // Labelled: this case survives a downgrade of the proc to `protectedProcedure`, so
+    // it is not evidence of moderator-only. Kept because "anon cannot reach this" is
+    // still worth pinning.
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockMessageAppOwner).not.toHaveBeenCalled();
+  });
+
+  it('a moderator passes, and the actor is bound to ctx.user.id (never client-supplied)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.messageAppOwner(INPUT)).resolves.toMatchObject({ recipientCount: 1 });
+    expect(mockMessageAppOwner).toHaveBeenCalledTimes(1);
+    // Field-by-field rather than `input: INPUT`: a middleware in the shared chain
+    // decorates the parsed input (it adds `browsingLevel`), so comparing against the
+    // literal makes this assertion a claim about the middleware chain rather than
+    // about what the proc forwards.
+    expect(mockMessageAppOwner.mock.calls[0][0]).toMatchObject({
+      moderatorUserId: mod.id,
+      input: { appListingId: INPUT.appListingId, subject: INPUT.subject, body: INPUT.body },
+    });
+  });
+
+  it('🔴 a client-supplied moderatorUserId cannot override the ctx-bound one', async () => {
+    // Mass-assignment / impersonation guard: the schema has no such field, so it is
+    // stripped, and the service is handed the session's id regardless.
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.messageAppOwner({ ...INPUT, moderatorUserId: 999 } as never);
+    expect(mockMessageAppOwner.mock.calls[0][0]).toMatchObject({ moderatorUserId: mod.id });
+    expect(
+      (mockMessageAppOwner.mock.calls[0][0] as { input: Record<string, unknown> }).input
+    ).not.toHaveProperty('moderatorUserId');
+  });
+
+  it('there is EXACTLY ONE message endpoint — no protectedProcedure self-serve variant', async () => {
+    const procs = Object.keys(
+      (appListingsRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def
+        .procedures
+    );
+    expect(procs).toContain('messageAppOwner');
+    // Assert by absence: the mod gate is the whole trust boundary here, exactly as it
+    // is for `claimListing`. A sibling that let a user message an owner would be a
+    // user-to-user DM with the platform's moderation framing on it.
+    expect(procs.filter((p) => /message/i.test(p))).toEqual(['messageAppOwner']);
+  });
+});
+
+describe('error mapping', () => {
+  it('🔴 RATE_LIMITED maps to TOO_MANY_REQUESTS, not the BAD_REQUEST default', async () => {
+    // BAD_REQUEST reads as "your input was wrong" and carries no retry semantics, so a
+    // moderator who hit the hourly ceiling would be told to fix a message that is fine.
+    mockMessageAppOwner.mockRejectedValueOnce(
+      modMessageErr('RATE_LIMITED', 'Too many moderator messages — try again in 900s.')
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+      message: expect.stringContaining('900'),
+    });
+  });
+
+  it('NOT_FOUND maps to NOT_FOUND', async () => {
+    mockMessageAppOwner.mockRejectedValueOnce(modMessageErr('NOT_FOUND', 'Listing not found.'));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('BLOCKED_LINK and INVALID_TEXT map to BAD_REQUEST', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    mockMessageAppOwner.mockRejectedValueOnce(
+      modMessageErr('BLOCKED_LINK', 'The message contains a blocked link domain.')
+    );
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    mockMessageAppOwner.mockRejectedValueOnce(modMessageErr('INVALID_TEXT', 'body too short'));
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('an unexpected infra error maps to INTERNAL without leaking the raw message', async () => {
+    const raw = 'connect ECONNREFUSED 10.0.0.5:5432 postgres://secret-dsn';
+    mockMessageAppOwner.mockRejectedValueOnce(new Error(raw));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    const err = await caller.messageAppOwner(INPUT).then(
+      () => {
+        throw new Error('expected a rejection');
+      },
+      (e) => e as TRPCError
+    );
+    expect(err.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(err.message).not.toContain('ECONNREFUSED');
+    expect(err.message).not.toContain('secret-dsn');
+  });
+
+  it('🔴 mapping the NEW error name did not break the two existing ones', async () => {
+    // `mapOffsiteError` is shared. Widening its `name` test is exactly the edit that
+    // silently narrows it — an `===` swapped for the new name alone would send every
+    // delist/claim failure to INTERNAL_SERVER_ERROR.
+    mockMessageAppOwner.mockRejectedValueOnce(
+      Object.assign(new Error('gone'), { name: 'OffsiteModerationError', code: 'NOT_FOUND' })
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    mockMessageAppOwner.mockRejectedValueOnce(
+      Object.assign(new Error('nope'), { name: 'OffsiteRequestError', code: 'NOT_OWNED' })
+    );
+    await expect(caller.messageAppOwner(INPUT)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});
+
+describe('schema bounds — rejected at the boundary, service NEVER called', () => {
+  it.each([
+    ['a missing subject', { subject: undefined }],
+    ['a missing body', { body: undefined }],
+    ['an empty subject', { subject: '' }],
+    ['a 2-character subject', { subject: 'hi' }],
+    ['a body under the floor', { body: 'x'.repeat(MOD_MESSAGE_BODY_MIN - 1) }],
+    ['an over-long subject', { subject: 'x'.repeat(MOD_MESSAGE_SUBJECT_MAX + 1) }],
+    ['an over-long body', { body: 'x'.repeat(MOD_MESSAGE_BODY_MAX + 1) }],
+    ['a missing appListingId', { appListingId: undefined }],
+    ['an empty appListingId', { appListingId: '' }],
+    ['a non-boolean includeCollaborators', { includeCollaborators: 'yes' }],
+  ])('rejects %s with BAD_REQUEST', async (_label, patch) => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    // BAD_REQUEST specifically — a missing proc rejects with NOT_FOUND, so a bare
+    // `instanceof TRPCError` here would be green with no schema at all.
+    await expect(caller.messageAppOwner({ ...INPUT, ...patch } as never)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+    expect(mockMessageAppOwner).not.toHaveBeenCalled();
+  });
+
+  it('accepts the boundary values on both ends', async () => {
+    // The other half of the bounds pin: a schema that rejected everything would pass
+    // every case above.
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.messageAppOwner({
+      ...INPUT,
+      subject: 'x'.repeat(MOD_MESSAGE_SUBJECT_MAX),
+      body: 'x'.repeat(MOD_MESSAGE_BODY_MAX),
+      includeCollaborators: true,
+    });
+    await caller.messageAppOwner({ ...INPUT, body: 'x'.repeat(MOD_MESSAGE_BODY_MIN) });
+    expect(mockMessageAppOwner).toHaveBeenCalledTimes(2);
+    expect(
+      (mockMessageAppOwner.mock.calls[0][0] as { input: { includeCollaborators?: boolean } }).input
+        .includeCollaborators
+    ).toBe(true);
+  });
+});
+
+describe('the mod-only limiter is not the inert middleware', () => {
+  it('🔴 the proc does NOT rely on the tRPC rateLimit middleware', () => {
+    // `rateLimit` short-circuits for moderators, so wiring it here would cap nothing
+    // while reading as a limit. This asserts the SOURCE, because the behaviour is
+    // unobservable: an inert middleware and no middleware are indistinguishable from
+    // outside, which is precisely what makes the mistake survivable in review.
+    const src = readFileSync(
+      path.join(process.cwd(), 'src/server/routers/app-listings.router.ts'),
+      'utf8'
+    );
+    const proc = src.slice(src.indexOf('messageAppOwner: moderatorProcedure'));
+    const body = proc.slice(0, proc.indexOf('\n  }),'));
+    expect(body).toContain('moderatorProcedure');
+    expect(body).not.toContain('.use(rateLimit(');
+    // …and the real ceilings exist and are reached from the service.
+    const svc = readFileSync(
+      path.join(process.cwd(), 'src/server/services/blocks/app-moderator-message.service.ts'),
+      'utf8'
+    );
+    expect(svc).toContain('checkModMessageModeratorQuota');
+    expect(svc).toContain('checkModMessageListingQuota');
+  });
+});

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -436,6 +436,11 @@ describe('claimListing (PR4) is exposed as moderator-only — NO self-service en
       'resolveReport',
       'dismissReport',
       'listModerationEvents',
+      // The message proc shares this boundary exactly — moderatorProcedure + the inner
+      // isModerator recheck, actor bound to ctx.user.id, one AppListingModerationEvent
+      // per call — so it belongs in the same enumeration. Its own matrix, bounds and
+      // error mapping live in `app-listings.router.messageAppOwner.test.ts`.
+      'messageAppOwner',
     ]) {
       expect(procs).toContain(p);
     }

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -240,9 +240,13 @@ describe('mod actions — reviewer id is bound to ctx (never client-supplied)', 
 
 describe('mod actions — error mapping via mapOffsiteError', () => {
   it('a typed NOT_TRANSITIONABLE maps to BAD_REQUEST', async () => {
-    mockDelist.mockRejectedValueOnce(offsiteModErr('NOT_TRANSITIONABLE', 'This listing can no longer be delisted.'));
+    mockDelist.mockRejectedValueOnce(
+      offsiteModErr('NOT_TRANSITIONABLE', 'This listing can no longer be delisted.')
+    );
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
-    await expect(caller.delistListing({ appListingId: 'apl_1', reason: REASON })).rejects.toMatchObject({
+    await expect(
+      caller.delistListing({ appListingId: 'apl_1', reason: REASON })
+    ).rejects.toMatchObject({
       code: 'BAD_REQUEST',
       message: expect.stringContaining('no longer be delisted'),
     });
@@ -251,13 +255,17 @@ describe('mod actions — error mapping via mapOffsiteError', () => {
   it('a typed NOT_FOUND maps to NOT_FOUND', async () => {
     mockRelist.mockRejectedValueOnce(offsiteModErr('NOT_FOUND', 'Standalone listing not found.'));
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
-    await expect(caller.relistListing({ appListingId: 'apl_x', reason: REASON })).rejects.toMatchObject({
+    await expect(
+      caller.relistListing({ appListingId: 'apl_x', reason: REASON })
+    ).rejects.toMatchObject({
       code: 'NOT_FOUND',
     });
   });
 
   it('a typed REPORT_NOT_PENDING maps to BAD_REQUEST', async () => {
-    mockResolve.mockRejectedValueOnce(offsiteModErr('REPORT_NOT_PENDING', 'This report has already been handled.'));
+    mockResolve.mockRejectedValueOnce(
+      offsiteModErr('REPORT_NOT_PENDING', 'This report has already been handled.')
+    );
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
     await expect(caller.resolveReport({ reportId: 'alrp_1' })).rejects.toMatchObject({
       code: 'BAD_REQUEST',

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -361,11 +361,11 @@ function mapOffsiteError(err: unknown): TRPCError {
         : code === 'ALREADY_REPORTED'
         ? 'CONFLICT'
         : // 🔴 An exhausted quota must NOT fall through to the BAD_REQUEST default.
-          // BAD_REQUEST reads to a caller as "your input was wrong" and carries no
-          // retry semantics, so a mod who hit the hourly ceiling would be told to fix
-          // a message that is fine. TOO_MANY_REQUESTS is the honest code and is what
-          // the sibling mod-only limiter (`blocks.retriggerBuild`) already returns.
-          code === 'RATE_LIMITED'
+        // BAD_REQUEST reads to a caller as "your input was wrong" and carries no
+        // retry semantics, so a mod who hit the hourly ceiling would be told to fix
+        // a message that is fine. TOO_MANY_REQUESTS is the honest code and is what
+        // the sibling mod-only limiter (`blocks.retriggerBuild`) already returns.
+        code === 'RATE_LIMITED'
         ? 'TOO_MANY_REQUESTS'
         : 'BAD_REQUEST';
     return new TRPCError({ code: trpcCode, message: err.message, cause: err });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -58,6 +58,7 @@ import {
   resolveReportSchema,
   unpublishOwnListingSchema,
 } from '~/server/schema/blocks/offsite-moderation.schema';
+import { messageAppOwnerSchema } from '~/server/schema/blocks/app-moderator-message.schema';
 import { rateLimit } from '~/server/middleware.trpc';
 import {
   recordStoreScopeApplied,
@@ -340,7 +341,15 @@ function mapOffsiteError(err: unknown): TRPCError {
   if (err instanceof TRPCError) return err;
   if (
     err instanceof Error &&
-    (err.name === 'OffsiteRequestError' || err.name === 'OffsiteModerationError') &&
+    (err.name === 'OffsiteRequestError' ||
+      err.name === 'OffsiteModerationError' ||
+      // Moderator → developer messaging. Duck-typed like its two siblings so the
+      // service stays out of this router's STATIC import graph, and mapped HERE
+      // rather than in a second mapper — a private `mapModMessageError` would be a
+      // fourth spelling of the same code→TRPCError table, and the shapes that drift
+      // between such copies are exactly the ones nobody re-reads (an unmapped code
+      // silently becomes BAD_REQUEST).
+      err.name === 'AppModeratorMessageError') &&
     typeof (err as { code?: unknown }).code === 'string'
   ) {
     const code = (err as { code?: unknown }).code as string;
@@ -351,6 +360,13 @@ function mapOffsiteError(err: unknown): TRPCError {
         ? 'FORBIDDEN'
         : code === 'ALREADY_REPORTED'
         ? 'CONFLICT'
+        : // 🔴 An exhausted quota must NOT fall through to the BAD_REQUEST default.
+          // BAD_REQUEST reads to a caller as "your input was wrong" and carries no
+          // retry semantics, so a mod who hit the hourly ceiling would be told to fix
+          // a message that is fine. TOO_MANY_REQUESTS is the honest code and is what
+          // the sibling mod-only limiter (`blocks.retriggerBuild`) already returns.
+          code === 'RATE_LIMITED'
+        ? 'TOO_MANY_REQUESTS'
         : 'BAD_REQUEST';
     return new TRPCError({ code: trpcCode, message: err.message, cause: err });
   }
@@ -1285,6 +1301,45 @@ export const appListingsRouter = router({
       throw mapOffsiteError(err);
     }
   }),
+
+  /**
+   * MOD send the app's OWNER a free-text message, delivered as a notification.
+   *
+   * The only mod action here that changes no listing state — it exists because the
+   * eleven app notification types are all event-triggered with fixed copy, so a
+   * moderator who needed to tell a developer something the platform has no event for
+   * had no in-product route at all (see `app-moderator-message.service.ts`).
+   *
+   * Same boundary as its neighbours: `moderatorProcedure` + the inner `isModerator`
+   * recheck, `moderatorUserId` bound to `ctx.user.id` (never client-supplied), one
+   * `AppListingModerationEvent` per send, and `mapOffsiteError` for typed failures
+   * (NOT_FOUND→NOT_FOUND, RATE_LIMITED→TOO_MANY_REQUESTS, BLOCKED_LINK/INVALID_TEXT→
+   * BAD_REQUEST, infra→INTERNAL with no leak).
+   *
+   * 🔴 NO `rateLimit()` MIDDLEWARE HERE ON PURPOSE — it short-circuits for moderators
+   * and would cap nothing while looking like a limit. The real ceilings are the two
+   * Redis windows spent inside the service
+   * (`~/server/utils/app-moderator-message-rate-limit`).
+   *
+   * DUAL-KIND: works for an on-site or an off-site listing, and accepts a shadow
+   * revision id (resolved to its parent), because the owner resolver handles all three
+   * and a moderator should not have to know which they pasted.
+   */
+  messageAppOwner: moderatorProcedure
+    .input(messageAppOwnerSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Messaging app owners is restricted to civitai team');
+      }
+      const { messageAppOwner } = await import(
+        '~/server/services/blocks/app-moderator-message.service'
+      );
+      try {
+        return await messageAppOwner({ input, moderatorUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
 
   /** MOD relist a removed off-site listing (removed → approved). Reversibility. */
   relistListing: moderatorProcedure.input(relistListingSchema).mutation(async ({ ctx, input }) => {

--- a/src/server/schema/blocks/app-moderator-message.schema.ts
+++ b/src/server/schema/blocks/app-moderator-message.schema.ts
@@ -1,0 +1,53 @@
+import * as z from 'zod';
+
+/**
+ * App Store Listings — MOD "message this app's owner" input.
+ *
+ * A moderator-initiated, free-text message that lands in the app owner's
+ * notifications. The listing is named by id (`apl_<ULID>`; a shadow revision id is
+ * accepted and resolved to its parent by the service), the recipient is DERIVED — the
+ * caller never supplies a userId, so this surface cannot be turned into a
+ * "notify arbitrary user" primitive by changing one field.
+ */
+
+/**
+ * Bounds. A notification renders as ONE message string in a drawer, so the ceiling is
+ * set by what is readable there rather than by what Postgres can hold.
+ *
+ * The floors are the point, not the ceilings: a 1-character subject or body is a
+ * misfire (a stray Enter in a modal), and it would still reach the developer as a
+ * "Civitai moderation sent you a message" push. `OFFSITE_MOD_REASON_MIN` (3) is the
+ * house precedent for "a mod must actually have typed something"; the BODY floor is
+ * deliberately higher, because a 3-character body cannot carry the "here is what to
+ * fix" this channel exists to deliver.
+ */
+export const MOD_MESSAGE_SUBJECT_MIN = 3;
+export const MOD_MESSAGE_SUBJECT_MAX = 200;
+export const MOD_MESSAGE_BODY_MIN = 20;
+export const MOD_MESSAGE_BODY_MAX = 2000;
+
+export const messageAppOwnerSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  subject: z.string().min(MOD_MESSAGE_SUBJECT_MIN).max(MOD_MESSAGE_SUBJECT_MAX),
+  body: z.string().min(MOD_MESSAGE_BODY_MIN).max(MOD_MESSAGE_BODY_MAX),
+  /**
+   * Also deliver to the listing's ACCEPTED collaborators.
+   *
+   * 🔴 DEFAULTS TO FALSE, deliberately. The OWNER is the accountable party — they are
+   * who the platform holds responsible for the listing, and who a takedown lands on.
+   * An accepted collaborator consented to EDIT an app, not to receive moderation
+   * correspondence about it, and a moderator's message can be adverse ("this claim is
+   * false"), so fanning it out by default would broadcast a private accusation to
+   * third parties the owner invited.
+   *
+   * It is offered at all because the failure mode in the other direction is real: on
+   * an app whose owner is unresponsive, the accepted editors are the only people who
+   * can actually fix the listing. That is a judgement call per message, which is
+   * exactly what an explicit opt-in is for.
+   *
+   * `displayed` is NOT consulted — it is a PUBLIC-CREDIT preference, not a capability,
+   * and an editor who declined a byline can still edit the listing.
+   */
+  includeCollaborators: z.boolean().optional(),
+});
+export type MessageAppOwnerInput = z.infer<typeof messageAppOwnerSchema>;

--- a/src/server/schema/blocks/offsite-moderation.schema.ts
+++ b/src/server/schema/blocks/offsite-moderation.schema.ts
@@ -77,9 +77,10 @@ export type ListListingReportsInput = z.infer<typeof listListingReportsSchema>;
  * `20260706120100_w13_p3b_app_listing_moderation_events`; the last three
  * (`reset-to-pending`/`owner-unpublish`/`owner-republish`) are added by the W13
  * post-approval-mgmt widen `20260713120000_w13_post_approval_mod_actions` (a strict
- * superset — additive DROP+ADD CHECK). A drift here would let a proc write an
- * `action` the DB rejects (23514). The action-agreement unit test pins this tuple
- * against the LATEST action-CHECK migration's IN-list.
+ * superset — additive DROP+ADD CHECK), and `message-owner` by
+ * `20260824120000_app_listing_mod_action_message_owner`. A drift here would let a proc
+ * write an `action` the DB rejects (23514). The action-agreement unit test pins this
+ * tuple against the LATEST action-CHECK migration's IN-list.
  *
  * NOTE the hyphen form (`report-resolve`/`report-dismiss`/`reset-to-pending`/
  * `owner-unpublish`/`owner-republish`) — it matches the shipped/widened migration
@@ -96,6 +97,12 @@ export const APP_LISTING_MODERATION_ACTIONS = [
   'reset-to-pending',
   'owner-unpublish',
   'owner-republish',
+  // Moderator → app-developer messaging. The ONE action here that changes NO state:
+  // it records that a moderator sent the app's owner a free-text message, with the
+  // subject in `reason` and the body in `detail`. It is in this taxonomy rather than a
+  // table of its own because it is a moderator action against a listing, attributable
+  // to an actor and reviewable in the same history — which is all a message needs.
+  'message-owner',
 ] as const;
 export type AppListingModerationAction = (typeof APP_LISTING_MODERATION_ACTIONS)[number];
 

--- a/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.call-site-ledger.test.ts
@@ -194,6 +194,20 @@ const GATE_LEDGER: Record<string, string> = {
     'recipient and for a moderator-claimed owner, on an app they can plainly edit. ' +
     'Refuses FORBIDDEN rather than returning [], because an empty list reads to the UI ' +
     'as "this app has no history", which is a lie a stranger should not be told either.',
+  'src/server/services/blocks/app-moderator-message.service.ts':
+    'NOT a caller-identity gate — the caller is a MODERATOR and the mod boundary is the ' +
+    'router (`moderatorProcedure` + the inner isModerator recheck), exactly as on ' +
+    'delist/relist/claim/purge. It calls resolveListingAccess to answer a different ' +
+    'question: WHO IS THE RECIPIENT. That is why it passes `userId: null` — it wants ' +
+    '`ownerUserId`, not a role, and null takes the early return so no seat lookup is ' +
+    'paid. 🔴 It is in this ledger for the reason the mapper and the backfill are: the ' +
+    'ownership-READ sites must stay enumerated. Reading the denormalized ' +
+    'AppListing.userId here would be worse than a missed delivery — on a drifted onsite ' +
+    'row it would send a moderator’s private message ABOUT someone’s app TO a user who ' +
+    'no longer owns it, while the real owner is never told their listing has a problem. ' +
+    'Collaborators are NOT included by default (an editor consented to edit, not to ' +
+    'receive moderation correspondence); `includeCollaborators` opts in per message and ' +
+    'reads the ACCEPTED set via listAcceptedCollaboratorUserIds, ignoring `displayed`.',
   'src/pages/api/v1/blocks/dev-token.ts':
     'NOT widened, deliberately. This is a THIRD gate shape the ledger surfaced: a ' +
     'positive-match BRANCH CONDITION (`block.app.userId === user.id`) rather than a ' +

--- a/src/server/services/blocks/__tests__/app-moderator-message-notify.test.ts
+++ b/src/server/services/blocks/__tests__/app-moderator-message-notify.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const { mockCreateNotification } = vi.hoisted(() => ({
-  mockCreateNotification: vi.fn(async (..._a: unknown[]) => undefined),
+  mockCreateNotification: vi.fn(async () => undefined),
 }));
 
 vi.mock('~/server/services/notification.service', () => ({

--- a/src/server/services/blocks/__tests__/app-moderator-message-notify.test.ts
+++ b/src/server/services/blocks/__tests__/app-moderator-message-notify.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `notifyAppModeratorMessage` — forwards to `createNotification` with the right shape
+ * via its dynamic import. Only the notifications client is mocked; the helper's static
+ * import is a type (erased), so nothing else is pulled. `~/server/common/enums` is the
+ * REAL module, so the asserted `NotificationCategory.System` is an actual value and not
+ * a string this file made up.
+ */
+
+const { mockCreateNotification } = vi.hoisted(() => ({
+  mockCreateNotification: vi.fn(async (..._a: unknown[]) => undefined),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+const { notifyAppModeratorMessage } = await import(
+  '~/server/services/blocks/app-moderator-message-notify'
+);
+
+const DETAILS = {
+  slug: 'prompt-vault',
+  listingId: 'apl_live',
+  subject: 'A false claim in your listing',
+  body: 'It says it asks before it spends. It does not.',
+};
+
+beforeEach(() => {
+  mockCreateNotification.mockReset().mockResolvedValue(undefined);
+});
+
+describe('notifyAppModeratorMessage', () => {
+  it('forwards ONE System notification carrying every recipient, the key and the details', async () => {
+    await notifyAppModeratorMessage({
+      userIds: [42, 77],
+      key: 'app-moderator-message:alme_1',
+      details: DETAILS,
+    });
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    const arg = mockCreateNotification.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      userIds: [42, 77],
+      category: 'System',
+      type: 'app-moderator-message',
+      key: 'app-moderator-message:alme_1',
+      details: DETAILS,
+    });
+  });
+
+  it('🔴 uses `userIds`, not a per-recipient call', async () => {
+    // `PendingNotification.key` is UNIQUE and a repeat emit MERGES recipients into the
+    // existing row, so N calls sharing one key produce one notification with N users
+    // anyway — but only after N round trips, and a partial failure would deliver to the
+    // owner and not the editors. One call is the substrate's own fan-out.
+    await notifyAppModeratorMessage({
+      userIds: [42, 77, 13],
+      key: 'app-moderator-message:alme_2',
+      details: DETAILS,
+    });
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification.mock.calls[0][0]).not.toHaveProperty('userId');
+  });
+
+  it('🔴 an EMPTY recipient list emits NOTHING', async () => {
+    // A zero-recipient emit would create a PendingNotification nobody can receive AND
+    // burn the key, so a genuine later delivery under the same key would be merged into
+    // the dead row instead of being sent — i.e. it fails silently and permanently.
+    await notifyAppModeratorMessage({
+      userIds: [],
+      key: 'app-moderator-message:alme_3',
+      details: DETAILS,
+    });
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
 
 import { dbMock } from '~/__tests__/mocks/db.mock';
 
@@ -253,6 +254,46 @@ describe('collaborators are opt-in, and the set is de-duplicated', () => {
     expect(where).not.toHaveProperty('displayed');
   });
 
+  it('🔴 the collaborator read is keyed on the PARENT listing, not the id that was passed', async () => {
+    // The quota key's parent-ness was pinned from the start and this was not, so a
+    // mutant swapping `seatListingId` for `appListingId` HERE survived. Under it, a
+    // moderator who pasted a shadow revision id delivers to the owner alone — a shadow
+    // holds no seats — while the audit row's `includeCollaborators: true` says the
+    // editors were looped in. Silent under-delivery with a record that disagrees.
+    dbMock.dbRead.appListing.findUnique.mockResolvedValue({
+      id: SHADOW,
+      userId: STALE_NAME,
+      slug: 'rev-01hx',
+      kind: 'onsite',
+      appBlockId: null,
+      revisionOfId: LIVE,
+      appBlock: null,
+      revisionOf: {
+        id: LIVE,
+        slug: 'prompt-vault',
+        userId: STALE_NAME,
+        kind: 'onsite',
+        appBlockId: 'ab_1',
+        appBlock: { app: { userId: REAL_OWNER } },
+      },
+    });
+    dbMock.dbRead.appCollaborator.findMany.mockResolvedValue([{ userId: EDITOR }]);
+
+    const result = await messageAppOwner({
+      input: input({ appListingId: SHADOW, includeCollaborators: true }),
+      moderatorUserId: MOD,
+    });
+
+    expect(dbMock.dbRead.appCollaborator.findMany.mock.calls[0][0]).toMatchObject({
+      where: { appListingId: LIVE },
+    });
+    expect((mockNotify.mock.calls[0][0] as { userIds: number[] }).userIds).toEqual([
+      REAL_OWNER,
+      EDITOR,
+    ]);
+    expect(result.recipientCount).toBe(2);
+  });
+
   it('an owner who also holds a seat is notified ONCE', async () => {
     dbMock.dbRead.appCollaborator.findMany.mockResolvedValue([
       { userId: REAL_OWNER },
@@ -306,6 +347,19 @@ describe('nothing is delivered that was not first recorded', () => {
     });
     // No state changed, so there is deliberately no `before`.
     expect((data as Record<string, unknown>).before).toBeUndefined();
+  });
+
+  it('🔴 `after.includeCollaborators` records FALSE on the default path', async () => {
+    // The true case alone left a hardcoded-`true` mutant alive, which is the one
+    // misreport that matters: `after` exists precisely so a later reviewer can tell
+    // whether a private accusation was broadcast to third parties, and a field that is
+    // always `true` answers that question wrongly on the DEFAULT path — the common one.
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    const data = dbMock.dbWrite.appListingModerationEvent.create.mock.calls[0][0].data as {
+      after: { includeCollaborators: boolean; recipientUserIds: number[] };
+    };
+    expect(data.after.includeCollaborators).toBe(false);
+    expect(data.after.recipientUserIds).toEqual([REAL_OWNER]);
   });
 
   it('the notification key is the audit event id, so a retry delivers once', async () => {
@@ -365,18 +419,44 @@ describe('rate limiting — BOTH windows, and a refusal writes and sends nothing
     expect(mockNotify).not.toHaveBeenCalled();
   });
 
-  it('when BOTH are exhausted the LONGER retry-after is reported', async () => {
+  it('🔴 an ALREADY-CAPPED moderator does NOT spend the LISTING budget', async () => {
+    // The harm this pins: the listing window is the harassment ceiling, 5/h across ALL
+    // moderators. If a refused send still INCR'd it, one already-capped moderator
+    // retrying five times would exhaust that app's ceiling and lock out every OTHER
+    // moderator for the rest of the hour, over messages that were never sent.
+    //
+    // Same ordering principle as the BLOCKED_LINK case below, applied to the other
+    // rejection path — that one was asserted from the start and this one was not, which
+    // is exactly how the two halves drifted apart.
+    mockActorQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 120 });
+    await expect(messageAppOwner({ input: input(), moderatorUserId: MOD })).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+    });
+    expect(mockActorQuota).toHaveBeenCalledTimes(1);
+    expect(mockListingQuota).not.toHaveBeenCalled();
+  });
+
+  it('an actor-capped refusal reports the ACTOR window retry-after', async () => {
     mockActorQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 120 });
     mockListingQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 3400 });
     await expect(messageAppOwner({ input: input(), moderatorUserId: MOD })).rejects.toMatchObject({
-      message: expect.stringContaining('3400'),
+      // 120, not 3400: the listing window is never consulted, so the number the mod is
+      // told is the one that actually governs their next attempt.
+      message: expect.stringContaining('120'),
     });
   });
 });
 
 describe('text validation runs BEFORE the quota is spent', () => {
   it('a blocked link domain refuses with BLOCKED_LINK; no write, no send', async () => {
-    mockBlockedLink.mockRejectedValue(new Error('invalid urls: evil.example'));
+    // 🔴 A REAL `TRPCError`/BAD_REQUEST, which is what `throwOnBlockedLinkDomain`
+    // actually throws (via `throwBadRequestError`) — not a bare `Error`. The bare-Error
+    // fixture this replaces was indistinguishable from an infra failure, so it was
+    // green against a catch that could not tell the two apart. See the ECONNREFUSED
+    // case above: the pair is what makes either one mean anything.
+    mockBlockedLink.mockRejectedValue(
+      new TRPCError({ code: 'BAD_REQUEST', message: 'invalid urls: evil.example' })
+    );
     const err = await messageAppOwner({ input: input(), moderatorUserId: MOD }).then(
       () => {
         throw new Error('expected a refusal');
@@ -391,6 +471,31 @@ describe('text validation runs BEFORE the quota is spent', () => {
     // silently spend the ceiling that protects the developer from being spammed.
     expect(mockListingQuota).not.toHaveBeenCalled();
     expect(mockActorQuota).not.toHaveBeenCalled();
+  });
+
+  it('🔴 an INFRA failure in the link scan is NOT relabelled as a blocked link', async () => {
+    // `throwOnBlockedLinkDomain` reaches `getBlocklistDTO`, whose first statement is an
+    // unguarded `await redis.get(...)`. A bare catch here would turn a Redis outage into
+    // "The message contains a blocked link domain." about a message with no link — and
+    // because BLOCKED_LINK maps to BAD_REQUEST it would never reach the INTERNAL branch
+    // that feeds the server-fault logger, so the outage would be invisible from here.
+    //
+    // 🔴 The fixture is a bare `Error`, which is what a Redis failure actually looks
+    // like at the catch site. The pre-fix test used `new Error('invalid urls: …')` for
+    // the BLOCKED case — indistinguishable from ECONNREFUSED to a bare catch, which is
+    // precisely why the suite could not see this defect.
+    mockBlockedLink.mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.5:6379'));
+    const err = await messageAppOwner({ input: input(), moderatorUserId: MOD }).then(
+      () => {
+        throw new Error('expected a rejection');
+      },
+      (e) => e as Error & { code?: string }
+    );
+    expect(err.code).not.toBe('BLOCKED_LINK');
+    expect(err).not.toBeInstanceOf(AppModeratorMessageError);
+    expect(err.message).toContain('ECONNREFUSED');
+    expect(dbMock.dbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it('the link scan covers the SUBJECT as well as the body', async () => {

--- a/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
@@ -34,10 +34,13 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
  */
 
 const { mockActorQuota, mockListingQuota, mockBlockedLink, mockNotify } = vi.hoisted(() => ({
-  mockActorQuota: vi.fn(async (_id: number) => ({ allowed: true } as unknown)),
-  mockListingQuota: vi.fn(async (_id: string) => ({ allowed: true } as unknown)),
-  mockBlockedLink: vi.fn(async (_v: string) => undefined),
-  mockNotify: vi.fn(async (_o: unknown) => undefined),
+  // No declared parameters: `vi.fn` records the arguments it is CALLED with regardless,
+  // so `toHaveBeenCalledWith(...)` below is unaffected — and a named-but-unused
+  // parameter is what `@typescript-eslint/no-unused-vars` flags.
+  mockActorQuota: vi.fn(async () => ({ allowed: true } as unknown)),
+  mockListingQuota: vi.fn(async () => ({ allowed: true } as unknown)),
+  mockBlockedLink: vi.fn(async () => undefined),
+  mockNotify: vi.fn(async () => undefined),
 }));
 
 vi.mock('~/server/utils/app-moderator-message-rate-limit', () => ({

--- a/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
@@ -1,0 +1,475 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `messageAppOwner` — the moderator → app-developer message path.
+ *
+ * 🔴 WHAT THIS FILE IS ACTUALLY GUARDING, in priority order:
+ *
+ *   1. THE RECIPIENT IS THE CANONICAL OWNER, never `AppListing.userId`. On an on-site
+ *      listing that column is a denormalized copy and is stale-able, so reading it
+ *      would send a moderator's private message about an app to a user who no longer
+ *      owns it while the real owner hears nothing. The drifted-row fixture below is
+ *      the only fixture that can see this: one where the column and the block AGREE
+ *      is green against both the correct and the broken resolution.
+ *   2. NOTHING IS DELIVERED THAT IS NOT FIRST RECORDED. Every refusal path asserts
+ *      the audit write AND the send did not happen — not merely that it threw — and
+ *      the happy path asserts the write's invocation ORDER precedes the send's.
+ *   3. BOTH rate-limit windows are spent. A short-circuit that skipped the per-listing
+ *      counter whenever the per-moderator one allowed would leave the harassment
+ *      ceiling unenforced in the normal case, and would pass a test that only checked
+ *      "a limit exists".
+ *
+ * 🔴 `dbRead` AND `dbWrite` ARE DISTINCT (the canonical `dbMock`), and that is
+ * load-bearing here rather than hygiene: this service READS the listing off the
+ * replica and WRITES the audit row on the primary. Aliasing them would make "the audit
+ * row went to the replica" structurally undetectable, which is the exact defect class
+ * this file family has been bitten by twice. Asserted explicitly at the end.
+ *
+ * The rate limiter is mocked at its module boundary so quota outcomes are declarable;
+ * the limiter's own Redis mechanics have their own file
+ * (`app-moderator-message-rate-limit.test.ts`). `resolveListingAccess` is NOT mocked —
+ * it is the thing under test on the ownership axis, and mocking it would delete case 1.
+ */
+
+const { mockActorQuota, mockListingQuota, mockBlockedLink, mockNotify } = vi.hoisted(() => ({
+  mockActorQuota: vi.fn(async (_id: number) => ({ allowed: true }) as unknown),
+  mockListingQuota: vi.fn(async (_id: string) => ({ allowed: true }) as unknown),
+  mockBlockedLink: vi.fn(async (_v: string) => undefined),
+  mockNotify: vi.fn(async (_o: unknown) => undefined),
+}));
+
+vi.mock('~/server/utils/app-moderator-message-rate-limit', () => ({
+  checkModMessageModeratorQuota: mockActorQuota,
+  checkModMessageListingQuota: mockListingQuota,
+}));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: mockBlockedLink,
+}));
+vi.mock('~/server/services/blocks/app-moderator-message-notify', () => ({
+  notifyAppModeratorMessage: mockNotify,
+}));
+vi.mock('~/server/utils/app-block-ids', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  newAppListingModerationEventId: () => 'alme_fixed',
+}));
+
+const { messageAppOwner, AppModeratorMessageError } = await import(
+  '~/server/services/blocks/app-moderator-message.service'
+);
+
+// 🔴 PAIRWISE-DISTINCT, and distinct from every constant the assertions name. Two roles
+// sharing a number is how a fixture "proves" a gate that reads the wrong field.
+const REAL_OWNER = 42; // OauthClient.userId, reached as appBlock.app.userId
+const STALE_NAME = 99; // what the drifted AppListing.userId column still says
+const EDITOR = 77; // holds an ACCEPTED seat on the parent
+const MOD = 8; // the acting moderator
+
+const LIVE = 'apl_live';
+const SHADOW = 'apl_shadow';
+
+const SUBJECT = 'Your listing describes a spend confirmation that does not exist';
+const BODY =
+  'The store listing says the app "estimates the cost and asks before it spends". ' +
+  'It has never shown a confirmation. Please correct the copy or ship the prompt.';
+
+/**
+ * A drifted ON-SITE parent: the column says {@link STALE_NAME}, the OauthClient says
+ * {@link REAL_OWNER}. Fields are a superset of `resolveListingAccess`'s select, so one
+ * row answers the whole resolution.
+ */
+function onsiteRow(over: Record<string, unknown> = {}) {
+  return {
+    id: LIVE,
+    userId: STALE_NAME,
+    slug: 'prompt-vault',
+    kind: 'onsite',
+    appBlockId: 'ab_1',
+    revisionOfId: null,
+    appBlock: { app: { userId: REAL_OWNER } },
+    revisionOf: null,
+    ...over,
+  };
+}
+
+function input(over: Record<string, unknown> = {}) {
+  return { appListingId: LIVE, subject: SUBJECT, body: BODY, ...over };
+}
+
+beforeEach(() => {
+  // Per-FILE reset for the shared hybrid mocks, so declare per-test here.
+  dbMock.dbRead.appListing.findUnique.mockReset().mockResolvedValue(onsiteRow());
+  dbMock.dbRead.appCollaborator.findMany.mockReset().mockResolvedValue([]);
+  dbMock.dbWrite.appListingModerationEvent.create
+    .mockReset()
+    .mockImplementation(async (a: { data: unknown }) => a.data);
+  mockActorQuota.mockReset().mockResolvedValue({ allowed: true });
+  mockListingQuota.mockReset().mockResolvedValue({ allowed: true });
+  mockBlockedLink.mockReset().mockResolvedValue(undefined);
+  mockNotify.mockReset().mockResolvedValue(undefined);
+});
+
+describe('the recipient is the CANONICAL owner, not the denormalized column', () => {
+  it('🔴 a DRIFTED on-site listing notifies the BLOCK owner and NOT the stale column', async () => {
+    const result = await messageAppOwner({ input: input(), moderatorUserId: MOD });
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    const sent = mockNotify.mock.calls[0][0] as { userIds: number[] };
+    // BOTH directions on one fixture. Asserting only the inclusion leaves a
+    // "notify everyone" mutant alive; asserting only the exclusion leaves "notify
+    // nobody" alive — and this service's whole job is delivering to exactly one user.
+    expect(sent.userIds).toEqual([REAL_OWNER]);
+    expect(sent.userIds).not.toContain(STALE_NAME);
+    expect(result.recipientCount).toBe(1);
+  });
+
+  it('🔴 the AUDIT row records the canonical owner as the recipient too', async () => {
+    // The audit row is the only durable record of who was told. If it disagreed with
+    // what was sent, a later review would exonerate or implicate the wrong account.
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    const data = dbMock.dbWrite.appListingModerationEvent.create.mock.calls[0][0].data as {
+      after: { recipientUserIds: number[] };
+    };
+    expect(data.after.recipientUserIds).toEqual([REAL_OWNER]);
+  });
+
+  it('an OFF-SITE listing that HAS a block notifies the COLUMN owner (issue #3844)', async () => {
+    // The control that keeps the fix from over-reaching: "always use the block owner"
+    // would be a NEW bug on this shape, which `mapAppBlockToListing` really mints.
+    dbMock.dbRead.appListing.findUnique.mockResolvedValue(
+      onsiteRow({ kind: 'offsite', slug: 'df-qwen-canvas' })
+    );
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    const sent = mockNotify.mock.calls[0][0] as { userIds: number[] };
+    expect(sent.userIds).toEqual([STALE_NAME]);
+    expect(sent.userIds).not.toContain(REAL_OWNER);
+  });
+
+  it('an UNKNOWN kind falls through to the column (fail-closed, matching the resolver)', async () => {
+    dbMock.dbRead.appListing.findUnique.mockResolvedValue(onsiteRow({ kind: 'somethingelse' }));
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    expect((mockNotify.mock.calls[0][0] as { userIds: number[] }).userIds).toEqual([STALE_NAME]);
+  });
+
+  it('a SHADOW revision id resolves to the PARENT: owner, slug, quota key and audit row', async () => {
+    // A moderator should not have to know which id they pasted. Every downstream key
+    // must be the parent's, or a shadow gets its own quota allowance and an audit row
+    // that the listing's history read cannot join.
+    dbMock.dbRead.appListing.findUnique.mockResolvedValue({
+      id: SHADOW,
+      userId: STALE_NAME,
+      slug: 'rev-01hx',
+      kind: 'onsite',
+      appBlockId: null,
+      revisionOfId: LIVE,
+      appBlock: null,
+      revisionOf: {
+        id: LIVE,
+        slug: 'prompt-vault',
+        userId: STALE_NAME,
+        kind: 'onsite',
+        appBlockId: 'ab_1',
+        appBlock: { app: { userId: REAL_OWNER } },
+      },
+    });
+
+    const result = await messageAppOwner({
+      input: input({ appListingId: SHADOW }),
+      moderatorUserId: MOD,
+    });
+
+    expect(result.appListingId).toBe(LIVE);
+    expect(mockListingQuota).toHaveBeenCalledWith(LIVE);
+    const sent = mockNotify.mock.calls[0][0] as {
+      userIds: number[];
+      details: { slug: string; listingId: string };
+    };
+    expect(sent.userIds).toEqual([REAL_OWNER]);
+    // The PARENT's public slug — a shadow's own is the synthetic `rev-…`, which names
+    // no app the developer would recognise.
+    expect(sent.details.slug).toBe('prompt-vault');
+    expect(sent.details.listingId).toBe(LIVE);
+    const data = dbMock.dbWrite.appListingModerationEvent.create.mock.calls[0][0].data as {
+      appListingId: string;
+      slug: string;
+    };
+    expect(data.appListingId).toBe(LIVE);
+    expect(data.slug).toBe('prompt-vault');
+  });
+
+  it('resolves the owner in ONE read and never asks for a role', async () => {
+    // `userId: null` takes the resolver's early return, so the seat lookup is not paid.
+    // A future edit passing `moderatorUserId` here would silently add a query per send
+    // and compute a role nobody reads.
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    expect(dbMock.dbRead.appListing.findUnique).toHaveBeenCalledTimes(1);
+    expect(dbMock.dbRead.appCollaborator.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('collaborators are opt-in, and the set is de-duplicated', () => {
+  it('by DEFAULT an accepted collaborator is NOT notified', async () => {
+    dbMock.dbRead.appCollaborator.findMany.mockResolvedValue([{ userId: EDITOR }]);
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    const sent = mockNotify.mock.calls[0][0] as { userIds: number[] };
+    expect(sent.userIds).toEqual([REAL_OWNER]);
+    expect(sent.userIds).not.toContain(EDITOR);
+    // …and the seat read is not even issued, so the default costs nothing.
+    expect(dbMock.dbRead.appCollaborator.findMany).not.toHaveBeenCalled();
+  });
+
+  it('includeCollaborators:true adds the ACCEPTED seats, keyed on the PARENT listing', async () => {
+    dbMock.dbRead.appCollaborator.findMany.mockResolvedValue([{ userId: EDITOR }]);
+    const result = await messageAppOwner({
+      input: input({ includeCollaborators: true }),
+      moderatorUserId: MOD,
+    });
+    const sent = mockNotify.mock.calls[0][0] as { userIds: number[] };
+    expect(sent.userIds).toEqual([REAL_OWNER, EDITOR]);
+    expect(result.recipientCount).toBe(2);
+    expect(dbMock.dbRead.appCollaborator.findMany.mock.calls[0][0]).toMatchObject({
+      where: { appListingId: LIVE, status: 'accepted' },
+    });
+  });
+
+  it('the ACCEPTED filter is not widened, and `displayed` is not consulted', async () => {
+    // `status: accepted` is CONSENT — a pending invitee is a stranger who happens to
+    // have been named, and must not receive moderation correspondence. `displayed` is
+    // a public-credit preference, so filtering on it would silently drop an editor who
+    // declined a byline but can still fix the listing.
+    await messageAppOwner({
+      input: input({ includeCollaborators: true }),
+      moderatorUserId: MOD,
+    });
+    const where = dbMock.dbRead.appCollaborator.findMany.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >;
+    expect(where.status).toBe('accepted');
+    expect(where).not.toHaveProperty('displayed');
+  });
+
+  it('an owner who also holds a seat is notified ONCE', async () => {
+    dbMock.dbRead.appCollaborator.findMany.mockResolvedValue([
+      { userId: REAL_OWNER },
+      { userId: EDITOR },
+    ]);
+    const result = await messageAppOwner({
+      input: input({ includeCollaborators: true }),
+      moderatorUserId: MOD,
+    });
+    expect((mockNotify.mock.calls[0][0] as { userIds: number[] }).userIds).toEqual([
+      REAL_OWNER,
+      EDITOR,
+    ]);
+    expect(result.recipientCount).toBe(2);
+  });
+});
+
+describe('nothing is delivered that was not first recorded', () => {
+  it('the audit write is invoked BEFORE the send', async () => {
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    const writeOrder =
+      dbMock.dbWrite.appListingModerationEvent.create.mock.invocationCallOrder[0];
+    const sendOrder = mockNotify.mock.invocationCallOrder[0];
+    expect(writeOrder).toBeLessThan(sendOrder);
+  });
+
+  it('a failed audit write means NO send at all', async () => {
+    dbMock.dbWrite.appListingModerationEvent.create.mockRejectedValue(
+      new Error('23514 check constraint')
+    );
+    await expect(messageAppOwner({ input: input(), moderatorUserId: MOD })).rejects.toThrow();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('the audit row carries the action, the actor, the subject, the body and the fan-out', async () => {
+    await messageAppOwner({
+      input: input({ includeCollaborators: true }),
+      moderatorUserId: MOD,
+    });
+    const data = dbMock.dbWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      id: 'alme_fixed',
+      appListingId: LIVE,
+      slug: 'prompt-vault',
+      action: 'message-owner',
+      actorUserId: MOD,
+      // The SUBJECT in `reason` and the BODY in `detail`: a history that recorded only
+      // that a message was sent could not be reviewed for what was said.
+      reason: SUBJECT,
+      detail: BODY,
+      after: { recipientUserIds: [REAL_OWNER], includeCollaborators: true },
+    });
+    // No state changed, so there is deliberately no `before`.
+    expect((data as Record<string, unknown>).before).toBeUndefined();
+  });
+
+  it('the notification key is the audit event id, so a retry delivers once', async () => {
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    expect((mockNotify.mock.calls[0][0] as { key: string }).key).toBe(
+      'app-moderator-message:alme_fixed'
+    );
+  });
+
+  it('the moderator is recorded in the audit row and ABSENT from what the recipient gets', async () => {
+    // Attribution belongs in the log, not on the wire — naming the individual to the
+    // developer is the retaliation vector the rest of the moderation surface declines
+    // to open.
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    const details = (mockNotify.mock.calls[0][0] as { details: Record<string, unknown> }).details;
+    expect(Object.values(details)).not.toContain(MOD);
+    expect(JSON.stringify(details)).not.toContain(String(MOD));
+  });
+});
+
+describe('rate limiting — BOTH windows, and a refusal writes and sends nothing', () => {
+  it('🔴 BOTH counters are spent even when the moderator counter allows', async () => {
+    // The mutation this exists for: `if (!actor.allowed) throw; …` with the listing
+    // check behind an `else` leaves the harassment ceiling unenforced for every mod
+    // under their own cap, i.e. the normal case.
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    expect(mockActorQuota).toHaveBeenCalledWith(MOD);
+    expect(mockListingQuota).toHaveBeenCalledWith(LIVE);
+  });
+
+  it('an exhausted MODERATOR window refuses with RATE_LIMITED; no write, no send', async () => {
+    mockActorQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 1800 });
+    const err = await messageAppOwner({ input: input(), moderatorUserId: MOD }).then(
+      () => {
+        throw new Error('expected a refusal');
+      },
+      (e) => e as InstanceType<typeof AppModeratorMessageError>
+    );
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.message).toContain('1800');
+    expect(dbMock.dbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('an exhausted LISTING window refuses even when the moderator has budget left', async () => {
+    mockActorQuota.mockResolvedValue({ allowed: true });
+    mockListingQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 900 });
+    const err = await messageAppOwner({ input: input(), moderatorUserId: MOD }).then(
+      () => {
+        throw new Error('expected a refusal');
+      },
+      (e) => e as InstanceType<typeof AppModeratorMessageError>
+    );
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.message).toContain('900');
+    expect(dbMock.dbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('when BOTH are exhausted the LONGER retry-after is reported', async () => {
+    mockActorQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 120 });
+    mockListingQuota.mockResolvedValue({ allowed: false, retryAfterSeconds: 3400 });
+    await expect(messageAppOwner({ input: input(), moderatorUserId: MOD })).rejects.toMatchObject({
+      message: expect.stringContaining('3400'),
+    });
+  });
+});
+
+describe('text validation runs BEFORE the quota is spent', () => {
+  it('a blocked link domain refuses with BLOCKED_LINK; no write, no send', async () => {
+    mockBlockedLink.mockRejectedValue(new Error('invalid urls: evil.example'));
+    const err = await messageAppOwner({ input: input(), moderatorUserId: MOD }).then(
+      () => {
+        throw new Error('expected a refusal');
+      },
+      (e) => e as InstanceType<typeof AppModeratorMessageError>
+    );
+    expect(err.code).toBe('BLOCKED_LINK');
+    expect(dbMock.dbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+    // 🔴 The ordering claim, asserted rather than described: a rejected draft must not
+    // consume the RECIPIENT's hourly allowance, or a moderator fixing a typo would
+    // silently spend the ceiling that protects the developer from being spammed.
+    expect(mockListingQuota).not.toHaveBeenCalled();
+    expect(mockActorQuota).not.toHaveBeenCalled();
+  });
+
+  it('the link scan covers the SUBJECT as well as the body', async () => {
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    expect(mockBlockedLink).toHaveBeenCalledTimes(1);
+    const scanned = mockBlockedLink.mock.calls[0][0] as string;
+    expect(scanned).toContain(SUBJECT);
+    expect(scanned).toContain(BODY);
+  });
+
+  it('a whitespace-only body is refused as INVALID_TEXT despite satisfying the schema min', async () => {
+    // ' '.repeat(30) passes `z.string().min(20)` and would arrive as an empty message
+    // under a "Civitai moderation sent you a message" push.
+    const err = await messageAppOwner({
+      input: input({ body: ' '.repeat(30) }),
+      moderatorUserId: MOD,
+    }).then(
+      () => {
+        throw new Error('expected a refusal');
+      },
+      (e) => e as InstanceType<typeof AppModeratorMessageError>
+    );
+    expect(err.code).toBe('INVALID_TEXT');
+    expect(dbMock.dbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('a whitespace-only subject is refused the same way', async () => {
+    await expect(
+      messageAppOwner({ input: input({ subject: '   ' }), moderatorUserId: MOD })
+    ).rejects.toMatchObject({ code: 'INVALID_TEXT' });
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('an over-long body is refused even if a caller skipped the schema', async () => {
+    await expect(
+      messageAppOwner({ input: input({ body: 'x'.repeat(2001) }), moderatorUserId: MOD })
+    ).rejects.toMatchObject({ code: 'INVALID_TEXT' });
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('the delivered text is TRIMMED, in the notification and in the audit row alike', async () => {
+    await messageAppOwner({
+      input: input({ subject: `  ${SUBJECT}  `, body: `\n${BODY}\n` }),
+      moderatorUserId: MOD,
+    });
+    const details = (mockNotify.mock.calls[0][0] as { details: { subject: string; body: string } })
+      .details;
+    expect(details.subject).toBe(SUBJECT);
+    expect(details.body).toBe(BODY);
+    const data = dbMock.dbWrite.appListingModerationEvent.create.mock.calls[0][0].data as {
+      reason: string;
+      detail: string;
+    };
+    expect(data.reason).toBe(SUBJECT);
+    expect(data.detail).toBe(BODY);
+  });
+});
+
+describe('a missing listing', () => {
+  it('refuses with NOT_FOUND before any quota, write or send', async () => {
+    dbMock.dbRead.appListing.findUnique.mockResolvedValue(null);
+    const err = await messageAppOwner({ input: input(), moderatorUserId: MOD }).then(
+      () => {
+        throw new Error('expected a refusal');
+      },
+      (e) => e as InstanceType<typeof AppModeratorMessageError>
+    );
+    expect(err.code).toBe('NOT_FOUND');
+    expect(mockActorQuota).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe('the read pool and the write pool are not interchangeable', () => {
+  it('the listing is READ on the replica and the audit row WRITTEN on the primary', async () => {
+    await messageAppOwner({ input: input(), moderatorUserId: MOD });
+    expect(dbMock.dbRead.appListing.findUnique).toHaveBeenCalledTimes(1);
+    expect(dbMock.dbWrite.appListing.findUnique).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(dbMock.dbRead.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-moderator-message.service.test.ts
@@ -34,8 +34,8 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
  */
 
 const { mockActorQuota, mockListingQuota, mockBlockedLink, mockNotify } = vi.hoisted(() => ({
-  mockActorQuota: vi.fn(async (_id: number) => ({ allowed: true }) as unknown),
-  mockListingQuota: vi.fn(async (_id: string) => ({ allowed: true }) as unknown),
+  mockActorQuota: vi.fn(async (_id: number) => ({ allowed: true } as unknown)),
+  mockListingQuota: vi.fn(async (_id: string) => ({ allowed: true } as unknown)),
   mockBlockedLink: vi.fn(async (_v: string) => undefined),
   mockNotify: vi.fn(async (_o: unknown) => undefined),
 }));
@@ -270,8 +270,7 @@ describe('collaborators are opt-in, and the set is de-duplicated', () => {
 describe('nothing is delivered that was not first recorded', () => {
   it('the audit write is invoked BEFORE the send', async () => {
     await messageAppOwner({ input: input(), moderatorUserId: MOD });
-    const writeOrder =
-      dbMock.dbWrite.appListingModerationEvent.create.mock.invocationCallOrder[0];
+    const writeOrder = dbMock.dbWrite.appListingModerationEvent.create.mock.invocationCallOrder[0];
     const sendOrder = mockNotify.mock.invocationCallOrder[0];
     expect(writeOrder).toBeLessThan(sendOrder);
   });

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -1423,7 +1423,30 @@ export async function listAppInsiderUserIds(appBlockId: string): Promise<number[
   const ids = new Set<number>([block.app.userId]);
   const appListingId = block.appListing?.id;
   if (!appListingId) return [...ids];
-  const seats = await safeCollaboratorQuery(
+  for (const userId of await listAcceptedCollaboratorUserIds(appListingId)) ids.add(userId);
+  return [...ids];
+}
+
+/**
+ * Every ACCEPTED collaborator on `appListingId`, REGARDLESS of `displayed` — i.e. the
+ * people who can actually EDIT this listing, minus the owner.
+ *
+ * 🔴 THE ONE SPELLING OF `{ status: ACCEPTED }`-without-`displayed`, extracted because
+ * it now has two callers and the pair must not drift. {@link listAppInsiderUserIds}
+ * (the self-review gate) and the moderator-message fan-out ask the SAME question —
+ * "who, other than the owner, is on the inside of this app" — and an answer that
+ * diverged between them would mean an editor who cannot 5-star the app they co-author
+ * silently stops receiving the moderation notice telling them what to fix, or the
+ * reverse. The predicate that must never be added here is `displayed`, for the reason
+ * {@link listDisplayedCollaboratorUserIds}'s header gives: it is PUBLIC-CREDIT
+ * preference, not capability.
+ *
+ * 🔴 `appListingId` MUST be a PARENT listing id — a shadow revision holds no seats
+ * (nothing may create one), so a shadow id returns an empty set rather than an error.
+ * Callers reach the parent via `resolveListingAccess`'s `seatListingId`.
+ */
+export async function listAcceptedCollaboratorUserIds(appListingId: string): Promise<number[]> {
+  const rows = await safeCollaboratorQuery(
     () =>
       dbRead.appCollaborator.findMany({
         where: { appListingId, status: ACCEPTED },
@@ -1431,6 +1454,5 @@ export async function listAppInsiderUserIds(appBlockId: string): Promise<number[
       }),
     [] as { userId: number }[]
   );
-  for (const s of seats) ids.add(s.userId);
-  return [...ids];
+  return rows.map((r: { userId: number }) => r.userId);
 }

--- a/src/server/services/blocks/app-moderator-message-notify.ts
+++ b/src/server/services/blocks/app-moderator-message-notify.ts
@@ -1,0 +1,48 @@
+import type { AppModeratorMessageNotificationDetails } from '~/server/notifications/app-moderator-message.notifications';
+
+/**
+ * App Store Listings — moderator-message emit helper.
+ *
+ * The fourth member of the family (`app-block-notify`, `app-listing-notify`,
+ * `app-collaborator-notify`) and built to the same discipline: the ONLY static import
+ * is a TYPE (erased at compile), and `createNotification` + `NotificationCategory` are
+ * imported DYNAMICALLY inside the async body — so importing this helper adds ZERO
+ * runtime graph to a caller, and the service's unit tests never pull the notifications
+ * client. A test that asserts emission mocks THIS module; a test that asserts the
+ * swallow mocks `~/server/services/notification.service`.
+ *
+ * 🔴 MULTI-RECIPIENT IN ONE CALL, and that is the substrate's design rather than an
+ * optimisation. `PendingNotification.key` is UNIQUE and a repeat emit with the same key
+ * MERGES the new recipients into the existing row (`apps/notifications`'s
+ * `create.ts`). So N separate calls sharing one key produce one notification with N
+ * users anyway — passing `userIds` just says so up front and pays one round trip. It
+ * also means a partial failure cannot deliver to the owner but not the editors.
+ *
+ * `createNotification` is itself best-effort (it swallows client errors + logs), and
+ * this is emitted AFTER the audit event commits, so a notifications outage costs the
+ * delivery, never the record that the moderator sent it.
+ */
+
+export async function notifyAppModeratorMessage(opts: {
+  /** Every recipient of this one message. Must be non-empty. */
+  userIds: number[];
+  /** Idempotency key — dedups repeat emissions of the same event. */
+  key: string;
+  details: AppModeratorMessageNotificationDetails;
+}): Promise<void> {
+  // A zero-recipient emit would create a PendingNotification nobody can ever receive
+  // and would burn the key, so a genuine later delivery under the same key would be
+  // merged into the dead row instead of being sent. Refuse it at the boundary.
+  if (opts.userIds.length === 0) return;
+  const [{ createNotification }, { NotificationCategory }] = await Promise.all([
+    import('~/server/services/notification.service'),
+    import('~/server/common/enums'),
+  ]);
+  await createNotification({
+    userIds: opts.userIds,
+    category: NotificationCategory.System,
+    type: 'app-moderator-message',
+    key: opts.key,
+    details: opts.details,
+  });
+}

--- a/src/server/services/blocks/app-moderator-message.service.ts
+++ b/src/server/services/blocks/app-moderator-message.service.ts
@@ -1,3 +1,5 @@
+import { TRPCError } from '@trpc/server';
+
 import { dbWrite } from '~/server/db/client';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
 import {
@@ -50,9 +52,20 @@ import { newAppListingModerationEventId } from '~/server/utils/app-block-ids';
  *
  * The write precedes the delivery so that a notifications outage costs the delivery
  * and never the record that a moderator sent a message — the inverse would let a mod
- * message a developer with nothing in the audit log. The text validation precedes the
- * rate-limit spend so a rejected draft does not consume the recipient's harassment
- * budget (a mod fixing a typo would otherwise burn the listing's hourly allowance).
+ * message a developer with nothing in the audit log.
+ *
+ * 🔴 ONE ORDERING PRINCIPLE, APPLIED IN THREE PLACES: a send that will not happen must
+ * never consume the RECIPIENT's budget. So the text validation precedes the quota spend
+ * (a mod fixing a typo would otherwise burn the listing's hourly allowance), and the
+ * ACTOR window is spent and checked before the LISTING window is touched at all. Step 3
+ * is therefore two steps, not one — see the note at the call site.
+ *
+ * ⚠️ SCOPE OF "nothing is delivered that is not first recorded": it is a property of
+ * THIS procedure, not of the `app-moderator-message` notification type. The
+ * webhook-token-gated `src/pages/api/mod/send-mod-notification.ts` can emit any type —
+ * this one included — with arbitrary `userIds` and text, no audit row and no rate limit.
+ * That is not moderator-reachable and is equally true of the eleven existing app types,
+ * but the claim above is about the proc.
  *
  * ## Authorization
  *
@@ -99,14 +112,24 @@ export type MessageAppOwnerResult = {
  * rendered in other users' browsers. Three of its five checks are actively wrong for
  * this surface:
  *
- *   - `includesMinor` / `includesPoi` HARD-FAIL the text. A moderator writing "your
- *     cover image appears to depict a minor — take it down" is exactly the message
- *     this channel exists to carry, and that belt refuses to send it. The control
- *     would block its own most important use.
- *   - `auditPromptServer(isGreen: true)` forces the SFW + profanity ceiling on
- *     correspondence between staff and a developer, and its abuse principal is the
- *     SENDER — so a moderator quoting an app's own offending content would accrue
- *     blocked-prompt strikes against their account for doing their job.
+ *   - `includesMinor` / `includesPoi` HARD-FAIL the text, with NO moderator bypass —
+ *     they run before the `isModerator` flag reaches anything. A moderator writing
+ *     "your cover image appears to depict a minor — take it down" is exactly the
+ *     message this channel exists to carry, and that belt refuses to send it. The
+ *     control would block its own most important use. This leg alone is sufficient.
+ *   - `auditPromptServer({ isGreen: true })` forces the SFW + profanity ceiling on
+ *     correspondence between staff and a developer, and on a hit appends
+ *     `GREEN_SFW_REDIRECT` — "please visit civitai.red where you have more freedom to
+ *     generate mature content" — which is nonsense copy to show a moderator writing to
+ *     a developer about their app.
+ *     ⚠️ CORRECTED: an earlier version of this comment claimed the audit accrues
+ *     blocked-prompt strikes against the SENDER. It does NOT. With `isGreen: true` the
+ *     handler takes the `else if (isGreen)` branch (`promptAuditing.ts`), which calls
+ *     neither `addBlockedPrompt` nor `reportProhibitedRequest` — no strike, no
+ *     ClickHouse row, no auto-mute; and `assertSharedTextSafe` threads `isModerator`
+ *     through anyway. The real cost is the hard-failed send and the wrong copy above,
+ *     which is narrower than what this comment used to assert. Left visible rather than
+ *     silently rewritten, because the overstated version was quoted in review.
  *
  * It would also be inconsistent rather than protective: EVERY existing moderator
  * free-text field that renders verbatim into a user-visible notification —
@@ -139,11 +162,38 @@ async function validateMessageText(subject: string, body: string): Promise<void>
   try {
     await throwOnBlockedLinkDomain(`${subject}\n${body}`);
   } catch (err) {
-    throw new AppModeratorMessageError(
-      'BLOCKED_LINK',
-      'The message contains a blocked link domain.',
-      { cause: err }
-    );
+    // 🔴 NARROW ON PURPOSE — a bare `catch` here is a live defect, not a style nit.
+    //
+    // `throwOnBlockedLinkDomain` reaches `getBlocklistDTO`, whose FIRST statement is an
+    // unguarded `await redis.get(...)`. So a Redis outage throws from inside this call,
+    // and a bare catch converts it into "The message contains a blocked link domain."
+    // about a message that contains no link — leaving the moderator to edit text that
+    // is fine, with no way to tell. Worse, `BLOCKED_LINK` maps to BAD_REQUEST, which
+    // never reaches the INTERNAL branch that feeds the server-fault logger, so the
+    // outage would be INVISIBLE from this path.
+    //
+    // 🔴 It would also invert this feature's own stated fail-direction: the rate limiter
+    // deliberately fails OPEN so a Redis incident cannot block moderation
+    // correspondence (see `app-moderator-message-rate-limit.ts`). A fail-CLOSED Redis
+    // dependency in front of the same send contradicts that.
+    //
+    // `throwOnBlockedLinkDomain` signals a REAL block with `throwBadRequestError`, i.e.
+    // a `TRPCError` with code BAD_REQUEST. Anything else — a Redis error, a JSON parse
+    // failure on a corrupt cache entry, a DB error in `readBlocklistRow` — is infra and
+    // is RETHROWN, so the router maps it to INTERNAL_SERVER_ERROR (no raw leak) and it
+    // is logged as the fault it is.
+    //
+    // ⚠️ `assertSharedTextSafe` has the byte-identical wart (its `catch {}` around the
+    // same call re-labels everything as `'link'`). This is a copied house pattern rather
+    // than a novel defect here; fixing it there is a separate change.
+    if (err instanceof TRPCError && err.code === 'BAD_REQUEST') {
+      throw new AppModeratorMessageError(
+        'BLOCKED_LINK',
+        'The message contains a blocked link domain.',
+        { cause: err }
+      );
+    }
+    throw err;
   }
 }
 
@@ -191,20 +241,34 @@ export async function messageAppOwner(opts: {
   // empty message. Runs BEFORE the quota spend — see the ordering note in the header.
   await validateMessageText(subject, body);
 
-  // 🔴 BOTH windows, and the ORDER between them does not matter for correctness but the
-  // fact that BOTH are spent does: a short-circuit that skipped the listing counter
-  // whenever the moderator counter allowed would leave the harassment ceiling
-  // unenforced for any mod under their own cap, which is the normal case.
+  // 🔴 THE ACTOR WINDOW IS SPENT AND CHECKED FIRST, AND THE LISTING WINDOW IS NOT
+  // TOUCHED WHEN THE ACTOR IS ALREADY CAPPED. Spending both unconditionally is a live
+  // defect, and it is the SAME ordering principle the text validation above obeys: a
+  // send that will not happen must not consume the RECIPIENT's budget.
+  //
+  // The concrete harm, because it is not obvious: the listing window is the harassment
+  // ceiling, 5/h across ALL moderators. A moderator who has exhausted their own 30/h
+  // window and keeps retrying would INCR the per-listing key on every attempt — five
+  // retries by one already-capped mod would exhaust that app's ceiling and LOCK OUT
+  // every other moderator for the rest of the hour, over messages that were never sent.
+  //
+  // 🔴 The short-circuit runs in ONE direction only. Skipping the listing spend when the
+  // actor is REFUSED is free (nothing is delivered, so nothing should count against the
+  // recipient). Skipping it when the actor is ALLOWED would be the opposite mistake and
+  // would leave the ceiling unenforced for every mod under their own cap — i.e. the
+  // normal case. `app-moderator-message.service.test.ts` pins both directions.
   const actorQuota = await checkModMessageModeratorQuota(moderatorUserId);
-  const listingQuota = await checkModMessageListingQuota(appListingId);
-  if (!actorQuota.allowed || !listingQuota.allowed) {
-    const retryAfterSeconds = Math.max(
-      actorQuota.allowed ? 0 : actorQuota.retryAfterSeconds,
-      listingQuota.allowed ? 0 : listingQuota.retryAfterSeconds
-    );
+  if (!actorQuota.allowed) {
     throw new AppModeratorMessageError(
       'RATE_LIMITED',
-      `Too many moderator messages — try again in ${retryAfterSeconds}s.`
+      `Too many moderator messages — try again in ${actorQuota.retryAfterSeconds}s.`
+    );
+  }
+  const listingQuota = await checkModMessageListingQuota(appListingId);
+  if (!listingQuota.allowed) {
+    throw new AppModeratorMessageError(
+      'RATE_LIMITED',
+      `Too many moderator messages — try again in ${listingQuota.retryAfterSeconds}s.`
     );
   }
 

--- a/src/server/services/blocks/app-moderator-message.service.ts
+++ b/src/server/services/blocks/app-moderator-message.service.ts
@@ -1,0 +1,258 @@
+import { dbWrite } from '~/server/db/client';
+import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import {
+  listAcceptedCollaboratorUserIds,
+  resolveListingAccess,
+} from '~/server/services/blocks/app-access.service';
+import { notifyAppModeratorMessage } from '~/server/services/blocks/app-moderator-message-notify';
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+  MOD_MESSAGE_SUBJECT_MIN,
+  type MessageAppOwnerInput,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+import {
+  checkModMessageListingQuota,
+  checkModMessageModeratorQuota,
+} from '~/server/utils/app-moderator-message-rate-limit';
+import { newAppListingModerationEventId } from '~/server/utils/app-block-ids';
+
+/**
+ * MODERATOR → APP-DEVELOPER MESSAGING.
+ *
+ * ## The gap this closes
+ *
+ * The platform already notifies app owners eleven ways (`app-block-*`,
+ * `app-listing-*`, `app-collaborator-*`, `app-ownership-transfer-*`). Every one is
+ * EVENT-TRIGGERED with copy the platform wrote — four of them splice in a moderator's
+ * `reason`, but the moderator never chooses the SUBJECT. So a moderator who needs to
+ * say something the platform has no event for — "your listing says it estimates the
+ * cost and asks before it spends; it has never done that" — has had two options: push
+ * a change to someone else's app, or find the developer off-platform. This is the
+ * third: a mod-only, free-text, one-way message that lands in the existing
+ * notification substrate as a twelfth type.
+ *
+ * ## What it deliberately is NOT
+ *
+ * Not an inbox, not a thread, no reply route, no read receipts, no message table. The
+ * notification IS the delivery, and the rendered copy says replies are not delivered
+ * (see `app-moderator-message.notifications.ts`). Everything durable about the send
+ * lives in the audit event, which is a table that already exists.
+ *
+ * ## Ordering, and why it is the order it is
+ *
+ * 1. RESOLVE the listing + its CANONICAL owner (read).
+ * 2. VALIDATE the text (bounds re-check + blocked-link scan).
+ * 3. SPEND the rate-limit budget.
+ * 4. WRITE the audit event.
+ * 5. DELIVER, best-effort, post-write.
+ *
+ * The write precedes the delivery so that a notifications outage costs the delivery
+ * and never the record that a moderator sent a message — the inverse would let a mod
+ * message a developer with nothing in the audit log. The text validation precedes the
+ * rate-limit spend so a rejected draft does not consume the recipient's harassment
+ * budget (a mod fixing a typo would otherwise burn the listing's hourly allowance).
+ *
+ * ## Authorization
+ *
+ * Enforced at the router (`moderatorProcedure` + the inner `isModerator` recheck —
+ * the house idiom for every mod action in `app-listings.router.ts`). This service does
+ * NOT re-derive it: `moderatorUserId` is bound from `ctx.user.id` and is never
+ * client-supplied, exactly as `reviewerUserId` is on delist/relist/claim/purge. The
+ * negative-per-role matrix is pinned in
+ * `app-listings.router.mod-actions-authz.test.ts` and asserts the service is NOT
+ * called, not merely that the call threw.
+ */
+
+/** Typed failure modes. Duck-typed by the router's `mapOffsiteError` via `name`. */
+export type AppModeratorMessageErrorCode =
+  //   NOT_FOUND    — no such listing → NOT_FOUND.
+  //   BLOCKED_LINK — the text carries a blocked link domain → BAD_REQUEST.
+  //   INVALID_TEXT — bounds re-check failed below the schema → BAD_REQUEST.
+  //   RATE_LIMITED — a fixed window is exhausted → TOO_MANY_REQUESTS.
+  'NOT_FOUND' | 'BLOCKED_LINK' | 'INVALID_TEXT' | 'RATE_LIMITED';
+
+export class AppModeratorMessageError extends Error {
+  readonly code: AppModeratorMessageErrorCode;
+  constructor(code: AppModeratorMessageErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AppModeratorMessageError';
+    this.code = code;
+  }
+}
+
+export type MessageAppOwnerResult = {
+  /** The PARENT listing the message was recorded against. */
+  appListingId: string;
+  /** The audit event id (`alme_<ULID>`) — also the notification's idempotency key. */
+  eventId: string;
+  /** How many users the message was delivered to. */
+  recipientCount: number;
+};
+
+/**
+ * 🔴 CONTENT SAFETY: `assertSharedTextSafe` IS DELIBERATELY NOT APPLIED HERE, and the
+ * reasoning is worth reading before "fixing" this.
+ *
+ * That belt exists for App Blocks SHARED storage — untrusted, cross-user, PUBLIC text
+ * rendered in other users' browsers. Three of its five checks are actively wrong for
+ * this surface:
+ *
+ *   - `includesMinor` / `includesPoi` HARD-FAIL the text. A moderator writing "your
+ *     cover image appears to depict a minor — take it down" is exactly the message
+ *     this channel exists to carry, and that belt refuses to send it. The control
+ *     would block its own most important use.
+ *   - `auditPromptServer(isGreen: true)` forces the SFW + profanity ceiling on
+ *     correspondence between staff and a developer, and its abuse principal is the
+ *     SENDER — so a moderator quoting an app's own offending content would accrue
+ *     blocked-prompt strikes against their account for doing their job.
+ *
+ * It would also be inconsistent rather than protective: EVERY existing moderator
+ * free-text field that renders verbatim into a user-visible notification —
+ * `delistListing.reason` → `app-listing-hidden`, `rejectRequest.reason` →
+ * `app-block-rejected`, `tos-violation.reason` — runs no content safety at all. A belt
+ * on this one path and none on those four is a spelled control, not a real one.
+ *
+ * 🔴 WHAT DOES APPLY, and is kept: the LINK check. Moderator status establishes that
+ * the sender is trusted staff; it does not survive a COMPROMISED mod session, and the
+ * one thing such a session can do through this channel that mod-status does not
+ * mitigate is put a hostile URL in front of a developer, carrying the platform's own
+ * "Civitai moderation sent you a message" framing. `throwOnBlockedLinkDomain` is the
+ * platform's existing answer to that and costs one cached Redis read. Plus the bounds
+ * below, re-asserted independent of the zod schema so a future second caller cannot
+ * skip the ceiling.
+ */
+async function validateMessageText(subject: string, body: string): Promise<void> {
+  if (subject.length < MOD_MESSAGE_SUBJECT_MIN || subject.length > MOD_MESSAGE_SUBJECT_MAX) {
+    throw new AppModeratorMessageError(
+      'INVALID_TEXT',
+      `subject must be between ${MOD_MESSAGE_SUBJECT_MIN} and ${MOD_MESSAGE_SUBJECT_MAX} characters`
+    );
+  }
+  if (body.length < MOD_MESSAGE_BODY_MIN || body.length > MOD_MESSAGE_BODY_MAX) {
+    throw new AppModeratorMessageError(
+      'INVALID_TEXT',
+      `body must be between ${MOD_MESSAGE_BODY_MIN} and ${MOD_MESSAGE_BODY_MAX} characters`
+    );
+  }
+  try {
+    await throwOnBlockedLinkDomain(`${subject}\n${body}`);
+  } catch (err) {
+    throw new AppModeratorMessageError(
+      'BLOCKED_LINK',
+      'The message contains a blocked link domain.',
+      { cause: err }
+    );
+  }
+}
+
+/**
+ * Send one moderator-authored message to an app's owner (and, on request, its accepted
+ * collaborators).
+ *
+ * 🔴 THE RECIPIENT IS THE CANONICAL OWNER, RESOLVED BY `resolveListingAccess` —
+ * NEVER the `AppListing.userId` column. For an ON-SITE listing that column is a
+ * DENORMALIZED COPY of `AppBlock.app.userId` and is stale-able: `beginListingRevision`
+ * freezes it at clone time, and no ownership write revisits the clone. On a drifted
+ * row, reading the copy sends a moderator's private message about someone's app to a
+ * user who no longer owns it — a disclosure, not merely a missed delivery — while the
+ * real owner is never told their listing has a problem. `resolveListingAccess` is the
+ * one place the kind branch is written (onsite → the block's `OauthClient.userId` with
+ * the column as fallback; offsite → the column unconditionally, issue #3844), and it
+ * hops a shadow revision to its parent, which is what makes `seatListingId` and `slug`
+ * below the PARENT's rather than a synthetic `rev-<ulid>`'s.
+ *
+ * 🔴 It is called with `userId: null`. This resolver's second argument asks "what is
+ * THIS caller's role", and the caller here is a MODERATOR who is not a party to the
+ * app. Passing the moderator's id would compute a role nobody reads AND cost the seat
+ * lookup; passing null takes the `typeof userId !== 'number'` early return, so the
+ * owner is resolved in exactly one query.
+ */
+export async function messageAppOwner(opts: {
+  input: MessageAppOwnerInput;
+  /** Bound from `ctx.user.id` at the router. NEVER client-supplied. */
+  moderatorUserId: number;
+}): Promise<MessageAppOwnerResult> {
+  const { input, moderatorUserId } = opts;
+  const subject = input.subject.trim();
+  const body = input.body.trim();
+
+  const access = await resolveListingAccess(input.appListingId, null);
+  if (!access) {
+    throw new AppModeratorMessageError('NOT_FOUND', 'Listing not found.');
+  }
+  // The PARENT listing: what a seat, a quota and an audit row are all keyed on. A mod
+  // who pasted a shadow revision id gets the same behaviour as one who pasted the
+  // listing id, rather than a second quota allowance and an orphaned audit row.
+  const appListingId = access.seatListingId;
+
+  // Trimmed, so a body of 30 spaces cannot satisfy the schema's `min` and arrive as an
+  // empty message. Runs BEFORE the quota spend — see the ordering note in the header.
+  await validateMessageText(subject, body);
+
+  // 🔴 BOTH windows, and the ORDER between them does not matter for correctness but the
+  // fact that BOTH are spent does: a short-circuit that skipped the listing counter
+  // whenever the moderator counter allowed would leave the harassment ceiling
+  // unenforced for any mod under their own cap, which is the normal case.
+  const actorQuota = await checkModMessageModeratorQuota(moderatorUserId);
+  const listingQuota = await checkModMessageListingQuota(appListingId);
+  if (!actorQuota.allowed || !listingQuota.allowed) {
+    const retryAfterSeconds = Math.max(
+      actorQuota.allowed ? 0 : actorQuota.retryAfterSeconds,
+      listingQuota.allowed ? 0 : listingQuota.retryAfterSeconds
+    );
+    throw new AppModeratorMessageError(
+      'RATE_LIMITED',
+      `Too many moderator messages — try again in ${retryAfterSeconds}s.`
+    );
+  }
+
+  const recipients = new Set<number>([access.ownerUserId]);
+  if (input.includeCollaborators) {
+    for (const userId of await listAcceptedCollaboratorUserIds(appListingId)) {
+      recipients.add(userId);
+    }
+  }
+  // A `Set` rather than an array: the owner can also hold a seat row on their own
+  // listing (nothing forbids it), and a duplicated recipient would be a second
+  // notification of the same message.
+  const recipientUserIds = [...recipients];
+
+  // 🔴 THE AUDIT ROW IS WRITTEN BEFORE ANYTHING IS DELIVERED. `reason` carries the
+  // subject and `detail` the body, so the moderation history renders the message a
+  // moderator actually sent rather than the fact that one was sent — which is the only
+  // form in which this channel can be reviewed after the fact. `actorUserId` is the
+  // durable attribution the RECIPIENT is deliberately not given (see the notification
+  // module's header). A single `create`, so no transaction: there is nothing to keep
+  // consistent with it.
+  const eventId = newAppListingModerationEventId();
+  await dbWrite.appListingModerationEvent.create({
+    data: {
+      id: eventId,
+      appListingId,
+      slug: access.slug,
+      action: 'message-owner',
+      actorUserId: moderatorUserId,
+      reason: subject,
+      detail: body,
+      // No state changed, so there is no `before`. `after` records the DELIVERY
+      // decision, which is the part a later reviewer cannot reconstruct: whether the
+      // collaborators were looped in, and who the owner resolved to at send time.
+      after: { recipientUserIds, includeCollaborators: !!input.includeCollaborators },
+    },
+  });
+
+  // Post-write, best-effort. `createNotification` swallows client errors itself, and
+  // the caller wraps this too, so a notifications outage can never fail a send that is
+  // already recorded.
+  await notifyAppModeratorMessage({
+    userIds: recipientUserIds,
+    // Keyed by the audit event id, so a retried request delivers once (mirrors
+    // `app-listing-hidden:${eventId}`) without needing a nonce.
+    key: `app-moderator-message:${eventId}`,
+    details: { slug: access.slug, listingId: appListingId, subject, body },
+  });
+
+  return { appListingId, eventId, recipientCount: recipientUserIds.length };
+}

--- a/src/server/utils/__tests__/app-moderator-message-rate-limit.test.ts
+++ b/src/server/utils/__tests__/app-moderator-message-rate-limit.test.ts
@@ -17,8 +17,13 @@ import { redisMock } from '~/__tests__/mocks/redis.mock';
  * than as a declared return value.
  */
 
-const { checkModMessageModeratorQuota, checkModMessageListingQuota, MOD_MESSAGE_MAX_PER_LISTING, MOD_MESSAGE_MAX_PER_MODERATOR, MOD_MESSAGE_WINDOW_SECONDS } =
-  await import('~/server/utils/app-moderator-message-rate-limit');
+const {
+  checkModMessageModeratorQuota,
+  checkModMessageListingQuota,
+  MOD_MESSAGE_MAX_PER_LISTING,
+  MOD_MESSAGE_MAX_PER_MODERATOR,
+  MOD_MESSAGE_WINDOW_SECONDS,
+} = await import('~/server/utils/app-moderator-message-rate-limit');
 
 beforeEach(() => {
   // Per-FILE reset for the shared hybrid mocks — declare per test.

--- a/src/server/utils/__tests__/app-moderator-message-rate-limit.test.ts
+++ b/src/server/utils/__tests__/app-moderator-message-rate-limit.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+/**
+ * The mod-message abuse controls.
+ *
+ * 🔴 THE REASON THIS FILE EXISTS AT ALL is the trap it defends: the tRPC `rateLimit`
+ * middleware SHORT-CIRCUITS for moderators (`if (ctx.user?.isModerator …) return
+ * next()`), so on a `moderatorProcedure` it caps nothing while looking like a limit in
+ * the router source, in review and in a diff. Every assertion here is therefore about a
+ * limiter that ACTUALLY counts — and the last describe block pins the router-side half:
+ * that no `rateLimit()` was wired onto the proc under the illusion that it works.
+ *
+ * The limiter runs against the canonical `redisMock`. Nothing here mocks the module
+ * under test, so an INCR that never happens is visible as a call count of zero rather
+ * than as a declared return value.
+ */
+
+const { checkModMessageModeratorQuota, checkModMessageListingQuota, MOD_MESSAGE_MAX_PER_LISTING, MOD_MESSAGE_MAX_PER_MODERATOR, MOD_MESSAGE_WINDOW_SECONDS } =
+  await import('~/server/utils/app-moderator-message-rate-limit');
+
+beforeEach(() => {
+  // Per-FILE reset for the shared hybrid mocks — declare per test.
+  redisMock.redis.incrBy.mockReset().mockResolvedValue(1);
+  redisMock.redis.expire.mockReset().mockResolvedValue(true);
+  redisMock.redis.ttl.mockReset().mockResolvedValue(MOD_MESSAGE_WINDOW_SECONDS);
+});
+
+describe('the two windows are SEPARATE keys', () => {
+  it('🔴 a moderator and a listing never share a counter', async () => {
+    // If both helpers wrote one key, the per-listing ceiling would be silently
+    // consumed by the moderator's own sends and vice versa — and the pair would still
+    // "have a rate limit". The two keys must be distinct AND each must name its own
+    // subject, so a second moderator gets a second budget while the recipient does not.
+    await checkModMessageModeratorQuota(8);
+    await checkModMessageListingQuota('apl_live');
+    const keys = redisMock.redis.incrBy.mock.calls.map((c) => c[0] as string);
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).not.toBe(keys[1]);
+    expect(keys[0]).toContain('8');
+    expect(keys[1]).toContain('apl_live');
+  });
+
+  it('different moderators, and different listings, get different keys', async () => {
+    await checkModMessageModeratorQuota(8);
+    await checkModMessageModeratorQuota(9);
+    await checkModMessageListingQuota('apl_a');
+    await checkModMessageListingQuota('apl_b');
+    const keys = redisMock.redis.incrBy.mock.calls.map((c) => c[0] as string);
+    expect(new Set(keys).size).toBe(4);
+  });
+});
+
+describe('the fixed window', () => {
+  it('allows a send at exactly the ceiling and refuses the one after', async () => {
+    // 🔴 The boundary in BOTH directions. `<=` vs `<` is a one-character mutation that
+    // an at-the-limit-only test and an over-the-limit-only test each survive.
+    redisMock.redis.incrBy.mockResolvedValue(MOD_MESSAGE_MAX_PER_MODERATOR);
+    expect(await checkModMessageModeratorQuota(8)).toEqual({ allowed: true });
+
+    redisMock.redis.incrBy.mockResolvedValue(MOD_MESSAGE_MAX_PER_MODERATOR + 1);
+    expect(await checkModMessageModeratorQuota(8)).toMatchObject({ allowed: false });
+  });
+
+  it('the LISTING ceiling is its own number, not the moderator one', async () => {
+    // The two constants differ (5 vs 30), so a limiter that used one number for both
+    // would let a single app receive six times the intended volume. Feeding a count
+    // that is over the listing ceiling and under the moderator ceiling separates them.
+    expect(MOD_MESSAGE_MAX_PER_LISTING).toBeLessThan(MOD_MESSAGE_MAX_PER_MODERATOR);
+    const between = MOD_MESSAGE_MAX_PER_LISTING + 1;
+    expect(between).toBeLessThanOrEqual(MOD_MESSAGE_MAX_PER_MODERATOR);
+    redisMock.redis.incrBy.mockResolvedValue(between);
+    expect(await checkModMessageListingQuota('apl_live')).toMatchObject({ allowed: false });
+    expect(await checkModMessageModeratorQuota(8)).toEqual({ allowed: true });
+  });
+
+  it('arms the TTL on the FIRST send of a window', async () => {
+    redisMock.redis.incrBy.mockResolvedValue(1);
+    await checkModMessageModeratorQuota(8);
+    expect(redisMock.redis.expire).toHaveBeenCalledTimes(1);
+    expect(redisMock.redis.expire.mock.calls[0][1]).toBe(MOD_MESSAGE_WINDOW_SECONDS);
+  });
+
+  it('does NOT extend an active window on a later send', async () => {
+    // Re-arming every send would make the window sliding-forever: a mod sending once a
+    // minute would never have their count reset, and the ceiling would become a
+    // lifetime cap. Note this is the case a "TTL is always set" test gets backwards.
+    redisMock.redis.incrBy.mockResolvedValue(3);
+    redisMock.redis.ttl.mockResolvedValue(1200);
+    await checkModMessageModeratorQuota(8);
+    expect(redisMock.redis.expire).not.toHaveBeenCalled();
+  });
+
+  it('SELF-HEALS a key that lost its TTL', async () => {
+    // An INCR that raced an expiring key leaves a TTL-less counter that would refuse
+    // this moderator forever. -1 means "no TTL" in Redis.
+    redisMock.redis.incrBy.mockResolvedValue(3);
+    redisMock.redis.ttl.mockResolvedValue(-1);
+    await checkModMessageModeratorQuota(8);
+    expect(redisMock.redis.expire).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the live TTL as retry-after', async () => {
+    redisMock.redis.incrBy.mockResolvedValue(MOD_MESSAGE_MAX_PER_LISTING + 1);
+    redisMock.redis.ttl.mockResolvedValue(742);
+    expect(await checkModMessageListingQuota('apl_live')).toEqual({
+      allowed: false,
+      retryAfterSeconds: 742,
+    });
+  });
+
+  it('falls back to the full window when the TTL read is unusable', async () => {
+    redisMock.redis.incrBy.mockResolvedValue(MOD_MESSAGE_MAX_PER_LISTING + 1);
+    redisMock.redis.ttl.mockResolvedValue(-2);
+    expect(await checkModMessageListingQuota('apl_live')).toEqual({
+      allowed: false,
+      retryAfterSeconds: MOD_MESSAGE_WINDOW_SECONDS,
+    });
+  });
+});
+
+describe('fail direction', () => {
+  it('FAILS OPEN when Redis errors', async () => {
+    // Deliberate, and documented in the module: the accountability mechanism is the
+    // Postgres audit row (written before delivery, carrying actorUserId), not the
+    // counter. Failing closed would let a Redis incident silently block moderation
+    // correspondence while every other mod action kept working.
+    redisMock.redis.incrBy.mockRejectedValue(new Error('ECONNREFUSED'));
+    expect(await checkModMessageModeratorQuota(8)).toEqual({ allowed: true });
+    expect(await checkModMessageListingQuota('apl_live')).toEqual({ allowed: true });
+  });
+
+  it('fails open when the TTL arm errors mid-window', async () => {
+    redisMock.redis.incrBy.mockResolvedValue(1);
+    redisMock.redis.expire.mockRejectedValue(new Error('ECONNREFUSED'));
+    expect(await checkModMessageModeratorQuota(8)).toEqual({ allowed: true });
+  });
+});

--- a/src/server/utils/__tests__/app-moderator-message-rate-limit.test.ts
+++ b/src/server/utils/__tests__/app-moderator-message-rate-limit.test.ts
@@ -33,18 +33,35 @@ beforeEach(() => {
 });
 
 describe('the two windows are SEPARATE keys', () => {
-  it('🔴 a moderator and a listing never share a counter', async () => {
-    // If both helpers wrote one key, the per-listing ceiling would be silently
-    // consumed by the moderator's own sends and vice versa — and the pair would still
-    // "have a rate limit". The two keys must be distinct AND each must name its own
-    // subject, so a second moderator gets a second budget while the recipient does not.
+  /**
+   * ⚠️ WHAT THIS BLOCK CAN AND CANNOT PROVE, stated because the first version of it
+   * overclaimed.
+   *
+   * A genuine COLLISION between the two counters is **not producible by any small
+   * mutation**: the subjects live in disjoint id spaces — an integer `userId` and an
+   * `apl_*` string — so even identical namespaces (`…:mod-message:8` vs
+   * `…:mod-message:apl_live`) yield distinct keys. A mutant that "makes them collide"
+   * has to hardcode a literal, which produces a defect no realistic edit produces, and
+   * a verdict from a non-productive mutant is a false alarm.
+   *
+   * What IS producible, and what these assertions actually pin: each helper writing
+   * the WRONG NAMESPACE — the shape a copy-paste between the two functions gives you.
+   * That is a real bug (the listing window would then share the actor's bucket for the
+   * same subject id, or land in a namespace nothing reads) and it is asserted on the
+   * literal below rather than inferred from the keys merely differing.
+   */
+  it('each helper writes its OWN namespace and its own subject', async () => {
     await checkModMessageModeratorQuota(8);
     await checkModMessageListingQuota('apl_live');
     const keys = redisMock.redis.incrBy.mock.calls.map((c) => c[0] as string);
     expect(keys).toHaveLength(2);
-    expect(keys[0]).not.toBe(keys[1]);
+    expect(keys[0]).toContain(':mod-message-actor:');
     expect(keys[0]).toContain('8');
+    expect(keys[1]).toContain(':mod-message-listing:');
     expect(keys[1]).toContain('apl_live');
+    // …and neither borrows the other's namespace, which is the copy-paste failure.
+    expect(keys[0]).not.toContain(':mod-message-listing:');
+    expect(keys[1]).not.toContain(':mod-message-actor:');
   });
 
   it('different moderators, and different listings, get different keys', async () => {

--- a/src/server/utils/app-moderator-message-rate-limit.ts
+++ b/src/server/utils/app-moderator-message-rate-limit.ts
@@ -1,0 +1,98 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+/**
+ * Redis-backed abuse controls for the moderator-only `appListings.messageAppOwner`
+ * mutation.
+ *
+ * 🔴 WHY NOT THE tRPC `rateLimit` MIDDLEWARE — `rateLimit` from
+ * `~/server/middleware.trpc` SHORT-CIRCUITS for moderators:
+ *
+ *     if (ctx.user?.isModerator || isDev || isTest || isPreview) return await next();
+ *
+ * so on a `moderatorProcedure` it is a guaranteed NO-OP. Wiring it here would look
+ * like a rate limit in review, in the router source, and in a diff — and cap nothing.
+ * This mirrors `blocks-retrigger-rate-limit.ts`, which exists for the same reason.
+ *
+ * 🔴 TWO COUNTERS, BECAUSE THEY BOUND DIFFERENT HARMS. One would not do:
+ *   - the PER-MODERATOR window bounds a runaway client / a compromised mod session
+ *     spraying the developer population, and is the one a single actor can exhaust;
+ *   - the PER-LISTING window bounds what any ONE developer can be made to receive,
+ *     ACROSS ALL moderators. That is the harassment ceiling, and a per-moderator cap
+ *     cannot express it: three moderators at nine messages an hour each are all
+ *     individually under a per-mod cap of ten while the recipient gets 27.
+ *
+ * FAIL DIRECTION — both FAIL OPEN on a Redis error, matching
+ * `blocks-retrigger-rate-limit` and the shared-storage limiters. The reasoning is that
+ * these are courtesy caps on an actor who is individually IDENTIFIED and permanently
+ * ATTRIBUTED: every send writes an `AppListingModerationEvent` carrying `actorUserId`,
+ * in Postgres, before anything is delivered. That record — not the counter — is the
+ * accountability mechanism, and it does not depend on Redis. Failing closed would mean
+ * a Redis incident silently blocks moderation correspondence while leaving every other
+ * mod action working. (Contrast `block-tip-rate-limit`, which fails CLOSED because it
+ * guards a money path reachable by any user.)
+ */
+
+/** Per-moderator ceiling: how many owner-messages one mod may send per window. */
+export const MOD_MESSAGE_MAX_PER_MODERATOR = 30;
+/** Per-listing ceiling: how many owner-messages ONE app may receive per window, from all mods. */
+export const MOD_MESSAGE_MAX_PER_LISTING = 5;
+/** Window for both ceilings. */
+export const MOD_MESSAGE_WINDOW_SECONDS = 60 * 60; // 1 hour
+
+function moderatorQuotaKey(moderatorUserId: number): string {
+  return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:mod-message-actor:${moderatorUserId}`;
+}
+
+function listingQuotaKey(appListingId: string): string {
+  return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:mod-message-listing:${appListingId}`;
+}
+
+export type ModMessageQuotaResult = { allowed: true } | { allowed: false; retryAfterSeconds: number };
+
+/**
+ * One INCR + EXPIRE fixed window. Shared by both counters so the two ceilings cannot
+ * drift in their TTL self-heal or their retry-after arithmetic — the duplication this
+ * replaces is what lets one of a pair of limiters quietly become TTL-less.
+ */
+async function checkFixedWindow(key: string, max: number): Promise<ModMessageQuotaResult> {
+  try {
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, MOD_MESSAGE_WINDOW_SECONDS);
+    } else {
+      // Self-heal a TTL-less key (re-arm ONLY when the TTL is actually missing, so an
+      // active window is never extended) — same footgun guard as the siblings.
+      const ttl = await redis.ttl(key as never);
+      if (ttl < 0) await redis.expire(key as never, MOD_MESSAGE_WINDOW_SECONDS);
+    }
+
+    if (count <= max) return { allowed: true };
+
+    let retryAfter = await redis.ttl(key as never);
+    if (!Number.isFinite(retryAfter) || retryAfter < 1) retryAfter = MOD_MESSAGE_WINDOW_SECONDS;
+    return { allowed: false, retryAfterSeconds: retryAfter };
+  } catch {
+    // FAIL OPEN — see the module doc.
+    return { allowed: true };
+  }
+}
+
+/** Record one send against this moderator's window. */
+export async function checkModMessageModeratorQuota(
+  moderatorUserId: number
+): Promise<ModMessageQuotaResult> {
+  return checkFixedWindow(moderatorQuotaKey(moderatorUserId), MOD_MESSAGE_MAX_PER_MODERATOR);
+}
+
+/**
+ * Record one send against this LISTING's window.
+ *
+ * 🔴 Keyed on the PARENT listing id, which the caller must have resolved already — a
+ * shadow revision is the same app, so keying on whatever id the moderator happened to
+ * paste would hand a second full allowance per open revision.
+ */
+export async function checkModMessageListingQuota(
+  appListingId: string
+): Promise<ModMessageQuotaResult> {
+  return checkFixedWindow(listingQuotaKey(appListingId), MOD_MESSAGE_MAX_PER_LISTING);
+}

--- a/src/server/utils/app-moderator-message-rate-limit.ts
+++ b/src/server/utils/app-moderator-message-rate-limit.ts
@@ -47,7 +47,9 @@ function listingQuotaKey(appListingId: string): string {
   return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:mod-message-listing:${appListingId}`;
 }
 
-export type ModMessageQuotaResult = { allowed: true } | { allowed: false; retryAfterSeconds: number };
+export type ModMessageQuotaResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
 
 /**
  * One INCR + EXPIRE fixed window. Shared by both counters so the two ceilings cannot


### PR DESCRIPTION
## The gap

The platform already notifies app owners **eleven** ways (`app-block-approved/rejected`, `app-listing-approved/rejected/hidden/reset-to-pending`, `app-collaborator-invited/accepted/removed`, `app-ownership-transfer-offered/accepted`). Every one is **event-triggered with fixed copy**. Four of them splice a moderator's `reason` into that fixed sentence — but the *subject* is always chosen by the code path, never by the moderator.

So a moderator who needs to say something the platform has no event for has had two options: push a change to someone else's app, or find the developer off-platform. The concrete case: a third-party listing (`prompt-vault`) claims it *"estimates the cost and asks before it spends"*, which it has never done; a second (`df-qwen-canvas`) has an entirely empty listing.

This adds a **twelfth notification type** and the smallest mod-only path to it.

```
appListings.messageAppOwner   (moderatorProcedure + the inner isModerator recheck)
  → resolveListingAccess         the CANONICAL owner, never AppListing.userId
  → bounds + throwOnBlockedLinkDomain
  → two Redis fixed windows      per-moderator AND per-listing
  → one AppListingModerationEvent   action `message-owner`  ← written BEFORE delivery
  → notifyAppModeratorMessage → createNotification   one call, N userIds
```

## Design decisions, and why

### The recipient is the canonical owner — `resolveListingAccess(id, null).ownerUserId`

`resolveCanonicalListingOwner` is the one place the kind branch is written: `onsite` → `AppBlock.app.userId` with the column as fallback; `offsite` → the column **unconditionally**, even when a block is attached (issue #3844). `resolveListingAccess` wraps it, hops a shadow revision to its parent, and takes `kind`/`slug`/`appBlockId`/`userId` from the parent row.

On an on-site listing `AppListing.userId` is a **denormalized copy** frozen at shadow-clone time. Reading it here would be worse than a missed delivery: it would send a moderator's private message *about* someone's app *to* a user who no longer owns it — a disclosure — while the real owner is never told their listing has a problem. The drifted-row fixture is the only fixture that can see this; one where the column and the block agree is green against both the correct and the broken resolution.

⚠️ **SCOPE — this is LATENT, not live, and the earlier framing overstated it.** Measured against production during review: **21 on-site parents, 21 with a backing block, 0 drifted; 0 accepted ownership transfers ever; 0 off-site listings carrying a block.** So there is no live damage here and this is defence-in-depth against a state that does not exist yet. It is still worth doing — it is correct-by-construction, costs one query, and the drift goes live on the first on-site transfer of a listing with an in-flight revision — but it is not a fix for something currently broken.

`userId: null` is deliberate: this caller is a moderator who is not a party to the app. The resolver's second argument asks "what is *this caller's* role", which nothing here reads — and `null` takes the early return, so the owner resolves in exactly **one** query with no seat lookup.

### The audit row precedes the delivery

⚠️ **Scope:** this is a property of **this procedure**, not of the notification type. The webhook-token-gated `src/pages/api/mod/send-mod-notification.ts` can emit any type — including `app-moderator-message` — with arbitrary `userIds` and text, no audit row and no rate limit. Not moderator-reachable, and equally true of the eleven existing app types, but the claim is about the proc.

Order: resolve → validate text → spend quota → **write the event** → deliver (best-effort).

A notifications outage costs the delivery, never the record that a moderator sent a message. The inverse would let a mod message a developer with nothing in the log. `reason` carries the subject and `detail` the body, so the history renders *what was said*, not merely that something was; `after` records the delivery decision (`recipientUserIds`, `includeCollaborators`), which is the part a later reviewer cannot reconstruct because the canonical owner can change afterwards.

Text validation runs **before** the quota spend so a rejected draft does not consume the *recipient's* harassment budget — a mod fixing a typo would otherwise burn the listing's hourly allowance.

### The moderator is not named to the recipient

Attribution lives in `AppListingModerationEvent.actorUserId` — durable, mod-visible, survives an account delete. Naming the individual on the wire would make "who acted on my app" answerable by a developer, a retaliation vector the rest of the moderation surface already declines to open (`delistListing` / `rejectRequest` carry the mod's *reason* to the user and never their identity). The owner-scoped history projection already drops `actor`, so this is consistent end to end.

### Content safety: `assertSharedTextSafe` is deliberately **not** applied

That belt exists for App Blocks *shared storage* — untrusted, cross-user, public text. Three of its five checks are actively wrong here:

- `includesMinor` / `includesPoi` **hard-fail** the text. A moderator writing *"your cover image appears to depict a minor — take it down"* is exactly the message this channel exists to carry, and the belt refuses to send it. **The control would block its own most important use.**
- `auditPromptServer({ isGreen: true })` forces an SFW/profanity ceiling on staff↔developer correspondence, hard-fails the send, and appends `GREEN_SFW_REDIRECT` — *"please visit civitai.red where you have more freedom to generate mature content"* — which is nonsense copy to put in front of a moderator writing to a developer about their app.

  ⚠️ **CORRECTED.** An earlier version of this section claimed the audit accrues blocked-prompt strikes against the sender. **That is wrong.** With `isGreen: true` the handler takes the `else if (isGreen)` branch in `promptAuditing.ts`, which calls neither `addBlockedPrompt` nor `reportProhibitedRequest` — no strike, no ClickHouse row, no auto-mute — and `assertSharedTextSafe` threads `isModerator` through anyway. The real cost is the hard-failed send and the wrong copy, which is narrower than what was claimed. The **conclusion is unchanged**: leg (a) is correct and independently sufficient. Left visible rather than silently rewritten, because the overstated version was quoted in review.

It would also be inconsistent rather than protective: **every** existing moderator free-text field that renders verbatim into a user-visible notification — `delistListing.reason` → `app-listing-hidden`, `rejectRequest.reason` → `app-block-rejected`, `tos-violation.reason` — runs no content safety at all. A belt on this one path and none on those four is a spelled control, not a real one.

**What is kept: the link check.** Moderator status establishes trusted staff; it does not survive a *compromised mod session*, and the one thing such a session can do here that mod-status does not mitigate is put a hostile URL in front of a developer wrapped in the platform's own "Civitai moderation sent you a message" framing. `throwOnBlockedLinkDomain` over subject+body costs one cached Redis read. Plus hard bounds, re-asserted in the service independently of the zod schema.

### Rate limiting: **not** the tRPC `rateLimit` middleware

```ts
if (ctx.user?.isModerator || isDev || isTest || isPreview) return await next();
```

`rateLimit` short-circuits for moderators, so on a `moderatorProcedure` it is a guaranteed **no-op** — it would cap nothing while reading as a limit in the router source, in review, and in a diff. This follows `blocks-retrigger-rate-limit.ts`, which exists for exactly this reason. A test asserts the source, because the behaviour is unobservable: an inert middleware and no middleware are indistinguishable from outside.

**Two counters, because they bound different harms.** The per-moderator window (30/h) bounds a runaway client or a compromised session; the per-listing window (5/h, across *all* moderators) is the harassment ceiling, which a per-moderator cap cannot express — three moderators at nine sends each are all individually under a cap of ten while the recipient gets 27.

**Fail open**, matching the sibling limiters. The accountability mechanism is the Postgres audit row (written before delivery, carrying `actorUserId`), not the counter; failing closed would let a Redis incident silently block moderation correspondence while every other mod action kept working.

### Collaborators are opt-in, default off

The **owner** is the accountable party. An accepted collaborator consented to *edit* an app, not to receive moderation correspondence about it, and a moderator's message can be adverse — fanning it out by default would broadcast a private accusation to third parties. But the failure in the other direction is real: on an app whose owner is unresponsive, the accepted editors are the only people who can fix the listing. That is a per-message judgement, which is what an explicit `includeCollaborators` is for. `displayed` is **not** consulted — it is a public-credit preference, not a capability.

The `{ status: 'accepted' }`-without-`displayed` predicate now has two callers, so it was extracted to `listAcceptedCollaboratorUserIds` and `listAppInsiderUserIds` delegates to it.

### The notification identifies the app by **slug**, not name

The sibling families carry `name` with a terse fallback. Here the recipient may own several apps, and one of the two listings that motivated this feature has an empty listing — a null name — i.e. the fallback would fire exactly where identification matters most. The slug is `NOT NULL`, is the app's public identity (`<slug>.civit.ai`), and is already resolved by the owner lookup.

### The copy says replies are not delivered

A notification is one-way and nothing routes a reply anywhere. Leaving that implicit would strand a developer who wants to answer, so the reply route is appended to every rendered message, and is part of the string rather than an optional field so it cannot be forgotten on one path.

## What I did **not** build

No inbox, no thread, no reply route, no read receipts, no message table, no UI. No widening of the owner-scoped history projection (it drops `detail`, so the owner sees the subject in history and the full body in the notification — widening it is a privacy change across *all* actions, not just this one). No new moderator-gating mechanism. No second error mapper.

## ⚠️ Manual migration, required before this ships

`20260824120000_app_listing_mod_action_message_owner` widens the `app_listing_mod_events_action_check` CHECK. Per the DB rule this repo follows, migrations are **applied by hand** per environment — apply to the dev clone before a preview exercises the proc, and to prod before main → release.

The failure mode without it is the safe one: the audit write is rejected (23514), so **no message is sent unrecorded**.

## Test matrix

Files: 5 new test files (72 cases) + 2 existing ledgers extended. Nothing added under `src/pages/**`.

**Red at `origin/main`, green at HEAD** — measured in a pristine `origin/main` worktree with my test files copied in:

| Test | at base | at HEAD | kind |
|---|---|---|---|
| `mod-actions-authz` → "router exposes … alongside the other mod actions" | ✗ FAIL (assertion) | ✓ | regression |
| `call-site-ledger` → "gate sites EXACTLY equals the ledger (GROWTH/SHRINK)" | ✗ FAIL (assertion) | ✓ | regression |
| `call-site-ledger` → "every ledger entry names an actual file" | ✗ FAIL (assertion) | ✓ | regression |
| `app-moderator-message.service.test.ts` (27) | ✗ COLLECT-ERROR — module absent | ✓ | **new-code, not regression** |
| `app-moderator-message-rate-limit.test.ts` (11) | ✗ COLLECT-ERROR — module absent | ✓ | **new-code, not regression** |
| `app-moderator-message-notify.test.ts` (3) | ✗ COLLECT-ERROR — module absent | ✓ | **new-code, not regression** |
| `app-moderator-message.notifications.test.ts` (8) | ✗ COLLECT-ERROR — module absent | ✓ | **new-code, not regression** |
| `app-listings.router.messageAppOwner.test.ts` (23) | ✗ COLLECT-ERROR — module absent | ✓ | **new-code, not regression** |
| `app-listing-mod-action.constants.test.ts` (3) | ✓ PASS | ✓ | **invariant guard** (re-derives; see M22/M23) |

Stated plainly: only the first three are regression evidence in the strict sense. The five COLLECT-ERROR rows are red at base because the module does not exist there — structurally red, not assertion-red, and I am not counting them as regression coverage. For those the evidence is the mutation battery below.

Two labelled non-guards, kept but not counted:
- the **anonymous** authz case survives a downgrade to `protectedProcedure` (`isAuthed` refuses before `isMod` runs) — it is an auth guard, not the mod gate. The **tester** and **developer** cases are the mod gate (gate 1), and both die to M31.
- 🔴 **the inner `isModerator` recheck (gate 2) is UNREACHABLE and is labelled, not counted.** It tests the identical predicate to `isMod` (`trpc.ts`: `if (!user.isModerator) throw FORBIDDEN`), so no context can reach the proc body with a non-moderator, and deleting its throw leaves every *behavioural* test green. It is defence-in-depth against a downgrade of gate 1. Its removal is caught by a **structural** case that says so in as many words (M32).
- `app-listing-mod-action.constants.test.ts` is green at base by construction (it compares the code tuple to the latest migration, and at base both lack the action). M22/M23 are what prove it is live.

## Mutation table — **25 defined, 25 verdicts produced, reconciled**

Harness controls run first: an **unmutated** run of all 7 target files was GREEN (8/23/48/3/3/27/11 passing, 0 failing) — the harness can report success. Every mutant asserted its search string occurred exactly once before replacing; 0 `PATTERN-MISS`. Files restored from byte copies, not git. Verdicts counted from the summary line, never an exit code. `killed_by_named_test` requires **that** guard's own test in the failing set — a mutant dying to a neighbour is not scored as coverage.

| # | Mutation | Defect produced | Killed by |
|---|---|---|---|
| M1 | recipient read from `AppListing.userId` | msg to the stale owner on a drifted onsite row | "DRIFTED on-site listing notifies the BLOCK owner" |
| M2 | send moved before the audit `create` | delivery with no record | "audit write is invoked BEFORE the send" |
| M3 | `\|\| !listingQuota.allowed` → `\|\| false` | harassment ceiling unenforced | "exhausted LISTING window refuses…" |
| M4 | text validation moved after the quota spend | a rejected draft burns the recipient's budget | "blocked link domain refuses with BLOCKED_LINK" |
| M5 | drop `.trim()` on body | whitespace-only message delivered | "whitespace-only body is refused as INVALID_TEXT" |
| M6 | `input.includeCollaborators` → `true` | collaborators broadcast by default | "by DEFAULT an accepted collaborator is NOT notified" |
| M7 | recipients array instead of `Set` | owner-with-a-seat notified twice | "owner who also holds a seat is notified ONCE" |
| M8 | `seatListingId` → `appListingId` | shadow gets its own quota + orphan audit row | "SHADOW revision id resolves to the PARENT" |
| M9 | link scan over body only | a hostile URL in the subject unscanned | "link scan covers the SUBJECT as well as the body" |
| M10 | `count <= max` → `count < max` | one fewer send than the stated ceiling | "allows a send at exactly the ceiling" |
| M11 | listing window uses the moderator ceiling | one app can receive 6× the intended volume | "LISTING ceiling is its own number" |
| M12 | TTL re-armed unconditionally | sliding-forever window ⇒ lifetime cap | "does NOT extend an active window" |
| ~~M13~~ → M30 | **withdrawn as non-productive**: an integer `userId` and an `apl_*` string cannot collide under any prefix, so "the two counters share a bucket" is not reachable by a small mutation — by this PR's own criterion that row was a false alarm. Replaced by the reachable defect: the listing key written into the **actor namespace** | "each helper writes its OWN namespace and its own subject" |
| M14 | `userIds` → `userId: userIds[0]` | only the owner is delivered to | "uses `userIds`, not a per-recipient call" |
| M15 | drop the empty-recipient guard | a dead PendingNotification burns the key | "EMPTY recipient list emits NOTHING" |
| M16 | drop the "replies are not delivered" clause | one-way channel with no route out | "always states that replies are not delivered" |
| M17 | render subject, drop body | a message with no content | "carries BOTH halves of what the moderator wrote" |
| M18 | remove the registry spread | `prepareMessage` never found ⇒ renders null | "is REGISTERED in the shared processor map" |
| M31 (was M19) | `moderatorProcedure` → `protectedProcedure` | **corrected:** *not* "any user can message any owner" — the inner recheck still refuses, with `UNAUTHORIZED`. The mutant dies on the **error-code mismatch**, and `mockMessageAppOwner` is never called under it either | "GATE 1 (moderatorProcedure): a non-moderator is FORBIDDEN" |
| M20 | `RATE_LIMITED` arm's code flipped | quota exhaustion reads as a bad request | "RATE_LIMITED maps to TOO_MANY_REQUESTS" |
| M21 | `OffsiteRequestError` dropped from the shared mapper | existing delist/claim errors → INTERNAL | "mapping the NEW error name did not break the two existing" |
| M22 | `'message-owner'` removed from the code tuple | code/DDL drift ⇒ 23514 at runtime | action-CHECK ⟺ tuple agreement |
| M23 | `'message-owner'` removed from the migration CHECK | same drift, other side | action-CHECK ⟺ tuple agreement |
| **M24** | **POSITIVE CONTROL** — `action: 'message-owner'` → `'delist'` | wrong audit action | "audit row carries the action, the actor…" |
| M25 | proc renamed away | the endpoint does not exist | shared authz ledger |

**All 25 KILLED, all `killed_by_named_test: true`.**

M3, M6 and M20 were deliberately narrowed to the smallest wrong expression rather than deleting the enclosing condition — a mutant that removes a guard together with its `if` proves nothing about the guard.

## One real gap this change introduced, found by an existing guard

`appListingModerationView.test.ts` iterates `APP_LISTING_MODERATION_ACTIONS` and asserts each has a chip label that is not the raw key. Adding `message-owner` to the tuple without a label failed with `expected 'message-owner' not to be 'message-owner'` — the event would have rendered its own action string in the history table. Fixed in the second commit. That map serves the **owner's** history as well as the mod queue, so the label is "Message from moderation", not "Messaged the owner".

## Runs

| Gate | Result |
|---|---|
| `pnpm typecheck` | **OK — 0 type errors** (116s, heap cap 8192 MB) |
| `pnpm test:unit:run` | **22,361 passed / 0 failed / 25 skipped**, 1439 files |
| `pnpm test:component` | 🔴 **COULD NOT RUN LOCALLY** — see below |
| targeted re-run after rebase | 167 passed / 0 failed (10 files) |

`pnpm test:component` collected 189 files and ran **zero** tests: `browserType.launch: Executable doesn't exist at …/chromium_headless_shell-1200/…`. The nix-provided browser set is `-1228`. **Verified identical in a pristine `origin/main` worktree**, so it is a local Playwright/nix version mismatch, not this change — but it means the component tier is **unverified locally**, and I am reporting that rather than a green. No `.browser.test.tsx` imports the one `src/components/` file this PR touches.

Separately, `feature-flags.early-adopter.seam.test.ts` failed in the first full run for a worktree-setup reason (`apps/auth/.svelte-kit/tsconfig.json` absent). Confirmed failing identically at `origin/main` in a clean worktree, then fixed by `svelte-kit sync`; the run above is after that.

## Drift

Rebased onto `origin/main` twice during the work. At the final rebase, `main` had moved 14 files; **zero overlap** with the 18 this PR touches. Branched directly off `origin/main` — not stacked.

---

## CI (updated after the lint fix)

**11 pass · 1 skipped by design · 1 still running.**

| Check | |
|---|---|
| App unit tests + typecheck | ✅ 2m28s |
| Unit tests (1)–(4) | ✅ 3m42s / 3m14s / 2m59s / 3m45s |
| Package unit tests | ✅ 1m24s |
| ESLint + Prettier (changed files) | ✅ 1m24s |
| Schema drift gate | ✅ 58s — the CHECK widen needs no Prisma schema change |
| event-engine-common pin | ✅ 25s |
| Windows dev-env (bash / pwsh) | ✅ 2m58s / 2m37s |
| Typecheck (main pushes / fork PRs / non-main base) | skipped by design — same-repo PR against `main` is covered by "App unit tests + typecheck" |
| `preview / deploy` | ⏳ still running at time of writing |

The first ESLint run failed on one real error — `consistent-type-imports` for a `TRPCError` import used only in a cast — plus five `no-unused-vars` warnings on named-but-unused `vi.fn` parameters. Fixed in the third commit; dropping the parameters is behaviour-neutral (`vi.fn` records the arguments it is *called* with regardless of its declared signature), re-verified by re-running the three files and `pnpm typecheck`.

⚠️ **`preview / component-tests` is known-red on `main`** on `ImagesAsPostsCardLazyCarousel.browser.test.tsx`, bisected to `d4c4a4e4cb` (#4365). Not this branch.



---

## Post-audit revision (commit 5)

An adversarial audit cleared the primary path — recipient resolution on every branch, audit-before-delivery, the authorization boundary, the migration's safe failure mode — and found **three defects plus two vacuous guards**. All fixed; the narrative corrections above are marked in place rather than silently rewritten.

### 🔴 1. The blocked-link `catch` was too wide, and inverted this feature's own fail-direction

`throwOnBlockedLinkDomain` reaches `getBlocklistDTO`, whose **first statement is an unguarded `await redis.get(...)`**. The bare `catch` turned a Redis outage into *"The message contains a blocked link domain."* about a message with no link, leaving the moderator to edit text that is fine — and because `BLOCKED_LINK` maps to `BAD_REQUEST`, it never reached the `INTERNAL_SERVER_ERROR` branch that feeds the server-fault logger, so **the outage was invisible from this path**.

It also contradicted the argument two sections up: the rate limiter fails *open* precisely so a Redis incident cannot block moderation correspondence, and this put a fail-*closed* Redis dependency in front of the same send.

Now only a `TRPCError`/`BAD_REQUEST` — what `throwBadRequestError` actually produces on a real block — is relabelled; anything else is rethrown as infra.

**Why the suite could not see it:** the BLOCKED case was fixtured with `new Error('invalid urls: …')`, which is indistinguishable from `ECONNREFUSED` at a bare catch site. It is now a real `TRPCError`, with an `ECONNREFUSED` case beside it — the pair is what makes either one mean anything.

`assertSharedTextSafe` has the byte-identical wart, so this is a copied house pattern rather than a novel defect; fixing it there is a separate change.

### 🔴 2. Half the content-safety rationale was factually wrong

See the ⚠️ CORRECTED note inline above. Conclusion unchanged, leg (a) independently sufficient, leg (b) replaced with the true and narrower claim. Leg (c) was independently **verified true**: `delistListing.reason` gets `requireModReason` (trim + 3-char floor) and nothing else.

### 🔴 3. A rejected send burned the *recipient's* harassment budget

Both windows were spent unconditionally before either was checked. A moderator who had exhausted their own 30/h window and kept retrying still `INCR`'d the per-listing key each time — **five retries by one already-capped moderator would exhaust that app's 5/h ceiling and lock out every other moderator for the rest of the hour**, over messages that were never sent.

That contradicted the ordering principle this PR already enforced for text-validation rejections. The actor window is now checked before the listing window is touched. The short-circuit runs in **one direction only** — skipping the listing spend when the actor is *allowed* would leave the ceiling unenforced in the normal case — and both directions are pinned.

### 🔴 The two source-level guards were VACUOUS

Both sliced the proc body to `'\n  }),'` — two spaces, where the real terminator has four. `indexOf` returned `-1`, `slice(0, -1)` kept nearly the whole 3k-line router, and the assertions were answered by **other procedures' source**. Measured: deleting this proc's inner `isModerator` recheck left "both gates are present" **green**, because a sibling's identical line was in scope.

The rate-limit guard was worse: it asserted `not.toContain('.use(rateLimit(')`, and this router **never uses that spelling** (it writes `.use(\n      rateLimit({`). The assertion was true no matter what, and would have passed with a rate limit sitting on the proc.

Both fixed, and a **positive control** now asserts the slice is bounded — under 1200 chars and containing no sibling proc — so a future terminator change fails loudly instead of silently restoring the whole-file scan (M34).

### Four coverage gaps the auditor's mutants found, all now closed

| Gap | Consequence if wrong | Now pinned by |
|---|---|---|
| collaborator read used the passed id, not the PARENT | a shadow id delivers to the owner alone while the audit row says the editors were looped in | "the collaborator read is keyed on the PARENT listing" (M28) |
| `after.includeCollaborators` asserted only in the true case | misreports on the **default** path — the common one, and the reason `after` exists | "records FALSE on the default path" (M29) |
| the limiter key test asserted only that the keys differ | each helper writing the *other's* namespace | "each helper writes its OWN namespace" (M30) |
| gate 2's removal was uncaught | the belt is silently deletable | the structural case + its positive control (M32/M34) |

Also corrected: `app-moderator-message.notifications.test.ts`'s "does not name the moderator" case claimed to assert the **type's** field set. TS types are erased, so it does not — it asserts a hand-written fixture. The real guard is in the service test (confirmed by mutation) and the comment now cites it.

### Round-2 mutation table — 10 defined, 10 verdicts, reconciled, all killed by their own named test

| # | Mutation | Defect produced | Killed by |
|---|---|---|---|
| M26 | the narrowed catch → bare `catch` | a Redis outage reads as a blocked link, invisibly | "an INFRA failure in the link scan is NOT relabelled" |
| M27 | listing quota spent before the actor check | a capped mod's retries burn the recipient's ceiling | "an ALREADY-CAPPED moderator does NOT spend the LISTING budget" |
| M3b | `if (!listingQuota.allowed)` → `if (false)` | harassment ceiling unenforced | "exhausted LISTING window refuses…" |
| M28 | collaborator read off the passed id | silent under-delivery on a shadow id | "collaborator read is keyed on the PARENT listing" |
| M29 | `after.includeCollaborators` hardcoded `true` | the audit misreports the fan-out | "records FALSE on the default path" |
| M30 | listing key written into the actor namespace | the two windows share a bucket | "each helper writes its OWN namespace" |
| M31 | gate 1 downgraded to `protectedProcedure` | error code changes; access still refused by gate 2 | "GATE 1: a non-moderator is FORBIDDEN" |
| M32 | gate 2's throw deleted | the belt is gone with no behavioural signal | "STRUCTURAL: both gates are present" |
| M33 | a `rateLimit()` wired onto the proc | an inert limiter that reads as a real one | "does NOT rely on the tRPC rateLimit middleware" |
| M34 | the proc terminator broken | the extractor silently rescans the whole file | "POSITIVE CONTROL: the extractor is BOUNDED" |

**Round-1 re-run**, because the fixes changed the code a round-1 verdict was taken against: **22 defined, 22 verdicts, reconciled, all killed by their own named test** (M3/M13/M19 dropped as superseded by M3b/M30/M31). One entry, M20, first came back **`PATTERN-MISS` rather than a verdict** — prettier had reshifted its indentation, so its search string matched zero times. That is the occurrence assertion doing its job; re-run with the corrected pattern it is killed by its named test. It is recorded here rather than quietly fixed, because a mutant scored without executing is exactly the false-alarm shape this battery exists to avoid.

**Combined: 32 mutants, 32 killed by their own named test, defined == produced in both rounds.** Harness controls re-run each round: unmutated runs GREEN on every target file, byte-copy restore (never git), verdicts counted from the summary line.

### Runs after the revision

| Gate | Result |
|---|---|
| `pnpm test:unit:run` | **22,383 passed / 0 failed / 25 skipped — 1439 files, 0 failing files** |
| `pnpm typecheck` | **OK — 0 type errors** |
| `npx eslint` (changed files) | **0 problems** |
| `npx prettier --check` | clean |

The earlier `feature-flags.early-adopter.seam.test.ts` worktree artifact is resolved (`svelte-kit sync`), so this is the first fully-green full-suite run — no failing files at all.
