### PR TITLE
feat(moderation): add BotAccount ban reason

### DIFF
--- a/apps/moderator/src/lib/enforcement.ts
+++ b/apps/moderator/src/lib/enforcement.ts
@@ -18,6 +18,7 @@ export const BAN_REASONS = [
   'Nudify',
   'Harassment',
   'SpamBot',
+  'BotAccount',
   'LeaderboardCheating',
   'BuzzCheating',
   'RRDViolation',

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1755,6 +1755,11 @@ export const banReasonDetails: Record<
     publicBanReasonLabel: 'Community Abuse',
     privateBanReasonLabel: 'Spambot or automated account',
   },
+  [BanReasonCode.BotAccount]: {
+    code: BanReasonCode.BotAccount,
+    publicBanReasonLabel: 'Community Abuse',
+    privateBanReasonLabel: 'Automated / bot account',
+  },
   [BanReasonCode.LeaderboardCheating]: {
     code: BanReasonCode.LeaderboardCheating,
     publicBanReasonLabel: 'Leaderboard manipulation',

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -334,6 +334,7 @@ export enum BanReasonCode {
   Nudify = 'Nudify',
   Harassment = 'Harassment',
   SpamBot = 'SpamBot',
+  BotAccount = 'BotAccount',
   LeaderboardCheating = 'LeaderboardCheating',
   BuzzCheating = 'BuzzCheating',
   RRDViolation = 'RRDViolation',


### PR DESCRIPTION
Closes [CU-868kw67xe](https://app.clickup.com/t/8459928/868kw67xe)

## What

Adds a `BotAccount` ban reason so moderators can record "this was an automated account" separately from `SpamBot` ("this account ran a spam campaign").

- `src/server/common/enums.ts` — new `BanReasonCode.BotAccount` member, placed next to `SpamBot`
- `src/server/common/constants.ts` — matching `banReasonDetails` entry
- `apps/moderator/src/lib/enforcement.ts` — added to the mirrored `BAN_REASONS` list

## Why no UI change

`UserBanModal` builds its dropdown from `Object.keys(BanReasonCode)` + `banReasonDetails`, so the new reason appears automatically. `z.enum(BanReasonCode)` in `user.schema.ts` and `/api/mod/ban-user.ts` accepts it for the same reason.

The moderator studio **does** hardcode its own list (`enforcement.ts`), whose comment states a code present in the main app but missing there is absent from the dropdown — so it is mirrored. Its `<Select.Item>` renders the raw code, so no label map to update. `apps/auth`'s ban path deliberately does not carry the enum or the label table, so it needs nothing.

## Two calls made, flagging for the reviewer

1. **Public label.** The task left `publicBanReasonLabel` as a TODO. Used `'Community Abuse'`, matching `SpamBot`, since it's the same class of ban from the banned user's point of view. Easy to change to `''` if we'd rather show nothing.
2. **Content removal is NOT pre-ticked.** `SpamBot` appears in `BAN_REASONS_REMOVING_CONTENT` (moderator) and in `UserBanModal`'s `handleReasonChange` (main app), so choosing it pre-ticks media/comment removal. `BotAccount` is deliberately left out of both — the task asked only for the reason, and pre-ticking a destructive default is not something to infer. Say the word if bot bans should take content down by default and I'll add it to both places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeHpsiPpnTv4aW43Kqpuyu
