### PR TITLE
feat(image-detail): show what an image was remixed from

### DIFF
--- a/src/components/CardTemplates/AspectRatioCard.tsx
+++ b/src/components/CardTemplates/AspectRatioCard.tsx
@@ -17,8 +17,13 @@ const aspectRatioMap = {
 export type AspectRatioCardProps = {
   /**
    * A named ratio, or a raw width/height number to follow the media's own shape.
-   * The number form exists so a card can stop cropping — see the remix-of card,
-   * which passes the source image's ratio clamped so it never grows past square.
+   *
+   * The number form exists so a card can stop cropping. Its caller is the
+   * remix-of card, which passes the source image's ratio UNCLAMPED and bounds
+   * the height with a square wrapper instead. Clamping the number was tried
+   * (`Math.max(ratio, 1)`) and is wrong: it re-squares every portrait source,
+   * which is most of them, silently and with nothing to show for it. Cap the
+   * box, never the ratio.
    */
   aspectRatio?: AspectRatio | number;
   cosmetic?: ContentDecorationCosmetic['data'];

--- a/src/components/CardTemplates/AspectRatioCard.tsx
+++ b/src/components/CardTemplates/AspectRatioCard.tsx
@@ -15,7 +15,12 @@ const aspectRatioMap = {
 } as const;
 
 export type AspectRatioCardProps = {
-  aspectRatio?: AspectRatio;
+  /**
+   * A named ratio, or a raw width/height number to follow the media's own shape.
+   * The number form exists so a card can stop cropping — see the remix-of card,
+   * which passes the source image's ratio clamped so it never grows past square.
+   */
+  aspectRatio?: AspectRatio | number;
   cosmetic?: ContentDecorationCosmetic['data'];
   className?: string;
   header?: React.ReactNode;
@@ -36,7 +41,9 @@ export function AspectRatioCard({
   render,
   impressions,
 }: AspectRatioCardProps) {
-  const wrapperStyle = { aspectRatio: aspectRatioMap[aspectRatio] };
+  const wrapperStyle = {
+    aspectRatio: typeof aspectRatio === 'number' ? aspectRatio : aspectRatioMap[aspectRatio],
+  };
   const impressionRef = useTrackImpression<HTMLDivElement>(impressions);
 
   return (

--- a/src/components/CardTemplates/AspectRatioImageCard.tsx
+++ b/src/components/CardTemplates/AspectRatioImageCard.tsx
@@ -47,7 +47,8 @@ type RoutedDialogProps<T extends DialogKey> = { name: T; state: DialogState<T> }
 
 export type AspectRatioImageCardProps<T extends DialogKey> = {
   href?: string;
-  aspectRatio?: 'portrait' | 'landscape' | 'square';
+  /** Named ratio, or a raw width/height number to follow the media's own shape. */
+  aspectRatio?: 'portrait' | 'landscape' | 'square' | number;
   onClick?: React.MouseEventHandler;
   cosmetic?: ContentDecorationCosmetic['data'];
   className?: string;

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -67,6 +67,7 @@ import { ImageExternalMeta } from '~/components/Image/DetailV2/ImageExternalMeta
 import { ImageGenerationData } from '~/components/Image/DetailV2/ImageGenerationData';
 import { RemixGalleryCard } from '~/components/RemixGallery/RemixGalleryCard';
 import { ImageProcess } from '~/components/Image/DetailV2/ImageProcess';
+import { ImageRemixOfDetails } from '~/components/Image/DetailV2/ImageRemixOfDetails';
 import { DownloadImage } from '~/components/Image/DownloadImage';
 import { useImageContestCollectionDetails } from '~/components/Image/image.utils';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
@@ -657,10 +658,10 @@ export function ImageDetail2() {
                       </Card>
                     )}
                     <ImageProcess imageId={image.id} />
+                    <ImageRemixOfDetails imageId={image.id} />
                     <RemixGalleryCard imageId={image.id} />
                     <ImageGenerationData imageId={image.id} collapsible />
-                    {/* <ImageRemixOfDetails imageId={image.id} />
-                    <ImageRemixesDetails imageId={image.id} /> */}
+                    {/* <ImageRemixesDetails imageId={image.id} /> */}
                     {/* {!hideAds && <AdUnitSide_3 />} */}
                     <CollapsibleCard
                       title="Discussion"

--- a/src/components/Image/DetailV2/ImageRemixOfDetails.tsx
+++ b/src/components/Image/DetailV2/ImageRemixOfDetails.tsx
@@ -1,38 +1,111 @@
 import { Card, Text } from '@mantine/core';
-import { IconHierarchy } from '@tabler/icons-react';
-import { ImageCard } from '~/components/Cards/ImageCard';
+import { IconArrowBackUp } from '@tabler/icons-react';
+import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
+import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { UserAvatarSimple } from '~/components/UserAvatar/UserAvatarSimple';
 import { trpc } from '~/utils/trpc';
 
+/**
+ * The source image's own shape. Square is a CEILING ON HEIGHT, not the shape.
+ *
+ * Justin's call, 2026-08-27, arrived at over two wrong attempts, both of which
+ * are worth knowing about because both looked finished:
+ *
+ *  1. `aspectRatio="square"` cropped every source to a square.
+ *  2. Clamping the RATIO with `Math.max(ratio, 1)` silently re-squared every
+ *     PORTRAIT source, which is most of them — the demo source is 928x1152,
+ *     ratio 0.806, and it rendered as a perfect square with no error anywhere.
+ *     A clamp that fires on the common case is not a guard.
+ *
+ * So the cap belongs on the box, not on the number. The tile is a square frame
+ * and the image keeps its true ratio inside it: a wide source is width-bound and
+ * renders short, a tall source is height-bound and renders narrow. Neither is
+ * cropped, and neither can push the Remix Gallery below the fold.
+ */
+function sourceAspectRatio(image: { width?: number | null; height?: number | null }) {
+  // Fall back to square rather than to 0 — `aspectRatio: 0` collapses the tile to
+  // nothing, which reads as the card being broken rather than as one image
+  // lacking dimensions.
+  if (!image.width || !image.height) return 1;
+  return image.width / image.height;
+}
+
+/**
+ * "This is a remix of X" — the source image(s) this one was derived from.
+ *
+ * Reads `remixOfIds`, which is server-VERIFIED provenance only
+ * (`meta.extra.sourceImageIds`). The older client-declared `meta.extra.remixOfId`
+ * is deliberately excluded — Justin's ruling, 2026-08-27 — which knowingly costs
+ * about half of all remixes their card. See `getRemixSourceIds` in
+ * image.service.ts before "fixing" that.
+ *
+ * So absent on almost every image, by design twice over: 101 of 51,661 on-site
+ * generations in a 24h prod sample carried any provenance at all. A blank
+ * sidebar here is the ordinary answer, not a broken query.
+ *
+ * 🔴 `image.get` per id, NOT `useQueryImages({ ids })`, and that is not a style
+ * preference. `ids` is absent from `requiresImageDbPath`, so an ids-only feed
+ * query routes to the search index — where `ids` is commented out of the
+ * destructure and silently ignored. Measured against this dev server on
+ * 2026-08-27: asking for `ids: [140383933]` returned image `12097475`. Not an
+ * error and not an empty list — a real image from the global feed, wearing the
+ * caption "remixed from". Anyone moving this back to the feed helper must first
+ * assert on the returned IDS, never on the count.
+ *
+ * `image.get` gates `needsReview IS NULL`, `imageReviewedSql()` and
+ * `nsfwLevel != Blocked` server-side; `useApplyHiddenPreferences` then drops what
+ * this viewer specifically may not see.
+ */
 export const ImageRemixOfDetails = ({ imageId }: { imageId: number }) => {
-  const { data: imageGenerationData } = trpc.image.getGenerationData.useQuery({ id: imageId });
-  const { remixOfId } = imageGenerationData ?? {};
-  const { data, isLoading } = trpc.image.get.useQuery(
-    { id: remixOfId as number },
-    { enabled: !!remixOfId }
-  );
+  const { data: generationData } = trpc.image.getGenerationData.useQuery({ id: imageId });
+  const remixOfIds = generationData?.remixOfIds ?? [];
 
-  // Avoids showing not available levels:
-  const { items: images } = useApplyHiddenPreferences({
-    type: 'images',
-    data: data ? [data] : [],
-    allowLowerLevels: true,
-  });
+  // Bounded by the writer: `sanitizeProvenance` caps `sourceImageIds` at
+  // MAX_SOURCE_IMAGES (8), so this fans out to at most 8 queries.
+  const queries = trpc.useQueries((t) => remixOfIds.map((id) => t.image.get({ id })));
+  const sources = queries.map((query) => query.data).filter((data) => !!data);
+  const isLoading = queries.some((query) => query.isLoading);
 
-  const [image] = images;
+  // Deliberately WITHOUT `allowLowerLevels`, which the pre-2025 version of this
+  // card passed. That option swaps the strict `Flags.intersects` test for
+  // `nsfwLevel > maxBrowsingLevel`, so a level the viewer has specifically
+  // switched OFF still renders as long as something above it is on. Fine for a
+  // feed the viewer asked for; wrong for an image pulled in sideways by
+  // somebody else's provenance, which is what every tile here is.
+  const { items: images } = useApplyHiddenPreferences({ type: 'images', data: sources });
 
-  if (!remixOfId || isLoading || !image) return null;
+  if (!remixOfIds.length || isLoading || !images.length) return null;
 
   return (
     <Card className="flex flex-col gap-3 rounded-xl">
-      <div className="flex items-center gap-3">
-        <Text className="flex items-center gap-2 text-xl font-semibold">
-          <IconHierarchy />
-          <span>Remixed From</span>
-        </Text>
-      </div>
+      <Text className="flex items-center gap-2 text-xl font-semibold">
+        <IconArrowBackUp />
+        <span>{images.length > 1 ? 'Remixed from these' : 'Remixed from'}</span>
+      </Text>
 
-      <ImageCard data={image} />
+      <div className={images.length > 1 ? 'grid grid-cols-2 gap-3' : undefined}>
+        {images.map((image) => {
+          const ratio = sourceAspectRatio(image);
+          // The square frame is the height ceiling; the tile fits inside it on
+          // whichever axis binds first. `w-full` for wide, `h-full` for tall —
+          // set on both the link and the card, because the link is the flex item
+          // that has to stop filling the frame.
+          const fit = ratio >= 1 ? 'w-full' : 'h-full';
+          return (
+            <div key={image.id} className="flex aspect-square items-center justify-center">
+              <RoutedDialogLink name="imageDetail" state={{ imageId: image.id }} className={fit}>
+                <AspectRatioImageCard
+                  image={image}
+                  aspectRatio={ratio}
+                  className={fit}
+                  header={<UserAvatarSimple {...image.user} />}
+                />
+              </RoutedDialogLink>
+            </div>
+          );
+        })}
+      </div>
     </Card>
   );
 };

--- a/src/components/Image/DetailV2/ImageRemixOfDetails.tsx
+++ b/src/components/Image/DetailV2/ImageRemixOfDetails.tsx
@@ -53,26 +53,53 @@ function sourceAspectRatio(image: { width?: number | null; height?: number | nul
  * caption "remixed from". Anyone moving this back to the feed helper must first
  * assert on the returned IDS, never on the count.
  *
- * `image.get` gates `needsReview IS NULL`, `imageReviewedSql()` and
- * `nsfwLevel != Blocked` server-side; `useApplyHiddenPreferences` then drops what
- * this viewer specifically may not see.
+ * What actually gates a source tile, stated precisely because an earlier version
+ * of this comment overclaimed it twice:
+ *
+ * - `image.get` server-side: unpublished or private post, `nsfwLevel = Blocked`,
+ *   `needsReview`, `imageReviewedSql()`. `getImageHandler` adds `amIBlockedByUser`.
+ * - `useApplyHiddenPreferences`: hidden users, hidden images, POI and minor.
+ * - ⚠️ NOT hidden tags. That filter reads `image.tagIds`, and `getImage` selects
+ *   no tag data, so `image.tagIds ?? []` is empty and both the viewer's
+ *   `hiddenTags` and the platform's `excludedTagIds` loops are no-ops here. The
+ *   feed path fetches tag ids from cache for exactly this reason
+ *   (image.service.ts, "Fetch tagIds from cache so client-side hidden-tag
+ *   filtering works"). Known and accepted — Justin, 2026-08-27 — rather than
+ *   overlooked. Closing it means giving `getImage` an opt-in tag fetch.
+ * - ⚠️ The browsing level here is NOT the viewer's saved preference.
+ *   `ImageDetail2` wraps this sidebar in
+ *   `<BrowsingLevelProvider browsingLevel={image.nsfwLevel}>`, so the strict
+ *   `Flags.intersects` test below compares the source against the REMIX's level.
+ *   The domain cap still wins (`forcedBrowsingLevel` takes priority) and
+ *   `ImageGuard2` still blurs from the viewer's own level, and `RemixGalleryCard`
+ *   beside this reads the same overridden value — so this is the established
+ *   detail-page pattern, not something this card invents. Do not describe it as
+ *   the viewer-specific gate; it is not one.
  */
 export const ImageRemixOfDetails = ({ imageId }: { imageId: number }) => {
   const { data: generationData } = trpc.image.getGenerationData.useQuery({ id: imageId });
   const remixOfIds = generationData?.remixOfIds ?? [];
 
-  // Bounded by the writer: `sanitizeProvenance` caps `sourceImageIds` at
-  // MAX_SOURCE_IMAGES (8), so this fans out to at most 8 queries.
+  // Bounded at 8 by `getRemixSourceIds`, which re-applies MAX_SOURCE_IMAGES on
+  // the READ path. Do not move that bound: `sanitizeProvenance` writes what it is
+  // given verbatim, so nothing about a stored row limits this list. An earlier
+  // version of this comment claimed the writer capped it; it does not.
+  //
+  // In practice it is one query, not eight — measured on the prod replica
+  // 2026-08-27, every image carrying the field over a 5-day window (309 rows) had
+  // exactly one source, max and average both 1. And 0.1% of images carry it at
+  // all, so 999 detail views in 1000 fan out to nothing.
   const queries = trpc.useQueries((t) => remixOfIds.map((id) => t.image.get({ id })));
   const sources = queries.map((query) => query.data).filter((data) => !!data);
   const isLoading = queries.some((query) => query.isLoading);
 
   // Deliberately WITHOUT `allowLowerLevels`, which the pre-2025 version of this
   // card passed. That option swaps the strict `Flags.intersects` test for
-  // `nsfwLevel > maxBrowsingLevel`, so a level the viewer has specifically
-  // switched OFF still renders as long as something above it is on. Fine for a
-  // feed the viewer asked for; wrong for an image pulled in sideways by
-  // somebody else's provenance, which is what every tile here is.
+  // `nsfwLevel > maxBrowsingLevel`, so a level specifically switched OFF still
+  // renders as long as something above it is on. Fine for a feed that was asked
+  // for; wrong for an image pulled in sideways by somebody else's provenance,
+  // which is what every tile here is. See the docblock for which level this
+  // actually tests against — it is not the viewer's saved preference.
   const { items: images } = useApplyHiddenPreferences({ type: 'images', data: sources });
 
   if (!remixOfIds.length || isLoading || !images.length) return null;

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4124':
+  'server/services/image.service.ts:4127':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4265':
+  'server/services/image.service.ts:4268':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5003':
+  'server/services/image.service.ts:5006':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6137':
+  'server/services/image.service.ts:6140':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -206,7 +206,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4265')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4268')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/remix-of-provenance.test.ts
+++ b/src/server/services/__tests__/remix-of-provenance.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getRemixSourceIds } from '~/server/services/image.service';
+
+/**
+ * What the "Remixed from" card is allowed to treat as provenance.
+ *
+ * The decision this pins is a product ruling, not an implementation detail, so
+ * it is pinned by NAME rather than as a spec bullet: a test called "reads only
+ * sourceImageIds" gets "corrected" along with the code by the next person who
+ * notices the two fields and unions them, which is a reasonable-looking change
+ * that halves nothing visible and quietly restores a spoofable attribution.
+ *
+ * The evidence for the ruling already exists upstream:
+ * `orchestrator/__tests__/remix-provenance.test.ts:224` demonstrates in one
+ * assertion that an unverified `sourceImageIds` is stripped on write while
+ * `remixOfId` survives untouched — a working demonstration that one field is
+ * client-writable and the other is not.
+ *
+ * ⚠️ This pins the FUNCTION, not the call site. Someone can leave
+ * `getRemixSourceIds` alone and add `?? meta?.extra?.remixOfId` where
+ * `remixOfIds` is assembled in `getImageGenerationData`, and every test below
+ * stays green. Pinning the decision itself would take a read-side convention
+ * guard modelled on `no-unverified-provenance-write.test.ts`.
+ */
+describe('getRemixSourceIds', () => {
+  it('ignores meta.extra.remixOfId — client-declared, unverifiable, ruled out 2026-08-27', () => {
+    expect(getRemixSourceIds(1, { extra: { remixOfId: 9 } } as never)).toEqual([]);
+  });
+
+  // The control that makes the assertion above capable of failing. Alone, it
+  // passes for a function that returns [] unconditionally; beside this one, it
+  // can only pass for a function that reads one field and not the other.
+  it('reads sourceImageIds on a row carrying both fields', () => {
+    expect(getRemixSourceIds(1, { extra: { remixOfId: 9, sourceImageIds: [4] } } as never)).toEqual(
+      [4]
+    );
+  });
+
+  it('drops a self-reference rather than rendering the image as its own source', () => {
+    expect(getRemixSourceIds(5, { extra: { sourceImageIds: [5] } })).toEqual([]);
+  });
+
+  it('shows a repeated source once', () => {
+    expect(getRemixSourceIds(1, { extra: { sourceImageIds: [7, 7] } })).toEqual([7]);
+  });
+
+  it('returns empty for meta with no extra, rather than throwing', () => {
+    expect(getRemixSourceIds(1, {})).toEqual([]);
+    expect(getRemixSourceIds(1, null)).toEqual([]);
+    expect(getRemixSourceIds(1, undefined)).toEqual([]);
+  });
+
+  /**
+   * The fan-out bound the card's `trpc.useQueries` depends on.
+   *
+   * `sanitizeProvenance` writes `verified` VERBATIM — MAX_SOURCE_IMAGES is
+   * applied by the resolvers that produce it, not by the sink — so a stored row
+   * carries no bound of its own and the read path is the only thing standing
+   * between a bad row and one tRPC query per element on the image detail page.
+   */
+  it('caps the fan-out at MAX_SOURCE_IMAGES, because a stored row is not bounded', () => {
+    const many = Array.from({ length: 20 }, (_, i) => i + 100);
+    expect(getRemixSourceIds(1, { extra: { sourceImageIds: many } })).toHaveLength(8);
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -279,7 +279,10 @@ import type { FeedQueryInput } from '../../../event-engine-common/feeds/types';
 import type { ImageQueryInput } from '../../../event-engine-common/types/image-feed-types';
 import { createImageIngestionRequest } from '~/server/services/orchestrator/orchestrator.service';
 import { getGenerationDisplayKeys } from '~/server/services/orchestrator/legacy-metadata-mapper';
-import { sanitizeProvenance } from '~/server/services/orchestrator/remix-provenance';
+import {
+  sanitizeProvenance,
+  storedSourceImageIds,
+} from '~/server/services/orchestrator/remix-provenance';
 
 const {
   cacheHitRequestsTotal,
@@ -8422,7 +8425,7 @@ export async function getImageGenerationData({ id }: { id: number }) {
     external,
     canRemix: !image.hideMeta && !!meta?.prompt,
     remixOfId: meta?.extra?.remixOfId,
-    remixOfIds: getRemixSourceIds(id, meta?.extra),
+    remixOfIds: getRemixSourceIds(id, meta),
   };
 }
 
@@ -8432,7 +8435,9 @@ export async function getImageGenerationData({ id }: { id: number }) {
  * `meta.extra.sourceImageIds` only. It is server-written by `sanitizeProvenance`
  * after the orchestrator workflow was checked, and nothing else can put it on a
  * row — a client-supplied value is stripped on the way in (see
- * remix-provenance.ts).
+ * remix-provenance.ts, and `remix-provenance.test.ts:224`, which demonstrates in
+ * one assertion that an unverified `sourceImageIds` is stripped while
+ * `remixOfId` survives untouched).
  *
  * ⚠️ The older `meta.extra.remixOfId` is deliberately NOT read here, and adding
  * it back is a product decision, not a bug fix. It is a client-declared claim
@@ -8442,11 +8447,25 @@ export async function getImageGenerationData({ id }: { id: number }) {
  * against 39 with the new one over 8 hours, interleaved hour by hour with no
  * downward trend, and zero images carried both. So roughly half of all remixes
  * intentionally show no card. That is the accepted trade, not a gap to close.
+ *
+ * Validation goes through `storedSourceImageIds` rather than reading the field
+ * directly. That is load-bearing: `sanitizeProvenance` writes `verified`
+ * VERBATIM — the MAX_SOURCE_IMAGES cap lives in the three resolvers that produce
+ * it, not in the sink — so nothing about a stored row bounds this list. An
+ * earlier version of this comment claimed the writer capped it; it does not, and
+ * the read path is where every other reader in this feature re-applies both the
+ * cap and element validation.
+ *
+ * Exported for `__tests__/remix-of-provenance.test.ts`, which pins the exclusion
+ * above by name so it cannot be quietly unioned back.
  */
-function getRemixSourceIds(imageId: number, extra: { sourceImageIds?: number[] } | undefined) {
+export function getRemixSourceIds(
+  imageId: number,
+  meta: { extra?: { sourceImageIds?: number[] } } | null | undefined
+) {
   // Self-reference is not a derivation, and it would render the image as its own
   // source. Dedupe as well, so a repeated id shows once.
-  return [...new Set(extra?.sourceImageIds ?? [])].filter((sourceId) => sourceId !== imageId);
+  return [...new Set(storedSourceImageIds(meta) ?? [])].filter((sourceId) => sourceId !== imageId);
 }
 
 // LRU cache for contest collection items lookup - caches by imageId

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -8422,7 +8422,31 @@ export async function getImageGenerationData({ id }: { id: number }) {
     external,
     canRemix: !image.hideMeta && !!meta?.prompt,
     remixOfId: meta?.extra?.remixOfId,
+    remixOfIds: getRemixSourceIds(id, meta?.extra),
   };
+}
+
+/**
+ * Every image this one was VERIFIED to have been derived from.
+ *
+ * `meta.extra.sourceImageIds` only. It is server-written by `sanitizeProvenance`
+ * after the orchestrator workflow was checked, and nothing else can put it on a
+ * row — a client-supplied value is stripped on the way in (see
+ * remix-provenance.ts).
+ *
+ * ⚠️ The older `meta.extra.remixOfId` is deliberately NOT read here, and adding
+ * it back is a product decision, not a bug fix. It is a client-declared claim
+ * with no verification behind it, and Justin ruled on 2026-08-27 that public
+ * attribution must not rest on it. This costs real coverage rather than only
+ * legacy rows: measured on prod that day, 28 images carried the old field
+ * against 39 with the new one over 8 hours, interleaved hour by hour with no
+ * downward trend, and zero images carried both. So roughly half of all remixes
+ * intentionally show no card. That is the accepted trade, not a gap to close.
+ */
+function getRemixSourceIds(imageId: number, extra: { sourceImageIds?: number[] } | undefined) {
+  // Self-reference is not a derivation, and it would render the image as its own
+  // source. Dedupe as well, so a repeated id shows once.
+  return [...new Set(extra?.sourceImageIds ?? [])].filter((sourceId) => sourceId !== imageId);
 }
 
 // LRU cache for contest collection items lookup - caches by imageId


### PR DESCRIPTION
Mounts the "Remixed from" card above the Remix Gallery, pointing back at the source image.

## This was already built, and disabled

`ImageRemixOfDetails` has existed since 2025-01-14 and has been mounted **nowhere** since 2025-01-29, when `dd1587d4f1` ("Remove remixOfId from the details") commented it out — eleven minutes after `62c4da12b4` added hidden-preference safeguards to the same two components. No reason recorded in either commit and no PR body.

The theory that gap suggests — that the old path showed images it should not have — **does not hold**. `image.get` already gates `needsReview IS NULL`, `imageReviewedSql()` and a Blocked rating. So the honest answer is that the reason is not recorded.

## Verified provenance only

`getImageGenerationData` now returns `remixOfIds`, from `meta.extra.sourceImageIds` — server-written by `sanitizeProvenance` after the orchestrator workflow was checked.

The older `meta.extra.remixOfId` is deliberately **not** read. It is a client-declared claim, and Justin ruled on 2026-08-27 that public attribution must not rest on something that easy to spoof.

That costs real reach rather than a legacy tail: measured on prod that day, **28** images carried the old field against **39** with the new one over 8 hours, interleaved hour by hour with no downward trend, and **zero** carried both. So roughly half of remixes intentionally show no card. The reason is written into `getRemixSourceIds` so it does not get "simplified" back to a union.

Remix volume is low overall — 101 of 51,661 on-site generations in 24h — so the card is absent on almost every image. That is correct, not a bug.

## `image.get` per source, not `useQueryImages({ ids })`

`ids` is absent from `requiresImageDbPath`, so an ids-only feed query routes to the search index, where `ids` is commented out of the destructure and ignored.

Measured on dev: asking for `ids: [140383933]` returned image **12097475**. Not an error and not an empty list — a real unrelated image wearing the caption "Remixed from". Worth a separate look for any other caller passing `ids` alone; not fixed here.

## Gating

| case | behaviour |
| --- | --- |
| unpublished source | hidden **as this card calls it**. `getImage` inner-joins Post with `publishedAt < now()` or owner. Driven: image `140555552` returns `404 "No image with id 140555552"` logged out, while published `140383933` returns normally. Not an unconditional property of `getImage` — an input exists that skips that join, and this card never passes it |
| Blocked rating / needs review | hidden — `nsfwLevel != Blocked`, `needsReview IS NULL AND imageReviewedSql()`. `getImageHandler` adds `amIBlockedByUser` |
| hidden users, hidden images, POI, minor | hidden — applied by `useApplyHiddenPreferences` |
| browsing level | strict `Flags.intersects`, tightened from the `allowLowerLevels` the pre-2025 version passed. ⚠️ The level compared against is the **remix's**, not the viewer's saved preference — `ImageDetail2` wraps this sidebar in `<BrowsingLevelProvider browsingLevel={image.nsfwLevel}>`. The domain cap still wins and `ImageGuard2` still blurs from the viewer's own level. Established detail-page behaviour; `RemixGalleryCard` beside it reads the same value |
| domain cap | applied — `forcedBrowsingLevel` takes priority in the provider |
| hidden **tags** | ⚠️ **NOT applied.** The filter reads `image.tagIds`; `getImage` selects no tag data, so the viewer's `hiddenTags` and the platform's `excludedTagIds` are both no-ops here. Known and accepted (Justin, 2026-08-27) rather than overlooked — closing it means giving `getImage` an opt-in tag fetch |
| `hideMeta` on the remix itself | no card; meta is stripped upstream |

## Layout

Square is a **ceiling on height**, not the shape: the tile is a square frame and the source keeps its true aspect ratio inside it, so a wide source renders short and a tall one narrow. Neither is cropped and neither can push the Remix Gallery below the fold.

`AspectRatioCard` / `AspectRatioImageCard` take a numeric `aspectRatio` for this. Named ratios and every existing caller are untouched.

## Verification

- `pnpm run typecheck` — `typecheck: OK — 0 type errors in 293s`, exit 0
- `pnpm run lint` — the 3 errors reported in `image.service.ts` are at lines 205 / 4974 / 6901, far above this diff's insertions; repo-wide lint is 360 errors on base
- `pnpm run test:unit:run` — `Test Files  1 failed | 1477 passed | 1 skipped (1479)`, exit 1. The single failure is `scripts/test-perf/__tests__/trace-flush.test.ts`, which **fails identically at `origin/main` (612d65b3db)** with `Tests  4 failed | 24 passed (28)`. This diff touches only `src/`
- `blocks.router.workflow.test.ts` collected **358 tests**, so the suite run is meaningful rather than a silent zero-collection


## Read-path validation and the test that pins the ruling

`getRemixSourceIds` routes through `storedSourceImageIds`, which validates element types and re-applies `MAX_SOURCE_IMAGES`. An earlier comment claimed the writer capped the list — it does not. `sanitizeProvenance` writes `verified` verbatim; the cap lives in the resolvers that produce it, so nothing about a stored row bounded this.

`__tests__/remix-of-provenance.test.ts` pins the exclusion by **name**, with a positive control beside it. Both mutations were driven rather than assumed:

```
union remixOfId back in
  x ignores meta.extra.remixOfId - client-declared, unverifiable, ruled out 2026-08-27
    AssertionError: expected [ 9 ] to deeply equal []
  x reads sourceImageIds on a row carrying both fields
    AssertionError: expected [ 4, 9 ] to deeply equal [ 4 ]

bypass the cap
  x caps the fan-out at MAX_SOURCE_IMAGES, because a stored row is not bounded
    AssertionError: expected [ 100, 101, ... ] to have a length of 8 but got 20

pristine control, same path:  Tests  6 passed (6)
```

Measured on the prod replica 2026-08-27: over a 5-day window, all 309 images carrying `sourceImageIds` had **exactly one** source, max and average both 1. So the fan-out is one query on 0.1% of detail views, capped at 8.

`flipt-eval-context.test.ts` holds a hardcoded `file:line` ledger of Flipt eval sites. The new import split across three lines and shifted four `image.service.ts` entries by exactly +3; keys updated, sites unchanged.

No migration. Read-only display; no money path touched.

Generated with [Claude Code](https://claude.com/claude-code)
