### PR TITLE
fix(app-listings): let an owner repair the copy of a listing they unpublished themselves, and stop blaming a moderator

### DIFF
--- a/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
+++ b/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
@@ -64,6 +64,10 @@ vi.mock('~/server/middleware.trpc', async () => {
 });
 
 import { blocksRouter } from '../blocks.router';
+import {
+  LISTING_STATUS_CHANGING_MODERATION_ACTIONS,
+  STATE_NEUTRAL_MODERATION_ACTIONS,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
@@ -241,6 +245,87 @@ describe('listMyPublishRequests — P4 owner-control augmentation', () => {
     // No app-block ids on the page → no backing-listing / moderation queries at all.
     expect(mockDbRead.appListing.findMany).not.toHaveBeenCalled();
     expect(mockDbRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 THE LAST-ACTION READ MUST ASK THE SAME QUESTION THE SERVER GATE ASKS.
+ *
+ * `lastModerationAction` is what /apps/mine maps to `owner-hidden` (Republish offered) vs
+ * `mod-removed` (Republish hidden, "removed by a moderator"). The SERVER gate that decides
+ * whether Republish actually works — `republishOwnListing`, and the author edit paths —
+ * reads `readLastModerationAction`, which filters to
+ * `LISTING_STATUS_CHANGING_MODERATION_ACTIONS`. This read was UNFILTERED, so the two
+ * disagreed the moment a state-neutral event landed on top: a moderator's `message-owner`
+ * ("fix X and republish"), a `claim`, or a `report-resolve` became the newest row, the
+ * client saw "not owner-unpublish" and hid Republish on a listing the server would happily
+ * republish — killing the exact repair loop this feature exists for.
+ *
+ * These pin the WHERE clause (the guard itself), not the projected shape.
+ */
+describe('listMyPublishRequests — the last-action read is FILTERED to status-changing actions', () => {
+  const removedRow = (id: string, blockId: string) => ({
+    id,
+    appBlockId: null,
+    slug: `${id}-app`,
+    version: '1.0.0',
+    status: 'approved',
+    submittedAt: new Date('2026-01-01'),
+    reviewedAt: new Date('2026-01-02'),
+    rejectionReason: null,
+    approvalNotes: null,
+    deployState: 'live',
+    deployDetail: null,
+    deployUpdatedAt: null,
+    fileSummary: null,
+    manifestDiffSummary: null,
+    appBlock: { id: blockId, manifest: PAGE_MANIFEST, _count: { userSubscriptions: 0 } },
+  });
+
+  async function lastEventWhere() {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([removedRow('req-h', 'block-h')]);
+    mockDbRead.appListing.findMany.mockResolvedValue([
+      { id: 'l-h', appBlockId: 'block-h', status: 'removed', _count: { screenshots: 3 } },
+    ]);
+    mockDbRead.appListingModerationEvent.findMany.mockResolvedValue([
+      { appListingId: 'l-h', action: 'owner-unpublish' },
+    ]);
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    await caller.listMyPublishRequests();
+    expect(mockDbRead.appListingModerationEvent.findMany).toHaveBeenCalledTimes(1);
+    return (
+      mockDbRead.appListingModerationEvent.findMany.mock.calls[0][0] as {
+        where: { action?: { in?: string[] } };
+      }
+    ).where;
+  }
+
+  it('🔴 carries an `action IN (…)` predicate at all — the clause whose absence is the bug', async () => {
+    const where = await lastEventWhere();
+    expect(where.action).toBeDefined();
+    // POSITIVE CONTROL on the same read: the list is non-empty, so a `not.toContain`
+    // below cannot pass merely because nothing is there.
+    expect(where.action?.in?.length).toBeGreaterThan(0);
+  });
+
+  it('🔴 uses the SHARED constant verbatim — not a second hand-typed spelling', async () => {
+    const where = await lastEventWhere();
+    expect(where.action?.in).toEqual([...LISTING_STATUS_CHANGING_MODERATION_ACTIONS]);
+  });
+
+  it.each([...STATE_NEUTRAL_MODERATION_ACTIONS])(
+    '🔴 %s cannot displace the removal event — excluded by the WHERE clause',
+    async (neutral) => {
+      const where = await lastEventWhere();
+      expect(where.action?.in).not.toContain(neutral);
+    }
+  );
+
+  it('still admits both an owner unpublish and a moderator takedown', async () => {
+    const where = await lastEventWhere();
+    expect(where.action?.in).toContain('owner-unpublish');
+    expect(where.action?.in).toContain('delist');
+    expect(where.action?.in).toContain('purge');
   });
 });
 

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -367,6 +367,17 @@ function mapOffsiteError(err: unknown): TRPCError {
         // the sibling mod-only limiter (`blocks.retriggerBuild`) already returns.
         code === 'RATE_LIMITED'
         ? 'TOO_MANY_REQUESTS'
+        : // 🔴 MAPPED EXPLICITLY even though it lands on the same TRPC code as the
+        // default. The default is a FALLTHROUGH, and this table's own note above warns
+        // that an unmapped code silently becomes BAD_REQUEST — so an entry here is the
+        // difference between "we decided" and "nobody looked". BAD_REQUEST is the honest
+        // code: the caller's AUTHORITY is fine (they own the listing and may edit it),
+        // it is the specific field in this specific state that is refused, and the
+        // message names the field and the way forward. FORBIDDEN would read as "you may
+        // not edit this listing", which is exactly the false attribution this arc exists
+        // to remove.
+        code === 'MATERIAL_CHANGE_BLOCKED'
+        ? 'BAD_REQUEST'
         : 'BAD_REQUEST';
     return new TRPCError({ code: trpcCode, message: err.message, cause: err });
   }
@@ -660,7 +671,9 @@ export const appListingsRouter = router({
    * contentRating) → in place; approved-material (externalUrl/name) → staged on a
    * shadow-draft revision (`requiresReview:true` + the `shadowId` to edit assets
    * against, then `submitListingRevision`). Owner-bound in the service. Rejected →
-   * MUST_RESUBMIT; removed → FORBIDDEN. Typed failures map via `mapOffsiteError`.
+   * MUST_RESUBMIT. `removed` is SPLIT: a moderator takedown → FORBIDDEN, an OWNER
+   * self-unpublish → trivial fields edit in place and a MATERIAL field →
+   * MATERIAL_CHANGE_BLOCKED. Typed failures map via `mapOffsiteError`.
    *
    * ## CLI-reachable (`listingMediaCliScope`) — a WRITE, so the three checks stated
    *
@@ -677,20 +690,34 @@ export const appListingsRouter = router({
    *       `buildListingPatchData`, whose entire output surface is author-owned scalars
    *       (externalUrl / sourceRepoUrl / name / tagline / description / category /
    *       contentRating / the derived connect-scope snapshot). No `status`, no
-   *       moderation event, no publish-request row. A `removed` listing is refused
-   *       outright (FORBIDDEN) and a `rejected` one steered to resubmit.
-   *   (c) IT RESPECTS THE SHADOW-REVISION MODEL. `approved` + a MATERIAL change stages
-   *       onto a shadow via `beginListingRevision` and leaves the live parent untouched;
-   *       only trivial edits touch an approved row in place, which is the documented
-   *       design. A shadow passed here is REFUSED (`revisionOfId != null` →
-   *       INVALID_REVISION) — shadows are `updateRevisionDraft`'s job.
+   *       moderation event, no publish-request row. A `rejected` listing is steered to
+   *       resubmit; a `removed` one is refused (FORBIDDEN) when a MODERATOR took it down.
+   *   (c) IT CANNOT PUT AN UNREVIEWED MATERIAL VALUE ON THE STORE, IN EITHER OF THE TWO
+   *       STATES THAT LOOK EDITABLE. This is the claim that actually carries the scope
+   *       annotation, so it is stated by mechanism rather than by status:
+   *         - `approved` + MATERIAL → staged onto a shadow via `beginListingRevision`;
+   *           the live parent is untouched until a moderator approves the revision. Only
+   *           trivial edits touch an approved row in place.
+   *         - `removed` + last status-changing event `owner-unpublish` (the owner's own
+   *           repair state, which this proc now admits) + MATERIAL →
+   *           MATERIAL_CHANGE_BLOCKED, refused. It is NOT applied and NOT staged. This
+   *           refusal is what stops the owner-driven loop `approved` →
+   *           `unpublishOwnListing` → patch `externalUrl`/`contentRating` in place →
+   *           `republishOwnListing` → `approved`, which would otherwise swap the store's
+   *           destination or lower its content rating after approval. Neither republish
+   *           gate is a content review (one checks image scans, the other that an https
+   *           href exists), so the refusal — not the republish path — is the guarantee.
+   *         - A shadow passed here is REFUSED (`revisionOfId != null` →
+   *           INVALID_REVISION) — shadows are `updateRevisionDraft`'s job.
+   *       Net: the ONLY route from a token to a changed material value on a live store
+   *       page still runs through moderator re-approval.
    *
    * 🔴 The scope-disclosure keys (`requestedScopes`/`scopeJustifications`) are reachable
    * through this patch, but they are SERVER-DERIVED: `deriveScopePatch` re-resolves the
    * linked OAuth client's `allowedScopes` ceiling and `assertConnectScopesValid` re-checks
    * the subset + justifications, so a token cannot request a scope its client does not
-   * already allow. A material scope change also routes to a shadow, i.e. back through mod
-   * review.
+   * already allow. A scope change is MATERIAL, so it follows (c): on `approved` it routes
+   * to a shadow, on an owner-unpublished `removed` it is refused.
    */
   updateListing: appDeveloperProcedure
     .meta(listingMediaCliScope)
@@ -725,7 +752,15 @@ export const appListingsRouter = router({
    * assets (edge-resolved) + status + hasPendingRevision, resolving an approved
    * parent's in-progress shadow so a resumed revision prefills its edited state.
    * Owner-bound in the service (NOT_OWNED→FORBIDDEN, NOT_FOUND, rejected→
-   * MUST_RESUBMIT/BAD_REQUEST, removed→FORBIDDEN). Typed failures via `mapOffsiteError`.
+   * MUST_RESUBMIT/BAD_REQUEST). `removed` is SPLIT on the last status-changing moderation
+   * event: a moderator takedown → FORBIDDEN, the owner's own `owner-unpublish` → the
+   * prefill resolves (the listing is in the owner's repair state). It agrees with
+   * `updateListing`'s gate by construction — both read the same predicate — so this read
+   * never hands back an editor the write path then refuses. Note the prefill is still
+   * WIDER than what the write accepts: a material field prefills but cannot be SAVED while
+   * unpublished (MATERIAL_CHANGE_BLOCKED), which is deliberate — the author has to be able
+   * to SEE the current value of a field they may not change. Typed failures via
+   * `mapOffsiteError`.
    */
   getMyListingForEdit: appDeveloperProcedure
     .meta(listingMediaCliScope)

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -118,6 +118,9 @@ import {
   computeListingProblems,
   type ListingProblemKind,
 } from '~/server/services/blocks/listing-problems';
+// The ONE spelling of "which moderation actions can explain a removal". Value import:
+// it is spread into a Prisma `where` below. See `app-listing-owner-unpublish`.
+import { LISTING_STATUS_CHANGING_MODERATION_ACTIONS } from '~/server/services/blocks/app-listing-owner-unpublish';
 import { getRequestDomainColor, isHostForColor } from '~/server/utils/server-domain';
 // Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
 // dynamic import() inside assertViewerCanGeneratePageResources so the heavy
@@ -2315,18 +2318,30 @@ export const blocksRouter = router({
       }
     }
 
-    // For every REMOVED backing listing, its MOST-RECENT moderation-event action —
-    // so the UI distinguishes an owner-hidden listing (last event `owner-unpublish`
-    // → Republish-eligible) from a moderator takedown (last event `delist`/`purge` →
-    // Republish FORBIDDEN, shown as "removed by a moderator"). Batched `distinct` +
-    // `orderBy desc` (ONE query, latest per listing), only over removed listings —
-    // mirrors the off-site `listMySubmissions` approach.
+    // For every REMOVED backing listing, its MOST-RECENT STATUS-CHANGING moderation-event
+    // action — so the UI distinguishes an owner-hidden listing (last event
+    // `owner-unpublish` → Republish-eligible) from a moderator takedown (last event
+    // `delist`/`purge` → Republish FORBIDDEN, shown as "removed by a moderator"). Batched
+    // `distinct` + `orderBy desc` (ONE query, latest per listing), only over removed
+    // listings — mirrors the off-site `listMySubmissions` approach.
+    //
+    // 🔴 FILTERED TO THE STATUS-CHANGING SET, FROM THE SHARED CONSTANT. An unfiltered read
+    // here answers a DIFFERENT question from the server gate (`republishOwnListing` and the
+    // author edit paths, which all route through `readLastModerationAction`), and the two
+    // disagree the moment a state-neutral event lands on top: a moderator's `message-owner`
+    // ("fix X and republish") is newest, the client maps "not owner-unpublish" to
+    // `mod-removed`, and /apps/mine tells the owner a moderator removed a listing the server
+    // would happily republish — killing the repair loop this feature exists for. `claim`,
+    // `report-resolve` and `report-dismiss` do the same. One spelling of the set.
     const removedListingIds = [...listingByBlockId.values()]
       .filter((l) => l.status === 'removed')
       .map((l) => l.id);
     const lastEvents = removedListingIds.length
       ? await dbRead.appListingModerationEvent.findMany({
-          where: { appListingId: { in: removedListingIds } },
+          where: {
+            appListingId: { in: removedListingIds },
+            action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
+          },
           orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
           distinct: ['appListingId'],
           select: { appListingId: true, action: true },

--- a/src/server/services/blocks/__tests__/app-access.my-app-listings-moderation.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.my-app-listings-moderation.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import {
+  LISTING_STATUS_CHANGING_MODERATION_ACTIONS,
+  STATE_NEUTRAL_MODERATION_ACTIONS,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
 
 /**
  * `listMyAppListings` — the `lastModerationAction` widening that makes the `/apps/mine`
@@ -137,7 +141,7 @@ type Event = { action: string; createdAt: Date; id: string };
 function historyFake(byListingId: Record<string, Event[]>) {
   return async (...a: unknown[]): Promise<unknown[]> => {
     const args = (a[0] ?? {}) as {
-      where?: { appListingId?: { in: string[] } };
+      where?: { appListingId?: { in: string[] }; action?: { in: string[] } };
       orderBy?: Array<Record<string, 'asc' | 'desc'>>;
       distinct?: string[];
     };
@@ -145,6 +149,12 @@ function historyFake(byListingId: Record<string, Event[]>) {
     let rows: Array<Event & { appListingId: string }> = ids.flatMap((id) =>
       (byListingId[id] ?? []).map((e) => ({ ...e, appListingId: id }))
     );
+    // 🔴 HONOUR `where.action` — the fake has to be able to answer DIFFERENTLY depending on
+    // whether the caller filtered, or a case built on it cannot see the filter at all. It
+    // could not before: a mutant that dropped the action filter from this read SURVIVED the
+    // whole battery, because the fake returned the same rows either way.
+    const allowedActions = args.where?.action?.in;
+    if (allowedActions) rows = rows.filter((r) => allowedActions.includes(r.action));
     // Apply the query's OWN sort, key by key, rather than a hardcoded newest-first.
     for (const clause of [...(args.orderBy ?? [])].reverse()) {
       const [key, dir] = Object.entries(clause)[0] as ['createdAt' | 'id', 'asc' | 'desc'];
@@ -258,6 +268,47 @@ describe('listMyAppListings — lastModerationAction', () => {
       orderBy: Array<Record<string, string>>;
     };
     expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
+  });
+
+  it('🔴 a moderator MESSAGE does not hide the owner-unpublish underneath it', async () => {
+    /**
+     * 🔴 THE WORKFLOW THAT BREAKS THIS ROW. A moderator messaging the owner *"fix X and
+     * republish"* writes `action:'message-owner'` — an `AppListingModerationEvent` that
+     * changes NO listing status. It is then the newest event, so an unfiltered
+     * most-recent-event read reports `other`, the row hides **Republish**, and the owner is
+     * told a moderator removed their app. That is the exact false attribution this whole
+     * arc exists to delete, re-introduced by the most ordinary moderator action there is.
+     *
+     * The server-side gate (`republishOwnListing`, and the three author edit paths) reads
+     * the same filtered predicate, so an unfiltered read here ALSO puts the page and the
+     * server into disagreement: no button, on a listing the server would happily republish.
+     *
+     * `report-resolve` / `report-dismiss` / `claim` are the same class; `closeTerminalListing`
+     * was already bitten by `report-resolve`, in the opposite direction.
+     */
+    mockDb.appListing.findMany.mockImplementation(findManyFake([stored({ id: 'apl_msg' })]));
+    mockDb.appListingModerationEvent.findMany.mockImplementation(
+      historyFake({
+        apl_msg: [
+          { action: 'owner-unpublish', createdAt: new Date('2026-05-01T00:00:00Z'), id: 'ev_a' },
+          // Newest overall, but state-neutral — it cannot explain the `removed` status.
+          { action: 'message-owner', createdAt: new Date('2026-05-02T00:00:00Z'), id: 'ev_b' },
+        ],
+      })
+    );
+
+    const rows = await listMyAppListings({ userId: OWNER });
+    expect(rows[0].lastModerationAction).toBe('owner-unpublish');
+
+    // Structural half: the filter is in the WHERE, and it excludes every state-neutral verb.
+    const args = mockDb.appListingModerationEvent.findMany.mock.calls[0]?.[0] as {
+      where: { action: { in: string[] } };
+    };
+    for (const neutral of STATE_NEUTRAL_MODERATION_ACTIONS) {
+      expect(args.where.action.in).not.toContain(neutral);
+    }
+    // Positive control on the same read — the set is not simply empty.
+    expect(args.where.action.in).toEqual([...LISTING_STATUS_CHANGING_MODERATION_ACTIONS]);
   });
 
   it('reads events ONLY for the removed subset', async () => {

--- a/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
@@ -72,12 +72,24 @@ describe('isOwnerUnpublishAction', () => {
 
 describe('LISTING_STATUS_CHANGING_MODERATION_ACTIONS', () => {
   /**
-   * 🔴 THE PARTITION IS PINNED AGAINST THE WHOLE TAXONOMY, NOT SAMPLED. The hazard this
-   * set exists to stop is a NEW action silently joining the log and changing who may
-   * edit — so the guard has to fail when the taxonomy GROWS, not merely when one known
-   * member is missing. `APP_LISTING_MODERATION_ACTIONS` is itself pinned against the
-   * migration's CHECK IN-list by `app-listing-mod-action.constants.test.ts`, so this
-   * chains all the way to the database.
+   * 🔴 BOTH HALVES ARE HARDCODED LITERALS, AND THAT IS WHAT MAKES THE ASSERTION BELOW
+   * MEAN ANYTHING. `STATE_NEUTRAL_MODERATION_ACTIONS` was briefly the DERIVED complement
+   * (`APP_LISTING_MODERATION_ACTIONS.filter(a => !CHANGING.includes(a))`). Under that
+   * construction union-equals-taxonomy, empty-intersection and size-sum are all
+   * TAUTOLOGIES: a new verb lands in the neutral half automatically and every assertion
+   * still holds. Measured — adding `'suspend'` to the taxonomy left 33 passing / 0
+   * failing. The guard read as coverage and provided none, which is worse than none.
+   *
+   * The hazard it was supposed to stop is real and FAIL-OPEN: a new status-CHANGING
+   * takedown verb omitted from `LISTING_STATUS_CHANGING_MODERATION_ACTIONS` is filtered
+   * OUT of `readLastModerationAction`'s WHERE clause, so an older `owner-unpublish`
+   * resurfaces beneath the moderator's takedown and the owner regains edit +
+   * `republishOwnListing` on content that was just removed.
+   *
+   * With both halves written out, a new verb is a member of NEITHER, so the union
+   * assertion goes RED and the classification has to be made out loud.
+   * `APP_LISTING_MODERATION_ACTIONS` is itself pinned against the migration's CHECK
+   * IN-list by `app-listing-mod-action.constants.test.ts`, so this chains to the DB.
    */
   it('🔴 partitions the FULL action taxonomy: status-changing ∪ state-neutral = all, ∩ = ∅', () => {
     const changing = new Set<string>(LISTING_STATUS_CHANGING_MODERATION_ACTIONS);
@@ -87,6 +99,31 @@ describe('LISTING_STATUS_CHANGING_MODERATION_ACTIONS', () => {
     expect(new Set([...changing, ...neutral])).toEqual(new Set(APP_LISTING_MODERATION_ACTIONS));
     // No duplicates hiding inside either half.
     expect(changing.size + neutral.size).toBe(APP_LISTING_MODERATION_ACTIONS.length);
+  });
+
+  /**
+   * INVARIANT GUARD (not regression coverage — it passed before this change too, because
+   * the derived complement produced exactly this list). It exists to pin the two halves
+   * as WHOLE ARRAYS so a member cannot be quietly dropped from one and appear in the
+   * other while the partition assertion above stays satisfied. Order is asserted too:
+   * these feed a SQL `IN` list, and a stable order keeps the pinned statement text in
+   * `offsite-listing.edit.service.test.ts` deterministic.
+   */
+  it('pins BOTH halves as whole literal arrays, so neither can be silently re-derived', () => {
+    expect([...LISTING_STATUS_CHANGING_MODERATION_ACTIONS]).toEqual([
+      'delist',
+      'relist',
+      'purge',
+      'reset-to-pending',
+      'owner-unpublish',
+      'owner-republish',
+    ]);
+    expect([...STATE_NEUTRAL_MODERATION_ACTIONS]).toEqual([
+      'claim',
+      'report-resolve',
+      'report-dismiss',
+      'message-owner',
+    ]);
   });
 
   it.each(['delist', 'relist', 'purge', 'reset-to-pending', 'owner-unpublish', 'owner-republish'])(

--- a/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isOwnerUnpublishAction,
+  isOwnerUnpublishedListing,
+  OWNER_UNPUBLISH_EVENT,
+  readLastModerationAction,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
+
+/**
+ * The single spelling of "did the OWNER take this listing down, or did a MODERATOR?".
+ *
+ * `app_listings.status = 'removed'` cannot answer that — both writers produce it — so the
+ * answer comes from the most-recent `AppListingModerationEvent`. This module is the one
+ * place that question is asked; `republishOwnListing`'s go-live guard and the three author
+ * edit paths in `offsite-listing.service` all read it from here.
+ */
+
+function fakeClient(row: { action: string } | null) {
+  const findFirst = vi.fn(async (..._a: unknown[]) => row);
+  return { client: { appListingModerationEvent: { findFirst } }, findFirst };
+}
+
+describe('isOwnerUnpublishAction', () => {
+  it("the owner's own unpublish is the ONLY action that answers true", () => {
+    expect(isOwnerUnpublishAction('owner-unpublish')).toBe(true);
+  });
+
+  it.each([
+    'delist',
+    'purge',
+    'owner-republish',
+    'relist',
+    'approve',
+    'reject',
+    'reset-to-pending',
+    'claim',
+    // Near-misses that a substring/prefix test would wrongly admit.
+    'owner-unpublished',
+    'not-owner-unpublish',
+    'OWNER-UNPUBLISH',
+  ])('%s ⇒ false', (action) => {
+    expect(isOwnerUnpublishAction(action)).toBe(false);
+  });
+
+  it('🔴 FAILS CLOSED on absence: null / undefined ⇒ false', () => {
+    expect(isOwnerUnpublishAction(null)).toBe(false);
+    expect(isOwnerUnpublishAction(undefined)).toBe(false);
+  });
+
+  it('names the action with the exported constant, so callers cannot re-spell it', () => {
+    expect(OWNER_UNPUBLISH_EVENT).toBe('owner-unpublish');
+  });
+});
+
+describe('readLastModerationAction', () => {
+  it('🔴 orders newest-first with the id tiebreak and selects only `action`', async () => {
+    // `createdAt` alone is not a total order — two events written in one transaction
+    // share a timestamp, and without the id tiebreak "most recent" is whichever row the
+    // planner returned first, which flips an owner capability on and off at random.
+    const { client, findFirst } = fakeClient({ action: 'delist' });
+
+    await readLastModerationAction(client, 'apl_x');
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_x' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      select: { action: true },
+    });
+  });
+
+  it('returns the action, and null when the listing has no events', async () => {
+    expect(await readLastModerationAction(fakeClient({ action: 'delist' }).client, 'apl_x')).toBe(
+      'delist'
+    );
+    expect(await readLastModerationAction(fakeClient(null).client, 'apl_x')).toBeNull();
+  });
+});
+
+describe('isOwnerUnpublishedListing', () => {
+  it.each([
+    ['owner-unpublish', true],
+    ['delist', false],
+    ['purge', false],
+  ] as const)('last event %s ⇒ %s', async (action, expected) => {
+    expect(await isOwnerUnpublishedListing(fakeClient({ action }).client, 'apl_x')).toBe(expected);
+  });
+
+  it('🔴 no events at all ⇒ false (a removal nothing proves the owner made)', async () => {
+    expect(await isOwnerUnpublishedListing(fakeClient(null).client, 'apl_x')).toBe(false);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { OWNER_UNPUBLISH_ACTION } from '~/components/Apps/offsiteOwnerControls';
+import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-moderation.schema';
 import {
   isOwnerUnpublishAction,
   isOwnerUnpublishedListing,
+  LISTING_STATUS_CHANGING_MODERATION_ACTIONS,
   OWNER_UNPUBLISH_EVENT,
   readLastModerationAction,
+  STATE_NEUTRAL_MODERATION_ACTIONS,
 } from '~/server/services/blocks/app-listing-owner-unpublish';
 
 /**
@@ -51,6 +55,63 @@ describe('isOwnerUnpublishAction', () => {
   it('names the action with the exported constant, so callers cannot re-spell it', () => {
     expect(OWNER_UNPUBLISH_EVENT).toBe('owner-unpublish');
   });
+
+  /**
+   * The CLIENT keeps its own literal (`OWNER_UNPUBLISH_ACTION` in
+   * `~/components/Apps/offsiteOwnerControls`) rather than importing this module, which is
+   * server-side and pulls the moderation schema with it. That is a deliberate bundle
+   * decision, not an accident — but it leaves two spellings of one action, and two
+   * literals are how the Republish button and the server gate drift apart. This is the
+   * seam that keeps them equal.
+   */
+  it('🔴 the CLIENT literal is the same string as the SERVER constant', () => {
+    expect(OWNER_UNPUBLISH_ACTION).toBe(OWNER_UNPUBLISH_EVENT);
+    expect(isOwnerUnpublishAction(OWNER_UNPUBLISH_ACTION)).toBe(true);
+  });
+});
+
+describe('LISTING_STATUS_CHANGING_MODERATION_ACTIONS', () => {
+  /**
+   * 🔴 THE PARTITION IS PINNED AGAINST THE WHOLE TAXONOMY, NOT SAMPLED. The hazard this
+   * set exists to stop is a NEW action silently joining the log and changing who may
+   * edit — so the guard has to fail when the taxonomy GROWS, not merely when one known
+   * member is missing. `APP_LISTING_MODERATION_ACTIONS` is itself pinned against the
+   * migration's CHECK IN-list by `app-listing-mod-action.constants.test.ts`, so this
+   * chains all the way to the database.
+   */
+  it('🔴 partitions the FULL action taxonomy: status-changing ∪ state-neutral = all, ∩ = ∅', () => {
+    const changing = new Set<string>(LISTING_STATUS_CHANGING_MODERATION_ACTIONS);
+    const neutral = new Set<string>(STATE_NEUTRAL_MODERATION_ACTIONS);
+
+    expect([...changing].filter((a) => neutral.has(a))).toEqual([]);
+    expect(new Set([...changing, ...neutral])).toEqual(new Set(APP_LISTING_MODERATION_ACTIONS));
+    // No duplicates hiding inside either half.
+    expect(changing.size + neutral.size).toBe(APP_LISTING_MODERATION_ACTIONS.length);
+  });
+
+  it.each(['delist', 'relist', 'purge', 'reset-to-pending', 'owner-unpublish', 'owner-republish'])(
+    '%s WRITES app_listings.status ⇒ status-changing',
+    (action) => {
+      expect(LISTING_STATUS_CHANGING_MODERATION_ACTIONS as readonly string[]).toContain(action);
+    }
+  );
+
+  it.each([
+    // A moderator writing to the owner ("fix X and republish") — the workflow that made
+    // an unfiltered last-event read revoke the very repair loop this arc adds.
+    'message-owner',
+    // A REPORT's status flips; the listing's does not.
+    'report-resolve',
+    'report-dismiss',
+    // The listing's `userId` moves; its `status` does not.
+    'claim',
+  ])(
+    '%s leaves app_listings.status alone ⇒ state-neutral, and must NOT displace a removal',
+    (action) => {
+      expect(LISTING_STATUS_CHANGING_MODERATION_ACTIONS as readonly string[]).not.toContain(action);
+      expect(STATE_NEUTRAL_MODERATION_ACTIONS as readonly string[]).toContain(action);
+    }
+  );
 });
 
 describe('readLastModerationAction', () => {
@@ -63,10 +124,31 @@ describe('readLastModerationAction', () => {
     await readLastModerationAction(client, 'apl_x');
 
     expect(findFirst).toHaveBeenCalledWith({
-      where: { appListingId: 'apl_x' },
+      where: {
+        appListingId: 'apl_x',
+        action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
+      },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       select: { action: true },
     });
+  });
+
+  it('🔴 FILTERS IN THE QUERY: every state-neutral action is excluded by the WHERE clause', async () => {
+    // The filter must be a `where`, not a post-hoc test on one fetched row: "the newest
+    // STATUS-CHANGING event" is not derivable from "the newest event of any kind" — if
+    // the newest row is a `message-owner`, a post-filter yields null (fail-closed, but
+    // WRONG: it hides the owner's real `owner-unpublish` underneath).
+    const { client, findFirst } = fakeClient({ action: 'owner-unpublish' });
+
+    await readLastModerationAction(client, 'apl_x');
+
+    const where = (findFirst.mock.calls[0]?.[0] as { where: { action: { in: string[] } } }).where;
+    for (const neutral of STATE_NEUTRAL_MODERATION_ACTIONS) {
+      expect(where.action.in).not.toContain(neutral);
+    }
+    // Positive control on the same read: the query is not simply empty.
+    expect(where.action.in).toContain('owner-unpublish');
+    expect(where.action.in).toContain('delist');
   });
 
   it('returns the action, and null when the listing has no events', async () => {

--- a/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
@@ -105,9 +105,23 @@ describe('LISTING_STATUS_CHANGING_MODERATION_ACTIONS', () => {
    * INVARIANT GUARD (not regression coverage — it passed before this change too, because
    * the derived complement produced exactly this list). It exists to pin the two halves
    * as WHOLE ARRAYS so a member cannot be quietly dropped from one and appear in the
-   * other while the partition assertion above stays satisfied. Order is asserted too:
-   * these feed a SQL `IN` list, and a stable order keeps the pinned statement text in
-   * `offsite-listing.edit.service.test.ts` deterministic.
+   * other while the partition assertion above stays satisfied.
+   *
+   * 🔴 ORDER IS ASSERTED TOO, AND THIS IS THE ONLY TEST THAT SEES A REORDER. An earlier
+   * version of this comment justified that by claiming the order keeps the pinned SQL text
+   * in `offsite-listing.edit.service.test.ts` deterministic. That is FALSE and is corrected
+   * rather than softened: the statement is pinned as `... AND action IN (?,?,?,?,?,?)`, so
+   * only the COUNT of the verbs reaches the text — the values are bound parameters and the
+   * pin is order-insensitive by construction. The companion assertion there,
+   * `expect(values).toEqual(['apl_removed', ...LISTING_STATUS_CHANGING_MODERATION_ACTIONS])`,
+   * derives its own expectation from the same constant, so it moves WITH a reorder and
+   * cannot see one either. Measured: reordering the constant leaves both of those GREEN and
+   * is caught here and nowhere else.
+   *
+   * What the order assertion actually buys, then, is a REVIEW property, not a runtime one:
+   * the two halves are written out as literals, so a reorder or a membership change shows up
+   * as a diff on this list and has to be looked at, instead of being absorbed silently by
+   * assertions computed from the constant itself.
    */
   it('pins BOTH halves as whole literal arrays, so neither can be silently re-derived', () => {
     expect([...LISTING_STATUS_CHANGING_MODERATION_ACTIONS]).toEqual([

--- a/src/server/services/blocks/__tests__/listing-mod-event-read-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/listing-mod-event-read-ledger.test.ts
@@ -1,0 +1,208 @@
+import { globSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { LISTING_STATUS_CHANGING_MODERATION_ACTIONS } from '~/server/services/blocks/app-listing-owner-unpublish';
+
+/**
+ * 🔴 A LEDGER OF EVERY READ OF `AppListingModerationEvent`, AND WHAT EACH ONE ASKS.
+ *
+ * WHY THIS EXISTS. "Which moderation event explains why this listing is `removed`?" is
+ * answered by the MOST-RECENT event whose action actually WRITES `app_listings.status`.
+ * `LISTING_STATUS_CHANGING_MODERATION_ACTIONS` is that set, and it is supposed to have ONE
+ * spelling. It did not: the predicate was open-coded, and each round of review found
+ * another copy — SIX read sites by the time anyone counted, two of them unfiltered, one of
+ * those in raw SQL where no behavioural test could see it. Every unfiltered copy fails the
+ * same way and in the same direction: a moderator's `message-owner` ("fix X and republish"),
+ * a `claim`, or a `report-resolve` is newer than the owner's own `owner-unpublish`, so the
+ * page tells the owner a moderator removed a listing the server would happily republish.
+ *
+ * 🔴 THIS PINS A RELATIONSHIP, NOT A COMPONENT — which is the point. Each of those six sites
+ * was individually reviewed and individually tested; the defect lived in the SEAM, in the
+ * fact that nobody owned the SET of readers. So this asserts the whole set: it fails when a
+ * SEVENTH read appears (an unclassified reader) AND when one disappears (a stale ledger
+ * entry, the direction allowlists routinely get wrong).
+ *
+ * 🔴 IT IS STRUCTURAL, SO IT IS NOT SUFFICIENT ON ITS OWN. It proves each `filtered` reader
+ * MENTIONS the constant near its read; it cannot prove the mention is wired correctly — a
+ * structural check type-checks straight past a wrong argument. The behavioural half lives
+ * with each reader (`app-listing-owner-unpublish.test.ts`,
+ * `blocks.router.listMyPublishRequests.test.ts`, `app-access.my-app-listings-moderation
+ * .test.ts`, and the whole-SQL-text pin in `offsite-listing.edit.service.test.ts`). Both
+ * halves are needed; neither replaces the other.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+
+/** A Prisma read, or the raw-SQL read, of the moderation-event table. */
+const READ_PATTERNS = [
+  /appListingModerationEvent\s*\.\s*(?:findFirst|findMany|findUnique|findUniqueOrThrow|findFirstOrThrow|aggregate|groupBy)\b/g,
+  /\bFROM\s+app_listing_moderation_events\b/g,
+];
+
+/**
+ * Strip comments before ANY proximity check.
+ *
+ * 🔴 LOAD-BEARING. Every filtered read below is documented with a comment naming the
+ * constant. Without this, the "the constant appears near the read" assertion is satisfied by
+ * the PROSE, and deleting the actual `action: { in: … }` clause would leave the guard green
+ * — the exact "a word another feature can spell" failure. Verified by the negative controls
+ * at the bottom: a file whose ONLY mention is in a comment is reported as unfiltered.
+ */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/** Lines (1-based) in `src` at which a moderation-event read appears. */
+function readLines(src: string): number[] {
+  const lines: number[] = [];
+  for (const re of READ_PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) lines.push(src.slice(0, m.index).split('\n').length);
+  }
+  return [...new Set(lines)].sort((a, b) => a - b);
+}
+
+/**
+ * Does a read at `line` carry the shared constant within the statement around it?
+ *
+ * A window rather than an exact parse: the constant is spread into a `where` (Prisma) or a
+ * `Prisma.join` (raw SQL) a handful of lines from the call, and a paren-balancing extractor
+ * is the fragile thing this deliberately avoids.
+ */
+const WINDOW = 14;
+function readIsFiltered(strippedLines: string[], line: number): boolean {
+  const window = strippedLines.slice(Math.max(0, line - 1 - 2), line - 1 + WINDOW).join('\n');
+  return window.includes('LISTING_STATUS_CHANGING_MODERATION_ACTIONS');
+}
+
+type Kind = 'filtered' | 'full-timeline';
+
+/**
+ * 🔴 THE LEDGER. Every non-test read of `AppListingModerationEvent` in the repo, and what
+ * question it asks. Adding a reader means adding a line here and stating which it is.
+ *
+ * `filtered`      — asks "what explains this removal?"; MUST restrict to
+ *                   `LISTING_STATUS_CHANGING_MODERATION_ACTIONS`.
+ * `full-timeline` — renders the audit history; deliberately reads EVERY action, because a
+ *                   `message-owner` is precisely what the owner is meant to see there.
+ */
+const LEDGER: Record<string, { kind: Kind; why: string }> = {
+  'src/server/services/blocks/app-listing-owner-unpublish.ts': {
+    kind: 'filtered',
+    why: 'readLastModerationAction — the canonical predicate every other filtered reader defers to.',
+  },
+  'src/server/services/blocks/app-access.service.ts': {
+    kind: 'filtered',
+    why: 'listMyAppListings — batched last-action per removed listing, drives the Republish affordance on /apps/mine.',
+  },
+  'src/server/routers/blocks.router.ts': {
+    kind: 'filtered',
+    why: 'listMyPublishRequests — same affordance for on-site apps. Was UNFILTERED (the sixth copy).',
+  },
+  'src/server/services/blocks/offsite-listing.service.ts': {
+    kind: 'filtered',
+    why: 'listMySubmissions — raw DISTINCT ON, the off-site my-submissions page. Was UNFILTERED (the seventh copy).',
+  },
+  'src/server/services/blocks/offsite-moderation.service.ts': {
+    kind: 'full-timeline',
+    why: 'queryModerationEvents — the paginated per-listing audit history (owner- and mod-scoped). Reads every action ON PURPOSE.',
+  },
+};
+
+function scan() {
+  const found: Record<string, number[]> = {};
+  const stripped: Record<string, string[]> = {};
+  for (const rel of globSync('src/**/*.{ts,tsx}', { cwd: REPO_ROOT })) {
+    const file = rel.replace(/\\/g, '/');
+    if (file.includes('/__tests__/') || /\.test\.tsx?$/.test(file)) continue;
+    const abs = path.join(REPO_ROOT, rel);
+    if (!statSync(abs, { throwIfNoEntry: false })?.isFile()) continue;
+    const src = readFileSync(abs, 'utf8');
+    const s = stripComments(src);
+    const lines = readLines(s);
+    if (lines.length) {
+      found[file] = lines;
+      stripped[file] = s.split('\n');
+    }
+  }
+  return { found, stripped };
+}
+
+describe('AppListingModerationEvent read ledger', () => {
+  const { found, stripped } = scan();
+
+  it('POSITIVE CONTROL: the scanner actually finds reads (a zero here would pass everything)', () => {
+    // A detector wired to nothing reports a clean repo. This is the number that must move.
+    expect(Object.keys(found).length).toBeGreaterThanOrEqual(5);
+    expect(Object.values(found).flat().length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('🔴 the set of readers is EXACTLY the ledger — fails when it grows AND when it shrinks', () => {
+    expect(Object.keys(found).sort()).toEqual(Object.keys(LEDGER).sort());
+  });
+
+  it.each(
+    Object.entries(LEDGER)
+      .filter(([, v]) => v.kind === 'filtered')
+      .map(([f]) => f)
+  )('🔴 %s restricts to the SHARED constant at every read', (file) => {
+    const lines = found[file] ?? [];
+    expect(lines.length).toBeGreaterThan(0);
+    const unfiltered = lines.filter((l) => !readIsFiltered(stripped[file], l));
+    expect(unfiltered).toEqual([]);
+  });
+
+  it('the full-timeline reader is deliberately NOT filtered — stated, not assumed', () => {
+    const file = 'src/server/services/blocks/offsite-moderation.service.ts';
+    const lines = found[file] ?? [];
+    expect(lines.length).toBeGreaterThan(0);
+    // If this ever starts filtering, the audit history silently stops showing the owner the
+    // moderator's message — a real regression that would otherwise look like a tightening.
+    expect(lines.every((l) => !readIsFiltered(stripped[file], l))).toBe(true);
+  });
+});
+
+/**
+ * NEGATIVE CONTROLS on the detector itself. Until each of these has been watched to work,
+ * the ledger above is a claim about the instrument, not about the repo.
+ */
+describe('the detector can go red', () => {
+  it('finds a planted Prisma read', () => {
+    expect(readLines('await dbRead.appListingModerationEvent.findMany({ where: {} });')).toEqual([
+      1,
+    ]);
+  });
+
+  it('finds a planted raw-SQL read', () => {
+    expect(readLines('SELECT action\nFROM app_listing_moderation_events\nWHERE x')).toEqual([2]);
+  });
+
+  it('🔴 a mention in a COMMENT does not count as a filter', () => {
+    const src = stripComments(
+      [
+        '// filtered to LISTING_STATUS_CHANGING_MODERATION_ACTIONS, honest',
+        '/* also LISTING_STATUS_CHANGING_MODERATION_ACTIONS */',
+        'await dbRead.appListingModerationEvent.findMany({ where: { appListingId } });',
+      ].join('\n')
+    ).split('\n');
+    // The read is on the LAST line; both mentions are above it and both are comments.
+    expect(readIsFiltered(src, 3)).toBe(false);
+  });
+
+  it('a real filter near the read DOES count', () => {
+    const src = stripComments(
+      [
+        'await dbRead.appListingModerationEvent.findMany({',
+        '  where: { action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] } },',
+        '});',
+      ].join('\n')
+    ).split('\n');
+    expect(readIsFiltered(src, 1)).toBe(true);
+  });
+
+  it('the constant it names is the real exported one, not a string that merely looks like it', () => {
+    expect(LISTING_STATUS_CHANGING_MODERATION_ACTIONS.length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/services/blocks/__tests__/listing-mod-event-read-ledger.test.ts
+++ b/src/server/services/blocks/__tests__/listing-mod-event-read-ledger.test.ts
@@ -11,16 +11,27 @@ import { LISTING_STATUS_CHANGING_MODERATION_ACTIONS } from '~/server/services/bl
  * answered by the MOST-RECENT event whose action actually WRITES `app_listings.status`.
  * `LISTING_STATUS_CHANGING_MODERATION_ACTIONS` is that set, and it is supposed to have ONE
  * spelling. It did not: the predicate was open-coded, and each round of review found
- * another copy — SIX read sites by the time anyone counted, two of them unfiltered, one of
- * those in raw SQL where no behavioural test could see it. Every unfiltered copy fails the
- * same way and in the same direction: a moderator's `message-owner` ("fix X and republish"),
- * a `claim`, or a `report-resolve` is newer than the owner's own `owner-unpublish`, so the
- * page tells the owner a moderator removed a listing the server would happily republish.
+ * another copy — TWO of them unfiltered, one of those in raw SQL where no behavioural test
+ * could see it. Every unfiltered copy fails the same way and in the same direction: a
+ * moderator's `message-owner` ("fix X and republish"), a `claim`, or a `report-resolve` is
+ * newer than the owner's own `owner-unpublish`, so the page tells the owner a moderator
+ * removed a listing the server would happily republish.
  *
- * 🔴 THIS PINS A RELATIONSHIP, NOT A COMPONENT — which is the point. Each of those six sites
- * was individually reviewed and individually tested; the defect lived in the SEAM, in the
- * fact that nobody owned the SET of readers. So this asserts the whole set: it fails when a
- * SEVENTH read appears (an unclassified reader) AND when one disappears (a stale ledger
+ * 🔴 TWO DIFFERENT COUNTING BASES APPEAR IN THIS ARC — do not read either as the other.
+ *   (a) READ SITES IN THIS LEDGER: **5** — the direct reads of the table that the scanner
+ *       below finds under `src/**` excluding tests. 4 `filtered` + 1 `full-timeline`. This
+ *       is the number the assertions here are about, and it is measured, not asserted from
+ *       memory: the scanner reports it on every run.
+ *   (b) OPEN-CODED COPIES FOUND ACROSS THE ARC: a running tally kept by the review rounds,
+ *       which also counted DELEGATING callers of `readLastModerationAction`, not only
+ *       direct table reads. That tally is where the "sixth copy" / "seventh copy" labels on
+ *       two ledger entries below come from. It is history, not a count of anything in this
+ *       file, and it is deliberately NOT reconciled with (a).
+ *
+ * 🔴 THIS PINS A RELATIONSHIP, NOT A COMPONENT — which is the point. Each of those read
+ * sites was individually reviewed and individually tested; the defect lived in the SEAM, in
+ * the fact that nobody owned the SET of readers. So this asserts the whole set: it fails
+ * when a SIXTH read appears (an unclassified reader) AND when one disappears (a stale ledger
  * entry, the direction allowlists routinely get wrong).
  *
  * 🔴 IT IS STRUCTURAL, SO IT IS NOT SUFFICIENT ON ITS OWN. It proves each `filtered` reader
@@ -83,6 +94,10 @@ type Kind = 'filtered' | 'full-timeline';
  * 🔴 THE LEDGER. Every non-test read of `AppListingModerationEvent` in the repo, and what
  * question it asks. Adding a reader means adding a line here and stating which it is.
  *
+ * There are FIVE entries, which is the read-site count — basis (a) in the header. The
+ * "sixth copy" / "seventh copy" labels in two `why` strings are basis (b), the arc-wide
+ * open-coded-copy tally; they are provenance, not a position in this list.
+ *
  * `filtered`      — asks "what explains this removal?"; MUST restrict to
  *                   `LISTING_STATUS_CHANGING_MODERATION_ACTIONS`.
  * `full-timeline` — renders the audit history; deliberately reads EVERY action, because a
@@ -99,11 +114,11 @@ const LEDGER: Record<string, { kind: Kind; why: string }> = {
   },
   'src/server/routers/blocks.router.ts': {
     kind: 'filtered',
-    why: 'listMyPublishRequests — same affordance for on-site apps. Was UNFILTERED (the sixth copy).',
+    why: 'listMyPublishRequests — same affordance for on-site apps. Was UNFILTERED (arc tally: the sixth open-coded copy; basis (b), not a read-site index).',
   },
   'src/server/services/blocks/offsite-listing.service.ts': {
     kind: 'filtered',
-    why: 'listMySubmissions — raw DISTINCT ON, the off-site my-submissions page. Was UNFILTERED (the seventh copy).',
+    why: 'listMySubmissions — raw DISTINCT ON, the off-site my-submissions page. Was UNFILTERED (arc tally: the seventh open-coded copy; basis (b), not a read-site index).',
   },
   'src/server/services/blocks/offsite-moderation.service.ts': {
     kind: 'full-timeline',
@@ -154,12 +169,38 @@ describe('AppListingModerationEvent read ledger', () => {
     expect(unfiltered).toEqual([]);
   });
 
+  /**
+   * 🔴 READ WHAT THIS ASSERTS, NOT WHAT IT SOUNDS LIKE. `readIsFiltered` is a NAME-PROXIMITY
+   * check: it asks only whether the string `LISTING_STATUS_CHANGING_MODERATION_ACTIONS`
+   * appears in the window around the read, on a non-comment line. So this test pins exactly
+   * one thing — the deliberate exception is not quietly routed through the SHARED constant
+   * like its four filtered siblings. That is the mutation the ledger exists to catch here
+   * (round-2 `L6`), and it is all this test can see.
+   *
+   * 🔴 IT IS THEREFORE **NOT** THE GUARD AGAINST THE NAMED REGRESSION. A `where` clause
+   * typed out by hand — `action: { in: ['delist', 'relist', …] }` — never mentions the
+   * constant, so `readIsFiltered` stays false and this assertion stays GREEN while the audit
+   * history silently stops showing the owner the moderator's `message-owner`. Measured on
+   * this tip: that exact hand-typed filter survives the whole battery, this test included.
+   *
+   * WHAT ACTUALLY PREVENTS IT is a pair of PRE-EXISTING behavioural pins this PR neither
+   * adds nor changes, both in `offsite-moderation.service.mod-actions.test.ts`: the
+   * `listModerationEvents` (mod-scoped) and `listMyListingModerationEvents` (owner-scoped)
+   * cases each assert the WHOLE `where` — `expect(args.where).toEqual({ appListingId })` —
+   * and both callers funnel into this same `queryModerationEvents` read. Any added filter,
+   * spelled any way, fails both. Measured on this tip: the hand-typed filter above leaves
+   * this file's 12 tests green and turns exactly those two red. Cite them, not this test,
+   * when someone asks what stops the tightening.
+   *
+   * POSSIBLE FOLLOW-UP (a code change, deliberately not made in a comments-only pass):
+   * strengthen this to assert the ABSENCE of any `action` filter in the window — a
+   * `/\baction\s*:\s*\{/` probe — so the structural guard covers the hand-typed shape too
+   * and stops depending on a sibling file for the property its title implies.
+   */
   it('the full-timeline reader is deliberately NOT filtered — stated, not assumed', () => {
     const file = 'src/server/services/blocks/offsite-moderation.service.ts';
     const lines = found[file] ?? [];
     expect(lines.length).toBeGreaterThan(0);
-    // If this ever starts filtering, the audit history silently stops showing the owner the
-    // moderator's message — a real regression that would otherwise look like a tightening.
     expect(lines.every((l) => !readIsFiltered(stripped[file], l))).toBe(true);
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -42,6 +42,14 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
     oauthClient: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
+    // The last-moderation-event lookup that separates an OWNER self-unpublish from a
+    // MODERATOR takedown on a `removed` listing (both write `status='removed'`). Default
+    // NO event ⇒ not owner-unpublish ⇒ still FORBIDDEN, which is what the `removed` case
+    // below asserts. Owner-unpublish is covered in
+    // `offsite-listing.owner-unpublish-editable.service.test.ts`.
+    appListingModerationEvent: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -11,6 +11,10 @@ import {
   updateListing,
   withdrawExternalRequest,
 } from '~/server/services/blocks/offsite-listing.service';
+import {
+  LISTING_STATUS_CHANGING_MODERATION_ACTIONS,
+  STATE_NEUTRAL_MODERATION_ACTIONS,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
 import type { UpdateListingPatch } from '~/server/schema/blocks/offsite-listing.schema';
 
 /**
@@ -1042,6 +1046,88 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
     const res = await listMySubmissions({ userId: OWNER });
     expect(mockRead.$queryRaw).not.toHaveBeenCalled();
     expect(res.items[0]).toMatchObject({ lastModerationAction: null });
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 THE RAW STATEMENT IS PINNED AS TEXT, IN FULL.
+  //
+  // This is the PRIMARY surface for owner republish, and it is the one last-action read
+  // written in SQL, so it is the one place a second hand-maintained spelling of the
+  // status-changing set would live and never be noticed. It was UNFILTERED: a
+  // `message-owner` / `claim` / `report-resolve` newer than the owner's own
+  // `owner-unpublish` became "the last action", the page badged the listing "removed by a
+  // moderator" and hid Republish on a listing `republishOwnListing` would have allowed.
+  //
+  // Every other test in this describe mocks `$queryRaw`'s RESULT, so no behavioural
+  // assertion can see the statement at all — deleting the new `AND action IN (…)` changes
+  // nothing any of them observe.
+  //
+  // 🔴 AND IT IS PINNED AS THE WHOLE NORMALISED STRING, not a regex feature of it. A
+  // partial pattern ("contains `action IN`") is satisfied by semantically INVERTED SQL
+  // (`action NOT IN`), by a predicate `OR`-ed instead of `AND`-ed, and by a token sitting
+  // inside a `--` comment — "the token is present" and "the clause is live" are different
+  // facts. A cosmetic reword of this SQL will fail this test; that is the price of a
+  // machine-readable claim, and it is worth paying here.
+  // -------------------------------------------------------------------------
+  describe('the DISTINCT ON statement (pinned as whole text)', () => {
+    /** Collapse all runs of whitespace so indentation changes don't churn the pin. */
+    const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+    async function rawCall() {
+      mockRead.appListingPublishRequest.findMany
+        .mockResolvedValueOnce([removedRequestRow])
+        .mockResolvedValueOnce([]);
+      mockRead.$queryRaw.mockResolvedValueOnce([
+        { appListingId: 'apl_removed', action: 'owner-unpublish' },
+      ]);
+      await listMySubmissions({ userId: OWNER });
+      expect(mockRead.$queryRaw).toHaveBeenCalledTimes(1);
+      // `Prisma.sql` builds a `Sql` object: `.strings` is the static text, `.values` the
+      // bound parameters. `$queryRaw(Prisma.sql`…`)` passes that object as calls[0][0].
+      const arg = mockRead.$queryRaw.mock.calls[0][0] as {
+        strings: string[];
+        values: unknown[];
+      };
+      return { sql: norm(arg.strings.join('?')), values: arg.values };
+    }
+
+    it('POSITIVE CONTROL: the pin is reading real SQL, not an empty string', async () => {
+      const { sql } = await rawCall();
+      // Without this, a `toBe('')`-shaped accident would read as a pass.
+      expect(sql.length).toBeGreaterThan(80);
+      expect(sql).toMatch(/\bSELECT DISTINCT ON\b/);
+    });
+
+    it('🔴 is EXACTLY this statement — filter, table, ordering and all', async () => {
+      const { sql } = await rawCall();
+      expect(sql).toBe(
+        norm(`
+          SELECT DISTINCT ON (app_listing_id)
+            app_listing_id AS "appListingId",
+            action
+          FROM app_listing_moderation_events
+          WHERE app_listing_id IN (?)
+            AND action IN (?,?,?,?,?,?)
+          ORDER BY app_listing_id, created_at DESC, id DESC
+        `)
+      );
+    });
+
+    it('🔴 the action list is BOUND from the shared constant, in order — not typed out', async () => {
+      const { sql, values } = await rawCall();
+      // One removed listing id, then the six status-changing actions, as parameters.
+      expect(values).toEqual(['apl_removed', ...LISTING_STATUS_CHANGING_MODERATION_ACTIONS]);
+      // A verb appearing in the STATIC half would mean a string-built second spelling.
+      for (const a of LISTING_STATUS_CHANGING_MODERATION_ACTIONS) expect(sql).not.toContain(a);
+    });
+
+    it.each([...STATE_NEUTRAL_MODERATION_ACTIONS])(
+      '🔴 %s is not bound — it cannot displace the event that explains the removal',
+      async (neutral) => {
+        const { values } = await rawCall();
+        expect(values).not.toContain(neutral);
+      }
+    );
   });
 });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -53,6 +53,14 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
     // denormalized AppListing.userId), the resolver is on EVERY path. Default: no seat,
     // i.e. exactly the owner-only behaviour these cases assert.
     appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    // The last-moderation-event lookup that separates an OWNER self-unpublish from a
+    // MODERATOR takedown on a `removed` listing (both write `status='removed'`). Default
+    // NO event ⇒ not owner-unpublish ⇒ still refused, which is what the `removed` cases
+    // below assert. Owner-unpublish is covered in
+    // `offsite-listing.owner-unpublish-editable.service.test.ts`.
+    appListingModerationEvent: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {

--- a/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import { LISTING_STATUS_CHANGING_MODERATION_ACTIONS } from '~/server/services/blocks/app-listing-owner-unpublish';
 import {
   getMyListingForApp,
   getMyListingForEdit,
@@ -30,6 +31,21 @@ import {
  * INVARIANT GUARDS (green on both sides) and are labelled as such below rather than
  * counted as regression coverage.
  *
+ * 🔴 SECOND ROUND (the audit fixes). Measured against the pre-fix tip of this branch,
+ * `255218262f`, by reverting the four SOURCE files to it and re-running this file:
+ *   - REGRESSION coverage (red at `255218262f`, green now): every MATERIAL-field refusal,
+ *     the state-neutral-event cases, the collaborator MATERIAL refusal, and the two
+ *     query-shape cases.
+ *   - MUTATION GUARDS (green on both sides, and NOT regression coverage): the two
+ *     "reads the PRIMARY (site 2/3 of 3)" cases. `getMyListingForEdit` and
+ *     `getMyListingForApp` already read `dbWrite`; the defect they close is that a
+ *     `dbWrite → dbRead` mutation at either site SURVIVED the whole blocks suite, because
+ *     only `updateListing` carried a pool assertion. They are labelled as guards here so
+ *     nobody counts them as proof of a fixed bug.
+ *   - POSITIVE CONTROLS / INVARIANT GUARDS (green on both sides): the trivial-edit cases,
+ *     the unchanged-material-key case, the approved-still-stages case, and the
+ *     mod-takedown-wins-first case.
+ *
  * DB fully mocked — no real Prisma.
  */
 
@@ -54,7 +70,18 @@ const LISTING_ID = 'apl_parent';
 const MOD_TAKEDOWN_MESSAGE =
   'this listing has been removed by a moderator and can no longer be edited';
 
-/** An owner-owned OFF-SITE listing row, as `editableListingSelect` returns it. */
+/**
+ * An owner-owned OFF-SITE listing row, as `editableListingSelect` returns it (plus
+ * `sourceRepoUrl`, which the service reads through its own guarded second query on the
+ * same `findUnique` fake).
+ *
+ * 🔴 EVERY MATERIAL FIELD CARRIES A DISTINCT, NON-DEFAULT VALUE, and none of them equals
+ * a value any assertion below names as the "changed" one. An all-defaults fixture (empty
+ * strings, `null` externalUrl, `contentRating: 'g'`) collapses "the patch changed X" and
+ * "the patch left X alone" into the same observable, so a mutant that compares the wrong
+ * field — or that hardcodes a constant — survives. `contentRating` is `'r'` specifically
+ * so the LOWERING case (`r → g`) can be exercised in the direction that matters.
+ */
 function listingRow(overrides: Partial<Row> = {}): Row {
   return {
     id: LISTING_ID,
@@ -67,8 +94,9 @@ function listingRow(overrides: Partial<Row> = {}): Row {
     tagline: 'the tagline',
     description: 'the description',
     category: 'utility',
-    contentRating: 'g',
+    contentRating: 'r',
     externalUrl: 'https://cool.example.com/app',
+    sourceRepoUrl: 'https://github.com/cool/app',
     connectClientId: null,
     connectRequestedScopes: null,
     connectScopeJustifications: null,
@@ -226,7 +254,10 @@ describe('updateListing on a `removed` listing', () => {
     await updateListing({ listingId: LISTING_ID, patch: { tagline: 'y' }, userId: OWNER });
 
     expect(mockWrite.appListingModerationEvent.findFirst).toHaveBeenCalledWith({
-      where: { appListingId: LISTING_ID },
+      where: {
+        appListingId: LISTING_ID,
+        action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
+      },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       select: { action: true },
     });
@@ -240,6 +271,381 @@ describe('updateListing on a `removed` listing', () => {
 
     expect(mockWrite.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
     expect(mockRead.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateListing — MATERIAL fields on the newly-opened `removed` path
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 THE EXPLOIT THIS BLOCK PINS SHUT, spelled out so nobody re-opens it by "simplifying"
+ * the branch. `removed` + `owner-unpublish` is the state an owner can put their OWN listing
+ * into and take it back out of, with NO moderator in the loop:
+ *
+ *     approved → unpublishOwnListing → updateListing(<material>) → republishOwnListing → approved
+ *
+ * `republishOwnListing` gates on `assertListingAssetsScanCleanInTx` (did the images finish
+ * scanning?) and `assertOffsiteListingActionableInTx` (is there an https href at all?).
+ * NEITHER is a content review, so without a material-field refusal the store's destination
+ * URL, its displayed name, its public repo link, its disclosed OAuth scopes and its content
+ * rating could all be swapped AFTER approval. The refusal below is the whole guarantee; the
+ * republish path contributes nothing to it.
+ *
+ * Reachable today via the `appListings.updateListing` tRPC mutation and by CLI token under
+ * `TokenScope.AppBlocksSubmit` — "there is no UI button" is not a mitigation.
+ *
+ * 🔴 RED AT BASE: every case here fails on the pre-fix tip of this branch
+ * (`255218262f`), where the arm wrote the FULL patch in place and returned
+ * `requiresReview:false`. They are regression coverage, not invariant guards.
+ */
+describe('updateListing on an OWNER-UNPUBLISHED listing — MATERIAL fields are REFUSED', () => {
+  /** The typed code the refusal must carry (the router maps it to BAD_REQUEST). */
+  const BLOCKED = 'MATERIAL_CHANGE_BLOCKED';
+
+  async function expectRefused(patch: Record<string, unknown>, field: string) {
+    wireLastModerationEvent('owner-unpublish');
+    const err = await updateListing({
+      listingId: LISTING_ID,
+      patch: patch as never,
+      userId: OWNER,
+    }).then(
+      () => null,
+      (e: unknown) => e as { code?: string; message?: string }
+    );
+
+    // Not merely "it threw" — the RIGHT refusal, naming the RIGHT field.
+    expect(err?.code).toBe(BLOCKED);
+    expect(err?.message).toContain(field);
+    // 🔴 AND NOTHING WAS WRITTEN, on either the parent or a shadow. A refusal that still
+    // persisted the row would be the same defect with an error message stapled on.
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    return err;
+  }
+
+  it('🔴 externalUrl — the STORE DESTINATION cannot be swapped after approval', async () => {
+    wireListing(listingRow());
+    await expectRefused({ externalUrl: 'https://evil.example.com/app' }, 'externalUrl');
+  });
+
+  it('🔴 name — the listing IDENTITY cannot be swapped after approval', async () => {
+    wireListing(listingRow());
+    await expectRefused({ name: 'Totally Different App' }, 'name');
+  });
+
+  it('🔴 contentRating LOWERED r → g — Finding 1 subsumes the SFW-filter half', async () => {
+    // `contentRating` drives the public SFW filter (`content_rating NOT IN ('r','x')`) and
+    // `republishOwnListing` runs NO rating floor (`resolveListingRatingFloorInTx` is wired
+    // into the approve paths only), so lowering it in place would surface a still-mature
+    // listing to SFW users with nothing else in the chain to catch it. It is refused here
+    // because it is MATERIAL — the same one rule, not a second special case.
+    wireListing(listingRow({ contentRating: 'r' }));
+    await expectRefused({ contentRating: 'g' }, 'contentRating');
+  });
+
+  it('contentRating RAISED g → r is refused too — the rule is "material", not "lowered"', async () => {
+    // Direction-independent on purpose: a rating change is a moderator-visible fact either
+    // way, and a rule that only caught the "dangerous" direction would be a rule about the
+    // exploit rather than about review.
+    wireListing(listingRow({ contentRating: 'g' }));
+    await expectRefused({ contentRating: 'r' }, 'contentRating');
+  });
+
+  it('🔴 sourceRepoUrl — the public OUTBOUND repo link is material for the same reason', async () => {
+    wireListing(listingRow());
+    await expectRefused(
+      { sourceRepoUrl: 'https://github.com/someone-else/other' },
+      'sourceRepoUrl'
+    );
+  });
+
+  it('🔴 requestedScopes — a DISCLOSED OAuth scope drift cannot go live unreviewed', async () => {
+    // The mask is SERVER-DERIVED from the client's current `allowedScopes`, so the drift
+    // that matters is client-ceiling vs stored snapshot, not what the form sent.
+    wireListing(listingRow({ connectClientId: 'oc_1', connectRequestedScopes: 1 }));
+    mockRead.oauthClient.findUnique.mockResolvedValue({ userId: OWNER, allowedScopes: 7 });
+
+    await expectRefused({ requestedScopes: 1, scopeJustifications: {} }, 'requestedScopes');
+  });
+
+  it('names EVERY offending field, not just the first', async () => {
+    wireListing(listingRow());
+    const err = await expectRefused(
+      { name: 'Other', externalUrl: 'https://evil.example.com/app', tagline: 'ok' },
+      'name'
+    );
+    expect(err?.message).toContain('externalUrl');
+    // The trivial key travelling alongside is not accused.
+    expect(err?.message).not.toContain('tagline: ');
+  });
+
+  it('🔴 POSITIVE CONTROL — the FEATURE still works: tagline/description/category edit in place', async () => {
+    // This is the user need the whole PR exists for ("unpublish → fix your copy →
+    // republish"). If the refusal above were over-broad it would land here, and this case
+    // is what would say so.
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    const res = await updateListing({
+      listingId: LISTING_ID,
+      patch: { tagline: 'clearer tagline', description: 'clearer copy', category: 'discovery' },
+      userId: OWNER,
+    });
+
+    expect(res).toEqual({
+      listingId: LISTING_ID,
+      status: 'removed',
+      requiresReview: false,
+      shadowId: null,
+    });
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: LISTING_ID },
+      data: { tagline: 'clearer tagline', description: 'clearer copy', category: 'discovery' },
+    });
+  });
+
+  /**
+   * 🔴 THIS IS ALSO THE ONLY CASE THAT CAN SEE A WRONG `live` BIND, and it took a surviving
+   * mutant to notice. Every "changed ⇒ refused" case above compares a patched value against
+   * a DIFFERENT live value, so replacing a `live.<field>` with a constant (`null`) leaves
+   * the inequality true and the refusal identical — the mutant `contentRating:
+   * listing.contentRating → contentRating: null` SURVIVED the whole battery on those cases
+   * alone. Only an UNCHANGED value distinguishes them: correct code sees equality and
+   * saves, a wrong bind sees `'r' !== null` and refuses. So every material field is
+   * re-sent VERBATIM here, not just one.
+   */
+  it('a material key present but UNCHANGED is not a change — every material field, verbatim', async () => {
+    // The editor round-trips every field, so a re-save of an untouched form carries them
+    // all. Refusing on PRESENCE rather than on CHANGE would make the repair loop unusable
+    // from the actual UI while looking correct in a unit test that only ever sends deltas.
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    const res = await updateListing({
+      listingId: LISTING_ID,
+      patch: {
+        name: 'Cool App',
+        contentRating: 'r',
+        externalUrl: 'https://cool.example.com/app',
+        sourceRepoUrl: 'https://github.com/cool/app',
+        tagline: 'still fixing',
+      },
+      userId: OWNER,
+    });
+
+    expect(res.requiresReview).toBe(false);
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: LISTING_ID },
+      data: {
+        name: 'Cool App',
+        contentRating: 'r',
+        externalUrl: 'https://cool.example.com/app',
+        sourceRepoUrl: 'https://github.com/cool/app',
+        tagline: 'still fixing',
+      },
+    });
+  });
+
+  it('🔴 the refusal is scoped to `removed` — an APPROVED listing still STAGES a material change', async () => {
+    // Negative control on the branch itself: if the refusal leaked into the approved arm
+    // it would break the shadow-revision flow, and every case above would still pass.
+    wireListing(listingRow({ status: 'approved' }));
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+
+    const res = await updateListing({
+      listingId: LISTING_ID,
+      patch: { name: 'Renamed' },
+      userId: OWNER,
+    });
+
+    expect(res).toMatchObject({ requiresReview: true, shadowId: 'apl_shadow' });
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_shadow' },
+      data: { name: 'Renamed' },
+    });
+  });
+
+  it('a MODERATOR takedown is refused BEFORE the material check — attribution wins', async () => {
+    // Ordering matters for the message the caller sees: on a mod takedown they must be
+    // told the listing is moderator-removed, not that `externalUrl` needs a republish
+    // they are not allowed to perform.
+    wireListing(listingRow());
+    wireLastModerationEvent('delist');
+
+    await expect(
+      updateListing({
+        listingId: LISTING_ID,
+        patch: { externalUrl: 'https://evil.example.com/app' },
+        userId: OWNER,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The repair loop survives a moderator MESSAGE (state-neutral events)
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 A moderator messaging the owner *"fix X and republish"* is the most natural workflow
+ * this feature has, and it writes an `AppListingModerationEvent` — `action:'message-owner'`
+ * — that changes no listing status. An unfiltered "last event of any kind" read therefore
+ * REVOKED the repair loop and re-showed the owner the false "removed by a moderator"
+ * attribution the PR exists to delete. Same class as `report-resolve`/`report-dismiss`
+ * (`closeReport` writes those ungated) and `claim`.
+ *
+ * These cases are behavioural: they wire the DB fake to answer the FILTERED query the way
+ * the database would, so a code path that dropped the filter reads the neutral row instead.
+ */
+describe('a STATE-NEUTRAL moderation event does not revoke the repair loop', () => {
+  /**
+   * Answer like the real table: the newest row overall is state-neutral, but the newest
+   * STATUS-CHANGING row is the owner's own unpublish. Which one comes back depends
+   * entirely on whether the caller filtered.
+   */
+  function wireNeutralOnTopOfOwnerUnpublish(neutral: string) {
+    const impl = async (args: unknown) => {
+      const a = args as { where?: { action?: { in?: string[] } } };
+      const allowed = a.where?.action?.in;
+      if (!allowed) return { action: neutral }; // unfiltered ⇒ the neutral row wins
+      return allowed.includes('owner-unpublish') ? { action: 'owner-unpublish' } : null;
+    };
+    mockRead.appListingModerationEvent.findFirst.mockImplementation(impl);
+    mockWrite.appListingModerationEvent.findFirst.mockImplementation(impl);
+  }
+
+  it.each(['message-owner', 'report-resolve', 'report-dismiss', 'claim'])(
+    '🔴 %s on top of an owner-unpublish ⇒ updateListing still edits in place',
+    async (neutral) => {
+      wireListing(listingRow());
+      wireNeutralOnTopOfOwnerUnpublish(neutral);
+
+      const res = await updateListing({
+        listingId: LISTING_ID,
+        patch: { tagline: 'as the mod asked' },
+        userId: OWNER,
+      });
+
+      expect(res.status).toBe('removed');
+      expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+        where: { id: LISTING_ID },
+        data: { tagline: 'as the mod asked' },
+      });
+    }
+  );
+
+  it('🔴 message-owner on top of an owner-unpublish ⇒ the media editor is not blocked', async () => {
+    wireListing(listingRow());
+    wireNeutralOnTopOfOwnerUnpublish('message-owner');
+
+    const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
+
+    expect(res.editBlockedReason).toBeNull();
+  });
+
+  it('🔴 message-owner on top of an owner-unpublish ⇒ the prefill read resolves', async () => {
+    wireListing(listingRow());
+    wireNeutralOnTopOfOwnerUnpublish('message-owner');
+
+    await expect(
+      getMyListingForEdit({ listingId: LISTING_ID, userId: OWNER })
+    ).resolves.toMatchObject({ status: 'removed' });
+  });
+
+  it('INVARIANT GUARD: a state-neutral event on top of a DELIST is still a delist', async () => {
+    // The filter must not become a way to walk past a moderator takedown by getting a
+    // report closed afterwards — the direction `closeTerminalListing` was already bitten in.
+    const impl = async (args: unknown) => {
+      const a = args as { where?: { action?: { in?: string[] } } };
+      const allowed = a.where?.action?.in;
+      if (!allowed) return { action: 'report-resolve' };
+      return allowed.includes('delist') ? { action: 'delist' } : null;
+    };
+    mockRead.appListingModerationEvent.findFirst.mockImplementation(impl);
+    mockWrite.appListingModerationEvent.findFirst.mockImplementation(impl);
+    wireListing(listingRow());
+
+    await expect(
+      updateListing({ listingId: LISTING_ID, patch: { tagline: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 7 — the grant reaches an accepted COLLABORATOR, deliberately
+// ---------------------------------------------------------------------------
+
+/**
+ * 🔴 STATED AND PINNED RATHER THAN LEFT IMPLICIT. `updateListing` gates through
+ * `resolveListingRole`, which admits the OWNER **or an accepted seat**, while
+ * `readLastModerationAction` selects only `action` — never `actorUserId`. So the predicate
+ * asks "is this listing in owner-repair state?" and the gate asks "may THIS caller edit
+ * it?", and they are different questions on purpose.
+ *
+ * The decision: KEEP the seat's reach. A collaborator already has exactly this power on
+ * draft/pending/approved, so refusing only in the repair state would make the one flow most
+ * likely to need help the one flow a team cannot share; the seat is an authorization the
+ * owner granted and can revoke; and with material fields refused, everything reachable is
+ * copy. The asymmetry that stays: `unpublishOwnListing`/`republishOwnListing` are
+ * OWNER-ONLY (`loadOwnedListingInTx` compares `listing.userId`), so a collaborator can
+ * repair the copy but can neither take the app down nor put it back.
+ */
+describe('an accepted COLLABORATOR on an owner-unpublished listing', () => {
+  const EDITOR = 99;
+
+  /** `resolveListingAccess` reads an accepted seat off `appCollaborator`. */
+  function wireAcceptedSeat() {
+    mockRead.appCollaborator.findFirst.mockResolvedValue({
+      id: 'ac_1',
+      userId: EDITOR,
+      appListingId: LISTING_ID,
+      status: 'accepted',
+      role: 'editor',
+    });
+  }
+
+  it('MAY make a TRIVIAL edit — the repair loop is shareable with the team', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+    wireAcceptedSeat();
+
+    const res = await updateListing({
+      listingId: LISTING_ID,
+      patch: { tagline: 'seat-holder copy fix' },
+      userId: EDITOR,
+    });
+
+    expect(res.status).toBe('removed');
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: LISTING_ID },
+      data: { tagline: 'seat-holder copy fix' },
+    });
+  });
+
+  it('🔴 MAY NOT change a MATERIAL field — the refusal is not owner-specific', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+    wireAcceptedSeat();
+
+    await expect(
+      updateListing({
+        listingId: LISTING_ID,
+        patch: { externalUrl: 'https://evil.example.com/app' },
+        userId: EDITOR,
+      })
+    ).rejects.toMatchObject({ code: 'MATERIAL_CHANGE_BLOCKED' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT GUARD: a stranger with no seat is still NOT_OWNED', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+    mockRead.appCollaborator.findFirst.mockResolvedValue(null);
+
+    await expect(
+      updateListing({ listingId: LISTING_ID, patch: { tagline: 'x' }, userId: 1234 })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
   });
 });
 
@@ -276,6 +682,21 @@ describe('getMyListingForEdit on a `removed` listing', () => {
       getMyListingForEdit({ listingId: LISTING_ID, userId: OWNER })
     ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
   });
+
+  it('🔴 reads the last event from the PRIMARY (site 2 of 3)', async () => {
+    // Same safety argument as `updateListing`, pinned SEPARATELY because it is a
+    // separate call: a `dbWrite → dbRead` mutation at this site SURVIVED the whole blocks
+    // suite while only `updateListing` carried a pool assertion. A stale replica can hide
+    // a moderator's just-written `delist` behind the owner's older `owner-unpublish`, and
+    // the direction that costs is the GRANT — this read is what mounts the editor.
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    await getMyListingForEdit({ listingId: LISTING_ID, userId: OWNER });
+
+    expect(mockWrite.appListingModerationEvent.findFirst).toHaveBeenCalled();
+    expect(mockRead.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -283,24 +704,24 @@ describe('getMyListingForEdit on a `removed` listing', () => {
 // ---------------------------------------------------------------------------
 
 describe('getMyListingForApp editBlockedReason on a `removed` listing', () => {
-  it('🔴 OWNER-UNPUBLISH ⇒ the media editor is NOT blocked (verdict is null)', async () => {
+  /**
+   * 🔴 ONE CASE, NOT TWO. This used to be split into "the verdict is null" and "the verdict
+   * never says 'by a moderator'", and the second could not fail unless the first did:
+   * identical fixture, identical call, and `null` satisfies both a `not.toContain` and a
+   * `not.toBe(MOD_TAKEDOWN_MESSAGE)` trivially. Two tests that die together are one test
+   * that reads as two — they inflate the count without adding a way for the code to be
+   * wrong. `toBeNull()` is the strictly stronger assertion, so it is the one kept.
+   */
+  it('🔴 OWNER-UNPUBLISH ⇒ the media editor is NOT blocked, so nothing blames a moderator', async () => {
     wireListing(listingRow());
     wireLastModerationEvent('owner-unpublish');
 
     const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
 
     expect(res.status).toBe('removed');
+    // Null is the whole claim: no verdict at all ⇒ no attribution, correct or otherwise.
+    // The mod-takedown case below is the arm that pins the message text.
     expect(res.editBlockedReason).toBeNull();
-  });
-
-  it('🔴 MESSAGE: an owner-unpublished listing never attributes the takedown to a moderator', async () => {
-    wireListing(listingRow());
-    wireLastModerationEvent('owner-unpublish');
-
-    const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
-
-    expect(res.editBlockedReason ?? '').not.toContain('by a moderator');
-    expect(res.editBlockedReason).not.toBe(MOD_TAKEDOWN_MESSAGE);
   });
 
   it('INVARIANT GUARD (green at base too): a MODERATOR delist still returns the moderator verdict', async () => {
@@ -319,6 +740,20 @@ describe('getMyListingForApp editBlockedReason on a `removed` listing', () => {
     const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
 
     expect(res.editBlockedReason).toBe(MOD_TAKEDOWN_MESSAGE);
+  });
+
+  it('🔴 reads the last event from the PRIMARY (site 3 of 3)', async () => {
+    // The third of the three sites, pinned for the same reason as the other two — a
+    // `dbWrite → dbRead` mutation here also SURVIVED the full blocks suite. This verdict
+    // is what unblocks the MEDIA editor, so a stale-read GRANT hands asset writes to
+    // someone a moderator has just cut off.
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
+
+    expect(mockWrite.appListingModerationEvent.findFirst).toHaveBeenCalled();
+    expect(mockRead.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getMyListingForApp,
+  getMyListingForEdit,
+  listingMediaEditBlockedReason,
+  updateListing,
+} from '~/server/services/blocks/offsite-listing.service';
+
+/**
+ * App Store Listings (W13) — `removed` IS TWO STATES, AND THE EDIT PATHS MUST TELL THEM
+ * APART.
+ *
+ * `app_listings.status = 'removed'` is written by BOTH `unpublishOwnListing` (the owner
+ * takes their own app down to fix it up) and a moderator `delist`/`purge`. Every author
+ * edit path refused BOTH, and told both callers a MODERATOR had done it — so an owner who
+ * unpublished their own listing had no repair step at all, and was misinformed about why.
+ *
+ * The distinguishing signal is the listing's MOST-RECENT `AppListingModerationEvent`:
+ * `owner-unpublish` ⇒ the owner's own action; anything else, or NO event, ⇒ moderator (or
+ * unprovable), which stays refused. This is the same predicate `republishOwnListing`'s
+ * go-live guard already used, now single-sourced in `app-listing-owner-unpublish`.
+ *
+ * Both directions are pinned for all three sites, plus the `!lastEvent` arm — that is a
+ * real branch, not a degenerate one, and it must FAIL CLOSED.
+ *
+ * 🔴 RED-AT-BASE, per direction: the `owner-unpublish ⇒ editable` cases and the
+ * message-attribution case fail on `origin/main`; the moderator/no-event cases are
+ * INVARIANT GUARDS (green on both sides) and are labelled as such below rather than
+ * counted as regression coverage.
+ *
+ * DB fully mocked — no real Prisma.
+ */
+
+type Row = Record<string, unknown> & { id: string };
+
+const { mockRead, mockWrite, seq } = vi.hoisted(() => {
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appListingScreenshot: {
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    appListingPublishRequest: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    appListingModerationEvent: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    image: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+  });
+  const mockRead = makeClient();
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite, seq: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_new_${++seq.n}`,
+  newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,
+  newAppListingScreenshotId: () => `apls_new_${++seq.n}`,
+  newUlid: () => `ULID${++seq.n}`,
+}));
+
+const OWNER = 42;
+const LISTING_ID = 'apl_parent';
+
+/** The one message a MODERATOR takedown is allowed to produce. Pinned as a literal. */
+const MOD_TAKEDOWN_MESSAGE =
+  'this listing has been removed by a moderator and can no longer be edited';
+
+/** An owner-owned OFF-SITE listing row, as `editableListingSelect` returns it. */
+function listingRow(overrides: Partial<Row> = {}): Row {
+  return {
+    id: LISTING_ID,
+    kind: 'offsite',
+    slug: 'cool-app',
+    status: 'removed',
+    userId: OWNER,
+    revisionOfId: null,
+    name: 'Cool App',
+    tagline: 'the tagline',
+    description: 'the description',
+    category: 'utility',
+    contentRating: 'g',
+    externalUrl: 'https://cool.example.com/app',
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 1,
+    coverId: 2,
+    ...overrides,
+  };
+}
+
+/** The `loadListingEditView` projection (the `select` carrying `icon`). */
+function editViewRow(): Record<string, unknown> {
+  return {
+    name: 'Cool App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 1,
+    coverId: 2,
+    icon: { url: 'icon-key' },
+    cover: { url: 'cover-key' },
+    screenshots: [],
+  };
+}
+
+/**
+ * Serve `row` on every `appListing.findUnique` shape the edit paths use — the entry
+ * resolve (`where.appBlockId`), the edit-view projection (`select` carries `icon`), and
+ * the owned/editable + ownership + source-repo reads (everything else).
+ */
+function wireListing(row: Row) {
+  const impl = async (args: unknown) => {
+    const a = args as { select?: Record<string, unknown> };
+    if ('icon' in (a.select ?? {})) return editViewRow();
+    return row;
+  };
+  mockRead.appListing.findUnique.mockImplementation(impl);
+  mockWrite.appListing.findUnique.mockImplementation(impl);
+  // `getMyListingForApp`'s SLUG arm resolves through `findFirst` on the replica.
+  mockRead.appListing.findFirst.mockImplementation(async (args: unknown) => {
+    const a = args as { where?: { slug?: string } };
+    return a.where?.slug === row.slug ? row : null;
+  });
+}
+
+/**
+ * Wire the listing's last moderation event on BOTH pools.
+ *
+ * Both, deliberately: a case that wired only the primary would pass even if the code read
+ * the replica, and vice versa — so no behavioural case here is secretly a pool assertion.
+ * WHICH pool the gates use is asserted on its own, by the "reads the last event from the
+ * PRIMARY" case below.
+ */
+function wireLastModerationEvent(action: string | null) {
+  const value = action == null ? null : { action };
+  mockRead.appListingModerationEvent.findFirst.mockResolvedValue(value);
+  mockWrite.appListingModerationEvent.findFirst.mockResolvedValue(value);
+}
+
+beforeEach(() => {
+  for (const client of [mockRead, mockWrite]) {
+    client.appListing.findUnique.mockReset().mockResolvedValue(null);
+    client.appListing.findFirst.mockReset().mockResolvedValue(null);
+    client.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appCollaborator.findFirst.mockReset().mockResolvedValue(null);
+    client.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+    client.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+    client.appListingModerationEvent.findFirst.mockReset().mockResolvedValue(null);
+    client.appListingModerationEvent.findMany.mockReset().mockResolvedValue([]);
+    client.image.findMany.mockReset().mockResolvedValue([]);
+  }
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  seq.n = 0;
+});
+
+// ---------------------------------------------------------------------------
+// updateListing — the WRITE path
+// ---------------------------------------------------------------------------
+
+describe('updateListing on a `removed` listing', () => {
+  it('🔴 OWNER-UNPUBLISH ⇒ EDITABLE: the scalar patch is written IN PLACE, no re-review', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    const res = await updateListing({
+      listingId: LISTING_ID,
+      patch: { tagline: 'fixing this up' },
+      userId: OWNER,
+    });
+
+    expect(res).toEqual({
+      listingId: LISTING_ID,
+      status: 'removed',
+      requiresReview: false,
+      shadowId: null,
+    });
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: LISTING_ID },
+      data: { tagline: 'fixing this up' },
+    });
+    // In place, exactly like draft/pending — a listing that is not being served has no
+    // live copy to protect behind a shadow revision.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT GUARD (green at base too): a MODERATOR delist stays FORBIDDEN, and keeps blaming a moderator', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('delist');
+
+    await expect(
+      updateListing({ listingId: LISTING_ID, patch: { tagline: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT GUARD (green at base too): a `purge` is likewise not owner-unpublish → FORBIDDEN', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('purge');
+
+    await expect(
+      updateListing({ listingId: LISTING_ID, patch: { tagline: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT GUARD (green at base too): NO moderation events at all → FORBIDDEN (fails CLOSED)', async () => {
+    // 🔴 `!lastEvent` is a real branch. Nothing proves the owner took this listing down,
+    // so it must be treated as a moderator removal — never trusted to the owner.
+    wireListing(listingRow());
+    wireLastModerationEvent(null);
+
+    await expect(
+      updateListing({ listingId: LISTING_ID, patch: { tagline: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('🔴 reads the last event from the PRIMARY, newest-first with the id tiebreak', async () => {
+    // Pool: a stale replica can hide a moderator's just-written `delist` behind the
+    // owner's older `owner-unpublish` and GRANT an edit that was revoked. Ordering:
+    // `createdAt` alone is not a total order (same-tx events share a timestamp), so the
+    // id tiebreak is what makes "most recent" deterministic.
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    await updateListing({ listingId: LISTING_ID, patch: { tagline: 'y' }, userId: OWNER });
+
+    expect(mockWrite.appListingModerationEvent.findFirst).toHaveBeenCalledWith({
+      where: { appListingId: LISTING_ID },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      select: { action: true },
+    });
+    expect(mockRead.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('does NOT read moderation events for a non-`removed` listing (no extra round trip)', async () => {
+    wireListing(listingRow({ status: 'draft' }));
+
+    await updateListing({ listingId: LISTING_ID, patch: { tagline: 'z' }, userId: OWNER });
+
+    expect(mockWrite.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+    expect(mockRead.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMyListingForEdit — the PREFILL read
+// ---------------------------------------------------------------------------
+
+describe('getMyListingForEdit on a `removed` listing', () => {
+  it('🔴 OWNER-UNPUBLISH ⇒ EDITABLE: the prefill resolves instead of throwing FORBIDDEN', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    const res = await getMyListingForEdit({ listingId: LISTING_ID, userId: OWNER });
+
+    expect(res).toMatchObject({ parentId: LISTING_ID, status: 'removed', shadowId: null });
+    // Not approved ⇒ edited in place, so no shadow revision is minted on the prefill.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT GUARD (green at base too): a MODERATOR delist stays FORBIDDEN with the moderator message', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('delist');
+
+    await expect(
+      getMyListingForEdit({ listingId: LISTING_ID, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+  });
+
+  it('INVARIANT GUARD (green at base too): NO moderation events → FORBIDDEN (fails CLOSED)', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent(null);
+
+    await expect(
+      getMyListingForEdit({ listingId: LISTING_ID, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: MOD_TAKEDOWN_MESSAGE });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMyListingForApp → editBlockedReason — the MEDIA-EDITOR verdict
+// ---------------------------------------------------------------------------
+
+describe('getMyListingForApp editBlockedReason on a `removed` listing', () => {
+  it('🔴 OWNER-UNPUBLISH ⇒ the media editor is NOT blocked (verdict is null)', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
+
+    expect(res.status).toBe('removed');
+    expect(res.editBlockedReason).toBeNull();
+  });
+
+  it('🔴 MESSAGE: an owner-unpublished listing never attributes the takedown to a moderator', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('owner-unpublish');
+
+    const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
+
+    expect(res.editBlockedReason ?? '').not.toContain('by a moderator');
+    expect(res.editBlockedReason).not.toBe(MOD_TAKEDOWN_MESSAGE);
+  });
+
+  it('INVARIANT GUARD (green at base too): a MODERATOR delist still returns the moderator verdict', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent('delist');
+
+    const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
+
+    expect(res.editBlockedReason).toBe(MOD_TAKEDOWN_MESSAGE);
+  });
+
+  it('INVARIANT GUARD (green at base too): NO moderation events → the moderator verdict (fails CLOSED)', async () => {
+    wireListing(listingRow());
+    wireLastModerationEvent(null);
+
+    const res = await getMyListingForApp({ slug: 'cool-app', userId: OWNER });
+
+    expect(res.editBlockedReason).toBe(MOD_TAKEDOWN_MESSAGE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listingMediaEditBlockedReason — the PURE branch table
+// ---------------------------------------------------------------------------
+
+describe('listingMediaEditBlockedReason (pure, synchronous)', () => {
+  const removed = { status: 'removed', revisionOfId: null };
+
+  it('🔴 removed + ownerUnpublished=true ⇒ null (editable)', () => {
+    expect(listingMediaEditBlockedReason(removed, true)).toBeNull();
+  });
+
+  it('INVARIANT GUARD (green at base too): removed + ownerUnpublished=false ⇒ the moderator message', () => {
+    expect(listingMediaEditBlockedReason(removed, false)).toBe(MOD_TAKEDOWN_MESSAGE);
+  });
+
+  it('INVARIANT GUARD: `ownerUnpublished` is consulted ONLY on `removed`', () => {
+    // A shadow, a rejected listing and an unknown status keep their verdicts whatever
+    // the owner-unpublish bit says — otherwise this parameter would be a way to walk
+    // past three other refusals.
+    for (const ownerUnpublished of [true, false]) {
+      expect(
+        listingMediaEditBlockedReason(
+          { status: 'approved', revisionOfId: 'apl_p' },
+          ownerUnpublished
+        )
+      ).toBe('this listing is an internal revision draft and cannot be edited directly');
+      expect(
+        listingMediaEditBlockedReason({ status: 'rejected', revisionOfId: null }, ownerUnpublished)
+      ).toBe('this listing was rejected; submit a new listing instead of editing it');
+      expect(
+        listingMediaEditBlockedReason({ status: 'banana', revisionOfId: null }, ownerUnpublished)
+      ).toBe('cannot edit a listing in status banana');
+      expect(
+        listingMediaEditBlockedReason({ status: 'approved', revisionOfId: null }, ownerUnpublished)
+      ).toBeNull();
+    }
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { dbMock } from '~/__tests__/mocks/db.mock';
 import {
   getMyListingForApp,
   getMyListingForEdit,
@@ -34,50 +35,17 @@ import {
 
 type Row = Record<string, unknown> & { id: string };
 
-const { mockRead, mockWrite, seq } = vi.hoisted(() => {
-  const makeClient = () => ({
-    appListing: {
-      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
-      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
-      create: vi.fn(async (args: { data: unknown }) => args.data),
-      update: vi.fn(async (args: { data: unknown }) => args.data),
-      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
-      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
-    },
-    appCollaborator: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
-    appListingScreenshot: {
-      count: vi.fn(async (..._a: unknown[]) => 0),
-      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
-      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
-    },
-    appListingPublishRequest: {
-      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
-      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
-    },
-    appListingModerationEvent: {
-      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
-      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
-      create: vi.fn(async (args: { data: unknown }) => args.data),
-    },
-    image: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
-    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
-  });
-  const mockRead = makeClient();
-  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
-    $transaction: ReturnType<typeof vi.fn>;
-  };
-  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
-  return { mockRead, mockWrite, seq: { n: 0 } };
-});
-
-vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
-vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
-vi.mock('~/server/utils/app-block-ids', () => ({
-  newAppListingId: () => `apl_new_${++seq.n}`,
-  newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,
-  newAppListingScreenshotId: () => `apls_new_${++seq.n}`,
-  newUlid: () => `ULID${++seq.n}`,
-}));
+/**
+ * 🔴 THE CANONICAL `~/server/db/client` MOCK, not a per-file `vi.mock`. Registered once in
+ * `src/__tests__/setup.ts`; a hand-rolled one here would freeze this file's mock shape into
+ * every later file in the same worker under `isolate: false`. See
+ * docs/testing/shared-module-mocks.md and `no-direct-shared-module-mock.test.ts`.
+ *
+ * `dbRead` and `dbWrite` are DISTINCT nodes here, which is what makes the "the gate reads
+ * the PRIMARY" case below able to say anything at all.
+ */
+const mockRead = dbMock.dbRead;
+const mockWrite = dbMock.dbWrite;
 
 const OWNER = 42;
 const LISTING_ID = 'apl_parent';
@@ -164,22 +132,25 @@ function wireLastModerationEvent(action: string | null) {
 }
 
 beforeEach(() => {
+  // 🔴 The canonical mock resets between FILES, not between tests — several cases here
+  // assert `not.toHaveBeenCalled()`, which silently reads a previous test's calls without
+  // this. Implementations survive `mockClear`, so the defaults below are re-declared after.
+  vi.clearAllMocks();
+  // The canonical mock resets every node between files; these are this file's DEFAULTS.
   for (const client of [mockRead, mockWrite]) {
-    client.appListing.findUnique.mockReset().mockResolvedValue(null);
-    client.appListing.findFirst.mockReset().mockResolvedValue(null);
-    client.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
-    client.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
-    client.appCollaborator.findFirst.mockReset().mockResolvedValue(null);
-    client.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
-    client.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
-    client.appListingModerationEvent.findFirst.mockReset().mockResolvedValue(null);
-    client.appListingModerationEvent.findMany.mockReset().mockResolvedValue([]);
-    client.image.findMany.mockReset().mockResolvedValue([]);
+    client.appListing.findUnique.mockResolvedValue(null);
+    client.appListing.findFirst.mockResolvedValue(null);
+    client.appListing.create.mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appListing.update.mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appCollaborator.findFirst.mockResolvedValue(null);
+    client.appListingScreenshot.findMany.mockResolvedValue([]);
+    client.appListingPublishRequest.findFirst.mockResolvedValue(null);
+    client.appListingModerationEvent.findFirst.mockResolvedValue(null);
+    client.image.findMany.mockResolvedValue([]);
   }
-  mockWrite.$transaction
-    .mockReset()
-    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
-  seq.n = 0;
+  mockWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb(mockWrite)
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -6,6 +6,11 @@ import { dbRead } from '~/server/db/client';
 // on the hot path of every `/apps/mine` render, where a dynamic import would cost a
 // microtask hop per call for nothing.
 import { loadListingAssetScansBatch } from '~/server/services/blocks/app-listing-assets.service';
+import {
+  isOwnerUnpublishAction,
+  OWNER_UNPUBLISH_EVENT,
+  readLastModerationAction,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
 import { listingCoverUrl, listingIconUrl } from '~/server/services/blocks/listing-media-url';
 import type { ListingProblem } from '~/server/services/blocks/listing-problems';
 import { computeListingProblems } from '~/server/services/blocks/listing-problems';
@@ -948,14 +953,19 @@ export type AppListingAuthoringContext = Omit<
  * on (it is what `republishOwnListing`'s last-event guard permits), so every other verb
  * collapses to `other` before it leaves the server. Widening this back to the raw string
  * re-opens the editor-disclosure hole described at the call site — do not "simplify" it away.
+ *
+ * 🔴 RE-EXPORTED FROM `app-listing-owner-unpublish`, NOT REDECLARED. That module owns the
+ * server-side predicate the SERVER branches on (`republishOwnListing`'s go-live guard and
+ * the author edit paths); this is the same fact reaching the CLIENT. Two literals spelling
+ * one action is how they drift apart.
  */
-export const OWNER_UNPUBLISH_EVENT = 'owner-unpublish';
+export { OWNER_UNPUBLISH_EVENT };
 export type NormalizedModerationAction = typeof OWNER_UNPUBLISH_EVENT | 'other';
 
 /** `null` in ⇒ `null` out (no event); the owner's own unpublish keeps its name; all else → `other`. */
 function normalizeLastModerationAction(action: string | null): NormalizedModerationAction | null {
   if (action == null) return null;
-  return action === OWNER_UNPUBLISH_EVENT ? OWNER_UNPUBLISH_EVENT : 'other';
+  return isOwnerUnpublishAction(action) ? OWNER_UNPUBLISH_EVENT : 'other';
 }
 
 /** Hydrate {@link resolveAccessibleListingIds} into rows, newest listing first. */
@@ -1345,21 +1355,21 @@ export async function getAppListingAuthoringContext(opts: {
    * anything on — every other status keeps this read at the two round trips it already
    * did. Same keyset (`orderBy desc` + `take 1`) the batched list read uses, and the same
    * NORMALISATION on the way out.
+   *
+   * 🔴 THE REPLICA IS CORRECT HERE and it is the opposite call from the one the SERVER
+   * gates make. This value only decides which BUTTON the Publishing tab renders; the
+   * mutation behind it re-checks on the primary inside its own transaction
+   * (`republishOwnListing`), so a stale read costs at worst one refused click. The gates
+   * in `offsite-listing.service` pass `dbWrite` because there a stale read would GRANT.
    */
-  const lastEvent =
-    row.status === 'removed'
-      ? await dbRead.appListingModerationEvent.findFirst({
-          where: { appListingId: access.seatListingId },
-          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-          select: { action: true },
-        })
-      : null;
+  const lastAction =
+    row.status === 'removed' ? await readLastModerationAction(dbRead, access.seatListingId) : null;
   return {
     appListingId: access.seatListingId,
     slug: row.slug,
     name: row.name,
     status: row.status,
-    lastModerationAction: normalizeLastModerationAction(lastEvent?.action ?? null),
+    lastModerationAction: normalizeLastModerationAction(lastAction),
     // 🔴 KIND AND BLOCK COME FROM `access` (the PARENT), never from the row asked for —
     // a shadow carries `appBlockId: null` by construction, so reading them off it would
     // make an in-flight revision look off-site and silently strip the block-only tabs.

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -8,6 +8,7 @@ import { dbRead } from '~/server/db/client';
 import { loadListingAssetScansBatch } from '~/server/services/blocks/app-listing-assets.service';
 import {
   isOwnerUnpublishAction,
+  LISTING_STATUS_CHANGING_MODERATION_ACTIONS,
   OWNER_UNPUBLISH_EVENT,
   readLastModerationAction,
 } from '~/server/services/blocks/app-listing-owner-unpublish';
@@ -954,12 +955,17 @@ export type AppListingAuthoringContext = Omit<
  * collapses to `other` before it leaves the server. Widening this back to the raw string
  * re-opens the editor-disclosure hole described at the call site — do not "simplify" it away.
  *
- * 🔴 RE-EXPORTED FROM `app-listing-owner-unpublish`, NOT REDECLARED. That module owns the
- * server-side predicate the SERVER branches on (`republishOwnListing`'s go-live guard and
- * the author edit paths); this is the same fact reaching the CLIENT. Two literals spelling
- * one action is how they drift apart.
+ * 🔴 THE VALUE IS IMPORTED FROM `app-listing-owner-unpublish`, NOT REDECLARED. That module
+ * owns the server-side predicate the SERVER branches on (`republishOwnListing`'s go-live
+ * guard and the author edit paths); this is the same fact reaching the CLIENT. Two literals
+ * spelling one action is how they drift apart.
+ *
+ * It is deliberately NOT re-exported from here. A re-export with no consumer reads as a
+ * second public home for the constant and invites the next caller to import the action name
+ * from a service that does not own it; `app-listing-owner-unpublish` is the one place to
+ * import it from. (`app-listing-owner-unpublish.test.ts` pins the client's own copy,
+ * `OWNER_UNPUBLISH_ACTION` in `~/components/Apps/offsiteOwnerControls`, against it.)
  */
-export { OWNER_UNPUBLISH_EVENT };
 export type NormalizedModerationAction = typeof OWNER_UNPUBLISH_EVENT | 'other';
 
 /** `null` in ⇒ `null` out (no event); the owner's own unpublish keeps its name; all else → `other`. */
@@ -1058,7 +1064,18 @@ async function hydrateMyAppListings(
   const [lastEvents, scansByListingId] = await Promise.all([
     removedListingIds.length
       ? dbRead.appListingModerationEvent.findMany({
-          where: { appListingId: { in: removedListingIds } },
+          // 🔴 FILTERED TO STATUS-CHANGING ACTIONS, exactly like
+          // `readLastModerationAction`, and from the SAME constant. This read decides
+          // whether `/apps/mine` offers **Republish**; the server-side gate
+          // (`republishOwnListing`, and now the three author edit paths) decides whether
+          // it works. An UNFILTERED read here and a filtered one there disagree the
+          // moment a moderator sends the owner a `message-owner` — the button vanishes
+          // from a listing the server would happily republish. Same query shape, one
+          // spelling of the set.
+          where: {
+            appListingId: { in: removedListingIds },
+            action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
+          },
           orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
           distinct: ['appListingId'],
           select: { appListingId: true, action: true },

--- a/src/server/services/blocks/app-listing-owner-unpublish.ts
+++ b/src/server/services/blocks/app-listing-owner-unpublish.ts
@@ -1,6 +1,5 @@
 import type { Prisma } from '@prisma/client';
 
-import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-moderation.schema';
 import type { AppListingModerationAction } from '~/server/schema/blocks/offsite-moderation.schema';
 
 /**
@@ -59,13 +58,24 @@ export const OWNER_UNPUBLISH_EVENT = 'owner-unpublish';
  * self-restore mod-mandated content). Same mechanism, opposite blast direction — which is
  * why the set is filtered in the QUERY rather than by post-hoc inspection of one row.
  *
- * 🔴 ADDING A NEW STATE-NEUTRAL ACTION MUST NOT SILENTLY CHANGE AUTHORIZATION. That is the
- * whole point of enumerating this explicitly instead of writing `NOT IN (…neutral…)`: a new
- * verb added to {@link APP_LISTING_MODERATION_ACTIONS} is EXCLUDED here by default, so the
- * failure mode of forgetting this file is "the new action does not affect owner editing" —
- * inert — rather than "the new action revokes it". `app-listing-owner-unpublish.test.ts`
- * pins the partition against the full taxonomy, so a new verb makes that test fail and
- * forces the decision to be made out loud.
+ * 🔴 ADDING A NEW ACTION TO THE TAXONOMY MUST NOT SILENTLY CHANGE AUTHORIZATION — AND THE
+ * DEFAULT IS NOT SAFE IN EITHER DIRECTION, WHICH IS WHY IT IS GATED RATHER THAN CHOSEN.
+ * Omitting a new verb from this list makes it invisible to the WHERE clause below, so a
+ * newer event of that verb does NOT displace an older `owner-unpublish` underneath it. For
+ * a state-NEUTRAL verb (`message-owner`) that is exactly right. For a new status-CHANGING
+ * takedown verb it is FAIL-OPEN: a moderator takes the listing down, the owner's stale
+ * `owner-unpublish` resurfaces as "the most recent status-changing event", and the owner
+ * regains edit AND `republishOwnListing` on content a moderator just removed.
+ *
+ * So the decision is forced to be made OUT LOUD rather than defaulted: both halves of the
+ * partition are HARDCODED LITERALS (`STATE_NEUTRAL_MODERATION_ACTIONS` is NOT derived from
+ * this one), `UnclassifiedModerationAction` below fails `pnpm typecheck` on any unclassified
+ * verb, and `app-listing-owner-unpublish.test.ts` asserts the union equals
+ * `APP_LISTING_MODERATION_ACTIONS` exactly. 🔴 Do NOT "simplify" either literal into
+ * `APP_LISTING_MODERATION_ACTIONS.filter(…)` — a derived complement makes every partition
+ * assertion a tautology that a new verb satisfies automatically, which is the precise shape
+ * that restores the fail-open default above while leaving the suite green. (Measured: with
+ * the neutral half derived, adding `'suspend'` to the taxonomy left 33/33 passing.)
  *
  * `purge` is included even though it hard-DELETES the row (its event's `appListingId` is
  * SetNull'd, so it can never come back from this query): the set is defined by what an
@@ -81,18 +91,50 @@ export const LISTING_STATUS_CHANGING_MODERATION_ACTIONS = [
 ] as const satisfies readonly AppListingModerationAction[];
 
 /**
- * The complement of {@link LISTING_STATUS_CHANGING_MODERATION_ACTIONS} — actions recorded
- * against a listing that leave `app_listings.status` alone. Exported so the partition can
- * be asserted as EXHAUSTIVE against the taxonomy rather than merely sampled.
+ * The other half of the partition — actions recorded against a listing that leave
+ * `app_listings.status` alone, and so must never displace the event that explains a
+ * removal. Exported so the partition can be asserted as EXHAUSTIVE against the taxonomy.
+ *
+ * 🔴 THIS IS A HARDCODED LITERAL ON PURPOSE, NOT
+ * `APP_LISTING_MODERATION_ACTIONS.filter(a => !CHANGING.includes(a))`. It was that derived
+ * complement for one round, and the consequence was that EVERY partition assertion —
+ * union-equals-taxonomy, empty intersection, size-sum — became a TAUTOLOGY satisfied by
+ * construction: a new verb flowed into this set automatically and the whole suite stayed
+ * green (measured: adding `'suspend'` to the taxonomy → 33 passed, 0 failed). The guard read
+ * as coverage and provided none. Written out, a new verb is in NEITHER literal, the union
+ * assertion fails, and the fail-open hazard described on
+ * {@link LISTING_STATUS_CHANGING_MODERATION_ACTIONS} cannot be introduced by omission.
+ *
+ * The `satisfies` clause pins membership in the taxonomy; EXHAUSTIVENESS of the two halves
+ * together is what `UnclassifiedModerationAction` and the partition test exist for.
  */
-export const STATE_NEUTRAL_MODERATION_ACTIONS = APP_LISTING_MODERATION_ACTIONS.filter(
-  (
-    a
-  ): a is Exclude<
-    AppListingModerationAction,
-    (typeof LISTING_STATUS_CHANGING_MODERATION_ACTIONS)[number]
-  > => !(LISTING_STATUS_CHANGING_MODERATION_ACTIONS as readonly string[]).includes(a)
-);
+export const STATE_NEUTRAL_MODERATION_ACTIONS = [
+  'claim',
+  'report-resolve',
+  'report-dismiss',
+  'message-owner',
+] as const satisfies readonly AppListingModerationAction[];
+
+/**
+ * A moderation action that is in the taxonomy but in NEITHER half of the partition above.
+ * `never` while the classification is complete.
+ *
+ * 🔴 THE COMPILE-TIME HALF OF THE SAME GATE, and it is here because a test can be skipped,
+ * excluded by a `-t` selector, or simply not run in whichever tier happened to go green.
+ * `typecheck` cannot be. The assignment below is the gate: while this type is `never` it is
+ * legal; the moment a verb joins {@link AppListingModerationAction} without being
+ * classified, the type widens to that verb and `pnpm typecheck` fails ON THIS LINE, naming
+ * it. The runtime partition test says the same thing a second time — two independent
+ * readings of one invariant, on purpose.
+ */
+export type UnclassifiedModerationAction = Exclude<
+  AppListingModerationAction,
+  | (typeof LISTING_STATUS_CHANGING_MODERATION_ACTIONS)[number]
+  | (typeof STATE_NEUTRAL_MODERATION_ACTIONS)[number]
+>;
+const _everyModerationActionIsClassified: never =
+  undefined as unknown as UnclassifiedModerationAction;
+void _everyModerationActionIsClassified;
 
 /**
  * The narrowest client shape this module needs.

--- a/src/server/services/blocks/app-listing-owner-unpublish.ts
+++ b/src/server/services/blocks/app-listing-owner-unpublish.ts
@@ -1,5 +1,8 @@
 import type { Prisma } from '@prisma/client';
 
+import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-moderation.schema';
+import type { AppListingModerationAction } from '~/server/schema/blocks/offsite-moderation.schema';
+
 /**
  * App Store Listings (W13) — "did the OWNER take this listing down, or did a MODERATOR?"
  *
@@ -36,6 +39,62 @@ import type { Prisma } from '@prisma/client';
 export const OWNER_UNPUBLISH_EVENT = 'owner-unpublish';
 
 /**
+ * The moderation actions that WRITE `app_listings.status`, i.e. the only ones that can
+ * explain why a listing is `removed`.
+ *
+ * 🔴 WHY THIS SET EXISTS: `AppListingModerationEvent` IS NOT A STATE LOG. It is a
+ * moderator ACTIVITY log, and several of its actions change no listing status at all —
+ * `message-owner` (a moderator writes to the owner), `report-resolve` / `report-dismiss`
+ * (a REPORT's status flips, not the listing's) and `claim` (the listing's `userId` moves).
+ * Reading "the last event of ANY kind" therefore answers a different question from the one
+ * the callers below ask, and it answers it WRONG in the direction that hurts most: a
+ * moderator who messages an owner *"fix X and republish"* — the single most natural
+ * workflow this feature has — would push `message-owner` in front of the owner's own
+ * `owner-unpublish`, silently REVOKING the repair loop and re-showing the owner the false
+ * "removed by a moderator" attribution this module exists to delete.
+ *
+ * 🔴 THIS CODEBASE HAS ALREADY BEEN BITTEN BY EXACTLY THIS. See the comment on
+ * `closeTerminalListing` in `offsite-listing.service`: a most-recent-event probe there was
+ * defeated by an intervening `report-resolve`, in the UNSAFE direction (it let an owner
+ * self-restore mod-mandated content). Same mechanism, opposite blast direction — which is
+ * why the set is filtered in the QUERY rather than by post-hoc inspection of one row.
+ *
+ * 🔴 ADDING A NEW STATE-NEUTRAL ACTION MUST NOT SILENTLY CHANGE AUTHORIZATION. That is the
+ * whole point of enumerating this explicitly instead of writing `NOT IN (…neutral…)`: a new
+ * verb added to {@link APP_LISTING_MODERATION_ACTIONS} is EXCLUDED here by default, so the
+ * failure mode of forgetting this file is "the new action does not affect owner editing" —
+ * inert — rather than "the new action revokes it". `app-listing-owner-unpublish.test.ts`
+ * pins the partition against the full taxonomy, so a new verb makes that test fail and
+ * forces the decision to be made out loud.
+ *
+ * `purge` is included even though it hard-DELETES the row (its event's `appListingId` is
+ * SetNull'd, so it can never come back from this query): the set is defined by what an
+ * action MEANS, not by what happens to be reachable today.
+ */
+export const LISTING_STATUS_CHANGING_MODERATION_ACTIONS = [
+  'delist',
+  'relist',
+  'purge',
+  'reset-to-pending',
+  'owner-unpublish',
+  'owner-republish',
+] as const satisfies readonly AppListingModerationAction[];
+
+/**
+ * The complement of {@link LISTING_STATUS_CHANGING_MODERATION_ACTIONS} — actions recorded
+ * against a listing that leave `app_listings.status` alone. Exported so the partition can
+ * be asserted as EXHAUSTIVE against the taxonomy rather than merely sampled.
+ */
+export const STATE_NEUTRAL_MODERATION_ACTIONS = APP_LISTING_MODERATION_ACTIONS.filter(
+  (
+    a
+  ): a is Exclude<
+    AppListingModerationAction,
+    (typeof LISTING_STATUS_CHANGING_MODERATION_ACTIONS)[number]
+  > => !(LISTING_STATUS_CHANGING_MODERATION_ACTIONS as readonly string[]).includes(a)
+);
+
+/**
  * The narrowest client shape this module needs.
  *
  * `Pick<Prisma.TransactionClient, …>` rather than the whole client so BOTH an in-tx `tx`
@@ -45,13 +104,24 @@ export const OWNER_UNPUBLISH_EVENT = 'owner-unpublish';
 export type ModerationEventReader = Pick<Prisma.TransactionClient, 'appListingModerationEvent'>;
 
 /**
- * The listing's most-recent moderation action, or `null` when it has none.
+ * The listing's most-recent STATUS-CHANGING moderation action, or `null` when it has none.
+ *
+ * 🔴 IT IS FILTERED, NOT "THE LAST EVENT" — see
+ * {@link LISTING_STATUS_CHANGING_MODERATION_ACTIONS}. A `message-owner`,
+ * `report-resolve`/`report-dismiss` or `claim` row records moderator activity without
+ * touching `app_listings.status`, so it cannot explain a removal and must not displace the
+ * event that can. The filter is in the WHERE clause rather than applied to a fetched row:
+ * "the newest of the interesting kind" is not derivable from "the newest of any kind".
  *
  * 🔴 THE ORDERING IS `createdAt desc, id desc` AND BOTH KEYS MATTER. `createdAt` alone is
- * not a total order — two events written in the same transaction can share a timestamp,
- * and the id tiebreak (ULID-ish, monotonic) is what makes "most recent" deterministic
- * rather than whichever row the planner happened to return first. A non-deterministic
- * answer here flips an owner capability on and off at random.
+ * not a total order — two events written in the same transaction can share a timestamp —
+ * so the id tiebreak is what makes this deterministic rather than whichever row the planner
+ * happened to return first. A non-deterministic answer here flips an owner capability on
+ * and off at random. NOTE the tiebreak buys DETERMINISM, not correctness: these ids are
+ * ULID-derived and so are monotonic only within one generating process, so for two events
+ * that genuinely share a `createdAt` across processes the id order is stable but arbitrary.
+ * That is enough here — every same-timestamp pair this query can see comes from one
+ * transaction in one process.
  *
  * 🔴 WHICH POOL TO PASS IS THE CALLER'S DECISION, AND IT IS A SAFETY DECISION. Pass the
  * PRIMARY (`dbWrite`, or the in-tx `tx`): a moderator's `delist` event is written to the
@@ -65,7 +135,10 @@ export async function readLastModerationAction(
   appListingId: string
 ): Promise<string | null> {
   const lastEvent = await db.appListingModerationEvent.findFirst({
-    where: { appListingId },
+    where: {
+      appListingId,
+      action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
+    },
     orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
     select: { action: true },
   });

--- a/src/server/services/blocks/app-listing-owner-unpublish.ts
+++ b/src/server/services/blocks/app-listing-owner-unpublish.ts
@@ -1,0 +1,94 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * App Store Listings (W13) — "did the OWNER take this listing down, or did a MODERATOR?"
+ *
+ * 🔴 THE PROBLEM THIS EXISTS TO SOLVE. `app_listings.status = 'removed'` is written by
+ * BOTH an owner self-unpublish (`unpublishOwnListing`) and a moderator takedown
+ * (`delistListing` / `purgeListing`). The STATUS COLUMN CANNOT TELL THEM APART. The only
+ * thing that can is the listing's MOST-RECENT `AppListingModerationEvent`: an
+ * `owner-unpublish` there means the owner did it to themselves and may undo/repair it;
+ * anything else — or no event at all — means a moderator did, or that nothing proves
+ * otherwise, and the owner must not be handed the affordance.
+ *
+ * 🔴 ONE SPELLING OF THE PREDICATE, deliberately. `republishOwnListing`'s go-live guard
+ * open-coded it first; the author EDIT paths in `offsite-listing.service` needed the same
+ * question answered and would have open-coded it a second (third, fourth) time. A
+ * predicate duplicated across call sites is wrong at all but one of them eventually, and
+ * the direction it goes wrong here is "an owner may self-restore a listing a moderator
+ * removed" — so it lives in exactly one place and every caller reads it from here.
+ *
+ * 🔴 FAIL-CLOSED ON ABSENCE. `null` (no events recorded) is NOT owner-unpublish. That is
+ * the SAFE direction and it is a real branch, not a degenerate one: a listing removed
+ * before the event table carried these actions, or a row whose events were pruned, must
+ * be treated as a moderator removal rather than trusted to the owner.
+ */
+
+/**
+ * The single action name an owner is allowed to act on. Every other verb is a moderator
+ * (or system) action as far as any owner-facing capability is concerned.
+ *
+ * 🔴 Do NOT widen this to a set. The value space is the point — see
+ * `normalizeLastModerationAction` in `app-access.service`, which collapses everything
+ * else to `'other'` before it leaves the server precisely so a seated editor never
+ * receives the moderator's actual verb.
+ */
+export const OWNER_UNPUBLISH_EVENT = 'owner-unpublish';
+
+/**
+ * The narrowest client shape this module needs.
+ *
+ * `Pick<Prisma.TransactionClient, …>` rather than the whole client so BOTH an in-tx `tx`
+ * and a bare `dbRead`/`dbWrite` satisfy it — the moderation path must run inside its
+ * transaction (see below), the author read paths must not open one.
+ */
+export type ModerationEventReader = Pick<Prisma.TransactionClient, 'appListingModerationEvent'>;
+
+/**
+ * The listing's most-recent moderation action, or `null` when it has none.
+ *
+ * 🔴 THE ORDERING IS `createdAt desc, id desc` AND BOTH KEYS MATTER. `createdAt` alone is
+ * not a total order — two events written in the same transaction can share a timestamp,
+ * and the id tiebreak (ULID-ish, monotonic) is what makes "most recent" deterministic
+ * rather than whichever row the planner happened to return first. A non-deterministic
+ * answer here flips an owner capability on and off at random.
+ *
+ * 🔴 WHICH POOL TO PASS IS THE CALLER'S DECISION, AND IT IS A SAFETY DECISION. Pass the
+ * PRIMARY (`dbWrite`, or the in-tx `tx`): a moderator's `delist` event is written to the
+ * primary, so a lagging replica can still show the owner's older `owner-unpublish` as
+ * "most recent" and hand the owner a capability the moderator has just revoked. Reading
+ * the primary can only err toward refusing, which is the direction that is safe. These
+ * are author edit paths — a handful of calls per editing session, not a hot read.
+ */
+export async function readLastModerationAction(
+  db: ModerationEventReader,
+  appListingId: string
+): Promise<string | null> {
+  const lastEvent = await db.appListingModerationEvent.findFirst({
+    where: { appListingId },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    select: { action: true },
+  });
+  return lastEvent?.action ?? null;
+}
+
+/**
+ * Was the listing's last recorded moderation action the OWNER's own unpublish?
+ *
+ * Pure + exported so the branch (including the `null` arm) is unit-testable without a DB,
+ * and so a caller that already holds the last action does not re-read it.
+ */
+export function isOwnerUnpublishAction(action: string | null | undefined): boolean {
+  return action === OWNER_UNPUBLISH_EVENT;
+}
+
+/**
+ * Convenience composition of the two above: read the last action on `db` and answer the
+ * question. See {@link readLastModerationAction} for which pool to pass.
+ */
+export async function isOwnerUnpublishedListing(
+  db: ModerationEventReader,
+  appListingId: string
+): Promise<boolean> {
+  return isOwnerUnpublishAction(await readLastModerationAction(db, appListingId));
+}

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -45,6 +45,7 @@ import {
   isOwnerUnpublishedListing,
   readLastModerationAction,
   isOwnerUnpublishAction,
+  LISTING_STATUS_CHANGING_MODERATION_ACTIONS,
 } from '~/server/services/blocks/app-listing-owner-unpublish';
 // TYPE-ONLY (erased at compile time) — the runtime reach into `app-access.service` stays
 // a dynamic import, so this adds nothing to the module graph. See `resolveListingRole`.
@@ -3448,10 +3449,21 @@ export async function listMySubmissions(opts: { userId: number } & ListOffsiteRe
   );
 
   // W13 post-approval mgmt (owner controls): for every REMOVED listing on the page,
-  // fetch its MOST-RECENT moderation-event action so the my-submissions UI can tell
-  // an owner-hidden listing (last event `owner-unpublish` → republish-eligible) from
-  // a moderator takedown (last event `delist` → republish FORBIDDEN, shown as
-  // "removed by a moderator") WITHOUT a per-row history fetch.
+  // fetch its MOST-RECENT STATUS-CHANGING moderation-event action so the my-submissions
+  // UI can tell an owner-hidden listing (last event `owner-unpublish` →
+  // republish-eligible) from a moderator takedown (last event `delist` → republish
+  // FORBIDDEN, shown as "removed by a moderator") WITHOUT a per-row history fetch.
+  //
+  // 🔴 THE `action IN (…)` PREDICATE IS LOAD-BEARING, AND ITS VALUES COME FROM
+  // `LISTING_STATUS_CHANGING_MODERATION_ACTIONS` — the same constant the Prisma reads use.
+  // This is the PRIMARY surface for the feature, and an unfiltered `DISTINCT ON` answers a
+  // different question from the server gate (`republishOwnListing`, the author edit paths):
+  // a `message-owner` / `claim` / `report-resolve` row newer than the owner's own
+  // `owner-unpublish` would badge the listing "removed by a moderator" and hide Republish on
+  // a listing the server would happily republish. Raw SQL is exactly where a second
+  // hand-maintained spelling of the set would go unnoticed, so the list is interpolated as
+  // BOUND PARAMETERS from the constant rather than typed out. The whole normalised statement
+  // is pinned in `offsite-listing.edit.service.test.ts`.
   //
   // Fix B4 (scaling): a Prisma `findMany({ distinct, orderBy: createdAt })` CANNOT
   // emit Postgres `DISTINCT ON` here — the `distinct` column (`appListingId`) is not
@@ -3472,6 +3484,7 @@ export async function listMySubmissions(opts: { userId: number } & ListOffsiteRe
             action
           FROM app_listing_moderation_events
           WHERE app_listing_id IN (${Prisma.join(removedParentIds)})
+            AND action IN (${Prisma.join([...LISTING_STATUS_CHANGING_MODERATION_ACTIONS])})
           ORDER BY app_listing_id, created_at DESC, id DESC
         `)
       : [];

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -109,7 +109,12 @@ export type OffsiteRequestErrorCode =
   | 'MUST_RESUBMIT'
   // A shadow-draft revision precondition failed (not a shadow / not a draft /
   // a concurrent revision is already pending / the parent isn't approved).
-  | 'INVALID_REVISION';
+  | 'INVALID_REVISION'
+  // The author tried to change a MATERIAL field (externalUrl / name / contentRating /
+  // sourceRepoUrl / the disclosed scope mask) on a listing the OWNER has unpublished.
+  // Trivial copy edits on that listing are fine; a material one has to go back through
+  // review, which means republishing first and editing through the shadow path.
+  | 'MATERIAL_CHANGE_BLOCKED';
 
 export class OffsiteRequestError extends Error {
   readonly code: OffsiteRequestErrorCode;
@@ -715,7 +720,12 @@ async function closeTerminalListing(
 //                      separately) is staged on a hidden DRAFT clone (the shadow)
 //                      and applied to the parent only on mod re-approve.
 //   rejected         → no row exists (reject deletes it) → MUST_RESUBMIT.
-//   removed          → mod-only takedown → FORBIDDEN for an author edit.
+//   removed          → SPLIT BY THE LAST STATUS-CHANGING MODERATION EVENT. A moderator
+//                      takedown stays FORBIDDEN. An OWNER self-unpublish
+//                      (`owner-unpublish`) is a REPAIR state: TRIVIAL fields edit in
+//                      place; any MATERIAL change is REFUSED (MATERIAL_CHANGE_BLOCKED)
+//                      — republish first, then edit through the shadow path, which is
+//                      the only route back into review.
 // ---------------------------------------------------------------------------
 
 /**
@@ -849,12 +859,20 @@ export function buildListingPatchData(
 }
 
 /**
- * True iff the patch changes a MATERIAL field (see MATERIAL_PATCH_FIELDS) to a
- * value DIFFERENT from the live listing. Iterates the material-field list so the
- * set is edited in ONE place; `externalUrl` compares against the validator's
- * canonical form, the rest are plain scalar inequality.
+ * The names of the MATERIAL fields this patch actually CHANGES relative to the live
+ * listing — `[]` when the edit is trivial-only. `patchHasMaterialChange` is the boolean
+ * view of this; the approved branch only needs the boolean, the `removed` branch needs the
+ * NAMES so its refusal can tell the caller which key to drop.
+ *
+ * 🔴 ONE ITERATION OVER {@link MATERIAL_PATCH_FIELDS}, and the two callers read the SAME
+ * answer. The `removed` branch could have re-listed the fields it wants to block; a second
+ * copy of that list is how `sourceRepoUrl` (added to the set later than the rest) would get
+ * blocked on one path and waved through on the other.
+ *
+ * `externalUrl`/`sourceRepoUrl` compare against the validator's CANONICAL form, the rest
+ * are plain scalar inequality.
  */
-function patchHasMaterialChange(
+function materialPatchChanges(
   patch: UpdateListingPatch,
   live: {
     externalUrl: string | null;
@@ -863,7 +881,8 @@ function patchHasMaterialChange(
     sourceRepoUrl: string | null;
     connectRequestedScopes: number | null;
   }
-): boolean {
+): string[] {
+  const changed: string[] = [];
   for (const field of MATERIAL_PATCH_FIELDS) {
     const patched = patch[field];
     if (patched === undefined) continue;
@@ -871,7 +890,7 @@ function patchHasMaterialChange(
       const url = validateExternalUrl(patched);
       // An invalid URL is a material change (it will be rejected downstream, but
       // it is not "unchanged").
-      if (!url.ok || url.url !== live.externalUrl) return true;
+      if (!url.ok || url.url !== live.externalUrl) changed.push(field);
       continue;
     }
     if (field === 'sourceRepoUrl') {
@@ -883,18 +902,18 @@ function patchHasMaterialChange(
       // noise for the mod and a needless "pending re-review" banner for the author.
       if (patched === null) {
         // An explicit CLEAR is material iff there was something to clear.
-        if (live.sourceRepoUrl !== null) return true;
+        if (live.sourceRepoUrl !== null) changed.push(field);
         continue;
       }
       const repo = validateRepositoryUrl(patched);
       // An invalid value is material (rejected downstream, but not "unchanged") —
       // mirrors the externalUrl branch, so an author cannot slip an unreviewed value
       // through the trivial in-place path by making it malformed.
-      if (!repo.ok || repo.url !== live.sourceRepoUrl) return true;
+      if (!repo.ok || repo.url !== live.sourceRepoUrl) changed.push(field);
       continue;
     }
     // name / contentRating: plain scalar inequality vs the live value.
-    if (patched !== live[field]) return true;
+    if (patched !== live[field]) changed.push(field);
   }
   // A change to the DISCLOSED OAuth scope subset is material — the mod approved a
   // specific set of scopes, so a new set must re-enter review (the shadow carries the
@@ -903,9 +922,21 @@ function patchHasMaterialChange(
     patch.requestedScopes !== undefined &&
     patch.requestedScopes !== (live.connectRequestedScopes ?? 0)
   ) {
-    return true;
+    changed.push('requestedScopes');
   }
-  return false;
+  return changed;
+}
+
+/**
+ * True iff the patch changes a MATERIAL field (see MATERIAL_PATCH_FIELDS) to a
+ * value DIFFERENT from the live listing. The boolean view of
+ * {@link materialPatchChanges}.
+ */
+function patchHasMaterialChange(
+  patch: UpdateListingPatch,
+  live: Parameters<typeof materialPatchChanges>[1]
+): boolean {
+  return materialPatchChanges(patch, live).length > 0;
 }
 
 export type UpdateListingResult = {
@@ -1135,18 +1166,84 @@ export async function updateListing(opts: {
       // moderator took down; only the last moderation event separates them. Refusing both
       // meant the owner's "take it down, repair it, put it back" loop had no repair step.
       // See `app-listing-owner-unpublish` — PRIMARY read, `null` (no events) fails closed.
+      //
+      // 🔴 THE PREDICATE IS ABOUT THE LISTING, THE GATE ABOVE IS ABOUT THE CALLER, AND
+      // THEY ARE DELIBERATELY DIFFERENT QUESTIONS. `readLastModerationAction` selects only
+      // `action` — never `actorUserId` — so this asks "is this listing in owner-repair
+      // state?", not "did YOU unpublish it?". `loadOwnedEditableListing` has already
+      // admitted the OWNER **or an accepted collaborator** (`resolveListingRole`), so an
+      // accepted seat-holder can make trivial edits here while the owner has the app down.
+      //
+      // That is INTENDED, not an oversight, and the reasoning is: (a) a seat-holder already
+      // has exactly this power on `draft`, `pending` and `approved`, so refusing only in the
+      // repair state would make "unpublish → fix your copy → republish" the one flow a team
+      // cannot share — which is the flow most likely to need a second pair of hands; (b) the
+      // seat is itself an authorization the OWNER granted and can revoke; and (c) with the
+      // material-field refusal below, everything reachable here is copy. Note the asymmetry
+      // this leaves standing on purpose: `unpublishOwnListing` and `republishOwnListing` are
+      // OWNER-ONLY (`loadOwnedListingInTx`), so a collaborator can repair the copy but
+      // cannot take the app down or put it back. Pinned by
+      // `offsite-listing.owner-unpublish-editable.service.test.ts`.
       if (!(await isOwnerUnpublishedListing(dbWrite, listingId))) {
         throw new OffsiteRequestError(
           'FORBIDDEN',
           'this listing has been removed by a moderator and can no longer be edited'
         );
       }
-      // Edit IN PLACE, exactly like draft/pending, and for the same reason: the listing is
-      // not being served, so there is nothing live to protect with a shadow revision and
-      // no re-review to stage. The go-live gates run on the way BACK UP —
-      // `republishOwnListing` re-asserts scan-clean assets + off-site actionability before
-      // it flips removed → approved — so an edit made while down still cannot reach the
-      // store unreviewed.
+      // 🔴 TRIVIAL FIELDS ONLY. A MATERIAL change is REFUSED here — it is NOT applied in
+      // place, and it is NOT staged on a shadow.
+      //
+      // 🔴 WHY, and this corrects what this comment used to claim. The earlier version
+      // asserted that "the go-live gates run on the way BACK UP — `republishOwnListing`
+      // re-asserts scan-clean assets + off-site actionability — so an edit made while down
+      // still cannot reach the store unreviewed." THAT IS FALSE, and it was the load-bearing
+      // safety claim on this branch. Neither of those gates is a CONTENT review:
+      // `assertListingAssetsScanCleanInTx` asks whether the images finished scanning, and
+      // `assertOffsiteListingActionableInTx` asks whether an https destination exists AT
+      // ALL — neither asks whether a MODERATOR ever approved the value now in the column.
+      // So without this refusal an owner drives the whole loop themselves, no moderator
+      // involved: `approved` → `unpublishOwnListing` (which requires `approved`) → patch
+      // `externalUrl` in place here → `republishOwnListing` → `approved` again, and the
+      // store's destination URL has been swapped after approval. `contentRating` is the
+      // same shape and worse: it drives the public SFW filter, and nothing on the republish
+      // path re-derives a rating floor. Both are reachable today through the
+      // `appListings.updateListing` tRPC mutation and by CLI token under
+      // `TokenScope.AppBlocksSubmit`; "there is no UI button" is not a gate.
+      //
+      // 🔴 WHY REFUSE RATHER THAN ROUTE TO A SHADOW. The shadow mechanism is defined for a
+      // parent that STAYS LIVE while its replacement is reviewed — `beginListingRevision`
+      // refuses any parent that is not `approved`, and `applyApprovedRevision` copies the
+      // shadow onto a live parent on approve. A `removed` parent has no live copy to
+      // protect and no defined post-approval status, so routing here would mean widening
+      // the revision state machine (and deciding whether approving a revision of an
+      // unpublished listing silently republishes it — a moderator action nobody asked for).
+      // Refusing keeps ONE way for a material change to reach the store: through review of
+      // a live listing. The author's path is stated in the message.
+      //
+      // The feature this branch exists for is untouched: `tagline`, `description` and
+      // `category` are not material, so "unpublish → fix your copy → republish" still works.
+      const material = materialPatchChanges(effectivePatch, {
+        externalUrl: listing.externalUrl,
+        name: listing.name,
+        contentRating: listing.contentRating,
+        sourceRepoUrl: listing.sourceRepoUrl,
+        connectRequestedScopes: listing.connectRequestedScopes,
+      });
+      if (material.length > 0) {
+        throw new OffsiteRequestError(
+          'MATERIAL_CHANGE_BLOCKED',
+          `${material.join(', ')} cannot be changed while this listing is unpublished, ` +
+            `because that change needs moderator review and an unpublished listing has no ` +
+            `way to reach it. Republish the listing first, then edit ` +
+            `${material.length > 1 ? 'those fields' : 'that field'} — the edit will be ` +
+            `staged for review. Tagline, description and category can be edited now.`
+        );
+      }
+      // Everything left is trivial, so edit IN PLACE exactly like draft/pending: the
+      // listing is not being served, so there is nothing live to protect with a shadow
+      // revision. Any material key still present in the patch is byte-identical to the live
+      // value (`material` is empty), so writing it is a harmless no-op — the same argument
+      // the `approved` trivial-only branch makes.
       const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
@@ -2109,10 +2206,24 @@ export function listingMediaEditBlockedReason(
       return 'this listing was rejected; submit a new listing instead of editing it';
     case 'removed':
       // 🔴 The owner's OWN unpublish is a repair state, not a terminal one: they took the
-      // app down to fix it and putting it back (`republishOwnListing`) re-runs the
-      // scan-clean + actionability go-live gates, so editing while it is down cannot
-      // sneak anything past review. A MODERATOR takedown stays terminal — and keeps
-      // saying so, which for this caller is now only ever the true attribution.
+      // app down to fix it, so the media editor mounts. A MODERATOR takedown stays
+      // terminal — and keeps saying so, which for this caller is now only ever the true
+      // attribution.
+      //
+      // 🔴 DO NOT RESTATE THE CLAIM THIS COMMENT USED TO MAKE. It said `republishOwnListing`
+      // "re-runs the scan-clean + actionability go-live gates, so editing while it is down
+      // cannot sneak anything past review". Those gates exist, but neither is a review:
+      // `assertListingAssetsScanCleanInTx` asks whether the images finished scanning
+      // without being `Blocked`, `assertOffsiteListingActionableInTx` asks whether an https
+      // destination exists. Neither asks whether a moderator ever saw the current values.
+      // What actually holds the line is per-surface: for SCALARS, `updateListing`'s
+      // MATERIAL_CHANGE_BLOCKED refusal on this same state. For ASSETS — which is what this
+      // verdict unblocks — nothing does, and that is PRE-EXISTING rather than opened here:
+      // `assertOwnerAssetEditable` already refuses only an `approved` top-level listing, so
+      // a `removed` listing has been directly asset-editable all along, and
+      // `republishOwnListing` runs no rating floor (`resolveListingRatingFloorInTx` is
+      // wired into the approve paths only). This verdict changes WHO IS TOLD WHAT, not what
+      // the asset procs permit. See the PR body's "known adjacent gap".
       return ownerUnpublished
         ? null
         : 'this listing has been removed by a moderator and can no longer be edited';

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -41,6 +41,11 @@ import {
   assertListingMeetsFloor,
 } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionable } from '~/server/services/blocks/app-listing-actionable.service';
+import {
+  isOwnerUnpublishedListing,
+  readLastModerationAction,
+  isOwnerUnpublishAction,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
 // TYPE-ONLY (erased at compile time) — the runtime reach into `app-access.service` stays
 // a dynamic import, so this adds nothing to the module graph. See `resolveListingRole`.
 import type { AppRole } from '~/server/services/blocks/app-access.service';
@@ -1124,11 +1129,28 @@ export async function updateListing(opts: {
   };
 
   switch (listing.status) {
-    case 'removed':
-      throw new OffsiteRequestError(
-        'FORBIDDEN',
-        'this listing has been removed by a moderator and can no longer be edited'
-      );
+    case 'removed': {
+      // 🔴 `removed` IS TWO DIFFERENT STATES WEARING ONE STATUS STRING. An owner who
+      // unpublished their own app to fix it up lands here, and so does a listing a
+      // moderator took down; only the last moderation event separates them. Refusing both
+      // meant the owner's "take it down, repair it, put it back" loop had no repair step.
+      // See `app-listing-owner-unpublish` — PRIMARY read, `null` (no events) fails closed.
+      if (!(await isOwnerUnpublishedListing(dbWrite, listingId))) {
+        throw new OffsiteRequestError(
+          'FORBIDDEN',
+          'this listing has been removed by a moderator and can no longer be edited'
+        );
+      }
+      // Edit IN PLACE, exactly like draft/pending, and for the same reason: the listing is
+      // not being served, so there is nothing live to protect with a shadow revision and
+      // no re-review to stage. The go-live gates run on the way BACK UP —
+      // `republishOwnListing` re-asserts scan-clean assets + off-site actionability before
+      // it flips removed → approved — so an edit made while down still cannot reach the
+      // store unreviewed.
+      const data = buildListingPatchData(effectivePatch, patchOpts);
+      await dbWrite.appListing.update({ where: { id: listingId }, data });
+      return { listingId, status: listing.status, requiresReview: false, shadowId: null };
+    }
     case 'rejected':
       // reject() deletes the draft, so this row usually doesn't exist (→ NOT_FOUND
       // above). If a rejected row somehow persists, steer the caller to resubmit.
@@ -1672,8 +1694,9 @@ async function loadListingEditView(
 /**
  * AUTHOR: owner-gated prefill read for the dual-mode edit wizard. Loads the
  * caller's OWN listing (NOT_OWNED / NOT_FOUND), asserts it is EDITABLE
- * (draft/pending/approved; rejected → MUST_RESUBMIT, removed → FORBIDDEN,
- * an internal shadow → INVALID_REVISION), and returns the prefill scalars +
+ * (draft/pending/approved; rejected → MUST_RESUBMIT; removed → editable ONLY when the
+ * owner unpublished it themselves, else FORBIDDEN; an internal shadow →
+ * INVALID_REVISION), and returns the prefill scalars +
  * current assets from the EFFECTIVE source: an approved parent's in-progress
  * shadow when one exists (so a resumed revision prefills its edited state), else
  * the listing itself. `slug` + `status` + `parentId` always describe the live
@@ -1693,11 +1716,19 @@ export async function getMyListingForEdit(opts: {
     );
   }
   switch (listing.status) {
-    case 'removed':
-      throw new OffsiteRequestError(
-        'FORBIDDEN',
-        'this listing has been removed by a moderator and can no longer be edited'
-      );
+    case 'removed': {
+      // 🔴 Same two-states-one-string branch as `updateListing` — the prefill read has to
+      // agree with the write path it prefills, or the owner gets an editor they are then
+      // refused by. `app-listing-owner-unpublish` is the single spelling of the predicate.
+      const lastAction = await readLastModerationAction(dbWrite, listingId);
+      if (!isOwnerUnpublishAction(lastAction)) {
+        throw new OffsiteRequestError(
+          'FORBIDDEN',
+          'this listing has been removed by a moderator and can no longer be edited'
+        );
+      }
+      break;
+    }
     case 'rejected':
       throw new OffsiteRequestError(
         'MUST_RESUBMIT',
@@ -2004,6 +2035,15 @@ export async function getMyListingForApp(opts: {
     effectiveId !== listing.id ? dbWrite : dbRead
   );
 
+  // 🔴 Only a `removed` listing needs this — it is the ONE status whose editability is not
+  // decided by the status column alone (owner self-unpublish and moderator takedown both
+  // write it). Gated on the status so the common path keeps its existing round-trip count.
+  // PRIMARY, not the replica: see `readLastModerationAction` — a lagging replica can hide
+  // a moderator's just-written `delist` behind the owner's older `owner-unpublish`, and
+  // reading the primary can only err toward refusing.
+  const ownerUnpublished =
+    listing.status === 'removed' ? await isOwnerUnpublishedListing(dbWrite, listing.id) : false;
+
   return {
     appListingId: listing.id,
     status: listing.status,
@@ -2013,7 +2053,7 @@ export async function getMyListingForApp(opts: {
     hasPendingRevision: !!pendingRevisionReq,
     shadowId,
     editTargetId: effectiveId,
-    editBlockedReason: listingMediaEditBlockedReason(listing),
+    editBlockedReason: listingMediaEditBlockedReason(listing, ownerUnpublished),
     assets,
   };
 }
@@ -2026,15 +2066,37 @@ export async function getMyListingForApp(opts: {
  * media editor mounting against a `removed` / `rejected` listing. Lazy creation
  * removes that call, so the verdict is computed here (read-only) and surfaced on the
  * read. Mirrors `updateListing`'s state routing: draft/pending edit in place,
- * approved edits through a revision, rejected → resubmit, removed → terminal. An
- * internal shadow (`revisionOfId != null`) is not a page the owner addresses directly.
+ * approved edits through a revision, rejected → resubmit, removed → terminal UNLESS the
+ * owner removed it themselves. An internal shadow (`revisionOfId != null`) is not a page
+ * the owner addresses directly.
+ *
+ * 🔴 STILL PURE AND STILL SYNCHRONOUS — the one bit that `removed` cannot supply arrives
+ * as an ARGUMENT rather than as a DB read inside this function. `status='removed'` is
+ * written by both an owner self-unpublish and a moderator takedown, so answering
+ * "editable?" needs the listing's last moderation action; making this function fetch that
+ * itself would have made it `async` and DB-bound, and the reason it is exported at all is
+ * that its branch table is unit-testable WITHOUT a DB. Its only caller already has the
+ * listing loaded and is already `async`, so the read belongs there.
+ *
+ * 🔴 `ownerUnpublished` IS REQUIRED, NOT OPTIONAL-DEFAULTING-TO-FALSE. A default would be
+ * the safe VALUE (refuse) but the wrong ERGONOMICS: a future caller could omit it and
+ * silently reintroduce exactly the defect this parameter fixes, with nothing going red.
+ * Required means every call site has to decide, out loud.
  *
  * Pure + exported so the branch table is unit-testable without a DB.
  */
-export function listingMediaEditBlockedReason(listing: {
-  status: string;
-  revisionOfId: string | null;
-}): string | null {
+export function listingMediaEditBlockedReason(
+  listing: {
+    status: string;
+    revisionOfId: string | null;
+  },
+  /**
+   * Did the OWNER take this listing down themselves (last moderation action ===
+   * `owner-unpublish`)? Only consulted on `removed`. `false` on a moderator takedown AND
+   * on a listing with no recorded events — see `app-listing-owner-unpublish`.
+   */
+  ownerUnpublished: boolean
+): string | null {
   if (listing.revisionOfId != null) {
     return 'this listing is an internal revision draft and cannot be edited directly';
   }
@@ -2046,7 +2108,14 @@ export function listingMediaEditBlockedReason(listing: {
     case 'rejected':
       return 'this listing was rejected; submit a new listing instead of editing it';
     case 'removed':
-      return 'this listing has been removed by a moderator and can no longer be edited';
+      // 🔴 The owner's OWN unpublish is a repair state, not a terminal one: they took the
+      // app down to fix it and putting it back (`republishOwnListing`) re-runs the
+      // scan-clean + actionability go-live gates, so editing while it is down cannot
+      // sneak anything past review. A MODERATOR takedown stays terminal — and keeps
+      // saying so, which for this caller is now only ever the true attribution.
+      return ownerUnpublished
+        ? null
+        : 'this listing has been removed by a moderator and can no longer be edited';
     default:
       return `cannot edit a listing in status ${listing.status}`;
   }

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -24,6 +24,7 @@ import { recordOwnershipEvent } from '~/server/services/blocks/app-collaborator.
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import { assertListingAssetsScanCleanInTx } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionableInTx } from '~/server/services/blocks/app-listing-actionable.service';
+import { isOwnerUnpublishedListing } from '~/server/services/blocks/app-listing-owner-unpublish';
 import {
   newAppListingModerationEventId,
   newAppListingPublishRequestId,
@@ -1495,12 +1496,7 @@ export async function republishOwnListing(opts: {
     // the PRIMARY inside the tx (a concurrent mod delist/purge would otherwise race
     // between a replica read and the flip). A mod delist/purge (or NO event) → the
     // owner may not self-restore.
-    const lastEvent = await tx.appListingModerationEvent.findFirst({
-      where: { appListingId: input.appListingId },
-      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-      select: { action: true },
-    });
-    if (!lastEvent || lastEvent.action !== 'owner-unpublish') {
+    if (!(await isOwnerUnpublishedListing(tx, input.appListingId))) {
       throw new OffsiteModerationError(
         'FORBIDDEN',
         'This listing was removed by a moderator and cannot be restored by its owner.'

--- a/src/shared/constants/app-capabilities.constants.ts
+++ b/src/shared/constants/app-capabilities.constants.ts
@@ -136,13 +136,23 @@ export function listingKindSupports(kind: string, capability: ListingCapability)
  * The listing statuses the CANONICAL AUTHORING PAGE may be opened on.
  *
  * 🔴 MIRRORS `getMyListingForEdit`'s existing switch, deliberately, so the entry point and
- * the first thing it loads cannot disagree: that proc already refuses `removed` with
- * FORBIDDEN ('removed by a moderator and can no longer be edited') and `rejected` with
+ * the first thing it loads cannot disagree: that proc refuses `removed` with FORBIDDEN
+ * ('removed by a moderator and can no longer be edited') and `rejected` with
  * MUST_RESUBMIT. Before this gate the authoring page opened happily on a moderator-REMOVED
  * listing — every tab rendered, and the Collaborators tab was fully live, so an owner
  * could still invite someone onto a delisted app and the acceptance would mint Forgejo
  * `write` on its repo. The procs were always going to refuse the CONTENT edits; it is this
  * PR that made the page reachable, so the gate belongs here.
+ *
+ * 🔴 IT NO LONGER MIRRORS THAT SWITCH EXACTLY, AND THE DIVERGENCE IS DELIBERATE.
+ * `getMyListingForEdit`/`updateListing` now admit a `removed` listing whose LAST
+ * moderation event is the owner's own `owner-unpublish` — an owner who took
+ * their app down to repair it can now repair it. This set was NOT widened to match,
+ * because `removed` is one status string covering two states and this constant cannot see
+ * which: adding it would also open every CONTENT tab — above all Collaborators, where
+ * accepting an invite mints repo `write` — on a MODERATOR-delisted listing. The status
+ * column is the wrong instrument for that question; the procs branch on the last
+ * moderation action instead. Widen this set only if it too gains that bit.
  */
 export const AUTHORABLE_LISTING_STATUSES = ['draft', 'pending', 'approved'] as const;
 


### PR DESCRIPTION
## The defect — two of them, one branch

`app_listings.status = 'removed'` is written by **both** `unpublishOwnListing` (an owner takes their own app down to fix it up) and a moderator `delist`/`purge`. Three author edit paths in `offsite-listing.service.ts` branched on that status column alone and refused everything, so for the owner both halves were wrong:

1. **Capability.** An owner who unpublished their own listing could not then edit it. Their own "take it down → repair it → put it back" loop had no repair step; the only way back was a moderator `relistListing`.
2. **Message.** Every refusal said `this listing has been removed by a moderator and can no longer be edited`. For an owner who removed it themselves, that sentence is false in both clauses.

The three sites, all with that same message:

| site | before | after |
|---|---|---|
| `updateListing`'s status switch | `case 'removed': throw FORBIDDEN` | owner-unpublished ⇒ **trivial** fields edit in place; a **material** field ⇒ `MATERIAL_CHANGE_BLOCKED`; a moderator takedown ⇒ FORBIDDEN, unchanged message |
| `getMyListingForEdit`'s status switch | `case 'removed': throw FORBIDDEN` | owner-unpublished ⇒ falls through to the prefill; else FORBIDDEN, unchanged message |
| `listingMediaEditBlockedReason` (pure) | `case 'removed': return <mod message>` | owner-unpublished ⇒ `null`; else the mod message, unchanged |

## The approach — branch on the last STATUS-CHANGING moderation action

The distinguishing signal already existed and was already trusted. `republishOwnListing` has always required the listing's most-recent `AppListingModerationEvent` to be `owner-unpublish` before letting an owner self-restore — a moderator `delist`/`purge`, or no event at all, is FORBIDDEN.

That predicate was open-coded there. It is now single-sourced in a new `src/server/services/blocks/app-listing-owner-unpublish.ts` and read by **all five** sites (the four gates plus the `/apps/mine` list read), so a change to what counts as owner-initiated cannot land at four of them and miss the fifth:

- **filtered to status-changing actions.** `AppListingModerationEvent` is a moderator *activity* log, not a state log: `message-owner`, `report-resolve`, `report-dismiss` and `claim` all write rows without touching `app_listings.status`. Reading "the last event of any kind" therefore answers a different question — and answers it wrong in the direction that hurts: a moderator messaging the owner *"fix X and republish"* would push `message-owner` in front of the owner's own `owner-unpublish`, silently revoking the repair loop and re-showing the false "removed by a moderator" attribution this PR exists to delete. `LISTING_STATUS_CHANGING_MODERATION_ACTIONS` is enumerated from `APP_LISTING_MODERATION_ACTIONS` (itself pinned against the migration's CHECK IN-list), and a test asserts the partition is exhaustive, so a **new** verb added to the taxonomy is excluded by default and makes that test fail rather than silently changing authorization. The same trap already bit `closeTerminalListing`, in the opposite blast direction — its comment records a most-recent-event probe defeated by an intervening `report-resolve`.
- same ordering — `orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]`. `createdAt` alone is not a total order (two events written in one transaction share a timestamp), so the id tiebreak makes this deterministic rather than planner-dependent. It buys determinism, not correctness: the ids are ULID-derived and monotonic only per generating process.
- same fail-closed treatment of absence — `!lastEvent` ⇒ **not** owner-unpublish. Nothing proves the owner did it, so it is treated as a moderator removal. Pinned by a test at every site.
- **primary reads on the gates.** `republishOwnListing` reads inside its transaction so a concurrent mod delist cannot race the flip. The three edit paths pass `dbWrite` for the same reason in the read direction: a lagging replica can hide a moderator's just-written `delist` behind the owner's older `owner-unpublish` and *grant* an edit that was revoked. Reading the primary can only err toward refusing. All three sites now carry their own pool assertion (previously only `updateListing` did — a `dbWrite → dbRead` mutation at the other two survived the whole blocks suite). (`getAppListingAuthoringContext` deliberately keeps the **replica** — it decides which button renders, and the mutation behind it re-checks on the primary, so a stale read costs one refused click. The asymmetry is written down at both sites.)

## 🔴 A MATERIAL change is REFUSED, not applied in place

This is the security core of the PR and it is why `updateListing`'s `removed` arm is not simply "edit in place like draft/pending".

`removed` + `owner-unpublish` is a state an owner can enter and leave **with no moderator in the loop**:

```
approved → unpublishOwnListing → updateListing(<material>) → republishOwnListing → approved
```

`republishOwnListing` gates on `assertListingAssetsScanCleanInTx` (did the images finish scanning?) and `assertOffsiteListingActionableInTx` (is there an https href at all?). **Neither is a content review.** Neither asks whether a moderator ever saw the value now in the column. So an unguarded in-place write would let the store's destination URL, its displayed name, its public repo link, its disclosed OAuth scope set, and its content rating all be swapped *after* approval. It is reachable through the `appListings.updateListing` tRPC mutation and by CLI token under `TokenScope.AppBlocksSubmit` — "there is no UI button" is not a gate.

So the `removed` arm computes `materialPatchChanges(...)` — the **same** iteration over `MATERIAL_PATCH_FIELDS` (`externalUrl`, `name`, `contentRating`, `sourceRepoUrl`, plus the derived scope mask) that the `approved` arm uses, refactored to return the offending field **names** rather than a boolean, so there is no second copy of the list — and throws a typed `MATERIAL_CHANGE_BLOCKED` naming every offending field and the way forward.

**Refuse rather than route to a shadow, and why.** The shadow-revision mechanism is defined for a parent that *stays live* while its replacement is reviewed: `beginListingRevision` refuses any parent that is not `approved`, and `applyApprovedRevision` copies the shadow onto a live parent on approve. A `removed` parent has no live copy to protect and no defined post-approval status, so routing here would mean widening the revision state machine *and* deciding whether approving a revision of an unpublished listing silently republishes it — a moderator-visible behaviour change nobody asked for. Refusing keeps exactly one route for a material change to reach the store: review of a live listing. `MATERIAL_CHANGE_BLOCKED` maps explicitly to tRPC `BAD_REQUEST` (not by falling through the mapper's default) — the caller's *authority* is fine, it is one field in one state that is refused, and `FORBIDDEN` would read as "you may not edit this listing", the false attribution this arc exists to remove.

**The feature is untouched.** `tagline`, `description` and `category` are not material, so "unpublish → fix your copy → republish" — the actual user need driving this PR — still works, and a positive-control test says so. A material key that is *present but unchanged* (the editor round-trips every field) is also not a change, and is likewise pinned.

**`contentRating` is subsumed by this, not handled separately.** It is in `MATERIAL_PATCH_FIELDS` because it drives the public SFW filter (`content_rating NOT IN ('r','x')`), so lowering `r → g` in place would surface a still-mature listing to SFW users. Tests pin **both** directions — the rule is "material", not "lowered", because a rating change is a moderator-visible fact either way and a rule that only caught the dangerous direction would be a rule about the exploit rather than about review.

## The grant reaches an accepted COLLABORATOR — deliberately, and now stated

`updateListing` gates through `resolveListingRole`, which admits the owner **or an accepted seat**, while `readLastModerationAction` selects only `action`, never `actorUserId`. So the predicate asks *"is this listing in owner-repair state?"* and the gate asks *"may this caller edit it?"* — different questions, on purpose.

Decision: **keep the seat's reach.** A collaborator already has exactly this power on `draft`/`pending`/`approved`, so refusing only in the repair state would make the one flow most likely to need a second pair of hands the one flow a team cannot share; the seat is an authorization the owner granted and can revoke; and with material fields refused, everything reachable is copy. The asymmetry that stays: `unpublishOwnListing`/`republishOwnListing` are owner-only (`loadOwnedListingInTx` compares `listing.userId`), so a collaborator can repair the copy but can neither take the app down nor put it back. Pinned by three tests (trivial edit allowed, material edit refused, no-seat stranger still `NOT_OWNED`).

## What did NOT change

- **The moderator takedown path.** Still refused at all three sites, still attributed to a moderator, still the same literal string — and the mod-takedown check runs *before* the material check, so a moderator-removed listing is told it is moderator-removed rather than told to republish first. Pinned by an invariant guard per site, plus a `purge` case so the guard is not just testing one verb.
- **`AUTHORABLE_LISTING_STATUSES` was deliberately not widened.** Adding `'removed'` would have been a one-line fix and it is the wrong one: that constant is status-only and structurally cannot see the last moderation action, so it would have unlocked the content tabs on **moderator-delisted** listings too — above all Collaborators, where accepting an invite mints Forgejo `write` on the app's repo.
- **The `approved` arm.** A material change there still stages onto a shadow and re-enters review; a negative-control test asserts the new refusal did not leak into it.

## 🔴 Two safety comments were WRONG and are corrected, not softened

Both claimed the same false thing — that the republish gates make an edit-while-down safe:

> *"The go-live gates run on the way BACK UP — `republishOwnListing` re-asserts scan-clean assets + off-site actionability … so an edit made while down still cannot reach the store unreviewed."*

That is false for material fields, and it was the load-bearing safety claim on the branch. Both comments (in `updateListing`'s `removed` arm and in `listingMediaEditBlockedReason`) now state what actually holds the line: for **scalars**, the `MATERIAL_CHANGE_BLOCKED` refusal; for **assets**, nothing — see the adjacent gap below.

The `updateListing` router doc comment carried the same problem in a place that matters more: it is the written justification for annotating a token-scoped write with `listingMediaCliScope`, and it claimed *"a `removed` listing is refused outright"*, which this PR made untrue. It has been rewritten to state the guarantee **by mechanism rather than by status** — approved-material stages to a shadow, removed-material is refused, a shadow is refused — so the claim survives the next state being opened.

## Known adjacent gap — PRE-EXISTING, deliberately not fixed here

A `removed` listing has been **directly asset-editable all along**: `assertOwnerAssetEditable` refuses only an `approved` top-level listing (`listing.status === 'approved' && listing.revisionOfId == null`), so icon/cover/screenshot writes on a `removed` listing were already permitted before this PR. And `republishOwnListing` runs **no rating floor** — `resolveListingRatingFloorInTx` is wired into the approve paths only (`publish-request.service.ts`). So mature-but-`Scanned` media can be attached to a `g`-rated listing while it is down and go live on republish.

This PR does not open that and does not widen it: `listingMediaEditBlockedReason` changes **who is told what**, not what the asset procs permit. Expanding scope to fix it here would mix an authorization change with a media-review change in one review.

*Closing condition:* a merged PR that calls `resolveListingRatingFloorInTx` inside `republishOwnListing`'s transaction (alongside the existing `assertListingAssetsScanCleanInTx` call), raising `contentRating` to the media-derived floor before the `removed → approved` flip — with a test in `offsite-moderation.service.*.test.ts` proving that a `g`-rated listing carrying an `x`-level screenshot republishes as `x`, and a negative control proving a clean listing's rating is unchanged. Checked by that PR's own suite going green.

## `listingMediaEditBlockedReason` stays pure and synchronous

It takes the owner-unpublish bit as a **required second parameter** rather than fetching it. Making it `async` and DB-bound would have cost the one property its own comment says is the point — that its branch table is unit-testable without a DB — and its only caller (`getMyListingForApp`) already has the listing loaded and is already async.

Required rather than optional-defaulting-to-`false`: the default would be the *safe value* but the wrong ergonomics, since a future call site could omit it and silently reinstate exactly this defect with nothing going red.

## Test matrix

Two files, `offsite-listing.owner-unpublish-editable.service.test.ts` (**39 cases**) and `app-listing-owner-unpublish.test.ts` (**33 cases**) — 72 total, all green at HEAD.

Rows are labelled by what they actually prove. **Invariant guards and positive controls are NOT counted as regression coverage.**

### Round 1 — against `origin/main` (48043e353f)

6 RED / 10 green-at-base. Unchanged from the original review; the ten green rows pin the moderator path and are labelled *invariant guards* in the file.

### Round 2 — the audit fixes, against the pre-fix branch tip `255218262f`

Measured by reverting the four source files to `255218262f` and re-running both test files unchanged: **28 RED / 44 green**, then 72/72 green at HEAD.

| case | proves | at `255218262f` | at HEAD |
|---|---|---|---|
| `externalUrl` change ⇒ `MATERIAL_CHANGE_BLOCKED`, nothing written | Finding 1 | **RED** | green |
| `name` change ⇒ refused | Finding 1 | **RED** | green |
| `contentRating` lowered `r → g` ⇒ refused | Finding 2 | **RED** | green |
| `contentRating` raised `g → r` ⇒ refused | rule is "material", not "lowered" | **RED** | green |
| `sourceRepoUrl` change ⇒ refused | Finding 1 | **RED** | green |
| `requestedScopes` drift ⇒ refused | Finding 1 | **RED** | green |
| the message names **every** offending field | error is actionable | **RED** | green |
| collaborator ⇒ material refused too | Finding 7 | **RED** | green |
| `message-owner`/`report-resolve`/`report-dismiss`/`claim` on top of an owner-unpublish ⇒ still editable (×4) | Finding 4 | **RED** | green |
| ditto ⇒ media editor not blocked / prefill resolves (×2) | Finding 4 | **RED** | green |
| the WHERE filters to status-changing actions (query shape ×2) | Finding 4 | **RED** | green |
| the taxonomy partition is exhaustive + per-action membership (×11) | Finding 4 (structural — the constant does not exist at base) | **RED** | green |
| tagline/description/category still edit in place | positive control | green | green |
| a material key present but **unchanged** still saves | positive control | green | green |
| `approved` + material still stages onto a shadow | negative control on the branch | green | green |
| mod takedown refused **before** the material check | ordering / attribution | green | green |
| collaborator ⇒ trivial edit allowed | Finding 7 (documented behaviour) | green | green |
| stranger with no seat ⇒ `NOT_OWNED` | invariant guard | green | green |
| a state-neutral event on top of a **delist** is still a delist | invariant guard | green | green |
| `getMyListingForEdit` reads the PRIMARY (site 2 of 3) | **mutation guard, not regression** | green | green |
| `getMyListingForApp` reads the PRIMARY (site 3 of 3) | **mutation guard, not regression** | green | green |
| the CLIENT literal `OWNER_UNPUBLISH_ACTION` equals the SERVER constant | invariant guard | green | green |

The two "reads the PRIMARY (site 2/3 of 3)" rows are explicitly **not** regression coverage: those sites already read `dbWrite`. What they close is that a `dbWrite → dbRead` mutation at either one **survived the entire blocks suite**, because only `updateListing` carried a pool assertion. Both mutants now die.

One pair of tests was **merged into one**: "the verdict is null" and "the verdict never says by a moderator" shared a fixture and a call, and the second could not fail unless the first did. `toBeNull()` is strictly stronger and is what remains.

### Mutation battery

Twenty-seven mutants over the blocks + Apps unit suites (**4,607 tests**), each reverted after measuring. Harness validated first: a positive control (`isOwnerUnpublishAction` → `return true`) **KILLED (35)**, a negative control (comment-only no-op) **SURVIVED**, baseline green.

**Result: 26 killed, 1 intended survivor (the negative control).** Two real survivors were found on the first pass and are named below rather than folded into the number.

| # | mutant | verdict |
|---|---|---|
| M1 | `isOwnerUnpublishAction`: `===` → `!==` | KILLED (69) |
| M2 | the constant names `owner-republish` (wrong bind) | KILLED (38) |
| M3 | **drop the action filter from the WHERE** (Finding 4 regression) | KILLED (9) |
| M4 | set widened: `message-owner` counted as status-changing | KILLED (1) |
| M5 | set narrowed: `delist` dropped | KILLED (2) |
| M6 | id tiebreak removed from the ordering | KILLED (2) |
| M7 | ordering reversed (oldest event wins) | KILLED (2) |
| M8 | fail-**OPEN** on absence: no events reads as `owner-unpublish` | KILLED (11) |
| M9 | off-by-one: refuse only when **two+** material fields changed | KILLED (7) |
| M10 | **comment out the refusal** (`if (false && …)` — token still present) | KILLED (8) |
| M11 | wrong bind: `contentRating` compared against a constant, not the live row | **SURVIVED → fixed → KILLED (1)** |
| M12 | refusal moved **after** the write (ordering mutant) | KILLED (8) |
| M13 | scalar comparison inverted (`!==` → `===`) | KILLED (9) |
| M14 | `contentRating` dropped from `MATERIAL_PATCH_FIELDS` | KILLED (3) |
| M15 | `sourceRepoUrl` dropped from `MATERIAL_PATCH_FIELDS` | KILLED (3) |
| M16 | scope drift no longer material | KILLED (3) |
| M17 | pool: `updateListing` reads the replica | KILLED (1) |
| M18 | pool: `getMyListingForEdit` reads the replica | KILLED (1) |
| M19 | pool: `getMyListingForApp` reads the replica | KILLED (1) |
| M20 | gate inverted: `owner-unpublish` is the one case refused | KILLED (23) |
| M21 | gate short-circuited: every `removed` listing editable | KILLED (7) |
| M22 | prefill gate short-circuited | KILLED (3) |
| M23 | media verdict: `removed` always editable | KILLED (5) |
| M24 | media verdict: `ownerUnpublished` ignored, always blocked | KILLED (3) |
| M25 | `patchHasMaterialChange` always false (approved arm loses staging) | KILLED (8) |
| M26 | **/apps/mine list read drops the action filter** | **SURVIVED → fixed → KILLED (1)** |

**The two survivors, stated plainly, because each was a real gap in the tests:**

- **M11** — replacing `contentRating: listing.contentRating` with a constant `null` in the `removed` arm's `live` object survived *every* material case. All of them compare a patched value against a **different** live value, so a wrong bind leaves the inequality true and the refusal identical: the mutant is unobservable on those fixtures. Only an **unchanged** value distinguishes them (correct code sees equality and saves; a wrong bind sees `'r' !== null` and refuses). The unchanged-key test now re-sends **every** material field verbatim, and the mutant dies to exactly that case.
- **M26** — dropping the action filter from `hydrateMyAppListings`' read survived because `historyFake` in `app-access.my-app-listings-moderation.test.ts` ignored `where.action` and returned the same rows either way — *the fake could not express the thing under test*. It now honours the filter, and a new case (history = older `owner-unpublish` + newer `message-owner` ⇒ still `owner-unpublish`, plus a structural assertion that the WHERE excludes every state-neutral verb) kills it.

Both were re-scored after the fix and each is killed by the single test written for it, attributed by name — not by a neighbouring assertion.

## Verification

- `pnpm typecheck` — **0 errors**. (`event-engine-common` must be initialised in a fresh worktree — `git submodule update --init event-engine-common` — or it reports 12 unrelated errors.)
- Full unit suite (`--project 'unit*'`): **1456 files / 22,667 passed, 25 skipped, 0 failed**. (One suite fails to *collect* in a fresh worktree until `svelte-kit sync` is run in `apps/auth`; unrelated to this change and green after.)
- Mutation scoring suite: `src/server/services/blocks/__tests__` + `src/components/Apps/__tests__`, **4606 tests**, green at baseline.

## Known gap — the UI entry point is a separate change

This PR fixes the **server**. The canonical authoring page still withholds the `details` and `media` tabs on a `removed` listing, because `editorTabsFor` gates them on `isAuthorableListingStatus`, which this PR deliberately did not widen. So the newly-permitted edit is reachable through the procs but has no button yet — deliberately, and in this order: the server gate was under repair, and making it reachable before that landed is the wrong sequence.

The right fix is to make the tab gate last-action-aware rather than status-only — and `AppListingAuthoringContext` **already carries** `lastModerationAction`, normalised, for exactly this distinction. That is a UI security gate (it decides whether Collaborators renders) and deserves its own review, so it is not folded in here. This repo bans stacked PRs, so it branches off `main` after this merges.

*Closing condition for that follow-up:* a merged PR in which `editorTabsFor` consumes `lastModerationAction`, with tests pinning `removed` + `owner-unpublish` ⇒ `details`/`media` offered and `removed` + anything-else ⇒ still withheld — checked by that PR's own suite going green.


---

# Round 2 — three delta-audit findings, fixed on top of `c049d13683`

Three commits, readable as a delta from the audited tip:

| commit | what |
|---|---|
| `4bd2c4d50b` | Finding 3 — the partition guard was a tautology, and it inverted a fail-closed default |
| `a9aadbb7ae` | Findings 1 + 2 — the last two open-coded last-action reads routed through the shared set |
| `d400527c1d` | a ledger of every `AppListingModerationEvent` read, so a further copy cannot appear |
| `af3d1ed6d0` | **docs-only** — three comment defects from a delta re-audit: a guard described wider than it asserts, a false SQL rationale for an order assertion, and a self-contradicting read-site count. No logic, no assertion, no control flow; proven inert (see below) |

## 🔴 Finding 3 — the partition guard proved nothing, and the direction was fail-OPEN

`STATE_NEUTRAL_MODERATION_ACTIONS` was the **derived complement** of
`LISTING_STATUS_CHANGING_MODERATION_ACTIONS`
(`APP_LISTING_MODERATION_ACTIONS.filter(a => !CHANGING.includes(a))`). Under that
construction, union-equals-taxonomy, empty-intersection and size-sum are all **tautologies
by construction**: a new verb flows into the neutral half automatically and every assertion
still holds. **Measured on `c049d13683`: adding `'suspend'` to
`APP_LISTING_MODERATION_ACTIONS` gave 33 passed / 0 failed.** The docstring claimed the
opposite — that a new verb "makes that test fail and forces the decision to be made out
loud". **A comment that reads as coverage while providing none is worse than no comment,
because it stops the next person looking.** It is corrected, not softened.

It is more than a test nit. A new status-**changing** takedown verb omitted from
`LISTING_STATUS_CHANGING_MODERATION_ACTIONS` is filtered *out* of
`readLastModerationAction`'s WHERE clause, so an older `owner-unpublish` resurfaces beneath
the moderator's takedown → `isOwnerUnpublishedListing` returns true → the owner regains edit
**and `republishOwnListing`** on a listing a moderator just removed. Pre-arc, the unfiltered
read failed **closed** in exactly that case. This is the inversion.

Both halves are now **hardcoded literals**, so a new verb belongs to neither and has to be
classified out loud. Two independent readings of the same invariant:

- **runtime** — the union assertion goes RED. Proved: with `'suspend'` added at the new tip,
  **155 passed / 1 failed**, killed by
  `🔴 partitions the FULL action taxonomy: status-changing ∪ state-neutral = all, ∩ = ∅`
  and by nothing else.
- **compile-time** — a new `UnclassifiedModerationAction` type is `never` while the
  classification is complete. With `'suspend'` added, `pnpm typecheck` fails **on that line,
  naming the verb**:
  `src/server/services/blocks/app-listing-owner-unpublish.ts(135,7): error TS2322: Type '"suspend"' is not assignable to type 'never'.`
  A test can be skipped or excluded by a `-t` filter; typecheck cannot.

A third assertion pins both halves as **whole literal arrays**, so a member cannot be moved
between them while the partition stays valid. That one is an **invariant guard** — green on
`c049d13683` too — and is labelled as such, not counted as regression coverage.

The derived constant is gone entirely; `STATE_NEUTRAL_MODERATION_ACTIONS` is still exported
because two test files iterate it, and a literal in one place is what makes it non-tautological
in both.

## 🟡 Findings 1 + 2 — a sixth and a seventh copy of the unfiltered read

Both on owner-facing surfaces, both with the same consequence: a state-neutral event newer
than the owner's own `owner-unpublish` becomes "the last action", the client maps
anything-but-`owner-unpublish` to `mod-removed`, and the page says **"removed by a
moderator"** and hides Republish on a listing the server would happily republish. The
triggering moderator workflow — `message-owner`, i.e. *"fix X and republish"* — is the most
natural one this feature has. `claim`, `report-resolve` and `report-dismiss` do the same.

1. **`blocks.router.ts` `listMyPublishRequests`** (`/apps/mine`, on-site apps) now carries
   `action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] }`, matching
   `app-access.service`'s batched read verbatim.
2. **`offsite-listing.service.ts` `listMySubmissions`** — the off-site my-submissions page,
   the primary surface for this feature, and the one read written in raw SQL. The
   `DISTINCT ON` now carries `AND action IN (…)` with the values **bound from the same
   constant** via `Prisma.join`, so there is no second hand-maintained spelling anywhere.

Because the SQL half can only be asserted on **text**, the test pins the **whole normalised
statement**, not a regex feature of it — a partial pattern is satisfied by semantically
inverted SQL, and a `--` comment makes *"the token is present"* and *"the clause is live"*
different facts. A cosmetic reword of that SQL will now fail the test; that is the price of
a machine-readable claim.

## Every read of `AppListingModerationEvent`, enumerated

Not sampled — the whole population, `src/**/*.{ts,tsx}` excluding tests, across Prisma
accessors, the raw-SQL table name, Kysely, and Prisma relation includes (**0** of the last
two exist).

🔴 **Two counting bases run through this PR; the table below is the wider one.** It has six
rows because row 2 is a *delegating caller* of `readLastModerationAction`, not a direct read
of the table. **Direct reads number FIVE** — measured by the ledger's own scanner: 5 files,
5 sites, 4 `filtered` + 1 `full-timeline`, which is why `LEDGER` has five entries. The
"sixth copy" / "seventh copy" labels elsewhere in this PR belong to the arc-wide tally of
open-coded copies (this table's basis), not to a position in the ledger. Both bases are now
named in the test file's header so neither reads as a measured count of the other.

| # | site | question it asks | routes through |
|---|---|---|---|
| 1 | `app-listing-owner-unpublish.ts` `readLastModerationAction` | what explains this removal? | **the constant** (canonical; sites 5–7 of the arc defer to it) |
| 2 | `app-access.service.ts:1389` (authoring context) | same | calls `readLastModerationAction` |
| 3 | `app-access.service.ts:1066` `listMyAppListings` (batched) | same | inline `action: { in: … }` from the constant |
| 4 | `blocks.router.ts:2340` `listMyPublishRequests` | same | **fixed here** (Finding 1) |
| 5 | `offsite-listing.service.ts:3485` `listMySubmissions` (raw SQL) | same | **fixed here** (Finding 2), values bound from the constant |
| 6 | `offsite-moderation.service.ts:1007` `queryModerationEvents` | *the full audit timeline* | **deliberately unfiltered** — a `message-owner` is exactly what the owner is meant to see there |

Site 6 is the only legitimate exception, and the ledger now **states** it rather than leaving
it implicit.

🔴 **Corrected — an earlier version of this paragraph said the new assertion is what makes a
future "tightening" fail a test. It over-read what that assertion does.** The ledger's
full-timeline case runs `readIsFiltered`, which is a NAME-PROXIMITY check: it sees only a
filter spelled with `LISTING_STATUS_CHANGING_MODERATION_ACTIONS`. A `where` clause typed out
by hand — `action: { in: ['delist', 'relist', …] }` — never mentions the constant, so the
ledger stays green while the audit history silently stops showing the owner the moderator's
message. **Measured on the tip: that exact hand-typed filter leaves the ledger file 12/12
green.**

What actually catches it is a pair of **pre-existing** behavioural pins this PR neither adds
nor changes, both in `offsite-moderation.service.mod-actions.test.ts`: the
`listModerationEvents` (mod-scoped) and `listMyListingModerationEvents` (owner-scoped) cases
each assert the **whole** `where` — `expect(args.where).toEqual({ appListingId })` — and both
funnel into this same `queryModerationEvents` read. The same mutation turns exactly those two
red. So the regression *is* guarded; it is guarded by those, not by the new assertion, and
the ledger's docblock now says so. Mutation **L6** below is real but narrower than its label
suggests — it mutates the reader to use the shared constant, which is the only shape
`readIsFiltered` can see.

Strengthening the ledger case to assert the absence of **any** `action` filter (a
`/\baction\s*:\s*\{/` probe) would close the gap structurally. It is a code change, so it is
recorded as a follow-up in the test's own docblock rather than made in a comments-only pass.

## The ledger guard — a seam, not a component

Five direct read sites (six entries in the table above, one of which delegates), found one
round at a time; each was individually reviewed and individually tested, and two of them were
wrong. **The defect was never in a component — it was in the seam nobody owned.**
`listing-mod-event-read-ledger.test.ts` pins the *relationship*: it fails when the set
**grows** (a sixth direct reader) and when it **shrinks** (a stale entry), and each entry
declares which question its reader asks.

Comments are stripped before the proximity check. Without that, the prose documenting each
filtered read satisfies the assertion and deleting the live `action: { in: … }` clause
leaves the guard green — a guard on a *word* rather than on the code. Mutation `L5` is
exactly that case.

It is **structural, therefore not sufficient**: it proves each filtered reader *mentions* the
constant near its read, not that the mention is wired correctly. The behavioural half stays
with each reader.

## Round-2 red-at-base matrix

Tests held at the new tip, the three source files reverted to `c049d13683`
(`git checkout c049d13683 -- <src>`), then the five affected suites run:

```
red at c049d13683 : 9 failed | 102 passed
green at HEAD     : 0 failed | 156 passed
```

The 9: 7 in `blocks.router.listMyPublishRequests.test.ts` (Finding 1) and 2 in
`offsite-listing.edit.service.test.ts` (Finding 2). `app-listing-owner-unpublish.test.ts` is
**green at base** — correctly, because Finding 3's regression evidence is the taxonomy-growth
mutation above, not a base-red assertion, and its whole-array pin is an invariant guard.

## Round-2 mutation battery — re-run in full, 21 mutants, **0 survivors**

The gate resets on a fix round, so nothing is carried forward from round 1.

| # | mutant | verdict |
|---|---|---|
| M1 | **taxonomy growth: `'suspend'` added to `APP_LISTING_MODERATION_ACTIONS`** | **KILLED (1)** — the partition test alone |
| M2 | M1 **plus** the neutral half reverted to the derived complement (the defect, reproduced) | KILLED (1) — by the whole-array pin |
| M3 | `'claim'` dropped from the neutral literal | KILLED (3) |
| M4 | `'claim'` **moved** from neutral into status-changing (partition stays valid) | KILLED (3) — the whole-array pin + the SQL text pin |
| M5 | Finding 1: the action filter deleted from `listMyPublishRequests` | KILLED (7) |
| M6 | Finding 1: shared constant replaced by a hand-typed list missing `'purge'` | KILLED (2) |
| M7 | Finding 1: `in` → `notIn` | KILLED (7) |
| M8 | Finding 2: `AND action IN (…)` deleted from the raw statement | KILLED (2) |
| M9 | Finding 2: **`action IN` → `action NOT IN`** (a `toContain('action IN')` would pass) | KILLED (1) |
| M10 | Finding 2: the clause commented out with `--` (token present, clause dead) | KILLED (2) |
| M11 | Finding 2: `AND` → `OR` | KILLED (1) |
| M12 | Finding 2: the six verbs hand-typed as SQL literals instead of bound | KILLED (2) |
| M13 | Finding 2: `id DESC` tiebreak dropped from the raw `ORDER BY` | KILLED (1) |
| M14 | the action filter deleted from the canonical `readLastModerationAction` | KILLED (9) |
| M15 | `isOwnerUnpublishAction` `===` → `!==` (**positive control** — a mutant known to be caught) | KILLED (54) |
| L1 | ledger: router read un-filtered again | KILLED (1) |
| L2 | ledger: raw SQL un-filtered again | KILLED (1) |
| L3 | ledger: a new file opens a **seventh** read | KILLED (1) |
| L4 | ledger: an entry goes stale (its reader removed) | KILLED (3) |
| L5 | ledger: **filter commented out, the prose naming the constant kept** | KILLED (1) |
| L6 | ledger: the full-timeline reader starts filtering **using the shared constant** | KILLED (1) — but see the correction above: the same tightening *hand-typed* survives the ledger and is killed only by the two pre-existing whole-`where` pins |

**No survivors.** Every mutant is attributed to the specific test that killed it, by name,
and each is reachable — no mutant dies to an earlier check. M2 is the honest one to read
carefully: it reproduces the tautology on demand and is caught by the *new* whole-array pin
rather than by the partition assertion, which is exactly what the tautology means.

Detector-level controls, because a scanner's verdict is a claim about the scanner: the
ledger file carries four negative controls (it finds a planted Prisma read, finds a planted
raw-SQL read, **refuses a comment-only mention**, accepts a real filter) and a positive
control asserting the scan count is non-zero — a detector wired to nothing reports a clean
repo.

## Round-2 verification

- `pnpm typecheck` — **0 errors** (73 s, full repo, submodule initialised). Negative control:
  with `'suspend'` added it reports exactly **1** error, on the compile-time gate's own line.
- Full unit suite (`pnpm test:unit:run`, `--project 'unit*'`) at the pushed tip `d400527c1d` —
  **1456 files passed / 1 skipped (1457); 22,710 passed / 25 skipped / 0 failed.**
  (An earlier run at `a9aadbb7ae`, before the ledger guard existed, gave 22,698 — the +12
  is that file.)
- The five affected suites — **156 passed / 0 failed**; the new ledger guard — **12 passed**.
- `eslint` on all seven changed files: **0 new errors**. The 3 errors it reports are
  pre-existing and untouched (`blocks.router.ts:5429`, `:7990`, and a `vi.mock` factory at
  `blocks.router.listMyPublishRequests.test.ts:27`).

## 🔴 `claim` transfers republish rights — stated, not discovered

`claim` is **state-neutral**, so after this arc it no longer displaces an older
`owner-unpublish`. The consequence is a real behaviour change and it should be on the record:
after a moderator `claim`s an owner-unpublished listing, **the new holder inherits edit *and*
`republishOwnListing`** — capabilities they would not have had before this round, when the
`claim` event was newest and the gate failed closed.

That is defensible: `claim` exists to hand a listing to its **rightful** owner, so the
inherited repair loop lands on the person the action was taken *for*; and a moderator who
wants the listing to stay down has `delist`, which is status-changing and wins. Material
fields remain refused either way. But it is a grant, it is new, and it is being stated rather
than left to be found.

## Out of scope — follow-up with a closing condition

`src/components/Apps/ExternalListingEditForm.tsx` still renders `name`, `externalUrl`,
`contentRating` and `sourceRepoUrl` as **editable** on an owner-unpublished listing, while
the save now hard-fails with `MATERIAL_CHANGE_BLOCKED`. A real UX defect — the user is
offered an input whose only outcome is a refusal — but it is client work and this PR is
server-side, so it is deliberately not fixed here.

*Closing condition:* a merged PR in which those four inputs render **disabled**, carrying the
refusal's reason, on an owner-unpublished listing — checked by that PR's own component tests
going green.


---

# Round 3 — `af3d1ed6d0`, documentation only

A delta re-audit of `d400527c1d` found three prose defects and no code defect. Fixed in one
commit that changes **comments, docblocks and two documentation-only `why` strings** —
no logic, no assertion, no control flow, so nothing here needs a re-audit of behaviour.

| # | defect | fix |
|---|---|---|
| 1 | the deliberate-exception guard's docblock claimed coverage it does not provide | rewritten to describe the name-proximity check it actually performs, cite the two pre-existing whole-`where` pins that really guard the regression, and record the structural strengthening as a follow-up |
| 2 | the whole-arrays pin justified asserting element ORDER by SQL-text determinism | that rationale is **false** — the pinned text is `AND action IN (?,?,?,?,?,?)`, so only the *count* reaches it and the companion `values` assertion derives from the same constant. Corrected to state the review property it does buy |
| 3 | the read-site count said SIX / SEVENTH against a five-entry ledger and a five-site scan | both counting bases named explicitly; every number now says which basis it uses. The arc history is kept, not deleted |

**Proof the change is inert** (each measured, not asserted):

- **AST-level, not eyeballed.** esbuild-stripped output of both files at `af3d1ed6d0` is
  **byte-identical** to `d400527c1d` except the two `why` strings. Comparator controls:
  a `1`→`2` edit reports different, a comment-only edit reports identical.
- **The `why` strings are not asserted on.** Replacing **all five** with a placeholder still
  leaves the ledger suite **12 passed / 12**.
- **Suite counts do not move.** The two edited suites: **46 passed** before, **46 passed**
  after. The whole `src/server/services/blocks/__tests__` directory:
  **153 files / 3541 tests passed** before *and* after (`--no-file-parallelism`; the
  parallel runs hit a Vite dep-optimizer cache race unrelated to this change).
- `prettier --check` clean on both files, with a negative control confirming it can go red;
  `eslint` **0 errors**, 1 pre-existing warning on an untouched line.

**Two measurements made while writing these comments, both reproducing the audit:**

- Swapping `delist`/`relist` in `LISTING_STATUS_CHANGING_MODERATION_ACTIONS` → the SQL text
  pin and the bound-`values` pin stay **GREEN**; exactly **one** test fails, the whole-arrays
  pin. It really is the only thing that sees a reorder.
- Adding a hand-typed `action: { in: [...] }` to `queryModerationEvents` → the ledger file
  stays **12/12 green**; exactly two tests fail, both pre-existing whole-`where` pins in
  `offsite-moderation.service.mod-actions.test.ts`.

*Not verified in this round:* `pnpm typecheck` reports **14 errors before and after, with a
byte-identical error set**, none of them in either edited file. They are all in
`user-hub.service.ts` / `Hubs/*` and come from a stale generated Prisma client in this
verification environment, not from the branch — the round-2 run in a properly-installed
worktree reported 0. The honest claim is "unchanged by this commit", not "0 errors".
