### PR TITLE
fix(feed): serve the own-content submit pickers from the database, not the search index

### DIFF
--- a/src/components/Challenge/ChallengeSubmitModal.tsx
+++ b/src/components/Challenge/ChallengeSubmitModal.tsx
@@ -87,6 +87,7 @@ import type {
   VideoBlob,
 } from '~/shared/orchestrator/workflow-data';
 import clsx from 'clsx';
+import { ownContentPickerFilters } from '~/components/Image/image.utils';
 
 // ---------------------------------------------------------------------------
 // Selection store (same pattern as AddUserContentModal)
@@ -499,9 +500,9 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
             icon={<IconClockHour4 size={16} />}
           >
             Less than an hour left in this challenge. Entries are judged only after an automated
-            content scan, which can lag behind submission when the queue is busy. If a scan
-            finishes after the challenge closes, that entry may not make it into judging in time —
-            but you&apos;ll still receive the participation prize for any entries that meet the
+            content scan, which can lag behind submission when the queue is busy. If a scan finishes
+            after the challenge closes, that entry may not make it into judging in time — but
+            you&apos;ll still receive the participation prize for any entries that meet the
             requirements.
           </AlertWithIcon>
         )}
@@ -535,8 +536,8 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
                     <MasonryContainer m={0} p={0} px={0}>
                       <ImagesInfinite
                         filters={{
+                          ...ownContentPickerFilters(currentUser?.id),
                           collectionId: undefined,
-                          userId: currentUser?.id,
                           period: 'AllTime',
                           sort: ImageSort.Newest,
                           hidden: undefined,
@@ -547,7 +548,6 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
                           hideAutoResources: undefined,
                           hideManualResources: undefined,
                           includeBaseModel: true,
-                          publishedOnly: true,
                         }}
                         renderItem={LibraryImageCard}
                         disableStoreFilters
@@ -667,31 +667,31 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
             }`,
           }}
         >
-        <Group gap="xs" justify="flex-end">
-          <Button variant="default" onClick={handleClose}>
-            Cancel
-          </Button>
-          {totalBuzzCost > 0 ? (
-            <BuzzTransactionButton
-              buzzAmount={totalBuzzCost}
-              onPerformTransaction={handleSubmit}
-              loading={loading || requestReviewMutation.isPending}
-              disabled={submitCount === 0 || remainingEntries === 0}
-              label={`Submit ${submitCount} ${submitCount === 1 ? 'Entry' : 'Entries'}`}
-              showPurchaseModal
-            />
-          ) : (
-            <Button
-              onClick={handleSubmit}
-              loading={loading || requestReviewMutation.isPending}
-              disabled={submitCount === 0 || remainingEntries === 0}
-            >
-              {submitCount > 0
-                ? `Submit ${submitCount} ${submitCount === 1 ? 'Entry' : 'Entries'}`
-                : 'Submit'}
+          <Group gap="xs" justify="flex-end">
+            <Button variant="default" onClick={handleClose}>
+              Cancel
             </Button>
-          )}
-        </Group>
+            {totalBuzzCost > 0 ? (
+              <BuzzTransactionButton
+                buzzAmount={totalBuzzCost}
+                onPerformTransaction={handleSubmit}
+                loading={loading || requestReviewMutation.isPending}
+                disabled={submitCount === 0 || remainingEntries === 0}
+                label={`Submit ${submitCount} ${submitCount === 1 ? 'Entry' : 'Entries'}`}
+                showPurchaseModal
+              />
+            ) : (
+              <Button
+                onClick={handleSubmit}
+                loading={loading || requestReviewMutation.isPending}
+                disabled={submitCount === 0 || remainingEntries === 0}
+              >
+                {submitCount > 0
+                  ? `Submit ${submitCount} ${submitCount === 1 ? 'Entry' : 'Entries'}`
+                  : 'Submit'}
+              </Button>
+            )}
+          </Group>
 
           {entryFeeInfo && (
             <Group gap={4} justify="flex-end" wrap="nowrap">
@@ -706,8 +706,8 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
                     <b>{entryFeeInfo.entryFee.toLocaleString()}</b> per entry
                   </>
                 )}{' '}
-                &middot; {(entryFeeInfo.houseCut * Math.max(submitCount, 1)).toLocaleString()}{' '}for AI
-                judging &middot;{' '}
+                &middot; {(entryFeeInfo.houseCut * Math.max(submitCount, 1)).toLocaleString()} for
+                AI judging &middot;{' '}
                 {(entryFeeInfo.perEntryToPool * Math.max(submitCount, 1)).toLocaleString()} to the
                 prize pool
                 {guaranteeCost > 0 && (
@@ -769,7 +769,10 @@ function GeneratorTab({ challenge }: { challenge?: ChallengeDetail }) {
   const currentUser = useCurrentUser();
 
   const { data, isFetching, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useGetTextToImageRequests({ tags: [WORKFLOW_TAGS.IMAGE] }, { enabled: !!currentUser, ignoreFilters: true });
+    useGetTextToImageRequests(
+      { tags: [WORKFLOW_TAGS.IMAGE] },
+      { enabled: !!currentUser, ignoreFilters: true }
+    );
 
   const generatedMedia = useMemo(
     () =>

--- a/src/components/Collections/AddUserContentModal.tsx
+++ b/src/components/Collections/AddUserContentModal.tsx
@@ -42,6 +42,7 @@ import { trpc } from '~/utils/trpc';
 import { useCollection } from './collection.utils';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { ownContentPickerFilters } from '~/components/Image/image.utils';
 
 export function AddUserContentModal({ collectionId }: Props) {
   const dialog = useDialogContext();
@@ -166,14 +167,14 @@ export function AddUserContentModal({ collectionId }: Props) {
             <MasonryContainer m={0} p={0} px={0}>
               <ImagesInfinite
                 filters={{
-                  collectionId: undefined,
-                  userId: currentUser?.id,
-                  period: 'AllTime',
-                  sort: ImageSort.Newest,
                   // The feed carves out the caller's own unpublished posts, which is right
                   // for a profile and wrong for a picker: an unpublished image cannot be
-                  // added to a collection.
-                  publishedOnly: true,
+                  // added to a collection. `ownContentPickerFilters` also routes this
+                  // picker off the search index — see its docblock.
+                  ...ownContentPickerFilters(currentUser?.id),
+                  collectionId: undefined,
+                  period: 'AllTime',
+                  sort: ImageSort.Newest,
                   hidden: undefined,
                   types: undefined,
                   withMeta: undefined,

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -105,6 +105,25 @@ export const imagesQueryParamSchema = z
   })
   .partial();
 
+/**
+ * The pair that routes an own-content submit picker off the search index.
+ *
+ * 🔴 These two are not two independent preferences. Together they are the signal
+ * `requiresImageDbPath` reads to serve the picker from the database instead of
+ * Meilisearch, and `getInfiniteImagesHandler` additionally requires the `userId`
+ * to be the caller's own. Measured on prod 2026-08-27: an image is absent from
+ * `metrics_images_v1` for 10-30 minutes after publish, so without this the one
+ * image someone opened the picker to submit is the one that is missing.
+ *
+ * It lives here, spread into all three pickers, because it used to be written out
+ * three times. Two of those copies had no test: deleting `publishedOnly` from an
+ * inline ten-key filter block sent that picker silently back to the index — the
+ * grid still rendered, still returned rows, and only the newest image was gone.
+ * One chokepoint means one assertion covers all three.
+ */
+export const ownContentPickerFilters = (userId: number | undefined) =>
+  ({ userId, publishedOnly: true } as const);
+
 export const useImageQueryParams = () => useZodRouteParams(imagesQueryParamSchema);
 
 // The media-type scope a feed falls back to when its filters are cleared.

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
+import { requiresImageDbPath } from '~/server/schema/image.schema';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import {
   dedupeGalleryItems,
@@ -413,6 +414,31 @@ describe('remixSubmitPickerFilters', () => {
     // The picker offers your own work to submit. Dropping this would offer
     // everyone's, and every one of them would be refused.
     expect(remixSubmitPickerFilters(7).userId).toBe(7);
+  });
+
+  // 🔴 To whoever is about to simplify this: the pair of `userId` and
+  // `publishedOnly` is not two independent preferences that happen to sit next
+  // to each other. Together they are the signal `requiresImageDbPath` reads to
+  // route this picker off the search index and onto the database, and that
+  // routing is the whole reason a freshly published image appears here at all.
+  // Measured on prod 2026-08-27: an image is absent from `metrics_images_v1`
+  // for 10-30 minutes after publish, while it is `Scanned` and carries an
+  // `nsfwLevel` inside the first minute. Someone posts an image, opens this
+  // picker to submit it, and the one image they came for is the one missing.
+  // Drop either half and the picker silently goes back to the index — the grid
+  // still renders, still returns rows, and the only symptom is the newest
+  // image not being there.
+  it('routes the picker to the database, not the search index', () => {
+    expect(requiresImageDbPath(remixSubmitPickerFilters(7))).toBe(true);
+  });
+
+  it('needs both halves to route to the database', () => {
+    // The control for the assertion above: it is the PAIR that routes, so
+    // neither half alone may. `publishedOnly` alone would be a broad-feed
+    // escape hatch anyone could type into a URL; `userId` alone is an ordinary
+    // profile feed the index serves fine.
+    expect(requiresImageDbPath({ publishedOnly: true })).toBe(false);
+    expect(requiresImageDbPath({ userId: 7 })).toBe(false);
   });
 });
 

--- a/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
+++ b/src/components/RemixGallery/__tests__/remix-gallery.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
 import { requiresImageDbPath } from '~/server/schema/image.schema';
+import { ownContentPickerFilters } from '~/components/Image/image.utils';
 import type { RemixGalleryItem } from '~/components/RemixGallery/remix-gallery.utils';
 import {
   dedupeGalleryItems,
@@ -430,6 +431,27 @@ describe('remixSubmitPickerFilters', () => {
   // image not being there.
   it('routes the picker to the database, not the search index', () => {
     expect(requiresImageDbPath(remixSubmitPickerFilters(7))).toBe(true);
+  });
+
+  // All three own-content submit pickers spread the same helper, so this one
+  // assertion covers the challenge and add-to-collection modals too. They used to
+  // write the pair out inline with no test of their own: deleting `publishedOnly`
+  // from either ten-key filter block sent that picker back to the index with a
+  // grid that still rendered and still returned rows.
+  it('routes every own-content picker, not only the remix one', () => {
+    expect(requiresImageDbPath(ownContentPickerFilters(7))).toBe(true);
+    expect(remixSubmitPickerFilters(7).publishedOnly).toBe(
+      ownContentPickerFilters(7).publishedOnly
+    );
+  });
+
+  it('routes nothing for a signed-out caller', () => {
+    // `currentUser?.id` is undefined while auth resolves, and the challenge and
+    // collection modals render their grid without waiting for it. Without a
+    // userId the pair does not form and the query stays on the index — which is
+    // correct, because a userId-less picker is a site-wide feed, not yours.
+    expect(requiresImageDbPath(ownContentPickerFilters(undefined))).toBe(false);
+    expect(requiresImageDbPath(remixSubmitPickerFilters(undefined))).toBe(false);
   });
 
   it('needs both halves to route to the database', () => {

--- a/src/components/RemixGallery/remix-gallery.utils.ts
+++ b/src/components/RemixGallery/remix-gallery.utils.ts
@@ -1,5 +1,6 @@
 import type { ImageGetInfinite } from '~/types/router';
 import { ImageSort } from '~/server/common/enums';
+import { ownContentPickerFilters } from '~/components/Image/image.utils';
 import { PLACEMENT_SURFACES, SHARED_ALLOWANCE_NOTE } from '~/shared/utils/placement';
 import { REMIX_GALLERY_ROW_WIDTH } from '~/shared/utils/remix-gallery';
 
@@ -335,11 +336,10 @@ export const submissionMethod = (
  */
 export const remixSubmitPickerFilters = (userId: number | undefined) =>
   ({
-    userId,
+    ...ownContentPickerFilters(userId),
     period: 'AllTime',
     limit: 50,
     sort: ImageSort.Newest,
-    publishedOnly: true,
   } as const);
 
 /**

--- a/src/server/controllers/__tests__/image.controller.feed-source.test.ts
+++ b/src/server/controllers/__tests__/image.controller.feed-source.test.ts
@@ -42,6 +42,18 @@ const ctx = {
 // regardless of the flag.
 const dbBoundInput = { limit: 10, browsingLevel: 1, include: [], postId: 5 } as never;
 const indexBoundInput = { limit: 10, browsingLevel: 1, include: [] } as never;
+// What the remix / challenge / add-to-collection submit pickers send: "show me
+// something of mine to submit". The index can serve this shape, which is why it
+// used to — and why a freshly published image was missing from the picker for
+// as long as the index took to catch up (measured on prod 2026-08-27: 26 of a
+// 40-image cohort were still unindexed 13 minutes after publish).
+const pickerInput = {
+  limit: 50,
+  browsingLevel: 1,
+  include: [],
+  userId: 7,
+  publishedOnly: true,
+} as never;
 
 describe('getInfiniteImagesHandler names the backend that served the page', () => {
   beforeEach(() => {
@@ -75,6 +87,37 @@ describe('getInfiniteImagesHandler names the backend that served the page', () =
 
     expect(getAllImagesIndexMock).toHaveBeenCalledTimes(1);
     expect(result.source).toBe('bitdex');
+  });
+
+  // 🔴 The picker beats BitDex on purpose, and that is the point of the test.
+  // `requiresImageDbPath` is evaluated BEFORE the Flipt call, so a DB-bound
+  // query never even asks what BitDex mode is in. If someone moves the Flipt
+  // evaluation above that check, or reorders the `useIndex` expression so
+  // `useBitdex` wins, this goes red — and nothing else in the suite would.
+  it('serves the own-content submit picker from the database even with BitDex primary', async () => {
+    getFliptVariantMock.mockResolvedValue('primary');
+
+    const result = await getInfiniteImagesHandler({ input: pickerInput, ctx });
+
+    expect(getAllImagesMock).toHaveBeenCalledTimes(1);
+    expect(getAllImagesIndexMock).not.toHaveBeenCalled();
+    expect(result.source).toBe('db');
+    // Not merely unused — never consulted. The short-circuit is what keeps a
+    // BitDex rollout from silently taking the picker back to the index.
+    expect(getFliptVariantMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves a broad feed on the index when only publishedOnly is set', async () => {
+    // The control for the case above: it is the PAIR that routes. Without a
+    // userId this is a site-wide feed, and routing it to the DB would be a
+    // broad-feed escape hatch anyone could type into a URL.
+    const result = await getInfiniteImagesHandler({
+      input: { limit: 10, browsingLevel: 1, include: [], publishedOnly: true } as never,
+      ctx,
+    });
+
+    expect(getAllImagesIndexMock).toHaveBeenCalledTimes(1);
+    expect(getAllImagesMock).not.toHaveBeenCalled();
   });
 
   it('reports meili when BitDex fell back and the index said so', async () => {

--- a/src/server/controllers/__tests__/image.controller.feed-source.test.ts
+++ b/src/server/controllers/__tests__/image.controller.feed-source.test.ts
@@ -107,6 +107,24 @@ describe('getInfiniteImagesHandler names the backend that served the page', () =
     expect(getFliptVariantMock).not.toHaveBeenCalled();
   });
 
+  // 🔴 Both halves of the routing pair are plain URL params, so without the
+  // caller check in the handler this is `/images?userId=<anyone>&publishedOnly=true`
+  // pinning an arbitrary creator's feed to raw SQL for any visitor. The pickers
+  // only ever send the signed-in user's own id, so scoping costs the fix nothing.
+  it('leaves another creator on the index even with publishedOnly set', async () => {
+    const result = await getInfiniteImagesHandler({
+      input: { ...(pickerInput as object), userId: 999 } as never,
+      ctx,
+    });
+
+    expect(getAllImagesIndexMock).toHaveBeenCalledTimes(1);
+    expect(getAllImagesMock).not.toHaveBeenCalled();
+    // Withdrawn, not forwarded — the flag only suppresses the caller's own
+    // unpublished carve-out, which cannot match rows scoped to someone else.
+    expect(getAllImagesIndexMock.mock.calls[0][0].publishedOnly).toBeUndefined();
+    expect(result.source).toBe('bitdex');
+  });
+
   it('leaves a broad feed on the index when only publishedOnly is set', async () => {
     // The control for the case above: it is the PAIR that routes. Without a
     // userId this is a site-wide feed, and routing it to the DB would be a

--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -285,7 +285,26 @@ export const getInfiniteImagesHandler = async ({
   if (input.hubId && !features.userHubs)
     throw throwAuthorizationError('Hubs are not available yet');
 
-  const requiresDbPath = requiresImageDbPath(input);
+  // `publishedOnly` + `userId` routes the own-content submit pickers onto the DB
+  // (see `requiresImageDbPath`), and both are plain URL params — so without this,
+  // `/images?userId=<anyone>&publishedOnly=true` would pin an ARBITRARY creator's
+  // feed to the raw-SQL path for any caller, logged out included. That is a wider
+  // promise than the pickers need: all three only ever send `currentUser?.id`.
+  //
+  // Withdrawn rather than refused, because for a foreign `userId` the flag is
+  // genuinely inert rather than ignored: on both the index and the DB path
+  // `publishedOnly`'s only job is to suppress the carve-out that ORs in the
+  // CALLER's own unpublished rows, and that arm cannot match rows already scoped
+  // to somebody else. Refusing would break a URL that works today and means the
+  // same thing either way. The `hubId` conflict in `getInfiniteImagesSchema` still
+  // reads the un-narrowed input and so stays the stricter of the two — it refuses
+  // a combination this would have served, which is the safe direction.
+  const scopedInput =
+    input.publishedOnly && input.userId && input.userId !== user?.id
+      ? { ...input, publishedOnly: undefined }
+      : input;
+
+  const requiresDbPath = requiresImageDbPath(scopedInput);
 
   // BitDex (Flipt-gated index experiment) routes through getAllImagesIndex, so it
   // can only run when the index can serve the query.
@@ -313,12 +332,12 @@ export const getInfiniteImagesHandler = async ({
   try {
     if (useIndex) {
       return await getAllImagesIndex({
-        ...input,
+        ...scopedInput,
         user,
         domain: getRequestBoardDomainColor(ctx.req),
         useCombinedNsfwLevel: !features.canViewNsfw,
         headers: { src: 'getInfiniteImagesHandler' },
-        include: [...input.include, 'tagIds'],
+        include: [...scopedInput.include, 'tagIds'],
         dbTarget: features.datapacketRead ? 'datapacket' : 'read',
         signal,
         // Forward pre-evaluated variant so getImagesFromSearch can skip a
@@ -332,12 +351,12 @@ export const getInfiniteImagesHandler = async ({
       });
     } else {
       const result = await getAllImages({
-        ...input,
+        ...scopedInput,
         user,
         domain: getRequestBoardDomainColor(ctx.req),
         useCombinedNsfwLevel: !features.canViewNsfw,
         headers: { src: 'getInfiniteImagesHandler' },
-        include: [...input.include, 'tagIds'],
+        include: [...scopedInput.include, 'tagIds'],
         dbTarget: features.datapacketRead ? 'datapacket' : 'read',
       });
       // Name this branch too, like the index path's `source`. Stamped here rather

--- a/src/server/schema/__tests__/hub-input-conflict.test.ts
+++ b/src/server/schema/__tests__/hub-input-conflict.test.ts
@@ -27,6 +27,7 @@ const dbForcing: Record<string, Record<string, unknown>> = {
   imageId: { imageId: 5 },
   'bare modelId': { modelId: 5 },
   'prioritizedUserIds with a model': { prioritizedUserIds: [5], modelVersionId: 9 },
+  'publishedOnly with a userId': { publishedOnly: true, userId: 5 },
 };
 
 describe('hubId cannot be combined with a filter that forces the DB path', () => {

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -364,8 +364,42 @@ export type GetInfiniteImagesOutput = z.output<typeof getInfiniteImagesSchema>;
 //   unpublished image — so this routes the three pickers and nothing else.
 //   Paired with userId for the same reason prioritizedUserIds is paired with a
 //   model: alone it would be a broad-feed DB escape hatch anyone could type
-//   into a URL. Scoped to one user it costs what a profile feed cost before
-//   imageIndexFeed existed.
+//   into a URL. Both halves ARE URL params, so pairing narrows the hatch rather
+//   than closing it — getInfiniteImagesHandler additionally withdraws
+//   `publishedOnly` unless the userId is the caller's own, which is what closes
+//   it. Do not read the pairing here as the whole guard.
+//
+//   Three accepted differences, none of them silent once you have read this.
+//   The DB path is NARROWER than the index for own content in three places, and
+//   in each the submit mutations refuse the row anyway (remix-gallery.service
+//   re-checks publishedAt, ingestion and needsReview), so nothing submittable is
+//   lost: own unscanned (`nsfwLevel = 0`), own `acceptableMinor`, and own
+//   `needsReview`. The first is the one to know about — between publish and the
+//   level landing, the picker shows nothing where the index showed the row. That
+//   window is under a minute (over 99% of images are Scanned and levelled inside
+//   one), against the 10-30 minutes this change removes.
+//   And `getAllImages` orders `Newest` by `i."id" DESC`, i.e. by UPLOAD, while the
+//   index orders by `sortAt` = GREATEST(publishedAt, scannedAt, createdAt). For
+//   the case this exists for — post, then submit — they agree. For "publish a
+//   months-old draft, then submit it" they do not, and the draft lands at its
+//   upload rank rather than first.
+//
+//   🔴 One difference goes the OTHER way, and it is an accepted widening rather
+//   than an oversight. The index filters on `combinedNsfwLevel` whenever
+//   `useCombinedNsfwLevel` is set (i.e. for anyone without NSFW access), and that
+//   is `nsfwLevelLocked ? nsfwLevel : max(nsfwLevel, aiNsfwLevel)`. `getAllImages`
+//   has no equivalent — it filters bare `i."nsfwLevel"`. So an image the AI scored
+//   higher than its assigned level is hidden by the index and returned by the DB.
+//   In these pickers that is the caller's own image shown back to the caller, and
+//   the handler's caller check keeps it that way. Justin accepted it knowingly on
+//   2026-08-27 rather than widen this change into the shared feed query. Do not
+//   "fix" it here by reverting the routing: the fix is to teach `getAllImages`
+//   about `aiNsfwLevel`, which is a feed change and wants its own review.
+//
+//   Cost, measured on the prod replica 2026-08-27: 0.83-1.03 ms at a wide
+//   browsing level, 14-82 ms at browsingLevel=1, where the backward index walk
+//   discards thousands of rows before 51 survive. Plan is an index scan backward
+//   on image_userid_id_idx in every case.
 //
 // A hub can only be served from the index, so this list is also the set `hubId`
 // cannot be combined with. Both the dispatcher and that rejection read it here so

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -352,6 +352,20 @@ export type GetInfiniteImagesOutput = z.output<typeof getInfiniteImagesSchema>;
 //   Only forces the DB when scoped to a model (its sole legit use — the model
 //   showcase carousel, which always pairs it with modelVersionId). Sent alone it
 //   degrades to index ordering rather than acting as a broad-feed DB escape hatch.
+// Freshness, not correctness:
+// - publishedOnly paired with userId: the "pick something of mine to submit"
+//   modals (remix gallery, challenge, add-to-collection). The index can serve
+//   this query, but not in time: measured on prod 2026-08-27, an image is
+//   missing from metrics_images_v1 for 10-30 minutes after it is published,
+//   while it is Scanned and carries an nsfwLevel within the first minute. So
+//   someone posts an image, opens the picker to submit it, and the one image
+//   they came to submit is the one that isn't there. No browse feed sends
+//   publishedOnly — it exists only because those mutations refuse an
+//   unpublished image — so this routes the three pickers and nothing else.
+//   Paired with userId for the same reason prioritizedUserIds is paired with a
+//   model: alone it would be a broad-feed DB escape hatch anyone could type
+//   into a URL. Scoped to one user it costs what a profile feed cost before
+//   imageIndexFeed existed.
 //
 // A hub can only be served from the index, so this list is also the set `hubId`
 // cannot be combined with. Both the dispatcher and that rejection read it here so
@@ -365,6 +379,8 @@ export function requiresImageDbPath(input: {
   modelId?: number | null;
   modelVersionId?: number | null;
   prioritizedUserIds?: number[] | null;
+  publishedOnly?: boolean | null;
+  userId?: number | null;
 }) {
   return (
     !!input.postId ||
@@ -373,7 +389,8 @@ export function requiresImageDbPath(input: {
     !!input.reactions?.length ||
     !!input.imageId ||
     (!!input.modelId && !input.modelVersionId) ||
-    (!!input.prioritizedUserIds?.length && (!!input.modelId || !!input.modelVersionId))
+    (!!input.prioritizedUserIds?.length && (!!input.modelId || !!input.modelVersionId)) ||
+    (!!input.publishedOnly && !!input.userId)
   );
 }
 


### PR DESCRIPTION
## The bug

Post an image, open the "submit your remix" modal to offer it to a creator's gallery, and the image you just posted is not in the list. Same in the Challenge submit modal and Add to collection.

All three ask `image.getInfinite` for the same shape — `{ userId: me, publishedOnly: true, sort: Newest }`, i.e. "show me something of mine to submit" — and that is served from Meilisearch, which does not have the image yet.

## Measured on prod, 2026-08-27

- A 40-image cohort tracked from the moment of publish: **14 indexed within a minute, the other 26 still missing 13 minutes later**, then a batch flush took it to 39/40. One never appeared inside 21 minutes.
- Separately, **53 of 60** images published in the previous ten minutes were absent from `metrics_images_v1`.
- Scanning is **not** the bottleneck: over 99% of images are `Scanned` and carry an `nsfwLevel` inside the first minute, so the database can serve them immediately.
- Data-layer proof: image `140967678`, published and scanned, is returned by the picker's DB query for its owner and returns `total: 0` from the index filtered to that exact owner **and** id — against a control of 3107 indexed rows for the same owner.

## The change

`requiresImageDbPath()` already exists to route `image.getInfinite` onto the raw-SQL path when the index cannot serve a query, and the decision is deliberately server-side. This extends it rather than adding a client flag:

```ts
(!!input.publishedOnly && !!input.userId)
```

`publishedOnly` is set in exactly three places in production code, and all three are these pickers. No browse feed sends it — it exists only because those submit mutations refuse an unpublished image.

**Both halves are URL params, so pairing narrows the hatch rather than closing it.** `getInfiniteImagesHandler` therefore also withdraws `publishedOnly` unless the `userId` is the caller's own. Without that, `/images?userId=<anyone>&publishedOnly=true` pinned an arbitrary creator's feed to raw SQL for any visitor including logged-out ones — a shape the perf review measured at **15,491 ms** with `types=[audio]`, under a bulkhead that is a concurrency cap rather than a rate limit, and below the 20 s statement ceiling so it returns a normal empty page with no error and no log line. Anonymous callers have no id, so the pair cannot form.

Withdrawn rather than refused because for a foreign `userId` the flag is inert, not ignored: on both paths `publishedOnly`'s only job is to suppress the arm that ORs in the *caller's* own unpublished rows, and that arm cannot match rows already scoped to someone else.

Scope was put to Justin: the discriminator fixes the Challenge and Add-to-collection pickers too, which have the identical bug. He chose to keep all three. All three now spread one `ownContentPickerFilters` helper, because two of them previously wrote the pair out inline with nothing asserting it — deleting `publishedOnly` from either ten-key filter block sent that picker silently back to the index, with a grid that still rendered and still returned rows.

## Differences between the two paths, all recorded in the schema comment

**Three narrowings.** The DB path drops own unscanned (`nsfwLevel = 0`), own `acceptableMinor` and own `needsReview`; the index keeps all three for the owner. Each is refused by the submit mutation anyway (`remix-gallery.service.ts` re-checks `publishedAt`, `ingestion` and `needsReview`), so nothing submittable is lost. The first has a sub-minute window against the 10–30 minutes this removes.

**One widening, accepted knowingly.** The index filters on `combinedNsfwLevel` = `nsfwLevelLocked ? nsfwLevel : max(nsfwLevel, aiNsfwLevel)` for any caller without NSFW access; `getAllImages` filters bare `nsfwLevel`. So an image the AI scored higher than its assigned level is hidden by the index and returned by the DB. After the caller check this is the caller's own image shown back to the caller. Justin accepted it rather than widen this change into the shared feed query; the real fix is to teach `getAllImages` about `aiNsfwLevel`, which is a feed change and wants its own review.

**Sort.** The DB orders `Newest` by `i."id" DESC` (upload); the index orders by `sortAt` = `GREATEST(publishedAt, scannedAt, createdAt)`. They agree for "post it, then submit it", which is the case this exists for. They disagree for "publish a months-old draft, then submit it", where it lands at its upload rank.

**Cost.** 0.83–1.03 ms at a wide browsing level, **14–82 ms at `browsingLevel=1`**, which is a common real setting — the walk discards thousands of rows before 51 survive the level filter. Plan is an index scan backward on `image_userid_id_idx` in every case. An earlier 2.165 ms figure in this PR was a real measurement at a convenient input and not representative.

## Review

Six reviewers over the first two commits: five passed, one blocked. The block was upheld — the caller scoping, the shared helper and every difference documented above came out of it, and the perf measurements above are its work.

## Tests

Reverting the predicate clause fails **four** named assertions across the three test files. Reverting the caller check fails `leaves another creator on the index even with publishedOnly set` with `expected "vi.fn()" to be called 1 times, but got 0 times`. Both controls were re-run *after* the helper refactor moved what they guard, not only before it.

The handler test asserts `getFliptVariant` is **never consulted**, which is the actual short-circuit — `bitdexMode` is only evaluated when `requiresDbPath` is false. Each assertion has a paired control asserting the other direction, including the signed-out case the challenge and collection modals reach during hydration.

## Known side effect

`hubId` cannot be combined with anything `requiresImageDbPath` returns true for, so `/hubs/N?userId=5&publishedOnly=true` now returns a schema refusal instead of being served. Not reachable from any UI — the hub feed enumerates its filters and sets `disableStoreFilters`.

## Verification

- `pnpm run typecheck` — 0 type errors.
- `pnpm exec eslint` on the changed files — 0 errors (8 pre-existing warnings).
- `pnpm run test:unit:run` — `Test Files 1 failed | 1476 passed | 1 skipped (1478)`. The one failing file is `scripts/test-perf/__tests__/trace-flush.test.ts`, reproduced identically with this diff stashed, so it is pre-existing and unrelated.
- `blocks.router.workflow.test.ts` collected **358** tests (nonzero — the submodule is initialised).
- Justin verified the fix by hand against a dev server pointed at the production database.

## Unrelated, but found on the way

The Flipt admin API reports `image-index-feed` as **DISABLED** and `bitdex-image-search` as "off" for every segment, but the live production page payload resolves `imageIndexFeed: true`. Control: every other Flipt-disabled flag checked (`userHubs`, `creatorAnnouncements`, `scheduledModelSales`, `liveMetrics`, `previewSiteAccess`) is absent from that payload, so it does reflect resolved state. Admin state and runtime state disagree. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
