### PR TITLE
fix(models): make Hash and AIR follow the selected download variant

### DIFF
--- a/src/components/Model/ModelURN/ModelURN.tsx
+++ b/src/components/Model/ModelURN/ModelURN.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Code, Group, Popover, Stack, Text, Tooltip } from '@mantine/core';
+import { Code, Group, Popover, Stack, Text, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCheck, IconCopy, IconInfoSquareRounded } from '@tabler/icons-react';
 import { useMemo } from 'react';
@@ -13,13 +13,14 @@ export const ModelURN = ({
   type,
   modelId,
   modelVersionId,
+  fileId,
   fileType,
   withCopy = true,
 }: Props) => {
   const { copied, copy } = useClipboard();
   const urn = useMemo(
-    () => stringifyAIR({ baseModel, type, modelId, id: modelVersionId, fileType }),
-    [baseModel, type, modelId, modelVersionId, fileType]
+    () => stringifyAIR({ baseModel, type, modelId, id: modelVersionId, fileId, fileType }),
+    [baseModel, type, modelId, modelVersionId, fileId, fileType]
   );
   if (!urn) return null;
 
@@ -54,6 +55,24 @@ export const ModelURN = ({
               {modelVersionId}
             </Code>
           </Tooltip>
+        )}
+        {fileId !== undefined && (
+          <>
+            <Code className={classes.code}>+</Code>
+            {withCopy ? (
+              <CopyTooltip copied={copied} label="File ID">
+                <Code className={classes.code} color="blue" onClick={() => copy(fileId)}>
+                  {fileId}
+                </Code>
+              </CopyTooltip>
+            ) : (
+              <Tooltip label="File ID">
+                <Code className={classes.code} color="blue">
+                  {fileId}
+                </Code>
+              </Tooltip>
+            )}
+          </>
         )}
       </Group>
       {withCopy && (
@@ -139,6 +158,9 @@ type Props = {
   type: ModelType;
   modelId: number;
   modelVersionId: number;
+  /** Selected `ModelFile.id`; emitted as the AIR's `+<fileId>` segment so the
+   * identifier resolves to the variant the user picked. */
+  fileId?: number;
   /** Primary `ModelFile.type`; lets diffusion-model checkpoints render the
    * correct AIR type segment (`diffusionmodel`) instead of `checkpoint`. */
   fileType?: string;

--- a/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
+++ b/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
@@ -16,7 +16,11 @@ import { useMemo, useState } from 'react';
 import { DownloadButton } from '~/components/Model/ModelVersions/DownloadButton';
 import { VerifiedText } from '~/components/VerifiedText/VerifiedText';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
-import { getPrimaryFile, groupFilesByVariant } from '~/server/utils/model-helpers';
+import {
+  getPrimaryFile,
+  groupFilesByVariant,
+  resolveActiveFile,
+} from '~/server/utils/model-helpers';
 import type { ModelType } from '~/shared/utils/prisma/enums';
 import type { ModelById } from '~/types/router';
 import { getFileDescription, getFileLabel } from '~/utils/file-display-helpers';
@@ -91,8 +95,7 @@ export function DownloadVariantDropdown({
     if (isControlled) onSelectFileId!(fileId);
     else setInternalFileId(fileId);
   };
-  const activeFile =
-    modelFiles.find((f) => f.id === selectedFileId) ?? bestMatchFile ?? modelFiles[0];
+  const activeFile = resolveActiveFile(modelFiles, selectedFileId, { metadata: userPreferences });
 
   // Calculate download URL
   const downloadUrl = activeFile

--- a/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
+++ b/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
@@ -250,8 +250,8 @@ export function DownloadVariantDropdown({
               className="hover:bg-gray-1 dark:hover:bg-dark-6/30"
             >
               <Group justify="space-between" wrap="nowrap">
-                <Group gap={8}>
-                  <Box w={16}>
+                <Group gap={8} wrap="nowrap">
+                  <Box w={16} miw={16} style={{ flexShrink: 0 }}>
                     {isSelected && <IconCheck size={16} color={theme.colors.green[5]} />}
                   </Box>
                   <Box>

--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -15,7 +15,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { getPrimaryFile } from '~/server/utils/model-helpers';
+import { resolveActiveFile } from '~/server/utils/model-helpers';
 import type { ModelById } from '~/types/router';
 import { formatBytes, numberWithCommas } from '~/utils/number-helpers';
 import {
@@ -52,15 +52,12 @@ export function ModelTensorMetadata({ files, userPreferences, enabled, selectedF
     () => files.filter((file) => inferTensorMetadataFormat(file)),
     [files]
   );
-  const defaultFile = useMemo(
-    () => getPrimaryFile(supportedFiles, { metadata: userPreferences }) ?? supportedFiles[0],
-    [supportedFiles, userPreferences]
+  // Only tensor-parseable files are offered here, so the shared download
+  // selection is ignored when it points at anything else.
+  const selectedFile = useMemo(
+    () => resolveActiveFile(supportedFiles, selectedFileId, { metadata: userPreferences }),
+    [supportedFiles, selectedFileId, userPreferences]
   );
-
-  // Follow the shared download selection when it points at a tensor-parseable
-  // file; otherwise fall back to this version's primary/default file.
-  const selectedFile =
-    supportedFiles.find((file) => file.id === selectedFileId) ?? defaultFile ?? null;
 
   // Summary is always fetched (cheap, server-cached) so the closed header can
   // show the VRAM range at a glance. The full tensor list is only fetched once

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -138,7 +138,11 @@ import { getBaseModelGroup } from '~/shared/constants/basemodel.constants';
 import { getEcosystemSeoPageForKey } from '~/shared/constants/ecosystem-seo.constants';
 import { ReportEntity } from '~/shared/utils/report-helpers';
 import type { ImagesInfiniteModel } from '~/server/services/image.service';
-import { getPrimaryFile, groupFilesByVariant } from '~/server/utils/model-helpers';
+import {
+  getPrimaryFile,
+  groupFilesByVariant,
+  resolveActiveFile,
+} from '~/server/utils/model-helpers';
 import {
   Availability,
   CollectionType,
@@ -233,7 +237,6 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   const primaryFile = getPrimaryFile(version.files, {
     metadata: user?.filePreferences,
   });
-  const hashes = primaryFile?.hashes ?? [];
 
   const filesCount = version.files?.length;
   // ExternalGeneration versions are intentionally file-less (routed via external engines),
@@ -264,8 +267,19 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   const tensorMetadataEnabled = detailAccordions.includes('tensor-metadata');
 
   // Shared active-file selection: the download variant picker drives it, and the
-  // Tensors panel follows it (instead of having its own file selector).
+  // Tensors panel and the details rows below follow it (instead of each having
+  // its own file selector).
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
+  // modelFilesVisible is empty for component-only and ExternalGeneration
+  // versions, which still need a file for the Hash/AIR rows below.
+  const activeFile = useMemo(
+    () =>
+      resolveActiveFile(modelFilesVisible, selectedFileId, {
+        metadata: user?.filePreferences,
+      }) ?? primaryFile,
+    [modelFilesVisible, selectedFileId, user?.filePreferences, primaryFile]
+  );
+  const hashes = activeFile?.hashes ?? [];
 
   // Check if this is a component-only model (no model files, only components)
   const isComponentOnlyModel =
@@ -1616,7 +1630,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         type={model.type}
                         modelId={model.id}
                         modelVersionId={version.id}
-                        fileType={primaryFile?.type}
+                        fileType={activeFile?.type}
                       />
                     </div>
                   )}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -1630,6 +1630,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         type={model.type}
                         modelId={model.id}
                         modelVersionId={version.id}
+                        fileId={activeFile?.id}
                         fileType={activeFile?.type}
                       />
                     </div>

--- a/src/server/utils/__tests__/model-helpers.test.ts
+++ b/src/server/utils/__tests__/model-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { selectLiveLinkedComponents } from '~/server/utils/model-helpers';
+import { resolveActiveFile, selectLiveLinkedComponents } from '~/server/utils/model-helpers';
 
 describe('selectLiveLinkedComponents', () => {
   const comps = [
@@ -15,5 +15,31 @@ describe('selectLiveLinkedComponents', () => {
 
   it('drops everything when the live set is empty', () => {
     expect(selectLiveLinkedComponents(comps, new Set())).toEqual([]);
+  });
+});
+
+describe('resolveActiveFile', () => {
+  const pruned = { id: 10, type: 'Model', metadata: { format: 'SafeTensor', size: 'pruned' } };
+  const full = { id: 20, type: 'Model', metadata: { format: 'SafeTensor', size: 'full' } };
+  const files = [pruned, full] as Parameters<typeof resolveActiveFile>[0];
+
+  it('returns the explicitly selected file even when preferences point elsewhere', () => {
+    // `pruned` is what the preferences would pick, so a helper that ignored the
+    // selection would still return a file — and silently the wrong one.
+    expect(resolveActiveFile(files, full.id, { metadata: { size: 'pruned' } })).toBe(full);
+    expect(resolveActiveFile(files, pruned.id, { metadata: { size: 'full' } })).toBe(pruned);
+  });
+
+  it('falls back to the preference-matched file when nothing is selected', () => {
+    expect(resolveActiveFile(files, null, { metadata: { size: 'full' } })).toBe(full);
+    expect(resolveActiveFile(files, undefined, { metadata: { size: 'pruned' } })).toBe(pruned);
+  });
+
+  it('ignores an id that belongs to another version instead of blanking out', () => {
+    expect(resolveActiveFile(files, 999, { metadata: { size: 'full' } })).toBe(full);
+  });
+
+  it('returns null when there are no files to choose from', () => {
+    expect(resolveActiveFile([], 10)).toBeNull();
   });
 });

--- a/src/server/utils/model-helpers.ts
+++ b/src/server/utils/model-helpers.ts
@@ -54,6 +54,27 @@ export function getPrimaryFile<T extends FileFormatType>(
     .sort((a, b) => b.score - a.score)[0]?.file;
 }
 
+/**
+ * The file a version's UI should describe. Every panel that shows per-file
+ * information (download picker, tensor metadata, the Hash/AIR detail rows)
+ * resolves it through here so they cannot disagree about which file is active.
+ *
+ * A `selectedFileId` left over from another version is ignored rather than
+ * blanking the panel.
+ */
+export function resolveActiveFile<T extends FileFormatType & { id: number }>(
+  files: Array<T>,
+  selectedFileId?: number | null,
+  preferences: Partial<FileFormatType> = defaultFilePreferences
+) {
+  return (
+    files.find((file) => file.id === selectedFileId) ??
+    getPrimaryFile(files, preferences) ??
+    files[0] ??
+    null
+  );
+}
+
 export const getFileDisplayName = ({
   file,
   modelType,


### PR DESCRIPTION
Closes [CU-868kpyh90](https://app.clickup.com/t/868kpyh90).

## Problem

Selecting a different file in the download variant dropdown left the **Details** table describing a different file. `Hash` and `AIR` were derived from `getPrimaryFile(version.files)` at the top of the component and never moved, so after picking (say) the fp8 variant you were still shown the fp16 file's hash and the primary file's AIR type segment.

## What changed

The "which file is active" rule turned out to be written three times — the download dropdown, the Tensors panel, and (implicitly) the Details rows — and the copies had already drifted:

| | resolved over |
|---|---|
| `DownloadVariantDropdown` | visible model files |
| `ModelTensorMetadata` | tensor-parseable files |
| Details `Hash` / `AIR` | **every file on the version** |

So even with nothing selected the rows could describe a file the dropdown wasn't offering — e.g. a non-public file on a version where the viewer isn't the owner or a moderator.

- Hoisted the rule into `resolveActiveFile` in `src/server/utils/model-helpers.ts`, beside `getPrimaryFile`, and routed all three call sites through it. Semantics per call site are unchanged (`explicit pick ?? preference-matched default ?? first`); the Details rows are the one that now behaves differently, which is the point of the ticket.
- Details rows keep falling back to the version's primary file when there are no model files to pick from — component-only and `ExternalGeneration` versions.

## Stats

The ticket mentions stats as an optional extra. Left out: the `Stats` row is version-level (`downloadCount`, generations, earned Buzz) and there is no per-file breakdown in this payload, so there is nothing file-specific to reflect there. Happy to pick it up separately if per-file download counts get exposed.

## Testing

- `resolveActiveFile` unit tests in `src/server/utils/__tests__/model-helpers.test.ts` (4 new cases). Revert-checked: dropping the selection branch fails `returns the explicitly selected file even when preferences point elsewhere` in under a second with a readable assertion, rather than passing or hanging.
- `pnpm run typecheck` — 0 errors.
- `pnpm run test:lint-rules` — 24 files / 359 passed.
- Full unit suite — 1509 files / 23673 passed, 27 skipped.

### Browser A/B against the dev database

Verified in a real browser on model **2857809** / version **3227890** (5 public SafeTensor variants, 5 distinct AutoV2 hashes), logged in — the `AIR` row is `availability: ['user']`. Two dev servers, same page, same clicks: `main` on :3000, this branch on :3002.

With the **int8 / 19.53 GB** variant selected (`ModelFile` 3110634, hash `F3594F5FFC`):

| | Hash row | Correct? |
|---|---|---|
| `main` | `DDB5E0590E` | ✗ frozen — that is a *different* file (3110296) |
| this branch | `F3594F5FFC` | ✓ the selected file |

Switching variants on this branch walks the Hash row correctly and it stays in step with the `Download Selected` href:

- default → picker `bf16 SafeTensor`, hash `29A7E03CB5`, `fileId=3110300`
- select int8 → hash `DDB5E0590E`, `fileId=3110296`
- select the other int8 → hash `F3594F5FFC`, `fileId=3110634`

On `main` the Hash row never moved from `DDB5E0590E` across the same clicks, while the download href tracked the selection — so the page was offering one file and displaying another file's hash.

The run also confirmed the default-state drift described above is real, not theoretical: on `main` the row opened showing `DDB5E0590E` while the picker's default was `bf16` (`29A7E03CB5`) — wrong before any click. On this branch the two agree from first paint.

### AIR now carries the file too

Follow-up from review. `stringifyAIR` already accepts `fileId` and emits it as `+<fileId>` — `mini/[id].ts` and the orchestrator both produce AIRs in that shape — but `ModelURN` never passed it, so the row was invariant across variants. It now takes `fileId` and renders the segment. `ModelURN`'s only other call site (`ResourceSelectCard`) passes none, so the segment is opt-in and nothing changes there.

Verified on model 4201 (two SafeTensor variants) — AIR, Hash and the `Download Selected` href move together:

| selected | AIR | Hash | href |
|---|---|---|---|
| fp16 | `civitai:4201@501240 +418904` | `0928B30687` | `fileId=418904` |
| fp16 pruned | `civitai:4201@501240 +418901` | `F47E942AD4` | `fileId=418901` |

### Check-mark gutter

Also from review: the selected row's check could end up above the row's text instead of beside it, and unselected rows lost their indent.

The gutter is a `Box w={16}` inside a `Group` that inherited `flex-wrap: wrap` and `flex-shrink: 1`. Measured in Chromium at 1100px and 900px, the content wrapped to a second line leaving the check alone on the first; and an empty gutter's `min-width: auto` resolves to 0, so it can compress away entirely. `wrap="nowrap"` plus a non-shrinking `miw={16}` fixes both.

Re-measured at 1280/1100/1000/900/820px: gutter 16px on every row, selected and unselected content at the same x, check vertically centered rather than above.

### Not covered

The Details-table wiring has no mounting test: `ModelVersionDetails` is an 85KB component that the existing `ModelVersionDetails.browser.test.tsx` explicitly declines to mount (~20 hooks, ~50 child components), so a fixture test there would pass on a revert and prove nothing. The extracted helper is the part that is genuinely testable; the wiring is covered by the browser A/B above rather than by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XegMPZre3PuyHw6UaB1Bat
