### PR TITLE
fix(collections): keep the sidebar usable behind the NSFW gate

### DIFF
--- a/src/components/Collections/CollectionsLayout.module.scss
+++ b/src/components/Collections/CollectionsLayout.module.scss
@@ -25,6 +25,11 @@
 
 .content {
   flex: 1;
+  // The NSFW/login gate renders as `absolute inset-0`. With no positioning context here it
+  // resolves against `.scroll-area` and covers the sidebar, leaving the rest of /collections
+  // unreachable; the height gives it the sidebar's column to centre in.
+  position: relative;
+  min-height: calc(100dvh - var(--header-height, 0px) - var(--footer-height, 0px) - 68px);
 }
 
 .drawerButton {


### PR DESCRIPTION
## Problem

Landing on an NSFW collection from civitai.com (the SFW site) makes the whole `/collections` page unreachable — the "My Collections" sidebar is unclickable and the only working control is **Continue on civitai.red**.

## Cause

`Gated` renders its gate views as `<div className="absolute inset-0 …">` (`src/components/Gated/Gated.tsx`). `.content` in `CollectionsLayout.module.scss` had no positioning context, so `inset-0` resolved against `.scroll-area` — which *is* `position: relative` (`src/styles/globals.css:513`) — and the overlay covered the entire main column, the sidebar included.

Collections is the only `Gated` consumer nested inside a layout with a persistent sibling; the other seven are full-page detail views where overlaying the scroll area is correct. So the fix is local to the collections layout, not to `Gated`.

## Fix

`position: relative` on `.content`, scoping the overlay to the collection column, plus a `min-height` matching the sidebar's height budget — in a gate state `Gated` renders no children, so `.content` would otherwise be 0-height and the shield card would centre on `y = 0`.

One file, six lines.

## Verification

- `pnpm run test:unit:run` — 22,631 passed. The one failing file (`src/components/Apps/__tests__/appListingDescription.test.ts`) fails on `main` too; see the note below.
- **Not** visually verified: `canViewNsfw` is available to the `blue` color (`feature-flags.service.ts:417`), so the gate never fires on a local dev server. This is verified by mechanism, not by screenshot.

## Unrelated, pre-existing (noted, not fixed here)

`src/components/Apps/AppListingDescription.tsx` and `src/components/Apps/appListingDescription.ts` differ only in case. On a case-insensitive filesystem both import spellings resolve to the `.ts` file, so on macOS `pnpm typecheck` reports 6 errors under `src/components/Apps/**` and the whole `component` vitest project fails its esbuild step (`Test Files (0)`). Present on `main`; worth a separate rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeHpsiPpnTv4aW43Kqpuyu