### PR TITLE
fix(remix-gallery): spread the real image.utils in the submit-modal test — a one-key mock the module outgrew

### DIFF
--- a/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
+++ b/src/components/RemixGallery/RemixGallerySubmitModal.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcModule from '~/utils/trpc';
+import type * as ImageUtils from '~/components/Image/image.utils';
 
 /**
  * The three branches of the submit card that decide what somebody is CHARGED or
@@ -29,7 +30,14 @@ import type * as TrpcModule from '~/utils/trpc';
  */
 
 const HOST = 74;
-const MINE = 85;
+// 🔴 HOISTED, and it has to be. `MINE` is read inside the `~/components/Image/image.utils`
+// factory below, and that factory is async (it spreads the real module). An async factory
+// resolves during module registration, BEFORE this file's body runs, so a plain
+// `const MINE = 85` is still in its temporal dead zone when the factory reads it —
+// vitest reports that as the generic "make sure there are no top level variables inside",
+// which names the symptom and not this line. A synchronous factory does not hit it, which
+// is why the plain const worked until the spread was added.
+const MINE = vi.hoisted(() => 85);
 const PRICE = 700;
 
 const mocks = vi.hoisted(() => ({
@@ -118,7 +126,19 @@ vi.mock('~/components/Dialog/DialogProvider', () => ({
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 52 }) }));
 vi.mock('~/components/Buzz/useAvailableBuzz', () => ({ useAvailableBuzz: () => ['yellow'] }));
 
-vi.mock('~/components/Image/image.utils', () => ({
+// Spread the real module first, for exactly the reason the `~/utils/trpc` mock
+// above already states — and this mock is the one that proved it. #4450 added
+// `ownContentPickerFilters` to image.utils and had remix-gallery.utils import it;
+// this factory listed one key, so the import failed the WHOLE FILE at collection
+// with `does not provide an export named 'ownContentPickerFilters'` and the suite
+// reported `Tests no tests` — no failing assertion to point at.
+//
+// 🔴 Do NOT "fix" a recurrence by adding the missing key. That resets the drift
+// clock rather than stopping it: the next export added to this module breaks the
+// file again, the same way, and the error still names something this test never
+// mentions. The spread is what makes the mock survive the module growing.
+vi.mock('~/components/Image/image.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof ImageUtils>()),
   useQueryImages: () => ({
     images: [{ id: MINE, nsfwLevel: 1, url: 'x', width: 1, height: 1, type: 'image' }],
     isLoading: false,


### PR DESCRIPTION

`preview / component-tests` went red again the day after the last fix, on a
different file and for a different reason:

  Failed to import test file .../RemixGallerySubmitModal.browser.test.tsx
  Caused by: SyntaxError: The requested module '/src/components/Image/image.utils.ts'
             does not provide an export named 'ownContentPickerFilters'

#4450 added `ownContentPickerFilters` to image.utils and had remix-gallery.utils
import it. This test wholesale-mocked image.utils with a factory returning ONE
key, so the new import resolved to nothing and the whole file failed at
collection. The suite reported `Tests no tests` -- 2150 tests passed and one file
never ran, with no failing assertion to point at.

Ruled out before fixing: not a stale base (both #4450 and the previous fix are
ancestors of the PR head that failed), and not a source break (the export exists
in the exact tree the suite built).

THE FIX IS THE ONE THIS FILE ALREADY USES ELEVEN LINES ABOVE. The `~/utils/trpc`
mock spreads `importOriginal` and carries a comment stating this exact hazard --
"so a new export does not silently become undefined for every importer in this
test's graph". That lesson was learned here, written down, and applied to one
mock and not the other. Adding the missing key instead would only reset the
drift clock: the next export added to image.utils breaks the file the same way.

🔴 THE SPREAD ALSO BREAKS A TOP-LEVEL CONST, AND THE ERROR DOES NOT SAY SO.
Spreading makes the factory async, and an async factory resolves during module
registration -- before this file's body runs. `const MINE = 85` is then in its
temporal dead zone when the factory reads it, and vitest reports the generic
"make sure there are no top level variables inside", which names the symptom
rather than the line. A synchronous factory never hits it, which is why the
plain const was fine until now. `MINE` is hoisted, and the reasoning is in a
comment beside it.

VERIFIED, single file, both arms:

  origin/main   Test Files  1 failed (1)   Tests  no tests
  with the fix  Test Files  1 passed (1)   Tests  15 passed (15)

The count moving off `no tests` is the control -- a PASS at zero collected is
the same vacuous green this class produces in the first place.

⚠ NOT VERIFIED LOCALLY: the full 194-file component suite. It was attempted and
died on browser-session infrastructure ("Failed to connect to the browser
session within the timeout") before reaching this file, which is a fact about
running 194 browser-mode files on one workstation, not about this change. The
preview tier is the authoritative runner for this suite -- it is the only runner:
`test:component` appears in no GitHub Actions workflow.

Note for whoever lands #4452, which reworks RemixGallerySubmitModal.tsx and
remix-gallery.utils.ts: this touches neither, only the .browser.test.tsx, and
spreading the real module is strictly more tolerant of import changes than the
one-key factory it replaces.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E9VFYjPYAcY5BuePKFvBw8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9VFYjPYAcY5BuePKFvBw8
