### PR TITLE
fix(licensing): a LoRA could inherit a checkpoint's per-image fee

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -741,16 +742,60 @@ describe('ModelVersionUpsertForm — licensing lineage pre-selection', () => {
     expect((await save()).licensingSourceVersionId).toBe(ANIMA_CHECKPOINT_ROOT.id);
   });
 
-  // 🔴 The gate this pins is `enabled: !!baseModel && !!model?.type`. Relaxing it back to `!!baseModel`
-  // fires one unscoped fetch whose CHECKPOINT roots get stamped onto a LoRA before the scoped refetch —
-  // which returns nothing, so the effect early-returns on a null default and can never clear it.
+  // 🔴 The gate this pins is `enabled: !!baseModel && !!model?.type`. Relaxing it back to
+  // `!!baseModel` fires one unscoped fetch whose CHECKPOINT roots get stamped onto a LoRA before the
+  // scoped refetch — which returns nothing, so the effect early-returns on a null default and can never
+  // clear it.
+  //
+  // The model is present here and only its TYPE is missing, which is what makes this test worth
+  // anything: with `model` undefined entirely, relaxing the gate to `!!model` also passes, so the test
+  // would pin the wrong half of the condition. (It is also the truer fixture — the wizard's step 2
+  // renders with a model object whose query has resolved and a type the user has not chosen yet.)
   test('stamps nothing while the model type is still unknown', async () => {
     licensingRoots.respond = (input) =>
       input.modelType === undefined
         ? { roots: [ANIMA_CHECKPOINT_ROOT], defaultVersionId: ANIMA_CHECKPOINT_ROOT.id }
         : NO_ROOTS;
-    renderNew(false);
+    renderWithProviders(
+      <ModelVersionUpsertForm
+        model={{ ...model, type: undefined } as typeof model}
+        onSubmit={vi.fn()}
+      >
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
 
+    expect((await save()).licensingSourceVersionId ?? null).toBeNull();
+  });
+
+  // 🔴 The type is editable at wizard step 1 until the model is trained, so it can change AFTER a
+  // root has been pre-selected. The pre-selection effect cannot undo that on its own: the query
+  // re-keys, the scoped result is empty, and the effect early-returns on a null default. The picker
+  // hides itself too (`licensingRoots.length > 0`), so without the clearing effect the stale id is
+  // invisible on screen and submitted anyway. The server coerces it, so this is about the form not
+  // carrying a selection it can neither show nor keep.
+  test('clears a stamped root when the model type changes under it', async () => {
+    licensingRoots.respond = (input) =>
+      input.modelType === 'Checkpoint'
+        ? { roots: [ANIMA_CHECKPOINT_ROOT], defaultVersionId: ANIMA_CHECKPOINT_ROOT.id }
+        : NO_ROOTS;
+
+    function Harness() {
+      const [type, setType] = React.useState('Checkpoint');
+      return (
+        <>
+          <button type="button" onClick={() => setType('LORA')}>
+            Make it a LoRA
+          </button>
+          <ModelVersionUpsertForm model={{ ...model, type } as typeof model} onSubmit={vi.fn()}>
+            {() => <button type="submit">Save</button>}
+          </ModelVersionUpsertForm>
+        </>
+      );
+    }
+    renderWithProviders(<Harness />);
+
+    await userEvent.click(page.getByRole('button', { name: 'Make it a LoRA' }));
     expect((await save()).licensingSourceVersionId ?? null).toBeNull();
   });
 });

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -765,37 +764,6 @@ describe('ModelVersionUpsertForm — licensing lineage pre-selection', () => {
       </ModelVersionUpsertForm>
     );
 
-    expect((await save()).licensingSourceVersionId ?? null).toBeNull();
-  });
-
-  // 🔴 The type is editable at wizard step 1 until the model is trained, so it can change AFTER a
-  // root has been pre-selected. The pre-selection effect cannot undo that on its own: the query
-  // re-keys, the scoped result is empty, and the effect early-returns on a null default. The picker
-  // hides itself too (`licensingRoots.length > 0`), so without the clearing effect the stale id is
-  // invisible on screen and submitted anyway. The server coerces it, so this is about the form not
-  // carrying a selection it can neither show nor keep.
-  test('clears a stamped root when the model type changes under it', async () => {
-    licensingRoots.respond = (input) =>
-      input.modelType === 'Checkpoint'
-        ? { roots: [ANIMA_CHECKPOINT_ROOT], defaultVersionId: ANIMA_CHECKPOINT_ROOT.id }
-        : NO_ROOTS;
-
-    function Harness() {
-      const [type, setType] = React.useState('Checkpoint');
-      return (
-        <>
-          <button type="button" onClick={() => setType('LORA')}>
-            Make it a LoRA
-          </button>
-          <ModelVersionUpsertForm model={{ ...model, type } as typeof model} onSubmit={vi.fn()}>
-            {() => <button type="submit">Save</button>}
-          </ModelVersionUpsertForm>
-        </>
-      );
-    }
-    renderWithProviders(<Harness />);
-
-    await userEvent.click(page.getByRole('button', { name: 'Make it a LoRA' }));
     expect((await save()).licensingSourceVersionId ?? null).toBeNull();
   });
 });

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -711,12 +711,9 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
  * effect pre-selected is what gets written.
  */
 describe('ModelVersionUpsertForm — licensing lineage pre-selection', () => {
-  const renderNew = (withModel: boolean) =>
+  const renderNew = () =>
     renderWithProviders(
-      // `model` undefined is not a contrived fixture: it is one render of the real wizard. `model`
-      // arrives from a query while `baseModel` is seeded synchronously from the last-used store, so
-      // there is a window where the form knows the ecosystem and not the model type.
-      <ModelVersionUpsertForm model={withModel ? model : undefined} onSubmit={vi.fn()}>
+      <ModelVersionUpsertForm model={model} onSubmit={vi.fn()}>
         {() => <button type="submit">Save</button>}
       </ModelVersionUpsertForm>
     );
@@ -736,7 +733,7 @@ describe('ModelVersionUpsertForm — licensing lineage pre-selection', () => {
       roots: [ANIMA_CHECKPOINT_ROOT],
       defaultVersionId: ANIMA_CHECKPOINT_ROOT.id,
     });
-    renderNew(true);
+    renderNew();
 
     expect((await save()).licensingSourceVersionId).toBe(ANIMA_CHECKPOINT_ROOT.id);
   });

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -21,7 +21,14 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcModule>()),
   trpc: {
     modelVersion: {
-      getLicensingRoots: { useQuery: () => ({ data: undefined }) },
+      getLicensingRoots: {
+        // Modelled on react-query's own contract, because that contract is what the fix turns on: a
+        // query with `enabled: false` never runs and therefore has no data. A fixed `{ data: undefined }`
+        // mock cannot tell a gated query from an ungated one, so it would pass either way.
+        useQuery: (input: { modelType?: string }, opts?: { enabled?: boolean }) => ({
+          data: opts?.enabled === false ? undefined : licensingRoots.respond(input),
+        }),
+      },
       getUserEarlyAccessVersions: { useQuery: () => ({ data: [] }) },
       upsert: { useMutation: () => ({ mutateAsync, isPending: false }) },
     },
@@ -34,6 +41,23 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
     }),
   },
 }));
+/** Anima's default licensing root: a Checkpoint charging 5 Buzz per image, settled to its own owner. */
+const ANIMA_CHECKPOINT_ROOT = {
+  id: 2945208,
+  modelId: 2458426,
+  versionName: 'base-v1.0',
+  isDefault: true,
+};
+const NO_ROOTS = { roots: [], defaultVersionId: null };
+
+const licensingRoots = vi.hoisted(() => ({
+  // Default: no roots for anyone, which is what every test in this file that predates the licensing
+  // lineage expects. The lineage tests below set their own, and those read the input.
+  respond: (() => ({ roots: [], defaultVersionId: null })) as (input: {
+    modelType?: string;
+  }) => unknown,
+}));
+
 const flags = vi.hoisted(() => ({
   // earlyAccessModel off keeps the Paid Access sub-section out of the way for the disclosure tests; the
   // removal test turns it on, because that section is what holds the irreversible warning.
@@ -156,6 +180,7 @@ beforeEach(() => {
   mutateAsync.mockClear();
   flags.current = { licensingFee: true, earlyAccessModel: false };
   currentUser.value = { id: 1, tier: 'free', isModerator: false, meta: {} };
+  licensingRoots.respond = () => NO_ROOTS;
 });
 
 describe('ModelVersionUpsertForm — monetization disclosure', () => {
@@ -672,5 +697,60 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     await userEvent.click(page.getByRole('button', { name: 'Save' }));
     await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(mutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `licensingSourceVersionId` makes a version inherit a root's per-image licence fee — charged to
+ * everyone who generates with it, settled to the ROOT's owner, on a line carrying THIS model's name.
+ * The form pre-selects the ecosystem default with `shouldDirty: false`, so a wrong pre-selection leaves
+ * no mark on screen, and no surface on the site can clear it afterwards (CU 868kwf2fd).
+ *
+ * Both tests render a BRAND-NEW version, which is the shape the leak actually takes: no `version` means
+ * no stored value to echo, and `!version?.id` sends the save straight to the mutation, so whatever the
+ * effect pre-selected is what gets written.
+ */
+describe('ModelVersionUpsertForm — licensing lineage pre-selection', () => {
+  const renderNew = (withModel: boolean) =>
+    renderWithProviders(
+      // `model` undefined is not a contrived fixture: it is one render of the real wizard. `model`
+      // arrives from a query while `baseModel` is seeded synchronously from the last-used store, so
+      // there is a window where the form knows the ecosystem and not the model type.
+      <ModelVersionUpsertForm model={withModel ? model : undefined} onSubmit={vi.fn()}>
+        {() => <button type="submit">Save</button>}
+      </ModelVersionUpsertForm>
+    );
+
+  const save = async () => {
+    await userEvent.click(page.getByRole('button', { name: 'Save' }));
+    await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    return mutateAsync.mock.calls[0][0] as { licensingSourceVersionId?: number | null };
+  };
+
+  // The control for the test below, and the reason it is worth anything: same fixtures, same save, a
+  // root the query DOES offer. If the pre-selection effect or this harness ever stops reaching the
+  // payload, this goes red — so a null in the test below cannot be an artifact of the form never
+  // stamping anything at all.
+  test('stamps a root the query offers', async () => {
+    licensingRoots.respond = () => ({
+      roots: [ANIMA_CHECKPOINT_ROOT],
+      defaultVersionId: ANIMA_CHECKPOINT_ROOT.id,
+    });
+    renderNew(true);
+
+    expect((await save()).licensingSourceVersionId).toBe(ANIMA_CHECKPOINT_ROOT.id);
+  });
+
+  // 🔴 The gate this pins is `enabled: !!baseModel && !!model?.type`. Relaxing it back to `!!baseModel`
+  // fires one unscoped fetch whose CHECKPOINT roots get stamped onto a LoRA before the scoped refetch —
+  // which returns nothing, so the effect early-returns on a null default and can never clear it.
+  test('stamps nothing while the model type is still unknown', async () => {
+    licensingRoots.respond = (input) =>
+      input.modelType === undefined
+        ? { roots: [ANIMA_CHECKPOINT_ROOT], defaultVersionId: ANIMA_CHECKPOINT_ROOT.id }
+        : NO_ROOTS;
+    renderNew(false);
+
+    expect((await save()).licensingSourceVersionId ?? null).toBeNull();
   });
 });

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -591,21 +591,14 @@ export function ModelVersionUpsertForm({
       form.setValue('licensingSourceVersionId', null, { shouldDirty: true });
   }, [baseModel]);
 
-  // The same argument for the MODEL TYPE, which roots are scoped by just as much and which is editable
-  // at wizard step 1 until the model is trained. Without this, moving a model Checkpoint -> LoRA after
-  // step 2 has already pre-selected a checkpoint root leaves the stale id in the form: the query
-  // re-keys, the scoped result is empty, the default effect early-returns on a null default, and the
-  // picker hides itself (`licensingRoots.length > 0`) — so the value is invisible AND submitted. The
-  // server coerces it, so nothing bad is written; this is about the form not carrying a selection it
-  // can neither show nor keep.
-  const prevModelTypeRef = useRef(model?.type);
-  useEffect(() => {
-    if (prevModelTypeRef.current === model?.type) return;
-    prevModelTypeRef.current = model?.type;
-    if (form.getValues('licensingSourceVersionId') != null)
-      form.setValue('licensingSourceVersionId', null, { shouldDirty: true });
-  }, [model?.type]);
-
+  // No effect clears the source when the MODEL TYPE changes, and adding one is not the oversight it
+  // looks like — a round of this fix did add one, and it was dead code. Mantine's Stepper renders only
+  // the active step's children, so this form is UNMOUNTED for the whole of the step-1 edit where the
+  // type is chosen; coming back remounts it and any `useRef` seed already holds the new type. No other
+  // in-app surface has a type control. The effect could not fire, and the test that appeared to cover
+  // it only passed because the harness re-rendered a MOUNTED form with a swapped type — a transition
+  // the wizard never produces. The server coerces a mismatched source regardless, which is where that
+  // rule belongs.
   // A derivative must record an explicit parent — a null source means no fee, so
   // pre-select the ecosystem's default root when none is set. Skipped for roots
   // and exempt versions (which legitimately have no parent).

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -591,6 +591,21 @@ export function ModelVersionUpsertForm({
       form.setValue('licensingSourceVersionId', null, { shouldDirty: true });
   }, [baseModel]);
 
+  // The same argument for the MODEL TYPE, which roots are scoped by just as much and which is editable
+  // at wizard step 1 until the model is trained. Without this, moving a model Checkpoint -> LoRA after
+  // step 2 has already pre-selected a checkpoint root leaves the stale id in the form: the query
+  // re-keys, the scoped result is empty, the default effect early-returns on a null default, and the
+  // picker hides itself (`licensingRoots.length > 0`) — so the value is invisible AND submitted. The
+  // server coerces it, so nothing bad is written; this is about the form not carrying a selection it
+  // can neither show nor keep.
+  const prevModelTypeRef = useRef(model?.type);
+  useEffect(() => {
+    if (prevModelTypeRef.current === model?.type) return;
+    prevModelTypeRef.current = model?.type;
+    if (form.getValues('licensingSourceVersionId') != null)
+      form.setValue('licensingSourceVersionId', null, { shouldDirty: true });
+  }, [model?.type]);
+
   // A derivative must record an explicit parent — a null source means no fee, so
   // pre-select the ecosystem's default root when none is set. Skipped for roots
   // and exempt versions (which legitimately have no parent).

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -552,9 +552,19 @@ export function ModelVersionUpsertForm({
   const removingStoredCharge = removingStoredFee || removingStoredGate;
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
+  // 🔴 `enabled` waits on the model's TYPE, not just on `baseModel`. Do not relax it back.
+  // `baseModel` is seeded synchronously (version -> previousBaseModel -> lastUsedBaseModel -> default)
+  // while `model` arrives from a query, so gating on `baseModel` alone fires a first fetch with
+  // `modelType: undefined`. The type filter inside `getLicensingRoots` is conditional, so that
+  // unscoped fetch returns the ecosystem's CHECKPOINT roots — and the default-selection effect below
+  // stamps one onto a LoRA with `shouldDirty: false`, where nothing on screen marks it as changed. The
+  // scoped refetch then returns [], and the effect early-returns on a null default, so it can never
+  // clear what it already set. That is how 160 non-Checkpoint versions came to charge a checkpoint's
+  // per-image fee (CU 868kwf2fd). The server coerces the same case, but this is what stops the form
+  // showing a selection it is about to lose.
   const { data: licensingRootsData } = trpc.modelVersion.getLicensingRoots.useQuery(
     { baseModel, modelType: model?.type },
-    { enabled: !!baseModel }
+    { enabled: !!baseModel && !!model?.type }
   );
   const defaultLicensingSourceId = licensingRootsData?.defaultVersionId ?? null;
   // A version that is itself a licensing root is the source, so it doesn't pick a parent.

--- a/src/server/common/entity-change.constants.ts
+++ b/src/server/common/entity-change.constants.ts
@@ -32,6 +32,11 @@ export const watchedEntityFields = {
     'flags',
     'trainedWords',
     'licensingFee',
+    // Decides who is paid per image and by whom: a derivative inherits its root's fee, charged to the
+    // derivative's users and settled to the ROOT's owner. It was writable with no trail at all until
+    // CU 868kwf2fd — 160 versions carried a value nobody could account for, and the one that reached
+    // support had been charging the reporter twice per image for a month.
+    'licensingSourceVersionId',
   ],
   ModelFile: ['hash.SHA256'],
 } as const;

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -45,12 +45,13 @@ const call = async ({
   root = animaRoot as { baseModel: string; modelType: string } | null,
   licensingSourceVersionId = ANIMA_ROOT_VERSION_ID as number | null,
 }: {
-  modelType: string;
+  /** `null` stands for a modelId that resolves to no model — the handler cannot check the type then. */
+  modelType: string | null;
   baseModel?: string;
   root?: { baseModel: string; modelType: string } | null;
   licensingSourceVersionId?: number | null;
 }) => {
-  mockGetModel.mockResolvedValue({ type: modelType, nsfw: false });
+  mockGetModel.mockResolvedValue(modelType === null ? null : { type: modelType, nsfw: false });
   dbMock.dbRead.licensingRoot.findUnique.mockResolvedValue(root);
 
   await upsertModelVersionHandler({
@@ -98,6 +99,10 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
   it.each([
     ['the base model does not match', { baseModel: 'Illustrious' }],
     ['the source is not a registered root', { root: null }],
+    // "Could not check" must land on the same side as "checked and wrong". Written as a permissive
+    // `sourceModel && …` this case passes the source straight through, and the guard reads as enforced
+    // while being inert for it.
+    ['the model itself cannot be read', { modelType: null }],
   ])('drops a source when %s', async (_label, overrides) => {
     const written = await call({ modelType: 'Checkpoint', ...overrides });
     expect(written.licensingSourceVersionId).toBeNull();

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -31,32 +31,55 @@ vi.mock('~/server/redis/caches', () => ({ dataForModelsCache: { refresh: vi.fn()
 
 import { upsertModelVersionHandler } from '~/server/controllers/model-version.controller';
 
-const MODEL_ID = 2790719;
 const OWNER_ID = 5479411;
+/** The model named in the payload. */
+const PAYLOAD_MODEL_ID = 2790719;
+/** The model the version being edited actually belongs to — deliberately a different row. */
+const STORED_MODEL_ID = 999001;
+const VERSION_ID = 3144879;
 /** Anima base-v1.0 — a Checkpoint root charging 5.00 PerImageBuzz. */
 const ANIMA_ROOT_VERSION_ID = 2945208;
 
 /** The stored `LicensingRoot` row for {@link ANIMA_ROOT_VERSION_ID}. */
 const animaRoot = { baseModel: 'Anima', modelType: 'Checkpoint' };
 
+type Root = { baseModel: string; modelType: string } | null;
+
+/**
+ * `modelTypes` maps a model id to the type stored for it, or to `null` for a row that cannot be read.
+ * Keyed by id on purpose: the payload's model and the edited version's model are different rows, and
+ * the whole point of the update test is that the guard must use the latter.
+ */
 const call = async ({
-  modelType,
+  modelTypes,
+  id,
   baseModel = 'Anima',
-  root = animaRoot as { baseModel: string; modelType: string } | null,
+  root = animaRoot as Root,
   licensingSourceVersionId = ANIMA_ROOT_VERSION_ID as number | null,
 }: {
-  /** `null` stands for a modelId that resolves to no model — the handler cannot check the type then. */
-  modelType: string | null;
+  modelTypes: Record<number, string | null>;
+  id?: number;
   baseModel?: string;
-  root?: { baseModel: string; modelType: string } | null;
+  root?: Root;
   licensingSourceVersionId?: number | null;
 }) => {
-  mockGetModel.mockResolvedValue(modelType === null ? null : { type: modelType, nsfw: false });
   dbMock.dbRead.licensingRoot.findUnique.mockResolvedValue(root);
+  // Serves both reads the handler makes off this table: `storedUsageControl` and the owning modelId.
+  dbMock.dbWrite.modelVersion.findUnique.mockResolvedValue({
+    usageControl: 'Download',
+    modelId: STORED_MODEL_ID,
+  });
+  dbMock.dbWrite.model.findUnique.mockImplementation(async (args: { where: { id: number } }) => {
+    const type = modelTypes[args.where.id];
+    return type == null ? null : { type };
+  });
+  // Only reached after the write, for the nsfw read on the create branch.
+  mockGetModel.mockResolvedValue({ nsfw: false, type: 'LORA' });
 
   await upsertModelVersionHandler({
     input: {
-      modelId: MODEL_ID,
+      id,
+      modelId: PAYLOAD_MODEL_ID,
       name: 'v1.0',
       baseModel,
       // Download keeps the generation-only entitlement gate out of the way, and a null fee keeps the
@@ -74,51 +97,81 @@ const call = async ({
 
   return mockUpsertModelVersion.mock.calls[0][0] as {
     licensingSourceVersionId: number | null;
+    licensingSourceCoerced?: boolean;
   };
 };
 
+/** A create, where the payload's model IS the version's model. */
+const creating = (type: string | null) => ({ modelTypes: { [PAYLOAD_MODEL_ID]: type } });
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockUpsertModelVersion.mockResolvedValue({ id: 3144879, modelId: MODEL_ID });
+  mockUpsertModelVersion.mockResolvedValue({ id: VERSION_ID, modelId: PAYLOAD_MODEL_ID });
 });
 
 describe('upsertModelVersionHandler — licensing lineage scope', () => {
   it('drops a checkpoint root from a LORA', async () => {
-    const written = await call({ modelType: 'LORA' });
+    const written = await call(creating('LORA'));
     expect(written.licensingSourceVersionId).toBeNull();
   });
 
-  // The control for the test above. Same root, same base model, same call shape — only the model type
-  // differs, so a `licensingSourceVersionId: null` that came from the handler ignoring the field
-  // entirely (or from the mock never being read) fails here instead of passing everywhere.
+  // The control for the test above, and the reason it is worth anything: same root, same base model,
+  // same call shape — only the model type differs. A `licensingSourceVersionId: null` that came from
+  // the handler ignoring the field entirely, or from the mocks never being read, fails here instead of
+  // passing everywhere.
   it('keeps a checkpoint root on a CHECKPOINT', async () => {
-    const written = await call({ modelType: 'Checkpoint' });
+    const written = await call(creating('Checkpoint'));
     expect(written.licensingSourceVersionId).toBe(ANIMA_ROOT_VERSION_ID);
   });
 
   it.each([
     ['the base model does not match', { baseModel: 'Illustrious' }],
     ['the source is not a registered root', { root: null }],
-    // "Could not check" must land on the same side as "checked and wrong". Written as a permissive
-    // `sourceModel && …` this case passes the source straight through, and the guard reads as enforced
-    // while being inert for it.
-    ['the model itself cannot be read', { modelType: null }],
+    // "Could not check" must land on the same side as "checked and wrong". Written the permissive way
+    // this case passes the source straight through, and the guard reads as enforced while being inert
+    // for it.
+    ['the model itself cannot be read', { modelTypes: { [PAYLOAD_MODEL_ID]: null } }],
   ])('drops a source when %s', async (_label, overrides) => {
-    const written = await call({ modelType: 'Checkpoint', ...overrides });
+    const written = await call({ ...creating('Checkpoint'), ...overrides });
     expect(written.licensingSourceVersionId).toBeNull();
   });
 
+  // 🔴 The type comes from the model the EDITED VERSION belongs to, never from the payload.
+  // `isOwnerOrModerator` authorises against the version's stored modelId and never compares it to
+  // `input.modelId`, so a caller who owns both a LoRA and a Checkpoint can name the Checkpoint in the
+  // payload while editing the LoRA's version. Read the payload's model here and the type check is
+  // satisfied by a model the row has nothing to do with.
+  it('reads the type from the edited version, not from the payload', async () => {
+    const written = await call({
+      id: VERSION_ID,
+      modelTypes: { [PAYLOAD_MODEL_ID]: 'Checkpoint', [STORED_MODEL_ID]: 'LORA' },
+    });
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(dbMock.dbWrite.model.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: STORED_MODEL_ID } })
+    );
+  });
+
   // 🔴 Coercion, not rejection, is the deliberate half of this fix — see the comment on the guard.
-  // Throwing would make all 160 already-stamped versions unsaveable by their owners, because the
-  // version editor resubmits the stored value out of `defaultValues`. If someone "tightens" the guard
-  // into a throw, this is the test that says why not.
+  // Throwing would make every already-stamped version unsaveable by its owner, because the version
+  // editor resubmits the stored value out of `defaultValues`. If someone "tightens" the guard into a
+  // throw, this is the test that says why not.
   it('saves rather than erroring when it drops one', async () => {
-    await expect(call({ modelType: 'LORA' })).resolves.toBeDefined();
+    await expect(call(creating('LORA'))).resolves.toBeDefined();
     expect(mockUpsertModelVersion).toHaveBeenCalledTimes(1);
   });
 
+  // A coercion is a rule acting, not the creator. Without this flag the audit rows this fix exists to
+  // produce would name owners who did nothing — worse than the missing trail it replaces.
+  it('tells the service the clear was automated, and only when it was', async () => {
+    expect((await call(creating('LORA'))).licensingSourceCoerced).toBe(true);
+    vi.clearAllMocks();
+    mockUpsertModelVersion.mockResolvedValue({ id: VERSION_ID, modelId: PAYLOAD_MODEL_ID });
+    expect((await call(creating('Checkpoint'))).licensingSourceCoerced).toBe(false);
+  });
+
   it('leaves an unset source alone without reading the root table', async () => {
-    const written = await call({ modelType: 'LORA', licensingSourceVersionId: null });
+    const written = await call({ ...creating('LORA'), licensingSourceVersionId: null });
     expect(written.licensingSourceVersionId).toBeNull();
     expect(dbMock.dbRead.licensingRoot.findUnique).not.toHaveBeenCalled();
   });

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * `licensingSourceVersionId` makes a version inherit a root's per-image licence fee: the fee is
+ * charged to everyone who GENERATES with the derivative and settled to the ROOT's owner, on a line
+ * labelled with the derivative's name. So the field decides who is paid, by whom, per image — and it
+ * arrives over the wire from a form, which is why it is validated here rather than trusted.
+ *
+ * Every `LicensingRoot` row is `modelType: 'Checkpoint'`. The guard used to check the base model and
+ * not the model type, so a LoRA could hold a checkpoint's fee: CU 868kwf2fd / Freshdesk #69622, where
+ * the reporter paid 10 Buzz/image instead of 5 for a month and no surface on the site could clear it.
+ */
+
+const { mockUpsertModelVersion, mockGetModel } = vi.hoisted(() => ({
+  mockUpsertModelVersion: vi.fn(),
+  mockGetModel: vi.fn(),
+}));
+
+vi.mock('~/server/services/model-version.service', () => ({
+  upsertModelVersion: mockUpsertModelVersion,
+  assertUserEarlyAccessLimits: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('~/server/services/model.service', () => ({
+  getModel: mockGetModel,
+  queueModelEarlyAccessReindex: vi.fn().mockResolvedValue(undefined),
+}));
+// Reached at import through the orchestrator caller, which throws without a token.
+vi.mock('~/server/services/training.service', () => ({}));
+vi.mock('~/server/redis/caches', () => ({ dataForModelsCache: { refresh: vi.fn() } }));
+
+import { upsertModelVersionHandler } from '~/server/controllers/model-version.controller';
+
+const MODEL_ID = 2790719;
+const OWNER_ID = 5479411;
+/** Anima base-v1.0 — a Checkpoint root charging 5.00 PerImageBuzz. */
+const ANIMA_ROOT_VERSION_ID = 2945208;
+
+/** The stored `LicensingRoot` row for {@link ANIMA_ROOT_VERSION_ID}. */
+const animaRoot = { baseModel: 'Anima', modelType: 'Checkpoint' };
+
+const call = async ({
+  modelType,
+  baseModel = 'Anima',
+  root = animaRoot as { baseModel: string; modelType: string } | null,
+  licensingSourceVersionId = ANIMA_ROOT_VERSION_ID as number | null,
+}: {
+  modelType: string;
+  baseModel?: string;
+  root?: { baseModel: string; modelType: string } | null;
+  licensingSourceVersionId?: number | null;
+}) => {
+  mockGetModel.mockResolvedValue({ type: modelType, nsfw: false });
+  dbMock.dbRead.licensingRoot.findUnique.mockResolvedValue(root);
+
+  await upsertModelVersionHandler({
+    input: {
+      modelId: MODEL_ID,
+      name: 'v1.0',
+      baseModel,
+      // Download keeps the generation-only entitlement gate out of the way, and a null fee keeps the
+      // tier-cap branch out. Neither is what this file is about.
+      usageControl: 'Download',
+      licensingFee: null,
+      licensingSourceVersionId,
+    },
+    ctx: {
+      user: { id: OWNER_ID, isModerator: false, meta: {} },
+      features: {},
+      track: { modelVersionEvent: vi.fn().mockResolvedValue(undefined) },
+    },
+  } as never);
+
+  return mockUpsertModelVersion.mock.calls[0][0] as {
+    licensingSourceVersionId: number | null;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpsertModelVersion.mockResolvedValue({ id: 3144879, modelId: MODEL_ID });
+});
+
+describe('upsertModelVersionHandler — licensing lineage scope', () => {
+  it('drops a checkpoint root from a LORA', async () => {
+    const written = await call({ modelType: 'LORA' });
+    expect(written.licensingSourceVersionId).toBeNull();
+  });
+
+  // The control for the test above. Same root, same base model, same call shape — only the model type
+  // differs, so a `licensingSourceVersionId: null` that came from the handler ignoring the field
+  // entirely (or from the mock never being read) fails here instead of passing everywhere.
+  it('keeps a checkpoint root on a CHECKPOINT', async () => {
+    const written = await call({ modelType: 'Checkpoint' });
+    expect(written.licensingSourceVersionId).toBe(ANIMA_ROOT_VERSION_ID);
+  });
+
+  it.each([
+    ['the base model does not match', { baseModel: 'Illustrious' }],
+    ['the source is not a registered root', { root: null }],
+  ])('drops a source when %s', async (_label, overrides) => {
+    const written = await call({ modelType: 'Checkpoint', ...overrides });
+    expect(written.licensingSourceVersionId).toBeNull();
+  });
+
+  // 🔴 Coercion, not rejection, is the deliberate half of this fix — see the comment on the guard.
+  // Throwing would make all 160 already-stamped versions unsaveable by their owners, because the
+  // version editor resubmits the stored value out of `defaultValues`. If someone "tightens" the guard
+  // into a throw, this is the test that says why not.
+  it('saves rather than erroring when it drops one', async () => {
+    await expect(call({ modelType: 'LORA' })).resolves.toBeDefined();
+    expect(mockUpsertModelVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an unset source alone without reading the root table', async () => {
+    const written = await call({ modelType: 'LORA', licensingSourceVersionId: null });
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(dbMock.dbRead.licensingRoot.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -142,28 +142,15 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
     expect(written.licensingSourceVersionId).toBeNull();
   });
 
-  // 🔴 An update touches TWO models and both have to pass. Checking only one leaves a hole either
-  // way, and the two holes are opposite, so neither test below is redundant.
+  // 🔴 The type is checked against `input.modelId` — the model this save LANDS the version on —
+  // and NOT against the model it currently belongs to. `modelId` rides `...data` into
+  // `dbWrite.modelVersion.update`, so the payload's modelId is not a claim to be verified, it is the
+  // instruction for where the version will live, and that is where the fee will apply.
   //
-  // Only the payload's: `isOwnerOrModerator` authorises against the stored version's modelId and never
-  // compares it to `input.modelId`, so a caller who owns both models can name the Checkpoint in the
-  // payload while editing the LoRA's version.
-  it('rejects when the model the version currently belongs to is the wrong type', async () => {
-    const written = await call({
-      id: VERSION_ID,
-      modelTypes: { [PAYLOAD_MODEL_ID]: 'Checkpoint', [STORED_MODEL_ID]: 'LORA' },
-    });
-    expect(written.licensingSourceVersionId).toBeNull();
-    expect(dbMock.dbWrite.model.findUnique).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: STORED_MODEL_ID } })
-    );
-  });
-
-  // Only the stored one: `modelId` is not destructured in `upsertModelVersion`, so it rides `...data`
-  // into `dbWrite.modelVersion.update` and the save MOVES the version. A Checkpoint version holding a
-  // legitimate root, re-parented onto a LoRA model in the same request, would pass a stored-model-only
-  // check and land a checkpoint's per-image fee on a LoRA — this bug, through the guard for it.
-  it('rejects when the model the save MOVES the version to is the wrong type', async () => {
+  // Both tests below describe a MOVE, and they pull in opposite directions on purpose. Check the
+  // stored model instead and the first passes wrongly; require both to match and the second fails
+  // wrongly. Two earlier rounds of this fix shipped one mistake each.
+  it('rejects a root the DESTINATION model cannot hold, whatever the version came from', async () => {
     const written = await call({
       id: VERSION_ID,
       modelTypes: { [PAYLOAD_MODEL_ID]: 'LORA', [STORED_MODEL_ID]: 'Checkpoint' },
@@ -174,19 +161,24 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
     );
   });
 
-  // A templated write carries an `id` and still creates a NEW version under `input.modelId`, so there
-  // is no stored model to consult and `!!input.id` is the wrong predicate. Without this case,
-  // substituting `!!input.id` for `updatesExistingVersion` leaves every other test green.
-  it('uses the payload model for a templated write, id or not', async () => {
+  // The legitimate move: a checkpoint filed under a model someone mis-typed as LORA, moved to a
+  // properly typed Checkpoint model with its root intact. The fee is valid at the destination, so it
+  // must survive. Nothing tells the creator when it does not — `mini/[id]` reads a null source as NO
+  // lineage fee, not as a fallback — so an over-strict guard here quietly stops a payment.
+  it('keeps the root when a move lands the version somewhere it fits', async () => {
     const written = await call({
       id: VERSION_ID,
-      templateId: 77,
       modelTypes: { [PAYLOAD_MODEL_ID]: 'Checkpoint', [STORED_MODEL_ID]: 'LORA' },
     });
     expect(written.licensingSourceVersionId).toBe(ANIMA_ROOT_VERSION_ID);
-    expect(dbMock.dbWrite.model.findUnique).not.toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: STORED_MODEL_ID } })
-    );
+  });
+
+  // "Could not check the destination" has to land with "checked and wrong". Written permissively this
+  // case passes the source straight through on the exact path the guard exists for.
+  it('drops the source when the destination model cannot be read', async () => {
+    const written = await call({ id: VERSION_ID, modelTypes: { [STORED_MODEL_ID]: 'Checkpoint' } });
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(written.licensingSourceCoercedReason).toBe('model-not-found');
   });
 
   // 🔴 Coercion, not rejection, is the deliberate half of this fix — see the comment on the guard.

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -65,7 +65,7 @@ const call = async ({
   root?: Root;
   licensingSourceVersionId?: number | null;
 }) => {
-  dbMock.dbRead.licensingRoot.findUnique.mockResolvedValue(root);
+  dbMock.dbWrite.licensingRoot.findUnique.mockResolvedValue(root);
   // Keyed on the argument, NOT a flat `mockResolvedValue`. A mock that ignores its `where` hands
   // STORED_MODEL_ID back whatever row the guard asked for, which leaves the one test in this file about
   // *which row was looked up* unable to detect the wrong row being looked up. Measured: with a flat
@@ -142,6 +142,24 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
     expect(written.licensingSourceVersionId).toBeNull();
   });
 
+  // 🔴 The rule is "the destination's type equals the ROOT's type", not "the destination is a
+  // Checkpoint". Every LicensingRoot row is a Checkpoint today, so with only Checkpoint fixtures a
+  // guard hardcoded to `!== 'Checkpoint'` passes every other test in this file — measured. The day a
+  // LoRA or Video root is registered, that guard would drop every legitimate same-type lineage while
+  // the suite still reported the rule as enforced.
+  const loraRoot = { baseModel: 'Anima', modelType: 'LORA' };
+
+  it('keeps a LORA root on a LORA, though no such root exists yet', async () => {
+    const written = await call({ ...creating('LORA'), root: loraRoot });
+    expect(written.licensingSourceVersionId).toBe(ANIMA_ROOT_VERSION_ID);
+  });
+
+  it('drops a LORA root from a CHECKPOINT', async () => {
+    const written = await call({ ...creating('Checkpoint'), root: loraRoot });
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(written.licensingSourceCoercedReason).toBe('model-type-mismatch');
+  });
+
   // 🔴 The type is checked against `input.modelId` — the model this save LANDS the version on —
   // and NOT against the model it currently belongs to. `modelId` rides `...data` into
   // `dbWrite.modelVersion.update`, so the payload's modelId is not a claim to be verified, it is the
@@ -207,9 +225,11 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
     expect((await call(creating('Checkpoint'))).licensingSourceCoercedReason).toBeUndefined();
   });
 
+  // Only the call-count assertion is worth anything here: with the input already null, nothing in any
+  // implementation of the guard assigns to it, so asserting it came back null passes even with the
+  // whole block deleted. Dropped rather than left in as apparent coverage.
   it('leaves an unset source alone without reading the root table', async () => {
-    const written = await call({ ...creating('LORA'), licensingSourceVersionId: null });
-    expect(written.licensingSourceVersionId).toBeNull();
-    expect(dbMock.dbRead.licensingRoot.findUnique).not.toHaveBeenCalled();
+    await call({ ...creating('LORA'), licensingSourceVersionId: null });
+    expect(dbMock.dbWrite.licensingRoot.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -53,22 +53,27 @@ type Root = { baseModel: string; modelType: string } | null;
 const call = async ({
   modelTypes,
   id,
+  templateId,
   baseModel = 'Anima',
   root = animaRoot as Root,
   licensingSourceVersionId = ANIMA_ROOT_VERSION_ID as number | null,
 }: {
   modelTypes: Record<number, string | null>;
   id?: number;
+  templateId?: number;
   baseModel?: string;
   root?: Root;
   licensingSourceVersionId?: number | null;
 }) => {
   dbMock.dbRead.licensingRoot.findUnique.mockResolvedValue(root);
-  // Serves both reads the handler makes off this table: `storedUsageControl` and the owning modelId.
-  dbMock.dbWrite.modelVersion.findUnique.mockResolvedValue({
-    usageControl: 'Download',
-    modelId: STORED_MODEL_ID,
-  });
+  // Keyed on the argument, NOT a flat `mockResolvedValue`. A mock that ignores its `where` hands
+  // STORED_MODEL_ID back whatever row the guard asked for, which leaves the one test in this file about
+  // *which row was looked up* unable to detect the wrong row being looked up. Measured: with a flat
+  // mock, changing the guard to read `input.modelId` left all nine tests green.
+  dbMock.dbWrite.modelVersion.findUnique.mockImplementation(
+    async (args: { where: { id: number } }) =>
+      args.where.id === VERSION_ID ? { usageControl: 'Download', modelId: STORED_MODEL_ID } : null
+  );
   dbMock.dbWrite.model.findUnique.mockImplementation(async (args: { where: { id: number } }) => {
     const type = modelTypes[args.where.id];
     return type == null ? null : { type };
@@ -79,6 +84,7 @@ const call = async ({
   await upsertModelVersionHandler({
     input: {
       id,
+      templateId,
       modelId: PAYLOAD_MODEL_ID,
       name: 'v1.0',
       baseModel,
@@ -97,7 +103,7 @@ const call = async ({
 
   return mockUpsertModelVersion.mock.calls[0][0] as {
     licensingSourceVersionId: number | null;
-    licensingSourceCoerced?: boolean;
+    licensingSourceCoercedReason?: string;
   };
 };
 
@@ -136,18 +142,49 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
     expect(written.licensingSourceVersionId).toBeNull();
   });
 
-  // 🔴 The type comes from the model the EDITED VERSION belongs to, never from the payload.
-  // `isOwnerOrModerator` authorises against the version's stored modelId and never compares it to
-  // `input.modelId`, so a caller who owns both a LoRA and a Checkpoint can name the Checkpoint in the
-  // payload while editing the LoRA's version. Read the payload's model here and the type check is
-  // satisfied by a model the row has nothing to do with.
-  it('reads the type from the edited version, not from the payload', async () => {
+  // 🔴 An update touches TWO models and both have to pass. Checking only one leaves a hole either
+  // way, and the two holes are opposite, so neither test below is redundant.
+  //
+  // Only the payload's: `isOwnerOrModerator` authorises against the stored version's modelId and never
+  // compares it to `input.modelId`, so a caller who owns both models can name the Checkpoint in the
+  // payload while editing the LoRA's version.
+  it('rejects when the model the version currently belongs to is the wrong type', async () => {
     const written = await call({
       id: VERSION_ID,
       modelTypes: { [PAYLOAD_MODEL_ID]: 'Checkpoint', [STORED_MODEL_ID]: 'LORA' },
     });
     expect(written.licensingSourceVersionId).toBeNull();
     expect(dbMock.dbWrite.model.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: STORED_MODEL_ID } })
+    );
+  });
+
+  // Only the stored one: `modelId` is not destructured in `upsertModelVersion`, so it rides `...data`
+  // into `dbWrite.modelVersion.update` and the save MOVES the version. A Checkpoint version holding a
+  // legitimate root, re-parented onto a LoRA model in the same request, would pass a stored-model-only
+  // check and land a checkpoint's per-image fee on a LoRA — this bug, through the guard for it.
+  it('rejects when the model the save MOVES the version to is the wrong type', async () => {
+    const written = await call({
+      id: VERSION_ID,
+      modelTypes: { [PAYLOAD_MODEL_ID]: 'LORA', [STORED_MODEL_ID]: 'Checkpoint' },
+    });
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(dbMock.dbWrite.model.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: PAYLOAD_MODEL_ID } })
+    );
+  });
+
+  // A templated write carries an `id` and still creates a NEW version under `input.modelId`, so there
+  // is no stored model to consult and `!!input.id` is the wrong predicate. Without this case,
+  // substituting `!!input.id` for `updatesExistingVersion` leaves every other test green.
+  it('uses the payload model for a templated write, id or not', async () => {
+    const written = await call({
+      id: VERSION_ID,
+      templateId: 77,
+      modelTypes: { [PAYLOAD_MODEL_ID]: 'Checkpoint', [STORED_MODEL_ID]: 'LORA' },
+    });
+    expect(written.licensingSourceVersionId).toBe(ANIMA_ROOT_VERSION_ID);
+    expect(dbMock.dbWrite.model.findUnique).not.toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: STORED_MODEL_ID } })
     );
   });
@@ -161,13 +198,21 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
     expect(mockUpsertModelVersion).toHaveBeenCalledTimes(1);
   });
 
-  // A coercion is a rule acting, not the creator. Without this flag the audit rows this fix exists to
-  // produce would name owners who did nothing — worse than the missing trail it replaces.
-  it('tells the service the clear was automated, and only when it was', async () => {
-    expect((await call(creating('LORA'))).licensingSourceCoerced).toBe(true);
-    vi.clearAllMocks();
-    mockUpsertModelVersion.mockResolvedValue({ id: VERSION_ID, modelId: PAYLOAD_MODEL_ID });
-    expect((await call(creating('Checkpoint'))).licensingSourceCoerced).toBe(false);
+  // A coercion is a rule acting, not the creator, and the audit has to say WHICH rule. A bare boolean
+  // collapses four distinct branches into one sentence, so a moderator reading the change history
+  // cannot tell a type mismatch from a model that could not be read. With no flag at all, the rows this
+  // fix exists to produce name owners who did nothing — worse than the missing trail it replaces.
+  it.each([
+    ['a type mismatch', {}, 'model-type-mismatch'],
+    ['an unregistered source', { root: null }, 'not-a-root'],
+    ['a base-model mismatch', { baseModel: 'Illustrious' }, 'base-model-mismatch'],
+  ])('tells the service the clear was automated, and why: %s', async (_l, overrides, expected) => {
+    const written = await call({ ...creating('LORA'), ...overrides });
+    expect(written.licensingSourceCoercedReason).toBe(expected);
+  });
+
+  it('says nothing about coercion when it kept the source', async () => {
+    expect((await call(creating('Checkpoint'))).licensingSourceCoercedReason).toBeUndefined();
   });
 
   it('leaves an unset source alone without reading the root table', async () => {

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -553,12 +553,17 @@ export const upsertModelVersionHandler = async ({
     //
     // 🔴 Coerced to null, NOT rejected, and that is deliberate — do not "tighten" it into a throw.
     // The version editor re-submits the stored value out of `defaultValues`, so throwing would make
-    // every already-stamped version unsaveable by its owner. 160 versions were in that state when this
-    // landed, including two whose base model no longer matches their source, so a throw would strand
-    // real creators on an error they cannot act on — a worse bug than the one being fixed. Coercing
-    // blocks the bad write AND repairs the stored value on the owner's next save.
+    // every already-stamped version unsaveable by its owner. 159 versions were in that state when this
+    // landed, and six of them ALSO carry a base model that no longer matches their source (four
+    // Checkpoints on Wan Video / Flux / SDXL / Other, two LoRAs on Illustrious, all pointing at Anima's
+    // root) — those six already hit the older base-model throw below and cannot be saved at all today.
+    // A throw would strand real creators on an error they cannot act on, which is a worse bug than the
+    // one being fixed. Coercing blocks the bad write AND repairs the stored value on the owner's next
+    // save.
     // Nothing legitimate is lost: the picker only ever offers roots that pass this same scope, so a
-    // deliberate selection cannot reach the coercion.
+    // deliberate selection cannot reach the coercion. It is also not a way to dodge a fee — sending
+    // `null` outright has always been allowed, and 99.77% of Anima and Krea 2 LoRAs do exactly that
+    // (107 of 46,994 and 45 of 19,999 carry a source at all).
     if (input.licensingSourceVersionId != null) {
       const [source, sourceModel] = await Promise.all([
         dbRead.licensingRoot.findUnique({
@@ -567,11 +572,17 @@ export const upsertModelVersionHandler = async ({
         }),
         getModel({ id: input.modelId, select: { type: true } }),
       ]);
+      // A missing model coerces rather than passing. `getModel` filters on nothing but the id, so this
+      // only happens for a modelId that does not exist — the upsert below throws on it anyway. Writing
+      // it as `sourceModel && ...` instead would make "we could not check" indistinguishable from
+      // "we checked and it was fine", which is the shape of every guard that turns out to be inert.
       const rejectedReason = !source
         ? 'not-a-root'
         : source.baseModel !== input.baseModel
         ? 'base-model-mismatch'
-        : sourceModel && source.modelType !== sourceModel.type
+        : !sourceModel
+        ? 'model-not-found'
+        : source.modelType !== sourceModel.type
         ? 'model-type-mismatch'
         : null;
       if (rejectedReason) {

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -542,6 +542,10 @@ export const upsertModelVersionHandler = async ({
         input.licensingFeeSettlementCurrency = LicensingFeeSettlementCurrency.Buzz;
     }
 
+    // Set when the block below repairs the payload, so the audit can attribute the change to the rule
+    // rather than to the creator. Without it the first rows this new trail ever produces are automated
+    // repairs wearing an owner's name — which is the opposite of why the field was added to the audit.
+    let licensingSourceCoerced = false;
     // Licensing lineage: the chosen source must be a registered LicensingRoot for the same base model
     // AND the same model type. The model-type half is the one that was missing (CU 868kwf2fd,
     // Freshdesk #69622): every LicensingRoot row is a Checkpoint, so a LoRA that inherits one charges
@@ -565,24 +569,55 @@ export const upsertModelVersionHandler = async ({
     // `null` outright has always been allowed, and 99.77% of Anima and Krea 2 LoRAs do exactly that
     // (107 of 46,994 and 45 of 19,999 carry a source at all).
     if (input.licensingSourceVersionId != null) {
-      const [source, sourceModel] = await Promise.all([
+      const [source, owningModel] = await Promise.all([
         dbRead.licensingRoot.findUnique({
           where: { modelVersionId: input.licensingSourceVersionId },
           select: { baseModel: true, modelType: true },
         }),
-        getModel({ id: input.modelId, select: { type: true } }),
+        // 🔴 Two things this read must NOT do, both of which it did in an earlier round of this fix.
+        //
+        // It must not read the model through `getModel`. That resolves its client through
+        // `getDbWithoutLag`, so a model created seconds ago — which is precisely the ModelWizard's
+        // step-1-then-step-2 shape — can come back as a replica miss. The coercion below turns a miss
+        // into `null`, and because it coerces rather than throws the creator is never told. The service
+        // reads the same row with `dbWrite.model.findUniqueOrThrow`, so the save still succeeds and the
+        // field is silently gone. `storedUsageControl` above uses `dbWrite` for the identical reason:
+        // "a replica miss must not read as already-generation-only".
+        //
+        // And on an update it must not trust `input.modelId`. `isOwnerOrModerator` authorises against
+        // the modelId of the version being EDITED, never against the one in the payload, so a caller
+        // who owns both a LoRA and a Checkpoint could send the LoRA's version id with the Checkpoint's
+        // modelId and have the type compared against the wrong model. `updatesExistingVersion` is the
+        // right predicate rather than `!!input.id`: a templated write carries an id and still creates a
+        // NEW version under `input.modelId`.
+        (async () => {
+          const owningModelId = updatesExistingVersion
+            ? (
+                await dbWrite.modelVersion.findUnique({
+                  where: { id: input.id },
+                  select: { modelId: true },
+                })
+              )?.modelId
+            : input.modelId;
+          if (owningModelId == null) return null;
+          return dbWrite.model.findUnique({
+            where: { id: owningModelId },
+            select: { type: true },
+          });
+        })(),
       ]);
-      // A missing model coerces rather than passing. `getModel` filters on nothing but the id, so this
-      // only happens for a modelId that does not exist — the upsert below throws on it anyway. Writing
-      // it as `sourceModel && ...` instead would make "we could not check" indistinguishable from
-      // "we checked and it was fine", which is the shape of every guard that turns out to be inert.
+      // A model that cannot be read coerces rather than passing. Read from `dbWrite` above, `null` here
+      // means the row genuinely does not exist — and the service's own `findUniqueOrThrow` on the same
+      // client will reject the save moments later, so this branch costs a real creator nothing. Written
+      // the permissive way (`owningModel && ...`) it would make "we could not check" indistinguishable
+      // from "we checked and it was fine", which is the shape of every guard that turns out inert.
       const rejectedReason = !source
         ? 'not-a-root'
         : source.baseModel !== input.baseModel
         ? 'base-model-mismatch'
-        : !sourceModel
+        : !owningModel
         ? 'model-not-found'
-        : source.modelType !== sourceModel.type
+        : source.modelType !== owningModel.type
         ? 'model-type-mismatch'
         : null;
       if (rejectedReason) {
@@ -596,12 +631,13 @@ export const upsertModelVersionHandler = async ({
           modelId: input.modelId,
           modelVersionId: input.id ?? null,
           requestedSourceVersionId: input.licensingSourceVersionId,
-          modelType: sourceModel?.type ?? null,
+          modelType: owningModel?.type ?? null,
           sourceModelType: source?.modelType ?? null,
           baseModel: input.baseModel ?? null,
           sourceBaseModel: source?.baseModel ?? null,
         }).catch(() => null);
         input.licensingSourceVersionId = null;
+        licensingSourceCoerced = true;
       }
     }
 
@@ -611,6 +647,7 @@ export const upsertModelVersionHandler = async ({
       tracker: ctx.track,
       actorUserId: userId,
       isModerator: ctx.user.isModerator,
+      licensingSourceCoerced,
     });
     if (!version) throw throwNotFoundError(`No model version with id ${input.id as number}`);
 

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -422,14 +422,15 @@ export const upsertModelVersionHandler = async ({
     const updatesExistingVersion = !!input.id && !input.templateId;
     // dbWrite, and a miss counts as a grant: this decides an entitlement, and the edit wizard saves again
     // fast enough to beat replication — a replica miss must not read as "already generation-only".
-    const storedUsageControl = updatesExistingVersion
-      ? (
-          await dbWrite.modelVersion.findUnique({
-            where: { id: input.id },
-            select: { usageControl: true },
-          })
-        )?.usageControl
+    // `modelId` comes along for the licensing-lineage guard further down, which needs the model this
+    // version currently belongs to. One read rather than two of the same row.
+    const storedVersion = updatesExistingVersion
+      ? await dbWrite.modelVersion.findUnique({
+          where: { id: input.id },
+          select: { usageControl: true, modelId: true },
+        })
       : undefined;
+    const storedUsageControl = storedVersion?.usageControl;
     const grantsGenerationOnly =
       input.usageControl !== ModelUsageControl.Download &&
       (!updatesExistingVersion || storedUsageControl !== ModelUsageControl.Generation);
@@ -545,7 +546,7 @@ export const upsertModelVersionHandler = async ({
     // Set when the block below repairs the payload, so the audit can attribute the change to the rule
     // rather than to the creator. Without it the first rows this new trail ever produces are automated
     // repairs wearing an owner's name — which is the opposite of why the field was added to the audit.
-    let licensingSourceCoerced = false;
+    let licensingSourceCoercedReason: string | undefined;
     // Licensing lineage: the chosen source must be a registered LicensingRoot for the same base model
     // AND the same model type. The model-type half is the one that was missing (CU 868kwf2fd,
     // Freshdesk #69622): every LicensingRoot row is a Checkpoint, so a LoRA that inherits one charges
@@ -569,55 +570,57 @@ export const upsertModelVersionHandler = async ({
     // `null` outright has always been allowed, and 99.77% of Anima and Krea 2 LoRAs do exactly that
     // (107 of 46,994 and 45 of 19,999 carry a source at all).
     if (input.licensingSourceVersionId != null) {
-      const [source, owningModel] = await Promise.all([
+      const [source, owningModels] = await Promise.all([
         dbRead.licensingRoot.findUnique({
           where: { modelVersionId: input.licensingSourceVersionId },
           select: { baseModel: true, modelType: true },
         }),
-        // 🔴 Two things this read must NOT do, both of which it did in an earlier round of this fix.
+        // 🔴 This resolves EVERY model the version touches on this save, and each one has to pass.
         //
-        // It must not read the model through `getModel`. That resolves its client through
-        // `getDbWithoutLag`, so a model created seconds ago — which is precisely the ModelWizard's
-        // step-1-then-step-2 shape — can come back as a replica miss. The coercion below turns a miss
-        // into `null`, and because it coerces rather than throws the creator is never told. The service
-        // reads the same row with `dbWrite.model.findUniqueOrThrow`, so the save still succeeds and the
-        // field is silently gone. `storedUsageControl` above uses `dbWrite` for the identical reason:
-        // "a replica miss must not read as already-generation-only".
+        // Not `getModel`: that goes through `getDbWithoutLag`, so a model created seconds ago — the
+        // ModelWizard's step-1-then-step-2 shape exactly — can come back as a replica miss. The
+        // coercion below turns a miss into `null`, and because it coerces rather than throws the
+        // creator is never told. `storedUsageControl` above uses `dbWrite` for the same reason: "a
+        // replica miss must not read as already-generation-only".
         //
-        // And on an update it must not trust `input.modelId`. `isOwnerOrModerator` authorises against
-        // the modelId of the version being EDITED, never against the one in the payload, so a caller
-        // who owns both a LoRA and a Checkpoint could send the LoRA's version id with the Checkpoint's
-        // modelId and have the type compared against the wrong model. `updatesExistingVersion` is the
-        // right predicate rather than `!!input.id`: a templated write carries an id and still creates a
-        // NEW version under `input.modelId`.
+        // And not one model but two, because `modelId` is not destructured in `upsertModelVersion` —
+        // it rides `...data` straight into `dbWrite.modelVersion.update`, so **a save can move the
+        // version to another model**. `isOwnerOrModerator` authorises only against the modelId of the
+        // version being EDITED and never compares it to the payload's. Check only the stored model and
+        // a Checkpoint version carrying a legitimate root can be re-parented onto a LoRA model in the
+        // same request: the guard sees Checkpoint, passes, and the write lands a checkpoint's per-image
+        // fee on a LoRA — this exact bug, through the guard that exists to stop it. Check only the
+        // payload's and the auth mismatch above reopens. So: both, deduped.
+        //
+        // `storedVersion` is already read only when `updatesExistingVersion` — a templated write
+        // carries an id and still creates a NEW version under `input.modelId`, where there is no
+        // stored model to consult, so it is `undefined` here and the set is just the payload's. Do NOT
+        // re-test that condition on this line: a mutation run proved the extra ternary can never
+        // change the result, and a conditional that cannot go the other way reads as a guard while
+        // guarding nothing.
         (async () => {
-          const owningModelId = updatesExistingVersion
-            ? (
-                await dbWrite.modelVersion.findUnique({
-                  where: { id: input.id },
-                  select: { modelId: true },
-                })
-              )?.modelId
-            : input.modelId;
-          if (owningModelId == null) return null;
-          return dbWrite.model.findUnique({
-            where: { id: owningModelId },
-            select: { type: true },
-          });
+          const ids = [...new Set([input.modelId, storedVersion?.modelId].filter(isDefined))];
+          // An update whose stored row could not be read leaves nothing to check it against; that is a
+          // "could not check", which lands with "checked and wrong" rather than passing.
+          if (updatesExistingVersion && storedVersion?.modelId == null) return null;
+          const models = await Promise.all(
+            ids.map((id) => dbWrite.model.findUnique({ where: { id }, select: { type: true } }))
+          );
+          return models.some((m) => !m) ? null : models.filter(isDefined);
         })(),
       ]);
-      // A model that cannot be read coerces rather than passing. Read from `dbWrite` above, `null` here
-      // means the row genuinely does not exist — and the service's own `findUniqueOrThrow` on the same
-      // client will reject the save moments later, so this branch costs a real creator nothing. Written
-      // the permissive way (`owningModel && ...`) it would make "we could not check" indistinguishable
-      // from "we checked and it was fine", which is the shape of every guard that turns out inert.
+      // A model that cannot be read coerces rather than passing. Written the permissive way
+      // (`owningModels && ...`) it would make "we could not check" indistinguishable from "we checked
+      // and it was fine", which is the shape of every guard that turns out inert. Do not soften this on
+      // the argument that the service throws on a missing model anyway: it throws on `data.modelId`,
+      // which on an update is not necessarily the row that failed to read here.
       const rejectedReason = !source
         ? 'not-a-root'
         : source.baseModel !== input.baseModel
         ? 'base-model-mismatch'
-        : !owningModel
+        : !owningModels
         ? 'model-not-found'
-        : source.modelType !== owningModel.type
+        : owningModels.some((m) => m.type !== source.modelType)
         ? 'model-type-mismatch'
         : null;
       if (rejectedReason) {
@@ -628,16 +631,20 @@ export const upsertModelVersionHandler = async ({
           type: 'info',
           reason: rejectedReason,
           userId,
+          // Both ids, because on an update they can differ and reporting one next to the other's type
+          // is how a log stops being evidence. `storedModelId` is where the version is now,
+          // `modelId` is where this save puts it.
           modelId: input.modelId,
+          storedModelId: storedVersion?.modelId ?? null,
           modelVersionId: input.id ?? null,
           requestedSourceVersionId: input.licensingSourceVersionId,
-          modelType: owningModel?.type ?? null,
+          modelTypes: owningModels?.map((m) => m.type) ?? null,
           sourceModelType: source?.modelType ?? null,
           baseModel: input.baseModel ?? null,
           sourceBaseModel: source?.baseModel ?? null,
         }).catch(() => null);
         input.licensingSourceVersionId = null;
-        licensingSourceCoerced = true;
+        licensingSourceCoercedReason = rejectedReason;
       }
     }
 
@@ -647,7 +654,7 @@ export const upsertModelVersionHandler = async ({
       tracker: ctx.track,
       actorUserId: userId,
       isModerator: ctx.user.isModerator,
-      licensingSourceCoerced,
+      licensingSourceCoercedReason,
     });
     if (!version) throw throwNotFoundError(`No model version with id ${input.id as number}`);
 

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -422,15 +422,14 @@ export const upsertModelVersionHandler = async ({
     const updatesExistingVersion = !!input.id && !input.templateId;
     // dbWrite, and a miss counts as a grant: this decides an entitlement, and the edit wizard saves again
     // fast enough to beat replication — a replica miss must not read as "already generation-only".
-    // `modelId` comes along for the licensing-lineage guard further down, which needs the model this
-    // version currently belongs to. One read rather than two of the same row.
-    const storedVersion = updatesExistingVersion
-      ? await dbWrite.modelVersion.findUnique({
-          where: { id: input.id },
-          select: { usageControl: true, modelId: true },
-        })
+    const storedUsageControl = updatesExistingVersion
+      ? (
+          await dbWrite.modelVersion.findUnique({
+            where: { id: input.id },
+            select: { usageControl: true },
+          })
+        )?.usageControl
       : undefined;
-    const storedUsageControl = storedVersion?.usageControl;
     const grantsGenerationOnly =
       input.usageControl !== ModelUsageControl.Download &&
       (!updatesExistingVersion || storedUsageControl !== ModelUsageControl.Generation);
@@ -570,57 +569,44 @@ export const upsertModelVersionHandler = async ({
     // `null` outright has always been allowed, and 99.77% of Anima and Krea 2 LoRAs do exactly that
     // (107 of 46,994 and 45 of 19,999 carry a source at all).
     if (input.licensingSourceVersionId != null) {
-      const [source, owningModels] = await Promise.all([
+      const [source, destinationModel] = await Promise.all([
         dbRead.licensingRoot.findUnique({
           where: { modelVersionId: input.licensingSourceVersionId },
           select: { baseModel: true, modelType: true },
         }),
-        // 🔴 This resolves EVERY model the version touches on this save, and each one has to pass.
+        // 🔴 The model this save LANDS the version on, which is `input.modelId` — always, on a create
+        // and on an update alike. `modelId` is not destructured in `upsertModelVersion`, so it rides
+        // `...data` into `dbWrite.modelVersion.update`: the payload's modelId is not a claim about
+        // where the version lives that we would have to verify, it is the instruction for where it
+        // will live. Whatever it names is where the fee will apply, so it is the only model whose type
+        // matters.
         //
-        // Not `getModel`: that goes through `getDbWithoutLag`, so a model created seconds ago — the
-        // ModelWizard's step-1-then-step-2 shape exactly — can come back as a replica miss. The
-        // coercion below turns a miss into `null`, and because it coerces rather than throws the
-        // creator is never told. `storedUsageControl` above uses `dbWrite` for the same reason: "a
-        // replica miss must not read as already-generation-only".
+        // Two earlier rounds of this fix got that backwards — one read the STORED model (so a version
+        // could be re-parented onto a LoRA model in the same request and keep a checkpoint's fee), the
+        // next required BOTH to match (which silently cleared a valid root when someone moved a
+        // version out of a mis-typed model into a correctly typed one). If `modelId` is ever stripped
+        // from the update payload, the destination becomes the stored model and this line has to move
+        // with it — the test named for the move is what will tell you.
         //
-        // And not one model but two, because `modelId` is not destructured in `upsertModelVersion` —
-        // it rides `...data` straight into `dbWrite.modelVersion.update`, so **a save can move the
-        // version to another model**. `isOwnerOrModerator` authorises only against the modelId of the
-        // version being EDITED and never compares it to the payload's. Check only the stored model and
-        // a Checkpoint version carrying a legitimate root can be re-parented onto a LoRA model in the
-        // same request: the guard sees Checkpoint, passes, and the write lands a checkpoint's per-image
-        // fee on a LoRA — this exact bug, through the guard that exists to stop it. Check only the
-        // payload's and the auth mismatch above reopens. So: both, deduped.
-        //
-        // `storedVersion` is already read only when `updatesExistingVersion` — a templated write
-        // carries an id and still creates a NEW version under `input.modelId`, where there is no
-        // stored model to consult, so it is `undefined` here and the set is just the payload's. Do NOT
-        // re-test that condition on this line: a mutation run proved the extra ternary can never
-        // change the result, and a conditional that cannot go the other way reads as a guard while
-        // guarding nothing.
-        (async () => {
-          const ids = [...new Set([input.modelId, storedVersion?.modelId].filter(isDefined))];
-          // An update whose stored row could not be read leaves nothing to check it against; that is a
-          // "could not check", which lands with "checked and wrong" rather than passing.
-          if (updatesExistingVersion && storedVersion?.modelId == null) return null;
-          const models = await Promise.all(
-            ids.map((id) => dbWrite.model.findUnique({ where: { id }, select: { type: true } }))
-          );
-          return models.some((m) => !m) ? null : models.filter(isDefined);
-        })(),
+        // Not `getModel`: that resolves its client through `getDbWithoutLag`, so a model created
+        // seconds ago — the ModelWizard's step-1-then-step-2 shape exactly — can come back as a
+        // replica miss. The coercion below turns a miss into `null`, and because it coerces rather
+        // than throws the creator is never told. `storedUsageControl` above uses `dbWrite` for the
+        // same reason: "a replica miss must not read as already-generation-only".
+        input.modelId
+          ? dbWrite.model.findUnique({ where: { id: input.modelId }, select: { type: true } })
+          : null,
       ]);
-      // A model that cannot be read coerces rather than passing. Written the permissive way
-      // (`owningModels && ...`) it would make "we could not check" indistinguishable from "we checked
-      // and it was fine", which is the shape of every guard that turns out inert. Do not soften this on
-      // the argument that the service throws on a missing model anyway: it throws on `data.modelId`,
-      // which on an update is not necessarily the row that failed to read here.
+      // A destination that cannot be read coerces rather than passing. Written the permissive way
+      // (`destinationModel && ...`) it would make "we could not check" indistinguishable from "we
+      // checked and it was fine", which is the shape of every guard that turns out inert.
       const rejectedReason = !source
         ? 'not-a-root'
         : source.baseModel !== input.baseModel
         ? 'base-model-mismatch'
-        : !owningModels
+        : !destinationModel
         ? 'model-not-found'
-        : owningModels.some((m) => m.type !== source.modelType)
+        : destinationModel.type !== source.modelType
         ? 'model-type-mismatch'
         : null;
       if (rejectedReason) {
@@ -631,14 +617,12 @@ export const upsertModelVersionHandler = async ({
           type: 'info',
           reason: rejectedReason,
           userId,
-          // Both ids, because on an update they can differ and reporting one next to the other's type
-          // is how a log stops being evidence. `storedModelId` is where the version is now,
-          // `modelId` is where this save puts it.
+          // `modelId` is where this save puts the version, and `modelType` is that model's type — the
+          // two have to name the same row or the log stops being evidence.
           modelId: input.modelId,
-          storedModelId: storedVersion?.modelId ?? null,
           modelVersionId: input.id ?? null,
           requestedSourceVersionId: input.licensingSourceVersionId,
-          modelTypes: owningModels?.map((m) => m.type) ?? null,
+          modelType: destinationModel?.type ?? null,
           sourceModelType: source?.modelType ?? null,
           baseModel: input.baseModel ?? null,
           sourceBaseModel: source?.baseModel ?? null,

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -12,6 +12,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { getFeatureFlagsLazy, userTiers } from '~/server/services/feature-flags.service';
 import type { SessionUser } from '~/types/session';
 import type { BaseModelType } from '~/server/common/constants';
+import type { LicensingSourceRejection } from '~/server/schema/model-version.schema';
 import { type BaseModel, DEPRECATED_BASE_MODELS } from '~/shared/constants/basemodel.constants';
 import { baseModelLicenses, constants } from '~/server/common/constants';
 import type { Context, ProtectedContext } from '~/server/createContext';
@@ -545,7 +546,7 @@ export const upsertModelVersionHandler = async ({
     // Set when the block below repairs the payload, so the audit can attribute the change to the rule
     // rather than to the creator. Without it the first rows this new trail ever produces are automated
     // repairs wearing an owner's name — which is the opposite of why the field was added to the audit.
-    let licensingSourceCoercedReason: string | undefined;
+    let licensingSourceCoercedReason: LicensingSourceRejection | undefined;
     // Licensing lineage: the chosen source must be a registered LicensingRoot for the same base model
     // AND the same model type. The model-type half is the one that was missing (CU 868kwf2fd,
     // Freshdesk #69622): every LicensingRoot row is a Checkpoint, so a LoRA that inherits one charges
@@ -570,7 +571,10 @@ export const upsertModelVersionHandler = async ({
     // (107 of 46,994 and 45 of 19,999 carry a source at all).
     if (input.licensingSourceVersionId != null) {
       const [source, destinationModel] = await Promise.all([
-        dbRead.licensingRoot.findUnique({
+        // `dbWrite`, matching the destination read below rather than sitting one line above it under the
+        // opposite rule. A root registered moments ago that misses on the replica reads as
+        // `'not-a-root'`, which silently clears a legitimate source with no error to the creator.
+        dbWrite.licensingRoot.findUnique({
           where: { modelVersionId: input.licensingSourceVersionId },
           select: { baseModel: true, modelType: true },
         }),
@@ -597,10 +601,14 @@ export const upsertModelVersionHandler = async ({
           ? dbWrite.model.findUnique({ where: { id: input.modelId }, select: { type: true } })
           : null,
       ]);
-      // A destination that cannot be read coerces rather than passing. Written the permissive way
-      // (`destinationModel && ...`) it would make "we could not check" indistinguishable from "we
-      // checked and it was fine", which is the shape of every guard that turns out inert.
-      const rejectedReason = !source
+      // A destination that cannot be read coerces rather than passing. Note what this branch is and is
+      // not: `upsertModelVersion` opens with `findUniqueOrThrow` on `data.modelId` against the same
+      // `dbWrite` client, so a miss here is a throw a few statements later and NO save lands either
+      // way. It is not load-bearing for any persisted outcome. It is kept because writing it the
+      // permissive way (`destinationModel && ...`) makes "we could not check" indistinguishable from
+      // "we checked and it was fine" in the source, and the next person to move this block should not
+      // have to rediscover which of those it meant.
+      const rejectedReason: LicensingSourceRejection | null = !source
         ? 'not-a-root'
         : source.baseModel !== input.baseModel
         ? 'base-model-mismatch'

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -542,18 +542,56 @@ export const upsertModelVersionHandler = async ({
         input.licensingFeeSettlementCurrency = LicensingFeeSettlementCurrency.Buzz;
     }
 
-    // Licensing lineage: the chosen source must be a registered LicensingRoot for
-    // the same base model. Guards against pointing at an arbitrary version to
-    // dodge the base-model rule.
+    // Licensing lineage: the chosen source must be a registered LicensingRoot for the same base model
+    // AND the same model type. The model-type half is the one that was missing (CU 868kwf2fd,
+    // Freshdesk #69622): every LicensingRoot row is a Checkpoint, so a LoRA that inherits one charges
+    // the checkpoint's per-image fee to everyone who generates with it, settled to the CHECKPOINT
+    // owner, on a line labelled with the LoRA's own name. The reporter paid 10 Buzz/image instead of 5
+    // for a month, and no surface on the site could clear it. `getLicensingRoots` already scopes the
+    // picker by model type "so a LoRA isn't offered a checkpoint's fee" — this is the same rule, on the
+    // side of the wire the client cannot race.
+    //
+    // 🔴 Coerced to null, NOT rejected, and that is deliberate — do not "tighten" it into a throw.
+    // The version editor re-submits the stored value out of `defaultValues`, so throwing would make
+    // every already-stamped version unsaveable by its owner. 160 versions were in that state when this
+    // landed, including two whose base model no longer matches their source, so a throw would strand
+    // real creators on an error they cannot act on — a worse bug than the one being fixed. Coercing
+    // blocks the bad write AND repairs the stored value on the owner's next save.
+    // Nothing legitimate is lost: the picker only ever offers roots that pass this same scope, so a
+    // deliberate selection cannot reach the coercion.
     if (input.licensingSourceVersionId != null) {
-      const source = await dbRead.licensingRoot.findUnique({
-        where: { modelVersionId: input.licensingSourceVersionId },
-        select: { baseModel: true },
-      });
-      if (!source)
-        throw throwBadRequestError('Invalid licensing source: not a licensing lineage root.');
-      if (source.baseModel !== input.baseModel)
-        throw throwBadRequestError('Licensing source must share the same base model.');
+      const [source, sourceModel] = await Promise.all([
+        dbRead.licensingRoot.findUnique({
+          where: { modelVersionId: input.licensingSourceVersionId },
+          select: { baseModel: true, modelType: true },
+        }),
+        getModel({ id: input.modelId, select: { type: true } }),
+      ]);
+      const rejectedReason = !source
+        ? 'not-a-root'
+        : source.baseModel !== input.baseModel
+        ? 'base-model-mismatch'
+        : sourceModel && source.modelType !== sourceModel.type
+        ? 'model-type-mismatch'
+        : null;
+      if (rejectedReason) {
+        // A coercion leaves no trace in the row it corrected, so emit the deciding branch. This is
+        // also the only signal that the client is still sending bad values.
+        logToAxiom({
+          name: 'model-version-licensing-source-rejected',
+          type: 'info',
+          reason: rejectedReason,
+          userId,
+          modelId: input.modelId,
+          modelVersionId: input.id ?? null,
+          requestedSourceVersionId: input.licensingSourceVersionId,
+          modelType: sourceModel?.type ?? null,
+          sourceModelType: source?.modelType ?? null,
+          baseModel: input.baseModel ?? null,
+          sourceBaseModel: source?.baseModel ?? null,
+        }).catch(() => null);
+        input.licensingSourceVersionId = null;
+      }
     }
 
     const version = await upsertModelVersion({

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -514,6 +514,17 @@ export const getModelVersionSchema = z.object({
   withFiles: z.boolean().optional(),
 });
 
+/**
+ * Why the upsert handler cleared a submitted `licensingSourceVersionId`. A union rather than a string
+ * because it is written straight into the audit's `reason` column: a typo in a free-form string reaches
+ * a moderator's change history with nothing on the way to catch it.
+ */
+export type LicensingSourceRejection =
+  | 'not-a-root'
+  | 'base-model-mismatch'
+  | 'model-not-found'
+  | 'model-type-mismatch';
+
 export type GetLicensingRootsSchema = z.infer<typeof getLicensingRootsSchema>;
 export const getLicensingRootsSchema = z.object({
   baseModel: z.string(),

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -10,6 +10,7 @@ import {
 } from '~/server/utils/early-access-helpers';
 import { env } from '~/env/server';
 import type { Tracker } from '~/server/clickhouse/client';
+import type { LicensingSourceRejection } from '~/server/schema/model-version.schema';
 import { clickhouse } from '~/server/clickhouse/client';
 import { diffEntityChanges, resolveActorRole } from '~/server/utils/entity-change-helpers';
 import {
@@ -528,7 +529,7 @@ export const upsertModelVersion = async ({
    * audit says which rule: otherwise the repairs land in the change log as edits by creators who did
    * nothing, and a moderator reading the history cannot tell a type mismatch from an unreadable model.
    */
-  licensingSourceCoercedReason?: string;
+  licensingSourceCoercedReason?: LicensingSourceRejection;
 }) => {
   if (data.description) await throwOnBlockedLinkDomain(data.description);
 

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -514,6 +514,7 @@ export const upsertModelVersion = async ({
   tracker,
   actorUserId,
   isModerator,
+  licensingSourceCoerced,
   ...data
 }: Omit<ModelVersionUpsertInput, 'trainingDetails'> & {
   meta?: Prisma.ModelVersionCreateInput['meta'];
@@ -521,6 +522,12 @@ export const upsertModelVersion = async ({
   tracker?: Tracker;
   actorUserId?: number;
   isModerator?: boolean;
+  /**
+   * The controller cleared `licensingSourceVersionId` because it pointed at a root of the wrong model
+   * type or base model. It is a rule acting, not the actor, and the audit says so — otherwise the
+   * repairs land in the change log as edits by creators who did nothing.
+   */
+  licensingSourceCoerced?: boolean;
 }) => {
   if (data.description) await throwOnBlockedLinkDomain(data.description);
 
@@ -910,6 +917,12 @@ export const upsertModelVersion = async ({
           ownerId: model.userId,
           isModerator,
         }),
+        systemFields: licensingSourceCoerced
+          ? {
+              licensingSourceVersionId:
+                'cleared: licensing source was not a root for this model type / base model',
+            }
+          : undefined,
       });
       tracker.entityChanges(changeRows).catch(() => null);
     }

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -731,6 +731,10 @@ export const upsertModelVersion = async ({
         usageControl: true,
         flags: true,
         licensingFee: true,
+        // Read for the audit diff, not for the write. `watchedEntityFields` compares before/after by
+        // key, so a watched field missing from this select silently produces no row rather than an
+        // error — the audit would look wired up and record nothing.
+        licensingSourceVersionId: true,
         model: {
           select: {
             id: true,

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -514,7 +514,7 @@ export const upsertModelVersion = async ({
   tracker,
   actorUserId,
   isModerator,
-  licensingSourceCoerced,
+  licensingSourceCoercedReason,
   ...data
 }: Omit<ModelVersionUpsertInput, 'trainingDetails'> & {
   meta?: Prisma.ModelVersionCreateInput['meta'];
@@ -523,11 +523,12 @@ export const upsertModelVersion = async ({
   actorUserId?: number;
   isModerator?: boolean;
   /**
-   * The controller cleared `licensingSourceVersionId` because it pointed at a root of the wrong model
-   * type or base model. It is a rule acting, not the actor, and the audit says so — otherwise the
-   * repairs land in the change log as edits by creators who did nothing.
+   * Why the controller cleared `licensingSourceVersionId` — `model-type-mismatch`,
+   * `base-model-mismatch`, `not-a-root` or `model-not-found`. A rule acting, not the actor, and the
+   * audit says which rule: otherwise the repairs land in the change log as edits by creators who did
+   * nothing, and a moderator reading the history cannot tell a type mismatch from an unreadable model.
    */
-  licensingSourceCoerced?: boolean;
+  licensingSourceCoercedReason?: string;
 }) => {
   if (data.description) await throwOnBlockedLinkDomain(data.description);
 
@@ -917,11 +918,8 @@ export const upsertModelVersion = async ({
           ownerId: model.userId,
           isModerator,
         }),
-        systemFields: licensingSourceCoerced
-          ? {
-              licensingSourceVersionId:
-                'cleared: licensing source was not a root for this model type / base model',
-            }
+        systemFields: licensingSourceCoercedReason
+          ? { licensingSourceVersionId: `cleared: ${licensingSourceCoercedReason}` }
           : undefined,
       });
       tracker.entityChanges(changeRows).catch(() => null);

--- a/src/server/utils/__tests__/entity-change.licensing-source.test.ts
+++ b/src/server/utils/__tests__/entity-change.licensing-source.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { watchedEntityFields } from '~/server/common/entity-change.constants';
+import { diffEntityChanges } from '~/server/utils/entity-change-helpers';
+
+/**
+ * The audit half of CU 868kwf2fd. `licensingSourceVersionId` decides who is paid per generated image
+ * and by whom, and it changed with no trail at all — `entityChangeEvents` held zero rows for it against
+ * 4,042 for `licensingFee` when this was written.
+ *
+ * 🔴 Every mechanism below fails SILENTLY when it breaks. A watched field missing from the service's
+ * `before` select produces no row rather than an error; a mistyped `systemFields` key is a plain object
+ * lookup that returns `undefined`; a field dropped from `watchedEntityFields` simply stops being
+ * compared. None of them throws, so nothing but an assertion of the wired-up state can notice. Three
+ * separate one-line deletions used to leave the whole suite green.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const OWNER_ID = 5479411;
+const VERSION_ID = 3144879;
+const ANIMA_ROOT = 2945208;
+
+const diff = (before: Record<string, unknown>, after: Record<string, unknown>, reason?: string) =>
+  diffEntityChanges({
+    entityType: 'ModelVersion',
+    entityId: VERSION_ID,
+    ownerId: OWNER_ID,
+    before,
+    after,
+    actorRole: 'owner',
+    systemFields: reason ? { licensingSourceVersionId: reason } : undefined,
+  });
+
+describe('licensingSourceVersionId — the settings audit', () => {
+  it('is watched at all', () => {
+    expect(watchedEntityFields.ModelVersion).toContain('licensingSourceVersionId');
+  });
+
+  it('records a creator clearing their own lineage', () => {
+    const rows = diff({ licensingSourceVersionId: ANIMA_ROOT }, { licensingSourceVersionId: null });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      field: 'licensingSourceVersionId',
+      oldValue: String(ANIMA_ROOT),
+      newValue: 'null',
+      actorRole: 'owner',
+    });
+  });
+
+  // The rows this field's audit will mostly produce are the server's own repairs, and attributing
+  // those to the creator is worse than the missing trail it replaces — the whole complaint was that
+  // 160 versions carried a value nobody could account for.
+  it('attributes a server-side coercion to the rule, not to the creator', () => {
+    const rows = diff(
+      { licensingSourceVersionId: ANIMA_ROOT },
+      { licensingSourceVersionId: null },
+      'model-type-mismatch'
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ actorRole: 'system', reason: 'model-type-mismatch' });
+  });
+
+  // Partial writes are ordinary here — requestReviewHandler and declineReviewHandler send a few fields
+  // — so an absent key must mean "untouched", never "cleared".
+  it('emits nothing when the field is absent from the payload', () => {
+    expect(diff({ licensingSourceVersionId: ANIMA_ROOT }, { name: 'v1.1' })).toHaveLength(0);
+  });
+
+  /**
+   * The two tests below assert on the SERVICE'S SOURCE TEXT, which is a weaker instrument than driving
+   * the code, and they are here because the alternative was nothing. `upsertModelVersion` reaches most
+   * of the schema, so a behavioural test of its audit path is a large mock surface; the wiring it would
+   * check is three lines that fail silently when broken. Measured before these existed: deleting the
+   * select line, deleting the `systemFields` block, or misspelling its key each left the entire suite
+   * green.
+   *
+   * If someone later writes the behavioural test, delete these rather than keeping both.
+   */
+
+  /**
+   * 🔴 `diffEntityChanges` compares `before[field]` to `after[field]`, so a watched field the
+   * service never selects is `undefined` on the before side and silently produces no row — the audit
+   * reads as wired up and records nothing.
+   *
+   * Asserted over the whole watched list, because the next field added will have the same trap and
+   * nobody will remember this test exists.
+   */
+  it('selects every watched ModelVersion column for the audit before-side', () => {
+    // Not columns: these three are computed and set as explicit keys on the `before` literal instead
+    // (`paidAccess` from its own read, `licensingFee` coerced off a Decimal, `monetization` reshaped).
+    // Listed rather than pattern-matched so that adding a fourth is a deliberate edit here.
+    const SUPPLIED_NOT_SELECTED = ['paidAccess', 'licensingFee', 'monetization'];
+
+    const service = readFileSync(
+      path.join(REPO_ROOT, 'src/server/services/model-version.service.ts'),
+      'utf8'
+    );
+    const at = service.indexOf(
+      'const existingVersion = await dbWrite.modelVersion.findUniqueOrThrow'
+    );
+    expect(
+      at,
+      'the upsert update-branch read moved; re-anchor this test, do not delete it'
+    ).toBeGreaterThan(-1);
+    const select = service.slice(at, service.indexOf('});', at));
+
+    const missing = watchedEntityFields.ModelVersion.filter(
+      (field) =>
+        !SUPPLIED_NOT_SELECTED.includes(field.split('.')[0]) &&
+        !new RegExp(`\\b${field.split('.')[0]}: (true|\\{)`).test(select)
+    );
+    expect(missing, `watched but not selected, so they audit nothing: ${missing}`).toEqual([]);
+  });
+
+  /**
+   * 🔴 `systemFields` is read as `systemFields?.[field]` — a plain object lookup. A key that does
+   * not match a watched field name returns `undefined`, so the row is still written and simply carries
+   * the creator's name instead of the rule's. No error, no missing row, just wrong attribution on the
+   * only field in this list that decides who gets paid.
+   */
+  it('attributes the licensing coercion under the exact watched field name', () => {
+    const service = readFileSync(
+      path.join(REPO_ROOT, 'src/server/services/model-version.service.ts'),
+      'utf8'
+    );
+    const at = service.indexOf('systemFields:');
+    expect(at, 'the upsert audit no longer passes systemFields at all').toBeGreaterThan(-1);
+    const block = service.slice(at, at + 300);
+    expect(block).toContain('licensingSourceVersionId:');
+  });
+});


### PR DESCRIPTION
## What was wrong

`ModelVersion.licensingSourceVersionId` makes a version inherit a root's per-image licence fee. The fee is charged to **everyone who generates with the derivative**, settled to the **root's** owner, on a line labelled with the **derivative's** name.

The server-side guard checked that the chosen source was a registered `LicensingRoot` **for the same base model**, and stopped there — it never checked the model *type*. Every `LicensingRoot` row is `modelType: 'Checkpoint'`, so nothing on the server ever stopped a LoRA holding a checkpoint's fee, even though `getLicensingRoots`' own comment says the picker is scoped *"so a LoRA isn't offered a checkpoint's fee"*.

**160 non-Checkpoint versions across 124 creators were in that state.** The one that reached support — Freshdesk #69622, `ModelVersion 3144879` — had been charging its owner 10 Buzz/image instead of 5 since 2026-07-20, to a third party, under her own model's name, with no surface on the site able to clear it.

Both the reporter's row and the 137 provably-accidental rows were repaired by hand under Justin's approval, ahead of this PR. 23 ambiguous rows are left for a separate decision.

## Where the bad value came from

`ModelVersionUpsertForm` pre-selects the ecosystem's default root whenever the field is empty, with `shouldDirty: false` so nothing on screen marks it as changed. The roots query was gated on `enabled: !!baseModel` — but `baseModel` is seeded **synchronously** while `model` arrives from a query. So the first fetch went out with `modelType: undefined`, the type filter in `getLicensingRoots` is conditional, and that unscoped fetch returned the **Checkpoint** roots. The effect stamped one; the scoped refetch then returned `[]` and the effect early-returns on a null default, so it could never clear what it had already set.

**A race, not a window.** Stamped versions ran at a steady **0.23% of all LoRA versions** in each affected ecosystem — 107 of 46,994 on Anima, 45 of 19,999 on Krea 2 — every week from 2026-07-06 until this landed. Two independent populations, the same fraction. The week before the feature shipped is 0 of 2,041, which is the control showing the query can return zero.

## The fix

**Server — authoritative.** The guard now also requires the root's `modelType` to match the type of the model the version lands on, and **coerces to `null` rather than rejecting**, recording the reason to Axiom and to the settings audit.

The model it checks is `input.modelId`, and that is deliberate: `modelId` is not destructured in `upsertModelVersion`, so it rides `...data` into `dbWrite.modelVersion.update`. The payload's modelId is not a claim about where the version lives that has to be verified — it is the instruction for where it *will* live, and that is where the fee applies. Two tests pull in opposite directions on this so the two obvious wrong answers (check the model it came from; require both to match) each fail one of them.

Coercion rather than rejection is the other load-bearing choice. The version editor resubmits the stored value out of `defaultValues`, so a throw would make every already-stamped version unsaveable by its owner — six rows were already in exactly that state under the *existing* base-model throw. Coercing blocks the bad write and repairs the stored value on the owner's next save. A test is named for the decision.

**Client.** `enabled: !!baseModel && !!model?.type` — the unscoped fetch never happens.

Why not the ticket's other two candidates: making the `modelType` filter unconditional changes a `publicProcedure`'s contract to fix a UI bug (callers omitting it would silently get `[]`); clearing when the scoped result is empty is indistinguishable from clearing while still loading, and would wipe a deliberate selection on every refetch.

**Audit.** `licensingSourceVersionId` joins `watchedEntityFields.ModelVersion`, with the column added to the service's before-side select. Verified against prod ClickHouse first, one query with its own control: `licensingFee` **4,042** rows, `licensingSourceVersionId` **0**. Server coercions are attributed to the rule, not to the creator.

## Verification

| Check | Result |
|---|---|
| `pnpm run typecheck` | 6 errors, **all** in `src/components/Apps/` (`868kwya83`, pre-existing case-only import clash). None in this diff. |
| `pnpm run lint`, this diff's files | **0 errors**, 0 new warnings |
| `pnpm run test:unit:run` | `Test Files 2 failed \| 1453 passed \| 1 skipped (1456)`, exit 1 — both failures are the same pre-existing `Apps/` files, which import nothing this diff touches |
| `blocks.router.workflow.test.ts` | **358 tests** collected, so the suite result means something |
| `--project component` | 23 passed (23) |

### Mutation testing

Every guard here is mutated on purpose rather than trusted. Pristine control green first, one mutant at a time, each restored before the next:

| Mutant | Killed by |
|---|---|
| check the model the version came from | "rejects a root the DESTINATION model cannot hold" |
| require both models to match | "keeps the root when a move lands the version somewhere it fits" |
| type check removed entirely | 3 tests, incl. the original LoRA case |
| hardcode `!== 'Checkpoint'` | both LORA-root tests |
| "could not read" made permissive | 2 not-found tests |
| unwatch the audit field | 3 tests |
| drop the audit before-side select | the watched-column invariant |
| misspell / drop `systemFields` | the attribution test |
| client gate relaxed to `!!baseModel` | "stamps nothing while the model type is still unknown" |

Two of those mutants survived the first time and the code changed rather than the test: a conditional that could never go the other way, and a guard that encoded "is a Checkpoint" where the rule is "same type as the root".

## Not in this PR

- The 23 ambiguous rows. They predate the `LicensingRoot` table, when a retired picker may have offered roots to LoRAs legitimately; clearing one could take income from someone who chose to earn it.
- No migration, no schema change.

CU `868kwf2fd` · Freshdesk #69622

🤖 Generated with [Claude Code](https://claude.com/claude-code)
