### PR TITLE
fix(apps): a republish whose images changed goes back to review — on the surface that can show them

### DIFF
--- a/src/components/Apps/ListingHistoryPanel.tsx
+++ b/src/components/Apps/ListingHistoryPanel.tsx
@@ -1,6 +1,7 @@
 import { Alert, Badge, Button, Group, Loader, Stack, Text } from '@mantine/core';
 import { useCallback } from 'react';
 
+import { withdrawSuccessMessage } from '~/components/Apps/listingPublishingActions';
 import { historyStatusColor } from '~/components/Apps/myAppsView';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { formatDate } from '~/utils/date-helpers';
@@ -174,6 +175,19 @@ export function ListingHistoryPanelView({
               color="gray"
               disabled={withdrawing}
               onClick={() => onWithdraw(e)}
+              /*
+                🔴 THE ONE-WAY WARNING IS ON THE CONTROL, not only in the toast that
+                follows it. Withdrawing the review of a listing that was previously LIVE
+                does not return it to how it was: the server closes it to `removed` behind
+                a `delist` event, which the owner-republish guard reads as a moderator
+                takedown, so only a moderator can put it back. That is deliberate (it
+                closes a self-restore exploit — see `closeTerminalListing`), which is
+                exactly why it has to be disclosed BEFORE the click rather than defended
+                afterwards. Worded for the case it warns about without asserting the
+                listing IS in it — this component cannot tell, and a warning that
+                over-claims gets ignored.
+              */
+              title="Withdraws this submission. If the listing was previously live, withdrawing takes it off the store and a moderator has to restore it."
               data-testid={`apps-history-withdraw-${e.id}`}
             >
               Withdraw
@@ -236,8 +250,16 @@ export function ListingHistoryPanel({ appListingId }: { appListingId: string }) 
     onError: (e) => onWithdrawError(e.message),
   });
   const withdrawListing = trpc.appListings.withdrawExternalRequest.useMutation({
-    onSuccess: () => {
-      showSuccessNotification({ message: 'Submission withdrawn.' });
+    /**
+     * 🔴 THE SERVER SAYS WHAT IT DID; DO NOT ASSUME. `outcome: 'removed'` means this
+     * withdraw closed the review of a formerly-LIVE listing, so the listing is now OFF the
+     * store behind a `delist` and the owner cannot republish it — a moderator must relist.
+     * `'deleted'` merely discarded a draft. Announcing both as "Submission withdrawn."
+     * left an owner looking at a "removed by a moderator" state they had caused
+     * themselves, with nothing having told them it would happen.
+     */
+    onSuccess: (data) => {
+      showSuccessNotification({ message: withdrawSuccessMessage(data?.outcome) });
       refetchHistory();
     },
     onError: (e) => onWithdrawError(e.message),

--- a/src/components/Apps/ListingHistoryPanel.tsx
+++ b/src/components/Apps/ListingHistoryPanel.tsx
@@ -186,6 +186,16 @@ export function ListingHistoryPanelView({
                 afterwards. Worded for the case it warns about without asserting the
                 listing IS in it — this component cannot tell, and a warning that
                 over-claims gets ignored.
+
+                🔴 THE VERSION ENTRIES (`source === 'version'`) ARE NOW CONDITIONAL, which
+                is why the hedged wording has to stay rather than be sharpened. Withdrawing
+                a VERSION reaches `closeOnsiteResetListingOnWithdraw`, which since the
+                asset-review route REFUSES to close a `pending` listing whose review
+                belongs to the LISTING queue. So a version withdraw delists in the
+                mod-reset case and does not in the republish-review case — and which case
+                you are in depends on a row this component does not read. Warning in both
+                is the safe direction for a one-way action; claiming either outcome
+                per-entry would be an assertion this surface cannot support.
               */
               title="Withdraws this submission. If the listing was previously live, withdrawing takes it off the store and a moderator has to restore it."
               data-testid={`apps-history-withdraw-${e.id}`}

--- a/src/components/Apps/ListingPublishingPanel.browser.test.tsx
+++ b/src/components/Apps/ListingPublishingPanel.browser.test.tsx
@@ -9,6 +9,7 @@ import {
   OWNER_ACTIONS_BY_STATE,
   sortPublishingActions,
 } from '~/components/Apps/listingPublishingActions';
+import { showSuccessNotification } from '~/utils/notifications';
 
 /**
  * THE OWNER PUBLISHING LEDGER, now on the authoring page's **Publishing** tab.
@@ -57,6 +58,15 @@ const mocks = vi.hoisted(() => ({
   /** `[procedureName, input]` for every mutation fired, in order. */
   calls: [] as Array<[string, unknown]>,
   republishPending: false,
+  /**
+   * What `republishOwnListing` resolves to. `'pending'` is a REAL success outcome (the
+   * asset-change review route), not an error, and the panel must say so — see
+   * `republishSuccessMessage`.
+   */
+  republishResult: { appListingId: 'apl_1', status: 'approved' } as {
+    appListingId: string;
+    status: 'approved' | 'pending';
+  },
   /** Every `utils.appListings.<proc>.invalidate()` the panel issues, by procedure name. */
   invalidated: [] as string[],
 }));
@@ -80,7 +90,12 @@ function mutationStub(name: string, isPending = false) {
     useMutation: (opts?: MutationOpts) => ({
       mutate: (input: unknown) => {
         mocks.calls.push([name, input]);
-        void opts?.onSuccess?.(undefined);
+        // 🔴 A REALISTIC payload, not `undefined`: `republishOwnListing` resolves to
+        // `{ appListingId, status }` and the panel DERIVES its success message from that
+        // status (a republish whose assets changed lands in `pending`, not live). A stub
+        // that hands the handler `undefined` is an unfaithful fake — it cannot see the
+        // wrong message and it crashes the handler that reads the field.
+        void opts?.onSuccess?.(mocks.republishResult);
       },
       isPending,
     }),
@@ -187,6 +202,7 @@ function renderedActions(): string[] {
 beforeEach(() => {
   mocks.calls = [];
   mocks.republishPending = false;
+  mocks.republishResult = { appListingId: 'apl_1', status: 'approved' };
   mocks.invalidated = [];
 });
 
@@ -340,6 +356,40 @@ describe('the wiring — each control fires the right procedure with the right i
     // fails in one of the two tests. Republish is not confirm-gated on purpose: it restores
     // the previous state, so the recovery from a misclick is the button next to it.
     expect(mocks.calls).toEqual([['republishOwnListing', { appListingId: 'apl_hidden_q2' }]]);
+  });
+
+  test('🔴 a republish routed to REVIEW tells the owner so, instead of claiming it is live', async () => {
+    /**
+     * 🔴 THE MESSAGE IS A CLAIM ABOUT THE SERVER'S ANSWER. `republishOwnListing` routes a
+     * republish to `pending` — a re-review — whenever the listing's assets changed since
+     * the last approval. The panel used to hardcode "App republished — it is live again",
+     * which is FALSE on that arm and survives review precisely because the mutation really
+     * did succeed. This drives the real click path and reads the notification the owner
+     * would actually see.
+     */
+    mocks.republishResult = { appListingId: 'apl_hidden_q2', status: 'pending' };
+    renderWithProviders(<ListingPublishingPanel {...OWNER_HIDDEN} />);
+    const button = page.getByTestId('apps-publishing-republish');
+    await expect.element(button).toBeInTheDocument();
+    await userEvent.click(button);
+
+    const message = vi.mocked(showSuccessNotification).mock.calls.at(-1)?.[0]?.message as string;
+    expect(message).toContain('review');
+    // The load-bearing ABSENCE — the old copy must not come back on this arm.
+    expect(message).not.toContain('live');
+  });
+
+  test('🔴 a republish that DID go live still says so (the other arm of the same branch)', async () => {
+    // Positive control on the same assertion: without this, a mutant that always returned
+    // the review wording would satisfy the test above.
+    mocks.republishResult = { appListingId: 'apl_hidden_q2', status: 'approved' };
+    renderWithProviders(<ListingPublishingPanel {...OWNER_HIDDEN} />);
+    const button = page.getByTestId('apps-publishing-republish');
+    await expect.element(button).toBeInTheDocument();
+    await userEvent.click(button);
+
+    const message = vi.mocked(showSuccessNotification).mock.calls.at(-1)?.[0]?.message as string;
+    expect(message).toContain('live');
   });
 
   test('a republish in flight DISABLES the button rather than allowing a second fire', async () => {

--- a/src/components/Apps/ListingPublishingPanel.tsx
+++ b/src/components/Apps/ListingPublishingPanel.tsx
@@ -8,6 +8,7 @@ import {
   type OwnerUnpublishVariant,
 } from '~/components/Apps/ownerListingModals';
 import {
+  republishSuccessMessage,
   showModRemovedNotice,
   showRepublish,
   showUnpublish,
@@ -88,8 +89,11 @@ export function ListingPublishingPanel({
   }, [utils, onChanged]);
 
   const republish = trpc.appListings.republishOwnListing.useMutation({
-    onSuccess: () => {
-      showSuccessNotification({ message: 'App republished — it is live again.' });
+    // 🔴 The message is DERIVED from the server's answer, never assumed: a republish whose
+    // assets changed since the last approval lands in `pending`, not live. See
+    // {@link republishSuccessMessage}.
+    onSuccess: (data) => {
+      showSuccessNotification({ message: republishSuccessMessage(data, kind) });
       refresh();
     },
     /**

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -51,10 +51,12 @@ vi.mock('~/utils/trpc', () => {
   // notification paths run.
   const mutation =
     (name: string) =>
-    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+    (opts?: { onSuccess?: (data?: unknown) => void; onError?: (e: { message: string }) => void }) => ({
       mutate: (vars: unknown) => {
         mocks.mutate(name, vars);
-        void opts?.onSuccess?.();
+        // Realistic mutation payload — the republish handler derives its message from
+        // the returned `status` (see `republishSuccessMessage`).
+        void opts?.onSuccess?.({ appListingId: 'apl_1', status: 'approved' });
       },
       isPending: false,
     });

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -26,6 +26,7 @@ import {
 } from '~/components/Apps/ListingProblemsIndicator';
 import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
 import { isStaleDeploy, isStrandedDeploy } from '~/components/Apps/deploy-status';
+import { republishSuccessMessage } from '~/components/Apps/listingPublishingActions';
 import {
   canOwnerRepublish,
   canOwnerUnpublish,
@@ -556,8 +557,11 @@ export function MySubmissionsList({
   const invalidateSubmissions = () => utils.blocks.listMyPublishRequests.invalidate();
 
   const republishMutation = trpc.appListings.republishOwnListing.useMutation({
-    onSuccess: async () => {
-      showSuccessNotification({ message: 'App republished — it is live again.' });
+    // 🔴 The message is DERIVED from the server's answer, never assumed: a republish whose
+    // assets changed since the last approval lands in `pending`, not live. See
+    // {@link republishSuccessMessage}.
+    onSuccess: async (data) => {
+      showSuccessNotification({ message: republishSuccessMessage(data, 'onsite') });
       await invalidateSubmissions();
     },
     onError: (e) => showErrorNotification({ title: 'Republish failed', error: new Error(e.message) }),

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -413,6 +413,12 @@ describe('OffsiteReviewModal — on-site listing-media revision (kind: onsite)',
       category: 'utility',
       contentRating: 'g',
       connectClientId: null,
+      // 🔴 A media revision request targets a SHADOW, so `revisionOfId` is always set.
+      // This fixture used to omit it, which made it indistinguishable from the OTHER
+      // on-site request shape (the republish re-review, `revisionOfId: null`) — the two
+      // are governed by opposite rating rules, so a fixture that cannot tell them apart
+      // was pinning the cap copy onto a request shape that may not be under a cap.
+      revisionOfId: 'listing-parent',
     },
     submittedBy: { id: 42, username: 'author-dev', image: null },
   };
@@ -447,6 +453,74 @@ describe('OffsiteReviewModal — on-site listing-media revision (kind: onsite)',
     // getByText matches two elements (strict-mode violation). Scope the reject-reason
     // assertion to the mismatch callout itself.
     await expect.element(mismatch).toHaveTextContent('must not exceed the app’s rating');
+  });
+});
+
+// 🔴 The OTHER on-site request shape: an owner republish whose store imagery changed
+// since the last approval. Same `kind: 'onsite'`, same modal — and the server applies the
+// OPPOSITE rating rule (`resolveOnsiteApprovalContentRating` FLOORS the app's declared
+// rating at the media-derived value, raise-only). Every assertion here is the mirror of
+// one in the media-revision block above, and the ONLY fixture difference is
+// `revisionOfId: null`.
+describe('OffsiteReviewModal — on-site republish re-review (kind: onsite, NON-shadow)', () => {
+  const ONSITE_REPUBLISH_ROW = {
+    id: 'rpb-1',
+    kind: 'onsite' as const,
+    appListingId: 'listing-1',
+    slug: 'onsite-republish-app',
+    status: 'pending',
+    submittedAt: new Date('2026-02-01T00:00:00Z'),
+    changelog: null,
+    appListing: {
+      name: 'On-site Republish App',
+      externalUrl: null,
+      category: 'utility',
+      contentRating: 'g',
+      connectClientId: null,
+      // The whole discriminator: this request targets the LIVE listing, not a shadow.
+      revisionOfId: null,
+    },
+    submittedBy: { id: 42, username: 'author-dev', image: null },
+  };
+
+  test('🔴 the note describes a REPUBLISH review and says the rating is RAISED, not capped', async () => {
+    renderWithProviders(<OffsiteReviewModal request={ONSITE_REPUBLISH_ROW} onClose={vi.fn()} />);
+    const note = page.getByTestId('apps-offsite-onsite-note');
+    await expect.element(note).toBeInTheDocument();
+    await expect.element(note).toHaveTextContent('Republish review');
+    await expect.element(note).toHaveTextContent('RAISES the app’s rating');
+    // The cap sentence — correct for a media revision — must NOT appear here.
+    expect(note.element().textContent).not.toContain('must not exceed');
+  });
+
+  test('🔴 the app rating is labelled a FLOOR, not a cap', async () => {
+    renderWithProviders(<OffsiteReviewModal request={ONSITE_REPUBLISH_ROW} onClose={vi.fn()} />);
+    await expect.element(page.getByText('app rating (floor)', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('app rating (cap)', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('🔴 the mismatch callout says approving RAISES the app, not that it is a reject reason', async () => {
+    // Assets derive 'r' vs the app's declared 'g' → the callout renders. For a media
+    // revision that is "reject or trim"; here approving is what the server will do, and
+    // it will raise the app to 'r'. Telling the moderator the opposite is the finding.
+    renderWithProviders(<OffsiteReviewModal request={ONSITE_REPUBLISH_ROW} onClose={vi.fn()} />);
+    const mismatch = page.getByTestId('apps-offsite-rating-mismatch');
+    await expect.element(mismatch).toBeInTheDocument();
+    await expect.element(mismatch).toHaveTextContent('it is a floor here, not a cap');
+    expect(mismatch.element().textContent).not.toContain('reject this revision');
+  });
+
+  test('🔴 the approve Select defaults to the DERIVED rating (the floor), not the app rating', async () => {
+    // The media-revision default is the app's own rating; offering that here offers a
+    // value the server would silently raise past. Fixture ratings are deliberately
+    // distinct — app 'g' vs derived 'R' — so a default that echoed either one is visible.
+    renderWithProviders(<OffsiteReviewModal request={ONSITE_REPUBLISH_ROW} onClose={vi.fn()} />);
+    await page.getByTestId('apps-offsite-approve-open').click();
+    const ratingInput = page
+      .getByTestId('apps-offsite-approve-rating')
+      .element() as HTMLInputElement;
+    expect(ratingInput.value).toBe('R');
+    expect(ratingInput.value).not.toBe('G');
   });
 });
 

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -488,6 +488,21 @@ export function OffsiteReviewModalBody({
   // mod-REJECT reason, not an auto-derive. Both surface the same `ratingExceeds`
   // comparison; only the copy + the approve default differ.
   const isOnsite = request.kind === 'onsite';
+  // 🔴 `kind === 'onsite'` NO LONGER IMPLIES "a media revision". A second producer of
+  // on-site listing requests exists — the owner-republish asset-change re-review — and it
+  // is NON-shadow (`revisionOfId == null`), targeting the live listing itself rather than
+  // a shadow copy of it. The two are reviewed in this same modal but the server applies
+  // OPPOSITE rating rules to them, so telling them apart here is not cosmetic:
+  //
+  //   • on-site media REVISION  → `applyApprovedRevision`, assets-only, the app's rating
+  //     is preserved. Treating it as a CAP is right: media above the app's rating is a
+  //     reject reason, not something to auto-derive.
+  //   • on-site republish RE-REVIEW → `resolveOnsiteApprovalContentRating`, which FLOORS
+  //     the app's declared rating at the media-derived value — RAISE-only. Telling the
+  //     moderator "the media must not exceed the app's rating" states a policy the server
+  //     does not implement, and defaulting the approve control to the app's rating offers
+  //     a value the server will silently raise past.
+  const isOnsiteRepublishReview = isOnsite && (request.appListing?.revisionOfId ?? null) == null;
   const declaredRating = request.appListing?.contentRating ?? null;
   // The app's rating (the CAP for an on-site media revision), narrowed to a valid
   // enum value; null when unknown/invalid.
@@ -501,9 +516,17 @@ export function OffsiteReviewModalBody({
     nsfwLevelFromContentRating(derivedRating) > nsfwLevelFromContentRating(declaredRating);
   // Keep the offsite name for the unchanged offsite paths below.
   const ratingMismatch = ratingExceeds;
-  // Onsite approve defaults to the app's rating (the cap — media inherits it); the
-  // offsite approve defaults to the derived floor. Either way the mod may override.
-  const defaultRating: OffsiteContentRating = isOnsite ? appRating ?? derivedRating : derivedRating;
+  // Onsite media REVISION defaults to the app's rating (the cap — media inherits it); the
+  // offsite approve defaults to the derived floor. An onsite republish RE-REVIEW mirrors
+  // the server's raise-only floor — `max(declared, derived)` — so the control shows what
+  // approving would actually stamp instead of a value the server would override.
+  const defaultRating: OffsiteContentRating = isOnsiteRepublishReview
+    ? nsfwLevelFromContentRating(derivedRating) > nsfwLevelFromContentRating(appRating)
+      ? derivedRating
+      : appRating ?? derivedRating
+    : isOnsite
+    ? appRating ?? derivedRating
+    : derivedRating;
   const selectedRating: OffsiteContentRating = ratingOverride ?? defaultRating;
 
   // OAuth-CONNECT sub-kind (PR3): render the requested-scope panel + the sensitive-
@@ -572,7 +595,9 @@ export function OffsiteReviewModalBody({
     <Stack gap="md">
       {isOnsite && (
         <Text size="xs" c="dimmed" data-testid="apps-offsite-onsite-note">
-          {`Listing media update — the ${EMBEDDED_KIND_LABEL} app’s media (icon / cover / screenshots) changed. Content-only review; the media must not exceed the app’s rating.`}
+          {isOnsiteRepublishReview
+            ? `Republish review — the owner unpublished this ${EMBEDDED_KIND_LABEL} app’s listing, changed its store imagery and asked for it back. Content review of the icon / cover / screenshots below. Approving RAISES the app’s rating if the imagery is more mature; it never lowers it.`
+            : `Listing media update — the ${EMBEDDED_KIND_LABEL} app’s media (icon / cover / screenshots) changed. Content-only review; the media must not exceed the app’s rating.`}
         </Text>
       )}
       <Group gap="xs">
@@ -640,7 +665,11 @@ export function OffsiteReviewModalBody({
                   {offsiteContentRatingLabel(request.appListing.contentRating)}
                 </Badge>
                 <Text size="xs" c="dimmed">
-                  {isOnsite ? 'app rating (cap)' : 'declared'}
+                  {isOnsiteRepublishReview
+                    ? 'app rating (floor)'
+                    : isOnsite
+                    ? 'app rating (cap)'
+                    : 'declared'}
                 </Text>
               </Group>
             )}
@@ -786,7 +815,14 @@ export function OffsiteReviewModalBody({
           icon={<IconAlertTriangle size={16} />}
           data-testid="apps-offsite-rating-mismatch"
         >
-          {isOnsite ? (
+          {isOnsiteRepublishReview ? (
+            <Text size="sm">
+              Store imagery is rated higher ({offsiteContentRatingLabel(derivedRating)}) than the
+              app’s rating ({declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}).
+              Approving RAISES the app to the detected rating — it is a floor here, not a cap. If
+              the app itself is not that mature, reject and ask the owner to change the imagery.
+            </Text>
+          ) : isOnsite ? (
             <Text size="sm">
               Media assets are rated higher ({offsiteContentRatingLabel(derivedRating)}) than the
               app’s rating ({declaredRating ? offsiteContentRatingLabel(declaredRating) : '—'}).
@@ -842,7 +878,9 @@ export function OffsiteReviewModalBody({
             <Select
               label="Final content rating"
               description={
-                isOnsite
+                isOnsiteRepublishReview
+                  ? 'Defaults to the higher of the app’s rating and the rating detected from the imagery. You may rate up; a lower choice is ignored — the server floors this at the app’s own rating and raises it to the detected value.'
+                  : isOnsite
                   ? 'Defaults to the app’s rating (the cap). Listing media must not exceed the app’s rating; assets rated higher are a reject reason.'
                   : 'Defaults to the rating detected from the assets. You may rate up; an under-rating is floored to the detected value on save.'
               }

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -39,10 +39,12 @@ vi.mock('~/utils/trpc', () => {
   // notification paths run.
   const mutation =
     (name: string) =>
-    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+    (opts?: { onSuccess?: (data?: unknown) => void; onError?: (e: { message: string }) => void }) => ({
       mutate: (vars: unknown) => {
         mocks.mutate(name, vars);
-        void opts?.onSuccess?.();
+        // Realistic mutation payload — the republish handler derives its message from
+        // the returned `status` (see `republishSuccessMessage`).
+        void opts?.onSuccess?.({ appListingId: 'apl_1', status: 'approved' });
       },
       isPending: false,
     });

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -35,6 +35,7 @@ import {
   OwnerModerationHistoryModal,
   OwnerUnpublishModal,
 } from '~/components/Apps/ownerListingModals';
+import { republishSuccessMessage } from '~/components/Apps/listingPublishingActions';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
 import {
@@ -417,8 +418,11 @@ export function OffsiteSubmissionsList({
   const invalidateSubmissions = () => utils.appListings.listMySubmissions.invalidate();
 
   const republishMutation = trpc.appListings.republishOwnListing.useMutation({
-    onSuccess: async () => {
-      showSuccessNotification({ message: 'App republished — it is live in the store again.' });
+    // 🔴 The message is DERIVED from the server's answer, never assumed: a republish whose
+    // assets changed since the last approval lands in `pending`, not live. See
+    // {@link republishSuccessMessage}.
+    onSuccess: async (data) => {
+      showSuccessNotification({ message: republishSuccessMessage(data, 'offsite') });
       await invalidateSubmissions();
     },
     onError: (e) => showErrorNotification({ title: 'Republish failed', error: new Error(e.message) }),

--- a/src/components/Apps/__tests__/listingPublishingActions.test.ts
+++ b/src/components/Apps/__tests__/listingPublishingActions.test.ts
@@ -7,6 +7,7 @@ import {
   OWNER_ACTIONS_BY_STATE,
   PUBLISHING_PANEL_ACTIONS,
   republishSuccessMessage,
+  withdrawSuccessMessage,
   showModRemovedNotice,
   showRepublish,
   showUnpublish,
@@ -222,14 +223,19 @@ describe('sortPublishingActions', () => {
 describe('republishSuccessMessage — 🔴 the UI must not claim "live" when it went to review', () => {
   it('says the listing is LIVE when the server approved it', () => {
     expect(republishSuccessMessage({ status: 'approved' }, 'onsite')).toContain('live');
-    expect(republishSuccessMessage({ status: 'approved' }, 'offsite')).toContain('live in the store');
+    expect(republishSuccessMessage({ status: 'approved' }, 'offsite')).toContain(
+      'live in the store'
+    );
   });
 
   it('🔴 says REVIEW when the server routed it to pending — for BOTH kinds', () => {
     // The wording is asserted on the PENDING arm for each kind separately: a mutant that
     // branched on `kind` before `status` would still satisfy a single-kind assertion.
     for (const kind of ['onsite', 'offsite'] as const) {
-      const message = republishSuccessMessage({ status: 'pending' }, kind);
+      const message = republishSuccessMessage(
+        { status: 'pending', reviewReason: 'assets-changed' },
+        kind
+      );
       expect(message).toContain('review');
       // 🔴 The load-bearing ABSENCE: the old hardcoded copy said "it is live again", which
       // is a lie on this arm. Pin that the word cannot come back.
@@ -242,4 +248,47 @@ describe('republishSuccessMessage — 🔴 the UI must not claim "live" when it 
       republishSuccessMessage({ status: 'approved' }, 'offsite')
     );
   });
+
+  it('🔴 only `assets-changed` claims the images changed', () => {
+    // The reason exists on the wire; using one sentence for every reason told an owner
+    // their images had changed on a path where nothing about their images necessarily
+    // did. Asserted as an EXCLUSIVE pair, so a mutant that returns the specific sentence
+    // unconditionally fails on the second half.
+    expect(
+      republishSuccessMessage({ status: 'pending', reviewReason: 'assets-changed' })
+    ).toContain('images changed');
+    expect(
+      republishSuccessMessage({ status: 'pending', reviewReason: 'unreadable-baseline' })
+    ).not.toContain('images changed');
+  });
+
+  it('🔴 an UNRECOGNISED reason falls back to the NEUTRAL wording, never the specific one', () => {
+    // A reason added server-side must not silently inherit a factual claim about the
+    // owner's actions that it does not support. `undefined` (an older client, or a server
+    // that omitted the field) takes the same safe branch.
+    for (const reviewReason of ['some-future-reason', undefined, null]) {
+      const message = republishSuccessMessage({ status: 'pending', reviewReason });
+      expect(message).toContain('review');
+      expect(message).not.toContain('images changed');
+    }
+  });
+});
+
+describe('withdrawSuccessMessage — 🔴 a one-way close must SAY it is one-way', () => {
+  it('🔴 a `removed` close tells the owner a moderator has to restore it', () => {
+    const message = withdrawSuccessMessage('removed');
+    expect(message).toContain('off the store');
+    expect(message).toContain('moderator');
+  });
+
+  it.each([['deleted'], ['none'], [undefined], [null]])(
+    'every other outcome (%s) keeps the plain wording — no moderator claim',
+    (outcome) => {
+      // The exclusive half. Without it a mutant returning the scary sentence
+      // unconditionally would pass the case above, and every draft withdraw would tell
+      // its author to go find a moderator for no reason.
+      const message = withdrawSuccessMessage(outcome);
+      expect(message).toBe('Submission withdrawn.');
+    }
+  );
 });

--- a/src/components/Apps/__tests__/listingPublishingActions.test.ts
+++ b/src/components/Apps/__tests__/listingPublishingActions.test.ts
@@ -6,6 +6,7 @@ import {
   listingPublishingActions,
   OWNER_ACTIONS_BY_STATE,
   PUBLISHING_PANEL_ACTIONS,
+  republishSuccessMessage,
   showModRemovedNotice,
   showRepublish,
   showUnpublish,
@@ -215,5 +216,30 @@ describe('sortPublishingActions', () => {
       'republish',
       'zz-new',
     ]);
+  });
+});
+
+describe('republishSuccessMessage — 🔴 the UI must not claim "live" when it went to review', () => {
+  it('says the listing is LIVE when the server approved it', () => {
+    expect(republishSuccessMessage({ status: 'approved' }, 'onsite')).toContain('live');
+    expect(republishSuccessMessage({ status: 'approved' }, 'offsite')).toContain('live in the store');
+  });
+
+  it('🔴 says REVIEW when the server routed it to pending — for BOTH kinds', () => {
+    // The wording is asserted on the PENDING arm for each kind separately: a mutant that
+    // branched on `kind` before `status` would still satisfy a single-kind assertion.
+    for (const kind of ['onsite', 'offsite'] as const) {
+      const message = republishSuccessMessage({ status: 'pending' }, kind);
+      expect(message).toContain('review');
+      // 🔴 The load-bearing ABSENCE: the old hardcoded copy said "it is live again", which
+      // is a lie on this arm. Pin that the word cannot come back.
+      expect(message).not.toContain('live');
+    }
+  });
+
+  it('the two arms produce DIFFERENT text (a mutant returning one constant cannot pass)', () => {
+    expect(republishSuccessMessage({ status: 'pending' }, 'offsite')).not.toBe(
+      republishSuccessMessage({ status: 'approved' }, 'offsite')
+    );
   });
 });

--- a/src/components/Apps/listingPublishingActions.ts
+++ b/src/components/Apps/listingPublishingActions.ts
@@ -186,3 +186,30 @@ export function showRepublish(row: PublishingActionRow): boolean {
 export function showModRemovedNotice(row: PublishingActionRow): boolean {
   return listingOwnerState(row) === 'mod-removed';
 }
+
+/**
+ * The message to show an owner after a successful `republishOwnListing`.
+ *
+ * 🔴 ONE SPELLING, because "republish" now has TWO successful outcomes and three surfaces
+ * announce it. The server routes a republish to `pending` (re-review) instead of
+ * `approved` whenever the listing's assets changed since the last approval — see
+ * `republishOwnListing` in `offsite-moderation.service.ts`. All three call sites
+ * previously hardcoded "it is live again", which is FALSE on that arm and is exactly the
+ * kind of claim that survives a review because the mutation genuinely succeeded. Reading
+ * the returned `status` in one place is what makes the wrong message impossible to write
+ * by copying the neighbouring component.
+ *
+ * `kind` only changes the wording of the LIVE arm (an on-site app comes back online; an
+ * off-site listing returns to the store), matching what the three surfaces already said.
+ */
+export function republishSuccessMessage(
+  result: { status: 'approved' | 'pending' },
+  kind?: 'onsite' | 'offsite' | string | null
+): string {
+  if (result.status === 'pending') {
+    return 'Submitted for review — your listing images changed since it was last approved, so a moderator needs to take another look before it goes back up.';
+  }
+  return kind === 'offsite'
+    ? 'App republished — it is live in the store again.'
+    : 'App republished — it is live again.';
+}

--- a/src/components/Apps/listingPublishingActions.ts
+++ b/src/components/Apps/listingPublishingActions.ts
@@ -192,24 +192,57 @@ export function showModRemovedNotice(row: PublishingActionRow): boolean {
  *
  * 🔴 ONE SPELLING, because "republish" now has TWO successful outcomes and three surfaces
  * announce it. The server routes a republish to `pending` (re-review) instead of
- * `approved` whenever the listing's assets changed since the last approval — see
- * `republishOwnListing` in `offsite-moderation.service.ts`. All three call sites
- * previously hardcoded "it is live again", which is FALSE on that arm and is exactly the
- * kind of claim that survives a review because the mutation genuinely succeeded. Reading
- * the returned `status` in one place is what makes the wrong message impossible to write
- * by copying the neighbouring component.
+ * `approved` when the listing's assets differ from the ones recorded at its last
+ * approval — see `republishOwnListing` in `offsite-moderation.service.ts`. All three call
+ * sites previously hardcoded "it is live again", which is FALSE on that arm and is exactly
+ * the kind of claim that survives a review because the mutation genuinely succeeded.
+ * Reading the returned `status` in one place is what makes the wrong message impossible to
+ * write by copying the neighbouring component.
+ *
+ * 🔴 AND THE REVIEW ARM HAS MORE THAN ONE REASON, so it must not have one message. The
+ * server returns `reviewReason` alongside `status`; `'assets-changed'` is the case the
+ * feature exists for, but `'unreadable-baseline'` fires when the recorded comparison point
+ * cannot be read — nothing about the owner's images necessarily changed, and telling them
+ * "your listing images changed" would be a flat assertion about their own actions that we
+ * have no evidence for. An unrecognised reason falls back to the neutral wording rather
+ * than to the specific one, so a reason added server-side can never silently inherit a
+ * claim it does not support.
  *
  * `kind` only changes the wording of the LIVE arm (an on-site app comes back online; an
  * off-site listing returns to the store), matching what the three surfaces already said.
  */
 export function republishSuccessMessage(
-  result: { status: 'approved' | 'pending' },
+  result: { status: 'approved' | 'pending'; reviewReason?: string | null },
   kind?: 'onsite' | 'offsite' | string | null
 ): string {
   if (result.status === 'pending') {
-    return 'Submitted for review — your listing images changed since it was last approved, so a moderator needs to take another look before it goes back up.';
+    return result.reviewReason === 'assets-changed'
+      ? 'Submitted for review — your listing images changed since they were last approved, so a moderator needs to take another look before it goes back up.'
+      : 'Submitted for review — we could not confirm your listing images against the last approved version, so a moderator needs to take another look before it goes back up.';
   }
   return kind === 'offsite'
     ? 'App republished — it is live in the store again.'
     : 'App republished — it is live again.';
+}
+
+/**
+ * The message to show after a successful `withdrawExternalRequest`.
+ *
+ * 🔴 A PURE FUNCTION RATHER THAN A TERNARY IN THE PANEL, so this branch is covered by the
+ * BLOCKING node `unit` project — the browser-mode component suites are report-only, and
+ * this particular claim is the one that matters most to get right.
+ *
+ * 🔴 THE TWO OUTCOMES ARE NOT EQUALLY REVERSIBLE, and one sentence covered both.
+ * `'deleted'` discards a draft. `'removed'` closes the review of a formerly-LIVE listing:
+ * the server writes a `delist` event, which `republishOwnListing`'s guard reads as a
+ * MODERATOR takedown — so the owner cannot put the listing back and must ask a moderator.
+ * That is deliberate (it closes a self-restore exploit), which is exactly why the owner
+ * has to be told, rather than discovering it as a "removed by a moderator" state they
+ * caused themselves. `'none'` means this call changed nothing (already withdrawn, or it
+ * lost the race), so it must not narrate someone else's close.
+ */
+export function withdrawSuccessMessage(outcome?: string | null): string {
+  return outcome === 'removed'
+    ? 'Submission withdrawn — your listing is off the store. Ask a moderator to restore it when you are ready.'
+    : 'Submission withdrawn.';
 }

--- a/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+import type { WithdrawExternalRequestResult } from '~/server/services/blocks/offsite-listing.service';
 
 /**
  * W13 P3a — off-site submission router AUTHZ matrix.
@@ -42,7 +43,10 @@ const {
   // Returns the real service shape: the close OUTCOME, which the router now passes
   // through so the UI can distinguish "a draft was discarded" from "your live listing is
   // now delisted and only a moderator can restore it".
-  mockWithdraw: vi.fn(async () => ({ outcome: 'none' as const })),
+  // Typed with the SERVICE's own result type, not a narrowed literal: the router
+  // must be free to receive any `CloseTerminalListingOutcome`, and a mock pinned to
+  // `'none'` would make the `'removed'` pass-through case below untypeable.
+  mockWithdraw: vi.fn(async (): Promise<WithdrawExternalRequestResult> => ({ outcome: 'none' })),
   mockListMy: vi.fn(async () => ({ items: [], nextCursor: null })),
   mockListPending: vi.fn(async () => ({ items: [{ id: 'alpr_1' }], nextCursor: null })),
   mockListApproved: vi.fn(async () => ({ items: [], nextCursor: null })),

--- a/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
@@ -39,7 +39,10 @@ const {
   mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => ({
   mockSubmit: vi.fn(async () => ({ listingId: 'apl_1', publishRequestId: 'alpr_1', slug: 's' })),
-  mockWithdraw: vi.fn(async () => undefined),
+  // Returns the real service shape: the close OUTCOME, which the router now passes
+  // through so the UI can distinguish "a draft was discarded" from "your live listing is
+  // now delisted and only a moderator can restore it".
+  mockWithdraw: vi.fn(async () => ({ outcome: 'none' as const })),
   mockListMy: vi.fn(async () => ({ items: [], nextCursor: null })),
   mockListPending: vi.fn(async () => ({ items: [{ id: 'alpr_1' }], nextCursor: null })),
   mockListApproved: vi.fn(async () => ({ items: [], nextCursor: null })),
@@ -85,8 +88,7 @@ vi.mock('~/server/services/feature-flags.service', async () => {
   return {
     ...actual,
     getFeatureFlags: (ctx: { user?: { id?: number; isModerator?: boolean } }) => ({
-      appBlocksAuthor:
-        !!ctx.user && (!!ctx.user.isModerator || AUTHOR_IDS.has(ctx.user.id ?? -1)),
+      appBlocksAuthor: !!ctx.user && (!!ctx.user.isModerator || AUTHOR_IDS.has(ctx.user.id ?? -1)),
     }),
   };
 });
@@ -199,8 +201,21 @@ describe('withdrawExternalRequest — appDeveloperProcedure', () => {
     expect(mockWithdraw).toHaveBeenCalledWith({ publishRequestId: 'alpr_1', userId: tester.id });
   });
 
+  it('🔴 passes the close OUTCOME through, rather than collapsing it into `{ ok: true }`', async () => {
+    // `'removed'` means this withdraw delisted a formerly-live listing that only a
+    // moderator can restore. The UI cannot warn about that if the router swallows it.
+    mockWithdraw.mockResolvedValueOnce({ outcome: 'removed' as const });
+    const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+    await expect(caller.withdrawExternalRequest({ publishRequestId: 'alpr_1' })).resolves.toEqual({
+      ok: true,
+      outcome: 'removed',
+    });
+  });
+
   it('a service failure maps to BAD_REQUEST with the message', async () => {
-    mockWithdraw.mockRejectedValueOnce(new Error('you can only withdraw your own publish requests'));
+    mockWithdraw.mockRejectedValueOnce(
+      new Error('you can only withdraw your own publish requests')
+    );
     const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
     await expect(
       caller.withdrawExternalRequest({ publishRequestId: 'alpr_x' })
@@ -251,7 +266,11 @@ describe('persistAssetImage — appDeveloperProcedure (asset-step glue)', () => 
 // ---------------------------------------------------------------------------
 
 describe('review-queue lists — moderatorProcedure', () => {
-  for (const proc of ['listPendingRequests', 'listApprovedRequests', 'listRejectedRequests'] as const) {
+  for (const proc of [
+    'listPendingRequests',
+    'listApprovedRequests',
+    'listRejectedRequests',
+  ] as const) {
     it(`${proc}: a non-mod AUTHOR (tester) is FORBIDDEN`, async () => {
       const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
       await expect(caller[proc]({})).rejects.toBeInstanceOf(TRPCError);
@@ -411,29 +430,33 @@ describe('rejectExternalRequest — moderatorProcedure', () => {
 describe('setIcon — widened author flag gate + service owner check', () => {
   it('non-author (author flag off) → UNAUTHORIZED, service NOT called', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(nonAuthor) as never);
-    await expect(
-      caller.setIcon({ listingId: 'own-3', imageId: 5 })
-    ).rejects.toBeInstanceOf(TRPCError);
+    await expect(caller.setIcon({ listingId: 'own-3', imageId: 5 })).rejects.toBeInstanceOf(
+      TRPCError
+    );
     expect(mockSetIcon).not.toHaveBeenCalled();
   });
 
   it('app-dev-tester CAN attach to their OWN listing', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
     // listingId `own-2` is owned by the tester (id 2).
-    await expect(caller.setIcon({ listingId: 'own-2', imageId: 5 })).resolves.toEqual({ iconId: 5 });
+    await expect(caller.setIcon({ listingId: 'own-2', imageId: 5 })).resolves.toEqual({
+      iconId: 5,
+    });
     expect(mockSetIcon).toHaveBeenCalledWith({ listingId: 'own-2', imageId: 5 }, tester);
   });
 
   it('app-dev-tester CANNOT attach to ANOTHER user’s listing (owner check → FORBIDDEN)', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
     // listingId `other-99` is owned by user 99, not the tester.
-    await expect(
-      caller.setIcon({ listingId: 'other-99', imageId: 5 })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(caller.setIcon({ listingId: 'other-99', imageId: 5 })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
   });
 
   it('moderator (author floor) can attach as well', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
-    await expect(caller.setIcon({ listingId: 'own-1', imageId: 5 })).resolves.toEqual({ iconId: 5 });
+    await expect(caller.setIcon({ listingId: 'own-1', imageId: 5 })).resolves.toEqual({
+      iconId: 5,
+    });
   });
 });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -650,11 +650,12 @@ export const appListingsRouter = router({
       const { withdrawExternalRequest } = await import(
         '~/server/services/blocks/offsite-listing.service'
       );
+      let outcome;
       try {
-        await withdrawExternalRequest({
+        ({ outcome } = await withdrawExternalRequest({
           publishRequestId: input.publishRequestId,
           userId: ctx.user.id,
-        });
+        }));
       } catch (err) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -662,7 +663,11 @@ export const appListingsRouter = router({
           cause: err,
         });
       }
-      return { ok: true };
+      // 🔴 `outcome` is NOT decoration. `'removed'` means this withdraw closed the review
+      // of a formerly-LIVE listing, which leaves it delisted and only a moderator can put
+      // it back; `'deleted'` merely discarded a draft. The UI must be able to say which,
+      // so it is returned rather than collapsed into `{ ok: true }`.
+      return { ok: true, outcome };
     }),
 
   /**

--- a/src/server/services/blocks/__tests__/app-listing-approved-assets.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-approved-assets.test.ts
@@ -7,7 +7,7 @@ import {
   buildApprovedAssetSnapshot,
   normalizeListingScreenshots,
   parseApprovedAssetSnapshot,
-  readRecordedAssetSnapshot,
+  readRecordedAssetBaseline,
   resolveRepublishReviewReason,
 } from '~/server/services/blocks/app-listing-approved-assets';
 
@@ -174,14 +174,14 @@ describe('parseApprovedAssetSnapshot — 🔴 unknown must never round-trip as e
   });
 });
 
-describe('readRecordedAssetSnapshot', () => {
+describe('readRecordedAssetBaseline — 🔴 absent and unreadable are DIFFERENT answers', () => {
   it('pulls the snapshot out of an event `before` payload', () => {
     expect(
-      readRecordedAssetSnapshot({
+      readRecordedAssetBaseline({
         status: 'approved',
         assets: { v: 1, iconId: 3, coverId: null, screenshots: [] },
       })
-    ).toEqual(snap({ iconId: 3 }));
+    ).toEqual({ kind: 'snapshot', snapshot: snap({ iconId: 3 }) });
   });
 
   it.each([
@@ -189,8 +189,30 @@ describe('readRecordedAssetSnapshot', () => {
     ['no payload at all', null],
     ['an undefined payload', undefined],
     ['a non-object payload', 'approved'],
-  ])('returns null for %s', (_label, before) => {
-    expect(readRecordedAssetSnapshot(before as never)).toBeNull();
+    ['an ARRAY payload', [{ v: 1 }]],
+  ])('reports ABSENT for %s — nothing was ever recorded', (_label, before) => {
+    expect(readRecordedAssetBaseline(before as never)).toEqual({ kind: 'absent' });
+  });
+
+  it.each([
+    ['an explicit null baseline', null],
+    ['a number where a snapshot should be', 7],
+    ['a snapshot from an UNKNOWN future version', { v: 2, iconId: 1, coverId: 2, screenshots: [] }],
+    ['a snapshot with a malformed screenshot', { v: 1, iconId: 1, coverId: 2, screenshots: [{}] }],
+    ['a snapshot missing `screenshots`', { v: 1, iconId: 1, coverId: 2 }],
+  ])('reports UNREADABLE for %s — a baseline was written and cannot be read', (_label, assets) => {
+    expect(readRecordedAssetBaseline({ status: 'approved', assets } as never)).toEqual({
+      kind: 'unreadable',
+    });
+  });
+
+  it('🔴 the two absences are NOT interchangeable', () => {
+    // The whole reason this function returns three things instead of `Snapshot | null`.
+    // A caller that collapses them either sweeps the entire pre-feature population into
+    // review, or silently disarms the gate the first time a payload goes bad.
+    expect(readRecordedAssetBaseline({ status: 'approved' } as never)).not.toEqual(
+      readRecordedAssetBaseline({ status: 'approved', assets: null } as never)
+    );
   });
 });
 
@@ -228,24 +250,41 @@ describe('approvedAssetSnapshotsEqual', () => {
 
 describe('resolveRepublishReviewReason — 🔴 the gate itself', () => {
   const live = snap({ iconId: 1, coverId: 2, screenshots: [{ imageId: 3, caption: null }] });
+  const recorded = (snapshot: ReturnType<typeof snap>) => ({ kind: 'snapshot' as const, snapshot });
 
   it('recorded === live ⇒ null (republish stays IMMEDIATE)', () => {
-    expect(resolveRepublishReviewReason(snap({ ...live }), live)).toBeNull();
+    expect(resolveRepublishReviewReason(recorded(snap({ ...live })), live)).toBeNull();
   });
 
   it('recorded !== live ⇒ assets-changed', () => {
-    expect(resolveRepublishReviewReason(snap({ ...live, iconId: 42 }), live)).toBe(
+    expect(resolveRepublishReviewReason(recorded(snap({ ...live, iconId: 42 })), live)).toBe(
       'assets-changed'
     );
   });
 
-  it('🔴 NO recorded baseline ⇒ no-recorded-assets, NOT null — absence is MISSING, not SAME', () => {
-    expect(resolveRepublishReviewReason(null, live)).toBe('no-recorded-assets');
+  it('🔴 an UNREADABLE baseline ⇒ review — a broken comparison point is not a pass', () => {
+    expect(resolveRepublishReviewReason({ kind: 'unreadable' }, live)).toBe('unreadable-baseline');
   });
 
-  it('🔴 NO recorded baseline against an ASSET-LESS listing still ⇒ review', () => {
+  it('🔴 an UNREADABLE baseline reviews even when the listing has NO assets', () => {
     // The case a coercing parser would get wrong: an empty snapshot compares EQUAL to a
-    // listing with no assets, so "unknown" would silently become "unchanged".
-    expect(resolveRepublishReviewReason(null, snap())).toBe('no-recorded-assets');
+    // listing with no assets, so "cannot read it" would silently become "unchanged".
+    expect(resolveRepublishReviewReason({ kind: 'unreadable' }, snap())).toBe(
+      'unreadable-baseline'
+    );
+  });
+
+  it('🔴 an ABSENT baseline ⇒ null — republish is IMMEDIATE, exactly as before the gate', () => {
+    // Deliberately fail-OPEN, and the ONLY arm that is. Nothing was ever recorded for
+    // this listing, so there is no change to show a moderator — routing it to review buys
+    // no review, and costs every already-removed listing its way back. Bounded and
+    // shrinking: only listings unpublished before the recording shipped land here.
+    expect(resolveRepublishReviewReason({ kind: 'absent' }, live)).toBeNull();
+  });
+
+  it('🔴 ABSENT and UNREADABLE do not share a verdict', () => {
+    expect(resolveRepublishReviewReason({ kind: 'absent' }, live)).not.toBe(
+      resolveRepublishReviewReason({ kind: 'unreadable' }, live)
+    );
   });
 });

--- a/src/server/services/blocks/__tests__/app-listing-approved-assets.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-approved-assets.test.ts
@@ -106,7 +106,12 @@ describe('normalizeListingScreenshots', () => {
 
 describe('buildApprovedAssetSnapshot', () => {
   it('reads the screenshots and takes icon/cover from the ALREADY-LOADED listing row', async () => {
-    const findMany = vi.fn(async () => [{ imageId: 5, order: 0, caption: 'shot' }]);
+    // Declared with the argument the real `appListingScreenshot.findMany` receives, so
+    // the `mock.calls[0][0]` assertion below is typed against a real parameter rather
+    // than an empty tuple.
+    const findMany = vi.fn(async (_args: { where: { appListingId: string } }) => [
+      { imageId: 5, order: 0, caption: 'shot' },
+    ]);
     const snapshot = await buildApprovedAssetSnapshot(
       { appListingScreenshot: { findMany } } as never,
       'apl_1',

--- a/src/server/services/blocks/__tests__/app-listing-approved-assets.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-approved-assets.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  APPROVED_ASSET_SNAPSHOT_VERSION,
+  type ApprovedAssetSnapshot,
+  approvedAssetSnapshotsEqual,
+  buildApprovedAssetSnapshot,
+  normalizeListingScreenshots,
+  parseApprovedAssetSnapshot,
+  readRecordedAssetSnapshot,
+  resolveRepublishReviewReason,
+} from '~/server/services/blocks/app-listing-approved-assets';
+
+/**
+ * The approved-asset baseline: build it, round-trip it through JSONB, compare it, and —
+ * the load-bearing half — REFUSE to compare when there is nothing to compare against.
+ *
+ * 🔴 Every "unknown ⇒ review" case here exists because the opposite default is invisible.
+ * A parser that coerced a malformed payload into `{iconId:null, coverId:null,
+ * screenshots:[]}` would compare EQUAL to any listing with no assets and unequal to every
+ * other — i.e. it would look like it worked, in both directions, while measuring nothing.
+ */
+
+const snap = (over: Partial<ApprovedAssetSnapshot> = {}): ApprovedAssetSnapshot => ({
+  v: APPROVED_ASSET_SNAPSHOT_VERSION,
+  iconId: null,
+  coverId: null,
+  screenshots: [],
+  ...over,
+});
+
+describe('normalizeListingScreenshots', () => {
+  it('orders by `order` and keeps imageId + caption, dropping the order value itself', () => {
+    expect(
+      normalizeListingScreenshots([
+        { imageId: 30, order: 2, caption: 'third' },
+        { imageId: 10, order: 0, caption: 'first' },
+        { imageId: 20, order: 1, caption: null },
+      ])
+    ).toEqual([
+      { imageId: 10, caption: 'first' },
+      { imageId: 20, caption: null },
+      { imageId: 30, caption: 'third' },
+    ]);
+  });
+
+  it('🔴 RENUMBERING the same sequence is NOT a change (the order VALUE is not recorded)', () => {
+    // 0,1,2 → 10,20,30 with the same relative order. A snapshot that stored the raw
+    // `order` column would report a change no viewer can see and force a needless review.
+    const a = normalizeListingScreenshots([
+      { imageId: 10, order: 0, caption: null },
+      { imageId: 20, order: 1, caption: null },
+    ]);
+    const b = normalizeListingScreenshots([
+      { imageId: 10, order: 10, caption: null },
+      { imageId: 20, order: 20, caption: null },
+    ]);
+    expect(a).toEqual(b);
+  });
+
+  it('🔴 genuinely SWAPPING two screenshots IS a change', () => {
+    const a = normalizeListingScreenshots([
+      { imageId: 10, order: 0, caption: null },
+      { imageId: 20, order: 1, caption: null },
+    ]);
+    const b = normalizeListingScreenshots([
+      { imageId: 10, order: 1, caption: null },
+      { imageId: 20, order: 0, caption: null },
+    ]);
+    expect(a).not.toEqual(b);
+  });
+
+  it('drops rows with no imageId (they display nothing) but keeps every real one', () => {
+    // Positive control on the same call: the filter is not simply eating everything.
+    expect(
+      normalizeListingScreenshots([
+        { imageId: null, order: 0, caption: 'orphan' },
+        { imageId: 7, order: 1, caption: 'real' },
+      ])
+    ).toEqual([{ imageId: 7, caption: 'real' }]);
+  });
+
+  it('normalises blank captions: null, empty and whitespace-only all compare equal', () => {
+    const [a, b, c] = [null, '', '   '].map(
+      (caption) => normalizeListingScreenshots([{ imageId: 1, order: 0, caption }])[0]
+    );
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+    expect(a.caption).toBeNull();
+    // …but a REAL caption survives, so the normalisation is not just erasing the field.
+    expect(
+      normalizeListingScreenshots([{ imageId: 1, order: 0, caption: '  hello  ' }])[0].caption
+    ).toBe('hello');
+  });
+
+  it('is deterministic when two rows share an `order` (the sort is total)', () => {
+    const rows = [
+      { imageId: 22, order: 0, caption: null },
+      { imageId: 11, order: 0, caption: null },
+    ];
+    expect(normalizeListingScreenshots(rows)).toEqual(
+      normalizeListingScreenshots([...rows].reverse())
+    );
+  });
+});
+
+describe('buildApprovedAssetSnapshot', () => {
+  it('reads the screenshots and takes icon/cover from the ALREADY-LOADED listing row', async () => {
+    const findMany = vi.fn(async () => [{ imageId: 5, order: 0, caption: 'shot' }]);
+    const snapshot = await buildApprovedAssetSnapshot(
+      { appListingScreenshot: { findMany } } as never,
+      'apl_1',
+      { iconId: 1, coverId: 2 }
+    );
+    expect(snapshot).toEqual(
+      snap({ iconId: 1, coverId: 2, screenshots: [{ imageId: 5, caption: 'shot' }] })
+    );
+    // Scoped to THIS listing — asserted on the actual argument, not "was it ever called".
+    expect(findMany.mock.calls[0][0]).toMatchObject({ where: { appListingId: 'apl_1' } });
+  });
+
+  it('coerces an undefined icon/cover to null rather than leaking undefined into JSONB', async () => {
+    const snapshot = await buildApprovedAssetSnapshot(
+      { appListingScreenshot: { findMany: vi.fn(async () => []) } } as never,
+      'apl_1',
+      { iconId: undefined, coverId: undefined }
+    );
+    expect(snapshot).toEqual(snap());
+  });
+});
+
+describe('parseApprovedAssetSnapshot — 🔴 unknown must never round-trip as empty', () => {
+  it('parses a well-formed payload', () => {
+    const value = { v: 1, iconId: 1, coverId: null, screenshots: [{ imageId: 9, caption: 'x' }] };
+    expect(parseApprovedAssetSnapshot(value)).toEqual(
+      snap({ iconId: 1, coverId: null, screenshots: [{ imageId: 9, caption: 'x' }] })
+    );
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', 'nope'],
+    ['a number', 7],
+    ['an array', [{ v: 1 }]],
+    ['no version', { iconId: null, coverId: null, screenshots: [] }],
+    ['a FUTURE version', { v: 2, iconId: null, coverId: null, screenshots: [] }],
+    ['a string version', { v: '1', iconId: null, coverId: null, screenshots: [] }],
+    ['a string iconId', { v: 1, iconId: '1', coverId: null, screenshots: [] }],
+    ['a float iconId', { v: 1, iconId: 1.5, coverId: null, screenshots: [] }],
+    ['an undefined coverId', { v: 1, iconId: null, screenshots: [] }],
+    ['screenshots not an array', { v: 1, iconId: null, coverId: null, screenshots: {} }],
+    ['a screenshot with no imageId', { v: 1, iconId: null, coverId: null, screenshots: [{}] }],
+    // 🔴 THE NEXT TWO ISOLATE THE imageId GUARD. `{}` above does NOT: its `caption` is
+    // `undefined`, so the CAPTION guard one line later rejects it first and the imageId
+    // guard never executes — a mutant that deletes the imageId check survives that case
+    // while the suite stays green (measured: it did). These carry a VALID caption, so
+    // nothing else can reject them and only the imageId guard can.
+    [
+      'a screenshot whose imageId is a string, with a valid caption',
+      { v: 1, iconId: null, coverId: null, screenshots: [{ imageId: '9', caption: null }] },
+    ],
+    [
+      'a screenshot whose imageId is a float, with a valid caption',
+      { v: 1, iconId: null, coverId: null, screenshots: [{ imageId: 9.5, caption: 'ok' }] },
+    ],
+    [
+      'a screenshot with a bad caption',
+      { v: 1, iconId: null, coverId: null, screenshots: [{ imageId: 1, caption: 5 }] },
+    ],
+    ['a null screenshot entry', { v: 1, iconId: null, coverId: null, screenshots: [null] }],
+  ])('returns null (UNKNOWN, not empty) for %s', (_label, value) => {
+    expect(parseApprovedAssetSnapshot(value)).toBeNull();
+  });
+});
+
+describe('readRecordedAssetSnapshot', () => {
+  it('pulls the snapshot out of an event `before` payload', () => {
+    expect(
+      readRecordedAssetSnapshot({
+        status: 'approved',
+        assets: { v: 1, iconId: 3, coverId: null, screenshots: [] },
+      })
+    ).toEqual(snap({ iconId: 3 }));
+  });
+
+  it.each([
+    ['a legacy payload with no `assets` key', { status: 'approved' }],
+    ['no payload at all', null],
+    ['an undefined payload', undefined],
+    ['a non-object payload', 'approved'],
+  ])('returns null for %s', (_label, before) => {
+    expect(readRecordedAssetSnapshot(before as never)).toBeNull();
+  });
+});
+
+describe('approvedAssetSnapshotsEqual', () => {
+  const base = snap({ iconId: 1, coverId: 2, screenshots: [{ imageId: 3, caption: 'a' }] });
+
+  it('equal for an identical surface', () => {
+    expect(approvedAssetSnapshotsEqual(base, snap({ ...base }))).toBe(true);
+  });
+
+  it.each([
+    ['icon swapped', snap({ ...base, iconId: 99 })],
+    ['icon cleared', snap({ ...base, iconId: null })],
+    ['cover swapped', snap({ ...base, coverId: 99 })],
+    ['a screenshot image swapped', snap({ ...base, screenshots: [{ imageId: 99, caption: 'a' }] })],
+    [
+      'a screenshot caption swapped',
+      snap({ ...base, screenshots: [{ imageId: 3, caption: 'b' }] }),
+    ],
+    [
+      'a screenshot added',
+      snap({ ...base, screenshots: [...base.screenshots, { imageId: 4, caption: null }] }),
+    ],
+    ['every screenshot removed', snap({ ...base, screenshots: [] })],
+  ])('NOT equal when %s', (_label, other) => {
+    expect(approvedAssetSnapshotsEqual(base, other)).toBe(false);
+  });
+
+  it('🔴 does not confuse iconId with coverId (a swap of the two is a change)', () => {
+    // The fixture's icon and cover are pairwise DISTINCT, so a mutant comparing iconId
+    // twice (or coverId twice) still has to see this.
+    expect(approvedAssetSnapshotsEqual(base, snap({ ...base, iconId: 2, coverId: 1 }))).toBe(false);
+  });
+});
+
+describe('resolveRepublishReviewReason — 🔴 the gate itself', () => {
+  const live = snap({ iconId: 1, coverId: 2, screenshots: [{ imageId: 3, caption: null }] });
+
+  it('recorded === live ⇒ null (republish stays IMMEDIATE)', () => {
+    expect(resolveRepublishReviewReason(snap({ ...live }), live)).toBeNull();
+  });
+
+  it('recorded !== live ⇒ assets-changed', () => {
+    expect(resolveRepublishReviewReason(snap({ ...live, iconId: 42 }), live)).toBe(
+      'assets-changed'
+    );
+  });
+
+  it('🔴 NO recorded baseline ⇒ no-recorded-assets, NOT null — absence is MISSING, not SAME', () => {
+    expect(resolveRepublishReviewReason(null, live)).toBe('no-recorded-assets');
+  });
+
+  it('🔴 NO recorded baseline against an ASSET-LESS listing still ⇒ review', () => {
+    // The case a coercing parser would get wrong: an empty snapshot compares EQUAL to a
+    // listing with no assets, so "unknown" would silently become "unchanged".
+    expect(resolveRepublishReviewReason(null, snap())).toBe('no-recorded-assets');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-owner-unpublish.test.ts
@@ -166,7 +166,7 @@ describe('LISTING_STATUS_CHANGING_MODERATION_ACTIONS', () => {
 });
 
 describe('readLastModerationAction', () => {
-  it('🔴 orders newest-first with the id tiebreak and selects only `action`', async () => {
+  it('🔴 orders newest-first with the id tiebreak and selects `action` + `before`', async () => {
     // `createdAt` alone is not a total order — two events written in one transaction
     // share a timestamp, and without the id tiebreak "most recent" is whichever row the
     // planner returned first, which flips an owner capability on and off at random.
@@ -180,7 +180,11 @@ describe('readLastModerationAction', () => {
         action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
       },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-      select: { action: true },
+      // `before` rides along because the owner-republish asset-review gate needs the verb
+      // and the payload to come from the SAME row — see
+      // `readLastStatusChangingModerationEvent`. Reading them in two queries would let a
+      // concurrent write pair one event's verb with another's payload.
+      select: { action: true, before: true },
     });
   });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-listing-approve.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-listing-approve.service.test.ts
@@ -113,7 +113,7 @@ function wire(
 /** The `data` of the guarded listing flip → approved. */
 function flipData() {
   const call = mockWrite.appListing.updateMany.mock.calls.find(
-    (c: [{ data?: { status?: string } }]) => c[0]?.data?.status === 'approved'
+    (c: { data?: { status?: string } }[]) => c[0]?.data?.status === 'approved'
   );
   return call?.[0]?.data;
 }

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-listing-approve.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-listing-approve.service.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NsfwLevel } from '~/server/common/enums';
+import { approveExternalRequest } from '~/server/services/blocks/offsite-listing.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * 🔴 APPROVING A NON-SHADOW **ON-SITE** LISTING REQUEST — a shape that did not exist
+ * before the owner-republish asset-review route.
+ *
+ * Every other on-site `AppListingPublishRequest` is a media REVISION: its listing carries
+ * `revisionOfId`, so `approveExternalRequest` returns early into `applyApprovedRevision`
+ * and the main approve path never sees `kind: 'onsite'`. The republish review arm mints
+ * the first non-shadow one, which lands on that main path — so the two on-site behaviours
+ * asserted here are NEW CODE on a NEWLY REACHABLE branch, not tweaks to an existing flow:
+ *
+ *   1. THE RATING IS RAISE-ONLY OVER THE APP'S OWN DECLARATION. Off-site, the rating IS
+ *      the assets, so the derived value REPLACES the stored one. On-site it describes the
+ *      APP (manifest-declared) and the store art is a strictly smaller surface, so
+ *      replacing it would LOWER a `pg13` app to `g` because its icon happens to be tame.
+ *   2. THE BACKING BLOCK IS UN-SUSPENDED. `AppBlock.status` is the only gate on whether a
+ *      hosted app serves. The review arm deliberately leaves it `suspended`, so approving
+ *      only the listing would put a store card live pointing at a dead app.
+ *
+ * DB deps come from the canonical `dbMock` — no real Prisma.
+ */
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn(async () => undefined) }));
+
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: mockNotify,
+}));
+
+const mockRead = dbMock.dbRead;
+const mockWrite = dbMock.dbWrite;
+
+const MOD = 7;
+const OWNER = 42;
+const REQUEST_ID = 'alpr_onsite';
+const LISTING_ID = 'apl_onsite';
+const BLOCK_ID = 'apb_backing';
+const SLUG = 'cool-app';
+
+/** Pairwise-DISTINCT image ids, so a mutant that reads the wrong field cannot pass. */
+const ICON_ID = 11;
+const COVER_ID = 22;
+const SHOT_ID = 33;
+
+/**
+ * Stage an on-site, NON-shadow, pending listing request whose listing is `pending`.
+ *
+ * `declared` is the app's stored `contentRating`; `levels` maps an image id to the
+ * `nsfwLevel` the scanner found, so the two inputs to the rating decision are set
+ * independently and a test can make them disagree in either direction.
+ */
+function wire(
+  opts: {
+    kind?: string;
+    declared?: string | null;
+    levels?: Record<number, number>;
+    appBlockId?: string | null;
+    blockUnsuspendCount?: number;
+  } = {}
+) {
+  const kind = opts.kind ?? 'onsite';
+  const levels = opts.levels ?? {};
+  const listing = {
+    id: LISTING_ID,
+    status: 'pending',
+    // An off-site listing must satisfy the go-live actionability gate (an https
+    // destination); an on-site one carries no URL and the gate is a no-op for it.
+    externalUrl: kind === 'offsite' ? 'https://cool.app' : null,
+    iconId: ICON_ID,
+    coverId: COVER_ID,
+    revisionOfId: null,
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    connectClient: null,
+    userId: OWNER,
+    name: 'Cool App',
+    slug: SLUG,
+    kind,
+    contentRating: opts.declared === undefined ? 'pg13' : opts.declared,
+    appBlockId: opts.appBlockId === undefined ? BLOCK_ID : opts.appBlockId,
+  };
+
+  mockRead.appListingPublishRequest.findUnique.mockReset().mockResolvedValue({
+    id: REQUEST_ID,
+    status: 'pending',
+    kind,
+    slug: SLUG,
+    appListingId: LISTING_ID,
+  });
+  for (const c of [mockRead, mockWrite]) {
+    c.appListing.findUnique.mockReset().mockResolvedValue(listing);
+    c.appListingScreenshot.findMany.mockReset().mockResolvedValue([{ imageId: SHOT_ID }]);
+    c.image.findMany
+      .mockReset()
+      .mockImplementation(async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: 'Scanned',
+          nsfwLevel: levels[id] ?? NsfwLevel.PG,
+        }))
+      );
+  }
+  mockWrite.appBlock.updateMany
+    .mockReset()
+    .mockResolvedValue({ count: opts.blockUnsuspendCount ?? 1 });
+}
+
+/** The `data` of the guarded listing flip → approved. */
+function flipData() {
+  const call = mockWrite.appListing.updateMany.mock.calls.find(
+    (c: [{ data?: { status?: string } }]) => c[0]?.data?.status === 'approved'
+  );
+  return call?.[0]?.data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // `clearAllMocks` clears CALLS, not implementations — every default below is set
+  // explicitly so a value left behind by an earlier test cannot decide a later one.
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  for (const c of [mockRead, mockWrite]) {
+    c.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  }
+  mockWrite.appBlock.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  mockNotify.mockReset().mockResolvedValue(undefined);
+});
+
+describe('approveExternalRequest — ON-SITE rating is RAISE-ONLY over the app declaration', () => {
+  it('🔴 tame store art does NOT lower the app rating (the whole point)', async () => {
+    // A `pg13` app whose icon/cover/screenshot all scan as PG. The off-site rule would
+    // derive `g` and STAMP it, under-rating the runtime because a picture looked tame.
+    wire({
+      declared: 'pg13',
+      levels: { [ICON_ID]: NsfwLevel.PG, [COVER_ID]: NsfwLevel.PG, [SHOT_ID]: NsfwLevel.PG },
+    });
+    await approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'pg13' });
+  });
+
+  it('🔴 mature store art DOES raise it', async () => {
+    wire({
+      declared: 'g',
+      levels: { [ICON_ID]: NsfwLevel.PG, [COVER_ID]: NsfwLevel.X, [SHOT_ID]: NsfwLevel.PG },
+    });
+    await approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'x' });
+  });
+
+  it('a moderator override may raise above the floor', async () => {
+    wire({ declared: 'g', levels: { [ICON_ID]: NsfwLevel.PG } });
+    await approveExternalRequest({
+      publishRequestId: REQUEST_ID,
+      reviewerUserId: MOD,
+      contentRating: 'r',
+    });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'r' });
+  });
+
+  it('🔴 a moderator override may NOT lower it below the app declaration', async () => {
+    wire({ declared: 'r', levels: { [ICON_ID]: NsfwLevel.PG } });
+    await approveExternalRequest({
+      publishRequestId: REQUEST_ID,
+      reviewerUserId: MOD,
+      contentRating: 'g',
+    });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'r' });
+  });
+
+  it('🔴 OFF-SITE is unchanged: the derived rating REPLACES the stored one, up or down', async () => {
+    // The control that makes every assertion above a claim about the on-site BRANCH
+    // rather than about the helper. Same declared rating, same tame media, opposite
+    // answer — so a mutant that took one path for both kinds fails here or above.
+    wire({
+      kind: 'offsite',
+      declared: 'pg13',
+      levels: { [ICON_ID]: NsfwLevel.PG, [COVER_ID]: NsfwLevel.PG, [SHOT_ID]: NsfwLevel.PG },
+    });
+    await approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'g' });
+  });
+});
+
+describe('approveExternalRequest — ON-SITE un-suspends the backing block', () => {
+  it('🔴 restores the runtime, not only the store card', async () => {
+    // `AppBlock.status` is the ONLY gate on whether a hosted app serves, and the review
+    // arm leaves it `suspended` on purpose. Approving only the listing would publish a
+    // store card pointing at a dead app — store-visible and not self-recoverable.
+    wire({});
+    await approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD });
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: BLOCK_ID, status: 'suspended' },
+      data: { status: 'approved' },
+    });
+  });
+
+  it('OFF-SITE touches no block', async () => {
+    wire({ kind: 'offsite', appBlockId: null });
+    await approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD });
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('an on-site listing with no backing block is a no-op, not a crash', async () => {
+    wire({ appBlockId: null });
+    await approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD });
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 does NOT un-suspend when the listing flip lost its race', async () => {
+    // A 0-count means a concurrent withdraw/reject already closed the listing. Waking the
+    // block anyway would leave the app serving with no approved store listing.
+    wire({});
+    mockWrite.appListing.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      approveExternalRequest({ publishRequestId: REQUEST_ID, reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'NOT_PENDING' });
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -3,7 +3,7 @@ import { join, relative, sep } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
-import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
+import { stripComments, stripCommentsAndStrings } from '../../../../../test/strip-comments';
 import {
   approveExternalRequest,
   rejectExternalRequest,
@@ -467,7 +467,48 @@ describe('mod queue procs — widened to kind IN (onsite, offsite), each row car
  * FAILS when the set GROWS (a producer added without a decision recorded) **or** SHRINKS
  * (one removed or renamed and the reasoning here went stale).
  *
- * Test files are out of scope — a test may construct any row for any reason.
+ * ## 🔴 WHAT "CREATES A ROW" MEANS HERE, STATED SO THE SCAN CAN BE CHECKED AGAINST IT
+ *
+ * This sentence is the whole point of the guard, so the scan has to be as wide as the
+ * sentence rather than as wide as whichever syntax the producers happened to use on the
+ * day it was written. It first matched `appListingPublishRequest.create(` and nothing
+ * else — which left it blind to two of the three ways this codebase can insert a row.
+ * Demonstrated by execution: a file doing `…createMany({…})` and another doing
+ * ``$executeRaw`INSERT INTO app_listing_publish_requests …` `` left the suite fully
+ * green. A ledger that cannot see a new producer is worse than no ledger, because it
+ * reads as coverage while providing none. So all three write routes are scanned
+ * (`PRODUCER_PATTERNS`):
+ *
+ *   1. **Prisma client** — `appListingPublishRequest.{create,createMany,upsert}(`.
+ *      `upsert` counts: its `create` branch mints a row. Matched against source with
+ *      comments AND string literals stripped, because this codebase discusses these
+ *      tables at length in prose and only real code is a producer.
+ *   2. **Raw SQL** — `INSERT INTO [public.]app_listing_publish_requests`, case- and
+ *      whitespace-insensitive, which covers `$executeRaw` / `$queryRaw` /
+ *      `$executeRawUnsafe` and any other tagged-template or string SQL path.
+ *   3. **Kysely** — `.insertInto('app_listing_publish_requests')`. Not hypothetical:
+ *      `apps/auth`, `apps/creator-studio` and `apps/moderator` reach Postgres through
+ *      Kysely and insert that way throughout, so a producer added in one of them would
+ *      be written in this syntax rather than Prisma's.
+ *
+ * 🔴 Routes 2 and 3 are matched with string literals KEPT (`stripComments`, not
+ * `stripCommentsAndStrings`) — the table name IS the string literal being looked for, so
+ * the stronger stripper would blank the very thing under test. Comments are still
+ * removed, so the long prose passages naming this table (e.g. the header of
+ * `app-listing-history.service.ts`) cannot satisfy the scan.
+ *
+ * ## SCOPE, STATED AS LIMITS RATHER THAN LEFT IMPLIED
+ *
+ * - **Roots walked: `src/`, `apps/`, `packages/`, `scripts/`** — every repo root that
+ *   holds non-test TypeScript, so a producer added outside `src/` is visible. (It used
+ *   to scan `src/` only; nothing would have flagged an `apps/` producer.)
+ * - **Test files are out of scope** — a test may construct any row for any reason. That
+ *   is the `__tests__` / `__mocks__` / `test(s)/` / `*.test.*` / `*.spec.*` filter, and
+ *   it is why the repo's `tests/` and `test/` roots are not walked at all.
+ * - **This is a lexical scan, not a parser.** A model accessed through a computed key
+ *   (`db[name].create(…)`) or SQL assembled from fragments would not be seen. Nothing in
+ *   this table's write path does that today; if one starts, this comment is the warning
+ *   that the ledger cannot follow it.
  */
 const LISTING_REQUEST_PRODUCERS: Record<string, string> = {
   'src/server/services/blocks/offsite-listing.service.ts::submitExternalListing':
@@ -489,42 +530,90 @@ const LISTING_REQUEST_PRODUCERS: Record<string, string> = {
     '`revisionOfId`, never on `kind`.',
 };
 
+/**
+ * One WRITE ROUTE into `app_listing_publish_requests`. See the ledger header for why
+ * there are three and why `keepStrings` differs between them.
+ */
+type ProducerPattern = { label: string; keepStrings: boolean; re: RegExp };
+
+const PRODUCER_PATTERNS: ProducerPattern[] = [
+  {
+    label: 'prisma',
+    keepStrings: false,
+    re: /appListingPublishRequest\.(?:create|createMany|upsert)\(/g,
+  },
+  {
+    label: 'raw-sql',
+    keepStrings: true,
+    re: /insert\s+into\s+(?:["'`]?public["'`]?\s*\.\s*)?["'`]?app_listing_publish_requests\b/gi,
+  },
+  {
+    label: 'kysely',
+    keepStrings: true,
+    re: /\.insertInto\(\s*['"`]app_listing_publish_requests['"`]/g,
+  },
+];
+
 describe('🔴 AppListingPublishRequest PRODUCER LEDGER — fails when the set grows or shrinks', () => {
   const ROOT = process.cwd();
   const walk = (dir: string, out: string[] = []): string[] => {
     for (const entry of readdirSync(dir)) {
-      if (entry === 'node_modules' || entry === '.next' || entry === '.git') continue;
+      // Dot-dirs cover `.git`, `.next`, `.svelte-kit`, `.turbo` in one rule.
+      if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue;
       const full = join(dir, entry);
       if (statSync(full).isDirectory()) walk(full, out);
       else if (/\.tsx?$/.test(entry)) out.push(full);
     }
     return out;
   };
-  const FILES = walk(join(ROOT, 'src'))
+  /** Every repo root holding non-test TypeScript — see the header's SCOPE section. */
+  const ROOTS = ['src', 'apps', 'packages', 'scripts'];
+  const FILES = ROOTS.flatMap((r) => walk(join(ROOT, r)))
     .map((f) => relative(ROOT, f).split(sep).join('/'))
-    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+    .filter((f) => !/(^|\/)(__tests__|__mocks__|tests?)\/|\.(test|spec)\.tsx?$/.test(f));
 
-  /** `<file>::<enclosing top-level function>` for every `…PublishRequest.create(` site. */
-  const findProducers = (needle: RegExp) => {
+  /** The enclosing top-level declaration for a match at `index` WITHIN `haystack`. */
+  const enclosingFn = (haystack: string, index: number) => {
+    const decls = [
+      ...haystack
+        .slice(0, index)
+        .matchAll(/^(?:export )?(?:async )?function (\w+)|^(?:export )?const (\w+) = /gm),
+    ];
+    const last = decls[decls.length - 1];
+    return last ? last[1] ?? last[2] : '<module scope>';
+  };
+
+  /**
+   * `<file>::<enclosing top-level function>` for every producer site, over all three
+   * write routes.
+   *
+   * 🔴 The two strippers return DIFFERENT-LENGTH text, so a match index is only
+   * meaningful against the haystack it came from — `enclosingFn` is handed that same
+   * haystack rather than a canonical one.
+   */
+  const scanSource = (file: string, source: string, patterns: ProducerPattern[]) => {
+    // Comments AND string literals stripped: this codebase discusses these tables at
+    // length in prose, and only real code is a producer.
+    const codeOnly = stripCommentsAndStrings(source);
+    // Comments only — for routes whose subject IS a string literal (a SQL table name).
+    const stringsKept = stripComments(source);
+    const found: string[] = [];
+    for (const p of patterns) {
+      const text = p.keepStrings ? stringsKept : codeOnly;
+      for (const m of text.matchAll(p.re)) found.push(`${file}::${enclosingFn(text, m.index)}`);
+    }
+    return found;
+  };
+
+  const findProducers = (patterns: ProducerPattern[]) => {
     const found: string[] = [];
     for (const file of FILES) {
-      // Comments and string literals stripped: this codebase discusses these tables at
-      // length in prose, and only real code is a producer.
-      const code = stripCommentsAndStrings(readFileSync(join(ROOT, file), 'utf8'));
-      for (const m of code.matchAll(needle)) {
-        const before = code.slice(0, m.index);
-        const decls = [
-          ...before.matchAll(/^(?:export )?(?:async )?function (\w+)|^(?:export )?const (\w+) = /gm),
-        ];
-        const last = decls[decls.length - 1];
-        const fn = last ? last[1] ?? last[2] : '<module scope>';
-        found.push(`${file}::${fn}`);
-      }
+      found.push(...scanSource(file, readFileSync(join(ROOT, file), 'utf8'), patterns));
     }
     return [...new Set(found)].sort();
   };
 
-  const PRODUCERS = findProducers(/appListingPublishRequest\.create\(/g);
+  const PRODUCERS = findProducers(PRODUCER_PATTERNS);
 
   it('POSITIVE CONTROL: the scan enumerates a real population and can match', () => {
     // A broken walk, a wrong regex or a stripper that ate the file would make the ledger
@@ -532,10 +621,68 @@ describe('🔴 AppListingPublishRequest PRODUCER LEDGER — fails when the set g
     expect(FILES.length).toBeGreaterThan(500);
     expect(FILES).toContain('src/server/services/blocks/offsite-listing.service.ts');
     expect(PRODUCERS.length).toBeGreaterThan(1);
+    // 🔴 The widened roots must actually be WALKED, or widening them is decorative and
+    // the header's scope claim is false. `src/` alone would satisfy every line above.
+    for (const root of ROOTS) {
+      expect(FILES.some((f) => f.startsWith(`${root}/`))).toBe(true);
+    }
+  });
+
+  it('POSITIVE CONTROL: each write route can match the syntax it claims to cover', () => {
+    // 🔴 Routes 2 and 3 have ZERO hits in the real tree, and a route wired to nothing is
+    // indistinguishable from a route that is merely unused. Feed each one source it MUST
+    // match, through the same code path the file scan uses.
+    const samples: Record<string, string> = {
+      prisma: 'await dbWrite.appListingPublishRequest.createMany({ data: [] });',
+      'raw-sql': 'await dbWrite.$executeRaw`\n  INSERT INTO app_listing_publish_requests (id)\n`;',
+      kysely: "await db.insertInto('app_listing_publish_requests').values(row).execute();",
+    };
+    for (const p of PRODUCER_PATTERNS) {
+      expect(scanSource('f.ts', samples[p.label], [p])).toHaveLength(1);
+    }
+    // …and the union really is wider than the original single-syntax scan: the two
+    // routes that were blind spots are matched by NEITHER of the other two patterns.
+    const prismaOnly = PRODUCER_PATTERNS.filter((p) => p.label === 'prisma');
+    expect(scanSource('f.ts', samples['raw-sql'], prismaOnly)).toEqual([]);
+    expect(scanSource('f.ts', samples.kysely, prismaOnly)).toEqual([]);
+    expect(scanSource('f.ts', samples.prisma, [PRODUCER_PATTERNS[1]])).toEqual([]);
+  });
+
+  it('NEGATIVE CONTROL: prose about these tables is not a producer, on any route', () => {
+    // The false-positive direction of the widening. The `keepStrings` routes deliberately
+    // scan string literals, so the ONLY thing keeping the many paragraphs that discuss
+    // this table out of the ledger is comment-stripping. Prove that for all three routes
+    // — and prove the sample is discriminating by running the SAME three lines as bare
+    // code, where all three must match. A control that matches nothing in both arms
+    // would attribute nothing.
+    const lines = [
+      'await dbWrite.appListingPublishRequest.upsert({ where: w, create: c, update: u });',
+      'await dbWrite.$executeRawUnsafe("INSERT INTO app_listing_publish_requests (id) …");',
+      "await db.insertInto('app_listing_publish_requests').values(row).execute();",
+    ];
+    expect(scanSource('bare.ts', lines.join('\n'), PRODUCER_PATTERNS)).toHaveLength(3);
+
+    const asBlockComment = ['/**', ...lines.map((l) => ` * ${l}`), ' */'].join('\n');
+    const asLineComments = lines.map((l) => `// ${l}`).join('\n');
+    expect(scanSource('doc.ts', asBlockComment, PRODUCER_PATTERNS)).toEqual([]);
+    expect(scanSource('doc.ts', asLineComments, PRODUCER_PATTERNS)).toEqual([]);
   });
 
   it('NEGATIVE CONTROL: a definitely-absent producer matches nothing', () => {
-    expect(findProducers(/appListingPublishRequestNoSuchTable\.create\(/g)).toEqual([]);
+    expect(
+      findProducers([
+        {
+          label: 'absent',
+          keepStrings: false,
+          re: /appListingPublishRequestNoSuchTable\.create\(/g,
+        },
+        {
+          label: 'absent-raw',
+          keepStrings: true,
+          re: /insert\s+into\s+app_listing_publish_requests_no_such_table\b/gi,
+        },
+      ])
+    ).toEqual([]);
   });
 
   it('🔴 the producer set is EXACTLY the ledger', () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -1,5 +1,9 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { stripCommentsAndStrings } from '../../../../../test/strip-comments';
 import {
   approveExternalRequest,
   rejectExternalRequest,
@@ -445,7 +449,141 @@ describe('mod queue procs — widened to kind IN (onsite, offsite), each row car
   });
 });
 
-describe('INVARIANT — the only producer of a kind:onsite AppListingPublishRequest is submitListingRevision on an onsite shadow', () => {
+/**
+ * 🔴 PRODUCER LEDGER for `AppListingPublishRequest`.
+ *
+ * `offsite-listing.service` used to carry a one-sentence INVARIANT above
+ * `REVIEWABLE_LISTING_KINDS`: *"the ONLY producer of a `kind='onsite'`
+ * `AppListingPublishRequest` is `submitListingRevision` on an onsite SHADOW"*. Six
+ * consumers of that constant reason from it, and it is what justifies
+ * `listMySubmissions`'s unconditional `{ kind: 'onsite' }` OR-branch.
+ *
+ * It went FALSE — the owner-republish asset-review route mints a NON-SHADOW onsite
+ * request — and the test named for it stayed green the whole time, because it asserted
+ * only that `submitListingRevision` produces a well-shaped row. Proving one member of a
+ * set is in it says nothing about whether the set has grown. So the shape assertion is
+ * kept below (it pins the VALUES) and this ledger is added beside it to pin the
+ * POPULATION: it enumerates every production site that creates a row in that table and
+ * FAILS when the set GROWS (a producer added without a decision recorded) **or** SHRINKS
+ * (one removed or renamed and the reasoning here went stale).
+ *
+ * Test files are out of scope — a test may construct any row for any reason.
+ */
+const LISTING_REQUEST_PRODUCERS: Record<string, string> = {
+  'src/server/services/blocks/offsite-listing.service.ts::submitExternalListing':
+    "OFF-SITE only (`kind: 'offsite'`), NON-shadow — a first-time off-site store " +
+    'submission, minted alongside the draft listing it targets.',
+  'src/server/services/blocks/offsite-listing.service.ts::submitListingRevision':
+    'BOTH kinds, always SHADOW (`revisionOfId` set on the target listing; the PARENT ' +
+    'slug is denormalized onto the request). This is the producer the old invariant ' +
+    'sentence named, and for on-site it was once the only one.',
+  'src/server/services/blocks/offsite-moderation.service.ts::resetListingToPending':
+    'OFF-SITE only, NON-shadow — the moderator reset. The ON-SITE reset is a different ' +
+    'function (`resetOnsiteListingToPending`) and re-queues on `AppBlockPublishRequest`, ' +
+    'which is why the on-site half of this table was shadow-only.',
+  'src/server/services/blocks/offsite-moderation.service.ts::routeRepublishToReviewInTx':
+    '🔴 THE SECOND ON-SITE PRODUCER, and the one that falsified the invariant. BOTH ' +
+    "kinds (`kind: listing.kind`), NON-shadow — an owner republish whose assets differ " +
+    'from the recorded approval baseline. Any consumer that reads `kind:onsite` as ' +
+    '"therefore a shadow revision" is wrong about this row; discriminate on ' +
+    '`revisionOfId`, never on `kind`.',
+};
+
+describe('🔴 AppListingPublishRequest PRODUCER LEDGER — fails when the set grows or shrinks', () => {
+  const ROOT = process.cwd();
+  const walk = (dir: string, out: string[] = []): string[] => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry === '.next' || entry === '.git') continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full, out);
+      else if (/\.tsx?$/.test(entry)) out.push(full);
+    }
+    return out;
+  };
+  const FILES = walk(join(ROOT, 'src'))
+    .map((f) => relative(ROOT, f).split(sep).join('/'))
+    .filter((f) => !/__tests__|\.test\.tsx?$|(^|\/)src\/tests\//.test(f));
+
+  /** `<file>::<enclosing top-level function>` for every `…PublishRequest.create(` site. */
+  const findProducers = (needle: RegExp) => {
+    const found: string[] = [];
+    for (const file of FILES) {
+      // Comments and string literals stripped: this codebase discusses these tables at
+      // length in prose, and only real code is a producer.
+      const code = stripCommentsAndStrings(readFileSync(join(ROOT, file), 'utf8'));
+      for (const m of code.matchAll(needle)) {
+        const before = code.slice(0, m.index);
+        const decls = [
+          ...before.matchAll(/^(?:export )?(?:async )?function (\w+)|^(?:export )?const (\w+) = /gm),
+        ];
+        const last = decls[decls.length - 1];
+        const fn = last ? last[1] ?? last[2] : '<module scope>';
+        found.push(`${file}::${fn}`);
+      }
+    }
+    return [...new Set(found)].sort();
+  };
+
+  const PRODUCERS = findProducers(/appListingPublishRequest\.create\(/g);
+
+  it('POSITIVE CONTROL: the scan enumerates a real population and can match', () => {
+    // A broken walk, a wrong regex or a stripper that ate the file would make the ledger
+    // assertion vacuously true. Prove the instrument works before reading its verdict.
+    expect(FILES.length).toBeGreaterThan(500);
+    expect(FILES).toContain('src/server/services/blocks/offsite-listing.service.ts');
+    expect(PRODUCERS.length).toBeGreaterThan(1);
+  });
+
+  it('NEGATIVE CONTROL: a definitely-absent producer matches nothing', () => {
+    expect(findProducers(/appListingPublishRequestNoSuchTable\.create\(/g)).toEqual([]);
+  });
+
+  it('🔴 the producer set is EXACTLY the ledger', () => {
+    expect(PRODUCERS).toEqual(Object.keys(LISTING_REQUEST_PRODUCERS).sort());
+  });
+
+  it('🔴 the on-site half is NO LONGER shadow-only — at least two producers can emit kind:onsite', () => {
+    // The claim the stale sentence made, stated so it can be checked: a producer emits
+    // on-site rows when it writes `kind: 'onsite'` or forwards a listing's own kind.
+    const onsiteCapable = Object.keys(LISTING_REQUEST_PRODUCERS).filter((k) =>
+      /BOTH kinds/.test(LISTING_REQUEST_PRODUCERS[k])
+    );
+    expect(onsiteCapable.sort()).toEqual([
+      'src/server/services/blocks/offsite-listing.service.ts::submitListingRevision',
+      'src/server/services/blocks/offsite-moderation.service.ts::routeRepublishToReviewInTx',
+    ]);
+  });
+
+  it('🔴 `routeRepublishToReviewInTx` really does forward the listing kind (not a hardcoded offsite)', () => {
+    // The ledger entry above is prose; this is the code it describes. Without it the
+    // ledger could record a producer that does not actually reach the on-site half.
+    const code = stripCommentsAndStrings(
+      readFileSync(
+        join(ROOT, 'src/server/services/blocks/offsite-moderation.service.ts'),
+        'utf8'
+      )
+    );
+    const fnStart = code.indexOf('function routeRepublishToReviewInTx');
+    expect(fnStart).toBeGreaterThan(-1); // the ledger key must still name a real function
+    const body = code.slice(fnStart);
+    const create = body.slice(body.indexOf('appListingPublishRequest.create('));
+    expect(create.slice(0, 400)).toContain('kind: listing.kind');
+    // …and the sibling that is genuinely off-site-only still hardcodes it, so the
+    // assertion above is discriminating rather than matching any create in the file.
+    // 🔴 Read from the RAW source here, not the stripped copy: the value under test IS a
+    // string literal, and `stripCommentsAndStrings` blanks it to `kind:  ,` — asserting
+    // against the stripped text would be asserting the stripper's output.
+    const raw = readFileSync(
+      join(ROOT, 'src/server/services/blocks/offsite-moderation.service.ts'),
+      'utf8'
+    );
+    const reset = raw.slice(raw.indexOf('async function resetListingToPending'));
+    const resetCreate = reset.slice(reset.indexOf('appListingPublishRequest.create('));
+    expect(resetCreate.slice(0, 400)).toContain("kind: 'offsite'");
+  });
+});
+
+describe('the shape of a kind:onsite AppListingPublishRequest minted by submitListingRevision', () => {
   it('submitListingRevision on an onsite shadow mints a kind:onsite request targeting the shadow (revisionOfId set)', async () => {
     // The shadow: a draft revision of an approved onsite parent (revisionOfId set).
     mockRead.appListing.findUnique.mockResolvedValue({

--- a/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.owner-unpublish-editable.service.test.ts
@@ -259,7 +259,10 @@ describe('updateListing on a `removed` listing', () => {
         action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
       },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-      select: { action: true },
+      // `before` rides along: the same query now also carries the approved-asset
+      // baseline the owner-republish review gate compares against — one row, so the verb
+      // and the payload can never describe different events.
+      select: { action: true, before: true },
     });
     expect(mockRead.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
   });

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -523,6 +523,35 @@ describe('withdrawExternalRequest', () => {
     });
   });
 
+  it('🔴 REPORTS WHICH CLOSE HAPPENED, so the UI can stop calling both "Submission withdrawn."', async () => {
+    // The two outcomes are not equally reversible. `'deleted'` throws away a draft;
+    // `'removed'` leaves a formerly-live listing delisted behind a `delist` event, which
+    // `republishOwnListing`'s guard reads as a moderator takedown — the owner cannot put
+    // it back and a moderator must relist. Announcing both with one sentence left an owner
+    // looking at a "removed by a moderator" state they had caused themselves, with nothing
+    // having warned them. Asserted as a PAIR so a mutant returning one constant fails.
+    async function withdrawWithListingStatus(status: string) {
+      vi.clearAllMocks();
+      mockWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+        cb(mockWrite)
+      );
+      mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+      mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+      mockWrite.appListing.deleteMany.mockResolvedValue({ count: 1 });
+      mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+        id: 'alpr_1',
+        status: 'pending',
+        submittedByUserId: CALLER,
+        appListingId: 'apl_1',
+      });
+      mockWrite.appListing.findUnique.mockResolvedValue({ status, slug: 'cool-app' });
+      return withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
+    }
+
+    expect(await withdrawWithListingStatus('pending')).toEqual({ outcome: 'removed' });
+    expect(await withdrawWithListingStatus('draft')).toEqual({ outcome: 'deleted' });
+  });
+
   it('🔴 Fix #1 regression: an intervening report-resolve event does NOT downgrade the close to owner-unpublish (still DELIST)', async () => {
     // The exploit closed: mod resets (report-driven) → mod resolves the triggering
     // report → the listing's NEWEST moderation event is now `report-resolve`, NOT
@@ -591,9 +620,11 @@ describe('withdrawExternalRequest', () => {
       submittedByUserId: CALLER,
       appListingId: 'apl_1',
     });
+    // 🔴 `'none'` rather than the outcome of whoever DID close it: this call did
+    // nothing, and the UI must not narrate someone else's close as its own.
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ outcome: 'none' });
     expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
@@ -610,9 +641,11 @@ describe('withdrawExternalRequest', () => {
     mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
     mockWrite.appListingPublishRequest.findUnique.mockResolvedValue({ status: 'withdrawn' });
 
+    // Lost the race → `'none'`: the concurrent withdraw owns both the close and the
+    // description of it.
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ outcome: 'none' });
     // We did not perform the withdraw → we do NOT re-delete the draft.
     expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
@@ -894,6 +927,11 @@ describe('approveExternalRequest', () => {
         // off-site-only and names the listing in its moderator-facing error.
         kind: true,
         slug: true,
+        // The two ON-SITE approve inputs, read on the PRIMARY with everything else so
+        // they are row-consistent with the flip: the app's DECLARED rating (the
+        // raise-only floor) and the backing block to un-suspend.
+        contentRating: true,
+        appBlockId: true,
       },
     });
     // The screenshot imageIds (for the floor count + the scan gate) are read from

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -625,12 +625,27 @@ const withAssets = <T extends object>(listing: T): T & { iconId: number; coverId
  * `before.assets` — the baseline `republishOwnListing`'s ASSET-CHANGE REVIEW GATE compares
  * the live listing against.
  *
- * 🔴 EVERY republish fixture in this file must state one. The gate FAILS CLOSED on an
- * absent baseline (`reviewReason: 'no-recorded-assets'`), so an event mocked as a bare
- * `{ action: 'owner-unpublish' }` routes the listing to `pending` instead of `approved` —
- * which is correct behaviour, but it means a fixture that forgets the baseline stops
- * testing whatever it was actually about. Tests that want the IMMEDIATE arm must record a
- * baseline that MATCHES their live assets; the review arm has its own dedicated file.
+ * 🔴 EVERY republish fixture in this file must state one, and the reason is the OPPOSITE
+ * of what this docstring used to give. It claimed the gate FAILS CLOSED on an absent
+ * baseline via `reviewReason: 'no-recorded-assets'`. Both halves are false: there is no
+ * such reason (`RepublishReviewReason` is `'assets-changed' | 'unreadable-baseline'`), and
+ * `resolveRepublishReviewReason` returns `null` for the `absent` kind — an event mocked as
+ * a bare `{ action: 'owner-unpublish' }` takes the **IMMEDIATE** arm and goes straight to
+ * `approved`. Only `unreadable` (an `assets` KEY that is present and does not parse) fails
+ * closed. See `app-listing-approved-assets.ts` for why the two absences go opposite ways.
+ *
+ * 🔴 So the failure mode a forgotten baseline produces is a SILENT PASS, not a loud
+ * re-route: a spec meaning to exercise the review arm, or meaning to prove that MATCHING
+ * assets republish immediately, gets `approved` either way — the second one while
+ * measuring nothing, because it never compared anything. Stating a baseline that MATCHES
+ * the live assets is what keeps an immediate-arm fixture on the equality path rather than
+ * on the never-recorded path. The review arm has its own dedicated file
+ * (`offsite-moderation.service.republish-asset-review.test.ts`), which owns both absences.
+ *
+ * Audited at the time of writing: every `republishOwnListing` fixture in this file stages
+ * an `assets` key (the rating-floor `wire()` derives one from its own live ids), and the
+ * ones that stage no event at all are refused earlier by the last-event guard — so none is
+ * currently passing vacuously. The hazard is for the next fixture, not this batch.
  */
 const approvedAssets = (
   over: {

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -619,6 +619,35 @@ const withAssets = <T extends object>(listing: T): T & { iconId: number; coverId
   iconId: 1,
   coverId: 2,
 });
+
+/**
+ * The asset snapshot `unpublishOwnListing` records into the `owner-unpublish` event's
+ * `before.assets` — the baseline `republishOwnListing`'s ASSET-CHANGE REVIEW GATE compares
+ * the live listing against.
+ *
+ * 🔴 EVERY republish fixture in this file must state one. The gate FAILS CLOSED on an
+ * absent baseline (`reviewReason: 'no-recorded-assets'`), so an event mocked as a bare
+ * `{ action: 'owner-unpublish' }` routes the listing to `pending` instead of `approved` —
+ * which is correct behaviour, but it means a fixture that forgets the baseline stops
+ * testing whatever it was actually about. Tests that want the IMMEDIATE arm must record a
+ * baseline that MATCHES their live assets; the review arm has its own dedicated file.
+ */
+const approvedAssets = (
+  over: {
+    iconId?: number | null;
+    coverId?: number | null;
+    screenshots?: { imageId: number; caption: string | null }[];
+  } = {}
+) => ({
+  v: 1,
+  iconId: over.iconId ?? null,
+  coverId: over.coverId ?? null,
+  screenshots: over.screenshots ?? [],
+});
+const ownerUnpublishEvent = (assets: unknown = approvedAssets()) => ({
+  action: 'owner-unpublish',
+  before: { status: 'approved', assets },
+});
 const injectIngestion = (byId: Record<number, string>) =>
   (async (args: { where?: { id?: { in?: number[] } } }) =>
     (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: byId[id] ?? 'Scanned' }))) as never;
@@ -684,9 +713,7 @@ describe('relistListing / republishOwnListing — go-live ACTIONABILITY gate', (
     // The owner-driven half of the same hazard: a removed listing stays directly
     // editable, so an owner can clear the URL and then self-restore.
     mockWrite.appListing.findUnique.mockResolvedValue(deadCta());
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({
-      action: 'owner-unpublish',
-    });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(ownerUnpublishEvent());
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
     ).rejects.toMatchObject({
@@ -1557,7 +1584,7 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
   it('OWNER restores their OWN owner-unpublished OFF-SITE listing (removed → approved) + owner-republish event, no block-flip', async () => {
     mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
     // The most-recent event is the owner's own unpublish → restore allowed.
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(ownerUnpublishEvent());
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
@@ -1574,7 +1601,7 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
 
   it('🔴 ON-SITE republish restores BOTH app_listings AND the backing app_blocks (suspended → approved) in ONE tx + owner-republish event', async () => {
     mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed', 'onsite', OWNER, BLOCK_ID));
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(ownerUnpublishEvent());
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
@@ -1603,7 +1630,7 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
 
   it('ON-SITE republish whose block-restore flip is a 0-count (drift) emits the post-commit warn (observability, mirrors mod relist)', async () => {
     mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed', 'onsite', OWNER, BLOCK_ID));
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(ownerUnpublishEvent());
     // The backing block wasn't `suspended` → the guarded block flip matches 0 rows.
     mockWrite.appBlock.updateMany.mockResolvedValueOnce({ count: 0 });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
@@ -1670,7 +1697,9 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
   // the flip.
   it('go-live scan gate: REFUSES republish when an asset is still scanning (no flip)', async () => {
     mockWrite.appListing.findUnique.mockResolvedValue(withAssets(ownerPrimary('removed')));
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(
+      ownerUnpublishEvent(approvedAssets({ iconId: 1, coverId: 2 }))
+    );
     mockWrite.image.findMany.mockImplementation(injectIngestion({ 1: 'Pending' }));
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
@@ -1681,7 +1710,9 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
 
   it('go-live scan gate: REFUSES republish when an asset was Blocked (no flip)', async () => {
     mockWrite.appListing.findUnique.mockResolvedValue(withAssets(ownerPrimary('removed')));
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(
+      ownerUnpublishEvent(approvedAssets({ iconId: 1, coverId: 2 }))
+    );
     mockWrite.image.findMany.mockImplementation(injectIngestion({ 2: 'Blocked' }));
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
@@ -1691,7 +1722,9 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
 
   it('go-live scan gate: SUCCEEDS when every asset is Scanned (normal republish unaffected)', async () => {
     mockWrite.appListing.findUnique.mockResolvedValue(withAssets(ownerPrimary('removed')));
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(
+      ownerUnpublishEvent(approvedAssets({ iconId: 1, coverId: 2 }))
+    );
     // Explicitly stage all-Scanned (clearAllMocks doesn't reset a prior test's impl).
     mockWrite.image.findMany.mockImplementation(injectIngestion({}));
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
@@ -1886,17 +1919,29 @@ describe('republishOwnListing — go-live RATING FLOOR (uniform, both kinds)', (
       externalUrl: opts.kind === 'offsite' ? EXTERNAL_URL : null,
       connectClientId: null,
     });
-    mockWrite.appListing.findUnique.mockResolvedValueOnce(
-      ownerPrimary({ kind: opts.kind, contentRating: opts.contentRating })
-    );
+    mockWrite.appListing.findUnique.mockResolvedValueOnce({
+      // `loadOwnedListingInTx` now also selects the asset ids (the scalar half of the
+      // snapshot the review gate compares), so the FIRST read has to carry them.
+      ...ownerPrimary({ kind: opts.kind, contentRating: opts.contentRating }),
+      iconId: icon,
+      coverId: cover,
+    });
     mockWrite.appListingScreenshot.findMany.mockResolvedValue(shots.map((imageId) => ({ imageId })));
     mockWrite.image.findMany.mockImplementation(
       async (args: { where?: { id?: { in?: number[] } } }) =>
         (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion, nsfwLevel: levels[id] ?? 0 }))
     );
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({
-      action: 'owner-unpublish',
-    });
+    // Baseline == live assets, so these tests stay on the IMMEDIATE arm and keep
+    // measuring the rating floor rather than the (separately tested) review route.
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(
+      ownerUnpublishEvent(
+        approvedAssets({
+          iconId: icon,
+          coverId: cover,
+          screenshots: shots.map((imageId) => ({ imageId, caption: null })),
+        })
+      )
+    );
   }
 
   /** The `data` payload of the listing status flip. */
@@ -2043,9 +2088,11 @@ describe('republishOwnListing — go-live RATING FLOOR (uniform, both kinds)', (
     mockWrite.appListing.findUnique.mockResolvedValueOnce(
       ownerPrimary({ kind: 'offsite', contentRating: 'pg13' })
     );
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({
-      action: 'owner-unpublish',
-    });
+    // Staged explicitly, not inherited: `vi.clearAllMocks()` clears call history but not
+    // implementations, so a previous `wire()`'s screenshot rows would otherwise leak in
+    // and make the live snapshot differ from the baseline below for the wrong reason.
+    mockWrite.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(ownerUnpublishEvent());
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
     expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
     expect(flipData()).toEqual({ status: 'approved', contentRating: 'pg13' });

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
@@ -407,9 +407,27 @@ describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
     expect(mockWrite.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
   });
 
+  // -------------------------------------------------------------------------
+  // The open-review guard, exercised against a fake `app_listing_publish_requests`
+  // table rather than a blanket `mockResolvedValue`. All three cases below differ ONLY
+  // in the ROWS, so the guard's two predicates — scoped to `appListingId` (not `slug`)
+  // and to `status: 'pending'` — are each pinned by a case that fails without it.
+  // -------------------------------------------------------------------------
+  const wireOpenRequestTable = (rows: Record<string, unknown>[]) => {
+    mockWrite.appListingPublishRequest.findFirst.mockImplementation(
+      async (args: { where?: Record<string, unknown> }) => {
+        const w = args?.where ?? {};
+        const hit = rows.find((r) => Object.entries(w).every(([k, v]) => r[k] === v));
+        return hit ? { id: hit.id } : null;
+      }
+    );
+  };
+
   it('🔴 a review already open on THIS listing → NOT_TRANSITIONABLE, and NOTHING is written', async () => {
     wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
-    mockWrite.appListingPublishRequest.findFirst.mockResolvedValue({ id: 'alpr_open' });
+    wireOpenRequestTable([
+      { id: 'alpr_open', appListingId: APP_ID, slug: SLUG, status: 'pending' },
+    ]);
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
     ).rejects.toMatchObject({
@@ -419,6 +437,36 @@ describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 a pending SHADOW media revision on the SAME SLUG does NOT block the republish', async () => {
+    // Why the guard is scoped to `appListingId` and not to `slug`, spelled as a case
+    // rather than only as a comment. A shadow revision DENORMALIZES the parent slug onto
+    // its request row while targeting a different `AppListing` — it is a legitimate
+    // concurrent review. A slug-scoped guard would refuse every republish for the length
+    // of an ordinary media review, and refuse it with a message about the wrong review.
+    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
+    wireOpenRequestTable([
+      { id: 'alpr_shadow', appListingId: 'apl_shadow', slug: SLUG, status: 'pending' },
+    ]);
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('pending');
+    expect(mockWrite.appListingPublishRequest.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('🔴 a CLOSED request on THIS listing does NOT block a later republish', async () => {
+    // Why the guard says `status: 'pending'`. Request rows accumulate forever — one
+    // completed imagery-review cycle is the ordinary shape. Without the status predicate
+    // the FIRST review an app ever goes through would permanently forbid every future
+    // republish, with "A review is already pending for this listing." naming a review that
+    // finished long ago and no owner-reachable way out.
+    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
+    wireOpenRequestTable([
+      { id: 'alpr_done', appListingId: APP_ID, slug: SLUG, status: 'approved' },
+    ]);
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('pending');
+    expect(mockWrite.appListingPublishRequest.create).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
@@ -43,7 +43,10 @@ type WriteMock = {
     findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
   };
-  appListingPublishRequest: { create: ReturnType<typeof vi.fn> };
+  appListingPublishRequest: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
   appBlockPublishRequest: {
     findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
@@ -223,6 +226,10 @@ beforeEach(() => {
   mockWrite.appListingPublishRequest.create.mockImplementation(
     async (a: { data: unknown }) => a.data
   );
+  // No review already open on the row, unless a test says otherwise. Set EXPLICITLY:
+  // `clearAllMocks` clears calls, not implementations, so a `mockResolvedValue` left by an
+  // earlier test would otherwise make every later republish refuse.
+  mockWrite.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
   mockWrite.appBlockPublishRequest.create.mockImplementation(
     async (a: { data: unknown }) => a.data
   );
@@ -297,8 +304,12 @@ describe('republishOwnListing — assets UNCHANGED ⇒ immediate (no behaviour c
 describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
   it.each([
     ['the ICON was swapped', { iconId: 99 }, undefined],
-    ['the ICON was cleared', { iconId: null }, undefined],
     ['the COVER was swapped', { coverId: 99 }, undefined],
+    ['BOTH the icon and the cover were swapped', { iconId: 99, coverId: 88 }, undefined],
+    // NOTE: "the icon was CLEARED" is deliberately not here. Clearing the icon or cover is
+    // a change, but it drops the listing below the publish floor, so it is refused with an
+    // actionable error instead of being queued for a review no moderator could approve —
+    // see the floor cases in the on-site block below.
     ['an ICON was ADDED where there was none', { iconId: ICON_ID }, { iconId: null }],
   ])('%s', async (_label, listingOver, baselineOver) => {
     wire({ ...listingOver, recorded: baseline(baselineOver ?? {}) });
@@ -368,7 +379,7 @@ describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
     expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
   });
 
-  it('🔴 ON-SITE: clones the approved block request and LEAVES THE BLOCK SUSPENDED', async () => {
+  it('🔴 ON-SITE: re-queues on the LISTING surface and LEAVES THE BLOCK SUSPENDED', async () => {
     wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
 
@@ -378,49 +389,43 @@ describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
       data: { status: 'pending', contentRating: 'g' },
     });
     // 🔴 THE LOAD-BEARING ABSENCE: an app awaiting review of its store card must NOT be
-    // serving. `approveRequest`'s (3b-reset) branch un-suspends it on re-approve, gated
-    // on exactly the `pending` listing status written above.
+    // serving. `approveExternalRequest` un-suspends it on approve, gated on exactly the
+    // `pending` on-site listing written above.
     expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
-    // Re-queued through the BLOCK request table (the onsite review queue), owner-submitted,
-    // carrying the approved version's bytes + provenance verbatim.
-    expect(mockWrite.appBlockPublishRequest.create).toHaveBeenCalledTimes(1);
-    expect(mockWrite.appBlockPublishRequest.create.mock.calls[0][0].data).toMatchObject({
-      appBlockId: BLOCK_ID,
+    // 🔴 THE FIX FOR THE ARM THAT COULD NOT SHOW WHAT IT WAS REVIEWING. What changed is
+    // the listing's IMAGERY, so it re-queues on the surface whose moderator modal reads
+    // `AppListing.iconId` / `coverId` / `AppListingScreenshot` — NOT the block-request
+    // queue, whose modal draws screenshots out of the bundle ZIP and would have shown a
+    // byte-identical re-submission of an already-approved version instead.
+    expect(mockWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingPublishRequest.create.mock.calls[0][0].data).toMatchObject({
+      appListingId: APP_ID,
+      kind: 'onsite',
       slug: SLUG,
       submittedByUserId: OWNER,
       status: 'pending',
-      version: '1.2.0',
-      bundleSha256: 'deadbeef',
-      sourceCommit: lastApprovedBlockRequest.sourceCommit,
-      sourceDirty: true,
     });
-    // The off-site listing-request table is NOT the onsite queue — writing there would
-    // strand the app where no moderator looks.
-    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
   });
 
-  it('🔴 ON-SITE with NO approved version to clone → NOT_TRANSITIONABLE, and NOTHING is written', async () => {
-    // Stranding the listing in `pending` with nothing in any queue would be unrecoverable
-    // for the owner, so the whole republish must refuse instead.
-    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
-    mockWrite.appBlockPublishRequest.findFirst.mockReset().mockResolvedValue(null);
-    await expect(
-      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
-    ).rejects.toMatchObject({
-      name: 'OffsiteModerationError',
-      code: 'NOT_TRANSITIONABLE',
-      message: expect.stringContaining('no approved version'),
+  it('🔴 ON-SITE does NOT consult `AppBlockPublishRequest` at all', async () => {
+    // The old on-site arm threw NOT_TRANSITIONABLE when a slug had no approved block
+    // request, no `appBlockId`, or a block review already open — three hard refusals that
+    // `republishOwnListing` never had before, on a path an owner reaches by pressing one
+    // button. Re-queueing on the listing surface removes the dependency, so none of the
+    // three can fire. Both block-request mocks are armed to fail loudly if touched.
+    mockWrite.appBlockPublishRequest.findFirst.mockReset().mockImplementation(async () => {
+      throw new Error('the review arm must not read AppBlockPublishRequest');
     });
-    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
-    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('pending');
+    expect(mockWrite.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
   });
 
-  it('🔴 ON-SITE with a review already in flight → NOT_TRANSITIONABLE, and NOTHING is written', async () => {
+  it('🔴 a review already open on THIS listing → NOT_TRANSITIONABLE, and NOTHING is written', async () => {
     wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
-    mockWrite.appBlockPublishRequest.findFirst
-      .mockReset()
-      .mockResolvedValueOnce(lastApprovedBlockRequest)
-      .mockResolvedValueOnce({ id: 'pubreq_open' });
+    mockWrite.appListingPublishRequest.findFirst.mockResolvedValue({ id: 'alpr_open' });
     await expect(
       republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
     ).rejects.toMatchObject({
@@ -428,8 +433,32 @@ describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
       message: expect.stringContaining('already pending'),
     });
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
-    expect(mockWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['no icon', { iconId: null }],
+    ['no cover', { coverId: null }],
+  ])(
+    '🔴 refuses with an actionable floor error when the listing has %s, leaving it `removed`',
+    async (_label, over) => {
+      // `approveExternalRequest` asserts icon+cover and does NOT exempt on-site, while the
+      // on-site FIRST-publish path never asserts it — so an approved on-site listing may
+      // genuinely have neither. Routing such a listing to review would strand it: pending
+      // listing, suspended app, and a moderator approve that fails the floor every time.
+      // Failing HERE keeps the listing `removed`, where its owner can still fix it.
+      wire({ kind: 'onsite', shots: [shot(99)], ...over, recorded: baseline() });
+      await expect(
+        republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('icon and cover'),
+      });
+      expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+      expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+      expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    }
+  );
 
   it('a raced 0-count on the pending flip aborts BEFORE any audit event or queue entry', async () => {
     wire({ iconId: 99, recorded: baseline() });
@@ -443,47 +472,57 @@ describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 🔴 The FAIL-CLOSED arm: no usable baseline.
+// 🔴 The two ABSENCES, which go OPPOSITE ways.
 // ---------------------------------------------------------------------------
 
-describe('republishOwnListing — 🔴 NO usable baseline ⇒ review, never a silent pass', () => {
-  it('a legacy `owner-unpublish` event with no recorded assets routes to review', async () => {
-    // The whole population of listings unpublished BEFORE the snapshot shipped.
+describe('republishOwnListing — 🔴 absent baseline vs unreadable baseline', () => {
+  it('🔴 a legacy `owner-unpublish` with NO recorded assets republishes IMMEDIATELY', async () => {
+    // The entire population of listings unpublished BEFORE the snapshot shipped. Nothing
+    // was ever recorded for them, so there is no "before" to show a moderator — routing
+    // them to review buys no review and takes every one of them offline behind a
+    // moderator on ship day. Measured against production at the time of writing: this is
+    // EVERY republish-eligible removed listing that exists. Deliberately fail-OPEN, and
+    // the only arm that is.
     wire({ iconId: 99, recorded: undefined });
     mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({
       action: 'owner-unpublish',
       before: { status: 'approved' },
     });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(res).toEqual({
-      appListingId: APP_ID,
-      status: 'pending',
-      reviewReason: 'no-recorded-assets',
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'removed' },
+      data: { status: 'approved', contentRating: 'g' },
     });
-    expect(eventData().detail).toContain('no recorded assets');
   });
 
-  it('🔴 an ASSET-LESS listing with no baseline ALSO routes to review', async () => {
-    // The case a coercing parser gets wrong: an "empty" snapshot compares EQUAL to a
-    // listing with no assets, so unknown would silently read as unchanged and go live.
+  it('🔴 an ASSET-LESS listing with no baseline is likewise IMMEDIATE, not review', async () => {
     wire({ iconId: null, coverId: null, shots: [] });
     mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({
       action: 'owner-unpublish',
       before: { status: 'approved' },
     });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(res.status).toBe('pending');
-    expect(res.reviewReason).toBe('no-recorded-assets');
+    expect(res.status).toBe('approved');
   });
 
   it.each([
     ['a FUTURE snapshot version', { v: 2, iconId: ICON_ID, coverId: COVER_ID, screenshots: [] }],
     ['a malformed payload', { v: 1, iconId: 'eleven', coverId: COVER_ID, screenshots: [] }],
-    ['a non-object payload', 'approved'],
-  ])('%s is UNKNOWN, not empty → review', async (_label, recorded) => {
+    ['an explicit null baseline', null],
+    ['a non-object baseline', 'approved'],
+  ])('🔴 a baseline that EXISTS and cannot be read → review (%s)', async (_label, recorded) => {
+    // The opposite of the absent arm and the reason the two must not share a verdict:
+    // this population is unbounded and is evidence something is wrong RIGHT NOW, so it
+    // fails CLOSED. Note every fixture here differs from the live surface only in being
+    // unreadable — the live assets are UNCHANGED, so a gate that fell back to a plain
+    // equality check would let all four through.
     wire({ recorded });
     const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
-    expect(res.reviewReason).toBe('no-recorded-assets');
+    expect(res.status).toBe('pending');
+    expect(res.reviewReason).toBe('unreadable-baseline');
+    expect(eventData().detail).toContain('could not be read');
   });
 });
 
@@ -518,9 +557,10 @@ describe('republishOwnListing — composition with the gates that were already t
   });
 
   it('🔴 #4418 RATING FLOOR is applied on the REVIEW arm too, not deferred to the approve', async () => {
-    // Declared `g`, an X-rated cover swapped in. On-site is the case that matters most:
-    // `approveRequest`'s (3b-reset) restore writes ONLY `status` and runs no floor of its
-    // own, so a review arm that skipped the floor would let mature art come back rated `g`.
+    // Declared `g`, an X-rated cover swapped in. The floor is applied on BOTH arms so the
+    // #4418 guarantee never depends on which arm a republish takes — a listing must not be
+    // sitting in a queue under a rating its own media contradicts, whatever the approve
+    // later does.
     wire({
       kind: 'onsite',
       contentRating: 'g',

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
@@ -197,21 +197,6 @@ function eventData() {
   return mockWrite.appListingModerationEvent.create.mock.calls[0]?.[0]?.data;
 }
 
-/** The approved block request the onsite re-queue clones. */
-const lastApprovedBlockRequest = {
-  appBlockId: BLOCK_ID,
-  version: '1.2.0',
-  manifest: { blockId: SLUG, scopes: [] },
-  bundleKey: 'bundles/deadbeef.zip',
-  bundleSha256: 'deadbeef',
-  bundleSizeBytes: BigInt(1024),
-  fileSummary: { files: [], added: [], removed: [], changed: [] },
-  manifestDiffSummary: { kind: 'update' },
-  forgejoCommitSha: 'sha_server_side',
-  sourceCommit: '4f3a9c2e17b06d85fa1c39e470b28d6ac519e0f3',
-  sourceDirty: true,
-};
-
 beforeEach(() => {
   ids.n = 0;
   vi.clearAllMocks();
@@ -230,13 +215,12 @@ beforeEach(() => {
   // `clearAllMocks` clears calls, not implementations, so a `mockResolvedValue` left by an
   // earlier test would otherwise make every later republish refuse.
   mockWrite.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
-  mockWrite.appBlockPublishRequest.create.mockImplementation(
-    async (a: { data: unknown }) => a.data
-  );
-  // Onsite default: one approved version to clone, no review already in flight.
-  mockWrite.appBlockPublishRequest.findFirst
-    .mockResolvedValueOnce(lastApprovedBlockRequest)
-    .mockResolvedValueOnce(null);
+  // 🔴 `appBlockPublishRequest` IS DELIBERATELY LEFT UNARMED. Nothing in `republishOwnListing`
+  // reads or writes that table any more — the review arm re-queues on the LISTING surface,
+  // because the block-request queue's modal cannot render listing imagery. Arming it with a
+  // plausible approved row would hand a regression a usable answer instead of a loud failure;
+  // the canonical mock's `findFirst` default is `null` and `create` is unstubbed, so a
+  // reintroduced clone shows up rather than quietly working.
   mockRead.appListing.findUnique.mockResolvedValue(null);
   mockNotify.mockResolvedValue(undefined);
 });

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
@@ -32,28 +32,13 @@ const mockWrite = dbMock.dbWrite;
  * abort BEFORE any audit event is written.
  */
 
-type WriteMock = {
-  $transaction: ReturnType<typeof vi.fn>;
-  appListing: {
-    findUnique: ReturnType<typeof vi.fn>;
-    updateMany: ReturnType<typeof vi.fn>;
-  };
-  appBlock: { updateMany: ReturnType<typeof vi.fn> };
-  appListingModerationEvent: {
-    findFirst: ReturnType<typeof vi.fn>;
-    create: ReturnType<typeof vi.fn>;
-  };
-  appListingPublishRequest: {
-    findFirst: ReturnType<typeof vi.fn>;
-    create: ReturnType<typeof vi.fn>;
-  };
-  appBlockPublishRequest: {
-    findFirst: ReturnType<typeof vi.fn>;
-    create: ReturnType<typeof vi.fn>;
-  };
-  appListingScreenshot: { findMany: ReturnType<typeof vi.fn> };
-  image: { findMany: ReturnType<typeof vi.fn> };
-};
+/**
+ * The transaction callback is handed the SAME write mock, so its parameter type is that
+ * mock's own type. A hand-written structural stand-in was used here and did not match:
+ * `dbMock.dbWrite` is a `HybridNode` (auto-vivifying proxy), not a fixed record of
+ * `vi.fn()`s, so the annotation described a shape the suite never passes.
+ */
+type WriteMock = typeof mockWrite;
 
 const { mockNotify, ids } = vi.hoisted(() => {
   return {
@@ -187,7 +172,7 @@ function wire(opts: {
 /** The `data` of the guarded `removed → …` status flip. */
 function flipData() {
   const call = mockWrite.appListing.updateMany.mock.calls.find(
-    (c: [{ where?: { status?: string } }]) => c[0]?.where?.status === 'removed'
+    (c: { where?: { status?: string } }[]) => c[0]?.where?.status === 'removed'
   );
   return call?.[0]?.data;
 }

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.republish-asset-review.test.ts
@@ -1,0 +1,625 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NsfwLevel } from '~/server/common/enums';
+import {
+  OffsiteModerationError,
+  republishOwnListing,
+  unpublishOwnListing,
+} from '~/server/services/blocks/offsite-moderation.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+// The onsite drift warn is a dynamic import of the logging client; the canonical
+// mock keeps that graph out of this suite.
+import '~/__tests__/mocks/logging.mock';
+const mockRead = dbMock.dbRead;
+const mockWrite = dbMock.dbWrite;
+
+/**
+ * 🔴 THE OWNER-REPUBLISH ASSET-CHANGE REVIEW GATE.
+ *
+ * An owner may `unpublishOwnListing` their own approved listing, swap the icon / cover /
+ * screenshots (a `removed` listing is directly asset-editable) and republish. Before this
+ * gate that put brand-new store-card imagery live with NO content review — the existing
+ * go-live gates read scan STATUS, the destination href and MATURITY, none of which is a
+ * review.
+ *
+ * The gate compares the listing's CURRENT asset surface against the one recorded into the
+ * `owner-unpublish` event when the owner took it down (= what a moderator last approved).
+ * Changed, or no baseline at all, ⇒ route to `pending` + re-queue. Unchanged ⇒ immediate,
+ * byte-for-behaviour as before.
+ *
+ * All DB deps are mocked; `dbWrite.$transaction` runs its callback against the SAME write
+ * mock, so `tx.*` calls land on the same spies and a guarded 0-count can be asserted to
+ * abort BEFORE any audit event is written.
+ */
+
+type WriteMock = {
+  $transaction: ReturnType<typeof vi.fn>;
+  appListing: {
+    findUnique: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+  };
+  appBlock: { updateMany: ReturnType<typeof vi.fn> };
+  appListingModerationEvent: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  appListingPublishRequest: { create: ReturnType<typeof vi.fn> };
+  appBlockPublishRequest: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  appListingScreenshot: { findMany: ReturnType<typeof vi.fn> };
+  image: { findMany: ReturnType<typeof vi.fn> };
+};
+
+const { mockNotify, ids } = vi.hoisted(() => {
+  return {
+    mockNotify: vi.fn(async () => undefined),
+    ids: { n: 0 },
+  };
+});
+
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: mockNotify,
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
+  newAppListingReportId: () => `alrp_test_${++ids.n}`,
+  newAppOwnershipEventId: () => `aoe_test_${++ids.n}`,
+  newUlid: () => `ULIDTEST${++ids.n}`,
+}));
+
+const APP_ID = 'apl_target';
+const SLUG = 'cool-app';
+const OWNER = 500;
+const BLOCK_ID = 'apb_backing';
+const EXTERNAL_URL = 'https://cool.app';
+
+/** Pairwise-DISTINCT asset ids, so a mutant that confuses two fields cannot pass. */
+const ICON_ID = 11;
+const COVER_ID = 22;
+const SHOT_ID = 33;
+
+type Shot = { imageId: number; order: number; caption: string | null };
+
+const shot = (imageId: number, order = 0, caption: string | null = null): Shot => ({
+  imageId,
+  order,
+  caption,
+});
+
+/** The listing row `loadOwnedListingInTx` returns (the FIRST `appListing.findUnique`). */
+function ownedListing(
+  over: {
+    kind?: string;
+    iconId?: number | null;
+    coverId?: number | null;
+    contentRating?: string | null;
+  } = {}
+) {
+  const kind = over.kind ?? 'offsite';
+  return {
+    userId: OWNER,
+    status: 'removed',
+    kind,
+    slug: SLUG,
+    name: 'Cool App',
+    appBlockId: kind === 'onsite' ? BLOCK_ID : null,
+    contentRating: over.contentRating === undefined ? 'g' : over.contentRating,
+    iconId: over.iconId === undefined ? ICON_ID : over.iconId,
+    coverId: over.coverId === undefined ? COVER_ID : over.coverId,
+    externalUrl: kind === 'offsite' ? EXTERNAL_URL : null,
+    connectClientId: null,
+  };
+}
+
+/** The baseline shape `unpublishOwnListing` writes into `owner-unpublish.before.assets`. */
+const baseline = (
+  over: {
+    iconId?: number | null;
+    coverId?: number | null;
+    screenshots?: { imageId: number; caption: string | null }[];
+  } = {}
+) => ({
+  v: 1,
+  iconId: over.iconId === undefined ? ICON_ID : over.iconId,
+  coverId: over.coverId === undefined ? COVER_ID : over.coverId,
+  screenshots: over.screenshots ?? [{ imageId: SHOT_ID, caption: null }],
+});
+
+/**
+ * Stage a republish: the owned listing, the live screenshots, and the recorded baseline.
+ *
+ * `recorded: undefined` means "the event carries no snapshot at all" — the legacy arm.
+ */
+function wire(opts: {
+  kind?: string;
+  iconId?: number | null;
+  coverId?: number | null;
+  contentRating?: string | null;
+  shots?: Shot[];
+  recorded?: unknown;
+  levels?: Record<number, number>;
+  lastAction?: string;
+}) {
+  const shots = opts.shots ?? [shot(SHOT_ID)];
+  const levels = opts.levels ?? {};
+  const listing = ownedListing(opts);
+
+  // Read 1 = loadOwnedListingInTx; every later read (scan gate, actionability, rating
+  // floor) takes the blanket value, which carries the same asset ids + the kind/url the
+  // actionability gate needs. A thinner blanket would silently DISARM that gate.
+  mockWrite.appListing.findUnique.mockReset().mockResolvedValue(listing);
+  mockWrite.appListing.findUnique.mockResolvedValueOnce(listing);
+  mockWrite.appListingScreenshot.findMany
+    .mockReset()
+    .mockImplementation(async (args: { where?: { imageId?: unknown } }) =>
+      // The scan gate + the rating floor select `imageId: { not: null }`; the snapshot
+      // builder selects every row. Honour the filter so both see what they expect.
+      args?.where?.imageId ? shots.filter((s) => s.imageId != null) : shots
+    );
+  mockWrite.image.findMany
+    .mockReset()
+    .mockImplementation(async (args: { where?: { id?: { in?: number[] } } }) =>
+      (args?.where?.id?.in ?? []).map((id) => ({
+        id,
+        ingestion: 'Scanned',
+        nsfwLevel: levels[id] ?? NsfwLevel.PG,
+      }))
+    );
+  mockWrite.appListingModerationEvent.findFirst.mockReset().mockResolvedValue(
+    'lastAction' in opts && opts.lastAction !== 'owner-unpublish'
+      ? { action: opts.lastAction, before: { status: 'approved' } }
+      : {
+          action: 'owner-unpublish',
+          before:
+            'recorded' in opts
+              ? { status: 'approved', assets: opts.recorded }
+              : { status: 'approved', assets: baseline() },
+        }
+  );
+}
+
+/** The `data` of the guarded `removed → …` status flip. */
+function flipData() {
+  const call = mockWrite.appListing.updateMany.mock.calls.find(
+    (c: [{ where?: { status?: string } }]) => c[0]?.where?.status === 'removed'
+  );
+  return call?.[0]?.data;
+}
+
+/** The single moderation event the republish wrote. */
+function eventData() {
+  return mockWrite.appListingModerationEvent.create.mock.calls[0]?.[0]?.data;
+}
+
+/** The approved block request the onsite re-queue clones. */
+const lastApprovedBlockRequest = {
+  appBlockId: BLOCK_ID,
+  version: '1.2.0',
+  manifest: { blockId: SLUG, scopes: [] },
+  bundleKey: 'bundles/deadbeef.zip',
+  bundleSha256: 'deadbeef',
+  bundleSizeBytes: BigInt(1024),
+  fileSummary: { files: [], added: [], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'update' },
+  forgejoCommitSha: 'sha_server_side',
+  sourceCommit: '4f3a9c2e17b06d85fa1c39e470b28d6ac519e0f3',
+  sourceDirty: true,
+};
+
+beforeEach(() => {
+  ids.n = 0;
+  vi.clearAllMocks();
+  mockWrite.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) =>
+    cb(mockWrite)
+  );
+  mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+  mockWrite.appBlock.updateMany.mockResolvedValue({ count: 1 });
+  mockWrite.appListingModerationEvent.create.mockImplementation(
+    async (a: { data: unknown }) => a.data
+  );
+  mockWrite.appListingPublishRequest.create.mockImplementation(
+    async (a: { data: unknown }) => a.data
+  );
+  mockWrite.appBlockPublishRequest.create.mockImplementation(
+    async (a: { data: unknown }) => a.data
+  );
+  // Onsite default: one approved version to clone, no review already in flight.
+  mockWrite.appBlockPublishRequest.findFirst
+    .mockResolvedValueOnce(lastApprovedBlockRequest)
+    .mockResolvedValueOnce(null);
+  mockRead.appListing.findUnique.mockResolvedValue(null);
+  mockNotify.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// The IMMEDIATE arm — unchanged assets must behave exactly as they did before.
+// ---------------------------------------------------------------------------
+
+describe('republishOwnListing — assets UNCHANGED ⇒ immediate (no behaviour change)', () => {
+  it('goes live, writes no re-review artifact, and reports `approved` with no reviewReason', async () => {
+    wire({ recorded: baseline() });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(flipData()).toEqual({ status: 'approved', contentRating: 'g' });
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
+    expect(eventData()).toMatchObject({
+      action: 'owner-republish',
+      before: { status: 'removed' },
+      after: { status: 'approved' },
+    });
+    expect(eventData().detail).toBeUndefined();
+  });
+
+  it('🔴 a screenshot RENUMBER with no reorder is still immediate (no false positive)', async () => {
+    // Baseline recorded at order 0/1; live rows renumbered 10/20 in the same sequence.
+    wire({
+      shots: [shot(SHOT_ID, 10), shot(44, 20)],
+      recorded: baseline({
+        screenshots: [
+          { imageId: SHOT_ID, caption: null },
+          { imageId: 44, caption: null },
+        ],
+      }),
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('approved');
+  });
+
+  it('🔴 a whitespace-only caption edit is still immediate (no false positive)', async () => {
+    wire({
+      shots: [shot(SHOT_ID, 0, '  hello  ')],
+      recorded: baseline({ screenshots: [{ imageId: SHOT_ID, caption: 'hello' }] }),
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('approved');
+  });
+
+  it('ON-SITE unchanged: restores the backing block, exactly as before', async () => {
+    wire({ kind: 'onsite', recorded: baseline() });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('approved');
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: BLOCK_ID, status: 'suspended' },
+      data: { status: 'approved' },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The REVIEW arm.
+// ---------------------------------------------------------------------------
+
+describe('republishOwnListing — assets CHANGED ⇒ routed to review', () => {
+  it.each([
+    ['the ICON was swapped', { iconId: 99 }, undefined],
+    ['the ICON was cleared', { iconId: null }, undefined],
+    ['the COVER was swapped', { coverId: 99 }, undefined],
+    ['an ICON was ADDED where there was none', { iconId: ICON_ID }, { iconId: null }],
+  ])('%s', async (_label, listingOver, baselineOver) => {
+    wire({ ...listingOver, recorded: baseline(baselineOver ?? {}) });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({
+      appListingId: APP_ID,
+      status: 'pending',
+      reviewReason: 'assets-changed',
+    });
+  });
+
+  it.each([
+    ['a screenshot IMAGE was swapped', [shot(99)], [{ imageId: SHOT_ID, caption: null }]],
+    ['a screenshot was ADDED', [shot(SHOT_ID), shot(44, 1)], [{ imageId: SHOT_ID, caption: null }]],
+    ['every screenshot was REMOVED', [], [{ imageId: SHOT_ID, caption: null }]],
+    [
+      'a screenshot CAPTION was rewritten',
+      [shot(SHOT_ID, 0, 'buy now')],
+      [{ imageId: SHOT_ID, caption: 'a demo' }],
+    ],
+    [
+      'two screenshots were REORDERED',
+      [shot(44, 0), shot(SHOT_ID, 1)],
+      [
+        { imageId: SHOT_ID, caption: null },
+        { imageId: 44, caption: null },
+      ],
+    ],
+  ])('%s', async (_label, shots, recordedShots) => {
+    wire({ shots: shots as Shot[], recorded: baseline({ screenshots: recordedShots as never }) });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('pending');
+    expect(res.reviewReason).toBe('assets-changed');
+  });
+
+  it('OFF-SITE: flips to pending, mints an owner-submitted pending request, writes the audit event', async () => {
+    wire({ iconId: 99, recorded: baseline() });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+
+    // The flip is status + kind guarded and carries the (floored) rating.
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'removed' },
+      data: { status: 'pending', contentRating: 'g' },
+    });
+    // Re-queued as a NON-shadow request owned by the LISTING OWNER — the shape
+    // `approveExternalRequest`'s widened `{draft,pending}` guard re-approves.
+    expect(mockWrite.appListingPublishRequest.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingPublishRequest.create.mock.calls[0][0].data).toMatchObject({
+      appListingId: APP_ID,
+      kind: 'offsite',
+      slug: SLUG,
+      submittedByUserId: OWNER,
+      status: 'pending',
+    });
+    // The history says it went to REVIEW, not live, and says why.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(eventData()).toMatchObject({
+      appListingId: APP_ID,
+      slug: SLUG,
+      action: 'owner-republish',
+      actorUserId: OWNER,
+      before: { status: 'removed' },
+      after: { status: 'pending' },
+    });
+    expect(eventData().detail).toContain('changed since the last approval');
+    // No block to touch on an off-site listing.
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 ON-SITE: clones the approved block request and LEAVES THE BLOCK SUSPENDED', async () => {
+    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+
+    expect(res.status).toBe('pending');
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'onsite', status: 'removed' },
+      data: { status: 'pending', contentRating: 'g' },
+    });
+    // 🔴 THE LOAD-BEARING ABSENCE: an app awaiting review of its store card must NOT be
+    // serving. `approveRequest`'s (3b-reset) branch un-suspends it on re-approve, gated
+    // on exactly the `pending` listing status written above.
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+    // Re-queued through the BLOCK request table (the onsite review queue), owner-submitted,
+    // carrying the approved version's bytes + provenance verbatim.
+    expect(mockWrite.appBlockPublishRequest.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appBlockPublishRequest.create.mock.calls[0][0].data).toMatchObject({
+      appBlockId: BLOCK_ID,
+      slug: SLUG,
+      submittedByUserId: OWNER,
+      status: 'pending',
+      version: '1.2.0',
+      bundleSha256: 'deadbeef',
+      sourceCommit: lastApprovedBlockRequest.sourceCommit,
+      sourceDirty: true,
+    });
+    // The off-site listing-request table is NOT the onsite queue — writing there would
+    // strand the app where no moderator looks.
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 ON-SITE with NO approved version to clone → NOT_TRANSITIONABLE, and NOTHING is written', async () => {
+    // Stranding the listing in `pending` with nothing in any queue would be unrecoverable
+    // for the owner, so the whole republish must refuse instead.
+    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
+    mockWrite.appBlockPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({
+      name: 'OffsiteModerationError',
+      code: 'NOT_TRANSITIONABLE',
+      message: expect.stringContaining('no approved version'),
+    });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 ON-SITE with a review already in flight → NOT_TRANSITIONABLE, and NOTHING is written', async () => {
+    wire({ kind: 'onsite', iconId: 99, recorded: baseline() });
+    mockWrite.appBlockPublishRequest.findFirst
+      .mockReset()
+      .mockResolvedValueOnce(lastApprovedBlockRequest)
+      .mockResolvedValueOnce({ id: 'pubreq_open' });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({
+      code: 'NOT_TRANSITIONABLE',
+      message: expect.stringContaining('already pending'),
+    });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('a raced 0-count on the pending flip aborts BEFORE any audit event or queue entry', async () => {
+    wire({ iconId: 99, recorded: baseline() });
+    mockWrite.appListing.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 The FAIL-CLOSED arm: no usable baseline.
+// ---------------------------------------------------------------------------
+
+describe('republishOwnListing — 🔴 NO usable baseline ⇒ review, never a silent pass', () => {
+  it('a legacy `owner-unpublish` event with no recorded assets routes to review', async () => {
+    // The whole population of listings unpublished BEFORE the snapshot shipped.
+    wire({ iconId: 99, recorded: undefined });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({
+      action: 'owner-unpublish',
+      before: { status: 'approved' },
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({
+      appListingId: APP_ID,
+      status: 'pending',
+      reviewReason: 'no-recorded-assets',
+    });
+    expect(eventData().detail).toContain('no recorded assets');
+  });
+
+  it('🔴 an ASSET-LESS listing with no baseline ALSO routes to review', async () => {
+    // The case a coercing parser gets wrong: an "empty" snapshot compares EQUAL to a
+    // listing with no assets, so unknown would silently read as unchanged and go live.
+    wire({ iconId: null, coverId: null, shots: [] });
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({
+      action: 'owner-unpublish',
+      before: { status: 'approved' },
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('pending');
+    expect(res.reviewReason).toBe('no-recorded-assets');
+  });
+
+  it.each([
+    ['a FUTURE snapshot version', { v: 2, iconId: ICON_ID, coverId: COVER_ID, screenshots: [] }],
+    ['a malformed payload', { v: 1, iconId: 'eleven', coverId: COVER_ID, screenshots: [] }],
+    ['a non-object payload', 'approved'],
+  ])('%s is UNKNOWN, not empty → review', async (_label, recorded) => {
+    wire({ recorded });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.reviewReason).toBe('no-recorded-assets');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition with the pre-existing gates.
+// ---------------------------------------------------------------------------
+
+describe('republishOwnListing — composition with the gates that were already there', () => {
+  it('🔴 the mod-takedown guard still wins: a `delist` last event is FORBIDDEN, gate never runs', async () => {
+    wire({ iconId: 99, lastAction: 'delist' });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('the scan-clean gate still refuses a Blocked asset — even on the review arm', async () => {
+    wire({ iconId: 99, recorded: baseline() });
+    mockWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: id === 99 ? 'Blocked' : 'Scanned',
+          nsfwLevel: NsfwLevel.PG,
+        }))
+    );
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('blocked') });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 #4418 RATING FLOOR is applied on the REVIEW arm too, not deferred to the approve', async () => {
+    // Declared `g`, an X-rated cover swapped in. On-site is the case that matters most:
+    // `approveRequest`'s (3b-reset) restore writes ONLY `status` and runs no floor of its
+    // own, so a review arm that skipped the floor would let mature art come back rated `g`.
+    wire({
+      kind: 'onsite',
+      contentRating: 'g',
+      coverId: 99,
+      recorded: baseline(),
+      levels: { [ICON_ID]: NsfwLevel.PG13, 99: NsfwLevel.X, [SHOT_ID]: NsfwLevel.PG },
+    });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res.status).toBe('pending');
+    expect(flipData()).toEqual({ status: 'pending', contentRating: 'x' });
+  });
+
+  it('the floor is RAISE-ONLY on the review arm as well (tame media never lowers `x`)', async () => {
+    wire({
+      contentRating: 'x',
+      iconId: 99,
+      recorded: baseline(),
+      levels: { 99: NsfwLevel.PG, [COVER_ID]: NsfwLevel.PG, [SHOT_ID]: NsfwLevel.PG },
+    });
+    await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(flipData()).toEqual({ status: 'pending', contentRating: 'x' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The RECORD side.
+// ---------------------------------------------------------------------------
+
+describe('unpublishOwnListing — records the approved asset surface', () => {
+  it('🔴 writes the live icon/cover/screenshots into `owner-unpublish.before.assets`', async () => {
+    const listing = { ...ownedListing({}), status: 'approved' };
+    mockWrite.appListing.findUnique.mockReset().mockResolvedValue(listing);
+    mockWrite.appListingScreenshot.findMany
+      .mockReset()
+      .mockResolvedValue([shot(SHOT_ID, 0, 'a demo'), shot(44, 1)]);
+
+    await unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+
+    expect(eventData()).toMatchObject({
+      action: 'owner-unpublish',
+      after: { status: 'removed' },
+      before: {
+        status: 'approved',
+        assets: {
+          v: 1,
+          iconId: ICON_ID,
+          coverId: COVER_ID,
+          screenshots: [
+            { imageId: SHOT_ID, caption: 'a demo' },
+            { imageId: 44, caption: null },
+          ],
+        },
+      },
+    });
+  });
+
+  it('records an explicit empty surface for a listing with no assets (not a missing one)', async () => {
+    const listing = { ...ownedListing({ iconId: null, coverId: null }), status: 'approved' };
+    mockWrite.appListing.findUnique.mockReset().mockResolvedValue(listing);
+    mockWrite.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+
+    await unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+
+    expect(eventData().before.assets).toEqual({
+      v: 1,
+      iconId: null,
+      coverId: null,
+      screenshots: [],
+    });
+  });
+
+  it('🔴 record → republish ROUND TRIP: what unpublish wrote lets an untouched republish stay immediate', async () => {
+    // The seam neither half tests alone. `unpublishOwnListing` writes the baseline;
+    // `republishOwnListing` reads it back and must recognise its own format. A shape
+    // change on either side that the other did not follow shows up HERE and nowhere else.
+    const shots = [shot(SHOT_ID, 0, 'a demo'), shot(44, 1)];
+    const approved = { ...ownedListing({}), status: 'approved' };
+    mockWrite.appListing.findUnique.mockReset().mockResolvedValue(approved);
+    mockWrite.appListingScreenshot.findMany.mockReset().mockResolvedValue(shots);
+    await unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    const recorded = eventData().before.assets;
+
+    vi.clearAllMocks();
+    mockWrite.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) =>
+      cb(mockWrite)
+    );
+    mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+    mockWrite.appListingModerationEvent.create.mockImplementation(
+      async (a: { data: unknown }) => a.data
+    );
+    wire({ shots, recorded });
+
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+  });
+});
+
+describe('OffsiteModerationError is still the error type callers map', () => {
+  it('exports the class the router duck-types on', () => {
+    expect(new OffsiteModerationError('NOT_FOUND', 'x').name).toBe('OffsiteModerationError');
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -212,7 +212,8 @@ afterAll(() => {
 function scalarSyncCalls() {
   return db.write.appListing.updateMany.mock.calls.filter((c) => {
     const arg = c[0] as { data?: Record<string, unknown> };
-    // The (3b-reset) restore writes ONLY `{ status: 'approved' }`.
+    // The (3b-reset) restore writes `status` (+ the go-live rating floor); the
+    // manifest scalar sync never writes `status`, so keying on its absence separates them.
     return arg?.data != null && !('status' in arg.data);
   });
 }

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -601,6 +601,100 @@ describe('submitVersion', () => {
     expect(mockDbWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
   });
 
+  // -------------------------------------------------------------------------
+  // 🔴 The cross-queue submit guard. `one_pending_per_slug` is partial-unique on
+  // `AppBlockPublishRequest` only; while that was the sole re-review surface for an
+  // on-site app it doubled as a mutual exclusion. The owner-republish asset-review route
+  // re-queues on `AppListingPublishRequest`, so the index sits free while a review IS
+  // open. Both cases below drive one fake `app_listing_publish_requests` table so the
+  // difference between them is the DATA, not the mock.
+  // -------------------------------------------------------------------------
+  const wireListingReviewTable = (rows: Record<string, unknown>[]) => {
+    mockDbRead.appListingPublishRequest.findFirst.mockImplementation(
+      async (args: { where?: Record<string, any> }) => {
+        const w = args?.where ?? {};
+        const hit = rows.find((r) =>
+          Object.entries(w).every(([k, v]) => {
+            if (k === 'appListing') {
+              // Relation predicate — compare each named field on the joined listing.
+              const joined = (r.appListing ?? {}) as Record<string, unknown>;
+              return Object.entries(v as Record<string, unknown>).every(
+                ([jk, jv]) => joined[jk] === jv
+              );
+            }
+            return r[k] === v;
+          })
+        );
+        return hit ? { id: hit.id } : null;
+      }
+    );
+  };
+
+  it('🔴 refuses a new version while a NON-SHADOW on-site listing review is open for the slug', async () => {
+    // The state the asset-review route creates: listing `pending`, block `suspended`, a
+    // pending listing request, and the block index FREE. Letting a version in here is how
+    // a moderator ends up approving a bundle whose approve branch would restore a listing
+    // whose imagery nobody has reviewed.
+    const { submitVersion } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    wireListingReviewTable([
+      {
+        id: 'alpr_imagery',
+        slug: 'hello',
+        kind: 'onsite',
+        status: 'pending',
+        appListing: { revisionOfId: null },
+      },
+    ]);
+    const buf = await makeValidBundle();
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /has a store-listing review open/
+    );
+    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(mockDbWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 does NOT refuse while only a SHADOW media revision is open — that has always coexisted with a code submit', async () => {
+    // The negative control, and the reason the guard is scoped to `revisionOfId: null`.
+    // A pending shadow media revision denormalizes the parent slug onto its request row,
+    // so a slug-only guard would block every release for the length of an ordinary media
+    // review — a regression, not a fix.
+    const { submitVersion } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    wireListingReviewTable([
+      {
+        id: 'alpr_shadow',
+        slug: 'hello',
+        kind: 'onsite',
+        status: 'pending',
+        appListing: { revisionOfId: 'apl_parent' },
+      },
+    ]);
+    const buf = await makeValidBundle();
+    const result = await submitVersion({ bundleBuffer: buf, submittedByUserId: 42 });
+    expect(result.publishRequestId).toMatch(/^pubreq_/);
+  });
+
+  it('does NOT refuse on a CLOSED listing review — one completed cycle must not block every future version', async () => {
+    // The other half of the predicate: `status: 'pending'`. A slug accumulates
+    // approved/rejected/withdrawn listing requests forever, so a guard that forgot the
+    // status would permanently wedge the app's releases after its first imagery review.
+    const { submitVersion } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    wireListingReviewTable([
+      {
+        id: 'alpr_done',
+        slug: 'hello',
+        kind: 'onsite',
+        status: 'approved',
+        appListing: { revisionOfId: null },
+      },
+    ]);
+    const buf = await makeValidBundle();
+    const result = await submitVersion({ bundleBuffer: buf, submittedByUserId: 42 });
+    expect(result.publishRequestId).toMatch(/^pubreq_/);
+  });
+
   it('rejects other-user collision without leaking the existing request id', async () => {
     const { submitVersion } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
@@ -832,6 +926,52 @@ describe('withdrawRequest', () => {
     expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith({
       where: { id: 'pubreq_version', status: 'pending' },
       data: { status: 'withdrawn' },
+    });
+  });
+
+  it('🔴 a CLOSED listing request on the row does NOT stop a mod-reset withdraw from delisting', async () => {
+    // The other half of the discriminator's predicate, and the case a shipped survivor
+    // exposed: `status: 'pending'`. A listing accumulates approved / rejected / withdrawn
+    // request rows forever — one completed imagery-review cycle is the ordinary shape, not
+    // an exotic one. A discriminator that only asked "is there ANY listing request on this
+    // row" would read a stale row as ownership and silently stop honouring the moderator's
+    // mandated re-review from then on, for every future withdraw on that app.
+    const { withdrawRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_reset',
+      status: 'pending',
+      submittedByUserId: 42,
+      slug: 'my-app',
+    });
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb(mockDbWrite)
+    );
+    mockDbRead.appListing.findFirst.mockResolvedValue({ id: 'apl_1', slug: 'my-app' });
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+    // One fake `app_listing_publish_requests` row: a review that is OVER.
+    const rows = [{ id: 'alpr_old', appListingId: 'apl_1', status: 'withdrawn' }];
+    mockDbRead.appListingPublishRequest.findFirst.mockImplementation(
+      async (args: { where?: Record<string, unknown> }) => {
+        const w = args?.where ?? {};
+        const hit = rows.find((r) =>
+          Object.entries(w).every(([k, v]) => (r as Record<string, unknown>)[k] === v)
+        );
+        return hit ? { id: hit.id } : null;
+      }
+    );
+
+    await withdrawRequest({ publishRequestId: 'pubreq_reset', userId: 42 });
+
+    // No PENDING listing request owns the row → this block request IS the open review →
+    // the mod reset still closes, exactly as before the discriminator existed.
+    expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', kind: 'onsite', status: 'pending' },
+      data: { status: 'removed' },
+    });
+    expect(mockDbWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'delist',
+      actorUserId: 42,
     });
   });
 
@@ -1553,6 +1693,127 @@ describe('approveRequest', () => {
       where: { id: 'apb_existing', status: 'suspended' },
       data: { status: 'approved' },
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 WHICH QUEUE OWNS THE REVIEW — the (3b-reset) discriminator.
+  //
+  // `one_pending_per_slug` (partial-unique on AppBlockPublishRequest) used to be an
+  // implicit MUTUAL EXCLUSION: an on-site re-review always occupied it, so a `pending`
+  // on-site listing implied a mod reset and a mod reset implied a pending block request.
+  // The owner-republish asset-review route re-queues on `AppListingPublishRequest`
+  // instead, leaving the index free — so a slug can carry an open IMAGERY review and an
+  // open CODE review at once, and approving the code one must not publish the imagery.
+  //
+  // Both arms below drive the SAME simulation: a one-row fake `app_listings` table whose
+  // `publishRequests` relation really is evaluated (`none` / `some` / `every`, field by
+  // field), rather than a mock that pattern-matches the filter this code happens to write.
+  // The two arms differ ONLY in that relation's contents, and the "no open review" arm
+  // carries an APPROVED request — a completed prior review cycle, the realistic shape —
+  // so a filter that forgot to say `status: 'pending'` refuses the legitimate restore and
+  // fails the control rather than passing it.
+  // -------------------------------------------------------------------------
+  const wireResetListingLookup = (opts: { openListingReview: boolean }) => {
+    const row = { id: 'apl_reset', contentRating: 'g' };
+    // What sits on `AppListing.publishRequests` for the fake row.
+    const requests: Record<string, unknown>[] = opts.openListingReview
+      ? [{ status: 'pending', kind: 'onsite' }]
+      : [{ status: 'approved', kind: 'onsite' }];
+    /** Every `updateMany` that actually MATCHED the fake row — i.e. really flipped it. */
+    const flippedRows: unknown[] = [];
+    const relationMatches = (rel: Record<string, any> | undefined) => {
+      if (!rel) return true;
+      const spec = rel.none ?? rel.some ?? rel.every;
+      const pred = (r: Record<string, unknown>) =>
+        Object.entries(spec ?? {}).every(([k, v]) => r[k] === v);
+      if (rel.none) return !requests.some(pred);
+      if (rel.some) return requests.some(pred);
+      if (rel.every) return requests.every(pred);
+      return true;
+    };
+    const matches = (where: Record<string, any> | undefined) => {
+      if (where?.appBlockId !== 'apb_existing') return false;
+      if (where?.kind !== 'onsite') return false;
+      if (where?.status !== 'pending') return false;
+      return relationMatches(where?.publishRequests);
+    };
+    mockDbWrite.appListing.findFirst.mockImplementation(async (args: { where?: any }) =>
+      matches(args?.where) ? row : null
+    );
+    mockDbWrite.appListing.updateMany.mockImplementation(async (args: { where?: any }) => {
+      const hit = matches(args?.where);
+      if (hit) flippedRows.push(args);
+      return { count: hit ? 1 : 0 };
+    });
+    // Scan-clean + rating-floor reads for the arm where the lookup DOES find the row.
+    mockDbWrite.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: 2, contentRating: 'g' });
+    mockDbWrite.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDbWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: 'Scanned',
+          nsfwLevel: NsfwLevel.PG,
+        }))
+    );
+    return { flippedRows };
+  };
+
+  const wireSubsequentVersionApprove = async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      id: 'apb_existing',
+      appId: 'oc_existing',
+      repoUrl: 'https://forgejo.example/civitai-apps/hello',
+      app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+    });
+    mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0' });
+  };
+
+  const unsuspendCall = () =>
+    mockDbWrite.appBlock.updateMany.mock.calls.find(
+      (c: any[]) => c[0]?.where?.status === 'suspended' && c[0]?.data?.status === 'approved'
+    );
+
+  it('🔴 (3b-reset) does NOT restore a pending on-site listing whose review belongs to the LISTING queue', async () => {
+    // The chain: owner unpublishes (listing `removed`, block `suspended`, asset baseline
+    // recorded) → owner swaps the icon/cover/screenshots and republishes → the assets
+    // differ, so the listing goes to `pending` with a pending `AppListingPublishRequest`
+    // and NO block request → a new app VERSION is submitted → a moderator approves THAT
+    // (a bundle review whose modal renders ZIP-extracted screenshots and nothing about
+    // listing imagery). Without the discriminator this branch flips the listing back to
+    // `approved` and un-suspends the block, putting never-reviewed store imagery live and
+    // stranding the listing request in a queue whose approve path can no longer match it.
+    const { approveRequest } = await import('../publish-request.service');
+    await wireSubsequentVersionApprove();
+    const { flippedRows } = wireResetListingLookup({ openListingReview: true });
+
+    const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+    // The CODE approve still lands — the listing restore is the only thing refused.
+    expect(result.isFirstVersion).toBe(false);
+
+    // The listing row was never matched, so it is still `pending` (in review) and its
+    // swapped imagery is still not public.
+    expect(flippedRows).toEqual([]);
+    // …and the block stays `suspended`: an app whose store card is awaiting review must
+    // not be serving. (The un-suspend is gated on the restore having matched.)
+    expect(unsuspendCall()).toBeUndefined();
+  });
+
+  it('🔴 (3b-reset) DOES restore a mod-reset listing — no listing request owns it (the discriminator is not a blanket refusal)', async () => {
+    // The negative control for the test above, run through the identical simulation. A
+    // mod reset (`resetOnsiteListingToPending`) re-queues on the BLOCK surface and leaves
+    // no listing request, so this approve IS the review that is open on the row and the
+    // restore must proceed end-to-end.
+    const { approveRequest } = await import('../publish-request.service');
+    await wireSubsequentVersionApprove();
+    const { flippedRows } = wireResetListingLookup({ openListingReview: false });
+
+    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+    expect(flippedRows).toHaveLength(1);
+    expect(flippedRows[0]).toMatchObject({ data: { status: 'approved' } });
+    expect(unsuspendCall()).toEqual([{ where: { id: 'apb_existing', status: 'suspended' }, data: { status: 'approved' } }]);
   });
 
   it('🔴 the reset restore FLOORS contentRating at the media-derived rating (raise-only)', async () => {

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import JSZip from 'jszip';
 
+import { NsfwLevel } from '~/server/common/enums';
+
 /**
  * Orchestration coverage for the W1 publish-request service. The existing
  * publish-request.service.test.ts covers the pure helpers (extract / diff);
@@ -65,6 +67,11 @@ const {
       // Fix #1 (onsite): withdrawRequest probes the listing's latest mod event to
       // decide whether a reset withdraw closes the listing. Null → no reset in flight.
       appListingModerationEvent: { findFirst: vi.fn(async () => null) },
+      // A `pending` onsite listing is no longer proof that THIS block request is the
+      // review open on it — the owner-republish asset-review route parks a listing in
+      // `pending` with an `AppListingPublishRequest` and no block request. Null → no
+      // listing-side review, i.e. the mod-reset case this suite's assertions describe.
+      appListingPublishRequest: { findFirst: vi.fn(async () => null) },
     },
     mockDbWrite: {
       // `updateMany` added (no-trust-on-push fix): approveRequest now supersedes
@@ -151,7 +158,8 @@ const {
       // repoCommitUrl — used by the list payloads' pushCommitUrl (links a
       // push-originated review to the canonical repo at the pushed sha).
       repoCommitUrl: vi.fn(
-        (slug: string, ref: string) => `https://forgejo.example/civitai-apps/${slug}/src/commit/${ref}`
+        (slug: string, ref: string) =>
+          `https://forgejo.example/civitai-apps/${slug}/src/commit/${ref}`
       ),
     },
     // apps-pipeline.service.triggerBuild — approveRequest now triggers the
@@ -354,22 +362,20 @@ beforeEach(() => {
   // (externalUrl=null) row derived from the default manifest, and create() echoes
   // the generated id back.
   mockDbRead.appListing.findUnique.mockResolvedValue(null);
-  mockDbWrite.appBlock.findUnique.mockImplementation(
-    async (args: { where: { id: string } }) => ({
-      id: args.where.id,
-      blockId: 'hello',
-      manifest: manifest(),
-      contentRating: 'g',
-      category: null,
-      featured: false,
-      featuredOrder: null,
-      externalUrl: null,
-      app: { userId: 42 },
-    })
-  );
-  mockDbWrite.appListing.create.mockImplementation(
-    async (args: { data: { id: string } }) => ({ id: args.data.id })
-  );
+  mockDbWrite.appBlock.findUnique.mockImplementation(async (args: { where: { id: string } }) => ({
+    id: args.where.id,
+    blockId: 'hello',
+    manifest: manifest(),
+    contentRating: 'g',
+    category: null,
+    featured: false,
+    featuredOrder: null,
+    externalUrl: null,
+    app: { userId: 42 },
+  }));
+  mockDbWrite.appListing.create.mockImplementation(async (args: { data: { id: string } }) => ({
+    id: args.data.id,
+  }));
 
   // S3 default no-op for PUT; GET returns whatever mockBundleBuffer.current is set to.
   mockS3Send.mockImplementation(async (cmd: { input?: { Key?: string } }) => {
@@ -678,7 +684,9 @@ describe('submitVersion', () => {
 
   it('Discord notify is invoked with the right shape on submission', async () => {
     const { submitVersion } = await import('../publish-request.service');
-    const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true, status: 200 } as Response));
+    const fetchSpy = vi.fn(
+      async (_url: string, _init?: RequestInit) => ({ ok: true, status: 200 } as Response)
+    );
     vi.stubGlobal('fetch', fetchSpy);
 
     const buf = await makeValidBundle();
@@ -761,8 +769,8 @@ describe('withdrawRequest', () => {
     });
     mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
     // beforeEach's mockReset strips the tx impl — re-wire it to run the callback.
-    mockDbWrite.$transaction.mockImplementation(
-      async (cb: (tx: unknown) => Promise<unknown>) => cb(mockDbWrite)
+    mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb(mockDbWrite)
     );
     // The reset target: an onsite listing for this slug is currently `pending`. A pending
     // onsite listing is ALWAYS a mod reset (deterministic — NO most-recent-event probe,
@@ -786,6 +794,44 @@ describe('withdrawRequest', () => {
       actorUserId: 42,
       before: { status: 'pending' },
       after: { status: 'removed' },
+    });
+  });
+
+  it('🔴 does NOT close a pending onsite listing whose review belongs to the LISTING queue', async () => {
+    // The hazard the owner-republish asset-review route introduced. That route parks the
+    // listing in `pending` with an `AppListingPublishRequest` and NO block request — so
+    // the one-pending-per-slug index is free and the owner can submit an ordinary new app
+    // VERSION. Withdrawing that version used to reach here, see `status: 'pending'`, and
+    // delist a listing whose image review was sitting untouched in the other queue: the
+    // owner goes from "waiting for review" to "removed by a moderator, ask a moderator to
+    // relist" for withdrawing something else entirely.
+    //
+    // This is a DISCRIMINATOR, not a relaxation — the mod-reset case below has no listing
+    // request and still closes, and nothing here decides whether an owner may self-restore.
+    const { withdrawRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_version',
+      status: 'pending',
+      submittedByUserId: 42,
+      slug: 'my-app',
+    });
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb(mockDbWrite)
+    );
+    mockDbRead.appListing.findFirst.mockResolvedValue({ id: 'apl_1', slug: 'my-app' });
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+    // The distinguishing fact, and the ONLY thing that differs from the mod-reset case.
+    mockDbRead.appListingPublishRequest.findFirst.mockResolvedValue({ id: 'alpr_open' });
+
+    await withdrawRequest({ publishRequestId: 'pubreq_version', userId: 42 });
+
+    expect(mockDbWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    // The version withdraw itself still happened — only the listing close is refused.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith({
+      where: { id: 'pubreq_version', status: 'pending' },
+      data: { status: 'withdrawn' },
     });
   });
 
@@ -1398,7 +1444,11 @@ describe('approveRequest', () => {
     // (a) listing restored pending → approved (guarded to `pending`; status-only).
     expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ appBlockId: 'apb_existing', kind: 'onsite', status: 'pending' }),
+        where: expect.objectContaining({
+          appBlockId: 'apb_existing',
+          kind: 'onsite',
+          status: 'pending',
+        }),
         data: { status: 'approved' },
       })
     );
@@ -1429,8 +1479,12 @@ describe('approveRequest', () => {
     // scanning (the shared wrapper re-reads icon/cover by id, then the scan gate).
     mockDbWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_reset' });
     mockDbWrite.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: 2 });
-    mockDbWrite.image.findMany.mockImplementation(async (args: { where?: { id?: { in?: number[] } } }) =>
-      (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: id === 1 ? 'Pending' : 'Scanned' }))
+    mockDbWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: id === 1 ? 'Pending' : 'Scanned',
+        }))
     );
     mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
 
@@ -1473,8 +1527,9 @@ describe('approveRequest', () => {
     mockDbWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_reset' });
     mockDbWrite.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: 2 });
     // Re-stage the clean image impl (clearAllMocks doesn't reset a prior test's impl).
-    mockDbWrite.image.findMany.mockImplementation(async (args: { where?: { id?: { in?: number[] } } }) =>
-      (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: 'Scanned' }))
+    mockDbWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: 'Scanned' }))
     );
     // The reset listing flip matches one row (listing WAS pending) → reset re-approve.
     mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
@@ -1485,7 +1540,11 @@ describe('approveRequest', () => {
     // (a) The store-visibility restore (pending → approved) PROCEEDED (gate passed).
     expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ appBlockId: 'apb_existing', kind: 'onsite', status: 'pending' }),
+        where: expect.objectContaining({
+          appBlockId: 'apb_existing',
+          kind: 'onsite',
+          status: 'pending',
+        }),
         data: { status: 'approved' },
       })
     );
@@ -1494,6 +1553,97 @@ describe('approveRequest', () => {
       where: { id: 'apb_existing', status: 'suspended' },
       data: { status: 'approved' },
     });
+  });
+
+  it('🔴 the reset restore FLOORS contentRating at the media-derived rating (raise-only)', async () => {
+    // 🔴 THE HOLE THIS CLOSES. `(3b-reset)` used to write `{ status: 'approved' }` and
+    // NOTHING ELSE, while its sibling `(3b-transition)` floored — and a `pending` listing
+    // is DIRECTLY owner-asset-editable (`assertOwnerAssetEditable` refuses only `approved`,
+    // and `pending` is authorable, so the Media tab is offered normally). The attach path
+    // rejects `Blocked`/`NotFound` but never compares an image's `nsfwLevel` against the
+    // listing rating, and `reDeriveContentRatingForModLiveEdit` no-ops for a non-moderator
+    // AND for any status other than `approved`. So: reset → owner swaps in a
+    // Scanned-but-MATURE cover → mod re-approves → live under the stale `g`, visible to
+    // SFW-only users.
+    //
+    // Fixture note: the declared rating and the two image levels are pairwise distinct, so
+    // a mutant that echoed the declared value, or read the icon instead of the cover,
+    // produces a different answer than the one asserted.
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      id: 'apb_existing',
+      appId: 'oc_existing',
+      repoUrl: 'https://forgejo.example/civitai-apps/hello',
+      app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+    });
+    mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0' });
+    mockDbWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_reset', contentRating: 'g' });
+    mockDbWrite.appListing.findUnique.mockResolvedValue({
+      iconId: 1,
+      coverId: 2,
+      contentRating: 'g',
+    });
+    mockDbWrite.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDbWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: 'Scanned',
+          // The COVER is the mature one; the icon stays tame.
+          nsfwLevel: id === 2 ? NsfwLevel.X : NsfwLevel.PG,
+        }))
+    );
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+    expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          appBlockId: 'apb_existing',
+          kind: 'onsite',
+          status: 'pending',
+        }),
+        data: { status: 'approved', contentRating: 'x' },
+      })
+    );
+  });
+
+  it('the reset restore floor is RAISE-ONLY — tame media never lowers a mature rating', async () => {
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      id: 'apb_existing',
+      appId: 'oc_existing',
+      repoUrl: 'https://forgejo.example/civitai-apps/hello',
+      app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+    });
+    mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0' });
+    mockDbWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_reset', contentRating: 'r' });
+    mockDbWrite.appListing.findUnique.mockResolvedValue({
+      iconId: 1,
+      coverId: 2,
+      contentRating: 'r',
+    });
+    mockDbWrite.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDbWrite.image.findMany.mockImplementation(
+      async (args: { where?: { id?: { in?: number[] } } }) =>
+        (args?.where?.id?.in ?? []).map((id) => ({
+          id,
+          ingestion: 'Scanned',
+          nsfwLevel: NsfwLevel.PG,
+        }))
+    );
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+    expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { status: 'approved', contentRating: 'r' },
+      })
+    );
   });
 
   it('normal subsequent-version approve (listing NOT pending) does NOT un-suspend the block', async () => {
@@ -1809,7 +1959,9 @@ describe('approveRequest', () => {
         (c: any[]) => c[0]?.data?.trustTier !== undefined
       );
       expect(tierUpdate?.[0]?.data?.trustTier).toBe('verified');
-      expect((tierUpdate?.[0]?.data?.manifest as { trustTier?: string }).trustTier).toBe('verified');
+      expect((tierUpdate?.[0]?.data?.manifest as { trustTier?: string }).trustTier).toBe(
+        'verified'
+      );
     });
 
     it('EXISTING unverified app: a manifest declaring internal stays unverified', async () => {
@@ -2248,8 +2400,7 @@ describe('approveRequest', () => {
       // manifest-governed on exactly the same terms, so it MUST re-sync (this
       // fixture's manifest declares none, so it re-syncs as null).
       const syncCalls = mockDbWrite.appListing.updateMany.mock.calls.filter(
-        (c: [{ data?: Record<string, unknown> }]) =>
-          c[0]?.data != null && !('status' in c[0].data) // exclude the (3b-reset) status flip
+        (c: [{ data?: Record<string, unknown> }]) => c[0]?.data != null && !('status' in c[0].data) // exclude the (3b-reset) status flip
       );
       expect(syncCalls).toHaveLength(1);
       expect(Object.keys(syncCalls[0][0].data).sort()).toEqual([
@@ -2600,7 +2751,9 @@ describe('approveRequest', () => {
     it('provisions the appsDb schema ONCE for a storage-declaring app with slug = sanitized blockId', async () => {
       const { approveRequest } = await import('../publish-request.service');
       mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
-        pendingRequest({ manifest: manifest({ scopes: ['apps:storage:read', 'apps:storage:write'] }) })
+        pendingRequest({
+          manifest: manifest({ scopes: ['apps:storage:read', 'apps:storage:write'] }),
+        })
       );
       mockDbRead.appBlock.findFirst.mockResolvedValue(null);
       mockBundleBuffer.current = await makeValidBundle({
@@ -3027,7 +3180,9 @@ describe('recordPendingFromPush', () => {
   it('(a) existingForSha refresh path — updates the existing (slug,sha) pending row, no create', async () => {
     const { recordPendingFromPush } = await import('../publish-request.service');
     // A pending row for THIS exact (slug, sha) already exists → refresh + done.
-    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValueOnce({ id: 'pubreq_existing_sha' });
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValueOnce({
+      id: 'pubreq_existing_sha',
+    });
     mockDbWrite.appBlockPublishRequest.update.mockResolvedValue(undefined);
 
     const res = await recordPendingFromPush(pushArgs);

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -29,6 +29,18 @@ import { NsfwLevel } from '~/server/common/enums';
  *   - global.fetch is mocked for the Discord webhook path.
  */
 
+/**
+ * The repo-standard signature for a mocked Prisma delegate (see
+ * `scope-grant.service.test.ts`): it takes an args object and resolves a row shape.
+ *
+ * 🔴 Declare it on every delegate that carries a DEFAULT implementation. `vi.fn(async
+ * () => null)` infers `() => Promise<null>` — a mock that takes NO argument and can
+ * only ever resolve `null` — so a per-test `mockResolvedValue(row)` or
+ * `mockImplementation((args) => …)` on the same delegate stops typechecking, even
+ * though both are exactly what the real delegate does at runtime.
+ */
+type DelegateMock = (...args: any[]) => Promise<any>;
+
 const {
   mockDbRead,
   mockDbWrite,
@@ -63,15 +75,15 @@ const {
       oauthClient: { findUnique: vi.fn() },
       // W13 auto-create-on-approve: approveRequest checks for an existing onsite
       // AppListing (idempotency, keyed on appBlockId) before creating one.
-      appListing: { findUnique: vi.fn(), findFirst: vi.fn(async () => null) },
+      appListing: { findUnique: vi.fn(), findFirst: vi.fn<DelegateMock>(async () => null) },
       // Fix #1 (onsite): withdrawRequest probes the listing's latest mod event to
       // decide whether a reset withdraw closes the listing. Null → no reset in flight.
-      appListingModerationEvent: { findFirst: vi.fn(async () => null) },
+      appListingModerationEvent: { findFirst: vi.fn<DelegateMock>(async () => null) },
       // A `pending` onsite listing is no longer proof that THIS block request is the
       // review open on it — the owner-republish asset-review route parks a listing in
       // `pending` with an `AppListingPublishRequest` and no block request. Null → no
       // listing-side review, i.e. the mod-reset case this suite's assertions describe.
-      appListingPublishRequest: { findFirst: vi.fn(async () => null) },
+      appListingPublishRequest: { findFirst: vi.fn<DelegateMock>(async () => null) },
     },
     mockDbWrite: {
       // `updateMany` added (no-trust-on-push fix): approveRequest now supersedes
@@ -119,13 +131,13 @@ const {
       // (gate skipped; the existing updateMany still runs), image → every id Scanned.
       appListing: {
         create: vi.fn(),
-        updateMany: vi.fn(async () => ({ count: 0 })),
-        findFirst: vi.fn(async () => null),
+        updateMany: vi.fn<DelegateMock>(async () => ({ count: 0 })),
+        findFirst: vi.fn<DelegateMock>(async () => null),
         // The shared assertListingAssetsScanCleanInTx wrapper re-reads the reset
         // listing's icon/cover by id from the PRIMARY.
-        findUnique: vi.fn(async () => null),
+        findUnique: vi.fn<DelegateMock>(async () => null),
       },
-      appListingScreenshot: { findMany: vi.fn(async () => []) },
+      appListingScreenshot: { findMany: vi.fn<DelegateMock>(async () => []) },
       image: {
         findMany: vi.fn(async (args: { where?: { id?: { in?: number[] } } }) =>
           (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: 'Scanned' }))
@@ -134,7 +146,7 @@ const {
       // Fix #1 (onsite) withdraw close: the reset-withdraw path flips the listing
       // pending→removed + writes a delist event inside a tx. `$transaction` is wired
       // post-hoist (below) to run its callback against this same write mock.
-      appListingModerationEvent: { create: vi.fn(async () => ({})) },
+      appListingModerationEvent: { create: vi.fn<DelegateMock>(async () => ({})) },
       $transaction: vi.fn(),
     },
     mockS3Send: vi.fn(),
@@ -2661,7 +2673,7 @@ describe('approveRequest', () => {
       // manifest-governed on exactly the same terms, so it MUST re-sync (this
       // fixture's manifest declares none, so it re-syncs as null).
       const syncCalls = mockDbWrite.appListing.updateMany.mock.calls.filter(
-        (c: [{ data?: Record<string, unknown> }]) => c[0]?.data != null && !('status' in c[0].data) // exclude the (3b-reset) status flip
+        (c: { data?: Record<string, unknown> }[]) => c[0]?.data != null && !('status' in c[0].data) // exclude the (3b-reset) status flip
       );
       expect(syncCalls).toHaveLength(1);
       expect(Object.keys(syncCalls[0][0].data).sort()).toEqual([

--- a/src/server/services/blocks/__tests__/publish-request.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.service.test.ts
@@ -28,6 +28,11 @@ const dbMocks = vi.hoisted(() => ({
   // W13 draft-at-submit — the pre-approval draft AppListing pre-check (read) + create (write).
   appListingFindFirst: vi.fn(),
   appListingCreate: vi.fn(),
+  // The cross-queue submit guard: `one_pending_per_slug` is partial-unique on
+  // AppBlockPublishRequest only, so submitVersion also asks whether a NON-SHADOW
+  // listing review is open for the slug. Null = no listing review, the shape every
+  // test in this file assumes.
+  listingReqFindFirst: vi.fn(async () => null),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -35,6 +40,7 @@ vi.mock('~/server/db/client', () => ({
     appBlockPublishRequest: { findFirst: dbMocks.pubReqFindFirst },
     appBlock: { findFirst: dbMocks.appBlockFindFirst },
     appListing: { findFirst: dbMocks.appListingFindFirst },
+    appListingPublishRequest: { findFirst: dbMocks.listingReqFindFirst },
     user: { findUnique: dbMocks.userFindUnique },
   },
   dbWrite: {

--- a/src/server/services/blocks/app-listing-approved-assets.ts
+++ b/src/server/services/blocks/app-listing-approved-assets.ts
@@ -41,13 +41,31 @@ import type { Prisma } from '@prisma/client';
  * This module IS that stored baseline, on the server, for a different question. Merging
  * them would drag a React-tree module onto the transaction path for no gain.
  *
- * 🔴 ABSENCE IS A REAL BRANCH AND IT FAILS CLOSED. {@link parseApprovedAssetSnapshot}
- * returns `null` for a missing, malformed or future-versioned payload — it never returns
- * an empty snapshot, because an empty snapshot would COMPARE EQUAL to a listing that
- * happens to have no assets and would silently read as "nothing changed". A comparison
- * against an absent operand must report MISSING, not SAME. The caller routes a `null` to
- * re-review. That is the whole population of listings unpublished BEFORE this shipped:
- * for them we genuinely cannot tell, so they get one re-review on their next republish.
+ * 🔴 ABSENCE IS A REAL BRANCH — AND THERE ARE **TWO** OF THEM, WHICH GO OPPOSITE WAYS.
+ * {@link parseApprovedAssetSnapshot} still returns `null` for anything it does not fully
+ * recognise, and it never returns an empty snapshot (an empty snapshot would COMPARE EQUAL
+ * to a listing that happens to have no assets and would silently read as "nothing
+ * changed"). But {@link readRecordedAssetBaseline} splits that `null` in two, because the
+ * two causes are not the same fact about the world:
+ *
+ *   - `absent`     — the event carries NO `assets` key at all. That is the signature of a
+ *                    listing unpublished BEFORE this feature shipped: a bounded, strictly
+ *                    SHRINKING population for which no baseline was ever written and none
+ *                    ever can be. Routing these to review is not a safety win — it does
+ *                    not make anyone look at a change, because there is no change to
+ *                    describe — while it DOES take every already-removed listing offline
+ *                    behind a moderator on ship day (measured against production at the
+ *                    time of writing: every removable on-site listing in this state). So
+ *                    `absent` keeps the PRE-EXISTING behaviour: republish goes live.
+ *   - `unreadable` — the event HAS an `assets` key and it does not parse (malformed, or a
+ *                    version this build does not understand). That is not history, it is
+ *                    something being WRONG right now, and the population is unbounded.
+ *                    It FAILS CLOSED → review.
+ *
+ * 🔴 THE DISTINCTION IS THE WHOLE POINT, so do not collapse it back to one `null`. A
+ * single "unknown ⇒ review" rule is the version that sweeps the legacy population; a
+ * single "unknown ⇒ allow" rule is the version that silently disarms the gate the first
+ * time a payload goes bad. Neither is safe on its own.
  */
 
 /**
@@ -202,16 +220,37 @@ export function parseApprovedAssetSnapshot(value: unknown): ApprovedAssetSnapsho
 }
 
 /**
- * Read the recorded asset snapshot out of a moderation event's `before` payload, or
- * `null` when the event carries none. Both arms of the absence — an event written before
- * this feature existed, and a payload that is not a snapshot — collapse to `null` here,
- * and the caller must treat `null` as UNKNOWN rather than as "no assets".
+ * What a moderation event's `before` payload tells us about the last-approved assets.
+ *
+ * 🔴 THREE OUTCOMES, NOT TWO, and the two non-`snapshot` ones are decided DIFFERENTLY by
+ * the gate — see the module docstring. `absent` is "this event predates the feature"
+ * (bounded, shrinking, no change to review); `unreadable` is "this event claims to carry a
+ * baseline and it is broken" (unbounded, fail closed).
  */
-export function readRecordedAssetSnapshot(
+export type RecordedAssetBaseline =
+  | { kind: 'absent' }
+  | { kind: 'unreadable' }
+  | { kind: 'snapshot'; snapshot: ApprovedAssetSnapshot };
+
+/**
+ * Read the recorded asset baseline out of a moderation event's `before` payload.
+ *
+ * 🔴 THE `absent` TEST IS ON THE **KEY**, NOT ON THE PARSE RESULT. `undefined` means the
+ * writer never wrote one; ANY other value — including `null`, a number, or a snapshot from
+ * a version this build does not understand — means a baseline was written and we cannot
+ * read it, which is a different fact and gets the opposite answer. A `before` that is not
+ * an object at all is likewise `absent`: that is the shape every pre-feature event has.
+ */
+export function readRecordedAssetBaseline(
   before: Prisma.JsonValue | null | undefined
-): ApprovedAssetSnapshot | null {
-  if (typeof before !== 'object' || before === null || Array.isArray(before)) return null;
-  return parseApprovedAssetSnapshot((before as Record<string, unknown>).assets);
+): RecordedAssetBaseline {
+  if (typeof before !== 'object' || before === null || Array.isArray(before)) {
+    return { kind: 'absent' };
+  }
+  const raw = (before as Record<string, unknown>).assets;
+  if (raw === undefined) return { kind: 'absent' };
+  const snapshot = parseApprovedAssetSnapshot(raw);
+  return snapshot === null ? { kind: 'unreadable' } : { kind: 'snapshot', snapshot };
 }
 
 /**
@@ -234,27 +273,33 @@ export function approvedAssetSnapshotsEqual(
 }
 
 /** Why an owner republish has to go back through review, or `null` when it does not. */
-export type RepublishReviewReason = 'assets-changed' | 'no-recorded-assets';
+export type RepublishReviewReason = 'assets-changed' | 'unreadable-baseline';
 
 /**
  * THE GATE. Decide whether an owner republish may go live immediately or must re-enter
  * the review queue.
  *
- * - no recorded snapshot → `'no-recorded-assets'` (FAIL CLOSED — we cannot tell)
- * - recorded snapshot differs from the live assets → `'assets-changed'`
- * - recorded snapshot matches → `null`, republish stays immediate exactly as before
+ * - `snapshot` that DIFFERS from the live assets → `'assets-changed'` (the point of all this)
+ * - `snapshot` that MATCHES → `null`; republish stays immediate exactly as before
+ * - `unreadable` → `'unreadable-baseline'` (FAIL CLOSED — a baseline exists and is broken)
+ * - `absent`   → `null`; NO baseline was ever recorded, so there is no change to review and
+ *                the pre-existing immediate republish stands. See the module docstring for
+ *                why this one arm is deliberately fail-OPEN — it is the only arm whose
+ *                population is bounded and shrinking, and closing it takes every
+ *                already-removed listing offline behind a moderator for no review value.
  */
 export function resolveRepublishReviewReason(
-  recorded: ApprovedAssetSnapshot | null,
+  recorded: RecordedAssetBaseline,
   live: ApprovedAssetSnapshot
 ): RepublishReviewReason | null {
-  if (recorded === null) return 'no-recorded-assets';
-  return approvedAssetSnapshotsEqual(recorded, live) ? null : 'assets-changed';
+  if (recorded.kind === 'absent') return null;
+  if (recorded.kind === 'unreadable') return 'unreadable-baseline';
+  return approvedAssetSnapshotsEqual(recorded.snapshot, live) ? null : 'assets-changed';
 }
 
 /** Human-readable `detail` for the audit event, so the history says WHY it re-queued. */
 export const REPUBLISH_REVIEW_DETAIL: Record<RepublishReviewReason, string> = {
   'assets-changed': 'listing assets changed since the last approval — routed to review',
-  'no-recorded-assets':
-    'no recorded assets from the last approval to compare against — routed to review',
+  'unreadable-baseline':
+    'the recorded assets from the last approval could not be read — routed to review',
 };

--- a/src/server/services/blocks/app-listing-approved-assets.ts
+++ b/src/server/services/blocks/app-listing-approved-assets.ts
@@ -1,0 +1,260 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * App Store Listings — "are this listing's assets the ones a moderator approved?"
+ *
+ * 🔴 THE PROBLEM THIS EXISTS TO SOLVE. An owner may `unpublishOwnListing` their own
+ * approved listing (approved → removed) and then republish it. A `removed` listing is
+ * DIRECTLY asset-editable — `assertOwnerAssetEditable` refuses only an `approved`,
+ * non-shadow row — so between those two actions the owner can swap the icon, the cover
+ * and every screenshot. `republishOwnListing`'s existing go-live gates do not see it:
+ * `assertListingAssetsScanCleanInTx` reads scan STATUS, `assertOffsiteListingActionableInTx`
+ * reads the destination href, and the #4418 rating floor reads MATURITY. None of them is
+ * a content review, so brand-new store-card imagery could reach the public store with no
+ * human ever looking at it.
+ *
+ * 🔴 NOTHING IN THE SCHEMA ALREADY RECORDS THIS. Enumerated over every non-test writer of
+ * `appListingModerationEvent.create` in `src/`: `delist`, `relist`, `claim`, `purge`,
+ * `reset-to-pending`, `owner-unpublish`, `owner-republish`, `message-owner` and the
+ * publish-request delist all write `before`/`after` payloads of the shape
+ * `{ status }` / `{ userId }` / `{ recipientUserIds }` — no writer records an asset id.
+ * `AppListingPublishRequest` snapshots no assets either (it carries slug/status/notes),
+ * and `AppListing.updatedAt` / `AppListingScreenshot.updatedAt` are useless as a signal:
+ * the republish flip itself bumps `AppListing.updatedAt`, and a DELETED screenshot row
+ * leaves no timestamp behind at all. So the signal has to be RECORDED, not inferred.
+ *
+ * 🔴 WHERE IT IS RECORDED, AND WHY THAT INSTANT IS THE RIGHT ONE. The snapshot is written
+ * into the `owner-unpublish` moderation event's `before` payload, by `unpublishOwnListing`,
+ * inside the same transaction as the flip. At that instant the listing is `approved` and an
+ * approved non-shadow listing is NOT owner-asset-editable, so its live assets ARE the
+ * assets that were last approved (an owner's edit to an approved listing goes through a
+ * shadow revision, which is moderator-reviewed before it is copied onto the parent; a
+ * moderator's live curation is itself a reviewed action). "The assets at the last
+ * approval" and "the assets at owner-unpublish" are therefore the same set, and the second
+ * one is the one we can observe on the path that needs it.
+ *
+ * SIBLING, DELIBERATELY NOT SHARED: `src/components/Apps/listingRevisionDrift.ts` holds a
+ * same-spirited `ListingAssetSnapshot` view-model + `computeListingRevisionDrift`. That
+ * one is CLIENT-side, computed at review time from two LIVE tRPC reads to show a moderator
+ * what approving a shadow revision would change; it is never persisted, and its own
+ * docstring records that answering "did the baseline move?" would need a stored baseline.
+ * This module IS that stored baseline, on the server, for a different question. Merging
+ * them would drag a React-tree module onto the transaction path for no gain.
+ *
+ * 🔴 ABSENCE IS A REAL BRANCH AND IT FAILS CLOSED. {@link parseApprovedAssetSnapshot}
+ * returns `null` for a missing, malformed or future-versioned payload — it never returns
+ * an empty snapshot, because an empty snapshot would COMPARE EQUAL to a listing that
+ * happens to have no assets and would silently read as "nothing changed". A comparison
+ * against an absent operand must report MISSING, not SAME. The caller routes a `null` to
+ * re-review. That is the whole population of listings unpublished BEFORE this shipped:
+ * for them we genuinely cannot tell, so they get one re-review on their next republish.
+ */
+
+/**
+ * The snapshot format version. BUMP IT if the shape below changes meaning, and leave
+ * {@link parseApprovedAssetSnapshot} rejecting every version it does not understand — an
+ * unrecognised version must degrade to "unknown" (→ re-review), never to a partial or
+ * coerced comparison against a shape it was not written in.
+ */
+export const APPROVED_ASSET_SNAPSHOT_VERSION = 1;
+
+/** One reviewable screenshot: the image it shows and the caption printed under it. */
+export type ApprovedAssetSnapshotScreenshot = {
+  imageId: number;
+  caption: string | null;
+};
+
+/**
+ * The reviewable asset surface of a listing: its icon, its cover, and its screenshots
+ * IN DISPLAY ORDER.
+ *
+ * 🔴 THE SCREENSHOT ARRAY IS POSITIONAL ON PURPOSE — the row's `order` COLUMN is not
+ * recorded. Renumbering the same sequence 0,1,2 → 10,20,30 changes no pixel a viewer
+ * sees and must not force a re-review; genuinely RE-ORDERING two screenshots does change
+ * the card and shows up as a different array. Recording the raw `order` value would
+ * invert both of those. The row `id` is likewise not recorded, so removing a screenshot
+ * and re-adding the identical image+caption is correctly read as unchanged.
+ *
+ * Captions ARE part of the surface: a caption is public text printed on the store card,
+ * so swapping one is a content change even when every image is identical.
+ */
+export type ApprovedAssetSnapshot = {
+  v: typeof APPROVED_ASSET_SNAPSHOT_VERSION;
+  iconId: number | null;
+  coverId: number | null;
+  screenshots: ApprovedAssetSnapshotScreenshot[];
+};
+
+/** A screenshot row as read from the database, before normalisation. */
+export type ListingScreenshotRow = {
+  imageId: number | null;
+  order: number;
+  caption: string | null;
+};
+
+/**
+ * Normalise a caption to its comparable form: trimmed, with blank collapsing to `null`.
+ * `''`, `'   '` and `null` all render the same nothing, so they must compare equal —
+ * otherwise a stray space forces a pointless re-review.
+ */
+function normalizeCaption(caption: string | null | undefined): string | null {
+  const trimmed = (caption ?? '').trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+/**
+ * Put screenshot rows into a deterministic display order and strip everything that is not
+ * part of the reviewable surface.
+ *
+ * 🔴 ROWS WITH NO `imageId` ARE DROPPED, not recorded as holes. Such a row displays
+ * nothing, so its creation or deletion is not a content change; recording it would make
+ * the gate fire on a difference no viewer can see. (It is also exactly what the go-live
+ * scan gate does — `assertListingAssetsScanCleanInTx` selects `imageId: { not: null }` —
+ * so the two agree on what "the listing's screenshots" means.)
+ *
+ * 🔴 THE SORT IS TOTAL, not just `order`. Two rows may legitimately share an `order`
+ * value, and a comparator that leaves them tied would hand back whichever order the query
+ * planner happened to produce — a snapshot that differs from itself between two reads,
+ * which fails CLOSED but at random. `imageId` then `caption` break the tie with values
+ * that are part of the content itself.
+ */
+export function normalizeListingScreenshots(
+  rows: readonly ListingScreenshotRow[]
+): ApprovedAssetSnapshotScreenshot[] {
+  return rows
+    .filter((r): r is ListingScreenshotRow & { imageId: number } => r.imageId != null)
+    .map((r) => ({ imageId: r.imageId, order: r.order, caption: normalizeCaption(r.caption) }))
+    .sort(
+      (a, b) =>
+        a.order - b.order ||
+        a.imageId - b.imageId ||
+        (a.caption ?? '').localeCompare(b.caption ?? '')
+    )
+    .map(({ imageId, caption }) => ({ imageId, caption }));
+}
+
+/** The narrowest client shape the snapshot reader needs — a `tx`, `dbWrite` or `dbRead`. */
+export type ListingScreenshotReader = Pick<Prisma.TransactionClient, 'appListingScreenshot'>;
+
+/**
+ * Build the CURRENT asset snapshot for a listing.
+ *
+ * `iconId`/`coverId` are passed in rather than re-read: every caller has already loaded
+ * the listing row on the primary inside its transaction, and re-reading them would open a
+ * second window in which they could move relative to the screenshots.
+ *
+ * Pass the in-transaction `tx` at both the record site and the compare site so the
+ * snapshot is row-consistent with the status flip it gates.
+ */
+export async function buildApprovedAssetSnapshot(
+  db: ListingScreenshotReader,
+  appListingId: string,
+  listing: { iconId: number | null | undefined; coverId: number | null | undefined }
+): Promise<ApprovedAssetSnapshot> {
+  const rows = await db.appListingScreenshot.findMany({
+    where: { appListingId },
+    select: { imageId: true, order: true, caption: true },
+    orderBy: [{ order: 'asc' }, { id: 'asc' }],
+  });
+  return {
+    v: APPROVED_ASSET_SNAPSHOT_VERSION,
+    iconId: listing.iconId ?? null,
+    coverId: listing.coverId ?? null,
+    screenshots: normalizeListingScreenshots(rows),
+  };
+}
+
+/** `number | null`, and nothing else — `undefined`, a string id or a float are all wrong. */
+function isNullableImageId(value: unknown): value is number | null {
+  return value === null || (typeof value === 'number' && Number.isInteger(value));
+}
+
+/**
+ * Parse a snapshot back out of a moderation event's JSONB payload.
+ *
+ * 🔴 RETURNS `null` FOR ANYTHING IT DOES NOT FULLY RECOGNISE — absent, not-an-object,
+ * wrong/absent version, or a screenshots array with even one malformed entry. It must
+ * NEVER coerce a partial payload into a snapshot: the caller's next move is an equality
+ * test, and a coerced value would compare equal to some real listing and wave it through.
+ * `null` means "we do not know what was approved", which the caller turns into a review.
+ */
+export function parseApprovedAssetSnapshot(value: unknown): ApprovedAssetSnapshot | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.v !== APPROVED_ASSET_SNAPSHOT_VERSION) return null;
+  if (!isNullableImageId(raw.iconId) || !isNullableImageId(raw.coverId)) return null;
+  if (!Array.isArray(raw.screenshots)) return null;
+
+  const screenshots: ApprovedAssetSnapshotScreenshot[] = [];
+  for (const entry of raw.screenshots) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return null;
+    const row = entry as Record<string, unknown>;
+    if (typeof row.imageId !== 'number' || !Number.isInteger(row.imageId)) return null;
+    if (row.caption !== null && typeof row.caption !== 'string') return null;
+    screenshots.push({ imageId: row.imageId, caption: row.caption });
+  }
+  return {
+    v: APPROVED_ASSET_SNAPSHOT_VERSION,
+    iconId: raw.iconId,
+    coverId: raw.coverId,
+    screenshots,
+  };
+}
+
+/**
+ * Read the recorded asset snapshot out of a moderation event's `before` payload, or
+ * `null` when the event carries none. Both arms of the absence — an event written before
+ * this feature existed, and a payload that is not a snapshot — collapse to `null` here,
+ * and the caller must treat `null` as UNKNOWN rather than as "no assets".
+ */
+export function readRecordedAssetSnapshot(
+  before: Prisma.JsonValue | null | undefined
+): ApprovedAssetSnapshot | null {
+  if (typeof before !== 'object' || before === null || Array.isArray(before)) return null;
+  return parseApprovedAssetSnapshot((before as Record<string, unknown>).assets);
+}
+
+/**
+ * Structural equality over the reviewable surface. Both operands must be real snapshots;
+ * "one side is unknown" is NOT an equality question and is decided by the caller before
+ * it gets here (see {@link parseApprovedAssetSnapshot}).
+ */
+export function approvedAssetSnapshotsEqual(
+  a: ApprovedAssetSnapshot,
+  b: ApprovedAssetSnapshot
+): boolean {
+  if (a.iconId !== b.iconId) return false;
+  if (a.coverId !== b.coverId) return false;
+  if (a.screenshots.length !== b.screenshots.length) return false;
+  for (let i = 0; i < a.screenshots.length; i++) {
+    if (a.screenshots[i].imageId !== b.screenshots[i].imageId) return false;
+    if (a.screenshots[i].caption !== b.screenshots[i].caption) return false;
+  }
+  return true;
+}
+
+/** Why an owner republish has to go back through review, or `null` when it does not. */
+export type RepublishReviewReason = 'assets-changed' | 'no-recorded-assets';
+
+/**
+ * THE GATE. Decide whether an owner republish may go live immediately or must re-enter
+ * the review queue.
+ *
+ * - no recorded snapshot → `'no-recorded-assets'` (FAIL CLOSED — we cannot tell)
+ * - recorded snapshot differs from the live assets → `'assets-changed'`
+ * - recorded snapshot matches → `null`, republish stays immediate exactly as before
+ */
+export function resolveRepublishReviewReason(
+  recorded: ApprovedAssetSnapshot | null,
+  live: ApprovedAssetSnapshot
+): RepublishReviewReason | null {
+  if (recorded === null) return 'no-recorded-assets';
+  return approvedAssetSnapshotsEqual(recorded, live) ? null : 'assets-changed';
+}
+
+/** Human-readable `detail` for the audit event, so the history says WHY it re-queued. */
+export const REPUBLISH_REVIEW_DETAIL: Record<RepublishReviewReason, string> = {
+  'assets-changed': 'listing assets changed since the last approval — routed to review',
+  'no-recorded-assets':
+    'no recorded assets from the last approval to compare against — routed to review',
+};

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -1164,9 +1164,20 @@ export async function loadListingAssetScansBatch(
  * never auto-lowered — mirrors `resolveApprovalContentRating`'s floor-at-derived.
  *
  * No-op for everyone else: owner edits on a live listing are blocked by the guard and
- * go through a shadow revision (re-derived at approve); draft/pending/shadow listings
- * are rated at approve. So it fires ONLY for `isModerator` on an `approved` non-shadow
- * (`revisionOfId == null`) listing. Runs INSIDE the caller's `dbWrite.$transaction`
+ * go through a shadow revision (re-derived at approve). So it fires ONLY for
+ * `isModerator` on an `approved` non-shadow (`revisionOfId == null`) listing.
+ *
+ * 🔴 "DRAFT/PENDING/SHADOW LISTINGS ARE RATED AT APPROVE" USED TO BE THE THIRD CLAUSE OF
+ * THAT SENTENCE, AND IT WAS NOT TRUE OF EVERY APPROVE. It reads as a blanket guarantee —
+ * "whatever an owner does to a non-live listing, the approve re-rates it" — and one
+ * approve did not: `approveRequest`'s `(3b-reset)` branch restored a `pending` ON-SITE
+ * listing by writing `{ status: 'approved' }` and nothing else, while its sibling
+ * `(3b-transition)` floored. A `pending` listing IS freely owner-asset-editable (this
+ * function's own guard skips it, and `assertOwnerAssetEditable` refuses only `approved`),
+ * so the two facts composed into a live mature card under a stale rating. The floor is
+ * now applied there too — but the lesson is the wording: state which approves rate, or
+ * a reader will trust the sentence instead of checking. Runs INSIDE the caller's
+ * `dbWrite.$transaction`
  * (the `tx` param) so the derive+floor is ATOMIC with the asset write that triggered
  * it — parity with approve's `resolveApprovalContentRating`. The guard short-circuits
  * BEFORE any query, so a non-mod / draft / pending / shadow edit adds ZERO queries to

--- a/src/server/services/blocks/app-listing-owner-unpublish.ts
+++ b/src/server/services/blocks/app-listing-owner-unpublish.ts
@@ -176,15 +176,41 @@ export async function readLastModerationAction(
   db: ModerationEventReader,
   appListingId: string
 ): Promise<string | null> {
+  return (await readLastStatusChangingModerationEvent(db, appListingId))?.action ?? null;
+}
+
+/**
+ * The row {@link readLastModerationAction} answers from, with its structured `before`
+ * payload attached.
+ *
+ * 🔴 WHY THE PAYLOAD IS EXPOSED SEPARATELY RATHER THAN FOLDED IN. A caller that needs BOTH
+ * "which verb was it?" and "what did that verb record?" must get them from ONE row — the
+ * verb and the payload have to describe the SAME event. Reading the action here and the
+ * payload in a second query would let a concurrent write land between them and pair an
+ * `owner-unpublish` verb with some other event's payload. Everything the filtering,
+ * ordering and pool-choice notes on {@link readLastModerationAction} say applies verbatim;
+ * this is the same query with one more column selected, and that function is now defined
+ * in terms of THIS one so the two can never disagree about which row is "last".
+ */
+export type LastStatusChangingModerationEvent = {
+  action: string;
+  before: Prisma.JsonValue | null;
+};
+
+export async function readLastStatusChangingModerationEvent(
+  db: ModerationEventReader,
+  appListingId: string
+): Promise<LastStatusChangingModerationEvent | null> {
   const lastEvent = await db.appListingModerationEvent.findFirst({
     where: {
       appListingId,
       action: { in: [...LISTING_STATUS_CHANGING_MODERATION_ACTIONS] },
     },
     orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-    select: { action: true },
+    select: { action: true, before: true },
   });
-  return lastEvent?.action ?? null;
+  if (!lastEvent) return null;
+  return { action: lastEvent.action, before: lastEvent.before ?? null };
 }
 
 /**

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -40,6 +40,7 @@ import {
 import {
   assertAssetsScanClean,
   assertListingMeetsFloor,
+  resolveListingRatingFloorInTx,
 } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionable } from '~/server/services/blocks/app-listing-actionable.service';
 import {
@@ -545,11 +546,22 @@ export async function deriveScopePatch(opts: {
  * from the PRIMARY and resolve: now `withdrawn` → idempotent success; now
  * `approved`/`rejected` → NOT_PENDING. Mirrors `withdrawRequest`
  * (publish-request.service.ts).
+ *
+ * 🔴 RETURNS WHAT IT DID, because the two outcomes are not equally reversible and the
+ * caller was announcing them with one sentence. Withdrawing a first-time submission
+ * (`'deleted'`) throws away a draft. Withdrawing the review of a FORMERLY-LIVE listing
+ * (`'removed'`) leaves it `removed` behind a `delist` event, which `republishOwnListing`'s
+ * last-event guard reads as a moderator takedown — so the owner cannot put it back and a
+ * moderator must `relistListing`. That is deliberate (see `closeTerminalListing`), but
+ * "Submission withdrawn." is not an honest description of it, so the outcome is surfaced
+ * and the UI says which one happened.
  */
+export type WithdrawExternalRequestResult = { outcome: CloseTerminalListingOutcome };
+
 export async function withdrawExternalRequest(opts: {
   publishRequestId: string;
   userId: number;
-}): Promise<void> {
+}): Promise<WithdrawExternalRequestResult> {
   const { publishRequestId, userId } = opts;
 
   const row = await dbRead.appListingPublishRequest.findUnique({
@@ -562,7 +574,9 @@ export async function withdrawExternalRequest(opts: {
   if (row.submittedByUserId !== userId) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only withdraw your own publish requests');
   }
-  if (row.status === 'withdrawn') return;
+  // Already withdrawn — idempotent success. `'none'` rather than a remembered outcome:
+  // this call did nothing, and the UI must not narrate someone else's close as its own.
+  if (row.status === 'withdrawn') return { outcome: 'none' };
   if (row.status !== 'pending') {
     throw new OffsiteRequestError(
       'NOT_PENDING',
@@ -582,15 +596,14 @@ export async function withdrawExternalRequest(opts: {
       where: { id: publishRequestId, status: 'pending' },
       data: { status: 'withdrawn' },
     });
-    if (count === 0) return false;
-    await closeTerminalListing(tx, row.appListingId, {
+    if (count === 0) return null;
+    return await closeTerminalListing(tx, row.appListingId, {
       actorUserId: userId,
       reason: null,
     });
-    return true;
   });
-  if (flipped) {
-    return;
+  if (flipped !== null) {
+    return { outcome: flipped };
   }
 
   // Raced: re-read from the PRIMARY (a replica read could be lag-stale and still
@@ -601,8 +614,9 @@ export async function withdrawExternalRequest(opts: {
   });
   if (!after || after.status === 'withdrawn') {
     // Raced into withdrawn (or vanished) → idempotent success. The concurrent
-    // withdraw owns the draft cleanup, so we do NOT re-delete here.
-    return;
+    // withdraw owns the draft cleanup, so we do NOT re-delete here — and it owns the
+    // outcome too, so this call reports `'none'`.
+    return { outcome: 'none' };
   }
   // Raced into approved/rejected → the not-pending guarantee, now true under
   // concurrency.
@@ -2288,12 +2302,19 @@ export function listingMediaEditBlockedReason(
       // destination exists. Neither asks whether a moderator ever saw the current values.
       // What actually holds the line is per-surface: for SCALARS, `updateListing`'s
       // MATERIAL_CHANGE_BLOCKED refusal on this same state. For ASSETS — which is what this
-      // verdict unblocks — nothing does, and that is PRE-EXISTING rather than opened here:
-      // `assertOwnerAssetEditable` already refuses only an `approved` top-level listing, so
-      // a `removed` listing has been directly asset-editable all along, and
-      // `republishOwnListing` runs no rating floor (`resolveListingRatingFloorInTx` is
-      // wired into the approve paths only). This verdict changes WHO IS TOLD WHAT, not what
-      // the asset procs permit. See the PR body's "known adjacent gap".
+      // verdict unblocks — `assertOwnerAssetEditable` refuses only an `approved` top-level
+      // listing, so a `removed` listing has been directly asset-editable all along. This
+      // verdict changes WHO IS TOLD WHAT, not what the asset procs permit.
+      //
+      // 🔴 THE LAST SENTENCE OF THAT PARAGRAPH USED TO SAY "`republishOwnListing` runs no
+      // rating floor (`resolveListingRatingFloorInTx` is wired into the approve paths
+      // only)". THAT HAS BEEN FALSE SINCE #4418 — republish derives and applies the
+      // raise-only floor itself, on every arm — and it is the kind of false comment that
+      // does damage rather than merely aging: it reads as a licence to skip the floor
+      // anywhere else on the republish path, which is exactly the hole #4440 had to close
+      // in `approveRequest`'s reset re-approve. The remaining "nothing reviews the assets"
+      // half was true when written and is what #4440 closed: an asset change across an
+      // owner unpublish/republish now re-enters the moderation queue.
       return ownerUnpublished
         ? null
         : 'this listing has been removed by a moderator and can no longer be edited';
@@ -2435,6 +2456,40 @@ async function resolveApprovalContentRating(
   return nsfwLevelFromContentRating(override) < nsfwLevelFromContentRating(derived)
     ? derived // floor: an under-rating override is clamped up to the derived value
     : override;
+}
+
+/**
+ * The ON-SITE counterpart of {@link resolveApprovalContentRating}, and the difference is
+ * the whole reason it exists rather than being one more branch inside that function.
+ *
+ * 🔴 OFF-SITE: the rating IS the assets — a listing has no other content, so the derived
+ * value REPLACES whatever was stored (`resolveApprovalContentRating` returns `derived`).
+ * 🔴 ON-SITE: the rating belongs to the APP, not to its store card. It is manifest-declared
+ * by the author and describes what the app DOES; its icon and cover are a strictly smaller
+ * surface. Replacing it with an asset-derived value would LOWER a `pg13` app to `g` because
+ * its store art happens to be tame — an under-rating of the runtime, produced by looking at
+ * a picture. So the app's declaration is a FLOOR that is raised by mature media and never
+ * lowered by tame media: exactly {@link resolveListingRatingFloorInTx}, the same helper
+ * `approveRequest`'s draft→approved transition and `republishOwnListing` use, so all three
+ * on-site rating sites have ONE spelling.
+ *
+ * A moderator override may still RAISE above the floor (a mod may always rate up) and is
+ * ignored when it would lower — same discipline as the off-site clamp above.
+ */
+async function resolveOnsiteApprovalContentRating(
+  tx: Prisma.TransactionClient,
+  args: {
+    appListingId: string;
+    declared: string | null;
+    override?: OffsiteContentRating | null;
+  }
+): Promise<string | null> {
+  const floored = await resolveListingRatingFloorInTx(tx, args.appListingId, args.declared);
+  const override = args.override ?? null;
+  if (override == null) return floored;
+  return nsfwLevelFromContentRating(override) > nsfwLevelFromContentRating(floored)
+    ? override
+    : floored;
 }
 
 /**
@@ -2692,6 +2747,11 @@ export async function approveExternalRequest(opts: {
         // needs the kind discriminator; `slug` names the listing in the error.
         kind: true,
         slug: true,
+        // ON-SITE approve inputs, read on the PRIMARY with everything else so they are
+        // row-consistent with the flip: the app's DECLARED rating (the raise-only floor —
+        // see `resolveOnsiteApprovalContentRating`) and the backing block to un-suspend.
+        contentRating: true,
+        appBlockId: true,
       },
     });
     if (!primaryListing) {
@@ -2800,12 +2860,26 @@ export async function approveExternalRequest(opts: {
     // Derive (+ mod-override, floored) the content rating from the assets' max
     // detected nsfwLevel and stamp it on the listing as it goes live. The author is
     // never blocked on the scanner's rating — it is confirmed HERE at review.
-    const finalRating = await resolveApprovalContentRating(tx, {
-      appListingId,
-      iconId: primaryListing.iconId,
-      coverId: primaryListing.coverId,
-      override: opts.contentRating,
-    });
+    //
+    // 🔴 ON-SITE TAKES THE RAISE-ONLY VARIANT, and this branch is NEW because until the
+    // owner-republish asset-review route existed nothing could reach this path with
+    // `kind: 'onsite'` — every other on-site listing request is a media REVISION and
+    // returns above via `applyApprovedRevision`. An on-site listing's `contentRating`
+    // describes the APP (manifest-declared), so it must be raised by mature media and
+    // never lowered by tame media. See {@link resolveOnsiteApprovalContentRating}.
+    const finalRating =
+      request.kind === 'onsite'
+        ? await resolveOnsiteApprovalContentRating(tx, {
+            appListingId,
+            declared: primaryListing.contentRating,
+            override: opts.contentRating,
+          })
+        : await resolveApprovalContentRating(tx, {
+            appListingId,
+            iconId: primaryListing.iconId,
+            coverId: primaryListing.coverId,
+            override: opts.contentRating,
+          });
     // Guard flips a `draft` OR a `pending` listing → approved. `pending` is the W13
     // post-approval-mgmt REOPEN path: `resetListingToPending` bounces an approved
     // listing back to `pending` + mints a fresh pending request pointing at it (a
@@ -2824,6 +2898,26 @@ export async function approveExternalRequest(opts: {
         'NOT_PENDING',
         `cannot approve — the draft/pending listing is no longer available`
       );
+    }
+
+    // 🔴 ON-SITE: RESTORE THE RUNTIME, NOT ONLY THE STORE CARD. `AppBlock.status` is the
+    // ONLY gate on whether a hosted app serves; `AppListing.status` gates store
+    // visibility and nothing else. `unpublishOwnListing` suspends the block, and the
+    // owner-republish review arm deliberately leaves it suspended so an app whose store
+    // card is awaiting review does not serve. Approving the card therefore has to undo
+    // BOTH halves, or the listing goes live pointing at a dead app — store-visible and
+    // not self-recoverable, the same failure `approveRequest`'s `(3b-reset)` branch
+    // exists to prevent on the block-request surface.
+    //
+    // Guarded to `suspended` so it is a 0-row no-op for every other case: a first-time
+    // on-site draft (there is no such listing request today, but the guard means one
+    // would be harmless), an on-site listing whose block is already approved, and every
+    // off-site listing (no `appBlockId` at all).
+    if (request.kind === 'onsite' && primaryListing.appBlockId) {
+      await tx.appBlock.updateMany({
+        where: { id: primaryListing.appBlockId, status: 'suspended' },
+        data: { status: 'approved' },
+      });
     }
     // Supersede any OTHER pending off-site request pointing at the SAME listing row
     // (`appListingId`), NOT merely the same slug. 🔴 A pending REVISION request

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -627,11 +627,12 @@ export type CloseTerminalListingOutcome = 'deleted' | 'removed' | 'none';
  *                 `removed` (recoverable via mod `relistListing`) AND write a `delist`
  *                 `AppListingModerationEvent`. 🔴 The action is UNCONDITIONALLY `delist`
  *                 (Fix #1 authz), for BOTH the reject and the withdraw caller: a
- *                 formerly-live `pending` listing is ALWAYS mod-mandated (only the mod
- *                 reset fns set `pending` on a live listing), so an owner who withdraws
- *                 the re-review must NOT be able to self-restore — `delist` makes the
- *                 last event a takedown, so `republishOwnListing` FORBIDS the owner and
- *                 a mod must relist. (This replaced a most-recent-event probe that an
+ *                 formerly-live `pending` listing is in review — mod-mandated, or (since
+ *                 the owner-republish asset-change gate) owner-initiated — and an owner
+ *                 who withdraws a re-review must NOT be able to self-restore, so `delist`
+ *                 makes the last event a takedown: `republishOwnListing` FORBIDS the owner
+ *                 and a mod must relist. Written UNCONDITIONALLY for both; see the
+ *                 in-branch note. (This replaced a most-recent-event probe that an
  *                 intervening report-resolve/dismiss event could defeat.)
  *   - anything else (approved/removed) → no-op (a terminal request never targets one;
  *                 guarded defensively).
@@ -674,14 +675,24 @@ async function closeTerminalListing(
     // ALWAYS mod-mandated, so the close ALWAYS writes a `delist` event (never
     // `owner-unpublish`), regardless of which caller (reject or withdraw) reached here.
     //
-    // WHY the pending branch is unconditionally mod-mandated: the ONLY writers of
-    // `status='pending'` for a formerly-LIVE listing are the two mod reset fns
-    // (`resetListingToPending` / `resetOnsiteListingToPending`). A first-time submission
-    // is `draft` (handled by the branch above → deleted); a revision is a `draft`
-    // shadow (also the `draft` branch); owner unpublish/republish only move
-    // approved↔removed and never touch `pending`. So reaching here means a mod bounced
-    // a live listing back to review — an owner withdrawing that re-review must NOT be
-    // able to self-restore the pre-reset content with no re-review.
+    // WHY the pending branch is written unconditionally: a first-time submission is
+    // `draft` (handled by the branch above → deleted) and a revision is a `draft` shadow
+    // (also the `draft` branch), so reaching here means a formerly-LIVE listing was
+    // bounced back to review — and an owner withdrawing a re-review must NOT be able to
+    // self-restore the pre-reset content with no re-review.
+    //
+    // 🔴 THE WRITER SET IS NO LONGER ONLY THE TWO MOD RESET FNS, and this comment used to
+    // say it was. `republishOwnListing`'s ASSET-CHANGE REVIEW GATE
+    // (`offsite-moderation.service`) also writes `pending` on a formerly-live listing:
+    // when an owner republishes a listing whose assets changed since the last approval, it
+    // routes to review instead of going live. So this branch can now close an
+    // OWNER-INITIATED review as well as a mod-mandated one, and it treats both the same —
+    // `delist`, i.e. the owner must ask a moderator to relist rather than self-restoring.
+    // For the mod-mandated case that is the point. For the owner-initiated case it is a
+    // deliberate FAIL-CLOSED choice, not an oversight: distinguishing them means
+    // re-introducing a most-recent-event probe here, and the last one was removed because
+    // it was exploitable (below). Nothing unreviewed reaches the store either way; the
+    // cost is that an owner who withdraws their own re-review needs a moderator.
     //
     // This REPLACES an earlier most-recent-event probe (`last event == reset-to-pending
     // ? delist : owner-unpublish`), which was BOTH exploitable and unsafe-by-default: an

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -2385,11 +2385,26 @@ export async function updateRevisionDraft(opts: {
 // Listing-request kinds surfaced by the CONSOLIDATION half of the flow
 // (approve/reject + the mod review queue + my-submissions).
 //
-// 🔴 INVARIANT: the ONLY producer of a `kind='onsite'` `AppListingPublishRequest`
-// is `submitListingRevision` on an onsite SHADOW (i.e. an onsite media revision) —
-// the onsite CODE review runs over a DIFFERENT table (`AppBlockPublishRequest`).
-// So widening these gates from `'offsite'` to this set surfaces EXACTLY onsite
-// media revisions, nothing else. (Asserted in the service tests.)
+// 🔴 THERE ARE TWO PRODUCERS OF A `kind='onsite'` `AppListingPublishRequest`, and this
+// comment used to name only one. The onsite CODE review still runs over a DIFFERENT
+// table (`AppBlockPublishRequest`); what changed is that the LISTING table now carries
+// on-site rows of two shapes:
+//
+//   1. `submitListingRevision` on an onsite SHADOW — a media revision, `revisionOfId`
+//      SET on the target listing, the parent slug denormalized onto the request.
+//   2. `routeRepublishToReviewInTx` (owner republish whose assets changed since the last
+//      approval) — NON-SHADOW, `revisionOfId` NULL, targeting the live listing itself.
+//
+// So widening these gates from `'offsite'` to this set no longer surfaces "exactly onsite
+// media revisions": it surfaces onsite media revisions AND onsite republish re-reviews.
+// Both belong in the queue — the modal reads `request.appListingId` and is kind-agnostic —
+// but any consumer that reasons "onsite request ⇒ shadow" is now wrong. Check
+// `revisionOfId` when you need to tell them apart, never `kind`.
+//
+// The producer SET is pinned as a ledger in
+// `src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts`
+// (`LISTING_REQUEST_PRODUCERS`), which fails when it GROWS or SHRINKS — this sentence went
+// stale precisely because nothing could notice a producer being added.
 // ---------------------------------------------------------------------------
 const REVIEWABLE_LISTING_KINDS = ['onsite', 'offsite'] as const;
 
@@ -2474,7 +2489,22 @@ async function resolveApprovalContentRating(
  * on-site rating sites have ONE spelling.
  *
  * A moderator override may still RAISE above the floor (a mod may always rate up) and is
- * ignored when it would lower — same discipline as the off-site clamp above.
+ * ignored when it would lower.
+ *
+ * 🔴 NOT quite "the same discipline as the off-site clamp above" — that sentence used to
+ * live here and it is inaccurate AT EQUAL LEVEL, which is a reachable case rather than a
+ * pedantic one. `nsfwLevelFromContentRating` maps BOTH `'g'` and `'pg'` to
+ * `NsfwLevel.PG`, so the two ratings are indistinguishable to these comparisons. Off-site
+ * asks `override < derived ? derived : override` and therefore returns the OVERRIDE on a
+ * tie; on-site asks `override > floored ? override : floored` and returns the FLOOR. So a
+ * moderator who explicitly picks `'pg'` for a `'g'`-declared app has that choice honoured
+ * off-site and silently dropped on-site.
+ *
+ * Left as-is deliberately: the two values carry the SAME maturity ceiling, so nothing
+ * about who can see the listing changes — the divergence is which LABEL is stored, and
+ * deciding that a tie-breaking override should overwrite an author's declaration is a
+ * product call, not a safety fix to make in passing. Recorded here so the next reader
+ * does not infer symmetry that is not there.
  */
 async function resolveOnsiteApprovalContentRating(
   tx: Prisma.TransactionClient,
@@ -3366,9 +3396,20 @@ export async function rejectExternalRequest(opts: {
     });
   });
 
-  // Post-commit, best-effort: notify the owner their first-time submission was not
-  // approved, carrying the mod reason. Skipped for a revision reject (parent still
-  // live) and when there was no listing. Keyed by the request → dedups a replay.
+  // Post-commit, best-effort: notify the owner their submission was not approved,
+  // carrying the mod reason. Skipped for a revision reject (parent still live) and when
+  // there was no listing. Keyed by the request → dedups a replay.
+  //
+  // 🔴 "FIRST-TIME submission" is what this comment used to say, and `revisionOfId == null`
+  // is no longer a test for that. The owner-republish asset-review route mints a NON-shadow
+  // request on a listing that has been live for as long as the app has existed, so a
+  // long-lived app's owner now reaches this branch. That is the right call — the reject
+  // ran `closeTerminalListing`, which took the listing OFF the store behind a `delist`, so
+  // the owner must be told — and the copy carries it: `app-listing-rejected` renders
+  // "<app> was not approved: <reason>", which claims nothing about it being a first
+  // submission. What is NOT covered is that the notice does not say the listing has been
+  // delisted and now needs a moderator to restore it; distinguishing the two cases needs a
+  // second notification type, which is a product decision rather than a correction.
   if (rejectedListing && rejectedListing.revisionOfId == null) {
     await notifyAppListingOwner({
       type: 'app-listing-rejected',
@@ -3572,11 +3613,22 @@ export async function listMySubmissions(opts: { userId: number } & ListOffsiteRe
       // surfaced as a `hasPendingRevision` flag on the PARENT's own submission row.
       // Keep requests with no listing.
       //
-      // ONSITE: an onsite listing is auto-created and has NO own publish request, so
-      // there is no parent row to badge — its ONLY representation IS the revision
-      // request (all onsite requests are shadow revisions, per the invariant). Include
-      // them directly via the `{ kind: 'onsite' }` OR branch so onsite media revisions
-      // appear on my-submissions (decision: yes).
+      // ONSITE: an onsite listing is auto-created and has NO own publish request, so a
+      // SHADOW revision has no parent row to badge — the revision request is its only
+      // representation. The `{ kind: 'onsite' }` OR branch surfaces it directly
+      // (decision: yes).
+      //
+      // 🔴 THAT BRANCH IS NO LONGER THE ONLY ROUTE FOR AN ONSITE ROW, and the sentence it
+      // used to carry — "all onsite requests are shadow revisions, per the invariant" —
+      // is false since the owner-republish asset-review route (see the producer ledger
+      // above `REVIEWABLE_LISTING_KINDS`). A republish re-review is NON-shadow, so the
+      // middle branch (`revisionOfId: null`) already matches it; `OR` is a set union, so
+      // it appears exactly once either way and this query is unchanged in behaviour. What
+      // IS affected is downstream: `hasPendingRevision` below is keyed on `revisionOfId`
+      // and is correctly `false` for such a row, and `lastActionByListing` populates only
+      // for `status: 'removed'`, so a listing sitting in republish review carries no
+      // last-action badge. Both are deliberate; neither may be re-derived from "onsite
+      // implies shadow".
       OR: [{ appListingId: null }, { appListing: { revisionOfId: null } }, { kind: 'onsite' }],
     },
     orderBy: { submittedAt: 'desc' },

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -27,7 +27,17 @@ import {
   resolveListingRatingFloorInTx,
 } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionableInTx } from '~/server/services/blocks/app-listing-actionable.service';
-import { isOwnerUnpublishedListing } from '~/server/services/blocks/app-listing-owner-unpublish';
+import {
+  isOwnerUnpublishAction,
+  readLastStatusChangingModerationEvent,
+} from '~/server/services/blocks/app-listing-owner-unpublish';
+import {
+  REPUBLISH_REVIEW_DETAIL,
+  type RepublishReviewReason,
+  buildApprovedAssetSnapshot,
+  readRecordedAssetSnapshot,
+  resolveRepublishReviewReason,
+} from '~/server/services/blocks/app-listing-approved-assets';
 import {
   newAppListingModerationEventId,
   newAppListingPublishRequestId,
@@ -1144,6 +1154,98 @@ export type ResetOnsiteListingToPendingResult = {
 };
 
 /**
+ * The columns a re-queue clones out of the most-recent APPROVED `AppBlockPublishRequest`.
+ *
+ * ONE SPELLING, shared by every caller that re-queues an on-site app for review
+ * ({@link resetOnsiteListingToPending} — the moderator reset — and the owner-republish
+ * asset-review route). The select and the create below are a matched pair: a column added
+ * to one and forgotten in the other silently drops that field from every re-queued
+ * request, which is exactly how the #4059 provenance columns nearly went missing.
+ */
+const APPROVED_BLOCK_REQUEST_CLONE_SELECT = {
+  appBlockId: true,
+  version: true,
+  manifest: true,
+  bundleKey: true,
+  bundleSha256: true,
+  bundleSizeBytes: true,
+  fileSummary: true,
+  manifestDiffSummary: true,
+  forgejoCommitSha: true,
+  // #4059 — selected so the clone can CARRY them. See the create.
+  sourceCommit: true,
+  sourceDirty: true,
+} as const;
+
+type ApprovedBlockRequestClone = Prisma.AppBlockPublishRequestGetPayload<{
+  select: typeof APPROVED_BLOCK_REQUEST_CLONE_SELECT;
+}>;
+
+/**
+ * Clone an approved on-site publish request into a FRESH `pending` one so the app
+ * re-enters `listPendingRequests` with the SAME assets/version/manifest — no owner
+ * resubmit, and a moderator re-approves it through the existing `approveRequest` flow.
+ *
+ * 🔴 #4059 — the client's provenance CLAIM is carried forward, VERBATIM.
+ *
+ * The justification is narrow and it is the only one: this clone re-submits
+ * BYTE-IDENTICAL bundle bytes (same `bundleKey`, same `bundleSha256` as the approved
+ * row). A claim about which tree those exact bytes came from is still the SAME claim
+ * about the SAME bytes — copying it invents nothing. Dropping it would permanently lose
+ * the answer to "which tree did these bytes come from?" for any app that goes through a
+ * suspend → reset-to-pending cycle, which is the archaeology #4059 exists to make
+ * unnecessary.
+ *
+ * Copied RAW, including NULL: a NULL on the source row means UNKNOWN and must stay
+ * UNKNOWN here. No `??` fallback of any kind — least of all to `forgejoCommitSha`, which
+ * is a SERVER-side sha in the platform's own repo and would fabricate an author's-tree
+ * claim nobody made. `false` likewise stays `false` (asserted CLEAN), never folded into
+ * UNKNOWN.
+ *
+ * 🔴 NOT the `recordPendingFromPush` case, which correctly writes NEITHER: that path has
+ * no client and no author work tree, so there is no claim in existence to carry.
+ *
+ * The partial-unique `app_block_publish_requests_one_pending_per_slug` index is the real
+ * guard against a second in-flight review; callers pre-check it for a friendly error and
+ * must still catch its P2002 as a race backstop.
+ */
+async function cloneApprovedBlockRequestToPending(
+  tx: Prisma.TransactionClient,
+  args: {
+    lastApproved: ApprovedBlockRequestClone;
+    publishRequestId: string;
+    slug: string;
+    appBlockId: string;
+    /**
+     * The LISTING OWNER, never the acting moderator — my-submissions and the mod queue
+     * attribute a re-queued request to the person whose app it is.
+     */
+    submittedByUserId: number;
+  }
+): Promise<void> {
+  const { lastApproved } = args;
+  await tx.appBlockPublishRequest.create({
+    data: {
+      id: args.publishRequestId,
+      appBlockId: lastApproved.appBlockId ?? args.appBlockId,
+      slug: args.slug,
+      submittedByUserId: args.submittedByUserId,
+      version: lastApproved.version,
+      manifest: lastApproved.manifest as Prisma.InputJsonValue,
+      bundleKey: lastApproved.bundleKey,
+      bundleSha256: lastApproved.bundleSha256,
+      bundleSizeBytes: lastApproved.bundleSizeBytes,
+      fileSummary: lastApproved.fileSummary as Prisma.InputJsonValue,
+      manifestDiffSummary: lastApproved.manifestDiffSummary as Prisma.InputJsonValue,
+      forgejoCommitSha: lastApproved.forgejoCommitSha,
+      sourceCommit: lastApproved.sourceCommit,
+      sourceDirty: lastApproved.sourceDirty,
+      status: 'pending',
+    },
+  });
+}
+
+/**
  * MOD reset an APPROVED ON-SITE (hosted app-block) listing back into the block
  * review queue (the W13-deferred onsite reset-to-pending — now built). Mirrors the
  * offsite `resetListingToPending` semantics across the DIFFERENT onsite plumbing:
@@ -1209,20 +1311,7 @@ export async function resetOnsiteListingToPending(opts: {
   const lastApproved = await dbRead.appBlockPublishRequest.findFirst({
     where: { slug: listing.slug, status: 'approved' },
     orderBy: [{ submittedAt: 'desc' }],
-    select: {
-      appBlockId: true,
-      version: true,
-      manifest: true,
-      bundleKey: true,
-      bundleSha256: true,
-      bundleSizeBytes: true,
-      fileSummary: true,
-      manifestDiffSummary: true,
-      forgejoCommitSha: true,
-      // #4059 — selected so the clone below can CARRY them. See the create.
-      sourceCommit: true,
-      sourceDirty: true,
-    },
+    select: APPROVED_BLOCK_REQUEST_CLONE_SELECT,
   });
   if (!lastApproved) {
     throw new OffsiteModerationError(
@@ -1277,45 +1366,15 @@ export async function resetOnsiteListingToPending(opts: {
       // it to the owner, not the acting mod). Same assets/version/manifest → a mod
       // re-approves with no owner resubmit. The partial-unique index (one pending per
       // slug) is satisfied (we pre-checked); a raced create fires P2002 → caught below.
-      await tx.appBlockPublishRequest.create({
-        data: {
-          id: publishRequestId,
-          appBlockId: lastApproved.appBlockId ?? appBlockId,
-          slug: listing.slug,
-          submittedByUserId: listing.userId,
-          version: lastApproved.version,
-          manifest: lastApproved.manifest as Prisma.InputJsonValue,
-          bundleKey: lastApproved.bundleKey,
-          bundleSha256: lastApproved.bundleSha256,
-          bundleSizeBytes: lastApproved.bundleSizeBytes,
-          fileSummary: lastApproved.fileSummary as Prisma.InputJsonValue,
-          manifestDiffSummary: lastApproved.manifestDiffSummary as Prisma.InputJsonValue,
-          forgejoCommitSha: lastApproved.forgejoCommitSha,
-          // #4059 — carry the client's provenance CLAIM forward, verbatim.
-          //
-          // The justification is narrow and it is the only one: this clone
-          // re-submits BYTE-IDENTICAL bundle bytes (same `bundleKey`, same
-          // `bundleSha256` as the approved row above). A claim about which tree
-          // those exact bytes came from is still the SAME claim about the SAME
-          // bytes — copying it invents nothing. Dropping it would permanently
-          // lose the answer to "which tree did these bytes come from?" for any
-          // app that goes through a suspend → reset-to-pending cycle, which is
-          // the archaeology #4059 exists to make unnecessary.
-          //
-          // Copied RAW, including NULL: a NULL on the source row means UNKNOWN
-          // and must stay UNKNOWN here. No `??` fallback of any kind — least of
-          // all to `forgejoCommitSha`, which is a SERVER-side sha in the
-          // platform's own repo and would fabricate an author's-tree claim
-          // nobody made. `false` likewise stays `false` (asserted CLEAN), never
-          // folded into UNKNOWN.
-          //
-          // 🔴 NOT the `recordPendingFromPush` case, which correctly writes
-          // NEITHER: that path has no client and no author work tree, so there
-          // is no claim in existence to carry.
-          sourceCommit: lastApproved.sourceCommit,
-          sourceDirty: lastApproved.sourceDirty,
-          status: 'pending',
-        },
+      // The clone payload (incl. the #4059 provenance rules) lives in
+      // {@link cloneApprovedBlockRequestToPending}, shared with the owner-republish
+      // asset-review route so the two can never drift a column apart.
+      await cloneApprovedBlockRequestToPending(tx, {
+        lastApproved,
+        publishRequestId,
+        slug: listing.slug,
+        appBlockId,
+        submittedByUserId: listing.userId,
       });
 
       // (4) audit event.
@@ -1373,6 +1432,8 @@ async function loadOwnedListingInTx(
   name: string | null;
   appBlockId: string | null;
   contentRating: string | null;
+  iconId: number | null;
+  coverId: number | null;
 }> {
   const listing = await tx.appListing.findUnique({
     where: { id: appListingId },
@@ -1386,6 +1447,13 @@ async function loadOwnedListingInTx(
       // The DECLARED rating, the input to `republishOwnListing`'s go-live rating floor.
       // `unpublishOwnListing` ignores it — a self-hide never touches the rating.
       contentRating: true,
+      // The two scalar halves of the reviewable ASSET SURFACE (the third — screenshots —
+      // is a child table). Selected HERE, on the row both owner procs already load on the
+      // primary inside their transaction, so `buildApprovedAssetSnapshot` neither re-reads
+      // them nor opens a second window in which they could move relative to the
+      // screenshots it does read. See `app-listing-approved-assets`.
+      iconId: true,
+      coverId: true,
     },
   });
   if (!listing) {
@@ -1402,6 +1470,8 @@ async function loadOwnedListingInTx(
     name: listing.name,
     appBlockId: listing.appBlockId,
     contentRating: listing.contentRating,
+    iconId: listing.iconId,
+    coverId: listing.coverId,
   };
 }
 
@@ -1453,6 +1523,22 @@ export async function unpublishOwnListing(opts: {
       from: 'approved',
       to: 'suspended',
     });
+    // 🔴 RECORD THE APPROVED ASSET SURFACE. This is the ONLY place the store learns what
+    // imagery a moderator last signed off on — nothing else in the schema captures it (no
+    // approve path writes a moderation event at all, and every existing `before`/`after`
+    // payload is `{status}`/`{userId}`). `republishOwnListing` compares against it to
+    // decide whether a republish may go live immediately or has to re-enter review.
+    //
+    // WHY IT IS SOUND HERE AND NOWHERE CHEAPER: the flip above ran on a listing that was
+    // `approved`, and an approved non-shadow listing is NOT owner-asset-editable
+    // (`assertOwnerAssetEditable`), so the assets read here ARE the last-approved ones. It
+    // is read on the PRIMARY inside the SAME tx as the flip, so a concurrent asset write
+    // cannot slip between the snapshot and the removal.
+    //
+    // It goes in `before` because that is the state this event moved AWAY from — the
+    // approved one. `after` describes the `removed` state, whose assets are about to
+    // become freely editable and therefore mean nothing to a later reviewer.
+    const approvedAssets = await buildApprovedAssetSnapshot(tx, input.appListingId, listing);
     await tx.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),
@@ -1461,7 +1547,7 @@ export async function unpublishOwnListing(opts: {
         action: 'owner-unpublish',
         actorUserId: userId,
         reason,
-        before: { status: 'approved' },
+        before: { status: 'approved', assets: approvedAssets },
         after: { status: 'removed' },
       },
     });
@@ -1470,23 +1556,81 @@ export async function unpublishOwnListing(opts: {
   return { appListingId: input.appListingId, status: 'removed' };
 }
 
-export type RepublishOwnListingResult = { appListingId: string; status: 'approved' };
+/**
+ * Where an owner republish LANDED.
+ *
+ * 🔴 `'pending'` IS A REAL, EXPECTED OUTCOME, NOT AN ERROR — the listing did not go live
+ * and every surface that reports the result must branch on this field rather than
+ * assuming success means "live". Telling an owner "it is live again" when it is sitting
+ * in a review queue is a lie the type system now refuses to let you tell silently.
+ */
+export type RepublishOwnListingResult = {
+  appListingId: string;
+  status: 'approved' | 'pending';
+  /** Set only on the `'pending'` arm — why the republish had to be reviewed. */
+  reviewReason?: RepublishReviewReason;
+};
 
 /**
- * OWNER restore their OWN owner-unpublished listing (removed → approved) — DUAL-KIND
- * (W13 P4).
+ * OWNER restore their OWN owner-unpublished listing — DUAL-KIND (W13 P4).
  *
- * 🔴 SAFETY GUARD (load-bearing): republish is allowed ONLY when the MOST-RECENT
- * `AppListingModerationEvent` for the listing is an `owner-unpublish`. If the last
- * event is a moderator `delist`/`purge` (a takedown-for-cause), republish is
+ * 🔴 ASSET-CHANGE REVIEW GATE (removed → approved, OR removed → pending). An owner may
+ * unpublish their own listing, swap the icon/cover/screenshots — a `removed` listing is
+ * DIRECTLY asset-editable, `assertOwnerAssetEditable` refuses only an `approved`
+ * non-shadow row — and republish. Before this gate that put brand-new imagery on a public
+ * store card with NO content review: the two go-live gates below read scan STATUS and the
+ * destination href, and #4418's floor reads MATURITY. None of them is a review.
+ *
+ * So: if ANY listing asset differs from what was live at the last approval, the republish
+ * routes the listing to `pending` (re-review) instead of `approved`, and re-queues it —
+ * off-site by minting a fresh pending `AppListingPublishRequest` (which
+ * `approveExternalRequest`'s widened `{draft,pending}` guard re-approves), on-site by
+ * cloning the latest approved `AppBlockPublishRequest` (which `approveRequest`'s
+ * `(3b-reset)` branch re-approves AND un-suspends the block for). Both are the EXISTING
+ * reset-to-pending machinery — see {@link resetListingToPending} /
+ * {@link resetOnsiteListingToPending}, whose writes this mirrors exactly.
+ *
+ * If NOTHING changed, republish is immediate exactly as it was — no extra queue entry, no
+ * moderator involvement, no behaviour change at all.
+ *
+ * 🔴 THE SIGNAL IS RECORDED, NOT INFERRED, AND ITS ABSENCE FAILS CLOSED. Nothing in the
+ * schema previously captured the approved asset set (no approve path writes a moderation
+ * event; every existing `before`/`after` payload is `{status}`/`{userId}`; `updatedAt` is
+ * bumped by the republish flip itself and a DELETED screenshot leaves no timestamp at
+ * all). {@link unpublishOwnListing} now records it into the `owner-unpublish` event's
+ * `before.assets`. A listing unpublished BEFORE that shipped has no snapshot, and a
+ * comparison against an absent operand reports MISSING, not SAME — those route to review
+ * (`reviewReason: 'no-recorded-assets'`) rather than being waved through. See
+ * `app-listing-approved-assets`.
+ *
+ * 🔴 THIS ADDS A SECOND WRITER OF `app_listings.status = 'pending'` ON A FORMERLY-LIVE
+ * LISTING. `closeTerminalListing` (`offsite-listing.service`) and
+ * `closeOnsiteResetListingOnWithdraw` (`publish-request.service`) both reason that such a
+ * listing is ALWAYS mod-mandated and unconditionally write a `delist` on withdraw/reject.
+ * That is now narrower than the truth, and the consequence is deliberate but not free:
+ * an owner who routes themselves into review and then WITHDRAWS the request lands on
+ * `removed` + `delist`, so `republishOwnListing` forbids them and a moderator must
+ * `relistListing`. Fail-CLOSED, and no content reaches the store unreviewed — but it is a
+ * self-inflicted lockout that did not exist before. Left as-is on purpose rather than
+ * loosened here: that predicate was made unconditional to close a real exploit (an
+ * intervening `report-resolve` shifted the newest event and let an owner self-restore
+ * mod-mandated content), and re-opening it is a product decision, not an implementation
+ * detail. Both comments are corrected in place; see the PR body.
+ *
+ * 🔴 SAFETY GUARD (load-bearing, unchanged): republish is allowed ONLY when the
+ * MOST-RECENT status-changing `AppListingModerationEvent` is an `owner-unpublish`. If the
+ * last event is a moderator `delist`/`purge` (a takedown-for-cause), republish is
  * FORBIDDEN — an owner must NOT be able to self-restore a listing a moderator
  * removed. No events at all → also FORBIDDEN (can't prove owner-initiated removal).
  * The latest-event read + the flip are in ONE tx on the PRIMARY so a concurrent mod
  * takedown can't slip between the check and the restore.
  *
- * ON-SITE: the backing `AppBlock` is also restored suspended → approved in the SAME
- * tx (via {@link flipBackingBlockStatus}), so the app serves again. OFF-SITE: only the
- * listing flips. `reason` optional.
+ * ON-SITE: on the IMMEDIATE arm the backing `AppBlock` is also restored suspended →
+ * approved in the SAME tx (via {@link flipBackingBlockStatus}), so the app serves again.
+ * On the REVIEW arm it is deliberately LEFT SUSPENDED — the app must not serve while its
+ * store card is unreviewed — and `approveRequest`'s `(3b-reset)` branch un-suspends it on
+ * re-approve, gated on exactly the `pending` listing status this route writes. OFF-SITE:
+ * only the listing flips. `reason` optional.
  *
  * 🔴 MATURITY IS RE-DERIVED AT GO-LIVE, UNIFORMLY FOR BOTH KINDS (this used to be a
  * pure visibility toggle with NO re-derive, which was the hole). A `removed` listing is
@@ -1508,6 +1652,8 @@ export async function republishOwnListing(opts: {
   // Set when the on-site block-restore flip matched 0 rows (drift — mirrors relist).
   let onsiteBlockRestoreDrift = false;
   let onsiteBlockId: string | null = null;
+  // Set by the REVIEW arm; `null` means the republish went live immediately.
+  let reviewReason: RepublishReviewReason | null = null;
 
   await dbWrite.$transaction(async (tx) => {
     const listing = await loadOwnedListingInTx(tx, input.appListingId, userId);
@@ -1521,7 +1667,12 @@ export async function republishOwnListing(opts: {
     // the PRIMARY inside the tx (a concurrent mod delist/purge would otherwise race
     // between a replica read and the flip). A mod delist/purge (or NO event) → the
     // owner may not self-restore.
-    if (!(await isOwnerUnpublishedListing(tx, input.appListingId))) {
+    //
+    // ONE read, not two: the same row also carries the asset snapshot the review gate
+    // below compares against, and the verb and the payload MUST come from the same event
+    // (see `readLastStatusChangingModerationEvent`).
+    const lastEvent = await readLastStatusChangingModerationEvent(tx, input.appListingId);
+    if (!isOwnerUnpublishAction(lastEvent?.action)) {
       throw new OffsiteModerationError(
         'FORBIDDEN',
         'This listing was removed by a moderator and cannot be restored by its owner.'
@@ -1591,6 +1742,40 @@ export async function republishOwnListing(opts: {
       listing.contentRating
     );
 
+    // 🔴 THE ASSET-CHANGE REVIEW GATE. Compare the listing's CURRENT reviewable asset
+    // surface against the one recorded when the owner unpublished it (= the one a
+    // moderator last approved — see the function doc). Read on the PRIMARY, inside this
+    // tx, so it is row-consistent with the flip it decides.
+    //
+    // 🔴 The absent-snapshot arm is EXPLICIT, and it is the whole reason this is not a
+    // bare `!==`: `resolveRepublishReviewReason` is handed `null` for a missing or
+    // malformed payload and returns `'no-recorded-assets'`, never `null`-meaning-fine.
+    // A comparison against an absent operand reports MISSING, not SAME.
+    //
+    // 🔴 IT RUNS AFTER THE RATING FLOOR ON PURPOSE. The floor is applied on BOTH arms —
+    // #4418's guarantee must not depend on which arm a republish takes. It especially
+    // must not be skipped on the review arm: the on-site re-approve that later restores
+    // a `pending` listing (`approveRequest`'s `(3b-reset)` branch) writes ONLY `status`
+    // and runs no floor of its own, so deferring the floor to "the approve will do it"
+    // would silently drop it for every on-site review-arm republish.
+    const liveAssets = await buildApprovedAssetSnapshot(tx, input.appListingId, listing);
+    reviewReason = resolveRepublishReviewReason(
+      readRecordedAssetSnapshot(lastEvent?.before),
+      liveAssets
+    );
+
+    if (reviewReason) {
+      await routeRepublishToReviewInTx(tx, {
+        appListingId: input.appListingId,
+        listing,
+        userId,
+        reason,
+        reviewReason,
+        flooredRating,
+      });
+      return;
+    }
+
     const flipped = await tx.appListing.updateMany({
       where: { id: input.appListingId, kind: listing.kind, status: 'removed' },
       data: { status: 'approved', contentRating: flooredRating },
@@ -1653,7 +1838,145 @@ export async function republishOwnListing(opts: {
       .catch(() => undefined);
   }
 
-  return { appListingId: input.appListingId, status: 'approved' };
+  // 🔴 The narrowing is on the LOCAL, not on a re-read: `reviewReason` is assigned inside
+  // the transaction callback and TypeScript cannot see through the closure, so it is
+  // widened back to the union here explicitly rather than trusted.
+  const landedReviewReason: RepublishReviewReason | null = reviewReason;
+  return landedReviewReason
+    ? { appListingId: input.appListingId, status: 'pending', reviewReason: landedReviewReason }
+    : { appListingId: input.appListingId, status: 'approved' };
+}
+
+/**
+ * REVIEW ARM of {@link republishOwnListing}: instead of going live, put the listing into
+ * `pending` and re-queue it so a moderator sees the changed assets.
+ *
+ * Every write here MIRRORS the existing reset-to-pending machinery rather than inventing
+ * a parallel concept — the re-approve paths that will bring the listing back
+ * (`approveExternalRequest` for off-site, `approveRequest`'s `(3b-reset)` branch for
+ * on-site) already recognise exactly this state and nothing else needed teaching:
+ *
+ *   OFF-SITE — flip `removed → pending`, mint a FRESH `pending` `AppListingPublishRequest`
+ *   owned by the listing owner (a NON-shadow request, which `approveExternalRequest`'s
+ *   widened `{draft,pending}` listing guard re-approves). Identical to
+ *   {@link resetListingToPending}'s writes.
+ *
+ *   ON-SITE — flip `removed → pending` and clone the latest approved
+ *   `AppBlockPublishRequest` into a fresh `pending` one (same assets/version/manifest, no
+ *   owner resubmit), exactly as {@link resetOnsiteListingToPending} does. The backing
+ *   block is LEFT SUSPENDED (`unpublishOwnListing` suspended it and nothing here restores
+ *   it) — an app whose store card is awaiting review must not be serving — and the
+ *   `(3b-reset)` re-approve branch un-suspends it, gated on the `pending` listing status
+ *   this writes.
+ *
+ * 🔴 `contentRating` IS WRITTEN ON THIS ARM TOO. It carries #4418's raise-only floor,
+ * already derived by the caller; see the call site for why deferring it to the approve is
+ * not equivalent.
+ *
+ * The audit event is an `owner-republish` whose `after.status` is `pending`, so the
+ * history reads "the owner asked for this back, and it went to review" rather than
+ * implying it went live. `detail` names WHY (changed assets vs. no recorded baseline).
+ *
+ * A guarded 0-count on the flip throws, rolling back the whole tx — including the
+ * re-queued request — so a raced listing can never leave a stray queue entry behind.
+ */
+async function routeRepublishToReviewInTx(
+  tx: Prisma.TransactionClient,
+  args: {
+    appListingId: string;
+    listing: { kind: string; slug: string; userId: number; appBlockId: string | null };
+    userId: number;
+    reason: string | null;
+    reviewReason: RepublishReviewReason;
+    flooredRating: string | null;
+  }
+): Promise<void> {
+  const { appListingId, listing, reviewReason, flooredRating } = args;
+  const isOnsite = listing.kind === 'onsite';
+
+  // Resolve the on-site clone source BEFORE the flip: no approved version to re-review
+  // (or a review already in flight) must refuse the whole republish rather than strand
+  // the listing in `pending` with nothing in any queue — which no owner could recover
+  // from without a moderator.
+  let lastApproved: ApprovedBlockRequestClone | null = null;
+  if (isOnsite) {
+    if (!listing.appBlockId) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This app has no approved version to re-review.'
+      );
+    }
+    lastApproved = await tx.appBlockPublishRequest.findFirst({
+      where: { slug: listing.slug, status: 'approved' },
+      orderBy: [{ submittedAt: 'desc' }],
+      select: APPROVED_BLOCK_REQUEST_CLONE_SELECT,
+    });
+    if (!lastApproved) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This app has no approved version to re-review.'
+      );
+    }
+    // Friendly pre-check for the partial-unique `one pending per slug` index (mirrors
+    // `resetOnsiteListingToPending`); a raced create still surfaces as P2002.
+    const openPending = await tx.appBlockPublishRequest.findFirst({
+      where: { slug: listing.slug, status: 'pending' },
+      select: { id: true },
+    });
+    if (openPending) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'A review is already pending for this app.'
+      );
+    }
+  }
+
+  const flipped = await tx.appListing.updateMany({
+    where: { id: appListingId, kind: listing.kind, status: 'removed' },
+    data: { status: 'pending', contentRating: flooredRating },
+  });
+  if (flipped.count === 0) {
+    throw new OffsiteModerationError(
+      'NOT_TRANSITIONABLE',
+      'This listing can no longer be republished.'
+    );
+  }
+
+  if (isOnsite && lastApproved && listing.appBlockId) {
+    await cloneApprovedBlockRequestToPending(tx, {
+      lastApproved,
+      publishRequestId: `pubreq_${newUlid()}`,
+      slug: listing.slug,
+      appBlockId: listing.appBlockId,
+      submittedByUserId: listing.userId,
+    });
+  } else {
+    await tx.appListingPublishRequest.create({
+      data: {
+        id: newAppListingPublishRequestId(),
+        appListingId,
+        kind: listing.kind,
+        slug: listing.slug,
+        // The LISTING OWNER, so my-submissions and the mod queue attribute it to them.
+        submittedByUserId: listing.userId,
+        status: 'pending',
+      },
+    });
+  }
+
+  await tx.appListingModerationEvent.create({
+    data: {
+      id: newAppListingModerationEventId(),
+      appListingId,
+      slug: listing.slug,
+      action: 'owner-republish',
+      actorUserId: args.userId,
+      reason: args.reason,
+      detail: REPUBLISH_REVIEW_DETAIL[reviewReason],
+      before: { status: 'removed' },
+      after: { status: 'pending' },
+    },
+  });
 }
 
 /**

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -24,6 +24,7 @@ import { recordOwnershipEvent } from '~/server/services/blocks/app-collaborator.
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
   assertListingAssetsScanCleanInTx,
+  assertListingMeetsFloor,
   resolveListingRatingFloorInTx,
 } from '~/server/services/blocks/app-listing-assets.service';
 import { assertOffsiteListingActionableInTx } from '~/server/services/blocks/app-listing-actionable.service';
@@ -35,7 +36,7 @@ import {
   REPUBLISH_REVIEW_DETAIL,
   type RepublishReviewReason,
   buildApprovedAssetSnapshot,
-  readRecordedAssetSnapshot,
+  readRecordedAssetBaseline,
   resolveRepublishReviewReason,
 } from '~/server/services/blocks/app-listing-approved-assets';
 import {
@@ -432,7 +433,11 @@ export async function delistListing(opts: {
     // idempotent removed→removed write keeps status `removed` but still counts (1 row),
     // so the event below is ALWAYS written on a matched row.
     const flipped = await tx.appListing.updateMany({
-      where: { id: input.appListingId, kind: listing.kind, status: { in: ['approved', 'removed'] } },
+      where: {
+        id: input.appListingId,
+        kind: listing.kind,
+        status: { in: ['approved', 'removed'] },
+      },
       data: { status: 'removed' },
     });
     if (flipped.count === 0) {
@@ -588,8 +593,7 @@ export async function relistListing(opts: {
           {
             type: 'warning',
             name: 'app-listing-relist-block-drift',
-            message:
-              'onsite relist: backing app_block was not suspended; the block may not serve',
+            message: 'onsite relist: backing app_block was not suspended; the block may not serve',
             details: { appListingId: input.appListingId, appBlockId: listing.appBlockId },
           },
           'app-blocks'
@@ -1154,98 +1158,6 @@ export type ResetOnsiteListingToPendingResult = {
 };
 
 /**
- * The columns a re-queue clones out of the most-recent APPROVED `AppBlockPublishRequest`.
- *
- * ONE SPELLING, shared by every caller that re-queues an on-site app for review
- * ({@link resetOnsiteListingToPending} — the moderator reset — and the owner-republish
- * asset-review route). The select and the create below are a matched pair: a column added
- * to one and forgotten in the other silently drops that field from every re-queued
- * request, which is exactly how the #4059 provenance columns nearly went missing.
- */
-const APPROVED_BLOCK_REQUEST_CLONE_SELECT = {
-  appBlockId: true,
-  version: true,
-  manifest: true,
-  bundleKey: true,
-  bundleSha256: true,
-  bundleSizeBytes: true,
-  fileSummary: true,
-  manifestDiffSummary: true,
-  forgejoCommitSha: true,
-  // #4059 — selected so the clone can CARRY them. See the create.
-  sourceCommit: true,
-  sourceDirty: true,
-} as const;
-
-type ApprovedBlockRequestClone = Prisma.AppBlockPublishRequestGetPayload<{
-  select: typeof APPROVED_BLOCK_REQUEST_CLONE_SELECT;
-}>;
-
-/**
- * Clone an approved on-site publish request into a FRESH `pending` one so the app
- * re-enters `listPendingRequests` with the SAME assets/version/manifest — no owner
- * resubmit, and a moderator re-approves it through the existing `approveRequest` flow.
- *
- * 🔴 #4059 — the client's provenance CLAIM is carried forward, VERBATIM.
- *
- * The justification is narrow and it is the only one: this clone re-submits
- * BYTE-IDENTICAL bundle bytes (same `bundleKey`, same `bundleSha256` as the approved
- * row). A claim about which tree those exact bytes came from is still the SAME claim
- * about the SAME bytes — copying it invents nothing. Dropping it would permanently lose
- * the answer to "which tree did these bytes come from?" for any app that goes through a
- * suspend → reset-to-pending cycle, which is the archaeology #4059 exists to make
- * unnecessary.
- *
- * Copied RAW, including NULL: a NULL on the source row means UNKNOWN and must stay
- * UNKNOWN here. No `??` fallback of any kind — least of all to `forgejoCommitSha`, which
- * is a SERVER-side sha in the platform's own repo and would fabricate an author's-tree
- * claim nobody made. `false` likewise stays `false` (asserted CLEAN), never folded into
- * UNKNOWN.
- *
- * 🔴 NOT the `recordPendingFromPush` case, which correctly writes NEITHER: that path has
- * no client and no author work tree, so there is no claim in existence to carry.
- *
- * The partial-unique `app_block_publish_requests_one_pending_per_slug` index is the real
- * guard against a second in-flight review; callers pre-check it for a friendly error and
- * must still catch its P2002 as a race backstop.
- */
-async function cloneApprovedBlockRequestToPending(
-  tx: Prisma.TransactionClient,
-  args: {
-    lastApproved: ApprovedBlockRequestClone;
-    publishRequestId: string;
-    slug: string;
-    appBlockId: string;
-    /**
-     * The LISTING OWNER, never the acting moderator — my-submissions and the mod queue
-     * attribute a re-queued request to the person whose app it is.
-     */
-    submittedByUserId: number;
-  }
-): Promise<void> {
-  const { lastApproved } = args;
-  await tx.appBlockPublishRequest.create({
-    data: {
-      id: args.publishRequestId,
-      appBlockId: lastApproved.appBlockId ?? args.appBlockId,
-      slug: args.slug,
-      submittedByUserId: args.submittedByUserId,
-      version: lastApproved.version,
-      manifest: lastApproved.manifest as Prisma.InputJsonValue,
-      bundleKey: lastApproved.bundleKey,
-      bundleSha256: lastApproved.bundleSha256,
-      bundleSizeBytes: lastApproved.bundleSizeBytes,
-      fileSummary: lastApproved.fileSummary as Prisma.InputJsonValue,
-      manifestDiffSummary: lastApproved.manifestDiffSummary as Prisma.InputJsonValue,
-      forgejoCommitSha: lastApproved.forgejoCommitSha,
-      sourceCommit: lastApproved.sourceCommit,
-      sourceDirty: lastApproved.sourceDirty,
-      status: 'pending',
-    },
-  });
-}
-
-/**
  * MOD reset an APPROVED ON-SITE (hosted app-block) listing back into the block
  * review queue (the W13-deferred onsite reset-to-pending — now built). Mirrors the
  * offsite `resetListingToPending` semantics across the DIFFERENT onsite plumbing:
@@ -1311,7 +1223,20 @@ export async function resetOnsiteListingToPending(opts: {
   const lastApproved = await dbRead.appBlockPublishRequest.findFirst({
     where: { slug: listing.slug, status: 'approved' },
     orderBy: [{ submittedAt: 'desc' }],
-    select: APPROVED_BLOCK_REQUEST_CLONE_SELECT,
+    select: {
+      appBlockId: true,
+      version: true,
+      manifest: true,
+      bundleKey: true,
+      bundleSha256: true,
+      bundleSizeBytes: true,
+      fileSummary: true,
+      manifestDiffSummary: true,
+      forgejoCommitSha: true,
+      // #4059 — selected so the clone below can CARRY them. See the create.
+      sourceCommit: true,
+      sourceDirty: true,
+    },
   });
   if (!lastApproved) {
     throw new OffsiteModerationError(
@@ -1366,15 +1291,45 @@ export async function resetOnsiteListingToPending(opts: {
       // it to the owner, not the acting mod). Same assets/version/manifest → a mod
       // re-approves with no owner resubmit. The partial-unique index (one pending per
       // slug) is satisfied (we pre-checked); a raced create fires P2002 → caught below.
-      // The clone payload (incl. the #4059 provenance rules) lives in
-      // {@link cloneApprovedBlockRequestToPending}, shared with the owner-republish
-      // asset-review route so the two can never drift a column apart.
-      await cloneApprovedBlockRequestToPending(tx, {
-        lastApproved,
-        publishRequestId,
-        slug: listing.slug,
-        appBlockId,
-        submittedByUserId: listing.userId,
+      await tx.appBlockPublishRequest.create({
+        data: {
+          id: publishRequestId,
+          appBlockId: lastApproved.appBlockId ?? appBlockId,
+          slug: listing.slug,
+          submittedByUserId: listing.userId,
+          version: lastApproved.version,
+          manifest: lastApproved.manifest as Prisma.InputJsonValue,
+          bundleKey: lastApproved.bundleKey,
+          bundleSha256: lastApproved.bundleSha256,
+          bundleSizeBytes: lastApproved.bundleSizeBytes,
+          fileSummary: lastApproved.fileSummary as Prisma.InputJsonValue,
+          manifestDiffSummary: lastApproved.manifestDiffSummary as Prisma.InputJsonValue,
+          forgejoCommitSha: lastApproved.forgejoCommitSha,
+          // #4059 — carry the client's provenance CLAIM forward, verbatim.
+          //
+          // The justification is narrow and it is the only one: this clone
+          // re-submits BYTE-IDENTICAL bundle bytes (same `bundleKey`, same
+          // `bundleSha256` as the approved row above). A claim about which tree
+          // those exact bytes came from is still the SAME claim about the SAME
+          // bytes — copying it invents nothing. Dropping it would permanently
+          // lose the answer to "which tree did these bytes come from?" for any
+          // app that goes through a suspend → reset-to-pending cycle, which is
+          // the archaeology #4059 exists to make unnecessary.
+          //
+          // Copied RAW, including NULL: a NULL on the source row means UNKNOWN
+          // and must stay UNKNOWN here. No `??` fallback of any kind — least of
+          // all to `forgejoCommitSha`, which is a SERVER-side sha in the
+          // platform's own repo and would fabricate an author's-tree claim
+          // nobody made. `false` likewise stays `false` (asserted CLEAN), never
+          // folded into UNKNOWN.
+          //
+          // 🔴 NOT the `recordPendingFromPush` case, which correctly writes
+          // NEITHER: that path has no client and no author work tree, so there
+          // is no claim in existence to carry.
+          sourceCommit: lastApproved.sourceCommit,
+          sourceDirty: lastApproved.sourceDirty,
+          status: 'pending',
+        },
       });
 
       // (4) audit event.
@@ -1581,27 +1536,31 @@ export type RepublishOwnListingResult = {
  * store card with NO content review: the two go-live gates below read scan STATUS and the
  * destination href, and #4418's floor reads MATURITY. None of them is a review.
  *
- * So: if ANY listing asset differs from what was live at the last approval, the republish
- * routes the listing to `pending` (re-review) instead of `approved`, and re-queues it —
- * off-site by minting a fresh pending `AppListingPublishRequest` (which
- * `approveExternalRequest`'s widened `{draft,pending}` guard re-approves), on-site by
- * cloning the latest approved `AppBlockPublishRequest` (which `approveRequest`'s
- * `(3b-reset)` branch re-approves AND un-suspends the block for). Both are the EXISTING
- * reset-to-pending machinery — see {@link resetListingToPending} /
- * {@link resetOnsiteListingToPending}, whose writes this mirrors exactly.
+ * So: if ANY listing asset differs from what was recorded at the last approval, the
+ * republish routes the listing to `pending` (re-review) instead of `approved` and mints a
+ * fresh pending non-shadow `AppListingPublishRequest` — FOR BOTH KINDS. That queue is the
+ * one whose moderator modal actually renders this listing's icon, cover and screenshots;
+ * see {@link routeRepublishToReviewInTx} for why the on-site arm does NOT re-queue on the
+ * block-request surface (a clone of the approved block request is byte-identical to what
+ * the moderator already approved and shows none of the imagery under review).
  *
  * If NOTHING changed, republish is immediate exactly as it was — no extra queue entry, no
  * moderator involvement, no behaviour change at all.
  *
- * 🔴 THE SIGNAL IS RECORDED, NOT INFERRED, AND ITS ABSENCE FAILS CLOSED. Nothing in the
- * schema previously captured the approved asset set (no approve path writes a moderation
- * event; every existing `before`/`after` payload is `{status}`/`{userId}`; `updatedAt` is
- * bumped by the republish flip itself and a DELETED screenshot leaves no timestamp at
- * all). {@link unpublishOwnListing} now records it into the `owner-unpublish` event's
- * `before.assets`. A listing unpublished BEFORE that shipped has no snapshot, and a
- * comparison against an absent operand reports MISSING, not SAME — those route to review
- * (`reviewReason: 'no-recorded-assets'`) rather than being waved through. See
- * `app-listing-approved-assets`.
+ * 🔴 THE SIGNAL IS RECORDED, NOT INFERRED. Nothing in the schema previously captured the
+ * approved asset set (no approve path writes a moderation event; every existing
+ * `before`/`after` payload is `{status}`/`{userId}`; `updatedAt` is bumped by the republish
+ * flip itself and a DELETED screenshot leaves no timestamp at all).
+ * {@link unpublishOwnListing} now records it into the `owner-unpublish` event's
+ * `before.assets`.
+ *
+ * 🔴 A LISTING UNPUBLISHED BEFORE THAT SHIPPED HAS NO BASELINE, AND THAT ARM IS
+ * DELIBERATELY FAIL-OPEN — it republishes immediately, exactly as it did before this PR.
+ * Routing it to review would not make anyone look at a change (there is no recorded
+ * "before" to compare against, so there is nothing to describe); it would only take the
+ * entire already-removed population offline behind a moderator on ship day. A baseline
+ * that EXISTS and does not parse is the opposite case — unbounded, and evidence something
+ * is wrong right now — and it fails CLOSED. See `app-listing-approved-assets`.
  *
  * 🔴 THIS ADDS A SECOND WRITER OF `app_listings.status = 'pending'` ON A FORMERLY-LIVE
  * LISTING. `closeTerminalListing` (`offsite-listing.service`) and
@@ -1611,11 +1570,12 @@ export type RepublishOwnListingResult = {
  * an owner who routes themselves into review and then WITHDRAWS the request lands on
  * `removed` + `delist`, so `republishOwnListing` forbids them and a moderator must
  * `relistListing`. Fail-CLOSED, and no content reaches the store unreviewed — but it is a
- * self-inflicted lockout that did not exist before. Left as-is on purpose rather than
- * loosened here: that predicate was made unconditional to close a real exploit (an
- * intervening `report-resolve` shifted the newest event and let an owner self-restore
- * mod-mandated content), and re-opening it is a product decision, not an implementation
- * detail. Both comments are corrected in place; see the PR body.
+ * self-inflicted lockout that did not exist before, so the withdraw affordance now SAYS SO
+ * before and after the click (`ListingHistoryPanel`). Left as-is rather than loosened:
+ * that predicate was made unconditional to close a real exploit (an intervening
+ * `report-resolve` shifted the newest event and let an owner self-restore mod-mandated
+ * content), and re-opening it is a product decision, not an implementation detail. Both
+ * comments are corrected in place; see the PR body.
  *
  * 🔴 SAFETY GUARD (load-bearing, unchanged): republish is allowed ONLY when the
  * MOST-RECENT status-changing `AppListingModerationEvent` is an `owner-unpublish`. If the
@@ -1628,9 +1588,9 @@ export type RepublishOwnListingResult = {
  * ON-SITE: on the IMMEDIATE arm the backing `AppBlock` is also restored suspended →
  * approved in the SAME tx (via {@link flipBackingBlockStatus}), so the app serves again.
  * On the REVIEW arm it is deliberately LEFT SUSPENDED — the app must not serve while its
- * store card is unreviewed — and `approveRequest`'s `(3b-reset)` branch un-suspends it on
- * re-approve, gated on exactly the `pending` listing status this route writes. OFF-SITE:
- * only the listing flips. `reason` optional.
+ * store card is unreviewed, the same posture {@link resetOnsiteListingToPending} takes —
+ * and `approveExternalRequest` un-suspends it on approve, gated on exactly the `pending`
+ * on-site listing this route writes. OFF-SITE: only the listing flips. `reason` optional.
  *
  * 🔴 MATURITY IS RE-DERIVED AT GO-LIVE, UNIFORMLY FOR BOTH KINDS (this used to be a
  * pure visibility toggle with NO re-derive, which was the hole). A `removed` listing is
@@ -1747,20 +1707,19 @@ export async function republishOwnListing(opts: {
     // moderator last approved — see the function doc). Read on the PRIMARY, inside this
     // tx, so it is row-consistent with the flip it decides.
     //
-    // 🔴 The absent-snapshot arm is EXPLICIT, and it is the whole reason this is not a
-    // bare `!==`: `resolveRepublishReviewReason` is handed `null` for a missing or
-    // malformed payload and returns `'no-recorded-assets'`, never `null`-meaning-fine.
-    // A comparison against an absent operand reports MISSING, not SAME.
+    // 🔴 A MISSING BASELINE AND AN UNREADABLE ONE GO OPPOSITE WAYS, which is the whole
+    // reason this is not a bare `!==` and not a bare null-check either.
+    // `readRecordedAssetBaseline` distinguishes "this event carries no `assets` key"
+    // (every listing unpublished before this feature shipped — a bounded, shrinking set
+    // with no change to review, so republish stays immediate exactly as it always was)
+    // from "it carries one and it does not parse" (unbounded, something is wrong now →
+    // review). See `app-listing-approved-assets`.
     //
     // 🔴 IT RUNS AFTER THE RATING FLOOR ON PURPOSE. The floor is applied on BOTH arms —
-    // #4418's guarantee must not depend on which arm a republish takes. It especially
-    // must not be skipped on the review arm: the on-site re-approve that later restores
-    // a `pending` listing (`approveRequest`'s `(3b-reset)` branch) writes ONLY `status`
-    // and runs no floor of its own, so deferring the floor to "the approve will do it"
-    // would silently drop it for every on-site review-arm republish.
+    // #4418's guarantee must not depend on which arm a republish takes.
     const liveAssets = await buildApprovedAssetSnapshot(tx, input.appListingId, listing);
     reviewReason = resolveRepublishReviewReason(
-      readRecordedAssetSnapshot(lastEvent?.before),
+      readRecordedAssetBaseline(lastEvent?.before),
       liveAssets
     );
 
@@ -1849,25 +1808,53 @@ export async function republishOwnListing(opts: {
 
 /**
  * REVIEW ARM of {@link republishOwnListing}: instead of going live, put the listing into
- * `pending` and re-queue it so a moderator sees the changed assets.
+ * `pending` and re-queue it on the surface that can actually SHOW the imagery under review.
  *
- * Every write here MIRRORS the existing reset-to-pending machinery rather than inventing
- * a parallel concept — the re-approve paths that will bring the listing back
- * (`approveExternalRequest` for off-site, `approveRequest`'s `(3b-reset)` branch for
- * on-site) already recognise exactly this state and nothing else needed teaching:
+ * 🔴 BOTH KINDS RE-QUEUE ONTO `AppListingPublishRequest`. THE ON-SITE ARM USED TO CLONE THE
+ * APPROVED `AppBlockPublishRequest` INSTEAD, AND THAT WAS THE BUG. What changed is the
+ * listing's IMAGERY, and the block-request queue cannot express that: a clone carries the
+ * same bundle key, the same sha256, the same manifest and the same version as the row the
+ * moderator already approved, and the modal that renders it (`OnsiteReviewModal`) draws its
+ * screenshots by re-extracting them from the bundle ZIP and never reads `AppListing.iconId`
+ * / `coverId` / `AppListingScreenshot` at all. So the moderator was handed a byte-identical
+ * re-submission of something they had already said yes to, with nothing on screen about the
+ * pictures that caused the re-queue — a review that structurally could not review the thing
+ * under review.
  *
- *   OFF-SITE — flip `removed → pending`, mint a FRESH `pending` `AppListingPublishRequest`
- *   owned by the listing owner (a NON-shadow request, which `approveExternalRequest`'s
- *   widened `{draft,pending}` listing guard re-approves). Identical to
- *   {@link resetListingToPending}'s writes.
+ * The listing-request queue is where listing imagery is reviewed already: the mod modal
+ * (`OffsiteReviewQueue`) keys `appListings.getAssets` and `getListingPreviewForReview` off
+ * `request.appListingId`, so it renders this listing's real icon, cover and screenshots and
+ * a store-layout preview. Both reads are kind-agnostic, and `listPendingOffsiteRequests`
+ * already selects `kind: { in: ['onsite','offsite'] }` with no `revisionOfId` constraint.
  *
- *   ON-SITE — flip `removed → pending` and clone the latest approved
- *   `AppBlockPublishRequest` into a fresh `pending` one (same assets/version/manifest, no
- *   owner resubmit), exactly as {@link resetOnsiteListingToPending} does. The backing
- *   block is LEFT SUSPENDED (`unpublishOwnListing` suspended it and nothing here restores
- *   it) — an app whose store card is awaiting review must not be serving — and the
- *   `(3b-reset)` re-approve branch un-suspends it, gated on the `pending` listing status
- *   this writes.
+ * 🔴 THIS IS THE FIRST NON-SHADOW `kind: 'onsite'` LISTING REQUEST IN THE SYSTEM. Every
+ * other onsite listing request is a media REVISION (`revisionOfId != null`) and returns
+ * early from `approveExternalRequest` into `applyApprovedRevision`. A non-shadow one takes
+ * the main approve path, which had no onsite behaviour because nothing could reach it —
+ * see the two onsite branches added there (raise-only rating, and un-suspending the
+ * backing block).
+ *
+ * WHAT EACH KIND GETS:
+ *
+ *   BOTH — flip `removed → pending` and mint a FRESH `pending` non-shadow
+ *   `AppListingPublishRequest` owned by the listing owner. Off-site this is byte-identical
+ *   to {@link resetListingToPending}'s writes.
+ *
+ *   ON-SITE additionally — the backing block is LEFT SUSPENDED (`unpublishOwnListing`
+ *   suspended it and nothing here restores it): an app whose store card is awaiting review
+ *   does not serve, which is the same posture {@link resetOnsiteListingToPending} takes.
+ *   `approveExternalRequest` un-suspends it on approve. Withdraw/reject leave listing
+ *   `removed` + block `suspended`, which is exactly the state the owner was in before they
+ *   pressed Republish — the two halves never diverge.
+ *
+ * 🔴 THE ICON+COVER FLOOR IS PRE-CHECKED HERE, BEFORE ANYTHING IS WRITTEN, and it is not
+ * decoration. `approveExternalRequest` asserts the floor and does NOT exempt on-site, while
+ * the on-site FIRST-publish path (`approveRequest`) never asserts it — so an approved
+ * on-site listing is genuinely allowed to have no icon or no cover. Routing such a listing
+ * to review without this check strands it: it sits `pending`, its app is suspended, and the
+ * moderator's approve fails on the floor every time, with no owner-reachable way out.
+ * Failing HERE turns that into an ordinary, actionable "add an icon and a cover" error and
+ * leaves the listing `removed` where the owner can still edit it.
  *
  * 🔴 `contentRating` IS WRITTEN ON THIS ARM TOO. It carries #4418's raise-only floor,
  * already derived by the caller; see the call site for why deferring it to the approve is
@@ -1875,7 +1862,7 @@ export async function republishOwnListing(opts: {
  *
  * The audit event is an `owner-republish` whose `after.status` is `pending`, so the
  * history reads "the owner asked for this back, and it went to review" rather than
- * implying it went live. `detail` names WHY (changed assets vs. no recorded baseline).
+ * implying it went live. `detail` names WHY.
  *
  * A guarded 0-count on the flip throws, rolling back the whole tx — including the
  * re-queued request — so a raced listing can never leave a stray queue entry behind.
@@ -1884,7 +1871,13 @@ async function routeRepublishToReviewInTx(
   tx: Prisma.TransactionClient,
   args: {
     appListingId: string;
-    listing: { kind: string; slug: string; userId: number; appBlockId: string | null };
+    listing: {
+      kind: string;
+      slug: string;
+      userId: number;
+      iconId: number | null;
+      coverId: number | null;
+    };
     userId: number;
     reason: string | null;
     reviewReason: RepublishReviewReason;
@@ -1892,43 +1885,30 @@ async function routeRepublishToReviewInTx(
   }
 ): Promise<void> {
   const { appListingId, listing, reviewReason, flooredRating } = args;
-  const isOnsite = listing.kind === 'onsite';
 
-  // Resolve the on-site clone source BEFORE the flip: no approved version to re-review
-  // (or a review already in flight) must refuse the whole republish rather than strand
-  // the listing in `pending` with nothing in any queue — which no owner could recover
-  // from without a moderator.
-  let lastApproved: ApprovedBlockRequestClone | null = null;
-  if (isOnsite) {
-    if (!listing.appBlockId) {
-      throw new OffsiteModerationError(
-        'NOT_TRANSITIONABLE',
-        'This app has no approved version to re-review.'
-      );
-    }
-    lastApproved = await tx.appBlockPublishRequest.findFirst({
-      where: { slug: listing.slug, status: 'approved' },
-      orderBy: [{ submittedAt: 'desc' }],
-      select: APPROVED_BLOCK_REQUEST_CLONE_SELECT,
-    });
-    if (!lastApproved) {
-      throw new OffsiteModerationError(
-        'NOT_TRANSITIONABLE',
-        'This app has no approved version to re-review.'
-      );
-    }
-    // Friendly pre-check for the partial-unique `one pending per slug` index (mirrors
-    // `resetOnsiteListingToPending`); a raced create still surfaces as P2002.
-    const openPending = await tx.appBlockPublishRequest.findFirst({
-      where: { slug: listing.slug, status: 'pending' },
-      select: { id: true },
-    });
-    if (openPending) {
-      throw new OffsiteModerationError(
-        'NOT_TRANSITIONABLE',
-        'A review is already pending for this app.'
-      );
-    }
+  // Publish-floor pre-check — see the 🔴 note above. `screenshotCount` is not part of the
+  // floor (screenshots are optional), so a constant satisfies the parameter shape; the
+  // floor reads only `iconId`/`coverId`.
+  assertListingMeetsFloor({
+    iconId: listing.iconId,
+    coverId: listing.coverId,
+    screenshotCount: 0,
+  });
+
+  // A pending listing request already pointing at THIS row would make the queue show two
+  // reviews of one listing, and the approve path would supersede whichever it did not
+  // action. Refuse with a friendly error rather than create the second one. (Scoped to
+  // `appListingId`, NOT slug: a shadow revision denormalizes the parent slug but targets a
+  // different row and is a legitimate concurrent review.)
+  const openRequest = await tx.appListingPublishRequest.findFirst({
+    where: { appListingId, status: 'pending' },
+    select: { id: true },
+  });
+  if (openRequest) {
+    throw new OffsiteModerationError(
+      'NOT_TRANSITIONABLE',
+      'A review is already pending for this listing.'
+    );
   }
 
   const flipped = await tx.appListing.updateMany({
@@ -1942,27 +1922,17 @@ async function routeRepublishToReviewInTx(
     );
   }
 
-  if (isOnsite && lastApproved && listing.appBlockId) {
-    await cloneApprovedBlockRequestToPending(tx, {
-      lastApproved,
-      publishRequestId: `pubreq_${newUlid()}`,
+  await tx.appListingPublishRequest.create({
+    data: {
+      id: newAppListingPublishRequestId(),
+      appListingId,
+      kind: listing.kind,
       slug: listing.slug,
-      appBlockId: listing.appBlockId,
+      // The LISTING OWNER, so my-submissions and the mod queue attribute it to them.
       submittedByUserId: listing.userId,
-    });
-  } else {
-    await tx.appListingPublishRequest.create({
-      data: {
-        id: newAppListingPublishRequestId(),
-        appListingId,
-        kind: listing.kind,
-        slug: listing.slug,
-        // The LISTING OWNER, so my-submissions and the mod queue attribute it to them.
-        submittedByUserId: listing.userId,
-        status: 'pending',
-      },
-    });
-  }
+      status: 'pending',
+    },
+  });
 
   await tx.appListingModerationEvent.create({
     data: {

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1425,12 +1425,20 @@ export class WithdrawRequestError extends Error {
  * offsite `closeTerminalListing` pending→removed+`delist` withdraw path.
  *
  * 🔴 DETERMINISTIC (mirrors the offsite `closeTerminalListing` rule): fires whenever an
- * ONSITE `AppListing` for this slug is currently `pending` — which is ALWAYS a mod
- * reset. Onsite listings are created `approved` on approve; the ONLY writer of
- * `status='pending'` on an onsite listing is `resetOnsiteListingToPending`, so a
- * `pending` onsite listing == a mod-mandated re-review. It therefore does NOT probe the
- * most-recent moderation event (an intervening report-resolve/dismiss event on the same
- * listing could shift the newest event off `reset-to-pending` and defeat such a probe).
+ * ONSITE `AppListing` for this slug is currently `pending` — i.e. it is IN REVIEW.
+ * Onsite listings are created `approved` on approve, so `pending` always means something
+ * bounced it back to the queue. It does NOT probe the most-recent moderation event (an
+ * intervening report-resolve/dismiss event on the same listing could shift the newest
+ * event off `reset-to-pending` and defeat such a probe).
+ *
+ * 🔴 THERE ARE NOW TWO WRITERS OF ONSITE `status='pending'`, and this comment used to
+ * name only one. Besides `resetOnsiteListingToPending` (the mod reset), the owner-facing
+ * `republishOwnListing` routes a republish to `pending` when the listing's assets changed
+ * since the last approval. This close therefore also fires for an OWNER-INITIATED review,
+ * and treats it identically — `delist`, so a moderator must relist. Deliberate and
+ * fail-CLOSED (nothing unreviewed serves), but it does mean an owner who withdraws their
+ * own re-review needs a moderator to get back. See the matching note in
+ * `closeTerminalListing` (`offsite-listing.service`).
  * Flip the listing `pending → removed` (status-guarded TOCTOU) + write a `delist` audit
  * event with the OWNER as actor: the last event is now a takedown, so
  * `republishOwnListing`'s guard FORBIDS the owner and a mod must `relistListing`

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1,4 +1,5 @@
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import type { Prisma } from '@prisma/client';
 import { createHash } from 'crypto';
 import { structuredPatch } from 'diff';
 import JSZip from 'jszip';
@@ -1135,6 +1136,46 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
     );
   }
 
+  // 🔴 THE INDEX ABOVE NO LONGER COVERS EVERY OPEN REVIEW FOR THIS SLUG.
+  //
+  // `one_pending_per_slug` is partial-unique on `AppBlockPublishRequest`, and while that
+  // table was the ONLY place an on-site app could be re-reviewed it was also an implicit
+  // MUTUAL EXCLUSION: one open review per slug, full stop. The owner-republish
+  // asset-review route re-queues an on-site listing on `AppListingPublishRequest`
+  // instead — an imagery review the block-request modal cannot even render — so the index
+  // sits free while a review IS open, and the two queues can be occupied at once.
+  //
+  // Refusing here shrinks that state rather than teaching each consumer about the split.
+  // It costs the owner nothing they could have had anyway: the review arm deliberately
+  // leaves the backing block `suspended`, and the subsequent-version approve branch
+  // refreshes manifest/version WITHOUT setting `AppBlock.status`, so a version submitted
+  // in this window could not serve until the imagery review resolved regardless.
+  //
+  // 🔴 THIS IS A REACHABILITY REDUCTION, NOT THE GUARANTEE. It cannot restore the old
+  // invariant and must not be relied on as if it had: `recordPendingFromPush` mints a
+  // pending block request straight off a git push without passing here, and the reverse
+  // ordering (submit the version FIRST, while the listing is merely `removed`, then
+  // republish) never reaches this check at all. What actually holds the line is
+  // `approveRequest`'s (3b-reset) relation filter, which asks which queue owns the review
+  // at the point of consumption. See the 🔴 block there.
+  //
+  // Scoped to a NON-SHADOW request (`revisionOfId: null`): a pending SHADOW media
+  // revision is a legitimate concurrent review that has always coexisted with a code
+  // submit, and blocking releases on one would be a real regression — a shadow's request
+  // row denormalizes the PARENT slug, so a slug-only predicate would catch every one.
+  // `kind` is deliberately NOT named: `AppListing.slug` is `@unique`, so slug +
+  // non-shadow already pins a single row, and a clause that no fixture can make matter is
+  // a clause no mutation can test.
+  const conflictingListingReview = await dbRead.appListingPublishRequest.findFirst({
+    where: { slug, status: 'pending', appListing: { revisionOfId: null } },
+    select: { id: true },
+  });
+  if (conflictingListingReview) {
+    throw new Error(
+      `slug ${slug} has a store-listing review open — its store card is awaiting moderator review and the app is suspended until that finishes, so a new version could not go live yet; wait for the listing review to be decided before submitting`
+    );
+  }
+
   // For subsequent versions, link to the existing app row.
   const existingApp = await dbRead.appBlock.findFirst({
     where: { blockId: slug },
@@ -1468,8 +1509,10 @@ async function closeOnsiteResetListingOnWithdraw(opts: {
   // mod reset, and a mod reset always leaves a `pending` `AppBlockPublishRequest`, so the
   // withdrawing request WAS the review. The owner-republish asset-review route breaks that
   // coupling: it parks the listing in `pending` with a pending `AppListingPublishRequest`
-  // and NO block request at all. The owner can then submit an ordinary new app VERSION —
-  // nothing stops them, since the one-pending-per-slug index is empty — and withdrawing
+  // and NO block request at all, so the one-pending-per-slug index is free. `submitVersion`
+  // now refuses in that window, but it is not the only producer — `recordPendingFromPush`
+  // mints a pending block request straight off a git push without passing that check, and
+  // submitting the version BEFORE the republish never passes it either — and withdrawing
   // that version would, without this check, delist a listing whose image review is sitting
   // untouched in the other queue, taking the owner from "waiting for review" to
   // "removed by a moderator, ask a moderator to relist" for pressing Withdraw on something
@@ -2908,8 +2951,43 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     // for scan-clean assets. `dbWrite` is passed where the helper expects a tx client
     // (approveRequest is deliberately non-transactional — see the :2326 comment; a
     // PrismaClient is structurally a TransactionClient for these reads).
+    // 🔴 WHICH QUEUE OWNS THE REVIEW — a `pending` on-site listing is NO LONGER proof
+    // that THIS block request is the review open on it, and restoring one whose review
+    // lives in the other queue publishes never-reviewed store imagery.
+    //
+    // Until the owner-republish asset-review route existed, "at most one open review per
+    // slug" was enforced for free by the partial unique index `one_pending_per_slug` on
+    // `AppBlockPublishRequest`: an on-site re-review ALWAYS occupied it, so a `pending`
+    // on-site listing implied a mod reset and a mod reset implied a pending block request.
+    // That route re-queues on `AppListingPublishRequest` instead, leaving the index FREE —
+    // so the owner can submit an ordinary new app VERSION alongside an open imagery review
+    // and a moderator approving the VERSION (a bundle/code review whose modal renders
+    // ZIP-extracted screenshots and nothing about listing imagery) would land here and flip
+    // the listing `pending → approved`, publishing the swapped icon/cover/screenshots that
+    // no one has looked at — the exact invariant this feature exists to hold — while
+    // stranding the listing request (`approveExternalRequest`'s `{draft,pending}` listing
+    // guard would then match 0 rows, and the open-review pre-check would block every future
+    // republish).
+    //
+    // So ASK WHICH QUEUE OWNS IT rather than inferring it from a status. This is the same
+    // discriminator `closeOnsiteResetListingOnWithdraw` applies on the withdraw leg, and it
+    // is a DISCRIMINATOR, NOT A RELAXATION: the mod-reset case has no listing request and
+    // still restores, and nothing here decides whether an owner may self-restore.
+    //
+    // 🔴 SPELLED ONCE, AS A RELATION FILTER ON BOTH STATEMENTS, so the pre-read and the
+    // write cannot disagree — a separate probe would leave a TOCTOU window (the republish
+    // tx committing between the two statements) that is precisely the hole being closed.
+    // Scoped through the relation (= `appListingId`), NOT by slug: a pending SHADOW media
+    // revision denormalizes the parent slug but targets a different row and is a
+    // legitimate concurrent review that must not block a reset restore.
+    const resetListingWhere = {
+      appBlockId,
+      kind: 'onsite',
+      status: 'pending',
+      publishRequests: { none: { status: 'pending' } },
+    } satisfies Prisma.AppListingWhereInput;
     const resetListing = await dbWrite.appListing.findFirst({
-      where: { appBlockId, kind: 'onsite', status: 'pending' },
+      where: resetListingWhere,
       select: { id: true, contentRating: true },
     });
     // 🔴 RATING FLOOR (go-live) — this restore is a PUBLISH, and it had no floor.
@@ -2941,7 +3019,10 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
       );
     }
     const restored = await dbWrite.appListing.updateMany({
-      where: { appBlockId, kind: 'onsite', status: 'pending' },
+      // Same `resetListingWhere` as the pre-read — including the which-queue-owns-it
+      // relation filter, which is what makes the discriminator atomic rather than a
+      // check-then-act.
+      where: resetListingWhere,
       data: {
         status: 'approved',
         // Only written when the pre-read found the listing — otherwise this `updateMany`

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1434,11 +1434,11 @@ export class WithdrawRequestError extends Error {
  * 🔴 THERE ARE NOW TWO WRITERS OF ONSITE `status='pending'`, and this comment used to
  * name only one. Besides `resetOnsiteListingToPending` (the mod reset), the owner-facing
  * `republishOwnListing` routes a republish to `pending` when the listing's assets changed
- * since the last approval. This close therefore also fires for an OWNER-INITIATED review,
- * and treats it identically — `delist`, so a moderator must relist. Deliberate and
- * fail-CLOSED (nothing unreviewed serves), but it does mean an owner who withdraws their
- * own re-review needs a moderator to get back. See the matching note in
- * `closeTerminalListing` (`offsite-listing.service`).
+ * since the last approval. Those two are reviewed on DIFFERENT queues — the mod reset
+ * re-queues an `AppBlockPublishRequest`, the owner republish an
+ * `AppListingPublishRequest` — so a `pending` on-site listing is no longer proof that
+ * THIS block request is the review that is open on it. The in-body check refuses to act
+ * when a pending listing request owns the row; read it before changing anything here.
  * Flip the listing `pending → removed` (status-guarded TOCTOU) + write a `delist` audit
  * event with the OWNER as actor: the last event is now a takedown, so
  * `republishOwnListing`'s guard FORBIDS the owner and a mod must `relistListing`
@@ -1460,9 +1460,36 @@ async function closeOnsiteResetListingOnWithdraw(opts: {
   });
   if (!listing) return; // not a reset withdraw (first-time submission, or already closed)
 
-  // A `pending` onsite listing is unconditionally a mod reset → close it. Imported here
-  // (only on the rare reset branch) to keep the common no-reset withdraw path free of
-  // the id-gen module.
+  // 🔴 NOT EVERY `pending` ON-SITE LISTING IS THIS WITHDRAW'S BUSINESS ANY MORE, and
+  // acting on one that is not would close a review this request has nothing to do with.
+  //
+  // This function reasons from a SLUG and a listing STATUS — it never looked at which
+  // queue owns the review, because there was only one: a `pending` on-site listing meant a
+  // mod reset, and a mod reset always leaves a `pending` `AppBlockPublishRequest`, so the
+  // withdrawing request WAS the review. The owner-republish asset-review route breaks that
+  // coupling: it parks the listing in `pending` with a pending `AppListingPublishRequest`
+  // and NO block request at all. The owner can then submit an ordinary new app VERSION —
+  // nothing stops them, since the one-pending-per-slug index is empty — and withdrawing
+  // that version would, without this check, delist a listing whose image review is sitting
+  // untouched in the other queue, taking the owner from "waiting for review" to
+  // "removed by a moderator, ask a moderator to relist" for pressing Withdraw on something
+  // else entirely.
+  //
+  // So: if a pending LISTING request points at this row, that request owns the review and
+  // this one does not. `withdrawExternalRequest` → `closeTerminalListing` is the path that
+  // closes it, and it writes the identical `pending → removed` + `delist`. This is a
+  // discriminator, NOT a relaxation: nothing here decides whether an owner may self-restore
+  // (that is still `republishOwnListing`'s last-event guard), and the mod-reset case —
+  // which has no listing request — is completely unaffected.
+  const listingReviewOwnsIt = await dbRead.appListingPublishRequest.findFirst({
+    where: { appListingId: listing.id, status: 'pending' },
+    select: { id: true },
+  });
+  if (listingReviewOwnsIt) return;
+
+  // A `pending` onsite listing with no listing-request review is a mod reset → close it.
+  // Imported here (only on the rare reset branch) to keep the common no-reset withdraw
+  // path free of the id-gen module.
   const { newAppListingModerationEventId } = await import('~/server/utils/app-block-ids');
   await dbWrite.$transaction(async (tx) => {
     const flipped = await tx.appListing.updateMany({
@@ -2866,7 +2893,9 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // count 0) does NOT touch the block, and a delisted-then-resubmitted app is never
   // auto-un-suspended here (its listing is `removed`, not `pending`, so count 0 too).
   // Both flips are status-guarded (never clobber a drifted/curated state) — the listing
-  // flip touches only `status`. Same log-and-continue posture: the store listing +
+  // flip touches `status` and the go-live rating floor (see the 🔴 note at the flip; the
+  // floor is raise-only, so it can never lower a curated rating). Same log-and-continue
+  // posture: the store listing +
   // block restore are a convenience and must NEVER gate the approve/deploy.
   try {
     // 🔴 Scan-clean go-live gate (same invariant + shared helper as the mod/owner
@@ -2881,17 +2910,45 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     // PrismaClient is structurally a TransactionClient for these reads).
     const resetListing = await dbWrite.appListing.findFirst({
       where: { appBlockId, kind: 'onsite', status: 'pending' },
-      select: { id: true },
+      select: { id: true, contentRating: true },
     });
+    // 🔴 RATING FLOOR (go-live) — this restore is a PUBLISH, and it had no floor.
+    //
+    // The sibling (3b-transition) branch above floors a draft→approved transition at the
+    // media-derived rating for a reason that applies here VERBATIM: while the listing sat
+    // `pending` it was DIRECTLY asset-editable by its owner (`assertOwnerAssetEditable`
+    // refuses only an `approved` non-shadow row, and `pending` is in
+    // `AUTHORABLE_LISTING_STATUSES`, so the Media tab is offered normally), and the attach
+    // path rejects only `Blocked`/`NotFound` — it never compares an image's `nsfwLevel`
+    // against the listing rating. `reDeriveContentRatingForModLiveEdit` does not cover it
+    // either: it no-ops for a non-moderator AND for any status other than `approved`.
+    //
+    // So without this line, `reset-to-pending → owner swaps in a Scanned-but-mature cover →
+    // mod re-approves` restored the listing to `approved` carrying its OLD rating, and a
+    // mature store card passed `listingMatureFilter(redCapable=false)` to SFW-only users.
+    // Raise-only, so a deliberately higher rating is never lowered — same helper, same
+    // discipline as (3b-transition) and the owner-republish path.
+    let flooredRating: string | null = null;
     if (resetListing) {
-      const { assertListingAssetsScanCleanInTx } = await import(
+      const { assertListingAssetsScanCleanInTx, resolveListingRatingFloorInTx } = await import(
         '~/server/services/blocks/app-listing-assets.service'
       );
       await assertListingAssetsScanCleanInTx(dbWrite, resetListing.id);
+      flooredRating = await resolveListingRatingFloorInTx(
+        dbWrite,
+        resetListing.id,
+        resetListing.contentRating
+      );
     }
     const restored = await dbWrite.appListing.updateMany({
       where: { appBlockId, kind: 'onsite', status: 'pending' },
-      data: { status: 'approved' },
+      data: {
+        status: 'approved',
+        // Only written when the pre-read found the listing — otherwise this `updateMany`
+        // matches nothing anyway and naming the column would stamp a `null` rating on a
+        // row that raced into `pending` between the two statements.
+        ...(resetListing ? { contentRating: flooredRating } : {}),
+      },
     });
     if (restored.count > 0) {
       // Reset re-approve confirmed → un-suspend the backing block so it serves again.


### PR DESCRIPTION
## The hole

An owner can **unpublish their own approved listing → swap the icon, cover and every screenshot → republish**, and the new imagery goes straight onto a public store card with **no content review**.

A `removed` listing is directly asset-editable — `assertOwnerAssetEditable` refuses only an `approved`, non-shadow row — and none of the gates `republishOwnListing` already runs is a review:

| gate | what it actually reads |
|---|---|
| `assertListingAssetsScanCleanInTx` | `Image.ingestion` — scan **status** |
| `assertOffsiteListingActionableInTx` | the destination link |
| #4418's rating floor | **maturity** (`nsfwLevel`) |

#4418 closed the maturity half. This closes the review half.

## What this changes

**If any listing asset differs from what was recorded at the last approval, the republish routes the listing to `pending` (re-review) instead of `approved`, and re-queues it. If nothing changed, republish is immediate exactly as it is today** — no extra queue entry, no moderator involvement, no behaviour change at all.

## 🔴 The review has to be able to SHOW what is under review

An earlier revision of this PR re-queued an **on-site** app by cloning its already-approved `AppBlockPublishRequest`. That was wrong, and wrong in the way that is hardest to see: the clone carries the **same bundle key, the same `bundleSha256`, the same manifest and the same version** as the row the moderator had already approved, and `OnsiteReviewModal` draws its screenshots by **re-extracting them from the bundle ZIP** — it contains no reference to `AppListing.iconId`, `coverId` or `AppListingScreenshot` at all. The recorded baseline was rendered nowhere (`OffsiteReviewQueue` reads `before` only for `claim` events). So the moderator was handed a byte-identical re-submission of something they had already said yes to, with **nothing on screen about the pictures that caused the re-queue** — a review that structurally could not review the thing under review.

**Both kinds now re-queue onto `AppListingPublishRequest`.** That queue's modal already keys `appListings.getAssets` and `appListings.getListingPreviewForReview` off `request.appListingId`, so it renders this listing's real icon, cover and screenshots plus a store-layout preview. Both reads are kind-agnostic, and `listPendingOffsiteRequests` already selects `kind: { in: ['onsite','offsite'] }` with no `revisionOfId` constraint.

It also makes the two arms **symmetric**, which removes "the guarantee depends on which arm" at the root rather than patching each arm.

| | flip | re-queue | re-approved by |
|---|---|---|---|
| off-site | `removed → pending` | fresh pending non-shadow `AppListingPublishRequest`, owner-submitted | `approveExternalRequest`'s widened `{draft,pending}` listing guard |
| on-site | `removed → pending` | **the same** | `approveExternalRequest` — plus the two on-site branches below |

On the review arm the backing block is **deliberately left suspended** — an app whose store card is awaiting review must not be serving, the same posture `resetOnsiteListingToPending` takes. Withdraw/reject leave listing `removed` + block `suspended`, which is exactly the state the owner was in before they pressed Republish, so the two halves never diverge.

### This is the first NON-SHADOW on-site listing request in the system

Every other on-site `AppListingPublishRequest` is a media **revision** (`revisionOfId != null`) and returns early from `approveExternalRequest` into `applyApprovedRevision`. A non-shadow one takes the main approve path, which had no on-site behaviour **because nothing could reach it**. Two branches were added there — new code on a newly reachable branch, not a change to any existing flow:

1. **The rating is RAISE-ONLY over the app's own declaration.** Off-site, the rating *is* the assets, so the derived value replaces the stored one. On-site it describes the **app** (manifest-declared) and the store art is a strictly smaller surface — replacing it would **lower a `pg13` app to `g`** because its icon happened to scan tame. `resolveOnsiteApprovalContentRating` floors instead, reusing `resolveListingRatingFloorInTx`, the same helper the draft→approved transition and `republishOwnListing` use, so all three on-site rating sites have one spelling. A moderator override may still raise, never lower.
2. **The backing block is un-suspended.** `AppBlock.status` is the only gate on whether a hosted app serves. Approving only the listing would publish a store card pointing at a dead app — the same failure `(3b-reset)` exists to prevent on the other surface.

### The maturity floor, closed at the root

Routing through the listing approve means the floor is applied at approve time. The **pre-existing** inconsistency it was composing with is fixed directly:

> `approveRequest`'s `(3b-reset)` branch restored a `pending` on-site listing by writing `{ status: 'approved' }` and **nothing else**, while its sibling `(3b-transition)` floored.

A `pending` listing is freely owner-asset-editable (`assertOwnerAssetEditable` refuses only `approved`, and `pending` is in `AUTHORABLE_LISTING_STATUSES`, so the Media tab is offered normally); the attach path rejects `Blocked`/`NotFound` but never compares an image's `nsfwLevel` against the listing rating; and `reDeriveContentRatingForModLiveEdit` no-ops for a non-moderator **and** for any status other than `approved`. So *mod reset → owner swaps in a `Scanned`-but-mature cover → mod re-approves* restored the listing live under a stale rating. `(3b-reset)` now floors too, raise-only.

That inconsistency is the real bug; this feature merely made it easy to reach. Both halves are pinned by tests.

## The signal: recorded, not inferred

**Nothing in the schema captured the approved asset set.** Enumerated, not sampled:

- **No approve path writes a moderation event at all.** There is no `approve` verb in the moderation-action taxonomy.
- **All twelve non-test writers of `appListingModerationEvent.create`** write `before`/`after` payloads of the shape `{status}` (10), `{userId}` (1) or `{recipientUserIds, includeCollaborators}` (1). **Zero record an asset id.**
- `AppListingPublishRequest` snapshots nothing (slug / status / notes / changelog).
- **The timestamps are unusable**: the republish flip *itself* bumps `AppListing.updatedAt`; screenshot add/remove/reorder/caption does not bump the parent; and a **deleted** screenshot row leaves no timestamp behind to compare.
- A shadow revision *is* an asset copy, but of the parent **at mint time**, not at approval, and it is deleted on approve/reject/withdraw.
- The only existing comparator is `src/components/Apps/listingRevisionDrift.ts` — **client-side, never persisted**, and its own docstring says answering "did the baseline move?" needs a stored baseline.

So the baseline is now **written**: `unpublishOwnListing` records the live icon / cover / ordered screenshots into the `owner-unpublish` event's `before.assets`, inside the same transaction as the flip.

**Why that instant is exactly "the last approval":** the flip runs on a listing that is `approved`, and an approved non-shadow listing is *not* owner-asset-editable — owner edits go through a shadow revision a moderator reviews before it is copied onto the parent, and a moderator's live curation is itself a reviewed action.

### 🔴 The two absences go OPPOSITE ways

`readRecordedAssetBaseline` returns three things, not two, and the distinction is load-bearing:

| baseline | meaning | verdict |
|---|---|---|
| `snapshot` | a readable baseline | compare; differs ⇒ review |
| `unreadable` | the event **has** an `assets` key and it does not parse (malformed, or a version this build does not understand) | **review** — fail closed |
| `absent` | the event carries **no** `assets` key | **immediate** — pre-existing behaviour |

The `absent` arm is the population of listings unpublished **before** this ships. An earlier revision routed those to review as well. That is not a safety win: there is no recorded "before", so there is *no change to describe to a moderator* — while it takes **every already-removed listing offline behind a moderator on ship day**. Measured against production: every republish-eligible removed on-site listing is in exactly that state, so the fail-closed reading would have swept all of them and none of the reviews would have shown anything.

`unreadable` is the opposite case — unbounded, and evidence something is wrong *right now* — and it still fails closed. The test is on the **presence of the key**, not on the parse result, so the two can never collapse into one.

### What counts as "changed"

Icon id, cover id, and the **positional** list of screenshot `{imageId, caption}`.

- Screenshot **order values are not recorded** — renumbering `0,1,2 → 10,20,30` is not a change; genuinely swapping two screenshots is.
- Screenshot **row ids are not recorded** — deleting a screenshot and re-adding the identical image + caption is not a change.
- **Captions are in scope** — a caption is public text on the store card. Whitespace-only/blank edits normalise away.
- Rows with no `imageId` are dropped — the same definition `assertListingAssetsScanCleanInTx` uses.

### The publish floor is pre-checked, and it is not decoration

`approveExternalRequest` asserts icon+cover and does **not** exempt on-site, while the on-site **first**-publish path never asserts it — so an approved on-site listing is genuinely allowed to have no icon or no cover. Routing such a listing to review would strand it: pending listing, suspended app, and a moderator approve that fails the floor every time with no owner-reachable way out. The review arm therefore asserts the floor **before writing anything**, turning that into an ordinary "add an icon and a cover" error and leaving the listing `removed` where its owner can still fix it.

## Interactions this opens, and how each is closed

### 🔴 `one_pending_per_slug` was an implicit MUTUAL EXCLUSION, and removing it took away more than one thing

The partial-unique index `one_pending_per_slug` lives on `AppBlockPublishRequest`. While that table was the **only** surface an on-site app could be re-reviewed on, it was also doing unnamed safety work: at most one open review per slug, full stop. Two sites relied on that without saying so, both by the same inference — *a `pending` on-site listing ⇒ a moderator reset ⇒ a pending block request ⇒ **this** block request is the review that is open on it*. Re-queueing on `AppListingPublishRequest` leaves the index free and breaks the inference. A previous round found and closed the **withdraw** leg; this round closes the **approve** leg, which is the one that had a security consequence.

**A version APPROVE no longer restores a listing whose review lives elsewhere.** `approveRequest`'s `(3b-reset)` branch selected `{ appBlockId, kind: 'onsite', status: 'pending' }` and never asked which queue owned the review. Reachable chain: owner unpublishes (listing `removed`, block `suspended`, baseline recorded) → swaps the icon/cover/screenshots and republishes → the assets differ, so the listing goes to `pending` with a pending **listing** request and no block request → owner submits an ordinary new app **version**, which nothing stopped → a moderator approves *that* — a bundle/code review whose modal draws ZIP-extracted screenshots and shows nothing about listing imagery — and `(3b-reset)` flipped the listing to `approved` and un-suspended the block. **Never-reviewed store imagery goes live** — the exact invariant this PR exists to hold, reopened from the other side — **and the listing request is stranded**: `approveExternalRequest`'s `{draft,pending}` listing guard then matches 0 rows, and `routeRepublishToReviewInTx`'s open-review pre-check refuses every future republish with "A review is already pending for this listing."

It now asks. The predicate is spelled **once**, as a relation filter shared by the pre-read and the write:

```ts
const resetListingWhere = {
  appBlockId, kind: 'onsite', status: 'pending',
  publishRequests: { none: { status: 'pending' } },
} satisfies Prisma.AppListingWhereInput;
```

Sharing it is not tidiness — a separate probe leaves a TOCTOU window (the republish transaction committing between the check and the write) which is precisely the hole being closed. It is scoped through the relation (i.e. `appListingId`), **not** by slug, because a pending shadow media revision denormalizes the parent slug onto its request row while targeting a different listing, and that is a legitimate concurrent review. **A discriminator, not a relaxation:** the mod-reset case has no listing request and still restores; nothing here decides whether an owner may self-restore.

**`submitVersion` additionally refuses while a non-shadow listing review is open for the slug** — and this is labelled a *reachability reduction, not the guarantee*, in the code as well as here. It costs the owner nothing they could have had anyway: the review arm deliberately leaves the block `suspended`, and the subsequent-version approve branch refreshes manifest/version without touching `AppBlock.status`, so a version submitted in that window could not serve until the imagery review resolved regardless. What it cannot do is restore the invariant, because it is not the only producer — `recordPendingFromPush` mints a pending block request straight off a git push without passing it, and submitting the version **before** the republish never reaches it at all. Scoped to `revisionOfId: null` so a shadow media revision, which has always coexisted with a code submit, still does not block a release.

**Why not restore the exclusion at the source instead?** Because a one-sided guard demonstrably cannot: the reverse ordering reaches the same state. Restoring it properly needs a symmetric refusal in `routeRepublishToReviewInTx` as well, which would refuse an owner's one-button republish while a code review is open — a previously-working path — and would re-introduce the block-request dependency this PR deliberately removed from that arm. `(3b-reset)`'s discriminator holds for **every** ordering and every producer, because it asks the question at the point of consumption. The `submitVersion` guard is kept for state-space reduction and a clear error message, not leaned on.

**What the enumeration found, and what it did not.** Every reader and writer of both request tables, every "a review is already pending" predicate, every `AppListing.status` branch and every `AppBlock.status === 'suspended'` consumer was enumerated (`command grep -rn` over `src/`, not sampled). No read path anywhere branches on *why* a block is suspended. `listPendingOffsiteRequests` is kind-agnostic, so the new row does surface in `/apps/review`. The residue is informational, not an exposure: `getMyPendingForSlug`, `blocks.router.listMyPublishRequests` and `GET /api/v1/blocks/submissions` all read the block table only, so an owner whose sole open review is the imagery one sees nothing in those three surfaces — `listListingHistory` merges both queues and is the one place they can see and act on either. Those are recorded under "Known limitations" rather than fixed here.

**A version withdraw no longer delists a listing whose review lives elsewhere.** (Unchanged from the previous round; kept because it is the sibling half.) `closeOnsiteResetListingOnWithdraw` reasoned from a slug and a listing status for the same reason. It now refuses to act when a pending listing request owns the row — again a discriminator, not a relaxation. Its comment used to say the owner could reach that state because "nothing stops them, since the one-pending-per-slug index is empty"; that is now only partly true and the comment says which parts.

**Withdrawing your own re-review is still one-way — and now it says so.** `closeTerminalListing` unconditionally writes `delist` on a formerly-live `pending` listing, which `republishOwnListing`'s guard reads as a moderator takedown. That predicate was *made* unconditional to close a real exploit (an intervening `report-resolve` shifted the newest event and let an owner self-restore mod-mandated content), so it is untouched. What changed is disclosure: `withdrawExternalRequest` now returns the close **outcome**, the router passes it through, and the Withdraw affordance warns before the click and reports accurately after it, instead of saying "Submission withdrawn." and leaving the owner looking at a "removed by a moderator" state they caused themselves.

## Three claims this delta falsified, now corrected

- **The `REVIEWABLE_LISTING_KINDS` invariant.** It read *"the ONLY producer of a `kind='onsite'` `AppListingPublishRequest` is `submitListingRevision` on an onsite SHADOW"* — false as of this PR, which introduces the first non-shadow one. Six consumers reason from that sentence and it is what justified `listMySubmissions`' unconditional `{ kind: 'onsite' }` OR-branch. The test named for it stayed green throughout, because it only asserted that `submitListingRevision` produces a well-shaped row — proving one member is IN a set says nothing about whether the set grew. The comment is corrected (two producers, told apart by `revisionOfId`, never by `kind`) and a **producer ledger** now enumerates every production site that inserts a row into `app_listing_publish_requests`, with its kind decision, and fails when the set **grows or shrinks** — both directions watched to fail. It scans all three write routes the codebase actually has — the Prisma client (`create` / `createMany` / `upsert`), raw SQL (`INSERT INTO app_listing_publish_requests`, covering `$executeRaw` / `$queryRaw` / `$executeRawUnsafe`) and Kysely (`.insertInto('…')`) — across `src/`, `apps/`, `packages/` and `scripts/`. It first matched `appListingPublishRequest.create(` in `src/` alone, which was blind to two of those three: a `createMany` producer and a raw-SQL producer each left the suite fully green. A guard whose whole purpose is to notice the set growing is worse than no guard when it reads as coverage and provides none, so the scan was widened to the sentence rather than the sentence narrowed to the scan. `listMySubmissions`' OR-branch is still correct (the middle branch already matches a non-shadow row and `OR` is a set union); its *justification* was not, and the downstream consequences — `hasPendingRevision` correctly `false`, no last-action badge while `pending` — are now stated rather than re-derivable from a false premise.
- **The republish fixture docstring.** It claimed the gate fails CLOSED on an absent baseline via `reviewReason: 'no-recorded-assets'`. Both halves were false: no such reason exists (`RepublishReviewReason` is `'assets-changed' | 'unreadable-baseline'`) and an absent baseline returns `null`, i.e. the **immediate** arm. So a forgotten baseline now produces a silent pass, not a loud re-route — a fixture meaning to prove that *matching* assets republish immediately gets `approved` while comparing nothing. Corrected. The accompanying claim that no fixture is *already* passing vacuously was checked by execution, not by reading: making the `absent` arm throw fired on exactly **2** tests, both in the dedicated absent-arm file, and **0** in the fixture file — with the 2 serving as the positive control that the probe can fire at all.
- **The moderator modal stated the opposite rating policy.** `OffsiteReviewQueue` branched on `kind === 'onsite'` and told the reviewer the app's rating is a **CAP** and mature imagery is a reject reason. For this new request kind the server **FLOORS**, raise-only. `kind === 'onsite'` no longer implies "media revision", so the explainer note, the `app rating (cap)` label, the mismatch callout and the approve control's default now branch on `revisionOfId`, and the default mirrors the server's `max(declared, derived)` instead of offering a value the server would silently raise past. The on-site revision browser fixture gained the `revisionOfId` that a real shadow request always carries — its absence was what made the two shapes indistinguishable in the first place.

## Also in here

- **`republishSuccessMessage`** — three surfaces announced a republish with a hardcoded *"App republished — it is live again."*, which is **false** on the review arm. They now derive the message from the returned `status` in one place, **and branch on `reviewReason`**: only `assets-changed` claims the owner's images changed. An unrecognised reason falls back to the neutral wording, so a reason added server-side can never silently inherit a factual claim it does not support.
- **`withdrawSuccessMessage`** — extracted as a pure function so the one-way-close copy is covered by the **blocking** `unit` project rather than the report-only browser tier.
- `RepublishOwnListingResult.status` is widened to `'approved' | 'pending'` with a `reviewReason`, so a caller cannot assume success means live.
- **Three comments that were false in the direction that invites the bug**, all predating this PR: `offsite-listing.service` claimed `republishOwnListing` runs no rating floor (untrue since #4418, and it reads as a licence to skip the floor elsewhere on that path — exactly the hole fixed here); `app-listing-assets.service` claimed "draft/pending/shadow listings are rated at approve" (untrue for the on-site `pending` re-approve); and the two withdraw-close comments naming a writer set that is no longer complete.

## Verification

**`pnpm typecheck`** — `typecheck: OK — 0 type errors in 64s (heap cap 8192 MB)`.
Instrument control, re-run this round: a deliberate `const __probe: number = 'not a number'` inside the `(3b-reset)` branch produced `publish-request.service.ts(2989,11): error TS2322` / `typecheck: 1 type error(s).` and exit **2**, then was reverted. (Run `pnpm typecheck`, not bare `tsc --noEmit` — the latter OOMs at the 4 GB default and exits 134 with zero errors.)

**`typecheck-tests` gate — the scope `pnpm typecheck` structurally cannot reach.** The root `tsconfig.json` carries `src/**/__tests__/**` in its `exclude`, so every "0 type errors" above is a claim about **production code only**: a type error in any file this PR adds or edits under a `__tests__/` directory is reported by `pnpm typecheck` as 0 errors, exit 0. That is not leniency, it is blindness, and every typecheck claim made on earlier revisions of this description was scoped that way. The instrument that does see those files is `node scripts/ci/typecheck-tests-gate.mjs`, which runs the same program against `tsconfig.tests.json` (the base config minus that one exclude entry) and blocks a file that is newly dirty or a baselined file whose count went up.

Run on three trees with the same command. The gate is already red at `main` for ~187 unrelated files, so the question is not "does it pass" but "does this PR make it worse" — answered by diffing the two flagged sets file-by-file, since the branch is a few commits behind `main` and the absolute totals are therefore not comparable.

| tree | gate-scope errors / files | flagged: new / worsened |
|---|---|---|
| `origin/main` (`570b7b01f5`) | 1,008 / 186 | 64 / 7 |
| this branch, before the fix | 1,027 / 188 | 66 / 9 |
| **this branch, after** | **997 / 185** | **63 / 7** |

Before the fix this PR contributed **five** entries `main` does not have — three files it adds, and two it worsens:

| file | at `main` | before | after |
|---|---|---|---|
| `app-listings.router.offsite-authz.test.ts` | 3 | 4 | **3** |
| `publish-request.orchestration.test.ts` | 15 | 29 | **5** |
| `app-listing-approved-assets.test.ts` | *(new file)* | 1 | **0** |
| `offsite-listing.onsite-listing-approve.service.test.ts` | *(new file)* | 1 | **0** |
| `offsite-moderation.service.republish-asset-review.test.ts` | *(new file)* | 3 | **0** |

Diffing the flagged sets after the fix leaves **zero** entries on this branch that `main` does not already have (and one fewer, because `main` has since dirtied a file this branch has not picked up). `scripts/ci/typecheck-tests-baseline.json` is **not** touched — raising a baseline entry is the escape hatch, and none was taken. The five surviving errors in `publish-request.orchestration.test.ts` are pre-existing `TS2737` BigInt literals (`target: ES2018`), unrelated to this PR and unchanged from `main`; the other ten it carried at `main` are fixed as a side effect.

**What the errors turned out to be — one of them was a fixture that did not match reality.** The `withdrawExternalRequest` router mock declared its return as `{ outcome: 'none' as const }`, i.e. a service that can only ever report `'none'`, while the real `WithdrawExternalRequestResult` is `{ outcome: CloseTerminalListingOutcome }` (`'deleted' | 'removed' | 'none'`). The `'removed'` pass-through — the whole point of returning the outcome — was the case the mock's own type said could not happen. It is now typed with the service's exported result type. The rest were mechanical: a `vi.fn(async () => null)` DB-delegate default infers `() => Promise<null>` (no argument, only ever `null`), which makes a later `mockResolvedValue(row)` on the same delegate untypeable; those now carry the repo-standard delegate signature. No `as any`, no `@ts-expect-error`, no assertion removed — every edit is type-annotation-only, and transpiling each file before and after with comments stripped emits **byte-identical** JavaScript for four of the five (the fifth differs only by one added unused parameter name).

**Tests — read as counts, both tiers**

| tier | result |
|---|---|
| `--project 'unit*'` (covers `unit` **and** `unit-native`) | **23,049 passed**, 25 skipped, 1,469 files, **23 failed** (re-measured after the typing round; the 23 are the same three localStorage files) |
| `--project unit-native` alone | **141 passed**, 6 files, **0 failed** |
| the seven block suites this touches | **418 passed**, 7 files, **0 failed** |
| `--project component` over `src/components/Apps/` | **1,098 passed**, 75 files, **0 failed** |

🔴 **The 23 failures are RED AT `main`, and that was measured rather than assumed.** They are `hiddenBlocks`, `recent-source-images.store` and `sticker-reveal.store` — all `Cannot read properties of undefined (reading 'setItem')`, i.e. a `localStorage` environment problem, in files no part of this PR touches. Running those same three files in a clean checkout of `main` (`b9e8e132d3`) produced **the identical 23 failures** — and CI settles it in the other direction too: every `Unit tests` shard on this PR is **green**, so the 23 are a property of this workstation's jsdom `localStorage`, not of the tree. The local baseline is reported anyway rather than quietly dropped, because "CI is green" would not have told you *why* a local run was red. `eventloop-watchdog.capture` also failed in one of the three full runs and passed in the others; it is likewise **red at `main`** in isolation, so it is a pre-existing flake, not this branch's.

⚠️ **Correction to an earlier revision of this description**, which claimed `--project unit` was "22,916 passed, 0 failed": that number predates `main` moving. The zero was true when written and is not true now, and the cause is upstream, not here.

**Scope note, stated rather than implied:** the browser tier was run over `src/components/Apps/` (the directory this PR touches), **not** the whole `component` project. So the previously-recorded 17 `ModelVersionUpsertForm` failures were neither reproduced nor refuted this round.

**`eslint`** over the ten changed files: **0 errors, 41 warnings** — all `no-explicit-any` / `no-unused-vars` of the same kinds already present in those files.

**Red at base / green at HEAD.** Every source guard added this round was watched to fail on pre-change code: see the mutation table, where the `N`/`S`/`U` rows ARE the pre-change state (each is the guard removed or re-spelled).

## Verification — the mutation table

Each row is a single isolated edit, applied one at a time to an otherwise-clean tree, restored before the next. Every run's **collected test count** is read, never an exit code, and every unmutated control was watched to report zero failures over a non-zero collection first.

### New this round — the 🔴 chain and its two fixes

| # | mutation | killed by | count |
|---|---|---|---|
| N0 | *(unmutated control)* | — | 121 passed / 0 failed |
| N1 | `(3b-reset)`: delete `publishRequests: { none: … }` from the shared where | `🔴 (3b-reset) does NOT restore a pending on-site listing whose review belongs to the LISTING queue` | 1 failed / 116 |
| N2 | `(3b-reset)`: `none` → `some` | the same test **and** `🔴 (3b-reset) DOES restore a mod-reset listing` | 2 failed / 115 |
| N3 | `(3b-reset)`: drop `status: 'pending'` from the relation filter | `🔴 (3b-reset) DOES restore a mod-reset listing …` (the control arm, by design) | 1 failed / 116 |
| S1 | `submitVersion`: delete the cross-queue guard | `🔴 refuses a new version while a NON-SHADOW on-site listing review is open for the slug` | 1 failed / 119 |
| S2 | `submitVersion`: drop `appListing: { revisionOfId: null }` | `🔴 does NOT refuse while only a SHADOW media revision is open …` | 1 failed / 119 |
| S3 | `submitVersion`: drop `status: 'pending'` | `does NOT refuse on a CLOSED listing review — one completed cycle must not block every future version` | 1 failed / 119 |
| U1 | modal: `isOnsiteRepublishReview = isOnsite` (drop the discriminator) | the two on-site **media-revision** cases | 2 failed / 23 |
| U2 | modal: invert the discriminator to `!= null` | all four republish cases **and** the two revision cases | 6 failed / 19 |
| U3 | modal: approve default `= appRating ?? derivedRating` (unfloored) | `🔴 the approve Select defaults to the DERIVED rating (the floor), not the app rating` | 1 failed / 24 |

### The three survivors from the previous round — now dead

| # | mutation | previously | killed by | count |
|---|---|---|---|---|
| X2 | withdraw discriminator: drop `status: 'pending'` | **SURVIVED** 115/115 | `🔴 a CLOSED listing request on the row does NOT stop a mod-reset withdraw from delisting` | 1 failed / 120 |
| X5 | open-review guard: `appListingId` → `slug: listing.slug` | **SURVIVED** 136/136 | `🔴 a pending SHADOW media revision on the SAME SLUG does NOT block the republish` | 1 failed / 35 |
| X6 | open-review guard: drop `status: 'pending'` | **SURVIVED** 136/136 | `🔴 a CLOSED request on THIS listing does NOT block a later republish` | 1 failed / 35 |

**Why they survived and what changed.** All three tests armed the probe with a blanket `mockResolvedValue({ id: … })`, which answers the same row for *any* `where` — so the `where` was never under test. Each is now driven by a small fake table that filters on the clause, and each fixture is a **realistic** row rather than a textbook one: a *withdrawn* request for X2, a *shadow* request on the same slug for X5, an *approved* request on the same listing for X6.

### Producer-ledger controls (🟡 2)

| mutation | result |
|---|---|
| add a new `appListingPublishRequest.create(` producer to a source file | `🔴 the producer set is EXACTLY the ledger` **fails** (grows) |
| add an `appListingPublishRequest.createMany({…})` producer | `🔴 the producer set is EXACTLY the ledger` **fails** — was **green** before the widening |
| add a raw-SQL `$executeRaw` producer whose body is `INSERT INTO app_listing_publish_requests` | `🔴 the producer set is EXACTLY the ledger` **fails** — was **green** before the widening |
| add a `.insertInto('app_listing_publish_requests')` producer under `apps/` | `🔴 the producer set is EXACTLY the ledger` **fails** — proves the Kysely route *and* that the widened roots are walked |
| rename `routeRepublishToReviewInTx` away | `🔴 the producer set is EXACTLY the ledger` **fails** (shrinks), and so does the sibling guard `🔴 routeRepublishToReviewInTx really does forward the listing kind` |
| *(the ledger's own controls)* | 4 producers over 4,817 files; each root asserted walked; each write route fed source it must match (two have no real hits, so a route wired to nothing would otherwise be invisible); the same three producer lines assert **3 matches as bare code and 0 as comments**; bogus table names match 0 |

### Re-run after the fix (a fix round resets the gate)

Every previous-round mutant whose code or whose killing test this round touched was re-applied. All still die, each on its own named assertion:

| # | mutation | still killed by | count |
|---|---|---|---|
| M4 | publish-floor pre-check deleted | the two `actionable floor error … leaving it removed` cases | 2 failed / 34 |
| M5 | open-review guard deleted | `🔴 a review already open on THIS listing → NOT_TRANSITIONABLE` | 1 failed / 35 |
| M6 | re-queue `kind` hardcoded to `offsite` | `🔴 ON-SITE: re-queues on the LISTING surface …` | 1 failed / 35 |
| M7 | on-site rating branch swapped to the off-site discipline | `🔴 mature store art DOES raise it` | 1 failed / 8 |
| M8 | on-site override comparator flipped | `a moderator override may raise above the floor` + `may NOT lower it` | 2 failed / 7 |
| M9 | block un-suspend `where` status swapped | 3 reset-restore cases, incl. the new control arm | 3 failed / 118 |
| M10 | `(3b-reset)` rating floor dropped | `🔴 the reset restore FLOORS contentRating` + the raise-only case | 2 failed / 119 |
| M11 | `(3b-reset)` declared rating stale-rebound to `null` | the gate-passes case + the raise-only case | 2 failed / 119 |
| M12 | withdraw discriminator deleted | `🔴 does NOT close a pending onsite listing whose review belongs to the LISTING queue` | 1 failed / 120 |
| M13 | withdraw outcome replaced by a constant | `🔴 REPORTS WHICH CLOSE HAPPENED …` | 1 failed / **79 collected** |

**M1, M2, M3, M14 and M15 were NOT re-run**, and the reason is mechanical rather than a judgement call: their code (`app-listing-approved-assets.ts`, `listingPublishingActions.ts`) and their tests are **byte-unchanged** this round — `git status` lists neither — and both modules are pure functions with no mock surface that this round's edits could have moved. M13 *was* re-run despite living in a file whose diff is comments-only, because it is the one that previously scored a false SURVIVED off a zero-collection run; its re-run collected **80** tests.

### Re-run after the test-fixture typing round

The typing fix above edits the five files that hold these guards, so the gate resets again. The structural half first: transpiling each edited file before and after the change, with comments stripped, emits **byte-identical** JavaScript for four of the five — so those guards cannot have moved. The fifth (`app-listing-approved-assets.test.ts`) differs by exactly one token, an added unused parameter name on a mock.

The empirical half — one mutant per edited test file, each applied alone to an otherwise-clean tree and restored before the next, counts read rather than exit codes:

| # | mutation | still killed by | count |
|---|---|---|---|
| — | *(unmutated control, all five files)* | — | 256 passed / 0 failed, 5 files |
| N1 | `(3b-reset)`: delete `publishRequests: { none: … }` | `🔴 (3b-reset) does NOT restore a pending on-site listing whose review belongs to the LISTING queue` | 1 failed / 120 |
| S1 | `submitVersion`: disable the cross-queue guard | `🔴 refuses a new version while a NON-SHADOW on-site listing review is open for the slug` | 1 failed / 120 |
| M5 | `republishOwnListing`: disable the open-review guard | `🔴 a review already open on THIS listing → NOT_TRANSITIONABLE, and NOTHING is written` | 1 failed / 35 |
| M7 | approve: on-site rating branch swapped to the off-site discipline | `🔴 tame store art does NOT lower the app rating` **and** `🔴 a moderator override may NOT lower it below the app declaration` | 2 failed / 7 |
| R1 | router: collapse the withdraw `outcome` back to a constant | `🔴 passes the close OUTCOME through, rather than collapsing it into \`{ ok: true }\`` | 1 failed / 36 |
| A1 | `buildApprovedAssetSnapshot`: drop the `where: { appListingId }` scoping | `reads the screenshots and takes icon/cover from the ALREADY-LOADED listing row` | 1 failed / 52 |

A1 is the one that matters most for this round: it dies through the exact `findMany.mock.calls[0][0]` assertion whose fixture was re-typed, which is what rules out the typing having weakened it. R1 likewise kills through the `'removed'` pass-through case that the mock's old `as const` type had declared impossible.

## Known limitations, stated rather than glossed

- **The moderator still sees no before/after diff.** `RevisionDriftSection` renders only for a shadow revision (`if (!parentId) return null`) and these requests are non-shadow. Unchanged this round; the recorded baseline that decided the routing could drive such a diff, and wiring it in is a separate change.
- **`getMyPendingForSlug` does not see the listing queue.** It reads `AppBlockPublishRequest` only, so while an imagery review is open the `/apps/submit` preview tells the owner the slug is clear and the new `submitVersion` guard rejects after the upload. That is the same shape as the pre-existing other-user collision (also invisible to that read), and widening it changes a return type and a UI affordance. Closing condition: `getMyPendingForSlug` returns the listing review too, or the submit preview surfaces it — checked by a browser test that renders the affordance with only a listing review open.
- **The mutual exclusion is NOT restored, deliberately.** See the enumeration above; `(3b-reset)` is what carries the guarantee.

## Not verified

- **No end-to-end run against a real database.** The 🔴 chain was established by code reading and then **exercised through the service layer against mocked Prisma** — the new regression test drives `approveRequest` end to end with a fake `app_listings` table and fails on pre-fix code. What is still inferred rather than observed is the SQL Prisma emits for the `publishRequests: { none: … }` relation filter inside an `updateMany`, and the re-queued request's appearance in the live moderator queue. The relation-filter-in-a-bulk-write construct is not novel here, which is weaker than executing it but better than nothing: `user.service.ts` already ships `dbWrite.bountyEntry.deleteMany({ where: { userId: id, benefactors: { none: {} } } })` on the account-deletion path.
- **`nsfwLevelFromContentRating` collides `'g'` and `'pg'`** (🟢6) — recorded in a comment, not fixed. The on-site override comparator therefore drops a moderator's explicit `'pg'` over a floored `'g'`, while the off-site clamp honours it. Label-only: both map to `NsfwLevel.PG`, so nothing about who can see the listing changes. Deciding that a tie-breaking override should overwrite an author's declaration is a product call. Closing condition: a product decision on tie-breaking, recorded in the comment or implemented with a mutation-checked test.
- **The rejection notification does not say the listing was delisted** (🟢10) — the `revisionOfId == null` gate no longer means "first-time submission", but the copy it fires (`"<app> was not approved: <reason>"`) never claimed it did, so the comment was corrected and the behaviour left alone. Distinguishing "your first submission was rejected" from "your republish was rejected and the listing is now off the store pending a moderator" needs a second notification type. Closing condition: a `app-listing-republish-rejected` type shipped with its own `prepareMessage` test, or an explicit decision that one message serves both.
- **The one-way withdraw warning still shows on version entries** (🟢9) — behaviour unchanged, comment corrected. Post-discriminator a version withdraw delists in the mod-reset case and does not in the republish-review case, and which one you are in depends on a row `ListingHistoryPanel` does not read. Warning in both is the safe direction for a one-way action; claiming either outcome per entry would be an assertion that surface cannot support.

**Overlap with #4437** (`zach/message-app-owner-ui`): still none — its **12** files and this PR's **30** are disjoint (`comm -12` over both `--name-only` lists returns empty), so no test-merge was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

