### PR TITLE
feat(moderator): record which service credential authenticated each inbound request

### DIFF
--- a/apps/moderator/src/__tests__/hooks.server.test.ts
+++ b/apps/moderator/src/__tests__/hooks.server.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * CREDENTIAL ATTRIBUTION AT THE INGRESS.
+ *
+ * `hooks.server.ts` is the only place a verified inbound service credential is turned into request
+ * state, so it is the only place that can record WHICH credential class authenticated. That record is
+ * the runtime signal the WEBHOOK_TOKEN removal is graded on (see the header of
+ * `$lib/server/webhook-endpoint`), which makes these behavioural guards, not logging cosmetics:
+ *
+ *   - BOTH classes emit. A legacy-only emitter would make a zero unfalsifiable.
+ *   - The record carries NOTHING derived from the token's bytes.
+ *   - `locals.tokenClient` is still exactly `'webhook'`, for both classes. Three call sites compare
+ *     that field strictly; widening it would 401 every token-authenticated request with no type error.
+ *   - A refused credential records nothing.
+ *   - A logging fault never becomes a failed request.
+ *
+ * Three modules are replaced at load. Each is named with why, because a wholesale module mock is how a
+ * suite goes green against a module that has since grown an export it needs:
+ *   `$lib/server/page-access` — transitively imports `$lib/server/db`, which demands DATABASE_URL and
+ *     DATABASE_REPLICA_URL at MODULE SCOPE. The moderator vitest config withholds the replica URL on
+ *     purpose, so importing the hook for real throws before any test runs. Only `loadPageAccessGrants`
+ *     is reachable from the hook.
+ *   `$lib/server/auth` — its `guard` opens a session client at module scope and would make a network
+ *     call on the session path. Only `guard.check` is reachable from the hook.
+ *   `$lib/server/axiom` — the surface under assertion. Both exports the hook imports are replaced.
+ *
+ * `$lib/server/webhook-endpoint` is deliberately NOT mocked: the credential the record carries comes
+ * from the real comparison against real env values, so these tests fail if attribution is wired to a
+ * constant.
+ */
+
+type Emitted = Record<string, unknown>;
+
+// The parameter types are declared rather than inferred: `vi.fn(async () => …)` infers an EMPTY
+// argument tuple, so `mock.calls[n][0]` is then `undefined` at the type level and every assertion on
+// the emitted record silently reads nothing.
+const { loadPageAccessGrants, guardCheck, logToAxiom, logAxiomError } = vi.hoisted(() => ({
+  loadPageAccessGrants: vi.fn(async () => ({})),
+  guardCheck: vi.fn(async (_cookieHeader: string, _returnUrl: string) => ({} as unknown)),
+  logToAxiom: vi.fn(async (_data: Emitted, _datastream?: string) => undefined as unknown),
+  logAxiomError: vi.fn(async (_error: unknown, _extra?: Emitted) => undefined as unknown),
+}));
+
+vi.mock('$lib/server/page-access', () => ({ loadPageAccessGrants }));
+vi.mock('$lib/server/auth', () => ({ guard: { check: guardCheck } }));
+vi.mock('$lib/server/axiom', () => ({
+  logToAxiom,
+  logAxiomError,
+  safeError: (e: unknown) => ({ e }),
+}));
+
+const { handle, CREDENTIAL_ATTRIBUTION_EVENT } = await import('../hooks.server');
+
+/**
+ * Fixture values, chosen pairwise distinct and distinct from every constant an assertion below names —
+ * neither secret spells a credential class, the path is not `/api/`, the method is not the `GET` a
+ * bare `new Request()` would default to, and the user-agent is not a substring of anything else. A
+ * fixture that can only ever produce the value an assertion hardcodes cannot see a hardcode mutant.
+ */
+const INBOUND_SECRET = 'sk-inbound-9f31c2';
+const LEGACY_SECRET = 'sk-legacy-4a70de';
+const PATH = '/api/mod/abuse-report';
+const METHOD = 'PATCH';
+const USER_AGENT = 'civitai-web/2026.08 (delegated-moderation)';
+
+function eventFor(options: { query?: string; authorization?: string; path?: string }) {
+  const url = new URL(`https://moderator.civitai.com${options.path ?? PATH}`);
+  if (options.query !== undefined) url.searchParams.set('token', options.query);
+  const headers = new Headers({ 'user-agent': USER_AGENT });
+  if (options.authorization !== undefined) headers.set('authorization', options.authorization);
+  return {
+    url,
+    request: new Request(url, { method: METHOD, headers }),
+    locals: {} as Record<string, unknown>,
+    route: { id: PATH },
+  };
+}
+
+/** Runs the hook with a resolve() that reports whether it was reached. */
+async function run(event: ReturnType<typeof eventFor>) {
+  // 204 marks "the handler ran", and is distinct from every status the hook itself can produce (302
+  // login, 303 forbidden/denied, 401 refused, 503 unconfigured) so a test can tell them apart. Null
+  // body because the Response constructor rejects a body on a 204.
+  const resolve = vi.fn(async () => new Response(null, { status: 204 }));
+  // The hook's real signature carries SvelteKit internals no test constructs; the shape above is
+  // everything this code path reads.
+  const response = await (handle as unknown as (arg: unknown) => Promise<Response>)({
+    event,
+    resolve,
+  });
+  return { response, resolve };
+}
+
+const emitted = (): Emitted[] => logToAxiom.mock.calls.map((call) => call[0] as Emitted);
+
+function setEnv(vars: { WEBHOOK_TOKEN?: string; MOD_INBOUND_TOKEN?: string }) {
+  delete process.env.WEBHOOK_TOKEN;
+  delete process.env.MOD_INBOUND_TOKEN;
+  if (vars.WEBHOOK_TOKEN !== undefined) process.env.WEBHOOK_TOKEN = vars.WEBHOOK_TOKEN;
+  if (vars.MOD_INBOUND_TOKEN !== undefined) process.env.MOD_INBOUND_TOKEN = vars.MOD_INBOUND_TOKEN;
+}
+
+const saved = {
+  WEBHOOK_TOKEN: process.env.WEBHOOK_TOKEN,
+  MOD_INBOUND_TOKEN: process.env.MOD_INBOUND_TOKEN,
+};
+
+/**
+ * Every test owns its own reset — no `vi.resetModules()`, and nothing here depends on the order the
+ * file runs in. Prove it with `--sequence.shuffle` rather than trusting the arrangement.
+ */
+beforeEach(() => {
+  logToAxiom.mockReset();
+  logToAxiom.mockResolvedValue(undefined);
+  logAxiomError.mockReset();
+  guardCheck.mockReset();
+  guardCheck.mockResolvedValue({ status: 'login', redirect: 'https://auth.example/login' });
+  setEnv({ MOD_INBOUND_TOKEN: INBOUND_SECRET, WEBHOOK_TOKEN: LEGACY_SECRET });
+});
+afterEach(() => setEnv(saved));
+
+describe('inbound credential attribution', () => {
+  it('records MOD_INBOUND_TOKEN, with exactly the fields the migration read needs and nothing else', async () => {
+    const { resolve } = await run(eventFor({ query: INBOUND_SECRET }));
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+    // An EXACT match, not a `toMatchObject`: the strongest available guard against a future edit
+    // adding a token prefix, length or hash to the record. Any extra key fails here.
+    expect(emitted()).toEqual([
+      {
+        type: 'info',
+        event: CREDENTIAL_ATTRIBUTION_EVENT,
+        credential: 'MOD_INBOUND_TOKEN',
+        path: PATH,
+        method: METHOD,
+        userAgent: USER_AGENT,
+      },
+    ]);
+  });
+
+  it('records WEBHOOK_TOKEN for the legacy credential — the class the migration is waiting to stop seeing', async () => {
+    await run(eventFor({ query: LEGACY_SECRET }));
+    expect(emitted()).toEqual([
+      {
+        type: 'info',
+        event: CREDENTIAL_ATTRIBUTION_EVENT,
+        credential: 'WEBHOOK_TOKEN',
+        path: PATH,
+        method: METHOD,
+        userAgent: USER_AGENT,
+      },
+    ]);
+  });
+
+  it('🔴 BOTH classes emit from one deployment — the zero is only evidence beside a live control', async () => {
+    // The property this whole change exists to provide, and the one a "log only the legacy token"
+    // optimisation would silently remove. Both requests hit the SAME env state, so a non-zero
+    // MOD_INBOUND_TOKEN count is the in-band positive control that proves the emit path was live at
+    // the moment a WEBHOOK_TOKEN count read zero. Asserted as a SET of classes so it cannot be
+    // satisfied by two lines naming the same one.
+    await run(eventFor({ query: INBOUND_SECRET }));
+    await run(eventFor({ query: LEGACY_SECRET }));
+    expect(emitted().map((record) => record.credential)).toEqual([
+      'MOD_INBOUND_TOKEN',
+      'WEBHOOK_TOKEN',
+    ]);
+  });
+
+  it('attributes a Bearer-presented credential the same as a query-presented one', async () => {
+    await run(eventFor({ authorization: `Bearer ${LEGACY_SECRET}` }));
+    expect(emitted()).toHaveLength(1);
+    expect(emitted()[0].credential).toBe('WEBHOOK_TOKEN');
+  });
+
+  it('🔴 carries NOTHING derived from the token bytes, even when the token is in the URL', async () => {
+    // `?token=` is how the main app calls in, so `url.href`/`url.search` would put the live secret on
+    // a log stream far more readable than the secret store. `pathname` is what keeps it out.
+    await run(eventFor({ query: LEGACY_SECRET }));
+    const serialized = JSON.stringify(emitted());
+    expect(serialized).not.toContain(LEGACY_SECRET);
+    // …and no PREFIX of it either, which is what a "just the first few characters for correlation"
+    // edit would add. Six characters past the shared `sk-` prefix is already an oracle.
+    expect(serialized).not.toContain(LEGACY_SECRET.slice(0, 9));
+    expect(serialized).not.toContain(String(LEGACY_SECRET.length));
+  });
+});
+
+describe('what must NOT be recorded', () => {
+  it('a REFUSED credential records nothing and never reaches a handler', async () => {
+    const { response, resolve } = await run(eventFor({ query: 'not-a-configured-secret' }));
+    expect(response.status).toBe(401);
+    expect(resolve).not.toHaveBeenCalled();
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('a request presenting NO credential falls through to the session guard and records nothing', async () => {
+    const { response, resolve } = await run(eventFor({}));
+    // The `none` verdict: the hook must not answer it, it must hand it to the session guard.
+    expect(guardCheck).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(302);
+    expect(resolve).not.toHaveBeenCalled();
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('the 503 no-secret-configured path is unchanged, and records nothing', async () => {
+    setEnv({});
+    const { response, resolve } = await run(eventFor({ query: LEGACY_SECRET }));
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Neither MOD_INBOUND_TOKEN nor WEBHOOK_TOKEN is configured on this deployment.',
+    });
+    expect(resolve).not.toHaveBeenCalled();
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('a non-/api/ path is not treated as token ingress even when a token is presented', async () => {
+    const { response } = await run(eventFor({ query: INBOUND_SECRET, path: '/reports/abc' }));
+    expect(guardCheck).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(302);
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+});
+
+describe('locals.tokenClient stays exactly "webhook"', () => {
+  /**
+   * The regression guard for the three strict consumers — `WebhookEndpoint` and
+   * `defineWebhookEndpoint` compare `!== 'webhook'`, `defineEndpoint` reads it for truthiness. The
+   * obvious way to expose the credential class is to widen this field; doing so refuses every
+   * token-authenticated request at all three sites, with no type error to catch it.
+   *
+   * `toBe` on the literal, not a truthiness check: `'webhook:legacy'` is truthy too.
+   */
+  it('for MOD_INBOUND_TOKEN', async () => {
+    const event = eventFor({ query: INBOUND_SECRET });
+    await run(event);
+    expect(event.locals.tokenClient).toBe('webhook');
+  });
+
+  it('for WEBHOOK_TOKEN', async () => {
+    const event = eventFor({ query: LEGACY_SECRET });
+    await run(event);
+    expect(event.locals.tokenClient).toBe('webhook');
+  });
+
+  it('and grants are emptied on token ingress, so nothing reached this way inherits a permission', async () => {
+    const event = eventFor({ query: INBOUND_SECRET });
+    await run(event);
+    expect(event.locals.grants).toEqual({});
+    expect(event.locals.user).toBeUndefined();
+  });
+});
+
+describe('attribution never breaks a request', () => {
+  it('ATTACHES a rejection handler to the emit — a logger that REJECTS must not surface anywhere', async () => {
+    // 🔴 The behavioural half of this (request still 204) passes with the `.catch()` DELETED, because
+    // an unhandled rejection inside a vitest worker is reported out-of-band and does not fail the
+    // request. Measured: removing `.catch(() => {})` left this file fully green. In the server it is
+    // not benign — Node's default `--unhandled-rejections=throw` terminates the process, so the
+    // deleted handler turns a logging blip into a pod restart.
+    //
+    // So the assertion is on the handler being attached, observed on the very promise the hook is
+    // handed. That IS the code path, not a word about it.
+    const rejected = Promise.reject(new Error('axiom ingest refused'));
+    const catchSpy = vi.spyOn(rejected, 'catch');
+    logToAxiom.mockReturnValue(rejected);
+
+    const { response, resolve } = await run(eventFor({ query: INBOUND_SECRET }));
+    // Read BEFORE this test attaches its own handler below, or the count stops being about the hook.
+    const attachedByHook = catchSpy.mock.calls.length;
+    rejected.catch(() => {});
+
+    expect(attachedByHook).toBe(1);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(204);
+  });
+
+  it('survives a logger that throws SYNCHRONOUSLY, which a bare .catch() would not', async () => {
+    // The half a promise `.catch()` cannot cover: a throw on the way IN never produces a promise to
+    // attach a handler to. Distinct from the rejecting case above, and it fails differently — the
+    // throw propagates out of the hook and the request 500s.
+    logToAxiom.mockImplementation(() => {
+      throw new Error('logger constructed badly');
+    });
+    const { response, resolve } = await run(eventFor({ query: INBOUND_SECRET }));
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(204);
+  });
+});

--- a/apps/moderator/src/hooks.server.ts
+++ b/apps/moderator/src/hooks.server.ts
@@ -3,8 +3,8 @@ import { civitaiAppUrl } from '$lib/server/civitai-url';
 import { guard } from '$lib/server/auth';
 import { applyGrants, canAccess, resolvePermissions } from '$lib/server/access';
 import { loadPageAccessGrants } from '$lib/server/page-access';
-import { authenticateWebhookToken } from '$lib/server/webhook-endpoint';
-import { logAxiomError } from '$lib/server/axiom';
+import { authenticateWebhookToken, type AcceptedCredential } from '$lib/server/webhook-endpoint';
+import { logAxiomError, logToAxiom } from '$lib/server/axiom';
 
 // Where authenticated-but-not-a-moderator users get sent. A 403 would be a dead end (re-login can't
 // grant the role); bounce them to the main site instead. Overridable via env for non-prod hosts.
@@ -21,6 +21,56 @@ const NON_MODERATOR_REDIRECT = civitaiAppUrl();
 // where there is no cookie). Everything else is gated.
 const PUBLIC_PATHS = new Set(['/favicon.svg']);
 
+/**
+ * The `event` string every credential-attribution line carries. One constant so a soak query and the
+ * emit below cannot drift, and so renaming it is a visible edit rather than a silently-unmatched
+ * filter.
+ */
+export const CREDENTIAL_ATTRIBUTION_EVENT = 'webhook credential presented';
+
+/**
+ * Records WHICH inbound service credential authenticated a request — the runtime signal that makes
+ * dropping WEBHOOK_TOKEN from `acceptedTokens` a checkable claim rather than an inferred one (see the
+ * header of $lib/server/webhook-endpoint).
+ *
+ * 🔴 EMITTED FOR EVERY CLASS, NOT JUST THE LEGACY ONE. Logging only WEBHOOK_TOKEN looks like the
+ * obvious saving — it is the thing we are waiting to stop seeing — and it destroys the evidence. A
+ * zero from a legacy-only emitter is indistinguishable from an emitter that was never deployed, never
+ * ingested, or quietly broken, so it can never license the removal. With both classes emitted, a
+ * non-zero MOD_INBOUND_TOKEN count is the IN-BAND POSITIVE CONTROL standing beside the WEBHOOK_TOKEN
+ * zero in the same window and proving the instrument was live when it read zero. The pair is the
+ * evidence. Do not narrow this to the legacy class.
+ *
+ * 🔴 NOTHING DERIVED FROM THE TOKEN'S BYTES GOES IN THE RECORD — no value, prefix, suffix, length or
+ * hash. Any of those is a credential oracle on a log stream that is far more widely readable than the
+ * secret store. The class NAME is the whole payload. `pathname` specifically, never `url.href` or
+ * `url.search`: callers may present the token as `?token=`, so the full URL carries the secret.
+ *
+ * `userAgent` and `method` are here because the migration's question is not only WHETHER the legacy
+ * credential is still presented but BY WHOM — a count with no way to reach the caller cannot be acted
+ * on.
+ *
+ * Fire-and-forget, and swallows its own failure both ways a promise-returning call can fail —
+ * attribution must never be the thing that breaks a request. Same contract as `logAxiomError`.
+ */
+function logCredentialAttribution(
+  event: Parameters<Handle>[0]['event'],
+  credential: AcceptedCredential
+): void {
+  try {
+    void logToAxiom({
+      type: 'info',
+      event: CREDENTIAL_ATTRIBUTION_EVENT,
+      credential,
+      path: event.url.pathname,
+      method: event.request.method,
+      userAgent: event.request.headers.get('user-agent'),
+    }).catch(() => {});
+  } catch {
+    /* see above: a logging fault must not surface as a failed moderation call */
+  }
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
   if (PUBLIC_PATHS.has(event.url.pathname)) return resolve(event);
   // An /api/* request presenting a credential of its own is verified HERE and never redirected to the hub
@@ -30,9 +80,18 @@ export const handle: Handle = async ({ event, resolve }) => {
   // can attribute a write.
   if (event.url.pathname.startsWith('/api/')) {
     const token = authenticateWebhookToken(event);
-    if (token instanceof Response) return token;
-    if (token === 'webhook') {
-      event.locals.tokenClient = token;
+    // Branch on the tag and nothing else — `refused` carries a Response, and a Response is an object,
+    // so an `instanceof`/`typeof` discriminator would silently start mis-sorting the moment another
+    // object-shaped member is added.
+    if (token.kind === 'refused') return token.response;
+    if (token.kind === 'authenticated') {
+      logCredentialAttribution(event, token.credential);
+      // 🔴 Stays the bare string, for BOTH credential classes. Which credential authenticated is a
+      // migration question and belongs in the log line above; it is NOT a privilege distinction, and
+      // three call sites compare this field strictly (`!== 'webhook'` in the two endpoint wrappers,
+      // truthiness in defineEndpoint). Widening it to carry the class would refuse every
+      // token-authenticated request at those sites without a type error anywhere.
+      event.locals.tokenClient = 'webhook';
       event.locals.grants = {};
       return resolve(event);
     }

--- a/apps/moderator/src/lib/server/__tests__/webhook-endpoint-timing.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/webhook-endpoint-timing.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * THE NO-EARLY-EXIT PROPERTY, pinned by counting the REAL comparisons the shipped loop performs.
+ *
+ * `authenticateWebhookToken` compares the presented token against every configured credential and
+ * never stops at the first match, so how long the loop runs does not reveal WHICH credential matched.
+ * That is a claim about the loop's control flow, and control flow is not observable from the return
+ * value — the verdict is identical with and without a `break`.
+ *
+ * So the observation is the number of `timingSafeEqual` calls one request produces. It is taken from
+ * the real `node:crypto` binding the module under test imports, not from a re-implementation: a model
+ * of the loop written in the test file would go on passing after a `break` was added to production.
+ *
+ * 🔴 EVERY FIXTURE SECRET BELOW IS THE SAME LENGTH. The loop checks length before calling
+ * timingSafeEqual (that function throws on a length mismatch), so a shorter second secret would be
+ * skipped by the length check and never counted — the test would then read 1 comparison and blame a
+ * `break` that is not there. Equal lengths are what make the count a measurement of the loop rather
+ * than of the fixture.
+ *
+ * This file mocks a module at load, so it is deliberately separate from `webhook-endpoint.test.ts`
+ * rather than being a `describe` block with a local reset: a module mock is file-scoped, and reaching
+ * for `vi.resetModules()` to confine one has already produced an order-dependent verdict in this
+ * codebase.
+ */
+
+const { timingSafeEqualSpy } = vi.hoisted(() => ({ timingSafeEqualSpy: vi.fn() }));
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  // Spread the real module and wrap ONE export. A hand-written replacement object goes stale the
+  // moment the module under test reaches for a second crypto function, and does so as an import-time
+  // failure that reads like a broken suite rather than a stale mock.
+  timingSafeEqualSpy.mockImplementation(actual.timingSafeEqual);
+  return { ...actual, timingSafeEqual: timingSafeEqualSpy };
+});
+
+const { authenticateWebhookToken } = await import('$lib/server/webhook-endpoint');
+
+/** Same LENGTH, different bytes — see the header. */
+const INBOUND_SECRET = 'inbound-secret-value-aaaa';
+const LEGACY_SECRET = 'legacy--secret-value-bbbb';
+
+function requestPresenting(token: string) {
+  const url = new URL('https://moderator.civitai.com/api/mod/abuse-report');
+  url.searchParams.set('token', token);
+  return { url, request: new Request(url, { method: 'POST' }) };
+}
+
+function setEnv(vars: { WEBHOOK_TOKEN?: string; MOD_INBOUND_TOKEN?: string }) {
+  delete process.env.WEBHOOK_TOKEN;
+  delete process.env.MOD_INBOUND_TOKEN;
+  if (vars.WEBHOOK_TOKEN !== undefined) process.env.WEBHOOK_TOKEN = vars.WEBHOOK_TOKEN;
+  if (vars.MOD_INBOUND_TOKEN !== undefined) process.env.MOD_INBOUND_TOKEN = vars.MOD_INBOUND_TOKEN;
+}
+
+const saved = {
+  WEBHOOK_TOKEN: process.env.WEBHOOK_TOKEN,
+  MOD_INBOUND_TOKEN: process.env.MOD_INBOUND_TOKEN,
+};
+
+/** Every test owns its own reset, so no verdict here depends on the order the file runs in. */
+beforeEach(() => {
+  timingSafeEqualSpy.mockClear();
+  setEnv({ MOD_INBOUND_TOKEN: INBOUND_SECRET, WEBHOOK_TOKEN: LEGACY_SECRET });
+});
+afterEach(() => setEnv(saved));
+
+describe('the token comparison loop', () => {
+  it('POSITIVE CONTROL: the counter tracks candidates — one configured credential produces one comparison', () => {
+    // Without this, a `2` below would be indistinguishable from a spy that fires on something other
+    // than the loop. Watch the number MOVE with the number of configured credentials before reading
+    // any other count in this file as evidence about control flow.
+    setEnv({ MOD_INBOUND_TOKEN: INBOUND_SECRET });
+    const result = authenticateWebhookToken(requestPresenting(INBOUND_SECRET));
+    expect(result).toEqual({ kind: 'authenticated', credential: 'MOD_INBOUND_TOKEN' });
+    expect(timingSafeEqualSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('REGRESSION: a match on the FIRST candidate STILL compares the second — no early exit', () => {
+    // The one observation that discriminates. An early exit answers 1 here and 2 in both controls
+    // below, so this case alone is what separates the two implementations.
+    const result = authenticateWebhookToken(requestPresenting(INBOUND_SECRET));
+    expect(result).toEqual({ kind: 'authenticated', credential: 'MOD_INBOUND_TOKEN' });
+    expect(timingSafeEqualSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('CONTROL: a match on the LAST candidate compares both — an early-exit loop answers 2 here too', () => {
+    const result = authenticateWebhookToken(requestPresenting(LEGACY_SECRET));
+    expect(result).toEqual({ kind: 'authenticated', credential: 'WEBHOOK_TOKEN' });
+    expect(timingSafeEqualSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('CONTROL: no match compares both — an early-exit loop answers 2 here too', () => {
+    const result = authenticateWebhookToken(requestPresenting('wrong-secret-value-cccccc'));
+    expect(result.kind).toBe('refused');
+    expect(timingSafeEqualSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('INVARIANT: a length mismatch is never handed to timingSafeEqual, which throws on one', () => {
+    // The length guard is what keeps a short token a 401 rather than a 500 out of the hook. Both
+    // configured secrets are longer than this, so a comparison count of 0 is the assertion that the
+    // guard ran ahead of the call for BOTH candidates.
+    const result = authenticateWebhookToken(requestPresenting('short'));
+    expect(result.kind).toBe('refused');
+    expect(timingSafeEqualSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/webhook-endpoint.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { authenticateWebhookToken } from '$lib/server/webhook-endpoint';
+import {
+  ACCEPTED_CREDENTIALS,
+  authenticateWebhookToken,
+  type WebhookAuthResult,
+} from '$lib/server/webhook-endpoint';
 
 /**
  * Inbound service-token authentication — the ONLY place this app verifies a token. `WebhookEndpoint`
@@ -8,20 +12,23 @@ import { authenticateWebhookToken } from '$lib/server/webhook-endpoint';
  * so everything about which credentials are accepted is decided here.
  *
  * Two tiers below, labelled, because they are not the same kind of evidence. The tiers are defined by
- * the MATRIX, not by subject matter — run this file against `origin/main`'s webhook-endpoint.ts and
- * exactly the REGRESSION set fails:
+ * the MATRIX, not by subject matter — run this file against a tree without the credential-attribution
+ * change and exactly the REGRESSION set fails:
  *
- *   REGRESSION — red before the change, green after. Mostly the MOD_INBOUND_TOKEN cases, plus the
- *     whitespace-only-secret case, which is not about the new variable at all: it pins an auth bypass
- *     the change closed as a side effect.
- *   INVARIANT  — green on BOTH sides: the WEBHOOK_TOKEN, fail-closed and rejection cases. They are
- *     here because the change's whole point is that they must KEEP passing — the main app presents
- *     WEBHOOK_TOKEN on every call into this app, so accepting a second token must not stop accepting
- *     the first.
+ *   REGRESSION — red before the change, green after: the cases that pin WHICH credential matched, and
+ *     the tagged-union verdict shape that carries it.
+ *   INVARIANT  — green on BOTH sides once the union shape is accounted for: the accept/refuse/503
+ *     decisions themselves, which this change must not move. They are here because the change's whole
+ *     point is that they must KEEP passing — the main app presents WEBHOOK_TOKEN on every call into
+ *     this app, so recording which credential matched must not stop either one from matching.
  *
  * `$env/dynamic/private` is aliased to `src/test/env.mock.ts`, which is `process.env` itself, and
  * `acceptedTokens()` re-reads it per call — so assigning here really does change what the function
  * sees.
+ *
+ * 🔴 The two secret VALUES are deliberately unrelated to the two credential CLASS names an assertion
+ * checks for. A fixture whose value equals the constant the assertion names cannot see a mutant that
+ * hardcodes that constant.
  */
 
 const LEGACY = 'legacy-shared-token';
@@ -43,6 +50,17 @@ function setEnv(vars: { WEBHOOK_TOKEN?: string; MOD_INBOUND_TOKEN?: string }) {
   if (vars.MOD_INBOUND_TOKEN !== undefined) process.env.MOD_INBOUND_TOKEN = vars.MOD_INBOUND_TOKEN;
 }
 
+/**
+ * Narrows to the refused arm, failing the test rather than throwing an unhelpful cast error when the
+ * verdict is something else. Asserting `kind` here is what makes the `.status` read below meaningful:
+ * a bare cast would read `undefined` off an authenticated verdict and compare it to a number.
+ */
+function refusalOf(result: WebhookAuthResult): Response {
+  expect(result.kind).toBe('refused');
+  if (result.kind !== 'refused') throw new Error('not a refusal');
+  return result.response;
+}
+
 const saved = {
   WEBHOOK_TOKEN: process.env.WEBHOOK_TOKEN,
   MOD_INBOUND_TOKEN: process.env.MOD_INBOUND_TOKEN,
@@ -52,131 +70,187 @@ beforeEach(() => setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: INBOUND }));
 afterEach(() => setEnv(saved));
 
 describe('authenticateWebhookToken', () => {
-  it('INVARIANT: returns "none" when no credential is presented, so the session guard runs', () => {
-    expect(authenticateWebhookToken(eventWith({}))).toBe('none');
+  it('INVARIANT: returns kind "none" when no credential is presented, so the session guard runs', () => {
+    expect(authenticateWebhookToken(eventWith({}))).toEqual({ kind: 'none' });
   });
 
-  it('INVARIANT: accepts WEBHOOK_TOKEN via ?token= — the main app calls in this way', () => {
-    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+  it('REGRESSION: attributes WEBHOOK_TOKEN via ?token= — the main app calls in this way', () => {
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toEqual({
+      kind: 'authenticated',
+      credential: 'WEBHOOK_TOKEN',
+    });
   });
 
-  it('INVARIANT: accepts WEBHOOK_TOKEN via Authorization: Bearer', () => {
-    expect(authenticateWebhookToken(eventWith({ authorization: `Bearer ${LEGACY}` }))).toBe(
-      'webhook'
-    );
+  it('REGRESSION: attributes WEBHOOK_TOKEN via Authorization: Bearer', () => {
+    expect(authenticateWebhookToken(eventWith({ authorization: `Bearer ${LEGACY}` }))).toEqual({
+      kind: 'authenticated',
+      credential: 'WEBHOOK_TOKEN',
+    });
   });
 
-  it('REGRESSION: accepts MOD_INBOUND_TOKEN via ?token=', () => {
-    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toBe('webhook');
+  it('REGRESSION: attributes MOD_INBOUND_TOKEN via ?token=', () => {
+    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toEqual({
+      kind: 'authenticated',
+      credential: 'MOD_INBOUND_TOKEN',
+    });
   });
 
-  it('REGRESSION: accepts MOD_INBOUND_TOKEN via Authorization: Bearer', () => {
-    expect(authenticateWebhookToken(eventWith({ authorization: `Bearer ${INBOUND}` }))).toBe(
-      'webhook'
-    );
+  it('REGRESSION: attributes MOD_INBOUND_TOKEN via Authorization: Bearer', () => {
+    expect(authenticateWebhookToken(eventWith({ authorization: `Bearer ${INBOUND}` }))).toEqual({
+      kind: 'authenticated',
+      credential: 'MOD_INBOUND_TOKEN',
+    });
+  });
+
+  it('REGRESSION: the two classes are attributed DIFFERENTLY from the same deployment', () => {
+    // The pairwise-distinct check the whole signal rests on: a stub returning one constant for every
+    // caller satisfies either test above on its own, and fails this one. Both verdicts are read from
+    // the SAME env state, so nothing but the presented bytes can be deciding.
+    const legacy = authenticateWebhookToken(eventWith({ query: LEGACY }));
+    const inbound = authenticateWebhookToken(eventWith({ query: INBOUND }));
+    expect(legacy).toEqual({ kind: 'authenticated', credential: 'WEBHOOK_TOKEN' });
+    expect(inbound).toEqual({ kind: 'authenticated', credential: 'MOD_INBOUND_TOKEN' });
   });
 
   it('REGRESSION: MOD_INBOUND_TOKEN alone is a complete configuration — the post-migration state', () => {
     setEnv({ MOD_INBOUND_TOKEN: INBOUND });
-    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toBe('webhook');
-  });
-
-  it('INVARIANT: WEBHOOK_TOKEN alone is a complete configuration — the pre-migration state', () => {
-    setEnv({ WEBHOOK_TOKEN: LEGACY });
-    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
-  });
-
-  it('REGRESSION: the two tokens are independent — presenting one does not depend on the other being set', async () => {
-    setEnv({ MOD_INBOUND_TOKEN: INBOUND });
-    const refused = authenticateWebhookToken(eventWith({ query: LEGACY }));
-    expect(refused).toBeInstanceOf(Response);
-    expect((refused as Response).status).toBe(401);
-  });
-
-  it('INVARIANT: refuses an unrecognised token with 401', async () => {
-    const result = authenticateWebhookToken(eventWith({ query: 'not-either-of-them' }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(401);
-  });
-
-  it('INVARIANT: refuses a token that is a PREFIX of an accepted one', async () => {
-    const result = authenticateWebhookToken(eventWith({ query: INBOUND.slice(0, -1) }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(401);
-  });
-
-  it('INVARIANT: refuses a token that is a SUPERSTRING of an accepted one', async () => {
-    // The mirror of the prefix case, and the one that exercises the length check as an EQUALITY
-    // rather than a floor: relaxing `===` to `>=` makes timingSafeEqual throw on this input, which
-    // is a 500 out of the hook instead of a 401.
-    const result = authenticateWebhookToken(eventWith({ query: `${INBOUND}x` }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(401);
-  });
-
-  it('INVARIANT: both variables set to the SAME value still authenticates', () => {
-    setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: LEGACY });
-    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
-  });
-
-  it('REGRESSION: a WHITESPACE-ONLY secret is not configured — this closed a real bypass', async () => {
-    // 🔴 The case that made the `.filter()` load-bearing rather than tidy. Before this change the
-    // guard was `if (!expected)`, which a whitespace-only value passes as truthy; the secret was then
-    // `.trim()`ed to ZERO length, and timingSafeEqual(<empty>, <empty>) is TRUE — so a request
-    // presenting `?token=` with no value authenticated as 'webhook' and every wrapped endpoint was
-    // open. Latent (a real deployment holds a real value) but real, and pinned here so it stays shut.
-    setEnv({ WEBHOOK_TOKEN: '   ' });
-    const result = authenticateWebhookToken(eventWith({ query: '' }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(503);
-  });
-
-  it('INVARIANT: fails CLOSED with 503 when neither variable is configured', async () => {
-    setEnv({});
-    const result = authenticateWebhookToken(eventWith({ query: LEGACY }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(503);
-  });
-
-  it('REGRESSION: the 503 names BOTH variables, so an operator knows either would fix it', async () => {
-    setEnv({});
-    const result = authenticateWebhookToken(eventWith({ query: LEGACY })) as Response;
-    await expect(result.json()).resolves.toMatchObject({
-      message: expect.stringContaining('MOD_INBOUND_TOKEN'),
+    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toEqual({
+      kind: 'authenticated',
+      credential: 'MOD_INBOUND_TOKEN',
     });
   });
 
-  it('INVARIANT: a variable set to empty is NOT configured — an empty presented token is refused', async () => {
+  it('REGRESSION: WEBHOOK_TOKEN alone is a complete configuration — the pre-migration state', () => {
+    setEnv({ WEBHOOK_TOKEN: LEGACY });
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toEqual({
+      kind: 'authenticated',
+      credential: 'WEBHOOK_TOKEN',
+    });
+  });
+
+  it('INVARIANT: the two tokens are independent — presenting one does not depend on the other being set', () => {
+    setEnv({ MOD_INBOUND_TOKEN: INBOUND });
+    expect(refusalOf(authenticateWebhookToken(eventWith({ query: LEGACY }))).status).toBe(401);
+  });
+
+  it('INVARIANT: refuses an unrecognised token with 401', () => {
+    expect(
+      refusalOf(authenticateWebhookToken(eventWith({ query: 'not-either-of-them' }))).status
+    ).toBe(401);
+  });
+
+  it('INVARIANT: refuses a token that is a PREFIX of an accepted one', () => {
+    expect(
+      refusalOf(authenticateWebhookToken(eventWith({ query: INBOUND.slice(0, -1) }))).status
+    ).toBe(401);
+  });
+
+  it('INVARIANT: refuses a token that is a SUPERSTRING of an accepted one', () => {
+    // The mirror of the prefix case, and the one that exercises the length check as an EQUALITY
+    // rather than a floor: relaxing `===` to `>=` makes timingSafeEqual throw on this input, which
+    // is a 500 out of the hook instead of a 401.
+    expect(refusalOf(authenticateWebhookToken(eventWith({ query: `${INBOUND}x` }))).status).toBe(
+      401
+    );
+  });
+
+  it('REGRESSION: both variables set to the SAME value attribute to the LEGACY class, not the preferred one', () => {
+    // 🔴 The ambiguous case, and the direction of the bias is the point. One shared value is
+    // indistinguishable on the wire, so attribution has to pick; picking the most legacy class can
+    // only OVERSTATE legacy use, and a migration proof that errs toward "still in use" is safe while
+    // one that errs toward zero authorises the removal that 401s every delegated moderation action.
+    //
+    // This also pins the no-`else`/last-match-wins shape of the match loop against the tidier-looking
+    // first-match-wins rewrite, which would report the post-migration class here.
+    setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: LEGACY });
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toEqual({
+      kind: 'authenticated',
+      credential: 'WEBHOOK_TOKEN',
+    });
+  });
+
+  it('REGRESSION: EVERY accepted class is reachable — no class can be listed but never attributable', () => {
+    // The ledger guard. A class added to ACCEPTED_CREDENTIALS but not read in `acceptedTokens` would
+    // be accepted-in-name-only: never matching, and therefore invisible in the attribution counts
+    // that the WEBHOOK_TOKEN removal is graded on. Driving each class from the list itself means the
+    // set cannot GROW past what is exercised here.
+    const distinct = Object.fromEntries(
+      ACCEPTED_CREDENTIALS.map((credential, i) => [credential, `secret-number-${i}`])
+    );
+    for (const credential of ACCEPTED_CREDENTIALS) {
+      setEnv(distinct);
+      expect(authenticateWebhookToken(eventWith({ query: distinct[credential] }))).toEqual({
+        kind: 'authenticated',
+        credential,
+      });
+    }
+  });
+
+  it('INVARIANT: a WHITESPACE-ONLY secret is not configured — this closed a real bypass', () => {
+    // 🔴 The case that made the `.filter()` load-bearing rather than tidy. Before it the guard was
+    // `if (!expected)`, which a whitespace-only value passes as truthy; the secret was then
+    // `.trim()`ed to ZERO length, and timingSafeEqual(<empty>, <empty>) is TRUE — so a request
+    // presenting `?token=` with no value authenticated and every wrapped endpoint was open. Latent (a
+    // real deployment holds a real value) but real, and pinned here so it stays shut.
+    setEnv({ WEBHOOK_TOKEN: '   ' });
+    expect(refusalOf(authenticateWebhookToken(eventWith({ query: '' }))).status).toBe(503);
+  });
+
+  it('INVARIANT: fails CLOSED with 503 when neither variable is configured', () => {
+    setEnv({});
+    expect(refusalOf(authenticateWebhookToken(eventWith({ query: LEGACY }))).status).toBe(503);
+  });
+
+  it('INVARIANT: the 503 names EVERY accepted class, so an operator knows any one would fix it', async () => {
+    setEnv({});
+    const body = await refusalOf(authenticateWebhookToken(eventWith({ query: LEGACY }))).json();
+    // The whole normalised sentence, not a substring: a body that names only one class still contains
+    // that class's name, so a `stringContaining` guard passes on exactly the message that would send
+    // an operator to set the wrong variable.
+    expect(body).toEqual({
+      message: 'Neither MOD_INBOUND_TOKEN nor WEBHOOK_TOKEN is configured on this deployment.',
+    });
+  });
+
+  it('INVARIANT: a variable set to empty is NOT configured — an empty presented token is refused', () => {
     // The dangerous shape: blanking the secret must not make every wrapped endpoint open. With both
     // blank there is nothing to accept, so this is the 503 fail-closed path, NOT a match.
     setEnv({ WEBHOOK_TOKEN: '', MOD_INBOUND_TOKEN: '' });
-    const result = authenticateWebhookToken(eventWith({ query: '' }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(503);
+    expect(refusalOf(authenticateWebhookToken(eventWith({ query: '' }))).status).toBe(503);
   });
 
-  it('INVARIANT: a blank MOD_INBOUND_TOKEN does not become a usable credential alongside a real one', async () => {
+  it('INVARIANT: a blank MOD_INBOUND_TOKEN does not become a usable credential alongside a real one', () => {
     setEnv({ WEBHOOK_TOKEN: LEGACY, MOD_INBOUND_TOKEN: '' });
-    const empty = authenticateWebhookToken(eventWith({ query: '' }));
-    expect(empty).toBeInstanceOf(Response);
-    expect((empty as Response).status).toBe(401);
-    // …and the real one still works.
-    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+    expect(refusalOf(authenticateWebhookToken(eventWith({ query: '' }))).status).toBe(401);
+    // …and the real one still works, still attributed to the class it came from.
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toEqual({
+      kind: 'authenticated',
+      credential: 'WEBHOOK_TOKEN',
+    });
   });
 
-  it('INVARIANT: a WEBHOOK_TOKEN injected with surrounding whitespace still matches what a caller sends', () => {
+  it('REGRESSION: a WEBHOOK_TOKEN injected with surrounding whitespace still matches, and is still attributed', () => {
     setEnv({ WEBHOOK_TOKEN: `  ${LEGACY}\n` });
-    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toBe('webhook');
+    expect(authenticateWebhookToken(eventWith({ query: LEGACY }))).toEqual({
+      kind: 'authenticated',
+      credential: 'WEBHOOK_TOKEN',
+    });
   });
 
   it('REGRESSION: the same whitespace tolerance applies to MOD_INBOUND_TOKEN', () => {
     setEnv({ MOD_INBOUND_TOKEN: `  ${INBOUND}\n` });
-    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toBe('webhook');
+    expect(authenticateWebhookToken(eventWith({ query: INBOUND }))).toEqual({
+      kind: 'authenticated',
+      credential: 'MOD_INBOUND_TOKEN',
+    });
   });
 
-  it('INVARIANT: a non-Bearer Authorization scheme is refused rather than treated as a token', async () => {
-    const result = authenticateWebhookToken(eventWith({ authorization: `Basic ${INBOUND}` }));
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).status).toBe(401);
+  it('INVARIANT: a non-Bearer Authorization scheme is refused rather than treated as a token', () => {
+    expect(
+      refusalOf(authenticateWebhookToken(eventWith({ authorization: `Basic ${INBOUND}` }))).status
+    ).toBe(401);
   });
 });
+
+// The no-early-exit property of the comparison loop is pinned in `webhook-endpoint-timing.test.ts`,
+// which needs a module-level mock of `node:crypto` and therefore its own file.

--- a/apps/moderator/src/lib/server/webhook-endpoint.ts
+++ b/apps/moderator/src/lib/server/webhook-endpoint.ts
@@ -34,10 +34,19 @@ import { env } from '$env/dynamic/private';
 //   1. "None present it inbound" is a claim about THE MAIN APP, not about this repo. The main app
 //      presents WEBHOOK_TOKEN on every call into this app, from its own codebase — so grepping HERE,
 //      finding no inbound presenter and concluding the migration is done 401s every delegated
-//      moderation action. Nothing in this app records WHICH credential authenticated, so there is
-//      also no runtime signal to check it against; add one before you rely on the answer.
+//      moderation action. The RUNTIME SIGNAL that settles it now exists: every token-authenticated
+//      request logs which credential class matched (`webhook credential presented`, emitted from
+//      hooks.server.ts), so the claim is checkable instead of inferred.
 //   2. Dropping it from `acceptedTokens` is NOT the same as unsetting the variable. Four services in
 //      this app present it OUTBOUND, and two of them degrade by WARNING rather than failing.
+//
+// 🔴 HOW TO READ THAT SIGNAL — the ZERO ALONE IS NOT THE EVIDENCE. Count the attribution lines grouped
+// by `credential` over a window long enough to cover every inbound caller's slowest schedule. The
+// verdict needs BOTH numbers: `WEBHOOK_TOKEN` at zero is only meaningful next to a NON-ZERO
+// `MOD_INBOUND_TOKEN` in the same window, which is the in-band positive control proving the emit path
+// was live and ingesting at the moment the legacy count read zero. Without the pair, "nobody presents
+// it any more" and "the log line never shipped, or stopped being ingested" produce the identical
+// observation. That is why the emit covers BOTH classes and not just the legacy one.
 //
 // Scoping a token to particular endpoints is a separate, later change: `EndpointAuth` is already
 // `{kind:'webhook'} | {kind:'session'; page}` (api-endpoint.ts), so `{kind:'webhook'; scope}` has
@@ -64,7 +73,24 @@ function presentedToken(event: { url: URL; request: Request }): Buffer {
 }
 
 /**
- * The credentials this deployment accepts inbound, as comparable buffers.
+ * The credential VARIABLE NAMES this app can accept inbound, in PREFERENCE-DESCENDING order — most
+ * preferred first, most legacy last. The order is load-bearing twice over: it decides which name the
+ * attribution record carries when a deployment sets both variables to the same value (see the match
+ * loop below), and it is the order the 503 body lists them in.
+ *
+ * A credential class is a variable NAME, never a value. Nothing derived from a token's bytes — not a
+ * prefix, a length, or a hash — may leave this module.
+ */
+export const ACCEPTED_CREDENTIALS = ['MOD_INBOUND_TOKEN', 'WEBHOOK_TOKEN'] as const;
+
+export type AcceptedCredential = (typeof ACCEPTED_CREDENTIALS)[number];
+
+/** One accepted credential: the class that identifies it, and the bytes to compare against. */
+type AcceptedToken = { credential: AcceptedCredential; secret: Buffer };
+
+/**
+ * The credentials this deployment accepts inbound, as comparable buffers LABELLED with the class they
+ * came from. The label is what makes the migration checkable at runtime — see the header.
  *
  * Trimmed to match what a caller sends: a secret injected with a trailing newline would otherwise
  * differ in length from the byte-identical token a caller presents, and every request would 401
@@ -75,51 +101,86 @@ function presentedToken(event: { url: URL; request: Request }): Buffer {
  * secret would turn every wrapped endpoint into an open one, which is the opposite of the
  * fail-closed behaviour the 503 below exists to provide.
  */
-function acceptedTokens(): Buffer[] {
-  return [env.MOD_INBOUND_TOKEN, env.WEBHOOK_TOKEN]
-    .map((value) => (value ?? '').trim())
-    .filter((value) => value.length > 0)
-    .map((value) => Buffer.from(value));
+function acceptedTokens(): AcceptedToken[] {
+  // Read by literal property rather than `env[credential]`: `$env/dynamic/private` is the deployment
+  // surface, and a literal keeps each variable greppable from the manifests that inject it. The
+  // Record type is what forces this map to grow when ACCEPTED_CREDENTIALS does — adding a name there
+  // and forgetting to read it here is a type error, not a credential that silently never matches.
+  const values: Record<AcceptedCredential, string | undefined> = {
+    MOD_INBOUND_TOKEN: env.MOD_INBOUND_TOKEN,
+    WEBHOOK_TOKEN: env.WEBHOOK_TOKEN,
+  };
+  return ACCEPTED_CREDENTIALS.map((credential) => ({
+    credential,
+    value: (values[credential] ?? '').trim(),
+  }))
+    .filter(({ value }) => value.length > 0)
+    .map(({ credential, value }) => ({ credential, secret: Buffer.from(value) }));
 }
 
 /**
- * Called from hooks.server.ts for every `/api/*` request.
+ * The verdict `authenticateWebhookToken` produces, tagged with an explicit `kind`.
  *
- * `'none'` — no credential presented; fall through to the session guard.
- * `Response` — a credential was presented and refused; answer with it. Returned rather than thrown so a
- *   script gets JSON: an `error()` from the hook renders the HTML error page.
- * `'webhook'` — verified.
+ * 🔴 The tag is the point. A `Response` is an object, so discriminating a union that carries one by
+ * `instanceof` or `typeof x === 'object'` is a foot-gun the moment another object-shaped member is
+ * added; every caller must branch on `kind` and nothing else.
+ *
+ * `none`          — no credential presented; fall through to the session guard.
+ * `refused`       — a credential was presented and refused; answer with `response`. Returned rather than
+ *                   thrown so a script gets JSON: an `error()` from the hook renders the HTML error page.
+ * `authenticated` — verified, and `credential` names WHICH class matched.
  */
-export function authenticateWebhookToken(event: {
-  url: URL;
-  request: Request;
-}): 'none' | Response | 'webhook' {
+export type WebhookAuthResult =
+  | { kind: 'none' }
+  | { kind: 'refused'; response: Response }
+  | { kind: 'authenticated'; credential: AcceptedCredential };
+
+/** Called from hooks.server.ts for every `/api/*` request. */
+export function authenticateWebhookToken(event: { url: URL; request: Request }): WebhookAuthResult {
   if (!event.url.searchParams.has('token') && !event.request.headers.has('authorization'))
-    return 'none';
+    return { kind: 'none' };
 
   const accepted = acceptedTokens();
   // Fails CLOSED — with NO secret configured every wrapped endpoint is unreachable rather than
   // unguarded. 503 rather than 401 so an operator reading logs sees a deployment problem, not a caller
   // with a bad token. Either variable alone is a complete configuration: WEBHOOK_TOKEN alone is the
-  // state before migration, MOD_INBOUND_TOKEN alone the state after.
-  if (accepted.length === 0)
-    return Response.json(
-      { message: 'Neither MOD_INBOUND_TOKEN nor WEBHOOK_TOKEN is configured on this deployment.' },
-      { status: 503 }
-    );
+  // state before migration, MOD_INBOUND_TOKEN alone the state after. The body names every accepted
+  // class, derived from the list itself so the two cannot drift.
+  if (accepted.length === 0) {
+    const names = ACCEPTED_CREDENTIALS.join(' nor ');
+    return {
+      kind: 'refused',
+      response: Response.json(
+        { message: `Neither ${names} is configured on this deployment.` },
+        { status: 503 }
+      ),
+    };
+  }
 
   const provided = presentedToken(event);
   // Every candidate is compared with no early exit on a match, so WHICH credential matched is not
   // revealed by how long the comparison takes. (It does not hide how many candidates share the
   // presented token's LENGTH — that is not a property being claimed here.) Length is checked first
   // because timingSafeEqual THROWS on a length mismatch; that leaks only the length, not the secret.
-  let matched = false;
-  for (const secret of accepted)
-    if (provided.length === secret.length && timingSafeEqual(provided, secret)) matched = true;
+  //
+  // 🔴 Recording WHICH candidate matched must not reintroduce that signal: this is the same single
+  // assignment the boolean flag used to be, in the same branch, with no `break` and no `else`. Do not
+  // add either.
+  //
+  // No `else` also means LAST MATCH WINS, and ACCEPTED_CREDENTIALS is preference-DESCENDING — so a
+  // deployment holding the same value in both variables attributes to the LAST, i.e. the most legacy,
+  // class. Deliberate: one shared value is indistinguishable on the wire, and attributing it to the
+  // legacy credential can only OVERSTATE legacy use. A migration proof that errs toward "still in
+  // use" is safe; one that errs toward zero is the failure this signal exists to prevent.
+  let matched: AcceptedCredential | null = null;
+  for (const candidate of accepted)
+    if (provided.length === candidate.secret.length && timingSafeEqual(provided, candidate.secret))
+      matched = candidate.credential;
 
-  if (!matched) return Response.json({ message: SEND_A_TOKEN }, { status: 401 });
+  if (matched === null)
+    return { kind: 'refused', response: Response.json({ message: SEND_A_TOKEN }, { status: 401 }) };
 
-  return 'webhook';
+  return { kind: 'authenticated', credential: matched };
 }
 
 // Generic over the event so a route's own `RequestHandler` type survives the wrap — otherwise `params`


### PR DESCRIPTION
## Why

`apps/moderator` accepts two inbound service credentials — `MOD_INBOUND_TOKEN` (inbound-only, the one to prefer) and `WEBHOOK_TOKEN` (accepted for compatibility). The migration's terminal step is stated in `webhook-endpoint.ts`'s own header: *move each inbound caller to `MOD_INBOUND_TOKEN`, and once none present `WEBHOOK_TOKEN` inbound, drop it from `acceptedTokens`.*

That header also said the step was **unprovable**: *"Nothing in this app records WHICH credential authenticated, so there is also no runtime signal to check it against; add one before you rely on the answer."*

This PR adds that signal. It does not move any caller — that is the next step, and it is deliberately left alone (see *Out of scope*).

## What changed

**`acceptedTokens()` returns labelled candidates.** A single `ACCEPTED_CREDENTIALS` list (preference-descending) drives both the env read and the 503 body, and a `Record<AcceptedCredential, …>` type forces the env read to grow whenever the list does — so a class cannot be accepted in name only, never matching and therefore invisible in the counts the removal is graded on.

**The comparison loop records which candidate matched.** Same single assignment the boolean flag used to be, in the same branch: no `break`, no `else`, length still checked before `timingSafeEqual`. The no-early-exit property is unchanged, and is now pinned *behaviourally* by counting real `timingSafeEqual` calls rather than by grepping the source for the absence of a keyword.

Last-match-wins is deliberate and documented. With the list preference-descending, a deployment holding **one shared value in both variables** attributes to the **legacy** class. The two are indistinguishable on the wire in that case, so attribution has to pick; picking legacy can only *overstate* legacy use. A migration proof that errs toward "still in use" is safe — one that errs toward zero authorises a removal that 401s every delegated moderation action.

**`authenticateWebhookToken` returns a tagged union.**

```ts
export type WebhookAuthResult =
  | { kind: 'none' }
  | { kind: 'refused'; response: Response }
  | { kind: 'authenticated'; credential: AcceptedCredential };
```

An explicit tag, not `instanceof` and not `typeof x === 'object'` — a `Response` is an object too, so either would start mis-sorting the moment another object-shaped member is added.

**`hooks.server.ts` emits one attribution record per token-authenticated request** and still sets `event.locals.tokenClient` to exactly `'webhook'`.

## 🔴 Both classes are logged, not just the legacy one

The tempting saving is to log only `WEBHOOK_TOKEN`, since that is the thing we are waiting to stop seeing. That would destroy the evidence: a zero from a legacy-only emitter is indistinguishable from a line that was never deployed, never ingested, or quietly broken, so it could never license the removal it exists to authorise.

With both classes emitted, a non-zero `MOD_INBOUND_TOKEN` count is the **in-band positive control** standing beside the `WEBHOOK_TOKEN` zero *in the same window*, proving the instrument was live at the moment it read zero. **The pair is the evidence; the zero alone is not.** That reasoning is written at the emit site and in the file header so a future editor does not optimise it back.

## The record

`{ type: 'info', event: 'webhook credential presented', credential, path, method, userAgent }`

- `credential` is the variable **name** (`MOD_INBOUND_TOKEN` / `WEBHOOK_TOKEN`).
- `path` is `url.pathname` **specifically, never `url.href`** — callers may present the token as `?token=`, so the full URL carries the secret.
- `method` and `userAgent` are there because the migration's question is not only *whether* the legacy credential is still presented but *by whom*; a count with no way to reach the caller cannot be acted on.
- **Nothing derived from the token bytes** — no value, prefix, suffix, length or hash. Any of those is a credential oracle on a log stream far more readable than the secret store. Pinned by an exact-object assertion, so *any* added field fails the test.

Fire-and-forget, swallowing failure both ways a promise-returning call can fail (a rejection *and* a synchronous throw), matching `logAxiomError`'s contract.

## Volume

Measured against the deployed app over 24 h: **~14.6k requests/day total (~0.17/s), peak ~1.6/s over any 5-minute window** — that is *every* request the app takes, UI included, so token-authenticated inbound calls are a strict subset (the POST subset alone is ~4.5k/day). One line per token-authenticated request is negligible at that rate, so there is **no sampling** — a sampler that could drop the legacy class would break the proof this exists to provide.

## Test coverage

41 tests across three files, all green; the whole `app:moderator` project is **27 files / 330 passed / 35 skipped**, `svelte-check` **0 errors**, eslint **0 errors**.

Red/green: the two new files and the rewritten one were run against `origin/main`'s implementation — **31 of 41 red**. The 10 that stayed green are the invariants this change must not move (`locals.tokenClient` is still `'webhook'`, grants still emptied, refusal/none/503 routing unchanged); several of those are *vacuously* green on the base side, since there is no record to be absent, and are guards against future edits rather than regression coverage. The mutation matrix is what shows they are not vacuous at HEAD.

**Mutation matrix — 17 mutants, 17 killed**, each named with the message it died to:

| Mutant | Killed by | Message |
|---|---|---|
| hardcode `credential` to one class | records WEBHOOK_TOKEN / BOTH-classes | `expected [ {…} ] to deeply equal [ {…} ]` |
| emit only for the legacy class | records MOD_INBOUND_TOKEN | `expected [] to deeply equal [ { type: 'info', …(5) } ]` |
| `pathname` → `href` | no-token-bytes + exact-record | `expected [ {…} ] to deeply equal [ {…} ]` |
| add a `tokenPrefix` field | no-token-bytes + exact-record | `expected [ { type: 'info', …(6) } ] to deeply equal [ …(5) ]` |
| `type: 'info'` → `'debug'` | exact-record | `expected [ { type: 'debug', … } ] to deeply equal [ { type: 'info', … } ]` |
| drop `userAgent` | exact-record | `expected [ …(4) ] to deeply equal [ …(5) ]` |
| drop `method` | exact-record | `expected [ …(4) ] to deeply equal [ …(5) ]` |
| widen `tokenClient` to carry the class | tokenClient guards | `expected 'webhook:MOD_INBOUND_TOKEN' to be 'webhook'` |
| emit on a refusal too | refused-records-nothing | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| drop the synchronous try/catch | survives-a-sync-throw | `logger constructed badly` |
| drop `.catch(() => {})` | attaches-a-rejection-handler | `expected +0 to be 1` |
| add `break` to the match loop | no-early-exit | `expected "vi.fn()" to be called 2 times, but got 1 times` |
| first-match-wins | shared-value-attributes-to-legacy | `expected { kind: 'authenticated', …(1) } to deeply equal { … }` |
| add an unreadable credential to the list | every-class-is-reachable | `expected { kind: 'refused', …} to deeply equal { kind: 'authenticated', …}` |
| 503 names only one class | 503-names-every-class | `expected { Object (message) } to deeply equal { Object (message) }` |
| length check `===` → `>=` | superstring refusal (+11 more) | `expected 401 to be 503` / cascading |
| drop the empty-value filter | whitespace-only-secret bypass | `expected 'authenticated' to be 'refused'` |

Two traps this codebase has been bitten by, handled explicitly:

- **Fixture values are pairwise distinct and distinct from every constant an assertion names** — neither secret spells a credential class, the fixture method is not `GET`, the path is not a substring of anything asserted. A fixture that can only produce the value an assertion hardcodes cannot see a hardcode mutant.
- **The `.catch()` guard needed strengthening.** Its first version asserted only that the request still returned 204 — and that stayed **green with `.catch()` deleted**, because an unhandled rejection inside a vitest worker is reported out-of-band. In the server it is not benign (Node's default `--unhandled-rejections=throw`). The guard now asserts the handler is attached, observed on the very promise the hook is handed.
- **No `vi.resetModules()`.** Each test owns its own reset; the `node:crypto` mock lives in its own file rather than a `describe` block. Order-independence verified with three `--sequence.shuffle` runs, all green.

**Test command**, and its output as read:

```
pnpm -C apps/moderator exec vitest run
  Test Files  27 passed (27)
  Tests  330 passed | 35 skipped (365)     rc=0
```

The runner was watched to go red before any green was believed (an early iteration failed 10 tests with `rc=1`), and both `Test Files` and the exit status are read — a suite that fails to import reports a passing test count.

## Out of scope

`src/server/services/moderator-app.service.ts` (the main app's outbound call, which presents `env.WEBHOOK_TOKEN`) is **deliberately untouched**. Repointing it needs the credential provisioned on the other side first, and doing it now would remove the contrast the positive control depends on while the instrument is still being proven.

## Not this PR's failure

`preview / component-tests` cannot see `apps/moderator` — its include is `src/**/*.browser.test.tsx` (the main app), while `apps/moderator` has its own `app:moderator` project. A red there on this PR is unrelated to it. (Established from the include glob, not from what other PRs are doing.)
