### PR TITLE
feat(chat): block members from chat menu, sync membership, fix system notes

### DIFF
--- a/src/components/Chat/ChatActions.tsx
+++ b/src/components/Chat/ChatActions.tsx
@@ -19,6 +19,7 @@ import {
 } from '@tabler/icons-react';
 import produce from 'immer';
 import React, { useState } from 'react';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { ChatAddMembersModal } from '~/components/Chat/ChatAddMembersModal';
 import { ChatRenameModal } from '~/components/Chat/ChatRenameModal';
 import { useChatStore } from '~/components/Chat/ChatProvider';
@@ -46,6 +47,11 @@ export const ChatActions = ({ chatObj }: { chatObj?: ChatListMessage }) => {
   // and have not been backfilled.
   const isGroup = !!chatObj?.isGroup || (chatObj?.chatMembers.length ?? 0) > 2;
   const isAdmin = isGroup && !!currentUser && chatObj?.ownerId === currentUser.id;
+  // Moderators are left out: blocking one severs the conversation the
+  // `cantLeave` guard exists to hold open.
+  const blockable =
+    chatObj?.chatMembers.filter((cm) => cm.userId !== currentUser?.id && !cm.user.isModerator) ??
+    [];
   const isMuted = myMember?.notifyLevel === ChatNotifyLevel.None;
   const isPinned = !!myMember?.pinnedAt;
 
@@ -221,6 +227,22 @@ export const ChatActions = ({ chatObj }: { chatObj?: ChatListMessage }) => {
             <Menu.Item leftSection={<IconFlag size={18} />} color="orange" onClick={reportModal}>
               Report
             </Menu.Item>
+            {blockable.length === 1 ? (
+              <BlockUserButton as="menu-item" userId={blockable[0].userId} />
+            ) : blockable.length > 1 ? (
+              <>
+                <Menu.Label>Block a member</Menu.Label>
+                {blockable.map((cm) => (
+                  <BlockUserButton
+                    key={cm.userId}
+                    as="menu-item"
+                    userId={cm.userId}
+                    label={`Block ${cm.user.username ?? `user ${cm.userId}`}`}
+                    unblockLabel={`Unblock ${cm.user.username ?? `user ${cm.userId}`}`}
+                  />
+                ))}
+              </>
+            ) : null}
             {isJoined && !isGroup && (
               <Menu.Item
                 leftSection={<IconArchive size={18} />}
@@ -264,9 +286,6 @@ export const ChatActions = ({ chatObj }: { chatObj?: ChatListMessage }) => {
                 {myMember.status === ChatMemberStatus.Ignored ? 'Unarchive' : 'Rejoin'}
               </Menu.Item>
             ) : undefined}
-
-            {/* TODO blocklist here? */}
-            {/*<Menu.Item>Manage blocklist</Menu.Item>*/}
           </Menu.Dropdown>
         </Menu>
       )}

--- a/src/components/Chat/ChatActionsV1.tsx
+++ b/src/components/Chat/ChatActionsV1.tsx
@@ -14,6 +14,7 @@ import {
 } from '@tabler/icons-react';
 import produce from 'immer';
 import React, { useState } from 'react';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { ChatAddMembersModal } from '~/components/Chat/ChatAddMembersModal';
 import { ChatRenameModal } from '~/components/Chat/ChatRenameModal';
 import { useChatStore } from '~/components/Chat/ChatProvider';
@@ -41,6 +42,11 @@ export const ChatActionsV1 = ({ chatObj }: { chatObj?: ChatListMessage }) => {
   // and have not been backfilled.
   const isGroup = !!chatObj?.isGroup || (chatObj?.chatMembers.length ?? 0) > 2;
   const isAdmin = isGroup && !!currentUser && chatObj?.ownerId === currentUser.id;
+  // Moderators are left out: blocking one severs the conversation the
+  // `cantLeave` guard exists to hold open.
+  const blockable =
+    chatObj?.chatMembers.filter((cm) => cm.userId !== currentUser?.id && !cm.user.isModerator) ??
+    [];
 
   const { mutate: modifyMembership } = trpc.chat.modifyUser.useMutation({
     onSuccess(data, req) {
@@ -161,6 +167,22 @@ export const ChatActionsV1 = ({ chatObj }: { chatObj?: ChatListMessage }) => {
               <Menu.Item leftSection={<IconFlag size={18} />} color="orange" onClick={reportModal}>
                 Report
               </Menu.Item>
+              {blockable.length === 1 ? (
+                <BlockUserButton as="menu-item" userId={blockable[0].userId} />
+              ) : blockable.length > 1 ? (
+                <>
+                  <Menu.Label>Block a member</Menu.Label>
+                  {blockable.map((cm) => (
+                    <BlockUserButton
+                      key={cm.userId}
+                      as="menu-item"
+                      userId={cm.userId}
+                      label={`Block ${cm.user.username ?? `user ${cm.userId}`}`}
+                      unblockLabel={`Unblock ${cm.user.username ?? `user ${cm.userId}`}`}
+                    />
+                  ))}
+                </>
+              ) : null}
               {myMember?.status === ChatMemberStatus.Joined ? (
                 <Tooltip
                   label={
@@ -190,9 +212,6 @@ export const ChatActionsV1 = ({ chatObj }: { chatObj?: ChatListMessage }) => {
                 </Menu.Item>
               ) : undefined}
             </>
-
-            {/* TODO blocklist here? */}
-            {/*<Menu.Item>Manage blocklist</Menu.Item>*/}
           </Menu.Dropdown>
         </Menu>
       )}

--- a/src/components/Chat/ChatSignals.ts
+++ b/src/components/Chat/ChatSignals.ts
@@ -6,7 +6,11 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { SignalMessages } from '~/server/common/enums';
 import { ChatMessageType, ChatNotifyLevel } from '~/shared/utils/prisma/enums';
-import { reviveChatMessageDates, shouldNotifyForMessage } from '~/shared/utils/chat';
+import {
+  reviveChatMessageDates,
+  shouldNotifyForMessage,
+  upsertChatInList,
+} from '~/shared/utils/chat';
 import type { ChatAllMessages, ChatCreateChat } from '~/types/router';
 import { isApril1 } from '~/utils/date-helpers';
 import { trpc } from '~/utils/trpc';
@@ -208,6 +212,25 @@ export const useChatRoomUpdatedSignal = () => {
   useSignalConnection(SignalMessages.ChatRoomUpdated, onUpdate);
 };
 
+/**
+ * Somebody joined, was invited, left, was removed, or handed the group over.
+ *
+ * The payload is the chat id alone, so this refetches rather than patching:
+ * member rows are scoped per-recipient on the way out of `getAllByUser`, and a
+ * signal broadcast to the whole conversation has no per-recipient shape to
+ * carry them in. Without it the member list, the admin crown and the "you were
+ * removed" state only moved on a full page load.
+ */
+export const useChatMembersUpdatedSignal = () => {
+  const queryUtils = trpc.useUtils();
+
+  const onUpdate = useCallback(() => {
+    queryUtils.chat.getAllByUser.invalidate();
+  }, [queryUtils]);
+
+  useSignalConnection(SignalMessages.ChatMembersUpdated, onUpdate);
+};
+
 export const useChatNewRoomSignal = () => {
   const queryUtils = trpc.useUtils();
   const currentUser = useCurrentUser();
@@ -227,15 +250,14 @@ export const useChatNewRoomSignal = () => {
         return;
       }
 
-      queryUtils.chat.getAllByUser.setData(undefined, (old) => {
-        if (!old) return [updated];
-        return [{ ...updated, createdAt: new Date(updated.createdAt) }, ...old];
-      });
+      const revived = { ...updated, createdAt: new Date(updated.createdAt) };
+      queryUtils.chat.getAllByUser.setData(undefined, (old) => upsertChatInList(old, revived));
 
       queryUtils.chat.getUnreadCount.setData(
         undefined,
         produce((old) => {
           if (!old) return old;
+          if (old.some((c) => c.chatId === updated.id)) return old;
           old.push({ chatId: updated.id, cnt: 1 });
         })
       );

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -60,7 +60,7 @@ import { constants } from '~/server/common/constants';
 import { SignalMessages } from '~/server/common/enums';
 import type { isTypingOutput } from '~/server/schema/chat.schema';
 import { ChatMemberMenu } from '~/components/Chat/ChatMemberMenu';
-import { activeMemberStatuses } from '~/shared/utils/chat';
+import { activeMemberStatuses, formatChatSystemMessage } from '~/shared/utils/chat';
 import { ChatMemberStatus, ChatMessageType } from '~/shared/utils/prisma/enums';
 import type { ChatAllMessages } from '~/types/router';
 import { formatDate } from '~/utils/date-helpers';
@@ -1312,7 +1312,10 @@ function DisplayMessages({
                 ) : isSystemChat ? (
                   <Text className={classes.systemNote} component="div" size="xs">
                     <CustomMarkdown allowedElements={['a', 'p', 'strong']} unwrapDisallowed>
-                      {c.content.replace(currentUser?.username ?? '', 'You')}
+                      {formatChatSystemMessage({
+                        content: c.content,
+                        username: currentUser?.username,
+                      })}
                     </CustomMarkdown>
                   </Text>
                 ) : (

--- a/src/components/Chat/ExistingChatV1.tsx
+++ b/src/components/Chat/ExistingChatV1.tsx
@@ -57,7 +57,7 @@ import { constants } from '~/server/common/constants';
 import { SignalMessages } from '~/server/common/enums';
 import type { isTypingOutput } from '~/server/schema/chat.schema';
 import { ChatMemberMenu } from '~/components/Chat/ChatMemberMenu';
-import { activeMemberStatuses } from '~/shared/utils/chat';
+import { activeMemberStatuses, formatChatSystemMessage } from '~/shared/utils/chat';
 import { ChatMemberStatus, ChatMessageType } from '~/shared/utils/prisma/enums';
 import type { ChatAllMessages } from '~/types/router';
 import { formatDate } from '~/utils/date-helpers';
@@ -981,7 +981,10 @@ function DisplayMessages({
                   }}
                 >
                   <CustomMarkdown allowedElements={['a', 'p', 'strong']} unwrapDisallowed>
-                    {c.content.replace(currentUser?.username ?? '', 'You')}
+                    {formatChatSystemMessage({
+                      content: c.content,
+                      username: currentUser?.username,
+                    })}
                   </CustomMarkdown>
                 </Text>
               ) : (

--- a/src/components/HideUserButton/BlockUserButton.tsx
+++ b/src/components/HideUserButton/BlockUserButton.tsx
@@ -93,7 +93,7 @@ export function BlockUserButton({
           )
         }
       >
-        {isBlocked ? 'Unblock' : 'Block'} this user
+        {isBlocked ? unblockLabel ?? 'Unblock this user' : label ?? 'Block this user'}
       </Menu.Item>
     </LoginRedirect>
   );

--- a/src/components/Signals/SignalsRegistrar.tsx
+++ b/src/components/Signals/SignalsRegistrar.tsx
@@ -4,6 +4,7 @@ import { useBuzzSignalUpdate } from '~/components/Buzz/useBuzz';
 import { useCryptoDepositSignal } from '~/components/Signals/CryptoDepositSignal';
 import { useReferralSignals } from '~/components/Referrals/ReferralSignals';
 import {
+  useChatMembersUpdatedSignal,
   useChatMessageDeletedSignal,
   useChatMessageUpdatedSignal,
   useChatNewMessageSignal,
@@ -43,6 +44,7 @@ export function SignalsRegistrar() {
   useChatNewMessageSignal();
   useChatNewRoomSignal();
   useChatRoomUpdatedSignal();
+  useChatMembersUpdatedSignal();
   useChatMessageDeletedSignal();
   useChatMessageUpdatedSignal();
 

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -144,6 +144,7 @@ export enum SignalMessages {
   ChatMessageDeleted = 'chat:message-deleted',
   ChatMessageUpdated = 'chat:message-updated',
   ChatRoomUpdated = 'chat:room-updated',
+  ChatMembersUpdated = 'chat:members-updated',
   OrchestratorUpdate = 'orchestrator-job:status-update',
   TextToImageUpdate = 'orchestrator:text-to-image-update',
   WorkflowUpdate = 'orchestrator:workflow-update',

--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -42,6 +42,7 @@ import {
   createMessage,
   maxUsersPerChat,
   resolveChatRecipients,
+  signalChatMembersUpdated,
   upsertChat,
 } from '~/server/services/chat.service';
 import {
@@ -500,6 +501,10 @@ export const addUsersHandler = async ({
       userId: -1,
     });
 
+    // Last, so the refetch it triggers already sees the note above. The invitees
+    // are named because they only join the `chat:<id>` signals group on accept.
+    await signalChatMembersUpdated({ chatId: existing.id, userIds: allowed });
+
     return insertedChat;
   } catch (error) {
     if (error instanceof TRPCError) throw error;
@@ -624,6 +629,8 @@ export const modifyUserHandler = async ({
         userId: -1,
       });
 
+      await signalChatMembersUpdated({ chatId: existing.chat.id });
+
       return promoted;
     }
 
@@ -711,6 +718,14 @@ export const modifyUserHandler = async ({
         content: `${successor.username ?? `User ${successor.userId}`} is now the group admin`,
         userId: -1,
       });
+    }
+
+    // Emitted once, after every system note above, so a recipient's refetch sees
+    // the finished state. The member themselves is named because a leave or a
+    // kick already took them out of the `chat:<id>` signals group, and the
+    // broadcast alone would skip the one person who most needs to know.
+    if (statusChanged || successor) {
+      await signalChatMembersUpdated({ chatId: existing.chat.id, userIds: [existing.userId] });
     }
 
     return resp;

--- a/src/server/services/chat.service.ts
+++ b/src/server/services/chat.service.ts
@@ -151,6 +151,43 @@ export const assertChatNameAllowed = async (name: string | null) => {
   await throwOnBlockedMessagePattern(name);
 };
 
+/**
+ * Tell every side of a conversation that its membership moved.
+ *
+ * The payload is the chat id and nothing else. Member rows are per-recipient —
+ * `scopeMemberPrivacy` scrubs another member's `filteredAt`, `pinnedAt` and
+ * read receipt out of a query result — and a group broadcast has one body for
+ * everyone, so shipping the rows here would hand each member the fields the
+ * query deliberately withholds. Recipients refetch instead.
+ *
+ * `userIds` names people the group broadcast cannot reach: someone just removed
+ * (their signals group membership is already gone) or just invited (they only
+ * join the group on accept).
+ */
+export const signalChatMembersUpdated = async ({
+  chatId,
+  userIds = [],
+}: {
+  chatId: number;
+  userIds?: number[];
+}) => {
+  const body = JSON.stringify({ chatId });
+  const urls = [
+    `${env.SIGNALS_ENDPOINT}/groups/chat:${chatId}/signals/${SignalMessages.ChatMembersUpdated}`,
+    ...uniq(userIds).map(
+      (uid) => `${env.SIGNALS_ENDPOINT}/users/${uid}/signals/${SignalMessages.ChatMembersUpdated}`
+    ),
+  ];
+
+  await Promise.all(
+    urls.map((url) =>
+      withSignals(() =>
+        fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body })
+      ).catch(() => undefined)
+    )
+  );
+};
+
 export const upsertChat = async ({
   userIds,
   isGroup,

--- a/src/shared/utils/__tests__/chat-system-message.test.ts
+++ b/src/shared/utils/__tests__/chat-system-message.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { formatChatSystemMessage, upsertChatInList } from '~/shared/utils/chat';
+
+/**
+ * Chat feedback (868kwtpac): the system notes addressed the reader as "You"
+ * with a raw substring replace, which left the verb agreeing with the name it
+ * replaced — "You is now the group admin", "You was kicked".
+ */
+
+const forReader = (content: string, username?: string | null) =>
+  formatChatSystemMessage({ content, username });
+
+describe('formatChatSystemMessage', () => {
+  it.each([
+    ['alice is now the group admin', 'You are now the group admin'],
+    ['alice was kicked', 'You were kicked'],
+    ['alice was added', 'You were added'],
+    ['alice joined', 'You joined'],
+    ['alice left', 'You left'],
+  ])('conjugates %j for the person it is about', (content, expected) => {
+    expect(forReader(content, 'alice')).toBe(expected);
+  });
+
+  it('leaves a message about somebody else alone', () => {
+    expect(forReader('bob was kicked', 'alice')).toBe('bob was kicked');
+  });
+
+  it('rewrites the reader inside a list without touching an already-plural verb', () => {
+    expect(forReader('bob, alice, carol were added', 'alice')).toBe('bob, You, carol were added');
+  });
+
+  it('rewrites a reader who leads a list', () => {
+    expect(forReader('alice, bob were added', 'alice')).toBe('You, bob were added');
+  });
+
+  it('does not match a name that merely starts with the username', () => {
+    expect(forReader('alicia was kicked', 'alice')).toBe('alicia was kicked');
+    expect(forReader('alice2 joined', 'alice')).toBe('alice2 joined');
+  });
+
+  it('leaves the username alone when it is not the subject', () => {
+    expect(forReader('Group renamed to "alice"', 'alice')).toBe('Group renamed to "alice"');
+  });
+
+  it('returns the message untouched for a user with no username', () => {
+    // The old `content.replace('', 'You')` matched at position zero and produced
+    // "Youalice joined" for every system note.
+    expect(forReader('alice joined', '')).toBe('alice joined');
+    expect(forReader('alice joined', null)).toBe('alice joined');
+    expect(forReader('alice joined', undefined)).toBe('alice joined');
+  });
+
+  it('treats a username with regex characters as literal text', () => {
+    expect(forReader('a.c was kicked', 'a.c')).toBe('You were kicked');
+    expect(forReader('abc was kicked', 'a.c')).toBe('abc was kicked');
+  });
+});
+
+describe('upsertChatInList', () => {
+  it('prepends a conversation the reader does not have yet', () => {
+    expect(upsertChatInList([{ id: 1 }], { id: 2 })).toEqual([{ id: 2 }, { id: 1 }]);
+  });
+
+  it('starts the list when there is none', () => {
+    expect(upsertChatInList(undefined, { id: 2 })).toEqual([{ id: 2 }]);
+  });
+
+  it('replaces in place rather than duplicating a conversation already held', () => {
+    // Being invited back to a group you left replays `chat:new-room` for a
+    // conversation still in your list.
+    const list = [
+      { id: 1, name: 'a' },
+      { id: 2, name: 'b' },
+    ];
+    expect(upsertChatInList(list, { id: 2, name: 'renamed' })).toEqual([
+      { id: 1, name: 'a' },
+      { id: 2, name: 'renamed' },
+    ]);
+  });
+});

--- a/src/shared/utils/chat.ts
+++ b/src/shared/utils/chat.ts
@@ -85,6 +85,53 @@ function mentionsUser(content: string, username: string): boolean {
 }
 
 /**
+ * Place a conversation into the cached conversation list.
+ *
+ * `chat:new-room` is replayed when somebody who had left is invited back, and
+ * that reader still holds the conversation — prepending it a second time gave
+ * them two entries for one thread, one of which never updated again.
+ */
+export function upsertChatInList<T extends { id: number }>(list: T[] | undefined, chat: T): T[] {
+  if (!list) return [chat];
+  return list.some((c) => c.id === chat.id)
+    ? list.map((c) => (c.id === chat.id ? chat : c))
+    : [chat, ...list];
+}
+
+const youVerb: Record<string, string> = { is: 'are', was: 'were', has: 'have' };
+
+/**
+ * Render a system message ("<name> joined", "<name> was kicked") for one reader,
+ * addressing them as "You".
+ *
+ * The naive `content.replace(username, 'You')` this replaces produced
+ * "You is now the group admin" and "You was kicked", and — because
+ * `String.replace('')` matches at position zero — prefixed a bare "You" onto
+ * every system message for a user with no username.
+ *
+ * Only the leading subject is rewritten: the templates put the actor first,
+ * either alone or in a comma list, so a name anywhere else (a group renamed
+ * after somebody) is not the reader being addressed.
+ */
+export function formatChatSystemMessage({
+  content,
+  username,
+}: {
+  content: string;
+  username?: string | null;
+}): string {
+  if (!username) return content;
+
+  const escaped = username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const asSubject = new RegExp(`(^|, )${escaped}(?=$|[ ,])`, 'g');
+  const rewritten = content.replace(asSubject, '$1You');
+
+  // A plural subject already carries a plural verb, so a singular one here can
+  // only have belonged to the reader alone.
+  return rewritten.replace(/^You (is|was|has)\b/, (_, verb: string) => `You ${youVerb[verb]}`);
+}
+
+/**
  * What to write to the two mute columns for one membership change.
  *
  * They are written by different surfaces — the previous chat writes `isMuted`,


### PR DESCRIPTION
Adds per-member Block/Unblock entries to the chat actions menu (moderators excluded so the `cantLeave` guard still holds), and emits a new `chat:members-updated` signal on invite, join, leave, kick and admin handoff so member lists and admin state refresh without a page reload. System notes are now conjugated per reader via `formatChatSystemMessage` instead of a raw substring replace that produced "You is now the group admin" and prefixed "You" for users with no username, and re-invites upsert into the cached chat list rather than adding a duplicate entry.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kwtpac`). Reviewed locally before push.