### PR TITLE
feat(app-blocks): real tool calling for the chat-completion step

### DIFF
--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -733,17 +733,40 @@ export type BlockWorkflowSnapshot = {
    */
   textOutputs?: string[];
   /**
-   * Set when generated text WAS produced but is being withheld — a content-policy
-   * hit, or a scanner error/timeout (the scan fails CLOSED).
+   * Set when a text-posture step produced nothing the block can be given, with a
+   * user-facing sentence saying why. TWO distinct causes land here:
    *
-   * `reason` is a user-facing message, deliberately generic: it does not name the
-   * labels that triggered. The triggering labels + scores go to the per-app
-   * trigger log instead, which is where the actionable signal lives (an app whose
-   * outputs trigger constantly is telling you about its system prompt).
+   *   1. WITHHELD — text WAS produced and is being kept back: a content-policy
+   *      hit, or a scanner error/timeout (the scan fails CLOSED).
+   *   2. UNPUBLISHABLE — the step SUCCEEDED and the scan RELEASED, but the
+   *      entry's extractors could publish none of what came back (e.g. a
+   *      provider tool-call `id` outside the published charset). Nothing was
+   *      moderated in this case, and the message says so explicitly.
+   *
+   * 🔴 AN EARLIER VERSION OF THIS DOC DESCRIBED ONLY CAUSE 1 — "generated text
+   * WAS produced but is being withheld" — and both halves of that sentence are
+   * FALSE on cause 2: no text was produced, and no policy or scanner event
+   * occurred. This is the doc the `@civitai/app-sdk` mirror-writer and block
+   * authors read, so a consumer branching on it was being told the wrong thing.
+   * If a third cause is ever added, correct this list in the same change.
+   *
+   * `reason` is deliberately generic: it does not name the labels that
+   * triggered. The triggering labels + scores go to the per-app trigger log
+   * instead, which is where the actionable signal lives (an app whose outputs
+   * trigger constantly is telling you about its system prompt).
+   *
+   * 🔴 THE TWO CAUSES ARE NOT MACHINE-SEPARABLE without matching on the string,
+   * which is NOT a contract. A consumer needing to branch on the difference is
+   * the trigger to add a discriminated reason code — not before.
+   *
+   * 🔴 CAUSE 2 IS GATED ON THE STEP'S OWN `succeeded` STATUS, so an in-flight or
+   * cancelled generation does NOT set this field. A block polling a healthy
+   * running workflow sees it absent, as it did before cause 2 existed.
    *
    * Independent of `textOutputs` rather than mutually exclusive: a workflow with
    * two text steps can release one and withhold the other, and both fields then
-   * appear.
+   * appear. Because of that pairing the `reason` is scoped to "a step in this
+   * response", never to the response as a whole.
    */
   textOutputWithheld?: { reason: string };
   /**
@@ -759,8 +782,19 @@ export type BlockWorkflowSnapshot = {
    * 🔴 WHY PUBLISHING THESE IS NOT A HOLE IN THE SCAN, since the objects
    * themselves are never handed to a scanner: the entry's `extractText` returns
    * every `arguments` string that appears here, so the released verdict was
-   * computed over exactly that prose, and registry clause 8b fails the build if
-   * an entry ever breaks that containment. The tool NAME is not scanned and does
+   * computed over exactly that prose.
+   *
+   * 🔴 WHAT ENFORCES THAT, STATED AT ITS REAL STRENGTH. For `chat-completion`
+   * the guarantee is STRUCTURAL — both extractors derive from one shared
+   * predicate, so they cannot disagree. Registry clause 8b is a load-time
+   * BACKSTOP against an entry re-splitting them, and it is only as wide as the
+   * shapes its `canonicalOutputFor` sample exercises: a re-split on an axis the
+   * sample does not cover would still pass. An earlier version of this line said
+   * clause 8b "fails the build if an entry ever breaks that containment", which
+   * is wider than the implementation — the same unscoped overclaim corrected in
+   * `steps/moderation.ts` and `steps/chat-completion.step.ts`. Do not restate it.
+   *
+   * The tool NAME is not scanned and does
    * not need to be — it is pattern-bounded to `[A-Za-z0-9_-]` at both the param
    * schema and the extractor, so it cannot carry prose. Widening that charset
    * would make the name a free-text surface and is a moderation change, not a

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -737,7 +737,10 @@ export type BlockWorkflowSnapshot = {
    * user-facing sentence saying why. TWO distinct causes land here:
    *
    *   1. WITHHELD — text WAS produced and is being kept back: a content-policy
-   *      hit, or a scanner error/timeout (the scan fails CLOSED).
+   *      hit, or any other fail-CLOSED scan outcome (scanner error or timeout,
+   *      no verdict at all, an over-cap payload, or requested labels that came
+   *      back missing or errored). Every one of those paths returns the SAME
+   *      message, so this cause is one string with several origins.
    *   2. UNPUBLISHABLE — the step SUCCEEDED and the scan RELEASED, but the
    *      entry's extractors could publish none of what came back (e.g. a
    *      provider tool-call `id` outside the published charset). Nothing was
@@ -759,9 +762,27 @@ export type BlockWorkflowSnapshot = {
    * which is NOT a contract. A consumer needing to branch on the difference is
    * the trigger to add a discriminated reason code — not before.
    *
-   * 🔴 CAUSE 2 IS GATED ON THE STEP'S OWN `succeeded` STATUS, so an in-flight or
-   * cancelled generation does NOT set this field. A block polling a healthy
-   * running workflow sees it absent, as it did before cause 2 existed.
+   * 🔴 ONLY CAUSE 2 IS STATUS-GATED, AND THE GATE READS THE STEP'S OWN
+   * `succeeded` STATUS — never the workflow's. CAUSE 1 IS NOT GATED AT ALL: in
+   * `steps/moderation.ts` the `succeeded` test guards the unpublishable branch
+   * only, and the withheld branch is the plain `else` beside it.
+   *
+   * So a CANCELLED generation CAN still set this field. The orchestrator returns
+   * whatever text it had already produced, that text is still scanned, and a hit
+   * still withholds it — `blocks.router.textOutputModeration.test.ts` pins
+   * exactly that, cancelling a workflow whose step succeeded and asserting the
+   * field IS set. A consumer that skips rendering `reason` on cancel would
+   * suppress a real content-policy explanation.
+   *
+   * A block polling a healthy in-flight generation does still see the field
+   * absent — but for a reason worth stating correctly rather than by status: a
+   * step that has produced no text YET can reach neither cause, because
+   * `screenGeneratedText` short-circuits to RELEASED on an empty text set, and
+   * cause 2 additionally needs `succeeded`.
+   *
+   * 🔴 THIS CLAUSE HAS NOW BEEN WRONG TWICE, both times by describing the FIELD
+   * when the code only ever gated ONE OF ITS TWO CAUSES. Before editing it
+   * again, check each cause against `steps/moderation.ts` separately.
    *
    * Independent of `textOutputs` rather than mutually exclusive: a workflow with
    * two text steps can release one and withhold the other, and both fields then

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -3,6 +3,7 @@ import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { REGISTERED_RECIPE_IDS } from '~/server/services/blocks/recipes';
 import { REGISTERED_STEP_IDS } from '~/server/services/blocks/steps';
+import type { BlockStepToolCall } from '~/server/services/blocks/steps';
 import {
   civitaiHostedImageUrlSchema,
   SOURCE_IMAGE_URL_MAX,
@@ -745,4 +746,37 @@ export type BlockWorkflowSnapshot = {
    * appear.
    */
   textOutputWithheld?: { reason: string };
+  /**
+   * Structured tool calls the model requested on a registered `'textOutput'`
+   * step — and which have PASSED the same output moderation scan `textOutputs`
+   * passes.
+   *
+   * 🔴 SAME SINGLE PRODUCER, SAME STRIPPING, SAME RULE.
+   * `attachModeratedStepTextOutputs` is the only writer; it strips any incoming
+   * value of this field before merging its own, and it attaches tool calls ONLY
+   * onto a released verdict. Do NOT set it anywhere else.
+   *
+   * 🔴 WHY PUBLISHING THESE IS NOT A HOLE IN THE SCAN, since the objects
+   * themselves are never handed to a scanner: the entry's `extractText` returns
+   * every `arguments` string that appears here, so the released verdict was
+   * computed over exactly that prose, and registry clause 8b fails the build if
+   * an entry ever breaks that containment. The tool NAME is not scanned and does
+   * not need to be — it is pattern-bounded to `[A-Za-z0-9_-]` at both the param
+   * schema and the extractor, so it cannot carry prose. Widening that charset
+   * would make the name a free-text surface and is a moderation change, not a
+   * validation one.
+   *
+   * WHERE IT APPEARS: `blocks.pollWorkflow` and `blocks.cancelWorkflow` — the
+   * same two wrapped procedures as `textOutputs`, for the same reason.
+   *
+   * OMITTED entirely when there are none, so every existing snapshot stays
+   * byte-identical.
+   *
+   * 🔴 WIRE CONTRACT: additive on the type `@civitai/app-sdk`'s `blocks/types.ts`
+   * mirrors, exactly like `textOutputs` and `modelSubstitutions` above. The SDK's
+   * inbound validator does not know it yet, so a block reads it only once that
+   * type is widened in the SDK repo — tracked separately; nothing here edits
+   * another repo.
+   */
+  toolCalls?: BlockStepToolCall[];
 };

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -5,6 +5,7 @@ import {
   CHAT_COMPLETION_MODELS,
   CHAT_COMPLETION_PRICE_BUZZ,
   chatCompletionStep,
+  MAX_TOOL_ROUNDS,
   type ChatCompletionStepParams,
 } from '~/server/services/blocks/steps/chat-completion.step';
 import {
@@ -505,7 +506,17 @@ describe('chat-completion — extractText, against the REAL response', () => {
     expect(chatCompletionStep.extractText(withImages)).toEqual(['here you go']);
   });
 
-  it('does NOT read `tool_calls[].function.arguments`', () => {
+  it('🔴 DOES read `tool_calls[].function.arguments` — model-written text must be scanned', () => {
+    // 🔴 THIS ASSERTION IS INVERTED FROM WHAT IT USED TO BE, DELIBERATELY. It
+    // previously pinned `extractText` NOT reading tool calls, which was correct
+    // while the entry could not expose `tools` at all: the only safe thing to do
+    // with a field that could never legitimately appear was drop it.
+    //
+    // Exposing `tools` falsified that premise. An `arguments` string is free
+    // text the MODEL wrote, on its way to a tool and to the block's UI, so
+    // dropping it would mean either publishing it unscanned through the
+    // structured surface, or shipping a capability that charges and returns
+    // nothing. Both are worse than scanning it.
     const withTools = {
       output: {
         choices: [
@@ -518,7 +529,7 @@ describe('chat-completion — extractText, against the REAL response', () => {
         ],
       },
     };
-    expect(chatCompletionStep.extractText(withTools)).toEqual(['calling']);
+    expect(chatCompletionStep.extractText(withTools)).toEqual(['calling', '{}']);
   });
 
   it('is total over absent, null and malformed input', () => {
@@ -549,5 +560,430 @@ describe('chat-completion — extractText, against the REAL response', () => {
         chatCompletionStep.extractText(chatCompletionStep.canonicalOutputFor(variant))
       ).toEqual(['OK']);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TOOL CALLING — the `tools` / `toolChoice` param surface, the round bound, and
+// the tool-call read path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A REAL tool-calling response, captured verbatim from a live orchestrator
+ * submit (`deepseek/deepseek-chat`, one `search_models` function,
+ * `toolChoice: "required"`, status `succeeded`).
+ *
+ * 🔴 CAPTURED, NOT INVENTED, for exactly the reason the entry's own
+ * `canonicalOutputFor` docstring gives: a fixture written FROM the extractor
+ * asserts only that the code agrees with itself. Note the two things a
+ * hand-written sample would almost certainly have got wrong — `message` carries
+ * NO `content` key at all (not `content: null`), and `finishReason` is
+ * `'tool_calls'` rather than `'stop'`.
+ */
+const REAL_TOOL_CALL_STEP = {
+  $type: 'chatCompletion',
+  name: 'block-step',
+  status: 'succeeded',
+  output: {
+    choices: [
+      {
+        index: 0,
+        finishReason: 'tool_calls',
+        message: {
+          role: 'assistant',
+          tool_calls: [
+            {
+              id: 'call_d41b5525e73e4551ab588457',
+              type: 'function',
+              function: {
+                name: 'search_models',
+                arguments: '{"query":"DreamShaper checkpoint","limit":1}',
+              },
+            },
+          ],
+        },
+      },
+    ],
+    usage: { promptTokens: 407, completionTokens: 27, totalTokens: 434 },
+  },
+};
+
+/** A minimal well-formed tool definition. */
+const VALID_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'search_models',
+    description: 'Search the model catalog',
+    parameters: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    },
+  },
+};
+
+describe('chat-completion — tools / toolChoice param surface', () => {
+  it('accepts a well-formed tools payload', () => {
+    const result = parse({ ...VALID_PARAMS, tools: [VALID_TOOL] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts each documented toolChoice string mode', () => {
+    for (const toolChoice of ['auto', 'none', 'required'] as const) {
+      expect(parse({ ...VALID_PARAMS, tools: [VALID_TOOL], toolChoice }).success).toBe(true);
+    }
+  });
+
+  it('accepts a toolChoice naming a DECLARED function', () => {
+    const result = parse({
+      ...VALID_PARAMS,
+      tools: [VALID_TOOL],
+      toolChoice: { type: 'function', function: { name: 'search_models' } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('REJECTS a toolChoice naming a function that is not in tools', () => {
+    const result = parse({
+      ...VALID_PARAMS,
+      tools: [VALID_TOOL],
+      toolChoice: { type: 'function', function: { name: 'not_declared' } },
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('not in tools');
+  });
+
+  it('REJECTS toolChoice with no tools — a no-op the caller would misread', () => {
+    const result = parse({ ...VALID_PARAMS, toolChoice: 'required' });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('requires tools');
+  });
+
+  it('REJECTS a bad toolChoice value', () => {
+    expect(parse({ ...VALID_PARAMS, tools: [VALID_TOOL], toolChoice: 'maybe' }).success).toBe(
+      false
+    );
+  });
+
+  it('REJECTS more than the maximum tool count', () => {
+    const tools = Array.from({ length: 9 }, (_, i) => ({
+      ...VALID_TOOL,
+      function: { ...VALID_TOOL.function, name: `tool_${i}` },
+    }));
+    expect(parse({ ...VALID_PARAMS, tools }).success).toBe(false);
+    // …and the boundary below it is accepted, so the rejection is the COUNT and
+    // not something else about the fixture.
+    expect(parse({ ...VALID_PARAMS, tools: tools.slice(0, 8) }).success).toBe(true);
+  });
+
+  it('REJECTS a tool name outside the safe character class', () => {
+    for (const name of ['has space', 'has.dot', 'has/slash', '']) {
+      const result = parse({
+        ...VALID_PARAMS,
+        tools: [{ ...VALID_TOOL, function: { ...VALID_TOOL.function, name } }],
+      });
+      expect(result.success, `name ${JSON.stringify(name)} must be rejected`).toBe(false);
+    }
+  });
+
+  it('REJECTS an over-long tool description', () => {
+    const result = parse({
+      ...VALID_PARAMS,
+      tools: [
+        { ...VALID_TOOL, function: { ...VALID_TOOL.function, description: 'x'.repeat(1_025) } },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('REJECTS an over-large serialized parameters object', () => {
+    const result = parse({
+      ...VALID_PARAMS,
+      tools: [
+        {
+          ...VALID_TOOL,
+          function: { ...VALID_TOOL.function, parameters: { type: 'object', pad: 'x'.repeat(5_000) } },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('serialized characters');
+  });
+
+  it('REJECTS a parameters object nested deeper than the cap', () => {
+    // 🔴 THE DEPTH CAP EXISTS SO THIS FAILS HERE RATHER THAN IN THE AIR SCAN.
+    // `containsAirReference` recurses fail-CLOSED past its own cap, so without
+    // this an over-nested schema would be rejected as "contains an AIR
+    // reference" — a confidently wrong diagnostic. Asserting the MESSAGE is what
+    // pins that; a bare `success === false` would pass either way.
+    let deep: Record<string, unknown> = { type: 'string' };
+    for (let i = 0; i < 12; i++) deep = { type: 'object', properties: { nested: deep } };
+    const result = parse({
+      ...VALID_PARAMS,
+      tools: [{ ...VALID_TOOL, function: { ...VALID_TOOL.function, parameters: deep } }],
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('nest deeper');
+  });
+
+  it('REJECTS a non-object parameters value', () => {
+    for (const parameters of ['a string', 42, ['an', 'array'], null]) {
+      const result = parse({
+        ...VALID_PARAMS,
+        tools: [{ ...VALID_TOOL, function: { ...VALID_TOOL.function, parameters } }],
+      });
+      expect(result.success, `parameters ${JSON.stringify(parameters)} must be rejected`).toBe(
+        false
+      );
+    }
+  });
+
+  it('REJECTS unknown properties on a tool (.strict)', () => {
+    expect(parse({ ...VALID_PARAMS, tools: [{ ...VALID_TOOL, extra: 1 }] }).success).toBe(false);
+    expect(
+      parse({
+        ...VALID_PARAMS,
+        tools: [{ ...VALID_TOOL, function: { ...VALID_TOOL.function, strict: true } }],
+      }).success
+    ).toBe(false);
+  });
+
+  it('🔴 NORMALISES parameters through JSON — a toJSON-bearing instance cannot hide from the AIR scan', () => {
+    // 🔴 THE MEASURED HAZARD `containsAirReference` DOCUMENTS. `Object.keys(new
+    // URL(…))` is `[]`, so a structural walk sees a harmless empty object while
+    // `JSON.stringify` emits the full href. superjson reconstructs a `URL`
+    // across the tRPC boundary, so this is reachable input, not a hypothetical.
+    //
+    // Both halves are asserted, and the FIRST is the control: without it a
+    // passing second half could just mean the value was dropped.
+    const smuggled = new URL('https://example.test/urn:air:sd1:checkpoint:civitai:4384@128713');
+    expect(containsAirReference({ parameters: smuggled })).toBe(false); // the hazard, unnormalised
+    const result = parse({
+      ...VALID_PARAMS,
+      tools: [
+        {
+          ...VALID_TOOL,
+          function: { ...VALID_TOOL.function, parameters: { type: 'object', href: smuggled } },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    // After normalisation the URL is a plain string, so the scan CAN see it —
+    // and the built step is therefore refused by the entitlement re-assert
+    // rather than sailing through it.
+    const built = chatCompletionStep.buildStep(result.data!);
+    expect(containsAirReference(built.input)).toBe(true);
+  });
+});
+
+describe('chat-completion — the tool ROUND bound', () => {
+  const toolMessage = (i: number) => ({
+    role: 'tool' as const,
+    content: `result ${i}`,
+    tool_call_id: `call_${i}`,
+  });
+
+  it('accepts exactly MAX_TOOL_ROUNDS tool messages', () => {
+    const messages = [
+      { role: 'user' as const, content: 'hello' },
+      ...Array.from({ length: MAX_TOOL_ROUNDS }, (_, i) => toolMessage(i)),
+    ];
+    expect(parse({ ...VALID_PARAMS, messages }).success).toBe(true);
+  });
+
+  it('🔴 REJECTS MAX_TOOL_ROUNDS + 1 tool messages', () => {
+    const messages = [
+      { role: 'user' as const, content: 'hello' },
+      ...Array.from({ length: MAX_TOOL_ROUNDS + 1 }, (_, i) => toolMessage(i)),
+    ];
+    const result = parse({ ...VALID_PARAMS, messages });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('too many tool rounds');
+  });
+
+  it('🔴 the bound is enforced on the ESTIMATE path too, not only on submit', () => {
+    // The AC3 property: the cap must hold wherever params are parsed. Both the
+    // estimate and the submit go through `parseStepParams`, which runs THIS
+    // schema — so a caller cannot probe or spend past it on either surface.
+    // Asserted through the registry's own accessor rather than the imported
+    // const, so it reads the entry the router would resolve.
+    const entry = getStep(STEP_ID) as AnyBlockStep;
+    const messages = [
+      { role: 'user' as const, content: 'hello' },
+      ...Array.from({ length: MAX_TOOL_ROUNDS + 1 }, (_, i) => toolMessage(i)),
+    ];
+    expect(entry.paramSchema.safeParse({ ...VALID_PARAMS, messages }).success).toBe(false);
+  });
+
+  it('does not count assistant tool_calls turns toward the round bound', () => {
+    // A round is a RESULT coming back. The assistant turn that requested it is
+    // replayed history and is bounded by `MAX_MESSAGES`, not by this cap.
+    const messages = [
+      { role: 'user' as const, content: 'hello' },
+      ...Array.from({ length: 6 }, () => ({
+        role: 'assistant' as const,
+        tool_calls: [
+          { id: 'c', type: 'function' as const, function: { name: 'f', arguments: '{}' } },
+        ],
+      })),
+      ...Array.from({ length: MAX_TOOL_ROUNDS }, (_, i) => toolMessage(i)),
+    ];
+    expect(parse({ ...VALID_PARAMS, messages }).success).toBe(true);
+  });
+});
+
+describe('chat-completion — the tool/assistant message members', () => {
+  it('accepts an assistant turn carrying tool_calls and no content', () => {
+    const result = parse({
+      ...VALID_PARAMS,
+      messages: [
+        { role: 'user', content: 'hello' },
+        {
+          role: 'assistant',
+          tool_calls: [
+            { id: 'call_1', type: 'function', function: { name: 'f', arguments: '{"a":1}' } },
+          ],
+        },
+        { role: 'tool', content: 'result', tool_call_id: 'call_1' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('REJECTS an assistant turn with neither content nor tool_calls', () => {
+    const result = parse({ ...VALID_PARAMS, messages: [{ role: 'assistant' }] });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('content, tool_calls, or both');
+  });
+
+  it('REJECTS a tool message with no tool_call_id', () => {
+    const result = parse({
+      ...VALID_PARAMS,
+      messages: [{ role: 'tool', content: 'result' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('REJECTS an unknown role and unknown message properties', () => {
+    expect(parse({ ...VALID_PARAMS, messages: [{ role: 'wizard', content: 'x' }] }).success).toBe(
+      false
+    );
+    expect(
+      parse({ ...VALID_PARAMS, messages: [{ role: 'user', content: 'x', name: 'n' }] }).success
+    ).toBe(false);
+  });
+
+  it('still rejects `images` on a message — the modalities surface stays shut', () => {
+    expect(
+      parse({
+        ...VALID_PARAMS,
+        messages: [{ role: 'assistant', content: 'x', images: [{ type: 'image_url' }] }],
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('chat-completion — buildStep emits the tool fields on the WIRE names', () => {
+  it('omits both fields entirely when no tools are declared', () => {
+    const built = chatCompletionStep.buildStep(VALID_PARAMS);
+    expect(Object.keys(built.input).sort()).toEqual(['maxTokens', 'messages', 'model']);
+  });
+
+  it('🔴 emits `tool_choice`, snake-cased, NOT the camelCase param name', () => {
+    // Getting this backwards does not error — an unknown field is ignored — so
+    // the feature would be silently inert. That is why it is pinned by key set.
+    const params = parse({ ...VALID_PARAMS, tools: [VALID_TOOL], toolChoice: 'required' });
+    expect(params.success).toBe(true);
+    const built = chatCompletionStep.buildStep(params.data!);
+    expect(Object.keys(built.input).sort()).toEqual([
+      'maxTokens',
+      'messages',
+      'model',
+      'tool_choice',
+      'tools',
+    ]);
+    expect((built.input as Record<string, unknown>).tool_choice).toBe('required');
+    expect((built.input as Record<string, unknown>).toolChoice).toBeUndefined();
+  });
+});
+
+describe('chat-completion — extractToolCalls', () => {
+  it('🔴 returns the structured call from the REAL captured response', () => {
+    expect(chatCompletionStep.extractToolCalls(REAL_TOOL_CALL_STEP)).toEqual([
+      {
+        id: 'call_d41b5525e73e4551ab588457',
+        type: 'function',
+        function: {
+          name: 'search_models',
+          arguments: '{"query":"DreamShaper checkpoint","limit":1}',
+        },
+      },
+    ]);
+  });
+
+  it('🔴 every arguments string it returns is ALSO returned by extractText', () => {
+    // The containment property clause 8b asserts at load. Without it the
+    // structured surface would publish prose the scan never read.
+    const calls = chatCompletionStep.extractToolCalls(REAL_TOOL_CALL_STEP);
+    const texts = chatCompletionStep.extractText(REAL_TOOL_CALL_STEP);
+    for (const call of calls) expect(texts).toContain(call.function.arguments);
+  });
+
+  it('DROPS a call whose name escapes the safe character class', () => {
+    // The name is the one published string the scan does not read; the pattern
+    // is the entire reason that is defensible, so it is enforced on the way OUT
+    // and not merely on the way in.
+    const evil = {
+      output: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                { id: '1', type: 'function', function: { name: 'a b c', arguments: '{}' } },
+                { id: '2', type: 'function', function: { name: 'ok_name', arguments: '{}' } },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(chatCompletionStep.extractToolCalls(evil).map((c) => c.function.name)).toEqual([
+      'ok_name',
+    ]);
+  });
+
+  it('DROPS partial calls rather than publishing a half-formed one', () => {
+    const partial = {
+      output: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                { type: 'function', function: { name: 'f', arguments: '{}' } }, // no id
+                { id: '2', type: 'function', function: { name: 'f' } }, // no arguments
+                { id: '3', type: 'function' }, // no function
+                null,
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(chatCompletionStep.extractToolCalls(partial)).toEqual([]);
+  });
+
+  it('is total over absent, null and malformed input', () => {
+    expect(chatCompletionStep.extractToolCalls(undefined)).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls(null)).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls({})).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls({ output: { choices: 'nope' } })).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls({ output: { choices: [null] } })).toEqual([]);
+    expect(
+      chatCompletionStep.extractToolCalls({ output: { choices: [{ message: { tool_calls: 'x' } }] } })
+    ).toEqual([]);
+  });
+
+  it('returns nothing for an ordinary reply that called no tool', () => {
+    expect(chatCompletionStep.extractToolCalls(REAL_COMPLETED_STEP)).toEqual([]);
   });
 });

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -917,8 +917,11 @@ describe('chat-completion — the tool ROUND bound', () => {
   it('does not count assistant tool_calls turns toward the round bound', () => {
     // A round is a RESULT coming back. The assistant turn that requested it is
     // replayed history and is bounded by `MAX_MESSAGES`, not by this cap. Here
-    // six extra asks are declared and left UNANSWERED — legal, since the
-    // correlation guard constrains answers to declared asks and not the reverse.
+    // six extra asks are declared and left UNANSWERED — which THIS SCHEMA
+    // ACCEPTS, because the correlation guard constrains answers to declared asks
+    // and not the reverse. That is a statement about what we accept, NOT a claim
+    // that an unanswered ask is legal at the provider: see the known-gap note on
+    // the correlation guard in `chat-completion.step.ts`.
     const messages = [
       { role: 'user' as const, content: 'hello' },
       ...Array.from({ length: 6 }, (_, i) => askMessage(100 + i)),
@@ -958,6 +961,71 @@ describe('chat-completion — the tool/assistant message members', () => {
       messages: [{ role: 'tool', content: 'result' }],
     });
     expect(result.success).toBe(false);
+  });
+
+  it('🔴 INPUT and OUTPUT agree on what a valid tool-call id is', () => {
+    // 🔴 THE FILE USED TO HOLD TWO DISAGREEING DEFINITIONS, which audit found:
+    // `call:with:colons` PARSED on input while `extractToolCalls` REFUSED it on
+    // the way out. Reconciled toward the stricter one. This cannot reject a
+    // legitimate payload, and that is the load-bearing half of the argument: the
+    // only id a block can legitimately replay is one WE published, and we
+    // publish only charset-conforming ids.
+    const withIds = (id: string) => ({
+      ...VALID_PARAMS,
+      messages: [
+        { role: 'user', content: 'hello' },
+        {
+          role: 'assistant',
+          tool_calls: [{ id, type: 'function', function: { name: 'f', arguments: '{}' } }],
+        },
+        { role: 'tool', content: 'result', tool_call_id: id },
+      ],
+    });
+    // Refused on input, exactly as the extractor refuses it on output.
+    expect(parse(withIds('call:with:colons')).success).toBe(false);
+    expect(parse(withIds('call has spaces')).success).toBe(false);
+
+    // 🔴 THE CASE ABOVE DOES NOT ATTRIBUTE, AND SAYING SO IS THE POINT. It
+    // carries BOTH an assistant `id` and a matching `tool_call_id`, which are
+    // separately charset-bounded — so removing either regex alone leaves the
+    // other (or the correlation guard) to reject the payload, and a mutation of
+    // one is masked by the other. Measured: dropping the assistant-side regex
+    // on its own left this whole suite GREEN. The assistant-only payload below
+    // has no tool message at all, so nothing else can do the rejecting and the
+    // assistant `id` regex is the only thing that can fail it.
+    expect(
+      parse({
+        ...VALID_PARAMS,
+        messages: [
+          { role: 'user', content: 'hello' },
+          {
+            role: 'assistant',
+            tool_calls: [
+              { id: 'call:with:colons', type: 'function', function: { name: 'f', arguments: '{}' } },
+            ],
+          },
+        ],
+      }).success
+    ).toBe(false);
+    // …and the real provider id shape still round-trips, so this is a bound and
+    // not a ban. Same literal the output-side test uses.
+    const good = 'call_d41b5525e73e4551ab588457';
+    expect(parse(withIds(good)).success).toBe(true);
+    expect(
+      chatCompletionStep.extractToolCalls({
+        output: {
+          choices: [
+            {
+              message: {
+                tool_calls: [
+                  { id: good, type: 'function', function: { name: 'f', arguments: '{}' } },
+                ],
+              },
+            },
+          ],
+        },
+      })
+    ).toHaveLength(1);
   });
 
   it('REJECTS an unknown role and unknown message properties', () => {
@@ -1083,6 +1151,19 @@ describe('chat-completion — extractToolCalls', () => {
     expect(chatCompletionStep.extractToolCalls(REAL_COMPLETED_STEP)).toEqual([]);
   });
 
+  // 🔴 THE THREE ID FIXTURES ARE PAIRWISE DISTINCT ON PURPOSE, so each one
+  // isolates ONE guard. The original single fixture was 4,900+ chars AND
+  // contained spaces and colons, so the pattern mutant and the length mutant
+  // each died to it individually — the test named after the audit finding could
+  // not tell you which guard was load-bearing. Re-derived: mutate either guard
+  // alone and exactly one of these goes red.
+  //
+  //   CHARSET-only violation, comfortably UNDER the length cap (43 chars).
+  const AIR_ID = 'urn:air:sd1:checkpoint:civitai:4384@128713';
+  //   LENGTH-only violation, fully charset-CONFORMING (cap is 64).
+  const LONG_ID = 'a'.repeat(65);
+  //   BOTH, i.e. the shape the audit actually demonstrated. Kept as the
+  //   end-to-end regression, but it is explicitly NOT the attributing case.
   const PROSE_ID = `not a real id ${'x'.repeat(4900)} urn:air:sd1:checkpoint:civitai:4384@128713`;
   const withToolCall = (id: string, args: string) => ({
     output: {
@@ -1096,26 +1177,38 @@ describe('chat-completion — extractToolCalls', () => {
     },
   });
 
+  it('🔴 DROPS an id on CHARSET alone — isolates the pattern guard', () => {
+    // 43 chars, so the length cap cannot be what rejects it. Mutate away the
+    // pattern test and this is the case that goes red.
+    expect(AIR_ID.length).toBeLessThan(64);
+    expect(chatCompletionStep.extractToolCalls(withToolCall(AIR_ID, '{}'))).toEqual([]);
+  });
+
+  it('🔴 DROPS an id on LENGTH alone — isolates the length guard', () => {
+    // Charset-conforming, so the pattern test cannot be what rejects it.
+    expect(/^[a-zA-Z0-9_-]+$/.test(LONG_ID)).toBe(true);
+    expect(chatCompletionStep.extractToolCalls(withToolCall(LONG_ID, '{}'))).toEqual([]);
+  });
+
   it('🔴 DROPS an unbounded prose `id` carrying an AIR literal', () => {
-    // 🔴 THE CASE THE AUDIT DEMONSTRATED, kept as the regression. `id` was
-    // accepted on `typeof id === 'string' && length > 0` alone, so a 5,000-char
-    // id carrying prose AND a literal AIR was published to the block verbatim.
-    // Neither clause 8b (which compares `arguments` only) nor the runtime shape
-    // guard in ./moderation (types, not bounds) sees it — the output-side
-    // pattern + length check is the whole control.
+    // 🔴 THE CASE THE AUDIT DEMONSTRATED, kept as the end-to-end regression. It
+    // violates BOTH bounds, so it does NOT attribute — the two cases above are
+    // what tell you which guard is load-bearing. Pre-fix, `id` was accepted on
+    // `typeof id === 'string' && length > 0` alone and a 5,000-char id carrying
+    // prose AND a literal AIR reached the block verbatim.
     expect(chatCompletionStep.extractToolCalls(withToolCall(PROSE_ID, '{}'))).toEqual([]);
   });
 
-  it('🔴 the ZERO-SCAN combination: a prose id with EMPTY arguments', () => {
-    // 🔴 THE SHARPER HALF, AND IT NEEDS BOTH FIXES. With empty `arguments`,
-    // `extractText` returns NOTHING for this response — so `screenGeneratedText`
-    // short-circuits on the empty text set and RELEASES WITHOUT EVER CALLING THE
-    // SCANNER. Pre-fix, the prose id was therefore published on a path where no
-    // scan ran at all. Note the assertion that `extractText` is empty is what
-    // makes this case distinct from the one above, where '{}' IS scanned.
-    const evil = withToolCall(PROSE_ID, '');
-    expect(chatCompletionStep.extractText(evil)).toEqual([]);
-    expect(chatCompletionStep.extractToolCalls(evil)).toEqual([]);
+  it('🔴 a REJECTED call leaves NO orphan arguments in extractText', () => {
+    // 🔴 THE PAIRING IS THE POINT, and its absence was an audit finding: the
+    // extractors used to decide independently, so a call dropped for a bad id
+    // still had its arguments published — the block got argument JSON in
+    // `textOutputs`, an empty `toolCalls`, and no id to answer with. Both sides
+    // now derive from `publishableToolCalls`, so a rejected call contributes
+    // nothing anywhere.
+    const rejected = withToolCall(AIR_ID, '{"query":"real arguments"}');
+    expect(chatCompletionStep.extractToolCalls(rejected)).toEqual([]);
+    expect(chatCompletionStep.extractText(rejected)).toEqual([]);
   });
 
   it('DROPS an id that escapes the safe character class, or exceeds the length cap', () => {
@@ -1139,13 +1232,16 @@ describe('chat-completion — extractToolCalls', () => {
     ).toHaveLength(1);
   });
 
-  it('🔴 DROPS empty / whitespace-only arguments, which is what makes containment TRUE', () => {
-    // Before this, `extractToolCalls` accepted any string while `extractText`
-    // required `trim().length > 0` — so a call with `arguments: ''` was
-    // published while the scan was handed nothing for it, and the containment
-    // property clause 8b and three docstrings state was literally false on
-    // UNMUTATED code. The ordinary no-argument encoding is '{}' and is
-    // unaffected.
+  it('🔴 NORMALISES empty / whitespace-only arguments to "{}" — it does not drop the call', () => {
+    // 🔴 THIS PINS A REGRESSION THIS PR SHIPPED AND AUDIT CAUGHT. Two wrong
+    // behaviours preceded it: first `extractToolCalls` accepted any string while
+    // `extractText` required `trim().length > 0`, so an empty-argument call was
+    // PUBLISHED but never SCANNED; then aligning them by DROPPING the call made
+    // a no-argument tool call vanish entirely — the step was charged, reported
+    // `succeeded`, and published nothing at all. Normalising to '{}' keeps the
+    // call reaching the block AND keeps containment true, because '{}' is what
+    // `extractText` then scans. `JSON.parse('')` throws; `JSON.parse('{}')` is
+    // the empty argument object the call actually means.
     const build = (args: string) => ({
       output: {
         choices: [
@@ -1157,8 +1253,15 @@ describe('chat-completion — extractToolCalls', () => {
         ],
       },
     });
-    expect(chatCompletionStep.extractToolCalls(build(''))).toEqual([]);
-    expect(chatCompletionStep.extractToolCalls(build('   \n\t '))).toEqual([]);
+    for (const empty of ['', '   \n\t ']) {
+      // The call SURVIVES, with usable arguments…
+      expect(chatCompletionStep.extractToolCalls(build(empty))).toEqual([
+        { id: 'call_1', type: 'function', function: { name: 'f', arguments: '{}' } },
+      ]);
+      // …and containment holds: what is published is what was scanned.
+      expect(chatCompletionStep.extractText(build(empty))).toEqual(['{}']);
+    }
+    // The ordinary encoding is unaffected.
     expect(chatCompletionStep.extractToolCalls(build('{}'))).toHaveLength(1);
 
     // The property itself, asserted over every shape above rather than only the

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -783,6 +783,22 @@ describe('chat-completion — the tool ROUND bound', () => {
     tool_call_id: `call_${i}`,
   });
 
+  it('🔴 MAX_TOOL_ROUNDS is a real exported number — the cases below degenerate without it', () => {
+    // 🔴 THIS GUARD EXISTS BECAUSE THE DEGENERATION WAS OBSERVED, not imagined.
+    // Measured while taking the red-at-base matrix for this change: against
+    // pre-change source the named import resolves to `undefined` (esbuild's CJS
+    // transform makes a missing named export undefined rather than a link
+    // error), so `Array.from({ length: MAX_TOOL_ROUNDS })` yields `[]`, the
+    // fixture collapses to a single user message, and
+    // "accepts exactly MAX_TOOL_ROUNDS tool messages" PASSED for a reason that
+    // had nothing to do with the round bound.
+    //
+    // Pinning the literal also pins the number the entry's header and the
+    // rejection message both state, so the three cannot drift apart silently.
+    expect(typeof MAX_TOOL_ROUNDS).toBe('number');
+    expect(MAX_TOOL_ROUNDS).toBe(3);
+  });
+
   it('accepts exactly MAX_TOOL_ROUNDS tool messages', () => {
     const messages = [
       { role: 'user' as const, content: 'hello' },

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -550,15 +550,35 @@ describe('chat-completion — extractText, against the REAL response', () => {
     ).toEqual([]);
   });
 
-  it('🔴 the entry’s own canonical sample is the SAME real response, for every variant', () => {
-    // Clause 8a probes `extractText(canonicalOutputFor(v))`. This asserts the
-    // sample was not quietly re-written to suit the extractor: it must still
-    // equal the captured response held independently at the top of this file.
+  it('🔴 every choice in the entry’s canonical sample is a REAL captured choice, for every variant', () => {
+    // Clauses 8a and 8b both probe `canonicalOutputFor(v)`. This asserts the
+    // sample was not quietly re-written to suit the extractors: each choice must
+    // still equal a choice from one of the two captured responses held
+    // independently at the top of this file.
+    //
+    // 🔴 THE SECOND CHOICE IS WHY THE SAMPLE CARRIES TWO, AND WHY THIS TEST
+    // CHANGED. With a content-only sample, clause 8b's containment loop iterates
+    // an EMPTY set and passes vacuously — the audit demonstrated that a real
+    // containment break in the shipped extractor loaded clean. The tool-call
+    // choice is what makes that clause execute. Asserting choice-by-choice
+    // rather than whole-object keeps the "verbatim, not invented" property that
+    // this test has always existed to pin.
     for (const variant of CHAT_COMPLETION_MODELS) {
-      expect(chatCompletionStep.canonicalOutputFor(variant)).toEqual(REAL_COMPLETED_STEP);
-      expect(
-        chatCompletionStep.extractText(chatCompletionStep.canonicalOutputFor(variant))
-      ).toEqual(['OK']);
+      const sample = chatCompletionStep.canonicalOutputFor(variant) as typeof REAL_COMPLETED_STEP & {
+        output: { choices: unknown[] };
+      };
+      expect(sample.output.choices).toHaveLength(2);
+      expect(sample.output.choices[0]).toEqual(REAL_COMPLETED_STEP.output.choices[0]);
+      expect(sample.output.choices[1]).toEqual({
+        ...REAL_TOOL_CALL_STEP.output.choices[0],
+        // The captured tool-call response is a single-choice response, so its
+        // own `index` is 0; only the position in this composed envelope differs.
+        index: 1,
+      });
+      expect(chatCompletionStep.extractText(sample)).toEqual([
+        'OK',
+        '{"query":"DreamShaper checkpoint","limit":1}',
+      ]);
     }
   });
 });
@@ -783,6 +803,32 @@ describe('chat-completion — the tool ROUND bound', () => {
     tool_call_id: `call_${i}`,
   });
 
+  /**
+   * The assistant turn that DECLARES `call_${i}`, so the matching tool message
+   * answers a call that was actually made.
+   *
+   * 🔴 REQUIRED SINCE THE CORRELATION GUARD LANDED, and the fixtures below were
+   * changed rather than the guard weakened. Before it, a `tool` message could
+   * reference an id no assistant turn had ever declared and still parse — which
+   * an OpenAI-compatible provider rejects, after the payload has been quoted,
+   * reserved and charged. A round is a PAIR (the ask, then the answer), and a
+   * fixture that carried only the answer was not modelling a real conversation.
+   */
+  const askMessage = (i: number) => ({
+    role: 'assistant' as const,
+    tool_calls: [
+      {
+        id: `call_${i}`,
+        type: 'function' as const,
+        function: { name: 'search_models', arguments: '{}' },
+      },
+    ],
+  });
+
+  /** `n` complete rounds: each ask immediately followed by its answer. */
+  const rounds = (n: number) =>
+    Array.from({ length: n }, (_, i) => [askMessage(i), toolMessage(i)]).flat();
+
   it('🔴 MAX_TOOL_ROUNDS is a real exported number — the cases below degenerate without it', () => {
     // 🔴 THIS GUARD EXISTS BECAUSE THE DEGENERATION WAS OBSERVED, not imagined.
     // Measured while taking the red-at-base matrix for this change: against
@@ -800,21 +846,22 @@ describe('chat-completion — the tool ROUND bound', () => {
   });
 
   it('accepts exactly MAX_TOOL_ROUNDS tool messages', () => {
-    const messages = [
-      { role: 'user' as const, content: 'hello' },
-      ...Array.from({ length: MAX_TOOL_ROUNDS }, (_, i) => toolMessage(i)),
-    ];
+    const messages = [{ role: 'user' as const, content: 'hello' }, ...rounds(MAX_TOOL_ROUNDS)];
     expect(parse({ ...VALID_PARAMS, messages }).success).toBe(true);
   });
 
   it('🔴 REJECTS MAX_TOOL_ROUNDS + 1 tool messages', () => {
-    const messages = [
-      { role: 'user' as const, content: 'hello' },
-      ...Array.from({ length: MAX_TOOL_ROUNDS + 1 }, (_, i) => toolMessage(i)),
-    ];
+    // 🔴 `rounds()`, NOT bare tool messages — the fixture must violate ONLY the
+    // round bound. With unpaired tool messages the correlation guard rejects
+    // this payload too, so the case would stay red with the round bound
+    // DELETED: green (or red) for the wrong reason, and a vacuous guard.
+    const messages = [{ role: 'user' as const, content: 'hello' }, ...rounds(MAX_TOOL_ROUNDS + 1)];
     const result = parse({ ...VALID_PARAMS, messages });
     expect(result.success).toBe(false);
-    expect(JSON.stringify(result.error?.issues)).toContain('too many tool rounds');
+    const issues = JSON.stringify(result.error?.issues);
+    expect(issues).toContain('too many tool rounds');
+    // ...and it is the ONLY complaint, which is what pins the attribution.
+    expect(issues).not.toContain('no PRECEDING assistant message');
   });
 
   it('🔴 the bound is enforced on the ESTIMATE path too, not only on submit', () => {
@@ -824,25 +871,58 @@ describe('chat-completion — the tool ROUND bound', () => {
     // Asserted through the registry's own accessor rather than the imported
     // const, so it reads the entry the router would resolve.
     const entry = getStep(STEP_ID) as AnyBlockStep;
+    const messages = [{ role: 'user' as const, content: 'hello' }, ...rounds(MAX_TOOL_ROUNDS + 1)];
+    const result = entry.paramSchema.safeParse({ ...VALID_PARAMS, messages });
+    expect(result.success).toBe(false);
+    // Same attribution point as the submit-path case: the round bound must be
+    // what rejects this, not the correlation guard.
+    expect(JSON.stringify(result.error?.issues)).toContain('too many tool rounds');
+  });
+
+  it('🔴 REJECTS a tool message whose tool_call_id no assistant turn declared', () => {
+    // The provider rejects this, but only AFTER the payload has been quoted,
+    // reserved against every cap and charged — with an error the app author
+    // cannot diagnose. Same class as `toolChoice` naming an undeclared function.
     const messages = [
       { role: 'user' as const, content: 'hello' },
-      ...Array.from({ length: MAX_TOOL_ROUNDS + 1 }, (_, i) => toolMessage(i)),
+      askMessage(0),
+      { role: 'tool' as const, content: 'result', tool_call_id: 'call_nobody_asked' },
     ];
-    expect(entry.paramSchema.safeParse({ ...VALID_PARAMS, messages }).success).toBe(false);
+    const result = parse({ ...VALID_PARAMS, messages });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('no PRECEDING assistant message');
+  });
+
+  it('🔴 REJECTS a tool message with no preceding assistant turn at all', () => {
+    const messages = [{ role: 'user' as const, content: 'hello' }, toolMessage(0)];
+    const result = parse({ ...VALID_PARAMS, messages });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('no PRECEDING assistant message');
+  });
+
+  it('🔴 REJECTS an answer that PRECEDES its own ask — ordering, not just membership', () => {
+    // 🔴 THE CASE THAT SEPARATES THIS GUARD FROM A MEMBERSHIP CHECK. The id IS
+    // declared in the payload, just later. Collecting every id first and then
+    // testing membership would accept this, and the provider would not.
+    const messages = [
+      { role: 'user' as const, content: 'hello' },
+      toolMessage(0),
+      askMessage(0),
+    ];
+    const result = parse({ ...VALID_PARAMS, messages });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('no PRECEDING assistant message');
   });
 
   it('does not count assistant tool_calls turns toward the round bound', () => {
     // A round is a RESULT coming back. The assistant turn that requested it is
-    // replayed history and is bounded by `MAX_MESSAGES`, not by this cap.
+    // replayed history and is bounded by `MAX_MESSAGES`, not by this cap. Here
+    // six extra asks are declared and left UNANSWERED — legal, since the
+    // correlation guard constrains answers to declared asks and not the reverse.
     const messages = [
       { role: 'user' as const, content: 'hello' },
-      ...Array.from({ length: 6 }, () => ({
-        role: 'assistant' as const,
-        tool_calls: [
-          { id: 'c', type: 'function' as const, function: { name: 'f', arguments: '{}' } },
-        ],
-      })),
-      ...Array.from({ length: MAX_TOOL_ROUNDS }, (_, i) => toolMessage(i)),
+      ...Array.from({ length: 6 }, (_, i) => askMessage(100 + i)),
+      ...rounds(MAX_TOOL_ROUNDS),
     ];
     expect(parse({ ...VALID_PARAMS, messages }).success).toBe(true);
   });
@@ -1001,5 +1081,94 @@ describe('chat-completion — extractToolCalls', () => {
 
   it('returns nothing for an ordinary reply that called no tool', () => {
     expect(chatCompletionStep.extractToolCalls(REAL_COMPLETED_STEP)).toEqual([]);
+  });
+
+  const PROSE_ID = `not a real id ${'x'.repeat(4900)} urn:air:sd1:checkpoint:civitai:4384@128713`;
+  const withToolCall = (id: string, args: string) => ({
+    output: {
+      choices: [
+        {
+          message: {
+            tool_calls: [{ id, type: 'function', function: { name: 'f', arguments: args } }],
+          },
+        },
+      ],
+    },
+  });
+
+  it('🔴 DROPS an unbounded prose `id` carrying an AIR literal', () => {
+    // 🔴 THE CASE THE AUDIT DEMONSTRATED, kept as the regression. `id` was
+    // accepted on `typeof id === 'string' && length > 0` alone, so a 5,000-char
+    // id carrying prose AND a literal AIR was published to the block verbatim.
+    // Neither clause 8b (which compares `arguments` only) nor the runtime shape
+    // guard in ./moderation (types, not bounds) sees it — the output-side
+    // pattern + length check is the whole control.
+    expect(chatCompletionStep.extractToolCalls(withToolCall(PROSE_ID, '{}'))).toEqual([]);
+  });
+
+  it('🔴 the ZERO-SCAN combination: a prose id with EMPTY arguments', () => {
+    // 🔴 THE SHARPER HALF, AND IT NEEDS BOTH FIXES. With empty `arguments`,
+    // `extractText` returns NOTHING for this response — so `screenGeneratedText`
+    // short-circuits on the empty text set and RELEASES WITHOUT EVER CALLING THE
+    // SCANNER. Pre-fix, the prose id was therefore published on a path where no
+    // scan ran at all. Note the assertion that `extractText` is empty is what
+    // makes this case distinct from the one above, where '{}' IS scanned.
+    const evil = withToolCall(PROSE_ID, '');
+    expect(chatCompletionStep.extractText(evil)).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls(evil)).toEqual([]);
+  });
+
+  it('DROPS an id that escapes the safe character class, or exceeds the length cap', () => {
+    const build = (id: string) => ({
+      output: {
+        choices: [
+          {
+            message: {
+              tool_calls: [{ id, type: 'function', function: { name: 'f', arguments: '{}' } }],
+            },
+          },
+        ],
+      },
+    });
+    expect(chatCompletionStep.extractToolCalls(build('call has spaces'))).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls(build('call:with:colons'))).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls(build('a'.repeat(65)))).toEqual([]);
+    // ...and the real provider id shape still passes, so the bound is not a ban.
+    expect(
+      chatCompletionStep.extractToolCalls(build('call_d41b5525e73e4551ab588457'))
+    ).toHaveLength(1);
+  });
+
+  it('🔴 DROPS empty / whitespace-only arguments, which is what makes containment TRUE', () => {
+    // Before this, `extractToolCalls` accepted any string while `extractText`
+    // required `trim().length > 0` — so a call with `arguments: ''` was
+    // published while the scan was handed nothing for it, and the containment
+    // property clause 8b and three docstrings state was literally false on
+    // UNMUTATED code. The ordinary no-argument encoding is '{}' and is
+    // unaffected.
+    const build = (args: string) => ({
+      output: {
+        choices: [
+          {
+            message: {
+              tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'f', arguments: args } }],
+            },
+          },
+        ],
+      },
+    });
+    expect(chatCompletionStep.extractToolCalls(build(''))).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls(build('   \n\t '))).toEqual([]);
+    expect(chatCompletionStep.extractToolCalls(build('{}'))).toHaveLength(1);
+
+    // The property itself, asserted over every shape above rather than only the
+    // captured response: whatever survives must be scannable.
+    for (const args of ['', '   \n\t ', '{}', '{"a":1}']) {
+      const step = build(args);
+      const texts = chatCompletionStep.extractText(step);
+      for (const call of chatCompletionStep.extractToolCalls(step)) {
+        expect(texts).toContain(call.function.arguments);
+      }
+    }
   });
 });

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -171,8 +171,22 @@ describe('chat-completion — the bounded param surface', () => {
     // `.strict()` in action. Each of these is a real `ChatCompletionInput`
     // field; forwarding any of them from an untrusted iframe is a widening
     // nobody reviewed.
+    //
+    // 🔴 `tools` WAS REMOVED FROM THIS LIST, AND THAT IS A CORRECTION, NOT A
+    // WEAKENING. This entry now DOES expose `tools`, so the field no longer
+    // belongs under a heading that says it does not. The entry stayed green
+    // only because the fixture value was `[]`, which fails the schema's
+    // `.min(1)` bound — i.e. it passed for a reason unrelated to the property
+    // the test is named for, and a reader would have concluded from a green run
+    // that tools were still rejected. `tools` acceptance is covered by the
+    // positive cases in the tool-surface describe block below.
+    //
+    // 🔴 `tool_choice` (snake_case) DELIBERATELY STAYS. The param this entry
+    // exposes is `toolChoice`; the snake_case spelling is the ORCHESTRATOR wire
+    // name and is not a param here, so `.strict()` must keep rejecting it. That
+    // distinction is load-bearing while the wire spelling is still unconfirmed
+    // against a live request — see the entry's own note.
     for (const [key, value] of [
-      ['tools', []],
       ['tool_choice', 'auto'],
       ['n', 4],
       ['stop', ['x']],
@@ -550,24 +564,33 @@ describe('chat-completion — extractText, against the REAL response', () => {
     ).toEqual([]);
   });
 
-  it('🔴 every choice in the entry’s canonical sample is a REAL captured choice, for every variant', () => {
-    // Clauses 8a and 8b both probe `canonicalOutputFor(v)`. This asserts the
-    // sample was not quietly re-written to suit the extractors: each choice must
-    // still equal a choice from one of the two captured responses held
-    // independently at the top of this file.
+  it('🔴 the canonical sample is 2 CAPTURED choices + 2 declared ADVERSARIAL ones, for every variant', () => {
+    // Clauses 8a and 8b both probe `canonicalOutputFor(v)`. This test exists to
+    // stop the sample being quietly re-written to suit the extractors — the
+    // both-wrong-blind hazard, where a probe asserts only that the code agrees
+    // with itself.
     //
-    // 🔴 THE SECOND CHOICE IS WHY THE SAMPLE CARRIES TWO, AND WHY THIS TEST
-    // CHANGED. With a content-only sample, clause 8b's containment loop iterates
-    // an EMPTY set and passes vacuously — the audit demonstrated that a real
-    // containment break in the shipped extractor loaded clean. The tool-call
-    // choice is what makes that clause execute. Asserting choice-by-choice
-    // rather than whole-object keeps the "verbatim, not invented" property that
-    // this test has always existed to pin.
+    // 🔴 IT NO LONGER SAYS "EVERY CHOICE IS CAPTURED", BECAUSE THAT STOPPED
+    // BEING TRUE. Choices 2 and 3 are adversarial: real message SHAPE, invented
+    // VALUES, added because clause 8b can only ever see what this sample
+    // contains and a sample of well-formed calls left two shipped divergence
+    // classes undetectable (measured — re-splitting either extractor loaded
+    // clean). Keeping the old blanket assertion would have meant either
+    // deleting the coverage or letting the test name lie.
+    //
+    // So the property pinned here is the SPLIT: the captured choices stay
+    // byte-equal to the responses held independently at the top of this file,
+    // and the adversarial ones stay exactly the values that arm 8b. Both halves
+    // are pinned so neither can drift silently.
     for (const variant of CHAT_COMPLETION_MODELS) {
-      const sample = chatCompletionStep.canonicalOutputFor(variant) as typeof REAL_COMPLETED_STEP & {
+      const sample = chatCompletionStep.canonicalOutputFor(
+        variant
+      ) as typeof REAL_COMPLETED_STEP & {
         output: { choices: unknown[] };
       };
-      expect(sample.output.choices).toHaveLength(2);
+      expect(sample.output.choices).toHaveLength(4);
+
+      // ── CAPTURED — must remain verbatim. ───────────────────────────────────
       expect(sample.output.choices[0]).toEqual(REAL_COMPLETED_STEP.output.choices[0]);
       expect(sample.output.choices[1]).toEqual({
         ...REAL_TOOL_CALL_STEP.output.choices[0],
@@ -575,9 +598,34 @@ describe('chat-completion — extractText, against the REAL response', () => {
         // own `index` is 0; only the position in this composed envelope differs.
         index: 1,
       });
+
+      // ── ADVERSARIAL — declared, and pinned so they keep arming clause 8b. ──
+      // Choice 2 arms 8b against an `extractText` that re-applies a
+      // `trim().length > 0` filter to raw arguments; choice 3 against an
+      // `extractToolCalls` re-split and widened on the id axis. 🔴 Choice 3's
+      // `arguments` must stay DISTINCT from every other choice's — a colliding
+      // string is found in the scanned set and 8b goes silent, which is
+      // mechanically how the previous sample failed to arm it.
+      const adversarial = sample.output.choices.slice(2) as Array<{
+        message: { tool_calls: Array<{ id: string; function: { arguments: string } }> };
+      }>;
+      expect(adversarial[0].message.tool_calls[0].function.arguments).toBe('');
+      expect(adversarial[1].message.tool_calls[0].id).toBe('call.with.dots');
+      expect(adversarial[1].message.tool_calls[0].function.arguments).toBe('{"modelId":4384}');
+
+      const allArgs = (
+        sample.output.choices as Array<{
+          message?: { tool_calls?: Array<{ function: { arguments: string } }> };
+        }>
+      ).flatMap((c) => (c.message?.tool_calls ?? []).map((t) => t.function.arguments));
+      expect(new Set(allArgs).size).toBe(allArgs.length);
+
+      // Choice 2's empty arguments are normalised to `'{}'` and scanned;
+      // choice 3 is dropped entirely, so it contributes no text.
       expect(chatCompletionStep.extractText(sample)).toEqual([
         'OK',
         '{"query":"DreamShaper checkpoint","limit":1}',
+        '{}',
       ]);
     }
   });
@@ -722,7 +770,10 @@ describe('chat-completion — tools / toolChoice param surface', () => {
       tools: [
         {
           ...VALID_TOOL,
-          function: { ...VALID_TOOL.function, parameters: { type: 'object', pad: 'x'.repeat(5_000) } },
+          function: {
+            ...VALID_TOOL.function,
+            parameters: { type: 'object', pad: 'x'.repeat(5_000) },
+          },
         },
       ],
     });
@@ -904,11 +955,7 @@ describe('chat-completion — the tool ROUND bound', () => {
     // 🔴 THE CASE THAT SEPARATES THIS GUARD FROM A MEMBERSHIP CHECK. The id IS
     // declared in the payload, just later. Collecting every id first and then
     // testing membership would accept this, and the provider would not.
-    const messages = [
-      { role: 'user' as const, content: 'hello' },
-      toolMessage(0),
-      askMessage(0),
-    ];
+    const messages = [{ role: 'user' as const, content: 'hello' }, toolMessage(0), askMessage(0)];
     const result = parse({ ...VALID_PARAMS, messages });
     expect(result.success).toBe(false);
     expect(JSON.stringify(result.error?.issues)).toContain('no PRECEDING assistant message');
@@ -1001,7 +1048,11 @@ describe('chat-completion — the tool/assistant message members', () => {
           {
             role: 'assistant',
             tool_calls: [
-              { id: 'call:with:colons', type: 'function', function: { name: 'f', arguments: '{}' } },
+              {
+                id: 'call:with:colons',
+                type: 'function',
+                function: { name: 'f', arguments: '{}' },
+              },
             ],
           },
         ],
@@ -1143,7 +1194,9 @@ describe('chat-completion — extractToolCalls', () => {
     expect(chatCompletionStep.extractToolCalls({ output: { choices: 'nope' } })).toEqual([]);
     expect(chatCompletionStep.extractToolCalls({ output: { choices: [null] } })).toEqual([]);
     expect(
-      chatCompletionStep.extractToolCalls({ output: { choices: [{ message: { tool_calls: 'x' } }] } })
+      chatCompletionStep.extractToolCalls({
+        output: { choices: [{ message: { tool_calls: 'x' } }] },
+      })
     ).toEqual([]);
   });
 
@@ -1247,7 +1300,9 @@ describe('chat-completion — extractToolCalls', () => {
         choices: [
           {
             message: {
-              tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'f', arguments: args } }],
+              tool_calls: [
+                { id: 'call_1', type: 'function', function: { name: 'f', arguments: args } },
+              ],
             },
           },
         ],

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -529,6 +529,100 @@ describe('block step registry — load-time invariants (each guard, mutation-pro
     expect(() => assertStepInvariants('fixture-step', makeTextOutputFixtureStep())).not.toThrow();
   });
 
+  // ── 🔴 CLAUSE 8b — THE TOOL-CALL CONTAINMENT CLAUSE ────────────────────────
+  //
+  // `extractToolCalls` is published by `attachModeratedStepTextOutputs` onto a
+  // RELEASED verdict, and that verdict is computed over `extractText`'s strings.
+  // The gating is therefore sound only while every model-written string the
+  // tool-call surface can publish is ALSO reachable through `extractText`. This
+  // clause is what makes that a build failure rather than a review question.
+
+  /** A `'textOutput'` fixture whose reply is a tool call, with containment intact. */
+  function makeToolCallFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+    const ARGS = '{"query":"model wrote this"}';
+    const sample = {
+      $type: 'fixtureStep',
+      output: {
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                { id: 'call_1', type: 'function', function: { name: 'search', arguments: ARGS } },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    return makeTextOutputFixtureStep({
+      canonicalOutputFor: (): unknown => sample,
+      // Containment: the arguments string is returned HERE, so it is scanned.
+      extractText: () => [ARGS],
+      extractToolCalls: () => [
+        { id: 'call_1', type: 'function' as const, function: { name: 'search', arguments: ARGS } },
+      ],
+      ...overrides,
+    } as Partial<AnyBlockStep>);
+  }
+
+  it('the tool-call fixture PASSES unmutated — every 8b failure below is the mutation', () => {
+    // 🔴 REACHABILITY, same as the textOutput fixture's own control above.
+    expect(() => assertStepInvariants('fixture-step', makeToolCallFixtureStep())).not.toThrow();
+  });
+
+  it('🔴 rejects extractToolCalls publishing an arguments string extractText does NOT return', () => {
+    // The fail-open this clause exists for: the structured surface would reach
+    // the block on the strength of a scan that never read it.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeToolCallFixtureStep({
+          extractText: () => ['some unrelated prose'],
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/publishes an arguments string that extractText\(\) does not return/);
+  });
+
+  it('rejects a malformed tool call from extractToolCalls', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeToolCallFixtureStep({
+          extractToolCalls: () => [{ id: 'call_1', type: 'function' }],
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/returned a malformed call/);
+  });
+
+  it('rejects extractToolCalls that returns a non-array', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeToolCallFixtureStep({
+          extractToolCalls: () => 'nope',
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractToolCalls\(\) returned a non-array/);
+  });
+
+  it('rejects extractToolCalls declared under a MEDIA posture (it would never be called)', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          moderationPosture: 'none',
+          extractToolCalls: () => [],
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/declares extractToolCalls\(\) but moderationPosture 'none' publishes MEDIA/);
+  });
+
+  it('a textOutput entry declaring NO extractToolCalls still registers — the field is optional', () => {
+    // Forcing every text entry to declare a `() => []` stub would be exactly the
+    // vacuous declaration clause 8a rejects on the text axis.
+    expect(() => assertStepInvariants('fixture-step', makeTextOutputFixtureStep())).not.toThrow();
+  });
+
   it("rejects a 'textOutput' entry that declares NO extractText (a posture with no output)", () => {
     expect(() =>
       assertStepInvariants(

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -126,6 +126,68 @@ function chatStep(content = GENERATED_TEXT) {
   };
 }
 
+/** The model-written argument string used by the tool-call cases below. */
+const TOOL_ARGUMENTS = '{"query":"the model chose this query","limit":1}';
+
+/** A COMPLETED chat step whose reply is a TOOL CALL rather than prose. */
+function toolCallStep(args = TOOL_ARGUMENTS) {
+  return {
+    $type: CHAT_TYPE,
+    output: {
+      choices: [
+        {
+          finishReason: 'tool_calls',
+          message: {
+            tool_calls: [
+              { id: 'call_1', type: 'function', function: { name: 'search_models', arguments: args } },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * A `'textOutput'` entry that ALSO publishes structured tool calls — the shape
+ * `chat-completion` has once tools are exposed.
+ *
+ * 🔴 `extractText` RETURNS THE ARGUMENTS TOO, and that is not fixture padding:
+ * it is the containment property registry clause 8b enforces, and the reason
+ * publishing the structured form is defensible at all. A fixture that omitted it
+ * would be a fixture the registry REJECTS — asserted below.
+ */
+function makeToolCallStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+  type Choices = Array<{
+    message?: {
+      content?: string;
+      tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>;
+    };
+  }>;
+  const readChoices = (step: unknown): Choices =>
+    (step as { output?: { choices?: Choices } })?.output?.choices ?? [];
+  return makeTextStep({
+    extractText: (step: unknown) => {
+      const texts: string[] = [];
+      for (const c of readChoices(step)) {
+        if (c.message?.content) texts.push(c.message.content);
+        for (const call of c.message?.tool_calls ?? []) texts.push(call.function.arguments);
+      }
+      return texts;
+    },
+    extractToolCalls: (step: unknown) =>
+      readChoices(step).flatMap((c) =>
+        (c.message?.tool_calls ?? []).map((call) => ({
+          id: call.id,
+          type: 'function' as const,
+          function: { name: call.function.name, arguments: call.function.arguments },
+        }))
+      ),
+    canonicalOutputFor: (): unknown => toolCallStep(),
+    ...overrides,
+  });
+}
+
 /**
  * A registry entry declaring `'textOutput'`. Shaped so the REAL
  * `assertStepInvariants` accepts it (asserted below) — a fixture the registry
@@ -1573,5 +1635,181 @@ describe('textOutput — an ERRORED label FAILS CLOSED', () => {
     const recovered = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
     expect(recovered).toEqual({ released: true, texts: [GENERATED_TEXT] });
     expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 STRUCTURED TOOL CALLS — published ONLY on a released verdict.
+//
+// This block is the AC4 control for tool calling. The tool-call objects are
+// never handed to a scanner as objects; what makes publishing them safe is that
+// (a) every `arguments` string is ALSO returned by `extractText` and therefore
+// scanned, enforced at load by clause 8b, and (b) they are attached only onto an
+// already-released verdict. Each of those halves has a case below, and each case
+// has its positive control — a bare "toolCalls is undefined" is indistinguishable
+// from a field nothing ever populates.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — structured tool calls are verdict-gated', () => {
+  beforeEach(() => {
+    registryOverride.set(CHAT_TYPE, makeToolCallStep());
+  });
+
+  it('the tool-call fixture is a REGISTRABLE entry', () => {
+    // Same control as the suite's own opening case: if the registry would reject
+    // this shape, every assertion below would describe an entry that cannot ship.
+    expect(() => assertStepInvariants('fixture-chat', makeToolCallStep())).not.toThrow();
+  });
+
+  it('🔴 A WITHHELD VERDICT PUBLISHES NO TOOL CALLS — the single most important case', async () => {
+    scannerReturns(scanOutput(['Young']));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toBeUndefined();
+    expect(snapshot.textOutputs).toBeUndefined();
+    // Not just the field: the model's argument string must not appear ANYWHERE
+    // in the object the block receives.
+    expect(JSON.stringify(snapshot)).not.toContain(TOOL_ARGUMENTS);
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+
+  it('🔴 POSITIVE CONTROL — the SAME path publishes the tool call on a clean scan', async () => {
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search_models', arguments: TOOL_ARGUMENTS },
+      },
+    ]);
+    // …and the arguments were scanned, which is what licenses publishing them.
+    expect(snapshot.textOutputs).toContain(TOOL_ARGUMENTS);
+  });
+
+  it('🔴 the model-written ARGUMENTS are what the scanner was actually given', async () => {
+    // The containment property, observed at the scanner boundary rather than
+    // inferred from the extractor. If `extractText` stopped returning arguments,
+    // the structured surface would still publish them — on the strength of a
+    // scan that never read them. This is the case that goes red for that.
+    scannerReturns(scanOutput([]));
+
+    await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    // Read the `content` field directly rather than stringifying the whole
+    // request: `JSON.stringify` escapes the quotes inside the arguments JSON, so
+    // a `toContain` against the raw string would fail even when the scanner DID
+    // receive it — a test that goes red for a reason that is not the property.
+    const arg = mockCreateXGuardModerationRequest.mock.calls[0][0] as { content: string };
+    expect(arg.content).toContain(TOOL_ARGUMENTS);
+  });
+
+  it('🔴 an INCOMING toolCalls on the snapshot is STRIPPED and cannot survive', async () => {
+    // The smuggle path. A caller that arrived carrying tool calls must not be
+    // able to publish them by pre-populating the field — the same property
+    // `textOutputs` and `textOutputWithheld` already have.
+    scannerReturns(scanOutput(['Young']));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      {
+        workflowId: 'wf-1',
+        status: 'succeeded' as const,
+        toolCalls: [
+          {
+            id: 'smuggled',
+            type: 'function' as const,
+            function: { name: 'evil_tool', arguments: '{"smuggled":true}' },
+          },
+        ],
+      },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain('smuggled');
+  });
+
+  it('🔴 an incoming toolCalls is stripped even when the scan RELEASES', async () => {
+    // The nastier half: on a withhold the field is absent anyway, so the case
+    // above passes for a "nothing was written" reason as well as the right one.
+    // On a RELEASE the field IS written, so this pins that what gets written is
+    // the scanned value and not the caller's.
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      {
+        workflowId: 'wf-1',
+        status: 'succeeded' as const,
+        toolCalls: [
+          {
+            id: 'smuggled',
+            type: 'function' as const,
+            function: { name: 'evil_tool', arguments: '{"smuggled":true}' },
+          },
+        ],
+      },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search_models', arguments: TOOL_ARGUMENTS },
+      },
+    ]);
+    expect(JSON.stringify(snapshot)).not.toContain('smuggled');
+  });
+
+  it('omits the field entirely for a text-only reply, so existing snapshots are byte-identical', async () => {
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+
+    expect(snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+    expect('toolCalls' in snapshot).toBe(false);
+  });
+
+  it('WITHHOLDS rather than publishing when the tool-call extractor returns a malformed call', async () => {
+    // Clause 8b probes the CANONICAL sample; a real response can still produce a
+    // shape it never saw, so the request-time guard fails closed the same way
+    // the `extractText` guard beside it does.
+    scannerReturns(scanOutput([]));
+    registryOverride.set(
+      CHAT_TYPE,
+      makeToolCallStep({
+        extractToolCalls: () => [{ id: 'x' }] as never,
+      })
+    );
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toBeUndefined();
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
   });
 });

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -35,9 +35,8 @@ import * as z from 'zod';
  *     keyed on `blocked` would release it.
  */
 
-const { mockCreateXGuardModerationRequest,  } = vi.hoisted(() => ({
+const { mockCreateXGuardModerationRequest } = vi.hoisted(() => ({
   mockCreateXGuardModerationRequest: vi.fn(),
-  
 }));
 
 vi.mock('~/server/services/orchestrator/orchestrator.service', () => ({
@@ -90,6 +89,7 @@ import {
   screenGeneratedText,
   SFW_ONLY_WITHHOLD_LABELS,
   TEXT_OUTPUT_SCAN_LABELS,
+  TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE,
   TEXT_OUTPUT_WITHHELD_MESSAGE,
   VERDICT_CACHE_MAX_ENTRIES,
   __clearTextOutputVerdictCacheForTests,
@@ -139,7 +139,11 @@ function toolCallStep(args = TOOL_ARGUMENTS) {
           finishReason: 'tool_calls',
           message: {
             tool_calls: [
-              { id: 'call_1', type: 'function', function: { name: 'search_models', arguments: args } },
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'search_models', arguments: args },
+              },
             ],
           },
         },
@@ -161,7 +165,11 @@ function makeToolCallStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
   type Choices = Array<{
     message?: {
       content?: string;
-      tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>;
+      tool_calls?: Array<{
+        id: string;
+        type: string;
+        function: { name: string; arguments: string };
+      }>;
     };
   }>;
   const readChoices = (step: unknown): Choices =>
@@ -529,11 +537,25 @@ describe('textOutput — 🔴 FAILS CLOSED', () => {
     expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
   });
 
-  it('releases an EMPTY result without scanning when there is no generated text', async () => {
+  it('releases an EMPTY result without scanning — and now SAYS SO rather than going silent', async () => {
     // The mirror image of the input-side rule, and deliberately NOT a rejection:
     // an empty extraction publishes nothing, so no unscanned text escapes. (On
     // the INPUT side an empty prompt IS rejected — there, "scan nothing" means
     // the submit proceeds unaudited.)
+    //
+    // 🔴 THE LAST ASSERTION FLIPPED, AND IT IS A DELIBERATE BEHAVIOUR CHANGE,
+    // NOT A TEST ACCOMMODATING A REGRESSION. This case used to assert
+    // `textOutputWithheld` was ALSO undefined — i.e. a text step that was
+    // charged and reported `succeeded` returned a snapshot with none of the
+    // three output fields, giving the app author neither output nor any reason
+    // for its absence. That is the silent-success class the no-silent-success
+    // invariant now closes (see the block at the end of this file, and
+    // `attachModeratedStepTextOutputs`).
+    //
+    // The SAFETY property this test was written for is untouched and still
+    // asserted: nothing was scanned, and nothing was published. What is added is
+    // diagnosability — and the reason deliberately is NOT the policy message,
+    // because no policy hit occurred.
     registryOverride.set(CHAT_TYPE, makeTextStep({ extractText: () => ['  ', ''] }));
     const snapshot = await attachModeratedStepTextOutputs(
       { workflowId: 'wf-1', status: 'succeeded' as const },
@@ -542,7 +564,8 @@ describe('textOutput — 🔴 FAILS CLOSED', () => {
     );
     expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
     expect(snapshot.textOutputs).toBeUndefined();
-    expect(snapshot.textOutputWithheld).toBeUndefined();
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE });
+    expect(snapshot.textOutputWithheld?.reason).not.toBe(TEXT_OUTPUT_WITHHELD_MESSAGE);
   });
 });
 
@@ -1838,5 +1861,137 @@ describe('textOutput — structured tool calls are verdict-gated', () => {
 
     expect(snapshot.toolCalls).toBeUndefined();
     expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE NO-SILENT-SUCCESS INVARIANT.
+//
+// A text-posture step that SUCCEEDED and passed the scan must never leave the
+// snapshot carrying none of `textOutputs` / `toolCalls` / `textOutputWithheld`.
+// That state is a step the viewer was CHARGED for which reports `succeeded` and
+// publishes nothing at all — no output, and no reason for its absence.
+//
+// 🔴 THIS BLOCK PINS THE INVARIANT, NOT THE INSTANCES. The same class has been
+// reached three times by three different routes (an extractor disagreement, a
+// drop-on-empty-arguments, and the shared predicate's charset axes), each closed
+// individually and each closure opening the next. Enumerating causes has failed
+// three times, so these cases assert the OUTCOME for an arbitrary "publishes
+// nothing" entry as well as for the two real axes — a fourth cause added later
+// is covered without editing this block.
+//
+// 🔴 THESE DRIVE THE REAL REGISTERED `chatCompletion` ENTRY, not a fixture. The
+// registry mock falls through to the real registry for any type it has no
+// override for, and `CHAT_TYPE` is `'fixtureChat'` — so `$type: 'chatCompletion'`
+// reaches shipped `publishableToolCalls` bounds. A fixture here would assert
+// only that the test agrees with itself on the axes that matter.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('no-silent-success invariant', () => {
+  const REAL_CHAT = 'chatCompletion';
+
+  /** A COMPLETED real-entry chat step whose only choice is one tool call. */
+  function realChatToolCall(call: Record<string, unknown>) {
+    return {
+      $type: REAL_CHAT,
+      output: { choices: [{ finishReason: 'tool_calls', message: { tool_calls: [call] } }] },
+    };
+  }
+
+  const GOOD_CALL = {
+    id: 'call_ok0000000000000000000',
+    type: 'function',
+    function: { name: 'search_models', arguments: '{"query":"x"}' },
+  };
+
+  // Each case is a DIFFERENT reason the entry publishes nothing. The two axes
+  // are the shipped ones; the third is an arbitrary unpublishable response, and
+  // it is what makes this a claim about the invariant rather than about two bugs.
+  const unpublishable: Array<{ label: string; step: unknown }> = [
+    {
+      label: 'ID axis — a provider id outside the published charset',
+      step: realChatToolCall({ ...GOOD_CALL, id: 'call.with.dots' }),
+    },
+    {
+      label: 'NAME axis — a tool name outside the published charset',
+      step: realChatToolCall({
+        ...GOOD_CALL,
+        function: { name: 'bad name!', arguments: '{"a":1}' },
+      }),
+    },
+    {
+      label: 'a succeeded response carrying no publishable field at all',
+      step: { $type: REAL_CHAT, output: { choices: [{ finishReason: 'stop', message: {} }] } },
+    },
+  ];
+
+  for (const { label, step } of unpublishable) {
+    it(`🔴 surfaces a REASON rather than silence — ${label}`, async () => {
+      scannerReturns(scanOutput([]));
+
+      const snapshot = await attachModeratedStepTextOutputs(
+        { workflowId: 'wf-1', status: 'succeeded' as const },
+        workflowWith(step),
+        CTX
+      );
+
+      // The invariant itself, stated as the property and not as three fields.
+      const surfaced =
+        snapshot.textOutputs !== undefined ||
+        snapshot.toolCalls !== undefined ||
+        snapshot.textOutputWithheld !== undefined;
+      expect(surfaced).toBe(true);
+
+      // …and specifically: nothing published, and a reason that does NOT claim a
+      // content-policy failure, because none occurred.
+      expect(snapshot.textOutputs).toBeUndefined();
+      expect(snapshot.toolCalls).toBeUndefined();
+      expect(snapshot.textOutputWithheld).toEqual({
+        reason: TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE,
+      });
+      expect(snapshot.textOutputWithheld?.reason).not.toBe(TEXT_OUTPUT_WITHHELD_MESSAGE);
+    });
+  }
+
+  it('🔴 POSITIVE CONTROL — a publishable call sets no unpublishable reason', async () => {
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(realChatToolCall(GOOD_CALL)),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toHaveLength(1);
+    expect(snapshot.textOutputs).toContain('{"query":"x"}');
+    expect(snapshot.textOutputWithheld).toBeUndefined();
+  });
+
+  it('🔴 A POLICY WITHHOLD KEEPS ITS OWN REASON — the two are not conflated', async () => {
+    scannerReturns(scanOutput(['Young']));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(realChatToolCall(GOOD_CALL)),
+      CTX
+    );
+
+    // A real policy hit must still say so; the new reason must not shadow it.
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+
+  it('🔴 SCOPING CONTROL — a MEDIA-posture entry publishes no text and is NOT a violation', async () => {
+    scannerReturns(scanOutput([]));
+
+    // `convert-image` is a real registered entry with `moderationPosture: 'none'`.
+    // It legitimately contributes no text here. Applying the invariant to every
+    // registered entry instead of text postures would report this correct
+    // absence as a fault, on any workflow mixing a media step with a chat step.
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith({ $type: 'convertImage', output: { blob: { url: 'https://x/y.png' } } }),
+      CTX
+    );
+
+    expect(snapshot.textOutputWithheld).toBeUndefined();
   });
 });

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -1812,4 +1812,31 @@ describe('textOutput — structured tool calls are verdict-gated', () => {
     expect(snapshot.textOutputs).toBeUndefined();
     expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
   });
+
+  it('WITHHOLDS on a call whose `type` is not the declared literal', async () => {
+    // `type` is a LITERAL on `BlockStepToolCall`, and the shape guard used to
+    // check every OTHER field while trusting this one to hold at runtime. A
+    // type declaration is not a runtime check: the extractor is called on a
+    // provider response, so the value can be anything. Fails closed like every
+    // other field in that guard.
+    scannerReturns(scanOutput([]));
+    registryOverride.set(
+      CHAT_TYPE,
+      makeToolCallStep({
+        extractToolCalls: () =>
+          [
+            { id: 'call_1', type: 'not_a_function', function: { name: 'f', arguments: '{}' } },
+          ] as never,
+      })
+    );
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(toolCallStep()),
+      CTX
+    );
+
+    expect(snapshot.toolCalls).toBeUndefined();
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
 });

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -118,12 +118,33 @@ const CHAT_TYPE = 'fixtureChat';
 type FixtureParams = { value: number };
 const fixtureParamSchema = z.object({ value: z.number().int().min(1).max(10) }).strict();
 
-/** An orchestrator-shaped COMPLETED chat step, as it arrives on a workflow. */
+/**
+ * An orchestrator-shaped COMPLETED chat step, as it arrives on a workflow.
+ *
+ * 🔴 `status` IS PART OF THE SHAPE AND WAS MISSING, which is exactly how the
+ * no-silent-success invariant shipped without a status gate. `WorkflowStep.status`
+ * is REQUIRED (non-optional) on the generated `@civitai/client` type, so a
+ * fixture omitting it is not orchestrator-shaped at all — and every test built on
+ * it was blind to the difference between a step that SUCCEEDED with no output and
+ * one that had simply not run yet. Keep it on every step fixture, and use
+ * `runningChatStep` below when a non-terminal step is what the case is about.
+ */
 function chatStep(content = GENERATED_TEXT) {
   return {
     $type: CHAT_TYPE,
+    status: 'succeeded',
     output: { choices: [{ message: { content } }] },
   };
+}
+
+/**
+ * A chat step that has NOT produced output yet — queued or mid-flight.
+ *
+ * This is the shape `pollWorkflow` sees for most of a generation's life, and the
+ * shape `cancelWorkflow` sees for a user-cancelled one.
+ */
+function runningChatStep(status: 'processing' | 'canceled' | 'failed' = 'processing') {
+  return { $type: CHAT_TYPE, status };
 }
 
 /** The model-written argument string used by the tool-call cases below. */
@@ -133,6 +154,7 @@ const TOOL_ARGUMENTS = '{"query":"the model chose this query","limit":1}';
 function toolCallStep(args = TOOL_ARGUMENTS) {
   return {
     $type: CHAT_TYPE,
+    status: 'succeeded',
     output: {
       choices: [
         {
@@ -1893,6 +1915,7 @@ describe('no-silent-success invariant', () => {
   function realChatToolCall(call: Record<string, unknown>) {
     return {
       $type: REAL_CHAT,
+      status: 'succeeded',
       output: { choices: [{ finishReason: 'tool_calls', message: { tool_calls: [call] } }] },
     };
   }
@@ -1920,7 +1943,11 @@ describe('no-silent-success invariant', () => {
     },
     {
       label: 'a succeeded response carrying no publishable field at all',
-      step: { $type: REAL_CHAT, output: { choices: [{ finishReason: 'stop', message: {} }] } },
+      step: {
+        $type: REAL_CHAT,
+        status: 'succeeded',
+        output: { choices: [{ finishReason: 'stop', message: {} }] },
+      },
     },
   ];
 
@@ -1979,6 +2006,125 @@ describe('no-silent-success invariant', () => {
     expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
   });
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 F1 — the invariant must not fire on a step that has not finished.
+  //
+  // `attachModeratedStepTextOutputs` runs on EVERY `pollWorkflow` and on
+  // `cancelWorkflow`. A queued/processing step has no `output`, so `extractText`
+  // returns `[]` and the verdict releases empty — the exact shape the invariant
+  // fires on. Before the status gate, a block polling a healthy in-flight
+  // generation was told for its whole duration that the response had
+  // "completed" with nothing to show, and a cancelled one got the same.
+  //
+  // Every case here is paired with the succeeded-and-unpublishable cases above,
+  // which are the positive control: if the gate were widened to fire on any
+  // status, those still pass, so these are what pin the difference.
+  // ───────────────────────────────────────────────────────────────────────────
+  for (const status of ['processing', 'canceled', 'failed'] as const) {
+    it(`🔴 NO reason on a step that is not succeeded — ${status}`, async () => {
+      scannerReturns(scanOutput([]));
+
+      const snapshot = await attachModeratedStepTextOutputs(
+        { workflowId: 'wf-1', status: status as 'processing' },
+        workflowWith(runningChatStep(status)),
+        CTX
+      );
+
+      // The pre-invariant behaviour, and the correct one: an absent field.
+      // A non-succeeded step's missing output is already explained by its own
+      // status; claiming it "completed" with nothing is a fabrication.
+      expect(snapshot.textOutputWithheld).toBeUndefined();
+      expect(snapshot.textOutputs).toBeUndefined();
+      expect(snapshot.toolCalls).toBeUndefined();
+    });
+  }
+
+  it('🔴 a step with NO status at all gets no reason — unreadable state fails to silence', async () => {
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      // No `status` key — the shape every fixture in this file used to have.
+      workflowWith({ $type: REAL_CHAT }),
+      CTX
+    );
+
+    expect(snapshot.textOutputWithheld).toBeUndefined();
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 F2 — a policy withhold must never be masked by a sibling's extraction
+  // failure, IN EITHER STEP ORDER.
+  //
+  // The reason slot was first-wins, and this round put two semantically OPPOSED
+  // values into it. Measured on the pre-fix code, same content, same scanner
+  // verdict, differing only in step order:
+  //   [unpublishable, policy-hit] → "No content policy issue was found"  ← WRONG
+  //   [policy-hit, unpublishable] → "did not pass Civitai's content policy"
+  //
+  // 🔴 BOTH ORDERINGS ARE REQUIRED. `A POLICY WITHHOLD KEEPS ITS OWN REASON`
+  // above uses ONE step and therefore cannot see this defect at all — with a
+  // single step there is no second candidate to win the slot. A test that
+  // cannot distinguish the fixed code from the broken code is not coverage.
+  //
+  // NOTE ON SEVERITY, so nobody reads this as a moderation bypass: the flagged
+  // text is WITHHELD in both orderings. Only the sentence explaining it was
+  // wrong. That is a diagnosability defect, and it pointed the app author away
+  // from the real cause.
+  // ───────────────────────────────────────────────────────────────────────────
+  for (const [label, steps] of [
+    ['unpublishable FIRST', ['unpublishable', 'policy'] as const],
+    ['policy-hit FIRST', ['policy', 'unpublishable'] as const],
+  ] as const) {
+    it(`🔴 a POLICY withhold wins the reason slot — ${label}`, async () => {
+      // The scanner trips on any scanned text. The unpublishable step
+      // contributes none, so only the policy step's text is ever scanned.
+      scannerReturns(scanOutput(['Young']));
+
+      const workflow = workflowWith(
+        ...steps.map((kind) =>
+          kind === 'policy'
+            ? realChatToolCall(GOOD_CALL)
+            : realChatToolCall({ ...GOOD_CALL, id: 'call.with.dots' })
+        )
+      );
+
+      const snapshot = await attachModeratedStepTextOutputs(
+        { workflowId: 'wf-1', status: 'succeeded' as const },
+        workflow,
+        CTX
+      );
+
+      // Order must not decide which of two opposed sentences the author reads.
+      expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+      expect(snapshot.textOutputWithheld?.reason).not.toBe(TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE);
+      // And the flagged content is withheld either way — this was never a leak.
+      expect(snapshot.textOutputs).toBeUndefined();
+      expect(snapshot.toolCalls).toBeUndefined();
+    });
+  }
+
+  it('🔴 F3 — the reason is scoped to A STEP, so a sibling’s published text does not contradict it', async () => {
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(
+        realChatToolCall(GOOD_CALL),
+        realChatToolCall({ ...GOOD_CALL, id: 'call.with.dots' })
+      ),
+      CTX
+    );
+
+    // Both fields legitimately co-exist (workflow.schema documents the pairing).
+    expect(snapshot.textOutputs).toContain('{"query":"x"}');
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE });
+    // So the sentence must not make a claim about the whole response, which the
+    // `textOutputs` beside it would flatly contradict.
+    expect(TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE).not.toContain('This response completed');
+    expect(TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE.startsWith('A step in this response')).toBe(true);
+  });
+
   it('🔴 SCOPING CONTROL — a MEDIA-posture entry publishes no text and is NOT a violation', async () => {
     scannerReturns(scanOutput([]));
 
@@ -1988,7 +2134,11 @@ describe('no-silent-success invariant', () => {
     // absence as a fault, on any workflow mixing a media step with a chat step.
     const snapshot = await attachModeratedStepTextOutputs(
       { workflowId: 'wf-1', status: 'succeeded' as const },
-      workflowWith({ $type: 'convertImage', output: { blob: { url: 'https://x/y.png' } } }),
+      workflowWith({
+        $type: 'convertImage',
+        status: 'succeeded',
+        output: { blob: { url: 'https://x/y.png' } },
+      }),
       CTX
     );
 

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -70,9 +70,28 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // block pasted back in — plus tool descriptions and JSON Schemas the app author
 // wrote. More volume and more provenance on a channel that was already
 // unaudited; no new channel. It is bounded rather than audited: `MAX_TOOL_ROUNDS`
-// caps how many tool results one submit can carry, `MAX_MESSAGE_CHARS` caps each,
-// and the OUTPUT scan still stands in front of everything the model says ABOUT a
-// tool result before a block can publish it.
+// caps how many tool results one submit can carry, and the OUTPUT scan still
+// stands in front of everything the model says ABOUT a tool result before a
+// block can publish it.
+//
+// 🔴 "`MAX_MESSAGE_CHARS` CAPS EACH" USED TO BE ON THAT LIST AND WAS WRONG.
+// That constant caps each `content` field, but an assistant message ALSO
+// carries up to `MAX_TOOLS` tool calls whose `arguments` each get the SAME cap,
+// so one message can now reach roughly `MAX_MESSAGE_CHARS * (1 + MAX_TOOLS)`
+// rather than `MAX_MESSAGE_CHARS`. Measured across the whole payload, the
+// maximum accepted built step grew ~9x with tool calling (≈257k -> ≈2.32M
+// chars). There is no per-message aggregate cap.
+//
+// 🔴 THAT IS A DELIBERATE DECLINE, NOT AN OVERSIGHT, AND HERE IS THE REASONING
+// SO IT CAN BE RE-EXAMINED RATHER THAN RE-DISCOVERED. It is not a spend hole:
+// prompt tokens are priced by the per-submit live quote and gated by
+// `buzzBudget` before anything is reserved. It is not a CPU hole either: the
+// AIR scan over a maximal ~2.3 MB payload measured ~6 ms. What it does cost is
+// request size and prefill compute, driven by an untrusted iframe, on the
+// ESTIMATE path as well as submit. If that becomes a problem the fix is a
+// per-message aggregate cap, which is additive and cheap; it is left out today
+// because a cap chosen without a real payload distribution would be a guess
+// that breaks legitimate callers.
 //
 // 🔴 DO NOT "CLOSE" THIS BY SWITCHING TO `'promptAudit'`. The map's own inclusion
 // criterion forbids exactly that trade: declaring it would audit the input and
@@ -318,28 +337,38 @@ const TEMPERATURE_MAX = 2;
  * The maximum number of `role: 'tool'` messages one submit may carry — i.e. the
  * bound on how many tool ROUNDS a conversation can accumulate.
  *
- * 🔴 THIS IS THE BILLING BOUND, AND IT IS WHY THE ENTRY CAN STAY `prepaidFixed`.
- * Tool calling makes a conversation a LOOP, and a loop is N charges rather than
- * one. `prepaidFixed` means "cost knowable before execution", which the submit
- * path enforces by quoting the orchestrator (`whatif:true`) for the step it is
- * about to submit and reserving `max(declared, quoted)`. That holds PER SUBMIT
- * and cannot bound a round that does not exist yet: round k+1's input depends on
- * what the model emitted and what the tool returned, neither of which exists
- * when round k is quoted.
+ * 🔴 BE EXACT ABOUT WHAT THIS BOUNDS: HISTORY DEPTH IN ONE PAYLOAD. It is NOT
+ * a bound on the conversation, and it is NOT what keeps the entry billable as
+ * `prepaidFixed`. An earlier revision of this comment called it "THE BILLING
+ * BOUND, AND WHY THE ENTRY CAN STAY `prepaidFixed`" and said "a caller cannot
+ * loop past it" — both were stronger than the code, and a reader relying on
+ * either would be wrong. A block that drops or summarises the oldest tool
+ * result keeps every payload at or under this cap and can submit
+ * INDEFINITELY; nothing counts rounds across submits, because submits are
+ * independent requests.
  *
- * The resolution is that each round IS its own submit — this entry does NOT
- * loop server-side, and the block drives the loop by appending the tool result
- * and submitting again. Every round therefore gets its own live quote, its own
- * per-call `buzzBudget` gate and its own reservation against every cap. What
- * this constant adds is the bound on how far that can run.
+ * WHAT ACTUALLY BOUNDS THE MONEY, and it is sound: each round is its own
+ * submit — this entry does NOT loop server-side, the block drives the loop by
+ * appending the tool result and submitting again — so every round gets its own
+ * live orchestrator quote (`whatif:true` on the exact step about to be
+ * submitted, reserving `max(declared, quoted)`), its own per-call `buzzBudget`
+ * gate, and its own reservation against the per-user daily cap, the per-app
+ * aggregate cap and the dev-session cap. That is what makes "cost knowable
+ * before execution" true per submit, and it is what stops a runaway loop —
+ * this constant is not load-bearing for either.
  *
- * 🔴 ENFORCED AT PARSE, NOT IN THE BLOCK, AND THAT PLACEMENT IS THE POINT. A
- * block is untrusted sandboxed code; a round cap it applies to itself is not a
- * cap. `parseStepParams` runs this schema on BOTH the estimate and the submit
- * path, so the two cannot disagree and a caller cannot loop past it by declining
- * to count. It rejects as BAD_REQUEST before the orchestrator quote and before
- * every reservation, so a rejection costs no round-trip and has nothing to
- * refund.
+ * 🔴 "ROUNDS" IS ALSO NOT "TOOL CALLS". An assistant turn's `tool_calls` array
+ * is capped by `MAX_TOOLS`, so a single submit can request that many tool
+ * executions while counting as one round — and a payload at this cap can carry
+ * several times that many calls in total. If you need to bound executions
+ * rather than history depth, this is the wrong constant.
+ *
+ * 🔴 ENFORCED AT PARSE, NOT IN THE BLOCK, AND THAT PLACEMENT IS STILL THE
+ * POINT. A block is untrusted sandboxed code, so a cap it applies to itself is
+ * not a cap. `parseStepParams` runs this schema on BOTH the estimate and the
+ * submit path, so the two cannot disagree about what is accepted. It rejects as
+ * BAD_REQUEST before the orchestrator quote and before every reservation, so a
+ * rejection costs no round-trip and has nothing to refund.
  *
  * WHY THREE. Two rounds cover the shape this exists for — call a catalog tool,
  * read the result, answer — and the third leaves room for one refinement when
@@ -423,18 +452,26 @@ const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
  * note prescribes, paid here where the unbounded value enters rather than left
  * for the scan to be wrong about.
  *
- * `JSON.stringify` also throws on a circular structure and returns `undefined`
- * for a bare function/symbol; both are caught and rejected rather than allowed
- * to surface as a 500 from inside the resolver.
+ * `JSON.stringify` also THROWS for several distinct reasons — a circular
+ * structure, a `BigInt`, a throwing getter, a throwing `toJSON` — and returns
+ * `undefined` for a bare function/symbol; all are caught and rejected rather
+ * than allowed to surface as a 500 from inside the resolver. 🔴 The rejection
+ * message names the CLASS rather than guessing the cause: it used to say "a
+ * circular structure was rejected" for every throw, which is a confidently
+ * wrong diagnostic for the `BigInt` and throwing-`toJSON` cases and sends an
+ * app author looking for a cycle that is not there.
  */
 const toolParametersSchema = z.unknown().transform((value, ctx) => {
   let serialized: string | undefined;
   try {
     serialized = JSON.stringify(value);
-  } catch {
+  } catch (e) {
     ctx.addIssue({
       code: 'custom',
-      message: 'tool parameters must be JSON-serializable (a circular structure was rejected)',
+      message:
+        'tool parameters must be JSON-serializable — serializing them threw ' +
+        `(${e instanceof Error ? e.message : String(e)}). Common causes: a circular reference, ` +
+        'a BigInt, or a getter/toJSON that throws',
     });
     return z.NEVER;
   }
@@ -681,6 +718,41 @@ const chatCompletionParamsSchema = z
           `${MAX_TOOL_ROUNDS}. Each round is a separate billed submit, so the loop is bounded ` +
           'here rather than by the caller',
       });
+    }
+
+    // ── A TOOL RESULT MUST ANSWER A TOOL CALL THAT WAS ACTUALLY MADE, AND MUST
+    // COME AFTER IT. Exactly the reasoning the `toolChoice` clause below
+    // applies to an undeclared function name, on the axis the provider is just
+    // as strict about: an OpenAI-compatible provider rejects a `tool` message
+    // whose `tool_call_id` matches no preceding assistant `tool_calls[].id`,
+    // and rejects one with no preceding assistant turn at all. There is no
+    // orchestrator-side validation that catches either before execution, so
+    // without this the payload is QUOTED, RESERVED against every cap, CHARGED,
+    // and only then fails at the provider — with a block-side error the app
+    // author cannot diagnose. Rejecting at parse costs no round-trip and has
+    // nothing to refund.
+    //
+    // 🔴 THE SET IS BUILT IN ORDER, WHICH IS WHAT MAKES THIS AN ORDERING CHECK
+    // AND NOT MERELY A MEMBERSHIP ONE. Collecting every id first and then
+    // testing membership would accept a `tool` message that PRECEDES the
+    // assistant turn declaring it — a payload the provider still rejects.
+    const declaredCallIds = new Set<string>();
+    for (const message of params.messages) {
+      if (message.role === 'assistant') {
+        for (const call of message.tool_calls ?? []) declaredCallIds.add(call.id);
+        continue;
+      }
+      if (message.role !== 'tool') continue;
+      if (!declaredCallIds.has(message.tool_call_id)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['messages'],
+          message:
+            `tool message references tool_call_id '${message.tool_call_id}', which no PRECEDING ` +
+            'assistant message declared in tool_calls. A tool result must answer a tool call ' +
+            'that was actually made, and must come after it',
+        });
+      }
     }
 
     // ── `toolChoice` WITHOUT `tools` IS A NO-OP THE CALLER WILL MISREAD.
@@ -1006,11 +1078,42 @@ export const chatCompletionStep = {
    * `StepOutputMedia.url` smuggle in a new field name.
    *
    * 🔴 IT DROPS, RATHER THAN PUBLISHES, A MALFORMED CALL — including one whose
-   * NAME does not match `TOOL_NAME_PATTERN`. The name is the one string here
-   * that does not go through the scan, and the argument for that is precisely
-   * that the pattern makes it incapable of carrying prose. A provider that
-   * echoed back an unbounded name would break that argument, so the extractor
+   * NAME or ID does not match `TOOL_NAME_PATTERN`. Those two are the strings
+   * here that do NOT go through the scan, and the argument for both is the
+   * same: the pattern makes them incapable of carrying prose. A provider that
+   * echoed back an unbounded value would break that argument, so the extractor
    * enforces the pattern on the way out rather than trusting the round trip.
+   *
+   * 🔴 THE ID BOUND IS NOT SYMMETRY-FOR-ITS-OWN-SAKE — IT CLOSES A ZERO-SCAN
+   * PUBLISH PATH. Until it existed, `id` was accepted on `typeof id === 'string'
+   * && length > 0` alone while the INPUT schema capped it at
+   * `MAX_TOOL_NAME_CHARS`. Measured: a 5,000-char `id` carrying prose and a
+   * literal `urn:air:` was published to the block verbatim — and because that
+   * response's `extractText` returns `[]`, `screenGeneratedText` short-circuits
+   * on the empty text set and releases WITHOUT EVER CALLING THE SCANNER. So the
+   * unbounded field was not merely unscanned, it was on a path where no scan
+   * ran at all. Neither clause 8b (which compares `arguments` only) nor the
+   * runtime shape guard in `./moderation` (which checks types, not bounds)
+   * would catch a regression here; this line is the whole control.
+   *
+   * 🔴 AND THE DOCSTRING THIS REPLACES ASSERTED THE NAME WAS "the one string
+   * here that does not go through the scan", WHICH WAS FALSE — `id` did not
+   * either. The unscanned published set is exactly `{ name, id }`, and it is
+   * enumerated here so the next person widening this surface has to count.
+   *
+   * 🔴 EMPTY / WHITESPACE-ONLY `arguments` ARE DROPPED, AND THAT IS WHAT MAKES
+   * THE CONTAINMENT INVARIANT TRUE AS WRITTEN. `extractText` pushes an
+   * arguments string only when `trim().length > 0`; accepting any string here
+   * meant a call with `arguments: ''` or `'   '` was published while
+   * `extractText` returned nothing for it — so the property clause 8b and three
+   * docstrings state ("every arguments string this can publish is also returned
+   * by extractText") was literally false on unmutated code. Aligning the two
+   * predicates is the fix, in the fail-closed direction the rest of this
+   * extractor already takes. The ordinary no-argument encoding is `'{}'`, which
+   * is neither empty nor whitespace and is unaffected; a provider that instead
+   * emits `''` for a no-arg call has that call DROPPED, and the fix for that
+   * would be to normalise it to `'{}'` at the point of capture — never to
+   * loosen the containment.
    */
   extractToolCalls: (step: unknown): BlockToolCall[] => {
     const choices = (step as ChatCompletionOutputStepLike | null | undefined)?.output?.choices;
@@ -1023,25 +1126,49 @@ export const chatCompletionStep = {
         const id = call?.id;
         const name = call?.function?.name;
         const args = call?.function?.arguments;
-        if (typeof id !== 'string' || id.length === 0) continue;
+        if (typeof id !== 'string' || !TOOL_NAME_PATTERN.test(id)) continue;
+        if (id.length > MAX_TOOL_NAME_CHARS) continue;
         if (typeof name !== 'string' || !TOOL_NAME_PATTERN.test(name)) continue;
         if (name.length > MAX_TOOL_NAME_CHARS) continue;
-        if (typeof args !== 'string') continue;
+        // Same predicate `extractText` applies — see the containment note above.
+        if (typeof args !== 'string' || args.trim().length === 0) continue;
         calls.push({ id, type: 'function', function: { name, arguments: args } });
       }
     }
     return calls;
   },
   /**
-   * A canonical COMPLETED step, for the load-time extraction probe (clause 8a).
+   * A canonical COMPLETED step, for the load-time extraction probes (clauses 8a
+   * and 8b).
    *
-   * 🔴 COPIED VERBATIM FROM A REAL ORCHESTRATOR RESPONSE, not invented to match
-   * `extractText`. A sample written from the extractor would make the probe
-   * assert only that the code agrees with itself — the both-wrong-blind shape
-   * clause 8a's own docstring names as the thing it cannot catch. Note what the
-   * real response does NOT contain: `choices[0].message` carries **only
-   * `content`** — no `role`, despite the generated `AssistantMessage` declaring
-   * it required. That absence is the reason `extractText` does not key off it.
+   * 🔴 EVERY CHOICE HERE IS COPIED VERBATIM FROM A REAL ORCHESTRATOR RESPONSE,
+   * not invented to match the extractors. A sample written from the extractor
+   * would make the probe assert only that the code agrees with itself — the
+   * both-wrong-blind shape clause 8a's own docstring names as the thing it
+   * cannot catch. Note what the first real response does NOT contain:
+   * `message` carries **only `content`** — no `role`, despite the generated
+   * `AssistantMessage` declaring it required. That absence is the reason
+   * `extractText` does not key off it.
+   *
+   * 🔴 THE SECOND CHOICE IS WHY THIS SAMPLE HAS TWO, AND IT IS LOAD-BEARING
+   * RATHER THAN DECORATIVE. Clause 8b asserts that every `arguments` string
+   * `extractToolCalls` publishes is also returned by `extractText` — but it can
+   * only assert it over THIS sample, so a sample with no `tool_calls` makes the
+   * clause iterate an EMPTY set and pass vacuously. That was the state when
+   * tool calling first landed: the containment property three separate
+   * docstrings name as the mechanism protecting the tool-call surface was
+   * asserted over nothing, and a real containment break in the shipped
+   * extractor (`arguments: args + 'SMUGGLED'`) loaded CLEAN. A guard that
+   * passes because its loop body never runs reads as coverage while providing
+   * none — the exact failure this registry's clause design exists to refuse.
+   *
+   * 🔴 THE TWO-CHOICE ENVELOPE IS A COMPOSITION, AND THAT IS SAID PLAINLY. Each
+   * choice object is verbatim from a captured response; no single captured
+   * response carried both, because `n` defaults to 1. The composition is
+   * legitimate for what these clauses actually test — that the extractor PAIR
+   * agrees with itself on a real message shape — and it is what keeps BOTH the
+   * content path and the tool-call path covered at load instead of trading one
+   * for the other. It is NOT a claim that the orchestrator emits two choices.
    */
   canonicalOutputFor: (): unknown => ({
     $type: 'chatCompletion',
@@ -1052,7 +1179,26 @@ export const chatCompletionStep = {
       object: 'chat.completion',
       created: 1785782779,
       model: 'openai/gpt-4o-mini',
-      choices: [{ index: 0, message: { content: 'OK' }, finishReason: 'stop' }],
+      choices: [
+        { index: 0, message: { content: 'OK' }, finishReason: 'stop' },
+        {
+          index: 1,
+          finishReason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_d41b5525e73e4551ab588457',
+                type: 'function',
+                function: {
+                  name: 'search_models',
+                  arguments: '{"query":"DreamShaper checkpoint","limit":1}',
+                },
+              },
+            ],
+          },
+        },
+      ],
       usage: { promptTokens: 12, completionTokens: 1, totalTokens: 13 },
       systemFingerprint: 'fp_5259353f0d',
     },

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -64,6 +64,20 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // violation counter. Closing it needs a registry-level decision about
 // multi-surface postures, not a workaround here.
 //
+// 🔴 TOOL CALLING ENLARGED THAT GAP WITHOUT CHANGING ITS KIND, AND THAT IS
+// STATED HERE RATHER THAN LEFT TO BE DISCOVERED. The unaudited input channel now
+// also carries `role: 'tool'` messages — content a THIRD PARTY produced and the
+// block pasted back in — plus tool descriptions and JSON Schemas the app author
+// wrote. More volume and more provenance on a channel that was already
+// unaudited; no new channel. It is bounded rather than audited: `MAX_TOOL_ROUNDS`
+// caps how many tool results one submit can carry, `MAX_MESSAGE_CHARS` caps each,
+// and the OUTPUT scan still stands in front of everything the model says ABOUT a
+// tool result before a block can publish it.
+//
+// 🔴 DO NOT "CLOSE" THIS BY SWITCHING TO `'promptAudit'`. The map's own inclusion
+// criterion forbids exactly that trade: declaring it would audit the input and
+// ship the OUTPUT unscanned, which is strictly worse than the status quo.
+//
 // 🔴 WHAT ACTUALLY WITHHOLDS — AN ENUMERATION, BECAUSE THE UNIVERSAL WAS FALSE.
 // This header and the `moderationPosture` field both used to say the reply is
 // withheld "on any scanner failure". That is NOT true of the shipped code, and
@@ -116,17 +130,38 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // `containsAirReference` is a case-insensitive SUBSTRING test for `urn:air:`
 // across every string, array element, object value and object KEY.
 //
-// `buildStep` emits exactly `{ model, messages, maxTokens, temperature? }`
-// (pinned by the exact-key-set test in `__tests__/chat-completion.step.test.ts`).
-// `model` is `z.enum`-bounded to `CHAT_COMPLETION_MODELS`, `maxTokens` and
-// `temperature` are numbers, every key is a fixed literal, and `role` is a
-// three-value enum. So **`messages[].content` is the only string in the built
-// input that an untrusted iframe can put arbitrary text into** — and it is
-// human prose, forwarded from whatever an end user typed into a chat block.
-// This entry is the FIRST whose scanned strings are prose; every earlier one
-// (`convert-image`) scanned urls the APP constructs. For this entry the guard
-// therefore reduces exactly to: reject any chat message containing the literal
-// `urn:air:`. A user asking "what does urn:air: mean?" gets a hard FORBIDDEN.
+// `buildStep` emits exactly `{ model, messages, maxTokens, temperature?, tools?,
+// tool_choice? }` (pinned by the exact-key-set test in
+// `__tests__/chat-completion.step.test.ts`). `model` is `z.enum`-bounded to
+// `CHAT_COMPLETION_MODELS`, `maxTokens` and `temperature` are numbers, and
+// `role` is a four-value literal set.
+//
+// 🔴 THE CALLER-CONTROLLED STRING SET GREW WHEN TOOLS SHIPPED, AND AN EARLIER
+// REVISION OF THIS PARAGRAPH NAMED ONLY ONE OF THEM. It said "**`messages[].content`
+// is the only string in the built input that an untrusted iframe can put
+// arbitrary text into**". That is now FALSE. The full set is:
+//   * `messages[].content` — human prose, as before;
+//   * `messages[].tool_calls[].function.arguments` and `.id` on a replayed
+//     assistant turn, and `messages[].tool_call_id` on a tool result;
+//   * `tools[].function.description` — free text the app author writes;
+//   * `tools[].function.parameters` — an arbitrary JSON Schema, every string
+//     and KEY inside it included.
+// Names are pattern-bounded (`TOOL_NAME_PATTERN`) and so cannot carry the
+// literal, but everything else above can. For this entry the guard therefore
+// reduces to: reject any of those carrying the literal `urn:air:`. A user asking
+// "what does urn:air: mean?" still gets a hard FORBIDDEN, and so now does a tool
+// whose description mentions AIRs — which is a REAL cost for a catalog toolset,
+// because catalog data is exactly where AIRs live. The fail-closed direction is
+// unchanged and deliberate; the fix belongs in what the caller puts in the
+// payload, not in narrowing the scan (see the paragraph below on why).
+//
+// 🔴 AND `parameters` IS WHY THE JSON ROUND-TRIP IN `toolParametersSchema` IS
+// LOAD-BEARING RATHER THAN TIDY. `containsAirReference` documents its own
+// totality limit at `toJSON`-bearing class instances, and names "the first time
+// an entry declares a `z.unknown()` / `z.any()` / `z.custom()` param" as the
+// point that becomes reachable. This entry is that entry. The normalisation
+// there is what keeps the value the scan walks identical to the value that
+// reaches the wire.
 //
 // WHAT THE ORCHESTRATOR ACTUALLY DOES WITH THAT PROSE — read from
 // `civitai/civitai-orchestration` at `origin/main` e9ce862cb, not assumed:
@@ -280,7 +315,242 @@ const TEMPERATURE_MIN = 0;
 const TEMPERATURE_MAX = 2;
 
 /**
- * One conversation turn.
+ * The maximum number of `role: 'tool'` messages one submit may carry — i.e. the
+ * bound on how many tool ROUNDS a conversation can accumulate.
+ *
+ * 🔴 THIS IS THE BILLING BOUND, AND IT IS WHY THE ENTRY CAN STAY `prepaidFixed`.
+ * Tool calling makes a conversation a LOOP, and a loop is N charges rather than
+ * one. `prepaidFixed` means "cost knowable before execution", which the submit
+ * path enforces by quoting the orchestrator (`whatif:true`) for the step it is
+ * about to submit and reserving `max(declared, quoted)`. That holds PER SUBMIT
+ * and cannot bound a round that does not exist yet: round k+1's input depends on
+ * what the model emitted and what the tool returned, neither of which exists
+ * when round k is quoted.
+ *
+ * The resolution is that each round IS its own submit — this entry does NOT
+ * loop server-side, and the block drives the loop by appending the tool result
+ * and submitting again. Every round therefore gets its own live quote, its own
+ * per-call `buzzBudget` gate and its own reservation against every cap. What
+ * this constant adds is the bound on how far that can run.
+ *
+ * 🔴 ENFORCED AT PARSE, NOT IN THE BLOCK, AND THAT PLACEMENT IS THE POINT. A
+ * block is untrusted sandboxed code; a round cap it applies to itself is not a
+ * cap. `parseStepParams` runs this schema on BOTH the estimate and the submit
+ * path, so the two cannot disagree and a caller cannot loop past it by declining
+ * to count. It rejects as BAD_REQUEST before the orchestrator quote and before
+ * every reservation, so a rejection costs no round-trip and has nothing to
+ * refund.
+ *
+ * WHY THREE. Two rounds cover the shape this exists for — call a catalog tool,
+ * read the result, answer — and the third leaves room for one refinement when
+ * the first query comes back empty, which is the whole argument for real tool
+ * calling over a one-shot heuristic. Raising it is additive and cheap; lowering
+ * it is breaking. It is deliberately far below the incidental ceiling
+ * `MAX_MESSAGES` already imposes (32 messages ≈ 15 rounds at 2 messages each),
+ * because that ceiling is neither stated nor intentional.
+ */
+export const MAX_TOOL_ROUNDS = 3;
+
+/**
+ * Bounds on the TOOL DEFINITIONS a caller may attach.
+ *
+ * 🔴 THESE ARE COMPUTE/LATENCY BOUNDS, NOT PRICE BOUNDS, AND THE DIFFERENCE
+ * MATTERS. Tool definitions inflate PROMPT tokens — the orchestrator estimates
+ * them explicitly — but the submit path quotes the orchestrator for the exact
+ * step it submits, and `tools` is inside that step, so the inflation is PRICED
+ * before the per-call budget gate rather than escaping it. What these bounds
+ * protect is the thing the quote does not: prefill compute and request size
+ * driven by an untrusted iframe.
+ *
+ * `MAX_TOOLS` is 8 because the read-only catalog toolset this capability exists
+ * to serve is seven tools; eight leaves one slot without inviting a caller to
+ * ship a toolbox as a prompt.
+ *
+ * `MAX_TOOL_PARAMETERS_DEPTH` is the one bound with a second, sharper reason.
+ * The built step is deep-scanned by `containsAirReference` (registry clause 7
+ * at load, and again request-time in `blocks.router.ts`), which recurses with a
+ * fail-CLOSED cap at `AIR_SCAN_MAX_DEPTH`: past that depth it returns TRUE. A
+ * caller-supplied JSON schema is now part of that scanned input, so without a
+ * parse-time depth cap an over-nested `parameters` object would be rejected as
+ * "contains an AIR reference" — a confidently wrong diagnostic for a payload
+ * with no AIR in it. Capping here, far below the scan's own cap, makes the
+ * error say what is actually wrong.
+ */
+const MAX_TOOLS = 8;
+const MAX_TOOL_NAME_CHARS = 64;
+const MAX_TOOL_DESCRIPTION_CHARS = 1_024;
+const MAX_TOOL_PARAMETERS_CHARS = 4_096;
+const MAX_TOOL_PARAMETERS_DEPTH = 8;
+
+/**
+ * The characters a tool NAME may contain.
+ *
+ * 🔴 A PATTERN, NOT MERELY A LENGTH, AND THAT IS LOAD-BEARING DOWNSTREAM. The
+ * name comes back on the model's `tool_calls[]` and `extractToolCalls` publishes
+ * it to the block WITHOUT it having been through the text scan — which is only
+ * defensible because a name matching this pattern cannot carry prose. If this is
+ * ever widened to admit spaces or punctuation, the name becomes a free-text
+ * surface and has to join the scanned set. The character class also matches the
+ * one OpenAI documents for function names, so a bounded name is not a
+ * civitai-specific restriction a caller has to discover.
+ */
+const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * A tool's JSON-Schema `parameters` object — bounded, and NORMALISED THROUGH
+ * JSON.
+ *
+ * 🔴 THE ROUND-TRIP IS THE WHOLE POINT, NOT A TIDY-UP. `./index`'s
+ * `containsAirReference` documents an exact limit on its own totality: its
+ * "scan every string anywhere" guarantee holds because `Object.entries`
+ * visibility matches `JSON.stringify` visibility — EXCEPT for `toJSON`-bearing
+ * class instances, where it does not. The measured example in that docstring is
+ * `new URL('https://x/urn:air:…')`, for which `containsAirReference` returns
+ * FALSE while `JSON.stringify` of it CONTAINS the AIR. That note names the
+ * precondition for the hazard becoming reachable: "the first time an entry
+ * declares a `z.unknown()` / `z.any()` / `z.custom()` param", because superjson
+ * reconstructs a `URL` across the tRPC boundary.
+ *
+ * THIS IS THAT ENTRY. A tool's `parameters` is an arbitrary JSON Schema, so it
+ * cannot be given a field-by-field shape — and a naive structural walk does NOT
+ * close the hole, because `Object.keys(new URL(…))` is `[]`: the instance reads
+ * as a harmless empty object and then serialises to its full href on the wire.
+ *
+ * So this validates the SERIALISED form and returns the PARSED-BACK value. After
+ * it, `parameters` is pure JSON data by construction, which makes what the AIR
+ * scan walks byte-identical to what reaches the orchestrator. That is exactly
+ * the "pre-scan `JSON.parse(JSON.stringify(input))` normalisation" the registry
+ * note prescribes, paid here where the unbounded value enters rather than left
+ * for the scan to be wrong about.
+ *
+ * `JSON.stringify` also throws on a circular structure and returns `undefined`
+ * for a bare function/symbol; both are caught and rejected rather than allowed
+ * to surface as a 500 from inside the resolver.
+ */
+const toolParametersSchema = z.unknown().transform((value, ctx) => {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'tool parameters must be JSON-serializable (a circular structure was rejected)',
+    });
+    return z.NEVER;
+  }
+  if (typeof serialized !== 'string') {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'tool parameters must be a JSON value, not a function or symbol',
+    });
+    return z.NEVER;
+  }
+  if (serialized.length > MAX_TOOL_PARAMETERS_CHARS) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `tool parameters exceed ${MAX_TOOL_PARAMETERS_CHARS} serialized characters`,
+    });
+    return z.NEVER;
+  }
+  const normalized: unknown = JSON.parse(serialized);
+  if (normalized === null || typeof normalized !== 'object' || Array.isArray(normalized)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'tool parameters must be a JSON Schema object',
+    });
+    return z.NEVER;
+  }
+  if (jsonDepth(normalized) > MAX_TOOL_PARAMETERS_DEPTH) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `tool parameters nest deeper than ${MAX_TOOL_PARAMETERS_DEPTH} levels`,
+    });
+    return z.NEVER;
+  }
+  return normalized as Record<string, unknown>;
+});
+
+/**
+ * Nesting depth of an already-JSON-normalised value.
+ *
+ * Total by construction rather than by a depth cap: it only ever runs on the
+ * output of `JSON.parse`, which cannot be circular, and the serialized-size cap
+ * above bounds how much there is to walk before this is reached.
+ */
+function jsonDepth(value: unknown): number {
+  if (Array.isArray(value)) {
+    return 1 + value.reduce<number>((max, v) => Math.max(max, jsonDepth(v)), 0);
+  }
+  if (value !== null && typeof value === 'object') {
+    return (
+      1 +
+      Object.values(value as Record<string, unknown>).reduce<number>(
+        (max, v) => Math.max(max, jsonDepth(v)),
+        0
+      )
+    );
+  }
+  return 0;
+}
+
+/**
+ * One tool the model may call.
+ *
+ * Anchored to the generated `ChatCompletionTool` / `ChatCompletionFunction` by
+ * NAME only — see `ChatCompletionInputWithTools` for why the generated TYPES
+ * cannot be used directly here.
+ *
+ * The tool-level `parameters` field the generated `ChatCompletionTool` also
+ * carries ("Server-tool parameters for providers such as OpenRouter") is
+ * deliberately NOT exposed: the JSON Schema belongs on `function.parameters`,
+ * and a second unbounded object with a different meaning is a surface this entry
+ * has no use for. `.strict()` rejects it.
+ */
+const chatToolSchema = z
+  .object({
+    type: z.literal('function'),
+    function: z
+      .object({
+        name: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
+        description: z.string().min(1).max(MAX_TOOL_DESCRIPTION_CHARS).optional(),
+        parameters: toolParametersSchema.optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+/**
+ * Which tool the model must call, if any.
+ *
+ * Bounded to the three documented string modes plus the "call this specific
+ * function" object form. The named form is cross-checked against the declared
+ * `tools` in the params-level refinement below — naming a function that was
+ * never declared is a caller mistake that would otherwise reach the provider and
+ * fail there, after the step had been quoted and charged.
+ */
+const chatToolChoiceSchema = z.union([
+  z.enum(['auto', 'none', 'required']),
+  z
+    .object({
+      type: z.literal('function'),
+      function: z
+        .object({ name: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN) })
+        .strict(),
+    })
+    .strict(),
+]);
+
+/**
+ * One conversation turn — a DISCRIMINATED UNION on `role`, every member
+ * `.strict()`.
+ *
+ * 🔴 IT USED TO BE A SINGLE FLAT OBJECT WITH A THREE-VALUE `role` ENUM, and the
+ * old docstring ended "`.strict()`, so `name`, `tool_calls` and `images` are
+ * rejected rather than forwarded". That sentence is now true of only two of
+ * those three: `tool_calls` is ACCEPTED on an assistant turn, because a tool
+ * result cannot be fed back without replaying the assistant turn that requested
+ * it. `name` and `images` are still rejected, and `images` deliberately so — see
+ * the `modalities` note below.
  *
  * 🔴 `content` IS A PLAIN STRING, and that is measured rather than read off the
  * generated type. `UserMessage.content` is typed `Array<ChatCompletionContentPart>`
@@ -294,15 +564,69 @@ const TEMPERATURE_MAX = 2;
  * `civitaiHostedImageUrlSchema`. Not exposing the part array avoids the question
  * entirely.
  *
- * `.strict()`, so `name`, `tool_calls` and `images` are rejected rather than
- * forwarded.
+ * 🔴 THE ASSISTANT MEMBER IS THE ONE WITH A REFINEMENT, AND IT IS NOT
+ * COSMETIC. Both its fields are optional individually — a replayed assistant
+ * turn that requested a tool carries `tool_calls` and NO content (the measured
+ * shape: a real reply with `finishReason: 'tool_calls'` has no `content` key at
+ * all), while an ordinary turn carries content and no tool calls. But a member
+ * with both omitted is an empty message: it costs prompt tokens, means nothing
+ * to the model, and is the shape a buggy block sends when its history-building
+ * drops a field. Requiring at least one is what stops "I sent the history" and
+ * "I sent 32 empty objects" from being the same request.
  */
-const chatMessageSchema = z
-  .object({
-    role: z.enum(['system', 'user', 'assistant']),
-    content: z.string().min(1).max(MAX_MESSAGE_CHARS),
-  })
-  .strict();
+const chatMessageSchema = z.discriminatedUnion('role', [
+  z
+    .object({
+      role: z.literal('system'),
+      content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal('user'),
+      content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal('assistant'),
+      content: z.string().min(1).max(MAX_MESSAGE_CHARS).optional(),
+      tool_calls: z
+        .array(
+          z
+            .object({
+              id: z.string().min(1).max(MAX_TOOL_NAME_CHARS),
+              type: z.literal('function'),
+              function: z
+                .object({
+                  name: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
+                  arguments: z.string().max(MAX_MESSAGE_CHARS),
+                })
+                .strict(),
+            })
+            .strict()
+        )
+        .min(1)
+        .max(MAX_TOOLS)
+        .optional(),
+    })
+    .strict()
+    .refine((m) => m.content !== undefined || m.tool_calls !== undefined, {
+      message: 'an assistant message must carry content, tool_calls, or both',
+    }),
+  z
+    .object({
+      role: z.literal('tool'),
+      content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+      /**
+       * REQUIRED. `ToolMessage.tool_call_id` is required on the orchestrator's
+       * own generated type, and a tool result with nothing to correlate it to is
+       * a result the model cannot attach to the call it made.
+       */
+      tool_call_id: z.string().min(1).max(MAX_TOOL_NAME_CHARS),
+    })
+    .strict(),
+]);
 
 const chatCompletionParamsSchema = z
   .object({
@@ -314,6 +638,10 @@ const chatCompletionParamsSchema = z
      */
     model: z.enum(CHAT_COMPLETION_MODELS),
     messages: z.array(chatMessageSchema).min(1).max(MAX_MESSAGES),
+    /** Tool definitions the model may call. See `MAX_TOOLS` for the bounds' reasoning. */
+    tools: z.array(chatToolSchema).min(1).max(MAX_TOOLS).optional(),
+    /** Which tool the model must call, if any. Requires `tools`. */
+    toolChoice: chatToolChoiceSchema.optional(),
     /**
      * 🔴 REQUIRED, NEVER `.optional()`, AND THAT IS THE POINT OF THE FIELD.
      * `.strict()` rejects params it does not know about; it does NOT bound a
@@ -337,7 +665,53 @@ const chatCompletionParamsSchema = z
      */
     temperature: z.number().min(TEMPERATURE_MIN).max(TEMPERATURE_MAX).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((params, ctx) => {
+    // ── THE ROUND BOUND. See `MAX_TOOL_ROUNDS` for why it exists and why it is
+    // enforced here rather than in the block. Counting `role: 'tool'` messages
+    // counts completed rounds: a round is "the model asked for a tool, the tool
+    // answered", and the answer is the `tool` message.
+    const toolRounds = params.messages.filter((m) => m.role === 'tool').length;
+    if (toolRounds > MAX_TOOL_ROUNDS) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['messages'],
+        message:
+          `too many tool rounds: ${toolRounds} tool messages exceeds the maximum of ` +
+          `${MAX_TOOL_ROUNDS}. Each round is a separate billed submit, so the loop is bounded ` +
+          'here rather than by the caller',
+      });
+    }
+
+    // ── `toolChoice` WITHOUT `tools` IS A NO-OP THE CALLER WILL MISREAD.
+    // "required" with nothing to require is not a stricter request, it is a
+    // request the provider cannot satisfy — rejected here so it fails before the
+    // step is quoted rather than at execution after it has been charged.
+    if (params.toolChoice !== undefined && params.tools === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['toolChoice'],
+        message: 'toolChoice requires tools to be declared',
+      });
+    }
+
+    // ── A NAMED FUNCTION MUST BE ONE THAT WAS DECLARED. Same reasoning as the
+    // model allowlist: there is no orchestrator-side validation to catch it, so
+    // an undeclared name is quoted, charged, and then fails at the provider.
+    const namedFunction =
+      typeof params.toolChoice === 'object' ? params.toolChoice.function.name : undefined;
+    if (
+      namedFunction !== undefined &&
+      params.tools !== undefined &&
+      !params.tools.some((t) => t.function.name === namedFunction)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['toolChoice', 'function', 'name'],
+        message: 'toolChoice names a function that is not in tools',
+      });
+    }
+  });
 
 export type ChatCompletionStepParams = z.infer<typeof chatCompletionParamsSchema>;
 
@@ -368,8 +742,60 @@ export type ChatCompletionStepParams = z.infer<typeof chatCompletionParamsSchema
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * `ChatCompletionInput` with its two TOOL fields corrected.
+ *
+ * 🔴 THE GENERATED TYPES CANNOT EXPRESS A TOOL CALL, AND THAT IS A GENERATOR
+ * ARTIFACT RATHER THAN A CONTRACT. Read off `@civitai/client`'s `types.gen.d.ts`
+ * at the version this repo pins:
+ *
+ *     ChatCompletionInput.tool_choice?: null;
+ *     ChatCompletionTool.parameters?:   null;
+ *     ChatCompletionFunction.parameters?: null;
+ *
+ * All three are `null` — not `unknown`, not a schema type. The C# side holds
+ * them as free-form JSON, and the OpenAPI generator emits an untyped
+ * schema-less field as `null`. Their own doc comments contradict the types they
+ * carry: `tool_choice`'s says it "Can be \"auto\", \"none\", \"required\", or an
+ * object specifying a particular function", and `ChatCompletionTool.parameters`
+ * is documented as "Server-tool parameters for providers such as OpenRouter".
+ *
+ * So the generated type says a tool call is impossible while the generated DOC
+ * says how to make one, and the wire accepts it — a real submit carrying a
+ * `tools` array and a tool choice was accepted, echoed back in the
+ * orchestrator's normalised input, and priced (its tool-definition token
+ * estimator is a first-class part of its cost path).
+ *
+ * 🔴 WHY A NARROW INTERSECTION AND NOT A CAST. `buildChatCompletionInput`'s
+ * declared return type is the anchor that makes every field NAME load-bearing —
+ * a rename on the orchestrator's input contract is a build failure here rather
+ * than a request the orchestrator silently ignores. An `as ChatCompletionInput`
+ * would throw that away for the whole object to fix two fields. `Omit`-ing
+ * exactly the two lossy fields and re-declaring them keeps `model`, `messages`,
+ * `maxTokens` and `temperature` anchored, and records IN THE TYPE which two
+ * fields this repo is not able to check against the generator.
+ *
+ * 🔴 IF THE GENERATOR IS EVER FIXED, DELETE THIS. Once `tool_choice` and
+ * `parameters` carry real types upstream, the `Omit` starts hiding a contract
+ * this file could otherwise be checked against — at which point it is no longer
+ * a workaround, it is the thing it was written to avoid.
+ */
+type ChatCompletionToolChoiceWire =
+  | 'auto'
+  | 'none'
+  | 'required'
+  | { type: 'function'; function: { name: string } };
+
+type ChatCompletionInputWithTools = Omit<ChatCompletionInput, 'tools' | 'tool_choice'> & {
+  tools?: Array<{
+    type: 'function';
+    function: { name: string; description?: string; parameters?: Record<string, unknown> };
+  }>;
+  tool_choice?: ChatCompletionToolChoiceWire;
+};
+
+/**
  * The bounded input this entry submits, ANCHORED to the generated
- * `ChatCompletionInput`.
+ * `ChatCompletionInput` (with the two documented exceptions above).
  *
  * Declaring the return type is what makes the field NAMES load-bearing: a
  * renamed or retyped field on the orchestrator's own input contract is a build
@@ -378,13 +804,24 @@ export type ChatCompletionStepParams = z.infer<typeof chatCompletionParamsSchema
  * `{ role: string }` base) rather than to `UserMessage`, because that alias's
  * `content: Array<ChatCompletionContentPart>` contradicts the measured wire
  * behaviour — see `chatMessageSchema`.
+ *
+ * 🔴 THE WIRE NAME IS `tool_choice`, SNAKE-CASED, WHILE THE PARAM IS
+ * `toolChoice`. That asymmetry is deliberate and is read off the generated type,
+ * not chosen: this input mixes conventions — `maxTokens` is camelCase while
+ * every tool-related field (`tool_choice`, `tool_calls`, `tool_call_id`) is
+ * snake-cased for OpenAI wire compatibility. The PARAM surface stays camelCase
+ * because that is what every other param on this entry is, and the mapping
+ * happens here, once. Getting this backwards does not error — an unknown field
+ * is simply ignored — so it is pinned by the exact-key-set test.
  */
-function buildChatCompletionInput(params: ChatCompletionStepParams): ChatCompletionInput {
+function buildChatCompletionInput(params: ChatCompletionStepParams): ChatCompletionInputWithTools {
   return {
     model: params.model,
     messages: params.messages,
     maxTokens: params.maxTokens,
     ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
+    ...(params.tools !== undefined ? { tools: params.tools } : {}),
+    ...(params.toolChoice !== undefined ? { tool_choice: params.toolChoice } : {}),
   };
 }
 
@@ -407,6 +844,33 @@ function buildChatCompletionInput(params: ChatCompletionStepParams): ChatComplet
 export type ChatCompletionMessageOutputLike = {
   content?: string | null;
   refusal?: string | null;
+  /**
+   * Tool calls the model requested. Present when `finishReason` is
+   * `'tool_calls'`, in which case `content` is typically absent entirely — the
+   * measured shape of a real tool-calling reply.
+   */
+  tool_calls?: readonly (ChatCompletionToolCallOutputLike | null)[] | null;
+};
+
+/** One tool call on an assistant message, as this entry reads it. */
+export type ChatCompletionToolCallOutputLike = {
+  id?: string | null;
+  type?: string | null;
+  function?: { name?: string | null; arguments?: string | null } | null;
+};
+
+/**
+ * A tool call as PUBLISHED to a block, once the scan has released it.
+ *
+ * Deliberately a narrow, fully-populated shape rather than the orchestrator's
+ * optional-everything read shape: a block should not have to defend against a
+ * half-formed tool call, and `extractToolCalls` drops anything that does not
+ * fill it.
+ */
+export type BlockToolCall = {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
 };
 
 /** One completion choice, as this entry reads it. */
@@ -473,11 +937,33 @@ export const chatCompletionStep = {
    * So anything this does not return is never scanned AND never published; the
    * two move together by construction.
    *
-   * 🔴 IT DOES NOT READ `message.images[]` OR `message.tool_calls[]`, and both
-   * omissions are safe in the same direction. Neither can appear — this entry
-   * never sets `modalities` and never exposes `tools` — and if one somehow did,
-   * it would be DROPPED rather than published, because a `'textOutput'` entry has
-   * no `extractOutput` to carry it. The fail-closed direction.
+   * 🔴 IT NOW READS `message.tool_calls[]`, AND THE OLD REASON FOR SKIPPING THEM
+   * IS GONE. This docstring used to say `images[]` and `tool_calls[]` were "safe
+   * in the same direction" because "this entry never sets `modalities` and never
+   * exposes `tools`", with the fallback that either "would be DROPPED rather
+   * than published". Exposing `tools` falsified the precondition, and DROPPING
+   * is precisely what a tool-calling capability cannot do — a dropped tool call
+   * is a step that charges, succeeds, and publishes nothing, which is the exact
+   * inert-capability failure clause 8a exists to catch.
+   *
+   * So the model-generated ARGUMENT STRINGS are returned here, which puts them
+   * through the same scan as any other generated text. That is not incidental:
+   * an argument string is free text the model wrote, on its way both to a tool
+   * and to the block's own UI, and it is the surface the posture would otherwise
+   * not cover.
+   *
+   * 🔴 AND RETURNING THEM HERE MEANS THEY ARE ALSO PUBLISHED, WHICH IS
+   * DELIBERATE. This field's contract is that whatever it returns is what the
+   * scan sees AND what a release publishes — "the two move together by
+   * construction". Scanning the arguments while withholding them from
+   * `textOutputs` would break that in the direction that reads as coverage, so
+   * they appear in both. The structured `extractToolCalls` surface below is the
+   * ergonomic form; this is the scanned-and-published form, and they are gated
+   * on the same verdict.
+   *
+   * `images[]` is still not read, and is still safe for the original reason:
+   * this entry never sets `modalities`, so it cannot appear, and a
+   * `'textOutput'` entry has no `extractOutput` to carry it if it somehow did.
    */
   extractText: (step: unknown): string[] => {
     const choices = (step as ChatCompletionOutputStepLike | null | undefined)?.output?.choices;
@@ -494,8 +980,57 @@ export const chatCompletionStep = {
         // to publish.
         if (typeof value === 'string' && value.trim().length > 0) texts.push(value);
       }
+      // Model-generated tool ARGUMENTS. The tool NAME is not included: it is
+      // pattern-bounded (`TOOL_NAME_PATTERN`) and echoed from what the caller
+      // itself declared, so it cannot carry prose — see that constant.
+      const toolCalls = message.tool_calls;
+      if (!Array.isArray(toolCalls)) continue;
+      for (const call of toolCalls) {
+        const args = call?.function?.arguments;
+        if (typeof args === 'string' && args.trim().length > 0) texts.push(args);
+      }
     }
     return texts;
+  },
+  /**
+   * The STRUCTURED tool calls, published to the block only when the scan
+   * RELEASES.
+   *
+   * 🔴 THIS IS NOT A SECOND CHANNEL AROUND THE SCAN, AND THE DISTINCTION IS THE
+   * whole reason the field is shaped this way. `attachModeratedStepTextOutputs`
+   * is the sole producer of `snapshot.toolCalls` exactly as it is of
+   * `snapshot.textOutputs`: it calls this only after `extractText`'s strings —
+   * which INCLUDE every `arguments` value this returns — have been through
+   * `screenGeneratedText` and released. A withheld verdict publishes neither.
+   * A `toolCalls` field populated anywhere else would be the
+   * `StepOutputMedia.url` smuggle in a new field name.
+   *
+   * 🔴 IT DROPS, RATHER THAN PUBLISHES, A MALFORMED CALL — including one whose
+   * NAME does not match `TOOL_NAME_PATTERN`. The name is the one string here
+   * that does not go through the scan, and the argument for that is precisely
+   * that the pattern makes it incapable of carrying prose. A provider that
+   * echoed back an unbounded name would break that argument, so the extractor
+   * enforces the pattern on the way out rather than trusting the round trip.
+   */
+  extractToolCalls: (step: unknown): BlockToolCall[] => {
+    const choices = (step as ChatCompletionOutputStepLike | null | undefined)?.output?.choices;
+    if (!Array.isArray(choices)) return [];
+    const calls: BlockToolCall[] = [];
+    for (const choice of choices) {
+      const toolCalls = choice?.message?.tool_calls;
+      if (!Array.isArray(toolCalls)) continue;
+      for (const call of toolCalls) {
+        const id = call?.id;
+        const name = call?.function?.name;
+        const args = call?.function?.arguments;
+        if (typeof id !== 'string' || id.length === 0) continue;
+        if (typeof name !== 'string' || !TOOL_NAME_PATTERN.test(name)) continue;
+        if (name.length > MAX_TOOL_NAME_CHARS) continue;
+        if (typeof args !== 'string') continue;
+        calls.push({ id, type: 'function', function: { name, arguments: args } });
+      }
+    }
+    return calls;
   },
   /**
    * A canonical COMPLETED step, for the load-time extraction probe (clause 8a).

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -632,7 +632,16 @@ const chatMessageSchema = z.discriminatedUnion('role', [
         .array(
           z
             .object({
-              id: z.string().min(1).max(MAX_TOOL_NAME_CHARS),
+              /**
+               * 🔴 SAME CHARSET AS THE OUTPUT EXTRACTOR PUBLISHES, deliberately.
+               * The file used to hold two disagreeing definitions of a valid id:
+               * `call:with:colons` PARSED here while `extractToolCalls` refused
+               * it on the way out. Reconciled toward the stricter one, and that
+               * cannot reject a legitimate payload: the ONLY id a block can
+               * legitimately replay is one WE published, and we publish only
+               * charset-conforming ids. See `publishableToolCalls`.
+               */
+              id: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
               type: z.literal('function'),
               function: z
                 .object({
@@ -659,8 +668,21 @@ const chatMessageSchema = z.discriminatedUnion('role', [
        * REQUIRED. `ToolMessage.tool_call_id` is required on the orchestrator's
        * own generated type, and a tool result with nothing to correlate it to is
        * a result the model cannot attach to the call it made.
+       *
+       * Charset-bounded for the same reason as the assistant-side `id` above —
+       * this value is correlated against those ids, so accepting a shape they
+       * can never hold would only ever fail the correlation guard later.
+       *
+       * 🔴 THIS REGEX IS DEFENCE-IN-DEPTH AND IS **NOT** INDEPENDENTLY TESTED —
+       * stated because "mutation-verified" would be false of it. Measured:
+       * removing it alone leaves the suite GREEN, because every payload that
+       * could violate it is already rejected by something earlier. A bad
+       * `tool_call_id` either matches a declared assistant `id` (which is itself
+       * charset-bounded, so that regex fires first) or matches none (so the
+       * correlation guard rejects it). Removing BOTH regexes together IS caught.
+       * It is kept as a redundant clause, not because a test proves it fires.
        */
-      tool_call_id: z.string().min(1).max(MAX_TOOL_NAME_CHARS),
+      tool_call_id: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
     })
     .strict(),
 ]);
@@ -736,6 +758,31 @@ const chatCompletionParamsSchema = z
     // AND NOT MERELY A MEMBERSHIP ONE. Collecting every id first and then
     // testing membership would accept a `tool` message that PRECEDES the
     // assistant turn declaring it — a payload the provider still rejects.
+    //
+    // 🔴 THIS GUARD COVERS ONE DIRECTION ONLY, AND THE OTHER IS A KNOWN,
+    // UNVALIDATED GAP. It constrains ANSWERS to declared ASKS. It does not
+    // constrain asks to be answered, and it does not deduplicate. **This schema
+    // therefore ACCEPTS all three of the following** — stated as what the schema
+    // does, not as a claim that they are legal at the provider:
+    //
+    //   1. `[user, assistant(tool_calls:[a])]`             — an ask never answered
+    //   2. `[user, assistant(tool_calls:[a]), user, tool(a)]` — answer split from its ask
+    //   3. `[user, assistant(tool_calls:[a]), tool(a), tool(a)]` — one ask answered twice
+    //
+    // 🔴 AN EARLIER REVISION CALLED (1) "legal, since the correlation guard
+    // constrains answers to declared asks and not the reverse". That sentence
+    // was a true statement about THIS SCHEMA'S ACCEPTANCE worded as a claim
+    // about the PROVIDER, which is not ours to make.
+    //
+    // No guard is added for these deliberately. The premise that providers
+    // reject them comes from the OpenAI-compatible contract, NOT from a probe
+    // against this orchestrator — and the wire spelling of the tool fields is
+    // itself still unconfirmed against a live request. A guard built on an
+    // unverified premise risks being TOO STRICT and rejecting payloads that
+    // actually work, which is the worse failure here: the cost of the gap is a
+    // charged submit plus a provider error, while the cost of a wrong guard is a
+    // working feature refused at parse. Close this once the live probe settles
+    // what the orchestrator accepts.
     const declaredCallIds = new Set<string>();
     for (const message of params.messages) {
       if (message.role === 'assistant') {
@@ -970,6 +1017,77 @@ export type ChatCompletionOutputStepLike = {
   } | null;
 };
 
+/**
+ * The canonical encoding of "this tool call takes no arguments".
+ *
+ * A provider that emits `''` (or whitespace) for a zero-parameter function is
+ * emitting something no consumer can use: `JSON.parse('')` THROWS, while
+ * `JSON.parse('{}')` is the empty argument object the call actually means.
+ * Normalising here is a repair, not a distortion of the provider's value.
+ */
+const EMPTY_TOOL_ARGUMENTS = '{}';
+
+/**
+ * THE ONE PREDICATE that decides which tool calls this entry publishes, and
+ * with what `arguments` — used by BOTH `extractText` and `extractToolCalls`.
+ *
+ * 🔴 IT IS SHARED BECAUSE TWO COPIES DRIFTED, TWICE, AND EACH DRIFT WAS A BUG.
+ * The extractors used to apply their own predicates, and audit found both
+ * failure directions this produces:
+ *
+ *   - `extractText` required `args.trim().length > 0` while `extractToolCalls`
+ *     accepted any string, so a call with `arguments: ''` was PUBLISHED but
+ *     never SCANNED — the containment property clause 8b and three docstrings
+ *     assert was literally false on shipped code.
+ *   - Aligning them by making `extractToolCalls` drop the call instead made a
+ *     no-argument tool call VANISH: measured end to end, a response whose only
+ *     choice was a tool call with `arguments: ''` produced a snapshot carrying
+ *     neither `textOutputs` nor `toolCalls` nor `textOutputWithheld`. The step
+ *     was charged, reported `succeeded`, and published nothing the app author
+ *     could diagnose.
+ *   - The same shape on the ID axis: a provider id outside `TOOL_NAME_PATTERN`
+ *     made `extractToolCalls` drop the whole call while `extractText` still
+ *     published its arguments, so a block received argument JSON in
+ *     `textOutputs`, an empty `toolCalls`, and no id to answer with.
+ *
+ * All three are the same defect — a rule open-coded at two sites is wrong at
+ * one of them — so the rule now has one home. Containment holds BY
+ * CONSTRUCTION: `extractText` publishes exactly the `arguments` of the calls
+ * this returns, so no divergence is expressible without editing this function.
+ *
+ * 🔴 WHAT THAT DOES TO CLAUSE 8b, STATED PLAINLY RATHER THAN QUIETLY. 8b
+ * compares the two extractors' outputs, and they now agree by construction, so
+ * it can no longer fail for a DIVERGENCE reason — it is a refactor tripwire,
+ * not a divergence detector. That is a real reduction in what it detects and it
+ * is the deliberate trade: a structural guarantee beats a checked one. It is
+ * NOT the vacuous shape a previous audit round found (a loop body that never
+ * ran over an empty set) — the loop still executes over real calls, and it
+ * still fires the moment anyone re-splits these predicates, which is exactly
+ * the regression it now exists to catch. That claim is mutation-tested.
+ */
+function publishableToolCalls(
+  message: { tool_calls?: readonly (ChatCompletionToolCallOutputLike | null)[] | null } | null
+): BlockToolCall[] {
+  const toolCalls = message?.tool_calls;
+  if (!Array.isArray(toolCalls)) return [];
+  const calls: BlockToolCall[] = [];
+  for (const call of toolCalls) {
+    const id = call?.id;
+    const name = call?.function?.name;
+    const args = call?.function?.arguments;
+    // 🔴 A REJECTED CALL CONTRIBUTES NOTHING ON EITHER SIDE — no published
+    // call AND no orphan argument string. That pairing is the point.
+    if (typeof id !== 'string' || !TOOL_NAME_PATTERN.test(id)) continue;
+    if (id.length > MAX_TOOL_NAME_CHARS) continue;
+    if (typeof name !== 'string' || !TOOL_NAME_PATTERN.test(name)) continue;
+    if (name.length > MAX_TOOL_NAME_CHARS) continue;
+    if (typeof args !== 'string') continue;
+    const normalised = args.trim().length === 0 ? EMPTY_TOOL_ARGUMENTS : args;
+    calls.push({ id, type: 'function', function: { name, arguments: normalised } });
+  }
+  return calls;
+}
+
 export const chatCompletionStep = {
   id: 'chat-completion',
   orchestratorType: 'chatCompletion',
@@ -1052,15 +1170,12 @@ export const chatCompletionStep = {
         // to publish.
         if (typeof value === 'string' && value.trim().length > 0) texts.push(value);
       }
-      // Model-generated tool ARGUMENTS. The tool NAME is not included: it is
-      // pattern-bounded (`TOOL_NAME_PATTERN`) and echoed from what the caller
-      // itself declared, so it cannot carry prose — see that constant.
-      const toolCalls = message.tool_calls;
-      if (!Array.isArray(toolCalls)) continue;
-      for (const call of toolCalls) {
-        const args = call?.function?.arguments;
-        if (typeof args === 'string' && args.trim().length > 0) texts.push(args);
-      }
+      // Model-generated tool ARGUMENTS, for exactly the calls this entry will
+      // publish — see `publishableToolCalls`, which both extractors share so a
+      // dropped call cannot leave its arguments behind and a published call
+      // cannot escape the scan. The tool NAME is not included; see the
+      // unscanned-set note on `extractToolCalls`.
+      for (const call of publishableToolCalls(message)) texts.push(call.function.arguments);
     }
     return texts;
   },
@@ -1079,10 +1194,26 @@ export const chatCompletionStep = {
    *
    * 🔴 IT DROPS, RATHER THAN PUBLISHES, A MALFORMED CALL — including one whose
    * NAME or ID does not match `TOOL_NAME_PATTERN`. Those two are the strings
-   * here that do NOT go through the scan, and the argument for both is the
-   * same: the pattern makes them incapable of carrying prose. A provider that
-   * echoed back an unbounded value would break that argument, so the extractor
-   * enforces the pattern on the way out rather than trusting the round trip.
+   * here that do NOT go through the scan.
+   *
+   * 🔴 THE ARGUMENT FOR LEAVING THEM UNSCANNED IS **NOT** THE SAME FOR BOTH,
+   * and an earlier revision of this docstring claimed it was. State the real
+   * asymmetry, because the weaker of the two is the one worth watching:
+   *
+   *   - `name` rests on TWO legs. It is echoed back from what the CALLER ITSELF
+   *     declared in `tools[]`, and the input schema enforces
+   *     `TOOL_NAME_PATTERN` on that declaration — so a name is both
+   *     caller-authored and charset-bounded before it is ever echoed.
+   *   - `id` rests on ONE leg. It is PROVIDER-generated: nothing on this side
+   *     authored it, and the only thing bounding it is the pattern test below.
+   *
+   * 🔴 AND THAT SURVIVING LEG IS WEAKER THAN "cannot carry prose" — do not
+   * re-assert that. `[a-zA-Z0-9_-]{1,64}` carries perfectly readable prose in
+   * snake_case; measured, a 63-char underscore-joined sentence passes this
+   * filter and is published verbatim. What the pattern actually buys is a hard
+   * BOUND on length and alphabet — no markup, no urls, no AIR literals, no
+   * whitespace, and 64 chars — which is what makes the residue small enough to
+   * accept, not an inability to say anything.
    *
    * 🔴 THE ID BOUND IS NOT SYMMETRY-FOR-ITS-OWN-SAKE — IT CLOSES A ZERO-SCAN
    * PUBLISH PATH. Until it existed, `id` was accepted on `typeof id === 'string'
@@ -1101,39 +1232,30 @@ export const chatCompletionStep = {
    * either. The unscanned published set is exactly `{ name, id }`, and it is
    * enumerated here so the next person widening this surface has to count.
    *
-   * 🔴 EMPTY / WHITESPACE-ONLY `arguments` ARE DROPPED, AND THAT IS WHAT MAKES
-   * THE CONTAINMENT INVARIANT TRUE AS WRITTEN. `extractText` pushes an
-   * arguments string only when `trim().length > 0`; accepting any string here
-   * meant a call with `arguments: ''` or `'   '` was published while
-   * `extractText` returned nothing for it — so the property clause 8b and three
-   * docstrings state ("every arguments string this can publish is also returned
-   * by extractText") was literally false on unmutated code. Aligning the two
-   * predicates is the fix, in the fail-closed direction the rest of this
-   * extractor already takes. The ordinary no-argument encoding is `'{}'`, which
-   * is neither empty nor whitespace and is unaffected; a provider that instead
-   * emits `''` for a no-arg call has that call DROPPED, and the fix for that
-   * would be to normalise it to `'{}'` at the point of capture — never to
-   * loosen the containment.
+   * 🔴 EMPTY / WHITESPACE-ONLY `arguments` ARE NORMALISED TO `'{}'`, NOT
+   * DROPPED — and the intermediate revision that dropped them was a REGRESSION
+   * this file shipped and audit caught. Measured end to end: a response whose
+   * only choice was a tool call with `arguments: ''` produced a snapshot with
+   * neither `textOutputs` nor `toolCalls` nor `textOutputWithheld`, i.e. a step
+   * that was CHARGED, reported `succeeded`, and published literally nothing the
+   * app author could diagnose. A no-argument call (`list_categories`) is an
+   * ordinary case, not a malformed one.
+   *
+   * Normalising loosens NOTHING, and that is the point clause 8b turns on: it
+   * compares published `arguments` against the SCANNED set, and a whitespace-
+   * only string carries nothing a scanner could read. `'{}'` is also the only
+   * value a consumer can use — `JSON.parse('')` throws. The ordinary encoding
+   * `'{}'` is unaffected either way.
    */
   extractToolCalls: (step: unknown): BlockToolCall[] => {
     const choices = (step as ChatCompletionOutputStepLike | null | undefined)?.output?.choices;
     if (!Array.isArray(choices)) return [];
     const calls: BlockToolCall[] = [];
     for (const choice of choices) {
-      const toolCalls = choice?.message?.tool_calls;
-      if (!Array.isArray(toolCalls)) continue;
-      for (const call of toolCalls) {
-        const id = call?.id;
-        const name = call?.function?.name;
-        const args = call?.function?.arguments;
-        if (typeof id !== 'string' || !TOOL_NAME_PATTERN.test(id)) continue;
-        if (id.length > MAX_TOOL_NAME_CHARS) continue;
-        if (typeof name !== 'string' || !TOOL_NAME_PATTERN.test(name)) continue;
-        if (name.length > MAX_TOOL_NAME_CHARS) continue;
-        // Same predicate `extractText` applies — see the containment note above.
-        if (typeof args !== 'string' || args.trim().length === 0) continue;
-        calls.push({ id, type: 'function', function: { name, arguments: args } });
-      }
+      // The SHARED predicate — see `publishableToolCalls`. `extractText`
+      // publishes exactly these calls' `arguments`, so containment holds by
+      // construction rather than by two predicates staying in step.
+      calls.push(...publishableToolCalls(choice?.message ?? null));
     }
     return calls;
   },

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -636,10 +636,22 @@ const chatMessageSchema = z.discriminatedUnion('role', [
                * 🔴 SAME CHARSET AS THE OUTPUT EXTRACTOR PUBLISHES, deliberately.
                * The file used to hold two disagreeing definitions of a valid id:
                * `call:with:colons` PARSED here while `extractToolCalls` refused
-               * it on the way out. Reconciled toward the stricter one, and that
-               * cannot reject a legitimate payload: the ONLY id a block can
-               * legitimately replay is one WE published, and we publish only
-               * charset-conforming ids. See `publishableToolCalls`.
+               * it on the way out. Reconciled toward the stricter one.
+               *
+               * 🔴 BE EXACT ABOUT WHAT THAT DOES NOT REJECT, BECAUSE AN EARLIER
+               * REVISION OVERCLAIMED IT. It said this "cannot reject a
+               * legitimate payload". The true guarantee is narrower: it cannot
+               * reject a payload DERIVED FROM OUR OWN OUTPUT, because we publish
+               * only charset-conforming ids (see `publishableToolCalls`).
+               *
+               * It CAN reject a hand-authored one. A block author writing
+               * few-shot tool-call history — an ordinary thing to do — may
+               * invent any id; `call.1` and `call:1` parsed before this
+               * tightening and are now `BAD_REQUEST`. That is accepted
+               * deliberately: the cost is one bounced request with a zod message
+               * naming the field, against a charset that must stay aligned with
+               * what the extractor will publish, or the two definitions diverge
+               * again. An author hitting it renames the id and moves on.
                */
               id: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
               type: z.literal('function'),
@@ -669,20 +681,28 @@ const chatMessageSchema = z.discriminatedUnion('role', [
        * own generated type, and a tool result with nothing to correlate it to is
        * a result the model cannot attach to the call it made.
        *
-       * Charset-bounded for the same reason as the assistant-side `id` above —
-       * this value is correlated against those ids, so accepting a shape they
-       * can never hold would only ever fail the correlation guard later.
+       * 🔴 LENGTH-BOUNDED BUT DELIBERATELY **NOT** CHARSET-BOUNDED, AND THE
+       * CHARSET REGEX THAT USED TO BE HERE WAS REMOVED RATHER THAN DOCUMENTED.
        *
-       * 🔴 THIS REGEX IS DEFENCE-IN-DEPTH AND IS **NOT** INDEPENDENTLY TESTED —
-       * stated because "mutation-verified" would be false of it. Measured:
-       * removing it alone leaves the suite GREEN, because every payload that
-       * could violate it is already rejected by something earlier. A bad
-       * `tool_call_id` either matches a declared assistant `id` (which is itself
-       * charset-bounded, so that regex fires first) or matches none (so the
-       * correlation guard rejects it). Removing BOTH regexes together IS caught.
-       * It is kept as a redundant clause, not because a test proves it fires.
+       * It changed NO accept/reject outcome. `declaredCallIds` is populated only
+       * from assistant `tool_calls[].id`, which IS charset-bounded above, so a
+       * charset-violating `tool_call_id` can never be a member of that set and
+       * the correlation guard rejects it either way. Measured twice: removing
+       * this regex alone left the suite green, and no input was found for which
+       * it was the sole rejector.
+       *
+       * Its one observable effect was making the diagnostic WORSE — the caller
+       * got a zod regex issue on a field instead of the correlation guard's
+       * message naming the id and saying no preceding assistant message
+       * declared it, which is the sentence that actually tells an app author
+       * what to change. A redundant clause that degrades the error is a net
+       * negative, so it is gone.
+       *
+       * The LENGTH bound stays: it is not redundant in the same way. It bounds
+       * the payload before correlation runs, rather than admitting an
+       * arbitrarily long string that correlation would then reject.
        */
-      tool_call_id: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
+      tool_call_id: z.string().min(1).max(MAX_TOOL_NAME_CHARS),
     })
     .strict(),
 ]);
@@ -1055,15 +1075,35 @@ const EMPTY_TOOL_ARGUMENTS = '{}';
  * CONSTRUCTION: `extractText` publishes exactly the `arguments` of the calls
  * this returns, so no divergence is expressible without editing this function.
  *
- * 🔴 WHAT THAT DOES TO CLAUSE 8b, STATED PLAINLY RATHER THAN QUIETLY. 8b
- * compares the two extractors' outputs, and they now agree by construction, so
- * it can no longer fail for a DIVERGENCE reason — it is a refactor tripwire,
- * not a divergence detector. That is a real reduction in what it detects and it
- * is the deliberate trade: a structural guarantee beats a checked one. It is
- * NOT the vacuous shape a previous audit round found (a loop body that never
- * ran over an empty set) — the loop still executes over real calls, and it
- * still fires the moment anyone re-splits these predicates, which is exactly
- * the regression it now exists to catch. That claim is mutation-tested.
+ * 🔴 WHAT THAT DOES TO CLAUSE 8b, STATED PLAINLY RATHER THAN QUIETLY. While
+ * BOTH extractors go through this function, they agree by construction, so 8b
+ * cannot fail for a divergence reason FOR THIS ENTRY — it is a re-split
+ * tripwire here, not a live divergence detector. That is a real reduction and
+ * it is the deliberate trade: a structural guarantee beats a checked one.
+ *
+ * 🔴 SCOPE THAT CLAIM TO THIS ENTRY. 8b remains a working divergence detector
+ * for any entry that open-codes two predicates — the `makeToolCallStep`
+ * fixtures in `__tests__/step-text-output-moderation.test.ts` are exactly that
+ * shape and 8b is live for them. The sentence is about `chat-completion`, not
+ * about the clause.
+ *
+ * 🔴 AND BE EXACT ABOUT WHAT THE TRIPWIRE IS TESTED AGAINST, BECAUSE AN EARLIER
+ * REVISION OF THIS PARAGRAPH WAS NOT. It claimed 8b "fires the moment anyone
+ * re-splits these predicates" and that the claim was "mutation-tested". The
+ * mutation actually run was the DELETION of `extractText`'s tool-arguments loop
+ * — and audit then executed two genuine re-splits that 8b did NOT catch:
+ * restoring `extractText`'s pre-consolidation `trim().length > 0` predicate,
+ * and re-splitting `extractToolCalls` widened on the id axis. Both loaded
+ * clean, because the canonical sample contained only well-formed calls. The
+ * description was wider than the implementation — the same defect class as the
+ * vacuous-loop finding before it, one level up.
+ *
+ * What is true NOW, and is what was mutation-tested: `canonicalOutputFor`
+ * carries a choice for each divergence class this file has shipped (empty
+ * `arguments`; an out-of-charset `id`), so all three mutants — the deletion and
+ * both re-splits — fire 8b at registry load with its own error. A re-split on
+ * an axis the sample does NOT cover would still pass; see that function's
+ * docstring for the rule about adding a choice when you add a drop reason.
  */
 function publishableToolCalls(
   message: { tool_calls?: readonly (ChatCompletionToolCallOutputLike | null)[] | null } | null
@@ -1263,34 +1303,67 @@ export const chatCompletionStep = {
    * A canonical COMPLETED step, for the load-time extraction probes (clauses 8a
    * and 8b).
    *
-   * 🔴 EVERY CHOICE HERE IS COPIED VERBATIM FROM A REAL ORCHESTRATOR RESPONSE,
-   * not invented to match the extractors. A sample written from the extractor
-   * would make the probe assert only that the code agrees with itself — the
-   * both-wrong-blind shape clause 8a's own docstring names as the thing it
-   * cannot catch. Note what the first real response does NOT contain:
-   * `message` carries **only `content`** — no `role`, despite the generated
-   * `AssistantMessage` declaring it required. That absence is the reason
-   * `extractText` does not key off it.
+   * 🔴 THE SAMPLE IS TWO CAPTURED CHOICES PLUS TWO ADVERSARIAL ONES, AND THE
+   * SPLIT IS STATED BECAUSE AN EARLIER REVISION CLAIMED ALL OF THEM WERE
+   * CAPTURED. That was true when there were two; it became false the moment
+   * choices 2 and 3 were added to arm clause 8b, and a stale "verbatim" banner
+   * over invented data is worse than no banner — it tells the next reader the
+   * probe has a property it does not have.
    *
-   * 🔴 THE SECOND CHOICE IS WHY THIS SAMPLE HAS TWO, AND IT IS LOAD-BEARING
-   * RATHER THAN DECORATIVE. Clause 8b asserts that every `arguments` string
-   * `extractToolCalls` publishes is also returned by `extractText` — but it can
-   * only assert it over THIS sample, so a sample with no `tool_calls` makes the
-   * clause iterate an EMPTY set and pass vacuously. That was the state when
-   * tool calling first landed: the containment property three separate
-   * docstrings name as the mechanism protecting the tool-call surface was
-   * asserted over nothing, and a real containment break in the shipped
-   * extractor (`arguments: args + 'SMUGGLED'`) loaded CLEAN. A guard that
-   * passes because its loop body never runs reads as coverage while providing
-   * none — the exact failure this registry's clause design exists to refuse.
+   *   - Choices 0 and 1 are COPIED VERBATIM from real orchestrator responses.
+   *     They are what keeps the both-wrong-blind hazard closed: a sample
+   *     written FROM the extractor would make the probe assert only that the
+   *     code agrees with itself, which clause 8a's own docstring names as the
+   *     thing it cannot catch. Note what the first real response does NOT
+   *     contain: `message` carries **only `content`** — no `role`, despite the
+   *     generated `AssistantMessage` declaring it required. That absence is the
+   *     reason `extractText` does not key off it.
+   *   - Choices 2 and 3 are ADVERSARIAL VARIANTS: the message and tool-call
+   *     SHAPE is the captured one, but the VALUES (`arguments: ''`, an `id`
+   *     outside `TOOL_NAME_PATTERN`) were chosen to make clause 8b non-vacuous
+   *     on the two divergence classes this file has actually shipped. They are
+   *     NOT a claim that the orchestrator emits these values. Reachability is
+   *     documented per choice; FREQUENCY is unmeasured, and no claim about it
+   *     is made here.
    *
-   * 🔴 THE TWO-CHOICE ENVELOPE IS A COMPOSITION, AND THAT IS SAID PLAINLY. Each
-   * choice object is verbatim from a captured response; no single captured
-   * response carried both, because `n` defaults to 1. The composition is
-   * legitimate for what these clauses actually test — that the extractor PAIR
-   * agrees with itself on a real message shape — and it is what keeps BOTH the
-   * content path and the tool-call path covered at load instead of trading one
-   * for the other. It is NOT a claim that the orchestrator emits two choices.
+   * That distinction is what keeps the both-wrong-blind argument intact: the
+   * hazard it names is an extractor and a sample agreeing on the wrong response
+   * SHAPE, and every shape here is still a captured one. Varying VALUES inside
+   * a captured shape does not reintroduce it. Do not add a choice with an
+   * invented shape.
+   *
+   * 🔴 WHY THE SAMPLE KEEPS GROWING: EACH CHOICE ARMS CLAUSE 8b AGAINST ONE
+   * DIVERGENCE CLASS, AND 8b CAN ONLY EVER SEE WHAT THIS SAMPLE CONTAINS.
+   * Clause 8b asserts that every `arguments` string `extractToolCalls`
+   * publishes is also returned by `extractText` — over THIS sample and nothing
+   * else. The failure mode is therefore always the same: a class the sample
+   * cannot express is a class 8b cannot detect, while still reading as
+   * coverage. It has now been hit TWICE, which is why this list is explicit:
+   *
+   *   1. NO `tool_calls` AT ALL (the state when tool calling first landed) —
+   *      the loop iterated an EMPTY set and passed vacuously. A real
+   *      containment break in the shipped extractor (`arguments: args +
+   *      'SMUGGLED'`) loaded CLEAN. Closed by choice 1.
+   *   2. ONLY WELL-FORMED CALLS (the state after that fix) — the loop ran, but
+   *      every value in it was conforming, so neither shipped divergence class
+   *      was expressible. Measured: re-splitting `extractText` back to its
+   *      pre-consolidation `trim().length > 0` predicate, and re-splitting
+   *      `extractToolCalls` widened on the id axis, BOTH loaded clean. Closed
+   *      by choices 2 and 3.
+   *
+   * 🔴 SO THE RULE FOR ANYONE EDITING `publishableToolCalls`: if you add a
+   * reason a call may be dropped or rewritten, add a choice that exercises it,
+   * and give it an `arguments` string DISTINCT from every other choice's. A
+   * colliding string is found in the scanned set and 8b stays silent — that
+   * collision is not hypothetical, it is mechanically how case 2 above hid.
+   *
+   * 🔴 THE MULTI-CHOICE ENVELOPE IS A COMPOSITION, AND THAT IS SAID PLAINLY. No
+   * single captured response carried more than one choice, because `n` defaults
+   * to 1. The composition is legitimate for what these clauses actually test —
+   * that the extractor PAIR agrees with itself on real message shapes — and it
+   * is what keeps the content path and every tool-call path covered at load
+   * instead of trading one for another. It is NOT a claim that the orchestrator
+   * emits four choices.
    */
   canonicalOutputFor: (): unknown => ({
     $type: 'chatCompletion',
@@ -1316,6 +1389,48 @@ export const chatCompletionStep = {
                   name: 'search_models',
                   arguments: '{"query":"DreamShaper checkpoint","limit":1}',
                 },
+              },
+            ],
+          },
+        },
+        // ADVERSARIAL 1 — empty `arguments`. Published (normalised to `'{}'`) by
+        // BOTH extractors on unmutated code, so containment still holds. Arms 8b
+        // against an `extractText` that re-applies a `trim().length > 0` filter:
+        // it would then drop this string while `extractToolCalls` still
+        // publishes the normalised `'{}'`, which is the divergence 8b exists for.
+        {
+          index: 2,
+          finishReason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_zeroargs00000000000000',
+                type: 'function',
+                function: { name: 'list_categories', arguments: '' },
+              },
+            ],
+          },
+        },
+        // ADVERSARIAL 2 — an `id` outside `TOOL_NAME_PATTERN` (dots), with
+        // arguments DISTINCT from every other string in this sample. Dropped by
+        // BOTH extractors on unmutated code, so containment still holds. Arms 8b
+        // against an `extractToolCalls` re-split and widened on the id axis: it
+        // would publish these arguments while `extractText` does not return
+        // them. 🔴 The distinctness is load-bearing — an arguments string that
+        // collided with another choice's would be found in the scanned set and
+        // 8b would stay silent, which is precisely how the pre-existing sample
+        // failed to arm it.
+        {
+          index: 3,
+          finishReason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call.with.dots',
+                type: 'function',
+                function: { name: 'get_model', arguments: '{"modelId":4384}' },
               },
             ],
           },

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -909,6 +909,25 @@ interface BlockStepBase<P> {
 // one rule.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * A structured tool call a `'textOutput'` step may publish alongside its text.
+ *
+ * Declared HERE rather than in the entry that produces one, for the same reason
+ * `StepOutputMedia` is: it is part of the registry's published surface — the
+ * snapshot field, the moderation module's verdict, and the wire type in
+ * `workflow.schema` all name it — and a per-entry definition would make the
+ * registry's contract depend on an entry.
+ *
+ * Fully populated by construction. An extractor that cannot fill every field
+ * DROPS the call rather than publishing a partial one, so a block never has to
+ * defend against a half-formed tool call.
+ */
+export type BlockStepToolCall = {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+};
+
 /** A step whose result is MEDIA — the pre-existing shape, unchanged. */
 type MediaOutputSurface = {
   /** Narrowed from `BlockStepBase`: every posture whose shape is `'media'`. */
@@ -935,6 +954,14 @@ type MediaOutputSurface = {
    * (clause 1c's reverse direction, at the type level).
    */
   extractText?: never;
+  /**
+   * FORBIDDEN, for the same reason and on the same axis. `extractToolCalls` is
+   * published by `attachModeratedStepTextOutputs` and ONLY on a released scan
+   * verdict — a media entry never reaches that function's text path, so an
+   * extractor here would be a declaration that reads as a capability and is
+   * never called.
+   */
+  extractToolCalls?: never;
 };
 
 /** A step whose result is generated FREE TEXT, published only through the scan. */
@@ -974,6 +1001,26 @@ type TextOutputSurface = {
    * gate stayed green. `never` is what makes that unwritable.
    */
   extractOutput?: never;
+  /**
+   * OPTIONAL structured tool calls the model requested, published to the block
+   * only when the scan RELEASES.
+   *
+   * 🔴 OPTIONAL, NOT REQUIRED, AND THE REASON IS NOT CONVENIENCE. Every
+   * `'textOutput'` entry publishes text; only some of them can request a tool.
+   * Making it required would force `mediaCaptioning` / `transcription` / `echo`
+   * to declare a `() => []` stub — exactly the vacuous declaration clause 8a
+   * exists to reject on the text axis. A field satisfiable by returning nothing
+   * is not a control.
+   *
+   * 🔴 IT IS NOT A SECOND PUBLICATION CHANNEL, AND THAT IS ENFORCED RATHER THAN
+   * PROMISED. `attachModeratedStepTextOutputs` calls this ONLY after the strings
+   * from `extractText` have been through the scan and RELEASED; a withheld
+   * verdict publishes neither. Clause 8b additionally asserts at load that every
+   * argument string this returns for `canonicalOutputFor(variant)` is ALSO
+   * returned by `extractText` — so an entry cannot use it to route model-written
+   * prose around the scan.
+   */
+  extractToolCalls?(step: unknown): BlockStepToolCall[];
 };
 
 /**
@@ -1917,6 +1964,67 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
           );
         }
       }
+
+      // (8b) THE TOOL-CALL CONTAINMENT CLAUSE — `extractToolCalls` may not
+      // publish a string the scan never saw.
+      //
+      // 🔴 WHAT IT IS FOR. `extractToolCalls` is published by
+      // `attachModeratedStepTextOutputs` on a RELEASED verdict, and that verdict
+      // is computed over `extractText`'s strings. So the gating is sound only
+      // while every model-written string reachable through the tool-call surface
+      // is also reachable through `extractText`. An entry whose `extractText`
+      // returned only `content` while `extractToolCalls` returned the model's
+      // `arguments` would publish argument prose on the strength of a scan that
+      // never read it — a fail-open with every other clause green, and exactly
+      // the shape clause 8-ii closes on the media axis.
+      //
+      // 🔴 WHAT IT CHECKS, STATED NARROWLY. It compares the ARGUMENTS only, and
+      // only for `canonicalOutputFor(variant)`. `id` and `type` are not prose,
+      // and `name` is required by the surface's own contract to be
+      // pattern-bounded rather than free text (an entry that widens its name
+      // charset owes a change here, which is why this comment names the
+      // assumption rather than leaving it implicit). Like clause 8a this is a
+      // SELF-CONSISTENT PAIR check against the entry's own canonical sample: it
+      // catches an extractor pair that disagrees, not one where both are wrong
+      // about the real response shape. `./type-contract` is the mitigation for
+      // that, same as clause 8a.
+      if (typeof step.extractToolCalls === 'function') {
+        const calls = step.extractToolCalls(sampleStep);
+        if (!Array.isArray(calls)) {
+          throw new Error(
+            `${vWhere}: extractToolCalls() returned a non-array — the read path would publish a ` +
+              'value it cannot iterate while the entry reports a tool-call surface'
+          );
+        }
+        const scanned = new Set(texts);
+        for (const call of calls) {
+          if (
+            call === null ||
+            typeof call !== 'object' ||
+            typeof call.function?.arguments !== 'string'
+          ) {
+            throw new Error(
+              `${vWhere}: extractToolCalls() returned a malformed call — a partial tool call ` +
+                'published to a block is a shape the block cannot defend against'
+            );
+          }
+          if (!scanned.has(call.function.arguments)) {
+            throw new Error(
+              `${vWhere}: extractToolCalls() publishes an arguments string that extractText() ` +
+                'does not return — it would reach the block on the strength of a scan that ' +
+                'never read it. Return every tool-call arguments string from extractText() too.'
+            );
+          }
+        }
+      }
+    } else if (step.extractToolCalls !== undefined) {
+      // The reverse direction, same shape as 1c's and 8-ii's. A media entry
+      // never reaches the text path, so an extractor here reads as a capability
+      // and is never called.
+      throw new Error(
+        `${vWhere}: declares extractToolCalls() but moderationPosture ` +
+          `'${step.moderationPosture}' publishes MEDIA — the extractor would never be called`
+      );
     }
   }
 

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -601,7 +601,31 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
 
   const released: string[] = [];
   const releasedToolCalls: BlockStepToolCall[] = [];
-  let withheldReason: string | undefined;
+
+  // ── 🔴 TWO REASON CHANNELS, NOT ONE, AND THE MERGE BELOW GIVES POLICY
+  //    PRECEDENCE. These are SEMANTICALLY OPPOSED values — one says the content
+  //    failed Civitai's policy, the other says explicitly that it did NOT — and
+  //    a single first-wins slot decided between them by STEP ORDER.
+  //
+  //    Measured on the pre-fix code, same content, scanner tripping `Young`:
+  //      [unpublishable, policy-hit] → "No content policy issue was found"  ← WRONG
+  //      [policy-hit, unpublishable] → "did not pass Civitai's content policy"
+  //    Opposite verdicts for the same workflow, chosen by which step came first.
+  //
+  //    🔴 BE EXACT ABOUT THE SEVERITY: the offending text was WITHHELD in both
+  //    orderings. This is a REASON-REPORTING defect, not a content leak — the
+  //    scan's release/withhold decision is per-step and was never in question.
+  //    What was wrong is the sentence the app author reads, and it was wrong in
+  //    the direction that matters: it told them nothing was moderated when
+  //    something was.
+  //
+  //    This was harmless until the round that introduced
+  //    `TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE`, because until then every candidate
+  //    value was the single constant `TEXT_OUTPUT_WITHHELD_MESSAGE` and
+  //    first-wins could not pick a wrong one. Adding a second, opposed value to
+  //    an existing first-wins slot is what created the defect.
+  let policyWithheldReason: string | undefined;
+  let unpublishableReason: string | undefined;
 
   for (const step of workflow.steps ?? []) {
     // Only REGISTERED step types have a declared posture. Everything else —
@@ -655,15 +679,48 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
       //
       // The reason is DISTINCT from the policy message on purpose: nothing was
       // moderated here. See `TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE`.
+      //
+      // 🔴 GATED ON THE STEP'S OWN TERMINAL STATUS, AND THAT GATE IS THE WHOLE
+      // DIFFERENCE BETWEEN A DIAGNOSTIC AND A LIE. This function runs on EVERY
+      // `pollWorkflow` and on `cancelWorkflow` — see this module's header — and
+      // the loop above iterates `workflow.steps` with no status filter of its
+      // own. A queued/processing chat step has no `output`, so `extractText`
+      // returns `[]` and the verdict releases empty, which is EXACTLY the shape
+      // this invariant fires on. Without the gate, a block polling a perfectly
+      // healthy in-flight generation was told, for the entire duration of that
+      // generation, that the response had "completed" with nothing to show —
+      // and a user-cancelled workflow got the same. Measured before this gate:
+      // a `processing` workflow and a `canceled` workflow both returned the
+      // message.
+      //
+      // `'succeeded'` and nothing else. The other terminal states —
+      // `failed` / `expired` / `canceled` — legitimately produce no output, and
+      // their absence is already explained by the workflow's own status; firing
+      // here would replace a correct explanation with a wrong one. The absent
+      // field is the right answer for every non-succeeded state, and it is what
+      // this path did before the invariant existed.
+      //
+      // Reading a `status` the orchestrator did not send yields `undefined`,
+      // which fails this test and therefore falls back to the pre-invariant
+      // behaviour (no field). That is the safe direction: silence, not a
+      // fabricated claim about a step whose state we could not read.
       if (
+        step.status === 'succeeded' &&
         postureRequiresTextExtraction(entry.moderationPosture) &&
         verdict.texts.length === 0 &&
         (verdict.toolCalls === undefined || verdict.toolCalls.length === 0)
       ) {
-        withheldReason ??= TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE;
+        unpublishableReason ??= TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE;
       }
-    } else withheldReason ??= verdict.reason;
+    } else policyWithheldReason ??= verdict.reason;
   }
+
+  // 🔴 POLICY WINS. A real content-policy withhold must never be masked by a
+  // sibling step's extraction failure: the two need different fixes, and only
+  // one of them is the app author's to make. Within each kind the merge stays
+  // first-wins, which is the pre-existing per-kind semantics — the change is
+  // that the two kinds no longer compete for one slot.
+  const withheldReason = policyWithheldReason ?? unpublishableReason;
 
   return {
     ...(rest as T),

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -344,6 +344,11 @@ const moderationPostureHandlers: Record<StepModerationPosture, StepModerationPha
                 c === null ||
                 typeof c !== 'object' ||
                 typeof c.id !== 'string' ||
+                // `type` is declared a LITERAL on `BlockStepToolCall`, so a value
+                // other than 'function' is a contract violation the block would
+                // have to defend against — check it like every other field
+                // rather than trusting the type to hold at runtime.
+                c.type !== 'function' ||
                 typeof c.function?.name !== 'string' ||
                 typeof c.function?.arguments !== 'string'
             )

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -6,12 +6,17 @@ import {
   getStepByOrchestratorType,
   isModerationPostureImplemented,
   posturePhaseRequirements,
+  postureRequiresTextExtraction,
   STEP_MODERATION_POSTURES,
   type AnyBlockStep,
   type BlockStepToolCall,
   type StepModerationPosture,
 } from './index';
-import { screenGeneratedText, TEXT_OUTPUT_WITHHELD_MESSAGE } from './text-output-moderation';
+import {
+  screenGeneratedText,
+  TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE,
+  TEXT_OUTPUT_WITHHELD_MESSAGE,
+} from './text-output-moderation';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MODERATION DISPATCH for the App Blocks step-type registry (`kind: 'step'`).
@@ -318,11 +323,13 @@ const moderationPostureHandlers: Record<StepModerationPosture, StepModerationPha
         });
 
         // 🔴 TOOL CALLS ARE ATTACHED ONLY ONTO A RELEASED VERDICT, AND ONLY
-        // HERE. The scan above ran over `extractText`'s strings, which registry
-        // clause 8b asserts already CONTAIN every arguments string
-        // `extractToolCalls` can return. So attaching them after a release
-        // publishes nothing the scan did not read, and a withheld verdict
-        // returns early below with no tool calls at all.
+        // HERE. The scan above ran over `extractText`'s strings, which already
+        // CONTAIN every arguments string `extractToolCalls` can return — held
+        // structurally by a shared predicate for `chat-completion`, and by
+        // registry clause 8b for any entry that open-codes the two extractors
+        // separately. So attaching them after a release publishes nothing the
+        // scan did not read, and a withheld verdict returns early below with no
+        // tool calls at all.
         //
         // 🔴 THE EARLY RETURN IS THE CONTROL, NOT AN OPTIMISATION. Writing this
         // as `{ ...verdict, toolCalls }` would attach the field to a WITHHELD
@@ -548,13 +555,22 @@ export type ModeratedTextOutputFields = {
  *
  * 🔴 THE SAME IS TRUE OF `toolCalls`, AND IT IS HELD BY A DIFFERENT MECHANISM
  * WORTH NAMING SEPARATELY. Tool calls are not scanned as structured objects —
- * the scan reads STRINGS. What makes publishing them safe is that registry
- * clause 8b asserts every `arguments` string `extractToolCalls` can return is
- * ALSO returned by `extractText`, so the released verdict was computed over
- * that text; and the posture handler attaches them only onto an already-released
- * verdict, never onto a withheld one. Take either half away and this becomes a
- * channel that publishes model-written prose on the strength of a scan that
- * never read it.
+ * the scan reads STRINGS. Publishing them is safe because of two things: every
+ * `arguments` string `extractToolCalls` can return is ALSO returned by
+ * `extractText`, so the released verdict was computed over that text; and the
+ * posture handler attaches them only onto an already-released verdict, never
+ * onto a withheld one. Take either half away and this becomes a channel that
+ * publishes model-written prose on the strength of a scan that never read it.
+ *
+ * 🔴 NAME THE RIGHT MECHANISM FOR THE FIRST HALF — an earlier revision credited
+ * registry clause 8b, and for `chat-completion` that is now stale. That entry
+ * derives BOTH extractors from one shared predicate, so containment holds
+ * STRUCTURALLY: no divergence is expressible without editing that function. 8b
+ * is what catches someone re-splitting it, and it remains the live check for any
+ * OTHER entry that open-codes two predicates. The safety conclusion is
+ * unchanged — if anything better supported, since a structural guarantee does
+ * not depend on a sample being rich enough to expose the divergence. Only the
+ * mechanism name was wrong.
  *
  * The incoming snapshot's own text fields are STRIPPED before merging, so a
  * caller that somehow arrived carrying text cannot smuggle it past the scan by
@@ -607,6 +623,45 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
     if (verdict.released) {
       released.push(...verdict.texts);
       if (verdict.toolCalls) releasedToolCalls.push(...verdict.toolCalls);
+
+      // ── 🔴 THE NO-SILENT-SUCCESS INVARIANT. ────────────────────────────────
+      //
+      // A text-posture step that SUCCEEDED and RELEASED, but contributed
+      // neither text nor a tool call, would leave the snapshot carrying none of
+      // `textOutputs` / `toolCalls` / `textOutputWithheld`. The step is CHARGED,
+      // reports `succeeded`, and publishes literally nothing the app author can
+      // act on — no output, and no reason for its absence.
+      //
+      // 🔴 THIS IS A STRUCTURAL INVARIANT, NOT A THIRD POINT-FIX, AND THE
+      // HISTORY IS WHY. The same silent-success class has now been reached
+      // three times by three different routes, each closed individually and
+      // each closure opening the next:
+      //   1. `extractText` required non-empty `arguments` while
+      //      `extractToolCalls` did not — fixed by aligning them;
+      //   2. aligning them by DROPPING empty-argument calls made a no-argument
+      //      tool call vanish — fixed by normalising `''` to `'{}'`;
+      //   3. the shared predicate then dropped calls on the `id`/`name` charset
+      //      axes on BOTH sides at once, which is unrepairable by normalisation
+      //      (an unusable id cannot be invented).
+      // Enumerating drop reasons has failed three times, so this does not
+      // enumerate them: it asserts the OUTCOME the entry owes a block,
+      // whatever the entry's extractors do now or later.
+      //
+      // 🔴 SCOPED TO TEXT POSTURES DELIBERATELY. A `'none'`/media entry legitimately
+      // contributes no text here — `runStepOutputModeration` returns an empty
+      // released verdict for it — so applying this to every registered entry
+      // would fire on `convert-image` in any mixed workflow and report an
+      // absence that is correct.
+      //
+      // The reason is DISTINCT from the policy message on purpose: nothing was
+      // moderated here. See `TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE`.
+      if (
+        postureRequiresTextExtraction(entry.moderationPosture) &&
+        verdict.texts.length === 0 &&
+        (verdict.toolCalls === undefined || verdict.toolCalls.length === 0)
+      ) {
+        withheldReason ??= TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE;
+      }
     } else withheldReason ??= verdict.reason;
   }
 

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -8,6 +8,7 @@ import {
   posturePhaseRequirements,
   STEP_MODERATION_POSTURES,
   type AnyBlockStep,
+  type BlockStepToolCall,
   type StepModerationPosture,
 } from './index';
 import { screenGeneratedText, TEXT_OUTPUT_WITHHELD_MESSAGE } from './text-output-moderation';
@@ -160,7 +161,7 @@ export type StepOutputModerationRequest = {
  * that did not come back through here cannot reach a block.
  */
 export type StepOutputModerationResult =
-  | { released: true; texts: string[] }
+  | { released: true; texts: string[]; toolCalls?: BlockStepToolCall[] }
   | { released: false; reason: string };
 
 type StepOutputModerationHandler = (
@@ -306,7 +307,7 @@ const moderationPostureHandlers: Record<StepModerationPosture, StepModerationPha
           return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
         }
 
-        return await screenGeneratedText({
+        const verdict = await screenGeneratedText({
           texts,
           userId,
           isGreen,
@@ -315,6 +316,45 @@ const moderationPostureHandlers: Record<StepModerationPosture, StepModerationPha
           stepId: step.id,
           model: step.orchestratorType,
         });
+
+        // 🔴 TOOL CALLS ARE ATTACHED ONLY ONTO A RELEASED VERDICT, AND ONLY
+        // HERE. The scan above ran over `extractText`'s strings, which registry
+        // clause 8b asserts already CONTAIN every arguments string
+        // `extractToolCalls` can return. So attaching them after a release
+        // publishes nothing the scan did not read, and a withheld verdict
+        // returns early below with no tool calls at all.
+        //
+        // 🔴 THE EARLY RETURN IS THE CONTROL, NOT AN OPTIMISATION. Writing this
+        // as `{ ...verdict, toolCalls }` would attach the field to a WITHHELD
+        // verdict too — where `attachModeratedStepTextOutputs` would ignore it
+        // today, and would publish it the moment anyone refactored that merge.
+        // The withhold path must not carry the value at all.
+        if (!verdict.released) return verdict;
+
+        const toolCalls = step.extractToolCalls?.(orchestratorStep);
+        // Same fail-closed posture as the extractor guard above: a malformed
+        // tool-call surface withholds rather than publishing a coerced value.
+        // Clause 8b probes the canonical sample; a REAL response can still
+        // produce a shape it never saw.
+        if (toolCalls !== undefined) {
+          if (
+            !Array.isArray(toolCalls) ||
+            toolCalls.some(
+              (c) =>
+                c === null ||
+                typeof c !== 'object' ||
+                typeof c.id !== 'string' ||
+                typeof c.function?.name !== 'string' ||
+                typeof c.function?.arguments !== 'string'
+            )
+          ) {
+            return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+          }
+        }
+
+        return toolCalls !== undefined && toolCalls.length > 0
+          ? { ...verdict, toolCalls }
+          : verdict;
       },
     },
   } satisfies Record<StepModerationPosture, StepModerationPhases>);
@@ -461,6 +501,14 @@ export async function runStepOutputModeration(
 export type ModeratedTextOutputFields = {
   textOutputs?: string[];
   textOutputWithheld?: { reason: string };
+  /**
+   * Structured tool calls the model requested, on a RELEASED verdict only.
+   *
+   * Same producer, same stripping and the same single-writer rule as
+   * `textOutputs` — see `attachModeratedStepTextOutputs`. Setting it anywhere
+   * else publishes model output the scan never released.
+   */
+  toolCalls?: BlockStepToolCall[];
 };
 
 /**
@@ -493,6 +541,16 @@ export type ModeratedTextOutputFields = {
  * `textOutputs` runs through the scan below, and the withhold branch simply
  * never writes the field.
  *
+ * 🔴 THE SAME IS TRUE OF `toolCalls`, AND IT IS HELD BY A DIFFERENT MECHANISM
+ * WORTH NAMING SEPARATELY. Tool calls are not scanned as structured objects —
+ * the scan reads STRINGS. What makes publishing them safe is that registry
+ * clause 8b asserts every `arguments` string `extractToolCalls` can return is
+ * ALSO returned by `extractText`, so the released verdict was computed over
+ * that text; and the posture handler attaches them only onto an already-released
+ * verdict, never onto a withheld one. Take either half away and this becomes a
+ * channel that publishes model-written prose on the strength of a scan that
+ * never read it.
+ *
  * The incoming snapshot's own text fields are STRIPPED before merging, so a
  * caller that somehow arrived carrying text cannot smuggle it past the scan by
  * pre-populating them. That is cheap, and it is what turns "nothing else sets
@@ -512,10 +570,16 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
   const {
     textOutputs: _ignoredIncomingTexts,
     textOutputWithheld: _ignoredIncomingWithheld,
+    // 🔴 STRIPPED FOR THE SAME REASON AS THE TWO ABOVE. A caller that arrived
+    // carrying tool calls must not be able to smuggle them past the scan by
+    // pre-populating the field — that is what turns "nothing else sets this
+    // field today" into "nothing else CAN".
+    toolCalls: _ignoredIncomingToolCalls,
     ...rest
   } = snapshot;
 
   const released: string[] = [];
+  const releasedToolCalls: BlockStepToolCall[] = [];
   let withheldReason: string | undefined;
 
   for (const step of workflow.steps ?? []) {
@@ -535,13 +599,16 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
       appId: ctx.appId,
       appBlockId: ctx.appBlockId,
     });
-    if (verdict.released) released.push(...verdict.texts);
-    else withheldReason ??= verdict.reason;
+    if (verdict.released) {
+      released.push(...verdict.texts);
+      if (verdict.toolCalls) releasedToolCalls.push(...verdict.toolCalls);
+    } else withheldReason ??= verdict.reason;
   }
 
   return {
     ...(rest as T),
     ...(released.length > 0 ? { textOutputs: released } : {}),
+    ...(releasedToolCalls.length > 0 ? { toolCalls: releasedToolCalls } : {}),
     ...(withheldReason ? { textOutputWithheld: { reason: withheldReason } } : {}),
   };
 }

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -534,10 +534,23 @@ export const TEXT_OUTPUT_WITHHELD_MESSAGE =
  * withhold without matching on the string, which is not a contract. If a
  * consumer ever needs to branch on the difference, that is the point to add a
  * discriminated reason code — not before.
+ *
+ * 🔴 IT SAYS "A STEP IN THIS RESPONSE", NOT "THIS RESPONSE", AND THAT IS NOT
+ * PEDANTRY. The condition is per-STEP; the field it lands in is per-SNAPSHOT.
+ * A workflow with two text steps can publish one and fail to publish the
+ * other, so the snapshot legitimately carries `textOutputs` AND this reason at
+ * once (`workflow.schema` documents that pairing). The earlier wording — "This
+ * response completed but contained nothing this app could display" — was then
+ * flatly contradicted by the `textOutputs` sitting beside it in the same
+ * object. Measured: a snapshot carrying `textOutputs: ["hello world"]` and a
+ * sentence asserting the response contained nothing.
+ *
+ * Any future reason written into a per-snapshot field must describe a
+ * per-snapshot fact, or scope itself the way this one now does.
  */
 export const TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE =
-  'This response completed but contained nothing this app could display. No content policy ' +
-  'issue was found; the model’s output did not include a usable text or tool-call result.';
+  'A step in this response completed but produced nothing this app could display. No content ' +
+  'policy issue was found; the model’s output did not include a usable text or tool-call result.';
 
 /**
  * How long to wait for the scan before giving up and FAILING CLOSED.

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -511,6 +511,35 @@ export const TEXT_OUTPUT_WITHHELD_MESSAGE =
   'This response was withheld because it did not pass Civitai’s content policy.';
 
 /**
+ * The reason surfaced when a text-posture step SUCCEEDED and passed the scan,
+ * but the entry could publish none of what it produced.
+ *
+ * 🔴 WHY THIS IS A SEPARATE CONSTANT AND NOT `TEXT_OUTPUT_WITHHELD_MESSAGE`.
+ * That message asserts the content failed Civitai's policy. In this case
+ * nothing did: the scan RELEASED, and the output was dropped by the entry's own
+ * extractor bounds (a provider `id` or tool `name` outside the published
+ * charset, a response carrying no publishable field at all). Reusing the policy
+ * message would tell the app author their content was moderated when it was
+ * not, and would make a real policy withhold indistinguishable from an
+ * extraction failure — the two need different fixes, so they need different
+ * words.
+ *
+ * 🔴 WHY IT REUSES THE `textOutputWithheld` FIELD RATHER THAN ADDING ONE. That
+ * field is already the "there was output and you are not getting it, here is
+ * why" channel, and a block that renders it shows this reason with no change.
+ * A new snapshot field would be a wire-surface addition the SDK has to mirror,
+ * for a case whose entire requirement is DIAGNOSABILITY.
+ *
+ * 🔴 HONEST LIMIT: a block cannot MACHINE-distinguish this from a policy
+ * withhold without matching on the string, which is not a contract. If a
+ * consumer ever needs to branch on the difference, that is the point to add a
+ * discriminated reason code — not before.
+ */
+export const TEXT_OUTPUT_UNPUBLISHABLE_MESSAGE =
+  'This response completed but contained nothing this app could display. No content policy ' +
+  'issue was found; the model’s output did not include a usable text or tool-call result.';
+
+/**
  * How long to wait for the scan before giving up and FAILING CLOSED.
  *
  * The scan is inline and blocking on a read path, so this is a user-visible


### PR DESCRIPTION
Widens the civitai edge so an App Block can submit a `chat-completion` step carrying `tools`, receive the model's `tool_calls`, and feed a tool **result** back for the next round. The orchestrator already supported all of this — the block was fenced off by three narrowings on this side.

## What changed

- **`chatMessageSchema` is now a discriminated union on `role`**, every member `.strict()`. `assistant` may carry `tool_calls` (needed to replay the turn that requested a tool) and must carry content, tool_calls, or both. `tool` carries `content` + a required `tool_call_id`.
- **`tools` / `toolChoice` on the params schema**, bounded: max 8 tools, pattern-bounded names, a description cap, and a `parameters` JSON Schema capped on serialized size **and** nesting depth.
- **`extractText` now returns each `tool_calls[].function.arguments`**, so model-written argument strings go through the same output scan as any other generated text.
- **A new optional `extractToolCalls` surface** publishes the structured calls, gated on the same scan verdict.

## Billing — the loop is bounded, `prepaidFixed` is unchanged

`MAX_TOOL_ROUNDS = 3`, enforced as a `superRefine` counting `role: 'tool'` messages.

**Why 3:** two rounds cover the shape this exists for — call a catalog tool, read the result, answer — and the third leaves room for one refinement when the first query comes back empty, which is the whole argument for real tool calling over a one-shot heuristic. Raising it is additive; lowering it is breaking. It sits far below the *incidental* ceiling `MAX_MESSAGES` already imposes (~15 rounds), because that ceiling is neither stated nor intentional.

**Why this keeps the mode honest:** there is **no server-side loop**. Each round is its own submit, so each gets its own live orchestrator quote, its own per-call `buzzBudget` gate and its own reservation against every cap — which is what "cost knowable before execution" actually requires. The bound is enforced at **parse**, so it holds on the estimate path as well as submit (both go through `parseStepParams`); a block cannot loop past a cap it applies to itself.

## Moderation — the new surfaces are covered, not silently widened

- Tool **arguments** are scanned, because `extractText` returns them.
- Structured tool calls are published **only** by `attachModeratedStepTextOutputs`, **only** onto a released verdict, and any incoming value of the field is **stripped** — the same single-writer property `textOutputs` has.
- **Containment holds BY CONSTRUCTION.** Both extractors derive from one shared predicate (`publishableToolCalls`), so `extractText` publishes exactly the `arguments` of the calls `extractToolCalls` returns and no divergence is expressible without editing that function.
  - ⚠️ **CORRECTED in audit round 3, and this is the second correction to the same sentence.** Round 2 claimed clause 8b "fires the moment anyone re-splits these predicates" and that the claim was **mutation-tested**. The mutation actually run (M5) was the *deletion* of `extractText`'s tool-arguments loop. Round 3 executed two **genuine re-splits** and both loaded **CLEAN**: restoring `extractText`'s pre-consolidation `trim().length > 0` predicate over raw arguments, and re-splitting `extractToolCalls` widened on the id axis — the latter being precisely the containment break 8b exists to catch. The description was wider than the implementation: the same defect class as the round-1 vacuous loop, one level up.
  - **Root cause was the SAMPLE, not the clause.** `canonicalOutputFor` carried one tool call with a conforming id, conforming name and non-empty arguments, so every divergence class this PR fixed was invisible to it. It now also carries a choice with **empty arguments** and one with an **out-of-charset id and distinct arguments**, each arming 8b against one class. On the final code all three mutants — both re-splits and the deletion — fire 8b's own error at registry load. The docstring now claims only that, and states that a re-split on an axis the sample does not cover would still pass.
  - 🔴 **Argument-string distinctness across choices is load-bearing.** A colliding `arguments` value is found in the scanned set and 8b goes silent — mechanically how the previous sample failed to arm it. Pinned by a test.
  - ⚠️ **CORRECTED after audit round 1.** As originally shipped this clause was **unreachable for `chat-completion`**: `canonicalOutputFor` returned a content-only sample, so the containment loop iterated an empty set and the invariant was asserted over nothing. Demonstrated by mutation — a real containment break in the shipped extractor loaded **clean**. The canonical sample now carries a real tool call and the clause executes; the same mutation now throws clause 8b's own message. The M2 row below is evidence about the synthetic registry fixture, not about the shipped entry.
- Tool **names and call ids** are not scanned. The unscanned published set is exactly `{name, id}`, enumerated in the code.
  - ⚠️ **CORRECTED in audit round 2.** This previously said the argument for both **is the same** and that neither **can carry prose**. Both claims were wrong. `name` rests on *two* legs — it is caller-authored and charset-enforced on input — while `id` is **provider-generated** and rests only on the extractor's pattern. And the pattern does not prevent prose: a 63-char underscore-joined sentence passes `[a-zA-Z0-9_-]{1,64}`. What it actually buys is a hard bound on length and alphabet (no markup, urls, AIR literals or whitespace), which is what makes the residue small enough to accept.
  - ⚠️ **CORRECTED after audit round 1.** This line originally enumerated the unscanned published set as **`{name}`** alone. `id` was missing from it and was, in fact, published **unbounded** — a 5,000-char id carrying prose and a literal AIR went through verbatim, and on a response whose `extractText` is empty the scanner was never invoked at all. `id` is now bounded exactly as `name` is. The unscanned published set is `{name, id}` and is enumerated in the code.

`moderationPosture` stays `'textOutput'`; `ACCEPTABLE_POSTURES_BY_TYPE` is untouched.

## Two things found while implementing

**The generated `@civitai/client` types cannot express a tool call.** `ChatCompletionInput.tool_choice`, `ChatCompletionTool.parameters` and `ChatCompletionFunction.parameters` are all typed `null` — a generator artifact for free-form JSON, contradicted by those fields' own doc comments (`tool_choice`'s says it "Can be \"auto\", \"none\", \"required\", or an object specifying a particular function"). Handled with a narrow, documented intersection that keeps every *other* field anchored to the generated type, rather than an `as` cast that would drop the anchor wholesale. If the generator is fixed upstream, delete it.

**The wire name is `tool_choice` (snake), the param is `toolChoice`.** This input mixes conventions — `maxTokens` is camelCase while every tool field follows OpenAI's snake_case. Getting it backwards does not error (an unknown field is ignored), so the feature would be silently inert; pinned by an exact-key-set test.

Separately: `tools[].function.parameters` is the **first `z.unknown()` param in this registry**, which is exactly the case `containsAirReference` documents as the point where its totality claim becomes reachable via `toJSON`-bearing instances. It is normalised through a JSON round-trip at parse, so what the AIR scan walks is byte-identical to what reaches the wire. A test demonstrates the hazard *and* the fix in both directions.

## Verification

**Red → green matrix.** Measured by reverting only the four source files to `origin/main` and re-running the new tests against pre-change code:

| | at `origin/main` | at HEAD |
|---|---|---|
| step suites + router moderation suite | **30 failed**, 295 passed | **325 passed** |

The 30 that go red are the regression tests. Named individually in the run log; they cover the round bound (both paths), the tool/assistant message members, `tool_choice` wire naming, `extractText` reading arguments, `extractToolCalls` in all its forms, clause 8b, the JSON normalisation, and the verdict-gating pair.

**Honest limits on the rest.** Some new cases pass at base and are **not** regression tests — they are forward guards, and they pass at base *for the wrong reason*: with `tools`/`toolChoice` absent from the schema, `.strict()` rejects the whole payload as an unknown key, and with no `'tool'` role the message is rejected by the enum. That covers `REJECTS a bad toolChoice value`, the name-charset / description-length / non-object-`parameters` / unknown-property cases, and `REJECTS a tool message with no tool_call_id`. They are worth keeping — they pin the bounds now that the fields exist — but they prove nothing about the change.

One case, `accepts exactly MAX_TOOL_ROUNDS tool messages`, **degenerated** at base: the named import resolved to `undefined`, so `Array.from({ length: undefined })` produced an empty array and the fixture collapsed to a single user message. Second commit adds a guard pinning `MAX_TOOL_ROUNDS === 3` so that cannot happen silently again.

**Mutation results** — each guard broken on purpose, on a reachable input:

| # | mutation | result |
|---|---|---|
| M1 | round-bound condition → `false` | **killed** (2: submit + estimate cases) |
| M2 | clause 8b containment → `false` | **killed** (1, on its own message) |
| M3 | withhold path carries `toolCalls` | 🔴 **SURVIVED** — see below |
| M3c | M3 **plus** the merge pushes unconditionally | **killed** (2, incl. the withhold case) |
| M4 | stop stripping incoming `toolCalls` | **killed** (1) |
| M5 | bypass the JSON normalisation | **killed** (1) |
| M6 | drop the name pattern in the extractor | **killed** (1) |
| M7 | `extractText` stops returning arguments | **killed** (2, incl. the containment case) |

🔴 **M3 survived, and it is reported rather than smoothed over.** Making the *withhold* path carry tool calls changes nothing observable, because `attachModeratedStepTextOutputs`'s merge ignores them on a withheld verdict — a second, independent layer. So the property "withheld ⇒ no tool calls" has genuine depth-2 protection and no single-point mutation breaks it. M3c confirms the test is not vacuous: break **both** layers and the withhold case goes red. The early return is therefore defence against a future refactor of that merge, which is what its comment claims — not the sole control.

**Suite-wide:** `pnpm typecheck` → 0 errors (watched go red→green: 12 → 0 while fixing a missing submodule). `vitest run --project unit*` over `blocks/`, `routers/__tests__/`, `schema/` → **261 files, 5920 tests, all passing**. `eslint` on the touched files → 0 errors (1 pre-existing unused-import warning, present at `origin/main`).

## Not done

- **No tool transport route.** Nothing here fetches a tool; the block calls the tool itself and submits the next round.
- **No sensei integration**, and the client-side heuristic is untouched.
- **No server-side loop**, deliberately — see the billing section.
- **SDK mirror follow-up needed.** `toolCalls` is additive on the snapshot type that `@civitai/app-sdk`'s `blocks/types.ts` mirrors. Nothing here edits another repo, so a block cannot read the field until that type is widened in the SDK — same posture as `textOutputs` and `modelSubstitutions` before it.
- **One thing to confirm before this is useful in prod:** the wire spelling of `tool_choice` is taken from the generated client type, which is the contract this repo pins. The prior live probe recorded that a tools payload is parsed and priced, but did not record the exact request key for the choice field. Worth one `whatif` against the live orchestrator to confirm before relying on `toolChoice: 'required'` behaving as requested — an ignored field fails silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit round 2 — what changed

A blind delta re-audit of the round-1 fixes found one regression **the round-1 fix itself introduced**, plus two prose defects.

- 🔴 **A no-argument tool call vanished.** Round 1 aligned the two extractors by *dropping* empty `arguments`. Measured end to end against the registered entry: a response whose only choice was a tool call with `arguments: ''` produced a snapshot with **neither `textOutputs` nor `toolCalls` nor `textOutputWithheld`** — charged, `succeeded`, publishing nothing diagnosable.

  | | `extractText` | `extractToolCalls` | snapshot |
  |---|---|---|---|
  | before | `[]` | 0 | `{workflowId, status}` |
  | after | `["{}"]` | 1 | `{…, textOutputs:["{}"], toolCalls:[…]}` |

  Empty/whitespace arguments are now **normalised to `'{}'`**. This loosens nothing: containment compares published arguments against the *scanned* set, and a whitespace-only string carries nothing a scanner can read. `'{}'` is also the only value a consumer can use — `JSON.parse('')` throws.

- **The real fix is consolidation.** The predicate had been open-coded at two sites and was wrong at one of them three separate ways: the empty-arguments divergence, the drop-the-call regression that replaced it, and the ID axis — a non-conforming provider id made `extractToolCalls` drop the whole call while `extractText` still published its arguments, handing a block argument JSON in `textOutputs`, an empty `toolCalls`, and no id to answer with. One predicate now, two consumers.

- **Input and output agreed to disagree about ids.** `call:with:colons` parsed on input while the extractor refused it on output. Reconciled toward the stricter definition, which cannot reject a legitimate payload: the only id a block can replay is one we published.

- **`MAX_TOOL_ROUNDS` prose (N3).** The comment calling an unanswered ask "legal" was a statement about *this schema's acceptance* worded as a claim about the *provider*. Rewritten, with the three accepted shapes recorded as a known unvalidated gap. **No guard added deliberately** — the premise comes from the OpenAI-compatible contract, not a probe against this orchestrator, and a guard on an unverified premise risks being *too strict*, which is the worse failure: the gap costs a charged submit, a wrong guard costs a working feature refused at parse.

### Round-2 mutation results

| mutant | outcome |
|---|---|
| M1 revert normalisation | killed — only the normalise test |
| M2 drop `id` charset | killed — CHARSET-only test; LENGTH-only survives |
| M3 drop `id` length | killed — LENGTH-only test; CHARSET-only survives |
| M4 diverge `extractText` | killed — the orphan-arguments test |
| M5 smuggle after the shared helper | killed — clause 8b fires at registry **load** |
| M6 drop assistant `id` regex | killed *(after the test was fixed — see below)* |
| M7 drop `tool_call_id` regex | 🔴 **SURVIVED** |
| M8 drop both id regexes | killed |

**M7 is reported, not hidden.** It is a true property of the code: every payload that could violate that regex is already rejected by the assistant-side regex or by the correlation guard, so it is defence-in-depth no test can isolate. The docstring now says exactly that rather than implying coverage.

**M6 initially survived, and the cause was the test just written for it** — it carried both an assistant `id` and a matching `tool_call_id`, each separately bounded, so removing either regex alone was masked by the other. Fixed with an assistant-only payload where nothing else can do the rejecting.

**Test attribution.** The headline id test used a fixture that was 4,900+ chars **and** contained spaces and colons, so the pattern and length mutants each died to it individually and it could not tell you which guard was load-bearing. Split into pairwise-distinct fixtures; the combined case is kept as the end-to-end regression and labelled non-attributing.

`typecheck` 0 errors; **5931 tests** pass across the blocks, router and schema suites.

## Audit round 3 — what changed

Delta round 5 confirmed all five round-2 claims fixed, and the M6/M7 reports accurate. It found two substantive residuals, both fixed here (`a8dedefa19`).

**N2 — clause 8b's stated coverage was refuted by execution.** See the corrected bullet above. Sample extended; all three mutants now fire.

**The canonical sample is now 2 CAPTURED choices + 2 declared ADVERSARIAL ones**, and the docstring says so. The previous "every choice is copied verbatim from a real orchestrator response" banner became false the moment adversarial values were added, and a stale verbatim claim over invented data is worse than none. The both-wrong-blind argument is intact because every *shape* is still captured; only *values* vary.

**N1 — the silent-success class had been moved and widened, for the third round running.** A malformed `id` or `name` is dropped by the shared predicate on both sides, so with the measured `finishReason: 'tool_calls'` shape (no `content` key) the response yields nothing anywhere: charged, `succeeded`, and publishing none of `textOutputs` / `toolCalls` / `textOutputWithheld`.

Enumerating drop reasons has failed three times, so this round does not enumerate them. `attachModeratedStepTextOutputs` now asserts the **outcome**: a text-posture step that released while contributing neither text nor tool calls surfaces a reason. Scoped to text postures deliberately — a media entry contributes no text legitimately, and widening it would report that correct absence as a fault on any mixed workflow.

The reason is a **distinct constant**, not `TEXT_OUTPUT_WITHHELD_MESSAGE`: nothing failed the content policy here, and reusing the policy message would mislead the app author *and* make a real withhold indistinguishable from an extraction failure. Honest limit recorded in code: the two are not machine-separable without matching on the string.

**N3 — the input `id` regex justification overclaimed.** It said the tightening "cannot reject a legitimate payload"; hand-authored few-shot tool-call history may use any id, and `call.1` / `call:1` now `BAD_REQUEST`. Reworded to the true guarantee — *cannot reject a payload derived from our own output* — with the accepted cost stated.

**The `tool_call_id` charset regex was REMOVED rather than documented.** Round 5 proved it changes no accept/reject outcome (`declaredCallIds` is populated only from already-bounded assistant ids), so its one observable effect was replacing the correlation guard's useful diagnostic with a zod regex issue. The length bound stays — it bounds the payload before correlation runs.

**N4/N5 — two stale clause-8b attributions scoped.** "8b can no longer fail for a divergence reason" is true of *this entry*, not the clause, which stays live for any entry open-coding two predicates. `moderation.ts` credited 8b as what makes publishing safe; for `chat-completion` the mechanism is now structural. Safety conclusion unchanged, mechanism name corrected.

### Two existing tests changed expectation, both deliberately

- The canonical-sample test asserted **every choice was captured**, which stopped being true. It now pins the **split**, with both halves pinned so neither drifts silently.
- The empty-extraction test asserted `textOutputWithheld` was **also** undefined — i.e. it encoded the silent-success behaviour. Its safety assertions (nothing scanned, nothing published) are untouched; only the diagnosability expectation flipped.

### A test that was passing for the wrong reason

`tools` was listed among "orchestrator input fields this entry does not expose". This PR **exposes** `tools`; the entry stayed green only because its fixture value was `[]`, which fails the schema's `.min(1)` bound. A green run would have told a reader tools were still rejected. Removed, with the reason recorded. `tool_choice` (snake_case) deliberately stays — the exposed param is `toolChoice`, and that distinction matters while the wire spelling is unconfirmed.

### Round-3 mutation results

| mutant | outcome |
|---|---|
| M-F re-split `extractText` to its pre-consolidation predicate | **silent → now fires** clause 8b's own error at load |
| M-K re-split `extractToolCalls`, widened on the id axis | **silent → now fires** clause 8b's own error at load |
| M-J delete `extractText`'s tool-arguments loop | fires (unchanged) |
| remove the no-silent-success invariant | exactly the **3** unpublishable cases red; all **3** controls green |
| widen the invariant's posture gate to every entry | exactly the **scoping control** red |

No survivors this round. Each read by failing-test name and assertion text, never by exit code.

`typecheck` 0 errors; **4412 tests / 177 files** green; prettier clean on all five changed files (the pre-existing 4 violations went too); eslint clean apart from the unused-`dbMock` warning already present at `main`.

🔴 **Still unproven and unchanged:** the `tool_choice` wire key has never been confirmed against a live orchestrator request. An ignored field fails silently.



---

## Round 4 — two regressions the previous round's own fix introduced

The round-3 no-silent-success invariant was correct in intent and wrong in two ways, both in the same three lines. Found by delta re-audit, both reproduced by execution before and after.

### F1 — the invariant fired on steps that had not finished

`attachModeratedStepTextOutputs` runs on **every** `pollWorkflow` and on `cancelWorkflow`, and its loop iterates `workflow.steps` with no status filter. A queued/processing chat step has no `output`, so `extractText` returns `[]` and the verdict releases empty — exactly the shape the invariant fires on.

Consequence: a block polling a perfectly healthy in-flight generation was told, **for the whole duration of that generation**, that the response had "completed" with nothing to display. A user-cancelled workflow got the same.

Now gated on the step's own `status === 'succeeded'`. `failed` / `expired` / `canceled` legitimately produce no output and are already explained by the workflow's own status — firing there would replace a correct explanation with a wrong one. An unreadable status falls back to the pre-invariant absent field, which is the safe direction.

### F2 — a real policy withhold could be masked, and reported as its own opposite

The reason slot was first-wins. That was provably harmless while every candidate value was the single constant `TEXT_OUTPUT_WITHHELD_MESSAGE`; round 3 put a second, **semantically opposed** value into the same slot without changing the merge. Step ORDER then decided which of two contradictory sentences the author read:

| step order | reason reported (pre-fix) |
|---|---|
| `[unpublishable, policy-hit]` | *"No content policy issue was found"* — **wrong**, a policy hit occurred |
| `[policy-hit, unpublishable]` | *"did not pass Civitai's content policy"* — correct |

Same content, same scanner verdict, opposite conclusions. Now two channels with **policy taking precedence**; within each kind the merge stays first-wins, preserving the pre-existing per-kind semantics.

🔴 **Severity, stated precisely:** the offending text was **withheld in both orderings**. This was a *reason-reporting* defect, not a content leak — but it pointed the app author away from the real cause, which is the direction that matters.

### F3 / F4 / F5

- **F3** — the message made a whole-response claim that a sibling step's `textOutputs` contradicted **in the same object**. The condition is per-step, the field is per-snapshot; the reason is now scoped to *"a step in this response"*.
- **F4** — `textOutputWithheld`'s wire-contract doc described only the withhold cause; both halves of that sentence are false on the unpublishable path. It now enumerates both causes, records that they are **not machine-separable** without string matching, and notes the status gate. This is the doc the `@civitai/app-sdk` mirror-writer and block authors read.
- **F5** — the third stale clause-8b attribution. Corrected to state what actually enforces containment here: a **shared predicate, structurally**, with clause 8b a load-time backstop only as wide as the shapes its canonical sample exercises.

### The fixtures were the root cause of F1 going unnoticed

Every step fixture in the suite carried **no `status` field at all**, though `WorkflowStep.status` is **required** on the generated `@civitai/client` type. A fixture omitting it is not orchestrator-shaped, and every test built on it was blind to the difference between a step that succeeded with no output and one that had simply not run yet. All fixtures now carry an explicit status, with a `runningChatStep` helper for the non-terminal case.

### F2's test needs both orderings, and here is why

The existing `A POLICY WITHHOLD KEEPS ITS OWN REASON` case uses **one** step and structurally **cannot** see this defect — with a single step there is no second candidate to win the slot. The new test asserts both orderings.

### Round-4 measurements

Before → after, same probe file against both trees:

| probe | before | after |
|---|---|---|
| `processing` workflow, un-run step | spurious *"response completed…"* | **no field** |
| `canceled` workflow, un-run step | spurious *"response completed…"* | **no field** |
| `[unpublishable, policy-hit]` | *"No content policy issue was found"* | policy message |
| `[policy-hit, unpublishable]` | policy message | policy message |
| publishable + unpublishable | *"This response completed…"* beside `textOutputs` | *"A step in this response…"* |
| single publishable step (control) | publishes | publishes (unchanged) |

Mutants — **no survivors**:

| mutant | outcome |
|---|---|
| drop the status gate | exactly the **4** F1 cases red, each by name |
| flip the precedence | **both** F2 orderings red |
| restore the single first-wins slot (the exact pre-fix defect) | **only** `unpublishable FIRST` red — the **isolating** mutant |
| revert the message wording | the F3 case red |

`typecheck` 0 errors (143s, heap cap named); **4419 tests / 177 files** green; prettier clean on all four changed files, verified against a **negative control** confirming prettier can still report a violation; eslint clean apart from the pre-existing unused-`dbMock` warning.

🔴 **Still unproven and unchanged:** the `tool_choice` wire key has never been confirmed against a live orchestrator request.


---

## Round 5 (docs only) — `be3255cca4`

The round-4 note on `textOutputWithheld` was itself wrong, and a delta audit caught it.

It read: *"CAUSE 2 IS GATED ON THE STEP'S OWN `succeeded` STATUS, so an in-flight or cancelled generation does NOT set this field."* **Only cause 2 is gated.** In `steps/moderation.ts` the `step.status === 'succeeded'` test guards the unpublishable branch inside the released arm; the withheld branch is the plain `else` beside it, with no status test. So a **cancelled generation can still set this field** — the orchestrator returns whatever text it had already produced, that text is still scanned, and a hit still withholds it.

Not a reading: a shipped, passing test already pinned it. `blocks.router.textOutputModeration.test.ts` cancels a workflow whose step succeeded and asserts `textOutputWithheld` **is** set.

This matters because the same doc block says, three paragraphs above, that it is what the `@civitai/app-sdk` mirror-writer and block authors read. A consumer who believed the old sentence and skipped rendering `reason` on cancel would **suppress a real content-policy explanation**.

The true half of the old note is kept, with its actual reason: a block polling a healthy in-flight generation does still see the field absent — not by status, but because a step that has produced no text yet reaches **neither** cause (`screenGeneratedText` short-circuits to RELEASED on an empty text set, and cause 2 additionally needs `succeeded`). The new wording deliberately says nothing about whether the orchestrator populates `output` on a still-running step: that was never verified, and no clause depends on it.

Also completed cause 1's sub-enumeration, which listed only a policy hit and a scanner error/timeout. **Seven** paths return that one message: over-cap, memo replay, scanner error, no-verdict, label-drift, label-error, and the policy hit.

🔴 This clause has now been wrong **twice**, both times by describing the *field* when the code only ever gated *one of its two causes*. The replacement carries a note to check each cause separately before editing it again.

**Docs only — no behaviour change, no new guard.** `typecheck` 0 errors (165s, heap cap named); **4419 tests / 177 files** green; the named cancel test re-run under a filter (1 passed / 11 skipped) with a zero-match control proving the filter discriminates; prettier clean on the changed file, with **two** negative controls — one confirming the invocation goes red on that exact file, one confirming `"All matched files use Prettier code style!"` also prints on a **zero-match** glob.
