### PR TITLE
fix(tours): teach the remix menu, and unskip the steps that were vanishing

### DIFF
--- a/src/components/Image/AsPosts/ImagesAsPostsInfinite.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsInfinite.tsx
@@ -261,9 +261,7 @@ export function ImagesAsPostsInfinite({
         <MasonryContainer>
           <Stack gap="md">
             <Group gap="xs">
-              <Title order={2} data-tour="model:gallery">
-                Gallery
-              </Title>
+              <Title order={2}>Gallery</Title>
               {!isMuted && (
                 <Group>
                   <LoginRedirect reason="post-images">

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -81,8 +81,9 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
     e.stopPropagation();
   }, []);
 
-  const handleRemixAction = useCallback(() => {
-    // Go to next step in tour when clicking
+  // The content-gen tour spends two steps here — one on the button, one on the
+  // options it opens — so both the open and the choice move it on by one.
+  const advanceTour = useCallback(() => {
     if (running) helpers?.next();
   }, [running, helpers]);
 
@@ -183,9 +184,11 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                       <RemixMenu
                         image={image}
                         source="remix:image-card"
-                        onAction={handleRemixAction}
-                        // The content-gen tour's remix step advances only by
-                        // clicking through to one of these options.
+                        onAction={advanceTour}
+                        onOpen={advanceTour}
+                        tourTarget={image.type === MediaType.image ? 'gen:remix-menu' : undefined}
+                        // The first of those has no footer, so the menu has to
+                        // clear the layers Joyride draws over it.
                         zIndex={running ? tourClickThroughZIndex : undefined}
                       >
                         <HoverActionButton

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -30,7 +30,7 @@ import { RemixMenu, isRemixMenuVisible } from '~/components/Image/Remix/RemixMen
 import { REMIX_FRAME } from '~/components/RemixGallery/remix-card-demo';
 import { useRemixCardData } from '~/components/RemixGallery/use-remix-card-data';
 import { RemixedCardFlyout } from '~/components/RemixGallery/RemixedCardFlyout';
-import { tourOverlayZIndex } from '~/shared/constants/app-layout.constants';
+import { tourClickThroughZIndex } from '~/shared/constants/app-layout.constants';
 import { useImageStore } from '~/store/image.store';
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import { BlockedReason } from '~/server/common/enums';
@@ -184,10 +184,9 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                         image={image}
                         source="remix:image-card"
                         onAction={handleRemixAction}
-                        // The content-gen tour's remix step can only be advanced
-                        // by clicking through to an option, and its overlay both
-                        // dims and swallows clicks below it.
-                        zIndex={running ? tourOverlayZIndex + 1 : undefined}
+                        // The content-gen tour's remix step advances only by
+                        // clicking through to one of these options.
+                        zIndex={running ? tourClickThroughZIndex : undefined}
                       >
                         <HoverActionButton
                           label="Remix"

--- a/src/components/Image/Remix/RemixMenu.tsx
+++ b/src/components/Image/Remix/RemixMenu.tsx
@@ -13,6 +13,7 @@ import {
   type RemixSourceImage,
 } from '~/components/Image/Remix/remix.utils';
 import { remixMenuZIndex } from '~/shared/constants/app-layout.constants';
+import { waitForElement } from '~/utils/html-helpers';
 
 type RemixOption = {
   label: string;
@@ -75,6 +76,8 @@ export function RemixMenu({
   source,
   sourceModelVersionId,
   onAction,
+  onOpen,
+  tourTarget,
   children,
   zIndex,
 }: {
@@ -84,6 +87,13 @@ export function RemixMenu({
   /** Known only where the surface is scoped to a version (the model carousel). */
   sourceModelVersionId?: number;
   onAction?: () => void;
+  /**
+   * The menu became visible. Separate from `onAction` so a tour can put one
+   * step on the button and the next on the options themselves.
+   */
+  onOpen?: () => void;
+  /** `data-tour` for the dropdown, where a tour step describes the options. */
+  tourTarget?: string;
   children: React.ReactNode;
   zIndex?: number;
 }) {
@@ -116,27 +126,37 @@ export function RemixMenu({
     onAction?.();
   };
 
-  // A menu holding nothing but a disabled refusal has no item to click, so an
-  // `onAction` that only fires from an item would strand a tour step whose only
-  // way forward is clicking through this button. Latched because `onOpen` fires
-  // on every open, and `onAction` advances a tour a step at a time.
+  // Latched: Mantine fires this on every open, while a tour advances a step at
+  // a time, so reopening the menu must not move it on again.
+  //
+  // The fallback keeps a caller that only passes `onAction` unstuck. A menu
+  // holding nothing but a disabled refusal has no item to click, so there an
+  // `onAction` that only fires from an item would strand a tour step whose sole
+  // exit is clicking through this button.
   const hasActionableItem = (!engineRefusal && kinds.length > 0) || showReuse;
-  const announcedRefusal = useRef(false);
-  const handleRefusalOpen = () => {
-    if (announcedRefusal.current) return;
-    announcedRefusal.current = true;
-    onAction?.();
+  const announcedOpen = useRef(false);
+  const handleOpen = () => {
+    if (announcedOpen.current) return;
+    announcedOpen.current = true;
+    if (!onOpen) {
+      if (!hasActionableItem) onAction?.();
+      return;
+    }
+    if (!tourTarget) return onOpen();
+    // Mantine calls this from the state setter, before the dropdown commits, so
+    // announcing the open straight away points a tour step at a target that is
+    // not in the document yet — Joyride reads that as `TARGET_NOT_FOUND` and
+    // skips the step it was meant to land on.
+    waitForElement({ selector: `[data-tour="${tourTarget}"]`, interval: 50, timeout: 2000 })
+      .catch(() => null)
+      .then(() => onOpen());
   };
 
   return (
-    <Menu
-      withinPortal
-      position="bottom-end"
-      zIndex={zIndex ?? remixMenuZIndex}
-      onOpen={hasActionableItem ? undefined : handleRefusalOpen}
-    >
+    <Menu withinPortal position="bottom-end" zIndex={zIndex ?? remixMenuZIndex} onOpen={handleOpen}>
       <Menu.Target>{children}</Menu.Target>
       <Menu.Dropdown
+        data-tour={tourTarget}
         className="w-[290px] p-1.5"
         onClick={(e) => {
           // These live inside RoutedDialogLink on the feed cards, which would

--- a/src/components/Image/Remix/__tests__/remix.utils.test.ts
+++ b/src/components/Image/Remix/__tests__/remix.utils.test.ts
@@ -168,9 +168,9 @@ describe('the refusal-only menu state', () => {
   // to fall back on — is what wedged the onboarding tour once already: the menu
   // rendered with nothing clickable in it, so the "user acted" callback never
   // fired and a step whose only exit is clicking through had no exit. RemixMenu
-  // handles it by firing that callback on open instead. If someone makes
-  // `isRemixMenuVisible` refusal-aware, this fails and points at the `onOpen`
-  // branch that then has no reason to exist.
+  // answers it on two fronts: a caller passing only `onAction` gets it fired on
+  // open, and the tour's own menu step keeps its footer. If someone makes
+  // `isRemixMenuVisible` refusal-aware, this fails and points at both.
   it('is reachable: visible, refused, and nothing to fall back on', () => {
     const refused = image({ poi: true });
     expect(getEngineRefusal(refused)).toBeDefined();

--- a/src/components/Model/Gallery/ModelGallery.tsx
+++ b/src/components/Model/Gallery/ModelGallery.tsx
@@ -33,14 +33,14 @@ export function ModelGallery(props: ModelGalleryProps) {
     triggerOnce: true,
   });
 
-  const content = inView && (
-    <ImagesAsPostsInfinite source={{ kind: 'model', model }} {...rest} />
-  );
+  const content = inView && <ImagesAsPostsInfinite source={{ kind: 'model', model }} {...rest} />;
   const forceMinorLevel = !!model.minor && !currentUser?.isModerator;
   const minorBrowsingLevel = currentUser ? sfwBrowsingLevelsFlag : publicBrowsingLevelsFlag;
 
   return (
-    <div ref={ref} className="min-h-80 w-full">
+    // The tour targets this wrapper, not the gallery's own heading: the heading
+    // only exists once `inView` has fired, and the step runs before that.
+    <div ref={ref} data-tour="model:gallery" className="min-h-80 w-full">
       {forceMinorLevel ? (
         <BrowsingLevelProvider forcedBrowsingLevel={minorBrowsingLevel}>
           <BrowsingSettingsAddonsProvider>

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Card, Center, Indicator, Loader, Stack } from '@mantine/core';
 import { IconBrush, IconInfoCircle } from '@tabler/icons-react';
 import { BrowsingLevelProvider } from '~/components/BrowsingLevel/BrowsingLevelProvider';
@@ -54,6 +55,11 @@ export function ModelCarousel(props: Props) {
 function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10 }: Props) {
   const features = useFeatureFlags();
   const { running, helpers } = useTourContext();
+  // Both model-page tours spend two steps here — one on the button, one on the
+  // options it opens — so the open and the choice each move on by one.
+  const advanceTour = useCallback(() => {
+    if (running) helpers?.next();
+  }, [running, helpers]);
   const { images, flatData, isLoading } = useQueryImages({
     modelVersionId: modelVersionId,
     prioritizedUserIds: [modelUserId],
@@ -122,12 +128,12 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
                                   image={image}
                                   source="remix:model-carousel"
                                   sourceModelVersionId={modelVersionId}
-                                  onAction={() => {
-                                    if (running) helpers?.next();
-                                  }}
-                                  // Both model-page tours put a step on this
-                                  // button that advances only by clicking
-                                  // through to one of these options.
+                                  onAction={advanceTour}
+                                  onOpen={advanceTour}
+                                  tourTarget="model:remix-menu"
+                                  // Both model-page tours spend a step on this
+                                  // button and the next on the options it
+                                  // opens, over the layers Joyride draws.
                                   zIndex={running ? tourClickThroughZIndex : undefined}
                                 >
                                   <HoverActionButton

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -23,7 +23,7 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import { ImageSort } from '~/server/common/enums';
 import { RemixMenu, isRemixMenuVisible } from '~/components/Image/Remix/RemixMenu';
-import { tourOverlayZIndex } from '~/shared/constants/app-layout.constants';
+import { tourClickThroughZIndex } from '~/shared/constants/app-layout.constants';
 import { BrowsingSettingsAddonsProvider } from '~/providers/BrowsingSettingsAddonsProvider';
 import { Embla } from '~/components/EmblaCarousel/EmblaCarousel';
 import { useContainerSmallerThan } from '~/components/ContainerProvider/useContainerSmallerThan';
@@ -126,10 +126,9 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
                                     if (running) helpers?.next();
                                   }}
                                   // Both model-page tours put a step on this
-                                  // button whose only way forward is clicking
-                                  // through it, and the overlay swallows clicks
-                                  // below it.
-                                  zIndex={running ? tourOverlayZIndex + 1 : undefined}
+                                  // button that advances only by clicking
+                                  // through to one of these options.
+                                  zIndex={running ? tourClickThroughZIndex : undefined}
                                 >
                                   <HoverActionButton
                                     label="Remix"

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -530,7 +530,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   });
 
   const downloadSection = showDownloadSection ? (
-    <Card withBorder>
+    <Card withBorder data-tour="model:download">
       <Card.Section withBorder inheritPadding py="xs" px="sm">
         <Group justify="space-between">
           <Text size="sm" fw={600}>

--- a/src/components/Tour/TourPopover.tsx
+++ b/src/components/Tour/TourPopover.tsx
@@ -37,7 +37,11 @@ export function TourPopover(props: TooltipRenderProps) {
         <Text className={clsx(!step.showProgress && 'hidden')} size="sm" c="dimmed">
           {index + 1} of {size}
         </Text>
-        {!step.hideCloseButton && <CloseButton aria-label="Close" ml="auto" />}
+        {/* Only the handler: `closeProps` also carries Joyride's own label as
+            `children`, which would render inside the icon button. */}
+        {!step.hideCloseButton && (
+          <CloseButton onClick={closeProps.onClick} aria-label="Close" ml="auto" />
+        )}
       </Group>
       <div className="flex flex-col gap-1">
         {step.title && step.showProgress && (

--- a/src/components/Tours/LazyTours.tsx
+++ b/src/components/Tours/LazyTours.tsx
@@ -12,6 +12,7 @@ import { IsClient } from '~/components/IsClient/IsClient';
 import { TourPopover } from '~/components/Tour/TourPopover';
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import type { StepData } from '~/types/tour';
+import { tourScrollBlock } from '~/components/Tours/tour-scroll';
 import { tourOverlayZIndex } from '~/shared/constants/app-layout.constants';
 
 const completeStatus: string[] = [STATUS.SKIPPED, STATUS.FINISHED];
@@ -28,7 +29,10 @@ export default function LazyTours({ getHelpers }: Pick<JoyrideProps, 'getHelpers
       if (action === ACTIONS.UPDATE && lifecycle === LIFECYCLE.TOOLTIP) {
         const target = document.querySelector(step?.target as string);
         if (target && step.placement !== 'center')
-          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          target.scrollIntoView({
+            behavior: 'smooth',
+            block: tourScrollBlock(target.getBoundingClientRect().height, window.innerHeight),
+          });
         window.dispatchEvent(new Event('resize'));
       }
 

--- a/src/components/Tours/__tests__/tour-steps.test.ts
+++ b/src/components/Tours/__tests__/tour-steps.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import { tourScrollBlock } from '~/components/Tours/tour-scroll';
 import { tourSteps } from '~/components/Tours/tours';
 
 const SRC = path.resolve(__dirname, '../../..');
@@ -55,18 +56,31 @@ describe('tour steps point at something', () => {
   });
 });
 
-describe('the content-generation remix steps', () => {
-  // Clicking the remix button opens a menu rather than the generator, so the
-  // tour spends a step on the button and the next on the options it reveals.
-  // Collapsing them back into one leaves the menu undescribed.
-  it('follows the button step with one on the menu it opens', () => {
-    const targets = tourSteps['content-generation'].map((step) => String(step.target));
-    const button = targets.indexOf('[data-tour="gen:remix"]');
+// Clicking a remix button opens a menu rather than the generator, so each tour
+// that spotlights one spends a step on the button and the next on the options it
+// reveals. Collapsing them back into one leaves the menu undescribed.
+describe.each([
+  ['content-generation', 'gen:remix'],
+  ['model-page', 'model:remix'],
+  ['welcome', 'model:remix'],
+] as const)('the %s remix steps', (tour, button) => {
+  const targets = () => tourSteps[tour].map((step) => String(step.target));
 
-    expect(button).toBeGreaterThan(-1);
-    expect(targets[button + 1]).toBe('[data-tour="gen:remix-menu"]');
+  it('follows the button step with one on the menu it opens', () => {
+    const index = targets().indexOf(`[data-tour="${button}"]`);
+
+    expect(index).toBeGreaterThan(-1);
+    expect(targets()[index + 1]).toBe(`[data-tour="${button}-menu"]`);
   });
 
+  it('leaves the menu step a way forward for an image every engine refuses', () => {
+    const menuStep = tourSteps[tour].find((step) => step.target === `[data-tour="${button}-menu"]`);
+
+    expect(menuStep?.hideFooter).not.toBe(true);
+  });
+});
+
+describe('the content-generation remix steps', () => {
   /**
    * `GenerationForm` used to cut the signed-out tour with `slice(0, 6)`, so
    * inserting a step silently pushed `gen:submit` off the end. The cuts name
@@ -80,14 +94,6 @@ describe('the content-generation remix steps', () => {
 
     expect(source).not.toMatch(/genSteps\.slice\(\s*0\s*,\s*-?\d/);
     expect(source).toContain("through(genSteps, 'gen:submit')");
-  });
-
-  it('leaves the menu step a way forward for an image every engine refuses', () => {
-    const menuStep = tourSteps['content-generation'].find(
-      (step) => step.target === '[data-tour="gen:remix-menu"]'
-    );
-
-    expect(menuStep?.hideFooter).not.toBe(true);
   });
 });
 
@@ -106,5 +112,23 @@ describe('TourPopover', () => {
 
     expect(destructured.length).toBeGreaterThan(0);
     expect(unwired).toEqual([]);
+  });
+});
+
+describe('tourScrollBlock', () => {
+  /**
+   * `model:gallery` targets the wrapper around the whole gallery so the step
+   * has something to aim at before the feed mounts. That wrapper is as tall as
+   * the feed, and centering it puts the user `(height - viewport) / 2` below
+   * its top — hundreds of images past the heading the step is describing.
+   */
+  it('scrolls to the top of a target taller than the viewport', () => {
+    expect(tourScrollBlock(5000, 806)).toBe('start');
+    expect((5000 - 806) / 2).toBeGreaterThan(2000); // what centering would cost
+  });
+
+  it('still centres a target that fits', () => {
+    expect(tourScrollBlock(40, 806)).toBe('center');
+    expect(tourScrollBlock(806, 806)).toBe('center');
   });
 });

--- a/src/components/Tours/__tests__/tour-steps.test.ts
+++ b/src/components/Tours/__tests__/tour-steps.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { tourSteps } from '~/components/Tours/tours';
+
+const SRC = path.resolve(__dirname, '../../..');
+const TOUR_DEFINITIONS = path.join(SRC, 'components', 'Tours', 'tours');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // The definitions name every key by construction, and a key mentioned
+      // only in a test is still a step pointing at nothing.
+      if (entry.name === '__tests__' || full === TOUR_DEFINITIONS) return [];
+      return sourceFiles(full);
+    }
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+const tourTargetKeys = Object.entries(tourSteps).flatMap(([tour, steps]) =>
+  steps.map((step) => {
+    const match = /^\[data-tour="([^"]+)"\]$/.exec(String(step.target));
+    return { tour, target: String(step.target), key: match?.[1] };
+  })
+);
+
+describe('tour steps point at something', () => {
+  it('targets a data-tour attribute, so the key below is checkable', () => {
+    expect(tourTargetKeys.filter((t) => !t.key).map((t) => `${t.tour}: ${t.target}`)).toEqual([]);
+  });
+
+  /**
+   * A step whose target is absent is not an error anyone sees: Joyride treats
+   * `TARGET_NOT_FOUND` as "next", so the step silently vanishes and the numbering
+   * jumps. `model:download` sat dead this way from #1964 until 2026-08-27,
+   * because the attribute went with the download UI rewrite and nothing failed.
+   */
+  it('names a data-tour key that some component still renders', () => {
+    const rendered = sourceFiles(SRC).map((file) => readFileSync(file, 'utf-8'));
+    // `data-tour={`gen:${key}`}` in GenerationTabs builds its keys from the
+    // panel's tab names, so no file holds the whole string. Anything under such
+    // a prefix is out of this guard's reach — today that is the `gen:` half of
+    // the generation panel, and `model:`/`post:`/`auction:` stay fully covered.
+    const computedPrefixes = rendered.flatMap((source) =>
+      [...source.matchAll(/data-tour=\{`([^`$]+)\$\{/g)].map((m) => m[1])
+    );
+    const orphans = [...new Set(tourTargetKeys.map((t) => t.key))].filter(
+      (key) =>
+        !rendered.some((source) => source.includes(`'${key}'`) || source.includes(`"${key}"`)) &&
+        !computedPrefixes.some((prefix) => key?.startsWith(prefix))
+    );
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe('the content-generation remix steps', () => {
+  // Clicking the remix button opens a menu rather than the generator, so the
+  // tour spends a step on the button and the next on the options it reveals.
+  // Collapsing them back into one leaves the menu undescribed.
+  it('follows the button step with one on the menu it opens', () => {
+    const targets = tourSteps['content-generation'].map((step) => String(step.target));
+    const button = targets.indexOf('[data-tour="gen:remix"]');
+
+    expect(button).toBeGreaterThan(-1);
+    expect(targets[button + 1]).toBe('[data-tour="gen:remix-menu"]');
+  });
+
+  /**
+   * `GenerationForm` used to cut the signed-out tour with `slice(0, 6)`, so
+   * inserting a step silently pushed `gen:submit` off the end. The cuts name
+   * their last step now; this fails if one goes back to an index.
+   */
+  it('is cut by target rather than by index', () => {
+    const source = readFileSync(
+      path.join(SRC, 'components', 'generation_v2', 'GenerationForm.tsx'),
+      'utf-8'
+    );
+
+    expect(source).not.toMatch(/genSteps\.slice\(\s*0\s*,\s*-?\d/);
+    expect(source).toContain("through(genSteps, 'gen:submit')");
+  });
+
+  it('leaves the menu step a way forward for an image every engine refuses', () => {
+    const menuStep = tourSteps['content-generation'].find(
+      (step) => step.target === '[data-tour="gen:remix-menu"]'
+    );
+
+    expect(menuStep?.hideFooter).not.toBe(true);
+  });
+});
+
+describe('TourPopover', () => {
+  /**
+   * The close button rendered for a year without `closeProps`, so the X was
+   * decorative in every tour while Esc still worked. Destructuring a render
+   * prop and not spreading it produces no type error and no test failure.
+   */
+  it('wires every render prop it destructures', () => {
+    const source = readFileSync(path.join(SRC, 'components', 'Tour', 'TourPopover.tsx'), 'utf-8');
+    const destructured = [...source.matchAll(/^\s{4}(\w+Props),$/gm)].map((m) => m[1]);
+    const unwired = destructured.filter(
+      (name) => !source.includes(`{...${name}}`) && !source.includes(`${name}.onClick`)
+    );
+
+    expect(destructured.length).toBeGreaterThan(0);
+    expect(unwired).toEqual([]);
+  });
+});

--- a/src/components/Tours/tour-scroll.ts
+++ b/src/components/Tours/tour-scroll.ts
@@ -1,0 +1,15 @@
+/**
+ * Where a tour should scroll its target.
+ *
+ * Centering suits a button or a heading, but a target that wraps a whole
+ * section is taller than the viewport, and centering it leaves the user
+ * halfway down the section rather than at the thing the step describes —
+ * `(height - viewport) / 2` past its top, which for a full model gallery is
+ * hundreds of images.
+ */
+export function tourScrollBlock(
+  targetHeight: number,
+  viewportHeight: number
+): ScrollLogicalPosition {
+  return targetHeight > viewportHeight ? 'start' : 'center';
+}

--- a/src/components/Tours/tours/content-gen.tour.tsx
+++ b/src/components/Tours/tours/content-gen.tour.tsx
@@ -74,7 +74,10 @@ export const contentGenerationTour: StepWithData[] = [
   {
     target: '[data-tour="gen:remix"]',
     title: 'Remix This Image',
-    content: 'Click this button to remix an image and create something new',
+    content:
+      'Click this button to see what you can make from an image — edit it with a prompt, animate it, or reuse its prompt and resources. Pick any one to carry on.',
+    // Below the button is where the remix menu opens; a tooltip there covers it.
+    placement: 'top',
     hideFooter: true,
     disableBeacon: true,
     spotlightClicks: true,

--- a/src/components/Tours/tours/content-gen.tour.tsx
+++ b/src/components/Tours/tours/content-gen.tour.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@mantine/core';
 import Router from 'next/router';
+import { remixMenuStep } from '~/components/Tours/tours/remix-menu.step';
 import { useGenerationPanelStore } from '~/store/generation-panel.store';
 import type { StepWithData } from '~/types/tour';
 import { waitForElement } from '~/utils/html-helpers';
@@ -90,47 +91,13 @@ export const contentGenerationTour: StepWithData[] = [
       },
     },
   },
-  {
-    target: '[data-tour="gen:remix-menu"]',
-    title: 'Pick How to Remix',
-    content: (
-      <Text>
-        <Text fw={600} span>
-          Edit image
-        </Text>{' '}
-        changes it with a prompt,{' '}
-        <Text fw={600} span>
-          Animate
-        </Text>{' '}
-        turns it into a video, and{' '}
-        <Text fw={600} span>
-          Reuse prompt &amp; resources
-        </Text>{' '}
-        starts from its settings. Any one of them opens the generator.
-      </Text>
-    ),
-    // The menu hangs below the button, so keep the tooltip off to the side.
-    placement: 'right',
-    disableBeacon: true,
-    spotlightClicks: true,
-    disableOverlayClose: true,
-    spotlightPadding: 6,
-    // The footer stays: an image every engine refuses opens a menu with nothing
-    // clickable in it, and this step would otherwise have no way forward.
-    data: {
-      onNext: async () => {
-        await waitForElement({ selector: '[data-tour="gen:submit"]', interval: 1000 }).catch(
-          () => null
-        );
-      },
+  remixMenuStep('gen:remix-menu', {
+    onNext: async () => {
+      await waitForElement({ selector: '[data-tour="gen:submit"]', interval: 1000 }).catch(
+        () => null
+      );
     },
-    styles: {
-      spotlight: {
-        animation: 'shadowGlow 2s infinite',
-        willChange: 'box-shadow',
-      },
-    },
-  },
+  }),
   {
     target: '[data-tour="gen:submit"]',
     title: 'Create Your Image',

--- a/src/components/Tours/tours/content-gen.tour.tsx
+++ b/src/components/Tours/tours/content-gen.tour.tsx
@@ -74,8 +74,7 @@ export const contentGenerationTour: StepWithData[] = [
   {
     target: '[data-tour="gen:remix"]',
     title: 'Remix This Image',
-    content:
-      'Click this button to see what you can make from an image — edit it with a prompt, animate it, or reuse its prompt and resources. Pick any one to carry on.',
+    content: 'Click this button to see what you can make from this image.',
     // Below the button is where the remix menu opens; a tooltip there covers it.
     placement: 'top',
     hideFooter: true,
@@ -84,6 +83,40 @@ export const contentGenerationTour: StepWithData[] = [
     disableCloseOnEsc: true,
     disableOverlayClose: true,
     spotlightPadding: 10,
+    styles: {
+      spotlight: {
+        animation: 'shadowGlow 2s infinite',
+        willChange: 'box-shadow',
+      },
+    },
+  },
+  {
+    target: '[data-tour="gen:remix-menu"]',
+    title: 'Pick How to Remix',
+    content: (
+      <Text>
+        <Text fw={600} span>
+          Edit image
+        </Text>{' '}
+        changes it with a prompt,{' '}
+        <Text fw={600} span>
+          Animate
+        </Text>{' '}
+        turns it into a video, and{' '}
+        <Text fw={600} span>
+          Reuse prompt &amp; resources
+        </Text>{' '}
+        starts from its settings. Any one of them opens the generator.
+      </Text>
+    ),
+    // The menu hangs below the button, so keep the tooltip off to the side.
+    placement: 'right',
+    disableBeacon: true,
+    spotlightClicks: true,
+    disableOverlayClose: true,
+    spotlightPadding: 6,
+    // The footer stays: an image every engine refuses opens a menu with nothing
+    // clickable in it, and this step would otherwise have no way forward.
     data: {
       onNext: async () => {
         await waitForElement({ selector: '[data-tour="gen:submit"]', interval: 1000 }).catch(

--- a/src/components/Tours/tours/model-page.tour.tsx
+++ b/src/components/Tours/tours/model-page.tour.tsx
@@ -1,3 +1,4 @@
+import { remixMenuStep } from '~/components/Tours/tours/remix-menu.step';
 import type { StepWithData } from '~/types/tour';
 import { waitForElement } from '~/utils/html-helpers';
 
@@ -79,6 +80,7 @@ export const modelPageTour: StepWithData[] = [
       },
     },
   },
+  remixMenuStep('model:remix-menu'),
 ];
 
 export const welcomeTour: StepWithData[] = [
@@ -116,4 +118,5 @@ export const welcomeTour: StepWithData[] = [
       },
     },
   },
+  remixMenuStep('model:remix-menu'),
 ];

--- a/src/components/Tours/tours/model-page.tour.tsx
+++ b/src/components/Tours/tours/model-page.tour.tsx
@@ -62,7 +62,10 @@ export const modelPageTour: StepWithData[] = [
   {
     target: '[data-tour="model:remix"]',
     title: 'Remix This Image',
-    content: 'Click this button to remix an image and create something new',
+    content:
+      'Click this button to see what you can make from an image — edit it with a prompt, animate it, or reuse its prompt and resources.',
+    // Below the button is where the remix menu opens; a tooltip there covers it.
+    placement: 'top',
     disableBeacon: true,
     spotlightClicks: true,
     disableOverlayClose: true,
@@ -94,7 +97,10 @@ export const welcomeTour: StepWithData[] = [
   {
     target: '[data-tour="model:remix"]',
     title: 'Create with this Resource',
-    content: 'Click here to generate content using this resource!',
+    content:
+      'Click here to make something from this image — edit it with a prompt, animate it, or reuse its prompt and resources. Pick any one to carry on.',
+    // Below the button is where the remix menu opens; a tooltip there covers it.
+    placement: 'top',
     disableBeacon: true,
     showProgress: false,
     hideFooter: true,

--- a/src/components/Tours/tours/model-page.tour.tsx
+++ b/src/components/Tours/tours/model-page.tour.tsx
@@ -55,6 +55,9 @@ export const modelPageTour: StepWithData[] = [
     content: `View images created with this resource. You can add your review and post your own images that you've created using this resource.`,
     data: {
       onNext: async () => {
+        // Reading this step scrolls the carousel out of view, and its slides
+        // only mount while they are in it.
+        document.querySelector('[data-tour="model:start"]')?.scrollIntoView({ block: 'start' });
         await waitForElement({ selector: '[data-tour="model:remix"]' }).catch(() => null);
       },
     },

--- a/src/components/Tours/tours/remix-menu.step.tsx
+++ b/src/components/Tours/tours/remix-menu.step.tsx
@@ -1,0 +1,46 @@
+import { Text } from '@mantine/core';
+import type { StepData, StepWithData } from '~/types/tour';
+
+/**
+ * The step describing the menu a remix button opens.
+ *
+ * Shared by the three tours that spotlight such a button, so they describe the
+ * same options the same way rather than drifting apart.
+ */
+export function remixMenuStep(target: string, data?: StepData): StepWithData {
+  return {
+    target: `[data-tour="${target}"]`,
+    title: 'Pick How to Remix',
+    content: (
+      <Text>
+        <Text fw={600} span>
+          Edit image
+        </Text>{' '}
+        changes it with a prompt,{' '}
+        <Text fw={600} span>
+          Animate
+        </Text>{' '}
+        turns it into a video, and{' '}
+        <Text fw={600} span>
+          Reuse prompt &amp; resources
+        </Text>{' '}
+        starts from its settings. Any one of them opens the generator.
+      </Text>
+    ),
+    // The menu hangs below the button, so keep the tooltip off to the side.
+    placement: 'right',
+    disableBeacon: true,
+    spotlightClicks: true,
+    disableOverlayClose: true,
+    spotlightPadding: 6,
+    // No `hideFooter`: an image every engine refuses opens a menu with nothing
+    // clickable in it, and this step would otherwise have no way forward.
+    ...(data ? { data } : {}),
+    styles: {
+      spotlight: {
+        animation: 'shadowGlow 2s infinite',
+        willChange: 'box-shadow',
+      },
+    },
+  };
+}

--- a/src/components/generation_v2/GenerationForm.tsx
+++ b/src/components/generation_v2/GenerationForm.tsx
@@ -273,12 +273,20 @@ export function GenerationForm() {
 
   // Configure tour steps based on user state
   useEffect(() => {
+    const through = (steps: typeof contentGenerationTour, target: string) => {
+      const end = steps.findIndex((step) => step.target === `[data-tour="${target}"]`);
+      return end === -1 ? steps : steps.slice(0, end + 1);
+    };
+
     if (!running || currentStep > 0 || loadingGeneratorData) return;
     const isRemix = remixOfId && activeTour === 'remix-content-generation';
     let genSteps = isRemix ? remixContentGenerationTour : contentGenerationTour;
 
-    if (!loadingGenQueueRequests && !hasGeneratedImages) genSteps = genSteps.slice(0, -2);
-    if (!currentUser) genSteps = isRemix ? genSteps.slice(0, 4) : genSteps.slice(0, 6);
+    // Both cuts name the step they end on. As positional indexes they silently
+    // re-aimed at whatever moved into the slot — inserting the remix-menu step
+    // pushed `gen:submit` out of the signed-out tour, and nothing failed.
+    if (!loadingGenQueueRequests && !hasGeneratedImages) genSteps = through(genSteps, 'gen:feed');
+    if (!currentUser) genSteps = through(genSteps, 'gen:submit');
 
     const alreadyReviewedTerms =
       window?.localStorage?.getItem('review-generation-terms') === 'true';

--- a/src/shared/constants/__tests__/tour-click-through-z-index.test.ts
+++ b/src/shared/constants/__tests__/tour-click-through-z-index.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'fs';
+import { createRequire } from 'module';
+import { describe, expect, it } from 'vitest';
+import {
+  remixMenuZIndex,
+  tourClickThroughZIndex,
+  tourOverlayZIndex,
+  tourTooltipZIndexOffset,
+} from '~/shared/constants/app-layout.constants';
+
+/**
+ * `react-joyride` draws its step tooltip above its overlay by a hardcoded
+ * amount that no public API reports, so `tourTooltipZIndexOffset` mirrors a
+ * number from inside the package. These read the installed build so a version
+ * bump that moves the tooltip layer fails here rather than in a tour.
+ */
+function joyrideFloaterOffsets() {
+  const entry = createRequire(import.meta.url).resolve('react-joyride');
+  const source = readFileSync(entry, 'utf-8');
+  return [...source.matchAll(/zIndex:\s*options\.zIndex\s*\+\s*(\d+)/g)].map((m) => Number(m[1]));
+}
+
+describe('tour click-through z-index', () => {
+  it('mirrors the offset react-joyride actually applies to its tooltip', () => {
+    expect(joyrideFloaterOffsets()).toEqual([tourTooltipZIndexOffset]);
+  });
+
+  it('clears the tooltip, not just the overlay', () => {
+    // The bug this pins: at `tourOverlayZIndex + 1` the remix menu cleared the
+    // click-swallowing overlay but opened *under* the tooltip, so a step with
+    // `hideFooter` had no reachable way forward.
+    expect(tourClickThroughZIndex).toBeGreaterThan(tourOverlayZIndex + tourTooltipZIndexOffset);
+  });
+
+  it('leaves the menu below the tour layers when no tour is running', () => {
+    expect(remixMenuZIndex).toBeLessThan(tourOverlayZIndex);
+  });
+});

--- a/src/shared/constants/app-layout.constants.ts
+++ b/src/shared/constants/app-layout.constants.ts
@@ -40,6 +40,23 @@ export const imageGenerationDrawerZIndex = 301;
 export const tourOverlayZIndex = 100000;
 
 /**
+ * How far above its overlay `react-joyride` draws the step tooltip — its
+ * `getStyles` hardcodes `options.zIndex + 100` and reports it nowhere, so
+ * `tour-click-through-z-index.test.ts` pins this against the installed package.
+ */
+export const tourTooltipZIndexOffset = 100;
+
+/**
+ * For anything a tour step expects the user to click that is not the target
+ * itself — the menu a spotlit button opens.
+ *
+ * Clearing `tourOverlayZIndex` is not enough. The overlay swallows clicks, but
+ * the tooltip is drawn above it, so a menu at overlay+1 opens *under* the
+ * tooltip; a step with `hideFooter` then has no reachable way forward.
+ */
+export const tourClickThroughZIndex = tourOverlayZIndex + tourTooltipZIndexOffset + 1;
+
+/**
  * The remix menu opens from cards that sit inside routed dialogs, which stack at
  * `300 + index` (DialogProvider), so Mantine's popover default of 300 only wins
  * on mount order. This clears a few levels of dialog stacking outright.


### PR DESCRIPTION
Closes the generator-tutorial UX issue in [CU-868kxguh0](https://app.clickup.com/t/8459928/868kxguh0).

The remix button on an image card used to open the generation panel. Since #3859 it opens a three-option menu, and the tours that point at it were never updated. Fixing that turned up four more defects in the same tours, three of which had been silently live for months.

## 1. The tour never described the menu

The step said *"click this button to remix an image"*, and the menu opened **underneath** the tour tooltip — so its options were unreadable and unclickable. That step is `hideFooter: true`, so clicking an option is its only exit: the tour stopped there.

Both call sites already raised the menu during a tour, but only to `tourOverlayZIndex + 1` (100001). That clears the overlay — the layer that swallows clicks — while `react-joyride` draws the tooltip at `options.zIndex + 100`. Confirmed live at **100100**, so the menu sat one level above the overlay and one below the tooltip.

`tourClickThroughZIndex` (100101) clears both, and `placement: 'top'` moves the tooltip off the space the menu drops into.

## 2. The menu now gets a step of its own

The button step and a following **"Pick How to Remix"** step on the open menu, which any of the three options advances.

`RemixMenu` gains `onOpen` and `tourTarget`. The open has to be announced *after* the dropdown commits: Mantine fires `onOpen` from its state setter, so announcing immediately pointed the new step at a target not yet in the document, and Joyride read that as `TARGET_NOT_FOUND` and skipped the step. Caught live — it jumped 5 → 7.

**The menu step keeps its footer.** An image every engine refuses opens a menu with nothing clickable in it; without a footer that step would be a dead end.

## 3. The menu step, on the model page too

`modelPageTour` and `welcomeTour` both end on the same remix button, so both now follow it with the menu step. `ModelCarousel` announces the open as well as the choice; picking any option opens the generator and ends the tour.

The step existed in three near-identical copies by then, so it is one `remixMenuStep(target, data?)` — the content-generation call passes the wait on `gen:submit`, the two model-page calls pass nothing.

## 4. The gallery step scrolled hundreds of images too far

Introduced by the fix below: `model:gallery` targets the wrapper so the step has something to aim at before the feed mounts, but that wrapper is as tall as the feed, and `LazyTours` centres what it scrolls to.

Measured in the browser, through the real code path, on a 5000px gallery in an 806px viewport:

| | scrollTop |
|---|---|
| `block: 'center'` (before) | 4821 |
| `block: 'start'` (after) | 2694 |
| **overshoot** | **2127px** |

`tourScrollBlock` scrolls to the start of any target taller than the viewport and centres everything else — `center` is right for a button or a heading, and only ever wrong for a target that wraps a section. The live step now lands at 2695 with the gallery's top flush at viewport y=0.

*Caveat on the evidence:* no model in the dev database has a gallery tall enough to trigger this, so the 5000px height was forced in the browser. The scroll numbers are real; the height is synthetic.

## 5. Steps that silently vanished

Joyride treats `TARGET_NOT_FOUND` as "next", so a step with a missing target disappears and the numbering jumps — which is how these went unnoticed.

- **`model:download`** — the attribute went with #1964's download rewrite and the step had pointed at nothing since. Probed live: 0 matches in the DOM.
- **`model:gallery`** — the heading it targeted is behind `useInView`. Probed live: **0 at page top, 1 after scrolling**. The target moves to the always-present wrapper. That alone then broke the *next* step, because reaching the gallery scrolls the carousel out of view and its slides unmount, so the gallery step now scrolls back before waiting on `model:remix`.

Model-page tour now runs **1→2→3→4→5→6→7** with no jumps.

## 6. The close button did nothing

`TourPopover` destructured `closeProps` and never wired it, so the X was decorative in **every** tour while Esc still worked. Only the handler is taken — `closeProps` also carries Joyride's own label as `children`, which renders as the word "Close" inside the icon button (hit this on the first attempt).

## 7. The step list was cut by index

`GenerationForm` used `genSteps.slice(0, 6)`. Inserting the menu step pushed `gen:submit` off the end of the signed-out tour, silently. Seen live before fixing: a signed-out run showed 6 steps ending at the new menu step instead of at Submit. Both cuts now name the step they end on.

## Tests

`tour-steps.test.ts` and `tour-click-through-z-index.test.ts`. Each guard fails on its own revert with the defect named:

| Revert | Failure |
|---|---|
| drop the `model:download` attribute | `expected [ 'model:download' ] to deeply equal []` |
| unwire `closeProps` | `expected [ 'closeProps' ] to deeply equal []` |
| go back to `slice(0, 6)` | `not to match /genSteps\.slice\(\s*0\s*,\s*-?\d/` |
| back to `tourOverlayZIndex + 1` | `expected 100001 to be greater than 100100` |

The remix-button/menu adjacency and the menu step's footer are checked across all three tours via `describe.each`, so adding a fourth tour that spotlights a remix button is a one-line addition rather than a silent gap.

The joyride offset is read from the **installed package**, so a version bump that moves the tooltip layer fails here rather than in a tour.

**One known blind spot, stated rather than papered over:** `GenerationTabs` builds `data-tour={\`gen:${key}\`}`, so no file holds those literal strings. The orphan guard skips anything under such a prefix — today that is part of the `gen:` namespace; `model:`, `post:` and `auction:` stay fully covered. (This is why the guard first reported `gen:queue`/`gen:feed` as dead when they are not.)

## Verification

Driven live against a dev server.

Content-gen tour, at the menu step: menu z **100101** vs tooltip **100100**; spotlight `(503,319,274,194)` wraps the menu `(508,325,262,182)`; tooltip at x 807–1182 beside the menu at x 508–771, no overlap. Clicking **Animate** advances 6/12 → 7/12 with `gen:submit` present.

Model-page tour: all seven steps consecutive; the X closes the tour (tooltip 1→0) and still renders as an icon, no stray text.

### Mobile (390x844)

The narrow viewport is the one that could have broken the new step: the menu is `w-[290px]`, so a 375px tooltip cannot fit beside it. `react-floater` flips `right` to above, and the two stay clear of each other.

| | content-gen | model-page |
|---|---|---|
| menu / tooltip z | 100101 / 100100 | 100101 / 100100 |
| tooltip rect | y 215-461 | y 210-431 |
| menu rect | y 481-663 | y 505-687 |
| overlap / off-screen | false / false | false / false |

Both tours run their steps consecutively at this width (content-gen 4→5→7 of 9→12, model-page 1-8), the generation panel closes for the remix step and reopens when an option is picked (the `window.innerWidth < 768` branch), and the X closes the tour.

**Pre-existing, not fixed here:** on mobile the step *total* jumps mid-tour (9 → 12) when the panel reopens, because `GenerationForm` unmounts with the panel and recomputes `setSteps` on remount with different inputs. Nothing in this PR changes when `setSteps` runs — only what the cuts compute — so this predates it; the same flow would have shown 8 → 11 before. The step landed on is correct throughout.

`pnpm run typecheck` 0 errors · lint 0 errors · prettier clean · unit suite **1506 files / 23576 tests, 0 failures**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG19Hb83wcAu3qEwQF2uDT
