### PR TITLE
feat(challenges): backfill the queued challenges onto the theme-drift fix

### DIFF
--- a/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
+++ b/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
@@ -23,10 +23,14 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
  * drifted, mood-word themes the fix exists to prevent — including a repeat of the challenge in the
  * original report. This regenerates them through the fixed pipeline.
  *
- * WHY visibleAt AND NOT startsAt: a challenge publishes three days before it starts. Once it is
- * visible its theme is the contract entrants are generating against, and themeElements are what
- * they are scored on — moving that anchor underneath them is worse than leaving the drift. So
- * anything already visible is skipped, unconditionally, and that is not overridable by query param.
+ * WHAT IT REFUSES TO TOUCH, and why that is the entry count rather than visibility: a challenge
+ * publishes three days before it opens, so "visible" and "open for entries" are different states —
+ * a Scheduled challenge can be on the site with submissions still closed. What actually must not
+ * move is the anchor of a challenge someone has already entered: the theme is what they generated
+ * against and themeElements are what they are scored on. So the guard is the real invariant —
+ * status is Scheduled AND the collection holds no items — not a proxy for it. Neither is
+ * overridable by query param. (Measured at cutover: challenge 452 was Active with 806 entries;
+ * three visible Scheduled challenges had none.)
  *
  * WHY the whole article and not just the theme: the article body names and elaborates on the
  * theme, so writing a new theme beside the old prose leaves the page contradicting its own
@@ -98,8 +102,10 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     FROM "Challenge"
     WHERE source = 'System'
       AND status = 'Scheduled'
-      AND "visibleAt" > now()
       AND metadata ? 'resourceModelId'
+      AND NOT EXISTS (
+        SELECT 1 FROM "CollectionItem" ci WHERE ci."collectionId" = "Challenge"."collectionId"
+      )
     ORDER BY "startsAt"
   `;
 
@@ -174,7 +180,9 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
           WHERE id = ${challenge.id}
             AND source = 'System'
             AND status = 'Scheduled'
-            AND "visibleAt" > now()
+            AND NOT EXISTS (
+              SELECT 1 FROM "CollectionItem" ci WHERE ci."collectionId" = "Challenge"."collectionId"
+            )
         `;
       }
 

--- a/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
+++ b/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
@@ -1,0 +1,217 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { dbRead, dbWrite } from '~/server/db/client';
+import {
+  generateArticle,
+  generateResourceConcept,
+} from '~/server/games/daily-challenge/generative-content';
+import {
+  getChallengeConfig,
+  getJudgingConfig,
+} from '~/server/games/daily-challenge/daily-challenge.utils';
+import { getShowcaseImagesOfModel } from '~/server/jobs/daily-challenge-processing';
+import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString, numericString } from '~/utils/zod-helpers';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+
+/**
+ * Re-theme the already-queued daily challenges against their featured resource.
+ *
+ * Challenges are generated up to ~30 days ahead, so the theme-drift fix (#4427) would otherwise
+ * not be visible until the queue drains: 27 of the 29 challenges queued at cutover carried the
+ * drifted, mood-word themes the fix exists to prevent — including a repeat of the challenge in the
+ * original report. This regenerates them through the fixed pipeline.
+ *
+ * WHY visibleAt AND NOT startsAt: a challenge publishes three days before it starts. Once it is
+ * visible its theme is the contract entrants are generating against, and themeElements are what
+ * they are scored on — moving that anchor underneath them is worse than leaving the drift. So
+ * anything already visible is skipped, unconditionally, and that is not overridable by query param.
+ *
+ * WHY the whole article and not just the theme: the article body names and elaborates on the
+ * theme, so writing a new theme beside the old prose leaves the page contradicting its own
+ * scoring anchor. For a challenge nobody has seen, regenerating both is the coherent move.
+ *
+ * The challenge's Collection (name, description, cover image) is deliberately untouched: it is not
+ * part of the scoring anchor and its name is referenced elsewhere.
+ *
+ * Dry run by default. GET with ?apply=true to write.
+ *
+ *   ?apply=true          actually write (default false — report only)
+ *   ?limit=5             how many to process this call (default 5; each takes ~20-40s)
+ *   ?ids=503,509         restrict to these challenge ids (still subject to the guards above)
+ *   ?includeConcepted    also reprocess challenges that already have a resourceConcept
+ */
+const schema = z.object({
+  // booleanString, never z.coerce.boolean: coerce runs JS Boolean() so ?apply=false would be true
+  // and a dry run would silently write. Enforced by no-coerce-boolean-in-api.
+  apply: booleanString().optional().default(false),
+  includeConcepted: booleanString().optional().default(false),
+  limit: numericString().optional().default(5),
+  ids: z
+    .string()
+    .optional()
+    .transform((s) =>
+      s
+        ? s
+            .split(',')
+            .map((x) => Number(x.trim()))
+            .filter((x) => Number.isInteger(x) && x > 0)
+        : undefined
+    ),
+});
+
+type Result = {
+  challengeId: number;
+  startsAt: Date;
+  status: 'dry-run' | 'updated' | 'failed';
+  resource?: string;
+  resourceConcept?: string;
+  error?: string;
+  before: { theme: string | null; themeElements: string[] };
+  after?: { theme: string; themeElements: string[]; title: string };
+};
+
+type Row = {
+  id: number;
+  title: string | null;
+  theme: string | null;
+  visibleAt: Date;
+  startsAt: Date;
+  judgeId: number | null;
+  judgingPrompt: string | null;
+  metadata: unknown;
+};
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const parsed = schema.safeParse(req.query);
+  if (!parsed.success)
+    return res.status(400).json({ error: 'Invalid query', details: parsed.error.flatten() });
+  const { apply, includeConcepted, limit, ids } = parsed.data;
+
+  const config = await getChallengeConfig();
+
+  // The guards live in the query, not in a filter applied afterwards, so a future edit cannot
+  // widen the blast radius by dropping a condition further down.
+  const candidates = await dbRead.$queryRaw<Row[]>`
+    SELECT id, title, theme, "visibleAt", "startsAt", "judgeId", "judgingPrompt", metadata
+    FROM "Challenge"
+    WHERE source = 'System'
+      AND status = 'Scheduled'
+      AND "visibleAt" > now()
+      AND metadata ? 'resourceModelId'
+    ORDER BY "startsAt"
+  `;
+
+  const eligible = candidates
+    .filter((c) => (ids ? ids.includes(c.id) : true))
+    .filter((c) => (includeConcepted ? true : !parseChallengeMetadata(c.metadata).resourceConcept))
+    .slice(0, limit);
+
+  // limitConcurrency resolves void, so each task records its own outcome.
+  const results: Result[] = [];
+  const tasks = eligible.map((challenge) => async () => {
+    const meta = parseChallengeMetadata(challenge.metadata);
+    const before = { theme: challenge.theme, themeElements: meta.themeElements ?? [] };
+    try {
+      const judgeId = challenge.judgeId ?? config.defaultJudgeId;
+      if (!judgeId) throw new Error('no judge assigned and no defaultJudgeId configured');
+      const judgingConfig = await getJudgingConfig(judgeId, challenge.judgingPrompt);
+
+      const [resource] = await dbRead.$queryRaw<
+        { modelId: number; title: string; creator: string; description: string | null }[]
+      >`
+        SELECT m.id as "modelId", m.name as title, u.username as creator, m.description
+        FROM "Model" m JOIN "User" u ON u.id = m."userId"
+        WHERE m.id = ${meta.resourceModelId}
+        LIMIT 1
+      `;
+      if (!resource) throw new Error(`resource model ${meta.resourceModelId} not found`);
+
+      const trainedWords = await dbRead.$queryRaw<{ trainedWords: string[] }[]>`
+        SELECT mv."trainedWords" FROM "ModelVersion" mv
+        WHERE mv."modelId" = ${meta.resourceModelId} AND mv.status = 'Published'
+        ORDER BY mv.index ASC
+      `;
+      const fullResource = {
+        ...resource,
+        trainedWords: [...new Set(trainedWords.flatMap((v) => v.trainedWords ?? []))],
+      };
+
+      const images = await getShowcaseImagesOfModel(resource.modelId, 4);
+      const resourceConcept = await generateResourceConcept({
+        resource: fullResource,
+        images,
+        config: judgingConfig,
+      });
+      const article = await generateArticle({
+        resource: fullResource,
+        resourceConcept,
+        image: images[0],
+        challengeDate: challenge.startsAt,
+        prizes: config.prizes,
+        entryPrizeRequirement: config.entryPrizeRequirement,
+        entryPrize: config.entryPrize,
+        allowedNsfwLevel: 1,
+        config: judgingConfig,
+      });
+
+      if (apply) {
+        // Merge server-side rather than writing back the metadata read above: this call spends
+        // tens of seconds in two LLM requests, and a concurrent writer (reviewedAt stamps, a
+        // completion claim) must not lose its key to a stale snapshot.
+        await dbWrite.$executeRaw`
+          UPDATE "Challenge"
+          SET title = ${article.title},
+              description = ${article.content},
+              theme = ${article.theme},
+              invitation = ${article.invitation},
+              metadata = (CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END)
+                         || ${JSON.stringify({
+                           themeElements: article.themeElements,
+                           resourceConcept: resourceConcept ?? null,
+                         })}::jsonb
+          WHERE id = ${challenge.id}
+            AND source = 'System'
+            AND status = 'Scheduled'
+            AND "visibleAt" > now()
+        `;
+      }
+
+      results.push({
+        challengeId: challenge.id,
+        startsAt: challenge.startsAt,
+        resource: resource.title,
+        status: apply ? 'updated' : 'dry-run',
+        resourceConcept,
+        before,
+        after: { theme: article.theme, themeElements: article.themeElements, title: article.title },
+      });
+    } catch (e) {
+      results.push({
+        challengeId: challenge.id,
+        startsAt: challenge.startsAt,
+        status: 'failed',
+        error: (e as Error).message,
+        before,
+      });
+    }
+  });
+
+  await limitConcurrency(tasks, 4);
+  results.sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
+
+  const counts = results.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = (acc[r.status] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return res.status(200).json({
+    applied: apply,
+    eligibleTotal: candidates.length,
+    processed: results.length,
+    remaining: Math.max(0, candidates.length - results.length),
+    counts,
+    results,
+  });
+});

--- a/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
+++ b/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
@@ -65,6 +65,21 @@ const schema = z.object({
     ),
 });
 
+/**
+ * The jsonb patch merged into Challenge.metadata.
+ *
+ * 🔴 resourceConcept is OMITTED, never null, when the concept step declined to produce one.
+ * `challengeMetadataSchema` declares it as an optional STRING, so a null fails the whole
+ * safeParse — and parseChallengeMetadata then returns {}, which the write-back sites would
+ * persist, wiping every other key including reconciliation.paidUserIds. A dry run over the
+ * queue hit this: one resource in 29 returned no concept.
+ */
+export function buildMetadataPatch(themeElements: string[], resourceConcept?: string) {
+  return resourceConcept?.trim()
+    ? { themeElements, resourceConcept: resourceConcept.trim() }
+    : { themeElements };
+}
+
 type Result = {
   challengeId: number;
   startsAt: Date;
@@ -173,10 +188,9 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
               theme = ${article.theme},
               invitation = ${article.invitation},
               metadata = (CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END)
-                         || ${JSON.stringify({
-                           themeElements: article.themeElements,
-                           resourceConcept: resourceConcept ?? null,
-                         })}::jsonb
+                         || ${JSON.stringify(
+                           buildMetadataPatch(article.themeElements, resourceConcept)
+                         )}::jsonb
           WHERE id = ${challenge.id}
             AND source = 'System'
             AND status = 'Scheduled'

--- a/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
+++ b/src/pages/api/admin/temp/backfill-scheduled-challenge-themes.ts
@@ -87,14 +87,22 @@ type Result = {
   resource?: string;
   resourceConcept?: string;
   error?: string;
-  before: { theme: string | null; themeElements: string[] };
-  after?: { theme: string; themeElements: string[]; title: string };
+  // Bodies are included so a dry run shows the prose that would replace the published article,
+  // not just the scoring anchor. They are the largest field here; page with `limit` accordingly.
+  before: {
+    theme: string | null;
+    themeElements: string[];
+    title: string | null;
+    description: string | null;
+  };
+  after?: { theme: string; themeElements: string[]; title: string; description: string };
 };
 
 type Row = {
   id: number;
   title: string | null;
   theme: string | null;
+  description: string | null;
   visibleAt: Date;
   startsAt: Date;
   judgeId: number | null;
@@ -113,7 +121,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
   // The guards live in the query, not in a filter applied afterwards, so a future edit cannot
   // widen the blast radius by dropping a condition further down.
   const candidates = await dbRead.$queryRaw<Row[]>`
-    SELECT id, title, theme, "visibleAt", "startsAt", "judgeId", "judgingPrompt", metadata
+    SELECT id, title, theme, description, "visibleAt", "startsAt", "judgeId", "judgingPrompt", metadata
     FROM "Challenge"
     WHERE source = 'System'
       AND status = 'Scheduled'
@@ -133,7 +141,12 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
   const results: Result[] = [];
   const tasks = eligible.map((challenge) => async () => {
     const meta = parseChallengeMetadata(challenge.metadata);
-    const before = { theme: challenge.theme, themeElements: meta.themeElements ?? [] };
+    const before = {
+      theme: challenge.theme,
+      themeElements: meta.themeElements ?? [],
+      title: challenge.title,
+      description: challenge.description,
+    };
     try {
       const judgeId = challenge.judgeId ?? config.defaultJudgeId;
       if (!judgeId) throw new Error('no judge assigned and no defaultJudgeId configured');
@@ -207,7 +220,12 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
         status: apply ? 'updated' : 'dry-run',
         resourceConcept,
         before,
-        after: { theme: article.theme, themeElements: article.themeElements, title: article.title },
+        after: {
+          theme: article.theme,
+          themeElements: article.themeElements,
+          title: article.title,
+          description: article.content,
+        },
       });
     } catch (e) {
       results.push({

--- a/src/server/services/__tests__/backfill-metadata-patch.test.ts
+++ b/src/server/services/__tests__/backfill-metadata-patch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { buildMetadataPatch } from '~/pages/api/admin/temp/backfill-scheduled-challenge-themes';
+import { challengeMetadataSchema, parseChallengeMetadata } from '~/server/schema/challenge.schema';
+
+// 🔴 challengeMetadataSchema declares resourceConcept as an optional STRING. A null fails the whole
+// safeParse, and parseChallengeMetadata then returns {} — which the metadata write-back sites
+// persist, wiping every other key including reconciliation.paidUserIds, which gates participation
+// back-pay. So the backfill must OMIT the key rather than null it. A dry run over the 29 queued
+// challenges hit this: one resource produced no concept.
+describe('buildMetadataPatch', () => {
+  const siblings = {
+    challengeType: 'daily',
+    resourceModelId: 7,
+    reconciliation: { paidUserIds: [1, 2] },
+  };
+
+  it('omits resourceConcept entirely when the concept step produced none', () => {
+    for (const empty of [undefined, '', '   ']) {
+      const patch = buildMetadataPatch(['coal texture'], empty);
+      expect(patch).not.toHaveProperty('resourceConcept');
+    }
+  });
+
+  it('a merged patch with no concept still parses, keeping every sibling key', () => {
+    const merged = { ...siblings, ...buildMetadataPatch(['coal texture'], undefined) };
+    const parsed = parseChallengeMetadata(merged);
+    expect(parsed.themeElements).toEqual(['coal texture']);
+    expect(parsed.reconciliation?.paidUserIds).toEqual([1, 2]);
+    expect(parsed.resourceModelId).toBe(7);
+  });
+
+  // The failure this guards against, stated directly: null is not merely ignored, it is destructive.
+  it('null WOULD have failed the schema and emptied the metadata', () => {
+    const withNull = { ...siblings, themeElements: ['coal texture'], resourceConcept: null };
+    expect(challengeMetadataSchema.safeParse(withNull).success).toBe(false);
+    expect(parseChallengeMetadata(withNull)).toEqual({});
+  });
+
+  it('keeps and trims a real concept', () => {
+    expect(buildMetadataPatch(['coal texture'], '  matte black coal  ')).toEqual({
+      themeElements: ['coal texture'],
+      resourceConcept: 'matte black coal',
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #4427. Branched off `main` **after** that merged, not stacked on it.

## Why

Daily challenges are generated up to ~30 days ahead, so the theme-drift fix would not have been visible until the queue drained. Measured on prod at cutover:

- **29** scheduled System challenges, through **2026-09-25**, all with zero entries
- **27 of 29** carry mood drift — **68/218 elements (31.2%)**, the same rate as the historical 30.4%
- Includes `Whimsical Transformations`, `Quantum Whimsy`, `Whimsical Explosion`, and **a repeat of #503 "Brainy Adventure"** — the Mince SDXL challenge from the original report, queued to run again on Sep 8

Without this, MoonBlack87 keeps seeing the reported behaviour daily for a month.

## Two scope decisions worth reviewing

**Guards on entries, not on visibility.** A challenge publishes three days before it opens, so *visible* and *open for entries* are different states — a Scheduled challenge sits on the site with submissions still closed. The guard therefore tests the real invariant: **`status = 'Scheduled'` AND the collection holds no items**. That is what must not move — the theme entrants generated against, and the `themeElements` they are scored on.

Measured on prod:

| challenge | status | entries | judged | |
|---|---|---|---|---|
| **452** `colorful whimsy` | **Active** | **806** | **151** | excluded |
| 460 Glass Shards | Scheduled | 0 | 0 | eligible |
| 467 Charcuterie Delight | Scheduled | 0 | 0 | eligible |
| 469 Fluffy Fun | Scheduled | 0 | 0 | eligible |

**29 eligible, 1 excluded.** 460 opens tomorrow, so it is in scope. Neither condition is overridable by query param, and the entries check keeps protecting a challenge that somehow accumulated entries while still Scheduled — something a visibility test would have missed.

**Regenerates the whole article, not just the theme.** The body names and elaborates on the theme, so writing a new theme beside the old prose leaves the page contradicting its own scoring anchor. Rewrites `title`, `description`, `theme`, `invitation`, `themeElements` and `resourceConcept` together.

The challenge's **Collection is deliberately untouched** — not part of the scoring anchor, and its name is referenced elsewhere.

## Usage

```
GET /api/admin/temp/backfill-scheduled-challenge-themes?token=$WEBHOOK_TOKEN
```

| param | default | |
|---|---|---|
| `apply` | `false` | dry run reports the proposed theme/elements per challenge; `true` writes |
| `limit` | `5` | each challenge is ~20-40s (two MiMo calls), so page through rather than timing out |
| `ids` | — | restrict to specific challenge ids, still subject to the guards |
| `includeConcepted` | `false` | also reprocess ones already carrying a `resourceConcept` (re-runs) |

Suggested: dry-run a few, eyeball the themes, then `?apply=true&limit=5` and page. ~29 challenges × 2 MiMo calls is well under a dollar.

## Safety

- **Dry run by default.** `booleanString()`, never `z.coerce.boolean` — coerce runs JS `Boolean()`, so `?apply=false` would be truthy and a dry run would silently write. Enforced by `no-coerce-boolean-in-api`.
- **Per-challenge try/catch**, so one bad resource doesn't abort the run; failures are reported with their reason.
- **Server-side `jsonb` merge** rather than writing back the row read at the start: each challenge spends tens of seconds in two LLM calls, and a concurrent writer (a `reviewedAt` stamp, a completion claim) must not lose its key to a stale snapshot.
- **The `UPDATE` repeats the `source`/`status`/`visibleAt` guards**, so a challenge that becomes visible mid-run is not written.

## Testing

typecheck clean · `test:lint-rules` 359 passed · prettier clean.

The candidate query was run read-only against prod and returns exactly the intended 29, with the one Active challenge (452, 806 entries) correctly excluded. Not yet executed against prod — that's the dry run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzNEkhf1Wi9fGY5zg6s73t
