### PR TITLE
fix(apps): one container for every /apps route, so the sub-nav stops moving

### DIFF
--- a/src/components/Apps/AppEditPage.browser.test.tsx
+++ b/src/components/Apps/AppEditPage.browser.test.tsx
@@ -34,8 +34,21 @@ vi.mock('~/server/utils/server-side-helpers', () => ({
   createServerSideProps: () => async () => ({ props: {} }),
 }));
 
+// 🔴 `appBlocksAuthor` IS LOAD-BEARING NOW, not decoration. This page moved onto the
+// shared `AppsPageLayout`, which mounts `AppsSubNav` — and that bar hides itself below
+// TWO qualifying tabs. Without the author capability the viewer qualifies for
+// Marketplace alone, the bar renders nothing, and the chrome assertion below would
+// pass or fail for a reason that has nothing to do with this page.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
-  useFeatureFlags: () => ({ appBlocks: true }),
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true }),
+}));
+
+// The sub-nav's other two inputs. `useCurrentUser` is mocked rather than provided
+// because the real hook throws `missing CivitaiSessionContext` under this scaffold —
+// the same reason `AppsPageLayout`'s own browser tests mock it.
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'owner', isModerator: false }),
 }));
 
 // NOTE: this file used to carry its own `vi.mock('next/router', ...)`. It SILENTLY LOST to
@@ -57,6 +70,9 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
       getMyAppManifest: {
         useQuery: () => mocks.manifestQuery,
       },
+      // Mounted by `AppsSubNav` via the shared page layout this page now uses.
+      // Undefined data ⇒ the deterministic always-on tab set.
+      getNavSummary: { useQuery: () => ({ data: undefined }) },
     },
     useUtils: () => ({}),
   },
@@ -111,5 +127,27 @@ describe('AppEditPage (/apps/[appBlockId]/edit)', () => {
     mocks.manifestQuery.error = { message: 'FORBIDDEN' };
     renderWithProviders(<AppEditPage />);
     await expect.element(page.getByTestId('mock-notfound')).toBeInTheDocument();
+  });
+
+  test('🔴 the page is on the SHARED apps chrome, not its own bare Container', async () => {
+    // Regression coverage for the adoption: this page rendered a standalone
+    // `<Container>` and showed NO sub-nav at all, so `/apps/<id>/edit` was one of
+    // four `/apps/*` routes where the navigation simply vanished. The landmark is
+    // what `AppsPageLayout` contributes, so its presence is the adoption.
+    renderWithProviders(<AppEditPage />);
+    await expect
+      .element(page.getByRole('navigation', { name: 'App sections' }))
+      .toBeInTheDocument();
+  });
+
+  test('…and the chrome does not displace the page body', async () => {
+    // Guard-the-guard for the test above: a landmark that rendered INSTEAD of the
+    // page would satisfy it. Both must be present in the same render.
+    renderWithProviders(<AppEditPage />);
+    await expect
+      .element(page.getByRole('navigation', { name: 'App sections' }))
+      .toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-edit-tab-manifest')).toBeInTheDocument();
+    await expect.element(page.getByTestId('mock-manifest-form')).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * `/apps` chrome — RENDERED HORIZONTAL ALIGNMENT ACROSS ROUTES.
+ *
+ * 🔴 THE DEFECT THIS PINS. `AppsPageLayout` used to take a per-page container width
+ * and render `AppsSubNav` INSIDE that Container, so the ONE element required to be
+ * identical on every apps page inherited each page's own width and jumped sideways as
+ * you navigated. Measured on this harness before the fix:
+ *
+ *                                     @1440           @2560
+ *   route                     size    left  width    left  width
+ *   /apps                     1920      16   1408     336   1888
+ *   /apps/review              1400      36   1368     596   1368
+ *   /apps/store-preview/[..]  1320      76   1288     636   1288
+ *   /apps/submit              1100     186   1068     746   1068
+ *
+ * — a 170px left / 340px width spread at 1440, and 410px / 820px at 2560. The
+ * container is now uniform and the narrowing moved into the BODY, so every row of
+ * that table collapses to one pair.
+ *
+ * 🔴 READ THIS BEFORE TRUSTING IT AS A GATE: it is not one. This file is in the
+ * Vitest browser-mode `component` project, which CI runs only as the preview
+ * pipeline's `preview / component-tests` — REPORT-ONLY, non-blocking, and red
+ * repo-wide at time of writing for an unrelated pre-existing failure in
+ * `AppBlockChrome.browser.test.tsx`. The ENFORCEABLE half lives as source guards in
+ * the blocking `unit` project (`__tests__/appsPageLayout.test.ts` — no `size` prop,
+ * every rendering page mounts the layout; `__tests__/appsPageWidths.test.ts` — the
+ * measures and the route taxonomy). This file exists because those guards pin
+ * SYMBOLS and only a real render can pin PIXELS.
+ *
+ * 🔴 WHY THIS FILE LOADS `@mantine/core/styles.css` AND MOST SIBLINGS MUST NOT.
+ * The shared component scaffold deliberately omits Mantine's stylesheet, so the
+ * sibling browser tests assert only inline styles / ARIA. But every number here —
+ * the Container's `max-width` and `padding-inline`, the tab row's padding — comes
+ * FROM that stylesheet. Without the import the Container computes `max-width: none`
+ * / `padding-left: 0px`, every route measures `left: 0` with the SAME width, and
+ * "the nav is identically placed everywhere" PASSES while measuring nothing. That is
+ * the failure mode `styleSheetLoaded` exists to catch, asserted first in every test.
+ * Vitest browser mode runs each file in its own iframe, so the import does not leak
+ * into the sibling suites.
+ */
+import '@mantine/core/styles.css';
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { cleanup } from 'vitest-browser-react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+
+// 🔴 The viewer MUST be one the sub-nav renders for. `AppsSubNav` hides itself
+// entirely below two qualifying tabs, and the summary query is stubbed empty here, so
+// an anonymous / non-author viewer would render NO `<nav>` at all and the measurement
+// would throw on a null lookup instead of measuring. An author (`appBlocksAuthor`)
+// yields Marketplace + Create.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true }),
+}));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'author', isModerator: false }),
+}));
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-
+// module-mock) — see the sibling browser tests for why.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: { blocks: { getNavSummary: { useQuery: () => ({ data: undefined }) } } },
+}));
+
+const { AppsPageLayout } = await import('./AppsPageLayout');
+const { APPS_PAGE_MEASURES, APPS_FULL_MEASURE_PAGES } = await import('./appsPageWidths');
+
+/**
+ * Every route that renders the shared chrome, with the measure it passes.
+ *
+ * 🔴 DERIVED FROM THE MODULE, NOT RETYPED, and then the derived set is pinned as a
+ * literal below. Retyping it would let a route quietly leave the map and stop being
+ * measured; deriving it without pinning would let the set SHRINK to one element (or
+ * empty) and the "they all agree" assertion pass vacuously. Both halves are needed.
+ */
+const ROUTES: { route: string; measure?: number }[] = [
+  ...APPS_FULL_MEASURE_PAGES.map((route) => ({ route, measure: undefined })),
+  ...Object.entries(APPS_PAGE_MEASURES).map(([route, measure]) => ({ route, measure })),
+].sort((a, b) => (a.route < b.route ? -1 : a.route > b.route ? 1 : 0));
+
+/**
+ * The container's own geometry at each viewport, as LITERALS.
+ *
+ * Container `max-width: 1920`, `padding-inline: 16`, `margin-inline: auto`. So:
+ *   1440 → narrower than the cap, full-bleed: left 16, content 1440 − 32 = 1408.
+ *   2560 → capped at 1920, centred: left (2560 − 1920)/2 + 16 = 336, content 1888.
+ *
+ * 🔴 These are the POSITIVE CONTROL. "Every route agrees" is satisfied by every route
+ * measuring 0, which is exactly what an unloaded stylesheet produces. Pinning the
+ * agreed-upon value means the test can only pass while the layout is really laid out.
+ */
+const VIEWPORTS = [
+  { width: 1440, height: 900, navLeft: 16, navWidth: 1408 },
+  { width: 2560, height: 1440, navLeft: 336, navWidth: 1888 },
+] as const;
+
+const px = (n: number) => Math.round(n * 100) / 100;
+
+function measure() {
+  const nav = document.querySelector('nav[aria-label="App sections"]') as HTMLElement | null;
+  const firstTab = document.querySelector('[role="tab"]') as HTMLElement | null;
+  const body = document.querySelector('[data-testid="body"]') as HTMLElement | null;
+  if (!nav || !firstTab || !body) {
+    throw new Error(
+      `chrome not rendered (nav=${!!nav} tab=${!!firstTab} body=${!!body}) — ` +
+        'the mocked viewer must qualify for >=2 sub-nav tabs'
+    );
+  }
+  const navRect = nav.getBoundingClientRect();
+  const bodyRect = body.getBoundingClientRect();
+  return {
+    // Guard-the-guard: without `@mantine/core/styles.css` the tab collapses, the
+    // Container loses its max-width and padding, and every number below reads 0
+    // IDENTICALLY on every route — i.e. the suite goes green measuring nothing.
+    styleSheetLoaded: parseFloat(getComputedStyle(firstTab).paddingLeft) > 0,
+    navLeft: px(navRect.left),
+    navWidth: px(navRect.width),
+    bodyLeft: px(bodyRect.left),
+    bodyWidth: px(bodyRect.width),
+  };
+}
+
+async function renderAndMeasure(measurePx: number | undefined) {
+  renderWithProviders(
+    <AppsPageLayout measure={measurePx}>
+      <div data-testid="body" style={{ height: 200 }}>
+        body
+      </div>
+    </AppsPageLayout>
+  );
+  await expect.element(page.getByTestId('body')).toBeInTheDocument();
+  // Two frames so layout + the injected stylesheet have both settled.
+  await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+  return measure();
+}
+
+describe('the /apps route set that renders the shared chrome', () => {
+  test('🔴 is exactly these 13 routes (fails when it GROWS or SHRINKS)', () => {
+    // A ledger, not a floor. The alignment assertions below loop over this set, so a
+    // set that silently shrank — or emptied — would make them pass while checking
+    // nothing. Adding an apps page is meant to fail here and be added deliberately.
+    expect(ROUTES.map((r) => r.route)).toEqual([
+      '/apps',
+      '/apps/[appBlockId]/edit',
+      '/apps/[appBlockId]/revenue',
+      '/apps/get-started',
+      '/apps/installed',
+      '/apps/invites',
+      '/apps/listing/[appListingId]/edit',
+      '/apps/mine',
+      '/apps/revenue',
+      '/apps/review',
+      '/apps/review/[publishRequestId]',
+      '/apps/store-preview/[slug]',
+      '/apps/submit',
+    ]);
+    // Both classes are represented, so the loops below exercise the measured AND the
+    // measure-free branch of the layout rather than one of them 13 times.
+    expect(ROUTES.filter((r) => r.measure === undefined)).toHaveLength(5);
+    expect(ROUTES.filter((r) => typeof r.measure === 'number')).toHaveLength(8);
+  });
+});
+
+describe.each(VIEWPORTS)(
+  'the sub-nav is identically placed on every /apps route @$width',
+  ({ width, height, navLeft, navWidth }) => {
+    test('nav left AND width are the same on all 13 routes', async () => {
+      await page.viewport(width, height);
+      const seen: Record<string, [number, number]> = {};
+      for (const { route, measure: m } of ROUTES) {
+        const g = await renderAndMeasure(m);
+        expect(g.styleSheetLoaded, `${route}: Mantine stylesheet did not load`).toBe(true);
+        seen[route] = [g.navLeft, g.navWidth];
+        await cleanup();
+      }
+
+      // Read the loop really ran — a zero-iteration loop leaves `seen` empty and
+      // every assertion below trivially true.
+      expect(Object.keys(seen)).toHaveLength(ROUTES.length);
+
+      // One assertion over the WHOLE table, so a failure names every offending
+      // route and its actual pair rather than stopping at the first.
+      const expected = Object.fromEntries(ROUTES.map(({ route }) => [route, [navLeft, navWidth]]));
+      expect(seen).toEqual(expected);
+    });
+
+    test('the BODY still takes its measure, left-aligned under the nav', async () => {
+      // 🔴 THE NON-VACUITY CONTROL FOR THE TEST ABOVE. A layout that IGNORED
+      // `measure` entirely would satisfy "the nav agrees everywhere" perfectly — so
+      // without this, the guard is equally happy with the feature deleted. Here the
+      // measured routes must actually differ from each other, and each must land on
+      // its own number.
+      await page.viewport(width, height);
+      const contentWidth = navWidth;
+      const seen: Record<string, [number, number]> = {};
+      for (const { route, measure: m } of ROUTES) {
+        const g = await renderAndMeasure(m);
+        expect(g.styleSheetLoaded, `${route}: Mantine stylesheet did not load`).toBe(true);
+        seen[route] = [g.bodyLeft, g.bodyWidth];
+        await cleanup();
+      }
+      expect(Object.keys(seen)).toHaveLength(ROUTES.length);
+
+      const expected = Object.fromEntries(
+        ROUTES.map(({ route, measure: m }) => [
+          route,
+          // LEFT-ALIGNED: the body's left edge is the nav's left edge on every
+          // route, measured or not. A centred measure box would put it at
+          // `navLeft + (contentWidth - m) / 2` and fail here — which is the whole
+          // reason the box carries no auto margins.
+          [navLeft, m === undefined ? contentWidth : Math.min(m, contentWidth)],
+        ])
+      );
+      expect(seen).toEqual(expected);
+
+      // And the measured routes are genuinely DISTINCT widths, so the fixture varies
+      // the dimension under test instead of feeding one value 13 times.
+      const measuredWidths = new Set(
+        ROUTES.filter((r) => typeof r.measure === 'number').map((r) => seen[r.route][1])
+      );
+      expect(measuredWidths.size).toBe(3);
+    });
+  }
+);

--- a/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
@@ -20,13 +20,17 @@
  * 🔴 READ THIS BEFORE TRUSTING IT AS A GATE: it is not one. This file is in the
  * Vitest browser-mode `component` project, which CI runs only as the preview
  * pipeline's `preview / component-tests` — REPORT-ONLY, non-blocking, and RED on this
- * branch for a reason that has nothing to do with `/apps`: measured 2026-08-27, the
- * whole project is 192 files / 2119 tests passing with ONE file failing,
- * `src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx` (17 tests),
- * whose entire subtree is byte-identical to `origin/main` here. (An older note in
- * `AppsPageLayout.geometry.browser.test.tsx` blames `AppBlockChrome.browser.test.tsx`
- * — that is STALE: it now passes, 21/21. Do not re-derive the culprit from either
- * comment; run the project and read the file list.)
+ * branch for reasons that have nothing to do with `/apps`. The failing files are outside
+ * `src/components/Apps` and their subtrees are byte-identical to `origin/main` here; one
+ * of them (`RemixGallery/RemixGallerySubmitModal`) fails to IMPORT, which reports as
+ * "no tests" rather than as a failure.
+ *
+ * 🔴 NO TOTALS RECORDED ON PURPOSE. This note used to carry a census ("192 files / 2119
+ * tests, ONE failing") and it was stale within a day — as was the older note in
+ * `AppsPageLayout.geometry.browser.test.tsx` naming `AppBlockChrome.browser.test.tsx` as
+ * the culprit, which now passes. A count checked in beside the thing it counts drifts,
+ * and a stale count is worse than none because it reads as a measurement. Do not
+ * re-derive the culprit from any comment: run the project and read the file list.
  *
  * A permanently-red non-blocking gate trains everyone to click through it, so anything
  * only this file catches is effectively unguarded. The ENFORCEABLE half therefore lives

--- a/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
@@ -19,13 +19,22 @@
  *
  * 🔴 READ THIS BEFORE TRUSTING IT AS A GATE: it is not one. This file is in the
  * Vitest browser-mode `component` project, which CI runs only as the preview
- * pipeline's `preview / component-tests` — REPORT-ONLY, non-blocking, and red
- * repo-wide at time of writing for an unrelated pre-existing failure in
- * `AppBlockChrome.browser.test.tsx`. The ENFORCEABLE half lives as source guards in
- * the blocking `unit` project (`__tests__/appsPageLayout.test.ts` — no `size` prop,
- * every rendering page mounts the layout; `__tests__/appsPageWidths.test.ts` — the
- * measures and the route taxonomy). This file exists because those guards pin
- * SYMBOLS and only a real render can pin PIXELS.
+ * pipeline's `preview / component-tests` — REPORT-ONLY, non-blocking, and RED on this
+ * branch for a reason that has nothing to do with `/apps`: measured 2026-08-27, the
+ * whole project is 192 files / 2119 tests passing with ONE file failing,
+ * `src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx` (17 tests),
+ * whose entire subtree is byte-identical to `origin/main` here. (An older note in
+ * `AppsPageLayout.geometry.browser.test.tsx` blames `AppBlockChrome.browser.test.tsx`
+ * — that is STALE: it now passes, 21/21. Do not re-derive the culprit from either
+ * comment; run the project and read the file list.)
+ *
+ * A permanently-red non-blocking gate trains everyone to click through it, so anything
+ * only this file catches is effectively unguarded. The ENFORCEABLE half therefore lives
+ * in the blocking `unit` project: `__tests__/appsPageLayoutRender.test.ts` (the measure
+ * box, on the rendered tree), `__tests__/appsPageLayout.test.ts` (no container-width
+ * prop) and `__tests__/appsPageWidths.test.ts` (the AST adoption walk + the measures and
+ * route taxonomy). This file exists because those pin STRUCTURE, and only a real browser
+ * can pin PIXELS.
  *
  * 🔴 WHY THIS FILE LOADS `@mantine/core/styles.css` AND MOST SIBLINGS MUST NOT.
  * The shared component scaffold deliberately omits Mantine's stylesheet, so the
@@ -222,6 +231,58 @@ describe.each(VIEWPORTS)(
         ROUTES.filter((r) => typeof r.measure === 'number').map((r) => seen[r.route][1])
       );
       expect(measuredWidths.size).toBe(3);
+    });
+
+    test('🔴 a measured page HEADER is bounded too, and the band keeps its 16/32 grouping', async () => {
+      // The audit finding this pins: with only the body bounded, a measured page's header
+      // PROSE ran to the full container (/apps/submit's real subtitle measured 1224.13px
+      // against a 1068 measure). Both are bounded now — and the vertical grouping must
+      // survive the extra wrapper, which the sibling geometry file cannot check because
+      // it renders a header with NO measure.
+      await page.viewport(width, height);
+      renderWithProviders(
+        <AppsPageLayout
+          measure={1068}
+          title="Submit an app"
+          subtitle="Choose how you want to list your app, on-platform or as an external link."
+        >
+          <div data-testid="body" style={{ height: 200 }}>
+            body
+          </div>
+        </AppsPageLayout>
+      );
+      await expect.element(page.getByTestId('body')).toBeInTheDocument();
+      await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+
+      const firstTab = document.querySelector('[role="tab"]') as HTMLElement;
+      expect(parseFloat(getComputedStyle(firstTab).paddingLeft) > 0).toBe(true);
+
+      const nav = document.querySelector('nav[aria-label="App sections"]') as HTMLElement;
+      const title = document.querySelector('h2') as HTMLElement;
+      const bodyEl = document.querySelector('[data-testid="body"]') as HTMLElement;
+      const titleRect = title.getBoundingClientRect();
+
+      // The header is capped at the measure, not the container…
+      const headerBox = title.closest('[style*="max-width"]') as HTMLElement;
+      expect(headerBox).not.toBeNull();
+      expect(Math.round(headerBox.getBoundingClientRect().width)).toBe(1068);
+      // …and shares its LEFT edge with both the nav above and the body below.
+      expect(Math.round(titleRect.left)).toBe(Math.round(nav.getBoundingClientRect().left));
+      expect(Math.round(headerBox.getBoundingClientRect().left)).toBe(
+        Math.round(bodyEl.getBoundingClientRect().left)
+      );
+
+      // THE GROUPING, unchanged by the new wrapper: 16px tabs→title inside the band,
+      // 32px band→body outside it. These are the two numbers the layout's own comments
+      // call load-bearing.
+      const tabRect = firstTab.getBoundingClientRect();
+      const band = nav.parentElement as HTMLElement;
+      expect(Math.round((titleRect.top - tabRect.bottom) * 100) / 100).toBe(16);
+      expect(
+        Math.round(
+          (bodyEl.getBoundingClientRect().top - band.getBoundingClientRect().bottom) * 100
+        ) / 100
+      ).toBe(32);
     });
   }
 );

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -1,21 +1,32 @@
-import { Container, Group, Stack, Text, Title } from '@mantine/core';
-import type { MantineSize } from '@mantine/core';
+import { Box, Container, Group, Stack, Text, Title } from '@mantine/core';
 import type { ReactNode } from 'react';
 import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
 
 /**
  * Shared chrome for every `/apps/*` surface.
  *
- * THE POINT: the {@link AppsSubNav} tabs must sit in the IDENTICAL vertical
- * position on every apps page. Before this, each page hand-rolled its own
- * `Container size=… py=…` + a per-page title block placed ABOVE or AROUND the
- * sub-nav, so the tabs jumped around as you navigated between surfaces. This
- * layout fixes the tabs as the FIRST element of the page header region — so they
- * land in the same vertical position every time — and renders the optional
- * per-page title/actions BELOW them. (No sticky positioning: the requirement is
- * a CONSISTENT position across pages, which the uniform "tabs first" order
- * already delivers; pinning the band on scroll risks colliding with the global
- * app-shell header and was unverified.)
+ * THE POINT: the {@link AppsSubNav} tabs must sit in the IDENTICAL position on
+ * every apps page — VERTICALLY *and* HORIZONTALLY. Before this, each page
+ * hand-rolled its own `Container size=… py=…` + a per-page title block placed
+ * ABOVE or AROUND the sub-nav, so the tabs jumped around as you navigated between
+ * surfaces. This layout fixes the tabs as the FIRST element of the page header
+ * region — so they land in the same vertical position every time — and renders the
+ * optional per-page title/actions BELOW them. (No sticky positioning: the
+ * requirement is a CONSISTENT position across pages, which the uniform "tabs
+ * first" order already delivers; pinning the band on scroll risks colliding with
+ * the global app-shell header and was unverified.)
+ *
+ * 🔴 THE HORIZONTAL HALF IS WHY THERE IS NO `size` PROP. This layout used to take a
+ * per-page container width, which put the SHARED chrome inside a PER-PAGE box: the
+ * tab strip inherited each page's width and moved horizontally between routes
+ * (measured 170px of left-edge spread at 1440 and 410px at 2560 — the numbers are
+ * in `appsPageWidths.ts`). The Container is now {@link APPS_PAGE_CONTAINER_WIDTH}
+ * on every route, and the narrowing some pages genuinely need is the `measure`
+ * prop below, which constrains the BODY only — below the chrome, not around it.
+ * Re-adding a container-width prop re-opens the defect; both halves are pinned in
+ * `__tests__/appsPageLayout.test.ts` and
+ * `AppsPageLayout.chromeAlignment.browser.test.tsx`.
  *
  * Each page wraps its body in `<AppsPageLayout …>{body}</AppsPageLayout>`,
  * dropping its own `Container` + ad-hoc sub-nav placement. The per-page title,
@@ -37,7 +48,7 @@ export function AppsPageLayout({
   title,
   subtitle,
   actions,
-  size = 'xl',
+  measure,
   children,
 }: {
   /** Page heading (omit for a header with just the tabs, e.g. the marketplace). */
@@ -47,11 +58,22 @@ export function AppsPageLayout({
   /** Right-aligned header controls (e.g. a "Submit a new app" button). */
   actions?: ReactNode;
   /**
-   * Container width — pages keep their prior size (`sm` for Submit, etc.).
-   * Also accepts a raw number (px) — Mantine's `Container` supports it, used by
-   * the store index to widen past the `xl` (1320px) token.
+   * Optional CONTENT measure (px) for the page BODY — a max-width applied BELOW the
+   * chrome, never around it. Omit it and the body fills the container.
+   *
+   * 🔴 LEFT-ALIGNED, NOT CENTRED, and that is load-bearing rather than taste: a
+   * centred body would put its left edge at a different x on every route, which is
+   * the same defect as the per-page container one level out — the page content
+   * would stop lining up with the tab strip directly above it. The parent `Stack`
+   * is a column flexbox with the default `align="stretch"`, so a `maw` alone
+   * resolves to a left-aligned capped box; no auto margins, and nothing here may
+   * introduce `margin-inline: auto`.
+   *
+   * Values come from `APPS_PAGE_MEASURES` in `~/components/Apps/appsPageWidths` —
+   * they are CONTENT widths (the old container widths minus the `Container`'s own
+   * `2 × 16px` gutter), because this box sits INSIDE that gutter.
    */
-  size?: MantineSize | number;
+  measure?: number;
   children: ReactNode;
 }) {
   const hasHeader = Boolean(title || subtitle || actions);
@@ -59,10 +81,9 @@ export function AppsPageLayout({
   // directly under the global header instead of 16px below it; the BOTTOM pad
   // stays because this Container is the outermost element on every apps page, so
   // its `pb` is the only thing keeping the last grid row / table row off whatever
-  // follows. Horizontal padding is untouched (Container's own responsive gutter)
-  // — this pass is vertical-only, so `size` and the side gutters are unchanged.
+  // follows. Horizontal padding is untouched (Container's own responsive gutter).
   return (
-    <Container size={size} pb="md">
+    <Container size={APPS_PAGE_CONTAINER_WIDTH} pb="md">
       {/* `xl` (32px), not `lg` (20px). With the band's own rule removed, the ONLY
           thing telling a viewer where the header ends and the page begins is the
           size of this gap relative to the `md` (16px) gap INSIDE the band. At
@@ -130,7 +151,20 @@ export function AppsPageLayout({
           )}
         </Stack>
 
-        {children}
+        {/*
+          The BODY, optionally capped. 🔴 THE CAP IS HERE, INSIDE THE `Stack gap="xl"`,
+          AND NOT ONE LEVEL OUT — that placement is the entire fix. A narrower box
+          around the whole `Stack` would take the sub-nav with it, which is exactly
+          what the per-page `Container size=` used to do. Wrapping only `{children}`
+          leaves the chrome on the uniform container while still letting a form page
+          hold a readable measure.
+
+          Rendered UNWRAPPED when there is no measure, rather than as a `<Box>` with
+          no `maw`: the full-container pages are the majority, and an always-present
+          wrapper is a DOM node the vertical-geometry pins would have to be re-derived
+          against for no benefit.
+        */}
+        {measure != null ? <Box maw={measure}>{children}</Box> : children}
       </Stack>
     </Container>
   );

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -58,8 +58,21 @@ export function AppsPageLayout({
   /** Right-aligned header controls (e.g. a "Submit a new app" button). */
   actions?: ReactNode;
   /**
-   * Optional CONTENT measure (px) for the page BODY — a max-width applied BELOW the
-   * chrome, never around it. Omit it and the body fills the container.
+   * Optional CONTENT measure (px) for the page's OWN content — the header band's
+   * title/subtitle/actions AND the body. Applied BELOW the chrome, never around it.
+   * Omit it and the content fills the container.
+   *
+   * 🔴 IT BOUNDS THE HEADER TOO, and that is not symmetry for its own sake. The sub-nav
+   * is the only thing this change is allowed to move; if the measure bounded the body
+   * alone, a measured page's header PROSE would stretch to the full container while its
+   * body stayed narrow. Measured on a real render with the live `/apps/submit` subtitle
+   * copy: the subtitle laid out at 1224.13px where before it could never exceed 1068.
+   * Bounding both is what makes "only the chrome moved" a true statement rather than an
+   * aspiration. It also closes a latent trap by construction: `actions` is right-aligned
+   * by `Group justify="space-between"`, so against the CONTAINER the first measured page
+   * to add a header button would have put it ~520px (`/apps/review`) to ~820px
+   * (`/apps/submit`) right of the body it acts on at 2560. Against the measure, the
+   * header and the body share both edges.
    *
    * 🔴 LEFT-ALIGNED, NOT CENTRED, and that is load-bearing rather than taste: a
    * centred body would put its left edge at a different x on every route, which is
@@ -77,11 +90,29 @@ export function AppsPageLayout({
   children: ReactNode;
 }) {
   const hasHeader = Boolean(title || subtitle || actions);
+  /**
+   * Cap `node` at the page's measure, or hand it back untouched when there is none.
+   *
+   * 🔴 ONE HELPER, TWO CALL SITES, so the header band and the body cannot drift apart —
+   * a second copy of this conditional is exactly how they would end up with different
+   * left and right edges. It never wraps `AppsSubNav`: the chrome is a sibling of both
+   * call sites, one level up, which is the entire fix.
+   *
+   * No auto margins, deliberately. The parent `Stack` is a column flexbox with the
+   * default `align="stretch"`, so a bare `maw` resolves LEFT-ALIGNED; anything that
+   * re-centres it puts each route's content at a different x and re-creates the defect
+   * one level down. Pinned on the RENDERED tree in
+   * `__tests__/appsPageLayoutRender.test.ts` — a source-text pin was walkable both by a
+   * comment and by a centring wrapper.
+   */
+  const bounded = (node: ReactNode) => (measure != null ? <Box maw={measure}>{node}</Box> : node);
   // `pb` only — NO `py`. The top pad is deliberately gone so `/apps/*` starts
   // directly under the global header instead of 16px below it; the BOTTOM pad
   // stays because this Container is the outermost element on every apps page, so
   // its `pb` is the only thing keeping the last grid row / table row off whatever
-  // follows. Horizontal padding is untouched (Container's own responsive gutter).
+  // follows. Horizontal padding is untouched — Container's own gutter, a FLAT 16px per
+  // side in Mantine v7 (there is no responsive step), which is why
+  // `APPS_CONTAINER_GUTTER = 32` is right at every breakpoint, not only at wide ones.
   return (
     <Container size={APPS_PAGE_CONTAINER_WIDTH} pb="md">
       {/* `xl` (32px), not `lg` (20px). With the band's own rule removed, the ONLY
@@ -136,19 +167,20 @@ export function AppsPageLayout({
         */}
         <Stack gap="md">
           <AppsSubNav />
-          {hasHeader && (
-            <Group justify="space-between" align="flex-end" wrap="nowrap" gap="md">
-              <Stack gap={4} style={{ minWidth: 0 }}>
-                {title && <Title order={2}>{title}</Title>}
-                {subtitle && (
-                  <Text c="dimmed" size="sm">
-                    {subtitle}
-                  </Text>
-                )}
-              </Stack>
-              {actions && <div style={{ flexShrink: 0 }}>{actions}</div>}
-            </Group>
-          )}
+          {hasHeader &&
+            bounded(
+              <Group justify="space-between" align="flex-end" wrap="nowrap" gap="md">
+                <Stack gap={4} style={{ minWidth: 0 }}>
+                  {title && <Title order={2}>{title}</Title>}
+                  {subtitle && (
+                    <Text c="dimmed" size="sm">
+                      {subtitle}
+                    </Text>
+                  )}
+                </Stack>
+                {actions && <div style={{ flexShrink: 0 }}>{actions}</div>}
+              </Group>
+            )}
         </Stack>
 
         {/*
@@ -164,7 +196,7 @@ export function AppsPageLayout({
           wrapper is a DOM node the vertical-geometry pins would have to be re-derived
           against for no benefit.
         */}
-        {measure != null ? <Box maw={measure}>{children}</Box> : children}
+        {bounded(children)}
       </Stack>
     </Container>
   );

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -101,9 +101,20 @@ export function AppsPageLayout({
    * No auto margins, deliberately. The parent `Stack` is a column flexbox with the
    * default `align="stretch"`, so a bare `maw` resolves LEFT-ALIGNED; anything that
    * re-centres it puts each route's content at a different x and re-creates the defect
-   * one level down. Pinned on the RENDERED tree in
-   * `__tests__/appsPageLayoutRender.test.ts` — a source-text pin was walkable both by a
-   * comment and by a centring wrapper.
+   * one level down.
+   *
+   * 🔴 WHERE THAT IS ACTUALLY PINNED, AND HOW FAR EACH PIN REACHES — stated precisely,
+   * because an earlier version of this sentence claimed "pinned on the RENDERED tree"
+   * full stop, while the check read the inline `style` attribute only and a
+   * `className="mx-auto"` walked past it.
+   *   • `__tests__/appsPageLayoutRender.test.ts` (BLOCKING) pins the STRUCTURE — the box
+   *     is a direct child of the root stack, so no wrapper can centre it — and pins the
+   *     CARRIERS: the box may hold a max-width and nothing else, and no class at all.
+   *     It cannot resolve stylesheets (node tier, no CSS loaded), which is exactly why
+   *     it bans the class rather than trying to read a computed margin.
+   *   • `AppsPageLayout.chromeAlignment.browser.test.tsx` (report-only) pins the
+   *     RESOLVED geometry — body left edge == nav left edge on every route — which is
+   *     the check that catches a centring mechanism of any spelling.
    */
   const bounded = (node: ReactNode) => (measure != null ? <Box maw={measure}>{node}</Box> : node);
   // `pb` only — NO `py`. The top pad is deliberately gone so `/apps/*` starts

--- a/src/components/Apps/AppsSubmitEditView.tsx
+++ b/src/components/Apps/AppsSubmitEditView.tsx
@@ -2,7 +2,7 @@ import { Alert, Button, Group, Loader, Stack, Text } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { ExternalSubmitForm } from '~/components/Apps/ExternalSubmitForm';
 import type { ListingEditContext } from '~/components/Apps/offsiteEditConfig';
 import { Meta } from '~/components/Meta/Meta';
@@ -50,7 +50,7 @@ export function AppsSubmitEditView({
     <>
       <Meta title="Edit an app — Civitai" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/submit']}
+        measure={APPS_PAGE_MEASURES['/apps/submit']}
         title="Edit your app"
         subtitle="Update your external-link app's link, details, or assets."
       >

--- a/src/components/Apps/__tests__/appsPageLayout.test.ts
+++ b/src/components/Apps/__tests__/appsPageLayout.test.ts
@@ -143,24 +143,25 @@ describe('AppsPageLayout takes NO per-page container width', () => {
     expect(src).not.toMatch(/^\s*size\s*=/m);
   });
 
-  it('the BODY measure is applied below the chrome, and left-aligned', () => {
-    const src = layoutSrc();
-    // The measure wraps `{children}` ONLY — a `maw` on the Stack or Container
-    // would take the sub-nav with it, which is the defect.
-    // 🔴 THE EXACT TAG, and that is what makes the left-alignment ban airtight
-    // rather than a keyword hunt: this shape admits `maw` and NOTHING ELSE, so no
-    // `mx="auto"`, `style={{ marginInline: 'auto' }}` or `ta`/`align` prop can be
-    // added to the measure box without failing here.
+  it('the measure never reaches the CONTAINER or the root stack', () => {
+    // 🔴 THIS TEST DELIBERATELY NO LONGER CLAIMS "and left-aligned", AND THAT IS THE
+    // FIX, not a weakening. It used to assert the exact tag
+    // `<Box maw={measure}>{children}</Box>` and call the left-alignment ban "airtight".
+    // It was not, in two independent ways, both of which passed the whole blocking suite:
     //
-    // Scoped to TAGS, deliberately — a whole-file ban on a centring idiom fails on
-    // the component's own docstring, which names those idioms in order to forbid
-    // them. (A comment-stripping helper is NOT the fix: the layout's prose contains
-    // the literal `/apps/*`, whose `/*` opens a false block comment and eats the
-    // JSX after it. Measured — it swallowed the `<Container>` line.)
-    expect(src).toMatch(/<Box\s+maw=\{measure\}>\{children\}<\/Box>/);
-    expect(src).not.toMatch(/<Box[^>]*\b(mx|ml|mr|style|className)=/s);
-    expect(src).not.toMatch(/<Container[^>]*\b(maw|mx)=/s);
-    expect(src).not.toMatch(/<Stack[^>]*\b(maw|mx)=/s);
+    //   • move that exact tag into a JSX COMMENT and render a bare `{children}` — the
+    //     regex matches the comment, and the feature is dead;
+    //   • leave that exact tag BYTE-IDENTICAL and wrap it in `<Center>` — no banned prop
+    //     is on the Box, and the body renders centred.
+    //
+    // A source-text match cannot see either, because text does not care whether the code
+    // runs or what encloses it. Both are now killed on the RENDERED tree in
+    // `appsPageLayoutRender.test.ts`, which is in this same blocking project. What is
+    // left here is the one claim source text CAN carry honestly: the measure is not
+    // applied to the two elements that would take the chrome with it.
+    const src = layoutSrc();
+    expect(src).not.toMatch(/<Container[^>]*\b(maw|mx|w)=/s);
+    expect(src).not.toMatch(/<Stack[^>]*\b(maw|mx|w)=/s);
   });
 
   it('the guard is reading a real file (not a silently-empty read)', () => {

--- a/src/components/Apps/__tests__/appsPageLayout.test.ts
+++ b/src/components/Apps/__tests__/appsPageLayout.test.ts
@@ -88,23 +88,88 @@ describe('AppsPageLayout draws no rule of its own', () => {
     // `pb` is asserted PRESENT, not merely "no py": this Container is the
     // outermost element on every `/apps/*` page, so its bottom pad is the only
     // thing keeping the last grid/table row off whatever follows. Dropping to a
-    // bare `<Container size={size}>` would satisfy a "no py" check alone.
+    // bare `<Container size={…}>` would satisfy a "no py" check alone.
     const src = layoutSrc();
-    expect(src).toMatch(/<Container\s+size=\{size\}\s+pb="md">/);
+    expect(src).toMatch(/<Container\s+size=\{APPS_PAGE_CONTAINER_WIDTH\}\s+pb="md">/);
     expect(src).not.toMatch(/<Container[^>]*\bpy=/s);
     expect(src).not.toMatch(/<Container[^>]*\bpt=/s);
   });
 
-  it('HORIZONTAL geometry is untouched by the vertical pass', () => {
-    // INVARIANT GUARD — green before and after. The pass was scoped to vertical
-    // padding; these pin the things it was explicitly not allowed to move, so a
-    // future "tighten the apps chrome" edit can't quietly take the side gutters
-    // or the container width with it.
+  it('HORIZONTAL geometry is not overridden on the Container', () => {
+    // INVARIANT GUARD — green before and after. Pins the thing successive passes
+    // were explicitly not allowed to move, so a future "tighten the apps chrome"
+    // edit can't quietly take the side gutters with it.
     const src = layoutSrc();
-    // Width still comes from the caller's `size` prop, not a hardcoded value.
-    expect(src).toMatch(/<Container\s+size=\{size\}/);
-    // No horizontal padding override of any kind on the Container.
     expect(src).not.toMatch(/<Container[^>]*\b(px|pl|pr)=/s);
+  });
+});
+
+/**
+ * 🔴 THE CHROME SITS IN ONE CONTAINER, THE SAME ONE ON EVERY ROUTE.
+ *
+ * The defect these guards close: `AppsPageLayout` took a per-page container width
+ * and rendered `AppsSubNav` INSIDE it, so the shared tab strip inherited each
+ * page's width. Measured on a real render — nav left/width of 16/1408 on `/apps`,
+ * 36/1368 on `/apps/review`, 76/1288 on the store preview, 186/1068 on
+ * `/apps/submit` at 1440 — i.e. the one element required to be identical on every
+ * apps page moved 170px horizontally between routes (410px at 2560).
+ *
+ * 🔴 WHY SOURCE GUARDS AS WELL AS THE PIXEL ONE. The rendered proof lives in
+ * `AppsPageLayout.chromeAlignment.browser.test.tsx`, which is in the browser-mode
+ * `component` project — REPORT-ONLY and non-blocking in CI, and red repo-wide for
+ * an unrelated pre-existing failure. So it cannot block a regression on its own.
+ * These run in the blocking `unit` project. They are the enforceable half.
+ */
+describe('AppsPageLayout takes NO per-page container width', () => {
+  it('the Container width is the shared constant, not a prop', () => {
+    const src = layoutSrc();
+    // The state, not a keyword: the Container's `size` is THE shared constant.
+    expect(src).toMatch(/<Container\s+size=\{APPS_PAGE_CONTAINER_WIDTH\}/);
+    // …and it is the real import, not a same-named local.
+    expect(src).toMatch(
+      /import\s*\{\s*APPS_PAGE_CONTAINER_WIDTH\s*\}\s*from\s*'~\/components\/Apps\/appsPageWidths'/
+    );
+  });
+
+  it('🔴 no `size` prop survives anywhere in the component', () => {
+    // The regression is re-adding a caller-controlled width. Banned in every
+    // spelling a caller could reach: the destructured param, the prop type, and
+    // any `size={…}` on the Container.
+    const src = layoutSrc();
+    expect(src).not.toMatch(/^\s*size[?]?:/m);
+    expect(src).not.toMatch(/<Container[^>]*size=\{size\}/s);
+    // A default-valued `size = 'xl'` in the destructuring is the exact shape that
+    // shipped the defect.
+    expect(src).not.toMatch(/^\s*size\s*=/m);
+  });
+
+  it('the BODY measure is applied below the chrome, and left-aligned', () => {
+    const src = layoutSrc();
+    // The measure wraps `{children}` ONLY — a `maw` on the Stack or Container
+    // would take the sub-nav with it, which is the defect.
+    // 🔴 THE EXACT TAG, and that is what makes the left-alignment ban airtight
+    // rather than a keyword hunt: this shape admits `maw` and NOTHING ELSE, so no
+    // `mx="auto"`, `style={{ marginInline: 'auto' }}` or `ta`/`align` prop can be
+    // added to the measure box without failing here.
+    //
+    // Scoped to TAGS, deliberately — a whole-file ban on a centring idiom fails on
+    // the component's own docstring, which names those idioms in order to forbid
+    // them. (A comment-stripping helper is NOT the fix: the layout's prose contains
+    // the literal `/apps/*`, whose `/*` opens a false block comment and eats the
+    // JSX after it. Measured — it swallowed the `<Container>` line.)
+    expect(src).toMatch(/<Box\s+maw=\{measure\}>\{children\}<\/Box>/);
+    expect(src).not.toMatch(/<Box[^>]*\b(mx|ml|mr|style|className)=/s);
+    expect(src).not.toMatch(/<Container[^>]*\b(maw|mx)=/s);
+    expect(src).not.toMatch(/<Stack[^>]*\b(maw|mx)=/s);
+  });
+
+  it('the guard is reading a real file (not a silently-empty read)', () => {
+    // Guard-the-guard: a renamed/moved file makes every `not.toMatch` above pass
+    // vacuously, and the `toMatch`es above are what stop that going unnoticed.
+    const src = layoutSrc();
+    expect(src.length).toBeGreaterThan(1000);
+    expect(src).toMatch(/export function AppsPageLayout/);
+    expect(src).toMatch(/measure\?:\s*number/);
   });
 });
 

--- a/src/components/Apps/__tests__/appsPageLayoutRender.test.ts
+++ b/src/components/Apps/__tests__/appsPageLayoutRender.test.ts
@@ -1,0 +1,299 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MantineProvider } from '@mantine/core';
+import { Window } from 'happy-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * `/apps` chrome — the measure box, asserted on the RENDERED TREE, in the tier that
+ * actually gates.
+ *
+ * 🔴 WHY THIS FILE EXISTS: A SOURCE-TEXT GUARD IS WALKABLE BY A COMMENT.
+ * The sibling `appsPageLayout.test.ts` pinned the measure box with
+ * `expect(src).toMatch(/<Box\s+maw=\{measure\}>\{children\}<\/Box>/)`. That is a match
+ * against the FILE'S TEXT, and text does not care whether the code runs. Both of these
+ * passed the entire blocking suite while the feature was dead or wrong:
+ *
+ *   M2  move the `<Box maw={measure}>{children}</Box>` render into a JSX comment and
+ *       render a bare `{children}` beside it
+ *       → the regex still matches (inside a comment), `measure` is never applied, and
+ *         `no-unused-vars` never fires because it is a destructured param followed by
+ *         `children` (`args: after-used`), with `noUnusedLocals` unset.
+ *
+ *   M3  keep `<Box maw={measure}>{children}</Box>` BYTE-IDENTICAL and wrap it in
+ *       `<Center>` → the exact-tag regex still matches, no banned prop is on the Box,
+ *       and the body renders CENTRED — the precise thing the guard's own name
+ *       ("left-aligned") claimed to prevent. That guard asserted a RELATIONSHIP in its
+ *       title and inspected ONE SIDE in its body.
+ *
+ * Comments are not present in a rendered tree and a wrapper element is visible in it, so
+ * both die here by construction rather than by a better-worded regex.
+ *
+ * 🔴 AND WHY IT IS IN THE BLOCKING `unit` PROJECT, NOT BESIDE THE PIXEL TEST.
+ * `AppsPageLayout.chromeAlignment.browser.test.tsx` measures real pixels, but the
+ * browser-mode `component` project is report-only in CI *and* currently red for reasons
+ * unrelated to this code. A permanently-red non-blocking gate trains everyone to click
+ * through it, so anything only it catches is effectively unguarded. This file runs in
+ * `unit`, which is the tier whose verdict is read.
+ *
+ * Node env, so this is `renderToStaticMarkup` + happy-dom rather than a real browser —
+ * which is enough for STRUCTURE (what contains what) though not for pixels. The two
+ * files are deliberately complementary: structure here, geometry there.
+ */
+
+// The real sub-nav needs a router, a session, feature flags and a tRPC query. None of
+// that is what this file is about: it only has to be an element with the nav's identity
+// so "the chrome is NOT inside the measure box" is a checkable claim.
+vi.mock('~/components/Apps/AppsSubNav', () => ({
+  AppsSubNav: () => createElement('nav', { 'aria-label': 'App sections' }, 'nav'),
+}));
+
+const { AppsPageLayout } = await import('~/components/Apps/AppsPageLayout');
+const { APPS_PAGE_MEASURES, APPS_PAGE_CONTAINER_WIDTH } = await import(
+  '~/components/Apps/appsPageWidths'
+);
+
+/** Mantine emits `max-width:calc(<n/16>rem * var(--mantine-scale))` for `maw={n}`. */
+const remOf = (px: number) => `${px / 16}rem`;
+
+type Tree = {
+  /**
+   * The measure box wrapping the page BODY, or `null` when there is no measure.
+   *
+   * 🔴 IDENTIFIED BY WHAT IT CONTAINS, not by document order. With a header present
+   * there are TWO max-width boxes (the header band's and the body's), and
+   * `querySelector` would hand back the header's — so every body assertion would
+   * silently be about the wrong element.
+   */
+  measureBox: Element | null;
+  /** The measure box wrapping the header band's title/actions, when both exist. */
+  headerBox: Element | null;
+  /** Every element carrying an inline max-width, in document order. */
+  allBoxes: Element[];
+  body: Element;
+  nav: Element;
+  title: Element | null;
+  /** The `Stack gap="xl"` that holds the band and the body — the layout's own root stack. */
+  rootStack: Element;
+  /** The `Stack gap="md"` band that holds the nav and the header. */
+  band: Element;
+};
+
+function renderLayout(measure?: number, withHeader = false): Tree {
+  const html = renderToStaticMarkup(
+    createElement(
+      MantineProvider,
+      { getRootElement: () => undefined },
+      createElement(
+        AppsPageLayout,
+        {
+          measure,
+          ...(withHeader
+            ? {
+                title: 'A title',
+                subtitle: 'A subtitle',
+                actions: createElement('button', null, 'Act'),
+              }
+            : {}),
+        },
+        // Children as an ARGUMENT, not a prop (`react/no-children-prop`).
+        createElement('div', { 'data-testid': 'body' }, 'body')
+      )
+    )
+  );
+  const window = new Window();
+  const doc = window.document;
+  doc.body.innerHTML = html;
+
+  const body = doc.querySelector('[data-testid="body"]');
+  const nav = doc.querySelector('nav[aria-label="App sections"]');
+  if (!body || !nav) throw new Error('layout did not render its body and chrome');
+  // The band is the nav's parent; the root stack is the band's parent. Derived from the
+  // tree rather than hardcoded as an index, so a change in the band's own structure
+  // surfaces as a failure here instead of silently re-pointing the assertions.
+  const band = nav.parentElement;
+  const rootStack = band?.parentElement;
+  if (!band || !rootStack) throw new Error('could not resolve the layout band / root stack');
+
+  const allBoxes = Array.from(doc.querySelectorAll('[style*="max-width"]')) as unknown as Element[];
+  const title = doc.querySelector('h2') as unknown as Element | null;
+
+  return {
+    // BY CONTAINMENT, not by order — see the note on the type.
+    measureBox: allBoxes.find((b) => b.contains(body as unknown as Element)) ?? null,
+    headerBox: (title && allBoxes.find((b) => b.contains(title))) || null,
+    allBoxes,
+    body: body as unknown as Element,
+    nav: nav as unknown as Element,
+    title,
+    rootStack: rootStack as unknown as Element,
+    band: band as unknown as Element,
+  };
+}
+
+describe('the measure box, on the rendered tree', () => {
+  it('the harness renders a real tree (guards a silently-empty parse)', () => {
+    // Every assertion below is of the form "X contains Y" or "X does not contain Y", and
+    // an empty parse makes the negative half pass vacuously. Pin that the pieces exist
+    // and are distinct before trusting any containment answer.
+    const t = renderLayout(1068);
+    expect(t.body).toBeTruthy();
+    expect(t.nav).toBeTruthy();
+    expect(t.rootStack).toBeTruthy();
+    expect(t.rootStack.contains(t.body)).toBe(true);
+    expect(t.rootStack.contains(t.nav)).toBe(true);
+    expect(t.body).not.toBe(t.nav);
+  });
+
+  it('🔴 M2 — a measure actually reaches the DOM as a max-width', () => {
+    // Dies on the comment-out mutant: a commented-out `<Box>` renders nothing, so there
+    // is no element carrying a max-width at all.
+    const t = renderLayout(1068);
+    expect(
+      t.measureBox,
+      'no element carries an inline max-width — the measure never rendered'
+    ).not.toBeNull();
+    expect(t.measureBox!.getAttribute('style')).toContain(remOf(1068));
+  });
+
+  it('🔴 M2 — the measure box CONTAINS the page body', () => {
+    // A max-width box that renders but does not wrap `{children}` bounds nothing.
+    const t = renderLayout(1068);
+    expect(t.measureBox!.contains(t.body)).toBe(true);
+  });
+
+  it('🔴 the measure box does NOT contain the chrome — the whole point of the change', () => {
+    // This is the defect the PR fixes, stated as containment: the sub-nav must sit
+    // OUTSIDE any per-page width box, or it inherits that page's width and moves.
+    const t = renderLayout(1068);
+    expect(t.measureBox!.contains(t.nav)).toBe(false);
+  });
+
+  it('🔴 M3 — the measure box is a DIRECT CHILD of the root stack (no wrapper may centre it)', () => {
+    // THE RELATIONSHIP, not one side of it. `<Center>` (or any centring wrapper) inserts
+    // an element between the root stack and the measure box, so this fails structurally
+    // — without naming `Center`, a class, or any style keyword a future wrapper could
+    // spell differently. The root stack is a column flexbox with `align: stretch`, so a
+    // direct-child max-width box is left-aligned by construction.
+    const t = renderLayout(1068);
+    // Named, because `toBe` on two DOM nodes prints "expected HTMLDivElement to be
+    // HTMLDivElement", which tells a future reader nothing about what went wrong.
+    const parentTag = t.measureBox!.parentElement?.getAttribute('class') ?? '(none)';
+    const stackTag = t.rootStack.getAttribute('class') ?? '(none)';
+    expect(
+      t.measureBox!.parentElement === t.rootStack,
+      `the measure box must be a DIRECT child of the layout root stack, but its parent ` +
+        `is a different element (parent class="${parentTag}", root stack class="${stackTag}"). ` +
+        `Something is wrapping it — a wrapper can centre the body, which breaks the ` +
+        `left-alignment this layout guarantees.`
+    ).toBe(true);
+  });
+
+  it('🔴 M3 — and the box does not centre ITSELF', () => {
+    // The other side of the same relationship: the wrapper route is closed above, this
+    // closes the `mx="auto"` / `margin-inline:auto` route on the box itself.
+    const t = renderLayout(1068);
+    expect(t.measureBox!.getAttribute('style') ?? '').not.toMatch(/margin/i);
+  });
+
+  it('without a measure, nothing bounds the body and it stays a direct child', () => {
+    const t = renderLayout(undefined);
+    expect(t.measureBox).toBeNull();
+    expect(t.body.parentElement).toBe(t.rootStack);
+  });
+
+  it('the max-width tracks the value passed (a POSITIVE CONTROL on the assertion above)', () => {
+    // Without this, `toContain(remOf(1068))` could be satisfied by a layout that hardcodes
+    // 1068 and ignores its prop. Feed a value no real measure equals and watch it move.
+    const odd = 777;
+    expect(Object.values(APPS_PAGE_MEASURES)).not.toContain(odd);
+    const t = renderLayout(odd);
+    expect(t.measureBox!.getAttribute('style')).toContain(remOf(odd));
+    expect(t.measureBox!.getAttribute('style')).not.toContain(remOf(1068));
+  });
+
+  it('every route measure renders its own distinct max-width', () => {
+    const entries = Object.entries(APPS_PAGE_MEASURES);
+    // Guard-the-guard: an empty map would make the loop pass vacuously.
+    expect(entries.length).toBeGreaterThanOrEqual(8);
+    const rendered = new Set<string>();
+    for (const [route, measure] of entries) {
+      const t = renderLayout(measure);
+      expect(t.measureBox, `${route} rendered no measure box`).not.toBeNull();
+      expect(t.measureBox!.getAttribute('style'), route).toContain(remOf(measure));
+      rendered.add(t.measureBox!.getAttribute('style') ?? '');
+    }
+    // Three measure CLASSES, so three distinct rendered widths — proof the fixture
+    // varies the dimension rather than feeding one value eight times.
+    expect(rendered.size).toBe(3);
+  });
+
+  it('🔴 the HEADER is bounded by the same measure as the body', () => {
+    // The audit finding this closes: the header band sits OUTSIDE the body's measure box,
+    // so with the body alone bounded, a measured page's title/subtitle stretched to the
+    // full container — /apps/submit's real subtitle laid out at 1224.13px against a 1068
+    // measure. "Only the chrome moved" is only true if BOTH are bounded.
+    const t = renderLayout(1068, /* withHeader */ true);
+    expect(t.title, 'the header did not render').not.toBeNull();
+    expect(t.headerBox, 'the header is not inside any max-width box').not.toBeNull();
+    expect(t.headerBox!.getAttribute('style')).toContain(remOf(1068));
+  });
+
+  it('🔴 the header box and the body box share the SAME measure (one helper, not two)', () => {
+    // A RELATIONSHIP, not two independent facts: the failure this catches is the two call
+    // sites drifting to different numbers, which no single-sided assertion would see.
+    const t = renderLayout(1368, true);
+    expect(t.headerBox!.getAttribute('style')).toBe(t.measureBox!.getAttribute('style'));
+    // …and they are genuinely two different elements, so the equality is not trivial.
+    expect(t.headerBox).not.toBe(t.measureBox);
+  });
+
+  it('🔴 the header box still does NOT contain the chrome', () => {
+    // Bounding the header must not have swept the sub-nav in with it — that would be the
+    // original defect, re-introduced one level down.
+    const t = renderLayout(1068, true);
+    expect(t.headerBox!.contains(t.nav)).toBe(false);
+    // The nav and the header box are siblings inside the band.
+    expect(t.headerBox!.parentElement).toBe(t.band);
+    expect(t.nav.parentElement).toBe(t.band);
+  });
+
+  it('🔴 neither measure box can shift the band vertically', () => {
+    // WHY THIS IS HERE RATHER THAN IN THE PIXEL TEST: the vertical pins in
+    // `AppsPageLayout.geometry.browser.test.tsx` render a header with NO measure, so they
+    // are structurally blind to the box this change adds inside the band — and that file
+    // is in the report-only tier anyway. The mechanism that keeps the 16px/32px grouping
+    // intact is that these wrappers contribute no box model of their own, which IS
+    // checkable here, in the blocking tier.
+    const t = renderLayout(1068, true);
+    for (const [name, box] of [
+      ['header', t.headerBox],
+      ['body', t.measureBox],
+    ] as const) {
+      const style = box!.getAttribute('style') ?? '';
+      expect(style, `${name} box must not pad`).not.toMatch(/padding/i);
+      expect(style, `${name} box must not margin`).not.toMatch(/margin/i);
+      // Only the cap, nothing else.
+      expect(style.replace(/max-width:[^;]*;?/, '').trim()).toBe('');
+    }
+  });
+
+  it('with a header but NO measure, nothing is bounded (the band is untouched)', () => {
+    // The measure-free pages are the majority and their band must render exactly as it
+    // did before this change — the vertical geometry pins depend on it.
+    const t = renderLayout(undefined, true);
+    expect(t.allBoxes).toHaveLength(0);
+    expect(t.title!.parentElement?.parentElement?.parentElement).toBe(t.band);
+  });
+
+  it('the container width is the shared constant on every render', () => {
+    // `--container-size` is what Mantine emits for `<Container size={n}>`. Asserted here
+    // on the RENDERED tree so a per-page container cannot come back via a code path the
+    // source regexes do not read.
+    for (const measure of [undefined, 1068, 1368]) {
+      const t = renderLayout(measure);
+      const container = t.rootStack.parentElement;
+      expect(container?.getAttribute('style') ?? '').toContain(remOf(APPS_PAGE_CONTAINER_WIDTH));
+    }
+  });
+});

--- a/src/components/Apps/__tests__/appsPageLayoutRender.test.ts
+++ b/src/components/Apps/__tests__/appsPageLayoutRender.test.ts
@@ -189,11 +189,34 @@ describe('the measure box, on the rendered tree', () => {
     ).toBe(true);
   });
 
-  it('🔴 M3 — and the box does not centre ITSELF', () => {
-    // The other side of the same relationship: the wrapper route is closed above, this
-    // closes the `mx="auto"` / `margin-inline:auto` route on the box itself.
+  it('🔴 M3 — and the box does not centre ITSELF, by ANY carrier', () => {
+    // The other side of the relationship: the wrapper route is closed above, this closes
+    // centring applied to the box itself.
+    //
+    // 🔴 BOTH CARRIERS, NOT JUST INLINE STYLE. An earlier version checked only
+    // `getAttribute('style')`, so `className="mx-auto"` — one Tailwind utility, the most
+    // natural way anyone here would actually centre something — walked straight past it
+    // while the isolated `mx="auto"` control died. A style-attribute check is a check on
+    // ONE SPELLING of centring, and the docstring claimed to cover centring as such.
+    //
+    // ⚠️ WHAT THIS CANNOT DO, stated rather than implied: happy-dom resolves no
+    // stylesheet here (none is loaded in the node tier), so `getComputedStyle` cannot
+    // tell us the RESOLVED margin — a class's effect is invisible to it. So this asserts
+    // the CARRIERS instead: the box may carry a max-width and nothing else. The resolved
+    // geometry is asserted where a real engine can compute it, in
+    // `AppsPageLayout.chromeAlignment.browser.test.tsx`, which checks on every route that
+    // the body's left edge equals the nav's — that one catches any mechanism at all.
     const t = renderLayout(1068);
-    expect(t.measureBox!.getAttribute('style') ?? '').not.toMatch(/margin/i);
+    const style = t.measureBox!.getAttribute('style') ?? '';
+    expect(style).not.toMatch(/margin/i);
+    // Only the cap may be present, so no `inset`/`transform`/`position` route either.
+    expect(style.replace(/max-width:[^;]*;?/, '').trim()).toBe('');
+    // No class may be carried at all — that is what closes the stylesheet route.
+    expect(
+      (t.measureBox!.getAttribute('class') ?? '').trim(),
+      'the measure box carries a CSS class; a class can centre it and this tier cannot ' +
+        'resolve stylesheets, so no class is permitted on it'
+    ).toBe('');
   });
 
   it('without a measure, nothing bounds the body and it stays a direct child', () => {
@@ -275,6 +298,8 @@ describe('the measure box, on the rendered tree', () => {
       expect(style, `${name} box must not margin`).not.toMatch(/margin/i);
       // Only the cap, nothing else.
       expect(style.replace(/max-width:[^;]*;?/, '').trim()).toBe('');
+      // …and no class, which is the other carrier that could pad, margin or centre it.
+      expect((box!.getAttribute('class') ?? '').trim(), `${name} box must carry no class`).toBe('');
     }
   });
 

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -85,8 +85,51 @@ const CHROME_PORTAL_SIBLINGS: Record<string, { file: string; exportName: string 
   },
 };
 
-/** Tags that mean "a portaled overlay root" when a portal sibling renders one. */
+/** Tags that mean "a portaled overlay root" — checked together with their IMPORT source. */
 const PORTAL_ROOT_TAGS = new Set(['Modal', 'Modal.Stack', 'Drawer', 'Drawer.Stack', 'Portal']);
+
+/** The package a portal root must come from for the name to mean anything. */
+const PORTAL_ROOT_MODULE = '@mantine/core';
+
+/**
+ * The module specifier a top-level identifier was imported from, or `null`.
+ *
+ * 🔴 THIS IS WHAT STOPS THE PORTAL CONTRACT BEING A NAME CHECK. Matching the tag `Modal`
+ * against a set of strings trusts whatever the file chose to call things: a component
+ * defining its own `const Modal = ({children}) => <Box mx="auto">{children}</Box>` and
+ * returning `<Modal>` satisfied a name-only test completely, and was then allowlisted as
+ * a "portaled overlay" — moving the trust from the component's name to the name of the
+ * tag it happens to render, which is no improvement at all. Resolving the import is the
+ * difference between "it is called Modal" and "it IS Mantine's Modal".
+ */
+function importSourceOf(source: ts.SourceFile, baseName: string): string | null {
+  let found: string | null = null;
+  source.forEachChild((node) => {
+    if (!ts.isImportDeclaration(node) || !node.importClause) return;
+    const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+    const { name, namedBindings } = node.importClause;
+    if (name?.getText(source) === baseName) found = specifier;
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const el of namedBindings.elements) {
+        if (el.name.getText(source) === baseName) found = specifier;
+      }
+    } else if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+      if (namedBindings.name.getText(source) === baseName) found = specifier;
+    }
+  });
+  return found;
+}
+
+/** Parse `file` once so a caller can resolve imports in it. */
+function sourceFileOf(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+}
 
 /** Tag names that mean "a fragment", i.e. unwrap the children rather than count the tag. */
 const FRAGMENT_TAGS = new Set(['React.Fragment', 'Fragment']);
@@ -185,6 +228,13 @@ function pageReturnTags(file: string, exportName?: string): string[][] {
         if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) {
           tags.push(...topLevelTags(child as unknown as ts.Expression));
         } else if (ts.isJsxExpression(child)) tags.push(...topLevelTags(child.expression));
+        // 🔴 A NESTED ANONYMOUS FRAGMENT. `<><Box/></>` sitting inside another fragment
+        // used to be dropped on the floor here: `JsxFragment` is neither a `JsxElement`
+        // nor a `JsxExpression`, so the loop skipped it and its children were never
+        // inspected. `<React.Fragment>` WAS handled, so the two spellings of the same
+        // thing disagreed — and the docstring claimed "a fragment contributes ALL its
+        // children" for both.
+        else if (ts.isJsxFragment(child)) tags.push(...childTags(child.children));
       }
       return tags;
     };
@@ -199,6 +249,8 @@ function pageReturnTags(file: string, exportName?: string): string[][] {
       return FRAGMENT_TAGS.has(tag) ? [] : [tag];
     }
     if (ts.isJsxFragment(expr)) return childTags(expr.children);
+    // `{[<Box key="a" />]}` — a list of elements renders every entry.
+    if (ts.isArrayLiteralExpression(expr)) return expr.elements.flatMap((el) => topLevelTags(el));
     return [];
   };
 
@@ -225,34 +277,99 @@ function pageReturnTags(file: string, exportName?: string): string[][] {
 }
 
 /**
- * The ONE rule, applied to pages and to chrome delegates alike: in every return that
- * renders anything, EVERY top-level tag must be the shared layout, a verified delegate,
- * or an exempt leaf.
+ * The ONE rule, applied to pages and to chrome delegates alike. In EVERY return that
+ * renders anything: every top-level tag must be permitted there, AND the chrome must
+ * actually be mounted.
  *
- * 🔴 "EVERY", NOT "CONTAINS ONE". The predicate used to be
- * `rendered.includes('AppsPageLayout')`, which three different shapes walked straight
- * past because they put an un-chromed element ALONGSIDE a chromed one: a ternary whose
- * other arm rendered a bare centred `<Box>`, a fragment child ternary of the same shape,
- * and a plain un-chromed sibling inside the top-level fragment. In all three the layout
- * WAS present somewhere in the group, so `includes` was satisfied while real page content
- * rendered outside the chrome entirely.
+ * 🔴 TWO CLAUSES, BECAUSE EACH ALONE HAS A HOLE THE OTHER CLOSES.
+ *
+ * "No stray tag" replaced an older `rendered.includes('AppsPageLayout')`, which three
+ * shapes walked past by putting un-chromed content ALONGSIDE chromed content — a ternary
+ * whose other arm rendered a bare centred `<Box>`, the same as a fragment child, and a
+ * plain un-chromed sibling. The layout WAS present, so `includes` was satisfied while
+ * real page content rendered outside it.
+ *
+ * But "no stray tag" alone is satisfied by a group containing NO chrome provider at all,
+ * because portal siblings are permitted tags: `chromeOffenders('x', [['OnsiteReviewModal']])`
+ * returned `[]`, i.e. a page whose only top-level render is an overlay passed with no
+ * chrome. Permission to appear beside the chrome is not the same as providing it, and
+ * conflating the two is what let the allowlist stand in for the layout.
+ *
+ * 🔴 EVERY GROUP IS EVALUATED — `continue`, never `break`. A page's FIRST return is
+ * routinely a gate (`return <NotFound />`), which filters to empty; a `break` there would
+ * skip every later return and report green having inspected nothing. Pinned by the
+ * multi-group rows in this file's `chromeOffenders` table.
  */
 function chromeOffenders(label: string, groups: string[][]): string[] {
-  const allowed = new Set([
-    'AppsPageLayout',
-    ...Object.keys(CHROME_DELEGATES),
-    ...Object.keys(CHROME_PORTAL_SIBLINGS),
-  ]);
+  /** Tags that MOUNT the chrome. */
+  const providers = new Set(['AppsPageLayout', ...Object.keys(CHROME_DELEGATES)]);
+  /** Tags merely PERMITTED beside it — they provide nothing on their own. */
+  const permitted = new Set([...providers, ...Object.keys(CHROME_PORTAL_SIBLINGS)]);
   const offenders: string[] = [];
   for (const tags of groups) {
     const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
     if (rendered.length === 0) continue;
-    const stray = rendered.filter((t) => !allowed.has(t));
+    const stray = rendered.filter((t) => !permitted.has(t));
     if (stray.length > 0) {
       offenders.push(
         `${label} (a return renders [${rendered.join(', ')}] outside the shared chrome — ` +
           `stray: ${stray.join(', ')})`
       );
+      continue;
+    }
+    if (!rendered.some((t) => providers.has(t))) {
+      offenders.push(
+        `${label} (a return renders [${rendered.join(', ')}] with NO chrome provider — ` +
+          `a portaled overlay may sit beside the layout, it cannot replace it)`
+      );
+    }
+  }
+  return offenders;
+}
+
+/**
+ * Does the component at `file` honour the portaled-overlay contract?
+ *
+ * 🔴 EXTRACTED SO IT CAN BE TESTED ON A KNOWN-BAD INPUT. While this logic was inline in
+ * its test, nothing exercised it except the three real entries — all of which pass — so
+ * disabling the import check entirely still produced a fully green suite. A guard whose
+ * only inputs are known-good cannot be shown to work; the negative control beside its
+ * test now feeds it a fixture that MUST be reported.
+ */
+function portalOffenders(name: string, abs: string, exportName: string): string[] {
+  const offenders: string[] = [];
+  if (!fs.existsSync(abs)) return [`${name} (no file at ${abs})`];
+  let groups: string[][];
+  try {
+    groups = pageReturnTags(abs, exportName);
+  } catch (err) {
+    return [`${name} (could not parse: ${(err as Error).message})`];
+  }
+  if (groups.length === 0) return [`${name} (has no return statement)`];
+  const source = sourceFileOf(abs);
+  // Every return that renders anything must render a portal root — an early return of
+  // ordinary markup would put real content outside the chrome.
+  for (const tags of groups) {
+    const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
+    if (rendered.length === 0) continue;
+    const stray = rendered.filter((t) => !PORTAL_ROOT_TAGS.has(t));
+    if (stray.length > 0) {
+      offenders.push(`${name} (a return renders non-portal roots: ${stray.join(', ')})`);
+      continue;
+    }
+    // 🔴 AND THE NAME MUST RESOLVE TO THE REAL COMPONENT. `Modal` is just an identifier;
+    // a file is free to define its own. Without this the contract trusted a spelling, and
+    // a locally-defined `const Modal = … <Box mx="auto">` satisfied it completely.
+    for (const tag of rendered) {
+      const base = tag.split('.')[0];
+      const from = importSourceOf(source, base);
+      if (from !== PORTAL_ROOT_MODULE) {
+        offenders.push(
+          `${name} (renders <${tag}>, but \`${base}\` is ` +
+            (from ? `imported from '${from}'` : 'not imported at all') +
+            ` — a portal root must come from '${PORTAL_ROOT_MODULE}')`
+        );
+      }
     }
   }
   return offenders;
@@ -679,7 +796,17 @@ describe('every /apps page on disk is classified', () => {
           offenders.push(`${name} (no file at ${abs})`);
           continue;
         }
-        const groups = pageReturnTags(abs, exportName);
+        // 🔴 CAUGHT, like the page loop. An allowlist entry written in a shape the walk
+        // cannot parse used to THROW out of the test, so the run died with a raw stack
+        // instead of the named offender assertion — the exact opposite of the message
+        // ordering fixed a round ago.
+        let groups: string[][];
+        try {
+          groups = pageReturnTags(abs, exportName);
+        } catch (err) {
+          offenders.push(`${name} (could not parse: ${(err as Error).message})`);
+          continue;
+        }
         if (groups.length === 0) {
           offenders.push(`${name} (has no return statement)`);
           continue;
@@ -710,33 +837,74 @@ describe('every /apps page on disk is classified', () => {
      * alongside page content rendering outside it.
      */
     describe('🔴 chromeOffenders — the rule, pinned directly', () => {
-      const cases: { name: string; group: string[]; offends: boolean }[] = [
-        { name: 'the layout alone', group: ['AppsPageLayout'], offends: false },
-        { name: 'Meta beside the layout', group: ['Meta', 'AppsPageLayout'], offends: false },
-        { name: 'a bare access-denied leaf', group: ['NotFound'], offends: false },
-        { name: 'nothing renderable', group: [], offends: false },
-        { name: 'a verified delegate', group: ['AppsSubmitEditView'], offends: false },
+      // 🔴 EVERY ROW IS A LIST OF GROUPS, NOT ONE GROUP, and that is the point of the
+      // shape. The table used to pass `[group]` — always exactly one — so the loop OVER
+      // groups was never exercised: `groups.slice(0, 1)` and `continue`→`break` both
+      // survived the whole suite, even with a real un-chromed sibling planted on
+      // /apps/review. `break` is the realistic one: a page's first return is routinely a
+      // gate that filters to empty, so it would skip every later return and report green
+      // having inspected nothing.
+      const cases: { name: string; groups: string[][]; offends: boolean }[] = [
+        { name: 'the layout alone', groups: [['AppsPageLayout']], offends: false },
+        { name: 'Meta beside the layout', groups: [['Meta', 'AppsPageLayout']], offends: false },
+        { name: 'a bare access-denied leaf', groups: [['NotFound']], offends: false },
+        { name: 'nothing renderable', groups: [[]], offends: false },
+        { name: 'no returns at all', groups: [], offends: false },
+        { name: 'a verified delegate', groups: [['AppsSubmitEditView']], offends: false },
         {
           name: 'a portaled overlay beside the layout',
-          group: ['AppsPageLayout', 'OnsiteReviewModal'],
+          groups: [['AppsPageLayout', 'OnsiteReviewModal']],
           offends: false,
         },
-        { name: 'page content with NO layout', group: ['Box'], offends: true },
+        { name: 'page content with NO layout', groups: [['Box']], offends: true },
         // 🔴 The two an `includes` check passes.
         {
           name: 'an un-chromed SIBLING alongside the layout',
-          group: ['AppsPageLayout', 'Box'],
+          groups: [['AppsPageLayout', 'Box']],
           offends: true,
         },
         {
           name: 'a ternary whose other arm is un-chromed (flattened to one group)',
-          group: ['AppsPageLayout', 'Container'],
+          groups: [['AppsPageLayout', 'Container']],
           offends: true,
+        },
+        // 🔴 F4 — permission to sit beside the chrome is not the same as providing it.
+        {
+          name: 'ONLY a portaled overlay, with no chrome provider',
+          groups: [['OnsiteReviewModal']],
+          offends: true,
+        },
+        // 🔴 THE MULTI-GROUP AXIS. Each row below is green in its first group and rotten
+        // in a later one, so anything that stops after the first return lets it through.
+        {
+          name: 'a GATE return first, then an un-chromed one (kills `break`)',
+          groups: [[], ['Box']],
+          offends: true,
+        },
+        {
+          name: 'a NotFound gate first, then an un-chromed one (kills `break`)',
+          groups: [['NotFound'], ['Box']],
+          offends: true,
+        },
+        {
+          name: 'a good return first, then an un-chromed one (kills slice(0, 1))',
+          groups: [['AppsPageLayout'], ['Box']],
+          offends: true,
+        },
+        {
+          name: 'three returns, only the LAST rotten',
+          groups: [['AppsPageLayout'], ['NotFound'], ['Container']],
+          offends: true,
+        },
+        {
+          name: 'several good returns stay clean',
+          groups: [['AppsPageLayout'], ['NotFound'], ['Meta', 'AppsPageLayout']],
+          offends: false,
         },
       ];
 
-      test.each(cases)('$name', ({ group, offends }) => {
-        const out = chromeOffenders('fixture', [group]);
+      test.each(cases)('$name', ({ groups, offends }) => {
+        const out = chromeOffenders('fixture', groups);
         expect(out.length > 0).toBe(offends);
       });
 
@@ -747,13 +915,48 @@ describe('every /apps page on disk is classified', () => {
         expect(msg).toContain('stray: Box');
       });
 
-      test('every case fixture is distinct (no row silently duplicates another)', () => {
-        // Guard-the-guard: duplicated rows inflate the table without adding coverage.
-        const keys = cases.map((c) => c.group.join('|'));
+      test('the NO-PROVIDER message is distinct from the stray-tag one', () => {
+        // Two different defects must not print the same sentence, or the message stops
+        // telling you which one you have.
+        const [stray] = chromeOffenders('/apps/x', [['AppsPageLayout', 'Box']]);
+        const [none] = chromeOffenders('/apps/x', [['OnsiteReviewModal']]);
+        expect(none).toContain('NO chrome provider');
+        expect(stray).not.toContain('NO chrome provider');
+      });
+
+      test('a later rotten return is reported even when an earlier one is fine', () => {
+        // The message must name the offending group, not merely count one.
+        const out = chromeOffenders('/apps/x', [['AppsPageLayout'], ['Box']]);
+        expect(out).toHaveLength(1);
+        expect(out[0]).toContain('stray: Box');
+      });
+
+      test('EVERY rotten group is reported, not just the first', () => {
+        // Pins that the loop keeps going after it finds one — a `break` on the offending
+        // branch would report 1 of 2 and still fail the suite, so only a count sees it.
+        const out = chromeOffenders('/apps/x', [['Box'], ['AppsPageLayout'], ['Container']]);
+        expect(out).toHaveLength(2);
+      });
+
+      test('the table exercises the multi-group axis and both verdicts', () => {
+        // Guard-the-guard: duplicated rows inflate the table without adding coverage, and
+        // a table of single-group rows cannot see a loop bug at all.
+        const keys = cases.map((c) => JSON.stringify(c.groups));
         expect(new Set(keys).size).toBe(keys.length);
-        // …and the table exercises BOTH verdicts, so it cannot pass by always agreeing.
         expect(cases.some((c) => c.offends)).toBe(true);
         expect(cases.some((c) => !c.offends)).toBe(true);
+        // At least two rows must carry MORE THAN ONE group, or the loop is unpinned again.
+        expect(cases.filter((c) => c.groups.length > 1).length).toBeGreaterThanOrEqual(2);
+        // …and at least one multi-group row must be clean ONLY in its first group, which
+        // is the precise shape `break` and `slice(0, 1)` survive.
+        expect(
+          cases.some(
+            (c) =>
+              c.groups.length > 1 &&
+              c.offends &&
+              chromeOffenders('probe', [c.groups[0]]).length === 0
+          )
+        ).toBe(true);
       });
     });
 
@@ -766,35 +969,142 @@ describe('every /apps page on disk is classified', () => {
       expect(names.length, 'the portal-sibling list is empty — nothing to verify').toBeGreaterThan(
         0
       );
-      const offenders: string[] = [];
-      for (const name of names) {
-        const { file, exportName } = CHROME_PORTAL_SIBLINGS[name];
-        const abs = path.resolve(__dirname, '../../../..', file);
-        if (!fs.existsSync(abs)) {
-          offenders.push(`${name} (no file at ${abs})`);
-          continue;
-        }
-        const groups = pageReturnTags(abs, exportName);
-        if (groups.length === 0) {
-          offenders.push(`${name} (has no return statement)`);
-          continue;
-        }
-        // Every return that renders anything must render a portal root — an early
-        // return of ordinary markup would put real content outside the chrome.
-        for (const tags of groups) {
-          const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
-          if (rendered.length === 0) continue;
-          const stray = rendered.filter((t) => !PORTAL_ROOT_TAGS.has(t));
-          if (stray.length > 0) {
-            offenders.push(`${name} (a return renders non-portal roots: ${stray.join(', ')})`);
-          }
-        }
-      }
+      const offenders = names.flatMap((name) =>
+        portalOffenders(
+          name,
+          path.resolve(__dirname, '../../../..', CHROME_PORTAL_SIBLINGS[name].file),
+          CHROME_PORTAL_SIBLINGS[name].exportName
+        )
+      );
       expect(
         offenders,
         'A component allowlisted as a portaled overlay renders ordinary markup instead — ' +
           'it would place page content outside the shared chrome.'
       ).toEqual([]);
+    });
+
+    describe('🔴 the portal contract, on known-BAD inputs (negative controls)', () => {
+      /**
+       * Why these exist: the portal check's only real inputs are the three genuine
+       * entries, and all three pass. So the check could be disabled outright — I removed
+       * the import comparison and the entire suite stayed green at 135/135 — because
+       * nothing ever fed it a case it had to reject. A guard tested only on known-good
+       * inputs is a guard nobody has watched work.
+       */
+      const write = (suffix: string, body: string) => {
+        const tmp = path.join(os.tmpdir(), `apps-portal-${suffix}-${process.pid}.tsx`);
+        fs.writeFileSync(tmp, body);
+        return tmp;
+      };
+
+      test('a LOCALLY DEFINED `Modal` is rejected, however convincingly named', () => {
+        // The exact shape that survived: the tag is called Modal, so a name-only check
+        // waves it through, but it is this file's own component wrapping a centred Box.
+        const tmp = write(
+          'local',
+          [
+            "import { Box } from '@mantine/core';",
+            "import type { ReactNode } from 'react';",
+            'const Modal = ({ children }: { children?: ReactNode }) => (',
+            '  <Box maw={700} mx="auto">{children}</Box>',
+            ');',
+            'export function FakeOverlay() {',
+            '  return <Modal>overlay</Modal>;',
+            '}',
+          ].join('\n')
+        );
+        try {
+          const out = portalOffenders('FakeOverlay', tmp, 'FakeOverlay');
+          expect(out).toHaveLength(1);
+          expect(out[0]).toContain('not imported at all');
+          expect(out[0]).toContain('@mantine/core');
+        } finally {
+          fs.unlinkSync(tmp);
+        }
+      });
+
+      test('a `Modal` imported from the WRONG package is rejected, and the message says which', () => {
+        const tmp = write(
+          'wrongpkg',
+          [
+            "import { Modal } from 'some-other-ui-kit';",
+            'export function FakeOverlay() {',
+            '  return <Modal>overlay</Modal>;',
+            '}',
+          ].join('\n')
+        );
+        try {
+          const out = portalOffenders('FakeOverlay', tmp, 'FakeOverlay');
+          expect(out).toHaveLength(1);
+          expect(out[0]).toContain("imported from 'some-other-ui-kit'");
+        } finally {
+          fs.unlinkSync(tmp);
+        }
+      });
+
+      test('ordinary markup is rejected even before the import question', () => {
+        const tmp = write(
+          'plain',
+          [
+            "import { Box } from '@mantine/core';",
+            'export function FakeOverlay() {',
+            '  return <Box maw={700} mx="auto" />;',
+            '}',
+          ].join('\n')
+        );
+        try {
+          const out = portalOffenders('FakeOverlay', tmp, 'FakeOverlay');
+          expect(out).toHaveLength(1);
+          expect(out[0]).toContain('non-portal roots: Box');
+        } finally {
+          fs.unlinkSync(tmp);
+        }
+      });
+
+      test('POSITIVE CONTROL — a real Mantine Modal passes', () => {
+        // Without this the three rejections above are satisfied by a function that
+        // rejects everything.
+        const tmp = write(
+          'good',
+          [
+            "import { Modal } from '@mantine/core';",
+            'export function RealOverlay() {',
+            '  return <Modal opened onClose={() => undefined}>overlay</Modal>;',
+            '}',
+          ].join('\n')
+        );
+        try {
+          expect(portalOffenders('RealOverlay', tmp, 'RealOverlay')).toEqual([]);
+        } finally {
+          fs.unlinkSync(tmp);
+        }
+      });
+
+      test('importSourceOf resolves each import form, and reports absence as null', () => {
+        const tmp = write(
+          'imports',
+          [
+            "import Default from 'pkg-default';",
+            "import { Named, Other as Aliased } from 'pkg-named';",
+            "import * as Ns from 'pkg-ns';",
+            'export function X() {',
+            '  return <Named />;',
+            '}',
+          ].join('\n')
+        );
+        try {
+          const src = sourceFileOf(tmp);
+          expect(importSourceOf(src, 'Default')).toBe('pkg-default');
+          expect(importSourceOf(src, 'Named')).toBe('pkg-named');
+          // An ALIASED import binds the local name, which is what a tag resolves against.
+          expect(importSourceOf(src, 'Aliased')).toBe('pkg-named');
+          expect(importSourceOf(src, 'Other')).toBeNull();
+          expect(importSourceOf(src, 'Ns')).toBe('pkg-ns');
+          expect(importSourceOf(src, 'NotImported')).toBeNull();
+        } finally {
+          fs.unlinkSync(tmp);
+        }
+      });
     });
 
     test('🔴 the AST walk can SEE a violation (negative control on the guard above)', () => {

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -2,172 +2,249 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, test } from 'vitest';
 import {
+  APPS_CONTAINER_GUTTER,
   APPS_FULL_BLEED_PAGES,
-  APPS_NARROW_TABLE_PAGE_WIDTH,
-  APPS_PAGE_WIDTHS,
-  APPS_READABLE_PAGE_WIDTH,
+  APPS_FULL_MEASURE_PAGES,
+  APPS_NARROW_TABLE_MEASURE,
+  APPS_PAGE_CONTAINER_WIDTH,
+  APPS_PAGE_MEASURES,
+  APPS_READABLE_MEASURE,
   APPS_REDIRECT_ONLY_PAGES,
-  APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH,
-  APPS_WIDE_PAGE_WIDTH,
+  APPS_TWO_COLUMN_DETAIL_MEASURE,
 } from '~/components/Apps/appsPageWidths';
+import * as widthsModule from '~/components/Apps/appsPageWidths';
 import { LISTING_GRID_SPAN, LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
+import {
+  SUBMISSIONS_CONTAINER_CHROME,
+  SUBMISSIONS_TABLE_MIN_WIDTH,
+} from '~/components/Apps/submissionsTable';
 
 /**
- * `/apps/*` container-width pins (blocking `unit` project).
+ * `/apps/*` geometry pins (blocking `unit` project).
  *
- * The product feedback was "the apps pages should use the full page width". The
- * implementation answer is a per-route decision recorded in ONE module, with the
- * store's width kept as an explicit matched pair with the grid span. Both halves
- * are pinned here so a later tweak can't quietly re-narrow a page or move the
- * container out from under the grid.
+ * The model: ONE container width for every route, plus an optional CONTENT MEASURE
+ * applied inside the body. It replaced a per-route CONTAINER width, which put the
+ * shared sub-nav inside a per-page box and made the tab strip move horizontally
+ * between routes.
+ *
+ * The RENDERED proof of the alignment lives in
+ * `AppsPageLayout.chromeAlignment.browser.test.tsx` (browser-mode, report-only). This
+ * file pins the CONSTANTS and the route taxonomy in the tier that actually gates.
  */
 
-describe('APPS_PAGE_WIDTHS — the decided value per route', () => {
-  test('the browse/manage surfaces are all the WIDE width (1920)', () => {
-    expect(APPS_WIDE_PAGE_WIDTH).toBe(1920);
-    expect(APPS_PAGE_WIDTHS['/apps']).toBe(1920);
-    expect(APPS_PAGE_WIDTHS['/apps/installed']).toBe(1920);
-    // `/apps/mine` took this width when it absorbed `/apps/my-submissions` (which now
-    // 301s to it and has no page file): it went from a single-column card list to a table
-    // carrying an icon, a cover, three badges and a date per row.
-    expect(APPS_PAGE_WIDTHS['/apps/mine']).toBe(1920);
-    expect(APPS_PAGE_WIDTHS['/apps/review/[publishRequestId]']).toBe(1920);
-    expect(APPS_PAGE_WIDTHS['/apps/revenue']).toBe(1920);
+describe('the container is uniform, and it is the only container', () => {
+  test('every `/apps/*` route renders in ONE container width (1920)', () => {
+    // A literal, not derived from the module's own arithmetic.
+    expect(APPS_PAGE_CONTAINER_WIDTH).toBe(1920);
   });
 
-  test('the /apps/review QUEUE is the narrow-table width (1400), not the wide one', () => {
-    // Four short columns (Kind / App / Submitter / Submitted) + a Review button
-    // cannot spend 1920: the table pads Submitter out to ~380px for a short
-    // username and opens a large dead gap before the action. Literal values, not
-    // derived from the module's own constant arithmetic.
-    expect(APPS_NARROW_TABLE_PAGE_WIDTH).toBe(1400);
-    expect(APPS_PAGE_WIDTHS['/apps/review']).toBe(1400);
-    // 🔴 The DETAIL route is deliberately NOT moved with it — it renders
-    // side-by-side diff panels + a live preview, which do use the width. If a
-    // later pass narrows the queue further, this is the pin that stops the detail
-    // page being dragged along by association.
-    expect(APPS_PAGE_WIDTHS['/apps/review/[publishRequestId]']).toBe(1920);
-    // …and the merged author table keeps 1920: two images + three badges per row is the
-    // same class of wide surface `/apps/my-submissions` was before the merge.
-    expect(APPS_PAGE_WIDTHS['/apps/mine']).toBe(1920);
-    // 🔴 The retired route must NOT come back as a listed width — its page is deleted, so
-    // a re-added entry would fail the consumption walk below with a confusing message.
-    expect(APPS_PAGE_WIDTHS).not.toHaveProperty('/apps/my-submissions');
+  test('🔴 there is no per-route CONTAINER width map any more', () => {
+    // The defect was `APPS_PAGE_WIDTHS`: a container width per route. If it comes
+    // back — under any name — the sub-nav starts moving again. `APPS_PAGE_MEASURES`
+    // is a different thing (a BODY cap), and the layout guards in
+    // `appsPageLayout.test.ts` pin that it can never reach the Container.
+    // A NAMESPACE import, not `require`: the `~` alias is a Vite resolver and does
+    // not exist for node's CJS loader, so `require` throws MODULE_NOT_FOUND and the
+    // test fails for a reason that has nothing to do with the claim.
+    expect(widthsModule).not.toHaveProperty('APPS_PAGE_WIDTHS');
+    expect(widthsModule).not.toHaveProperty('APPS_WIDE_PAGE_WIDTH');
+    expect(widthsModule).not.toHaveProperty('APPS_READABLE_PAGE_WIDTH');
+    // Guard-the-guard: an empty namespace would satisfy every `not.toHaveProperty`.
+    expect(widthsModule).toHaveProperty('APPS_PAGE_CONTAINER_WIDTH');
+    expect(widthsModule).toHaveProperty('APPS_PAGE_MEASURES');
+  });
+});
+
+describe('APPS_PAGE_MEASURES — the decided CONTENT measure per route', () => {
+  test('the narrow-table measure is 1368 and only /apps/review takes it', () => {
+    expect(APPS_NARROW_TABLE_MEASURE).toBe(1368);
+    expect(APPS_PAGE_MEASURES['/apps/review']).toBe(1368);
+    const takers = Object.entries(APPS_PAGE_MEASURES)
+      .filter(([, m]) => m === APPS_NARROW_TABLE_MEASURE)
+      .map(([r]) => r);
+    expect(takers).toEqual(['/apps/review']);
   });
 
-  test('the form surfaces are all the READABLE width (1100)', () => {
-    expect(APPS_READABLE_PAGE_WIDTH).toBe(1100);
-    expect(APPS_PAGE_WIDTHS['/apps/submit']).toBe(1100);
-    expect(APPS_PAGE_WIDTHS['/apps/[appBlockId]/edit']).toBe(1100);
-    expect(APPS_PAGE_WIDTHS['/apps/[appBlockId]/revenue']).toBe(1100);
-    expect(APPS_PAGE_WIDTHS['/apps/get-started']).toBe(1100);
+  test('the two-column detail measure is 1288 and only the store preview takes it', () => {
+    expect(APPS_TWO_COLUMN_DETAIL_MEASURE).toBe(1288);
+    expect(APPS_PAGE_MEASURES['/apps/store-preview/[slug]']).toBe(1288);
+    // 🔴 Pinned in BOTH directions so a later "tidy-up" that folds the detail into
+    // another class fails here rather than silently squeezing the right rail
+    // (readable) or putting the markdown description on a ~1250px measure (full).
+    expect(APPS_PAGE_MEASURES['/apps/store-preview/[slug]']).not.toBe(APPS_READABLE_MEASURE);
+    expect(APPS_PAGE_MEASURES['/apps/store-preview/[slug]']).not.toBe(APPS_PAGE_CONTAINER_WIDTH);
   });
 
-  test('the listing DETAIL is the two-column width (1320 — Mantine xl, the model page)', () => {
-    // The detail body is a port of the model detail page's layout (main column +
-    // right rail via ContainerGrid2), so it takes that page's own container size
-    // rather than a bespoke number. Literal, not derived from the module's constant.
-    expect(APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH).toBe(1320);
-    expect(APPS_PAGE_WIDTHS['/apps/store-preview/[slug]']).toBe(1320);
-    // 🔴 It is NOT the readable width any more, and NOT the wide one. Pinned in both
-    // directions so a later "tidy-up" that folds the detail back into either class
-    // fails here rather than silently squeezing the rail (1100) or putting the
-    // markdown description on a ~1250px measure (1920).
-    expect(APPS_PAGE_WIDTHS['/apps/store-preview/[slug]']).not.toBe(APPS_READABLE_PAGE_WIDTH);
-    expect(APPS_PAGE_WIDTHS['/apps/store-preview/[slug]']).not.toBe(APPS_WIDE_PAGE_WIDTH);
+  test('the readable measure is 1068, and these six form/prose routes take it', () => {
+    expect(APPS_READABLE_MEASURE).toBe(1068);
+    const takers = Object.entries(APPS_PAGE_MEASURES)
+      .filter(([, m]) => m === APPS_READABLE_MEASURE)
+      .map(([r]) => r)
+      .sort();
+    // The SET, not a spot-check: this fails when a route joins or leaves.
+    expect(takers).toEqual([
+      '/apps/[appBlockId]/edit',
+      '/apps/[appBlockId]/revenue',
+      '/apps/get-started',
+      '/apps/invites',
+      '/apps/listing/[appListingId]/edit',
+      '/apps/submit',
+    ]);
   });
 
-  test('🔴 the detail width is NOT half of the store grid pair', () => {
-    // The pair documented in the module header couples `/apps` to LISTING_GRID_SPAN.
-    // Widening the DETAIL route must not move the store container, or the grid's
-    // card-width arithmetic (asserted below) silently changes.
-    expect(LISTING_STORE_CONTAINER_SIZE).toBe(APPS_PAGE_WIDTHS['/apps']);
-    expect(LISTING_STORE_CONTAINER_SIZE).not.toBe(
-      APPS_PAGE_WIDTHS['/apps/store-preview/[slug]']
-    );
-  });
-
-  test('the RETIRED /apps/[appBlockId] is redirect-only, not a width', () => {
-    // It was listed as a rendering route with the comment "still renders for a
-    // direct hit". The page's own docstring says RETIRED and its
-    // `getServerSideProps` unconditionally redirects to
-    // `/apps/store-preview/<slug>`, so a width there was unreachable AND made
-    // this module assert a false fact about the app.
-    expect(APPS_PAGE_WIDTHS).not.toHaveProperty('/apps/[appBlockId]');
-    expect(APPS_REDIRECT_ONLY_PAGES).toContain('/apps/[appBlockId]');
-  });
-
-  test('every width is one of the FOUR decided values — no fifth hand-picked number', () => {
+  test('every measure is one of the THREE decided values — no fourth hand-picked number', () => {
     // The whole point of the module is that there are a few CLASSES of apps page,
-    // not eleven bespoke widths. A new page must join a class (or the class list
-    // must grow deliberately, failing here first — which is exactly what happened
-    // when `/apps/review` needed the narrow-table class, and again when the listing
-    // detail became a two-column layout).
-    for (const [route, width] of Object.entries(APPS_PAGE_WIDTHS)) {
+    // not eleven bespoke numbers. A new page must join a class, or the class list
+    // must grow deliberately — failing here first.
+    for (const [route, measure] of Object.entries(APPS_PAGE_MEASURES)) {
       expect(
-        [
-          APPS_WIDE_PAGE_WIDTH,
-          APPS_NARROW_TABLE_PAGE_WIDTH,
-          APPS_READABLE_PAGE_WIDTH,
-          APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH,
-        ],
+        [APPS_NARROW_TABLE_MEASURE, APPS_TWO_COLUMN_DETAIL_MEASURE, APPS_READABLE_MEASURE],
         `${route}`
-      ).toContain(width);
+      ).toContain(measure);
     }
     // Pin the class list itself, as literals. Without this the check above is
-    // satisfied by ANY set of constants, including a fifth one added silently.
+    // satisfied by ANY set of constants, including a fourth one added silently.
     expect([
-      APPS_WIDE_PAGE_WIDTH,
-      APPS_NARROW_TABLE_PAGE_WIDTH,
-      APPS_READABLE_PAGE_WIDTH,
-      APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH,
-    ]).toEqual([1920, 1400, 1100, 1320]);
+      APPS_NARROW_TABLE_MEASURE,
+      APPS_TWO_COLUMN_DETAIL_MEASURE,
+      APPS_READABLE_MEASURE,
+    ]).toEqual([1368, 1288, 1068]);
   });
 
-  test('a route is classified exactly once (no overlap between the three lists)', () => {
-    const all = [
-      ...Object.keys(APPS_PAGE_WIDTHS),
-      ...APPS_FULL_BLEED_PAGES,
-      ...APPS_REDIRECT_ONLY_PAGES,
-    ];
-    expect(new Set(all).size).toBe(all.length);
+  test('🔴 a measure is always strictly inside the container', () => {
+    // A measure ≥ the container is a no-op that reads as a decision. A measure
+    // larger than the container's usable width is worse: it silently does nothing
+    // while claiming a class.
+    const usable = APPS_PAGE_CONTAINER_WIDTH - APPS_CONTAINER_GUTTER;
+    for (const [route, measure] of Object.entries(APPS_PAGE_MEASURES)) {
+      expect(measure, `${route} must actually narrow the body`).toBeLessThan(usable);
+      expect(measure, `${route} must be a positive px value`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('🔴 the measures preserve the OLD rendered content widths exactly', () => {
+  /**
+   * THE +32px TRAP, PINNED. Mantine's `Container` is border-box: `size={N}` renders
+   * `N − 2×16` of content. A `maw={N}` box lives INSIDE that gutter and renders `N`.
+   * So carrying the old round container numbers over as measures would have widened
+   * every narrowed page by 32px — a confounded change hiding inside an alignment fix.
+   *
+   * Each measure is therefore the OLD container width minus the gutter, and the old
+   * numbers are named here as literals so the provenance is checkable rather than
+   * asserted in prose.
+   */
+  test('the Container gutter is 16px per side', () => {
+    expect(APPS_CONTAINER_GUTTER).toBe(32);
+  });
+
+  test.each([
+    ['narrow table', APPS_NARROW_TABLE_MEASURE, 1400],
+    ['two-column detail', APPS_TWO_COLUMN_DETAIL_MEASURE, 1320],
+    ['readable', APPS_READABLE_MEASURE, 1100],
+  ])('%s: measure = old container width − gutter', (_label, measure, oldContainerWidth) => {
+    expect(measure).toBe(oldContainerWidth - APPS_CONTAINER_GUTTER);
+  });
+
+  test('the two-column measure equals the MODEL DETAIL page content width', () => {
+    // Its documented justification is "the same width as the model detail page",
+    // which renders `<Container size="xl">` — Mantine's `xl` is 1320 border-box, so
+    // its CONTENT is 1288. Stating the claim in content terms is what makes it true.
+    const MANTINE_XL_CONTAINER = 1320;
+    expect(APPS_TWO_COLUMN_DETAIL_MEASURE).toBe(MANTINE_XL_CONTAINER - APPS_CONTAINER_GUTTER);
   });
 });
 
 describe('🔴 the store width and the store grid span are a MATCHED PAIR', () => {
-  test('LISTING_STORE_CONTAINER_SIZE reads through to the /apps entry (one number, not two)', () => {
-    // `appListingGrid.ts` used to carry its own literal 1600. If it drifts back to
-    // a literal, this fails the moment the two disagree.
-    expect(LISTING_STORE_CONTAINER_SIZE).toBe(APPS_PAGE_WIDTHS['/apps']);
+  test('LISTING_STORE_CONTAINER_SIZE reads the shared container width (one number, not two)', () => {
+    // `appListingGrid.ts` used to carry its own literal 1600. If it drifts back to a
+    // literal, this fails the moment the two disagree.
+    expect(LISTING_STORE_CONTAINER_SIZE).toBe(APPS_PAGE_CONTAINER_WIDTH);
     expect(LISTING_STORE_CONTAINER_SIZE).toBe(1920);
   });
 
-  test('the widened container yields the card width the xl span was tuned for', () => {
-    // The pair, stated as arithmetic rather than as a code-review promise:
+  test('🔴 /apps takes NO body measure, so its content width IS the container width', () => {
+    // This is what keeps the card arithmetic below true after the container/measure
+    // split. Give `/apps` a measure and the grid silently re-truncates.
+    expect(APPS_PAGE_MEASURES).not.toHaveProperty('/apps');
+    expect(APPS_FULL_MEASURE_PAGES).toContain('/apps');
+  });
+
+  test('the container yields the card width the xl span was tuned for', () => {
     //   container 1920 − 2×16 Container padding = 1888 usable
     //   xl span 3/12 → 4 columns; Grid gutter "md" (16) → 3 gutters between them
     //   → (1888 − 3×16) / 4 = 460 px per card.
-    // Pinned so that moving EITHER number without re-deriving the other fails
-    // here. (The judgment call — 460px covers at 1920 vs re-tuning the span to 5
-    // columns — is recorded in the PR; see `appListingGrid.ts`.)
-    const CONTAINER_PADDING = 32;
     const GUTTER = 16;
     const columns = 12 / LISTING_GRID_SPAN.xl;
-    const usable = (LISTING_STORE_CONTAINER_SIZE as number) - CONTAINER_PADDING;
+    const usable = LISTING_STORE_CONTAINER_SIZE - APPS_CONTAINER_GUTTER;
     const cardWidth = (usable - GUTTER * (columns - 1)) / columns;
     expect(columns).toBe(4);
     expect(cardWidth).toBe(460);
   });
 });
 
+describe('🔴 /apps/mine is wide enough for its table, as a RELATIONSHIP', () => {
+  /**
+   * This replaces the deleted `MY_APPS_CONTAINER_SIZE` alias and its `> 1100` pin.
+   * The alias could not have noticed the container dropping to 1400; the relationship
+   * can, because it names the floor the table actually has.
+   */
+  test('the container clears the submissions-table scroll floor', () => {
+    const contentWidth = APPS_PAGE_CONTAINER_WIDTH - SUBMISSIONS_CONTAINER_CHROME;
+    expect(contentWidth).toBeGreaterThan(SUBMISSIONS_TABLE_MIN_WIDTH);
+  });
+
+  test('…and it does so because /apps/mine takes no measure', () => {
+    // If it ever took the readable measure, the floor would NOT be cleared — which
+    // is exactly the clip the wide width was introduced to fix. Asserted as the
+    // counterfactual so the previous test cannot pass for the wrong reason.
+    expect(APPS_PAGE_MEASURES).not.toHaveProperty('/apps/mine');
+    expect(APPS_FULL_MEASURE_PAGES).toContain('/apps/mine');
+    expect(APPS_READABLE_MEASURE - SUBMISSIONS_CONTAINER_CHROME).toBeLessThan(
+      SUBMISSIONS_TABLE_MIN_WIDTH
+    );
+  });
+});
+
+describe('the route taxonomy', () => {
+  test('a route is classified exactly once (no overlap between the four lists)', () => {
+    const all = [
+      ...Object.keys(APPS_PAGE_MEASURES),
+      ...APPS_FULL_MEASURE_PAGES,
+      ...APPS_FULL_BLEED_PAGES,
+      ...APPS_REDIRECT_ONLY_PAGES,
+    ];
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  test('the RETIRED /apps/[appBlockId] is redirect-only, not a measure', () => {
+    // It was once listed as a rendering route with the comment "still renders for a
+    // direct hit". The page's own docstring says RETIRED and its
+    // `getServerSideProps` unconditionally redirects, so a width there was
+    // unreachable AND made the module assert a false fact about the app.
+    expect(APPS_PAGE_MEASURES).not.toHaveProperty('/apps/[appBlockId]');
+    expect(APPS_REDIRECT_ONLY_PAGES).toContain('/apps/[appBlockId]');
+  });
+
+  test('the merged-away /apps/my-submissions is not listed anywhere', () => {
+    const all = [
+      ...Object.keys(APPS_PAGE_MEASURES),
+      ...APPS_FULL_MEASURE_PAGES,
+      ...APPS_FULL_BLEED_PAGES,
+      ...APPS_REDIRECT_ONLY_PAGES,
+    ];
+    expect(all).not.toContain('/apps/my-submissions');
+  });
+});
+
 /**
  * 🔴 THE ENUMERATION GUARD — the reason this file reads the filesystem.
  *
- * A constants map is only "every apps page" if something checks it against the
- * pages that actually exist. Without this, a new `/apps/*` route silently
- * inherits `AppsPageLayout`'s `xl` default (or hand-picks a width) and the
- * "full width" decision quietly stops being true — exactly the drift that
- * produced the 1600 / 1500 / 'lg' / 'xl' / 'sm' spread this module replaced.
+ * A constants map is only "every apps page" if something checks it against the pages
+ * that actually exist. Without this, a new `/apps/*` route silently renders its own
+ * bare `<Container>` and the uniform-chrome decision quietly stops being true —
+ * exactly the drift that left FOUR pages (`get-started`, `[appBlockId]/edit`,
+ * `[appBlockId]/revenue`, `listing/[appListingId]/edit`) with no sub-nav at all.
  */
 describe('every /apps page on disk is classified', () => {
   const PAGES_DIR = path.resolve(__dirname, '../../../pages/apps');
@@ -191,26 +268,40 @@ describe('every /apps page on disk is classified', () => {
     return out.sort();
   }
 
+  /** Absolute path of the page file backing a route pathname. */
+  function pageFile(route: string): string {
+    const rel = route === '/apps' ? '/apps/index' : route;
+    return path.resolve(PAGES_DIR, '..', `${rel.replace(/^\/apps\//, 'apps/')}.tsx`);
+  }
+
   test('the walker actually found the apps pages (guards a silently-empty scan)', () => {
     // A test that classifies zero routes would pass vacuously — the failure mode
-    // that makes an fs-backed guard worthless. Pin a floor and a known member.
+    // that makes an fs-backed guard worthless. Pin a floor AND known members from
+    // every list, so a walk that finds only the shallow files still fails.
     const routes = appsRoutes();
-    expect(routes.length).toBeGreaterThanOrEqual(15);
+    expect(routes.length).toBeGreaterThanOrEqual(20);
     expect(routes).toContain('/apps');
+    expect(routes).toContain('/apps/review');
+    expect(routes).toContain('/apps/get-started');
+    expect(routes).toContain('/apps/[appBlockId]/edit');
+    expect(routes).toContain('/apps/listing/[appListingId]/edit');
+    expect(routes).toContain('/apps/run/[slug]/[[...path]]');
   });
 
   test('no /apps route is unclassified', () => {
     const classified = new Set<string>([
-      ...Object.keys(APPS_PAGE_WIDTHS),
+      ...Object.keys(APPS_PAGE_MEASURES),
+      ...APPS_FULL_MEASURE_PAGES,
       ...APPS_FULL_BLEED_PAGES,
       ...APPS_REDIRECT_ONLY_PAGES,
     ]);
     const unclassified = appsRoutes().filter((r) => !classified.has(r));
     expect(
       unclassified,
-      `Unclassified /apps route(s). Add each to APPS_PAGE_WIDTHS (with a width), ` +
-        `APPS_FULL_BLEED_PAGES (full-viewport iframe/shell) or APPS_REDIRECT_ONLY_PAGES ` +
-        `(getServerSideProps always redirects/404s) in src/components/Apps/appsPageWidths.ts.`
+      `Unclassified /apps route(s). Add each to APPS_PAGE_MEASURES (a narrower body), ` +
+        `APPS_FULL_MEASURE_PAGES (full container), APPS_FULL_BLEED_PAGES (full-viewport ` +
+        `iframe/shell) or APPS_REDIRECT_ONLY_PAGES (getServerSideProps always ` +
+        `redirects/404s) in src/components/Apps/appsPageWidths.ts.`
     ).toEqual([]);
   });
 
@@ -218,49 +309,138 @@ describe('every /apps page on disk is classified', () => {
    * 🔴 CONSUMPTION — the cheap half of "is this entry real?".
    *
    * The completeness walk only proves a route is LISTED. It cannot notice that a
-   * listed route's width is never read, which is exactly how
-   * `/apps/[appBlockId]` came to carry a `Container size=` that its own
-   * always-redirecting `getServerSideProps` made unreachable.
+   * listed route's measure is never read, which is exactly how `/apps/[appBlockId]`
+   * came to carry a `Container size=` its always-redirecting `getServerSideProps`
+   * made unreachable.
    *
-   * Two pages read their width through a NAMED ALIAS instead of indexing the map
-   * directly — the store via `LISTING_STORE_CONTAINER_SIZE` (paired with the grid
-   * span) and my-submissions via `MY_SUBMISSIONS_CONTAINER_SIZE` (paired with the
-   * table scroll floor). Both alias constants are defined as
-   * `APPS_PAGE_WIDTHS[<route>]`, so they are genuine consumers; they are listed
-   * here rather than special-cased silently.
+   * There are no ALIAS consumers left. Both former ones —
+   * `LISTING_STORE_CONTAINER_SIZE` for `/apps` and `MY_APPS_CONTAINER_SIZE` for
+   * `/apps/mine` — existed to hand a per-page CONTAINER width to the layout; both
+   * routes are now measure-free, so every entry below is read directly and the
+   * special-casing is gone. (The old ALIASES map also carried real doc-rot: it named
+   * `MY_SUBMISSIONS_CONTAINER_SIZE`, a constant that had been renamed.)
    *
-   * ⚠️ WHAT THIS STILL CANNOT CATCH: a route that is listed, consumes its width,
-   * and yet never renders (because something upstream always redirects). That
-   * remains a judgement made by reading the page — see the module docstring.
+   * ⚠️ WHAT THIS STILL CANNOT CATCH: a route that is listed, consumes its measure,
+   * and yet never renders because something upstream always redirects. That remains
+   * a judgement made by reading the page — see the module docstring.
    */
-  test('every APPS_PAGE_WIDTHS entry is actually consumed by its page', () => {
-    const ALIASES: Record<string, string> = {
-      '/apps': 'LISTING_STORE_CONTAINER_SIZE',
-      '/apps/mine': 'MY_APPS_CONTAINER_SIZE',
-    };
+  test('every APPS_PAGE_MEASURES entry is actually consumed by its page', () => {
     const unconsumed: string[] = [];
-    for (const route of Object.keys(APPS_PAGE_WIDTHS)) {
-      const rel = route === '/apps' ? '/apps/index' : route;
-      const file = path.resolve(PAGES_DIR, '..', `${rel.replace(/^\/apps\//, 'apps/')}.tsx`);
+    for (const route of Object.keys(APPS_PAGE_MEASURES)) {
+      const file = pageFile(route);
       if (!fs.existsSync(file)) {
         unconsumed.push(`${route} (no page file at ${file})`);
         continue;
       }
       const src = fs.readFileSync(file, 'utf8');
-      const token = ALIASES[route] ?? `APPS_PAGE_WIDTHS['${route}']`;
-      if (!src.includes(token)) unconsumed.push(`${route} (expected ${token})`);
+      if (!src.includes(`APPS_PAGE_MEASURES['${route}']`)) {
+        unconsumed.push(`${route} (expected APPS_PAGE_MEASURES['${route}'])`);
+      }
     }
     expect(
       unconsumed,
-      'Listed route(s) whose page never reads the width — either wire the page up ' +
-        'or move the route to APPS_FULL_BLEED_PAGES / APPS_REDIRECT_ONLY_PAGES.'
+      'Listed route(s) whose page never reads the measure — either wire the page up ' +
+        'or move the route to APPS_FULL_MEASURE_PAGES / APPS_FULL_BLEED_PAGES / ' +
+        'APPS_REDIRECT_ONLY_PAGES.'
     ).toEqual([]);
+  });
+
+  /**
+   * 🔴 LAYOUT ADOPTION — the guard that catches the FOUR orphans, and any new page.
+   *
+   * Completeness and consumption between them still allowed a page to render its own
+   * bare `<Container>` with no sub-nav: `/apps/get-started`, `/apps/[appBlockId]/edit`,
+   * `/apps/[appBlockId]/revenue` and `/apps/listing/[appListingId]/edit` all did, and
+   * every guard in this file passed. Uniform chrome is a claim about EVERY rendering
+   * route, so it is checked against every rendering route.
+   */
+  describe('🔴 every rendering /apps page renders the shared chrome', () => {
+    /** Routes expected to mount `AppsPageLayout`: measured + full-measure. */
+    const RENDERING_ROUTES = [
+      ...Object.keys(APPS_PAGE_MEASURES),
+      ...APPS_FULL_MEASURE_PAGES,
+    ].sort();
+
+    test('the rendering set is the one we think it is (fails if it grows OR shrinks)', () => {
+      // A ledger, not a floor: a loop over a set nobody pinned passes vacuously when
+      // the set empties, and silently skips a page when the set shrinks.
+      expect(RENDERING_ROUTES).toEqual([
+        '/apps',
+        '/apps/[appBlockId]/edit',
+        '/apps/[appBlockId]/revenue',
+        '/apps/get-started',
+        '/apps/installed',
+        '/apps/invites',
+        '/apps/listing/[appListingId]/edit',
+        '/apps/mine',
+        // 🔴 'revenue' sorts BEFORE 'review' — they diverge at index 9, 'e' < 'i'.
+        '/apps/revenue',
+        '/apps/review',
+        '/apps/review/[publishRequestId]',
+        '/apps/store-preview/[slug]',
+        '/apps/submit',
+      ]);
+      expect(RENDERING_ROUTES).toHaveLength(13);
+    });
+
+    test('each of them imports AND mounts AppsPageLayout', () => {
+      const offenders: string[] = [];
+      let filesRead = 0;
+      for (const route of RENDERING_ROUTES) {
+        const file = pageFile(route);
+        if (!fs.existsSync(file)) {
+          offenders.push(`${route} (no page file at ${file})`);
+          continue;
+        }
+        const src = fs.readFileSync(file, 'utf8');
+        filesRead += 1;
+        if (
+          !/import\s*\{[^}]*\bAppsPageLayout\b[^}]*\}\s*from\s*'~\/components\/Apps\/AppsPageLayout'/.test(
+            src
+          )
+        ) {
+          offenders.push(`${route} (does not import AppsPageLayout)`);
+          continue;
+        }
+        if (!/<AppsPageLayout[\s>]/.test(src)) {
+          offenders.push(`${route} (imports AppsPageLayout but never renders it)`);
+        }
+      }
+      // Guard-the-guard: a reassuring empty `offenders` is indistinguishable from a
+      // loop that read nothing.
+      expect(filesRead).toBe(RENDERING_ROUTES.length);
+      expect(
+        offenders,
+        'Rendering /apps route(s) not on the shared chrome. Wrap the page body in ' +
+          '<AppsPageLayout> (passing `measure` only if it is in APPS_PAGE_MEASURES) ' +
+          'instead of a bare <Container>.'
+      ).toEqual([]);
+    });
+
+    test('🔴 no rendering page hand-rolls its own top-level Mantine Container', () => {
+      // The specific shape of the defect: a page-level `<Container>` re-creates the
+      // per-page box the layout exists to remove. Nested containers inside a body
+      // component are not this file's business — this checks the PAGE files, which
+      // are the ones that own the outermost element.
+      const offenders: string[] = [];
+      let filesRead = 0;
+      for (const route of RENDERING_ROUTES) {
+        const file = pageFile(route);
+        if (!fs.existsSync(file)) continue;
+        const src = fs.readFileSync(file, 'utf8');
+        filesRead += 1;
+        if (/<Container[\s>]/.test(src)) offenders.push(`${route} (renders its own <Container>)`);
+      }
+      expect(filesRead).toBe(RENDERING_ROUTES.length);
+      expect(offenders).toEqual([]);
+    });
   });
 
   test('no classified route is stale (every entry maps to a real page file)', () => {
     const onDisk = new Set(appsRoutes());
     const stale = [
-      ...Object.keys(APPS_PAGE_WIDTHS),
+      ...Object.keys(APPS_PAGE_MEASURES),
+      ...APPS_FULL_MEASURE_PAGES,
       ...APPS_FULL_BLEED_PAGES,
       ...APPS_REDIRECT_ONLY_PAGES,
     ].filter((r) => !onDisk.has(r));

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -60,13 +60,53 @@ const CHROME_DELEGATES: Record<string, { file: string; exportName: string }> = {
 };
 
 /**
- * The top-level JSX tag names of each `return` in a page's default-export component,
- * one array per return statement, fragments unwrapped.
+ * Components a page may render as a SIBLING of the chrome because they are portaled
+ * overlays — they leave the container's layout flow entirely, so "outside the measure
+ * box" is where they belong rather than a defect.
  *
- * 🔴 THIS IS AN AST WALK BECAUSE A TEXT GUARD IS WALKABLE BY A COMMENT. `/<AppsPageLayout[\s>]/`
- * over the file's source matches a `{/* <AppsPageLayout …> *​/}` just as happily as a real
- * render, so a page can be re-orphaned while the guard stays green. Comments are TRIVIA in
- * the TypeScript AST — they are not nodes — so a commented-out element simply is not here.
+ * 🔴 VERIFIED, NOT TRUSTED — the same rule as {@link CHROME_DELEGATES}, and for the same
+ * reason: an allowlist keyed on a NAME is exactly where real page content would hide, and
+ * "…Modal" is a naming convention, not a guarantee. The test below parses each entry and
+ * fails unless it actually renders a portaling overlay at its top level. Adding a name
+ * here cannot silence the guard.
+ */
+const CHROME_PORTAL_SIBLINGS: Record<string, { file: string; exportName: string }> = {
+  OnsiteReviewModal: {
+    file: 'src/components/Apps/OnsiteReviewModal.tsx',
+    exportName: 'OnsiteReviewModal',
+  },
+  OffsiteReviewModal: {
+    file: 'src/components/Apps/OffsiteReviewQueue.tsx',
+    exportName: 'OffsiteReviewModal',
+  },
+  CombinedReviewModal: {
+    file: 'src/components/Apps/CombinedReviewModal.tsx',
+    exportName: 'CombinedReviewModal',
+  },
+};
+
+/** Tags that mean "a portaled overlay root" when a portal sibling renders one. */
+const PORTAL_ROOT_TAGS = new Set(['Modal', 'Modal.Stack', 'Drawer', 'Drawer.Stack', 'Portal']);
+
+/** Tag names that mean "a fragment", i.e. unwrap the children rather than count the tag. */
+const FRAGMENT_TAGS = new Set(['React.Fragment', 'Fragment']);
+
+/**
+ * EVERY top-level renderable JSX tag a component can render, one array per `return`.
+ *
+ * 🔴 AN AST WALK BECAUSE A TEXT GUARD IS WALKABLE BY A COMMENT. `/<AppsPageLayout[\s>]/`
+ * over the file's source matches a commented-out element just as happily as a real render,
+ * so a page could be re-orphaned while the guard stayed green. Comments are TRIVIA in the
+ * TypeScript AST — not nodes — so a commented-out element simply is not here.
+ *
+ * 🔴 EVERY BRANCH IS COLLECTED, AND THAT IS LOAD-BEARING GIVEN HOW THE RESULT IS USED.
+ * A ternary contributes BOTH arms, a fragment contributes ALL its children, and a
+ * `&&` contributes its JSX side. That is only safe because {@link chromeOffenders}
+ * requires EVERY tag to be allowed rather than asking whether the layout appears
+ * SOMEWHERE. An earlier version paired this same flattening with an `includes` check, so
+ * one good ternary arm covered for a re-orphaned one — the union hid the violation
+ * instead of exposing it. Union + "all must be allowed" is the combination that works;
+ * union + "any may match" is strictly worse than not flattening at all.
  *
  * Nested functions are deliberately NOT descended into: a `.map()` callback or a locally
  * declared sub-component has its own returns, and they are not the page's outermost render.
@@ -80,19 +120,52 @@ function pageReturnTags(file: string, exportName?: string): string[][] {
     ts.ScriptKind.TSX
   );
 
-  let component: ts.FunctionDeclaration | undefined;
+  // 🔴 THREE DEFAULT-EXPORT SHAPES, because rejecting a legitimate one turns the BLOCKING
+  // suite red on a page that is perfectly correct: `export default function P() {}`,
+  // `const P = () => {}; export default P;`, and `export default () => {}`. A guard that
+  // only understands one spelling is a guard against a spelling, not against the hazard.
+  let body: ts.Node | undefined;
+  const defaultExportedNames = new Set<string>();
   source.forEachChild((node) => {
-    if (!ts.isFunctionDeclaration(node)) return;
-    const matches = exportName
-      ? node.name?.getText(source) === exportName
-      : node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
-    if (matches) component = node;
+    if (ts.isExportAssignment(node) && !node.isExportEquals) {
+      if (ts.isIdentifier(node.expression))
+        defaultExportedNames.add(node.expression.getText(source));
+      // `export default () => …` / `export default function () {}`
+      else if (ts.isArrowFunction(node.expression) || ts.isFunctionExpression(node.expression)) {
+        if (!exportName) body = node.expression.body;
+      }
+    }
   });
-  if (!component?.body) {
+  source.forEachChild((node) => {
+    if (ts.isFunctionDeclaration(node)) {
+      const name = node.name?.getText(source);
+      const matches = exportName
+        ? name === exportName
+        : node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword) ||
+          (name != null && defaultExportedNames.has(name));
+      if (matches && node.body) body = node.body;
+      return;
+    }
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        const name = decl.name.getText(source);
+        const isExported = node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+        const matches = exportName
+          ? name === exportName && isExported
+          : defaultExportedNames.has(name);
+        if (!matches || !decl.initializer) continue;
+        if (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer)) {
+          body = decl.initializer.body;
+        }
+      }
+    }
+  });
+  if (!body) {
     throw new Error(
       exportName
-        ? `no \`export function ${exportName}\` found`
-        : 'no `export default function` component found'
+        ? `no exported component \`${exportName}\` found`
+        : 'no default-exported component found (tried: export default function, ' +
+          'const X = () => …; export default X, export default () => …)'
     );
   }
 
@@ -100,22 +173,32 @@ function pageReturnTags(file: string, exportName?: string): string[][] {
   const topLevelTags = (expr: ts.Expression | undefined): string[] => {
     if (!expr) return [];
     if (ts.isParenthesizedExpression(expr)) return topLevelTags(expr.expression);
-    // `cond ? <A/> : <B/>` renders one of two trees; both must satisfy the rule.
+    // Both arms — see the 🔴 note above on why the union is safe here.
     if (ts.isConditionalExpression(expr))
       return [...topLevelTags(expr.whenTrue), ...topLevelTags(expr.whenFalse)];
-    // `cond && <A/>` — the JSX side is what can render.
-    if (ts.isBinaryExpression(expr)) return topLevelTags(expr.right);
-    if (ts.isJsxElement(expr)) return [expr.openingElement.tagName.getText(source)];
-    if (ts.isJsxSelfClosingElement(expr)) return [expr.tagName.getText(source)];
-    if (ts.isJsxFragment(expr)) {
+    // `cond && <A/>` / `a ?? <B/>` — either side may be the JSX.
+    if (ts.isBinaryExpression(expr))
+      return [...topLevelTags(expr.left), ...topLevelTags(expr.right)];
+    const childTags = (children: ts.NodeArray<ts.JsxChild>): string[] => {
       const tags: string[] = [];
-      for (const child of expr.children) {
-        if (ts.isJsxElement(child)) tags.push(child.openingElement.tagName.getText(source));
-        else if (ts.isJsxSelfClosingElement(child)) tags.push(child.tagName.getText(source));
-        else if (ts.isJsxExpression(child)) tags.push(...topLevelTags(child.expression));
+      for (const child of children) {
+        if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) {
+          tags.push(...topLevelTags(child as unknown as ts.Expression));
+        } else if (ts.isJsxExpression(child)) tags.push(...topLevelTags(child.expression));
       }
       return tags;
+    };
+    if (ts.isJsxElement(expr)) {
+      const tag = expr.openingElement.tagName.getText(source);
+      // `<React.Fragment>` is a fragment written the long way — unwrap it, or a perfectly
+      // correct page reads as rendering an unknown element called `React.Fragment`.
+      return FRAGMENT_TAGS.has(tag) ? childTags(expr.children) : [tag];
     }
+    if (ts.isJsxSelfClosingElement(expr)) {
+      const tag = expr.tagName.getText(source);
+      return FRAGMENT_TAGS.has(tag) ? [] : [tag];
+    }
+    if (ts.isJsxFragment(expr)) return childTags(expr.children);
     return [];
   };
 
@@ -135,8 +218,44 @@ function pageReturnTags(file: string, exportName?: string): string[][] {
     }
     ts.forEachChild(node, visit);
   };
-  ts.forEachChild(component.body, visit);
+  // A concise arrow body (`() => <X/>`) is an expression, not a block: it IS the return.
+  if (ts.isBlock(body as ts.Node)) ts.forEachChild(body as ts.Node, visit);
+  else groups.push(topLevelTags(body as ts.Expression));
   return groups;
+}
+
+/**
+ * The ONE rule, applied to pages and to chrome delegates alike: in every return that
+ * renders anything, EVERY top-level tag must be the shared layout, a verified delegate,
+ * or an exempt leaf.
+ *
+ * 🔴 "EVERY", NOT "CONTAINS ONE". The predicate used to be
+ * `rendered.includes('AppsPageLayout')`, which three different shapes walked straight
+ * past because they put an un-chromed element ALONGSIDE a chromed one: a ternary whose
+ * other arm rendered a bare centred `<Box>`, a fragment child ternary of the same shape,
+ * and a plain un-chromed sibling inside the top-level fragment. In all three the layout
+ * WAS present somewhere in the group, so `includes` was satisfied while real page content
+ * rendered outside the chrome entirely.
+ */
+function chromeOffenders(label: string, groups: string[][]): string[] {
+  const allowed = new Set([
+    'AppsPageLayout',
+    ...Object.keys(CHROME_DELEGATES),
+    ...Object.keys(CHROME_PORTAL_SIBLINGS),
+  ]);
+  const offenders: string[] = [];
+  for (const tags of groups) {
+    const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
+    if (rendered.length === 0) continue;
+    const stray = rendered.filter((t) => !allowed.has(t));
+    if (stray.length > 0) {
+      offenders.push(
+        `${label} (a return renders [${rendered.join(', ')}] outside the shared chrome — ` +
+          `stray: ${stray.join(', ')})`
+      );
+    }
+  }
+  return offenders;
 }
 
 describe('the container is uniform, and it is the only container', () => {
@@ -517,39 +636,39 @@ describe('every /apps page on disk is classified', () => {
           offenders.push(`${route} (default export has no return statement)`);
           continue;
         }
-        for (const tags of groups) {
-          returnsInspected += 1;
-          // A return that renders nothing renderable, or only an access-denied leaf, is
-          // not required to mount the chrome — those are the gate returns.
-          const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
-          if (rendered.length === 0) continue;
-          if (rendered.includes('AppsPageLayout')) continue;
-          // A delegate satisfies the rule only because it mounts the chrome itself —
-          // which the sibling test proves, rather than this list asserting it.
-          if (rendered.some((t) => CHROME_DELEGATES[t])) continue;
-          offenders.push(
-            `${route} (a return renders [${rendered.join(', ')}] with no AppsPageLayout)`
-          );
-        }
+        returnsInspected += groups.length;
+        // ONE rule, shared with the delegate check below — see `chromeOffenders`.
+        offenders.push(...chromeOffenders(route, groups));
       }
-      // Guard-the-guard, twice: an empty `offenders` is indistinguishable from a loop
-      // that parsed nothing, AND from one that parsed files but found no returns.
-      expect(filesParsed, 'the AST walk parsed no page files').toBe(RENDERING_ROUTES.length);
-      expect(returnsInspected, 'the AST walk found no returns to inspect').toBeGreaterThanOrEqual(
-        RENDERING_ROUTES.length
-      );
+      // 🔴 THE OFFENDER LIST IS ASSERTED FIRST, DELIBERATELY. When a page uses a shape the
+      // walk cannot parse, `filesParsed` also comes up short — and if the count assertion
+      // ran first it would fail with "expected 12 to be 13", burying the one message that
+      // says WHICH page and WHY. Vitest stops at the first failing expect, so the
+      // informative assertion has to be the first one.
       expect(
         offenders,
         'Rendering /apps route(s) not on the shared chrome. Wrap the page body in ' +
           '<AppsPageLayout> (passing `measure` only if it is in APPS_PAGE_MEASURES) ' +
           'instead of any container of its own.'
       ).toEqual([]);
+      // Guard-the-guard, twice: an empty `offenders` is indistinguishable from a loop
+      // that parsed nothing, AND from one that parsed files but found no returns.
+      expect(filesParsed, 'the AST walk parsed no page files').toBe(RENDERING_ROUTES.length);
+      expect(returnsInspected, 'the AST walk found no returns to inspect').toBeGreaterThanOrEqual(
+        RENDERING_ROUTES.length
+      );
     });
 
     test('🔴 every chrome DELEGATE really does mount the chrome', () => {
-      // The allowlist above is the one place a genuine orphan could hide behind a
-      // reassuring name. Parse each delegate and require it to render AppsPageLayout in
-      // every return that renders anything — the same rule the pages are held to.
+      // The allowlist is the one place a genuine orphan could hide behind a reassuring
+      // name, so the delegate is held to LITERALLY the same rule as a page — the same
+      // `chromeOffenders` function, not a paraphrase of it.
+      //
+      // 🔴 IT USED TO BE `groups.some(tags => tags.includes('AppsPageLayout'))` while this
+      // test's own description said "every return that renders anything". Giving
+      // `AppsSubmitEditView` an early return rendering a bare centred `<Box>` walked
+      // straight past it: one good return vouched for a bad one, in the very check whose
+      // job is to stop the allowlist being taken on trust.
       const names = Object.keys(CHROME_DELEGATES);
       expect(names.length, 'the delegate list is empty — nothing to verify').toBeGreaterThan(0);
       const offenders: string[] = [];
@@ -561,12 +680,120 @@ describe('every /apps page on disk is classified', () => {
           continue;
         }
         const groups = pageReturnTags(abs, exportName);
+        if (groups.length === 0) {
+          offenders.push(`${name} (has no return statement)`);
+          continue;
+        }
         const renders = groups.some((tags) => tags.includes('AppsPageLayout'));
         if (!renders) offenders.push(`${name} (does not render AppsPageLayout)`);
+        offenders.push(...chromeOffenders(name, groups));
       }
       expect(
         offenders,
         'A component allowlisted as mounting the shared chrome does not actually mount it.'
+      ).toEqual([]);
+    });
+
+    /**
+     * 🔴 THE RULE ITSELF, TABLE-DRIVEN — because every other test here consumes
+     * `chromeOffenders` and none of them PINS it.
+     *
+     * Found by mutating the guard rather than the code: weakening `chromeOffenders` back
+     * to its old "does the layout appear anywhere in this group" semantics, together with
+     * a real un-chromed sibling on a page, passed the entire blocking suite. The AST
+     * negative control below could not see it — it exercises `pageReturnTags` and
+     * inspects the tags itself, never routing through the rule. So the rule was the one
+     * piece of this machinery with no guard of its own.
+     *
+     * The `[AppsPageLayout, Box]` rows are the load-bearing ones: they are exactly the
+     * shapes an `includes`-style predicate waves through, because the layout IS present —
+     * alongside page content rendering outside it.
+     */
+    describe('🔴 chromeOffenders — the rule, pinned directly', () => {
+      const cases: { name: string; group: string[]; offends: boolean }[] = [
+        { name: 'the layout alone', group: ['AppsPageLayout'], offends: false },
+        { name: 'Meta beside the layout', group: ['Meta', 'AppsPageLayout'], offends: false },
+        { name: 'a bare access-denied leaf', group: ['NotFound'], offends: false },
+        { name: 'nothing renderable', group: [], offends: false },
+        { name: 'a verified delegate', group: ['AppsSubmitEditView'], offends: false },
+        {
+          name: 'a portaled overlay beside the layout',
+          group: ['AppsPageLayout', 'OnsiteReviewModal'],
+          offends: false,
+        },
+        { name: 'page content with NO layout', group: ['Box'], offends: true },
+        // 🔴 The two an `includes` check passes.
+        {
+          name: 'an un-chromed SIBLING alongside the layout',
+          group: ['AppsPageLayout', 'Box'],
+          offends: true,
+        },
+        {
+          name: 'a ternary whose other arm is un-chromed (flattened to one group)',
+          group: ['AppsPageLayout', 'Container'],
+          offends: true,
+        },
+      ];
+
+      test.each(cases)('$name', ({ group, offends }) => {
+        const out = chromeOffenders('fixture', [group]);
+        expect(out.length > 0).toBe(offends);
+      });
+
+      test('the offender message names the stray tag, not just the route', () => {
+        // A guard whose message does not say WHAT is wrong sends the next reader hunting.
+        const [msg] = chromeOffenders('/apps/x', [['AppsPageLayout', 'Box']]);
+        expect(msg).toContain('/apps/x');
+        expect(msg).toContain('stray: Box');
+      });
+
+      test('every case fixture is distinct (no row silently duplicates another)', () => {
+        // Guard-the-guard: duplicated rows inflate the table without adding coverage.
+        const keys = cases.map((c) => c.group.join('|'));
+        expect(new Set(keys).size).toBe(keys.length);
+        // …and the table exercises BOTH verdicts, so it cannot pass by always agreeing.
+        expect(cases.some((c) => c.offends)).toBe(true);
+        expect(cases.some((c) => !c.offends)).toBe(true);
+      });
+    });
+
+    test('🔴 every PORTAL SIBLING really is a portaled overlay', () => {
+      // Same contract as the delegate check: the exemption is earned by what the
+      // component renders, not by what it is called. A page-content component wrongly
+      // listed here would be waved past the chrome rule, which is the whole hazard an
+      // allowlist introduces.
+      const names = Object.keys(CHROME_PORTAL_SIBLINGS);
+      expect(names.length, 'the portal-sibling list is empty — nothing to verify').toBeGreaterThan(
+        0
+      );
+      const offenders: string[] = [];
+      for (const name of names) {
+        const { file, exportName } = CHROME_PORTAL_SIBLINGS[name];
+        const abs = path.resolve(__dirname, '../../../..', file);
+        if (!fs.existsSync(abs)) {
+          offenders.push(`${name} (no file at ${abs})`);
+          continue;
+        }
+        const groups = pageReturnTags(abs, exportName);
+        if (groups.length === 0) {
+          offenders.push(`${name} (has no return statement)`);
+          continue;
+        }
+        // Every return that renders anything must render a portal root — an early
+        // return of ordinary markup would put real content outside the chrome.
+        for (const tags of groups) {
+          const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
+          if (rendered.length === 0) continue;
+          const stray = rendered.filter((t) => !PORTAL_ROOT_TAGS.has(t));
+          if (stray.length > 0) {
+            offenders.push(`${name} (a return renders non-portal roots: ${stray.join(', ')})`);
+          }
+        }
+      }
+      expect(
+        offenders,
+        'A component allowlisted as a portaled overlay renders ordinary markup instead — ' +
+          'it would place page content outside the shared chrome.'
       ).toEqual([]);
     });
 

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import ts from 'typescript';
 import { describe, expect, test } from 'vitest';
 import {
   APPS_CONTAINER_GUTTER,
@@ -31,6 +33,111 @@ import {
  * `AppsPageLayout.chromeAlignment.browser.test.tsx` (browser-mode, report-only). This
  * file pins the CONSTANTS and the route taxonomy in the tier that actually gates.
  */
+
+/**
+ * Tags a page's default export may render WITHOUT mounting the shared chrome: the
+ * access-denied leaf and the document-head element that is a sibling of the layout
+ * rather than a substitute for it.
+ */
+const CHROME_EXEMPT_TAGS = new Set(['Meta', 'NotFound']);
+
+/**
+ * Components a page may render INSTEAD of mounting the chrome itself, because they mount
+ * it one level down. `/apps/submit`'s `?edit=<listingId>` branch is the only such case:
+ * it returns `<AppsSubmitEditView …/>`, and that component owns its own `AppsPageLayout`
+ * (nesting a second one inside it would double the chrome).
+ *
+ * 🔴 EVERY ENTRY IS VERIFIED, NOT TRUSTED. An allowlist is exactly where a real orphan
+ * would hide — "it's fine, that component handles it" is the sentence that stops anyone
+ * looking. The test below parses each delegate's own source and fails if it does not in
+ * fact render `AppsPageLayout`, so adding a name here cannot silence the guard.
+ */
+const CHROME_DELEGATES: Record<string, { file: string; exportName: string }> = {
+  AppsSubmitEditView: {
+    file: 'src/components/Apps/AppsSubmitEditView.tsx',
+    exportName: 'AppsSubmitEditView',
+  },
+};
+
+/**
+ * The top-level JSX tag names of each `return` in a page's default-export component,
+ * one array per return statement, fragments unwrapped.
+ *
+ * 🔴 THIS IS AN AST WALK BECAUSE A TEXT GUARD IS WALKABLE BY A COMMENT. `/<AppsPageLayout[\s>]/`
+ * over the file's source matches a `{/* <AppsPageLayout …> *​/}` just as happily as a real
+ * render, so a page can be re-orphaned while the guard stays green. Comments are TRIVIA in
+ * the TypeScript AST — they are not nodes — so a commented-out element simply is not here.
+ *
+ * Nested functions are deliberately NOT descended into: a `.map()` callback or a locally
+ * declared sub-component has its own returns, and they are not the page's outermost render.
+ */
+function pageReturnTags(file: string, exportName?: string): string[][] {
+  const source = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  let component: ts.FunctionDeclaration | undefined;
+  source.forEachChild((node) => {
+    if (!ts.isFunctionDeclaration(node)) return;
+    const matches = exportName
+      ? node.name?.getText(source) === exportName
+      : node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
+    if (matches) component = node;
+  });
+  if (!component?.body) {
+    throw new Error(
+      exportName
+        ? `no \`export function ${exportName}\` found`
+        : 'no `export default function` component found'
+    );
+  }
+
+  /** Tag names at the TOP level of one returned expression. */
+  const topLevelTags = (expr: ts.Expression | undefined): string[] => {
+    if (!expr) return [];
+    if (ts.isParenthesizedExpression(expr)) return topLevelTags(expr.expression);
+    // `cond ? <A/> : <B/>` renders one of two trees; both must satisfy the rule.
+    if (ts.isConditionalExpression(expr))
+      return [...topLevelTags(expr.whenTrue), ...topLevelTags(expr.whenFalse)];
+    // `cond && <A/>` — the JSX side is what can render.
+    if (ts.isBinaryExpression(expr)) return topLevelTags(expr.right);
+    if (ts.isJsxElement(expr)) return [expr.openingElement.tagName.getText(source)];
+    if (ts.isJsxSelfClosingElement(expr)) return [expr.tagName.getText(source)];
+    if (ts.isJsxFragment(expr)) {
+      const tags: string[] = [];
+      for (const child of expr.children) {
+        if (ts.isJsxElement(child)) tags.push(child.openingElement.tagName.getText(source));
+        else if (ts.isJsxSelfClosingElement(child)) tags.push(child.tagName.getText(source));
+        else if (ts.isJsxExpression(child)) tags.push(...topLevelTags(child.expression));
+      }
+      return tags;
+    }
+    return [];
+  };
+
+  const groups: string[][] = [];
+  const visit = (node: ts.Node) => {
+    // Do not descend into a nested function — its returns are not the page's render.
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node)
+    ) {
+      return;
+    }
+    if (ts.isReturnStatement(node)) {
+      groups.push(topLevelTags(node.expression));
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(component.body, visit);
+  return groups;
+}
 
 describe('the container is uniform, and it is the only container', () => {
   test('every `/apps/*` route renders in ONE container width (1920)', () => {
@@ -383,38 +490,118 @@ describe('every /apps page on disk is classified', () => {
       expect(RENDERING_ROUTES).toHaveLength(13);
     });
 
-    test('each of them imports AND mounts AppsPageLayout', () => {
+    test('every RETURN of every page renders the layout (AST, not text)', () => {
+      // 🔴 PARSED, NOT GREPPED, and that is the whole point — see `pageReturnTags`.
+      // A text guard here was walkable two ways at once: move `<AppsPageLayout …>` into
+      // a JSX comment (the regex matches the COMMENT) and render `<Box maw={…}
+      // mx="auto">` instead (no `<Container>`, so the sibling ban never fires). The page
+      // is re-orphaned with no sub-nav and both text guards stay green.
       const offenders: string[] = [];
-      let filesRead = 0;
+      let filesParsed = 0;
+      let returnsInspected = 0;
       for (const route of RENDERING_ROUTES) {
         const file = pageFile(route);
         if (!fs.existsSync(file)) {
           offenders.push(`${route} (no page file at ${file})`);
           continue;
         }
-        const src = fs.readFileSync(file, 'utf8');
-        filesRead += 1;
-        if (
-          !/import\s*\{[^}]*\bAppsPageLayout\b[^}]*\}\s*from\s*'~\/components\/Apps\/AppsPageLayout'/.test(
-            src
-          )
-        ) {
-          offenders.push(`${route} (does not import AppsPageLayout)`);
+        let groups: string[][];
+        try {
+          groups = pageReturnTags(file);
+        } catch (err) {
+          offenders.push(`${route} (could not parse: ${(err as Error).message})`);
           continue;
         }
-        if (!/<AppsPageLayout[\s>]/.test(src)) {
-          offenders.push(`${route} (imports AppsPageLayout but never renders it)`);
+        filesParsed += 1;
+        if (groups.length === 0) {
+          offenders.push(`${route} (default export has no return statement)`);
+          continue;
+        }
+        for (const tags of groups) {
+          returnsInspected += 1;
+          // A return that renders nothing renderable, or only an access-denied leaf, is
+          // not required to mount the chrome — those are the gate returns.
+          const rendered = tags.filter((t) => !CHROME_EXEMPT_TAGS.has(t));
+          if (rendered.length === 0) continue;
+          if (rendered.includes('AppsPageLayout')) continue;
+          // A delegate satisfies the rule only because it mounts the chrome itself —
+          // which the sibling test proves, rather than this list asserting it.
+          if (rendered.some((t) => CHROME_DELEGATES[t])) continue;
+          offenders.push(
+            `${route} (a return renders [${rendered.join(', ')}] with no AppsPageLayout)`
+          );
         }
       }
-      // Guard-the-guard: a reassuring empty `offenders` is indistinguishable from a
-      // loop that read nothing.
-      expect(filesRead).toBe(RENDERING_ROUTES.length);
+      // Guard-the-guard, twice: an empty `offenders` is indistinguishable from a loop
+      // that parsed nothing, AND from one that parsed files but found no returns.
+      expect(filesParsed, 'the AST walk parsed no page files').toBe(RENDERING_ROUTES.length);
+      expect(returnsInspected, 'the AST walk found no returns to inspect').toBeGreaterThanOrEqual(
+        RENDERING_ROUTES.length
+      );
       expect(
         offenders,
         'Rendering /apps route(s) not on the shared chrome. Wrap the page body in ' +
           '<AppsPageLayout> (passing `measure` only if it is in APPS_PAGE_MEASURES) ' +
-          'instead of a bare <Container>.'
+          'instead of any container of its own.'
       ).toEqual([]);
+    });
+
+    test('🔴 every chrome DELEGATE really does mount the chrome', () => {
+      // The allowlist above is the one place a genuine orphan could hide behind a
+      // reassuring name. Parse each delegate and require it to render AppsPageLayout in
+      // every return that renders anything — the same rule the pages are held to.
+      const names = Object.keys(CHROME_DELEGATES);
+      expect(names.length, 'the delegate list is empty — nothing to verify').toBeGreaterThan(0);
+      const offenders: string[] = [];
+      for (const name of names) {
+        const { file, exportName } = CHROME_DELEGATES[name];
+        const abs = path.resolve(__dirname, '../../../..', file);
+        if (!fs.existsSync(abs)) {
+          offenders.push(`${name} (no file at ${abs})`);
+          continue;
+        }
+        const groups = pageReturnTags(abs, exportName);
+        const renders = groups.some((tags) => tags.includes('AppsPageLayout'));
+        if (!renders) offenders.push(`${name} (does not render AppsPageLayout)`);
+      }
+      expect(
+        offenders,
+        'A component allowlisted as mounting the shared chrome does not actually mount it.'
+      ).toEqual([]);
+    });
+
+    test('🔴 the AST walk can SEE a violation (negative control on the guard above)', () => {
+      // The guard above returns a reassuring empty list; this proves the machinery that
+      // produces it can produce a non-empty one. A synthetic page whose layout call sits
+      // in a comment — mutant M5b exactly — must be reported, and the comment must NOT
+      // count as a render.
+      const tmp = path.join(os.tmpdir(), `apps-chrome-negative-control-${process.pid}.tsx`);
+      fs.writeFileSync(
+        tmp,
+        [
+          "import { Box } from '@mantine/core';",
+          "import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';",
+          'export default function FakePage() {',
+          '  return (',
+          '    <>',
+          '      {/* <AppsPageLayout measure={1068}> */}',
+          '      <Box maw={1068} mx="auto" />',
+          '      {/* </AppsPageLayout> */}',
+          '    </>',
+          '  );',
+          '}',
+        ].join('\n')
+      );
+      try {
+        const groups = pageReturnTags(tmp);
+        expect(groups).toHaveLength(1);
+        const rendered = groups[0].filter((t) => !CHROME_EXEMPT_TAGS.has(t));
+        // The comment is trivia in the AST, so it cannot masquerade as a render.
+        expect(rendered).not.toContain('AppsPageLayout');
+        expect(rendered).toContain('Box');
+      } finally {
+        fs.unlinkSync(tmp);
+      }
     });
 
     test('🔴 no rendering page hand-rolls its own top-level Mantine Container', () => {

--- a/src/components/Apps/__tests__/myAppsView.test.ts
+++ b/src/components/Apps/__tests__/myAppsView.test.ts
@@ -7,7 +7,6 @@ import {
   isInactiveListing,
   listingMediaIndex,
   listingMediaShots,
-  MY_APPS_CONTAINER_SIZE,
   myAppListingHref,
   orphanGroupStartsOpen,
   pageCount,
@@ -393,18 +392,21 @@ describe('canOpenListingAuthoringPage — the row link rule, and the only rule',
   });
 });
 
-describe('MY_APPS_CONTAINER_SIZE', () => {
-  it('is a raw px number, not a Mantine size token (tokens cap at xl = 1320)', () => {
-    expect(typeof MY_APPS_CONTAINER_SIZE).toBe('number');
-    expect(Number.isFinite(MY_APPS_CONTAINER_SIZE)).toBe(true);
-  });
-
-  it('is wider than the readable/form width the page used before the merge', () => {
-    // The page went from a single-column card list to a two-image table when it absorbed
-    // /apps/my-submissions; 1100 is the width that made the old submissions table clip.
-    expect(MY_APPS_CONTAINER_SIZE).toBeGreaterThan(1100);
-  });
-});
+/**
+ * 🔴 THE `MY_APPS_CONTAINER_SIZE` BLOCK THAT LIVED HERE IS DELETED WITH THE CONSTANT.
+ *
+ * It aliased `APPS_PAGE_WIDTHS['/apps/mine']` so the page could hand a per-page width to
+ * `AppsPageLayout size=`. That prop is gone — every `/apps/*` route renders in the one
+ * `APPS_PAGE_CONTAINER_WIDTH` container, because the shared sub-nav lived inside the
+ * per-page box and moved horizontally between routes.
+ *
+ * Its assertions are not merely dropped. `> 1100` was a weak proxy for "this page is wide
+ * enough for its table" — it could not have noticed the container falling to 1400, which
+ * would have re-opened the clip. The real relationship,
+ * `APPS_PAGE_CONTAINER_WIDTH − SUBMISSIONS_CONTAINER_CHROME > SUBMISSIONS_TABLE_MIN_WIDTH`,
+ * is asserted in `appsPageWidths.test.ts` together with the counterfactual that the
+ * readable measure would NOT clear that floor.
+ */
 
 /* ------------------------------------------------------------------ *
  * The row's two images, as ONE viewer list

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -665,12 +665,13 @@ describe('SUBMISSIONS_TABLE_MIN_WIDTH', () => {
 });
 
 /**
- * 🔴 THE `MY_SUBMISSIONS_CONTAINER_SIZE` BLOCK THAT LIVED HERE MOVED WITH ITS PAGE.
- * `/apps/my-submissions` merged into `/apps/mine` and 301s there, so the container-width
- * alias is now `MY_APPS_CONTAINER_SIZE` in `myAppsView.ts` and its assertions live in
- * `myAppsView.test.ts` (plus the consumption walk in `appsPageWidths.test.ts`, whose
- * ALIASES map now names it). The scroll-floor arithmetic below stays here because it is
- * still about THESE two tables.
+ * 🔴 THE `MY_SUBMISSIONS_CONTAINER_SIZE` BLOCK THAT LIVED HERE IS GONE FOR GOOD.
+ * `/apps/my-submissions` merged into `/apps/mine` and 301s there; the alias became
+ * `MY_APPS_CONTAINER_SIZE` in `myAppsView.ts`, and that has now been deleted too — every
+ * `/apps/*` route renders in ONE container (`APPS_PAGE_CONTAINER_WIDTH`), so no page has a
+ * width of its own to alias. What the alias was really protecting — that this page is wide
+ * enough for the floor below — is asserted as a relationship in `appsPageWidths.test.ts`.
+ * The scroll-floor arithmetic below stays here because it is still about THESE two tables.
  */
 
 describe('both my-submissions tables scroll rather than clip (S3, structural)', () => {
@@ -691,7 +692,8 @@ describe('both my-submissions tables scroll rather than clip (S3, structural)', 
    * this rewrite. Same trap for the negative `minWidth` assertion, which an
    * unrelated `minWidth={400}` anywhere in a ~700-line file would trip.
    */
-  const inTag = (prop: string) => new RegExp(String.raw`<Table\.ScrollContainer\b[^>]*?\s${prop}`, 's');
+  const inTag = (prop: string) =>
+    new RegExp(String.raw`<Table\.ScrollContainer\b[^>]*?\s${prop}`, 's');
 
   for (const file of LISTS) {
     describe(file, () => {

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -1,5 +1,4 @@
-import type { MantineSize } from '@mantine/core';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
 
 /**
  * App Store Listings (W13) — the `/apps` store's GEOMETRY constants, split out of
@@ -35,20 +34,27 @@ export const LISTING_GRID_SPAN = {
 } as const;
 
 /**
- * `/apps` store container width (px), passed to `AppsPageLayout size=`.
+ * The container width the `/apps` store grid is sized against (px).
  *
- * 🔴 NO LONGER A LITERAL HERE. The number now lives in
- * `~/components/Apps/appsPageWidths` alongside every other `/apps/*` route's
- * width, because the store is one page in a set whose widths were decided
- * together; this file re-exports it so the container/span pair stays visible
- * from the grid side. Two copies of the number is exactly the drift the pairing
- * comment above is trying to prevent — don't inline it back.
+ * 🔴 NO LONGER A LITERAL HERE, AND NO LONGER A PROP. The number lives in
+ * `~/components/Apps/appsPageWidths` as {@link APPS_PAGE_CONTAINER_WIDTH}, the ONE
+ * container width every `/apps/*` route now renders in; this file re-exports it so
+ * the container/span pair stays visible and assertable from the grid side. Two
+ * copies of the number is exactly the drift the pairing comment above is trying to
+ * prevent — don't inline it back.
  *
- * The full-width pass moved it 1600 → 1920. The `xl` span was DELIBERATELY left
- * at 3 (four columns): at 1920 that yields ~460 px cards (vs ~383 at 1600), so
- * the 2026-07 "make app cover images larger" pass gets larger still rather than
- * being undone. Re-tuning to five columns at `xl` would land ~365 px — narrower
- * than what that pass shipped — so it is not a neutral "keep the density"
- * choice. The arithmetic is pinned in `__tests__/appsPageWidths.test.ts`.
+ * It used to be passed to `AppsPageLayout size=`. That prop is gone (the shared
+ * chrome rendered inside it, so a per-page width moved the sub-nav horizontally
+ * between routes). `/apps` takes NO body measure, so its content width still IS the
+ * container width and the arithmetic below is unchanged — this constant is now the
+ * DERIVATION the grid span is tuned against rather than a value the page hands the
+ * layout.
+ *
+ * The full-width pass moved it 1600 → 1920. The `xl` span was DELIBERATELY left at 3
+ * (four columns): at 1920 that yields ~460 px cards (vs ~383 at 1600), so the
+ * 2026-07 "make app cover images larger" pass gets larger still rather than being
+ * undone. Re-tuning to five columns at `xl` would land ~365 px — narrower than what
+ * that pass shipped — so it is not a neutral "keep the density" choice. The
+ * arithmetic is pinned in `__tests__/appsPageWidths.test.ts`.
  */
-export const LISTING_STORE_CONTAINER_SIZE: MantineSize | number = APPS_PAGE_WIDTHS['/apps'];
+export const LISTING_STORE_CONTAINER_SIZE: number = APPS_PAGE_CONTAINER_WIDTH;

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -50,6 +50,14 @@ export const LISTING_GRID_SPAN = {
  * DERIVATION the grid span is tuned against rather than a value the page hands the
  * layout.
  *
+ * 🔴 IT HAS NO PRODUCTION CONSUMER ANY MORE — it is read only by
+ * `__tests__/appListingGrid.test.ts` and `__tests__/appsPageWidths.test.ts`. That is
+ * deliberate, not dead code left behind: the pair below is arithmetic nobody executes at
+ * runtime (the container width is applied by `AppsPageLayout`, the span by the grid), so
+ * a named constant read by the tests is the only place the coupling can be STATED and
+ * checked. Deleting it would not remove any behaviour; it would remove the only thing
+ * that fails when someone moves one half of the pair.
+ *
  * The full-width pass moved it 1600 → 1920. The `xl` span was DELIBERATELY left at 3
  * (four columns): at 1920 that yields ~460 px cards (vs ~383 at 1600), so the
  * 2026-07 "make app cover images larger" pass gets larger still rather than being

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -1,188 +1,230 @@
 /**
- * `/apps/*` CONTAINER WIDTHS — one constants module, one decision per route.
+ * `/apps/*` GEOMETRY — ONE container for every route, an optional CONTENT MEASURE
+ * inside it.
  *
- * Why a module and not a `size=` literal per page: before this, every `/apps`
- * surface picked its own width by hand — the store passed a raw `1600`,
- * `/apps/my-submissions` passed `1500` (derived from a table measurement), a few
- * passed a Mantine token (`'lg'` 990 / `'xl'` 1320 / `'sm'` 620), and the rest
- * silently inherited `AppsPageLayout`'s `'xl'` default. Nothing recorded WHY any
- * of them differed, so "make the apps pages full width" had no single place to
- * land and no way to prove it landed everywhere.
+ * 🔴 THE MODEL, AND WHY IT CHANGED. This module used to export `APPS_PAGE_WIDTHS`,
+ * a per-route CONTAINER width, and `AppsPageLayout` fed it straight into its
+ * `<Container size=…>`. The shared chrome — the {@link ~/components/Apps/AppsSubNav}
+ * tab strip — renders INSIDE that Container, so it inherited each page's own width
+ * and the one element that is supposed to be identical on every apps page moved
+ * horizontally as you navigated. Measured on a real render of `AppsPageLayout`
+ * (Chromium, Mantine stylesheet loaded), reading the nav's `getBoundingClientRect()`:
  *
- * 🔴 THE PAIR. The store's width is HALF of a matched pair with the grid column
- * span in {@link ~/components/Apps/appListingGrid} — the span decides how many
- * cards fit a row, the width decides how wide a row is, and moving one without
- * the other silently re-truncates (or over-stretches) the cards. That file's
- * `LISTING_STORE_CONTAINER_SIZE` now reads `APPS_PAGE_WIDTHS['/apps']` from here
- * rather than carrying its own copy of the number, and both halves are pinned in
+ *                                     @1440           @2560
+ *   route                     size    left  width    left  width
+ *   /apps                     1920      16   1408     336   1888
+ *   /apps/review              1400      36   1368     596   1368
+ *   /apps/store-preview/[..]  1320      76   1288     636   1288
+ *   /apps/submit              1100     186   1068     746   1068
+ *
+ * i.e. a 170px left / 340px width spread at 1440 and a 410px / 820px spread at 2560,
+ * for a tab strip whose whole job is to stay put. The container is now UNIFORM
+ * ({@link APPS_PAGE_CONTAINER_WIDTH}) and the narrowing that some pages genuinely
+ * need moved INSIDE the body, below the chrome, as a left-aligned max-width box.
+ *
+ * The measures below are therefore CONTENT widths, not container widths, and they
+ * are the OLD container widths minus the `Container`'s own `2 × 16px` gutter — so
+ * every page's rendered content is byte-identical in width to what it was before,
+ * and the ONLY thing this change moves is the chrome's alignment. See
+ * {@link APPS_CONTAINER_GUTTER} for that arithmetic, which is pinned in
+ * `__tests__/appsPageWidths.test.ts`.
+ *
+ * 🔴 THE PAIR (unchanged in force, and now stronger). The store's width is HALF of a
+ * matched pair with the grid column span in {@link ~/components/Apps/appListingGrid}
+ * — the span decides how many cards fit a row, the width decides how wide a row is,
+ * and moving one without the other silently re-truncates (or over-stretches) the
+ * cards. `/apps` takes NO measure, so its content width IS the container width, and
+ * `LISTING_STORE_CONTAINER_SIZE` reads {@link APPS_PAGE_CONTAINER_WIDTH} rather than
+ * carrying its own copy of the number. Both halves stay pinned in
  * `__tests__/appsPageWidths.test.ts` + `__tests__/appListingGrid.test.ts`.
  *
  * "Fluid → max N" is exactly what Mantine's `Container size={N}` already is: a
- * `max-width` with responsive horizontal padding and auto margins. So a page at
- * 1920 fills a 1440px viewport edge-to-edge (minus padding) and only stops
+ * `max-width` with responsive horizontal padding and auto margins. So the apps
+ * container fills a 1440px viewport edge-to-edge (minus padding) and only stops
  * growing past 1920 — it is NOT a fixed 1920px box.
  */
 
 /**
- * The WIDE width — the browse/manage surfaces that render a grid or a wide table
- * and are actively hurt by an artificial cap on a large monitor.
+ * The horizontal gutter Mantine's `Container` reserves — `16px` per side, and it is
+ * INSIDE the `max-width` (the component is border-box).
  *
- * 1920 rather than "unbounded": at 2560 an unbounded store grid runs 6+ cards
- * across with the text measure of each card's tagline unchanged, and the wide
- * tables (`/apps/my-submissions`, `/apps/review`) put ~1500px of columns beside
- * ~1000px of whitespace-padded row actions. 1920 is the common wide-desktop
- * width, so on a 1920 monitor the pages are genuinely edge-to-edge and on a
- * 2560 one they stay a readable block.
+ * 🔴 THIS IS THE WHOLE REASON THE MEASURES ARE NOT ROUND NUMBERS. A page that used to
+ * pass `size={1100}` rendered `1100 − 32 = 1068px` of content. A measure box lives
+ * INSIDE that gutter, so `maw={1100}` would render `1100px` of content — 32px wider
+ * than before. Subtracting the gutter here keeps this change a PURE alignment fix:
+ * no page's content width moves, so any visual regression is attributable to the
+ * alignment and not to a confounded width change.
  */
-export const APPS_WIDE_PAGE_WIDTH = 1920;
+export const APPS_CONTAINER_GUTTER = 32;
 
 /**
- * The READABLE width — single-column form/detail surfaces where line length, not
- * available space, is the constraint. A submit wizard or a listing detail page
- * stretched to 1920 puts prose on a 1900px measure, which is unreadable.
+ * The ONE container width every `/apps/*` route renders in.
  *
- * 1100 is wider than the previous `'sm'` (620) / `'md'` (800) / `'lg'` (990)
- * tokens these pages used — the forms have two-column rows and media grids that
- * were cramped at 620 — while staying inside a comfortable measure.
+ * 1920 rather than "unbounded": at 2560 an unbounded store grid runs 6+ cards across
+ * with the text measure of each card's tagline unchanged, and the wide tables put
+ * ~1500px of columns beside ~1000px of whitespace-padded row actions. 1920 is the
+ * common wide-desktop width, so on a 1920 monitor the pages are genuinely
+ * edge-to-edge and on a 2560 one they stay a readable block.
+ *
+ * 🔴 IT IS ALSO THE CHROME'S WIDTH, on every route, which is the point of this
+ * module. Do not reintroduce a per-page `Container size=` — `AppsPageLayout` no
+ * longer accepts one, and `__tests__/appsPageLayout.test.ts` pins that.
  */
-export const APPS_READABLE_PAGE_WIDTH = 1100;
+export const APPS_PAGE_CONTAINER_WIDTH = 1920;
 
 /**
- * The NARROW-TABLE width — a table surface with few, short columns, where 1920 is
- * not "full width" but "stretched".
+ * The READABLE measure — single-column form/detail surfaces where line length, not
+ * available space, is the constraint. A submit wizard or a listing editor stretched
+ * to 1888 puts prose and form rows on an unreadable measure.
  *
- * `/apps/review` is the case this exists for. It renders FOUR narrow columns
- * (Kind / App / Submitter / Submitted) plus a Review button. At 1920 the columns
- * cannot spend the space, so the table distributes it as padding: Submitter grows
- * to ~380px to hold a short username, and a large dead gap opens between the last
- * column and the Review button, which is the action the moderator is actually
- * aiming at. The same table reads well at 1200.
+ * `1068 = 1100 − 32`: the content width these pages rendered when they passed
+ * `size={1100}`. 1100 was chosen as wider than the `sm` (620) / `md` (800) / `lg`
+ * (990) tokens these pages used before it — the forms have two-column rows and media
+ * grids that were cramped at 620 — while staying inside a comfortable measure.
+ */
+export const APPS_READABLE_MEASURE = 1068;
+
+/**
+ * The NARROW-TABLE measure — a table surface with few, short columns, where the full
+ * container is not "full width" but "stretched".
  *
- * 1400 rather than 1200: it keeps the page wider than the readable/form width and
- * still fills a 1440 laptop edge-to-edge, while stopping short of the width where
- * the row's two ends stop reading as one row.
+ * `/apps/review` is the case this exists for. It renders FOUR narrow columns (Kind /
+ * App / Submitter / Submitted) plus a Review button. At 1888 the columns cannot spend
+ * the space, so the table distributes it as padding: Submitter grows to ~380px to
+ * hold a short username, and a large dead gap opens between the last column and the
+ * Review button, which is the action the moderator is actually aiming at.
  *
- * 🔴 This is a THIRD class, deliberately — not a one-off number. The module's rule
- * is "a page joins a class, or the class list grows on purpose"; the guard in
- * `__tests__/appsPageWidths.test.ts` enumerates the classes, so adding a fourth
- * bespoke width still fails there first. `/apps/my-submissions` is NOT moved here:
- * its table is genuinely wide (a 1424px scroll floor), so 1920 is load-bearing for
+ * `1368 = 1400 − 32`: the content width the page rendered at `size={1400}`. 1400 was
+ * picked over 1200 to keep the page wider than the readable/form width while stopping
+ * short of the width where the row's two ends stop reading as one row.
+ *
+ * 🔴 A DISTINCT CLASS, deliberately — not a one-off number. The module's rule is "a
+ * page joins a class, or the class list grows on purpose"; the guard in
+ * `__tests__/appsPageWidths.test.ts` enumerates the classes as literals, so adding a
+ * fourth bespoke measure still fails there first. `/apps/mine` is NOT moved here: its
+ * table has a measured 1424px scroll floor, so the full container is load-bearing for
  * it in a way it is not for `/apps/review`.
  */
-export const APPS_NARROW_TABLE_PAGE_WIDTH = 1400;
+export const APPS_NARROW_TABLE_MEASURE = 1368;
 
 /**
- * The TWO-COLUMN DETAIL width — a detail page laid out as a main column plus a
+ * The TWO-COLUMN DETAIL measure — a detail page laid out as a main column plus a
  * right rail, where BOTH halves have to be usable at once.
  *
- * `/apps/store-preview/[slug]` is the case this exists for, and it is a FOURTH class
- * on purpose (the guard in `__tests__/appsPageWidths.test.ts` enumerates the class
- * list as literals, so this could not be added silently — which is the point).
+ * `/apps/store-preview/[slug]` is the case this exists for. It is a deliberate port
+ * of the MODEL DETAIL page's layout (`<Container size="xl">` in
+ * `src/pages/models/[id]/[[...slug]].tsx`) — the same `ContainerGrid2` with the same
+ * `{ base: 12, sm: 7, md: 8 }` / `{ base: 12, sm: 5, md: 4 }` spans — so it takes
+ * that page's content measure rather than a number of its own.
  *
- * 1320 is Mantine's `xl` container, which is what the MODEL DETAIL page uses
- * (`<Container size="xl">` in `src/pages/models/[id]/[[...slug]].tsx`). The listing
- * detail is a deliberate port of that page's layout — the same `ContainerGrid2` with
- * the same `{ base: 12, sm: 7, md: 8 }` / `{ base: 12, sm: 5, md: 4 }` spans — so it
- * takes the same width rather than a number of its own. Matching the source of the
- * design language is the whole reason this class is not just "readable, but bigger".
+ * `1288 = 1320 − 32`, and Mantine's `xl` container is 1320 border-box, so 1288 is
+ * EXACTLY what the model detail page renders its content at. Stating the equivalence
+ * in content terms is what makes it true: `maw={1320}` here would have been 32px
+ * wider than the page it claims to match.
  *
- * Why not the READABLE 1100 it used to be: at 1100 the `md` split gives a ~350px
- * right rail, which is narrower than the creator card + action card want, and the
- * page reads as a squeezed single column with a sliver beside it. Why not the WIDE
- * 1920: the left column is prose (a `CustomMarkdown` description), and 8/12 of 1888
- * is a ~1250px measure — the exact thing {@link APPS_READABLE_PAGE_WIDTH} exists to
- * avoid. At 1320 the left column is ~845px and the rail ~420px.
+ * Why not the READABLE measure it used to be: at 1068 the `md` split gives a ~340px
+ * right rail, narrower than the creator card + action card want, and the page reads as
+ * a squeezed single column with a sliver beside it. Why not the full container: the
+ * left column is prose (a `CustomMarkdown` description), and 8/12 of 1888 is a
+ * ~1250px measure — the exact thing {@link APPS_READABLE_MEASURE} exists to avoid. At
+ * 1288 the left column is ~825px and the rail ~410px.
  */
-export const APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH = 1320;
+export const APPS_TWO_COLUMN_DETAIL_MEASURE = 1288;
 
 /**
- * Container width per `/apps/*` route, keyed by the NEXT ROUTE PATHNAME (the
- * `src/pages` path, `[param]` segments included) so a reader can map an entry to
- * a file without guessing.
+ * CONTENT MEASURE per `/apps/*` route, keyed by the NEXT ROUTE PATHNAME (the
+ * `src/pages` path, `[param]` segments included) so a reader can map an entry to a
+ * file without guessing.
  *
- * Every rendering `/apps/*` route must appear here or in
- * {@link APPS_FULL_BLEED_PAGES}/{@link APPS_REDIRECT_ONLY_PAGES} — enforced by a
- * unit test that walks `src/pages/apps` on disk, so a NEW apps page cannot ship
- * without an explicit width decision.
+ * A route is listed here ONLY if its body should be narrower than the container.
+ * Everything else takes the full container and is listed in
+ * {@link APPS_FULL_MEASURE_PAGES}. Every rendering `/apps/*` route must appear in one
+ * of the four lists in this module — enforced by a unit test that walks
+ * `src/pages/apps` on disk, so a NEW apps page cannot ship without an explicit
+ * decision.
  *
- * 🔴 WHAT THE GUARDS DO AND DO NOT ENFORCE — read this before trusting the
- * taxonomy below, because it has already been wrong once.
+ * 🔴 WHAT THE GUARDS DO AND DO NOT ENFORCE — read this before trusting the taxonomy
+ * below, because it has already been wrong once.
  *
- * The tests enforce exactly two things:
+ * The tests enforce exactly three things:
  *   1. COMPLETENESS — every `/apps/*` page file on disk is listed somewhere, and
  *      every listed route has a page file (the fs walk).
- *   2. CONSUMPTION — every route in `APPS_PAGE_WIDTHS` has a page that actually
- *      reads its width from here, so an entry cannot be dead code.
+ *   2. CONSUMPTION — every route in {@link APPS_PAGE_MEASURES} has a page that
+ *      actually reads its measure from here, so an entry cannot be dead code.
+ *   3. LAYOUT ADOPTION — every rendering route imports and renders `AppsPageLayout`,
+ *      which is what makes the chrome uniform in the first place.
  *
  * They do NOT enforce CORRECTNESS OF CLASSIFICATION. Nothing checks that a route
- * listed as rendering really renders. `/apps/[appBlockId]` was listed here with
- * the comment "still renders for a direct hit" while the page's own docstring
- * said RETIRED and its `getServerSideProps` unconditionally redirects — so the
- * width was unreachable AND this module asserted a false fact about the app.
- * Deciding which list a route belongs in is a JUDGEMENT that has to be made by
- * reading the page's `getServerSideProps`; a passing test suite is not evidence
- * that it was made correctly.
+ * listed as rendering really renders. `/apps/[appBlockId]` was once listed with the
+ * comment "still renders for a direct hit" while the page's own docstring said
+ * RETIRED and its `getServerSideProps` unconditionally redirects — so the width was
+ * unreachable AND this module asserted a false fact about the app. Deciding which
+ * list a route belongs in is a JUDGEMENT that has to be made by reading the page's
+ * `getServerSideProps`; a passing test suite is not evidence that it was made
+ * correctly.
  */
-export const APPS_PAGE_WIDTHS = {
-  // ── Wide: grids + wide tables ────────────────────────────────────────────
-  /** The store grid. Paired with `LISTING_GRID_SPAN` — see the 🔴 note above. */
-  '/apps': APPS_WIDE_PAGE_WIDTH,
-  '/apps/installed': APPS_WIDE_PAGE_WIDTH,
+export const APPS_PAGE_MEASURES = {
   /**
-   * `/apps/mine` — the merged author table (it absorbed `/apps/my-submissions`, which now
-   * 301s here and has no page file).
+   * NARROW TABLE, not full width. Four short columns (Kind / App / Submitter /
+   * Submitted) cannot spend the container — see {@link APPS_NARROW_TABLE_MEASURE}.
+   * The DETAIL route takes no measure at all: it renders side-by-side diff panels +
+   * a live preview, which do use the space.
+   */
+  '/apps/review': APPS_NARROW_TABLE_MEASURE,
+  /**
+   * TWO-COLUMN DETAIL, not readable-single-column — the model-detail-page layout
+   * (main column + right rail), so it takes that page's content measure.
    *
-   * 🔴 MOVED FROM 1100 TO 1920 WITH THE MERGE, and the reason is the content, not the
-   * route. At 1100 this page was a single-column card list; it is now a table carrying an
-   * icon, a cover, three badges and a date per row, i.e. the same class of surface as the
-   * wide table it replaced (which held this width under its own key). Leaving it readable
-   * would have re-created the exact clip the wide width was introduced to fix.
+   * 🔴 NOT part of the store's matched pair. The pair documented at the top of this
+   * file couples {@link APPS_PAGE_CONTAINER_WIDTH} to `LISTING_GRID_SPAN`; the only
+   * reader of that pair is `LISTING_STORE_CONTAINER_SIZE`, and nothing in
+   * `appListingGrid.ts` reads this route. Moving this number cannot re-truncate a
+   * store card.
    */
-  '/apps/mine': APPS_WIDE_PAGE_WIDTH,
-  /**
-   * NARROW TABLE, not wide. Four short columns (Kind / App / Submitter /
-   * Submitted) cannot spend 1920 — see {@link APPS_NARROW_TABLE_PAGE_WIDTH}. The
-   * DETAIL route below stays wide: it renders side-by-side diff panels + a live
-   * preview, which do use the space.
-   */
-  '/apps/review': APPS_NARROW_TABLE_PAGE_WIDTH,
-  '/apps/review/[publishRequestId]': APPS_WIDE_PAGE_WIDTH,
-  '/apps/revenue': APPS_WIDE_PAGE_WIDTH,
-
-  // ── Readable: forms + detail ─────────────────────────────────────────────
+  '/apps/store-preview/[slug]': APPS_TWO_COLUMN_DETAIL_MEASURE,
   /** The submit wizard — a form, so measure beats space. */
-  '/apps/submit': APPS_READABLE_PAGE_WIDTH,
-  /**
-   * TWO-COLUMN DETAIL, not readable-single-column. It was 1100 while the body was one
-   * stacked column; it is now the model-detail-page layout (main column + right rail),
-   * so it takes that page's own width. See {@link APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH}.
-   *
-   * 🔴 NOT part of the store's matched pair. The pair documented at the top of this file
-   * couples `APPS_PAGE_WIDTHS['/apps']` to `LISTING_GRID_SPAN` — verified: the only
-   * reader of that pair is `LISTING_STORE_CONTAINER_SIZE`, which indexes `'/apps'`, and
-   * nothing in `appListingGrid.ts` reads this route. Moving this number therefore cannot
-   * re-truncate a store card.
-   */
-  '/apps/store-preview/[slug]': APPS_TWO_COLUMN_DETAIL_PAGE_WIDTH,
+  '/apps/submit': APPS_READABLE_MEASURE,
+  /** The invitee's pending-invitation inbox — a short card list. */
+  '/apps/invites': APPS_READABLE_MEASURE,
   /**
    * The LEGACY block-keyed tabbed editor. Still RENDERING, not redirect-only: its
-   * `getServerSideProps` 302s to `/apps/listing/<appListingId>/edit` only when the block
-   * HAS a listing, and falls through to this page when it does not (a first-version app
-   * pending approval has no `AppListing` row). Classified by reading that resolver — see
-   * the 🔴 note above about `/apps/[appBlockId]` having been mis-listed once.
+   * `getServerSideProps` 302s to `/apps/listing/<appListingId>/edit` only when the
+   * block HAS a listing, and falls through to this page when it does not (a
+   * first-version app pending approval has no `AppListing` row). Classified by
+   * reading that resolver — see the 🔴 note above about `/apps/[appBlockId]` having
+   * been mis-listed once.
    */
-  '/apps/[appBlockId]/edit': APPS_READABLE_PAGE_WIDTH,
+  '/apps/[appBlockId]/edit': APPS_READABLE_MEASURE,
   /** The CANONICAL listing-keyed authoring editor — serves both store kinds. */
-  '/apps/listing/[appListingId]/edit': APPS_READABLE_PAGE_WIDTH,
-  /** The invitee's pending-invitation inbox — a short card list. */
-  '/apps/invites': APPS_READABLE_PAGE_WIDTH,
+  '/apps/listing/[appListingId]/edit': APPS_READABLE_MEASURE,
   /** Per-app revenue detail. */
-  '/apps/[appBlockId]/revenue': APPS_READABLE_PAGE_WIDTH,
+  '/apps/[appBlockId]/revenue': APPS_READABLE_MEASURE,
   /** The developer get-started explainer — prose. */
-  '/apps/get-started': APPS_READABLE_PAGE_WIDTH,
+  '/apps/get-started': APPS_READABLE_MEASURE,
 } as const satisfies Record<string, number>;
 
-export type AppsPageRoute = keyof typeof APPS_PAGE_WIDTHS;
+export type AppsMeasuredRoute = keyof typeof APPS_PAGE_MEASURES;
+
+/**
+ * Rendering routes that take the FULL container — the browse/manage surfaces that
+ * render a grid or a wide table and are actively hurt by an artificial cap on a large
+ * monitor. They pass no `measure` to `AppsPageLayout` at all.
+ *
+ * 🔴 `/apps/mine` is here, not in {@link APPS_PAGE_MEASURES}, and the reason is the
+ * content rather than the route: it absorbed `/apps/my-submissions` (which now 301s
+ * here and has no page file) and is a table carrying an icon, a cover, three badges
+ * and a date per row, with a measured `SUBMISSIONS_TABLE_MIN_WIDTH` scroll floor of
+ * 1424px. Giving it the readable measure would re-create the exact clip the wide
+ * width was introduced to fix; `__tests__/appsPageWidths.test.ts` pins the container
+ * against that floor.
+ */
+export const APPS_FULL_MEASURE_PAGES = [
+  '/apps',
+  '/apps/installed',
+  '/apps/mine',
+  '/apps/revenue',
+  '/apps/review/[publishRequestId]',
+] as const;
 
 /**
  * Routes that deliberately have NO container: they host a full-viewport iframe
@@ -198,7 +240,7 @@ export const APPS_FULL_BLEED_PAGES = [
 /**
  * Routes whose `getServerSideProps` always redirects or 404s — their default
  * export exists only to satisfy Next's page contract and never renders, so a
- * width would be dead code.
+ * measure would be dead code.
  */
 export const APPS_REDIRECT_ONLY_PAGES = [
   '/apps/store-preview',
@@ -208,10 +250,10 @@ export const APPS_REDIRECT_ONLY_PAGES = [
    * RETIRED (S8/PR-2). Its `getServerSideProps` unconditionally redirects to
    * `/apps/store-preview/<slug>`; the component body is retained only so a stale
    * bookmark resolves through the hop, and is documented in that file as
-   * unreachable. It was briefly listed in {@link APPS_PAGE_WIDTHS} above with the
-   * comment "still renders for a direct hit" — which the page itself contradicts.
-   * A width there was dead code AND, worse, made this module's own taxonomy
-   * assert a false fact about the app.
+   * unreachable. It was briefly listed as a rendering route with the comment "still
+   * renders for a direct hit" — which the page itself contradicts. A width there was
+   * dead code AND, worse, made this module's own taxonomy assert a false fact about
+   * the app.
    */
   '/apps/[appBlockId]',
 ] as const;

--- a/src/components/Apps/myAppsView.ts
+++ b/src/components/Apps/myAppsView.ts
@@ -1,6 +1,5 @@
 import type { EditorTab } from '~/components/Apps/appListingEditorTabs';
 import { editorTabsFor, listingEditHref } from '~/components/Apps/appListingEditorTabs';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
 import type { ListingProblem } from '~/server/services/blocks/listing-problems';
 import type {
   AppRole,
@@ -18,11 +17,22 @@ import type {
  */
 
 /**
- * The container width. Alias-with-a-consumer, the same shape as
- * `LISTING_STORE_CONTAINER_SIZE` — `appsPageWidths.test.ts` recognises the pattern and
- * checks the page really reads it.
+ * 🔴 `MY_APPS_CONTAINER_SIZE` LIVED HERE AND IS GONE ON PURPOSE. Do not re-add it.
+ *
+ * It aliased `APPS_PAGE_WIDTHS['/apps/mine']` so the page could hand a per-page width
+ * to `AppsPageLayout size=`. That prop no longer exists: every `/apps/*` route now
+ * renders in the ONE `APPS_PAGE_CONTAINER_WIDTH` container, because the shared sub-nav
+ * lived inside the per-page box and moved horizontally between routes. `/apps/mine`
+ * takes no body measure either — its table has a measured 1424px scroll floor
+ * (`SUBMISSIONS_TABLE_MIN_WIDTH`) that the full container is what clears.
+ *
+ * The thing the alias was protecting — "this page is wide enough for its table" — is
+ * now a RELATIONSHIP rather than a number, and is asserted directly in
+ * `__tests__/appsPageWidths.test.ts` as
+ * `APPS_PAGE_CONTAINER_WIDTH − SUBMISSIONS_CONTAINER_CHROME > SUBMISSIONS_TABLE_MIN_WIDTH`.
+ * That is strictly stronger than the old `> 1100` pin, which could not have noticed the
+ * container dropping to 1400.
  */
-export const MY_APPS_CONTAINER_SIZE: number = APPS_PAGE_WIDTHS['/apps/mine'];
 
 /** Rows per page in the Inactive collapse. */
 export const INACTIVE_PAGE_SIZE = 10;

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -72,12 +72,16 @@ export const SUBMISSIONS_TABLE_MIN_WIDTH = 1424;
 export const SUBMISSIONS_CONTAINER_CHROME = 34;
 
 /**
- * 🔴 `MY_SUBMISSIONS_CONTAINER_SIZE` LIVED HERE AND IS GONE. `/apps/my-submissions` was
- * merged into `/apps/mine` and 301s there; the container-width alias moved with the page
- * it belongs to and is now `MY_APPS_CONTAINER_SIZE` in `myAppsView.ts`, reading through to
- * `APPS_PAGE_WIDTHS['/apps/mine']` (also 1920 — see that entry for why the merged table
- * took the wide width). {@link SUBMISSIONS_CONTAINER_CHROME} stays here because the
- * scroll-floor arithmetic it belongs to is still this module's.
+ * 🔴 `MY_SUBMISSIONS_CONTAINER_SIZE` LIVED HERE AND IS GONE, AND SO HAS ITS SUCCESSOR.
+ * `/apps/my-submissions` merged into `/apps/mine` and 301s there, so the alias moved to
+ * `MY_APPS_CONTAINER_SIZE` in `myAppsView.ts` — and that is now gone too: every `/apps/*`
+ * route renders in the single `APPS_PAGE_CONTAINER_WIDTH` (1920) container, so there is no
+ * per-page width left to alias. `/apps/mine` takes no body measure either, precisely so the
+ * table below clears the floor. The relationship that used to be implied by the alias is
+ * asserted directly in `__tests__/appsPageWidths.test.ts`:
+ * `APPS_PAGE_CONTAINER_WIDTH − SUBMISSIONS_CONTAINER_CHROME > SUBMISSIONS_TABLE_MIN_WIDTH`.
+ * {@link SUBMISSIONS_CONTAINER_CHROME} stays here because the scroll-floor arithmetic it
+ * belongs to is still this module's.
  */
 
 /** Sortable columns shared by both tables. */

--- a/src/pages/apps/[appBlockId]/edit.tsx
+++ b/src/pages/apps/[appBlockId]/edit.tsx
@@ -91,6 +91,25 @@ export default function AppEditPage() {
   return (
     <>
       <Meta title="Edit app — Civitai Apps" deIndex />
+      {/*
+        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S — one of three adopted pages
+        where that is true. The `getServerSideProps` above gates on `appBlocks` ALONE,
+        with no author requirement, while `AppsSubNav` hides itself entirely below TWO
+        qualifying tabs. Only "Marketplace" is unconditional; every other tab needs an
+        author capability, an install, an approved app, a pending invite or reviewer
+        status. So a viewer granted `app-blocks-enabled` in Flipt who is not a moderator,
+        not an author, and holds none of those — a seated collaborator on someone else's
+        listing is the realistic shape — reaches this page, qualifies for one tab, and
+        gets an EMPTY chrome band: the `Stack gap="xl"` above the body and nothing else.
+
+        Not a live defect (pre-GA the flag resolves for mods, who are authors), and not a
+        correctness problem when it does happen — it is 32px of dead space, not a broken
+        page. Recorded because the trigger is a RUNTIME Flipt toggle rather than a deploy:
+        `appBlocks` is `{ availability: ['mod'], fliptKey: 'app-blocks-enabled' }` and
+        `getFeatureFlags` returns the Flipt answer before it evaluates `availability`, so
+        this widens with no code change and no PR. See the fuller note in
+        `src/pages/apps/get-started.tsx`.
+      */}
       <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/[appBlockId]/edit']}>
         <Stack gap="lg">
           {/* Item 3: history-aware back — pop history when there's any, else fall

--- a/src/pages/apps/[appBlockId]/edit.tsx
+++ b/src/pages/apps/[appBlockId]/edit.tsx
@@ -1,8 +1,9 @@
-import { Anchor, Center, Container, Group, Loader, Stack, Tabs } from '@mantine/core';
+import { Anchor, Center, Group, Loader, Stack, Tabs } from '@mantine/core';
 import { IconArrowLeft, IconPhoto, IconSettings } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { NotFound } from '~/components/AppLayout/NotFound';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { ListingMediaEditor } from '~/components/Apps/ListingMediaEditor';
 import { ManifestEditForm } from '~/components/Apps/ManifestEditForm';
 import { ALL_EDITOR_TABS } from '~/components/Apps/appListingEditorTabs';
@@ -90,7 +91,7 @@ export default function AppEditPage() {
   return (
     <>
       <Meta title="Edit app — Civitai Apps" deIndex />
-      <Container size={APPS_PAGE_WIDTHS['/apps/[appBlockId]/edit']} py="md">
+      <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/[appBlockId]/edit']}>
         <Stack gap="lg">
           {/* Item 3: history-aware back — pop history when there's any, else fall
               back to the app details page (the media editor is now a TAB here, so
@@ -152,7 +153,7 @@ export default function AppEditPage() {
             </Tabs.Panel>
           </Tabs>
         </Stack>
-      </Container>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/[appBlockId]/edit.tsx
+++ b/src/pages/apps/[appBlockId]/edit.tsx
@@ -92,8 +92,8 @@ export default function AppEditPage() {
     <>
       <Meta title="Edit app — Civitai Apps" deIndex />
       {/*
-        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S — one of three adopted pages
-        where that is true. The `getServerSideProps` above gates on `appBlocks` ALONE,
+        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S. The `getServerSideProps` above
+        gates on `appBlocks` ALONE,
         with no author requirement, while `AppsSubNav` hides itself entirely below TWO
         qualifying tabs. Only "Marketplace" is unconditional; every other tab needs an
         author capability, an install, an approved app, a pending invite or reviewer

--- a/src/pages/apps/[appBlockId]/revenue.tsx
+++ b/src/pages/apps/[appBlockId]/revenue.tsx
@@ -1,9 +1,10 @@
-import { Anchor, Badge, Container, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Badge, Group, Stack, Text, Title } from '@mantine/core';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { RevenuePanel } from '~/components/AppBlocks/RevenuePanel';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
@@ -65,7 +66,7 @@ export default function AppRevenuePage() {
   return (
     <>
       <Meta title={`Revenue — ${thisApp?.appName ?? appBlockId}`} deIndex />
-      <Container size={APPS_PAGE_WIDTHS['/apps/[appBlockId]/revenue']} py="xl">
+      <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/[appBlockId]/revenue']}>
         <Stack gap="lg">
           <div>
             <Group gap="xs" align="baseline">
@@ -98,7 +99,7 @@ export default function AppRevenuePage() {
           */}
           <RevenuePanel appBlockId={appBlockId} />
         </Stack>
-      </Container>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/get-started.tsx
+++ b/src/pages/apps/get-started.tsx
@@ -53,17 +53,28 @@ export default function AppsGetStartedPage() {
         deIndex
       />
       {/*
-        🔴 ONE OF THREE ADOPTED PAGES WHOSE GATE DOES NOT IMPLY THE SUB-NAV'S. This page
+        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S. This page
         gates on `appBlocksGetStarted` ALONE (see the docstring above), while
         `AppsSubNav` renders only for `hasAppsStoreAccess` (`appListings || appBlocks`)
         AND hides itself below two qualifying tabs. Those are independent flags, so a
         viewer can hold this page's flag and not the nav's — and then the chrome band
         renders empty (the sub-nav returns `null`), costing the `Stack gap="xl"` above
-        the body and nothing else. The other two are `/apps/[appBlockId]/edit` and
-        `/apps/listing/[appListingId]/edit`, which gate on `appBlocks` alone; see the
-        matching note in each. (`/apps/[appBlockId]/revenue` is NOT affected — it gates
-        on `appBlocksAuthor` + `isAppDeveloper`, which guarantees the Create tab and so
-        clears the two-tab floor.)
+        the body and nothing else.
+
+        🔴 THE CRITERION, NOT A COUNT — apply it, do not trust a total written here. An
+        earlier version of this note said "one of three", and it was wrong: it stated the
+        two-tab floor as part of the test and then counted only the pages whose FLAG
+        mismatches, missing `/apps` and `/apps/store-preview/[slug]`, which gate on
+        `hasAppsStoreAccess` — a predicate that likewise does not imply two tabs (see
+        `AppsSubNav.tsx`, which names the reachable cohort outright: `app-listings=true`,
+        `app-blocks-author=false`, non-author, no installs ⇒ Marketplace alone). That was
+        the second hand-maintained integer in this change to go stale, so there is no
+        third one. THE TEST: a page can show an empty band iff its gate does not
+        guarantee the viewer ≥2 qualifying sub-nav tabs. Read the page's
+        `getServerSideProps`, then read `SUB_NAV_LINKS` + `if (links.length < 2) return
+        null` in `AppsSubNav.tsx`, and decide. `/apps/[appBlockId]/revenue` is the useful
+        contrast — it gates on `appBlocksAuthor` + `isAppDeveloper`, which guarantees the
+        Create tab and therefore clears the floor.
 
         NOT REACHABLE TODAY: `appBlocksGetStarted` is staged mod-only, and a moderator
         holds `appBlocks` (hence the store predicate) and is an `isAppDeveloper`, so the

--- a/src/pages/apps/get-started.tsx
+++ b/src/pages/apps/get-started.tsx
@@ -53,18 +53,35 @@ export default function AppsGetStartedPage() {
         deIndex
       />
       {/*
-        🔴 THE ONE ADOPTED PAGE WHOSE GATE DOES NOT IMPLY THE SUB-NAV'S. This page
+        🔴 ONE OF THREE ADOPTED PAGES WHOSE GATE DOES NOT IMPLY THE SUB-NAV'S. This page
         gates on `appBlocksGetStarted` ALONE (see the docstring above), while
-        `AppsSubNav` renders only for `hasAppsStoreAccess` (`appListings || appBlocks`).
-        Those are independent flags, so a viewer can hold this page's flag and not the
-        nav's — and then the chrome band renders empty (the sub-nav returns `null`),
-        costing the `Stack gap="xl"` above the body and nothing else.
+        `AppsSubNav` renders only for `hasAppsStoreAccess` (`appListings || appBlocks`)
+        AND hides itself below two qualifying tabs. Those are independent flags, so a
+        viewer can hold this page's flag and not the nav's — and then the chrome band
+        renders empty (the sub-nav returns `null`), costing the `Stack gap="xl"` above
+        the body and nothing else. The other two are `/apps/[appBlockId]/edit` and
+        `/apps/listing/[appListingId]/edit`, which gate on `appBlocks` alone; see the
+        matching note in each. (`/apps/[appBlockId]/revenue` is NOT affected — it gates
+        on `appBlocksAuthor` + `isAppDeveloper`, which guarantees the Create tab and so
+        clears the two-tab floor.)
+
         NOT REACHABLE TODAY: `appBlocksGetStarted` is staged mod-only, and a moderator
         holds `appBlocks` (hence the store predicate) and is an `isAppDeveloper`, so the
-        bar clears its own two-tab floor with Marketplace + Create. It becomes reachable
-        the moment this flag widens to `['public']` — which is a one-line change in
-        feature-flags.service.ts. TODO(launch): widen the sub-nav's gate with it, or
-        keep this page off the shared chrome.
+        bar clears its floor with Marketplace + Create.
+
+        🔴 BUT THE TRIGGER IS A RUNTIME TOGGLE, NOT A DEPLOY. An earlier version of this
+        note said it becomes reachable "the moment this flag widens to ['public'] — a
+        one-line change in feature-flags.service.ts". That is wrong, and wrong in the
+        dangerous direction: it pins the hazard to an event a reviewer would see in a
+        diff. `appBlocksGetStarted` is `{ availability: ['mod'], fliptKey:
+        'app-blocks-get-started' }`, and `getFeatureFlags` returns the Flipt answer
+        BEFORE it ever evaluates `availability` ("Flipt overrides role checks (both
+        enable AND disable)"). So `availability` is only the Flipt-DOWN fallback: this
+        page can widen to the public by flipping `app-blocks-get-started` in Flipt, with
+        no code change, no PR and no deploy. All four App-Blocks flags are shaped this
+        way (`appBlocks`, `appListings`, `appBlocksAuthor`, `appBlocksGetStarted`).
+        TODO(launch): before any Flipt widening, either widen the sub-nav's gate with it
+        or keep this page off the shared chrome.
       */}
       <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/get-started']}>
         <GetStartedBody />

--- a/src/pages/apps/get-started.tsx
+++ b/src/pages/apps/get-started.tsx
@@ -1,6 +1,6 @@
-import { Container } from '@mantine/core';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { GetStartedBody } from '~/components/Apps/GetStartedBody';
 import { resolveGetStartedAccess } from '~/components/Apps/resolveGetStartedAccess';
 import { Meta } from '~/components/Meta/Meta';
@@ -52,9 +52,23 @@ export default function AppsGetStartedPage() {
         description="Build small web apps that run inside Civitai. Install the Civitai CLI and runtime SDK, scaffold an app, and test it locally."
         deIndex
       />
-      <Container size={APPS_PAGE_WIDTHS['/apps/get-started']} py="xl">
+      {/*
+        🔴 THE ONE ADOPTED PAGE WHOSE GATE DOES NOT IMPLY THE SUB-NAV'S. This page
+        gates on `appBlocksGetStarted` ALONE (see the docstring above), while
+        `AppsSubNav` renders only for `hasAppsStoreAccess` (`appListings || appBlocks`).
+        Those are independent flags, so a viewer can hold this page's flag and not the
+        nav's — and then the chrome band renders empty (the sub-nav returns `null`),
+        costing the `Stack gap="xl"` above the body and nothing else.
+        NOT REACHABLE TODAY: `appBlocksGetStarted` is staged mod-only, and a moderator
+        holds `appBlocks` (hence the store predicate) and is an `isAppDeveloper`, so the
+        bar clears its own two-tab floor with Marketplace + Create. It becomes reachable
+        the moment this flag widens to `['public']` — which is a one-line change in
+        feature-flags.service.ts. TODO(launch): widen the sub-nav's gate with it, or
+        keep this page off the shared chrome.
+      */}
+      <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/get-started']}>
         <GetStartedBody />
-      </Container>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { AppListingsMarketplaceBody } from '~/components/Apps/AppListingsMarketplaceBody';
-import { LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
 import { buildAppsStoreFeedbackContext } from '~/components/Apps/appsStoreFeedbackContext';
 import { parseAppsStoreFilters } from '~/components/Apps/appsStoreQueryParams';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
@@ -71,7 +70,7 @@ export default function AppsPage() {
           (`blocks.backfillAppListings` → `appListings.backfillListingAssets`,
           a separate post-deploy op step) — the empty state renders sanely
           ("No apps yet"); expected + fine while dark. */}
-      <AppsPageLayout size={LISTING_STORE_CONTAINER_SIZE}>
+      <AppsPageLayout>
         {/* FEEDBACK PROMPT — above the store controls, mirroring where the images
             feed mounts it (above the grid rather than after it).
 

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -30,7 +30,6 @@ import { NotFound } from '~/components/AppLayout/NotFound';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
 import { groupSubscriptionsByApp } from '~/components/Apps/groupSubscriptionsByApp';
 import type { GroupedApp } from '~/components/Apps/groupSubscriptionsByApp';
 import { useHiddenBlockList, unhideBlock } from '~/components/AppBlocks/hiddenBlocks';
@@ -264,10 +263,7 @@ function InstalledAppCard({ app, onManage }: InstalledAppCardProps) {
                 </Tooltip>
               )}
               {blanketViewer && (
-                <Tooltip
-                  label="Visible only to you, on every model page you open."
-                  withArrow
-                >
+                <Tooltip label="Visible only to you, on every model page you open." withArrow>
                   <Badge
                     size="sm"
                     variant="light"
@@ -404,8 +400,8 @@ function HiddenBlocksPanel() {
         <Stack align="center" gap="xs">
           <IconEyeOff size={28} opacity={0.5} />
           <Text size="sm" c="dimmed" ta="center" maw={420}>
-            You haven't hidden any apps. Use the ⋯ menu on an app to hide it on this
-            device — it only affects what you see, never the publisher or other viewers.
+            You haven't hidden any apps. Use the ⋯ menu on an app to hide it on this device — it
+            only affects what you see, never the publisher or other viewers.
           </Text>
         </Stack>
       </Center>
@@ -460,10 +456,7 @@ export default function InstalledAppsPage() {
     enabled: !!features.appBlocks,
   });
 
-  const groupedApps = useMemo(
-    () => groupSubscriptionsByApp(subs ?? []),
-    [subs]
-  );
+  const groupedApps = useMemo(() => groupSubscriptionsByApp(subs ?? []), [subs]);
 
   function handleManage(sub: SubscriptionRecord) {
     // Build an AvailableBlock-shaped object from the subscription's
@@ -503,7 +496,6 @@ export default function InstalledAppsPage() {
     <>
       <Meta title="Installed Apps — Civitai" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/installed']}
         title="Your installed apps"
         subtitle="Manage where Civitai Apps show up across the site."
         actions={
@@ -518,75 +510,70 @@ export default function InstalledAppsPage() {
         }
       >
         <Tabs defaultValue="subscriptions" variant="outline">
-            <Tabs.List>
-              <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
-                Installs
-              </Tabs.Tab>
-              <Tabs.Tab value="permissions" leftSection={<IconShieldLock size={14} />}>
-                Apps & permissions
-              </Tabs.Tab>
-              <Tabs.Tab value="activity" leftSection={<IconHistory size={14} />}>
-                Recent activity
-              </Tabs.Tab>
-              <Tabs.Tab value="hidden" leftSection={<IconEyeOff size={14} />}>
-                Hidden
-              </Tabs.Tab>
-            </Tabs.List>
+          <Tabs.List>
+            <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
+              Installs
+            </Tabs.Tab>
+            <Tabs.Tab value="permissions" leftSection={<IconShieldLock size={14} />}>
+              Apps & permissions
+            </Tabs.Tab>
+            <Tabs.Tab value="activity" leftSection={<IconHistory size={14} />}>
+              Recent activity
+            </Tabs.Tab>
+            <Tabs.Tab value="hidden" leftSection={<IconEyeOff size={14} />}>
+              Hidden
+            </Tabs.Tab>
+          </Tabs.List>
 
-            <Tabs.Panel value="subscriptions" pt="md">
-              {isLoading ? (
-                <Center py="xl">
-                  <Loader />
-                </Center>
-              ) : groupedApps.length === 0 ? (
-                <EmptyState label="Nothing installed yet — browse the marketplace." />
-              ) : (
-                <Stack gap="md">
-                  {groupedApps.map((app) => (
-                    <InstalledAppCard
-                      key={app.appBlockId}
-                      app={app}
-                      onManage={handleManage}
-                    />
-                  ))}
-                </Stack>
-              )}
-            </Tabs.Panel>
-
-            <Tabs.Panel value="permissions" pt="md">
-              <Stack gap="sm">
-                <Text size="sm" c="dimmed">
-                  What each app you've installed can request, and where you have it. This is a
-                  reflection of the current state — to revoke access, remove the install or
-                  subscription on the Subscriptions tab.
-                </Text>
-                <ScopeGrantsPanel />
+          <Tabs.Panel value="subscriptions" pt="md">
+            {isLoading ? (
+              <Center py="xl">
+                <Loader />
+              </Center>
+            ) : groupedApps.length === 0 ? (
+              <EmptyState label="Nothing installed yet — browse the marketplace." />
+            ) : (
+              <Stack gap="md">
+                {groupedApps.map((app) => (
+                  <InstalledAppCard key={app.appBlockId} app={app} onManage={handleManage} />
+                ))}
               </Stack>
-            </Tabs.Panel>
+            )}
+          </Tabs.Panel>
 
-            <Tabs.Panel value="activity" pt="md">
-              <Stack gap="sm">
-                <Text size="sm" c="dimmed">
-                  Recent actions apps have taken on your behalf — Buzz spends plus every
-                  scope-gated API call (read profile, read model, etc.).
-                </Text>
-                <AppActivityPanel />
-              </Stack>
-            </Tabs.Panel>
+          <Tabs.Panel value="permissions" pt="md">
+            <Stack gap="sm">
+              <Text size="sm" c="dimmed">
+                What each app you've installed can request, and where you have it. This is a
+                reflection of the current state — to revoke access, remove the install or
+                subscription on the Subscriptions tab.
+              </Text>
+              <ScopeGrantsPanel />
+            </Stack>
+          </Tabs.Panel>
 
-            <Tabs.Panel value="hidden" pt="md">
-              <Stack gap="sm">
-                <Text size="sm" c="dimmed">
-                  Apps you've hidden on this device. Hiding is local to your browser —
-                  it never affects the publisher's install or other viewers. Restore one to
-                  have it show on its model page again.
-                </Text>
-                <HiddenBlocksPanel />
-              </Stack>
-            </Tabs.Panel>
+          <Tabs.Panel value="activity" pt="md">
+            <Stack gap="sm">
+              <Text size="sm" c="dimmed">
+                Recent actions apps have taken on your behalf — Buzz spends plus every scope-gated
+                API call (read profile, read model, etc.).
+              </Text>
+              <AppActivityPanel />
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="hidden" pt="md">
+            <Stack gap="sm">
+              <Text size="sm" c="dimmed">
+                Apps you've hidden on this device. Hiding is local to your browser — it never
+                affects the publisher's install or other viewers. Restore one to have it show on its
+                model page again.
+              </Text>
+              <HiddenBlocksPanel />
+            </Stack>
+          </Tabs.Panel>
         </Tabs>
       </AppsPageLayout>
     </>
   );
 }
-

--- a/src/pages/apps/invites.tsx
+++ b/src/pages/apps/invites.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { AppInvitesBody } from '~/components/Apps/AppInvitesBody';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { AppTransferOffers } from '~/components/Apps/AppTransferOffers';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
@@ -44,7 +44,7 @@ export default function AppInvitesPage() {
     <>
       <Meta title="App invitations — Civitai Apps" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/invites']}
+        measure={APPS_PAGE_MEASURES['/apps/invites']}
         title="App invitations"
         subtitle="Invitations to collaborate on someone else's app, and offers to take one over."
       >

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -186,8 +186,8 @@ export default function AppListingEditPage() {
     <>
       <Meta title={`Edit ${context.name} — Civitai Apps`} deIndex />
       {/*
-        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S — one of three adopted pages
-        where that is true. The `getServerSideProps` above gates on `appBlocks` ALONE,
+        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S. The `getServerSideProps` above
+        gates on `appBlocks` ALONE,
         with no author requirement, while `AppsSubNav` hides itself entirely below TWO
         qualifying tabs. Only "Marketplace" is unconditional; every other tab needs an
         author capability, an install, an approved app, a pending invite or reviewer

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -185,6 +185,25 @@ export default function AppListingEditPage() {
   return (
     <>
       <Meta title={`Edit ${context.name} — Civitai Apps`} deIndex />
+      {/*
+        🔴 THIS PAGE'S GATE DOES NOT IMPLY THE SUB-NAV'S — one of three adopted pages
+        where that is true. The `getServerSideProps` above gates on `appBlocks` ALONE,
+        with no author requirement, while `AppsSubNav` hides itself entirely below TWO
+        qualifying tabs. Only "Marketplace" is unconditional; every other tab needs an
+        author capability, an install, an approved app, a pending invite or reviewer
+        status. So a viewer granted `app-blocks-enabled` in Flipt who is not a moderator,
+        not an author, and holds none of those — a seated collaborator on someone else's
+        listing is the realistic shape — reaches this page, qualifies for one tab, and
+        gets an EMPTY chrome band: the `Stack gap="xl"` above the body and nothing else.
+
+        Not a live defect (pre-GA the flag resolves for mods, who are authors), and not a
+        correctness problem when it does happen — it is 32px of dead space, not a broken
+        page. Recorded because the trigger is a RUNTIME Flipt toggle rather than a deploy:
+        `appBlocks` is `{ availability: ['mod'], fliptKey: 'app-blocks-enabled' }` and
+        `getFeatureFlags` returns the Flipt answer before it evaluates `availability`, so
+        this widens with no code change and no PR. See the fuller note in
+        `src/pages/apps/get-started.tsx`.
+      */}
       <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/listing/[appListingId]/edit']}>
         <Stack gap="lg">
           <Anchor

--- a/src/pages/apps/listing/[appListingId]/edit.tsx
+++ b/src/pages/apps/listing/[appListingId]/edit.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Center, Container, Group, Loader, Stack, Tabs } from '@mantine/core';
+import { Anchor, Center, Group, Loader, Stack, Tabs } from '@mantine/core';
 import {
   IconArrowLeft,
   IconCoin,
@@ -21,7 +21,8 @@ import {
   listingEditHref,
   resolveEditorTab,
 } from '~/components/Apps/appListingEditorTabs';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { ListingHistoryPanel } from '~/components/Apps/ListingHistoryPanel';
 import { ListingPublishingPanel } from '~/components/Apps/ListingPublishingPanel';
 import { AppsListingDetailsEditor } from '~/components/Apps/AppsSubmitEditView';
@@ -148,11 +149,11 @@ export default function AppListingEditPage() {
 
   if (isLoading || !context) {
     return (
-      <Container size={APPS_PAGE_WIDTHS['/apps/listing/[appListingId]/edit']} py="md">
+      <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/listing/[appListingId]/edit']}>
         <Center py="xl">
           <Loader />
         </Center>
-      </Container>
+      </AppsPageLayout>
     );
   }
 
@@ -184,7 +185,7 @@ export default function AppListingEditPage() {
   return (
     <>
       <Meta title={`Edit ${context.name} — Civitai Apps`} deIndex />
-      <Container size={APPS_PAGE_WIDTHS['/apps/listing/[appListingId]/edit']} py="md">
+      <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/listing/[appListingId]/edit']}>
         <Stack gap="lg">
           <Anchor
             component="button"
@@ -290,7 +291,7 @@ export default function AppListingEditPage() {
             ) : null}
           </Tabs>
         </Stack>
-      </Container>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/mine.tsx
+++ b/src/pages/apps/mine.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { MyAppsBody } from '~/components/Apps/MyAppsBody';
 import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
-import { MY_APPS_CONTAINER_SIZE } from '~/components/Apps/myAppsView';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
@@ -47,7 +46,6 @@ export default function MyAppsPage() {
     <>
       <Meta title="My apps — Civitai Apps" deIndex />
       <AppsPageLayout
-        size={MY_APPS_CONTAINER_SIZE}
         title="My apps"
         // 🔴 COMPOSED FROM THE KIND LABELS, not retyped. This subtitle spelled the
         // kinds by hand and drifted from every other surface; enrolled in

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -5,7 +5,6 @@ import { AppAnalyticsPanel } from '~/components/AppBlocks/AppAnalyticsPanel';
 import { RevenuePanel } from '~/components/AppBlocks/RevenuePanel';
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -41,7 +40,6 @@ export default function AppBlocksDashboardPage() {
     <>
       <Meta title="Apps Dashboard — Civitai" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/revenue']}
         title="Apps Dashboard"
         subtitle={
           <>

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -1,11 +1,5 @@
 import { Tabs } from '@mantine/core';
-import {
-  IconCheck,
-  IconClipboardList,
-  IconClock,
-  IconFlag,
-  IconX,
-} from '@tabler/icons-react';
+import { IconCheck, IconClipboardList, IconClock, IconFlag, IconX } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
@@ -39,7 +33,7 @@ import type {
 } from '~/components/Apps/unifiedReviewRow';
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { EMBEDDED_KIND_LABEL, STANDALONE_KIND_LABEL } from '~/components/Apps/listingKindLabels';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
@@ -96,11 +90,7 @@ type TabValue = 'pending' | 'approved' | 'rejected' | 'reports' | 'manage';
 
 function isTabValue(v: unknown): v is TabValue {
   return (
-    v === 'pending' ||
-    v === 'approved' ||
-    v === 'rejected' ||
-    v === 'reports' ||
-    v === 'manage'
+    v === 'pending' || v === 'approved' || v === 'rejected' || v === 'reports' || v === 'manage'
   );
 }
 
@@ -194,7 +184,7 @@ export default function ReviewQueuePage() {
     <>
       <Meta title="App publish-request queue — Civitai" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/review']}
+        measure={APPS_PAGE_MEASURES['/apps/review']}
         title="App publish-request queue"
         subtitle={`Moderator review for Apps. ${EMBEDDED_KIND_LABEL} + ${STANDALONE_KIND_LABEL} submissions share one queue per tab; Pending is oldest-first, history is newest-first.`}
       >

--- a/src/pages/apps/review/[publishRequestId].tsx
+++ b/src/pages/apps/review/[publishRequestId].tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
 import {
   OnsiteReviewModalTitle,
   type AnyRequest,
@@ -109,7 +108,6 @@ export default function ReviewDetailPage({ publishRequestId }: ReviewDetailPageP
     <>
       <Meta title="App submission review — Civitai" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/review/[publishRequestId]']}
         title={selection ? <OnsiteReviewModalTitle selection={selection} /> : 'Submission review'}
         actions={
           <Button

--- a/src/pages/apps/store-preview/[slug].tsx
+++ b/src/pages/apps/store-preview/[slug].tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppListingDetailBody } from '~/components/Apps/AppListingDetailBody';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -63,7 +63,7 @@ export default function AppStoreListingDetailPage() {
         description={detail?.tagline ?? 'Unified app store preview'}
         deIndex
       />
-      <AppsPageLayout size={APPS_PAGE_WIDTHS['/apps/store-preview/[slug]']}>
+      <AppsPageLayout measure={APPS_PAGE_MEASURES['/apps/store-preview/[slug]']}>
         {isLoading ? (
           <Center py="xl">
             <Loader />

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { APPS_PAGE_WIDTHS } from '~/components/Apps/appsPageWidths';
+import { APPS_PAGE_MEASURES } from '~/components/Apps/appsPageWidths';
 import { AppsSubmitEditView } from '~/components/Apps/AppsSubmitEditView';
 import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
 import { ExternalSubmitForm } from '~/components/Apps/ExternalSubmitForm';
@@ -71,7 +71,7 @@ export default function SubmitAppPage() {
     <>
       <Meta title="Submit an app — Civitai" deIndex />
       <AppsPageLayout
-        size={APPS_PAGE_WIDTHS['/apps/submit']}
+        measure={APPS_PAGE_MEASURES['/apps/submit']}
         title="Submit an app"
         subtitle={
           mode === null ? (

--- a/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
+++ b/src/tests/pages/apps/listing-collaborators-transfer.browser.test.tsx
@@ -88,6 +88,19 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => state.flags,
 }));
 
+// 🔴 THE SHARED SUB-NAV IS STUBBED, and that is a scoping decision rather than
+// convenience. `/apps/listing/[appListingId]/edit` moved onto `AppsPageLayout`, which
+// mounts `AppsSubNav` — a component with three context/data inputs of its own
+// (`useIsClient`, `useCurrentUser`, `blocks.getNavSummary`). Wiring them here would
+// make this suite, which is about the listing editor, fail the next time the nav
+// gains an input. The ADOPTION is covered where it belongs: structurally in
+// `__tests__/appsPageWidths.test.ts` (every rendering /apps page mounts the layout),
+// as pixels in `AppsPageLayout.chromeAlignment.browser.test.tsx`, and end-to-end on
+// one page in `AppEditPage.browser.test.tsx`.
+vi.mock('~/components/Apps/AppsSubNav', () => ({
+  AppsSubNav: () => <div data-testid="stub-apps-subnav" />,
+}));
+
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ id: 10, username: 'owner' }),
 }));

--- a/src/tests/pages/apps/listing-edit-owner-unpublished-tabs.browser.test.tsx
+++ b/src/tests/pages/apps/listing-edit-owner-unpublished-tabs.browser.test.tsx
@@ -58,6 +58,19 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => state.flags,
 }));
 
+// 🔴 THE SHARED SUB-NAV IS STUBBED, and that is a scoping decision rather than
+// convenience. `/apps/listing/[appListingId]/edit` moved onto `AppsPageLayout`, which
+// mounts `AppsSubNav` — a component with three context/data inputs of its own
+// (`useIsClient`, `useCurrentUser`, `blocks.getNavSummary`). Wiring them here would
+// make this suite, which is about the listing editor, fail the next time the nav
+// gains an input. The ADOPTION is covered where it belongs: structurally in
+// `__tests__/appsPageWidths.test.ts` (every rendering /apps page mounts the layout),
+// as pixels in `AppsPageLayout.chromeAlignment.browser.test.tsx`, and end-to-end on
+// one page in `AppEditPage.browser.test.tsx`.
+vi.mock('~/components/Apps/AppsSubNav', () => ({
+  AppsSubNav: () => <div data-testid="stub-apps-subnav" />,
+}));
+
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ id: 10, username: 'owner' }),
 }));

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -64,6 +64,19 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => state.flags,
 }));
 
+// 🔴 THE SHARED SUB-NAV IS STUBBED, and that is a scoping decision rather than
+// convenience. `/apps/listing/[appListingId]/edit` moved onto `AppsPageLayout`, which
+// mounts `AppsSubNav` — a component with three context/data inputs of its own
+// (`useIsClient`, `useCurrentUser`, `blocks.getNavSummary`). Wiring them here would
+// make this suite, which is about the listing editor, fail the next time the nav
+// gains an input. The ADOPTION is covered where it belongs: structurally in
+// `__tests__/appsPageWidths.test.ts` (every rendering /apps page mounts the layout),
+// as pixels in `AppsPageLayout.chromeAlignment.browser.test.tsx`, and end-to-end on
+// one page in `AppEditPage.browser.test.tsx`.
+vi.mock('~/components/Apps/AppsSubNav', () => ({
+  AppsSubNav: () => <div data-testid="stub-apps-subnav" />,
+}));
+
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => state.currentUser,
 }));


### PR DESCRIPTION
## The mechanism

`AppsPageLayout` rendered the shared `/apps` chrome — the `AppsSubNav` tab strip — **inside** the per-page `<Container>`:

```
<Container size={size}>     <- per-page width
  <Stack gap="xl">
    <Stack gap="md">
      <AppsSubNav />        <- shared chrome, inheriting the PAGE's width
```

`size` came from `APPS_PAGE_WIDTHS`, which deliberately assigned four different widths. So the one element that is supposed to be identical on every apps page inherited each page's content width and jumped horizontally as you navigated.

## Measured, before

Real Chromium render of `AppsPageLayout`, `nav[aria-label="App sections"].getBoundingClientRect()`:

| route | size | left @1440 | width @1440 | left @2560 | width @2560 |
|---|---|---|---|---|---|
| `/apps` | 1920 | 16 | 1408 | 336 | 1888 |
| `/apps/review` | 1400 | 36 | 1368 | 596 | 1368 |
| `/apps/store-preview/[slug]` | 1320 | 76 | 1288 | 636 | 1288 |
| `/apps/submit` | 1100 | 186 | 1068 | 746 | 1068 |

170px of left-edge spread at 1440; 410px at 2560.

## Measured, after

Every one of the 13 chrome routes reports **16 / 1408** at 1440 and **336 / 1888** at 2560. Asserted against those literals, not merely "they all agree" — see the harness note below.

## The change

- `APPS_PAGE_WIDTHS` (a per-route **container** width) becomes `APPS_PAGE_MEASURES` (a per-route **content** measure). `APPS_PAGE_CONTAINER_WIDTH = 1920` is the one container width for every route.
- `AppsPageLayout` drops `size` entirely and gains `measure?: number`, applied as a left-aligned `<Box maw={measure}>` around `{children}` **only** — below the chrome, never around it.
- The band structure is untouched: `Stack gap="xl"` → `Stack gap="md"` → `{children}`, `pb`-only padding. The 16px-in / 32px-out proximity pair and every vertical number in `AppsPageLayout.geometry.browser.test.tsx` are unchanged and that file is **unedited**.

### The +32px decision: measures are 1068 / 1368 / 1288, not 1100 / 1400 / 1320

Mantine's `Container` is border-box, so `size={1100}` renders **1068px** of content. A `maw` box sits *inside* that padding, so `maw={1100}` would render **1100** — 32px wider than before.

I chose to **preserve exact content widths**: each measure is the old container width minus the 2×16px gutter. Every page's rendered content width is byte-identical to before, so this is a pure alignment change with no confounded width delta — any visual regression report can be attributed to the alignment alone. Pinned in `appsPageWidths.test.ts` with the old numbers named as literals so the provenance is checkable.

A side benefit: `APPS_TWO_COLUMN_DETAIL_MEASURE`'s documented justification is "the same width as the model detail page", which renders `<Container size="xl">` = 1320 border-box = **1288** content. Stating it in content terms makes that claim true rather than 32px off.

## Four orphan pages adopted

These rendered a bare `<Container>` and showed **no sub-nav at all**:

- `/apps/get-started`
- `/apps/[appBlockId]/edit`
- `/apps/[appBlockId]/revenue`
- `/apps/listing/[appListingId]/edit` (two `<Container>` sites — loading and ready states; both converted)

### One caveat, deliberately surfaced rather than forced

`/apps/get-started` gates on `appBlocksGetStarted` **alone**, while `AppsSubNav` renders only for `hasAppsStoreAccess` (`appListings || appBlocks`). Those are independent flags, so a viewer could hold the page's flag and not the nav's, and get an empty chrome band.

**Not reachable today**: `appBlocksGetStarted` is staged mod-only, and a moderator holds `appBlocks` and is an `isAppDeveloper`, so the bar clears its own two-tab floor. It becomes reachable when that flag widens to `['public']`. Recorded as a `TODO(launch)` at the call site.

## Why the existing guards missed this

- `appsPageWidths.test.ts` enforced completeness, consumption, and "one of exactly four classes" — none of which is a relationship **between** pages.
- `AppsPageLayout.geometry.browser.test.tsx` has a test named "HORIZONTAL geometry is byte-identical" that renders **one** layout at the **default** size and never varies it — structurally blind to the `size` dimension.

## Tests changed, and why

**New — `AppsPageLayout.chromeAlignment.browser.test.tsx`.** Renders every one of the 13 chrome routes at 1440 and 2560 and asserts nav `left` AND `width` are identical across all of them. Notes:
- Route set is *derived* from the module and then *pinned as a literal*, so it fails when the set grows **or** shrinks. A loop over a silently-emptied set passes vacuously.
- It imports `@mantine/core/styles.css`. Without it the Container computes `max-width: none` / `padding-left: 0`, every route measures `0` **identically**, and "they all agree" passes while measuring nothing. A `styleSheetLoaded` guard is the first assertion in every test, and the agreed-upon value is pinned to a literal as a positive control.
- A second test asserts the body still takes its measure and is **left-aligned** (body left == nav left on every route). Without it, a layout that ignored `measure` entirely would satisfy the alignment test perfectly.

**New — blocking-tier source guards.** The browser project is report-only in CI, so it cannot block a regression. In `appsPageLayout.test.ts`: `AppsPageLayout` accepts no container-width prop, in every spelling. In `appsPageWidths.test.ts`: **every rendering `/apps` page imports AND mounts `AppsPageLayout`**, and none hand-rolls its own top-level `<Container>` — this is the guard that catches the four orphans and any new page. Both walks assert a non-zero file count.

**Ported — `appsPageWidths.test.ts`.** Keeps completeness, consumption and a literal-pinned class list for the measures. The consumption test's `ALIASES` map is gone entirely (both aliases existed to hand a per-page container width to the layout, and both routes are now measure-free) — which also removes its doc-rot: it named `MY_SUBMISSIONS_CONTAINER_SIZE`, a constant that had been renamed.

**Deleted — `MY_APPS_CONTAINER_SIZE`.** Its `> 1100` assertion was a weak proxy for "this page is wide enough for its table" and could not have noticed the container dropping to 1400. Replaced by the real relationship: `APPS_PAGE_CONTAINER_WIDTH - SUBMISSIONS_CONTAINER_CHROME > SUBMISSIONS_TABLE_MIN_WIDTH`, plus the counterfactual that the readable measure would *not* clear that floor.

**Unedited and still green:** `__tests__/appListingGrid.test.ts` (5 tests) and `AppsPageLayout.geometry.browser.test.tsx` (3 tests). The store's matched pair with `LISTING_GRID_SPAN` is untouched — `/apps` takes no measure, so its content width is still the container width and the 460px card arithmetic is unchanged.

**Test-harness follow-on:** adopting the orphans made four page suites render `AppsSubNav`, which has three context/data inputs of its own. `AppEditPage.browser.test.tsx` gets the real mocks plus two new assertions that the page really is on the shared chrome; the three listing-edit suites stub the sub-nav, because wiring its data contract into suites about the listing editor would break them the next time the nav gains an input.

## Verification

- **Red/green matrix:** the new alignment guard was watched to FAIL at `origin/main` (`786fe0449`) — reproducing the before-table exactly — and passes at HEAD. The red run used the committed test file with a 4-hunk adapter for the renamed prop and module surface; the alignment assertion body is byte-identical between the two.
- **Mutation-checked** in both tiers, each time reverting exactly **one** route: the pixel guard names `/apps/review` moving 16/1408 -> 36/1368 (with all 13 `styleSheetLoaded` guards still passing, so the assertion was reached); the blocking guard names `/apps/get-started` with its own message.
- Full blocking `unit` project: **1470 files / 22945 tests passed**, 0 failures. Typecheck: 0 errors. Lint: no new errors (one pre-existing unused-import warning removed).
