### PR TITLE
fix(images): surface unmatched resources detected only via meta.hashes

### DIFF
--- a/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
+++ b/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
@@ -65,7 +65,7 @@ import { useCurrentUserRequired } from '~/hooks/useCurrentUser';
 import { DEFAULT_EDGE_IMAGE_WIDTH, MAX_RESOURCES_PER_IMAGE } from '~/server/common/constants';
 import type { NsfwLevel } from '~/server/common/enums';
 import { BlockedReason } from '~/server/common/enums';
-import type { ImageMetaProps } from '~/server/schema/image.schema';
+import type { ImageMetaProps, UnmatchedResource } from '~/server/schema/image.schema';
 import type { VideoMetadata } from '~/server/schema/media.schema';
 import type { PostEditImageDetail, ResourceHelper } from '~/server/services/post.service';
 import {
@@ -623,15 +623,25 @@ function EditDetail() {
   const hasSimpleMeta = !!simpleMeta.length;
   const resourcesSorted = sortByModelTypes(resources);
   const unmatchedResources = useMemo(() => {
+    const derived = meta?.unmatchedResources as UnmatchedResource[] | undefined;
+    if (derived) return derived;
+    // Images ingested before the server derived this list carry a per-resource flag instead
     const metaResources = (meta?.resources ?? []) as {
-      type: string;
+      type?: string;
       name?: string;
       hash?: string;
       unmatched?: boolean;
     }[];
-    return metaResources.filter((r) => r.unmatched && r.name);
-  }, [meta?.resources]);
+    return metaResources
+      .filter((r) => r.unmatched && r.name)
+      .map((r) => ({
+        type: r.type,
+        name: r.name!.replace(/.*[/\\]/, '').replace(/\.[^/.]+$/, ''),
+        hash: r.hash ?? '',
+      }));
+  }, [meta?.unmatchedResources, meta?.resources]);
   const hasLegacyUnmatched = useMemo(() => {
+    if (meta?.unmatchedResources) return false; // server computed the full list; trust it
     if (unmatchedResources.length > 0) return false; // new-style flags take precedence
     const metaResources = (meta?.resources ?? []) as { hash?: string; unmatched?: boolean }[];
     const resourcesWithHashes = metaResources.filter((r) => !!r.hash);
@@ -640,7 +650,7 @@ function EditDetail() {
     if (hasAnyFlags) return false;
     const detectedCount = resources.filter((r) => r.detected).length;
     return resourcesWithHashes.length > detectedCount;
-  }, [meta?.resources, resources, unmatchedResources.length]);
+  }, [meta?.unmatchedResources, meta?.resources, resources, unmatchedResources.length]);
   const cannotVerifyAi =
     !isValidAIGeneration({
       id: image.id,
@@ -848,19 +858,19 @@ function EditDetail() {
                     <Text size="sm">
                       The following resources could not be matched to models on Civitai:
                     </Text>
-                    {unmatchedResources.map((r, i) => {
-                      const displayName = r.name?.replace(/.*[/\\]/, '').replace(/\.[^/.]+$/, '');
-                      return (
-                        <Group key={i} gap="xs" wrap="nowrap" mt={4}>
-                          <Text size="sm" lineClamp={1}>
-                            {displayName}
-                          </Text>
+                    {unmatchedResources.map((r, i) => (
+                      <Group key={i} gap="xs" wrap="nowrap" mt={4}>
+                        <Text size="sm" lineClamp={1}>
+                          {r.name}
+                        </Text>
+                        {/* Absent for resources detected only via meta.hashes */}
+                        {!!r.type && (
                           <Badge color="gray" size="sm" variant="filled">
                             {getDisplayName(r.type)}
                           </Badge>
-                        </Group>
-                      );
-                    })}
+                        )}
+                      </Group>
+                    ))}
                   </Alert>
                 )}
                 {hasLegacyUnmatched && (

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4123':
+  'server/services/image.service.ts:4124':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4264':
+  'server/services/image.service.ts:4265':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5002':
+  'server/services/image.service.ts:5003':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6136':
+  'server/services/image.service.ts:6137':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4264')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4265')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/routers/image.router.ts
+++ b/src/server/routers/image.router.ts
@@ -232,5 +232,6 @@ export const imageRouter = router({
   refreshImageResources: protectedProcedure
     .meta({ requiredScope: TokenScope.MediaWrite })
     .input(getByIdSchema)
+    .use(isOwnerOrModerator)
     .mutation(({ input }) => refreshImageResources(input.id)),
 });

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -95,6 +95,13 @@ export const imageMetadataResourceSchema = z.object({
   unmatched: z.boolean().optional(),
 });
 
+export type UnmatchedResource = z.infer<typeof unmatchedResourceSchema>;
+export const unmatchedResourceSchema = z.object({
+  type: z.string().optional(),
+  name: z.string(),
+  hash: z.string(),
+});
+
 export const additionalResourceSchema = z.object({
   name: z.string().optional(),
   type: z.string().optional(),
@@ -119,6 +126,7 @@ export const imageGenerationSchema = z.object({
   sampler: undefinedString,
   seed: stringToNumber,
   hashes: z.record(z.string(), z.string()).optional(),
+  unmatchedResources: z.array(unmatchedResourceSchema).optional(),
   clipSkip: z.coerce.number().optional(),
   'Clip skip': z.coerce.number().optional(),
   comfy: z.union([z.string().optional(), comfyMetaSchema.optional()]).optional(), // stored as stringified JSON

--- a/src/server/services/__tests__/create-image-resources-unmatched.test.ts
+++ b/src/server/services/__tests__/create-image-resources-unmatched.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as RedisCaches from '~/server/redis/caches';
+
+const { mockCacheRefresh } = vi.hoisted(() => ({ mockCacheRefresh: vi.fn(async () => undefined) }));
+
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof RedisCaches>()),
+  imageResourcesCache: { refresh: mockCacheRefresh },
+}));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { createImageResources } from '~/server/services/image.service';
+
+type Row = {
+  id: number;
+  modelversionid: number | null;
+  name: string | null;
+  hash: string | null;
+  strength: number | null;
+  detected: boolean;
+};
+
+const row = (over: Partial<Row>): Row => ({
+  id: 1,
+  modelversionid: null,
+  name: null,
+  hash: null,
+  strength: null,
+  detected: true,
+  ...over,
+});
+
+/** First $queryRaw is get_image_resources(); the second is the ImageResourceNew upsert. */
+function givenDetected(rows: Row[], meta: Record<string, unknown>) {
+  dbMock.dbWrite.$queryRaw.mockResolvedValueOnce(rows).mockResolvedValue([]);
+  dbMock.dbWrite.image.findUnique.mockResolvedValue({ meta } as never);
+}
+
+const metaWritten = () =>
+  (dbMock.dbWrite.image.update.mock.calls[0][0] as { data: { meta: Record<string, any> } }).data
+    .meta;
+
+describe('createImageResources — unmatched resource meta', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('records a resource detected only via meta.hashes, which meta.resources cannot flag', async () => {
+    givenDetected(
+      [
+        row({ name: 'Checkpoint', hash: 'aabbccddee', modelversionid: 7 }),
+        row({ name: 'lycoris:local-lora', hash: '0123456789ab' }),
+      ],
+      { resources: [{ type: 'model', name: 'Checkpoint', hash: 'aabbccddee' }] }
+    );
+
+    await createImageResources({ imageId: 1 });
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+    expect(metaWritten().unmatchedResources).toEqual([
+      { hash: '0123456789ab', name: 'local-lora' },
+    ]);
+  });
+
+  it('clears a flag that no longer holds, so the warning goes away after the model is uploaded', async () => {
+    givenDetected([row({ name: 'now-published', hash: 'abcdef012345', modelversionid: 99 })], {
+      resources: [{ type: 'lora', name: 'now-published', hash: 'abcdef012345', unmatched: true }],
+    });
+
+    await createImageResources({ imageId: 1 });
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+    const meta = metaWritten();
+    expect(meta.resources[0].unmatched).toBe(false);
+    expect(meta.unmatchedResources).toEqual([]);
+  });
+
+  it('clears a stored list once nothing is unmatched, even though no flag has to flip', async () => {
+    // The headline flow: user uploads the missing model, hits refresh. Nothing is unmatched now, so
+    // the old `unmatchedHashes.size > 0` guard would skip the meta block and strand the warning.
+    givenDetected([row({ name: 'now-published', hash: 'abcdef012345', modelversionid: 99 })], {
+      resources: [{ type: 'lora', name: 'now-published', hash: 'abcdef012345' }],
+      unmatchedResources: [{ hash: 'abcdef012345', name: 'now-published' }],
+    });
+
+    await createImageResources({ imageId: 1 });
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+    expect(metaWritten().unmatchedResources).toEqual([]);
+  });
+
+  it('writes nothing when the stored meta already matches', async () => {
+    givenDetected([row({ name: 'lycoris:local-lora', hash: '0123456789ab' })], {
+      resources: [],
+      unmatchedResources: [{ hash: '0123456789ab', name: 'local-lora' }],
+    });
+
+    await createImageResources({ imageId: 1 });
+
+    expect(dbMock.dbWrite.image.update).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing for a fully matched image that never had the field', async () => {
+    givenDetected([row({ name: 'Checkpoint', hash: 'aabbccddee', modelversionid: 7 })], {
+      resources: [{ type: 'model', name: 'Checkpoint', hash: 'aabbccddee' }],
+    });
+
+    await createImageResources({ imageId: 1 });
+
+    expect(dbMock.dbWrite.image.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/no-unverified-provenance-write.test.ts
+++ b/src/server/services/__tests__/no-unverified-provenance-write.test.ts
@@ -20,8 +20,9 @@ const SRC = path.resolve(__dirname, '../../..');
 /** Write sites whose meta is read back off the row rather than supplied by a caller. */
 const DERIVED_FROM_ROW = [
   // image.service.ts `updateImageResources`-style rewrite: spreads the stored
-  // meta and replaces `resources`, so no new claim can enter.
-  'meta: { ...meta, resources: metaResources }',
+  // meta and replaces `resources` plus `unmatchedResources`, both derived from
+  // the row and from get_image_resources(), so no new claim can enter.
+  'meta: { ...meta, resources: metaResources, unmatchedResources }',
 ];
 
 function walk(dir: string, files: string[] = []): string[] {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { randomUUID } from 'crypto';
 import type { ManipulateType } from 'dayjs';
 import dayjs from '~/shared/utils/dayjs';
-import { chunk, truncate, uniq, uniqBy } from 'lodash-es';
+import { chunk, isEqual, truncate, uniq, uniqBy } from 'lodash-es';
 import { MeiliSearch, type SearchParams } from 'meilisearch';
 import type { SessionUser } from '~/types/session';
 import { v4 as uuid } from 'uuid';
@@ -74,6 +74,7 @@ import {
 import { getNewCreatorUserIds } from '~/server/services/new-creators.service';
 import { imageOnSiteSql, isImageMetaOnSite } from '~/server/utils/image-onsite';
 import { stripImageForInfiniteWire } from '~/server/utils/image-infinite-wire';
+import { deriveUnmatchedResources } from '~/server/utils/unmatched-resources';
 import {
   getBaseModelFromResources,
   getUserFollows,
@@ -8713,6 +8714,7 @@ export async function getImageResourcesFromImageId({
     {
       id: number;
       modelversionid: number | null;
+      name: string | null;
       hash: string | null;
       strength: number | null;
       detected: boolean;
@@ -8758,36 +8760,45 @@ export async function createImageResources({
     `;
   }
 
-  // Flag unmatched resources on image meta
+  // Recomputed in full rather than only stamped: a user who uploads the missing model and hits
+  // refresh has to see the warning clear, so a flag that no longer holds must come back off.
   const unmatchedHashes = new Set(
     resources
       .filter((r) => r.detected && !r.modelversionid && r.hash)
       .map((r) => r.hash!.toLowerCase())
   );
 
-  if (unmatchedHashes.size > 0) {
-    const image = await dbClient.image.findUnique({
+  const image = await dbClient.image.findUnique({
+    where: { id: imageId },
+    select: { meta: true },
+  });
+
+  const meta = (image?.meta ?? {}) as Record<string, any>;
+  const metaResources = (meta.resources ?? []) as {
+    type?: string;
+    name?: string;
+    hash?: string;
+    unmatched?: boolean;
+  }[];
+  let updated = false;
+
+  for (const resource of metaResources) {
+    const unmatched = !!resource.hash && unmatchedHashes.has(resource.hash.toLowerCase());
+    if (unmatched === !!resource.unmatched) continue;
+    // Set false rather than deleted: a client that predates meta.unmatchedResources reads the key's
+    // absence as "legacy image" and falls through to a count heuristic that over-reports.
+    resource.unmatched = unmatched;
+    updated = true;
+  }
+
+  const unmatchedResources = deriveUnmatchedResources(resources, metaResources);
+  if (!isEqual(unmatchedResources, meta.unmatchedResources ?? [])) updated = true;
+
+  if (updated) {
+    await dbClient.image.update({
       where: { id: imageId },
-      select: { meta: true },
+      data: { meta: { ...meta, resources: metaResources, unmatchedResources } },
     });
-
-    const meta = (image?.meta ?? {}) as Record<string, any>;
-    const metaResources = (meta.resources ?? []) as { hash?: string; unmatched?: boolean }[];
-    let updated = false;
-
-    for (const resource of metaResources) {
-      if (resource.hash && unmatchedHashes.has(resource.hash.toLowerCase())) {
-        resource.unmatched = true;
-        updated = true;
-      }
-    }
-
-    if (updated) {
-      await dbClient.image.update({
-        where: { id: imageId },
-        data: { meta: { ...meta, resources: metaResources } },
-      });
-    }
   }
 
   await imageResourcesCache.refresh(imageId);

--- a/src/server/utils/__tests__/unmatched-resources.test.ts
+++ b/src/server/utils/__tests__/unmatched-resources.test.ts
@@ -1,0 +1,144 @@
+import { isEqual } from 'lodash-es';
+import { describe, expect, it } from 'vitest';
+import type { DetectedResource } from '~/server/utils/unmatched-resources';
+import { deriveUnmatchedResources } from '~/server/utils/unmatched-resources';
+
+const detected = (over: Partial<DetectedResource>): DetectedResource => ({
+  modelversionid: null,
+  name: null,
+  hash: null,
+  detected: true,
+  ...over,
+});
+
+describe('deriveUnmatchedResources', () => {
+  it('surfaces a resource detected only via meta.hashes, with no meta.resources entry', () => {
+    // The reported bug: an unpublished local LoRA reaches get_image_resources() through the
+    // meta.hashes union branch, so nothing in meta.resources can carry a flag for it.
+    const result = deriveUnmatchedResources(
+      [
+        detected({ name: 'Some Checkpoint', hash: 'aabbccddee', modelversionid: 42 }),
+        detected({ name: 'lycoris:my-turbo-lora', hash: '0123456789ab' }),
+      ],
+      [{ type: 'model', name: 'Some Checkpoint', hash: 'aabbccddee' }]
+    );
+
+    expect(result).toHaveLength(1);
+    // toStrictEqual, not toEqual: an absent `type` key and `type: undefined` are different here —
+    // the latter cannot survive jsonb and would make the caller rewrite meta on every run.
+    expect(result[0]).toStrictEqual({ hash: '0123456789ab', name: 'my-turbo-lora' });
+  });
+
+  it('accounts for every unmatched resource when one is named and one is orphaned', () => {
+    const result = deriveUnmatchedResources(
+      [
+        detected({ name: 'detail-tweaker', hash: 'ffffffffffff' }),
+        detected({ name: 'checkpoint:nameless-orphan', hash: 'aaaaaaaaaaaa' }),
+      ],
+      [{ type: 'lycoris', name: 'detail-tweaker.safetensors', hash: 'FFFFFFFFFFFF' }]
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.name)).toEqual(['detail-tweaker', 'nameless-orphan']);
+    expect(result[0].type).toBe('lycoris');
+  });
+
+  it('ignores resources that resolved to a model version', () => {
+    const result = deriveUnmatchedResources([
+      detected({ name: 'matched', hash: 'abcdef0123', modelversionid: 7 }),
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('drops junk values that meta.hashes carries alongside real hashes', () => {
+    const result = deriveUnmatchedResources([
+      detected({ name: 'manual1', hash: 'false' }),
+      detected({ name: 'manual1', hash: ' ' }),
+      detected({ name: 'model', hash: '' }),
+      detected({ name: 'manual1', hash: 'abc' }),
+      detected({ name: 'manual1', hash: 'b166b8' }),
+      detected({ name: 'nothash', hash: 'zzzzzzzzzz' }),
+      detected({ name: 'real', hash: 'b166b8931f32' }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].hash).toBe('b166b8931f32');
+  });
+
+  it('excludes hashless detections', () => {
+    const result = deriveUnmatchedResources([detected({ name: 'prompt-embedding', hash: null })]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('dedupes by hash across detection branches', () => {
+    // meta.resources and meta.hashes both report the same LoRA
+    const result = deriveUnmatchedResources([
+      detected({ name: 'my-lora', hash: 'abcdef012345' }),
+      detected({ name: 'lora:my-lora', hash: 'ABCDEF012345' }),
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('normalises an uppercase detected hash rather than discarding it as junk', () => {
+    // HASH_SHAPE only matches lowercase, so a missing toLowerCase() here drops the row entirely.
+    // The dedupe test above cannot catch that: there, the uppercase row is the duplicate.
+    const result = deriveUnmatchedResources([detected({ name: 'solo', hash: 'ABCDEF012345' })]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].hash).toBe('abcdef012345');
+  });
+
+  it('ignores rows the function returns as not detected', () => {
+    const result = deriveUnmatchedResources([
+      detected({ name: 'post model version', hash: 'aabbccddeeff', detected: false }),
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('equals its own stored form, so the caller does not rewrite meta on every run', () => {
+    // jsonb cannot hold undefined. A `type: undefined` key survives in memory but not through
+    // storage, so carrying one makes isEqual false forever and rewrites Image.meta every call.
+    const derived = deriveUnmatchedResources([
+      detected({ name: 'lora:orphan-with-no-type', hash: 'aabbccddeeff' }),
+    ]);
+    const stored = JSON.parse(JSON.stringify(derived));
+
+    expect(isEqual(derived, stored)).toBe(true);
+  });
+
+  it('returns a stable order regardless of detection order', () => {
+    // get_image_resources() has no ORDER BY, and the caller compares arrays positionally.
+    const rows = [
+      detected({ name: 'zebra', hash: 'cccccccccccc' }),
+      detected({ name: 'alpha', hash: 'aaaaaaaaaaaa' }),
+      detected({ name: 'middle', hash: 'bbbbbbbbbbbb' }),
+    ];
+
+    const forward = deriveUnmatchedResources(rows);
+    const reversed = deriveUnmatchedResources([...rows].reverse());
+
+    expect(forward.map((r) => r.name)).toEqual(['alpha', 'middle', 'zebra']);
+    expect(isEqual(forward, reversed)).toBe(true);
+  });
+
+  it('always produces a name, so no consumer has to handle a missing label', () => {
+    const sha256 = 'a'.repeat(64);
+    const result = deriveUnmatchedResources([detected({ name: 'lycoris:', hash: sha256 })]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('a'.repeat(12));
+  });
+
+  it('prefers the meta.resources name and strips path and extension', () => {
+    const result = deriveUnmatchedResources(
+      [detected({ name: 'lora:ugly_key_name', hash: '112233445566' })],
+      [{ type: 'lora', name: 'C:\\models\\Pretty Name.safetensors', hash: '112233445566' }]
+    );
+
+    expect(result[0].name).toBe('Pretty Name');
+  });
+});

--- a/src/server/utils/unmatched-resources.ts
+++ b/src/server/utils/unmatched-resources.ts
@@ -1,0 +1,71 @@
+import type { UnmatchedResource } from '~/server/schema/image.schema';
+
+export type DetectedResource = {
+  modelversionid: number | null;
+  name?: string | null;
+  hash: string | null;
+  detected: boolean;
+};
+
+export type MetaResource = { type?: string; name?: string; hash?: string };
+
+// get_image_resources() surfaces every value in meta.hashes, which is user-writable and holds
+// junk alongside real hashes ('false', ' ', '' and 1-5 char values in a day's prod sample).
+const HASH_SHAPE = /^[0-9a-f]{8,}$/;
+
+// The SQL strips these prefixes from meta.hashes keys before returning them, but only some of them.
+const NAME_PREFIX = /^(lora|lycoris|embed|hypernet|model|checkpoint):/i;
+
+function cleanName(name?: string | null) {
+  const stripped = name
+    ?.replace(NAME_PREFIX, '')
+    .replace(/.*[/\\]/, '')
+    .replace(/\.[^/.]+$/, '');
+  return stripped?.trim() || undefined;
+}
+
+/**
+ * Resources the image reported that resolved to no model version.
+ *
+ * Derived from get_image_resources() rather than from meta.resources: that function unions four
+ * detection sources, so a resource present only in meta.hashes has no meta.resources entry to
+ * carry a flag. Those are the ones users report as missing from the upload warning.
+ *
+ * Hashless detections are deliberately excluded. They can never be matched by definition, and
+ * every prompt-referenced embedding is one — surfacing them would bury the actionable cases.
+ */
+export function deriveUnmatchedResources(
+  detected: DetectedResource[],
+  metaResources: MetaResource[] = []
+): UnmatchedResource[] {
+  const byHash = new Map<string, MetaResource>();
+  for (const resource of metaResources) {
+    const hash = resource.hash?.toLowerCase().trim();
+    if (hash && !byHash.has(hash)) byHash.set(hash, resource);
+  }
+
+  const unmatched: UnmatchedResource[] = [];
+  const seen = new Set<string>();
+
+  for (const resource of detected) {
+    if (!resource.detected || resource.modelversionid) continue;
+
+    const hash = resource.hash?.toLowerCase().trim();
+    if (!hash || !HASH_SHAPE.test(hash) || seen.has(hash)) continue;
+    seen.add(hash);
+
+    const fromMeta = byHash.get(hash);
+    unmatched.push({
+      hash,
+      // Total by construction so no consumer has to handle a missing label
+      name: cleanName(fromMeta?.name) ?? cleanName(resource.name) ?? hash.slice(0, 12),
+      // Omitted rather than set undefined: jsonb drops an undefined key, so carrying one would
+      // make this value unequal to its own stored form and rewrite Image.meta on every run.
+      ...(fromMeta?.type ? { type: fromMeta.type } : {}),
+    });
+  }
+
+  // get_image_resources() has no ORDER BY, so detection order is not stable between calls. Sort
+  // before returning: the caller diffs this against the stored value to decide whether to write.
+  return unmatched.sort((a, b) => a.name.localeCompare(b.name) || a.hash.localeCompare(b.hash));
+}


### PR DESCRIPTION
createImageResources flagged unmatched resources by iterating meta.resources and keying on resource.hash. Detection actually comes from get_image_resources() (prisma/programmability), which unions five sources — so a resource reaching detection only through the meta.hashes branch has no meta.resources entry to carry a flag, and was invisible in every UI path. Measured 305 images/day in prod.

Derive the list from the function's own output instead and store it as meta.unmatchedResources. Junk is filtered by hash shape, since meta.hashes is user-writable and carries 'false', whitespace and short values alongside real hashes. Hashless detections stay excluded: they can never be matched by definition and every prompt-referenced embedding is one, so surfacing them would bury the actionable cases.

Also fixes two defects found alongside it:

- The unmatched flag was only ever set, never cleared, so the warning never went away after a user uploaded the missing model and hit refresh. This required dropping the `unmatchedHashes.size > 0` guard, which costs one PK findUnique per ingestion (0.018ms against the 7ms get_image_resources call already on that path).
- refreshImageResources took an image id with no ownership check while the delete mutation beside it uses isOwnerOrModerator. Harmless before, since a cross-owner call rarely wrote meta; the change above makes it an on-demand meta rewrite of an arbitrary image.

The derived value is sorted and omits undefined keys so it compares equal to its own stored form — get_image_resources() has no ORDER BY, and jsonb drops an undefined key, either of which would rewrite Image.meta on every run.