### PR TITLE
fix(announcements): keep creator posts in the Announcements tab, unbreak the domain chips, clamp the window

### DIFF
--- a/apps/creator-studio/src/hooks.server.ts
+++ b/apps/creator-studio/src/hooks.server.ts
@@ -1,11 +1,30 @@
-import type { Handle, HandleServerError } from '@sveltejs/kit';
+import type { Handle, HandleServerError, ServerInit } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
+import { registerEnumArrayTypeParsers } from '@civitai/db/kysely';
 import { guard } from '$lib/server/auth';
+import { dbPool } from '$lib/server/db';
 import { getLogger } from '$lib/server/logger';
 
 const FALLBACK_REDIRECT = env.CIVITAI_APP_URL || 'https://civitai.com';
 
 console.info(`[creator-studio] version ${__APP_VERSION__}`);
+
+/**
+ * pg has no parser for arrays of a user-defined enum, so a `"SomeEnum"[]` column arrives as the raw
+ * Postgres literal `{a,b}` — a string where the Kysely type promises `string[]`. SvelteKit awaits
+ * `init` before it handles a request, which is the guarantee this needs: the parsers are in place
+ * before the first query rather than a few queries in.
+ *
+ * Fail-open, matching the main app's `instrumentation.node.ts`: a DB hiccup at boot must not stop the
+ * app serving. Read sites still have to tolerate the unparsed shape — see `getMyAnnouncements`.
+ */
+export const init: ServerInit = async () => {
+  try {
+    await registerEnumArrayTypeParsers(dbPool);
+  } catch (err) {
+    console.error('[creator-studio] enum-array type-parser registration failed (fail-open):', err);
+  }
+};
 
 // Prerendered at build (no cookie), so it must resolve before the gate.
 const PUBLIC_PATHS = new Set(['/favicon.svg']);

--- a/apps/creator-studio/src/hooks.server.ts
+++ b/apps/creator-studio/src/hooks.server.ts
@@ -10,13 +10,11 @@ const FALLBACK_REDIRECT = env.CIVITAI_APP_URL || 'https://civitai.com';
 console.info(`[creator-studio] version ${__APP_VERSION__}`);
 
 /**
- * pg has no parser for arrays of a user-defined enum, so a `"SomeEnum"[]` column arrives as the raw
- * Postgres literal `{a,b}` — a string where the Kysely type promises `string[]`. SvelteKit awaits
- * `init` before it handles a request, which is the guarantee this needs: the parsers are in place
- * before the first query rather than a few queries in.
+ * pg has no parser for arrays of a user-defined enum — see `toDomainArray`. `init` is awaited before
+ * the first request, which is why registration lives here and not at module scope.
  *
- * Fail-open, matching the main app's `instrumentation.node.ts`: a DB hiccup at boot must not stop the
- * app serving. Read sites still have to tolerate the unparsed shape — see `getMyAnnouncements`.
+ * Fail-open, matching `instrumentation.node.ts`: a DB hiccup at boot must not stop the app serving,
+ * so read sites still have to tolerate the unparsed shape.
  */
 export const init: ServerInit = async () => {
   try {

--- a/apps/creator-studio/src/lib/announcements.ts
+++ b/apps/creator-studio/src/lib/announcements.ts
@@ -3,7 +3,7 @@ import type { DomainColor } from '@civitai/db-schema/enums';
 // Mirrors upsertCreatorAnnouncementSchema in the main app (src/server/schema/announcement.schema.ts).
 // The endpoint rejects anything longer, so these must not drift upward without it.
 export const TITLE_MAX = 120;
-export const CONTENT_MAX = 5000;
+export const CONTENT_MAX = 500;
 export const LINK_TEXT_MAX = 40;
 
 export const DOMAIN_COLORS = [

--- a/apps/creator-studio/src/lib/announcements.ts
+++ b/apps/creator-studio/src/lib/announcements.ts
@@ -37,13 +37,45 @@ export const DEFAULT_DOMAINS: AnnouncementDomain[] = DOMAIN_CHIPS.map((c) => c.c
 
 // Labels for rendering an announcement's stored domains, including values the picker does not
 // offer — `all` is on every migrated profile banner, and `red` on anything written before this.
+//
+// The host IS the label: the colour names do not match the sites (see DOMAIN_CHIPS), so showing a
+// creator "green" or even "Civitai" leaves them guessing which of the two sites they picked.
 export const DOMAIN_LABELS: Record<AnnouncementDomain, { label: string; hint: string }> = {
-  green: { label: 'Civitai', hint: 'civitai.com' },
-  blue: { label: 'Civitai Red', hint: 'civitai.red' },
+  green: { label: 'civitai.com', hint: 'Civitai' },
+  blue: { label: 'civitai.red', hint: 'Civitai Red' },
   // Only reachable on rows written before the picker existed — no request resolves to this colour.
   red: { label: 'Unrouted', hint: 'no site resolves to this' },
   all: { label: 'Everywhere', hint: 'All domains' },
 };
+
+/**
+ * Normalises a `DomainColor[]` column into an array.
+ *
+ * pg has no parser for arrays of a user-defined enum, so unless `registerEnumArrayTypeParsers` has
+ * run this column arrives as the raw Postgres literal `{green,blue}` — a string that every array
+ * operation accepts and treats as its characters. `[...new Set(value)]` on it yielded one chip per
+ * distinct LETTER. `hooks.server.ts` registers the parser at boot, but does so fail-open, so this
+ * has to stand on its own.
+ */
+export function toDomainArray(value: unknown): string[] {
+  const list = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+    ? value.replace(/^\{|\}$/g, '').split(',')
+    : [];
+
+  return [...new Set(list.map((entry) => String(entry).trim()).filter(Boolean))];
+}
+
+/**
+ * Shortest announcement the server will store. The picker enforces it so the creator sees the
+ * constraint while choosing; `clampAnnouncementWindow` in the main app enforces it again on arrival,
+ * because a wall-clock picker cannot bind a value that is already minutes old when it is submitted.
+ *
+ * Must stay in step with MIN_ANNOUNCEMENT_DURATION_MS in
+ * src/server/services/creator-announcement.service.ts.
+ */
+export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
 
 export type AnnouncementAllowance = {
   eligible: boolean;

--- a/apps/creator-studio/src/lib/announcements.ts
+++ b/apps/creator-studio/src/lib/announcements.ts
@@ -37,9 +37,6 @@ export const DEFAULT_DOMAINS: AnnouncementDomain[] = DOMAIN_CHIPS.map((c) => c.c
 
 // Labels for rendering an announcement's stored domains, including values the picker does not
 // offer — `all` is on every migrated profile banner, and `red` on anything written before this.
-//
-// The host IS the label: the colour names do not match the sites (see DOMAIN_CHIPS), so showing a
-// creator "green" or even "Civitai" leaves them guessing which of the two sites they picked.
 export const DOMAIN_LABELS: Record<AnnouncementDomain, { label: string; hint: string }> = {
   green: { label: 'civitai.com', hint: 'Civitai' },
   blue: { label: 'civitai.red', hint: 'Civitai Red' },
@@ -49,13 +46,9 @@ export const DOMAIN_LABELS: Record<AnnouncementDomain, { label: string; hint: st
 };
 
 /**
- * Normalises a `DomainColor[]` column into an array.
- *
- * pg has no parser for arrays of a user-defined enum, so unless `registerEnumArrayTypeParsers` has
- * run this column arrives as the raw Postgres literal `{green,blue}` — a string that every array
- * operation accepts and treats as its characters. `[...new Set(value)]` on it yielded one chip per
- * distinct LETTER. `hooks.server.ts` registers the parser at boot, but does so fail-open, so this
- * has to stand on its own.
+ * Unless `registerEnumArrayTypeParsers` has run, pg hands a user-defined enum array back as the raw
+ * literal `{green,blue}` — and `[...new Set(value)]` on that string yielded one chip per LETTER.
+ * `hooks.server.ts` registers the parser at boot but fail-open, so this must stand on its own.
  */
 export function toDomainArray(value: unknown): string[] {
   const list = Array.isArray(value)
@@ -68,11 +61,8 @@ export function toDomainArray(value: unknown): string[] {
 }
 
 /**
- * Shortest announcement the server will store. The picker enforces it so the creator sees the
- * constraint while choosing; `clampAnnouncementWindow` in the main app enforces it again on arrival,
- * because a wall-clock picker cannot bind a value that is already minutes old when it is submitted.
- *
- * Must stay in step with MIN_ANNOUNCEMENT_DURATION_MS in
+ * Shortest announcement the server will store; the picker enforces it so the creator sees the
+ * constraint while choosing. Must stay in step with MIN_ANNOUNCEMENT_DURATION_MS in
  * src/server/services/creator-announcement.service.ts.
  */
 export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;

--- a/apps/creator-studio/src/lib/announcements.ts
+++ b/apps/creator-studio/src/lib/announcements.ts
@@ -61,8 +61,8 @@ export function toDomainArray(value: unknown): string[] {
   const list = Array.isArray(value)
     ? value
     : typeof value === 'string'
-    ? value.replace(/^\{|\}$/g, '').split(',')
-    : [];
+      ? value.replace(/^\{|\}$/g, '').split(',')
+      : [];
 
   return [...new Set(list.map((entry) => String(entry).trim()).filter(Boolean))];
 }

--- a/apps/creator-studio/src/lib/announcements.ts
+++ b/apps/creator-studio/src/lib/announcements.ts
@@ -4,6 +4,18 @@ import type { DomainColor } from '@civitai/db-schema/enums';
 // The endpoint rejects anything longer, so these must not drift upward without it.
 export const TITLE_MAX = 120;
 export const CONTENT_MAX = 500;
+/**
+ * The form's hard bound, deliberately ABOVE CONTENT_MAX.
+ *
+ * A migrated profile banner can already be longer than CONTENT_MAX through no act of its owner.
+ * Rejecting it here would stop it ever reaching the main app, which is what decides whether an
+ * over-long row may be saved (it may, if it is not being lengthened) — so this form would refuse a
+ * save the server would have allowed, and the owner could not edit their own card at all.
+ *
+ * Must stay in step with CREATOR_ANNOUNCEMENT_CONTENT_CEILING in
+ * src/server/schema/announcement.schema.ts.
+ */
+export const CONTENT_CEILING = 1500;
 export const LINK_TEXT_MAX = 40;
 
 export const DOMAIN_COLORS = [

--- a/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
@@ -118,7 +118,10 @@ describe('announcementFormSchema', () => {
     if (result.success) expect(result.data.content).toBe(legacy);
   });
 
-  it('still refuses a body past the hard ceiling', () => {
+  it('accepts a body at the ceiling and refuses one past it', () => {
+    // Both sides: `too long fails` alone is also true of a schema capped back at CONTENT_MAX,
+    // which is the regression this pair exists to catch.
+    expect(parse({ content: 'y'.repeat(CONTENT_CEILING) }).success).toBe(true);
     expect(parse({ content: 'y'.repeat(CONTENT_CEILING + 1) }).success).toBe(false);
   });
 

--- a/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
@@ -94,16 +94,19 @@ describe('announcementFormSchema', () => {
     expect(parse({ startsAt: 'sometime next week' }).success).toBe(false);
   });
 
-  it('rejects an end date at or before the start date', () => {
-    expect(
-      messages({
-        startsAt: '2026-09-01T10:00:00.000Z',
-        endsAt: '2026-08-01T10:00:00.000Z',
-      })
-    ).toContain('End date must be after the start date');
-    expect(
-      parse({ startsAt: '2026-08-01T10:00:00.000Z', endsAt: '2026-09-01T10:00:00.000Z' }).success
-    ).toBe(true);
+  // Ordering is the main app's to enforce, by sliding the end forward rather than refusing the save.
+  // Rejecting here would stop the value ever reaching that clamp.
+  it('passes an inverted window through for the server to clamp', () => {
+    const result = parse({
+      startsAt: '2026-09-01T10:00:00.000Z',
+      endsAt: '2026-08-01T10:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.startsAt?.toISOString()).toBe('2026-09-01T10:00:00.000Z');
+      expect(result.data.endsAt?.toISOString()).toBe('2026-08-01T10:00:00.000Z');
+    }
   });
 
   it('rejects a cover key that is not the uploader UUID', () => {

--- a/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
@@ -94,8 +94,6 @@ describe('announcementFormSchema', () => {
     expect(parse({ startsAt: 'sometime next week' }).success).toBe(false);
   });
 
-  // Ordering is the main app's to enforce, by sliding the end forward rather than refusing the save.
-  // Rejecting here would stop the value ever reaching that clamp.
   it('passes an inverted window through for the server to clamp', () => {
     const result = parse({
       startsAt: '2026-09-01T10:00:00.000Z',

--- a/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/announcement-form-schema.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { allowanceSchema, announcementFormSchema } from '../announcements-schema';
-import { DOMAIN_CHIPS } from '../../announcements';
+import { CONTENT_CEILING, DOMAIN_CHIPS } from '../../announcements';
 
 // A complete, valid submission as the action receives it — Object.fromEntries(FormData), so every
 // value is a string. Each test overrides only the field it is about.
@@ -105,6 +105,21 @@ describe('announcementFormSchema', () => {
       expect(result.data.startsAt?.toISOString()).toBe('2026-09-01T10:00:00.000Z');
       expect(result.data.endsAt?.toISOString()).toBe('2026-08-01T10:00:00.000Z');
     }
+  });
+
+  // A migrated profile banner can already exceed CONTENT_MAX through no act of its owner. Capping
+  // this form at CONTENT_MAX refused it before it ever reached the main app, which is the thing that
+  // decides whether an over-long row may be saved — so the owner could not edit their own card.
+  it('passes an over-limit legacy body through for the main app to judge', () => {
+    const legacy = 'y'.repeat(900);
+    const result = parse({ content: legacy });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.content).toBe(legacy);
+  });
+
+  it('still refuses a body past the hard ceiling', () => {
+    expect(parse({ content: 'y'.repeat(CONTENT_CEILING + 1) }).success).toBe(false);
   });
 
   it('rejects a cover key that is not the uploader UUID', () => {

--- a/apps/creator-studio/src/lib/server/__tests__/domain-array.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/domain-array.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from 'vitest';
-// Relative, not `$lib`: this project's node vitest has no SvelteKit plugin, and an aliased import
-// fails COLLECTION — which reads as zero tests rather than as a failure.
-import { DOMAIN_LABELS, toDomainArray } from '../../announcements';
+import { DOMAIN_LABELS, toDomainArray } from '$lib/announcements';
 
 describe('toDomainArray', () => {
   it('parses the raw Postgres literal pg hands back for an unparsed enum array', () => {

--- a/apps/creator-studio/src/lib/server/__tests__/domain-array.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/domain-array.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+// Relative, not `$lib`: this project's node vitest has no SvelteKit plugin, and an aliased import
+// fails COLLECTION — which reads as zero tests rather than as a failure.
+import { DOMAIN_LABELS, toDomainArray } from '../../announcements';
+
+describe('toDomainArray', () => {
+  it('parses the raw Postgres literal pg hands back for an unparsed enum array', () => {
+    // The bug this exists for: `[...new Set('{green,blue}')]` is ten single-character chips.
+    expect(toDomainArray('{green,blue}')).toEqual(['green', 'blue']);
+  });
+
+  it('parses a single-element literal', () => {
+    expect(toDomainArray('{all}')).toEqual(['all']);
+  });
+
+  it('yields nothing for an empty literal', () => {
+    expect(toDomainArray('{}')).toEqual([]);
+  });
+
+  it('passes a real array through, deduped', () => {
+    expect(toDomainArray(['green', 'blue', 'green'])).toEqual(['green', 'blue']);
+  });
+
+  it('yields nothing for null or undefined', () => {
+    expect(toDomainArray(null)).toEqual([]);
+    expect(toDomainArray(undefined)).toEqual([]);
+  });
+
+  it('never returns a value longer than the number of domains that exist', () => {
+    // A structural guard on the failure mode itself: any character-wise reading of a literal
+    // produces more entries than there are DomainColor values, whatever the spelling.
+    const parsed = toDomainArray('{green,blue}');
+
+    expect(parsed.length).toBeLessThanOrEqual(Object.keys(DOMAIN_LABELS).length);
+    expect(parsed.every((entry) => entry in DOMAIN_LABELS)).toBe(true);
+  });
+});
+
+describe('domain labels name the site, not the colour', () => {
+  it('renders the two pickable domains as their hosts', () => {
+    expect(DOMAIN_LABELS.green.label).toBe('civitai.com');
+    expect(DOMAIN_LABELS.blue.label).toBe('civitai.red');
+  });
+
+  it('never shows a raw colour name to a creator', () => {
+    const labels = Object.values(DOMAIN_LABELS).map((entry) => entry.label);
+
+    expect(labels).not.toContain('green');
+    expect(labels).not.toContain('blue');
+  });
+});

--- a/apps/creator-studio/src/lib/server/announcements-schema.ts
+++ b/apps/creator-studio/src/lib/server/announcements-schema.ts
@@ -63,10 +63,8 @@ export const announcementFormSchema = z
     message: 'A button needs both a link and button text',
     path: ['linkText'],
   });
-// Deliberately NOT refined on start/end ordering. The picker constrains both with `min`, and the
-// main app clamps whatever arrives (clampAnnouncementWindow) — a wall-clock value can be minutes
-// stale by the time it is submitted, and sliding it forward is the intended handling. Rejecting here
-// would turn that into an error the creator has to fix by hand, and the clamp would never run.
+// No start/end ordering refine: the main app slides the end forward (clampAnnouncementWindow);
+// rejecting here means the clamp never runs.
 
 export type AnnouncementForm = z.infer<typeof announcementFormSchema>;
 

--- a/apps/creator-studio/src/lib/server/announcements-schema.ts
+++ b/apps/creator-studio/src/lib/server/announcements-schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 // SvelteKit plugin and cannot resolve the alias — an aliased import fails COLLECTION, which reads as
 // zero tests rather than as a failure.
 import { checkbox, numberish } from './form-fields';
-import { CONTENT_MAX, DOMAIN_COLORS, LINK_TEXT_MAX, TITLE_MAX } from '../announcements';
+import { CONTENT_CEILING, DOMAIN_COLORS, LINK_TEXT_MAX, TITLE_MAX } from '../announcements';
 
 const optionalText = (max: number) =>
   z.preprocess(
@@ -37,7 +37,9 @@ export const announcementFormSchema = z
   .object({
     id: z.preprocess(numberish, z.number().int().positive().optional()),
     title: z.string().trim().min(1, 'Add a subject').max(TITLE_MAX),
-    content: z.string().trim().min(1, 'Add a message').max(CONTENT_MAX),
+    // CONTENT_CEILING, not CONTENT_MAX: the main app enforces the real limit and grandfathers rows
+    // that were already over it. Capping at CONTENT_MAX here would refuse those before they got there.
+    content: z.string().trim().min(1, 'Add a message').max(CONTENT_CEILING),
     domain: domainList,
     profileOnly: checkbox,
     startsAt: optionalDate,

--- a/apps/creator-studio/src/lib/server/announcements-schema.ts
+++ b/apps/creator-studio/src/lib/server/announcements-schema.ts
@@ -62,11 +62,11 @@ export const announcementFormSchema = z
   .refine((v) => !!v.linkUrl === !!v.linkText, {
     message: 'A button needs both a link and button text',
     path: ['linkText'],
-  })
-  .refine((v) => !v.startsAt || !v.endsAt || v.endsAt > v.startsAt, {
-    message: 'End date must be after the start date',
-    path: ['endsAt'],
   });
+// Deliberately NOT refined on start/end ordering. The picker constrains both with `min`, and the
+// main app clamps whatever arrives (clampAnnouncementWindow) — a wall-clock value can be minutes
+// stale by the time it is submitted, and sliding it forward is the intended handling. Rejecting here
+// would turn that into an error the creator has to fix by hand, and the clamp would never run.
 
 export type AnnouncementForm = z.infer<typeof announcementFormSchema>;
 

--- a/apps/creator-studio/src/lib/server/announcements.ts
+++ b/apps/creator-studio/src/lib/server/announcements.ts
@@ -2,7 +2,7 @@ import type { SessionUser } from '@civitai/auth';
 import { dbRead } from '$lib/server/db';
 import { callMainApp, type MainAppResult } from '$lib/server/main-app';
 import { getFlipt, fliptContext } from '$lib/server/flipt';
-import type { AnnouncementAllowance } from '$lib/announcements';
+import { toDomainArray, type AnnouncementAllowance } from '$lib/announcements';
 import { allowanceSchema, type AnnouncementForm } from './announcements-schema';
 
 // Announcement writes go through the MAIN APP, not kysely: the allowance check, the creator/sitewide
@@ -88,7 +88,7 @@ export async function getMyAnnouncements(userId: number): Promise<AnnouncementRo
       id: row.id,
       title: row.title,
       content: row.content,
-      domain: [...new Set(row.domain as string[])],
+      domain: toDomainArray(row.domain),
       startsAt: row.startsAt,
       endsAt: row.endsAt,
       disabled: row.disabled,

--- a/apps/creator-studio/src/lib/server/db.ts
+++ b/apps/creator-studio/src/lib/server/db.ts
@@ -9,8 +9,6 @@ function required(name: 'DATABASE_URL' | 'DATABASE_REPLICA_URL'): string {
   return value;
 }
 
-// `pool` is the primary pg pool: `hooks.server.ts`'s `init` needs it to register the enum-array type
-// parsers before the first query. See registerEnumArrayTypeParsers in @civitai/db/kysely.
 export const {
   dbRead,
   dbWrite,

--- a/apps/creator-studio/src/lib/server/db.ts
+++ b/apps/creator-studio/src/lib/server/db.ts
@@ -9,7 +9,13 @@ function required(name: 'DATABASE_URL' | 'DATABASE_REPLICA_URL'): string {
   return value;
 }
 
-export const { dbRead, dbWrite } = createKyselyClients<DB>({
+// `pool` is the primary pg pool: `hooks.server.ts`'s `init` needs it to register the enum-array type
+// parsers before the first query. See registerEnumArrayTypeParsers in @civitai/db/kysely.
+export const {
+  dbRead,
+  dbWrite,
+  pool: dbPool,
+} = createKyselyClients<DB>({
   connectionString: required('DATABASE_URL'),
   replicaConnectionString: required('DATABASE_REPLICA_URL'),
   sslNoVerify: true,

--- a/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
@@ -11,6 +11,7 @@
   import { ToggleGroup, ToggleGroupItem } from '@civitai/ui/components/ui/toggle-group/index.js';
   import { IconCheck } from '@tabler/icons-svelte';
   import {
+    CONTENT_CEILING,
     CONTENT_MAX,
     DEFAULT_DOMAINS,
     DOMAIN_CHIPS,
@@ -107,8 +108,8 @@
   const startsAt = $derived(toInstant(startsLocal));
   const endsAt = $derived(toInstant(endsLocal));
 
-  // Re-read on every keystroke in the pickers so the floor tracks the clock across a long compose,
-  // rather than freezing at whatever `now` was when the form mounted.
+  // Re-read whenever a date field is touched, so the floor is current at the moment the creator
+  // picks. It does NOT advance while they type elsewhere — the server clamp covers that.
   let clock = $state(Date.now());
 
   // An announcement that is already running legitimately started in the past, and a `min` above its
@@ -206,13 +207,15 @@
     <div class="flex flex-col gap-1.5">
       <div class="flex items-baseline justify-between gap-2">
         <Label for="announcement-content">Message</Label>
-        <span class="text-xs text-dark-2">{content.length}/{CONTENT_MAX}</span>
+        <span class={content.length > CONTENT_MAX ? 'text-xs text-red-300' : 'text-xs text-dark-2'}>
+          {content.length}/{CONTENT_MAX}
+        </span>
       </div>
       <Textarea
         id="announcement-content"
         name="content"
         bind:value={content}
-        maxlength={CONTENT_MAX}
+        maxlength={CONTENT_CEILING}
         rows={5}
         placeholder="Tell your followers what is happening."
         required

--- a/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
@@ -9,13 +9,16 @@
   import { Switch } from '@civitai/ui/components/ui/switch/index.js';
   import { Textarea } from '@civitai/ui/components/ui/textarea/index.js';
   import { ToggleGroup, ToggleGroupItem } from '@civitai/ui/components/ui/toggle-group/index.js';
+  import { IconCheck } from '@tabler/icons-svelte';
   import {
     CONTENT_MAX,
     DEFAULT_DOMAINS,
     DOMAIN_CHIPS,
     LINK_TEXT_MAX,
     TITLE_MAX,
+    MIN_ANNOUNCEMENT_DURATION_MS,
     allowanceState,
+    toDomainArray,
     type AnnouncementAllowance,
     type AnnouncementDomain,
   } from '$lib/announcements';
@@ -57,7 +60,9 @@
   let title = $state(seed?.title ?? '');
   let content = $state(seed?.content ?? '');
   let domains = $state<AnnouncementDomain[]>(
-    seed?.domain?.length ? [...new Set(seed.domain as AnnouncementDomain[])] : [...DEFAULT_DOMAINS]
+    seed?.domain?.length
+      ? (toDomainArray(seed.domain) as AnnouncementDomain[])
+      : [...DEFAULT_DOMAINS]
   );
   let profileOnly = $state(seed?.profileOnly ?? false);
   let startsLocal = $state(toLocalInput(seed?.startsAt));
@@ -101,6 +106,35 @@
 
   const startsAt = $derived(toInstant(startsLocal));
   const endsAt = $derived(toInstant(endsLocal));
+
+  // Re-read on every keystroke in the pickers so the floor tracks the clock across a long compose,
+  // rather than freezing at whatever `now` was when the form mounted.
+  let clock = $state(Date.now());
+
+  // An announcement that is already running legitimately started in the past, and a `min` above its
+  // own value makes the field invalid and blocks the form. Its existing start is the floor instead.
+  const startFloor = $derived(
+    seed?.startsAt && new Date(seed.startsAt).getTime() < clock
+      ? new Date(seed.startsAt)
+      : new Date(clock)
+  );
+  const startMin = $derived(toLocalInput(startFloor));
+  const endMin = $derived(
+    toLocalInput(
+      new Date(
+        (startsAt ? new Date(startsAt).getTime() : startFloor.getTime()) +
+          MIN_ANNOUNCEMENT_DURATION_MS
+      )
+    )
+  );
+
+  // Pull the end along rather than leaving an invalid value behind: moving the start past the end is
+  // the ordinary way to reach the state, and a picker that silently blocks submit reads as a bug.
+  function onStartChange() {
+    clock = Date.now();
+    if (!endsLocal) return;
+    if (endsLocal < endMin) endsLocal = endMin;
+  }
 
   const allowState = $derived(allowance ? allowanceState(allowance) : null);
   // A slot is spent on the profile-only → notifying transition, so editing an announcement that
@@ -197,27 +231,45 @@
         onValueChange={setDomains}
       >
         {#each DOMAIN_CHIPS as chip (chip.color)}
-          <ToggleGroupItem value={chip.color} aria-label={chip.label}>{chip.label}</ToggleGroupItem>
+          {@const selected = domains.includes(chip.color)}
+          <ToggleGroupItem
+            value={chip.color}
+            aria-label={`${chip.label} (${chip.host})`}
+            class="gap-1.5"
+          >
+            <!-- Reserved rather than conditionally rendered: the chip would otherwise resize as it is
+                 toggled, which moves its neighbour out from under the pointer. -->
+            <IconCheck size={14} class={selected ? '' : 'invisible'} aria-hidden="true" />
+            {chip.host}
+          </ToggleGroupItem>
         {/each}
       </ToggleGroup>
-      <span class="text-xs text-dark-2">
-        {DOMAIN_CHIPS.filter((c) => domains.includes(c.color))
-          .map((c) => c.host)
-          .join(' · ')}
-      </span>
     </fieldset>
 
     <div class="grid gap-4 sm:grid-cols-2">
       <div class="flex flex-col gap-1.5">
         <Label for="announcement-starts">Starts</Label>
-        <Input id="announcement-starts" type="datetime-local" bind:value={startsLocal} />
+        <Input
+          id="announcement-starts"
+          type="datetime-local"
+          min={startMin}
+          bind:value={startsLocal}
+          oninput={onStartChange}
+        />
       </div>
       <div class="flex flex-col gap-1.5">
         <Label for="announcement-ends">Ends</Label>
-        <Input id="announcement-ends" type="datetime-local" bind:value={endsLocal} />
+        <Input
+          id="announcement-ends"
+          type="datetime-local"
+          min={endMin}
+          bind:value={endsLocal}
+          oninput={() => (clock = Date.now())}
+        />
       </div>
       <span class="text-xs text-dark-2 sm:col-span-2">
         Your local time{timeZone ? ` (${timeZone})` : ''}. Leave both empty to show it from now on.
+        An announcement runs for at least an hour.
       </span>
     </div>
 

--- a/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
@@ -11,7 +11,6 @@
   import { ToggleGroup, ToggleGroupItem } from '@civitai/ui/components/ui/toggle-group/index.js';
   import { IconCheck } from '@tabler/icons-svelte';
   import {
-    CONTENT_CEILING,
     CONTENT_MAX,
     DEFAULT_DOMAINS,
     DOMAIN_CHIPS,
@@ -145,6 +144,10 @@
   // The migrated profile banners carry no subject, and the server requires one on every write.
   const needsTitle = $derived(!!seed && seed.title.trim() === '' && title.trim() === '');
 
+  // The ceiling is only for a row that was ALREADY over the limit when it was seeded. Raising the
+  // input's own bound for everyone replaces a keystroke-level stop with a round-trip that fails.
+  const contentMax = $derived(Math.max(CONTENT_MAX, seed?.content?.length ?? 0));
+
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   function setDomains(next: string[]) {
@@ -215,7 +218,7 @@
         id="announcement-content"
         name="content"
         bind:value={content}
-        maxlength={CONTENT_CEILING}
+        maxlength={contentMax}
         rows={5}
         placeholder="Tell your followers what is happening."
         required

--- a/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/AnnouncementComposer.svelte
@@ -128,8 +128,8 @@
     )
   );
 
-  // Pull the end along rather than leaving an invalid value behind: moving the start past the end is
-  // the ordinary way to reach the state, and a picker that silently blocks submit reads as a bug.
+  // Pull the end along; otherwise moving the start past the end leaves the field invalid and blocks
+  // submit with nothing on screen saying why.
   function onStartChange() {
     clock = Date.now();
     if (!endsLocal) return;

--- a/packages/civitai-db-queries/README.md
+++ b/packages/civitai-db-queries/README.md
@@ -134,8 +134,13 @@ inferred type says `Date`/`number`. Parse those fields where a real `Date`/`bigi
   INSERTs and `ON CONFLICT DO UPDATE` still set `updatedAt` explicitly.
 - **Postgres enum-ARRAY columns need a parser.** pg has no parser for an array of a user-defined enum (dynamic
   oid), so a `SomeEnum[]` column reads back as the raw `{a,b}` literal string. Consumers call
-  `registerEnumArrayTypeParsers(pool)` (from `@civitai/db/kysely`) once at startup (main app:
-  `src/instrumentation.node.ts`) so those columns parse to `string[]`. Scalar enums are fine without it.
+  `registerEnumArrayTypeParsers(pool)` (from `@civitai/db/kysely`) once at startup — main app:
+  `src/instrumentation.node.ts`; SvelteKit spokes: a `ServerInit` `init` export in `hooks.server.ts`
+  (SvelteKit awaits `init` before the first request), using the `pool` returned by
+  `createKyselyClients`. Both register **fail-open**, so a read site that can receive an enum-array
+  column must still tolerate the raw literal — `{green,blue}` is a string that every array operation
+  accepts and iterates by character (see `toDomainArray` in `apps/creator-studio/src/lib/announcements.ts`).
+  Scalar enums are fine without it.
 - **Nested writes** (Prisma `connect`/`connectOrCreate`/nested `create`): decompose into explicit statement
   functions, and have a compose function open `db.transaction().execute((trx) => …)` and pass `trx` as each
   statement's `db`. See **Tag links** below for the canonical example.

--- a/packages/civitai-db/README.md
+++ b/packages/civitai-db/README.md
@@ -25,7 +25,7 @@ directly (e.g. `import { sql } from 'kysely'`).
 | Import | Returns | Env | Use when |
 |---|---|---|---|
 | `@civitai/db` (`createPrismaClients`) | `{ dbRead, dbWrite }` Prisma clients | **Requires** the full DB env set (below) | App uses Prisma |
-| `@civitai/db/kysely` (`createKyselyClients<DB>`) | `{ dbRead, dbWrite }` or `{ db }` Kysely clients | **None** — connection config is explicit | App uses Kysely (lighter; no Prisma engine) |
+| `@civitai/db/kysely` (`createKyselyClients<DB>`) | `{ dbRead, dbWrite, pool }` or `{ db, pool }` Kysely clients — `pool` is the primary pg pool | **None** — connection config is explicit | App uses Kysely (lighter; no Prisma engine) |
 
 The `/kysely` subpath imports only `kysely` + `pg` (never Prisma), so a Vite/SSR app can use it without
 pulling the Prisma engine.
@@ -52,8 +52,12 @@ export const { dbRead, dbWrite } = createKyselyClients<DB>({
 });
 ```
 
-Other shapes: `singleClient: true` → `{ db }` (no replica / read-your-writes); or pass pre-built
+Other shapes: `singleClient: true` → `{ db, pool }` (no replica / read-your-writes); or pass pre-built
 `pool` / `readPool` (e.g. the main app's `getClient()` pools) for full control.
+
+The returned `pool` is the **primary** pg pool backing `dbWrite`, handed back for startup work that
+needs a pool rather than a Kysely instance — `registerEnumArrayTypeParsers` being the one that exists.
+Kysely does not expose its dialect's pool.
 
 ## Gotchas
 

--- a/packages/civitai-db/src/kysely.ts
+++ b/packages/civitai-db/src/kysely.ts
@@ -78,10 +78,8 @@ function forceSslNoVerify(connectionString?: string): string | undefined {
 }
 
 /**
- * `pool` is the PRIMARY pg pool backing `dbWrite`, handed back so a caller can run the startup work
- * that needs a pool rather than a Kysely instance — `registerEnumArrayTypeParsers` above being the
- * one that exists. Kysely does not expose its dialect's pool, and an app that builds its own to get
- * one has to re-derive the SSL and sizing config this factory owns.
+ * `pool` is the PRIMARY pg pool backing `dbWrite`. Handed back because Kysely does not expose its
+ * dialect's pool, and an app that builds its own re-derives the SSL and sizing config this factory owns.
  */
 export type KyselyReadWrite<DB> = { dbRead: Kysely<DB>; dbWrite: Kysely<DB>; pool: Pool };
 

--- a/packages/civitai-db/src/kysely.ts
+++ b/packages/civitai-db/src/kysely.ts
@@ -77,7 +77,13 @@ function forceSslNoVerify(connectionString?: string): string | undefined {
   return url.toString();
 }
 
-export type KyselyReadWrite<DB> = { dbRead: Kysely<DB>; dbWrite: Kysely<DB> };
+/**
+ * `pool` is the PRIMARY pg pool backing `dbWrite`, handed back so a caller can run the startup work
+ * that needs a pool rather than a Kysely instance — `registerEnumArrayTypeParsers` above being the
+ * one that exists. Kysely does not expose its dialect's pool, and an app that builds its own to get
+ * one has to re-derive the SSL and sizing config this factory owns.
+ */
+export type KyselyReadWrite<DB> = { dbRead: Kysely<DB>; dbWrite: Kysely<DB>; pool: Pool };
 
 export interface CreateKyselyClientsOptions extends PoolConfig {
   /** Pre-built write pool (primary). Overrides connectionString. */
@@ -100,11 +106,11 @@ export interface CreateKyselyClientsOptions extends PoolConfig {
 
 export function createKyselyClients<DB>(
   options: CreateKyselyClientsOptions & { singleClient: true }
-): { db: Kysely<DB> };
+): { db: Kysely<DB>; pool: Pool };
 export function createKyselyClients<DB>(options?: CreateKyselyClientsOptions): KyselyReadWrite<DB>;
 export function createKyselyClients<DB>(
   options: CreateKyselyClientsOptions = {}
-): { db: Kysely<DB> } | KyselyReadWrite<DB> {
+): { db: Kysely<DB>; pool: Pool } | KyselyReadWrite<DB> {
   registerNumericTypeParsers();
 
   const {
@@ -157,12 +163,13 @@ export function createKyselyClients<DB>(
     return p;
   };
 
-  const primary = make(pool ?? guard(new Pool(config)));
-  if (singleClient) return { db: primary };
+  const primaryPool = pool ?? guard(new Pool(config));
+  const primary = make(primaryPool);
+  if (singleClient) return { db: primary, pool: primaryPool };
 
   const dbRead =
     readPool || replicaString
       ? make(readPool ?? guard(new Pool({ ...config, connectionString: replicaString })))
       : primary;
-  return { dbRead, dbWrite: primary };
+  return { dbRead, dbWrite: primary, pool: primaryPool };
 }

--- a/packages/civitai-ui/src/lib/components/ui/toggle/toggle.svelte
+++ b/packages/civitai-ui/src/lib/components/ui/toggle/toggle.svelte
@@ -7,7 +7,7 @@
 			variant: {
 				default: "bg-transparent",
 				outline:
-					"border-input hover:bg-accent hover:text-accent-foreground border bg-transparent shadow-xs",
+					"border-input hover:bg-accent/40 hover:text-accent-foreground data-[state=on]:hover:bg-accent/80 border bg-transparent shadow-xs",
 			},
 			size: {
 				default: "h-9 min-w-9 px-2",

--- a/src/server/notifications/__tests__/creator-announcement.notifications.test.ts
+++ b/src/server/notifications/__tests__/creator-announcement.notifications.test.ts
@@ -1,93 +1,37 @@
 import { describe, it, expect } from 'vitest';
 import { creatorAnnouncementNotifications } from '../creator-announcement.notifications';
-
-// This notification is a SQL string, so the properties worth pinning are the ones whose
-// absence is silent: a missing mute anti-join still sends (to people who muted), and a
-// missing profileOnly exclusion still sends (for rows that must notify nobody). Neither
-// failure shows up as an error anywhere — the notification just goes to the wrong people.
+import { notificationCategoryTypes } from '~/server/notifications/utils.notifications';
 
 const processor = creatorAnnouncementNotifications['creator-announcement'];
-const LAST_SENT = '2026-08-19T00:00:00.000Z';
 
-function query() {
-  const prepared = processor.prepareQuery?.({ lastSent: LAST_SENT } as never);
-  if (typeof prepared !== 'string') throw new Error('expected a SQL string');
-  return prepared.replace(/\s+/g, ' ');
-}
-
-describe('creator announcement fan-out', () => {
-  it('resolves the audience from followers at send time', () => {
-    const sql = query();
-
-    expect(sql).toContain('"UserEngagement"');
-    expect(sql).toMatch(/ue\."targetUserId" = la\.author_id AND ue\.type = 'Follow'/);
-    // Rows, not a query, is the shape this deliberately avoids: the allowlist caps at
-    // 50,000 and the largest eligible creator has more followers than that.
-    expect(sql).not.toContain('AnnouncementUser');
+describe('creator announcements do not fan out as notifications', () => {
+  // The revert this is here to catch is re-adding prepareQuery: send-notifications guards on
+  // `if (query)`, so a restored fan-out produces notifications again and nothing else changes.
+  it('has no fan-out query', () => {
+    expect(processor.prepareQuery).toBeUndefined();
   });
 
-  it('anti-joins the per-creator mute', () => {
-    const sql = query();
+  it('is absent from the notification settings page', () => {
+    const types = Object.values(notificationCategoryTypes)
+      .flat()
+      .map((entry) => entry.type);
 
-    expect(sql).toContain('"UserAnnouncementMute"');
-    expect(sql).toMatch(
-      /NOT EXISTS \( SELECT 1 FROM "UserAnnouncementMute" m WHERE m\."userId" = ue\."userId" AND m\."creatorId" = la\.author_id \)/
-    );
-  });
-
-  it('honours the category-wide off switch', () => {
-    // Whitespace is normalised before matching, but the repo's notification-settings
-    // polarity guard scans the raw SQL and only recognises the single-line spelling of
-    // this clause — so the shape here has to stay the shape that guard can see.
-    expect(query()).toMatch(
-      /NOT EXISTS \(SELECT 1 FROM "UserNotificationSettings" uns WHERE uns\."userId" = r\.recipient_id AND uns\.type = 'creator-announcement'\)/
-    );
-  });
-
-  it('never sends for a platform row or a profile-only row', () => {
-    const sql = query();
-
-    expect(sql).toContain('a."userId" IS NOT NULL');
-    expect(sql).toContain('a."profileOnly" = false');
-    expect(sql).toContain('a.disabled = false');
-  });
-
-  it('bounds the scan so a stale cursor cannot walk every announcement ever written', () => {
-    expect(query()).toContain("now() - INTERVAL '30 minutes'");
-  });
-
-  it('keys one notification per announcement per recipient', () => {
-    expect(query()).toContain("concat('creator-announcement:', details->>'announcementId')");
-  });
-
-  it('reads as an announcement, naming the creator and the subject', () => {
-    const { message, url } = processor.prepareMessage({
-      details: { username: 'mnemic', title: 'New LoRA is up', announcementId: 12, creatorId: 5 },
-    } as never);
-
-    expect(message).toBe('mnemic made an announcement: New LoRA is up. Check it out.');
-    expect(url).toContain('/user/mnemic');
-    expect(url).toContain('announcement=12');
+    expect(types).not.toContain('creator-announcement');
+    // A control: the list is populated, so the assertion above is not passing on an empty array.
+    expect(types.length).toBeGreaterThan(0);
   });
 });
 
-describe('blocks are honoured, as in every other follow-derived fan-out', () => {
-  it('ties each direction to its own type list, not merely to being present', () => {
-    const sql = query();
+describe('already-delivered notifications still render', () => {
+  // prepareMessage resolves at render time, so removing it would blank out every row already in
+  // users' inboxes rather than merely stopping new ones.
+  it('builds a message and a url from stored details', () => {
+    const message = processor.prepareMessage({
+      type: 'creator-announcement',
+      details: { username: 'alice', title: 'New LoRA', announcementId: 42 },
+    });
 
-    // 🔴 The asymmetry IS the semantics. Swapping the two arguments to notBlockedBetween
-    // leaves both direction pairs present and 'Block','Hide' still somewhere in the
-    // string, so assertions that check only for presence pass for the inverted clause.
-    // Each direction is pinned to its own type list here.
-    //
-    // The recipient blocking OR hiding the creator stops it.
-    expect(sql).toMatch(
-      /blk\."userId" = ue\."userId" AND blk\."targetUserId" = la\.author_id AND blk\.type IN \('Block', 'Hide'\)/
-    );
-    // The creator's side stops it only on a Block — hiding a follower is not a request to
-    // stop being announced to.
-    expect(sql).toMatch(
-      /blk\."userId" = la\.author_id AND blk\."targetUserId" = ue\."userId" AND blk\.type = 'Block'/
-    );
+    expect(message?.message).toBe('alice made an announcement: New LoRA. Check it out.');
+    expect(message?.url).toBe('/user/alice?announcement=42');
   });
 });

--- a/src/server/notifications/__tests__/creator-announcement.notifications.test.ts
+++ b/src/server/notifications/__tests__/creator-announcement.notifications.test.ts
@@ -5,8 +5,7 @@ import { notificationCategoryTypes } from '~/server/notifications/utils.notifica
 const processor = creatorAnnouncementNotifications['creator-announcement'];
 
 describe('creator announcements do not fan out as notifications', () => {
-  // The revert this is here to catch is re-adding prepareQuery: send-notifications guards on
-  // `if (query)`, so a restored fan-out produces notifications again and nothing else changes.
+  // send-notifications guards on `if (query)` — re-adding prepareQuery silently restores the fan-out.
   it('has no fan-out query', () => {
     expect(processor.prepareQuery).toBeUndefined();
   });
@@ -23,8 +22,6 @@ describe('creator announcements do not fan out as notifications', () => {
 });
 
 describe('already-delivered notifications still render', () => {
-  // prepareMessage resolves at render time, so removing it would blank out every row already in
-  // users' inboxes rather than merely stopping new ones.
   it('builds a message and a url from stored details', () => {
     const message = processor.prepareMessage({
       type: 'creator-announcement',

--- a/src/server/notifications/creator-announcement.notifications.ts
+++ b/src/server/notifications/creator-announcement.notifications.ts
@@ -2,13 +2,9 @@ import { NotificationCategory } from '~/server/common/enums';
 import { createNotificationProcessor } from '~/server/notifications/base.notifications';
 
 export const creatorAnnouncementNotifications = createNotificationProcessor({
-  // No longer sent — a creator's announcement reaches followers through the Announcements tab
-  // (`getFollowedAnnouncements`), which resolves the audience at read time. Fanning out a second
-  // copy into Updates put the same announcement in two places and buried the tab that owns it.
-  //
-  // Kept, rather than deleted, because getNotificationMessage resolves at render time: dropping the
-  // entry would blank out every notification already delivered. `toggleable: false` retires its
-  // checkbox from the settings page, since there is no longer anything to toggle.
+  // No longer fanned out — followers get these from the Announcements tab (`getFollowedAnnouncements`).
+  // The entry stays because getNotificationMessage resolves at render time: deleting it would blank
+  // out every notification already delivered.
   'creator-announcement': {
     displayName: 'Announcements from creators you follow',
     category: NotificationCategory.Update,

--- a/src/server/notifications/creator-announcement.notifications.ts
+++ b/src/server/notifications/creator-announcement.notifications.ts
@@ -1,79 +1,21 @@
 import { NotificationCategory } from '~/server/common/enums';
-import {
-  createNotificationProcessor,
-  notBlockedBetween,
-} from '~/server/notifications/base.notifications';
+import { createNotificationProcessor } from '~/server/notifications/base.notifications';
 
 export const creatorAnnouncementNotifications = createNotificationProcessor({
+  // No longer sent — a creator's announcement reaches followers through the Announcements tab
+  // (`getFollowedAnnouncements`), which resolves the audience at read time. Fanning out a second
+  // copy into Updates put the same announcement in two places and buried the tab that owns it.
+  //
+  // Kept, rather than deleted, because getNotificationMessage resolves at render time: dropping the
+  // entry would blank out every notification already delivered. `toggleable: false` retires its
+  // checkbox from the settings page, since there is no longer anything to toggle.
   'creator-announcement': {
     displayName: 'Announcements from creators you follow',
     category: NotificationCategory.Update,
+    toggleable: false,
     prepareMessage: ({ details }) => ({
       message: `${details.username} made an announcement: ${details.title}. Check it out.`,
       url: `/user/${details.username}?announcement=${details.announcementId}`,
     }),
-    /**
-     * Fans out to the author's followers.
-     *
-     * Audience is resolved here rather than materialised at save time: the allowlist
-     * `AnnouncementUser` caps at 50,000 rows and the largest eligible creator already has
-     * 53,085 followers, so rows cannot express the audience at all — and a creator who
-     * gains followers between writing and going live should reach them too.
-     *
-     * `profileOnly` rows are excluded: those are the migrated profile banners and anything
-     * a creator pins to their own profile. They notify nobody by definition.
-     */
-    prepareQuery: ({ lastSent }) => `
-      WITH live_announcements AS (
-        SELECT
-          a.id announcement_id,
-          a."userId" author_id,
-          a.title,
-          u.username
-        FROM "Announcement" a
-        JOIN "User" u ON u.id = a."userId"
-        WHERE a."userId" IS NOT NULL
-          AND a."profileOnly" = false
-          AND a.disabled = false
-          AND COALESCE(a."startsAt", a."createdAt") >= '${lastSent}'
-          AND COALESCE(a."startsAt", a."createdAt") < now()
-          AND (a."endsAt" IS NULL OR a."endsAt" > now())
-          -- Wall-clock floor, matching new-model-version: a stale cursor must not turn
-          -- this into a scan of every announcement ever written.
-          AND COALESCE(a."startsAt", a."createdAt") > now() - INTERVAL '30 minutes'
-      ), recipients AS (
-        SELECT DISTINCT
-          ue."userId" recipient_id,
-          jsonb_build_object(
-            'announcementId', la.announcement_id,
-            'title', la.title,
-            'username', la.username,
-            'creatorId', la.author_id
-          ) details
-        FROM live_announcements la
-        -- Index-only scan on UserEngagement_type_targetUserId_idx, which exists in prod
-        -- but is NOT declared in schema.full.prisma. A database built from the schema
-        -- alone seq-scans 11.7M rows here.
-        JOIN "UserEngagement" ue
-          ON ue."targetUserId" = la.author_id AND ue.type = 'Follow'
-        -- The per-creator escape hatch: silences one author without unfollowing them.
-        WHERE NOT EXISTS (
-          SELECT 1 FROM "UserAnnouncementMute" m
-          WHERE m."userId" = ue."userId" AND m."creatorId" = la.author_id
-        )
-          -- A follow predates the block that followed it, so the follow edge alone would
-          -- keep a blocked creator reaching this recipient. Every other follow-derived
-          -- fan-out applies this.
-          AND ${notBlockedBetween('ue."userId"', 'la.author_id')}
-      )
-      SELECT
-        concat('creator-announcement:', details->>'announcementId') "key",
-        recipient_id "userId",
-        'creator-announcement' "type",
-        details
-      FROM recipients r
-      WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" uns
-        WHERE uns."userId" = r.recipient_id AND uns.type = 'creator-announcement')
-    `,
   },
 });

--- a/src/server/schema/announcement.schema.ts
+++ b/src/server/schema/announcement.schema.ts
@@ -86,10 +86,28 @@ export const getCurrentAnnouncementsSchema = z.object({
  *
  * `domain` IS creator-settable: DomainColor selects an audience, it does not widen reach.
  */
+/**
+ * An announcement is a short pointer at something else, and the card that renders it has no line
+ * clamp (`AnnouncementCard`) — whatever is stored is drawn in full, in a 710px drawer or a 540px
+ * `Container size="sm"`. 500 is about 7-11 lines there.
+ */
+export const CREATOR_ANNOUNCEMENT_CONTENT_MAX = 500;
+
+/**
+ * The schema's hard bound, deliberately ABOVE the limit above.
+ *
+ * The pending profile-banner backfill inserts 25,655 rows from `UserProfile.message`, and 8,757 of
+ * those are longer than 500 (measured on prod: p50 152, p99 1200, max 1232). Capping the schema at
+ * 500 would mean a creator opening their own migrated banner to fix a typo cannot save it at all.
+ * `assertContentLength` in the service enforces 500 on anything NEW or LENGTHENED instead, so an
+ * over-long legacy row can still be edited and shortened, just never grown.
+ */
+export const CREATOR_ANNOUNCEMENT_CONTENT_CEILING = 1500;
+
 export const upsertCreatorAnnouncementSchema = z.object({
   id: z.number().optional(),
   title: z.string().trim().min(1).max(120),
-  content: z.string().trim().min(1).max(5000),
+  content: z.string().trim().min(1).max(CREATOR_ANNOUNCEMENT_CONTENT_CEILING),
   emoji: z.string().max(8).optional(),
   color: z.string().max(32).optional(),
   domain: z.array(domainColorEnum).nonempty().default([DomainColor.all]),

--- a/src/server/services/__tests__/creator-announcement-boundary.test.ts
+++ b/src/server/services/__tests__/creator-announcement-boundary.test.ts
@@ -359,6 +359,8 @@ describe('the allowance cannot be walked around', () => {
       id: 9,
       coverId: null,
       profileOnly: true,
+      startsAt: null,
+      content: validInput.content,
     } as never);
 
     await upsertCreatorAnnouncement({ ...validInput, id: 9, profileOnly: false, userId: AUTHOR });
@@ -437,6 +439,8 @@ describe('the allowance cannot be walked around', () => {
       id: 9,
       coverId: null,
       profileOnly: true,
+      startsAt: null,
+      content: validInput.content,
     } as never);
     // The writer knows better: this row already flipped and already paid.
     tx.announcement.findUnique.mockResolvedValue({ profileOnly: false, spends: [{ id: 1 }] });
@@ -547,6 +551,8 @@ describe('a row crossing into notifying starts its life then', () => {
       id: 9,
       coverId: null,
       profileOnly: true,
+      startsAt: null,
+      content: validInput.content,
     } as never);
 
     const before = Date.now();
@@ -565,8 +571,12 @@ describe('a row crossing into notifying starts its life then', () => {
       id: 9,
       coverId: null,
       profileOnly: true,
+      startsAt: null,
+      content: validInput.content,
     } as never);
-    const scheduled = new Date('2026-12-01T00:00:00.000Z');
+    // Relative, not a literal: wiring clampAnnouncementWindow into the write path made this date
+    // live, and a fixed one silently becomes a past date that the clamp slides forward.
+    const scheduled = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
     await upsertCreatorAnnouncement({
       ...validInput,
@@ -706,12 +716,18 @@ describe('the write path actually applies the guards', () => {
 
     await upsertCreatorAnnouncement({ ...validInput, id: 9, content: legacy, userId: AUTHOR });
 
-    expect(dbMock.dbWrite.announcement.update).toHaveBeenCalled();
+    const data = (
+      dbMock.dbWrite.announcement.update.mock.calls[0][0] as { data: { content: string } }
+    ).data;
+    expect(data.content).toBe(legacy);
   });
 
   // The regression the unit test could not see: the composer round-trips a stored start through a
   // `datetime-local`, which truncates to the minute. Passing the SAME Date object on both sides
   // (as creator-announcement-window.test.ts does) never exercises that.
+  //
+  // This one pins the COMPARISON, not the wiring — with the clamp call deleted it still passes,
+  // because the unclamped value is the same. The three above are what catch an unwired guard.
   it('does not reschedule a running announcement the creator did not touch', async () => {
     const stored = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
     stored.setSeconds(37, 123);

--- a/src/server/services/__tests__/creator-announcement-boundary.test.ts
+++ b/src/server/services/__tests__/creator-announcement-boundary.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import { CREATOR_ANNOUNCEMENT_CONTENT_MAX } from '~/server/schema/announcement.schema';
 
 // The property under test is that a creator write cannot reach a sitewide surface, and it
 // is enforced structurally rather than by a check: the creator schema has no `metadata.type`
@@ -37,6 +38,7 @@ import {
   getCreatorAnnouncements,
   getFollowedAnnouncements,
   upsertCreatorAnnouncement,
+  MIN_ANNOUNCEMENT_DURATION_MS,
 } from '../creator-announcement.service';
 import { getAnnouncementAllowance } from '~/server/services/announcement-allowance.service';
 import { amIBlockedByUser } from '~/server/services/user.service';
@@ -79,10 +81,15 @@ beforeEach(() => {
   dbMock.dbWrite.announcement.delete.mockResolvedValue({ id: 1 } as never);
   dbMock.dbRead.announcement.findMany.mockResolvedValue([] as never);
   vi.mocked(amIBlockedByUser).mockResolvedValue(false as never);
+  // `startsAt` and `content` are selected by assertOwnedAnnouncement and drive the reschedule
+  // and legacy-length branches. Omitting them left both permanently undefined here — green,
+  // and blind to the two guards this file is the only place that drives.
   dbMock.dbRead.announcement.findFirst.mockResolvedValue({
     id: 1,
     coverId: null,
     profileOnly: false,
+    startsAt: null,
+    content: 'Trained on a fresh dataset.',
   } as never);
 });
 
@@ -547,9 +554,8 @@ describe('a row crossing into notifying starts its life then', () => {
 
     const data = (tx.announcement.update.mock.calls[0][0] as { data: { startsAt: Date } }).data;
 
-    // The fan-out selects COALESCE(startsAt, createdAt) inside a 30-minute floor. A draft
-    // written an hour ago keeps its old timestamp, is charged a slot, and is then picked
-    // up by nobody — the creator pays and reaches no one, with no error anywhere.
+    // `getFollowedAnnouncements` orders by startsAt desc NULLS LAST, so a draft that keeps its
+    // old timestamp is charged a slot and then sits at the bottom of every follower's feed.
     expect(data.startsAt).toBeInstanceOf(Date);
     expect(data.startsAt.getTime()).toBeGreaterThanOrEqual(before);
   });
@@ -630,5 +636,108 @@ describe('a link to one of our own domains becomes a path', () => {
 
   it('turns our bare domain into the site root rather than an empty string', () => {
     expect(toDomainRelativeLink('https://civitai-dev.green')).toBe('/');
+  });
+});
+
+// These drive `upsertCreatorAnnouncement` itself rather than the two guard functions, because the
+// unit tests beside them pass with the guards UNWIRED: deleting both calls from the service left
+// 347 files / 4814 tests green. Testing a pure function says nothing about whether anything calls it.
+describe('the write path actually applies the guards', () => {
+  const overLimit = 'x'.repeat(CREATOR_ANNOUNCEMENT_CONTENT_MAX + 1);
+
+  it('clamps a past start forward on the way to the database', async () => {
+    dbMock.dbRead.announcement.findFirst.mockResolvedValue(null as never);
+    const before = Date.now();
+
+    await upsertCreatorAnnouncement({
+      ...validInput,
+      profileOnly: true,
+      startsAt: new Date('2020-01-01T00:00:00.000Z'),
+      userId: AUTHOR,
+    });
+
+    const data = (
+      dbMock.dbWrite.announcement.create.mock.calls[0][0] as { data: { startsAt: Date } }
+    ).data;
+    expect(data.startsAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('pushes an end that does not clear the start by the minimum', async () => {
+    dbMock.dbRead.announcement.findFirst.mockResolvedValue(null as never);
+    const start = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    await upsertCreatorAnnouncement({
+      ...validInput,
+      profileOnly: true,
+      startsAt: start,
+      endsAt: new Date(start.getTime() + 60_000),
+      userId: AUTHOR,
+    });
+
+    const data = (dbMock.dbWrite.announcement.create.mock.calls[0][0] as { data: { endsAt: Date } })
+      .data;
+    expect(data.endsAt.getTime()).toBe(start.getTime() + MIN_ANNOUNCEMENT_DURATION_MS);
+  });
+
+  it('refuses over-limit content instead of writing it', async () => {
+    dbMock.dbRead.announcement.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      upsertCreatorAnnouncement({
+        ...validInput,
+        content: overLimit,
+        profileOnly: true,
+        userId: AUTHOR,
+      })
+    ).rejects.toThrow();
+
+    expect(dbMock.dbWrite.announcement.create).not.toHaveBeenCalled();
+  });
+
+  it('lets a row that was already over the limit be saved unchanged', async () => {
+    const legacy = 'y'.repeat(900);
+    dbMock.dbRead.announcement.findFirst.mockResolvedValue({
+      id: 9,
+      coverId: null,
+      profileOnly: false,
+      startsAt: null,
+      content: legacy,
+    } as never);
+
+    await upsertCreatorAnnouncement({ ...validInput, id: 9, content: legacy, userId: AUTHOR });
+
+    expect(dbMock.dbWrite.announcement.update).toHaveBeenCalled();
+  });
+
+  // The regression the unit test could not see: the composer round-trips a stored start through a
+  // `datetime-local`, which truncates to the minute. Passing the SAME Date object on both sides
+  // (as creator-announcement-window.test.ts does) never exercises that.
+  it('does not reschedule a running announcement the creator did not touch', async () => {
+    const stored = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+    stored.setSeconds(37, 123);
+    dbMock.dbRead.announcement.findFirst.mockResolvedValue({
+      id: 9,
+      coverId: null,
+      profileOnly: false,
+      startsAt: stored,
+      content: validInput.content,
+    } as never);
+
+    // Exactly what the picker hands back: same minute, seconds and milliseconds gone.
+    const roundTripped = new Date(stored);
+    roundTripped.setSeconds(0, 0);
+
+    await upsertCreatorAnnouncement({
+      ...validInput,
+      id: 9,
+      startsAt: roundTripped,
+      userId: AUTHOR,
+    });
+
+    const data = (
+      dbMock.dbWrite.announcement.update.mock.calls[0][0] as { data: { startsAt: Date } }
+    ).data;
+    expect(data.startsAt).toEqual(roundTripped);
+    expect(data.startsAt.getTime()).toBeLessThan(Date.now() - 60_000);
   });
 });

--- a/src/server/services/__tests__/creator-announcement-content-length.test.ts
+++ b/src/server/services/__tests__/creator-announcement-content-length.test.ts
@@ -67,7 +67,7 @@ describe('the limit itself', () => {
 
   // The spoke form must accept anything the main app might still allow, or a legacy over-limit row
   // is refused before it ever reaches the grandfather branch above.
-  it('is matched by a creator-studio ceiling no lower than ours', async () => {
+  it('is the same ceiling the creator-studio form bounds at', async () => {
     const { readFileSync } = await import('fs');
     const { fileURLToPath } = await import('url');
     const source = readFileSync(

--- a/src/server/services/__tests__/creator-announcement-content-length.test.ts
+++ b/src/server/services/__tests__/creator-announcement-content-length.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { assertContentLength } from '~/server/services/creator-announcement.service';
-import { CREATOR_ANNOUNCEMENT_CONTENT_MAX } from '~/server/schema/announcement.schema';
+import {
+  CREATOR_ANNOUNCEMENT_CONTENT_CEILING,
+  CREATOR_ANNOUNCEMENT_CONTENT_MAX,
+} from '~/server/schema/announcement.schema';
 
 const text = (length: number) => 'x'.repeat(length);
 const OVER = CREATOR_ANNOUNCEMENT_CONTENT_MAX + 1;
@@ -60,5 +63,23 @@ describe('the limit itself', () => {
 
     expect(declared, 'CONTENT_MAX not found in the creator-studio source').toBeDefined();
     expect(Number(declared)).toBe(CREATOR_ANNOUNCEMENT_CONTENT_MAX);
+  });
+
+  // The spoke form must accept anything the main app might still allow, or a legacy over-limit row
+  // is refused before it ever reaches the grandfather branch above.
+  it('is matched by a creator-studio ceiling no lower than ours', async () => {
+    const { readFileSync } = await import('fs');
+    const { fileURLToPath } = await import('url');
+    const source = readFileSync(
+      fileURLToPath(
+        new URL('../../../../apps/creator-studio/src/lib/announcements.ts', import.meta.url)
+      ),
+      'utf8'
+    );
+
+    const declared = source.match(/export const CONTENT_CEILING = (\d+);/)?.[1];
+
+    expect(declared, 'CONTENT_CEILING not found in the creator-studio source').toBeDefined();
+    expect(Number(declared)).toBe(CREATOR_ANNOUNCEMENT_CONTENT_CEILING);
   });
 });

--- a/src/server/services/__tests__/creator-announcement-content-length.test.ts
+++ b/src/server/services/__tests__/creator-announcement-content-length.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { assertContentLength } from '~/server/services/creator-announcement.service';
+import { CREATOR_ANNOUNCEMENT_CONTENT_MAX } from '~/server/schema/announcement.schema';
+
+const text = (length: number) => 'x'.repeat(length);
+const OVER = CREATOR_ANNOUNCEMENT_CONTENT_MAX + 1;
+
+describe('new content is held to the limit', () => {
+  it('accepts content at the limit', () => {
+    expect(() => assertContentLength(text(CREATOR_ANNOUNCEMENT_CONTENT_MAX))).not.toThrow();
+  });
+
+  it('refuses content one character over', () => {
+    expect(() => assertContentLength(text(OVER))).toThrow(
+      new RegExp(String(CREATOR_ANNOUNCEMENT_CONTENT_MAX))
+    );
+  });
+});
+
+describe('a row that was already over the limit stays editable', () => {
+  // The pending profile-banner backfill inserts rows from UserProfile.message, thousands of which
+  // are longer than the limit. Refusing every save would leave those creators unable to touch
+  // their own card — the revert this catches is dropping the previousContent branch.
+  it('allows an over-limit legacy row to be saved unchanged', () => {
+    const legacy = text(900);
+    expect(() => assertContentLength(legacy, legacy)).not.toThrow();
+  });
+
+  it('allows an over-limit legacy row to be shortened but still over', () => {
+    expect(() => assertContentLength(text(700), text(900))).not.toThrow();
+  });
+
+  it('refuses growing an over-limit legacy row', () => {
+    expect(() => assertContentLength(text(901), text(900))).toThrow();
+  });
+
+  it('does not let a short row grow past the limit just because it has a previous value', () => {
+    // The bug this catches is comparing against the limit instead of against the previous length:
+    // an ordinary edit must not inherit the legacy allowance.
+    expect(() => assertContentLength(text(OVER), text(100))).toThrow();
+  });
+});
+
+describe('the limit itself', () => {
+  it('is 500 — the card has no line clamp, so this is what renders in full', () => {
+    expect(CREATOR_ANNOUNCEMENT_CONTENT_MAX).toBe(500);
+  });
+
+  it('is the same number the creator-studio composer counts against', async () => {
+    const { readFileSync } = await import('fs');
+    const { fileURLToPath } = await import('url');
+    const source = readFileSync(
+      fileURLToPath(
+        new URL('../../../../apps/creator-studio/src/lib/announcements.ts', import.meta.url)
+      ),
+      'utf8'
+    );
+
+    const declared = source.match(/export const CONTENT_MAX = (\d+);/)?.[1];
+
+    expect(declared, 'CONTENT_MAX not found in the creator-studio source').toBeDefined();
+    expect(Number(declared)).toBe(CREATOR_ANNOUNCEMENT_CONTENT_MAX);
+  });
+});

--- a/src/server/services/__tests__/creator-announcement-window.test.ts
+++ b/src/server/services/__tests__/creator-announcement-window.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_ANNOUNCEMENT_DURATION_MS,
+  clampAnnouncementWindow,
+} from '~/server/services/creator-announcement.service';
+
+const NOW = new Date('2026-08-25T12:00:00.000Z');
+const at = (iso: string) => new Date(iso);
+const HOUR = 60 * 60 * 1000;
+
+describe('clampAnnouncementWindow — the start', () => {
+  it('slides a past start up to now', () => {
+    const { startsAt } = clampAnnouncementWindow({
+      startsAt: at('2026-08-25T11:45:00.000Z'),
+      now: NOW,
+    });
+
+    expect(startsAt).toEqual(NOW);
+  });
+
+  it('leaves a future start exactly where it was', () => {
+    const chosen = at('2026-08-26T09:00:00.000Z');
+    const { startsAt } = clampAnnouncementWindow({ startsAt: chosen, now: NOW });
+
+    expect(startsAt).toEqual(chosen);
+  });
+
+  it('keeps a null start null rather than pinning it to now', () => {
+    // Null means "from now on" and is what the composer sends for an open-ended announcement.
+    // Writing `now` instead would make the row sort above every other open-ended one forever.
+    expect(clampAnnouncementWindow({ startsAt: null, now: NOW }).startsAt).toBeNull();
+  });
+
+  it('does not re-stamp a running announcement the creator did not reschedule', () => {
+    // The revert this catches: dropping the `untouched` check. A typo fix on a live announcement
+    // would then move its start to now and republish it to the top of every follower's feed.
+    const live = at('2026-08-20T08:00:00.000Z');
+    const { startsAt } = clampAnnouncementWindow({
+      startsAt: live,
+      previousStartsAt: live,
+      now: NOW,
+    });
+
+    expect(startsAt).toEqual(live);
+  });
+
+  it('still slides when the creator moves a start to a different past time', () => {
+    const { startsAt } = clampAnnouncementWindow({
+      startsAt: at('2026-08-21T08:00:00.000Z'),
+      previousStartsAt: at('2026-08-20T08:00:00.000Z'),
+      now: NOW,
+    });
+
+    expect(startsAt).toEqual(NOW);
+  });
+});
+
+describe('clampAnnouncementWindow — the end', () => {
+  it('pushes an end that is before the start out to start + the minimum', () => {
+    const start = at('2026-08-26T09:00:00.000Z');
+    const { endsAt } = clampAnnouncementWindow({
+      startsAt: start,
+      endsAt: at('2026-08-25T09:00:00.000Z'),
+      now: NOW,
+    });
+
+    expect(endsAt).toEqual(new Date(start.getTime() + MIN_ANNOUNCEMENT_DURATION_MS));
+  });
+
+  it('pushes an end equal to the start out by the minimum', () => {
+    const start = at('2026-08-26T09:00:00.000Z');
+    const { endsAt } = clampAnnouncementWindow({ startsAt: start, endsAt: start, now: NOW });
+
+    expect(endsAt).toEqual(new Date(start.getTime() + MIN_ANNOUNCEMENT_DURATION_MS));
+  });
+
+  it('pushes an end that is under an hour after the start', () => {
+    const start = at('2026-08-26T09:00:00.000Z');
+    const { endsAt } = clampAnnouncementWindow({
+      startsAt: start,
+      endsAt: new Date(start.getTime() + 59 * 60 * 1000),
+      now: NOW,
+    });
+
+    expect(endsAt).toEqual(new Date(start.getTime() + HOUR));
+  });
+
+  it('leaves an end more than an hour out alone', () => {
+    const start = at('2026-08-26T09:00:00.000Z');
+    const chosen = new Date(start.getTime() + 3 * HOUR);
+    const { endsAt } = clampAnnouncementWindow({ startsAt: start, endsAt: chosen, now: NOW });
+
+    expect(endsAt).toEqual(chosen);
+  });
+
+  it('keeps a null end null — an announcement with no end runs indefinitely', () => {
+    expect(clampAnnouncementWindow({ startsAt: null, endsAt: null, now: NOW }).endsAt).toBeNull();
+  });
+
+  it('measures the minimum from the SLID start, not the submitted one', () => {
+    // Both dates are stale by the time they arrive. Measuring from the submitted start would store
+    // an end in the past, i.e. an announcement that is over before it is saved.
+    const { startsAt, endsAt } = clampAnnouncementWindow({
+      startsAt: at('2026-08-25T10:00:00.000Z'),
+      endsAt: at('2026-08-25T10:30:00.000Z'),
+      now: NOW,
+    });
+
+    expect(startsAt).toEqual(NOW);
+    expect(endsAt).toEqual(new Date(NOW.getTime() + HOUR));
+    expect(endsAt!.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it('floors a null-start announcement against now', () => {
+    const { endsAt } = clampAnnouncementWindow({
+      startsAt: null,
+      endsAt: at('2026-08-25T12:10:00.000Z'),
+      now: NOW,
+    });
+
+    expect(endsAt).toEqual(new Date(NOW.getTime() + HOUR));
+  });
+});
+
+describe('the minimum duration', () => {
+  it('is one hour, and the creator-studio picker mirrors this number', () => {
+    expect(MIN_ANNOUNCEMENT_DURATION_MS).toBe(HOUR);
+  });
+});

--- a/src/server/services/__tests__/creator-announcement-window.test.ts
+++ b/src/server/services/__tests__/creator-announcement-window.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
 import {
   MIN_ANNOUNCEMENT_DURATION_MS,
@@ -123,7 +125,29 @@ describe('clampAnnouncementWindow — the end', () => {
 });
 
 describe('the minimum duration', () => {
-  it('is one hour, and the creator-studio picker mirrors this number', () => {
+  it('is one hour', () => {
     expect(MIN_ANNOUNCEMENT_DURATION_MS).toBe(HOUR);
+  });
+
+  // The creator-studio picker cannot import this constant across the app boundary, so it keeps its
+  // own copy. Reading that file is the only thing that can catch the two drifting apart — a picker
+  // offering 30 minutes against a server that clamps to 60 silently slides every such save.
+  it('is the same number the creator-studio picker enforces', () => {
+    const source = readFileSync(
+      fileURLToPath(
+        new URL('../../../../apps/creator-studio/src/lib/announcements.ts', import.meta.url)
+      ),
+      'utf8'
+    );
+
+    const declaration = source.match(/export const MIN_ANNOUNCEMENT_DURATION_MS = ([^;]+);/)?.[1];
+
+    // Fail loudly if the constant was renamed or moved, rather than passing on a null match.
+    expect(
+      declaration,
+      'MIN_ANNOUNCEMENT_DURATION_MS not found in the creator-studio source'
+    ).toBeDefined();
+    // eslint-disable-next-line no-eval
+    expect(eval(declaration!)).toBe(MIN_ANNOUNCEMENT_DURATION_MS);
   });
 });

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -204,7 +204,7 @@ export async function getFollowedAnnouncements({
 async function assertOwnedAnnouncement(id: number, userId: number, isModerator = false) {
   const existing = await dbRead.announcement.findFirst({
     where: isModerator ? { id, userId: { not: null } } : { id, userId },
-    select: { id: true, coverId: true, profileOnly: true },
+    select: { id: true, coverId: true, profileOnly: true, startsAt: true },
   });
   if (!existing) throw throwAuthorizationError('Announcement not found');
   return existing;
@@ -234,6 +234,49 @@ export function toDomainRelativeLink(link: string) {
   if (!ours) return link;
 
   return `${url.pathname}${url.search}${url.hash}` || '/';
+}
+
+/**
+ * Shortest announcement we will store. Mirrored in apps/creator-studio/src/lib/announcements.ts,
+ * where the picker enforces the same floor while the creator is choosing.
+ */
+export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
+
+/**
+ * Slides a submitted window into the range we accept instead of refusing it.
+ *
+ * The picker is wall-clock: a creator who selects "in two minutes" and then spends five minutes
+ * writing the message submits a start that is already past. Refusing that is a dead end the creator
+ * cannot distinguish from a bug, so the start moves up to now and the end moves out to clear it by
+ * an hour.
+ *
+ * 🔴 A start the creator did not touch is left alone, even when it is in the past. Re-stamping it
+ * would republish a running announcement to the top of every follower's feed on an edit that only
+ * fixed a typo — `getFollowedAnnouncements` orders by `startsAt` desc.
+ *
+ * A null start still means "from now on" and stays null; only the end is then floored against now.
+ */
+export function clampAnnouncementWindow({
+  startsAt,
+  endsAt,
+  previousStartsAt,
+  now,
+}: {
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+  previousStartsAt?: Date | null;
+  now: Date;
+}): { startsAt: Date | null; endsAt: Date | null } {
+  const untouched =
+    !!startsAt && !!previousStartsAt && startsAt.getTime() === previousStartsAt.getTime();
+
+  const start =
+    startsAt && !untouched && startsAt.getTime() < now.getTime() ? now : startsAt ?? null;
+
+  const earliestEnd = (start ?? now).getTime() + MIN_ANNOUNCEMENT_DURATION_MS;
+  const end = endsAt && endsAt.getTime() < earliestEnd ? new Date(earliestEnd) : endsAt ?? null;
+
+  return { startsAt: start, endsAt: end };
 }
 
 export async function upsertCreatorAnnouncement({
@@ -279,14 +322,21 @@ export async function upsertCreatorAnnouncement({
       : {}),
   };
 
+  const window = clampAnnouncementWindow({
+    startsAt: input.startsAt,
+    endsAt: input.endsAt,
+    previousStartsAt: existing?.startsAt,
+    now: new Date(),
+  });
+
   const data = {
     title: input.title,
     content: input.content,
     emoji: input.emoji,
     color: input.color ?? 'blue',
     domain: input.domain,
-    startsAt: input.startsAt ?? null,
-    endsAt: input.endsAt ?? null,
+    startsAt: window.startsAt,
+    endsAt: window.endsAt,
     // Never written on an update. A creator cannot set `disabled` at all (the schema has
     // no such field), so a row a moderator took down stays down through any edit.
     ...(existing ? {} : { disabled: false }),
@@ -355,9 +405,9 @@ export async function upsertCreatorAnnouncement({
     const announcement = existing
       ? await tx.announcement.update({
           where: { id: existing.id },
-          // A row crossing into notifying starts its life now. The fan-out selects on
-          // COALESCE(startsAt, createdAt) inside a 30-minute floor, so a draft written
-          // an hour ago would be charged a slot and then picked up by nobody.
+          // A row crossing into notifying starts its life now. `getFollowedAnnouncements` orders
+          // by startsAt desc NULLS LAST, so a draft that keeps a null start is charged a slot and
+          // then lands at the bottom of every follower's feed.
           data: { ...data, startsAt: data.startsAt ?? new Date() },
           select: creatorAnnouncementSelect,
         })

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -254,6 +254,10 @@ export function assertContentLength(content: string, previousContent?: string) {
 
 export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
 
+const MINUTE_MS = 60_000;
+const sameMinute = (a: Date, b: Date) =>
+  Math.floor(a.getTime() / MINUTE_MS) === Math.floor(b.getTime() / MINUTE_MS);
+
 /**
  * The picker is wall-clock: a creator who selects "in two minutes" then spends five writing submits
  * a start that is already past. Refusing that is a dead end, so the start moves up to now and the
@@ -262,20 +266,17 @@ export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
  * 🔴 A start the creator did not touch is left alone even when past. Re-stamping it would
  * republish a running announcement to the top of every follower's feed on a typo fix —
  * `getFollowedAnnouncements` orders by `startsAt` desc.
- */
-/**
- * `datetime-local` cannot express seconds, so the composer round-trips a stored start through
- * `YYYY-MM-DDTHH:mm` and hands back a value truncated to the minute. Comparing exact timestamps
- * therefore reported "changed" for every row whose start carried seconds — which is precisely the
- * rows this protects, since a row crossing into notifying is stamped with `new Date()`.
  *
- * The picker cannot produce a sub-minute edit, so a real reschedule always differs by a whole
- * minute and this cannot mask one.
+ * "Did not touch" is compared at MINUTE granularity, not by exact timestamp. The composer
+ * round-trips a stored start through a `datetime-local`, whose `YYYY-MM-DDTHH:mm` IS a
+ * floor-to-the-minute — so a value derived that way always lands in the same bucket as the value it
+ * came from, whatever produced the original. That is a property of the transform, not of the
+ * widget, and it is what stops a row stamped `new Date()` (every row crossing into notifying) from
+ * reading as rescheduled on an edit that changed nothing.
+ *
+ * REST and tRPC accept arbitrary instants, so two starts under a minute apart CAN read as
+ * unchanged there. That direction leaves the start alone, which is the safe one.
  */
-const MINUTE_MS = 60_000;
-const sameMinute = (a: Date, b: Date) =>
-  Math.floor(a.getTime() / MINUTE_MS) === Math.floor(b.getTime() / MINUTE_MS);
-
 export function clampAnnouncementWindow({
   startsAt,
   endsAt,

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -128,9 +128,8 @@ export async function getCreatorAnnouncements({
 /**
  * The *Creators* chip: live announcements from authors the caller follows.
  *
- * Muted creators are absent entirely, not merely un-pinged. A mute that silenced the
- * notification but left the posts in the feed would not be the escape hatch the ticket
- * asked for — the follower would still be reading what they opted out of.
+ * Muted creators are absent entirely, not merely demoted — leaving their posts in the feed
+ * would not be the escape hatch the ticket asked for.
  *
  * Profile-only rows never appear here; that is what profile-only means.
  */
@@ -243,18 +242,13 @@ export function toDomainRelativeLink(link: string) {
 export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
 
 /**
- * Slides a submitted window into the range we accept instead of refusing it.
+ * The picker is wall-clock: a creator who selects "in two minutes" then spends five writing submits
+ * a start that is already past. Refusing that is a dead end, so the start moves up to now and the
+ * end out to clear it by an hour.
  *
- * The picker is wall-clock: a creator who selects "in two minutes" and then spends five minutes
- * writing the message submits a start that is already past. Refusing that is a dead end the creator
- * cannot distinguish from a bug, so the start moves up to now and the end moves out to clear it by
- * an hour.
- *
- * 🔴 A start the creator did not touch is left alone, even when it is in the past. Re-stamping it
- * would republish a running announcement to the top of every follower's feed on an edit that only
- * fixed a typo — `getFollowedAnnouncements` orders by `startsAt` desc.
- *
- * A null start still means "from now on" and stays null; only the end is then floored against now.
+ * 🔴 A start the creator did not touch is left alone even when past. Re-stamping it would
+ * republish a running announcement to the top of every follower's feed on a typo fix —
+ * `getFollowedAnnouncements` orders by `startsAt` desc.
  */
 export function clampAnnouncementWindow({
   startsAt,

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -237,10 +237,6 @@ export function toDomainRelativeLink(link: string) {
 }
 
 /**
- * Shortest announcement we will store. Mirrored in apps/creator-studio/src/lib/announcements.ts,
- * where the picker enforces the same floor while the creator is choosing.
- */
-/**
  * Enforces the content limit on new writing without trapping the rows that predate it.
  *
  * A migrated profile banner can be longer than the limit through no act of its owner, and
@@ -267,6 +263,19 @@ export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
  * republish a running announcement to the top of every follower's feed on a typo fix —
  * `getFollowedAnnouncements` orders by `startsAt` desc.
  */
+/**
+ * `datetime-local` cannot express seconds, so the composer round-trips a stored start through
+ * `YYYY-MM-DDTHH:mm` and hands back a value truncated to the minute. Comparing exact timestamps
+ * therefore reported "changed" for every row whose start carried seconds — which is precisely the
+ * rows this protects, since a row crossing into notifying is stamped with `new Date()`.
+ *
+ * The picker cannot produce a sub-minute edit, so a real reschedule always differs by a whole
+ * minute and this cannot mask one.
+ */
+const MINUTE_MS = 60_000;
+const sameMinute = (a: Date, b: Date) =>
+  Math.floor(a.getTime() / MINUTE_MS) === Math.floor(b.getTime() / MINUTE_MS);
+
 export function clampAnnouncementWindow({
   startsAt,
   endsAt,
@@ -278,8 +287,7 @@ export function clampAnnouncementWindow({
   previousStartsAt?: Date | null;
   now: Date;
 }): { startsAt: Date | null; endsAt: Date | null } {
-  const untouched =
-    !!startsAt && !!previousStartsAt && startsAt.getTime() === previousStartsAt.getTime();
+  const untouched = !!startsAt && !!previousStartsAt && sameMinute(startsAt, previousStartsAt);
 
   const start =
     startsAt && !untouched && startsAt.getTime() < now.getTime() ? now : startsAt ?? null;

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -322,7 +322,7 @@ export async function upsertCreatorAnnouncement({
       : {}),
   };
 
-  const window = clampAnnouncementWindow({
+  const schedule = clampAnnouncementWindow({
     startsAt: input.startsAt,
     endsAt: input.endsAt,
     previousStartsAt: existing?.startsAt,
@@ -335,8 +335,8 @@ export async function upsertCreatorAnnouncement({
     emoji: input.emoji,
     color: input.color ?? 'blue',
     domain: input.domain,
-    startsAt: window.startsAt,
-    endsAt: window.endsAt,
+    startsAt: schedule.startsAt,
+    endsAt: schedule.endsAt,
     // Never written on an update. A creator cannot set `disabled` at all (the schema has
     // no such field), so a row a moderator took down stays down through any edit.
     ...(existing ? {} : { disabled: false }),

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -4,6 +4,7 @@ import type {
   AnnouncementMetaSchema,
   UpsertCreatorAnnouncementSchema,
 } from '~/server/schema/announcement.schema';
+import { CREATOR_ANNOUNCEMENT_CONTENT_MAX } from '~/server/schema/announcement.schema';
 import { getAnnouncementAllowance } from '~/server/services/announcement-allowance.service';
 import { resolveCoverImageId } from '~/server/services/cover-image.service';
 import { isImageOwner } from '~/server/services/util.service';
@@ -203,7 +204,7 @@ export async function getFollowedAnnouncements({
 async function assertOwnedAnnouncement(id: number, userId: number, isModerator = false) {
   const existing = await dbRead.announcement.findFirst({
     where: isModerator ? { id, userId: { not: null } } : { id, userId },
-    select: { id: true, coverId: true, profileOnly: true, startsAt: true },
+    select: { id: true, coverId: true, profileOnly: true, startsAt: true, content: true },
   });
   if (!existing) throw throwAuthorizationError('Announcement not found');
   return existing;
@@ -239,6 +240,22 @@ export function toDomainRelativeLink(link: string) {
  * Shortest announcement we will store. Mirrored in apps/creator-studio/src/lib/announcements.ts,
  * where the picker enforces the same floor while the creator is choosing.
  */
+/**
+ * Enforces the content limit on new writing without trapping the rows that predate it.
+ *
+ * A migrated profile banner can be longer than the limit through no act of its owner, and
+ * refusing every save would leave them unable to edit their own card at all. Shortening is
+ * always allowed; growing past the limit never is.
+ */
+export function assertContentLength(content: string, previousContent?: string) {
+  if (content.length <= CREATOR_ANNOUNCEMENT_CONTENT_MAX) return;
+  if (previousContent && content.length <= previousContent.length) return;
+
+  throw throwBadRequestError(
+    `Announcements are limited to ${CREATOR_ANNOUNCEMENT_CONTENT_MAX} characters.`
+  );
+}
+
 export const MIN_ANNOUNCEMENT_DURATION_MS = 60 * 60 * 1000;
 
 /**
@@ -315,6 +332,8 @@ export async function upsertCreatorAnnouncement({
         }
       : {}),
   };
+
+  assertContentLength(input.content, existing?.content);
 
   const schedule = clampAnnouncementWindow({
     startsAt: input.startsAt,


### PR DESCRIPTION
Three creator reports about announcements, plus review feedback. Fixes are independent; the interesting one is the first.

## 1. Announcements were arriving as a notification instead of in the Announcements tab

Creators reported followers getting an "X made an announcement" row in **Updates** rather than the announcement appearing in the Announcements tab.

The cause is worse than a routing mistake. The `creator-announcement` fan-out had **no feature-flag check at all** — verified, zero flag/Flipt/tester references in its SQL — so it reached every follower. The Announcements tab it points at is gated: `creatorAnnouncements` is `availability: ['mod']` plus a Flipt flag whose only rollout is the `testers` segment. So followers got the notification, clicked through, and found nothing they could see.

`prepareQuery` is dropped, so nothing new is generated (`send-notifications` guards on `if (query)`). `prepareMessage` is **kept** and `toggleable: false` added — `getNotificationMessage` resolves at render time, so deleting the entry would blank out every notification already delivered. Same pattern the repo already uses for `beggars-board-rejected`.

🔴 **Rollout note for the reviewer:** the notification was the only delivery path un-flagged followers had. Until `creator-announcements` widens past `testers`, ordinary followers see nothing. That is correct dark-launch behaviour and it stops the leak, but it is a deliberate choice, not an oversight.

## 2. The domain chips rendered one chip per letter

The dashboard showed `{`, `g`, `r`, `e`, `n`, `,`, `b`, `l`, `u`, `}` — which is `[...new Set("{green,blue}")]`, the string iterated as characters and deduped.

pg has no parser for arrays of a user-defined enum, so a `DomainColor[]` column arrives as the raw Postgres literal. The main app registers the parsers in `instrumentation.node.ts`; **creator-studio never did**.

Fixed at two altitudes, deliberately:
- A SvelteKit `init` hook, which SvelteKit awaits before the first request — this fixes every enum-array read in the app, not just this one.
- `toDomainArray` at the read site, replacing an `as string[]` cast that was simply untrue. The registration is **fail-open** by design (matching the main app), so the read site cannot lean on it.

`createKyselyClients` now also returns the primary pg pool, since Kysely does not expose its dialect's pool and an app that builds its own re-derives the SSL and sizing config the factory owns.

## 3. Start and end dates were unbounded

`clampAnnouncementWindow` slides rather than refuses: start up to `now`, end out to start + 1h. The picker constrains both with `min` and pulls the end along when the start moves past it; creator-studio's client-side ordering refine was **removed**, or the value would be rejected before ever reaching the clamp.

🔴 **A start the creator did not touch is left alone, even when past.** Re-stamping it would republish a running announcement to the top of every follower's feed on an edit that only fixed a typo — `getFollowedAnnouncements` orders by `startsAt` desc.

## 4. Domain labels, and chips you can tell apart

Labels now read `civitai.com` / `civitai.red` rather than colour names — the colour names do not match the sites, so "green" told a creator nothing.

Selected chips gained a check mark. The space is **reserved rather than conditionally rendered**, so the chip does not resize on toggle and shift its neighbour out from under the pointer.

The hover state was indistinguishable from selected. That is stock shadcn: the `outline` variant sets `hover:bg-accent` and the base sets `data-[state=on]:bg-accent` — the same token. Fixed in the shared variant, since **13 `outline` ToggleGroups across 8 files** have it — the composer, dashboard, earnings, and four analytics pages, all in creator-studio. (An earlier revision of this description said 4; my grep required the variant on the same line as the tag and undercounted. Moderator uses ToggleGroup without a variant and is unaffected — that half I verified independently.) Note that reverting hover to `bg-muted` would **not** have worked: `--muted` and `--accent` are the same value in light mode. It is three weights of one token instead.

## 5. Content limit: 5000 → 500

`AnnouncementCard` has **no line clamp**, so whatever is stored renders in full, in a 710px drawer or a 540px `Container size="sm"`. 500 is roughly 7–11 lines there; 5000 was a 70–110 line wall inside a notification dropdown.

A flat 500 would have trapped people. The pending profile-banner backfill inserts **25,655 rows** from `UserProfile.message`, and **8,757 of those exceed 500** (measured on prod: p50 152, p99 1200, max 1232). A creator opening their own migrated banner to fix a typo could not have saved it. So the schema keeps a higher hard ceiling and the service enforces 500 on anything **new or lengthened** — an over-long legacy row can be edited and shortened, never grown.

## Testing

Full unit suite green: **1437 files, 22320 passed, 0 failed**. Apps 991, packages 1130, guards 351. Typecheck 0 errors, `svelte-check` 0 errors / 0 warnings, eslint and prettier clean on changed files.

Every new test was **positive-controlled** — the fix was broken deliberately and the failure observed — rather than trusted because it was green:

| Mutation | Result |
|---|---|
| Drop the `untouched` guard in `clampAnnouncementWindow` | 1 failed |
| Re-add `prepareQuery` | 1 failed |
| Revert `toDomainArray` to the original `[...new Set(value as string[])]` | 7 failed |
| Drift creator-studio's `MIN_ANNOUNCEMENT_DURATION_MS` to 30 min | `expected 1800000 to be 3600000` |
| Drop the grandfather branch in `assertContentLength` | 2 failed |
| Deliberate type error in the composer | `svelte-check` caught it (its clean run was 84ms, which was too fast to trust unverified) |

Two failures encountered and confirmed **not** caused by this branch: a `pageRunScrollContract` CSS test that fails at the merge-base with none of these changes present and has since been fixed on main (branch rebased), and `@civitai/redis` `cache-key-prefix`, which is **flaky** — 3 failures in 6 runs on `origin/main` itself, a 5s timeout on a dynamic import.

## Adversarial review, and what it found

An adversarial reviewer was run against this branch with instructions to falsify the claims above rather than read the diff. It found three real defects, all reproduced independently before fixing, all fixed in `15b53fdc`:

- **The `untouched` guard was defeated by the picker it serves.** `datetime-local` cannot express seconds, so the composer round-trips a stored start through `YYYY-MM-DDTHH:mm` and returns it truncated to the minute. An exact timestamp comparison reported "changed" for every row whose start carried seconds — which is exactly the rows the guard protects, since a row crossing into notifying is stamped `new Date()`. A typo fix would have republished a running announcement to the top of every follower's feed: the precise outcome the comment claimed to prevent. Now compared at minute granularity.
- **The content grandfather clause was unreachable from the only creator UI.** creator-studio's own form schema capped at `CONTENT_MAX`, so a migrated 900-char banner was refused in the spoke before reaching the main app that decides. The form now bounds at the ceiling.
- **Neither could be caught by the tests in the earlier commits.** Deleting *both* new guards from the write path left **347 files / 4814 tests green** — the unit tests exercised the functions and nothing asserted anything called them. The window test also passed the same `Date` object on both sides, so it could not observe a lossy round-trip by construction. Wiring tests were added to the boundary suite (the only place that drives the real write path), whose ownership mock also lacked the two fields the service now selects.

Re-running the same mutations against the fixed branch: unwiring both guards fails 3, reverting the minute comparison fails the named regression, capping the spoke schema again fails the legacy-content test.

Five other claims were checked and could not be falsified, including one useful nuance: writes were flag-gated all along (`isFlagProtected('creatorAnnouncements')`), so the un-flagged fan-out could only be triggered by an announcement a mod or tester authored. The leak was real; the population that could cause one was small.

Known and not addressed here, filed rather than fixed: `previousStartsAt` is read from the replica, so replica lag can still defeat the untouched guard; and users who previously opted out of `creator-announcement` keep a `UserNotificationSettings` row no UI can now clear (inert while the fan-out is gone).

## Notes for review

- Two constants are mirrored across the app boundary (`MIN_ANNOUNCEMENT_DURATION_MS`, `CONTENT_MAX`) because creator-studio cannot import from the main app. Both are now pinned by tests that read the other file's source, so drift fails rather than passing quietly.
- `packages/civitai-db` and `packages/civitai-ui` are touched. The db change is purely additive (a returned `pool`); the ui change affects the four `outline` ToggleGroups listed above and nothing in moderator.
- Two READMEs were corrected where this change made them wrong (`civitai-db` return shape, `db-queries` parser call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xboS6BWLNnDcxz67WsFT4
