### PR TITLE
test(images): spread the real RoutedDialogLink instead of replacing it, and put it under the wholesale-mock rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,28 @@ module.exports = {
     // comment, a false negative costs a silently-empty test suite. The known
     // false-positive shapes are listed in eslint-local-rules.js so a blocked
     // author can recognise their own and reach for a disable comment.
-    'local-rules/no-wholesale-module-mock': ['error', { modules: ['~/utils/trpc'] }],
+    // `modules` is a CURATED registry, not the whole hazard: the rule only looks
+    // at modules named here, so a module absent from this list is not "safe", it
+    // is UNWATCHED. That is not hypothetical — `~/utils/trpc` was the only entry
+    // when the identical defect landed on `~/components/Dialog/RoutedDialogLink`
+    // (#4364 added a `triggerRoutedDialog` importer three files away from a
+    // factory that listed only `RoutedDialogLink`; the carousel suite died at
+    // import and collected 0 tests for ~17h, reported as `Tests 2062 passed`).
+    //
+    // Add a module here once its wholesale mocks are converted to the
+    // `importOriginal` spread — the entry is only free while the site count is
+    // low. Measured on this tree: 62 modules are wholesale-mocked somewhere in
+    // the browser suite with at least one REAL export omitted, over 329 call
+    // sites, and `eslint src/**/*.browser.test.tsx` already reports 52 files
+    // violating this rule for `~/utils/trpc` alone. Those persist because the
+    // ESLint gate in .github/workflows/lint.yml blocks only ADDED files; the
+    // modified-files pass is `continue-on-error: true`. So widening this list
+    // holds NEW browser tests to the pattern and annotates the rest — it does
+    // not retroactively fix them.
+    'local-rules/no-wholesale-module-mock': [
+      'error',
+      { modules: ['~/utils/trpc', '~/components/Dialog/RoutedDialogLink'] },
+    ],
 
     // aligns closing brackets for tags
     'react/jsx-closing-bracket-location': ['error', 'line-aligned'],

--- a/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
@@ -4,6 +4,7 @@ import { page, userEvent } from 'vitest/browser';
 // does not participate in mock hoisting. `@typescript-eslint/consistent-type-imports` rejects
 // the `typeof import('...')` form, which is why this is a named namespace.
 import type * as TrpcUtils from '~/utils/trpc';
+import type * as RoutedDialogLinkModule from '~/components/Dialog/RoutedDialogLink';
 
 // =============================================================================
 // Gallery lazy per-post carousel (`galleryLazyPostImages`).
@@ -172,14 +173,16 @@ vi.mock('~/components/Image/ContextMenu/ImagesAsPostsContextMenu', () => ({
 }));
 vi.mock('~/components/Image/Meta/ImageMetaPopover', () => ({ ImageMetaPopover2: () => null }));
 vi.mock('~/components/Cards/components/HoverActionButton', () => ({ default: () => null }));
-// A whole-module factory REPLACES the module, so it must carry every export the
-// import graph reaches — not just the one this test renders. #4364 pulled
-// RemixedCardFlyout into ImagesAsPostsCard, and that component imports
-// `triggerRoutedDialog` from here, so a factory listing only RoutedDialogLink turns
-// into an import-time SyntaxError for the whole file.
-vi.mock('~/components/Dialog/RoutedDialogLink', () => ({
+// Spread the real module and override only what this test renders. A WHOLESALE
+// factory would replace the module, pinning its export surface to whatever was
+// needed the day it was written: #4364 pulled RemixedCardFlyout into
+// ImagesAsPostsCard, that component imports `triggerRoutedDialog` from here, and
+// the then-current factory listed only RoutedDialogLink — so the whole FILE died
+// at import with a SyntaxError and collected 0 tests for ~17h without going red
+// in any pass/fail count. Spreading is immune to the next export added upstream.
+vi.mock('~/components/Dialog/RoutedDialogLink', async (importOriginal) => ({
+  ...(await importOriginal<typeof RoutedDialogLinkModule>()),
   RoutedDialogLink: ({ children }: any) => <a>{children}</a>,
-  triggerRoutedDialog: vi.fn(),
 }));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ imageGeneration: false }),


### PR DESCRIPTION
Follow-up to #4393, which stopped the bleeding by hand-adding the one missing export. This removes the failure mode instead of patching its latest instance.

## What broke

`ImagesAsPostsCardLazyCarousel.browser.test.tsx` mocked `~/components/Dialog/RoutedDialogLink` with a **wholesale** factory. A factory that returns a hand-written object *replaces* the module, so its export surface is frozen at whatever the author needed that day. #4364 pulled `RemixedCardFlyout` into `ImagesAsPostsCard`, and that component imports `triggerRoutedDialog` from RoutedDialogLink. Browser mode serves native ESM, so a missing named export is a **link-time** error that kills the whole file:

```
SyntaxError: The requested module '/src/components/Dialog/RoutedDialogLink.tsx'
does not provide an export named 'triggerRoutedDialog'
```

## It was never a flake

It is a deterministic function of which commits a PR's tree contains. Over the six PRs that actually ran the component tier, ancestry predicts the outcome **6 for 6**:

| PR | contains #4364 (breaks) | contains #4393 (fixes) | predicted | observed |
|---|---|---|---|---|
| #4370 | yes | no | RED | `component-tests` fail |
| #4390 | yes | no | RED | `component-tests` fail |
| #4392 | yes | no | RED | `component-tests` fail |
| #4403 | yes | yes | GREEN | `component-tests` pass |
| #4416 | yes | yes | GREEN | `component-tests` pass |
| #4419 | yes | yes | GREEN | `component-tests` pass |

The window was #4364 (2026-08-25T03:33Z) → #4393 (2026-08-25T20:13Z), ~17h. A local run on a checkout outside that window is green, which is why re-running never reproduced it. The small denominator is just that the tier runs only on preview-labelled PRs.

This is also the **second** time this file lost all nine of its tests to this class — the comment above its `~/utils/trpc` mock records #3859 doing the same thing via `trpcVanilla`. Hand-adding the missing export fixes the instance and leaves the mechanism armed.

## The change

1. The factory now spreads the real module and overrides only what it renders, so a future export added upstream is inherited and this cannot recur here.
2. `~/components/Dialog/RoutedDialogLink` joins the `no-wholesale-module-mock` module list. **That rule already existed and is correct** — it was configured with exactly one module (`~/utils/trpc`), so it was structurally blind to this one. A module absent from that list is not safe, it is *unwatched*; the comment now says so.

## Red / green

All measured on this branch's merge base (`24d8f4b3e4`), component project run alone against real Chromium.

**Guard** — it pins the *shape*, so it would have fired before #4364 ever landed, not merely after the export went missing:

| tree | `no-wholesale-module-mock` |
|---|---|
| pre-change factory + widened rule | **ERROR** at the factory (19 problems) |
| this change | 0 findings (18 problems, all pre-existing) |

**Behaviour:**

| tree | result |
|---|---|
| fix line removed (reproducing the original defect on *current* main) | `Test Files 1 failed (1)` / `Tests no tests`, exit 1 |
| #4393 as merged | 1 passed, 9 tests |
| this change (`importOriginal` spread) | 1 passed, 9 tests |
| full component project, before | `190 passed (190)`, 2094 tests |
| full component project, after | `190 passed (190)`, 2094 tests |

Counted **files**, not the pass total, on purpose: an import failure collects zero tests, so the broken run still read `Tests 2062 passed, 0 failed`.

Typecheck (`node scripts/typecheck.mjs -p tsconfig.tests.json`) is red on main for pre-existing reasons — 967 errors here. Neither changed file appears in any of them. Prettier clean.

## Scope, stated honestly

This does **not** retroactively fix the rest of the field, and the field is large: `eslint 'src/**/*.browser.test.tsx'` on this tree reports **52 files** already violating this rule for `~/utils/trpc` alone, and an independent scan finds **329 wholesale mock sites across 62 modules** that omit at least one real export — each a latent copy of this outage. They persist because the ESLint gate in `.github/workflows/lint.yml` blocks only **added** files; its modified-files pass is `continue-on-error: true`. Widening the module list holds new browser tests to the pattern and annotates the rest.

#4416 (`deps.optimizer`) is **not** involved: the red arm above reproduces byte-identically on top of it, and it scoped its optimizer and `fsModuleCache` changes to the unit projects, not the browser `component` project.

Since the tier was never flaky — it was correctly red for a real defect that is now fixed, and it is green at 190/190 on current main — there is no de-flaking blocker left in the way of promoting it to gating.
