### PR TITLE
fix(app-listings): re-derive media maturity when an owner republishes their own listing

### DIFF
--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 
-import { APP_LISTING_REPORT_REASONS } from '~/server/schema/blocks/offsite-moderation.schema';
+import { NsfwLevel } from '~/server/common/enums';
 
 import {
   OffsiteModerationError,
@@ -44,9 +44,8 @@ type WriteMock = {
   };
   appListingReport: {
     updateMany: ReturnType<typeof vi.fn>;
-    // The on-site over-rated-media review queue: republish check-then-inserts an
-    // advisory `AppListingReport` in the SAME tx as the status flip.
-    findFirst: ReturnType<typeof vi.fn>;
+    // Spied ONLY so the removal guard can assert republish files no advisory report —
+    // an earlier revision of the rating change queued one for over-rated on-site media.
     create: ReturnType<typeof vi.fn>;
   };
   // claim validates the target owner on the primary inside the tx.
@@ -91,8 +90,6 @@ const { mockRead, mockWrite, mockNotify, mockLogToAxiom, ids } = vi.hoisted(() =
     },
     appListingReport: {
       updateMany: vi.fn(async () => ({ count: 1 })),
-      // Default: no OPEN review for this listing+reporter → the queue write proceeds.
-      findFirst: vi.fn(async (): Promise<{ id: string } | null> => null),
       create: vi.fn(async (a: { data: unknown }) => a.data),
     },
     user: { findUnique: vi.fn(async () => ({ id: 1 })) },
@@ -1787,7 +1784,7 @@ describe('OffsiteModerationError (PR3/PR4 + W13 codes)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 🔴 republishOwnListing — GO-LIVE MATURITY GATE (kind-aware).
+// 🔴 republishOwnListing — GO-LIVE RATING FLOOR (UNIFORM, both kinds).
 //
 // The hole this closes: republish is an OWNER-driven go-live with NO human in the
 // loop, and a `removed` listing is directly asset-editable. The attach path rejects
@@ -1796,19 +1793,15 @@ describe('OffsiteModerationError (PR3/PR4 + W13 codes)', () => {
 // republish` put mature store art back under an unchanged declared rating, which
 // passes `listingMatureFilter(redCapable=false)` (`content_rating NOT IN ('r','x')`).
 //
-// KIND-AWARE by design:
-//   OFF-SITE → RAISE the stored rating to the media-derived one (raise-only).
-//   ON-SITE  → do NOT raise (the rating mirrors `AppBlock.content_rating`); allow the
-//              republish and queue an advisory `AppListingReport` for a moderator.
+// UNIFORM BY DESIGN — the floor is applied identically to BOTH kinds, matching the
+// on-site draft go-live (`publish-request.service.ts`, "🔴 RATING FLOOR (go-live)")
+// which already runs the manifest-declared rating through THIS SAME helper. The raise
+// targets `AppListing.contentRating` (the store card); the runtime serving gate reads
+// `AppBlock.contentRating`, a separate column.
 //
-// 🔴 COVERAGE HONESTY. Of the 15 cases below, SEVEN are RED at `origin/main` and green
-// at HEAD — those are the regression coverage:
-//   off-site ABOVE · on-site ABOVE (+ its CHECK-set case) · screenshots-contribute ·
-//   idempotence · fail-closed · transactional.
-// The other EIGHT are green at `origin/main` too and are labelled `[INVARIANT GUARD]`:
-// they pin behaviour this change must NOT alter (raise-only never lowers, no-assets,
-// absent row, the pre-existing scan gate, the mod relist path). They are preservation
-// guards and are deliberately NOT counted as regression coverage.
+// 🔴 COVERAGE HONESTY. Cases labelled `[INVARIANT GUARD]` are green at `origin/main`
+// too — they pin behaviour this change must NOT alter and are deliberately NOT counted
+// as regression coverage. Everything else is RED at `origin/main`.
 //
 // Levels are the REAL enum (`src/server/common/enums.ts`): PG=1, PG13=2, R=4, X=8.
 // The ladder is `['g','pg','pg13','r','x']`; `deriveContentRatingFromAssets` picks the
@@ -1816,29 +1809,31 @@ describe('OffsiteModerationError (PR3/PR4 + W13 codes)', () => {
 // exactly the two values `listingMatureFilter` hides, which is why the fixtures use
 // them rather than the level-2 art that happens to be live today.
 // ---------------------------------------------------------------------------
-describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
+describe('republishOwnListing — go-live RATING FLOOR (uniform, both kinds)', () => {
   /** Pairwise-distinct asset ids, so a wrong-bind mutant cannot alias two of them. */
   const ICON_ID = 101;
   const COVER_ID = 202;
   const SHOT_ID = 303;
-  /** Real `NsfwLevel` members — not magic numbers. */
-  const LVL_PG = 1;
-  const LVL_PG13 = 2;
-  const LVL_R = 4;
-  const LVL_X = 8;
+  /**
+   * DERIVED from the enum, not hand-typed. A local `const LVL_R = 4` is a guard spelled
+   * rather than structural: it keeps passing after the enum's bits move, and the test
+   * would then be asserting a ladder position that no longer exists.
+   * `~/server/common/enums` has ZERO imports of its own, so this pulls no module graph.
+   */
+  const LVL_NONE = 0;
+  const LVL_PG = NsfwLevel.PG;
+  const LVL_PG13 = NsfwLevel.PG13;
+  const LVL_R = NsfwLevel.R;
+  const LVL_X = NsfwLevel.X;
 
-  function ownerPrimary(opts: {
-    kind: string;
-    contentRating: string | null;
-    appBlockId?: string | null;
-  }) {
+  function ownerPrimary(opts: { kind: string; contentRating: string | null }) {
     return {
       userId: OWNER,
       status: 'removed',
       kind: opts.kind,
       slug: SLUG,
       name: 'Cool App',
-      appBlockId: opts.appBlockId ?? (opts.kind === 'onsite' ? BLOCK_ID : null),
+      appBlockId: opts.kind === 'onsite' ? BLOCK_ID : null,
       contentRating: opts.contentRating,
       externalUrl: opts.kind === 'offsite' ? EXTERNAL_URL : null,
       connectClientId: null,
@@ -1846,15 +1841,22 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
   }
 
   /**
-   * Wire the three `appListing.findUnique` reads republish performs, in order:
-   *   1. `loadOwnedListingInTx`      → the owned-listing snapshot (with contentRating)
+   * Wire the FOUR `appListing.findUnique` reads republish performs, in order:
+   *   1. `loadOwnedListingInTx`             → the owned-listing snapshot (+ contentRating)
    *   2. `assertListingAssetsScanCleanInTx` → the asset ids for the scan gate
-   *   3. `resolveListingRatingFloorInTx`    → the asset ids for the maturity derive
-   * plus the screenshot + image reads BOTH (2) and (3) share.
+   *   3. `assertOffsiteListingActionableInTx` → kind/slug/externalUrl/connectClientId
+   *   4. `resolveListingRatingFloorInTx`    → the asset ids for the maturity derive
+   * plus the screenshot + image reads (2) and (4) share.
+   *
+   * 🔴 The blanket shape carries `kind`/`slug`/`externalUrl`/`connectClientId` as well
+   * as the asset ids. Without them read (3) sees `kind: undefined`, and
+   * `checkOffsiteListingActionable` returns `skipped` on `kind !== 'offsite'` — i.e. a
+   * thinner fixture SILENTLY DISARMS the actionability gate and the floor would only
+   * ever be reached past a gate that never ran. Carrying them makes the floor reachable
+   * on an input no earlier check rejects, which is the point.
    *
    * `levels` maps image id → nsfwLevel; every image also carries `ingestion` so the
-   * pre-existing scan gate is satisfied and the maturity code is REACHABLE (an input
-   * no earlier check rejects).
+   * pre-existing scan gate is satisfied.
    */
   function wire(opts: {
     kind: string;
@@ -1872,14 +1874,18 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
     const ingestion = opts.ingestion ?? 'Scanned';
 
     // 🔴 Re-established on EVERY wire(), not left to `beforeEach`: `vi.clearAllMocks()`
-    // clears call history but NOT implementations, so a `mockResolvedValue` set by an
-    // earlier test leaks forward. That leak silently disarmed the transactional test
-    // (the idempotence test's "an open review exists" stub made the queue write a
-    // no-op, so nothing could throw) — a green-for-the-wrong-reason, caught only
-    // because the assertion happened to be a rejection.
-    mockWrite.appListingReport.findFirst.mockResolvedValue(null);
+    // clears call history but NOT implementations, so a `mockResolvedValue` /
+    // `mockImplementation` set by an earlier test leaks forward and can silently disarm
+    // a later one (green for the wrong reason).
     mockWrite.appListingReport.create.mockImplementation(async (a: { data: unknown }) => a.data);
-    mockWrite.appListing.findUnique.mockResolvedValue({ iconId: icon, coverId: cover });
+    mockWrite.appListing.findUnique.mockResolvedValue({
+      iconId: icon,
+      coverId: cover,
+      kind: opts.kind,
+      slug: SLUG,
+      externalUrl: opts.kind === 'offsite' ? EXTERNAL_URL : null,
+      connectClientId: null,
+    });
     mockWrite.appListing.findUnique.mockResolvedValueOnce(
       ownerPrimary({ kind: opts.kind, contentRating: opts.contentRating })
     );
@@ -1901,137 +1907,138 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
     return call?.[0]?.data;
   }
 
-  // ---- OFF-SITE × media-vs-declared -------------------------------------------------
+  const KINDS = ['offsite', 'onsite'] as const;
 
-  it('[INVARIANT GUARD — green at origin/main] OFF-SITE, media BELOW declared → rating UNCHANGED (raise-only never lowers)', async () => {
-    // Max asset level R(4) → derived 'r'; declared 'x' (level 8) is HIGHER, so a
-    // raise-only floor must leave it alone. A lower-vs-raise inversion mutant would
-    // write 'r' here and lose a deliberately mature rating.
-    wire({
-      kind: 'offsite',
-      contentRating: 'x',
-      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG },
-    });
-    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
-    expect(flipData()).toEqual({ status: 'approved' });
-    expect(flipData()).not.toHaveProperty('contentRating');
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
-  });
+  // ---- The floor, applied IDENTICALLY to both kinds ---------------------------------
 
-  it('[INVARIANT GUARD — green at origin/main] OFF-SITE, media EQUAL to declared → rating UNCHANGED (no needless write)', async () => {
-    // Max R(4) → derived 'r' === declared 'r'. Strict-inequality boundary: a `>` → `>=`
-    // mutant in the floor would still produce 'r', but the ABOVE case below pins the
-    // raise, and this pins that EQUAL does not emit a contentRating key at all.
+  it.each(KINDS)(
+    '%s: media BELOW declared → floored value is the DECLARED rating (raise-only never lowers)',
+    async (kind) => {
+      // Max asset level R(4) → derived 'r'; declared 'x' (level 8) is HIGHER, so the
+      // raise-only floor must return 'x'. A lower-vs-raise inversion would write 'r'
+      // here and silently drop a deliberately mature rating; a wrong-bind that passed
+      // anything other than the declared rating as the floor's third argument would
+      // also land on 'r'.
+      wire({
+        kind,
+        contentRating: 'x',
+        levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG },
+      });
+      const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+      expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+      expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
+    }
+  );
+
+  it.each(KINDS)('%s: media EQUAL to declared → floored value is unchanged', async (kind) => {
+    // Max R(4) → derived 'r' === declared 'r'. Pins the strict-inequality boundary from
+    // the equal side: the value written is still 'r', never a neighbour.
     wire({
-      kind: 'offsite',
+      kind,
       contentRating: 'r',
       levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG13 },
     });
     await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(flipData()).toEqual({ status: 'approved' });
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'r' });
   });
 
-  it('🔴 OFF-SITE, media ABOVE declared → rating RAISED to the derived value', async () => {
+  it.each(KINDS)('%s: media ABOVE declared → rating RAISED to the derived value', async (kind) => {
     // THE DEFECT. Declared 'g' with X(8) cover art: pre-fix this went live as 'g' and
     // `content_rating NOT IN ('r','x')` showed it to SFW-only users.
     wire({
-      kind: 'offsite',
+      kind,
       contentRating: 'g',
       levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
     });
     await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
-    // Off-site is fixed by the raise alone — it must NOT also spend a moderator slot.
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+    // 🔴 The derive is scoped to THIS listing. Asserted over EVERY screenshot read, not
+    // via `toHaveBeenCalledWith` — the scan gate makes the same call with the same id
+    // one step earlier, so a "was it ever called with APP_ID" matcher is satisfied by
+    // the NEIGHBOURING call and an id wrong-bind in the floor survives it. (Measured: it
+    // did survive, as a mutant passing `listing.slug`.)
+    const shotCalls = mockWrite.appListingScreenshot.findMany.mock.calls;
+    expect(shotCalls.length).toBeGreaterThan(1);
+    for (const [args] of shotCalls) expect(args?.where?.appListingId).toBe(APP_ID);
   });
 
-  // ---- ON-SITE × media-vs-declared --------------------------------------------------
-
-  it('[INVARIANT GUARD — green at origin/main] ON-SITE, media BELOW declared → republishes normally, rating untouched, NO queue entry', async () => {
-    wire({
-      kind: 'onsite',
-      contentRating: 'x',
-      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG },
-    });
-    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
-    expect(flipData()).toEqual({ status: 'approved' });
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
-    // The backing block is still restored — the maturity gate must not disturb that.
-    expect(mockWrite.appBlock.updateMany).toHaveBeenCalled();
+  it('🔴 PARITY: the two kinds produce a BYTE-IDENTICAL flip payload for the same media', async () => {
+    // The kind axis is GONE. This is the case a re-introduced `kind`/`isOnsite` branch
+    // in the rating path dies on — the per-kind cases above would each still pass if
+    // one kind silently stopped being floored only when read in isolation, so compare
+    // the two payloads directly.
+    const payloads: Record<string, unknown> = {};
+    for (const kind of KINDS) {
+      vi.clearAllMocks();
+      mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+      mockWrite.appBlock.updateMany.mockResolvedValue({ count: 1 });
+      mockWrite.appListingModerationEvent.create.mockImplementation(
+        async (a: { data: unknown }) => a.data
+      );
+      wire({
+        kind,
+        contentRating: 'g',
+        levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+      });
+      await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+      payloads[kind] = flipData();
+    }
+    expect(payloads.onsite).toEqual(payloads.offsite);
+    expect(payloads.onsite).toEqual({ status: 'approved', contentRating: 'x' });
   });
 
-  it('[INVARIANT GUARD — green at origin/main] ON-SITE, media EQUAL to declared → republishes normally, NO queue entry', async () => {
-    wire({
-      kind: 'onsite',
-      contentRating: 'r',
-      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG13 },
-    });
-    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(flipData()).toEqual({ status: 'approved' });
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
-  });
+  it.each(KINDS)(
+    '%s: a deliberately HIGHER declared rating is never lowered by TAME media',
+    async (kind) => {
+      // Every asset is SFW (max PG13(2) → derived 'pg13'); the declaration is 'x'. This
+      // is the strongest form of the raise-only contract — the gap is three ladder rungs,
+      // so a comparison-direction flip cannot land back on 'x' by coincidence.
+      wire({
+        kind,
+        contentRating: 'x',
+        levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_PG13, [SHOT_ID]: LVL_NONE },
+      });
+      await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+      expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
+    }
+  );
 
-  it('🔴 ON-SITE, media ABOVE declared → stored rating UNCHANGED (manifest mirror) + queue entry created', async () => {
-    // The kind-aware half. An on-site listing's rating mirrors AppBlock.content_rating,
-    // so it is deliberately NOT auto-raised — a kind-branch-inversion mutant would
-    // write contentRating here and break the manifest-mirror invariant.
-    wire({
-      kind: 'onsite',
-      contentRating: 'g',
-      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
-    });
-    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
-    // INVARIANT: the rating is NOT raised.
-    expect(flipData()).toEqual({ status: 'approved' });
-    expect(flipData()).not.toHaveProperty('contentRating');
-    // ...and a moderator IS queued.
-    expect(mockWrite.appListingReport.create).toHaveBeenCalledTimes(1);
-    const queued = mockWrite.appListingReport.create.mock.calls[0][0].data;
-    expect(queued).toMatchObject({
-      appListingId: APP_ID,
-      reporterUserId: OWNER,
-      reason: 'inappropriate',
-      status: 'pending',
-    });
-    // The details string names the DERIVED rating first and the DECLARED second — a
-    // wrong-bind mutant that swaps them produces a plausible sentence, so pin both
-    // fragments positionally rather than merely asserting the two words appear.
-    expect(queued.details).toContain('media rated "x"');
-    expect(queued.details).toContain('declared content rating of "g"');
-  });
-
-  it('ON-SITE over-rated: the queue reason is a member of the CHECK-constrained reason set', async () => {
-    // A value outside the DB CHECK (impersonation|phishing-malware|broken|
-    // inappropriate|spam|other) would be rejected at 23514 in production, where the
-    // mock happily accepts anything.
-    wire({
-      kind: 'onsite',
-      contentRating: 'g',
-      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_PG13 },
-    });
-    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    const queued = mockWrite.appListingReport.create.mock.calls[0][0].data;
-    expect(APP_LISTING_REPORT_REASONS as readonly string[]).toContain(queued.reason);
-    expect(['pending', 'resolved', 'dismissed']).toContain(queued.status);
-  });
+  it.each(KINDS)(
+    '%s: a NULL declared rating with tame media stays NULL (never stamped `g`)',
+    async (kind) => {
+      // 🔴 The strict-inequality boundary, from the only side that can observe it.
+      // `nsfwLevelFromContentRating` maps BOTH `null` and `'g'` to the SFW floor PG(1),
+      // so with tame media `derived === 'g'` ties the declared `null` on level. A
+      // `>` → `>=` mutant then returns `'g'` and silently stamps a rating onto a listing
+      // that had none. Every OTHER case in this block ties nowhere and cannot see it —
+      // measured: without this case that mutant was killed only by a PRE-EXISTING test
+      // elsewhere in the file, i.e. it survived this PR's own coverage.
+      wire({
+        kind,
+        contentRating: null,
+        levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_NONE, [SHOT_ID]: LVL_PG },
+      });
+      await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+      expect(flipData()).toEqual({ status: 'approved', contentRating: null });
+    }
+  );
 
   // ---- Edge cases -------------------------------------------------------------------
 
-  it('[INVARIANT GUARD — green at origin/main] listing with NO attached assets → rating unchanged, no queue entry, no crash', async () => {
+  it('listing with NO attached assets → declared rating preserved, no crash', async () => {
     wire({ kind: 'offsite', contentRating: 'g', icon: null, cover: null, shots: [] });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
-    expect(flipData()).toEqual({ status: 'approved' });
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'g' });
+    // The helper short-circuits before the image read — a mutant that dropped that
+    // guard would derive 'g' from an empty set and coincidentally agree, so pin the
+    // read count too.
+    expect(mockWrite.image.findMany).not.toHaveBeenCalled();
   });
 
-  it('[INVARIANT GUARD — green at origin/main] absent listing row on the FLOOR read → declared rating preserved, republish still succeeds', async () => {
+  it('absent listing row on the FLOOR read → declared rating preserved, republish still succeeds', async () => {
     // The floor helper returns `declaredRating` when its own findUnique misses (a race
-    // with a concurrent purge). Pre-existing behaviour must survive.
+    // with a concurrent purge). Pre-existing helper behaviour must survive the new call.
     mockWrite.appListing.findUnique.mockResolvedValue(null);
     mockWrite.appListing.findUnique.mockResolvedValueOnce(
       ownerPrimary({ kind: 'offsite', contentRating: 'pg13' })
@@ -2041,56 +2048,33 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
     });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
-    expect(flipData()).toEqual({ status: 'approved' });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'pg13' });
   });
 
   it('🔴 SCREENSHOTS contribute to the derived max, not just icon/cover', async () => {
     // Icon and cover are both tame; the ONLY mature asset is a screenshot. A mutant
     // that derives from `[iconId, coverId]` and drops the screenshot spread survives
-    // every icon/cover-driven case above and dies here.
+    // every icon/cover-driven case above and dies here ('pg13' instead of 'x').
     wire({
       kind: 'offsite',
       contentRating: 'g',
-      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_PG, [SHOT_ID]: LVL_X },
+      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_PG13, [SHOT_ID]: LVL_X },
     });
     await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
   });
 
-  it('IDEMPOTENCE: a repeat republish with an OPEN review does NOT create a duplicate queue entry', async () => {
-    wire({
-      kind: 'onsite',
-      contentRating: 'g',
-      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
-    });
-    // An open advisory review already exists for this listing+reporter — mirroring the
-    // DB's partial-unique `(app_listing_id, reporter_user_id) WHERE status='pending'`.
-    mockWrite.appListingReport.findFirst.mockResolvedValue({ id: 'alrp_existing' });
-    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    // The republish still succeeds — an existing review must never block the owner.
-    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
-    // The dedup probe is scoped to pending + this listing + this reporter.
-    expect(mockWrite.appListingReport.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { appListingId: APP_ID, reporterUserId: OWNER, status: 'pending' },
-      })
-    );
-  });
-
-  it('[INVARIANT GUARD — green at origin/main] 🔴 a BLOCKED asset still refuses via the PRE-EXISTING scan gate (the new code did not displace it)', async () => {
-    // Reachability/attribution: the media is also over-rated (X), so BOTH gates would
-    // have something to say. The scan gate runs FIRST, so the listing must not flip and
-    // no queue entry may be written — proving the maturity code did not take over.
+  it('[INVARIANT GUARD — green at origin/main] 🔴 a BLOCKED asset still refuses via the PRE-EXISTING scan gate (the floor did not displace it)', async () => {
+    // Reachability/attribution: the media is ALSO over-rated (X), so both the scan gate
+    // and the floor would have something to say. The scan gate runs FIRST, so the
+    // listing must not flip — and the assertion names the SCAN gate's own error, not
+    // merely "something threw", which is the exact displacement it rules out.
     wire({
       kind: 'onsite',
       contentRating: 'g',
       levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
       ingestion: 'Blocked',
     });
-    // ATTRIBUTION: assert the SCAN gate's own error, not merely "something threw" —
-    // otherwise this passes just as well if the maturity code throws first, which is
-    // the exact displacement it is meant to rule out.
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
     ).rejects.toMatchObject({
@@ -2098,7 +2082,6 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
       message: expect.stringContaining('blocked'),
     });
     expect(flipData()).toBeUndefined();
-    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
@@ -2108,8 +2091,8 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
       contentRating: 'g',
       levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
     });
-    // First image.findMany (the scan gate) succeeds; the SECOND (the maturity derive)
-    // throws — so the failure is attributable to the derive, not the scan gate.
+    // The FIRST image.findMany (the scan gate) succeeds; the SECOND (the floor's own
+    // read) throws — so the failure is attributable to the derive, not the scan gate.
     let call = 0;
     mockWrite.image.findMany.mockImplementation(
       async (args: { where?: { id?: { in?: number[] } } }) => {
@@ -2125,29 +2108,45 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
-  it('🔴 TRANSACTIONAL: a failing queue write aborts the whole republish (nothing half-committed)', async () => {
-    wire({
-      kind: 'onsite',
-      contentRating: 'g',
-      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
-    });
-    mockWrite.appListingReport.create.mockRejectedValueOnce(new Error('queue write failed'));
-    await expect(
-      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
-    ).rejects.toThrow('queue write failed');
-    // The queue write is INSIDE the tx callback, so the error escapes $transaction and
-    // the status flip rolls back with it. The audit event (written after the queue)
-    // never happens — if it did, the two would be able to disagree.
-    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
-  });
+  // ---- REMOVAL COVERAGE: the on-site moderator queue is GONE -------------------------
+
+  it.each(KINDS)(
+    '%s: republish files NO AppListingReport, even when the media is over-rated',
+    async (kind) => {
+      // 🔴 REMOVAL GUARD, not decoration. An earlier revision of this change queued an
+      // advisory `AppListingReport` for over-rated ON-SITE media instead of raising the
+      // rating. The uniform floor makes that queue entry meaningless — the card is no
+      // longer under-rated — so it was removed, and without this assertion its return
+      // would be untested. `create` is still a spy for exactly this reason.
+      wire({
+        kind,
+        contentRating: 'g',
+        levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+      });
+      await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+      // 🔴 ASSERTED FIRST, deliberately. Behind the payload assertion this test would go
+      // red at the pre-change tip for the WRONG reason (the missing raise), and the
+      // removal itself would still be unmeasured. First position makes the red
+      // attributable to the queue write and nothing else.
+      expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+      expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
+    }
+  );
 
   // ---- Regression: the sibling flips are untouched -----------------------------------
 
-  it('[INVARIANT GUARD — green at origin/main] relistListing (mod, human in the loop) applies NO floor and queues NOTHING', async () => {
+  it('[INVARIANT GUARD — green at origin/main] relistListing (mod, human in the loop) applies NO floor', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
-    mockWrite.appListing.findUnique.mockResolvedValue({ iconId: ICON_ID, coverId: COVER_ID });
+    mockWrite.appListing.findUnique.mockResolvedValue({
+      iconId: ICON_ID,
+      coverId: COVER_ID,
+      kind: 'offsite',
+      slug: SLUG,
+      externalUrl: EXTERNAL_URL,
+      connectClientId: null,
+    });
     mockWrite.appListingScreenshot.findMany.mockResolvedValue([{ imageId: SHOT_ID }]);
-    // Deliberately over-rated media — the mod path must still not auto-raise or queue.
+    // Deliberately over-rated media — the mod path must still not auto-raise.
     mockWrite.image.findMany.mockImplementation(
       async (args: { where?: { id?: { in?: number[] } } }) =>
         (args?.where?.id?.in ?? []).map((id) => ({

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -2088,9 +2088,15 @@ describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
       levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
       ingestion: 'Blocked',
     });
+    // ATTRIBUTION: assert the SCAN gate's own error, not merely "something threw" —
+    // otherwise this passes just as well if the maturity code throws first, which is
+    // the exact displacement it is meant to rule out.
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('blocked'),
+    });
     expect(flipData()).toBeUndefined();
     expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 
+import { APP_LISTING_REPORT_REASONS } from '~/server/schema/blocks/offsite-moderation.schema';
+
 import {
   OffsiteModerationError,
   claimListing,
@@ -40,7 +42,13 @@ type WriteMock = {
     // republish reads the LATEST event on the primary inside the tx.
     findFirst: ReturnType<typeof vi.fn>;
   };
-  appListingReport: { updateMany: ReturnType<typeof vi.fn> };
+  appListingReport: {
+    updateMany: ReturnType<typeof vi.fn>;
+    // The on-site over-rated-media review queue: republish check-then-inserts an
+    // advisory `AppListingReport` in the SAME tx as the status flip.
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
   // claim validates the target owner on the primary inside the tx.
   user: { findUnique: ReturnType<typeof vi.fn> };
   // claim NEVER writes this (submitter preserved); reset CREATES a fresh pending request.
@@ -81,7 +89,12 @@ const { mockRead, mockWrite, mockNotify, mockLogToAxiom, ids } = vi.hoisted(() =
       create: vi.fn(async (a: { data: unknown }) => a.data),
       findFirst: vi.fn(async () => null),
     },
-    appListingReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    appListingReport: {
+      updateMany: vi.fn(async () => ({ count: 1 })),
+      // Default: no OPEN review for this listing+reporter → the queue write proceeds.
+      findFirst: vi.fn(async (): Promise<{ id: string } | null> => null),
+      create: vi.fn(async (a: { data: unknown }) => a.data),
+    },
     user: { findUnique: vi.fn(async () => ({ id: 1 })) },
     appListingPublishRequest: {
       updateMany: vi.fn(async () => ({ count: 1 })),
@@ -1770,5 +1783,381 @@ describe('OffsiteModerationError (PR3/PR4 + W13 codes)', () => {
     expect(new OffsiteModerationError('INVALID_TARGET_USER', 'x').code).toBe('INVALID_TARGET_USER');
     expect(new OffsiteModerationError('NOT_OWNED', 'x').code).toBe('NOT_OWNED');
     expect(new OffsiteModerationError('FORBIDDEN', 'x').code).toBe('FORBIDDEN');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 republishOwnListing — GO-LIVE MATURITY GATE (kind-aware).
+//
+// The hole this closes: republish is an OWNER-driven go-live with NO human in the
+// loop, and a `removed` listing is directly asset-editable. The attach path rejects
+// only `Blocked`/`NotFound` images, never a `Scanned` MATURE one, and neither
+// pre-existing gate inspects maturity — so `unpublish → attach mature media →
+// republish` put mature store art back under an unchanged declared rating, which
+// passes `listingMatureFilter(redCapable=false)` (`content_rating NOT IN ('r','x')`).
+//
+// KIND-AWARE by design:
+//   OFF-SITE → RAISE the stored rating to the media-derived one (raise-only).
+//   ON-SITE  → do NOT raise (the rating mirrors `AppBlock.content_rating`); allow the
+//              republish and queue an advisory `AppListingReport` for a moderator.
+//
+// 🔴 COVERAGE HONESTY. Of the 15 cases below, SEVEN are RED at `origin/main` and green
+// at HEAD — those are the regression coverage:
+//   off-site ABOVE · on-site ABOVE (+ its CHECK-set case) · screenshots-contribute ·
+//   idempotence · fail-closed · transactional.
+// The other EIGHT are green at `origin/main` too and are labelled `[INVARIANT GUARD]`:
+// they pin behaviour this change must NOT alter (raise-only never lowers, no-assets,
+// absent row, the pre-existing scan gate, the mod relist path). They are preservation
+// guards and are deliberately NOT counted as regression coverage.
+//
+// Levels are the REAL enum (`src/server/common/enums.ts`): PG=1, PG13=2, R=4, X=8.
+// The ladder is `['g','pg','pg13','r','x']`; `deriveContentRatingFromAssets` picks the
+// minimal rating covering the MAX asset level, so R(4)→'r' and X(8)→'x' — those are
+// exactly the two values `listingMatureFilter` hides, which is why the fixtures use
+// them rather than the level-2 art that happens to be live today.
+// ---------------------------------------------------------------------------
+describe('republishOwnListing — go-live MATURITY gate (kind-aware)', () => {
+  /** Pairwise-distinct asset ids, so a wrong-bind mutant cannot alias two of them. */
+  const ICON_ID = 101;
+  const COVER_ID = 202;
+  const SHOT_ID = 303;
+  /** Real `NsfwLevel` members — not magic numbers. */
+  const LVL_PG = 1;
+  const LVL_PG13 = 2;
+  const LVL_R = 4;
+  const LVL_X = 8;
+
+  function ownerPrimary(opts: {
+    kind: string;
+    contentRating: string | null;
+    appBlockId?: string | null;
+  }) {
+    return {
+      userId: OWNER,
+      status: 'removed',
+      kind: opts.kind,
+      slug: SLUG,
+      name: 'Cool App',
+      appBlockId: opts.appBlockId ?? (opts.kind === 'onsite' ? BLOCK_ID : null),
+      contentRating: opts.contentRating,
+      externalUrl: opts.kind === 'offsite' ? EXTERNAL_URL : null,
+      connectClientId: null,
+    };
+  }
+
+  /**
+   * Wire the three `appListing.findUnique` reads republish performs, in order:
+   *   1. `loadOwnedListingInTx`      → the owned-listing snapshot (with contentRating)
+   *   2. `assertListingAssetsScanCleanInTx` → the asset ids for the scan gate
+   *   3. `resolveListingRatingFloorInTx`    → the asset ids for the maturity derive
+   * plus the screenshot + image reads BOTH (2) and (3) share.
+   *
+   * `levels` maps image id → nsfwLevel; every image also carries `ingestion` so the
+   * pre-existing scan gate is satisfied and the maturity code is REACHABLE (an input
+   * no earlier check rejects).
+   */
+  function wire(opts: {
+    kind: string;
+    contentRating: string | null;
+    icon?: number | null;
+    cover?: number | null;
+    shots?: number[];
+    levels?: Record<number, number>;
+    ingestion?: string;
+  }) {
+    const icon = opts.icon === undefined ? ICON_ID : opts.icon;
+    const cover = opts.cover === undefined ? COVER_ID : opts.cover;
+    const shots = opts.shots ?? [SHOT_ID];
+    const levels = opts.levels ?? {};
+    const ingestion = opts.ingestion ?? 'Scanned';
+
+    // 🔴 Re-established on EVERY wire(), not left to `beforeEach`: `vi.clearAllMocks()`
+    // clears call history but NOT implementations, so a `mockResolvedValue` set by an
+    // earlier test leaks forward. That leak silently disarmed the transactional test
+    // (the idempotence test's "an open review exists" stub made the queue write a
+    // no-op, so nothing could throw) — a green-for-the-wrong-reason, caught only
+    // because the assertion happened to be a rejection.
+    mockWrite.appListingReport.findFirst.mockResolvedValue(null);
+    mockWrite.appListingReport.create.mockImplementation(async (a: { data: unknown }) => a.data);
+    mockWrite.appListing.findUnique.mockResolvedValue({ iconId: icon, coverId: cover });
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(
+      ownerPrimary({ kind: opts.kind, contentRating: opts.contentRating })
+    );
+    mockWrite.appListingScreenshot.findMany.mockResolvedValue(shots.map((imageId) => ({ imageId })));
+    mockWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion, nsfwLevel: levels[id] ?? 0 }))
+    );
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({
+      action: 'owner-unpublish',
+    });
+  }
+
+  /** The `data` payload of the listing status flip. */
+  function flipData() {
+    const call = mockWrite.appListing.updateMany.mock.calls.find(
+      (c: [{ where?: { status?: string } }]) => c[0]?.where?.status === 'removed'
+    );
+    return call?.[0]?.data;
+  }
+
+  // ---- OFF-SITE × media-vs-declared -------------------------------------------------
+
+  it('[INVARIANT GUARD — green at origin/main] OFF-SITE, media BELOW declared → rating UNCHANGED (raise-only never lowers)', async () => {
+    // Max asset level R(4) → derived 'r'; declared 'x' (level 8) is HIGHER, so a
+    // raise-only floor must leave it alone. A lower-vs-raise inversion mutant would
+    // write 'r' here and lose a deliberately mature rating.
+    wire({
+      kind: 'offsite',
+      contentRating: 'x',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG },
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(flipData()).toEqual({ status: 'approved' });
+    expect(flipData()).not.toHaveProperty('contentRating');
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+  });
+
+  it('[INVARIANT GUARD — green at origin/main] OFF-SITE, media EQUAL to declared → rating UNCHANGED (no needless write)', async () => {
+    // Max R(4) → derived 'r' === declared 'r'. Strict-inequality boundary: a `>` → `>=`
+    // mutant in the floor would still produce 'r', but the ABOVE case below pins the
+    // raise, and this pins that EQUAL does not emit a contentRating key at all.
+    wire({
+      kind: 'offsite',
+      contentRating: 'r',
+      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG13 },
+    });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(flipData()).toEqual({ status: 'approved' });
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 OFF-SITE, media ABOVE declared → rating RAISED to the derived value', async () => {
+    // THE DEFECT. Declared 'g' with X(8) cover art: pre-fix this went live as 'g' and
+    // `content_rating NOT IN ('r','x')` showed it to SFW-only users.
+    wire({
+      kind: 'offsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+    });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
+    // Off-site is fixed by the raise alone — it must NOT also spend a moderator slot.
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+  });
+
+  // ---- ON-SITE × media-vs-declared --------------------------------------------------
+
+  it('[INVARIANT GUARD — green at origin/main] ON-SITE, media BELOW declared → republishes normally, rating untouched, NO queue entry', async () => {
+    wire({
+      kind: 'onsite',
+      contentRating: 'x',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG },
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(flipData()).toEqual({ status: 'approved' });
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+    // The backing block is still restored — the maturity gate must not disturb that.
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalled();
+  });
+
+  it('[INVARIANT GUARD — green at origin/main] ON-SITE, media EQUAL to declared → republishes normally, NO queue entry', async () => {
+    wire({
+      kind: 'onsite',
+      contentRating: 'r',
+      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_R, [SHOT_ID]: LVL_PG13 },
+    });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(flipData()).toEqual({ status: 'approved' });
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 ON-SITE, media ABOVE declared → stored rating UNCHANGED (manifest mirror) + queue entry created', async () => {
+    // The kind-aware half. An on-site listing's rating mirrors AppBlock.content_rating,
+    // so it is deliberately NOT auto-raised — a kind-branch-inversion mutant would
+    // write contentRating here and break the manifest-mirror invariant.
+    wire({
+      kind: 'onsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    // INVARIANT: the rating is NOT raised.
+    expect(flipData()).toEqual({ status: 'approved' });
+    expect(flipData()).not.toHaveProperty('contentRating');
+    // ...and a moderator IS queued.
+    expect(mockWrite.appListingReport.create).toHaveBeenCalledTimes(1);
+    const queued = mockWrite.appListingReport.create.mock.calls[0][0].data;
+    expect(queued).toMatchObject({
+      appListingId: APP_ID,
+      reporterUserId: OWNER,
+      reason: 'inappropriate',
+      status: 'pending',
+    });
+    // The details string names the DERIVED rating first and the DECLARED second — a
+    // wrong-bind mutant that swaps them produces a plausible sentence, so pin both
+    // fragments positionally rather than merely asserting the two words appear.
+    expect(queued.details).toContain('media rated "x"');
+    expect(queued.details).toContain('declared content rating of "g"');
+  });
+
+  it('ON-SITE over-rated: the queue reason is a member of the CHECK-constrained reason set', async () => {
+    // A value outside the DB CHECK (impersonation|phishing-malware|broken|
+    // inappropriate|spam|other) would be rejected at 23514 in production, where the
+    // mock happily accepts anything.
+    wire({
+      kind: 'onsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_PG13 },
+    });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    const queued = mockWrite.appListingReport.create.mock.calls[0][0].data;
+    expect(APP_LISTING_REPORT_REASONS as readonly string[]).toContain(queued.reason);
+    expect(['pending', 'resolved', 'dismissed']).toContain(queued.status);
+  });
+
+  // ---- Edge cases -------------------------------------------------------------------
+
+  it('[INVARIANT GUARD — green at origin/main] listing with NO attached assets → rating unchanged, no queue entry, no crash', async () => {
+    wire({ kind: 'offsite', contentRating: 'g', icon: null, cover: null, shots: [] });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(flipData()).toEqual({ status: 'approved' });
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+  });
+
+  it('[INVARIANT GUARD — green at origin/main] absent listing row on the FLOOR read → declared rating preserved, republish still succeeds', async () => {
+    // The floor helper returns `declaredRating` when its own findUnique misses (a race
+    // with a concurrent purge). Pre-existing behaviour must survive.
+    mockWrite.appListing.findUnique.mockResolvedValue(null);
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(
+      ownerPrimary({ kind: 'offsite', contentRating: 'pg13' })
+    );
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({
+      action: 'owner-unpublish',
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(flipData()).toEqual({ status: 'approved' });
+  });
+
+  it('🔴 SCREENSHOTS contribute to the derived max, not just icon/cover', async () => {
+    // Icon and cover are both tame; the ONLY mature asset is a screenshot. A mutant
+    // that derives from `[iconId, coverId]` and drops the screenshot spread survives
+    // every icon/cover-driven case above and dies here.
+    wire({
+      kind: 'offsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG, [COVER_ID]: LVL_PG, [SHOT_ID]: LVL_X },
+    });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
+  });
+
+  it('IDEMPOTENCE: a repeat republish with an OPEN review does NOT create a duplicate queue entry', async () => {
+    wire({
+      kind: 'onsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+    });
+    // An open advisory review already exists for this listing+reporter — mirroring the
+    // DB's partial-unique `(app_listing_id, reporter_user_id) WHERE status='pending'`.
+    mockWrite.appListingReport.findFirst.mockResolvedValue({ id: 'alrp_existing' });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    // The republish still succeeds — an existing review must never block the owner.
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+    // The dedup probe is scoped to pending + this listing + this reporter.
+    expect(mockWrite.appListingReport.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { appListingId: APP_ID, reporterUserId: OWNER, status: 'pending' },
+      })
+    );
+  });
+
+  it('[INVARIANT GUARD — green at origin/main] 🔴 a BLOCKED asset still refuses via the PRE-EXISTING scan gate (the new code did not displace it)', async () => {
+    // Reachability/attribution: the media is also over-rated (X), so BOTH gates would
+    // have something to say. The scan gate runs FIRST, so the listing must not flip and
+    // no queue entry may be written — proving the maturity code did not take over.
+    wire({
+      kind: 'onsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+      ingestion: 'Blocked',
+    });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toThrow();
+    expect(flipData()).toBeUndefined();
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 FAIL-CLOSED: a throwing rating derivation leaves the listing NOT live', async () => {
+    wire({
+      kind: 'offsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+    });
+    // First image.findMany (the scan gate) succeeds; the SECOND (the maturity derive)
+    // throws — so the failure is attributable to the derive, not the scan gate.
+    let call = 0;
+    mockWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) => {
+        if (++call >= 2) throw new Error('nsfwLevel read failed');
+        return (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: 'Scanned', nsfwLevel: 0 }));
+      }
+    );
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toThrow('nsfwLevel read failed');
+    // NOT live, and no audit event claiming it was.
+    expect(flipData()).toBeUndefined();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 TRANSACTIONAL: a failing queue write aborts the whole republish (nothing half-committed)', async () => {
+    wire({
+      kind: 'onsite',
+      contentRating: 'g',
+      levels: { [ICON_ID]: LVL_PG13, [COVER_ID]: LVL_X, [SHOT_ID]: LVL_R },
+    });
+    mockWrite.appListingReport.create.mockRejectedValueOnce(new Error('queue write failed'));
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toThrow('queue write failed');
+    // The queue write is INSIDE the tx callback, so the error escapes $transaction and
+    // the status flip rolls back with it. The audit event (written after the queue)
+    // never happens — if it did, the two would be able to disagree.
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  // ---- Regression: the sibling flips are untouched -----------------------------------
+
+  it('[INVARIANT GUARD — green at origin/main] relistListing (mod, human in the loop) applies NO floor and queues NOTHING', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValue({ iconId: ICON_ID, coverId: COVER_ID });
+    mockWrite.appListingScreenshot.findMany.mockResolvedValue([{ imageId: SHOT_ID }]);
+    // Deliberately over-rated media — the mod path must still not auto-raise or queue.
+    mockWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: 'Scanned',
+          nsfwLevel: id === COVER_ID ? LVL_X : LVL_PG,
+        }))
+    );
+    await relistListing({
+      input: { appListingId: APP_ID, reason: GOOD_REASON },
+      userId: REVIEWER,
+    });
+    const relistCall = mockWrite.appListing.updateMany.mock.calls.find(
+      (c: [{ data?: Record<string, unknown> }]) => c[0]?.data?.status === 'approved'
+    );
+    expect(relistCall?.[0]?.data).not.toHaveProperty('contentRating');
+    expect(mockWrite.appListingReport.create).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -1383,9 +1383,8 @@ async function loadOwnedListingInTx(
       slug: true,
       name: true,
       appBlockId: true,
-      // The DECLARED rating, needed by `republishOwnListing`'s go-live rating floor
-      // (off-site) / over-rated-media review queue (on-site). `unpublishOwnListing`
-      // ignores it — a self-hide never touches the rating.
+      // The DECLARED rating, the input to `republishOwnListing`'s go-live rating floor.
+      // `unpublishOwnListing` ignores it — a self-hide never touches the rating.
       contentRating: true,
     },
   });
@@ -1489,18 +1488,14 @@ export type RepublishOwnListingResult = { appListingId: string; status: 'approve
  * tx (via {@link flipBackingBlockStatus}), so the app serves again. OFF-SITE: only the
  * listing flips. `reason` optional.
  *
- * 🔴 MATURITY IS RE-DERIVED AT GO-LIVE, KIND-AWARE (this used to be a pure visibility
- * toggle with NO re-derive, which was the hole). A `removed` listing is directly
- * asset-editable and the attach path never rejects a `Scanned` MATURE image, so
+ * 🔴 MATURITY IS RE-DERIVED AT GO-LIVE, UNIFORMLY FOR BOTH KINDS (this used to be a
+ * pure visibility toggle with NO re-derive, which was the hole). A `removed` listing is
+ * directly asset-editable and the attach path never rejects a `Scanned` MATURE image, so
  * `unpublish → attach mature media → republish` re-published mature store art under an
- * unchanged declared rating:
- *   - OFF-SITE → the declared rating is RAISED to the media-derived one
- *     ({@link resolveListingRatingFloorInTx}, RAISE-ONLY — tame media never lowers a
- *     deliberately higher rating). Off-site listings carry their own rating.
- *   - ON-SITE → the rating is NOT raised (it mirrors `AppBlock.content_rating`; the
- *     listing must not override the runtime serving gate). The republish is allowed and
- *     an `AppListingReport` is queued for a moderator instead. The over-rated art is
- *     LIVE while queued — a documented, deliberate cost; see the in-body comment.
+ * unchanged declared rating. The stored rating is therefore FLOORED at the media-derived
+ * one ({@link resolveListingRatingFloorInTx}, RAISE-ONLY — tame media never lowers a
+ * deliberately higher rating).
+ *
  * Fail-closed: the derive runs INSIDE the tx and is not caught, so a throw leaves the
  * listing `removed`.
  */
@@ -1547,7 +1542,7 @@ export async function republishOwnListing(opts: {
     await assertOffsiteListingActionableInTx(tx, input.appListingId);
     const isOnsite = listing.kind === 'onsite';
 
-    // 🔴 GO-LIVE RATING FLOOR / OVER-RATED-MEDIA gate — KIND-AWARE.
+    // 🔴 GO-LIVE RATING FLOOR — UNIFORM, BOTH KINDS.
     //
     // Republish is an OWNER-DRIVEN go-live with NO human in the loop, and a `removed`
     // listing is DIRECTLY asset-editable (`assertOwnerAssetEditable` refuses only an
@@ -1558,38 +1553,47 @@ export async function republishOwnListing(opts: {
     // art back on a `g`-rated card, which passes `listingMatureFilter(redCapable=false)`
     // (`content_rating NOT IN ('r','x')`) and shows it to SFW-ONLY users.
     //
+    // 🔴 WHY ON-SITE IS FLOORED TOO (this is EXISTING precedent, not a new policy). The
+    // on-site DRAFT go-live already does exactly this: `approveRequest` reads the
+    // AppBlock's manifest-declared `contentRating`, passes it through THIS SAME helper
+    // and writes the floored result to the listing — for the same stated reason
+    // (`publish-request.service.ts`, "🔴 RATING FLOOR (go-live)"). Two properties make
+    // it safe on both kinds:
+    //   - it writes `AppListing.contentRating` (the STORE CARD). The runtime .red/.com
+    //     serving gate reads `AppBlock.contentRating` / `AppBlock.manifest.contentRating`
+    //     — SEPARATE columns — so a raise here cannot change what the block is allowed to
+    //     render. Enumerated over `src/`: no runtime gate reads the listing column, and
+    //     nothing ever copies listing → block (the mirror runs block → listing only).
+    //     The raise's real effect is STORE VISIBILITY, and only ever NARROWING it:
+    //     `listingMatureFilter` hides the card and `getListingDetail` 404s it for
+    //     SFW-only viewers. That is the point of the fix.
+    //   - the raise PERSISTS: `buildListingScalarSync` deliberately EXCLUDES
+    //     `contentRating` from the manifest re-sync ("mod override, floored at the
+    //     derived rating" — `app-listing-mapper.ts`, restated at the approve call site in
+    //     `publish-request.service.ts`), so a later version approve does not undo it.
+    // 🔴 Three comments elsewhere still assert an UNQUALIFIED "on-site listings MIRROR
+    // AppBlock.content_rating" (the `AppListing.contentRating` schema comment, the
+    // mapper's create path, the backfill service) and the on-site media-revision copy
+    // step declines to floor. Those describe the block → listing MIRROR and that one copy
+    // step; they are narrower than the code, which already floors on-site at draft
+    // go-live and on mod live-edit. Not rewritten here — see the PR body's open item.
+    //
     // Derived BEFORE the flip and NOT wrapped in try/catch: a throw here aborts the tx,
     // so a listing whose rating cannot be derived does NOT go live (fail-closed).
-    const derivedRating = await resolveListingRatingFloorInTx(
+    //
+    // RAISE-ONLY is the helper's contract — it returns `declaredRating` unchanged unless
+    // the derived ceiling is strictly higher — so writing the result UNCONDITIONALLY is
+    // safe: tame media can never lower a deliberately higher declaration, and an
+    // unchanged rating writes its own value back. Same shape as `approveRequest`'s.
+    const flooredRating = await resolveListingRatingFloorInTx(
       tx,
       input.appListingId,
       listing.contentRating
     );
-    // RAISE-ONLY is already the helper's contract (it returns `declaredRating` unchanged
-    // unless the derived ceiling is strictly higher), so an inequality here means
-    // "the media is MORE mature than the declared rating" and nothing else. Tame media
-    // can never lower a deliberately higher declaration.
-    const mediaOverRated = derivedRating !== listing.contentRating;
 
     const flipped = await tx.appListing.updateMany({
       where: { id: input.appListingId, kind: listing.kind, status: 'removed' },
-      data: {
-        status: 'approved',
-        // OFF-SITE: apply the floor, exactly as the off-site approve path does — an
-        // off-site listing carries its OWN rating (schema: "Off-site listings carry
-        // their own"), so raising it is the correct, complete fix.
-        //
-        // ON-SITE: DELIBERATELY NOT RAISED. An on-site listing's `contentRating`
-        // MIRRORS `AppBlock.content_rating` (schema comment on `AppListing.contentRating`:
-        // "For on-site listings this MIRRORS AppBlock.content_rating (single source —
-        // the listing must NOT override the runtime .red/.com serving gate)"), and the
-        // on-site revision path states the same policy: "over-rated media is a
-        // mod-reject at review, never an auto-raise" (`offsite-listing.service`, the
-        // ONSITE = ASSETS-ONLY branch). Auto-raising here would silently diverge the
-        // store card from the app's manifest rating. Instead the republish is ALLOWED
-        // and the listing is QUEUED for a moderator (below).
-        ...(!isOnsite && mediaOverRated ? { contentRating: derivedRating } : {}),
-      },
+      data: { status: 'approved', contentRating: flooredRating },
     });
     if (flipped.count === 0) {
       throw new OffsiteModerationError(
@@ -1612,64 +1616,6 @@ export async function republishOwnListing(opts: {
         to: 'approved',
       });
       if (!flippedBlock) onsiteBlockRestoreDrift = true;
-    }
-
-    // 🔴 ON-SITE OVER-RATED MEDIA → MODERATOR REVIEW QUEUE (the on-site half of the
-    // kind-aware gate above). The rating was deliberately left mirroring the manifest,
-    // so nothing else would ever surface that this listing's media is more mature than
-    // its card claims. File an `AppListingReport` — the ONLY advisory queue in this
-    // codebase: it is filed against an already-`approved` (live) listing, it NEVER
-    // touches `AppListing.status`, and a moderator works it from the Reports tab of
-    // `/apps/review` (`listListingReports`), resolving via `resolveReport` /
-    // `dismissReport` or escalating to `delistListing`. The gating queues
-    // (`AppListingPublishRequest` / `AppBlockPublishRequest`) are deliberately NOT used
-    // — they hold the object in a non-visible status, which is a different decision.
-    //
-    // 🔴 KNOWN COST, stated rather than papered over: the over-rated art IS LIVE while
-    // the report sits in the queue. There is no cheap display-layer interim guard —
-    // the public store query gates on `al.status = 'approved'` AND
-    // `listingMatureFilter` (`content_rating NOT IN ('r','x')`) only, so hiding this
-    // listing without mutating `content_rating` would need a new column (manual-apply
-    // migration) or a join on `app_listing_reports` (which would let ANY single user
-    // report hide ANY listing). Both are disproportionate here; see the PR body.
-    //
-    // `reporterUserId` is the OWNER: the column is NOT NULL with an FK to `User` and
-    // this codebase has no system-user sentinel, so the acting user is the only honest
-    // value — and it buys idempotence for free, because the DB carries a PARTIAL-UNIQUE
-    // `(app_listing_id, reporter_user_id) WHERE status='pending'`. The check-then-insert
-    // below mirrors that constraint IN-TX rather than catching P2002: a constraint
-    // violation inside a Postgres transaction aborts the WHOLE transaction, so a caught
-    // P2002 could not be recovered from here — it would roll the republish back.
-    if (isOnsite && mediaOverRated) {
-      const openReview = await tx.appListingReport.findFirst({
-        where: {
-          appListingId: input.appListingId,
-          reporterUserId: userId,
-          status: 'pending',
-        },
-        select: { id: true },
-      });
-      if (!openReview) {
-        await tx.appListingReport.create({
-          data: {
-            id: newAppListingReportId(),
-            appListingId: input.appListingId,
-            reporterUserId: userId,
-            // `inappropriate` is the closest member of the CHECK-constrained reason set
-            // (impersonation | phishing-malware | broken | inappropriate | spam | other)
-            // — a maturity mismatch is a content-appropriateness call. Writing a value
-            // outside that set would be rejected by the DB (23514).
-            reason: 'inappropriate',
-            details:
-              `Automated review: on-site listing republished by its owner with media rated ` +
-              `"${derivedRating ?? 'unknown'}" but a declared content rating of ` +
-              `"${listing.contentRating ?? 'none'}". The declared rating mirrors the app ` +
-              `manifest and was deliberately NOT auto-raised — a moderator should either ` +
-              `reject the media or have the author raise the manifest rating.`,
-            status: 'pending',
-          },
-        });
-      }
     }
 
     await tx.appListingModerationEvent.create({

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -22,7 +22,10 @@ import {
 import { safeCollaboratorQuery } from '~/server/services/blocks/app-access.service';
 import { recordOwnershipEvent } from '~/server/services/blocks/app-collaborator.service';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
-import { assertListingAssetsScanCleanInTx } from '~/server/services/blocks/app-listing-assets.service';
+import {
+  assertListingAssetsScanCleanInTx,
+  resolveListingRatingFloorInTx,
+} from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionableInTx } from '~/server/services/blocks/app-listing-actionable.service';
 import { isOwnerUnpublishedListing } from '~/server/services/blocks/app-listing-owner-unpublish';
 import {
@@ -1369,10 +1372,22 @@ async function loadOwnedListingInTx(
   slug: string;
   name: string | null;
   appBlockId: string | null;
+  contentRating: string | null;
 }> {
   const listing = await tx.appListing.findUnique({
     where: { id: appListingId },
-    select: { userId: true, status: true, kind: true, slug: true, name: true, appBlockId: true },
+    select: {
+      userId: true,
+      status: true,
+      kind: true,
+      slug: true,
+      name: true,
+      appBlockId: true,
+      // The DECLARED rating, needed by `republishOwnListing`'s go-live rating floor
+      // (off-site) / over-rated-media review queue (on-site). `unpublishOwnListing`
+      // ignores it — a self-hide never touches the rating.
+      contentRating: true,
+    },
   });
   if (!listing) {
     throw new OffsiteModerationError('NOT_FOUND', 'Listing not found.');
@@ -1387,6 +1402,7 @@ async function loadOwnedListingInTx(
     slug: listing.slug,
     name: listing.name,
     appBlockId: listing.appBlockId,
+    contentRating: listing.contentRating,
   };
 }
 
@@ -1471,8 +1487,22 @@ export type RepublishOwnListingResult = { appListingId: string; status: 'approve
  *
  * ON-SITE: the backing `AppBlock` is also restored suspended → approved in the SAME
  * tx (via {@link flipBackingBlockStatus}), so the app serves again. OFF-SITE: only the
- * listing flips. Pure visibility toggle — no re-derive, no publish request. `reason`
- * optional.
+ * listing flips. `reason` optional.
+ *
+ * 🔴 MATURITY IS RE-DERIVED AT GO-LIVE, KIND-AWARE (this used to be a pure visibility
+ * toggle with NO re-derive, which was the hole). A `removed` listing is directly
+ * asset-editable and the attach path never rejects a `Scanned` MATURE image, so
+ * `unpublish → attach mature media → republish` re-published mature store art under an
+ * unchanged declared rating:
+ *   - OFF-SITE → the declared rating is RAISED to the media-derived one
+ *     ({@link resolveListingRatingFloorInTx}, RAISE-ONLY — tame media never lowers a
+ *     deliberately higher rating). Off-site listings carry their own rating.
+ *   - ON-SITE → the rating is NOT raised (it mirrors `AppBlock.content_rating`; the
+ *     listing must not override the runtime serving gate). The republish is allowed and
+ *     an `AppListingReport` is queued for a moderator instead. The over-rated art is
+ *     LIVE while queued — a documented, deliberate cost; see the in-body comment.
+ * Fail-closed: the derive runs INSIDE the tx and is not caught, so a throw leaves the
+ * listing `removed`.
  */
 export async function republishOwnListing(opts: {
   input: RepublishOwnListingInput;
@@ -1516,9 +1546,50 @@ export async function republishOwnListing(opts: {
     // (`tx`), row-consistent with the flip. On-site republishes no-op.
     await assertOffsiteListingActionableInTx(tx, input.appListingId);
     const isOnsite = listing.kind === 'onsite';
+
+    // 🔴 GO-LIVE RATING FLOOR / OVER-RATED-MEDIA gate — KIND-AWARE.
+    //
+    // Republish is an OWNER-DRIVEN go-live with NO human in the loop, and a `removed`
+    // listing is DIRECTLY asset-editable (`assertOwnerAssetEditable` refuses only an
+    // `approved` non-shadow row). The attach path rejects only `Blocked`/`NotFound`
+    // images — never a `Scanned` MATURE one — and neither gate above inspects maturity:
+    // `assertListingAssetsScanCleanInTx` reads scan STATUS, `assertOffsiteListingActionableInTx`
+    // reads the href. So `unpublish → attach mature media → republish` put mature store
+    // art back on a `g`-rated card, which passes `listingMatureFilter(redCapable=false)`
+    // (`content_rating NOT IN ('r','x')`) and shows it to SFW-ONLY users.
+    //
+    // Derived BEFORE the flip and NOT wrapped in try/catch: a throw here aborts the tx,
+    // so a listing whose rating cannot be derived does NOT go live (fail-closed).
+    const derivedRating = await resolveListingRatingFloorInTx(
+      tx,
+      input.appListingId,
+      listing.contentRating
+    );
+    // RAISE-ONLY is already the helper's contract (it returns `declaredRating` unchanged
+    // unless the derived ceiling is strictly higher), so an inequality here means
+    // "the media is MORE mature than the declared rating" and nothing else. Tame media
+    // can never lower a deliberately higher declaration.
+    const mediaOverRated = derivedRating !== listing.contentRating;
+
     const flipped = await tx.appListing.updateMany({
       where: { id: input.appListingId, kind: listing.kind, status: 'removed' },
-      data: { status: 'approved' },
+      data: {
+        status: 'approved',
+        // OFF-SITE: apply the floor, exactly as the off-site approve path does — an
+        // off-site listing carries its OWN rating (schema: "Off-site listings carry
+        // their own"), so raising it is the correct, complete fix.
+        //
+        // ON-SITE: DELIBERATELY NOT RAISED. An on-site listing's `contentRating`
+        // MIRRORS `AppBlock.content_rating` (schema comment on `AppListing.contentRating`:
+        // "For on-site listings this MIRRORS AppBlock.content_rating (single source —
+        // the listing must NOT override the runtime .red/.com serving gate)"), and the
+        // on-site revision path states the same policy: "over-rated media is a
+        // mod-reject at review, never an auto-raise" (`offsite-listing.service`, the
+        // ONSITE = ASSETS-ONLY branch). Auto-raising here would silently diverge the
+        // store card from the app's manifest rating. Instead the republish is ALLOWED
+        // and the listing is QUEUED for a moderator (below).
+        ...(!isOnsite && mediaOverRated ? { contentRating: derivedRating } : {}),
+      },
     });
     if (flipped.count === 0) {
       throw new OffsiteModerationError(
@@ -1542,6 +1613,65 @@ export async function republishOwnListing(opts: {
       });
       if (!flippedBlock) onsiteBlockRestoreDrift = true;
     }
+
+    // 🔴 ON-SITE OVER-RATED MEDIA → MODERATOR REVIEW QUEUE (the on-site half of the
+    // kind-aware gate above). The rating was deliberately left mirroring the manifest,
+    // so nothing else would ever surface that this listing's media is more mature than
+    // its card claims. File an `AppListingReport` — the ONLY advisory queue in this
+    // codebase: it is filed against an already-`approved` (live) listing, it NEVER
+    // touches `AppListing.status`, and a moderator works it from the Reports tab of
+    // `/apps/review` (`listListingReports`), resolving via `resolveReport` /
+    // `dismissReport` or escalating to `delistListing`. The gating queues
+    // (`AppListingPublishRequest` / `AppBlockPublishRequest`) are deliberately NOT used
+    // — they hold the object in a non-visible status, which is a different decision.
+    //
+    // 🔴 KNOWN COST, stated rather than papered over: the over-rated art IS LIVE while
+    // the report sits in the queue. There is no cheap display-layer interim guard —
+    // the public store query gates on `al.status = 'approved'` AND
+    // `listingMatureFilter` (`content_rating NOT IN ('r','x')`) only, so hiding this
+    // listing without mutating `content_rating` would need a new column (manual-apply
+    // migration) or a join on `app_listing_reports` (which would let ANY single user
+    // report hide ANY listing). Both are disproportionate here; see the PR body.
+    //
+    // `reporterUserId` is the OWNER: the column is NOT NULL with an FK to `User` and
+    // this codebase has no system-user sentinel, so the acting user is the only honest
+    // value — and it buys idempotence for free, because the DB carries a PARTIAL-UNIQUE
+    // `(app_listing_id, reporter_user_id) WHERE status='pending'`. The check-then-insert
+    // below mirrors that constraint IN-TX rather than catching P2002: a constraint
+    // violation inside a Postgres transaction aborts the WHOLE transaction, so a caught
+    // P2002 could not be recovered from here — it would roll the republish back.
+    if (isOnsite && mediaOverRated) {
+      const openReview = await tx.appListingReport.findFirst({
+        where: {
+          appListingId: input.appListingId,
+          reporterUserId: userId,
+          status: 'pending',
+        },
+        select: { id: true },
+      });
+      if (!openReview) {
+        await tx.appListingReport.create({
+          data: {
+            id: newAppListingReportId(),
+            appListingId: input.appListingId,
+            reporterUserId: userId,
+            // `inappropriate` is the closest member of the CHECK-constrained reason set
+            // (impersonation | phishing-malware | broken | inappropriate | spam | other)
+            // — a maturity mismatch is a content-appropriateness call. Writing a value
+            // outside that set would be rejected by the DB (23514).
+            reason: 'inappropriate',
+            details:
+              `Automated review: on-site listing republished by its owner with media rated ` +
+              `"${derivedRating ?? 'unknown'}" but a declared content rating of ` +
+              `"${listing.contentRating ?? 'none'}". The declared rating mirrors the app ` +
+              `manifest and was deliberately NOT auto-raised — a moderator should either ` +
+              `reject the media or have the author raise the manifest rating.`,
+            status: 'pending',
+          },
+        });
+      }
+    }
+
     await tx.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),


### PR DESCRIPTION
## The defect

`republishOwnListing` flips a listing `removed → approved`. It is **entirely owner-driven, with no human in the loop**, and it gated on exactly two things:

- `assertListingAssetsScanCleanInTx` — scan **status** only (Blocked / still-scanning)
- `assertOffsiteListingActionableInTx` — whether an `https` href exists

**Neither inspects media maturity.** Meanwhile a `removed` listing is directly asset-editable (`assertOwnerAssetEditable` refuses only `approved && revisionOfId == null`), and the attach path rejects only `Blocked`/`NotFound` images — **never a `Scanned` but mature one**.

So the sequence `unpublish → attach mature media → republish` put mature store art back on an unchanged declared rating. An under-rated listing then passes `listingMatureFilter(redCapable=false)` (`content_rating NOT IN ('r','x')`) on the store list, and the detail read's `if (!redCapable && isMatureContentRating(row.contentRating)) return null` — i.e. **it is shown to SFW-only users on both surfaces**.

The rating floor helper `resolveListingRatingFloorInTx` already existed and already documents this exact consequence in its own docstring. `republishOwnListing` called it zero times.

Not currently exploited — the path is open and unexercised.

## The fix: one uniform, raise-only floor for both kinds

`republishOwnListing` now runs the declared rating through the existing `resolveListingRatingFloorInTx` and writes the floored result — **identically for on-site and off-site**. No second derivation, no kind branching in the rating path. **RAISE-ONLY**: the helper returns the declared rating unchanged unless the derived ceiling is strictly higher, so tame media can never lower a deliberately higher declaration.

Fail-closed: the derive runs inside the existing transaction and is deliberately **not** caught, so a listing whose rating cannot be derived does not go live.

**One deliberate difference from the previous revision, called out for review:** the floored value is written **unconditionally**, not only when it differs. That is what removes the last conditional, and it is the same shape `approveRequest` uses. The cost is that a republish of an unchanged rating now writes the same value back, so a concurrent write to `contentRating` landing between the in-tx read and the update would be last-writer-wins. The window is inside one transaction on the primary, against a `removed` (not-live) row, and the update is status-guarded so a concurrent republish cannot double-apply — but if a reviewer wants the write narrowed to "only when it changes", that is a one-line change.

### Why on-site is floored too — this is existing precedent, not a new policy

**The on-site go-live path already does exactly this.** `approveRequest`'s draft transition (`publish-request.service.ts:2643-2680` on `origin/release`) reads `abForTransition.contentRating` — the AppBlock's manifest-declared value — passes it through **this same helper**, and writes the floored result to `AppListing`. Its own comment gives precisely the rationale this PR exists for: the attach path "rejects only `Blocked`/`NotFound`", so stamping the declared rating verbatim would "let mature-but-Scanned media go live on a `g`-rated card and pass `listingMatureFilter(redCapable=false)` to SFW-only users."

Two properties make the raise safe on both kinds:

1. **The raise cannot touch the runtime serving gate.** It writes `AppListing.contentRating` (the store card). The runtime value lives on `AppBlock.contentRating` / `AppBlock.manifest.contentRating` — **separate columns**.
2. **A raise persists.** `buildListingScalarSync` explicitly **excludes** `contentRating` from the manifest re-sync, describing it as "(mod override, floored at the derived rating)" — `app-listing-mapper.ts:105-108`, restated at the approve call site in `publish-request.service.ts:2758-2759`. A later version approve does not undo it.

A third existing caller agrees: `reDeriveContentRatingForModLiveEdit` raises the rating on any approved listing **with no kind check at all**.

Point 1 was checked by **enumeration, not sampling** — every `contentRating`/`content_rating` occurrence in `src/` (617 lines / 130 files; 161 / 43 excluding tests), plus the raw-SQL forms (`al.content_rating`, `ab.content_rating`) and all 8 `appBlock.*` write sites:

- Every runtime gate reads the **block**, never the listing: the run-page SSR 404 (`apps/run/[slug]`, via `AppBlock.contentRating`), the token-mint refusal and ceiling claim (`block-tokens/index.ts`, via `AppBlock.manifest.contentRating` and the request host), the per-model slot filter and slot ceiling (`block-registry.service.ts`, via `AppBlock.manifest`), and the AppBlock detail/list SQL (`ab.content_rating`).
- `domainBrowsingCeiling` — the documented single source of truth for a domain's max browsing level — takes a `ColorDomain` and nothing else. No rating of any model can structurally reach it.
- **Nothing ever copies listing → block.** All 8 `appBlock.*` writes take `manifest.contentRating`; there is no raw `UPDATE app_blocks` anywhere. The mirror is one-directional, block → listing.

**What the raise DOES do — worth a reviewer's attention.** It narrows *store visibility*, and only ever narrows it: `listingMatureFilter` hides the card from the SFW store list and `getListingDetail` 404s the store detail page for SFW-only viewers. So an on-site app that declares `g` but attaches `x`-rated store art now becomes invisible on the SFW store **while the app itself keeps serving on `.com`**. That is the intended outcome (the *art* is what is mature, not the app), but it is a real product-visible effect and it is what makes this a decision rather than a pure bugfix.

### The statements that read the other way, and their scope

Four comments assert an unqualified "an on-site listing's rating MIRRORS `AppBlock.content_rating`": the `AppListing.contentRating` schema comment, `app-listing-mapper.ts:208-209` (the create path), `app-listing-backfill.service.ts:45-46`, and `offsite-listing.service.ts` (~2840, "over-rated media is a mod-reject at review, never an auto-raise").

The first three describe the **block → listing mirror**, which is real and unchanged. The fourth is scoped to the **on-site media-revision copy step** — the branch it sits in copies `iconId`/`coverId` and nothing else. Generalising the fourth to every on-site write is what the earlier revision of this PR did, and it contradicts the two existing floors above. Left as an open item below rather than silently rewritten.

## Test coverage

`offsite-moderation.service.mod-actions.test.ts`, **19 cases** in one describe block. **17 are RED at `origin/main` and green at HEAD**; **2 are green at base and are labelled `[INVARIANT GUARD]` in-source** — they pin behaviour this change must not alter and are deliberately *not* counted as regression coverage.

Matrix (`offsite` + `onsite` where marked ×2):

| Case | ×2 kinds | at `origin/main` |
|---|---|---|
| media BELOW declared → floored value **is** the declared rating | ✓ | RED |
| media EQUAL to declared → unchanged | ✓ | RED |
| media ABOVE declared → raised to the derived value | ✓ | RED |
| **PARITY**: both kinds produce a byte-identical flip payload | — | RED |
| a deliberately higher declaration is never lowered by tame media | ✓ | RED |
| a **NULL** declared rating with tame media stays NULL (never stamped `g`) | ✓ | RED |
| no attached assets → declared preserved, no image read, no crash | — | RED |
| absent listing row on the floor read → declared preserved | — | RED |
| screenshots contribute to the derived max, not just icon/cover | — | RED |
| **fail-closed**: a throwing derivation leaves the listing not live | — | RED |
| **removal**: republish files NO `AppListingReport` | ✓ | RED |
| `[INVARIANT GUARD]` a `Blocked` asset still refuses via the pre-existing scan gate | — | green |
| `[INVARIANT GUARD]` `relistListing` (mod, human in the loop) applies no floor | — | green |

Levels are imported from the real `NsfwLevel` enum rather than hand-typed, and the fixtures exercise **R/X**-level art — the two values `listingMatureFilter` actually hides — not the level-2 art that happens to be live today. Asset ids and sibling levels are pairwise distinct.

### Three scaffold defects found while reworking the matrix

Each of these made a test pass for the wrong reason; all are fixed here.

1. **The actionability gate was never running.** The fixture for the third `appListing.findUnique` lacked `kind`/`externalUrl`, so `checkOffsiteListingActionable` saw `kind: undefined` and returned `skipped`. The floor was only ever reached past a gate that had disarmed itself. The fixture now carries all four columns.
2. **A scoping assertion was satisfied by a neighbouring call.** `expect(appListingScreenshot.findMany).toHaveBeenCalledWith({ where: { appListingId: APP_ID } })` is true because the *scan gate* makes that call one step earlier — so a mutant binding the floor to the wrong listing id **survived**. Now asserted over every call, and the mutant dies.
3. **The removal guard asserted the payload first.** Behind the payload assertion it went red at the pre-change tip for the wrong reason (the missing raise) and the removal itself stayed unmeasured. `create` is now asserted first.

### Mutation battery — 16 mutants, 16 killed, 0 survivors

Re-run from scratch for this design (a change round resets the gate), with a negative control (unmutated: 102/102 green) and every mutant's kill attributed to a named test. Enumerated from semantic failure modes rather than from deletion alone: deletion, comment-out with the token retained, wrong bind ×4 (declared-instead-of-floored, `null`, `listing.kind`, wrong listing id), branch re-introduction, branch inversion, fail-open, **removal regression** (the on-site queue re-added — the positive control for the removal guard), comparison-direction flip, boundary `>` → `>=`, operand swap, raise/lower inversion, drop-screenshots, drop-the-empty-guard.

**Two rounds were needed, and both findings are worth stating plainly rather than folding into a clean number:**

- Round 1 had **one survivor** — the wrong-listing-id bind (scaffold defect 2 above).
- Round 1's `>` → `>=` mutant was **killed only by a pre-existing test elsewhere in this file**, i.e. it survived *this PR's* coverage. Every case in the block ties nowhere on the ladder, and `>=` only differs on a tie. The NULL-declared case was added specifically to produce one (`nsfwLevelFromContentRating` maps both `null` and `'g'` to the SFW floor), and it now kills that mutant in-block.
- Mutants against `resolveListingRatingFloorInTx` itself are included because this change depends on its raise-only semantics; the helper is pre-existing and separately tested.

## Scope — deliberately narrow

`relistListing` and the on-site reset re-approve both have a **moderator in the loop**, which is why this targets `republishOwnListing` only. An invariant guard pins that `relistListing` still applies no floor.

## Adjacent items (filed, not fixed)

- **Two live listings sit above their declared rating** (`panorama-360`, `prompt-vault` — both `g` with level-2 art). This is a data question, not this code path. *Reported in the task brief; not independently verified here — I have no production data access.* **Closing condition:** a moderator re-rates both from `/apps/review` → Manage listings, or confirms level-2 art is acceptable at `g`; verified by re-reading `content_rating` for those two slugs.
- **Four comments now read narrower than the code** (schema `AppListing.contentRating`, `app-listing-mapper.ts:208-209`, `app-listing-backfill.service.ts:45-46`, `offsite-listing.service.ts` ~2840). `approveRequest`, `reDeriveContentRatingForModLiveEdit` and now `republishOwnListing` all floor an on-site listing's rating. **Closing condition:** a reviewer on this PR decides which reading is canonical and either updates those comments or removes the on-site floors; the comment edit lands in whichever PR they pick. Not done here because the answer changes which code is wrong, not just which sentence.
- **`PlatformDefaultBlock.minContentRating` / `maxContentRating` have zero readers in `src/`** (surfaced by the enumeration above). Dead columns — noted so nobody assumes a third maturity gate exists. **Closing condition:** someone confirms they are unused and drops them, or names the consumer; a `git grep` returning only the schema closes it either way.
- **Do the sibling flips want the same floor?** `relistListing` and the on-site reset re-approve are unfloored today. Both have a human in the loop, so neither is unsafe — but the asymmetry is now the only kind-shaped thing left in this area. **Closing condition:** a reviewer on this PR says yes or no; a yes becomes a follow-up PR touching those two call sites, a no is recorded in this thread and closes it.

## 🔴 Sequencing — BLOCKED on #4413

**#4413 (`zach/app-listing-owner-unpublish-editable`, unmerged) edits `republishOwnListing` in this same file** — 21 hits, and it extracts the last-event guard into a new `app-listing-owner-unpublish.ts`. This PR is branched directly on `main` (not stacked) and must be **rebased onto updated `main` and test-merged after #4413 lands.**

**A clean git merge is not a clean merge.** Both sides edit different parts of the same function, so a *semantic* conflict survives a textless merge. **The merged body of `republishOwnListing` needs reading by a human** before this is taken off draft.

The two are complementary rather than redundant: #4413 blocks the owner from *lowering the declared rating* on a removed listing, and its own docstring says *"Neither republish gate is a content review … so the refusal — not the republish path — is the guarantee."* This PR closes the other half — *raising the media maturity past* an untouched declared rating — and makes the republish path itself a guarantee.
