### PR TITLE
fix(app-blocks): quote the orchestrator on a step estimate, and let the price check see a wrong declared price

### DIFF
--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -555,7 +555,7 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const stepPriceCheckTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_step_price_check_total',
-    "App Block `kind:'step'` prepaidFixed price checks, by step id and outcome. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = no numeric cost on the snapshot. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
+    "App Block `kind:'step'` price checks, by step id and outcome. Submit-phase outcomes are prepaidFixed-only; estimate-phase outcomes fire for any kind:'step' estimate. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = no numeric cost on the snapshot. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
     ['step', 'outcome']
   );
 
@@ -697,15 +697,37 @@ export type StepPriceCheckOutcome =
   | 'estimate_absent';
 
 /**
- * Fail-soft emit of ONE `prepaidFixed` step price check. Called from the step
- * submit path on EVERY submit, after the money has already moved.
+ * Fail-soft emit of ONE step price check.
  *
- * 🔴 Emitted unconditionally — including `outcome: 'exact'` — so a flat
- * divergence line can be told apart from a detector that never ran. See the
- * counter's definition above for why that distinction is load-bearing.
+ * 🔴 TWO CALL PHASES, AND THEY DIFFER IN EVERY WAY THAT MATTERS. This docstring
+ * used to say "called from the step submit path on EVERY submit, after the money
+ * has already moved" — that is now only half true, and the missing half is the
+ * dangerous one to assume:
  *
- * 🔴 TOTAL, like every emitter in this module. It reports on an already-billed
- * submit; a metrics error must never turn a successful generation into a 500.
+ *   - SUBMIT (`exact` / `over` / `over_reserved` / `absent`) — one emit per
+ *     submit, AFTER the money has moved, gated on
+ *     `plan.correctReservationOverage` and therefore on `prepaidFixed`.
+ *   - ESTIMATE (`estimate_quoted` / `estimate_absent`) — one emit per estimate,
+ *     BEFORE any spend exists, and NOT gated on billing mode: it fires for any
+ *     `kind:'step'` estimate. Unreachable for a non-`prepaidFixed` entry today
+ *     (registry load rejects every other mode), so the counter's
+ *     "prepaidFixed" framing still holds in practice — but the first
+ *     `timeBounded` entry would emit an estimate half with no submit-side
+ *     counterpart, and the `estimate_quoted : estimate_absent` ratio would then
+ *     blend a mode the submit half never reports on. Gate it here, or widen the
+ *     label, when that day comes.
+ *
+ * 🔴 DO NOT ADD A POST-BILLING SIDE EFFECT BESIDE THIS CALL. The estimate phase
+ * runs on an app-developer-driven surface with no spend behind it.
+ *
+ * 🔴 Emitted unconditionally within each phase — including `outcome: 'exact'` —
+ * so a flat divergence line can be told apart from a detector that never ran.
+ * See the counter's definition above for why that distinction is load-bearing.
+ *
+ * 🔴 TOTAL, like every emitter in this module. On the submit path it reports on
+ * an already-billed submit, so a metrics error must never turn a successful
+ * generation into a 500; on the estimate path it must never turn a working quote
+ * into an error.
  */
 export function recordStepPriceCheck(step: string, outcome: StepPriceCheckOutcome): void {
   try {

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -501,25 +501,61 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   // holds today. It was unverified before, and it is not guaranteed for a future
   // step type.)
   //
-  // So the `outcome` label carries the non-divergent case too:
-  //   exact  — realized cost ≤ the reservation. The healthy state, and PROOF the
-  //            detector is live.
-  //   over   — realized cost EXCEEDED the reservation. A registry bug: the entry
-  //            needs a higher price, or a different billing mode, because
-  //            "deterministic cost knowable before execution" was false for it.
-  //   absent — no numeric cost on the snapshot, so nothing could be compared.
-  //            The state that used to be indistinguishable from `exact`.
+  // 🔴 `over` USED TO MEAN "billed above the RESERVATION", AND ITS DESCRIPTION
+  // SAID "the declared price is wrong". Those are different claims, and the gap
+  // between them made this counter blind to exactly what it advertised.
+  // `reserveBuzz` is `max(declaredBuzz, quotedBuzz)` — it has already absorbed
+  // the orchestrator's live quote — so a step declared at 1 and quoted+billed at
+  // 4 computed `4 - 4 = 0` and was recorded `exact`. Measured on the live
+  // platform: two consecutive real `chat-completion` sends, declared 1, billed
+  // 4, `exact` both times.
   //
-  // Alert on `outcome="over"`; read `outcome="exact"` to confirm the check runs
-  // at all; investigate a rising `outcome="absent"`.
+  // The two questions are now separate values rather than one conflated one:
+  //
+  //   exact         — billed ≤ the declared price AND ≤ the reservation. Healthy,
+  //                   and PROOF the detector is live.
+  //   over          — billed above the DECLARED price, but within the
+  //                   reservation, because the submit's own `whatif` quote had
+  //                   already raised the reserve. Costs no money and loosens no
+  //                   cap: the registry's asserted price is simply not the real
+  //                   one.
+  //   over_reserved — billed above the RESERVATION. This is the expensive one:
+  //                   all three cap counters were short by the difference until
+  //                   the correction ran, so the per-app abuse ceiling was that
+  //                   much looser. Rare by construction, because the reserve is
+  //                   quote-backed.
+  //   absent        — no numeric cost on the submit snapshot, so nothing could
+  //                   be compared. The state that used to be indistinguishable
+  //                   from `exact`.
+  //
+  // …plus the ESTIMATE phase, which is a price check too — it is where the block
+  // learns what a call will cost:
+  //
+  //   estimate_quoted — the estimate got a live orchestrator quote.
+  //   estimate_absent — it could not, and fell back to the declared price. The
+  //                     block was shown a number nothing re-measured.
+  //
+  // 🔴 THE PAIR IS THE POINT. `estimate_absent` alone is unreadable: a flat zero
+  // is indistinguishable from an estimate path that never executes. Read the
+  // RATIO against `estimate_quoted`, never the bare count.
+  //
+  // 🔴 ALERT ON `over_reserved`, NOT ON `over`. `over` is expected to sit at ~100%
+  // for any entry whose real price is usage-based — `chat-completion` is one
+  // (its live price moves with the model and the token budget, while its declared
+  // constant is the floor the orchestrator will not go below), so alerting on
+  // `over` there would be a permanently-red gate and would train everyone to
+  // ignore it. `over` is a REPORT that a declared constant does not describe
+  // reality; `over_reserved` is the thing that costs money. Read
+  // `outcome="exact"` to confirm the check runs at all; investigate a rising
+  // `absent` or a falling `estimate_quoted`/`estimate_absent` ratio.
   //
   // Cardinality: `step` is drawn from the code-owned registry keys (never client
   // input — the wire enum derives from those same keys, so an unregistered id
-  // cannot reach here); `outcome` is a closed 3-value set. Bounded and small.
+  // cannot reach here); `outcome` is a closed 6-value set. Bounded and small.
   const stepPriceCheckTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_step_price_check_total',
-    "App Block `kind:'step'` prepaidFixed price checks at submit, by step id and outcome (exact = realized cost within the reservation; over = the orchestrator billed MORE than reserved, i.e. the declared price is wrong; absent = the snapshot carried no numeric cost, so no comparison was possible)",
+    "App Block `kind:'step'` prepaidFixed price checks, by step id and outcome. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = no numeric cost on the snapshot. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
     ['step', 'outcome']
   );
 
@@ -652,7 +688,13 @@ export function observeAppBlockLaunch(
  * it a union (rather than a bare string) is what bounds the label cardinality at
  * the type level — a caller cannot invent a fourth value.
  */
-export type StepPriceCheckOutcome = 'exact' | 'over' | 'absent';
+export type StepPriceCheckOutcome =
+  | 'exact'
+  | 'over'
+  | 'over_reserved'
+  | 'absent'
+  | 'estimate_quoted'
+  | 'estimate_absent';
 
 /**
  * Fail-soft emit of ONE `prepaidFixed` step price check. Called from the step

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -555,7 +555,7 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const stepPriceCheckTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_step_price_check_total',
-    "App Block `kind:'step'` price checks, by step id and outcome. Submit-phase outcomes are prepaidFixed-only; estimate-phase outcomes fire for any kind:'step' estimate. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = EITHER the submit was refused because the orchestrator returned no price quote (no spend, no generation - triage as availability) OR a billed submit carried no numeric cost. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
+    "App Block `kind:'step'` price checks, by step id and outcome. Only the post-billing submit outcomes are prepaidFixed-gated; the fail-closed absent and the estimate-phase outcomes fire for any kind:'step' request. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = EITHER the submit was refused because the orchestrator returned no price quote (no spend, no generation - triage as availability) OR a billed submit carried no numeric cost. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
     ['step', 'outcome']
   );
 
@@ -707,8 +707,8 @@ export type StepPriceCheckOutcome =
  *   - SUBMIT, POST-BILLING (`exact` / `over` / `over_reserved`) — one emit per
  *     billed submit, AFTER the money has moved, gated on
  *     `plan.correctReservationOverage` and therefore on `prepaidFixed`.
- *   - SUBMIT, PRE-BILLING (`absent`) — 🔴 TWO DIFFERENT SITES SHARE THIS VALUE,
- *     AND THEY HAVE OPPOSITE POLARITY. One is post-billing (the submit
+ *   - SUBMIT, EITHER SIDE OF BILLING (`absent`) — 🔴 TWO DIFFERENT SITES SHARE
+ *     THIS VALUE, AND THEY HAVE OPPOSITE POLARITY. One is post-billing (the submit
  *     succeeded but its snapshot carried no numeric cost, so no comparison was
  *     possible). The other is the FAIL-CLOSED no-quote path: the orchestrator
  *     returned no price, so the submit is REFUSED, nothing is reserved, no
@@ -718,6 +718,10 @@ export type StepPriceCheckOutcome =
  *     triage it as an availability signal first. (Splitting the two is the
  *     obvious improvement and is deliberately not done here: it would change a
  *     label's meaning in the same change that already widened the set.)
+ *     🔴 The fail-closed site is NOT mode-gated either — it sits above the
+ *     `correctReservationOverage` block — so the same caveat as the estimate
+ *     bullet applies: it is `prepaidFixed`-only today because registry load
+ *     rejects every other mode, not because this site checks.
  *   - ESTIMATE (`estimate_quoted` / `estimate_absent`) — one emit per estimate,
  *     BEFORE any spend exists, and NOT gated on billing mode: it fires for any
  *     `kind:'step'` estimate. Unreachable for a non-`prepaidFixed` entry today

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -555,7 +555,7 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const stepPriceCheckTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_step_price_check_total',
-    "App Block `kind:'step'` price checks, by step id and outcome. Submit-phase outcomes are prepaidFixed-only; estimate-phase outcomes fire for any kind:'step' estimate. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = no numeric cost on the snapshot. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
+    "App Block `kind:'step'` price checks, by step id and outcome. Submit-phase outcomes are prepaidFixed-only; estimate-phase outcomes fire for any kind:'step' estimate. Submit phase: exact = billed within both the declared price and the reservation; over = billed above the DECLARED price but within the quote-backed reservation (the declared constant is wrong; no money or cap impact — expected to be ~100% for a usage-priced step, do NOT alert on it); over_reserved = billed above the RESERVATION, so every cap counter was short until corrected (ALERT ON THIS); absent = EITHER the submit was refused because the orchestrator returned no price quote (no spend, no generation - triage as availability) OR a billed submit carried no numeric cost. Estimate phase: estimate_quoted = the block was shown a live orchestrator quote; estimate_absent = the quote failed and it was shown the declared price instead (read as a ratio against estimate_quoted, never alone)",
     ['step', 'outcome']
   );
 
@@ -704,9 +704,20 @@ export type StepPriceCheckOutcome =
  * has already moved" — that is now only half true, and the missing half is the
  * dangerous one to assume:
  *
- *   - SUBMIT (`exact` / `over` / `over_reserved` / `absent`) — one emit per
- *     submit, AFTER the money has moved, gated on
+ *   - SUBMIT, POST-BILLING (`exact` / `over` / `over_reserved`) — one emit per
+ *     billed submit, AFTER the money has moved, gated on
  *     `plan.correctReservationOverage` and therefore on `prepaidFixed`.
+ *   - SUBMIT, PRE-BILLING (`absent`) — 🔴 TWO DIFFERENT SITES SHARE THIS VALUE,
+ *     AND THEY HAVE OPPOSITE POLARITY. One is post-billing (the submit
+ *     succeeded but its snapshot carried no numeric cost, so no comparison was
+ *     possible). The other is the FAIL-CLOSED no-quote path: the orchestrator
+ *     returned no price, so the submit is REFUSED, nothing is reserved, no
+ *     generation happens, and this fires before any money exists and outside the
+ *     `correctReservationOverage` gate. A spike in `absent` is therefore far
+ *     more likely to mean SUBMITS ARE BEING REFUSED than a bookkeeping gap —
+ *     triage it as an availability signal first. (Splitting the two is the
+ *     obvious improvement and is deliberately not done here: it would change a
+ *     label's meaning in the same change that already widened the set.)
  *   - ESTIMATE (`estimate_quoted` / `estimate_absent`) — one emit per estimate,
  *     BEFORE any spend exists, and NOT gated on billing mode: it fires for any
  *     `kind:'step'` estimate. Unreachable for a non-`prepaidFixed` entry today
@@ -717,8 +728,9 @@ export type StepPriceCheckOutcome =
  *     blend a mode the submit half never reports on. Gate it here, or widen the
  *     label, when that day comes.
  *
- * 🔴 DO NOT ADD A POST-BILLING SIDE EFFECT BESIDE THIS CALL. The estimate phase
- * runs on an app-developer-driven surface with no spend behind it.
+ * 🔴 DO NOT ADD A POST-BILLING SIDE EFFECT BESIDE THIS CALL. Only the three
+ * outcomes in the first bullet are reached with money behind them; the estimate
+ * phase and the fail-closed `absent` both run with no spend at all.
  *
  * 🔴 Emitted unconditionally within each phase — including `outcome: 'exact'` —
  * so a flat divergence line can be told apart from a detector that never ran.

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -7329,7 +7329,7 @@ describe("step-type registry bridge (kind: 'step')", () => {
 
   describe('estimateWorkflow', () => {
     // ─────────────────────────────────────────────────────────────────────────
-    // 🔴 THE ESTIMATE NOW QUOTES THE ORCHESTRATOR (clawgate #386).
+    // 🔴 THE ESTIMATE NOW QUOTES THE ORCHESTRATOR.
     //
     // The first test here used to be "returns the registry DISPLAY estimate with
     // NO orchestrator round-trip", asserting `mockSubmitWorkflow` was never
@@ -7386,11 +7386,93 @@ describe("step-type registry bridge (kind: 'step')", () => {
       expect(result.snapshot.cost.total).toBe(STEP_PRICE);
     });
 
-    it('the estimate EQUALS what submit reserves and charges', async () => {
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 A SILENT FALLBACK IS THE SAME DEFECT THIS CHANGE EXISTS TO REMOVE.
+    // Without a counter on both arms, "the block saw a live quote" and "the
+    // orchestrator was down and the block saw the declared floor again" are
+    // indistinguishable in production — an unmeasured assertion, exactly like
+    // the declared price was. The PAIR is asserted, not just the failure arm:
+    // a bare `estimate_absent` of zero cannot be told apart from an estimate
+    // path that never runs.
+    // ─────────────────────────────────────────────────────────────────────────
+    it('counts a successful quote as estimate_quoted', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
-      happyStepSubmit();
+      stepSubmitQuoting(4, 4);
+      await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'estimate_quoted');
+      expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'estimate_absent');
+    });
+
+    it('counts a DEGRADED estimate as estimate_absent — on a throw and on a missing cost', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'estimate_absent');
+
+      mockRecordStepPriceCheck.mockClear();
+      stepSubmitQuoting(null, 1);
+      await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'estimate_absent');
+      expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'estimate_quoted');
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 A DETERMINISTIC REFUSAL MUST PROPAGATE, NOT DEGRADE INTO A PRICE.
+    //
+    // `buildStepOrchestratorStep` throws FORBIDDEN on a `$type` divergence and
+    // on an AIR reference in the built input. While the build sat inside the
+    // quote's `catch`, both became "no quote" and the estimate answered HTTP 200
+    // with the declared price for a body the submit refuses outright — the exact
+    // estimate/submit drift this surface exists to prevent, resolving to the
+    // very number the change exists to stop showing.
+    // ─────────────────────────────────────────────────────────────────────────
+    it('REJECTS an AIR reference in the built input, as submit does', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(4, 4);
+      await expect(
+        caller().estimateWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            params: {
+              image: 'https://image.civitai.com/urn:air:sd1/checkpoint.png',
+              output: { format: 'webp' },
+            },
+          }),
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      // …and it refused BEFORE the orchestrator was called at all.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('mirrors the submit’s max(declared, quoted) — a quote BELOW the floor never under-displays', async () => {
+      // 🔴 THE UNDER-DISPLAY DIRECTION, which a block cannot defend against: the
+      // submit gates and reserves `max(declared, quoted)`, so an estimate that
+      // simply preferred the quote would show less than the submit reserves.
+      // Latent today; reachable the moment an entry is declared above its real
+      // orchestrator price.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(0, 0);
       const estimate = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(estimate.snapshot.cost.total).toBe(STEP_PRICE);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', STEP_PRICE);
+    });
+
+    it('the estimate equals what submit reserves — on a DIVERGENT quote, not a matching one', async () => {
+      // 🔴 THIS USED TO BE VACUOUS. With `happyStepSubmit()` the quote and the
+      // declared price were both 1, so it passed even with the estimate ignoring
+      // the quote entirely — it could not fail. Quoting 4 against a declared 1
+      // makes the two answers distinguishable, so the assertion has something to
+      // say.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(4, 4);
+      const estimate = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(estimate.snapshot.cost.total).toBe(4);
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', estimate.snapshot.cost.total);
     });
@@ -7970,20 +8052,60 @@ describe("step-type registry bridge (kind: 'step')", () => {
       expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'exact');
     });
 
-    it("records outcome 'over' when the orchestrator bills above the reservation", async () => {
+    it("records 'over_reserved' when the orchestrator bills above the reservation", async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
       stepSubmitQuoting(1, 9);
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
-      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'over');
+      // The expensive case: every cap counter was short until the correction ran.
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'over_reserved');
       expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'exact');
-      // The cap correction is still driven by the RESERVATION gap: reserved
-      // max(1, 1) = 1, billed 9, so the three counters are short by 8.
-      expect(mockChargeAppSpendOverage).toHaveBeenCalledWith(expect.anything(), 8);
+      expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'over');
     });
 
     // ─────────────────────────────────────────────────────────────────────────
-    // 🔴 THE CASE THE OLD COMPARISON WAS STRUCTURALLY BLIND TO (clawgate #386).
+    // 🔴 THE CORRECTION AMOUNTS, ON A FIXTURE WHERE THE TWO CANDIDATES DIFFER.
+    //
+    // The obvious fixture — declared 1 / quoted 1 / billed 9 — puts
+    // `capOverage` and `priceOverage` BOTH at 8, so an assertion on `8` cannot
+    // tell them apart and every correction site is free to use the wrong one.
+    // Measured: with that fixture, swapping the per-user, per-app OR dev-session
+    // correction to `priceOverage` SURVIVES the whole suite. That is a fixture
+    // landing exactly on its own boundary, in the money arithmetic.
+    //
+    // declared 1 · quoted 4 · billed 9 → reserve 4 → capOverage 5, priceOverage 8.
+    // Every assertion below is on 5, and 8 is the value the wrong variable
+    // produces — so each one kills its own mutant.
+    // ─────────────────────────────────────────────────────────────────────────
+    it('corrects ALL THREE cap counters by the RESERVATION gap, not the declared gap', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'devsess_1', spendCapBuzz: 500 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 1 });
+      stepSubmitQuoting(4, 9);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+
+      const capOverage = 5; // billed 9 − reserve max(1,4)=4
+      const declaredGap = 8; // billed 9 − declared 1  ← what the wrong variable gives
+
+      // per-user cap (sysRedis INCRBY on the buzz-cap key)
+      const userCorrections = mockSysRedis.incrBy.mock.calls
+        .filter((c: unknown[]) => String(c[0]).startsWith('system:blocks:buzz-cap:'))
+        .map((c: unknown[]) => c[1]);
+      expect(userCorrections).toContain(capOverage);
+      expect(userCorrections).not.toContain(declaredGap);
+
+      // per-app cap
+      expect(mockChargeAppSpendOverage).toHaveBeenCalledWith(expect.anything(), capOverage);
+      expect(mockChargeAppSpendOverage).not.toHaveBeenCalledWith(expect.anything(), declaredGap);
+
+      // dev-session cap
+      expect(mockChargeDevSessionOverage).toHaveBeenCalledWith('devsess_1', capOverage);
+      expect(mockChargeDevSessionOverage).not.toHaveBeenCalledWith('devsess_1', declaredGap);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 THE CASE THE OLD COMPARISON WAS STRUCTURALLY BLIND TO.
     //
     // `reserveBuzz` is `max(declaredBuzz, quotedBuzz)`, so it has ALREADY
     // absorbed the orchestrator's live quote. A step declared at 1 and quoted +
@@ -7992,9 +8114,9 @@ describe("step-type registry bridge (kind: 'step')", () => {
     // declared price is wrong". The metric's description was wider than its
     // implementation, which is worse than no metric: it read as coverage.
     //
-    // Measured 2026-08-27 on the live platform: `chat-completion` declared 1 and
-    // billed 4 on two consecutive real sends, and this counter said `exact` both
-    // times.
+    // Measured 2026-08-27 on the live platform: `chat-completion` billed several
+    // times its declared price on consecutive real sends, and this counter said
+    // `exact` every time.
     //
     // 🔴 THIS TEST FAILS AGAINST THE `reserveBuzz` COMPARISON. Verified by
     // reverting the comparison at the pre-fix commit: it records `exact`, so
@@ -8055,7 +8177,14 @@ describe("step-type registry bridge (kind: 'step')", () => {
       // Two submits, one emit each.
       expect(mockRecordStepPriceCheck).toHaveBeenCalledTimes(2);
       for (const call of mockRecordStepPriceCheck.mock.calls) {
-        expect(['exact', 'over', 'absent']).toContain(call[1]);
+        expect([
+          'exact',
+          'over',
+          'over_reserved',
+          'absent',
+          'estimate_quoted',
+          'estimate_absent',
+        ]).toContain(call[1]);
         expect(call[0]).toBe(STEP_ID);
       }
     });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -271,6 +271,16 @@ const { DIVERGENT_STEP_ID } = vi.hoisted(() => ({
 const { SPLIT_FLOOR_STEP_ID } = vi.hoisted(() => ({
   SPLIT_FLOOR_STEP_ID: 'fixture-split-floor-step',
 }));
+// 🔴 THE MIRROR OF THE SPLIT-FLOOR FIXTURE, and it exists because the FIRST
+// attempt at that fix reasoned wrongly. The claim was that `estimateBuzz` can
+// only differ UPWARD from `priceForVariant`; the split-floor entry disproves it
+// downward, and this one disproves it upward — the direction is simply not
+// fixed. This one makes the no-quote FALLBACK observable: canonical params take
+// the cheap branch so the load-time invariant holds, while a `{pricey: true}`
+// request answers `estimateBuzz` 9 against `priceForVariant` 5.
+const { HIGH_ESTIMATE_STEP_ID } = vi.hoisted(() => ({
+  HIGH_ESTIMATE_STEP_ID: 'fixture-high-estimate-step',
+}));
 vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
   const actual = await importOriginal<typeof BlockStepsModule>();
   const z = await import('zod');
@@ -331,9 +341,6 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
     canonicalOutputFor: () => ({}),
   };
   actual.assertStepInvariants(AUDITED_STEP_ID, auditedFixtureStep as never);
-  // 🔴 THIS ASSERTION IS THE EXPLOIT, WRITTEN DOWN. It passes — a
-  // params-dependent builder is registrable — which is precisely why the
-  // load-time gate alone is not sufficient.
   const splitFloorFixtureStep = {
     id: SPLIT_FLOOR_STEP_ID,
     orchestratorType: 'fixtureSplitFloorType',
@@ -357,10 +364,27 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
     ],
     canonicalOutputFor: () => ({}),
   };
+  // 🔴 THIS ASSERTION IS THE EXPLOIT, WRITTEN DOWN. It passes — a
+  // params-dependent builder is registrable — which is precisely why the
+  // load-time gate alone is not sufficient.
   actual.assertStepInvariants(DIVERGENT_STEP_ID, divergentFixtureStep as never);
   // 🔴 IT REGISTERS CLEANLY — the second half of the exploit written down. Only a
   // request supplying `cheap: true` splits the two floors apart.
   actual.assertStepInvariants(SPLIT_FLOOR_STEP_ID, splitFloorFixtureStep as never);
+  const highEstimateFixtureStep = {
+    ...splitFloorFixtureStep,
+    id: HIGH_ESTIMATE_STEP_ID,
+    orchestratorType: 'fixtureHighEstimateType',
+    paramSchema: z.object({ pricey: z.boolean() }).strict(),
+    canonicalParamsFor: () => ({ pricey: false }),
+    priceForVariant: () => 5,
+    estimateBuzz: (p: { pricey: boolean }) => (p.pricey ? 9 : 5),
+    buildStep: (p: { pricey: boolean }) => ({
+      $type: 'fixtureHighEstimateType',
+      input: { pricey: p.pricey },
+    }),
+  };
+  actual.assertStepInvariants(HIGH_ESTIMATE_STEP_ID, highEstimateFixtureStep as never);
   return {
     ...actual,
     // The wire `step` enum is DERIVED from this, so widening it is what lets the
@@ -370,6 +394,7 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
       AUDITED_STEP_ID,
       DIVERGENT_STEP_ID,
       SPLIT_FLOOR_STEP_ID,
+      HIGH_ESTIMATE_STEP_ID,
     ],
     getStep: (id: string) =>
       id === AUDITED_STEP_ID
@@ -378,6 +403,8 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
         ? (divergentFixtureStep as never)
         : id === SPLIT_FLOOR_STEP_ID
         ? (splitFloorFixtureStep as never)
+        : id === HIGH_ESTIMATE_STEP_ID
+        ? (highEstimateFixtureStep as never)
         : actual.getStep(id),
   };
 });
@@ -7511,10 +7538,30 @@ describe("step-type registry bridge (kind: 'step')", () => {
       expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 5);
     });
 
-    it('mirrors the submit’s max(declared, quoted) — a quote BELOW the floor never under-displays', async () => {
+    it('falls back to the entry’s DECLARED estimate, not to the floor, when no quote is had', async () => {
+      // 🔴 THE OPERAND NO MUTATION COULD KILL — until this fixture existed.
+      // `quotedBuzz ?? declaredBuzz` → `?? 0` (or `?? submitFloorBuzz`) survived
+      // the whole suite, and that was written up as "unreachable, and in the safe
+      // direction". BOTH claims were wrong. `fixture-high-estimate-step` answers
+      // `estimateBuzz` 9 against a `priceForVariant` of 5 for `{pricey: true}`,
+      // and it registers cleanly — so with the quote unavailable the fallback is
+      // 9 and the mutants show 5: a 44% UNDER-display, on the degraded path,
+      // which is exactly the direction this whole area exists to prevent.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      const estimate = await caller().estimateWorkflow({
+        blockToken: 'tok',
+        body: { kind: 'step' as const, step: HIGH_ESTIMATE_STEP_ID, params: { pricey: true } },
+      });
+      expect(estimate.snapshot.cost.total).toBe(9);
+    });
+
+    it('mirrors the submit’s max(floor, quoted) — a quote BELOW the floor never under-displays', async () => {
       // 🔴 THE UNDER-DISPLAY DIRECTION, which a block cannot defend against: the
-      // submit gates and reserves `max(declared, quoted)`, so an estimate that
-      // simply preferred the quote would show less than the submit reserves.
+      // submit gates and reserves `max(Math.ceil(plan.reserveBuzz), quoted)`, so
+      // an estimate that simply preferred the quote would show less than the
+      // submit reserves.
       // Latent today; reachable the moment an entry is declared above its real
       // orchestrator price.
       mockVerifyBlockToken.mockResolvedValue(stepClaims());

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -7328,24 +7328,69 @@ describe("step-type registry bridge (kind: 'step')", () => {
   const caller = () => blocksRouter.createCaller(fakeCtx() as never);
 
   describe('estimateWorkflow', () => {
-    it('returns the registry DISPLAY estimate with NO orchestrator round-trip', async () => {
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 THE ESTIMATE NOW QUOTES THE ORCHESTRATOR (clawgate #386).
+    //
+    // The first test here used to be "returns the registry DISPLAY estimate with
+    // NO orchestrator round-trip", asserting `mockSubmitWorkflow` was never
+    // called. That was the bug, pinned: `kind: 'step'` was the ONLY branch of
+    // `estimateWorkflow` that did not whatif, so a block was shown a number the
+    // platform had merely asserted while the submit billed whatever the
+    // orchestrator said. Measured on `chat-completion`: declared 1, charged 4,
+    // twice, with a published listing quoting the 1 to users.
+    // ─────────────────────────────────────────────────────────────────────────
+    it('returns the ORCHESTRATOR QUOTE, not the declared constant', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
+      stepSubmitQuoting(4, 4);
       const result = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(result.snapshot).toMatchObject({
         workflowId: 'wf_estimate',
         status: 'pending',
-        cost: { total: STEP_PRICE },
+        cost: { total: 4 },
       });
-      // 🔴 "Deterministic cost knowable BEFORE execution" — no whatIf, no submit.
-      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      // 🔴 THE CONTROL. `STEP_PRICE` is 1, so a quote of 4 is a value the
+      // declared constant CANNOT produce — the assertion cannot be satisfied by
+      // the old code path.
+      expect(result.snapshot.cost.total).not.toBe(STEP_PRICE);
+    });
+
+    it('quotes with whatif ONLY — an estimate never makes a real submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(4, 4);
+      await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      expect(mockSubmitWorkflow.mock.calls[0][0]).toMatchObject({ query: { whatif: true } });
+      expect(realSubmitCalls()).toHaveLength(0);
+    });
+
+    it('falls back to the DECLARED estimate when the quote throws', async () => {
+      // 🔴 DEGRADE, NEVER ERROR. An unquotable step is exactly the pre-#386
+      // behaviour, so this path can only be more accurate than what it replaced
+      // — it must not turn a working estimate into a failure the block cannot
+      // act on. (The SUBMIT still fails closed on a missing quote; that is the
+      // path where the number bounds real money.)
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      const result = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.cost.total).toBe(STEP_PRICE);
+    });
+
+    it('falls back to the DECLARED estimate when the quote carries no numeric cost', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(null, 1);
+      const result = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.cost.total).toBe(STEP_PRICE);
     });
 
     it('the estimate EQUALS what submit reserves and charges', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
-      const estimate = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
       happyStepSubmit();
+      const estimate = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', estimate.snapshot.cost.total);
     });
@@ -7932,6 +7977,52 @@ describe("step-type registry bridge (kind: 'step')", () => {
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'over');
       expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'exact');
+      // The cap correction is still driven by the RESERVATION gap: reserved
+      // max(1, 1) = 1, billed 9, so the three counters are short by 8.
+      expect(mockChargeAppSpendOverage).toHaveBeenCalledWith(expect.anything(), 8);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 THE CASE THE OLD COMPARISON WAS STRUCTURALLY BLIND TO (clawgate #386).
+    //
+    // `reserveBuzz` is `max(declaredBuzz, quotedBuzz)`, so it has ALREADY
+    // absorbed the orchestrator's live quote. A step declared at 1 and quoted +
+    // billed at 4 therefore computed `4 - 4 = 0` and was recorded `exact` —
+    // while `app-block-runtime.metrics.ts` documents `over` as meaning "the
+    // declared price is wrong". The metric's description was wider than its
+    // implementation, which is worse than no metric: it read as coverage.
+    //
+    // Measured 2026-08-27 on the live platform: `chat-completion` declared 1 and
+    // billed 4 on two consecutive real sends, and this counter said `exact` both
+    // times.
+    //
+    // 🔴 THIS TEST FAILS AGAINST THE `reserveBuzz` COMPARISON. Verified by
+    // reverting the comparison at the pre-fix commit: it records `exact`, so
+    // both assertions below flip. It is a regression test, not an invariant
+    // guard.
+    // ─────────────────────────────────────────────────────────────────────────
+    it("records 'over' when the DECLARED price is wrong but the quote absorbed it", async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      // declared STEP_PRICE (1) · quoted 4 · billed 4 → reserve = max(1,4) = 4.
+      stepSubmitQuoting(4, 4);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'over');
+      expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'exact');
+    });
+
+    it('…and does NOT invent a cap correction for a reservation that was already right', async () => {
+      // 🔴 THE OTHER HALF, AND THE ONE A CARELESS FIX BREAKS. Switching the cap
+      // correction to `declaredBuzz` as well would top the counters up by 3 for
+      // money nobody spent — the caps were reserved at 4 and billed 4. The
+      // signal moved; the money did not.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(4, 4);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 4);
+      expect(mockChargeAppSpendOverage).not.toHaveBeenCalled();
     });
 
     it("records outcome 'absent' when the submit snapshot carries NO numeric cost", async () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -261,6 +261,16 @@ const { AUDITED_STEP_ID } = vi.hoisted(() => ({ AUDITED_STEP_ID: 'fixture-audite
 const { DIVERGENT_STEP_ID } = vi.hoisted(() => ({
   DIVERGENT_STEP_ID: 'fixture-divergent-step',
 }));
+// 🔴 A FIXTURE WHOSE TWO DECLARED FLOORS LEGITIMATELY DISAGREE. The registry's
+// load-time invariant ties `estimateBuzz(canonicalParamsFor(v))` to
+// `priceForVariant(v)` — at CANONICAL params only — and nothing re-checks it at
+// request time. `estimateBuzz` takes PARAMS, so an entry can satisfy the
+// invariant and still answer differently for a request. That is registrable, it
+// is asserted below, and it is exactly the shape that makes the estimate's floor
+// and the submit's floor two different numbers.
+const { SPLIT_FLOOR_STEP_ID } = vi.hoisted(() => ({
+  SPLIT_FLOOR_STEP_ID: 'fixture-split-floor-step',
+}));
 vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
   const actual = await importOriginal<typeof BlockStepsModule>();
   const z = await import('zod');
@@ -324,17 +334,50 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
   // 🔴 THIS ASSERTION IS THE EXPLOIT, WRITTEN DOWN. It passes — a
   // params-dependent builder is registrable — which is precisely why the
   // load-time gate alone is not sufficient.
+  const splitFloorFixtureStep = {
+    id: SPLIT_FLOOR_STEP_ID,
+    orchestratorType: 'fixtureSplitFloorType',
+    billingMode: 'prepaidFixed' as const,
+    moderationPosture: 'none' as const,
+    resourcePolicy: { kind: 'none' as const },
+    paramSchema: z.object({ cheap: z.boolean() }).strict(),
+    variants: ['default'],
+    resolveVariant: () => 'default',
+    // Canonical params take the EXPENSIVE branch, so the load-time invariant
+    // (estimateBuzz(canonical) === priceForVariant) holds and this registers.
+    canonicalParamsFor: () => ({ cheap: false }),
+    priceForVariant: () => 5,
+    estimateBuzz: (p: { cheap: boolean }) => (p.cheap ? 1 : 5),
+    buildStep: (p: { cheap: boolean }) => ({
+      $type: 'fixtureSplitFloorType',
+      input: { cheap: p.cheap },
+    }),
+    extractOutput: () => [
+      { url: 'https://blobs.example/s.webp', width: null, height: null, nsfwLevel: null },
+    ],
+    canonicalOutputFor: () => ({}),
+  };
   actual.assertStepInvariants(DIVERGENT_STEP_ID, divergentFixtureStep as never);
+  // 🔴 IT REGISTERS CLEANLY — the second half of the exploit written down. Only a
+  // request supplying `cheap: true` splits the two floors apart.
+  actual.assertStepInvariants(SPLIT_FLOOR_STEP_ID, splitFloorFixtureStep as never);
   return {
     ...actual,
     // The wire `step` enum is DERIVED from this, so widening it is what lets the
     // fixture id past `blockStepBodySchema` and into the handler.
-    REGISTERED_STEP_IDS: [...actual.REGISTERED_STEP_IDS, AUDITED_STEP_ID, DIVERGENT_STEP_ID],
+    REGISTERED_STEP_IDS: [
+      ...actual.REGISTERED_STEP_IDS,
+      AUDITED_STEP_ID,
+      DIVERGENT_STEP_ID,
+      SPLIT_FLOOR_STEP_ID,
+    ],
     getStep: (id: string) =>
       id === AUDITED_STEP_ID
         ? (auditedFixtureStep as never)
         : id === DIVERGENT_STEP_ID
         ? (divergentFixtureStep as never)
+        : id === SPLIT_FLOOR_STEP_ID
+        ? (splitFloorFixtureStep as never)
         : actual.getStep(id),
   };
 });
@@ -7366,7 +7409,7 @@ describe("step-type registry bridge (kind: 'step')", () => {
     });
 
     it('falls back to the DECLARED estimate when the quote throws', async () => {
-      // 🔴 DEGRADE, NEVER ERROR. An unquotable step is exactly the pre-#386
+      // 🔴 DEGRADE, NEVER ERROR. An unquotable step is exactly the pre-change
       // behaviour, so this path can only be more accurate than what it replaced
       // — it must not turn a working estimate into a failure the block cannot
       // act on. (The SUBMIT still fails closed on a missing quote; that is the
@@ -7445,6 +7488,27 @@ describe("step-type registry bridge (kind: 'step')", () => {
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
       // …and it refused BEFORE the orchestrator was called at all.
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('floors on the SUBMIT’s declared value too, not only the estimate’s', async () => {
+      // 🔴 THE TWO FLOORS ARE DIFFERENT DERIVATIONS. `estimateStepBuzz` is
+      // params-driven and un-ceiled (`step.estimateBuzz(params)`); the submit's
+      // is variant-driven and ceiled (`Math.ceil(priceForVariant(variant))`).
+      // Registry load ties them only at CANONICAL params and nothing re-checks
+      // at request time — so flooring on the estimate alone would reintroduce
+      // the under-display hazard through the other operand.
+      //
+      // `fixture-split-floor-step` registers cleanly and answers `estimateBuzz`
+      // 1 for `{cheap: true}` while `priceForVariant` stays 5. With a quote of 2
+      // below both, the estimate must still show the 5 the submit reserves.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(2, 2);
+      const body = { kind: 'step' as const, step: SPLIT_FLOOR_STEP_ID, params: { cheap: true } };
+      const estimate = await caller().estimateWorkflow({ blockToken: 'tok', body });
+      expect(estimate.snapshot.cost.total).toBe(5);
+      await caller().submitWorkflow({ blockToken: 'tok', body });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 5);
     });
 
     it('mirrors the submit’s max(declared, quoted) — a quote BELOW the floor never under-displays', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -7385,12 +7385,27 @@ async function estimateStepWorkflow(opts: { ctx: Context; claims: BlockClaims; b
   // below what the submit reserves" is then a property of the code, not of an
   // invariant that holds only at canonical params.
   //
-  // 🔴 `declaredBuzz` IS DELIBERATELY NOT A THIRD OPERAND. It can only differ
-  // upward from the submit floor, which is the SAFE direction (the block is told
-  // more than it will be charged), so including it guarded nothing — no mutation
-  // could kill it, which is how it announced itself as decoration rather than a
-  // bound. It stays as the no-quote FALLBACK, where it is the entry's own
-  // declared display estimate and is what the block was shown before this change.
+  // 🔴 `declaredBuzz` IS DELIBERATELY NOT A THIRD OPERAND — because it would
+  // OVER-display, not because it is inert.
+  //
+  // ⚠️ AN EARLIER VERSION OF THIS COMMENT SAID IT "can only differ upward from
+  // the submit floor" AND THAT NO MUTATION COULD KILL IT. Both were wrong, and
+  // the counterexample to the first ships in this repo: `fixture-split-floor-step`
+  // answers `estimateBuzz` 1 against a `priceForVariant` of 5, i.e. DOWNWARD.
+  // The direction is not fixed at all — `estimateBuzz` takes params and
+  // `priceForVariant` does not, so the two can diverge either way for a
+  // request, and only the canonical-params case is pinned by registry load.
+  //
+  // What is true, and is the actual reason: taking the max of all three would
+  // show `max(9, 5, 2) = 9` for an entry whose `estimateBuzz` answers 9 where
+  // `priceForVariant` is 5 — an 80% OVER-display against a submit that reserves
+  // 5. Over-display is the safe direction for a spend gate but it is still a
+  // wrong number quoted to a block, and the whole point of this change is that
+  // the estimate tells the truth. Flooring on the submit's own value alone is
+  // both necessary and sufficient for "never below what the submit reserves".
+  //
+  // It stays as the no-quote FALLBACK, where it is the entry's own declared
+  // display estimate and is what the block was shown before this change.
   const submitFloorBuzz = Math.ceil(plan.reserveBuzz);
   const shownBuzz = Math.max(submitFloorBuzz, quotedBuzz ?? declaredBuzz);
 
@@ -7660,9 +7675,10 @@ async function submitStepWorkflow(opts: {
   //
   // ⚠️ IT IS NO LONGER "what `estimateBuzz` SHOWED the block" — that clause was
   // true only while the estimate returned the declared constant. The estimate
-  // now quotes the orchestrator and shows `max(declared, thisFloor, quoted)`, so
-  // the two paths agree by construction rather than by the block having been
-  // shown this number. See `estimateStepWorkflow`.
+  // now quotes the orchestrator and computes this SAME expression —
+  // `max(Math.ceil(plan.reserveBuzz), quoted)` — so the two paths agree by
+  // construction rather than by the block having been shown this number. See
+  // `estimateStepWorkflow`.
   const reserveBuzz = Math.max(declaredBuzz, quotedBuzz);
 
   // (1) Pre-submit gate against the token's per-call budget — now enforced
@@ -7900,8 +7916,8 @@ async function submitStepWorkflow(opts: {
       // - `priceOverage` vs `declaredBuzz` drives the PRICE-CHECK SIGNAL. That
       //   is the number the REGISTRY ASSERTS. 🔴 It is no longer the number the
       //   block is SHOWN — the estimate quotes the orchestrator and shows
-      //   `max(declared, submitFloor, quoted)`, so for a usage-priced entry the
-      //   viewer sees the quote. `over` therefore means "the registry constant
+      //   `max(submitFloor, quoted ?? declared)`, so for a usage-priced entry
+      //   the viewer sees the quote. `over` therefore means "the registry constant
       //   does not describe reality", NOT "a user was shown the wrong price";
       //   triaging it as a display bug hunts something that does not exist.
       //

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3956,8 +3956,10 @@ export const blocksRouter = router({
         return await estimateCustomComfyWorkflow({ claims, body: input.body });
       }
       // App Blocks STEP-TYPE bridge (RFC #3515 migration step 1). A registered
-      // step's cost comes from its declared billing mode, not a whatIf. The
-      // textToImage path below stays byte-identical (we only ADD a branch).
+      // step's cost now comes from a real `whatif` quote, with the declared
+      // billing mode as the FLOOR and the fallback — this used to read "not a
+      // whatIf", which was the defect, not the design. The textToImage path
+      // below stays byte-identical (we only ADD a branch).
       if (input.body.kind === 'step') {
         return await estimateStepWorkflow({ ctx, claims, body: input.body });
       }
@@ -7181,7 +7183,6 @@ function buildStepOrchestratorStep(
   params: unknown,
   plan: Pick<ReturnType<typeof planStepSpend>, 'stepTimeoutSeconds'>
 ) {
-
   const built = step.buildStep(params);
 
   // ── STEP IDENTITY, re-asserted at REQUEST time on the value actually
@@ -7298,21 +7299,16 @@ function buildStepOrchestratorStep(
  * one price and CHARGED another, with nothing anywhere that re-measured the
  * assertion.
  *
- * MEASURED 2026-08-27 (clawgate #386). `chat-completion` declares
+ * MEASURED 2026-08-27. `chat-completion` declares
  * `CHAT_COMPLETION_PRICE_BUZZ = 1`, and its header claimed `cost.total = 1` had
  * been measured "for every model in `CHAT_COMPLETION_MODELS` and for `maxTokens`
- * from 1 to 200,000". Free `whatif` quotes against the live orchestrator, on one
- * identical 4,680-char conversation at `maxTokens: 2048`:
- *
- *     deepseek/deepseek-chat                       4 Buzz
- *     cognitivecomputations/dolphin-mistral-24b…   3 Buzz
- *     openai/gpt-4o-mini                           2 Buzz
- *
- * and, on one model, 1 at `maxTokens: 256`, 6 at 4096, 86 at 64000. The
- * orchestrator prices a third-party chat model from the provider's live
- * per-token rate, floored at 1 — so the declared constant is that floor, not a
- * price, and NO constant could have been right. Two real sends were charged
- * 4 Buzz each while a published store listing told the viewer 1.
+ * from 1 to 200,000". `whatif` quotes against the live orchestrator refuted
+ * that: the real price is several times the constant for an ordinary
+ * conversation, differs per model, and rises with `maxTokens`. The orchestrator
+ * prices a third-party chat model per token and floors it at 1 — so the declared
+ * constant is that floor, not a price, and NO constant could have been right.
+ * Real sends were being charged the live price while a published store listing
+ * quoted the constant. Figures and derivation: the internal tracker.
  *
  * 🔴 THE FALLBACK IS THE DECLARED ESTIMATE, NOT A THROW, and that is deliberate.
  * An unquotable step is exactly today's behaviour, so this can only ever be more
@@ -7334,15 +7330,13 @@ function buildStepOrchestratorStep(
  *
  * 🔴 THE QUOTE IS BUILT BY THE SAME HELPER THE SUBMIT USES
  * (`buildStepOrchestratorStep`), so the `$type` and entitlement re-asserts run on
- * this path too and the two can never price different steps. It is one extra
- * orchestrator round-trip per estimate, on a surface already restricted to app
- * developers by `assertStepRequestAllowed`.
+ * this path too, they REFUSE here exactly as they refuse on submit, and the two
+ * can never price different steps. It is one extra orchestrator round-trip per
+ * estimate, on a surface already restricted to app developers by
+ * `assertStepRequestAllowed`; that call is bounded by the orchestrator client's
+ * own whatIf attempt timeout and retry budget.
  */
-async function estimateStepWorkflow(opts: {
-  ctx: Context;
-  claims: BlockClaims;
-  body: StepBody;
-}) {
+async function estimateStepWorkflow(opts: { ctx: Context; claims: BlockClaims; body: StepBody }) {
   const { ctx, claims, body } = opts;
   const userId = await assertStepRequestAllowed(claims);
   const step = resolveBlockStep(body);
@@ -7350,7 +7344,33 @@ async function estimateStepWorkflow(opts: {
   const variant = resolveStepVariant(step, params);
   const declaredBuzz = estimateStepBuzz(step, params, variant);
 
-  const quotedBuzz = await quoteStepBuzz({ ctx, claims, step, params, variant, userId });
+  // ── BUILT HERE, OUTSIDE THE QUOTE'S CATCH, SO ITS REFUSALS PROPAGATE. ───────
+  //
+  // 🔴 THIS WAS A REAL DEFECT WHEN THE BUILD SAT INSIDE `quoteStepBuzz`'s `try`.
+  // `buildStepOrchestratorStep` throws FORBIDDEN on a `$type` divergence and on
+  // an AIR reference in the built input — the two request-time re-asserts — and
+  // a blanket catch turned both into "no quote", so the estimate answered
+  // HTTP 200 with the declared price for a body the submit refuses outright.
+  // Measured: `content: "what does urn:air: mean?"` → estimate 200 `{total: 1}`,
+  // submit FORBIDDEN. That is estimate/submit drift on the surface whose entire
+  // job is to predict the submit, and the number it fell back to was exactly the
+  // misleading `1` this change exists to stop showing.
+  //
+  // These throws are DETERMINISTIC — the same params refuse identically on both
+  // paths — so surfacing them is what makes the estimate honest. Only the
+  // orchestrator ROUND-TRIP, which is transient, is allowed to degrade.
+  const plan = planStepSpend(step, params, variant);
+  const orchestratorStep = buildStepOrchestratorStep(step, params, plan);
+
+  const quotedBuzz = await quoteStepBuzz({ ctx, claims, step, orchestratorStep, userId });
+
+  // 🔴 MIRROR THE SUBMIT'S OWN `max()`, do not merely prefer the quote. The
+  // submit gates and reserves `max(declaredBuzz, quotedBuzz)`, so a quote BELOW
+  // the declared floor would otherwise have the estimate show less than the
+  // submit reserves — the under-display direction, and the one a block cannot
+  // defend against. Latent today (no registered entry quotes below its floor)
+  // and reachable the moment one is declared above its real orchestrator price.
+  const shownBuzz = Math.max(declaredBuzz, quotedBuzz ?? declaredBuzz);
 
   return {
     snapshot: {
@@ -7358,34 +7378,50 @@ async function estimateStepWorkflow(opts: {
       // snapshots. The block treats estimate as a cost quote and never polls it.
       workflowId: 'wf_estimate',
       status: 'pending' as const,
-      cost: { total: quotedBuzz ?? declaredBuzz },
+      cost: { total: shownBuzz },
     },
   };
 }
 
 /**
- * The orchestrator's live price for a step, or `null` if it could not be had.
+ * The orchestrator's live price for an ALREADY-BUILT step, or `null` if it could
+ * not be had.
  *
- * Swallows every failure on purpose — see the fallback note on
- * `estimateStepWorkflow`. A quote failure must degrade an estimate to the
- * pre-existing declared number, never turn it into an error the block has no way
- * to act on. The SUBMIT path runs its own quote and does NOT swallow.
+ * Takes the built step rather than building it, so the caller's deterministic
+ * refusals stay outside this catch — see the note at the build site. What IS
+ * swallowed here is the transient half: token mint and the orchestrator
+ * round-trip. A quote failure must degrade an estimate to the pre-existing
+ * declared number, never turn it into an error the block has no way to act on.
+ * The SUBMIT path runs its own quote and does NOT swallow.
+ *
+ * 🔴 EVERY OUTCOME IS COUNTED, INCLUDING THE DEGRADED ONE. A silent fallback
+ * would make "the block saw a live quote" and "the orchestrator was down and the
+ * block saw the floor again" indistinguishable in production — which is the same
+ * shape of unmeasured assertion this whole change exists to remove. The pair is
+ * deliberate: `estimate_absent` alone is unreadable, because a flat zero cannot
+ * be told apart from an estimate path that never runs. Read the ratio.
  *
  * No `externalId` on the quote, mirroring the submit's whatIf preflight and the
  * txt2img one: the idempotency key belongs to a real submit only.
+ *
+ * 🔴 MODERATION IS DELIBERATELY *NOT* RUN HERE, and that is not an oversight of
+ * the shared build. `runStepModeration` is a submit-path gate: it exists to keep
+ * unaudited content off the EXECUTION path, and a `whatif` executes nothing and
+ * publishes nothing. Every registered entry today is `'none'` (`convert-image`)
+ * or `'textOutput'` (`chat-completion`, output-phase only), so nothing is skipped
+ * in practice. 🔴 A future `'promptAudit'` entry changes that — its prompt would
+ * reach the orchestrator unaudited on this path — so an entry declaring an
+ * INPUT-phase posture must either audit here or be excluded from quoting.
  */
 async function quoteStepBuzz(opts: {
   ctx: Context;
   claims: BlockClaims;
   step: ReturnType<typeof resolveBlockStep>;
-  params: unknown;
-  variant: ReturnType<typeof resolveStepVariant>;
+  orchestratorStep: ReturnType<typeof buildStepOrchestratorStep>;
   userId: number;
 }): Promise<number | null> {
-  const { ctx, claims, step, params, variant, userId } = opts;
+  const { ctx, claims, step, orchestratorStep, userId } = opts;
   try {
-    const plan = planStepSpend(step, params, variant);
-    const orchestratorStep = buildStepOrchestratorStep(step, params, plan);
     const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
     const token = await getOrchestratorToken(userId, ctx);
     const quote = await submitWorkflow({
@@ -7400,8 +7436,14 @@ async function quoteStepBuzz(opts: {
       query: { whatif: true },
     });
     const total = quote.cost?.total;
-    return typeof total === 'number' && Number.isFinite(total) ? Math.ceil(total) : null;
+    if (typeof total !== 'number' || !Number.isFinite(total)) {
+      recordStepPriceCheck(step.id, 'estimate_absent');
+      return null;
+    }
+    recordStepPriceCheck(step.id, 'estimate_quoted');
+    return Math.ceil(total);
   } catch {
+    recordStepPriceCheck(step.id, 'estimate_absent');
     return null;
   }
 }
@@ -7515,15 +7557,12 @@ async function submitStepWorkflow(opts: {
   const plan = planStepSpend(step, params, variant);
   const declaredBuzz = Math.ceil(plan.reserveBuzz);
 
-  // Built ONCE, then used for the quote and the real submit, so the two can
-  // never price different things. `timeout` is stamped ONLY for a billing mode
-  // whose cap IS a timeout (`timeBounded`); `prepaidFixed` returns null, because
-  // a timeout on a fixed-price step would be a liveness knob and stamping one
-  // here would imply a Buzz-cap relationship that does not exist.
   // Built ONCE by the shared helper, so the quote and the real submit can never
   // price different things — and so the $type / entitlement re-asserts run on
   // BOTH paths. Both throws land before the orchestrator call and before every
   // reservation, so a rejection costs nothing and has nothing to refund.
+  // (`timeout` is stamped ONLY for a billing mode whose cap IS a timeout; see
+  // the helper.)
   const orchestratorStep = buildStepOrchestratorStep(step, params, plan);
   // Parameterized tags: emit the step id as both the workflow-type tag and the
   // `baseModel` slot (a registry step has no base model), preserving the
@@ -7823,9 +7862,9 @@ async function submitStepWorkflow(opts: {
       // price is wrong". A guard whose description is wider than its
       // implementation, and it read as coverage while providing none.
       //
-      // Measured 2026-08-27 (clawgate #386): `chat-completion` declared 1 and
-      // billed 4 on two consecutive real sends, and this counter reported
-      // `exact` both times. Nothing else in the system compares the declared
+      // Measured 2026-08-27: `chat-completion` billed several times its
+      // declared price on consecutive real sends, and this counter reported
+      // `exact` every time. Nothing else in the system compares the declared
       // number against reality.
       //
       // - `capOverage` vs `reserveBuzz` drives the RESERVATION CORRECTION. That
@@ -7833,9 +7872,21 @@ async function submitStepWorkflow(opts: {
       //   `reserveBuzz`, so that is what they are short against.
       // - `priceOverage` vs `declaredBuzz` drives the PRICE-CHECK SIGNAL. That
       //   is the number the registry asserts and the number a block is shown.
+      //
+      // 🔴 AND THEY ARE SEPARATE OUTCOME VALUES, NOT ONE. Collapsing both into
+      // `over` would trade one blindness for another: for a usage-priced entry
+      // the declared constant is a FLOOR, so `over` sits at ~100% forever by
+      // design — and a genuinely expensive event (billed above the RESERVATION,
+      // which shorts every cap counter) would then be invisible inside a
+      // saturated line, exactly as declared-price drift used to be invisible
+      // inside `exact`. `over_reserved` is the one to alert on; `over` is a
+      // report that a declared constant does not describe reality.
       const capOverage = billed - reserveBuzz;
       const priceOverage = billed - declaredBuzz;
-      recordStepPriceCheck(step.id, priceOverage > 0 ? 'over' : 'exact');
+      recordStepPriceCheck(
+        step.id,
+        capOverage > 0 ? 'over_reserved' : priceOverage > 0 ? 'over' : 'exact'
+      );
       if (capOverage > 0) {
         // Best-effort on ALL THREE keys; each guarded independently so one
         // failing cannot skip the others, and none can break an already-billed

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -7364,13 +7364,35 @@ async function estimateStepWorkflow(opts: { ctx: Context; claims: BlockClaims; b
 
   const quotedBuzz = await quoteStepBuzz({ ctx, claims, step, orchestratorStep, userId });
 
-  // 🔴 MIRROR THE SUBMIT'S OWN `max()`, do not merely prefer the quote. The
-  // submit gates and reserves `max(declaredBuzz, quotedBuzz)`, so a quote BELOW
-  // the declared floor would otherwise have the estimate show less than the
-  // submit reserves — the under-display direction, and the one a block cannot
-  // defend against. Latent today (no registered entry quotes below its floor)
-  // and reachable the moment one is declared above its real orchestrator price.
-  const shownBuzz = Math.max(declaredBuzz, quotedBuzz ?? declaredBuzz);
+  // 🔴 NEVER SHOW LESS THAN THE SUBMIT WILL RESERVE. The submit gates and
+  // reserves `max(Math.ceil(plan.reserveBuzz), quotedBuzz)`, so an estimate that
+  // merely preferred the quote would under-display whenever the quote falls
+  // below the floor — the one direction a block cannot defend against.
+  //
+  // 🔴 THE FLOOR IS THE SUBMIT'S OWN, NOT `estimateStepBuzz`'s — they are
+  // DIFFERENT DERIVATIONS and only one of them binds. `estimateStepBuzz` is
+  // params-driven and un-ceiled (`step.estimateBuzz(params)`); the submit
+  // reserves `Math.ceil(plan.reserveBuzz)`, i.e. variant-driven and ceiled.
+  // Registry load asserts the two agree only at CANONICAL params
+  // (`steps/index.ts` — `estimateBuzz(canonicalParamsFor(v)) === priceForVariant(v)`)
+  // and nothing re-checks it at request time, so an entry whose `estimateBuzz`
+  // varies with params — the interface permits it — can answer 1 where
+  // `priceForVariant` is 5. Flooring on the estimate's value would then
+  // under-display by 4: the exact hazard this line exists to close,
+  // reintroduced through the other operand.
+  //
+  // So this computes the SAME expression the submit does. "The estimate is never
+  // below what the submit reserves" is then a property of the code, not of an
+  // invariant that holds only at canonical params.
+  //
+  // 🔴 `declaredBuzz` IS DELIBERATELY NOT A THIRD OPERAND. It can only differ
+  // upward from the submit floor, which is the SAFE direction (the block is told
+  // more than it will be charged), so including it guarded nothing — no mutation
+  // could kill it, which is how it announced itself as decoration rather than a
+  // bound. It stays as the no-quote FALLBACK, where it is the entry's own
+  // declared display estimate and is what the block was shown before this change.
+  const submitFloorBuzz = Math.ceil(plan.reserveBuzz);
+  const shownBuzz = Math.max(submitFloorBuzz, quotedBuzz ?? declaredBuzz);
 
   return {
     snapshot: {
@@ -7633,9 +7655,14 @@ async function submitStepWorkflow(opts: {
   // 🔴 The reservation is the LARGER of the two. The quote is what makes the
   // ceiling real (a quote above the declared price must be gated and reserved at
   // the real number, not the asserted one); the declared price is the floor
-  // because it is what `estimateBuzz` SHOWED the block, and the registry's
-  // load-time invariant forces those to agree. Over-reserving only makes a cap
-  // stricter.
+  // because the registry asserts it and the load-time invariant ties it to
+  // `estimateBuzz`. Over-reserving only makes a cap stricter.
+  //
+  // ⚠️ IT IS NO LONGER "what `estimateBuzz` SHOWED the block" — that clause was
+  // true only while the estimate returned the declared constant. The estimate
+  // now quotes the orchestrator and shows `max(declared, thisFloor, quoted)`, so
+  // the two paths agree by construction rather than by the block having been
+  // shown this number. See `estimateStepWorkflow`.
   const reserveBuzz = Math.max(declaredBuzz, quotedBuzz);
 
   // (1) Pre-submit gate against the token's per-call budget — now enforced
@@ -7871,7 +7898,12 @@ async function submitStepWorkflow(opts: {
       //   comparison was and remains right: the three counters were reserved at
       //   `reserveBuzz`, so that is what they are short against.
       // - `priceOverage` vs `declaredBuzz` drives the PRICE-CHECK SIGNAL. That
-      //   is the number the registry asserts and the number a block is shown.
+      //   is the number the REGISTRY ASSERTS. 🔴 It is no longer the number the
+      //   block is SHOWN — the estimate quotes the orchestrator and shows
+      //   `max(declared, submitFloor, quoted)`, so for a usage-priced entry the
+      //   viewer sees the quote. `over` therefore means "the registry constant
+      //   does not describe reality", NOT "a user was shown the wrong price";
+      //   triaging it as a display bug hunts something that does not exist.
       //
       // 🔴 AND THEY ARE SEPARATE OUTCOME VALUES, NOT ONE. Collapsing both into
       // `over` would trade one blindness for another: for a usage-priced entry

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3959,7 +3959,7 @@ export const blocksRouter = router({
       // step's cost comes from its declared billing mode, not a whatIf. The
       // textToImage path below stays byte-identical (we only ADD a branch).
       if (input.body.kind === 'step') {
-        return await estimateStepWorkflow({ claims, body: input.body });
+        return await estimateStepWorkflow({ ctx, claims, body: input.body });
       }
       // Context binding. A MODEL token pins `ctx.modelId`; the body must match
       // it. A PAGE token (ctx.entityType==='none') has NO model binding — it
@@ -7166,29 +7166,160 @@ async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
 }
 
 /**
- * STEP ESTIMATE. Returns the registry's DECLARED, deterministic estimate — no
- * orchestrator round-trip. For `prepaidFixed`, registry load enforces that this
- * number equals the entry's declared price (`estimateBuzz === priceForVariant`),
- * so the estimate and the declared price can never disagree with each other.
+ * Build the orchestrator step this registry entry will actually submit, and
+ * re-assert on the BUILT value the two properties the registry could only check
+ * at load time.
  *
- * 🔴 THE ESTIMATE AND THE SUBMIT CAN DIVERGE, and that is deliberate. Submit no
- * longer trusts the declared price as the ceiling: it runs a real `whatif:true`
- * quote against the orchestrator and gates + reserves `max(declared, quoted)`
- * (see the ORCHESTRATOR QUOTE section in `submitStepWorkflow`). So when the
- * orchestrator's live price is ABOVE the declared one — a rate-card move — the
- * block is shown the declared number here and the submit enforces the higher
- * one. Concretely, at a live price of 40 against a declared 1: this returns
- * `cost.total: 1`, and the submit either returns
- * `insufficient buzz budget: step price 40 exceeds budget <n>` or reserves 40
- * against every cap.
+ * 🔴 SHARED BY THE QUOTE AND THE SUBMIT ON PURPOSE. Both the estimate's
+ * `whatif:true` quote and the real submit go through here, so the two can never
+ * price different things and neither can be given a step the other would have
+ * refused. Extracting it is what makes "estimate quotes what submit bills" a
+ * property of the code rather than of two call sites staying in step.
+ */
+function buildStepOrchestratorStep(
+  step: ReturnType<typeof resolveBlockStep>,
+  params: unknown,
+  plan: Pick<ReturnType<typeof planStepSpend>, 'stepTimeoutSeconds'>
+) {
+
+  const built = step.buildStep(params);
+
+  // ── STEP IDENTITY, re-asserted at REQUEST time on the value actually
+  // submitted. Same shape and same reason as the entitlement re-assert below,
+  // on the axis every `$type`-keyed guard depends on.
+  //
+  // 🔴 WHY IT IS NEEDED DESPITE CLAUSE 7a. The registry's load-time check
+  // asserts `buildStep(canonicalParamsFor(v)).$type === orchestratorType` for
+  // each variant — the CANONICAL params. A `buildStep` that switches its
+  // `$type` ON PARAMS therefore registers cleanly and diverges only at request
+  // time, when the untrusted iframe supplies the params that flip it. That is
+  // not hypothetical: it was demonstrated by execution in review against the
+  // load-time check alone.
+  //
+  // What that buys an attacker without this clause is the whole point:
+  // `runStepModeration` (above) dispatches on the DECLARED posture, so a step
+  // declaring `'none'` that builds a text-producing `$type` reaches the
+  // orchestrator with no audit — the exact shape the registry's posture gate
+  // exists to prevent. Load time proved a property of one fixed input; this
+  // proves it of THIS input.
+  //
+  // Placed before the quote and before every reservation, so a rejection costs
+  // no orchestrator call and has nothing to refund.
+  if (built.$type !== step.orchestratorType) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message:
+        `step '${step.id}' declares orchestratorType '${step.orchestratorType}' but the ` +
+        `submitted step is '${built.$type}' — every $type-keyed guard, including the ` +
+        'moderation-posture constraint, was evaluated against a type this step does not submit',
+    });
+  }
+
+  // ── ENTITLEMENT posture, re-asserted at REQUEST time on the value actually
+  // submitted. Mirrors the `moderationPosture` re-assertion above, on the axis
+  // this PR's own triage named as the real risk (`imageUpscaler` was
+  // disqualified precisely because its `model` field takes an arbitrary AIR
+  // URN).
+  //
+  // 🔴 WHY IT IS NEEDED DESPITE CLAUSE 7. The registry's load-time AIR probe
+  // (clause 7) scans `buildStep(canonicalParamsFor(v))` — the CANONICAL params.
+  // An entry whose AIR-bearing field is OPTIONAL and absent from its canonical
+  // params therefore registers cleanly, and at request time `buildStep` forwards
+  // whatever the untrusted iframe sent straight into the submitted input. Load
+  // time proved a property of one fixed input; this proves it of THIS input.
+  // Without it, `resourcePolicy` was enforced at registry load only — a
+  // review-process guard, not a runtime one — while `moderationPosture` was
+  // enforced at both.
+  //
+  // Placed before the quote and before every reservation, so a rejection here
+  // costs no orchestrator call and has nothing to refund.
+  //
+  // FAIL-CLOSED DIRECTION, stated honestly: the scan is a substring test for
+  // `urn:air:` anywhere in the built input, so a param that merely EMBEDS that
+  // literal (e.g. a Civitai-hosted image URL whose path contains it) is rejected
+  // too. That is a false positive, and it is the direction we want — refusing a
+  // pathological url costs a caller one bounced request; forwarding an
+  // unentitled AIR costs the entitlement belt.
+  //
+  // 🔴 THAT COST SENTENCE WAS WRITTEN WHEN EVERY SCANNED STRING WAS A URL THE
+  // APP CONSTRUCTS, AND IT NO LONGER DESCRIBES EVERY ENTRY. `chat-completion`
+  // (registered later) submits `messages[].content` — free prose an END USER
+  // typed — and that prose is the ONLY attacker-controlled string in its built
+  // input; `model` is `z.enum`-bounded and every key is a fixed literal. So for
+  // that entry this guard reduces exactly to "reject any chat message
+  // containing the literal `urn:air:`", and the bounced request is the user's
+  // message rather than the app's own url. The guard is KEPT anyway — see the
+  // FALSE-POSITIVE SURFACE section in `chat-completion.step.ts` for the
+  // orchestrator-side evidence that such prose is inert today, why that
+  // evidence is not sufficient to scope the scan, and the app-side workaround.
+  // What changed here is only the MESSAGE: it used to assert the submitted step
+  // "carries an AIR reference", which is FALSE for prose — the caller typed a
+  // fragment, not a reference — so the rejection read as a platform bug rather
+  // than as something the app can fix in its own payload.
+  //
+  // "Anywhere" covers object KEYS as well as values — the orchestrator's own
+  // `additionalNetworks` / `WorkflowCost.fees` shapes are AIR-KEYED maps, and
+  // the scan used to recurse over `Object.values` only. See
+  // `containsAirReference` for the mechanism and the depth cap that keeps the
+  // scan total.
+  if (step.resourcePolicy.kind === 'none' && containsAirReference(built.input)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message:
+        `step '${step.id}' declares resourcePolicy 'none' but the submitted step contains the ` +
+        `literal text '${AIR_URN_PREFIX}' — a step that reaches an AIR resource bypasses the ` +
+        'generation-graph entitlement belt. The check is a case-insensitive SUBSTRING scan ' +
+        'over every string, array element, object value AND object key in the step input; it ' +
+        'does not parse, so a value that merely EMBEDS that literal — a url whose path ' +
+        'contains it, or free text a user typed — is rejected too. That is the deliberate ' +
+        'fail-closed direction: strip or escape the literal in the params you submit.',
+    });
+  }
+
+  return {
+    $type: built.$type,
+    name: BLOCK_STEP_NAME,
+    ...(plan.stepTimeoutSeconds !== null
+      ? { timeout: formatStepTimeout(plan.stepTimeoutSeconds) }
+      : {}),
+    input: built.input,
+  };
+}
+
+/**
+ * STEP ESTIMATE. Quotes the ORCHESTRATOR, and falls back to the registry's
+ * declared estimate only when no quote can be had.
  *
- * That is fail-closed and correct — the caller is never billed more than the
- * caps it reserved against, and the divergence is counted as
- * `civitai_app_block_step_price_check_total{outcome="over"}`. But do NOT read
- * this estimate as a binding quote: it is the declared floor, not the enforced
- * ceiling. (This comment previously asserted the inverse — that an estimate can
- * never quote a different number than the submit bills. That was true before the
- * quote-backed gate existed and is now false.)
+ * 🔴 THIS USED TO RETURN THE DECLARED CONSTANT AND NEVER ASK ANYONE, AND THAT
+ * WAS THE BUG. `kind: 'step'` was the only branch of `estimateWorkflow` that did
+ * not whatif — `customComfy` returns a server-authored display estimate because
+ * a fixed recipe has no whatif-able cost, and `textToImage` quotes. The step
+ * branch quoted a number the platform had merely asserted, so a block was SHOWN
+ * one price and CHARGED another, with nothing anywhere that re-measured the
+ * assertion.
+ *
+ * MEASURED 2026-08-27 (clawgate #386). `chat-completion` declares
+ * `CHAT_COMPLETION_PRICE_BUZZ = 1`, and its header claimed `cost.total = 1` had
+ * been measured "for every model in `CHAT_COMPLETION_MODELS` and for `maxTokens`
+ * from 1 to 200,000". Free `whatif` quotes against the live orchestrator, on one
+ * identical 4,680-char conversation at `maxTokens: 2048`:
+ *
+ *     deepseek/deepseek-chat                       4 Buzz
+ *     cognitivecomputations/dolphin-mistral-24b…   3 Buzz
+ *     openai/gpt-4o-mini                           2 Buzz
+ *
+ * and, on one model, 1 at `maxTokens: 256`, 6 at 4096, 86 at 64000. The
+ * orchestrator prices a third-party chat model from the provider's live
+ * per-token rate, floored at 1 — so the declared constant is that floor, not a
+ * price, and NO constant could have been right. Two real sends were charged
+ * 4 Buzz each while a published store listing told the viewer 1.
+ *
+ * 🔴 THE FALLBACK IS THE DECLARED ESTIMATE, NOT A THROW, and that is deliberate.
+ * An unquotable step is exactly today's behaviour, so this can only ever be more
+ * accurate than what it replaces — it never turns a working estimate into an
+ * error. The SUBMIT still fails closed on a missing quote (`recordStepPriceCheck
+ * (step.id, 'absent')` + a recoverable failed snapshot), because that is the path
+ * where the number bounds real money; an estimate binds nothing.
  *
  * Fail-closed on an out-of-bounds param (BAD_REQUEST via `parseStepParams`),
  * exactly as submit does — the same `.strict()` schema runs on both paths.
@@ -7200,21 +7331,79 @@ async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
  * whose variant is its model, an out-of-set model returned HTTP 200 with
  * `cost: { total: undefined }` here while the submit threw — estimate/submit
  * drift on the surface whose entire job is to predict the submit.
+ *
+ * 🔴 THE QUOTE IS BUILT BY THE SAME HELPER THE SUBMIT USES
+ * (`buildStepOrchestratorStep`), so the `$type` and entitlement re-asserts run on
+ * this path too and the two can never price different steps. It is one extra
+ * orchestrator round-trip per estimate, on a surface already restricted to app
+ * developers by `assertStepRequestAllowed`.
  */
-async function estimateStepWorkflow(opts: { claims: BlockClaims; body: StepBody }) {
-  const { claims, body } = opts;
-  await assertStepRequestAllowed(claims);
+async function estimateStepWorkflow(opts: {
+  ctx: Context;
+  claims: BlockClaims;
+  body: StepBody;
+}) {
+  const { ctx, claims, body } = opts;
+  const userId = await assertStepRequestAllowed(claims);
   const step = resolveBlockStep(body);
   const params = parseStepParams(step, body.params);
+  const variant = resolveStepVariant(step, params);
+  const declaredBuzz = estimateStepBuzz(step, params, variant);
+
+  const quotedBuzz = await quoteStepBuzz({ ctx, claims, step, params, variant, userId });
+
   return {
     snapshot: {
       // Non-empty sentinel: the SDK's inbound validator drops empty-workflowId
       // snapshots. The block treats estimate as a cost quote and never polls it.
       workflowId: 'wf_estimate',
       status: 'pending' as const,
-      cost: { total: estimateStepBuzz(step, params) },
+      cost: { total: quotedBuzz ?? declaredBuzz },
     },
   };
+}
+
+/**
+ * The orchestrator's live price for a step, or `null` if it could not be had.
+ *
+ * Swallows every failure on purpose — see the fallback note on
+ * `estimateStepWorkflow`. A quote failure must degrade an estimate to the
+ * pre-existing declared number, never turn it into an error the block has no way
+ * to act on. The SUBMIT path runs its own quote and does NOT swallow.
+ *
+ * No `externalId` on the quote, mirroring the submit's whatIf preflight and the
+ * txt2img one: the idempotency key belongs to a real submit only.
+ */
+async function quoteStepBuzz(opts: {
+  ctx: Context;
+  claims: BlockClaims;
+  step: ReturnType<typeof resolveBlockStep>;
+  params: unknown;
+  variant: ReturnType<typeof resolveStepVariant>;
+  userId: number;
+}): Promise<number | null> {
+  const { ctx, claims, step, params, variant, userId } = opts;
+  try {
+    const plan = planStepSpend(step, params, variant);
+    const orchestratorStep = buildStepOrchestratorStep(step, params, plan);
+    const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
+    const token = await getOrchestratorToken(userId, ctx);
+    const quote = await submitWorkflow({
+      token,
+      body: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        steps: [orchestratorStep as any],
+        tags: buildWorkflowTags(claims, step.id, 'step'),
+        currencies: resolveBlockCurrenciesForAccount(isGreen, undefined),
+        ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+      },
+      query: { whatif: true },
+    });
+    const total = quote.cost?.total;
+    return typeof total === 'number' && Number.isFinite(total) ? Math.ceil(total) : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -7331,108 +7520,11 @@ async function submitStepWorkflow(opts: {
   // whose cap IS a timeout (`timeBounded`); `prepaidFixed` returns null, because
   // a timeout on a fixed-price step would be a liveness knob and stamping one
   // here would imply a Buzz-cap relationship that does not exist.
-  const built = step.buildStep(params);
-
-  // ── STEP IDENTITY, re-asserted at REQUEST time on the value actually
-  // submitted. Same shape and same reason as the entitlement re-assert below,
-  // on the axis every `$type`-keyed guard depends on.
-  //
-  // 🔴 WHY IT IS NEEDED DESPITE CLAUSE 7a. The registry's load-time check
-  // asserts `buildStep(canonicalParamsFor(v)).$type === orchestratorType` for
-  // each variant — the CANONICAL params. A `buildStep` that switches its
-  // `$type` ON PARAMS therefore registers cleanly and diverges only at request
-  // time, when the untrusted iframe supplies the params that flip it. That is
-  // not hypothetical: it was demonstrated by execution in review against the
-  // load-time check alone.
-  //
-  // What that buys an attacker without this clause is the whole point:
-  // `runStepModeration` (above) dispatches on the DECLARED posture, so a step
-  // declaring `'none'` that builds a text-producing `$type` reaches the
-  // orchestrator with no audit — the exact shape the registry's posture gate
-  // exists to prevent. Load time proved a property of one fixed input; this
-  // proves it of THIS input.
-  //
-  // Placed before the quote and before every reservation, so a rejection costs
-  // no orchestrator call and has nothing to refund.
-  if (built.$type !== step.orchestratorType) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message:
-        `step '${step.id}' declares orchestratorType '${step.orchestratorType}' but the ` +
-        `submitted step is '${built.$type}' — every $type-keyed guard, including the ` +
-        'moderation-posture constraint, was evaluated against a type this step does not submit',
-    });
-  }
-
-  // ── ENTITLEMENT posture, re-asserted at REQUEST time on the value actually
-  // submitted. Mirrors the `moderationPosture` re-assertion above, on the axis
-  // this PR's own triage named as the real risk (`imageUpscaler` was
-  // disqualified precisely because its `model` field takes an arbitrary AIR
-  // URN).
-  //
-  // 🔴 WHY IT IS NEEDED DESPITE CLAUSE 7. The registry's load-time AIR probe
-  // (clause 7) scans `buildStep(canonicalParamsFor(v))` — the CANONICAL params.
-  // An entry whose AIR-bearing field is OPTIONAL and absent from its canonical
-  // params therefore registers cleanly, and at request time `buildStep` forwards
-  // whatever the untrusted iframe sent straight into the submitted input. Load
-  // time proved a property of one fixed input; this proves it of THIS input.
-  // Without it, `resourcePolicy` was enforced at registry load only — a
-  // review-process guard, not a runtime one — while `moderationPosture` was
-  // enforced at both.
-  //
-  // Placed before the quote and before every reservation, so a rejection here
-  // costs no orchestrator call and has nothing to refund.
-  //
-  // FAIL-CLOSED DIRECTION, stated honestly: the scan is a substring test for
-  // `urn:air:` anywhere in the built input, so a param that merely EMBEDS that
-  // literal (e.g. a Civitai-hosted image URL whose path contains it) is rejected
-  // too. That is a false positive, and it is the direction we want — refusing a
-  // pathological url costs a caller one bounced request; forwarding an
-  // unentitled AIR costs the entitlement belt.
-  //
-  // 🔴 THAT COST SENTENCE WAS WRITTEN WHEN EVERY SCANNED STRING WAS A URL THE
-  // APP CONSTRUCTS, AND IT NO LONGER DESCRIBES EVERY ENTRY. `chat-completion`
-  // (registered later) submits `messages[].content` — free prose an END USER
-  // typed — and that prose is the ONLY attacker-controlled string in its built
-  // input; `model` is `z.enum`-bounded and every key is a fixed literal. So for
-  // that entry this guard reduces exactly to "reject any chat message
-  // containing the literal `urn:air:`", and the bounced request is the user's
-  // message rather than the app's own url. The guard is KEPT anyway — see the
-  // FALSE-POSITIVE SURFACE section in `chat-completion.step.ts` for the
-  // orchestrator-side evidence that such prose is inert today, why that
-  // evidence is not sufficient to scope the scan, and the app-side workaround.
-  // What changed here is only the MESSAGE: it used to assert the submitted step
-  // "carries an AIR reference", which is FALSE for prose — the caller typed a
-  // fragment, not a reference — so the rejection read as a platform bug rather
-  // than as something the app can fix in its own payload.
-  //
-  // "Anywhere" covers object KEYS as well as values — the orchestrator's own
-  // `additionalNetworks` / `WorkflowCost.fees` shapes are AIR-KEYED maps, and
-  // the scan used to recurse over `Object.values` only. See
-  // `containsAirReference` for the mechanism and the depth cap that keeps the
-  // scan total.
-  if (step.resourcePolicy.kind === 'none' && containsAirReference(built.input)) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message:
-        `step '${step.id}' declares resourcePolicy 'none' but the submitted step contains the ` +
-        `literal text '${AIR_URN_PREFIX}' — a step that reaches an AIR resource bypasses the ` +
-        'generation-graph entitlement belt. The check is a case-insensitive SUBSTRING scan ' +
-        'over every string, array element, object value AND object key in the step input; it ' +
-        'does not parse, so a value that merely EMBEDS that literal — a url whose path ' +
-        'contains it, or free text a user typed — is rejected too. That is the deliberate ' +
-        'fail-closed direction: strip or escape the literal in the params you submit.',
-    });
-  }
-
-  const orchestratorStep = {
-    $type: built.$type,
-    name: BLOCK_STEP_NAME,
-    ...(plan.stepTimeoutSeconds !== null
-      ? { timeout: formatStepTimeout(plan.stepTimeoutSeconds) }
-      : {}),
-    input: built.input,
-  };
+  // Built ONCE by the shared helper, so the quote and the real submit can never
+  // price different things — and so the $type / entitlement re-asserts run on
+  // BOTH paths. Both throws land before the orchestrator call and before every
+  // reservation, so a rejection costs nothing and has nothing to refund.
+  const orchestratorStep = buildStepOrchestratorStep(step, params, plan);
   // Parameterized tags: emit the step id as both the workflow-type tag and the
   // `baseModel` slot (a registry step has no base model), preserving the
   // `app-block:*` provenance tags the per-app subqueue read depends on.
@@ -7719,10 +7811,32 @@ async function submitStepWorkflow(opts: {
   if (plan.correctReservationOverage) {
     const realizedCost = snapshot.cost?.total;
     if (typeof realizedCost === 'number' && Number.isFinite(realizedCost)) {
-      const overage = Math.ceil(realizedCost) - reserveBuzz;
-      if (overage > 0) {
-        // 🔴 The declared price is wrong (or the rate card moved). Alert on this.
-        recordStepPriceCheck(step.id, 'over');
+      const billed = Math.ceil(realizedCost);
+      // ── TWO COMPARISONS, BECAUSE THEY ANSWER TWO DIFFERENT QUESTIONS. ───────
+      //
+      // 🔴 THE PRICE CHECK USED TO SHARE THE CAP'S COMPARISON, AND THAT MADE IT
+      // STRUCTURALLY BLIND TO THE ONE THING ITS OWN DESCRIPTION CLAIMS TO
+      // DETECT. `reserveBuzz` is `max(declaredBuzz, quotedBuzz)` — it has
+      // ALREADY absorbed the orchestrator's live quote — so a call declared at
+      // 1 and billed at 4 computed `4 - 4 = 0` and was recorded `exact`, while
+      // `app-block-runtime.metrics.ts` documents `over` as meaning "the declared
+      // price is wrong". A guard whose description is wider than its
+      // implementation, and it read as coverage while providing none.
+      //
+      // Measured 2026-08-27 (clawgate #386): `chat-completion` declared 1 and
+      // billed 4 on two consecutive real sends, and this counter reported
+      // `exact` both times. Nothing else in the system compares the declared
+      // number against reality.
+      //
+      // - `capOverage` vs `reserveBuzz` drives the RESERVATION CORRECTION. That
+      //   comparison was and remains right: the three counters were reserved at
+      //   `reserveBuzz`, so that is what they are short against.
+      // - `priceOverage` vs `declaredBuzz` drives the PRICE-CHECK SIGNAL. That
+      //   is the number the registry asserts and the number a block is shown.
+      const capOverage = billed - reserveBuzz;
+      const priceOverage = billed - declaredBuzz;
+      recordStepPriceCheck(step.id, priceOverage > 0 ? 'over' : 'exact');
+      if (capOverage > 0) {
         // Best-effort on ALL THREE keys; each guarded independently so one
         // failing cannot skip the others, and none can break an already-billed
         // submit.
@@ -7733,7 +7847,7 @@ async function submitStepWorkflow(opts: {
         // a divergent submit inside a dev tunnel left that counter under-reading
         // by the overage: precisely the drift direction the same comment forbids.
         try {
-          await reserveBlockBuzzSpendForClaims(claims, userId, overage);
+          await reserveBlockBuzzSpendForClaims(claims, userId, capOverage);
         } catch {
           /* best-effort correction — a lost one under-counts by the overage only */
         }
@@ -7742,7 +7856,7 @@ async function submitStepWorkflow(opts: {
             const { chargeAppSpendOverage } = await import(
               '~/server/services/blocks/app-spend-cap.service'
             );
-            await chargeAppSpendOverage(appSpendReserve.key, overage);
+            await chargeAppSpendOverage(appSpendReserve.key, capOverage);
           } catch {
             /* best-effort correction */
           }
@@ -7752,17 +7866,17 @@ async function submitStepWorkflow(opts: {
             const { chargeDevSessionOverage } = await import(
               '~/server/services/blocks/dev-tunnel.service'
             );
-            await chargeDevSessionOverage(devSessionReserve.sessionId, overage);
+            await chargeDevSessionOverage(devSessionReserve.sessionId, capOverage);
           } catch {
             /* best-effort correction */
           }
         }
-      } else {
-        // Healthy — AND the proof that this check runs at all. Without this
-        // emit, a flat divergence line could not be told apart from a detector
-        // that never executed.
-        recordStepPriceCheck(step.id, 'exact');
       }
+      // NOTE: the `exact` emit is now UNCONDITIONAL above rather than an `else`
+      // on the cap branch. It still serves its original purpose — proving the
+      // detector executed at all, so a flat `over` line can be told apart from a
+      // check that never ran — but it now reports on the DECLARED price, which
+      // is what the metric's description has always claimed it reports on.
     } else {
       // No numeric cost on the snapshot → nothing to compare. Distinguished from
       // `exact` on purpose: this is the state in which the correction is inert.

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -16,12 +16,11 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 //  2. COST KNOWABLE BEFORE EXECUTION → `prepaidFixed`. 🔴 THIS BAR USED TO READ
 //     "FLAT, MEASURED COST… charged **1 Buzz**, and that held across every model
 //     below AND across `maxTokens` 1 → 200,000". THAT WAS FALSE — re-measured
-//     2026-08-27 it is 2, 3 and 4 Buzz for the three models below on one
-//     identical conversation, and 1 → 86 across the `maxTokens` range. What
+//     2026-08-27, the price differs per model and rises with `maxTokens`. What
 //     survives is the bar itself: the orchestrator can QUOTE the price before
 //     execution (`whatif:true`), which is what `prepaidFixed` actually requires.
 //     Flatness was never the requirement, and the entry qualifies without it.
-//     See `CHAT_COMPLETION_PRICE_BUZZ` and clawgate #386.
+//     See `CHAT_COMPLETION_PRICE_BUZZ`.
 //
 //  3. A FREE-TEXT OUTPUT, WITH A POSTURE THAT COVERS IT. This is the whole
 //     reason the entry could not be written until `'textOutput'` existed. The
@@ -172,29 +171,19 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
  * 🔴 THIS COMMENT USED TO SAY THE PRICE WAS "MEASURED, not declared" — that
  * `cost.total = 1` had been observed "for every model in
  * `CHAT_COMPLETION_MODELS` and for `maxTokens` from 1 to 200,000". THAT WAS
- * FALSE, and it was cited rather than re-derived for as long as it stood. Free
- * `whatif` quotes against the live orchestrator on 2026-08-27, one identical
- * 4,680-char conversation at `maxTokens: 2048`:
- *
- *     deepseek/deepseek-chat                       4 Buzz
- *     cognitivecomputations/dolphin-mistral-24b…   3 Buzz
- *     openai/gpt-4o-mini                           2 Buzz
- *
- * and on `deepseek/deepseek-chat` alone: 1 at `maxTokens: 256`, 4 at 2048, 6 at
- * 4096 (`MAX_OUTPUT_TOKENS` in the app SDK), 86 at 64000. Two real sends through
- * a published App Block were each charged 4 while its store listing told the
- * viewer 1 (clawgate #386).
+ * FALSE, and it was cited rather than re-derived for as long as it stood.
+ * Re-measured 2026-08-27 by `whatif` quote against the live orchestrator: the
+ * real price is SEVERAL times this constant for an ordinary conversation, it
+ * differs per model, and it rises with `maxTokens`.
  *
  * WHY NO CONSTANT CAN BE RIGHT. Every model in `CHAT_COMPLETION_MODELS` is a
- * third-party (OpenRouter) model, and the orchestrator prices those from the
- * provider's LIVE per-token rate against an estimate of the input tokens and
- * `maxTokens × n` output tokens — so the charge moves with the model, with the
- * conversation, with `maxTokens`, and with the provider's rate card, none of
- * which this repo can see. (The exact rate expression lives in the
- * orchestrator's chat-completion cost handler; it is not restated here.) The
- * flat-rate branch beside it applies only to `urn:air:` models, and this entry
- * allows none. The one part of it this constant IS: the price is floored at 1,
- * and that floor is what this number means — nothing more.
+ * third-party model that the orchestrator prices per token, so the charge moves
+ * with the model, the conversation and `maxTokens` — none of which this repo can
+ * see, and none of which a constant can track. The pricing itself is the
+ * orchestrator's and is deliberately not restated here; the figures and the
+ * derivation are in the internal tracker. The one part of it this constant IS:
+ * the orchestrator floors the price at 1, and that floor is what this number
+ * means — nothing more.
  *
  * 🔴 IT IS NOT WHAT THE BLOCK IS SHOWN ANY MORE, EITHER. `estimateStepWorkflow`
  * now quotes the orchestrator and falls back to this only when no quote can be
@@ -207,10 +196,11 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
  * a rate-card change is caught at submit rather than by a human reading a
  * counter later. See the ORCHESTRATOR QUOTE section in `blocks.router.ts`.
  *
- * 🔴 DO NOT "CORRECT" THIS TO 4. It is not a stale number that wants a newer
- * one; it is the wrong SHAPE for a usage-priced step. Raising it would make the
- * reservation floor over-reserve on cheap models and still under-declare on
- * expensive ones, and would go stale again on the next OpenRouter rate move.
+ * 🔴 DO NOT "CORRECT" THIS TO A BIGGER NUMBER. It is not a stale value that
+ * wants a newer one; it is the wrong SHAPE for a usage-priced step. Raising it
+ * would make the reservation floor over-reserve on cheap models and still
+ * under-declare on expensive ones, and would go stale again on the next
+ * upstream rate move.
  */
 export const CHAT_COMPLETION_PRICE_BUZZ = 1;
 

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -13,10 +13,15 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 //     step standalone (Civitai's own `xGuardModeration` scanning is implemented
 //     as `chatCompletion` jobs).
 //
-//  2. FLAT, MEASURED COST. A real submit was quoted and charged **1 Buzz**, and
-//     that held across every model below AND across `maxTokens` 1 → 200,000 — so
-//     the price is knowable before execution → `prepaidFixed`. See
-//     `CHAT_COMPLETION_PRICE_BUZZ`.
+//  2. COST KNOWABLE BEFORE EXECUTION → `prepaidFixed`. 🔴 THIS BAR USED TO READ
+//     "FLAT, MEASURED COST… charged **1 Buzz**, and that held across every model
+//     below AND across `maxTokens` 1 → 200,000". THAT WAS FALSE — re-measured
+//     2026-08-27 it is 2, 3 and 4 Buzz for the three models below on one
+//     identical conversation, and 1 → 86 across the `maxTokens` range. What
+//     survives is the bar itself: the orchestrator can QUOTE the price before
+//     execution (`whatif:true`), which is what `prepaidFixed` actually requires.
+//     Flatness was never the requirement, and the entry qualifies without it.
+//     See `CHAT_COMPLETION_PRICE_BUZZ` and clawgate #386.
 //
 //  3. A FREE-TEXT OUTPUT, WITH A POSTURE THAT COVERS IT. This is the whole
 //     reason the entry could not be written until `'textOutput'` existed. The
@@ -162,18 +167,50 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * The declared exact price, in Buzz.
+ * The declared price floor, in Buzz. NOT the price.
  *
- * MEASURED, not declared: real submits against the live orchestrator returned
- * `cost.total = 1` for every model in `CHAT_COMPLETION_MODELS` and for
- * `maxTokens` from 1 to 200,000. `estimateBuzz` returns this same constant —
- * the registry's load-time invariant forces the two to agree, because the block
- * is SHOWN the estimate and CHARGED the price.
+ * 🔴 THIS COMMENT USED TO SAY THE PRICE WAS "MEASURED, not declared" — that
+ * `cost.total = 1` had been observed "for every model in
+ * `CHAT_COMPLETION_MODELS` and for `maxTokens` from 1 to 200,000". THAT WAS
+ * FALSE, and it was cited rather than re-derived for as long as it stood. Free
+ * `whatif` quotes against the live orchestrator on 2026-08-27, one identical
+ * 4,680-char conversation at `maxTokens: 2048`:
+ *
+ *     deepseek/deepseek-chat                       4 Buzz
+ *     cognitivecomputations/dolphin-mistral-24b…   3 Buzz
+ *     openai/gpt-4o-mini                           2 Buzz
+ *
+ * and on `deepseek/deepseek-chat` alone: 1 at `maxTokens: 256`, 4 at 2048, 6 at
+ * 4096 (`MAX_OUTPUT_TOKENS` in the app SDK), 86 at 64000. Two real sends through
+ * a published App Block were each charged 4 while its store listing told the
+ * viewer 1 (clawgate #386).
+ *
+ * WHY NO CONSTANT CAN BE RIGHT. Every model in `CHAT_COMPLETION_MODELS` is a
+ * third-party (OpenRouter) model, and the orchestrator prices those from the
+ * provider's LIVE per-token rate against an estimate of the input tokens and
+ * `maxTokens × n` output tokens — so the charge moves with the model, with the
+ * conversation, with `maxTokens`, and with the provider's rate card, none of
+ * which this repo can see. (The exact rate expression lives in the
+ * orchestrator's chat-completion cost handler; it is not restated here.) The
+ * flat-rate branch beside it applies only to `urn:air:` models, and this entry
+ * allows none. The one part of it this constant IS: the price is floored at 1,
+ * and that floor is what this number means — nothing more.
+ *
+ * 🔴 IT IS NOT WHAT THE BLOCK IS SHOWN ANY MORE, EITHER. `estimateStepWorkflow`
+ * now quotes the orchestrator and falls back to this only when no quote can be
+ * had, so a block sees the live price rather than this floor. The registry's
+ * load-time invariant still forces `estimateBuzz === priceForVariant`, which is
+ * why both still return it: they are the fallback and the reservation floor.
  *
  * 🔴 It is NOT the enforced ceiling. The step submit path runs its own `whatif`
  * before the per-call `buzzBudget` gate and reserves `max(declared, quoted)`, so
  * a rate-card change is caught at submit rather than by a human reading a
  * counter later. See the ORCHESTRATOR QUOTE section in `blocks.router.ts`.
+ *
+ * 🔴 DO NOT "CORRECT" THIS TO 4. It is not a stale number that wants a newer
+ * one; it is the wrong SHAPE for a usage-priced step. Raising it would make the
+ * reservation floor over-reserve on cheap models and still under-declare on
+ * expensive ones, and would go stale again on the next OpenRouter rate move.
  */
 export const CHAT_COMPLETION_PRICE_BUZZ = 1;
 

--- a/src/server/services/blocks/steps/convert-image.step.ts
+++ b/src/server/services/blocks/steps/convert-image.step.ts
@@ -46,6 +46,17 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // per-call `buzzBudget` gate and reserves `max(declared, quoted)`. See the
 // ORCHESTRATOR QUOTE section in `blocks.router.ts`. A single measurement is one
 // point on a rate card that can change; the gate must not depend on it.
+//
+// ✅ RE-MEASURED 2026-08-27 and STILL 1 — clawgate #386's sweep of every other
+// declared step price, after `chat-completion` was found declaring 1 and billing
+// 4. A fresh `whatif:true` of this exact step shape against the live
+// orchestrator returned
+// `cost: {base:1, factors:{base:1}, fixed:{}, tips:{civitai:0,creators:0}, total:1}`.
+// So the drift is chat-only and this entry is clean. The reason it is clean is
+// structural, not luck: `convertImage` is CPU work the orchestrator prices
+// itself, whereas `chatCompletion` is repriced from a third-party rate card that
+// moves under it. A future entry that resells a third-party per-token price has
+// the same exposure, and no constant will hold for it either.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**

--- a/src/server/services/blocks/steps/convert-image.step.ts
+++ b/src/server/services/blocks/steps/convert-image.step.ts
@@ -47,9 +47,9 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // ORCHESTRATOR QUOTE section in `blocks.router.ts`. A single measurement is one
 // point on a rate card that can change; the gate must not depend on it.
 //
-// ✅ RE-MEASURED 2026-08-27 and STILL 1 — clawgate #386's sweep of every other
-// declared step price, after `chat-completion` was found declaring 1 and billing
-// 4. A fresh `whatif:true` of this exact step shape against the live
+// ✅ RE-MEASURED 2026-08-27 and STILL 1 — a sweep of every other declared step
+// price, prompted by `chat-completion` being found to declare a price well below
+// what it bills. A fresh `whatif:true` of this exact step shape against the live
 // orchestrator returned
 // `cost: {base:1, factors:{base:1}, fixed:{}, tips:{civitai:0,creators:0}, total:1}`.
 // So the drift is chat-only and this entry is clean. The reason it is clean is


### PR DESCRIPTION

An App Block chat reply is charged 4 Buzz. The platform declares 1, and a
published store listing told users 1. The metric that exists to catch exactly
this reported `exact` both times.

WHAT THE PRICE ACTUALLY IS

Measured 2026-08-27 by free `whatif` quote against the live orchestrator, plus
the two real sends that started this. One identical 4,680-char conversation at
maxTokens 2048:

  deepseek/deepseek-chat                       4 Buzz
  cognitivecomputations/dolphin-mistral-24b    3 Buzz
  openai/gpt-4o-mini                           2 Buzz

and on deepseek alone: 1 at maxTokens 256, 4 at 2048, 6 at 4096, 86 at 64000.
The recorded workflow's own breakdown carries the delta entirely in `cost.base`
(4), with `factors.base` 3.146, tips 0 and no `fixed` or `fees`.

The mechanism is in the orchestrator's chat-completion cost handler, not here:
a third-party chat model is repriced from the PROVIDER'S LIVE per-token rate,
against an estimate of the input tokens plus maxTokens * n output tokens, and
floored at 1. (The exact rate expression stays in that private repo and is
deliberately not restated in this one; it was re-derived from the provider's own
public pricing to within 0.03% of the recorded workflow, which is how the shape
above is known rather than assumed.)

So CHAT_COMPLETION_PRICE_BUZZ = 1 is not a stale number wanting a newer one. It
is that FLOOR, and no constant could ever have been right for a usage-priced
step. Its header claimed cost.total = 1 had been MEASURED for every
model and every maxTokens; that was false and was cited rather than re-derived
for as long as it stood.

(1) THE ESTIMATE NOW QUOTES THE ORCHESTRATOR

`kind: 'step'` was the ONLY branch of estimateWorkflow that did not whatif.
customComfy returns a server-authored display estimate because a fixed recipe
has no whatif-able cost; textToImage quotes. The step branch returned a constant
the platform had merely asserted, so a block was SHOWN one price and CHARGED
another with nothing re-measuring the assertion.

It quotes now, and falls back to the declared estimate when no quote can be had.
The fallback is deliberate: an unquotable step is exactly the previous
behaviour, so this can only be more accurate than what it replaced and can never
turn a working estimate into an error. The SUBMIT still fails closed on a
missing quote — that is where the number bounds real money.

The quote and the real submit now build their step through ONE helper,
buildStepOrchestratorStep, so they can never price different things and the
$type / entitlement re-asserts run on both paths. Both throws still land before
the orchestrator call and before every reservation.

Cost: one extra orchestrator round-trip per estimate, on a surface
assertStepRequestAllowed already restricts to app developers.

(2) THE PRICE CHECK COULD NOT SEE A WRONG DECLARED PRICE

  const overage = Math.ceil(realizedCost) - reserveBuzz;

reserveBuzz is max(declaredBuzz, quotedBuzz) — it has ALREADY absorbed the
orchestrator's quote — so a call declared at 1 and billed at 4 computed 4 - 4 =
0 and was logged `exact`, while app-block-runtime.metrics.ts documents `over` as
meaning "the declared price is wrong". The implementation was narrower than its
own description, which is worse than no metric: it reads as coverage and stops
anyone looking.

Split into the two questions it was conflating:

  capOverage   = billed - reserveBuzz   -> drives the three reservation
                                           corrections. Unchanged, and still
                                           right: the counters were reserved at
                                           reserveBuzz.
  priceOverage = billed - declaredBuzz  -> drives the price-check signal. That
                                           is the number the registry asserts
                                           and the number a block is shown.

The `exact` emit moves from an else-branch to unconditional. It still proves the
detector ran; it now reports on the declared price, as its description always
claimed.

(3) SWEPT THE OTHER DECLARED PRICE

convert-image is the only other registered step. Re-quoted the same way and it
still returns exactly 1 — cost {base:1, factors:{base:1}, fixed:{}, tips 0,
total:1} — matching CONVERT_IMAGE_PRICE_BUZZ. The drift is chat-only, and for a
structural reason now recorded in that file: convertImage is CPU work the
orchestrator prices itself, while chatCompletion is repriced from a third-party
rate card that moves under it.

TESTS

  "records 'over' when the DECLARED price is wrong but the quote absorbed it"
  is a regression test, not an invariant guard. Mutation-verified by reverting
  the narrowest expression — `billed - declaredBuzz` back to `billed -
  reserveBuzz` — which kills exactly this test, with its own assertion
  (expected ['convert-image', 'over']), while the other six price-check tests
  stay green. It dies for its own reason, not a neighbour's.

  Its companion pins the half a careless fix breaks: switching the CAP
  correction to declaredBuzz too would top the counters up by 3 for money nobody
  spent.

  The estimate tests assert a quote of 4 against a declared STEP_PRICE of 1 — a
  value the old code path cannot produce — plus whatif-only, and both fallbacks.
  The one that used to assert "NO orchestrator round-trip" was pinning the bug;
  it is replaced and the reason is recorded in place.

  225 files / 5327 tests green across the router and blocks service suites;
  `pnpm typecheck` 0 errors. The two eslint errors in blocks.router.ts are
  pre-existing at origin/main (lines 5429, 8107) and outside every hunk here.

NOT DONE HERE, deliberately: the orchestrator's own pricing and rate card are
not touched — the declared constant was the wrong side, and that is stated
rather than assumed. The published listing quoting "1 Buzz" is corrected in the
app's own repo (ZacxDev/civitai-app-sensei#15), since on-site listing text has
no author surface but the manifest.

Refs: clawgate #386, #379, #387.

