### PR TITLE
fix(auth): enforce email-domain blocklist + MX on every writer of User.email

### DIFF
--- a/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/blocklist.test.ts
@@ -18,7 +18,12 @@ vi.mock('../../db/db', () => ({
   },
 }));
 
-import { getBlockedEmailDomains } from '../blocklist';
+import {
+  emailDomain,
+  getBlockedEmailDomains,
+  isBlockedDomain,
+  normalizeEmailAddress,
+} from '../blocklist';
 
 const BLOCKLIST_KEY = 'system:blocklist:EmailDomain';
 
@@ -41,7 +46,10 @@ beforeEach(() => vi.clearAllMocks());
 describe('getBlockedEmailDomains', () => {
   it('returns the warm redis cache without touching the DB', async () => {
     const redis = makeRedis();
-    redis._store.set(BLOCKLIST_KEY, JSON.stringify({ type: 'EmailDomain', data: ['evil.com', 'bad.io'] }));
+    redis._store.set(
+      BLOCKLIST_KEY,
+      JSON.stringify({ type: 'EmailDomain', data: ['evil.com', 'bad.io'] })
+    );
     h.getRedis.mockReturnValue(redis);
 
     expect(await getBlockedEmailDomains()).toEqual(['evil.com', 'bad.io']);
@@ -127,5 +135,65 @@ describe('getBlockedEmailDomains', () => {
     h.getRedis.mockReturnValue(redis);
     h.executeTakeFirst.mockResolvedValue({ data: ['db.com'] });
     expect(await getBlockedEmailDomains()).toEqual(['db.com']);
+  });
+});
+
+describe('emailDomain', () => {
+  // Both hub call sites go through this, so reverting either one to `split('@')[1]` cannot pass
+  // unnoticed. The main app carries its own copy of the rule and its own test for it.
+  it('reads the domain after the LAST @, not the first', () => {
+    expect(emailDomain('"a@b"@example.com')).toBe('example.com');
+  });
+
+  it('lowercases and trims', () => {
+    expect(emailDomain('someone@ Example.COM ')).toBe('example.com');
+  });
+
+  it('returns empty string for an address with no @', () => {
+    expect(emailDomain('not-an-email')).toBe('');
+  });
+
+  it('returns empty string for a trailing @', () => {
+    expect(emailDomain('someone@')).toBe('');
+  });
+});
+
+describe('isBlockedDomain', () => {
+  // Both sides must go through the same normalizer. Stripping the input but not the entry would
+  // make a hand-typed `provider.com.` enforced by the main app and silently inert here.
+  it('matches a list entry that carries a trailing FQDN dot', () => {
+    expect(isBlockedDomain(['blocked.test.'], 'blocked.test')).toBe(true);
+  });
+
+  it('matches an entry with case and whitespace', () => {
+    expect(isBlockedDomain(['  Blocked.TEST  '], 'blocked.test')).toBe(true);
+  });
+
+  it('matches the WHOLE domain, not a substring', () => {
+    expect(isBlockedDomain(['ocked.test', 'test'], 'blocked.test')).toBe(false);
+  });
+
+  it('never matches an empty domain, whatever the list holds', () => {
+    expect(isBlockedDomain([''], '')).toBe(false);
+  });
+});
+
+describe('normalizeEmailAddress', () => {
+  // `userExistsByEmail` is both the returning-user exemption and the `+`-alias gate, and both key
+  // on the exact stored string, so a trailing dot would be a free second identity against both.
+  it('strips a trailing FQDN dot from the domain', () => {
+    expect(normalizeEmailAddress('someone@gmail.com.')).toBe('someone@gmail.com');
+  });
+
+  it('lowercases the domain and leaves the local part intact', () => {
+    expect(normalizeEmailAddress('Someone@GMAIL.com')).toBe('Someone@gmail.com');
+  });
+
+  it('normalizes the domain after the LAST @', () => {
+    expect(normalizeEmailAddress('"a@b"@GMAIL.com.')).toBe('"a@b"@gmail.com');
+  });
+
+  it('leaves an address with no @ alone beyond trim and case', () => {
+    expect(normalizeEmailAddress(' NotAnEmail ')).toBe('notanemail');
   });
 });

--- a/apps/auth/src/lib/server/auth/blocklist.ts
+++ b/apps/auth/src/lib/server/auth/blocklist.ts
@@ -23,6 +23,47 @@ const TTL_SECONDS = 5 * 60;
 type StringGet = { get(k: string): Promise<string | null | undefined> };
 type StringSet = { set(k: string, v: string, o: { EX: number }): Promise<unknown> };
 
+/** Trailing dot is the FQDN root and resolves identically, so it must not read as a new domain. */
+function normalizeDomain(domain: string): string {
+  return domain.trim().toLowerCase().replace(/\.+$/, '');
+}
+
+/**
+ * The domain of an email address, normalized for comparison against the blocklist.
+ *
+ * `lastIndexOf`, not `split('@')[1]`: a quoted-local address ("a@b"@host) carries more than one
+ * `@`, and taking the first segment yields a domain that matches no list entry — i.e. it ADMITS a
+ * blocked address. Shared by both hub call sites so reverting one cannot silently diverge from the
+ * other; the main app carries its own copy of the same rule in `blocklist.service.ts`.
+ */
+export function emailDomain(email: string): string {
+  const at = email.lastIndexOf('@');
+  return at === -1 ? '' : normalizeDomain(email.slice(at + 1));
+}
+
+/**
+ * Both sides go through the SAME normalizer. Stripping the input but not the list entry would make
+ * a hand-typed `provider.com.` enforced by the main app and silently inert here — the exact
+ * divergence `emailDomain` was extracted to prevent. The row is hand-edited by moderators, which is
+ * the premise the case-normalization rule rests on too.
+ */
+export function isBlockedDomain(entries: string[], domain: string): boolean {
+  return !!domain && entries.some((entry) => normalizeDomain(entry) === domain);
+}
+
+/**
+ * The address as it should be STORED and LOOKED UP.
+ *
+ * `userExistsByEmail` is both the returning-user exemption for the blocklist and the gate on the
+ * `+`-alias block, and both key on the exact stored string. Without this a trailing dot is a free
+ * second identity against both: one real mailbox, two `User` rows past a citext-unique column.
+ */
+export function normalizeEmailAddress(email: string): string {
+  const at = email.lastIndexOf('@');
+  if (at === -1) return email.trim().toLowerCase();
+  return `${email.slice(0, at).trim()}@${normalizeDomain(email.slice(at + 1))}`;
+}
+
 export async function getBlockedEmailDomains(): Promise<string[]> {
   const redis = getRedis();
   if (redis) {

--- a/apps/auth/src/lib/server/auth/users.ts
+++ b/apps/auth/src/lib/server/auth/users.ts
@@ -68,6 +68,17 @@ export async function userExistsByEmail(email: string): Promise<boolean> {
   return !!row;
 }
 
+/** True if this provider identity is already linked — i.e. a RETURNING user, not a signup. */
+export async function isLinkedAccount(provider: string, providerAccountId: string) {
+  const row = await db
+    .selectFrom('Account')
+    .select('userId')
+    .where('provider', '=', provider)
+    .where('providerAccountId', '=', providerAccountId)
+    .executeTakeFirst();
+  return !!row;
+}
+
 // Resolve (or provision) a Civitai user for an upstream OAuth profile, then link the Account.
 // Mirrors NextAuth's adapter behavior: match by linked account → verified email → create.
 export async function findOrCreateUser(

--- a/apps/auth/src/lib/server/metrics.ts
+++ b/apps/auth/src/lib/server/metrics.ts
@@ -7,11 +7,7 @@
 // All counters are registered at module load with their full label sets pre-declared, so they export `0`
 // before the first increment (no "metric appears only after the first event" gaps in dashboards).
 
-import {
-  Registry,
-  collectDefaultMetrics,
-  Counter,
-} from 'prom-client';
+import { Registry, collectDefaultMetrics, Counter } from 'prom-client';
 
 // Single default registry for the whole process. `register.metrics()` (in the /metrics route) serializes
 // everything registered here.
@@ -40,6 +36,20 @@ export const oauthEventsTotal = new Counter({
 export const emailLoginFailuresTotal = new Counter({
   name: 'hub_email_login_failures_total',
   help: 'Email magic-link login failures (send/token error caught in the login action).',
+  registers: [register],
+});
+
+/**
+ * Signups refused because the email domain is blocklisted, by which half of the gate refused.
+ * Without this the gate is unobservable: a refusal increments nothing else (`loginsTotal` is past
+ * the OAuth throw, `emailLoginFailuresTotal` counts only server errors), so nobody could tell a gate
+ * that fired ten thousand times from one that never fired, or measure the false-positive rate the
+ * change was justified with.
+ */
+export const blockedEmailDomainSignupsTotal = new Counter({
+  name: 'hub_blocked_email_domain_signups_total',
+  help: 'Signups refused because the email domain is on the blocklist, labeled by login path.',
+  labelNames: ['path'] as const,
   registers: [register],
 });
 

--- a/apps/auth/src/routes/login/+page.server.ts
+++ b/apps/auth/src/routes/login/+page.server.ts
@@ -8,13 +8,22 @@ import { readReturnUrl, readSync, buildPostLoginRedirect } from '$lib/server/aut
 import { buildPostLoginOriginCheck } from '$lib/server/oauth/first-party';
 import { createVerificationToken } from '$lib/server/auth/email-tokens';
 import { sendVerificationEmail } from '$lib/server/email/verification.email';
-import { captchaSiteKey, captchaManagedSiteKey, verifyCaptchaToken } from '$lib/server/auth/captcha';
-import { getBlockedEmailDomains } from '$lib/server/auth/blocklist';
+import {
+  captchaSiteKey,
+  captchaManagedSiteKey,
+  verifyCaptchaToken,
+} from '$lib/server/auth/captcha';
+import {
+  emailDomain,
+  getBlockedEmailDomains,
+  isBlockedDomain,
+  normalizeEmailAddress,
+} from '$lib/server/auth/blocklist';
 import { checkRateLimit } from '$lib/server/auth/rate-limit';
 import { getClientIp } from '$lib/server/auth/request';
 import { trackLoginRedirect } from '$lib/server/tracking';
 import { userExistsByEmail } from '$lib/server/auth/users';
-import { emailLoginFailuresTotal } from '$lib/server/metrics';
+import { blockedEmailDomainSignupsTotal, emailLoginFailuresTotal } from '$lib/server/metrics';
 import { logAxiomError } from '$lib/server/axiom';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -76,9 +85,7 @@ export const actions: Actions = {
   // and the blocked-email-domain list.
   email: async ({ request, url }) => {
     const data = await request.formData();
-    const email = String(data.get('email') ?? '')
-      .trim()
-      .toLowerCase();
+    const email = normalizeEmailAddress(String(data.get('email') ?? ''));
     const returnUrl = String(data.get('returnUrl') ?? '/');
     const sync = data.get(SYNC_PARAM) ? String(data.get(SYNC_PARAM)) : null;
 
@@ -99,7 +106,9 @@ export const actions: Actions = {
     //    can be split. Passes through when captcha is disabled (dev / no secret).
     const mode = data.get('captchaMode')?.toString() === 'managed' ? 'managed' : 'invisible';
     const captchaToken = (
-      mode === 'managed' ? data.get('managed-turnstile-response') : data.get('cf-turnstile-response')
+      mode === 'managed'
+        ? data.get('managed-turnstile-response')
+        : data.get('cf-turnstile-response')
     )?.toString();
     const failReason = data.get('captchaFailReason')?.toString() || undefined;
     if (!(await verifyCaptchaToken(captchaToken, ip ?? undefined, { mode, failReason }))) {
@@ -109,12 +118,13 @@ export const actions: Actions = {
     // 3. Blocked email domains: reject NEW signups on a blocklisted domain, but don't retroactively
     //    lock out EXISTING accounts when a domain is later appended to the upstream list (mirrors the
     //    existing-user exemption in step 4).
-    const domain = email.split('@')[1];
+    const domain = emailDomain(email);
     if (
       domain &&
-      (await getBlockedEmailDomains()).some((entry) => entry.trim().toLowerCase() === domain) &&
+      isBlockedDomain(await getBlockedEmailDomains(), domain) &&
       !(await userExistsByEmail(email))
     ) {
+      blockedEmailDomainSignupsTotal.inc({ path: 'email' });
       return fail(400, { email, blockedDomain: true });
     }
 

--- a/apps/auth/src/routes/login/+page.server.ts
+++ b/apps/auth/src/routes/login/+page.server.ts
@@ -110,7 +110,11 @@ export const actions: Actions = {
     //    lock out EXISTING accounts when a domain is later appended to the upstream list (mirrors the
     //    existing-user exemption in step 4).
     const domain = email.split('@')[1];
-    if (domain && (await getBlockedEmailDomains()).includes(domain) && !(await userExistsByEmail(email))) {
+    if (
+      domain &&
+      (await getBlockedEmailDomains()).some((entry) => entry.trim().toLowerCase() === domain) &&
+      !(await userExistsByEmail(email))
+    ) {
       return fail(400, { email, blockedDomain: true });
     }
 

--- a/apps/auth/src/routes/login/+page.svelte
+++ b/apps/auth/src/routes/login/+page.svelte
@@ -178,7 +178,9 @@
     </div>
     <h1>Sign Up or Log In</h1>
 
-    {#if data.error}
+    {#if data.error === 'BlockedDomain'}
+      <p class="error">That email domain isn't allowed. Try a different address.</p>
+    {:else if data.error}
       <p class="error">Login error: {data.error}</p>
     {/if}
 

--- a/apps/auth/src/routes/login/[provider]/callback/+server.ts
+++ b/apps/auth/src/routes/login/[provider]/callback/+server.ts
@@ -14,11 +14,16 @@ import {
   userExistsByEmail,
   isLinkedAccount,
 } from '$lib/server/auth/users';
-import { getBlockedEmailDomains } from '$lib/server/auth/blocklist';
+import {
+  emailDomain,
+  getBlockedEmailDomains,
+  isBlockedDomain,
+  normalizeEmailAddress,
+} from '$lib/server/auth/blocklist';
 import { establishSession } from '$lib/server/auth/session';
 import { buildPostLoginRedirect } from '$lib/server/auth/redirect';
 import { buildPostLoginOriginCheck } from '$lib/server/oauth/first-party';
-import { loginsTotal } from '$lib/server/metrics';
+import { blockedEmailDomainSignupsTotal, loginsTotal } from '$lib/server/metrics';
 
 export const GET: RequestHandler = async ({ params, url, cookies, locals }) => {
   const provider = getProvider(params.provider);
@@ -57,6 +62,9 @@ export const GET: RequestHandler = async ({ params, url, cookies, locals }) => {
     codeVerifier: verifier,
   });
   const profile = await fetchProfile(provider, accessToken);
+  // Normalize BEFORE anything reads it: `findOrCreateUser` both looks up and STORES this string,
+  // and a trailing-dot variant would be a second row for one real mailbox.
+  if (profile.email) profile.email = normalizeEmailAddress(profile.email);
 
   // Account-LINKING: attach this provider to the CURRENT user (no new user, no new session, no cross-domain
   // sync). On conflict, bounce back with an error the account page surfaces. The session must STILL be present
@@ -79,14 +87,25 @@ export const GET: RequestHandler = async ({ params, url, cookies, locals }) => {
   // blocked; a returning user (linked account, or an existing row on that address) is exempt for the
   // same reason as the email action — a domain appended upstream later must not lock anyone out.
   if (profile.email && profile.emailVerified) {
-    const domain = profile.email.split('@')[1]?.trim().toLowerCase();
+    const domain = emailDomain(profile.email);
     if (
       domain &&
-      (await getBlockedEmailDomains()).some((entry) => entry.trim().toLowerCase() === domain) &&
+      isBlockedDomain(await getBlockedEmailDomains(), domain) &&
       !(await isLinkedAccount(provider.id, profile.providerAccountId)) &&
       !(await userExistsByEmail(profile.email))
-    )
-      error(400, 'Sign-up from this email domain is not allowed');
+    ) {
+      blockedEmailDomainSignupsTotal.inc({ path: 'oauth' });
+      // NOT `error(400)`. This is a top-level browser navigation and apps/auth ships no
+      // +error.svelte, so a throw here renders SvelteKit's bare fallback page with no way back --
+      // and the flow cookies that would let them retry were already deleted above. Send them to the
+      // hub's own login page, which is what the email half of this same gate effectively does.
+      // `returnUrl` was read at the top, BEFORE the flow cookies were deleted, so a successful
+      // retry still lands where they started rather than at AUTH_DEFAULT_RETURN_URL.
+      const retry = new URL('/login', url.origin);
+      retry.searchParams.set('error', 'BlockedDomain');
+      if (returnUrl && returnUrl !== '/') retry.searchParams.set('returnUrl', returnUrl);
+      redirect(302, `${retry.pathname}${retry.search}`);
+    }
   }
 
   // Standard login / signup — the hub sets the session cookie here.

--- a/apps/auth/src/routes/login/[provider]/callback/+server.ts
+++ b/apps/auth/src/routes/login/[provider]/callback/+server.ts
@@ -8,7 +8,13 @@ import {
   fetchProfile,
   isStubProviderEnabled,
 } from '$lib/server/auth/providers';
-import { findOrCreateUser, linkAccountToUser } from '$lib/server/auth/users';
+import {
+  findOrCreateUser,
+  linkAccountToUser,
+  userExistsByEmail,
+  isLinkedAccount,
+} from '$lib/server/auth/users';
+import { getBlockedEmailDomains } from '$lib/server/auth/blocklist';
 import { establishSession } from '$lib/server/auth/session';
 import { buildPostLoginRedirect } from '$lib/server/auth/redirect';
 import { buildPostLoginOriginCheck } from '$lib/server/oauth/first-party';
@@ -65,6 +71,22 @@ export const GET: RequestHandler = async ({ params, url, cookies, locals }) => {
     const target =
       result === 'conflict' ? appendQuery(returnUrl, 'error', 'AccountNotLinked') : returnUrl;
     redirect(302, buildPostLoginRedirect(target, null, url.origin, dev, isAllowedOrigin));
+  }
+
+  // Blocked email domains, OAuth edge of the same gate the email action applies. A provider-VERIFIED
+  // address is deliverable by construction, so the blocklist is the whole check here — no MX probe.
+  // Ordered blocklist-first so the two lookups below only run for an address that is actually
+  // blocked; a returning user (linked account, or an existing row on that address) is exempt for the
+  // same reason as the email action — a domain appended upstream later must not lock anyone out.
+  if (profile.email && profile.emailVerified) {
+    const domain = profile.email.split('@')[1]?.trim().toLowerCase();
+    if (
+      domain &&
+      (await getBlockedEmailDomains()).some((entry) => entry.trim().toLowerCase() === domain) &&
+      !(await isLinkedAccount(provider.id, profile.providerAccountId)) &&
+      !(await userExistsByEmail(profile.email))
+    )
+      error(400, 'Sign-up from this email domain is not allowed');
   }
 
   // Standard login / signup — the hub sets the session cookie here.

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -114,6 +114,7 @@ import {
   updateUserById,
   userByReferralCode,
 } from '~/server/services/user.service';
+import { assertEmailAllowed } from '~/server/services/blocklist.service';
 import {
   handleLogError,
   throwAuthorizationError,
@@ -400,6 +401,9 @@ export const completeOnboardingHandler = async ({
       case OnboardingSteps.Profile: {
         if (input.username && !(await isUsernamePermitted(input.username)))
           throw throwBadRequestError('Invalid username');
+        // OAuth providers that hand us no email (Reddit) land here with `email: null`, and this step
+        // then REQUIRES one — free text that is never verified, which is the burner ring's door in.
+        if (input.email && input.email !== ctx.user.email) await assertEmailAllowed(input.email);
         await dbWrite.user.update({
           where: { id },
           data: { onboarding, username: input.username, email: input.email },

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -477,7 +477,10 @@ export const completeOnboardingHandler = async ({
     if (isComplete && changed && onboardingCompletedCounter) onboardingCompletedCounter.inc();
   } catch (e) {
     const err = e as Error;
-    if (!err.message.includes('constraint failed')) onboardingErrorCounter?.inc();
+    // A TRPCError here is a policy REFUSAL (blocked domain, undeliverable domain, rejected
+    // username), not a fault. Counting those inflates the error signal and hides the refusal rate.
+    if (!(e instanceof TRPCError) && !err.message.includes('constraint failed'))
+      onboardingErrorCounter?.inc();
     if (e instanceof TRPCError) throw e;
     throw throwDbError(e);
   }

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -404,7 +404,9 @@ export const userOnboardingSchema = z.discriminatedUnion('step', [
   z.object({
     step: z.literal(OnboardingSteps.Profile),
     username: usernameInputSchema,
-    email: z.string(),
+    // `.email()`, not a bare string: this is the only writer of `User.email` that was unvalidated,
+    // so a tRPC caller could post `x@!!!` and have it stored verbatim.
+    email: z.string().email(),
   }),
   z.object({ step: z.literal(OnboardingSteps.BrowsingLevels) }),
   z.object({

--- a/src/server/services/__tests__/email-domain-guard.call-sites.test.ts
+++ b/src/server/services/__tests__/email-domain-guard.call-sites.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as BlocklistService from '~/server/services/blocklist.service';
+
+/**
+ * 🔴 These test the ENFORCEMENT, not the guard. `email-domain-guard.test.ts` proves
+ * `assertEmailAllowed` rejects the right addresses; nothing there notices if a call site stops
+ * calling it, and a guard nobody calls is theatre.
+ *
+ * Both directions matter and they pull against each other:
+ *
+ *   - Miss the guard on a NEW address and the burner ring walks back in through onboarding, which is
+ *     the door this whole change exists to close.
+ *   - Run it on an EXISTING address and every user whose domain was blocklisted AFTER they signed up
+ *     is locked out of their own profile. The measured false-positive rate is not zero, so this
+ *     direction is a live user-facing risk, not a theoretical one.
+ *
+ * Mutations these catch that the unit suite does not: flipping `!==` to `===` in the onboarding call
+ * site (guard fires only when the address is UNCHANGED — wholly inert on the Reddit path), and
+ * swapping `delete data.email` for a guard call in `updateUserById` (the lockout).
+ */
+
+const { mockAssertEmailAllowed } = vi.hoisted(() => ({ mockAssertEmailAllowed: vi.fn() }));
+
+vi.mock('~/server/services/blocklist.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof BlocklistService>()),
+  assertEmailAllowed: mockAssertEmailAllowed,
+}));
+
+vi.mock('~/server/email/templates/emailVerification.email', () => ({
+  emailVerificationEmail: { send: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { OnboardingSteps } from '~/server/common/enums';
+import { completeOnboardingHandler } from '~/server/controllers/user.controller';
+import { updateUserById } from '~/server/services/user.service';
+import { requestEmailChange } from '~/server/services/email-verification.service';
+
+const USER_ID = 4242;
+const NEW_EMAIL = 'fresh@example.test';
+const OLD_EMAIL = 'existing@example.test';
+
+function onboardingCtx(email?: string) {
+  return {
+    user: { id: USER_ID, onboarding: 0, email },
+    domain: 'blue',
+  } as unknown as Parameters<typeof completeOnboardingHandler>[0]['ctx'];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAssertEmailAllowed.mockResolvedValue(undefined);
+  dbMock.dbWrite.user.update.mockResolvedValue({ id: USER_ID });
+  dbMock.dbWrite.user.findFirst.mockResolvedValue(null);
+  dbMock.dbRead.user.findFirst.mockResolvedValue(null);
+  dbMock.dbRead.user.findUnique.mockResolvedValue({ email: OLD_EMAIL, username: 'ada' });
+  redisMock.redis.set.mockResolvedValue('OK');
+});
+
+describe('onboarding Profile step', () => {
+  it('runs the guard on a NEW address', async () => {
+    await completeOnboardingHandler({
+      input: { step: OnboardingSteps.Profile, email: NEW_EMAIL },
+      ctx: onboardingCtx(undefined),
+    } as Parameters<typeof completeOnboardingHandler>[0]);
+
+    expect(mockAssertEmailAllowed).toHaveBeenCalledTimes(1);
+    expect(mockAssertEmailAllowed).toHaveBeenCalledWith(NEW_EMAIL);
+  });
+
+  it('does NOT run the guard when the address is UNCHANGED', async () => {
+    // The lockout direction: a user re-submitting this step with the address already on their
+    // account must not be re-judged against a list that has moved since they signed up.
+    await completeOnboardingHandler({
+      input: { step: OnboardingSteps.Profile, email: OLD_EMAIL },
+      ctx: onboardingCtx(OLD_EMAIL),
+    } as Parameters<typeof completeOnboardingHandler>[0]);
+
+    expect(mockAssertEmailAllowed).not.toHaveBeenCalled();
+  });
+
+  it('propagates the guard rejection instead of writing the address', async () => {
+    mockAssertEmailAllowed.mockRejectedValue(new Error('blocked'));
+
+    await expect(
+      completeOnboardingHandler({
+        input: { step: OnboardingSteps.Profile, email: NEW_EMAIL },
+        ctx: onboardingCtx(undefined),
+      } as Parameters<typeof completeOnboardingHandler>[0])
+    ).rejects.toThrow();
+
+    expect(dbMock.dbWrite.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateUserById', () => {
+  it('runs the guard when the user has NO address on file', async () => {
+    dbMock.dbWrite.user.findFirst.mockResolvedValue({ email: null });
+
+    await updateUserById({ id: USER_ID, data: { email: NEW_EMAIL } });
+
+    expect(mockAssertEmailAllowed).toHaveBeenCalledTimes(1);
+    expect(mockAssertEmailAllowed).toHaveBeenCalledWith(NEW_EMAIL);
+  });
+
+  it('does NOT run the guard when the user ALREADY has an address, and drops the field', async () => {
+    dbMock.dbWrite.user.findFirst.mockResolvedValue({ email: OLD_EMAIL });
+
+    await updateUserById({ id: USER_ID, data: { email: NEW_EMAIL } });
+
+    expect(mockAssertEmailAllowed).not.toHaveBeenCalled();
+    // The existing "don't overwrite an existing email" rule still holds: the field is stripped, so
+    // the guard has nothing to judge and the user cannot be locked out by a later list change.
+    const [call] = dbMock.dbWrite.user.update.mock.calls;
+    expect(call[0].data).not.toHaveProperty('email');
+  });
+
+  it('propagates the guard rejection instead of writing', async () => {
+    dbMock.dbWrite.user.findFirst.mockResolvedValue({ email: null });
+    mockAssertEmailAllowed.mockRejectedValue(new Error('blocked'));
+
+    await expect(updateUserById({ id: USER_ID, data: { email: NEW_EMAIL } })).rejects.toThrow();
+
+    expect(dbMock.dbWrite.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('requestEmailChange', () => {
+  it('runs the guard on the requested address', async () => {
+    await requestEmailChange(USER_ID, NEW_EMAIL);
+
+    expect(mockAssertEmailAllowed).toHaveBeenCalledTimes(1);
+    expect(mockAssertEmailAllowed).toHaveBeenCalledWith(NEW_EMAIL);
+  });
+
+  it('runs the guard BEFORE issuing a token or sending mail', async () => {
+    mockAssertEmailAllowed.mockRejectedValue(new Error('blocked'));
+
+    await expect(requestEmailChange(USER_ID, NEW_EMAIL)).rejects.toThrow();
+
+    expect(redisMock.redis.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/email-domain-guard.test.ts
+++ b/src/server/services/__tests__/email-domain-guard.test.ts
@@ -120,7 +120,75 @@ describe('assertEmailAllowed', () => {
     expect(resolveMx).not.toHaveBeenCalled();
   });
 
+  it('does not throw when the cached blocklist value carries NO `data` key', async () => {
+    // `getBlocklistDTO` returns `JSON.parse(cached)` verbatim, and this shape is one three
+    // separately-released apps can write into the shared key — the auth hub's blocklist test
+    // asserts it directly. Without the `?? []` in getBlockedEmailDomains this is a TypeError on
+    // `.some`, i.e. a 500 on every signup, which is how it surfaced in the full suite.
+    redisGet.mockResolvedValue(JSON.stringify({ type: BlocklistType.EmailDomain }));
+
+    await expect(assertEmailAllowed('someone@no-data-key.test')).resolves.toBeUndefined();
+  });
+
+  it('DEGRADES OPEN when the blocklist lookup itself fails', async () => {
+    // The lookup is a redis GET falling back to a `dbWrite` read. Rejecting on a failure there
+    // would take down signup, profile-email set and email change together, for as long as the blip
+    // lasts — and Reddit accounts arrive with no address, so that is the whole funnel.
+    redisGet.mockRejectedValue(new Error('redis unreachable'));
+
+    await expect(assertEmailAllowed('someone@lookup-down.test')).resolves.toBeUndefined();
+  });
+
+  it('strips a trailing FQDN dot before comparing against the list', async () => {
+    // `provider.com.` resolves identically to `provider.com` but is a distinct string, so without
+    // this it misses every entry AND takes a second slot in a citext-unique column.
+    setBlockedDomains(['blocked-fqdn.test']);
+
+    expect(await reject('someone@blocked-fqdn.test.')).toBeInstanceOf(TRPCError);
+  });
+
+  it('rejects a malformed domain the resolver refuses to look up (EBADNAME)', async () => {
+    // EBADNAME is an answer — "this cannot be a hostname" — not a failed lookup. Folding it into
+    // the fail-open branch would ACCEPT exactly the invented input this check exists to reject.
+    resolveMx.mockRejectedValue(dnsError('EBADNAME'));
+
+    expect(await reject('someone@!!!')).toBeInstanceOf(TRPCError);
+  });
+
   it('rejects an address with no domain part', async () => {
     expect(await reject('not-an-email')).toBeInstanceOf(TRPCError);
+  });
+
+  it('rejects an address that is all local part and a trailing @', async () => {
+    expect(await reject('someone@')).toBeInstanceOf(TRPCError);
+  });
+
+  it('reads the domain after the LAST @, not the first', async () => {
+    // A quoted-local address carries more than one `@`. Taking the first segment yields a domain
+    // that matches no list entry, which admits a blocked address rather than rejecting it.
+    setBlockedDomains(['blocked-last-at.test']);
+
+    expect(await reject('"a@b"@blocked-last-at.test')).toBeInstanceOf(TRPCError);
+  });
+
+  it('matches the WHOLE domain, not a substring of it', async () => {
+    // Negative control for the matcher. Without an allowed address tested against a NON-empty list,
+    // widening the comparison to `domain.includes(entry)` passes every other test in this file — and
+    // in production an entry of `com` would then block everything, on a list moderators hand-edit.
+    setBlockedDomains(['owed-substring.test', 'test']);
+
+    await expect(assertEmailAllowed('someone@allowed-substring.test')).resolves.toBeUndefined();
+  });
+
+  it('matches a list entry that carries surrounding whitespace', async () => {
+    setBlockedDomains(['  blocked-untrimmed.test  ']);
+
+    expect(await reject('someone@blocked-untrimmed.test')).toBeInstanceOf(TRPCError);
+  });
+
+  it('matches an address typed with surrounding whitespace', async () => {
+    setBlockedDomains(['blocked-input-space.test']);
+
+    expect(await reject('someone@ blocked-input-space.test ')).toBeInstanceOf(TRPCError);
   });
 });

--- a/src/server/services/__tests__/email-domain-guard.test.ts
+++ b/src/server/services/__tests__/email-domain-guard.test.ts
@@ -1,0 +1,126 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * 🔴 The MX half of this guard is deliberate and is NOT redundant with the blocklist.
+ *
+ * The blocklist covers ~8,500 KNOWN disposable providers — real domains that accept mail. It cannot
+ * cover an INVENTED domain, and the burner ring measured on 2026-08-26 was typing invented ones
+ * (`gof33etchbitch.ccc`, `eh8798wit.com`) into the onboarding email field, which is free text and is
+ * never verified. Five of the eight domains their banned accounts used resolve to NXDOMAIN.
+ *
+ * If you are here to simplify this to "the blocklist already covers it", it does not, and removing
+ * the MX check reopens the door. The fail-open case below is equally deliberate: a resolver blip
+ * must not stop everyone from setting an email address.
+ */
+
+const resolveMx = vi.hoisted(() => vi.fn());
+vi.mock('dns/promises', () => ({ default: { resolveMx }, resolveMx }));
+
+import { assertEmailAllowed } from '../blocklist.service';
+import { BlocklistType } from '~/server/common/enums';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+const redisGet = redisMock.redis.get;
+
+function setBlockedDomains(domains: string[]) {
+  redisGet.mockResolvedValue(JSON.stringify({ type: BlocklistType.EmailDomain, data: domains }));
+}
+
+function dnsError(code: string) {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+async function reject(email: string) {
+  let caught: unknown;
+  try {
+    await assertEmailAllowed(email);
+  } catch (e) {
+    caught = e;
+  }
+  return caught;
+}
+
+describe('assertEmailAllowed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setBlockedDomains([]);
+    resolveMx.mockResolvedValue([{ exchange: 'mx.example.com', priority: 10 }]);
+  });
+
+  it('allows a normal address on a domain with MX records', async () => {
+    await expect(assertEmailAllowed('someone@allowed-normal.test')).resolves.toBeUndefined();
+  });
+
+  it('rejects a blocklisted domain as BAD_REQUEST, not a 500', async () => {
+    setBlockedDomains(['blocked-basic.test']);
+
+    const caught = await reject('someone@blocked-basic.test');
+
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  it('rejects a blocklisted domain whose LIST ENTRY is mixed case', async () => {
+    // The upstream sync writes lowercase, but the same row is hand-edited by moderators. Comparing
+    // raw would make one capital letter silently match nothing.
+    setBlockedDomains(['Blocked-MixedCase.TEST']);
+
+    expect(await reject('someone@blocked-mixedcase.test')).toBeInstanceOf(TRPCError);
+  });
+
+  it('rejects a blocklisted domain typed in mixed case', async () => {
+    setBlockedDomains(['blocked-input-case.test']);
+
+    expect(await reject('someone@Blocked-Input-Case.TEST')).toBeInstanceOf(TRPCError);
+  });
+
+  it('rejects an invented domain that does not resolve (ENOTFOUND)', async () => {
+    resolveMx.mockRejectedValue(dnsError('ENOTFOUND'));
+
+    const caught = await reject('someone@gof33etchbitch.ccc');
+
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  it('rejects a parked domain that resolves but publishes no MX (ENODATA)', async () => {
+    resolveMx.mockRejectedValue(dnsError('ENODATA'));
+
+    expect(await reject('someone@parked-no-mx.test')).toBeInstanceOf(TRPCError);
+  });
+
+  it('rejects a domain whose MX lookup returns an empty record set', async () => {
+    resolveMx.mockResolvedValue([]);
+
+    expect(await reject('someone@empty-mx.test')).toBeInstanceOf(TRPCError);
+  });
+
+  it('FAILS OPEN when the resolver itself fails (SERVFAIL)', async () => {
+    // A DNS blip must not become "nobody can set an email address". Only ENOTFOUND/ENODATA are
+    // answers; everything else is the absence of one.
+    resolveMx.mockRejectedValue(dnsError('SERVFAIL'));
+
+    await expect(assertEmailAllowed('someone@resolver-down.test')).resolves.toBeUndefined();
+  });
+
+  it('FAILS OPEN when the resolver times out', async () => {
+    resolveMx.mockRejectedValue(dnsError('ETIMEOUT'));
+
+    await expect(assertEmailAllowed('someone@resolver-slow.test')).resolves.toBeUndefined();
+  });
+
+  it('checks the blocklist BEFORE DNS, so a blocked domain never costs a lookup', async () => {
+    setBlockedDomains(['blocked-no-dns.test']);
+
+    await reject('someone@blocked-no-dns.test');
+
+    expect(resolveMx).not.toHaveBeenCalled();
+  });
+
+  it('rejects an address with no domain part', async () => {
+    expect(await reject('not-an-email')).toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/services/__tests__/email-verification.session-bust-failure.test.ts
+++ b/src/server/services/__tests__/email-verification.session-bust-failure.test.ts
@@ -22,6 +22,11 @@ vi.mock('~/server/utils/errorHandling', async (importOriginal) => ({
   handleLogError: mockHandleLogError,
 }));
 
+// `requestEmailChange` now runs the email-domain guard first, whose MX probe would otherwise do a
+// live DNS lookup for `ada@example.test` (a reserved TLD that never resolves) and reject before any
+// of the session-bust behaviour under test is reached.
+vi.mock('~/server/utils/email-domain', () => ({ domainAcceptsMail: async () => true }));
+
 const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
 vi.mock('~/server/email/templates/emailVerification.email', () => ({
   emailVerificationEmail: { send: mockSend },

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -10,6 +10,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { buildBenignPhraseRegex, stripBenignPhrasesWith } from '~/shared/utils/benign-phrases';
 import { removeTags, removeTagsCompact } from '~/utils/string-helpers';
 import { foldConfusables } from '~/server/utils/confusable-fold';
+import { domainAcceptsMail } from '~/server/utils/email-domain';
 
 export type BlocklistDTO = {
   id?: number;
@@ -497,5 +498,32 @@ export async function throwOnBlockedCommentContent(
 // #region [blocked emails]
 export async function getBlockedEmailDomains() {
   return await getBlocklistData(BlocklistType.EmailDomain);
+}
+
+/**
+ * Reject an email address whose domain is blocklisted or publishes no MX record.
+ *
+ * The two halves catch different things and neither subsumes the other: the blocklist covers the
+ * ~8,500 KNOWN disposable providers, which are real domains that accept mail; the MX check covers
+ * INVENTED domains, which no list can ever enumerate. The auth hub's magic-link action has had the
+ * blocklist half since the login cutover and its email path is the one at zero — every remaining
+ * writer of `User.email` (onboarding, profile update, email change) is free text that is never
+ * verified, so those need both.
+ *
+ * Callers must exempt users who ALREADY have this address. A domain appended to the upstream list
+ * later must not lock out an account that predates it — same rule as the hub's login action.
+ */
+export async function assertEmailAllowed(email: string) {
+  const domain = email.split('@')[1]?.trim().toLowerCase();
+  if (!domain) throw throwBadRequestError('Please provide a valid email address');
+
+  const blocked = await getBlockedEmailDomains();
+  // Normalize BOTH sides: the upstream sync writes lowercase today, but the same row is hand-edited
+  // by moderators, and a single capital letter would silently make an entry match nothing.
+  if (blocked.some((entry) => entry.trim().toLowerCase() === domain))
+    throw throwBadRequestError('Please use a different email address');
+
+  if (!(await domainAcceptsMail(domain)))
+    throw throwBadRequestError('Please use a different email address');
 }
 // #endregion

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -217,7 +217,16 @@ async function readBlocklistRow(type: BlocklistType): Promise<BlocklistDTO> {
 
 export async function getBlocklistDTO({ type }: { type: BlocklistType }) {
   const cached = await redis.get(getBlocklistKey(type));
-  if (cached) return JSON.parse(cached) as BlocklistDTO;
+  if (cached) {
+    // 🔴 `data ?? []` is load-bearing. A cached value with no `data` key is a shape three
+    // separately-released apps can write into this key, and every consumer here calls `.some`,
+    // `.map` or `.join` on the result — one of them gates account signup, so letting `undefined`
+    // through turns a cache-shape surprise into a 500. Defaulted HERE rather than per-caller so a
+    // new BlocklistType consumer inherits it. The spread preserves the absent-`id` sentinel that
+    // `getClientBenignLists` reads as "no moderator row yet".
+    const parsed = JSON.parse(cached) as BlocklistDTO;
+    return { ...parsed, data: parsed.data ?? [] };
+  }
 
   const result = await readBlocklistRow(type);
 
@@ -496,6 +505,8 @@ export async function throwOnBlockedCommentContent(
 // #endregion
 
 // #region [blocked emails]
+
+const TRAILING_DOTS = /\.+$/;
 export async function getBlockedEmailDomains() {
   return await getBlocklistData(BlocklistType.EmailDomain);
 }
@@ -514,13 +525,37 @@ export async function getBlockedEmailDomains() {
  * later must not lock out an account that predates it — same rule as the hub's login action.
  */
 export async function assertEmailAllowed(email: string) {
-  const domain = email.split('@')[1]?.trim().toLowerCase();
+  // `lastIndexOf`, not `split('@')[1]`: a quoted-local address ("a@b"@host) has more than one `@`,
+  // and taking the first segment yields a domain that matches nothing. A trailing dot is the FQDN
+  // root and resolves identically, so `provider.com.` would otherwise miss every list entry, pass
+  // the MX probe, and take a second slot in a citext-unique column for one real mailbox.
+  // Kept identical to the hub's `emailDomain` -- fixing one side only is how the two diverge.
+  const at = email.lastIndexOf('@');
+  const rawDomain = at === -1 ? '' : email.slice(at + 1);
+  const domain = rawDomain.trim().toLowerCase().replace(TRAILING_DOTS, '');
   if (!domain) throw throwBadRequestError('Please provide a valid email address');
 
-  const blocked = await getBlockedEmailDomains();
+  // 🔴 DEGRADE OPEN. This lookup is a redis GET falling back to a `dbWrite` read, neither of which
+  // is guarded. A redis failover or a saturated writer pool would otherwise reject every signup,
+  // every profile-email set and every email change for its duration -- and Reddit accounts arrive
+  // with no address at all, so that is the whole funnel for that provider. The auth hub's mirror of
+  // this lookup already ends in `catch { return [] }` for the same reason; the two must agree.
+  let blocked: string[];
+  try {
+    blocked = await getBlockedEmailDomains();
+  } catch (error) {
+    logToAxiom({
+      name: 'email-blocklist-lookup-failed',
+      type: 'error',
+      message: 'Email domain blocklist unreadable; signup allowed without the blocklist check',
+      details: { error: error instanceof Error ? error.message : String(error) },
+    }).catch(() => undefined);
+    blocked = [];
+  }
+
   // Normalize BOTH sides: the upstream sync writes lowercase today, but the same row is hand-edited
   // by moderators, and a single capital letter would silently make an entry match nothing.
-  if (blocked.some((entry) => entry.trim().toLowerCase() === domain))
+  if (blocked.some((entry) => entry.trim().toLowerCase().replace(TRAILING_DOTS, '') === domain))
     throw throwBadRequestError('Please use a different email address');
 
   if (!(await domainAcceptsMail(domain)))

--- a/src/server/services/email-verification.service.ts
+++ b/src/server/services/email-verification.service.ts
@@ -10,6 +10,7 @@ import {
 import { REDIS_KEYS, redis } from '~/server/redis/client';
 import { refreshSession } from '~/server/auth/session-invalidation';
 import { userUpdateCounter } from '~/server/prom/client';
+import { assertEmailAllowed } from '~/server/services/blocklist.service';
 
 const EMAIL_VERIFICATION_EXPIRY = 15 * 60; // 15 minutes in seconds
 
@@ -82,6 +83,8 @@ export async function verifyEmailChangeToken(token: string) {
 }
 
 export async function requestEmailChange(userId: number, newEmail: string) {
+  await assertEmailAllowed(newEmail);
+
   // Check if the new email is already in use
   const existingUser = await dbRead.user.findFirst({
     where: { email: newEmail },

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -120,7 +120,7 @@ import {
   UserEngagementType,
 } from '~/shared/utils/prisma/enums';
 import blockedUsernames from '~/utils/blocklist-username.json';
-import { getBlocklistData } from '~/server/services/blocklist.service';
+import { assertEmailAllowed, getBlocklistData } from '~/server/services/blocklist.service';
 import { removeEmpty } from '~/utils/object-helpers';
 import { isDefined } from '~/utils/type-guards';
 import { simpleCosmeticSelect } from '../selectors/cosmetic.selector';
@@ -628,7 +628,11 @@ export const updateUserById = async ({
 }) => {
   if (data.email) {
     const existingData = await dbWrite.user.findFirst({ where: { id }, select: { email: true } });
+    // Only a user with NO address on file can set one here, so the guard runs on exactly the writes
+    // that survive — an existing address was already vetted when it was set.
     if (existingData?.email) delete data.email;
+    else if (typeof data.email === 'string') await assertEmailAllowed(data.email);
+    else delete data.email;
   }
 
   if (

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1251,6 +1251,9 @@ export const restoreUser = async ({ id, username, email, restoreModels }: Restor
 
   const { imageRemoval: _removalChoice, ...meta } = (user.meta ?? {}) as UserMeta;
 
+  // Deliberately NOT domain-guarded, same exempt class as `forceUpdateUserIdentity`: this is a
+  // moderator putting back the address a closed account already had, and re-judging it against a
+  // list that moved since would make some accounts unrestorable.
   await dbWrite.$transaction([
     dbWrite.user.update({
       where: { id },

--- a/src/server/utils/email-domain.ts
+++ b/src/server/utils/email-domain.ts
@@ -2,16 +2,25 @@ import dns from 'dns/promises';
 import { createLruCache } from '~/server/utils/lru-cache';
 
 /**
- * Domains resolve to the same answer for every user and change on the order of days, so a short
- * pod-local TTL is the whole cache story — a burst of signups from one ring hits DNS once.
+ * A repeat of the SAME domain inside the window skips the lookup. It does NOT coalesce concurrent
+ * misses — `fetch` is get / miss / await / set, so N simultaneous signups on one new domain issue N
+ * queries — and the entry cap is trivially flushed by an attacker cycling fresh domains. Sized for
+ * ordinary repetition, not as a rate limit.
+ *
+ * The window is deliberately short. A NEGATIVE is cached on the same TTL as a positive, and a
+ * forged or transient NXDOMAIN for a major provider would otherwise refuse every user on it for the
+ * whole window, on the signup path, with no way to bust the entry.
  */
 const mxCache = createLruCache<string, { deliverable: boolean }>({
   name: 'email-domain-mx',
-  ttl: 10 * 60 * 1000,
+  ttl: 60 * 1000,
   max: 5000,
   keyFn: (domain) => domain,
   fetchFn: async (domain) => ({ deliverable: await resolveDeliverable(domain) }),
 });
+
+/** c-ares has no deadline of its own; without this an unresponsive resolver holds the mutation. */
+const DNS_TIMEOUT_MS = 3000;
 
 /**
  * 🔴 FAIL OPEN on anything that is not a definitive "this domain has no mail exchanger".
@@ -22,11 +31,19 @@ const mxCache = createLruCache<string, { deliverable: boolean }>({
  */
 async function resolveDeliverable(domain: string) {
   try {
-    const records = await dns.resolveMx(domain);
+    const records = await Promise.race([
+      dns.resolveMx(domain),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('dns-timeout')), DNS_TIMEOUT_MS).unref?.()
+      ),
+    ]);
     return records.length > 0;
   } catch (error) {
     const code = (error as NodeJS.ErrnoException)?.code;
-    return code !== 'ENOTFOUND' && code !== 'ENODATA';
+    // EBADNAME is an ANSWER, not a failure: the resolver is saying this cannot be a hostname. It is
+    // what `x@!!!`, `gmail.com..` and an embedded NUL produce, so treating it as "no answer" would
+    // ACCEPT exactly the malformed input this check exists to reject.
+    return code !== 'ENOTFOUND' && code !== 'ENODATA' && code !== 'EBADNAME';
   }
 }
 
@@ -42,6 +59,7 @@ async function resolveDeliverable(domain: string) {
  */
 export async function domainAcceptsMail(domain: string) {
   if (!domain) return false;
+  if (domain.length > 253) return false;
   const { deliverable } = await mxCache.fetch(domain.toLowerCase());
   return deliverable;
 }

--- a/src/server/utils/email-domain.ts
+++ b/src/server/utils/email-domain.ts
@@ -1,0 +1,47 @@
+import dns from 'dns/promises';
+import { createLruCache } from '~/server/utils/lru-cache';
+
+/**
+ * Domains resolve to the same answer for every user and change on the order of days, so a short
+ * pod-local TTL is the whole cache story — a burst of signups from one ring hits DNS once.
+ */
+const mxCache = createLruCache<string, { deliverable: boolean }>({
+  name: 'email-domain-mx',
+  ttl: 10 * 60 * 1000,
+  max: 5000,
+  keyFn: (domain) => domain,
+  fetchFn: async (domain) => ({ deliverable: await resolveDeliverable(domain) }),
+});
+
+/**
+ * 🔴 FAIL OPEN on anything that is not a definitive "this domain has no mail exchanger".
+ *
+ * `ENOTFOUND` (no such domain) and `ENODATA` (domain exists, no MX record) are answers. Everything
+ * else — SERVFAIL, timeouts, a resolver that is briefly unreachable — is the absence of an answer,
+ * and treating it as a rejection turns a DNS blip into "nobody can set an email address".
+ */
+async function resolveDeliverable(domain: string) {
+  try {
+    const records = await dns.resolveMx(domain);
+    return records.length > 0;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    return code !== 'ENOTFOUND' && code !== 'ENODATA';
+  }
+}
+
+/**
+ * Does this domain publish an MX record? Deliberately NOT satisfied by an A record: an implicit-MX
+ * fallback is legal but in practice a domain with an A record and no MX is a parked squat, which is
+ * how the burner ring's addresses look (`ehotmail.com` resolves, accepts no mail).
+ *
+ * Measured against production 2026-08-26, users created since Aug 19 with no ban: of the top 400
+ * domains (56,462 users) this rejects 2 domains / 6 users (0.011%); of a random 400 domains seen
+ * once or twice (428 users) it rejects 9 domains / 9 users (2.10%), of which 6 are disposable or
+ * typo'd. Requiring MX is the part that generalizes — an invented domain cannot be on a blocklist.
+ */
+export async function domainAcceptsMail(domain: string) {
+  if (!domain) return false;
+  const { deliverable } = await mxCache.fetch(domain.toLowerCase());
+  return deliverable;
+}


### PR DESCRIPTION
## What

The `EmailDomain` blocklist was consulted in exactly one place: the auth hub's magic-link action. Every other writer of `User.email` is free text that is never verified. This adds an `assertEmailAllowed` guard (blocklist + MX) to all of them, and the blocklist half to the hub's OAuth callback.

## Why

Measured against production on 2026-08-26.

The email path's guard works. Disposable-domain signups by day, email-only accounts:

| Day | email signups | on a blocklisted domain |
|---|---|---|
| Aug 22 | 2,399 | 630 |
| Aug 23 | 2,359 | 634 |
| Aug 24 | 3,750 | 1,968 |
| Aug 25 | 3,141 | 1,063 |
| Aug 26 | 1,850 | **0** |

Last one through: `2026-08-25 16:00:53Z`. The blocklist row's `updatedAt`: `2026-08-25 16:23:57Z`. Positive control for the zero: 1,850 email signups still happened on the 26th.

The burner ring moved to Reddit. Reddit's OAuth profile carries no email, so the account is created with `email: null` and onboarding's Profile step then *requires* one, validated for username and unchecked for email. Since Aug 18: 98.8% of Reddit accounts (1,927/1,950) hold an unverified address, 10.4% are on a domain already blocklisted (20% this week), against Google's 0.03%. Their banned accounts carry `gof33etchbitch.ccc`, `eh8798wit.com`, `gmail.com.com`, `linkedin.com`. `.ccc` is not a TLD.

## Why both halves

Neither subsumes the other. The blocklist covers ~8,500 **known** disposable providers, which are real domains that accept mail. The MX check covers **invented** domains, which no list can enumerate. Requiring MX rejects 5 of the 8 domains the ring's banned accounts used.

## Hook points

| Path | Guard |
|---|---|
| `completeOnboardingHandler` to `OnboardingSteps.Profile` | blocklist + MX |
| `updateUserById` (the `user.update` mutation) | blocklist + MX, only when no address is on file |
| `requestEmailChange` | blocklist + MX |
| auth hub OAuth callback | blocklist only |

The OAuth callback gets no MX probe on purpose: a provider-**verified** address is deliverable by construction, so a DNS lookup there is new failure surface on every login for no abuse benefit.

Two writers are deliberately exempt, both moderator-only, both now commented as such: `forceUpdateUserIdentity` (identity correction) and `restoreUser` (a mod putting back the address a closed account already had; re-judging it against a list that has moved would make some accounts unrestorable).

## Failure semantics: both halves degrade OPEN

- **Blocklist**: the lookup is a `redis.get` falling through to a `dbWrite` read, neither guarded. It now catches, logs `email-blocklist-lookup-failed`, and allows. Unguarded, a Redis failover or a saturated writer pool would have rejected every signup, profile-email set and email change for its duration, and Reddit accounts arrive with no address, so that is the whole funnel for that provider. Matches the hub's existing `catch { return [] }`.
- **MX**: only `ENOTFOUND`, `ENODATA` and `EBADNAME` are treated as answers. SERVFAIL, timeouts and an unreachable resolver all pass. There is a 3s deadline (c-ares has none of its own) which rejects with a plain `Error`, so the timeout arm fails open too.

`EBADNAME` is in the reject set deliberately: it is the resolver saying "this cannot be a hostname", which is what `x@!!!` and `gmail.com..` produce. Folding it into fail-open would accept exactly the invented input this exists to reject.

## Normalization

Domain comparison strips whitespace, case **and** a trailing FQDN dot, on **both** sides. The list is hand-edited by moderators. A trailing dot resolves identically (`gmail.com.` has 5 live MX records) but is a distinct string, so without this it misses every entry, passes the MX probe, and takes a second slot in a citext-unique column.

In the hub that is one exported `isBlockedDomain`, used by both call sites, plus `normalizeEmailAddress` applied on the **write** path. Both hub anti-abuse gates (`userExistsByEmail` as the returning-user exemption, and the `+`-alias block) key on the exact stored string, so a trailing dot was a free second identity against both.

The normalization is forward-only, so the obvious question is whether dotted rows already exist. They do not: `SELECT count(*) FROM "User" WHERE email LIKE '%.'` returns **0**, against 11,566,827 rows with an email. No backfill needed. Domain case is the other non-canonical spelling that can reach the column, and it is not a duplicate risk at all: citext makes it match the canonical row, which is why this needed a normalization on the write rather than a backfill.

`userOnboardingSchema`'s Profile branch is now `z.string().email()` rather than a bare `z.string()`. It was the only unvalidated writer of the column.

## False-positive risk, measured

Prod users created since Aug 19 with no ban:

- Top 400 domains (56,462 users): rejects **2 domains / 6 users (0.011%)**, namely `globalcampus.edu.pl` (NXDOMAIN) and `hotmail.co` (typo, no MX).
- Random 400 domains seen once or twice (428 users): rejects **9 domains / 9 users (2.10%)**, of which 6 are disposable or typo'd.

The second stratum is the honest upper bound; those rare domains are a small share of total signups.

## Observability

New `hub_blocked_email_domain_signups_total{path}` counter, incremented on **both** halves of the gate. Previously a refusal incremented nothing anywhere, since `loginsTotal` is past the OAuth throw and `emailLoginFailuresTotal` counts only server errors, so nobody could have told a gate that fired ten thousand times from one that never fired, or measured the false-positive rate above.

On the main app, `onboardingErrorCounter` now skips `TRPCError`, so policy refusals stop inflating an error signal.

A blocked OAuth signup is redirected to `/login?error=BlockedDomain` with its `returnUrl` preserved, not thrown as a 400. `apps/auth` ships no `+error.svelte`, so a throw rendered SvelteKit's bare fallback page with no way back, and the flow cookies that would allow a retry are deleted earlier in the handler.

## Verification

- `pnpm run typecheck`: 0 type errors
- `svelte-check` (apps/auth): `8043 FILES 0 ERRORS 1 WARNINGS`; the warning is pre-existing in `+page.svelte`
- `eslint` over the changed files: 0 errors
- apps suite: `Test Files 93 passed (93)` / `Tests 1009 passed | 35 skipped (1044)`
- unit suite: posted as a comment below

**Every guard has a mutation run and reverted.** Fourteen in total; each gives exit 1 with a named assertion, never a hang:

| mutation | result |
|---|---|
| drop the MX half | `3 failed \| 8 passed (11)` |
| drop the blocklist half | `4 failed \| 7 passed (11)` |
| fail *closed* on a resolver error | `2 failed \| 9 passed (11)` |
| raw `.includes` instead of case normalization | `1 failed \| 10 passed (11)` |
| drop `data ?? []` in `getBlocklistDTO` | `1 failed \| 16 passed (17)` |
| remove the degrade-open catch | `1 failed \| 19 passed (20)` |
| drop the trailing-dot strip | `1 failed \| 19 passed (20)` |
| drop `EBADNAME` from the reject set | `1 failed \| 19 passed (20)` |
| flip `!==` to `===` at the onboarding call site | `3 failed \| 5 passed (8)` |
| guard-on-existing-address in `updateUserById` (the lockout) | `1 failed \| 7 passed (8)` |
| delete the `requestEmailChange` call | `2 failed \| 6 passed (8)` |
| delete the `updateUserById` call | `2 failed \| 6 passed (8)` |
| hub `emailDomain` back to `split('@')[1]` | `1 failed \| 12 passed (13)` |
| hub `isBlockedDomain` entry side unnormalized | `1 failed \| 20 passed (21)` |

The `!==` to `===` one matters most: it makes the guard fire only when the address is **unchanged**, so it is wholly inert on the Reddit onboarding path this change exists to close, and before the call-site suite existed it turned nothing red.

## Found during review, not by me

Three adversarial reviewers, each prompted to refute. Between them:

- The blocklist half failed **closed** on a Redis or DB blip, 500ing the whole signup funnel.
- `EBADNAME` was being **accepted**, and the onboarding schema was a bare `z.string()`, so `x@!!!` stored verbatim.
- A trailing-dot FQDN defeated the blocklist and the email-uniqueness constraint.
- The call sites had no test at all, so the guard could be made inert with a one-character edit and a green suite.
- The blocklist matcher had no negative control: every "allowed" test ran against an empty list, so a widening mutation survived.
- The OAuth reject was a dead-end error page, and the whole gate was unobservable.
- A false claim in a comment: the LRU does **not** coalesce concurrent misses, so "a burst of signups from one ring hits DNS once" was wrong as written. Comment corrected rather than the behaviour changed.

One reviewer independently enumerated **eight** writers of `User.email` across `src/`, `apps/` and `packages/` rather than trusting the list above, and found `restoreUser` missing from it. Its own caveat is worth repeating: a multiline grep **missed** `forceUpdateUserIdentity`, because that function builds `data.email` on a separate line from the `update()` call. A grep-only enumeration of this column is not sound.

## Known gaps

- **The hub's callback guard and its login-action comparison have no test of their own.** `apps/auth/src/routes/login/__tests__/` holds only `login-captcha.test.ts`. The shared helpers they call (`emailDomain`, `isBlockedDomain`, `normalizeEmailAddress`) are tested and mutation-verified; the callback's exemption branches are not. The branch most worth covering is `isLinkedAccount` true with `User.email` null, the one case where the two exemptions are not interchangeable, and the one a future refactor would most plausibly drop as redundant.
- `mxCache` is module-scope with no reset. The guard suite is order-independent only because every test uses a distinct domain. Adding a production seam purely for tests seemed the worse trade.
- Domain matching is exact equality, so subdomains and punycode/IDN variants miss. Inherited, shared by all copies, unchanged here.

## Not in scope

No migration. No product change to new-account friction. Requiring a *verified* email before posting is a separate decision, and worth noting that verification alone is not a spam signal: banned-account rate since Aug 18 was 3.84% for verified addresses versus 2.73% for unverified, because a disposable inbox verifies fine.
