### PR TITLE
test(redis): correct the 8 remaining drifted key constants, and record why the other 42 stay

### DIFF
--- a/src/server/events/__tests__/base-event.sysredis-soft.test.ts
+++ b/src/server/events/__tests__/base-event.sysredis-soft.test.ts
@@ -29,11 +29,11 @@ const { hGetAll, hSet, mockWithSysReadDeadline, mockLogSysRedisFailOpen, mockGet
 vi.mock('~/server/redis/client', () => ({
   redis: { hGet: vi.fn(), hSet: vi.fn(), del: vi.fn(), hDel: vi.fn() },
   sysRedis: { hGetAll, hSet },
-  REDIS_KEYS: { COSMETICS: { IDS: 'cosmetics:ids' }, EVENT: { CACHE: 'event:cache' } },
+  REDIS_KEYS: { COSMETICS: { IDS: 'cosmeticIds' }, EVENT: { CACHE: 'packed:event' } },
   REDIS_SUB_KEYS: {
     EVENT: { MANUAL_ASSIGNMENTS: 'manual-assignments', DISCORD_ROLES: 'discord-roles', COSMETICS: 'cosmetics' },
   },
-  REDIS_SYS_KEYS: { EVENT: 'sys:event' },
+  REDIS_SYS_KEYS: { EVENT: 'event' },
   withSysReadDeadline: mockWithSysReadDeadline,
 }));
 vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));

--- a/src/server/jobs/__tests__/restore-user-images.test.ts
+++ b/src/server/jobs/__tests__/restore-user-images.test.ts
@@ -27,7 +27,7 @@ vi.mock('~/server/logging/client', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockSysRedis,
-  REDIS_SYS_KEYS: { SYSTEM: { PENDING_IMAGE_RESTORES: 'pending-restores' } },
+  REDIS_SYS_KEYS: { SYSTEM: { PENDING_IMAGE_RESTORES: 'system:pending-image-restores' } },
 }));
 vi.mock('~/server/services/image.service', () => ({
   resetBlockedNsfwLevel: mockResetNsfwLevel,
@@ -144,7 +144,7 @@ describe('restoreUserImages', () => {
     expect(mockUnblock).not.toHaveBeenCalled();
     // Kept, the id costs a `User` round-trip every other minute forever, and nothing ever
     // reclaims it; `restoreUser` re-adds it if the account genuinely comes back.
-    expect(mockSysRedis.sRem).toHaveBeenCalledWith('pending-restores', '7');
+    expect(mockSysRedis.sRem).toHaveBeenCalledWith('system:pending-image-restores', '7');
     expect(pendingSet).toEqual([]);
     expect(result).toMatchObject({ reDeleted: 1, finished: 0 });
   });
@@ -178,7 +178,7 @@ describe('restoreUserImages', () => {
 
     await run();
 
-    expect(mockSysRedis.sRem).toHaveBeenCalledWith('pending-restores', '7');
+    expect(mockSysRedis.sRem).toHaveBeenCalledWith('system:pending-image-restores', '7');
     expect(pendingSet).toEqual([]);
   });
 

--- a/src/server/routers/__tests__/track.router.blockRender.test.ts
+++ b/src/server/routers/__tests__/track.router.blockRender.test.ts
@@ -22,7 +22,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('~/server/redis/client', () => ({
   sysRedis: { hGetAll: vi.fn(async () => ({})) },
   withSysReadDeadline: (p: Promise<unknown>) => p,
-  REDIS_SYS_KEYS: { CLIENT: 'system:client' },
+  REDIS_SYS_KEYS: { CLIENT: 'client' },
 }));
 vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
 

--- a/src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts
+++ b/src/server/services/__tests__/no-hand-typed-redis-key-constants.test.ts
@@ -64,6 +64,41 @@ import { mockPattern } from '~/__tests__/mocks/guarded-specifiers';
  * built from a variable or template literal; a computed (`[K]:`) or shorthand (`REDIS_KEYS,`)
  * property; a factory delegating to a helper that lives in another file. Widen it when one of
  * those appears rather than assuming the set below is the population.
+ *
+ * 🔴 THE BASELINE HOLDS TWO DIFFERENT SHAPES, AND ONLY ONE OF THEM IS DRIFT. Surveyed
+ * 2026-08-26, all 50 entries:
+ *
+ *   32 hand-type a literal key object — the drift class this guard was built for.
+ *   18 substitute a CATCH-ALL PROXY and type no constant at all:
+ *        const make = (): any => new Proxy(() => 'k', { get: () => make() });
+ *      Every property access returns another callable proxy, so the ENTIRE namespace —
+ *      264 key literals across 63 top-level groups — stringifies to the single string
+ *      'k', and every key collides with every other (verified by running it).
+ *
+ * 🔴 DO NOT "CONVERT" THE 18. They cannot drift, because they name no value; and the fix
+ * this guard prescribes would import the real `@civitai/redis/client` — pulling `redis`,
+ * `msgpackr`, `lodash-es` and `slugify` — into files whose Proxy exists precisely to avoid
+ * that graph. `model-version-blocklist.test.ts` says so in its own comment: "so module-eval-
+ * time dereferences like REDIS_SYS_KEYS.DOWNLOAD.COUNT resolve WITHOUT a real redis client".
+ * Import is 81–84% of unit-test worker time and cost is linear in module COUNT, so that
+ * conversion is a net loss. They are on the baseline because the detector is deliberately
+ * loose (it matches the property, not the value) — that is correct and should stay.
+ *
+ * 🔴 REMAINING DRIFT, ENUMERATED EXACTLY rather than estimated. Of the 32 literal-shape
+ * files: 8 genuinely drifted constants across 4 files (base-event.sysredis-soft ×3,
+ * health.runHealthChecks ×3, restore-user-images ×1, track.router.blockRender ×1) — all
+ * corrected 2026-08-26 in place, WITHOUT converting the mocks. The other flagged values are
+ * legitimate: 5 deliberate `BLOCKS.TOKEN_RATE_LIMIT: 'rl'` stubs, and 3 files whose key
+ * object is empty (`REDIS_KEYS: {}`) so they carry no constant to drift.
+ *
+ * Detectability is the thing to check before spending effort here: 15 of the 32 reference a
+ * key value somewhere outside its own definition, but only `restore-user-images` had an
+ * assertion pinned to a DRIFTED one — correcting the constant turned that suite red (2
+ * failures, 'pending-restores' vs the real 'system:pending-image-restores') before its
+ * assertions were updated. In every other file both the writer and the reader resolve the
+ * same fake, so a wrong value is invisible to the suite and correcting it changes nothing
+ * observable. Fixing the VALUE is cheap and removes false documentation; restructuring the
+ * MOCK buys no assertion. Prefer the former.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');

--- a/src/tests/api/health.runHealthChecks.test.ts
+++ b/src/tests/api/health.runHealthChecks.test.ts
@@ -77,9 +77,9 @@ vi.mock('~/server/redis/client', () => ({
   sysRedis: mocks.sysRedis,
   REDIS_SYS_KEYS: {
     SYSTEM: {
-      DISABLED_HEALTHCHECKS: 'sys:disabled-healthchecks',
-      NON_CRITICAL_HEALTHCHECKS: 'sys:non-critical-healthchecks',
-      FEATURES: 'sys:features',
+      DISABLED_HEALTHCHECKS: 'disabled-healthchecks',
+      NON_CRITICAL_HEALTHCHECKS: 'non-critical-healthchecks',
+      FEATURES: 'system:features',
     },
   },
 }));


### PR DESCRIPTION
Closes the question #4406's guard left open in its own docblock — *"≥8 live drifts remain … **Nobody has enumerated it exactly.**"*

Now enumerated exactly, by comparing every `HAND_TYPED_BASELINE` entry against the real values in `@civitai/redis/client` **by path** (not by value-set membership, which cannot tell a moved key from a renamed one).

## What was actually wrong: 8 constants, 4 files

| file | constant | test said | production uses |
|---|---|---|---|
| `base-event.sysredis-soft` | `COSMETICS.IDS` | `'cosmetics:ids'` | `'cosmeticIds'` |
| | `EVENT.CACHE` | `'event:cache'` | `'packed:event'` |
| | `REDIS_SYS_KEYS.EVENT` | `'sys:event'` | `'event'` |
| `health.runHealthChecks` | `DISABLED_HEALTHCHECKS` | `'sys:disabled-healthchecks'` | `'disabled-healthchecks'` |
| | `NON_CRITICAL_HEALTHCHECKS` | `'sys:non-critical-healthchecks'` | `'non-critical-healthchecks'` |
| | `FEATURES` | `'sys:features'` | `'system:features'` |
| `restore-user-images` | `SYSTEM.PENDING_IMAGE_RESTORES` | `'pending-restores'` | `'system:pending-image-restores'` |
| `track.router.blockRender` | `REDIS_SYS_KEYS.CLIENT` | `'system:client'` | `'client'` |

**Fixed in place — the mocks are not restructured.** No file leaves `HAND_TYPED_BASELINE`, the count stays `toBe(50)`, and the ratchet is untouched.

### One of them was observable, and it went red

`restore-user-images` pins the key in two assertions. Correcting the constant *alone* turned the suite **red** — 2 failures, `expected 'pending-restores'` against the real `'system:pending-image-restores'` — before those assertions were updated. That is the drift class doing visible damage, not a hypothetical.

Everywhere else, writer and reader resolve the same fake, so the wrong value was invisible to the suite. That is what makes the class dangerous, not a reason to leave it.

## What is still flagged, and why it is fine

- **5 × `BLOCKS.TOKEN_RATE_LIMIT: 'rl'`** — the deliberate short stub the guard's docblock already sanctions.
- **3 files with an empty key object** (`REDIS_KEYS: {}`) — no constant to drift.

## The finding worth keeping: the baseline holds two shapes

Recorded in the guard's docblock so it is not re-derived. **18 of the 50 hand-type nothing at all** — they substitute a catch-all Proxy:

```ts
const make = (): any => new Proxy(() => 'k', { get: () => make() });
```

Every property access returns another callable proxy, so the **entire namespace — 264 key literals across 63 top-level groups — collapses to the single string `'k'`**, and every key collides with every other. Verified by running it.

**These must not be "converted."** They cannot drift (they name no value), and the fix the guard prescribes would import the real `@civitai/redis/client` — dragging in `redis`, `msgpackr`, `lodash-es`, `slugify` — into files whose Proxy exists precisely to avoid that graph. `model-version-blocklist.test.ts` says so itself: *"so module-eval-time dereferences … resolve **without a real redis client**."* Import is 81–84% of unit-test worker time and cost is linear in module **count**, so converting them is a net loss.

They remain on the baseline because the detector matches the *property*, not the *value* — which is correct and deliberate.

## Verification

- The 4 edited suites + the ratchet guard: **39 tests, all passing**.
- The guard family (`no-direct-shared-module-mock`, `no-wholesale-module-mock`, `no-lint-rules-script-drift`, `no-hand-typed-redis-key-constants`): **115 tests, all passing**.
- Re-ran the by-path drift comparison over the edited tree: **0 genuine drifts remain**, only the 5 sanctioned `'rl'` stubs.
- The comparison tool was validated against ground truth before being trusted — run at `9b4a8a5487^` it reproduces exactly the **15** drifts #4400 fixed across those 6 files.
- Prettier flags 2 of the edited files, and both are **flagged identically at `origin/main`** — pre-existing, not introduced here.
