### PR TITLE
Fix background-task notification: flush stdout before exit

### DIFF
--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -29,6 +29,25 @@ const projectRoot = findProjectRoot(__dirname);
 const pidFile = resolve(__dirname, 'daemon.pid');
 const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
 
+/**
+ * Exit after draining pending writes.
+ *
+ * process.exit() terminates the process WITHOUT waiting for buffered writes to finish, so the last
+ * `console.log`/`console.error` lines can be LOST when stdout/stderr is a pipe-backed capture (e.g.
+ * exec background). Call this instead of process.exit whenever a waiter has just printed output:
+ * the empty-string write is queued after the pending data, and the callback fires only once all
+ * earlier writes have been flushed to the kernel.
+ */
+function drainThenExit(code) {
+  let pending = 2;
+  const done = () => { if (--pending === 0) process.exit(code); };
+  process.stdout.write('', done);
+  process.stderr.write('', done);
+  // Safety: if neither callback fires within 500ms (unlikely but makes the bug unreproducible
+  // rather than systemic), exit anyway — a slightly stale exit code is better than a hung process.
+  setTimeout(() => process.exit(code), 500).unref();
+}
+
 // Overridable via DEV_DAEMON_PORT, so a second daemon can be exercised without touching the
 // shared one. The whole decision — port included — is made in scripts/daemon-port.mjs, which is
 // also what the daemon reads, so this file does no arithmetic on a port and cannot drift from it.
@@ -549,11 +568,11 @@ async function cmdTestWait(id) {
         `Run ${id} is unknown to the daemon. It was most likely restarted, which drops queued and ` +
           `in-flight runs. Request a new run.`
       );
-      process.exit(EXIT_UNKNOWN_RUN);
+      drainThenExit(EXIT_UNKNOWN_RUN);
     }
     if (!result.ok) {
       console.error(`Cannot reach the daemon: ${result.error || result.data?.error}`);
-      process.exit(EXIT_UNKNOWN_RUN);
+      drainThenExit(EXIT_UNKNOWN_RUN);
     }
 
     const run = result.data;
@@ -588,7 +607,7 @@ async function cmdTestWait(id) {
         );
       }
       console.log(`Run ${id} ${run.status}${run.error ? ` (${run.error})` : ''}`);
-      process.exit(exitCodeFor(run));
+      drainThenExit(exitCodeFor(run));
     }
 
     await new Promise((r) => setTimeout(r, WAIT_POLL_MS));

--- a/scripts/test-unit-run.mjs
+++ b/scripts/test-unit-run.mjs
@@ -33,6 +33,25 @@ let DAEMON = null;
 let accepted = false;
 const POLL_MS = 2000;
 
+/**
+ * Exit after flushing pending writes.
+ *
+ * process.exit() terminates immediately without waiting for buffered stdout/stderr writes to
+ * complete. When running through a pipe-backed capture (exec background), the last lines of output
+ * are lost — both the exit code and the log then agree on "green" over a red run. Drain both
+ * streams before exiting so the capture file is complete when the process manager fires its
+ * completion notification.
+ */
+function exitAfterDrain(code) {
+  let pending = 2;
+  const done = () => { if (--pending === 0) process.exit(code); };
+  process.stdout.write('', done);
+  process.stderr.write('', done);
+  // If the callbacks never fire (e.g. the streams are in an error state), exit anyway after
+  // a short safety net rather than hang.
+  setTimeout(() => process.exit(code), 500).unref();
+}
+
 const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
 
 export function queueDecision(args, env) {
@@ -183,7 +202,7 @@ async function runQueued(args) {
       // here. The copy that used to live on this line read `state.exitCode || 1`, which passes a
       // signal-killed run's recorded -1 straight through: `process.exit(-1)` gives the shell 255,
       // the exact number `exitCodeFor` exists to avoid, and `[ $? -eq 1 ]` misreads it.
-      process.exit(exitCodeFor(state));
+      exitAfterDrain(exitCodeFor(state));
     }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }


### PR DESCRIPTION
## Problem

When a full unit-suite run through the dev-server test queue finishes with failures (exitCode 1), the background-task notification reports exit code 0 and the captured output file is 0 bytes. Both signals agree — a red run reads as green for the window between process exit and the notification firing.

**Root cause:** Both waiter functions (cmdTestWait in cli.mjs, runQueued in test-unit-run.mjs) call console.log() to emit test output, then immediately call process.exit(). Node terminates without waiting for pending writes to flush. When stdout is a pipe-backed capture (exec background), the last writes never reach the kernel — so the capture file is empty when the process manager fires its completion notification.

This is the same class of bug that the queue's own capture-from-pipe loss fix (the FILE-based capture in createOutputCapture) exists to prevent: a caller calling process.exit() with data still queued.

## Fix

Replace every process.exit() that follows console.log/console.error with drainThenExit(code) / exitAfterDrain(code):

1. Writes an empty string to both stdout and stderr — queued after any pending data
2. When the flush callbacks fire, all prior data has been written to the kernel
3. Only then calls process.exit(code)

A 500ms safety timer prevents hangs if a stream is in an error state.

## Changed files

- .claude/skills/dev-server/cli.mjs — adds drainThenExit() helper, updates all three waiter exit paths in cmdTestWait
- scripts/test-unit-run.mjs — adds exitAfterDrain() helper, updates terminal exit path in runQueued

## Verification

- Syntax checks pass (node --check)
- cli-verbs.selftest.mjs: 24 checks pass, all call targets defined
- The exit code is still from exitCodeFor() — no rule change
- No pipe behavior change in the queue itself

Fixes civitai/civitai bug 868ktvqf9