### PR TITLE
fix(stickers): let the chip hide stickers on a ?stickers=1 view

### DIFF
--- a/src/store/__tests__/sticker-reveal.store.test.ts
+++ b/src/store/__tests__/sticker-reveal.store.test.ts
@@ -32,7 +32,7 @@ function mount(present: boolean) {
 
 describe('the reveal query param', () => {
   beforeEach(() => {
-    useStickerRevealStore.setState({ revealed: false, forced: 0 });
+    useStickerRevealStore.setState({ revealed: false, forced: 0, forcedDismissed: false });
   });
 
   const shown = () => stickersRevealed(useStickerRevealStore.getState());
@@ -98,21 +98,78 @@ describe('the reveal query param', () => {
   });
 
   /**
-   * The chip is inert while the link is forcing the reveal.
+   * 🔴 THE CHIP WINS OVER THE LINK. Do not restore the inert-while-forced
+   * toggle this replaced (Justin, 2026-08-27).
    *
-   * It reads as ON — `stickersRevealed` is what feeds it — so a toggle that
-   * flipped the stored flag underneath would leave the chip saying "on", the
-   * stickers still showing, and the viewer's actual setting silently changed by
-   * a press that appeared to do nothing.
+   * The link may open the door; it may not hold it open. The earlier design made
+   * the press a no-op so the chip could never lie about what it had done — but
+   * that left a viewer who followed a notification with a visible control that
+   * did nothing, and no way to put the overlay away short of a reload.
+   *
+   * The URL still says `stickers=1` afterwards and that is accepted, not an
+   * oversight: the address bar is not the control.
    */
-  it('does not let the chip flip the stored setting under a forced view', () => {
+  it('lets the chip hide stickers on a forced view', () => {
     const view = mount(true);
+    expect(shown()).toBe(true);
 
     useStickerRevealStore.getState().toggle();
 
-    expect(useStickerRevealStore.getState().revealed).toBe(false);
-    expect(shown()).toBe(true);
+    expect(shown()).toBe(false);
     view.unmount();
+  });
+
+  /**
+   * 🔴 THE COHORT MOST LIKELY TO BE LOOKING: someone who already had stickers on
+   * before the link arrived.
+   *
+   * Spending the override alone is not enough for them — `revealed` is still
+   * true underneath, so the selector keeps returning true and the press does
+   * nothing while the chip goes on reading "Hide". Dropping the `revealed: false`
+   * half of that branch reintroduces the inert chip for exactly these viewers,
+   * and every other test here starts from `revealed: false`, so this is the only
+   * one that can see it.
+   */
+  it('hides stickers on a forced view for a viewer who already had them on', () => {
+    useStickerRevealStore.getState().setRevealed(true);
+    const view = mount(true);
+    expect(shown()).toBe(true);
+
+    useStickerRevealStore.getState().toggle();
+
+    expect(shown()).toBe(false);
+    expect(useStickerRevealStore.getState().revealed).toBe(false);
+    view.unmount();
+  });
+
+  // A dismissed override stays dismissed for as long as the view holding it is
+  // there — otherwise the next re-render puts the stickers straight back.
+  it('keeps the reveal off while the forced view is still mounted', () => {
+    const view = mount(true);
+    useStickerRevealStore.getState().toggle();
+
+    expect(shown()).toBe(false);
+
+    // And an ordinary press still turns them back on afterwards.
+    useStickerRevealStore.getState().toggle();
+    expect(shown()).toBe(true);
+    expect(useStickerRevealStore.getState().revealed).toBe(true);
+
+    view.unmount();
+  });
+
+  // The dismissal belongs to the episode, not to the viewer: a later link must
+  // still be able to reveal.
+  it('forgets the dismissal once the last forced view leaves', () => {
+    const first = mount(true);
+    useStickerRevealStore.getState().toggle();
+    expect(shown()).toBe(false);
+    first.unmount();
+
+    const second = mount(true);
+
+    expect(shown()).toBe(true);
+    second.unmount();
   });
 
   /**
@@ -162,6 +219,7 @@ describe('the reveal query param', () => {
    */
   it('never writes the per-view override to storage', () => {
     useStickerRevealStore.getState().pushForced();
+    useStickerRevealStore.getState().toggle();
     useStickerRevealStore.getState().setRevealed(true);
 
     const stored = JSON.parse(localStorage.getItem('sticker-reveal') ?? '{}');

--- a/src/store/sticker-reveal.store.ts
+++ b/src/store/sticker-reveal.store.ts
@@ -25,7 +25,9 @@ interface StickerRevealStore {
    * "see my sticker" (Justin, 2026-08-24).
    *
    * While it is above zero the surface behaves exactly as if the toggle were on,
-   * including the count chip, and the chip does nothing when pressed.
+   * including the count chip — but the chip still works: pressing it sets
+   * `forcedDismissed` and hides them. A link may open the door; it may not hold
+   * it open against the viewer (Justin, 2026-08-27).
    *
    * 🔴 A COUNT, NOT A BOOLEAN, and the difference is a live bug rather than
    * defensiveness. Two `ImageDetail2` instances can be mounted at once — the
@@ -45,6 +47,14 @@ interface StickerRevealStore {
    * for as long as that subtree was mounted.
    */
   forced: number;
+  /**
+   * The viewer pressed the chip while `forced` was holding the reveal open, so
+   * the override is spent for this episode.
+   *
+   * Not persisted, and cleared when the last forced view leaves, so it scopes to
+   * the one link-driven visit rather than to the viewer's stored setting.
+   */
+  forcedDismissed: boolean;
   toggle: () => void;
   setRevealed: (revealed: boolean) => void;
   /** Claims the override for one view; the returned count is not for callers. */
@@ -58,16 +68,27 @@ export const useStickerRevealStore = create<StickerRevealStore>()(
     (set) => ({
       revealed: false,
       forced: 0,
-      // Inert while forced. The alternative is a chip that reads "on", turns the
-      // underlying flag off, and leaves the stickers exactly where they were —
-      // a control that reports having done something it did not do.
-      toggle: () => set((state) => (state.forced > 0 ? {} : { revealed: !state.revealed })),
+      forcedDismissed: false,
+      // The first press under a live override spends the override rather than
+      // flipping the stored flag beneath it, because flipping alone would leave
+      // the stickers exactly where they were — a control reporting it had done
+      // something it had not. Every press after that is an ordinary toggle.
+      toggle: () =>
+        set((state) =>
+          state.forced > 0 && !state.forcedDismissed
+            ? { forcedDismissed: true, revealed: false }
+            : { revealed: !state.revealed }
+        ),
       setRevealed: (revealed) => set({ revealed }),
       pushForced: () => set((state) => ({ forced: state.forced + 1 })),
       // Floored, so a stray release cannot take the override away from a view
       // that still holds one — the failure that would look like the boolean bug
       // coming back.
-      popForced: () => set((state) => ({ forced: Math.max(0, state.forced - 1) })),
+      popForced: () =>
+        set((state) => {
+          const forced = Math.max(0, state.forced - 1);
+          return forced > 0 ? { forced } : { forced, forcedDismissed: false };
+        }),
     }),
     {
       name: 'sticker-reveal',
@@ -86,7 +107,8 @@ export const useStickerRevealStore = create<StickerRevealStore>()(
  * What every surface should ask, rather than reading `revealed` directly: a
  * consumer that reads the stored flag alone renders nothing on a forced view.
  */
-export const stickersRevealed = (state: StickerRevealStore) => state.revealed || state.forced > 0;
+export const stickersRevealed = (state: StickerRevealStore) =>
+  state.revealed || (state.forced > 0 && !state.forcedDismissed);
 
 /**
  * Honours `?stickers=1` for as long as the view is mounted — see


### PR DESCRIPTION
## What

Sticker notifications link to `/images/<id>?stickers=1`, which forces the overlay on for that view. The count chip was deliberately **inert** while that override was live — so a viewer who followed the notification had a visible control that did nothing, and no way to put the overlay away short of a reload.

The chip now wins over the link.

## How

`src/store/sticker-reveal.store.ts`

- New **non-persisted** `forcedDismissed`. The first press while `forced > 0` spends the override (`forcedDismissed: true, revealed: false`) instead of being a no-op. Every press after that is an ordinary toggle.
- `popForced()` clears `forcedDismissed` when the count reaches 0, so the dismissal scopes to the one link-driven visit — a later link can still reveal.
- `stickersRevealed = revealed || (forced > 0 && !forcedDismissed)`.

Clearing `revealed` as well as setting the flag is load-bearing, not belt-and-braces: for a viewer who already had stickers on site-wide, spending the override alone leaves the selector returning `true`, and the chip goes back to being inert for exactly the cohort most likely to be looking at stickers.

The URL still reads `stickers=1` afterwards. Accepted per Justin, not an oversight — the address bar is not the control.

## Verification

Store suite: `Tests 11 passed (11)`, exit 0.

Two mutant controls, each run and each failing legibly:

| Mutant | Result |
|---|---|
| revert `toggle` + selector to the inert-while-forced form | `3 failed \| 7 passed (10)`, exit 1, `AssertionError: expected true to be false` x3 |
| drop the `revealed: false` half of the dismiss branch | `1 failed \| 10 passed (11)`, exit 1, on `hides stickers on a forced view for a viewer who already had them on` |

Full unit suite (run on the base commit, in the primary checkout): `Test Files 2 failed | 1461 passed | 1 skipped (1464)`, `Tests 22866 passed | 27 skipped (22893)`. **Zero test failures** — both failing files are collection errors from stale local `node_modules` (`Failed to resolve import "html2canvas-pro"`, `Cannot find package '@civitai/moderation'`), unrelated to this diff. `blocks.router.workflow.test.ts` collected **358 tests**, so the submodule was initialised and the run means something.

`eslint` on both changed files: exit 0. Prettier written.

Note: `pnpm run typecheck` on that box reports 417 errors, **none** in these two files (grep for `sticker-reveal` over the log returns 0 hits). Cause is the same dependency staleness: `node_modules/@civitai/client` is `0.2.0-beta.90` against a `0.2.0-beta.94` pin.

## Reviewed

An adversarial pass over the diff (prompted to refute) attacked the two-views-holding-the-override case, `partialize` leakage, direct `revealed` reads across all six consumers, and whether the chip tooltip can lie. It confirmed one gap — the untested `revealed: false` clause — which is what the second control above now closes. It also flagged one behaviour worth naming explicitly rather than inheriting silently:

**Off-then-on on a forced view writes the site-wide preference.** Press once (stickers hide), press again, and the second press is an ordinary toggle that persists `revealed: true`. The chip's tooltip at that moment reads "Show stickers on all images", so the control is honest about it — but it is reachable in two presses where it previously was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
