### PR TITLE
test(auth): enforce that credential detection stays a superset of the session layer

### DIFF
--- a/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
+++ b/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
@@ -16,7 +16,7 @@ import { requestCarriesCallerCredentials } from '~/server/utils/endpoint-helpers
  *     credentialed  -> private, no-cache   (never stored by a shared cache)
  *     anonymous     -> public, s-maxage=…  (stored at the edge, replayed to anyone)
  *
- * That predicate is the whole mechanism, because the edge does not help.
+ * That predicate is the whole mechanism, because the edge does not back it up.
  * Measured on production, same URL across arms: an anonymous request populates a
  * URL, and a later request carrying `Authorization` is served that cached entry
  * (`cf-cache-status: HIT`, still `public`). `Vary: Authorization` is INERT at our
@@ -30,27 +30,34 @@ import { requestCarriesCallerCredentials } from '~/server/utils/endpoint-helpers
  * and served to other people. Nothing throws.
  *
  * ── WHAT THIS CERTIFIES, AND WHAT IT DOES NOT ────────────────────────────────
- * 🔴 Read this before trusting a green run. An earlier version claimed a spelling
- * "nobody has thought of yet is handled by construction". An adversarial 14-mutant
- * sweep killed that claim: nine survived — a header read through a `const` alias,
- * one through destructuring, a credential read moved to a NEW FILE, and a NEW
- * COOKIE, on the axis that version called un-driftable. This is the honest
- * contract.
+ * 🔴 Read this before trusting a green run, and do not strengthen it without
+ * re-measuring. Two successive adversarial sweeps found this file claiming more
+ * than it did — first "handled by construction" (nine of fourteen mutants
+ * survived), then a rewrite that introduced three fresh fail-opens of its own: a
+ * destructuring pattern that anchored on the wrong brace and reported a
+ * fabricated header name, a constant-resolution map shared across files so a
+ * name collision made a real read VANISH, and a cookie axis with no fail-closed
+ * path at all. Every claim below is mutation-verified; treat an unverified
+ * addition to this list as false.
  *
- * CAUGHT (each mutation-verified below):
+ * CAUGHT:
  *   - a header or query param read by literal name, dot or bracket notation;
- *   - a header read via a `const NAME = 'literal'` alias in the same source;
+ *   - a header read via a `const NAME = 'literal'` alias in the SAME file;
  *   - a header read by DESTRUCTURING `req.headers`, renamed or not;
- *   - a bracket read whose name cannot be resolved — that FAILS rather than
- *     vanishing, which is the difference between a guard and a filter;
- *   - a credential-reading module added to the entry point's import graph;
- *   - a new cookie helper used on the session path but not by the predicate;
- *   - the predicate narrowing on any of the above.
+ *   - a cookie read by literal name, by a `const` alias, or via a name helper;
+ *   - a bracket read whose name cannot be resolved — on ANY of the three axes,
+ *     that FAILS rather than vanishing;
+ *   - a credential-reading module added to the entry point's import graph,
+ *     whether imported as `./x` or `~/server/x`;
+ *   - the predicate narrowing on ANY SINGLE channel — `req.query` and `req.url`
+ *     are probed independently, so two redundant branches cannot shield each
+ *     other.
  *
- * NOT CAUGHT: a name computed at runtime (a function return, a template, a config
- * value), or a credential read in a module reached other than by a static
- * relative import from the entry point. Both are out of reach of a source parse;
- * the fail-closed bracket rule narrows the first considerably.
+ * NOT CAUGHT: a name computed at runtime (a function return, a template, a
+ * config value) — that surfaces as a sentinel FAILURE rather than passing, but
+ * the guard cannot tell you the real name; and a credential read in a module
+ * reached other than by a static import from the entry point (a dynamic
+ * `import()`, or a transitive import two hops away).
  */
 
 const SRC = resolve(__dirname, '../../..');
@@ -60,19 +67,24 @@ const ENTRY = 'server/auth/get-server-auth-session.ts';
  * The modules that turn a raw request into a session.
  *
  * A LEDGER, not a convenience list: the scope test derives the entry point's own
- * local imports and fails when this set misses one, so a credential read cannot
- * be quarantined into a file the guard never reads. Listed files must also exist,
- * so a rename cannot silently shrink the scanned surface.
+ * imports and fails when this set misses one, so a credential read cannot be
+ * quarantined into a file the guard never reads.
  */
 const SESSION_PATH_FILES = [ENTRY, 'server/auth/session-client.ts', 'server/auth/bearer-token.ts'];
 
 /**
- * Local modules the entry point imports that do NOT read credentials off the
- * request. Fail-closed: anything else it imports must be scanned.
+ * Modules the entry point imports that do NOT read credentials off the request.
+ * Fail-closed: anything else it imports must be scanned.
+ *
+ * Keep this HONEST — an entry that no longer matches a real import is dead, and
+ * a dead exemption is evidence the derivation's output was never read. The scope
+ * test asserts the derivation is non-empty for exactly that reason.
  */
 const NON_CREDENTIAL_MODULES: Record<string, string> = {
   'server/auth/session-metrics.ts': 'counters only — takes no request',
-  'server/utils/url-helpers.ts': 'builds a base URL; reads nothing off the request',
+  'server/utils/url-helpers.ts': 'builds a base URL from config; reads nothing off the request',
+  'env/server.ts': 'environment config; reads nothing off the request',
+  'env/other.ts': 'environment config; reads nothing off the request',
 };
 
 /** Request HEADER reads on the session path that are not credentials. */
@@ -83,18 +95,25 @@ const NON_CREDENTIAL_HEADERS: Record<string, string> = {
 /** QUERY reads on the session path that are not credentials. */
 const NON_CREDENTIAL_QUERY: Record<string, string> = {};
 
-/**
- * Cookie-name helpers used on the session path that do NOT name a credential.
- * Deliberately a separate list per axis: one flat map meant exempting a header
- * silently exempted an identically-named query param.
- */
-const NON_CREDENTIAL_COOKIE_HELPERS: Record<string, string> = {
+/** COOKIE names/helpers on the session path that do not name a credential. */
+const NON_CREDENTIAL_COOKIES: Record<string, string> = {
   deviceCookieName:
     'a device identifier used for rolling/upgrade bookkeeping; authenticates nobody on its own',
 };
 
-/** `in` fails open on prototype keys (`constructor`, `valueOf`, `toString`). */
+/** Marker for a read whose name this parse could not determine. */
+const UNRESOLVABLE = '<unresolvable>';
+const isUnresolvable = (n: string) => n.startsWith(UNRESOLVABLE);
+
+/**
+ * `in` fails open on prototype keys (`constructor`, `valueOf`, `toString`).
+ *
+ * Also refuses to exempt a sentinel: an unresolvable read must be made
+ * resolvable, never silenced by keying an exemption on the source text that
+ * happened to produce it (rename the variable and the failure returns).
+ */
 function isExempt(list: Record<string, string>, name: string): boolean {
+  if (isUnresolvable(name)) return false;
   return Object.prototype.hasOwnProperty.call(list, name);
 }
 
@@ -102,55 +121,81 @@ function readSource(rel: string): string {
   return stripSourceComments(readFileSync(resolve(SRC, rel), 'utf8'));
 }
 
-function sessionPathSource(): string {
-  return SESSION_PATH_FILES.map(readSource).join('\n');
-}
-
-/** Resolve `const NAME = 'literal'` so a bracket read via a constant is visible. */
-function literalConsts(src: string): Map<string, string> {
-  const out = new Map<string, string>();
-  for (const m of src.matchAll(
-    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*['"]([^'"]+)['"]/g
-  ))
-    out.set(m[1], m[2]);
-  return out;
+/** Each scanned file separately — extraction is PER FILE, never over a join. */
+function sessionPathSources(): { rel: string; src: string }[] {
+  return SESSION_PATH_FILES.map((rel) => ({ rel, src: readSource(rel) }));
 }
 
 /**
- * Names read off `req.<bag>`, by any spelling this parse can see.
+ * `const NAME = 'literal'` within ONE file.
  *
- * 🔴 An unresolvable bracket read yields a SENTINEL rather than nothing. Silently
- * dropping what it cannot understand is exactly how the first version let a
- * `const`-aliased header through.
+ * 🔴 Per-file, and a name declared twice with different values resolves to
+ * NOTHING rather than to one of them. A single map over the concatenated
+ * sources let a `const CRED = 'host'` in one file resolve a `req.headers[CRED]`
+ * in another onto the exempt `host`, so a real credential read vanished with no
+ * sentinel — strictly worse than being unresolvable.
  */
-function extractReads(src: string, bag: 'headers' | 'query'): string[] {
+function literalConsts(src: string): Map<string, string> {
+  const seen = new Map<string, string>();
+  const conflicted = new Set<string>();
+  for (const m of src.matchAll(
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*['"]([^'"]+)['"]/g
+  )) {
+    const [, name, value] = m;
+    if (seen.has(name) && seen.get(name) !== value) conflicted.add(name);
+    seen.set(name, value);
+  }
+  for (const n of conflicted) seen.delete(n);
+  return seen;
+}
+
+/** Classify one bracket-expression body into a name, or a sentinel. */
+function classifyBracket(inner: string, consts: Map<string, string>): string {
+  const t = inner.trim();
+  const literal = t.match(/^['"]([^'"]+)['"]$/);
+  if (literal) return literal[1];
+  const ident = t.match(/^[A-Za-z_$][\w$]*$/);
+  const resolved = ident ? consts.get(t) : undefined;
+  return resolved ?? `${UNRESOLVABLE}:${t}`;
+}
+
+/** Names read off `req.<bag>` in ONE file, by any spelling this parse can see. */
+function extractReadsIn(src: string, bag: 'headers' | 'query' | 'cookies'): string[] {
   const names = new Set<string>();
   const consts = literalConsts(src);
   const B = `req\\.${bag}`;
 
+  // req.x.name / req.x?.name
   for (const m of src.matchAll(new RegExp(`\\b${B}\\s*\\??\\.\\s*([A-Za-z][\\w]*)`, 'g')))
     names.add(m[1]);
 
-  // Capture the WHOLE bracket expression, then decide. Matching only the shapes
-  // we understand means anything else vanishes — and a read we cannot see is
-  // exactly the one that gets through. `req.headers[computeName()]` failed this
-  // way while an identifier-only pattern was in place.
+  // req.x[<anything>] — the WHOLE expression, then classified. Matching only
+  // understood shapes means anything else vanishes, and a read the guard cannot
+  // see is exactly the one that gets through.
   for (const m of src.matchAll(new RegExp(`\\b${B}\\s*(?:\\?\\.)?\\[([^\\]]+)\\]`, 'g'))) {
     const inner = m[1].trim();
-    const literal = inner.match(/^['"]([^'"]+)['"]$/);
-    if (literal) {
-      names.add(literal[1]);
-      continue;
-    }
-    const ident = inner.match(/^[A-Za-z_$][\w$]*$/);
-    const resolved = ident ? consts.get(inner) : undefined;
-    names.add(resolved ?? `<unresolvable:${inner}>`);
+    // A COOKIE name may be produced by a name helper, and the cookie test can
+    // evaluate one — so record the helper. On headers/query there is no such
+    // convention, so a call is simply a name we cannot determine: it must become
+    // a sentinel, not be mistaken for the callee's identifier.
+    const call = bag === 'cookies' ? inner.match(/^([A-Za-z_$][\w$]*)\s*\(/) : null;
+    names.add(call ? call[1] : classifyBracket(inner, consts));
   }
 
-  for (const m of src.matchAll(new RegExp(`\\{([^}]*)\\}\\s*=\\s*${B}\\b`, 'g'))) {
+  // const { authorization, 'x-api-key': alias } = req.x
+  //
+  // 🔴 Anchored on the DECLARATION KEYWORD. `\{([^}]*)\}` alone cannot cross a
+  // `}`, so it anchored on whichever `{` had the pattern's `}` as its first —
+  // in practice the enclosing FUNCTION BODY brace — and extracted the leading
+  // tokens of the body ("authorization", "host", "if") while missing the real
+  // name entirely. It then told the maintainer to exempt `if`, which would have
+  // gone green with the credential read still invisible.
+  for (const m of src.matchAll(
+    new RegExp(`\\b(?:const|let|var)\\s*\\{([^{}]*)\\}\\s*=\\s*${B}\\b`, 'g')
+  )) {
     for (const part of m[1].split(',')) {
       const t = part.trim();
-      if (!t) continue;
+      if (!t || t.startsWith('...')) continue;
       const quoted = t.match(/^['"]([^'"]+)['"]\s*:/);
       if (quoted) {
         names.add(quoted[1]);
@@ -161,32 +206,44 @@ function extractReads(src: string, bag: 'headers' | 'query'): string[] {
     }
   }
 
-  const exempt = bag === 'headers' ? NON_CREDENTIAL_HEADERS : NON_CREDENTIAL_QUERY;
+  const exempt =
+    bag === 'headers'
+      ? NON_CREDENTIAL_HEADERS
+      : bag === 'query'
+      ? NON_CREDENTIAL_QUERY
+      : NON_CREDENTIAL_COOKIES;
   return [...names].filter((n) => !isExempt(exempt, n));
 }
 
+/** Union across the scanned files, extracting each SEPARATELY. */
+function extractReads(bag: 'headers' | 'query' | 'cookies'): string[] {
+  const out = new Set<string>();
+  for (const { src } of sessionPathSources()) for (const n of extractReadsIn(src, bag)) out.add(n);
+  return [...out];
+}
+
 /** Query params also arrive via `new URL(...).searchParams.get('x')`. */
-function extractQueryReads(src: string): string[] {
-  const names = new Set<string>(extractReads(src, 'query'));
-  for (const m of src.matchAll(/searchParams\.get\(\s*['"]([^'"]+)['"]\s*\)/g)) names.add(m[1]);
-  return [...names].filter((n) => !isExempt(NON_CREDENTIAL_QUERY, n));
+function extractQueryReads(): string[] {
+  const out = new Set<string>(extractReads('query'));
+  for (const { src } of sessionPathSources())
+    for (const m of src.matchAll(/searchParams\.get\(\s*['"]([^'"]+)['"]\s*\)/g)) out.add(m[1]);
+  return [...out].filter((n) => !isExempt(NON_CREDENTIAL_QUERY, n));
 }
 
-/** Cookie-name HELPERS invoked in a `req.cookies[...]` read on the session path. */
-function extractCookieHelpers(src: string): string[] {
-  const names = new Set<string>();
-  for (const m of src.matchAll(/req\.cookies\s*\??\.?\[\s*([A-Za-z_$][\w$]*)\s*\(/g))
-    names.add(m[1]);
-  return [...names].filter((n) => !isExempt(NON_CREDENTIAL_COOKIE_HELPERS, n));
-}
-
-/** Local (relative) modules a source file imports, as repo-relative paths. */
-function localImports(rel: string): string[] {
+/** Modules a source file imports, relative (`./x`) or aliased (`~/server/x`). */
+function moduleImports(rel: string): string[] {
   const src = readSource(rel);
   const dir = resolve(SRC, rel, '..');
   const out = new Set<string>();
-  for (const m of src.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
-    const abs = resolve(dir, m[1]);
+  // Value imports only: `import type` cannot carry a runtime credential read.
+  for (const m of src.matchAll(/import\s+(?!type\s)[^;]*?from\s+['"]([^'"]+)['"]/g)) {
+    const spec = m[1];
+    const abs = spec.startsWith('~/')
+      ? resolve(SRC, spec.slice(2))
+      : spec.startsWith('.')
+      ? resolve(dir, spec)
+      : null;
+    if (!abs) continue; // a package, not our source
     for (const cand of [`${abs}.ts`, `${abs}.tsx`, `${abs}/index.ts`]) {
       if (existsSync(cand)) {
         out.add(cand.slice(SRC.length + 1));
@@ -200,10 +257,10 @@ function localImports(rel: string): string[] {
 /**
  * A request carrying `name`, in the shape Next hands an API route.
  *
- * Axis-aware deliberately: `cookie` is a real header the predicate parses, and
+ * Axis-aware: `cookie` is a real header the predicate parses, and
  * `'synthetic-value'` is not a parseable cookie pair — a naive fixture made a
- * legitimate `req.headers.cookie` read look UNRECOGNISED and pointed the reader
- * at exempting the whole raw-Cookie axis.
+ * legitimate `req.headers.cookie` read look UNRECOGNISED and steered the reader
+ * toward exempting the whole raw-Cookie axis.
  */
 function reqWithHeader(name: string): NextApiRequest {
   const value =
@@ -216,12 +273,31 @@ function reqWithHeader(name: string): NextApiRequest {
   } as unknown as NextApiRequest;
 }
 
-function reqWithQuery(name: string): NextApiRequest {
+/**
+ * Query fixtures, ONE CHANNEL EACH.
+ *
+ * 🔴 A fixture populating both `req.query` and `req.url` lets the predicate's
+ * two query branches shield each other: dropping either one alone stayed green,
+ * and only removing BOTH went red. A guard that cannot see a single-branch
+ * narrowing is not guarding the branch.
+ */
+function reqWithQueryOnly(name: string): NextApiRequest {
   return {
     headers: {},
     cookies: {},
     query: { [name]: 'synthetic-value' },
-    url: `/api/v1/x?${name}=synthetic-value`,
+    url: '/api/v1/x',
+  } as unknown as NextApiRequest;
+}
+
+function reqWithUrlQueryOnly(name: string): NextApiRequest {
+  // Encoded: a sentinel is raw source text and could otherwise inject query
+  // structure (`…&token=1`) and be blessed by the predicate.
+  return {
+    headers: {},
+    cookies: {},
+    query: {},
+    url: `/api/v1/x?${encodeURIComponent(name)}=synthetic-value`,
   } as unknown as NextApiRequest;
 }
 
@@ -234,90 +310,156 @@ function reqWithCookie(name: string): NextApiRequest {
   } as unknown as NextApiRequest;
 }
 
+/** Cookie-name helpers this guard can evaluate. */
+const COOKIE_HELPERS: Record<string, (secure?: boolean) => string> = {
+  sessionCookieName,
+  legacySessionCookieName,
+};
+
 describe('credential detection is a superset of the session layer', () => {
   // ── Controls on the DERIVATION ─────────────────────────────────────────────
   // Without these a broken parse yields an empty set and everything below passes
   // vacuously — a guard that reads as coverage while providing none.
 
-  it('the session-path sources are readable, listed and non-trivial', () => {
-    const src = sessionPathSource();
-    expect(src.length).toBeGreaterThan(2_000);
-    expect(src).toContain('getServerAuthSession');
+  it('every listed session-path file exists and is non-trivial', () => {
+    // Existence FIRST: sessionPathSources() would throw ENOENT before a later
+    // existence assertion could produce its own message.
     for (const f of SESSION_PATH_FILES)
       expect(existsSync(resolve(SRC, f)), `${f} is listed but does not exist`).toBe(true);
+    const joined = sessionPathSources()
+      .map((f) => f.src)
+      .join('\n');
+    expect(joined.length).toBeGreaterThan(2_000);
+    expect(joined).toContain('getServerAuthSession');
   });
 
   it('finds the credential spellings we KNOW exist', () => {
-    const src = sessionPathSource();
-    expect(extractReads(src, 'headers')).toContain('authorization');
-    expect(extractQueryReads(src)).toContain('token');
-    expect(extractCookieHelpers(src).sort()).toEqual(
+    expect(extractReads('headers')).toContain('authorization');
+    expect(extractQueryReads()).toContain('token');
+    expect(extractReads('cookies').sort()).toEqual(
       ['legacySessionCookieName', 'sessionCookieName'].sort()
     );
   });
 
-  it('sees every notation it claims to', () => {
-    // Each of these SURVIVED an earlier version; all are now pinned.
-    expect(extractReads("const t = req.headers['x-api-key'];", 'headers')).toContain('x-api-key');
-    expect(extractReads("const t = req.headers?.['x-fwd'];", 'headers')).toContain('x-fwd');
-    expect(extractReads("const H = 'x-alias';\nconst t = req.headers[H];", 'headers')).toContain(
-      'x-alias'
-    );
-    expect(extractReads('const { authorization } = req.headers;', 'headers')).toContain(
-      'authorization'
-    );
-    expect(extractReads("const { 'x-api-key': k } = req.headers;", 'headers')).toContain(
-      'x-api-key'
-    );
-    expect(extractQueryReads("const t = req.query['api_key'];")).toContain('api_key');
+  it('the import derivation is not empty (positive control)', () => {
+    // Gutting moduleImports to return [] left the scope test green — every other
+    // derivation here had a positive control and that one did not.
+    const imports = moduleImports(ENTRY);
+    expect(imports).toContain('server/auth/bearer-token.ts');
+    expect(imports).toContain('server/auth/session-client.ts');
   });
 
-  it('FAILS CLOSED on a bracket read it cannot resolve', () => {
-    const found = extractReads('const t = req.headers[computeName()];', 'headers');
-    const sentinel = found.find((n) => n.startsWith('<unresolvable:'));
-    expect(sentinel, 'an unresolvable read must surface, not vanish').toBeDefined();
-    // And the sentinel is not something the predicate accepts, so it fails the
-    // relationship assertion rather than passing quietly.
-    expect(requestCarriesCallerCredentials(reqWithHeader(sentinel as string))).toBe(false);
+  it('sees every notation it claims to', () => {
+    // Each of these survived some earlier version of this file.
+    expect(extractReadsIn("const t = req.headers['x-api-key'];", 'headers')).toContain('x-api-key');
+    expect(extractReadsIn("const t = req.headers?.['x-fwd'];", 'headers')).toContain('x-fwd');
+    expect(extractReadsIn("const H = 'x-alias';\nconst t = req.headers[H];", 'headers')).toContain(
+      'x-alias'
+    );
+    expect(extractReadsIn("const t = req.cookies?.['civ-alt'];", 'cookies')).toContain('civ-alt');
+    expect(
+      extractReadsIn("const C = 'civ-alt2';\nconst t = req.cookies?.[C];", 'cookies')
+    ).toContain('civ-alt2');
+    expect(extractReadsIn("const t = req.query['api_key'];", 'query')).toContain('api_key');
+  });
+
+  it('parses destructuring from the DECLARATION, not the enclosing brace', () => {
+    // 🔴 The regression that mattered most. With the pattern early in a function
+    // body, an unanchored `\{([^}]*)\}` matched from the body brace and yielded
+    // the body's leading tokens while MISSING the real name — then advised
+    // exempting the fabricated one.
+    const inBody = [
+      'async function f(req) {',
+      '  if (req.context) return null;',
+      "  const { 'x-real-cred': c } = req.headers;",
+      '  return c;',
+      '}',
+    ].join('\n');
+    const found = extractReadsIn(inBody, 'headers');
+    expect(found).toContain('x-real-cred');
+    expect(found).not.toContain('if');
+    expect(extractReadsIn('const { authorization } = req.headers;', 'headers')).toContain(
+      'authorization'
+    );
+    // A rest element names no specific header.
+    expect(extractReadsIn('const { ...rest } = req.headers;', 'headers')).not.toContain('...rest');
+  });
+
+  it('FAILS CLOSED on an unresolvable read, on every axis', () => {
+    // headers/query: a call is a name we cannot determine -> sentinel.
+    for (const bag of ['headers', 'query'] as const) {
+      const found = extractReadsIn(`const t = req.${bag}[computeName()];`, bag);
+      expect(
+        found.some(isUnresolvable),
+        `an unresolvable ${bag} read must surface, not vanish`
+      ).toBe(true);
+    }
+    // cookies: a non-call expression is equally unresolvable.
+    expect(
+      extractReadsIn('const t = req.cookies[opts.name];', 'cookies').some(isUnresolvable),
+      'an unresolvable cookie read must surface, not vanish'
+    ).toBe(true);
+    // A sentinel cannot be silenced through the exemption channel.
+    expect(isExempt(NON_CREDENTIAL_HEADERS, `${UNRESOLVABLE}:k`)).toBe(false);
+  });
+
+  it('an UNKNOWN cookie helper is not silently accepted', () => {
+    // The cookies axis records a helper CALL by name rather than as a sentinel,
+    // because the cookie test can evaluate a known helper. The closure for an
+    // UNKNOWN one is that test: it falls through to being treated as a literal
+    // cookie name, which the predicate does not recognise, so the relationship
+    // assertion goes red. Pinned here so the two halves cannot drift apart.
+    const found = extractReadsIn('const t = req.cookies?.[mysteryCookieName()];', 'cookies');
+    expect(found).toContain('mysteryCookieName');
+    expect(Object.prototype.hasOwnProperty.call(COOKIE_HELPERS, 'mysteryCookieName')).toBe(false);
+    expect(requestCarriesCallerCredentials(reqWithCookie('mysteryCookieName'))).toBe(false);
+  });
+
+  it('refuses to resolve a constant declared twice with different values', () => {
+    // Per-file scoping plus conflict-rejection: a colliding alias must become a
+    // sentinel, never silently resolve onto an exempt name like `host`.
+    const src = [
+      "const CRED = 'host';",
+      "const CRED = 'x-secret';",
+      'const t = req.headers[CRED];',
+    ].join('\n');
+    const found = extractReadsIn(src, 'headers');
+    expect(found.some(isUnresolvable)).toBe(true);
+    expect(found).not.toContain('host');
   });
 
   it('ignores commented-out reads — and this control is not vacuous', () => {
-    // 🔴 BRACKET notation deliberately. An earlier version used a hyphenated name
-    // in DOT notation, which the dot pattern can never yield, so the assertion
-    // held even with comment-stripping replaced by the identity function — the
-    // one control protecting a real fail-open direction was decorative.
     const src = [
       "      // const a = req.headers['x-commented'];",
       "      const b = req.headers['x-live'];",
     ].join('\n');
-    const stripped = extractReads(stripSourceComments(src), 'headers');
+    const stripped = extractReadsIn(stripSourceComments(src), 'headers');
     expect(stripped).toContain('x-live');
     expect(stripped).not.toContain('x-commented');
     // Prove the fixture CAN express the failure: unstripped, it is found.
-    expect(extractReads(src, 'headers')).toContain('x-commented');
+    expect(extractReadsIn(src, 'headers')).toContain('x-commented');
   });
 
   // ── Scope ──────────────────────────────────────────────────────────────────
 
-  it('scans every local module the session entry point imports', () => {
-    // Extracting bearer parsing into a helper file is an ordinary refactor, and
-    // it silently disarmed the previous version of this guard.
-    const unscanned = localImports(ENTRY).filter(
+  it('scans every module the session entry point imports', () => {
+    // Both spellings: `~/server/…` is this repo's dominant style, and an earlier
+    // version resolved only `./…`, so the LIKELY refactor was the uncaught one.
+    const unscanned = moduleImports(ENTRY).filter(
       (f) => !SESSION_PATH_FILES.includes(f) && !isExempt(NON_CREDENTIAL_MODULES, f)
     );
     expect(
       unscanned,
-      `${ENTRY} imports these local modules, which are neither scanned for credential reads ` +
-        `nor declared non-credential: [${unscanned.join(', ')}]. A credential read in one of ` +
-        `them is invisible here. Add it to SESSION_PATH_FILES, or to NON_CREDENTIAL_MODULES ` +
-        `with a reason.`
+      `${ENTRY} imports these modules, which are neither scanned for credential reads nor ` +
+        `declared non-credential: [${unscanned.join(', ')}]. A credential read in one of them ` +
+        `is invisible here. Add it to SESSION_PATH_FILES, or to NON_CREDENTIAL_MODULES with a reason.`
     ).toEqual([]);
   });
 
   // ── The relationship ───────────────────────────────────────────────────────
 
   it('every HEADER the session path reads is recognised as a credential', () => {
-    const unrecognised = extractReads(sessionPathSource(), 'headers').filter(
+    const unrecognised = extractReads('headers').filter(
       (h) => !requestCarriesCallerCredentials(reqWithHeader(h))
     );
     expect(
@@ -325,50 +467,52 @@ describe('credential detection is a superset of the session layer', () => {
       `the session layer reads these request headers, but requestCarriesCallerCredentials does ` +
         `not treat them as credentials: [${unrecognised.join(', ')}]. A request carrying one ` +
         `would be classified ANONYMOUS and its per-caller body cached publicly. Teach the ` +
-        `predicate the spelling, or declare it in NON_CREDENTIAL_HEADERS with a reason — noting ` +
-        `that exempting a whole axis (e.g. 'cookie') hides future reads on it too.`
+        `predicate the spelling; or, if a name is <unresolvable>, make it resolvable (a literal ` +
+        `or a single-valued const) rather than exempting it.`
     ).toEqual([]);
   });
 
-  it('every QUERY PARAM the session path reads is recognised as a credential', () => {
-    const unrecognised = extractQueryReads(sessionPathSource()).filter(
-      (q) => !requestCarriesCallerCredentials(reqWithQuery(q))
+  it('every QUERY PARAM is recognised on BOTH channels independently', () => {
+    // req.query and req.url are separate branches in the predicate. Probing them
+    // together let each shield the other's removal.
+    const names = extractQueryReads();
+    const missedInQuery = names.filter(
+      (q) => !requestCarriesCallerCredentials(reqWithQueryOnly(q))
+    );
+    const missedInUrl = names.filter(
+      (q) => !requestCarriesCallerCredentials(reqWithUrlQueryOnly(q))
     );
     expect(
-      unrecognised,
-      `the session layer reads these query parameters, but requestCarriesCallerCredentials does ` +
-        `not treat them as credentials: [${unrecognised.join(', ')}].`
+      missedInQuery,
+      `not recognised via req.query: [${missedInQuery.join(', ')}] — getServerAuthSession reads ` +
+        `the parsed query, so the predicate must too.`
+    ).toEqual([]);
+    expect(
+      missedInUrl,
+      `not recognised via req.url: [${missedInUrl.join(', ')}] — getServerAuthSession parses ` +
+        `req.url directly, so a predicate that only reads req.query can be bypassed.`
     ).toEqual([]);
   });
 
   it('every COOKIE the session path authenticates with is recognised', () => {
-    // BEHAVIOURAL, not textual. The previous version asserted both files mention
-    // the same helper NAMES — which a decoy call elsewhere in a 700-line file
-    // satisfies while the real list is hardcoded. This calls each helper and asks
-    // the predicate about the cookie it actually names, so the two sides can only
-    // agree by agreeing.
-    const helpers: Record<string, (secure?: boolean) => string> = {
-      sessionCookieName,
-      legacySessionCookieName,
-    };
-    const used = extractCookieHelpers(sessionPathSource());
-
-    const unknown = used.filter((h) => !Object.prototype.hasOwnProperty.call(helpers, h));
+    // BEHAVIOURAL for helpers, and literal names are checked directly — an
+    // earlier version matched ONLY `req.cookies[helper(` , so a literal or
+    // const-aliased cookie name was dropped with no sentinel.
+    const used = extractReads('cookies');
+    const unresolved = used.filter(isUnresolvable);
     expect(
-      unknown,
-      `the session path resolves cookie names with these helpers, which this guard cannot ` +
-        `evaluate: [${unknown.join(', ')}]. If one names a credential the predicate must ` +
-        `recognise it — add it to the map here, or to NON_CREDENTIAL_COOKIE_HELPERS with a reason.`
+      unresolved,
+      `cookie reads whose name could not be determined: [${unresolved.join(', ')}]`
     ).toEqual([]);
 
     for (const name of used) {
-      // Both variants: the predicate registers secure and non-secure spellings,
-      // and a deploy's env decides which is live.
-      for (const secure of [true, false]) {
-        const cookie = helpers[name](secure);
+      const cookies = Object.prototype.hasOwnProperty.call(COOKIE_HELPERS, name)
+        ? [COOKIE_HELPERS[name](true), COOKIE_HELPERS[name](false)]
+        : [name];
+      for (const cookie of cookies) {
         expect(
           requestCarriesCallerCredentials(reqWithCookie(cookie)),
-          `the session path authenticates with ${name}(${secure}) = "${cookie}", but the ` +
+          `the session path authenticates with the cookie "${cookie}" (from ${name}), but the ` +
             `predicate does not recognise it`
         ).toBe(true);
       }
@@ -379,7 +523,8 @@ describe('credential detection is a superset of the session layer', () => {
 
   it('does NOT demand that unrelated request fields be credentials', () => {
     expect(requestCarriesCallerCredentials(reqWithHeader('accept-language'))).toBe(false);
-    expect(requestCarriesCallerCredentials(reqWithQuery('limit'))).toBe(false);
+    expect(requestCarriesCallerCredentials(reqWithQueryOnly('limit'))).toBe(false);
+    expect(requestCarriesCallerCredentials(reqWithUrlQueryOnly('limit'))).toBe(false);
     expect(requestCarriesCallerCredentials(reqWithCookie('theme'))).toBe(false);
   });
 

--- a/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
+++ b/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
@@ -1,0 +1,241 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { NextApiRequest } from 'next';
+import { describe, expect, it } from 'vitest';
+import { stripSourceComments } from '~/components/AppBlocks/stripSourceComments';
+import { requestCarriesCallerCredentials } from '~/server/utils/endpoint-helpers';
+
+/**
+ * RELATIONSHIP GUARD — the cache-control credential predicate must stay a
+ * SUPERSET of what the session layer actually accepts as a credential.
+ *
+ * WHY THIS MATTERS. `PublicEndpoint` / `MixedAuthEndpoint` decide a response's
+ * `Cache-Control` from `requestCarriesCallerCredentials(req)`:
+ *
+ *     credentialed  -> private, no-cache   (never stored by a shared cache)
+ *     anonymous     -> public, s-maxage=…  (stored at the edge, replayed to anyone)
+ *
+ * That is the ONLY thing standing between a personalised response body and a
+ * shared cache. It is also load-bearing in a way that is easy to miss, because
+ * the edge does not help: `Vary: Authorization` is INERT at our CDN — measured
+ * on production, an anonymous request populates a URL and a subsequent request
+ * carrying `Authorization` is served that cached entry (`cf-cache-status: HIT`).
+ * So `Vary` cannot be relied on to separate the two audiences; the origin header
+ * is the whole mechanism.
+ *
+ * The failure mode is therefore precise and silent: if the session layer learns
+ * a credential spelling this predicate does not recognise, a request carrying it
+ * is classified ANONYMOUS, gets `public, s-maxage`, and its per-caller body is
+ * cached and served to other people. Nothing errors. Everything keeps working.
+ *
+ * `endpoint-helpers.ts` already states the invariant in prose — "the set of
+ * credential spellings this predicate recognises must stay a superset of the set
+ * `getServerAuthSession` accepts; when one grows, so must the other". This file
+ * is that sentence, enforced.
+ *
+ * ── How it derives, and why not a hand-written list ───────────────────────────
+ * A list of spellings is exactly what `public-endpoint-credential-detection.test.ts`
+ * already has, and a list cannot fail when the OTHER side grows — which is the
+ * event this guard exists for. So the spellings are EXTRACTED from the session
+ * layer's own source, and each extracted spelling is then used to SYNTHESISE a
+ * request that is fed to the real predicate. A spelling nobody has thought of yet
+ * is handled by construction: it is extracted, a request is built from it, and
+ * the predicate must answer `true`.
+ *
+ * Two axes exist, and only one can drift:
+ *   - COOKIES cannot. Both sides resolve names through the same shared helpers
+ *     (`sessionCookieName` / `legacySessionCookieName`), so there is no second
+ *     copy to fall out of step. Asserted structurally below rather than assumed.
+ *   - HEADERS and QUERY PARAMS can, because each side reads them by literal name.
+ *     Those are what is extracted.
+ *
+ * Fails CLOSED: an unrecognised header/param on the session path is a failure
+ * unless it is explicitly declared a non-credential below, with a reason. A new
+ * read is therefore a deliberate decision, not an omission.
+ */
+
+const SRC = resolve(__dirname, '../../..');
+
+/**
+ * The modules that turn a raw request into a session. If the credential-reading
+ * surface grows a new file, add it here — `getServerAuthSession` is the entry
+ * point and these are the ones it delegates credential EXTRACTION to.
+ */
+const SESSION_PATH_FILES = [
+  'server/auth/get-server-auth-session.ts',
+  'server/auth/session-client.ts',
+  'server/auth/bearer-token.ts',
+];
+
+/**
+ * Reads on the session path that are NOT credentials. Fail-closed means anything
+ * not listed here must be recognised by the predicate, so each entry needs a
+ * reason a reviewer can check.
+ */
+const NON_CREDENTIAL_READS: Record<string, string> = {
+  host: 'response-side only — the cookie domain for maybeRollHubCookie/maybeUpgradeLegacySession, never read to identify a caller',
+};
+
+function sessionPathSource(): string {
+  return SESSION_PATH_FILES.map((f) =>
+    stripSourceComments(readFileSync(resolve(SRC, f), 'utf8'))
+  ).join('\n');
+}
+
+/**
+ * Header names the session path reads off the request, by literal name.
+ *
+ * 🔴 BOTH notations, and the bracket form is the important one: a header name
+ * containing a hyphen — `x-api-key`, `x-forwarded-user` — CANNOT be read with
+ * dot access, so the most likely spelling for a newly-added header is exactly
+ * the one a dot-only pattern cannot see. A first version of this matched dot
+ * access only, and a mutation adding `req.headers['x-api-key']` to the session
+ * path walked straight past the guard.
+ */
+function extractHeaderReads(src: string): string[] {
+  const names = new Set<string>();
+  // req.headers.name / req.headers?.name
+  for (const m of src.matchAll(/\breq\.headers\s*\??\.\s*([A-Za-z][A-Za-z0-9_]*)/g))
+    names.add(m[1]);
+  // req.headers['name'] / req.headers["name"] / req.headers?.['name']
+  for (const m of src.matchAll(/\breq\.headers\s*(?:\?\.)?\[\s*['"]([^'"]+)['"]\s*\]/g))
+    names.add(m[1]);
+  return [...names].filter((n) => !(n in NON_CREDENTIAL_READS));
+}
+
+/** Query-parameter names the session path reads, by literal name. */
+function extractQueryReads(src: string): string[] {
+  const names = new Set<string>();
+  for (const m of src.matchAll(/searchParams\.get\(\s*['"]([^'"]+)['"]\s*\)/g)) names.add(m[1]);
+  for (const m of src.matchAll(/\breq\.query\s*\??\.\s*([A-Za-z][A-Za-z0-9_]*)/g)) names.add(m[1]);
+  for (const m of src.matchAll(/\breq\.query\s*(?:\?\.)?\[\s*['"]([^'"]+)['"]\s*\]/g))
+    names.add(m[1]);
+  return [...names].filter((n) => !(n in NON_CREDENTIAL_READS));
+}
+
+function reqWithHeader(name: string): NextApiRequest {
+  return {
+    headers: { [name]: 'synthetic-value' },
+    cookies: {},
+    query: {},
+    url: '/api/v1/x',
+  } as unknown as NextApiRequest;
+}
+
+function reqWithQuery(name: string): NextApiRequest {
+  return {
+    headers: {},
+    cookies: {},
+    query: { [name]: 'synthetic-value' },
+    url: `/api/v1/x?${name}=synthetic-value`,
+  } as unknown as NextApiRequest;
+}
+
+describe('credential detection is a superset of the session layer', () => {
+  // ── Controls on the EXTRACTOR itself ───────────────────────────────────────
+  // Without these, a broken regex yields an empty set and every assertion below
+  // passes vacuously — the guard would be inert and read as coverage.
+
+  it('the session-path sources are readable and non-trivial', () => {
+    const src = sessionPathSource();
+    expect(src.length).toBeGreaterThan(2_000);
+    // The entry point must be in the scanned set, or the extraction is blind.
+    expect(src).toContain('getServerAuthSession');
+  });
+
+  it('the extractor finds the credential spellings we KNOW exist', () => {
+    // Positive control. `authorization` and `token` are read by
+    // getServerAuthSession today; an extractor that cannot see them cannot see
+    // a new one either.
+    const src = sessionPathSource();
+    expect(extractHeaderReads(src)).toContain('authorization');
+    expect(extractQueryReads(src)).toContain('token');
+  });
+
+  it('the extractor sees BRACKET access, not just dot access', () => {
+    // Regression control. Hyphenated header names cannot be read with dot
+    // access, so bracket access is the ONLY spelling available for them — and a
+    // dot-only extractor is blind to exactly the names most likely to be added.
+    // A mutation adding `req.headers['x-api-key']` to the session path survived
+    // the first version of this guard.
+    const bracket = "const t = req.headers['x-api-key'];";
+    expect(extractHeaderReads(bracket)).toContain('x-api-key');
+    const optional = "const t = req.headers?.['x-forwarded-user'];";
+    expect(extractHeaderReads(optional)).toContain('x-forwarded-user');
+    const q = "const t = req.query['api_key'];";
+    expect(extractQueryReads(q)).toContain('api_key');
+  });
+
+  it('the extractor ignores comments (a commented-out read is not a read)', () => {
+    const withComment = `
+      // req.headers.x-made-up-credential
+      const a = req.headers.authorization;
+    `;
+    const found = extractHeaderReads(stripSourceComments(withComment));
+    expect(found).toContain('authorization');
+    expect(found).not.toContain('x-made-up-credential');
+  });
+
+  // ── The relationship ───────────────────────────────────────────────────────
+
+  it('every HEADER the session path reads is recognised as a credential', () => {
+    const src = sessionPathSource();
+    const unrecognised = extractHeaderReads(src).filter(
+      (h) => !requestCarriesCallerCredentials(reqWithHeader(h))
+    );
+    expect(
+      unrecognised,
+      `the session layer reads these request headers, but requestCarriesCallerCredentials ` +
+        `does not treat them as credentials: [${unrecognised.join(
+          ', '
+        )}]. A request carrying one ` +
+        `would be classified ANONYMOUS and its per-caller body cached publicly. Either teach the ` +
+        `predicate the spelling, or declare it in NON_CREDENTIAL_READS with a reason.`
+    ).toEqual([]);
+  });
+
+  it('every QUERY PARAM the session path reads is recognised as a credential', () => {
+    const src = sessionPathSource();
+    const unrecognised = extractQueryReads(src).filter(
+      (q) => !requestCarriesCallerCredentials(reqWithQuery(q))
+    );
+    expect(
+      unrecognised,
+      `the session layer reads these query parameters, but requestCarriesCallerCredentials ` +
+        `does not treat them as credentials: [${unrecognised.join(
+          ', '
+        )}]. See the header case above.`
+    ).toEqual([]);
+  });
+
+  it('the COOKIE axis is shared-by-construction, not duplicated', () => {
+    // Cookies are the one axis that cannot drift, because both sides resolve
+    // names through the same helpers rather than each spelling them. Pinned so
+    // that if either side ever hardcodes a name, this fails and the cookie axis
+    // joins the extracted ones above.
+    const predicateSrc = stripSourceComments(
+      readFileSync(resolve(SRC, 'server/utils/endpoint-helpers.ts'), 'utf8')
+    );
+    const sessionSrc = sessionPathSource();
+    for (const helper of ['sessionCookieName', 'legacySessionCookieName']) {
+      expect(predicateSrc, `the predicate must derive cookie names via ${helper}()`).toContain(
+        `${helper}(`
+      );
+      expect(sessionSrc, `the session path must derive cookie names via ${helper}()`).toContain(
+        `${helper}(`
+      );
+    }
+  });
+
+  // ── Negative control on the guard's own strictness ─────────────────────────
+
+  it('does NOT demand that unrelated request fields be treated as credentials', () => {
+    // The predicate is deliberately narrow, and this guard must not quietly
+    // require it to widen to anything the session path happens to touch. If this
+    // fails, the extractor is over-matching and the assertions above are
+    // demanding more than the invariant does.
+    expect(requestCarriesCallerCredentials(reqWithHeader('accept-language'))).toBe(false);
+    expect(requestCarriesCallerCredentials(reqWithQuery('limit'))).toBe(false);
+    expect(extractHeaderReads(sessionPathSource())).not.toContain('accept-language');
+  });
+});

--- a/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
+++ b/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { legacySessionCookieName, sessionCookieName } from '@civitai/auth';
 import type { NextApiRequest } from 'next';
 import { describe, expect, it } from 'vitest';
 import { stripSourceComments } from '~/components/AppBlocks/stripSourceComments';
@@ -9,113 +10,206 @@ import { requestCarriesCallerCredentials } from '~/server/utils/endpoint-helpers
  * RELATIONSHIP GUARD — the cache-control credential predicate must stay a
  * SUPERSET of what the session layer actually accepts as a credential.
  *
- * WHY THIS MATTERS. `PublicEndpoint` / `MixedAuthEndpoint` decide a response's
+ * WHY IT MATTERS. `PublicEndpoint` / `MixedAuthEndpoint` pick a response's
  * `Cache-Control` from `requestCarriesCallerCredentials(req)`:
  *
  *     credentialed  -> private, no-cache   (never stored by a shared cache)
  *     anonymous     -> public, s-maxage=…  (stored at the edge, replayed to anyone)
  *
- * That is the ONLY thing standing between a personalised response body and a
- * shared cache. It is also load-bearing in a way that is easy to miss, because
- * the edge does not help: `Vary: Authorization` is INERT at our CDN — measured
- * on production, an anonymous request populates a URL and a subsequent request
- * carrying `Authorization` is served that cached entry (`cf-cache-status: HIT`).
- * So `Vary` cannot be relied on to separate the two audiences; the origin header
- * is the whole mechanism.
+ * That predicate is the whole mechanism, because the edge does not help.
+ * Measured on production, same URL across arms: an anonymous request populates a
+ * URL, and a later request carrying `Authorization` is served that cached entry
+ * (`cf-cache-status: HIT`, still `public`). `Vary: Authorization` is INERT at our
+ * CDN. A virgin URL requested first WITH a credential does correctly get
+ * `private` + `BYPASS`, so the origin predicate works and that third arm is a
+ * cache hit rather than a misclassification.
  *
- * The failure mode is therefore precise and silent: if the session layer learns
- * a credential spelling this predicate does not recognise, a request carrying it
- * is classified ANONYMOUS, gets `public, s-maxage`, and its per-caller body is
- * cached and served to other people. Nothing errors. Everything keeps working.
+ * The failure is therefore silent and specific: if the session layer learns a
+ * credential spelling this predicate does not recognise, a request carrying it is
+ * classified ANONYMOUS, gets `public, s-maxage`, and its per-caller body is cached
+ * and served to other people. Nothing throws.
  *
- * `endpoint-helpers.ts` already states the invariant in prose — "the set of
- * credential spellings this predicate recognises must stay a superset of the set
- * `getServerAuthSession` accepts; when one grows, so must the other". This file
- * is that sentence, enforced.
+ * ── WHAT THIS CERTIFIES, AND WHAT IT DOES NOT ────────────────────────────────
+ * 🔴 Read this before trusting a green run. An earlier version claimed a spelling
+ * "nobody has thought of yet is handled by construction". An adversarial 14-mutant
+ * sweep killed that claim: nine survived — a header read through a `const` alias,
+ * one through destructuring, a credential read moved to a NEW FILE, and a NEW
+ * COOKIE, on the axis that version called un-driftable. This is the honest
+ * contract.
  *
- * ── How it derives, and why not a hand-written list ───────────────────────────
- * A list of spellings is exactly what `public-endpoint-credential-detection.test.ts`
- * already has, and a list cannot fail when the OTHER side grows — which is the
- * event this guard exists for. So the spellings are EXTRACTED from the session
- * layer's own source, and each extracted spelling is then used to SYNTHESISE a
- * request that is fed to the real predicate. A spelling nobody has thought of yet
- * is handled by construction: it is extracted, a request is built from it, and
- * the predicate must answer `true`.
+ * CAUGHT (each mutation-verified below):
+ *   - a header or query param read by literal name, dot or bracket notation;
+ *   - a header read via a `const NAME = 'literal'` alias in the same source;
+ *   - a header read by DESTRUCTURING `req.headers`, renamed or not;
+ *   - a bracket read whose name cannot be resolved — that FAILS rather than
+ *     vanishing, which is the difference between a guard and a filter;
+ *   - a credential-reading module added to the entry point's import graph;
+ *   - a new cookie helper used on the session path but not by the predicate;
+ *   - the predicate narrowing on any of the above.
  *
- * Two axes exist, and only one can drift:
- *   - COOKIES cannot. Both sides resolve names through the same shared helpers
- *     (`sessionCookieName` / `legacySessionCookieName`), so there is no second
- *     copy to fall out of step. Asserted structurally below rather than assumed.
- *   - HEADERS and QUERY PARAMS can, because each side reads them by literal name.
- *     Those are what is extracted.
- *
- * Fails CLOSED: an unrecognised header/param on the session path is a failure
- * unless it is explicitly declared a non-credential below, with a reason. A new
- * read is therefore a deliberate decision, not an omission.
+ * NOT CAUGHT: a name computed at runtime (a function return, a template, a config
+ * value), or a credential read in a module reached other than by a static
+ * relative import from the entry point. Both are out of reach of a source parse;
+ * the fail-closed bracket rule narrows the first considerably.
  */
 
 const SRC = resolve(__dirname, '../../..');
+const ENTRY = 'server/auth/get-server-auth-session.ts';
 
 /**
- * The modules that turn a raw request into a session. If the credential-reading
- * surface grows a new file, add it here — `getServerAuthSession` is the entry
- * point and these are the ones it delegates credential EXTRACTION to.
+ * The modules that turn a raw request into a session.
+ *
+ * A LEDGER, not a convenience list: the scope test derives the entry point's own
+ * local imports and fails when this set misses one, so a credential read cannot
+ * be quarantined into a file the guard never reads. Listed files must also exist,
+ * so a rename cannot silently shrink the scanned surface.
  */
-const SESSION_PATH_FILES = [
-  'server/auth/get-server-auth-session.ts',
-  'server/auth/session-client.ts',
-  'server/auth/bearer-token.ts',
-];
+const SESSION_PATH_FILES = [ENTRY, 'server/auth/session-client.ts', 'server/auth/bearer-token.ts'];
 
 /**
- * Reads on the session path that are NOT credentials. Fail-closed means anything
- * not listed here must be recognised by the predicate, so each entry needs a
- * reason a reviewer can check.
+ * Local modules the entry point imports that do NOT read credentials off the
+ * request. Fail-closed: anything else it imports must be scanned.
  */
-const NON_CREDENTIAL_READS: Record<string, string> = {
-  host: 'response-side only — the cookie domain for maybeRollHubCookie/maybeUpgradeLegacySession, never read to identify a caller',
+const NON_CREDENTIAL_MODULES: Record<string, string> = {
+  'server/auth/session-metrics.ts': 'counters only — takes no request',
+  'server/utils/url-helpers.ts': 'builds a base URL; reads nothing off the request',
 };
 
+/** Request HEADER reads on the session path that are not credentials. */
+const NON_CREDENTIAL_HEADERS: Record<string, string> = {
+  host: 'response-side only — the cookie domain for maybeRollHubCookie / maybeUpgradeLegacySession, never read to identify a caller',
+};
+
+/** QUERY reads on the session path that are not credentials. */
+const NON_CREDENTIAL_QUERY: Record<string, string> = {};
+
+/**
+ * Cookie-name helpers used on the session path that do NOT name a credential.
+ * Deliberately a separate list per axis: one flat map meant exempting a header
+ * silently exempted an identically-named query param.
+ */
+const NON_CREDENTIAL_COOKIE_HELPERS: Record<string, string> = {
+  deviceCookieName:
+    'a device identifier used for rolling/upgrade bookkeeping; authenticates nobody on its own',
+};
+
+/** `in` fails open on prototype keys (`constructor`, `valueOf`, `toString`). */
+function isExempt(list: Record<string, string>, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(list, name);
+}
+
+function readSource(rel: string): string {
+  return stripSourceComments(readFileSync(resolve(SRC, rel), 'utf8'));
+}
+
 function sessionPathSource(): string {
-  return SESSION_PATH_FILES.map((f) =>
-    stripSourceComments(readFileSync(resolve(SRC, f), 'utf8'))
-  ).join('\n');
+  return SESSION_PATH_FILES.map(readSource).join('\n');
+}
+
+/** Resolve `const NAME = 'literal'` so a bracket read via a constant is visible. */
+function literalConsts(src: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const m of src.matchAll(
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*['"]([^'"]+)['"]/g
+  ))
+    out.set(m[1], m[2]);
+  return out;
 }
 
 /**
- * Header names the session path reads off the request, by literal name.
+ * Names read off `req.<bag>`, by any spelling this parse can see.
  *
- * 🔴 BOTH notations, and the bracket form is the important one: a header name
- * containing a hyphen — `x-api-key`, `x-forwarded-user` — CANNOT be read with
- * dot access, so the most likely spelling for a newly-added header is exactly
- * the one a dot-only pattern cannot see. A first version of this matched dot
- * access only, and a mutation adding `req.headers['x-api-key']` to the session
- * path walked straight past the guard.
+ * 🔴 An unresolvable bracket read yields a SENTINEL rather than nothing. Silently
+ * dropping what it cannot understand is exactly how the first version let a
+ * `const`-aliased header through.
  */
-function extractHeaderReads(src: string): string[] {
+function extractReads(src: string, bag: 'headers' | 'query'): string[] {
   const names = new Set<string>();
-  // req.headers.name / req.headers?.name
-  for (const m of src.matchAll(/\breq\.headers\s*\??\.\s*([A-Za-z][A-Za-z0-9_]*)/g))
+  const consts = literalConsts(src);
+  const B = `req\\.${bag}`;
+
+  for (const m of src.matchAll(new RegExp(`\\b${B}\\s*\\??\\.\\s*([A-Za-z][\\w]*)`, 'g')))
     names.add(m[1]);
-  // req.headers['name'] / req.headers["name"] / req.headers?.['name']
-  for (const m of src.matchAll(/\breq\.headers\s*(?:\?\.)?\[\s*['"]([^'"]+)['"]\s*\]/g))
-    names.add(m[1]);
-  return [...names].filter((n) => !(n in NON_CREDENTIAL_READS));
+
+  // Capture the WHOLE bracket expression, then decide. Matching only the shapes
+  // we understand means anything else vanishes — and a read we cannot see is
+  // exactly the one that gets through. `req.headers[computeName()]` failed this
+  // way while an identifier-only pattern was in place.
+  for (const m of src.matchAll(new RegExp(`\\b${B}\\s*(?:\\?\\.)?\\[([^\\]]+)\\]`, 'g'))) {
+    const inner = m[1].trim();
+    const literal = inner.match(/^['"]([^'"]+)['"]$/);
+    if (literal) {
+      names.add(literal[1]);
+      continue;
+    }
+    const ident = inner.match(/^[A-Za-z_$][\w$]*$/);
+    const resolved = ident ? consts.get(inner) : undefined;
+    names.add(resolved ?? `<unresolvable:${inner}>`);
+  }
+
+  for (const m of src.matchAll(new RegExp(`\\{([^}]*)\\}\\s*=\\s*${B}\\b`, 'g'))) {
+    for (const part of m[1].split(',')) {
+      const t = part.trim();
+      if (!t) continue;
+      const quoted = t.match(/^['"]([^'"]+)['"]\s*:/);
+      if (quoted) {
+        names.add(quoted[1]);
+        continue;
+      }
+      const bare = t.match(/^([A-Za-z_$][\w$]*)/);
+      if (bare) names.add(bare[1]);
+    }
+  }
+
+  const exempt = bag === 'headers' ? NON_CREDENTIAL_HEADERS : NON_CREDENTIAL_QUERY;
+  return [...names].filter((n) => !isExempt(exempt, n));
 }
 
-/** Query-parameter names the session path reads, by literal name. */
+/** Query params also arrive via `new URL(...).searchParams.get('x')`. */
 function extractQueryReads(src: string): string[] {
-  const names = new Set<string>();
+  const names = new Set<string>(extractReads(src, 'query'));
   for (const m of src.matchAll(/searchParams\.get\(\s*['"]([^'"]+)['"]\s*\)/g)) names.add(m[1]);
-  for (const m of src.matchAll(/\breq\.query\s*\??\.\s*([A-Za-z][A-Za-z0-9_]*)/g)) names.add(m[1]);
-  for (const m of src.matchAll(/\breq\.query\s*(?:\?\.)?\[\s*['"]([^'"]+)['"]\s*\]/g))
-    names.add(m[1]);
-  return [...names].filter((n) => !(n in NON_CREDENTIAL_READS));
+  return [...names].filter((n) => !isExempt(NON_CREDENTIAL_QUERY, n));
 }
 
+/** Cookie-name HELPERS invoked in a `req.cookies[...]` read on the session path. */
+function extractCookieHelpers(src: string): string[] {
+  const names = new Set<string>();
+  for (const m of src.matchAll(/req\.cookies\s*\??\.?\[\s*([A-Za-z_$][\w$]*)\s*\(/g))
+    names.add(m[1]);
+  return [...names].filter((n) => !isExempt(NON_CREDENTIAL_COOKIE_HELPERS, n));
+}
+
+/** Local (relative) modules a source file imports, as repo-relative paths. */
+function localImports(rel: string): string[] {
+  const src = readSource(rel);
+  const dir = resolve(SRC, rel, '..');
+  const out = new Set<string>();
+  for (const m of src.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+    const abs = resolve(dir, m[1]);
+    for (const cand of [`${abs}.ts`, `${abs}.tsx`, `${abs}/index.ts`]) {
+      if (existsSync(cand)) {
+        out.add(cand.slice(SRC.length + 1));
+        break;
+      }
+    }
+  }
+  return [...out];
+}
+
+/**
+ * A request carrying `name`, in the shape Next hands an API route.
+ *
+ * Axis-aware deliberately: `cookie` is a real header the predicate parses, and
+ * `'synthetic-value'` is not a parseable cookie pair — a naive fixture made a
+ * legitimate `req.headers.cookie` read look UNRECOGNISED and pointed the reader
+ * at exempting the whole raw-Cookie axis.
+ */
 function reqWithHeader(name: string): NextApiRequest {
+  const value =
+    name.toLowerCase() === 'cookie' ? `${sessionCookieName()}=synthetic` : 'synthetic-value';
   return {
-    headers: { [name]: 'synthetic-value' },
+    headers: { [name]: value },
     cookies: {},
     query: {},
     url: '/api/v1/x',
@@ -131,111 +225,167 @@ function reqWithQuery(name: string): NextApiRequest {
   } as unknown as NextApiRequest;
 }
 
-describe('credential detection is a superset of the session layer', () => {
-  // ── Controls on the EXTRACTOR itself ───────────────────────────────────────
-  // Without these, a broken regex yields an empty set and every assertion below
-  // passes vacuously — the guard would be inert and read as coverage.
+function reqWithCookie(name: string): NextApiRequest {
+  return {
+    headers: {},
+    cookies: { [name]: 'synthetic-value' },
+    query: {},
+    url: '/api/v1/x',
+  } as unknown as NextApiRequest;
+}
 
-  it('the session-path sources are readable and non-trivial', () => {
+describe('credential detection is a superset of the session layer', () => {
+  // ── Controls on the DERIVATION ─────────────────────────────────────────────
+  // Without these a broken parse yields an empty set and everything below passes
+  // vacuously — a guard that reads as coverage while providing none.
+
+  it('the session-path sources are readable, listed and non-trivial', () => {
     const src = sessionPathSource();
     expect(src.length).toBeGreaterThan(2_000);
-    // The entry point must be in the scanned set, or the extraction is blind.
     expect(src).toContain('getServerAuthSession');
+    for (const f of SESSION_PATH_FILES)
+      expect(existsSync(resolve(SRC, f)), `${f} is listed but does not exist`).toBe(true);
   });
 
-  it('the extractor finds the credential spellings we KNOW exist', () => {
-    // Positive control. `authorization` and `token` are read by
-    // getServerAuthSession today; an extractor that cannot see them cannot see
-    // a new one either.
+  it('finds the credential spellings we KNOW exist', () => {
     const src = sessionPathSource();
-    expect(extractHeaderReads(src)).toContain('authorization');
+    expect(extractReads(src, 'headers')).toContain('authorization');
     expect(extractQueryReads(src)).toContain('token');
+    expect(extractCookieHelpers(src).sort()).toEqual(
+      ['legacySessionCookieName', 'sessionCookieName'].sort()
+    );
   });
 
-  it('the extractor sees BRACKET access, not just dot access', () => {
-    // Regression control. Hyphenated header names cannot be read with dot
-    // access, so bracket access is the ONLY spelling available for them — and a
-    // dot-only extractor is blind to exactly the names most likely to be added.
-    // A mutation adding `req.headers['x-api-key']` to the session path survived
-    // the first version of this guard.
-    const bracket = "const t = req.headers['x-api-key'];";
-    expect(extractHeaderReads(bracket)).toContain('x-api-key');
-    const optional = "const t = req.headers?.['x-forwarded-user'];";
-    expect(extractHeaderReads(optional)).toContain('x-forwarded-user');
-    const q = "const t = req.query['api_key'];";
-    expect(extractQueryReads(q)).toContain('api_key');
+  it('sees every notation it claims to', () => {
+    // Each of these SURVIVED an earlier version; all are now pinned.
+    expect(extractReads("const t = req.headers['x-api-key'];", 'headers')).toContain('x-api-key');
+    expect(extractReads("const t = req.headers?.['x-fwd'];", 'headers')).toContain('x-fwd');
+    expect(extractReads("const H = 'x-alias';\nconst t = req.headers[H];", 'headers')).toContain(
+      'x-alias'
+    );
+    expect(extractReads('const { authorization } = req.headers;', 'headers')).toContain(
+      'authorization'
+    );
+    expect(extractReads("const { 'x-api-key': k } = req.headers;", 'headers')).toContain(
+      'x-api-key'
+    );
+    expect(extractQueryReads("const t = req.query['api_key'];")).toContain('api_key');
   });
 
-  it('the extractor ignores comments (a commented-out read is not a read)', () => {
-    const withComment = `
-      // req.headers.x-made-up-credential
-      const a = req.headers.authorization;
-    `;
-    const found = extractHeaderReads(stripSourceComments(withComment));
-    expect(found).toContain('authorization');
-    expect(found).not.toContain('x-made-up-credential');
+  it('FAILS CLOSED on a bracket read it cannot resolve', () => {
+    const found = extractReads('const t = req.headers[computeName()];', 'headers');
+    const sentinel = found.find((n) => n.startsWith('<unresolvable:'));
+    expect(sentinel, 'an unresolvable read must surface, not vanish').toBeDefined();
+    // And the sentinel is not something the predicate accepts, so it fails the
+    // relationship assertion rather than passing quietly.
+    expect(requestCarriesCallerCredentials(reqWithHeader(sentinel as string))).toBe(false);
+  });
+
+  it('ignores commented-out reads — and this control is not vacuous', () => {
+    // 🔴 BRACKET notation deliberately. An earlier version used a hyphenated name
+    // in DOT notation, which the dot pattern can never yield, so the assertion
+    // held even with comment-stripping replaced by the identity function — the
+    // one control protecting a real fail-open direction was decorative.
+    const src = [
+      "      // const a = req.headers['x-commented'];",
+      "      const b = req.headers['x-live'];",
+    ].join('\n');
+    const stripped = extractReads(stripSourceComments(src), 'headers');
+    expect(stripped).toContain('x-live');
+    expect(stripped).not.toContain('x-commented');
+    // Prove the fixture CAN express the failure: unstripped, it is found.
+    expect(extractReads(src, 'headers')).toContain('x-commented');
+  });
+
+  // ── Scope ──────────────────────────────────────────────────────────────────
+
+  it('scans every local module the session entry point imports', () => {
+    // Extracting bearer parsing into a helper file is an ordinary refactor, and
+    // it silently disarmed the previous version of this guard.
+    const unscanned = localImports(ENTRY).filter(
+      (f) => !SESSION_PATH_FILES.includes(f) && !isExempt(NON_CREDENTIAL_MODULES, f)
+    );
+    expect(
+      unscanned,
+      `${ENTRY} imports these local modules, which are neither scanned for credential reads ` +
+        `nor declared non-credential: [${unscanned.join(', ')}]. A credential read in one of ` +
+        `them is invisible here. Add it to SESSION_PATH_FILES, or to NON_CREDENTIAL_MODULES ` +
+        `with a reason.`
+    ).toEqual([]);
   });
 
   // ── The relationship ───────────────────────────────────────────────────────
 
   it('every HEADER the session path reads is recognised as a credential', () => {
-    const src = sessionPathSource();
-    const unrecognised = extractHeaderReads(src).filter(
+    const unrecognised = extractReads(sessionPathSource(), 'headers').filter(
       (h) => !requestCarriesCallerCredentials(reqWithHeader(h))
     );
     expect(
       unrecognised,
-      `the session layer reads these request headers, but requestCarriesCallerCredentials ` +
-        `does not treat them as credentials: [${unrecognised.join(
-          ', '
-        )}]. A request carrying one ` +
-        `would be classified ANONYMOUS and its per-caller body cached publicly. Either teach the ` +
-        `predicate the spelling, or declare it in NON_CREDENTIAL_READS with a reason.`
+      `the session layer reads these request headers, but requestCarriesCallerCredentials does ` +
+        `not treat them as credentials: [${unrecognised.join(', ')}]. A request carrying one ` +
+        `would be classified ANONYMOUS and its per-caller body cached publicly. Teach the ` +
+        `predicate the spelling, or declare it in NON_CREDENTIAL_HEADERS with a reason — noting ` +
+        `that exempting a whole axis (e.g. 'cookie') hides future reads on it too.`
     ).toEqual([]);
   });
 
   it('every QUERY PARAM the session path reads is recognised as a credential', () => {
-    const src = sessionPathSource();
-    const unrecognised = extractQueryReads(src).filter(
+    const unrecognised = extractQueryReads(sessionPathSource()).filter(
       (q) => !requestCarriesCallerCredentials(reqWithQuery(q))
     );
     expect(
       unrecognised,
-      `the session layer reads these query parameters, but requestCarriesCallerCredentials ` +
-        `does not treat them as credentials: [${unrecognised.join(
-          ', '
-        )}]. See the header case above.`
+      `the session layer reads these query parameters, but requestCarriesCallerCredentials does ` +
+        `not treat them as credentials: [${unrecognised.join(', ')}].`
     ).toEqual([]);
   });
 
-  it('the COOKIE axis is shared-by-construction, not duplicated', () => {
-    // Cookies are the one axis that cannot drift, because both sides resolve
-    // names through the same helpers rather than each spelling them. Pinned so
-    // that if either side ever hardcodes a name, this fails and the cookie axis
-    // joins the extracted ones above.
-    const predicateSrc = stripSourceComments(
-      readFileSync(resolve(SRC, 'server/utils/endpoint-helpers.ts'), 'utf8')
-    );
-    const sessionSrc = sessionPathSource();
-    for (const helper of ['sessionCookieName', 'legacySessionCookieName']) {
-      expect(predicateSrc, `the predicate must derive cookie names via ${helper}()`).toContain(
-        `${helper}(`
-      );
-      expect(sessionSrc, `the session path must derive cookie names via ${helper}()`).toContain(
-        `${helper}(`
-      );
+  it('every COOKIE the session path authenticates with is recognised', () => {
+    // BEHAVIOURAL, not textual. The previous version asserted both files mention
+    // the same helper NAMES — which a decoy call elsewhere in a 700-line file
+    // satisfies while the real list is hardcoded. This calls each helper and asks
+    // the predicate about the cookie it actually names, so the two sides can only
+    // agree by agreeing.
+    const helpers: Record<string, (secure?: boolean) => string> = {
+      sessionCookieName,
+      legacySessionCookieName,
+    };
+    const used = extractCookieHelpers(sessionPathSource());
+
+    const unknown = used.filter((h) => !Object.prototype.hasOwnProperty.call(helpers, h));
+    expect(
+      unknown,
+      `the session path resolves cookie names with these helpers, which this guard cannot ` +
+        `evaluate: [${unknown.join(', ')}]. If one names a credential the predicate must ` +
+        `recognise it — add it to the map here, or to NON_CREDENTIAL_COOKIE_HELPERS with a reason.`
+    ).toEqual([]);
+
+    for (const name of used) {
+      // Both variants: the predicate registers secure and non-secure spellings,
+      // and a deploy's env decides which is live.
+      for (const secure of [true, false]) {
+        const cookie = helpers[name](secure);
+        expect(
+          requestCarriesCallerCredentials(reqWithCookie(cookie)),
+          `the session path authenticates with ${name}(${secure}) = "${cookie}", but the ` +
+            `predicate does not recognise it`
+        ).toBe(true);
+      }
     }
   });
 
-  // ── Negative control on the guard's own strictness ─────────────────────────
+  // ── Negative controls on the guard's own strictness ────────────────────────
 
-  it('does NOT demand that unrelated request fields be treated as credentials', () => {
-    // The predicate is deliberately narrow, and this guard must not quietly
-    // require it to widen to anything the session path happens to touch. If this
-    // fails, the extractor is over-matching and the assertions above are
-    // demanding more than the invariant does.
+  it('does NOT demand that unrelated request fields be credentials', () => {
     expect(requestCarriesCallerCredentials(reqWithHeader('accept-language'))).toBe(false);
     expect(requestCarriesCallerCredentials(reqWithQuery('limit'))).toBe(false);
-    expect(extractHeaderReads(sessionPathSource())).not.toContain('accept-language');
+    expect(requestCarriesCallerCredentials(reqWithCookie('theme'))).toBe(false);
+  });
+
+  it('exemption lookup does not fail open on prototype keys', () => {
+    expect(isExempt(NON_CREDENTIAL_HEADERS, 'constructor')).toBe(false);
+    expect(isExempt(NON_CREDENTIAL_HEADERS, 'valueOf')).toBe(false);
+    expect(isExempt(NON_CREDENTIAL_HEADERS, 'host')).toBe(true);
   });
 });

--- a/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
+++ b/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import fs from 'fs';
+import path from 'path';
 import { legacySessionCookieName, sessionCookieName } from '@civitai/auth';
 import type { NextApiRequest } from 'next';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
-import { stripSourceComments } from '~/components/AppBlocks/stripSourceComments';
 import { requestCarriesCallerCredentials } from '~/server/utils/endpoint-helpers';
 
 /**
@@ -20,66 +20,56 @@ import { requestCarriesCallerCredentials } from '~/server/utils/endpoint-helpers
  * Measured on production, same URL across arms: an anonymous request populates a
  * URL, and a later request carrying `Authorization` is served that cached entry
  * (`cf-cache-status: HIT`, still `public`). `Vary: Authorization` is INERT at our
- * CDN. A virgin URL requested first WITH a credential does correctly get
- * `private` + `BYPASS`, so the origin predicate works and that third arm is a
- * cache hit rather than a misclassification.
+ * CDN. A virgin URL requested first WITH a credential correctly gets `private` +
+ * `BYPASS`, so the origin predicate works and that third arm is a cache hit
+ * rather than a misclassification.
  *
- * The failure is therefore silent and specific: if the session layer learns a
- * credential spelling this predicate does not recognise, a request carrying it is
- * classified ANONYMOUS, gets `public, s-maxage`, and its per-caller body is cached
- * and served to other people. Nothing throws.
+ * So if the session layer learns a credential spelling the predicate does not
+ * recognise, a request carrying it is classified ANONYMOUS, gets
+ * `public, s-maxage`, and its per-caller body is cached and served to other
+ * people. Nothing throws.
  *
- * ── WHAT THIS CERTIFIES, AND WHAT IT DOES NOT ────────────────────────────────
- * 🔴 Read this before trusting a green run, and do not strengthen it without
- * re-measuring. Two successive adversarial sweeps found this file claiming more
- * than it did — first "handled by construction" (nine of fourteen mutants
- * survived), then a rewrite that introduced three fresh fail-opens of its own: a
- * destructuring pattern that anchored on the wrong brace and reported a
- * fabricated header name, a constant-resolution map shared across files so a
- * name collision made a real read VANISH, and a cookie axis with no fail-closed
- * path at all. Every claim below is mutation-verified; treat an unverified
- * addition to this list as false.
+ * ── WHY THIS USES THE TYPESCRIPT AST, AND NOT A REGEX ────────────────────────
+ * 🔴 Four successive adversarial sweeps rejected four regex-based versions of
+ * this file, and the failure was the same every time: a pattern fixes the shapes
+ * someone thought of and stays blind to the next ones. Measured casualties, each
+ * a real credential read on the real session file that left the suite fully
+ * green — a `const` alias; a destructured read; a computed key
+ * `{ ['x-api-secret']: s }`; a parenthesized right-hand side `= (req.headers ?? {})`;
+ * a read quarantined into a new module; a new cookie. Worse than the misses, two
+ * versions FABRICATED a header name — anchoring on an enclosing brace or on a
+ * type annotation's brace — and told the maintainer to exempt the fabrication,
+ * which would have gone green with the real read still invisible.
  *
- * CAUGHT:
- *   - a header or query param read by literal name, dot or bracket notation;
- *   - a header read via a `const NAME = 'literal'` alias in the SAME file;
- *   - a header read by DESTRUCTURING `req.headers`, renamed or not;
- *   - a cookie read by literal name, by a `const` alias, or via a name helper;
- *   - a bracket read whose name cannot be resolved — on ANY of the three axes,
- *     that FAILS rather than vanishing;
- *   - a credential-reading module added to the entry point's import graph,
- *     whether imported as `./x` or `~/server/x`;
- *   - the predicate narrowing on ANY SINGLE channel — `req.query` and `req.url`
- *     are probed independently, so two redundant branches cannot shield each
- *     other.
+ * The lesson is not "write a better regex". JavaScript is not a regular
+ * language, and every one of those defects is a parsing defect. The compiler
+ * already parses it correctly, this repo already uses its AST for exactly this
+ * kind of ledger (see `components/Apps/__tests__/appsStoreAccessCallSites.test.ts`),
+ * and doing so also deletes the comment-stripping axis entirely — the AST never
+ * sees a comment, so a commented-out read cannot be mistaken for a live one and
+ * no stripper can over- or under-strip.
  *
- * NOT CAUGHT: a name computed at runtime (a function return, a template, a
- * config value) — that surfaces as a sentinel FAILURE rather than passing, but
- * the guard cannot tell you the real name; and a credential read in a module
- * reached other than by a static import from the entry point (a dynamic
- * `import()`, or a transitive import two hops away).
+ * WHAT IT CERTIFIES. Every read of `req.headers` / `req.query` / `req.cookies`
+ * on the session path resolves to a name the predicate must recognise, or — when
+ * the name cannot be determined statically — to a sentinel that FAILS. That
+ * includes property access, element access with a literal or a resolvable
+ * `const`, destructuring in every form the parser accepts, and assignment of the
+ * whole bag to a variable (which hides later reads, so it fails closed).
+ *
+ * WHAT IT DOES NOT. A name computed at runtime surfaces as a sentinel failure,
+ * but the guard cannot tell you what it is. A credential read reached other than
+ * by a static import/export from the entry point is out of scope. And a
+ * structural check cannot prove the predicate is CORRECT — only that it is asked
+ * about every name the session path reads.
  */
 
-const SRC = resolve(__dirname, '../../..');
+const SRC = path.resolve(__dirname, '../../..');
 const ENTRY = 'server/auth/get-server-auth-session.ts';
 
-/**
- * The modules that turn a raw request into a session.
- *
- * A LEDGER, not a convenience list: the scope test derives the entry point's own
- * imports and fails when this set misses one, so a credential read cannot be
- * quarantined into a file the guard never reads.
- */
+/** Modules that turn a raw request into a session. A ledger, enforced below. */
 const SESSION_PATH_FILES = [ENTRY, 'server/auth/session-client.ts', 'server/auth/bearer-token.ts'];
 
-/**
- * Modules the entry point imports that do NOT read credentials off the request.
- * Fail-closed: anything else it imports must be scanned.
- *
- * Keep this HONEST — an entry that no longer matches a real import is dead, and
- * a dead exemption is evidence the derivation's output was never read. The scope
- * test asserts the derivation is non-empty for exactly that reason.
- */
+/** Entry-point imports that do NOT read credentials off the request. */
 const NON_CREDENTIAL_MODULES: Record<string, string> = {
   'server/auth/session-metrics.ts': 'counters only — takes no request',
   'server/utils/url-helpers.ts': 'builds a base URL from config; reads nothing off the request',
@@ -87,184 +77,180 @@ const NON_CREDENTIAL_MODULES: Record<string, string> = {
   'env/other.ts': 'environment config; reads nothing off the request',
 };
 
-/**
- * Workspace packages the entry point imports. Not scanned (they are whole
- * packages), so each must be declared with a reason — fail-closed, like modules.
- */
+/** Workspace packages the entry point imports. Not scanned, so declared. */
 const NON_CREDENTIAL_PACKAGES: Record<string, string> = {
   '@civitai/auth':
-    'owns the cookie-NAME vocabulary (sessionCookieName / legacySessionCookieName) and the legacy cookie decode; no `req` crosses this boundary — the session path reads req.cookies itself and passes only a string',
+    'owns the cookie-NAME vocabulary and the legacy cookie decode; no `req` crosses this boundary — the session path reads req.cookies itself and passes only a string',
 };
 
-/** Request HEADER reads on the session path that are not credentials. */
 const NON_CREDENTIAL_HEADERS: Record<string, string> = {
   host: 'response-side only — the cookie domain for maybeRollHubCookie / maybeUpgradeLegacySession, never read to identify a caller',
 };
-
-/** QUERY reads on the session path that are not credentials. */
 const NON_CREDENTIAL_QUERY: Record<string, string> = {};
-
-/** COOKIE names/helpers on the session path that do not name a credential. */
 const NON_CREDENTIAL_COOKIES: Record<string, string> = {
   deviceCookieName:
     'a device identifier used for rolling/upgrade bookkeeping; authenticates nobody on its own',
 };
 
-/** Marker for a read whose name this parse could not determine. */
 const UNRESOLVABLE = '<unresolvable>';
 const isUnresolvable = (n: string) => n.startsWith(UNRESOLVABLE);
 
-/**
- * `in` fails open on prototype keys (`constructor`, `valueOf`, `toString`).
- *
- * Also refuses to exempt a sentinel: an unresolvable read must be made
- * resolvable, never silenced by keying an exemption on the source text that
- * happened to produce it (rename the variable and the failure returns).
- */
+/** `in` fails open on prototype keys; a sentinel may never be exempted. */
 function isExempt(list: Record<string, string>, name: string): boolean {
   if (isUnresolvable(name)) return false;
   return Object.prototype.hasOwnProperty.call(list, name);
 }
 
-function readSource(rel: string): string {
-  return stripSourceComments(readFileSync(resolve(SRC, rel), 'utf8'));
+type Bag = 'headers' | 'query' | 'cookies';
+
+function parse(rel: string): ts.SourceFile {
+  const file = path.resolve(SRC, rel);
+  return ts.createSourceFile(file, fs.readFileSync(file, 'utf8'), ts.ScriptTarget.Latest, true);
 }
 
-/** Each scanned file separately — extraction is PER FILE, never over a join. */
-function sessionPathSources(): { rel: string; src: string }[] {
-  return SESSION_PATH_FILES.map((rel) => ({ rel, src: readSource(rel) }));
+/** Strip parens / `as X` / `!` / `satisfies` so `(req.headers as any)!` is seen. */
+function unwrap(node: ts.Expression): ts.Expression {
+  let n = node;
+  for (;;) {
+    if (ts.isParenthesizedExpression(n)) n = n.expression;
+    else if (ts.isAsExpression(n) || ts.isSatisfiesExpression(n)) n = n.expression;
+    else if (ts.isNonNullExpression(n)) n = n.expression;
+    else break;
+  }
+  return n;
 }
 
 /**
- * `const NAME = 'literal'` within ONE file.
+ * Is this expression `req.<bag>`, however parenthesised, asserted or defaulted?
  *
- * 🔴 Per-file, and a name declared twice with different values resolves to
- * NOTHING rather than to one of them. A single map over the concatenated
- * sources let a `const CRED = 'host'` in one file resolve a `req.headers[CRED]`
- * in another onto the exempt `host`, so a real credential read vanished with no
- * sentinel — strictly worse than being unresolvable.
+ * `?? {}` is included deliberately: `= (req.headers ?? {})` is still a read of
+ * the bag, and a regex version that did not see through it shipped a live
+ * unrecognised credential header green.
  */
-function literalConsts(src: string): Map<string, string> {
+function isBag(node: ts.Expression, bag: Bag): boolean {
+  const n = unwrap(node);
+  if (
+    ts.isBinaryExpression(n) &&
+    (n.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+      n.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+  ) {
+    return isBag(n.left, bag);
+  }
+  if (!ts.isPropertyAccessExpression(n) && !ts.isPropertyAccessChain(n)) return false;
+  const obj = unwrap(n.expression as ts.Expression);
+  return ts.isIdentifier(obj) && obj.text === 'req' && n.name.text === bag;
+}
+
+/** `const NAME = 'literal'` in one file; a conflicting redeclaration resolves to nothing. */
+function literalConsts(sf: ts.SourceFile): Map<string, string> {
   const seen = new Map<string, string>();
   const conflicted = new Set<string>();
-  for (const m of src.matchAll(
-    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*['"]([^'"]+)['"]/g
-  )) {
-    const [, name, value] = m;
-    if (seen.has(name) && seen.get(name) !== value) conflicted.add(name);
-    seen.set(name, value);
-  }
+  const visit = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const init = unwrap(node.initializer);
+      if (ts.isStringLiteralLike(init)) {
+        const prev = seen.get(node.name.text);
+        if (prev !== undefined && prev !== init.text) conflicted.add(node.name.text);
+        seen.set(node.name.text, init.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
   for (const n of conflicted) seen.delete(n);
   return seen;
 }
 
-/** Split a destructuring pattern on TOP-LEVEL commas (nested braces intact). */
-function splitTopLevel(inner: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let cur = '';
-  for (const ch of inner) {
-    if (ch === '{' || ch === '[' || ch === '(') depth++;
-    else if (ch === '}' || ch === ']' || ch === ')') depth--;
-    if (ch === ',' && depth === 0) {
-      parts.push(cur);
-      cur = '';
-      continue;
-    }
-    cur += ch;
+/** A property NAME from a binding element / element access, or a sentinel. */
+function nameOf(node: ts.Node | undefined, consts: Map<string, string>, bag?: Bag): string {
+  if (!node) return `${UNRESOLVABLE}:missing`;
+  if (ts.isStringLiteralLike(node) || ts.isNumericLiteral(node)) return node.text;
+  if (ts.isIdentifier(node)) return node.text;
+  if (ts.isComputedPropertyName(node)) return nameOfExpr(node.expression, consts, bag);
+  return `${UNRESOLVABLE}:${node.getText().slice(0, 40)}`;
+}
+
+function nameOfExpr(expr: ts.Expression, consts: Map<string, string>, bag?: Bag): string {
+  const e = unwrap(expr);
+  if (ts.isStringLiteralLike(e) || ts.isNumericLiteral(e)) return e.text;
+  if (ts.isIdentifier(e)) {
+    const resolved = consts.get(e.text);
+    return resolved ?? `${UNRESOLVABLE}:${e.text}`;
   }
-  if (cur.trim()) parts.push(cur);
-  return parts;
+  // COOKIES only: names come from helpers (`sessionCookieName()`), and the
+  // cookie test can EVALUATE a known one. There is no such convention on
+  // headers/query, so a call there stays unresolvable.
+  if (bag === 'cookies' && ts.isCallExpression(e) && ts.isIdentifier(e.expression))
+    return e.expression.text;
+  return `${UNRESOLVABLE}:${e.getText().slice(0, 40)}`;
 }
 
-/** Classify one bracket-expression body into a name, or a sentinel. */
-function classifyBracket(inner: string, consts: Map<string, string>): string {
-  const t = inner.trim();
-  const literal = t.match(/^['"]([^'"]+)['"]$/);
-  if (literal) return literal[1];
-  const ident = t.match(/^[A-Za-z_$][\w$]*$/);
-  const resolved = ident ? consts.get(t) : undefined;
-  return resolved ?? `${UNRESOLVABLE}:${t}`;
-}
-
-/** Names read off `req.<bag>` in ONE file, by any spelling this parse can see. */
-function extractReadsIn(
-  src: string,
-  bag: 'headers' | 'query' | 'cookies',
-  opts: { applyExemptions?: boolean } = {}
-): string[] {
+/**
+ * Every name read off `req.<bag>` in one source file.
+ *
+ * Fails CLOSED twice over: an undeterminable name becomes a sentinel, and
+ * assigning the WHOLE bag to something becomes a sentinel too, because every
+ * later read through that alias is invisible to any static analysis.
+ */
+function extractReadsFrom(sf: ts.SourceFile, bag: Bag, applyExemptions = true): string[] {
+  const consts = literalConsts(sf);
   const names = new Set<string>();
-  const consts = literalConsts(src);
-  const B = `req\\.${bag}`;
 
-  // req.x.name / req.x?.name
-  for (const m of src.matchAll(new RegExp(`\\b${B}\\s*\\??\\.\\s*([A-Za-z_$][\\w$]*)`, 'g')))
-    names.add(m[1]);
+  const visit = (node: ts.Node) => {
+    // req.headers.authorization
+    if (
+      (ts.isPropertyAccessExpression(node) || ts.isPropertyAccessChain(node)) &&
+      isBag(node.expression as ts.Expression, bag)
+    ) {
+      names.add(node.name.text);
+    }
 
-  // req.x[<anything>] — the WHOLE expression, then classified. Matching only
-  // understood shapes means anything else vanishes, and a read the guard cannot
-  // see is exactly the one that gets through.
-  for (const m of src.matchAll(new RegExp(`\\b${B}\\s*(?:\\?\\.)?\\[([^\\]]+)\\]`, 'g'))) {
-    const inner = m[1].trim();
-    // A COOKIE name may be produced by a name helper, and the cookie test can
-    // evaluate one — so record the helper. On headers/query there is no such
-    // convention, so a call is simply a name we cannot determine: it must become
-    // a sentinel, not be mistaken for the callee's identifier.
-    const call = bag === 'cookies' ? inner.match(/^([A-Za-z_$][\w$]*)\s*\(/) : null;
-    names.add(call ? call[1] : classifyBracket(inner, consts));
-  }
+    // req.headers['x'] / req.headers[K] / req.headers[f()]
+    if (
+      (ts.isElementAccessExpression(node) || ts.isElementAccessChain(node)) &&
+      isBag(node.expression as ts.Expression, bag)
+    ) {
+      names.add(nameOfExpr(node.argumentExpression, consts, bag));
+    }
 
-  // Destructuring, via a balanced-brace scan backwards from `= req.<bag>`.
-  //
-  // 🔴 A regex cannot do this. `\{([^}]*)\}` anchored on the enclosing FUNCTION
-  // BODY brace and reported a fabricated name; anchoring on the declaration
-  // keyword fixed that and silently dropped the keyword-less assignment form.
-  // And every shape a flat pattern cannot express — a type annotation on the
-  // left, a default containing braces, a nested pattern — was failing OPEN,
-  // while the bracket axis beside it failed closed. Scan, and emit a sentinel
-  // for anything unparseable.
-  // The negative lookahead is load-bearing: `= req.cookies?.[helper()]` is an
-  // ordinary READ, not an alias. Without it every such read was misread as the
-  // bag escaping and produced a false sentinel on the real source.
-  for (const m of src.matchAll(new RegExp(`=\\s*${B}\\s*(?![.?\\[])`, 'g'))) {
-    const before = src.slice(0, m.index ?? 0).trimEnd();
-    const lastBrace = before.lastIndexOf('}');
-    const tail = lastBrace >= 0 ? before.slice(lastBrace + 1).trim() : null;
-    // Allow a type annotation between the pattern and the `=`.
-    const isPattern = tail !== null && (tail === '' || /^:[^=]*$/.test(tail));
-    if (!isPattern) {
-      // `const h = req.headers` — the bag ESCAPES into a variable and every
-      // later read through it is invisible. Fail closed rather than pretend.
+    // const { a, 'b-c': d, [K]: e } = req.headers   (and the assignment form)
+    const bound = (target: ts.Node, source: ts.Expression) => {
+      if (!isBag(source, bag)) return;
+      if (ts.isObjectBindingPattern(target)) {
+        for (const el of target.elements) {
+          if (el.dotDotDotToken) continue; // a rest element names nothing specific
+          names.add(nameOf(el.propertyName ?? el.name, consts, bag));
+        }
+        return;
+      }
+      if (ts.isObjectLiteralExpression(target)) {
+        // `({ 'x': c } = req.headers)` parses the LHS as an object literal.
+        for (const p of target.properties) {
+          if (ts.isShorthandPropertyAssignment(p)) names.add(p.name.text);
+          else if (ts.isPropertyAssignment(p)) names.add(nameOf(p.name, consts, bag));
+          else if (ts.isSpreadAssignment(p)) continue;
+          else names.add(`${UNRESOLVABLE}:${p.getText().slice(0, 40)}`);
+        }
+        return;
+      }
+      // `const h = req.headers` — the bag ESCAPES; later reads are invisible.
       names.add(`${UNRESOLVABLE}:aliased-${bag}`);
-      continue;
-    }
-    let depth = 0;
-    let i = lastBrace;
-    for (; i >= 0; i--) {
-      if (before[i] === '}') depth++;
-      else if (before[i] === '{') {
-        depth--;
-        if (depth === 0) break;
-      }
-    }
-    if (i < 0) {
-      names.add(`${UNRESOLVABLE}:unbalanced-pattern`);
-      continue;
-    }
-    for (const part of splitTopLevel(before.slice(i + 1, lastBrace))) {
-      const t = part.trim();
-      if (!t || t.startsWith('...')) continue;
-      const quoted = t.match(/^['"]([^'"]+)['"]\s*:/);
-      if (quoted) {
-        names.add(quoted[1]);
-        continue;
-      }
-      const bare = t.match(/^([A-Za-z_$][\w$]*)/);
-      if (bare) names.add(bare[1]);
-    }
-  }
+    };
 
-  if (opts.applyExemptions === false) return [...names];
+    if (ts.isVariableDeclaration(node) && node.initializer) bound(node.name, node.initializer);
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isBag(node.right, bag)
+    ) {
+      bound(unwrap(node.left as ts.Expression), node.right);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+
+  if (!applyExemptions) return [...names];
   const exempt =
     bag === 'headers'
       ? NON_CREDENTIAL_HEADERS
@@ -274,71 +260,81 @@ function extractReadsIn(
   return [...names].filter((n) => !isExempt(exempt, n));
 }
 
-/** Every name the session path reads on `bag`, BEFORE exemptions are applied. */
-function extractReadsRaw(bag: 'headers' | 'query' | 'cookies'): string[] {
-  const out = new Set<string>();
-  for (const { src } of sessionPathSources())
-    for (const n of extractReadsIn(src, bag, { applyExemptions: false })) out.add(n);
-  return [...out];
-}
-
-/** Union across the scanned files, extracting each SEPARATELY. */
-function extractReads(bag: 'headers' | 'query' | 'cookies'): string[] {
-  const out = new Set<string>();
-  for (const { src } of sessionPathSources()) for (const n of extractReadsIn(src, bag)) out.add(n);
-  return [...out];
-}
-
 /** Query params also arrive via `new URL(...).searchParams.get('x')`. */
-function extractQueryReads(): string[] {
-  const out = new Set<string>(extractReads('query'));
-  for (const { src } of sessionPathSources())
-    for (const m of src.matchAll(/searchParams\.get\(\s*['"]([^'"]+)['"]\s*\)/g)) out.add(m[1]);
-  return [...out].filter((n) => !isExempt(NON_CREDENTIAL_QUERY, n));
+function searchParamReads(sf: ts.SourceFile, consts: Map<string, string>): string[] {
+  const out: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      (ts.isPropertyAccessExpression(node.expression) ||
+        ts.isPropertyAccessChain(node.expression)) &&
+      node.expression.name.text === 'get'
+    ) {
+      const recv = unwrap(node.expression.expression as ts.Expression);
+      const isSearchParams =
+        (ts.isPropertyAccessExpression(recv) || ts.isPropertyAccessChain(recv)) &&
+        recv.name.text === 'searchParams';
+      if (isSearchParams && node.arguments.length) out.push(nameOfExpr(node.arguments[0], consts));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+function extractReads(bag: Bag, applyExemptions = true): string[] {
+  const out = new Set<string>();
+  for (const rel of SESSION_PATH_FILES) {
+    const sf = parse(rel);
+    for (const n of extractReadsFrom(sf, bag, applyExemptions)) out.add(n);
+    if (bag === 'query')
+      for (const n of searchParamReads(sf, literalConsts(sf))) {
+        if (applyExemptions && isExempt(NON_CREDENTIAL_QUERY, n)) continue;
+        out.add(n);
+      }
+  }
+  return [...out];
 }
 
 /**
- * Modules a source file depends on: `import … from`, `export … from`, and
- * side-effect `import '…'`.
+ * Modules and workspace packages a source file depends on, from the AST.
  *
- * 🔴 `export … from` is a STATIC, EXECUTED dependency and belongs here. A
- * previous version matched a bare `from '…'`, caught it by accident, and a
- * narrowing to `import … from` silently dropped it — a re-export of a
- * credential-reading module became invisible. That regression was introduced by
- * the fix for the `~/` gap, which is the third time in this file's history that
- * a fix opened the next hole. Widen deliberately, and re-measure.
- *
- * Workspace packages (`@civitai/*`) are dependencies of this repo's own source,
- * NOT third-party — an earlier comment calling them "not our source" was simply
- * wrong. They are not scanned (they are whole packages), so they must be
- * declared in NON_CREDENTIAL_PACKAGES with a reason instead of ignored.
+ * 🔴 Split from `moduleImports` so it can be exercised DIRECTLY. The previous
+ * version's regression test re-implemented the parse on a fixture instead of
+ * calling the real function, so deleting `export … from` support from the real
+ * one left the suite green — the fix was real and nothing tested it. A scope
+ * ledger can only flag what it FINDS, so a detection gap is invisible to it by
+ * construction; the only way to cover one is to test the finder.
  */
-function moduleImports(rel: string): { local: string[]; packages: string[] } {
-  const src = readSource(rel);
-  const dir = resolve(SRC, rel, '..');
+function depsOf(sf: ts.SourceFile, dir: string): { local: string[]; packages: string[] } {
   const local = new Set<string>();
   const packages = new Set<string>();
 
-  const specs: string[] = [];
-  // import/export … from '…' — `type` forms carry no runtime read.
-  for (const m of src.matchAll(/\b(?:import|export)\s+(?!type\s)[^;]*?from\s+['"]([^'"]+)['"]/g))
-    specs.push(m[1]);
-  // side-effect: import '…'
-  for (const m of src.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)) specs.push(m[1]);
+  for (const st of sf.statements) {
+    let spec: string | undefined;
+    let typeOnly = false;
+    if (ts.isImportDeclaration(st)) {
+      spec = ts.isStringLiteral(st.moduleSpecifier) ? st.moduleSpecifier.text : undefined;
+      typeOnly = !!st.importClause?.isTypeOnly;
+    } else if (ts.isExportDeclaration(st) && st.moduleSpecifier) {
+      // `export … from '…'` is a static, executed dependency.
+      spec = ts.isStringLiteral(st.moduleSpecifier) ? st.moduleSpecifier.text : undefined;
+      typeOnly = st.isTypeOnly;
+    }
+    if (!spec || typeOnly) continue;
 
-  for (const spec of specs) {
     if (spec.startsWith('@civitai/')) {
       packages.add(spec);
       continue;
     }
     const abs = spec.startsWith('~/')
-      ? resolve(SRC, spec.slice(2))
+      ? path.resolve(SRC, spec.slice(2))
       : spec.startsWith('.')
-      ? resolve(dir, spec)
+      ? path.resolve(dir, spec)
       : null;
-    if (!abs) continue; // genuine third-party
+    if (!abs) continue;
     for (const cand of [`${abs}.ts`, `${abs}.tsx`, `${abs}/index.ts`]) {
-      if (existsSync(cand)) {
+      if (fs.existsSync(cand)) {
         local.add(cand.slice(SRC.length + 1));
         break;
       }
@@ -347,14 +343,16 @@ function moduleImports(rel: string): { local: string[]; packages: string[] } {
   return { local: [...local], packages: [...packages] };
 }
 
-/**
- * A request carrying `name`, in the shape Next hands an API route.
- *
- * Axis-aware: `cookie` is a real header the predicate parses, and
- * `'synthetic-value'` is not a parseable cookie pair — a naive fixture made a
- * legitimate `req.headers.cookie` read look UNRECOGNISED and steered the reader
- * toward exempting the whole raw-Cookie axis.
- */
+function moduleImports(rel: string): { local: string[]; packages: string[] } {
+  return depsOf(parse(rel), path.resolve(SRC, rel, '..'));
+}
+
+/** Parse a snippet the same way the real files are parsed (for the unit cases). */
+function readsIn(code: string, bag: Bag): string[] {
+  const sf = ts.createSourceFile('snippet.ts', code, ts.ScriptTarget.Latest, true);
+  return extractReadsFrom(sf, bag);
+}
+
 function reqWithHeader(name: string): NextApiRequest {
   const value =
     name.toLowerCase() === 'cookie' ? `${sessionCookieName()}=synthetic` : 'synthetic-value';
@@ -365,15 +363,6 @@ function reqWithHeader(name: string): NextApiRequest {
     url: '/api/v1/x',
   } as unknown as NextApiRequest;
 }
-
-/**
- * Query fixtures, ONE CHANNEL EACH.
- *
- * 🔴 A fixture populating both `req.query` and `req.url` lets the predicate's
- * two query branches shield each other: dropping either one alone stayed green,
- * and only removing BOTH went red. A guard that cannot see a single-branch
- * narrowing is not guarding the branch.
- */
 function reqWithQueryOnly(name: string): NextApiRequest {
   return {
     headers: {},
@@ -382,10 +371,7 @@ function reqWithQueryOnly(name: string): NextApiRequest {
     url: '/api/v1/x',
   } as unknown as NextApiRequest;
 }
-
 function reqWithUrlQueryOnly(name: string): NextApiRequest {
-  // Encoded: a sentinel is raw source text and could otherwise inject query
-  // structure (`…&token=1`) and be blessed by the predicate.
   return {
     headers: {},
     cookies: {},
@@ -393,7 +379,6 @@ function reqWithUrlQueryOnly(name: string): NextApiRequest {
     url: `/api/v1/x?${encodeURIComponent(name)}=synthetic-value`,
   } as unknown as NextApiRequest;
 }
-
 function reqWithCookie(name: string): NextApiRequest {
   return {
     headers: {},
@@ -403,303 +388,229 @@ function reqWithCookie(name: string): NextApiRequest {
   } as unknown as NextApiRequest;
 }
 
-/** Cookie-name helpers this guard can evaluate. */
 const COOKIE_HELPERS: Record<string, (secure?: boolean) => string> = {
   sessionCookieName,
   legacySessionCookieName,
 };
 
 describe('credential detection is a superset of the session layer', () => {
-  // ── Controls on the DERIVATION ─────────────────────────────────────────────
-  // Without these a broken parse yields an empty set and everything below passes
-  // vacuously — a guard that reads as coverage while providing none.
+  // ── Controls on the derivation ─────────────────────────────────────────────
 
-  it('every listed session-path file exists and is non-trivial', () => {
-    // Existence FIRST: sessionPathSources() would throw ENOENT before a later
-    // existence assertion could produce its own message.
-    for (const f of SESSION_PATH_FILES)
-      expect(existsSync(resolve(SRC, f)), `${f} is listed but does not exist`).toBe(true);
-    const joined = sessionPathSources()
-      .map((f) => f.src)
-      .join('\n');
-    expect(joined.length).toBeGreaterThan(2_000);
-    expect(joined).toContain('getServerAuthSession');
+  it('every listed session-path file exists and parses', () => {
+    for (const rel of SESSION_PATH_FILES) {
+      expect(fs.existsSync(path.resolve(SRC, rel)), `${rel} is listed but does not exist`).toBe(
+        true
+      );
+      const sf = parse(rel);
+      expect(sf.statements.length, `${rel} parsed to nothing`).toBeGreaterThan(0);
+    }
   });
 
   it('finds the credential spellings we KNOW exist', () => {
     expect(extractReads('headers')).toContain('authorization');
-    expect(extractQueryReads()).toContain('token');
+    expect(extractReads('query')).toContain('token');
     expect(extractReads('cookies').sort()).toEqual(
       ['legacySessionCookieName', 'sessionCookieName'].sort()
     );
   });
 
-  it('the import derivation is not empty (positive control)', () => {
-    // Gutting moduleImports to return [] left the scope test green — every other
-    // derivation here had a positive control and that one did not.
+  it('the import derivation is not empty, and reaches re-exports', () => {
     const { local } = moduleImports(ENTRY);
     expect(local).toContain('server/auth/bearer-token.ts');
     expect(local).toContain('server/auth/session-client.ts');
   });
 
-  it('sees every notation it claims to', () => {
-    // Each of these survived some earlier version of this file.
-    expect(extractReadsIn("const t = req.headers['x-api-key'];", 'headers')).toContain('x-api-key');
-    expect(extractReadsIn("const t = req.headers?.['x-fwd'];", 'headers')).toContain('x-fwd');
-    expect(extractReadsIn("const H = 'x-alias';\nconst t = req.headers[H];", 'headers')).toContain(
+  it('the dependency finder sees import, export-from and side-effect forms', () => {
+    // Exercises depsOf ITSELF — not a re-implementation. `export … from` is a
+    // static, executed dependency: a re-exported credential-reading module is
+    // as reachable as an imported one, and a previous version silently stopped
+    // seeing it.
+    const dir = path.resolve(SRC, 'server/auth');
+    const sf = ts.createSourceFile(
+      'synthetic.ts',
+      [
+        "export { x } from './bearer-token';",
+        "import './session-metrics';",
+        "import { y } from '~/server/auth/session-client';",
+        "import type { T } from './session-metrics';",
+        "import { z } from '@civitai/auth';",
+      ].join('\n'),
+      ts.ScriptTarget.Latest,
+      true
+    );
+    const { local, packages } = depsOf(sf, dir);
+    expect(local, 'export … from must be a dependency').toContain('server/auth/bearer-token.ts');
+    expect(local, 'a side-effect import must be a dependency').toContain(
+      'server/auth/session-metrics.ts'
+    );
+    expect(local, '~/ specifiers must resolve').toContain('server/auth/session-client.ts');
+    expect(packages, 'workspace packages must be surfaced').toContain('@civitai/auth');
+  });
+
+  it('parses every read shape, including the ones four regexes missed', () => {
+    // Each line below was a measured fail-open or fabrication in some earlier
+    // regex version of this file.
+    expect(readsIn("const t = req.headers['x-api-key'];", 'headers')).toContain('x-api-key');
+    expect(readsIn("const t = req.headers?.['x-fwd'];", 'headers')).toContain('x-fwd');
+    expect(readsIn("const H = 'x-alias';\nconst t = req.headers[H];", 'headers')).toContain(
       'x-alias'
     );
-    expect(extractReadsIn("const t = req.cookies?.['civ-alt'];", 'cookies')).toContain('civ-alt');
-    expect(
-      extractReadsIn("const C = 'civ-alt2';\nconst t = req.cookies?.[C];", 'cookies')
-    ).toContain('civ-alt2');
-    expect(extractReadsIn("const t = req.query['api_key'];", 'query')).toContain('api_key');
+    expect(readsIn('const { authorization } = req.headers;', 'headers')).toContain('authorization');
+    expect(readsIn("const { 'x-a': c }: any = req.headers;", 'headers')).toContain('x-a');
+    expect(readsIn("const { 'x-b': c = {} } = req.headers;", 'headers')).toContain('x-b');
+    expect(readsIn("const { 'x-c': { d } } = req.headers as any;", 'headers')).toContain('x-c');
+    expect(readsIn("({ 'x-d': c } = req.headers as any);", 'headers')).toContain('x-d');
+    // Computed key and parenthesized RHS — both shipped GREEN in the last version.
+    expect(readsIn("const { ['x-e']: s } = req.headers;", 'headers')).toContain('x-e');
+    expect(readsIn("const { 'x-f': s } = (req.headers ?? {}) as any;", 'headers')).toContain('x-f');
+    expect(readsIn("const t = (req.headers ?? {})['x-h'];", 'headers')).toContain('x-h');
+    // A type annotation that is an object literal — the shape that FABRICATED a
+    // header name and advised exempting it.
+    const ann = readsIn("const { 'x-g': c }: { other?: string } = req.headers;", 'headers');
+    expect(ann).toContain('x-g');
+    expect(ann).not.toContain('other');
+    expect(readsIn('const t = req.query?._apitoken;', 'query')).toContain('_apitoken');
+    expect(readsIn("const t = req.cookies?.['civ-alt'];", 'cookies')).toContain('civ-alt');
   });
 
-  it('parses destructuring from the DECLARATION, not the enclosing brace', () => {
-    // 🔴 The regression that mattered most. With the pattern early in a function
-    // body, an unanchored `\{([^}]*)\}` matched from the body brace and yielded
-    // the body's leading tokens while MISSING the real name — then advised
-    // exempting the fabricated one.
-    const inBody = [
-      'async function f(req) {',
-      '  if (req.context) return null;',
-      "  const { 'x-real-cred': c } = req.headers;",
-      '  return c;',
-      '}',
+  it('a comment is never a read (no stripper needed — the AST has none)', () => {
+    const src = [
+      "// const a = req.headers['x-commented'];",
+      "const b = req.headers['x-live'];",
     ].join('\n');
-    const found = extractReadsIn(inBody, 'headers');
-    expect(found).toContain('x-real-cred');
-    expect(found).not.toContain('if');
-    expect(extractReadsIn('const { authorization } = req.headers;', 'headers')).toContain(
-      'authorization'
-    );
-    // A rest element names no specific header.
-    expect(extractReadsIn('const { ...rest } = req.headers;', 'headers')).not.toContain('...rest');
+    const found = readsIn(src, 'headers');
+    expect(found).toContain('x-live');
+    expect(found).not.toContain('x-commented');
   });
 
-  it('FAILS CLOSED on an unresolvable read, on every axis', () => {
-    // headers/query: a call is a name we cannot determine -> sentinel.
+  it('FAILS CLOSED on an undeterminable name, and on an aliased bag', () => {
     for (const bag of ['headers', 'query'] as const) {
-      const found = extractReadsIn(`const t = req.${bag}[computeName()];`, bag);
       expect(
-        found.some(isUnresolvable),
-        `an unresolvable ${bag} read must surface, not vanish`
+        readsIn(`const t = req.${bag}[computeName()];`, bag).some(isUnresolvable),
+        `an unresolvable ${bag} read must surface`
       ).toBe(true);
     }
-    // cookies: a non-call expression is equally unresolvable.
+    // Cookies name themselves through helpers, so a CALL is recorded by callee
+    // name (the cookie test evaluates known ones and rejects unknown ones — see
+    // below). A non-call expression there is still unresolvable.
+    expect(readsIn('const t = req.cookies[opts.name];', 'cookies').some(isUnresolvable)).toBe(true);
     expect(
-      extractReadsIn('const t = req.cookies[opts.name];', 'cookies').some(isUnresolvable),
-      'an unresolvable cookie read must surface, not vanish'
+      readsIn('const { [dyn]: s } = req.headers;', 'headers').some(isUnresolvable),
+      'an unresolvable computed key must surface'
     ).toBe(true);
-    // A sentinel cannot be silenced through the exemption channel.
+    for (const alias of [
+      'const h = req.headers;',
+      'const h = req.headers ?? {};',
+      'const h = (req.headers as any)!;',
+    ]) {
+      expect(readsIn(alias, 'headers').some(isUnresolvable), `aliased: ${alias}`).toBe(true);
+    }
+    // An ordinary read is NOT an alias.
+    expect(
+      readsIn('const t = req.cookies?.[sessionCookieName()];', 'cookies').some(isUnresolvable)
+    ).toBe(false);
+    // A sentinel can never be silenced through an exemption map.
     expect(isExempt(NON_CREDENTIAL_HEADERS, `${UNRESOLVABLE}:k`)).toBe(false);
   });
 
   it('an UNKNOWN cookie helper is not silently accepted', () => {
-    // The cookies axis records a helper CALL by name rather than as a sentinel,
-    // because the cookie test can evaluate a known helper. The closure for an
-    // UNKNOWN one is that test: it falls through to being treated as a literal
-    // cookie name, which the predicate does not recognise, so the relationship
-    // assertion goes red. Pinned here so the two halves cannot drift apart.
-    const found = extractReadsIn('const t = req.cookies?.[mysteryCookieName()];', 'cookies');
+    // The closure for an unrecognised helper is the cookie relationship test: it
+    // falls through to being treated as a literal cookie name, which the
+    // predicate does not recognise, so that assertion goes red. Pinned here so
+    // the two halves cannot drift apart.
+    const found = readsIn('const t = req.cookies?.[mysteryCookieName()];', 'cookies');
     expect(found).toContain('mysteryCookieName');
     expect(Object.prototype.hasOwnProperty.call(COOKIE_HELPERS, 'mysteryCookieName')).toBe(false);
     expect(requestCarriesCallerCredentials(reqWithCookie('mysteryCookieName'))).toBe(false);
   });
 
   it('refuses to resolve a constant declared twice with different values', () => {
-    // Per-file scoping plus conflict-rejection: a colliding alias must become a
-    // sentinel, never silently resolve onto an exempt name like `host`.
-    const src = [
-      "const CRED = 'host';",
-      "const CRED = 'x-secret';",
-      'const t = req.headers[CRED];',
-    ].join('\n');
-    const found = extractReadsIn(src, 'headers');
+    const found = readsIn(
+      ["const CRED = 'host';", "const CRED = 'x-secret';", 'const t = req.headers[CRED];'].join(
+        '\n'
+      ),
+      'headers'
+    );
     expect(found.some(isUnresolvable)).toBe(true);
     expect(found).not.toContain('host');
   });
 
-  it('ignores commented-out reads — and this control is not vacuous', () => {
-    const src = [
-      "      // const a = req.headers['x-commented'];",
-      "      const b = req.headers['x-live'];",
-    ].join('\n');
-    const stripped = extractReadsIn(stripSourceComments(src), 'headers');
-    expect(stripped).toContain('x-live');
-    expect(stripped).not.toContain('x-commented');
-    // Prove the fixture CAN express the failure: unstripped, it is found.
-    expect(extractReadsIn(src, 'headers')).toContain('x-commented');
+  it('no exemption is STALE', () => {
+    const { local, packages } = moduleImports(ENTRY);
+    expect({
+      modules: Object.keys(NON_CREDENTIAL_MODULES).filter((k) => !local.includes(k)),
+      packages: Object.keys(NON_CREDENTIAL_PACKAGES).filter((k) => !packages.includes(k)),
+      headers: Object.keys(NON_CREDENTIAL_HEADERS).filter(
+        (k) => !extractReads('headers', false).includes(k)
+      ),
+      query: Object.keys(NON_CREDENTIAL_QUERY).filter(
+        (k) => !extractReads('query', false).includes(k)
+      ),
+      cookies: Object.keys(NON_CREDENTIAL_COOKIES).filter(
+        (k) => !extractReads('cookies', false).includes(k)
+      ),
+    }).toEqual({ modules: [], packages: [], headers: [], query: [], cookies: [] });
   });
 
   // ── Scope ──────────────────────────────────────────────────────────────────
 
-  it('scans every module the session entry point imports', () => {
-    // Both spellings: `~/server/…` is this repo's dominant style, and an earlier
-    // version resolved only `./…`, so the LIKELY refactor was the uncaught one.
+  it('scans every module and package the session entry point depends on', () => {
     const { local, packages } = moduleImports(ENTRY);
     const unscanned = local.filter(
       (f) => !SESSION_PATH_FILES.includes(f) && !isExempt(NON_CREDENTIAL_MODULES, f)
     );
-    const undeclaredPackages = packages.filter((q) => !isExempt(NON_CREDENTIAL_PACKAGES, q));
-    expect(
-      undeclaredPackages,
-      `${ENTRY} imports these workspace packages, which are not scanned and not declared: ` +
-        `[${undeclaredPackages.join(', ')}]. They are this repo's own source, not third-party — ` +
-        `declare each in NON_CREDENTIAL_PACKAGES with a reason.`
-    ).toEqual([]);
+    const undeclared = packages.filter((q) => !isExempt(NON_CREDENTIAL_PACKAGES, q));
     expect(
       unscanned,
-      `${ENTRY} imports these modules, which are neither scanned for credential reads nor ` +
-        `declared non-credential: [${unscanned.join(', ')}]. A credential read in one of them ` +
-        `is invisible here. Add it to SESSION_PATH_FILES, or to NON_CREDENTIAL_MODULES with a reason.`
+      `${ENTRY} depends on these modules, neither scanned nor declared: [${unscanned.join(', ')}]`
     ).toEqual([]);
-  });
-
-  it('no exemption is STALE — every declared entry must still be a real read', () => {
-    // 🔴 A non-empty derivation cannot detect a dead exemption, though a comment
-    // here once claimed it did. Measured: adding a bogus module or header name
-    // to an exemption map left the suite green. A stale entry is evidence the
-    // derivation's output was never read, and it silently widens the exemption
-    // surface.
-    const { local, packages } = moduleImports(ENTRY);
-    const staleModules = Object.keys(NON_CREDENTIAL_MODULES).filter((k) => !local.includes(k));
-    const stalePackages = Object.keys(NON_CREDENTIAL_PACKAGES).filter((k) => !packages.includes(k));
-    const staleHeaders = Object.keys(NON_CREDENTIAL_HEADERS).filter(
-      (k) => !extractReadsRaw('headers').includes(k)
-    );
-    const staleQuery = Object.keys(NON_CREDENTIAL_QUERY).filter(
-      (k) => !extractReadsRaw('query').includes(k)
-    );
-    const staleCookies = Object.keys(NON_CREDENTIAL_COOKIES).filter(
-      (k) => !extractReadsRaw('cookies').includes(k)
-    );
     expect(
-      { staleModules, stalePackages, staleHeaders, staleQuery, staleCookies },
-      'these exemptions no longer match anything the session path reads — remove them'
-    ).toEqual({
-      staleModules: [],
-      stalePackages: [],
-      staleHeaders: [],
-      staleQuery: [],
-      staleCookies: [],
-    });
-  });
-
-  it('sees a re-export as a dependency (regression)', () => {
-    // `export … from` is a static, executed dependency. A previous version
-    // caught it by accident with a bare `from '…'` match, and narrowing to
-    // `import … from` silently dropped it — a re-exported credential-reading
-    // module became invisible.
-    const src = "export { qPeek } from './audit-quarantine';\nimport './side-effect';";
-    // Parse the same way moduleImports does, on a fixture rather than the tree.
-    const specs = [
-      ...[...src.matchAll(/\b(?:import|export)\s+(?!type\s)[^;]*?from\s+['"]([^'"]+)['"]/g)].map(
-        (m) => m[1]
-      ),
-      ...[...src.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)].map((m) => m[1]),
-    ];
-    expect(specs).toContain('./audit-quarantine');
-    expect(specs).toContain('./side-effect');
-  });
-
-  it('destructuring fails CLOSED on shapes it cannot parse', () => {
-    // The bracket axis failed closed while this one failed OPEN — a type
-    // annotation, a brace-containing default, a nested pattern and an aliased
-    // bag all passed silently.
-    expect(extractReadsIn("const { 'x-a': c }: any = req.headers;", 'headers')).toContain('x-a');
-    expect(extractReadsIn("const { 'x-b': c = {} } = req.headers;", 'headers')).toContain('x-b');
-    expect(extractReadsIn("const { 'x-c': { d } } = req.headers as any;", 'headers')).toContain(
-      'x-c'
-    );
-    // The keyword-less assignment form.
-    expect(extractReadsIn("({ 'x-d': c } = req.headers as any);", 'headers')).toContain('x-d');
-    // An ordinary read is NOT an alias — this distinction produced a false
-    // sentinel on real source when the lookahead was missing.
-    expect(
-      extractReadsIn('const t = req.cookies?.[sessionCookieName()];', 'cookies').some(
-        isUnresolvable
-      ),
-      'a normal bracket read must not be mistaken for an aliased bag'
-    ).toBe(false);
-    // Aliasing the bag hides every later read — that must be a sentinel.
-    expect(
-      extractReadsIn("const h = req.headers;\nconst t = h['x-hidden'];", 'headers').some(
-        isUnresolvable
-      ),
-      'an aliased bag must fail closed'
-    ).toBe(true);
-  });
-
-  it('sees a leading-underscore property name', () => {
-    expect(extractReadsIn('const t = req.query?._apitoken;', 'query')).toContain('_apitoken');
+      undeclared,
+      `${ENTRY} imports these workspace packages, neither scanned nor declared: ` +
+        `[${undeclared.join(', ')}]`
+    ).toEqual([]);
   });
 
   // ── The relationship ───────────────────────────────────────────────────────
 
   it('every HEADER the session path reads is recognised as a credential', () => {
-    const unrecognised = extractReads('headers').filter(
+    const missed = extractReads('headers').filter(
       (h) => !requestCarriesCallerCredentials(reqWithHeader(h))
     );
     expect(
-      unrecognised,
-      `the session layer reads these request headers, but requestCarriesCallerCredentials does ` +
-        `not treat them as credentials: [${unrecognised.join(', ')}]. A request carrying one ` +
-        `would be classified ANONYMOUS and its per-caller body cached publicly. Teach the ` +
-        `predicate the spelling; or, if a name is <unresolvable>, make it resolvable (a literal ` +
-        `or a single-valued const) rather than exempting it.`
+      missed,
+      `the session layer reads these headers, but requestCarriesCallerCredentials does not treat ` +
+        `them as credentials: [${missed.join(', ')}]. A request carrying one would be classified ` +
+        `ANONYMOUS and its per-caller body cached publicly. Teach the predicate the spelling; if a ` +
+        `name is <unresolvable>, make it statically determinable rather than exempting it.`
     ).toEqual([]);
   });
 
   it('every QUERY PARAM is recognised on BOTH channels independently', () => {
-    // req.query and req.url are separate branches in the predicate. Probing them
-    // together let each shield the other's removal.
-    const names = extractQueryReads();
-    const missedInQuery = names.filter(
-      (q) => !requestCarriesCallerCredentials(reqWithQueryOnly(q))
-    );
-    const missedInUrl = names.filter(
-      (q) => !requestCarriesCallerCredentials(reqWithUrlQueryOnly(q))
-    );
-    expect(
-      missedInQuery,
-      `not recognised via req.query: [${missedInQuery.join(', ')}] — getServerAuthSession reads ` +
-        `the parsed query, so the predicate must too.`
-    ).toEqual([]);
-    expect(
-      missedInUrl,
-      `not recognised via req.url: [${missedInUrl.join(', ')}] — getServerAuthSession parses ` +
-        `req.url directly, so a predicate that only reads req.query can be bypassed.`
-    ).toEqual([]);
+    const names = extractReads('query');
+    const viaQuery = names.filter((q) => !requestCarriesCallerCredentials(reqWithQueryOnly(q)));
+    const viaUrl = names.filter((q) => !requestCarriesCallerCredentials(reqWithUrlQueryOnly(q)));
+    expect(viaQuery, `not recognised via req.query: [${viaQuery.join(', ')}]`).toEqual([]);
+    expect(viaUrl, `not recognised via req.url: [${viaUrl.join(', ')}]`).toEqual([]);
   });
 
   it('every COOKIE the session path authenticates with is recognised', () => {
-    // BEHAVIOURAL for helpers, and literal names are checked directly — an
-    // earlier version matched ONLY `req.cookies[helper(` , so a literal or
-    // const-aliased cookie name was dropped with no sentinel.
     const used = extractReads('cookies');
     const unresolved = used.filter(isUnresolvable);
-    expect(
-      unresolved,
-      `cookie reads whose name could not be determined: [${unresolved.join(', ')}]`
-    ).toEqual([]);
-
+    expect(unresolved, `cookie names not determinable: [${unresolved.join(', ')}]`).toEqual([]);
     for (const name of used) {
       const cookies = Object.prototype.hasOwnProperty.call(COOKIE_HELPERS, name)
         ? [COOKIE_HELPERS[name](true), COOKIE_HELPERS[name](false)]
         : [name];
-      for (const cookie of cookies) {
+      for (const cookie of cookies)
         expect(
           requestCarriesCallerCredentials(reqWithCookie(cookie)),
-          `the session path authenticates with the cookie "${cookie}" (from ${name}), but the ` +
-            `predicate does not recognise it`
+          `the session path authenticates with cookie "${cookie}" (from ${name}), unrecognised`
         ).toBe(true);
-      }
     }
   });
 
-  // ── Negative controls on the guard's own strictness ────────────────────────
+  // ── Negative controls ──────────────────────────────────────────────────────
 
   it('does NOT demand that unrelated request fields be credentials', () => {
     expect(requestCarriesCallerCredentials(reqWithHeader('accept-language'))).toBe(false);

--- a/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
+++ b/src/server/utils/__tests__/credential-detection-superset.guard.test.ts
@@ -87,6 +87,15 @@ const NON_CREDENTIAL_MODULES: Record<string, string> = {
   'env/other.ts': 'environment config; reads nothing off the request',
 };
 
+/**
+ * Workspace packages the entry point imports. Not scanned (they are whole
+ * packages), so each must be declared with a reason — fail-closed, like modules.
+ */
+const NON_CREDENTIAL_PACKAGES: Record<string, string> = {
+  '@civitai/auth':
+    'owns the cookie-NAME vocabulary (sessionCookieName / legacySessionCookieName) and the legacy cookie decode; no `req` crosses this boundary — the session path reads req.cookies itself and passes only a string',
+};
+
 /** Request HEADER reads on the session path that are not credentials. */
 const NON_CREDENTIAL_HEADERS: Record<string, string> = {
   host: 'response-side only — the cookie domain for maybeRollHubCookie / maybeUpgradeLegacySession, never read to identify a caller',
@@ -149,6 +158,25 @@ function literalConsts(src: string): Map<string, string> {
   return seen;
 }
 
+/** Split a destructuring pattern on TOP-LEVEL commas (nested braces intact). */
+function splitTopLevel(inner: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of inner) {
+    if (ch === '{' || ch === '[' || ch === '(') depth++;
+    else if (ch === '}' || ch === ']' || ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      parts.push(cur);
+      cur = '';
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur.trim()) parts.push(cur);
+  return parts;
+}
+
 /** Classify one bracket-expression body into a name, or a sentinel. */
 function classifyBracket(inner: string, consts: Map<string, string>): string {
   const t = inner.trim();
@@ -160,13 +188,17 @@ function classifyBracket(inner: string, consts: Map<string, string>): string {
 }
 
 /** Names read off `req.<bag>` in ONE file, by any spelling this parse can see. */
-function extractReadsIn(src: string, bag: 'headers' | 'query' | 'cookies'): string[] {
+function extractReadsIn(
+  src: string,
+  bag: 'headers' | 'query' | 'cookies',
+  opts: { applyExemptions?: boolean } = {}
+): string[] {
   const names = new Set<string>();
   const consts = literalConsts(src);
   const B = `req\\.${bag}`;
 
   // req.x.name / req.x?.name
-  for (const m of src.matchAll(new RegExp(`\\b${B}\\s*\\??\\.\\s*([A-Za-z][\\w]*)`, 'g')))
+  for (const m of src.matchAll(new RegExp(`\\b${B}\\s*\\??\\.\\s*([A-Za-z_$][\\w$]*)`, 'g')))
     names.add(m[1]);
 
   // req.x[<anything>] — the WHOLE expression, then classified. Matching only
@@ -182,18 +214,44 @@ function extractReadsIn(src: string, bag: 'headers' | 'query' | 'cookies'): stri
     names.add(call ? call[1] : classifyBracket(inner, consts));
   }
 
-  // const { authorization, 'x-api-key': alias } = req.x
+  // Destructuring, via a balanced-brace scan backwards from `= req.<bag>`.
   //
-  // 🔴 Anchored on the DECLARATION KEYWORD. `\{([^}]*)\}` alone cannot cross a
-  // `}`, so it anchored on whichever `{` had the pattern's `}` as its first —
-  // in practice the enclosing FUNCTION BODY brace — and extracted the leading
-  // tokens of the body ("authorization", "host", "if") while missing the real
-  // name entirely. It then told the maintainer to exempt `if`, which would have
-  // gone green with the credential read still invisible.
-  for (const m of src.matchAll(
-    new RegExp(`\\b(?:const|let|var)\\s*\\{([^{}]*)\\}\\s*=\\s*${B}\\b`, 'g')
-  )) {
-    for (const part of m[1].split(',')) {
+  // 🔴 A regex cannot do this. `\{([^}]*)\}` anchored on the enclosing FUNCTION
+  // BODY brace and reported a fabricated name; anchoring on the declaration
+  // keyword fixed that and silently dropped the keyword-less assignment form.
+  // And every shape a flat pattern cannot express — a type annotation on the
+  // left, a default containing braces, a nested pattern — was failing OPEN,
+  // while the bracket axis beside it failed closed. Scan, and emit a sentinel
+  // for anything unparseable.
+  // The negative lookahead is load-bearing: `= req.cookies?.[helper()]` is an
+  // ordinary READ, not an alias. Without it every such read was misread as the
+  // bag escaping and produced a false sentinel on the real source.
+  for (const m of src.matchAll(new RegExp(`=\\s*${B}\\s*(?![.?\\[])`, 'g'))) {
+    const before = src.slice(0, m.index ?? 0).trimEnd();
+    const lastBrace = before.lastIndexOf('}');
+    const tail = lastBrace >= 0 ? before.slice(lastBrace + 1).trim() : null;
+    // Allow a type annotation between the pattern and the `=`.
+    const isPattern = tail !== null && (tail === '' || /^:[^=]*$/.test(tail));
+    if (!isPattern) {
+      // `const h = req.headers` — the bag ESCAPES into a variable and every
+      // later read through it is invisible. Fail closed rather than pretend.
+      names.add(`${UNRESOLVABLE}:aliased-${bag}`);
+      continue;
+    }
+    let depth = 0;
+    let i = lastBrace;
+    for (; i >= 0; i--) {
+      if (before[i] === '}') depth++;
+      else if (before[i] === '{') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    if (i < 0) {
+      names.add(`${UNRESOLVABLE}:unbalanced-pattern`);
+      continue;
+    }
+    for (const part of splitTopLevel(before.slice(i + 1, lastBrace))) {
       const t = part.trim();
       if (!t || t.startsWith('...')) continue;
       const quoted = t.match(/^['"]([^'"]+)['"]\s*:/);
@@ -206,6 +264,7 @@ function extractReadsIn(src: string, bag: 'headers' | 'query' | 'cookies'): stri
     }
   }
 
+  if (opts.applyExemptions === false) return [...names];
   const exempt =
     bag === 'headers'
       ? NON_CREDENTIAL_HEADERS
@@ -213,6 +272,14 @@ function extractReadsIn(src: string, bag: 'headers' | 'query' | 'cookies'): stri
       ? NON_CREDENTIAL_QUERY
       : NON_CREDENTIAL_COOKIES;
   return [...names].filter((n) => !isExempt(exempt, n));
+}
+
+/** Every name the session path reads on `bag`, BEFORE exemptions are applied. */
+function extractReadsRaw(bag: 'headers' | 'query' | 'cookies'): string[] {
+  const out = new Set<string>();
+  for (const { src } of sessionPathSources())
+    for (const n of extractReadsIn(src, bag, { applyExemptions: false })) out.add(n);
+  return [...out];
 }
 
 /** Union across the scanned files, extracting each SEPARATELY. */
@@ -230,28 +297,54 @@ function extractQueryReads(): string[] {
   return [...out].filter((n) => !isExempt(NON_CREDENTIAL_QUERY, n));
 }
 
-/** Modules a source file imports, relative (`./x`) or aliased (`~/server/x`). */
-function moduleImports(rel: string): string[] {
+/**
+ * Modules a source file depends on: `import … from`, `export … from`, and
+ * side-effect `import '…'`.
+ *
+ * 🔴 `export … from` is a STATIC, EXECUTED dependency and belongs here. A
+ * previous version matched a bare `from '…'`, caught it by accident, and a
+ * narrowing to `import … from` silently dropped it — a re-export of a
+ * credential-reading module became invisible. That regression was introduced by
+ * the fix for the `~/` gap, which is the third time in this file's history that
+ * a fix opened the next hole. Widen deliberately, and re-measure.
+ *
+ * Workspace packages (`@civitai/*`) are dependencies of this repo's own source,
+ * NOT third-party — an earlier comment calling them "not our source" was simply
+ * wrong. They are not scanned (they are whole packages), so they must be
+ * declared in NON_CREDENTIAL_PACKAGES with a reason instead of ignored.
+ */
+function moduleImports(rel: string): { local: string[]; packages: string[] } {
   const src = readSource(rel);
   const dir = resolve(SRC, rel, '..');
-  const out = new Set<string>();
-  // Value imports only: `import type` cannot carry a runtime credential read.
-  for (const m of src.matchAll(/import\s+(?!type\s)[^;]*?from\s+['"]([^'"]+)['"]/g)) {
-    const spec = m[1];
+  const local = new Set<string>();
+  const packages = new Set<string>();
+
+  const specs: string[] = [];
+  // import/export … from '…' — `type` forms carry no runtime read.
+  for (const m of src.matchAll(/\b(?:import|export)\s+(?!type\s)[^;]*?from\s+['"]([^'"]+)['"]/g))
+    specs.push(m[1]);
+  // side-effect: import '…'
+  for (const m of src.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)) specs.push(m[1]);
+
+  for (const spec of specs) {
+    if (spec.startsWith('@civitai/')) {
+      packages.add(spec);
+      continue;
+    }
     const abs = spec.startsWith('~/')
       ? resolve(SRC, spec.slice(2))
       : spec.startsWith('.')
       ? resolve(dir, spec)
       : null;
-    if (!abs) continue; // a package, not our source
+    if (!abs) continue; // genuine third-party
     for (const cand of [`${abs}.ts`, `${abs}.tsx`, `${abs}/index.ts`]) {
       if (existsSync(cand)) {
-        out.add(cand.slice(SRC.length + 1));
+        local.add(cand.slice(SRC.length + 1));
         break;
       }
     }
   }
-  return [...out];
+  return { local: [...local], packages: [...packages] };
 }
 
 /**
@@ -344,9 +437,9 @@ describe('credential detection is a superset of the session layer', () => {
   it('the import derivation is not empty (positive control)', () => {
     // Gutting moduleImports to return [] left the scope test green — every other
     // derivation here had a positive control and that one did not.
-    const imports = moduleImports(ENTRY);
-    expect(imports).toContain('server/auth/bearer-token.ts');
-    expect(imports).toContain('server/auth/session-client.ts');
+    const { local } = moduleImports(ENTRY);
+    expect(local).toContain('server/auth/bearer-token.ts');
+    expect(local).toContain('server/auth/session-client.ts');
   });
 
   it('sees every notation it claims to', () => {
@@ -445,15 +538,102 @@ describe('credential detection is a superset of the session layer', () => {
   it('scans every module the session entry point imports', () => {
     // Both spellings: `~/server/…` is this repo's dominant style, and an earlier
     // version resolved only `./…`, so the LIKELY refactor was the uncaught one.
-    const unscanned = moduleImports(ENTRY).filter(
+    const { local, packages } = moduleImports(ENTRY);
+    const unscanned = local.filter(
       (f) => !SESSION_PATH_FILES.includes(f) && !isExempt(NON_CREDENTIAL_MODULES, f)
     );
+    const undeclaredPackages = packages.filter((q) => !isExempt(NON_CREDENTIAL_PACKAGES, q));
+    expect(
+      undeclaredPackages,
+      `${ENTRY} imports these workspace packages, which are not scanned and not declared: ` +
+        `[${undeclaredPackages.join(', ')}]. They are this repo's own source, not third-party — ` +
+        `declare each in NON_CREDENTIAL_PACKAGES with a reason.`
+    ).toEqual([]);
     expect(
       unscanned,
       `${ENTRY} imports these modules, which are neither scanned for credential reads nor ` +
         `declared non-credential: [${unscanned.join(', ')}]. A credential read in one of them ` +
         `is invisible here. Add it to SESSION_PATH_FILES, or to NON_CREDENTIAL_MODULES with a reason.`
     ).toEqual([]);
+  });
+
+  it('no exemption is STALE — every declared entry must still be a real read', () => {
+    // 🔴 A non-empty derivation cannot detect a dead exemption, though a comment
+    // here once claimed it did. Measured: adding a bogus module or header name
+    // to an exemption map left the suite green. A stale entry is evidence the
+    // derivation's output was never read, and it silently widens the exemption
+    // surface.
+    const { local, packages } = moduleImports(ENTRY);
+    const staleModules = Object.keys(NON_CREDENTIAL_MODULES).filter((k) => !local.includes(k));
+    const stalePackages = Object.keys(NON_CREDENTIAL_PACKAGES).filter((k) => !packages.includes(k));
+    const staleHeaders = Object.keys(NON_CREDENTIAL_HEADERS).filter(
+      (k) => !extractReadsRaw('headers').includes(k)
+    );
+    const staleQuery = Object.keys(NON_CREDENTIAL_QUERY).filter(
+      (k) => !extractReadsRaw('query').includes(k)
+    );
+    const staleCookies = Object.keys(NON_CREDENTIAL_COOKIES).filter(
+      (k) => !extractReadsRaw('cookies').includes(k)
+    );
+    expect(
+      { staleModules, stalePackages, staleHeaders, staleQuery, staleCookies },
+      'these exemptions no longer match anything the session path reads — remove them'
+    ).toEqual({
+      staleModules: [],
+      stalePackages: [],
+      staleHeaders: [],
+      staleQuery: [],
+      staleCookies: [],
+    });
+  });
+
+  it('sees a re-export as a dependency (regression)', () => {
+    // `export … from` is a static, executed dependency. A previous version
+    // caught it by accident with a bare `from '…'` match, and narrowing to
+    // `import … from` silently dropped it — a re-exported credential-reading
+    // module became invisible.
+    const src = "export { qPeek } from './audit-quarantine';\nimport './side-effect';";
+    // Parse the same way moduleImports does, on a fixture rather than the tree.
+    const specs = [
+      ...[...src.matchAll(/\b(?:import|export)\s+(?!type\s)[^;]*?from\s+['"]([^'"]+)['"]/g)].map(
+        (m) => m[1]
+      ),
+      ...[...src.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)].map((m) => m[1]),
+    ];
+    expect(specs).toContain('./audit-quarantine');
+    expect(specs).toContain('./side-effect');
+  });
+
+  it('destructuring fails CLOSED on shapes it cannot parse', () => {
+    // The bracket axis failed closed while this one failed OPEN — a type
+    // annotation, a brace-containing default, a nested pattern and an aliased
+    // bag all passed silently.
+    expect(extractReadsIn("const { 'x-a': c }: any = req.headers;", 'headers')).toContain('x-a');
+    expect(extractReadsIn("const { 'x-b': c = {} } = req.headers;", 'headers')).toContain('x-b');
+    expect(extractReadsIn("const { 'x-c': { d } } = req.headers as any;", 'headers')).toContain(
+      'x-c'
+    );
+    // The keyword-less assignment form.
+    expect(extractReadsIn("({ 'x-d': c } = req.headers as any);", 'headers')).toContain('x-d');
+    // An ordinary read is NOT an alias — this distinction produced a false
+    // sentinel on real source when the lookahead was missing.
+    expect(
+      extractReadsIn('const t = req.cookies?.[sessionCookieName()];', 'cookies').some(
+        isUnresolvable
+      ),
+      'a normal bracket read must not be mistaken for an aliased bag'
+    ).toBe(false);
+    // Aliasing the bag hides every later read — that must be a sentinel.
+    expect(
+      extractReadsIn("const h = req.headers;\nconst t = h['x-hidden'];", 'headers').some(
+        isUnresolvable
+      ),
+      'an aliased bag must fail closed'
+    ).toBe(true);
+  });
+
+  it('sees a leading-underscore property name', () => {
+    expect(extractReadsIn('const t = req.query?._apitoken;', 'query')).toContain('_apitoken');
   });
 
   // ── The relationship ───────────────────────────────────────────────────────


### PR DESCRIPTION
> **Note:** rewritten twice after adversarial sweeps. The first version had **nine of fourteen** mutants survive; the rewrite that fixed those introduced **three new fail-opens** of its own, found by a second 22-mutant sweep. This describes the current state. If you are strengthening this file, re-measure — do not trust a claim in it that has no mutant behind it.

## Why

`PublicEndpoint` / `MixedAuthEndpoint` choose a response's `Cache-Control` from `requestCarriesCallerCredentials(req)`:

```
credentialed  ->  private, no-cache    (never stored by a shared cache)
anonymous     ->  public, s-maxage=…   (stored at the edge, replayed to anyone)
```

That predicate is the **entire** mechanism keeping a per-caller body out of a shared cache — and the edge does not back it up. Measured on production, same URL across arms:

```
1) anon (populate)            -> MISS
2) anon again                 -> HIT      (the URL caches)
3) SAME url + Authorization   -> HIT, cache-control: public, s-maxage=300
```

`Vary: Authorization` is **inert** at our CDN. A *virgin* URL requested first with a credential correctly gets `private` + `BYPASS`, so the origin predicate works and arm 3 is a cache hit rather than a misclassification — the origin header is all there is.

The failure is silent and specific: if the session layer learns a credential spelling the predicate doesn't recognise, a request carrying it is classified **anonymous**, gets `public, s-maxage`, and its personalised body is cached and served to other people. Nothing throws.

`endpoint-helpers.ts` already states the invariant — *"must stay a superset of the set `getServerAuthSession` accepts"* — but nothing enforced it, and the existing test hand-enumerates spellings, which by construction cannot fail when the **other** side grows.

**Both sides are in sync today** (enumerated, not sampled). This is drift protection, not a live gap.

## What it certifies

Spellings are **extracted from the session layer's own source**, per file, and each is used to **synthesise a request** fed to the real predicate.

**Caught**, each mutation-verified: a header or query param by literal name, dot or bracket notation; a read via a same-file `const` alias; a read by **destructuring** `req.headers`; a **cookie** by literal name, const alias, or name helper; a bracket read whose name **cannot be resolved**, on any of the three axes — that fails rather than vanishing; a credential-reading module added to the entry point's imports, whether `./x` or `~/server/x`; and the predicate narrowing on **any single channel** (`req.query` and `req.url` are probed independently, so redundant branches cannot shield each other).

**Not caught**: a name computed at runtime — that surfaces as a sentinel *failure* rather than passing, but the guard cannot name it; and a credential read in a module reached other than by a static import from the entry point.

## Mutation results

Every mutant either sweep found surviving is now killed:

| Mutation | Then | Now |
|---|---|---|
| destructure early in a function body | **survived** — reported a fabricated `if`, missed the real name | 1 fail, naming `x-real-cred` |
| cross-file `const` collision | **survived** — read vanished with no sentinel | 1 fail |
| new cookie, literal name | **survived** | 2 fail |
| new cookie, const alias | **survived** | 2 fail |
| module imported via `~/` alias | **survived** | 1 fail |
| drop the `req.query` branch only | **survived** | 1 fail |
| drop the `req.url` branch only | **survived** | 1 fail |
| const-alias header read | **survived** | 1 fail |
| header read moved to a new file | **survived** | 1 fail |
| predicate hardcodes cookies + decoy | **survived** | 1 fail |
| comment-strip replaced by identity | **survived** | 1 fail |
| prototype-key exemption | **survived** | 1 fail |
| session path gains a literal `x-api-key` | 1 fail | 1 fail |
| extractors blinded to `[]` | 3 fails | 3 fails |

Two worth calling out, because they are the shapes that made earlier versions *worse than nothing*:

- The **destructuring** rule anchored on the enclosing function-body brace, so it extracted the body's leading tokens, missed the real credential, and told the maintainer to exempt `if`. Following that instruction would have gone green with the read still invisible.
- The **cross-file `const` collision** resolved a real read onto the exempt `host`, so it disappeared with **no sentinel** — the fail-closed path never fired. Extraction is per-file now, and a name declared twice with differing values resolves to nothing.

## Test plan

`src/server/utils` + `src/server/auth`: **86 files / 1242 tests**, green. `pnpm typecheck` 0 errors. eslint + prettier clean. (A scoped subset, not the whole `unit` project — which has 3 suites that fail to collect on `sharp`'s native binary under `--ignore-scripts`, unrelated to any PR.)

## Note for review

The import of `stripSourceComments` from the AppBlocks directory. It's a pure utility with no React or AppBlocks coupling, and this is its second consumer in a different domain — the tidier home is a neutral `src/utils`. Deliberately not moved: that would churn files from a just-merged PR and mix a refactor into a security guard. Closing condition for the follow-up: both consumers import it from `src/utils` and neither declares its own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
