### PR TITLE
feat(apps): give moderators a way to actually message an app's owner

### DIFF
--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * W13 post-approval mgmt (P2) — the unified moderator listings management table.
@@ -152,7 +153,14 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: (...a: unknown[]) => showError(...a),
 }));
 
-vi.mock('~/utils/trpc', () => {
+// 🔴 `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock, which this file was violating). A hand-written factory
+// breaks this whole FILE's ESM link the day `~/utils/trpc` gains an export something in
+// the module graph imports — and that failure reports as "0 tests collected", i.e. a
+// silent green, not a failure. Converted while adding the owner-message proc below,
+// because that addition is exactly the kind of edit that would have tripped it.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
   // A mutation mock: records (name, vars), then drives onSuccess/onError so the
   // component's success + error paths both run.
   const mutation =
@@ -175,6 +183,7 @@ vi.mock('~/utils/trpc', () => {
     },
   };
   return {
+    ...actual,
     trpc: {
       useUtils: () => utils,
       appListings: {
@@ -263,6 +272,25 @@ vi.mock('~/utils/trpc', () => {
         purgeListing: { useMutation: mutation('purge') },
         approveExternalRequest: { useMutation: mutation('approve') },
         rejectExternalRequest: { useMutation: mutation('reject') },
+        // The owner-message proc RESOLVES WITH A VALUE (`{ recipientCount }`) that the
+        // composer's success handler reads, so it cannot use the shared `mutation`
+        // factory above — that one calls `onSuccess()` with no argument, which would
+        // throw inside the component and report as a render failure rather than as the
+        // mock gap it is.
+        messageAppOwner: {
+          useMutation: (opts?: {
+            onSuccess?: (r: { recipientCount: number }) => void | Promise<void>;
+            onError?: (e: { message: string }) => void;
+          }) => ({
+            mutate: (vars: unknown) => {
+              mocks.mutate('messageAppOwner', vars);
+              if (mocks.errorMode) opts?.onError?.({ message: 'boom' });
+              else void opts?.onSuccess?.({ recipientCount: 1 });
+            },
+            mutateAsync: vi.fn(),
+            isPending: false,
+          }),
+        },
       },
     },
   };
@@ -583,6 +611,61 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
     await page.getByTestId('apps-mod-action-reason').fill('spammy content');
     await page.getByTestId('apps-mod-action-confirm').click();
     expect(showError).toHaveBeenCalledWith(expect.objectContaining({ title: 'Hide failed' }));
+  });
+});
+
+/**
+ * The owner-message action. `appListings.messageAppOwner` shipped with no UI caller at
+ * all; this table is the surface that gives it one, and the properties worth pinning
+ * are that the button is on EVERY row (the proc has no status branch), that it opens
+ * the message composer rather than the reason-gated lifecycle modal, and that it fires
+ * with the row's LISTING ID.
+ */
+describe('AppListingsModerationTable — Message owner', () => {
+  test('every row offers the action, including a rejected/draft row that has no lifecycle action', async () => {
+    mocks.draftPending = true;
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
+    // A draft-with-a-pending-request (bucketed Pending) offers it…
+    await expect
+      .element(page.getByTestId('apps-mod-message-owner-draft-pending-ext'))
+      .toBeInTheDocument();
+    // …and so does the true ORPHAN draft, whose action cell was previously a dead `—`.
+    await page.getByTestId('apps-mod-listings-section-draft-toggle').click();
+    await expect
+      .element(page.getByTestId('apps-mod-message-owner-draft-orphan-ext'))
+      .toBeInTheDocument();
+  });
+
+  test('it is offered on an ON-SITE row too (the proc is dual-kind)', async () => {
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
+    await expect
+      .element(page.getByTestId('apps-mod-message-owner-onsite-live'))
+      .toBeInTheDocument();
+  });
+
+  test('it opens the MESSAGE composer, not the reason-gated lifecycle modal', async () => {
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
+    await page.getByTestId('apps-mod-message-owner-alpha-live').click();
+    await expect.element(page.getByTestId('apps-mod-message-subject')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-message-body')).toBeInTheDocument();
+    // 🔴 The negative half: the shared reason field must NOT be on screen. Without it
+    // this test passes even if BOTH modals opened.
+    expect(page.getByTestId('apps-mod-action-reason').elements()).toHaveLength(0);
+  });
+
+  test('sending forwards the row LISTING ID (never the slug) with the composed text', async () => {
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
+    await page.getByTestId('apps-mod-message-owner-alpha-live').click();
+    await page.getByTestId('apps-mod-message-subject').fill('Your listing overstates a feature');
+    await page
+      .getByTestId('apps-mod-message-body')
+      .fill('The listing says it asks before spending; it never has. Please correct it.');
+    await page.getByTestId('apps-mod-message-send').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('messageAppOwner', {
+      appListingId: 'apl_a',
+      subject: 'Your listing overstates a feature',
+      body: 'The listing says it asks before spending; it never has. Please correct it.',
+    });
   });
 });
 

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -294,10 +294,13 @@ export function AppListingsModerationTable({
     }
     // 🔴 BRANCHED ON, not a fall-through. `actionRequiresReason` is the third and last
     // route out of this function, so a future action it answers `false` for opens
-    // nothing — the loud failure — where a bare `setPendingAction(...)` here is the quiet
-    // one: an action with no `reason` of its own lands in the reason-gated modal and
-    // calls its proc with an input the schema rejects, the mis-route `message-owner` was
-    // carved out of.
+    // nothing — loud IN THE TEST AND TYPE TIERS, where a missing route-table property is a
+    // `pnpm typecheck` failure and an unrouted action fails the jointly-total sweep. On
+    // SCREEN it is a dead button: no toast, no error, no menu close. That is still the
+    // better of the two, because a bare `setPendingAction(...)` here is the quiet one: an
+    // action with no `reason` of its own lands in the reason-gated modal and calls its
+    // proc with an input the schema rejects, the mis-route `message-owner` was carved
+    // out of.
     //
     // 🔴 The BRANCH alone did not deliver that, and this comment used to say it did. Both
     // predicates now read a single exhaustive `Record<ListingModAction, …>` route table,

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -16,11 +16,13 @@ import { IconAlertTriangle, IconBox, IconThumbUp } from '@tabler/icons-react';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Fragment, useMemo, useState } from 'react';
 import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+import { MessageAppOwnerModal } from '~/components/Apps/MessageAppOwnerModal';
 import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
 import { ReasonGatedActionModal } from '~/components/Apps/ReasonGatedActionModal';
 import { listingStatusChip } from '~/components/Apps/appListingModerationView';
 import { LISTING_KIND_LABELS } from '~/components/Apps/listingKindLabels';
 import {
+  actionOpensOwnerMessage,
   effectiveModerationStatus,
   isDestructiveListingModAction,
   listingKindChip,
@@ -58,7 +60,13 @@ import { trpc } from '~/utils/trpc';
  *   - pending  → Review (opens the existing off-site review modal to approve/reject),
  *   - approved → Reset to pending (off-site) + Hide (delist, dual-kind),
  *   - removed  → Relist (dual-kind) + Claim + Purge (off-site; Purge is destructive),
- *   - draft/rejected → read-only (unless a pending request offers Review).
+ *   - draft/rejected → no LIFECYCLE action (unless a pending request offers Review).
+ *
+ * Plus one action on EVERY row, of every status and both kinds: Message owner, which
+ * opens `MessageAppOwnerModal` and calls `appListings.messageAppOwner`. It is the only
+ * action here that changes no listing state, and it is unconditional because the proc
+ * has no status branch — see `listingModActions`. It is also why a draft/rejected row
+ * no longer renders a dead `—`.
  *
  * Dark + mod-only: the whole /apps/review page requires `isAppReviewer`, the query
  * is `moderatorProcedure`, and a query error (non-mod / flag off) renders nothing.
@@ -151,6 +159,11 @@ export function AppListingsModerationTable({
     action: ListingModAction;
     row: ModerationListingRow;
   } | null>(null);
+  // The owner-message composer is a SEPARATE piece of state from `pendingAction`: it
+  // opens its own modal (different fields, different floors — see
+  // `MessageAppOwnerModal`), and keeping the two apart means a lifecycle action can
+  // never render the message form's gate, or vice versa.
+  const [messageRow, setMessageRow] = useState<ModerationListingRow | null>(null);
 
   // A filter/search change = a NEW result set → reset pagination SYNCHRONOUSLY in the
   // onChange handler (batched with the filter state change in the same React event) so
@@ -263,6 +276,10 @@ export function AppListingsModerationTable({
       if (reviewable) openOffsiteReview(reviewable, invalidate);
       return;
     }
+    if (actionOpensOwnerMessage(action)) {
+      setMessageRow(row);
+      return;
+    }
     setPendingAction({ action, row });
   };
 
@@ -351,6 +368,10 @@ export function AppListingsModerationTable({
                     </Group>
                   </Table.Td>
                   <Table.Td>
+                    {/* The `—` branch is now UNREACHABLE from live data — `Message
+                        owner` is offered on every row — and is kept only as the total
+                        fallback for an empty action set. Do not read it as evidence
+                        that a dead-end row still exists. */}
                     {actions.length === 0 ? (
                       <Text size="xs" c="dimmed">
                         —
@@ -487,6 +508,30 @@ export function AppListingsModerationTable({
         pending={pendingAction}
         onClose={() => setPendingAction(null)}
         onDone={invalidate}
+      />
+
+      {/* 🔴 NO `onSent={invalidate}`, and that is measured rather than assumed:
+          `messageAppOwner` writes an `AppListingModerationEvent` and changes NO listing
+          state, and `ModerationListingRow` carries no moderation-event field for the
+          new row to differ in. `invalidate` also RESETS PAGING, so refetching here
+          would throw away every page the moderator had loaded in exchange for a
+          byte-identical result. If this row ever gains a "last moderator action"
+          column, wire the callback then. */}
+      <MessageAppOwnerModal
+        listing={
+          messageRow
+            ? {
+                appListingId: messageRow.id,
+                slug: messageRow.slug,
+                ownerLabel: messageRow.owner?.username
+                  ? `@${messageRow.owner.username}`
+                  : messageRow.owner?.id != null
+                  ? `#${messageRow.owner.id}`
+                  : null,
+              }
+            : null
+        }
+        onClose={() => setMessageRow(null)}
       />
     </Stack>
   );

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -23,6 +23,7 @@ import { listingStatusChip } from '~/components/Apps/appListingModerationView';
 import { LISTING_KIND_LABELS } from '~/components/Apps/listingKindLabels';
 import {
   actionOpensOwnerMessage,
+  actionRequiresReason,
   effectiveModerationStatus,
   isDestructiveListingModAction,
   listingKindChip,
@@ -216,9 +217,20 @@ export function AppListingsModerationTable({
   const nextCursor = query.data?.nextCursor ?? null;
 
   // Merge the current page into the accumulated set (dedupe by id — defensive), then
-  // drop on-site + pending rows: those live in the actionable on-site review FIFO queue
-  // (with a Review action); here they'd render as a dead-end `—`-action row. Off-site
-  // pending stays (it carries the Review action).
+  // drop on-site + pending rows: those live in the actionable on-site review FIFO
+  // queue, and listing them here too would put one item in two moderator surfaces with
+  // different action sets. Off-site pending stays (it carries the Review action).
+  //
+  // 🔴 THE OLD REASON FOR THIS FILTER IS NO LONGER TRUE, and the gap it leaves is real.
+  // It used to read "here they'd render as a dead-end `—`-action row" — that stopped
+  // being the case the moment `message-owner` became unconditional, since such a row now
+  // offers Message owner. So this table cannot message the owner of an on-site listing
+  // while it is awaiting review, which is one of the states a developer most needs to
+  // hear from a moderator in. Deliberately NOT widened here: which rows a live
+  // moderator surface lists is a product decision about surface duplication, not a
+  // should-fix on the composer. Closing it means giving the on-site review queue its own
+  // composer entry point (which also means adding that queue to the mount ledger in
+  // `__tests__/appModeratorMessageForm.callSites.test.ts`).
   const items = useMemo(() => {
     const merged = !cursor
       ? page
@@ -280,7 +292,14 @@ export function AppListingsModerationTable({
       setMessageRow(row);
       return;
     }
-    setPendingAction({ action, row });
+    // 🔴 BRANCHED ON, not a fall-through. `actionRequiresReason` is the third and last
+    // route out of this function, so the three predicates have to be jointly total over
+    // `ListingModAction` or an action opens nothing — which is the loud failure, and the
+    // one `appListingModerationTableView.test.ts` pins. A bare `setPendingAction(...)`
+    // here is the quiet one: a future action with no `reason` of its own would land in
+    // the reason-gated modal and call its proc with an input the schema rejects, which
+    // is exactly the mis-route `message-owner` was carved out of.
+    if (actionRequiresReason(action)) setPendingAction({ action, row });
   };
 
   const renderTable = (groups: SubmissionGroup<ModerationListingRow>[]) => (
@@ -517,20 +536,14 @@ export function AppListingsModerationTable({
           would throw away every page the moderator had loaded in exchange for a
           byte-identical result. If this row ever gains a "last moderator action"
           column, wire the callback then. */}
+      {/* 🔴 NO OWNER IS PASSED, and the composer's prop shape refuses one. `row.owner`
+          is `AppListing.userId`'s denormalised copy; for an on-site listing the proc
+          resolves the backing block's owner instead, so handing that copy to a composer
+          that presented it as the delivery target would let a moderator address the
+          wrong developer. The Owner COLUMN above still shows it — as a column, not as a
+          promise about where this message goes. */}
       <MessageAppOwnerModal
-        listing={
-          messageRow
-            ? {
-                appListingId: messageRow.id,
-                slug: messageRow.slug,
-                ownerLabel: messageRow.owner?.username
-                  ? `@${messageRow.owner.username}`
-                  : messageRow.owner?.id != null
-                  ? `#${messageRow.owner.id}`
-                  : null,
-              }
-            : null
-        }
+        listing={messageRow ? { appListingId: messageRow.id, slug: messageRow.slug } : null}
         onClose={() => setMessageRow(null)}
       />
     </Stack>

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -293,12 +293,17 @@ export function AppListingsModerationTable({
       return;
     }
     // 🔴 BRANCHED ON, not a fall-through. `actionRequiresReason` is the third and last
-    // route out of this function, so the three predicates have to be jointly total over
-    // `ListingModAction` or an action opens nothing — which is the loud failure, and the
-    // one `appListingModerationTableView.test.ts` pins. A bare `setPendingAction(...)`
-    // here is the quiet one: a future action with no `reason` of its own would land in
-    // the reason-gated modal and call its proc with an input the schema rejects, which
-    // is exactly the mis-route `message-owner` was carved out of.
+    // route out of this function, so a future action it answers `false` for opens
+    // nothing — the loud failure — where a bare `setPendingAction(...)` here is the quiet
+    // one: an action with no `reason` of its own lands in the reason-gated modal and
+    // calls its proc with an input the schema rejects, the mis-route `message-owner` was
+    // carved out of.
+    //
+    // 🔴 The BRANCH alone did not deliver that, and this comment used to say it did. Both
+    // predicates now read a single exhaustive `Record<ListingModAction, …>` route table,
+    // so an action absent from it answers `false` to BOTH and reaches nothing; while
+    // `actionRequiresReason` was written as a negation, a new union member defaulted to
+    // `true` and landed here regardless of how carefully this branch was written.
     if (actionRequiresReason(action)) setPendingAction({ action, row });
   };
 

--- a/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
+++ b/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+  MOD_MESSAGE_SUBJECT_MIN,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+
+/**
+ * The moderator → app-developer message composer (`appListings.messageAppOwner`, which
+ * shipped with no UI at all). Browser-mode (report-only in Tekton): the two-field gate,
+ * the collaborator opt-in, the exact mutation payload, and the failure posture.
+ *
+ * The gate RULE is pinned in the blocking node project by
+ * `__tests__/appModeratorMessageForm.test.ts`; this file pins that the COMPONENT is
+ * wired to it.
+ */
+
+const A = (n: number) => 'a'.repeat(n);
+const OK_SUBJECT = A(MOD_MESSAGE_SUBJECT_MIN + 5);
+const OK_BODY = A(MOD_MESSAGE_BODY_MIN + 5);
+
+const LISTING = { appListingId: 'apl_1', slug: 'prompt-vault', ownerLabel: '@dev' };
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  onClose: vi.fn(),
+  onSent: vi.fn().mockResolvedValue(undefined),
+  errorMode: false,
+  /** What the mocked proc resolves with — drives the success-toast copy. */
+  recipientCount: 1,
+}));
+
+const showSuccess = vi.fn();
+const showError = vi.fn();
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: (...a: unknown[]) => showSuccess(...a),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
+}));
+
+// 🔴 `importOriginal` SPREAD, not a wholesale replacement (local-rules/
+// no-wholesale-module-mock): a hand-written factory breaks this whole FILE's ESM link
+// the day `~/utils/trpc` gains an export the factory omits, and that failure reports as
+// "0 tests collected" rather than as a failure.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  return {
+    ...actual,
+    trpc: {
+      appListings: {
+        messageAppOwner: {
+          useMutation: (opts?: {
+            onSuccess?: (r: { recipientCount: number }) => void | Promise<void>;
+            onError?: (e: { message: string }) => void;
+          }) => ({
+            mutate: (vars: unknown) => {
+              mocks.mutate(vars);
+              if (mocks.errorMode) opts?.onError?.({ message: 'Too many moderator messages' });
+              else void opts?.onSuccess?.({ recipientCount: mocks.recipientCount });
+            },
+            mutateAsync: vi.fn(),
+            isPending: false,
+          }),
+        },
+      },
+    },
+  };
+});
+
+const { MessageAppOwnerModal } = await import('./MessageAppOwnerModal');
+
+function render(listing: typeof LISTING | null = LISTING) {
+  return renderWithProviders(
+    <MessageAppOwnerModal listing={listing} onClose={mocks.onClose} onSent={mocks.onSent} />
+  );
+}
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.onClose.mockClear();
+  mocks.onSent.mockClear();
+  mocks.errorMode = false;
+  mocks.recipientCount = 1;
+  showSuccess.mockClear();
+  showError.mockClear();
+});
+
+describe('MessageAppOwnerModal — closed state', () => {
+  test('renders nothing when no listing is selected', async () => {
+    render(null);
+    expect(page.getByTestId('apps-mod-message-subject').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-mod-message-send').elements()).toHaveLength(0);
+  });
+});
+
+describe('MessageAppOwnerModal — the two-field gate', () => {
+  test('the send button is disabled on an empty form, and no mutation fires', async () => {
+    render();
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('a valid SUBJECT alone is not enough — the body floor still closes the gate', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+
+    // 🔴 The discriminating case: text that clears the SUBJECT floor and not the BODY
+    // floor. A composer that reused one floor for both fields enables here.
+    await page.getByTestId('apps-mod-message-body').fill(A(MOD_MESSAGE_SUBJECT_MIN));
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('a valid BODY alone is not enough — the subject is required', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+  });
+
+  test('both fields valid → the button enables', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeEnabled();
+  });
+
+  test('the body counter shows the floor AND the ceiling, and climbs as text is typed', async () => {
+    render();
+    await expect
+      .element(
+        page.getByText(`0/${MOD_MESSAGE_BODY_MIN} characters minimum (max ${MOD_MESSAGE_BODY_MAX})`)
+      )
+      .toBeInTheDocument();
+    await page.getByTestId('apps-mod-message-body').fill('ab');
+    await expect
+      .element(
+        page.getByText(`2/${MOD_MESSAGE_BODY_MIN} characters minimum (max ${MOD_MESSAGE_BODY_MAX})`)
+      )
+      .toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 THE CEILING GATE. Every field clears its FLOOR here, so a floor-only composer
+   * enables the button, fires, and the moderator gets an unattributed BAD_REQUEST with
+   * their text still in the box.
+   */
+  test('an over-length BODY disables the send and names the ceiling', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(A(MOD_MESSAGE_BODY_MAX + 1));
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+    await expect
+      .element(
+        page.getByText(`Keep it to ${MOD_MESSAGE_BODY_MAX} characters or fewer`, { exact: false })
+      )
+      .toBeInTheDocument();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('an over-length SUBJECT disables the send and names the ceiling', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(A(MOD_MESSAGE_SUBJECT_MAX + 1));
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+    await expect
+      .element(
+        page.getByText(`Keep it to ${MOD_MESSAGE_SUBJECT_MAX} characters or fewer`, {
+          exact: false,
+        })
+      )
+      .toBeInTheDocument();
+  });
+
+  test('a whitespace-only body cannot open the gate', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(' '.repeat(MOD_MESSAGE_BODY_MIN + 10));
+    await expect.element(page.getByTestId('apps-mod-message-send')).toBeDisabled();
+  });
+});
+
+describe('MessageAppOwnerModal — the mutation payload', () => {
+  test('sends the trimmed subject + body against the LISTING ID, collaborators omitted by default', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(`  ${OK_SUBJECT}  `);
+    await page.getByTestId('apps-mod-message-body').fill(`  ${OK_BODY}  `);
+    await page.getByTestId('apps-mod-message-send').click();
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      appListingId: 'apl_1',
+      subject: OK_SUBJECT,
+      body: OK_BODY,
+    });
+  });
+
+  test('the collaborator checkbox is OFF by default and adds includeCollaborators when ticked', async () => {
+    render();
+    await expect.element(page.getByTestId('apps-mod-message-collaborators')).not.toBeChecked();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await page.getByTestId('apps-mod-message-collaborators').click();
+    await page.getByTestId('apps-mod-message-send').click();
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      appListingId: 'apl_1',
+      subject: OK_SUBJECT,
+      body: OK_BODY,
+      includeCollaborators: true,
+    });
+  });
+});
+
+describe('MessageAppOwnerModal — success and failure posture', () => {
+  test('a successful send toasts, calls onSent, and closes', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await page.getByTestId('apps-mod-message-send').click();
+    await vi.waitFor(() => expect(mocks.onClose).toHaveBeenCalled());
+    expect(showSuccess).toHaveBeenCalledWith({ message: 'Message sent to the app owner.' });
+    expect(mocks.onSent).toHaveBeenCalled();
+  });
+
+  test('the success toast names the RECIPIENT COUNT once collaborators were included', async () => {
+    mocks.recipientCount = 3;
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await page.getByTestId('apps-mod-message-send').click();
+    await vi.waitFor(() => expect(showSuccess).toHaveBeenCalled());
+    expect(showSuccess).toHaveBeenCalledWith({ message: 'Message sent to 3 recipients.' });
+  });
+
+  /**
+   * 🔴 A FAILED SEND MUST NOT DESTROY THE MESSAGE. Every typed failure this proc
+   * returns is retryable by the moderator — RATE_LIMITED says "try again in Ns",
+   * BLOCKED_LINK and INVALID_TEXT say "edit this text" — so clearing the body would
+   * throw away the work the error is asking them to reuse.
+   */
+  test('a failed send toasts the error, keeps the modal open, and keeps the typed text', async () => {
+    mocks.errorMode = true;
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await page.getByTestId('apps-mod-message-send').click();
+
+    expect(showError).toHaveBeenCalledWith(expect.objectContaining({ title: 'Message failed' }));
+    expect(mocks.onClose).not.toHaveBeenCalled();
+    expect(mocks.onSent).not.toHaveBeenCalled();
+    await expect.element(page.getByTestId('apps-mod-message-body')).toHaveValue(OK_BODY);
+    await expect.element(page.getByTestId('apps-mod-message-subject')).toHaveValue(OK_SUBJECT);
+  });
+});
+
+describe('MessageAppOwnerModal — the delivery notice', () => {
+  test('says the message is one-way and audited, and shows the owner chip', async () => {
+    render();
+    await expect
+      .element(page.getByText('replies are not delivered', { exact: false }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText('moderation history', { exact: false }))
+      .toBeInTheDocument();
+    await expect.element(page.getByText('@dev')).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
+++ b/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
@@ -324,7 +324,10 @@ describe('MessageAppOwnerModal — the delivery notice', () => {
     render();
     // Await the notice first: the modal is portalled and `render()` returns before it is
     // in the DOM, so a synchronous read of `document.body` sees an empty string — which
-    // would make the assertions below pass over nothing at all.
+    // would make the NEGATIVE assertion below pass over nothing at all. (The whole-sentence
+    // `toContain` would fail on an empty string rather than pass, so it is the sigil check
+    // that needs this await; awaiting also keeps the positive one from failing for a timing
+    // reason that has nothing to do with the copy.)
     await expect
       .element(page.getByText('resolved when you send', { exact: false }))
       .toBeInTheDocument();
@@ -332,11 +335,12 @@ describe('MessageAppOwnerModal — the delivery notice', () => {
     // injected <style> block, whose `@media` rules match the handle pattern below and
     // would fail this for a reason that has nothing to do with the copy.
     const composer = page.getByRole('dialog').element().textContent ?? '';
-    // 🔴 THE WHOLE SENTENCE, not a pattern. The `/[@#]\w/` check this replaced was a
-    // SPELLED guard: rewriting the notice as "…to the app owner devuser, resolved when
-    // you send" names a recipient in plain prose, matches no handle sigil, and passed
-    // all 17 tests in this file. A reword now fails here on purpose — the copy is a
-    // claim about where a moderation message goes.
+    // 🔴 THE WHOLE SENTENCE, not a pattern. This was added ALONGSIDE the `/[@#]\w/` check
+    // below — it supplements it, it did not replace it — because that one is a SPELLED
+    // guard: rewriting the notice as "…to the app owner devuser, resolved when you send"
+    // names a recipient in plain prose, matches no handle sigil, and passed all 17 tests
+    // in this file. A reword now fails here on purpose — the copy is a claim about where
+    // a moderation message goes.
     expect(composer).toContain(
       "Delivered as a notification to the app's owner, resolved when you send. " +
         'One-way — replies are not delivered — and the subject and message are recorded ' +

--- a/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
+++ b/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
@@ -24,7 +24,9 @@ const A = (n: number) => 'a'.repeat(n);
 const OK_SUBJECT = A(MOD_MESSAGE_SUBJECT_MIN + 5);
 const OK_BODY = A(MOD_MESSAGE_BODY_MIN + 5);
 
-const LISTING = { appListingId: 'apl_1', slug: 'prompt-vault', ownerLabel: '@dev' };
+// 🔴 NO OWNER FIELD, and the prop type refuses one: the recipient is resolved
+// server-side at send time and the mod table only holds a denormalised copy of it.
+const LISTING = { appListingId: 'apl_1', slug: 'prompt-vault' };
 
 const mocks = vi.hoisted(() => ({
   mutate: vi.fn(),
@@ -224,6 +226,49 @@ describe('MessageAppOwnerModal — success and failure posture', () => {
     expect(mocks.onSent).toHaveBeenCalled();
   });
 
+  /**
+   * 🔴 OPT IN PER MESSAGE, NEVER PER SESSION. An accepted collaborator consented to EDIT
+   * the app, not to receive moderation correspondence about it — and a moderator's
+   * message can be adverse. The composer is not unmounted between sends (the parent owns
+   * `listing`), so a tick that survived a send would silently fan the NEXT message out to
+   * third parties the moderator never opted in for.
+   *
+   * Until this test existed, deleting `setIncludeCollaborators(false)` from `reset()`
+   * survived both suites — the property was a comment, not behaviour. The second send
+   * below is the half that catches it: the checkbox assertion alone would still pass a
+   * composer that re-rendered unchecked while holding stale state.
+   */
+  test('a successful send clears the collaborator opt-in, and the NEXT message does not carry it', async () => {
+    render();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await page.getByTestId('apps-mod-message-collaborators').click();
+    await expect.element(page.getByTestId('apps-mod-message-collaborators')).toBeChecked();
+
+    await page.getByTestId('apps-mod-message-send').click();
+    await vi.waitFor(() => expect(mocks.onClose).toHaveBeenCalled());
+    expect(mocks.mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ includeCollaborators: true })
+    );
+
+    // Every field is back to its initial state — the opt-in included.
+    await expect.element(page.getByTestId('apps-mod-message-collaborators')).not.toBeChecked();
+    await expect.element(page.getByTestId('apps-mod-message-subject')).toHaveValue('');
+    await expect.element(page.getByTestId('apps-mod-message-body')).toHaveValue('');
+
+    // …and the state behind it, not merely the rendered tick: a second message composed
+    // in the same still-mounted modal must omit `includeCollaborators` entirely.
+    mocks.mutate.mockClear();
+    await page.getByTestId('apps-mod-message-subject').fill(OK_SUBJECT);
+    await page.getByTestId('apps-mod-message-body').fill(OK_BODY);
+    await page.getByTestId('apps-mod-message-send').click();
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      appListingId: 'apl_1',
+      subject: OK_SUBJECT,
+      body: OK_BODY,
+    });
+  });
+
   test('the success toast names the RECIPIENT COUNT once collaborators were included', async () => {
     mocks.recipientCount = 3;
     render();
@@ -256,7 +301,7 @@ describe('MessageAppOwnerModal — success and failure posture', () => {
 });
 
 describe('MessageAppOwnerModal — the delivery notice', () => {
-  test('says the message is one-way and audited, and shows the owner chip', async () => {
+  test('says the message is one-way, audited, and resolved at send time', async () => {
     render();
     await expect
       .element(page.getByText('replies are not delivered', { exact: false }))
@@ -264,6 +309,30 @@ describe('MessageAppOwnerModal — the delivery notice', () => {
     await expect
       .element(page.getByText('moderation history', { exact: false }))
       .toBeInTheDocument();
-    await expect.element(page.getByText('@dev')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('resolved when you send', { exact: false }))
+      .toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 It must not name a specific person. For an on-site listing the send resolves the
+   * BACKING BLOCK's owner, which can differ from the listing column the mod table
+   * displays — so a composer that echoed a handle would let a moderator address copy to
+   * one developer while the platform delivered it to another.
+   */
+  test('names no recipient — no @handle or #id appears in the composer', async () => {
+    render();
+    // Await the notice first: the modal is portalled and `render()` returns before it is
+    // in the DOM, so a synchronous read of `document.body` sees an empty string — which
+    // would make the negative assertion below pass over nothing at all.
+    await expect
+      .element(page.getByText('resolved when you send', { exact: false }))
+      .toBeInTheDocument();
+    // Scoped to the dialog, not `document.body`: the body also carries Mantine's
+    // injected <style> block, whose `@media` rules match the handle pattern below and
+    // would fail this for a reason that has nothing to do with the copy.
+    const composer = page.getByRole('dialog').element().textContent ?? '';
+    expect(composer).toContain('resolved when you send');
+    expect(composer).not.toMatch(/[@#]\w/);
   });
 });

--- a/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
+++ b/src/components/Apps/MessageAppOwnerModal.browser.test.tsx
@@ -320,11 +320,11 @@ describe('MessageAppOwnerModal — the delivery notice', () => {
    * displays — so a composer that echoed a handle would let a moderator address copy to
    * one developer while the platform delivered it to another.
    */
-  test('names no recipient — no @handle or #id appears in the composer', async () => {
+  test('names no recipient — the notice is exactly the sentence that names none', async () => {
     render();
     // Await the notice first: the modal is portalled and `render()` returns before it is
     // in the DOM, so a synchronous read of `document.body` sees an empty string — which
-    // would make the negative assertion below pass over nothing at all.
+    // would make the assertions below pass over nothing at all.
     await expect
       .element(page.getByText('resolved when you send', { exact: false }))
       .toBeInTheDocument();
@@ -332,7 +332,18 @@ describe('MessageAppOwnerModal — the delivery notice', () => {
     // injected <style> block, whose `@media` rules match the handle pattern below and
     // would fail this for a reason that has nothing to do with the copy.
     const composer = page.getByRole('dialog').element().textContent ?? '';
-    expect(composer).toContain('resolved when you send');
+    // 🔴 THE WHOLE SENTENCE, not a pattern. The `/[@#]\w/` check this replaced was a
+    // SPELLED guard: rewriting the notice as "…to the app owner devuser, resolved when
+    // you send" names a recipient in plain prose, matches no handle sigil, and passed
+    // all 17 tests in this file. A reword now fails here on purpose — the copy is a
+    // claim about where a moderation message goes.
+    expect(composer).toContain(
+      "Delivered as a notification to the app's owner, resolved when you send. " +
+        'One-way — replies are not delivered — and the subject and message are recorded ' +
+        "in this listing's moderation history."
+    );
+    // Kept beside it: the sigil pattern still catches a handle appended ANYWHERE else in
+    // the composer, which a single-string assertion on one paragraph cannot see.
     expect(composer).not.toMatch(/[@#]\w/);
   });
 });

--- a/src/components/Apps/MessageAppOwnerModal.tsx
+++ b/src/components/Apps/MessageAppOwnerModal.tsx
@@ -1,0 +1,206 @@
+import { Alert, Button, Checkbox, Code, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { useState } from 'react';
+
+import {
+  ReasonGatedField,
+  ReasonGatedSubmitButton,
+} from '~/components/Apps/ReasonGatedActionModal';
+import {
+  modMessageGate,
+  modMessagePayload,
+  modMessageSentSummary,
+  modMessageSubjectState,
+} from '~/components/Apps/appModeratorMessageForm';
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+  MOD_MESSAGE_SUBJECT_MIN,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * MODERATOR → APP-DEVELOPER message composer.
+ *
+ * ## Why this component exists
+ *
+ * `appListings.messageAppOwner` (civitai/civitai#4401) shipped with a service, an audit
+ * event, two Redis rate-limit windows, a notification type and a migration — and ZERO
+ * UI callers. A moderator who needed to tell a developer something the platform has no
+ * event for could not reach it from any surface. This is that surface.
+ *
+ * ## Why it is NOT `ListingModActionModal`
+ *
+ * Every other moderator action on this table is gated on ONE free-text `reason` with a
+ * single floor (`OFFSITE_MOD_REASON_MIN` = 3), which is exactly what the shared
+ * {@link ReasonGatedActionModal} shell encodes. This action takes TWO fields with
+ * DIFFERENT floors (subject ≥ 3, body ≥ 20) and two server-enforced CEILINGS, and it
+ * carries a delivery-scope choice. Overloading the shell would have meant a `reason`
+ * prop that is really a body, an `extraSlot` that is really a required field, and a
+ * `minLength` that only describes one of the two gates.
+ *
+ * It still composes the shell's ATOMS ({@link ReasonGatedField} +
+ * {@link ReasonGatedSubmitButton}) rather than hand-rolling a textarea and a disabled
+ * button — the same call the two inline reject panels make, and the reason the atoms
+ * were split out from the shell in the first place.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * No draft persistence, no template picker, no thread. The proc is one-way by design
+ * (there is no reply route and no message table), so a composer that implied otherwise
+ * would be lying about the channel.
+ */
+export function MessageAppOwnerModal({
+  listing,
+  onClose,
+  onSent,
+}: {
+  /**
+   * The listing to message the owner of, or `null` when closed. `appListingId` is the
+   * `apl_<ULID>` (`ModerationListingRow.id`); the proc also accepts a shadow revision
+   * id and resolves it to the parent, so no caller has to know which it holds.
+   *
+   * 🔴 The RECIPIENT is not passed and cannot be: `messageAppOwner` derives the owner
+   * server-side through `resolveListingAccess`. `ownerLabel` below is DISPLAY ONLY —
+   * it is the table's denormalised owner chip, and the proc may resolve a different
+   * (correct) user if that column has drifted. Never present it as the delivery target.
+   */
+  listing: { appListingId: string; slug: string; ownerLabel?: string | null } | null;
+  onClose: () => void;
+  /** Fired after a successful send (the table's invalidate). */
+  onSent?: () => void | Promise<void>;
+}) {
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [includeCollaborators, setIncludeCollaborators] = useState(false);
+
+  function reset() {
+    setSubject('');
+    setBody('');
+    setIncludeCollaborators(false);
+  }
+
+  const mutation = trpc.appListings.messageAppOwner.useMutation({
+    onSuccess: async (result) => {
+      showSuccessNotification({ message: modMessageSentSummary(result.recipientCount) });
+      await onSent?.();
+      reset();
+      onClose();
+    },
+    // 🔴 The composed text is NOT cleared on failure. Every typed failure this proc can
+    // return is RETRYABLE by the moderator — RATE_LIMITED says "try again in Ns",
+    // BLOCKED_LINK and INVALID_TEXT say "edit this text" — so discarding the body would
+    // destroy work the error is asking them to reuse. The modal stays open for the
+    // same reason.
+    onError: (e) => showErrorNotification({ title: 'Message failed', error: new Error(e.message) }),
+  });
+
+  if (!listing) return null;
+
+  const subjectState = modMessageSubjectState(subject);
+  const gate = modMessageGate({ subject, body });
+  const busy = mutation.isPending;
+
+  function submit() {
+    if (!listing || !gate.open) return;
+    mutation.mutate(
+      modMessagePayload({
+        appListingId: listing.appListingId,
+        subject,
+        body,
+        includeCollaborators,
+      })
+    );
+  }
+
+  function cancel() {
+    if (busy) return;
+    reset();
+    onClose();
+  }
+
+  return (
+    <Modal
+      opened
+      onClose={cancel}
+      centered
+      title={<Text fw={600}>Message owner — {listing.slug}</Text>}
+    >
+      <Stack gap="md">
+        <Alert color="blue" variant="light" icon={<IconInfoCircle size={16} />}>
+          <Text size="sm">
+            Delivered as a notification to the app&apos;s owner
+            {listing.ownerLabel ? (
+              <>
+                {' '}
+                (currently <Code>{listing.ownerLabel}</Code>)
+              </>
+            ) : null}
+            . One-way — replies are not delivered — and the subject and message are recorded in this
+            listing&apos;s moderation history.
+          </Text>
+        </Alert>
+
+        <TextInput
+          label="Subject"
+          placeholder="e.g. Your listing describes a feature the app does not have"
+          description={
+            `${subjectState.length}/${MOD_MESSAGE_SUBJECT_MIN} characters minimum ` +
+            `(max ${MOD_MESSAGE_SUBJECT_MAX})`
+          }
+          error={
+            subjectState.tooLong
+              ? `Keep it to ${MOD_MESSAGE_SUBJECT_MAX} characters or fewer (currently ${subjectState.length}).`
+              : subjectState.tooShort && subjectState.length > 0
+              ? `Enter at least ${MOD_MESSAGE_SUBJECT_MIN} characters.`
+              : undefined
+          }
+          value={subject}
+          onChange={(e) => setSubject(e.currentTarget.value)}
+          disabled={busy}
+          data-testid="apps-mod-message-subject"
+        />
+
+        <ReasonGatedField
+          value={body}
+          onChange={setBody}
+          disabled={busy}
+          minLength={MOD_MESSAGE_BODY_MIN}
+          maxLength={MOD_MESSAGE_BODY_MAX}
+          label="Message"
+          placeholder="What the developer needs to know, and what (if anything) they should change."
+          testId="apps-mod-message-body"
+          minRows={5}
+        />
+
+        {/* 🔴 DEFAULTS OFF, mirroring the schema. An accepted collaborator consented to
+            EDIT the app, not to receive moderation correspondence about it — and a
+            moderator's message can be adverse. Opt in per message, never per session. */}
+        <Checkbox
+          label="Also send to accepted collaborators"
+          description="Off by default — the owner is the accountable party. Turn this on when the owner is unresponsive and the editors are the only people who can fix the listing."
+          checked={includeCollaborators}
+          onChange={(e) => setIncludeCollaborators(e.currentTarget.checked)}
+          disabled={busy}
+          data-testid="apps-mod-message-collaborators"
+        />
+
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={cancel} disabled={busy}>
+            Cancel
+          </Button>
+          <ReasonGatedSubmitButton
+            onClick={submit}
+            gateOpen={gate.open}
+            busy={busy}
+            label="Send message"
+            tooltipLabel={gate.tooltip}
+            testId="apps-mod-message-send"
+          />
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/Apps/MessageAppOwnerModal.tsx
+++ b/src/components/Apps/MessageAppOwnerModal.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Checkbox, Code, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import { Alert, Button, Checkbox, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import { useState } from 'react';
 
@@ -51,6 +51,9 @@ import { trpc } from '~/utils/trpc';
  * No draft persistence, no template picker, no thread. The proc is one-way by design
  * (there is no reply route and no message table), so a composer that implied otherwise
  * would be lying about the channel.
+ *
+ * It also NAMES NO RECIPIENT — see the `listing` prop below. The only owner a caller
+ * could hand it is the denormalised column, which the send may resolve past.
  */
 export function MessageAppOwnerModal({
   listing,
@@ -62,12 +65,21 @@ export function MessageAppOwnerModal({
    * `apl_<ULID>` (`ModerationListingRow.id`); the proc also accepts a shadow revision
    * id and resolves it to the parent, so no caller has to know which it holds.
    *
-   * 🔴 The RECIPIENT is not passed and cannot be: `messageAppOwner` derives the owner
-   * server-side through `resolveListingAccess`. `ownerLabel` below is DISPLAY ONLY —
-   * it is the table's denormalised owner chip, and the proc may resolve a different
-   * (correct) user if that column has drifted. Never present it as the delivery target.
+   * 🔴 THE RECIPIENT IS NOT PASSED, AND THIS TYPE DELIBERATELY CANNOT CARRY ONE.
+   * `messageAppOwner` derives the owner server-side through `resolveListingAccess`,
+   * which for an ON-SITE listing resolves the backing block's owner and NOT the
+   * listing's own `userId` column — `resolveCanonicalListingOwner` exists precisely to
+   * override that denormalised copy. The mod table holds only the copy, so any owner
+   * this composer could be handed is a value the send may disagree with, and a
+   * composer that displayed it would let a moderator write to the person on screen
+   * while the platform delivered to a different one. That is a disclosure, not merely
+   * a mislabel. So the composer names no recipient at all: the table's own Owner
+   * column stays the (clearly denormalised) display, and the send resolves the real
+   * one. An earlier revision of this file said exactly that in prose and then
+   * rendered the label anyway — hence the prop-shape ledger in
+   * `__tests__/appModeratorMessageForm.callSites.test.ts`.
    */
-  listing: { appListingId: string; slug: string; ownerLabel?: string | null } | null;
+  listing: { appListingId: string; slug: string } | null;
   onClose: () => void;
   /** Fired after a successful send (the table's invalidate). */
   onSent?: () => void | Promise<void>;
@@ -130,15 +142,12 @@ export function MessageAppOwnerModal({
     >
       <Stack gap="md">
         <Alert color="blue" variant="light" icon={<IconInfoCircle size={16} />}>
+          {/* 🔴 NAMES NO RECIPIENT. The owner is resolved when the message is sent, and
+              for an on-site listing that resolution can disagree with the owner this
+              table displays — see the `listing` prop's docstring. */}
           <Text size="sm">
-            Delivered as a notification to the app&apos;s owner
-            {listing.ownerLabel ? (
-              <>
-                {' '}
-                (currently <Code>{listing.ownerLabel}</Code>)
-              </>
-            ) : null}
-            . One-way — replies are not delivered — and the subject and message are recorded in this
+            Delivered as a notification to the app&apos;s owner, resolved when you send. One-way —
+            replies are not delivered — and the subject and message are recorded in this
             listing&apos;s moderation history.
           </Text>
         </Alert>

--- a/src/components/Apps/ReasonGatedActionModal.tsx
+++ b/src/components/Apps/ReasonGatedActionModal.tsx
@@ -13,6 +13,11 @@ import {
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
+
+import {
+  reasonGatedFieldDescription,
+  reasonGatedFieldError,
+} from '~/components/Apps/reasonGatedFieldCopy';
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 
 /**
@@ -86,8 +91,11 @@ export function ReasonGatedField({
   maxRows?: number;
 }) {
   const len = value.trim().length;
-  const tooShort = required && len < minLength;
-  const tooLong = maxLength != null && len > maxLength;
+  // Both strings come from the pure `reasonGatedFieldCopy` module rather than being
+  // built inline. Built here they were pinned ONLY by the report-only browser tier, so
+  // dropping the ceiling from the counter — the one thing this prop was added for —
+  // left every blocking suite green. See that module's header.
+  const copy = { length: len, minLength, maxLength, required };
   return (
     <Textarea
       label={label}
@@ -95,24 +103,8 @@ export function ReasonGatedField({
       minRows={minRows}
       maxRows={maxRows}
       placeholder={placeholder}
-      // Live counter — only meaningful when a floor applies. The ceiling is appended
-      // only when one was given, so the no-ceiling callers keep their exact copy.
-      description={
-        required
-          ? `${len}/${minLength} characters minimum` +
-            (maxLength != null ? ` (max ${maxLength})` : '')
-          : undefined
-      }
-      // Inline error once the mod has typed SOMETHING but not enough (an empty field
-      // shows the neutral counter, not a red error) — or once they have typed too much,
-      // which needs no such grace period since it can only happen after typing.
-      error={
-        tooLong
-          ? `Keep it to ${maxLength} characters or fewer (currently ${len}).`
-          : tooShort && len > 0
-          ? `Enter at least ${minLength} characters.`
-          : undefined
-      }
+      description={reasonGatedFieldDescription(copy)}
+      error={reasonGatedFieldError(copy)}
       value={value}
       onChange={(e) => onChange(e.currentTarget.value)}
       disabled={disabled}

--- a/src/components/Apps/ReasonGatedActionModal.tsx
+++ b/src/components/Apps/ReasonGatedActionModal.tsx
@@ -1,4 +1,16 @@
-import { Alert, Box, Button, Code, Group, Modal, Stack, Text, Textarea, TextInput, Tooltip } from '@mantine/core';
+import {
+  Alert,
+  Box,
+  Button,
+  Code,
+  Group,
+  Modal,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
@@ -42,6 +54,7 @@ export function ReasonGatedField({
   onChange,
   disabled,
   minLength = OFFSITE_MOD_REASON_MIN,
+  maxLength,
   required = true,
   label,
   placeholder,
@@ -53,6 +66,17 @@ export function ReasonGatedField({
   onChange: (value: string) => void;
   disabled?: boolean;
   minLength?: number;
+  /**
+   * An optional CEILING, surfaced the same way the floor is.
+   *
+   * 🔴 OPTIONAL AND INERT WHEN OMITTED — every pre-existing caller (reset / hide /
+   * relist / claim / purge / the two reject panels / the report notes) passes no
+   * ceiling and renders the byte-identical description and error it always did. It
+   * exists because `appListings.messageAppOwner` is the first moderator free-text
+   * field with a server-side MAXIMUM zod actually rejects (2000); without it, a long
+   * message opens the gate, fires, and comes back as an unattributed BAD_REQUEST.
+   */
+  maxLength?: number;
   /** When false, this is an OPTIONAL note — no counter, no floor, no inline error. */
   required?: boolean;
   label?: ReactNode;
@@ -63,6 +87,7 @@ export function ReasonGatedField({
 }) {
   const len = value.trim().length;
   const tooShort = required && len < minLength;
+  const tooLong = maxLength != null && len > maxLength;
   return (
     <Textarea
       label={label}
@@ -70,11 +95,24 @@ export function ReasonGatedField({
       minRows={minRows}
       maxRows={maxRows}
       placeholder={placeholder}
-      // Live counter — only meaningful when a floor applies.
-      description={required ? `${len}/${minLength} characters minimum` : undefined}
+      // Live counter — only meaningful when a floor applies. The ceiling is appended
+      // only when one was given, so the no-ceiling callers keep their exact copy.
+      description={
+        required
+          ? `${len}/${minLength} characters minimum` +
+            (maxLength != null ? ` (max ${maxLength})` : '')
+          : undefined
+      }
       // Inline error once the mod has typed SOMETHING but not enough (an empty field
-      // shows the neutral counter, not a red error).
-      error={tooShort && len > 0 ? `Enter at least ${minLength} characters.` : undefined}
+      // shows the neutral counter, not a red error) — or once they have typed too much,
+      // which needs no such grace period since it can only happen after typing.
+      error={
+        tooLong
+          ? `Keep it to ${maxLength} characters or fewer (currently ${len}).`
+          : tooShort && len > 0
+          ? `Enter at least ${minLength} characters.`
+          : undefined
+      }
       value={value}
       onChange={(e) => onChange(e.currentTarget.value)}
       disabled={disabled}

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   actionOpensOwnerMessage,
   actionRequiresReason,
+  ALL_LISTING_MOD_ACTIONS,
   effectiveModerationStatus,
   isDestructiveListingModAction,
   listingKindChip,
@@ -138,19 +139,19 @@ describe('listingModActions — the owner-message action is offered on EVERY row
 });
 
 /**
- * The full action vocabulary, spelled once. Every `describe` below iterates THIS, so a
- * member added to `ListingModAction` without a label / a routing decision fails here
- * rather than rendering an empty button or falling through both modal branches.
+ * The full action vocabulary, IMPORTED rather than re-spelled. Every `describe` below
+ * iterates THIS.
+ *
+ * 🔴 IT IS DERIVED FROM THE PRODUCTION ROUTE TABLE, AND THE EARLIER HAND-MAINTAINED
+ * ARRAY IS WHY. That array's docstring claimed "a member added to `ListingModAction`
+ * without a label / a routing decision fails here" — the label half was real (an
+ * exhaustive switch), the ROUTING half was not: `actionRequiresReason` was a negation,
+ * so a new member answered `true` by default, landed in the reason-gated modal, and
+ * every assertion below still passed. Measured: adding a member to the union left all 46
+ * unit tests green. Now a new member must appear in `LISTING_MOD_ROUTES` to exist here
+ * at all — it cannot compile otherwise — and once it does, the sweeps below walk it.
  */
-const ALL_ACTIONS: ListingModAction[] = [
-  'review',
-  'message-owner',
-  'reset-to-pending',
-  'hide',
-  'relist',
-  'claim',
-  'purge',
-];
+const ALL_ACTIONS: ListingModAction[] = ALL_LISTING_MOD_ACTIONS;
 
 describe('action metadata', () => {
   it('only purge is destructive', () => {
@@ -187,6 +188,17 @@ describe('action metadata', () => {
     for (const a of ['reset-to-pending', 'hide', 'relist', 'claim', 'purge'] as const) {
       expect(actionRequiresReason(a)).toBe(true);
     }
+  });
+
+  /**
+   * The derived vocabulary really is the whole union. Without this, every sweep that
+   * iterates `ALL_ACTIONS` would pass vacuously if the route table were ever emptied —
+   * the positive control on the derivation itself, not on any one predicate.
+   */
+  it('the vocabulary derived from the route table is the whole union', () => {
+    expect([...ALL_ACTIONS].sort()).toEqual(
+      ['claim', 'hide', 'message-owner', 'purge', 'relist', 'reset-to-pending', 'review'].sort()
+    );
   });
 
   /**

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  actionOpensOwnerMessage,
   actionRequiresReason,
   effectiveModerationStatus,
   isDestructiveListingModAction,
   listingKindChip,
   listingModActionLabel,
   listingModActions,
+  type ListingModAction,
 } from '~/components/Apps/appListingModerationTableView';
 
 const pendingReq = {
@@ -25,37 +27,37 @@ const pendingReq = {
  */
 
 describe('listingModActions — off-site rows', () => {
-  it('pending (with a pending request) → Review only', () => {
-    expect(listingModActions({ status: 'pending', kind: 'offsite', hasPendingRequest: true })).toEqual(
-      ['review']
-    );
+  it('pending (with a pending request) → Review + Message owner', () => {
+    expect(
+      listingModActions({ status: 'pending', kind: 'offsite', hasPendingRequest: true })
+    ).toEqual(['review', 'message-owner']);
   });
 
   it('approved → Reset to pending + Hide', () => {
     expect(
       listingModActions({ status: 'approved', kind: 'offsite', hasPendingRequest: false })
-    ).toEqual(['reset-to-pending', 'hide']);
+    ).toEqual(['message-owner', 'reset-to-pending', 'hide']);
   });
 
   it('removed → Relist + Claim + Purge', () => {
     expect(
       listingModActions({ status: 'removed', kind: 'offsite', hasPendingRequest: false })
-    ).toEqual(['relist', 'claim', 'purge']);
+    ).toEqual(['message-owner', 'relist', 'claim', 'purge']);
   });
 
   it('draft → no lifecycle action (unless a pending request offers Review)', () => {
-    expect(listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: false })).toEqual(
-      []
-    );
-    expect(listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: true })).toEqual(
-      ['review']
-    );
+    expect(
+      listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: false })
+    ).toEqual(['message-owner']);
+    expect(
+      listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: true })
+    ).toEqual(['review', 'message-owner']);
   });
 
-  it('rejected → read-only', () => {
+  it('rejected → read-only apart from Message owner', () => {
     expect(
       listingModActions({ status: 'rejected', kind: 'offsite', hasPendingRequest: false })
-    ).toEqual([]);
+    ).toEqual(['message-owner']);
   });
 });
 
@@ -63,44 +65,151 @@ describe('listingModActions — on-site rows hide the off-site-only actions', ()
   it('approved on-site → Reset to pending + Hide (reset is now dual-kind, #3165)', () => {
     expect(
       listingModActions({ status: 'approved', kind: 'onsite', hasPendingRequest: false })
-    ).toEqual(['reset-to-pending', 'hide']);
+    ).toEqual(['message-owner', 'reset-to-pending', 'hide']);
   });
 
   it('removed on-site → Relist ONLY (no claim / purge)', () => {
     expect(
       listingModActions({ status: 'removed', kind: 'onsite', hasPendingRequest: false })
-    ).toEqual(['relist']);
+    ).toEqual(['message-owner', 'relist']);
   });
 
   it('pending on-site → NO Review (approve/reject is off-site only; onsite uses its own queue)', () => {
     expect(
       listingModActions({ status: 'pending', kind: 'onsite', hasPendingRequest: true })
-    ).toEqual([]);
+    ).toEqual(['message-owner']);
   });
 });
+
+/**
+ * 🔴 `message-owner` IS THE ONE UNCONDITIONAL ACTION, and this block is the guard on
+ * that claim rather than a restatement of the cases above.
+ *
+ * The proc it fronts (`appListings.messageAppOwner`) resolves its recipient through
+ * `resolveListingAccess`, which branches on KIND and never on STATUS — so there is no
+ * row in this table on which the button would 4xx. The whole reason the feature was
+ * unreachable for its first release is that no surface offered it; a narrowing that
+ * silently drops it from (say) rejected rows re-creates that, and it is exactly the
+ * kind of regression the per-status cases above would NOT catch, because each of them
+ * only pins the status it names.
+ *
+ * The cross product is enumerated, not sampled.
+ */
+describe('listingModActions — the owner-message action is offered on EVERY row', () => {
+  const STATUSES = ['draft', 'pending', 'approved', 'rejected', 'removed'] as const;
+  const KINDS = ['onsite', 'offsite'] as const;
+
+  it('appears for every status × kind × pending-request combination', () => {
+    const missing: string[] = [];
+    for (const status of STATUSES) {
+      for (const kind of KINDS) {
+        for (const hasPendingRequest of [true, false]) {
+          const actions = listingModActions({ status, kind, hasPendingRequest });
+          if (!actions.includes('message-owner')) {
+            missing.push(`${kind}/${status}/pending=${hasPendingRequest}`);
+          }
+        }
+      }
+    }
+    // Positive control on the enumeration itself: 5 statuses × 2 kinds × 2 = 20 cases
+    // were actually walked, so an empty `missing` is a real sweep and not an empty loop.
+    expect(STATUSES.length * KINDS.length * 2).toBe(20);
+    expect(missing).toEqual([]);
+  });
+
+  it('is never the LAST action when a destructive one is present (purge stays rightmost)', () => {
+    const removed = listingModActions({
+      status: 'removed',
+      kind: 'offsite',
+      hasPendingRequest: false,
+    });
+    // Positive control: this row really does carry the destructive action.
+    expect(removed).toContain('purge');
+    expect(removed.at(-1)).toBe('purge');
+    expect(removed.indexOf('message-owner')).toBeLessThan(removed.indexOf('purge'));
+  });
+
+  it('never appears twice on one row', () => {
+    for (const status of STATUSES) {
+      const actions = listingModActions({ status, kind: 'offsite', hasPendingRequest: true });
+      expect(actions.filter((a) => a === 'message-owner')).toHaveLength(1);
+    }
+  });
+});
+
+/**
+ * The full action vocabulary, spelled once. Every `describe` below iterates THIS, so a
+ * member added to `ListingModAction` without a label / a routing decision fails here
+ * rather than rendering an empty button or falling through both modal branches.
+ */
+const ALL_ACTIONS: ListingModAction[] = [
+  'review',
+  'message-owner',
+  'reset-to-pending',
+  'hide',
+  'relist',
+  'claim',
+  'purge',
+];
 
 describe('action metadata', () => {
   it('only purge is destructive', () => {
     expect(isDestructiveListingModAction('purge')).toBe(true);
-    for (const a of ['review', 'reset-to-pending', 'hide', 'relist', 'claim'] as const) {
+    for (const a of [
+      'review',
+      'message-owner',
+      'reset-to-pending',
+      'hide',
+      'relist',
+      'claim',
+    ] as const) {
       expect(isDestructiveListingModAction(a)).toBe(false);
     }
   });
 
-  it('every action except review requires a reason', () => {
+  /**
+   * 🔴 `message-owner` is NOT reason-gated, and that is a claim about the SURFACE it
+   * opens: `MessageAppOwnerModal` has no `reason` field at all — it has a subject and a
+   * body with their own floors. Answering `true` here would send it to
+   * `ListingModActionModal`, which renders one `reason` textarea and would call
+   * `messageAppOwner` with an input its schema rejects.
+   */
+  it('every mutating action except message-owner requires a reason; review requires none', () => {
     expect(actionRequiresReason('review')).toBe(false);
+    expect(actionRequiresReason('message-owner')).toBe(false);
     for (const a of ['reset-to-pending', 'hide', 'relist', 'claim', 'purge'] as const) {
       expect(actionRequiresReason(a)).toBe(true);
     }
   });
 
+  /**
+   * The two modal routers are MUTUALLY EXCLUSIVE and together they must not leave a
+   * mutating action unrouted. `review` is the deliberate third case (it opens the
+   * publish-request review modal, which is neither of these).
+   */
+  it('exactly one action opens the owner-message composer, and it opens no other modal', () => {
+    const opensMessage = ALL_ACTIONS.filter(actionOpensOwnerMessage);
+    expect(opensMessage).toEqual(['message-owner']);
+    for (const a of ALL_ACTIONS) {
+      // No action may be claimed by BOTH routers.
+      expect(actionOpensOwnerMessage(a) && actionRequiresReason(a)).toBe(false);
+      // And every action must be claimed by one of the three routes.
+      expect(actionOpensOwnerMessage(a) || actionRequiresReason(a) || a === 'review').toBe(true);
+    }
+  });
+
   it('labels each action', () => {
     expect(listingModActionLabel('review')).toBe('Review');
+    expect(listingModActionLabel('message-owner')).toBe('Message owner');
     expect(listingModActionLabel('reset-to-pending')).toBe('Reset to pending');
     expect(listingModActionLabel('hide')).toBe('Hide');
     expect(listingModActionLabel('relist')).toBe('Relist');
     expect(listingModActionLabel('claim')).toBe('Claim');
     expect(listingModActionLabel('purge')).toBe('Purge');
+    // Totality: every member of the vocabulary has a non-empty, distinct label.
+    const labels = ALL_ACTIONS.map(listingModActionLabel);
+    expect(labels.every((l) => l.length > 0)).toBe(true);
+    expect(new Set(labels).size).toBe(ALL_ACTIONS.length);
   });
 
   // 🔴 THIS CHIP WAS A THIRD, DIVERGENT KIND-LABEL IMPLEMENTATION — lowercase
@@ -125,7 +234,9 @@ describe('effectiveModerationStatus', () => {
   });
 
   it('approved → approved (unchanged)', () => {
-    expect(effectiveModerationStatus({ status: 'approved', pendingRequest: null })).toBe('approved');
+    expect(effectiveModerationStatus({ status: 'approved', pendingRequest: null })).toBe(
+      'approved'
+    );
   });
 
   it('pending → pending (unchanged)', () => {

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -170,9 +170,16 @@ describe('action metadata', () => {
   /**
    * 🔴 `message-owner` is NOT reason-gated, and that is a claim about the SURFACE it
    * opens: `MessageAppOwnerModal` has no `reason` field at all — it has a subject and a
-   * body with their own floors. Answering `true` here would send it to
-   * `ListingModActionModal`, which renders one `reason` textarea and would call
-   * `messageAppOwner` with an input its schema rejects.
+   * body with their own floors.
+   *
+   * 🔴 Stated precisely, because the looser version of this sentence was WRONG.
+   * `openAction` checks `actionOpensOwnerMessage` BEFORE this predicate, so answering
+   * `true` here would NOT on its own send `message-owner` to `ListingModActionModal` —
+   * it would put the action in two routers at once, which the exclusivity test below is
+   * what actually forbids. The mis-route this pair prevents is the one that arrives via
+   * a NEW action: an action neither router claims must open nothing, and an action this
+   * one claims must genuinely carry a `reason`, or `ListingModActionModal` calls its
+   * proc with an input the schema rejects.
    */
   it('every mutating action except message-owner requires a reason; review requires none', () => {
     expect(actionRequiresReason('review')).toBe(false);

--- a/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
@@ -31,24 +31,45 @@ import {
  *
  * 🔴 KNOWN LIMITS, stated rather than implied. Detection is syntactic and per-file: a
  * site that mounts the modal through a wrapper or `React.createElement` is invisible
- * here. The numeric-literal scan strips comments with a regex, so a `//` sequence
- * inside a string literal in one of the scanned files would confuse it — neither
- * scanned file contains one today, and the positive control below proves the detector
- * can still fire when it matters.
+ * here. Every source assertion reads through {@link codeOf}, which strips comments with
+ * a regex, so a `//` sequence inside a string literal in one of the three scanned files
+ * would confuse it — none contains one today (checked), and the positive control below
+ * proves the detector can still fire when it matters. The MOUNT sweep deliberately reads
+ * RAW: a comment quoting `<MessageAppOwnerModal` there produces a loud ledger mismatch,
+ * whereas a bad strip would silently hide a real second mount, and loud is the direction
+ * to fail in for a sweep whose whole job is to notice a new site. That sweep also matches
+ * a PREFIX, so a sibling named `MessageAppOwnerModalCompact` counts as a mount of this
+ * one — again the loud direction (an unexpected ledger entry), and again not a silent
+ * miss. Renaming BOTH the component and its file to a longer name is the one case it
+ * would not notice, and the `MODAL_MODULE` reads below throw ENOENT on that.
  *
- * 🔴 The reset-completeness ledger further down is scoped to `useState` DECLARATIONS in
- * the composer module. State introduced some other way — `useReducer`, a custom hook, a
- * ref — is invisible to it, so its claim is "every `useState` piece", not "every piece
- * of state that exists". It is also module-scoped rather than component-scoped: a second
- * component added to this file would have ITS setters demanded inside `reset()` too.
- * That direction fails loudly and is the safe one; the `useState`-only direction is the
- * gap, and widening the composer's state to a reducer means widening this with it.
+ * 🔴 The reset ledger further down is scoped to `useState` DECLARATIONS in the composer
+ * module. State introduced some other way — `useReducer`, a custom hook, a ref — is
+ * invisible to it, so its claim is "every `useState` piece", not "every piece of state
+ * that exists". It is also module-scoped rather than component-scoped: a second component
+ * added to this file would have ITS setters demanded inside `reset()` too. That direction
+ * fails loudly and is the safe one; the `useState`-only direction is the gap, and widening
+ * the composer's state to a reducer means widening this with it.
+ *
+ * 🔴 And the reset ledger reads `reset()`'s OWN body only. A `reset()` that delegates —
+ * `function reset() { clearComposer(); }` — satisfies nothing it should: every setter
+ * would read as uncalled and the ledger would fail LOUDLY, which is safe but is a false
+ * alarm rather than a finding. Inlining the clears, or teaching {@link resetOffences} to
+ * follow one call, are the two fixes; do not "fix" it by dropping the assertion.
  */
 
 const SRC = path.resolve(__dirname, '../../..');
 
 const FORM_MODULE = 'components/Apps/appModeratorMessageForm.ts';
 const MODAL_MODULE = 'components/Apps/MessageAppOwnerModal.tsx';
+/**
+ * The shared field the composer renders its body through. Enrolled here because it is
+ * read by NO blocking test otherwise — measured, and the reason `reasonGatedFieldCopy`
+ * was extracted in the first place. That extraction moved the STRINGS somewhere a
+ * blocking suite can see them; it left the WIRING (which copy function feeds which prop,
+ * and whether the length handed to them is trimmed) exactly as unobservable as before.
+ */
+const FIELD_MODULE = 'components/Apps/ReasonGatedActionModal.tsx';
 
 /**
  * Every PRODUCTION site that mounts `MessageAppOwnerModal`. One today: the /apps/review
@@ -67,6 +88,21 @@ function read(rel: string): string {
 /** Strip `/* *\/` and `//` comments so prose that MENTIONS a bound is not a hit. */
 function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/**
+ * 🔴 THE ONLY READER ANY ASSERTION BELOW SHOULD USE — comment-stripped source.
+ *
+ * Every check here is a claim about CODE, and prose is not code. A raw read gets the
+ * polarity wrong in BOTH directions: a `toContain` is satisfied by a comment that merely
+ * quotes the call it demands (so a deleted branch reads as present), and a
+ * `not.toContain` is broken by a comment that names the identifier it forbids (so a
+ * correct file reads as an offence). Neither is hypothetical in a file whose comments
+ * deliberately quote the code around them — this one included. The numeric-bounds scan
+ * already stripped; four source assertions did not, and now nothing reads raw.
+ */
+function codeOf(rel: string): string {
+  return stripComments(read(rel));
 }
 
 /** Standalone occurrences of `value` as a numeric token (not part of an identifier). */
@@ -95,22 +131,52 @@ function balanced(source: string, from: number, open: string, close: string): st
 }
 
 /**
- * The body of a `function <name>(…) { … }` declaration. The parameter list is skipped
- * with its own balance pass so a destructured parameter's `{` can't be mistaken for the
- * opening brace of the body.
+ * The body of `function <name>(…) { … }` OR of `const <name> = (…) => { … }`. The
+ * parameter list is skipped with its own balance pass so a destructured parameter's `{`
+ * can't be mistaken for the opening brace of the body.
+ *
+ * 🔴 BOTH FORMS, because supporting only the `function` keyword made this throw
+ * `no function reset` on a pure refactor — an error naming a syntax choice rather than a
+ * defect, which is the shape that gets a guard deleted as broken instead of read as a
+ * finding. Behaviour is identical either way, so the ledger must not have an opinion.
+ * An arrow with a CONCISE body (`const reset = () => setX('')`) is still unsupported and
+ * throws by name below; it cannot express the multi-statement reset this pins.
  */
 function functionBody(source: string, name: string): string {
-  const at = source.indexOf(`function ${name}(`);
-  if (at < 0) throw new Error(`no function ${name}`);
+  const declaration = new RegExp(
+    `(?:function\\s+${name}\\s*\\()|(?:const\\s+${name}\\s*=\\s*(?:async\\s*)?\\()`
+  ).exec(source);
+  if (!declaration) {
+    throw new Error(
+      `no \`function ${name}(\` and no \`const ${name} = (\` — if it was refactored to ` +
+        `another form, widen functionBody rather than deleting this ledger`
+    );
+  }
   let depth = 0;
-  for (let i = source.indexOf('(', at); i < source.length; i++) {
+  for (let i = source.indexOf('(', declaration.index); i < source.length; i++) {
     if (source[i] === '(') depth++;
     else if (source[i] === ')') {
       depth--;
-      if (depth === 0) return balanced(source, i + 1, '{', '}');
+      if (depth === 0) {
+        const rest = source.slice(i + 1);
+        // The arrow form puts `=> ` (and possibly a return type) between `)` and `{`;
+        // a concise-body arrow has no `{` of its own and must not silently borrow the
+        // next block in the file.
+        if (/^\s*(?::[^=]*)?=>/.test(rest) && !/^\s*(?::[^=]*)?=>\s*\{/.test(rest)) {
+          throw new Error(`${name} is a concise-body arrow — functionBody needs a block body`);
+        }
+        return balanced(source, i + 1, '{', '}');
+      }
     }
   }
   throw new Error(`unbalanced parameter list in ${name}`);
+}
+
+/** The initialiser of a `const <name> = …;` binding, up to the `;` or the line end. */
+function constInitialiser(source: string, name: string): string {
+  const m = new RegExp(`const\\s+${name}\\s*=\\s*([^;\\n]+)`).exec(source);
+  if (!m) throw new Error(`no const ${name}`);
+  return normalise(m[1]);
 }
 
 /** The single argument of a `<callee>(…)` call. */
@@ -138,15 +204,82 @@ function objectProperty(objectInner: string, key: string): string {
   return objectInner.slice(start);
 }
 
-/** Every `set…` returned by a `const [x, setX] = useState(…)` in a module. */
-function stateSetters(source: string): string[] {
-  const re = /const\s*\[\s*[A-Za-z0-9_$]+\s*,\s*(set[A-Za-z0-9_$]+)\s*\]\s*=\s*useState/g;
-  return [...source.matchAll(re)].map((m) => m[1]);
+/** Whitespace collapsed to single spaces and trimmed, so formatting is not a difference. */
+function normalise(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
 }
 
-/** Which of `setters` are NOT called anywhere in `body`. */
-function settersNotCalledIn(body: string, setters: string[]): string[] {
-  return setters.filter((s) => !new RegExp(`\\b${s}\\s*\\(`).test(body));
+/**
+ * Every `useState` piece in a module: the setter name → the NORMALISED text of the
+ * DECLARED INITIAL VALUE. Comment-stripped source only.
+ *
+ * The initial value is read with a balance pass from the `(` that follows `useState`
+ * rather than by regex, so a type argument of any shape (`useState<Foo<Bar>>('')`) and
+ * an initialiser containing its own parens both survive. A `useState` with no call
+ * parens at all would make that `(` belong to some later expression, so the text between
+ * is asserted to be argument-free first — it throws rather than silently reading the
+ * wrong span.
+ */
+function stateInitialValues(source: string): Map<string, string> {
+  const re = /const\s*\[\s*[A-Za-z0-9_$]+\s*,\s*(set[A-Za-z0-9_$]+)\s*\]\s*=\s*useState/g;
+  const out = new Map<string, string>();
+  for (const m of source.matchAll(re)) {
+    const after = m.index + m[0].length;
+    const paren = source.indexOf('(', after);
+    if (paren < 0) throw new Error(`no useState call parens for ${m[1]}`);
+    const between = source.slice(after, paren);
+    if (/[;{}=]/.test(between)) throw new Error(`useState for ${m[1]} is not called`);
+    out.set(m[1], normalise(balanced(source, paren, '(', ')')));
+  }
+  return out;
+}
+
+/**
+ * 🔴 EVERY WAY `reset()` CAN FAIL TO RESET, as human-readable offences.
+ *
+ * Two of them, and the second is why this replaced a "was the setter CALLED" check:
+ * mutating `setIncludeCollaborators(false)` to `setIncludeCollaborators(true)` inside
+ * `reset()` left the whole blocking tier green (13/13), because the setter was still
+ * called — only the report-only browser tier saw it. A ledger that asserts a call
+ * happened cannot see the value it carries, and the value is the entire hazard: a
+ * collaborator opt-in that survives a send fans the NEXT moderation message out to third
+ * parties who opted into nothing.
+ *
+ * So the assertion is the RELATIONSHIP `reset() restores the declared initial`, not
+ * `reset() mentions the setter`. It fails when a piece of state is added without a
+ * reset, when an existing reset is deleted, AND when a reset is rewritten to a value
+ * that is not what the component mounts with.
+ */
+function resetOffences(body: string, initials: Map<string, string>): string[] {
+  const offences: string[] = [];
+  for (const [setter, initial] of initials) {
+    const call = new RegExp(`\\b${setter}\\s*\\(`).exec(body);
+    if (!call) {
+      offences.push(`${setter}: never called in reset() (declared initial ${initial})`);
+      continue;
+    }
+    const arg = normalise(balanced(body, call.index + call[0].length - 1, '(', ')'));
+    if (arg !== initial) {
+      offences.push(`${setter}: reset() passes ${arg}, declared initial is ${initial}`);
+    }
+  }
+  return offences;
+}
+
+/**
+ * The literal text between `open` and the next `close`, for a JSX element whose children
+ * are prose. It refuses a span containing a `<`, so a nested element makes this throw by
+ * name rather than return a half-string that a whole-sentence assertion would then
+ * compare against and fail confusingly.
+ */
+function elementText(source: string, open: string, close: string): string {
+  const start = source.indexOf(open);
+  if (start < 0) throw new Error(`no ${open}`);
+  const end = source.indexOf(close, start + open.length);
+  if (end < 0) throw new Error(`no ${close} after ${open}`);
+  const text = source.slice(start + open.length, end);
+  if (text.includes('<')) throw new Error(`${open} has nested elements — widen elementText`);
+  return text;
 }
 
 /** A self-closing JSX element's full text, `<Name` through the matching `/>`. */
@@ -196,7 +329,7 @@ describe('the owner-message surface is MOUNTED (it shipped dark once already)', 
   });
 
   it('the mounting site routes the action through actionOpensOwnerMessage, not the reason modal', () => {
-    const table = read(MOUNT_SITES[0]);
+    const table = codeOf(MOUNT_SITES[0]);
     // The router must be CALLED, not merely imported — an import with no call site is
     // exactly how the message action would silently fall through to
     // `setPendingAction` and open the wrong modal.
@@ -210,7 +343,7 @@ describe('the owner-message surface is MOUNTED (it shipped dark once already)', 
     // gated routing — measured by reverting it to `action !== 'review'`, which left all
     // 48 component tests green. A ledger over MOUNTS has to cover the ROUTERS too, or
     // the surface stays mounted and reachable by the wrong modal.
-    const table = read(MOUNT_SITES[0]);
+    const table = codeOf(MOUNT_SITES[0]);
     expect(table).toContain('actionRequiresReason(action)');
     expect(table).toContain('setPendingAction({ action, row })');
   });
@@ -219,7 +352,7 @@ describe('the owner-message surface is MOUNTED (it shipped dark once already)', 
     // `messageAppOwner` keys on `apl_<ULID>`; a slug would come back NOT_FOUND. The
     // row carries both and they are adjacent in the object literal, so this is a
     // realistic transposition rather than a hypothetical one.
-    const table = read(MOUNT_SITES[0]);
+    const table = codeOf(MOUNT_SITES[0]);
     expect(table).toMatch(/appListingId:\s*messageRow\.id/);
   });
 });
@@ -240,7 +373,7 @@ describe('the composer bounds are single-sourced from the server schema', () => 
     };
     const offences: string[] = [];
     for (const rel of [FORM_MODULE, MODAL_MODULE]) {
-      const code = stripComments(read(rel));
+      const code = codeOf(rel);
       for (const [name, value] of Object.entries(bounds)) {
         const hits = bareNumericHits(code, value);
         if (hits > 0) offences.push(`${rel}: ${hits}× bare ${value} (use ${name})`);
@@ -275,7 +408,7 @@ describe('the composer bounds are single-sourced from the server schema', () => 
    * it was pinned only in the report-only browser tier.
    */
   it('each field is wired to ITS OWN bounds — the body to the body pair, the subject to the subject pair', () => {
-    const code = stripComments(read(MODAL_MODULE));
+    const code = codeOf(MODAL_MODULE);
 
     const body = selfClosingElement(code, 'ReasonGatedField');
     // Positive control on the extractor: it grabbed the body field and not some other
@@ -290,6 +423,50 @@ describe('the composer bounds are single-sourced from the server schema', () => 
     expect(subject).toContain('MOD_MESSAGE_SUBJECT_MIN');
     expect(subject).toContain('MOD_MESSAGE_SUBJECT_MAX');
     expect(subject).not.toContain('MOD_MESSAGE_BODY_');
+  });
+});
+
+/**
+ * 🔴 THE SEAM THE EXTRACTION CREATED, WHICH NEITHER TIER WAS WATCHING.
+ *
+ * `reasonGatedFieldCopy` was split out of `ReasonGatedField` so the counter and the
+ * inline error would be pinned by something that can block a merge. That closed half the
+ * hole: the strings are now pure functions with their own blocking suite, but the JSX
+ * that CALLS them is in a file no blocking test reads. Measured on the extracted code —
+ * both of these survived 1318 blocking + 1113 browser tests:
+ *
+ *   - swapping `description={reasonGatedFieldDescription(copy)}` with
+ *     `error={reasonGatedFieldError(copy)}`, which renders the "too long" message as the
+ *     neutral counter and the counter as a red error;
+ *   - `length: len` → `length: value.length`, which silently drops the trimming the
+ *     server's own validation assumes, so a body of spaces opens the gate and comes
+ *     straight back rejected.
+ *
+ * Two hermetically-tested halves, a defect that lives only between them. These pin the
+ * RELATIONSHIP: which function feeds which prop, and that the length both receive is the
+ * trimmed one no matter which identifier it arrives under.
+ */
+describe('the shared field is wired to the copy module it was extracted into', () => {
+  it('each prop is fed by ITS OWN copy function', () => {
+    const code = codeOf(FIELD_MODULE);
+    const textarea = selfClosingElement(code, 'Textarea');
+    // Positive control on the extractor: it grabbed the reason textarea and not some
+    // other self-closing element in the file.
+    expect(textarea).toContain('data-testid={testId}');
+    expect(textarea).toContain('description={reasonGatedFieldDescription(copy)}');
+    expect(textarea).toContain('error={reasonGatedFieldError(copy)}');
+  });
+
+  it('the copy input is built from the TRIMMED length, through however many aliases', () => {
+    const code = codeOf(FIELD_MODULE);
+    const at = code.indexOf('const copy = {');
+    expect(at).toBeGreaterThan(-1);
+    const copyLiteral = balanced(code, at, '{', '}');
+    const written = normalise(objectProperty(copyLiteral, 'length').replace(/^length:\s*/, ''));
+    // Written as a bare identifier? Resolve it to what that identifier is assigned, so
+    // the trim can't be dropped one level up where this assertion could not see it.
+    const resolved = /^[A-Za-z0-9_$]+$/.test(written) ? constInitialiser(code, written) : written;
+    expect(resolved).toBe('value.trim().length');
   });
 });
 
@@ -309,7 +486,7 @@ describe('the composer bounds are single-sourced from the server schema', () => 
  */
 describe('the composer takes no owner from its caller', () => {
   it('the exact key set of the listing prop', () => {
-    const code = stripComments(read(MODAL_MODULE));
+    const code = codeOf(MODAL_MODULE);
     const at = code.indexOf('listing: {');
     expect(at).toBeGreaterThan(-1);
     const shape = balanced(code, at, '{', '}');
@@ -319,10 +496,33 @@ describe('the composer takes no owner from its caller', () => {
 
   it('neither the composer nor its mount site carries a display owner', () => {
     for (const rel of [MODAL_MODULE, MOUNT_SITES[0]]) {
-      expect(read(rel)).not.toContain('ownerLabel');
+      expect(codeOf(rel)).not.toContain('ownerLabel');
     }
     // Positive control: the mount site DOES still build the props it is supposed to.
-    expect(read(MOUNT_SITES[0])).toMatch(/appListingId:\s*messageRow\.id/);
+    expect(codeOf(MOUNT_SITES[0])).toMatch(/appListingId:\s*messageRow\.id/);
+  });
+
+  /**
+   * 🔴 THE NOTICE, PINNED WHOLE — because a guard on WORDS is walkable by REWORDING.
+   *
+   * The browser tier asked only that no `@handle`/`#id` appear. That is a SPELLED guard:
+   * rewriting the notice as "…to the app owner devuser, resolved when you send" names a
+   * recipient in plain prose, matches no `[@#]\w`, and passed all 17 browser tests. The
+   * prop-shape ledger above already stops a CALLER handing the composer an owner, so the
+   * residual hazard is this file naming one itself — which is a change to this exact
+   * string and nothing else.
+   *
+   * So the whole normalised sentence is the assertion, and it lives in the BLOCKING tier
+   * rather than only in the report-only browser one. A deliberate reword fails this and
+   * is meant to: the copy is a claim about where a moderation message goes, and updating
+   * a machine-readable pin is the cheap half of changing it.
+   */
+  it('the delivery notice is exactly this sentence', () => {
+    expect(normalise(elementText(codeOf(MODAL_MODULE), '<Text size="sm">', '</Text>'))).toBe(
+      'Delivered as a notification to the app&apos;s owner, resolved when you send. One-way — ' +
+        'replies are not delivered — and the subject and message are recorded in this ' +
+        'listing&apos;s moderation history.'
+    );
   });
 });
 
@@ -332,35 +532,61 @@ describe('the composer takes no owner from its caller', () => {
  * claims in a comment rather than pinned behaviour.
  */
 describe('the composer resets per message and never on failure', () => {
-  it('reset() clears every useState piece the composer declares, the collaborator opt-in included', () => {
-    const code = stripComments(read(MODAL_MODULE));
-    const setters = stateSetters(code);
-    // Positive control on the detector: the composer really does declare state, and the
-    // opt-in is one of the pieces this is asserting about.
-    expect(setters.length).toBeGreaterThan(0);
-    expect(setters).toContain('setIncludeCollaborators');
-    // The RELATIONSHIP, not a fixed list: the ledger fails when state is ADDED without a
-    // matching reset just as it does when an existing reset is dropped.
-    expect(settersNotCalledIn(functionBody(code, 'reset'), setters)).toEqual([]);
+  it('reset() restores every useState piece to its DECLARED initial value, the collaborator opt-in included', () => {
+    const code = codeOf(MODAL_MODULE);
+    const initials = stateInitialValues(code);
+    // Positive control on the detector: the composer really does declare state, the
+    // opt-in is one of the pieces this is asserting about, and it mounts OFF — so the
+    // comparison below has a real, non-empty right-hand side to be wrong about.
+    expect(initials.size).toBeGreaterThan(0);
+    expect(initials.get('setIncludeCollaborators')).toBe('false');
+    expect(resetOffences(functionBody(code, 'reset'), initials)).toEqual([]);
   });
 
-  it('the reset-completeness detector fires on a composer that forgets one setter', () => {
-    const planted = [
+  it('the reset detector fires on a forgotten setter AND on one reset to the wrong value', () => {
+    const declarations = [
       "const [subject, setSubject] = useState('');",
       'const [includeCollaborators, setIncludeCollaborators] = useState(false);',
+    ];
+    const forgot = [...declarations, 'function reset() {', "  setSubject('');", '}'].join('\n');
+    const forgotInitials = stateInitialValues(forgot);
+    expect([...forgotInitials.entries()]).toEqual([
+      ['setSubject', "''"],
+      ['setIncludeCollaborators', 'false'],
+    ]);
+    expect(resetOffences(functionBody(forgot, 'reset'), forgotInitials)).toEqual([
+      'setIncludeCollaborators: never called in reset() (declared initial false)',
+    ]);
+
+    // 🔴 THE MUTANT THE OLD "was it called" LEDGER LET THROUGH. The setter is called, so
+    // a call-presence check is satisfied; the value it carries is the opposite of what
+    // the composer mounts with.
+    const wrongValue = [
+      ...declarations,
       'function reset() {',
       "  setSubject('');",
+      '  setIncludeCollaborators(true);',
       '}',
     ].join('\n');
-    const setters = stateSetters(planted);
-    expect(setters).toEqual(['setSubject', 'setIncludeCollaborators']);
-    expect(settersNotCalledIn(functionBody(planted, 'reset'), setters)).toEqual([
-      'setIncludeCollaborators',
+    const wrongInitials = stateInitialValues(wrongValue);
+    expect(resetOffences(functionBody(wrongValue, 'reset'), wrongInitials)).toEqual([
+      'setIncludeCollaborators: reset() passes true, declared initial is false',
     ]);
+
+    // And a correct composer produces no offence at all — so the detector is not simply
+    // always-red, which would make the real assertion above meaningless.
+    const correct = [
+      ...declarations,
+      'function reset() {',
+      "  setSubject('');",
+      '  setIncludeCollaborators(false);',
+      '}',
+    ].join('\n');
+    expect(resetOffences(functionBody(correct, 'reset'), stateInitialValues(correct))).toEqual([]);
   });
 
   it('a failed send does not reset — the mutation onError never calls reset()', () => {
-    const options = callArgument(stripComments(read(MODAL_MODULE)), 'useMutation');
+    const options = callArgument(codeOf(MODAL_MODULE), 'useMutation');
     // Positive control on the property extractor: the SUCCESS handler does reset, so a
     // clean `onError` is a real read of real code and not an empty match.
     expect(objectProperty(options, 'onSuccess')).toContain('reset()');

--- a/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
@@ -35,6 +35,14 @@ import {
  * inside a string literal in one of the scanned files would confuse it — neither
  * scanned file contains one today, and the positive control below proves the detector
  * can still fire when it matters.
+ *
+ * 🔴 The reset-completeness ledger further down is scoped to `useState` DECLARATIONS in
+ * the composer module. State introduced some other way — `useReducer`, a custom hook, a
+ * ref — is invisible to it, so its claim is "every `useState` piece", not "every piece
+ * of state that exists". It is also module-scoped rather than component-scoped: a second
+ * component added to this file would have ITS setters demanded inside `reset()` too.
+ * That direction fails loudly and is the safe one; the `useState`-only direction is the
+ * gap, and widening the composer's state to a reducer means widening this with it.
  */
 
 const SRC = path.resolve(__dirname, '../../..');
@@ -324,7 +332,7 @@ describe('the composer takes no owner from its caller', () => {
  * claims in a comment rather than pinned behaviour.
  */
 describe('the composer resets per message and never on failure', () => {
-  it('reset() clears EVERY piece of composer state, the collaborator opt-in included', () => {
+  it('reset() clears every useState piece the composer declares, the collaborator opt-in included', () => {
     const code = stripComments(read(MODAL_MODULE));
     const setters = stateSetters(code);
     // Positive control on the detector: the composer really does declare state, and the

--- a/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
@@ -68,6 +68,89 @@ function bareNumericHits(source: string, value: number): number {
 }
 
 /**
+ * The text between a balanced pair of `open`/`close`, starting at the first `open` at
+ * or after `from`. Comment-stripped source only — a delimiter inside a comment or a
+ * string literal would throw the depth off, and every caller below strips first.
+ */
+function balanced(source: string, from: number, open: string, close: string): string {
+  const start = source.indexOf(open, from);
+  if (start < 0) throw new Error(`no "${open}" at or after index ${from}`);
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === open) depth++;
+    else if (source[i] === close) {
+      depth--;
+      if (depth === 0) return source.slice(start + 1, i);
+    }
+  }
+  throw new Error(`unbalanced "${open}" from index ${start}`);
+}
+
+/**
+ * The body of a `function <name>(…) { … }` declaration. The parameter list is skipped
+ * with its own balance pass so a destructured parameter's `{` can't be mistaken for the
+ * opening brace of the body.
+ */
+function functionBody(source: string, name: string): string {
+  const at = source.indexOf(`function ${name}(`);
+  if (at < 0) throw new Error(`no function ${name}`);
+  let depth = 0;
+  for (let i = source.indexOf('(', at); i < source.length; i++) {
+    if (source[i] === '(') depth++;
+    else if (source[i] === ')') {
+      depth--;
+      if (depth === 0) return balanced(source, i + 1, '{', '}');
+    }
+  }
+  throw new Error(`unbalanced parameter list in ${name}`);
+}
+
+/** The single argument of a `<callee>(…)` call. */
+function callArgument(source: string, callee: string): string {
+  const at = source.indexOf(`${callee}(`);
+  if (at < 0) throw new Error(`no call to ${callee}`);
+  return balanced(source, at + callee.length, '(', ')');
+}
+
+/**
+ * The text of one TOP-LEVEL property of an object literal (the `{…}` inner text), from
+ * its key through to the `,` that ends it. Depth-aware, so a `,` inside a nested call
+ * or object belongs to that nesting and not to this property.
+ */
+function objectProperty(objectInner: string, key: string): string {
+  const start = objectInner.indexOf(`${key}:`);
+  if (start < 0) throw new Error(`no property ${key}`);
+  let depth = 0;
+  for (let i = start; i < objectInner.length; i++) {
+    const c = objectInner[i];
+    if (c === '{' || c === '(' || c === '[') depth++;
+    else if (c === '}' || c === ')' || c === ']') depth--;
+    else if (c === ',' && depth === 0) return objectInner.slice(start, i);
+  }
+  return objectInner.slice(start);
+}
+
+/** Every `set…` returned by a `const [x, setX] = useState(…)` in a module. */
+function stateSetters(source: string): string[] {
+  const re = /const\s*\[\s*[A-Za-z0-9_$]+\s*,\s*(set[A-Za-z0-9_$]+)\s*\]\s*=\s*useState/g;
+  return [...source.matchAll(re)].map((m) => m[1]);
+}
+
+/** Which of `setters` are NOT called anywhere in `body`. */
+function settersNotCalledIn(body: string, setters: string[]): string[] {
+  return setters.filter((s) => !new RegExp(`\\b${s}\\s*\\(`).test(body));
+}
+
+/** A self-closing JSX element's full text, `<Name` through the matching `/>`. */
+function selfClosingElement(source: string, name: string): string {
+  const at = source.indexOf(`<${name}`);
+  if (at < 0) throw new Error(`no <${name}`);
+  const end = source.indexOf('/>', at);
+  if (end < 0) throw new Error(`<${name} is not self-closing`);
+  return source.slice(at, end + 2);
+}
+
+/**
  * Every production `.ts`/`.tsx` under `src/components` and `src/pages`, test files
  * excluded. Both trees are walked because a moderator surface can be a page as easily
  * as a component, and a mount added to a page would otherwise be invisible to the
@@ -111,6 +194,17 @@ describe('the owner-message surface is MOUNTED (it shipped dark once already)', 
     // `setPendingAction` and open the wrong modal.
     expect(table).toContain('actionOpensOwnerMessage(action)');
     expect(table).toContain('setMessageRow(row)');
+  });
+
+  it('the mounting site BRANCHES on actionRequiresReason for the reason-gated actions', () => {
+    // The third route out of `openAction`. Until this assertion existed the predicate
+    // was referenced by nothing but its own test while carrying 🔴 comments claiming it
+    // gated routing — measured by reverting it to `action !== 'review'`, which left all
+    // 48 component tests green. A ledger over MOUNTS has to cover the ROUTERS too, or
+    // the surface stays mounted and reachable by the wrong modal.
+    const table = read(MOUNT_SITES[0]);
+    expect(table).toContain('actionRequiresReason(action)');
+    expect(table).toContain('setPendingAction({ action, row })');
   });
 
   it('the modal is fed the listing ID, never the slug', () => {
@@ -164,5 +258,104 @@ describe('the composer bounds are single-sourced from the server schema', () => 
     // And it must not fire on a number that merely CONTAINS the bound's digits.
     const embedded = `const other = ${MOD_MESSAGE_BODY_MAX}0;`;
     expect(bareNumericHits(stripComments(embedded), MOD_MESSAGE_BODY_MAX)).toBe(0);
+  });
+
+  /**
+   * Importing the right constants is not the same as WIRING them to the right field.
+   * Cross-wiring the body's ceiling to `MOD_MESSAGE_SUBJECT_MAX` passes every check
+   * above (both names are imported, no bare literal appears) and every blocking suite —
+   * it was pinned only in the report-only browser tier.
+   */
+  it('each field is wired to ITS OWN bounds — the body to the body pair, the subject to the subject pair', () => {
+    const code = stripComments(read(MODAL_MODULE));
+
+    const body = selfClosingElement(code, 'ReasonGatedField');
+    // Positive control on the extractor: it grabbed the body field and not some other
+    // self-closing element.
+    expect(body).toContain('testId="apps-mod-message-body"');
+    expect(body).toContain('minLength={MOD_MESSAGE_BODY_MIN}');
+    expect(body).toContain('maxLength={MOD_MESSAGE_BODY_MAX}');
+    expect(body).not.toContain('MOD_MESSAGE_SUBJECT_');
+
+    const subject = selfClosingElement(code, 'TextInput');
+    expect(subject).toContain('data-testid="apps-mod-message-subject"');
+    expect(subject).toContain('MOD_MESSAGE_SUBJECT_MIN');
+    expect(subject).toContain('MOD_MESSAGE_SUBJECT_MAX');
+    expect(subject).not.toContain('MOD_MESSAGE_BODY_');
+  });
+});
+
+/**
+ * 🔴 THE COMPOSER MUST NAME NO RECIPIENT.
+ *
+ * `messageAppOwner` resolves the owner server-side, and for an ON-SITE listing
+ * `resolveCanonicalListingOwner` resolves the backing block's owner rather than the
+ * listing's `userId` column. The mod table holds only that column. A composer that
+ * displayed it would let a moderator write copy aimed at the person on screen while the
+ * platform delivered it to a different one — a disclosure, not a mislabel.
+ *
+ * This is pinned as a PROP-SHAPE LEDGER rather than a search for one word, because the
+ * defect it replaces was not a missing warning: an earlier revision carried a `🔴 Never
+ * present it as the delivery target` docstring on the very value it then rendered.
+ * Prose does not gate anything; the accepted key set does.
+ */
+describe('the composer takes no owner from its caller', () => {
+  it('the exact key set of the listing prop', () => {
+    const code = stripComments(read(MODAL_MODULE));
+    const at = code.indexOf('listing: {');
+    expect(at).toBeGreaterThan(-1);
+    const shape = balanced(code, at, '{', '}');
+    const keys = [...shape.matchAll(/([A-Za-z0-9_$]+)\??\s*:/g)].map((m) => m[1]);
+    expect(keys).toEqual(['appListingId', 'slug']);
+  });
+
+  it('neither the composer nor its mount site carries a display owner', () => {
+    for (const rel of [MODAL_MODULE, MOUNT_SITES[0]]) {
+      expect(read(rel)).not.toContain('ownerLabel');
+    }
+    // Positive control: the mount site DOES still build the props it is supposed to.
+    expect(read(MOUNT_SITES[0])).toMatch(/appListingId:\s*messageRow\.id/);
+  });
+});
+
+/**
+ * 🔴 TWO STATE-LIFECYCLE PROPERTIES THE PR MARKS 🔴 AND THE BLOCKING TIER DID NOT SEE.
+ * Both survived the unit suite untouched before this block existed, so both were
+ * claims in a comment rather than pinned behaviour.
+ */
+describe('the composer resets per message and never on failure', () => {
+  it('reset() clears EVERY piece of composer state, the collaborator opt-in included', () => {
+    const code = stripComments(read(MODAL_MODULE));
+    const setters = stateSetters(code);
+    // Positive control on the detector: the composer really does declare state, and the
+    // opt-in is one of the pieces this is asserting about.
+    expect(setters.length).toBeGreaterThan(0);
+    expect(setters).toContain('setIncludeCollaborators');
+    // The RELATIONSHIP, not a fixed list: the ledger fails when state is ADDED without a
+    // matching reset just as it does when an existing reset is dropped.
+    expect(settersNotCalledIn(functionBody(code, 'reset'), setters)).toEqual([]);
+  });
+
+  it('the reset-completeness detector fires on a composer that forgets one setter', () => {
+    const planted = [
+      "const [subject, setSubject] = useState('');",
+      'const [includeCollaborators, setIncludeCollaborators] = useState(false);',
+      'function reset() {',
+      "  setSubject('');",
+      '}',
+    ].join('\n');
+    const setters = stateSetters(planted);
+    expect(setters).toEqual(['setSubject', 'setIncludeCollaborators']);
+    expect(settersNotCalledIn(functionBody(planted, 'reset'), setters)).toEqual([
+      'setIncludeCollaborators',
+    ]);
+  });
+
+  it('a failed send does not reset — the mutation onError never calls reset()', () => {
+    const options = callArgument(stripComments(read(MODAL_MODULE)), 'useMutation');
+    // Positive control on the property extractor: the SUCCESS handler does reset, so a
+    // clean `onError` is a real read of real code and not an empty match.
+    expect(objectProperty(options, 'onSuccess')).toContain('reset()');
+    expect(objectProperty(options, 'onError')).not.toContain('reset(');
   });
 });

--- a/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
@@ -32,9 +32,11 @@ import {
  * 🔴 KNOWN LIMITS, stated rather than implied. Detection is syntactic and per-file: a
  * site that mounts the modal through a wrapper or `React.createElement` is invisible
  * here. Every source assertion reads through {@link codeOf}, which strips comments with
- * a regex, so a `//` sequence inside a string literal in one of the three scanned files
- * would confuse it — none contains one today (checked), and the positive control below
- * proves the detector can still fire when it matters. The MOUNT sweep deliberately reads
+ * a regex, so a `//` sequence inside a string literal in one of the scanned modules —
+ * the `*_MODULE` constants plus {@link MOUNT_SITES}, deliberately not restated as a
+ * count that would rot the moment one is added — would confuse it. None contains one
+ * today (checked), and the positive control below proves the detector can still fire when
+ * it matters. The MOUNT sweep deliberately reads
  * RAW: a comment quoting `<MessageAppOwnerModal` there produces a loud ledger mismatch,
  * whereas a bad strip would silently hide a real second mount, and loud is the direction
  * to fail in for a sweep whose whole job is to notice a new site. That sweep also matches
@@ -50,6 +52,15 @@ import {
  * added to this file would have ITS setters demanded inside `reset()` too. That direction
  * fails loudly and is the safe one; the `useState`-only direction is the gap, and widening
  * the composer's state to a reducer means widening this with it.
+ *
+ * 🔴 It also compares the initialiser's TEXT, not the value it evaluates to. So a legal,
+ * behaviour-preserving refactor to a lazy initialiser — `useState(() => false)` — or to a
+ * computed one — `useState(props.subject ?? '')` — makes the declared initial `'() => false'`
+ * / `'props.subject ?? \'\''` and every reset read as passing the wrong value
+ * (`expected '() => false' to be 'false'`). That is a false alarm, not a finding, and it
+ * is deliberately left loud: the alternative is evaluating source text. If you hit it,
+ * teach {@link stateInitialValues} to unwrap the thunk — do not delete the assertion, and
+ * do not "fix" it by making the reset match the new text.
  *
  * 🔴 And the reset ledger reads `reset()`'s OWN body only. A `reset()` that delegates —
  * `function reset() { clearComposer(); }` — satisfies nothing it should: every setter
@@ -98,8 +109,14 @@ function stripComments(source: string): string {
  * quotes the call it demands (so a deleted branch reads as present), and a
  * `not.toContain` is broken by a comment that names the identifier it forbids (so a
  * correct file reads as an offence). Neither is hypothetical in a file whose comments
- * deliberately quote the code around them — this one included. The numeric-bounds scan
- * already stripped; four source assertions did not, and now nothing reads raw.
+ * deliberately quote the code around them — this one included.
+ *
+ * 🔴 ONE reader is deliberately raw and it is not this one: the MOUNT sweep's
+ * `read(rel).includes('<MessageAppOwnerModal')`, for the reason given in the known-limits
+ * header above (for a sweep, a false ledger entry is the safe direction and a silently
+ * hidden mount is not). Every OTHER source read goes through here. Stated as a
+ * one-exception rule rather than a count of converted assertions, because the count was
+ * wrong within one round of being written.
  */
 function codeOf(rel: string): string {
   return stripComments(read(rel));
@@ -249,17 +266,28 @@ function stateInitialValues(source: string): Map<string, string> {
  * `reset() mentions the setter`. It fails when a piece of state is added without a
  * reset, when an existing reset is deleted, AND when a reset is rewritten to a value
  * that is not what the component mounts with.
+ *
+ * 🔴 EVERY CALL IS COMPARED, not the first one. Reading only the first match let a
+ * composer that clears a setter and then OVERWRITES it —
+ * `setIncludeCollaborators(false); setIncludeCollaborators(true);` — read as correct,
+ * because the first call is the declared initial and the state the component is actually
+ * left in is the second. Measured surviving, 38/38 green, before this loop existed: the
+ * exact hazard the value comparison was introduced for, one statement further down.
+ * Flagging ANY differing call rather than only the last is the loud direction — a reset
+ * that transiently passes some other value is at best pointless — and it makes the
+ * offence name the wrong value, not just the fact of one.
  */
 function resetOffences(body: string, initials: Map<string, string>): string[] {
   const offences: string[] = [];
   for (const [setter, initial] of initials) {
-    const call = new RegExp(`\\b${setter}\\s*\\(`).exec(body);
-    if (!call) {
+    const args = [...body.matchAll(new RegExp(`\\b${setter}\\s*\\(`, 'g'))].map((call) =>
+      normalise(balanced(body, call.index + call[0].length - 1, '(', ')'))
+    );
+    if (args.length === 0) {
       offences.push(`${setter}: never called in reset() (declared initial ${initial})`);
       continue;
     }
-    const arg = normalise(balanced(body, call.index + call[0].length - 1, '(', ')'));
-    if (arg !== initial) {
+    for (const arg of new Set(args.filter((a) => a !== initial))) {
       offences.push(`${setter}: reset() passes ${arg}, declared initial is ${initial}`);
     }
   }
@@ -360,7 +388,10 @@ describe('the owner-message surface is MOUNTED (it shipped dark once already)', 
 describe('the composer bounds are single-sourced from the server schema', () => {
   it('both modules import the bounds from messageAppOwnerSchema', () => {
     for (const rel of [FORM_MODULE, MODAL_MODULE]) {
-      expect(read(rel)).toContain(SCHEMA_IMPORT);
+      // Comment-stripped, like every other source assertion: a `toContain` on a raw read
+      // is satisfied by the old path left behind in a comment while the real import is
+      // redirected somewhere else. Measured surviving, 38/38 green, before this changed.
+      expect(codeOf(rel)).toContain(SCHEMA_IMPORT);
     }
   });
 
@@ -543,7 +574,7 @@ describe('the composer resets per message and never on failure', () => {
     expect(resetOffences(functionBody(code, 'reset'), initials)).toEqual([]);
   });
 
-  it('the reset detector fires on a forgotten setter AND on one reset to the wrong value', () => {
+  it('the reset detector fires on a forgotten setter, on a wrong value, AND on an overwrite', () => {
     const declarations = [
       "const [subject, setSubject] = useState('');",
       'const [includeCollaborators, setIncludeCollaborators] = useState(false);',
@@ -572,6 +603,22 @@ describe('the composer resets per message and never on failure', () => {
     expect(resetOffences(functionBody(wrongValue, 'reset'), wrongInitials)).toEqual([
       'setIncludeCollaborators: reset() passes true, declared initial is false',
     ]);
+
+    // 🔴 THE MUTANT THE "first call only" LEDGER LET THROUGH, one round later. The
+    // declared initial IS passed — to a call that a second one immediately overwrites, so
+    // a reader that stops at the first match sees a correct reset and the component is
+    // left with the opt-in ON. Measured surviving 38/38 before the every-call loop.
+    const overwritten = [
+      ...declarations,
+      'function reset() {',
+      "  setSubject('');",
+      '  setIncludeCollaborators(false);',
+      '  setIncludeCollaborators(true);',
+      '}',
+    ].join('\n');
+    expect(
+      resetOffences(functionBody(overwritten, 'reset'), stateInitialValues(overwritten))
+    ).toEqual(['setIncludeCollaborators: reset() passes true, declared initial is false']);
 
     // And a correct composer produces no offence at all — so the detector is not simply
     // always-red, which would make the real assertion above meaningless.

--- a/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
@@ -1,0 +1,168 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+  MOD_MESSAGE_SUBJECT_MIN,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+
+/**
+ * 🔒 THE CALL-SITE LEDGER for the moderator → app-developer message surface.
+ *
+ * WHY THIS FILE EXISTS. `appListings.messageAppOwner` shipped complete — service,
+ * audit event, rate limits, notification type, migration — and then sat in production
+ * with ZERO UI callers, because nothing anywhere asserted that a caller existed. A
+ * ledger is the cheap, mechanical version of the review that did not happen: it fails
+ * when the set of mounting sites SHRINKS (the surface goes dark again) and when it
+ * GROWS (a second surface appears that nobody wired to the same rules).
+ *
+ * It also pins the BOUNDS SINGLE-SOURCE. The composer's floors and ceilings belong to
+ * `messageAppOwnerSchema`; a hand-typed copy in the component drifts silently and then
+ * either offers a moderator a field they can fill and can never send, or blocks a
+ * message the server would have accepted.
+ *
+ * 🔴 A STRUCTURAL CHECK IS NOT A BEHAVIOURAL ONE. That the modal is mounted says
+ * nothing about whether the gate works — that is
+ * `__tests__/appModeratorMessageForm.test.ts` (blocking) and
+ * `MessageAppOwnerModal.browser.test.tsx` (report-only in CI).
+ *
+ * 🔴 KNOWN LIMITS, stated rather than implied. Detection is syntactic and per-file: a
+ * site that mounts the modal through a wrapper or `React.createElement` is invisible
+ * here. The numeric-literal scan strips comments with a regex, so a `//` sequence
+ * inside a string literal in one of the scanned files would confuse it — neither
+ * scanned file contains one today, and the positive control below proves the detector
+ * can still fire when it matters.
+ */
+
+const SRC = path.resolve(__dirname, '../../..');
+
+const FORM_MODULE = 'components/Apps/appModeratorMessageForm.ts';
+const MODAL_MODULE = 'components/Apps/MessageAppOwnerModal.tsx';
+
+/**
+ * Every PRODUCTION site that mounts `MessageAppOwnerModal`. One today: the /apps/review
+ * "Manage listings" table, which is the only moderator surface that holds an
+ * `AppListing` id for an arbitrary listing in any status. Adding a second surface means
+ * adding it here — that is the point, not an inconvenience.
+ */
+const MOUNT_SITES = ['components/Apps/AppListingsModerationTable.tsx'] as const;
+
+const SCHEMA_IMPORT = '~/server/schema/blocks/app-moderator-message.schema';
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(SRC, rel), 'utf8');
+}
+
+/** Strip `/* *\/` and `//` comments so prose that MENTIONS a bound is not a hit. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** Standalone occurrences of `value` as a numeric token (not part of an identifier). */
+function bareNumericHits(source: string, value: number): number {
+  const re = new RegExp(`(?<![\\w.$])${value}(?![\\w.$])`, 'g');
+  return (source.match(re) ?? []).length;
+}
+
+/**
+ * Every production `.ts`/`.tsx` under `src/components` and `src/pages`, test files
+ * excluded. Both trees are walked because a moderator surface can be a page as easily
+ * as a component, and a mount added to a page would otherwise be invisible to the
+ * ledger.
+ */
+function productionSources(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        walk(full);
+        continue;
+      }
+      if (!/\.(ts|tsx)$/.test(entry.name)) continue;
+      if (/\.(test|browser\.test|spec)\.tsx?$/.test(entry.name)) continue;
+      out.push(path.relative(SRC, full));
+    }
+  };
+  walk(path.join(SRC, 'components'));
+  walk(path.join(SRC, 'pages'));
+  return out;
+}
+
+describe('the owner-message surface is MOUNTED (it shipped dark once already)', () => {
+  it('the exact ledger of sites that mount MessageAppOwnerModal', () => {
+    const mounting = productionSources().filter((rel) =>
+      read(rel).includes('<MessageAppOwnerModal')
+    );
+    // Positive control: the scan really does see mounts, so an equal-to-ledger result
+    // is a match and not an empty sweep.
+    expect(mounting.length).toBeGreaterThan(0);
+    expect(mounting.sort()).toEqual([...MOUNT_SITES].sort());
+  });
+
+  it('the mounting site routes the action through actionOpensOwnerMessage, not the reason modal', () => {
+    const table = read(MOUNT_SITES[0]);
+    // The router must be CALLED, not merely imported — an import with no call site is
+    // exactly how the message action would silently fall through to
+    // `setPendingAction` and open the wrong modal.
+    expect(table).toContain('actionOpensOwnerMessage(action)');
+    expect(table).toContain('setMessageRow(row)');
+  });
+
+  it('the modal is fed the listing ID, never the slug', () => {
+    // `messageAppOwner` keys on `apl_<ULID>`; a slug would come back NOT_FOUND. The
+    // row carries both and they are adjacent in the object literal, so this is a
+    // realistic transposition rather than a hypothetical one.
+    const table = read(MOUNT_SITES[0]);
+    expect(table).toMatch(/appListingId:\s*messageRow\.id/);
+  });
+});
+
+describe('the composer bounds are single-sourced from the server schema', () => {
+  it('both modules import the bounds from messageAppOwnerSchema', () => {
+    for (const rel of [FORM_MODULE, MODAL_MODULE]) {
+      expect(read(rel)).toContain(SCHEMA_IMPORT);
+    }
+  });
+
+  it('neither module hardcodes a bound as a numeric literal', () => {
+    const bounds = {
+      MOD_MESSAGE_SUBJECT_MIN,
+      MOD_MESSAGE_SUBJECT_MAX,
+      MOD_MESSAGE_BODY_MIN,
+      MOD_MESSAGE_BODY_MAX,
+    };
+    const offences: string[] = [];
+    for (const rel of [FORM_MODULE, MODAL_MODULE]) {
+      const code = stripComments(read(rel));
+      for (const [name, value] of Object.entries(bounds)) {
+        const hits = bareNumericHits(code, value);
+        if (hits > 0) offences.push(`${rel}: ${hits}× bare ${value} (use ${name})`);
+      }
+    }
+    expect(offences).toEqual([]);
+  });
+
+  /**
+   * 🔴 POSITIVE CONTROL on the detector above. A "no offences" result is
+   * indistinguishable from a scan wired to nothing until the same detector has been
+   * watched to FIRE — here on a synthetic source that hardcodes the body ceiling, and
+   * NOT on the same source once it is written as a comment (which is the false positive
+   * the comment-stripping exists to avoid).
+   */
+  it('the hardcoded-bound detector fires on a planted literal and not on prose', () => {
+    const planted = `const max = ${MOD_MESSAGE_BODY_MAX};`;
+    expect(bareNumericHits(stripComments(planted), MOD_MESSAGE_BODY_MAX)).toBe(1);
+
+    const prose = `// the ceiling is ${MOD_MESSAGE_BODY_MAX} characters\nconst max = MOD_MESSAGE_BODY_MAX;`;
+    expect(bareNumericHits(stripComments(prose), MOD_MESSAGE_BODY_MAX)).toBe(0);
+
+    // And it must not fire on a number that merely CONTAINS the bound's digits.
+    const embedded = `const other = ${MOD_MESSAGE_BODY_MAX}0;`;
+    expect(bareNumericHits(stripComments(embedded), MOD_MESSAGE_BODY_MAX)).toBe(0);
+  });
+});

--- a/src/components/Apps/__tests__/appModeratorMessageForm.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  modMessageBodyState,
+  modMessageGate,
+  modMessagePayload,
+  modMessageSentSummary,
+  modMessageSubjectState,
+} from '~/components/Apps/appModeratorMessageForm';
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+  MOD_MESSAGE_SUBJECT_MIN,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+
+/**
+ * The BLOCKING gate on the moderator → app-developer message composer.
+ *
+ * `MessageAppOwnerModal` is covered by a browser suite too, but the browser project is
+ * REPORT-ONLY in this repo's CI, so the rule that decides whether a half-typed message
+ * can be sent to a developer is pinned here, in the node `unit` project, exactly as
+ * `appListingModerationTableView.test.ts` pins the action set.
+ *
+ * 🔴 EVERY BOUNDARY CASE IS BUILT FROM THE SCHEMA CONSTANTS, not from the literals 3 /
+ * 200 / 20 / 2000. A test that hardcodes them keeps passing when the schema moves and
+ * the UI does not — which is the precise defect this file exists to prevent.
+ */
+
+const A = (n: number) => 'a'.repeat(n);
+const okSubject = A(MOD_MESSAGE_SUBJECT_MIN);
+const okBody = A(MOD_MESSAGE_BODY_MIN);
+
+describe('the constants this file measures against are actually distinct', () => {
+  // A positive control on the FIXTURES: if the subject and body floors were equal, a
+  // mutant swapping one for the other would survive every assertion below. They are
+  // not (3 vs 20), and this pins that they must stay unequal for this suite to
+  // discriminate at all.
+  it('the subject and body floors differ, and each floor is below its ceiling', () => {
+    expect(MOD_MESSAGE_SUBJECT_MIN).not.toBe(MOD_MESSAGE_BODY_MIN);
+    expect(MOD_MESSAGE_SUBJECT_MAX).not.toBe(MOD_MESSAGE_BODY_MAX);
+    expect(MOD_MESSAGE_SUBJECT_MIN).toBeLessThan(MOD_MESSAGE_SUBJECT_MAX);
+    expect(MOD_MESSAGE_BODY_MIN).toBeLessThan(MOD_MESSAGE_BODY_MAX);
+  });
+});
+
+describe('modMessageSubjectState / modMessageBodyState', () => {
+  it('measures the TRIMMED length', () => {
+    // The service trims before it validates, so whitespace padding must not be
+    // counted toward the floor — a body of N spaces is an empty message.
+    expect(modMessageBodyState(' '.repeat(MOD_MESSAGE_BODY_MIN + 10)).length).toBe(0);
+    expect(modMessageBodyState(`  ${okBody}  `).length).toBe(MOD_MESSAGE_BODY_MIN);
+  });
+
+  it('a subject one character under the floor is tooShort; exactly at the floor is ok', () => {
+    const under = modMessageSubjectState(A(MOD_MESSAGE_SUBJECT_MIN - 1));
+    expect(under.tooShort).toBe(true);
+    expect(under.ok).toBe(false);
+
+    const at = modMessageSubjectState(A(MOD_MESSAGE_SUBJECT_MIN));
+    expect(at.tooShort).toBe(false);
+    expect(at.ok).toBe(true);
+  });
+
+  it('a subject exactly at the ceiling is ok; one over is tooLong', () => {
+    expect(modMessageSubjectState(A(MOD_MESSAGE_SUBJECT_MAX)).ok).toBe(true);
+    const over = modMessageSubjectState(A(MOD_MESSAGE_SUBJECT_MAX + 1));
+    expect(over.tooLong).toBe(true);
+    expect(over.ok).toBe(false);
+  });
+
+  it('a body one character under the floor is tooShort; exactly at the floor is ok', () => {
+    expect(modMessageBodyState(A(MOD_MESSAGE_BODY_MIN - 1)).tooShort).toBe(true);
+    expect(modMessageBodyState(A(MOD_MESSAGE_BODY_MIN)).ok).toBe(true);
+  });
+
+  it('a body exactly at the ceiling is ok; one over is tooLong', () => {
+    expect(modMessageBodyState(A(MOD_MESSAGE_BODY_MAX)).ok).toBe(true);
+    expect(modMessageBodyState(A(MOD_MESSAGE_BODY_MAX + 1)).tooLong).toBe(true);
+  });
+
+  it('reports the bounds it measured against, so a caller cannot re-derive them wrong', () => {
+    expect(modMessageSubjectState('x')).toMatchObject({
+      min: MOD_MESSAGE_SUBJECT_MIN,
+      max: MOD_MESSAGE_SUBJECT_MAX,
+    });
+    expect(modMessageBodyState('x')).toMatchObject({
+      min: MOD_MESSAGE_BODY_MIN,
+      max: MOD_MESSAGE_BODY_MAX,
+    });
+  });
+});
+
+describe('modMessageGate', () => {
+  it('opens only when BOTH fields clear BOTH bounds', () => {
+    expect(modMessageGate({ subject: okSubject, body: okBody })).toEqual({
+      open: true,
+      blockedBy: null,
+      tooltip: undefined,
+    });
+  });
+
+  it('an empty form is blocked on the subject', () => {
+    const gate = modMessageGate({ subject: '', body: '' });
+    expect(gate.open).toBe(false);
+    expect(gate.blockedBy).toBe('subject-too-short');
+    expect(gate.tooltip).toContain(String(MOD_MESSAGE_SUBJECT_MIN));
+  });
+
+  /**
+   * 🔴 THE CASE THE UI EXISTS TO CATCH, and the one a floor-only gate gets wrong: a
+   * moderator pastes a long message. Every field clears its floor, so a
+   * `length >= min`-only check enables the button — and the send comes back a
+   * BAD_REQUEST with the text still in the box and no indication which field was at
+   * fault. Both ceilings must close the gate.
+   */
+  it('blocks an over-length BODY even though every floor is cleared', () => {
+    const gate = modMessageGate({ subject: okSubject, body: A(MOD_MESSAGE_BODY_MAX + 1) });
+    expect(gate.open).toBe(false);
+    expect(gate.blockedBy).toBe('body-too-long');
+    expect(gate.tooltip).toContain(String(MOD_MESSAGE_BODY_MAX));
+  });
+
+  it('blocks an over-length SUBJECT even though every floor is cleared', () => {
+    const gate = modMessageGate({ subject: A(MOD_MESSAGE_SUBJECT_MAX + 1), body: okBody });
+    expect(gate.open).toBe(false);
+    expect(gate.blockedBy).toBe('subject-too-long');
+    expect(gate.tooltip).toContain(String(MOD_MESSAGE_SUBJECT_MAX));
+  });
+
+  it('blocks a body that is long enough for the SUBJECT floor but not the BODY floor', () => {
+    // The discriminating fixture: `MOD_MESSAGE_SUBJECT_MIN` characters satisfies the
+    // subject and NOT the body. A gate that reused one floor for both fields passes
+    // every same-length fixture and dies here.
+    const gate = modMessageGate({ subject: okSubject, body: A(MOD_MESSAGE_SUBJECT_MIN) });
+    expect(gate.open).toBe(false);
+    expect(gate.blockedBy).toBe('body-too-short');
+  });
+
+  it('a whitespace-only body cannot open the gate', () => {
+    const gate = modMessageGate({
+      subject: okSubject,
+      body: ' '.repeat(MOD_MESSAGE_BODY_MIN + 5),
+    });
+    expect(gate.open).toBe(false);
+    expect(gate.blockedBy).toBe('body-too-short');
+  });
+
+  it('reports the SUBJECT first when both fields are blocked (it is the first input)', () => {
+    expect(modMessageGate({ subject: '', body: '' }).blockedBy).toBe('subject-too-short');
+  });
+
+  it('a closed gate always carries a tooltip, and an open one never does', () => {
+    const closed = [
+      { subject: '', body: okBody },
+      { subject: okSubject, body: '' },
+      { subject: A(MOD_MESSAGE_SUBJECT_MAX + 1), body: okBody },
+      { subject: okSubject, body: A(MOD_MESSAGE_BODY_MAX + 1) },
+    ];
+    for (const input of closed) {
+      const gate = modMessageGate(input);
+      expect(gate.open).toBe(false);
+      expect(gate.tooltip).toBeTruthy();
+    }
+    expect(modMessageGate({ subject: okSubject, body: okBody }).tooltip).toBeUndefined();
+  });
+});
+
+describe('modMessagePayload', () => {
+  it('trims both fields — the service audits the TRIMMED text', () => {
+    expect(
+      modMessagePayload({
+        appListingId: 'apl_1',
+        subject: `  ${okSubject}  `,
+        body: `\n${okBody}\n`,
+        includeCollaborators: false,
+      })
+    ).toEqual({ appListingId: 'apl_1', subject: okSubject, body: okBody });
+  });
+
+  it('omits includeCollaborators when off, and sends `true` when on', () => {
+    const off = modMessagePayload({
+      appListingId: 'apl_1',
+      subject: okSubject,
+      body: okBody,
+      includeCollaborators: false,
+    });
+    expect('includeCollaborators' in off).toBe(false);
+
+    const on = modMessagePayload({
+      appListingId: 'apl_1',
+      subject: okSubject,
+      body: okBody,
+      includeCollaborators: true,
+    });
+    expect(on.includeCollaborators).toBe(true);
+  });
+
+  it('passes the listing id through UNCHANGED (the proc resolves a revision id itself)', () => {
+    // A shadow revision id must reach the server as written — the service hops it to
+    // the parent. Any client-side "normalisation" here would be a second, drift-capable
+    // implementation of a rule the server already owns.
+    expect(
+      modMessagePayload({
+        appListingId: 'rev_01JABCDEF',
+        subject: okSubject,
+        body: okBody,
+        includeCollaborators: false,
+      }).appListingId
+    ).toBe('rev_01JABCDEF');
+  });
+});
+
+describe('modMessageSentSummary', () => {
+  it('says "the app owner" for a single recipient', () => {
+    expect(modMessageSentSummary(1)).toBe('Message sent to the app owner.');
+  });
+
+  it('names the COUNT once collaborators were looped in', () => {
+    // The count is the only signal a moderator gets that a message they may have
+    // intended for one person reached several.
+    expect(modMessageSentSummary(3)).toContain('3');
+    expect(modMessageSentSummary(3)).not.toContain('the app owner');
+  });
+});

--- a/src/components/Apps/__tests__/reasonGatedFieldCopy.test.ts
+++ b/src/components/Apps/__tests__/reasonGatedFieldCopy.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  reasonGatedFieldDescription,
+  reasonGatedFieldError,
+} from '~/components/Apps/reasonGatedFieldCopy';
+
+/**
+ * The copy a reason-gated free-text field renders.
+ *
+ * 🔴 WHY THIS FILE IS IN THE BLOCKING `unit` PROJECT. These two strings used to be built
+ * inline in `ReasonGatedField`'s JSX, where the only thing asserting them was
+ * `MessageAppOwnerModal.browser.test.tsx` — the browser tier, which is REPORT-ONLY in
+ * this repo's CI. Measured: deleting the ` (max N)` suffix from the counter left every
+ * blocking suite green, so the ceiling — the entire reason the `maxLength` prop was
+ * added — was pinned by nothing that can stop a merge.
+ *
+ * The FLOOR-ONLY cases are asserted first and in full, because five pre-existing call
+ * sites pass no ceiling and must keep byte-identical copy.
+ *
+ * Fixture numbers are pairwise distinct and none is a multiple of another (min 20,
+ * max 2000 are the real bounds; lengths 0, 1, 7, 19, 20, 33, 2000, 2001), so an
+ * assertion cannot pass by two different quantities coinciding.
+ */
+
+const MIN = 20;
+const MAX = 2000;
+
+describe('reasonGatedFieldDescription — the live counter', () => {
+  it('an optional note has no counter at all', () => {
+    expect(
+      reasonGatedFieldDescription({ length: 7, minLength: MIN, maxLength: MAX, required: false })
+    ).toBeUndefined();
+    expect(
+      reasonGatedFieldDescription({ length: 7, minLength: MIN, required: false })
+    ).toBeUndefined();
+  });
+
+  /** The five legacy call sites. Their copy must not move. */
+  it('with NO ceiling it is exactly the floor counter', () => {
+    expect(reasonGatedFieldDescription({ length: 0, minLength: MIN, required: true })).toBe(
+      '0/20 characters minimum'
+    );
+    expect(
+      reasonGatedFieldDescription({ length: 33, minLength: MIN, maxLength: null, required: true })
+    ).toBe('33/20 characters minimum');
+    expect(
+      reasonGatedFieldDescription({
+        length: 19,
+        minLength: MIN,
+        maxLength: undefined,
+        required: true,
+      })
+    ).toBe('19/20 characters minimum');
+  });
+
+  /**
+   * 🔴 THE MUTANT THIS FILE EXISTS FOR: dropping the ` (max N)` suffix. Asserted as the
+   * WHOLE string rather than a `toContain`, so a reworded suffix fails too.
+   */
+  it('with a ceiling it names the ceiling, appended to the same floor counter', () => {
+    expect(
+      reasonGatedFieldDescription({ length: 0, minLength: MIN, maxLength: MAX, required: true })
+    ).toBe('0/20 characters minimum (max 2000)');
+    expect(
+      reasonGatedFieldDescription({ length: 2000, minLength: MIN, maxLength: MAX, required: true })
+    ).toBe('2000/20 characters minimum (max 2000)');
+  });
+
+  /**
+   * The floor and the ceiling must come from DIFFERENT inputs. A counter that rendered
+   * one of them twice passes every case above whenever the two happen to coincide, so
+   * the discriminating case feeds two values that cannot be confused.
+   */
+  it('the floor and the ceiling are distinct inputs', () => {
+    expect(
+      reasonGatedFieldDescription({ length: 1, minLength: 7, maxLength: 33, required: true })
+    ).toBe('1/7 characters minimum (max 33)');
+  });
+});
+
+describe('reasonGatedFieldError — the inline error', () => {
+  it('an untouched required field shows no error (the neutral counter, not red)', () => {
+    expect(
+      reasonGatedFieldError({ length: 0, minLength: MIN, maxLength: MAX, required: true })
+    ).toBeUndefined();
+  });
+
+  it('a required field with SOME text but not enough names the floor', () => {
+    expect(reasonGatedFieldError({ length: 1, minLength: MIN, required: true })).toBe(
+      'Enter at least 20 characters.'
+    );
+    expect(
+      reasonGatedFieldError({ length: 19, minLength: MIN, maxLength: MAX, required: true })
+    ).toBe('Enter at least 20 characters.');
+  });
+
+  it('a value exactly ON the floor clears it', () => {
+    expect(
+      reasonGatedFieldError({ length: 20, minLength: MIN, maxLength: MAX, required: true })
+    ).toBeUndefined();
+  });
+
+  it('an optional note has no floor error however short it is', () => {
+    expect(reasonGatedFieldError({ length: 1, minLength: MIN, required: false })).toBeUndefined();
+  });
+
+  it('a value exactly ON the ceiling clears it; one over does not', () => {
+    expect(
+      reasonGatedFieldError({ length: 2000, minLength: MIN, maxLength: MAX, required: true })
+    ).toBeUndefined();
+    expect(
+      reasonGatedFieldError({ length: 2001, minLength: MIN, maxLength: MAX, required: true })
+    ).toBe('Keep it to 2000 characters or fewer (currently 2001).');
+  });
+
+  it('a ceiling applies to an OPTIONAL note too — the server rejects it either way', () => {
+    expect(
+      reasonGatedFieldError({ length: 2001, minLength: MIN, maxLength: MAX, required: false })
+    ).toBe('Keep it to 2000 characters or fewer (currently 2001).');
+  });
+
+  /**
+   * 🔴 TOO-LONG OUTRANKS TOO-SHORT, and this is the case that can tell them apart: a
+   * field whose floor sits ABOVE its ceiling is over-long and under-length at once. An
+   * implementation that checked the floor first would name the wrong bound.
+   */
+  it('too-long wins when a value is somehow both', () => {
+    expect(reasonGatedFieldError({ length: 7, minLength: 33, maxLength: 1, required: true })).toBe(
+      'Keep it to 1 characters or fewer (currently 7).'
+    );
+  });
+
+  it('with no ceiling given, no length can produce a ceiling error', () => {
+    expect(
+      reasonGatedFieldError({ length: 2001, minLength: MIN, maxLength: null, required: true })
+    ).toBeUndefined();
+    expect(reasonGatedFieldError({ length: 2001, minLength: MIN, required: true })).toBeUndefined();
+  });
+});

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -145,6 +145,15 @@ type ListingModRoute =
  * predicates answer `false` and the action opens nothing — the loud direction, which is
  * what the comment always said and now describes.
  *
+ * 🔴 "EVERY ACTION NAMES EXACTLY ONE ROUTE" IS TRUE OF THIS TABLE, NOT OF THE DISPATCH.
+ * The `review` value is read by nothing: `AppListingsModerationTable.openAction` and its
+ * test both branch on the literal `action === 'review'` before either predicate runs. So
+ * a NEW member mapped here to `'review'` typechecks cleanly and opens nothing at all —
+ * caught, but by the jointly-total sweep in `appListingModerationTableView.test.ts` (a
+ * blocking test), not by the type system this docstring credits above. Wiring the review
+ * branch through the table would close that; until it is, the row is documentation of the
+ * third route rather than the thing that selects it.
+ *
  * 🔴 `message-owner` routes to the composer, NOT to `reason`, and that is not an
  * oversight. It carries no `reason` at all: `appListings.messageAppOwner` takes a
  * SUBJECT and a BODY with their own, different floors (`MOD_MESSAGE_SUBJECT_MIN` /

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -46,6 +46,7 @@ export function effectiveModerationStatus(
 /** The lifecycle actions a mod row can offer (a subset renders per row). */
 export type ListingModAction =
   | 'review'
+  | 'message-owner'
   | 'reset-to-pending'
   | 'hide'
   | 'relist'
@@ -58,11 +59,26 @@ export type ListingModAction =
  *   - `review`: off-site + a pending publish request exists (any status — normally
  *     a `pending` listing, but a lingering pending request on another status still
  *     lets a mod open the review). Opens the reused off-site review modal.
+ *   - `message-owner`: EVERY row, EVERY status, BOTH kinds. See below.
  *   - `approved` → `reset-to-pending` (dual-kind — off-site + on-site re-queue) +
  *     `hide` (delist, dual-kind).
  *   - `removed`  → `relist` (dual-kind) + `claim` + `purge` (both off-site only).
- *   - `draft` / `rejected` → no lifecycle action (read-only) unless a pending
- *     request makes `review` available.
+ *   - `draft` / `rejected` → no LIFECYCLE action (read-only) beyond `message-owner`,
+ *     unless a pending request makes `review` available.
+ *
+ * 🔴 `message-owner` IS UNCONDITIONAL, and that is a claim about the SERVER, not a
+ * preference. `appListings.messageAppOwner` resolves its recipient through
+ * `resolveListingAccess`, which branches on KIND and never on STATUS — so there is no
+ * listing in this table the proc would refuse. Narrowing the button to (say) approved
+ * rows would withhold it in exactly the states where a moderator most needs it: a
+ * `rejected` or `draft` row is one a developer is being asked to FIX, and before this
+ * change those rows rendered a dead `—` with no way to tell them what to fix.
+ *
+ * 🔴 It is placed AFTER `review` and BEFORE the lifecycle actions so the row reads in
+ * increasing severity (Review → Message owner → Reset → Hide → … → Purge) and the
+ * destructive `purge` stays rightmost. Do not move it after `purge`: the rendering
+ * order in `AppListingsModerationTable` is this array's order, and a benign button to
+ * the right of a red irreversible one is a misclick waiting to happen.
  */
 export function listingModActions(input: {
   status: string;
@@ -74,6 +90,9 @@ export function listingModActions(input: {
 
   // Review is available whenever there's a pending request to act on (off-site).
   if (offsite && input.hasPendingRequest) actions.push('review');
+
+  // Messaging the owner is state-neutral and dual-kind — always offered.
+  actions.push('message-owner');
 
   if (input.status === 'approved') {
     // Reset-to-pending is now dual-kind: off-site → resetListingToPending, on-site →
@@ -96,9 +115,27 @@ export function isDestructiveListingModAction(action: ListingModAction): boolean
   return action === 'purge';
 }
 
-/** Whether an action opens a reason-gated modal (all mutating actions require a reason). */
+/**
+ * Whether an action opens the shared REASON-gated modal (`ListingModActionModal`,
+ * whose one free-text field is `reason` and whose floor is `OFFSITE_MOD_REASON_MIN`).
+ *
+ * 🔴 `message-owner` is FALSE, and it is not an oversight. That action does not carry a
+ * `reason` at all: `appListings.messageAppOwner` takes a SUBJECT and a BODY with their
+ * own, different floors (`MOD_MESSAGE_SUBJECT_MIN` / `MOD_MESSAGE_BODY_MIN`), so it
+ * routes to `MessageAppOwnerModal` instead. Answering `true` here would be a
+ * predicate that reads "shows a reason textarea" while the surface shows none.
+ */
 export function actionRequiresReason(action: ListingModAction): boolean {
-  return action !== 'review';
+  return action !== 'review' && action !== 'message-owner';
+}
+
+/**
+ * Whether an action routes to `MessageAppOwnerModal` rather than the shared
+ * reason-gated one. The complement of `actionRequiresReason` over the MUTATING
+ * actions — `review` is neither (it opens the publish-request review modal).
+ */
+export function actionOpensOwnerMessage(action: ListingModAction): boolean {
+  return action === 'message-owner';
 }
 
 /** Human label for a mod action button. */
@@ -106,6 +143,8 @@ export function listingModActionLabel(action: ListingModAction): string {
   switch (action) {
     case 'review':
       return 'Review';
+    case 'message-owner':
+      return 'Message owner';
     case 'reset-to-pending':
       return 'Reset to pending';
     case 'hide':

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -119,11 +119,26 @@ export function isDestructiveListingModAction(action: ListingModAction): boolean
  * Whether an action opens the shared REASON-gated modal (`ListingModActionModal`,
  * whose one free-text field is `reason` and whose floor is `OFFSITE_MOD_REASON_MIN`).
  *
+ * 🔴 THIS IS THE MGMT TABLE'S THIRD ROUTE, AND IT IS BRANCHED ON.
+ * `AppListingsModerationTable.openAction` tries `review`, then
+ * {@link actionOpensOwnerMessage}, then this — so an action this answers `false` for
+ * opens NOTHING. That is deliberate: the three predicates are jointly total over
+ * `ListingModAction`, and a future action claimed by none of them should visibly do
+ * nothing rather than quietly land in a reason-gated modal whose one field it does not
+ * carry.
+ *
  * 🔴 `message-owner` is FALSE, and it is not an oversight. That action does not carry a
  * `reason` at all: `appListings.messageAppOwner` takes a SUBJECT and a BODY with their
- * own, different floors (`MOD_MESSAGE_SUBJECT_MIN` / `MOD_MESSAGE_BODY_MIN`), so it
- * routes to `MessageAppOwnerModal` instead. Answering `true` here would be a
- * predicate that reads "shows a reason textarea" while the surface shows none.
+ * own, different floors (`MOD_MESSAGE_SUBJECT_MIN` / `MOD_MESSAGE_BODY_MIN`), so the
+ * router above claims it first. Answering `true` here would put one action in two
+ * routers at once and leave this predicate reading "shows a reason textarea" for a
+ * surface that shows none.
+ *
+ * Both halves are pinned: the vocabulary in `appListingModerationTableView.test.ts`,
+ * and that the table still CALLS this at all in
+ * `__tests__/appModeratorMessageForm.callSites.test.ts` — this predicate spent one
+ * revision referenced by nothing but its own test, which is the shape that lets a
+ * "🔴 routing depends on this" comment describe dead code.
  */
 export function actionRequiresReason(action: ListingModAction): boolean {
   return action !== 'review' && action !== 'message-owner';

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -115,42 +115,83 @@ export function isDestructiveListingModAction(action: ListingModAction): boolean
   return action === 'purge';
 }
 
+/** Which modal a mod action opens. Three routes, and every action names exactly one. */
+type ListingModRoute =
+  /** The reused off-site publish-request review modal. */
+  | 'review'
+  /** `MessageAppOwnerModal` — subject + body, no `reason`. */
+  | 'owner-message'
+  /** The shared `ListingModActionModal` — one `reason` at `OFFSITE_MOD_REASON_MIN`. */
+  | 'reason';
+
+/**
+ * 🔴 THE ROUTING TABLE, AND THE REASON IT IS A TABLE RATHER THAN TWO PREDICATES.
+ *
+ * `AppListingsModerationTable.openAction` tries `review`, then
+ * {@link actionOpensOwnerMessage}, then {@link actionRequiresReason}, and an action
+ * claimed by none of the three opens NOTHING. That "jointly total" property is what the
+ * table's own comment leans on — but while `actionRequiresReason` was written as a
+ * NEGATION (`action !== 'review' && action !== 'message-owner'`) the property was
+ * decorative: a member added to {@link ListingModAction} answered `true` by DEFAULT and
+ * landed in the reason-gated modal, which is precisely the quiet mis-route the comment
+ * claimed to prevent. Measured before this table existed: adding a member to the union
+ * left all 46 unit tests green, and the only objection came from
+ * {@link listingModActionLabel}'s exhaustive switch — the LABEL half, not the routing
+ * half.
+ *
+ * An exhaustive `Record<ListingModAction, …>` moves the claim into the type system: a
+ * new member is a MISSING PROPERTY here (`pnpm typecheck`, a blocking check) rather than
+ * a silent default, and at runtime an unlisted action resolves to `undefined`, so both
+ * predicates answer `false` and the action opens nothing — the loud direction, which is
+ * what the comment always said and now describes.
+ *
+ * 🔴 `message-owner` routes to the composer, NOT to `reason`, and that is not an
+ * oversight. It carries no `reason` at all: `appListings.messageAppOwner` takes a
+ * SUBJECT and a BODY with their own, different floors (`MOD_MESSAGE_SUBJECT_MIN` /
+ * `MOD_MESSAGE_BODY_MIN`). Routing it to `reason` would leave that predicate reading
+ * "shows a reason textarea" for a surface that shows none, and — because a table entry
+ * is single-valued — is now unrepresentable rather than merely discouraged.
+ */
+const LISTING_MOD_ROUTES: Record<ListingModAction, ListingModRoute> = {
+  review: 'review',
+  'message-owner': 'owner-message',
+  'reset-to-pending': 'reason',
+  hide: 'reason',
+  relist: 'reason',
+  claim: 'reason',
+  purge: 'reason',
+};
+
+/**
+ * Every member of {@link ListingModAction}, derived from {@link LISTING_MOD_ROUTES}
+ * rather than hand-listed, so the vocabulary has ONE spelling. Iterated by
+ * `appListingModerationTableView.test.ts` for its label/route totality sweeps — a
+ * hand-maintained copy there could silently stop covering a member the union gained.
+ */
+export const ALL_LISTING_MOD_ACTIONS = Object.keys(LISTING_MOD_ROUTES) as ListingModAction[];
+
 /**
  * Whether an action opens the shared REASON-gated modal (`ListingModActionModal`,
  * whose one free-text field is `reason` and whose floor is `OFFSITE_MOD_REASON_MIN`).
  *
- * 🔴 THIS IS THE MGMT TABLE'S THIRD ROUTE, AND IT IS BRANCHED ON.
- * `AppListingsModerationTable.openAction` tries `review`, then
- * {@link actionOpensOwnerMessage}, then this — so an action this answers `false` for
- * opens NOTHING. That is deliberate: the three predicates are jointly total over
- * `ListingModAction`, and a future action claimed by none of them should visibly do
- * nothing rather than quietly land in a reason-gated modal whose one field it does not
- * carry.
- *
- * 🔴 `message-owner` is FALSE, and it is not an oversight. That action does not carry a
- * `reason` at all: `appListings.messageAppOwner` takes a SUBJECT and a BODY with their
- * own, different floors (`MOD_MESSAGE_SUBJECT_MIN` / `MOD_MESSAGE_BODY_MIN`), so the
- * router above claims it first. Answering `true` here would put one action in two
- * routers at once and leave this predicate reading "shows a reason textarea" for a
- * surface that shows none.
- *
- * Both halves are pinned: the vocabulary in `appListingModerationTableView.test.ts`,
- * and that the table still CALLS this at all in
+ * Pinned in two places: the vocabulary in `appListingModerationTableView.test.ts`, and
+ * that the table still CALLS this at all in
  * `__tests__/appModeratorMessageForm.callSites.test.ts` — this predicate spent one
  * revision referenced by nothing but its own test, which is the shape that lets a
  * "🔴 routing depends on this" comment describe dead code.
  */
 export function actionRequiresReason(action: ListingModAction): boolean {
-  return action !== 'review' && action !== 'message-owner';
+  return LISTING_MOD_ROUTES[action] === 'reason';
 }
 
 /**
  * Whether an action routes to `MessageAppOwnerModal` rather than the shared
- * reason-gated one. The complement of `actionRequiresReason` over the MUTATING
- * actions — `review` is neither (it opens the publish-request review modal).
+ * reason-gated one. Disjoint from `actionRequiresReason` BY CONSTRUCTION — one table
+ * entry per action — where the two used to be independent predicates that merely
+ * happened to disagree on every member.
  */
 export function actionOpensOwnerMessage(action: ListingModAction): boolean {
-  return action === 'message-owner';
+  return LISTING_MOD_ROUTES[action] === 'owner-message';
 }
 
 /** Human label for a mod action button. */

--- a/src/components/Apps/appModeratorMessageForm.ts
+++ b/src/components/Apps/appModeratorMessageForm.ts
@@ -1,0 +1,156 @@
+/**
+ * App Store Listings — the MOD "message this app's owner" COMPOSER view model (pure,
+ * React-free).
+ *
+ * Extracted from `MessageAppOwnerModal` for the same reason
+ * `appListingModerationTableView` was extracted from the mgmt table: the browser-mode
+ * suites are REPORT-ONLY in this repo's CI, so a correctness gate that lives only in a
+ * `.browser.test.tsx` blocks nothing. The submit gate on a moderator-authored message —
+ * the thing that decides whether a half-typed message can be sent to a developer — is
+ * pinned in the blocking node `unit` project instead.
+ *
+ * 🔴 EVERY BOUND HERE IS IMPORTED FROM THE SERVER SCHEMA, NEVER RETYPED. The floors and
+ * ceilings are `messageAppOwnerSchema`'s, and zod re-checks them (as does
+ * `validateMessageText` in the service, deliberately independent of the schema). A
+ * hand-typed copy that drifted would either offer a moderator a field they can fill and
+ * can never send, or gate a message the server would have accepted. Pinned by
+ * `appModeratorMessageForm.callSites.test.ts`.
+ */
+
+import {
+  MOD_MESSAGE_BODY_MAX,
+  MOD_MESSAGE_BODY_MIN,
+  MOD_MESSAGE_SUBJECT_MAX,
+  MOD_MESSAGE_SUBJECT_MIN,
+} from '~/server/schema/blocks/app-moderator-message.schema';
+
+/** One field's live state: what the counter renders and whether it clears its bounds. */
+export type ModMessageFieldState = {
+  /** TRIMMED length — the server trims before it validates, so the UI must too. */
+  length: number;
+  min: number;
+  max: number;
+  tooShort: boolean;
+  tooLong: boolean;
+  /** Within `[min, max]` after trimming. */
+  ok: boolean;
+};
+
+function fieldState(value: string, min: number, max: number): ModMessageFieldState {
+  // 🔴 TRIMMED, because `messageAppOwner` trims BEFORE it validates
+  // (`app-moderator-message.service.ts`). An untrimmed client check would let a body of
+  // 25 spaces open the gate, fire the mutation, and come back INVALID_TEXT → a
+  // BAD_REQUEST toast on a field the moderator was just told was long enough.
+  const length = value.trim().length;
+  const tooShort = length < min;
+  const tooLong = length > max;
+  return { length, min, max, tooShort, tooLong, ok: !tooShort && !tooLong };
+}
+
+export function modMessageSubjectState(subject: string): ModMessageFieldState {
+  return fieldState(subject, MOD_MESSAGE_SUBJECT_MIN, MOD_MESSAGE_SUBJECT_MAX);
+}
+
+export function modMessageBodyState(body: string): ModMessageFieldState {
+  return fieldState(body, MOD_MESSAGE_BODY_MIN, MOD_MESSAGE_BODY_MAX);
+}
+
+/**
+ * Which gate is closed, if any. Ordered so the hint names the field a moderator is
+ * most likely looking at: the SUBJECT is the first input in the modal, so a closed
+ * subject gate is reported before a closed body gate.
+ */
+export type ModMessageGateBlocker =
+  | 'subject-too-short'
+  | 'subject-too-long'
+  | 'body-too-short'
+  | 'body-too-long';
+
+export type ModMessageGate = {
+  /** True only when BOTH fields clear BOTH of their bounds. */
+  open: boolean;
+  /** `null` iff `open`. */
+  blockedBy: ModMessageGateBlocker | null;
+  /** Hover copy for the disabled submit. `undefined` iff `open`. */
+  tooltip: string | undefined;
+};
+
+/**
+ * The submit gate for the composer.
+ *
+ * 🔴 The CEILINGS are gated, not only the floors, and that asymmetry was the whole
+ * reason to write this as a function. `ReasonGatedField` — the shared atom every other
+ * moderator action uses — enforces a MINIMUM only, because every other moderator
+ * free-text field is a `reason` with no server ceiling worth surfacing. This one has
+ * two ceilings (200 / 2000) that zod rejects. Gating on the floor alone would let a
+ * moderator paste a long message into an enabled button and lose it to a `BAD_REQUEST`
+ * toast, with the text still in the box but no indication of which field was too long.
+ */
+export function modMessageGate(input: { subject: string; body: string }): ModMessageGate {
+  const subject = modMessageSubjectState(input.subject);
+  const body = modMessageBodyState(input.body);
+
+  const blockedBy: ModMessageGateBlocker | null = subject.tooShort
+    ? 'subject-too-short'
+    : subject.tooLong
+    ? 'subject-too-long'
+    : body.tooShort
+    ? 'body-too-short'
+    : body.tooLong
+    ? 'body-too-long'
+    : null;
+
+  if (blockedBy === null) return { open: true, blockedBy: null, tooltip: undefined };
+  return { open: false, blockedBy, tooltip: MOD_MESSAGE_GATE_TOOLTIPS[blockedBy] };
+}
+
+const MOD_MESSAGE_GATE_TOOLTIPS: Record<ModMessageGateBlocker, string> = {
+  'subject-too-short': `Enter a subject — at least ${MOD_MESSAGE_SUBJECT_MIN} characters.`,
+  'subject-too-long': `Shorten the subject to ${MOD_MESSAGE_SUBJECT_MAX} characters or fewer.`,
+  'body-too-short': `Enter a message — at least ${MOD_MESSAGE_BODY_MIN} characters.`,
+  'body-too-long': `Shorten the message to ${MOD_MESSAGE_BODY_MAX} characters or fewer.`,
+};
+
+/**
+ * The exact payload the mutation is called with.
+ *
+ * 🔴 TRIMMED HERE TOO. The service trims and then audits the TRIMMED text, so sending
+ * the raw value would record something different from what the moderator sees echoed
+ * back in the notification. There is no `appListingId` normalisation to do — the proc
+ * accepts a shadow revision id and resolves it to the parent itself.
+ *
+ * 🔴 `includeCollaborators` is sent ONLY when true. The schema's default is
+ * `undefined`→falsey and the field's docstring makes the false case the deliberate
+ * one; sending an explicit `false` is equivalent but makes the audit row's
+ * `after.includeCollaborators` read as an active choice on every single message.
+ */
+export function modMessagePayload(input: {
+  appListingId: string;
+  subject: string;
+  body: string;
+  includeCollaborators: boolean;
+}): {
+  appListingId: string;
+  subject: string;
+  body: string;
+  includeCollaborators?: boolean;
+} {
+  return {
+    appListingId: input.appListingId,
+    subject: input.subject.trim(),
+    body: input.body.trim(),
+    ...(input.includeCollaborators ? { includeCollaborators: true } : {}),
+  };
+}
+
+/**
+ * Success-toast copy. Reads the proc's `recipientCount` rather than asserting "sent to
+ * the owner": with `includeCollaborators` on, the real recipient set is the owner PLUS
+ * the accepted collaborators, and the moderator should be told how many people just
+ * received a message they may have intended for one person.
+ */
+export function modMessageSentSummary(recipientCount: number): string {
+  return recipientCount === 1
+    ? 'Message sent to the app owner.'
+    : `Message sent to ${recipientCount} recipients.`;
+}

--- a/src/components/Apps/reasonGatedFieldCopy.ts
+++ b/src/components/Apps/reasonGatedFieldCopy.ts
@@ -1,0 +1,59 @@
+/**
+ * App Store Listings — the COPY a reason-gated free-text field renders: its live
+ * counter and its inline error, as pure (React-free) functions.
+ *
+ * Extracted from {@link ReasonGatedField} for the reason the rest of this feature's
+ * view models were extracted: the browser-mode suites are REPORT-ONLY in this repo's
+ * CI, so a string built inline in JSX is pinned by nothing that can block a merge.
+ * The CEILING half is the case that motivated it — deleting the `(max N)` suffix left
+ * every blocking suite green while the one moderator field with a server-enforced
+ * maximum silently stopped naming it, which is exactly the state that lets a
+ * moderator fill a field the server will reject.
+ *
+ * 🔴 BEHAVIOUR-PRESERVING BY CONSTRUCTION, and that matters because five pre-existing
+ * call sites pass no ceiling at all. `maxLength == null` must render the byte-identical
+ * description and error those callers have always rendered; the no-ceiling cases are
+ * pinned first in `__tests__/reasonGatedFieldCopy.test.ts` for that reason.
+ */
+
+/** The shared inputs both strings are derived from. `length` is the TRIMMED length. */
+export type ReasonGatedFieldCopyInput = {
+  /** The TRIMMED length of the current value — what both strings count. */
+  length: number;
+  minLength: number;
+  /** The optional ceiling. `null`/`undefined` = no ceiling (every legacy caller). */
+  maxLength?: number | null;
+  /** When false this is an OPTIONAL note: no counter, no floor, no floor error. */
+  required: boolean;
+};
+
+/**
+ * The live counter under the field.
+ *
+ * `undefined` for an optional note (no floor to count toward). The ceiling is appended
+ * ONLY when one was given, so a caller that passes none keeps its exact copy.
+ */
+export function reasonGatedFieldDescription(input: ReasonGatedFieldCopyInput): string | undefined {
+  if (!input.required) return undefined;
+  const counter = `${input.length}/${input.minLength} characters minimum`;
+  return input.maxLength != null ? `${counter} (max ${input.maxLength})` : counter;
+}
+
+/**
+ * The inline error, or `undefined` when the field is fine.
+ *
+ * 🔴 TOO-LONG OUTRANKS TOO-SHORT and is NOT gated on `required`: a ceiling is a server
+ * rejection either way, so an optional note that overshoots still says so. Too-short
+ * needs the `length > 0` grace period — an untouched required field shows the neutral
+ * counter, not a red error — while too-long needs none, since it can only be reached
+ * by typing.
+ */
+export function reasonGatedFieldError(input: ReasonGatedFieldCopyInput): string | undefined {
+  if (input.maxLength != null && input.length > input.maxLength) {
+    return `Keep it to ${input.maxLength} characters or fewer (currently ${input.length}).`;
+  }
+  if (input.required && input.length < input.minLength && input.length > 0) {
+    return `Enter at least ${input.minLength} characters.`;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What

`appListings.messageAppOwner` — the moderator-to-app-developer message — shipped complete on the server: the procedure, the audit event, two rate-limit windows, its own notification type and the migration. It shipped with **zero UI callers**. A moderator who needed to tell a developer something the platform has no event for ("your listing says it estimates the cost and asks before it spends; it never has") had no in-product route to it at all.

This PR gives it one.

## Where, and why there

A **Message owner** action on every row of **/apps/review → Manage listings**.

That table is the moderator surface that holds a listing id for an *arbitrary* listing, and it is where a moderator is already standing at the moment they conclude "this needs a word with the developer" rather than a takedown. It sits between Review and the lifecycle actions, so a row reads in increasing severity — Review → Message owner → Reset to pending → Hide → … → Purge — and the destructive action stays rightmost.

⚠️ **One gap, stated rather than implied.** An earlier version of this paragraph claimed the table holds a listing in *any* status. It does not: the table filters out every row where `kind === 'onsite'` and the effective status is `pending`, because those live in the on-site review FIFO queue. So **this action is unreachable for an on-site listing while it is awaiting review** — one of the states a developer most needs to hear from a moderator in.

That filter is **not** widened here, and the gap is **not** closed by this PR. Which rows a live moderator surface lists is a product decision about surface duplication, not a should-fix on the composer; closing it means giving the on-site review queue its own composer entry point (and adding that queue to the mount ledger). What this PR does do is correct the filter's stale justification in the code: it said those rows are dropped because "here they'd render as a dead-end `—`-action row", which stopped being true the moment `message-owner` became unconditional.

The per-request review detail page was considered and rejected: it operates on block publish requests and has no listing id in scope, so wiring it there would mean an extra lookup for a second surface nobody asked for.

## The action is offered on every row that reaches the table

The procedure resolves its recipient without branching on listing status, so there is no row the button would be refused on. Narrowing it — to approved rows, say — would withhold it in exactly the states where a developer is being asked to fix something: a `rejected` or `draft` row previously rendered a dead `—` with no way to tell them what to fix.

That claim is enumerated over the full status × kind × pending-request cross product in the blocking unit suite, not sampled. ⚠️ It exercises the **pure action-set function**, not the rendered table — so it says nothing about which rows the table decides to display, which is the gap above.

## The composer

A dedicated modal rather than the shared reason-gated one, because this action takes a **subject** and a **body** with different floors plus a delivery-scope opt-in, where every other action on this table takes a single `reason`. It still composes the shared field + submit atoms, so the live counter, the inline error and the disabled-with-tooltip submit look and behave exactly like the neighbouring actions.

Behaviour worth calling out:

- **It names no recipient, and its prop type cannot carry one.** The mod table holds `AppListing.userId` — a denormalised copy. For an on-site listing the send resolves the *backing block's* owner instead, which is exactly what `resolveCanonicalListingOwner` exists to do. A composer that echoed the column would let a moderator write copy aimed at the person on screen while the platform delivered it to someone else — a disclosure, not a mislabel. The notice therefore says the owner is *resolved when you send*; the table's Owner column is unchanged, because a column is a display, not a promise about where a message goes. (No on-site listing is drifted today, so this was latent rather than live — but an earlier revision of the file carried a 🔴 "never present it as the delivery target" docstring on the very value it then rendered, which is why this is now a prop-shape ledger rather than a comment.)
- **Both ceilings gate the submit, not only the floors.** Every other moderator free-text field has no server-side maximum worth surfacing; this one has two that are enforced. A floor-only gate would let a long paste through to an unattributed 400 with the text still in the box and no indication which field was at fault. `ReasonGatedField` gains an optional `maxLength` — inert when omitted, which is the case at all three pre-existing render sites (one of them the shared modal shell, so every modal built on it is covered); each keeps its exact copy, verified by re-running all four sibling suites.
- **Both fields are measured trimmed**, because the server trims before it validates. Otherwise a body of spaces opens the gate and comes straight back rejected.
- **"Also send to accepted collaborators" defaults off**, mirroring the schema, and **is cleared on every send** — opt in per message, never per session. The owner is the accountable party; an accepted collaborator consented to edit an app, not to receive moderation correspondence about it, and a moderator's message can be adverse. It is offered at all because on an app with an unresponsive owner the editors are the only people who can fix the listing — a judgement call per message.
- **A failed send keeps the modal open and the typed text intact.** Every typed failure this procedure returns is one the moderator can act on and retry ("try again in Ns", "edit this text"), so discarding the body would throw away the work the error is asking them to reuse.
- **The success toast reads the returned recipient count**, so a moderator who ticked the collaborator box is told how many people the message actually reached.
- **No query invalidation on send.** The procedure changes no listing state and the row carries no field that would differ; invalidating also resets pagination, so it would discard the moderator's loaded pages in exchange for a byte-identical result.

The modal also states, on screen, that the message is one-way and that its subject and body are recorded in the listing's moderation history — both true of the procedure, and neither obvious from a compose box.

## Routing

`openAction` has three routes — `review`, the owner-message composer, and the shared reason-gated modal — and it now **branches on all three**, including the last. Previously `actionRequiresReason` carried 🔴 comments describing it as the routing gate while being referenced by nothing but its own test; the reason-gated modal was reached by bare fall-through. Measured: reverting the predicate to `action !== 'review'` left **all 48 component tests green**, so the test's stated claim ("answering `true` would send it to `ListingModActionModal`") was false.

It is wired rather than deleted, because the branch is what makes the three predicates' **jointly-total** property load-bearing: an action claimed by none of them opens nothing (loud) instead of landing in a modal whose one field it does not carry (quiet).

⚠️ **The branch alone did not deliver that, and an earlier version of this paragraph said it did.** While `actionRequiresReason` was written as a NEGATION (`action !== 'review' && action !== 'message-owner'`), a member added to `ListingModAction` answered `true` by DEFAULT and landed in the reason-gated modal no matter how the branch above was written — the totality property was decorative. Measured: adding a member to the union left **all 46 unit tests green**, and once a label case was supplied so the exhaustive switch stopped objecting, `pnpm typecheck` was clean too. The only thing ever enforced was the LABEL half.

Both predicates now read a single exhaustive `Record<ListingModAction, ListingModRoute>`. A new member is a **missing property** — a `pnpm typecheck` failure naming the route table, which is a blocking check — and at runtime an unlisted action resolves to `undefined`, so both predicates answer `false` and it opens nothing. Mutual exclusivity is by construction rather than by two predicates that happen to disagree. The test's action vocabulary is derived from that table instead of hand-listed, so a member the union gains cannot silently stop being swept.

## Tests

| File | Project | Covers |
|---|---|---|
| `__tests__/appModeratorMessageForm.test.ts` | `unit` (blocking) | the gate rule, every boundary case built from the schema constants, trimming, the payload shape, the toast copy |
| `__tests__/appModeratorMessageForm.callSites.test.ts` | `unit` (blocking) | a mount ledger that fails when the surface goes dark again **or** when a second one appears unwired; that the table still *calls* the reason-gate router; the composer's exact `listing` prop key set; that each field is wired to **its own** bounds pair; that `reset()` restores every `useState` piece to the initial value it declares; that the shared field's props are each fed by their own copy function from a trimmed length; the whole delivery-notice sentence; that `onError` never resets; plus positive controls on each detector |
| `__tests__/reasonGatedFieldCopy.test.ts` | `unit` (blocking) | **new** — the shared field's counter and inline error as pure functions, including the ceiling suffix, the no-ceiling legacy copy, and the too-long/too-short precedence |
| `__tests__/appListingModerationTableView.test.ts` | `unit` (blocking) | the action sets, ordering, and the routing predicates' exclusivity + totality over a vocabulary derived from the route table |
| `MessageAppOwnerModal.browser.test.tsx` | `component` | the two-field gate, the ceilings, the payload, the collaborator opt-in **and its reset**, the failure posture, and the exact delivery-notice sentence |
| `AppListingsModerationTable.browser.test.tsx` | `component` | the action on every row incl. on-site and orphan-draft; opens the composer and **not** the reason modal; fires with the listing id |

The correctness gates live in the **blocking** node project deliberately — the browser suites are report-only, so a rule pinned only there blocks nothing. Three properties this PR marks 🔴 were previously pinned only there, and each survived the blocking tier untouched:

- **the ` (max N)` ceiling suffix.** Enumerated over all **1,468** files matching the `unit` project's include globs at the previous tip: **zero** reference `ReasonGatedActionModal` (positive control on the same sweep: 3 files reference `MessageAppOwnerModal`). Nothing in the blocking tier *could* observe that string. Both copy strings are now a pure `reasonGatedFieldCopy` module with its own blocking suite; the extraction is behaviour-preserving and the four sibling suites (43 tests) are unchanged.

  ⚠️ **That extraction moved the strings, not the wiring, and an earlier version of this bullet read as if it closed the whole hole.** `ReasonGatedActionModal.tsx` was still read by no blocking test, so which copy function feeds which prop — and whether the length handed to both is trimmed — remained pinned by nothing that can block a merge. Measured: swapping `description` with `error`, and `length: len` → `length: value.length`, each survived the **entire** suite in both tiers. The file is now enrolled in the call-site ledger; the trimmed length is resolved through its alias, so dropping the trim one level up (`const len = value.length`) fails the same assertion.
- **the body field's ceiling constant**, which could be cross-wired to `MOD_MESSAGE_SUBJECT_MAX` and pass every existing check (both names are imported; no bare literal appears). Now a call-site assertion.
- **a failed send not wiping the composed text**, now asserted on the mutation's `onError`, with the success handler as the extractor's positive control.

**Every guard was watched to fail**, one mutation at a time, each killed by its own assertion:

| Mutation | Killed by | Tier |
|---|---|---|
| `setIncludeCollaborators(false)` deleted from `reset()` | `reset() restores every useState piece to its DECLARED initial value…` → `["setIncludeCollaborators: never called in reset() (declared initial false)"]`; **and** the browser test, on the reopened checkbox | blocking + component |
| body ceiling cross-wired to `MOD_MESSAGE_SUBJECT_MAX` | per-field bounds assertion | blocking |
| ` (max N)` suffix deleted from the counter | 2 exact-string failures | blocking |
| the counter's ceiling rendered from `minLength` instead | the distinct-inputs case | blocking |
| too-short made to outrank too-long | the both-at-once case | blocking |
| `reset()` added to `onError` | `onError` assertion (`onSuccess` control still green) | blocking |
| the `actionRequiresReason` branch removed from `openAction` | router-wiring assertion | blocking |
| a display owner re-added to the prop under a **different name** (`ownerHandle`) | the prop **key-set** ledger — so it is a state guard, not a spelled one | blocking |
| a handle re-added to the notice, control phrase left intact | `not to match /[@#]\w/`, in isolation | component |
| the action narrowed to approved rows | cross-product enumeration (8 failures) | blocking |
| the modal mount removed | ledger + listing-id wiring (3 failures) | blocking |

All were reverted and the suites re-run green. **The whole table above was re-run against the current tip** after every later round, since a later edit can resurrect a mutant an earlier round killed — every row still dies, and the table shows the round-four re-run rather than the original wording.

⚠️ **"On the same assertion" was true of the mutants and not of their messages, and an earlier version of this line claimed both.** Round three replaced the reset ledger's call-presence check with a value comparison, which renamed the assertion and rewrote its offence strings: row 1 above was first recorded as `expected [ 'setIncludeCollaborators' ] to deeply equal []` and now reads `["setIncludeCollaborators: never called in reset() (declared initial false)"]`. Same mutation, same tier, still dead — different name and different message. Every quoted message in both tables is the one measured at the current tip.

### Round three — three guards a neighbouring mutant walked past

A delta re-audit found that each guard was written to catch the mutant its author had in mind. These are the neighbours, all measured **surviving** before the fix and **dying in the blocking tier** after it, one mutation at a time:

| Mutation | Before | Killed by, now | Tier |
|---|---|---|---|
| `setIncludeCollaborators(false)` → `(true)` inside `reset()` | **survived, 13/13 green** | `reset() restores every useState piece to its DECLARED initial value…` → `["setIncludeCollaborators: reset() passes true, declared initial is false"]` | blocking |
| a member added to `ListingModAction`, **with** its label case supplied | **survived** — 46 tests green, `typecheck: OK — 0 type errors` | `error TS2741: Property 'suspend' is missing in type … but required in type 'Record<ListingModAction, ListingModRoute>'` | blocking (`pnpm typecheck`) |
| `description={…Description(copy)}` swapped with `error={…Error(copy)}` | **survived** both tiers | `each prop is fed by ITS OWN copy function` | blocking |
| `length: len` → `length: value.length` | **survived** both tiers | `the copy input is built from the TRIMMED length…` → `expected 'value.length' to be 'value.trim().length'` | blocking |
| `const len = value.trim().length` → `const len = value.length` (the same defect one level up) | n/a — new case | same assertion, same message | blocking |
| the notice reworded to *"…to the app owner devuser, resolved when you send"* | **survived** — matches no `[@#]\w`, 17/17 green | `the delivery notice is exactly this sentence` | blocking **and** component |
| the `actionRequiresReason` branch deleted **and quoted in a comment** on the line above | would have **satisfied** the raw-text assertion | `the mounting site BRANCHES on actionRequiresReason…` — the reader strips comments | blocking |

Two controls on that last pair, since comment-stripping cuts both ways: a comment that merely *mentions* `ownerLabel` is **not** an offence (16/16 green), while a prop actually named `ownerLabel` still fails `neither the composer nor its mount site carries a display owner`.

And one refactor that must **not** fail: converting `reset()` to `const reset = () => {…}` used to throw `no function reset` — an error naming a syntax choice rather than a defect. It is now green (16/16), and the wrong-value mutant above still dies **in that form too**.

**Red at the previous tip**, with the new tests held constant: the router-wiring assertion, the prop key-set ledger and the display-owner assertion all fail against the pre-change table and composer, as do the two delivery-notice browser tests. The remaining new guards (reset completeness, `onError`, per-field bounds, and the pure copy suite) are **invariant guards on already-correct behaviour** — they were never red at base, and their evidence is the mutation table above, not a base run.

**Round three's guards are invariant guards too, with one exception, and are labelled as such.** The reset-value comparison, the field-wiring pair, the trimmed-length resolution and the whole-notice pin all pin behaviour that was already correct; their evidence is the round-three mutation table, not a base run. The exception is the **route table**: it is a behaviour change in the loud-safe direction (an action absent from it now opens nothing instead of defaulting into the reason-gated modal), and it is red at the previous tip in the only way that property can be — the union-member mutant typechecks clean there and fails after.

### Round four — two guards satisfied by the wrong thing, and four false claims

Both guards were written in round three and both were walkable by a mutant one statement away from the one their author had in mind. Neither is a defect in shipped behaviour — the composer resets correctly and imports the right constants — but a ledger that cannot see the hazard it was written for is not evidence.

| Mutation | Before | Killed by, now | Tier |
|---|---|---|---|
| `reset()` clears the opt-in and then **overwrites** it — `setIncludeCollaborators(false); setIncludeCollaborators(true);` | **survived, 38/38 green.** The ledger `exec`'d a non-global RegExp, so only the FIRST call per setter was ever compared, and the first call is the declared initial | `reset() restores every useState piece to its DECLARED initial value…` → `["setIncludeCollaborators: reset() passes true, declared initial is false"]` | blocking |
| the bounds import redirected to another module path, the original left behind in a **comment** | **survived, 38/38 green.** That assertion read RAW source — the `toContain`-satisfied-by-a-comment polarity the file's own reader docstring warns about three paragraphs earlier | `both modules import the bounds from messageAppOwnerSchema`, which now reads comment-stripped source like every other source assertion | blocking |

The reset ledger compares **every** call per setter now, not the last, so a transient wrong value is an offence too — the loud direction, and it names the value rather than only the fact.

Four prose claims were measured false and are corrected rather than renumbered:

- *"…and now nothing reads raw"* was false when written. The mount sweep reads raw **deliberately** (documented three paragraphs above it), and the schema-import assertion did so by accident. It is now stated as a one-exception rule instead of a count of converted assertions.
- *"one of the **three** scanned files"* — the comment-stripping reader is applied to **four**. Replaced with the definition of that population, since a count maintained in parallel with the thing it counts is exactly what rotted.
- the browser test said an empty read *"would make the assertions below pass over nothing"*. The whole-sentence `toContain` would **fail**, not pass; only the sigil check is at risk. That check was also **supplemented, not replaced**, which the comment two lines down already said.
- the table's dead-branch comment still called an unrouted action *"the loud failure"* after the delta removed the clause that made it true. It is loud in the **test and type** tiers; on screen it is a dead button — no toast, no error, no menu close.

Two limits are documented rather than fixed, both loud-and-safe as they stand:

- the state ledger compares the initialiser's **text**, so a legal, behaviour-preserving refactor to `useState(() => false)` reads as a defect (`expected '() => false' to be 'false'`). Noted in known-limits with the fix to make if anyone hits it.
- the route table's `review` entry is read by **nothing** — the dispatch and its test both branch on the literal `action === 'review'`. So *"every action names exactly one route"* is a property of the table, not of the dispatch: a new member mapped to `'review'` typechecks and opens nothing, caught by the jointly-total sweep rather than by the type system. The docstring says so now.

## Verification

- `pnpm typecheck` → `typecheck: OK — 0 type errors in 20s (heap cap 8192 MB)`, identical to the baseline taken on this tree before round four's edits. Instrument control: the union-member mutant above gives `typecheck: 1 type error(s).`, exit 2 — so it can go red, and it goes red for the routing reason specifically.
- `vitest --project 'unit*'` — the **whole** blocking project → **1,468 files, 22,999 passed, 25 skipped, 0 failed**. The four Apps view-model suites in it → **4 files, 70 tests** (66 before round three, 47 before this PR); round four added assertions inside existing tests, so the count is deliberately unchanged.
- `vitest --project component` over `src/components/Apps` → **76 files, 1,113 tests passed**; the two touched suites alone → **2 files, 50 tests**.
- **The round one/two/three mutation battery re-run in full at the round-four tip**, one mutation at a time, each applied by exact-anchor replacement with the anchor count asserted first: all 18 mutants still die on their own assertion, plus the four controls — a comment merely *mentioning* `ownerLabel` stays green (1,309/1,309), `reset()` as `const reset = () => {…}` stays green, the wrong-value mutant dies **in that arrow form too**, and a delegated `reset() { clearComposer(); }` fails loudly with **3** offences.
- Prettier clean on all changed files. Negative control from this round: a deliberately misformatted copy of one of them was named, **1 of 5**, so the clean verdict is a read and not an empty glob.
- ESLint clean on every changed file. One pre-existing `react-hooks/exhaustive-deps` warning remains in untouched code in the table — confirmed identical at the previous tip.

## Drive-by

`AppListingsModerationTable.browser.test.tsx` used a wholesale `vi.mock('~/utils/trpc')` factory, which this repo's own lint rule flags: it is the shape that fails the file's module link and reports "0 tests collected" as a silent green. Converted to the `importOriginal` spread form while adding the new procedure to it — that addition is precisely the kind of edit that would have tripped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TSaLRkbL9SUzUyuvjDChL


