### PR TITLE
test(redis): stop hand-typing drifted CACHE_LOCKS in two cache suites

### DIFF
--- a/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
+++ b/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
@@ -30,7 +30,12 @@ const setMock = vi.fn(async (key: string, value: unknown) => {
 const delMock = vi.fn(async () => undefined);
 const setNxMock = vi.fn().mockResolvedValue(true);
 
-vi.mock('~/server/redis/client', () => ({
+// 🔴 Spreads the real package for the key CONSTANTS; only the client stubs are overridden.
+// `REDIS_KEYS.CACHE_LOCKS` used to be hand-typed here as 'caches:lock' — the real value is
+// 'cache-lock'. Both the lock writer and the lock reader read that one fake, so the suite
+// passed while exercising a key Redis never sees. See no-hand-typed-redis-key-constants.test.ts.
+vi.mock('~/server/redis/client', async () => ({
+  ...(await import('@civitai/redis/client')),
   redis: {
     packed: {
       mGet: (...args: unknown[]) => mGetMock(...(args as [string[]])),
@@ -40,7 +45,6 @@ vi.mock('~/server/redis/client', () => ({
     del: (...args: unknown[]) => delMock(...args),
   },
   sysRedis: {},
-  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
 }));
 vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
 vi.mock('~/server/prom/client', () => ({

--- a/src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts
+++ b/src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts
@@ -24,7 +24,7 @@ import { mockPattern } from '~/__tests__/mocks/guarded-specifiers';
  * spread `@civitai/redis/client` into the factory for the real constants, and keep only your
  * own client stub and control-surface overrides as explicit properties.
  *
- * 🔴 A RATCHET, NOT A RULE, and deliberately so. 52 files hand-type these blocks today; a
+ * 🔴 A RATCHET, NOT A RULE, and deliberately so. 50 files hand-type these blocks today; a
  * hard rule would be red on all of them from day one, and a permanently-red gate is worse
  * than no gate — it trains everyone to click through. Some are also LEGITIMATE:
  * `BLOCKS.TOKEN_RATE_LIMIT: 'rl'` is a deliberate short stub, not drift. So this does not
@@ -132,7 +132,6 @@ const HAND_TYPED_BASELINE: string[] = [
   'src/server/jobs/__tests__/rewards-abuse-prevention.test.ts',
   'src/server/metrics/__tests__/base.metrics.test.ts',
   'src/server/orchestrator/__tests__/get-orchestrator-token.sysredis-soft.test.ts',
-  'src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts',
   'src/server/redis/__tests__/queues.test.ts',
   'src/server/routers/__tests__/track.router.blockRender.test.ts',
   'src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts',
@@ -144,7 +143,6 @@ const HAND_TYPED_BASELINE: string[] = [
   'src/server/services/generation/__tests__/generation.service.client-rejections.test.ts',
   'src/server/services/generation/__tests__/generation.service.generation-disabled-flag.test.ts',
   'src/server/services/generation/__tests__/generation.service.hidden-prompt.test.ts',
-  'src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts',
   'src/server/services/generation/__tests__/generation.service.scheduled-status.test.ts',
   'src/server/services/generation/__tests__/generation.service.sysredis-soft.test.ts',
   'src/server/services/orchestrator/__tests__/orchestration-new.air-map.test.ts',
@@ -239,6 +237,6 @@ describe('no hand-typed Redis key constants in a guarded mock', () => {
   // load-bearing, add the entry AND raise this number in the same commit, with a note saying
   // which it is. A raise is then a visible, reviewable claim rather than a silent one.
   it('the baseline is exactly the recorded size', () => {
-    expect(HAND_TYPED_BASELINE.length).toBe(52);
+    expect(HAND_TYPED_BASELINE.length).toBe(50);
   });
 });

--- a/src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts
@@ -23,9 +23,18 @@ const setMock = vi.fn().mockResolvedValue(undefined);
 const setNxMock = vi.fn().mockResolvedValue(true);
 const delMock = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('~/server/redis/client', () => {
-  const sysKeyProxy: any = new Proxy(() => 'sys', { get: () => sysKeyProxy });
+// 🔴 Spreads the real package for the key CONSTANTS; only the client stubs and the transparent
+// read-deadline are overridden. This block used to hand-type them: `CACHE_LOCKS: 'caches:lock'`
+// against the real 'cache-lock', and a catch-all Proxy standing in for the whole REDIS_SYS_KEYS /
+// REDIS_SUB_KEYS tables (every sys key stringified to 'sys'). Both sides of every lock read the
+// same fake, so the suite passed while exercising keys Redis never sees. `withSysReadDeadline`
+// stays overridden because it is a control surface, not a constant, and the package does not
+// export it — the app shim re-exports it from '~/server/redis/sys-read-deadline'.
+// See no-hand-typed-redis-key-constants.test.ts.
+vi.mock('~/server/redis/client', async () => {
+  const real = await import('@civitai/redis/client');
   return {
+    ...real,
     redis: {
       packed: {
         mGet: (...args: unknown[]) => mGetMock(...args),
@@ -39,12 +48,6 @@ vi.mock('~/server/redis/client', () => {
     },
     // getGateRules reads this; null => no gate rules configured.
     sysRedis: { hGet: vi.fn().mockResolvedValue(null), hSet: vi.fn() },
-    REDIS_KEYS: {
-      CACHE_LOCKS: 'caches:lock',
-      GENERATION: { RESOURCE_DATA: 'packed:generation:resource-data-3' },
-    },
-    REDIS_SYS_KEYS: sysKeyProxy,
-    REDIS_SUB_KEYS: sysKeyProxy,
     withSysReadDeadline: vi.fn((p: Promise<unknown>) => p),
   };
 });


### PR DESCRIPTION
Two suites mocked `~/server/redis/client` with hand-typed Redis key constants. Both are on `HAND_TYPED_BASELINE`; this converts them to spread the real package and drops them from the baseline.

## Every constant in both fixtures

Enumerated against `@civitai/redis/client` (read at runtime, not by grep — `REDIS_KEYS` is built through `applyCacheKeyPrefix`, which is a no-op when `CACHE_KEY_NAMESPACE` is unset, as it is under test).

**`src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts`**

| Constant | Hand-typed | Real | Verdict |
|---|---|---|---|
| `REDIS_KEYS.CACHE_LOCKS` | `'caches:lock'` | `'cache-lock'` | **DRIFTED** |

That is the file's only constant.

**`src/server/services/generation/__tests__/generation.service.resource-data-aliasing.test.ts`**

| Constant | Hand-typed | Real | Verdict |
|---|---|---|---|
| `REDIS_KEYS.CACHE_LOCKS` | `'caches:lock'` | `'cache-lock'` | **DRIFTED** |
| `REDIS_KEYS.GENERATION.RESOURCE_DATA` | `'packed:generation:resource-data-3'` | same | correct |
| `REDIS_SYS_KEYS` | catch-all `Proxy`, every key stringifies to `'sys'` | 32 real top-level groups | synthetic stand-in |
| `REDIS_SUB_KEYS` | catch-all `Proxy`, every key stringifies to `'sys'` | 3 real top-level groups | synthetic stand-in |

The two Proxies were not drift in the "wrong literal" sense — they were a wholesale stand-in for the entire sys/sub key tables, which the spread replaces with the real values.

## The fix

The shape `src/__tests__/setup.ts` already uses globally: spread `@civitai/redis/client` into the factory for the constants, keep each file's behavioural stubs as explicit overrides. File 2's factory is a block body rather than a bare object, so it binds the import to a local and spreads that, instead of copying the inline form.

`withSysReadDeadline` stays overridden in file 2: it is a control surface, not a constant, and the package does not export it — the app shim re-exports it from `~/server/redis/sys-read-deadline`.

## Vacuity check — a finding, not a kill

Per file, `CACHE_LOCKS` was overridden in the spread back to the pre-fix `'caches:lock'` and the file re-run:

| File | Result |
|---|---|
| `model-version-public-donation-goals-cache.test.ts` | 4 passed — **SURVIVED** |
| `generation.service.resource-data-aliasing.test.ts` | 4 passed — **SURVIVED** |

**Neither file can be made to go red, so both are key-agnostic on `CACHE_LOCKS`.** Reported rather than engineered around: no assertion was edited to force green, and no two-specifier shape was manufactured just to produce a red.

This is not a mutant that failed to execute. A temporary probe asserting the value the module under test actually receives printed `PROBE CACHE_LOCKS = "caches:lock"` and failed under each mutant, and passed against `'cache-lock'` on the converted file. The mutants ran; the suites simply cannot observe the key, because both the lock writer and the lock reader resolve the same specifier out of the same in-memory fake.

So the conversion removes the drift class and pins these constants to one source, but adds no detectable assertion to either suite. Worth stating plainly, since the value here is preventing future drift rather than catching present breakage.

## Baseline decrement

Both entries removed from `HAND_TYPED_BASELINE`, exact-size assertion `52` → `50`, and the ratchet count in the docblock updated to match. The guard fails on growth *and* on a stale entry, so this had to land in the same commit.

**Guard control** — with the files converted, one entry was re-added *and* the size raised to 51, so the size assertion could not be what failed. Exactly one test went red:

```
FAIL  every baseline entry is still a real violation
+   "src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts"
Tests  1 failed | 3 passed (4)
```

The decrement therefore reflects the detector, not an edited number.

## Counts

| Run | Result |
|---|---|
| Both target files, before (at the merge base) | 2 files passed, **8 tests passed** |
| Both target files, after | 2 files passed, **8 tests passed** |
| Guard at 50 | 1 file passed, **4 tests passed** |
| All three files together | 3 files passed, **12 tests passed** |
| Siblings `no-direct-shared-module-mock` + `no-wholesale-module-mock` | 2 files passed, **100 tests passed** |

Prettier and ESLint clean on all three files, each verified against a known-bad probe file first so the clean verdicts are a fact about the code and not about the invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
