### PR TITLE
fix(monetization): re-point the version-form tests at the copy and the policy that shipped

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -143,7 +143,11 @@ function renderNewVersionForm(onSubmit: (v?: unknown) => void = vi.fn()) {
   );
 }
 
-const chargeSwitch = () => page.getByRole('switch', { name: /I want to charge for this version/ });
+// Matches the switch's own label in ModelVersionUpsertForm. The copy moved from "charge for" to
+// "monetize" in acd61ae136 ("say 'monetize'"), which silently broke every test reaching the fee UI
+// through this locator — 16 of them, all reporting `Cannot find element` rather than anything about
+// copy. Keep this string in step with the `label=` prop, not with the surrounding prose.
+const chargeSwitch = () => page.getByRole('switch', { name: /I want to monetize this version/ });
 const accessSwitch = () => page.getByRole('switch', { name: /Charge for access to this version/ });
 const feeSwitch = () =>
   page.getByRole('switch', { name: /Charge a fee to generate with this version/ });
@@ -718,22 +722,26 @@ describe('ModelVersionUpsertForm — monetization disclosure', () => {
     expect(terms?.download?.price).toBe(3000);
   });
 
-  // The other half of the same expression, and the reason it can't simply drop to the tier cap: a stored
-  // price above the cap stays chargeable (the server rejects raises only), so clamping the input down
-  // would cut a lapsed creator's price on the next unrelated save.
-  test('keeps a grandfathered over-cap price rather than clamping to the tier cap', async () => {
-    // Free caps paid access at 500; this version stores 5000.
+  // The other half of the same expression. This used to assert the opposite — that a raise was pulled
+  // back down to the stored price — because a tier-based clamp existed. 307e35f8d7 removed it on
+  // purpose ("revert(monetization): drop the tier price clamps — the article stands"): membership
+  // governs how OFTEN a creator prices and never how much, so there is no cap to clamp to and a free
+  // creator's raise must go through untouched. Re-pointed rather than deleted, because a
+  // reintroduced clamp is exactly what that revert says must not come back.
+  test('submits a raise above the old tier cap unchanged — membership limits how often, not how much', async () => {
+    // Free would once have capped paid access at 500; this version stores 5000.
     renderChargingForm();
 
     await userEvent.fill(page.getByLabelText('Price for access'), '6000');
-    // An edit the clamp can't undo, so the save isn't short-circuited as pristine once 6000 comes back
-    // down to the stored 5000.
+    // Edit a second field too, so the save cannot be short-circuited as pristine on any path — that
+    // would pass this assertion without the price ever being submitted.
     await userEvent.fill(page.getByLabelText('Name'), 'v1.1');
     await userEvent.click(page.getByRole('button', { name: 'Save' }));
     await vi.waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
     const terms = (mutateAsync.mock.calls[0][0] as { paidAccess?: { terms?: ModelVersionTerms } })
       .paidAccess?.terms;
-    expect(terms?.download?.price).toBe(5000);
+    // A reintroduced clamp reports `expected 5000 to be 6000` — the stored price winning over the edit.
+    expect(terms?.download?.price).toBe(6000);
   });
 
   // A pristine edit short-circuits the mutation, so the observable is the form's own onSubmit: it fires


### PR DESCRIPTION
`preview / component-tests` has posted a `failure` status on every PR based after **2026-08-26 15:34**. Two independent causes, both a test left behind by a deliberate change, both in `ModelVersionUpsertForm.browser.test.tsx`.

## 1 — the charge switch was renamed (16 tests)

`acd61ae136` ("say 'monetize'") changed the switch's label:

```diff
-  label="I want to charge for this version"
+  label="I want to monetize this version"
```

The suite's `chargeSwitch()` locator matches on the accessible name, so every test that reaches the fee UI through it stopped finding the switch — the whole *monetization eligibility floor* and *monetization disclosure* blocks. They fail with `Cannot find element with locator` or a 15s `locator.click` timeout, neither of which says anything about copy, which is why this read as a broken suite rather than a rename.

## 2 — the tier price clamp was reverted on purpose (1 test)

`307e35f8d7` ("drop the tier price clamps — the article stands") removed the clamp deliberately. One test still pinned its behaviour — fill 6000 over a stored 5000, expect 5000 back — and now fails `expected 6000 to be 5000`. That failure *is* the revert working.

Rather than delete it, this re-points the test at the invariant that replaced the clamp: membership governs how **often** a creator prices, never how much, so a free creator's raise must be submitted untouched. A reintroduced clamp is precisely what that revert says must not come back, and the assertion still discriminates — it was red at `5000` against a live `6000`, green at `6000`, same fixture.

## Verification

Run on this file alone, unmodified vs fixed:

| tree | result |
|---|---|
| `origin/main` | `Tests  17 failed \| 10 passed (27)` |
| with this fix | `Tests  27 passed (27)` |

17 is the same count every preview run has reported since 08-26, and the two failure reasons match one-for-one (16 locator, 1 assertion).

## One thing worth knowing while judging this

`test:component` is in **no** GitHub Actions workflow — `lint.yml` runs `test:unit`, `test:packages` and `test:apps` only. So the report-only preview status is the component suite's **only** runner. "It's report-only" is true, but it isn't a duplicate of a gating signal elsewhere; there is nothing else.

Both breakages are also the same shape: a test that pins UI copy or a policy has no link back to the code that owns it, so a deliberate change lands green and the test discovers it days later in a tier nobody is watching. The locator here will break again on the next copy edit — worth a follow-up if you want it structural, though that means giving the switch a stable hook in the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9VFYjPYAcY5BuePKFvBw8
