### PR TITLE
fix(remix-gallery): cast the Availability parameter that is 500ing every gallery read (42883)

### DIFF
--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -149,6 +149,7 @@ const {
   setRemixGalleryPins,
   parseGalleryCursor,
   getRemixGallery,
+  getRemixGalleryCardSummaries,
   getRemixGalleryVisibility,
   getRemixGalleryFreeEligibility,
   getMyRemixGallerySubmissions,
@@ -2399,5 +2400,181 @@ describe('the removal cooldown on a free entry', () => {
         isModerator: true,
       })
     ).resolves.toMatchObject({ removed: true });
+  });
+});
+
+/**
+ * Every `Availability` value bound into raw SQL carries its `::"Availability"` cast.
+ *
+ * 🔴 This is a REGRESSION guard, not a style rule. Prisma binds an interpolated
+ * string as a `text` parameter, and Postgres has no `"Availability" <> text`
+ * operator, so an uncast comparison does not filter fewer rows — it aborts the
+ * whole statement at parse time with SQLSTATE 42883 (`operator does not exist`).
+ * Every read composing the predicate then 500s deterministically, whatever the
+ * data looks like. That is exactly what happened when the shared entry predicate
+ * gained its private-post guard: `placement.getRemixGalleryCardSummaries`,
+ * `getRemixGalleryVisibility`, `getRemixGallery` and
+ * `getMyRemixGallerySubmissions` all failed together.
+ *
+ * ⚠️ What this cannot do: with no database in this suite it asserts on the SQL
+ * the service COMPOSES, so it proves the cast is written, not that Postgres
+ * accepts the statement. It is aimed at the one failure mode that has actually
+ * shipped — the cast being absent.
+ *
+ * Deliberately NOT a search for the literal `::"Availability"` anywhere in the
+ * query. That passes while a *second*, different comparison in the same
+ * statement is still uncast, which is the whole shape of this defect: three
+ * queries shared one broken fragment. The guard walks every bound parameter
+ * instead, so it is as wide as the class.
+ */
+describe('Availability parameters are cast to the enum, not bound as text', () => {
+  const AVAILABILITY_VALUES = new Set<unknown>(Object.values(Availability));
+
+  type SqlLike = { strings: readonly string[]; values: readonly unknown[] };
+
+  /**
+   * Duck-typed rather than `instanceof Prisma.Sql`: `@prisma/client` may resolve
+   * to a stub here, where `Prisma.Sql` is `undefined` and `instanceof` throws.
+   */
+  const isSql = (value: unknown): value is SqlLike =>
+    !!value &&
+    typeof value === 'object' &&
+    Array.isArray((value as SqlLike).strings) &&
+    Array.isArray((value as SqlLike).values);
+
+  /**
+   * The statement Prisma would send, with each scalar replaced by the `$N`
+   * placeholder it is bound to — nested fragments spliced inline and numbered
+   * left to right, which is Prisma's own rule. `flatten` above cannot serve
+   * here: it drops the values entirely, so the text it returns has nothing
+   * where the parameter goes and cannot say what follows one.
+   *
+   * 🔴 `--` line comments are stripped BEFORE any assertion reads this. The
+   * service explains this very cast in a comment beside the clause, so a naive
+   * substring check would be satisfied by the prose whether or not the cast is
+   * in the SQL.
+   */
+  function render(call: unknown[]) {
+    const [strings, ...values] = call as [readonly string[], ...unknown[]];
+    const params: unknown[] = [];
+    const expand = (parts: readonly string[], vals: readonly unknown[]): string =>
+      parts.reduce((out, part, i) => {
+        if (i >= vals.length) return out + part;
+        const value = vals[i];
+        if (isSql(value)) return out + part + expand(value.strings, value.values);
+        params.push(value);
+        return `${out}${part}$${params.length}`;
+      }, '');
+    const sql = expand(strings, values)
+      .replace(/--[^\n]*/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return { sql, params };
+  }
+
+  /** Every placeholder an Availability member is bound to, with the text that follows it. */
+  const availabilityBindings = () =>
+    queryRaw.mock.calls.flatMap((call) => {
+      const { sql, params } = render(call as unknown[]);
+      return params.flatMap((param, index) => {
+        if (!AVAILABILITY_VALUES.has(param)) return [];
+        const placeholder = `$${index + 1}`;
+        // `(?!\d)` so `$1` does not match inside `$12`.
+        const at = sql.search(new RegExp(`\\${placeholder}(?!\\d)`));
+        return [
+          {
+            param,
+            placeholder,
+            follows: at < 0 ? null : sql.slice(at + placeholder.length),
+          },
+        ];
+      });
+    });
+
+  const expectEveryBindingCast = (route: string) => {
+    const bindings = availabilityBindings();
+    // 🔴 Positive control. A read that stopped comparing availability at all
+    // binds nothing, and the loop below would then assert over an empty list and
+    // pass — the reassuring zero this repo keeps getting caught by. Naming the
+    // route makes the failure say which read went quiet.
+    expect(
+      bindings.length,
+      `${route} bound no Availability parameter at all — the guard has nothing to check`
+    ).toBeGreaterThan(0);
+    for (const binding of bindings)
+      expect(
+        binding.follows,
+        `${route}: ${binding.placeholder} (${String(binding.param)}) is bound as text; ` +
+          'append ::"Availability" or Postgres rejects the statement with 42883'
+      ).toMatch(/^::"Availability"/);
+  };
+
+  beforeEach(() => {
+    queryRaw.mockImplementation(async () => []);
+  });
+
+  it('in the batched card-summary read', async () => {
+    await getRemixGalleryCardSummaries({
+      imageIds: [HOST_IMAGE],
+      browsingLevel: sfwBrowsingLevelsFlag,
+    });
+    expectEveryBindingCast('getRemixGalleryCardSummaries');
+  });
+
+  it('in the gallery ordering read', async () => {
+    await getRemixGallery({ hostImageId: HOST_IMAGE, browsingLevel: sfwBrowsingLevelsFlag });
+    expectEveryBindingCast('getRemixGallery');
+  });
+
+  // Its own case rather than folded into the one above: `galleryHasEntries` is a
+  // separate statement that composes the same fragment, and it runs on every
+  // image detail view.
+  it('in the has-entries read behind the visibility card', async () => {
+    resolvePlacementSpaceFor.mockResolvedValue(openSpace);
+    await getRemixGalleryVisibility({
+      hostImageId: HOST_IMAGE,
+      browsingLevel: sfwBrowsingLevelsFlag,
+      domainLevels: allBrowsingLevelsFlag,
+    });
+    expectEveryBindingCast('getRemixGalleryVisibility');
+  });
+
+  // The second copy of the clause, written out inline rather than composed from
+  // the shared fragment — so fixing the fragment does not fix this one.
+  it("in the submitter's own-submissions host read", async () => {
+    placementFindMany.mockResolvedValue([
+      { id: 1, targetId: HOST_IMAGE, ownerId: OWNER, data: { imageId: REMIX_IMAGE } },
+    ]);
+    await getMyRemixGallerySubmissions({
+      placerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+    expectEveryBindingCast('getMyRemixGallerySubmissions');
+  });
+
+  /**
+   * The whole clause, its cast and both of its neighbours, as one normalised
+   * string — not a substring of it.
+   *
+   * The leading and trailing `AND`s are load-bearing for the same reason the
+   * host-read test above says they are: pinning the fragment alone pins the
+   * spelling of a predicate without pinning how it joins the others, and
+   * flipping one `AND` to `OR` makes the entire WHERE permissive while every
+   * fragment-shaped assertion stays green.
+   */
+  it('pins the shared entry predicate as a whole, cast included', async () => {
+    await getRemixGalleryCardSummaries({
+      imageIds: [HOST_IMAGE],
+      browsingLevel: sfwBrowsingLevelsFlag,
+    });
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const { sql, params } = render(queryRaw.mock.calls[0] as unknown[]);
+    const n = params.indexOf(Availability.Private) + 1;
+    expect(n, 'Availability.Private is not bound by this read').toBeGreaterThan(0);
+    expect(sql).toContain(
+      `AND p."publishedAt" < now() AND p."availability" != $${n}::"Availability" ` +
+        `AND i.ingestion = 'Scanned'`
+    );
   });
 });

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -2428,13 +2428,24 @@ describe('the removal cooldown on a free entry', () => {
  * instead, so it is as wide as the class.
  */
 describe('Availability parameters are cast to the enum, not bound as text', () => {
+  // Identified BY VALUE, because a Prisma tagged template hands the test bare
+  // scalars with no type information attached. Deliberately over-inclusive: a
+  // future unrelated parameter whose value happens to be the string 'Public' or
+  // 'Private' would be required to carry the cast too. That direction is the
+  // safe one — it can demand a cast that is not needed, never miss one that is —
+  // and the failure message names the route and the placeholder, so a false
+  // positive is a minute's work rather than a mystery.
   const AVAILABILITY_VALUES = new Set<unknown>(Object.values(Availability));
 
   type SqlLike = { strings: readonly string[]; values: readonly unknown[] };
 
   /**
-   * Duck-typed rather than `instanceof Prisma.Sql`: `@prisma/client` may resolve
-   * to a stub here, where `Prisma.Sql` is `undefined` and `instanceof` throws.
+   * Duck-typed rather than `instanceof Prisma.Sql`. Not because the class is
+   * unavailable — this suite mocks neither `@prisma/client` nor the Prisma
+   * namespace, and takes `Availability` from `~/shared/utils/prisma/enums` — but
+   * because the recursion below only ever reads `.strings` and `.values`, so the
+   * shape is the whole contract and `instanceof` would narrow on more than is
+   * used. It also keeps the guard working on a plain object fixture.
    */
   const isSql = (value: unknown): value is SqlLike =>
     !!value &&
@@ -2449,10 +2460,26 @@ describe('Availability parameters are cast to the enum, not bound as text', () =
    * here: it drops the values entirely, so the text it returns has nothing
    * where the parameter goes and cannot say what follows one.
    *
-   * 🔴 `--` line comments are stripped BEFORE any assertion reads this. The
-   * service explains this very cast in a comment beside the clause, so a naive
-   * substring check would be satisfied by the prose whether or not the cast is
-   * in the SQL.
+   * 🔴 Comments are stripped BEFORE any assertion reads this — BOTH `--` to
+   * end-of-line AND slash-star … star-slash blocks. (Spelled out: the closing
+   * delimiter would end this very comment.) The service explains this cast in a
+   * comment beside the clause, so a naive substring check would be satisfied by
+   * the prose whether or not the cast is in the SQL.
+   *
+   * 🔴 The block-comment half is not symmetry for its own sake: a clause wrapped
+   * in a block comment is DEAD SQL whose text and bound parameter both survive
+   * untouched, so every per-parameter assertion below still sees a correctly
+   * cast `Availability` while Postgres is handed a WHERE with the private-post
+   * guard missing. Measured: commenting out the `getMyRemixGallerySubmissions`
+   * clause that way passed this entire file before this strip existed.
+   *
+   * One `replace` with an alternation, not two passes: a single left-to-right
+   * scan lets whichever opener appears FIRST win, which is what a SQL lexer
+   * does. Stripping one kind and then the other lets a `--` inside a block
+   * comment (or a block opener inside a line comment) eat the other's
+   * delimiter. Postgres block comments nest and this does not — a nested one
+   * leaves a stray closing delimiter behind, which the whole-clause pins below
+   * fail on, so it is caught rather than waved through.
    */
   function render(call: unknown[]) {
     const [strings, ...values] = call as [readonly string[], ...unknown[]];
@@ -2466,7 +2493,7 @@ describe('Availability parameters are cast to the enum, not bound as text', () =
         return `${out}${part}$${params.length}`;
       }, '');
     const sql = expand(strings, values)
-      .replace(/--[^\n]*/g, ' ')
+      .replace(/--[^\n]*|\/\*[\s\S]*?\*\//g, ' ')
       .replace(/\s+/g, ' ')
       .trim();
     return { sql, params };
@@ -2501,12 +2528,26 @@ describe('Availability parameters are cast to the enum, not bound as text', () =
       bindings.length,
       `${route} bound no Availability parameter at all — the guard has nothing to check`
     ).toBeGreaterThan(0);
-    for (const binding of bindings)
+    for (const binding of bindings) {
+      // 🔴 Its own assertion, ahead of the cast check. A parameter that is bound
+      // but whose placeholder appears NOWHERE in the rendered statement means the
+      // clause using it was commented out — the binding survives, the SQL does
+      // not, and the comparison is not made at all. Without this case
+      // `toMatch(null)` throws `expects to receive a string, but got object`,
+      // which fails (so nothing passes vacuously) but reads as a broken harness
+      // instead of naming the defect, and the message below never renders.
+      expect(
+        binding.follows,
+        `${route}: ${binding.placeholder} (${String(binding.param)}) is bound, but its ` +
+          'placeholder appears nowhere in the statement — the clause using it is ' +
+          'commented out, so availability is not being compared at all'
+      ).not.toBeNull();
       expect(
         binding.follows,
         `${route}: ${binding.placeholder} (${String(binding.param)}) is bound as text; ` +
           'append ::"Availability" or Postgres rejects the statement with 42883'
       ).toMatch(/^::"Availability"/);
+    }
   };
 
   beforeEach(() => {
@@ -2572,6 +2613,45 @@ describe('Availability parameters are cast to the enum, not bound as text', () =
     const { sql, params } = render(queryRaw.mock.calls[0] as unknown[]);
     const n = params.indexOf(Availability.Private) + 1;
     expect(n, 'Availability.Private is not bound by this read').toBeGreaterThan(0);
+    expect(sql).toContain(
+      `AND p."publishedAt" < now() AND p."availability" != $${n}::"Availability" ` +
+        `AND i.ingestion = 'Scanned'`
+    );
+  });
+
+  /**
+   * The same whole-clause pin for the second copy of the predicate.
+   *
+   * 🔴 This is the guard that gives the block-comment strip in `render` teeth.
+   * `getMyRemixGallerySubmissions` writes the clause out inline instead of
+   * composing `entryIsVisible`, so the pin above cannot reach it — and a
+   * per-parameter assertion cannot tell a live clause from a commented-out one,
+   * because commenting it out changes neither the text nor the binding. With
+   * only the per-parameter checks, that mutant passed all 141 tests here.
+   */
+  it("pins the submitter's own-submissions host clause as a whole, cast included", async () => {
+    placementFindMany.mockResolvedValue([
+      { id: 1, targetId: HOST_IMAGE, ownerId: OWNER, data: { imageId: REMIX_IMAGE } },
+    ]);
+    await getMyRemixGallerySubmissions({
+      placerId: PLACER,
+      domainLevels: allBrowsingLevelsFlag,
+      viewerLevels: allBrowsingLevelsFlag,
+    });
+    // Two raw reads run here — the submitter's own images by id, then the host
+    // read under the visibility filter. Only the host read binds Availability,
+    // so selecting by that is what identifies it, and asserting exactly one
+    // match is the positive control: a read that stopped comparing availability
+    // lands here as 0, not as a vacuous pass.
+    const bound = queryRaw.mock.calls
+      .map((call) => render(call as unknown[]))
+      .filter(({ params }) => params.includes(Availability.Private));
+    expect(
+      bound,
+      'exactly one read in getMyRemixGallerySubmissions should bind Availability.Private'
+    ).toHaveLength(1);
+    const { sql, params } = bound[0];
+    const n = params.indexOf(Availability.Private) + 1;
     expect(sql).toContain(
       `AND p."publishedAt" < now() AND p."availability" != $${n}::"Availability" ` +
         `AND i.ingestion = 'Scanned'`

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1906,7 +1906,15 @@ export const getAllImages = async (
 
   if (!isModerator) {
     AND.push(
-      Prisma.sql`((p."availability" != ${Availability.Private} AND i."ingestion" != 'Blocked') OR p."userId" = ${userId})`
+      // ::"Availability" is defensive here rather than a live fix. This fragment
+      // is executed through the node-postgres pool (`queryWithTimeout(imageDb, …)`),
+      // which sends parameters untyped and lets Postgres infer the enum — so the
+      // uncast form has worked. The same shape under Prisma's `$queryRaw` binds
+      // `text` and dies with 42883 (`operator does not exist: "Availability" <> text`),
+      // which is what broke the remix gallery. The commented-out
+      // `dbRead.$queryRaw(query)` below is one edit away from re-arming that, so
+      // pin the cast now and make the fragment executor-independent.
+      Prisma.sql`((p."availability" != ${Availability.Private}::"Availability" AND i."ingestion" != 'Blocked') OR p."userId" = ${userId})`
     );
   }
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1906,15 +1906,7 @@ export const getAllImages = async (
 
   if (!isModerator) {
     AND.push(
-      // ::"Availability" is defensive here rather than a live fix. This fragment
-      // is executed through the node-postgres pool (`queryWithTimeout(imageDb, …)`),
-      // which sends parameters untyped and lets Postgres infer the enum — so the
-      // uncast form has worked. The same shape under Prisma's `$queryRaw` binds
-      // `text` and dies with 42883 (`operator does not exist: "Availability" <> text`),
-      // which is what broke the remix gallery. The commented-out
-      // `dbRead.$queryRaw(query)` below is one edit away from re-arming that, so
-      // pin the cast now and make the fragment executor-independent.
-      Prisma.sql`((p."availability" != ${Availability.Private}::"Availability" AND i."ingestion" != 'Blocked') OR p."userId" = ${userId})`
+      Prisma.sql`((p."availability" != ${Availability.Private} AND i."ingestion" != 'Blocked') OR p."userId" = ${userId})`
     );
   }
 

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -1193,7 +1193,16 @@ const entryIsVisible = (levels: number, host: Prisma.Sql) => Prisma.sql`
         -- No owner arm, deliberately: getAllImages re-admits a private image
         -- to its own author, which is right for their own feed and wrong on
         -- somebody else's public gallery.
-        AND p."availability" != ${Availability.Private}
+        --
+        -- 🔴 The ::"Availability" cast is load-bearing, not decoration. (No
+        -- backticks in this comment: a template literal ends at the first one.)
+        -- Prisma binds an interpolated string as text, and Postgres has no
+        -- "Availability" <> text operator, so without the cast the WHOLE query
+        -- dies at parse time with SQLSTATE 42883 — every caller of this
+        -- fragment 500s deterministically, not just the rows a private post
+        -- would have filtered. Same shape as meilisearch/cleanup.ts and
+        -- models.search-index.ts.
+        AND p."availability" != ${Availability.Private}::"Availability"
         AND i.ingestion = 'Scanned'
         AND i."needsReview" IS NULL
         AND NOT i."tosViolation"
@@ -1961,7 +1970,10 @@ export async function getMyRemixGallerySubmissions({
           --   needsReview / acceptableMinor - a moderator flag leaves ingestion
           --   at 'Scanned', so neither is implied by the ingestion clause below.
           AND p."publishedAt" < now()
-          AND p."availability" != ${Availability.Private}
+          -- ::"Availability" for the same reason as in entryIsVisible: an
+          -- uncast bound parameter is text, and "Availability" <> text is not
+          -- an operator Postgres has (SQLSTATE 42883).
+          AND p."availability" != ${Availability.Private}::"Availability"
           AND i.ingestion = 'Scanned'
           AND i."needsReview" IS NULL
           AND NOT i."acceptableMinor"


### PR DESCRIPTION
## The bug

Every Remix Gallery read is returning a 500. Not intermittently and not data-dependent — the SQL is rejected at parse time:

```
Invalid `prisma.$queryRaw()` invocation:
Raw query failed. Code: `42883`. Message: `ERROR: operator does not exist: "Availability" <> text
HINT: No operator matches the given name and argument types. You might need to add explicit type casts.`
```

The cause is one clause:

```ts
AND p."availability" != ${Availability.Private}
```

Inside a Prisma tagged template, `${Availability.Private}` is bound as a **`text`** parameter. Postgres has no `"Availability" <> text` operator, so it refuses the whole statement. This is a type error in a *static* predicate, so it does not filter fewer rows — nothing is returned at all, on every call, for every viewer.

The clause lives in `entryIsVisible`, the shared predicate that `getRemixGallery`, `galleryHasEntries` and `getRemixGalleryCardSummaries` compose **unconditionally**. That is why several routes fail identically. `getMyRemixGallerySubmissions` carries a second, inline copy of the same clause and fails the same way.

Affected tRPC procedures, by error volume:

| Procedure | Share of the errors |
|---|---|
| `placement.getRemixGalleryCardSummaries` | 99.5% combined |
| `placement.getRemixGalleryVisibility` | ↑ |
| `placement.getRemixGallery` | remainder |
| `placement.getMyRemixGallerySubmissions` | remainder |

Introduced by 9214e2235e — *feat(remix-gallery): make remixed images discoverable in the feed (#4364)*. High-volume in production for roughly 19 hours.

**No privacy exposure.** The clause it broke is a privacy guard: it stops a gallery returning the URL of an image whose owner marked the post non-public. Its failure mode is **fail-closed** — the query throws rather than serving the row. The cost is that the feature is down, not that anything leaked.

## The fix

`::"Availability"`, which is the convention already used elsewhere in this repo — `src/server/meilisearch/cleanup.ts`, `src/server/search-index/models.search-index.ts`, `src/server/services/model-version.service.ts`.

### Changed

Two casts, both in `src/server/services/remix-gallery.service.ts`, plus the tests:

| File | What |
|---|---|
| `src/server/services/remix-gallery.service.ts` | the clause in `entryIsVisible` (the shared fragment behind three queries) — **this is the fix for the outage** |
| `src/server/services/remix-gallery.service.ts` | the second inline copy, in `getMyRemixGallerySubmissions` |
| `src/server/services/__tests__/remix-gallery.service.test.ts` | the regression guard (below) |

### Same-class hits deliberately left alone

| Site | Why |
|---|---|
| `src/server/services/image.service.ts` (`getAllImages`) | executed through the **node-postgres** pool (`queryWithTimeout(imageDb, …)`), which sends parameters **untyped** and lets Postgres infer the enum — so the uncast form has worked there since March and never threw. See the note below. |
| `src/components/AutocompleteSearch/AutocompleteSearch.tsx` | Meilisearch filter string, not SQL |
| `src/pages/search/models.tsx` | Meilisearch filter string, not SQL |
| `src/server/services/image.service.ts` (`getImagesFromSearch` filters) | Meilisearch filter string, not SQL |
| `src/server/services/image.service.ts` (`getImage`) | compares against an untyped SQL **literal** (`!= 'Private'`), which Postgres coerces to the enum on its own — no bound parameter, no `text` |

`cleanup.ts`, `models.search-index.ts` and `model-version.service.ts` already carry the cast.

#### Why `getAllImages` is not in this PR

An earlier revision of this PR *did* cast `getAllImages` as a defensive third change. **It has been dropped**, and the file is now byte-identical to `origin/main`. Three reasons, in order of weight:

1. **It fixes nothing live.** Prisma's `$queryRaw` is what binds the parameter as `text`; the node-postgres pool is the discriminator between the two sites, not the SQL. That fragment has never thrown 42883.
2. **It broke a gate.** The explanatory comment was a net **+8 lines**, and `src/server/flipt/__tests__/flipt-eval-context.test.ts` keys its `ENTITY_WITHOUT_CONTEXT_LEDGER` by `file:line`. Four `image.service.ts` entries shifted (`4123→4131`, `4264→4272`, `5002→5010`, `6136→6144`), failing a hard-coded assertion. Fixing *that* by editing the ledger would have been a line-number churn commit in exchange for a change that fixes nothing.
3. **It silently changed a cache key.** The `getAllImages` Redis cache key is derived from the query, so the cast would have invalidated it for no behavioural gain.

The residual risk the cast was aimed at is real but small and unchanged from before #4364: the commented-out `dbRead.$queryRaw(query)` a few lines below is one edit away from arming the defect on the busiest feed query in the app. That is a comment-level hazard on a dormant code path, not something to fix inside an outage PR.

### On the two non-remix procedures in the error log

I checked the two procedures the error log attributes a share of these 42883s to but which are not remix-gallery routes — `model.getActiveSales` and `image.getGenerationData`. **Neither code path contains an `Availability` comparison at all**, cast or otherwise: `getActiveSalesForModels` → `querySalesForModels` compares only `mv.status`, and it already casts (`'Published'::"ModelStatus"`); `getCapTiers` → `getCapTier` has no enum comparison; `getImageGenerationData` has no raw availability predicate. Both are called from components that also mount the remix-gallery queries (`ModelCardContext`, the image detail view), so the most likely explanation is attribution at the batched-request level rather than a second defect — but I could not confirm that from the code, so it is flagged rather than asserted.

## Coverage

Six new cases in `src/server/services/__tests__/remix-gallery.service.test.ts`. No database is reachable from that suite, so the assertion is on the SQL the service **composes** — it proves the cast is written, not that Postgres accepts the statement.

Four cases drive each of the four affected reads and assert that **every** bound `Availability` parameter is immediately followed by `::"Availability"`. That is a walk over the parameter list, not a search for the cast somewhere in the query — the latter passes while a *second* comparison in the same statement is still uncast, which is precisely this defect's shape (three queries, one shared broken fragment).

Two more cases pin the whole normalised clause, together with both of its neighbouring `AND`s — one for the shared `entryIsVisible` fragment, one for the inline copy in `getMyRemixGallerySubmissions`. A flipped `AND`→`OR` makes the entire `WHERE` permissive while every fragment-shaped assertion stays green, so the joins have to be pinned too, and the two clauses need separate pins because the second is written out inline rather than composed.

Three things the guard needed in order not to be vacuous:

- **A positive control per route.** A read that stopped comparing availability at all binds nothing, and the loop would then assert over an empty list and pass. Each case asserts at least one binding was found, naming the route in the failure. The whole-clause pin on `getMyRemixGallerySubmissions` selects its read by *which one binds `Availability.Private`* and asserts exactly one match, so a read that went quiet fails as 0 rather than passing.
- **Comments stripped before any assertion reads the SQL — both `--` and block comments.** The `--` half matters because the fix adds a comment beside the clause that *explains* the cast, so a naive substring check would be satisfied by the prose. The block-comment half matters more, and was **a real hole found by mutation testing rather than by review**: a clause wrapped in a block comment is dead SQL whose text and bound parameter both survive, so every per-parameter assertion still saw a correctly cast `Availability` while Postgres would be handed a `WHERE` with the private-post guard missing. That mutant passed all 141 tests of the previous revision. Both forms are now stripped in one left-to-right alternation, so whichever opener comes first wins, the way a SQL lexer reads it.
- **A failure message that names the defect.** A parameter bound with no placeholder anywhere in the rendered statement previously reached `toMatch(null)`, which throws `expects to receive a string, but got object` — it fails, so nothing passed vacuously, but it reads as a broken harness. That case now has its own assertion saying the clause is commented out.

### Red/green matrix

Same command both times:

```
node scripts/test-unit-run.mjs src/server/services/__tests__/remix-gallery.service.test.ts
```

| Tree | Result |
|---|---|
| tests applied, `remix-gallery.service.ts` reverted to the merge base | **6 failed** / 136 passed (142) — all six, each naming the uncast placeholder and the text that follows it |
| HEAD (fix applied) | **142 passed** (142) |

The pre-existing 136 pass in both arms, so the six are attributable to the change and nothing else moved.

### Mutation control

Run in a scratch copy off this tree, not in the branch:

| Mutant | Result |
|---|---|
| block-comment the `getMyRemixGallerySubmissions` clause (text and binding both survive, clause dead) | **survived** 141/141 before this revision; now **fails 2**, both with their own authored assertions |
| block-comment the shared `entryIsVisible` clause | **fails 4** — every route that composes the fragment |
| drop the cast (positive control) | **fails** with `is bound as text; append ::"Availability" or Postgres rejects the statement with 42883`, before and after |

Also green: `remix-gallery-entry-visibility.test.ts` (7) and `src/server/flipt/__tests__/flipt-eval-context.test.ts` (12/12 — this was 3 failed / 9 passed on the previous revision, which is what dropping the `image.service.ts` hunk fixed).

## Not verified

- **Against a real Postgres.** The tests prove the cast is composed into the statement, not that Postgres accepts it. The cast form itself is copied verbatim from three queries already running in production.
- **Typecheck is not clean, and not because of this change.** `node scripts/typecheck.mjs` reports 14 errors, all in `src/server/services/user-hub.service.ts` and `src/components/Hubs/*`, all of the form `Property 'userHubFollow' does not exist on PrismaClient`. `model UserHubFollow` was added to the schema in b2727ecf72 (#4389) and the generated client available here predates it. **Zero** errors name either file in this PR.
- **Two `@typescript-eslint/no-explicit-any` errors** at `remix-gallery.service.test.ts:109` are pre-existing — byte-identical at the merge base, and outside both of this PR's hunks (which start at lines 149 and 2402).
