### PR TITLE
test(auth): stop hand-typing drifted Redis key constants in ban-session-revocation

### DIFF
--- a/src/server/auth/__tests__/ban-session-revocation.test.ts
+++ b/src/server/auth/__tests__/ban-session-revocation.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { SessionClaims } from '@civitai/auth';
+// The REAL key constants, from the package. `~/server/redis/client` is mocked below and the
+// mock spreads this same package, so the shim production reads and the values asserted here
+// are pinned to one source. They used to be hand-typed in the hoisted block, and three of the
+// four had drifted: USER_TOKENS 'session:usertokens' vs the real 'session:user-tokens2',
+// USER.SESSION 'user:session' vs 'session:data2', TOKEN_STATE 'session:tokenstate' vs
+// 'session:token-state' (only SESSION.ALL was right). The suite passed the whole time —
+// both sides used the same wrong string, so it asserted against keys Redis never sees.
+import { REDIS_KEYS, REDIS_SYS_KEYS } from '@civitai/redis/client';
 
 // End-to-end revocation property (the coverage gap behind review finding B2): a banned/logged-out user's
 // active civ-token must stop verifying. The chain spans two modules that share sysRedis:
@@ -11,15 +19,6 @@ import type { SessionClaims } from '@civitai/auth';
 const h = vi.hoisted(() => {
   const hashes = new Map<string, Map<string, string>>();
   const strings = new Map<string, string>();
-  const KEYS = {
-    REDIS_KEYS: {
-      SESSION: { USER_TOKENS: 'session:usertokens' },
-      USER: { SESSION: 'user:session' }, // invalidateAllSessions clears this pattern
-    },
-    REDIS_SYS_KEYS: {
-      SESSION: { TOKEN_STATE: 'session:tokenstate', ALL: 'session:all' },
-    },
-  };
   const sysRedis = {
     hGetAll: async (k: string) => Object.fromEntries(hashes.get(k) ?? new Map<string, string>()),
     // The revocation read scans for field NAMES rather than fetching every value. One page, complete scan —
@@ -40,12 +39,15 @@ const h = vi.hoisted(() => {
       strings.set(k, v);
     },
   };
-  return { hashes, strings, KEYS, sysRedis };
+  return { hashes, strings, sysRedis };
 });
 
-vi.mock('~/server/redis/client', () => ({
+// 🔴 Spread the REAL package for the key constants rather than re-typing them — the same shape
+// `src/__tests__/setup.ts` uses globally. Only the client and the control surface stay
+// overridden; every constant comes from production's own definitions.
+vi.mock('~/server/redis/client', async () => ({
+  ...(await import('@civitai/redis/client')),
   sysRedis: h.sysRedis,
-  ...h.KEYS,
   withSysReadDeadline: <T>(p: Promise<T>) => p, // transparent in tests (matches rate-limiting.test.ts)
 }));
 // session-invalidation marks TOKEN_STATE via the atomic eval helper (hSetMultiWithTTL); the
@@ -70,7 +72,7 @@ vi.mock('~/server/auth/session-cache', () => ({ clearSessionCache: async () => {
 vi.mock('~/server/auth/session-client', () => ({
   sessionClient: {
     invalidateAll: async () => {
-      h.strings.set(h.KEYS.REDIS_SYS_KEYS.SESSION.ALL, new Date(5000).toISOString());
+      h.strings.set(REDIS_SYS_KEYS.SESSION.ALL, new Date(5000).toISOString());
     },
   },
 }));
@@ -92,12 +94,12 @@ import {
 import { isRevoked } from '~/server/auth/session-verifier';
 
 const USER = 5;
-const TOKEN_STATE = h.KEYS.REDIS_SYS_KEYS.SESSION.TOKEN_STATE;
+const TOKEN_STATE = REDIS_SYS_KEYS.SESSION.TOKEN_STATE;
 const claims = (jti: string, signedAt = 1000): SessionClaims => ({ jti, signedAt });
 
 // Mirror the hub's sessions.trackToken (session.ts): record the token's jti under the user's token hash.
 function trackToken(jti: string, userId: number) {
-  const key = `${h.KEYS.REDIS_KEYS.SESSION.USER_TOKENS}:${userId}`;
+  const key = `${REDIS_KEYS.SESSION.USER_TOKENS}:${userId}`;
   const m = h.hashes.get(key) ?? new Map<string, string>();
   m.set(jti, '1');
   h.hashes.set(key, m);

--- a/src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts
+++ b/src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts
@@ -24,7 +24,7 @@ import { mockPattern } from '~/__tests__/mocks/guarded-specifiers';
  * spread `@civitai/redis/client` into the factory for the real constants, and keep only your
  * own client stub and control-surface overrides as explicit properties.
  *
- * 🔴 A RATCHET, NOT A RULE, and deliberately so. 53 files hand-type these blocks today; a
+ * 🔴 A RATCHET, NOT A RULE, and deliberately so. 52 files hand-type these blocks today; a
  * hard rule would be red on all of them from day one, and a permanently-red gate is worse
  * than no gate — it trains everyone to click through. Some are also LEGITIMATE:
  * `BLOCKS.TOKEN_RATE_LIMIT: 'rl'` is a deliberate short stub, not drift. So this does not
@@ -48,6 +48,8 @@ import { mockPattern } from '~/__tests__/mocks/guarded-specifiers';
  * live drifts, `'session:usertokens'` among them. That is not an exotic evasion: 57 of the 66
  * files mocking this specifier already use `vi.hoisted()`, so it was one ordinary refactor
  * away for most of the population — and it made the guard go green rather than red.
+ * (That file is now converted and off the baseline; its three drifts were USER_TOKENS,
+ * USER.SESSION and TOKEN_STATE — its fourth constant, SESSION.ALL, was already correct.)
  *
  * The fix was to stop parsing. This now scans the WHOLE FILE for the property literal rather
  * than the factory body, which catches the hoisted shape and deletes an entire class of
@@ -120,7 +122,6 @@ const HAND_TYPED_BASELINE: string[] = [
   'src/__tests__/pages/api/download/download-quota-seam.test.ts',
   'src/__tests__/pages/api/download/model-version-blocklist.test.ts',
   'src/__tests__/pages/api/download/split-query-repair.test.ts',
-  'src/server/auth/__tests__/ban-session-revocation.test.ts',
   'src/server/auth/__tests__/session-client.test.ts',
   'src/server/events/__tests__/base-event.sysredis-soft.test.ts',
   'src/server/games/daily-challenge/__tests__/challenge-helpers.test.ts',
@@ -238,6 +239,6 @@ describe('no hand-typed Redis key constants in a guarded mock', () => {
   // load-bearing, add the entry AND raise this number in the same commit, with a note saying
   // which it is. A raise is then a visible, reviewable claim rather than a silent one.
   it('the baseline is exactly the recorded size', () => {
-    expect(HAND_TYPED_BASELINE.length).toBe(53);
+    expect(HAND_TYPED_BASELINE.length).toBe(52);
   });
 });


### PR DESCRIPTION
`src/server/auth/__tests__/ban-session-revocation.test.ts` hand-typed its Redis key constants in a `vi.hoisted()` block and spread them into its `~/server/redis/client` mock as `...h.KEYS`. Three of its four constants had drifted from what production uses.

This is the same class #4400 fixed elsewhere. This file survived it because the hoisted-spread shape was invisible to the first revision of the drift guard — that gap is documented in `no-hand-typed-redis-key-constants.test.ts`, and this file is the worked example named there.

## Drift audit — every constant in the fixture

The prior write-up recorded three drifts but noted nobody had enumerated the fixture exactly. Full enumeration; the "real" column is a runtime read of `@civitai/redis/client` under the unit vitest project, not a grep of the source.

| constant | test value | real value | verdict |
|---|---|---|---|
| `REDIS_KEYS.SESSION.USER_TOKENS` | `session:usertokens` | `session:user-tokens2` | **drifted** |
| `REDIS_KEYS.USER.SESSION` | `user:session` | `session:data2` | **drifted** |
| `REDIS_SYS_KEYS.SESSION.TOKEN_STATE` | `session:tokenstate` | `session:token-state` | **drifted** |
| `REDIS_SYS_KEYS.SESSION.ALL` | `session:all` | `session:all` | correct |

Four constants, three drifted. `SESSION.ALL` was the one that was already right — reported because a clean result is part of the enumeration, not an omission.

`REDIS_KEYS.USER.SESSION` is additionally **dead** in this fixture: nothing in the file or its module graph reads it (`clearCacheByPattern` is stubbed to a no-op). Its comment claimed `invalidateAllSessions` clears that pattern, which is no longer true either — mass invalidation now routes through the hub and deliberately does not wipe the shaped session cache. It goes away with the hand-typed block rather than being corrected in place.

## The fix

The shape `src/__tests__/setup.ts` already uses globally, and that the sibling `session-invalidation.test.ts` already uses locally:

```ts
vi.mock('~/server/redis/client', async () => ({
  ...(await import('@civitai/redis/client')),
  sysRedis: h.sysRedis,
  withSysReadDeadline: <T>(p: Promise<T>) => p,
}));
```

Only the client stub and the transparent read-deadline stay overridden; every constant now comes from production's own definitions. The file's behavioural stubs are untouched — the in-memory `h` harness, the `hSetMultiWithTTL` write-through, the simulated hub in the `session-client` mock.

The assertion side (`trackToken`, `TOKEN_STATE`, the hub's `SESSION.ALL` write) imports the same constants from the package directly, matching what `session-invalidation.test.ts` in the same directory does. That is deliberate and is what makes the mutation below possible: the test asserts through the **package**, production reads through the **shim**, so the suite now pins that the two agree on the session keys rather than merely agreeing with itself.

## Before / after

Both runs: `vitest run --project 'unit*' src/server/auth/__tests__/ban-session-revocation.test.ts`

| | Test Files | Tests |
|---|---|---|
| baseline, unmodified `main` | 1 passed (1) | **7 passed (7)** |
| after conversion | 1 passed (1) | **7 passed (7)** |

No assertion was edited. The suite passing unchanged is the expected result and is also the evidence of what was wrong: the old fixture was internally consistent, so the writer and the reader agreed on a key Redis never sees.

## Vacuity proof

A test that passes with both fake and real keys is testing nothing, so the conversion has to be shown to buy something. Two mutants, each overriding exactly one constant in the spread back to its pre-fix drifted value, leaving everything else real. Both killed:

| mutant | result |
|---|---|
| `TOKEN_STATE` → `session:tokenstate` | **3 failed / 4 passed** |
| `USER_TOKENS` → `session:usertokens` | **5 failed / 2 passed** |

Both first fail at `revokes a tracked token after invalidateSession (ban path)`:

```
AssertionError: expected undefined to be 'invalid' // Object.is equality
- Expected: "invalid"
+ Received: undefined
```

— the `expect(h.hashes.get(TOKEN_STATE)?.get('tok-1')).toBe('invalid')` hash-layout assertion. Mutants reverted; back to 7/7.

Worth stating what the kill counts show. Under the `TOKEN_STATE` mutant the three failures are all hash-layout assertions; the `isRevoked(...)` assertions still pass, because the writer and the reader both moved to the mutated key and stayed consistent with each other. That is exactly the vacuity the fixture used to have, reproduced on demand — and it is the reason the direct-on-the-store assertions are load-bearing rather than redundant with the `isRevoked` ones. The `USER_TOKENS` mutant is broader (5) because production then scans a hash the test never wrote to, so no token is found at all and the whole ban→revoke chain no-ops.

## Baseline decrement

`HAND_TYPED_BASELINE` in `src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts` loses this file, and `expect(HAND_TYPED_BASELINE.length).toBe(53)` becomes `52`. That guard fails in both directions — on growth and on a stale entry — so a half-done edit turns it red; both halves are in this commit.

Control run, so the decrement is not just a number I edited: putting the entry back with the file converted turns `every baseline entry is still a real violation` red (1 failed / 3 passed), which is the detector confirming it genuinely no longer sees the file.

The guard's docblock is updated in two places: the `53 files ... today` count, and a note on the passage that uses this file as its worked example so it does not keep reading as an open drift.

## Checks run

| check | result |
|---|---|
| target file (`unit*`) | 7 passed (7) |
| drift guard | 4 passed (4) |
| with `no-direct-shared-module-mock`, `no-wholesale-module-mock`, `session-invalidation` | 5 files, 128 passed (128) |
| `pnpm typecheck` | `OK — 0 type errors in 90s` |
| `prettier --check` (both files) | clean |
| `eslint` (both files) | 6 pre-existing `no-empty-function` errors on the stub lines — byte-identical count and rules on `main`, none introduced here |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
