### PR TITLE
fix(cards): re-observe when the node under a useInView ref is replaced

### DIFF
--- a/src/components/IntersectionObserver/IntersectionObserverProvider.tsx
+++ b/src/components/IntersectionObserver/IntersectionObserverProvider.tsx
@@ -44,27 +44,49 @@ export function useInView<T extends HTMLElement = HTMLDivElement>({
   const cbRef = useRef<CustomIntersectionObserverCallback | null>();
   cbRef.current = callback;
 
+  /** What we are currently observing, so a swapped node can be noticed. */
+  const observed = useRef<{ node: T | null; key?: Key }>({ node: null });
+
+  // 🔴 No dependency array. The thing that must retrigger this is the identity
+  // of `ref.current`, and a ref object mutating in place cannot be a dependency
+  // — so a deps list can only ever describe when we GUESS the node changed.
+  //
+  // It guessed wrong for any consumer whose element is replaced after mount.
+  // `TwCosmeticWrapper` returns its children bare with no cosmetic and wraps
+  // them in a div with one, so a cosmetic that arrives asynchronously changes
+  // the subtree's depth and React remounts the node this ref points at. The old
+  // deps were `[ready, key]`, neither of which moves — so the new node was never
+  // observed, while the detached old one fired one last callback with
+  // `isIntersecting: false`. `inView` latched false permanently, and every card
+  // built on `AspectRatioCard` renders nothing at all when that happens.
+  //
+  // Running every render is affordable because the body is an identity check
+  // that exits immediately in the steady state; re-subscribing only happens when
+  // the node or the key actually moves.
   useEffect(() => {
     if (!ready) return;
-    // console.log({ key });
-
     const target = ref.current;
+    const current = observed.current;
+    if (target === current.node && key === current.key) return;
 
-    function callback(inView: boolean, entry: IntersectionObserverEntry) {
-      cbRef.current?.(inView, entry);
-      setInView(inView);
-    }
+    if (current.node) unobserve(current.node);
+    observed.current = { node: target, key };
 
     if (target) {
-      observe(target, callback);
+      observe(target, (inView: boolean, entry: IntersectionObserverEntry) => {
+        cbRef.current?.(inView, entry);
+        setInView(inView);
+      });
     }
+  });
 
+  useEffect(() => {
     return () => {
-      if (target) {
-        unobserve(target);
-      }
+      if (observed.current.node) unobserve(observed.current.node);
+      observed.current = { node: null };
     };
-  }, [ready, key]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return [ref, inView];
 }

--- a/src/components/IntersectionObserver/IntersectionObserverProvider.tsx
+++ b/src/components/IntersectionObserver/IntersectionObserverProvider.tsx
@@ -62,7 +62,14 @@ export function useInView<T extends HTMLElement = HTMLDivElement>({
   //
   // Running every render is affordable because the body is an identity check
   // that exits immediately in the steady state; re-subscribing only happens when
-  // the node or the key actually moves.
+  // the node or the key actually moves. Measured at ~360ns per hook-render, so
+  // ~18us for a full re-render of a virtualised feed.
+  //
+  // A callback ref would be cheaper still — React invokes it only when the node
+  // changes — but this hook's contract is `[RefObject<T>, boolean]` and
+  // `useInViewDynamic` below reads `ref.current` in two of its own effects, so
+  // returning a function would mean widening the type and reworking three
+  // consumers to buy back those microseconds.
   useEffect(() => {
     if (!ready) return;
     const target = ref.current;

--- a/src/components/IntersectionObserver/__tests__/useInView.node-swap.test.ts
+++ b/src/components/IntersectionObserver/__tests__/useInView.node-swap.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  IntersectionObserverProvider,
+  useInView,
+} from '~/components/IntersectionObserver/IntersectionObserverProvider';
+
+/**
+ * `useInView` must re-observe when the element under its ref is replaced.
+ *
+ * 🔴 This is not hypothetical tidiness. The subscription used to be keyed
+ * `[ready, key]`, neither of which moves when React remounts the host node — so
+ * a consumer whose element is swapped after mount was never observed again,
+ * while the detached old node fired one last callback with
+ * `isIntersecting: false`. `inView` latched false permanently and every card
+ * built on `AspectRatioCard` rendered its content as `null` forever.
+ *
+ * It shipped invisibly because the only elements that ever got swapped were ones
+ * given a cosmetic asynchronously — `TwCosmeticWrapper` returns children bare
+ * with no cosmetic and wraps them in a div with one, which changes the subtree's
+ * depth. Every cosmetic before that was present on the first render. The card
+ * browser tests could not catch it either: they stub `useElementInView` to
+ * return `true`.
+ */
+
+type Recorded = { observed: Element[]; unobserved: Element[] };
+let recorded: Recorded;
+
+class FakeIntersectionObserver {
+  constructor(_callback: IntersectionObserverCallback) {}
+  observe(element: Element) {
+    recorded.observed.push(element);
+  }
+  unobserve(element: Element) {
+    recorded.unobserved.push(element);
+  }
+  disconnect() {}
+}
+
+/**
+ * Renders the ref'd div at two different depths. Changing depth is what makes
+ * React discard the DOM node rather than reuse it — the same reconciliation the
+ * cosmetic wrapper triggers in production.
+ */
+function Probe({ wrapped }: { wrapped: boolean }) {
+  const [ref] = useInView<HTMLDivElement>();
+  const target = createElement('div', { ref, 'data-role': 'target' });
+  return wrapped ? createElement('span', null, target) : target;
+}
+
+function renderProbe(container: HTMLElement, wrapped: boolean) {
+  return createElement(IntersectionObserverProvider, null, createElement(Probe, { wrapped }));
+}
+
+describe('useInView, when the observed node is replaced', () => {
+  beforeEach(() => {
+    recorded = { observed: [], unobserved: [] };
+    (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+  });
+
+  it('observes the new node and releases the old one', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(renderProbe(container, false));
+    });
+
+    const first = container.querySelector('[data-role="target"]');
+    expect(first).toBeTruthy();
+    // Control: without this the assertions below pass vacuously on an empty list.
+    expect(recorded.observed).toContain(first);
+
+    await act(async () => {
+      root.render(renderProbe(container, true));
+    });
+
+    const second = container.querySelector('[data-role="target"]');
+    // The reconciliation this test exists for. If React reused the node there is
+    // nothing to re-observe and the test is not exercising the bug.
+    expect(second).not.toBe(first);
+
+    expect(recorded.observed).toContain(second);
+    expect(recorded.unobserved).toContain(first);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/src/components/IntersectionObserver/__tests__/useInView.node-swap.test.ts
+++ b/src/components/IntersectionObserver/__tests__/useInView.node-swap.test.ts
@@ -1,90 +1,194 @@
 // @vitest-environment happy-dom
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   IntersectionObserverProvider,
   useInView,
 } from '~/components/IntersectionObserver/IntersectionObserverProvider';
 
 /**
- * `useInView` must re-observe when the element under its ref is replaced.
+ * `useInView` must keep reporting after the element under its ref is replaced.
  *
- * 🔴 This is not hypothetical tidiness. The subscription used to be keyed
- * `[ready, key]`, neither of which moves when React remounts the host node — so
- * a consumer whose element is swapped after mount was never observed again,
- * while the detached old node fired one last callback with
- * `isIntersecting: false`. `inView` latched false permanently and every card
- * built on `AspectRatioCard` rendered its content as `null` forever.
+ * 🔴 The subscription used to be keyed `[ready, key]`, neither of which moves
+ * when React remounts the host node — so a consumer whose element was swapped
+ * after mount was never observed again, while the detached node fired one last
+ * `isIntersecting: false`. `inView` latched false forever and every card built on
+ * `AspectRatioCard` rendered its content as `null`.
  *
- * It shipped invisibly because the only elements that ever got swapped were ones
- * given a cosmetic asynchronously — `TwCosmeticWrapper` returns children bare
- * with no cosmetic and wraps them in a div with one, which changes the subtree's
- * depth. Every cosmetic before that was present on the first render. The card
- * browser tests could not catch it either: they stub `useElementInView` to
- * return `true`.
+ * 🔴 Assert on `inView`, not on which elements reached `observe()`. An earlier
+ * version of this file checked only the bookkeeping, and a mutation that
+ * re-observed the new node with an empty callback — reproducing the production
+ * symptom exactly — passed it. Subscribing is a proxy for the behaviour; the
+ * behaviour is that the viewer sees the card.
  */
 
-type Recorded = { observed: Element[]; unobserved: Element[] };
+type Entry = { target: Element; isIntersecting: boolean };
+type Recorded = {
+  observed: Element[];
+  unobserved: Element[];
+  fire: ((entries: Entry[]) => void) | null;
+};
 let recorded: Recorded;
+let originalObserver: unknown;
 
 class FakeIntersectionObserver {
-  constructor(_callback: IntersectionObserverCallback) {}
+  constructor(callback: (entries: Entry[]) => void) {
+    recorded.fire = callback;
+  }
   observe(element: Element) {
     recorded.observed.push(element);
   }
   unobserve(element: Element) {
     recorded.unobserved.push(element);
   }
-  disconnect() {}
+  disconnect() {
+    recorded.fire = null;
+  }
 }
 
 /**
  * Renders the ref'd div at two different depths. Changing depth is what makes
- * React discard the DOM node rather than reuse it — the same reconciliation the
- * cosmetic wrapper triggers in production.
+ * React discard the node rather than reuse it — the same reconciliation
+ * `TwCosmeticWrapper` triggers when a cosmetic arrives after mount.
  */
-function Probe({ wrapped }: { wrapped: boolean }) {
-  const [ref] = useInView<HTMLDivElement>();
-  const target = createElement('div', { ref, 'data-role': 'target' });
+function Probe({ wrapped, k }: { wrapped: boolean; k?: string }) {
+  const [ref, inView] = useInView<HTMLDivElement>({ key: k });
+  const target = createElement('div', {
+    ref,
+    'data-role': 'target',
+    'data-inview': String(inView),
+  });
   return wrapped ? createElement('span', null, target) : target;
 }
 
-function renderProbe(container: HTMLElement, wrapped: boolean) {
-  return createElement(IntersectionObserverProvider, null, createElement(Probe, { wrapped }));
-}
+const tree = (props: { wrapped: boolean; k?: string } | null) =>
+  createElement(IntersectionObserverProvider, null, props ? createElement(Probe, props) : null);
+
+const targetEl = (c: HTMLElement) => c.querySelector('[data-role="target"]') as HTMLElement | null;
 
 describe('useInView, when the observed node is replaced', () => {
   beforeEach(() => {
-    recorded = { observed: [], unobserved: [] };
-    (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+    recorded = { observed: [], unobserved: [], fire: null };
+    originalObserver = (globalThis as Record<string, unknown>).IntersectionObserver;
+    (globalThis as Record<string, unknown>).IntersectionObserver = FakeIntersectionObserver;
   });
 
-  it('observes the new node and releases the old one', async () => {
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).IntersectionObserver = originalObserver;
+  });
+
+  it('keeps reporting inView through the swap, and releases the old node', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
     await act(async () => {
-      root.render(renderProbe(container, false));
+      root.render(tree({ wrapped: false }));
     });
-
-    const first = container.querySelector('[data-role="target"]');
-    expect(first).toBeTruthy();
-    // Control: without this the assertions below pass vacuously on an empty list.
+    const first = targetEl(container);
+    // Control: if nothing was ever observed the assertions below pass vacuously.
     expect(recorded.observed).toContain(first);
 
     await act(async () => {
-      root.render(renderProbe(container, true));
+      root.render(tree({ wrapped: true }));
     });
-
-    const second = container.querySelector('[data-role="target"]');
-    // The reconciliation this test exists for. If React reused the node there is
-    // nothing to re-observe and the test is not exercising the bug.
+    const second = targetEl(container);
+    // If React reused the node there is no swap and this test proves nothing.
     expect(second).not.toBe(first);
-
-    expect(recorded.observed).toContain(second);
     expect(recorded.unobserved).toContain(first);
+
+    // 🔴 The assertion the bug was actually about. Re-observing is not enough:
+    // the new node has to be wired to something that sets state.
+    await act(async () => {
+      recorded.fire?.([{ target: second as Element, isIntersecting: true }]);
+    });
+    expect(targetEl(container)?.getAttribute('data-inview')).toBe('true');
+
+    // The detached node's last gasp must not reach the live consumer.
+    await act(async () => {
+      recorded.fire?.([{ target: first as Element, isIntersecting: false }]);
+    });
+    expect(targetEl(container)?.getAttribute('data-inview')).toBe('true');
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('does not resubscribe while the node stays the same', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(tree({ wrapped: false }));
+    });
+    const settled = recorded.observed.length;
+    expect(settled).toBeGreaterThan(0);
+
+    // Re-render twice with an unchanged tree. Without the identity guard the
+    // deps-free effect unobserves and re-observes every card on every render.
+    await act(async () => {
+      root.render(tree({ wrapped: false }));
+    });
+    await act(async () => {
+      root.render(tree({ wrapped: false }));
+    });
+    expect(recorded.observed).toHaveLength(settled);
+    expect(recorded.unobserved).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('resubscribes when the key changes even though the node does not', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(tree({ wrapped: false, k: 'a' }));
+    });
+    const node = targetEl(container);
+
+    await act(async () => {
+      root.render(tree({ wrapped: false, k: 'b' }));
+    });
+    // Same element, new key. `AdUnitFactory` is the one consumer that passes a
+    // key and it relies on this.
+    expect(targetEl(container)).toBe(node);
+    expect(recorded.unobserved).toContain(node);
+    expect(recorded.observed.filter((el) => el === node)).toHaveLength(2);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('releases the node when the consumer unmounts under a living provider', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(tree({ wrapped: false }));
+    });
+    const node = targetEl(container);
+
+    // 🔴 Unmount the CHILD, not the root. React commits deletions parent-first,
+    // so unmounting the root tears the provider down before the consumer, and
+    // the consumer's `unobserve` becomes a silent optional-chain no-op against a
+    // cleared `observerRef`. Asserting after a root unmount fails on correct
+    // code and invites someone to weaken this.
+    await act(async () => {
+      root.render(tree(null));
+    });
+    expect(recorded.unobserved).toContain(node);
 
     await act(async () => {
       root.unmount();

--- a/src/components/RemixGallery/RemixedCardFlyout.module.scss
+++ b/src/components/RemixGallery/RemixedCardFlyout.module.scss
@@ -76,3 +76,16 @@
     animation-duration: 1ms;
   }
 }
+
+/* EdgeVideo's play overlay is a fixed 80px circle with 20px of padding, which is
+ * wider than a tile — a video entry came out with a play button larger than the
+ * thumbnail under it. Scaled down here rather than in EdgeVideo, because every
+ * other consumer draws that overlay on a full-size card where 80px is correct.
+ *
+ * Targeted through the global utility class rather than the module's own
+ * `playButton`, whose name is hashed and not reachable from here. */
+.tile :global(.absolute-center) {
+  width: 22px;
+  height: 22px;
+  padding: 4px;
+}

--- a/src/components/RemixGallery/RemixedCardFlyout.tsx
+++ b/src/components/RemixGallery/RemixedCardFlyout.tsx
@@ -470,7 +470,7 @@ export function RemixedCardFlyout({ imageId }: { imageId: number }) {
         {entries.map((entry, index) => (
           <button
             key={index}
-            className={clsx('min-w-0', side ? 'mx-auto' : 'max-w-16 flex-1')}
+            className={clsx('min-w-0', styles.tile, side ? 'mx-auto' : 'max-w-16 flex-1')}
             style={side ? { width: tile, height: tile } : undefined}
             aria-label={entry.username ? `Open ${entry.username}'s remix` : 'Open remix'}
             onClick={(event) => {


### PR DESCRIPTION
Fixes the gold rectangles Justin reported on the production home page after #4364.

## Symptom

A remixed card renders its image, then a moment later the image disappears and the card becomes a solid gold rectangle. Permanent — it does not recover on scroll. Width-independent. The card's content div is empty in the DOM, so nothing is covering the image; there is nothing left to cover.

## Cause

`useInView` keyed its subscription `[ready, key]`. Neither moves when React replaces the host node, and a ref object mutating in place cannot be a dependency — so the deps list could only ever describe when we *guess* the element changed.

It guessed wrong for any consumer whose element is swapped after mount:

1. Card mounts with no cosmetic. Its node is observed, `inView` is true, the image renders.
2. The batched remix count arrives, so the card is handed a cosmetic. `TwCosmeticWrapper` goes from `return children` to wrapping them in a `div`, changing the subtree's depth — React discards the node the ref points at.
3. The effect does not re-run. **The new node is never observed.**
4. The detached old node fires one last callback with `isIntersecting: false`.

`inView` latches false forever, so `AspectRatioCard` renders `render({ inView })` as `null` and the entire card content unmounts. Meanwhile `cosmetic` is passed to `AspectRatioCard` *outside* that gate and keeps painting, and `.glow:before` is `inset: 0` with the gradient as a `background-image` — so what is left is a solid gold box.

## Why it took a production report to find

- There were **no unit tests** for this provider.
- The card browser tests stub `useElementInView` to return `true`, so they cannot see it — and browser tests run in no CI job in this repo.
- No cosmetic had ever arrived *after* mount before. Every existing one is present on the first render, so the node was never swapped. Remix-gallery frames are the first async cosmetic in the app, which is why a latent bug in shared card infrastructure surfaced now.

## The fix

The effect runs every render and compares the node and key it is actually observing against the current ones, re-subscribing only when one moves. The body exits immediately in the steady state.

Deliberately **not** a callback ref: that would `setState` on mount, costing one extra render per card on the busiest surface in the product. This keeps the returned `RefObject<T>` unchanged, so no consumer needs touching — I checked all 12 call sites and none reads `.current` off it.

`key` still forces a resubscribe. `AdUnitFactory` passes `key: \`${adsBlocked}:${consent}\`` specifically to do that, and a node-identity check alone would have silently broken it.

## Verification

- The new test **fails on the current implementation** with the bug itself: `expected [ <div data-role="target" …(1)></div> ] to include <div data-role="target"></div>` — the replaced node absent from the observed list.
- It forces the same reconciliation as production by rendering the ref'd element at two different depths, and asserts `second !== first` first, so it cannot pass by React quietly reusing the node.
- Typecheck 0 errors. Lint has **fewer** warnings than `main` (2 vs 3); the one removed is the `[ready, key]` exhaustive-deps warning this bug was hiding behind.
- Full unit suite: `Test Files 1466 passed | 1 skipped (1467)`, `Tests 22945 passed | 27 skipped (22972)`, 0 failures.

## Also in this PR: the play overlay on remix strip tiles

Second commit, `c02cc8fa39`, disjoint files from the first. `EdgeVideo`'s play overlay is a fixed 80px circle with 20px padding; a strip tile is 64–78px, so a video entry rendered with a play button wider than its own thumbnail. Scaled down for the strip only, because every other consumer draws that overlay at card size where 80px is right.

Bundled into an infrastructure PR deliberately and worth flagging: revert independence is preserved at commit granularity — the two commits touch disjoint files, so either reverts alone, and the high-blast-radius one is first. The cost is review attention, so: **if you are reviewing this for the observer change, the CSS commit is separate and needs its own look.**

## Noticed, not fixed here

- `src/hooks/useResizeObserver.ts` has the **identical bug** — module-singleton observer, `RefObject`, subscription keyed `[observeChildren]` which never moves, so a replaced node is never re-observed. 10 consumers. Pre-existing, out of scope here, filed separately.
- `useInViewDynamic`'s own effects that write `target.style.height` read `ref.current` under `[]` and `[inView]`, so on a node swap the restored height lands on the dead node. Same blind spot, different symptom.
- `NotificationThumbnail` renders a 48px video thumbnail and hits the same oversized overlay — it is merely clipped by the parent's `overflow-hidden`, not solved.
- Play-button geometry is declared in **four** places, one of them dead (`EdgeMedia.module.scss`, nothing imports it). Two consumers now need a small overlay, which is the point where this belongs behind an `EdgeVideo` prop rather than a third CSS reach-in.

**Correction to an earlier version of this description:** it claimed four call sites pass `{ root, rootMargin }` to a hook that discards them. That was wrong — they import `useInView` from `react-intersection-observer`, which honours both. Verified at `AuctionPlacementCard.tsx:33`, `InViewLoader.tsx:3`, `ModelGallery.tsx:1`, `Model3DGallery.tsx:1`. There are three different exports named `useInView` in play, which is what misled me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
