### PR TITLE
fix(api): by-hash batch lookup built downloadUrl from a header that does not exist

### DIFF
--- a/src/pages/api/v1/model-versions/by-hash/index.ts
+++ b/src/pages/api/v1/model-versions/by-hash/index.ts
@@ -45,7 +45,13 @@ export default PublicEndpoint(
     });
     const paidAccess = await getPublicPaidAccessForModelVersions(modelVersionIds);
 
-    const baseUrl = new URL(isProd ? `https://${req.headers.posthost}` : 'http://localhost:3000');
+    // Matches `resModelVersionDetails` in ./[id], which shapes the singular
+    // by-hash response through the same `prepareModelVersionResponse`. The two
+    // must derive the base URL identically or the batch and single lookups
+    // advertise different download hosts for the same file.
+    const baseUrl = new URL(
+      isProd && req.headers.host ? `https://${req.headers.host}` : 'http://localhost:3000'
+    );
     const modelVersions = await Promise.all(
       files.map((file) =>
         prepareModelVersionResponse(

--- a/src/tests/api/v1/model-versions/by-hash-index-base-url.test.ts
+++ b/src/tests/api/v1/model-versions/by-hash-index-base-url.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+/**
+ * Regression coverage for POST /api/v1/model-versions/by-hash — the batch
+ * lookup must build its `downloadUrl`s from the REQUEST's host.
+ *
+ * The handler built its base URL from `req.headers.posthost`, which is not an
+ * HTTP header and is set by nothing. `IncomingHttpHeaders` carries an index
+ * signature (`NodeJS.Dict<string | string[]>`), so the misspelling is a legal
+ * property access and typechecks; at runtime it is `undefined`, and
+ * `new URL('https://undefined')` PARSES — origin `https://undefined` — rather
+ * than throwing. Every `downloadUrl` in the response therefore pointed at
+ * `https://undefined/...` in production, silently.
+ *
+ * The sibling `[id].ts` (whose `prepareModelVersionResponse` this endpoint
+ * calls) and `by-hash/[hash].ts` (which reaches the same shaper through
+ * `resModelVersionDetails`) both derive the base URL from `req.headers.host`
+ * and fall back to localhost when it is absent. This suite pins that this
+ * endpoint agrees with them.
+ *
+ * 🔴 `isProd` is mocked TRUE deliberately. It is `NODE_ENV === 'production'`,
+ * evaluated at module load, so under Vitest it is FALSE and the handler takes
+ * its `'http://localhost:3000'` dev branch — the production expression that
+ * carries the defect never executes. Without this mock every assertion below
+ * passes on the BROKEN code.
+ */
+vi.mock('~/env/other', () => ({
+  isProd: true,
+  isDev: false,
+  isTest: false,
+  isPreview: false,
+}));
+
+/**
+ * `~/env/client-schema` reads the SAME `isProd` and tightens itself when it is
+ * true (`NEXT_PUBLIC_CIVITAI_LINK` goes from optional to required). Vitest does
+ * not load `.env` into `process.env`, so without this the mock above turns a
+ * client-env validation throw into a COLLECTION failure — which reports as
+ * "no tests" rather than as a red assertion. Hoisted so it lands before the
+ * module graph is imported.
+ */
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_CIVITAI_LINK ??= 'https://link.example.test';
+});
+
+// Unwrap PublicEndpoint so the raw handler is invoked directly (no CORS/cache side effects).
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: unknown) => handler,
+  MixedAuthEndpoint: (handler: unknown) => handler,
+}));
+
+// I/O behind the real `prepareModelVersionResponse`. The URL construction
+// itself (`createSerializedFileDownloadUrl`, `getPrimaryFile`) stays REAL — the
+// emitted string is the contract under test.
+vi.mock('~/server/services/model.service', () => ({ getVaeFiles: vi.fn(async () => []) }));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(async () => []),
+}));
+vi.mock('~/server/services/paid-access.service', () => ({
+  getPaidAccess: vi.fn(async () => ({})),
+  getPublicPaidAccessForModelVersions: vi.fn(async () => ({})),
+  toPublicPaidAccessDto: () => null,
+  bustModelSaleCache: vi.fn(),
+}));
+vi.mock('~/server/services/creator-program.service', () => ({
+  hasValidCreatorMembershipCached: async () => false,
+}));
+vi.mock('~/server/services/file.service', () => ({
+  getDownloadFilename: ({ file }: any) => `${file.id}.safetensors`,
+}));
+vi.mock('~/client-utils/edge-url', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => 'US',
+  isRegionRestricted: () => false,
+}));
+
+import handler from '~/pages/api/v1/model-versions/by-hash/index';
+
+const HASH = 'A'.repeat(64);
+
+/**
+ * Two Public files on one version, pairwise distinct on every axis the
+ * serializer could key off, so an assertion cannot pass by coincidence.
+ */
+const FILES = [
+  {
+    id: 21,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 1111,
+    modelVersionId: 4242,
+    url: 's3://a',
+    name: 'a.safetensors',
+    hashes: [{ type: 'SHA256', hash: 'aaaa1111' }],
+    metadata: { format: 'SafeTensor', size: 'pruned', fp: 'fp16' },
+  },
+  {
+    id: 22,
+    type: 'Model',
+    visibility: 'Public',
+    sizeKB: 2222,
+    modelVersionId: 4242,
+    url: 's3://b',
+    name: 'b.ckpt',
+    hashes: [{ type: 'SHA256', hash: 'bbbb2222' }],
+    metadata: { format: 'PickleTensor', size: 'full', fp: 'fp32' },
+  },
+];
+
+function modelVersion() {
+  return {
+    id: 4242,
+    modelId: 77,
+    name: 'v1',
+    baseModel: 'SD 1.5',
+    status: 'Published',
+    nsfwLevel: 1,
+    licensingFee: null,
+    files: FILES.map((f) => ({ ...f })),
+    metrics: [{ downloadCount: 5, thumbsUpCount: 2 }],
+    model: { name: 'Model 77', type: 'Checkpoint', nsfw: false, poi: false, mode: null },
+  } as any;
+}
+
+async function invokeByHash(headers: Record<string, unknown>) {
+  const res: any = {
+    setHeader() {
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+  await (handler as unknown as (req: any, res: any) => Promise<void>)(
+    { method: 'POST', body: [HASH], headers },
+    res
+  );
+  return res;
+}
+
+/** Every absolute URL the response advertises, across all versions and files. */
+function downloadUrls(res: any): string[] {
+  const versions = res.body as any[];
+  return versions.flatMap((v) => [
+    v.downloadUrl,
+    ...(v.files as any[]).map((f: any) => f.downloadUrl),
+  ]);
+}
+
+describe('POST /api/v1/model-versions/by-hash — downloadUrl host', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.dbRead.modelFile.findMany.mockResolvedValue([{ modelVersion: modelVersion() }]);
+    dbMock.dbRead.modelVersion.findUnique.mockResolvedValue(null);
+  });
+
+  it('builds every downloadUrl from the request host', async () => {
+    const res = await invokeByHash({ host: 'models.example.test' });
+    expect(res.statusCode).toBe(200);
+
+    const urls = downloadUrls(res);
+    // Positive control: the assertions below are claims about a non-empty set.
+    expect(urls).toHaveLength(3);
+
+    for (const url of urls) {
+      expect(new URL(url).origin, `downloadUrl ${url}`).toBe('https://models.example.test');
+    }
+  });
+
+  /**
+   * The control that separates "reads the request host" from "happens to emit
+   * the constant the previous test names". A hardcoded origin — including the
+   * broken `https://undefined` — cannot satisfy both hosts.
+   */
+  it('tracks the host per request rather than emitting a fixed origin', async () => {
+    const first = downloadUrls(await invokeByHash({ host: 'first.example.test' }));
+    dbMock.dbRead.modelFile.findMany.mockResolvedValue([{ modelVersion: modelVersion() }]);
+    const second = downloadUrls(await invokeByHash({ host: 'second.example.test' }));
+
+    expect(new Set(first.map((u) => new URL(u).origin))).toEqual(
+      new Set(['https://first.example.test'])
+    );
+    expect(new Set(second.map((u) => new URL(u).origin))).toEqual(
+      new Set(['https://second.example.test'])
+    );
+  });
+
+  it('never emits the literal host "undefined"', async () => {
+    const urls = downloadUrls(await invokeByHash({ host: 'models.example.test' }));
+    expect(urls).not.toHaveLength(0);
+    for (const url of urls) expect(new URL(url).hostname).not.toBe('undefined');
+  });
+
+  /**
+   * The second half of the defect: the broken expression had no guard, so a
+   * request arriving without a Host header produced `https://undefined` too.
+   * The siblings fall back to localhost; this pins that behaviour.
+   */
+  it('falls back to localhost when the request carries no host header', async () => {
+    const urls = downloadUrls(await invokeByHash({}));
+    expect(urls).toHaveLength(3);
+    for (const url of urls) {
+      expect(new URL(url).origin, `downloadUrl ${url}`).toBe('http://localhost:3000');
+    }
+  });
+});

--- a/src/tests/api/v1/model-versions/by-hash-index-base-url.test.ts
+++ b/src/tests/api/v1/model-versions/by-hash-index-base-url.test.ts
@@ -19,14 +19,34 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
  * and fall back to localhost when it is absent. This suite pins that this
  * endpoint agrees with them.
  *
- * 🔴 `isProd` is mocked TRUE deliberately. It is `NODE_ENV === 'production'`,
- * evaluated at module load, so under Vitest it is FALSE and the handler takes
- * its `'http://localhost:3000'` dev branch — the production expression that
- * carries the defect never executes. Without this mock every assertion below
- * passes on the BROKEN code.
+ * 🔴 `isProd` is mocked rather than inherited, and it is what gives this suite
+ * any discriminating power at all. It is `NODE_ENV === 'production'` evaluated
+ * at module load, so under Vitest it is really FALSE and the handler always
+ * takes its `'http://localhost:3000'` branch — the production expression that
+ * carried the defect never executes.
+ *
+ * Measured with the mock removed, on both trees:
+ *
+ *   pre-fix (`req.headers.posthost`)  2 failed / 2 passed
+ *   post-fix (`req.headers.host`)     2 failed / 2 passed   — IDENTICAL
+ *
+ * So without it the suite does not go vacuously green; it goes red on both
+ * trees and tells them apart on nothing. The two production-host cases fail
+ * whatever the source says, and the two that survive (`hostname` is never
+ * `undefined`, and the no-Host fallback) pass whatever the source says. The
+ * mock is what makes the pre-fix and post-fix trees produce different results.
+ *
+ * `isProd` is a mutable holder rather than a literal so the `isProd &&` operand
+ * of the expression under test is itself reachable — see the development case
+ * at the bottom of this file. Pinned to a constant, dropping `isProd &&` from
+ * the source is a mutation no test in this file can see.
  */
+const envState = vi.hoisted(() => ({ isProd: true }));
+
 vi.mock('~/env/other', () => ({
-  isProd: true,
+  get isProd() {
+    return envState.isProd;
+  },
   isDev: false,
   isTest: false,
   isPreview: false,
@@ -156,6 +176,8 @@ function downloadUrls(res: any): string[] {
 describe('POST /api/v1/model-versions/by-hash — downloadUrl host', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Restored per test so the development case below cannot leak into the rest.
+    envState.isProd = true;
     dbMock.dbRead.modelFile.findMany.mockResolvedValue([{ modelVersion: modelVersion() }]);
     dbMock.dbRead.modelVersion.findUnique.mockResolvedValue(null);
   });
@@ -204,6 +226,26 @@ describe('POST /api/v1/model-versions/by-hash — downloadUrl host', () => {
    */
   it('falls back to localhost when the request carries no host header', async () => {
     const urls = downloadUrls(await invokeByHash({}));
+    expect(urls).toHaveLength(3);
+    for (const url of urls) {
+      expect(new URL(url).origin, `downloadUrl ${url}`).toBe('http://localhost:3000');
+    }
+  });
+
+  /**
+   * Covers the `isProd &&` operand, which every case above leaves unreachable
+   * because they all pin `isProd` true.
+   *
+   * A Host header IS present here, so the only thing that can send the result
+   * to localhost is `isProd` being false. Dropping `isProd &&` from the source
+   * leaves `req.headers.host ? … : …`, which would emit
+   * `https://models.example.test` and break local development — a mutation no
+   * other test in this file can observe.
+   */
+  it('ignores the request host outside production', async () => {
+    envState.isProd = false;
+
+    const urls = downloadUrls(await invokeByHash({ host: 'models.example.test' }));
     expect(urls).toHaveLength(3);
     for (const url of urls) {
       expect(new URL(url).origin, `downloadUrl ${url}`).toBe('http://localhost:3000');


### PR DESCRIPTION
## The defect

`src/pages/api/v1/model-versions/by-hash/index.ts` built its base URL from a header that does not exist:

```ts
const baseUrl = new URL(isProd ? `https://${req.headers.posthost}` : 'http://localhost:3000');
```

`posthost` is not an HTTP header. It is the **only** occurrence of that string in the repo, so nothing sets it and nothing else reads it.

Two properties kept it silent rather than loud:

- `IncomingHttpHeaders` extends `NodeJS.Dict<string | string[]>` — an index signature — so the misspelling is a legal property access and **typechecks**.
- `new URL('https://undefined')` **parses**. Host is the literal string `undefined`, `origin` is `https://undefined`. No throw.

`createModelFileDownloadUrl` / `createSerializedFileDownloadUrl` return a root-relative path, so `baseUrl.origin` is the only thing supplying a host — there is no second chance to recover it. In any `NODE_ENV=production` build, every `downloadUrl` this endpoint returned (both the per-file ones and the version-level one) was:

```
https://undefined/api/download/models/<versionId>?fileId=<n>
```

Introduced Feb 2023 in the commit that extracted `prepareModelVersionResponse`; the same diff kept the correct spelling in `[id].ts` and mistyped it in this new file. Line 48 had not been touched since.

## The fix

Adopt the guarded form already used by `resModelVersionDetails` in `./[id]` and by `v1/images/index.ts`:

```ts
const baseUrl = new URL(
  isProd && req.headers.host ? `https://${req.headers.host}` : 'http://localhost:3000'
);
```

There were **two** defects, and the guard matters on its own: without `&& req.headers.host`, a request arriving with no `Host` header still yields `https://undefined` even after the typo is corrected.

### Why `req.headers.host` and not `getBaseUrl()`

`mini/[id].ts` uses `getBaseUrl()`, so it is worth saying why this endpoint should not:

- **The siblings that share this endpoint's shaper derive from the request host.** `by-hash/index.ts` calls `prepareModelVersionResponse` from `[id].ts`; the singular `by-hash/[hash].ts` reaches the *same* shaper via `resModelVersionDetails`, which uses `req.headers.host`. Anything else here would make the batch and single by-hash lookups advertise **different download hosts for the same file**.
- **It is the established pattern for this family** — the identical expression appears in `[id].ts` and `v1/images/index.ts`.
- `getBaseUrl()` resolves to a fixed configured base (`NEXTAUTH_URL` server-side), not the request's host. Switching to it would be a behaviour change beyond the defect, which this PR deliberately avoids.

The batch handler now duplicates a line that also lives in `resModelVersionDetails` — that duplication is exactly what allowed the drift. Consolidating the two behind a shared helper is a reasonable follow-up but is deliberately **not** bundled here, to keep this a minimal behaviour-preserving fix.

### Two consequences worth naming explicitly

Neither is a defect being introduced, and this PR deliberately does **not** change either — but reviewers should see them stated rather than discover them:

1. **A malformed `Host` can now throw.** The fixed line interpolates `req.headers.host` into `new URL()` with no `try`/`catch`, so a non-empty malformed Host (`exa mple.com`, `[bad`, `ho%st` — all verified to throw `ERR_INVALID_URL`) produces a 500 where the old constant expression could not throw at all. This is **exact parity with the singular `by-hash/[hash].ts`**, which has the same exposure through `resModelVersionDetails` — so the fix does not make this endpoint an outlier, it makes it match its sibling. Worth knowing: `[id].ts` is the **only** member of this family that wraps the call in its own `try`/`catch` (lines 61–159); neither by-hash endpoint does. An empty Host does *not* throw, because `&& req.headers.host` is falsy for `''` and routes it to the localhost fallback. Adding validation or a `try` here would be scope this PR is intentionally not taking.

2. **With no `Host` in production the response now advertises `http://localhost:3000`** rather than `https://undefined`. Both are useless to an external caller; this is the deliberate consequence of matching the sibling's fallback rather than inventing a third behaviour.

## Test

New: `src/tests/api/v1/model-versions/by-hash-index-base-url.test.ts` (5 tests), following the existing `by-hash-ids-endpoint` / `id-file-download-url` harness — global `dbMock`, `PublicEndpoint` unwrapped, real `prepareModelVersionResponse` so the asserted URL is the genuinely emitted string.

**Red → green matrix**

| Tree | Result |
|---|---|
| `ad51a8a7f9` (`origin/main`, pre-fix) + test only | **4 failed / 4** — every failure `expected 'https://undefined' to be 'https://models.example.test'` |
| this branch (post-fix) | **5 passed / 5** |

Mutation checks (each applied to the fixed line, then reverted; source restored and verified byte-identical):

| Mutant | Outcome |
|---|---|
| `new URL(getBaseUrl())` — the plausible *wrong* fix | **killed**, 2 failed — proves the test pins *request-host* derivation, not merely "not undefined" |
| `isProd ? …host…` — typo fixed, guard removed | **killed**, 1 failed, by the fallback test with its own specific error — proves `&& req.headers.host` is independently reachable |
| `req.headers.host ? …` — `isProd &&` removed | **killed**, 1 failed, by the development test — this mutant *shipped green* before the latest commit; see below |

> 🔴 **Why `isProd` is mocked, stated accurately.** `isProd` is `NODE_ENV === 'production'` evaluated at module load, so under Vitest it is really false and the handler always takes its localhost branch — the production expression that carried the defect never executes. Measured with the mock removed, **both trees report 2 failed / 2 passed, identically**. So the mock does not prevent a vacuous green; it is what gives the suite any power to tell the two trees apart at all. Without it the two production-host cases fail whichever source is present, and the two that survive pass whichever source is present.
>
> `isProd` is a mutable holder read through a getter rather than a pinned literal, so that the `isProd &&` operand is itself reachable. Pinned to `true` — as an earlier revision of this test had it — dropping `isProd &&` from the source ships **green**, and that mutation would emit `https://<host>` in development and break local dev.

Also run: `pnpm typecheck` → 0 errors. Prettier clean, ESLint 0 errors. The `no-direct-shared-module-mock` ratchet and `no-test-files-in-pages-tree` guards pass; full targeted sweep 29 passed.

## Blast radius

- **Live and routable.** `next.config.mjs` declares no `rewrites`; the middlewares matching `/api/v1/:path*` (`api-cache`, `api-region-block`, `bot-detection`) are header-annotating passthroughs or a region gate — none rewrites the path or the `Host` header. The handler sees the real inbound host.
- **Affected the batch endpoint only.** The singular `by-hash/[hash]` is correct (it delegates to `resModelVersionDetails`), and `by-hash/ids` returns only ids and never builds a URL.
- **Zero in-repo consumers.** Nothing in the repo calls `POST /api/v1/model-versions/by-hash`, no in-repo doc describes it, and no OpenAPI artifact covers it (the only generator is scoped to the moderator API). In-repo download links are built client-side via `createModelFileDownloadUrl` rather than read from this field. The consumers are **external** — third-party hash→version batch resolution, e.g. the SD-WebUI helper extensions named in the existing `id-file-download-url` blast-radius comment.
- That combination — no in-repo caller, no doc, and **no test importing `by-hash/index.ts`** — is why it survived ~3.5 years. This PR closes the coverage gap.

Severity is therefore real but externally-scoped: it does not break any first-party flow, and it makes every `downloadUrl` from this endpoint unusable for the third-party tooling that does call it.
