### PR TITLE
fix(remix-gallery): send the placer fields the manage modal renders

### DIFF
--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -1438,6 +1438,40 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     placementFindMany.mockResolvedValue([]);
   });
 
+  /**
+   * Named for the decision, because the narrow select this replaced type-checked
+   * fine: `UserAvatar` takes `Partial<UserWithCosmetics>`, so dropping the three
+   * keys below is invisible to tsc and shows up only as a wrong-looking avatar.
+   *
+   * `User.image` is what the queue used to send, and it is a dead column — of
+   * the 121 distinct placers on this surface in production, 0 have it set and 93
+   * have a `profilePicture`. So the old select handed the avatar null for every
+   * placer alive, and stripped the equipped cosmetics of 61 of them.
+   *
+   * Asserted on the ARGUMENT rather than on a returned row: the Prisma mock
+   * ignores `select` and hands back whatever the fixture holds, so an assertion
+   * made on the result passes with any select at all.
+   */
+  it('sends the placer fields the avatar renders, not just id and username', async () => {
+    // A populated page, because the service returns before it ever reaches
+    // `findMany` on an empty one — the default `beforeEach` state would make
+    // this assert against a call that never happened.
+    respond({
+      page: [{ id: 1, createdAt: new Date('2026-01-01T00:00:00.000Z') }],
+      images: [image(101), image(HOST_IMAGE)],
+    });
+    placementFindMany.mockResolvedValue([queueRow(1, 101, '2026-01-01T00:00:00.000Z')]);
+
+    await ask({ limit: 2 });
+
+    const placerSelect = placementFindMany.mock.calls[0][0].select.placer.select;
+    // Named individually so a revert says which one went missing. `deletedAt`
+    // is in here because the avatar and the username both branch on it and a
+    // deleted placer would otherwise render as a live one.
+    for (const field of ['profilePicture', 'cosmetics', 'deletedAt'])
+      expect(placerSelect, `placer select is missing ${field}`).toHaveProperty(field);
+  });
+
   it('takes the cursor from the last row of the page, not the last row it returns', async () => {
     // Three rows for a page of two: the third is the "is there more" probe. Row
     // 2 is selected but dropped afterwards for an unreadable payload — exactly

--- a/src/server/services/__tests__/remix-gallery.service.test.ts
+++ b/src/server/services/__tests__/remix-gallery.service.test.ts
@@ -8,6 +8,7 @@ import {
 import type * as MetricHelpers from '~/server/utils/metric-helpers';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import type { HybridNode } from '~/__tests__/mocks/hybrid';
 
 const updateEntityMetricDetached = vi.fn(async () => undefined);
@@ -1443,16 +1444,18 @@ describe('getPendingRemixGallerySubmissions paging', () => {
    * fine: `UserAvatar` takes `Partial<UserWithCosmetics>`, so dropping the three
    * keys below is invisible to tsc and shows up only as a wrong-looking avatar.
    *
-   * `User.image` is what the queue used to send, and it is a dead column — of
-   * the 121 distinct placers on this surface in production, 0 have it set and 93
-   * have a `profilePicture`. So the old select handed the avatar null for every
-   * placer alive, and stripped the equipped cosmetics of 61 of them.
+   * `User.image` is what the queue used to send, and it is a dead column:
+   * measured 2026-08-27, 0 of the 121 distinct placers on this surface had it
+   * set and 93 had a `profilePicture`. So the old select handed the avatar null
+   * for every placer alive, and stripped the equipped cosmetics of 61 of them.
+   * Those counts are a snapshot and nothing rechecks them; the ratio is not
+   * what makes this true — a null `image` renders initials at any ratio.
    *
    * Asserted on the ARGUMENT rather than on a returned row: the Prisma mock
    * ignores `select` and hands back whatever the fixture holds, so an assertion
    * made on the result passes with any select at all.
    */
-  it('sends the placer fields the avatar renders, not just id and username', async () => {
+  it('sends the placer fields the avatar renders (here for the paging fixtures)', async () => {
     // A populated page, because the service returns before it ever reaches
     // `findMany` on an empty one — the default `beforeEach` state would make
     // this assert against a call that never happened.
@@ -1470,6 +1473,15 @@ describe('getPendingRemixGallerySubmissions paging', () => {
     // deleted placer would otherwise render as a live one.
     for (const field of ['profilePicture', 'cosmetics', 'deletedAt'])
       expect(placerSelect, `placer select is missing ${field}`).toHaveProperty(field);
+
+    // The loop above is existence-only, and the mutation that actually breaks
+    // the avatar keeps all three names: an inlined `cosmetics: true` returns
+    // UserCosmetic scalars with no nested `cosmetic`, so every frame and badge
+    // silently vanishes while `toHaveProperty` stays green. Compared against
+    // the imported selector rather than a copy of its shape, so this cannot
+    // drift from what production sends. `toEqual`, not `toBe`, so a spread of
+    // the same selector still passes.
+    expect(placerSelect).toEqual(userWithCosmeticsSelect);
   });
 
   it('takes the cursor from the last row of the page, not the last row it returns', async () => {

--- a/src/server/services/remix-gallery.service.ts
+++ b/src/server/services/remix-gallery.service.ts
@@ -16,6 +16,7 @@ import { holdPlacementEscrow, settlePlacement } from '~/server/services/placemen
 import { assertCanPlace } from '~/server/services/placement-moderation.service';
 import { getPlacementConfig } from '~/server/services/placement.service';
 import { resolvePlacementSpaceFor } from '~/server/services/placement-space.service';
+import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { imageReviewedSql } from '~/server/common/image-visibility';
 import type { QueueImage as SharedQueueImage } from '~/server/utils/queue-image';
 import { toQueueImage } from '~/server/utils/queue-image';
@@ -1784,7 +1785,7 @@ export async function getPendingRemixGallerySubmissions({
       data: true,
       createdAt: true,
       expiresAt: true,
-      placer: { select: { id: true, username: true, image: true } },
+      placer: { select: userWithCosmeticsSelect },
     },
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
   });


### PR DESCRIPTION
@
The owner review queue in the remix gallery manage modal rendered every submitter as bare initials with no cosmetics.

## Cause

`getPendingRemixGallerySubmissions` selected `placer: { id, username, image }`. `UserAvatar` reads `profilePicture`, `cosmetics` and `deletedAt` — none were sent. It takes `Partial<UserWithCosmetics>`, so the narrow shape type-checked and nothing failed.

`User.image` is a dead column. Across all 121 distinct placers on this surface in production:

| | count |
|---|---|
| placers | 121 |
| with legacy `User.image` | 0 |
| with `profilePicture` | 93 |
| with equipped cosmetics | 61 |

So the avatar fell back to a column that is null for every placer alive, and 61 of them also lost their equipped frame and badges.

## Fix

`placer: { select: userWithCosmeticsSelect }` — the selector the rest of the app uses for this.

## Scope

This is the only `UserAvatar` consumer among the remix-gallery and placement components. The similar narrow selects nearby are not the same bug and are left alone: `sticker-placement.service.ts:1035` feeds a queue that renders `placer?.username` as text, `sticker-book.service.ts:212` feeds a grid that passes `userId=` and lets `UserAvatar` fetch the user itself, and `sticker-placement.service.ts:538` already uses this selector.

## Test

`sends the placer fields the avatar renders, not just id and username`, named for the decision because the narrow select type-checked. It asserts on the `findMany` argument rather than on a returned row — the Prisma mock ignores `select`, so an assertion on the result would pass with any select at all.

Positive control: reverting the select to `{ id, username, image }` fails it in ~0.5s with `AssertionError: placer select is missing profilePicture: expected { id: true, username: true, ...(1) } to have property "profilePicture"`, with the other 142 in the file still passing.

## Verification

- `pnpm run typecheck` -> `OK - 0 type errors in 196s`, exit 0
- `pnpm run lint` -> exit 1 with 360 pre-existing errors repo-wide; zero on either file here
- `pnpm run test:unit:run` -> `Test Files 1465 passed | 1 skipped (1466)`, `Tests 22949 passed | 28 skipped (22977)`, exit 0
- `blocks.router.workflow.test.ts` collected 358 tests, so the submodule was initialised

## Known, not fixed here

`RemixGallerySettings.tsx:52` calls this procedure with `{}` only to draw a count badge, so it now also pays the profile-picture join and the cosmetics subquery for 50 users it never renders. That call already fetches a full page of rows, raw-queries the submission and host images, loads the placement config and computes per-row earnings, all discarded for a number — the right fix is a count procedure, not a narrower select here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@