### PR TITLE
feat(chat): add seven membership chat themes

### DIFF
--- a/docs/features/chat-dm-redesign.md
+++ b/docs/features/chat-dm-redesign.md
@@ -256,8 +256,8 @@ side of the thread; without it, a report filed today can be rendered unreviewabl
 ## Themes
 
 A theme is a palette applied as CSS variables on the chat window and nothing else — the other
-side of a conversation sees their own. `default` is free; `citron`, `bubblegum` and `terminal`
-come with any active membership.
+side of a conversation sees their own. `default` is free and every other theme in
+`chatThemes` comes with any active membership.
 
 The palettes live in `src/shared/constants/chat-theme.ts`. The *choice* is a chat user setting;
 the *entitlement* is the membership, and the two are resolved against each other at render
@@ -267,6 +267,11 @@ to set it again.
 
 Themes reach the chrome, the message rows and the type, not just accent colours — but every token
 they move resolves to the stock value in the default palette, so the unthemed window is unchanged.
+`--chat-bg-image` takes any CSS background, so a theme's texture is gradients or an inline SVG
+filter rather than an asset.
+
+The app loads no webfonts, so a theme's display face is whatever of its stack is already installed.
+Naming the Google face first costs nothing and makes the stack correct if the app ever loads one.
 
 A named theme is a fixed palette in both colour schemes. Picking Terminal is picking the terminal
 look, not a preference the light/dark setting gets to reinterpret; only `default` follows the

--- a/src/components/Chat/Chat.module.scss
+++ b/src/components/Chat/Chat.module.scss
@@ -24,7 +24,9 @@
   --chat-panel-strong: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
   --chat-selected: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
 
-  /* Body copy, and the quieter grade used for quoted text and inline labels. */
+  /* Body copy, and the quieter grade used for quoted text and inline labels.
+     --chat-text is also what the window inherits from, so a fixed palette is
+     not left reading the app's own light/dark text colour. */
   --chat-text: inherit;
   --chat-text-dim: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
 
@@ -57,6 +59,7 @@
   background-color: var(--chat-bg);
   background-image: var(--chat-bg-image);
   font-family: var(--chat-ui-font);
+  color: var(--chat-text);
 }
 
 /* The rail, the conversation header and the composer are the chrome around the

--- a/src/shared/constants/__tests__/chat-appearance.test.ts
+++ b/src/shared/constants/__tests__/chat-appearance.test.ts
@@ -32,6 +32,15 @@ describe('chat themes', () => {
     }
   });
 
+  it('gives every membership theme its own text colour', () => {
+    // The window paints `color: var(--chat-text)`, whose stock value is
+    // `inherit` — so a theme that skips it inherits the app's light/dark text
+    // onto a fixed palette, which is white-on-cream for the light themes.
+    for (const theme of chatThemes.filter((t) => t.slug !== CHAT_THEME_DEFAULT)) {
+      expect(theme.vars?.['--chat-text'], theme.slug).toMatch(/^#[0-9a-f]{3,8}$/i);
+    }
+  });
+
   it('leaves the default theme without vars so the app tokens show through', () => {
     expect(chatThemes.find((t) => t.slug === CHAT_THEME_DEFAULT)?.vars).toBeNull();
   });

--- a/src/shared/constants/chat-theme.ts
+++ b/src/shared/constants/chat-theme.ts
@@ -13,6 +13,13 @@ export const chatThemeSlugs = [
   'orange',
   'blue',
   'violet',
+  'teal',
+  'dark-purple',
+  'cyberpunk',
+  'synthwave',
+  'sci-fi',
+  'pastels',
+  'cream',
 ] as const;
 export type ChatThemeSlug = (typeof chatThemeSlugs)[number];
 
@@ -40,6 +47,33 @@ export type ChatTheme = {
  */
 const TERMINAL_FONT =
   "'Cascadia Mono', 'Cascadia Code', 'JetBrains Mono', 'Fira Code', 'DejaVu Sans Mono', Consolas, 'Liberation Mono', 'Courier New', monospace";
+
+/**
+ * Same local-only rule as TERMINAL_FONT, for the same reason: the app loads no
+ * webfonts, so a display face has to already be on the machine. The Google name
+ * leads each stack so these become real the day the app does load one; until
+ * then the near-equivalents behind it — Windows and macOS system faces — are
+ * what most readers actually get, and each stack ends on a generic that still
+ * differs from the app's own face.
+ */
+const CYBER_FONT =
+  "Rajdhani, 'Chakra Petch', Bahnschrift, 'DIN Alternate', 'Franklin Gothic Medium', 'Arial Narrow', sans-serif";
+const SYNTH_FONT =
+  "Audiowide, Michroma, Orbitron, 'Bahnschrift SemiBold', Impact, 'Haettenschweiler', sans-serif";
+const SCIFI_FONT =
+  "'Titillium Web', 'Chakra Petch', Bahnschrift, 'Avenir Next Condensed', 'Segoe UI', sans-serif";
+const ROUNDED_FONT =
+  "Nunito, Quicksand, 'Varela Round', 'SF Pro Rounded', 'Segoe UI Variable', 'Trebuchet MS', sans-serif";
+const BOOK_FONT =
+  "'EB Garamond', 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif";
+
+/**
+ * Grain as a tiled SVG filter rather than an image: it costs no asset request,
+ * and it is the one texture that gradients cannot fake, because the point of it
+ * is that the value never repeats on a period the eye can find.
+ */
+const grain = (opacity: number, frequency: number) =>
+  `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='${frequency}' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23g)' opacity='${opacity}'/%3E%3C/svg%3E")`;
 
 export const chatThemes: ChatTheme[] = [
   {
@@ -202,6 +236,215 @@ export const chatThemes: ChatTheme[] = [
       '--chat-bubble-me': 'rgb(177 151 252 / 22%)',
       '--chat-bubble-pad': '5px 10px',
       '--chat-bubble-radius': '14px',
+    },
+  },
+  {
+    slug: 'teal',
+    name: 'Teal',
+    free: false,
+    swatch: ['#04151a', '#38d9a9'],
+    vars: {
+      '--chat-bg': '#04151a',
+      '--chat-bg-image':
+        'radial-gradient(125% 85% at 20% 0%, rgb(56 217 169 / 10%), transparent 68%)',
+      '--chat-panel': '#082027',
+      '--chat-panel-strong': '#0b2a33',
+      '--chat-selected': '#0f3540',
+      '--chat-line': '#154a56',
+      '--chat-accent': '#38d9a9',
+      '--chat-send': '#087f5b',
+      '--chat-text': '#dcf5ee',
+      '--chat-text-dim': '#a2ccc2',
+      '--chat-meta': '#6f948c',
+      '--chat-hover': 'rgb(56 217 169 / 9%)',
+      '--chat-bubble': '#0a2830',
+      '--chat-bubble-me': 'rgb(56 217 169 / 20%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '14px',
+    },
+  },
+  {
+    slug: 'dark-purple',
+    name: 'Dark Purple',
+    free: false,
+    swatch: ['#0c0513', '#9d4edd'],
+    vars: {
+      '--chat-bg': '#0c0513',
+      '--chat-bg-image':
+        'radial-gradient(130% 80% at 50% 0%, rgb(157 78 221 / 14%), transparent 62%)',
+      '--chat-panel': '#150920',
+      '--chat-panel-strong': '#1d0d2c',
+      '--chat-selected': '#251037',
+      '--chat-line': '#3b1a55',
+      '--chat-accent': '#9d4edd',
+      '--chat-send': '#5f259f',
+      '--chat-text': '#ead9f7',
+      '--chat-text-dim': '#b795cf',
+      '--chat-meta': '#8567a0',
+      '--chat-hover': 'rgb(157 78 221 / 10%)',
+      '--chat-bubble': '#1a0c28',
+      '--chat-bubble-me': 'rgb(157 78 221 / 24%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '14px',
+    },
+  },
+  {
+    slug: 'cyberpunk',
+    name: 'Cyberpunk',
+    free: false,
+    swatch: ['#05060f', '#ff4fd8'],
+    vars: {
+      '--chat-bg': '#05060f',
+      // The static sits on top: it is what makes the neon read as a screen
+      // rather than as a flat recolour.
+      '--chat-bg-image': [
+        grain(0.05, 0.9),
+        'radial-gradient(90% 60% at 85% 0%, rgb(255 79 216 / 12%), transparent 60%)',
+        'repeating-linear-gradient(90deg, rgb(34 211 238 / 6%) 0 1px, transparent 1px 46px)',
+        'repeating-linear-gradient(0deg, rgb(34 211 238 / 6%) 0 1px, transparent 1px 46px)',
+      ].join(', '),
+      '--chat-panel': '#0a0c1a',
+      '--chat-panel-strong': '#0f1224',
+      '--chat-selected': '#16182e',
+      '--chat-line': '#0f4a5c',
+      '--chat-accent': '#ff4fd8',
+      '--chat-send': '#0b7285',
+      '--chat-text': '#d7e8f5',
+      '--chat-text-dim': '#8fb3c9',
+      '--chat-meta': '#5f7d92',
+      '--chat-hover': 'rgb(34 211 238 / 10%)',
+      '--chat-ui-font': CYBER_FONT,
+      '--chat-radius': '2px',
+      '--chat-bubble': '#101427',
+      '--chat-bubble-me': 'rgb(255 79 216 / 18%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '2px',
+    },
+  },
+  {
+    slug: 'synthwave',
+    name: 'Synthwave',
+    free: false,
+    swatch: ['#170a26', '#ff6ec7'],
+    vars: {
+      '--chat-bg': '#170a26',
+      // First layer is the frontmost, so this is mist over grid over sunset.
+      '--chat-bg-image': [
+        'radial-gradient(80% 50% at 20% 20%, rgb(177 151 252 / 10%), transparent 70%)',
+        'repeating-linear-gradient(0deg, rgb(255 110 199 / 9%) 0 1px, transparent 1px 22px)',
+        'linear-gradient(0deg, rgb(255 138 61 / 22%) 0%, rgb(255 110 199 / 16%) 18%, transparent 45%)',
+      ].join(', '),
+      '--chat-panel': '#1f0e33',
+      '--chat-panel-strong': '#2a1345',
+      '--chat-selected': '#341a52',
+      '--chat-line': '#4a2170',
+      '--chat-accent': '#ff6ec7',
+      '--chat-send': '#c2255c',
+      '--chat-text': '#f6e6ff',
+      '--chat-text-dim': '#c6a8e0',
+      '--chat-meta': '#9078ad',
+      '--chat-hover': 'rgb(255 110 199 / 10%)',
+      '--chat-ui-font': SYNTH_FONT,
+      '--chat-bubble': '#26123c',
+      '--chat-bubble-me': 'rgb(255 110 199 / 22%)',
+      '--chat-bubble-pad': '5px 10px',
+      '--chat-bubble-radius': '12px',
+    },
+  },
+  {
+    slug: 'sci-fi',
+    name: 'Sci-Fi',
+    free: false,
+    swatch: ['#040a15', '#ffb340'],
+    vars: {
+      '--chat-bg': '#040a15',
+      // A third the contrast of the grid themes: the lattice shows through the
+      // translucent panels below, and has to stay behind the text it lands on.
+      '--chat-bg-image': [
+        'radial-gradient(100% 55% at 50% 0%, rgb(56 189 248 / 9%), transparent 60%)',
+        'repeating-linear-gradient(60deg, rgb(56 189 248 / 4%) 0 1px, transparent 1px 26px)',
+        'repeating-linear-gradient(120deg, rgb(56 189 248 / 4%) 0 1px, transparent 1px 26px)',
+      ].join(', '),
+      '--chat-panel': '#0a1a2e',
+      '--chat-panel-strong': '#0e2340',
+      '--chat-selected': '#123050',
+      '--chat-line': '#1c4a63',
+      '--chat-accent': '#ffb340',
+      '--chat-send': '#9a6207',
+      '--chat-text': '#a8e4f0',
+      '--chat-text-dim': '#79b3c4',
+      '--chat-meta': '#5b8496',
+      '--chat-hover': 'rgb(56 189 248 / 10%)',
+      '--chat-ui-font': SCIFI_FONT,
+      '--chat-msg-font': SCIFI_FONT,
+      '--chat-radius': '3px',
+      // Translucent so the lattice shows through the panel, which is what makes
+      // it read as glass instead of as another flat fill.
+      '--chat-bubble': 'rgb(13 42 66 / 72%)',
+      '--chat-bubble-me': 'rgb(56 189 248 / 20%)',
+      '--chat-bubble-pad': '6px 11px',
+      '--chat-bubble-radius': '3px',
+    },
+  },
+  {
+    slug: 'pastels',
+    name: 'Pastels',
+    free: false,
+    swatch: ['#f5f3fc', '#6f5bc4'],
+    vars: {
+      '--chat-bg': '#f5f3fc',
+      '--chat-bg-image': [
+        'radial-gradient(70% 50% at 0% 0%, rgb(177 151 252 / 22%), transparent 65%)',
+        'radial-gradient(70% 50% at 100% 0%, rgb(247 131 172 / 18%), transparent 65%)',
+        'radial-gradient(90% 55% at 50% 100%, rgb(99 217 194 / 18%), transparent 70%)',
+      ].join(', '),
+      '--chat-panel': '#eeeafa',
+      '--chat-panel-strong': '#ffffff',
+      '--chat-selected': '#e2dbf6',
+      '--chat-line': '#d8d0ee',
+      '--chat-accent': '#6f5bc4',
+      '--chat-send': '#6f5bc4',
+      '--chat-text': '#3b3357',
+      '--chat-text-dim': '#615884',
+      '--chat-meta': '#8d85a8',
+      '--chat-hover': 'rgb(111 91 196 / 8%)',
+      '--chat-ui-font': ROUNDED_FONT,
+      '--chat-radius': '20px',
+      '--chat-bubble': '#ffffff',
+      '--chat-bubble-me': 'rgb(111 91 196 / 16%)',
+      '--chat-bubble-pad': '6px 11px',
+      '--chat-bubble-radius': '16px',
+    },
+  },
+  {
+    slug: 'cream',
+    name: 'Cream',
+    free: false,
+    swatch: ['#f5ecd9', '#8a5a2b'],
+    vars: {
+      '--chat-bg': '#f5ecd9',
+      '--chat-bg-image': [
+        grain(0.045, 0.75),
+        'radial-gradient(120% 90% at 50% 0%, rgb(122 82 48 / 6%), transparent 70%)',
+      ].join(', '),
+      '--chat-panel': '#efe4cd',
+      '--chat-panel-strong': '#fbf5e8',
+      '--chat-selected': '#e6d8bd',
+      '--chat-line': '#ddcdae',
+      '--chat-accent': '#8a5a2b',
+      '--chat-send': '#7a4d22',
+      '--chat-text': '#3f2f1e',
+      '--chat-text-dim': '#5f4b33',
+      '--chat-meta': '#8a7455',
+      '--chat-hover': 'rgb(122 82 48 / 8%)',
+      '--chat-ui-font': BOOK_FONT,
+      '--chat-msg-font': BOOK_FONT,
+      // A serif of the same nominal size reads smaller than the app's sans.
+      '--chat-msg-size': '14.5px',
+      '--chat-bubble': '#fbf5e8',
+      '--chat-bubble-me': 'rgb(138 90 43 / 14%)',
+      '--chat-bubble-pad': '6px 11px',
+      '--chat-bubble-radius': '12px',
     },
   },
 ];


### PR DESCRIPTION
Adds teal, dark-purple, cyberpunk, synthwave, sci-fi, pastels and cream palettes, with local-only display font stacks and gradient/SVG-grain backgrounds so no new assets or webfonts are needed. The chat window now paints `color: var(--chat-text)` and a test asserts every membership theme sets its own text colour, since the stock `inherit` left fixed light palettes reading the app's dark-mode text.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Implemented by the local ticket agent (task `868kut5yj`). Reviewed locally before push.