### PR TITLE
fix(search): sort model search on attributes the models index actually exposes

### DIFF
--- a/src/components/Search/__tests__/search-index-contract.test.ts
+++ b/src/components/Search/__tests__/search-index-contract.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { queryFilters } from '~/components/AutocompleteSearch/autocomplete-query';
+import { ArticlesSearchIndexSortBy } from '~/components/Search/parsers/article.parser';
+import { BountiesSearchIndexSortBy } from '~/components/Search/parsers/bounties.parser';
+import { CollectionsSearchIndexSortBy } from '~/components/Search/parsers/collection.parser';
+import { ComicsSearchIndexSortBy } from '~/components/Search/parsers/comic.parser';
+import { ImagesSearchIndexSortBy } from '~/components/Search/parsers/image.parser';
+import { ModelSearchIndexSortBy } from '~/components/Search/parsers/model.parser';
+import { ToolsSearchIndexSortBy } from '~/components/Search/parsers/tool.parser';
+import { UsersSearchIndexSortBy } from '~/components/Search/parsers/user.parser';
 import { BROWSING_LEVEL_ATTRIBUTE } from '~/components/Search/search-index-filters';
 import { buildBrowsingLevelClause } from '~/components/Search/search-filters';
 import type { SearchIndexKey } from '~/components/Search/search.types';
 import { searchIndexMap } from '~/components/Search/search.types';
 import { IMAGES_SEARCH_INDEX } from '~/server/common/constants';
 import { filterableAttributesByIndex } from '~/server/search-index/filterable-attributes';
+import {
+  modelsSortableAttributes,
+  sortableAttributesByIndex,
+} from '~/server/search-index/sortable-attributes';
 
 const searchIndexKeys = Object.keys(searchIndexMap) as SearchIndexKey[];
 
@@ -70,6 +82,83 @@ describe('filterableAttributesByIndex', () => {
       expect(duplicates, `${indexName} repeats ${duplicates.join(', ')}`).toEqual([]);
     }
   );
+});
+
+describe('search sort options', () => {
+  // Every `sortBy` an InstantSearch results page can put on the URL, keyed by the index it is
+  // sent to. A value is either the bare index name (relevancy, no sort) or
+  // `<index>:<attribute>[:<direction>]`.
+  const sortOptionsByIndex: Record<string, readonly string[]> = {
+    [searchIndexMap.articles]: ArticlesSearchIndexSortBy,
+    [searchIndexMap.bounties]: BountiesSearchIndexSortBy,
+    [searchIndexMap.collections]: CollectionsSearchIndexSortBy,
+    [searchIndexMap.comics]: ComicsSearchIndexSortBy,
+    [searchIndexMap.images]: ImagesSearchIndexSortBy,
+    [searchIndexMap.models]: ModelSearchIndexSortBy,
+    [searchIndexMap.tools]: ToolsSearchIndexSortBy,
+    [searchIndexMap.users]: UsersSearchIndexSortBy,
+  };
+
+  const sortedAttributes = Object.entries(sortOptionsByIndex).flatMap(([indexName, options]) =>
+    options
+      // An attribute never contains `:`, so index 1 is the whole attribute path.
+      .map((option) => option.split(':')[1])
+      .filter((attribute): attribute is string => Boolean(attribute))
+      .map((attribute) => [indexName, attribute] as [string, string])
+  );
+
+  it('covers a sort option from every index', () => {
+    expect(Object.keys(sortOptionsByIndex).sort()).toEqual(
+      Object.values(searchIndexMap).slice().sort()
+    );
+    expect(sortedAttributes.length).toBeGreaterThan(0);
+  });
+
+  it.each(sortedAttributes)(
+    '%s sorts on %s, which that index declares sortable',
+    (indexName, attribute) => {
+      expect(
+        sortableAttributesByIndex[indexName as keyof typeof sortableAttributesByIndex],
+        `a sort option sends \`${indexName}:${attribute}\`, but ${indexName} does not declare ${attribute} sortable — Meilisearch answers \`Attribute \`${attribute}\` is not sortable\` and the whole results page fails`
+      ).toContain(attribute);
+    }
+  );
+});
+
+describe('the models index sort contract', () => {
+  // Literal, not derived: these are the attributes the live models index is provisioned with.
+  // `sortableAttributes` only ever reach a live index through `onIndexSetup`, which runs solely
+  // inside the manual (`UNRUNNABLE_JOB_CRON`) index-reset job — so renaming an attribute here and
+  // pointing the client at the new name in the same release leaves the client asking for something
+  // the live index has never heard of, and every sorted model search 400s until someone runs a
+  // reset. Update these two lists only together with a reset that has actually shipped.
+  it('declares exactly the sortable attributes the live models index is provisioned with', () => {
+    expect(modelsSortableAttributes.slice().sort()).toEqual([
+      'createdAt',
+      'id',
+      'metrics.collectedCount',
+      'metrics.commentCount',
+      'metrics.downloadCount',
+      'metrics.favoriteCount',
+      'metrics.thumbsUpCount',
+      'metrics.tippedAmountCount',
+    ]);
+  });
+
+  it('offers exactly the sort options those attributes support, in label order', () => {
+    // Order is load-bearing: src/pages/search/models.tsx maps its dropdown labels
+    // ("Relevancy", "Highest Rated", "Most Downloaded", …) onto these by position.
+    expect(ModelSearchIndexSortBy.slice()).toEqual([
+      'models_v9',
+      'models_v9:metrics.thumbsUpCount:desc',
+      'models_v9:metrics.downloadCount:desc',
+      'models_v9:metrics.favoriteCount:desc',
+      'models_v9:metrics.commentCount:desc',
+      'models_v9:metrics.collectedCount:desc',
+      'models_v9:metrics.tippedAmountCount:desc',
+      'models_v9:createdAt:desc',
+    ]);
+  });
 });
 
 describe('an index with no browsing-level attribute', () => {

--- a/src/components/Search/__tests__/search-index-contract.test.ts
+++ b/src/components/Search/__tests__/search-index-contract.test.ts
@@ -15,6 +15,7 @@ import { searchIndexMap } from '~/components/Search/search.types';
 import { IMAGES_SEARCH_INDEX } from '~/server/common/constants';
 import { filterableAttributesByIndex } from '~/server/search-index/filterable-attributes';
 import {
+  bountiesSortableAttributes,
   modelsSortableAttributes,
   sortableAttributesByIndex,
 } from '~/server/search-index/sortable-attributes';
@@ -126,8 +127,8 @@ describe('search sort options', () => {
 });
 
 describe('the models index sort contract', () => {
-  // Literal, not derived: these are the attributes the live models index is provisioned with.
-  // `sortableAttributes` only ever reach a live index through `onIndexSetup`, which runs solely
+  // Literal, and read back from the live search index rather than derived from the code under
+  // test. `sortableAttributes` only ever reach a live index through `onIndexSetup`, which runs solely
   // inside the manual (`UNRUNNABLE_JOB_CRON`) index-reset job — so renaming an attribute here and
   // pointing the client at the new name in the same release leaves the client asking for something
   // the live index has never heard of, and every sorted model search 400s until someone runs a
@@ -157,6 +158,35 @@ describe('the models index sort contract', () => {
       'models_v9:metrics.collectedCount:desc',
       'models_v9:metrics.tippedAmountCount:desc',
       'models_v9:createdAt:desc',
+    ]);
+  });
+});
+
+describe('the bounties index sort contract', () => {
+  // Literal, and verified against the live search index rather than inferred. A bounty document
+  // carries its counts only under `stats`, so a bare `favoriteCountAllTime` names a field no
+  // document has: declaring it sortable would not surface an error, it would let Meilisearch
+  // accept the sort and answer in an arbitrary order — a silent wrong answer where the prefixed
+  // spelling gives a correct one.
+  it('declares exactly the sortable attributes the live bounties index is provisioned with', () => {
+    expect(bountiesSortableAttributes.slice().sort()).toEqual([
+      'createdAt',
+      'id',
+      'stats.entryCountAllTime',
+      'stats.favoriteCountAllTime',
+      'stats.unitAmountCountAllTime',
+    ]);
+  });
+
+  it('offers exactly the sort options those attributes support, in label order', () => {
+    // Order is load-bearing: src/pages/search/bounties.tsx maps its dropdown labels
+    // ("Relevancy", "Most Buzz", "Entry Count", "Favorite", "Newest") onto these by position.
+    expect(BountiesSearchIndexSortBy.slice()).toEqual([
+      'bounties_v3',
+      'bounties_v3:stats.unitAmountCountAllTime:desc',
+      'bounties_v3:stats.entryCountAllTime:desc',
+      'bounties_v3:stats.favoriteCountAllTime:desc',
+      'bounties_v3:createdAt',
     ]);
   });
 });

--- a/src/components/Search/parsers/bounties.parser.ts
+++ b/src/components/Search/parsers/bounties.parser.ts
@@ -14,7 +14,9 @@ export const BountiesSearchIndexSortBy = [
   BOUNTIES_SEARCH_INDEX,
   `${BOUNTIES_SEARCH_INDEX}:stats.unitAmountCountAllTime:desc`,
   `${BOUNTIES_SEARCH_INDEX}:stats.entryCountAllTime:desc`,
-  `${BOUNTIES_SEARCH_INDEX}:favoriteCountAllTime:desc`,
+  // `stats.`-prefixed, like its siblings: that is where the bounty document carries the count, and
+  // what the index declares sortable. A bare `favoriteCountAllTime` names no field at all.
+  `${BOUNTIES_SEARCH_INDEX}:stats.favoriteCountAllTime:desc`,
   `${BOUNTIES_SEARCH_INDEX}:createdAt`,
 ] as const;
 

--- a/src/components/Search/parsers/model.parser.ts
+++ b/src/components/Search/parsers/model.parser.ts
@@ -10,17 +10,23 @@ import { removeEmpty } from '~/utils/object-helpers';
 import type { IndexUiState, UiState } from 'instantsearch.js';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 
+// Every entry must name an attribute the LIVE models index declares sortable — see
+// `modelsSortableAttributes` in src/server/search-index/sortable-attributes.ts and the contract
+// test in src/components/Search/__tests__/search-index-contract.test.ts. InstantSearch sends this
+// string straight through to Meilisearch, so an attribute the index does not expose is not a
+// degraded sort, it is a failed request and an empty results page.
 export const ModelSearchIndexSortBy = [
   MODELS_SEARCH_INDEX,
   `${MODELS_SEARCH_INDEX}:metrics.thumbsUpCount:desc`,
-  // Creator Controls: sort on the REAL sort-only mirrors — the displayed
-  // `metrics.downloadCount` / `metrics.tippedAmountCount` are masked to null when a
-  // creator hides them, so sorting on those would break the order.
-  `${MODELS_SEARCH_INDEX}:sortMetrics.downloadCount:desc`,
+  // Creator Controls keeps unmasked copies of downloads/tips in a sort-only `sortMetrics` field so
+  // a hidden number can still order correctly. That field is not sortable on the live index yet —
+  // declaring it and sorting on it needs a models index reset first — so these two stay on
+  // `metrics.*` until that lands.
+  `${MODELS_SEARCH_INDEX}:metrics.downloadCount:desc`,
   `${MODELS_SEARCH_INDEX}:metrics.favoriteCount:desc`,
   `${MODELS_SEARCH_INDEX}:metrics.commentCount:desc`,
   `${MODELS_SEARCH_INDEX}:metrics.collectedCount:desc`,
-  `${MODELS_SEARCH_INDEX}:sortMetrics.tippedAmountCount:desc`,
+  `${MODELS_SEARCH_INDEX}:metrics.tippedAmountCount:desc`,
   `${MODELS_SEARCH_INDEX}:createdAt:desc`,
 ] as const;
 

--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -6,6 +6,7 @@ import { ArticleIngestionStatus, ArticleStatus, Availability } from '~/shared/ut
 import { articleDetailSelect } from '~/server/selectors/article.selector';
 import { ARTICLES_SEARCH_INDEX } from '~/server/common/constants';
 import { articlesFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { articlesSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { removeTags } from '~/utils/string-helpers';
 import { isDefined } from '~/utils/type-guards';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
@@ -43,13 +44,7 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
   );
 
   const sortableFieldsAttributesTask = await index.updateSortableAttributes([
-    'createdAt',
-    'stats.commentCount',
-    'stats.favoriteCount',
-    'stats.collectedCount',
-    'stats.viewCount',
-    'stats.tippedAmountCount',
-    'id',
+    ...articlesSortableAttributes,
   ]);
 
   console.log('onIndexSetup :: sortableFieldsAttributesTask created', sortableFieldsAttributesTask);

--- a/src/server/search-index/bounties.search-index.ts
+++ b/src/server/search-index/bounties.search-index.ts
@@ -11,6 +11,7 @@ import type {
 } from '~/shared/utils/prisma/enums';
 import { BOUNTIES_SEARCH_INDEX } from '~/server/common/constants';
 import { bountiesFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { bountiesSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { isDefined } from '~/utils/type-guards';
 import { dbRead } from '~/server/db/client';
 import type { ImageMetadata } from '~/server/schema/media.schema';
@@ -44,14 +45,8 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     );
   }
 
-  const sortableAttributes = [
-    'createdAt',
-    // `id` required by the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
-    'id',
-    'stats.unitAmountCountAllTime',
-    'stats.entryCountAllTime',
-    'stats.favoriteCountAllTime',
-  ];
+  // `id` required by the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
+  const sortableAttributes = [...bountiesSortableAttributes];
 
   if (JSON.stringify(sortableAttributes.sort()) !== JSON.stringify(settings.sortableAttributes)) {
     const sortableFieldsAttributesTask = await index.updateSortableAttributes(sortableAttributes);

--- a/src/server/search-index/collections.search-index.ts
+++ b/src/server/search-index/collections.search-index.ts
@@ -12,6 +12,7 @@ import type {
 import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
 import { COLLECTIONS_SEARCH_INDEX } from '~/server/common/constants';
 import { collectionsFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { collectionsSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { isDefined } from '~/utils/type-guards';
 import { uniqBy } from 'lodash-es';
 import { tagIdsForImagesCache } from '~/server/redis/caches';
@@ -49,13 +50,7 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     );
   }
 
-  const sortableAttributes = [
-    'createdAt',
-    'id',
-    'metrics.itemCount',
-    'metrics.followerCount',
-    'metrics.contributorCount',
-  ];
+  const sortableAttributes = [...collectionsSortableAttributes];
 
   if (JSON.stringify(sortableAttributes.sort()) !== JSON.stringify(settings.sortableAttributes)) {
     const sortableFieldsAttributesTask = await index.updateSortableAttributes(sortableAttributes);

--- a/src/server/search-index/comics.search-index.ts
+++ b/src/server/search-index/comics.search-index.ts
@@ -4,6 +4,7 @@ import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { COMICS_SEARCH_INDEX } from '~/server/common/constants';
 import { comicsFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { comicsSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { isDefined } from '~/utils/type-guards';
 import { parseBitwiseBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
 import { profileImageSelect } from '../selectors/image.selector';
@@ -15,13 +16,7 @@ const INDEX_ID = COMICS_SEARCH_INDEX;
 const searchableAttributes = ['name', 'description', 'user.username'];
 // `id` is here and in the filterable list for the keyset cleanup scan
 // (src/server/meilisearch/cleanup.ts).
-const sortableAttributes = [
-  'createdAt',
-  'id',
-  'updatedAt',
-  'stats.chapterCount',
-  'stats.followerCount',
-];
+const sortableAttributes = [...comicsSortableAttributes];
 const rankingRules = ['sort', 'words', 'typo', 'proximity', 'attribute', 'exactness'];
 
 const onIndexSetup = async ({ indexName }: { indexName: string }) => {

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -18,6 +18,7 @@ import {
 } from '~/server/redis/caches';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { imagesFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { imagesSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { modelsSearchIndex } from '~/server/search-index/models.search-index';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
@@ -46,14 +47,7 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   const searchableAttributes: SearchableAttributes = ['prompt', 'tagNames', 'user.username'];
 
-  const sortableAttributes: SortableAttributes = [
-    'id',
-    'sortAt',
-    'stats.commentCountAllTime',
-    'stats.reactionCountAllTime',
-    'stats.collectedCountAllTime',
-    'stats.tippedAmountCountAllTime',
-  ];
+  const sortableAttributes: SortableAttributes = [...imagesSortableAttributes];
 
   if (JSON.stringify(searchableAttributes) !== JSON.stringify(settings.searchableAttributes)) {
     const updateSearchableAttributesTask = await index.updateSearchableAttributes(

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -16,6 +16,7 @@ import type { RecommendedSettingsSchema } from '~/server/schema/model-version.sc
 import type { ModelMeta } from '~/server/schema/model.schema';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { modelsFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { modelsSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { getValidCreatorMembershipMap } from '~/server/services/creator-program.service';
 import {
   anyMetricHidden,
@@ -65,18 +66,7 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     );
   }
 
-  const sortableAttributes = [
-    // sort
-    'createdAt',
-    'id',
-    'metrics.collectedCount',
-    'metrics.commentCount',
-    'metrics.thumbsUpCount',
-    // Creator Controls: downloads + tipped can be masked in the displayed `metrics`,
-    // so sort on the REAL sort-only mirrors (excluded from displayedAttributes).
-    'sortMetrics.downloadCount',
-    'sortMetrics.tippedAmountCount',
-  ];
+  const sortableAttributes = [...modelsSortableAttributes];
 
   // Meilisearch stores sorted.
   if (JSON.stringify(sortableAttributes.sort()) !== JSON.stringify(settings.sortableAttributes)) {
@@ -371,9 +361,13 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
           collectedCount: metrics.collectedCount ?? 0,
           tippedAmountCount: hidden.buzz ? null : realTippedAmountCount,
         },
-        // SORT-ONLY: REAL values, excluded from `displayedAttributes` (see
-        // onIndexSetup) so sort by most-downloaded / most-tipped keeps the true
-        // order even when the displayed number is masked. Never returned to clients.
+        // SORT-ONLY: REAL values, excluded from `displayedAttributes` (see onIndexSetup) so they
+        // are never returned to clients. NOT sortable yet: `sortableAttributes` only reach a live
+        // index through the manual index-reset job, so until a reset ships, the search sort options
+        // stay on `metrics.*` (see `modelsSortableAttributes` and
+        // src/components/Search/parsers/model.parser.ts). Once one has, add these two back to
+        // `modelsSortableAttributes` and repoint those options — then most-downloaded /
+        // most-tipped keeps the true order even when the displayed number is masked.
         sortMetrics: {
           downloadCount: realDownloadCount,
           tippedAmountCount: realTippedAmountCount,

--- a/src/server/search-index/sortable-attributes.ts
+++ b/src/server/search-index/sortable-attributes.ts
@@ -23,6 +23,14 @@ import {
 // using that sort answers `Attribute ... is not sortable` and the results page fails outright.
 // The sort options the client may request live in src/components/Search/parsers/*.parser.ts and are
 // pinned against these lists by src/components/Search/__tests__/search-index-contract.test.ts.
+//
+// The models, images and bounties lists were read back from the live search index and match it
+// exactly. The rest are what the code declared before this module existed, and have NOT been
+// checked against a live index — treat them as a starting point, not as ground truth.
+//
+// Adding an attribute no document carries is not free either: after a reset Meilisearch would
+// ACCEPT a sort on it and answer in an arbitrary order, which is a silent wrong answer rather than
+// a loud `Attribute ... is not sortable`. Every entry must be a real field path.
 
 // `id` is sortable on every index because the keyset cleanup scan in
 // src/server/meilisearch/cleanup.ts pages on it.
@@ -39,11 +47,6 @@ export const articlesSortableAttributes = [
 export const bountiesSortableAttributes = [
   'createdAt',
   'id',
-  // The bounties sort options ask for a bare `favoriteCountAllTime`, while the document only
-  // carries it as `stats.favoriteCountAllTime`. Declared so the option cannot answer
-  // `Attribute ... is not sortable`; re-pointing the option at the `stats.` spelling is a
-  // behaviour change and is tracked separately.
-  'favoriteCountAllTime',
   'stats.unitAmountCountAllTime',
   'stats.entryCountAllTime',
   'stats.favoriteCountAllTime',

--- a/src/server/search-index/sortable-attributes.ts
+++ b/src/server/search-index/sortable-attributes.ts
@@ -1,0 +1,108 @@
+import {
+  ARTICLES_SEARCH_INDEX,
+  BOUNTIES_SEARCH_INDEX,
+  COLLECTIONS_SEARCH_INDEX,
+  COMICS_SEARCH_INDEX,
+  IMAGES_SEARCH_INDEX,
+  MODELS_SEARCH_INDEX,
+  TOOLS_SEARCH_INDEX,
+  USERS_SEARCH_INDEX,
+} from '~/server/common/constants';
+
+// Kept a leaf so a test can read these without loading `~/server/meilisearch/client`, which builds
+// pLimit/prom collectors at module load. Same reasoning as ./filterable-attributes.ts.
+
+// 🔴 These lists are only ever WRITTEN to a live index by each index's `onIndexSetup`, and
+// `onIndexSetup` runs in exactly one place: `reset()` in ./base.search-index.ts, against the
+// `<index>_NEW` swap index. Every `search-index-sync-<name>-reset` job is registered with
+// `UNRUNNABLE_JOB_CRON`, i.e. it is manual-only and can go years between runs.
+//
+// So editing a list here does NOT change what a live index accepts. Adding an entry is safe (it
+// takes effect whenever a reset next happens). REMOVING or RENAMING one is a migration: the client
+// must keep sorting on the old attribute until a reset has actually shipped, otherwise every search
+// using that sort answers `Attribute ... is not sortable` and the results page fails outright.
+// The sort options the client may request live in src/components/Search/parsers/*.parser.ts and are
+// pinned against these lists by src/components/Search/__tests__/search-index-contract.test.ts.
+
+// `id` is sortable on every index because the keyset cleanup scan in
+// src/server/meilisearch/cleanup.ts pages on it.
+export const articlesSortableAttributes = [
+  'createdAt',
+  'id',
+  'stats.commentCount',
+  'stats.favoriteCount',
+  'stats.collectedCount',
+  'stats.viewCount',
+  'stats.tippedAmountCount',
+];
+
+export const bountiesSortableAttributes = [
+  'createdAt',
+  'id',
+  // The bounties sort options ask for a bare `favoriteCountAllTime`, while the document only
+  // carries it as `stats.favoriteCountAllTime`. Declared so the option cannot answer
+  // `Attribute ... is not sortable`; re-pointing the option at the `stats.` spelling is a
+  // behaviour change and is tracked separately.
+  'favoriteCountAllTime',
+  'stats.unitAmountCountAllTime',
+  'stats.entryCountAllTime',
+  'stats.favoriteCountAllTime',
+];
+
+export const collectionsSortableAttributes = [
+  'createdAt',
+  'id',
+  'metrics.itemCount',
+  'metrics.followerCount',
+  'metrics.contributorCount',
+];
+
+export const comicsSortableAttributes = [
+  'createdAt',
+  'id',
+  'updatedAt',
+  'stats.chapterCount',
+  'stats.followerCount',
+];
+
+export const imagesSortableAttributes = [
+  'createdAt',
+  'id',
+  'sortAt',
+  'stats.commentCountAllTime',
+  'stats.reactionCountAllTime',
+  'stats.collectedCountAllTime',
+  'stats.tippedAmountCountAllTime',
+];
+
+export const modelsSortableAttributes = [
+  'createdAt',
+  'id',
+  'metrics.collectedCount',
+  'metrics.commentCount',
+  'metrics.downloadCount',
+  'metrics.favoriteCount',
+  'metrics.thumbsUpCount',
+  'metrics.tippedAmountCount',
+];
+
+export const toolsSortableAttributes = ['createdAt', 'id', 'name'];
+
+export const usersSortableAttributes = [
+  'createdAt',
+  'id',
+  'metrics.thumbsUpCount',
+  'metrics.followerCount',
+  'metrics.uploadCount',
+];
+
+export const sortableAttributesByIndex = {
+  [ARTICLES_SEARCH_INDEX]: articlesSortableAttributes,
+  [BOUNTIES_SEARCH_INDEX]: bountiesSortableAttributes,
+  [COLLECTIONS_SEARCH_INDEX]: collectionsSortableAttributes,
+  [COMICS_SEARCH_INDEX]: comicsSortableAttributes,
+  [IMAGES_SEARCH_INDEX]: imagesSortableAttributes,
+  [MODELS_SEARCH_INDEX]: modelsSortableAttributes,
+  [TOOLS_SEARCH_INDEX]: toolsSortableAttributes,
+  [USERS_SEARCH_INDEX]: usersSortableAttributes,
+} as const;

--- a/src/server/search-index/tools.search-index.ts
+++ b/src/server/search-index/tools.search-index.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import type { ToolType } from '~/shared/utils/prisma/enums';
 import { TOOLS_SEARCH_INDEX } from '~/server/common/constants';
 import { toolsFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { toolsSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { updateDocs } from '~/server/meilisearch/client';
 
 import { getOrCreateIndex } from '~/server/meilisearch/util';
@@ -14,7 +15,7 @@ const MEILISEARCH_DOCUMENT_BATCH_SIZE = 1000;
 const INDEX_ID = TOOLS_SEARCH_INDEX;
 
 const searchableAttributes = ['name', 'domain', 'company', 'description'];
-const sortableAttributes = ['createdAt', 'id', 'name'];
+const sortableAttributes = [...toolsSortableAttributes];
 const rankingRules = [
   'supported:desc',
   'sort',

--- a/src/server/search-index/users.search-index.ts
+++ b/src/server/search-index/users.search-index.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { USERS_SEARCH_INDEX } from '~/server/common/constants';
 import { usersFilterableAttributes } from '~/server/search-index/filterable-attributes';
+import { usersSortableAttributes } from '~/server/search-index/sortable-attributes';
 import { updateDocs } from '~/server/meilisearch/client';
 
 import { getOrCreateIndex } from '~/server/meilisearch/util';
@@ -40,13 +41,7 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     );
   }
 
-  const sortableAttributes = [
-    'createdAt',
-    'id',
-    'metrics.thumbsUpCount',
-    'metrics.followerCount',
-    'metrics.uploadCount',
-  ];
+  const sortableAttributes = [...usersSortableAttributes];
 
   if (JSON.stringify(sortableAttributes.sort()) !== JSON.stringify(settings.sortableAttributes)) {
     const sortableFieldsAttributesTask = await index.updateSortableAttributes(sortableAttributes);


### PR DESCRIPTION
## The bug

Sorted model searches fail outright. Choosing **Most Downloaded** or **Most Buzz** on `/search/models` puts this on the URL:

```
/search/models?modelType=Checkpoint&sortBy=models_v9%3AsortMetrics.downloadCount%3Adesc&query=…
```

`instant-meilisearch` sends that string straight to Meilisearch, which answers:

```
MeiliSearchApiError: Inside `.queries[0]`: Index `models_v9`:
Attribute `sortMetrics.downloadCount` is not sortable. Available sortable attributes are:
`createdAt, id, isOfficial, metrics.collectedCount, metrics.commentCount, metrics.downloadCount,
 metrics.favoriteCount, metrics.thumbsUpCount, metrics.tippedAmountCount`.
```

…and the results page renders nothing. Same for `sortMetrics.tippedAmountCount` at lower volume. Frontend error telemetry shows a flat rate across the whole day, every day — chronic, not a recent regression.

## Root cause

A deploy-ordering gap, not a typo.

#3266 (Creator Controls, 2026-07-21) renamed the sort target to a sort-only `sortMetrics` mirror in **both** the client sort options and the declared `sortableAttributes`, in a single commit. But a declared `sortableAttributes` list only reaches a live index one way:

1. `sortableAttributes` are written only by each index's `onIndexSetup`.
2. `onIndexSetup` is called from exactly one place — `reset()` in `src/server/search-index/base.search-index.ts`, against the `<index>_NEW` swap index. The call in `updateSync` is commented out.
3. Every `search-index-sync-<name>-reset` job is registered with `UNRUNNABLE_JOB_CRON` in `src/server/jobs/search-index-sync.ts` — manual-only, no schedule.

So the rename shipped to the client and never to the index. The client has been asking `models_v9` for an attribute it has never been told about, ever since.

**Confirmed against the live search index**, not just inferred from the error text: `models_v9` exposes `createdAt, id, isOfficial, metrics.collectedCount, metrics.commentCount, metrics.downloadCount, metrics.favoriteCount, metrics.thumbsUpCount, metrics.tippedAmountCount`. `sortMetrics.*` is absent; both fix targets are present. It also **still exposes `metrics.favoriteCount`**, which was deleted from the declared list in `c43e5f199` on 2024-07-28 — the declared list has not been applied to the live models index in over two years.

## Which direction I fixed, and why

Two directions were possible: repair the client sort key, or treat `sortMetrics.*` as the intended naming and update the index settings. **I fixed the client**, because the second is not a code change this repo can ship — the settings source is *already* correct on `main`; only a manual index reset can apply it, and nothing in a merge triggers one. A change that depends on someone running a reindex-and-swap is inert until they do, and users are broken now.

## Changes

- **`src/components/Search/parsers/model.parser.ts`** — "Most Downloaded" and "Most Buzz" sort on `metrics.downloadCount` / `metrics.tippedAmountCount` again, which the live index does expose. The `sortMetrics` document field stays as-is.
- **`src/server/search-index/sortable-attributes.ts`** (new) — a leaf module holding the declared sortable set per index, same shape and same rationale as the existing `filterable-attributes.ts` (kept import-light so a test can read it without pulling in the Meilisearch client). Every index's `onIndexSetup` now sources its list from here, and the module header states plainly that editing a list does not change what a live index accepts, records which lists have been checked against a live index (models, images, bounties) and which have not (the other five), and warns that declaring a field path no document carries is its own hazard.
- **`src/components/Search/parsers/bounties.parser.ts`** — the "Favorite" option asked for a bare `favoriteCountAllTime`; the bounty document carries the count only as `stats.favoriteCountAllTime`, live `bounties_v3` declares only the prefixed spelling, and both sibling options already use it. Repointed to match. See the note below on why this one is latent, not user-visible.
- **Declared-list repairs** — `metrics.favoriteCount` (models) and `createdAt` (images), both attributes the sort options already request and the declared lists had lost. Both verified present on the live indexes, so this is bringing the declaration back in line with reality; it changes nothing until a reset next runs, and stops that reset breaking "Most Liked" / "Newest".
- **`src/components/Search/__tests__/search-index-contract.test.ts`** — extends the existing contract suite with: every sort option on every index must name an attribute that index declares sortable (parameterised, all 8 indexes), plus literal pins of the models and bounties sortable sets and of their sort options in dropdown-label order (`src/pages/search/models.tsx` and `…/bounties.tsx` map their labels onto them by position, so order is part of the contract).

## Test matrix

Run: `npx vitest run --project unit src/components/Search/__tests__/search-index-contract.test.ts`

| Tree | Result |
|---|---|
| Pre-change declared lists + pre-change sort options | **5 failed / 60 passed (65)** |
| Models fix applied, before the bounties commit | **2 failed / 65 passed (67)** |
| This branch | **67 passed (67)** |

The five original failures are `bounties_v3:favoriteCountAllTime`, `images_v6:createdAt`, `models_v9:metrics.favoriteCount`, plus both models literal pins. The two remaining after the models fix are the bounties pins.

Mutation checks, each on top of the final branch:

- Reintroduce only the `sortMetrics.downloadCount` option → **2 red**, with this guard's own message: ``a sort option sends `models_v9:sortMetrics.downloadCount`, but models_v9 does not declare sortMetrics.downloadCount sortable``.
- Reintroduce only the bare `bounties_v3:favoriteCountAllTime` option → **2 red**, same guard, naming `favoriteCountAllTime`.
- Add the bare `favoriteCountAllTime` back to the declared bounties list → **1 red**, on the declared-list pin alone. This is the mutation the subset check structurally *cannot* see (declaring the bogus attribute is exactly what makes the subset check pass), which is why the literal pin is there.

Also run green: `pnpm typecheck` (0 errors), `eslint` + `prettier --check` on the touched files (0 errors, only pre-existing warnings elsewhere), `pnpm test:lint-rules` (355 passed / 23 files), and the wider search slice `src/components/Search src/server/meilisearch src/server/search-index` (288 passed / 9 files).

## Scope honesty: the bounties change is latent, not user-visible

Frontend error telemetry over 6h shows **zero** `is not sortable` errors for `bounties_v3`, against four figures for `models_v9` on the same query — so the instrument works and the bounty "Favorite" sort is simply **not being exercised**. That is not evidence it works. Treat it as a latent-correctness fix: today the bare attribute is inert because nothing applies the declared list, but after any future reset it would flip from a loud failure to a silently arbitrary ordering, which is the worse of the two.

## Known gap this does not close

While a Creator Program member has their download or tip count hidden, the index masks `metrics.downloadCount` / `metrics.tippedAmountCount` to `null` — so those models now sort last under "Most Downloaded" / "Most Buzz" instead of in their true position. That is the exact problem `sortMetrics` was introduced to solve, and it cannot be solved on the current live index.

**Follow-up, with a closing condition:** run a models search-index reset, then confirm `models_v9`'s live `sortableAttributes` contain `sortMetrics.downloadCount` and `sortMetrics.tippedAmountCount`; at that point re-add both to `modelsSortableAttributes`, repoint the two sort options, and update the two literal pins in the contract test. Until that verification passes, the pins should stay where they are.

## Adjacent finding, deliberately left alone

`isOfficial` is sortable on the live models index and appears in no declared list. Nothing sorts on it, so it is left out; a future reset would drop it, harmlessly.
