### PR TITLE
fix(auth): preserve email local-part case during verification

### DIFF
--- a/apps/auth/src/routes/login/email/verify/+server.ts
+++ b/apps/auth/src/routes/login/email/verify/+server.ts
@@ -4,6 +4,7 @@ import { SYNC_PARAM } from '@civitai/auth';
 import type { RequestHandler } from './$types';
 import { consumeVerificationToken } from '$lib/server/auth/email-tokens';
 import { findOrCreateUserByEmail } from '$lib/server/auth/users';
+import { normalizeEmailAddress } from '$lib/server/auth/blocklist';
 import { establishSession } from '$lib/server/auth/session';
 import { buildPostLoginRedirect } from '$lib/server/auth/redirect';
 import { buildPostLoginOriginCheck } from '$lib/server/oauth/first-party';
@@ -12,7 +13,8 @@ import { loginsTotal } from '$lib/server/metrics';
 // Magic-link landing: validate + consume the token, establish the session, honor returnUrl/sync.
 export const GET: RequestHandler = async ({ url, cookies }) => {
   const token = url.searchParams.get('token');
-  const email = url.searchParams.get('email')?.toLowerCase();
+  const rawEmail = url.searchParams.get('email');
+  const email = rawEmail ? normalizeEmailAddress(rawEmail) : null;
   const returnUrl = url.searchParams.get('returnUrl') ?? '/';
   const sync = url.searchParams.get(SYNC_PARAM);
 

--- a/apps/auth/src/routes/login/email/verify/__tests__/server.test.ts
+++ b/apps/auth/src/routes/login/email/verify/__tests__/server.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  consumeVerificationToken: vi.fn().mockResolvedValue(true),
+  findOrCreateUserByEmail: vi.fn().mockResolvedValue({ id: 7 }),
+  establishSession: vi.fn().mockResolvedValue(undefined),
+  buildPostLoginOriginCheck: vi.fn().mockResolvedValue(() => true),
+}));
+
+vi.mock('$lib/server/auth/email-tokens', () => ({
+  consumeVerificationToken: h.consumeVerificationToken,
+}));
+vi.mock('$lib/server/auth/users', () => ({
+  findOrCreateUserByEmail: h.findOrCreateUserByEmail,
+}));
+vi.mock('$lib/server/auth/session', () => ({ establishSession: h.establishSession }));
+vi.mock('$lib/server/oauth/first-party', () => ({
+  buildPostLoginOriginCheck: h.buildPostLoginOriginCheck,
+}));
+// `normalizeEmailAddress` is pure, but its blocklist module also exposes DB-backed helpers.
+// Keep the real normalizer in this route test while preventing that unrelated DB module from booting.
+vi.mock('$lib/server/db/db', () => ({ db: {} }));
+
+import { GET } from '../+server';
+
+function makeEvent(email: string) {
+  const url = new URL('https://auth.civitai.com/login/email/verify');
+  url.searchParams.set('token', 'valid-token');
+  url.searchParams.set('email', email);
+
+  return { url, cookies: {} } as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.consumeVerificationToken.mockResolvedValue(true);
+  h.findOrCreateUserByEmail.mockResolvedValue({ id: 7 });
+  h.establishSession.mockResolvedValue(undefined);
+  h.buildPostLoginOriginCheck.mockResolvedValue(() => true);
+});
+
+describe('email magic-link verification', () => {
+  it('preserves uppercase characters in the local part when validating the issued token', async () => {
+    await expect(GET(makeEvent('User@Example.COM'))).rejects.toMatchObject({ status: 302 });
+
+    expect(h.consumeVerificationToken).toHaveBeenCalledWith('User@example.com', 'valid-token');
+    expect(h.findOrCreateUserByEmail).toHaveBeenCalledWith('User@example.com');
+  });
+});


### PR DESCRIPTION
## Summary

- Use the shared email normalizer when processing email magic-link verification links.
- Preserve the email local-part casing while normalizing the domain.
- Add route-level regression coverage for mixed-case email addresses.

## Problem

Email magic-link verification failed when the submitted address contained uppercase characters in its local part.

For example, submitting `User@Example.COM` created a verification token with the normalized identifier `User@example.com`. However, the verification endpoint lowercased the entire address from the link and attempted to validate the token against `user@example.com`.

Because `VerificationToken.identifier` is stored as case-sensitive text, the valid token could not be found.

## Root cause

Token issuance and token verification used different email-normalization rules:

- Issuance used `normalizeEmailAddress()`, which preserves the local part and normalizes the domain.
- Verification used `.toLowerCase()`, which modified both parts of the address.

The `User.email` column is case-insensitive, but that does not help because token validation happens first against the case-sensitive verification-token identifier.

## Fix

The verification endpoint now uses `normalizeEmailAddress()` as well. This ensures token creation and consumption derive the same identifier without incorrectly changing the local part.

Existing lowercase-email behavior remains unchanged, and previously issued mixed-case links will validate correctly after deployment.

## Testing

- `pnpm --filter @civitai/auth-app test`
  - 38 test files passed
  - 386 tests passed
- `pnpm --filter @civitai/auth-app check`
  - 0 errors
- Prettier check passed
- `git diff --check` passed