### PR TITLE
test(meilisearch): freeze the clock for the cursor staleness boundary

### DIFF
--- a/src/server/meilisearch/__tests__/cleanup.test.ts
+++ b/src/server/meilisearch/__tests__/cleanup.test.ts
@@ -1092,30 +1092,49 @@ describe('cleanupIndex: a stored cursor cannot be carried indefinitely', () => {
     // Boundary, lower side. Paired with the case below so the bound is observable
     // in BOTH directions — either one alone is satisfied by an implementation that
     // ignores the age entirely, or by one that ignores the cursor entirely.
-    seedCursor('models', {
-      lastId: 6,
-      startedAt: Date.now() - MAX_CURSOR_AGE_MS,
-      covered: 5,
-    });
-    const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
-    setFakeIndex(fake);
-    const rec = makeDelayRecorder();
+    //
+    // 🔴 The clock is frozen because this seed sits EXACTLY on the bound: `age` is
+    // `MAX_CURSOR_AGE_MS` and the guard rejects on `age > MAX`, so it is inside by
+    // one millisecond. Against a live clock, any time elapsed between seeding here
+    // and the read tips it to stale — which made the test a function of how loaded
+    // the box was, passing alone and failing inside a full suite.
+    //
+    // Frozen rather than given slack: slack would stop pinning `>` against `>=`,
+    // which is the one distinction this pair exists to make.
+    //
+    // Restored in `finally` — this file has no `afterEach` and the vitest config
+    // sets no `restoreMocks`, so a spy that leaked would freeze every test after it.
+    const frozenNow = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(frozenNow);
 
-    const stats = await cleanupIndex(modelsCfg, {
-      apply: false,
-      batch: 10,
-      resumable: true,
-      delay: rec.delay,
-    });
+    try {
+      seedCursor('models', {
+        lastId: 6,
+        startedAt: frozenNow - MAX_CURSOR_AGE_MS,
+        covered: 5,
+      });
+      const fake = makeFakeIndex({ docs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+      setFakeIndex(fake);
+      const rec = makeDelayRecorder();
 
-    expect(stats.resumedFrom).toBe(6);
-    expect(fake.searchCalls[0].filter).toBe('id > 6');
-    // The pass covered 5 + 4 = 9 of 10, so it is credited and rolls over. Pins the
-    // completion threshold from ABOVE — raising it toward 1 holds a cursor on a pass
-    // that plainly finished, and the un-scanned tail of a shrinking index would then
-    // wedge the rollover permanently.
-    expect(stats.passCovered).toBe(9);
-    expect(storedCursor('models')).toBeUndefined();
+      const stats = await cleanupIndex(modelsCfg, {
+        apply: false,
+        batch: 10,
+        resumable: true,
+        delay: rec.delay,
+      });
+
+      expect(stats.resumedFrom).toBe(6);
+      expect(fake.searchCalls[0].filter).toBe('id > 6');
+      // The pass covered 5 + 4 = 9 of 10, so it is credited and rolls over. Pins the
+      // completion threshold from ABOVE — raising it toward 1 holds a cursor on a pass
+      // that plainly finished, and the un-scanned tail of a shrinking index would then
+      // wedge the rollover permanently.
+      expect(stats.passCovered).toBe(9);
+      expect(storedCursor('models')).toBeUndefined();
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('forces a from-the-bottom pass once a cursor is older than the bound', async () => {


### PR DESCRIPTION
Ticket `868kwu5bq`. The last thing making a full-suite result ambiguous on the Windows box.

## The defect is the boundary, not the load

`src/server/meilisearch/__tests__/cleanup.test.ts` seeded:

```ts
startedAt: Date.now() - MAX_CURSOR_AGE_MS,
```

and `cleanup-cursor.ts` rejects on `age > MAX_CURSOR_AGE_MS`. At the seed instant `age` equals the bound **exactly**, so `>` is false and the cursor resumes — inside by one millisecond. Any time elapsing between the seed and the read makes it stale, `resumedFrom` comes back null, and you get:

```
AssertionError: expected null to be 6
```

Run alone it passes 62/62. Under a 31-worker suite that millisecond reliably elapses. **Reading it as a flake and re-running is how it survived** — and re-running genuinely "works", which is the trap.

## The fix

Freeze `Date.now` for that one test and seed relative to the frozen value.

**Frozen rather than given slack.** Seeding a minute inside the bound would also be deterministic, but it would stop distinguishing `>` from `>=` — which is exactly what this test exists to pin, paired with its sibling `forces a from-the-bottom pass once a cursor is older than the bound`. The comment on the pair says so: *"either one alone is satisfied by an implementation that ignores the age entirely"*.

**Restored in `finally`.** This file has no `afterEach` and the vitest config sets no `restoreMocks`, so a spy that leaked would freeze every test after it — including on a mid-test assertion failure, which is why it is `finally` and not a trailing call.

**`cleanup-cursor.ts` is untouched.** Whether a cursor sitting exactly on the age limit *ought* to be stale — i.e. whether that guard should be `>=` — is a question for whoever owns Meilisearch cleanup, not something to settle inside a test fix. `git diff --stat` is one file.

Also considered and rejected: threading a clock through. `readScanCursor(key, now = Date.now())` already takes an injectable clock, but the test drives it via `cleanupIndex`, which calls it with one argument — so using it would mean changing a production signature in the ringfenced file.

## Freezing a clock inside a scan loop is safe here — checked, not assumed

A frozen clock inside a loop is how a test hangs instead of failing. There are exactly two `Date.now()` calls in this path:

- `cleanup.ts:433` — `passStartedAt`, only ever **written into a cursor** (`:877`), never compared
- `cleanup-cursor.ts:71` — the injectable default

Both scan loops are bounded by array length and `maxBatches`, not by elapsed time. Nothing in the path can spin on a stopped clock.

## Controls

| control | result |
|---|---|
| mutate the guard `>` → `>=`, clock frozen | **caught** — `Tests 1 failed \| 61 passed (62)`, `expected null to be 6` |
| revert to the live clock, force 5ms elapsed | **fails** — `expected null to be 6` |

The first proves the frozen test still pins the bound to the millisecond, so determinism was not bought by defanging the assertion. The second reproduces the reported failure deterministically, proving the diagnosis rather than assuming it.

⚠️ Worth recording: the `>=` mutant and the flake produce an **identical** message. A real regression in that guard would have looked exactly like the noise everyone was re-running past.

## Closing condition: passes INSIDE a full suite

A green run of the file alone is not evidence — it already passed that way. From the run's own sequencer cache:

```
unit:src/server/meilisearch/__tests__/cleanup.test.ts
  { duration: 12880.9, failed: False }
```

Positive evidence that it ran and passed within the suite, rather than inference from "only one file failed" — a file can contribute zero tests without reporting red.

```
Test Files  1 failed | 1423 passed | 1 skipped (1425)
Tests  1 failed | 22233 passed | 27 skipped (22261)
```

Files 1423+1+1 = 1425; tests 22233+1+27 = 22261. Both add up. The cache reports **exactly one** failed file, `pageRunScrollContract.test.ts` — the known Windows path-separator red pending #4397, not this.

**Base SHA: `afe84cf7c8`** (`main` had already moved past the SHA I was given). `blocks.router.workflow.test.ts` ran in the same suite and passed, so the submodule is initialised and the run covered real code.

typecheck 0 errors · `test:lint-rules` 351/351 · 62/62 after prettier.
