### PR TITLE
fix(app-listings): make #4413's owner-repair loop reachable — last-action-aware editor tabs, plus the two defects that opens

### DIFF
--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -270,10 +270,7 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
         }
         if (!scalarChanged && !assetsDirty) {
           // Nothing to review — just return to the list.
-          showSuccessNotification({
-            title: 'No changes',
-            message: 'Nothing to submit for review.',
-          });
+          showSuccessNotification({ title: 'No changes', message: 'Nothing to submit for review.' });
           void router.push('/apps/mine');
           return;
         }
@@ -345,7 +342,9 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           title="This app is unpublished"
           data-testid="apps-offsite-edit-material-locked-notice"
         >
-          <Text size="sm">{materialBlockedReason}</Text>
+          <Text size="sm">
+            {materialBlockedReason}
+          </Text>
         </Alert>
       )}
 
@@ -378,102 +377,101 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
 
       <Stepper active={active} onStepClick={setActive} size="sm">
         {showUrlStep ? (
-          <Stepper.Step
-            label="URL"
-            description="The link"
-            data-testid="apps-offsite-wizard-step-url"
-          >
-            <FadeIn>
-              <Stack gap="md" mt="md">
-                <TextInput
-                  label="App URL"
-                  description="Your app’s public https link — users open it from the listing."
-                  placeholder="example.com/app"
-                  value={values.externalUrl}
-                  onChange={(e) => {
-                    setField('externalUrl', e.currentTarget.value);
-                    autofill.clearNote();
-                  }}
-                  onBlur={handleUrlBlur}
-                  onKeyDown={handleUrlKeyDown}
-                  error={errors.externalUrl}
-                  maxLength={OFFSITE_SUBMIT_LIMITS.urlMax}
-                  data-autofocus
-                  data-testid="apps-offsite-edit-url"
-                  // 🔴 MATERIAL. See `materialBlockedReason`. The `data-material-field` tag is
-                  // what lets the ledger test walk `MATERIAL_LISTING_PATCH_FIELDS` and assert
-                  // an input exists AND is disabled for every member — so a field added to
-                  // that set with no input here turns the ledger red.
-                  data-material-field="externalUrl"
-                  disabled={materialBlocked}
-                />
-                {values.externalUrl.trim().length === 0 && (
-                  <Alert
-                    color="yellow"
-                    variant="light"
-                    icon={<IconInfoCircle size={16} />}
-                    data-testid="apps-offsite-edit-url-prompt"
-                  >
-                    <Text size="sm">
-                      This listing has no App URL. Adding one lets users open your app (and lets us
-                      suggest a name, description and images) — but it’s optional here.
-                    </Text>
-                  </Alert>
-                )}
-                {/* The OG pull auto-fires when the URL changes to a valid https URL (blur,
+        <Stepper.Step
+          label="URL"
+          description="The link"
+          data-testid="apps-offsite-wizard-step-url"
+        >
+          <FadeIn>
+            <Stack gap="md" mt="md">
+              <TextInput
+                label="App URL"
+                description="Your app’s public https link — users open it from the listing."
+                placeholder="example.com/app"
+                value={values.externalUrl}
+                onChange={(e) => {
+                  setField('externalUrl', e.currentTarget.value);
+                  autofill.clearNote();
+                }}
+                onBlur={handleUrlBlur}
+                onKeyDown={handleUrlKeyDown}
+                error={errors.externalUrl}
+                maxLength={OFFSITE_SUBMIT_LIMITS.urlMax}
+                data-autofocus
+                data-testid="apps-offsite-edit-url"
+                // 🔴 MATERIAL. See `materialBlockedReason`. The `data-material-field` tag is
+                // what lets the ledger test walk `MATERIAL_LISTING_PATCH_FIELDS` and assert
+                // an input exists AND is disabled for every member — so a field added to
+                // that set with no input here turns the ledger red.
+                data-material-field="externalUrl"
+                disabled={materialBlocked}
+              />
+              {values.externalUrl.trim().length === 0 && (
+                <Alert
+                  color="yellow"
+                  variant="light"
+                  icon={<IconInfoCircle size={16} />}
+                  data-testid="apps-offsite-edit-url-prompt"
+                >
+                  <Text size="sm">
+                    This listing has no App URL. Adding one lets users open your app (and lets us
+                    suggest a name, description and images) — but it’s optional here.
+                  </Text>
+                </Alert>
+              )}
+              {/* The OG pull auto-fires when the URL changes to a valid https URL (blur,
                   Enter, Next, or a debounced pause) — no manual button. A subtle inline
                   status reports loading / applied / partial / empty / error. The
                   assets-step "Re-pull from site" button is the manual retry. */}
-                {autofill.loading && (
-                  <Group gap={6} data-testid="apps-offsite-edit-meta-loading">
-                    <Loader size={12} />
-                    <Text size="xs" c="dimmed">
-                      Looking for a name, description and images from your link…
-                    </Text>
-                  </Group>
-                )}
-                {!autofill.loading && autofill.result?.status === 'error' && (
-                  <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
-                    Couldn’t read that site’s details.
+              {autofill.loading && (
+                <Group gap={6} data-testid="apps-offsite-edit-meta-loading">
+                  <Loader size={12} />
+                  <Text size="xs" c="dimmed">
+                    Looking for a name, description and images from your link…
                   </Text>
-                )}
-                {!autofill.loading && autofill.result?.status === 'empty' && (
-                  <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-empty">
-                    {autofill.result.siteExposedNothing
-                      ? 'Your site didn’t expose a name, description, icon or cover to pull — add them manually.'
-                      : 'Nothing to autofill — your details and assets are already set.'}
-                  </Text>
-                )}
-                {!autofill.loading && autofill.result?.status === 'partial' && (
-                  <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-partial">
-                    Pulled what your link exposed —{' '}
-                    {describeMissingChannels(autofill.result.missing)}{' '}
-                    {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
-                    {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check
-                    the Details and Assets steps for what we found.
-                  </Text>
-                )}
-                {!autofill.loading && autofill.result?.status === 'applied' && (
-                  <Alert
-                    color="grape"
-                    variant="light"
-                    icon={<IconSparkles size={16} />}
-                    data-testid="apps-offsite-edit-autofill-applied"
-                  >
-                    <Text size="sm">
-                      Pulled the latest details from your link — check the Details and Assets steps
-                      to review the name, description and the suggested icon/cover.
-                    </Text>
-                  </Alert>
-                )}
-                <Group justify="flex-end">
-                  <Button onClick={handleAdvanceFromUrl} data-testid="apps-offsite-wizard-next-url">
-                    Next
-                  </Button>
                 </Group>
-              </Stack>
-            </FadeIn>
-          </Stepper.Step>
+              )}
+              {!autofill.loading && autofill.result?.status === 'error' && (
+                <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
+                  Couldn’t read that site’s details.
+                </Text>
+              )}
+              {!autofill.loading && autofill.result?.status === 'empty' && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-empty">
+                  {autofill.result.siteExposedNothing
+                    ? 'Your site didn’t expose a name, description, icon or cover to pull — add them manually.'
+                    : 'Nothing to autofill — your details and assets are already set.'}
+                </Text>
+              )}
+              {!autofill.loading && autofill.result?.status === 'partial' && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-partial">
+                  Pulled what your link exposed — {describeMissingChannels(autofill.result.missing)}{' '}
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check the
+                  Details and Assets steps for what we found.
+                </Text>
+              )}
+              {!autofill.loading && autofill.result?.status === 'applied' && (
+                <Alert
+                  color="grape"
+                  variant="light"
+                  icon={<IconSparkles size={16} />}
+                  data-testid="apps-offsite-edit-autofill-applied"
+                >
+                  <Text size="sm">
+                    Pulled the latest details from your link — check the Details and Assets steps to
+                    review the name, description and the suggested icon/cover.
+                  </Text>
+                </Alert>
+              )}
+              <Group justify="flex-end">
+                <Button onClick={handleAdvanceFromUrl} data-testid="apps-offsite-wizard-next-url">
+                  Next
+                </Button>
+              </Group>
+            </Stack>
+          </FadeIn>
+        </Stepper.Step>
         ) : null}
 
         <Stepper.Step
@@ -483,130 +481,130 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           data-testid="apps-offsite-wizard-step-details"
         >
           <FadeIn>
-            <Stack gap="md" mt="md">
-              <TextInput
-                label="Name"
-                value={values.name}
-                onChange={(e) => setField('name', e.currentTarget.value)}
-                error={errors.name}
-                maxLength={OFFSITE_SUBMIT_LIMITS.nameMax}
-                required
-                data-testid="apps-offsite-edit-name"
-                // 🔴 MATERIAL — the listing's identity. See `materialBlockedReason`.
-                data-material-field="name"
-                disabled={materialBlocked}
-              />
+          <Stack gap="md" mt="md">
+            <TextInput
+              label="Name"
+              value={values.name}
+              onChange={(e) => setField('name', e.currentTarget.value)}
+              error={errors.name}
+              maxLength={OFFSITE_SUBMIT_LIMITS.nameMax}
+              required
+              data-testid="apps-offsite-edit-name"
+              // 🔴 MATERIAL — the listing's identity. See `materialBlockedReason`.
+              data-material-field="name"
+              disabled={materialBlocked}
+            />
 
-              <TextInput
-                label="Slug"
-                description="Your app's URL slug is fixed once created — it identifies the listing."
-                value={values.slug}
-                readOnly
-                disabled
-                rightSection={<IconLock size={14} />}
-                data-testid="apps-offsite-edit-slug"
-              />
+            <TextInput
+              label="Slug"
+              description="Your app's URL slug is fixed once created — it identifies the listing."
+              value={values.slug}
+              readOnly
+              disabled
+              rightSection={<IconLock size={14} />}
+              data-testid="apps-offsite-edit-slug"
+            />
 
-              <TextInput
-                label="Tagline"
-                description="A short one-liner (optional)."
-                value={values.tagline}
-                onChange={(e) => setField('tagline', e.currentTarget.value)}
-                error={errors.tagline}
-                maxLength={OFFSITE_SUBMIT_LIMITS.taglineMax}
-              />
+            <TextInput
+              label="Tagline"
+              description="A short one-liner (optional)."
+              value={values.tagline}
+              onChange={(e) => setField('tagline', e.currentTarget.value)}
+              error={errors.tagline}
+              maxLength={OFFSITE_SUBMIT_LIMITS.taglineMax}
+            />
 
-              <Textarea
-                label="Description"
-                description="What the app does (optional)."
-                autosize
-                minRows={3}
-                maxRows={8}
-                value={values.description}
-                onChange={(e) => setField('description', e.currentTarget.value)}
-                error={errors.description}
-                maxLength={OFFSITE_SUBMIT_LIMITS.descriptionMax}
-              />
+            <Textarea
+              label="Description"
+              description="What the app does (optional)."
+              autosize
+              minRows={3}
+              maxRows={8}
+              value={values.description}
+              onChange={(e) => setField('description', e.currentTarget.value)}
+              error={errors.description}
+              maxLength={OFFSITE_SUBMIT_LIMITS.descriptionMax}
+            />
 
-              {/* Public source repository. The copy states the re-review consequence
+            {/* Public source repository. The copy states the re-review consequence
                 up front: this is a MATERIAL field, so on an approved listing changing
                 it stages a shadow revision and the change does not go live until a
                 moderator approves it. An author who is not told that reads the
                 unchanged live page afterwards as a bug. */}
-              <TextInput
-                label="Source repository"
-                description={`Public link to your app's source code, shown on its store page (optional). ${SOURCE_REPO_HOSTS_LABEL} only, linking to the repository itself — e.g. https://github.com/your-org/your-app. Changing this needs moderator re-review before it goes live.`}
-                placeholder="https://github.com/your-org/your-app"
-                value={values.sourceRepoUrl}
-                onChange={(e) => setField('sourceRepoUrl', e.currentTarget.value)}
-                error={errors.sourceRepoUrl}
-                maxLength={OFFSITE_SUBMIT_LIMITS.sourceRepoUrlMax}
-                data-testid="apps-offsite-edit-source-repo"
-                // 🔴 MATERIAL — a public outbound link a moderator approved. See
-                // `materialBlockedReason`.
-                data-material-field="sourceRepoUrl"
+            <TextInput
+              label="Source repository"
+              description={`Public link to your app's source code, shown on its store page (optional). ${SOURCE_REPO_HOSTS_LABEL} only, linking to the repository itself — e.g. https://github.com/your-org/your-app. Changing this needs moderator re-review before it goes live.`}
+              placeholder="https://github.com/your-org/your-app"
+              value={values.sourceRepoUrl}
+              onChange={(e) => setField('sourceRepoUrl', e.currentTarget.value)}
+              error={errors.sourceRepoUrl}
+              maxLength={OFFSITE_SUBMIT_LIMITS.sourceRepoUrlMax}
+              data-testid="apps-offsite-edit-source-repo"
+              // 🔴 MATERIAL — a public outbound link a moderator approved. See
+              // `materialBlockedReason`.
+              data-material-field="sourceRepoUrl"
+              disabled={materialBlocked}
+            />
+
+            <Group grow align="flex-start">
+              <Select
+                label="Category"
+                placeholder="No category"
+                data={OFFSITE_CATEGORY_OPTIONS}
+                value={values.category}
+                onChange={(v: string | null) =>
+                  setField('category', (v as MarketplaceCategory) || null)
+                }
+                error={errors.category}
+                clearable
+                data-testid="apps-offsite-edit-category"
+              />
+              <Select
+                label="Content rating"
+                data={OFFSITE_CONTENT_RATING_OPTIONS}
+                value={values.contentRating}
+                onChange={(v: string | null) =>
+                  setField('contentRating', (v as OffsiteContentRating) || 'g')
+                }
+                error={errors.contentRating}
+                allowDeselect={false}
+                data-testid="apps-offsite-edit-rating"
+                // 🔴 MATERIAL, and the sharpest of the four: `contentRating` drives the
+                // public SFW filter (`content_rating NOT IN ('r','x')`), so an in-place
+                // change with no re-review would surface a mature listing to SFW users.
+                data-material-field="contentRating"
                 disabled={materialBlocked}
               />
+            </Group>
 
-              <Group grow align="flex-start">
-                <Select
-                  label="Category"
-                  placeholder="No category"
-                  data={OFFSITE_CATEGORY_OPTIONS}
-                  value={values.category}
-                  onChange={(v: string | null) =>
-                    setField('category', (v as MarketplaceCategory) || null)
-                  }
-                  error={errors.category}
-                  clearable
-                  data-testid="apps-offsite-edit-category"
-                />
-                <Select
-                  label="Content rating"
-                  data={OFFSITE_CONTENT_RATING_OPTIONS}
-                  value={values.contentRating}
-                  onChange={(v: string | null) =>
-                    setField('contentRating', (v as OffsiteContentRating) || 'g')
-                  }
-                  error={errors.contentRating}
-                  allowDeselect={false}
-                  data-testid="apps-offsite-edit-rating"
-                  // 🔴 MATERIAL, and the sharpest of the four: `contentRating` drives the
-                  // public SFW filter (`content_rating NOT IN ('r','x')`), so an in-place
-                  // change with no re-review would surface a mature listing to SFW users.
-                  data-material-field="contentRating"
-                  disabled={materialBlocked}
-                />
-              </Group>
-
-              {/* 🔴 OFF-SITE ONLY. An on-site app is not an OAuth-connect integration —
+            {/* 🔴 OFF-SITE ONLY. An on-site app is not an OAuth-connect integration —
                 there is no linked client whose scopes a user would be consenting to, so
                 the disclosure would be describing a grant that does not exist. */}
-              {showUrlStep && edit.connectClientId != null && (
-                <DerivedScopesDisclosure
-                  requestedScopes={values.requestedScopes}
-                  justifications={values.scopeJustifications}
-                  onJustificationChange={handleJustificationChange}
-                  // 🔴 `scopeLocked`, NOT `materialBlocked` — see `scopeDisclosureLockedForEdit`.
-                  // A justification edit is trivial and saves fine on an unpublished listing
-                  // while the scope masks agree; it is only unsaveable once they have DRIFTED,
-                  // because the drifted mask then rides along on every patch and the server
-                  // counts it as material.
-                  disabled={saving || scopeLocked}
-                  forceShowErrors={showScopeErrors}
-                  intro="These are your OAuth app's allowed scopes — they're derived from the app and can't be changed here. Editing a justification (or a change to your app's scopes) is sent for review on a live listing."
-                />
-              )}
+            {showUrlStep && edit.connectClientId != null && (
+              <DerivedScopesDisclosure
+                requestedScopes={values.requestedScopes}
+                justifications={values.scopeJustifications}
+                onJustificationChange={handleJustificationChange}
+                // 🔴 `scopeLocked`, NOT `materialBlocked` — see `scopeDisclosureLockedForEdit`.
+                // A justification edit is trivial and saves fine on an unpublished listing
+                // while the scope masks agree; it is only unsaveable once they have DRIFTED,
+                // because the drifted mask then rides along on every patch and the server
+                // counts it as material.
+                disabled={saving || scopeLocked}
+                forceShowErrors={showScopeErrors}
+                intro="These are your OAuth app's allowed scopes — they're derived from the app and can't be changed here. Editing a justification (or a change to your app's scopes) is sent for review on a live listing."
+              />
+            )}
 
-              <Group justify={showUrlStep ? 'space-between' : 'flex-end'}>
-                {showUrlStep ? (
-                  <Button variant="default" onClick={() => setActive(STEP_URL)}>
-                    Back
-                  </Button>
-                ) : null}
-                <Button onClick={() => setActive(STEP_ASSETS)}>Next</Button>
-              </Group>
-            </Stack>
+            <Group justify={showUrlStep ? 'space-between' : 'flex-end'}>
+              {showUrlStep ? (
+                <Button variant="default" onClick={() => setActive(STEP_URL)}>
+                  Back
+                </Button>
+              ) : null}
+              <Button onClick={() => setActive(STEP_ASSETS)}>Next</Button>
+            </Group>
+          </Stack>
           </FadeIn>
         </Stepper.Step>
 
@@ -652,10 +650,11 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                   ) : (
                     <> — its owner unpublished it</>
                   )}
-                  . Image changes here save <b>immediately</b> and are <b>not</b> staged for review
-                  — they are not held until you press Save, and leaving this page does not undo
-                  them. They appear in the store when the app is republished. Media can be added
-                  while it is still scanning; it only appears once its scan finishes cleanly.
+                  . Image changes here save <b>immediately</b> and are <b>not</b> staged for
+                  review — they are not held until you press Save, and leaving this page does
+                  not undo them. They appear in the store when the app is republished. Media
+                  can be added while it is still scanning; it only appears once its scan
+                  finishes cleanly.
                 </Text>
               </Alert>
             )}

--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -44,6 +44,7 @@ import {
   isOnsiteEdit,
   hasScalarChanges,
   isApprovedEdit,
+  isOwnerEdit,
   listingEditHeaderCopy,
   materialEditBlockedReason,
   scopeDisclosureLockedForEdit,
@@ -323,8 +324,16 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
       {/* 🔴 THE REPAIR-STATE NOTICE. Rendered ABOVE the stepper so the reason is on screen
           before the author reaches a locked field — a disabled input with its explanation
           somewhere else reads as a bug. The copy is the server's refusal, restated ahead of
-          time instead of after a failed Save, and it names the way out (republish, then
-          edit). `scopeLocked` appends the one extra sentence its own case needs. */}
+          time instead of after a failed Save, and it names the way out.
+          🔴 THE `scopeLocked` APPEND IS GONE, and its removal is the point rather than a
+          tidy-up. It read "…so the scope justifications are locked until you republish",
+          which understated the state by a long way: in the drifted state NOTHING on this
+          screen can be saved, because the drifted mask rides along on every patch and
+          `handleSave` aborts client-side before any of it. Worse, it sat directly after a
+          sentence that said "Tagline, description and category can be edited now" — two
+          claims that cannot both be true. `materialEditBlockedReason` now owns the whole
+          drifted-state message, so there is ONE sentence to keep honest instead of two
+          that disagreed. */}
       {materialBlockedReason && (
         <Alert
           color="yellow"
@@ -333,13 +342,7 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           title="This app is unpublished"
           data-testid="apps-offsite-edit-material-locked-notice"
         >
-          <Text size="sm">
-            {materialBlockedReason}
-            {scopeLocked
-              ? ' Your app’s OAuth scopes have also changed since it was last reviewed, so' +
-                ' the scope justifications are locked until you republish.'
-              : ''}
-          </Text>
+          <Text size="sm">{materialBlockedReason}</Text>
         </Alert>
       )}
 
@@ -610,6 +613,45 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           data-testid="apps-offsite-wizard-step-assets"
         >
           <div data-testid="apps-offsite-wizard-assets-panel">
+            {/* 🔴 THE ASSETS STEP NEEDS THE REPAIR FRAME TOO, AND IT IS THE ONLY IMAGE
+                SURFACE AN OFF-SITE LISTING HAS. `capabilitiesForKind('offsite').listingMedia`
+                is `false`, so `editorTabsFor` withholds the Media tab entirely and
+                `ListingMediaEditor` — which DID get an unpublished frame — never mounts for
+                these listings. This step is where their icon, cover and screenshots are
+                edited, it became newly reachable in the repair state, and it shipped with no
+                framing at all.
+                🔴 AND THE WRITE SEMANTICS ARE THE SURPRISING PART, which is exactly why the
+                frame has to say them. `ListingAssetStep` writes EAGERLY, one mutation per
+                change, against `edit.parentId` — there is no shadow for a non-approved
+                listing, so nothing here is staged and nothing is undone by leaving without
+                pressing Save. That differs from the approved case the author has seen
+                before AND from the scalar fields on the previous step, which do wait for
+                Save. An author who assumes either would be wrong in a way that costs them
+                their live imagery.
+                🔴 Deliberately NOT gated on `scopeLocked`: the scope-drift dead end blocks
+                the SAVE path (scalars), and these writes do not go through it. Media stays
+                editable in that state, which is worth saying plainly rather than leaving
+                the author to infer it from a notice that talks about saving. */}
+            {materialBlockedReason && (
+              <Alert
+                color="yellow"
+                variant="light"
+                icon={<IconAlertTriangle size={16} />}
+                title="This app is unpublished"
+                mb="md"
+                data-testid="apps-offsite-edit-assets-unpublished-notice"
+              >
+                <Text size="sm">
+                  This app is <b>not visible in the store</b>
+                  {isOwnerEdit(edit) ? <> — you unpublished it</> : <> — its owner unpublished it</>}.
+                  Image changes here save <b>immediately</b> and are <b>not</b> staged for
+                  review — they are not held until you press Save, and leaving this page does
+                  not undo them. They appear in the store when the app is republished. Media
+                  can be added while it is still scanning; it only appears once its scan
+                  finishes cleanly.
+                </Text>
+              </Alert>
+            )}
             {effectiveId ? (
               <ListingAssetStep
                 listingId={effectiveId}

--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -45,6 +45,8 @@ import {
   hasScalarChanges,
   isApprovedEdit,
   listingEditHeaderCopy,
+  materialEditBlockedReason,
+  scopeDisclosureLockedForEdit,
   type ListingEditContext,
 } from '~/components/Apps/offsiteEditConfig';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
@@ -95,6 +97,23 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
   const showUrlStep = !isOnsiteEdit(edit);
   // 🔴 The HEADER reads the SAME flag the wizard shape does — see `listingEditHeaderCopy`.
   const headerCopy = listingEditHeaderCopy(showUrlStep);
+
+  /**
+   * 🔴 THE REPAIR-STATE LOCK. Non-null while this listing is UNPUBLISHED, in which case the
+   * server refuses any MATERIAL change with `MATERIAL_CHANGE_BLOCKED` — see
+   * `materialEditBlockedReason` and `updateListing`'s `removed` branch. Every input this
+   * gates is one the author could otherwise fill and never save.
+   *
+   * 🔴 THE VALUE IS THE GUARD *AND* THE COPY, deliberately one expression rather than a
+   * boolean beside a string. A separate `materialBlocked` flag is how the inputs get
+   * disabled with no explanation on screen, or explained while still enabled.
+   */
+  const materialBlockedReason = materialEditBlockedReason(edit);
+  const materialBlocked = materialBlockedReason != null;
+  // See `scopeDisclosureLockedForEdit`: a DRIFTED scope mask makes every save material, so
+  // the justification boxes are unsaveable too and must not stay live. Not implied by
+  // `materialBlocked` — while the masks agree, a justification edit is trivial and saves.
+  const scopeLocked = scopeDisclosureLockedForEdit(edit);
   const STEP_DETAILS = showUrlStep ? 1 : 0;
   const STEP_ASSETS = showUrlStep ? 2 : 1;
 
@@ -301,6 +320,29 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
         </Alert>
       )}
 
+      {/* 🔴 THE REPAIR-STATE NOTICE. Rendered ABOVE the stepper so the reason is on screen
+          before the author reaches a locked field — a disabled input with its explanation
+          somewhere else reads as a bug. The copy is the server's refusal, restated ahead of
+          time instead of after a failed Save, and it names the way out (republish, then
+          edit). `scopeLocked` appends the one extra sentence its own case needs. */}
+      {materialBlockedReason && (
+        <Alert
+          color="yellow"
+          variant="light"
+          icon={<IconLock size={16} />}
+          title="This app is unpublished"
+          data-testid="apps-offsite-edit-material-locked-notice"
+        >
+          <Text size="sm">
+            {materialBlockedReason}
+            {scopeLocked
+              ? ' Your app’s OAuth scopes have also changed since it was last reviewed, so' +
+                ' the scope justifications are locked until you republish.'
+              : ''}
+          </Text>
+        </Alert>
+      )}
+
       {edit.hasPendingRevision && (
         <Alert
           color="orange"
@@ -352,6 +394,12 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                 maxLength={OFFSITE_SUBMIT_LIMITS.urlMax}
                 data-autofocus
                 data-testid="apps-offsite-edit-url"
+                // 🔴 MATERIAL. See `materialBlockedReason`. The `data-material-field` tag is
+                // what lets the ledger test walk `MATERIAL_LISTING_PATCH_FIELDS` and assert
+                // an input exists AND is disabled for every member — so a field added to
+                // that set with no input here turns the ledger red.
+                data-material-field="externalUrl"
+                disabled={materialBlocked}
               />
               {values.externalUrl.trim().length === 0 && (
                 <Alert
@@ -437,6 +485,9 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
               maxLength={OFFSITE_SUBMIT_LIMITS.nameMax}
               required
               data-testid="apps-offsite-edit-name"
+              // 🔴 MATERIAL — the listing's identity. See `materialBlockedReason`.
+              data-material-field="name"
+              disabled={materialBlocked}
             />
 
             <TextInput
@@ -484,6 +535,10 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
               error={errors.sourceRepoUrl}
               maxLength={OFFSITE_SUBMIT_LIMITS.sourceRepoUrlMax}
               data-testid="apps-offsite-edit-source-repo"
+              // 🔴 MATERIAL — a public outbound link a moderator approved. See
+              // `materialBlockedReason`.
+              data-material-field="sourceRepoUrl"
+              disabled={materialBlocked}
             />
 
             <Group grow align="flex-start">
@@ -509,6 +564,11 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                 error={errors.contentRating}
                 allowDeselect={false}
                 data-testid="apps-offsite-edit-rating"
+                // 🔴 MATERIAL, and the sharpest of the four: `contentRating` drives the
+                // public SFW filter (`content_rating NOT IN ('r','x')`), so an in-place
+                // change with no re-review would surface a mature listing to SFW users.
+                data-material-field="contentRating"
+                disabled={materialBlocked}
               />
             </Group>
 
@@ -520,7 +580,12 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                 requestedScopes={values.requestedScopes}
                 justifications={values.scopeJustifications}
                 onJustificationChange={handleJustificationChange}
-                disabled={saving}
+                // 🔴 `scopeLocked`, NOT `materialBlocked` — see `scopeDisclosureLockedForEdit`.
+                // A justification edit is trivial and saves fine on an unpublished listing
+                // while the scope masks agree; it is only unsaveable once they have DRIFTED,
+                // because the drifted mask then rides along on every patch and the server
+                // counts it as material.
+                disabled={saving || scopeLocked}
                 forceShowErrors={showScopeErrors}
                 intro="These are your OAuth app's allowed scopes — they're derived from the app and can't be changed here. Editing a justification (or a change to your app's scopes) is sent for review on a live listing."
               />

--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -270,7 +270,10 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
         }
         if (!scalarChanged && !assetsDirty) {
           // Nothing to review — just return to the list.
-          showSuccessNotification({ title: 'No changes', message: 'Nothing to submit for review.' });
+          showSuccessNotification({
+            title: 'No changes',
+            message: 'Nothing to submit for review.',
+          });
           void router.push('/apps/mine');
           return;
         }
@@ -375,101 +378,102 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
 
       <Stepper active={active} onStepClick={setActive} size="sm">
         {showUrlStep ? (
-        <Stepper.Step
-          label="URL"
-          description="The link"
-          data-testid="apps-offsite-wizard-step-url"
-        >
-          <FadeIn>
-            <Stack gap="md" mt="md">
-              <TextInput
-                label="App URL"
-                description="Your app’s public https link — users open it from the listing."
-                placeholder="example.com/app"
-                value={values.externalUrl}
-                onChange={(e) => {
-                  setField('externalUrl', e.currentTarget.value);
-                  autofill.clearNote();
-                }}
-                onBlur={handleUrlBlur}
-                onKeyDown={handleUrlKeyDown}
-                error={errors.externalUrl}
-                maxLength={OFFSITE_SUBMIT_LIMITS.urlMax}
-                data-autofocus
-                data-testid="apps-offsite-edit-url"
-                // 🔴 MATERIAL. See `materialBlockedReason`. The `data-material-field` tag is
-                // what lets the ledger test walk `MATERIAL_LISTING_PATCH_FIELDS` and assert
-                // an input exists AND is disabled for every member — so a field added to
-                // that set with no input here turns the ledger red.
-                data-material-field="externalUrl"
-                disabled={materialBlocked}
-              />
-              {values.externalUrl.trim().length === 0 && (
-                <Alert
-                  color="yellow"
-                  variant="light"
-                  icon={<IconInfoCircle size={16} />}
-                  data-testid="apps-offsite-edit-url-prompt"
-                >
-                  <Text size="sm">
-                    This listing has no App URL. Adding one lets users open your app (and lets us
-                    suggest a name, description and images) — but it’s optional here.
-                  </Text>
-                </Alert>
-              )}
-              {/* The OG pull auto-fires when the URL changes to a valid https URL (blur,
+          <Stepper.Step
+            label="URL"
+            description="The link"
+            data-testid="apps-offsite-wizard-step-url"
+          >
+            <FadeIn>
+              <Stack gap="md" mt="md">
+                <TextInput
+                  label="App URL"
+                  description="Your app’s public https link — users open it from the listing."
+                  placeholder="example.com/app"
+                  value={values.externalUrl}
+                  onChange={(e) => {
+                    setField('externalUrl', e.currentTarget.value);
+                    autofill.clearNote();
+                  }}
+                  onBlur={handleUrlBlur}
+                  onKeyDown={handleUrlKeyDown}
+                  error={errors.externalUrl}
+                  maxLength={OFFSITE_SUBMIT_LIMITS.urlMax}
+                  data-autofocus
+                  data-testid="apps-offsite-edit-url"
+                  // 🔴 MATERIAL. See `materialBlockedReason`. The `data-material-field` tag is
+                  // what lets the ledger test walk `MATERIAL_LISTING_PATCH_FIELDS` and assert
+                  // an input exists AND is disabled for every member — so a field added to
+                  // that set with no input here turns the ledger red.
+                  data-material-field="externalUrl"
+                  disabled={materialBlocked}
+                />
+                {values.externalUrl.trim().length === 0 && (
+                  <Alert
+                    color="yellow"
+                    variant="light"
+                    icon={<IconInfoCircle size={16} />}
+                    data-testid="apps-offsite-edit-url-prompt"
+                  >
+                    <Text size="sm">
+                      This listing has no App URL. Adding one lets users open your app (and lets us
+                      suggest a name, description and images) — but it’s optional here.
+                    </Text>
+                  </Alert>
+                )}
+                {/* The OG pull auto-fires when the URL changes to a valid https URL (blur,
                   Enter, Next, or a debounced pause) — no manual button. A subtle inline
                   status reports loading / applied / partial / empty / error. The
                   assets-step "Re-pull from site" button is the manual retry. */}
-              {autofill.loading && (
-                <Group gap={6} data-testid="apps-offsite-edit-meta-loading">
-                  <Loader size={12} />
-                  <Text size="xs" c="dimmed">
-                    Looking for a name, description and images from your link…
+                {autofill.loading && (
+                  <Group gap={6} data-testid="apps-offsite-edit-meta-loading">
+                    <Loader size={12} />
+                    <Text size="xs" c="dimmed">
+                      Looking for a name, description and images from your link…
+                    </Text>
+                  </Group>
+                )}
+                {!autofill.loading && autofill.result?.status === 'error' && (
+                  <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
+                    Couldn’t read that site’s details.
                   </Text>
+                )}
+                {!autofill.loading && autofill.result?.status === 'empty' && (
+                  <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-empty">
+                    {autofill.result.siteExposedNothing
+                      ? 'Your site didn’t expose a name, description, icon or cover to pull — add them manually.'
+                      : 'Nothing to autofill — your details and assets are already set.'}
+                  </Text>
+                )}
+                {!autofill.loading && autofill.result?.status === 'partial' && (
+                  <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-partial">
+                    Pulled what your link exposed —{' '}
+                    {describeMissingChannels(autofill.result.missing)}{' '}
+                    {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
+                    {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check
+                    the Details and Assets steps for what we found.
+                  </Text>
+                )}
+                {!autofill.loading && autofill.result?.status === 'applied' && (
+                  <Alert
+                    color="grape"
+                    variant="light"
+                    icon={<IconSparkles size={16} />}
+                    data-testid="apps-offsite-edit-autofill-applied"
+                  >
+                    <Text size="sm">
+                      Pulled the latest details from your link — check the Details and Assets steps
+                      to review the name, description and the suggested icon/cover.
+                    </Text>
+                  </Alert>
+                )}
+                <Group justify="flex-end">
+                  <Button onClick={handleAdvanceFromUrl} data-testid="apps-offsite-wizard-next-url">
+                    Next
+                  </Button>
                 </Group>
-              )}
-              {!autofill.loading && autofill.result?.status === 'error' && (
-                <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
-                  Couldn’t read that site’s details.
-                </Text>
-              )}
-              {!autofill.loading && autofill.result?.status === 'empty' && (
-                <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-empty">
-                  {autofill.result.siteExposedNothing
-                    ? 'Your site didn’t expose a name, description, icon or cover to pull — add them manually.'
-                    : 'Nothing to autofill — your details and assets are already set.'}
-                </Text>
-              )}
-              {!autofill.loading && autofill.result?.status === 'partial' && (
-                <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-partial">
-                  Pulled what your link exposed — {describeMissingChannels(autofill.result.missing)}{' '}
-                  {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
-                  {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check the
-                  Details and Assets steps for what we found.
-                </Text>
-              )}
-              {!autofill.loading && autofill.result?.status === 'applied' && (
-                <Alert
-                  color="grape"
-                  variant="light"
-                  icon={<IconSparkles size={16} />}
-                  data-testid="apps-offsite-edit-autofill-applied"
-                >
-                  <Text size="sm">
-                    Pulled the latest details from your link — check the Details and Assets steps to
-                    review the name, description and the suggested icon/cover.
-                  </Text>
-                </Alert>
-              )}
-              <Group justify="flex-end">
-                <Button onClick={handleAdvanceFromUrl} data-testid="apps-offsite-wizard-next-url">
-                  Next
-                </Button>
-              </Group>
-            </Stack>
-          </FadeIn>
-        </Stepper.Step>
+              </Stack>
+            </FadeIn>
+          </Stepper.Step>
         ) : null}
 
         <Stepper.Step
@@ -479,130 +483,130 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           data-testid="apps-offsite-wizard-step-details"
         >
           <FadeIn>
-          <Stack gap="md" mt="md">
-            <TextInput
-              label="Name"
-              value={values.name}
-              onChange={(e) => setField('name', e.currentTarget.value)}
-              error={errors.name}
-              maxLength={OFFSITE_SUBMIT_LIMITS.nameMax}
-              required
-              data-testid="apps-offsite-edit-name"
-              // 🔴 MATERIAL — the listing's identity. See `materialBlockedReason`.
-              data-material-field="name"
-              disabled={materialBlocked}
-            />
+            <Stack gap="md" mt="md">
+              <TextInput
+                label="Name"
+                value={values.name}
+                onChange={(e) => setField('name', e.currentTarget.value)}
+                error={errors.name}
+                maxLength={OFFSITE_SUBMIT_LIMITS.nameMax}
+                required
+                data-testid="apps-offsite-edit-name"
+                // 🔴 MATERIAL — the listing's identity. See `materialBlockedReason`.
+                data-material-field="name"
+                disabled={materialBlocked}
+              />
 
-            <TextInput
-              label="Slug"
-              description="Your app's URL slug is fixed once created — it identifies the listing."
-              value={values.slug}
-              readOnly
-              disabled
-              rightSection={<IconLock size={14} />}
-              data-testid="apps-offsite-edit-slug"
-            />
+              <TextInput
+                label="Slug"
+                description="Your app's URL slug is fixed once created — it identifies the listing."
+                value={values.slug}
+                readOnly
+                disabled
+                rightSection={<IconLock size={14} />}
+                data-testid="apps-offsite-edit-slug"
+              />
 
-            <TextInput
-              label="Tagline"
-              description="A short one-liner (optional)."
-              value={values.tagline}
-              onChange={(e) => setField('tagline', e.currentTarget.value)}
-              error={errors.tagline}
-              maxLength={OFFSITE_SUBMIT_LIMITS.taglineMax}
-            />
+              <TextInput
+                label="Tagline"
+                description="A short one-liner (optional)."
+                value={values.tagline}
+                onChange={(e) => setField('tagline', e.currentTarget.value)}
+                error={errors.tagline}
+                maxLength={OFFSITE_SUBMIT_LIMITS.taglineMax}
+              />
 
-            <Textarea
-              label="Description"
-              description="What the app does (optional)."
-              autosize
-              minRows={3}
-              maxRows={8}
-              value={values.description}
-              onChange={(e) => setField('description', e.currentTarget.value)}
-              error={errors.description}
-              maxLength={OFFSITE_SUBMIT_LIMITS.descriptionMax}
-            />
+              <Textarea
+                label="Description"
+                description="What the app does (optional)."
+                autosize
+                minRows={3}
+                maxRows={8}
+                value={values.description}
+                onChange={(e) => setField('description', e.currentTarget.value)}
+                error={errors.description}
+                maxLength={OFFSITE_SUBMIT_LIMITS.descriptionMax}
+              />
 
-            {/* Public source repository. The copy states the re-review consequence
+              {/* Public source repository. The copy states the re-review consequence
                 up front: this is a MATERIAL field, so on an approved listing changing
                 it stages a shadow revision and the change does not go live until a
                 moderator approves it. An author who is not told that reads the
                 unchanged live page afterwards as a bug. */}
-            <TextInput
-              label="Source repository"
-              description={`Public link to your app's source code, shown on its store page (optional). ${SOURCE_REPO_HOSTS_LABEL} only, linking to the repository itself — e.g. https://github.com/your-org/your-app. Changing this needs moderator re-review before it goes live.`}
-              placeholder="https://github.com/your-org/your-app"
-              value={values.sourceRepoUrl}
-              onChange={(e) => setField('sourceRepoUrl', e.currentTarget.value)}
-              error={errors.sourceRepoUrl}
-              maxLength={OFFSITE_SUBMIT_LIMITS.sourceRepoUrlMax}
-              data-testid="apps-offsite-edit-source-repo"
-              // 🔴 MATERIAL — a public outbound link a moderator approved. See
-              // `materialBlockedReason`.
-              data-material-field="sourceRepoUrl"
-              disabled={materialBlocked}
-            />
-
-            <Group grow align="flex-start">
-              <Select
-                label="Category"
-                placeholder="No category"
-                data={OFFSITE_CATEGORY_OPTIONS}
-                value={values.category}
-                onChange={(v: string | null) =>
-                  setField('category', (v as MarketplaceCategory) || null)
-                }
-                error={errors.category}
-                clearable
-                data-testid="apps-offsite-edit-category"
-              />
-              <Select
-                label="Content rating"
-                data={OFFSITE_CONTENT_RATING_OPTIONS}
-                value={values.contentRating}
-                onChange={(v: string | null) =>
-                  setField('contentRating', (v as OffsiteContentRating) || 'g')
-                }
-                error={errors.contentRating}
-                allowDeselect={false}
-                data-testid="apps-offsite-edit-rating"
-                // 🔴 MATERIAL, and the sharpest of the four: `contentRating` drives the
-                // public SFW filter (`content_rating NOT IN ('r','x')`), so an in-place
-                // change with no re-review would surface a mature listing to SFW users.
-                data-material-field="contentRating"
+              <TextInput
+                label="Source repository"
+                description={`Public link to your app's source code, shown on its store page (optional). ${SOURCE_REPO_HOSTS_LABEL} only, linking to the repository itself — e.g. https://github.com/your-org/your-app. Changing this needs moderator re-review before it goes live.`}
+                placeholder="https://github.com/your-org/your-app"
+                value={values.sourceRepoUrl}
+                onChange={(e) => setField('sourceRepoUrl', e.currentTarget.value)}
+                error={errors.sourceRepoUrl}
+                maxLength={OFFSITE_SUBMIT_LIMITS.sourceRepoUrlMax}
+                data-testid="apps-offsite-edit-source-repo"
+                // 🔴 MATERIAL — a public outbound link a moderator approved. See
+                // `materialBlockedReason`.
+                data-material-field="sourceRepoUrl"
                 disabled={materialBlocked}
               />
-            </Group>
 
-            {/* 🔴 OFF-SITE ONLY. An on-site app is not an OAuth-connect integration —
+              <Group grow align="flex-start">
+                <Select
+                  label="Category"
+                  placeholder="No category"
+                  data={OFFSITE_CATEGORY_OPTIONS}
+                  value={values.category}
+                  onChange={(v: string | null) =>
+                    setField('category', (v as MarketplaceCategory) || null)
+                  }
+                  error={errors.category}
+                  clearable
+                  data-testid="apps-offsite-edit-category"
+                />
+                <Select
+                  label="Content rating"
+                  data={OFFSITE_CONTENT_RATING_OPTIONS}
+                  value={values.contentRating}
+                  onChange={(v: string | null) =>
+                    setField('contentRating', (v as OffsiteContentRating) || 'g')
+                  }
+                  error={errors.contentRating}
+                  allowDeselect={false}
+                  data-testid="apps-offsite-edit-rating"
+                  // 🔴 MATERIAL, and the sharpest of the four: `contentRating` drives the
+                  // public SFW filter (`content_rating NOT IN ('r','x')`), so an in-place
+                  // change with no re-review would surface a mature listing to SFW users.
+                  data-material-field="contentRating"
+                  disabled={materialBlocked}
+                />
+              </Group>
+
+              {/* 🔴 OFF-SITE ONLY. An on-site app is not an OAuth-connect integration —
                 there is no linked client whose scopes a user would be consenting to, so
                 the disclosure would be describing a grant that does not exist. */}
-            {showUrlStep && edit.connectClientId != null && (
-              <DerivedScopesDisclosure
-                requestedScopes={values.requestedScopes}
-                justifications={values.scopeJustifications}
-                onJustificationChange={handleJustificationChange}
-                // 🔴 `scopeLocked`, NOT `materialBlocked` — see `scopeDisclosureLockedForEdit`.
-                // A justification edit is trivial and saves fine on an unpublished listing
-                // while the scope masks agree; it is only unsaveable once they have DRIFTED,
-                // because the drifted mask then rides along on every patch and the server
-                // counts it as material.
-                disabled={saving || scopeLocked}
-                forceShowErrors={showScopeErrors}
-                intro="These are your OAuth app's allowed scopes — they're derived from the app and can't be changed here. Editing a justification (or a change to your app's scopes) is sent for review on a live listing."
-              />
-            )}
+              {showUrlStep && edit.connectClientId != null && (
+                <DerivedScopesDisclosure
+                  requestedScopes={values.requestedScopes}
+                  justifications={values.scopeJustifications}
+                  onJustificationChange={handleJustificationChange}
+                  // 🔴 `scopeLocked`, NOT `materialBlocked` — see `scopeDisclosureLockedForEdit`.
+                  // A justification edit is trivial and saves fine on an unpublished listing
+                  // while the scope masks agree; it is only unsaveable once they have DRIFTED,
+                  // because the drifted mask then rides along on every patch and the server
+                  // counts it as material.
+                  disabled={saving || scopeLocked}
+                  forceShowErrors={showScopeErrors}
+                  intro="These are your OAuth app's allowed scopes — they're derived from the app and can't be changed here. Editing a justification (or a change to your app's scopes) is sent for review on a live listing."
+                />
+              )}
 
-            <Group justify={showUrlStep ? 'space-between' : 'flex-end'}>
-              {showUrlStep ? (
-                <Button variant="default" onClick={() => setActive(STEP_URL)}>
-                  Back
-                </Button>
-              ) : null}
-              <Button onClick={() => setActive(STEP_ASSETS)}>Next</Button>
-            </Group>
-          </Stack>
+              <Group justify={showUrlStep ? 'space-between' : 'flex-end'}>
+                {showUrlStep ? (
+                  <Button variant="default" onClick={() => setActive(STEP_URL)}>
+                    Back
+                  </Button>
+                ) : null}
+                <Button onClick={() => setActive(STEP_ASSETS)}>Next</Button>
+              </Group>
+            </Stack>
           </FadeIn>
         </Stepper.Step>
 
@@ -643,12 +647,15 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
               >
                 <Text size="sm">
                   This app is <b>not visible in the store</b>
-                  {isOwnerEdit(edit) ? <> — you unpublished it</> : <> — its owner unpublished it</>}.
-                  Image changes here save <b>immediately</b> and are <b>not</b> staged for
-                  review — they are not held until you press Save, and leaving this page does
-                  not undo them. They appear in the store when the app is republished. Media
-                  can be added while it is still scanning; it only appears once its scan
-                  finishes cleanly.
+                  {isOwnerEdit(edit) ? (
+                    <> — you unpublished it</>
+                  ) : (
+                    <> — its owner unpublished it</>
+                  )}
+                  . Image changes here save <b>immediately</b> and are <b>not</b> staged for review
+                  — they are not held until you press Save, and leaving this page does not undo
+                  them. They appear in the store when the app is republished. Media can be added
+                  while it is still scanning; it only appears once its scan finishes cleanly.
                 </Text>
               </Alert>
             )}

--- a/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
@@ -378,9 +378,17 @@ describe('🔴 the OAuth scope disclosure follows the DRIFT, not the status', ()
     // /scopes have also changed/i — a sentence appended after "Tagline, description and
     // category can be edited now", i.e. the test pinned HALF of a self-contradicting
     // message and was satisfied. The notice now states the actual consequence.
-    await expect
-      .element(page.getByTestId('apps-offsite-edit-material-locked-notice'))
-      .toHaveTextContent(/nothing on this screen can be saved/i);
+    const notice = page.getByTestId('apps-offsite-edit-material-locked-notice');
+    await expect.element(notice).toHaveTextContent(/nothing on this screen can be saved/i);
+    // 🔴 AND THE FALSE SENTENCE IS ABSENT FROM THE RENDER, not merely from the function's
+    // return value. This second assertion is not redundant with the unit test that pins
+    // `materialEditBlockedReason`'s output: the contradiction originally lived in the JSX,
+    // as a `{scopeLocked ? '…' : ''}` APPENDED after the reason. A mutant that re-adds any
+    // such append is invisible to a unit test of the copy function — the function's return
+    // is still correct — and invisible to a presence-only assertion here, because appending
+    // does not disturb the text already matched. Found exactly that way: this mutation
+    // SURVIVED the whole battery until this line existed.
+    await expect.element(notice).not.toHaveTextContent(/can be edited now/i);
     await page.getByRole('button', { name: 'Next' }).click();
     await expect.element(page.getByTestId('apps-offsite-justification-8')).toBeDisabled();
   });

--- a/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { MATERIAL_LISTING_PATCH_FIELDS } from '~/shared/constants/app-capabilities.constants';
+import {
+  MATERIAL_LISTING_PATCH_FIELDS,
+  type MaterialListingPatchField,
+} from '~/shared/constants/app-capabilities.constants';
 import type * as TrpcModule from '~/utils/trpc';
 import type { ListingEditContext } from './offsiteEditConfig';
 
@@ -257,9 +260,28 @@ describe('🔴 an OWNER-UNPUBLISHED listing: material fields are shown, and lock
     await expect.element(notice).toBeInTheDocument();
     await expect.element(notice).not.toHaveTextContent(/App URL/);
     await expect.element(notice).toHaveTextContent(/source repository/i);
-    // On-site opens straight on Details (no URL step), and the three fields are locked.
+    // On-site opens straight on Details (no URL step), and every field it HAS is locked.
     await expect.element(page.getByTestId('apps-offsite-edit-name')).toBeInTheDocument();
-    for (const field of ['name', 'contentRating', 'sourceRepoUrl'] as const) {
+
+    // 🔴 DERIVED FROM THE SERVER'S CONSTANT, NOT HAND-LISTED. This used to spell
+    // `['name', 'contentRating', 'sourceRepoUrl']` — three of the four members of
+    // `MATERIAL_LISTING_PATCH_FIELDS` — which is a LEDGER THAT CANNOT GROW: a fifth
+    // material field added server-side would be refused by `updateListing` and would render
+    // an ENABLED input here, and this test would stay green because the literal never
+    // mentioned it. The off-site arm above already walks the constant; this arm is now the
+    // same sweep minus the ONE field on-site genuinely does not have.
+    //
+    // `externalUrl` is excluded by NAME rather than by "whatever is missing", so the
+    // exclusion is a claim that can itself be wrong and be caught — the assertion below
+    // pins that it really is absent.
+    const onsiteMaterialFields = MATERIAL_LISTING_PATCH_FIELDS.filter(
+      (f): f is Exclude<MaterialListingPatchField, 'externalUrl'> => f !== 'externalUrl'
+    );
+    // Positive control: the filter must leave a NON-EMPTY set. A rename of the excluded
+    // member (or of any other) that emptied this list would otherwise make the loop below
+    // vacuous and green.
+    expect(onsiteMaterialFields.length).toBeGreaterThan(0);
+    for (const field of onsiteMaterialFields) {
       expect(materialControl(field)?.disabled, field).toBe(true);
     }
     expect(materialControl('externalUrl'), 'no URL step for an on-site listing').toBeNull();

--- a/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
@@ -266,6 +266,65 @@ describe('🔴 an OWNER-UNPUBLISHED listing: material fields are shown, and lock
   });
 });
 
+/**
+ * 🔴 THE ASSETS STEP — NEWLY REACHABLE, EAGERLY WRITING, AND IT SHIPPED WITH NO FRAME.
+ *
+ * `ListingMediaEditor` got a careful repair-state frame. This step got none, and for an
+ * OFF-SITE listing it is the ONLY image surface there is:
+ * `capabilitiesForKind('offsite').listingMedia` is `false`, so `editorTabsFor` withholds
+ * the Media tab entirely and `ListingMediaEditor` never mounts for these listings. The
+ * frame that was added therefore covered the case that did NOT need it most.
+ *
+ * The write semantics are the part that must be stated. `ListingAssetStep` writes EAGERLY,
+ * one mutation per change, against `edit.parentId` — a non-approved listing has no shadow,
+ * so nothing is staged, nothing waits for Save, and leaving the page does not undo it. That
+ * differs BOTH from the approved case (which stages a revision) and from the scalar fields
+ * on the previous step of this very wizard (which do wait for Save). An author who assumes
+ * either is wrong in a way that costs them their live imagery.
+ */
+describe('🔴 the ASSETS step carries the repair frame too', () => {
+  async function openAssets() {
+    // URL step -> Details -> Assets. Two `Next` clicks for an off-site listing.
+    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
+  }
+
+  test('🔴 an unpublished listing is told these image writes are IMMEDIATE, not staged', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await openAssets();
+
+    const notice = page.getByTestId('apps-offsite-edit-assets-unpublished-notice');
+    await expect.element(notice).toBeInTheDocument();
+    // The app is DOWN…
+    await expect.element(notice).toHaveTextContent(/not visible in the store/i);
+    // …and the surprising half: these writes do NOT wait for Save and are NOT staged.
+    await expect.element(notice).toHaveTextContent(/immediately/i);
+    await expect.element(notice).toHaveTextContent(/not.*staged/i);
+  });
+
+  test('🔴 CONTROL — a PUBLISHED listing gets NO such frame', async () => {
+    // Without this the notice could be unconditional, and every assertion above would pass
+    // while every approved author was told their staged edits apply immediately — the exact
+    // inversion of the truth, and a worse defect than the one being fixed.
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ status: 'approved' })} />);
+    await openAssets();
+
+    await expect.element(page.getByTestId('apps-offsite-wizard-assets-panel')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-edit-assets-unpublished-notice').elements()).toHaveLength(
+      0
+    );
+  });
+
+  test('🔴 it is ROLE-AWARE, like every other repair-state sentence', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ role: 'editor' })} />);
+    await openAssets();
+
+    const notice = page.getByTestId('apps-offsite-edit-assets-unpublished-notice');
+    await expect.element(notice).toHaveTextContent(/its owner unpublished it/i);
+    await expect.element(notice).not.toHaveTextContent(/you unpublished it/i);
+  });
+});
+
 describe('🔴 the OAuth scope disclosure follows the DRIFT, not the status', () => {
   const connect = {
     connectClientId: 'oauth-1',
@@ -293,10 +352,80 @@ describe('🔴 the OAuth scope disclosure follows the DRIFT, not the status', ()
     renderWithProviders(
       <ExternalSubmitForm edit={makeCtx({ ...connect, connectAllowedScopes: 28 })} />
     );
+    // 🔴 THE ASSERTION CHANGED WITH THE COPY, AND THE OLD ONE WAS THE BUG. It matched
+    // /scopes have also changed/i — a sentence appended after "Tagline, description and
+    // category can be edited now", i.e. the test pinned HALF of a self-contradicting
+    // message and was satisfied. The notice now states the actual consequence.
     await expect
       .element(page.getByTestId('apps-offsite-edit-material-locked-notice'))
-      .toHaveTextContent(/scopes have also changed/i);
+      .toHaveTextContent(/nothing on this screen can be saved/i);
     await page.getByRole('button', { name: 'Next' }).click();
     await expect.element(page.getByTestId('apps-offsite-justification-8')).toBeDisabled();
+  });
+
+  /**
+   * 🔴 THE MISSING HALF: ATTEMPT THE SAVE.
+   *
+   * The test above asserts the box is DISABLED and stops there — which is precisely why the
+   * dead end was invisible. A disabled input is only half the story; the question an author
+   * has is "can I save anything from this screen", and nothing ever asked it.
+   *
+   * The answer is no, and by a route that is easy to miss: `handleSave` runs
+   * `scopeJustificationError(values)` for ANY connect listing (gated on
+   * `edit.connectClientId != null`, NOT on `scopeLocked`). The drifted mask adds a sensitive
+   * scope with no prefilled justification, so the save aborts CLIENT-side, sets the scope
+   * error and jumps the author to Details — where the box that would clear it is disabled.
+   *
+   * So this drives the real click path: edit a NON-material field the copy used to promise
+   * was saveable (tagline), press Save, and assert it did not go through.
+   *
+   * 🟡 LABEL: THIS IS A CHARACTERISATION GUARD, NOT REGRESSION COVERAGE, and it is measured
+   * rather than assumed — restoring `offsiteEditConfig.ts` + `ExternalListingEditForm.tsx`
+   * to b16cc80c2c and re-running leaves this test GREEN (11 executed, only the copy test
+   * red). That is the correct result and the reason the finding was worded as "the copy
+   * claims the opposite": the dead end is PRE-EXISTING and this PR does not remove it. The
+   * fix is that the copy stops denying it.
+   *
+   * What this test is FOR, then, is the next change rather than this one. The dead end has
+   * two independent halves — the unconditional scope check in `handleSave` and the disabled
+   * boxes — and a plausible future "fix" addresses one and leaves the other, which would
+   * still be a dead end while looking repaired. Both halves are asserted here, so a half-fix
+   * reddens exactly one line.
+   */
+  test('🟡 in the DRIFTED state a tagline-only Save is REFUSED — the screen is a dead end', async () => {
+    const onDrift = makeCtx({
+      ...connect,
+      // Stored mask is 12 (= ModelsRead 4 | ModelsWrite 8), with ModelsWrite justified.
+      // The client now allows 24 (= ModelsWrite 8 | ModelsDelete 16). ModelsDelete is
+      // SENSITIVE and has NO stored rationale — the client did not have it when the listing
+      // was last reviewed — and `editContextToForm` cannot invent one. That is what makes
+      // the save unclearable rather than merely inconvenient.
+      connectAllowedScopes: 24,
+    });
+    renderWithProviders(<ExternalSubmitForm edit={onDrift} />);
+
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Edit the tagline — the field the old copy explicitly said "can be edited now".
+    const tagline = page.getByRole('textbox', { name: 'Tagline' });
+    await expect.element(tagline).toBeInTheDocument();
+    // 🔴 NOT disabled. The tagline is genuinely editable, which is exactly what made the old
+    // copy plausible — the defect is that editing it achieves nothing.
+    await expect.element(tagline).not.toBeDisabled();
+    await tagline.fill('A brand new tagline');
+
+    await page.getByTestId('apps-offsite-edit-save').click();
+
+    // 🔴 THE SAVE DID NOT LAND, asserted on the MUTATION SPY rather than on the absence of a
+    // success toast: a missing toast is indistinguishable from one that has not rendered
+    // yet, whereas "the mutation was never called" is a positive statement about the path.
+    expect(mocks.updateListing).not.toHaveBeenCalled();
+
+    // 🔴 AND THE DEAD END IS NOW ON SCREEN IN ONE FRAME: the unjustified sensitive scope
+    // (ModelsDelete, bit 16) carries a REQUIRED error, and the same input is DISABLED. An
+    // error on a box the author cannot type in is the whole defect, stated as an assertion.
+    const blocked = page.getByTestId('apps-offsite-justification-16');
+    await expect.element(blocked).toBeDisabled();
+    await expect.element(blocked).toHaveAccessibleDescription(/justification is required/i);
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
@@ -54,14 +54,16 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     mutateAsync: vi.fn().mockResolvedValue({}),
     isPending: false,
   });
-  const recording = (fn: (v: unknown) => void, result: unknown = {}) => () => ({
-    mutate: vi.fn(),
-    mutateAsync: (vars: unknown) => {
-      fn(vars);
-      return Promise.resolve(result);
-    },
-    isPending: false,
-  });
+  const recording =
+    (fn: (v: unknown) => void, result: unknown = {}) =>
+    () => ({
+      mutate: vi.fn(),
+      mutateAsync: (vars: unknown) => {
+        fn(vars);
+        return Promise.resolve(result);
+      },
+      isPending: false,
+    });
   return {
     ...actual,
     trpc: {

--- a/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
@@ -147,6 +147,55 @@ function materialControl(field: string): HTMLInputElement | HTMLSelectElement | 
   return tagged.querySelector<HTMLInputElement>('input, select');
 }
 
+/**
+ * A notice's whole rendered text, whitespace-normalised.
+ *
+ * 🔴 `toHaveTextContent(string)` is a SUBSTRING match, so it cannot pin a whole message —
+ * anything APPENDED to the notice still satisfies it. That is precisely the mutation shape
+ * this file has to see (see `DRIFTED_NOTICE_TEXT`), so the drifted-state assertion compares
+ * the normalised string with `toBe` instead. Read SYNCHRONOUSLY, so every call site must
+ * already have awaited an assertion on the same element.
+ */
+function noticeText(testId: string): string {
+  const el = document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+  return (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * 🔴 THE WHOLE DRIFTED-STATE NOTICE, PINNED AS ONE STRING — and the cost is deliberate.
+ *
+ * The previous guard here asserted the ABSENCE of one substring (`/can be edited now/i`),
+ * which is a guard on a WORD rather than on the message. It is walkable by REWORDING:
+ * re-appending the old false promise as `' You may still edit the tagline, description and
+ * category.'` says the same untrue thing, matches no part of that regex, and SURVIVED the
+ * whole 14-case battery. Absence-of-a-phrase can only ever catch the one spelling somebody
+ * already thought of.
+ *
+ * So this pins the entire normalised render instead. The trade is real and accepted: a
+ * COSMETIC reword of this copy now fails this test and has to be re-pinned here. That is
+ * the right exchange for a sentence that was factually wrong in production once already —
+ * the notice tells an author whether their work can be saved, and a machine-readable claim
+ * about it is worth a line of churn per reword.
+ *
+ * 🔴 IT IS A LITERAL, NOT `materialEditBlockedReason(ctx)`. Deriving the expectation from
+ * the function under test would make this pass for any copy that function emits, which is
+ * half of what has to be pinned — the original defect lived in the JSX, APPENDING to a
+ * return value that was itself correct.
+ *
+ * The leading duplication is the Mantine Alert TITLE running into the body in
+ * `textContent`; they are separate elements on screen. Spelled out via `ALERT_TITLE` so it
+ * reads as structure rather than as a copy defect.
+ */
+const ALERT_TITLE = 'This app is unpublished';
+const DRIFTED_NOTICE_TEXT =
+  ALERT_TITLE +
+  `This app is unpublished, so its name, App URL, source repository and content rating ` +
+  `are locked — and your OAuth app's permissions have changed since this listing was last ` +
+  `reviewed. That changed permission set rides along on every save, so while the app stays ` +
+  `unpublished NOTHING on this screen can be saved — not the tagline, description or ` +
+  `category either. To edit anything, ask the app's owner to republish it; the new ` +
+  `permissions are then reviewed along with your changes.`;
+
 beforeEach(() => {
   mocks.meta = { data: undefined, isFetching: false, isError: false, isSuccess: false };
   mocks.refetch.mockClear();
@@ -345,6 +394,41 @@ describe('🔴 the ASSETS step carries the repair frame too', () => {
     await expect.element(notice).toHaveTextContent(/its owner unpublished it/i);
     await expect.element(notice).not.toHaveTextContent(/you unpublished it/i);
   });
+
+  /**
+   * 🔴 THE OWNER ARM — the other direction of the same branch, and without it the branch is
+   * not covered at all.
+   *
+   * The editor case above and the default fixture BOTH land on the non-owner arm
+   * (`makeCtx()` carries no `role`, and `isOwnerEdit` fails safe to `false`), so replacing
+   * `isOwnerEdit(edit)` in `ExternalListingEditForm.tsx` with a bare `false` changes nothing
+   * either of them can see and SURVIVED all 14 cases. A branch only one side of which is
+   * ever exercised is a constant with extra steps.
+   *
+   * This is the same pair `ListingMediaEditor` already keeps
+   * (`src/tests/pages/apps/listing-media-page.browser.test.tsx`), and it is kept for the
+   * same reason stated there: a mutant that emits ONE role's copy for everybody passes every
+   * assertion on the other side. Run the two as a pair.
+   *
+   * The two attributions are mutually exclusive by construction — "you unpublished it" and
+   * "its owner unpublished it" cannot both be true of one reader — so each arm asserts the
+   * presence of its own and the ABSENCE of the other's. The role-independent half ("not
+   * visible in the store") is asserted on both, so collapsing the branch into an empty
+   * string cannot pass either.
+   */
+  test('🔴 the OWNER gets the owner attribution — the branch is not a blanket reword', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ role: 'owner' })} />);
+    await openAssets();
+
+    const notice = page.getByTestId('apps-offsite-edit-assets-unpublished-notice');
+    await expect.element(notice).toBeInTheDocument();
+    // Role-independent, and true on both arms — so this cannot be what carries the case.
+    await expect.element(notice).toHaveTextContent(/not visible in the store/i);
+    // The owner's own attribution…
+    await expect.element(notice).toHaveTextContent(/you unpublished it/i);
+    // …and NOT the editor's, which would be false for the person who did it.
+    await expect.element(notice).not.toHaveTextContent(/its owner unpublished it/i);
+  });
 });
 
 describe('🔴 the OAuth scope disclosure follows the DRIFT, not the status', () => {
@@ -380,15 +464,22 @@ describe('🔴 the OAuth scope disclosure follows the DRIFT, not the status', ()
     // message and was satisfied. The notice now states the actual consequence.
     const notice = page.getByTestId('apps-offsite-edit-material-locked-notice');
     await expect.element(notice).toHaveTextContent(/nothing on this screen can be saved/i);
-    // 🔴 AND THE FALSE SENTENCE IS ABSENT FROM THE RENDER, not merely from the function's
-    // return value. This second assertion is not redundant with the unit test that pins
-    // `materialEditBlockedReason`'s output: the contradiction originally lived in the JSX,
-    // as a `{scopeLocked ? '…' : ''}` APPENDED after the reason. A mutant that re-adds any
-    // such append is invisible to a unit test of the copy function — the function's return
-    // is still correct — and invisible to a presence-only assertion here, because appending
-    // does not disturb the text already matched. Found exactly that way: this mutation
-    // SURVIVED the whole battery until this line existed.
-    await expect.element(notice).not.toHaveTextContent(/can be edited now/i);
+    // 🔴 AND THE WHOLE RENDERED MESSAGE IS PINNED, not merely the function's return value.
+    // This is not redundant with the unit test of `materialEditBlockedReason`'s output: the
+    // contradiction originally lived in the JSX, as a `{scopeLocked ? '…' : ''}` APPENDED
+    // after the reason. A mutant that re-adds any such append is invisible to a unit test of
+    // the copy function — the function's return is still correct — and invisible to a
+    // presence-only assertion here, because appending does not disturb text already matched.
+    //
+    // 🔴 IT IS ALSO NOT AN ABSENCE ASSERTION ANY MORE, and that is the point of this round.
+    // The previous line here was `.not.toHaveTextContent(/can be edited now/i)`, which pins
+    // one SPELLING of the false promise. Re-appending the exact old sentence died; appending
+    // a reworded equivalent ("You may still edit the tagline, description and category.")
+    // said the same untrue thing and SURVIVED all 14 cases. Equality over the normalised
+    // string cannot be walked that way — any append, in any wording, moves it.
+    // The awaited assertion above has already settled this element, so the synchronous read
+    // is safe here.
+    expect(noticeText('apps-offsite-edit-material-locked-notice')).toBe(DRIFTED_NOTICE_TEXT);
     await page.getByRole('button', { name: 'Next' }).click();
     await expect.element(page.getByTestId('apps-offsite-justification-8')).toBeDisabled();
   });

--- a/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.ownerUnpublished.browser.test.tsx
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { MATERIAL_LISTING_PATCH_FIELDS } from '~/shared/constants/app-capabilities.constants';
+import type * as TrpcModule from '~/utils/trpc';
+import type { ListingEditContext } from './offsiteEditConfig';
+
+/**
+ * THE EDIT WIZARD ON AN OWNER-UNPUBLISHED LISTING — the MATERIAL fields must be visible
+ * and NOT editable.
+ *
+ * 🔴 WHY THIS IS A DEFECT AND NOT A NICETY. `updateListing`'s `removed` branch refuses any
+ * change to a field in `MATERIAL_LISTING_PATCH_FIELDS` with `MATERIAL_CHANGE_BLOCKED`
+ * (→ BAD_REQUEST), and it refuses it AFTER the author has typed the change and pressed
+ * Save. That refusal was unreachable while no editor tab opened on this status; opening the
+ * Details tab without this makes it four boxes the author can fill and can never save,
+ * discovering the rule only from a red toast. An editable input that can never save is
+ * worse than a hidden one.
+ *
+ * 🔴 THE PREFILL STAYS WIDER THAN THE WRITE, DELIBERATELY. The author must be able to READ
+ * their current name, URL, repository and rating — those values are what they are deciding
+ * whether to republish. Showing a value is a different act from offering an edit of it, and
+ * these cases pin the difference: the inputs are IN the document, carrying their real
+ * values, and disabled.
+ *
+ * 🔴 THE LEDGER CASE IS THE ONE THAT SURVIVES FUTURE CHANGE. It walks
+ * `MATERIAL_LISTING_PATCH_FIELDS` — the SAME constant `offsite-listing.service` refuses on —
+ * and demands a disabled input per member, so a field added to the server's material set
+ * with no counterpart here goes red instead of shipping another unsaveable box.
+ */
+
+const mocks = vi.hoisted(() => ({
+  meta: { data: undefined, isFetching: false, isError: false, isSuccess: false } as {
+    data?: unknown;
+    isFetching?: boolean;
+    isError?: boolean;
+    isSuccess?: boolean;
+  },
+  refetch: vi.fn(),
+  updateListing: vi.fn(),
+  updateRevision: vi.fn(),
+  submitRevision: vi.fn(),
+  invalidate: vi.fn(),
+}));
+
+// Spread the REAL module and override only `trpc` (per `local-rules/no-wholesale-module-mock`):
+// a hand-written replacement silently drops any export a transitive importer needs, and the
+// whole file then fails to load as "0 tests collected" — green for the worst possible reason.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  const noopMutation = () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  });
+  const recording = (fn: (v: unknown) => void, result: unknown = {}) => () => ({
+    mutate: vi.fn(),
+    mutateAsync: (vars: unknown) => {
+      fn(vars);
+      return Promise.resolve(result);
+    },
+    isPending: false,
+  });
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({
+        appListings: {
+          listMySubmissions: { invalidate: mocks.invalidate },
+          getMyListingForEdit: { invalidate: mocks.invalidate },
+        },
+      }),
+      appListings: {
+        fetchListingMetaFromUrl: { useQuery: () => ({ ...mocks.meta, refetch: mocks.refetch }) },
+        updateListing: { useMutation: recording(mocks.updateListing) },
+        updateRevisionDraft: { useMutation: recording(mocks.updateRevision) },
+        submitListingRevision: { useMutation: recording(mocks.submitRevision) },
+        removeScreenshot: { useMutation: noopMutation },
+        persistAssetImage: { useMutation: noopMutation },
+        ingestAssetFromUrl: { useMutation: noopMutation },
+        ingestAssetFromDataUri: { useMutation: noopMutation },
+        setIcon: { useMutation: noopMutation },
+        setCover: { useMutation: noopMutation },
+        addScreenshot: { useMutation: noopMutation },
+      },
+    },
+  };
+});
+
+vi.mock('~/hooks/useCFImageUpload', () => ({
+  useCFImageUpload: () => ({
+    uploadToCF: vi.fn(),
+    files: [],
+    resetFiles: vi.fn(),
+    removeImage: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+const { ExternalSubmitForm } = await import('./ExternalSubmitForm');
+
+function makeCtx(overrides: Partial<ListingEditContext> = {}): ListingEditContext {
+  return {
+    parentId: 'apl_parent',
+    slug: 'vitrine',
+    status: 'removed',
+    hasPendingRevision: false,
+    shadowId: null,
+    scalars: {
+      name: 'Vitrine',
+      tagline: 'A gallery',
+      description: 'desc',
+      category: 'utility',
+      contentRating: 'g',
+      externalUrl: 'https://vitrine.civitai.com/',
+      sourceRepoUrl: 'https://github.com/civitai/vitrine',
+    },
+    assets: {
+      icon: { imageId: 10, url: 'https://cdn/icon.png' },
+      cover: { imageId: 20, url: 'https://cdn/cover.png' },
+      screenshots: [],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * The form control carrying a `data-material-field` tag. Mantine spreads unknown props onto
+ * the underlying input, so this is normally the input itself; the fallback covers a control
+ * whose tag lands on a wrapper, so the ledger cannot pass by finding a DIV that is trivially
+ * "not enabled".
+ */
+function materialControl(field: string): HTMLInputElement | HTMLSelectElement | null {
+  const tagged = document.querySelector<HTMLElement>(`[data-material-field="${field}"]`);
+  if (!tagged) return null;
+  if (tagged instanceof HTMLInputElement || tagged instanceof HTMLSelectElement) return tagged;
+  return tagged.querySelector<HTMLInputElement>('input, select');
+}
+
+beforeEach(() => {
+  mocks.meta = { data: undefined, isFetching: false, isError: false, isSuccess: false };
+  mocks.refetch.mockClear();
+  mocks.updateListing.mockClear();
+  mocks.updateRevision.mockClear();
+  mocks.submitRevision.mockClear();
+  mocks.invalidate.mockClear();
+});
+
+describe('🔴 an OWNER-UNPUBLISHED listing: material fields are shown, and locked', () => {
+  test('🔴 the reason is on screen BEFORE the author reaches a locked field', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    const notice = page.getByTestId('apps-offsite-edit-material-locked-notice');
+    await expect.element(notice).toBeInTheDocument();
+    // It states the refusal AND the way out — an author told only "no" has nowhere to go.
+    await expect.element(notice).toHaveTextContent(/republish/i);
+    await expect.element(notice).toHaveTextContent(/moderator review/i);
+    // And what is STILL editable, so the tab is not read as entirely dead.
+    await expect.element(notice).toHaveTextContent(/tagline, description and category/i);
+  });
+
+  test('🔴 EVERY material field the server refuses has a DISABLED input — the ledger', async () => {
+    // Walks the SERVER's own constant. `externalUrl` lives on the URL step and the other
+    // three on Details, so both steps are visited and the union is asserted to cover the
+    // whole set — a new material field with no input here leaves `missing` non-empty.
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await expect.element(page.getByTestId('apps-offsite-edit-url')).toBeInTheDocument();
+
+    const found = new Map<string, boolean>();
+    const sweep = () => {
+      for (const field of MATERIAL_LISTING_PATCH_FIELDS) {
+        const el = materialControl(field);
+        if (el) found.set(field, el.disabled === true);
+      }
+    };
+    sweep();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect.element(page.getByTestId('apps-offsite-edit-name')).toBeInTheDocument();
+    sweep();
+
+    const missing = MATERIAL_LISTING_PATCH_FIELDS.filter((f) => !found.has(f));
+    expect(missing, 'material fields with no tagged input in the edit form').toEqual([]);
+    const enabled = [...found.entries()].filter(([, disabled]) => !disabled).map(([f]) => f);
+    expect(enabled, 'material fields the author can still type into').toEqual([]);
+  });
+
+  test('🔴 the locked inputs still SHOW their values — prefill is wider than the write', async () => {
+    // The author has to be able to READ what a moderator approved; that is exactly the
+    // information they need to decide whether to republish. This is the arm that fails if
+    // the fix is "hide the fields" rather than "disable them".
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await expect
+      .element(page.getByTestId('apps-offsite-edit-url'))
+      .toHaveValue('https://vitrine.civitai.com/');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect.element(page.getByTestId('apps-offsite-edit-name')).toHaveValue('Vitrine');
+    await expect
+      .element(page.getByTestId('apps-offsite-edit-source-repo'))
+      .toHaveValue('https://github.com/civitai/vitrine');
+  });
+
+  test('🔴 the TRIVIAL fields stay editable and still save in place', async () => {
+    // The control arm, and it is not optional: disabling the whole form satisfies every
+    // assertion above while deleting the feature this state exists for — "unpublish, fix
+    // your copy, republish". Tagline/description/category are not material, so the server
+    // edits them IN PLACE on this status.
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('textbox', { name: /^Tagline/ }).fill('A better gallery');
+    await page.getByTestId('apps-offsite-edit-save').click();
+
+    await vi.waitFor(() => expect(mocks.updateListing).toHaveBeenCalledTimes(1));
+    expect(mocks.updateListing).toHaveBeenCalledWith(
+      expect.objectContaining({ listingId: 'apl_parent', patch: { tagline: 'A better gallery' } })
+    );
+    // No revision: a removed listing has no live copy to protect, so there is no shadow.
+    expect(mocks.submitRevision).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE STATUS ARM, one CASE per status rather than one loop, so the scaffold's
+  // auto-cleanup runs between renders (a manual `unmount()` fights it and blanks the next
+  // container). Without these, the lock could be unconditional and every case above would
+  // still pass while `draft` / `pending` / `approved` silently lost their edits.
+  test.each(['draft', 'pending', 'approved'] as const)(
+    '🔴 a %s listing leaves EVERY material field enabled and shows no lock notice',
+    async (status) => {
+      renderWithProviders(
+        <ExternalSubmitForm
+          edit={makeCtx({ status, shadowId: status === 'approved' ? 'shadow-1' : null })}
+        />
+      );
+      await expect.element(page.getByTestId('apps-offsite-edit-url')).toBeInTheDocument();
+      expect(materialControl('externalUrl')?.disabled, status).toBe(false);
+      expect(
+        page.getByTestId('apps-offsite-edit-material-locked-notice').elements(),
+        status
+      ).toHaveLength(0);
+      await page.getByRole('button', { name: 'Next' }).click();
+      await expect.element(page.getByTestId('apps-offsite-edit-name')).toBeInTheDocument();
+      for (const field of ['name', 'contentRating', 'sourceRepoUrl'] as const) {
+        expect(materialControl(field)?.disabled, `${status}/${field}`).toBe(false);
+      }
+    }
+  );
+
+  test('🔴 an ON-SITE unpublished listing is not told its "App URL" is locked', async () => {
+    // It has no URL step and no external URL, so naming the field would describe something
+    // that is not on screen. The three fields it DOES have are still named.
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ kind: 'onsite' })} />);
+    const notice = page.getByTestId('apps-offsite-edit-material-locked-notice');
+    await expect.element(notice).toBeInTheDocument();
+    await expect.element(notice).not.toHaveTextContent(/App URL/);
+    await expect.element(notice).toHaveTextContent(/source repository/i);
+    // On-site opens straight on Details (no URL step), and the three fields are locked.
+    await expect.element(page.getByTestId('apps-offsite-edit-name')).toBeInTheDocument();
+    for (const field of ['name', 'contentRating', 'sourceRepoUrl'] as const) {
+      expect(materialControl(field)?.disabled, field).toBe(true);
+    }
+    expect(materialControl('externalUrl'), 'no URL step for an on-site listing').toBeNull();
+  });
+});
+
+describe('🔴 the OAuth scope disclosure follows the DRIFT, not the status', () => {
+  const connect = {
+    connectClientId: 'oauth-1',
+    connectAllowedScopes: 12,
+    connectRequestedScopes: 12,
+    connectScopeJustifications: { ModelsWrite: 'original reason' },
+  };
+
+  test('🔴 while the masks AGREE, a justification edit stays live on an unpublished listing', async () => {
+    // `buildScalarPatch` sends the (unchanged) mask alongside the edited justifications, and
+    // `materialPatchChanges` counts the key as material only when the masks DIFFER — so this
+    // save is trivial and the server takes it. Locking the box here would remove a
+    // legitimate edit.
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ ...connect })} />);
+    await page.getByRole('button', { name: 'Next' }).click();
+    const justification = page.getByTestId('apps-offsite-justification-8');
+    await expect.element(justification).toBeInTheDocument();
+    await expect.element(justification).not.toBeDisabled();
+  });
+
+  test('🔴 once the mask has DRIFTED, the justifications lock and the notice says so', async () => {
+    // A drifted mask rides along on EVERY patch, so even a tagline-only save is refused —
+    // the same fillable-but-unsaveable defect one field further out. Same fixture, one
+    // number different.
+    renderWithProviders(
+      <ExternalSubmitForm edit={makeCtx({ ...connect, connectAllowedScopes: 28 })} />
+    );
+    await expect
+      .element(page.getByTestId('apps-offsite-edit-material-locked-notice'))
+      .toHaveTextContent(/scopes have also changed/i);
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect.element(page.getByTestId('apps-offsite-justification-8')).toBeDisabled();
+  });
+});

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -50,6 +50,14 @@ import { trpc } from '~/utils/trpc';
  *     measurement taken under different preconditions is the exact error that produced
  *     the first, wrong version of this gate. If you need the number, go count it.
  *
+ * 🔴 AND A THIRD FRAMING STATE, added when the editor tabs opened on an OWNER-UNPUBLISHED
+ * listing (civitai/civitai#4413 made the server accept it; nothing in the UI could reach
+ * it). Every notice above is gated on `isApproved`, so this editor mounted with NO frame at
+ * all for a listing that is currently DOWN — and whose write semantics are a third case
+ * again: no shadow, no re-approval, the write lands on the listing and becomes visible on
+ * republish. See `isOwnerUnpublished`, which reads the SERVER's `editBlockedReason` rather
+ * than taking a second view of `status === 'removed'`.
+ *
  * NOTE: the "Back to app" affordance lives on the OWNING page (so the tabbed /edit
  * page has a single back control), not here.
  */
@@ -89,6 +97,18 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
   const shadowId = listing?.shadowId ?? null;
   const editBlockedReason = listing?.editBlockedReason ?? null;
   const isApproved = listing?.status === 'approved';
+  /**
+   * 🔴 THE OWNER-REPAIR STATE — `removed` AND the server said it is editable.
+   *
+   * `status === 'removed'` alone is ambiguous (an owner self-unpublish and a moderator
+   * takedown both write it), which is exactly why the second conjunct is the SERVER's own
+   * verdict rather than a second client opinion: `listingMediaEditBlockedReason` returns
+   * `null` for an owner-unpublished listing and the "removed by a moderator" message
+   * otherwise. So this frame appears on precisely the rows the server will accept an asset
+   * write for, and a mod takedown falls through to the red alert below with no framing at
+   * all — never both.
+   */
+  const isOwnerUnpublished = listing?.status === 'removed' && !editBlockedReason;
 
   // 🔴 THE ONE DISCRIMINATOR for "this edit goes live immediately" — see the header.
   // `!shadowId` is what makes it correct: it is exactly `editTargetId === appListingId`
@@ -221,6 +241,34 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
             </Text>
           </Alert>
         ))}
+
+      {/* 🔴 THE REPAIR-STATE FRAME. Without it this editor mounted for an owner-unpublished
+          listing with NO notice at all: the notice above is gated on `isApproved`, which is
+          false here, so the author saw a plain image editor for an app that is currently
+          DOWN — and, worse, one whose writes behave differently from the live case they
+          have seen before. Both facts are stated: the app is not visible, and (unlike an
+          approved listing) these edits are NOT staged — they apply to the listing directly
+          and become visible on republish. That is accurate: `getMyListingForApp` resolves
+          no shadow for a non-approved listing, so `editTargetId` is the listing itself, and
+          `assertOwnerAssetEditable` refuses only an APPROVED top-level listing. It is also
+          why no "Submit for review" control renders below — there is no revision to submit. */}
+      {isOwnerUnpublished && !listingError && (
+        <Alert
+          icon={<IconAlertTriangle size={16} />}
+          color="yellow"
+          variant="light"
+          title="This app is unpublished"
+          data-testid="apps-listing-media-unpublished-notice"
+        >
+          <Text size="sm">
+            This app is <b>not visible in the store</b> — you unpublished it. Image changes
+            here are <b>not</b> staged as a revision and need no re-approval: they save to the
+            listing straight away and appear when you <b>republish</b> it from the Publishing
+            tab. Media can be added while it is still scanning; it only appears once its scan
+            finishes cleanly.
+          </Text>
+        </Alert>
+      )}
 
       {listing?.hasPendingRevision && (
         <Alert

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -299,13 +299,9 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
               same for both roles; only the attribution and the way out differ. */}
           <Text size="sm">
             This app is <b>not visible in the store</b> —{' '}
-            {isOwner ? (
-              <>you unpublished it</>
-            ) : (
-              <>its owner unpublished it</>
-            )}
-            . Image changes here are <b>not</b> staged as a revision and need no
-            re-approval: they save to the listing straight away and appear when{' '}
+            {isOwner ? <>you unpublished it</> : <>its owner unpublished it</>}. Image changes here
+            are <b>not</b> staged as a revision and need no re-approval: they save to the listing
+            straight away and appear when{' '}
             {isOwner ? (
               <>
                 you <b>republish</b> it from the Publishing tab
@@ -315,8 +311,8 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
                 the owner <b>republishes</b> it
               </>
             )}
-            . Media can be added while it is still scanning; it only appears once its scan
-            finishes cleanly.
+            . Media can be added while it is still scanning; it only appears once its scan finishes
+            cleanly.
           </Text>
         </Alert>
       )}

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -15,11 +15,19 @@ import { trpc } from '~/utils/trpc';
  * `/apps/[appBlockId]/listing` page so it can be embedded as the "Listing media" tab
  * of the unified `/apps/[appBlockId]/edit` page (and reused anywhere else).
  *
- * Owner gating is single-sourced at the tRPC layer: `getMyListingForApp` throws
- * NOT_OWNED→FORBIDDEN (non-owner) / NOT_FOUND (no listing) → this renders NotFound.
- * 🔴 That owner check has NO moderator branch, so this editor is only ever reachable
- * for the caller's OWN listing — including for a moderator (the production incident
+ * Access gating is single-sourced at the tRPC layer: `getMyListingForApp` throws
+ * NOT_OWNED→FORBIDDEN / NOT_FOUND (no listing) → this renders NotFound.
+ * 🔴 That check has NO moderator branch, so this editor is only ever reachable for a
+ * listing the caller holds a ROLE on — including for a moderator (the production incident
  * behind the notice below was an owner-AND-moderator editing their own live apps).
+ *
+ * 🔴 "ROLE", NOT "OWNERSHIP", AND THIS SENTENCE USED TO SAY OWNER. The gate is
+ * `resolveListingRole(listing.id, userId) === null`, which is non-null for the owner **or**
+ * an ACCEPTED COLLABORATOR seat — so a seated editor reaches this component. Reading the
+ * old wording as an ownership guarantee is what produced copy telling an editor "you
+ * unpublished it" and pointing them at a Publishing tab `editorTabsFor` withholds from
+ * them. The proc now returns the resolved `role`; branch on it (see `isOwner`) rather than
+ * assuming.
  *
  * 🔴 THREE WRITE SEMANTICS on an APPROVED listing, and the copy MUST match. The
  * discriminator is `isModerator && !shadowId` — NOT `isModerator` alone:
@@ -109,6 +117,27 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
    * all — never both.
    */
   const isOwnerUnpublished = listing?.status === 'removed' && !editBlockedReason;
+  /**
+   * 🔴 IS THE CALLER THE OWNER? FROM THE SERVER, NOT FROM THE SESSION.
+   *
+   * The header above says owner gating is single-sourced at the tRPC layer, and that is
+   * still true of the GATE — but it is a ROLE gate, not an ownership one:
+   * `getMyListingForApp` refuses on `resolveListingRole(...) === null`, which admits an
+   * ACCEPTED COLLABORATOR. So this component is reachable by a seated editor, and the
+   * unpublished frame below used to address all of them as the person who unpublished the
+   * app and point them at an owner-only Publishing tab.
+   *
+   * 🔴 DELIBERATELY NOT `currentUser` — there is no session field that answers "are you the
+   * owner OF THIS LISTING", and `isModerator` is a different question entirely (see
+   * `modDirectLiveEdit`). The role is resolved by the proc's own access check and returned
+   * on the read, so every host of this editor is correct by default — the same reason
+   * `isModerator` is read from the hook rather than threaded as a prop.
+   *
+   * Absent (an older cached payload) reads as NOT-owner, which is the safe direction for
+   * COPY: the non-owner wording is true for an owner too, while the owner wording asserts
+   * things an editor would find false.
+   */
+  const isOwner = listing?.role === 'owner';
 
   // 🔴 THE ONE DISCRIMINATOR for "this edit goes live immediately" — see the header.
   // `!shadowId` is what makes it correct: it is exactly `editTargetId === appListingId`
@@ -260,11 +289,33 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
           title="This app is unpublished"
           data-testid="apps-listing-media-unpublished-notice"
         >
+          {/* 🔴 ROLE-AWARE, AND BOTH HALVES OF THE OWNER SENTENCE WERE FALSE FOR AN EDITOR.
+              This editor is NOT owner-only — `getMyListingForApp` gates on
+              `resolveListingRole(...) === null`, which admits an accepted collaborator, and
+              `editorTabsFor` hands an editor `['details','media','history']` in exactly this
+              repair state. So a seated editor read "you unpublished it" (they did not) and
+              "republish it from the Publishing tab" (`publishing` is owner-only in
+              `editorTabsFor` — a tab they cannot see). The write semantics below are the
+              same for both roles; only the attribution and the way out differ. */}
           <Text size="sm">
-            This app is <b>not visible in the store</b> — you unpublished it. Image changes
-            here are <b>not</b> staged as a revision and need no re-approval: they save to the
-            listing straight away and appear when you <b>republish</b> it from the Publishing
-            tab. Media can be added while it is still scanning; it only appears once its scan
+            This app is <b>not visible in the store</b> —{' '}
+            {isOwner ? (
+              <>you unpublished it</>
+            ) : (
+              <>its owner unpublished it</>
+            )}
+            . Image changes here are <b>not</b> staged as a revision and need no
+            re-approval: they save to the listing straight away and appear when{' '}
+            {isOwner ? (
+              <>
+                you <b>republish</b> it from the Publishing tab
+              </>
+            ) : (
+              <>
+                the owner <b>republishes</b> it
+              </>
+            )}
+            . Media can be added while it is still scanning; it only appears once its scan
             finishes cleanly.
           </Text>
         </Alert>

--- a/src/components/Apps/MyAppsBody.browser.test.tsx
+++ b/src/components/Apps/MyAppsBody.browser.test.tsx
@@ -127,6 +127,11 @@ function row(over: Partial<MyAppRow> & { appListingId: string }): MyAppRow {
     iconUrl: null,
     coverUrl: null,
     updatedAt: '2026-08-01T00:00:00Z',
+    // 🔴 SPELLED, not defaulted-by-omission. `null` is the fail-closed value ("not proven
+    // to be the owner's own"), and the field is REQUIRED on `MyAppRow` because its former
+    // optionality — justified in exactly these words, "so a fixture need not spell it" —
+    // is what let `myAppListingHref` silently drop it into `editorTabsFor`.
+    lastModerationAction: null,
     ...over,
     // `capabilities` must follow the FINAL kind, not the default one.
     ...(over.capabilities ? {} : { capabilities: capabilitiesForKind(over.kind ?? kind) }),

--- a/src/components/Apps/__tests__/appListingEditorTabs.callers.test.ts
+++ b/src/components/Apps/__tests__/appListingEditorTabs.callers.test.ts
@@ -1,0 +1,285 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * CALLER LEDGER — every production call site of `editorTabsFor` passes `lastModerationAction`.
+ *
+ * ## Why this file exists, and what it is NOT
+ *
+ * 🔴 THE PRIMARY ENFORCEMENT IS THE TYPE, NOT THIS TEST. `EditorTabContext.lastModerationAction`
+ * is REQUIRED (`string | null`), so omitting it at a call site is a compile error, and
+ * `tekton / typecheck` runs on every PR. If you are here because you added a caller and this
+ * went red, the compiler almost certainly told you first.
+ *
+ * 🔴 SO WHAT DOES THIS ADD? Exactly the cases the compiler structurally cannot see:
+ *
+ *   - `tsconfig.json` excludes `src/**` + `/__tests__/**` from the program, so a call site in a
+ *     `__tests__/` directory is NEVER typechecked. Measured on this tree with
+ *     `tsc -p tsconfig.json --listFilesOnly`: `appListingEditorTabs.test.ts` appears 0 times.
+ *   - a caller that launders the argument past the checker — `as any`, `as EditorTabContext`,
+ *     a spread of a wider object, or a `.js`/untyped module.
+ *   - a caller added in a NEW FILE nobody thought to look at, which is the case the ledger
+ *     below is really for: it fails when the caller set GROWS as well as when a caller drops
+ *     the field.
+ *
+ * ## The defect this is the guard for
+ *
+ * `lastModerationAction` was OPTIONAL for one release. In that window there were two
+ * production callers and only one passed it: `myAppListingHref` (`myAppsView.ts`) dropped it,
+ * even though the row it receives carries the field (`MyAppsBody` renders a badge off
+ * `row.lastModerationAction` at the same call site). Result: two different tab sets derived for
+ * ONE listing — the authoring page offered the owner `details`/`media` on their own
+ * unpublished app, while the `/apps/mine` row linked at `?tab=publishing`. Nothing went red,
+ * because optionality is precisely what makes a dropped field type-check.
+ *
+ * That is also mutant M8 of this PR's battery ("delete the `lastModerationAction:` line")
+ * living unguarded at a second call site — the browser suite built to kill M8 covered one
+ * caller of two.
+ *
+ * ## Reading discipline
+ *
+ * 🔴 COMMENTS ARE STRIPPED BEFORE ANY PROXIMITY TEST. Without that, this file's own prose —
+ * which names both `editorTabsFor` and `lastModerationAction` many times — would satisfy the
+ * guard, and so would the long doc comment above every real call site. A guard that its own
+ * documentation can satisfy is worse than none: it reads as coverage while providing none.
+ *
+ * 🔴 THE POSITIVE CONTROL IS NOT OPTIONAL. A scan that resolves the wrong root, or whose
+ * extension filter is wrong, finds zero call sites and passes every "all callers pass the
+ * field" assertion vacuously. `it('positive control …')` asserts the sweep visited a
+ * non-trivial number of files AND found a non-zero number of call sites, so a reassuring green
+ * here cannot be a probe wired to nothing.
+ */
+
+/** Repo root, resolved from THIS file rather than from `process.cwd()`. */
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const SRC_ROOT = join(REPO_ROOT, 'src');
+
+/**
+ * 🔴 THE LEDGER. Every PRODUCTION file that calls `editorTabsFor`, repo-root-relative.
+ *
+ * Asserted as a SET, so it fails in BOTH directions:
+ *   - a caller REMOVED  → the set shrank, and the ledger's claim to be complete is stale;
+ *   - a caller ADDED    → the set grew, and nobody has checked the new one passes the field
+ *     for the right reason (it must read the LISTING's own last moderation action, not a
+ *     hardcoded `null` bolted on to silence the compiler).
+ *
+ * Growing this list is a deliberate act. When you add an entry, say in the PR why the new
+ * caller's value is the listing's real one.
+ */
+const EXPECTED_CALLER_FILES = [
+  'src/components/Apps/myAppsView.ts',
+  'src/pages/apps/listing/[appListingId]/edit.tsx',
+] as const;
+
+/**
+ * Strip `//` line comments and block comments, leaving string/template literals intact.
+ *
+ * A small state machine rather than a regex, because a regex cannot tell a `//` inside a
+ * string (`'https://…'`, and this repo has many) from a real comment — and stripping the
+ * remainder of such a line would silently delete real code, which fails OPEN (the argument
+ * object would look empty and the guard would report a missing field that is present).
+ */
+function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+    // Line comment
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i++;
+      continue;
+    }
+    // Block comment
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    // String / template literal — copied through verbatim, escapes honoured.
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      out += c;
+      i++;
+      while (i < n) {
+        if (source[i] === '\\') {
+          out += source[i] + (source[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/** Every `.ts`/`.tsx` file under `src/`, excluding test files and `__tests__/` dirs. */
+function productionSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      productionSourceFiles(full, acc);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry)) continue;
+    // `.test.ts`, `.test.tsx`, `.browser.test.tsx`, `.spec.ts` — not production.
+    if (/\.(test|spec)\.tsx?$/.test(entry)) continue;
+    acc.push(full);
+  }
+  return acc;
+}
+
+/**
+ * Extract the source text of each `editorTabsFor(...)` argument list in `code`, by
+ * BRACKET-MATCHING from the opening paren rather than by regex — the argument is a
+ * multi-line object literal containing nested braces, which no regex handles.
+ */
+function editorTabsForCallArgs(code: string): string[] {
+  const calls: string[] = [];
+  const needle = 'editorTabsFor(';
+  let from = 0;
+  for (;;) {
+    const at = code.indexOf(needle, from);
+    if (at === -1) break;
+    // Skip an identifier match that is part of a longer name (e.g. `myEditorTabsForX`).
+    const before = at > 0 ? code[at - 1] : ' ';
+    if (/[A-Za-z0-9_$]/.test(before)) {
+      from = at + needle.length;
+      continue;
+    }
+    // 🔴 SKIP THE DECLARATION SITE. `export function editorTabsFor(ctx: EditorTabContext)`
+    // matches the same needle as a call, so without this the defining module reports itself
+    // as a caller whose "argument list" is a PARAMETER list — which of course does not
+    // contain `lastModerationAction`. That is a false POSITIVE (a spurious red), and it was
+    // caught on this guard's first run, which is the outcome a negative control is for.
+    // Keyed on the preceding `function` keyword rather than on the file path, so the
+    // definition can move without silently un-skipping.
+    if (/\bfunction\s*$/.test(code.slice(Math.max(0, at - 24), at))) {
+      from = at + needle.length;
+      continue;
+    }
+    let depth = 0;
+    let i = at + needle.length - 1; // at the '('
+    const start = i + 1;
+    for (; i < code.length; i++) {
+      if (code[i] === '(') depth++;
+      else if (code[i] === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    calls.push(code.slice(start, i));
+    from = i;
+  }
+  return calls;
+}
+
+const scanned = productionSourceFiles(SRC_ROOT).map((path) => {
+  const stripped = stripComments(readFileSync(path, 'utf8'));
+  return {
+    path,
+    rel: relative(REPO_ROOT, path).split('\\').join('/'),
+    calls: editorTabsForCallArgs(stripped),
+  };
+});
+const callerFiles = scanned.filter((f) => f.calls.length > 0);
+
+describe('editorTabsFor — the CALLER LEDGER', () => {
+  /**
+   * 🔴 POSITIVE CONTROL. Everything below is of the form "for each caller found, assert X".
+   * With zero callers found — a wrong root, a wrong extension filter, a comment stripper that
+   * ate the file — all of them pass vacuously and this suite reports a confident, meaningless
+   * green. These two numbers are what make the green mean something.
+   */
+  it('positive control — the sweep actually read the tree and found call sites', () => {
+    // A floor, not the exact count: `src/` has thousands of files and this must not become a
+    // tripwire that reddens whenever someone adds an unrelated component.
+    expect(scanned.length).toBeGreaterThan(500);
+    expect(callerFiles.length).toBeGreaterThan(0);
+    expect(callerFiles.reduce((n, f) => n + f.calls.length, 0)).toBeGreaterThan(0);
+  });
+
+  /**
+   * 🔴 NEGATIVE CONTROL FOR THE COMMENT STRIPPER, and it is the load-bearing one.
+   *
+   * The proximity test below asks "does the argument text contain `lastModerationAction`". If
+   * comments survived stripping, a call site whose DOC COMMENT names the field would pass
+   * while the code omitted it — which is exactly the shape of the defect being guarded (every
+   * real call site here carries a long comment that names the field repeatedly). This asserts
+   * the stripper removes both comment forms and, critically, does NOT damage a string that
+   * merely looks like one.
+   */
+  it('the comment stripper removes comments and preserves strings', () => {
+    expect(stripComments('a // lastModerationAction\nb')).not.toMatch(/lastModerationAction/);
+    expect(stripComments('a /* lastModerationAction */ b')).not.toMatch(/lastModerationAction/);
+    // A `//` inside a string is NOT a comment — eating it would delete real code and make
+    // this guard fail open.
+    expect(stripComments(`const u = 'https://x/y'; const k = lastModerationAction;`)).toMatch(
+      /lastModerationAction/
+    );
+    expect(stripComments(`const u = 'https://x/y';`)).toMatch(/https:\/\/x\/y/);
+  });
+
+  /**
+   * 🔴 THE SET, PINNED IN BOTH DIRECTIONS. `toEqual` on a sorted array fails when the caller
+   * set SHRINKS (a caller was deleted and this ledger's completeness claim went stale) and
+   * when it GROWS (a new caller nobody has vetted). The seam this file guards is a
+   * RELATIONSHIP — "every caller agrees on the inputs" — and a relationship can only be
+   * pinned by enumerating the whole population, never by checking one member.
+   */
+  it('🔴 the set of production callers is EXACTLY the ledger — fails if it grows OR shrinks', () => {
+    expect(callerFiles.map((f) => f.rel).sort()).toEqual([...EXPECTED_CALLER_FILES].sort());
+  });
+
+  /**
+   * 🔴 THE ACTUAL SEAM ASSERTION. Every call site passes the field, checked against
+   * COMMENT-STRIPPED source so neither the surrounding doc comment nor this file's own prose
+   * can satisfy it.
+   */
+  it('🔴 EVERY production call site passes `lastModerationAction`', () => {
+    const offenders: string[] = [];
+    for (const file of callerFiles) {
+      file.calls.forEach((args, idx) => {
+        if (!/\blastModerationAction\b/.test(args)) {
+          offenders.push(`${file.rel} (call #${idx + 1})`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * The field must be WIRED, not silenced. `lastModerationAction: null` written as a literal
+   * at a call site that HAS the real value available is how a required field gets defeated
+   * while still type-checking — the compiler is satisfied and the behaviour is the old bug.
+   *
+   * 🟡 LABEL: this is an INVARIANT GUARD, not regression coverage. Neither of today's callers
+   * ever passed a literal `null`, so this pins a property the bug never violated. It is here
+   * because it is the cheapest next failure mode once the field is required, and because the
+   * fix direction for a compile error is genuinely tempting to get wrong.
+   */
+  it('🟡 invariant — no call site silences the requirement with a literal `null`', () => {
+    const silenced: string[] = [];
+    for (const file of callerFiles) {
+      file.calls.forEach((args, idx) => {
+        if (/\blastModerationAction\s*:\s*null\b/.test(args)) {
+          silenced.push(`${file.rel} (call #${idx + 1})`);
+        }
+      });
+    }
+    expect(silenced).toEqual([]);
+  });
+});

--- a/src/components/Apps/__tests__/appListingEditorTabs.test.ts
+++ b/src/components/Apps/__tests__/appListingEditorTabs.test.ts
@@ -5,10 +5,16 @@ import {
   DEFAULT_EDITOR_TAB,
   EDITOR_TAB_LABELS,
   editorTabsFor,
+  isOwnerUnpublishedTabContext,
   listingEditHref,
   resolveEditorTab,
 } from '~/components/Apps/appListingEditorTabs';
-import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+import { OWNER_UNPUBLISH_ACTION } from '~/components/Apps/offsiteOwnerControls';
+import {
+  AUTHORABLE_LISTING_STATUSES,
+  capabilitiesForKind,
+  isAuthorableListingStatus,
+} from '~/shared/constants/app-capabilities.constants';
 
 /**
  * The canonical authoring page's TAB SET, pinned in BOTH directions.
@@ -391,5 +397,257 @@ describe('the tab vocabulary is complete', () => {
       expect(EDITOR_TAB_LABELS[tab]).toBeTruthy();
     }
     expect(ALL_EDITOR_TABS).toContain(DEFAULT_EDITOR_TAB);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * THE OWNER-REPAIR BRANCH — `removed`, but the OWNER took it down
+ * ------------------------------------------------------------------ */
+
+/**
+ * 🔴 `removed` IS TWO STATES WEARING ONE STATUS STRING, AND THIS IS THE HALF THE SERVER
+ * ALREADY ACCEPTS.
+ *
+ * civitai/civitai#4413 taught `getMyListingForEdit`, `updateListing` and
+ * `getMyListingForApp` to distinguish an owner self-unpublish from a moderator takedown via
+ * the listing's most-recent STATUS-CHANGING moderation event, and to permit repair edits on
+ * the former. Nothing in the UI could reach that: this function gated `details` and `media`
+ * on `isAuthorableListingStatus`, which excludes `removed`. So the cases below are the
+ * REACHABILITY half of that change.
+ *
+ * 🔴 EVERY CASE IS PINNED IN BOTH DIRECTIONS, and the pairs are chosen so each clause of
+ * `isOwnerUnpublishedTabContext` is the SOLE cause of an answer somewhere:
+ *   - owner-unpublish vs `other`  kills the ACTION clause;
+ *   - `removed` vs `rejected`/`approved` carrying the SAME action kills the STATUS clause;
+ *   - `null` (no events) is the fail-closed arm, and it is a real branch, not a degenerate
+ *     one — a listing whose events were pruned must read as a moderator removal.
+ */
+describe('🔴 an OWNER-UNPUBLISHED listing regains Details + Media — and nothing else', () => {
+  const ownerUnpublished = {
+    kind: 'onsite',
+    appBlockId: 'ab_ou',
+    role: 'owner',
+    status: 'removed',
+    lastModerationAction: 'owner-unpublish',
+    capabilities: onsite,
+  } as const;
+
+  it('🔴 DETAILS is offered — `getMyListingForEdit` accepts this listing', () => {
+    // The proc's `removed` branch reads the last status-changing action on the PRIMARY and
+    // returns the prefill when it is `owner-unpublish`. Withholding the tab left that
+    // capability with no caller at all.
+    expect(editorTabsFor(ownerUnpublished)).toContain('details');
+  });
+
+  it('🔴 MEDIA is offered — `listingMediaEditBlockedReason` returns null for this listing', () => {
+    // Both other clauses of the media rule are satisfied in this fixture (`listingMedia` is
+    // true for on-site, `appBlockId` is non-null), so the repair branch is the sole cause of
+    // this presence and a mutant that drops it reddens exactly here.
+    expect(editorTabsFor(ownerUnpublished)).toContain('media');
+  });
+
+  it('🔴 NEVER Collaborators — the seat gate still refuses this status server-side', () => {
+    // `assertSeatGrantable` uses `isAuthorableListingStatus`, which does NOT include
+    // `removed`, so `inviteCollaborator` / `respondToInvite` refuse here. Offering the tab
+    // would offer a guaranteed refusal on the surface that mints Forgejo `write`. THIS is
+    // the case that fails if someone "simplifies" the fix by widening
+    // `AUTHORABLE_LISTING_STATUSES` instead of branching on the last action.
+    expect(editorTabsFor(ownerUnpublished)).not.toContain('collaborators');
+  });
+
+  it('🔴 NEVER Manifest or Earnings — nothing in this change opens either', () => {
+    // Same construction as the media case: `submitVersion` and `earnings` are both true for
+    // on-site and the block id is present, so their absence is the branch split alone.
+    expect(editorTabsFor(ownerUnpublished)).not.toContain('manifest');
+    expect(editorTabsFor(ownerUnpublished)).not.toContain('earnings');
+  });
+
+  it('🔴 the OWNER set is EXACTLY Details, Media, Publishing, History — in that order', () => {
+    // The aggregate AFTER the named cases, so a tab that creeps in later is caught even if
+    // no case above happens to name it. Order matters: the panel renders in this sequence.
+    expect(editorTabsFor(ownerUnpublished)).toEqual(['details', 'media', 'publishing', 'history']);
+  });
+
+  it('🔴 a MODERATOR takedown gets NONE of it — the ACTION clause, isolated', () => {
+    // Identical fixture, one field different. `other` is what
+    // `normalizeLastModerationAction` sends for every moderator verb, so this is the shape
+    // a real `delist` / `purge` produces on the wire.
+    expect(editorTabsFor({ ...ownerUnpublished, lastModerationAction: 'other' })).toEqual([
+      'publishing',
+      'history',
+    ]);
+  });
+
+  it('🔴 a RAW moderator verb is not the owner action either — `delist` / `purge` by name', () => {
+    // The wire value is normalised, but this function takes a plain string and is exported.
+    // A caller that has not normalised must not accidentally satisfy an `!= null` style
+    // check. Two pairwise-distinct real verbs, neither of which is a prefix or suffix of
+    // `owner-unpublish`.
+    for (const verb of ['delist', 'purge'] as const) {
+      expect(editorTabsFor({ ...ownerUnpublished, lastModerationAction: verb }), verb).toEqual([
+        'publishing',
+        'history',
+      ]);
+    }
+  });
+
+  it('🔴 NO moderation events at all fails CLOSED — `null` is a real branch', () => {
+    // A listing removed before the taxonomy carried these actions, or one whose events were
+    // pruned. Nothing proves the owner did it, so it is treated as a moderator removal.
+    // Asserted for BOTH absent spellings: the field omitted entirely (the shape a caller
+    // that has not been updated produces) and an explicit null (the shape the server sends).
+    expect(editorTabsFor({ ...ownerUnpublished, lastModerationAction: null })).toEqual([
+      'publishing',
+      'history',
+    ]);
+    const { lastModerationAction: _omitted, ...withoutTheField } = ownerUnpublished;
+    expect(editorTabsFor(withoutTheField)).toEqual(['publishing', 'history']);
+  });
+
+  it('🔴 the ACTION alone is not enough — a REJECTED listing carrying it stays narrowed', () => {
+    // The STATUS clause, isolated. `rejected` is non-authorable and is not the repair state,
+    // and `isPublishableListingStatus` withholds Publishing too, so the answer is History
+    // alone — a DIFFERENT answer from the removed cases above, which is what stops a mutant
+    // treating every non-authorable status alike.
+    expect(editorTabsFor({ ...ownerUnpublished, status: 'rejected' })).toEqual(['history']);
+  });
+
+  it('🔴 a STALE owner-unpublish on a RELISTED listing changes nothing — still the full set', () => {
+    // 🔴 INVARIANT GUARD, NOT REGRESSION COVERAGE: `approved` is authorable, so it took the
+    // wide branch before this change and takes it now. It is here because the repair branch
+    // is an OR — an implementation that reached the wide branch through the repair clause on
+    // an approved listing would also be wrong, just invisibly. (`getAppListingAuthoringContext`
+    // additionally refuses to READ the event on a non-`removed` listing, so this shape does
+    // not occur on the wire; the predicate must be right anyway.)
+    expect(editorTabsFor({ ...ownerUnpublished, status: 'approved' })).toEqual([
+      'details',
+      'media',
+      'manifest',
+      'earnings',
+      'collaborators',
+      'publishing',
+      'history',
+    ]);
+  });
+
+  it('🔴 an OFF-SITE owner-unpublished listing gets Details but NOT Media', () => {
+    // The media rule's other two clauses still apply in the repair branch — they were not
+    // bypassed. An off-site listing has no block to hand `<ListingMediaEditor>`, and
+    // `listingMedia` is false for the kind.
+    const tabs = editorTabsFor({
+      ...ownerUnpublished,
+      kind: 'offsite',
+      appBlockId: null,
+      capabilities: offsite,
+    });
+    expect(tabs).toEqual(['details', 'publishing', 'history']);
+    expect(tabs).not.toContain('media');
+  });
+
+  it('🔴 a seated EDITOR on an owner-unpublished listing repairs the copy but cannot republish', () => {
+    // `loadOwnedEditableListing` admits the owner OR an accepted collaborator, so the repair
+    // EDIT paths are seat-aware; `unpublishOwnListing` / `republishOwnListing` are
+    // owner-only. So the content tabs appear and Publishing does not — a third distinct
+    // answer, isolating the ROLE clause inside the repair branch.
+    expect(editorTabsFor({ ...ownerUnpublished, role: 'editor' })).toEqual([
+      'details',
+      'media',
+      'history',
+    ]);
+  });
+
+  it('🔴 `?tab=collaborators` on an owner-unpublished listing lands on Details, never Collaborators', () => {
+    // The deep-link arm. A DIFFERENT answer from the moderator-takedown case (which resolves
+    // to `publishing`, pinned above), so a mutant that hardcodes either literal fails in
+    // exactly one of the two.
+    const allowed = editorTabsFor(ownerUnpublished);
+    expect(resolveEditorTab('collaborators', allowed)).toBe('details');
+    expect(resolveEditorTab('collaborators', allowed)).not.toBe('collaborators');
+    expect(resolveEditorTab('manifest', allowed)).toBe('details');
+  });
+});
+
+describe('isOwnerUnpublishedTabContext — the predicate, both clauses', () => {
+  it('is true ONLY for `removed` + the owner action', () => {
+    expect(
+      isOwnerUnpublishedTabContext({ status: 'removed', lastModerationAction: 'owner-unpublish' })
+    ).toBe(true);
+  });
+
+  it('🔴 names the action with the shared client constant, so it cannot be re-spelled', () => {
+    // `OWNER_UNPUBLISH_ACTION` is the literal `app-listing-owner-unpublish.test.ts` pins
+    // against the SERVER's `OWNER_UNPUBLISH_EVENT`. Reading it here is what keeps the tab
+    // gate and the server predicate on one spelling.
+    expect(
+      isOwnerUnpublishedTabContext({
+        status: 'removed',
+        lastModerationAction: OWNER_UNPUBLISH_ACTION,
+      })
+    ).toBe(true);
+    expect(OWNER_UNPUBLISH_ACTION).toBe('owner-unpublish');
+  });
+
+  it('🔴 is false for every other (status, action) combination that matters', () => {
+    // Pairwise-distinct statuses and actions, so no case can pass by accident of two
+    // fixture values colliding.
+    const cases: Array<[string, string | null | undefined]> = [
+      ['removed', 'other'],
+      ['removed', 'delist'],
+      ['removed', 'relist'],
+      ['removed', null],
+      ['removed', undefined],
+      ['removed', ''],
+      ['rejected', 'owner-unpublish'],
+      ['draft', 'owner-unpublish'],
+      ['pending', 'owner-unpublish'],
+      ['approved', 'owner-unpublish'],
+      ['quarantined', 'owner-unpublish'],
+    ];
+    for (const [status, lastModerationAction] of cases) {
+      expect(
+        isOwnerUnpublishedTabContext({ status, lastModerationAction }),
+        `${status}/${String(lastModerationAction)}`
+      ).toBe(false);
+    }
+  });
+});
+
+/**
+ * 🔴 THE ROAD NOT TAKEN, PINNED: `AUTHORABLE_LISTING_STATUSES` MUST NOT GROW.
+ *
+ * The one-line "fix" for the repair state is to add `removed` to that set — and it works,
+ * for the tabs. It also silently changes a SERVER gate: `assertSeatGrantable` in
+ * `app-collaborator.service` is its other consumer, so `inviteCollaborator` and
+ * `respondToInvite` would start ADMITTING moderator-delisted listings, where accepting a
+ * seat still mints Forgejo `write` on the app's repo. That is the exact hazard the narrowed
+ * tab set was introduced to close, re-opened from the other end and server-side, where a
+ * UI narrowing cannot help.
+ *
+ * 🔴 THIS IS AN INVARIANT GUARD, NOT REGRESSION COVERAGE. It pins a set the change
+ * deliberately did NOT touch, so it was green before this PR and is green after. It is here
+ * because the wrong fix is cheaper to type than the right one, and because the damage lands
+ * two modules away from anyone editing the tab set. The BEHAVIOURAL half of the same
+ * property — that the collaborator procs still refuse `removed` — is
+ * `app-collaborator.seat-grant-status.test.ts`; a set assertion alone would type-check past
+ * a consumer that stopped reading the set.
+ */
+describe('🔴 the shared AUTHORABLE set was not widened to make the repair state work', () => {
+  it('is exactly draft, pending, approved — `removed` is NOT in it', () => {
+    expect([...AUTHORABLE_LISTING_STATUSES]).toEqual(['draft', 'pending', 'approved']);
+    expect(isAuthorableListingStatus('removed')).toBe(false);
+    expect(isAuthorableListingStatus('rejected')).toBe(false);
+  });
+
+  it('and the repair branch is therefore STRICTLY narrower than the authorable one', () => {
+    // Stated as a property rather than as a fixture: no status can be both, so the two arms
+    // of the `authorable || ownerRepair` disjunction can never disagree about which tabs a
+    // single listing gets. A mutant that widens either one collapses this.
+    for (const status of ['draft', 'pending', 'approved', 'removed', 'rejected'] as const) {
+      const repair = isOwnerUnpublishedTabContext({
+        status,
+        lastModerationAction: OWNER_UNPUBLISH_ACTION,
+      });
+      expect(isAuthorableListingStatus(status) && repair, status).toBe(false);
+    }
   });
 });

--- a/src/components/Apps/__tests__/myAppsView.test.ts
+++ b/src/components/Apps/__tests__/myAppsView.test.ts
@@ -285,12 +285,53 @@ describe('🔴 myAppListingHref follows the STATUS-narrowed tab set', () => {
     appBlockId: 'ab_h',
     role: 'owner',
     capabilities: capabilitiesForKind('onsite'),
+    // 🔴 SPELLED, and `null` is the fail-closed value ("not proven to be the owner's own").
+    // The field is REQUIRED on this row type; leaving fixtures to omit it is precisely the
+    // ergonomics decision that let the production caller drop it.
+    lastModerationAction: null,
   } as const;
 
-  it('an owner on a REMOVED listing lands on Publishing — their route back', () => {
+  it('an owner on a MODERATOR-removed listing lands on Publishing — their route back', () => {
+    // `lastModerationAction: null` reads as a moderator removal (fail-closed), so the tab
+    // set is the narrowed publishing/history pair and `tabs[0]` is Publishing.
     expect(myAppListingHref({ ...base, status: 'removed' })).toBe(
       '/apps/listing/apl_h/edit?tab=publishing'
     );
+  });
+
+  /**
+   * 🔴 THE BEHAVIOURAL CASE FOR THE DROPPED-FIELD DEFECT — and the reason a structural
+   * guard is not enough on its own.
+   *
+   * `appListingEditorTabs.callers.test.ts` asserts that every call site PASSES
+   * `lastModerationAction`. That is a claim about the argument list, and a structural check
+   * like it type-checks straight past a WRONG argument — passing the field but reading it
+   * off the wrong object, or hardcoding it, would satisfy the ledger completely. This pins
+   * the OUTCOME instead: the same listing, distinguished only by the moderation action,
+   * must produce a DIFFERENT href.
+   *
+   * It is also the user-visible half of the defect. While the field was dropped, an
+   * owner-unpublished listing produced `?tab=publishing` from this function while the
+   * authoring page offered `details` + `media` for the very same row — two surfaces
+   * disagreeing about one listing.
+   */
+  it('🔴 an OWNER-unpublished listing lands on Details — the row now agrees with the page', () => {
+    expect(
+      myAppListingHref({ ...base, status: 'removed', lastModerationAction: 'owner-unpublish' })
+    ).toBe('/apps/listing/apl_h/edit?tab=details');
+  });
+
+  it('🔴 the pair DIFFERS on the moderation action alone — one field, two answers', () => {
+    // The discriminating control. Both fixtures are `removed`, same kind, same role, same
+    // capabilities; only `lastModerationAction` moves. A mutant that ignores the field
+    // makes these two equal, and this is the assertion that says so directly.
+    const modRemoved = myAppListingHref({ ...base, status: 'removed' });
+    const ownerUnpublished = myAppListingHref({
+      ...base,
+      status: 'removed',
+      lastModerationAction: 'owner-unpublish',
+    });
+    expect(modRemoved).not.toBe(ownerUnpublished);
   });
 
   it('an owner on a REJECTED listing lands on History — a different answer, same branch', () => {

--- a/src/components/Apps/__tests__/offsiteEditConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteEditConfig.test.ts
@@ -611,8 +611,19 @@ describe('🔴 scope drift — the save dead end, and the copy that denies it', 
   // pre-existing; this pins it so a half-fix cannot land quietly.
   it('🟡 the drifted state is a HARD dead end — the save aborts CLIENT-side before any server call', () => {
     // This is the mechanism the browser test exercises end-to-end, pinned here as pure
-    // logic so it runs in the `unit` project — the tier CI actually executes. The browser
-    // suite that drives the real click path runs in NO CI job (see the PR body).
+    // logic so it also runs in the `unit` project.
+    //
+    // 🔴 CORRECTION — an earlier version of this comment said the browser suite "runs in NO
+    // CI job". That was WRONG: `preview / component-tests` (Tekton preview pipeline) runs
+    // the `component` project and reported "Component suite passed (report-only)" on
+    // civitai/civitai#4431. The claim came from enumerating `.github/workflows/`, which is a
+    // complete population of GitHub ACTIONS and silent about Tekton.
+    //
+    // What is true, and why this duplicate still earns its place: NEITHER tier BLOCKS. The
+    // component check is report-only, the `unit` job is `continue-on-error` on pull
+    // requests, and the preview tier only exists when the preview pipeline runs at all
+    // (opt-in for non-maintainers) and registers ~40 min after the Actions rollup goes
+    // green. Two independent report-only paths to the same fact is the point.
     const form = editContextToForm(driftedCtx());
 
     // The prefill carries the drifted mask…

--- a/src/components/Apps/__tests__/offsiteEditConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteEditConfig.test.ts
@@ -12,6 +12,7 @@ import {
   scopeDisclosureLockedForEdit,
   type ListingEditContext,
 } from '~/components/Apps/offsiteEditConfig';
+import { scopeJustificationError } from '~/components/Apps/offsiteSubmitFormConfig';
 import { MATERIAL_LISTING_PATCH_FIELDS } from '~/shared/constants/app-capabilities.constants';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
@@ -527,5 +528,220 @@ describe('scopeDisclosureLockedForEdit', () => {
         makeCtx({ status: 'removed', connectClientId: 'oauth-1', connectRequestedScopes: 4 })
       )
     ).toBe(true);
+  });
+});
+
+/**
+ * 🔴 THE SCOPE-DRIFT DEAD END, AND THE COPY THAT USED TO DENY IT.
+ *
+ * `scopeDisclosureLockedForEdit` already had good coverage: it asserts the boxes are
+ * DISABLED in the drifted state, and stops there. That is exactly why the defect below
+ * stayed invisible — nothing ever attempted the SAVE those disabled boxes block.
+ *
+ * The state: an unpublished listing whose connect client's `allowedScopes` have DRIFTED to
+ * ADD a sensitive scope. Two independent mechanisms then refuse every save:
+ *
+ *   1. CLIENT, and it fires first. `ExternalListingEditForm.handleSave` runs
+ *      `scopeJustificationError(values)` whenever `edit.connectClientId != null` —
+ *      INDEPENDENTLY of `scopeLocked`. The newly-added sensitive scope has no prefilled
+ *      justification, because `editContextToForm` prunes justifications to the DERIVED mask
+ *      and there was never a stored rationale for a scope the client did not previously
+ *      have. So the save aborts and steers the author to Details…
+ *   2. …where `scopeDisclosureLockedForEdit` has DISABLED the very boxes that would clear
+ *      the error. The author cannot type the justification, so cannot clear the error, so
+ *      cannot save — not the scopes, and not the tagline either.
+ *
+ * And the SERVER would refuse anyway: the drifted mask rides along on every patch via
+ * `buildScalarPatch`, and `materialPatchChanges` counts it as material.
+ *
+ * The OUTCOME is honest. The COPY was not: it ended "Tagline, description and category can
+ * be edited now", which is false in precisely the state `scopeLocked` exists for.
+ *
+ * 🟡 READ THE LABELS — THIS BLOCK IS A MIX, and only some of it is regression coverage.
+ * Measured by restoring `offsiteEditConfig.ts` to b16cc80c2c and re-running:
+ *
+ *   RED at base (genuine regression coverage for the copy fix):
+ *     - 'the COPY tells the truth in the drifted state'
+ *   GREEN at base (INVARIANT / CHARACTERISATION guards — the mechanism they pin was
+ *   already true at b16cc80c2c, and they exist to stop a WRONG future fix, not to prove
+ *   this one):
+ *     - 'the drifted state is a HARD dead end'  — the dead end is PRE-EXISTING. This
+ *       pins the CONJUNCTION (check fires AND boxes are locked) so that a future "fix"
+ *       which unlocks the boxes without addressing the save check, or vice versa,
+ *       reddens exactly one line instead of silently half-fixing it.
+ *     - 'the control: WITHOUT drift…'          — a negative control, green by design.
+ *     - 'the UNDRIFTED unpublished copy is UNCHANGED' — the other direction of the new
+ *       branch; green at base because that copy is what base emitted.
+ *
+ * Counting the green-at-base ones as evidence for this fix would be exactly the vacuous
+ * guard the repo's rules warn about, so they are named as what they are.
+ */
+describe('🔴 scope drift — the save dead end, and the copy that denies it', () => {
+  /** A drifted context: stored mask carried ONE sensitive scope, the client now demands TWO. */
+  function driftedCtx(overrides: Partial<ListingEditContext> = {}): ListingEditContext {
+    return makeCtx({
+      status: 'removed',
+      connectClientId: 'oauth-1',
+      // STORED snapshot: UserRead only, and it HAS a rationale.
+      connectRequestedScopes: TokenScope.UserRead,
+      // CURRENT client scopes: UserRead + ModelsWrite. Both are sensitive
+      // (SENSITIVE_TOKEN_SCOPES), and ModelsWrite has no stored rationale because the
+      // client did not have it when the listing was last reviewed.
+      connectAllowedScopes: TokenScope.UserRead | TokenScope.ModelsWrite,
+      connectScopeJustifications: { UserRead: 'We show your display name on the dashboard.' },
+      ...overrides,
+    });
+  }
+
+  // 🟡 INVARIANT GUARD, GREEN AT BASE — see the block comment above. The dead end is
+  // pre-existing; this pins it so a half-fix cannot land quietly.
+  it('🟡 the drifted state is a HARD dead end — the save aborts CLIENT-side before any server call', () => {
+    // This is the mechanism the browser test exercises end-to-end, pinned here as pure
+    // logic so it runs in the `unit` project — the tier CI actually executes. The browser
+    // suite that drives the real click path runs in NO CI job (see the PR body).
+    const form = editContextToForm(driftedCtx());
+
+    // The prefill carries the drifted mask…
+    expect(form.requestedScopes).toBe(TokenScope.UserRead | TokenScope.ModelsWrite);
+    // …but only the ONE stored rationale, because pruning cannot invent one for a scope
+    // that was never reviewed.
+    expect(Object.keys(form.scopeJustifications).sort()).toEqual(['UserRead']);
+
+    // So `handleSave`'s scope check — which runs for ANY connect listing, gated on
+    // `edit.connectClientId != null` and NOT on `scopeLocked` — produces an error.
+    const saveBlockingError = scopeJustificationError(form);
+    expect(saveBlockingError).toBeDefined();
+
+    // And the boxes that would clear that error are disabled. Both halves asserted
+    // TOGETHER: either one alone is survivable, and it is the CONJUNCTION that is the dead
+    // end. A fix that unlocked the boxes, or one that skipped the check, would redden
+    // exactly one of these lines and that is the point.
+    expect(scopeDisclosureLockedForEdit(driftedCtx())).toBe(true);
+  });
+
+  // 🟡 NEGATIVE CONTROL, green at base by design.
+  it('🟡 the control: WITHOUT drift the same shape saves fine — so the dead end is the DRIFT, not the unpublished state', () => {
+    // 🔴 NEGATIVE CONTROL. Without it the test above cannot tell "drift dead-ends the save"
+    // from "an unpublished connect listing can never save", which is a different and much
+    // larger claim. Same status, same client, same justification — masks AGREE.
+    const undrifted = makeCtx({
+      status: 'removed',
+      connectClientId: 'oauth-1',
+      connectRequestedScopes: TokenScope.UserRead,
+      connectAllowedScopes: TokenScope.UserRead,
+      connectScopeJustifications: { UserRead: 'We show your display name on the dashboard.' },
+    });
+    expect(scopeJustificationError(editContextToForm(undrifted))).toBeUndefined();
+    expect(scopeDisclosureLockedForEdit(undrifted)).toBe(false);
+  });
+
+  it('🔴 the COPY tells the truth in the drifted state — it no longer promises an edit that cannot land', () => {
+    const reason = materialEditBlockedReason(driftedCtx())!;
+
+    // 🔴 THE EXACT FALSE SENTENCE, pinned as a NEGATIVE. This is the assertion that was RED
+    // at b16cc80c2c: the old copy ended with this clause verbatim in the drifted state.
+    expect(reason).not.toMatch(/can be edited now/i);
+
+    // And it says the true thing instead: nothing here saves while the app is unpublished.
+    expect(reason).toMatch(/nothing on this screen can be saved/i);
+    // Naming the three fields explicitly, because "nothing" is exactly the word a reader
+    // discounts — the old copy had told them those three were fine.
+    expect(reason).toMatch(/tagline, description or category/i);
+    // The permission change is named as the cause, or the author cannot act on it.
+    expect(reason).toMatch(/permission/i);
+  });
+
+  // 🟡 Green at base — the other direction of the new branch, not evidence for it.
+  it('🟡 the UNDRIFTED unpublished copy is UNCHANGED — the new arm is a narrowing, not a rewrite', () => {
+    // 🔴 The other direction of the same clause: a mutant that returns the drifted message
+    // unconditionally would pass every assertion above. This is what makes the drift
+    // condition individually killable.
+    const plain = materialEditBlockedReason(makeCtx({ status: 'removed' }))!;
+    expect(plain).toMatch(/Tagline, description and category can be edited now/);
+    expect(plain).not.toMatch(/nothing on this screen can be saved/i);
+  });
+});
+
+/**
+ * 🔴 ROLE-AWARE COPY. `loadOwnedEditableListing` is named for ownership but gates on
+ * `resolveListingRole(...) === null`, which admits an ACCEPTED COLLABORATOR — so a seated
+ * editor reads this copy. It used to tell them to "Republish the app from the Publishing
+ * tab", a tab `editorTabsFor` withholds from an editor (`publishing` is owner-only).
+ *
+ * 🔴 THE WHOLE NORMALISED STRING IS PINNED, not a keyword. The artifact under test IS
+ * prose, and a guard on WORDS is walkable by REWORDING — the pre-existing tests here match
+ * `/republish/i` and `/tagline, description and category/i`, both of which the old,
+ * editor-hostile copy satisfies perfectly. A cosmetic reword will now fail these; that is
+ * the price of a machine-checkable claim about what the author is told.
+ */
+describe('🔴 materialEditBlockedReason — role-aware, and pinned as WHOLE strings', () => {
+  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+  const OWNER_COPY =
+    'This app is unpublished, so its name, App URL, source repository and content rating ' +
+    'are locked. Changing any of them needs moderator review, and an unpublished listing ' +
+    'has no way to reach it. Republish the app from the Publishing tab first, then edit ' +
+    'those fields — the edit is staged for review. Tagline, description and category can ' +
+    'be edited now.';
+
+  const EDITOR_COPY =
+    'This app is unpublished, so its name, App URL, source repository and content rating ' +
+    'are locked. Changing any of them needs moderator review, and an unpublished listing ' +
+    "has no way to reach it. The app's owner has to republish it before those fields can " +
+    'be edited — the Publishing tab that does it is theirs, not yours. Tagline, ' +
+    'description and category can be edited now.';
+
+  // 🟡 Green at base (base emitted the owner copy unconditionally); the EDITOR case below
+  // is the one that was red.
+  it('🟡 an OWNER is addressed as the person who can republish', () => {
+    expect(norm(materialEditBlockedReason(makeCtx({ status: 'removed', role: 'owner' }))!)).toBe(
+      norm(OWNER_COPY)
+    );
+  });
+
+  it('🔴 a seated EDITOR is NOT told to use a tab they cannot see', () => {
+    const reason = materialEditBlockedReason(makeCtx({ status: 'removed', role: 'editor' }))!;
+    expect(norm(reason)).toBe(norm(EDITOR_COPY));
+    // The two specific falsehoods, pinned as negatives so a future reword cannot
+    // reintroduce them while still passing a whole-string equality that someone updated.
+    expect(reason).not.toMatch(/Republish the app from the Publishing tab/i);
+  });
+
+  it('🔴 an ABSENT role gets the ROLE-NEUTRAL copy, never the owner copy', () => {
+    // 🔴 THE FAIL-SAFE DIRECTION, AND IT IS THE OPPOSITE OF A NORMAL NARROWING. Absence
+    // cannot distinguish an owner from an editor, and the owner wording asserts things an
+    // editor would find false ("Republish … from the Publishing tab"), while the neutral
+    // wording is true for BOTH. So unknown must resolve to neutral. Every pre-existing
+    // fixture in this file predates the field and lands here.
+    expect(norm(materialEditBlockedReason(makeCtx({ status: 'removed' }))!)).toBe(
+      norm(EDITOR_COPY)
+    );
+  });
+
+  it('🔴 the two role copies actually DIFFER — the branch is not a no-op', () => {
+    // A mutant that returns the owner string for both roles passes every "matches /republish/"
+    // assertion in this file. This is the cheapest thing that kills it.
+    const owner = materialEditBlockedReason(makeCtx({ status: 'removed', role: 'owner' }))!;
+    const editor = materialEditBlockedReason(makeCtx({ status: 'removed', role: 'editor' }))!;
+    expect(owner).not.toBe(editor);
+  });
+
+  it('🔴 role-awareness survives the DRIFTED arm too', () => {
+    // The drifted message has its own way-out clause, and it is the same trap one branch
+    // deeper — a drifted EDITOR must not be told to use the Publishing tab either.
+    const drifted = (role?: 'owner' | 'editor') =>
+      materialEditBlockedReason(
+        makeCtx({
+          status: 'removed',
+          role,
+          connectClientId: 'oauth-1',
+          connectRequestedScopes: TokenScope.UserRead,
+          connectAllowedScopes: TokenScope.UserRead | TokenScope.ModelsWrite,
+        })
+      )!;
+    expect(drifted('owner')).toMatch(/republish the app from the Publishing tab/i);
+    expect(drifted('editor')).not.toMatch(/republish the app from the Publishing tab/i);
+    expect(drifted('editor')).toMatch(/ask the app's owner to republish it/i);
+    expect(drifted(undefined)).not.toMatch(/republish the app from the Publishing tab/i);
   });
 });

--- a/src/components/Apps/__tests__/offsiteEditConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteEditConfig.test.ts
@@ -7,8 +7,12 @@ import {
   editContextToForm,
   hasScalarChanges,
   isApprovedEdit,
+  isUnpublishedEdit,
+  materialEditBlockedReason,
+  scopeDisclosureLockedForEdit,
   type ListingEditContext,
 } from '~/components/Apps/offsiteEditConfig';
+import { MATERIAL_LISTING_PATCH_FIELDS } from '~/shared/constants/app-capabilities.constants';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 /**
@@ -366,5 +370,162 @@ describe('sourceRepoUrl — prefill and the minimal patch', () => {
     const ctx = makeCtx({ scalars: { ...makeCtx().scalars, sourceRepoUrl: REPO } });
     const patch = buildScalarPatch(ctx, { ...editContextToForm(ctx), sourceRepoUrl: `${REPO}.git` });
     expect(patch.sourceRepoUrl).toBe(`${REPO}.git`);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * THE REPAIR STATE — an OWNER-UNPUBLISHED listing's locked material fields
+ * ------------------------------------------------------------------ */
+
+/**
+ * 🔴 THE CLIENT HALF OF `MATERIAL_CHANGE_BLOCKED`.
+ *
+ * `updateListing`'s `removed` branch refuses any change to a field in
+ * `MATERIAL_LISTING_PATCH_FIELDS` — the value a moderator approved cannot change while the
+ * listing is down, because an unpublished listing has no route back into review. Until the
+ * editor tabs opened on this state that refusal was unreachable; with the tabs open and
+ * nothing else done, it is four inputs the author can fill and can never save.
+ *
+ * These pin the PURE verdict. The rendered consequence (which inputs are actually disabled,
+ * over the whole material set) is `ExternalSubmitForm.ownerUnpublished.browser.test.tsx`.
+ */
+describe('materialEditBlockedReason', () => {
+  it('🔴 is non-null ONLY on an unpublished listing', () => {
+    expect(materialEditBlockedReason(makeCtx({ status: 'removed' }))).not.toBeNull();
+    // Every status the edit form can otherwise be reached on. `rejected` is included even
+    // though `getMyListingForEdit` refuses it: this predicate must not invent a lock for a
+    // state whose message would be wrong ("republish it" is nonsense for a rejected app).
+    for (const status of ['draft', 'pending', 'approved', 'rejected'] as const) {
+      expect(materialEditBlockedReason(makeCtx({ status })), status).toBeNull();
+    }
+  });
+
+  it('🔴 names the way OUT, not just the refusal', () => {
+    // An author told only "no" has nowhere to go. The server's own message names republish →
+    // edit → staged for review, and this is that message stated BEFORE the failed save
+    // rather than after it.
+    const reason = materialEditBlockedReason(makeCtx({ status: 'removed' }))!;
+    expect(reason).toMatch(/republish/i);
+    expect(reason).toMatch(/moderator review/i);
+    // And what IS still editable, so the tab is not read as entirely dead.
+    expect(reason).toMatch(/tagline, description and category/i);
+  });
+
+  it('🔴 is KIND-AWARE — an on-site listing is not told its "App URL" is locked', () => {
+    // An on-site listing has no external URL and is rendered no step that could change one
+    // (`isOnsiteEdit` / `showUrlStep`), so naming it would describe a field that is not on
+    // screen — the exact defect `listingEditHeaderCopy` exists to fix, one alert further on.
+    const offsite = materialEditBlockedReason(makeCtx({ status: 'removed' }))!;
+    const onsite = materialEditBlockedReason(makeCtx({ status: 'removed', kind: 'onsite' }))!;
+    expect(offsite).toMatch(/App URL/);
+    expect(onsite).not.toMatch(/App URL/);
+    // Both still name the three fields that exist for either kind, so the on-site branch is
+    // a narrowing rather than a different (or empty) sentence.
+    for (const copy of [offsite, onsite]) {
+      expect(copy).toMatch(/name/i);
+      expect(copy).toMatch(/source repository/i);
+      expect(copy).toMatch(/content rating/i);
+    }
+  });
+
+  it('🔴 the locked set is exactly the SERVER’s material set — one list, not two', () => {
+    // The ledger. `MATERIAL_LISTING_PATCH_FIELDS` is what `offsite-listing.service` refuses
+    // on, and this asserts the value space the copy above is written against. A field added
+    // to that constant with no counterpart here (or in the form) is what this catches.
+    expect([...MATERIAL_LISTING_PATCH_FIELDS]).toEqual([
+      'externalUrl',
+      'name',
+      'contentRating',
+      'sourceRepoUrl',
+    ]);
+  });
+});
+
+describe('isUnpublishedEdit', () => {
+  it('is true for `removed` and false for every other status', () => {
+    expect(isUnpublishedEdit({ status: 'removed' })).toBe(true);
+    for (const status of ['draft', 'pending', 'approved', 'rejected', 'quarantined']) {
+      expect(isUnpublishedEdit({ status }), status).toBe(false);
+    }
+  });
+});
+
+/**
+ * 🔴 THE SCOPE-DRIFT ARM, which is NOT implied by the material lock.
+ *
+ * `buildScalarPatch` sends `requestedScopes` when the justifications changed OR when the
+ * connect client's CURRENT `allowedScopes` has drifted from the stored snapshot, and
+ * `materialPatchChanges` counts that key as material only when the two masks DIFFER. So
+ * while they agree a justification edit is trivial and saves fine on an unpublished
+ * listing; once they have drifted, the drifted mask rides along on EVERY patch and even a
+ * tagline-only save is refused. Disabling the boxes in the first case would remove a
+ * legitimate edit; leaving them live in the second is the fillable-but-unsaveable defect
+ * one field further out.
+ */
+describe('scopeDisclosureLockedForEdit', () => {
+  const connect = {
+    connectClientId: 'oauth-1',
+    connectAllowedScopes: 12,
+    connectRequestedScopes: 12,
+  };
+
+  it('🔴 is FALSE while the masks agree — a justification edit is trivial and saves', () => {
+    expect(scopeDisclosureLockedForEdit(makeCtx({ status: 'removed', ...connect }))).toBe(false);
+  });
+
+  it('🔴 is TRUE once the mask has DRIFTED on an unpublished listing', () => {
+    expect(
+      scopeDisclosureLockedForEdit(
+        makeCtx({ status: 'removed', ...connect, connectAllowedScopes: 28 })
+      )
+    ).toBe(true);
+  });
+
+  it('🔴 drift alone is NOT enough — a live listing stages the change instead of refusing it', () => {
+    // On `approved` a material change routes to a SHADOW revision and goes to review; it is
+    // only the `removed` branch that has nowhere to route it. Same drift, opposite answer,
+    // so the status clause is individually killable.
+    for (const status of ['draft', 'pending', 'approved'] as const) {
+      expect(
+        scopeDisclosureLockedForEdit(
+          makeCtx({ status, ...connect, connectAllowedScopes: 28 })
+        ),
+        status
+      ).toBe(false);
+    }
+  });
+
+  it('🔴 no connect client ⇒ no scope section ⇒ never locked, even with the masks apart', () => {
+    // A non-connect listing renders no disclosure at all, so a `true` here would be a lock
+    // on nothing — and `buildScalarPatch` emits no scope keys for it either.
+    expect(
+      scopeDisclosureLockedForEdit(
+        makeCtx({
+          status: 'removed',
+          connectClientId: null,
+          connectAllowedScopes: 28,
+          connectRequestedScopes: 12,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('🔴 absent masks read as 0 on BOTH sides, exactly as the server’s `?? 0` does', () => {
+    // A legacy context with neither field is NOT drifted (0 vs 0). One side present and
+    // non-zero IS. Asserting both directions is what stops an `undefined !== undefined`
+    // style mutant reading every legacy row as drifted and locking a box that saves fine.
+    expect(
+      scopeDisclosureLockedForEdit(makeCtx({ status: 'removed', connectClientId: 'oauth-1' }))
+    ).toBe(false);
+    expect(
+      scopeDisclosureLockedForEdit(
+        makeCtx({ status: 'removed', connectClientId: 'oauth-1', connectAllowedScopes: 4 })
+      )
+    ).toBe(true);
+    expect(
+      scopeDisclosureLockedForEdit(
+        makeCtx({ status: 'removed', connectClientId: 'oauth-1', connectRequestedScopes: 4 })
+      )
+    ).toBe(true);
   });
 });

--- a/src/components/Apps/__tests__/offsiteEditConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteEditConfig.test.ts
@@ -50,7 +50,16 @@ function makeCtx(overrides: Partial<ListingEditContext> = {}): ListingEditContex
 describe('editContextToForm', () => {
   it('maps scalars to form values, filling slug and blanking null fields', () => {
     const form = editContextToForm(
-      makeCtx({ scalars: { name: 'X', tagline: null, description: null, category: null, contentRating: null, externalUrl: null } })
+      makeCtx({
+        scalars: {
+          name: 'X',
+          tagline: null,
+          description: null,
+          category: null,
+          contentRating: null,
+          externalUrl: null,
+        },
+      })
     );
     expect(form.slug).toBe('vitrine');
     expect(form.name).toBe('X');
@@ -162,8 +171,12 @@ describe('buildScalarPatch', () => {
 
   it('captures a category change and a category clear', () => {
     const ctx = makeCtx();
-    expect(buildScalarPatch(ctx, { ...editContextToForm(ctx), category: 'games' }).category).toBe('games');
-    expect(buildScalarPatch(ctx, { ...editContextToForm(ctx), category: null }).category).toBeNull();
+    expect(buildScalarPatch(ctx, { ...editContextToForm(ctx), category: 'games' }).category).toBe(
+      'games'
+    );
+    expect(
+      buildScalarPatch(ctx, { ...editContextToForm(ctx), category: null }).category
+    ).toBeNull();
   });
 });
 
@@ -369,7 +382,10 @@ describe('sourceRepoUrl — prefill and the minimal patch', () => {
     // compares CANONICAL forms — so this patch is classified as no material change and
     // applied in place, rather than queuing a moderator re-review.
     const ctx = makeCtx({ scalars: { ...makeCtx().scalars, sourceRepoUrl: REPO } });
-    const patch = buildScalarPatch(ctx, { ...editContextToForm(ctx), sourceRepoUrl: `${REPO}.git` });
+    const patch = buildScalarPatch(ctx, {
+      ...editContextToForm(ctx),
+      sourceRepoUrl: `${REPO}.git`,
+    });
     expect(patch.sourceRepoUrl).toBe(`${REPO}.git`);
   });
 });
@@ -488,9 +504,7 @@ describe('scopeDisclosureLockedForEdit', () => {
     // so the status clause is individually killable.
     for (const status of ['draft', 'pending', 'approved'] as const) {
       expect(
-        scopeDisclosureLockedForEdit(
-          makeCtx({ status, ...connect, connectAllowedScopes: 28 })
-        ),
+        scopeDisclosureLockedForEdit(makeCtx({ status, ...connect, connectAllowedScopes: 28 })),
         status
       ).toBe(false);
     }

--- a/src/components/Apps/appListingEditorTabs.ts
+++ b/src/components/Apps/appListingEditorTabs.ts
@@ -93,12 +93,30 @@ export type EditorTabContext = {
    * self-unpublish and a moderator takedown; only the last status-changing event
    * separates them. See {@link isOwnerUnpublishedTabContext}.
    *
-   * 🔴 OPTIONAL, AND ABSENT MEANS "NOT PROVEN TO BE THE OWNER'S OWN", i.e. today's
-   * narrowed behaviour. Same fail-closed direction as the server predicate
-   * (`app-listing-owner-unpublish`): a caller that has not wired the field through gets
-   * the narrow set, never the wide one.
+   * 🔴 REQUIRED, AND IT WAS OPTIONAL FOR EXACTLY ONE RELEASE — that is the whole reason
+   * this comment is long. `null` still means "not proven to be the owner's own", i.e. the
+   * narrowed behaviour, and the runtime direction is unchanged and still fail-closed
+   * (`undefined !== OWNER_UNPUBLISH_ACTION`, so a JS caller that omits it gets the narrow
+   * set). What changed is that OMITTING IT IS NOW A COMPILE ERROR.
+   *
+   * 🔴 WHY, CONCRETELY. While the field was optional there were two production callers of
+   * {@link editorTabsFor} — the authoring page and `myAppListingHref` (`myAppsView.ts`) —
+   * and only ONE of them passed it. The row `myAppListingHref` receives already CARRIES
+   * `lastModerationAction` (`MyAppsBody` reads it off the same object two lines away), so
+   * this was not a plumbing gap, it was a dropped field. The consequence was two different
+   * tab sets derived for ONE listing: the page offered the owner `details`/`media`, the
+   * `/apps/mine` row linked at `?tab=publishing`. Nothing went red, because optionality is
+   * precisely what makes a dropped field type-check.
+   *
+   * 🔴 SO THE ENFORCEMENT IS THE TYPE, NOT A TEST. A ledger test can assert that today's
+   * call sites pass the field (and `appListingEditorTabs.callers.test.ts` does, as
+   * defence-in-depth for a caller added in a way the compiler cannot see — a `.js` file, an
+   * `as any`, a spread of a wider object). But the compiler is what makes the NEXT caller
+   * impossible to get wrong, and it runs on every PR as `tekton / typecheck`, which the
+   * browser suite that covers this function does NOT. Pass `null` explicitly when the
+   * caller genuinely does not know — that is a decision, and it now reads as one.
    */
-  lastModerationAction?: string | null;
+  lastModerationAction: string | null;
 };
 
 /**

--- a/src/components/Apps/appListingEditorTabs.ts
+++ b/src/components/Apps/appListingEditorTabs.ts
@@ -1,3 +1,4 @@
+import { OWNER_UNPUBLISH_ACTION } from '~/components/Apps/offsiteOwnerControls';
 import type {
   AppRole,
   ListingCapability,
@@ -82,7 +83,57 @@ export type EditorTabContext = {
    * publishing/history pair; see {@link editorTabsFor}.
    */
   status: string;
+  /**
+   * The listing's most-recent STATUS-CHANGING moderation action, NORMALISED
+   * (`'owner-unpublish' | 'other' | null`) — straight off
+   * `AppListingAuthoringContext.lastModerationAction`.
+   *
+   * 🔴 `status` ALONE CANNOT ANSWER "MAY THIS BE EDITED?" ON `removed`, and this is the
+   * bit that can. `app_listings.status = 'removed'` is written by BOTH an owner
+   * self-unpublish and a moderator takedown; only the last status-changing event
+   * separates them. See {@link isOwnerUnpublishedTabContext}.
+   *
+   * 🔴 OPTIONAL, AND ABSENT MEANS "NOT PROVEN TO BE THE OWNER'S OWN", i.e. today's
+   * narrowed behaviour. Same fail-closed direction as the server predicate
+   * (`app-listing-owner-unpublish`): a caller that has not wired the field through gets
+   * the narrow set, never the wide one.
+   */
+  lastModerationAction?: string | null;
 };
+
+/**
+ * Is this listing in the OWNER-REPAIR state — `removed`, because the owner unpublished it
+ * themselves?
+ *
+ * 🔴 THIS IS THE CLIENT MIRROR OF THE SERVER PREDICATE, NOT A SECOND OPINION.
+ * `isOwnerUnpublishedListing` in `app-listing-owner-unpublish` is authoritative and is what
+ * `getMyListingForEdit` / `updateListing` / `getMyListingForApp` actually branch on; this
+ * decides only whether the caller is OFFERED the surface those procs will accept. The two
+ * read the same normalised fact, and the action name comes from
+ * {@link OWNER_UNPUBLISH_ACTION} — the client literal `app-listing-owner-unpublish.test.ts`
+ * pins against the server's `OWNER_UNPUBLISH_EVENT` — so they cannot drift into different
+ * spellings.
+ *
+ * 🔴 BOTH CLAUSES ARE LOAD-BEARING AND NEITHER IS REDUNDANT.
+ *   - Without the STATUS clause a stale `owner-unpublish` on a listing that has since been
+ *     relisted (`approved`) or reset to `pending` would report `true`. That is harmless for
+ *     the tab set (those statuses are authorable anyway) but this predicate is exported, and
+ *     the next caller's default must not be "an old event still speaks for the row".
+ *     `getAppListingAuthoringContext` additionally refuses to even READ the event on a
+ *     non-`removed` listing, so the two agree.
+ *   - Without the ACTION clause every moderator takedown re-opens the content tabs — the
+ *     exact hazard the narrowing exists to prevent.
+ *
+ * 🔴 FAIL-CLOSED ON ABSENCE. `null` (no recorded event) and `'other'` (a moderator verb,
+ * collapsed by `normalizeLastModerationAction` before it leaves the server) are both
+ * `false`. A listing whose events were pruned, or that predates the taxonomy, is treated as
+ * a moderator removal — the safe direction, and a REAL branch rather than a degenerate one.
+ */
+export function isOwnerUnpublishedTabContext(
+  ctx: Pick<EditorTabContext, 'status' | 'lastModerationAction'>
+): boolean {
+  return ctx.status === 'removed' && ctx.lastModerationAction === OWNER_UNPUBLISH_ACTION;
+}
 
 /**
  * The tabs this caller may actually open, in display order.
@@ -106,6 +157,30 @@ export type EditorTabContext = {
  *   test in `appListingEditorTabs.test.ts`; the `collaborators` one names the Forgejo
  *   consequence.
  *
+ * 🔴 SECOND, THE OWNER-REPAIR BRANCH, AND IT IS NARROWER THAN THE FIRST ON PURPOSE.
+ * `status='removed'` is written by BOTH an owner self-unpublish and a moderator takedown,
+ * and civitai/civitai#4413 made the SERVER tell them apart: `getMyListingForEdit`,
+ * `updateListing` and `getMyListingForApp` now ACCEPT an owner-unpublished listing (trivial
+ * scalars in place, media edited directly) and still refuse a moderator takedown. Until this
+ * change nothing in the UI could reach that: `editorTabsFor` gated `details` and `media` on
+ * `isAuthorableListingStatus`, which excludes `removed`, so the owner had a repair loop with
+ * no repair step — a server capability with zero callers, which is how #4401's
+ * `messageAppOwner` shipped dark.
+ *
+ *   🔴 SO THE FIX BRANCHES ON THE LAST ACTION, IT DOES NOT WIDEN
+ *   `AUTHORABLE_LISTING_STATUSES`. That set has THREE consumers, and the other one is
+ *   `assertSeatGrantable` in `app-collaborator.service` — the server gate on
+ *   `inviteCollaborator` / `respondToInvite`. Adding `removed` to it would unlock
+ *   collaborator invites on MODERATOR-DELISTED listings, where accepting still mints
+ *   Forgejo `write` on the app's repo: exactly the hazard the first branch exists to
+ *   close, re-opened from the other end and server-side rather than merely in the UI.
+ *
+ *   🔴 AND THE REPAIR BRANCH GRANTS `details` + `media` ONLY. `collaborators` stays
+ *   withheld (its server gate refuses this status, so the tab would 403 — and it is the
+ *   Forgejo surface). `manifest` and `earnings` stay withheld too: nothing in this change
+ *   opens a version-submit or an earnings read on an unpublished app, and withholding a
+ *   tab is always safe — a tab set is a UI narrowing, never a gate.
+ *
  * 🔴 AND THE TAB SET IS A UI NARROWING, NEVER A GATE. Measured on this tree:
  * `appCollaborators.list`, `inviteCollaborator` and `respondToInvite` did NOT check
  * listing status at all — only `getAppListingAuthoringContext`'s refusal stood between a
@@ -114,14 +189,24 @@ export type EditorTabContext = {
  * THAT is the enforcement point. This function only stops the caller being offered a
  * surface the server is going to refuse.
  *
- *   - `details`       — every AUTHORABLE status. `appListings.getMyListingForEdit` /
+ *   - `details`       — every AUTHORABLE status, PLUS the owner-repair state. `getMyListingForEdit` /
  *                       `updateListing` are
  *                       LISTING-keyed and seat-aware (both route through
  *                       `resolveListingAccess` via `loadOwnedEditableListing`), and
  *                       `capabilitiesForKind(...).listingContent` is `true` for BOTH
  *                       kinds. There is no shape in which this tab is unreachable.
+ *                       🔴 On the repair state the panel is NOT fully editable: the server
+ *                       refuses a MATERIAL scalar change with `MATERIAL_CHANGE_BLOCKED`, so
+ *                       `ExternalListingEditForm` renders those four inputs disabled with
+ *                       the refusal's reason. Offering the tab and NOT doing that is an
+ *                       input the author can fill and can never save.
  *
- *   - `media`         — BOTH `capabilities.listingMedia` AND a backing block.
+ *   - `media`         — BOTH `capabilities.listingMedia` AND a backing block; on the
+ *                       AUTHORABLE statuses and on the repair state.
+ *                       🔴 The repair arm MIRRORS `listingMediaEditBlockedReason`, which
+ *                       returns `null` (editable) for an owner-unpublished listing and the
+ *                       moderator-takedown message otherwise. Offering this tab where that
+ *                       verdict is non-null would mount an editor over its own red alert.
  *                       🔴 The capability is the AUTHORITY here; the block check is the
  *                       renderability floor. That ordering used to be reversed — this arm
  *                       gated on block-presence ALONE, because `listingContent` was `true`
@@ -166,7 +251,9 @@ export type EditorTabContext = {
  * `appListingEditorTabs.test.ts` pins one case per direction, so dropping either clause
  * reddens exactly one of them.
  *
- *   - `collaborators` — every AUTHORABLE status, and NEVER on a non-authorable one. Seats
+ *   - `collaborators` — every AUTHORABLE status, and NEVER on a non-authorable one — the
+ *                       owner-repair state INCLUDED, which is why the repair branch is
+ *                       separate from `authorable` rather than folded into it. Seats
  *                       are listing-keyed, so both kinds have a roster, and
  *                       `appCollaborators.list` admits the OWNER **and** an ACCEPTED
  *                       editor. (Which CONTROLS render inside the panel is a separate,
@@ -191,9 +278,15 @@ export type EditorTabContext = {
 export function editorTabsFor(ctx: EditorTabContext): EditorTab[] {
   const tabs: EditorTab[] = [];
   // 🔴 THE SECURITY BRANCH. See the block above before touching it.
-  if (isAuthorableListingStatus(ctx.status)) {
+  const authorable = isAuthorableListingStatus(ctx.status);
+  // 🔴 THE REPAIR BRANCH — strictly narrower than `authorable`, and deliberately NOT a
+  // widening of `AUTHORABLE_LISTING_STATUSES`. See the block above.
+  const ownerRepair = isOwnerUnpublishedTabContext(ctx);
+  if (authorable || ownerRepair) {
     tabs.push('details');
     if (ctx.capabilities.listingMedia === true && ctx.appBlockId != null) tabs.push('media');
+  }
+  if (authorable) {
     if (ctx.capabilities.submitVersion === true && ctx.appBlockId != null) tabs.push('manifest');
     if (ctx.capabilities.earnings === true && ctx.appBlockId != null) tabs.push('earnings');
     tabs.push('collaborators');

--- a/src/components/Apps/appListingEditorTabs.ts
+++ b/src/components/Apps/appListingEditorTabs.ts
@@ -112,9 +112,19 @@ export type EditorTabContext = {
    * call sites pass the field (and `appListingEditorTabs.callers.test.ts` does, as
    * defence-in-depth for a caller added in a way the compiler cannot see — a `.js` file, an
    * `as any`, a spread of a wider object). But the compiler is what makes the NEXT caller
-   * impossible to get wrong, and it runs on every PR as `tekton / typecheck`, which the
-   * browser suite that covers this function does NOT. Pass `null` explicitly when the
-   * caller genuinely does not know — that is a decision, and it now reads as one.
+   * impossible to get wrong, and it runs on every PR as `tekton / typecheck` — which is the
+   * only check covering this function that actually BLOCKS.
+   *
+   * 🔴 BE PRECISE ABOUT THAT, because an earlier version of this comment overstated it as
+   * "the browser suite that covers this function does NOT run in CI". It does:
+   * `preview / component-tests` runs the `component` project. The real distinction is
+   * BLOCKING vs ANNOTATING — that check is report-only, and the `unit` job is
+   * `continue-on-error` on pull requests. So every test covering this field annotates; only
+   * the type gates. That is the argument for making it required, and it survives the
+   * correction intact.
+   *
+   * Pass `null` explicitly when the caller genuinely does not know — that is a decision, and
+   * it now reads as one.
    */
   lastModerationAction: string | null;
 };

--- a/src/components/Apps/myAppsView.ts
+++ b/src/components/Apps/myAppsView.ts
@@ -74,11 +74,17 @@ export type MyAppRow = {
    *
    * 🔴 ONLY MEANINGFUL WHEN `status === 'removed'`, and it is the only thing that separates
    * "I unpublished this and may put it back" from "a moderator removed this and only a
-   * moderator can restore it". `status` alone reads `removed` for both. Optional on the type
-   * so a fixture need not spell it; absent is read as a moderator removal, which is the safe
-   * direction (it withholds a button the server would refuse rather than inventing one).
+   * moderator can restore it". `status` alone reads `removed` for both.
+   *
+   * 🔴 REQUIRED, AND IT USED TO BE OPTIONAL "so a fixture need not spell it". That
+   * convenience is what let `myAppListingHref` drop the field on its way into
+   * `editorTabsFor` for a release — a fixture-ergonomics decision that bought a silent
+   * production defect (two different tab sets derived for one listing). It is never absent
+   * from the real `listMine` payload, so the type now says so and a fixture spells `null`.
+   * `null` still reads as a moderator removal, which is the safe direction: it withholds a
+   * button the server would refuse rather than inventing one.
    */
-  lastModerationAction?: string | null;
+  lastModerationAction: string | null;
   /**
    * The listing-completeness advisory (missing icon / cover / screenshots / description /
    * tagline / category), computed server-side by `computeListingProblems`.
@@ -304,6 +310,22 @@ export function myAppListingHref(row: {
   appBlockId: string | null;
   role: AppRole;
   status: string;
+  /**
+   * 🔴 THE SECOND HALF OF THE STATUS INPUT, AND THIS CALLER DROPPED IT FOR A RELEASE.
+   *
+   * `status='removed'` is written by BOTH an owner self-unpublish and a moderator
+   * takedown, so `status` alone cannot decide the tab set — `editorTabsFor` needs the
+   * last status-changing action to tell them apart. The authoring page passed it; this
+   * function did not, while the field was optional on `EditorTabContext`. The row handed
+   * in HAS it (`MyAppsBody` renders `ownerStateChip` off `row.lastModerationAction` at the
+   * same call site), so the two surfaces derived DIFFERENT tab sets for one listing: the
+   * page offered `details` + `media`, this href pointed at `?tab=publishing`.
+   *
+   * The field is now REQUIRED on `EditorTabContext`, so this parameter is what the
+   * compiler forces the caller to supply. Keep it required HERE too — making it optional
+   * on this row type would re-open the identical hole one level out.
+   */
+  lastModerationAction: string | null;
   capabilities: Readonly<Record<ListingCapability, boolean>>;
 }): string {
   const tabs: EditorTab[] = editorTabsFor({
@@ -311,6 +333,7 @@ export function myAppListingHref(row: {
     appBlockId: row.appBlockId,
     role: row.role,
     status: row.status,
+    lastModerationAction: row.lastModerationAction,
     capabilities: row.capabilities,
   });
   return listingEditHref(row.appListingId, tabs[0]);

--- a/src/components/Apps/offsiteEditConfig.ts
+++ b/src/components/Apps/offsiteEditConfig.ts
@@ -372,10 +372,7 @@ export function listingEditHeaderCopy(showUrlStep: boolean): ListingEditHeaderCo
 }
 
 /** True iff two string→string maps have identical keys + values. PURE. */
-function shallowEqualStringMap(
-  a: Record<string, string>,
-  b: Record<string, string>
-): boolean {
+function shallowEqualStringMap(a: Record<string, string>, b: Record<string, string>): boolean {
   const ak = Object.keys(a);
   if (ak.length !== Object.keys(b).length) return false;
   return ak.every((k) => a[k] === b[k]);

--- a/src/components/Apps/offsiteEditConfig.ts
+++ b/src/components/Apps/offsiteEditConfig.ts
@@ -91,6 +91,90 @@ export function isApprovedEdit(ctx: ListingEditContext): boolean {
 }
 
 /**
+ * True for an edit context whose live parent is UNPUBLISHED — the owner-repair state.
+ * PURE.
+ *
+ * 🔴 `status === 'removed'` IS SUFFICIENT *HERE*, AND ONLY BECAUSE OF WHERE THIS CONTEXT
+ * COMES FROM. `ListingEditContext` is `getMyListingForEdit`'s result, and that proc's
+ * `removed` branch reads the last STATUS-CHANGING moderation action on the PRIMARY and
+ * throws `FORBIDDEN` unless it is the owner's own `owner-unpublish`
+ * (`app-listing-owner-unpublish`). So a moderator takedown never produces a context at all
+ * — the form is not reached, `AppsListingDetailsEditor` renders its error alert instead.
+ * A `removed` context that EXISTS is therefore owner-unpublished by construction.
+ *
+ * 🔴 AND THE FAILURE DIRECTION IS SAFE IF THAT EVER STOPS BEING TRUE. Should a mod-removed
+ * listing somehow reach this form, this predicate still returns `true`, the material inputs
+ * are still disabled, and the author is still told the truth — the server would refuse
+ * every one of those edits anyway. The mistake this CANNOT make is enabling an input the
+ * server refuses, which is the whole point.
+ */
+export function isUnpublishedEdit(ctx: Pick<ListingEditContext, 'status'>): boolean {
+  return ctx.status === 'removed';
+}
+
+/**
+ * Why this listing's MATERIAL scalar fields cannot be edited right now, or `null` when they
+ * can. PURE.
+ *
+ * 🔴 THIS MIRRORS A REFUSAL THAT ALREADY EXISTS SERVER-SIDE; it does not invent a rule.
+ * `updateListing`'s `removed` branch throws `MATERIAL_CHANGE_BLOCKED` (→ `BAD_REQUEST`) for
+ * any change to a field in `MATERIAL_LISTING_PATCH_FIELDS`, and it does so AFTER the author
+ * has typed the change and pressed Save. Until the editor tabs opened on this state that
+ * was unreachable; opening them without this makes it four inputs an author can fill and
+ * can never save, which is strictly worse than not offering the field at all. The PREFILL
+ * being wider than the write is deliberate — an author must be able to READ their current
+ * name and URL — and that is a different thing from offering an EDIT.
+ *
+ * 🔴 THE COPY NAMES THE WAY OUT, because the server's message does and an author who is
+ * only told "no" has nowhere to go: republish, then edit, and the edit is staged for
+ * review.
+ *
+ * Kind-aware for the same reason the header is (`listingEditHeaderCopy`): an on-site
+ * listing has no App URL and is rendered no step that could change one, so naming it here
+ * would describe a field that is not on screen.
+ */
+export function materialEditBlockedReason(
+  ctx: Pick<ListingEditContext, 'status' | 'kind'>
+): string | null {
+  if (!isUnpublishedEdit(ctx)) return null;
+  const fields = isOnsiteEdit(ctx)
+    ? 'name, source repository and content rating'
+    : 'name, App URL, source repository and content rating';
+  return (
+    `This app is unpublished, so its ${fields} are locked. Changing any of them needs ` +
+    `moderator review, and an unpublished listing has no way to reach it. Republish the ` +
+    `app from the Publishing tab first, then edit those fields — the edit is staged for ` +
+    `review. Tagline, description and category can be edited now.`
+  );
+}
+
+/**
+ * Does the OAuth scope disclosure ALSO have to be locked in the repair state? PURE.
+ *
+ * 🔴 A JUSTIFICATION EDIT IS NORMALLY TRIVIAL, SO THIS IS NOT "LOCK IT WHEN UNPUBLISHED".
+ * `buildScalarPatch` emits `requestedScopes` when the justifications changed OR when the
+ * connect client's CURRENT `allowedScopes` has DRIFTED from the stored snapshot, and
+ * `materialPatchChanges` counts that key as material only when the two masks actually
+ * differ. So while they agree, a justification edit is trivial and saves fine here.
+ *
+ * 🔴 WHEN THEY HAVE DRIFTED, EVERY SAVE IS REFUSED — including a tagline-only one, because
+ * the drifted mask rides along on the patch. Leaving the justification boxes live in that
+ * state is the same defect as the material inputs, one field further out, so they are
+ * disabled and the reason says so. Detectable client-side because both masks are on the
+ * edit context; absent values read as `0` exactly as the server's `?? 0` does.
+ */
+export function scopeDisclosureLockedForEdit(
+  ctx: Pick<
+    ListingEditContext,
+    'status' | 'kind' | 'connectClientId' | 'connectAllowedScopes' | 'connectRequestedScopes'
+  >
+): boolean {
+  if (materialEditBlockedReason(ctx) == null) return false;
+  if (ctx.connectClientId == null) return false;
+  return (ctx.connectAllowedScopes ?? 0) !== (ctx.connectRequestedScopes ?? 0);
+}
+
+/**
  * Map the edit prefill payload → the wizard form values. `slug` is filled from the
  * parent (shown read-only in edit mode); `changelog` starts blank (an edit note is
  * optional). A null tagline/description becomes '' (the form's blank), and a

--- a/src/components/Apps/offsiteEditConfig.ts
+++ b/src/components/Apps/offsiteEditConfig.ts
@@ -49,6 +49,19 @@ export type ListingEditContext = {
    */
   kind?: 'onsite' | 'offsite';
   status: string;
+  /**
+   * The CALLER's role on this listing — `owner`, or `editor` for an accepted seat.
+   *
+   * 🔴 OPTIONAL, AND ABSENT IS TREATED AS "ROLE UNKNOWN" RATHER THAN AS "OWNER". Optional
+   * for the same reason `kind` is: every pre-existing fixture predates the field. But the
+   * fail-safe here runs the OTHER way from a normal narrowing — an unknown role must not
+   * be told "you unpublished it" or "republish it from the Publishing tab", because those
+   * are false for an editor and there is no way to tell from absence. So
+   * {@link materialEditBlockedReason} emits ROLE-NEUTRAL wording when this is absent,
+   * which is true for both, and the owner-specific phrasing only on a positive `'owner'`.
+   * See {@link isOwnerEdit}.
+   */
+  role?: 'owner' | 'editor';
   hasPendingRevision: boolean;
   shadowId: string | null;
   scalars: {
@@ -134,18 +147,85 @@ export function isUnpublishedEdit(ctx: Pick<ListingEditContext, 'status'>): bool
  * would describe a field that is not on screen.
  */
 export function materialEditBlockedReason(
-  ctx: Pick<ListingEditContext, 'status' | 'kind'>
+  ctx: Pick<
+    ListingEditContext,
+    | 'status'
+    | 'kind'
+    | 'role'
+    | 'connectClientId'
+    | 'connectAllowedScopes'
+    | 'connectRequestedScopes'
+  >
 ): string | null {
   if (!isUnpublishedEdit(ctx)) return null;
   const fields = isOnsiteEdit(ctx)
     ? 'name, source repository and content rating'
     : 'name, App URL, source repository and content rating';
+
+  // 🔴 ROLE-AWARE, AND THE DEFAULT IS THE NEUTRAL ONE — see `ListingEditContext.role`.
+  // `loadOwnedEditableListing` admits an accepted editor seat, so this copy is read by
+  // people who did NOT unpublish the app and who cannot see the Publishing tab
+  // (`editorTabsFor` makes `publishing` owner-only). Naming that tab at an editor is an
+  // instruction they cannot follow, so they are pointed at the person who can.
+  const wayOut = isOwnerEdit(ctx)
+    ? `Republish the app from the Publishing tab first, then edit those fields — the ` +
+      `edit is staged for review.`
+    : `The app's owner has to republish it before those fields can be edited — the ` +
+      `Publishing tab that does it is theirs, not yours.`;
+
+  // 🔴 THE SCOPE-DRIFT ARM, AND IT EXISTS BECAUSE THE OLD LAST SENTENCE WAS FALSE IN
+  // EXACTLY THE STATE `scopeDisclosureLockedForEdit` EXISTS FOR.
+  //
+  // It ended "Tagline, description and category can be edited now." When the connect
+  // client's `allowedScopes` have DRIFTED from the stored snapshot, that is untrue and the
+  // screen is a hard dead end:
+  //
+  //   - `buildScalarPatch` emits the drifted `requestedScopes` on EVERY save, so even a
+  //     tagline-only edit carries a material change and the server refuses it; and
+  //   - `handleSave` runs `scopeJustificationError(values)` for any connect listing, and a
+  //     newly-added sensitive scope has no prefilled justification (`editContextToForm`
+  //     prunes justifications to the DERIVED mask), so the save aborts CLIENT-side first
+  //     and steers the author to Details — where `scopeDisclosureLockedForEdit` has
+  //     disabled the very boxes that would clear the error.
+  //
+  // So the author was invited to edit three fields, and could not save any of them, with
+  // the copy insisting otherwise. The outcome is honest (the server would refuse too); the
+  // sentence was not. Say the true thing instead — nothing here can be saved until the
+  // scopes are re-reviewed — rather than describing an edit that cannot land.
+  if (scopeDisclosureLockedForEdit(ctx)) {
+    const scopeWayOut = isOwnerEdit(ctx)
+      ? `republish the app from the Publishing tab`
+      : `ask the app's owner to republish it`;
+    return (
+      `This app is unpublished, so its ${fields} are locked — and your OAuth app's ` +
+      `permissions have changed since this listing was last reviewed. That changed ` +
+      `permission set rides along on every save, so while the app stays unpublished ` +
+      `NOTHING on this screen can be saved — not the tagline, description or category ` +
+      `either. To edit anything, ${scopeWayOut}; the new permissions are then reviewed ` +
+      `along with your changes.`
+    );
+  }
+
   return (
     `This app is unpublished, so its ${fields} are locked. Changing any of them needs ` +
-    `moderator review, and an unpublished listing has no way to reach it. Republish the ` +
-    `app from the Publishing tab first, then edit those fields — the edit is staged for ` +
-    `review. Tagline, description and category can be edited now.`
+    `moderator review, and an unpublished listing has no way to reach it. ${wayOut} ` +
+    `Tagline, description and category can be edited now.`
   );
+}
+
+/**
+ * Is the caller the listing's OWNER? PURE.
+ *
+ * 🔴 FAIL-SAFE DEFAULT IS `false`, i.e. "not proven to be the owner" — and that direction is
+ * the opposite of what a narrowing usually wants, so it is worth stating why. This predicate
+ * does not gate a capability; it only picks which SENTENCE the author reads. The owner
+ * phrasing asserts two things an editor would find false ("you unpublished it", "republish
+ * it from the Publishing tab" — a tab `editorTabsFor` withholds from an editor). The
+ * role-neutral phrasing is true for BOTH. So an absent role must resolve to the neutral
+ * copy, never to the owner copy.
+ */
+export function isOwnerEdit(ctx: Pick<ListingEditContext, 'role'>): boolean {
+  return ctx.role === 'owner';
 }
 
 /**
@@ -169,7 +249,15 @@ export function scopeDisclosureLockedForEdit(
     'status' | 'kind' | 'connectClientId' | 'connectAllowedScopes' | 'connectRequestedScopes'
   >
 ): boolean {
-  if (materialEditBlockedReason(ctx) == null) return false;
+  // 🔴 `isUnpublishedEdit`, NOT `materialEditBlockedReason` — AND THE TWO ARE EQUIVALENT
+  // HERE BY CONSTRUCTION, so this is not a weakening. `materialEditBlockedReason` returns
+  // non-null IFF `isUnpublishedEdit(ctx)` is true; its first line IS that check. This used
+  // to call it and read the result for null, which was fine until
+  // `materialEditBlockedReason` grew a scope-drift arm that calls THIS function — a cycle
+  // (`materialEditBlockedReason` → `scopeDisclosureLockedForEdit` → `materialEditBlocked-
+  // Reason` → …). Depending on the narrower predicate breaks it and states the real
+  // precondition directly: the lock applies in the unpublished state.
+  if (!isUnpublishedEdit(ctx)) return false;
   if (ctx.connectClientId == null) return false;
   return (ctx.connectAllowedScopes ?? 0) !== (ctx.connectRequestedScopes ?? 0);
 }

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -58,6 +58,15 @@ import { trpc } from '~/utils/trpc';
  * its own enforcement point (`inviteCollaborator` / `respondToInvite` refuse a non-authorable
  * listing), because a tab set is a UI narrowing and never a gate.
  *
+ * 🔴 AND THE SET NOW ALSO READS `lastModerationAction`, because `status` alone cannot answer
+ * the question on `removed`. civitai/civitai#4413 taught the SERVER to tell an owner
+ * self-unpublish from a moderator takedown and to accept repair edits on the former; this
+ * page is what makes that reachable. An owner-unpublished listing regains Details + Media
+ * (each rendered in a repair-aware mode — see `ExternalListingEditForm`'s locked material
+ * fields and `ListingMediaEditor`'s unpublished frame); a moderator-delisted one still gets
+ * the narrowed set, and `AUTHORABLE_LISTING_STATUSES` is deliberately NOT widened, because
+ * its other consumer is the server gate on collaborator invites.
+ *
  * Access is single-sourced at the tRPC layer: `appListings.getAuthoringContext` resolves
  * the caller's role (owner OR accepted editor) and throws FORBIDDEN/NOT_FOUND otherwise
  * — both settle to `NotFound` here, which is the established non-enumerable posture.
@@ -155,6 +164,14 @@ export default function AppListingEditPage() {
     // set to at most Publishing + History — no Details, and above all no Collaborators.
     // See `editorTabsFor`; the page must never hardcode a tab past this derivation.
     status: context.status,
+    // 🔴 THE SECOND HALF OF THAT INPUT, and without it `status` cannot answer the question.
+    // `removed` is written by BOTH an owner self-unpublish and a moderator takedown; the
+    // server (civitai/civitai#4413) lets the owner repair the FIRST and still refuses the
+    // second, so the tab set has to read the same bit or the page offers a surface the
+    // procs refuse (or withholds one they accept). Arrives NORMALISED
+    // (`owner-unpublish` | `other` | null) — a seated editor never receives a moderator's
+    // actual verb. Same field the Publishing tab already branches on, two panels down.
+    lastModerationAction: context.lastModerationAction,
     capabilities: context.capabilities,
   });
   const tab = resolveEditorTab(router.query.tab, tabs);

--- a/src/server/services/blocks/__tests__/app-access.editor-tabs.seam.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.editor-tabs.seam.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 /**
  * 🔴 THE SEAM: `getAppListingAuthoringContext` (server) → `editorTabsFor` (client).

--- a/src/server/services/blocks/__tests__/app-access.editor-tabs.seam.test.ts
+++ b/src/server/services/blocks/__tests__/app-access.editor-tabs.seam.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE SEAM: `getAppListingAuthoringContext` (server) → `editorTabsFor` (client).
+ *
+ * Both halves are hermetically tested already, and BOTH suites are green on a tree where
+ * the owner-repair loop has no UI: `app-access.accessible-listings.test.ts` proves the
+ * server projects `lastModerationAction`, and `appListingEditorTabs.test.ts` proves the tab
+ * set branches on it — with a fixture the test wrote by hand. Neither ever builds the
+ * COMBINED state, so neither can see the bit failing to travel: a rename, a normalisation
+ * that flattens the distinction, or the page simply not passing the field would leave both
+ * suites passing while the feature is dark. That is the defect class this file exists for,
+ * and #4401's `messageAppOwner` (a live proc with zero UI callers, still dark) is the
+ * worked example of it in this codebase.
+ *
+ * 🔴 IT PINS A RELATIONSHIP, NOT A COMPONENT: the REAL service (with its real query, its
+ * real normalisation and its real fail-closed arms) feeding the REAL tab derivation. The
+ * only thing faked is Postgres — and the moderation-event fake INTERPRETS the `where`
+ * rather than returning a canned row, so the query's own `action: { in: … }` filter is
+ * observable here. A canned fake would make the filter unobservable and every mutant to it
+ * would pass.
+ *
+ * 🔴 WHY THE FILTER MATTERS AT THIS SEAM. `AppListingModerationEvent` is a moderator
+ * ACTIVITY log, not a state log: `message-owner`, `report-resolve` / `report-dismiss` and
+ * `claim` change no listing status. A moderator messaging an owner *"fix X and republish"*
+ * — the most natural workflow this feature has — would otherwise push `message-owner` in
+ * front of the owner's own `owner-unpublish` and silently revoke the repair tabs. The tab
+ * gate has no way to notice; only the query's filter stops it.
+ */
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { getAppListingAuthoringContext } from '~/server/services/blocks/app-access.service';
+import { editorTabsFor } from '~/components/Apps/appListingEditorTabs';
+
+/**
+ * 🔴 NO PER-FILE MOCK OF THE DB CLIENT HERE — the CANONICAL shared mock, registered once in
+ * `src/__tests__/setup.ts`, is used instead. A per-file db mock freezes its own partial shape
+ * into every later file in the same worker under `--no-isolate`; `no-direct-shared-module-mock`
+ * is the ratchet that stops a new one being added. See docs/testing/shared-module-mocks.md.
+ * (That guard scans this file's TEXT, so it must not spell the specifier inside a mock call
+ * even in prose — hence the wording.)
+ */
+const mockDb = dbMock.dbRead;
+const mockWriteDb = dbMock.dbWrite;
+
+const OWNER = 10;
+
+type Event = { action: string; createdAt: number; id: string };
+
+/**
+ * A moderation-event table that EVALUATES the query's `where` + `orderBy` the way Postgres
+ * would. It filters on `where.action.in` and sorts `createdAt desc, id desc` — the exact
+ * two things `readLastModerationAction` relies on and the exact two a mutant would break.
+ */
+function withEvents(events: Event[]) {
+  const impl = async (...a: unknown[]) => {
+    const args = a[0] as {
+      where: { appListingId: string; action?: { in?: string[] } };
+      orderBy: unknown;
+      select: { action: boolean };
+    };
+    const allowed = args.where.action?.in;
+    const rows = events
+      .filter((e) => allowed == null || allowed.includes(e.action))
+      .sort((x, y) => y.createdAt - x.createdAt || y.id.localeCompare(x.id));
+    return rows.length > 0 ? { action: rows[0].action } : null;
+  };
+  mockDb.appListingModerationEvent.findFirst.mockImplementation(impl);
+  mockWriteDb.appListingModerationEvent.findFirst.mockImplementation(impl);
+}
+
+/** The two `findUnique` reads `getAppListingAuthoringContext` makes, discriminated by select. */
+function withListing(status: string) {
+  mockDb.appListing.findUnique.mockImplementation(async (...a: unknown[]) =>
+    (a[0] as { select?: { connectClientId?: boolean } }).select?.connectClientId
+      ? { id: 'apl_1', slug: 'my-app', name: 'My App', status, connectClientId: null }
+      : {
+          id: 'apl_1',
+          userId: OWNER,
+          kind: 'onsite',
+          appBlockId: 'ab_1',
+          revisionOfId: null,
+          appBlock: { app: { userId: OWNER } },
+          revisionOf: null,
+        }
+  );
+}
+
+/** The page's OWN derivation, verbatim — see `/apps/listing/[appListingId]/edit`. */
+async function tabsForListing(status: string, events: Event[]) {
+  withListing(status);
+  withEvents(events);
+  const ctx = await getAppListingAuthoringContext({ appListingId: 'apl_1', userId: OWNER });
+  return {
+    lastModerationAction: ctx.lastModerationAction,
+    tabs: editorTabsFor({
+      kind: ctx.kind,
+      appBlockId: ctx.appBlockId,
+      role: ctx.role,
+      status: ctx.status,
+      lastModerationAction: ctx.lastModerationAction,
+      capabilities: ctx.capabilities,
+    }),
+  };
+}
+
+beforeEach(() => {
+  // 🔴 PER-TEST, because `resetSharedMocks()` runs once per FILE. Without this the call-count
+  // assertion in the approved case would count every earlier case's reads and pass (or fail)
+  // for reasons unrelated to it.
+  mockDb.appListing.findUnique.mockReset();
+  mockDb.appListingModerationEvent.findFirst.mockReset();
+  mockWriteDb.appListingModerationEvent.findFirst.mockReset();
+  mockDb.appCollaborator.findFirst.mockReset();
+  mockWriteDb.appCollaborator.findFirst.mockReset();
+  mockDb.appCollaborator.findFirst.mockImplementation(async () => null);
+  mockWriteDb.appCollaborator.findFirst.mockImplementation(async () => null);
+});
+
+describe('🔴 the owner-repair bit survives the whole trip: DB row → normalisation → tab set', () => {
+  it('🔴 an OWNER self-unpublish ends with Details + Media actually offered', async () => {
+    const { lastModerationAction, tabs } = await tabsForListing('removed', [
+      { action: 'owner-unpublish', createdAt: 100, id: 'ev_1' },
+    ]);
+    // The intermediate value is asserted as well as the end state, so a failure says WHICH
+    // half broke instead of only that the seam did.
+    expect(lastModerationAction).toBe('owner-unpublish');
+    expect(tabs).toEqual(['details', 'media', 'publishing', 'history']);
+  });
+
+  it('🔴 a MODERATOR takedown ends with them withheld — the same trip, opposite answer', async () => {
+    const { lastModerationAction, tabs } = await tabsForListing('removed', [
+      { action: 'owner-unpublish', createdAt: 100, id: 'ev_1' },
+      { action: 'delist', createdAt: 200, id: 'ev_2' },
+    ]);
+    // Normalised on the way out, so the seated-editor disclosure boundary holds here too.
+    expect(lastModerationAction).toBe('other');
+    expect(tabs).toEqual(['publishing', 'history']);
+  });
+
+  it('🔴 a STATE-NEUTRAL event on top of the unpublish does NOT revoke the repair tabs', async () => {
+    // The workflow the filter exists for: the owner takes the app down, a moderator then
+    // messages them about it. `message-owner` is NEWER but changes no status, so it must not
+    // displace the event that explains the removal. Driven over all four neutral verbs, each
+    // strictly newer than the unpublish.
+    for (const verb of ['message-owner', 'report-resolve', 'report-dismiss', 'claim'] as const) {
+      const { lastModerationAction, tabs } = await tabsForListing('removed', [
+        { action: 'owner-unpublish', createdAt: 100, id: 'ev_1' },
+        { action: verb, createdAt: 300, id: 'ev_9' },
+      ]);
+      expect(lastModerationAction, verb).toBe('owner-unpublish');
+      expect(tabs, verb).toEqual(['details', 'media', 'publishing', 'history']);
+    }
+  });
+
+  it('🔴 a STATUS-CHANGING event on top of it DOES — the control for the case above', async () => {
+    // Same shape, same ordering, one field different: `relist` is in the status-changing
+    // half of the partition, so it legitimately displaces the unpublish. Without this arm
+    // the neutral case above would also pass on an implementation that ignores the newest
+    // event entirely.
+    const { lastModerationAction, tabs } = await tabsForListing('removed', [
+      { action: 'owner-unpublish', createdAt: 100, id: 'ev_1' },
+      { action: 'relist', createdAt: 300, id: 'ev_9' },
+    ]);
+    expect(lastModerationAction).toBe('other');
+    expect(tabs).toEqual(['publishing', 'history']);
+  });
+
+  it('🔴 NO events at all fails closed all the way to the tab set', async () => {
+    const { lastModerationAction, tabs } = await tabsForListing('removed', []);
+    expect(lastModerationAction).toBeNull();
+    expect(tabs).toEqual(['publishing', 'history']);
+  });
+
+  it('🔴 the tie-break decides a same-timestamp pair, and it reaches the tabs', async () => {
+    // Two events written in one transaction share a `createdAt`; `id desc` is what makes the
+    // answer deterministic rather than planner-dependent. A non-deterministic answer here
+    // flips the owner's content tabs on and off at random between page loads.
+    const { tabs } = await tabsForListing('removed', [
+      { action: 'owner-unpublish', createdAt: 100, id: 'ev_a' },
+      { action: 'delist', createdAt: 100, id: 'ev_b' },
+    ]);
+    expect(tabs).toEqual(['publishing', 'history']);
+  });
+
+  it('🔴 an APPROVED listing never reads the event at all, and keeps the full set', async () => {
+    // The control arm for the whole file: it proves the pipeline above is doing work on
+    // `removed` specifically, and pins that a stale `owner-unpublish` on a relisted app costs
+    // no round trip and changes nothing.
+    const { lastModerationAction, tabs } = await tabsForListing('approved', [
+      { action: 'owner-unpublish', createdAt: 100, id: 'ev_1' },
+    ]);
+    expect(lastModerationAction).toBeNull();
+    expect(mockDb.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+    expect(tabs).toEqual([
+      'details',
+      'media',
+      'manifest',
+      'earnings',
+      'collaborators',
+      'publishing',
+      'history',
+    ]);
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -151,6 +151,11 @@ beforeEach(() => {
   seq.n = 0;
   mockRead.appListing.findUnique.mockResolvedValue(null);
   mockRead.appListing.findFirst.mockResolvedValue(null);
+  // 🔴 EXPLICIT, because `vi.clearAllMocks()` clears CALLS but not IMPLEMENTATIONS — a
+  // `mockResolvedValue` set by one case survives into every later case in the file. The
+  // hoisted factory's "no seat" default therefore only holds until the first test that
+  // wires a seat, and the leak lands on the NEXT non-owner case as a spurious pass.
+  mockRead.appCollaborator.findFirst.mockResolvedValue(null);
   mockRead.appListingScreenshot.findMany.mockResolvedValue([]);
   mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
   mockRead.oauthClient.findUnique.mockResolvedValue(null);
@@ -471,6 +476,56 @@ describe('getMyListingForEdit', () => {
     await expect(getMyListingForEdit({ listingId: 'nope', userId: 7 })).rejects.toBeInstanceOf(
       OffsiteRequestError
     );
+  });
+
+  /**
+   * 🔴 THE RESOLVED ROLE, ASSERTED BY VALUE — the sibling `getMyListingForApp` already has
+   * this pair (`offsite-listing.get-my-listing-for-app.service.test.ts`) and this proc did
+   * not, which is a real hole rather than a symmetry nit.
+   *
+   * ~20 cases above call `getMyListingForEdit` and none of them mentions `role`. The
+   * explicit `Promise<GetMyListingForEditResult>` annotation catches the field being
+   * DROPPED, so the surviving mutation is the one that keeps the field and gets its VALUE
+   * wrong: hardcode `role: 'owner'` in place of `listing.callerRole` and the whole unit
+   * suite stays green. Downstream that is not cosmetic — `isOwnerEdit` branches the entire
+   * repair-state copy on this one string, so a seated editor would be told "you unpublished
+   * it" and sent to a Publishing tab `editorTabsFor` withholds from them.
+   *
+   * The pair is what makes it discriminating. One case on an owner fixture cannot see a
+   * hardcoded `'owner'` at all; the editor case is the arm that can, and it is built on a
+   * listing owned by SOMEBODY ELSE so the fixture is incapable of producing `'owner'` by
+   * accident.
+   */
+  describe('🔴 the CALLER ROLE is returned by value, not assumed', () => {
+    const EDITOR = 42;
+
+    it('returns the OWNER role for the listing owner', async () => {
+      wireFindUnique(ownedRow({ status: 'draft' }), { apl_parent: editViewRow('ss_parent') });
+
+      const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+      expect(res.role).toBe('owner');
+    });
+
+    it('🔴 returns the EDITOR role for an ACCEPTED SEAT — this proc is not owner-only', async () => {
+      // 🔴 `userId: 7` stays on the ROW while the CALLER is 42, so the caller cannot be the
+      // owner however `resolveCanonicalListingOwner` resolves it (offsite ⇒ the column). A
+      // fixture whose caller is also the owner could only ever produce `'owner'` and would
+      // be blind to the hardcoding mutant — which is exactly how this survived.
+      wireFindUnique(ownedRow({ status: 'draft' }), { apl_parent: editViewRow('ss_parent') });
+      mockRead.appCollaborator.findFirst.mockResolvedValue({
+        id: 'acol_1',
+        appListingId: 'apl_parent',
+        userId: EDITOR,
+        status: 'accepted',
+        role: 'editor',
+      });
+
+      const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: EDITOR });
+      expect(res.role).toBe('editor');
+      // The discriminating control: the two roles must actually DIFFER on this proc, or a
+      // mutant that hardcodes `'owner'` passes the case above and nothing here can see it.
+      expect(res.role).not.toBe('owner');
+    });
   });
 });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -270,6 +270,64 @@ describe('getMyListingForApp', () => {
     expect(mockRead.appListingPublishRequest.findFirst).not.toHaveBeenCalled();
   });
 
+  /**
+   * 🔴 THE SEAM: the proc RESOLVES a role, and `ListingMediaEditor` BRANCHES on it.
+   *
+   * Nothing bound those two together, which is exactly the shape that stays broken while
+   * both sides look tested. `listing-media-page.browser.test.tsx` STUBS this query, so it
+   * asserts what the component does with a `role` it was handed — it cannot notice the
+   * server no longer sending one. And the cases above assert this proc's other fields
+   * without ever mentioning `role`. Drop `role` from the return and every one of those
+   * tests still passes, while `listing?.role === 'owner'` silently becomes `false` for
+   * OWNERS and every owner reads the collaborator copy.
+   *
+   * So this asserts the PRODUCED value, per role, on the same fixture — the half the
+   * component tests structurally cannot cover.
+   */
+  it('🔴 returns the OWNER role — the media editor branches its copy on this', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
+    });
+    withShadow('apl_shadow');
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+    expect(res.role).toBe('owner');
+  });
+
+  it('🔴 returns the EDITOR role for an ACCEPTED SEAT — this proc is not owner-only', async () => {
+    // 🔴 The listing is owned by someone ELSE and the call still succeeds, which is the
+    // whole point: the gate is `resolveListingRole(...) === null`, not an ownership
+    // comparison. Reading it as owner-only is what produced copy telling a seated editor
+    // "you unpublished it" and pointing them at an owner-only Publishing tab.
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OTHER, status: 'approved', contentRating: 'pg13' },
+      // 🔴 `userId: OTHER` on the OWNED row too, not just the entry — `resolveListingAccess`
+      // reads THIS row to decide ownership. Leaving it as the default OWNER makes the caller
+      // the owner and the seat is never consulted, so the case would assert 'editor' against
+      // a fixture that can only ever produce 'owner'.
+      owned: ownedRow({ userId: OTHER, appBlock: { app: { userId: OTHER } } }),
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
+    });
+    withShadow('apl_shadow');
+    // An ACCEPTED seat on the LISTING for the caller.
+    mockRead.appCollaborator.findFirst.mockResolvedValue({
+      id: 'acol_1',
+      appListingId: 'apl_onsite',
+      userId: OWNER,
+      status: 'accepted',
+      role: 'editor',
+    });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+    expect(res.role).toBe('editor');
+    // The discriminating control: the two roles must actually DIFFER on this proc, or a
+    // mutant that hardcodes `'owner'` passes the case above and this one is the only thing
+    // that can see it.
+    expect(res.role).not.toBe('owner');
+  });
+
   it('no listing row for the app → NOT_FOUND', async () => {
     mockRead.appListing.findUnique.mockResolvedValue(null);
 

--- a/src/server/services/blocks/app-access.service.ts
+++ b/src/server/services/blocks/app-access.service.ts
@@ -1373,11 +1373,37 @@ export async function getAppListingAuthoringContext(opts: {
    * did. Same keyset (`orderBy desc` + `take 1`) the batched list read uses, and the same
    * NORMALISATION on the way out.
    *
-   * 🔴 THE REPLICA IS CORRECT HERE and it is the opposite call from the one the SERVER
-   * gates make. This value only decides which BUTTON the Publishing tab renders; the
-   * mutation behind it re-checks on the primary inside its own transaction
-   * (`republishOwnListing`), so a stale read costs at worst one refused click. The gates
-   * in `offsite-listing.service` pass `dbWrite` because there a stale read would GRANT.
+   * 🔴 THE REPLICA IS STILL CORRECT HERE, BUT NOT FOR THE REASON THIS COMMENT USED TO GIVE.
+   * It said the value "only decides which BUTTON the Publishing tab renders". That stopped
+   * being true in civitai/civitai#4431: the field is now also an input to `editorTabsFor`,
+   * so it decides the TAB SET — whether the owner-repair branch opens `details` and `media`
+   * on a `removed` listing at all. It is a wider blast radius than one button, and anyone
+   * re-deriving the replica-vs-primary choice from the old sentence would be reasoning from
+   * a premise that no longer holds.
+   *
+   * 🔴 THE CHOICE SURVIVES THAT WIDENING BECAUSE THE DIRECTION IS SAFE, WHICH IS A CLAIM
+   * ABOUT THE LAG'S SIGN, NOT ABOUT ITS SIZE. The only value this read can be stale in
+   * FAVOUR of is an older event — concretely, a lagging replica can still show the owner's
+   * own `owner-unpublish` after a moderator has just written a `delist`. That is the
+   * PERMISSIVE direction, and it is the one that matters, so spell out why it is still not
+   * an escalation:
+   *
+   *   - The wide tab set is a UI narrowing, never a gate — the standing rule for this
+   *     function. A stale-wide `details`/`media` offers surfaces whose procs
+   *     (`getMyListingForEdit`, `updateListing`, `getMyListingForApp`, and the owner asset
+   *     procs) each re-read the last moderation action on the PRIMARY inside their own
+   *     gate. So the tab opens and the panel behind it refuses. One wasted click, not a
+   *     write.
+   *   - `publishing` does not widen at all here: it is gated on `isPublishableListingStatus`
+   *     + `role`, neither of which reads this value, and `republishOwnListing` re-checks on
+   *     the primary in its own transaction.
+   *   - The reverse staleness (a fresh `delist` visible, an older `owner-unpublish` hidden)
+   *     is the RESTRICTIVE direction and costs the owner nothing but a refresh.
+   *
+   * The gates in `offsite-listing.service` pass `dbWrite` precisely because there the same
+   * permissive staleness would GRANT rather than merely OFFER. That asymmetry — offer here,
+   * grant there — is the whole reason the two callers read different pools, and it is what
+   * must be re-checked if this value ever gains a THIRD consumer that acts on it directly.
    */
   const lastAction =
     row.status === 'removed' ? await readLastModerationAction(dbRead, access.seatListingId) : null;

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -968,6 +968,15 @@ type EditableListing = {
   kind: string;
   slug: string;
   status: string;
+  /**
+   * The CALLER's role on this listing, as resolved by the access gate in
+   * {@link loadOwnedEditableListing} — never `null`, because a null role throws there.
+   *
+   * 🔴 NOT THE SAME THING AS `userId` BELOW, and conflating them is the bug this exists to
+   * prevent. `userId` is the listing's denormalized OWNER column; `callerRole` is who the
+   * CALLER is relative to this row. They differ for every accepted editor seat.
+   */
+  callerRole: AppRole;
   userId: number;
   revisionOfId: string | null;
   name: string;
@@ -1093,7 +1102,14 @@ async function loadOwnedEditableListing(
   if (!listing) {
     throw new OffsiteRequestError('NOT_FOUND', `listing ${listingId} not found`);
   }
-  if ((await resolveListingRole(listingId, userId)) === null) {
+  // 🔴 THE RESOLVED ROLE IS KEPT AND RETURNED, not merely null-checked — and note that
+  // this function's NAME oversells its gate. It admits the OWNER *or* an accepted editor
+  // seat (that is what `resolveListingRole` returns non-null for); "Owned" here means "you
+  // hold a role on it", not "you own it". Callers that need to distinguish the two — the
+  // repair-state copy does, because Republish is owner-only — read `callerRole` rather
+  // than re-deriving it from a second read or from the session.
+  const callerRole = await resolveListingRole(listingId, userId);
+  if (callerRole === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only edit your own listings');
   }
   // Guarded second read for the MANUAL-APPLY `source_repo_url` column — see the
@@ -1103,6 +1119,7 @@ async function loadOwnedEditableListing(
   const sourceRepo: ListingSourceRepoRead = await readListingSourceRepoUrl(listingId, dbRead);
   return {
     ...listing,
+    callerRole,
     sourceRepoUrl: sourceRepo.value,
     sourceRepoAvailable: sourceRepo.available,
   };
@@ -1645,6 +1662,18 @@ export type GetMyListingForEditResult = {
   slug: string;
   /** The parent's status (draft | pending | approved). */
   status: string;
+  /**
+   * The CALLER's role on this listing — `owner` or an accepted `editor` seat.
+   *
+   * 🔴 SAME REASON AS `GetMyListingForAppResult.role`, AND THE SAME MISREADING TO CORRECT.
+   * `loadOwnedEditableListing` is named for ownership but gates on
+   * `resolveListingRole(...) === null`, so an accepted editor reaches this prefill. The
+   * unpublished-state copy (`materialEditBlockedReason`) tells the caller to "republish the
+   * app from the Publishing tab" — owner-only in `editorTabsFor`, so for an editor that is
+   * an instruction they cannot follow. The role is resolved by the gate anyway; returning
+   * it is what lets the copy say the true thing to each.
+   */
+  role: AppRole;
   /** True when an in-flight shadow revision is already under review. */
   hasPendingRevision: boolean;
   /**
@@ -1908,6 +1937,7 @@ export async function getMyListingForEdit(opts: {
     kind: listing.kind,
     slug: listing.slug,
     status: listing.status,
+    role: listing.callerRole,
     hasPendingRevision,
     shadowId,
     scalars: view.scalars,
@@ -1924,6 +1954,19 @@ export type GetMyListingForAppResult = {
   appListingId: string;
   /** The listing's TRUE lifecycle status (`draft|pending|approved|rejected|removed`). */
   status: string;
+  /**
+   * The CALLER's role on this listing — `owner` or an accepted `editor` seat.
+   *
+   * 🔴 THIS PROC HAS NEVER BEEN OWNER-ONLY, and the media editor's copy assumed it was.
+   * The gate below is `resolveListingRole(...) === null`, which admits an accepted
+   * collaborator; the role it resolves was then thrown away. So `ListingMediaEditor` had no
+   * way to tell the two apart and told an editor "you unpublished it" and "republish it
+   * from the Publishing tab" — a thing they did not do, and a tab `editorTabsFor` does not
+   * give them (`publishing` is owner-only). Returning the role the gate ALREADY computes is
+   * what lets the copy be true for both, without a second access read and without the
+   * component guessing from the session.
+   */
+  role: AppRole;
   /** The listing's stored content rating (drives the asset NSFW-scan threshold). */
   contentRating: string;
   /** Whether a shadow-revision publish request is already under review for this listing. */
@@ -2100,7 +2143,12 @@ export async function getMyListingForApp(opts: {
   // it for every caller to improve one error string on a race with a moderator delete.
   // Written down rather than left as a puzzle for whoever next reads a NOT_OWNED in the
   // logs for a listing that no longer exists.
-  if ((await resolveListingRole(listing.id, userId)) === null) {
+  // 🔴 KEEP THE RESOLVED ROLE — it is returned, not just null-checked. The copy in
+  // `ListingMediaEditor` branches on it (an editor is not told they unpublished the app,
+  // nor pointed at an owner-only Publishing tab). Discarding it here is what forced that
+  // component to have no answer.
+  const callerRole = await resolveListingRole(listing.id, userId);
+  if (callerRole === null) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');
   }
   // A pending revision REQUEST (not mere shadow existence) drives the "already
@@ -2154,6 +2202,7 @@ export async function getMyListingForApp(opts: {
   return {
     appListingId: listing.id,
     status: listing.status,
+    role: callerRole,
     // Nullable column; fall back to the safest rating so the asset step's scan
     // threshold is always defined.
     contentRating: listing.contentRating ?? 'g',

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -29,6 +29,7 @@ import {
   type PersistListingAssetImageInput,
   type SubmitExternalListingInput,
 } from '~/server/schema/blocks/offsite-listing.schema';
+import { MATERIAL_LISTING_PATCH_FIELDS } from '~/shared/constants/app-capabilities.constants';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
 import {
   connectScopesSubsetOfCeiling,
@@ -747,8 +748,16 @@ async function closeTerminalListing(
  * rather than going live silently. Like `externalUrl` it compares against the
  * validator's CANONICAL form, so re-saving `…/a/b` as `…/a/b.git` is correctly seen
  * as no change and does not cost a pointless mod re-review.
+ *
+ * 🔴 THE LIST ITSELF NOW LIVES IN `shared/`, and this is an ALIAS of it — not a copy. The
+ * EDIT FORM has to disable exactly these inputs while a listing is unpublished (the
+ * `removed` branch below refuses them with `MATERIAL_CHANGE_BLOCKED`), and it cannot import
+ * this module: `offsite-listing.service` top-level-imports `~/server/db/client`, so reading
+ * the list from here would drag Prisma into the browser bundle. A second literal in the
+ * component is how the form starts offering a field the server refuses. See
+ * {@link MATERIAL_LISTING_PATCH_FIELDS}.
  */
-const MATERIAL_PATCH_FIELDS = ['externalUrl', 'name', 'contentRating', 'sourceRepoUrl'] as const;
+const MATERIAL_PATCH_FIELDS = MATERIAL_LISTING_PATCH_FIELDS;
 
 /**
  * Validate + normalize an update patch (shared by the in-place + shadow paths).

--- a/src/shared/constants/app-capabilities.constants.ts
+++ b/src/shared/constants/app-capabilities.constants.ts
@@ -185,6 +185,40 @@ export function isPublishableListingStatus(status: string): boolean {
 }
 
 /**
+ * The MATERIAL scalar fields of a listing patch — the ones whose value a MODERATOR
+ * approved, so a change to any of them cannot go live without re-review.
+ *
+ * 🔴 IT LIVES HERE, IN `shared/`, FOR THE SAME STRUCTURAL REASON THE CAPABILITY TABLE
+ * ABOVE DOES. The definition was a module-private literal in `offsite-listing.service.ts`,
+ * which top-level-imports `~/server/db/client` — so the EDIT FORM could not read it without
+ * dragging Prisma into the browser bundle, and therefore could not know which of its inputs
+ * the server is going to refuse. It re-typed nothing and simply rendered every field as
+ * editable; on an owner-unpublished listing that is four inputs an author can fill and can
+ * never save (`MATERIAL_CHANGE_BLOCKED`). `offsite-listing.service.ts` now imports this,
+ * so there is still exactly ONE definition and the form's disabled set cannot drift from
+ * the server's refusal set.
+ *
+ * 🔴 ADDING A FIELD HERE IS A UI CHANGE AS WELL AS A SERVER ONE. `ExternalListingEditForm`
+ * tags each material input with `data-material-field="<name>"` and
+ * `ExternalSubmitForm.ownerUnpublished.browser.test.tsx` iterates THIS list asserting every
+ * member has such an input and that it is disabled in the repair state — so a new material
+ * field with no disabled input turns that ledger red rather than shipping an unsaveable box.
+ *
+ * NOT the whole material surface: a change to the DISCLOSED OAuth scope mask
+ * (`requestedScopes`) is material too, but it is not an author-typed field — it is derived
+ * from the connect client's current `allowedScopes` — so it has no input to disable and is
+ * handled separately at both ends. See `materialPatchChanges`.
+ */
+export const MATERIAL_LISTING_PATCH_FIELDS = [
+  'externalUrl',
+  'name',
+  'contentRating',
+  'sourceRepoUrl',
+] as const;
+
+export type MaterialListingPatchField = (typeof MATERIAL_LISTING_PATCH_FIELDS)[number];
+
+/**
  * Every listing status the canonical authoring ROUTE may open on — in FULL authoring mode
  * or in the narrowed publishing/history mode.
  *

--- a/src/shared/constants/app-capabilities.constants.ts
+++ b/src/shared/constants/app-capabilities.constants.ts
@@ -216,6 +216,16 @@ export const MATERIAL_LISTING_PATCH_FIELDS = [
   'sourceRepoUrl',
 ] as const;
 
+/**
+ * One member of {@link MATERIAL_LISTING_PATCH_FIELDS}.
+ *
+ * 🔴 ITS JOB IS TO MAKE A NARROWED SWEEP FAIL WHEN THE SET GROWS. The ledger tests walk the
+ * constant, but an arm that legitimately covers only SOME members (the on-site case, which
+ * has no `externalUrl` input because it has no URL step) has to express that as
+ * `Exclude<MaterialListingPatchField, 'externalUrl'>` rather than as a hand-written literal
+ * list. A literal is a ledger that cannot grow: add a fifth material field and the sweep
+ * still passes, having never mentioned it.
+ */
 export type MaterialListingPatchField = (typeof MATERIAL_LISTING_PATCH_FIELDS)[number];
 
 /**

--- a/src/tests/pages/apps/listing-edit-owner-unpublished-tabs.browser.test.tsx
+++ b/src/tests/pages/apps/listing-edit-owner-unpublished-tabs.browser.test.tsx
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { useRouter } from 'next/router';
+import { capabilitiesForKind } from '~/shared/constants/app-capabilities.constants';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * `/apps/listing/<id>/edit` — THE TAB SET AN OWNER-UNPUBLISHED LISTING ACTUALLY RENDERS.
+ *
+ * 🔴 THIS FILE EXISTS FOR ONE HOP THAT NO OTHER INSTRUMENT SEES: does the PAGE hand
+ * `lastModerationAction` to `editorTabsFor` at all?
+ *
+ *   - `appListingEditorTabs.test.ts` proves the derivation branches on the field — from a
+ *     fixture the test writes itself.
+ *   - `app-access.editor-tabs.seam.test.ts` proves the value survives the service's query
+ *     and normalisation — and then calls `editorTabsFor` with it, in the TEST.
+ *   - Neither renders the page. Delete the `lastModerationAction:` line from
+ *     `/apps/listing/[appListingId]/edit` and BOTH stay green while the feature is dark,
+ *     because the field is optional (fail-closed) and its absence is not a type error.
+ *
+ * That is the same shape as #4401's `messageAppOwner` — a live server capability with no
+ * caller — and it is the shape this whole change exists to close, so it gets its own guard
+ * rather than being assumed.
+ *
+ * Every panel BODY is stubbed. The subject is which tabs exist, not what is inside them;
+ * the bodies have their own suites (`ExternalSubmitForm.ownerUnpublished.browser.test.tsx`,
+ * `listing-media-page.browser.test.tsx`).
+ */
+
+type AuthoringContext = {
+  appListingId: string;
+  slug: string;
+  name: string;
+  status: string;
+  kind: 'onsite' | 'offsite';
+  appBlockId: string | null;
+  connectClientId: string | null;
+  lastModerationAction: string | null;
+  role: string;
+  capabilities: Readonly<Record<string, boolean>>;
+};
+
+const state = vi.hoisted(() => ({
+  /** The `getAuthoringContext` payload — THE ONLY THING ANY ARM VARIES. */
+  context: null as unknown,
+  flags: { appBlocks: true } as Record<string, boolean>,
+}));
+
+// The page's `getServerSideProps` calls createServerSideProps at module top — stub it so
+// importing the page in a browser test doesn't pull the server graph (and `sharp`).
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => state.flags,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 10, username: 'owner' }),
+}));
+
+vi.mock('~/components/AppLayout/NotFound', () => ({
+  NotFound: () => <div data-testid="not-found">Not found</div>,
+}));
+
+// `Meta` reads the app-wide BrowserRouter context, which `renderWithProviders` deliberately
+// does not mount. It contributes nothing to this suite's subject.
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+// Panel bodies — stubbed so this file is about the TAB LIST and so their module graphs stay
+// out of the browser build (the collaborators panel reaches a Meilisearch client that reads
+// its host URL AT IMPORT TIME and throws).
+vi.mock('~/components/Apps/AppsSubmitEditView', () => ({
+  AppsListingDetailsEditor: () => <div data-testid="stub-details" />,
+}));
+vi.mock('~/components/Apps/ListingMediaEditor', () => ({
+  ListingMediaEditor: () => <div data-testid="stub-media" />,
+}));
+vi.mock('~/components/Apps/ManifestEditForm', () => ({
+  ManifestEditForm: () => <div data-testid="stub-manifest" />,
+}));
+vi.mock('~/components/Apps/AppEarningsPanel', () => ({
+  AppEarningsPanel: () => <div data-testid="stub-earnings" />,
+}));
+vi.mock('~/components/Apps/AppCollaboratorsPanel', () => ({
+  AppCollaboratorsPanel: () => <div data-testid="stub-collaborators" />,
+}));
+vi.mock('~/components/Apps/ListingPublishingPanel', () => ({
+  ListingPublishingPanel: () => <div data-testid="stub-publishing" />,
+}));
+vi.mock('~/components/Apps/ListingHistoryPanel', () => ({
+  ListingHistoryPanel: () => <div data-testid="stub-history" />,
+}));
+
+// Spread the REAL module and override only `trpc` (per `local-rules/no-wholesale-module-mock`):
+// a hand-written replacement silently drops any export a transitive importer needs, and the
+// whole file then fails to load as "0 tests collected" — green for the worst possible reason.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({}),
+      appListings: {
+        getAuthoringContext: {
+          useQuery: () => ({
+            data: state.context,
+            isLoading: state.context == null,
+            error: null,
+          }),
+        },
+      },
+    },
+  };
+});
+
+const AppListingEditPage = (await import('~/pages/apps/listing/[appListingId]/edit')).default;
+
+const LISTING_ID = 'apl_repair';
+
+function contextFor(over: Partial<AuthoringContext>): AuthoringContext {
+  const kind = over.kind ?? 'onsite';
+  return {
+    appListingId: LISTING_ID,
+    slug: 'my-app',
+    name: 'My App',
+    status: 'removed',
+    kind,
+    appBlockId: kind === 'onsite' ? 'ab_1' : null,
+    connectClientId: null,
+    lastModerationAction: null,
+    role: 'owner',
+    capabilities: capabilitiesForKind(kind),
+    ...over,
+  };
+}
+
+function openListing(tab?: string) {
+  const router = (useRouter as unknown as () => { query: Record<string, string> })();
+  router.query.appListingId = LISTING_ID;
+  if (tab) router.query.tab = tab;
+  else delete router.query.tab;
+}
+
+/** The rendered tab strip, in DOM order. Read off the DOM, never off a captured prop. */
+function renderedTabs(): string[] {
+  return page
+    .getByTestId(/^apps-edit-tab-/)
+    .elements()
+    .map((el) => (el.getAttribute('data-testid') ?? '').replace('apps-edit-tab-', ''));
+}
+
+beforeEach(() => {
+  state.context = null;
+  state.flags = { appBlocks: true };
+  openListing();
+});
+
+describe('🔴 the page hands `lastModerationAction` to the tab derivation', () => {
+  test('🔴 an OWNER-UNPUBLISHED listing renders the Details and Media tabs', async () => {
+    state.context = contextFor({ lastModerationAction: 'owner-unpublish' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-edit-tab-details')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-edit-tab-media')).toBeInTheDocument();
+    // Order is asserted too — the strip is what the owner scans, and `details` must be the
+    // landing tab (a bare `/edit` resolves to DEFAULT_EDITOR_TAB when it is allowed).
+    expect(renderedTabs()).toEqual(['details', 'media', 'publishing', 'history']);
+  });
+
+  test('🔴 a MODERATOR-DELISTED listing renders NEITHER — same payload, one field apart', async () => {
+    // `other` is what `normalizeLastModerationAction` sends for every moderator verb, so
+    // this is the shape a real `delist`/`purge` produces on the wire. This is the arm that
+    // fails if someone widens `AUTHORABLE_LISTING_STATUSES` instead of branching.
+    state.context = contextFor({ lastModerationAction: 'other' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-edit-tab-publishing')).toBeInTheDocument();
+    expect(page.getByTestId('apps-edit-tab-details').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-edit-tab-media').elements()).toHaveLength(0);
+    // 🔴 The Forgejo-write surface, named. Accepting an invite still mints repo `write`.
+    expect(page.getByTestId('apps-edit-tab-collaborators').elements()).toHaveLength(0);
+    expect(renderedTabs()).toEqual(['publishing', 'history']);
+  });
+
+  test('🔴 a removed listing with NO moderation event fails closed', async () => {
+    state.context = contextFor({ lastModerationAction: null });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-edit-tab-publishing')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual(['publishing', 'history']);
+  });
+
+  test('🔴 the repair state does NOT open Collaborators, Manifest or Earnings', async () => {
+    // Every one of the three is available on this fixture's kind + block id, so their
+    // absence is the branch split alone and not a collapsed payload. The two tabs that DO
+    // render are the control that the page is not simply empty.
+    state.context = contextFor({ lastModerationAction: 'owner-unpublish' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-edit-tab-details')).toBeInTheDocument();
+    for (const tab of ['collaborators', 'manifest', 'earnings']) {
+      expect(page.getByTestId(`apps-edit-tab-${tab}`).elements(), tab).toHaveLength(0);
+    }
+  });
+
+  test('🔴 a `?tab=collaborators` deep link on a repaired listing lands on Details', async () => {
+    // The withheld tab must not be reachable by URL either — and it lands somewhere REAL,
+    // not on a blank panel. A different answer from the delisted case, which has no
+    // `details` to fall back to.
+    openListing('collaborators');
+    state.context = contextFor({ lastModerationAction: 'owner-unpublish' });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-edit-panel-details')).toBeInTheDocument();
+    expect(page.getByTestId('apps-edit-panel-collaborators').elements()).toHaveLength(0);
+  });
+
+  test('the payload reaches the page and different payloads render differently (control)', async () => {
+    // 🔴 THE FAKE'S OWN CONTROL, read through a fact this change does not touch: an APPROVED
+    // listing renders the full strip. Without it, every arm above could be passing because
+    // the mock serves a frozen payload and the page renders one fixed set.
+    state.context = contextFor({ status: 'approved', lastModerationAction: null });
+    renderWithProviders(<AppListingEditPage />);
+
+    await expect.element(page.getByTestId('apps-edit-tab-collaborators')).toBeInTheDocument();
+    expect(renderedTabs()).toEqual([
+      'details',
+      'media',
+      'manifest',
+      'earnings',
+      'collaborators',
+      'publishing',
+      'history',
+    ]);
+  });
+});

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -602,3 +602,117 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     expect(page.getByTestId('asset-step').elements()).toHaveLength(0);
   });
 });
+
+/**
+ * 🔴 THE OWNER-UNPUBLISHED FRAME — the third write semantics, and the one that had no copy.
+ *
+ * Every notice this editor renders was gated on `isApproved`, so an OWNER-UNPUBLISHED
+ * listing mounted the image editor with NO framing at all: no statement that the app is
+ * currently DOWN, and no statement of how these writes behave — which is a third case again
+ * (no shadow, no re-approval, the write lands on the listing and becomes visible on
+ * republish). That was unreachable until the editor tabs opened on this state; opening them
+ * without this ships the bare editor.
+ *
+ * 🔴 THE DISCRIMINATOR IS THE SERVER'S OWN VERDICT, not a second reading of `status`.
+ * `status === 'removed'` is ambiguous (owner self-unpublish vs moderator takedown);
+ * `editBlockedReason` is `null` for exactly the first. So the frame appears on precisely the
+ * rows the server will accept an asset write for, and the moderator case keeps its red
+ * alert with no frame — never both, which is the contradictory half-UI the case above pins.
+ */
+describe('ListingMediaEditor — the OWNER-UNPUBLISHED frame', () => {
+  function unpublished(over: Record<string, unknown> = {}) {
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      status: 'removed',
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+      editBlockedReason: null,
+      ...over,
+    };
+  }
+
+  test('🔴 an owner-unpublished listing is framed as DOWN, and the editor still mounts', async () => {
+    unpublished();
+    renderWithProviders(<ListingMediaPage />);
+
+    const notice = page.getByTestId('apps-listing-media-unpublished-notice');
+    await expect.element(notice).toBeInTheDocument();
+    // The two facts the author needs, asserted separately: the app is not visible, and
+    // these edits are NOT staged (unlike the live case they have seen before).
+    await expect.element(notice).toHaveTextContent(/not visible in the store/i);
+    await expect.element(notice).toHaveTextContent(/republish/i);
+    // Control arm: it is a FRAME over a working editor, not a replacement for one. The
+    // server permits asset edits here, so withholding the editor would be the mirror defect.
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_onsite');
+  });
+
+  test('🔴 it does NOT claim the app is live, and offers no revision to submit', async () => {
+    // Both live notices are wrong here, and `Submit for review` is `isApproved`-gated with
+    // `disabled={… || !shadowId}` — on a removed listing no edit ever mints a shadow, so a
+    // rendered button would be permanently dead and would contradict the frame above it.
+    unpublished();
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect
+      .element(page.getByTestId('apps-listing-media-unpublished-notice'))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-submit').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-begin-error').elements()).toHaveLength(0);
+  });
+
+  test('🔴 a MODERATOR takedown gets the red alert and NO frame — same status, one field apart', async () => {
+    // `editBlockedReason` is the ONLY difference from the fixture above. Rendering the
+    // unpublished frame here would put "you unpublished it" over a listing a moderator took
+    // down — the false attribution civitai/civitai#4413 exists to delete.
+    unpublished({
+      editBlockedReason: 'this listing has been removed by a moderator and can no longer be edited',
+    });
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect
+      .element(page.getByTestId('apps-listing-media-begin-error'))
+      .toHaveTextContent(/removed by a moderator/i);
+    expect(page.getByTestId('apps-listing-media-unpublished-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('asset-step').elements()).toHaveLength(0);
+  });
+
+  test('🔴 a moderator on their OWN unpublished app gets the same frame, not the mod-live one', async () => {
+    // `modDirectLiveEdit` (`isModerator && !shadowId`) is true for this fixture, and it is
+    // consumed only inside `isApproved` gates — so a mutant that widens the mod-live notice
+    // past that gate lands here. The copy is also CORRECT for them: a removed listing mints
+    // no shadow for anyone, so nobody's write is staged.
+    state.currentUser = { id: 7, username: 'mod', isModerator: true };
+    unpublished();
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect
+      .element(page.getByTestId('apps-listing-media-unpublished-notice'))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
+  });
+
+  test.each(['approved', 'draft', 'pending'] as const)(
+    '🔴 a %s listing shows NO unpublished frame — the status arm',
+    async (status) => {
+      // The control for the whole block: without it the frame could be unconditional and
+      // every case above would pass while every OTHER listing gained a false "this app is
+      // unpublished" banner.
+      state.query.data = {
+        ...(state.query.data as Record<string, unknown>),
+        status,
+        shadowId: status === 'approved' ? 'apl_shadow' : null,
+        editTargetId: status === 'approved' ? 'apl_shadow' : 'apl_onsite',
+        editBlockedReason: null,
+      };
+      renderWithProviders(<ListingMediaPage />);
+
+      await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+      expect(
+        page.getByTestId('apps-listing-media-unpublished-notice').elements(),
+        status
+      ).toHaveLength(0);
+    }
+  );
+});

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -102,7 +102,11 @@ vi.mock('~/components/Apps/ListingAssetStep', () => ({
         assets:{props.listingId}:{props.contentRating}
         <span data-testid="asset-step-seeded-icon">{String(seededIcon ?? 'none')}</span>
         {/* Stands in for a successful attach/remove inside the real step. */}
-        <button type="button" data-testid="asset-step-mutate" onClick={() => props.onAssetMutated?.()}>
+        <button
+          type="button"
+          data-testid="asset-step-mutate"
+          onClick={() => props.onAssetMutated?.()}
+        >
           mutate
         </button>
       </div>
@@ -167,6 +171,11 @@ beforeEach(() => {
     data: {
       appListingId: 'apl_onsite',
       status: 'approved',
+      // 🔴 THE CALLER'S ROLE, returned by `getMyListingForApp`. Spelled in the default
+      // fixture rather than left absent, because absent is a REAL third state here (an
+      // older cached payload) with its own copy branch — a fixture that omits it would
+      // silently test that branch while reading as if it tested the owner one.
+      role: 'owner',
       contentRating: 'pg13',
       hasPendingRevision: false,
       shadowId: 'apl_shadow',
@@ -201,7 +210,9 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
 
     // The reused asset step is hosted against the edit target + the listing's rating.
     await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
-    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_shadow:pg13');
+    await expect
+      .element(page.getByTestId('asset-step'))
+      .toHaveTextContent('assets:apl_shadow:pg13');
     expect(state.assetProps.last).toMatchObject({ listingId: 'apl_shadow', contentRating: 'pg13' });
     expect(page.getByTestId('not-found').elements()).toHaveLength(0);
   });
@@ -221,7 +232,9 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     // It renders (no "Preparing your revision…" gate — there is nothing to prepare),
     // hosted against the LIVE listing id. The first mutation mints the shadow
     // server-side and applies there.
-    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_onsite:pg13');
+    await expect
+      .element(page.getByTestId('asset-step'))
+      .toHaveTextContent('assets:apl_onsite:pg13');
   });
 
   test('🔴 Submit is DISABLED until a shadow exists — no edits means no revision to submit', async () => {
@@ -491,7 +504,9 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
   test('does NOT show the pending-revision notice when none is queued', async () => {
     renderWithProviders(<ListingMediaPage />);
     await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
-    expect(page.getByTestId('apps-listing-media-pending-revision-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-pending-revision-notice').elements()).toHaveLength(
+      0
+    );
   });
 
   test('fails closed to NotFound when the owner resolve errors (non-owner / missing listing)', async () => {
@@ -532,7 +547,9 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     // Without this the cached `assets` stay pre-mutation and the /edit page's
     // `keepMounted={false}` tab round-trip re-seeds the step from them — a just-
     // attached icon reads as unattached and Submit goes disabled again.
-    await vi.waitFor(() => expect(state.invalidate).toHaveBeenCalledWith({ appBlockId: 'my-block' }));
+    await vi.waitFor(() =>
+      expect(state.invalidate).toHaveBeenCalledWith({ appBlockId: 'my-block' })
+    );
   });
 
   test('a re-attached icon survives a tab round-trip: the REMOUNT re-seeds from the refreshed assets', async () => {
@@ -660,6 +677,72 @@ describe('ListingMediaEditor — the OWNER-UNPUBLISHED frame', () => {
     expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-listing-media-submit').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-listing-media-begin-error').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 THE SEATED EDITOR, AND BOTH HALVES OF THE OWNER SENTENCE WERE FALSE FOR THEM.
+   *
+   * This editor is NOT owner-only, though its header said so for a long time.
+   * `getMyListingForApp` refuses on `resolveListingRole(...) === null`, which is non-null
+   * for the owner OR an ACCEPTED COLLABORATOR — and `editorTabsFor` deliberately hands an
+   * editor `['details','media','history']` in exactly this repair state (pinned at
+   * `appListingEditorTabs.test.ts`). So a seated editor reaches this component, and was
+   * told:
+   *
+   *   "you unpublished it"                        — they did not; the owner did.
+   *   "republish it from the Publishing tab"      — `publishing` is OWNER-ONLY in
+   *                                                 `editorTabsFor`, so that tab is not on
+   *                                                 their screen. An instruction naming a
+   *                                                 surface the reader cannot see is worse
+   *                                                 than no instruction.
+   *
+   * The WRITE SEMANTICS are identical for both roles, so only the attribution and the way
+   * out change — the control below pins that the editor is still fully mounted.
+   */
+  test('🔴 a seated EDITOR is not blamed for the unpublish, nor sent to an owner-only tab', async () => {
+    unpublished({ role: 'editor' });
+    renderWithProviders(<ListingMediaPage />);
+
+    const notice = page.getByTestId('apps-listing-media-unpublished-notice');
+    await expect.element(notice).toBeInTheDocument();
+    // Still told the app is DOWN — that fact is role-independent and is the whole point of
+    // the frame.
+    await expect.element(notice).toHaveTextContent(/not visible in the store/i);
+    // Attribution is correct…
+    await expect.element(notice).toHaveTextContent(/its owner unpublished it/i);
+    await expect.element(notice).not.toHaveTextContent(/you unpublished it/i);
+    // …and they are not pointed at a tab they cannot open.
+    await expect.element(notice).not.toHaveTextContent(/from the Publishing tab/i);
+
+    // 🔴 CONTROL ARM. The editor still MOUNTS for them — the server accepts their asset
+    // writes, so withholding the editor would be the mirror defect of mis-addressing them.
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_onsite');
+  });
+
+  test('🔴 the OWNER still gets the owner copy — the branch is not a blanket reword', () => {
+    // Guards the other direction: a mutant that emits the editor copy for everyone passes
+    // every assertion above. Run as a pair with it.
+    unpublished({ role: 'owner' });
+    renderWithProviders(<ListingMediaPage />);
+
+    return (async () => {
+      const notice = page.getByTestId('apps-listing-media-unpublished-notice');
+      await expect.element(notice).toHaveTextContent(/you unpublished it/i);
+      await expect.element(notice).toHaveTextContent(/from the Publishing tab/i);
+    })();
+  });
+
+  test('🔴 an ABSENT role falls back to the NON-owner copy, never the owner copy', async () => {
+    // 🔴 THE FAIL-SAFE DIRECTION, and it is the opposite of a normal narrowing. Absence
+    // cannot tell owner from editor; the owner wording asserts two things an editor would
+    // find false, while the non-owner wording is true for both. So unknown resolves to
+    // non-owner. Reachable in production from an older cached payload.
+    unpublished({ role: undefined });
+    renderWithProviders(<ListingMediaPage />);
+
+    const notice = page.getByTestId('apps-listing-media-unpublished-notice');
+    await expect.element(notice).toBeInTheDocument();
+    await expect.element(notice).not.toHaveTextContent(/you unpublished it/i);
   });
 
   test('🔴 a MODERATOR takedown gets the red alert and NO frame — same status, one field apart', async () => {


### PR DESCRIPTION
## What this is

**#4413 shipped a server capability with no caller.** It taught the server to tell an owner
self-unpublish from a moderator takedown (`status='removed'` is written by both; only the
last *status-changing* moderation event separates them) and to accept repair edits on the
former — `getMyListingForEdit`, `updateListing` and `getMyListingForApp` all branch on it now.

No UI could reach any of it. `editorTabsFor` still gated `details` and `media` on
`isAuthorableListingStatus`, which excludes `removed`, so an owner-unpublished listing got at
most Publishing + History and the repair loop had a take-down step, a put-back step, and no
repair step. That is the same shape as #4401's `messageAppOwner` — a live proc with zero UI
callers, still dark today — which is exactly what this PR exists to stop happening twice.

This wires the bit through, and handles the two defects that opening those tabs makes
reachable. **Neither is optional**: with the tabs open and nothing else done, the UI ships
broken.

## 1. The tab gate is now last-action-aware

`editorTabsFor` takes the `lastModerationAction` the authoring context **already carried**
(normalised `'owner-unpublish' | 'other' | null`; the Publishing panel two lines down was
already reading it) and adds one branch:

```ts
const authorable   = isAuthorableListingStatus(ctx.status);
const ownerRepair  = isOwnerUnpublishedTabContext(ctx);   // 'removed' AND 'owner-unpublish'
if (authorable || ownerRepair) { details; media }
if (authorable)                { manifest; earnings; collaborators }
```

* **Owner-unpublished** → `['details', 'media', 'publishing', 'history']`
* **Moderator-delisted / no events at all** → `['publishing', 'history']`, unchanged
* Absence fails **closed**, same direction as the server predicate: `null` and `'other'` are
  both `false`, and the field is optional, so a caller that has not been updated gets the
  narrow set.

The action name comes from `OWNER_UNPUBLISH_ACTION` — the client literal
`app-listing-owner-unpublish.test.ts` already pins against the server's
`OWNER_UNPUBLISH_EVENT` — so the gate and the server predicate cannot drift into different
spellings.

### Why `AUTHORABLE_LISTING_STATUSES` was NOT widened

Adding `'removed'` to that set is a one-line fix that works — for the tabs. It also silently
changes a **server** gate. The set has three consumers, and the other one is
`assertSeatGrantable` (`app-collaborator.service.ts` ~:357), which is what
`inviteCollaborator` and `respondToInvite` refuse on. Widening it would start admitting
**moderator-delisted** listings on the collaborator path, where accepting a seat still mints
Forgejo `write` on the app's repo — the exact hazard the narrowed tab set was introduced to
close, re-opened from the other end, server-side, where a UI narrowing cannot help.

So the repair branch is strictly narrower than the authorable one and grants **`details` +
`media` only**. `collaborators` stays withheld (its server gate refuses this status).
`manifest` and `earnings` stay withheld too — nothing here opens a version submit or an
earnings read on an unpublished app, and withholding a tab is always safe: a tab set is a UI
narrowing, never a gate.

There is an explicit guard for the road not taken
(`🔴 the shared AUTHORABLE set was not widened…`), labelled in-source as an **invariant
guard**, not regression coverage. The behavioural half — that the collaborator procs still
refuse `removed` — is `app-collaborator.seat-grant-status.test.ts`, untouched and still green.

## 2. The two dark defects this makes reachable

### (a) `ExternalListingEditForm` — four inputs you can fill and can never save

`updateListing`'s `removed` branch refuses any change to `MATERIAL_PATCH_FIELDS`
(`externalUrl`, `name`, `contentRating`, `sourceRepoUrl`) with `MATERIAL_CHANGE_BLOCKED` →
`BAD_REQUEST` — *after* the author has typed it and pressed Save. Unreachable while no tab
opened; with the tab open it is four editable boxes and a red toast.

They now render **disabled, with the refusal's reason on screen above the stepper** —
including the way out (republish → edit → staged for review) and what *is* still editable
(tagline, description, category). The prefill stays wider than the write on purpose: the
author must be able to **read** the values a moderator approved, which is what they are
deciding whether to republish. Showing a value is not offering an edit of it.

`MATERIAL_PATCH_FIELDS` moved to `shared/app-capabilities.constants` as
`MATERIAL_LISTING_PATCH_FIELDS` (the service now aliases it), because the form cannot import
`offsite-listing.service` — it top-level-imports the db client. Each locked input carries
`data-material-field="<name>"`, and a **ledger test walks the shared constant** demanding a
disabled input per member, so a field added to the server's material set with no counterpart
in the form goes red instead of shipping another unsaveable box. Mutant M22 (dropping
`sourceRepoUrl` from the constant) is killed on **both** sides.

**A third case, found while doing this and handled:** `buildScalarPatch` also emits
`requestedScopes` when the connect client's `allowedScopes` has **drifted** from the stored
snapshot, and the server counts a drifted mask as material — so on a drifted, unpublished
listing *every* save is refused, tagline-only included. The scope-justification boxes are
therefore locked in that case (and only that case: while the masks agree a justification edit
is trivial and saves fine), with a sentence appended to the notice.

### (b) `ListingMediaEditor` — mounts with no notice the app is down

Every framing alert was gated on `isApproved`, so once the media tab opens for an
owner-unpublished listing the editor mounted with **no frame at all** — no statement that the
app is not visible, and no statement of the write semantics, which are a third case again: no
shadow, no re-approval, the write lands on the listing and appears on republish.

It now renders an accurate frame. The discriminator is `status === 'removed' && !editBlockedReason`
— the **server's own verdict**, not a second client reading of `status`, so the frame appears
on precisely the rows `listingMediaEditBlockedReason` permits and a moderator takedown keeps
its red alert with no frame. Never both.

## 3. The seam

`listingMediaEditBlockedReason` permits an owner-unpublished listing → the media tab agrees.
`getMyListingForEdit` permits it → the details tab agrees, with the material subset the write
path refuses rendered disabled. `assertSeatGrantable` refuses it → the collaborators tab stays
withheld. No surface now offers something the server refuses.

Both halves were already tested **in isolation** and both would stay green on a tree where
this feature is dark, so `app-access.editor-tabs.seam.test.ts` runs the REAL service (real
query, real normalisation, real fail-closed arms) into the REAL tab derivation, with a
moderation-event fake that **interprets the `where`** rather than returning a canned row —
so the query's own `action: { in: … }` filter is observable. That is what pins the case the
filter exists for: a `message-owner` / `report-resolve` / `report-dismiss` / `claim` sitting
*above* the owner's `owner-unpublish` must **not** revoke the repair tabs, with `relist` as
the control that legitimately does.

And because that seam test still calls `editorTabsFor` *in the test*, deleting the
`lastModerationAction:` line from the page would leave it green — so
`listing-edit-owner-unpublished-tabs.browser.test.tsx` renders the real page and reads the
tab strip off the DOM. Mutants M8 (comment-out, token retained) and M9 (wrong-field bind) are
killed **only** there.

## Red at base → green at HEAD

Source files reverted to `origin/main`, every test file kept from HEAD, per suite:

| suite | at `origin/main` | at HEAD |
|---|---|---|
| `unit … appListingEditorTabs.test.ts` | **10 failed** \| 36 passed (46) | 46 passed |
| `unit … offsiteEditConfig.test.ts` | **10 failed** \| 29 passed (39) | 39 passed |
| `unit … app-access.editor-tabs.seam.test.ts` | **2 failed** \| 5 passed (7) | 7 passed |
| `component … ExternalSubmitForm.ownerUnpublished.browser.test.tsx` | **7 failed** \| 3 passed (10) | 10 passed |
| `component … listing-edit-owner-unpublished-tabs.browser.test.tsx` | **3 failed** \| 3 passed (6) | 6 passed |
| `component … listing-media-page.browser.test.tsx` | **3 failed** \| 28 passed (31) | 31 passed |

Stated honestly: of the 35 base failures, **20 are assertion failures** on code that exists at
base (`expected [ 'publishing', 'history' ] to include 'details'`), and **15 are
`X is not a function` / `not iterable`** on symbols this PR introduces. The reachability proof
for those is the mutation battery below, not the base run.

Reproduce (`$WT` = a worktree of this branch):

```bash
SRC="src/components/Apps/appListingEditorTabs.ts src/components/Apps/offsiteEditConfig.ts \
src/components/Apps/ExternalListingEditForm.tsx src/components/Apps/ListingMediaEditor.tsx \
src/shared/constants/app-capabilities.constants.ts \
src/server/services/blocks/offsite-listing.service.ts"
git -C "$WT" checkout origin/main -- $SRC "src/pages/apps/listing/[appListingId]/edit.tsx"
# …run the six suites…
git -C "$WT" checkout HEAD -- $SRC "src/pages/apps/listing/[appListingId]/edit.tsx"
```

## Mutation battery — 23 mutants, 23 killed, 0 survivors

Enumerated from semantic failure modes (branch inversion, condition widening, condition
negation, wrong-field bind, comment-out with the token retained, wrong literal, fail-open on
absence, shrink-the-shared-set), not from deletion. Each is the **narrowest expression that
can be wrong**; each run records the *named* test that failed, and the harness asserts the
find-string occurs exactly once and that the file's sha256 actually moved.

| # | file | mutation | killed by (named test) |
|---|---|---|---|
| M1 | `appListingEditorTabs.ts` | drop the repair clause (`authorable \|\| ownerRepair` → `authorable`) | 🔴 DETAILS is offered … (+5) |
| M2 | `appListingEditorTabs.ts` | widen the second block to `authorable \|\| ownerRepair` | 🔴 NEVER Collaborators — the seat gate still refuses this status server-side (+5) |
| M3 | `appListingEditorTabs.ts` | predicate: drop the STATUS clause | 🔴 the ACTION alone is not enough — a REJECTED listing carrying it stays narrowed (+2) |
| M4 | `appListingEditorTabs.ts` | predicate: drop the ACTION clause | 🔴 NEVER Details — `getMyListingForEdit` refuses a removed listing outright (+5) |
| M5 | `appListingEditorTabs.ts` | predicate: `===` → `!==` on the action | same six, inverted |
| M6 | `appListingEditorTabs.ts` | wrong-field bind (`ctx.status` for the action) | 🔴 DETAILS is offered … (+5) |
| M7 | `appListingEditorTabs.ts` | fail **open** on absence (`!== 'other'`) | 🔴 NEVER Details … / 🔴 NO moderation events at all fails CLOSED (+4) |
| M8 | `edit.tsx` | comment out `lastModerationAction:`, token retained | *(page browser suite only)* 🔴 an OWNER-UNPUBLISHED listing renders the Details and Media tabs (+2) |
| M9 | `edit.tsx` | wrong-field bind (`context.status`) | same three |
| M10 | `offsiteEditConfig.ts` | invert the material-lock guard | 🔴 is non-null ONLY on an unpublished listing (+5) |
| M11 | `offsiteEditConfig.ts` | `'removed'` → `'rejected'` | is true for `removed` and false for every other status (+5) |
| M12 | `offsiteEditConfig.ts` | scope-drift compare `!==` → `===` | 🔴 is FALSE while the masks agree … / 🔴 is TRUE once the mask has DRIFTED … (+3) |
| M13 | `offsiteEditConfig.ts` | drop the status guard from the scope lock | 🔴 drift alone is NOT enough — a live listing stages the change instead of refusing it |
| M14 | `offsiteEditConfig.ts` | drop kind-awareness from the copy | 🔴 is KIND-AWARE … / 🔴 an ON-SITE unpublished listing is not told its "App URL" is locked |
| M15 | `ExternalListingEditForm.tsx` | `name` left editable (one field only) | 🔴 EVERY material field the server refuses has a DISABLED input — the ledger (+1) |
| M16 | `ExternalListingEditForm.tsx` | `contentRating` Select left editable | the ledger (+1) |
| M17 | `ExternalListingEditForm.tsx` | drop the scope-justification lock | 🔴 once the mask has DRIFTED, the justifications lock and the notice says so |
| M18 | `ExternalListingEditForm.tsx` | suppress the NOTICE, inputs still disabled | 🔴 the reason is on screen BEFORE the author reaches a locked field (+2) |
| M19 | `ListingMediaEditor.tsx` | drop the `!editBlockedReason` conjunct | 🔴 a MODERATOR takedown gets the red alert and NO frame — same status, one field apart |
| M20 | `ListingMediaEditor.tsx` | `'removed'` → `'approved'` | 🔴 an owner-unpublished listing is framed as DOWN … (+3) |
| M21 | `ListingMediaEditor.tsx` | suppress the frame entirely | 🔴 an owner-unpublished listing is framed as DOWN … (+2) |
| M22 | `app-capabilities.constants.ts` | drop `sourceRepoUrl` from the shared material set | client: 🔴 the locked set is exactly the SERVER's material set — one list, not two **and** server: 🔴 sourceRepoUrl — the public OUTBOUND repo link is material for the same reason |
| POS | `appListingEditorTabs.ts` | **positive control** — remove the unconditional `history` push | 6 pre-existing cases, incl. ON-SITE owner on a LIVE listing: every tab, in order |

**Survivors: none.** No mutant reported "no tests" or a missing summary line (checked
explicitly — a suite that fails to import reports `Tests no tests`, not a failure count).
M8 is the one attributed to a single suite: the unit suite was also run for it and correctly
did **not** kill it, which is what makes the page-level guard non-redundant.

---

# Audit round 2 — findings fixed on top of `b16cc80c2c`

An adversarial audit of `b16cc80c2c` found eight issues. Eight commits address them, added
**on top** of the audited tip (no rebase, no force-push), so the delta is readable:

```
948c6387b0  fix(ci)   format the added browser test so the BLOCKING prettier gate passes
1b07ca5a88  fix       make lastModerationAction REQUIRED — the 2nd editorTabsFor caller dropped it
fd4e75813b  fix       tell the truth in the scope-drift dead end; stop addressing editors as the owner
afffe22252  test      drive the drifted SAVE, the seated EDITOR, and the unframed Assets step
39fa058b31  test      derive the on-site material ledger from the constant instead of a literal
ded3630039  test      pin the OUTCOME of the dropped-field defect, not just the argument list
4f706ba742  test      bind the server's resolved role to the component that branches on it
6b02736383  fix       undo a wholesale reformat, and close the survivor it exposed
```

## 🔴 CI was RED, and the section below used to misreport why

The `ESLint + Prettier (changed files)` check was **failing**, and the old Verification
section did not say so. It reported "`eslint` … 0 new errors" — true, and about the wrong
half. Per `.github/workflows/lint.yml` the job splits by how the PR touched the file:

| step | files | blocking? |
|---|---|---|
| **ESLint (added files)** | added | **BLOCKING** (no `--max-warnings`, so warnings annotate but do not fail) |
| **Prettier (added files)** | added | **BLOCKING** |
| ESLint (modified files) | modified/renamed | report-only (`continue-on-error`) |
| Prettier (modified files) | modified/renamed | report-only (`continue-on-error`) |

The failing half was **Prettier on added files** — `ExternalSubmitForm.ownerUnpublished.browser.test.tsx`
was unformatted. Quoting only the eslint half named the report-only side while the blocking
side was red.

Fixed and re-verified with the instrument validated in **both** directions first, because a
clean `--list-different` is otherwise indistinguishable from a run that examined nothing:

```
negative control   deliberately mis-formatted temp file  -> listed, rc=1
positive control   well-formatted temp file              -> not listed
under test         3 added files (count read, not assumed)
                     before: 1 listed, rc=123
                     after:  0 listed, rc=0
```

An unused `vi` import in the added seam test (an ESLint **warning** on a blocking step —
annotates, does not fail) was dropped in the same pass.

## 🔴 Which suites CI actually runs — CORRECTED

> ⚠️ **An earlier revision of this section said the browser suites run in NO CI job. That was
> wrong, and the way it was wrong is worth keeping.** I enumerated `.github/workflows/` —
> which is a complete population of *GitHub Actions* and says nothing about *Tekton* — and
> then "confirmed" it against this PR's check list at a moment when the Tekton **preview**
> statuses had not registered yet. They post ~40 minutes after the push
> (`preview / *` all created `21:27:4xZ`, long after every Actions check had settled), so the
> absence I read as evidence was just latency. An absence has many causes; confirming the
> mechanism I had already investigated proved nothing about the other one. Corrected below
> from the settled rollup.

Suite→project resolved with `vitest list --filesOnly --project …` (positive control on the
project counts: `unit*` 1,462 files, `component` 192 — a zero on either would have made the
table meaningless). The CI column is read from the **settled** check rollup:

| suite | project | runs in CI? | blocks? |
|---|---|---|---|
| `__tests__/appListingEditorTabs.test.ts` | `unit` | ✅ `Unit tests` | ⚠️ advisory on PRs |
| `__tests__/appListingEditorTabs.callers.test.ts` | `unit` | ✅ `Unit tests` | ⚠️ advisory on PRs |
| `__tests__/offsiteEditConfig.test.ts` | `unit` | ✅ `Unit tests` | ⚠️ advisory on PRs |
| `blocks/__tests__/app-access.editor-tabs.seam.test.ts` | `unit` | ✅ `Unit tests` | ⚠️ advisory on PRs |
| `ExternalSubmitForm.ownerUnpublished.browser.test.tsx` | `component` | ✅ `preview / component-tests` | ❌ report-only |
| `MyAppsBody.browser.test.tsx` | `component` | ✅ `preview / component-tests` | ❌ report-only |
| `listing-edit-owner-unpublished-tabs.browser.test.tsx` | `component` | ✅ `preview / component-tests` | ❌ report-only |
| `listing-media-page.browser.test.tsx` | `component` | ✅ `preview / component-tests` | ❌ report-only |

**So every new suite IS executed by CI** — the browser ones by
`preview / component-tests`, part of the Tekton **preview** pipeline, which reports
*"Component suite passed (report-only)"* on this PR. `listing-media-page.browser.test.tsx`'s
header comment ("report-only in Tekton") turns out to be accurate, not stale; I had flagged it
as possibly stale, and it was right.

What remains true, and is the part that actually matters for this battery:

1. **Nothing here BLOCKS.** The four `component` suites are report-only by their own status
   description; the four `unit` suites sit behind
   `continue-on-error: ${{ github.event_name == 'pull_request' }}`, so they are advisory on a
   PR and only block on push to `main`. Every mutant in the table below is caught by a check
   that annotates rather than one that gates.
2. **The browser tier is CONDITIONAL on the preview pipeline running at all.** These statuses
   exist because the preview deployed. Preview is opt-in for non-maintainers (the `preview`
   label) and this PR carries **no labels** — so it ran on author identity, not on anything
   the diff did. A contributor PR without the label would get no component execution.
   ⚠️ Stated as a caveat, not a finding: the preview pipeline's definition lives outside this
   repo and I could not read its gating condition from here.
3. **It registers AFTER the Actions rollup is fully green.** A merge decision made the moment
   GitHub goes green precedes the browser result by ~40 minutes. That is the same shape as
   this repo's known "Tekton status can appear after you merge" hazard, and it is why the
   ✅ column above should not be read as "covered at merge time".
4. It is still why finding 2's fix is a **required type** rather than a test:
   `tekton / typecheck` is the one check in this set that genuinely gates, so the compiler
   enforces every production call site regardless of which suites ran.

**Not changed here, by instruction** — no CI job was added. The honest follow-up is narrower
than "add a component job", since one effectively exists: *closing condition — `preview /
component-tests` is either made blocking, or its report-only status is documented as
deliberate in `lint.yml`'s header alongside the other tiers, checked by whoever next touches
that header.* Flagging it because a report-only check that everyone reads as coverage is the
gate-shaped-object this repo already distrusts.

## Findings, one by one

| # | finding | outcome |
|---|---|---|
| 1 | `Prettier (added files)` red; PR body misreports it | **fixed** — see above |
| 2 | 2nd `editorTabsFor` caller drops `lastModerationAction` | **fixed structurally** — field is now REQUIRED |
| 3 | scope-drift is a dead end; copy claims otherwise | **copy fixed**; dead end left (see below) |
| 4 | new copy is owner-specific, surfaces are seat-aware | **fixed** — both components role-aware |
| 5 | browser suites have no CI coverage | **verified — and the premise was WRONG**; they run report-only via `preview / component-tests`. Corrected above rather than repeated |
| 6 | Assets step newly reachable with no repair framing | **fixed** |
| 7 | unreviewed-media path | **untouched** — awaiting a human decision |
| 8 | stale replica-read rationale comment | **fixed** |

### 2 — made the field REQUIRED rather than adding only a ledger

`myAppListingHref` called `editorTabsFor` without `lastModerationAction` while the authoring
page passed it, so **two different tab sets were derived for one listing**: the page offered
`details` + `media` on an owner-unpublished listing, the `/apps/mine` row linked at
`?tab=publishing`. The row already carries the field — `MyAppsBody` renders the
owner-vs-moderator badge off `row.lastModerationAction` at the same call site — so it was a
dropped field, not a plumbing gap. Optionality is exactly what made it type-check.

**Why required beats a ledger test:** the compiler checks every production call site on every
PR via `tekton / typecheck`, which actually GATES — whereas every suite covering this
function is either advisory (`unit`, `continue-on-error` on PRs) or report-only
(`preview / component-tests`). Runtime behaviour is unchanged and still fail-closed. Blast radius of requiring
it, measured: **one test row factory**.

**The ledger is still there**, as defence-in-depth for what the compiler structurally cannot
see — `tsconfig.json` excludes `src/**/__tests__/**` (measured: `tsc --listFilesOnly` contains
`appListingEditorTabs.test.ts` **0 times**), plus `as any`/spread launders. It asserts the
caller **set**, so it fails when the set GROWS as well as when a caller drops the field;
strips comments before the proximity check (this file's own prose names the field repeatedly,
and so does the doc comment at every real call site); and carries a positive control so a
sweep wired to nothing cannot report green. Its first run caught a false positive in itself —
the declaration site matches the same needle as a call.

### 3 — the copy is fixed; the dead end is NOT, and that is deliberate

The dead end is **pre-existing** and this PR does not remove it: `handleSave` runs
`scopeJustificationError(values)` for any connect listing independently of `scopeLocked`, the
drifted mask has no prefilled justification, and the boxes that would clear the error are
disabled. What was wrong was the copy — it ended *"Tagline, description and category can be
edited now"*, and then appended *"…the scope justifications are locked until you republish"*
directly after it. Two claims that cannot both be true. One honest message now replaces both.

A save is now actually **attempted** in that state (the old coverage asserted the box is
disabled and stopped, which is why this was invisible), asserted on the mutation spy rather
than a missing toast.

### 4 — role, from the server

`loadOwnedEditableListing` / `getMyListingForApp` are named for ownership but gate on
`resolveListingRole(...) === null`, which **admits an accepted collaborator** — and
`editorTabsFor` deliberately gives an editor `['details','media','history']` here. Both procs
already resolved the role and discarded it; they now return it. An **absent** role gets
role-neutral wording — the opposite of a normal fail-safe, because the owner wording is the
one that asserts things an editor would find false.

Two stale comments corrected rather than left to mislead: `ListingMediaEditor`'s header
asserted owner-only reachability (reading it as an ownership guarantee is what produced the
copy), and `loadOwnedEditableListing`'s "still requires the caller to own the LISTING itself".

### Nits

* **`DEFAULT_EDITOR_TAB` is `'details'`**, so an owner opening a bare `/edit` URL on an
  unpublished listing lands on Details rather than Publishing, moving Republish one click
  away. **Left as-is, intentionally** — Details is where the repair work happens, and
  `myAppListingHref` now links `/apps/mine` rows at `?tab=details` for the same reason —
  which is a **real consequence of fixing finding 2**, not a no-op: before the fix that row
  linked at `?tab=publishing`, because the dropped field collapsed the tab set. The row now
  agrees with the destination page, which is the point, but Republish is one click further
  from `/apps/mine` than it was. Flagged rather than settled: if the preferred landing is
  Publishing, that is a small change to `resolveEditorTab`'s fallback, and it is a product
  call, not a correctness one.
* **`MaterialListingPatchField`** now has a consumer (see below).
* **The on-site ledger arm** hand-listed three of four field names. Now derived from the
  constant. Measured both ways with a fifth member added: **before** 1 failed/14 (only the
  off-site ledger fired, on-site arm gave 0), **after** 2 failed/14.

## Verification

* `pnpm typecheck` — **0 type errors**.
  (A worktree without `git submodule update --init event-engine-common` reports 12 spurious
  `TS2307 Cannot find module` errors. Initialising the submodule clears all 12 — noted so the
  next person does not read them as a red base.)
* `vitest --project unit` over `src/components/Apps` + `src/server/services/blocks` —
  **219 files, 5,009 passed, 0 failed**.
* `vitest --project component` over `src/components/Apps` + `src/tests/pages/apps` —
  **82 files, 1,173 passed, 0 failed**.
* **Blocking CI gates**: `Prettier (added files)` **PASS** (0 unformatted, negative control
  verified); `ESLint (added files)` **clean**.
* **`ExternalListingEditForm.tsx` is deliberately left unformatted.** It was already
  unformatted at `b16cc80c2c`, prettier on MODIFIED files is report-only, and reformatting it
  turned a 60-line change into a 469-line diff (only 79 real by `diff -w`). Reverted so the
  delta against the audited tip stays reviewable — the exact trade-off the lint workflow's own
  header describes.
* Report-only: one pre-existing `no-wholesale-module-mock` error in
  `listing-media-page.browser.test.tsx` — present at `b16cc80c2c` (verified), untouched here.
  Not reshaped, because that mock's own warning describes the 0-tests-collected trap and
  rewriting it is a separate change.

### Red-at-base matrix

Measured by restoring the **production** files to `b16cc80c2c` and re-running:

| tier | suite | result at base | failure kind |
|---|---|---|---|
| unit | `offsiteEditConfig.test.ts` | **5 red** / 48 | 5 `AssertionError` |
| browser | `ExternalSubmitForm.ownerUnpublished…` | **3 red** / 14 executed | assertions |
| browser | `listing-media-page…` | **2 red** / 34 executed | assertions |

**0 "is not a function" and 0 import failures across all three** — checked explicitly, so no
test here is merely proving that a symbol is new rather than that a guard is covered.

🟡 **Tests that were GREEN at base are labelled 🟡 in the source and are NOT counted as
regression coverage**, per the labels measured above: the drifted-save dead end is
pre-existing, and the owner / published / undrifted arms are controls.

### Browser-runner validation

This host's nix Chromium is revision **1228**; `playwright-core@1.57.0` pins **1200**, and on
a mismatch the `component` project **collects files and executes ZERO tests while reporting
zero failures**. Runs used the `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` escape hatch, and every
verdict quotes the **executed test count** parsed from the summary line, never an exit code.

The counter was itself wrong on the first attempt — counting per-test `✓` lines reports 0 for
a healthy all-green run, because vitest prints them only on failure. Corrected against a
negative control: pointing the `component` project at a non-browser file correctly reports
**0 executed / meaningless**.

Similarly, the first dependency install reported **exit 0** while having run in the wrong
directory (`ERR_PNPM_NO_PKG_MANIFEST`, swallowed). Caught by checking `node_modules/.bin`
rather than the status.

### Round-2 mutation battery — 23 mutants + 1 positive control

Re-run in full (a fix round resets the gate). The harness **refuses a no-op mutation**
(exit 3), so a "SURVIVED" can never silently mean "the mutant never applied" — and that
fired once, on M16, whose target text prettier had reformatted; re-run against the real text
it was killed. Every mutant's file was restored and `cmp`-verified byte-identical.

| # | mutation | killed by |
|---|---|---|
| POS | `isUnpublishedEdit`: `'removed'`→`'nope'` (known-caught control) | 14/48 |
| M1 | `myAppListingHref` drops `lastModerationAction` (**the original defect**) | 🔴 EVERY production call site passes `lastModerationAction` |
| M2 | field named only in a **comment** inside the argument | 🔴 same assertion — proves the comment stripper is load-bearing |
| M3 | requirement silenced with a literal `null` | 🟡 no call site silences the requirement with a literal `null` |
| M4 | `editorTabsFor` ignores `lastModerationAction` entirely | 10 cases incl. NEVER Details / NEVER Media on a mod takedown |
| M5 | drop the drift arm (restores the FALSE sentence) | 🔴 the COPY tells the truth in the drifted state |
| M6 | drift arm fires **always** | 🟡 the UNDRIFTED copy is UNCHANGED (+3) |
| M7 | `scopeDisclosureLockedForEdit` drops the drift compare | 🔴 is TRUE once the mask has DRIFTED (+4) |
| M8 | `scopeDisclosureLockedForEdit` drops the status clause | 🔴 drift alone is NOT enough |
| M9 | `isOwnerEdit` always true (editor gets owner copy) | 🔴 a seated EDITOR is NOT told to use a tab they cannot see (+3) |
| M10 | `isOwnerEdit` always false (owner gets neutral copy) | 🟡 an OWNER is addressed as the person who can republish (+2) |
| M11 | absent role treated as OWNER (fail-safe inverted) | 🔴 an ABSENT role gets the ROLE-NEUTRAL copy |
| M12 | `ListingMediaEditor` `isOwner` always true | 🔴 a seated EDITOR is not blamed for the unpublish (+1) |
| M13 | `ListingMediaEditor` `isOwner` always false | 🔴 the OWNER still gets the owner copy |
| M14 | remove the Assets frame entirely | 🔴 …told these image writes are IMMEDIATE (+1) |
| M15 | Assets frame renders unconditionally | 🔴 CONTROL — a PUBLISHED listing gets NO such frame |
| M16 | Assets frame loses the role branch | 🔴 it is ROLE-AWARE, like every other repair-state sentence |
| M17 | add a **fifth** member to `MATERIAL_LISTING_PATCH_FIELDS` | 🔴 the ledger **and** the on-site arm (the latter only after the nit fix) |
| M1b | `myAppListingHref` drops the field — graded against the **behavioural** cases | 🔴 an OWNER-unpublished listing lands on Details (+1) |
| **M18** | field **PASSED but hardcoded** to `null` — the "wrong argument" shape a structural guard cannot see | 🔴 both behavioural cases **+** 🟡 the literal-`null` invariant. The ledger's SET and PROXIMITY assertions do **not** fire here — this is the gap the behavioural cases close |
| M19a | server drops `role` from `getMyListingForApp`'s return — graded by the **server** suite | 🔴 returns the OWNER role (+1) |
| **M19b** | **the SAME mutant, graded by the COMPONENT suite** | 🔴 **SURVIVED** — 34 executed, so it ran. **Deliberate**: see below |
| M20 | `role` hardcoded to `'owner'` (the plausible wrong fix) | 🔴 returns the EDITOR role for an ACCEPTED SEAT |
| **M21** | **re-append the false sentence to the locked notice — the original finding-3 contradiction** | 🔴 …the notice says so. **SURVIVED the first battery**; see below |

**Survivors: one, and it is the finding rather than a gap — M19b.** Every other mutant died
to an assertion naming **that** guard, and no mutant reported a zero or absent test count.

M19b is the same mutation as M19a graded against a different suite, run to **measure** a seam
rather than to guard it. `getMyListingForApp` now resolves a role and `ListingMediaEditor`
branches its copy on it, but `listing-media-page.browser.test.tsx` **stubs that query** — so
it asserts what the component does with a `role` it was handed and is structurally incapable
of noticing the server no longer sending one — a gap no amount of CI wiring closes, because
the suite itself cannot see it. Meanwhile the server suite asserted every other
field of the return and never mentioned `role`. Both sides hermetically tested; the pair still
breakable, and the failure is silent (`listing?.role === 'owner'` becomes `false` for OWNERS,
so every owner reads the collaborator copy).

The new server-side cases close it, which is what M19a shows. M19b is reported as a survivor
on purpose: it is the evidence that the component tier could never have caught this, and its
executed count (34) is quoted so "survived" cannot be read as "never ran".

**M21 was a genuine survivor and is now closed.** It re-appends *"Tagline, description and
category can be edited now."* to the material-locked notice — i.e. restores the exact
finding-3 contradiction — and it survived the whole battery (14 executed, so it ran). Both
existing assertions were correct and both passed:

* the **unit** test pins `materialEditBlockedReason`'s **return value**, and the mutant does
  not touch that function — the return is still right;
* the **browser** test asserted the notice **contains** "nothing on this screen can be saved",
  and appending text does not disturb a substring already matched.

Not a hypothetical shape: the original defect lived in the JSX as precisely such an append
(`{scopeLocked ? '…' : ''}` after the reason). Closed by asserting the **absence** of the
false sentence **in the render**, not merely in the function's output. Now KILLED (1/14).

It was only posed because the mutants had to be re-derived against a restored file (see
commit `6b02736383`) — a reminder that a battery only ever covers the mutations someone
thought to write.

## Still open — a human decision, deliberately untouched

**Finding 7.** The new media frame instructs an unreviewed-media path (unpublish → swap
imagery → republish, with no content review and no rating floor). This is **pre-existing at
the proc level** — `assertOwnerAssetEditable` refuses only an *approved* top-level listing, so
a `removed` listing has been directly asset-editable all along, and `republishOwnListing` runs
no rating floor. What this PR changes is its **discoverability**: the frame now tells authors
the path exists.

Behaviour and copy are **left exactly as they are**, pending an operator decision. #4418 adds
the rating floor that closes part of it.
