### PR TITLE
fix(apps): listing description above the screenshots, and one rule for how it renders

### DIFF
--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -716,3 +716,100 @@ describe('AppBlockCard — cover image (first screenshot) + placeholder fallback
     expect(placeholder!.querySelector('svg')).not.toBeNull();
   });
 });
+
+/**
+ * The CARD's description is the PLAIN-TEXT PROJECTION of the stored markdown.
+ *
+ * The stored `description` is markdown (see `appListingDescription.ts` for the one
+ * rule). The card is a 3-line clamp in a grid, where markdown BLOCK elements would be
+ * wrong — so it is the one surface that deliberately does NOT render markdown. That
+ * makes it the surface where showing raw SOURCE is tempting and wrong: several live
+ * first-party listings use backticks for literal syntax (`{style}`, `#tag`, `.txt`),
+ * which printed as literal backtick characters in the grid.
+ *
+ * 🔴 RED at `origin/main` on the backtick, emphasis and hard-wrap tests: main passes
+ * `manifest.description` straight into `<Text className="line-clamp-3">`, so the
+ * rendered text still carries the markdown punctuation.
+ */
+describe('AppBlockCard description — plain-text projection', () => {
+  /** The card's description node, read by its rendered text content. */
+  function descriptionText(): string {
+    const el = document.querySelector('.line-clamp-3');
+    if (!el) throw new Error('no .line-clamp-3 description node on the card');
+    return el.textContent ?? '';
+  }
+
+  test('🔴 a backticked token loses its backticks and keeps its content', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ description: 'Use `{style}` and `#tag` here.' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    expect(descriptionText()).toBe('Use {style} and #tag here.');
+  });
+
+  test('🔴 emphasis markers do not reach the grid', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ description: 'a **bold** and _italic_ word' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    expect(descriptionText()).toBe('a bold and italic word');
+  });
+
+  test('🔴 hard line wraps collapse into single spaces', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ description: 'wrapped at a fixed\ncolumn width by hand' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    expect(descriptionText()).toBe('wrapped at a fixed column width by hand');
+  });
+
+  // MEASURED GREEN AT BASE → INVARIANT GUARD, not regression coverage for this
+  // change. At base the card passed raw source into a `<Text>`, so it rendered no
+  // markdown elements either — the assertion cannot tell the two implementations
+  // apart. Kept because it pins the card as a NON-renderer against a future "just
+  // render markdown everywhere" change, which is a real and tempting mistake. NOT
+  // counted in the red/green matrix.
+  test('invariant: the card renders NO markdown elements — it is text, not a renderer', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({
+          description: '# Heading\n\n- one\n- two\n\n[link](https://example.com)',
+        })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    const el = document.querySelector('.line-clamp-3')!;
+    // Positive control first: the text DID render, so the zero counts below are facts
+    // about markdown elements rather than about an empty node.
+    expect(el.textContent).toContain('Heading');
+    expect(el.querySelectorAll('h1, ul, li, a, code, strong, em')).toHaveLength(0);
+  });
+
+  test('invariant: plain prose is unchanged', async () => {
+    // Green at base AND at HEAD. Pins that the projection does not mangle ordinary
+    // descriptions, which is the majority case.
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ description: 'Does a thing.' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    expect(descriptionText()).toBe('Does a thing.');
+  });
+});

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { AppDetailsModal } from '~/components/Apps/AppDetailsModal';
+import { appListingDescriptionToPlainText } from '~/components/Apps/appListingDescription';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import {
@@ -249,8 +250,14 @@ export function AppBlockCard({
             // M1: the description link is a detail-page open too — record it.
             onClick={() => onRecentOpen?.(block)}
           >
+            {/* 🔴 The card shows the PLAIN-TEXT PROJECTION, not the markdown source.
+                This is the second half of the one rule (`appListingDescription.ts`):
+                a 3-line clamp in a grid cannot render markdown block elements, so
+                it renders markdown's text instead. Passing the raw source here
+                would print literal backticks and `**` in the grid — the same
+                unpredictability the rule exists to remove, just relocated. */}
             <Text size="sm" c="dimmed" className="line-clamp-3">
-              {manifest.description}
+              {appListingDescriptionToPlainText(manifest.description)}
             </Text>
           </Anchor>
         )}

--- a/src/components/Apps/AppDetailsModal.tsx
+++ b/src/components/Apps/AppDetailsModal.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link';
 import { useMemo } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
+import { AppListingDescription } from '~/components/Apps/AppListingDescription';
 import { getAppDetailAuthor } from '~/components/Apps/appDetailAuthorView';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -200,11 +201,10 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
           )}
         </Stack>
 
-        {description && (
-          <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-            {description}
-          </Text>
-        )}
+        {/* Markdown, via the shared renderer (`appListingDescription.ts` holds the
+            rule). Was `pre-wrap` plain text, which disagreed with the listing
+            detail body's markdown rendering of the same stored string. */}
+        {description && <AppListingDescription description={description} />}
 
         {/* Detail-load failure (audit M1): when the public-detail query errors
             we can't say anything definitive about screenshots OR scopes, so

--- a/src/components/Apps/AppListingDescription.tsx
+++ b/src/components/Apps/AppListingDescription.tsx
@@ -1,0 +1,84 @@
+import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
+
+/**
+ * The elements an app-listing description may render.
+ *
+ * 🔴 This is an ALLOWLIST, and it is deliberately explicit rather than absent.
+ *
+ * `CustomMarkdown` leaves `allowedElements` as `undefined` when a caller passes
+ * none, and `undefined` in react-markdown means EVERYTHING is permitted. The
+ * listing detail body used to call it that way. That was survivable while the
+ * detail body was the only markdown surface; this change puts markdown on two
+ * more (the app detail page and the details modal), so the element set is now
+ * stated instead of inherited.
+ *
+ * What is NOT here, and why:
+ *
+ * - **`img`** — a markdown image (`![alt](https://…)`) renders a real `<img>`,
+ *   which loads an author-controlled remote URL in every viewer's browser. A
+ *   listing already has a first-class image channel — the screenshot gallery,
+ *   whose images are auto-discovered from the submitted bundle,
+ *   magic-byte-validated and MOD-REVIEWED before approval. An unmoderated image
+ *   channel inside the description is redundant with a moderated one, so the
+ *   description is text. (The alt text is preserved on the teaser/meta surfaces
+ *   by `appListingDescriptionToPlainText`.)
+ * - **`iframe`** — only reachable via `CustomMarkdown`'s `allowExternalVideo`,
+ *   which we do not pass. Listed here so the omission reads as a decision.
+ * - **table elements** — GFM tables need `remark-gfm`, which this surface does
+ *   not load, so `th`/`td` are unreachable here regardless. Kept out so the
+ *   allowlist describes what can actually render.
+ *
+ * Note this is not an XSS boundary and does not need to be: react-markdown does
+ * not parse raw HTML without `rehype-raw`, which this surface also does not
+ * load. Raw `<script>` in a description is inert text either way. The concern
+ * this list addresses is remote-resource embedding, not script injection.
+ *
+ * `CustomMarkdown` unions `time` in on top of whatever we pass, so Discord-style
+ * `<t:UNIX:STYLE>` timestamps keep working.
+ */
+export const APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS = [
+  // text + inline formatting
+  'p',
+  'br',
+  'strong',
+  'em',
+  'a',
+  // literal syntax — the reason authors reach for backticks in the first place
+  'code',
+  'pre',
+  // structure
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'hr',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+];
+
+/**
+ * The full-surface renderer for an app-listing `description`.
+ *
+ * Use this on every surface whose job is to SHOW the description: the listing
+ * detail body, `/apps/[appBlockId]`, and the details modal. Surfaces that cannot
+ * render markdown (the card's 3-line clamp, `<meta>`) use
+ * `appListingDescriptionToPlainText` instead — see `appListingDescription.ts`
+ * for the full rule and why it is split this way.
+ *
+ * Layout is the caller's business: the detail body wraps this in a
+ * `ContentClamp`, the modal does not. Only the RENDERING is shared, because the
+ * rendering is what authors need to be able to predict.
+ */
+export function AppListingDescription({ description }: { description: string }) {
+  return (
+    <div className="markdown-content">
+      <CustomMarkdown allowedElements={APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS}>
+        {description}
+      </CustomMarkdown>
+    </div>
+  );
+}

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -1610,3 +1610,136 @@ describe('AppListingDetailBody — store-scope review seam', () => {
     expect(dropdown.querySelector('[data-testid="apps-listing-review-action"]')).not.toBeNull();
   });
 });
+
+/**
+ * THE DESCRIPTION RENDERS ABOVE THE SCREENSHOTS.
+ *
+ * The reported defect, from the operator looking at the store preview page: "app
+ * listing description should be above screenshots". The description is what tells a
+ * reader what the app IS; the gallery is supporting evidence for that claim, so
+ * leading with pictures made the reader scroll past the answer to reach it.
+ *
+ * 🔴 WHAT IS ASSERTED IS DOCUMENT ORDER, NOT PRESENCE. `compareDocumentPosition` is
+ * the whole point of this block. A test asserting "the description exists and the
+ * gallery exists" passes in EITHER order — green on the broken code AND green on the
+ * fix — which is precisely the defect class here.
+ *
+ * 🔴 NOT A MERGE GATE: this file is in the browser-mode `component` project, which CI
+ * runs only as the preview pipeline's report-only `preview / component-tests` (the
+ * same caveat `.gallery.browser.test.tsx` carries). The blocking half of this change
+ * is `__tests__/appListingDescription.test.ts` in the node project — it gates the
+ * renderer rule but cannot see a node's position. Both are needed; neither substitutes.
+ *
+ * RED at `origin/main` on the `toBe(DOCUMENT_POSITION_FOLLOWING)` assertion: main
+ * renders the gallery first, so the comparison returns DOCUMENT_POSITION_PRECEDING (2)
+ * rather than FOLLOWING (4). Full matrix in the PR body.
+ */
+describe('AppListingDetailBody — description / screenshot order', () => {
+  /** A listing with BOTH — the only shape in which an ordering claim is meaningful. */
+  function withBoth(over: Partial<ListingDetail> = {}) {
+    return base({
+      description: 'The description body.',
+      // Distinct, non-round URLs so nothing below can match a hardcoded constant.
+      screenshots: [
+        { url: 'https://cdn.example/shot-7311.png', caption: 'first' },
+        { url: 'https://cdn.example/shot-9427.png', caption: 'second' },
+      ],
+      ...over,
+    });
+  }
+
+  /**
+   * `compareDocumentPosition(description, gallery)`.
+   *
+   * 🔴 Throws when either node is missing rather than returning a falsy value. A
+   * helper that returned 0 for an absent node would let every ordering assertion
+   * pass vacuously the moment a testid was renamed — the reassuring-zero failure
+   * mode. Failing loudly is what makes a green here mean both nodes were found.
+   */
+  function comparePositions(container: HTMLElement): number {
+    const description = container.querySelector('[data-testid="apps-listing-description"]');
+    const gallery = container.querySelector('[data-testid="apps-listing-screenshot-grid"]');
+    if (!description) throw new Error('no [data-testid="apps-listing-description"] in the tree');
+    if (!gallery) throw new Error('no [data-testid="apps-listing-screenshot-grid"] in the tree');
+    return description.compareDocumentPosition(gallery);
+  }
+
+  test('🔴 the description precedes the screenshot gallery in document order', async () => {
+    const { container } = await renderScoped(<AppListingDetailBody detail={withBoth()} />);
+    // DOCUMENT_POSITION_FOLLOWING (4) = "the gallery comes AFTER the description".
+    // An exact `toBe` against the named constant, not a bitmask test: the nodes are
+    // siblings in one subtree, so exactly one bit is set, and an exact comparison
+    // cannot be satisfied by an unrelated CONTAINS/CONTAINED_BY bit.
+    expect(comparePositions(container)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  test('🔴 the gallery does NOT precede the description (the inverse, stated directly)', async () => {
+    const { container } = await renderScoped(<AppListingDetailBody detail={withBoth()} />);
+    expect(comparePositions(container) & Node.DOCUMENT_POSITION_PRECEDING).toBe(0);
+  });
+
+  test('🔴 both sit in the MAIN column, description first', async () => {
+    // Guards a "fix" that satisfied document order by moving the description into
+    // the right rail — a different, wrong change. Pins the RELATIONSHIP (same
+    // parent column + order), not just the order.
+    const { container } = await renderScoped(<AppListingDetailBody detail={withBoth()} />);
+    const mainCol = container.querySelector('[data-testid="apps-listing-main-col"]');
+    expect(mainCol).not.toBeNull();
+    const description = mainCol!.querySelector('[data-testid="apps-listing-description"]');
+    const gallery = mainCol!.querySelector('[data-testid="apps-listing-screenshot-grid"]');
+    expect(description).not.toBeNull();
+    expect(gallery).not.toBeNull();
+    expect(description!.compareDocumentPosition(gallery!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  // MEASURED GREEN AT BASE → INVARIANT GUARD, not regression coverage. This surface
+  // already rendered markdown before this change; what changed is that the OTHER
+  // full surfaces now match it. Kept because the reorder and the new allowlist both
+  // touch this call site, and a regression to plain text here would be silent.
+  // NOT counted in the red/green matrix.
+  test('invariant: the description renders markdown — a backticked token becomes a code span', async () => {
+    // The renderer half of the rule, at the surface. A description using backticks
+    // for literal syntax must not show the backticks.
+    const { container } = await renderScoped(
+      <AppListingDetailBody detail={withBoth({ description: 'Use `{style}` here.' })} />
+    );
+    expect(container.querySelector('.markdown-content code')?.textContent).toBe('{style}');
+  });
+
+  test('🔴 the description renders NO <img>, even when the markdown asks for one', async () => {
+    // `img` is excluded from APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS. Asserted here
+    // through a real render because the array test in the node project proves the
+    // array's CONTENTS, not that this array is the one handed to react-markdown.
+    const { container } = await renderScoped(
+      <AppListingDetailBody
+        detail={withBoth({ description: 'before ![alt](https://cdn.example/x.png) after' })}
+      />
+    );
+    const markdown = container.querySelector('.markdown-content');
+    expect(markdown).not.toBeNull();
+    // Positive control for the negative assertion: the surrounding text DID render,
+    // so an img count of 0 is a fact about images — not about a markdown block that
+    // never mounted.
+    expect(markdown!.textContent).toContain('before');
+    expect(markdown!.textContent).toContain('after');
+    expect(markdown!.querySelectorAll('img')).toHaveLength(0);
+  });
+
+  // ── invariant guards: green at base, LABELLED as such, not counted as
+  //    regression coverage for the reorder ─────────────────────────────────────
+  test('invariant: no description → the gallery still renders', async () => {
+    const { container } = await renderScoped(
+      <AppListingDetailBody detail={withBoth({ description: null })} />
+    );
+    expect(container.querySelector('[data-testid="apps-listing-description"]')).toBeNull();
+    expect(container.querySelector('[data-testid="apps-listing-screenshot-grid"]')).not.toBeNull();
+  });
+
+  test('invariant: no screenshots → the description still renders', async () => {
+    const { container } = await renderScoped(
+      <AppListingDetailBody detail={withBoth({ screenshots: [] })} />
+    );
+    expect(container.querySelector('[data-testid="apps-listing-description"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="apps-listing-screenshot-grid"]')).toBeNull();
+  });
+});

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -68,6 +68,7 @@ import {
   useReportListingAffordance,
 } from '~/components/Apps/ReportListingModal';
 import { ReviewListingModal, useCanReviewListing } from '~/components/Apps/ReviewListingButton';
+import { AppListingDescription } from '~/components/Apps/AppListingDescription';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
@@ -76,7 +77,6 @@ import { SmartCreatorCard } from '~/components/CreatorCard/CreatorCard';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { StatHoverCard } from '~/components/Stats/StatHoverCard';
-import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import {
   isMarketplaceCategory,
   marketplaceCategoryLabel,
@@ -96,7 +96,7 @@ import type {
  * PAGE's layout, deliberately: a full-bleed hero, then a header block (icon + name +
  * tagline + collaborator byline + interactive stat chips + a `⋮` overflow menu + an
  * `Updated: <date> │ <category>` meta line), then a two-column `ContainerGrid2` — main
- * content left (screenshots, `About` under a `ContentClamp`), a stack of `Card
+ * content left (`About` under a `ContentClamp`, THEN screenshots), a stack of `Card
  * withBorder` rails right (the primary action, the `SmartCreatorCard`, a "Details"
  * accordion) — then the full-width discovery rail, reviews and discussion.
  *
@@ -156,8 +156,11 @@ import type {
  *
  * XSS / encoding discipline (mirrors P2b): external hrefs are https-guarded in the
  * pure view-model (`safeExternalHref`) + rendered with rel="noopener noreferrer"
- * target="_blank"; the markdown description goes through the shared `CustomMarkdown`
- * (react-markdown, no `dangerouslySetInnerHTML`). 🔴 `ContentClamp` wraps that markdown
+ * target="_blank"; the markdown description goes through the shared
+ * `AppListingDescription` → `CustomMarkdown` (react-markdown, no
+ * `dangerouslySetInnerHTML`), which also states the element allowlist — `img` is
+ * NOT in it, so a description cannot embed a remote image. 🔴 `ContentClamp` wraps
+ * that markdown
  * — it does NOT replace it. Do not swap in `RenderHtml` to get a nicer clamp: the
  * markdown path is the XSS posture, not a formatting preference.
  *
@@ -1118,20 +1121,29 @@ export function AppListingDetailBody({
           data-testid="apps-listing-main-col"
         >
           <Stack gap="lg">
-            <ScreenshotGallery screenshots={detail.screenshots} name={detail.name} />
+            {/* Description — ABOVE the screenshots. The description is what tells a
+                reader what the app IS; the gallery is supporting evidence for that
+                claim, so leading with pictures made the reader scroll past the
+                answer to reach it. 🔴 The DOM order here is the presentation
+                decision and is pinned by a test that asserts the two nodes'
+                relative document position — a test that merely asserts both are
+                present passes in either order, which is exactly the defect.
 
-            {/* Description — shared CustomMarkdown (no dangerouslySetInnerHTML), under
-                the model page's `ContentClamp maxHeight={460}`. */}
+                Rendering goes through the shared `AppListingDescription` (still
+                `CustomMarkdown` underneath — no `dangerouslySetInnerHTML`), which
+                is the single place the markdown element allowlist is stated. Under
+                the model page's `ContentClamp maxHeight={460}`; the clamp is this
+                surface's layout choice, not part of the shared rule. */}
             {detail.description && (
-              <Stack gap="xs">
+              <Stack gap="xs" data-testid="apps-listing-description">
                 <Title order={4}>About</Title>
                 <ContentClamp maxHeight={460}>
-                  <div className="markdown-content">
-                    <CustomMarkdown>{detail.description}</CustomMarkdown>
-                  </div>
+                  <AppListingDescription description={detail.description} />
                 </ContentClamp>
               </Stack>
             )}
+
+            <ScreenshotGallery screenshots={detail.screenshots} name={detail.name} />
 
             {/* Off-site external destination disclosure (mirrors the live detail).
                 🔴 The condition lives in `shouldShowOffsiteDisclosure`, NOT here —

--- a/src/components/Apps/__tests__/appListingDescription.test.ts
+++ b/src/components/Apps/__tests__/appListingDescription.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'vitest';
+import { appListingDescriptionToPlainText } from '~/components/Apps/appListingDescription';
+import { APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS } from '~/components/Apps/AppListingDescription';
+
+/**
+ * The plain-text projection half of the app-listing description rule.
+ *
+ * Every test here was watched RED against `origin/main` (where neither module
+ * existed — the suite failed to import) and green at HEAD. The RED there is
+ * "module not found", which is weak evidence on its own, so the mutation table
+ * in the PR body is what actually establishes that each assertion can fail for
+ * its OWN reason against a present-but-wrong implementation.
+ */
+describe('appListingDescriptionToPlainText', () => {
+  // ── the backtick case: the reason this function exists ──────────────────────
+  //
+  // Twelve first-party listings shipped descriptions using backticks for literal
+  // syntax. On the markdown surface those became code spans; on the card and in
+  // og:description they were literal backtick characters.
+  test('🔴 strips inline-code backticks and keeps their content', () => {
+    expect(appListingDescriptionToPlainText('Use `{style}` and `#tag` in `.txt`')).toBe(
+      'Use {style} and #tag in .txt'
+    );
+  });
+
+  test('🔴 strips emphasis markers and keeps their content', () => {
+    expect(appListingDescriptionToPlainText('a **bold** and _italic_ word')).toBe(
+      'a bold and italic word'
+    );
+  });
+
+  test('🔴 keeps link TEXT and drops the URL syntax', () => {
+    expect(appListingDescriptionToPlainText('see [the docs](https://example.com/x) now')).toBe(
+      'see the docs now'
+    );
+  });
+
+  test('🔴 drops heading hashes and keeps the heading text', () => {
+    expect(appListingDescriptionToPlainText('# Title\n\nBody text.')).toBe('Title Body text.');
+  });
+
+  // ── the hard-wrap case: `prompt-vault` wraps at ~76 columns ─────────────────
+  //
+  // Those wraps were literal under `pre-wrap` and collapsed under markdown. The
+  // teaser/meta projection collapses them, which is right for a single line.
+  test('🔴 collapses hard line wraps into single spaces', () => {
+    const wrapped = 'A description that the author\nhard-wrapped at a fixed\ncolumn width.';
+    expect(appListingDescriptionToPlainText(wrapped)).toBe(
+      'A description that the author hard-wrapped at a fixed column width.'
+    );
+  });
+
+  test('🔴 separates block elements rather than concatenating their text', () => {
+    // Without a separator this reads "onetwo" — a wrong word, not just wrong
+    // spacing. Distinct fixture words so the assertion cannot pass by accident.
+    expect(appListingDescriptionToPlainText('one\n\ntwo')).toBe('one two');
+  });
+
+  test('🔴 separates list items rather than concatenating them', () => {
+    expect(appListingDescriptionToPlainText('- alpha\n- beta\n- gamma')).toBe('alpha beta gamma');
+  });
+
+  test('keeps fenced code CONTENT, without the fence', () => {
+    expect(appListingDescriptionToPlainText('```\nnpm install\n```')).toBe('npm install');
+  });
+
+  test('substitutes an image with its alt text', () => {
+    // `img` is not renderable on any surface this function feeds, and it is not
+    // in the markdown allowlist either — alt text is the honest stand-in.
+    expect(appListingDescriptionToPlainText('before ![a diagram](https://x/y.png) after')).toBe(
+      'before a diagram after'
+    );
+  });
+
+  // ── the metadata safety property ───────────────────────────────────────────
+  test('🔴 never emits markup, so it is safe for <meta content=…>', () => {
+    const hostile = '[x](https://e.com) **b** `c` ![i](https://e.com/p.png)';
+    const out = appListingDescriptionToPlainText(hostile);
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).toBe('x b c i');
+  });
+
+  test('passes literal angle brackets through as TEXT without constructing markup', () => {
+    // A positive control for the assertion above: prove the `not.toContain('<')`
+    // check is not vacuous by showing the function CAN carry a `<` when the
+    // author typed one — what it must never do is CREATE one. Without this, a
+    // function that returned '' would satisfy every no-markup assertion.
+    expect(appListingDescriptionToPlainText('a < b and c > d')).toBe('a < b and c > d');
+  });
+
+  test('is total — empty and whitespace-only input return an empty string', () => {
+    expect(appListingDescriptionToPlainText('')).toBe('');
+    expect(appListingDescriptionToPlainText('   \n\n  ')).toBe('');
+  });
+
+  test('leaves plain prose byte-identical', () => {
+    expect(appListingDescriptionToPlainText('Just a normal sentence.')).toBe(
+      'Just a normal sentence.'
+    );
+  });
+});
+
+/**
+ * The markdown allowlist half of the rule.
+ *
+ * 🔴 These assert the CONTENT of the exported allowlist, which is what the
+ * renderer actually passes to `CustomMarkdown`. A test that only asserted the
+ * array is non-empty would pass with `img` in it.
+ */
+describe('APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS', () => {
+  test('🔴 excludes `img` — a description must not embed a remote image', () => {
+    // The listing has a mod-reviewed screenshot gallery for imagery; the
+    // description is text. Adding `img` here re-opens author-controlled remote
+    // resource loading on three surfaces at once.
+    expect(APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS).not.toContain('img');
+  });
+
+  test('🔴 excludes `iframe`', () => {
+    expect(APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS).not.toContain('iframe');
+  });
+
+  test('🔴 includes `code` — literal syntax is the format authors actually use', () => {
+    expect(APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS).toContain('code');
+  });
+
+  test('includes the text and structure elements a description needs', () => {
+    // Named explicitly: dropping `p` silently blanks every description, and that
+    // is not something a "list is non-empty" check would catch.
+    for (const el of ['p', 'br', 'strong', 'em', 'a', 'pre', 'ul', 'ol', 'li', 'blockquote']) {
+      expect(APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS).toContain(el);
+    }
+  });
+
+  test('is a non-empty allowlist, not an accidental empty array', () => {
+    // An empty array is NOT the same as `undefined` in react-markdown: undefined
+    // permits everything, [] permits nothing. Both are wrong here, and this
+    // pins the difference.
+    expect(APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS.length).toBeGreaterThan(5);
+  });
+});

--- a/src/components/Apps/__tests__/appListingDescriptionCallSites.test.ts
+++ b/src/components/Apps/__tests__/appListingDescriptionCallSites.test.ts
@@ -1,0 +1,144 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, test } from 'vitest';
+
+/**
+ * 🔒 THE ENROLMENT LEDGER for the app-listing DESCRIPTION presentation rule.
+ *
+ * WHY THIS FILE EXISTS. The same stored `description` rendered three different
+ * ways across four surfaces — full markdown on the listing detail body, `pre-wrap`
+ * plain text on the app detail page and the details modal, and a raw-source
+ * `line-clamp-3` on the card. Nobody chose that; it accumulated because each call
+ * site made its own decision. An author writing a description could not predict
+ * what it would look like, so live first-party listings hedge: some use backticks
+ * (a markdown idiom, which printed as literal backticks on three of the four), one
+ * hard-wraps at ~76 columns (literal under `pre-wrap`, reflowed under markdown).
+ *
+ * Fixing the four sites does not remove that condition — the NEXT surface can
+ * re-open it. So this asserts the RELATIONSHIP rather than any one component: the
+ * set of files that present a listing description is exactly the ledger below, and
+ * each uses the renderer its role calls for. It fails when the ledger GROWS (a new
+ * surface appears) and when it SHRINKS (a site stops using the shared rule).
+ *
+ * 🔴 WHAT THIS GUARD CANNOT SEE, stated so it is not read as wider than it is: a
+ * brand-new surface that open-codes `<Text>{listing.description}</Text>` imports
+ * neither module and is therefore invisible here. This guard catches regression of
+ * the KNOWN sites and growth through the sanctioned path; it is not a proof that no
+ * unenrolled site exists. The behavioural cover in
+ * `AppListingDetailBody.browser.test.tsx` and `AppBlockCard.browser.test.tsx` is
+ * the other half — it proves the wiring actually renders, which source text cannot.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+const MARKDOWN_MODULE = '~/components/Apps/AppListingDescription';
+const PLAINTEXT_MODULE = '~/components/Apps/appListingDescription';
+
+/**
+ * Every surface that presents a listing description, and which of the TWO
+ * presentations it uses.
+ *
+ * - `markdown` — a surface whose job is to SHOW the description in full.
+ * - `plaintext` — a surface that cannot render markdown (a clamped card in a grid,
+ *   a `<meta>` tag), so it shows the markdown's plain-text projection.
+ */
+const LEDGER: Record<string, 'markdown' | 'plaintext' | 'both'> = {
+  'components/Apps/AppListingDetailBody.tsx': 'markdown',
+  'components/Apps/AppDetailsModal.tsx': 'markdown',
+  // The page renders markdown in the body AND feeds the plain-text projection to
+  // its `<meta>`/`og:description`, so it legitimately uses both.
+  'pages/apps/[appBlockId]/index.tsx': 'both',
+  'components/Apps/AppBlockCard.tsx': 'plaintext',
+};
+
+/** Recursively list every .ts/.tsx file under `dir`, excluding tests. */
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      walk(full, out);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.(test|browser\.test)\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Files that import either half of the shared rule, as SRC-relative paths. */
+function findImporters(): Map<string, Set<'markdown' | 'plaintext'>> {
+  const found = new Map<string, Set<'markdown' | 'plaintext'>>();
+  const roots = [path.join(SRC, 'components'), path.join(SRC, 'pages')];
+  for (const root of roots) {
+    for (const file of walk(root)) {
+      const text = fs.readFileSync(file, 'utf8');
+      // The two module specifiers differ only in the leading capital, so match the
+      // full quoted specifier — a `includes(PLAINTEXT_MODULE)` would also match the
+      // markdown one on a case-insensitive read and silently merge the two sets.
+      const usesMarkdown = text.includes(`'${MARKDOWN_MODULE}'`);
+      const usesPlaintext = text.includes(`'${PLAINTEXT_MODULE}'`);
+      if (!usesMarkdown && !usesPlaintext) continue;
+      const rel = path.relative(SRC, file);
+      const kinds = found.get(rel) ?? new Set();
+      if (usesMarkdown) kinds.add('markdown');
+      if (usesPlaintext) kinds.add('plaintext');
+      found.set(rel, kinds);
+    }
+  }
+  return found;
+}
+
+describe('app-listing description — enrolment ledger', () => {
+  test('🔴 the set of enrolled surfaces is EXACTLY the ledger (fails on growth and on shrinkage)', () => {
+    const importers = findImporters();
+    // Sorted arrays, compared whole — not a subset check. A `toContain` per entry
+    // passes while an unlisted fifth surface quietly joins.
+    expect([...importers.keys()].sort()).toEqual(Object.keys(LEDGER).sort());
+  });
+
+  test('🔴 each surface uses the renderer its ROLE calls for', () => {
+    const importers = findImporters();
+    for (const [rel, expected] of Object.entries(LEDGER)) {
+      const kinds = importers.get(rel);
+      expect(kinds, `${rel} imports neither half of the shared rule`).toBeDefined();
+      const actual = [...kinds!].sort().join('+');
+      const want = expected === 'both' ? 'markdown+plaintext' : expected;
+      expect(actual, `${rel} presents its description as "${actual}", ledger says "${want}"`).toBe(
+        want
+      );
+    }
+  });
+
+  test('🔴 the page feeds <Meta> the PLAIN-TEXT projection, never the markdown source', () => {
+    // The metadata safety property, pinned at the one call site that can violate
+    // it. A meta tag cannot render markdown, so shipping the source put literal
+    // `**` and backticks into og:description.
+    const page = fs.readFileSync(path.join(SRC, 'pages/apps/[appBlockId]/index.tsx'), 'utf8');
+    expect(page).toContain('description={metaDescription ||');
+    // And the raw value must not be what reaches the tag. Stated as the exact
+    // rejected spelling rather than a fuzzy "does not contain description" — the
+    // raw `description` identifier legitimately appears all over this file.
+    expect(page).not.toContain('description={description ||');
+    expect(page).toContain('appListingDescriptionToPlainText(description)');
+  });
+
+  test('🔴 no enrolled surface still hand-rolls a pre-wrap description', () => {
+    // The exact spelling the two plain-text surfaces used before this change. If it
+    // comes back on an enrolled file, the shared rule has been bypassed in place.
+    for (const rel of Object.keys(LEDGER)) {
+      const text = fs.readFileSync(path.join(SRC, rel), 'utf8');
+      const offending = text.includes("whiteSpace: 'pre-wrap'");
+      expect(offending, `${rel} re-introduced a hand-rolled pre-wrap description`).toBe(false);
+    }
+  });
+
+  test('the ledger is non-trivial — a positive control on the scan itself', () => {
+    // 🔴 Without this, every assertion above is satisfiable by a `findImporters`
+    // that silently returns an empty map (a bad root path, a changed extension
+    // filter). The reassuring-zero failure mode: an empty scan compared against an
+    // empty expectation would read as a clean pass.
+    const importers = findImporters();
+    expect(importers.size).toBe(4);
+    expect(Object.keys(LEDGER)).toHaveLength(4);
+  });
+});

--- a/src/components/Apps/appListingDescription.ts
+++ b/src/components/Apps/appListingDescription.ts
@@ -1,0 +1,130 @@
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+/**
+ * ONE rule for how an app-listing `description` is presented, in one place.
+ *
+ * ## Why this module exists
+ *
+ * The same stored string used to render three different ways across four
+ * surfaces, so an author could not predict what their description would look
+ * like:
+ *
+ * | surface                     | before                          |
+ * |-----------------------------|---------------------------------|
+ * | `AppListingDetailBody`      | `CustomMarkdown` (full markdown)|
+ * | `/apps/[appBlockId]`        | `<Text whiteSpace: pre-wrap>`   |
+ * | `AppDetailsModal`           | `<Text whiteSpace: pre-wrap>`   |
+ * | `AppBlockCard`              | `<Text line-clamp-3>`           |
+ *
+ * A description written with backticks (`` `{style}` ``, `` `#tag` ``) rendered
+ * as a code span on the first surface and as literal backtick characters on the
+ * other three; one written with hard line wraps rendered as wrapped lines under
+ * `pre-wrap` and as a reflowed paragraph under markdown. Both spellings are in
+ * live first-party listings, because authors were hedging against a platform
+ * that had no stated rule.
+ *
+ * ## The rule
+ *
+ * **The stored `description` is Markdown.** That is now true everywhere, and it
+ * is the format authors were already writing (backticks are a markdown idiom).
+ * There are exactly TWO presentations of it, chosen by what the surface is for:
+ *
+ * 1. **Full surfaces** render the markdown — see `AppListingDescription` in
+ *    `AppListingDescription.tsx`. These are the places a reader goes to read the
+ *    description: the listing detail body, the app detail page, the details
+ *    modal.
+ * 2. **Teaser / metadata surfaces** render the markdown's PLAIN-TEXT PROJECTION
+ *    — this file's {@link appListingDescriptionToPlainText}. These are places
+ *    where markdown block elements would be wrong or impossible: a 3-line
+ *    clamped card in a grid, and `<meta name="description">` / `og:description`.
+ *
+ * The second half is what makes the rule honest. If the canonical format is
+ * markdown, a surface that cannot render markdown must not show markdown
+ * SOURCE — otherwise the card and the OG snippet display raw `` `{style}` ``
+ * backticks and `**bold**` asterisks, which is the same unpredictability in a
+ * new place.
+ *
+ * 🔴 The projection is also the metadata safety property: it emits only the
+ * VALUES of mdast text-ish nodes, so it can never introduce markup into a
+ * `<meta>` tag. It does not "strip HTML" — it never constructs any.
+ */
+
+/** A structural stand-in for mdast nodes; `@types/mdast` is not a direct dep. */
+type MdNode = {
+  type: string;
+  value?: unknown;
+  alt?: unknown;
+  children?: MdNode[];
+};
+
+/**
+ * Node types whose `value` IS the text to keep.
+ *
+ * `inlineCode` and `code` are the load-bearing entries: a description using
+ * `` `{style}` `` for literal syntax must show `{style}` in a teaser, not
+ * `` `{style}` `` with the backticks still attached.
+ */
+const VALUE_NODES = new Set(['text', 'inlineCode', 'code']);
+
+/**
+ * Node types that separate their text from the next text with a space.
+ *
+ * `break` (a hard line break) and the block containers are here so that
+ * `paragraph one\nparagraph two` reads as `paragraph one paragraph two` rather
+ * than `paragraph oneparagraph two`. This is what collapses the ~76-column hard
+ * wraps some listings carry — correct for a teaser, where the author's column
+ * width is meaningless.
+ */
+const SEPARATING_NODES = new Set([
+  'break',
+  'paragraph',
+  'heading',
+  'listItem',
+  'blockquote',
+  'thematicBreak',
+  'table',
+  'tableRow',
+  'code',
+]);
+
+function collect(node: MdNode, out: string[]): void {
+  if (VALUE_NODES.has(node.type) && typeof node.value === 'string') {
+    out.push(node.value);
+  } else if (node.type === 'image' && typeof node.alt === 'string') {
+    // An image cannot render in a teaser or a meta tag; its alt text is the
+    // closest honest textual stand-in.
+    out.push(node.alt);
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) collect(child, out);
+  }
+
+  if (SEPARATING_NODES.has(node.type)) out.push(' ');
+}
+
+/**
+ * Render an app-listing description's markdown down to a single line of plain
+ * text, for surfaces that cannot render markdown (the card teaser, `<meta>`).
+ *
+ * Guarantees, each pinned by a test in
+ * `src/components/Apps/__tests__/appListingDescription.test.ts`:
+ *
+ * - **No markdown syntax survives.** Backticks, `**`, `_`, `#`, `[]()` are gone;
+ *   their CONTENT remains.
+ * - **No markup is produced.** The output is built only from mdast text values,
+ *   so it can never contain `<` from a construct this function created.
+ * - **Whitespace is collapsed** to single spaces and trimmed, so hard-wrapped
+ *   source reflows into one line.
+ * - **Total.** Every string is valid markdown, so there is no throwing input.
+ */
+export function appListingDescriptionToPlainText(description: string): string {
+  if (!description) return '';
+
+  const tree = unified().use(remarkParse).parse(description) as unknown as MdNode;
+  const parts: string[] = [];
+  collect(tree, parts);
+
+  return parts.join('').replace(/\s+/g, ' ').trim();
+}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -29,6 +29,8 @@ import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
+import { appListingDescriptionToPlainText } from '~/components/Apps/appListingDescription';
+import { AppListingDescription } from '~/components/Apps/AppListingDescription';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import {
@@ -235,6 +237,12 @@ export default function AppDetailPage() {
   const detail = data as PublicAppDetail | undefined;
   const name = detail?.manifest.name ?? detail?.blockId ?? appBlockId;
   const description = detail?.manifest.description ?? '';
+  // 🔴 `<meta>` gets the PLAIN-TEXT PROJECTION, never the markdown source. The
+  // stored description is markdown (see `appListingDescription.ts`), and a meta
+  // tag cannot render it — shipping the source put literal `**bold**` and
+  // backticks into og:description. The projection is built only from mdast text
+  // values, so it also cannot introduce markup into the tag.
+  const metaDescription = appListingDescriptionToPlainText(description);
   const slots = detail?.manifest.targets?.map((t) => t.slotId).filter(Boolean) ?? [];
   // Show Install ONLY for an app that installs into a model/in-context slot.
   // A page app (target slot `app.page`) is STATELESS (installModel `'none'`) — no
@@ -302,7 +310,7 @@ export default function AppDetailPage() {
       */}
       <Meta
         title={`${name} — Civitai Apps`}
-        description={description || `${name} on the Civitai Apps marketplace.`}
+        description={metaDescription || `${name} on the Civitai Apps marketplace.`}
         deIndex
       />
       <Container size="md" py="md">
@@ -431,11 +439,12 @@ export default function AppDetailPage() {
                 </Group>
               </Group>
 
-              {description && (
-                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                  {description}
-                </Text>
-              )}
+              {/* Markdown, via the shared renderer — see `appListingDescription.ts`
+                  for the one rule. This surface used to be `pre-wrap` plain text
+                  while the listing detail body rendered the SAME stored string as
+                  markdown, so a description written with backticks showed literal
+                  backtick characters here and a code span there. */}
+              {description && <AppListingDescription description={description} />}
 
               {/* F-E E5 — publisher screenshot gallery. Public display URLs
                   (the gated /api/blocks/screenshot/... route); the images were


### PR DESCRIPTION
## 1. The reported defect

> "store preview page: app listing description should be above screenshots."

On the listing detail body the gallery rendered first and the description second, so a reader scrolled past the pictures to reach the sentence telling them what the app is. The description now precedes the gallery.

### Which surfaces this moves

`AppListingDetailBody` has **two** render sites, not one — worth stating because the brief for this work assumed only the store preview:

| render site | route | gating |
|---|---|---|
| `src/pages/apps/store-preview/[slug].tsx` | `/apps/store-preview/<slug>` | `resolveAppsPageAccess` → `appListings \|\| appBlocks \|\| appListingsPublicExternal`; mod-segmented in Flipt, `deIndex` on. Anon-capable but dark. |
| `src/components/Apps/OffsiteReviewQueue.tsx` → `ListingPreviewSection` | `/apps/review` (via `OffsiteReviewModal` and `CombinedReviewModal`) | `getServerSideProps`: `appBlocks` flag + signed in + `isAppReviewer` (`isModerator`). |

So the reorder also changes what **moderators** see in the listing-preview pane of the review queue — which is the right outcome (the preview should match the store), but it is a second surface and reviewers will notice.

There are no barrels re-exporting the component and no dynamic imports; every consumer imports the file directly.

## 2. The real finding: the renderer split

The same stored `description` rendered **three ways across four surfaces**, measured at `798d0893a9`:

| surface | before | after |
|---|---|---|
| `AppListingDetailBody.tsx` | `CustomMarkdown`, **no element allowlist** | `AppListingDescription` (markdown, explicit allowlist) |
| `src/pages/apps/[appBlockId]/index.tsx` | `<Text whiteSpace: 'pre-wrap'>` | `AppListingDescription` |
| `AppDetailsModal.tsx` | `<Text whiteSpace: 'pre-wrap'>` | `AppListingDescription` |
| `AppBlockCard.tsx` | `<Text className="line-clamp-3">`, **raw source** | plain-text **projection** of the markdown |
| `[appBlockId]` `<meta>` / `og:description` | **raw markdown source** | plain-text **projection** |

A description using backticks for literal syntax (`` `{style}` ``, `` `#tag` ``, `` `.txt` ``) rendered as a code span on surface 1 and as literal backtick characters on 2–4. One with hard wraps at ~76 columns rendered wrapped under `pre-wrap` and reflowed under markdown. Live first-party listings contain **both** spellings — authors were hedging against a platform with no stated rule.

### The decision

**Two renderers, one stated rule, single-sourced in `src/components/Apps/appListingDescription.ts`:**

> The stored description is **Markdown**. Surfaces whose job is to *show* it render the markdown. Surfaces that *cannot* render markdown — a 3-line clamp in a grid, a `<meta>` tag — render its **plain-text projection**.

Why not the alternatives:

- **Unify on `CustomMarkdown` everywhere** — wrong for the card. It is a 3-line clamp in a grid; markdown block elements (headings, lists, tables, images) would break the layout, and it would put author-controlled links and remote images on the marketplace grid.
- **Unify on plain text everywhere** — throws away the format authors are *already writing*. Backticks are a markdown idiom; the twelve listings updated today reach for them deliberately. Plain-text-everywhere makes that punctuation garbage on every surface instead of one.
- **Keep the split and document it** — documentation does not stop the fifth call site. The rule is pinned by tests, including an enrolment ledger that fails when the set of surfaces grows *or* shrinks.

The second half of the rule is what makes it honest: if the canonical format is markdown, a surface that cannot render markdown must not display markdown **source**. Otherwise the card and the OG snippet show raw `` `{style}` `` and `**bold**` — the same unpredictability, relocated. `appListingDescriptionToPlainText` parses with `remark-parse` (already a direct dependency) and emits only mdast text values.

### `CustomMarkdown`'s allowlist — checked, as asked

**It has none by default.** `CustomMarkdown` sets `allowedElements` to `undefined` unless a caller passes one, and `undefined` in react-markdown means *everything is permitted*. `AppListingDetailBody` called it with no props, so the listing description permitted the full CommonMark element set — including `![alt](url)`, which renders a real `<img>` loading an author-controlled remote URL.

What it is **not**: an XSS surface. react-markdown does not parse raw HTML without `rehype-raw`, which this call site does not load, so `<script>` in a description is inert text. `allowExternalVideo` (the `iframe` path) is also not passed. GFM tables/strikethrough are unreachable here too — `remark-gfm` is not loaded on this surface.

The concern is **remote-resource embedding**, and it matters more now because this change puts markdown on two additional surfaces. So `APP_LISTING_DESCRIPTION_ALLOWED_ELEMENTS` is explicit and **excludes `img`**: a listing already has a first-class image channel — the screenshot gallery, whose images are auto-discovered from the submitted bundle, magic-byte-validated and **mod-reviewed before approval**. An unmoderated image channel inside the description is redundant with a moderated one.

Included: `p br strong em a code pre ul ol li blockquote hr h1–h6` (+ `time`, which `CustomMarkdown` unions in for Discord-style timestamps).

🔴 **Open item, stated plainly:** I did not enumerate live listing descriptions to confirm none currently use `![...]`. If one does, its image disappears (alt text survives on the card/meta). This is a one-array revert.

### Metadata

Confirmed: `description` feeds `<Meta description>` at `[appBlockId]/index.tsx:305` → `<meta name="description">` / `og:description`. It now receives the projection, which is built only from mdast text values and therefore cannot construct markup. Previously it shipped raw markdown source (safe, but with literal `**` and backticks in the snippet).

## 3. Red/green matrix

Base = `798d0893a9` (this branch's merge-base), run in a **separate pristine worktree** so in-flight edits could not contaminate it. For the ordering tests the base tree carries an **isolated back-port of the `data-testid` only** — otherwise they would fail on a missing node rather than on the order, which is the assertion that matters.

| test | base | HEAD | base failure reason |
|---|---|---|---|
| **`AppListingDetailBody.browser.test.tsx`** | | | |
| 🔴 description precedes the gallery in document order | **RED** | green | `expected 2 to be 4` — `DOCUMENT_POSITION_PRECEDING` vs `FOLLOWING` |
| 🔴 the gallery does NOT precede the description | **RED** | green | `expected 2 to be +0` |
| 🔴 both sit in the main column, description first | **RED** | green | `expected 2 to be 4` |
| 🔴 description renders NO `<img>` | **RED** | green | `expected <img> to have length +0 but got 1` |
| *invariant*: backtick → code span | green | green | already markdown at base — **labelled invariant, not counted** |
| *invariant*: no description → gallery still renders | green | green | invariant |
| *invariant*: no screenshots → description still renders | green | green | invariant |
| **`AppBlockCard.browser.test.tsx`** | | | |
| 🔴 backticks stripped, content kept | **RED** | green | `expected 'Use \`{style}\` and \`#tag\` here.' to be 'Use {style} and #tag here.'` |
| 🔴 emphasis markers do not reach the grid | **RED** | green | `expected 'a **bold** and _italic_ word' to be 'a bold and italic word'` |
| 🔴 hard wraps collapse to single spaces | **RED** | green | wrapped text retained the newline |
| *invariant*: card renders no markdown elements | green | green | base rendered raw text, so also no elements — **labelled invariant, not counted** |
| *invariant*: plain prose unchanged | green | green | invariant |
| **`__tests__/appListingDescription.test.ts`** (18) | **RED (weak)** | green | module absent at base → `Tests no tests`. Honest caveat below. |
| **`__tests__/appListingDescriptionCallSites.test.ts`** (5) | **RED (weak)** | green | same — new modules |

🔴 **The weak red, stated rather than dressed up:** the 23 node-project tests are red at base only because the modules they import do not exist there, which surfaces as `Tests no tests` — the shape that reads as "nothing to see" rather than as a failure. That is not regression evidence. Their real evidence is the mutation table below, which runs them against a *present-but-wrong* implementation.

**Regression coverage: 10 tests.** **Invariant guards (labelled, not counted): 5.**

## 4. Mutation table

Every mutant was applied by a harness that asserts the target text occurs the expected number of times **and** that the write changed the file; each mutant declares the test it must die to, and a kill is only counted when *that* test is in the failing set. Mutants defined vs verdicts produced are reconciled at the end.

| # | mutant (narrowest expression) | must die to | verdict |
|---|---|---|---|
| M1 | reorder: gallery back above the description | description precedes the gallery | **KILLED** (3 ordering tests) |
| M2 | add `'img'` to the allowlist array | excludes `img` | **KILLED** |
| M3 | drop the `allowedElements` prop from the renderer | renders NO `<img>` | **KILLED** |
| M4 | remove `inlineCode` from `VALUE_NODES` | strips inline-code backticks | **KILLED** |
| M5 | remove the whitespace collapse | collapses hard line wraps | **KILLED** |
| M6 | remove `paragraph` from `SEPARATING_NODES` | separates block elements | **KILLED** |
| M7 | card renders raw markdown source | backticks stripped | **KILLED** (3 card tests) |
| M9 | remove the image-alt branch | substitutes image alt text | **KILLED** |
| M10 | `<Meta>` reverts to the markdown source | Meta gets the projection | **KILLED** |
| M11 | card un-enrols from the rule (drop the import) | ledger is exactly the ledger | **KILLED** |
| PC | **positive control** — flattener returns a constant | plain prose unchanged | **KILLED** (13 tests) |

**Reconciliation: 11 mutants defined, 11 verdicts produced, 11 killed, 0 survived, 0 killed-by-other.**

Two things worth calling out:

- **M2 and M3 kill disjoint tests.** M2 (array contents) kills only the node-project allowlist test; M3 (the wiring) kills only the browser `<img>` test. That is deliberate — a test asserting the array's contents proves nothing about whether that array is the one handed to react-markdown. Both halves are covered independently.
- 🔴 **M1 initially reported SURVIVED, and it was a false alarm from a NON-PRODUCTIVE mutant.** The mutation inserted the gallery above the description and then deleted "the gallery line" — which deleted the copy just inserted, since it was the earlier occurrence, leaving the description still first. The file changed (whitespace) so a naive `after != before` check passed, and 78 tests ran green against effectively unmutated code. Fixed by deleting first, inserting second, and adding a **productivity control** asserting the mutant actually places the gallery before the description. It then killed all three ordering guards. Recorded because the false SURVIVED is indistinguishable from a real coverage gap unless the mutant is checked for productivity.

## 5. Suites

Run with `pnpm typecheck`, `pnpm test:unit:run`, `pnpm test:component`, counting result lines rather than reading exit codes.

| suite | result |
|---|---|
| `pnpm typecheck` | **0 errors**, rc=0 |
| typecheck of the two `__tests__` files (excluded by `tsconfig`) | **0 errors in my files**; run deliberately via a temp config that drops `src/**/__tests__/**`. That run reports 928 errors in *other* pre-existing `__tests__` files — which is why the exclusion exists, and which doubles as the positive control that this invocation *can* go red. |
| `pnpm test:unit:run` | **22226 passed, 0 failed**, 25 skipped. 1 suite-level failure: `feature-flags.early-adopter.seam.test.ts`, `TSConfckParseError` on `apps/auth/.svelte-kit/tsconfig.json`. **Control: fails identically in a pristine base worktree** — a fresh-worktree artifact (no `svelte-kit sync`), not this change. |
| `pnpm test:component` (HEAD) | **2039 passed, 0 individual test failures**; 8 suite-level failures. |
| `pnpm test:component` (pristine base, control) | **1943 passed, 25 failed**, 13 suite-level failures — i.e. the base tree is *noisier* than this branch. |
| the three files this change touches, in isolation | **130/130 passed** (`AppListingDetailBody`, `AppBlockCard`, `AppDetailsModal`) |

🔴 **On the component suite's suite-level failures — they do not converge, so I am not claiming a clean run.** Three full runs produced three different failing-file sets, with **zero individual test failures** in each:

- HEAD run 1: 2 files (incl. `ImagesAsPostsCardLazyCarousel` — the known-red), then a `Browser connection was closed` crash.
- HEAD run 2: 8 files, **0 individual test failures**, none touched by this change.
- pristine-base run: 13 files / **25 individual test failures** — the known-red carousel plus a cluster of unrelated notice/referral-persistence specs. **None of the three files this PR touches appears in that set.**

The base tree failing *harder* than this branch is the cleanest statement available: whatever is producing these is in the environment, not in the diff.

`AppsSubNav.ssrHydration.browser.test.tsx` was the sharpest example: it failed in HEAD's full run, then passed 5/5 in isolation at **both** HEAD and base, twice each. A real defect converges; this does not. The known-red `ImagesAsPostsCardLazyCarousel` (bisected to `d4c4a4e4cb`, #4365) appears at base too — noted and not chased.

## 6. Environment note for anyone reproducing this

`pnpm test:component` does **not** run on this NixOS host out of the box, and it fails in the way that reads as "nothing to see": `PLAYWRIGHT_BROWSERS_PATH` provides `chromium_headless_shell-1228` while the repo's playwright pin wants `1200`, so vitest collects all 189 files and executes **none**, reporting `Tests no tests`. The `1200` in `~/.cache/ms-playwright` is an unpatched generic-linux binary that cannot exec here. The fix is the escape hatch already documented in `vitest.config.mts:395` — point `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` at the nix bundle's `chrome-headless-shell`. Fresh worktrees also need `packages/*/node_modules` and `apps/*/node_modules` symlinked, not just the top level.

## 7. Base

Branched directly off `origin/main` at `798d0893a9`. Not stacked. Re-fetched before opening: `origin/main` has advanced **22 commits / 168 files**, and the overlap with the 6 files this PR modifies is **zero** — measured, not assumed — so no rebase is needed.
