### PR TITLE
fix(collections): make the showcase confirm's No button close the dialog

### DIFF
--- a/src/components/Collections/AddToCollectionModal.tsx
+++ b/src/components/Collections/AddToCollectionModal.tsx
@@ -49,12 +49,14 @@ import {
 import { getDisplayName } from '~/utils/string-helpers';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isDefined } from '~/utils/type-guards';
-import { closeAllModals, openModal } from '@mantine/modals';
+import { closeModal, openModal } from '@mantine/modals';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { ReadOnlyAlert } from '~/components/ReadOnlyAlert/ReadOnlyAlert';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import classes from './AddToCollectionModal.module.scss';
+
+const SHOWCASE_COLLECTION_MODAL_ID = 'set-showcase-collection';
 
 type Props = Partial<AddCollectionItemInput> & { createNew?: boolean };
 
@@ -347,6 +349,7 @@ function CollectionListForm({
             const [collection] = collections;
             if (collection.read === CollectionReadConfiguration.Public) {
               openModal({
+                modalId: SHOWCASE_COLLECTION_MODAL_ID,
                 title: 'Set Showcase Collection',
                 centered: true,
                 children: (
@@ -615,6 +618,7 @@ function NewCollectionForm({
           result.isOwner
         ) {
           openModal({
+            modalId: SHOWCASE_COLLECTION_MODAL_ID,
             title: 'Set Showcase Collection',
             centered: true,
             children: <ConfirmSetShowcaseCollection modelId={modelId} collectionId={result.id} />,
@@ -764,7 +768,7 @@ function ConfirmSetShowcaseCollection({
   collectionId: number;
 }) {
   const setShowcaseCollectionMutation = trpc.model.setCollectionShowcase.useMutation({
-    onSuccess: () => closeAllModals(),
+    onSuccess: () => closeModal(SHOWCASE_COLLECTION_MODAL_ID),
   });
 
   const handleSetShowcase = () => {
@@ -775,7 +779,9 @@ function ConfirmSetShowcaseCollection({
     <div className="flex flex-col gap-4">
       <Text>Would you like to set this collection as this model&apos;s showcase collection?</Text>
       <div className="flex justify-end gap-2">
-        <Button variant="default">No</Button>
+        <Button variant="default" onClick={() => closeModal(SHOWCASE_COLLECTION_MODAL_ID)}>
+          No
+        </Button>
         <Button onClick={handleSetShowcase} loading={setShowcaseCollectionMutation.isPending}>
           Yes
         </Button>


### PR DESCRIPTION
## Problem

The **Set Showcase Collection** confirm dialog — "Would you like to set this collection as this model's showcase collection?" — shipped a `No` button with no `onClick`:

```tsx
<Button variant="default">No</Button>
```

It renders, styles, and takes a pointer cursor on hover like a working control, so a user hovers it, gets the hand cursor, clicks repeatedly with no response, and is left dismissing the dialog with the X. Reported by a tester in `#civitai-testers` with a screen recording ("cant click no D:").

Nothing is set incorrectly and nothing is lost — declining by dismissing has the same net effect — but it reads as the site being broken.

Both call sites that render `ConfirmSetShowcaseCollection` (`AddToCollectionModal.tsx:353` and `:620`) got the dead button.

## Fix

`No` now closes the dialog.

Rather than reusing the `Yes` path's `closeAllModals()`, both buttons close by an explicit `modalId`. `AddToCollectionModal` itself is a dialog-registry dialog, not a Mantine one, so `closeAllModals()` happens to be harmless today — but it would tear down any unrelated Mantine modal open underneath, and the targeted close costs nothing. This follows the `modalId` + `closeModal(id)` pattern already used in `DeleteImage`, `UnblockImage` and `CsamDetailsForm`.

## Testing

No automated coverage — the change is a `closeModal` call wired to an existing button, matching a pattern used verbatim in five other components. Verify by hand: add a model to a single public collection you own, then click **No** on the confirm dialog and check it closes without setting a showcase collection.

Closes [868kxcfgt](https://app.clickup.com/t/8459928/868kxcfgt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHW81j13teRJDXQMUzzNo1