### PR TITLE
fix(rewards): stop an expired subscription from paying perks forever

### DIFF
--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -156,4 +156,19 @@ describe('userMultipliersCache wiring', () => {
   it('resolves multipliers through foldUserMultipliers', () => {
     expect(lookup).toContain('foldUserMultipliers(');
   });
+
+  // 🔴 ALSO A TRIPWIRE. `status` alone let a subscription whose period ended keep paying perks
+  // indefinitely — 17 of 5,588 active rows on 2026-08-25, all carrying a multiplier above 1, the
+  // oldest expired in February (ClickUp 868kw98pv). Whether the guard WORKS is a database question
+  // and this cannot answer it; the A/B against the prod replica in the PR is that evidence.
+  //
+  // The comparison is pinned WITH its direction on purpose: asserting the column name alone passes
+  // against `<= now()`, which restores the bug and inverts it for everyone else.
+  it('gates the subscription join on the period still being open', () => {
+    expect(lookup).toMatch(/"currentPeriodEnd"\s*>=\s*now\(\)/);
+  });
+
+  // The row an expired subscription now produces — every multiplier null — is the same shape a
+  // perkless grant produces, and `falls back to 1 when the only active row carries no perks` above
+  // already pins that it folds to 1 rather than to 0. Not repeated here.
 });

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -353,6 +353,7 @@ export const userMultipliersCache = createCachedObject<CachedUserMultiplier>({
       FROM "User" u
       LEFT JOIN "CustomerSubscription" cs
         ON cs."userId" = u.id AND cs.status IN ('active', 'trialing')
+        AND cs."currentPeriodEnd" >= now()
       LEFT JOIN "Product" p ON p.id = cs."productId"
       WHERE u.id IN (${Prisma.join(goodIds)});
     `;


### PR DESCRIPTION
ClickUp [`868kw98pv`](https://app.clickup.com/t/868kw98pv).

`userMultipliersCache` (`src/server/redis/caches.ts`) joined `CustomerSubscription` on `status IN ('active','trialing')` with no check that the billing period was still open, so a subscription whose period ended kept granting its rewards and purchases multipliers indefinitely.

## 🔴 This deliberately takes a multiplier away from 17 users

**Justin's call, 2026-08-25: hard cut, no grace period.** He was given the alternative and the reason for it — `currentPeriodEnd` passes before the renewal webhook lands, so across 5,588 subscriptions a strict `>= now()` can briefly drop a *paying* member's multiplier — and chose the hard cut anyway.

So this is a chosen behaviour change, not an oversight. **17 users lose a 1.5x–2.5x rewards multiplier the moment it deploys, and none of them are told.** Written down here so nobody later reads it as a bug and reverses it.

## Measurement (prod replica, 2026-08-25 — re-measured, not inherited from the ticket)

| | |
|---|---|
| `active` subscriptions | 5,588 |
| …with `currentPeriodEnd` in the past | **17** |
| …of those, carrying a rewards multiplier > 1 | **17** |

Oldest expired 2026-02-28. Several are `cancelAtPeriodEnd: true` with `updatedAt` six months stale — missed Stripe/Paddle webhooks, not members still paying. Tiers affected are bronze (1.5x / 1.05x) and silver (2.5x / 1.10x).

## The control: an A/B of both queries over every subscriber

A unit test cannot tell you whether this SQL is right — it would take a database. So I ran both versions of the lookup against the prod replica, over every user with an active subscription:

```
subscribers: 5567   changed: 17   gained: 0   lost: 17
```

Exactly the 17 move, all in one direction, and **nobody else's multiplier changes**. `changed: 17` being non-zero is what makes `gained: 0` meaningful — the comparison can detect a difference, so the zero is a result rather than an empty query.

## The failure mode I checked for, and disproved

The guard sits inside the `LEFT JOIN`'s `ON`, not in the `WHERE`. Had it gone in the `WHERE`, an expired-only subscriber would have vanished from the result set entirely — and a user *missing* from this cache is not the same as a user with multiplier 1. Confirmed on the same replica:

```
expired_users: 17   rows_returned: 17   with_null_subscription: 17   still_matching_a_product: 0
```

All 17 still come back, with a null subscription, which `foldUserMultipliers` folds to `BASE_MULTIPLIER` 1. That row shape is identical to a perkless grant, and the existing test `falls back to 1 when the only active row carries no perks` already pins it — so I did not duplicate it.

## The test is a tripwire and is labelled as one

`user-multipliers.test.ts` already carries an explicitly-labelled tripwire block for this query, with a comment saying it is *not* coverage. Mine follows that convention and pins the comparison **with its direction**:

```ts
expect(lookup).toMatch(/"currentPeriodEnd"\s*>=\s*now\(\)/);
```

Asserting the column name alone would pass against `<= now()`, which restores the bug *and* inverts it for everyone else. Controls:

| Mutation | Result |
|---|---|
| Remove the guard entirely | `Tests 1 failed \| 15 passed (16)` |
| `>= now()` → `<= now()` | `Tests 1 failed \| 15 passed (16)` |

Restored file identical after each.

## Verification

- `user-multipliers.test.ts`: `Test Files 1 passed (1)` / `Tests 16 passed (16)`, exit 0.
- Prettier clean on both files.
- 🔴 **`pnpm run typecheck` fails on this branch with 6 errors, none of them mine, and `main` is red for the same reason.** All six are the `AppListingDescription.tsx` / `appListingDescription.ts` case collision introduced by #4404 (`350b61642c`) — two tracked files whose names differ only in case, which is fine on Linux CI and breaks module resolution on any case-insensitive filesystem (Windows, default macOS). Neither file existed at `386ea4d07d`, where my typecheck was clean at 0 errors, and no error names a file in this diff. Raised separately.

**No migration.**
