### PR TITLE
fix(images): stop writing Image rows for media that was never stored

### DIFF
--- a/packages/civitai-shared/package.json
+++ b/packages/civitai-shared/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./media-key": "./src/media-key.ts",
     "./basemodel.constants": "./src/basemodel.constants.ts",
     "./lazy": "./src/lazy.ts",
     "./type-guards": "./src/type-guards.ts",

--- a/packages/civitai-shared/src/media-key.ts
+++ b/packages/civitai-shared/src/media-key.ts
@@ -1,0 +1,47 @@
+/**
+ * The single rule for "may this `Image.url` be handed to our media store as an object key?".
+ *
+ * 🔴 It lives here because it was open-coded twice, by OPPOSITE construction, and the two answers
+ * disagreed on real rows. One spelling asked "does it carry a URI scheme?" and probed everything
+ * else; the other asked "is it a bare uuid?" and probed only that. For `some-file.png` the first
+ * probes, gets a 404, and PERMANENTLY refuses a moderator publish; the second never asks. A
+ * predicate open-coded at two call sites regenerates the same bug at both, so there is one copy and
+ * both call sites import it.
+ *
+ * 🔴 THE OBVIOUS JUSTIFICATION FOR THIS TEST IS FALSE, AND THAT MATTERS FOR HOW IT IS READ.
+ * It is NOT true that every legitimate bucket key in `Image.url` is a uuid. Every key-MINTING site
+ * is a bare `crypto.randomUUID()` with no prefix and no extension — `src/pages/api/v1/image-upload/
+ * index.ts`, `.../multipart/index.ts`, `uploadImageBufferToStore` in `src/utils/s3-utils.ts`, the
+ * orchestrator poll/polyGen handlers, the app-listing asset service and the comics router's own
+ * upload paths — but several WRITE paths accept a caller-supplied string and never check its shape:
+ * seven `comics.router.ts` call sites validate the url with `z.string().min(1)`, and the article
+ * `edge-media` sync (`article-content-cleanup.service.ts`) copies the attribute verbatim from
+ * sanitized HTML, where the sanitizer does not filter a custom attribute named `url`. Any of those
+ * can put `foo/uuid`, `photo.jpg` or `12345` into the column.
+ *
+ * So this is a deliberate UNDER-approximation: it matches the shape our upload endpoints issue, and
+ * classifies everything else as "not something to ask this bucket about". The direction is chosen
+ * from what each error COSTS, not from what is most accurate:
+ *
+ *   - a false NEGATIVE (a real key we decline to probe) costs a detection we would otherwise have
+ *     made — the caller falls back to whatever it did before the check existed;
+ *   - a false POSITIVE (a non-key we probe) costs a 404 that is indistinguishable from a genuine
+ *     miss, and the acting call site turns that into a PERMANENT, un-overridable refusal to publish
+ *     an image that may render fine.
+ *
+ * The heterogeneous, unvalidated population above is exactly where a 404 against our bucket is not
+ * evidence of loss, so it must not be probed by a check whose `absent` verdict enforces anything.
+ *
+ * Relation to the write validators: this is strictly BROADER than zod's `.uuid()` (it accepts an
+ * invalid version nibble), so every value `imageSchema`/`addPostImageSchema` admits as a key passes
+ * here. That is the sound direction — the guard never declines a key the schema called a key.
+ *
+ * A url carrying a URI scheme (`http:`, `https:`, `blob:`, `data:`) fails this test for free: none
+ * of them is a uuid. That is intentional and is why the older scheme-negative spelling was dropped
+ * rather than kept alongside — its complement swept in every legacy oddball above.
+ */
+const MEDIA_KEY_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isProbeableMediaKey(url: unknown): url is string {
+  return typeof url === 'string' && MEDIA_KEY_RE.test(url);
+}

--- a/src/components/Bounty/BountyEntryUpsertForm.tsx
+++ b/src/components/Bounty/BountyEntryUpsertForm.tsx
@@ -109,7 +109,10 @@ export function BountyEntryUpsertForm({ bountyEntry, bounty }: Props) {
 
   const handleDropImages = async (droppedFiles: File[]) => {
     for (const file of droppedFiles) {
-      uploadToCF(file);
+      // See BountyUpsertForm: fire-and-forget, and `uploadToCF` now rejects on a
+      // refused PUT, so the promise has to be attached or every 403 is an unhandled
+      // rejection. The hook marks the tracked file `error`, which is what renders.
+      uploadToCF(file).catch(() => undefined);
     }
   };
 

--- a/src/components/Bounty/BountyUpsertForm.tsx
+++ b/src/components/Bounty/BountyUpsertForm.tsx
@@ -148,7 +148,12 @@ export function BountyUpsertForm({ bounty }: { bounty?: BountyGetById }) {
 
   const handleDropImages = async (droppedFiles: File[]) => {
     for (const file of droppedFiles) {
-      uploadToCF(file);
+      // Fire-and-forget by design — the UI reads progress/state off `imageFiles`, not
+      // off this promise. `uploadToCF` now REJECTS on a refused PUT (403/400/503)
+      // instead of resolving as if it had worked, so an unattached promise would be an
+      // unhandled rejection on every such failure. The tracked file is already marked
+      // `error` by the hook, which is what this component renders.
+      uploadToCF(file).catch(() => undefined);
     }
   };
 

--- a/src/components/Challenge/ChallengeSubmitModal.tsx
+++ b/src/components/Challenge/ChallengeSubmitModal.tsx
@@ -569,7 +569,11 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
             <Stack gap="md" py="md">
               <MediaDropzone
                 onDrop={(args) => {
-                  args.forEach(({ file }) => uploadToCF(file));
+                  // Attached: `uploadToCF` now rejects on a refused PUT (403/400/503)
+                  // instead of resolving as if it had worked, and this is
+                  // fire-and-forget. The hook marks the tracked file `error`, which is
+                  // what `uploadedFiles` below renders.
+                  args.forEach(({ file }) => uploadToCF(file).catch(() => undefined));
                 }}
                 accept={[...IMAGE_MIME_TYPE, ...VIDEO_MIME_TYPE]}
                 disabled={remainingEntries === 0}

--- a/src/components/Comics/PanelModal.tsx
+++ b/src/components/Comics/PanelModal.tsx
@@ -479,27 +479,40 @@ export function PanelModal({
   const handleBulkImageDrop = async (files: File[]) => {
     if (files.length === 0) return;
     setBulkUploading(true);
+    /**
+     * 🔴 DECLARED OUTSIDE THE `try`, AND COMMITTED IN THE `finally`. RESTORED.
+     *
+     * This invariant was established deliberately: the commit used to sit at the end of
+     * the `try`, so one throw past it discarded the WHOLE batch — the panels that had
+     * already uploaded fine included. Extracting the loop into `uploadBulkPanels` moved
+     * `items` back inside the `try` and deleted the comment saying why it must not be
+     * there, which silently weakened the invariant. No reachable thrower was found between
+     * the upload and the commit today, so this was not a live regression — but "no
+     * reachable thrower today" is exactly the claim that stops being true when someone adds
+     * a line here, and the failure mode is silent data loss the user already saw succeed.
+     *
+     * 🔴 NOT PINNED BY A TEST, and it cannot cheaply be: driving it needs `PanelModal`
+     * mounted, which takes ~40 required props plus the Buzz hooks, feature flags, a tRPC
+     * query, dnd-kit and `dialogStore` — the very reason the loop was extracted. The loop's
+     * own failure policy IS pinned, in `bulk-panel-upload.browser.test.tsx`; this ordering
+     * is held by the shape of the code and by this comment.
+     */
+    let landed: BulkPanelItem[] = [];
     try {
       /**
        * 🔴 THE LOOP LIVES IN `bulk-panel-upload.ts`, AND ITS FAILURE POLICY IS DECIDED
        * THERE — read that file, not this handler, for why one refused PUT does not end
-       * the batch. It was moved out because it is the half of this component that needed
-       * an executed test and could not have one while it was inline: `PanelModal` takes
-       * ~40 required props and pulls in the Buzz hooks, feature flags, a tRPC query,
-       * dnd-kit and `dialogStore`.
+       * the batch.
        *
        * `uploadBulkPanels` does not throw on a refused upload — it returns the panels that
        * landed and the files that did not. The `try` here is for the unexpected only.
        */
       const { items, failed } = await uploadBulkPanels({ files, uploadToCF: uploadBulkToCF });
-
-      // Commit BEFORE reporting: the panels that uploaded are kept whatever else happened.
-      // A first-file failure leaves `items` empty, so this is a no-op rather than a
-      // spurious state write.
-      if (items.length > 0) setBulkItems((prev) => [...prev, ...items].slice(0, 20));
+      landed = items;
 
       // 🔴 Names the files and the count. The whole-loop `catch` this replaces showed one
-      // "Failed to upload image" naming neither, over a batch of up to 20.
+      // "Failed to upload image" naming neither, over a batch of up to 20. Reporting sits
+      // INSIDE the try on purpose: if it throws, the `finally` still commits `landed`.
       const report = batchUploadFailureNotification(failed, files.length);
       if (report) showErrorNotification(report);
     } catch (err) {
@@ -507,6 +520,9 @@ export function PanelModal({
       // reaches here; a genuine defect still should be surfaced rather than swallowed.
       showErrorNotification({ error: err as Error, title: 'Failed to upload image' });
     } finally {
+      // 🔴 The panels that DID upload are kept, on every path. `landed` is empty when the
+      // first file failed, so this is a no-op rather than a spurious state write.
+      if (landed.length > 0) setBulkItems((prev) => [...prev, ...landed].slice(0, 20));
       setBulkUploading(false);
     }
   };

--- a/src/components/Comics/PanelModal.tsx
+++ b/src/components/Comics/PanelModal.tsx
@@ -60,7 +60,6 @@ import { batchUploadFailureNotification } from '~/utils/upload-batch';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { fetchAndUploadGeneratorImage } from '~/utils/comic-image-picker';
-import { getMetadata } from '~/utils/metadata';
 import { trpc } from '~/utils/trpc';
 import { useComicsQueueStatus } from '~/components/Comics/hooks/useComicsQueueStatus';
 import styles from '~/pages/comics/project/[id]/ProjectWorkspace.module.scss';

--- a/src/components/Comics/PanelModal.tsx
+++ b/src/components/Comics/PanelModal.tsx
@@ -377,6 +377,11 @@ export function PanelModal({
         width: dims.width,
         height: dims.height,
       });
+    } catch (err) {
+      // `uploadToCF` now REJECTS on a refused PUT (403/400/503) rather than resolving
+      // as if it had worked. Without this catch the rejection escapes this async
+      // dropzone handler unhandled and the user is told nothing at all.
+      showErrorNotification({ error: err as Error, title: 'Failed to upload image' });
     } finally {
       setEnhanceUploading(false);
     }
@@ -518,6 +523,11 @@ export function PanelModal({
         });
       }
       setBulkItems((prev) => [...prev, ...newItems].slice(0, 20));
+    } catch (err) {
+      // Same as the enhance drop above: a refused PUT now rejects, and this handler
+      // had no catch — the whole batch was discarded silently and the rejection
+      // escaped. Keep the partial batch behaviour, but say something.
+      showErrorNotification({ error: err as Error, title: 'Failed to upload image' });
     } finally {
       setBulkUploading(false);
     }

--- a/src/components/Comics/PanelModal.tsx
+++ b/src/components/Comics/PanelModal.tsx
@@ -478,8 +478,16 @@ export function PanelModal({
   const handleBulkImageDrop = async (files: File[]) => {
     if (files.length === 0) return;
     setBulkUploading(true);
+    /**
+     * 🔴 DECLARED OUTSIDE THE `try`, and committed in the `finally`.
+     *
+     * The commit used to sit at the end of the `try`, after the loop, so one refused PUT
+     * threw past it and discarded the WHOLE batch — including the panels that had already
+     * uploaded fine. The comment claiming "keep the partial batch behaviour" described
+     * the opposite of what the code did.
+     */
+    const newItems: BulkPanelItem[] = [];
     try {
-      const newItems: BulkPanelItem[] = [];
       for (const file of files) {
         const img = new window.Image();
         const objectUrl = URL.createObjectURL(file);
@@ -522,13 +530,15 @@ export function PanelModal({
           meta: extractedMeta,
         });
       }
-      setBulkItems((prev) => [...prev, ...newItems].slice(0, 20));
+      // Nothing after the loop — the commit is in `finally` so it runs on both paths.
     } catch (err) {
       // Same as the enhance drop above: a refused PUT now rejects, and this handler
-      // had no catch — the whole batch was discarded silently and the rejection
-      // escaped. Keep the partial batch behaviour, but say something.
+      // had no catch — the rejection escaped and the user was told nothing.
       showErrorNotification({ error: err as Error, title: 'Failed to upload image' });
     } finally {
+      // 🔴 The panels that DID upload are kept. `newItems` is empty when the first file
+      // fails, so this is a no-op in that case rather than a spurious state write.
+      if (newItems.length > 0) setBulkItems((prev) => [...prev, ...newItems].slice(0, 20));
       setBulkUploading(false);
     }
   };

--- a/src/components/Comics/PanelModal.tsx
+++ b/src/components/Comics/PanelModal.tsx
@@ -55,6 +55,8 @@ import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { showErrorNotification } from '~/utils/notifications';
+import { uploadBulkPanels } from '~/components/Comics/bulk-panel-upload';
+import { batchUploadFailureNotification } from '~/utils/upload-batch';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { fetchAndUploadGeneratorImage } from '~/utils/comic-image-picker';
@@ -478,67 +480,34 @@ export function PanelModal({
   const handleBulkImageDrop = async (files: File[]) => {
     if (files.length === 0) return;
     setBulkUploading(true);
-    /**
-     * 🔴 DECLARED OUTSIDE THE `try`, and committed in the `finally`.
-     *
-     * The commit used to sit at the end of the `try`, after the loop, so one refused PUT
-     * threw past it and discarded the WHOLE batch — including the panels that had already
-     * uploaded fine. The comment claiming "keep the partial batch behaviour" described
-     * the opposite of what the code did.
-     */
-    const newItems: BulkPanelItem[] = [];
     try {
-      for (const file of files) {
-        const img = new window.Image();
-        const objectUrl = URL.createObjectURL(file);
-        const dims = await new Promise<{ width: number; height: number }>((resolve, reject) => {
-          img.onload = () => {
-            resolve({ width: img.naturalWidth, height: img.naturalHeight });
-            URL.revokeObjectURL(objectUrl);
-          };
-          img.onerror = () => {
-            URL.revokeObjectURL(objectUrl);
-            reject(new Error('Failed to load image'));
-          };
-          img.src = objectUrl;
-        }).catch(() => ({ width: 512, height: 512 }));
+      /**
+       * 🔴 THE LOOP LIVES IN `bulk-panel-upload.ts`, AND ITS FAILURE POLICY IS DECIDED
+       * THERE — read that file, not this handler, for why one refused PUT does not end
+       * the batch. It was moved out because it is the half of this component that needed
+       * an executed test and could not have one while it was inline: `PanelModal` takes
+       * ~40 required props and pulls in the Buzz hooks, feature flags, a tRPC query,
+       * dnd-kit and `dialogStore`.
+       *
+       * `uploadBulkPanels` does not throw on a refused upload — it returns the panels that
+       * landed and the files that did not. The `try` here is for the unexpected only.
+       */
+      const { items, failed } = await uploadBulkPanels({ files, uploadToCF: uploadBulkToCF });
 
-        // Try to extract embedded generation metadata (Automatic1111 /
-        // ComfyUI / SwarmUI / RuinedFooocus PNG tags) so we can attribute
-        // the panel's Image to whatever model produced the upload. Failures
-        // here are non-fatal — we just continue without meta.
-        let extractedMeta: Record<string, unknown> | undefined;
-        try {
-          const parsed = await getMetadata(file);
-          if (parsed && Object.keys(parsed).length > 0) extractedMeta = parsed;
-        } catch (err) {
-          console.error('Failed to extract metadata from uploaded image:', err);
-        }
+      // Commit BEFORE reporting: the panels that uploaded are kept whatever else happened.
+      // A first-file failure leaves `items` empty, so this is a no-op rather than a
+      // spurious state write.
+      if (items.length > 0) setBulkItems((prev) => [...prev, ...items].slice(0, 20));
 
-        const result = await uploadBulkToCF(file);
-        newItems.push({
-          id: `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-          sourceImage: {
-            url: result.id,
-            cfId: result.id,
-            width: dims.width,
-            height: dims.height,
-            preview: getEdgeUrl(result.id, { width: 120 }) ?? result.id,
-          },
-          prompt: '',
-          aspectRatio: '3:4',
-          meta: extractedMeta,
-        });
-      }
-      // Nothing after the loop — the commit is in `finally` so it runs on both paths.
+      // 🔴 Names the files and the count. The whole-loop `catch` this replaces showed one
+      // "Failed to upload image" naming neither, over a batch of up to 20.
+      const report = batchUploadFailureNotification(failed, files.length);
+      if (report) showErrorNotification(report);
     } catch (err) {
-      // Same as the enhance drop above: a refused PUT now rejects, and this handler
-      // had no catch — the rejection escaped and the user was told nothing.
+      // Anything the per-file policy did NOT already handle. A refused PUT no longer
+      // reaches here; a genuine defect still should be surfaced rather than swallowed.
       showErrorNotification({ error: err as Error, title: 'Failed to upload image' });
     } finally {
-      // 🔴 The panels that DID upload are kept. `newItems` is empty when the first file
-      // fails, so this is a no-op in that case rather than a spurious state write.
-      if (newItems.length > 0) setBulkItems((prev) => [...prev, ...newItems].slice(0, 20));
       setBulkUploading(false);
     }
   };

--- a/src/components/Comics/PanelModal.tsx
+++ b/src/components/Comics/PanelModal.tsx
@@ -480,22 +480,24 @@ export function PanelModal({
     if (files.length === 0) return;
     setBulkUploading(true);
     /**
-     * 🔴 DECLARED OUTSIDE THE `try`, AND COMMITTED IN THE `finally`. RESTORED.
+     * 🔴 "PANELS THAT UPLOADED ARE KEPT" IS GUARANTEED IN TWO PLACES, AND THIS IS THE
+     * SECOND, NARROWER ONE. Read both before moving either.
      *
-     * This invariant was established deliberately: the commit used to sit at the end of
-     * the `try`, so one throw past it discarded the WHOLE batch — the panels that had
-     * already uploaded fine included. Extracting the loop into `uploadBulkPanels` moved
-     * `items` back inside the `try` and deleted the comment saying why it must not be
-     * there, which silently weakened the invariant. No reachable thrower was found between
-     * the upload and the commit today, so this was not a live regression — but "no
-     * reachable thrower today" is exactly the claim that stops being true when someone adds
-     * a line here, and the failure mode is silent data loss the user already saw succeed.
+     * The batch can be lost at two different points, and only one of them is here:
      *
-     * 🔴 NOT PINNED BY A TEST, and it cannot cheaply be: driving it needs `PanelModal`
-     * mounted, which takes ~40 required props plus the Buzz hooks, feature flags, a tRPC
-     * query, dnd-kit and `dialogStore` — the very reason the loop was extracted. The loop's
-     * own failure policy IS pinned, in `bulk-panel-upload.browser.test.tsx`; this ordering
-     * is held by the shape of the code and by this comment.
+     * - INSIDE the loop, i.e. a throw while file N is being processed. `landed` cannot help
+     *   there: it is assigned only after `uploadBulkPanels` returns as a WHOLE, so a throw
+     *   that escaped the loop would leave it `[]` and the finally would commit nothing.
+     *   That case is owned by `bulk-panel-upload.ts`, whose per-file `try` spans the whole
+     *   loop body so the function always returns the panels that landed — pinned by
+     *   `bulk-panel-upload.browser.test.tsx`.
+     * - AFTER the loop, i.e. a throw between `uploadBulkPanels` returning and the commit —
+     *   today only the reporting call below. That is what declaring `landed` outside the
+     *   `try` and committing it in the `finally` buys, and it is why the commit must not be
+     *   moved back to the end of the `try`. It is held by the shape of the code and by this
+     *   comment, not by a test: driving it needs `PanelModal` mounted, which takes ~40
+     *   required props plus the Buzz hooks, feature flags, a tRPC query, dnd-kit and
+     *   `dialogStore` — the very reason the loop was extracted in the first place.
      */
     let landed: BulkPanelItem[] = [];
     try {
@@ -520,8 +522,10 @@ export function PanelModal({
       // reaches here; a genuine defect still should be surfaced rather than swallowed.
       showErrorNotification({ error: err as Error, title: 'Failed to upload image' });
     } finally {
-      // 🔴 The panels that DID upload are kept, on every path. `landed` is empty when the
-      // first file failed, so this is a no-op rather than a spurious state write.
+      // 🔴 The panels that DID upload are kept whether the reporting above threw or not.
+      // A throw from INSIDE the loop is not covered here — `uploadBulkPanels` owns that,
+      // see the block above. `landed` is empty when every file failed, so this is a no-op
+      // rather than a spurious state write.
       if (landed.length > 0) setBulkItems((prev) => [...prev, ...landed].slice(0, 20));
       setBulkUploading(false);
     }

--- a/src/components/Comics/ProjectSettingsModal.tsx
+++ b/src/components/Comics/ProjectSettingsModal.tsx
@@ -26,6 +26,7 @@ import type { ComicGenre } from '~/shared/utils/prisma/enums';
 import { getImageDimensions } from '~/utils/image-utils';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { openGeneratorImagePicker } from '~/utils/comic-image-picker';
+import { showErrorNotification } from '~/utils/notifications';
 import styles from '~/pages/comics/project/[id]/ProjectWorkspace.module.scss';
 
 const ImageSelectModal = dynamic(() => import('~/components/Training/Form/ImageSelectModal'), {
@@ -120,10 +121,22 @@ export function ProjectSettingsModal({
         onConfirm: async (output: { src: string; cropped?: Blob }[]) => {
           const blob = output[0]?.cropped;
           const uploadFile = blob ? new File([blob], 'cover.jpg', { type: blob.type }) : file;
-          const result = await uploadToCF(uploadFile);
-          setEditCoverUrl(result.id);
-          setEditCoverImageId(null);
-          URL.revokeObjectURL(url);
+          /**
+           * 🔴 `finally`, because `uploadToCF` now REJECTS on a refused PUT. `onConfirm`
+           * is typed `() => void` and the modal discards the promise, so a rejection
+           * skipped the revoke and `onCancel` can no longer run — the blob was retained
+           * for the page's lifetime. The catch also surfaces the failure, which the
+           * dropped promise otherwise swallowed entirely.
+           */
+          try {
+            const result = await uploadToCF(uploadFile);
+            setEditCoverUrl(result.id);
+            setEditCoverImageId(null);
+          } catch (error) {
+            showErrorNotification({ title: 'Upload failed', error: error as Error });
+          } finally {
+            URL.revokeObjectURL(url);
+          }
         },
         onCancel: () => URL.revokeObjectURL(url),
       },
@@ -132,9 +145,13 @@ export function ProjectSettingsModal({
 
   const handleHeroDrop = async (files: File[]) => {
     if (files.length === 0) return;
-    const result = await uploadHeroToCF(files[0]);
-    setEditHeroUrl(result.id);
-    setEditHeroImageId(null);
+    try {
+      const result = await uploadHeroToCF(files[0]);
+      setEditHeroUrl(result.id);
+      setEditHeroImageId(null);
+    } catch (error) {
+      showErrorNotification({ title: 'Upload failed', error: error as Error });
+    }
   };
 
   const handlePickCoverFromGenerator = () =>

--- a/src/components/Comics/bulk-panel-upload.browser.test.tsx
+++ b/src/components/Comics/bulk-panel-upload.browser.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  BULK_PANEL_FALLBACK_DIMENSIONS,
+  uploadBulkPanels,
+} from '~/components/Comics/bulk-panel-upload';
+
+/**
+ * `PanelModal`'s bulk panel drop, after a REFUSED presigned PUT part-way through a batch.
+ *
+ * 🔴 THE CLAIM THIS PINS, which round 2 flagged as reviewed-by-reading only: a refused PUT
+ * on file 2 of N must NOT abandon files 3..N. The handler used to wrap the whole loop in
+ * one `try`, so the first rejection left the loop and every later file was silently never
+ * attempted, under a single `Failed to upload image` toast naming no file and no count.
+ * `character.tsx`'s identically-shaped reference loop got the opposite remedy in the same
+ * round (per-file `catch` + `continue`). Two shapes, one question, two answers.
+ *
+ * Lives in the `component` (real Chromium) project rather than the node `unit` one because
+ * the loop reads each file's natural size through `window.Image` + `URL.createObjectURL`.
+ * Running it in a real browser keeps that half of the code under test instead of stubbing
+ * the thing that decides each panel's dimensions.
+ *
+ * `uploadToCF` is the only injected dependency, and it is injected because it is a React
+ * hook's method — the metadata reader and the edge-url builder are the production imports.
+ */
+
+/** A real, decodable 2x2 PNG, so `readDimensions` resolves rather than falling back. */
+const PNG_2X2 = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAACddGYaAAAAFUlEQVR4nGP8z8DAwMDAxMDAwMAAAA8AAf8Ct4gAAAAASUVORK5CYII='
+  ),
+  (c) => c.charCodeAt(0)
+);
+
+const png = (name: string) => new File([PNG_2X2 as BlobPart], name, { type: 'image/png' });
+
+describe('uploadBulkPanels — one refused PUT must not end the batch', () => {
+  test('the first file lands, the second is refused, and the THIRD is still attempted', async () => {
+    /**
+     * 🔴 THREE files, not two, and the assertion is on the third.
+     *
+     * With two files a "stops on failure" implementation and a "continues" one are
+     * indistinguishable when the failure is last, and nearly so when it is first. Failing
+     * the MIDDLE one makes the difference observable: a stopping loop calls `uploadToCF`
+     * twice and returns one item; a continuing loop calls it three times and returns two.
+     */
+    const uploadToCF = vi
+      .fn<(file: File) => Promise<{ id: string }>>()
+      .mockResolvedValueOnce({ id: 'key-one' })
+      .mockRejectedValueOnce(new Error('Upload failed (status 403)'))
+      .mockResolvedValueOnce({ id: 'key-three' });
+
+    const { items, failed } = await uploadBulkPanels({
+      files: [png('a.png'), png('b.png'), png('c.png')],
+      uploadToCF,
+    });
+
+    expect(uploadToCF).toHaveBeenCalledTimes(3);
+    expect(items.map((item) => item.sourceImage?.cfId)).toEqual(['key-one', 'key-three']);
+    expect(failed).toEqual([
+      { name: 'b.png', error: expect.objectContaining({ message: 'Upload failed (status 403)' }) },
+    ]);
+  });
+
+  test('it REPORTS the failure rather than swallowing it', async () => {
+    // The mirror of the case above: continuing must not mean "pretend nothing happened".
+    // `failed` is what the handler turns into the notification, so an empty `failed` on a
+    // refused PUT is the silent-failure bug wearing a different hat.
+    const uploadToCF = vi
+      .fn<(file: File) => Promise<{ id: string }>>()
+      .mockRejectedValue(new Error('Upload failed (status 503)'));
+
+    const { items, failed } = await uploadBulkPanels({
+      files: [png('only.png')],
+      uploadToCF,
+    });
+
+    expect(items).toEqual([]);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].name).toBe('only.png');
+    expect(failed[0].error.message).toBe('Upload failed (status 503)');
+  });
+
+  test('POSITIVE CONTROL: a clean batch produces a panel per file and no failures', async () => {
+    /**
+     * 🔴 Without this, every assertion above is satisfiable by a loop that returns nothing
+     * and reports everything as failed. It also pins that the real `window.Image` decode
+     * ran: a 2x2 PNG must come back as 2x2, NOT as the 512x512 fallback — so a change that
+     * broke dimension reading would show up here rather than shipping panels sized wrong.
+     */
+    const uploadToCF = vi
+      .fn<(file: File) => Promise<{ id: string }>>()
+      .mockImplementation(async (file) => ({ id: `key-${file.name}` }));
+
+    const { items, failed } = await uploadBulkPanels({
+      files: [png('a.png'), png('b.png')],
+      uploadToCF,
+    });
+
+    expect(failed).toEqual([]);
+    expect(items).toHaveLength(2);
+    expect(items[0].sourceImage).toMatchObject({ cfId: 'key-a.png', width: 2, height: 2 });
+    expect(items[0].sourceImage?.width).not.toBe(BULK_PANEL_FALLBACK_DIMENSIONS.width);
+    expect(items[1].sourceImage).toMatchObject({ cfId: 'key-b.png' });
+  });
+
+  test('an UNDECODABLE file still uploads, at the fallback size', async () => {
+    // Pre-existing behaviour, pinned so the `continue` above cannot be widened into
+    // "skip anything that is not a valid image". The dimension read fails; the upload does
+    // not, so the panel is still worth creating.
+    const uploadToCF = vi
+      .fn<(file: File) => Promise<{ id: string }>>()
+      .mockResolvedValue({ id: 'key-junk' });
+
+    const { items, failed } = await uploadBulkPanels({
+      files: [new File(['not an image'], 'junk.png', { type: 'image/png' })],
+      uploadToCF,
+    });
+
+    expect(failed).toEqual([]);
+    expect(items).toHaveLength(1);
+    expect(items[0].sourceImage).toMatchObject({
+      cfId: 'key-junk',
+      width: BULK_PANEL_FALLBACK_DIMENSIONS.width,
+      height: BULK_PANEL_FALLBACK_DIMENSIONS.height,
+    });
+  });
+});

--- a/src/components/Comics/bulk-panel-upload.browser.test.tsx
+++ b/src/components/Comics/bulk-panel-upload.browser.test.tsx
@@ -26,7 +26,7 @@ import {
 /** A real, decodable 2x2 PNG, so `readDimensions` resolves rather than falling back. */
 const PNG_2X2 = Uint8Array.from(
   atob(
-    'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAACddGYaAAAAFUlEQVR4nGP8z8DAwMDAxMDAwMAAAA8AAf8Ct4gAAAAASUVORK5CYII='
+    'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg=='
   ),
   (c) => c.charCodeAt(0)
 );

--- a/src/components/Comics/bulk-panel-upload.browser.test.tsx
+++ b/src/components/Comics/bulk-panel-upload.browser.test.tsx
@@ -124,4 +124,63 @@ describe('uploadBulkPanels — one refused PUT must not end the batch', () => {
       height: BULK_PANEL_FALLBACK_DIMENSIONS.height,
     });
   });
+
+  test('a throw from OUTSIDE the upload call keeps the panels that already landed', async () => {
+    /**
+     * 🔴 THE INVARIANT `PanelModal` USED TO HOLD IN A `finally`, NOW HELD HERE.
+     *
+     * The handler assigns its `landed` only once `uploadBulkPanels` has returned as a
+     * whole, so anything that escapes this loop discards every panel that already uploaded
+     * — uploads the user watched succeed. The per-file `try` therefore spans the whole loop
+     * body, not just `uploadToCF`.
+     *
+     * Driven through a REAL escape hatch rather than an invented one: `readDimensions`
+     * calls `URL.createObjectURL` outside every `try` in that helper, so a synchronous
+     * throw from it rejects the awaited promise. Stubbing it for exactly one file's name
+     * reproduces that without touching the module under test.
+     *
+     * The failure is on the FIRST of three files on purpose — `items` is empty at that
+     * point, so the case also pins that a wide `try` does not simply mean "swallow": the
+     * loop must go on to upload b and c and must report a.
+     */
+    const realCreateObjectURL = URL.createObjectURL.bind(URL);
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation((blob: Blob | MediaSource) => {
+        if ((blob as File).name === 'a.png') throw new Error('createObjectURL refused a.png');
+        return realCreateObjectURL(blob);
+      });
+
+    try {
+      const uploadToCF = vi
+        .fn<(file: File) => Promise<{ id: string }>>()
+        .mockImplementation(async (file) => ({ id: `key-${file.name}` }));
+
+      const { items, failed } = await uploadBulkPanels({
+        files: [png('a.png'), png('b.png'), png('c.png')],
+        uploadToCF,
+      }).catch((err: unknown) => {
+        // The mutant's signature. `uploadBulkPanels` returns partials by contract; when it
+        // throws instead, the caller's `landed` stays `[]` and b + c are lost silently.
+        throw new Error(
+          'uploadBulkPanels must not throw on a mid-loop failure — the panels that already ' +
+            `uploaded are discarded when it does. It threw: ${(err as Error).message}`
+        );
+      });
+
+      // b and c still uploaded, and their panels came back.
+      expect(uploadToCF).toHaveBeenCalledTimes(2);
+      expect(items.map((item) => item.sourceImage?.cfId)).toEqual(['key-b.png', 'key-c.png']);
+
+      // …and a was REPORTED, not silently dropped.
+      expect(failed).toEqual([
+        {
+          name: 'a.png',
+          error: expect.objectContaining({ message: 'createObjectURL refused a.png' }),
+        },
+      ]);
+    } finally {
+      createObjectURL.mockRestore();
+    }
+  });
 });

--- a/src/components/Comics/bulk-panel-upload.ts
+++ b/src/components/Comics/bulk-panel-upload.ts
@@ -30,7 +30,11 @@ export const BULK_PANEL_FALLBACK_DIMENSIONS = { width: 512, height: 512 } as con
 export type BulkPanelUploadResult = {
   /** The panels that uploaded, in drop order. */
   items: BulkPanelItem[];
-  /** One entry per file whose upload was refused, in drop order. */
+  /**
+   * One entry per file that did not produce a panel, in drop order — normally a refused
+   * upload, but any throw raised while processing that file lands here too rather than
+   * escaping and taking the whole batch with it.
+   */
   failed: BatchUploadFailure[];
 };
 
@@ -77,43 +81,55 @@ export async function uploadBulkPanels({
   const failed: BatchUploadFailure[] = [];
 
   for (const file of files) {
-    const dims = await readDimensions(file);
-    const meta = await readMeta(file);
-
     /**
-     * 🔴 PER FILE, WITH `continue` — the same remedy `character.tsx`'s reference loop got.
+     * 🔴 PER FILE, AND AROUND THE WHOLE BODY — the same remedy `character.tsx`'s reference
+     * loop got, plus the width that makes `items` survivable.
      *
-     * This loop originally had no catch at all, then a whole-loop one. Both stop the batch
-     * on the first refused PUT: files 3–10 are never attempted, and the user is told
-     * "Failed to upload image" with no file named and no count. Stopping is not obviously
-     * wrong, but it was never a decision — it was the shape a `try` around the whole loop
-     * happens to have. Two identically-shaped loops must not have two different answers to
-     * one question, so both continue, and the caller reports the failures it is handed.
+     * Two separate reasons this `try` is shaped the way it is:
      *
-     * Scoped to the upload alone: the dimension read and the metadata read above already
-     * swallow their own failures and cannot reach here.
+     * 1. PER FILE, so one refused PUT does not end the batch. This loop originally had no
+     *    catch at all, then a whole-loop one. Both stop on the first refusal: files 3–10 are
+     *    never attempted, and the user is told "Failed to upload image" with no file named
+     *    and no count. Stopping was never a decision — it was the shape a `try` around the
+     *    whole loop happens to have. Two identically-shaped loops must not have two
+     *    different answers to one question, so both continue, and the caller reports the
+     *    failures it is handed.
+     *
+     * 2. AROUND THE WHOLE BODY, so nothing thrown while processing file N can discard the
+     *    panels files 1..N−1 already uploaded. `uploadBulkPanels` returns `items` by value
+     *    and its caller assigns them only after it returns as a whole, so a throw that
+     *    escapes this loop is silent data loss for uploads the user watched succeed. The
+     *    narrower "upload only" version of this `try` used to carry a comment claiming the
+     *    reads above "cannot reach here"; that was false — `URL.createObjectURL` in
+     *    `readDimensions` sits outside every `try` in that helper, and a synchronous throw
+     *    from it rejects the awaited promise. Unlikely, but the point of the wide `try` is
+     *    that a future line added anywhere in this body is covered by construction rather
+     *    than by re-deriving that argument.
+     *
+     * Pinned by `bulk-panel-upload.browser.test.tsx` — both the refused-PUT case and the
+     * mid-loop-throw case, the latter by making `URL.createObjectURL` throw on one file.
      */
-    let result: { id: string };
     try {
-      result = await uploadToCF(file);
+      const dims = await readDimensions(file);
+      const meta = await readMeta(file);
+      const result = await uploadToCF(file);
+
+      items.push({
+        id: `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        sourceImage: {
+          url: result.id,
+          cfId: result.id,
+          width: dims.width,
+          height: dims.height,
+          preview: getEdgeUrl(result.id, { width: 120 }) ?? result.id,
+        },
+        prompt: '',
+        aspectRatio: '3:4',
+        meta,
+      });
     } catch (error) {
       failed.push({ name: file.name, error: error as Error });
-      continue;
     }
-
-    items.push({
-      id: `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      sourceImage: {
-        url: result.id,
-        cfId: result.id,
-        width: dims.width,
-        height: dims.height,
-        preview: getEdgeUrl(result.id, { width: 120 }) ?? result.id,
-      },
-      prompt: '',
-      aspectRatio: '3:4',
-      meta,
-    });
   }
 
   return { items, failed };

--- a/src/components/Comics/bulk-panel-upload.ts
+++ b/src/components/Comics/bulk-panel-upload.ts
@@ -1,0 +1,120 @@
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import type { BulkPanelItem } from '~/components/Comics/comic-project-constants';
+import { getMetadata } from '~/utils/metadata';
+import type { BatchUploadFailure } from '~/utils/upload-batch';
+
+/**
+ * The bulk-panel drop loop, lifted out of `PanelModal` so its control flow can be driven
+ * by a test.
+ *
+ * 🔴 WHY IT LIVES HERE. The policy this loop implements — *keep going when one file is
+ * refused, and report which ones were* — is the finding the round-2 audit raised, and it
+ * was previously unexercised by anything: `PanelModal` takes ~40 required props and pulls
+ * in the Buzz account hooks, feature flags, a tRPC query, dnd-kit and `dialogStore`, so
+ * "reviewed by reading" was the honest label for it. As a module function it is driven
+ * directly, with a real `File`, a real `URL.createObjectURL` and the real metadata reader.
+ *
+ * `uploadToCF` is a parameter because it is a React hook's method; everything else is the
+ * production import.
+ */
+
+/**
+ * What a panel falls back to when the browser cannot decode the dropped file.
+ *
+ * Pre-existing behaviour, kept: an undecodable image still uploads, and the server sizes
+ * it later. Named rather than inlined so the test asserting the fallback is not restating
+ * a literal from the implementation it tests.
+ */
+export const BULK_PANEL_FALLBACK_DIMENSIONS = { width: 512, height: 512 } as const;
+
+export type BulkPanelUploadResult = {
+  /** The panels that uploaded, in drop order. */
+  items: BulkPanelItem[];
+  /** One entry per file whose upload was refused, in drop order. */
+  failed: BatchUploadFailure[];
+};
+
+/** Decode the file just far enough to read its natural size. */
+async function readDimensions(file: File): Promise<{ width: number; height: number }> {
+  const img = new window.Image();
+  const objectUrl = URL.createObjectURL(file);
+  return new Promise<{ width: number; height: number }>((resolve, reject) => {
+    img.onload = () => {
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+      URL.revokeObjectURL(objectUrl);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Failed to load image'));
+    };
+    img.src = objectUrl;
+  }).catch(() => ({ ...BULK_PANEL_FALLBACK_DIMENSIONS }));
+}
+
+/**
+ * Extract embedded generation metadata (Automatic1111 / ComfyUI / SwarmUI / RuinedFooocus
+ * PNG tags) so the panel's `Image` can be attributed to whatever model produced it.
+ * Failures are non-fatal — the panel is still worth creating without attribution.
+ */
+async function readMeta(file: File): Promise<Record<string, unknown> | undefined> {
+  try {
+    const parsed = await getMetadata(file);
+    if (parsed && Object.keys(parsed).length > 0) return parsed;
+  } catch (err) {
+    console.error('Failed to extract metadata from uploaded image:', err);
+  }
+  return undefined;
+}
+
+export async function uploadBulkPanels({
+  files,
+  uploadToCF,
+}: {
+  files: File[];
+  uploadToCF: (file: File) => Promise<{ id: string }>;
+}): Promise<BulkPanelUploadResult> {
+  const items: BulkPanelItem[] = [];
+  const failed: BatchUploadFailure[] = [];
+
+  for (const file of files) {
+    const dims = await readDimensions(file);
+    const meta = await readMeta(file);
+
+    /**
+     * 🔴 PER FILE, WITH `continue` — the same remedy `character.tsx`'s reference loop got.
+     *
+     * This loop originally had no catch at all, then a whole-loop one. Both stop the batch
+     * on the first refused PUT: files 3–10 are never attempted, and the user is told
+     * "Failed to upload image" with no file named and no count. Stopping is not obviously
+     * wrong, but it was never a decision — it was the shape a `try` around the whole loop
+     * happens to have. Two identically-shaped loops must not have two different answers to
+     * one question, so both continue, and the caller reports the failures it is handed.
+     *
+     * Scoped to the upload alone: the dimension read and the metadata read above already
+     * swallow their own failures and cannot reach here.
+     */
+    let result: { id: string };
+    try {
+      result = await uploadToCF(file);
+    } catch (error) {
+      failed.push({ name: file.name, error: error as Error });
+      continue;
+    }
+
+    items.push({
+      id: `bulk-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      sourceImage: {
+        url: result.id,
+        cfId: result.id,
+        width: dims.width,
+        height: dims.height,
+        preview: getEdgeUrl(result.id, { width: 120 }) ?? result.id,
+      },
+      prompt: '',
+      aspectRatio: '3:4',
+      meta,
+    });
+  }
+
+  return { items, failed };
+}

--- a/src/components/CosmeticShop/CosmeticShopItemUpsertForm.tsx
+++ b/src/components/CosmeticShop/CosmeticShopItemUpsertForm.tsx
@@ -576,15 +576,7 @@ export const CosmeticShopItemUpsertForm = ({ shopItem, onSuccess, onCancel }: Pr
             description="This description will be shown in the shop"
             label="Content"
             editorSize="xl"
-            includeControls={[
-              'heading',
-              'formatting',
-              'list',
-              'link',
-              'media',
-              'colors',
-              'blurb',
-            ]}
+            includeControls={['heading', 'formatting', 'list', 'link', 'media', 'colors', 'blurb']}
             withAsterisk
             stickyToolbar
           />

--- a/src/components/CosmeticShop/CosmeticShopItemUpsertForm.tsx
+++ b/src/components/CosmeticShop/CosmeticShopItemUpsertForm.tsx
@@ -59,6 +59,7 @@ import type { CosmeticGetById, CosmeticShopItemGetById } from '~/types/router';
 import { formatBytes } from '~/utils/number-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { isDefined } from '~/utils/type-guards';
+import { isUploadInFlight } from '~/utils/upload-status';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 const formSchema = upsertCosmeticShopItemInput;
@@ -167,9 +168,16 @@ const NewCosmeticInlineCreator = ({ onCreated }: { onCreated: (cosmeticId: numbe
       }
     }
 
-    const result = await uploadToCF(file);
-    setImageId(result.id);
-    setPreviewUrl(result.objectUrl ?? result.id);
+    // 🔴 A refused PUT now REJECTS (see `useCFImageUpload`). Without this catch the
+    // rejection escapes into Mantine's `onDrop`, which discards the promise: the user is
+    // told nothing at all and the console gets an unhandled rejection.
+    try {
+      const result = await uploadToCF(file);
+      setImageId(result.id);
+      setPreviewUrl(result.objectUrl ?? result.id);
+    } catch (error) {
+      showErrorNotification({ title: 'Upload failed', error: error as Error });
+    }
   };
 
   const handleRemoveImage = () => {
@@ -236,7 +244,10 @@ const NewCosmeticInlineCreator = ({ onCreated }: { onCreated: (cosmeticId: numbe
   };
 
   const imageFile = imageFiles[0];
-  const showLoading = imageFile && imageFile.progress < 100;
+  // 🔴 Derived from `status`, NOT from `progress` — see `isUploadInFlight`. The render
+  // below is `showLoading ? overlay : previewUrl ? preview : <Dropzone/>`, so a latched
+  // spinner unmounts the Dropzone and there is no retry without a page reload.
+  const showLoading = isUploadInFlight(imageFile);
 
   return (
     <Paper withBorder p="md" radius="md">

--- a/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
+++ b/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
@@ -39,6 +39,7 @@ import {
 import { CosmeticShopItemStatus, CosmeticSource, CosmeticType } from '~/shared/utils/prisma/enums';
 import { isAnimatedImage } from '~/utils/media-preprocessors/image.preprocessor';
 import { showErrorNotification } from '~/utils/notifications';
+import { isUploadInFlight } from '~/utils/upload-status';
 import { trpc } from '~/utils/trpc';
 
 // Owns the submit/edit form: local field state, the derived readiness/affordability
@@ -232,7 +233,11 @@ export function useSubmitCreatorShopForm({
     isEdit || (submissionFee !== undefined && feeAccountBalance >= submissionFee);
 
   const maxSize = constants.mediaUpload.maxImageFileSize;
-  const uploading = !!files[0] && files[0].progress < 100;
+  // Status-derived, not `progress`-derived — see `isUploadInFlight`. The `resetFiles()`
+  // in `handleDrop`'s catch below was compensating for the old `progress < 100` spelling
+  // latching on after a refused PUT; it is kept because it also lets the creator re-drop,
+  // but this predicate no longer depends on it.
+  const uploading = isUploadInFlight(files[0]);
   const allChecksPassed = checks.length > 0 && checks.every((c) => c.passed);
   // Existing art (edit, not replaced) is trusted; new art must pass its checks.
   const artOk = !!imageId && (isEdit && !artReplaced ? true : allChecksPassed);

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -234,7 +234,7 @@ export function ImageUpload({
                      * on error, which clears `image.file` — and that remedy is kept, because
                      * it is also what makes the tile disappear so the user can retry.
                      *
-                     * Round 2 then added `isUploadInFlight(match) ||` in front, on the
+                     * A later pass then added `isUploadInFlight(match) ||` in front, on the
                      * reasoning that one rule should be spelled one way. It is DEAD: `match`
                      * comes from `imageFiles.find((f) => image.file === f.file)` and a
                      * `TrackedFile.file` is always a `File`, so `match !== undefined` implies

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -115,16 +115,28 @@ export function ImageUpload({
     ]);
     await Promise.all(
       toUpload.map(async (image) => {
-        const { id } = await uploadToCF(image.file);
-        filesHandler.setState(
-          produce((current) => {
-            const index = current.findIndex((x) => x.file === image.file);
-            if (index === -1) return;
-            current[index].url = id;
-            current[index].file = undefined;
-          })
-        );
-        URL.revokeObjectURL(image.url);
+        try {
+          const { id } = await uploadToCF(image.file);
+          filesHandler.setState(
+            produce((current) => {
+              const index = current.findIndex((x) => x.file === image.file);
+              if (index === -1) return;
+              current[index].url = id;
+              current[index].file = undefined;
+            })
+          );
+          URL.revokeObjectURL(image.url);
+        } catch (e) {
+          // `uploadToCF` now REJECTS when the presigned PUT is refused (403/400/503)
+          // rather than resolving as if it had worked. Without this the tile's
+          // placeholder entry survives with `file` still set, and `showLoading`
+          // (`(match && progress < 100) || image.file`) latches on forever — and the
+          // rejection escapes `Promise.all` into the dropzone handler unhandled.
+          // Drop the placeholder so the tile disappears and the user can retry.
+          filesHandler.setState((current) => current.filter((x) => x.file !== image.file));
+          URL.revokeObjectURL(image.url);
+          setError(e instanceof Error ? e.message : 'Failed to upload image, please try again');
+        }
       })
     );
   };

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -54,7 +54,6 @@ import styles from './ImageUpload.module.css';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { isAndroidDevice } from '~/utils/device-helpers';
-import { isUploadInFlight } from '~/utils/upload-status';
 
 type Props = Omit<InputWrapperProps, 'children' | 'onChange'> & {
   hasPrimaryImage?: boolean;
@@ -88,7 +87,9 @@ export function ImageUpload({
   const colorScheme = useComputedColorScheme('dark');
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
-  const { files: imageFiles, uploadToCF, removeImage } = useCFImageUpload();
+  // `files` is no longer destructured: the only consumer was the dead
+  // `isUploadInFlight(match)` term removed below.
+  const { uploadToCF, removeImage } = useCFImageUpload();
   const [files, filesHandler] = useListState<CustomFile>(Array.isArray(value) ? value : []);
   const [activeId, setActiveId] = useState<UniqueIdentifier>();
   const [error, setError] = useState('');
@@ -223,22 +224,26 @@ export function ImageUpload({
                   }}
                 >
                   {files.map((image, index) => {
-                    const match = imageFiles.find((file) => image.file === file.file);
                     /**
-                     * 🔴 THE FIFTH COPY OF THE SPINNER PREDICATE, now on the shared rule.
+                     * 🔴 THIS SITE IS GOVERNED BY `image.file`, NOT BY THE SHARED STATUS
+                     * RULE — and saying otherwise here was worse than saying nothing.
                      *
-                     * It used to be `(match && progress < 100) || image.file`. Round 1 gave
-                     * this file a DIFFERENT remedy from the other four — dropping the
-                     * placeholder entry on error, which clears `image.file` and so does
-                     * prevent the latch — and that remedy is kept, because it is also what
-                     * makes the tile disappear so the user can retry. But leaving the
-                     * predicate open-coded here left the rule spelled two ways in one repo,
-                     * which is the exact thing `isUploadInFlight` exists to stop. The
-                     * `|| image.file` half stays: an entry queued for upload has no tracked
-                     * file yet, so `match` is undefined and only that half can show its
-                     * spinner.
+                     * It used to be `(match && progress < 100) || image.file`, which is the
+                     * latch `isUploadInFlight` exists to remove. Round 1 gave this file a
+                     * DIFFERENT remedy from the other four — dropping the placeholder entry
+                     * on error, which clears `image.file` — and that remedy is kept, because
+                     * it is also what makes the tile disappear so the user can retry.
+                     *
+                     * Round 2 then added `isUploadInFlight(match) ||` in front, on the
+                     * reasoning that one rule should be spelled one way. It is DEAD: `match`
+                     * comes from `imageFiles.find((f) => image.file === f.file)` and a
+                     * `TrackedFile.file` is always a `File`, so `match !== undefined` implies
+                     * `image.file` is truthy and the whole expression is identically
+                     * `!!image.file`. Leaving it in told a reader the status rule governs
+                     * this spinner when the placeholder-drop is what actually protects it —
+                     * a comment claiming coverage that stops anyone looking. Removed.
                      */
-                    const showLoading = isUploadInFlight(match) || !!image.file;
+                    const showLoading = !!image.file;
 
                     if (showLoading)
                       return (

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -54,6 +54,7 @@ import styles from './ImageUpload.module.css';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { isAndroidDevice } from '~/utils/device-helpers';
+import { isUploadInFlight } from '~/utils/upload-status';
 
 type Props = Omit<InputWrapperProps, 'children' | 'onChange'> & {
   hasPrimaryImage?: boolean;
@@ -223,8 +224,21 @@ export function ImageUpload({
                 >
                   {files.map((image, index) => {
                     const match = imageFiles.find((file) => image.file === file.file);
-                    const { progress } = match ?? { progress: 0 };
-                    const showLoading = (match && progress < 100) || image.file;
+                    /**
+                     * 🔴 THE FIFTH COPY OF THE SPINNER PREDICATE, now on the shared rule.
+                     *
+                     * It used to be `(match && progress < 100) || image.file`. Round 1 gave
+                     * this file a DIFFERENT remedy from the other four — dropping the
+                     * placeholder entry on error, which clears `image.file` and so does
+                     * prevent the latch — and that remedy is kept, because it is also what
+                     * makes the tile disappear so the user can retry. But leaving the
+                     * predicate open-coded here left the rule spelled two ways in one repo,
+                     * which is the exact thing `isUploadInFlight` exists to stop. The
+                     * `|| image.file` half stays: an entry queued for upload has no tracked
+                     * file yet, so `match` is undefined and only that half can show its
+                     * spinner.
+                     */
+                    const showLoading = isUploadInFlight(match) || !!image.file;
 
                     if (showLoading)
                       return (

--- a/src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx
@@ -26,8 +26,15 @@ import { renderWithProviders } from '../../../test/component-setup';
 
 const mocks = vi.hoisted(() => ({
   behavior: 'success' as 'success' | 'fail' | 'hang',
-  /** ms the mocked PUT stays in flight — see the note in `uploadToCF` below. */
-  uploadMs: 150,
+  /**
+   * ms the mocked PUT stays in flight — see the note in `uploadToCF` below.
+   *
+   * Comfortably wider than `vi.waitFor`'s 50 ms poll interval so the "the spinner went UP"
+   * edge cannot be stepped over between polls. At 150 ms it passed 5/5 under load but had
+   * only ~3 polls of margin; the window is free to widen, a missed edge is a hard failure
+   * (the assertion can never become true afterwards), so buy the margin.
+   */
+  uploadMs: 500,
   uploaded: { url: 'new-key', objectUrl: 'blob:new', id: 'new-key', type: 'image' },
 }));
 
@@ -83,6 +90,10 @@ vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
 import { ProfileImageUpload } from '~/components/ProfileImageUpload/ProfileImageUpload';
 
 const overlay = () => document.querySelector('.mantine-LoadingOverlay-root');
+const preview = () => document.querySelector('[data-testid="preview"]') as HTMLImageElement | null;
+
+/** A pre-existing avatar, in the string form `value` accepts. */
+const EXISTING = 'https://cdn.example.com/existing-avatar.png';
 
 async function dropFile() {
   await expect
@@ -150,6 +161,37 @@ describe('ProfileImageUpload — a refused PUT', () => {
     await vi.waitFor(() =>
       expect(document.body.textContent).toContain('Upload failed (status 403)')
     );
+    /**
+     * 🔴 AND NO PREVIEW OF THE REFUSED FILE.
+     *
+     * The `useDidUpdate` used to set `image` from the tracked file on EVERY status,
+     * `error` included, and call `onChange` only on `success`. So a refused PUT painted
+     * the new avatar into the circle while the form still held the old value — the user
+     * saw their new avatar plus an error line, and Save silently kept the old one. There
+     * is no `value` here, so the honest render is no preview at all.
+     */
+    expect(preview()).toBeNull();
+  });
+
+  test('a refused PUT leaves the EXISTING avatar on screen, not the refused one', async () => {
+    /**
+     * 🔴 THE SAME DEFECT WITH A NON-EMPTY FORM VALUE, which is the shape a real user hits.
+     *
+     * Two ways to be wrong and this pins both: painting `new-key` claims an upload that
+     * did not happen, and painting nothing claims the avatar was removed. `onChange` never
+     * fired, so the form still holds `EXISTING` and that is what has to be on screen.
+     */
+    mocks.behavior = 'fail';
+    const onChange = vi.fn();
+    renderWithProviders(<ProfileImageUpload label="Avatar" value={EXISTING} onChange={onChange} />);
+
+    await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe(EXISTING));
+    await dropFile();
+    await vi.waitFor(() =>
+      expect(document.body.textContent).toContain('Upload failed (status 403)')
+    );
+    await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe(EXISTING));
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('the refused PUT does not produce an unhandled rejection', async () => {
@@ -175,5 +217,8 @@ describe('ProfileImageUpload — a refused PUT', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ url: 'new-key' }));
     await vi.waitFor(() => expect(overlay()).toBeNull());
     expect(document.body.textContent).not.toContain('Upload failed');
+    // 🔴 POSITIVE CONTROL for the two `preview()` absences above: they are only meaningful
+    // if this component renders a preview at all and the selector matches it.
+    await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe('blob:new'));
   });
 });

--- a/src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * `ProfileImageUpload` after a REFUSED presigned PUT.
+ *
+ * 🔴 THE DEFECT THIS PINS. `uploadToCF` now rejects when the store refuses the PUT
+ * (403 on an expired presign, 400, 503) instead of resolving as though it had worked.
+ * Two things were then wrong here, and the PR body's justification for leaving this
+ * component alone — "every one of these derives its spinner from that status" — was
+ * false for it:
+ *
+ *   1. `showLoading` was `imageFile && imageFile.progress < 100`. `progress` is written
+ *      only by the `xhr.upload` progress listener; no failure branch touches it. A PUT
+ *      refused before its first progress event leaves it at `0`, so the overlay latched
+ *      on with no way to clear it.
+ *   2. `handleDrop` was a bare `await uploadToCF(file)` inside a Mantine `onDrop`, which
+ *      discards the returned promise. The rejection surfaced as an unhandled rejection
+ *      and the user was told nothing at all.
+ *
+ * The dropzone here is never gated on `showLoading`, so a retry was always physically
+ * possible — what was missing was the spinner clearing and any indication of failure.
+ * (In the two sibling consumers the render IS gated, and the Dropzone unmounts.)
+ */
+
+const mocks = vi.hoisted(() => ({
+  behavior: 'success' as 'success' | 'fail' | 'hang',
+  /** ms the mocked PUT stays in flight — see the note in `uploadToCF` below. */
+  uploadMs: 150,
+  uploaded: { url: 'new-key', objectUrl: 'blob:new', id: 'new-key', type: 'image' },
+}));
+
+/**
+ * Real hook SHAPE, driven per test. `files` is genuine React state so the component's
+ * `useDidUpdate([imageFile])` fires exactly as it does against the real hook.
+ *
+ * 🔴 The failure branch reproduces the real hook's state precisely: `status: 'error'`
+ * with `progress` left at **0**. That combination is the whole bug — a fake that set
+ * `progress: 100` on failure would encode the same wrong assumption the old code made
+ * and pass with the defect present.
+ */
+vi.mock('~/hooks/useCFImageUpload', async () => {
+  const { useState } = await import('react');
+  return {
+    useCFImageUpload: () => {
+      const [files, setFiles] = useState<Record<string, unknown>[]>([]);
+      return {
+        files,
+        removeImage: () => undefined,
+        resetFiles: () => setFiles([]),
+        uploadToCF: async () => {
+          setFiles([{ ...mocks.uploaded, status: 'uploading', progress: 0 }]);
+          if (mocks.behavior === 'hang') return new Promise(() => undefined);
+          /**
+           * 🔴 A REAL, OBSERVABLE IN-FLIGHT WINDOW, not a microtask.
+           *
+           * `vi.waitFor(() => expect(x).toBeNull())` is satisfied by the state BEFORE
+           * anything happened, so a test that only waits for the spinner to vanish
+           * passes against a component that never showed one. Measured: with a
+           * `setTimeout(0)` here, the `progress < 100` mutant SURVIVED that assertion.
+           * The delay makes "it went up, then it came down" a sequence the test can
+           * actually observe.
+           */
+          await new Promise((r) => setTimeout(r, mocks.uploadMs));
+          if (mocks.behavior === 'fail') {
+            setFiles([{ ...mocks.uploaded, status: 'error', progress: 0 }]);
+            throw new Error('Upload failed (status 403)');
+          }
+          setFiles([{ ...mocks.uploaded, status: 'success', progress: 100 }]);
+          return mocks.uploaded;
+        },
+      };
+    },
+  };
+});
+
+// Not under test, and the real one resolves a delivery URL through client-only hooks.
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: ({ src }: { src: string }) => <img alt="preview" data-testid="preview" src={src} />,
+}));
+
+import { ProfileImageUpload } from '~/components/ProfileImageUpload/ProfileImageUpload';
+
+const overlay = () => document.querySelector('.mantine-LoadingOverlay-root');
+
+async function dropFile() {
+  await expect
+    .poll(() => document.querySelector('input[type="file"]'), {
+      message: 'the dropzone file input should mount',
+    })
+    .not.toBeNull();
+
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const transfer = new DataTransfer();
+  transfer.items.add(new File(['x'], 'avatar.png', { type: 'image/png' }));
+  input.files = transfer.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+describe('ProfileImageUpload — a refused PUT', () => {
+  let unhandled: unknown[] = [];
+  const record = (event: PromiseRejectionEvent) => {
+    unhandled.push(event.reason);
+    event.preventDefault();
+  };
+
+  beforeEach(() => {
+    mocks.behavior = 'success';
+    unhandled = [];
+    window.addEventListener('unhandledrejection', record);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('unhandledrejection', record);
+  });
+
+  test('POSITIVE CONTROL: the spinner IS shown while the upload is in flight', async () => {
+    /**
+     * 🔴 Without this, "the spinner cleared" is satisfied by a component that never
+     * renders a spinner at all, and by a selector that matches nothing. This case pins
+     * the selector against an upload that never settles, so it cannot race.
+     */
+    mocks.behavior = 'hang';
+    renderWithProviders(<ProfileImageUpload label="Avatar" />);
+
+    await dropFile();
+    await vi.waitFor(() => expect(overlay()).not.toBeNull());
+  });
+
+  test('the spinner CLEARS when the upload errors with progress still at 0', async () => {
+    // 🔴 THE REGRESSION. `progress` is 0 here and stays 0, so the replaced
+    // `imageFile.progress < 100` is true forever and the overlay never came down.
+    mocks.behavior = 'fail';
+    renderWithProviders(<ProfileImageUpload label="Avatar" />);
+
+    await dropFile();
+    // 🔴 BOTH EDGES, IN ORDER. Waiting only for the overlay to be null is vacuous: it is
+    // already null before the drop is processed, which is exactly how the
+    // `progress < 100` mutant survived an earlier draft of this test.
+    await vi.waitFor(() => expect(overlay()).not.toBeNull());
+    await vi.waitFor(() => expect(overlay()).toBeNull());
+  });
+
+  test('the failure is SURFACED to the user instead of vanishing', async () => {
+    mocks.behavior = 'fail';
+    renderWithProviders(<ProfileImageUpload label="Avatar" />);
+
+    await dropFile();
+    await vi.waitFor(() =>
+      expect(document.body.textContent).toContain('Upload failed (status 403)')
+    );
+  });
+
+  test('the refused PUT does not produce an unhandled rejection', async () => {
+    mocks.behavior = 'fail';
+    renderWithProviders(<ProfileImageUpload label="Avatar" />);
+
+    await dropFile();
+    // Wait past the mocked in-flight window plus a margin, rather than on a DOM
+    // condition: an unhandled rejection is reported asynchronously and is not visible in
+    // the tree at all, so there is nothing to poll for.
+    await new Promise((r) => setTimeout(r, mocks.uploadMs + 250));
+    expect(unhandled).toEqual([]);
+  });
+
+  test('a SUCCESSFUL upload still clears the spinner and emits the new key', async () => {
+    // The invariant half: the fix must not have been "never show a spinner".
+    mocks.behavior = 'success';
+    const onChange = vi.fn();
+    renderWithProviders(<ProfileImageUpload label="Avatar" onChange={onChange} />);
+
+    await dropFile();
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ url: 'new-key' }));
+    await vi.waitFor(() => expect(overlay()).toBeNull());
+    expect(document.body.textContent).not.toContain('Upload failed');
+  });
+});

--- a/src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx
@@ -92,8 +92,23 @@ import { ProfileImageUpload } from '~/components/ProfileImageUpload/ProfileImage
 const overlay = () => document.querySelector('.mantine-LoadingOverlay-root');
 const preview = () => document.querySelector('[data-testid="preview"]') as HTMLImageElement | null;
 
-/** A pre-existing avatar, in the string form `value` accepts. */
-const EXISTING = 'https://cdn.example.com/existing-avatar.png';
+/**
+ * The two string shapes `value` accepts, BOTH of them.
+ *
+ * 🔴 `value` is typed `string | { url: string }`, and the string half has two real
+ * inhabitants: a legacy absolute URL, and a bare media key — which is what `onChange`
+ * emits and what `Image.url` stores, i.e. the shape a saved avatar actually round-trips
+ * as. An earlier draft of the restore test used the URL alone, which is the one string
+ * shape that worked: `valuePreview` gated a string on `isValidURL`, so with a bare key it
+ * returned `undefined` and the restore rendered an empty circle. Fixing that meant
+ * consolidating the derivation; keeping this guard honest means driving both.
+ */
+const EXISTING_URL = 'https://cdn.example.com/existing-avatar.png';
+const EXISTING_KEY = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
+const EXISTING_SHAPES: ReadonlyArray<[label: string, value: string]> = [
+  ['a full url', EXISTING_URL],
+  ['a bare media key', EXISTING_KEY],
+];
 
 async function dropFile() {
   await expect
@@ -173,26 +188,36 @@ describe('ProfileImageUpload — a refused PUT', () => {
     expect(preview()).toBeNull();
   });
 
-  test('a refused PUT leaves the EXISTING avatar on screen, not the refused one', async () => {
-    /**
-     * 🔴 THE SAME DEFECT WITH A NON-EMPTY FORM VALUE, which is the shape a real user hits.
-     *
-     * Two ways to be wrong and this pins both: painting `new-key` claims an upload that
-     * did not happen, and painting nothing claims the avatar was removed. `onChange` never
-     * fired, so the form still holds `EXISTING` and that is what has to be on screen.
-     */
-    mocks.behavior = 'fail';
-    const onChange = vi.fn();
-    renderWithProviders(<ProfileImageUpload label="Avatar" value={EXISTING} onChange={onChange} />);
+  test.each(EXISTING_SHAPES)(
+    'a refused PUT leaves the EXISTING avatar on screen when `value` is %s',
+    async (_label, existing) => {
+      /**
+       * 🔴 THE SAME DEFECT WITH A NON-EMPTY FORM VALUE, which is the shape a real user hits.
+       *
+       * Two ways to be wrong and this pins both: painting `new-key` claims an upload that
+       * did not happen, and painting nothing claims the avatar was removed. `onChange` never
+       * fired, so the form still holds `existing` and that is what has to be on screen.
+       *
+       * 🔴 RUN OVER BOTH STRING SHAPES. With the bare key this went red before the
+       * derivations were consolidated — preview present before the drop (the effect set
+       * it), `null` after (the restore's `valuePreview` returned `undefined` for a
+       * non-URL string, and the effect could not re-run because `value` never changed).
+       */
+      mocks.behavior = 'fail';
+      const onChange = vi.fn();
+      renderWithProviders(
+        <ProfileImageUpload label="Avatar" value={existing} onChange={onChange} />
+      );
 
-    await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe(EXISTING));
-    await dropFile();
-    await vi.waitFor(() =>
-      expect(document.body.textContent).toContain('Upload failed (status 403)')
-    );
-    await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe(EXISTING));
-    expect(onChange).not.toHaveBeenCalled();
-  });
+      await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe(existing));
+      await dropFile();
+      await vi.waitFor(() =>
+        expect(document.body.textContent).toContain('Upload failed (status 403)')
+      );
+      await vi.waitFor(() => expect(preview()?.getAttribute('src')).toBe(existing));
+      expect(onChange).not.toHaveBeenCalled();
+    }
+  );
 
   test('the refused PUT does not produce an unhandled rejection', async () => {
     mocks.behavior = 'fail';

--- a/src/components/ProfileImageUpload/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.tsx
@@ -22,6 +22,18 @@ type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> &
   previewDisabled?: boolean;
 };
 
+/**
+ * The preview the CURRENT form value implies, or `undefined` when the form holds nothing.
+ *
+ * Used both for the initial state and to put the preview back after a refused upload —
+ * `handleDrop` clears it optimistically, and on failure the form value is unchanged, so
+ * the honest render is the one that value describes.
+ */
+function valuePreview(value: SimpleImageUploadProps['value']) {
+  if (typeof value === 'string') return isValidURL(value) ? { url: value } : undefined;
+  return value ? { url: value.url } : undefined;
+}
+
 export function ProfileImageUpload({
   value,
   onChange,
@@ -31,8 +43,8 @@ export function ProfileImageUpload({
   ...props
 }: SimpleImageUploadProps) {
   const { uploadToCF, files: imageFiles, resetFiles } = useCFImageUpload();
-  const [image, setImage] = useState<{ url: string; objectUrl?: string } | undefined>(
-    typeof value === 'string' && isValidURL(value) ? { url: value } : undefined
+  const [image, setImage] = useState<{ url: string; objectUrl?: string } | undefined>(() =>
+    valuePreview(value)
   );
   const [error, setError] = useState('');
 
@@ -55,17 +67,33 @@ export function ProfileImageUpload({
       await uploadToCF(file);
     } catch (e) {
       setError((e as Error).message);
+      // 🔴 The form value never changed, so put its preview back. `handleDrop` cleared it
+      // optimistically above; leaving it cleared renders an empty circle for a user whose
+      // avatar is still set, which reads as "your avatar was removed".
+      setImage(valuePreview(value));
     }
   };
 
   useDidUpdate(() => {
     if (!imageFile) return;
-    setImage({ url: imageFile.url, objectUrl: imageFile.objectUrl });
+    /**
+     * 🔴 ONLY A SUCCEEDED UPLOAD MAY SET THE PREVIEW.
+     *
+     * This used to `setImage(...)` unconditionally and then call `onChange` only on
+     * `success`. While the latched `progress < 100` spinner existed the preview branch was
+     * unreachable on failure, so the bug was invisible; deriving the spinner from `status`
+     * exposed it. On a refused PUT the effect fired with `status: 'error'` and painted the
+     * NEW avatar into the circle beside the error line, while `onChange` never fired and
+     * the form still held the OLD value — so Save silently kept the old avatar.
+     *
+     * The preview and the emitted value must come from the same branch, because they are
+     * the same claim: "this is the image the form now holds."
+     */
+    if (imageFile.status !== 'success') return;
 
-    if (imageFile.status === 'success') {
-      const { status, ...file } = imageFile;
-      onChange?.(file);
-    }
+    setImage({ url: imageFile.url, objectUrl: imageFile.objectUrl });
+    const { status, ...file } = imageFile;
+    onChange?.(file);
   }, [imageFile]);
 
   useEffect(() => {

--- a/src/components/ProfileImageUpload/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.tsx
@@ -28,19 +28,25 @@ type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> &
  *
  * There used to be two, and they disagreed. This one gated a STRING `value` on
  * `isValidURL`; the effect below took `typeof value === 'string' ? { url: value } : value`
- * with no gate. A bare media key — the exact shape `onChange` emits and `Image.url`
- * stores — therefore RENDERED on mount via the effect but returned `undefined` here, so
- * the refused-upload restore cleared the circle and the effect could not put it back
- * (`value` never changed, so it never re-ran). Measured with
- * `value="7c9e6679-7425-40de-944b-e07fc1f90ae7"` and a refused PUT: preview present before
- * the drop, `null` after — precisely the "your avatar was removed" render this component's
- * restore path exists to prevent.
+ * with no gate. A bare media key — the shape `Image.url` stores — therefore RENDERED on
+ * mount via the effect but returned `undefined` here, so the refused-upload restore
+ * cleared the circle and the effect could not put it back (`value` never changed, so it
+ * never re-ran). Measured with `value="7c9e6679-7425-40de-944b-e07fc1f90ae7"` and a refused
+ * PUT: preview present before the drop, `null` after — precisely the "your avatar was
+ * removed" render this component's restore path exists to prevent.
  *
- * The permissive reading wins, because it is the one that was already observable: the
- * effect runs after the first render, so on `main` a bare key rendered anyway. It is also
- * what the OBJECT branch always did (`{ url: value.url }`, never gated), and `EdgeMedia`
- * resolves a bare key perfectly well. Empty string stays `undefined` — that is "the form
- * holds nothing", not "the form holds a key".
+ * 🔴 WHY THE PERMISSIVE READING IS THE ONE TO KEEP, stated at the strength the evidence
+ * actually supports. It is NOT that a bare string is what callers pass: `onChange` emits an
+ * OBJECT (`{ status, ...file }` minus `status`, below), and the sole consumer —
+ * `UserProfileEditModal`'s `InputProfileImageUpload`, typed `profilePictureSchema.nullish()`
+ * — passes an object or null. No caller in the repo passes a string at all. The reason is
+ * that the permissive branch is the one that was already OBSERVABLE: the effect runs after
+ * the first render, so on `main` a bare key rendered regardless of what this function said.
+ * Consolidating on the strict reading would therefore have DELETED a render that ships
+ * today, on the strength of a type nobody currently produces. It is also what the OBJECT
+ * branch always did (`{ url: value.url }`, never gated), and `EdgeMedia` resolves a bare key
+ * perfectly well. Empty string stays `undefined` — that is "the form holds nothing", not
+ * "the form holds a key".
  */
 function valuePreview(value: SimpleImageUploadProps['value']) {
   if (!value) return undefined;

--- a/src/components/ProfileImageUpload/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.tsx
@@ -11,6 +11,7 @@ import { IMAGE_MIME_TYPE } from '~/shared/constants/mime-types';
 import { formatBytes } from '~/utils/number-helpers';
 import { IconUser } from '@tabler/icons-react';
 import { isValidURL } from '~/utils/type-guards';
+import { isUploadInFlight } from '~/utils/upload-status';
 import { isAndroidDevice } from '~/utils/device-helpers';
 
 type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> & {
@@ -46,7 +47,15 @@ export function ProfileImageUpload({
     resetFiles();
     const [file] = droppedFiles;
 
-    await uploadToCF(file);
+    // 🔴 A refused PUT now REJECTS (see `useCFImageUpload`). Without this catch the
+    // rejection escapes into Mantine's `onDrop`, which discards the promise: the user is
+    // told nothing at all and the console gets an unhandled rejection. This wrapper has
+    // its own `error` slot, so the message goes there rather than into a notification.
+    try {
+      await uploadToCF(file);
+    } catch (e) {
+      setError((e as Error).message);
+    }
   };
 
   useDidUpdate(() => {
@@ -68,7 +77,10 @@ export function ProfileImageUpload({
   }, [value]);
 
   const hasError = !!props.error || !!error;
-  const showLoading = imageFile && imageFile.progress < 100;
+  // 🔴 Derived from `status`, NOT from `progress` — see `isUploadInFlight`. A PUT refused
+  // before its first progress event leaves `progress` at 0, which `progress < 100` reads
+  // as "still uploading" forever.
+  const showLoading = isUploadInFlight(imageFile);
 
   return (
     <Input.Wrapper {...props} error={props.error ?? error}>

--- a/src/components/ProfileImageUpload/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.tsx
@@ -10,7 +10,6 @@ import { constants } from '~/server/common/constants';
 import { IMAGE_MIME_TYPE } from '~/shared/constants/mime-types';
 import { formatBytes } from '~/utils/number-helpers';
 import { IconUser } from '@tabler/icons-react';
-import { isValidURL } from '~/utils/type-guards';
 import { isUploadInFlight } from '~/utils/upload-status';
 import { isAndroidDevice } from '~/utils/device-helpers';
 
@@ -23,15 +22,29 @@ type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> &
 };
 
 /**
- * The preview the CURRENT form value implies, or `undefined` when the form holds nothing.
+ * 🔴 THE ONE DERIVATION OF "what preview does the CURRENT form value imply?", used by all
+ * three places that need it: the initial state, the reconciling effect, and the restore
+ * after a refused upload.
  *
- * Used both for the initial state and to put the preview back after a refused upload —
- * `handleDrop` clears it optimistically, and on failure the form value is unchanged, so
- * the honest render is the one that value describes.
+ * There used to be two, and they disagreed. This one gated a STRING `value` on
+ * `isValidURL`; the effect below took `typeof value === 'string' ? { url: value } : value`
+ * with no gate. A bare media key — the exact shape `onChange` emits and `Image.url`
+ * stores — therefore RENDERED on mount via the effect but returned `undefined` here, so
+ * the refused-upload restore cleared the circle and the effect could not put it back
+ * (`value` never changed, so it never re-ran). Measured with
+ * `value="7c9e6679-7425-40de-944b-e07fc1f90ae7"` and a refused PUT: preview present before
+ * the drop, `null` after — precisely the "your avatar was removed" render this component's
+ * restore path exists to prevent.
+ *
+ * The permissive reading wins, because it is the one that was already observable: the
+ * effect runs after the first render, so on `main` a bare key rendered anyway. It is also
+ * what the OBJECT branch always did (`{ url: value.url }`, never gated), and `EdgeMedia`
+ * resolves a bare key perfectly well. Empty string stays `undefined` — that is "the form
+ * holds nothing", not "the form holds a key".
  */
 function valuePreview(value: SimpleImageUploadProps['value']) {
-  if (typeof value === 'string') return isValidURL(value) ? { url: value } : undefined;
-  return value ? { url: value.url } : undefined;
+  if (!value) return undefined;
+  return typeof value === 'string' ? { url: value } : { url: value.url };
 }
 
 export function ProfileImageUpload({
@@ -97,7 +110,9 @@ export function ProfileImageUpload({
   }, [imageFile]);
 
   useEffect(() => {
-    const currentValue = value ? (typeof value === 'string' ? { url: value } : value) : undefined;
+    // Same derivation as the initial state and the refused-upload restore — see
+    // `valuePreview`. Open-coding it here is what let the three disagree.
+    const currentValue = valuePreview(value);
     if (currentValue && image?.url !== currentValue.url) {
       setImage(currentValue);
     }

--- a/src/env/__tests__/server-schema-create-image-verify-media.test.ts
+++ b/src/env/__tests__/server-schema-create-image-verify-media.test.ts
@@ -30,7 +30,13 @@ describe('CREATE_IMAGE_VERIFY_MEDIA_ENFORCE env gate', () => {
     expect(typeof parsed).toBe('boolean');
   });
 
-  it.each(['', 'false', 'FALSE', 'no', '0', 'yes', 'garbage', 'TRUE '])(
+  // 🔴 `'1'` and `'TRUE'` are in this list on purpose: they are the two spellings an
+  // operator is most likely to reach for, and both are SILENT no-ops. `zc.booleanString`
+  // is `val === true || val === 'true'` — exact and case-sensitive — so neither errors,
+  // neither warns, and the only tell is `enforcing: false` on the
+  // `create-image-media-verify` log line. Pinned here so a future widening of the
+  // preprocessor is a deliberate edit rather than a surprise at rollout time.
+  it.each(['', 'false', 'FALSE', 'no', '0', '1', 'TRUE', 'True', 'yes', 'garbage', 'TRUE '])(
     'treats %j as NOT enforcing — a malformed value lands on observe-only, never on rejecting',
     (value) => {
       const parsed = field.parse(value);

--- a/src/env/__tests__/server-schema-create-image-verify-media.test.ts
+++ b/src/env/__tests__/server-schema-create-image-verify-media.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { serverSchema } from '~/env/server-schema';
+
+/**
+ * CREATE_IMAGE_VERIFY_MEDIA_ENFORCE gates whether `createImage` REJECTS a row whose
+ * media the store answered was absent. It ships OFF: the probe runs and logs, but
+ * nothing fails, so the `absent` rate can be measured against the total before
+ * enforcement.
+ *
+ * 🔴 Why this is tested at the SCHEMA and not left to inspection. The service reads
+ * `env.CREATE_IMAGE_VERIFY_MEDIA_ENFORCE === true`. If the schema yielded the STRING
+ * `'true'` instead of a boolean, that comparison would be false forever and the gate
+ * could never be turned on — an inert config key that reads as enabled and does
+ * nothing, with no error anywhere. The values below are hand-written literals for what
+ * a deployment actually sets, not values recomputed from the schema.
+ *
+ * Sibling of server-schema-upload-complete-verify.test.ts, which pins the same
+ * property for the multipart-completion gate this one is modelled on.
+ */
+const field = serverSchema.shape.CREATE_IMAGE_VERIFY_MEDIA_ENFORCE;
+
+describe('CREATE_IMAGE_VERIFY_MEDIA_ENFORCE env gate', () => {
+  it('defaults to false when unset — enforcement is opt-in', () => {
+    expect(field.parse(undefined)).toBe(false);
+  });
+
+  it("yields a real BOOLEAN true for the string 'true', so `=== true` can fire", () => {
+    const parsed = field.parse('true');
+    expect(parsed).toBe(true);
+    expect(typeof parsed).toBe('boolean');
+  });
+
+  it.each(['', 'false', 'FALSE', 'no', '0', 'yes', 'garbage', 'TRUE '])(
+    'treats %j as NOT enforcing — a malformed value lands on observe-only, never on rejecting',
+    (value) => {
+      const parsed = field.parse(value);
+      expect(parsed).toBe(false);
+      expect(typeof parsed).toBe('boolean');
+    }
+  );
+
+  it('accepts a real boolean true as well', () => {
+    expect(field.parse(true)).toBe(true);
+  });
+});

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -666,14 +666,36 @@ export const serverSchema = z
     //      a write-only/rotated key answers 403 — both land on `unknown`, both look
     //      clean. A low `absent` count is only meaningful once `present` proves the probe
     //      reaches the bucket at all.
-    //   2. `unknown` is a small share of the total. A large `unknown` share means the
-    //      probe is mostly failing open, so the `absent` count is not a rate.
-    //   3. The `absent` rate is at or below the known defect rate of ~0.01% (10 rows in
-    //      ~101k/day of key mints — NOT the ~0.04% an earlier draft of this comment gave;
-    //      that number divided by a sample size instead of a rate). Materially higher and
-    //      the excess is false rejects. Settle "defect or false reject" by taking a
-    //      logged `absent` key and HEADing the bucket by hand — which is what the `url`
-    //      field on the log line exists for.
+    //   2. `unknown` is a small share of the PROBED lines (`present + absent + unknown`,
+    //      i.e. excluding `not-applicable`). A large `unknown` share means the probe is
+    //      mostly failing open, so the `absent` count is not a rate.
+    //   3. The `absent` rate is at or below ~0.011%.
+    //
+    // 🔴 CONDITION 3'S DENOMINATOR IS THE LOG'S OWN LINE COUNT, and that is the whole
+    // reason a line is emitted on EVERY call rather than only on a bad verdict:
+    //
+    //        absent rate = (lines with verdict `absent`) / (ALL `create-image-media-
+    //                       verify` lines in the window)
+    //
+    // One line per `createImage` call, so the denominator is "image creations" — which is
+    // exactly the population the numerator was measured against: **10 defective rows over
+    // ~92,000 image creations in the same ~24 h window ⇒ ~0.011%**, about 1 in 9,000.
+    // Numerator and denominator come from one query over one population; nothing here is
+    // reconciled across two.
+    //
+    // 🔴 TWO OTHER FIGURES ARE IN CIRCULATION AND NEITHER IS THIS DENOMINATOR:
+    //   - **~22,800** was the SAMPLE SIZE an early defect query examined, not a rate and
+    //     not a population count. Dividing by it produced ~0.04%; that number is retired.
+    //   - **~101k–105k/day** is the KEY-MINT rate (`POST /api/v1/image-upload[/multipart]
+    //     /index`, spanmetrics x10). Different population: browser-originated upload
+    //     requests, not image creations. It is quoted in the PR body only as an
+    //     order-of-magnitude cross-check — it lands within ~10% of 92,000, which is what
+    //     you would expect given abandoned uploads on one side and server-side creation
+    //     paths on the other. Do NOT use it as the threshold's denominator.
+    //
+    // Materially above ~0.011% and the excess is false rejects. Settle "defect or false
+    // reject" per-verdict by taking a logged `absent` key and HEADing the bucket by hand —
+    // which is what the `url` field on the log line exists for.
     //
     // 🔴 `=1` and `=TRUE` are SILENT NO-OPS. `zc.booleanString` is an exact,
     // case-sensitive match on `'true'`; every other value parses to `false` without

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -671,6 +671,13 @@ export const serverSchema = z
     //      mostly failing open, so the `absent` count is not a rate.
     //   3. The `absent` rate is at or below ~0.011%.
     //
+    // 🔴 CONDITION 3'S NUMBER IS A DATED MEASUREMENT, NOT A LIVE RATE. It was taken once,
+    // on 2026-08-28, and has not been re-run; the id-range window it used has since
+    // advanced. Re-derive it before grading anything against it — the derivation is
+    // written out in `src/server/utils/created-image-media-probe.ts`, including the exact
+    // query. This caveat used to live only in the PR description, where nobody reads it at
+    // the moment they act on the threshold.
+    //
     // 🔴 CONDITION 3'S DENOMINATOR IS THE LOG'S OWN LINE COUNT, and that is the whole
     // reason a line is emitted on EVERY call rather than only on a bad verdict:
     //
@@ -679,19 +686,24 @@ export const serverSchema = z
     //
     // One line per `createImage` call, so the denominator is "image creations" — which is
     // exactly the population the numerator was measured against: **10 defective rows over
-    // ~92,000 image creations in the same ~24 h window ⇒ ~0.011%**, about 1 in 9,000.
-    // Numerator and denominator come from one query over one population; nothing here is
-    // reconciled across two.
+    // 92,759 image creations in the same ~24 h window ⇒ 0.0108%**, about 1 in 9,000. Both
+    // come from ONE query over ONE population — `Image` rows in the id range
+    // 141000000–141100000, spanning 2026-08-27 14:28 → 2026-08-28 14:29 — so nothing here
+    // is reconciled across two. The full derivation is in
+    // `src/server/utils/created-image-media-probe.ts`.
     //
     // 🔴 TWO OTHER FIGURES ARE IN CIRCULATION AND NEITHER IS THIS DENOMINATOR:
-    //   - **~22,800** was the SAMPLE SIZE an early defect query examined, not a rate and
-    //     not a population count. Dividing by it produced ~0.04%; that number is retired.
+    //   - **~22,846** was a set of three `media_locations` REGISTRY-COVERAGE samples
+    //     (872 + 3,568 + 18,406), run for a different question and with a different
+    //     finding: 3 unregistered rows, not 10. The 10 did NOT come from it, so
+    //     `10 / 22,800` divides a numerator by a denominator it was never measured
+    //     against. That produced ~0.04%; it is retired, and this is why.
     //   - **~101k–105k/day** is the KEY-MINT rate (`POST /api/v1/image-upload[/multipart]
     //     /index`, spanmetrics x10). Different population: browser-originated upload
-    //     requests, not image creations. It is quoted in the PR body only as an
-    //     order-of-magnitude cross-check — it lands within ~10% of 92,000, which is what
-    //     you would expect given abandoned uploads on one side and server-side creation
-    //     paths on the other. Do NOT use it as the threshold's denominator.
+    //     requests, not image creations. It is quoted only as an order-of-magnitude
+    //     cross-check — spread against 92,759 is **10% at 24 h and 14% at 7 d**, which is
+    //     what you would expect given abandoned uploads on one side and server-side
+    //     creation paths on the other. Do NOT use it as the threshold's denominator.
     //
     // Materially above ~0.011% and the excess is false rejects. Settle "defect or false
     // reject" per-verdict by taking a logged `absent` key and HEADing the bucket by hand —

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -652,13 +652,35 @@ export const serverSchema = z
     UPLOAD_COMPLETE_VERIFY_ENFORCE: zc.booleanString.optional().default(false),
     // Enforce the media-existence check in `createImage` (every Image row, whatever
     // the entry point). Same family, same stance as the flag above.
+    //
     // 🔴 Defaults to FALSE = observe-only: the probe still runs and its verdict is
     // logged on every call, but an `absent` verdict does NOT reject the creation. The
-    // measurement has to come first — the observed defect rate is ~10 rows in ~22,800
-    // creations, so a false-reject rate anywhere near that would cost more than the
-    // bug, and it can only be read from the log this emits. Flip it only once the
-    // logged `absent` rate has been compared against the total and matches the known
-    // defect rate.
+    // measurement has to come first, and it can only be read from the log this emits.
+    //
+    // 🔴 THREE CONDITIONS, ALL REQUIRED, before flipping this on — see the PR body for
+    // the derivation:
+    //
+    //   1. POSITIVE CONTROL: a NON-ZERO `present` count in the window. A probe that can
+    //      never answer emits zero `absent` verdicts, and "zero absent" is exactly what a
+    //      clean result looks like. `getB2ImageS3Client()` throws without credentials and
+    //      a write-only/rotated key answers 403 — both land on `unknown`, both look
+    //      clean. A low `absent` count is only meaningful once `present` proves the probe
+    //      reaches the bucket at all.
+    //   2. `unknown` is a small share of the total. A large `unknown` share means the
+    //      probe is mostly failing open, so the `absent` count is not a rate.
+    //   3. The `absent` rate is at or below the known defect rate of ~0.01% (10 rows in
+    //      ~101k/day of key mints — NOT the ~0.04% an earlier draft of this comment gave;
+    //      that number divided by a sample size instead of a rate). Materially higher and
+    //      the excess is false rejects. Settle "defect or false reject" by taking a
+    //      logged `absent` key and HEADing the bucket by hand — which is what the `url`
+    //      field on the log line exists for.
+    //
+    // 🔴 `=1` and `=TRUE` are SILENT NO-OPS. `zc.booleanString` is an exact,
+    // case-sensitive match on `'true'`; every other value parses to `false` without
+    // error. The only tell is `enforcing: false` on the `create-image-media-verify` log
+    // line — check that after setting it, not the deploy.
+    //
+    // Flipping it back off is a config change, not a revert.
     CREATE_IMAGE_VERIFY_MEDIA_ENFORCE: zc.booleanString.optional().default(false),
     POST_INTENT_DETAILS_HOSTS: z.preprocess(stringToArray, z.array(z.url()).optional()),
     CHOPPED_TOKEN: z.string().optional(),

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -650,6 +650,16 @@ export const serverSchema = z
     // an env var rather than a Flipt flag: this endpoint family removed Flipt
     // precisely because init failure caused a silent fallback.
     UPLOAD_COMPLETE_VERIFY_ENFORCE: zc.booleanString.optional().default(false),
+    // Enforce the media-existence check in `createImage` (every Image row, whatever
+    // the entry point). Same family, same stance as the flag above.
+    // 🔴 Defaults to FALSE = observe-only: the probe still runs and its verdict is
+    // logged on every call, but an `absent` verdict does NOT reject the creation. The
+    // measurement has to come first — the observed defect rate is ~10 rows in ~22,800
+    // creations, so a false-reject rate anywhere near that would cost more than the
+    // bug, and it can only be read from the log this emits. Flip it only once the
+    // logged `absent` rate has been compared against the total and matches the known
+    // defect rate.
+    CREATE_IMAGE_VERIFY_MEDIA_ENFORCE: zc.booleanString.optional().default(false),
     POST_INTENT_DETAILS_HOSTS: z.preprocess(stringToArray, z.array(z.url()).optional()),
     CHOPPED_TOKEN: z.string().optional(),
     TIER_METADATA_KEY: z.string().default('tier'),

--- a/src/hooks/__tests__/useCFImageUpload.test.ts
+++ b/src/hooks/__tests__/useCFImageUpload.test.ts
@@ -1,0 +1,318 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * `uploadToCF` — the PROMISE is the contract, and it was broken.
+ *
+ * The hook's `loadend` listener used to compute `success` and then `resolve(success)`
+ * on EVERY outcome. XHR fires `error` only on a NETWORK failure, so a PUT that
+ * reaches the store and is refused — an expired presign (403), a malformed request
+ * (400), a store that is briefly unavailable (503) — completes normally, lands on
+ * `load` → `loadend`, and was reported to the caller as a successful upload. Every
+ * caller discards that boolean and `uploadToCF` returns `{ url, id, ... }`
+ * unconditionally, so consumers persisted a media key with nothing behind it.
+ *
+ * 🔴 These assert the PROMISE OUTCOME, not the tracked-file UI state. The UI state
+ * was already wrong here (a refused PUT left the tile on `uploading`) but only
+ * cosmetically; the promise is what the row was written from. One case below does
+ * additionally pin the tracked status, and it is the ABORT one — because `abort` is
+ * followed by its own `loadend`, so the new rejecting branch could silently
+ * overwrite `aborted` with `error`.
+ *
+ * Expected values are hand-written literals for what a caller observes, never
+ * recomputed from the hook.
+ */
+
+// React 18.3 exposes `act` on the `react` export, but our @types/react (18.0.14)
+// predates that typing. Use the runtime `React.act` and borrow the typed signature.
+const act = (React as unknown as { act: typeof actType }).act;
+
+const { preprocessFileMock, auditImageMetaMock, showErrorNotificationMock } = vi.hoisted(() => ({
+  preprocessFileMock: vi.fn(),
+  auditImageMetaMock: vi.fn(),
+  showErrorNotificationMock: vi.fn(),
+}));
+
+// Only the two functions `getDataFromFile` calls are replaced; every other export of
+// the module is carried through, so nothing else in the hook's import graph silently
+// loses a binding.
+vi.mock('~/utils/media-preprocessors', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  preprocessFile: preprocessFileMock,
+  auditImageMeta: auditImageMetaMock,
+}));
+vi.mock('~/utils/notifications', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  showErrorNotification: showErrorNotificationMock,
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, isModerator: false }),
+}));
+
+import { useCFImageUpload } from '~/hooks/useCFImageUpload';
+
+/** The key the (stubbed) /api/v1/image-upload endpoint hands back. */
+const UPLOAD_ID = '11111111-2222-4333-8444-555555555555';
+const UPLOAD_URL = `https://store.example/${UPLOAD_ID}?signature=abc`;
+
+type Listener = (this: unknown) => void;
+
+/**
+ * A hand-rolled XHR double, so each test drives the exact event sequence a real
+ * XMLHttpRequest produces. The distinction under test lives entirely in WHICH event
+ * fires — a refused PUT emits `load`+`loadend` and NOT `error` — so a double that
+ * only exposed a "did it fail" flag could not express the bug at all.
+ */
+class FakeXhr {
+  static instances: FakeXhr[] = [];
+
+  readyState = 0;
+  status = 0;
+  openedWith: { method: string; url: string } | null = null;
+  sentBody: unknown = undefined;
+  aborted = false;
+
+  private listeners: Record<string, Listener[]> = {};
+  private uploadListeners: Record<string, Listener[]> = {};
+
+  upload = {
+    addEventListener: (type: string, handler: Listener) => {
+      (this.uploadListeners[type] ??= []).push(handler);
+    },
+  };
+
+  constructor() {
+    FakeXhr.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: Listener) {
+    (this.listeners[type] ??= []).push(handler);
+  }
+
+  open(method: string, url: string) {
+    this.openedWith = { method, url };
+  }
+
+  send(body: unknown) {
+    this.sentBody = body;
+  }
+
+  abort() {
+    this.aborted = true;
+  }
+
+  /** Fire one listener type, as the browser would. */
+  emit(type: string) {
+    for (const handler of this.listeners[type] ?? []) handler.call(this);
+  }
+
+  /** A PUT that got an HTTP answer: `load` then `loadend`. No `error` — that is the point. */
+  completeWithStatus(status: number) {
+    this.readyState = 4;
+    this.status = status;
+    this.emit('load');
+    this.emit('loadend');
+  }
+
+  /** A network failure: `error` then `loadend`, status 0. */
+  failWithNetworkError() {
+    this.readyState = 4;
+    this.status = 0;
+    this.emit('error');
+    this.emit('loadend');
+  }
+
+  /** A cancel: `abort` then `loadend`. */
+  cancel() {
+    this.readyState = 4;
+    this.status = 0;
+    this.emit('abort');
+    this.emit('loadend');
+  }
+}
+
+type HookApi = ReturnType<typeof useCFImageUpload>;
+
+function renderUploader() {
+  const captured: { current: HookApi | null } = { current: null };
+  function Probe() {
+    captured.current = useCFImageUpload();
+    return null;
+  }
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(Probe));
+  });
+  return {
+    get api() {
+      if (!captured.current) throw new Error('hook did not render');
+      return captured.current;
+    },
+    unmount() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+/** Start an upload and wait until the hook has created (and opened) its XHR. */
+async function startUpload(api: HookApi) {
+  const file = new File([new Uint8Array([1, 2, 3])], 'pic.png', { type: 'image/png' });
+  const promise = api.uploadToCF(file);
+  // Never leave it unattached — a rejection before the test attaches its own handler
+  // would be an unhandled rejection that fails the run for the wrong reason.
+  const settled = promise.then(
+    (value) => ({ outcome: 'resolved' as const, value }),
+    (error: unknown) => ({ outcome: 'rejected' as const, error })
+  );
+  await vi.waitFor(() => {
+    expect(FakeXhr.instances.length).toBe(1);
+    expect(FakeXhr.instances[0].openedWith).not.toBeNull();
+  });
+  return { xhr: FakeXhr.instances[0], settled, file };
+}
+
+let originalXhr: typeof XMLHttpRequest;
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  FakeXhr.instances = [];
+  preprocessFileMock.mockResolvedValue({
+    type: 'image',
+    meta: {},
+    metadata: { width: 640, height: 480, hash: 'LKO2' },
+    objectUrl: 'blob:local-preview',
+  });
+  auditImageMetaMock.mockResolvedValue({ blockedFor: undefined });
+
+  originalXhr = globalThis.XMLHttpRequest;
+  originalFetch = globalThis.fetch;
+  globalThis.XMLHttpRequest = FakeXhr as unknown as typeof XMLHttpRequest;
+  globalThis.fetch = vi.fn(async () => ({
+    json: async () => ({ id: UPLOAD_ID, uploadURL: UPLOAD_URL }),
+  })) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.XMLHttpRequest = originalXhr;
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+describe('uploadToCF — a PUT that is refused must REJECT', () => {
+  // All three, not just one: 403 is the expired-presign case that produced the
+  // production defect, 400 is a malformed request, 500 is the store faulting. They
+  // travel the same `load` → `loadend` path and a guard that only names one of them
+  // would let the other two through.
+  it.each([403, 400, 500])(
+    'rejects when the presigned PUT completes with HTTP %i',
+    async (status) => {
+      const view = renderUploader();
+      try {
+        const { xhr, settled } = await startUpload(view.api);
+        await act(async () => {
+          xhr.completeWithStatus(status);
+        });
+        const result = await settled;
+        expect(result.outcome).toBe('rejected');
+        expect((result as { error: Error }).error).toBeInstanceOf(Error);
+        expect((result as { error: Error }).error.message).toBe(`Upload failed (status ${status})`);
+      } finally {
+        view.unmount();
+      }
+    }
+  );
+
+  it('marks the tracked file `error` on a refused PUT, so a spinner keyed on `uploading` clears', async () => {
+    const view = renderUploader();
+    try {
+      const { xhr, settled } = await startUpload(view.api);
+      await act(async () => {
+        xhr.completeWithStatus(403);
+      });
+      await settled;
+      expect(view.api.files.map((f) => f.status)).toEqual(['error']);
+    } finally {
+      view.unmount();
+    }
+  });
+});
+
+describe('uploadToCF — outcomes that must NOT change', () => {
+  it('resolves a 200 with the existing shape', async () => {
+    const view = renderUploader();
+    try {
+      const { xhr, settled } = await startUpload(view.api);
+      await act(async () => {
+        xhr.completeWithStatus(200);
+      });
+      const result = await settled;
+      expect(result.outcome).toBe('resolved');
+      // Literal expectations for what a caller has always observed: the signed URL
+      // with its query stripped, the key, the local preview URL, and the media type.
+      expect((result as { value: unknown }).value).toEqual({
+        url: 'https://store.example/11111111-2222-4333-8444-555555555555',
+        id: UPLOAD_ID,
+        objectUrl: 'blob:local-preview',
+        type: 'image',
+      });
+      expect(view.api.files.map((f) => f.status)).toEqual(['success']);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it('keeps rejecting on a network `error` event', async () => {
+    const view = renderUploader();
+    try {
+      const { xhr, settled } = await startUpload(view.api);
+      await act(async () => {
+        xhr.failWithNetworkError();
+      });
+      const result = await settled;
+      expect(result.outcome).toBe('rejected');
+      expect((result as { error: Error }).error.message).toBe('Upload failed (status 0)');
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it('keeps rejecting on `abort`, and the tracked status stays `aborted`', async () => {
+    // 🔴 The regression this guards is specific to the fix: `abort` is followed by a
+    // `loadend` whose status is not 200, so the new rejecting branch would run second
+    // and overwrite `aborted` with `error` — and change the message the caller sees.
+    const view = renderUploader();
+    try {
+      const { xhr, settled } = await startUpload(view.api);
+      await act(async () => {
+        xhr.cancel();
+      });
+      const result = await settled;
+      expect(result.outcome).toBe('rejected');
+      expect((result as { error: Error }).error.message).toBe('Upload canceled');
+      expect(view.api.files.map((f) => f.status)).toEqual(['aborted']);
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it('sends the file to the signed URL with PUT', async () => {
+    const view = renderUploader();
+    try {
+      const { xhr, settled, file } = await startUpload(view.api);
+      expect(xhr.openedWith).toEqual({ method: 'PUT', url: UPLOAD_URL });
+      expect(xhr.sentBody).toBe(file);
+      await act(async () => {
+        xhr.completeWithStatus(200);
+      });
+      await settled;
+    } finally {
+      view.unmount();
+    }
+  });
+});

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -110,8 +110,15 @@ export const useCFImageUpload: UseCFImageUpload = () => {
       );
     }
 
-    await new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       let uploadStart = Date.now();
+      /**
+       * `error` / `abort` are each followed by a `loadend`, so without this the
+       * settled outcome would be re-decided by the handler below — harmless for the
+       * promise (already settled) but it would overwrite the tracked file's
+       * `aborted` status with `error`. Set by whichever terminal handler runs first.
+       */
+      let terminated = false;
       xhr.upload.addEventListener('loadstart', () => {
         uploadStart = Date.now();
       });
@@ -136,18 +143,42 @@ export const useCFImageUpload: UseCFImageUpload = () => {
         }
       });
       xhr.addEventListener('loadend', () => {
+        if (terminated) return;
         const success = xhr.readyState === 4 && xhr.status === 200;
         if (success) {
           updateFile({ status: 'success' });
           // URL.revokeObjectURL(imageData.objectUrl);
+          resolve();
+          return;
         }
-        resolve(success);
+        /**
+         * 🔴 A FAILED PUT MUST REJECT. This used to `resolve(success)` on every
+         * outcome and the caller discarded the value, so `uploadToCF` returned its
+         * `{ url, id, ... }` unconditionally and consumers persisted a media key
+         * with nothing behind it.
+         *
+         * XHR's `error` event fires only on a NETWORK failure. A PUT that reaches
+         * the store and is refused — an expired presign (403), a malformed request
+         * (400), a store that is briefly unavailable (503) — completes normally and
+         * lands HERE, on `load` → `loadend`. That is the whole gap: measured over
+         * ~22,800 image creations, 10 rows referenced media that was never stored,
+         * and 7 of those had a real upload attempted seconds earlier that failed
+         * silently down this path.
+         *
+         * The status is in the message deliberately: the consumers that surface
+         * `error.message` then say which failure it was, and the ones that swallow
+         * it at least stop persisting the key.
+         */
+        updateFile({ status: 'error' });
+        reject(new Error(`Upload failed (status ${xhr.status})`));
       });
       xhr.addEventListener('error', () => {
+        terminated = true;
         updateFile({ status: 'error' });
         reject(new Error(`Upload failed (status ${xhr.status})`));
       });
       xhr.addEventListener('abort', () => {
+        terminated = true;
         updateFile({ status: 'aborted' });
         reject(new Error('Upload canceled'));
       });

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -7,8 +7,8 @@ import { showErrorNotification } from '~/utils/notifications';
 import { isDefined } from '~/utils/type-guards';
 import { v4 as uuidv4 } from 'uuid';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import type { TrackedFileStatus } from '~/utils/upload-status';
 
-type TrackedFileStatus = 'pending' | 'error' | 'success' | 'uploading' | 'aborted' | 'blocked';
 type TrackedFile = AsyncReturnType<typeof getDataFromFile> & {
   progress: number;
   uploaded: number;

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -174,8 +174,9 @@ export const useCFImageUpload: UseCFImageUpload = () => {
          * lands HERE, on `load` → `loadend`. That is the whole gap: over a ~24 h
          * window 10 rows referenced media that was never stored, and 7 of those had
          * a real upload attempted seconds earlier that failed silently down this
-         * path. (~22,800 was the sample size that query examined, not a rate — see
-         * `created-image-media-probe.ts` for the corrected denominator.)
+         * path. (The denominator is 92,759 image creations over that window;
+         * ~22,846 is a DIFFERENT population — a registry-coverage sample whose own
+         * finding was 3, not 10. See `created-image-media-probe.ts`.)
          *
          * The status is in the message deliberately: the consumers that surface
          * `error.message` then say which failure it was, and the ones that swallow

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -144,6 +144,17 @@ export const useCFImageUpload: UseCFImageUpload = () => {
       });
       xhr.addEventListener('loadend', () => {
         if (terminated) return;
+        /**
+         * KNOWN COUPLING, recorded rather than changed: success is `status === 200`
+         * EXACTLY, and that predicate now decides whether the promise rejects rather
+         * than only what the tracked file's status says. A store that answered a
+         * single-shot PUT with `201`, `204` or a `3xx` would be turned into a hard
+         * failure and the row would not be written. That is the correct direction to
+         * err (it refuses to persist a key it is not sure about), and B2's S3 API
+         * answers 200 to this PUT today — but it is a behavioural dependency on the
+         * store's exact status code, so widening it is a deliberate decision and not
+         * a tidy-up.
+         */
         const success = xhr.readyState === 4 && xhr.status === 200;
         if (success) {
           updateFile({ status: 'success' });
@@ -160,10 +171,11 @@ export const useCFImageUpload: UseCFImageUpload = () => {
          * XHR's `error` event fires only on a NETWORK failure. A PUT that reaches
          * the store and is refused — an expired presign (403), a malformed request
          * (400), a store that is briefly unavailable (503) — completes normally and
-         * lands HERE, on `load` → `loadend`. That is the whole gap: measured over
-         * ~22,800 image creations, 10 rows referenced media that was never stored,
-         * and 7 of those had a real upload attempted seconds earlier that failed
-         * silently down this path.
+         * lands HERE, on `load` → `loadend`. That is the whole gap: over a ~24 h
+         * window 10 rows referenced media that was never stored, and 7 of those had
+         * a real upload attempted seconds earlier that failed silently down this
+         * path. (~22,800 was the sample size that query examined, not a rate — see
+         * `created-image-media-probe.ts` for the corrected denominator.)
          *
          * The status is in the message deliberately: the consumers that surface
          * `error.message` then say which failure it was, and the ones that swallow

--- a/src/pages/comics/create.tsx
+++ b/src/pages/comics/create.tsx
@@ -40,6 +40,7 @@ import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { formatGenreLabel } from '~/utils/comic-helpers';
 import { openGeneratorImagePicker } from '~/utils/comic-image-picker';
 import { ComicGenre } from '~/shared/utils/prisma/enums';
+import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import styles from './CreateComic.module.scss';
 
@@ -105,9 +106,21 @@ function CreateComicPage() {
         onConfirm: async (output: { src: string; cropped?: Blob }[]) => {
           const blob = output[0]?.cropped;
           const uploadFile = blob ? new File([blob], 'cover.jpg', { type: blob.type }) : file;
-          const result = await uploadCoverToCF(uploadFile);
-          setCoverUrl(result.id);
-          URL.revokeObjectURL(url);
+          /**
+           * 🔴 `finally`, because `uploadToCF` now REJECTS on a refused PUT. `onConfirm`
+           * is typed `() => void` and the modal discards the promise, so a rejection
+           * skipped the revoke and `onCancel` can no longer run — the blob was retained
+           * for the page's lifetime. The catch also surfaces the failure, which the
+           * dropped promise otherwise swallowed entirely.
+           */
+          try {
+            const result = await uploadCoverToCF(uploadFile);
+            setCoverUrl(result.id);
+          } catch (error) {
+            showErrorNotification({ title: 'Upload failed', error: error as Error });
+          } finally {
+            URL.revokeObjectURL(url);
+          }
         },
         onCancel: () => URL.revokeObjectURL(url),
       },
@@ -116,8 +129,12 @@ function CreateComicPage() {
 
   const handleHeroDrop = async (files: File[]) => {
     if (files.length === 0) return;
-    const result = await uploadHeroToCF(files[0]);
-    setHeroUrl(result.id);
+    try {
+      const result = await uploadHeroToCF(files[0]);
+      setHeroUrl(result.id);
+    } catch (error) {
+      showErrorNotification({ title: 'Upload failed', error: error as Error });
+    }
   };
 
   const handlePickCoverFromGenerator = () =>

--- a/src/pages/comics/project/[id]/character.tsx
+++ b/src/pages/comics/project/[id]/character.tsx
@@ -46,6 +46,7 @@ import { Meta } from '~/components/Meta/Meta';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { trpc } from '~/utils/trpc';
+import { showErrorNotification } from '~/utils/notifications';
 import { fetchAndUploadGeneratorImage } from '~/utils/comic-image-picker';
 import { fetchBlob } from '~/utils/file-utils';
 
@@ -350,7 +351,27 @@ function ReferenceUpload() {
 
   const handleRefImageDrop = async (files: File[]) => {
     for (const file of files) {
-      const result = await uploadToCF(file);
+      /**
+       * 🔴 PER-FILE, so one refused PUT cannot end the batch.
+       *
+       * `uploadToCF` now rejects on a refused PUT instead of resolving as if it had
+       * worked. Un-caught, that throw leaves the `for` loop: files 2..N are never
+       * attempted, nothing is shown, and the rejection escapes into Mantine's `onDrop`
+       * (and `onDropCapture`), both of which discard the promise. Before the hook change
+       * a 403 resolved and the loop continued — with a dead key — so the loop's
+       * continue-on-failure behaviour is pre-existing and is what is restored here; only
+       * the dead key and the silence are removed.
+       */
+      let result: Awaited<ReturnType<typeof uploadToCF>>;
+      try {
+        result = await uploadToCF(file);
+      } catch (error) {
+        showErrorNotification({
+          title: `Failed to upload ${file.name}`,
+          error: error as Error,
+        });
+        continue;
+      }
       const img = new window.Image();
       img.src = result.objectUrl;
       await new Promise<void>((resolve) => {

--- a/src/pages/comics/project/[id]/character.tsx
+++ b/src/pages/comics/project/[id]/character.tsx
@@ -401,16 +401,26 @@ function ReferenceUpload() {
      * One notification naming how many of how many failed, and which files — not one toast
      * per file, which over a ten-file drop buries the UI it is reporting on.
      *
-     * 🔴 THE COST, SO IT IS A DECISION AND NOT AN ACCIDENT: failure feedback is now
-     * DEFERRED TO THE END OF THE BATCH. Previously each failure toasted the moment it
-     * happened. On a ten-file drop with a slow tail, a user whose FIRST file was refused
-     * now waits for every remaining upload to finish before being told anything — the loop
-     * is sequential (`await` per file, plus an `img.onload`/`onerror` round-trip each), so
-     * that wait is the whole batch, not a scheduling artefact. Judged the better trade at
-     * ten files, where per-file toasts stack over the grid they describe; it is the worse
-     * trade at two files with a 30 s tail. If that shape shows up, the fix is to surface
-     * failures incrementally in-place (a marker on the tile) rather than to go back to a
-     * toast per file.
+     * 🔴 THE COST, SO IT IS A DECISION AND NOT AN ACCIDENT — AND NAME THE BASELINE, because
+     * the two available ones give opposite verdicts:
+     *
+     * - vs `88d3ec9c12`, an EARLIER COMMIT OF THIS SAME PR, this is a regression in latency:
+     *   that commit toasted each failure the moment it happened, and feedback is now
+     *   DEFERRED TO THE END OF THE BATCH. On a ten-file drop with a slow tail, a user whose
+     *   FIRST file was refused waits for every remaining upload before being told anything —
+     *   the loop is sequential (`await` per file, plus an `img.onload`/`onerror` round-trip
+     *   each), so that wait is the whole batch, not a scheduling artefact.
+     * - vs `main` (`ed0b0b04e3`), i.e. SHIPPED behaviour, this is a strict improvement:
+     *   `handleRefImageDrop` had no `catch` at all there, so the first refused PUT threw out
+     *   of the async handler into Mantine's `onDrop`, which discards the promise. Files
+     *   2..N were never attempted and the user was told NOTHING, ever.
+     *
+     * So nothing a user has today gets worse. The trade being weighed is only between two
+     * candidate designs inside this PR, and per-file toasts were judged the worse of the two
+     * at ten files, where they stack over the grid they describe; they are the better one at
+     * two files with a 30 s tail. If that shape shows up, the fix is to surface failures
+     * incrementally in-place (a marker on the tile) rather than to go back to a toast per
+     * file.
      *
      * 🔴 AND THIS LOOP IS MOUNTED BY NO TEST. `PanelModal`'s twin was extracted into
      * `bulk-panel-upload.ts` precisely so it could be driven; this one was not, so its

--- a/src/pages/comics/project/[id]/character.tsx
+++ b/src/pages/comics/project/[id]/character.tsx
@@ -397,8 +397,26 @@ function ReferenceUpload() {
       });
     }
 
-    // One notification naming how many of how many failed, and which files — not one
-    // toast per file, which over a ten-file drop buries the UI it is reporting on.
+    /**
+     * One notification naming how many of how many failed, and which files — not one toast
+     * per file, which over a ten-file drop buries the UI it is reporting on.
+     *
+     * 🔴 THE COST, SO IT IS A DECISION AND NOT AN ACCIDENT: failure feedback is now
+     * DEFERRED TO THE END OF THE BATCH. Previously each failure toasted the moment it
+     * happened. On a ten-file drop with a slow tail, a user whose FIRST file was refused
+     * now waits for every remaining upload to finish before being told anything — the loop
+     * is sequential (`await` per file, plus an `img.onload`/`onerror` round-trip each), so
+     * that wait is the whole batch, not a scheduling artefact. Judged the better trade at
+     * ten files, where per-file toasts stack over the grid they describe; it is the worse
+     * trade at two files with a 30 s tail. If that shape shows up, the fix is to surface
+     * failures incrementally in-place (a marker on the tile) rather than to go back to a
+     * toast per file.
+     *
+     * 🔴 AND THIS LOOP IS MOUNTED BY NO TEST. `PanelModal`'s twin was extracted into
+     * `bulk-panel-upload.ts` precisely so it could be driven; this one was not, so its
+     * continue-on-failure policy and this aggregation are reviewed-by-reading only. That is
+     * the honest label for it.
+     */
     const report = batchUploadFailureNotification(failed, files.length);
     if (report) showErrorNotification(report);
   };

--- a/src/pages/comics/project/[id]/character.tsx
+++ b/src/pages/comics/project/[id]/character.tsx
@@ -422,7 +422,9 @@ function ReferenceUpload() {
             <Card withBorder p="xl">
               <Stack align="center" gap="lg">
                 <IconAlertTriangle size={40} className="text-yellow-500" />
-                <Text size="sm" c="dimmed">This reference could not be found.</Text>
+                <Text size="sm" c="dimmed">
+                  This reference could not be found.
+                </Text>
                 <Button component={Link} href={`/comics/project/${projectId}`}>
                   Back to Project
                 </Button>
@@ -530,12 +532,19 @@ function ReferenceUpload() {
                       </>
                     )}
                     {(existingReference as any).type && (
-                      <Badge size="sm" variant="light" color={
-                        (existingReference as any).type === 'Location' ? 'teal'
-                        : (existingReference as any).type === 'Style' ? 'orange'
-                        : (existingReference as any).type === 'Item' ? 'grape'
-                        : 'blue'
-                      }>
+                      <Badge
+                        size="sm"
+                        variant="light"
+                        color={
+                          (existingReference as any).type === 'Location'
+                            ? 'teal'
+                            : (existingReference as any).type === 'Style'
+                            ? 'orange'
+                            : (existingReference as any).type === 'Item'
+                            ? 'grape'
+                            : 'blue'
+                        }
+                      >
                         {(existingReference as any).type}
                       </Badge>
                     )}
@@ -627,7 +636,8 @@ function ReferenceUpload() {
                                     e.stopPropagation();
                                     openConfirmModal({
                                       title: 'Delete Reference Image',
-                                      children: 'Are you sure you want to delete this reference image?',
+                                      children:
+                                        'Are you sure you want to delete this reference image?',
                                       labels: { confirm: 'Delete', cancel: 'Cancel' },
                                       confirmProps: { color: 'red' },
                                       onConfirm: () => {
@@ -739,8 +749,7 @@ function ReferenceUpload() {
                                       'ref_add',
                                       uploadToCF
                                     );
-                                    const previewUrl =
-                                      getEdgeUrl(cfId, { width: 200 }) ?? img.url;
+                                    const previewUrl = getEdgeUrl(cfId, { width: 200 }) ?? img.url;
                                     setUploadedImages((prev) => [
                                       ...prev,
                                       { url: cfId, previewUrl, width, height },
@@ -835,7 +844,9 @@ function ReferenceUpload() {
               <Card withBorder>
                 <Stack gap="md">
                   <div>
-                    <Text size="sm" fw={500}>Upload Reference Images</Text>
+                    <Text size="sm" fw={500}>
+                      Upload Reference Images
+                    </Text>
                     <Text size="sm" c="dimmed">
                       Upload 1-10 images. These will be used as reference for panel generation.
                     </Text>
@@ -896,20 +907,17 @@ function ReferenceUpload() {
                                   'ref_create',
                                   uploadImageToCF
                                 );
-                                const previewUrl =
-                                  getEdgeUrl(cfId, { width: 200 }) ?? img.url;
+                                const previewUrl = getEdgeUrl(cfId, { width: 200 }) ?? img.url;
                                 // Create a synthetic File-like blob for state consistency
-                                const blob = await fetch(previewUrl).then((r) =>
-                                  r.blob()
-                                );
+                                const blob = await fetch(previewUrl).then((r) => r.blob());
                                 const file = new File([blob], 'generator-image.jpg', {
                                   type: 'image/jpeg',
                                 });
                                 setImages((prev) =>
-                                  [
-                                    ...prev,
-                                    { file, preview: previewUrl, width, height },
-                                  ].slice(0, 10)
+                                  [...prev, { file, preview: previewUrl, width, height }].slice(
+                                    0,
+                                    10
+                                  )
                                 );
                               } catch (err) {
                                 console.error('Failed to pick generator image:', err);
@@ -958,7 +966,9 @@ function ReferenceUpload() {
 
               <Card withBorder>
                 <Stack gap="md">
-                  <Text size="sm" fw={500}>Tips for Good References</Text>
+                  <Text size="sm" fw={500}>
+                    Tips for Good References
+                  </Text>
                   <ul className="text-sm text-gray-400 list-disc ml-4 space-y-1">
                     <li>Clear, front-facing view of the subject</li>
                     <li>Same subject in all images</li>

--- a/src/pages/comics/project/[id]/character.tsx
+++ b/src/pages/comics/project/[id]/character.tsx
@@ -47,6 +47,8 @@ import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { trpc } from '~/utils/trpc';
 import { showErrorNotification } from '~/utils/notifications';
+import type { BatchUploadFailure } from '~/utils/upload-batch';
+import { batchUploadFailureNotification } from '~/utils/upload-batch';
 import { fetchAndUploadGeneratorImage } from '~/utils/comic-image-picker';
 import { fetchBlob } from '~/utils/file-utils';
 
@@ -350,26 +352,24 @@ function ReferenceUpload() {
   };
 
   const handleRefImageDrop = async (files: File[]) => {
+    /**
+     * 🔴 PER-FILE `continue`, AND ONE AGGREGATED REPORT AT THE END — the same policy, from
+     * the same module, as `PanelModal`'s bulk panel drop. See `~/utils/upload-batch`.
+     *
+     * `uploadToCF` now rejects on a refused PUT instead of resolving as if it had worked.
+     * Un-caught, that throw leaves the `for` loop: files 2..N are never attempted, nothing
+     * is shown, and the rejection escapes into Mantine's `onDrop` (and `onDropCapture`),
+     * both of which discard the promise. Before the hook change a 403 resolved and the
+     * loop continued — with a dead key — so continue-on-failure is the pre-existing
+     * behaviour and is what is restored; only the dead key and the silence are removed.
+     */
+    const failed: BatchUploadFailure[] = [];
     for (const file of files) {
-      /**
-       * 🔴 PER-FILE, so one refused PUT cannot end the batch.
-       *
-       * `uploadToCF` now rejects on a refused PUT instead of resolving as if it had
-       * worked. Un-caught, that throw leaves the `for` loop: files 2..N are never
-       * attempted, nothing is shown, and the rejection escapes into Mantine's `onDrop`
-       * (and `onDropCapture`), both of which discard the promise. Before the hook change
-       * a 403 resolved and the loop continued — with a dead key — so the loop's
-       * continue-on-failure behaviour is pre-existing and is what is restored here; only
-       * the dead key and the silence are removed.
-       */
       let result: Awaited<ReturnType<typeof uploadToCF>>;
       try {
         result = await uploadToCF(file);
       } catch (error) {
-        showErrorNotification({
-          title: `Failed to upload ${file.name}`,
-          error: error as Error,
-        });
+        failed.push({ name: file.name, error: error as Error });
         continue;
       }
       const img = new window.Image();
@@ -396,6 +396,11 @@ function ReferenceUpload() {
         };
       });
     }
+
+    // One notification naming how many of how many failed, and which files — not one
+    // toast per file, which over a ten-file drop buries the UI it is reporting on.
+    const report = batchUploadFailureNotification(failed, files.length);
+    if (report) showErrorNotification(report);
   };
 
   const handleSaveUploadedRefs = () => {

--- a/src/pages/moderator/cosmetic-store/badges/index.tsx
+++ b/src/pages/moderator/cosmetic-store/badges/index.tsx
@@ -45,6 +45,7 @@ import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { IMAGE_MIME_TYPE } from '~/shared/constants/mime-types';
 import { formatBytes } from '~/utils/number-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { isUploadInFlight } from '~/utils/upload-status';
 import { trpc } from '~/utils/trpc';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { constants } from '~/server/common/constants';
@@ -289,10 +290,17 @@ function BadgeForm({
       return;
     }
 
-    const result = await uploadToCF(file);
-    setUploadedUrl(result.id);
-    setPreviewUrl(result.objectUrl ?? result.id);
-    setSourceDimensions(dimensions);
+    // 🔴 A refused PUT now REJECTS (see `useCFImageUpload`). Without this catch the
+    // rejection escapes into Mantine's `onDrop`, which discards the promise: the user is
+    // told nothing at all and the console gets an unhandled rejection.
+    try {
+      const result = await uploadToCF(file);
+      setUploadedUrl(result.id);
+      setPreviewUrl(result.objectUrl ?? result.id);
+      setSourceDimensions(dimensions);
+    } catch (error) {
+      showErrorNotification({ title: 'Upload failed', error: error as Error });
+    }
   };
 
   const handleRemoveImage = () => {
@@ -340,7 +348,10 @@ function BadgeForm({
   };
 
   const imageFile = imageFiles[0];
-  const showLoading = imageFile && imageFile.progress < 100;
+  // 🔴 Derived from `status`, NOT from `progress` — see `isUploadInFlight`. The render
+  // below is `showLoading ? overlay : previewUrl ? preview : <Dropzone/>`, so a latched
+  // spinner unmounts the Dropzone and there is no retry without a page reload.
+  const showLoading = isUploadInFlight(imageFile);
 
   return (
     <Stack gap="md">

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4127':
+  'server/services/image.service.ts:4128':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4268':
+  'server/services/image.service.ts:4269':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5006':
+  'server/services/image.service.ts:5007':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6140':
+  'server/services/image.service.ts:6141':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4268')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4269')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/create-image-caller-seam.test.ts
+++ b/src/server/services/__tests__/create-image-caller-seam.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+// Setup-order import: installs the shared ~/env/server / db / logging mocks.
+import '~/__tests__/setup';
+
+/**
+ * THE SEAM: `createImage` is the single funnel every `Image` row for a post goes
+ * through, and `addPostImage` is the single funnel the post entry points go through
+ * to reach it.
+ *
+ * 🔴 That claim is what makes the media-existence check in `createImage` a complete
+ * fix rather than a partial one, and nothing else in this PR tests it. The gate tests
+ * are scoped to `createImage` alone; the callers were never loaded, so a defect living
+ * in the SEAM — a caller that mangles the url before handing it over, or one that
+ * swallows the rejection so enforcement silently does nothing — is invisible to every
+ * one of them.
+ *
+ * Two halves, deliberately:
+ *  - BEHAVIOURAL: drive the real `addPostImage` and assert what actually crosses the
+ *    seam. A structural check would type-check past a wrong argument.
+ *  - STRUCTURAL LEDGER: an asserted list of the entry points, failing when the set
+ *    GROWS (a new path that might not funnel) or SHRINKS (a path silently rerouted).
+ */
+
+const { createImageMock, createImageResourcesMock } = vi.hoisted(() => ({
+  createImageMock: vi.fn(),
+  createImageResourcesMock: vi.fn(async () => undefined),
+}));
+
+// Keep the REAL image.service and override only the two functions `addPostImage`
+// calls into, so nothing else in post.service's import graph loses a binding.
+vi.mock('~/server/services/image.service', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createImage: createImageMock,
+  createImageResources: createImageResourcesMock,
+}));
+
+import { addPostImage } from '~/server/services/post.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const USER = { id: 4242, isModerator: false } as never;
+const POST_ID = 1010;
+const MEDIA_KEY = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+/**
+ * A sentinel thrown BY `createImage`, so each case can inspect exactly what crossed
+ * the seam without having to stand up the whole post-creation tail. It doubles as the
+ * propagation assertion: if `addPostImage` swallowed a `createImage` rejection,
+ * enabling enforcement would silently do nothing and these would not reject.
+ */
+const SENTINEL = new Error('sentinel: createImage was reached');
+
+beforeEach(() => {
+  createImageMock.mockReset();
+  createImageMock.mockRejectedValue(SENTINEL);
+  dbMock.dbRead.post.findFirst.mockReset();
+  dbMock.dbRead.post.findFirst.mockResolvedValue({ userId: USER.id, collection: null });
+  dbMock.dbRead.image.findFirst.mockReset();
+  dbMock.dbRead.image.findFirst.mockResolvedValue(null);
+});
+
+/** What `createImage` was handed, or `undefined` if it was never reached. */
+const seamArgs = () => createImageMock.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+
+describe('addPostImage → createImage seam', () => {
+  it('forwards the client-supplied media KEY verbatim — the probe must see the key the row will carry', async () => {
+    await expect(
+      addPostImage({
+        url: MEDIA_KEY,
+        postId: POST_ID,
+        index: 0,
+        type: 'image',
+        meta: { prompt: 'a cat' },
+        user: USER,
+      } as never)
+    ).rejects.toBe(SENTINEL);
+
+    expect(createImageMock).toHaveBeenCalledTimes(1);
+    // Literal, not recomputed: the key must arrive unmodified — not normalised, not
+    // rewritten into an edge URL. A caller that transformed it would leave the probe
+    // asking the bucket about something that is not the row's `url`.
+    expect(seamArgs()).toMatchObject({ url: MEDIA_KEY, userId: USER.id, postId: POST_ID });
+  });
+
+  it('forwards a full http(s) url verbatim too — the not-applicable case must reach the funnel unchanged', async () => {
+    // `addPostImageSchema` accepts `z.url().or(z.string().uuid())`. The decision to
+    // skip the probe belongs to `createImage`, so the url must arrive intact rather
+    // than being filtered out here.
+    await expect(
+      addPostImage({
+        url: 'https://cdn.example.com/legacy/avatar.png',
+        postId: POST_ID,
+        index: 0,
+        type: 'image',
+        meta: { prompt: 'a cat' },
+        user: USER,
+      } as never)
+    ).rejects.toBe(SENTINEL);
+
+    expect(seamArgs()).toMatchObject({ url: 'https://cdn.example.com/legacy/avatar.png' });
+  });
+
+  it('PROPAGATES a createImage rejection instead of swallowing it', async () => {
+    // If this were caught and turned into a partial success, enabling
+    // CREATE_IMAGE_VERIFY_MEDIA_ENFORCE would reject inside `createImage` and the
+    // caller would carry on as though a row had been written — enforcement that
+    // reports success. The `.rejects.toBe(SENTINEL)` above is the same assertion; this
+    // one names it, and pins that the ORIGINAL error survives rather than being
+    // relabelled into something a client cannot act on.
+    const rejection = addPostImage({
+      url: MEDIA_KEY,
+      postId: POST_ID,
+      index: 0,
+      type: 'image',
+      meta: { prompt: 'a cat' },
+      user: USER,
+    } as never);
+
+    await expect(rejection).rejects.toBe(SENTINEL);
+    await expect(rejection).rejects.toThrow('sentinel: createImage was reached');
+  });
+
+  it('returns the created image when createImage succeeds — the happy path is unchanged', async () => {
+    const CREATED_ID = 55_555;
+    createImageMock.mockReset();
+    createImageMock.mockResolvedValue({ id: CREATED_ID });
+    // The tail after createImage re-reads the row; a miss throws a db error, which is
+    // enough to prove the funnel returned and the tail ran with the created id.
+    dbMock.dbWrite.image.findUnique.mockReset();
+    dbMock.dbWrite.image.findUnique.mockResolvedValue(null);
+
+    await expect(
+      addPostImage({
+        url: MEDIA_KEY,
+        postId: POST_ID,
+        index: 0,
+        type: 'image',
+        meta: { prompt: 'a cat' },
+        user: USER,
+      } as never)
+      // `throwDbError` relabels the internal message; this is the literal a caller sees.
+    ).rejects.toThrow('An unexpected error ocurred, please try again later');
+
+    expect(createImageMock).toHaveBeenCalledTimes(1);
+    expect(createImageResourcesMock).toHaveBeenCalledWith({ imageId: CREATED_ID });
+    expect(dbMock.dbWrite.image.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: CREATED_ID } })
+    );
+  });
+});
+
+describe('structural ledger — the post entry points funnel through addPostImage', () => {
+  /**
+   * 🔴 An ASSERTED LEDGER, not a spot-check. It fails when the set grows (a new post
+   * entry point that might bypass the funnel) and when it shrinks (one silently
+   * rerouted). Either direction is a change to the claim that the media check in
+   * `createImage` covers every post image, and either should be a deliberate edit
+   * here rather than something that slips through.
+   *
+   * These four are the paths named in the defect report. They are asserted as
+   * PRESENT; the ledger does not claim to enumerate every `createImage` caller in the
+   * repo (comics, cover images and offsite listings call it directly, and are covered
+   * by the funnel itself rather than by this list).
+   */
+  const REPO_ROOT = path.resolve(__dirname, '../../../..');
+  const read = (relative: string) => fs.readFileSync(path.join(REPO_ROOT, relative), 'utf8');
+
+  const ENTRY_POINTS: ReadonlyArray<{ file: string; symbol: string }> = [
+    { file: 'src/server/services/post.service.ts', symbol: 'addPostImage' },
+    { file: 'src/server/controllers/post.controller.ts', symbol: 'createPostWithImagesHandler' },
+    { file: 'src/server/services/model-version.service.ts', symbol: 'addPostImage' },
+    { file: 'src/server/controllers/collection.controller.ts', symbol: 'addPostImage' },
+  ];
+
+  it.each(ENTRY_POINTS)('$file reaches the funnel via $symbol', ({ file, symbol }) => {
+    const source = read(file);
+    expect(source).toContain(symbol);
+  });
+
+  it('none of the post entry points writes an Image row directly', () => {
+    // A direct `image.create` / `image.createMany` in one of these files would be a
+    // row the media check never sees. post.service.ts is exempt from the `create`
+    // half only for the funnel call itself, so it is checked for the bypass shapes.
+    const bypassing = ENTRY_POINTS.map(({ file }) => file)
+      .filter((file, index, all) => all.indexOf(file) === index)
+      .filter((file) => /db(Write|Read)\.image\.create(Many)?\(/.test(read(file)));
+    expect(bypassing).toEqual([]);
+  });
+});

--- a/src/server/services/__tests__/create-image-caller-seam.test.ts
+++ b/src/server/services/__tests__/create-image-caller-seam.test.ts
@@ -235,10 +235,14 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
    *
    * 🔴 STILL NOT A PROOF OF COMPLETENESS, and the names above say only what is checked.
    * Out of reach by construction: a dynamic member access (`db['image']['create']`), a
-   * table alias, an `INSERT` assembled from fragments, and anything outside `src/`
-   * (`packages/`, `apps/`, `prisma/`). This is a LEDGER OVER TWO NAMED SHAPES, not an
-   * exhaustive census, and it is worth having because those two shapes are the ones the
-   * repo actually uses.
+   * destructured handle (`const { image } = dbWrite; image.create(...)` — the receiver is
+   * then a bare identifier, not `<expr>.image`), a table alias, an `INSERT` assembled from
+   * fragments, and anything outside `src/` (`packages/`, `apps/`, `prisma/`). The
+   * destructured case was measured rather than assumed: widening the matcher to accept a
+   * bare `image` identifier as the receiver returns the SAME four Prisma files today, so
+   * it buys nothing and only widens the false-positive surface. This is a LEDGER OVER TWO
+   * NAMED SHAPES, not an exhaustive census, and it is worth having because those two
+   * shapes are the ones the repo actually uses.
    *
    * WHEN THIS GOES RED: a file was added to or removed from the set. Do not widen the
    * ledger to make it pass — decide whether the new writer should route through

--- a/src/server/services/__tests__/create-image-caller-seam.test.ts
+++ b/src/server/services/__tests__/create-image-caller-seam.test.ts
@@ -208,13 +208,23 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
    *   1. A Prisma call `<anything>.image.create | createMany | createManyAndReturn(...)`,
    *      found by PARSING each candidate file with the TypeScript compiler and matching
    *      the call's shape in the AST.
-   *   2. A raw-SQL `INSERT INTO "Image"`, found textually in the source of a string or
-   *      template literal. `daily-challenge-processing.ts` writes rows this way, through
+   *   2. A raw-SQL `INSERT INTO "Image"`, found textually **inside a string or template
+   *      literal NODE** — also from the parse, for the same reason arm 1 is parsed.
+   *      `daily-challenge-processing.ts` writes rows this way, through
    *      `dbWrite.$queryRawUnsafe`, and NO Prisma-shaped matcher can see it. The first
    *      revision of this block claimed to cover "every file that writes an Image row
    *      directly" while being structurally blind to it.
    *
-   * 🔴 IT IS AN AST WALK, NOT A REGEX, AND THAT IS THE POINT. The regex it replaces —
+   * 🔴 BOTH ARMS PARSE. The raw-SQL arm used to run its regex over the WHOLE FILE TEXT,
+   * which reproduced — in the arm added to fix a blind spot — the exact false-fail the
+   * AST rewrite existed to remove. Measured: a file containing nothing but two COMMENT
+   * lines mentioning `INSERT INTO "Image" ("id","url") SELECT` was added to the found set
+   * and turned the ledger red. That is worse than a nuisance here, because the
+   * `WHEN THIS GOES RED` instruction below tells the next contributor to add the offending
+   * file to `IMAGE_ROW_WRITERS` with a reason — so a false fail does not get fixed, it gets
+   * baked into the ledger permanently.
+   *
+   * 🔴 IT IS AN AST WALK, NOT A REGEX, AND THAT IS THE POINT. The regex arm 1 replaces —
    * `/\.image\.create(Many(AndReturn)?)?\(/` over a line-comment-stripped source — was
    * walkable and false-positive-prone in the same breath:
    *
@@ -231,18 +241,39 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
    *     `const __note = 1; // historical: this used to call tx.image.create({ data })`.
    *
    * A parse answers both: comments and string literals are not expressions, and source
-   * formatting is not part of the AST.
+   * formatting is not part of the AST. For arm 2 the parse answers the mirror question —
+   * a comment is not a string literal either.
    *
    * 🔴 STILL NOT A PROOF OF COMPLETENESS, and the names above say only what is checked.
-   * Out of reach by construction: a dynamic member access (`db['image']['create']`), a
-   * destructured handle (`const { image } = dbWrite; image.create(...)` — the receiver is
-   * then a bare identifier, not `<expr>.image`), a table alias, an `INSERT` assembled from
-   * fragments, and anything outside `src/` (`packages/`, `apps/`, `prisma/`). The
-   * destructured case was measured rather than assumed: widening the matcher to accept a
-   * bare `image` identifier as the receiver returns the SAME four Prisma files today, so
-   * it buys nothing and only widens the false-positive surface. This is a LEDGER OVER TWO
-   * NAMED SHAPES, not an exhaustive census, and it is worth having because those two
-   * shapes are the ones the repo actually uses.
+   * Out of reach by construction, ALL of them measured at zero occurrences in `src/` today
+   * rather than assumed, so nothing is currently hidden behind this list:
+   *
+   *   - ARM 1. A dynamic member access (`db['image']['create']`); a destructured handle
+   *     (`const { image } = dbWrite; image.create(...)` — the receiver is then a bare
+   *     identifier, not `<expr>.image`); `image.upsert(...)`, which writes a row on the
+   *     create branch and is not in `CREATE_METHODS`; and a Prisma NESTED write
+   *     (`post.create({ data: { images: { create: … } } })`), where no node is shaped
+   *     `<expr>.image.create` at all. The destructured case was measured rather than
+   *     assumed: widening the matcher to accept a bare `image` identifier as the receiver
+   *     returns the SAME four Prisma files today, so it buys nothing and only widens the
+   *     false-positive surface. A NON-NULL ASSERTION on the receiver
+   *     (`tx.image!.createManyAndReturn(...)` — the receiver is a `NonNullExpression`, so
+   *     `ts.isPropertyAccessExpression` is false) used to be in this list and is now
+   *     HANDLED; see `unwrapReceiver`.
+   *   - ARM 2. `INSERT INTO "Image" SELECT …` with NO column list — `RAW_IMAGE_INSERT`
+   *     requires the `(`, and dropping it would sweep in `INSERT INTO "ImageFlag"` unless
+   *     the discrimination were rebuilt. A SCHEMA-QUALIFIED target,
+   *     `INSERT INTO "public"."Image" (`. A statement assembled from fragments, or one
+   *     whose table name arrives through an interpolation — a match must live inside ONE
+   *     literal chunk, so nothing is spliced across a `${…}` boundary. And the cheap
+   *     textual PRE-FILTER (`/insert/i` over the raw source, below) is over source text,
+   *     so a character escape inside the keyword itself (`'\x49NSERT INTO "Image" ('`)
+   *     would never reach the parse.
+   *   - BOTH ARMS. A table alias, and anything outside `src/` (`packages/`, `apps/`,
+   *     `prisma/`).
+   *
+   * This is a LEDGER OVER TWO NAMED SHAPES, not an exhaustive census, and it is worth
+   * having because those two shapes are the ones the repo actually uses.
    *
    * WHEN THIS GOES RED: a file was added to or removed from the set. Do not widen the
    * ledger to make it pass — decide whether the new writer should route through
@@ -288,6 +319,22 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
   const CREATE_METHODS = new Set(['create', 'createMany', 'createManyAndReturn']);
 
   /**
+   * Strip the wrappers that sit between a call and its real receiver without changing
+   * which object is being called into.
+   *
+   * `tx.image!.createManyAndReturn(…)` parses with a `NonNullExpression` in the receiver
+   * slot, so `ts.isPropertyAccessExpression(receiver)` is false and the bypass is
+   * invisible. `(tx.image).create(…)` is the same shape with a `ParenthesizedExpression`.
+   * Neither can create a false positive — both are transparent by definition — so this is
+   * a pure widening.
+   */
+  function unwrapReceiver(node: ts.Expression): ts.Expression {
+    return ts.isNonNullExpression(node) || ts.isParenthesizedExpression(node)
+      ? unwrapReceiver(node.expression)
+      : node;
+  }
+
+  /**
    * Does this source contain a call shaped `<expr>.image.<createMethod>(…)`?
    *
    * Parsed, not matched. `ts.createSourceFile` gives an AST in which comments are trivia
@@ -300,13 +347,70 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
 
     const visit = (node: ts.Node): void => {
       if (found) return;
-      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-        const method = node.expression.name.text;
-        const receiver = node.expression.expression;
+      if (ts.isCallExpression(node)) {
+        const callee = unwrapReceiver(node.expression);
+        if (ts.isPropertyAccessExpression(callee)) {
+          const method = callee.name.text;
+          const receiver = unwrapReceiver(callee.expression);
+          if (
+            CREATE_METHODS.has(method) &&
+            ts.isPropertyAccessExpression(receiver) &&
+            receiver.name.text === 'image'
+          ) {
+            found = true;
+            return;
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+    return found;
+  }
+
+  /**
+   * A raw `INSERT INTO "Image"` — matched against the COOKED TEXT OF A STRING OR TEMPLATE
+   * LITERAL, never against the file.
+   *
+   * The pattern itself stays textual on purpose: the statement is assembled from a
+   * template literal with interpolated column lists, so the table name is the only stable
+   * token and it does not live in a node shape worth matching. `"Image"` is quoted in the
+   * SQL, which is what keeps `"ImageFlag"` / `"ImageResourceNew"` / `"ImageTagForReview"`
+   * out — a bare `Image` prefix match would sweep all three in.
+   */
+  const RAW_IMAGE_INSERT = /INSERT\s+INTO\s+"Image"\s*\(/i;
+
+  /**
+   * Does this source contain a raw `INSERT INTO "Image" (` inside a string or template
+   * literal?
+   *
+   * 🔴 THE `WHERE`, NOT JUST THE `WHAT`. Running `RAW_IMAGE_INSERT` over the whole file
+   * matches comments and ordinary prose, which adds an innocent file to the ledger and
+   * breaks a build with an opaque set-inequality error — the same false-fail the Prisma
+   * arm was rewritten to remove.
+   *
+   * Each literal CHUNK of a template is tested on its own (`head`, then each span's
+   * `literal`), so a match can never be spliced together across a `${…}` interpolation
+   * boundary out of text that is not contiguous in the source.
+   */
+  function hasRawImageInsert(source: string, fileName: string): boolean {
+    const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+    let found = false;
+
+    const visit = (node: ts.Node): void => {
+      if (found) return;
+      if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+        if (RAW_IMAGE_INSERT.test(node.text)) {
+          found = true;
+          return;
+        }
+      } else if (ts.isTemplateExpression(node)) {
+        // `TemplateMiddle`/`TemplateTail` are not string-literal nodes, so the generic
+        // child walk below never tests them — they are tested here instead.
         if (
-          CREATE_METHODS.has(method) &&
-          ts.isPropertyAccessExpression(receiver) &&
-          receiver.name.text === 'image'
+          RAW_IMAGE_INSERT.test(node.head.text) ||
+          node.templateSpans.some((span) => RAW_IMAGE_INSERT.test(span.literal.text))
         ) {
           found = true;
           return;
@@ -320,29 +424,29 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
   }
 
   /**
-   * A raw `INSERT INTO "Image"` in a string or template literal.
-   *
-   * Kept textual on purpose: the statement is assembled from a template literal with
-   * interpolated column lists, so the table name is the only stable token and it does not
-   * live in a node shape worth matching. `"Image"` is quoted in the SQL, which is what
-   * keeps `"ImageFlag"` / `"ImageResourceNew"` / `"ImageTagForReview"` out — a bare
-   * `Image` prefix match would sweep all three in.
+   * The ledger's classifier, for ONE file. Exercised directly by the tests below, so the
+   * cases they plant are graded by the same function that grades the tree.
    */
-  const RAW_IMAGE_INSERT = /INSERT\s+INTO\s+"Image"\s*\(/i;
+  function isImageRowWriter(source: string, file: string): boolean {
+    // Cheap textual pre-filters so only a handful of files are actually parsed. Each is a
+    // deliberate SUPERSET of the AST match it guards — the Prisma one also hits comments,
+    // strings and any amount of wrapping/trivia between the two property accesses; the
+    // raw-SQL one hits the word anywhere at all — so narrowing with the parse afterwards
+    // cannot drop a real site. Over-matching only costs a parse.
+    //
+    // 🔴 MEASURED, not asserted: setting BOTH to `true` — parsing all 4,007 files under
+    // `src/` — returns the same five-file ledger and leaves the suite green, at ~15s
+    // instead of ~9s. So the pre-filters are a speed choice today, not a hiding place.
+    const prismaCandidate = /\.\s*image\b[\s\S]{0,200}?\.\s*create/.test(source);
+    const rawCandidate = /insert/i.test(source);
+    return (
+      (prismaCandidate && hasPrismaImageCreate(source, file)) ||
+      (rawCandidate && hasRawImageInsert(source, file))
+    );
+  }
 
   const found = sourceFiles('src')
-    .filter((file) => {
-      const source = read(file);
-      // Cheap textual pre-filter so only a handful of files are actually parsed. It is a
-      // deliberate SUPERSET of the AST match — it also hits comments, strings and any
-      // amount of wrapping/trivia between the two property accesses — so narrowing it
-      // with the parse afterwards cannot drop a real call site. Over-matching only costs
-      // a parse. The raw-SQL arm is evaluated independently and is not pre-filtered.
-      const prismaCandidate = /\.\s*image\b[\s\S]{0,200}?\.\s*create/.test(source);
-      return (
-        (prismaCandidate && hasPrismaImageCreate(source, file)) || RAW_IMAGE_INSERT.test(source)
-      );
-    })
+    .filter((file) => isImageRowWriter(read(file), file))
     .sort();
 
   it('the scan is wired to something — it finds the funnel itself', () => {
@@ -378,6 +482,23 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
     );
   });
 
+  it('a non-null assertion or a paren between the accesses does not hide the call', () => {
+    // 🔴 `unwrapReceiver`. Both of these are the SAME call as `tx.image.create(...)`; before
+    // the unwrap the receiver was a `NonNullExpression` / `ParenthesizedExpression` and
+    // `ts.isPropertyAccessExpression` was false, so a real bypass written this way was
+    // invisible to the ledger. Zero occurrences in `src/` today — this is prevention.
+    expect(hasPrismaImageCreate('await tx.image!.createManyAndReturn({ data: [] });', 'a.ts')).toBe(
+      true
+    );
+    // No `await` on the parenthesised cases: at the top level of a script `await (x)`
+    // parses as a CALL of an identifier named `await`, so the fixture would be testing
+    // something else entirely.
+    expect(hasPrismaImageCreate('(tx.image).create({ data: {} });', 'b.ts')).toBe(true);
+    expect(hasPrismaImageCreate('(tx!.image!).createMany({ data: [] });', 'c.ts')).toBe(true);
+    // The unwrap must not make a neighbouring model match.
+    expect(hasPrismaImageCreate('await tx.imageFlag!.create({ data: {} });', 'd.ts')).toBe(false);
+  });
+
   it('a comment or a string mentioning the call is NOT a call site', () => {
     /**
      * 🔴 THE FALSE-FAIL HALF, and it is the half that breaks someone else's build.
@@ -386,6 +507,10 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
      * set, turning an ordinary comment or a log message into a red build with an opaque
      * set-inequality error. A parse cannot make that mistake: trivia and string leaves
      * are not call expressions.
+     *
+     * 🔴 This covers ARM 1 ONLY. The raw-SQL arm has the same exposure and its own case —
+     * `a comment mentioning the raw INSERT is NOT a write site` below. Round 3 found this
+     * test being cited as if it covered both; it never loaded the other arm.
      */
     expect(
       hasPrismaImageCreate('const __note = 1; // historical: called tx.image.create({ data })', 'a')
@@ -404,13 +529,75 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
   it('the raw-SQL arm sees `INSERT INTO "Image"` and ignores neighbouring tables', () => {
     // 🔴 POSITIVE CONTROL for the second arm, plus the discrimination that keeps
     // `"ImageFlag"` / `"ImageResourceNew"` / `"ImageTagForReview"` — all three real, all
-    // three in this repo — out of the ledger.
-    expect(RAW_IMAGE_INSERT.test('INSERT INTO "Image" ("id", "url") SELECT')).toBe(true);
-    expect(RAW_IMAGE_INSERT.test('insert into "Image"  (a) values')).toBe(true);
-    expect(RAW_IMAGE_INSERT.test('INSERT INTO "ImageFlag" ("imageId") VALUES')).toBe(false);
-    expect(RAW_IMAGE_INSERT.test('INSERT INTO "ImageResourceNew" ("imageId") VALUES')).toBe(false);
-    // And it actually fires on the real file, not just on the fixture above.
+    // three in this repo — out of the ledger. Driven through the AST arm, not the bare
+    // regex, so what is pinned is what the ledger actually runs.
+    const inString = (sql: string) => `await dbWrite.$queryRawUnsafe(\`${sql}\`);`;
+    expect(hasRawImageInsert(inString('INSERT INTO "Image" ("id", "url") SELECT'), 'a.ts')).toBe(
+      true
+    );
+    expect(hasRawImageInsert(inString('insert into "Image"  (a) values'), 'b.ts')).toBe(true);
+    expect(hasRawImageInsert(inString('INSERT INTO "ImageFlag" ("imageId") VALUES'), 'c.ts')).toBe(
+      false
+    );
+    expect(
+      hasRawImageInsert(inString('INSERT INTO "ImageResourceNew" ("imageId") VALUES'), 'd.ts')
+    ).toBe(false);
+    // The real shape: a template literal whose column list is interpolated, so the match
+    // has to come off `head` rather than off a whole cooked string.
+    expect(
+      hasRawImageInsert(
+        'const q = `\n  INSERT INTO "Image" (${cols.join(", ")}, "userId")\n  SELECT 1;\n`;',
+        'e.ts'
+      )
+    ).toBe(true);
+    // A single-quoted string counts too — the arm is about WHERE the text lives, not which
+    // quote style it lives in.
+    expect(hasRawImageInsert('const q = \'INSERT INTO "Image" ("id") VALUES (1)\';', 'f.ts')).toBe(
+      true
+    );
+    // And it actually fires on the real file, not just on the fixtures above.
     expect(found).toContain('src/server/jobs/daily-challenge-processing.ts');
+  });
+
+  it('a comment mentioning the raw INSERT is NOT a write site', () => {
+    /**
+     * 🔴 THE ROUND-3 FALSE-FAIL, PLANTED. The raw-SQL arm shipped as
+     * `RAW_IMAGE_INSERT.test(source)` over the whole file, which is the same defect the
+     * AST rewrite existed to remove, in the arm added to fix a different blind spot.
+     *
+     * Measured before the fix: a file containing ONLY these two comment lines turned the
+     * ledger red with `+ "src/…/c-sqlcomment.ts"`. That matters more than a nuisance —
+     * the `WHEN THIS GOES RED` instruction above sends the next contributor to add the
+     * file to `IMAGE_ROW_WRITERS` with a reason, so a false fail is baked in rather than
+     * fixed.
+     */
+    const COMMENT_ONLY =
+      '// historical: this used to run INSERT INTO "Image" ("id","url") SELECT\n' +
+      '// see duplicateImage — INSERT INTO "Image" ("id","url") SELECT ... FROM "Image"\n';
+    expect(hasRawImageInsert(COMMENT_ONLY, 'c-sqlcomment.ts')).toBe(false);
+    // Graded by the ledger's own classifier, not just by the arm in isolation: this is the
+    // function the tree walk calls, so a file like this cannot enter the found set.
+    expect(isImageRowWriter(COMMENT_ONLY, 'src/zzaudit3probe/c-sqlcomment.ts')).toBe(false);
+
+    // Block comments and JSDoc are the same case.
+    expect(
+      hasRawImageInsert('/* INSERT INTO "Image" ("id") VALUES (1) */\nexport const x = 1;', 'a.ts')
+    ).toBe(false);
+    expect(
+      hasRawImageInsert('/** INSERT INTO "Image" ("id") VALUES (1) */\nexport const y = 2;', 'b.ts')
+    ).toBe(false);
+
+    // 🔴 POSITIVE CONTROL, so the four `false`s above are not four ways of saying "the
+    // matcher matches nothing": the same SQL, moved into a string, still fires.
+    expect(
+      hasRawImageInsert('export const q = \'INSERT INTO "Image" ("id") VALUES (1)\';', 'c.ts')
+    ).toBe(true);
+    expect(
+      isImageRowWriter(
+        'export const q = \'INSERT INTO "Image" ("id") VALUES (1)\';',
+        'src/zzaudit3probe/c-sqlstring.ts'
+      )
+    ).toBe(true);
   });
 
   it('the set of Image-row writers outside `createImage` is exactly the ledger', () => {

--- a/src/server/services/__tests__/create-image-caller-seam.test.ts
+++ b/src/server/services/__tests__/create-image-caller-seam.test.ts
@@ -246,7 +246,10 @@ describe('repo-wide ledger — every file that writes an Image row outside `crea
    *
    * 🔴 STILL NOT A PROOF OF COMPLETENESS, and the names above say only what is checked.
    * Out of reach by construction, ALL of them measured at zero occurrences in `src/` today
-   * rather than assumed, so nothing is currently hidden behind this list:
+   * rather than assumed, so nothing is currently hidden behind this list. Method: a GNU
+   * `grep -E` over the same file set this walk covers (non-test `.ts`/`.tsx` under `src/`,
+   * `__tests__` excluded), one pattern per shape, on 2026-08-28. Re-run those before
+   * trusting the zero — it is a dated measurement, not an invariant.
    *
    *   - ARM 1. A dynamic member access (`db['image']['create']`); a destructured handle
    *     (`const { image } = dbWrite; image.create(...)` — the receiver is then a bare

--- a/src/server/services/__tests__/create-image-caller-seam.test.ts
+++ b/src/server/services/__tests__/create-image-caller-seam.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+// The repo-wide ledger below PARSES its candidates rather than grepping them — see the
+// note there for why a regex over source text was walkable in one direction and
+// false-failing in the other.
+import ts from 'typescript';
 // Setup-order import: installs the shared ~/env/server / db / logging mocks.
 import '~/__tests__/setup';
 
@@ -22,9 +26,12 @@ import '~/__tests__/setup';
  *  - SPOT CHECK: the four post entry points named in the defect report still route
  *    through `addPostImage`. This one is a fixed list and cannot see a NEW entry point;
  *    it says so where it lives.
- *  - REPO-WIDE LEDGER: a scan of `src/` for every direct `image.create*` call, asserted
- *    equal to a named set. This is the half that fails when the set GROWS (a new writer
- *    that bypasses the funnel) or SHRINKS.
+ *  - REPO-WIDE LEDGER: a scan of `src/` for the two shapes that write an `Image` row
+ *    without going through `createImage` — a parsed Prisma `*.image.create*(…)` call and
+ *    a raw `INSERT INTO "Image"` — asserted equal to a named set. This is the half that
+ *    fails when the set GROWS (a new writer that bypasses the funnel) or SHRINKS. It is a
+ *    ledger over those two NAMED shapes and not a completeness proof; the limits it
+ *    cannot see are enumerated where it lives.
  */
 
 const { createImageMock, createImageResourcesMock } = vi.hoisted(() => ({
@@ -184,27 +191,54 @@ describe('the four post entry points named in the defect report reach addPostIma
   });
 });
 
-describe('repo-wide ledger — every file that writes an Image row directly', () => {
+describe('repo-wide ledger — every file that writes an Image row outside `createImage`', () => {
   /**
    * 🔴 THE LEDGER THAT ACTUALLY SCANS THE TREE.
    *
-   * The media-existence check sits in `createImage`. Any Prisma `image.create*` call
-   * that does NOT go through it is a row the check never sees — the "not covered"
-   * caveat in the PR body is exactly this set, so it has to be a set the repo can be
-   * held to rather than a sentence.
+   * The media-existence check sits in `createImage`. Any write of an `Image` row that
+   * does NOT go through it is a row the check never sees — the "not covered" caveat in
+   * the PR body is exactly this set, so it has to be a set the repo can be held to
+   * rather than a sentence.
    *
-   * 🔴 THE MATCH IS WIDER THAN IT LOOKS LIKE IT NEEDS TO BE, ON PURPOSE. The regex this
-   * replaces was `db(Write|Read)\.image\.create(Many)?\(`, which is wrong twice over
-   * and was measured to survive a planted bypass:
+   * 🔴 WHAT IT SCANS FOR, AND — SAID PLAINLY — WHAT IT DOES NOT.
    *
-   *   - it cannot match `createManyAndReturn(` — the shape BOTH real bypass writers in
-   *     this repo use (`article.service.ts`, `migrate-article-images.ts`);
-   *   - it pins the receiver to `dbWrite`/`dbRead`, and both of those writers go through
-   *     a transaction handle (`tx.image.…`) instead.
+   * TWO scans, because there are two ways to write the row and a Prisma-shaped check
+   * silently misses the other:
    *
-   * So it matches on `.image.create…(` with ANY receiver. Line comments are stripped
-   * first, because `huggingFaceModel.ts` carries a commented-out `tx.image.create({`
-   * that is not a call site and must not be one.
+   *   1. A Prisma call `<anything>.image.create | createMany | createManyAndReturn(...)`,
+   *      found by PARSING each candidate file with the TypeScript compiler and matching
+   *      the call's shape in the AST.
+   *   2. A raw-SQL `INSERT INTO "Image"`, found textually in the source of a string or
+   *      template literal. `daily-challenge-processing.ts` writes rows this way, through
+   *      `dbWrite.$queryRawUnsafe`, and NO Prisma-shaped matcher can see it. The first
+   *      revision of this block claimed to cover "every file that writes an Image row
+   *      directly" while being structurally blind to it.
+   *
+   * 🔴 IT IS AN AST WALK, NOT A REGEX, AND THAT IS THE POINT. The regex it replaces —
+   * `/\.image\.create(Many(AndReturn)?)?\(/` over a line-comment-stripped source — was
+   * walkable and false-positive-prone in the same breath:
+   *
+   *   - PRETTIER WRAPS CHAINS AT 100 COLUMNS. A real bypass on a long receiver renders as
+   *     `tx.image\n  .createManyAndReturn({...})`, and the regex requires `.image.create`
+   *     to be adjacent. Measured: planting that shape in `post.service.ts` left the suite
+   *     at 11 passed — the ledger did not fire. That is the same defect class the ledger
+   *     exists to catch.
+   *   - THE COMMENT STRIPPER FALSE-FAILED ON ORDINARY PROSE. It dropped only lines whose
+   *     FIRST non-space token was `//`, `*` or `/*`, so a TRAILING comment — or a string
+   *     literal — mentioning `tx.image.create({ data })` added that file to the found set
+   *     and broke the build for a contributor who touched nothing relevant, with an
+   *     opaque set-inequality error. Measured on a planted
+   *     `const __note = 1; // historical: this used to call tx.image.create({ data })`.
+   *
+   * A parse answers both: comments and string literals are not expressions, and source
+   * formatting is not part of the AST.
+   *
+   * 🔴 STILL NOT A PROOF OF COMPLETENESS, and the names above say only what is checked.
+   * Out of reach by construction: a dynamic member access (`db['image']['create']`), a
+   * table alias, an `INSERT` assembled from fragments, and anything outside `src/`
+   * (`packages/`, `apps/`, `prisma/`). This is a LEDGER OVER TWO NAMED SHAPES, not an
+   * exhaustive census, and it is worth having because those two shapes are the ones the
+   * repo actually uses.
    *
    * WHEN THIS GOES RED: a file was added to or removed from the set. Do not widen the
    * ledger to make it pass — decide whether the new writer should route through
@@ -227,6 +261,10 @@ describe('repo-wide ledger — every file that writes an Image row directly', ()
       file: 'src/pages/api/admin/temp/migrate-article-images.ts',
       why: 'one-off admin backfill over rows that already exist; not a user path',
     },
+    {
+      file: 'src/server/jobs/daily-challenge-processing.ts',
+      why: 'raw `INSERT INTO "Image" ... SELECT` via `$queryRawUnsafe` — `duplicateImage` copies an EXISTING row\'s columns, `url` included, so the object exists by construction. Invisible to any Prisma-shaped matcher; the raw-SQL scan is here for it.',
+    },
   ];
 
   /** Walk `src/`, skipping test files — a mock or an assertion is not a call site. */
@@ -243,40 +281,135 @@ describe('repo-wide ledger — every file that writes an Image row directly', ()
     return acc;
   }
 
-  const CREATE_CALL = /\.image\.create(Many(AndReturn)?)?\(/;
-  const stripLineComments = (source: string) =>
-    source
-      .split('\n')
-      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
-      .join('\n');
+  const CREATE_METHODS = new Set(['create', 'createMany', 'createManyAndReturn']);
+
+  /**
+   * Does this source contain a call shaped `<expr>.image.<createMethod>(…)`?
+   *
+   * Parsed, not matched. `ts.createSourceFile` gives an AST in which comments are trivia
+   * and string literals are leaves, so neither can be mistaken for a call — and line
+   * wrapping is invisible, which is what the regex could not manage.
+   */
+  function hasPrismaImageCreate(source: string, fileName: string): boolean {
+    const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+    let found = false;
+
+    const visit = (node: ts.Node): void => {
+      if (found) return;
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+        const method = node.expression.name.text;
+        const receiver = node.expression.expression;
+        if (
+          CREATE_METHODS.has(method) &&
+          ts.isPropertyAccessExpression(receiver) &&
+          receiver.name.text === 'image'
+        ) {
+          found = true;
+          return;
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+    return found;
+  }
+
+  /**
+   * A raw `INSERT INTO "Image"` in a string or template literal.
+   *
+   * Kept textual on purpose: the statement is assembled from a template literal with
+   * interpolated column lists, so the table name is the only stable token and it does not
+   * live in a node shape worth matching. `"Image"` is quoted in the SQL, which is what
+   * keeps `"ImageFlag"` / `"ImageResourceNew"` / `"ImageTagForReview"` out — a bare
+   * `Image` prefix match would sweep all three in.
+   */
+  const RAW_IMAGE_INSERT = /INSERT\s+INTO\s+"Image"\s*\(/i;
 
   const found = sourceFiles('src')
-    .filter((file) => CREATE_CALL.test(stripLineComments(read(file))))
+    .filter((file) => {
+      const source = read(file);
+      // Cheap textual pre-filter so only a handful of files are actually parsed. It is a
+      // deliberate SUPERSET of the AST match — it also hits comments, strings and any
+      // amount of wrapping/trivia between the two property accesses — so narrowing it
+      // with the parse afterwards cannot drop a real call site. Over-matching only costs
+      // a parse. The raw-SQL arm is evaluated independently and is not pre-filtered.
+      const prismaCandidate = /\.\s*image\b[\s\S]{0,200}?\.\s*create/.test(source);
+      return (
+        (prismaCandidate && hasPrismaImageCreate(source, file)) || RAW_IMAGE_INSERT.test(source)
+      );
+    })
     .sort();
 
   it('the scan is wired to something — it finds the funnel itself', () => {
     // 🔴 POSITIVE CONTROL. A reassuring empty/short result is indistinguishable from a
-    // walker pointed at the wrong root or a regex that matches nothing, and the
+    // walker pointed at the wrong root or a matcher that matches nothing, and the
     // equality assertion below would then be comparing two lists of the same wrong
     // thing. `image.service.ts` MUST be in any correct scan.
     expect(found).toContain('src/server/services/image.service.ts');
     expect(found.length).toBeGreaterThan(1);
   });
 
-  it('the widened regex matches `createManyAndReturn`, which the old one could not', () => {
-    // The exact planted-mutant shape that survived the previous spelling.
-    expect(CREATE_CALL.test('const rows = await tx.image.createManyAndReturn({ data: [] })')).toBe(
+  it('the AST match survives a prettier-wrapped chain, which the regex did not', () => {
+    // 🔴 THE EXACT PLANTED MUTANT THAT SURVIVED THE PREVIOUS SPELLING. Prettier breaks a
+    // chain whose receiver pushes past 100 columns onto its own line, so a real bypass
+    // routinely looks like this and `\.image\.create` never matched it.
+    expect(
+      hasPrismaImageCreate(
+        'async function f(tx: any) {\n  return await tx.image\n    .createManyAndReturn({ data: [] });\n}',
+        'wrapped.ts'
+      )
+    ).toBe(true);
+    // The unwrapped shapes still match.
+    expect(
+      hasPrismaImageCreate('await dbWrite.image.createManyAndReturn({ data: [] });', 'a.ts')
+    ).toBe(true);
+    expect(hasPrismaImageCreate('await dbWrite.image.createMany({ data: [] });', 'b.ts')).toBe(
       true
     );
-    expect(CREATE_CALL.test('await dbWrite.image.createMany({ data: [] })')).toBe(true);
-    expect(CREATE_CALL.test('await dbWrite.image.create({ data: {} })')).toBe(true);
-    // And a comment is not a call site.
-    expect(stripLineComments('  //   const image = await tx.image.create({')).not.toMatch(
-      CREATE_CALL
+    expect(hasPrismaImageCreate('await tx.image.create({ data: {} });', 'c.ts')).toBe(true);
+    // A neighbouring model is not this model.
+    expect(hasPrismaImageCreate('await dbWrite.imageFlag.create({ data: {} });', 'd.ts')).toBe(
+      false
     );
   });
 
-  it('the set of direct Image-row writers is exactly the ledger', () => {
+  it('a comment or a string mentioning the call is NOT a call site', () => {
+    /**
+     * 🔴 THE FALSE-FAIL HALF, and it is the half that breaks someone else's build.
+     *
+     * All four shapes below made the old line-prefix stripper add the file to the found
+     * set, turning an ordinary comment or a log message into a red build with an opaque
+     * set-inequality error. A parse cannot make that mistake: trivia and string leaves
+     * are not call expressions.
+     */
+    expect(
+      hasPrismaImageCreate('const __note = 1; // historical: called tx.image.create({ data })', 'a')
+    ).toBe(false);
+    expect(hasPrismaImageCreate('//   const image = await tx.image.create({ data });', 'b')).toBe(
+      false
+    );
+    expect(
+      hasPrismaImageCreate('/* block: await dbWrite.image.createMany({ data: [] }); */', 'c')
+    ).toBe(false);
+    expect(
+      hasPrismaImageCreate("const msg = 'do not call dbWrite.image.create({}) here';", 'd')
+    ).toBe(false);
+  });
+
+  it('the raw-SQL arm sees `INSERT INTO "Image"` and ignores neighbouring tables', () => {
+    // 🔴 POSITIVE CONTROL for the second arm, plus the discrimination that keeps
+    // `"ImageFlag"` / `"ImageResourceNew"` / `"ImageTagForReview"` — all three real, all
+    // three in this repo — out of the ledger.
+    expect(RAW_IMAGE_INSERT.test('INSERT INTO "Image" ("id", "url") SELECT')).toBe(true);
+    expect(RAW_IMAGE_INSERT.test('insert into "Image"  (a) values')).toBe(true);
+    expect(RAW_IMAGE_INSERT.test('INSERT INTO "ImageFlag" ("imageId") VALUES')).toBe(false);
+    expect(RAW_IMAGE_INSERT.test('INSERT INTO "ImageResourceNew" ("imageId") VALUES')).toBe(false);
+    // And it actually fires on the real file, not just on the fixture above.
+    expect(found).toContain('src/server/jobs/daily-challenge-processing.ts');
+  });
+
+  it('the set of Image-row writers outside `createImage` is exactly the ledger', () => {
     expect(found).toEqual(IMAGE_ROW_WRITERS.map((entry) => entry.file).sort());
   });
 });

--- a/src/server/services/__tests__/create-image-caller-seam.test.ts
+++ b/src/server/services/__tests__/create-image-caller-seam.test.ts
@@ -16,11 +16,15 @@ import '~/__tests__/setup';
  * swallows the rejection so enforcement silently does nothing — is invisible to every
  * one of them.
  *
- * Two halves, deliberately:
+ * Three parts, deliberately:
  *  - BEHAVIOURAL: drive the real `addPostImage` and assert what actually crosses the
  *    seam. A structural check would type-check past a wrong argument.
- *  - STRUCTURAL LEDGER: an asserted list of the entry points, failing when the set
- *    GROWS (a new path that might not funnel) or SHRINKS (a path silently rerouted).
+ *  - SPOT CHECK: the four post entry points named in the defect report still route
+ *    through `addPostImage`. This one is a fixed list and cannot see a NEW entry point;
+ *    it says so where it lives.
+ *  - REPO-WIDE LEDGER: a scan of `src/` for every direct `image.create*` call, asserted
+ *    equal to a named set. This is the half that fails when the set GROWS (a new writer
+ *    that bypasses the funnel) or SHRINKS.
  */
 
 const { createImageMock, createImageResourcesMock } = vi.hoisted(() => ({
@@ -150,22 +154,24 @@ describe('addPostImage → createImage seam', () => {
   });
 });
 
-describe('structural ledger — the post entry points funnel through addPostImage', () => {
-  /**
-   * 🔴 An ASSERTED LEDGER, not a spot-check. It fails when the set grows (a new post
-   * entry point that might bypass the funnel) and when it shrinks (one silently
-   * rerouted). Either direction is a change to the claim that the media check in
-   * `createImage` covers every post image, and either should be a deliberate edit
-   * here rather than something that slips through.
-   *
-   * These four are the paths named in the defect report. They are asserted as
-   * PRESENT; the ledger does not claim to enumerate every `createImage` caller in the
-   * repo (comics, cover images and offsite listings call it directly, and are covered
-   * by the funnel itself rather than by this list).
-   */
-  const REPO_ROOT = path.resolve(__dirname, '../../../..');
-  const read = (relative: string) => fs.readFileSync(path.join(REPO_ROOT, relative), 'utf8');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const read = (relative: string) => fs.readFileSync(path.join(REPO_ROOT, relative), 'utf8');
 
+describe('the four post entry points named in the defect report reach addPostImage', () => {
+  /**
+   * 🔴 A SPOT CHECK OVER FOUR HARDCODED FILES, and labelled as one.
+   *
+   * The previous docstring here claimed this "fails when the set grows (a new post entry
+   * point that might bypass the funnel)". It cannot: the list below is a literal array
+   * and each case only asserts `toContain(symbol)`, so a new entry point anywhere in the
+   * repo is invisible to it. That was a description claiming coverage the implementation
+   * did not provide, which is worse than no guard because it stops anyone looking.
+   *
+   * What it actually pins: these four named paths still route through `addPostImage`. If
+   * one is rewritten to call `createImage` directly, or to write a row itself, this goes
+   * red. The GROWS half of the claim is carried by the repo-wide ledger below, which is
+   * where it belongs.
+   */
   const ENTRY_POINTS: ReadonlyArray<{ file: string; symbol: string }> = [
     { file: 'src/server/services/post.service.ts', symbol: 'addPostImage' },
     { file: 'src/server/controllers/post.controller.ts', symbol: 'createPostWithImagesHandler' },
@@ -174,17 +180,103 @@ describe('structural ledger — the post entry points funnel through addPostImag
   ];
 
   it.each(ENTRY_POINTS)('$file reaches the funnel via $symbol', ({ file, symbol }) => {
-    const source = read(file);
-    expect(source).toContain(symbol);
+    expect(read(file)).toContain(symbol);
+  });
+});
+
+describe('repo-wide ledger — every file that writes an Image row directly', () => {
+  /**
+   * 🔴 THE LEDGER THAT ACTUALLY SCANS THE TREE.
+   *
+   * The media-existence check sits in `createImage`. Any Prisma `image.create*` call
+   * that does NOT go through it is a row the check never sees — the "not covered"
+   * caveat in the PR body is exactly this set, so it has to be a set the repo can be
+   * held to rather than a sentence.
+   *
+   * 🔴 THE MATCH IS WIDER THAN IT LOOKS LIKE IT NEEDS TO BE, ON PURPOSE. The regex this
+   * replaces was `db(Write|Read)\.image\.create(Many)?\(`, which is wrong twice over
+   * and was measured to survive a planted bypass:
+   *
+   *   - it cannot match `createManyAndReturn(` — the shape BOTH real bypass writers in
+   *     this repo use (`article.service.ts`, `migrate-article-images.ts`);
+   *   - it pins the receiver to `dbWrite`/`dbRead`, and both of those writers go through
+   *     a transaction handle (`tx.image.…`) instead.
+   *
+   * So it matches on `.image.create…(` with ANY receiver. Line comments are stripped
+   * first, because `huggingFaceModel.ts` carries a commented-out `tx.image.create({`
+   * that is not a call site and must not be one.
+   *
+   * WHEN THIS GOES RED: a file was added to or removed from the set. Do not widen the
+   * ledger to make it pass — decide whether the new writer should route through
+   * `createImage`, and if it genuinely should not, add it here WITH the reason.
+   */
+  const IMAGE_ROW_WRITERS: ReadonlyArray<{ file: string; why: string }> = [
+    {
+      file: 'src/server/services/image.service.ts',
+      why: 'the funnel itself (`createImage`), plus the `createMany` bulk paths it owns',
+    },
+    {
+      file: 'src/server/services/article.service.ts',
+      why: 'edge-media sync, `tx.image.createManyAndReturn` — NOT covered by the check; this is the "createEntityImages" caveat in the PR body',
+    },
+    {
+      file: 'src/server/services/blocks/app-listing-assets.service.ts',
+      why: 'app-listing asset rows; mints its own key via `uploadImageBufferToStore`, so the object exists by construction',
+    },
+    {
+      file: 'src/pages/api/admin/temp/migrate-article-images.ts',
+      why: 'one-off admin backfill over rows that already exist; not a user path',
+    },
+  ];
+
+  /** Walk `src/`, skipping test files — a mock or an assertion is not a call site. */
+  function sourceFiles(dir: string, acc: string[] = []): string[] {
+    for (const entry of fs.readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })) {
+      const relative = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        sourceFiles(relative, acc);
+      } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+        acc.push(relative);
+      }
+    }
+    return acc;
+  }
+
+  const CREATE_CALL = /\.image\.create(Many(AndReturn)?)?\(/;
+  const stripLineComments = (source: string) =>
+    source
+      .split('\n')
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+      .join('\n');
+
+  const found = sourceFiles('src')
+    .filter((file) => CREATE_CALL.test(stripLineComments(read(file))))
+    .sort();
+
+  it('the scan is wired to something — it finds the funnel itself', () => {
+    // 🔴 POSITIVE CONTROL. A reassuring empty/short result is indistinguishable from a
+    // walker pointed at the wrong root or a regex that matches nothing, and the
+    // equality assertion below would then be comparing two lists of the same wrong
+    // thing. `image.service.ts` MUST be in any correct scan.
+    expect(found).toContain('src/server/services/image.service.ts');
+    expect(found.length).toBeGreaterThan(1);
   });
 
-  it('none of the post entry points writes an Image row directly', () => {
-    // A direct `image.create` / `image.createMany` in one of these files would be a
-    // row the media check never sees. post.service.ts is exempt from the `create`
-    // half only for the funnel call itself, so it is checked for the bypass shapes.
-    const bypassing = ENTRY_POINTS.map(({ file }) => file)
-      .filter((file, index, all) => all.indexOf(file) === index)
-      .filter((file) => /db(Write|Read)\.image\.create(Many)?\(/.test(read(file)));
-    expect(bypassing).toEqual([]);
+  it('the widened regex matches `createManyAndReturn`, which the old one could not', () => {
+    // The exact planted-mutant shape that survived the previous spelling.
+    expect(CREATE_CALL.test('const rows = await tx.image.createManyAndReturn({ data: [] })')).toBe(
+      true
+    );
+    expect(CREATE_CALL.test('await dbWrite.image.createMany({ data: [] })')).toBe(true);
+    expect(CREATE_CALL.test('await dbWrite.image.create({ data: {} })')).toBe(true);
+    // And a comment is not a call site.
+    expect(stripLineComments('  //   const image = await tx.image.create({')).not.toMatch(
+      CREATE_CALL
+    );
+  });
+
+  it('the set of direct Image-row writers is exactly the ledger', () => {
+    expect(found).toEqual(IMAGE_ROW_WRITERS.map((entry) => entry.file).sort());
   });
 });

--- a/src/server/services/__tests__/create-image-media-verify.test.ts
+++ b/src/server/services/__tests__/create-image-media-verify.test.ts
@@ -237,6 +237,40 @@ describe('createImage media verification — the log is the measurement', () => 
     });
   });
 
+  it('carries the media KEY when the probe actually ran — the per-verdict check needs it', async () => {
+    // 🔴 POSITIVE CONTROL for the omission below. "url is null" is only meaningful if the
+    // field is ever populated at all; this is the branch that populates it, and the value
+    // has to be the key itself or there is nothing to HEAD by hand.
+    respondAbsent();
+    setEnforce(false);
+
+    await createImage(imageInput);
+
+    expect(verifyEvent()).toMatchObject({ verdict: 'absent', url: MEDIA_KEY });
+  });
+
+  it('OMITS the url on a `not-applicable` verdict — that is the arbitrary-text population', async () => {
+    /**
+     * 🔴 `not-applicable` is BY DEFINITION the urls that failed `isProbeableMediaKey` —
+     * the arbitrary caller-supplied strings this PR exists because callers can invent.
+     * They are never rejected and nobody will ever HEAD one by hand, so logging them buys
+     * nothing and ships unbounded caller text to a log sink. The comment justifying the
+     * field ("a bare UUID … not PII") was only ever true of the OTHER branch.
+     *
+     * Driven with a long, non-key string rather than the tidy `https://` case above, so a
+     * fix that special-cased only real URLs would not satisfy it.
+     */
+    respondAbsent();
+    setEnforce(true);
+    const junk = `not-a-key/${'x'.repeat(500)}?token=shouldnotbelogged`;
+
+    const result = await createImage({ ...imageInput, url: junk });
+
+    expect(result).toEqual({ id: CREATED_ID });
+    expect(verifyEvent()).toMatchObject({ verdict: 'not-applicable' });
+    expect(verifyEvent()?.url).toBeNull();
+  });
+
   it('a telemetry failure cannot change the outcome of the creation', async () => {
     // The log is fire-and-forget and contained. An awaited, uncontained logToAxiom
     // once turned ~5,300 successful uploads into 500s when the ingest host went

--- a/src/server/services/__tests__/create-image-media-verify.test.ts
+++ b/src/server/services/__tests__/create-image-media-verify.test.ts
@@ -8,7 +8,7 @@ import '~/__tests__/setup';
  *
  * An `Image` row is written from client-supplied JSON: `url` (the media key), `width`,
  * `height`, `name`, `mimeType` and `sizeKB` all arrive over the wire and none of them
- * was checked against storage. Measured over ~22,800 image creations, 10 rows
+ * was checked against storage. Measured over a ~24 h window (~22,800 rows sampled), 10 rows
  * referenced media that was never stored — 7 where an upload had been attempted
  * seconds earlier and silently failed, 3 where no upload was ever attempted at all.
  * Both populations produce a complete, healthy-looking row whose media 404s forever.

--- a/src/server/services/__tests__/create-image-media-verify.test.ts
+++ b/src/server/services/__tests__/create-image-media-verify.test.ts
@@ -8,9 +8,11 @@ import '~/__tests__/setup';
  *
  * An `Image` row is written from client-supplied JSON: `url` (the media key), `width`,
  * `height`, `name`, `mimeType` and `sizeKB` all arrive over the wire and none of them
- * was checked against storage. Measured over a ~24 h window (~22,800 rows sampled), 10 rows
- * referenced media that was never stored — 7 where an upload had been attempted
+ * was checked against storage. Measured over a ~24 h window of 92,759 image creations,
+ * 10 rows referenced media that was never stored — 7 where an upload had been attempted
  * seconds earlier and silently failed, 3 where no upload was ever attempted at all.
+ * (The derivation, and why ~22,846 is a DIFFERENT population with a different finding,
+ * is in `src/server/utils/created-image-media-probe.ts`.)
  * Both populations produce a complete, healthy-looking row whose media 404s forever.
  *
  * 🔴 Which is why this is an EXISTENCE check and not a "was this key ever signed"

--- a/src/server/services/__tests__/create-image-media-verify.test.ts
+++ b/src/server/services/__tests__/create-image-media-verify.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// Setup-order import: installs the shared ~/env/server / db / logging mocks before
+// image.service evaluates env at module load.
+import '~/__tests__/setup';
+
+/**
+ * `createImage` — the media a row points at must exist in the store.
+ *
+ * An `Image` row is written from client-supplied JSON: `url` (the media key), `width`,
+ * `height`, `name`, `mimeType` and `sizeKB` all arrive over the wire and none of them
+ * was checked against storage. Measured over ~22,800 image creations, 10 rows
+ * referenced media that was never stored — 7 where an upload had been attempted
+ * seconds earlier and silently failed, 3 where no upload was ever attempted at all.
+ * Both populations produce a complete, healthy-looking row whose media 404s forever.
+ *
+ * 🔴 Which is why this is an EXISTENCE check and not a "was this key ever signed"
+ * registry lookup: a signature check sees only the 3.
+ *
+ * 🔴 And why the verdict is THREE-VALUED. `unknown` — the probe threw, timed out or
+ * is unconfigured — is not evidence of loss, so it must fail OPEN. A boolean would
+ * force that case to be counted as one of the other two and corrupt the very
+ * measurement the observe-only rollout exists to take.
+ *
+ * These drive the REAL probe and the REAL `headObject` over a stubbed S3 `send`, so
+ * the three verdicts are produced by AWS-SDK-shaped answers rather than by a fake
+ * that could encode the same wrong shape as the code.
+ */
+
+import type * as S3Utils from '~/utils/s3-utils';
+
+const { mockS3Send } = vi.hoisted(() => ({ mockS3Send: vi.fn() }));
+
+// Keep the REAL module — the real `headObject` and the real not-found classifier must
+// run — and override only the backend resolution, so the probe talks to `mockS3Send`.
+vi.mock('~/utils/s3-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof S3Utils>();
+  return {
+    ...actual,
+    getImageUploadBackend: vi.fn(async () => ({
+      s3: { send: mockS3Send },
+      bucket: 'test-media-bucket',
+      backend: 'backblaze' as const,
+    })),
+  };
+});
+
+import { createImage } from '~/server/services/image.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { logToAxiom } from '~/server/logging/client';
+import { env } from '~/env/server';
+
+/** A bare media key — the shape an upload endpoint issues and stores as `Image.url`. */
+const MEDIA_KEY = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const CREATED_ID = 987_654;
+const USER_ID = 4242;
+
+/** The row `createImage` is asked to write. Literal, so nothing is derived from the code. */
+const imageInput = {
+  url: MEDIA_KEY,
+  userId: USER_ID,
+  name: 'pic.png',
+  width: 640,
+  height: 480,
+  mimeType: 'image/png',
+  sizeKB: 128,
+  type: 'image' as const,
+  // Isolates the gate from the ingestion pipeline, which is not what these assert.
+  skipIngestion: true,
+};
+
+/** The bucket ANSWERS that the key is not there. */
+function respondAbsent() {
+  mockS3Send.mockRejectedValue(
+    Object.assign(new Error('NotFound'), { name: 'NotFound', $metadata: { httpStatusCode: 404 } })
+  );
+}
+
+/** The bucket cannot be consulted at all — a 403 from a rotated key, not a 404. */
+function respondUnknown() {
+  mockS3Send.mockRejectedValue(
+    Object.assign(new Error('Forbidden'), {
+      name: 'AccessDenied',
+      $metadata: { httpStatusCode: 403 },
+    })
+  );
+}
+
+/** The bucket answers with a real object. */
+function respondPresent() {
+  mockS3Send.mockResolvedValue({ ContentLength: 131_072 });
+}
+
+const envRecord = env as unknown as Record<string, unknown>;
+const setEnforce = (value: boolean) => {
+  envRecord.CREATE_IMAGE_VERIFY_MEDIA_ENFORCE = value;
+};
+
+const verifyEvent = () =>
+  vi
+    .mocked(logToAxiom)
+    .mock.calls.map((c) => c[0] as Record<string, unknown>)
+    .find((c) => c?.name === 'create-image-media-verify');
+
+beforeEach(() => {
+  vi.mocked(logToAxiom).mockClear();
+  mockS3Send.mockReset();
+  // Cleared per test, not merely re-stubbed: the shared db mock is reset once per FILE,
+  // so without this every `toHaveBeenCalledTimes(1)` is really asserting a running total.
+  dbMock.dbWrite.image.create.mockReset();
+  dbMock.dbWrite.image.create.mockResolvedValue({ id: CREATED_ID });
+});
+
+afterEach(() => {
+  delete envRecord.CREATE_IMAGE_VERIFY_MEDIA_ENFORCE;
+});
+
+describe('createImage media verification — three verdicts x two gate states', () => {
+  describe('verdict `absent` — the defect', () => {
+    it('OBSERVE-ONLY (the shipped default): still creates the row, and logs', async () => {
+      // 🔴 This is the case that protects the rollout, and the one most likely to be
+      // written backwards. With the gate off nothing about the caller's outcome may
+      // change — the row is written exactly as it is today. The only new thing is the
+      // log line the `absent` rate will be read from.
+      respondAbsent();
+      setEnforce(false);
+
+      const result = await createImage(imageInput);
+
+      expect(result).toEqual({ id: CREATED_ID });
+      expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+      expect(verifyEvent()).toMatchObject({
+        name: 'create-image-media-verify',
+        verdict: 'absent',
+        enforcing: false,
+        rejected: false,
+      });
+    });
+
+    it('ENFORCING: rejects, and no row is written', async () => {
+      respondAbsent();
+      setEnforce(true);
+
+      await expect(createImage(imageInput)).rejects.toThrow(
+        'One of the files did not upload properly, please try again'
+      );
+      expect(dbMock.dbWrite.image.create).not.toHaveBeenCalled();
+      expect(verifyEvent()).toMatchObject({ verdict: 'absent', enforcing: true, rejected: true });
+    });
+  });
+
+  describe('verdict `unknown` — fail OPEN, in both gate states', () => {
+    it('OBSERVE-ONLY: creates the row', async () => {
+      respondUnknown();
+      setEnforce(false);
+
+      const result = await createImage(imageInput);
+
+      expect(result).toEqual({ id: CREATED_ID });
+      expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+      expect(verifyEvent()).toMatchObject({ verdict: 'unknown', rejected: false });
+    });
+
+    it('ENFORCING: still creates the row — inability to consult the bucket is not evidence of loss', async () => {
+      respondUnknown();
+      setEnforce(true);
+
+      const result = await createImage(imageInput);
+
+      expect(result).toEqual({ id: CREATED_ID });
+      expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+      expect(verifyEvent()).toMatchObject({
+        verdict: 'unknown',
+        enforcing: true,
+        rejected: false,
+      });
+    });
+  });
+
+  describe('verdict `present` — unchanged, in both gate states', () => {
+    it.each([false, true])('creates the row with enforcing=%s', async (enforcing) => {
+      respondPresent();
+      setEnforce(enforcing);
+
+      const result = await createImage(imageInput);
+
+      expect(result).toEqual({ id: CREATED_ID });
+      expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+      expect(verifyEvent()).toMatchObject({ verdict: 'present', rejected: false });
+    });
+  });
+});
+
+describe('createImage media verification — what must NOT be probed', () => {
+  it('does not probe a full http(s) url, and never rejects it', async () => {
+    // `addPostImageSchema` permits `z.url().or(z.string().uuid())`, and legacy avatar
+    // rows hold a full external URL for a bucket we do not own — the same distinction
+    // `deleteImageFromS3` documents. HEADing one of those against OUR bucket asks a
+    // nonsensical question and would answer `absent` for a perfectly good row.
+    respondAbsent();
+    setEnforce(true);
+
+    const result = await createImage({
+      ...imageInput,
+      url: 'https://cdn.example.com/legacy/avatar.png',
+    });
+
+    expect(result).toEqual({ id: CREATED_ID });
+    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(verifyEvent()).toMatchObject({ verdict: 'not-applicable', rejected: false });
+  });
+
+  it('probes the media KEY, in the bucket the image-upload backend resolved', async () => {
+    respondPresent();
+    setEnforce(false);
+
+    await createImage(imageInput);
+
+    expect(mockS3Send).toHaveBeenCalledTimes(1);
+    const command = mockS3Send.mock.calls[0][0] as { input: Record<string, unknown> };
+    expect(command.input).toMatchObject({ Bucket: 'test-media-bucket', Key: MEDIA_KEY });
+  });
+});
+
+describe('createImage media verification — the log is the measurement', () => {
+  it('logs a verdict on EVERY call, not only the bad one — the rate needs a denominator', async () => {
+    respondPresent();
+    setEnforce(false);
+
+    await createImage(imageInput);
+
+    expect(verifyEvent()).toMatchObject({
+      name: 'create-image-media-verify',
+      verdict: 'present',
+      enforcing: false,
+      rejected: false,
+      userId: USER_ID,
+    });
+  });
+
+  it('a telemetry failure cannot change the outcome of the creation', async () => {
+    // The log is fire-and-forget and contained. An awaited, uncontained logToAxiom
+    // once turned ~5,300 successful uploads into 500s when the ingest host went
+    // unreachable; nothing here may be able to repeat that.
+    respondPresent();
+    setEnforce(true);
+    vi.mocked(logToAxiom).mockRejectedValueOnce(new Error('axiom unreachable'));
+
+    const result = await createImage(imageInput);
+
+    expect(result).toEqual({ id: CREATED_ID });
+    expect(dbMock.dbWrite.image.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -7347,6 +7347,23 @@ export const getImagesByEntity = async ({
   return attachTagsToImages(images, tagsVar);
 };
 
+/**
+ * Hard ceiling on the `url` value the `create-image-media-verify` line carries.
+ *
+ * That line only carries a `url` for a PROBED verdict, where `isProbeableMediaKey` has
+ * already accepted the value and it is therefore a 36-character UUID. This bound is the
+ * belt-and-braces half: it is caller-supplied text reaching a log sink, so it gets a
+ * length that does not depend on the predicate staying exactly as strict as it is today.
+ * 64 leaves obvious headroom over 36 and is far below anything worth truncating a log
+ * line for — so on today's population it never fires, which is the intent.
+ *
+ * 🔴 Declared here rather than beside the probe deliberately: an import line in this file
+ * shifts the four `image.service.ts:<line>` keys the Flipt-eval ledger
+ * (`src/server/flipt/__tests__/flipt-eval-context.test.ts`) pins, and this constant sits
+ * comfortably below all four.
+ */
+export const CREATE_IMAGE_MEDIA_VERIFY_URL_LOG_MAX = 64;
+
 export async function createImage({
   toolIds,
   techniqueIds,
@@ -7396,8 +7413,16 @@ export async function createImage({
   // key, HEADing the bucket by hand and looking for the row. Without the key there is
   // nothing to look up — `postId` is null on most non-post paths (comics, cover images,
   // thumbnails, model-version images before the post exists) and `userId` alone selects
-  // thousands of rows. The value is the media key itself: a bare UUID minted by
-  // `/api/v1/image-upload`, not a filename and not PII.
+  // thousands of rows.
+  //
+  // 🔴 LOGGED ONLY WHEN THE PROBE ACTUALLY RAN, AND LENGTH-BOUNDED. On a probed verdict
+  // the value is a bare UUID that `isProbeableMediaKey` already accepted — 36 chars, not
+  // a filename and not PII. `not-applicable` is the opposite population by definition:
+  // it is precisely the urls that FAILED that predicate, i.e. the arbitrary caller-
+  // supplied strings this PR exists because callers can invent. Those can be any length
+  // and any content, they are never rejected, and nobody will ever HEAD one by hand — so
+  // they are omitted rather than shipped to the log. The `slice` is belt-and-braces for
+  // the probed branch, where the predicate already bounds the shape.
   //
   // There is deliberately no image id — the row does not exist yet at this point, which
   // is the whole reason the check sits here.
@@ -7413,7 +7438,10 @@ export async function createImage({
     verdict: mediaVerdict,
     enforcing: enforcingMediaVerify,
     rejected: rejectingMedia,
-    url: typeof image.url === 'string' ? image.url : null,
+    url:
+      mediaVerdict !== 'not-applicable' && typeof image.url === 'string'
+        ? image.url.slice(0, CREATE_IMAGE_MEDIA_VERIFY_URL_LOG_MAX)
+        : null,
     userId: image.userId,
     postId: image.postId ?? null,
   }).catch(() => undefined);

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -7390,6 +7390,18 @@ export async function createImage({
   // against the total. A log emitted only on the bad verdict has no denominator, and
   // the denominator is the entire point of the observe-only phase.
   //
+  // 🔴 `url` IS THE FIELD THAT MAKES THE ROLLOUT CRITERION ANSWERABLE, so it is logged.
+  // The criterion is "is this `absent` rate real defects or false rejects?", and that is
+  // a question about INDIVIDUAL verdicts: it can only be settled by taking an `absent`
+  // key, HEADing the bucket by hand and looking for the row. Without the key there is
+  // nothing to look up — `postId` is null on most non-post paths (comics, cover images,
+  // thumbnails, model-version images before the post exists) and `userId` alone selects
+  // thousands of rows. The value is the media key itself: a bare UUID minted by
+  // `/api/v1/image-upload`, not a filename and not PII.
+  //
+  // There is deliberately no image id — the row does not exist yet at this point, which
+  // is the whole reason the check sits here.
+  //
   // NOT awaited, and contained. On 2026-08-23 an awaited, uncontained `logToAxiom`
   // turned ~5,300 successful uploads into 500s when the ingest host went unreachable
   // for 44 minutes. Telemetry must never be able to change this call's outcome, and
@@ -7401,6 +7413,7 @@ export async function createImage({
     verdict: mediaVerdict,
     enforcing: enforcingMediaVerify,
     rejected: rejectingMedia,
+    url: typeof image.url === 'string' ? image.url : null,
     userId: image.userId,
     postId: image.postId ?? null,
   }).catch(() => undefined);

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -225,6 +225,7 @@ import { getMetadata } from '~/utils/metadata';
 import { removeEmpty } from '~/utils/object-helpers';
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
+import { probeCreatedImageMedia } from '~/server/utils/created-image-media-probe';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
 import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
@@ -7362,10 +7363,56 @@ export async function createImage({
    */
   verifiedSourceImageIds?: number[] | null;
 }) {
+  /**
+   * 🔴 THE ROW MUST NOT OUTLIVE ITS MEDIA — so ask the store before writing it.
+   *
+   * Every `Image` row goes through here: `addPostImage`, `createPostWithImagesHandler`,
+   * the model-version and collection paths, comics, cover images, thumbnails. The
+   * check belongs at this one funnel and nowhere else — not per-router (four copies of
+   * a predicate is a predicate that is wrong at three of them) and not in the zod
+   * schema (it needs IO).
+   *
+   * 🔴 OBSERVE-ONLY BY DEFAULT. The probe always runs and always logs; whether an
+   * `absent` verdict actually REJECTS is gated by `CREATE_IMAGE_VERIFY_MEDIA_ENFORCE`,
+   * which ships off. Rejecting here is a new failure mode on the image-creation happy
+   * path, and the only way to size it is to let the `absent` rate accumulate against
+   * the total first. Flipping it back off is a config change, not a revert.
+   *
+   * Compared against `true` explicitly: the gate guards a REJECTION, so anything other
+   * than an unambiguous opt-in — unset, malformed, a stray string — must land on
+   * observe-only rather than on failing image creation.
+   */
+  const mediaVerdict = await probeCreatedImageMedia(image.url);
+  const enforcingMediaVerify = env.CREATE_IMAGE_VERIFY_MEDIA_ENFORCE === true;
+  const rejectingMedia = mediaVerdict === 'absent' && enforcingMediaVerify;
+
+  // Logged on EVERY call, whatever the verdict, so the `absent` rate can be read
+  // against the total. A log emitted only on the bad verdict has no denominator, and
+  // the denominator is the entire point of the observe-only phase.
+  //
+  // NOT awaited, and contained. On 2026-08-23 an awaited, uncontained `logToAxiom`
+  // turned ~5,300 successful uploads into 500s when the ingest host went unreachable
+  // for 44 minutes. Telemetry must never be able to change this call's outcome, and
+  // must not sit on a user-facing mutation's latency budget either.
+  void logToAxiom({
+    type: rejectingMedia ? 'warning' : 'info',
+    name: 'create-image-media-verify',
+    message: 'createImage media existence probe',
+    verdict: mediaVerdict,
+    enforcing: enforcingMediaVerify,
+    rejected: rejectingMedia,
+    userId: image.userId,
+    postId: image.postId ?? null,
+  }).catch(() => undefined);
+
+  if (rejectingMedia)
+    throw throwBadRequestError('One of the files did not upload properly, please try again');
+
   const meta = sanitizeProvenance(
     image.meta as Record<string, unknown> | null | undefined,
     verifiedSourceImageIds
   );
+
   const result = await dbWrite.image.create({
     data: {
       ...image,

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import '~/__tests__/setup';
 
+import { isProbeableMediaKey } from '@civitai/shared/media-key';
 import {
-  isProbeableMediaKey,
   probeCreatedImageMedia,
   type CreatedImageMediaProbeDeps,
 } from '~/server/utils/created-image-media-probe';
@@ -44,7 +44,18 @@ function notFoundError() {
   });
 }
 
-describe('isProbeableMediaKey', () => {
+/**
+ * 🔴 The predicate itself now lives in `@civitai/shared/media-key` and is imported by BOTH media
+ * existence checks — this one and the moderator publish guard. It used to be open-coded at each,
+ * by opposite construction, and the two disagreed on real rows: for `some-file.png` the other
+ * spelling probed, got a 404 and PERMANENTLY refused the publish, while this one never asked.
+ *
+ * These cases stay HERE as well as in the shared package's own suite, deliberately. They are not a
+ * duplicate of it — they run under THIS app's resolver and module graph, so they are what proves
+ * the import actually resolves and that this call site is reading the shared rule rather than a
+ * reintroduced local one.
+ */
+describe('isProbeableMediaKey — the SHARED predicate, as this app resolves it', () => {
   it('accepts a bare media key (the uuid an upload endpoint issues)', () => {
     expect(isProbeableMediaKey('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee')).toBe(true);
   });
@@ -55,8 +66,10 @@ describe('isProbeableMediaKey', () => {
     'https://image.civitai.com/xyz/width=450/thing.jpeg',
     '',
     'not-a-uuid',
+    'some-file.png',
     'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/extra',
     '  aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee  ',
+    'blob:https://civitai.com/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
   ])('rejects %j — not a key this store can be asked about', (value) => {
     expect(isProbeableMediaKey(value)).toBe(false);
   });

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import '~/__tests__/setup';
+
+import {
+  isProbeableMediaKey,
+  probeCreatedImageMedia,
+  type CreatedImageMediaProbeDeps,
+} from '~/server/utils/created-image-media-probe';
+import { headObject } from '~/utils/s3-utils';
+
+/**
+ * The media-existence probe behind `createImage`.
+ *
+ * 🔴 These drive the REAL `headObject` (and therefore the real not-found classifier)
+ * over a stubbed S3 `send`, rather than faking `headObject` itself. A fake could
+ * encode the same wrong shape as the code and pass with the bug present; an
+ * AWS-SDK-shaped rejection cannot.
+ *
+ * Every expected verdict below is a hand-written literal, not something recomputed
+ * from the implementation.
+ */
+
+const BUCKET = 'test-media-bucket';
+const KEY = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+/** Build the deps with a `send` that answers however the case needs. */
+function depsWithSend(send: (command: unknown) => unknown): CreatedImageMediaProbeDeps {
+  return {
+    getBackend: async () => ({
+      s3: { send: vi.fn(send) } as unknown as Awaited<
+        ReturnType<CreatedImageMediaProbeDeps['getBackend']>
+      >['s3'],
+      bucket: BUCKET,
+    }),
+    headObject,
+  };
+}
+
+/** The shape the AWS SDK throws for a key that is not there. */
+function notFoundError() {
+  return Object.assign(new Error('NotFound'), {
+    name: 'NotFound',
+    $metadata: { httpStatusCode: 404 },
+  });
+}
+
+describe('isProbeableMediaKey', () => {
+  it('accepts a bare media key (the uuid an upload endpoint issues)', () => {
+    expect(isProbeableMediaKey('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee')).toBe(true);
+  });
+
+  it.each([
+    'https://example.com/some/image.png',
+    'http://example.com/some/image.png',
+    'https://image.civitai.com/xyz/width=450/thing.jpeg',
+    '',
+    'not-a-uuid',
+    'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/extra',
+    '  aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee  ',
+  ])('rejects %j — not a key this store can be asked about', (value) => {
+    expect(isProbeableMediaKey(value)).toBe(false);
+  });
+
+  it.each([null, undefined, 42, {}, []])('rejects the non-string %j', (value) => {
+    expect(isProbeableMediaKey(value)).toBe(false);
+  });
+});
+
+describe('probeCreatedImageMedia — three verdicts, never a boolean', () => {
+  it('returns `present` when the bucket answers with a non-empty object', async () => {
+    const verdict = await probeCreatedImageMedia(
+      KEY,
+      depsWithSend(async () => ({ ContentLength: 12_345 }))
+    );
+    expect(verdict).toBe('present');
+  });
+
+  it('returns `absent` when the bucket ANSWERS that the key is not there', async () => {
+    const verdict = await probeCreatedImageMedia(
+      KEY,
+      depsWithSend(async () => {
+        throw notFoundError();
+      })
+    );
+    expect(verdict).toBe('absent');
+  });
+
+  it('returns `absent` for a definitively ZERO-length object', async () => {
+    // A stored but empty object is the same defect from the reader's point of view.
+    const verdict = await probeCreatedImageMedia(
+      KEY,
+      depsWithSend(async () => ({ ContentLength: 0 }))
+    );
+    expect(verdict).toBe('absent');
+  });
+
+  it('returns `present` when the backend reports NO length — `null` is not zero', async () => {
+    // 🔴 The distinction the size check must not collapse: "the backend did not report
+    // a length" is not "the object has no bytes". Treating it as zero would reject
+    // healthy rows on any backend that omits ContentLength.
+    const verdict = await probeCreatedImageMedia(
+      KEY,
+      depsWithSend(async () => ({}))
+    );
+    expect(verdict).toBe('present');
+  });
+
+  it('returns `unknown` when the bucket cannot be consulted — a 403, not a 404', async () => {
+    const verdict = await probeCreatedImageMedia(
+      KEY,
+      depsWithSend(async () => {
+        throw Object.assign(new Error('Forbidden'), {
+          name: 'AccessDenied',
+          $metadata: { httpStatusCode: 403 },
+        });
+      })
+    );
+    expect(verdict).toBe('unknown');
+  });
+
+  it('returns `unknown` when resolving the storage backend throws (unconfigured env)', async () => {
+    // 🔴 A probe that GUARDS a working code path must not be able to fail that path by
+    // its own absence.
+    const verdict = await probeCreatedImageMedia(KEY, {
+      getBackend: async () => {
+        throw new Error('Next S3 Upload: Missing ENVs S3_UPLOAD_KEY');
+      },
+      headObject,
+    });
+    expect(verdict).toBe('unknown');
+  });
+
+  it('returns `unknown` on an abort (the timeout budget), never `absent`', async () => {
+    const verdict = await probeCreatedImageMedia(
+      KEY,
+      depsWithSend(async () => {
+        throw Object.assign(new Error('Request aborted'), { name: 'AbortError' });
+      })
+    );
+    expect(verdict).toBe('unknown');
+  });
+
+  it('returns `not-applicable` for a full http(s) url, and never touches the bucket', async () => {
+    // `addPostImageSchema` permits `z.url().or(z.string().uuid())`, and legacy avatar
+    // rows hold a full external URL. HEADing one of those against OUR bucket asks a
+    // nonsensical question and would answer `absent` for a perfectly good row.
+    const send = vi.fn(async () => ({ ContentLength: 1 }));
+    const verdict = await probeCreatedImageMedia('https://example.com/avatar.png', {
+      getBackend: async () => ({
+        s3: { send } as never,
+        bucket: BUCKET,
+      }),
+      headObject,
+    });
+    expect(verdict).toBe('not-applicable');
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('asks for the key it was given, in the bucket the backend resolved', async () => {
+    const send = vi.fn(async () => ({ ContentLength: 1 }));
+    await probeCreatedImageMedia(KEY, {
+      getBackend: async () => ({ s3: { send } as never, bucket: BUCKET }),
+      headObject,
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0][0] as unknown as { input: Record<string, unknown> };
+    expect(command.input).toMatchObject({ Bucket: BUCKET, Key: KEY });
+  });
+});

--- a/src/server/utils/__tests__/created-image-media-probe.test.ts
+++ b/src/server/utils/__tests__/created-image-media-probe.test.ts
@@ -3,6 +3,7 @@ import '~/__tests__/setup';
 
 import { isProbeableMediaKey } from '@civitai/shared/media-key';
 import {
+  CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS,
   probeCreatedImageMedia,
   type CreatedImageMediaProbeDeps,
 } from '~/server/utils/created-image-media-probe';
@@ -167,6 +168,46 @@ describe('probeCreatedImageMedia — three verdicts, never a boolean', () => {
     });
     expect(verdict).toBe('not-applicable');
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it('BOUNDS the probe: `headObject` is handed an abort signal', async () => {
+    /**
+     * 🔴 This exists because deleting the whole
+     * `{ abortSignal: AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS) }`
+     * argument passed the entire suite. The abort test above proves how an abort is
+     * CLASSIFIED (it injects an `AbortError` from the stubbed `send`); it does not, and
+     * cannot, prove that anything ever asks for one. An unbounded probe on a
+     * user-facing mutation turns a guard into a hang against a degraded backend —
+     * strictly worse than the bug it guards — so the budget's existence is its own
+     * assertion.
+     *
+     * It asserts the SIGNAL, not the constant, because `AbortSignal.timeout` exposes no
+     * readable deadline. The reachable, observable claim is "a live AbortSignal arrives
+     * at the call that performs the network IO".
+     */
+    const headObjectSpy = vi.fn(headObject);
+    await probeCreatedImageMedia(KEY, {
+      getBackend: async () => ({
+        s3: { send: vi.fn(async () => ({ ContentLength: 1 })) } as never,
+        bucket: BUCKET,
+      }),
+      headObject: headObjectSpy,
+    });
+
+    expect(headObjectSpy).toHaveBeenCalledTimes(1);
+    const options = headObjectSpy.mock.calls[0][3];
+    expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
+    // Not already aborted — a spent signal would abort every probe instantly, which is
+    // the failure mode a bare `toBeDefined()` would sail past.
+    expect(options?.abortSignal?.aborted).toBe(false);
+  });
+
+  it('the timeout budget is a positive, finite number of milliseconds', () => {
+    // The value the signal above is built from. Pinned as a range rather than a literal
+    // so tuning it is not a test edit, but a 0 / NaN / negative budget — each of which
+    // makes `AbortSignal.timeout` fire immediately or throw — is caught.
+    expect(Number.isFinite(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS)).toBe(true);
+    expect(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS).toBeGreaterThan(0);
   });
 
   it('asks for the key it was given, in the bucket the backend resolved', async () => {

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -10,8 +10,13 @@ import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
  * none of them is checked against storage, so any key a caller invents produces a
  * complete, healthy-looking row whose media 404s forever.
  *
- * Measured in production over ~22,800 image creations, 10 rows referenced media
- * that was never stored, in two distinct populations:
+ * Measured in production: over a ~24 h window, 10 rows referenced media that was
+ * never stored. 🔴 ~22,800 was the SAMPLE SIZE that query examined, not a rate —
+ * the denominator is the key-mint rate, ~101k–105k/day (`POST /api/v1/image-upload/
+ * multipart/index` + `.../index`, spanmetrics x10, measured 2026-08-28), so the
+ * defect rate is ~0.010%, not the ~0.04% an earlier draft derived.
+ *
+ * The 10 split into two distinct populations:
  *   - 7 had a key that WAS issued by an upload endpoint 2.0–23.3s before the row
  *     was written, but no object ever landed — a real upload that failed silently;
  *   - 3 had a key no endpoint ever issued at all.
@@ -68,6 +73,28 @@ export type CreatedImageMediaProbeDeps = {
   headObject: typeof headObject;
 };
 
+/**
+ * 🔴 THE BUCKET IS RESOLVED THROUGH `getImageUploadBackend()`, NOT OPEN-CODED.
+ *
+ * The media-key PREDICATE was consolidated into `@civitai/shared/media-key` because two
+ * existence checks open-coded it by opposite construction and disagreed on real rows.
+ * The BUCKET is the second half of the same question — "does this key exist in the store
+ * we own?" — and it has to be consolidated for the same reason. `getImageUploadBackend()`
+ * is the one place that answers it, and every key-minting site already goes through it
+ * (`/api/v1/image-upload/index`, `.../multipart/index`, `uploadImageBufferToStore`), so
+ * this probe asks about the bucket the key was actually minted into by construction
+ * rather than by two constants happening to agree.
+ *
+ * ⚠️ CROSS-PR NOTE. The moderator publish guard being added in civitai#4475 currently
+ * open-codes this as `getB2ImageS3Client()` + `env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads'`,
+ * which is a literal inlining of `getImageUploadBackend`'s body. The two agree TODAY only
+ * because those constants return the same values. Change the backend — a second image
+ * store, a bucket rename, a per-tenant bucket — and the two guards return different
+ * verdicts about the same row, and on that side an `absent` is a PERMANENT refusal to
+ * publish. That is exactly the drift the shared predicate exists to prevent, one layer
+ * down. The fix on that side is one line (call `getImageUploadBackend()`); it is not made
+ * here because it is another PR's branch.
+ */
 const defaultDeps: CreatedImageMediaProbeDeps = {
   getBackend: async () => {
     const { s3, bucket } = await getImageUploadBackend();

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -10,11 +10,18 @@ import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
  * none of them is checked against storage, so any key a caller invents produces a
  * complete, healthy-looking row whose media 404s forever.
  *
- * Measured in production: over a ~24 h window, 10 rows referenced media that was
- * never stored. 🔴 ~22,800 was the SAMPLE SIZE that query examined, not a rate —
- * the denominator is the key-mint rate, ~101k–105k/day (`POST /api/v1/image-upload/
- * multipart/index` + `.../index`, spanmetrics x10, measured 2026-08-28), so the
- * defect rate is ~0.010%, not the ~0.04% an earlier draft derived.
+ * Measured in production: over a ~24 h window of **~92,000 image creations, 10 rows**
+ * referenced media that was never stored — **~0.011%**, about 1 in 9,000. Numerator
+ * and denominator are one query over one population, and it is the same population
+ * the observe-only log counts (one line per `createImage` call), so the historical
+ * rate and the live rate are the same quantity.
+ *
+ * 🔴 Two other figures are in circulation and neither is this denominator: ~22,800
+ * was the SAMPLE SIZE an early query examined (dividing by it gave ~0.04%, retired),
+ * and ~101k–105k/day is the KEY-MINT rate (`POST /api/v1/image-upload/multipart/
+ * index` + `.../index`, spanmetrics x10, measured 2026-08-28) — a different
+ * population, upload requests rather than image creations, useful only as an
+ * order-of-magnitude cross-check on the 92,000.
  *
  * The 10 split into two distinct populations:
  *   - 7 had a key that WAS issued by an upload endpoint 2.0–23.3s before the row

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -1,4 +1,5 @@
 import type { S3Client } from '@aws-sdk/client-s3';
+import { isProbeableMediaKey } from '@civitai/shared/media-key';
 import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
 
 /**
@@ -57,27 +58,6 @@ export type CreatedImageMediaVerdict =
 export const CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS = 3_000;
 
 /**
- * A bare media key — the UUID an upload endpoint issues and stores as `Image.url`.
- *
- * 🔴 Not every `Image.url` is one. `addPostImageSchema` accepts
- * `z.url().or(z.string().uuid())`, and legacy avatar rows hold a full external URL
- * where every other row holds a bucket key — the same distinction
- * `deleteImageFromS3` documents when it declines to delete an `http`-prefixed url
- * because it names a bucket we do not own. HEADing one of those against OUR bucket
- * asks a nonsensical question and would answer `absent` for a perfectly good row,
- * so those are classified `not-applicable` and never probed.
- *
- * Deliberately a positive test (it IS a uuid) rather than a negative one (it is NOT
- * an http url): a relative path, an empty string or a stray token is equally not a
- * key we can look up, and a negative test would send all of them to the bucket.
- */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-export function isProbeableMediaKey(url: unknown): url is string {
-  return typeof url === 'string' && UUID_RE.test(url);
-}
-
-/**
  * Seam for tests. Both default to the real implementations, so production behaviour
  * is whatever `getImageUploadBackend` / `headObject` do — the injection point exists
  * so a test can drive the three verdicts without a bucket, not so the probe can
@@ -105,6 +85,20 @@ export async function probeCreatedImageMedia(
   url: unknown,
   deps: CreatedImageMediaProbeDeps = defaultDeps
 ): Promise<CreatedImageMediaVerdict> {
+  /**
+   * 🔴 The SHARED predicate (`@civitai/shared/media-key`), not a local copy.
+   *
+   * This rule used to be open-coded here AND in the moderator publish guard, by
+   * OPPOSITE construction — this one asked "is it a bare uuid?", that one asked
+   * "does it carry a URI scheme?" and probed everything else. For `some-file.png`
+   * they returned opposite verdicts, and on that side the verdict is a PERMANENT
+   * refusal to publish. Read that module for why the surviving test is a
+   * deliberate under-approximation rather than an accurate one.
+   *
+   * The two call sites act differently on the answer and that is fine: this one is
+   * observe-only behind a flag defaulting off, so a wrong verdict is logged; the
+   * publish guard's is enforced immediately. What must not differ is the QUESTION.
+   */
   if (!isProbeableMediaKey(url)) return 'not-applicable';
 
   try {

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -10,18 +10,39 @@ import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
  * none of them is checked against storage, so any key a caller invents produces a
  * complete, healthy-looking row whose media 404s forever.
  *
- * Measured in production: over a ~24 h window of **~92,000 image creations, 10 rows**
- * referenced media that was never stored — **~0.011%**, about 1 in 9,000. Numerator
- * and denominator are one query over one population, and it is the same population
- * the observe-only log counts (one line per `createImage` call), so the historical
- * rate and the live rate are the same quantity.
+ * Measured in production: over a ~24 h window of **92,759 image creations, 10 rows**
+ * referenced media that was never stored — **10 / 92,759 = 0.0108%**, about 1 in 9,000.
  *
- * 🔴 Two other figures are in circulation and neither is this denominator: ~22,800
- * was the SAMPLE SIZE an early query examined (dividing by it gave ~0.04%, retired),
- * and ~101k–105k/day is the KEY-MINT rate (`POST /api/v1/image-upload/multipart/
- * index` + `.../index`, spanmetrics x10, measured 2026-08-28) — a different
- * population, upload requests rather than image creations, useful only as an
- * order-of-magnitude cross-check on the 92,000.
+ * 🔴 THE DERIVATION, WRITTEN HERE SO THE NEXT READER CAN CHECK IT WITHOUT ASKING.
+ * Numerator and denominator are one query over one population:
+ *
+ *     Image WHERE id BETWEEN 141000000 AND 141100000
+ *       AND scanJobs->'error'->>'reason' = 'Input image failed to download from URL.'
+ *
+ * That id range holds **92,759** rows spanning `2026-08-27 14:28` → `2026-08-28 14:29`
+ * (~24 h). All 10 defects came from inside it. It is also the same population the
+ * observe-only log counts — one line per `createImage` call — so the historical rate and
+ * the live rate are the same quantity, and condition 3 of the rollout gate below can be
+ * read straight off the log.
+ *
+ * 🔴 PROVENANCE, AND ITS LIMIT. The 92,759 and the 10 come from that one query, run once,
+ * on 2026-08-28. **It has not been re-run since, and the id-range window has since
+ * advanced** — so treat the figure as a dated measurement, not a live rate. Re-derive it
+ * (same query, a current 100k id range) before using it to grade anything; a threshold is
+ * only as fresh as the number under it. This caveat used to live in the PR description,
+ * which nobody reads at the moment they act on the threshold.
+ *
+ * 🔴 TWO OTHER FIGURES ARE IN CIRCULATION AND NEITHER IS THIS DENOMINATOR:
+ *   - **~22,846** (872 + 3,568 + 18,406) was a set of three `media_locations`
+ *     REGISTRY-COVERAGE samples, run to establish that a missing registry row means a key
+ *     was never signed. **Different population, different finding: 3 unregistered rows,
+ *     not 10.** The 10 did NOT come from it. Dividing 10 by 22,800 gave ~0.04%, which is a
+ *     number about no population at all; it is retired, and this is why.
+ *   - **~101k–105k/day** is the KEY-MINT rate (`POST /api/v1/image-upload/multipart/
+ *     index` + `.../index`, spanmetrics x10, measured 2026-08-28) — a different
+ *     population, upload requests rather than image creations, useful only as an
+ *     order-of-magnitude cross-check on the 92,759. Spread against it is 10% at 24 h
+ *     and 14% at 7 d.
  *
  * The 10 split into two distinct populations:
  *   - 7 had a key that WAS issued by an upload endpoint 2.0–23.3s before the row

--- a/src/server/utils/created-image-media-probe.ts
+++ b/src/server/utils/created-image-media-probe.ts
@@ -1,0 +1,127 @@
+import type { S3Client } from '@aws-sdk/client-s3';
+import { getImageUploadBackend, headObject } from '~/utils/s3-utils';
+
+/**
+ * Does the media an `Image` row is about to point at actually exist in the store?
+ *
+ * `createImage` writes its row from client-supplied JSON. `url` (the media key),
+ * `width`, `height`, `name`, `mimeType` and `sizeKB` all arrive over the wire and
+ * none of them is checked against storage, so any key a caller invents produces a
+ * complete, healthy-looking row whose media 404s forever.
+ *
+ * Measured in production over ~22,800 image creations, 10 rows referenced media
+ * that was never stored, in two distinct populations:
+ *   - 7 had a key that WAS issued by an upload endpoint 2.0–23.3s before the row
+ *     was written, but no object ever landed — a real upload that failed silently;
+ *   - 3 had a key no endpoint ever issued at all.
+ *
+ * 🔴 That split is why this is an EXISTENCE check and not a "was this key ever
+ * signed" registry lookup. A signature check sees only the second population — 3
+ * of the 10. Asking the bucket sees all 10, and it is also the only question whose
+ * answer stays true: a key can be signed and still have nothing behind it.
+ */
+
+/**
+ * What the probe concluded. 🔴 THREE values, never a boolean.
+ *
+ * A boolean forces the fail-open case to be reported as one of the other two, and
+ * both readings are wrong: counting `unknown` as present asserts we confirmed an
+ * object we never saw, and counting it as absent inflates the defect rate with
+ * probes that simply could not reach the bucket. Both directions corrupt the very
+ * measurement the observe-only rollout exists to take.
+ *
+ * Mirrors the verdict shape already used by the multipart-completion path in
+ * `src/pages/api/upload/complete.ts`.
+ */
+export type CreatedImageMediaVerdict =
+  /** The bucket answered that the key is there. */
+  | 'present'
+  /** The bucket ANSWERED absent. This is the defect. */
+  | 'absent'
+  /** The bucket could not be consulted — probe threw, timed out, or is unconfigured. Fail open. */
+  | 'unknown'
+  /** `url` is not a bare media key this store owns, so there is nothing to ask about. */
+  | 'not-applicable';
+
+/**
+ * Timeout budget for the probe. `createImage` sits on a user-facing mutation, and the
+ * client is built with SDK-default retries and NO request timeout, so an unbounded
+ * probe against a degraded backend would turn a guard into a hang — strictly worse
+ * than the bug it guards.
+ *
+ * Per `headObject`'s contract this bounds each network ATTEMPT, not wall-clock: the
+ * SDK's retry sleep is not abort-aware, so worst case is this budget plus one
+ * backoff. An abort surfaces as an `AbortError`, which is not a not-found shape, so
+ * it lands on `unknown` and the caller fails open like any other unreachable bucket.
+ */
+export const CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * A bare media key — the UUID an upload endpoint issues and stores as `Image.url`.
+ *
+ * 🔴 Not every `Image.url` is one. `addPostImageSchema` accepts
+ * `z.url().or(z.string().uuid())`, and legacy avatar rows hold a full external URL
+ * where every other row holds a bucket key — the same distinction
+ * `deleteImageFromS3` documents when it declines to delete an `http`-prefixed url
+ * because it names a bucket we do not own. HEADing one of those against OUR bucket
+ * asks a nonsensical question and would answer `absent` for a perfectly good row,
+ * so those are classified `not-applicable` and never probed.
+ *
+ * Deliberately a positive test (it IS a uuid) rather than a negative one (it is NOT
+ * an http url): a relative path, an empty string or a stray token is equally not a
+ * key we can look up, and a negative test would send all of them to the bucket.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isProbeableMediaKey(url: unknown): url is string {
+  return typeof url === 'string' && UUID_RE.test(url);
+}
+
+/**
+ * Seam for tests. Both default to the real implementations, so production behaviour
+ * is whatever `getImageUploadBackend` / `headObject` do — the injection point exists
+ * so a test can drive the three verdicts without a bucket, not so the probe can
+ * behave differently in production.
+ */
+export type CreatedImageMediaProbeDeps = {
+  getBackend: () => Promise<{ s3: S3Client; bucket: string }>;
+  headObject: typeof headObject;
+};
+
+const defaultDeps: CreatedImageMediaProbeDeps = {
+  getBackend: async () => {
+    const { s3, bucket } = await getImageUploadBackend();
+    return { s3, bucket };
+  },
+  headObject,
+};
+
+/**
+ * 🔴 NEVER THROWS. This probe guards a working code path, so it must not be able to
+ * fail that path by its own absence: resolving the backend is inside the try, and an
+ * unconfigured environment lands on `unknown` rather than propagating.
+ */
+export async function probeCreatedImageMedia(
+  url: unknown,
+  deps: CreatedImageMediaProbeDeps = defaultDeps
+): Promise<CreatedImageMediaVerdict> {
+  if (!isProbeableMediaKey(url)) return 'not-applicable';
+
+  try {
+    const { s3, bucket } = await deps.getBackend();
+    const head = await deps.headObject(bucket, url, s3, {
+      abortSignal: AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS),
+    });
+    if (head.status === 'absent') return 'absent';
+    if (head.status === 'unknown') return 'unknown';
+    /**
+     * A zero-length object is a stored object that cannot render, and is the same
+     * defect from the reader's point of view. `size: null` is "the backend reported
+     * no length", NOT "size zero", so it must not trip this — see `ObjectHeadResult`.
+     */
+    if (head.size === 0) return 'absent';
+    return 'present';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/utils/__tests__/upload-batch.test.ts
+++ b/src/utils/__tests__/upload-batch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { batchUploadFailureNotification } from '~/utils/upload-batch';
+
+/**
+ * The shared "some files in this drop failed" report, used by BOTH multi-file upload loops
+ * in the comics flow (`PanelModal`'s bulk panel drop and `character.tsx`'s reference drop).
+ *
+ * 🔴 WHAT THESE ARE FOR. The round-2 audit's finding was not a crash — it was that two
+ * identically-shaped loops had two different answers to one question, and that the message
+ * a user actually saw ("Failed to upload image") named neither the file nor the count. So
+ * the assertions here are on the CONTENT of the message, not merely on its existence: a
+ * report that omits the count or the filename is exactly the defect, and would pass a test
+ * that only checked "a notification was produced".
+ */
+describe('batchUploadFailureNotification', () => {
+  it('returns null when nothing failed — so no caller can raise a "0 of N" toast', () => {
+    // The empty check lives here rather than at each call site, which is what makes the
+    // spurious-toast case unreachable instead of merely avoided twice.
+    expect(batchUploadFailureNotification([], 5)).toBeNull();
+    expect(batchUploadFailureNotification([], 0)).toBeNull();
+  });
+
+  it('names how many of how many failed', () => {
+    const report = batchUploadFailureNotification(
+      [{ name: 'b.png', error: new Error('Upload failed (status 403)') }],
+      10
+    );
+
+    // Literal, not recomputed from the implementation: both numbers must be present and
+    // must be the right way round. "1 of 10" and "10 of 1" are equally well-formed.
+    expect(report?.title).toBe('Failed to upload 1 of 10 files');
+  });
+
+  it('names EVERY failed file, with its own reason', () => {
+    const report = batchUploadFailureNotification(
+      [
+        { name: 'b.png', error: new Error('Upload failed (status 403)') },
+        { name: 'd.png', error: new Error('Upload failed (status 503)') },
+      ],
+      4
+    );
+
+    expect(report?.title).toBe('Failed to upload 2 of 4 files');
+    // One entry per failure — `showErrorNotification` renders an array as a list, so a
+    // collapsed single string would lose the per-file reason.
+    expect(report?.error).toEqual([
+      { message: 'b.png: Upload failed (status 403)' },
+      { message: 'd.png: Upload failed (status 503)' },
+    ]);
+  });
+
+  it('says "file" for a single-file drop', () => {
+    const report = batchUploadFailureNotification(
+      [{ name: 'only.png', error: new Error('nope') }],
+      1
+    );
+
+    expect(report?.title).toBe('Failed to upload 1 of 1 file');
+  });
+});

--- a/src/utils/__tests__/upload-status.test.ts
+++ b/src/utils/__tests__/upload-status.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUploadInFlight, type TrackedFileStatus } from '~/utils/upload-status';
+
+/**
+ * The spinner predicate for `useCFImageUpload` tracked files.
+ *
+ * 🔴 WHY THIS EXISTS AS A TESTED UNIT AT ALL. Four consumers open-coded it as
+ * `imageFile && imageFile.progress < 100` and every one was wrong in the same
+ * direction — `progress` is written only by the `xhr.upload` progress listener, and
+ * neither the success branch nor either failure branch touches it. A PUT refused before
+ * its first progress event therefore leaves `progress` at its initial `0`, and
+ * `progress < 100` reads that as "still uploading" forever. In two of those four the
+ * render is `showLoading ? overlay : previewUrl ? preview : <Dropzone/>`, so a latched
+ * spinner unmounts the Dropzone and there is no retry short of a page reload.
+ *
+ * These are hand-written literals for what each status MEANS, not values recomputed
+ * from the implementation. The two components that own the latching render have no
+ * executed test of their own — the component project is browser-mode and does not run
+ * here — so this predicate is where the defect is actually pinned.
+ */
+describe('isUploadInFlight', () => {
+  const t = (status: TrackedFileStatus) => ({ status });
+
+  it.each<TrackedFileStatus>(['pending', 'uploading'])(
+    'is IN FLIGHT for %j — the upload has not settled',
+    (status) => {
+      expect(isUploadInFlight(t(status))).toBe(true);
+    }
+  );
+
+  it.each<TrackedFileStatus>(['success', 'error', 'aborted', 'blocked'])(
+    'is SETTLED for %j — the spinner must clear',
+    (status) => {
+      expect(isUploadInFlight(t(status))).toBe(false);
+    }
+  );
+
+  it('clears on `error` even though `progress` never reached 100', () => {
+    // 🔴 THE REGRESSION CASE, spelled out. This is the exact shape a refused presigned
+    // PUT leaves behind: the hook marks the tracked file `error` and no progress event
+    // ever fired, so `progress` is still 0. The old `progress < 100` spelling returns
+    // `true` here — permanently.
+    const refusedBeforeAnyProgress = { status: 'error' as const, progress: 0 };
+    expect(isUploadInFlight(refusedBeforeAnyProgress)).toBe(false);
+  });
+
+  it('is IN FLIGHT while uploading even when `progress` has already reached 100', () => {
+    // The mirror-image failure of the same replaced expression, and the reason this
+    // suite cannot be satisfied by a predicate that still reads `progress`: the request
+    // body can be fully sent (progress 100) while the store has not yet answered, so
+    // `progress >= 100` would clear the spinner before the outcome is known.
+    const bodySentAwaitingResponse = { status: 'uploading' as const, progress: 100 };
+    expect(isUploadInFlight(bodySentAwaitingResponse)).toBe(true);
+  });
+
+  it.each([null, undefined])('is SETTLED for %j — nothing has been dropped yet', (value) => {
+    expect(isUploadInFlight(value)).toBe(false);
+  });
+});

--- a/src/utils/upload-batch.ts
+++ b/src/utils/upload-batch.ts
@@ -1,0 +1,43 @@
+/**
+ * 🔴 ONE RULE FOR "SOME FILES IN THIS DROP FAILED", IN ONE PLACE.
+ *
+ * Two multi-file upload loops in the comics flow — `PanelModal`'s bulk panel drop and
+ * `character.tsx`'s reference drop — are the same shape and, after this PR's hook change,
+ * face the same new event: `uploadToCF` REJECTS on a refused PUT instead of resolving with
+ * a dead key. They initially got two different remedies, which is how a predicate becomes
+ * wrong at N−1 of its N sites. They now share this one:
+ *
+ *   1. CONTINUE. A refused PUT on file 2 of 10 must not silently abandon files 3–10. That
+ *      is also the PRE-EXISTING behaviour of both loops — before the hook change a 403
+ *      resolved and the loop carried on (with a dead key), so continuing restores what
+ *      users had, minus the dead key.
+ *   2. REPORT WHAT ACTUALLY HAPPENED. One notification, naming how many of how many
+ *      failed and which files. A bare "Failed to upload image" over a ten-file drop tells
+ *      the user neither that nine succeeded nor which one to retry.
+ *
+ * One aggregated notification rather than one per file, in both places: a bulk drop takes
+ * up to 20 files and N toasts bury the UI they are reporting on.
+ */
+export type BatchUploadFailure = { name: string; error: Error };
+
+/**
+ * Arguments for `showErrorNotification` describing a partially-failed batch.
+ *
+ * Returns `null` when nothing failed, so a caller can write
+ * `const report = batchUploadFailureNotification(...); if (report) showErrorNotification(report);`
+ * without also open-coding the empty check — the case that produced a spurious
+ * "0 of 5 failed" toast is then unreachable rather than merely avoided.
+ */
+export function batchUploadFailureNotification(
+  failures: BatchUploadFailure[],
+  total: number
+): { title: string; error: { message: string }[] } | null {
+  if (failures.length === 0) return null;
+
+  // `showErrorNotification` renders an array of `{ message }` as a list, so each failed
+  // file keeps its own name and its own reason rather than being collapsed into one line.
+  return {
+    title: `Failed to upload ${failures.length} of ${total} ${total === 1 ? 'file' : 'files'}`,
+    error: failures.map(({ name, error }) => ({ message: `${name}: ${error.message}` })),
+  };
+}

--- a/src/utils/upload-status.ts
+++ b/src/utils/upload-status.ts
@@ -15,11 +15,20 @@ export type TrackedFileStatus =
 /**
  * 🔴 "STILL UPLOADING" IS A STATUS, NEVER A PROGRESS NUMBER.
  *
- * Three consumers open-coded this as `imageFile && imageFile.progress < 100`, and every
- * one of them was wrong in the same direction — which is what a predicate open-coded at
- * N sites does. `progress` is written by exactly one place, the `xhr.upload` progress
- * listener in `src/hooks/useCFImageUpload.tsx`; neither the success branch nor either
- * failure branch touches it. So:
+ * 🔴 FIVE consumers open-coded this, every one of them derived from `progress`:
+ * `ProfileImageUpload`, `CosmeticShopItemUpsertForm`, `moderator/cosmetic-store/badges`
+ * and `useSubmitCreatorShopForm` as `progress < 100`, and `ImageUpload` as
+ * `(match && progress < 100) || image.file`. That is what a predicate open-coded at N
+ * sites does — three of the five latched outright, the fourth only worked because its
+ * `catch` called `resetFiles()` to clear the stuck tracked file, and the fifth needed a
+ * second term to compensate.
+ *
+ * (The other `progress < 100` hits in the repo are progress-BAR colour — "is the bar
+ * full" is a legitimate question about `progress`. This one is not.)
+ *
+ * `progress` is written by exactly one place, the `xhr.upload` progress listener in
+ * `src/hooks/useCFImageUpload.tsx`; neither the success branch nor either failure branch
+ * touches it. So:
  *
  *   - a PUT refused before any progress event fires (an expired presign answers on the
  *     request headers) leaves `progress` at its initial `0` forever. `progress < 100` is

--- a/src/utils/upload-status.ts
+++ b/src/utils/upload-status.ts
@@ -1,0 +1,43 @@
+/**
+ * The status a `useCFImageUpload` tracked file can be in.
+ *
+ * Lives here rather than in the hook so the in-flight predicate below can be imported
+ * (and unit-tested) without pulling React and the whole hook module graph in.
+ */
+export type TrackedFileStatus =
+  | 'pending'
+  | 'error'
+  | 'success'
+  | 'uploading'
+  | 'aborted'
+  | 'blocked';
+
+/**
+ * 🔴 "STILL UPLOADING" IS A STATUS, NEVER A PROGRESS NUMBER.
+ *
+ * Three consumers open-coded this as `imageFile && imageFile.progress < 100`, and every
+ * one of them was wrong in the same direction — which is what a predicate open-coded at
+ * N sites does. `progress` is written by exactly one place, the `xhr.upload` progress
+ * listener in `src/hooks/useCFImageUpload.tsx`; neither the success branch nor either
+ * failure branch touches it. So:
+ *
+ *   - a PUT refused before any progress event fires (an expired presign answers on the
+ *     request headers) leaves `progress` at its initial `0` forever. `progress < 100` is
+ *     then permanently true and the spinner never clears;
+ *   - a PUT refused after the body is fully sent leaves `progress` at 100, so the
+ *     spinner clears and the failure is indistinguishable from a success that produced
+ *     no preview.
+ *
+ * Two opposite wrong answers from the same expression. `status` is the field the hook
+ * actually maintains across all four terminal outcomes, so it is the one to ask.
+ *
+ * `pending` counts as in-flight: the tracked file is pushed with that status BEFORE
+ * `xhr.send`, so excluding it would blink the spinner off between the drop and the first
+ * progress event.
+ */
+export function isUploadInFlight(
+  trackedFile: { status: TrackedFileStatus } | null | undefined
+): boolean {
+  if (!trackedFile) return false;
+  return trackedFile.status === 'pending' || trackedFile.status === 'uploading';
+}

--- a/src/utils/upload-status.ts
+++ b/src/utils/upload-status.ts
@@ -23,6 +23,13 @@ export type TrackedFileStatus =
  * `catch` called `resetFiles()` to clear the stuck tracked file, and the fifth needed a
  * second term to compensate.
  *
+ * 🔴 FIVE IS THE HISTORICAL COUNT, NOT THE CALL-SITE COUNT — grep finds FOUR callers.
+ * `ImageUpload` is the fifth: it got a different remedy (drop the placeholder entry on
+ * error, which clears `image.file`), and an `isUploadInFlight(match) ||` added on top of
+ * that turned out to be DEAD — `match` is only ever defined when `image.file` is already
+ * truthy, so the term could not change the result. It was removed rather than left
+ * standing as a claim this rule governs that spinner. See the comment at its `showLoading`.
+ *
  * (The other `progress < 100` hits in the repo are progress-BAR colour — "is the bar
  * full" is a legitimate question about `progress`. This one is not.)
  *


### PR DESCRIPTION
## The defect

An `Image` row can reference a media key with no object behind it. `createImage` writes the row from client-supplied JSON — `url`, `width`, `height`, `name`, `mimeType`, `sizeKB` all arrive over the wire and none of them was checked against storage. `addPostImageSchema` accepts `url: z.url().or(z.string().uuid())`, so any UUID a caller invents produces a complete, healthy-looking row. Downstream the media 404s forever.

Measured in production: over a ~24 h window of **~92,000 image creations, 10 rows referenced media that was never stored — ~0.011%**, about 1 in 9,000. They split into two populations:

- **7 of 10** — the key *was* issued by an upload endpoint 2.0–23.3 s before the row was written, but no object ever landed. A real upload was attempted and silently failed.
- **3 of 10** — the key was never issued at all; the caller supplied a UUID no endpoint ever produced.

Two producers. This PR closes both.

> 🔴 **Two other figures appear in earlier revisions of this PR and in #4475's body; neither is this denominator.** **~22,800** was the *sample size* an early defect query examined — not a rate, not a population count; dividing 10 by it produced ~0.04%, and that number is **retired**. **~101k–105k/day** is the *key-mint* rate (upload-endpoint requests), a different population; it is kept below only as an order-of-magnitude cross-check on the 92,000. See [Rollout criterion](#rollout-criterion).

---

## Producer A — the client reported a failed PUT as a success

`src/hooks/useCFImageUpload.tsx`:

```ts
xhr.addEventListener('loadend', () => {
  const success = xhr.readyState === 4 && xhr.status === 200;
  if (success) updateFile({ status: 'success' });
  resolve(success);        // resolves either way; the caller discards the value
});
```

XHR's `error` event fires only on a **network** failure. A PUT that reaches the store and is refused — an expired presign (403), a malformed request (400), a store that is briefly unavailable (503) — completes normally and lands on `load` → `loadend`. It was reported to the caller as a successful upload; `uploadToCF` awaits that promise, discards its value, and returns `{ url, id, ... }` unconditionally. Consumers then persist the key. That is the 7.

**Fix:** the non-success branch now marks the tracked file `error` and rejects with `Upload failed (status <n>)`. A `terminated` flag keeps the pre-existing `error` / `abort` outcomes intact — each of those is followed by its own `loadend`, which would otherwise overwrite `aborted` with `error` and change the message the caller sees.

This hook backs avatars, cosmetics, comics, tiptap images, app-block images, collection content, bounties, challenges and `SimpleImageUpload`. Every call site was audited (table below); the ones that needed a change are included.

## Producer B — nothing server-side checked the object exists

`createImage` (`src/server/services/image.service.ts`) is the single funnel behind `addPostImage`, `createPostWithImagesHandler`, the model-version path and the collection path, plus comics, cover images and thumbnails. The check goes **there** — not per-router (a predicate open-coded at four call sites is wrong at three of them) and not in the zod schema (it needs IO).

### Why existence, not signature

A "was this key ever signed" registry lookup catches only the 3 rows whose key was never issued. **Asking the bucket catches all 10** — and it is also the only question whose answer stays true, since a key can be signed and still have nothing behind it.

### The bucket is resolved through `getImageUploadBackend()`, not open-coded

The media-key **predicate** was consolidated into `@civitai/shared/media-key` because two existence checks open-coded it by opposite construction and disagreed on real rows. The **bucket** is the second half of the same question — *"does this key exist in the store we own?"* — so it is consolidated for the same reason. Every key-minting site already routes through `getImageUploadBackend()` (`/api/v1/image-upload/index`, `.../multipart/index`, `uploadImageBufferToStore`), so this probe asks about the bucket the key was actually minted into **by construction**, not because two constants happen to agree.

⚠️ **Cross-PR note.** The moderator publish guard in **civitai#4475** currently open-codes this as `getB2ImageS3Client()` + `env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads'` — a literal inlining of `getImageUploadBackend`'s body. The two agree *today* only because those constants return the same values. Change the backend (a second image store, a bucket rename, a per-tenant bucket) and the two guards return **different verdicts about the same row** — and on that side an `absent` is a *permanent* refusal to publish, not a logged observation. That is exactly the drift the shared predicate exists to prevent, one layer down. The fix on that side is one line (call `getImageUploadBackend()`); it is not made here because it is another PR's branch. Flagged rather than silently left to diverge.

### Why the verdict is three-valued

`present` / `absent` / `unknown`, mirroring `src/pages/api/upload/complete.ts`, which solved the same problem for the multipart-completion path.

- `absent` — the bucket **answered** absent, or answered with a definitively zero `ContentLength`. This is the defect.
- `unknown` — the probe threw, timed out, or the client is unconfigured. **Fail open.** Inability to consult the bucket is not evidence of loss.
- `present` — fine.

A boolean would force the fail-open case to be counted as one of the other two. Counting it as present asserts we confirmed an object we never saw; counting it as absent inflates the defect rate with probes that could not reach the bucket. Both directions corrupt the very measurement this PR exists to take.

A fourth value, `not-applicable`, covers a `url` that is not a bare media key. `addPostImageSchema` permits a full URL as well as a UUID, and legacy avatar rows hold an external URL for a store we do not own — the same distinction `deleteImageFromS3` already documents. Those are never probed; HEADing one against our bucket would answer `absent` for a perfectly good row.

### Shipped OBSERVE-ONLY

The probe **always runs and always logs**; whether an `absent` verdict actually rejects is gated by a new `CREATE_IMAGE_VERIFY_MEDIA_ENFORCE`, defaulting to **off**. Same family, same stance, same schema shape as `UPLOAD_COMPLETE_VERIFY_ENFORCE` — `zc.booleanString.optional().default(false)`, compared with `=== true` at the use site so a malformed value lands on observe-only rather than on failing image creation.

Every call emits a structured `create-image-media-verify` line carrying `verdict` / `enforcing` / `rejected` / `userId` / `postId`, **and `url` when the probe actually ran**. A log emitted only on the bad verdict has no denominator, and the denominator is the whole point of this phase — one line per `createImage` call *is* the denominator condition 3 below is measured against.

🔴 **Why `url` is on the line, and why only on a probed verdict.** The criterion asks whether an `absent` verdict is a real defect or a false reject, and that is a question about *individual* verdicts: it can only be settled by taking an `absent` key, HEADing the bucket by hand, and looking for the row. `postId` is null on most non-post paths (comics, cover images, thumbnails, model-version images before the post exists) and `userId` alone selects thousands of rows. On a probed verdict the value is a 36-character UUID that `isProbeableMediaKey` already accepted — not a filename and not PII. A **`not-applicable`** verdict is the opposite population by definition: it is precisely the urls that *failed* that predicate, i.e. the arbitrary caller-supplied strings this PR exists because callers can invent. Those are never rejected and nobody will ever HEAD one by hand, so they are omitted. There is deliberately no image id: the row does not exist yet at this point, which is the whole reason the check sits here.

Cost: **≤ ~1.1 HEAD/s** at current volume (92,000 creations / 86,400 s = 1.07/s, and only the probeable subset issues a HEAD), bounded by a 3 s abort budget per call.

<a name="rollout-criterion"></a>
### Rollout criterion — three conditions, all required

🔴 **The threshold's denominator is the log's own line count.** The log fires on every `createImage` call, so it emits its own denominator:

```
absent rate = (lines with verdict `absent`) / (ALL `create-image-media-verify` lines in the window)
```

One line per call, so the denominator is *image creations* — **exactly the population the numerator was measured against**: 10 defective rows over ~92,000 image creations in the same ~24 h window ⇒ **~0.011%**. Numerator and denominator come from one query over one population; nothing is reconciled across two.

**The two figures that are NOT this denominator, stated so nobody re-derives from them:**

| figure | what it actually is | status |
|---|---|---|
| **~22,800** | the **sample size** an early defect query examined — not a rate, not a population count | **retired.** Dividing 10 by it gave ~0.04%, ~4x too loose |
| **~101,184 / day** (24 h) · **~104,949 / day** (7 d) | the **key-mint** rate: `POST /api/v1/image-upload/multipart/index` + `.../index`, spanmetrics on `service_name="civitai-dp-prod-api"` x10 for the app's head sampler, measured 2026-08-28, stable across 6 h / 24 h / 7 d windows | **kept only as a cross-check.** Upload *requests*, not image *creations*. It runs **10% (24 h) to 14% (7 d) above** 92,000, in that direction, which is what you would expect given abandoned uploads on one side and server-side creation paths (`uploadImageBufferToStore`, the orchestrator, app-listing assets) on the other |

*Caveat on the 92,000, stated because the threshold is set from it:* the original DB query behind "10 defects over ~92,000 image creations" was not re-run here; its ~24 h window is taken as given.

**All three of these must hold before flipping `CREATE_IMAGE_VERIFY_MEDIA_ENFORCE`:**

1. 🔴 **POSITIVE CONTROL — a non-zero `present` count in the window.** A probe that can never answer emits **zero `absent` verdicts**, and zero-absent is exactly what a clean result looks like. `getB2ImageS3Client()` throws when credentials are missing, and a rotated, write-only or wrong-bucket key answers 403 — every one of those lands on `unknown`, and every one of them reads as "no defects found". A low `absent` count means nothing until `present` proves the probe reaches the bucket at all.
2. **`unknown` is a small share of the PROBED lines** (`present + absent + unknown`, i.e. excluding `not-applicable`). A large `unknown` share means the probe is mostly failing open, so the `absent` count is not a rate.
3. **The `absent` rate, over ALL lines, is at or below ~0.011%.** Materially higher and the excess is false rejects. Settle "defect or false reject" per-verdict by taking a logged `absent` key and HEADing the bucket by hand — that is what `url` on the log line is for.

🔴 **`=1` and `=TRUE` are silent no-ops.** `zc.booleanString` is `val === true || val === 'true'` — exact and case-sensitive — so any other spelling parses to `false` with no error and no warning. The only tell is `enforcing: false` on the `create-image-media-verify` line. Check that after setting the value, not the deploy. `'1'`, `'TRUE'` and `'True'` are pinned as non-enforcing in the env-gate test.

Flipping it back off is a config change, not a revert. **The flag is not enabled anywhere in this PR.**

---

## Test matrix — red at `origin/main`, green at HEAD

Every regression test below was run against pre-change code and watched to fail. Counts are the runner's own per-test result lines.

### `src/hooks/__tests__/useCFImageUpload.test.ts` — 8 tests

At `origin/main`: **4 failed | 4 passed**. At HEAD: **8 passed**.

| test | at main | note |
|---|---|---|
| rejects when the PUT completes with HTTP 403 | **RED** — `expected 'resolved' to be 'rejected'` | regression |
| rejects when the PUT completes with HTTP 400 | **RED** — same | regression |
| rejects when the PUT completes with HTTP 500 | **RED** — same | regression |
| marks the tracked file `error` on a refused PUT | **RED** — `expected [ 'uploading' ] to deeply equal [ 'error' ]` | regression |
| resolves a 200 with the existing shape | green | invariant guard |
| keeps rejecting on a network `error` event | green | invariant guard |
| keeps rejecting on `abort`, status stays `aborted` | green | invariant guard at main; a **regression guard for this fix** — see mutation A2 |
| sends the file to the signed URL with PUT | green | invariant guard |

These assert the **promise outcome**, not the tracked-file UI state — the UI state was already wrong-but-cosmetic; the promise is the contract the row was written from. The one exception is the `abort` case, which additionally pins the tracked status because that is precisely what the fix could regress.

The XHR double drives the real event sequence (`load`+`loadend` with no `error` for a refused PUT), because the distinction under test lives entirely in *which* event fires.

### `src/server/services/__tests__/create-image-media-verify.test.ts` — 12 tests

At `origin/main` (with `image.service.ts` and `server-schema.ts` reverted): **9 failed | 1 passed** for the 10 cases that existed then. At HEAD: **12 passed**.

The 6 required cases — three verdicts x two gate states:

| verdict | gate | expected | at main |
|---|---|---|---|
| `absent` | observe-only | **creates the row as today, and logs** | **RED** — `expected undefined to match object {...}` (no verdict logged) |
| `absent` | enforcing | rejects, no row written | **RED** — `promise resolved "{ id: 987654 }" instead of rejecting` |
| `unknown` | observe-only | creates | **RED** |
| `unknown` | enforcing | creates (fail open) | **RED** |
| `present` | observe-only | creates unchanged | **RED** |
| `present` | enforcing | creates unchanged | **RED** |

Plus: a full `http(s)://` url is not probed and not rejected (**RED** at main); the probe asks for the media key in the bucket the image-upload backend resolved (**RED** at main); a verdict is logged on every call (**RED** at main); the log **carries the media key on a probed verdict** and **omits the url on `not-applicable`** (both added this round — see mutations D1/D2); and "a telemetry failure cannot change the outcome of the creation" — **green at main**, so it is an **invariant guard**, not regression coverage (there is no telemetry call at main to fail).

These drive the **real** `probeCreatedImageMedia` and the **real** `headObject` over a stubbed S3 `send`, so the three verdicts are produced by AWS-SDK-shaped answers rather than by a fake that could encode the same wrong shape as the code.

### `src/server/utils/__tests__/created-image-media-probe.test.ts` — 26 tests

New module, so "red at main" is vacuous (the file does not exist there) — these are **contract tests for the new unit**, not regression coverage, and are stated as such. They are the tests the mutation sweep below actually kills. Cover: the three verdicts; `size === 0` → `absent`; `size === null` → `present` (the backend reporting no length is not zero); an unconfigured backend → `unknown`; an abort → `unknown`; `not-applicable` for http(s) urls, non-uuids, empty strings and non-strings; that the command carries the right `Bucket` + `Key`; and the shared-predicate cases added in round 4 (`some-file.png`, a `blob:` handle with an embedded uuid), which run under **this app's** resolver and so prove the import resolves rather than duplicating the shared package's own suite.

### `src/env/__tests__/server-schema-create-image-verify-media.test.ts` — 14 tests

At `origin/main`: **11 failed** (`Cannot read properties of undefined (reading 'parse')` — the key does not exist) — measured when the file held 11 cases; the three `'1'` / `'TRUE'` / `'True'` cases were added afterwards and were not separately re-run against main, though they fail there for the same reason (the key does not exist). At HEAD: **14 passed**.

Modelled on the existing `server-schema-upload-complete-verify.test.ts`. Pins that the field yields a real boolean: `undefined` → `false`; `'true'` → `true` and `typeof === 'boolean'`; and that `''`, `'false'`, `'FALSE'`, `'no'`, `'0'`, `'yes'`, `'garbage'`, `'TRUE '` all land on **observe-only, never on rejecting**.

### `src/server/services/__tests__/create-image-caller-seam.test.ts` — 13 tests

**Green at main by construction** (it mocks `createImage`), so it is an **invariant / seam guard**, not regression coverage. It exists because the gate tests are scoped to `createImage` alone and never load its callers — a defect living in the seam is invisible to every one of them. It drives the real `addPostImage` and pins that:

- the client-supplied media key is forwarded **verbatim** (so the probe sees the key the row will carry);
- a full `http(s)` url is forwarded verbatim too (the skip decision belongs to `createImage`, not the caller);
- a `createImage` rejection **propagates** rather than being swallowed — if it were caught, enabling the flag would reject inside `createImage` while the caller reported success;
- on success the tail runs with the created id (`createImageResources`, the row re-read).

It also carries the **repo-wide ledger** of every file that writes an `Image` row outside the funnel. That ledger was rebuilt this round; see [Round 5](#round-5).

---

## Mutation checks

Each guard was neutered and the run watched to go red **with that guard's own message**, on a fixture no earlier check rejects.

| # | mutation | test that failed | message |
|---|---|---|---|
| A1 | `loadend` non-success branch → `resolve()` (the pre-fix behaviour) | the three HTTP-status tests + the tracked-status test | `expected 'resolved' to be 'rejected'`; `expected [ 'uploading' ] to deeply equal [ 'error' ]` — **4 failed, 4 passed** |
| A2 | delete `if (terminated) return;` from `loadend` | *keeps rejecting on `abort`, status stays `aborted`* — **and only that test** | `expected [ 'error' ] to deeply equal [ 'aborted' ]` — 1 failed, 7 passed |
| B1 | probe: `unknown` → `absent` (collapse the tri-state) | 2 probe tests + both `unknown` gate tests | `expected 'absent' to be 'unknown'`; and the `unknown`+enforcing case died on **this guard's own error**, `TRPCError: One of the files did not upload properly, please try again` — proving the fail-open branch is reachable and asserted |
| B2 | drop the gate: `rejectingMedia = mediaVerdict === 'absent'` | *`absent` + OBSERVE-ONLY: still creates the row* — **and only that test** | `TRPCError: One of the files did not upload properly, please try again` — 1 failed, 9 passed. This is the case that protects the rollout. |
| B3 | `isProbeableMediaKey` → `typeof url === 'string'` (probe everything) | 7 predicate cases + `not-applicable` verdict + the createImage http-url case | `expected true to be false`; `expected 'present' to be 'not-applicable'`; `TRPCError: One of the files did not upload properly…` — 9 failed, 23 passed |
| B4 | `head.size === 0` → `!head.size` (treat "no length reported" as zero) | *returns `present` when the backend reports NO length* — **and only that test** | `expected 'absent' to be 'present'` — 1 failed, 21 passed |
| E1 | env key → `z.string().optional().default('false')` | all 11 env-gate tests | `expected 'true' to be true`; `expected 'false' to be false` — the exact inert-config-key failure the test exists to prevent |

A2, B2 and B4 each killed **exactly one** test, so the assertion that died is the one that owns the guard rather than a neighbour's.

### Mutants that SURVIVED an earlier revision, and now die

| # | mutation | before | now |
|---|---|---|---|
| C1 | plant `dbWrite.image.createManyAndReturn({ data: [] })` above the `createImage` call in `post.service.ts` | **SURVIVED** 62/62 | **1 failed, 10 passed** — `expected [ …(5) ] to deeply equal [ …(4) ]`, naming `+ "src/server/services/post.service.ts"` |
| C2 | reroute `app-listing-assets.service.ts`'s `dbWrite.image.create(` through `createImage(` (the SHRINK direction) | not detectable | **1 failed, 10 passed** — `- "src/server/services/blocks/app-listing-assets.service.ts"` |
| C3 | *negative control* — restore the OLD regex `/db(Write\|Read)\.image\.create(Many)?\(/` **with C1 still planted** | — | `post.service.ts` is **not** in the found set: that spelling is provably blind to exactly this mutant. 2 failed |
| C4 | delete the whole `{ abortSignal: AbortSignal.timeout(CREATED_IMAGE_MEDIA_PROBE_TIMEOUT_MS) }` argument | **SURVIVED** 62/62 | **1 failed, 35 passed** — `AssertionError: expected undefined to be an instance of AbortSignal` |
| C5 | `isUploadInFlight` → `(trackedFile.progress ?? 0) < 100` (the open-coded spellings this replaces) | new guard | **6 failed, 4 passed** — `expected true to be false` on all four terminal statuses **and** on the `error`+`progress:0` regression case, `expected false to be true` on `uploading`+`progress:100` |
| C6 | `ProfileImageUpload`: `showLoading` → `imageFile && imageFile.progress < 100` | new guard | **1 failed, 4 passed** (browser) — `expected <div …(2)>…(3)</div> to be null`, and **only** the spinner test |
| C7 | `ProfileImageUpload`: delete the `try`/`catch` around `await uploadToCF(file)` | new guard | **2 failed, 3 passed** (browser) — `expected '…' to contain 'Upload failed (status 403)'` and `expected [ Error: Upload failed (status 403) ] to deeply equal []` |

🔴 **C6 initially SURVIVED, and why is worth recording.** The first draft of that test was `await vi.waitFor(() => expect(overlay()).toBeNull())` — but `waitFor` on an **absence** is satisfied by the state *before* the drop is even processed, so it passed against a component whose spinner never came down. Fixed by giving the mocked PUT a real in-flight window and asserting **both edges in order** (`not.toBeNull()` then `toBeNull()`), plus a separate `hang`-behaviour positive control that pins the selector actually matches something.

---

## `uploadToCF` consumers — full audit

Every call site was read. The rest already sit behind a `try`/`catch`.

**Changed in this PR:**

| file | why |
|---|---|
| `src/components/ImageUpload/ImageUpload.tsx` | inside `Promise.all` with no catch. The tile's `showLoading` was `(match && progress < 100) \|\| image.file`, and `image.file` was only cleared on success — a refused PUT latched the spinner **permanently**. Now drops the placeholder, revokes the object URL and sets the field error; the predicate is the shared `isUploadInFlight`. Highest-traffic consumer (post/model image upload). |
| `src/components/Bounty/BountyUpsertForm.tsx` | `uploadToCF(file)` not awaited — a guaranteed unhandled rejection. `.catch(() => undefined)`; the UI already renders the hook's `error` status. |
| `src/components/Bounty/BountyEntryUpsertForm.tsx` | identical shape |
| `src/components/Challenge/ChallengeSubmitModal.tsx` | `args.forEach(({ file }) => uploadToCF(file))` — same |
| `src/components/Comics/PanelModal.tsx` (x2) | `try { … } finally { … }` with **no catch**: the flag cleared but the rejection escaped and the user was told nothing. Now shows an error notification. Plus the bulk-drop failure policy below. |
| `src/utils/upload-status.ts` **(new)** | the shared `isUploadInFlight` predicate + `TrackedFileStatus`, replacing five open-coded `progress < 100` spellings |
| `src/utils/upload-batch.ts` **(new)** | the shared "some files in this drop failed" report, so both multi-file loops answer one question the same way |
| `src/components/Comics/bulk-panel-upload.ts` **(new)** | `PanelModal`'s bulk drop loop, lifted out so its failure policy can be driven by a test |
| `src/pages/moderator/cosmetic-store/badges/index.tsx` | `progress`-derived spinner (latches, unmounts the Dropzone) + bare `await` in `onDrop` |
| `src/components/CosmeticShop/CosmeticShopItemUpsertForm.tsx` | identical shape |
| `src/components/ProfileImageUpload/ProfileImageUpload.tsx` | identical shape (Dropzone stays mounted here, so retry was possible — the spinner and the silence were not), plus the preview fix in [Round 5](#round-5) |
| `src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts` | another open-coded copy; worked only because its `catch` called `resetFiles()`. Now uses the shared predicate and no longer depends on that. |
| `src/pages/comics/project/[id]/character.tsx` | multi-file drop loop aborted on the first failure — per-file `catch` + `continue`, then one aggregated report |
| `src/pages/comics/create.tsx`, `src/components/Comics/ProjectSettingsModal.tsx` | object-URL leak on the new rejection path; `revokeObjectURL` moved into a `finally`, hero handlers get a `catch` |

**Would now show the raw message to a user** — acceptable and informational (`Upload failed (status 403)` is a better message than silence), listed so it is a decision and not an accident: `SimpleImageUpload.tsx` (`Image upload failed: …`), `BlockImageUploadModal.tsx`, `ListingAssetStep.tsx`, `model3d-seed.tsx`, `GenerateImageModal.tsx`, `PanelModal.tsx` (annotation save), `Model3DViewer.tsx`, `FeedbackPrompt.tsx`, `IterativeImageEditor.tsx`, `CreatorShopPackModal.tsx`, `useSubmitCreatorShopForm.ts`.

**Already correct, no change needed:** `intent/avatar.tsx` (generic message + clears its flag), `libs/tiptap/extensions/CustomImage.tsx` and `TipTap/EdgeMediaNode.tsx` (friendly notification, clears the loader), `utils/comic-image-picker.ts` (`Promise.allSettled` + `finally`), `CreatorShopPackModal.tsx` / `useSubmitCreatorShopForm.ts` (both call `resetFiles()`).

**Previously left alone — now all six are fixed, because the justification for leaving them was wrong.**

🔴 That justification read: *"no stuck spinner, because the hook now marks the tracked file `error` and every one of these derives its spinner from that status."* It is true for three of the six and **false for the other three**:

| file | spinner derived from | verdict |
|---|---|---|
| `pages/comics/create.tsx` | `coverFiles.some(f => f.status === 'uploading')` | claim held |
| `components/Comics/ProjectSettingsModal.tsx` | `coverUploadFiles.some(f => f.status === 'uploading')` | claim held |
| `pages/comics/project/[id]/character.tsx` | `uploadingFiles.some(f => f.status === 'uploading')` | claim held |
| `pages/moderator/cosmetic-store/badges/index.tsx` | **`imageFile.progress < 100`** | 🔴 claim false |
| `components/CosmeticShop/CosmeticShopItemUpsertForm.tsx` | **`imageFile.progress < 100`** | 🔴 claim false |
| `components/ProfileImageUpload/ProfileImageUpload.tsx` | **`imageFile.progress < 100`** | 🔴 claim false |

`progress` is written by exactly one place — the `xhr.upload` progress listener — and neither the success branch nor either failure branch touches it. So `progress < 100` is wrong in **both** directions: a PUT refused before its first progress event (an expired presign answers on the request headers) leaves it at `0` and the spinner latches on **forever**; a PUT refused after the body is fully sent leaves it at `100` and the spinner clears as though nothing went wrong. In the first two files the render is `showLoading ? <LoadingOverlay/> : previewUrl ? <preview/> : <Dropzone/>` — so a latched spinner **unmounts the Dropzone and there is no retry without a page reload**. All three were also bare `await` with no `try`/`catch` inside a Mantine `onDrop`, which discards the promise, so a refused PUT produced **no message at all**.

**Fixed:**

- **`src/utils/upload-status.ts`** owning `TrackedFileStatus` and `isUploadInFlight(trackedFile)`. One rule, one place. It was open-coded at **five** sites, every one of them derived from `progress` — a field no failure branch writes: `ProfileImageUpload`, `CosmeticShopItemUpsertForm` and `moderator/cosmetic-store/badges` latched outright; `useSubmitCreatorShopForm` only worked because its `catch` called `resetFiles()`; and `ImageUpload` needed a second term (`|| image.file`) to compensate. (The repo's other `progress < 100` hits are progress-BAR colour — a legitimate question about `progress`. This one was not.) All five now call the shared predicate; `useSubmitCreatorShopForm.ts` no longer depends on its `resetFiles()` workaround. `ImageUpload.tsx` — the fifth site — keeps its own remedy (dropping the placeholder on error) **and** uses the shared predicate; see [Round 5](#round-5).
- `try`/`catch` around the bare `await` in all three, surfacing `error.message` (a notification in the two moderator forms, the wrapper's own `error` slot in `ProfileImageUpload`).
- **`character.tsx` `handleRefImageDrop`** and **`PanelModal.tsx` `handleBulkImageDrop`** — one shared failure policy; see [Round 5](#round-5).
- **`comics/create.tsx` and `ProjectSettingsModal.tsx` cover-crop handlers** — `URL.revokeObjectURL(url)` moved into a `finally`. `ImageCropModal`'s `onConfirm` is typed `() => void` and the modal discards the promise, so a rejection skipped the revoke *and* `onCancel` can no longer run: the blob was retained for the page's lifetime. Their hero handlers get a `catch` for the same silent-rejection reason.

**Behaviour change worth flagging:** `PanelModal.tsx` at the generator→enhance and generator→bulk paths catches the rejection and substitutes the raw generator URL as the panel's image url. Previously a 403 produced a valid-looking media key that 404'd; now it produces a non-first-party URL. Both are wrong; the failure mode changes. Pre-existing shape, not introduced here.

**Known coupling, recorded rather than changed:** success in the `loadend` handler is `xhr.status === 200` **exactly**, and that predicate now decides whether the promise *rejects* rather than only what the tracked file's status says. A store answering a single-shot PUT with `201`, `204` or a `3xx` would be turned into a hard failure and the row would not be written. That is the correct direction to err — it refuses to persist a key it is not sure about — and B2's S3 API answers `200` to this PUT today. But it is a behavioural dependency on the store's exact status code, so widening it is a deliberate decision rather than a tidy-up. Noted in the code at the call site.

---

## Not covered

- `createEntityImages` writes `Image` rows via `createMany` and does **not** go through `createImage`, so it is not covered by this check. Those rows have no post. Called out rather than silently included in the funnel claim, and pinned by the repo-wide ledger.
- The probe catches **absent** and **empty**. It cannot catch a short-but-non-zero object — there is no trustworthy expected size at this point (`sizeKB` is client-supplied and never verified against the bytes). A present, non-empty object is strictly better evidence than none, and inventing a comparison that looks rigorous and isn't would be worse.
- The observe-only phase is the measurement; nothing here proves the false-reject rate is low, which is exactly why the gate ships off.

### Component fixes: what is and is not covered by an executed test

Stated explicitly rather than implied.

**Covered by an executed test:**

- `isUploadInFlight` — `src/utils/__tests__/upload-status.test.ts`, 10 cases in the `unit` (node) project. Includes the exact regression shape (`status: 'error'`, `progress: 0`) and its mirror (`status: 'uploading'`, `progress: 100`). Mutation C5.
- `batchUploadFailureNotification` — `src/utils/__tests__/upload-batch.test.ts`, 4 cases in the `unit` project. Asserts the *content* of the report (count both ways round, one entry per failed file with its own reason), because a report that omits the count or the filename **is** the defect. Mutation D5.
- `ProfileImageUpload` end to end — `src/components/ProfileImageUpload/ProfileImageUpload.browser.test.tsx`, 6 cases in the `component` (real Chromium) project: the spinner goes up and comes back down on a refused PUT, the message is surfaced, no unhandled rejection escapes, **no preview of the refused file is painted**, an existing avatar survives a refused PUT, and a success still emits the new key. Mutations C6, C7, D3, D4.
- `PanelModal`'s bulk-drop failure policy — `src/components/Comics/bulk-panel-upload.browser.test.tsx`, 4 cases in the `component` project, driven with real `File`s through a real `URL.createObjectURL`/`window.Image` decode. Mutation D6.

**NOT covered by an executed test — no test exercises these paths:**

- `pages/moderator/cosmetic-store/badges/index.tsx` and `components/CosmeticShop/CosmeticShopItemUpsertForm.tsx`. Both call the same `isUploadInFlight` (unit-tested) and use the same `try`/`catch` shape as `ProfileImageUpload` (browser-tested), but neither component is mounted by any test. Both pull in tRPC queries, `QuickSearchDropdown` (a search client) and `SmartCreatorCard`, which is a substantial mocking exercise for a shape already pinned twice over.
- `pages/comics/project/[id]/character.tsx` `handleRefImageDrop`. Its two moving parts are covered separately — the `continue` policy by the `bulk-panel-upload` suite that implements the same rule, and the report by `upload-batch`'s own tests — but the loop itself lives inside a ~1,000-line page behind `getServerSideProps`, tRPC, dnd-kit and a dynamic modal import, and is not mounted.
- The `showLoading` call site in `components/ImageUpload/ImageUpload.tsx`. The predicate it now calls is unit-tested and mutation-swept; the component is not mounted by any test.
- The object-URL `finally` in `comics/create.tsx` and `ProjectSettingsModal.tsx`. Verifying a blob was revoked needs the crop modal driven end to end.
- The length bound on the logged `url` (`CREATE_IMAGE_MEDIA_VERIFY_URL_LOG_MAX`). It is **unreachable on today's population** and deliberately so: `url` is only logged on a probed verdict, and `isProbeableMediaKey` has already constrained that value to a 36-character UUID. No test can reach it without mocking the predicate, which would test the mock. It is a defensive bound against that predicate later widening — **not** a guard with executed coverage, and it is not counted as one. The *omission* on `not-applicable` is the actual fix, and that one is tested and mutation-killed (D2).

*Environment note:* the `component` project **does** run here, but only after working around a Playwright browser-revision mismatch — `node_modules` wants `chromium_headless_shell-1200` and the nix `playwright-browsers` derivation ships `-1228`. Symlinking `1228` as `1200` into a writable `PLAYWRIGHT_BROWSERS_PATH` makes the whole suite run. Without that workaround `pnpm test:component` reports `Test Files (194) / Tests no tests`, which is a **broken invocation, not a pass** — worth knowing before anyone reads a zero from it.

---

## Incidental

`src/server/flipt/__tests__/flipt-eval-context.test.ts` carries a ledger keyed on
`image.service.ts:<line>`. Adding one import line to `image.service.ts` shifted four
entries by +1; the ledger is updated to match. No Flipt call site changed.

🔴 Every later addition to `image.service.ts` — including this round's — is placed **below** all four recorded sites for exactly this reason, so the `+1` is still the whole delta. That is why `CREATE_IMAGE_MEDIA_VERIFY_URL_LOG_MAX` is declared next to `createImage` rather than exported from the probe module: an import line at the top of the file would have shifted all four keys again.

---

# Round 4 — the predicate collision with #4475

## 🔴 MERGE NOTE — re-derive the flipt ledger; do not pick a conflict side

`src/server/flipt/__tests__/flipt-eval-context.test.ts` conflicts with #4475 and **neither branch's numbers are correct after both land**. The ledger keys off line numbers in `image.service.ts`, and both PRs insert lines above the recorded sites.

| site | `main` | **#4474 (this, +1)** | #4475 (+6) | **after both (+7)** |
|---|---|---|---|---|
| `feed-fetch-filter-in-post` | 4127 | 4128 | 4133 | **4134** |
| `feed-image-existence` #1 | 4268 | 4269 | 4274 | **4275** |
| `feed-image-existence` #2 | 5006 | 5007 | 5012 | **5013** |
| `feed-image-existence` #3 | 6140 | 6141 | 6146 | **6147** |

🔴 **`4274`/`4269` occurs TWICE in that file** — once as a ledger key and once as a behavioural assertion (`expect(bySite.get(...)?.argc).toBe(2)`). **Both** must become `4275`. Resolving only the ledger leaves a green-looking file with one stale assertion.

Two independent derivations agree on these values, and they were re-derived after round 3's changes as well: no round has added a line above any of the four sites, so the `+1` is unchanged and the flipt suite passes on this branch's tip as it stands.

## Finding 1 — two functions, one name, opposite construction

This PR and #4475 each exported `isProbeableMediaKey`, answering the same question by opposite construction, **each with a docstring arguing against the other**:

| | this PR | #4475 (was) |
|---|---|---|
| test | positive — strict UUID | negative — `!/^[a-z][a-z0-9+.-]*:/i` |
| `some-file.png` | `not-applicable` → allow | probe → 404 → `absent` → **permanent refusal** |

After both merged the repo would hold two contradictory copies of the rule the shared package exists to unify. There is now **one**, `packages/civitai-shared/src/media-key.ts`, imported by this probe and by both publish call sites. This branch adds that file and its `exports` entry with **byte-identical content** to #4475, so either merge order compiles standalone and the two additions auto-merge.

### Which one survived, and the evidence

**The UUID positive test — this PR's construction — but NOT on the grounds originally written down for it.**

The premise "every legitimate `Image.url` that is a bucket key is a UUID" does **not** hold. Every key-**minting** site is a bare `randomUUID()`, but several **write** paths take a caller-supplied string and never check its shape: **seven `comics.router.ts` call sites** validate the url with `z.string().min(1)`, and the article **`edge-media`** sync copies the attribute verbatim out of sanitized HTML, where the sanitizer does not filter a custom attribute named `url`. Any of those can put `foo/uuid`, `photo.jpg` or `12345` into the column.

So the surviving predicate is a deliberate **under-approximation**, and the direction is chosen from **what each error costs at the strictest call site**:

- a false **negative** (a real key we decline to probe) costs a detection;
- a false **positive** (a non-key we probe) costs a 404 indistinguishable from a genuine miss — which in #4475 becomes a permanent, un-overridable refusal to publish an image that may render fine.

It is also strictly **broader** than zod's `.uuid()` (it accepts an invalid version nibble), so no check can decline a key the write schema already called a key.

### What changed there

**Behaviour is unchanged** — same test, same verdicts, same three-plus-one verdict union. The local `UUID_RE` and predicate are deleted and imported from `@civitai/shared/media-key` instead.

The two call sites still act **differently on the answer**, which is deliberate and written down at the seam: this one is observe-only behind a flag defaulting off, so a wrong verdict is logged rather than enforced; #4475's refuses a moderator action immediately. What must not differ is the **question**.

The predicate's cases are kept in this suite **as well as** in the shared package's own, on purpose. They are not a duplicate: they run under **this app's** resolver and module graph, so they are what proves the import resolves and that this call site reads the shared rule rather than a reintroduced local one.

---

<a name="round-5"></a>
# Round 5 — round-2 audit fixes

Six findings. One of them was a regression this PR's own round 2 introduced.

## 1. 🔴 A refused upload rendered a preview as if it had succeeded

`ProfileImageUpload`'s `useDidUpdate` set `image` from the tracked file **unconditionally**, including on `status: 'error'`, and called `onChange` only on `success`. While the latched `progress < 100` spinner existed the preview branch was unreachable on failure, so this was invisible; **consolidating the spinner onto `status` exposed it.**

Net effect before this round: a user whose PUT was refused saw their **new avatar in the circle plus an error line**, while `onChange` never fired and the form still held the old value — clicking Save silently kept the old avatar.

The preview and the emitted value now come from **one branch**, because they are the same claim. And on failure the preview of the *current form value* is restored rather than left blank: `handleDrop` clears it optimistically, and leaving it cleared renders an empty circle for a user whose avatar is still set, which reads as "your avatar was removed".

The two sibling components are **not** affected — their `previewUrl` is only set inside the `try`.

Pinned by two new browser cases and killed by mutations D3 and D4 below.

## 2/3/4. The repo-wide ledger reproduced the class it was written to retire

`src/server/services/__tests__/create-image-caller-seam.test.ts`. Round 2's ledger matched `/\.image\.create(Many(AndReturn)?)?\(/` against source with lines stripped when their *first* non-space token was `//`, `*` or `/*`. That was wrong in three ways:

- 🔴 **Walkable by a line wrap.** Prettier breaks a chain at 100 columns, so a real bypass on a long receiver renders as `tx.image\n  .createManyAndReturn({...})` and the regex requires the two accesses to be adjacent. Measured: planting exactly that in `post.service.ts` left the suite green at **11 passed**. The same defect class the ledger exists to catch.
- 🔴 **False-failed on ordinary prose.** A *trailing* comment — or a string literal — mentioning the call was not stripped, so `const __note = 1; // historical: this used to call tx.image.create({ data })` produced a red build naming `post.service.ts`, for a contributor who touched nothing relevant, with an opaque set-inequality error.
- 🔴 **The names claimed coverage the matcher did not have.** `daily-challenge-processing.ts` writes `Image` rows with `dbWrite.$queryRawUnsafe(\`INSERT INTO "Image" (...) SELECT ...\`)`, invisible to any Prisma-shaped matcher. "Every file that writes an Image row directly" was false.

**Rebuilt as two scans, and renamed to what it checks** (*"every file that writes an Image row outside `createImage`"*):

1. A **TypeScript AST walk** (`ts.createSourceFile`) over candidate files, matching a `CallExpression` whose callee is `<expr>.image.{create|createMany|createManyAndReturn}`. Comments are trivia and string literals are leaves, so neither can be mistaken for a call — and source formatting is not part of the AST, so wrapping is invisible. A cheap textual pre-filter (a deliberate superset) keeps the number of files actually parsed small.
2. A **raw-SQL arm** matching `INSERT INTO "Image" (` in the source, quoted so `"ImageFlag"` / `"ImageResourceNew"` / `"ImageTagForReview"` — all three real in this repo — stay out.

`daily-challenge-processing.ts` joins the ledger with its reason: `duplicateImage` copies an existing row's columns, `url` included, so the object exists by construction.

🔴 **And the ledger now says what it CANNOT see**, in its own docstring: a dynamic member access (`db['image']['create']`), a table alias, an `INSERT` assembled from fragments, and anything outside `src/`. It is a ledger over two named shapes, not a completeness proof. A guard whose description claims coverage it lacks is worse than none, because it stops the next person looking.

## 5. The flip criterion's threshold now uses the population it will be read against

Round 2 derived the threshold from **key mints** (~101k/day) while the rate will be computed from the **log**, i.e. per `createImage` call. Different populations, and three unreconciled figures were in circulation (`~22,800`, `~101k`, and `~92,000 image creations in 24h` in #4475's body).

The log fires on every call, so it **emits its own denominator**. The criterion is rewritten to quote that, and the numerator's own denominator — 10 defects over **~92,000 image creations** in the same ~24 h window — is the same quantity: **~0.011%**. `~22,800` was a sample size and is retired; `~101k/day` is named as the key-mint rate and demoted to an order-of-magnitude cross-check. All of this is written into `src/env/server-schema.ts` and `created-image-media-probe.ts` as well, not only here.

## 6. Two identically-shaped loops, one policy

`character.tsx`'s reference drop got a per-file `catch` + `continue`; `PanelModal`'s bulk panel drop got a whole-loop `try` with a partial commit — so a refused PUT on file 2 of 10 left files 3–10 **never attempted**, under one generic `Failed to upload image` naming no file and no count.

**Decision: both continue, and both report what actually happened.** Reasoning, since the audit asked for a deliberate one rather than an inherited shape:

- Continuing is what the code did **before** this PR's hook change — a 403 resolved and the loop carried on (with a dead key). Stopping would be a *new* behaviour introduced as a side effect of making failures visible, which is the wrong way round.
- Nine good uploads are worth keeping. The user can retry the one that failed; they cannot retry nine they were never told about.
- The two loops are the same shape and answer the same question, so they must not answer it differently. That is the "one rule, one place" argument this PR makes everywhere else.

The report is one aggregated notification rather than one per file (a bulk drop takes up to 20 files; N toasts bury the UI they report on), built by the shared `batchUploadFailureNotification` in **`src/utils/upload-batch.ts`** and used by both loops. It names how many of how many failed and lists each file with its own reason.

`PanelModal`'s loop moved into **`src/components/Comics/bulk-panel-upload.ts`** so it can be driven by a test — it could not have one while inline in a ~40-prop modal that pulls in the Buzz hooks, feature flags, a tRPC query, dnd-kit and `dialogStore`. The new browser suite drives it with real `File`s through the real `window.Image` decode.

## 7. The logged `url` was unbounded exactly where it was arbitrary caller text

`typeof image.url === 'string' ? image.url : null` ran on every call **including `not-applicable`** — by definition the urls that failed `isProbeableMediaKey`, i.e. the arbitrary-string population. The comment's justification ("a bare UUID … not PII") was true only of the branch that is *not* the risky one.

Now: the `url` is **omitted on a `not-applicable` verdict**, and length-bounded on the probed branch. The comment says which branch it is describing. See the honesty note in *Not covered* about the bound being unreachable today.

## 8. The fifth spinner predicate

`ImageUpload.tsx:227` still open-coded `(match && progress < 100) || image.file`. Round 1 gave it a different remedy — dropping the placeholder on error, which does prevent the latch and is what makes the tile disappear so the user can retry — and that remedy is **kept**. But leaving the predicate spelled a second way contradicted this PR's own argument, so it now calls `isUploadInFlight` as well. The `|| image.file` half stays: an entry queued for upload has no tracked file yet, so `match` is `undefined` and only that half can show its spinner.

## 9. Browser-test timing

`ProfileImageUpload.browser.test.tsx` waits for the spinner's **rising** edge inside the mocked PUT's in-flight window. At 150 ms that was ~3 polls of `vi.waitFor`'s 50 ms interval; a missed edge is a hard failure, not a retry, because the assertion can never become true afterwards. Widened to 500 ms. (It passed 5/5 under load at 150 ms — a note, not an observed flake.)

## Round 5 mutation checks

Each mutation was applied to the shipped code, the run watched to go red **with that guard's own message**, and the run narrowed to the owning file.

| # | mutation | tests that failed | message |
|---|---|---|---|
| D1 | ledger: **plant a prettier-wrapped `tx.image\n  .createManyAndReturn({ data: [] })`** in `post.service.ts` | *the set of Image-row writers outside `createImage` is exactly the ledger* — **and only that test** | `expected [ …(6) ] to deeply equal [ …(5) ]`, diff line `+ "src/server/services/post.service.ts"` — **1 failed, 12 passed** |
| D1-neg | *negative control, plant still in place* — run round 2's regex + line-prefix stripper over the same file | — | `false`. The previous spelling is **provably blind** to exactly this mutant |
| D1-inv | *inverse control* — plant only `const __note = 1; // historical: … tx.image.create({ data })` **and** a string literal naming the call | none | **13 passed.** Round 2's stripper + regex on the same file returns `true`, i.e. it would have **false-failed** the build |
| D2 | log: revert the `url` field to `typeof image.url === 'string' ? image.url : null` | *OMITS the url on a `not-applicable` verdict* — **and only that test** | `expected 'not-a-key/xxxxxxxxxxxx…' to be null` — **1 failed, 11 passed** |
| D2-pc | *positive control* — `url: null` unconditionally | *carries the media KEY when the probe actually ran* — **and only that test** | `expected { type: 'info', …(8) } to match object { verdict: 'absent', …(1) }` — **1 failed, 11 passed** |
| D3 | `ProfileImageUpload`: restore the unconditional `setImage(...)` on every status | *the failure is SURFACED…* and *a refused PUT leaves the EXISTING avatar on screen* | `expected <img alt="preview" …(2)></img> to be null`; `expected 'blob:new' to be 'https://cdn.example.com/existing-avat…'` — **2 failed, 4 passed** (browser) |
| D4 | `ProfileImageUpload`: delete `setImage(valuePreview(value))` from the failure branch (isolates the restore from D3's status guard) | *a refused PUT leaves the EXISTING avatar on screen* — **and only that test** | `expected undefined to be 'https://cdn.example.com/existing-avat…'` — **1 failed, 5 passed** (browser) |
| D5 | `batchUploadFailureNotification`: title → the old generic `'Failed to upload image'` | all three content assertions | `expected 'Failed to upload image' to be 'Failed to upload 1 of 10 files'` (and the 2-of-4 and 1-of-1 forms) — **3 failed, 1 passed** |
| D6 | `uploadBulkPanels`: `continue` → `break`, **keeping the catch and the report**, so only the continue decision is mutated | *the first file lands, the second is refused, and the THIRD is still attempted* — **and only that test** | `expected "vi.fn()" to be called 3 times, but got 2 times` — **1 failed, 3 passed** (browser) |
| D6-x | *wider variant* — remove the per-file `try`/`catch` entirely (the pre-fix whole-loop abort) | 2 of the 4 | dies on the escaping `Error: Upload failed (status 403)`. Recorded but **not** counted as the guard's own kill: it removes the reporting as well, so D6 above is the isolated one |
| D4-ledger | ledger: delete the `|| RAW_IMAGE_INSERT.test(source)` arm | *the raw-SQL arm sees `INSERT INTO "Image"`…* and *…is exactly the ledger* | `expected [ …(4) ] to include 'src/server/jobs/daily-challenge-proce…'`; diff line `- "src/server/jobs/daily-challenge-processing.ts"` — **2 failed, 11 passed** |

The three-file fixture in D6 is deliberate: with two files, "stops on failure" and "continues" are indistinguishable when the failure is last. Failing the **middle** one makes the difference observable — 2 upload calls versus 3.

🔴 **D2, D4 and D6 were additionally re-run `-t`-narrowed to their single owning test**, so a co-firing pin in the same file cannot be miscredited with the kill. Each failed **alone** under the mutant and passed **alone** once restored, with the same message:

| # | mutant, `-t` narrowed | restored, same `-t` |
|---|---|---|
| D2 | `1 failed \| 11 skipped (12)` — `expected 'not-a-key/xxxxxxxxxx…' to be null` | `1 passed \| 11 skipped (12)` |
| D4 | `1 failed \| 5 skipped (6)` — `expected undefined to be 'https://cdn.example.com/existing-avat…'` | `1 passed \| 5 skipped (6)` |
| D6 | `1 failed \| 3 skipped (4)` — `expected "vi.fn()" to be called 3 times, but got 2 times` | `1 passed \| 3 skipped (4)` |

## Round 6 — the invariant now lives where a test can reach it

The restored `landed`/`finally` invariant in `PanelModal` protected a **narrower window than its comment claimed**. `landed` is assigned only after `uploadBulkPanels` returns *as a whole*, so a throw **inside** the loop left it `[]` and the `finally` committed nothing — discarding every panel that had already uploaded, which is the exact failure the invariant exists to prevent. The comment said the panels are kept *"on every path"*, false on precisely that path, and it pointed the next contributor at the handler (*"when someone adds a line here"*) when the loop is where a new thrower would land.

The path is real, if unlikely: **`URL.createObjectURL` in `readDimensions` sits outside every `try` in that helper**, so a synchronous throw from it rejects the awaited promise and escaped the per-file `try`, which covered `uploadToCF` only.

**Fix:** the per-file `try` in `uploadBulkPanels` now spans the **whole loop body**. Anything raised while processing file N is recorded as that file's failure, the loop continues, and files 1..N−1 survive *by construction* rather than by re-deriving "no reachable thrower today". Both comments were rewritten to describe the two-part guarantee that now exists — the module owns throws inside the loop, the handler's `finally` owns a throw in the reporting step after it.

**And it is pinned.** The previous round's claim that this could not be cheaply tested (mounting `PanelModal` needs ~40 props plus Buzz hooks, flags, tRPC and dnd-kit) does not apply once the guarantee lives in the module: `bulk-panel-upload.browser.test.tsx` already drives it. New case — *"a throw from OUTSIDE the upload call keeps the panels that already landed"* — stubs `URL.createObjectURL` to throw for one file's **name**, so it goes through the real escape hatch rather than an invented one, and fails the **first** of three files so the case also pins that a wide `try` is not "swallow everything": b and c must still upload and a must still be reported.

**Mutation check.** Narrowing the `try` back to `uploadToCF` alone (`readDimensions`/`readMeta` hoisted back above it, `catch` unchanged) and re-running the same file:

| | result |
|---|---|
| at this tip | `Tests 5 passed (5)` |
| with the `try` narrowed | `Tests 1 failed \| 4 passed (5)` — **only the new case**, with its own message: `uploadBulkPanels must not throw on a mid-loop failure — the panels that already uploaded are discarded when it does. It threw: createObjectURL refused a.png` |

The other four stayed green, so the mutant is attributable to this guard and did not die to a neighbour's assertion. Narrowed with `-t 'a throw from OUTSIDE the upload call'` → `1 passed | 4 skipped (5)`.

Two comment corrections rode along, in a separate commit: `ProfileImageUpload`'s justification for the permissive `valuePreview` branch claimed a bare media key is *"the exact shape `onChange` emits"* — it is not (`onChange` emits an object; the sole consumer passes `profilePictureSchema.nullish()`, and no caller in the repo passes a string), so the sentence now gives the true reason; and `character.tsx`'s cost note now **names its baseline**, because measured against `main` (`ed0b0b04e3`, no `catch` at all) the change is a strict improvement, and only against `88d3ec9c12` — a commit inside this PR — is the deferred toast a regression.

## Verification at this tip

Counted from the runners' own per-test result lines, ANSI stripped, never from an exit code.

- `pnpm test:unit:run` — **1,521 files passed | 1 skipped (1,522); 23,821 tests passed, 0 failed, 26 skipped (23,847)**
- `pnpm test:component` — **196 files passed (196); 2,192 tests passed, 0 failed.** Requires the Playwright browser-revision symlink described under *Not covered*; without it the runner cannot launch Chromium and reports `Tests no tests`. 🔴 The **2,190** recorded here in an earlier round was one short of that tip: re-running this tip with only the new test reverted gives **2,191**, so the round's own delta is **+1**, not +2. The isolation run is also what shows the code change breaks nothing — all 2,191 passed with the widened `try` in place and the old test file
- `pnpm test:packages:run` — 1,155 passed, **8 failed** (3 files), all in `*.explain.test.ts` under `@civitai/db-queries` (`ECONNREFUSED 127.0.0.1:15432` — nothing listening locally). Environmental; identical on every branch. **Carried over from the previous round, not re-run at this tip** — the final round's diff is five files, all under `src/components` and `src/pages`, and touches nothing under `packages/`
- `pnpm test:apps:run` — 1,092 passed, **36 failed** (1 file), all in `apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts`, same cause and same figures. **Carried over, not re-run at this tip**, for the same reason — nothing under `apps/` changed
- `pnpm typecheck` — **`OK — 0 type errors in 104s` (heap cap 8192 MB)**, with a negative control: `const __tcControl: number = 'not a number'` in `src/components/Comics/bulk-panel-upload.ts` — a file the root tsconfig actually covers, unlike anything under `apps/` — made the same invocation print `bulk-panel-upload.ts(138,7): error TS2322` and `1 type error(s)`, so the clean arm is a real zero
- `prettier --list-different` over all 31 files this branch changes — **no output over 31 files checked**, with a positive control: appending mangled whitespace to `src/components/Comics/bulk-panel-upload.ts` and re-running the *same* invocation listed exactly that file, so the clean arm is a real zero and not a glob that matched nothing

### The CI rollup on this PR settles at 19, not 18

An earlier round recorded the rollup growing **12 → 13 → 18** and treated 18 as the count to poll for. That is one short. The terminal count is **19 — 18 `SUCCESS` + 1 `SKIPPED`** (`Typecheck (main pushes / fork PRs / non-main base)`, skipped by design on a same-repo PR against `main`), confirmed by three independent reads: `gh pr checks --json name,state,bucket` (19 rows), `gh pr view --json statusCheckRollup` (length 19), and the raw API, which shows *why* — the rollup is **12 check-runs + 7 commit statuses**, and the 7 (`tekton / *`, `preview / *`) are the half that lands late.

🔴 **A minimum pinned at 18 false-settles, and this tip demonstrated it rather than merely implying it.** Polling every ~25 s while `d56a1338bf` built, the rollup read **`count=18 busy=0`** for **five consecutive reads over ~1 m 45 s** (02:02:34 → 02:04:17) before the 19th registered at 02:04:43. Every check present was genuinely terminal the whole time, so *inverting the test* — the usual remedy — does not catch this on its own; only the count does, and only if the count is right.

The rest of the lesson is unchanged: a rollup **grows while you read it**, and a freshly-registered check has an **empty** conclusion, so it matches no busy keyword and a keyword-based poll reports `SETTLED` over checks that have not started. The guard needs all three of (a) every check holding a TERMINAL conclusion, empty included as busy, (b) a minimum count of **19**, and (c) stability across two consecutive reads. Or wait on the named late checks (`preview / smoke-tests` was last here).

## Merge order relative to #4475

The two PRs are asymmetric around `packages/civitai-shared`, and that asymmetry decides the order:

| | #4474 (this) | #4475 |
|---|---|---|
| `src/media-key.ts` | added | added — **byte-identical** (`git diff` between the two heads over that path is empty) |
| `package.json` `"./media-key"` export | added | added — the **same line** |
| `package.json` `scripts.test` + `devDependencies.vitest` | — | added |
| `vitest.config.ts` for the package | — | added |
| `src/__tests__/media-key.test.ts` | — | added |
| `src/index.ts` re-export | — | adds `export * from './missing-media'` (not `media-key`; that module is reached through its own `./media-key` export entry) |

The root `vitest.config.mts` globs its package projects on **`packages/*/vitest.config.ts`**, deliberately — a bare `packages/*` glob would adopt packages that have no config. `packages/civitai-shared` has no such file on `main`, and **#4474 does not add one**. So if this PR lands first, `media-key.ts` ships into `packages/civitai-shared` with **no test runner attached to that package at all** until #4475 follows; `pnpm test:packages:run` will not select it, and nothing in CI executes its tests. That is the same failure shape as #3591's schema-drift detector shipping with 81 tests CI never ran.

**Recommendation: merge #4475 first**, then this one. Landing #4474 first is not broken, only untested-in-CI for the interval between the two merges.

The `packages/civitai-shared/package.json` auto-merge is coherent either way: both branches add the identical `"./media-key": "./src/media-key.ts"` line, and a merge of the two heads reports `Auto-merging packages/civitai-shared/package.json` with the key appearing **once** in the result, not duplicated.

🔴 **They do conflict elsewhere, though — "no conflict" is true only of `civitai-shared`.** `git merge-tree --write-tree` between the two heads exits **non-zero** (branch on the exit code, never on a marker grep — the two-arg form prints a tree OID on success and no `<<<<<<<`), with content conflicts in **`src/server/services/image.service.ts`** and **`src/server/flipt/__tests__/flipt-eval-context.test.ts`**. `gh pr view 4474 --json mergeable` still reports `MERGEABLE` because that is a claim about **this branch against `main`**, which is the state today; it says nothing about the tree the *second* merge creates. So whichever lands second needs a rebase onto the updated `main` and a hand resolution in those two files, and the full suite must be run on the **merged** tree, not on the branch alone.
