### PR TITLE
docs(xguard): hand out the inbound-only token, not the platform-wide one

### DIFF
--- a/apps/moderator/src/routes/xguard/docs/+page.svelte
+++ b/apps/moderator/src/routes/xguard/docs/+page.svelte
@@ -55,8 +55,11 @@
     <h2 class="mb-1 text-base font-semibold text-white">Getting access</h2>
     <ol class="ml-4 list-decimal text-sm text-dark-2">
       <li class="mb-1">
-        Ask a moderator admin for <code class="font-mono text-dark-1">WEBHOOK_TOKEN</code>. It is the
-        shared service secret the moderator app already uses, not a per-person credential.
+        Ask a moderator admin for <code class="font-mono text-dark-1">MOD_INBOUND_TOKEN</code>. It
+        is a service secret, not a per-person credential — but it is <strong>inbound-only</strong>:
+        this app accepts it and nothing else does, so it cannot be used anywhere but here. Ask for
+        this one. <code class="font-mono text-dark-1">WEBHOOK_TOKEN</code> is also accepted for
+        compatibility and reaches further than this app, so it is the wrong thing to hand out.
       </li>
       <li class="mb-1">
         Send it as <code class="font-mono text-dark-1">?token=</code> or
@@ -68,7 +71,7 @@
         only way to revoke access is to rotate the token for everyone.
       </li>
     </ol>
-    <pre class="mt-3 overflow-x-auto rounded-lg bg-dark-8 p-3 font-mono text-xs text-dark-1">curl -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+    <pre class="mt-3 overflow-x-auto rounded-lg bg-dark-8 p-3 font-mono text-xs text-dark-1">curl -H "Authorization: Bearer $MOD_INBOUND_TOKEN" \
   https://moderator.civitai.com/api/xguard/me</pre>
   </section>
 

--- a/apps/moderator/src/routes/xguard/docs/__tests__/credential-handed-out.test.ts
+++ b/apps/moderator/src/routes/xguard/docs/__tests__/credential-handed-out.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * WHICH credential the XGuard docs tell an operator to ask for.
+ *
+ * 🔴 This page is the human distribution channel for a service token, so what it names is what
+ * people end up holding. It told operators to ask for `WEBHOOK_TOKEN` — which this app accepts, so
+ * nothing was broken and nothing failed — but that token is shared with the main app, while
+ * `MOD_INBOUND_TOKEN` is accepted here and nowhere else. XGuard's API is an inbound-only consumer,
+ * so every operator onboarded through this page was handed more reach than the job needs.
+ *
+ * 🔴 DELIBERATELY NOT `expect(page).not.toMatch(/WEBHOOK_TOKEN/)`. The page names the legacy token
+ * on purpose, to say why it is the wrong one to hand out — a blanket ban on the word would fail on
+ * the explanation and push a future editor to delete the very sentence that prevents the mistake.
+ * (That exact trap cost two rounds elsewhere in this app: a guard forbidding a string failed on the
+ * comment explaining the string.) Assert the INSTRUCTION and the COPY-PASTEABLE EXAMPLE — the two
+ * things an operator actually acts on.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const page = readFileSync(join(HERE, '../+page.svelte'), 'utf8');
+const readme = readFileSync(join(HERE, '../../../../../xguard-lab/README.md'), 'utf8');
+
+describe('the XGuard docs hand out the inbound-only token', () => {
+  it('the "ask for" instruction names MOD_INBOUND_TOKEN', () => {
+    const ask = /Ask a moderator admin for\s*<code[^>]*>([A-Z_]+)<\/code>/.exec(page);
+    expect(ask, 'the getting-access step must still name a specific variable').toBeTruthy();
+    expect(ask![1]).toBe('MOD_INBOUND_TOKEN');
+  });
+
+  it('the curl example an operator copies uses the same token', () => {
+    // The instruction and the example are edited independently; one updated without the other
+    // leaves the page telling you to ask for one credential and paste another.
+    const curl = /curl -H "Authorization: Bearer \$([A-Z_]+)"/.exec(page);
+    expect(curl, 'the page must still carry a copy-pasteable example').toBeTruthy();
+    expect(curl![1]).toBe('MOD_INBOUND_TOKEN');
+  });
+
+  it('the lab README points the same way, and says why', () => {
+    // Two surfaces, one instruction: an operator reaches either. The "why" is what stops the next
+    // editor "simplifying" back to the shared token because both work.
+    expect(readme).toMatch(/Hand out `MOD_INBOUND_TOKEN`, not `WEBHOOK_TOKEN`/);
+    expect(readme, 'the reason must survive, not just the name').toMatch(/inbound-only/);
+  });
+
+  it('the page still explains that the legacy token also works', () => {
+    // The positive half of the rule above. Deleting this explanation would make the page read as
+    // "only MOD_INBOUND_TOKEN is accepted", which is false while compatibility lasts and would send
+    // anyone debugging a working legacy caller down the wrong path.
+    expect(page).toMatch(/WEBHOOK_TOKEN/);
+  });
+});

--- a/apps/moderator/xguard-lab/README.md
+++ b/apps/moderator/xguard-lab/README.md
@@ -36,9 +36,16 @@ only `moderator:admin` can open the lab.
 ## Driving it from an agent
 
 Everything above except reviewing is also an HTTP endpoint under `/api/xguard/*`, each wrapped in
-`WebhookEndpoint` (`$lib/server/webhook-endpoint`) and authenticated with the shared `WEBHOOK_TOKEN`,
-sent as `?token=` or `Authorization: Bearer`. There is no user behind it: calls are not attributed to
-anybody, and revoking access means rotating the token for everyone holding it.
+`WebhookEndpoint` (`$lib/server/webhook-endpoint`), sent as `?token=` or `Authorization: Bearer`.
+There is no user behind it: calls are not attributed to anybody, and revoking access means rotating
+the token for everyone holding it.
+
+🔴 **Hand out `MOD_INBOUND_TOKEN`, not `WEBHOOK_TOKEN`.** Both are accepted — `acceptedTokens()` in
+`$lib/server/webhook-endpoint` returns both — but only the first is inbound-only: nothing outside
+this app accepts it, and nothing in this app sends it anywhere. `WEBHOOK_TOKEN` is shared with the
+main app and is kept accepted for compatibility while callers migrate. Since revocation here means
+rotating for every holder, which token an agent operator holds decides how much a rotation costs and
+how far a leak reaches.
 
 `/xguard/docs` is the operator guide, and its endpoint list is generated from the routes rather than
 written down. Read it there; a copy here would be the version that goes stale.
@@ -71,13 +78,13 @@ A refusal is not a verdict. Recording it as `false` would quietly bias the train
 
 The unit of work is a **(sample, label) pair**, not a sample. A prompt sampled today for age can be judged for sexual content next month without being re-sampled.
 
-| table | holds |
-|---|---|
-| `sample` | prompt text, live XGuard scores at sample time, which batch |
-| `label_def` / `label_policy` | the label set, and every revision of its policy prose |
-| `machine_judgement` | what XGuard or the AI rater said, with reason and highlight spans |
-| `human_judgement` | agree/disagree, resulting verdict, reviewer, time on item |
-| `ground_truth` (view) | current verdict per pair, with reviewer count and whether contested |
+| table                        | holds                                                               |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `sample`                     | prompt text, live XGuard scores at sample time, which batch         |
+| `label_def` / `label_policy` | the label set, and every revision of its policy prose               |
+| `machine_judgement`          | what XGuard or the AI rater said, with reason and highlight spans   |
+| `human_judgement`            | agree/disagree, resulting verdict, reviewer, time on item           |
+| `ground_truth` (view)        | current verdict per pair, with reviewer count and whether contested |
 
 Judgements reference an exact `label_policy` row, so editing a policy never silently rewrites past results. `duration_ms` is recorded because a reviewer averaging two seconds is rubber-stamping, and that only shows up if the number is honest.
 


### PR DESCRIPTION
## What

The XGuard docs page told operators *"Ask a moderator admin for `WEBHOOK_TOKEN`"*, with a matching curl example. It now names `MOD_INBOUND_TOKEN`, and `xguard-lab/README.md` says which to hand out **and why**.

## Why

That page is the **human distribution channel** for a service token, so what it names is what people end up holding.

Nothing was broken — this app accepts `WEBHOOK_TOKEN`, so every operator onboarded through it worked fine. But XGuard's API is an inbound-only consumer, and since #4326 there is a token that reaches this app and **nothing else**. The page was handing out more reach than the job needs, to everyone who read it.

Revocation here means rotating for **every** holder, so which token an operator holds decides what a rotation costs and how far a leak reaches.

## The guard deliberately does not ban the word

It would be natural to assert `not.toMatch(/WEBHOOK_TOKEN/)`. That would be wrong: the page names the legacy token **on purpose**, to say why it is the wrong one to ask for. A blanket ban would fail on that explanation and push a future editor to delete the sentence that prevents the mistake.

That exact trap cost two rounds elsewhere in this app this week — a guard forbidding a string failed on the comment explaining the string. So the test asserts the **instruction** and the **copy-pasteable example** (the two things an operator acts on), plus a **positive** assertion that the explanation survives.

## Verification

Mutation-verified, each killed by its own assertion, control clean, both files restored byte-identical:

| mutant | |
|---|---|
| revert the instruction to the shared token | KILLED |
| instruction updated, curl example left behind | **KILLED** ← the realistic half-edit |
| README keeps the name, loses the "why" | KILLED |
| strip the legacy-token explanation | **KILLED** ← page would read as "only one works" |

`app:moderator` 309 passed / 35 skipped · `svelte-check` 9379 files, 0 errors · prettier clean.

## Scope

Documentation only. **No deployment change and no behaviour change** — `acceptedTokens()` still returns both, so every existing caller keeps working. This changes which credential new operators are given.
