### PR TITLE
fix(blurbs): read BlurbReference only inside the feature gate

### DIFF
--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -190,7 +190,7 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   // 🔴 So this flag can only be ramped by PERCENTAGE or BOOLEAN. A SEGMENT rollout silently
   // matches nothing here and looks exactly like "blurbs are off". The full warning is on
   // FLIPT_FEATURE_FLAGS.TEXT_BLURBS, which is where someone running the ramp will look.
-  'server/services/blurb-materialize.service.ts:56':
+  'server/services/blurb-materialize.service.ts:65':
     'text-blurbs has no segment rollouts; entityId is the CONTENT OWNER (not the actor) so the intended threshold rollout is sticky per creator; no SessionUser for the owner exists on either the moderator-edit path or the fan-out job',
 };
 

--- a/src/server/services/__tests__/blurb-article-wiring.test.ts
+++ b/src/server/services/__tests__/blurb-article-wiring.test.ts
@@ -183,11 +183,17 @@ describe('upsertArticle — blurb expansion', () => {
 
     // Without this a moderator could splice in guessed `data-id`s across a range and read
     // the owner's whole blurb library back out of the mutation response.
+    // Handed over as a RESOLVER, not an awaited array. `expandBlurbs` owns the flag gate
+    // and the has-spans check, so resolving the set before it is called reads
+    // BlurbReference on saves where the feature is off or no blurb is named.
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(getReferencedBlurbIds).not.toHaveBeenCalled();
+
+    expect(await restrictToBlurbIds()).toEqual([7]);
     expect(getReferencedBlurbIds).toHaveBeenCalledWith({
       entityType: 'Article',
       entityId: ARTICLE_ID,
     });
-    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ restrictToBlurbIds: [7] }));
   });
 
   it('leaves the owner unrestricted', async () => {

--- a/src/server/services/__tests__/blurb-bounty-wiring.test.ts
+++ b/src/server/services/__tests__/blurb-bounty-wiring.test.ts
@@ -170,11 +170,17 @@ describe('upsertBounty — blurb expansion', () => {
   it('resolves only the blurbs the bounty already references when a moderator saves', async () => {
     await upsert({ userId: MODERATOR_ID, isModerator: true });
 
+    // Handed over as a RESOLVER, not an awaited array. `expandBlurbs` owns the flag gate
+    // and the has-spans check, so resolving the set before it is called reads
+    // BlurbReference on saves where the feature is off or no blurb is named.
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(getReferencedBlurbIds).not.toHaveBeenCalled();
+
+    expect(await restrictToBlurbIds()).toEqual([7]);
     expect(getReferencedBlurbIds).toHaveBeenCalledWith({
       entityType: 'Bounty',
       entityId: BOUNTY_ID,
     });
-    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ restrictToBlurbIds: [7] }));
   });
 
   it('leaves the owner unrestricted', async () => {

--- a/src/server/services/__tests__/blurb-cosmetic-shop-wiring.test.ts
+++ b/src/server/services/__tests__/blurb-cosmetic-shop-wiring.test.ts
@@ -92,11 +92,17 @@ describe('upsertCosmeticShopItem — blurb expansion', () => {
   it('resolves only the blurbs the item already references when a moderator saves', async () => {
     await upsert({ userId: MODERATOR_ID });
 
+    // Handed over as a RESOLVER, not an awaited array. `expandBlurbs` owns the flag gate
+    // and the has-spans check, so resolving the set before it is called reads
+    // BlurbReference on saves where the feature is off or no blurb is named.
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(getReferencedBlurbIds).not.toHaveBeenCalled();
+
+    expect(await restrictToBlurbIds()).toEqual([7]);
     expect(getReferencedBlurbIds).toHaveBeenCalledWith({
       entityType: 'CosmeticShopItem',
       entityId: ITEM_ID,
     });
-    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ restrictToBlurbIds: [7] }));
   });
 
   it('leaves the owner unrestricted', async () => {

--- a/src/server/services/__tests__/blurb-materialize.test.ts
+++ b/src/server/services/__tests__/blurb-materialize.test.ts
@@ -132,7 +132,7 @@ describe('expandBlurbs', () => {
       const { html, uses } = await expandEvaluated({
         userId: 10,
         html: '<div data-type="blurb" data-id="7">stale</div>',
-        restrictToBlurbIds: [7],
+        restrictToBlurbIds: () => [7],
       });
 
       expect(html).toBe('<div data-type="blurb" data-id="7">REFERENCED</div>');
@@ -145,7 +145,7 @@ describe('expandBlurbs', () => {
       const { html, uses } = await expandEvaluated({
         userId: 10,
         html: '<div data-type="blurb" data-id="8">guessed</div>',
-        restrictToBlurbIds: [7],
+        restrictToBlurbIds: () => [7],
       });
 
       expect(html).toBe('guessed');
@@ -159,7 +159,7 @@ describe('expandBlurbs', () => {
         html:
           '<div data-type="blurb" data-id="7">a</div>' +
           '<div data-type="blurb" data-id="8">b</div>',
-        restrictToBlurbIds: [7],
+        restrictToBlurbIds: () => [7],
       });
 
       expect(dbRead.blurb.findMany).toHaveBeenCalledWith(
@@ -171,7 +171,7 @@ describe('expandBlurbs', () => {
       const { html, uses } = await expandEvaluated({
         userId: 10,
         html: '<div data-type="blurb" data-id="8">guessed</div>',
-        restrictToBlurbIds: [],
+        restrictToBlurbIds: () => [],
       });
 
       expect(html).toBe('guessed');
@@ -186,6 +186,47 @@ describe('expandBlurbs', () => {
       });
 
       expect(html).toBe('<div data-type="blurb" data-id="8">PRIVATE</div>');
+    });
+
+    // Producing the set means reading BlurbReference, so WHEN it is resolved decides whether a
+    // blurb table is touched on a save that has nothing to do with blurbs. The caller-side
+    // consequence is pinned in blurb-reference-read-gate.test.ts; this is the same rule at the
+    // one place that owns it.
+    describe('is resolved lazily', () => {
+      it('does not resolve when the flag is off for the owner', async () => {
+        isFlipt.mockResolvedValue(false);
+        const restrictToBlurbIds = vi.fn(async () => [7]);
+
+        await expandBlurbs({
+          userId: 10,
+          html: '<div data-type="blurb" data-id="7">x</div>',
+          restrictToBlurbIds,
+        });
+
+        expect(restrictToBlurbIds).not.toHaveBeenCalled();
+      });
+
+      it('does not resolve when the html carries no blurb spans', async () => {
+        const restrictToBlurbIds = vi.fn(async () => [7]);
+
+        await expandBlurbs({ userId: 10, html: '<p>plain</p>', restrictToBlurbIds });
+
+        expect(restrictToBlurbIds).not.toHaveBeenCalled();
+      });
+
+      it('DOES resolve once the flag is on and a span is present', async () => {
+        // Positive control for the two zeros above: a resolver that is never wired up would
+        // satisfy them both.
+        const restrictToBlurbIds = vi.fn(async () => [7]);
+
+        await expandBlurbs({
+          userId: 10,
+          html: '<div data-type="blurb" data-id="7">x</div>',
+          restrictToBlurbIds,
+        });
+
+        expect(restrictToBlurbIds).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/server/services/__tests__/blurb-model-version-wiring.test.ts
+++ b/src/server/services/__tests__/blurb-model-version-wiring.test.ts
@@ -162,11 +162,17 @@ describe('upsertModelVersion — blurb expansion', () => {
   it('resolves only the blurbs the version already references when a moderator saves', async () => {
     await upsert({ actorUserId: MODERATOR_ID, isModerator: true });
 
+    // Handed over as a RESOLVER, not an awaited array. `expandBlurbs` owns the flag gate and the
+    // has-spans check, so resolving the set before it is called reads BlurbReference on saves
+    // where the feature is off or no blurb is named.
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(getReferencedBlurbIds).not.toHaveBeenCalled();
+
+    expect(await restrictToBlurbIds()).toEqual([7]);
     expect(getReferencedBlurbIds).toHaveBeenCalledWith({
       entityType: 'ModelVersion',
       entityId: VERSION_ID,
     });
-    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ restrictToBlurbIds: [7] }));
   });
 
   it('leaves the owner unrestricted', async () => {
@@ -190,15 +196,21 @@ describe('upsertModelVersion — a non-owner creating a row', () => {
     // A new row references nothing yet, so the allowed set is empty — never `undefined`, which
     // means "unrestricted".
     expect(getReferencedBlurbIds).not.toHaveBeenCalled();
-    expect(expandBlurbs).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: OWNER_ID, restrictToBlurbIds: [] })
-    );
+    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ userId: OWNER_ID }));
+
+    // A resolver that yields the empty set — NOT `undefined`, which means "unrestricted". The
+    // two are different values of the same parameter and only one of them is safe here.
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(restrictToBlurbIds).toBeInstanceOf(Function);
+    expect(await restrictToBlurbIds()).toEqual([]);
   });
 
   it('🔴 restricts a TEMPLATED write too, which creates a new row despite carrying an id', async () => {
     await upsert({ templateId: 5, actorUserId: MODERATOR_ID, isModerator: true });
 
-    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ restrictToBlurbIds: [] }));
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(restrictToBlurbIds).toBeInstanceOf(Function);
+    expect(await restrictToBlurbIds()).toEqual([]);
   });
 
   it('leaves the OWNER creating a version unrestricted', async () => {

--- a/src/server/services/__tests__/blurb-model-wiring.test.ts
+++ b/src/server/services/__tests__/blurb-model-wiring.test.ts
@@ -192,11 +192,17 @@ describe('upsertModel — blurb expansion', () => {
   it('resolves only the blurbs the model already references when a moderator saves', async () => {
     await upsert({ userId: MODERATOR_ID, isModerator: true });
 
+    // Handed over as a RESOLVER, not an awaited array. `expandBlurbs` owns the flag gate
+    // and the has-spans check, so resolving the set before it is called reads
+    // BlurbReference on saves where the feature is off or no blurb is named.
+    const { restrictToBlurbIds } = expandBlurbs.mock.calls[0][0];
+    expect(getReferencedBlurbIds).not.toHaveBeenCalled();
+
+    expect(await restrictToBlurbIds()).toEqual([7]);
     expect(getReferencedBlurbIds).toHaveBeenCalledWith({
       entityType: 'Model',
       entityId: MODEL_ID,
     });
-    expect(expandBlurbs).toHaveBeenCalledWith(expect.objectContaining({ restrictToBlurbIds: [7] }));
   });
 
   it('leaves the owner unrestricted', async () => {

--- a/src/server/services/__tests__/blurb-reference-read-gate.test.ts
+++ b/src/server/services/__tests__/blurb-reference-read-gate.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as BlocklistService from '~/server/services/blocklist.service';
+import type * as DbLagHelpers from '~/server/db/db-lag-helpers';
+import type * as FliptClient from '~/server/flipt/client';
+import type * as RedisCaches from '~/server/redis/caches';
+import type * as ModelModerationAdapter from '~/server/services/model-moderation.adapter';
+import type * as ModelVersionService from '~/server/services/model-version.service';
+import type * as AutoNsfw from '~/server/services/auto-nsfw';
+
+// The seam `blurb-model-wiring.test.ts` cannot see. That suite mocks
+// `blurb-materialize.service` wholesale, so it pins which ARGUMENTS the service passes and
+// never executes the flag gate — the question of WHEN the blurb tables are read falls between
+// the two surfaces and is owned by neither.
+//
+// So this file runs `upsertModel` against the REAL blurb-materialize module and asserts on the
+// db mock: the invariant is that `BlurbReference` is not read unless the flag is on for the
+// owner AND the content actually carries blurb spans. Everything else is stubbed exactly as the
+// wiring suite stubs it (with no live Redis those awaits never settle and the tests hang).
+const {
+  throwOnBlockedLinkDomain,
+  submitModelTextModeration,
+  preventReplicationLag,
+  evaluateAutoNsfw,
+  isFlipt,
+} = vi.hoisted(() => ({
+  throwOnBlockedLinkDomain: vi.fn(),
+  submitModelTextModeration: vi.fn(),
+  preventReplicationLag: vi.fn(async () => undefined),
+  evaluateAutoNsfw: vi.fn(),
+  isFlipt: vi.fn(),
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof FliptClient>()),
+  isFlipt,
+}));
+vi.mock('~/server/services/blocklist.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof BlocklistService>()),
+  throwOnBlockedLinkDomain,
+}));
+vi.mock('~/server/services/model-moderation.adapter', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelModerationAdapter>()),
+  submitModelTextModeration,
+}));
+vi.mock('~/server/services/auto-nsfw', async (importOriginal) => ({
+  ...(await importOriginal<typeof AutoNsfw>()),
+  evaluateAutoNsfw,
+}));
+vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof DbLagHelpers>()),
+  preventReplicationLag,
+}));
+vi.mock('~/server/services/model-version.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelVersionService>()),
+  bustPublicModelResponseCache: vi.fn(async () => undefined),
+  bustMvCache: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/redis/caches', async (importOriginal) => {
+  const actual = await importOriginal<typeof RedisCaches>();
+  return {
+    ...actual,
+    userModelCountCache: { ...actual.userModelCountCache, refresh: vi.fn(async () => undefined) },
+    modelTagCache: { ...actual.modelTagCache, refresh: vi.fn(async () => undefined) },
+    modelVotableTagsCache: { ...actual.modelVotableTagsCache, bust: vi.fn(async () => undefined) },
+  };
+});
+
+import { upsertModel } from '~/server/services/model.service';
+
+const MODEL_ID = 51;
+const OWNER_ID = 7;
+const MODERATOR_ID = 9;
+
+const PLAIN_HTML = '<p>no blurbs here</p>';
+const BLURB_HTML = '<div data-type="blurb" data-id="7">CLIENT TEXT</div>';
+
+const storedModel = {
+  name: 'Stored name',
+  description: 'stored description',
+  poi: false,
+  userId: OWNER_ID,
+  minor: false,
+  sfwOnly: false,
+  nsfw: false,
+  lockedProperties: [],
+  gallerySettings: {},
+  meta: {},
+  availability: 'Public',
+  mode: null,
+  allowNoCredit: true,
+  allowCommercialUse: [],
+  allowDerivatives: true,
+  allowDifferentLicense: true,
+  type: 'Checkpoint',
+  uploadType: 'Created',
+};
+
+const upsert = (input: Record<string, unknown> = {}) =>
+  upsertModel({
+    id: MODEL_ID,
+    userId: OWNER_ID,
+    name: 'A model',
+    description: PLAIN_HTML,
+    type: 'Checkpoint',
+    uploadType: 'Created',
+    status: 'Draft',
+    ...input,
+  } as never);
+
+/** A moderator saving someone else's model — the only path that restricts the resolvable set. */
+const moderatorUpsert = (input: Record<string, unknown> = {}) =>
+  upsert({ userId: MODERATOR_ID, isModerator: true, ...input });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFlipt.mockResolvedValue(true);
+  throwOnBlockedLinkDomain.mockResolvedValue(undefined);
+  submitModelTextModeration.mockResolvedValue(undefined);
+  evaluateAutoNsfw.mockReturnValue(null);
+  dbMock.dbRead.blurbReference.findMany.mockResolvedValue([]);
+  dbMock.dbRead.blurb.findMany.mockResolvedValue([]);
+  dbMock.dbWrite.blurbReference.deleteMany.mockResolvedValue({ count: 0 });
+  dbMock.dbWrite.blurbReference.upsert.mockResolvedValue({});
+  dbMock.dbRead.model.findUnique.mockResolvedValue(storedModel);
+  dbMock.dbWrite.model.findUnique.mockResolvedValue({
+    name: storedModel.name,
+    nsfw: false,
+    lockedProperties: [],
+    meta: null,
+  });
+  dbMock.dbWrite.model.update.mockResolvedValue({
+    id: MODEL_ID,
+    name: 'A model',
+    description: PLAIN_HTML,
+    nsfwLevel: 1,
+    meta: {},
+    availability: 'Public',
+    userId: OWNER_ID,
+    poi: false,
+    minor: false,
+    sfwOnly: false,
+    nsfw: false,
+    status: 'Draft',
+    type: 'Checkpoint',
+  });
+  dbMock.dbWrite.model.create.mockResolvedValue({
+    id: MODEL_ID,
+    nsfwLevel: 1,
+    meta: {},
+    availability: 'Public',
+  });
+  dbMock.dbWrite.modelVersion.findMany.mockResolvedValue([]);
+  dbMock.dbWrite.$executeRaw.mockResolvedValue(1);
+});
+
+// `reconcileBlurbReferences` reads the SAME table with byte-identical arguments, so the db mock
+// cannot tell the two readers apart. Both cases below therefore pick a fixture in which
+// reconcile provably cannot run — flag off (`expansion.evaluated` is false) or no `description`
+// on the payload (`descriptionSupplied` is false) — which leaves the restrict read as the only
+// possible caller and makes the zero attributable.
+describe('BlurbReference is not read outside the feature gate', () => {
+  it('does not read BlurbReference when the flag is off for the owner', async () => {
+    isFlipt.mockResolvedValue(false);
+
+    await moderatorUpsert({ description: BLURB_HTML });
+
+    // Flag off means the feature is off, end to end. A read here is the kill switch failing to
+    // switch anything off — the residual production failure that survives flipping the flag
+    // while `BlurbReference` does not yet exist.
+    expect(dbMock.dbRead.blurbReference.findMany).not.toHaveBeenCalled();
+  });
+
+  it('does not read BlurbReference on a save that omits the description column', async () => {
+    // The review handlers select without `description`. Nothing about the blurb spans in the
+    // stored body can change on such a write, so the referenced-id set has nothing to filter.
+    await moderatorUpsert({ description: undefined });
+
+    expect(dbMock.dbRead.blurbReference.findMany).not.toHaveBeenCalled();
+  });
+
+  it('still reads BlurbReference when a moderator saves content that DOES carry spans', async () => {
+    // The positive control for the two zeros above: same suite, same fixture, one field changed.
+    // Without it a resolver wired to nothing would satisfy both assertions.
+    await moderatorUpsert({ description: BLURB_HTML });
+
+    expect(dbMock.dbRead.blurbReference.findMany).toHaveBeenCalledWith({
+      where: { entityType: 'Model', entityId: MODEL_ID },
+      select: { blurbId: true },
+    });
+  });
+
+  it('leaves the owner unrestricted — no restrict read even with spans present', async () => {
+    // Invariant guard, not a regression test: this held before the change too. It is here so a
+    // later "just resolve it for everyone" simplification of the restrict predicate goes red.
+    await upsert({ description: BLURB_HTML });
+
+    // Exactly one read, and it is reconcile's — the owner branch passes no restriction at all.
+    expect(dbMock.dbRead.blurbReference.findMany).toHaveBeenCalledTimes(1);
+    // …and the owner's own blurbs ARE resolved, so this is not "the path never ran".
+    expect(dbMock.dbRead.blurb.findMany).toHaveBeenCalled();
+  });
+});

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -852,7 +852,7 @@ export const upsertArticle = async ({
     // blurbs and would strip every span.
     const restrictToBlurbIds =
       article && article.userId !== userId
-        ? await getReferencedBlurbIds({ entityType: 'Article', entityId: article.id })
+        ? () => getReferencedBlurbIds({ entityType: 'Article', entityId: article.id })
         : undefined;
     const expansion = await expandBlurbs({
       userId: article?.userId ?? userId,

--- a/src/server/services/blurb-materialize.service.ts
+++ b/src/server/services/blurb-materialize.service.ts
@@ -41,8 +41,17 @@ export async function expandBlurbs({
    * owner passes the ids the entity already references: they can keep the blurbs that are
    * there, but a `data-id` they invent resolves to nothing instead of splicing the owner's
    * private blurb text into a response the editor reads back.
+   *
+   * A RESOLVER, not an array, because producing that set means reading `BlurbReference` and
+   * this function owns the two conditions under which any blurb table may be read at all: the
+   * flag is on for the owner, and the content actually names a blurb. A caller that awaited the
+   * ids itself did the read before either had been evaluated — so the feature's kill switch did
+   * not switch it off, and every ordinary save (no spans, which is nearly all of them) paid for
+   * a set with nothing to filter. The thunk makes that call-site shape unrepresentable rather
+   * than merely discouraged; `undefined` still means "no restriction" and `() => []` means
+   * "restricted to nothing", which an array could not distinguish from unset.
    */
-  restrictToBlurbIds?: number[];
+  restrictToBlurbIds?: () => number[] | Promise<number[]>;
 }): Promise<BlurbExpansion> {
   // Keyed on the owner rather than the actor so a rollout picks a sticky subset of creators.
   //
@@ -60,7 +69,9 @@ export async function expandBlurbs({
   if (!spans.length) return { evaluated: true, html, uses: [] };
 
   const spanIds = [...new Set(spans.map((s) => s.blurbId))];
-  const allowed = restrictToBlurbIds && new Set(restrictToBlurbIds);
+  // Resolved HERE — after the flag gate and after the no-spans return — because that is the
+  // first point at which the set is actually needed. See the `restrictToBlurbIds` doc above.
+  const allowed = restrictToBlurbIds && new Set(await restrictToBlurbIds());
   const ids = allowed ? spanIds.filter((id) => allowed.has(id)) : spanIds;
 
   const blurbs = ids.length

--- a/src/server/services/bounty.service.ts
+++ b/src/server/services/bounty.service.ts
@@ -488,7 +488,7 @@ export const upsertBounty = async ({
   const ownerId = stored?.userId ?? userId;
   const restrictToBlurbIds =
     id && ownerId !== userId
-      ? await getReferencedBlurbIds({ entityType: 'Bounty', entityId: id })
+      ? () => getReferencedBlurbIds({ entityType: 'Bounty', entityId: id })
       : undefined;
   const expansion = await expandBlurbs({
     userId: ownerId,

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -254,7 +254,7 @@ export const upsertCosmeticShopItem = async ({
   const ownerId = existingItem?.addedById ?? userId;
   const restrictToBlurbIds =
     existingItem && ownerId !== userId
-      ? await getReferencedBlurbIds({ entityType: 'CosmeticShopItem', entityId: existingItem.id })
+      ? () => getReferencedBlurbIds({ entityType: 'CosmeticShopItem', entityId: existingItem.id })
       : undefined;
   const expansion = await expandBlurbs({
     userId: ownerId,

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -592,11 +592,11 @@ export const upsertModelVersion = async ({
     model.userId === actorId
       ? undefined
       : editsExistingVersion
-      ? await getReferencedBlurbIds({ entityType: 'ModelVersion', entityId: id as number })
+      ? () => getReferencedBlurbIds({ entityType: 'ModelVersion', entityId: id as number })
       : // A new row references nothing yet, so there is no set to keep — and `undefined` here
         // would leave a moderator adding a version to someone else's model free to guess
         // `data-id`s and read the creator's private blurb text out of the response.
-        [];
+        () => [];
   // Whether the CALLER supplied the column, captured before the expansion overwrites it below.
   // A write that omits `description` — the review handlers select without it — must not
   // reconcile: Prisma leaves the column alone, so an empty expansion would delete every

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2384,7 +2384,7 @@ export const upsertModel = async (
   const ownerId = beforeUpdate?.userId ?? userId;
   const restrictToBlurbIds =
     beforeUpdate && ownerId !== userId
-      ? await getReferencedBlurbIds({ entityType: 'Model', entityId: id as number })
+      ? () => getReferencedBlurbIds({ entityType: 'Model', entityId: id as number })
       : undefined;
   // Whether the CALLER supplied the column, captured before the expansion overwrites it below.
   // A write that omits `description` — the review handlers select without it — must not


### PR DESCRIPTION
## What

`expandBlurbs` owns the two conditions under which any blurb table may be read: the `text-blurbs` flag is on for the **content owner**, and the content **actually names a blurb**. Five upsert services broke that — each `await`ed `getReferencedBlurbIds()` and passed the result in, so the read happened before either condition had been evaluated.

This makes `restrictToBlurbIds` a resolver and has `expandBlurbs` invoke it after the flag gate and after the no-spans early return, which is the first point the set is actually needed.

## Why now

`Blurb` and `BlurbReference` do not yet exist in the production database, so every read of them currently throws. Since ~19:20Z on 2026-08-27 these routes have been returning `INTERNAL_SERVER_ERROR` in production:

```
Invalid `prisma.blurbReference.findMany()` invocation:
The table `public.BlurbReference` does not exist in the current database.
```

`model.upsert`, `modelVersion.upsert`, `article.upsert`, `bounty.upsert` — plus `blurb.getMine` / `blurb.create` on `public.Blurb`. Introduced by #4414.

**This PR is not the fix for that.** That needs the `20260825000000_add_blurbs` migration applied. This PR fixes two things that are true independently of it:

1. **The kill switch does not switch it off.** With the flag off, `expandBlurbs` returns `evaluated: false` and every `reconcileBlurbReferences` call site is gated on that — but `getReferencedBlurbIds` runs before the gate. So a moderator editing someone else's model / version / article / bounty / shop item still hits `BlurbReference` with the feature switched off.
2. **Every ordinary save pays for a read with nothing to filter.** The referenced-id set exists solely to narrow the ids the content *names*. Of 752 sampled production failures across these routes, **752** were saves of content carrying no blurb span at all. Once the tables exist that read stops being an error and becomes a per-save query on the hot write paths.

## Shape

`restrictToBlurbIds?: number[]` → `restrictToBlurbIds?: () => number[] | Promise<number[]>`.

The thunk makes the eager call-site shape unrepresentable rather than merely discouraged, and preserves the distinction an array could not carry: `undefined` = "no restriction", `() => []` = "restricted to nothing" (the moderator-creating-a-new-row branch in `model-version.service.ts` depends on exactly that difference).

No behaviour change when the feature is on and a blurb span is present.

## Tests

`src/server/services/__tests__/blurb-reference-read-gate.test.ts` drives `upsertModel` against the **real** `blurb-materialize` module and asserts on the db mock — the seam `blurb-model-wiring.test.ts` cannot see, because that suite mocks the blurb module wholesale and so never executes the flag gate.

`reconcileBlurbReferences` reads the same table with byte-identical arguments, so both regression cases pick a fixture in which reconcile provably cannot run (flag off ⇒ `evaluated: false`; no `description` on the payload ⇒ `descriptionSupplied: false`). That leaves the restrict read as the only possible caller and makes the zero attributable. Each zero is paired with a positive control in the same suite.

**Red/green matrix** — `node scripts/test-unit-run.mjs src/server/services/__tests__/blurb-reference-read-gate.test.ts`

| ref | result |
|---|---|
| `ad51a8a7f9` (base, test file only) | **2 failed**, 2 passed |
| this branch | 4 passed |

The 2 that pass at base are the positive control and an invariant guard, labelled as such in the file.

**Mutation check.** Hoisting the resolution back above the flag gate kills exactly those 2, plus the 2 module-level laziness cases in `blurb-materialize.test.ts`, each on its own assertion — with the other 20 tests in those two files still passing.

Full `src/server/services/__tests__` suite: 368 files, 5219 passed. Typecheck error set is byte-identical to `ad51a8a7f9` (the local errors are a stale generated Prisma client, which CI regenerates).
