### PR TITLE
test(lint): widen no-wholesale-module-mock to the 3 modules a one-key mock actually breaks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,9 +111,55 @@ module.exports = {
     // modified-files pass is `continue-on-error: true`. So widening this list
     // holds NEW browser tests to the pattern and annotates the rest — it does
     // not retroactively fix them.
+    //
+    // THE THREE ENTRIES BELOW WERE PICKED BY MEASUREMENT, NOT BY MOCK VOLUME.
+    // The hazard is a wide export surface reached by many `src/` modules: any
+    // one of those importers landing in a test's graph kills the whole FILE. So
+    // the admission test is three conditions, all of which must hold:
+    //
+    //   (a) >= 15 exported bindings   — a surface wide enough that a one-key
+    //       factory is a landmine rather than a complete stand-in;
+    //   (b) >= 25 non-test `src/` importers — enough reach that some importer
+    //       plausibly lands in an unrelated suite's module graph;
+    //   (c) ZERO files violating this rule today — the entry must annotate
+    //       nothing retroactively, so no pre-existing file goes newly red.
+    //
+    // Enumerated (not sampled) over all 501 `~/`-specifiers any `src/` test
+    // wholesale-mocks: 27 clear (a)+(b), and exactly 3 of those also clear (c).
+    // Those 3 are listed. The rest fail ONLY on (c) and are deliberately left
+    // out rather than baselined — e.g. `~/server/common/constants` (97 exports,
+    // 352 importers) has 14 existing violators, `~/server/services/buzz.service`
+    // (37/61) has 110. They are the NEXT candidates, each gated behind
+    // converting its own violators first.
+    //
+    // Volume is explicitly NOT the criterion, and the counterexample matters:
+    // `~/hooks/useCurrentUser` is one-key-mocked by 108 files and is harmless,
+    // because it exports 2 things — a factory naming both IS the whole module.
+    // Listing it would turn ~108 files red to guard nothing.
+    //
+    //   module                                        exports  src importers  mocked by
+    //   ~/shared/data-graph/generation/config/workflows    27        32           1
+    //   ~/components/Image/image.utils                     17        29           1
+    //   ~/components/Sticker/sticker.util                  16        25           5
+    //
+    // `image.utils` is the worked example this list gap was found through: #4450
+    // added `ownContentPickerFilters` and had `remix-gallery.utils` import it,
+    // and `RemixGallerySubmitModal.browser.test.tsx`'s one-key factory then took
+    // the whole file out at collection — `Tests no tests`, 2150 others passing,
+    // nothing red (fixed in #4463). All 7 files mocking the three modules above
+    // already use the `importOriginal` spread; listing them is what stops the
+    // next one from not doing so.
     'local-rules/no-wholesale-module-mock': [
       'error',
-      { modules: ['~/utils/trpc', '~/components/Dialog/RoutedDialogLink'] },
+      {
+        modules: [
+          '~/utils/trpc',
+          '~/components/Dialog/RoutedDialogLink',
+          '~/shared/data-graph/generation/config/workflows',
+          '~/components/Image/image.utils',
+          '~/components/Sticker/sticker.util',
+        ],
+      },
     ],
 
     // aligns closing brackets for tags


### PR DESCRIPTION
## What

Adds three modules to `local-rules/no-wholesale-module-mock`'s `modules` list in `.eslintrc.js`. No rule code changes — the guard already implements exactly the check needed and simply was not watching these modules.

## Why

#4463 fixed a suite that had silently stopped existing: #4450 added `ownContentPickerFilters` to `~/components/Image/image.utils` and had `remix-gallery.utils` import it, so `RemixGallerySubmitModal.browser.test.tsx`'s one-key `vi.mock` factory made the whole file fail at collection — `Tests no tests` for that file, 2150 other tests passing, nothing red to point at.

The guard for that already existed. `~/components/Image/image.utils` was simply not on its list. **This is a list gap, not a missing rule.**

## How the three were picked — measured, not intuited

A module absent from this list is not "safe", it is *unwatched*. The hazard is a **wide export surface reached by many `src/` modules**: any one of those importers landing in an unrelated suite's module graph kills the whole file. So the admission test is three conditions, all required:

- **(a)** ≥ 15 exported bindings — wide enough that a one-key factory is a landmine rather than a complete stand-in
- **(b)** ≥ 25 non-test `src/` importers — enough reach to plausibly land in an unrelated suite's graph
- **(c)** **zero** files violating the rule today — the entry must annotate nothing retroactively

Enumerated rather than sampled, over all **501** `~/`-specifiers that any `src/` test wholesale-mocks: **27** clear (a)+(b), and exactly **3** of those also clear (c).

| module | exports | `src/` importers | tests mocking it |
|---|---|---|---|
| `~/shared/data-graph/generation/config/workflows` | 27 | 32 | 1 |
| `~/components/Image/image.utils` | 17 | 29 | 1 |
| `~/components/Sticker/sticker.util` | 16 | 25 | 5 |

Everything else fails **only** on (c) and is deliberately left out rather than baselined — `~/server/common/constants` (97 exports / 352 importers) has 14 existing violators, `~/server/services/buzz.service` has 110. Each is a good future candidate, gated behind converting its own violators first.

**Volume is explicitly not the criterion**, and the counterexample is the point: `~/hooks/useCurrentUser` is one-key-mocked by 108 files and is harmless, because it exports 2 things — a factory naming both *is* the whole module. Listing it would redden ~108 files to guard nothing.

## Verification

**The rule fires on a planted violation, and is clean without it** — a one-key factory per newly-listed module planted in a `*.browser.test.tsx`, under the real `.eslintrc.js` via `pnpm eslint`:

- plant present → exactly **3 errors**, each naming its own module
- plant removed → **clean, exit 0**
- **negative control**: the same planted file under the *pre-change* two-module list → **no findings**. That is what attributes the 3 errors to this change rather than to something else in the config.

**No pre-existing file goes newly red.** Rule run over all of `src/` with the final five-module list: 57 files for the pre-existing `~/utils/trpc` backlog, and **zero** attributable to the three added modules. All 7 files that mock these modules today already use the `importOriginal` spread — listing them is what stops the next one from not doing so.

**`pnpm test:lint-rules`** → `Test Files 24 passed (24)`, `Tests 359 passed (359)`, including `no-lint-rules-script-drift` (confirmed executed — 11 assertions, not skipped). No guard file was added or renamed, and nothing in `CLAUDE.md` or `.claude/agents/civitai-test-review.md` pins the module list, so neither needed updating.

## Scope / known ceiling (unchanged, deliberately)

The ESLint gate in `.github/workflows/lint.yml` blocks only **added** files; the modified-files pass is `continue-on-error: true`. So this holds **new** tests to the pattern and annotates the rest — it does not retroactively fix a stale mock in an existing test. Changing that is a policy decision affecting every contributor's PR and is not a rider on this change.

Not done, per the task's stated non-goals: no inversion to all-modules-with-allowlist, no `continue-on-error` change, no retroactive conversion of existing one-key mocks, and no listing of `~/hooks/useCurrentUser` / `~/providers/FeatureFlagsProvider` on volume alone.

## Blast radius

Reversible — one array in `.eslintrc.js`. Rollback is removing the three entries.
