### PR TITLE
ci(cache): reclaim 9.65 GB of the cache budget and cache the vitest transform cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,9 +86,11 @@ name: Lint
 # than as one bad commit.
 #
 # The push path deliberately does NOT run every job here. `eslint` is diff-vs-
-# base by construction and is skipped; so are the three sibling workflows
-# (schema-drift, submodule-pin-guard, windows-dev-env), which are all
-# base-relative gates with nothing to compare against on a push. The consequence
+# base by construction and is skipped; so are the sibling workflows schema-drift
+# and submodule-pin-guard, which are base-relative gates with nothing to compare
+# against on a push. (`windows-dev-env` was in that list and did not belong in
+# it — it is not base-relative, it just never had a push trigger. It gained one
+# on 2026-08-25 to fix an Actions-cache leak; see its header.) The consequence
 # is worth stating rather than leaving implied: the added-file ESLint/Prettier
 # gate and the stray-migrations guard remain reachable only through a PR, so a
 # direct push to `main` still bypasses them. Closing that is a separate change,
@@ -469,6 +471,54 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      # ── VITE PRE-BUNDLE CACHE ───────────────────────────────────────────
+      #
+      # A DIFFERENT cache from the one `setup-node` keeps. `cache: pnpm` above
+      # caches the pnpm STORE — the downloaded packages. This caches what Vite's
+      # dependency optimizer BUILDS out of them.
+      #
+      # What is in there, measured 2026-08-25 on a warm local checkout rather
+      # than assumed: `node_modules/.vite` is 302 MB, all of it under
+      # `.vite/vitest/<project-config-hash>/{deps,deps_ssr}` — esbuild pre-bundles
+      # — plus a few hundred KB of `results.json`. It is NOT per-test-file output,
+      # which is why the key below does not mention the shard's file list: the
+      # content is a function of the dependency set and the Vitest config, so
+      # `pnpm-lock.yaml` is the right thing to key on.
+      #
+      # Every one of the 4 shards rebuilds this from cold on every PR today, and
+      # nothing in the repo caches it. (Do not reach for the `optimizeDeps`
+      # pre-bundle list in vitest.config.mts as prior art here: that block belongs
+      # to the `component` project, which this job does not run. It moves WHEN the
+      # optimize pass happens within a run; it does not carry anything between
+      # runs.)
+      #
+      # 🔴 RESTORE ALWAYS, SAVE ONLY ON `main`, and that asymmetry is the whole
+      # design rather than a tuning choice. An Actions cache saved by a PR run is
+      # scoped to `refs/pull/N/merge`, readable by NOTHING else, and counts
+      # against the same 10 GB repo budget as everything useful. Saving from PRs
+      # would mint 4 dead entries per open PR — the exact leak this PR's sibling
+      # change exists to clean up (20 orphans, 9.65 GB, 95.3% of the budget).
+      # Saving only on `main` keeps this at FOUR entries total, restorable by
+      # every PR because a PR can read its base branch's scope.
+      #
+      # Budget: 4 x 302 MB = 1.21 GB worst case, and that is an over-estimate
+      # twice over — the 302 MB is the full local project set (this job runs
+      # `--project unit*`, a subset) and Actions compresses on upload.
+      #
+      # A PR that changes `pnpm-lock.yaml` misses the exact key and falls back to
+      # the prefix, restoring the previous lockfile's bundles; Vite validates its
+      # own optimizer metadata and re-optimizes what actually moved. It then
+      # saves nothing, so that PR pays cold-ish cost until it merges. That is the
+      # correct trade: lockfile changes are rare and per-PR entries are the bug.
+      - name: Restore Vite pre-bundle cache
+        id: vite-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules/.vite
+          key: vite-unit-${{ runner.os }}-${{ runner.arch }}-${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            vite-unit-${{ runner.os }}-${{ runner.arch }}-${{ matrix.shard }}-
+
       # `scripts/test-unit-run.mjs` forwards process.argv.slice(2) straight into
       # `vitest run --project unit* ...args`, and its queueDecision() returns
       # early on CI, so the dev-server queue never sees this.
@@ -514,6 +564,27 @@ jobs:
         # of the run that shipped the `--` bug.
         if: ${{ !cancelled() }}
         run: node scripts/ci/assert-shard-ran.mjs unit-report.json ${{ matrix.shard }} 4
+
+      # See the restore step for why this is `main`-only. Three further details:
+      #
+      #   `!cancelled()` rather than the default — a RED suite still produced a
+      #     valid set of pre-bundles, and refusing to save them would mean a
+      #     single red commit on `main` leaves every subsequent PR cold.
+      #   `cache-hit != 'true'` — an exact-key hit means this content is already
+      #     stored under this key, so re-uploading ~300 MB would buy nothing. A
+      #     PREFIX hit leaves this false, which is right: that content belongs to
+      #     a different lockfile and does want re-saving under the new key.
+      #   `continue-on-error` — a cache save is best-effort infrastructure. Two
+      #     shards can race the same key, and the loser reports "another job may
+      #     be creating this cache". That must not red a commit on `main`, where
+      #     this job is no longer report-only.
+      - name: Save Vite pre-bundle cache
+        if: ${{ !cancelled() && github.event_name == 'push' && steps.vite-cache.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: node_modules/.vite
+          key: vite-unit-${{ runner.os }}-${{ runner.arch }}-${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml') }}
 
   packages:
     name: Package unit tests

--- a/.github/workflows/windows-dev-env.yml
+++ b/.github/workflows/windows-dev-env.yml
@@ -24,10 +24,11 @@ name: Windows dev-env smoke
 # the TODO above was Git-Bash-specific. A pwsh-only job would not reproduce it, and
 # would report green over the one case we have written evidence about.
 #
-# DELIBERATELY NON-BLOCKING (`continue-on-error: true`) to start. A gate that lands
-# red on day one and stops unrelated PRs trains everyone to click through, which is
-# strictly worse than no gate. Turn it off once this has been green long enough to
-# mean something.
+# DELIBERATELY NON-BLOCKING ON PULL REQUESTS to start. A gate that lands red on day
+# one and stops unrelated PRs trains everyone to click through, which is strictly
+# worse than no gate. Turn it off once this has been green long enough to mean
+# something. It is NOT non-blocking on a push to `main` — see the job's
+# `continue-on-error` comment for why the two cases differ.
 #
 # DELIBERATELY NOT starting the compose stack: those are Linux containers, and
 # Docker on Windows runners is slow and flaky — it would buy noise, not signal.
@@ -36,23 +37,70 @@ name: Windows dev-env smoke
 #
 # COST: `windows-latest` is a standard GitHub-hosted runner, which is free for
 # public repositories. This adds no Actions minutes.
+#
+# ── ALSO RUNS ON PUSH TO `main`, AND THAT IS A CACHE FIX ─────────────────────
+#
+# `setup-node` with `cache: pnpm` writes an Actions cache entry keyed
+# `node-cache-Windows-x64-pnpm-<lockfile-hash>`. Actions caches are SCOPED TO A
+# REF: a PR run can READ an entry saved on its base branch, but it cannot read
+# one saved on another PR, and it saves into its own `refs/pull/N/merge` scope.
+#
+# With this workflow `pull_request`-only there was no entry on `refs/heads/main`
+# for a PR to restore from, so EVERY PR missed, re-resolved the whole store and
+# then saved its own ~518 MB copy under the same key in its own scope. Measured
+# 2026-08-25: 20 such copies, one per open PR, 9.65 GB — 95.3% of the repo's
+# 10 GB cache budget, against ONE 511 MB Linux entry on `main` from `lint.yml`.
+# The repo was over the limit, so LRU eviction was live and was evicting the
+# useful entries to keep 20 identical useless ones.
+#
+# `lint.yml` never had this problem, and the reason is exactly the leg added
+# below: it has a `push: [main]` trigger, so one base-branch entry serves every
+# PR and no PR ever saves its own. This makes that true here too. One entry,
+# reused by every PR, refreshed whenever `main` moves.
+#
+# The two matrix shells share one cache key (same OS, arch and lockfile), so on
+# `main` they race to save it and one logs "another job may be creating this
+# cache". That is the intended outcome — one entry is the point — not a defect.
+#
+# Nothing in this workflow reads `github.base_ref` or `github.event.pull_request`
+# (both are empty/null on a push), so no step needs gating. That is not luck:
+# `scripts/__tests__/main-branch-ci-coverage.test.ts` asserts it as a repo-wide
+# relationship over every push-reachable job.
 
 on:
   pull_request:
     branches: [main, release]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
 
+# On a PR, unchanged: `github.ref` is `refs/pull/N/merge`, so a new push to the
+# branch cancels the in-flight run.
+#
+# On a push to `main` it MUST NOT be `github.ref` — that is one group for the
+# whole branch, so a busy `main` would cancel its own runs and only the last
+# commit would ever be checked (and the losers would render as `cancelled`,
+# which is indistinguishable from a real failure). Same expression as `lint.yml`,
+# for the same reason, and pinned by the same test.
 concurrency:
-  group: windows-dev-env-${{ github.ref }}
+  group: windows-dev-env-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
   smoke:
     name: Windows dev-env (${{ matrix.shell }})
     runs-on: windows-latest
-    continue-on-error: true
+    # REPORT-ONLY ON PULL REQUESTS, REAL VERDICT ON `main` — the same split
+    # `lint.yml`'s `unit` job makes, for the same reason. The header's
+    # non-blocking rationale is explicitly about not stopping UNRELATED PRs over
+    # a canary that might be red on day one. On a push the merge has already
+    # happened, so there is no unrelated work to stop and nothing to block; what
+    # `continue-on-error: true` would buy there is a run reporting `success`
+    # while the step underneath failed, which is a green that has to be
+    # disbelieved. `main` carries no required_status_checks either way.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     timeout-minutes: 25
     strategy:
       fail-fast: false


### PR DESCRIPTION
## The measurement

`gh api repos/civitai/civitai/actions/cache/usage` today:

| | |
|---|---|
| entries | **21** |
| bytes | **10,878,231,374** |
| per-repo limit | **10 GB** |

We are **over the limit**, so LRU eviction is live — GitHub is throwing entries away to make room.

There are exactly **two** cache keys in the repo, same content hash, differing only by OS:

| key | copies | scope | size |
|---|---|---|---|
| `node-cache-Linux-x64-pnpm-428a04cc…` | 1 | `refs/heads/main` | 511 MB |
| `node-cache-Windows-x64-pnpm-428a04cc…` | **20** | 20 different `refs/pull/N/merge` | ~518 MB each |

That second row is **9.65 GB — 95.3% of the entire budget**, spent on twenty byte-equivalent copies of one thing. The one entry that is actually reused by every PR (the Linux one) is competing for space against them.

## The mechanism

An Actions cache entry is **scoped to a ref**. A PR run can *read* an entry saved on its base branch, but it cannot read one saved by another PR, and anything it saves goes into its own `refs/pull/N/merge` scope.

`.github/workflows/windows-dev-env.yml` triggers on `pull_request` **only**. So there was no entry on `refs/heads/main` for a PR to restore from:

1. PR opens → `setup-node`'s `cache: pnpm` looks for `node-cache-Windows-x64-pnpm-<lockhash>` → **miss**, because the only copies live in other PRs' scopes.
2. The run resolves the store from scratch and saves its own ~518 MB copy into *its* scope.
3. That copy is now unreadable by anything, forever, and occupies 5% of the budget until it is evicted or the PR closes.
4. Repeat per open PR. Twenty open PRs, twenty copies.

`.github/workflows/lint.yml` never had this problem, and the reason is exactly the fix: it has a `push: [main]` leg, so one base-branch entry exists and every PR restores from it.

## Change 1 — give `windows-dev-env.yml` a push-to-`main` leg

One entry on `main`, refreshed whenever `main` moves, restorable by every PR. No PR ever saves its own again.

Adding a push trigger pulls the workflow into the scope of `scripts/__tests__/main-branch-ci-coverage.test.ts`, which asserts repo-wide properties over every push-reachable job. Two of them applied, and both are fixed here rather than worked around:

- **Concurrency group must vary per commit.** It was `windows-dev-env-${{ github.ref }}` — one group for the whole branch, so a busy `main` would cancel its own runs and only the last commit would ever be checked (and the losers render as `cancelled`, which is indistinguishable from a real failure). Now the same expression `lint.yml` uses.
- **No unconditionally report-only job on the push path.** The job was `continue-on-error: true`. On a push that buys a run reporting `success` while the step underneath failed — a green that has to be disbelieved. It is now `${{ github.event_name == 'pull_request' }}`: still report-only on PRs, which is what the workflow header actually argues for (*"a gate that lands red on day one and stops **unrelated PRs**"* — on a push the merge has already happened, so there is no unrelated work to stop and nothing to block), and honest on `main`. Neither `main` nor `release` carries required status checks either way.

**Checked the `github.event.pull_request` class explicitly**, per the long comment in `lint.yml`: no step in `windows-dev-env.yml` reads `github.base_ref` or `github.event.pull_request`. It is not a base-relative gate — it checks out, installs, and asserts an artifact. (A stale line in `lint.yml`'s header listed it among the "base-relative sibling gates"; that was never true of this one, and is corrected in the diff.)

Cost: the two-shell matrix also runs on each push to `main`. `windows-latest` is free for public repositories. Both shells share one cache key, so on `main` they race to save it and the loser logs *"another job may be creating this cache"* — one entry is the point, so that is the intended outcome.

## Change 2 — cache `node_modules/.vite` on the `unit` shards

**What is actually in there**, measured on a warm local checkout rather than assumed: **302 MB**, all of it under `node_modules/.vite/vitest/<project-config-hash>/{deps,deps_ssr}` — esbuild pre-bundles from Vite's dependency optimizer — plus a few hundred KB of `results.json`. It is **not** per-test-file output. That is why the key is `pnpm-lock.yaml` + OS + arch and does not mention the shard's file list: the content is a function of the dependency set and the Vitest config.

This is a **different** cache from the one `setup-node` already keeps. `cache: pnpm` caches the pnpm *store* — the downloaded packages. This caches what the optimizer *builds out of* them. All four shards rebuild it from cold on every PR today and nothing in the repo caches it.

### Why restore-always / save-only-on-`main` — the justification

The obvious implementation (`actions/cache@v4`, which restores and saves) is the **exact bug this PR exists to fix**: every PR would mint four more entries in its own dead `refs/pull/N/merge` scope. Four per open PR is worse than the twenty-entry leak above.

So the steps are split:

- `actions/cache/restore@v4` — **always**, on PRs and pushes alike. A PR reads its base branch's scope, which is where the entries live.
- `actions/cache/save@v4` — **only when `github.event_name == 'push'`**, i.e. only on `main`.

Result: **four entries, total, ever** (one per shard), reused by every PR.

Budget:

| | |
|---|---|
| worst case | 4 × 302 MB = **1.21 GB** |
| plus the two `node-cache-*` entries | ~1.03 GB |
| **total after this lands** | **~2.2 GB of 10 GB** |

And 1.21 GB over-estimates it twice over: the 302 MB is the full *local* project set including the browser `component` project, while this job runs `--project unit*`; and Actions compresses on upload.

Three smaller decisions, each with a reason:

- **`!cancelled()` on the save** — a red suite still produced a valid set of pre-bundles. Skipping the save on red would mean one bad commit on `main` leaves every subsequent PR cold.
- **`cache-hit != 'true'`** — an exact-key hit means the content is already stored under that key, so re-uploading ~300 MB buys nothing. A *prefix* hit leaves this `false`, which is correct: that content belongs to a different lockfile and does want re-saving under the new key.
- **`continue-on-error` on the save step** — a cache save is best-effort infrastructure; two shards racing a key must not red a commit on `main`, where this job is no longer report-only. (Step-level only. The job-level setting is untouched.)

A PR that changes `pnpm-lock.yaml` misses the exact key, falls back to the `restore-keys` prefix, and gets the previous lockfile's bundles; Vite validates its own optimizer metadata and re-optimizes what moved. It saves nothing, so it pays cold-ish cost until it merges. That is the right trade — lockfile changes are rare and per-PR entries are the bug.

### Deliberately not done

The `packages` and `apps` jobs run in ~15s and ~7s respectively. Adding a ~300 MB restore to each would plausibly cost more wall-clock than the transform work it skips, for two more entries of budget. Not worth it; left alone.

## Expected post-merge state

| | now | after |
|---|---|---|
| entries | 21 | **~2**, then ~6 once the vite caches populate |
| bytes | 10.88 GB (over limit) | ~1.03 GB, then ~2.2 GB |
| eviction pressure | active | none |

The first `main` push after merge saves the Windows entry; from then on every PR restores it instead of minting its own. The four vite entries appear on the same push.

The 20 existing orphaned Windows entries do not expire on their own quickly enough to be worth waiting for — **they are being deleted separately by the operator via `gh api`.** No reaper step is added here on purpose: a scheduled cache-deleting job is a standing footgun for a one-time cleanup, and the leak that generated them is closed by change 1.

## Verification

- **`actionlint` clean** on both files. Validated as an instrument first: a deliberately broken copy (an undefined `github.*` context in a step input) is reported with a caret and a non-zero exit, so the clean run is not a wiring failure.
- Both files parse as YAML.
- **`scripts/__tests__/main-branch-ci-coverage.test.ts`: 6/6 green.** Also mutation-checked rather than merely run — reverting the concurrency group to `github.ref` and `continue-on-error` to literal `true` turns exactly those two assertions red, each with its own message, and green again on restore. So the guard sees this file and those two edits were load-bearing, not defensive.
- **Explicitly confirmed the test jobs' trigger surface is unchanged.** `unit`, `packages` and `apps` carry **no job-level `if:`** before or after this change (verified by parsing the workflow, not by eye), so all three still run on every PR to `main` and `release`. That property is load-bearing — the in-cluster Tekton duplicates of those three suites were retired on the understanding that Actions covers every PR — and nothing here touches it. The only job-level conditions in the file remain `eslint` (`pull_request` only) and `typecheck` (its three-disjunct gate), both untouched.
- One comment claim was corrected while writing this rather than restated: an earlier draft cited `vitest.config.mts`'s `optimizeDeps` list as prior art for the vite cache. Read at HEAD, that block belongs to the `component` project, which this job does not run, and it moves *when* the optimize pass happens within a run rather than carrying anything between runs. The comment now says so, so the next reader does not go looking for a cache that is not there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
