### PR TITLE
fix(moderation): refuse to publish an image whose media file is missing

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -166,3 +166,26 @@ describe('spoke resolveIngestionError — missing-media guard', () => {
     expect(headObject).not.toHaveBeenCalled();
   });
 });
+
+describe('spoke resolveIngestionError — a non-key Image.url is never a missing object', () => {
+  /**
+   * The mirror of the main app's case, and it exists because the round-1 mutation sweep found this
+   * side UNCOVERED: dropping the spoke's short-circuit left every test green. Both runtimes share
+   * one rule, so both need a case proving they actually apply it — otherwise "shared" is a claim
+   * about the module rather than about the call sites.
+   *
+   * The store is armed to answer `absent`, so if the probe ran at all the publish would be refused.
+   */
+  it.each([
+    ['an external avatar CDN url', 'https://cdn.discordapp.com/avatars/123/abc.png'],
+    ['a legacy blob: handle', 'blob:https://civitai.com/9f8e-1234'],
+  ])('publishes without consulting the store for %s', async (_label, url) => {
+    imageRow = { postId: null, metadata: {}, url };
+    headObject.mockResolvedValue({ exists: false });
+
+    await resolve();
+
+    expect(headObject).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(1);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MISSING_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
+import {
+  MISSING_MEDIA_PUBLISH_MESSAGE,
+  UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
+} from '@civitai/shared';
 
 /**
  * The write-side guard in the spoke's `resolveIngestionError` — the call site that caused the
@@ -94,7 +97,11 @@ const published = () =>
 const resolve = () => resolveIngestionError({ id: 4242, nsfwLevel: 1, userId: 7 });
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // 🔴 reset, not clear. `clearAllMocks` clears CALLS but leaves IMPLEMENTATIONS installed, so a
+  // `mockResolvedValue`/`mockRejectedValue` from an earlier case leaks into every later one — and a
+  // case that then forgets to arm the store passes for the wrong reason, or a broken short-circuit
+  // is hidden by a leaked `{ exists: true }`.
+  vi.resetAllMocks();
   updates.length = 0;
   // postId is null so the post-level recompute (raw SQL against the real client) stays out of the
   // way; it is not what these cases are about.
@@ -191,7 +198,8 @@ describe('spoke resolveIngestionError — a non-key Image.url is never a missing
    */
   it.each([
     ['an external avatar CDN url', 'https://cdn.discordapp.com/avatars/123/abc.png'],
-    ['a legacy blob: handle', 'blob:https://civitai.com/9f8e-1234'],
+    ['a bare filename the comics router can write', 'some-file.png'],
+    ['a prefixed key shape no upload endpoint issues', 'foo/0f8fad5b-d9cb-469f-a165-70867728950e'],
   ])('publishes without consulting the store for %s', async (_label, url) => {
     imageRow = { postId: null, metadata: {}, url };
     headObject.mockResolvedValue({ exists: false });
@@ -200,6 +208,26 @@ describe('spoke resolveIngestionError — a non-key Image.url is never a missing
 
     expect(headObject).not.toHaveBeenCalled();
     expect(updates).toHaveLength(1);
+  });
+
+  it('REFUSES a legacy blob: handle, without consulting the store', async () => {
+    /**
+     * 🔴 This case used to assert the opposite, on the stated grounds that a `blob:` row "renders
+     * perfectly well". It does not. `getEdgeUrl` here and in the main app both return the value
+     * VERBATIM for a `blob` prefix, so publishing one emits `<img src="blob:...">` into a browser
+     * that never created the handle — a permanently broken image, which is the harm this guard
+     * exists to prevent.
+     *
+     * The store is armed PRESENT, so the refusal demonstrably comes from the url, not the bucket.
+     */
+    imageRow = { postId: null, metadata: {}, url: 'blob:https://civitai.com/9f8e-1234' };
+    headObject.mockResolvedValue({ exists: true });
+
+    await expect(resolve()).rejects.toThrow(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE);
+
+    expect(headObject).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+    expect(recordModActivity).not.toHaveBeenCalled();
   });
 });
 
@@ -233,6 +261,31 @@ describe('spoke resolveIngestionError — which collaborators the guard reaches'
 
       expect(warn).toHaveBeenCalledTimes(1);
       expect(warn.mock.calls[0][0]).toContain('refused publish');
+      // Carries WHICH refusal. A bucket can produce `absent` and can never produce `unrenderable`,
+      // so a fail-CLOSED misconfiguration is only legible if the two are counted apart.
+      expect(warn.mock.calls[0]).toContain('absent');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('bounds the probe error it logs, so a remote response body cannot flood the log', async () => {
+    /**
+     * A `StorageClientError` embeds the remote response BODY in its message verbatim — unbounded
+     * third-party text (an HTML error page, an XML fault) written to stdout and therefore Loki once
+     * per inconclusive probe. The guard logs a bounded summary instead of the error.
+     */
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      headObject.mockRejectedValue(new Error(`storage request failed (503) ${'x'.repeat(10_000)}`));
+
+      await resolve();
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      const logged = warn.mock.calls[0].map(String).join(' ');
+      expect(logged.length).toBeLessThan(500);
+      expect(logged).toContain('storage request failed (503)');
+      expect(logged).toContain('[truncated]');
     } finally {
       warn.mockRestore();
     }

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -65,7 +65,12 @@ vi.mock('../db', () => ({
   },
 }));
 
-vi.mock('../storage', () => ({ getStorage: () => ({ headObject }) }));
+// Both factories: the probe deliberately uses a SEPARATE, tightly-bounded client, and mocking only
+// `getStorage` would leave the real one in place and fail at import.
+vi.mock('../storage', () => ({
+  getStorage: () => ({ headObject }),
+  getMediaProbeStorage: () => ({ headObject }),
+}));
 vi.mock('../mod-activity', () => ({ recordModActivity }));
 vi.mock('../search-index', () => ({ syncSearchIndex }));
 vi.mock('../cache', () => ({ bustCachedObject }));

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  MISSING_MEDIA_PUBLISH_MESSAGE,
-  UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
-} from '@civitai/shared';
+import { MISSING_MEDIA_PUBLISH_MESSAGE, UNRENDERABLE_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
 
 /**
  * The write-side guard in the spoke's `resolveIngestionError` — the call site that caused the

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -155,14 +155,17 @@ describe('spoke resolveIngestionError — missing-media guard', () => {
     // throw from the storage client; rejecting on any of them would let a verification step block
     // legitimate moderation on the queue whose job is unblocking content.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    headObject.mockRejectedValue(new Error('storage request failed (503)'));
+    try {
+      headObject.mockRejectedValue(new Error('storage request failed (503)'));
 
-    await resolve();
+      await resolve();
 
-    expect(updates).toHaveLength(1);
-    expect(published()).toMatchObject({ ingestion: 'Scanned', nsfwLevelLocked: true });
-    expect(warn).toHaveBeenCalledTimes(1);
-    warn.mockRestore();
+      expect(updates).toHaveLength(1);
+      expect(published()).toMatchObject({ ingestion: 'Scanned', nsfwLevelLocked: true });
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('still refuses before the probe when there is no such image', async () => {
@@ -211,20 +214,27 @@ describe('spoke resolveIngestionError — which collaborators the guard reaches'
 
     await resolve();
 
-    expect(headObject).toHaveBeenCalledTimes(1);
+    // The distinguishing assertion FIRST: three other tests already assert `headObject` was called,
+    // so leading with that made this one die to a shared assertion and name the wrong regression.
     expect(unboundedHeadObject).not.toHaveBeenCalled();
+    expect(headObject).toHaveBeenCalledTimes(1);
   });
 
   it('reports a refusal, so a fail-CLOSED misconfiguration cannot look like a clean run', async () => {
     // A wrong bucket name 404s for EVERY key, which reads as `absent` for every image. Without this
     // wiring the guard would refuse every publish and emit nothing to say so.
+    // try/finally: this config sets no `restoreMocks`, so a failing assertion would otherwise leave
+    // `console.warn` stubbed for the rest of the worker.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    headObject.mockResolvedValue({ exists: false });
+    try {
+      headObject.mockResolvedValue({ exists: false });
 
-    await expect(resolve()).rejects.toThrow(MISSING_MEDIA_PUBLISH_MESSAGE);
+      await expect(resolve()).rejects.toThrow(MISSING_MEDIA_PUBLISH_MESSAGE);
 
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toContain('refused publish');
-    warn.mockRestore();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('refused publish');
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -65,10 +65,20 @@ vi.mock('../db', () => ({
   },
 }));
 
-// Both factories: the probe deliberately uses a SEPARATE, tightly-bounded client, and mocking only
-// `getStorage` would leave the real one in place and fail at import.
+/**
+ * 🔴 The two factories return DISTINCT spies on purpose.
+ *
+ * Returning the same `headObject` for both made them indistinguishable by construction: swapping
+ * the probe back to the unbounded `getStorage()` client — reverting the whole 5 s / no-retry budget
+ * — passed every test. A mock that cannot tell two collaborators apart cannot pin which one is
+ * used, so the assertion below is the only thing holding the bound in place.
+ *
+ * (Mocking only `getStorage` would not fail at import — vitest replaces the module wholesale, so a
+ * missing export surfaces when the binding is ACCESSED, i.e. inside the probe.)
+ */
+const unboundedHeadObject = vi.fn();
 vi.mock('../storage', () => ({
-  getStorage: () => ({ headObject }),
+  getStorage: () => ({ headObject: unboundedHeadObject }),
   getMediaProbeStorage: () => ({ headObject }),
 }));
 vi.mock('../mod-activity', () => ({ recordModActivity }));
@@ -187,5 +197,34 @@ describe('spoke resolveIngestionError — a non-key Image.url is never a missing
 
     expect(headObject).not.toHaveBeenCalled();
     expect(updates).toHaveLength(1);
+  });
+});
+
+describe('spoke resolveIngestionError — which collaborators the guard reaches', () => {
+  it('probes through the BOUNDED client, never the general-purpose one', async () => {
+    /**
+     * The default client is 10 s x 3 attempts plus backoff — ~31 s on a moderator's click, for an
+     * answer that allows either way when it cannot be had. The probe therefore uses a separate 5 s
+     * / no-retry client, and this is what stops that from being silently reverted.
+     */
+    headObject.mockResolvedValue({ exists: true });
+
+    await resolve();
+
+    expect(headObject).toHaveBeenCalledTimes(1);
+    expect(unboundedHeadObject).not.toHaveBeenCalled();
+  });
+
+  it('reports a refusal, so a fail-CLOSED misconfiguration cannot look like a clean run', async () => {
+    // A wrong bucket name 404s for EVERY key, which reads as `absent` for every image. Without this
+    // wiring the guard would refuse every publish and emit nothing to say so.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    headObject.mockResolvedValue({ exists: false });
+
+    await expect(resolve()).rejects.toThrow(MISSING_MEDIA_PUBLISH_MESSAGE);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('refused publish');
+    warn.mockRestore();
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -207,6 +207,54 @@ describe('spoke resolveIngestionError — a non-key Image.url is never a missing
     expect(updates).toHaveLength(1);
   });
 
+  it('COUNTS the short-circuit at this call site, rather than passing silently', async () => {
+    /**
+     * 🔴 The shared module declares `onSkipped` and its own docstring says "silent fail-open is how
+     * a guard lies for months, so the caller is expected to log here" — and neither production call
+     * site passed one. That is worse than the hook not existing, because the module reads as though
+     * the branch is observable.
+     *
+     * It matters most on THIS branch. `isProbeableMediaKey` is an acknowledged UNDER-approximation
+     * (it matches only the bare-uuid shape our upload endpoints mint, while several write paths
+     * accept a caller-supplied string), so it is KNOWN to decline real keys. Without a line here, a
+     * deployment in which it declines EVERY row emits nothing at all and is byte-identical to one
+     * where the guard did its job — there is no counter anywhere that could show it.
+     *
+     * Pinned at the CALL SITE, not in the module: the module's own suite already covered the hook,
+     * and the defect was precisely that coverage and use had come apart.
+     */
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      imageRow = { postId: null, metadata: {}, url: 'https://cdn.discordapp.com/avatars/1/a.png' };
+      headObject.mockResolvedValue({ exists: false });
+
+      await resolve();
+
+      expect(updates).toHaveLength(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('not probeable');
+      // The image id, so the count is attributable rather than an anonymous tally.
+      expect(warn.mock.calls[0]).toContain(4242);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does NOT count a probe that actually ran as a skip', async () => {
+    // The discriminating half: if `onSkipped` were wired to fire unconditionally, or `onUnknown`
+    // and `onSkipped` were folded back together, the number this channel exists to produce would
+    // include every ordinary publish and answer nothing.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      headObject.mockResolvedValue({ exists: true });
+      await resolve();
+      expect(headObject).toHaveBeenCalledTimes(1);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('REFUSES a legacy blob: handle, without consulting the store', async () => {
     /**
      * 🔴 This case used to assert the opposite, on the stated grounds that a `blob:` row "renders

--- a/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-missing-media-guard.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MISSING_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
+
+/**
+ * The write-side guard in the spoke's `resolveIngestionError` — the call site that caused the
+ * incident. Publishing an image is exactly what this function does (`ingestion = 'Scanned'` plus a
+ * locked nsfwLevel), and it used to do it without ever asking whether the media exists.
+ *
+ * Every case here drives the REAL shared verdict; only the storage probe and the database are
+ * stood in for. The three storage answers are covered separately because the fail-open one
+ * (`unknown`) is the easy one to get backwards, and getting it backwards turns a storage blip into
+ * a moderation outage rather than a missed 404.
+ */
+
+type Call = [string, unknown[]];
+
+const updates: Call[][] = [];
+const headObject = vi.fn();
+const recordModActivity = vi.fn();
+const syncSearchIndex = vi.fn();
+const bustCachedObject = vi.fn();
+
+/** `undefined` reproduces "no such image", so the earlier not-found check owns that case. */
+let imageRow: { postId: number | null; metadata: unknown; url: string } | undefined;
+
+function chain(record: (calls: Call[]) => void, resolve: (calls: Call[]) => unknown) {
+  const calls: Call[] = [];
+  const builder: Record<string, unknown> = {};
+  for (const method of ['select', 'set', 'where', 'returning']) {
+    builder[method] = (...args: unknown[]) => {
+      calls.push([method, args]);
+      return builder;
+    };
+  }
+  builder.executeTakeFirst = async () => {
+    record(calls);
+    return resolve(calls);
+  };
+  builder.execute = async () => {
+    record(calls);
+    return resolve(calls);
+  };
+  return builder;
+}
+
+vi.mock('../db', () => ({
+  dbRead: {},
+  dbWrite: {
+    selectFrom: (table: string) =>
+      chain(
+        () => undefined,
+        () => {
+          expect(table).toBe('Image');
+          return imageRow;
+        }
+      ),
+    updateTable: (table: string) =>
+      chain(
+        (calls) => {
+          expect(table).toBe('Image');
+          updates.push(calls);
+        },
+        () => []
+      ),
+  },
+}));
+
+vi.mock('../storage', () => ({ getStorage: () => ({ headObject }) }));
+vi.mock('../mod-activity', () => ({ recordModActivity }));
+vi.mock('../search-index', () => ({ syncSearchIndex }));
+vi.mock('../cache', () => ({ bustCachedObject }));
+
+const { resolveIngestionError } = await import('../ingestion.service');
+
+/** The `set()` payload of the publishing UPDATE, or undefined when no UPDATE was issued. */
+const published = () =>
+  updates[0]?.find(([m]) => m === 'set')?.[1][0] as Record<string, unknown> | undefined;
+
+const resolve = () => resolveIngestionError({ id: 4242, nsfwLevel: 1, userId: 7 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updates.length = 0;
+  // postId is null so the post-level recompute (raw SQL against the real client) stays out of the
+  // way; it is not what these cases are about.
+  imageRow = {
+    postId: null,
+    metadata: { foo: 'bar' },
+    url: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  };
+});
+
+describe('spoke resolveIngestionError — missing-media guard', () => {
+  it('REFUSES to publish when the store answered that the object is absent', async () => {
+    headObject.mockResolvedValue({ exists: false });
+
+    await expect(resolve()).rejects.toThrow(MISSING_MEDIA_PUBLISH_MESSAGE);
+
+    // The whole point: nothing was written. Before this guard the UPDATE below ran unconditionally.
+    expect(updates).toHaveLength(0);
+    expect(recordModActivity).not.toHaveBeenCalled();
+    expect(syncSearchIndex).not.toHaveBeenCalled();
+    expect(bustCachedObject).not.toHaveBeenCalled();
+  });
+
+  it('probes the image row url against the media backend every image lives in', async () => {
+    headObject.mockResolvedValue({ exists: true });
+    await resolve();
+    expect(headObject).toHaveBeenCalledTimes(1);
+    expect(headObject).toHaveBeenCalledWith({
+      backend: 'b2Image',
+      key: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    });
+  });
+
+  it('publishes exactly as before when the store confirms the object is present', async () => {
+    headObject.mockResolvedValue({ exists: true });
+
+    await resolve();
+
+    expect(updates).toHaveLength(1);
+    // Literal expectations, not derived from the implementation.
+    expect(published()).toMatchObject({
+      nsfwLevel: 1,
+      nsfwLevelLocked: true,
+      ingestion: 'Scanned',
+    });
+    expect(recordModActivity).toHaveBeenCalledWith({
+      userId: 7,
+      entityType: 'image',
+      entityId: 4242,
+      activity: 'setNsfwLevel',
+    });
+    expect(syncSearchIndex).toHaveBeenCalledTimes(1);
+    expect(bustCachedObject).toHaveBeenCalledTimes(2);
+  });
+
+  it('publishes and logs when the probe THREW — inability to consult is not evidence of loss', async () => {
+    // The fail-open half. A rotated credential, a 5xx, or an unset endpoint all surface here as a
+    // throw from the storage client; rejecting on any of them would let a verification step block
+    // legitimate moderation on the queue whose job is unblocking content.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    headObject.mockRejectedValue(new Error('storage request failed (503)'));
+
+    await resolve();
+
+    expect(updates).toHaveLength(1);
+    expect(published()).toMatchObject({ ingestion: 'Scanned', nsfwLevelLocked: true });
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('still refuses before the probe when there is no such image', async () => {
+    // Reachability control for the case above: the not-found check runs FIRST, so a fixture with no
+    // row never reaches the guard. Any test that forgets to supply a row is testing that check, not
+    // this one.
+    imageRow = undefined;
+    headObject.mockResolvedValue({ exists: false });
+
+    await expect(resolve()).rejects.toThrow('Image not found');
+    expect(headObject).not.toHaveBeenCalled();
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -128,14 +128,23 @@ describe('ingestion-error queue predicates', () => {
     expect(missing.parameters).toEqual(['permanent', 'blob:%']);
   });
 
-  it('keeps Image.url NOT NULL, which is what actually makes the url half a partition', () => {
+  it('keeps Image.url NOT NULL in the DECLARED schema, which is what the query assumes', () => {
     /**
-     * 🔴 THE REAL INVARIANT, PINNED AT ITS SOURCE — and it is NOT the COALESCE below.
+     * 🔴 THE INVARIANT, PINNED AT THE ONLY SOURCE THIS TEST CAN READ — and it is NOT the COALESCE
+     * below.
      *
      * The story this suite used to tell was that `COALESCE(i.url, '')` was load-bearing against a
-     * NULL url. It is not: `Image.url` is NOT NULL, so the row it defends against cannot exist and
-     * removing the COALESCE changes no result. What keeps the url half of the split a partition is
-     * the column constraint, so the constraint is what gets a guard.
+     * NULL url. It is not: `Image.url` is declared NOT NULL, so the row it defends against cannot
+     * exist and removing the COALESCE changes no result. What keeps the url half of the split a
+     * partition is the column constraint, so the constraint is what gets a guard.
+     *
+     * 🔴 BE EXACT ABOUT WHAT IS CHECKED: `schema.full.prisma` and the generated Kysely types are
+     * the DECLARED schema, not the database. Migrations in this org are applied BY HAND per
+     * environment — `_prisma_migrations` is not the source of truth — so a database whose column
+     * has drifted from the declaration satisfies this guard while the invariant it names is false
+     * of the live table. This is a declaration guard: it catches the change landing in the repo,
+     * which is where the change is made, and it cannot catch drift. That is exactly why the
+     * COALESCE is retained below rather than simplified away.
      *
      * Read from BOTH the defining schema and the generated Kysely types, which fail differently: a
      * hand-edit to one without regenerating the other is caught, and so is a regeneration that

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -1,4 +1,23 @@
 import { describe, expect, it, vi } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * The monorepo root, found by walking up for the workspace manifest rather than counting `../`
+ * segments. A fixed depth silently changes meaning the moment this file moves, and the failure
+ * would be an unreadable ENOENT rather than "the guard moved".
+ */
+const repoRoot = (() => {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('ingestion-queue-partition.test: could not locate the workspace root');
+})();
 
 /**
  * The ingestion-error page's SQL, compiled for real.
@@ -109,13 +128,54 @@ describe('ingestion-error queue predicates', () => {
     expect(missing.parameters).toEqual(['permanent', 'blob:%']);
   });
 
-  it('is NULL-safe on the url half too, so the split stays a partition', async () => {
+  it('keeps Image.url NOT NULL, which is what actually makes the url half a partition', () => {
     /**
-     * 🔴 The `IS NOT DISTINCT FROM` trap one operator over. `NULL LIKE 'blob:%'` is NULL, so on a
-     * row with a NULL url and a non-permanent class the disjunction is NULL — which a WHERE treats
-     * as false on BOTH sides, dropping the row out of the review queue and the missing-media queue
-     * simultaneously. That is a hole in something the suite above asserts is an exact partition, and
-     * it is invisible in the emitted SQL unless you look for the COALESCE.
+     * 🔴 THE REAL INVARIANT, PINNED AT ITS SOURCE — and it is NOT the COALESCE below.
+     *
+     * The story this suite used to tell was that `COALESCE(i.url, '')` was load-bearing against a
+     * NULL url. It is not: `Image.url` is NOT NULL, so the row it defends against cannot exist and
+     * removing the COALESCE changes no result. What keeps the url half of the split a partition is
+     * the column constraint, so the constraint is what gets a guard.
+     *
+     * Read from BOTH the defining schema and the generated Kysely types, which fail differently: a
+     * hand-edit to one without regenerating the other is caught, and so is a regeneration that
+     * drops the guard's own subject. `url String?` in Prisma / `url: string | null` in Kysely are
+     * the two spellings that would make this queue silently non-exhaustive.
+     */
+    const prisma = readFileSync(
+      path.join(repoRoot, 'packages/civitai-db-schema/prisma/schema.full.prisma'),
+      'utf8'
+    );
+    const imageModel = /\nmodel Image \{\n([\s\S]*?)\n\}/.exec(prisma)?.[1];
+    // Positive control on the extraction: a regex that stopped matching would make every assertion
+    // below vacuous, and `?.[1]` would hand `undefined` to a `toMatch` that never runs.
+    expect(imageModel, 'the Image model must be locatable in schema.full.prisma').toBeTruthy();
+    expect(imageModel).toMatch(/^\s{2}url\s+String\s*$/m);
+    expect(imageModel, 'Image.url must not become nullable').not.toMatch(/^\s{2}url\s+String\?/m);
+
+    const kysely = readFileSync(
+      path.join(repoRoot, 'packages/civitai-db-schema/src/kysely/types.ts'),
+      'utf8'
+    );
+    const imageType = /\nexport type Image = \{\n([\s\S]*?)\n\};/.exec(kysely)?.[1];
+    expect(
+      imageType,
+      'the Image table type must be locatable in the generated kysely types'
+    ).toBeTruthy();
+    expect(imageType).toMatch(/^\s{2}url: string;$/m);
+  });
+
+  it('still COALESCEs the url, as defence in depth if that constraint ever goes', async () => {
+    /**
+     * 🔴 AN INVARIANT GUARD, NOT A REGRESSION TEST — labelled as one because the previous version
+     * of this case was presented as the reason the split stays a partition, and it is not (see the
+     * case above). The bug it describes has never been reachable.
+     *
+     * What it pins is a spelling, deliberately: were `Image.url` ever made nullable, `NULL LIKE
+     * 'blob:%'` is NULL, so on a row with a non-permanent class the disjunction is NULL — which a
+     * WHERE treats as false on BOTH sides, dropping the row out of the review queue and the
+     * missing-media queue simultaneously. Silent, and invisible in the emitted SQL unless you look
+     * for the COALESCE. Cheap to keep; do not re-promote it to load-bearing.
      */
     const errors = await run(() => countIngestionErrorImages());
     expect(errors.sql).toContain("COALESCE(i.url, '') LIKE");
@@ -177,6 +237,50 @@ describe('ingestion-error queue predicates', () => {
     // Exhaustive and exclusive in one line: `missing` must be the same base plus exactly the
     // predicate `errors` negates — no extra clause on either side, no clause missing from either.
     expect(missing).toBe(`${base} AND ${splitPredicate}`);
+
+    /**
+     * 🔴 THE SPLIT PREDICATE MUST BE PARENTHESISED, AND THIS IS THE ONLY PLACE THAT SAYS SO.
+     *
+     * Dropping the parens around `unpublishableMedia` is a one-character edit whose effect is
+     * enormous: `NOT (a OR b)` becomes `(NOT a) OR b`, i.e. the review queue would take EVERY
+     * `blob:` row — at any age within the window and whatever its scan class — instead of routing
+     * it to the delete-only view, which is exactly the harm this branch exists to remove.
+     *
+     * Measured before this assertion existed: that mutant SURVIVED a run narrowed to this test and
+     * died only on the whole-statement pins above — the same pins whose own comments invite an
+     * author to rewrite them on a deliberate predicate change. A structural test that cannot see a
+     * precedence bug is not covering the structure.
+     *
+     * `AND` binds tighter than `OR` in SQL, so the requirement is precise: the negated predicate
+     * must be a single parenthesised group, and the disjunction must live INSIDE it. Asserted on
+     * shape rather than on the exact statement so it survives an edit to the disjuncts themselves.
+     */
+    expect(
+      splitPredicate.startsWith('('),
+      `split predicate must open a group: ${splitPredicate}`
+    ).toBe(true);
+    expect(
+      splitPredicate.endsWith(')'),
+      `split predicate must close a group: ${splitPredicate}`
+    ).toBe(true);
+    // ...and the group is the WHOLE predicate, not the first of several. Walking the depth rather
+    // than trusting the two ends catches `(a OR b) OR c`, where both ends are still parens.
+    let depth = 0;
+    let closedEarly = false;
+    for (let i = 0; i < splitPredicate.length; i++) {
+      if (splitPredicate[i] === '(') depth++;
+      else if (splitPredicate[i] === ')') {
+        depth--;
+        if (depth === 0 && i < splitPredicate.length - 1) closedEarly = true;
+      }
+    }
+    expect(depth, 'parentheses in the split predicate must balance').toBe(0);
+    expect(closedEarly, `the negated group must span the WHOLE predicate: ${splitPredicate}`).toBe(
+      false
+    );
+    // The OR is inside that group. Without the parens it would sit at the top level of the WHERE,
+    // which is the mutant.
+    expect(splitPredicate).toMatch(/\bOR\b/);
   });
 
   it('gives the ingestion-error badge the same predicate as its queue', async () => {
@@ -306,8 +410,17 @@ describe("the delete gate's own predicate", () => {
     // string and the equality below would pass vacuously.
     expect(gateState.length).toBeGreaterThanOrEqual(3);
     expect(queueState.length).toBeGreaterThanOrEqual(3);
-    // ...and the window really was the only thing subtracted from the queue side.
-    expect(clauses(queue).length - queueState.length).toBe(2);
+    // 🔴 BOTH subtractions are counted, not just the queue's. Checking only one side leaves the
+    // other filter free to drop an arbitrary number of clauses and still reach equality — e.g. a
+    // gate clause that happened to start `i.id =` would vanish silently. The two deliberate
+    // differences are exactly: two window bounds on the queue side, one id binding on the gate side.
+    expect(
+      clauses(queue).length - queueState.length,
+      'the queue drops exactly its two window bounds'
+    ).toBe(2);
+    expect(clauses(gate).length - gateState.length, 'the gate drops exactly its id binding').toBe(
+      1
+    );
 
     // 🔴 Bidirectional. `toEqual` on sorted arrays fails when either side gains OR loses a clause.
     expect([...gateState].sort()).toEqual([...queueState].sort());

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -37,6 +37,7 @@ const {
   countIngestionErrorImages,
   getMissingMediaImages,
   countMissingMediaImages,
+  isMissingMediaImage,
 } = await import('../ingestion.service');
 
 const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
@@ -146,5 +147,57 @@ describe('ingestion-error queue predicates', () => {
     const { sql, parameters } = await run(() => getMissingMediaImages({ limit: 25, cursor: 999 }));
     expect(sql).toContain('AND (i.id < $2)');
     expect(parameters).toEqual(['permanent', 999, 26]);
+  });
+});
+
+describe("the delete gate's own predicate", () => {
+  /**
+   * 🔴 This query gates a PERMANENT, CASCADING delete, and it was the one query in this module the
+   * harness did not compile. A mutation sweep found `WHERE ${missingMediaScope}` could be replaced
+   * with `WHERE TRUE` — restoring the arbitrary delete-any-image-by-id endpoint the guard exists to
+   * prevent — with the whole suite still green, because its only test mocked the function wholesale
+   * and therefore pinned the call site rather than the predicate.
+   */
+  it('scopes the delete to a permanently-failed, unpublished ingestion error', async () => {
+    const { sql, parameters } = await run(() => isMissingMediaImage(4242));
+
+    expect(sql).toBe(
+      'SELECT i.id FROM "Image" i WHERE i.ingestion = \'Error\'::"ImageIngestionStatus" ' +
+        'AND i."nsfwLevel" = 0 ' +
+        "AND i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 " +
+        'AND i.id = $2 LIMIT 1'
+    );
+    expect(parameters).toEqual(['permanent', 4242]);
+  });
+
+  it('is always bound to the requested id — never an unscoped match', async () => {
+    // The specific mutant: dropping the state predicates, or the id, makes this a delete-anything
+    // endpoint. Asserted separately from the pin above so it stays reachable if the pin is edited.
+    const { sql } = await run(() => isMissingMediaImage(4242));
+    expect(sql).toContain('AND i.id = $2');
+    expect(sql).not.toMatch(/WHERE\s+TRUE/i);
+  });
+
+  it('deliberately omits the 2-day display window the queue applies', async () => {
+    /**
+     * Safety is about the image's STATE, which does not expire; the window is a display concern.
+     * Conflating them made the gate a race: a row ageing out between page load and click was
+     * refused for an image visibly on screen, and was then permanently uncleanable — it had left
+     * the only view offering a delete while still sitting at `ingestion = 'Error'`.
+     */
+    const gate = (await run(() => isMissingMediaImage(4242))).sql;
+    expect(gate).not.toContain('createdAt');
+
+    // ...while the queue itself still applies it, or the page would grow without bound.
+    const queue = (await run(() => countMissingMediaImages())).sql;
+    expect(queue).toContain('i."createdAt" > now() - INTERVAL \'2 days\'');
+  });
+
+  it('shares the failure-class predicate with the queue, so the two cannot disagree', async () => {
+    const gate = (await run(() => isMissingMediaImage(4242))).sql;
+    const queue = (await run(() => countMissingMediaImages())).sql;
+    const clause = "i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1";
+    expect(gate).toContain(clause);
+    expect(queue).toContain(clause);
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -11,25 +11,38 @@ import { describe, expect, it, vi } from 'vitest';
  * A hand-rolled fake cannot see any of that — only the emitted SQL can. So `dbRead` here is real
  * Kysely on a driver that never connects, and every assertion reads the statement it produced.
  */
-const captured = vi.hoisted(() => [] as { sql: string; parameters: readonly unknown[] }[]);
+const captured = vi.hoisted(
+  () => [] as { sql: string; parameters: readonly unknown[]; client: 'read' | 'write' }[]
+);
 
 // Built inside the factory, not in `vi.hoisted`: hoisted blocks run before this file's own imports,
 // so constructing Kysely there reads it before initialisation.
+/**
+ * 🔴 `dbRead` and `dbWrite` are DISTINCT instances that tag what they compiled.
+ *
+ * Aliasing them to one object — which this harness used to do — makes them indistinguishable by
+ * construction, so nothing can pin WHICH client a query runs on. That matters because
+ * `imageRowExists` is a read-your-write: on the replica, lag past the delete's own round trip makes
+ * a successful delete read as "still present", producing a false failure and no audit row for a
+ * delete that did happen. A single shared instance cannot see that regression.
+ */
 vi.mock('$lib/server/db', async () => {
   const { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } =
     await import('kysely');
-  const db = new Kysely<never>({
-    dialect: {
-      createAdapter: () => new PostgresAdapter(),
-      createDriver: () => new DummyDriver(),
-      createIntrospector: (i) => new PostgresIntrospector(i),
-      createQueryCompiler: () => new PostgresQueryCompiler(),
-    },
-    log: (e) => {
-      if (e.level === 'query') captured.push({ sql: e.query.sql, parameters: e.query.parameters });
-    },
-  });
-  return { dbRead: db, dbWrite: db };
+  const make = (client: 'read' | 'write') =>
+    new Kysely<never>({
+      dialect: {
+        createAdapter: () => new PostgresAdapter(),
+        createDriver: () => new DummyDriver(),
+        createIntrospector: (i) => new PostgresIntrospector(i),
+        createQueryCompiler: () => new PostgresQueryCompiler(),
+      },
+      log: (e) => {
+        if (e.level === 'query')
+          captured.push({ sql: e.query.sql, parameters: e.query.parameters, client });
+      },
+    });
+  return { dbRead: make('read'), dbWrite: make('write') };
 });
 
 const {
@@ -38,6 +51,7 @@ const {
   getMissingMediaImages,
   countMissingMediaImages,
   isMissingMediaImage,
+  imageRowExists,
 } = await import('../ingestion.service');
 
 const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
@@ -48,7 +62,11 @@ async function run(fn: () => Promise<unknown>) {
   // A positive control on the harness itself: a query that never compiled would leave this empty,
   // and every assertion below would then be reading a stale or absent statement.
   expect(captured.length, 'the query under test must have compiled').toBe(1);
-  return { sql: norm(captured[0].sql), parameters: captured[0].parameters };
+  return {
+    sql: norm(captured[0].sql),
+    parameters: captured[0].parameters,
+    client: captured[0].client,
+  };
 }
 
 /** The predicate only: everything between WHERE and ORDER BY (or the end, for the count queries). */
@@ -193,11 +211,56 @@ describe("the delete gate's own predicate", () => {
     expect(queue).toContain('i."createdAt" > now() - INTERVAL \'2 days\'');
   });
 
-  it('shares the failure-class predicate with the queue, so the two cannot disagree', async () => {
+  it('shares EVERY state predicate with the queue, so the two cannot disagree', async () => {
+    /**
+     * 🔴 Asserted over the whole clause SET, not one clause of three. The earlier version named the
+     * relationship in its title and checked only `failureClass`: changing the queue's
+     * `nsfwLevel = 0` bound left the gate behind and the test stayed green — the gate would then
+     * refuse images the queue renders, and those become permanently uncleanable. That is the same
+     * bug the display-window split fixed, on the state axis instead of the time axis.
+     */
     const gate = (await run(() => isMissingMediaImage(4242))).sql;
     const queue = (await run(() => countMissingMediaImages())).sql;
-    const clause = "i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1";
-    expect(gate).toContain(clause);
-    expect(queue).toContain(clause);
+
+    const clauses = (statement: string) =>
+      statement
+        .slice(statement.indexOf(' WHERE ') + ' WHERE '.length)
+        .split(/\bAND\b/)
+        .map((c) =>
+          c
+            .trim()
+            .replace(/^\(+|\)+$/g, '')
+            .trim()
+        )
+        .filter(Boolean);
+
+    // Everything the gate asserts, minus its own id binding, must appear in the queue verbatim.
+    const gateState = clauses(gate).filter((c) => !c.startsWith('i.id ='));
+    expect(gateState.length).toBeGreaterThanOrEqual(3);
+    for (const clause of gateState) expect(clauses(queue), clause).toContain(clause);
+  });
+});
+
+describe('read-your-write: the delete confirmation must not read a replica', () => {
+  /**
+   * 🔴 `imageRowExists` runs milliseconds after a delete on the primary, to decide whether that
+   * delete happened. On `dbRead` — a separate pool on the replica connection string — any lag past
+   * that round trip makes a SUCCESSFUL delete read as "still present": a false failure, and no audit
+   * row for a delete that did happen. The exact mirror of the bug the read-back prevents.
+   *
+   * Nothing pinned this before, so a one-word revert to `dbRead` would have been invisible.
+   */
+  it('confirms the delete against the PRIMARY, not the replica', async () => {
+    const { client, sql, parameters } = await run(() => imageRowExists(4242));
+    expect(client).toBe('write');
+    expect(sql).toBe('SELECT i.id FROM "Image" i WHERE i.id = $1 LIMIT 1');
+    expect(parameters).toEqual([4242]);
+  });
+
+  it('still reads the replica for the queues and badges, which are not read-your-write', async () => {
+    // The flip side: these are ordinary list reads and must NOT be moved onto the primary.
+    expect((await run(() => countMissingMediaImages())).client).toBe('read');
+    expect((await run(() => getMissingMediaImages({ limit: 10 }))).client).toBe('read');
+    expect((await run(() => countIngestionErrorImages())).client).toBe('read');
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -79,10 +79,19 @@ describe('ingestion-error queue predicates', () => {
         "AND i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1"
     );
 
-    // The class is a BOUND PARAMETER carrying the exact stored value, not a fuzzy text match. A
-    // `reason ILIKE '%download%'` predicate would pass a keyword assertion and fail this one.
+    // The class is a BOUND PARAMETER carrying the exact stored value.
     expect(errors.parameters).toEqual(['permanent']);
     expect(missing.parameters).toEqual(['permanent']);
+  });
+
+  it('never keys the split off the scanner reason TEXT', async () => {
+    // Its own case, deliberately, so it stays REACHABLE. Folded into the pin above it would be
+    // unreachable the moment the pin fails, and a mutant that swapped the class predicate for
+    // `reason ILIKE '%download%'` would then die to the pin rather than to the rule it violates.
+    // The reason string is prose the scanner owns: one reword and every permanently-broken image
+    // walks back into the review queue, silently.
+    const errors = await run(() => countIngestionErrorImages());
+    const missing = await run(() => countMissingMediaImages());
     for (const s of [errors.sql, missing.sql]) {
       expect(s).not.toMatch(/like/i);
       expect(s).not.toMatch(/reason/i);

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The ingestion-error page's SQL, compiled for real.
+ *
+ * These four queries are built from two shared `sql` fragments, and the property that matters is a
+ * relationship BETWEEN them, not the content of any one: the list and its badge must carry the same
+ * predicate (or the count never reaches zero on a drained page), and the review queue and the
+ * missing-media view must partition the same window rather than overlap or leave a gap.
+ *
+ * A hand-rolled fake cannot see any of that — only the emitted SQL can. So `dbRead` here is real
+ * Kysely on a driver that never connects, and every assertion reads the statement it produced.
+ */
+const captured = vi.hoisted(() => [] as { sql: string; parameters: readonly unknown[] }[]);
+
+// Built inside the factory, not in `vi.hoisted`: hoisted blocks run before this file's own imports,
+// so constructing Kysely there reads it before initialisation.
+vi.mock('$lib/server/db', async () => {
+  const { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } =
+    await import('kysely');
+  const db = new Kysely<never>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (i) => new PostgresIntrospector(i),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+    log: (e) => {
+      if (e.level === 'query') captured.push({ sql: e.query.sql, parameters: e.query.parameters });
+    },
+  });
+  return { dbRead: db, dbWrite: db };
+});
+
+const {
+  getIngestionErrorImages,
+  countIngestionErrorImages,
+  getMissingMediaImages,
+  countMissingMediaImages,
+} = await import('../ingestion.service');
+
+const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+async function run(fn: () => Promise<unknown>) {
+  captured.length = 0;
+  await fn();
+  // A positive control on the harness itself: a query that never compiled would leave this empty,
+  // and every assertion below would then be reading a stale or absent statement.
+  expect(captured.length, 'the query under test must have compiled').toBe(1);
+  return { sql: norm(captured[0].sql), parameters: captured[0].parameters };
+}
+
+/** The predicate only: everything between WHERE and ORDER BY (or the end, for the count queries). */
+function whereClause(sql: string) {
+  const at = sql.indexOf(' WHERE ');
+  expect(at, 'statement has a WHERE clause').toBeGreaterThan(-1);
+  const rest = sql.slice(at + ' WHERE '.length);
+  const order = rest.indexOf(' ORDER BY ');
+  return order === -1 ? rest : rest.slice(0, order);
+}
+
+describe('ingestion-error queue predicates', () => {
+  it('splits the window on the stored failure class, not on the scanner reason text', async () => {
+    const errors = await run(() => countIngestionErrorImages());
+    const missing = await run(() => countMissingMediaImages());
+
+    // Pinned WHOLE, not by keyword. A guard on a word is walkable by rewording; a guard on the
+    // whole normalised statement is not, and a deliberate predicate change has to come here.
+    expect(errors.sql).toBe(
+      'SELECT count(*) AS count FROM "Image" i WHERE i."createdAt" > now() - INTERVAL \'2 days\' ' +
+        'AND i."createdAt" < now() - INTERVAL \'1 hour\' ' +
+        'AND i.ingestion = \'Error\'::"ImageIngestionStatus" AND i."nsfwLevel" = 0 ' +
+        "AND NOT ( i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 )"
+    );
+    expect(missing.sql).toBe(
+      'SELECT count(*) AS count FROM "Image" i WHERE i."createdAt" > now() - INTERVAL \'2 days\' ' +
+        'AND i."createdAt" < now() - INTERVAL \'1 hour\' ' +
+        'AND i.ingestion = \'Error\'::"ImageIngestionStatus" AND i."nsfwLevel" = 0 ' +
+        "AND i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1"
+    );
+
+    // The class is a BOUND PARAMETER carrying the exact stored value, not a fuzzy text match. A
+    // `reason ILIKE '%download%'` predicate would pass a keyword assertion and fail this one.
+    expect(errors.parameters).toEqual(['permanent']);
+    expect(missing.parameters).toEqual(['permanent']);
+    for (const s of [errors.sql, missing.sql]) {
+      expect(s).not.toMatch(/like/i);
+      expect(s).not.toMatch(/reason/i);
+    }
+  });
+
+  it('is NULL-safe, so an unclassified failure still reaches a human', async () => {
+    // The false-positive guard, and the one that matters more than the true positive. The JSON path
+    // yields NULL for an image with no stored scan error, and `NULL <> 'permanent'` is NULL — which
+    // a WHERE treats as false. A plain `<>` would therefore drop every unclassified failure out of
+    // the review queue, i.e. the ordinary timeouts and container churn that are the bulk of it.
+    const errors = await run(() => countIngestionErrorImages());
+    expect(errors.sql).toContain('IS NOT DISTINCT FROM');
+    expect(errors.sql).not.toMatch(/failureClass'\s*<>/);
+    expect(errors.sql).not.toMatch(/failureClass'\s*!=/);
+  });
+
+  it('partitions the same window: the two views share every other predicate', async () => {
+    const errors = whereClause((await run(() => countIngestionErrorImages())).sql);
+    const missing = whereClause((await run(() => countMissingMediaImages())).sql);
+
+    // Structural, not textual: the missing-media predicate is the error predicate with the negation
+    // removed. Widening the window, changing the ingestion state, or moving the nsfwLevel bound on
+    // one side only breaks this, whichever side is edited.
+    const base = missing.slice(0, missing.indexOf('AND i."scanJobs"'));
+    expect(base.length).toBeGreaterThan(0);
+    expect(errors.startsWith(base)).toBe(true);
+    // `missing` adds `AND <class predicate>`; `errors` must add exactly its negation.
+    const classPredicate = missing.slice(base.length).replace(/^AND /, '');
+    expect(errors.slice(base.length)).toBe(`AND NOT ( ${classPredicate} )`);
+  });
+
+  it('gives the ingestion-error badge the same predicate as its queue', async () => {
+    // The property the service comments call out: a divergence here is a count that never reaches
+    // zero. Written so that FORKING the const — giving the count its own copy of the predicate and
+    // then editing either one — fails, rather than only a wholesale rewrite.
+    const list = whereClause((await run(() => getIngestionErrorImages({ limit: 50 }))).sql);
+    const count = whereClause((await run(() => countIngestionErrorImages())).sql);
+    expect(list.startsWith(count)).toBe(true);
+    // The only thing the list adds is its cursor clause.
+    expect(list.slice(count.length).trim()).toBe('AND (TRUE)');
+  });
+
+  it('gives the missing-media badge the same predicate as its queue', async () => {
+    const list = whereClause((await run(() => getMissingMediaImages({ limit: 50 }))).sql);
+    const count = whereClause((await run(() => countMissingMediaImages())).sql);
+    expect(list.startsWith(count)).toBe(true);
+    expect(list.slice(count.length).trim()).toBe('AND (TRUE)');
+  });
+
+  it('pages the missing-media view by cursor, like the queue it was split from', async () => {
+    const { sql, parameters } = await run(() => getMissingMediaImages({ limit: 25, cursor: 999 }));
+    expect(sql).toContain('AND (i.id < $2)');
+    expect(parameters).toEqual(['permanent', 999, 26]);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/ingestion-queue-partition.test.ts
@@ -79,7 +79,7 @@ function whereClause(sql: string) {
 }
 
 describe('ingestion-error queue predicates', () => {
-  it('splits the window on the stored failure class, not on the scanner reason text', async () => {
+  it('splits the window on publishability, not on the scanner reason text', async () => {
     const errors = await run(() => countIngestionErrorImages());
     const missing = await run(() => countMissingMediaImages());
 
@@ -89,18 +89,38 @@ describe('ingestion-error queue predicates', () => {
       'SELECT count(*) AS count FROM "Image" i WHERE i."createdAt" > now() - INTERVAL \'2 days\' ' +
         'AND i."createdAt" < now() - INTERVAL \'1 hour\' ' +
         'AND i.ingestion = \'Error\'::"ImageIngestionStatus" AND i."nsfwLevel" = 0 ' +
-        "AND NOT ( i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 )"
+        "AND NOT ( i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 " +
+        "OR COALESCE(i.url, '') LIKE $2 )"
     );
     expect(missing.sql).toBe(
       'SELECT count(*) AS count FROM "Image" i WHERE i."createdAt" > now() - INTERVAL \'2 days\' ' +
         'AND i."createdAt" < now() - INTERVAL \'1 hour\' ' +
         'AND i.ingestion = \'Error\'::"ImageIngestionStatus" AND i."nsfwLevel" = 0 ' +
-        "AND i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1"
+        "AND ( i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 " +
+        "OR COALESCE(i.url, '') LIKE $2 )"
     );
 
-    // The class is a BOUND PARAMETER carrying the exact stored value.
-    expect(errors.parameters).toEqual(['permanent']);
-    expect(missing.parameters).toEqual(['permanent']);
+    // Both halves are BOUND PARAMETERS carrying the exact stored values, and the second is built
+    // from `@civitai/shared`'s `UNRENDERABLE_MEDIA_URL_PREFIX` — the SAME constant the write-side
+    // refusal is built from — so the queue cannot select a different set from the one the guard
+    // refuses. Divergence there has no symptom on this page and a severe one for the moderator: a
+    // row refused on the rating queue and missing from the delete queue has no action left at all.
+    expect(errors.parameters).toEqual(['permanent', 'blob:%']);
+    expect(missing.parameters).toEqual(['permanent', 'blob:%']);
+  });
+
+  it('is NULL-safe on the url half too, so the split stays a partition', async () => {
+    /**
+     * 🔴 The `IS NOT DISTINCT FROM` trap one operator over. `NULL LIKE 'blob:%'` is NULL, so on a
+     * row with a NULL url and a non-permanent class the disjunction is NULL — which a WHERE treats
+     * as false on BOTH sides, dropping the row out of the review queue and the missing-media queue
+     * simultaneously. That is a hole in something the suite above asserts is an exact partition, and
+     * it is invisible in the emitted SQL unless you look for the COALESCE.
+     */
+    const errors = await run(() => countIngestionErrorImages());
+    expect(errors.sql).toContain("COALESCE(i.url, '') LIKE");
+    // The bare form, which is what a "simplification" would produce.
+    expect(errors.sql).not.toMatch(/\bi\.url LIKE/);
   });
 
   it('never keys the split off the scanner reason TEXT', async () => {
@@ -112,8 +132,18 @@ describe('ingestion-error queue predicates', () => {
     const errors = await run(() => countIngestionErrorImages());
     const missing = await run(() => countMissingMediaImages());
     for (const s of [errors.sql, missing.sql]) {
-      expect(s).not.toMatch(/like/i);
       expect(s).not.toMatch(/reason/i);
+      // 🔴 There IS a `LIKE` in these statements now — the url-shape disjunct — so a blanket
+      // `not.toMatch(/like/i)` is no longer available and would have to be deleted. Deleting it is
+      // the wrong move: what it was protecting is that no pattern match is ever aimed at the
+      // scanner's PROSE. So the assertion narrows rather than disappears — every `LIKE` in the
+      // statement must be the url one, against a bound parameter, and `ILIKE` (the spelling a
+      // case-insensitive prose match reaches for) must not appear at all.
+      expect(s).not.toMatch(/ILIKE/i);
+      // Exactly one, and it is the url one against a bound parameter. A second `LIKE` appearing —
+      // which is what a prose match would be — fails on the count before anything else.
+      expect([...s.matchAll(/\bLIKE\b/gi)]).toHaveLength(1);
+      expect(s).toContain("COALESCE(i.url, '') LIKE $2");
     }
   });
 
@@ -134,13 +164,19 @@ describe('ingestion-error queue predicates', () => {
 
     // Structural, not textual: the missing-media predicate is the error predicate with the negation
     // removed. Widening the window, changing the ingestion state, or moving the nsfwLevel bound on
-    // one side only breaks this, whichever side is edited.
-    const base = missing.slice(0, missing.indexOf('AND i."scanJobs"'));
+    // one side only breaks this, whichever side is edited. Derived from `errors` — where the split
+    // predicate is unambiguously delimited by ` AND NOT ` — so adding a disjunct to the split cannot
+    // silently move where this test thinks the shared base ends.
+    const marker = ' AND NOT ';
+    const at = errors.indexOf(marker);
+    expect(at, 'the review queue negates the split predicate').toBeGreaterThan(-1);
+    const base = errors.slice(0, at);
+    const splitPredicate = errors.slice(at + marker.length);
     expect(base.length).toBeGreaterThan(0);
-    expect(errors.startsWith(base)).toBe(true);
-    // `missing` adds `AND <class predicate>`; `errors` must add exactly its negation.
-    const classPredicate = missing.slice(base.length).replace(/^AND /, '');
-    expect(errors.slice(base.length)).toBe(`AND NOT ( ${classPredicate} )`);
+    expect(splitPredicate.length).toBeGreaterThan(0);
+    // Exhaustive and exclusive in one line: `missing` must be the same base plus exactly the
+    // predicate `errors` negates — no extra clause on either side, no clause missing from either.
+    expect(missing).toBe(`${base} AND ${splitPredicate}`);
   });
 
   it('gives the ingestion-error badge the same predicate as its queue', async () => {
@@ -163,8 +199,8 @@ describe('ingestion-error queue predicates', () => {
 
   it('pages the missing-media view by cursor, like the queue it was split from', async () => {
     const { sql, parameters } = await run(() => getMissingMediaImages({ limit: 25, cursor: 999 }));
-    expect(sql).toContain('AND (i.id < $2)');
-    expect(parameters).toEqual(['permanent', 999, 26]);
+    expect(sql).toContain('AND (i.id < $3)');
+    expect(parameters).toEqual(['permanent', 'blob:%', 999, 26]);
   });
 });
 
@@ -176,24 +212,45 @@ describe("the delete gate's own predicate", () => {
    * prevent — with the whole suite still green, because its only test mocked the function wholesale
    * and therefore pinned the call site rather than the predicate.
    */
-  it('scopes the delete to a permanently-failed, unpublished ingestion error', async () => {
+  it('scopes the delete to an unpublishable, unpublished ingestion error', async () => {
     const { sql, parameters } = await run(() => isMissingMediaImage(4242));
 
     expect(sql).toBe(
       'SELECT i.id FROM "Image" i WHERE i.ingestion = \'Error\'::"ImageIngestionStatus" ' +
         'AND i."nsfwLevel" = 0 ' +
-        "AND i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 " +
-        'AND i.id = $2 LIMIT 1'
+        "AND ( i.\"scanJobs\"->'error'->>'failureClass' IS NOT DISTINCT FROM $1 " +
+        "OR COALESCE(i.url, '') LIKE $2 ) " +
+        'AND i.id = $3 LIMIT 1'
     );
-    expect(parameters).toEqual(['permanent', 4242]);
+    expect(parameters).toEqual(['permanent', 'blob:%', 4242]);
   });
 
   it('is always bound to the requested id — never an unscoped match', async () => {
     // The specific mutant: dropping the state predicates, or the id, makes this a delete-anything
     // endpoint. Asserted separately from the pin above so it stays reachable if the pin is edited.
     const { sql } = await run(() => isMissingMediaImage(4242));
-    expect(sql).toContain('AND i.id = $2');
+    expect(sql).toContain('AND i.id = $3');
     expect(sql).not.toMatch(/WHERE\s+TRUE/i);
+  });
+
+  it('accepts a row refused for its URL SHAPE, not only one with a permanent scan failure', async () => {
+    /**
+     * 🔴 THE FINDING THIS CLOSES. The publish guard refuses two verdicts — `absent` and
+     * `unrenderable` — and this gate used to admit only the first. A `blob:` row whose scan failure
+     * was transient, or unclassified (a NULL `failureClass`, which `ingestionErrorWhere`
+     * deliberately routes to the rateable queue), was therefore refused on the rating queue AND
+     * refused by the only delete this app offers: a refusal with no reachable action, i.e. a
+     * permanently stuck row. The message the guard shows says "Delete it"; this clause is what makes
+     * that sentence true.
+     *
+     * Asserted on the DISJUNCTION rather than by re-pinning the statement, so it stays reachable
+     * when the whole-statement pin above is edited.
+     */
+    const { sql } = await run(() => isMissingMediaImage(4242));
+    expect(sql).toContain("COALESCE(i.url, '') LIKE $2");
+    // ...and as a disjunct, never an extra requirement — an `AND` here would refuse every row that
+    // is missing from storage but has an ordinary key, which is the bulk of this queue.
+    expect(sql).toMatch(/IS NOT DISTINCT FROM \$1 OR COALESCE/);
   });
 
   it('deliberately omits the 2-day display window the queue applies', async () => {
@@ -213,11 +270,18 @@ describe("the delete gate's own predicate", () => {
 
   it('shares EVERY state predicate with the queue, so the two cannot disagree', async () => {
     /**
-     * 🔴 Asserted over the whole clause SET, not one clause of three. The earlier version named the
-     * relationship in its title and checked only `failureClass`: changing the queue's
-     * `nsfwLevel = 0` bound left the gate behind and the test stayed green — the gate would then
-     * refuse images the queue renders, and those become permanently uncleanable. That is the same
-     * bug the display-window split fixed, on the state axis instead of the time axis.
+     * 🔴 Asserted over the whole clause SET, not one clause of three, and in BOTH directions.
+     *
+     * The first version named the relationship in its title and checked only `failureClass`:
+     * changing the queue's `nsfwLevel = 0` bound left the gate behind and the test stayed green.
+     * The second widened that to every gate clause — but only as `gate ⊆ queue`, which is blind in
+     * the direction that actually widens a permanent cascading delete: the QUEUE gaining a clause
+     * the gate lacks. (Measured: adding a clause to `missingMediaWhere` alone was killed by the
+     * queue's own whole-statement pins, not by this test — so the title was not true of the code.)
+     *
+     * Equality of the two sets is what the title claims, so equality is what is asserted. The two
+     * differences that are DELIBERATE are subtracted by name: the gate's id binding, and the queue's
+     * display window (see the case above for why the gate must not carry it).
      */
     const gate = (await run(() => isMissingMediaImage(4242))).sql;
     const queue = (await run(() => countMissingMediaImages())).sql;
@@ -225,6 +289,7 @@ describe("the delete gate's own predicate", () => {
     const clauses = (statement: string) =>
       statement
         .slice(statement.indexOf(' WHERE ') + ' WHERE '.length)
+        .replace(/ LIMIT \d+$/, '')
         .split(/\bAND\b/)
         .map((c) =>
           c
@@ -234,10 +299,18 @@ describe("the delete gate's own predicate", () => {
         )
         .filter(Boolean);
 
-    // Everything the gate asserts, minus its own id binding, must appear in the queue verbatim.
     const gateState = clauses(gate).filter((c) => !c.startsWith('i.id ='));
+    const queueState = clauses(queue).filter((c) => !c.startsWith('i."createdAt"'));
+
+    // Positive control on the splitter: if it stopped decomposing, both sides would be one opaque
+    // string and the equality below would pass vacuously.
     expect(gateState.length).toBeGreaterThanOrEqual(3);
-    for (const clause of gateState) expect(clauses(queue), clause).toContain(clause);
+    expect(queueState.length).toBeGreaterThanOrEqual(3);
+    // ...and the window really was the only thing subtracted from the queue side.
+    expect(clauses(queue).length - queueState.length).toBe(2);
+
+    // 🔴 Bidirectional. `toEqual` on sorted arrays fails when either side gains OR loses a clause.
+    expect([...gateState].sort()).toEqual([...queueState].sort());
   });
 });
 

--- a/apps/moderator/src/lib/server/__tests__/storage-probe-client.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/storage-probe-client.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The BUDGET the media-existence probe runs under, pinned as a value rather than as a behaviour.
+ *
+ * 🔴 Why this file exists. `getMediaProbeStorage` builds a second storage client purely to bound a
+ * probe that sits on a moderator's click path: `timeoutMs: 5_000, retries: 0`. The guard's own suite
+ * mocks `$lib/server/storage` wholesale, so it can prove the probe reaches the SEPARATE factory but
+ * says nothing about what that factory asks for — deleting both lines left the whole `app:moderator`
+ * project green. The defaults it would fall back to are `timeoutMs: 10_000, retries: 2`
+ * (`packages/civitai-storage/src/client.ts`), i.e. three attempts plus backoff: roughly 31 s of a
+ * moderator waiting for an answer that ALLOWS either way when it cannot be had.
+ *
+ * So the config object is asserted directly, at the seam where it is handed over.
+ */
+type ProbeConfig = {
+  endpoint?: string;
+  token?: string;
+  timeoutMs?: number;
+  retries?: number;
+};
+
+// Returns a FRESH object per call, so identity distinguishes the two clients without any test
+// having to install an implementation (one installed here would leak to every later case).
+const createStorageClient = vi.hoisted(() =>
+  vi.fn((_config: ProbeConfig) => ({ tag: 'client' }) as Record<string, unknown>)
+);
+vi.mock('@civitai/storage', () => ({ createStorageClient }));
+
+const ENDPOINT = 'https://storage.test.invalid';
+const TOKEN = 'test-token';
+
+/**
+ * Both factories memoize their client in a module-scoped variable, so every case re-imports the
+ * module to get an unbuilt one. Without this the second test in the file sees zero calls and passes
+ * vacuously — the reassuring-zero shape.
+ */
+async function freshModule() {
+  vi.resetModules();
+  createStorageClient.mockClear();
+  process.env.STORAGE_ENDPOINT = ENDPOINT;
+  process.env.STORAGE_TOKEN = TOKEN;
+  return import('../storage');
+}
+
+beforeEach(() => {
+  createStorageClient.mockClear();
+});
+
+describe('getMediaProbeStorage — the probe budget', () => {
+  it('asks for ONE attempt at 5 s, and nothing else', async () => {
+    const { getMediaProbeStorage } = await freshModule();
+
+    getMediaProbeStorage();
+
+    // Pinned as a whole object, not by keyword. `toEqual` on the exact config fails if either bound
+    // is deleted (the fallback is the client's own default, so the key is simply absent), if either
+    // is retyped, or if an extra option is smuggled in.
+    expect(createStorageClient).toHaveBeenCalledTimes(1);
+    expect(createStorageClient).toHaveBeenCalledWith({
+      endpoint: ENDPOINT,
+      token: TOKEN,
+      timeoutMs: 5_000,
+      retries: 0,
+    });
+  });
+
+  it('bounds it BELOW the library defaults it would otherwise inherit', async () => {
+    /**
+     * The mutation this kills that the pin above would also kill, but for the wrong reason: a value
+     * that is present but useless (`retries: 2`, `timeoutMs: 10_000`) is not a bound at all. Written
+     * against the LIBRARY's defaults rather than against the literals above, so it keeps meaning
+     * something if someone re-tunes the pin.
+     */
+    const { getMediaProbeStorage } = await freshModule();
+
+    getMediaProbeStorage();
+
+    const config = createStorageClient.mock.calls[0][0];
+    expect(config.timeoutMs).toBeLessThan(10_000);
+    expect(config.retries).toBeLessThan(2);
+    // One attempt, so the worst case is the timeout itself rather than a multiple of it.
+    expect(config.retries).toBe(0);
+  });
+
+  it('memoizes, so a click path never rebuilds the client', async () => {
+    const { getMediaProbeStorage } = await freshModule();
+
+    const first = getMediaProbeStorage();
+    const second = getMediaProbeStorage();
+
+    expect(second).toBe(first);
+    expect(createStorageClient).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getStorage — the general-purpose client is deliberately NOT bounded', () => {
+  it('takes the library defaults, so the two clients are not interchangeable', async () => {
+    /**
+     * The other half of the relationship, and the reason the probe needs its own client at all.
+     * Asserting only the probe's config would stay green if someone "simplified" by bounding
+     * `getStorage` too and pointing the probe at it — which would put a 5 s / no-retry budget on the
+     * WRITE operations this client serves, where giving up early loses work.
+     */
+    const { getStorage } = await freshModule();
+
+    getStorage();
+
+    expect(createStorageClient).toHaveBeenCalledTimes(1);
+    expect(createStorageClient).toHaveBeenCalledWith({ endpoint: ENDPOINT, token: TOKEN });
+  });
+
+  it('is a DIFFERENT client instance from the probe one', async () => {
+    // No `mockImplementation` here on purpose: the hoisted factory already returns a fresh object
+    // per call, and installing one would LEAK to every later case (`clearAllMocks`/`mockClear`
+    // clear calls, not implementations) — the exact harness defect this PR fixed elsewhere.
+    const { getStorage, getMediaProbeStorage } = await freshModule();
+
+    expect(getStorage()).not.toBe(getMediaProbeStorage());
+    expect(createStorageClient).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/storage-probe-client.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/storage-probe-client.test.ts
@@ -23,7 +23,7 @@ type ProbeConfig = {
 // Returns a FRESH object per call, so identity distinguishes the two clients without any test
 // having to install an implementation (one installed here would leak to every later case).
 const createStorageClient = vi.hoisted(() =>
-  vi.fn((_config: ProbeConfig) => ({ tag: 'client' }) as Record<string, unknown>)
+  vi.fn((_config: ProbeConfig) => ({ tag: 'client' } as Record<string, unknown>))
 );
 vi.mock('@civitai/storage', () => ({ createStorageClient }));
 

--- a/apps/moderator/src/lib/server/access.ts
+++ b/apps/moderator/src/lib/server/access.ts
@@ -90,6 +90,9 @@ export const NAVIGATION: NavLink[] = [
         informational: true,
       },
       { path: '/images/ingestion-errors', label: 'Ingestion Errors', countKey: 'ingestionErrors' },
+      // The permanent-failure half of the ingestion errors, carved off so they are never rated:
+      // publishing one puts a permanent 404 on the site. Delete-only.
+      { path: '/images/missing-media', label: 'Missing Media', countKey: 'missingMedia' },
     ],
   },
   // Models gets its own group beside Images and Articles rather than a single top-level entry — the

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -71,6 +71,32 @@ const ingestionErrorState = sql`
   AND i."nsfwLevel" = 0
 `;
 
+/**
+ * 🔴 THE 2-DAY LOWER BOUND IS A REAL LIMIT ON REACH, AND BOTH QUEUES INHERIT IT.
+ *
+ * It is right for the RATING queue: a moderator rates recent scan errors, and an unbounded backlog
+ * of old ones is not work anybody is going to do. It is less obviously right for the missing-media
+ * queue, whose rows are terminal — they only leave it by being deleted — and whose motivating
+ * population, `blob:` urls from a legacy upload bug (`src/utils/type-guards.ts`), is plausibly
+ * mostly OLDER than two days. That is inference from where the bug came from, not a production
+ * count; nobody has measured it.
+ *
+ * So the state of play, said rather than glossed: an unpublishable row older than two days is
+ * deletable by the POST action (`missingMediaScope` deliberately drops the window — see that const)
+ * but is rendered by NO page here. The copy in `@civitai/shared/missing-media` and on the article
+ * surface is written so it does not promise a queue that will list such a row.
+ *
+ * Widening it was considered and NOT taken, for a reason that is worth writing down because it is
+ * not the obvious one: both queues order `createdAt DESC`, so dropping the bound would put the old
+ * `blob:` rows at the BACK of an unbounded list behind every historical permanent scan failure —
+ * burying the motivating population rather than surfacing it, at an unmeasured queue size. The one
+ * query that would settle whether widening is worth it, and what shape it should take:
+ *
+ *     SELECT count(*) FROM "Image"
+ *      WHERE ingestion = 'Error' AND "nsfwLevel" = 0
+ *        AND "createdAt" < now() - INTERVAL '2 days'
+ *        AND url LIKE 'blob:%';
+ */
 const ingestionErrorBaseWhere = sql`
   i."createdAt" > now() - INTERVAL '2 days'
   AND i."createdAt" < now() - INTERVAL '1 hour'
@@ -109,28 +135,59 @@ const permanentScanFailure = sql`
  * misses is refused by the moderator's only remaining action too, i.e. permanently stuck. The shared
  * predicate is case-SENSITIVE, and so is SQL `LIKE`, so the two agree by construction.
  *
- * `COALESCE(i.url, '')` rather than a bare `LIKE`, and it is load-bearing: `NULL LIKE 'blob:%'` is
- * NULL, so on a NULL url `permanent OR NULL` is NULL when the class is not permanent — which a
- * WHERE treats as false on BOTH sides of the split, dropping the row out of the review queue and out
- * of the missing-media queue at the same time. That is a gap in what is supposed to be a partition,
- * and it is exactly the `IS NOT DISTINCT FROM` trap one predicate up, in the other operator.
+ * `COALESCE(i.url, '')` rather than a bare `LIKE`, and 🔴 BE PRECISE ABOUT WHAT IT BUYS, because an
+ * earlier version of this comment overstated it and the overstatement was doing the work of the
+ * argument. It is NOT load-bearing today and removing it changes no result: `Image.url` is NOT NULL
+ * (`packages/civitai-db-schema/prisma/schema.full.prisma`, and the generated Kysely type is
+ * `url: string`, not `string | null`), so the row this defends against cannot exist. What actually
+ * keeps the split a partition on the url half is that column constraint, and nothing else.
+ *
+ * It stays as defence-in-depth against exactly one future change — the column being made nullable —
+ * because THAT is where the failure is silent: `NULL LIKE 'blob:%'` is NULL, so on a NULL url
+ * `permanent OR NULL` is NULL whenever the class is not permanent, which a WHERE treats as false on
+ * BOTH sides of the split, dropping the row out of the review queue and the missing-media queue at
+ * once. Same shape as the `IS NOT DISTINCT FROM` trap one predicate up, in the other operator. The
+ * NOT NULL constraint itself is pinned by this module's test, so if it ever goes away that is a
+ * visible failure rather than a silent re-partition.
  */
 const unrenderableMediaUrl = sql`
   COALESCE(i.url, '') LIKE ${`${UNRENDERABLE_MEDIA_URL_PREFIX}%`}
 `;
 
 /**
- * "This image cannot be published, whatever a moderator rates it."
+ * "This image probably cannot be published, whatever a moderator rates it."
  *
- * 🔴 The two disjuncts are the two verdicts `assertMediaPresentForPublish` REFUSES on, and that is
- * the property to preserve when editing either: this predicate decides which rows reach the queue
- * that can delete them, so a refusal the write guard makes and this query does not see is a row with
- * no reachable action at all — refused on the rating queue, absent from the delete queue. That was
- * the state `blob:` rows were left in when the refusal was added without this disjunct.
+ * This predicate decides which rows reach the queue that can delete them. A row the write guard
+ * refuses and this query does not see has no reachable action at all — refused on the rating queue,
+ * absent from the delete queue — so what the two cover, and where they DIVERGE, is the property to
+ * hold in mind when editing either.
  *
- *   - `permanentScanFailure` is the trigger for "the store probably does not have it"; the write
- *     guard's `absent` verdict is the actual verdict, from an existence check.
- *   - `unrenderableMediaUrl` needs no probe: the url can never render for anyone.
+ * 🔴 THE TWO DISJUNCTS ARE NOT THE WRITE GUARD'S TWO REFUSALS. Only one of them is:
+ *
+ *   - `unrenderableMediaUrl` IS `assertMediaPresentForPublish`'s `unrenderable` refusal, exactly:
+ *     same shared prefix constant, same case-sensitive prefix test, decided without a probe on both
+ *     sides. For this half the reachable-action property holds outright, and it is why the disjunct
+ *     was added — `blob:` rows were refused on the rating queue and absent from the delete queue.
+ *
+ *   - `permanentScanFailure` is a TRIGGER, not a verdict. The write guard's other refusal is
+ *     `absent`, which comes from an existence check against the media store — a probe result, so it
+ *     is not expressible in SQL at all and this query cannot select on it. The stored class is the
+ *     best SQL-side correlate we have, not the same set.
+ *
+ * 🔴 THE RESIDUAL GAP THAT FOLLOWS, STATED PLAINLY RATHER THAN GLOSSED. A row whose `failureClass`
+ * is `transient`, `unknown` or NULL but whose object really is gone routes to the RATING queue
+ * (NULL `IS NOT DISTINCT FROM 'permanent'` is false). A moderator rates it, the probe answers
+ * `absent`, the publish is refused — and `isMissingMediaImage` does not admit it, so the delete this
+ * app offers refuses it too. That row is stuck. It is a smaller population than the one this change
+ * fixes and it is NOT made worse by anything here, but it is not closed either.
+ *
+ * Widening this predicate is NOT the fix, and the tempting version is actively worse: "accept
+ * anything the write guard could refuse" means accepting every row with a probeable key, i.e. every
+ * unpublished ingestion error — which turns a scoped, permanent, cascading delete into an
+ * unscoped one while adding no affordance to any page, since neither queue renders those rows.
+ * Closing it properly needs the `absent` verdict to be persisted at the moment the probe produces
+ * it, and that is a separate change with its own hazard (a misconfigured bucket answers 404 for
+ * every key, so a naive write-back would permanently reclassify every row a moderator touched).
  */
 const unpublishableMedia = sql`
   ( ${permanentScanFailure} OR ${unrenderableMediaUrl} )
@@ -237,9 +294,11 @@ export async function countIngestionErrorImages(): Promise<number> {
 
 /**
  * The missing-media view: same window, opposite side of the publishability split. These images are
- * NOT rateable — their file can never be fetched, or their url can never render — so the only useful
- * affordance is deleting them. That affordance is why the split has to be the same predicate the
- * write guard refuses on: a refusal with no reachable action is a dead end, not a guard.
+ * NOT rateable — their file probably can never be fetched, or their url can never render — so the
+ * only useful affordance is deleting them. That affordance is why the url half of the split is
+ * literally the write guard's own predicate: a refusal with no reachable action is a dead end, not a
+ * guard. See `unpublishableMedia` for the half where the two are correlated rather than identical,
+ * and for what that leaves uncovered.
  */
 export async function getMissingMediaImages({
   limit,

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -5,6 +5,7 @@ import {
   IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
   MediaPresence,
   summarizeProbeError,
+  UNRENDERABLE_MEDIA_URL_PREFIX,
 } from '@civitai/shared';
 import { dbRead, dbWrite } from './db';
 import { bustCachedObject } from './cache';
@@ -62,8 +63,8 @@ export async function countImagesPendingIngestion(): Promise<number> {
 
 /**
  * The window + state every ingestion-error queue on this page shares. Split out so the two views
- * below can differ in exactly ONE predicate — whether the scan failed permanently — and cannot
- * drift in the window, the ingestion state, or the level bound.
+ * below can differ in exactly ONE predicate — whether the image can be published at all — and
+ * cannot drift in the window, the ingestion state, or the level bound.
  */
 const ingestionErrorState = sql`
   i.ingestion = 'Error'::"ImageIngestionStatus"
@@ -99,29 +100,66 @@ const permanentScanFailure = sql`
 `;
 
 /**
+ * The url-shape half of "cannot be published", and the reason this const exists at all.
+ *
+ * 🔴 THE PATTERN IS BUILT FROM THE SHARED PREFIX, NEVER SPELLED HERE. `isUnrenderableMediaUrl` in
+ * `@civitai/shared/missing-media` is what REFUSES these rows at write time; this is what routes them
+ * to the one view that offers a delete. Spelling `'blob:%'` locally would let the two drift, and the
+ * drift is invisible in the direction that matters: a row the write guard refuses but this query
+ * misses is refused by the moderator's only remaining action too, i.e. permanently stuck. The shared
+ * predicate is case-SENSITIVE, and so is SQL `LIKE`, so the two agree by construction.
+ *
+ * `COALESCE(i.url, '')` rather than a bare `LIKE`, and it is load-bearing: `NULL LIKE 'blob:%'` is
+ * NULL, so on a NULL url `permanent OR NULL` is NULL when the class is not permanent — which a
+ * WHERE treats as false on BOTH sides of the split, dropping the row out of the review queue and out
+ * of the missing-media queue at the same time. That is a gap in what is supposed to be a partition,
+ * and it is exactly the `IS NOT DISTINCT FROM` trap one predicate up, in the other operator.
+ */
+const unrenderableMediaUrl = sql`
+  COALESCE(i.url, '') LIKE ${`${UNRENDERABLE_MEDIA_URL_PREFIX}%`}
+`;
+
+/**
+ * "This image cannot be published, whatever a moderator rates it."
+ *
+ * 🔴 The two disjuncts are the two verdicts `assertMediaPresentForPublish` REFUSES on, and that is
+ * the property to preserve when editing either: this predicate decides which rows reach the queue
+ * that can delete them, so a refusal the write guard makes and this query does not see is a row with
+ * no reachable action at all — refused on the rating queue, absent from the delete queue. That was
+ * the state `blob:` rows were left in when the refusal was added without this disjunct.
+ *
+ *   - `permanentScanFailure` is the trigger for "the store probably does not have it"; the write
+ *     guard's `absent` verdict is the actual verdict, from an existence check.
+ *   - `unrenderableMediaUrl` needs no probe: the url can never render for anyone.
+ */
+const unpublishableMedia = sql`
+  ( ${permanentScanFailure} OR ${unrenderableMediaUrl} )
+`;
+
+/**
  * The human review queue: ingestion errors a moderator can still usefully rate — i.e. everything
- * whose scan failure was NOT permanent (timeouts, container churn, unclassified failures). Images
- * whose media can never be fetched are routed to the missing-media view instead, because rating one
- * publishes a permanent 404.
+ * that is not unpublishable (timeouts, container churn, unclassified failures). Images whose media
+ * can never be fetched, or whose url can never render, are routed to the missing-media view instead,
+ * because rating one publishes a permanent 404.
  *
  * Shared by the queue and its badge: a divergence here is a count that never reaches zero.
  */
 const ingestionErrorWhere = sql`
   ${ingestionErrorBaseWhere}
-  AND NOT (${permanentScanFailure})
+  AND NOT ${unpublishableMedia}
 `;
 
 /**
- * The complement, over the same window: ingestion errors whose media the scanner could never fetch
- * or decode. Same shared-const discipline — `getMissingMediaImages` and `countMissingMediaImages`
- * both read this one value, so the page and its badge cannot disagree.
+ * The complement, over the same window: ingestion errors that can never be published. Same
+ * shared-const discipline — `getMissingMediaImages` and `countMissingMediaImages` both read this one
+ * value, so the page and its badge cannot disagree.
  *
  * Together with `ingestionErrorWhere` this is an exact partition of `ingestionErrorBaseWhere`: no
  * image in the window is in both views, and none is in neither.
  */
 const missingMediaWhere = sql`
   ${ingestionErrorBaseWhere}
-  AND ${permanentScanFailure}
+  AND ${unpublishableMedia}
 `;
 
 /**
@@ -134,20 +172,22 @@ const missingMediaWhere = sql`
  * was then permanently uncleanable: it had left the only view offering a delete while still sitting
  * at `ingestion = 'Error'`.
  *
- * What actually makes a delete safe is the image's STATE — an unpublished ingestion error whose scan
- * failed permanently — and that does not expire. So the gate asserts the state, composed from the
- * SAME `ingestionErrorState` the queue uses so the two cannot drift on it, and the queue applies the
- * window on top.
+ * What actually makes a delete safe is the image's STATE — an unpublished ingestion error that
+ * cannot be published — and that does not expire. So the gate asserts the state, composed from the
+ * SAME `ingestionErrorState` and `unpublishableMedia` the queue uses so the two cannot drift on
+ * either, and the queue applies the window on top.
  *
  * Note this drops BOTH window bounds, the 1-hour lower one included, so a very new row the page does
- * not yet render is deletable by a hand-crafted POST. Checked, and safe: `permanent` is a terminal
- * class — `IMAGE_SCAN_PERMANENT_RETRY_LIMIT` is 1 and `markImageScanError` has already spent it — so
- * such a row is never re-driven into a different state by the ingest cron, and rows predating the
- * classification carry a NULL `failureClass`, which `IS NOT DISTINCT FROM` excludes.
+ * not yet render is deletable by a hand-crafted POST. Checked, and safe on both disjuncts:
+ * `permanent` is a terminal class — `IMAGE_SCAN_PERMANENT_RETRY_LIMIT` is 1 and `markImageScanError`
+ * has already spent it — so such a row is never re-driven into a different state by the ingest cron,
+ * and rows predating the classification carry a NULL `failureClass`, which `IS NOT DISTINCT FROM`
+ * excludes. A `blob:` url is terminal for a stronger reason still: no rescan, credential, or bucket
+ * state can ever make it fetchable.
  */
 const missingMediaScope = sql`
   ${ingestionErrorState}
-  AND ${permanentScanFailure}
+  AND ${unpublishableMedia}
 `;
 
 export type IngestionErrorImage = {
@@ -196,8 +236,10 @@ export async function countIngestionErrorImages(): Promise<number> {
 }
 
 /**
- * The missing-media view: same window, opposite side of the `failureClass` split. These images are
- * NOT rateable — their file can never be fetched, so the only useful affordance is deleting them.
+ * The missing-media view: same window, opposite side of the publishability split. These images are
+ * NOT rateable — their file can never be fetched, or their url can never render — so the only useful
+ * affordance is deleting them. That affordance is why the split has to be the same predicate the
+ * write guard refuses on: a refusal with no reachable action is a dead end, not a guard.
  */
 export async function getMissingMediaImages({
   limit,
@@ -345,6 +387,13 @@ export async function resolveIngestionError({
     // `presence` separates that from the url-shape refusal, which no bucket state can cause.
     onRefused: (presence) =>
       console.warn('[ingestion] refused publish; media cannot be served', id, presence),
+    /**
+     * 🔴 The short-circuit needs a counter too. `isProbeableMediaKey` is a deliberate
+     * UNDER-approximation — it matches only the bare-uuid shape our upload endpoints mint — so it is
+     * KNOWN to decline real keys. Without this line a run in which it declines EVERY row emits
+     * nothing and is indistinguishable from a run where the guard actually ran.
+     */
+    onSkipped: () => console.warn('[ingestion] media not probeable; no existence check ran', id),
   });
 
   const metadata = {

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -120,6 +120,26 @@ const missingMediaWhere = sql`
   AND ${permanentScanFailure}
 `;
 
+/**
+ * "Is this image a missing-media image?" — WITHOUT the 2-day display window.
+ *
+ * 🔴 The window is a QUEUE-DISPLAY concern, not a safety one, and conflating the two made the delete
+ * gate a race. The page orders `createdAt DESC`, so the rows nearest the window's edge sit at the
+ * bottom — exactly where a moderator draining the queue works. A row that aged out between page load
+ * and click was refused with "not in the missing-media queue" for an image visibly on screen, and
+ * was then permanently uncleanable: it had left the only view offering a delete while still sitting
+ * at `ingestion = 'Error'`.
+ *
+ * What actually makes a delete safe is the image's STATE — an unpublished ingestion error whose scan
+ * failed permanently — and that does not expire. So the gate asserts the state and the queue applies
+ * the window on top.
+ */
+const missingMediaScope = sql`
+  i.ingestion = 'Error'::"ImageIngestionStatus"
+  AND i."nsfwLevel" = 0
+  AND ${permanentScanFailure}
+`;
+
 export type IngestionErrorImage = {
   id: number;
   url: string;
@@ -198,15 +218,30 @@ export async function getMissingMediaImages({
  * The page's delete action takes an id off a form, and deleting an image is permanent and
  * cascading (row + stored object + de-index). Re-selecting through the SAME shared predicate is
  * what keeps the action scoped to what the page shows, instead of turning a moderator route into an
- * arbitrary delete-by-id. Uses `missingMediaWhere`, so it cannot drift from the queue or its badge.
+ * arbitrary delete-by-id. Uses `missingMediaScope` — the queue's predicates minus the display window; see that const.
  */
 export async function isMissingMediaImage(id: number): Promise<boolean> {
   const result = await sql<{ id: number }>`
     SELECT i.id
     FROM "Image" i
-    WHERE ${missingMediaWhere}
+    WHERE ${missingMediaScope}
       AND i.id = ${id}
     LIMIT 1
+  `.execute(dbRead);
+  return result.rows.length > 0;
+}
+
+/**
+ * Does this image row still exist?
+ *
+ * 🔴 Needed because `deleteImagesByIds` RESOLVES on failure. It wraps every per-image body in a
+ * `try/catch` that logs and continues, and its only un-caught statement is a `void`-ed async call —
+ * so a resolved promise is not evidence that anything was deleted. Without this the action reports
+ * success and the mod-activity record attests a delete that never happened.
+ */
+export async function imageRowExists(id: number): Promise<boolean> {
+  const result = await sql<{ id: number }>`
+    SELECT i.id FROM "Image" i WHERE i.id = ${id} LIMIT 1
   `.execute(dbRead);
   return result.rows.length > 0;
 }

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -3,8 +3,8 @@ import { REDIS_KEYS } from '@civitai/redis';
 import {
   assertMediaPresentForPublish,
   IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
-  isProbeableMediaKey,
   MediaPresence,
+  summarizeProbeError,
 } from '@civitai/shared';
 import { dbRead, dbWrite } from './db';
 import { bustCachedObject } from './cache';
@@ -286,13 +286,14 @@ export async function countMissingMediaImages(): Promise<number> {
  * Every image lives in the `b2Image` backend — the same assumption the image-deletion path makes,
  * where `Image.url` is passed straight through as the object key.
  */
-async function probeImageMediaPresence(url: string) {
-  // 🔴 Not every `Image.url` is a bucket key — see `isProbeableMediaKey`. This is also what keeps
+async function probeImageMediaPresence(key: string) {
+  // 🔴 No key check here, deliberately. `assertMediaPresentForPublish` classifies the url and only
+  // calls this with a value that already passed the SHARED `isProbeableMediaKey`. That is what keeps
   // the two runtimes agreeing: their storage clients fail DIFFERENTLY on a non-key url (the main
-  // app's 404s to `absent`; this one throws on an empty parsed bucket to `unknown`), so deciding it
-  // here rather than in each probe is the difference between one rule and two.
-  if (!isProbeableMediaKey(url)) return MediaPresence.Unknown;
-  const { exists } = await getMediaProbeStorage().headObject({ backend: 'b2Image', key: url });
+  // app's 404s to `absent`; this one throws on an empty parsed bucket to `unknown`), so a copy of
+  // the test in each probe is the difference between one rule and two — which is how they came to
+  // return opposite verdicts for the same row.
+  const { exists } = await getMediaProbeStorage().headObject({ backend: 'b2Image', key });
   return exists ? MediaPresence.Present : MediaPresence.Absent;
 }
 
@@ -322,16 +323,28 @@ export async function resolveIngestionError({
    * the queue; this is the write-side guard, and it is the authority: the queue predicate is a
    * trigger, an existence check against the store is the verdict.
    *
-   * Three-valued and only `absent` refuses — an unconsultable store must not block moderation. The
-   * thrown message reaches the moderator verbatim through the action's `fail(400, { error })`.
+   * Only `absent` and `unrenderable` refuse — an unconsultable store must not block moderation, and
+   * a url that is not a key this store issues is not asked about at all. The thrown message reaches
+   * the moderator verbatim through the action's `fail(400, { error })`.
    */
   await assertMediaPresentForPublish({
-    probe: () => probeImageMediaPresence(image.url),
-    onUnknown: (error) =>
-      console.warn('[ingestion] media probe inconclusive; allowing publish', id, error),
+    url: image.url,
+    probe: (key) => probeImageMediaPresence(key),
+    // 🔴 `summarizeProbeError`, never the raw error. A `StorageClientError` embeds the remote
+    // response BODY in its message — unbounded third-party text (an HTML error page, an XML fault)
+    // straight into stdout and therefore Loki, once per inconclusive probe.
+    onUnknown: ({ reason, error }) =>
+      console.warn(
+        '[ingestion] media probe inconclusive; allowing publish',
+        id,
+        reason,
+        summarizeProbeError(error)
+      ),
     // The mirror of onUnknown: a wrong bucket name 404s for EVERY key, so a fail-CLOSED
     // misconfiguration would refuse every publish and look exactly like a real run of misses.
-    onRefused: () => console.warn('[ingestion] refused publish; media object reported absent', id),
+    // `presence` separates that from the url-shape refusal, which no bucket state can cause.
+    onRefused: (presence) =>
+      console.warn('[ingestion] refused publish; media cannot be served', id, presence),
   });
 
   const metadata = {

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -1,9 +1,15 @@
 import { sql } from '@civitai/db/kysely';
 import { REDIS_KEYS } from '@civitai/redis';
+import {
+  assertMediaPresentForPublish,
+  IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
+  MediaPresence,
+} from '@civitai/shared';
 import { dbRead, dbWrite } from './db';
 import { bustCachedObject } from './cache';
 import { syncSearchIndex } from './search-index';
 import { recordModActivity } from './mod-activity';
+import { getStorage } from './storage';
 import type { MediaType } from '$lib/media/edge-url';
 
 export type PendingIngestionImage = {
@@ -53,12 +59,58 @@ export async function countImagesPendingIngestion(): Promise<number> {
   return Number(row?.count ?? 0);
 }
 
-/** Shared by the queue and its badge: a divergence here is a count that never reaches zero. */
-const ingestionErrorWhere = sql`
+/**
+ * The window + state every ingestion-error queue on this page shares. Split out so the two views
+ * below can differ in exactly ONE predicate — whether the scan failed permanently — and cannot
+ * drift in the window, the ingestion state, or the level bound.
+ */
+const ingestionErrorBaseWhere = sql`
   i."createdAt" > now() - INTERVAL '2 days'
   AND i."createdAt" < now() - INTERVAL '1 hour'
   AND i.ingestion = 'Error'::"ImageIngestionStatus"
   AND i."nsfwLevel" = 0
+`;
+
+/**
+ * The scan pipeline's own stored classification of an unfetchable/undecodable input.
+ *
+ * 🔴 Deliberately NOT a match on the scanner's reason text. A `reason ILIKE '%download%'` predicate
+ * is a spelled guard: one scanner reword and every permanently-broken image walks back into the
+ * review queue. `failureClass` is written at scan time from a fixed set, so it survives a reword.
+ *
+ * `IS [NOT] DISTINCT FROM` rather than `= / <>`: the JSON path yields NULL for an image with no
+ * stored scan error at all, and `NULL <> 'permanent'` is NULL — which a WHERE treats as false, so a
+ * plain `<>` would silently drop every image whose failure was never classified out of the review
+ * queue. Those are exactly the ordinary failures moderators are here to clear.
+ */
+const permanentScanFailure = sql`
+  i."scanJobs"->'error'->>'failureClass' IS NOT DISTINCT FROM ${IMAGE_SCAN_FAILURE_CLASS_PERMANENT}
+`;
+
+/**
+ * The human review queue: ingestion errors a moderator can still usefully rate — i.e. everything
+ * whose scan failure was NOT permanent (timeouts, container churn, unclassified failures). Images
+ * whose media can never be fetched are routed to the missing-media view instead, because rating one
+ * publishes a permanent 404.
+ *
+ * Shared by the queue and its badge: a divergence here is a count that never reaches zero.
+ */
+const ingestionErrorWhere = sql`
+  ${ingestionErrorBaseWhere}
+  AND NOT (${permanentScanFailure})
+`;
+
+/**
+ * The complement, over the same window: ingestion errors whose media the scanner could never fetch
+ * or decode. Same shared-const discipline — `getMissingMediaImages` and `countMissingMediaImages`
+ * both read this one value, so the page and its badge cannot disagree.
+ *
+ * Together with `ingestionErrorWhere` this is an exact partition of `ingestionErrorBaseWhere`: no
+ * image in the window is in both views, and none is in neither.
+ */
+const missingMediaWhere = sql`
+  ${ingestionErrorBaseWhere}
+  AND ${permanentScanFailure}
 `;
 
 export type IngestionErrorImage = {
@@ -106,6 +158,59 @@ export async function countIngestionErrorImages(): Promise<number> {
   return Number(result.rows[0]?.count ?? 0);
 }
 
+/**
+ * The missing-media view: same window, opposite side of the `failureClass` split. These images are
+ * NOT rateable — their file can never be fetched, so the only useful affordance is deleting them.
+ */
+export async function getMissingMediaImages({
+  limit,
+  cursor,
+}: {
+  limit: number;
+  cursor?: number;
+}): Promise<{ items: IngestionErrorImage[]; nextCursor?: number }> {
+  const result = await sql<IngestionErrorImage>`
+    SELECT i.id, i.url, i.name, i."nsfwLevel", i.type, i.width, i.height, i."createdAt"
+    FROM "Image" i
+    WHERE ${missingMediaWhere}
+      AND (${cursor != null ? sql`i.id < ${cursor}` : sql`TRUE`})
+    ORDER BY i."createdAt" DESC
+    LIMIT ${limit + 1}
+  `.execute(dbRead);
+
+  const items = result.rows;
+  let nextCursor: number | undefined;
+  if (items.length > limit) nextCursor = items.pop()?.id;
+
+  return { items, nextCursor };
+}
+
+/** The badge for `/images/missing-media` — same shared const as its queue, for the same reason. */
+export async function countMissingMediaImages(): Promise<number> {
+  const result = await sql<{ count: string }>`
+    SELECT count(*) AS count
+    FROM "Image" i
+    WHERE ${missingMediaWhere}
+  `.execute(dbRead);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+/**
+ * Ask the media store whether an image's object is actually there, as a three-valued answer.
+ *
+ * The storage client resolves `{ exists }` on a definitive answer and THROWS on anything else — a
+ * transport failure, a 5xx, a rotated credential, an unconfigured endpoint. That last shape is why
+ * the client is built inside the probe rather than at module scope: every one of them has to land
+ * on `unknown` and allow, and `assertMediaPresentForPublish` runs this inside its own try.
+ *
+ * Every image lives in the `b2Image` backend — the same assumption the image-deletion path makes,
+ * where `Image.url` is passed straight through as the object key.
+ */
+async function probeImageMediaPresence(key: string) {
+  const { exists } = await getStorage().headObject({ backend: 'b2Image', key });
+  return exists ? MediaPresence.Present : MediaPresence.Absent;
+}
+
 export async function resolveIngestionError({
   id,
   nsfwLevel,
@@ -117,10 +222,29 @@ export async function resolveIngestionError({
 }): Promise<void> {
   const image = await dbWrite
     .selectFrom('Image')
-    .select(['postId', 'metadata'])
+    .select(['postId', 'metadata', 'url'])
     .where('id', '=', id)
     .executeTakeFirst();
   if (!image) throw new Error('Image not found');
+
+  /**
+   * 🔴 REFUSE TO PUBLISH AN IMAGE WHOSE MEDIA IS GONE.
+   *
+   * This is the call site that caused the incident. Everything below makes the image visible —
+   * `ingestion = 'Scanned'` plus a locked nsfwLevel — and it ran unconditionally, so an image whose
+   * file can never be fetched was rated by a human exactly like a scan that merely timed out, and
+   * publishing it put a permanent 404 on the site. The `failureClass` split above keeps these off
+   * the queue; this is the write-side guard, and it is the authority: the queue predicate is a
+   * trigger, an existence check against the store is the verdict.
+   *
+   * Three-valued and only `absent` refuses — an unconsultable store must not block moderation. The
+   * thrown message reaches the moderator verbatim through the action's `fail(400, { error })`.
+   */
+  await assertMediaPresentForPublish({
+    probe: () => probeImageMediaPresence(image.url),
+    onUnknown: (error) =>
+      console.warn('[ingestion] media probe inconclusive; allowing publish', id, error),
+  });
 
   const metadata = {
     ...((image.metadata as Record<string, unknown> | null) ?? {}),

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -72,30 +72,52 @@ const ingestionErrorState = sql`
 `;
 
 /**
- * 🔴 THE 2-DAY LOWER BOUND IS A REAL LIMIT ON REACH, AND BOTH QUEUES INHERIT IT.
+ * 🔴 THE WINDOW IS A REAL LIMIT ON REACH IN BOTH DIRECTIONS, AND BOTH QUEUES INHERIT IT.
  *
- * It is right for the RATING queue: a moderator rates recent scan errors, and an unbounded backlog
- * of old ones is not work anybody is going to do. It is less obviously right for the missing-media
- * queue, whose rows are terminal — they only leave it by being deleted — and whose motivating
- * population, `blob:` urls from a legacy upload bug (`src/utils/type-guards.ts`), is plausibly
- * mostly OLDER than two days. That is inference from where the bug came from, not a production
- * count; nobody has measured it.
+ * TWO bounds, not one: `createdAt` must be older than 1 hour AND younger than 2 days. The 1-hour
+ * bound predates this app — it arrived with the original main-app query in `3575ab0413` and again
+ * in the cutover `e4104d5bf1`, in both cases with NO comment — so the reason for it is not recorded
+ * anywhere and is not restated here as though it were. What matters for the copy on the page is the
+ * EFFECT, which is measurable: a row younger than an hour is not listed.
  *
- * So the state of play, said rather than glossed: an unpublishable row older than two days is
- * deletable by the POST action (`missingMediaScope` deliberately drops the window — see that const)
- * but is rendered by NO page here. The copy in `@civitai/shared/missing-media` and on the article
- * surface is written so it does not promise a queue that will list such a row.
+ * The lower bound is right for the RATING queue: a moderator rates recent scan errors, and an
+ * unbounded backlog of old ones is not work anybody is going to do. It is less obviously right for
+ * the missing-media queue, whose rows are terminal — they only leave it by being deleted — and
+ * whose motivating population, `blob:` urls from a legacy upload bug (`src/utils/type-guards.ts`),
+ * is plausibly mostly OLDER than two days. That is inference from where the bug came from, not a
+ * production count; nobody has measured it.
+ *
+ * So the state of play, said rather than glossed: an unpublishable row on EITHER side of the window
+ * — older than two days, or younger than an hour — is deletable by the POST action
+ * (`missingMediaScope` deliberately drops both bounds; see that const) but is rendered by NO page
+ * here. The copy in `@civitai/shared/missing-media`, on this page, and on the article surface is
+ * written so it does not promise a queue that will list such a row.
  *
  * Widening it was considered and NOT taken, for a reason that is worth writing down because it is
- * not the obvious one: both queues order `createdAt DESC`, so dropping the bound would put the old
- * `blob:` rows at the BACK of an unbounded list behind every historical permanent scan failure —
- * burying the motivating population rather than surfacing it, at an unmeasured queue size. The one
- * query that would settle whether widening is worth it, and what shape it should take:
+ * not the obvious one: both queues order `createdAt DESC`, so dropping the lower bound would put
+ * the old `blob:` rows at the BACK of an unbounded list behind every historical permanent scan
+ * failure — burying the motivating population rather than surfacing it, at an unmeasured queue
+ * size. The one query that would settle whether widening is worth it, and what shape it should
+ * take, counts the WHOLE stranded set: both sides of the window, and both disjuncts of
+ * `unpublishableMedia` rather than the `blob:` half alone.
  *
- *     SELECT count(*) FROM "Image"
- *      WHERE ingestion = 'Error' AND "nsfwLevel" = 0
- *        AND "createdAt" < now() - INTERVAL '2 days'
- *        AND url LIKE 'blob:%';
+ *     SELECT
+ *       count(*) FILTER (WHERE "createdAt" < now() - INTERVAL '2 days')  AS too_old,
+ *       count(*) FILTER (WHERE "createdAt" > now() - INTERVAL '1 hour')  AS too_new,
+ *       count(*) FILTER (WHERE url LIKE 'blob:%')                        AS unrenderable_url,
+ *       count(*) FILTER (
+ *         WHERE "scanJobs"->'error'->>'failureClass' IS NOT DISTINCT FROM 'permanent'
+ *       )                                                                AS permanent_failure,
+ *       count(*)                                                         AS total
+ *     FROM "Image"
+ *     WHERE ingestion = 'Error' AND "nsfwLevel" = 0
+ *       AND ( "scanJobs"->'error'->>'failureClass' IS NOT DISTINCT FROM 'permanent'
+ *             OR COALESCE(url, '') LIKE 'blob:%' )
+ *       AND ( "createdAt" < now() - INTERVAL '2 days'
+ *             OR "createdAt" > now() - INTERVAL '1 hour' );
+ *
+ * (The `too_old`/`too_new` columns overlap with nothing — the WHERE already excludes the window —
+ * so they sum to `total`, while the two disjunct columns can both count the same row.)
  */
 const ingestionErrorBaseWhere = sql`
   i."createdAt" > now() - INTERVAL '2 days'
@@ -147,8 +169,10 @@ const permanentScanFailure = sql`
  * `permanent OR NULL` is NULL whenever the class is not permanent, which a WHERE treats as false on
  * BOTH sides of the split, dropping the row out of the review queue and the missing-media queue at
  * once. Same shape as the `IS NOT DISTINCT FROM` trap one predicate up, in the other operator. The
- * NOT NULL constraint itself is pinned by this module's test, so if it ever goes away that is a
- * visible failure rather than a silent re-partition.
+ * DECLARED NOT NULL constraint is pinned by this module's test, so if it goes away in the repo that
+ * is a visible failure rather than a silent re-partition. Only the declaration, though — migrations
+ * here are applied by hand, so a live column that has drifted from the schema is not caught by
+ * anything, which is the residual reason the COALESCE stays.
  */
 const unrenderableMediaUrl = sql`
   COALESCE(i.url, '') LIKE ${`${UNRENDERABLE_MEDIA_URL_PREFIX}%`}
@@ -384,8 +408,28 @@ export async function countMissingMediaImages(): Promise<number> {
  * the client is built inside the probe rather than at module scope: every one of them has to land
  * on `unknown` and allow, and `assertMediaPresentForPublish` runs this inside its own try.
  *
- * Every image lives in the `b2Image` backend — the same assumption the image-deletion path makes,
- * where `Image.url` is passed straight through as the object key.
+ * Every image lives in the `b2Image` backend — the same assumption the image-deletion path in this
+ * app makes, where `Image.url` is passed straight through as the object key.
+ *
+ * 🔴 `'b2Image'` IS AN ALIAS, NOT A BUCKET — AND IT IS A DIFFERENT SOURCE OF TRUTH FROM THE MAIN
+ * APP'S. It is a member of `@civitai/storage`'s wire enum (`packages/civitai-storage/src/schema.ts`)
+ * that the `apps/storage` service resolves in its own process
+ * (`apps/storage/src/lib/server/backends.ts`) from its own `S3_IMAGE_B2_ENDPOINT` /
+ * `S3_IMAGE_B2_BUCKET` — same variable NAMES as the main app's, but a different deployment and a
+ * different Secret. The main app's probe resolves through `getImageUploadBackend()`, i.e. the
+ * function its uploader uses, so there it cannot ask a different store from the one that wrote the
+ * key. Here there is no such function to route through: the two agree today because the two
+ * deployments are configured to the same bucket, which is a fact about config, not about code.
+ *
+ * That matters only if the upload store MOVES, and the two ways it would then break are NOT the
+ * same. A live endpoint on the WRONG bucket 404s for every key, i.e. `absent`, which refuses every
+ * publish — fail-closed, no broken image reaches the site, but indistinguishable from a real run of
+ * misses (the `onRefused` counter at `resolveIngestionError` exists for exactly that). An endpoint
+ * left UNCONFIGURED instead THROWS, which lands on `unknown`, and `unknown` ALLOWS — the silent
+ * direction. Neither is caught by anything in this repo, because both are config.
+ *
+ * Recorded so the next person moving that store knows this is a third place to change and not a
+ * copy of the main app's resolver.
  */
 async function probeImageMediaPresence(key: string) {
   // 🔴 No key check here, deliberately. `assertMediaPresentForPublish` classifies the url and only

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -65,11 +65,15 @@ export async function countImagesPendingIngestion(): Promise<number> {
  * below can differ in exactly ONE predicate — whether the scan failed permanently — and cannot
  * drift in the window, the ingestion state, or the level bound.
  */
+const ingestionErrorState = sql`
+  i.ingestion = 'Error'::"ImageIngestionStatus"
+  AND i."nsfwLevel" = 0
+`;
+
 const ingestionErrorBaseWhere = sql`
   i."createdAt" > now() - INTERVAL '2 days'
   AND i."createdAt" < now() - INTERVAL '1 hour'
-  AND i.ingestion = 'Error'::"ImageIngestionStatus"
-  AND i."nsfwLevel" = 0
+  AND ${ingestionErrorState}
 `;
 
 /**
@@ -131,12 +135,18 @@ const missingMediaWhere = sql`
  * at `ingestion = 'Error'`.
  *
  * What actually makes a delete safe is the image's STATE — an unpublished ingestion error whose scan
- * failed permanently — and that does not expire. So the gate asserts the state and the queue applies
- * the window on top.
+ * failed permanently — and that does not expire. So the gate asserts the state, composed from the
+ * SAME `ingestionErrorState` the queue uses so the two cannot drift on it, and the queue applies the
+ * window on top.
+ *
+ * Note this drops BOTH window bounds, the 1-hour lower one included, so a very new row the page does
+ * not yet render is deletable by a hand-crafted POST. Checked, and safe: `permanent` is a terminal
+ * class — `IMAGE_SCAN_PERMANENT_RETRY_LIMIT` is 1 and `markImageScanError` has already spent it — so
+ * such a row is never re-driven into a different state by the ingest cron, and rows predating the
+ * classification carry a NULL `failureClass`, which `IS NOT DISTINCT FROM` excludes.
  */
 const missingMediaScope = sql`
-  i.ingestion = 'Error'::"ImageIngestionStatus"
-  AND i."nsfwLevel" = 0
+  ${ingestionErrorState}
   AND ${permanentScanFailure}
 `;
 
@@ -238,11 +248,20 @@ export async function isMissingMediaImage(id: number): Promise<boolean> {
  * `try/catch` that logs and continues, and its only un-caught statement is a `void`-ed async call —
  * so a resolved promise is not evidence that anything was deleted. Without this the action reports
  * success and the mod-activity record attests a delete that never happened.
+ *
+ * 🔴 READS THE PRIMARY, and must keep doing so. This is a read-your-write: the delete happened on
+ * `dbWrite` milliseconds earlier, and `dbRead` is a SEPARATE pool on the replica connection string
+ * (`./db.ts`). Any replica lag past that round trip makes a SUCCESSFUL delete read as "still
+ * present" — producing a false failure and, worse, NO audit row for a delete that did happen. That
+ * is the precise mirror of the bug this function exists to prevent, on the same artefact.
+ *
+ * `getLiveStrikes({ readYourWrite })` in `./user-lookup.service.ts` is the same call shape with the
+ * same reasoning already written out; this follows it.
  */
 export async function imageRowExists(id: number): Promise<boolean> {
   const result = await sql<{ id: number }>`
     SELECT i.id FROM "Image" i WHERE i.id = ${id} LIMIT 1
-  `.execute(dbRead);
+  `.execute(dbWrite);
   return result.rows.length > 0;
 }
 

--- a/apps/moderator/src/lib/server/ingestion.service.ts
+++ b/apps/moderator/src/lib/server/ingestion.service.ts
@@ -3,13 +3,14 @@ import { REDIS_KEYS } from '@civitai/redis';
 import {
   assertMediaPresentForPublish,
   IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
+  isProbeableMediaKey,
   MediaPresence,
 } from '@civitai/shared';
 import { dbRead, dbWrite } from './db';
 import { bustCachedObject } from './cache';
 import { syncSearchIndex } from './search-index';
 import { recordModActivity } from './mod-activity';
-import { getStorage } from './storage';
+import { getMediaProbeStorage } from './storage';
 import type { MediaType } from '$lib/media/edge-url';
 
 export type PendingIngestionImage = {
@@ -74,9 +75,15 @@ const ingestionErrorBaseWhere = sql`
 /**
  * The scan pipeline's own stored classification of an unfetchable/undecodable input.
  *
- * 🔴 Deliberately NOT a match on the scanner's reason text. A `reason ILIKE '%download%'` predicate
- * is a spelled guard: one scanner reword and every permanently-broken image walks back into the
- * review queue. `failureClass` is written at scan time from a fixed set, so it survives a reword.
+ * 🔴 Deliberately NOT a match on the scanner's reason text HERE. A `reason ILIKE '%download%'`
+ * predicate in this query would be a spelled guard: one scanner reword and every permanently-broken
+ * image walks back into the review queue, silently, at query time.
+ *
+ * Being honest about what that does and does not buy: the stored CLASS is a fixed enum, but the
+ * classification that produces it is itself a substring match on the scanner's prose, one layer up
+ * in `image-scan-failure.ts`. So a reword still moves images between these two queues — it just
+ * does so at SCAN time, on new rows, where it is visible in that module's own tests, rather than
+ * silently re-partitioning every historical row the next time this query runs.
  *
  * `IS [NOT] DISTINCT FROM` rather than `= / <>`: the JSON path yields NULL for an image with no
  * stored scan error at all, and `NULL <> 'permanent'` is NULL — which a WHERE treats as false, so a
@@ -185,6 +192,25 @@ export async function getMissingMediaImages({
   return { items, nextCursor };
 }
 
+/**
+ * Is this image actually in the missing-media set right now?
+ *
+ * The page's delete action takes an id off a form, and deleting an image is permanent and
+ * cascading (row + stored object + de-index). Re-selecting through the SAME shared predicate is
+ * what keeps the action scoped to what the page shows, instead of turning a moderator route into an
+ * arbitrary delete-by-id. Uses `missingMediaWhere`, so it cannot drift from the queue or its badge.
+ */
+export async function isMissingMediaImage(id: number): Promise<boolean> {
+  const result = await sql<{ id: number }>`
+    SELECT i.id
+    FROM "Image" i
+    WHERE ${missingMediaWhere}
+      AND i.id = ${id}
+    LIMIT 1
+  `.execute(dbRead);
+  return result.rows.length > 0;
+}
+
 /** The badge for `/images/missing-media` — same shared const as its queue, for the same reason. */
 export async function countMissingMediaImages(): Promise<number> {
   const result = await sql<{ count: string }>`
@@ -206,8 +232,13 @@ export async function countMissingMediaImages(): Promise<number> {
  * Every image lives in the `b2Image` backend — the same assumption the image-deletion path makes,
  * where `Image.url` is passed straight through as the object key.
  */
-async function probeImageMediaPresence(key: string) {
-  const { exists } = await getStorage().headObject({ backend: 'b2Image', key });
+async function probeImageMediaPresence(url: string) {
+  // 🔴 Not every `Image.url` is a bucket key — see `isProbeableMediaKey`. This is also what keeps
+  // the two runtimes agreeing: their storage clients fail DIFFERENTLY on a non-key url (the main
+  // app's 404s to `absent`; this one throws on an empty parsed bucket to `unknown`), so deciding it
+  // here rather than in each probe is the difference between one rule and two.
+  if (!isProbeableMediaKey(url)) return MediaPresence.Unknown;
+  const { exists } = await getMediaProbeStorage().headObject({ backend: 'b2Image', key: url });
   return exists ? MediaPresence.Present : MediaPresence.Absent;
 }
 
@@ -244,6 +275,9 @@ export async function resolveIngestionError({
     probe: () => probeImageMediaPresence(image.url),
     onUnknown: (error) =>
       console.warn('[ingestion] media probe inconclusive; allowing publish', id, error),
+    // The mirror of onUnknown: a wrong bucket name 404s for EVERY key, so a fail-CLOSED
+    // misconfiguration would refuse every publish and look exactly like a real run of misses.
+    onRefused: () => console.warn('[ingestion] refused publish; media object reported absent', id),
   });
 
   const metadata = {

--- a/apps/moderator/src/lib/server/sidebar-counts.service.ts
+++ b/apps/moderator/src/lib/server/sidebar-counts.service.ts
@@ -4,7 +4,11 @@ import { createCache } from './cache';
 import { dbRead } from './db';
 import { bounded } from './bounded';
 import { getImageReviewCounts } from './image-review.service';
-import { countImagesPendingIngestion, countIngestionErrorImages } from './ingestion.service';
+import {
+  countImagesPendingIngestion,
+  countIngestionErrorImages,
+  countMissingMediaImages,
+} from './ingestion.service';
 import { getImageRatingReviewCount } from './image-rating-review.service';
 import { countModeratorArticles } from './articles.service';
 import { getArticleRatingReviewCounts } from './article-rating-reviews.service';
@@ -30,6 +34,7 @@ async function fetchCounts(): Promise<SidebarCounts> {
     reports,
     toIngest,
     ingestionErrors,
+    missingMedia,
   ] = await Promise.all([
     getImageReviewCounts(),
     // Bitmask predicates must match the TagsOnImageNew_needsReview_idx partial index (bit 9 set, bit 10 clear).
@@ -63,6 +68,7 @@ async function fetchCounts(): Promise<SidebarCounts> {
     // neither predicate has an index of its own; see `bounded`.
     bounded(countImagesPendingIngestion),
     bounded(countIngestionErrorImages),
+    bounded(countMissingMediaImages),
   ]);
   return {
     ...modes,
@@ -75,5 +81,6 @@ async function fetchCounts(): Promise<SidebarCounts> {
     articleRatings: articleRatings.Pending,
     ...(toIngest != null ? { toIngest } : {}),
     ...(ingestionErrors != null ? { ingestionErrors } : {}),
+    ...(missingMedia != null ? { missingMedia } : {}),
   };
 }

--- a/apps/moderator/src/lib/server/storage.ts
+++ b/apps/moderator/src/lib/server/storage.ts
@@ -8,3 +8,25 @@ export function getStorage(): ReturnType<typeof createStorageClient> {
     client = createStorageClient({ endpoint: env.STORAGE_ENDPOINT, token: env.STORAGE_TOKEN });
   return client;
 }
+
+let probeClient: ReturnType<typeof createStorageClient> | undefined;
+
+/**
+ * A SEPARATE client for existence probes that sit on a moderator's click path.
+ *
+ * The default config is `timeoutMs: 10_000, retries: 2` — up to three attempts plus backoff, so a
+ * degraded store turns one click into ~31 s of waiting. That budget is right for the write
+ * operations `getStorage()` serves and wrong for a guard: a probe that cannot answer quickly is
+ * simply `unknown`, and `unknown` allows, so waiting longer buys nothing. Bounded to ONE attempt at
+ * 5 s, matching the budget the main app's copy of this guard already uses.
+ */
+export function getMediaProbeStorage(): ReturnType<typeof createStorageClient> {
+  if (!probeClient)
+    probeClient = createStorageClient({
+      endpoint: env.STORAGE_ENDPOINT,
+      token: env.STORAGE_TOKEN,
+      timeoutMs: 5_000,
+      retries: 0,
+    });
+  return probeClient;
+}

--- a/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
+++ b/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
@@ -15,6 +15,7 @@ const getIngestionErrorImages = vi.fn(async () => ({ items: [] }));
 const getMissingMediaImages = vi.fn(async () => ({ items: [] }));
 const deleteImagesByIds = vi.fn();
 const isMissingMediaImage = vi.fn(async () => true);
+const imageRowExists = vi.fn(async () => false);
 const recordModActivity = vi.fn();
 
 vi.mock('$lib/server/ingestion.service', () => ({
@@ -22,6 +23,7 @@ vi.mock('$lib/server/ingestion.service', () => ({
   getIngestionErrorImages,
   getMissingMediaImages,
   isMissingMediaImage,
+  imageRowExists,
 }));
 vi.mock('$lib/server/image-deletion', () => ({ deleteImagesByIds }));
 vi.mock('$lib/server/mod-activity', () => ({ recordModActivity }));
@@ -42,9 +44,14 @@ const locals = { user: { id: 7 } } as never;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // `clearAllMocks` clears calls, not implementations — but re-stating it keeps each case's
-  // starting point explicit rather than inherited from whichever test ran last.
+  // 🔴 `clearAllMocks` clears CALLS, not IMPLEMENTATIONS. Every mock whose implementation any test
+  // changes must be restored here or it leaks into whatever runs next — the defect class that
+  // already made one suite in this PR pass for the wrong reason. Listing all three, not just the
+  // one that bit us: `deleteImagesByIds` carries both a resolve and a reject below, and was benign
+  // only by accident of test order.
   isMissingMediaImage.mockResolvedValue(true);
+  imageRowExists.mockResolvedValue(false);
+  deleteImagesByIds.mockResolvedValue(undefined);
 });
 
 describe('ingestion-errors resolve action', () => {
@@ -131,13 +138,41 @@ describe('missing-media delete action — scoping', () => {
     });
   });
 
-  it('records nothing when the delete itself failed', async () => {
-    deleteImagesByIds.mockRejectedValue(new Error('storage exploded'));
+  it('records nothing when the delete SILENTLY failed and the row survived', async () => {
+    /**
+     * 🔴 The reachable shape, and the one that shipped broken. `deleteImagesByIds` wraps every
+     * per-image body in a try/catch that logs and continues, so a failed DB or storage step
+     * RESOLVES. An earlier revision of this test used `mockRejectedValue` — a state the real
+     * function cannot reach — so it read as coverage while providing none, and the action happily
+     * reported success and wrote an audit row for an image still on the site.
+     */
+    deleteImagesByIds.mockResolvedValue(undefined); // resolves, exactly as the real one does
+    imageRowExists.mockResolvedValue(true); // ...but the row is still there
+
     const result = (await missingActions.delete({
       request: request({ id: '4242' }),
       locals,
-    } as never)) as { status: number };
+    } as never)) as { status: number; data: { error: string } };
+
     expect(result.status).toBe(400);
+    expect(result.data.error).toBe(
+      'The delete did not complete — the image is still present. Nothing was recorded.'
+    );
+    // The whole point: no audit row attesting a delete that did not happen.
     expect(recordModActivity).not.toHaveBeenCalled();
+  });
+
+  it('confirms the row is gone before attributing, not merely that the call resolved', async () => {
+    deleteImagesByIds.mockResolvedValue(undefined);
+    imageRowExists.mockResolvedValue(false);
+
+    const result = await missingActions.delete({
+      request: request({ id: '4242' }),
+      locals,
+    } as never);
+
+    expect(imageRowExists).toHaveBeenCalledWith(4242);
+    expect(result).toEqual({ success: true, id: 4242 });
+    expect(recordModActivity).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
+++ b/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
@@ -112,7 +112,7 @@ describe('missing-media delete action', () => {
 });
 
 describe('missing-media delete action — scoping', () => {
-  it('refuses an id that is not in the missing-media queue, and deletes nothing', async () => {
+  it('refuses an id that is not an unpublishable ingestion error, and deletes nothing', async () => {
     // The action takes an id off a form and `deleteImagesByIds` is permanent and cascading. Without
     // this re-selection the page is an arbitrary delete-any-image-by-id endpoint.
     isMissingMediaImage.mockResolvedValue(false);
@@ -123,7 +123,13 @@ describe('missing-media delete action — scoping', () => {
     } as never)) as { status: number; data: { error: string } };
 
     expect(result.status).toBe(400);
-    expect(result.data.error).toBe('That image is not in the missing-media queue.');
+    // Pinned WHOLE, and it must NOT name the queue: the gate is `missingMediaScope`, which drops
+    // the display window on purpose, so a refusal phrased as "not in the queue" describes a
+    // different set from the one it actually rejects.
+    expect(result.data.error).toBe(
+      'That image cannot be deleted here — it is not an unpublishable ingestion error.'
+    );
+    expect(result.data.error).not.toContain('queue');
     expect(deleteImagesByIds).not.toHaveBeenCalled();
     expect(recordModActivity).not.toHaveBeenCalled();
   });

--- a/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
+++ b/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
@@ -47,8 +47,9 @@ beforeEach(() => {
   // 🔴 `clearAllMocks` clears CALLS, not IMPLEMENTATIONS. Every mock whose implementation any test
   // changes must be restored here or it leaks into whatever runs next — the defect class that
   // already made one suite in this PR pass for the wrong reason. Listing all three, not just the
-  // one that bit us: `deleteImagesByIds` carries both a resolve and a reject below, and was benign
-  // only by accident of test order.
+  // one that bit us. `deleteImagesByIds` no longer carries a reject (that test pinned a state the
+  // real function cannot reach and was replaced), but it IS reassigned per case, so it is reset
+  // here rather than relying on the order the cases happen to run in.
   isMissingMediaImage.mockResolvedValue(true);
   imageRowExists.mockResolvedValue(false);
   deleteImagesByIds.mockResolvedValue(undefined);

--- a/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
+++ b/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MISSING_MEDIA_PUBLISH_MESSAGE, MissingMediaError } from '@civitai/shared';
+
+/**
+ * The two page actions behind the ingestion-error split.
+ *
+ * The refusal message is USER-FACING: the guard throws it deep in the service, and the only thing
+ * that makes a moderator ever see it is this action turning the error into `fail(400, { error })`.
+ * A guard whose message never reaches the screen leaves the moderator staring at a generic failure
+ * and re-clicking, which is how the original defect stayed invisible.
+ */
+
+const resolveIngestionError = vi.fn();
+const getIngestionErrorImages = vi.fn(async () => ({ items: [] }));
+const getMissingMediaImages = vi.fn(async () => ({ items: [] }));
+const deleteImagesByIds = vi.fn();
+
+vi.mock('$lib/server/ingestion.service', () => ({
+  resolveIngestionError,
+  getIngestionErrorImages,
+  getMissingMediaImages,
+}));
+vi.mock('$lib/server/image-deletion', () => ({ deleteImagesByIds }));
+
+const { actions: errorActions } = await import('../ingestion-errors/+page.server');
+const { actions: missingActions } = await import('../missing-media/+page.server');
+
+const request = (fields: Record<string, string>) =>
+  ({
+    formData: async () => {
+      const form = new FormData();
+      for (const [k, v] of Object.entries(fields)) form.set(k, v);
+      return form;
+    },
+  } as never);
+
+const locals = { user: { id: 7 } } as never;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('ingestion-errors resolve action', () => {
+  it('renders the missing-media refusal to the moderator as a 400 carrying the message', async () => {
+    resolveIngestionError.mockRejectedValue(new MissingMediaError());
+
+    const result = (await errorActions.resolve({
+      request: request({ id: '4242', nsfwLevel: '1' }),
+      locals,
+    } as never)) as { status: number; data: { error: string } };
+
+    expect(result.status).toBe(400);
+    expect(result.data.error).toBe(MISSING_MEDIA_PUBLISH_MESSAGE);
+  });
+
+  it('still reports success for an image the guard allowed', async () => {
+    resolveIngestionError.mockResolvedValue(undefined);
+
+    const result = await errorActions.resolve({
+      request: request({ id: '4242', nsfwLevel: '1' }),
+      locals,
+    } as never);
+
+    expect(result).toEqual({ success: true, id: 4242, nsfwLevel: 1 });
+  });
+});
+
+describe('missing-media delete action', () => {
+  it('deletes exactly the image it was given', async () => {
+    deleteImagesByIds.mockResolvedValue(undefined);
+
+    const result = await missingActions.delete({
+      request: request({ id: '4242' }),
+      locals,
+    } as never);
+
+    expect(deleteImagesByIds).toHaveBeenCalledWith([4242]);
+    expect(result).toEqual({ success: true, id: 4242 });
+  });
+
+  it('offers no way to publish — resolve is not an action on this page', () => {
+    // The whole reason the view exists. A `resolve` action here would put the rating buttons back
+    // in front of images that can never be rated.
+    expect(Object.keys(missingActions)).toEqual(['delete']);
+  });
+
+  it('rejects a request with no image id', async () => {
+    const result = (await missingActions.delete({
+      request: request({}),
+      locals,
+    } as never)) as { status: number; data: { error: string } };
+
+    expect(result.status).toBe(400);
+    expect(result.data.error).toBe('Missing image id');
+    expect(deleteImagesByIds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
+++ b/apps/moderator/src/routes/images/__tests__/ingestion-error-actions.test.ts
@@ -14,13 +14,17 @@ const resolveIngestionError = vi.fn();
 const getIngestionErrorImages = vi.fn(async () => ({ items: [] }));
 const getMissingMediaImages = vi.fn(async () => ({ items: [] }));
 const deleteImagesByIds = vi.fn();
+const isMissingMediaImage = vi.fn(async () => true);
+const recordModActivity = vi.fn();
 
 vi.mock('$lib/server/ingestion.service', () => ({
   resolveIngestionError,
   getIngestionErrorImages,
   getMissingMediaImages,
+  isMissingMediaImage,
 }));
 vi.mock('$lib/server/image-deletion', () => ({ deleteImagesByIds }));
+vi.mock('$lib/server/mod-activity', () => ({ recordModActivity }));
 
 const { actions: errorActions } = await import('../ingestion-errors/+page.server');
 const { actions: missingActions } = await import('../missing-media/+page.server');
@@ -36,7 +40,12 @@ const request = (fields: Record<string, string>) =>
 
 const locals = { user: { id: 7 } } as never;
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  // `clearAllMocks` clears calls, not implementations — but re-stating it keeps each case's
+  // starting point explicit rather than inherited from whichever test ran last.
+  isMissingMediaImage.mockResolvedValue(true);
+});
 
 describe('ingestion-errors resolve action', () => {
   it('renders the missing-media refusal to the moderator as a 400 carrying the message', async () => {
@@ -91,5 +100,44 @@ describe('missing-media delete action', () => {
     expect(result.status).toBe(400);
     expect(result.data.error).toBe('Missing image id');
     expect(deleteImagesByIds).not.toHaveBeenCalled();
+  });
+});
+
+describe('missing-media delete action — scoping', () => {
+  it('refuses an id that is not in the missing-media queue, and deletes nothing', async () => {
+    // The action takes an id off a form and `deleteImagesByIds` is permanent and cascading. Without
+    // this re-selection the page is an arbitrary delete-any-image-by-id endpoint.
+    isMissingMediaImage.mockResolvedValue(false);
+
+    const result = (await missingActions.delete({
+      request: request({ id: '4242' }),
+      locals,
+    } as never)) as { status: number; data: { error: string } };
+
+    expect(result.status).toBe(400);
+    expect(result.data.error).toBe('That image is not in the missing-media queue.');
+    expect(deleteImagesByIds).not.toHaveBeenCalled();
+    expect(recordModActivity).not.toHaveBeenCalled();
+  });
+
+  it('attributes the delete to the moderator who performed it', async () => {
+    deleteImagesByIds.mockResolvedValue(undefined);
+    await missingActions.delete({ request: request({ id: '4242' }), locals } as never);
+    expect(recordModActivity).toHaveBeenCalledWith({
+      userId: 7,
+      entityType: 'image',
+      entityId: 4242,
+      activity: 'deleteMissingMedia',
+    });
+  });
+
+  it('records nothing when the delete itself failed', async () => {
+    deleteImagesByIds.mockRejectedValue(new Error('storage exploded'));
+    const result = (await missingActions.delete({
+      request: request({ id: '4242' }),
+      locals,
+    } as never)) as { status: number };
+    expect(result.status).toBe(400);
+    expect(recordModActivity).not.toHaveBeenCalled();
   });
 });

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -1,6 +1,10 @@
 import { fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import { getMissingMediaImages, isMissingMediaImage } from '$lib/server/ingestion.service';
+import {
+  getMissingMediaImages,
+  imageRowExists,
+  isMissingMediaImage,
+} from '$lib/server/ingestion.service';
 import { deleteImagesByIds } from '$lib/server/image-deletion';
 import { recordModActivity } from '$lib/server/mod-activity';
 
@@ -39,14 +43,32 @@ export const actions: Actions = {
     if (!(await isMissingMediaImage(id)))
       return fail(400, { error: 'That image is not in the missing-media queue.' });
 
+    // Kept for a genuine throw, but note it is nearly dead: see below.
     try {
       await deleteImagesByIds([id]);
     } catch (e) {
       return fail(400, { error: e instanceof Error ? e.message : 'Failed to delete.' });
     }
 
-    // Every other mutating moderator action is attributed; a permanent destructive one especially
-    // should not land anonymously. After the delete, so a failed delete records nothing.
+    /**
+     * 🔴 A RESOLVED `deleteImagesByIds` IS NOT EVIDENCE THE IMAGE IS GONE.
+     *
+     * It wraps every per-image body in a `try/catch` that logs and continues, and its only statement
+     * outside a try is a `void`-ed async call — so it effectively never rejects. A failed DB or
+     * storage step returns normally, which previously produced `{ success: true }`, a card rendering
+     * "Deleted", and a `deleteMissingMedia` audit row attesting a delete that never happened, all
+     * for an image still on the site.
+     *
+     * So confirm by reading the row back. Cheap, and it is the difference between an audit log that
+     * records outcomes and one that records intentions.
+     */
+    if (await imageRowExists(id))
+      return fail(400, {
+        error: 'The delete did not complete — the image is still present. Nothing was recorded.',
+      });
+
+    // Attributed only once the delete is CONFIRMED. Every other mutating moderator action is
+    // attributed; a permanent destructive one especially should not land anonymously.
     await recordModActivity({
       userId: locals.user.id,
       entityType: 'image',

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -1,15 +1,16 @@
 import { fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import { getMissingMediaImages } from '$lib/server/ingestion.service';
+import { getMissingMediaImages, isMissingMediaImage } from '$lib/server/ingestion.service';
 import { deleteImagesByIds } from '$lib/server/image-deletion';
+import { recordModActivity } from '$lib/server/mod-activity';
 
 const LIMIT_OPTIONS = [10, 25, 50, 100];
 
 /**
- * Images whose scan failed permanently because the media itself could not be fetched. They are
- * carved out of `/images/ingestion-errors` deliberately: rating one there set `ingestion='Scanned'`
- * and published a permanent 404. There is no rating affordance here, because there is nothing to
- * rate — the only useful action is removing the row.
+ * Images whose scan failed permanently because the media itself could not be fetched or decoded.
+ * They are carved out of `/images/ingestion-errors` deliberately: rating one there set
+ * `ingestion='Scanned'` and published a permanent 404. There is no rating affordance here, because
+ * these can never be scanned — the only useful action is removing the row.
  */
 export const load: PageServerLoad = async ({ url }) => {
   const limitParam = Number(url.searchParams.get('limit'));
@@ -22,16 +23,37 @@ export const load: PageServerLoad = async ({ url }) => {
 
 // Access is enforced globally (hooks.server.ts).
 export const actions: Actions = {
-  delete: async ({ request }) => {
+  delete: async ({ request, locals }) => {
     const form = await request.formData();
     const id = Number(form.get('id'));
     if (!id) return fail(400, { error: 'Missing image id' });
+
+    /**
+     * 🔴 SCOPE THE DELETE TO WHAT THIS PAGE SHOWS.
+     *
+     * `deleteImagesByIds` is permanent and cascading — row, stored object, search de-index — and
+     * the id arrives on a form. Every other caller in the app hands it a server-computed id set;
+     * without this re-selection through the SAME shared predicate the page is an arbitrary
+     * delete-any-image-by-id endpoint that merely happens to render the missing-media queue.
+     */
+    if (!(await isMissingMediaImage(id)))
+      return fail(400, { error: 'That image is not in the missing-media queue.' });
 
     try {
       await deleteImagesByIds([id]);
     } catch (e) {
       return fail(400, { error: e instanceof Error ? e.message : 'Failed to delete.' });
     }
+
+    // Every other mutating moderator action is attributed; a permanent destructive one especially
+    // should not land anonymously. After the delete, so a failed delete records nothing.
+    await recordModActivity({
+      userId: locals.user.id,
+      entityType: 'image',
+      entityId: id,
+      activity: 'deleteMissingMedia',
+    });
+
     return { success: true, id };
   },
 };

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -11,10 +11,15 @@ import { recordModActivity } from '$lib/server/mod-activity';
 const LIMIT_OPTIONS = [10, 25, 50, 100];
 
 /**
- * Images whose scan failed permanently because the media itself could not be fetched or decoded.
+ * Images that can never be published: the media itself could not be fetched or decoded (a permanent
+ * scan failure), or the url is a browser-session `blob:` handle that can never render for anyone.
  * They are carved out of `/images/ingestion-errors` deliberately: rating one there set
  * `ingestion='Scanned'` and published a permanent 404. There is no rating affordance here, because
  * these can never be scanned — the only useful action is removing the row.
+ *
+ * 🔴 This page is the REACHABLE ACTION behind both refusals `assertMediaPresentForPublish` throws.
+ * The rating queue now 400s on these rows, so if `missingMediaWhere` ever stopped selecting one of
+ * them the moderator would have no action left at all. That is why the two predicates are one const.
  */
 export const load: PageServerLoad = async ({ url }) => {
   const limitParam = Number(url.searchParams.get('limit'));

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -1,0 +1,37 @@
+import { fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { getMissingMediaImages } from '$lib/server/ingestion.service';
+import { deleteImagesByIds } from '$lib/server/image-deletion';
+
+const LIMIT_OPTIONS = [10, 25, 50, 100];
+
+/**
+ * Images whose scan failed permanently because the media itself could not be fetched. They are
+ * carved out of `/images/ingestion-errors` deliberately: rating one there set `ingestion='Scanned'`
+ * and published a permanent 404. There is no rating affordance here, because there is nothing to
+ * rate — the only useful action is removing the row.
+ */
+export const load: PageServerLoad = async ({ url }) => {
+  const limitParam = Number(url.searchParams.get('limit'));
+  const limit = LIMIT_OPTIONS.includes(limitParam) ? limitParam : 50;
+  const cursor = Number(url.searchParams.get('cursor')) || undefined;
+
+  const data = await getMissingMediaImages({ limit, cursor });
+  return { limit, limitOptions: LIMIT_OPTIONS, wide: true, ...data };
+};
+
+// Access is enforced globally (hooks.server.ts).
+export const actions: Actions = {
+  delete: async ({ request }) => {
+    const form = await request.formData();
+    const id = Number(form.get('id'));
+    if (!id) return fail(400, { error: 'Missing image id' });
+
+    try {
+      await deleteImagesByIds([id]);
+    } catch (e) {
+      return fail(400, { error: e instanceof Error ? e.message : 'Failed to delete.' });
+    }
+    return { success: true, id };
+  },
+};

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -17,9 +17,19 @@ const LIMIT_OPTIONS = [10, 25, 50, 100];
  * `ingestion='Scanned'` and published a permanent 404. There is no rating affordance here, because
  * these can never be scanned — the only useful action is removing the row.
  *
- * 🔴 This page is the REACHABLE ACTION behind both refusals `assertMediaPresentForPublish` throws.
- * The rating queue now 400s on these rows, so if `missingMediaWhere` ever stopped selecting one of
- * them the moderator would have no action left at all. That is why the two predicates are one const.
+ * 🔴 This page is the reachable action behind the `unrenderable` refusal `assertMediaPresentForPublish`
+ * throws, and behind those `absent` refusals whose row also carries a permanent scan class. The
+ * rating queue 400s on these rows, so if `missingMediaWhere` ever stopped selecting one of them the
+ * moderator would have no action left at all — which is why the queue predicate and the delete gate
+ * are built from one const.
+ *
+ * 🔴 It is NOT the reachable action behind EVERY refusal, and the exceptions are named rather than
+ * implied. `absent` is a probe verdict and cannot be selected on in SQL, so a row with a transient
+ * or unclassified failure whose object is genuinely gone is refused on the rating queue and not
+ * listed here; and both queues carry a 2-day window this page inherits, so an older row is deletable
+ * by this action but rendered by no page. Both gaps, why widening the predicate is the wrong fix for
+ * the first, and the query that would settle the second, are written out on `unpublishableMedia` and
+ * `ingestionErrorBaseWhere` in `$lib/server/ingestion.service`.
  */
 export const load: PageServerLoad = async ({ url }) => {
   const limitParam = Number(url.searchParams.get('limit'));

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -26,10 +26,11 @@ const LIMIT_OPTIONS = [10, 25, 50, 100];
  * 🔴 It is NOT the reachable action behind EVERY refusal, and the exceptions are named rather than
  * implied. `absent` is a probe verdict and cannot be selected on in SQL, so a row with a transient
  * or unclassified failure whose object is genuinely gone is refused on the rating queue and not
- * listed here; and both queues carry a 2-day window this page inherits, so an older row is deletable
- * by this action but rendered by no page. Both gaps, why widening the predicate is the wrong fix for
- * the first, and the query that would settle the second, are written out on `unpublishableMedia` and
- * `ingestionErrorBaseWhere` in `$lib/server/ingestion.service`.
+ * listed here; and both queues carry a window this page inherits — `createdAt` BETWEEN two days and
+ * one hour ago, so a row on EITHER side of it (older than two days, or younger than an hour) is
+ * deletable by this action but rendered by no page. Both gaps, why widening the predicate is the
+ * wrong fix for the first, and the query that would settle the second, are written out on
+ * `unpublishableMedia` and `ingestionErrorBaseWhere` in `$lib/server/ingestion.service`.
  */
 export const load: PageServerLoad = async ({ url }) => {
   const limitParam = Number(url.searchParams.get('limit'));
@@ -55,8 +56,14 @@ export const actions: Actions = {
      * without this re-selection through the SAME shared predicate the page is an arbitrary
      * delete-any-image-by-id endpoint that merely happens to render the missing-media queue.
      */
+    // 🔴 The message names the STATE, not the QUEUE. `isMissingMediaImage` deliberately drops the
+    // display window (see `missingMediaScope`), so "not in the missing-media queue" was false in
+    // the one direction that matters: a row outside the window IS refused by no gate here and
+    // WOULD be deleted, while a row this refusal actually rejects may well have been on screen.
     if (!(await isMissingMediaImage(id)))
-      return fail(400, { error: 'That image is not in the missing-media queue.' });
+      return fail(400, {
+        error: 'That image cannot be deleted here — it is not an unpublishable ingestion error.',
+      });
 
     // Kept as insurance if the collaborator ever starts throwing, but it is UNREACHABLE today —
     // `deleteImagesByIds` catches per image and its one un-caught statement is a `void`-ed async

--- a/apps/moderator/src/routes/images/missing-media/+page.server.ts
+++ b/apps/moderator/src/routes/images/missing-media/+page.server.ts
@@ -43,7 +43,10 @@ export const actions: Actions = {
     if (!(await isMissingMediaImage(id)))
       return fail(400, { error: 'That image is not in the missing-media queue.' });
 
-    // Kept for a genuine throw, but note it is nearly dead: see below.
+    // Kept as insurance if the collaborator ever starts throwing, but it is UNREACHABLE today —
+    // `deleteImagesByIds` catches per image and its one un-caught statement is a `void`-ed async
+    // call. Deliberately untested: there is no reachable input that enters this branch, and a test
+    // that forced one would be pinning a state the real function cannot produce.
     try {
       await deleteImagesByIds([id]);
     } catch (e) {
@@ -54,13 +57,17 @@ export const actions: Actions = {
      * 🔴 A RESOLVED `deleteImagesByIds` IS NOT EVIDENCE THE IMAGE IS GONE.
      *
      * It wraps every per-image body in a `try/catch` that logs and continues, and its only statement
-     * outside a try is a `void`-ed async call — so it effectively never rejects. A failed DB or
-     * storage step returns normally, which previously produced `{ success: true }`, a card rendering
-     * "Deleted", and a `deleteMissingMedia` audit row attesting a delete that never happened, all
-     * for an image still on the site.
+     * outside a try is a `void`-ed async call — so it effectively never rejects. A failed DB step
+     * returns normally, which previously produced `{ success: true }`, a card rendering "Deleted",
+     * and a `deleteMissingMedia` audit row attesting a delete that never happened, all for an image
+     * still on the site.
      *
      * So confirm by reading the row back. Cheap, and it is the difference between an audit log that
      * records outcomes and one that records intentions.
+     *
+     * Scope, precisely: this confirms the ROW is gone, which is the authoritative moderation
+     * outcome. It does NOT confirm the stored object was removed — that delete is best-effort and
+     * swallowed inside `deleteImagesByIds` — so a success here can still leave an orphaned object.
      */
     if (await imageRowExists(id))
       return fail(400, {

--- a/apps/moderator/src/routes/images/missing-media/+page.svelte
+++ b/apps/moderator/src/routes/images/missing-media/+page.svelte
@@ -44,13 +44,20 @@
     first: images whose media could not be fetched or decoded, and images whose url is a
     browser-session `blob:` handle that can never render for anyone. Neither can be scanned, so
     there is nothing to rate; the only useful action is removing the row. Membership is
-    `missingMediaWhere` in `$lib/server/ingestion.service` — keep this wording in step with it. -->
+    `missingMediaWhere` in `$lib/server/ingestion.service` — keep this wording in step with it.
+
+    🔴 THE WINDOW HAS TWO BOUNDS AND THE COPY NAMES BOTH. `ingestionErrorBaseWhere` is
+    `createdAt > now() - '2 days' AND createdAt < now() - '1 hour'`, so a row younger than an hour
+    is as absent from this page as one older than two days. Naming only the lower bound is the same
+    defect this queue exists to close one bound over: copy promising a listing that may not contain
+    the row the reader is looking for. -->
   <p class="mt-1 text-xs text-muted-foreground">
     These images can never be scanned, so there is nothing to rate: either the media behind them
     could not be fetched or decoded, or the url is a browser-session <code>blob:</code> handle that
     can never load for anyone else. Publishing one would put a permanently broken image on the site.
-    Delete them, or ask the uploader to upload again. Only images created in the last 2 days are
-    listed here.
+    Delete them, or ask the uploader to upload again. Only images created between 2 days and 1 hour
+    ago are listed here — anything newer or older will not appear, even though it can still be
+    deleted.
   </p>
   <div class="mt-1 flex items-center gap-1">
     <span class="text-xs text-muted-foreground">Per page:</span>

--- a/apps/moderator/src/routes/images/missing-media/+page.svelte
+++ b/apps/moderator/src/routes/images/missing-media/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { applyAction, enhance } from '$app/forms';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import { SvelteSet } from 'svelte/reactivity';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import { Button } from '@civitai/ui/components/ui/button/index.js';
+  import ImageQueueGrid from '$lib/components/ImageQueueGrid.svelte';
+  import type { ActionData, PageData } from './$types';
+  import { clearPaging } from '$lib/paging';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+  // All nsfwLevel 0 here — strip it so the grid doesn't draw a meaningless rating badge.
+  type Item = Omit<PageData['items'][number], 'nsfwLevel'>;
+
+  const deleted = new SvelteSet<number>();
+  $effect(() => {
+    data.items;
+    deleted.clear();
+  });
+
+  const items = $derived(data.items.map(({ nsfwLevel, ...rest }) => rest));
+
+  function limitHref(n: number) {
+    const url = new URL(page.url);
+    url.searchParams.set('limit', String(n));
+    clearPaging(url.searchParams);
+    return url.pathname + url.search;
+  }
+
+  const deleteImage =
+    (id: number): SubmitFunction =>
+    () =>
+    async ({ result }) => {
+      if (result.type === 'success') deleted.add(id);
+      else await applyAction(result);
+    };
+</script>
+
+<header class="page-header">
+  <h1>Missing Media</h1>
+  <p class="mt-1 text-xs text-muted-foreground">
+    The file behind these images could not be fetched, so they can never be scanned and must not be
+    published — publishing one puts a permanently broken image on the site. Delete them, or ask the
+    uploader to upload again.
+  </p>
+  <div class="mt-1 flex items-center gap-1">
+    <span class="text-xs text-muted-foreground">Per page:</span>
+    {#each data.limitOptions as n (n)}
+      <Button
+        size="sm"
+        variant={n === data.limit ? 'default' : 'outline'}
+        onclick={() => n !== data.limit && goto(limitHref(n))}
+      >
+        {n}
+      </Button>
+    {/each}
+  </div>
+</header>
+
+{#if form?.error}
+  <ErrorAlert class="mb-4" message={form.error} />
+{/if}
+
+{#snippet card(image: Item)}
+  <form method="POST" action="?/delete" use:enhance={deleteImage(image.id)}>
+    <input type="hidden" name="id" value={image.id} />
+    <Button type="submit" size="sm" variant="destructive" disabled={deleted.has(image.id)}>
+      {deleted.has(image.id) ? 'Deleted' : 'Delete'}
+    </Button>
+  </form>
+{/snippet}
+
+<ImageQueueGrid
+  {items}
+  civitaiUrl={data.civitaiUrl}
+  nextCursor={data.nextCursor}
+  {card}
+  itemClass={(image) => (deleted.has(image.id) ? 'opacity-50' : '')}
+  empty="No images with missing media."
+/>

--- a/apps/moderator/src/routes/images/missing-media/+page.svelte
+++ b/apps/moderator/src/routes/images/missing-media/+page.svelte
@@ -40,10 +40,17 @@
 
 <header class="page-header">
   <h1>Missing Media</h1>
+  <!-- Two populations, and the header names both because the second joined this queue after the
+    first: images whose media could not be fetched or decoded, and images whose url is a
+    browser-session `blob:` handle that can never render for anyone. Neither can be scanned, so
+    there is nothing to rate; the only useful action is removing the row. Membership is
+    `missingMediaWhere` in `$lib/server/ingestion.service` — keep this wording in step with it. -->
   <p class="mt-1 text-xs text-muted-foreground">
-    The media behind these images could not be fetched or decoded, so they can never be scanned and
-    there is nothing to rate. Where the file is genuinely gone, publishing one would put a
-    permanently broken image on the site. Delete them, or ask the uploader to upload again.
+    These images can never be scanned, so there is nothing to rate: either the media behind them
+    could not be fetched or decoded, or the url is a browser-session <code>blob:</code> handle that
+    can never load for anyone else. Publishing one would put a permanently broken image on the site.
+    Delete them, or ask the uploader to upload again. Only images created in the last 2 days are
+    listed here.
   </p>
   <div class="mt-1 flex items-center gap-1">
     <span class="text-xs text-muted-foreground">Per page:</span>

--- a/apps/moderator/src/routes/images/missing-media/+page.svelte
+++ b/apps/moderator/src/routes/images/missing-media/+page.svelte
@@ -41,9 +41,9 @@
 <header class="page-header">
   <h1>Missing Media</h1>
   <p class="mt-1 text-xs text-muted-foreground">
-    The file behind these images could not be fetched, so they can never be scanned and must not be
-    published — publishing one puts a permanently broken image on the site. Delete them, or ask the
-    uploader to upload again.
+    The media behind these images could not be fetched or decoded, so they can never be scanned and
+    there is nothing to rate. Where the file is genuinely gone, publishing one would put a
+    permanently broken image on the site. Delete them, or ask the uploader to upload again.
   </p>
   <div class="mt-1 flex items-center gap-1">
     <span class="text-xs text-muted-foreground">Per page:</span>

--- a/packages/civitai-shared/package.json
+++ b/packages/civitai-shared/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./media-key": "./src/media-key.ts",
     "./basemodel.constants": "./src/basemodel.constants.ts",
     "./lazy": "./src/lazy.ts",
     "./type-guards": "./src/type-guards.ts",

--- a/packages/civitai-shared/package.json
+++ b/packages/civitai-shared/package.json
@@ -9,9 +9,17 @@
     "./basemodel.constants": "./src/basemodel.constants.ts",
     "./lazy": "./src/lazy.ts",
     "./type-guards": "./src/type-guards.ts",
-    "./moderator-paths": "./src/moderator-paths.ts"
+    "./moderator-paths": "./src/moderator-paths.ts",
+    "./missing-media": "./src/missing-media.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@civitai/db-schema": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/civitai-shared/src/__tests__/media-key.test.ts
+++ b/packages/civitai-shared/src/__tests__/media-key.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { isProbeableMediaKey } from '../media-key';
+
+/**
+ * The ONE predicate both media-existence checks import — the publish guard, which enforces on a
+ * refusal, and the upload-time probe, which only records. They used to carry a copy each, built by
+ * OPPOSITE construction, and the disagreement was not theoretical: for `some-file.png` the negative
+ * spelling probed, got a 404 and permanently refused a moderator publish, while the positive
+ * spelling never asked.
+ *
+ * Every expectation here is a hand-written literal. Deriving one from the regex would make the test
+ * agree with whatever the implementation now says.
+ */
+describe('isProbeableMediaKey', () => {
+  it('accepts the bare uuid every key-minting site issues', () => {
+    // `randomUUID()` output: no prefix, no extension, no path.
+    expect(isProbeableMediaKey('aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee')).toBe(true);
+    expect(isProbeableMediaKey('0f8fad5b-d9cb-469f-a165-70867728950e')).toBe(true);
+  });
+
+  it('is case-insensitive, because callers do not normalise the column', () => {
+    expect(isProbeableMediaKey('0F8FAD5B-D9CB-469F-A165-70867728950E')).toBe(true);
+  });
+
+  it('is BROADER than the write validators, never narrower', () => {
+    /**
+     * The sound direction, asserted rather than assumed: zod's `.uuid()` rejects an invalid version
+     * nibble, this accepts it. So every value `imageSchema` admitted as a key still passes here, and
+     * the guard can never decline to check a key the schema already called a key.
+     */
+    expect(isProbeableMediaKey('aaaaaaaa-bbbb-9ccc-1ddd-eeeeeeeeeeee')).toBe(true);
+  });
+
+  it('rejects the legacy external-avatar urls the profile-picture path stores verbatim', () => {
+    for (const url of [
+      'https://cdn.discordapp.com/avatars/123/abc.png',
+      'https://avatars.githubusercontent.com/u/12345',
+      'https://lh3.googleusercontent.com/a/AAcHTtd',
+      'http://example.com/x.png',
+    ]) {
+      expect(isProbeableMediaKey(url), url).toBe(false);
+    }
+  });
+
+  it('rejects a `blob:` handle, whose embedded uuid is a browser handle and not a key', () => {
+    // 🔴 The reason a bare-uuid EXTRACTION would be wrong where a whole-string MATCH is right: this
+    // value contains something uuid-shaped and is not remotely a bucket key.
+    expect(isProbeableMediaKey('blob:https://civitai.com/0f8fad5b-d9cb-469f-a165-70867728950e')).toBe(
+      false
+    );
+    expect(isProbeableMediaKey('data:image/png;base64,AAAA')).toBe(false);
+  });
+
+  it('rejects the unvalidated shapes the comics router and article sync can write', () => {
+    /**
+     * 🔴 These are the cases that decided which construction to keep, and they are NOT hypothetical:
+     * seven `comics.router.ts` call sites validate the url with `z.string().min(1)`, and the article
+     * `edge-media` sync copies the attribute verbatim out of sanitized HTML. Under the negative
+     * (scheme-based) spelling every one of them was handed to the bucket, 404'd, and became a
+     * permanent refusal to publish. Under this one they are simply not asked about.
+     */
+    for (const value of [
+      'some-file.png',
+      'photo.jpg',
+      '12345',
+      'foo/0f8fad5b-d9cb-469f-a165-70867728950e',
+      '0f8fad5b-d9cb-469f-a165-70867728950e/width=450',
+      'some/path:with-a-colon',
+      '../../etc/passwd',
+      '',
+    ]) {
+      expect(isProbeableMediaKey(value), value).toBe(false);
+    }
+  });
+
+  it('rejects whitespace padding rather than trimming it', () => {
+    // Trimming would make the predicate disagree with the key the row actually holds, which is what
+    // any subsequent HEAD would be sent.
+    expect(isProbeableMediaKey('  0f8fad5b-d9cb-469f-a165-70867728950e  ')).toBe(false);
+    expect(isProbeableMediaKey('0f8fad5b-d9cb-469f-a165-70867728950e\n')).toBe(false);
+  });
+
+  it('rejects every non-string, so a null column cannot reach a bucket', () => {
+    for (const value of [null, undefined, 42, {}, [], true]) {
+      expect(isProbeableMediaKey(value)).toBe(false);
+    }
+  });
+});

--- a/packages/civitai-shared/src/__tests__/media-key.test.ts
+++ b/packages/civitai-shared/src/__tests__/media-key.test.ts
@@ -45,9 +45,9 @@ describe('isProbeableMediaKey', () => {
   it('rejects a `blob:` handle, whose embedded uuid is a browser handle and not a key', () => {
     // 🔴 The reason a bare-uuid EXTRACTION would be wrong where a whole-string MATCH is right: this
     // value contains something uuid-shaped and is not remotely a bucket key.
-    expect(isProbeableMediaKey('blob:https://civitai.com/0f8fad5b-d9cb-469f-a165-70867728950e')).toBe(
-      false
-    );
+    expect(
+      isProbeableMediaKey('blob:https://civitai.com/0f8fad5b-d9cb-469f-a165-70867728950e')
+    ).toBe(false);
     expect(isProbeableMediaKey('data:image/png;base64,AAAA')).toBe(false);
   });
 

--- a/packages/civitai-shared/src/__tests__/missing-media.test.ts
+++ b/packages/civitai-shared/src/__tests__/missing-media.test.ts
@@ -10,6 +10,7 @@ import {
   MissingMediaError,
   summarizeProbeError,
   UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
+  UNRENDERABLE_MEDIA_URL_PREFIX,
 } from '../missing-media';
 
 /** A url that reaches the probe. Every case that must NOT be short-circuited uses this one. */
@@ -71,6 +72,24 @@ describe('decideMediaPublish', () => {
     // a moderator sees, so the test owns it and a copy change has to come here.
     expect(MISSING_MEDIA_PUBLISH_MESSAGE).toBe(
       'The media file for this image is missing from storage, so it cannot be published — publishing it would put a permanently broken image on the site. Delete it, or ask the uploader to upload it again.'
+    );
+  });
+
+  it('gives the url-shape refusal a message that names a REACHABLE action', () => {
+    /**
+     * 🔴 Same doctrine as its sibling above, and it was missing: replacing this constant with
+     * `'Nope.'` left the whole package green. A guard on words is walkable by rewording, so the
+     * whole normalised string is pinned and a copy change has to come here.
+     *
+     * What the string has to say is not arbitrary. The earlier wording told a moderator to "delete
+     * it" on two surfaces that offered no delete for exactly the rows this refusal creates — the
+     * spoke listed them only on the rating queue, and the article card offered only Override and
+     * Retry. Both exits now exist (the spoke routes these rows into its delete-only Missing Media
+     * queue; the article card withdraws the two dead-end controls and points at the editor), and
+     * this message is where a moderator is told so.
+     */
+    expect(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE).toBe(
+      'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it from the Missing Media queue, or remove it from the article that uses it, and ask the uploader to upload the file again.'
     );
   });
 });
@@ -231,6 +250,40 @@ describe('assertMediaPresentForPublish — the url decides whether a probe happe
     expect(onSkipped).toHaveBeenCalledTimes(1);
   });
 
+  it('will not let a STORE answer with a verdict only the url can produce', async () => {
+    /**
+     * 🔴 A TYPE-LEVEL guard, and it is the only kind that can hold this one — there is no runtime
+     * behaviour to assert, because the point is that the call never compiles.
+     *
+     * `probe` is typed `MediaProbeAnswer` (present | absent | unknown), not the full five-valued
+     * `MediaPresence`. Widening it back would let a store return the two verdicts this module
+     * decides ABOUT the url before any store is consulted, and each defeats a hook: a store-sourced
+     * `not-applicable` skips `onSkipped`, whose whole job is counting the short-circuit, and a
+     * store-sourced `unrenderable` produces a refusal that `onRefused`'s own comment says no bucket
+     * state can cause — which is what separates a fail-CLOSED misconfiguration from a url-shape
+     * refusal in the logs.
+     *
+     * This file sits under a workspace package's `src`, which tsconfig INCLUDES — the exclusion for
+     * `__tests__` is scoped to the ROOT `src` tree only — so `pnpm typecheck` reads these lines. If
+     * the type widened, the suppression would be unused and TS2578 fails the run. The assertion IS
+     * the `@ts-expect-error`.
+     */
+    await assertMediaPresentForPublish({
+      url: KEY,
+      // @ts-expect-error a probe must not be able to answer `not-applicable`
+      probe: async () => MediaPresence.NotApplicable,
+    });
+    await expect(
+      assertMediaPresentForPublish({
+        url: KEY,
+        // @ts-expect-error a probe must not be able to answer `unrenderable`
+        probe: async () => MediaPresence.Unrenderable,
+      })
+      // Runtime behaviour is unchanged and deliberately unpinned as a contract: the guard is the
+      // compile error. This only keeps the call from throwing an unhandled rejection.
+    ).rejects.toThrow();
+  });
+
   it('hands the probe the key itself, so the runtime cannot re-derive it', async () => {
     const probe = vi.fn(async () => MediaPresence.Present);
     await assertMediaPresentForPublish({ url: KEY, probe });
@@ -290,14 +343,41 @@ describe('assertMediaPresentForPublish — the url decides whether a probe happe
 });
 
 describe('isUnrenderableMediaUrl', () => {
-  it('matches a blob: handle, case-insensitively', () => {
+  it('matches a blob: handle', () => {
     expect(isUnrenderableMediaUrl('blob:https://civitai.com/abc')).toBe(true);
-    expect(isUnrenderableMediaUrl('BLOB:https://civitai.com/abc')).toBe(true);
   });
 
-  it('is anchored, so a key that merely CONTAINS the word is not swept in', () => {
+  it('is CASE-SENSITIVE, because the renderers whose behaviour licenses the refusal are', () => {
+    /**
+     * 🔴 This case asserted the opposite (`/^blob:/i`), and the assertion was wider than the
+     * evidence. The warrant for refusing without a probe is that both renderers emit the value
+     * VERBATIM — `src.startsWith('blob')`, case-SENSITIVE, in `src/client-utils/cf-images-utils.ts`
+     * and `apps/moderator/src/lib/media/edge-url.ts`. `BLOB:https://…` does not clear that test:
+     * the renderers REWRITE it into a CDN path. That row is probably broken too, but by a different
+     * mechanism and by inference — and inference is not enough for a permanent refusal, which is the
+     * bar this module sets for itself and applies to `data:` for the same reason.
+     */
+    expect(isUnrenderableMediaUrl('BLOB:https://civitai.com/abc')).toBe(false);
+    expect(isUnrenderableMediaUrl('Blob:https://civitai.com/abc')).toBe(false);
+  });
+
+  it('is anchored AND keeps the colon, so it stays a strict subset of the passthrough set', () => {
     expect(isUnrenderableMediaUrl('my-blob:thing')).toBe(false);
+    // `blobfish.png` DOES clear the renderers' `startsWith('blob')` and is passed through verbatim,
+    // so it is genuinely broken as a relative path. It is still not refused: it is not a url scheme,
+    // it is not a population anyone has measured, and the refusal is permanent. Deliberately
+    // narrower than the warrant rather than wider than it.
     expect(isUnrenderableMediaUrl('blobfish.png')).toBe(false);
+  });
+
+  it('exposes the prefix the routing SQL builds its LIKE pattern from', () => {
+    // The spoke interpolates this into `COALESCE(i.url,'') LIKE '<prefix>%'` to route these rows to
+    // the one queue that offers a delete. Two properties have to hold for that to be the same rule:
+    expect(UNRENDERABLE_MEDIA_URL_PREFIX).toBe('blob:');
+    // ...and it must carry no LIKE metacharacter, or the SQL silently matches a different set.
+    expect(UNRENDERABLE_MEDIA_URL_PREFIX).not.toMatch(/[%_\\]/);
+    // The predicate is built FROM the prefix, so a change to one cannot leave the other behind.
+    expect(isUnrenderableMediaUrl(`${UNRENDERABLE_MEDIA_URL_PREFIX}anything`)).toBe(true);
   });
 
   it('does not claim anything else is unrenderable', () => {

--- a/packages/civitai-shared/src/__tests__/missing-media.test.ts
+++ b/packages/civitai-shared/src/__tests__/missing-media.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   assertMediaPresentForPublish,
+  isProbeableMediaKey,
   decideMediaPublish,
   IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
   MediaPresence,
@@ -143,5 +144,70 @@ describe('assertMediaPresentForPublish', () => {
       ).resolves.toMatchObject({ allow: true });
     }
     expect(raise).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The regression this predicate exists for. `Image.url` is a bucket key for MOST rows, not all:
+ * profile pictures may store a whitelisted external avatar CDN url verbatim, and those rows are
+ * created and ingested like any other, so they carry a current timestamp and reach the review
+ * queue. A legacy bug also persisted `blob:` handles.
+ *
+ * Handing one of those to the bucket as a Key 404s, which the store reports as `absent` — so
+ * without this the guard REFUSES, permanently and with no override, an image that renders fine.
+ * That is worse than the bug the guard fixes, so these cases are pinned literally.
+ */
+describe('isProbeableMediaKey', () => {
+  it('accepts the bare object keys that are the overwhelming majority', () => {
+    expect(isProbeableMediaKey('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')).toBe(true);
+    // Keys with a path, and a colon appearing LATER, are still keys — a scheme cannot contain `/`.
+    expect(isProbeableMediaKey('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/width=450')).toBe(true);
+    expect(isProbeableMediaKey('some/path:with-a-colon')).toBe(true);
+  });
+
+  it('rejects every external-avatar CDN url the profile-picture path whitelists', () => {
+    // These four prefixes are the ones `verifyAvatar` accepts, written out rather than generated,
+    // so a change to that whitelist has to be reflected here deliberately.
+    for (const url of [
+      'https://cdn.discordapp.com/avatars/123/abc.png',
+      'https://cdn.discordapp.com/embed/avatars/1.png',
+      'https://avatars.githubusercontent.com/u/12345',
+      'https://lh3.googleusercontent.com/a/AAcHTtd',
+    ]) {
+      expect(isProbeableMediaKey(url), url).toBe(false);
+    }
+  });
+
+  it('rejects the legacy blob: population, which is what made the two runtimes disagree', () => {
+    expect(isProbeableMediaKey('blob:https://civitai.com/9f8e-1234')).toBe(false);
+  });
+
+  it('rejects http, data: and an empty or absent url', () => {
+    expect(isProbeableMediaKey('http://example.com/x.png')).toBe(false);
+    expect(isProbeableMediaKey('data:image/png;base64,AAAA')).toBe(false);
+    expect(isProbeableMediaKey('')).toBe(false);
+    expect(isProbeableMediaKey(null)).toBe(false);
+    expect(isProbeableMediaKey(undefined)).toBe(false);
+  });
+});
+
+describe('assertMediaPresentForPublish — refusal is observable', () => {
+  it('reports every refusal, so a fail-CLOSED misconfiguration cannot hide', () => {
+    // The mirror of the unknown-logging case: a wrong bucket name 404s for every key, which reads
+    // as `absent` for every image. Without this hook that is indistinguishable from a clean run.
+    const onRefused = vi.fn();
+    return expect(
+      assertMediaPresentForPublish({ probe: async () => MediaPresence.Absent, onRefused })
+    )
+      .rejects.toThrow(MissingMediaError)
+      .then(() => expect(onRefused).toHaveBeenCalledTimes(1));
+  });
+
+  it('never reports a refusal on a verdict that allows', async () => {
+    const onRefused = vi.fn();
+    for (const presence of [MediaPresence.Present, MediaPresence.Unknown]) {
+      await assertMediaPresentForPublish({ probe: async () => presence, onRefused });
+    }
+    expect(onRefused).not.toHaveBeenCalled();
   });
 });

--- a/packages/civitai-shared/src/__tests__/missing-media.test.ts
+++ b/packages/civitai-shared/src/__tests__/missing-media.test.ts
@@ -78,7 +78,9 @@ describe('decideMediaPublish', () => {
 describe('assertMediaPresentForPublish', () => {
   it('throws MissingMediaError when the store answered ABSENT', async () => {
     const probe = vi.fn(async () => MediaPresence.Absent);
-    await expect(assertMediaPresentForPublish({ url: KEY, probe })).rejects.toThrow(MissingMediaError);
+    await expect(assertMediaPresentForPublish({ url: KEY, probe })).rejects.toThrow(
+      MissingMediaError
+    );
     await expect(assertMediaPresentForPublish({ url: KEY, probe })).rejects.toThrow(
       MISSING_MEDIA_PUBLISH_MESSAGE
     );

--- a/packages/civitai-shared/src/__tests__/missing-media.test.ts
+++ b/packages/civitai-shared/src/__tests__/missing-media.test.ts
@@ -84,12 +84,19 @@ describe('decideMediaPublish', () => {
      * What the string has to say is not arbitrary. The earlier wording told a moderator to "delete
      * it" on two surfaces that offered no delete for exactly the rows this refusal creates — the
      * spoke listed them only on the rating queue, and the article card offered only Override and
-     * Retry. Both exits now exist (the spoke routes these rows into its delete-only Missing Media
-     * queue; the article card withdraws the two dead-end controls and points at the editor), and
-     * this message is where a moderator is told so.
+     * Retry. Both exits now exist (the spoke's delete gate selects on THIS predicate; the article
+     * card withdraws the two dead-end controls and points at the editor), and this message is where
+     * a moderator is told so.
+     *
+     * 🔴 IT NAMES THE ACTION, NOT THE QUEUE, and the parenthetical is what makes that honest. The
+     * delete ACTION is unwindowed (`missingMediaScope`); the QUEUE that renders it is bounded to the
+     * last 2 days (`ingestionErrorBaseWhere`), and `blob:` urls come from a legacy upload bug, so
+     * the population is plausibly mostly older than that. An unqualified "Delete it from the Missing
+     * Media queue" would promise a listing that may not contain the row — the same class of defect
+     * as the original wording, one level down.
      */
     expect(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE).toBe(
-      'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it from the Missing Media queue, or remove it from the article that uses it, and ask the uploader to upload the file again.'
+      'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it — recent ones are listed in the Missing Media queue — or remove it from the article that uses it and ask the uploader to upload the file again.'
     );
   });
 });

--- a/packages/civitai-shared/src/__tests__/missing-media.test.ts
+++ b/packages/civitai-shared/src/__tests__/missing-media.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertMediaPresentForPublish,
+  decideMediaPublish,
+  IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
+  MediaPresence,
+  MISSING_MEDIA_PUBLISH_MESSAGE,
+  MissingMediaError,
+} from '../missing-media';
+
+/**
+ * The rule both `resolveIngestionError` implementations delegate to. Expectations here are pinned
+ * LITERALLY rather than derived from the module, so a change to the implementation shows up as a
+ * failing test instead of a test that quietly agrees with whatever the code now does.
+ */
+describe('decideMediaPublish', () => {
+  /**
+   * Exhaustive over the value set, as a table. The mutant this catches and a per-case test does
+   * not: swapping which verdict refuses. Every row is a distinct outcome, so no single flipped
+   * comparison leaves the table green.
+   */
+  it('refuses exactly one of the three verdicts', () => {
+    expect(decideMediaPublish('absent')).toEqual({
+      allow: false,
+      presence: 'absent',
+      message: MISSING_MEDIA_PUBLISH_MESSAGE,
+    });
+    expect(decideMediaPublish('present')).toEqual({ allow: true, presence: 'present' });
+    expect(decideMediaPublish('unknown')).toEqual({ allow: true, presence: 'unknown' });
+  });
+
+  it('names the three verdicts with the strings the storage layers speak', () => {
+    // Pinned as literals: the probes in both runtimes build these strings from their own client's
+    // answer, so renaming a member here without updating them would silently make every probe
+    // return an unrecognised value that falls through to "allow".
+    expect(MediaPresence.Present).toBe('present');
+    expect(MediaPresence.Absent).toBe('absent');
+    expect(MediaPresence.Unknown).toBe('unknown');
+  });
+
+  it('exports the stored scan-failure class the missing-media queue keys off', () => {
+    expect(IMAGE_SCAN_FAILURE_CLASS_PERMANENT).toBe('permanent');
+  });
+
+  it('gives the moderator a message that says what to do instead', () => {
+    // Pinned whole, not by keyword: a guard on WORDS is walkable by rewording. This is the string
+    // a moderator sees, so the test owns it and a copy change has to come here.
+    expect(MISSING_MEDIA_PUBLISH_MESSAGE).toBe(
+      'The media file for this image is missing from storage, so it cannot be published — publishing it would put a permanently broken image on the site. Delete it, or ask the uploader to upload it again.'
+    );
+  });
+});
+
+describe('assertMediaPresentForPublish', () => {
+  it('throws MissingMediaError when the store answered ABSENT', async () => {
+    const probe = vi.fn(async () => MediaPresence.Absent);
+    await expect(assertMediaPresentForPublish({ probe })).rejects.toThrow(MissingMediaError);
+    await expect(assertMediaPresentForPublish({ probe })).rejects.toThrow(
+      MISSING_MEDIA_PUBLISH_MESSAGE
+    );
+  });
+
+  it('allows and does not log when the store answered PRESENT', async () => {
+    const onUnknown = vi.fn();
+    const decision = await assertMediaPresentForPublish({
+      probe: async () => MediaPresence.Present,
+      onUnknown,
+    });
+    expect(decision).toEqual({ allow: true, presence: 'present' });
+    expect(onUnknown).not.toHaveBeenCalled();
+  });
+
+  it('allows and logs when the store ANSWERED unknown', async () => {
+    const onUnknown = vi.fn();
+    const decision = await assertMediaPresentForPublish({
+      probe: async () => MediaPresence.Unknown,
+      onUnknown,
+    });
+    expect(decision).toEqual({ allow: true, presence: 'unknown' });
+    expect(onUnknown).toHaveBeenCalledTimes(1);
+    // No error to report — the probe returned a verdict rather than failing.
+    expect(onUnknown).toHaveBeenCalledWith(undefined);
+  });
+
+  it('allows and logs the error when the probe THREW', async () => {
+    // The fail-open case. Inability to consult the store is not evidence of loss, and rejecting on
+    // it would let a storage blip block moderation on the queue whose job is unblocking content.
+    const boom = new Error('credentials not configured');
+    const onUnknown = vi.fn();
+    const decision = await assertMediaPresentForPublish({
+      probe: async () => {
+        throw boom;
+      },
+      onUnknown,
+    });
+    expect(decision).toEqual({ allow: true, presence: 'unknown' });
+    expect(onUnknown).toHaveBeenCalledWith(boom);
+  });
+
+  it('allows when the probe throws SYNCHRONOUSLY, e.g. a storage client that cannot be built', async () => {
+    // `getB2ImageS3Client()` throws on construction when credentials are absent, and the main app's
+    // probe builds it inline. A try that only covered the await would let that escape as a 500 on a
+    // publish that should have been allowed.
+    const onUnknown = vi.fn();
+    const decision = await assertMediaPresentForPublish({
+      probe: () => {
+        throw new Error('B2 image upload credentials not configured');
+      },
+      onUnknown,
+    });
+    expect(decision).toEqual({ allow: true, presence: 'unknown' });
+    expect(onUnknown).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the caller-supplied raise for the refusal, so each runtime throws its own error type', async () => {
+    class Trpcish extends Error {}
+    const raise = vi.fn((message: string) => {
+      throw new Trpcish(message);
+    });
+    await expect(
+      assertMediaPresentForPublish({ probe: async () => MediaPresence.Absent, raise })
+    ).rejects.toThrow(Trpcish);
+    expect(raise).toHaveBeenCalledWith(MISSING_MEDIA_PUBLISH_MESSAGE);
+  });
+
+  it('still refuses when a supplied raise returns instead of throwing', async () => {
+    // The backstop. A `raise` that merely returns would otherwise fall through and publish the
+    // broken image — the exact defect this module exists to remove.
+    const raise = vi.fn(() => undefined);
+    await expect(
+      assertMediaPresentForPublish({ probe: async () => MediaPresence.Absent, raise })
+    ).rejects.toThrow(MissingMediaError);
+    expect(raise).toHaveBeenCalledTimes(1);
+  });
+
+  it('never calls raise on a verdict that allows', async () => {
+    const raise = vi.fn(() => {
+      throw new Error('should not be reached');
+    });
+    for (const presence of [MediaPresence.Present, MediaPresence.Unknown]) {
+      await expect(
+        assertMediaPresentForPublish({ probe: async () => presence, raise })
+      ).resolves.toMatchObject({ allow: true });
+    }
+    expect(raise).not.toHaveBeenCalled();
+  });
+});

--- a/packages/civitai-shared/src/__tests__/missing-media.test.ts
+++ b/packages/civitai-shared/src/__tests__/missing-media.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   assertMediaPresentForPublish,
-  isProbeableMediaKey,
   decideMediaPublish,
   IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
+  isUnrenderableMediaUrl,
+  MEDIA_PROBE_ERROR_MAX_LENGTH,
   MediaPresence,
   MISSING_MEDIA_PUBLISH_MESSAGE,
   MissingMediaError,
+  summarizeProbeError,
+  UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
 } from '../missing-media';
+
+/** A url that reaches the probe. Every case that must NOT be short-circuited uses this one. */
+const KEY = '0f8fad5b-d9cb-469f-a165-70867728950e';
 
 /**
  * The rule both `resolveIngestionError` implementations delegate to. Expectations here are pinned
@@ -20,23 +26,40 @@ describe('decideMediaPublish', () => {
    * not: swapping which verdict refuses. Every row is a distinct outcome, so no single flipped
    * comparison leaves the table green.
    */
-  it('refuses exactly one of the three verdicts', () => {
+  it('refuses exactly two of the five verdicts, each with its own message', () => {
     expect(decideMediaPublish('absent')).toEqual({
       allow: false,
       presence: 'absent',
       message: MISSING_MEDIA_PUBLISH_MESSAGE,
     });
+    expect(decideMediaPublish('unrenderable')).toEqual({
+      allow: false,
+      presence: 'unrenderable',
+      message: UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
+    });
     expect(decideMediaPublish('present')).toEqual({ allow: true, presence: 'present' });
     expect(decideMediaPublish('unknown')).toEqual({ allow: true, presence: 'unknown' });
+    expect(decideMediaPublish('not-applicable')).toEqual({
+      allow: true,
+      presence: 'not-applicable',
+    });
   });
 
-  it('names the three verdicts with the strings the storage layers speak', () => {
+  it('gives the two refusals DIFFERENT messages, because they have different remedies', () => {
+    // Folding them onto one string would tell a moderator to go looking in storage for a file that
+    // was never uploaded there.
+    expect(MISSING_MEDIA_PUBLISH_MESSAGE).not.toBe(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE);
+  });
+
+  it('names the five verdicts with the strings the storage layers speak', () => {
     // Pinned as literals: the probes in both runtimes build these strings from their own client's
     // answer, so renaming a member here without updating them would silently make every probe
     // return an unrecognised value that falls through to "allow".
     expect(MediaPresence.Present).toBe('present');
     expect(MediaPresence.Absent).toBe('absent');
     expect(MediaPresence.Unknown).toBe('unknown');
+    expect(MediaPresence.NotApplicable).toBe('not-applicable');
+    expect(MediaPresence.Unrenderable).toBe('unrenderable');
   });
 
   it('exports the stored scan-failure class the missing-media queue keys off', () => {
@@ -55,8 +78,8 @@ describe('decideMediaPublish', () => {
 describe('assertMediaPresentForPublish', () => {
   it('throws MissingMediaError when the store answered ABSENT', async () => {
     const probe = vi.fn(async () => MediaPresence.Absent);
-    await expect(assertMediaPresentForPublish({ probe })).rejects.toThrow(MissingMediaError);
-    await expect(assertMediaPresentForPublish({ probe })).rejects.toThrow(
+    await expect(assertMediaPresentForPublish({ url: KEY, probe })).rejects.toThrow(MissingMediaError);
+    await expect(assertMediaPresentForPublish({ url: KEY, probe })).rejects.toThrow(
       MISSING_MEDIA_PUBLISH_MESSAGE
     );
   });
@@ -64,6 +87,7 @@ describe('assertMediaPresentForPublish', () => {
   it('allows and does not log when the store answered PRESENT', async () => {
     const onUnknown = vi.fn();
     const decision = await assertMediaPresentForPublish({
+      url: KEY,
       probe: async () => MediaPresence.Present,
       onUnknown,
     });
@@ -74,13 +98,15 @@ describe('assertMediaPresentForPublish', () => {
   it('allows and logs when the store ANSWERED unknown', async () => {
     const onUnknown = vi.fn();
     const decision = await assertMediaPresentForPublish({
+      url: KEY,
       probe: async () => MediaPresence.Unknown,
       onUnknown,
     });
     expect(decision).toEqual({ allow: true, presence: 'unknown' });
     expect(onUnknown).toHaveBeenCalledTimes(1);
-    // No error to report — the probe returned a verdict rather than failing.
-    expect(onUnknown).toHaveBeenCalledWith(undefined);
+    // 🔴 The reason is what makes the two unknown causes distinguishable. The probe RETURNED a
+    // verdict rather than failing, so there is no error and the reason must say why.
+    expect(onUnknown).toHaveBeenCalledWith({ reason: 'store-inconclusive', error: undefined });
   });
 
   it('allows and logs the error when the probe THREW', async () => {
@@ -89,13 +115,14 @@ describe('assertMediaPresentForPublish', () => {
     const boom = new Error('credentials not configured');
     const onUnknown = vi.fn();
     const decision = await assertMediaPresentForPublish({
+      url: KEY,
       probe: async () => {
         throw boom;
       },
       onUnknown,
     });
     expect(decision).toEqual({ allow: true, presence: 'unknown' });
-    expect(onUnknown).toHaveBeenCalledWith(boom);
+    expect(onUnknown).toHaveBeenCalledWith({ reason: 'probe-threw', error: boom });
   });
 
   it('allows when the probe throws SYNCHRONOUSLY, e.g. a storage client that cannot be built', async () => {
@@ -104,6 +131,7 @@ describe('assertMediaPresentForPublish', () => {
     // publish that should have been allowed.
     const onUnknown = vi.fn();
     const decision = await assertMediaPresentForPublish({
+      url: KEY,
       probe: () => {
         throw new Error('B2 image upload credentials not configured');
       },
@@ -119,7 +147,7 @@ describe('assertMediaPresentForPublish', () => {
       throw new Trpcish(message);
     });
     await expect(
-      assertMediaPresentForPublish({ probe: async () => MediaPresence.Absent, raise })
+      assertMediaPresentForPublish({ url: KEY, probe: async () => MediaPresence.Absent, raise })
     ).rejects.toThrow(Trpcish);
     expect(raise).toHaveBeenCalledWith(MISSING_MEDIA_PUBLISH_MESSAGE);
   });
@@ -129,7 +157,7 @@ describe('assertMediaPresentForPublish', () => {
     // broken image — the exact defect this module exists to remove.
     const raise = vi.fn(() => undefined);
     await expect(
-      assertMediaPresentForPublish({ probe: async () => MediaPresence.Absent, raise })
+      assertMediaPresentForPublish({ url: KEY, probe: async () => MediaPresence.Absent, raise })
     ).rejects.toThrow(MissingMediaError);
     expect(raise).toHaveBeenCalledTimes(1);
   });
@@ -140,54 +168,10 @@ describe('assertMediaPresentForPublish', () => {
     });
     for (const presence of [MediaPresence.Present, MediaPresence.Unknown]) {
       await expect(
-        assertMediaPresentForPublish({ probe: async () => presence, raise })
+        assertMediaPresentForPublish({ url: KEY, probe: async () => presence, raise })
       ).resolves.toMatchObject({ allow: true });
     }
     expect(raise).not.toHaveBeenCalled();
-  });
-});
-
-/**
- * The regression this predicate exists for. `Image.url` is a bucket key for MOST rows, not all:
- * profile pictures may store a whitelisted external avatar CDN url verbatim, and those rows are
- * created and ingested like any other, so they carry a current timestamp and reach the review
- * queue. A legacy bug also persisted `blob:` handles.
- *
- * Handing one of those to the bucket as a Key 404s, which the store reports as `absent` — so
- * without this the guard REFUSES, permanently and with no override, an image that renders fine.
- * That is worse than the bug the guard fixes, so these cases are pinned literally.
- */
-describe('isProbeableMediaKey', () => {
-  it('accepts the bare object keys that are the overwhelming majority', () => {
-    expect(isProbeableMediaKey('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')).toBe(true);
-    // Keys with a path, and a colon appearing LATER, are still keys — a scheme cannot contain `/`.
-    expect(isProbeableMediaKey('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/width=450')).toBe(true);
-    expect(isProbeableMediaKey('some/path:with-a-colon')).toBe(true);
-  });
-
-  it('rejects every external-avatar CDN url the profile-picture path whitelists', () => {
-    // These four prefixes are the ones `verifyAvatar` accepts, written out rather than generated,
-    // so a change to that whitelist has to be reflected here deliberately.
-    for (const url of [
-      'https://cdn.discordapp.com/avatars/123/abc.png',
-      'https://cdn.discordapp.com/embed/avatars/1.png',
-      'https://avatars.githubusercontent.com/u/12345',
-      'https://lh3.googleusercontent.com/a/AAcHTtd',
-    ]) {
-      expect(isProbeableMediaKey(url), url).toBe(false);
-    }
-  });
-
-  it('rejects the legacy blob: population, which is what made the two runtimes disagree', () => {
-    expect(isProbeableMediaKey('blob:https://civitai.com/9f8e-1234')).toBe(false);
-  });
-
-  it('rejects http, data: and an empty or absent url', () => {
-    expect(isProbeableMediaKey('http://example.com/x.png')).toBe(false);
-    expect(isProbeableMediaKey('data:image/png;base64,AAAA')).toBe(false);
-    expect(isProbeableMediaKey('')).toBe(false);
-    expect(isProbeableMediaKey(null)).toBe(false);
-    expect(isProbeableMediaKey(undefined)).toBe(false);
   });
 });
 
@@ -197,17 +181,167 @@ describe('assertMediaPresentForPublish — refusal is observable', () => {
     // as `absent` for every image. Without this hook that is indistinguishable from a clean run.
     const onRefused = vi.fn();
     return expect(
-      assertMediaPresentForPublish({ probe: async () => MediaPresence.Absent, onRefused })
+      assertMediaPresentForPublish({ url: KEY, probe: async () => MediaPresence.Absent, onRefused })
     )
       .rejects.toThrow(MissingMediaError)
-      .then(() => expect(onRefused).toHaveBeenCalledTimes(1));
+      .then(() => {
+        expect(onRefused).toHaveBeenCalledTimes(1);
+        // Carries WHICH refusal: a bucket can cause `absent` and can never cause `unrenderable`,
+        // so a fail-CLOSED misconfiguration is only legible if the two are counted apart.
+        expect(onRefused).toHaveBeenCalledWith('absent');
+      });
   });
 
   it('never reports a refusal on a verdict that allows', async () => {
     const onRefused = vi.fn();
     for (const presence of [MediaPresence.Present, MediaPresence.Unknown]) {
-      await assertMediaPresentForPublish({ probe: async () => presence, onRefused });
+      await assertMediaPresentForPublish({ url: KEY, probe: async () => presence, onRefused });
     }
     expect(onRefused).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The classification now lives INSIDE `assertMediaPresentForPublish`, not in each runtime's probe.
+ * That is the whole point of the consolidation: a runtime cannot supply its own idea of what a key
+ * is, because it never gets to decide whether the probe runs.
+ */
+describe('assertMediaPresentForPublish — the url decides whether a probe happens at all', () => {
+  it('never asks the store about a url that is not a key, and does not call it unknown', async () => {
+    const probe = vi.fn(async () => MediaPresence.Absent);
+    const onUnknown = vi.fn();
+    const onSkipped = vi.fn();
+
+    const decision = await assertMediaPresentForPublish({
+      url: 'https://cdn.discordapp.com/avatars/123/abc.png',
+      probe,
+      onUnknown,
+      onSkipped,
+    });
+
+    // 🔴 The probe is rigged to answer ABSENT. If the short-circuit were removed this would refuse,
+    // so the case cannot pass by the probe happening to be harmless.
+    expect(decision).toEqual({ allow: true, presence: 'not-applicable' });
+    expect(probe).not.toHaveBeenCalled();
+    // The finding this fixes: folding `not-applicable` into `unknown` made a store outage and a
+    // profile-picture url emit the same line, so the count could not answer its own question.
+    expect(onUnknown).not.toHaveBeenCalled();
+    expect(onSkipped).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands the probe the key itself, so the runtime cannot re-derive it', async () => {
+    const probe = vi.fn(async () => MediaPresence.Present);
+    await assertMediaPresentForPublish({ url: KEY, probe });
+    expect(probe).toHaveBeenCalledWith(KEY);
+  });
+
+  it('REFUSES a blob: url without consulting the store', async () => {
+    /**
+     * The behaviour change. A `blob:` handle is passed through verbatim by both renderers, so a
+     * published row emits `<img src="blob:…">` into someone else's browser and resolves to nothing.
+     * The previous rule allowed these on the stated grounds that they "render perfectly well".
+     */
+    const probe = vi.fn(async () => MediaPresence.Present);
+    const onRefused = vi.fn();
+
+    await expect(
+      assertMediaPresentForPublish({
+        url: 'blob:https://civitai.com/0f8fad5b-d9cb-469f-a165-70867728950e',
+        probe,
+        onRefused,
+      })
+    ).rejects.toThrow(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE);
+
+    // Rigged to answer PRESENT: the refusal cannot be coming from the store.
+    expect(probe).not.toHaveBeenCalled();
+    expect(onRefused).toHaveBeenCalledWith('unrenderable');
+  });
+
+  it('still allows http(s), which really does render', async () => {
+    // The line between the two: `getEdgeUrl` passes `http`/`blob` through verbatim, and only one of
+    // those two is a live handle. Refusing http rows would break the legacy-avatar population.
+    const probe = vi.fn(async () => MediaPresence.Absent);
+    const decision = await assertMediaPresentForPublish({
+      url: 'https://avatars.githubusercontent.com/u/12345',
+      probe,
+    });
+    expect(decision).toEqual({ allow: true, presence: 'not-applicable' });
+  });
+
+  it('leaves data: fail-open, deliberately', async () => {
+    // Probably broken too — it is NOT in either renderer's passthrough set — but "probably" is not
+    // enough to justify a permanent refusal, so it is classified, not enforced.
+    const decision = await assertMediaPresentForPublish({
+      url: 'data:image/png;base64,AAAA',
+      probe: async () => MediaPresence.Absent,
+    });
+    expect(decision).toEqual({ allow: true, presence: 'not-applicable' });
+  });
+
+  it('allows a null/absent url rather than failing the moderation path', async () => {
+    for (const url of [null, undefined, '']) {
+      await expect(
+        assertMediaPresentForPublish({ url, probe: async () => MediaPresence.Absent })
+      ).resolves.toEqual({ allow: true, presence: 'not-applicable' });
+    }
+  });
+});
+
+describe('isUnrenderableMediaUrl', () => {
+  it('matches a blob: handle, case-insensitively', () => {
+    expect(isUnrenderableMediaUrl('blob:https://civitai.com/abc')).toBe(true);
+    expect(isUnrenderableMediaUrl('BLOB:https://civitai.com/abc')).toBe(true);
+  });
+
+  it('is anchored, so a key that merely CONTAINS the word is not swept in', () => {
+    expect(isUnrenderableMediaUrl('my-blob:thing')).toBe(false);
+    expect(isUnrenderableMediaUrl('blobfish.png')).toBe(false);
+  });
+
+  it('does not claim anything else is unrenderable', () => {
+    for (const url of [
+      'https://example.com/x.png',
+      'data:image/png;base64,AAAA',
+      '0f8fad5b-d9cb-469f-a165-70867728950e',
+      '',
+      null,
+      undefined,
+    ]) {
+      expect(isUnrenderableMediaUrl(url)).toBe(false);
+    }
+  });
+});
+
+describe('summarizeProbeError', () => {
+  /**
+   * A `StorageClientError` embeds the remote response BODY in its message — an HTML error page or
+   * an XML fault document, i.e. unbounded third-party text. Logging it raw puts that straight into
+   * stdout and therefore Loki, once per inconclusive probe.
+   */
+  it('bounds an oversized message and SAYS it clipped it', () => {
+    const body = 'x'.repeat(10_000);
+    const out = summarizeProbeError(new Error(body));
+    expect(out.length).toBeLessThan(MEDIA_PROBE_ERROR_MAX_LENGTH + 20);
+    expect(out.endsWith('…[truncated]')).toBe(true);
+    // The marker matters: a silently clipped body reads as a complete, different error.
+    expect(out.startsWith('x'.repeat(MEDIA_PROBE_ERROR_MAX_LENGTH))).toBe(true);
+  });
+
+  it('leaves a short message intact and unmarked', () => {
+    expect(summarizeProbeError(new Error('credentials not configured'))).toBe(
+      'credentials not configured'
+    );
+  });
+
+  it('flattens newlines, so one probe cannot become many log lines', () => {
+    expect(summarizeProbeError(new Error('<html>\n  <body>oops</body>\n</html>'))).toBe(
+      '<html> <body>oops</body> </html>'
+    );
+  });
+
+  it('handles a non-Error and an absent error without throwing', () => {
+    expect(summarizeProbeError('plain string')).toBe('plain string');
+    expect(summarizeProbeError(undefined)).toBe('');
+    expect(summarizeProbeError(null)).toBe('');
   });
 });

--- a/packages/civitai-shared/src/index.ts
+++ b/packages/civitai-shared/src/index.ts
@@ -6,3 +6,4 @@ export * from './browsing-levels';
 export * from './model-version-flags.constants';
 export * from './comic-views.constants';
 export * from './model3d-views.constants';
+export * from './missing-media';

--- a/packages/civitai-shared/src/media-key.ts
+++ b/packages/civitai-shared/src/media-key.ts
@@ -1,0 +1,47 @@
+/**
+ * The single rule for "may this `Image.url` be handed to our media store as an object key?".
+ *
+ * 🔴 It lives here because it was open-coded twice, by OPPOSITE construction, and the two answers
+ * disagreed on real rows. One spelling asked "does it carry a URI scheme?" and probed everything
+ * else; the other asked "is it a bare uuid?" and probed only that. For `some-file.png` the first
+ * probes, gets a 404, and PERMANENTLY refuses a moderator publish; the second never asks. A
+ * predicate open-coded at two call sites regenerates the same bug at both, so there is one copy and
+ * both call sites import it.
+ *
+ * 🔴 THE OBVIOUS JUSTIFICATION FOR THIS TEST IS FALSE, AND THAT MATTERS FOR HOW IT IS READ.
+ * It is NOT true that every legitimate bucket key in `Image.url` is a uuid. Every key-MINTING site
+ * is a bare `crypto.randomUUID()` with no prefix and no extension — `src/pages/api/v1/image-upload/
+ * index.ts`, `.../multipart/index.ts`, `uploadImageBufferToStore` in `src/utils/s3-utils.ts`, the
+ * orchestrator poll/polyGen handlers, the app-listing asset service and the comics router's own
+ * upload paths — but several WRITE paths accept a caller-supplied string and never check its shape:
+ * seven `comics.router.ts` call sites validate the url with `z.string().min(1)`, and the article
+ * `edge-media` sync (`article-content-cleanup.service.ts`) copies the attribute verbatim from
+ * sanitized HTML, where the sanitizer does not filter a custom attribute named `url`. Any of those
+ * can put `foo/uuid`, `photo.jpg` or `12345` into the column.
+ *
+ * So this is a deliberate UNDER-approximation: it matches the shape our upload endpoints issue, and
+ * classifies everything else as "not something to ask this bucket about". The direction is chosen
+ * from what each error COSTS, not from what is most accurate:
+ *
+ *   - a false NEGATIVE (a real key we decline to probe) costs a detection we would otherwise have
+ *     made — the caller falls back to whatever it did before the check existed;
+ *   - a false POSITIVE (a non-key we probe) costs a 404 that is indistinguishable from a genuine
+ *     miss, and the acting call site turns that into a PERMANENT, un-overridable refusal to publish
+ *     an image that may render fine.
+ *
+ * The heterogeneous, unvalidated population above is exactly where a 404 against our bucket is not
+ * evidence of loss, so it must not be probed by a check whose `absent` verdict enforces anything.
+ *
+ * Relation to the write validators: this is strictly BROADER than zod's `.uuid()` (it accepts an
+ * invalid version nibble), so every value `imageSchema`/`addPostImageSchema` admits as a key passes
+ * here. That is the sound direction — the guard never declines a key the schema called a key.
+ *
+ * A url carrying a URI scheme (`http:`, `https:`, `blob:`, `data:`) fails this test for free: none
+ * of them is a uuid. That is intentional and is why the older scheme-negative spelling was dropped
+ * rather than kept alongside — its complement swept in every legacy oddball above.
+ */
+const MEDIA_KEY_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isProbeableMediaKey(url: unknown): url is string {
+  return typeof url === 'string' && MEDIA_KEY_RE.test(url);
+}

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -66,9 +66,15 @@ export const MISSING_MEDIA_PUBLISH_MESSAGE =
  * The other refusal, and it needs its own words: nothing is missing from the store, because the row
  * never referred to the store at all. Telling a moderator to check storage for a `blob:` handle
  * would send them looking for something that was never there.
+ *
+ * 🔴 IT SAYS "DELETE IT", NOT "DELETE IT FROM THE MISSING MEDIA QUEUE", AND THE DIFFERENCE IS LOAD-
+ * BEARING. The spoke's delete ACTION is unwindowed (`missingMediaScope`), but the queue that renders
+ * it is bounded to the last 2 days (`ingestionErrorBaseWhere`) — and `blob:` urls come from a legacy
+ * upload bug, so the population is plausibly mostly older than that. Naming the queue would promise
+ * a listing that may not contain the row; naming the action promises only what is true.
  */
 export const UNRENDERABLE_MEDIA_PUBLISH_MESSAGE =
-  'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it from the Missing Media queue, or remove it from the article that uses it, and ask the uploader to upload the file again.';
+  'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it — recent ones are listed in the Missing Media queue — or remove it from the article that uses it and ask the uploader to upload the file again.';
 
 /** Thrown when the publish is refused. Never thrown for a verdict that allows. */
 export class MissingMediaError extends Error {
@@ -140,9 +146,11 @@ export const UNRENDERABLE_MEDIA_URL_PREFIX = 'blob:';
  * these on the stated grounds that they "render perfectly well", which was simply wrong.
  *
  * 🔴 A refusal must leave a reachable action, or it is a dead end rather than a guard. That is what
- * `UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` names, and it is only true because the spoke routes these
- * rows into its delete-only Missing Media queue (`missingMediaWhere` in the moderator app's
- * `ingestion.service.ts`) and the article surface stops offering an override that can only 400.
+ * `UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` names, and it is true because the spoke's delete gate
+ * (`missingMediaScope` in the moderator app's `ingestion.service.ts`) selects on THIS predicate —
+ * literally this constant, not a second spelling of it — and the article surface stops offering an
+ * override that can only 400. The spoke's delete-only Missing Media QUEUE renders the recent ones;
+ * the action itself is unwindowed, which is why the message names the action rather than the queue.
  *
  * Deliberately NOT extended to `data:` or `http(s):`. `http(s)` really does render — both renderers
  * pass it through and it is the documented legacy-avatar population. `data:` is a different case

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared rule for "may this image be published given what the media store says about its object?".
+ *
+ * An `Image` row can reference a media key that has no object behind it. The scan pipeline already
+ * detects that correctly — the scanner reports the media could not be downloaded, the failure is
+ * stamped `permanent`, and the row sits at `ingestion = 'Error'`, `nsfwLevel = 0`, i.e. invisible.
+ * The harm came from the moderator ingestion-error-review queue, which published such rows anyway:
+ * it set `ingestion = 'Scanned'` + an nsfwLevel unconditionally, with nothing checking that the
+ * media exists. Measured over ~92,000 image creations in 24h: 10 images had unfetchable media, all
+ * 10 confirmed absent from the media store by a direct existence check, and 8 of those 10 were
+ * published by the review queue that same day — so they now serve a 404 to every viewer.
+ *
+ * 🔴 The rule lives HERE, in one place, because the publish happens in TWO runtimes: the Next.js
+ * app's `resolveIngestionError` (Prisma) and the moderator spoke's `resolveIngestionError` (Kysely).
+ * A predicate open-coded at two call sites regenerates the same bug at both, and the spoke is the
+ * one that actually caused the incident. Each runtime supplies only the PROBE (how to ask its own
+ * storage client); the verdict and the refusal are decided here.
+ */
+
+/**
+ * What consulting the media store concluded. 🔴 THREE values, never a boolean.
+ *
+ * A boolean forces the "could not consult the store" case to be reported as one of the other two,
+ * and both readings are wrong. Counting it as present asserts we confirmed an object we never saw;
+ * counting it as absent lets a verification step block legitimate moderation whenever credentials
+ * are missing, a key is rotated, or the network hiccups. The same reasoning is written out at the
+ * upload-completion call site that solved this problem first.
+ */
+export const MediaPresence = {
+  /** The store answered: the object is there. */
+  Present: 'present',
+  /** The store answered: the object is NOT there. The only verdict that refuses a publish. */
+  Absent: 'absent',
+  /** The store could not be consulted (threw, timed out, unconfigured, 403). Never a refusal. */
+  Unknown: 'unknown',
+} as const;
+export type MediaPresence = (typeof MediaPresence)[keyof typeof MediaPresence];
+
+/**
+ * Shown to a moderator, verbatim, by both runtimes — the spoke renders it into its form error and
+ * the main app puts it on a BAD_REQUEST. So it has to explain what happened and what to do instead,
+ * not read like a stack trace.
+ */
+export const MISSING_MEDIA_PUBLISH_MESSAGE =
+  'The media file for this image is missing from storage, so it cannot be published — publishing it would put a permanently broken image on the site. Delete it, or ask the uploader to upload it again.';
+
+/** Thrown when the store ANSWERED that the object is absent. Never thrown for an unknown answer. */
+export class MissingMediaError extends Error {
+  constructor(message: string = MISSING_MEDIA_PUBLISH_MESSAGE) {
+    super(message);
+    this.name = 'MissingMediaError';
+  }
+}
+
+/**
+ * The stored classification a scan failure carries when the media itself can never be fetched or
+ * decoded. It is a classification written at scan time, NOT a match on the scanner's prose: keying
+ * a queue off the reason text would be walked past by a single scanner reword. The class is the
+ * TRIGGER for treating an image as missing-media; an existence check against the store is the
+ * VERDICT.
+ */
+export const IMAGE_SCAN_FAILURE_CLASS_PERMANENT = 'permanent';
+
+export type MediaPublishDecision =
+  | { allow: true; presence: typeof MediaPresence.Present | typeof MediaPresence.Unknown }
+  | { allow: false; presence: typeof MediaPresence.Absent; message: string };
+
+/**
+ * The whole rule, as a pure function. Refuse on `absent` — and ONLY on `absent`.
+ *
+ * Inability to consult the store is not evidence of loss, so `unknown` allows. That is the
+ * fail-open half and it is the easy one to get backwards: getting it wrong turns a storage blip
+ * into a moderation outage on a queue whose whole job is unblocking content.
+ */
+export function decideMediaPublish(presence: MediaPresence): MediaPublishDecision {
+  if (presence === MediaPresence.Absent)
+    return { allow: false, presence: MediaPresence.Absent, message: MISSING_MEDIA_PUBLISH_MESSAGE };
+  return { allow: true, presence };
+}
+
+export type AssertMediaPresentOptions = {
+  /** Ask the runtime's own storage client. May throw — a throw is an `unknown` answer, not a miss. */
+  probe: () => Promise<MediaPresence>;
+  /** Called for every `unknown`, with the probe's error when it threw. Silent fail-open is how a
+   *  guard lies for months, so the caller is expected to log here. Must not throw. */
+  onUnknown?: (error: unknown) => void;
+  /** Optional runtime-appropriate throw (e.g. a tRPC BAD_REQUEST). CONTRACT: it must throw. */
+  raise?: (message: string) => void;
+};
+
+/**
+ * Run a caller-supplied probe and refuse the publish when — and only when — the store answered
+ * that the object is absent.
+ *
+ * The probe is called inside the try on purpose: a runtime whose storage client throws on
+ * construction (unconfigured credentials) must land on `unknown` and allow, exactly as a network
+ * failure does. A guard that can fail the path by its own absence is worse than no guard.
+ */
+export async function assertMediaPresentForPublish({
+  probe,
+  onUnknown,
+  raise,
+}: AssertMediaPresentOptions): Promise<MediaPublishDecision> {
+  let presence: MediaPresence;
+  let probeError: unknown;
+  try {
+    presence = await probe();
+  } catch (error) {
+    probeError = error;
+    presence = MediaPresence.Unknown;
+  }
+
+  if (presence === MediaPresence.Unknown) onUnknown?.(probeError);
+
+  const decision = decideMediaPublish(presence);
+  if (!decision.allow) {
+    raise?.(decision.message);
+    // Backstop, not dead code: `raise` is contractually a throw, but a caller that passes one which
+    // merely RETURNS would otherwise fall through and publish the broken image — the exact defect
+    // this module exists to remove. The refusal must not depend on the caller getting that right.
+    throw new MissingMediaError(decision.message);
+  }
+  return decision;
+}

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -68,7 +68,7 @@ export const MISSING_MEDIA_PUBLISH_MESSAGE =
  * would send them looking for something that was never there.
  */
 export const UNRENDERABLE_MEDIA_PUBLISH_MESSAGE =
-  'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it, or ask the uploader to upload it again.';
+  'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it from the Missing Media queue, or remove it from the article that uses it, and ask the uploader to upload the file again.';
 
 /** Thrown when the publish is refused. Never thrown for a verdict that allows. */
 export class MissingMediaError extends Error {
@@ -99,21 +99,50 @@ export const IMAGE_SCAN_FAILURE_CLASS_PERMANENT = 'permanent';
 export { isProbeableMediaKey };
 
 /**
+ * The one url prefix `isUnrenderableMediaUrl` refuses, exported so the SQL that routes these rows to
+ * a queue offering a delete cannot spell it differently from the predicate that refuses them.
+ *
+ * 🔴 It is matched CASE-SENSITIVELY, and that is the whole warrant — see `isUnrenderableMediaUrl`.
+ * It also has to stay free of `%` and `_`, because the spoke interpolates it into a SQL `LIKE`
+ * pattern; `no LIKE metacharacters` is pinned by this module's own test.
+ */
+export const UNRENDERABLE_MEDIA_URL_PREFIX = 'blob:';
+
+/**
  * Is this url broken for every viewer regardless of what any store holds?
  *
  * One shape qualifies today: a `blob:` handle. `URL.createObjectURL` mints a url scoped to the
  * document that created it, and a legacy upload bug persisted some into `Image.url` (see
  * `src/utils/type-guards.ts`, which records that the embedded uuid is a browser handle and "can't
- * be salvaged"). Both renderers pass it through VERBATIM rather than rewriting it to the image CDN
- * — `src/client-utils/cf-images-utils.ts` and `apps/moderator/src/lib/media/edge-url.ts` both do
- * `if (!src || src.startsWith('http') || src.startsWith('blob')) return src;` — so publishing one
- * emits `<img src="blob:…">` into someone else's browser, which resolves to nothing. Forever.
+ * be salvaged").
+ *
+ * 🔴 THE WARRANT IS THE RENDERERS' OWN TEST, SO THIS ONE IS SPELLED THE SAME WAY THEY SPELL IT.
+ * `src/client-utils/cf-images-utils.ts` and `apps/moderator/src/lib/media/edge-url.ts` both do
+ * `if (!src || src.startsWith('http') || src.startsWith('blob')) return src;` — a CASE-SENSITIVE,
+ * colon-less prefix test. Everything that clears that test is emitted VERBATIM into someone else's
+ * browser, so `<img src="blob:…">` resolves to nothing. Forever.
+ *
+ * That fixes the shape of this predicate in both directions:
+ *
+ *   - It is case-SENSITIVE. A `/^blob:/i` spelling refused `BLOB:https://…`, which the renderers do
+ *     NOT pass through — they rewrite it into a CDN path. That row is probably broken too, but by a
+ *     different mechanism and by inference, and inference does not license a permanent refusal. It
+ *     is left fail-open, exactly like `data:` below.
+ *   - It keeps the colon, so it is a strict SUBSET of the renderers' passthrough set rather than
+ *     equal to it. `blobfish.png` clears `startsWith('blob')` and really is passed through verbatim
+ *     — but it is a relative path, not a url scheme, it is not a population anyone has measured,
+ *     and refusing it would be enforcing on a shape this guard has no evidence about.
  *
  * 🔴 This is a REFUSAL decided WITHOUT a probe, so it is held to the same bar as `absent` and it is
  * the one case that clears it: the harm is definitional rather than inferred. There is no store
  * state, credential, or bucket name under which a `blob:` row renders, so the false-positive risk
  * that makes every other permanent refusal dangerous does not exist here. The previous rule allowed
  * these on the stated grounds that they "render perfectly well", which was simply wrong.
+ *
+ * 🔴 A refusal must leave a reachable action, or it is a dead end rather than a guard. That is what
+ * `UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` names, and it is only true because the spoke routes these
+ * rows into its delete-only Missing Media queue (`missingMediaWhere` in the moderator app's
+ * `ingestion.service.ts`) and the article surface stops offering an override that can only 400.
  *
  * Deliberately NOT extended to `data:` or `http(s):`. `http(s)` really does render — both renderers
  * pass it through and it is the documented legacy-avatar population. `data:` is a different case
@@ -122,8 +151,17 @@ export { isProbeableMediaKey };
  * not enough to justify a permanent refusal. It stays fail-open until someone measures it.
  */
 export function isUnrenderableMediaUrl(url: unknown): url is string {
-  return typeof url === 'string' && /^blob:/i.test(url);
+  return typeof url === 'string' && url.startsWith(UNRENDERABLE_MEDIA_URL_PREFIX);
 }
+
+/**
+ * The three answers a media STORE can give. See `AssertMediaPresentOptions.probe` for why the probe
+ * is typed on this rather than on the full five-valued `MediaPresence`.
+ */
+export type MediaProbeAnswer =
+  | typeof MediaPresence.Present
+  | typeof MediaPresence.Absent
+  | typeof MediaPresence.Unknown;
 
 export type MediaPublishDecision =
   | {
@@ -200,8 +238,15 @@ export type AssertMediaPresentOptions = {
    * Ask the runtime's own storage client about a key. 🔴 Called ONLY with a value that already
    * passed `isProbeableMediaKey`, so it never has to re-check, and never can re-check differently.
    * May throw — a throw is an `unknown` answer, not a miss.
+   *
+   * 🔴 Its return type is NARROWER than `MediaPresence`, deliberately. The other two members are
+   * decisions this module makes ABOUT the url, before any store is consulted, and a probe that
+   * could return them would defeat both: a store-sourced `not-applicable` skips `onSkipped`, whose
+   * whole job is counting the short-circuit, and a store-sourced `unrenderable` produces a refusal
+   * whose `onRefused` comment asserts no bucket state can cause it. A bucket answers one of three
+   * things — it is there, it is not, or it would not say.
    */
-  probe: (key: string) => Promise<MediaPresence>;
+  probe: (key: string) => Promise<MediaProbeAnswer>;
   /**
    * Called for every `unknown`, with why. Silent fail-open is how a guard lies for months, so the
    * caller is expected to log here. Must not throw.

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -261,8 +261,7 @@ export async function assertMediaPresentForPublish({
     }
   }
 
-  if (presence === MediaPresence.Unknown)
-    onUnknown?.({ reason: unknownReason, error: probeError });
+  if (presence === MediaPresence.Unknown) onUnknown?.({ reason: unknownReason, error: probeError });
 
   const decision = decideMediaPublish(presence);
   if (!decision.allow) {

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -73,11 +73,16 @@ export const IMAGE_SCAN_FAILURE_CLASS_PERMANENT = 'permanent';
  * miss — so without this check the guard would REFUSE, permanently and with no override, an image
  * that renders perfectly well. That is strictly worse than the bug the guard exists to fix.
  *
- * The main app's delete path makes exactly this exclusion for exactly this reason ("Legacy avatar
- * rows hold a full external URL where every other row holds a bucket key"), and it is why the
- * predicate lives HERE: the two runtimes reach the store through different clients that fail
- * differently on a non-key url (one 404s to `absent`, the other throws to `unknown`), so leaving it
- * to them produced opposite verdicts for the same row.
+ * The main app's delete path excludes non-keys for the same REASON ("Legacy avatar rows hold a full
+ * external URL where every other row holds a bucket key") but with a different TEST — it checks
+ * `url.startsWith('http')`. The two disagree in both directions: `startsWith('http')` would exclude
+ * a key literally named `httpfoo` and would NOT exclude `blob:` or `data:`; this one does the
+ * opposite. They are not yet consolidated, so do not read this as one rule in two places — it is
+ * two spellings of one idea, and the delete path's is the older.
+ *
+ * The predicate lives HERE because the two PUBLISH runtimes reach the store through different
+ * clients that fail differently on a non-key url (one 404s to `absent`, the other throws to
+ * `unknown`), so leaving it to them produced opposite verdicts for the same row.
  *
  * Conservative in the safe direction: anything carrying a URI scheme is treated as not-a-key, which
  * yields `unknown` and therefore ALLOWS. A false negative here costs nothing; a false positive is

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -157,6 +157,22 @@ export const UNRENDERABLE_MEDIA_URL_PREFIX = 'blob:';
  * and is left alone on purpose: it is NOT in either renderer's passthrough set, so it is rewritten
  * into a CDN path and is probably broken too, but "probably broken" is inference, and inference is
  * not enough to justify a permanent refusal. It stays fail-open until someone measures it.
+ *
+ * 🔴 THERE ARE OTHER SPELLINGS OF "IS THIS A BLOB URL" IN THE REPO, AND THEY DIVERGE FROM THIS ONE
+ * ON PURPOSE. Recorded here because "one rule, one place" is the usual instinct and consolidating
+ * these would be wrong — they answer a different question, so they get to be wider:
+ *
+ *   - `isBlobUrl` (`src/utils/type-guards.ts`) and the inline `src?.startsWith('blob')` in
+ *     `src/libs/tiptap/extensions/CustomImage.tsx` / `src/components/TipTap/EdgeMediaNode.tsx` are
+ *     colon-LESS, i.e. strictly wider: they also catch `blobfish.png`. Their consequence is a
+ *     DISPLAY FALLBACK — render `user.image` instead, treat the node as an unsaved object url — and
+ *     a false positive there costs one avatar. Being wide is the right trade for that.
+ *   - This predicate's consequence is a PERMANENT PUBLISH REFUSAL. A false positive there is
+ *     unrecoverable for the uploader, so it is deliberately the narrower, colon-bearing subset, on
+ *     the reasoning two paragraphs up.
+ *
+ * So: do NOT "unify" them, and do not widen this one to match theirs. If you are adding a THIRD
+ * spelling, decide which of the two consequences yours has and reuse the matching predicate.
  */
 export function isUnrenderableMediaUrl(url: unknown): url is string {
   return typeof url === 'string' && url.startsWith(UNRENDERABLE_MEDIA_URL_PREFIX);

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -16,23 +16,41 @@
  * one that actually caused the incident. Each runtime supplies only the PROBE (how to ask its own
  * storage client); the verdict and the refusal are decided here.
  */
+import { isProbeableMediaKey } from './media-key';
 
 /**
- * What consulting the media store concluded. 🔴 THREE values, never a boolean.
+ * What consulting the media store concluded. 🔴 NEVER a boolean, and never fewer values than there
+ * are distinguishable causes.
  *
  * A boolean forces the "could not consult the store" case to be reported as one of the other two,
  * and both readings are wrong. Counting it as present asserts we confirmed an object we never saw;
  * counting it as absent lets a verification step block legitimate moderation whenever credentials
  * are missing, a key is rotated, or the network hiccups. The same reasoning is written out at the
  * upload-completion call site that solved this problem first.
+ *
+ * 🔴 `NotApplicable` exists for the same reason one step down. It used to be folded into `Unknown`,
+ * which meant the not-a-key short-circuit and a genuine store failure emitted an identical log line
+ * with an empty `error` — reintroducing, inside the detector, exactly the indistinguishability the
+ * log exists to remove. An `unknown` count that silently includes every profile-picture url cannot
+ * answer the one question it is watched for: "is the bucket answering at all?"
  */
 export const MediaPresence = {
   /** The store answered: the object is there. */
   Present: 'present',
-  /** The store answered: the object is NOT there. The only verdict that refuses a publish. */
+  /** The store answered: the object is NOT there. Refuses the publish. */
   Absent: 'absent',
   /** The store could not be consulted (threw, timed out, unconfigured, 403). Never a refusal. */
   Unknown: 'unknown',
+  /**
+   * The url is not a key this store issues, so there was nothing to ask. Allows, and is NOT an
+   * inconclusive probe — the probe was never run. See `isProbeableMediaKey`.
+   */
+  NotApplicable: 'not-applicable',
+  /**
+   * The url can never render for a viewer, whatever the store holds. Refuses — see
+   * `isUnrenderableMediaUrl` for the one shape this covers and why it is decided without a probe.
+   */
+  Unrenderable: 'unrenderable',
 } as const;
 export type MediaPresence = (typeof MediaPresence)[keyof typeof MediaPresence];
 
@@ -44,7 +62,15 @@ export type MediaPresence = (typeof MediaPresence)[keyof typeof MediaPresence];
 export const MISSING_MEDIA_PUBLISH_MESSAGE =
   'The media file for this image is missing from storage, so it cannot be published — publishing it would put a permanently broken image on the site. Delete it, or ask the uploader to upload it again.';
 
-/** Thrown when the store ANSWERED that the object is absent. Never thrown for an unknown answer. */
+/**
+ * The other refusal, and it needs its own words: nothing is missing from the store, because the row
+ * never referred to the store at all. Telling a moderator to check storage for a `blob:` handle
+ * would send them looking for something that was never there.
+ */
+export const UNRENDERABLE_MEDIA_PUBLISH_MESSAGE =
+  'This image points at a browser-session handle (a blob: url) rather than an uploaded file, so it can never load for anyone else and cannot be published. Delete it, or ask the uploader to upload it again.';
+
+/** Thrown when the publish is refused. Never thrown for a verdict that allows. */
 export class MissingMediaError extends Error {
   constructor(message: string = MISSING_MEDIA_PUBLISH_MESSAGE) {
     super(message);
@@ -62,101 +88,185 @@ export class MissingMediaError extends Error {
 export const IMAGE_SCAN_FAILURE_CLASS_PERMANENT = 'permanent';
 
 /**
- * Can this `Image.url` be handed to the media store as an object key at all?
+ * "Is this `Image.url` a key we can ask the store about?" — re-exported, not defined here.
  *
- * 🔴 NOT every `Image.url` is a bucket key. Most are a bare UUID, but some rows hold a full
- * external URL — profile pictures accept a whitelisted external avatar CDN and store it verbatim,
- * and that row is created and ingested like any other, so it carries today's timestamp and lands in
- * the review queue's window. A legacy bug also persisted `blob:` handles.
- *
- * Handing one of those to a bucket as a Key returns 404, which is indistinguishable from a genuine
- * miss — so without this check the guard would REFUSE, permanently and with no override, an image
- * that renders perfectly well. That is strictly worse than the bug the guard exists to fix.
- *
- * The main app's delete path excludes non-keys for the same REASON ("Legacy avatar rows hold a full
- * external URL where every other row holds a bucket key") but with a different TEST — it checks
- * `url.startsWith('http')`. The two disagree in both directions: `startsWith('http')` would exclude
- * a key literally named `httpfoo` and would NOT exclude `blob:` or `data:`; this one does the
- * opposite. They are not yet consolidated, so do not read this as one rule in two places — it is
- * two spellings of one idea, and the delete path's is the older.
- *
- * The predicate lives HERE because the two PUBLISH runtimes reach the store through different
- * clients that fail differently on a non-key url (one 404s to `absent`, the other throws to
- * `unknown`), so leaving it to them produced opposite verdicts for the same row.
- *
- * Conservative in the safe direction: anything carrying a URI scheme is treated as not-a-key, which
- * yields `unknown` and therefore ALLOWS. A false negative here costs nothing; a false positive is
- * the permanent refusal above. A `/` cannot appear in a scheme, so a key containing a colon later
- * in a path is unaffected.
+ * 🔴 It is defined in `@civitai/shared/media-key` because the UPLOAD-time existence check needs the
+ * same rule and must not carry its own copy: this module used to define its own, by the opposite
+ * construction, and the two disagreed on real rows. Read that file for why the test is what it is —
+ * in particular for why the premise "every bucket key is a uuid" is FALSE and the predicate is a
+ * deliberate under-approximation anyway.
  */
-export function isProbeableMediaKey(url: string | null | undefined): url is string {
-  return !!url && !/^[a-z][a-z0-9+.-]*:/i.test(url);
+export { isProbeableMediaKey };
+
+/**
+ * Is this url broken for every viewer regardless of what any store holds?
+ *
+ * One shape qualifies today: a `blob:` handle. `URL.createObjectURL` mints a url scoped to the
+ * document that created it, and a legacy upload bug persisted some into `Image.url` (see
+ * `src/utils/type-guards.ts`, which records that the embedded uuid is a browser handle and "can't
+ * be salvaged"). Both renderers pass it through VERBATIM rather than rewriting it to the image CDN
+ * — `src/client-utils/cf-images-utils.ts` and `apps/moderator/src/lib/media/edge-url.ts` both do
+ * `if (!src || src.startsWith('http') || src.startsWith('blob')) return src;` — so publishing one
+ * emits `<img src="blob:…">` into someone else's browser, which resolves to nothing. Forever.
+ *
+ * 🔴 This is a REFUSAL decided WITHOUT a probe, so it is held to the same bar as `absent` and it is
+ * the one case that clears it: the harm is definitional rather than inferred. There is no store
+ * state, credential, or bucket name under which a `blob:` row renders, so the false-positive risk
+ * that makes every other permanent refusal dangerous does not exist here. The previous rule allowed
+ * these on the stated grounds that they "render perfectly well", which was simply wrong.
+ *
+ * Deliberately NOT extended to `data:` or `http(s):`. `http(s)` really does render — both renderers
+ * pass it through and it is the documented legacy-avatar population. `data:` is a different case
+ * and is left alone on purpose: it is NOT in either renderer's passthrough set, so it is rewritten
+ * into a CDN path and is probably broken too, but "probably broken" is inference, and inference is
+ * not enough to justify a permanent refusal. It stays fail-open until someone measures it.
+ */
+export function isUnrenderableMediaUrl(url: unknown): url is string {
+  return typeof url === 'string' && /^blob:/i.test(url);
 }
 
 export type MediaPublishDecision =
-  | { allow: true; presence: typeof MediaPresence.Present | typeof MediaPresence.Unknown }
-  | { allow: false; presence: typeof MediaPresence.Absent; message: string };
+  | {
+      allow: true;
+      presence:
+        | typeof MediaPresence.Present
+        | typeof MediaPresence.Unknown
+        | typeof MediaPresence.NotApplicable;
+    }
+  | {
+      allow: false;
+      presence: typeof MediaPresence.Absent | typeof MediaPresence.Unrenderable;
+      message: string;
+    };
 
 /**
- * The whole rule, as a pure function. Refuse on `absent` — and ONLY on `absent`.
+ * The whole rule, as a pure function. Refuse on `absent` and `unrenderable` — and only those two.
  *
- * Inability to consult the store is not evidence of loss, so `unknown` allows. That is the
- * fail-open half and it is the easy one to get backwards: getting it wrong turns a storage blip
- * into a moderation outage on a queue whose whole job is unblocking content.
+ * Inability to consult the store is not evidence of loss, so `unknown` allows, and so does
+ * `not-applicable`. That is the fail-open half and it is the easy one to get backwards: getting it
+ * wrong turns a storage blip into a moderation outage on a queue whose whole job is unblocking
+ * content. The two refusing verdicts differ in provenance — one is the store's answer, one is a
+ * property of the url itself — which is why they carry different messages.
  */
 export function decideMediaPublish(presence: MediaPresence): MediaPublishDecision {
   if (presence === MediaPresence.Absent)
     return { allow: false, presence: MediaPresence.Absent, message: MISSING_MEDIA_PUBLISH_MESSAGE };
+  if (presence === MediaPresence.Unrenderable)
+    return {
+      allow: false,
+      presence: MediaPresence.Unrenderable,
+      message: UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
+    };
   return { allow: true, presence };
 }
 
+/**
+ * The maximum number of characters of a probe failure that reaches a log line.
+ *
+ * A storage client's error message can embed the remote response BODY verbatim, which is
+ * third-party text of unbounded length — an HTML error page, an XML fault document, or whatever a
+ * misbehaving proxy returns. Writing that straight to stdout puts an attacker-influenced,
+ * unbounded blob into the log pipeline once per refused publish.
+ */
+export const MEDIA_PROBE_ERROR_MAX_LENGTH = 200;
+
+/**
+ * Render a probe failure as a bounded, single-line string safe to log.
+ *
+ * Truncation is marked, so a reader can tell a short message from a clipped one; without the marker
+ * a cut-off body reads as a complete (and different) error.
+ */
+export function summarizeProbeError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error ?? '');
+  const flat = raw.replace(/\s+/g, ' ').trim();
+  if (flat.length <= MEDIA_PROBE_ERROR_MAX_LENGTH) return flat;
+  return `${flat.slice(0, MEDIA_PROBE_ERROR_MAX_LENGTH)}…[truncated]`;
+}
+
+/** Why a probe could not answer. The two are indistinguishable in the payload without this. */
+export type MediaProbeUnknownReason =
+  /** The probe threw — client could not be built, network failed, credentials rotated, timeout. */
+  | 'probe-threw'
+  /** The probe ran and the store itself declined to answer (a 403, a 5xx, an unclassified shape). */
+  | 'store-inconclusive';
+
 export type AssertMediaPresentOptions = {
-  /** Ask the runtime's own storage client. May throw — a throw is an `unknown` answer, not a miss. */
-  probe: () => Promise<MediaPresence>;
-  /** Called for every `unknown`, with the probe's error when it threw. Silent fail-open is how a
-   *  guard lies for months, so the caller is expected to log here. Must not throw. */
-  onUnknown?: (error: unknown) => void;
   /**
-   * Called for every REFUSAL, before it is thrown. Must not throw.
+   * The row's `Image.url`. Classified HERE, not by the caller: this function decides whether the
+   * probe runs at all, so a runtime cannot reintroduce its own idea of what a key is.
+   */
+  url: unknown;
+  /**
+   * Ask the runtime's own storage client about a key. 🔴 Called ONLY with a value that already
+   * passed `isProbeableMediaKey`, so it never has to re-check, and never can re-check differently.
+   * May throw — a throw is an `unknown` answer, not a miss.
+   */
+  probe: (key: string) => Promise<MediaPresence>;
+  /**
+   * Called for every `unknown`, with why. Silent fail-open is how a guard lies for months, so the
+   * caller is expected to log here. Must not throw.
+   *
+   * 🔴 NOT called for `not-applicable`. It used to be, because the two shared one verdict, and the
+   * resulting log line could not tell a store outage from a profile-picture url — which made the
+   * one number this hook exists to produce unreadable.
+   */
+  onUnknown?: (info: { reason: MediaProbeUnknownReason; error: unknown }) => void;
+  /** Called when the url was not a key, so no probe ran. Allows. Must not throw. */
+  onSkipped?: () => void;
+  /**
+   * Called for every REFUSAL, before it is thrown, with which verdict caused it. Must not throw.
    *
    * The mirror of `onUnknown`, needed for the same reason in the opposite direction: a misconfigured
    * bucket name answers 404 for EVERY key, which this module reads as `absent`. That refuses every
    * publish while looking exactly like a run where the media really was missing. A silent
    * fail-CLOSED lies just as long as a silent fail-open.
    */
-  onRefused?: () => void;
+  onRefused?: (presence: typeof MediaPresence.Absent | typeof MediaPresence.Unrenderable) => void;
   /** Optional runtime-appropriate throw (e.g. a tRPC BAD_REQUEST). CONTRACT: it must throw. */
   raise?: (message: string) => void;
 };
 
 /**
- * Run a caller-supplied probe and refuse the publish when — and only when — the store answered
- * that the object is absent.
+ * Classify the url, probe it if that is a meaningful thing to do, and refuse the publish when — and
+ * only when — the answer is `absent` or the url is one that can never render.
  *
  * The probe is called inside the try on purpose: a runtime whose storage client throws on
  * construction (unconfigured credentials) must land on `unknown` and allow, exactly as a network
  * failure does. A guard that can fail the path by its own absence is worse than no guard.
  */
 export async function assertMediaPresentForPublish({
+  url,
   probe,
   onUnknown,
+  onSkipped,
   onRefused,
   raise,
 }: AssertMediaPresentOptions): Promise<MediaPublishDecision> {
   let presence: MediaPresence;
   let probeError: unknown;
-  try {
-    presence = await probe();
-  } catch (error) {
-    probeError = error;
-    presence = MediaPresence.Unknown;
+  let unknownReason: MediaProbeUnknownReason = 'store-inconclusive';
+
+  if (isUnrenderableMediaUrl(url)) {
+    presence = MediaPresence.Unrenderable;
+  } else if (!isProbeableMediaKey(url)) {
+    presence = MediaPresence.NotApplicable;
+    onSkipped?.();
+  } else {
+    try {
+      presence = await probe(url);
+    } catch (error) {
+      probeError = error;
+      unknownReason = 'probe-threw';
+      presence = MediaPresence.Unknown;
+    }
   }
 
-  if (presence === MediaPresence.Unknown) onUnknown?.(probeError);
+  if (presence === MediaPresence.Unknown)
+    onUnknown?.({ reason: unknownReason, error: probeError });
 
   const decision = decideMediaPublish(presence);
   if (!decision.allow) {
-    onRefused?.();
+    onRefused?.(decision.presence);
     raise?.(decision.message);
     // Backstop, not dead code: `raise` is contractually a throw, but a caller that passes one which
     // merely RETURNS would otherwise fall through and publish the broken image — the exact defect

--- a/packages/civitai-shared/src/missing-media.ts
+++ b/packages/civitai-shared/src/missing-media.ts
@@ -61,6 +61,33 @@ export class MissingMediaError extends Error {
  */
 export const IMAGE_SCAN_FAILURE_CLASS_PERMANENT = 'permanent';
 
+/**
+ * Can this `Image.url` be handed to the media store as an object key at all?
+ *
+ * 🔴 NOT every `Image.url` is a bucket key. Most are a bare UUID, but some rows hold a full
+ * external URL — profile pictures accept a whitelisted external avatar CDN and store it verbatim,
+ * and that row is created and ingested like any other, so it carries today's timestamp and lands in
+ * the review queue's window. A legacy bug also persisted `blob:` handles.
+ *
+ * Handing one of those to a bucket as a Key returns 404, which is indistinguishable from a genuine
+ * miss — so without this check the guard would REFUSE, permanently and with no override, an image
+ * that renders perfectly well. That is strictly worse than the bug the guard exists to fix.
+ *
+ * The main app's delete path makes exactly this exclusion for exactly this reason ("Legacy avatar
+ * rows hold a full external URL where every other row holds a bucket key"), and it is why the
+ * predicate lives HERE: the two runtimes reach the store through different clients that fail
+ * differently on a non-key url (one 404s to `absent`, the other throws to `unknown`), so leaving it
+ * to them produced opposite verdicts for the same row.
+ *
+ * Conservative in the safe direction: anything carrying a URI scheme is treated as not-a-key, which
+ * yields `unknown` and therefore ALLOWS. A false negative here costs nothing; a false positive is
+ * the permanent refusal above. A `/` cannot appear in a scheme, so a key containing a colon later
+ * in a path is unaffected.
+ */
+export function isProbeableMediaKey(url: string | null | undefined): url is string {
+  return !!url && !/^[a-z][a-z0-9+.-]*:/i.test(url);
+}
+
 export type MediaPublishDecision =
   | { allow: true; presence: typeof MediaPresence.Present | typeof MediaPresence.Unknown }
   | { allow: false; presence: typeof MediaPresence.Absent; message: string };
@@ -84,6 +111,15 @@ export type AssertMediaPresentOptions = {
   /** Called for every `unknown`, with the probe's error when it threw. Silent fail-open is how a
    *  guard lies for months, so the caller is expected to log here. Must not throw. */
   onUnknown?: (error: unknown) => void;
+  /**
+   * Called for every REFUSAL, before it is thrown. Must not throw.
+   *
+   * The mirror of `onUnknown`, needed for the same reason in the opposite direction: a misconfigured
+   * bucket name answers 404 for EVERY key, which this module reads as `absent`. That refuses every
+   * publish while looking exactly like a run where the media really was missing. A silent
+   * fail-CLOSED lies just as long as a silent fail-open.
+   */
+  onRefused?: () => void;
   /** Optional runtime-appropriate throw (e.g. a tRPC BAD_REQUEST). CONTRACT: it must throw. */
   raise?: (message: string) => void;
 };
@@ -99,6 +135,7 @@ export type AssertMediaPresentOptions = {
 export async function assertMediaPresentForPublish({
   probe,
   onUnknown,
+  onRefused,
   raise,
 }: AssertMediaPresentOptions): Promise<MediaPublishDecision> {
   let presence: MediaPresence;
@@ -114,6 +151,7 @@ export async function assertMediaPresentForPublish({
 
   const decision = decideMediaPublish(presence);
   if (!decision.allow) {
+    onRefused?.();
     raise?.(decision.message);
     // Backstop, not dead code: `raise` is contractually a throw, but a caller that passes one which
     // merely RETURNS would otherwise fall through and publish the broken image — the exact defect

--- a/packages/civitai-shared/vitest.config.ts
+++ b/packages/civitai-shared/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// Same shape as the other `packages/*` configs. The root config globs
+// `packages/*/vitest.config.ts` into its project list, so adding this file is what makes this
+// package's suite run at all — without it the tests exist on disk and nothing invokes them.
+// The project name comes from `package.json` (`@civitai/shared`), which is what
+// `--project '@civitai/*'` (pnpm test:packages:run) selects.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1589,6 +1589,10 @@ importers:
       '@civitai/db-schema':
         specifier: workspace:*
         version: link:../civitai-db-schema
+    devDependencies:
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.9.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(jsdom@27.4.0(@noble/hashes@1.8.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(msw@2.12.10(@types/node@24.13.3)(typescript@5.9.3))(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(sugarss@5.0.1(postcss@8.5.23))(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.1))
 
   packages/civitai-storage:
     dependencies:

--- a/src/components/Article/ArticleProblematicImages.tsx
+++ b/src/components/Article/ArticleProblematicImages.tsx
@@ -23,6 +23,7 @@ import { showErrorNotification, showSuccessNotification } from '~/utils/notifica
 import { browsingLevels, browsingLevelLabels } from '~/shared/constants/browsingLevel.constants';
 import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import type { EntityModerationStatus } from '~/shared/utils/prisma/enums';
+import { articleImageActions } from './articleImageActions';
 
 export type TextModerationIssue = {
   // Terminal-state reason the text pipeline produced an article-blocking result.
@@ -261,41 +262,51 @@ export function ArticleProblematicImages({
               </Text>
             </Group>
             <Stack gap="sm">
-              {blockedImages.map((image) => (
-                <Paper key={image.id} p="xs" withBorder className="border-l-2 border-l-red-6">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                    <div className="flex min-w-0 flex-1 items-start gap-3">
-                      <div className="relative size-16 shrink-0 overflow-hidden rounded border border-red-6">
-                        <EdgeMedia
-                          src={image.url}
-                          width={64}
-                          className="size-full object-cover"
-                          alt="Blocked image (removed for policy violation)"
-                        />
-                      </div>
-                      <Stack gap={4} className="min-w-0 flex-1">
-                        <Text size="xs" fw={500} c="red.7">
-                          Blocked: {image.blockedFor || 'Policy violation'}
-                        </Text>
-                        {canOverride && (
-                          <Text size="xs" c="dimmed">
-                            ID: {image.id}
+              {blockedImages.map((image) => {
+                const remedy = articleImageActions(image.url);
+                return (
+                  <Paper key={image.id} p="xs" withBorder className="border-l-2 border-l-red-6">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                      <div className="flex min-w-0 flex-1 items-start gap-3">
+                        <div className="relative size-16 shrink-0 overflow-hidden rounded border border-red-6">
+                          <EdgeMedia
+                            src={image.url}
+                            width={64}
+                            className="size-full object-cover"
+                            alt="Blocked image (removed for policy violation)"
+                          />
+                        </div>
+                        <Stack gap={4} className="min-w-0 flex-1">
+                          <Text size="xs" fw={500} c="red.7">
+                            Blocked: {image.blockedFor || 'Policy violation'}
                           </Text>
-                        )}
-                      </Stack>
-                    </div>
-                    {canOverride && (
-                      <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-                        <ImageOverrideControl
-                          articleId={articleId}
-                          imageId={image.id}
-                          locked={image.nsfwLevelLocked}
-                        />
+                          {canOverride && (
+                            <Text size="xs" c="dimmed">
+                              ID: {image.id}
+                            </Text>
+                          )}
+                          {/* The server refuses to publish this url whatever it is rated, so the note
+                            replaces the control rather than sitting beside it. */}
+                          {remedy.blockingNote && (
+                            <Text size="xs" c="dimmed">
+                              {remedy.blockingNote}
+                            </Text>
+                          )}
+                        </Stack>
                       </div>
-                    )}
-                  </div>
-                </Paper>
-              ))}
+                      {canOverride && remedy.offerOverride && (
+                        <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                          <ImageOverrideControl
+                            articleId={articleId}
+                            imageId={image.id}
+                            locked={image.nsfwLevelLocked}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </Paper>
+                );
+              })}
             </Stack>
           </Stack>
         )}
@@ -310,46 +321,53 @@ export function ArticleProblematicImages({
               </Text>
             </Group>
             <Stack gap="sm">
-              {errorImages.map((image) => (
-                <Paper key={image.id} p="xs" withBorder className="border-l-2 border-l-yellow-6">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                    <div className="flex min-w-0 flex-1 items-start gap-3">
-                      <div className="relative size-16 shrink-0 overflow-hidden rounded border border-yellow-6 bg-gray-1 dark:bg-gray-8">
-                        <EdgeMedia
-                          src={image.url}
-                          width={64}
-                          className="size-full object-cover"
-                          alt="Error image (may be broken)"
-                        />
-                      </div>
-                      <Stack gap={4} className="min-w-0 flex-1">
-                        <Text size="xs" fw={500} c="yellow.7">
-                          {errorImageCause(image)}
-                        </Text>
-                        {canOverride && (
-                          <Text size="xs" c="dimmed">
-                            ID: {image.id}
-                          </Text>
-                        )}
-                      </Stack>
-                    </div>
-                    {(canRetry || canOverride) && (
-                      <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-                        {canRetry && !image.nsfwLevelLocked && (
-                          <ImageRetryButton articleId={articleId} imageId={image.id} />
-                        )}
-                        {canOverride && (
-                          <ImageOverrideControl
-                            articleId={articleId}
-                            imageId={image.id}
-                            locked={image.nsfwLevelLocked}
+              {errorImages.map((image) => {
+                const remedy = articleImageActions(image.url);
+                return (
+                  <Paper key={image.id} p="xs" withBorder className="border-l-2 border-l-yellow-6">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                      <div className="flex min-w-0 flex-1 items-start gap-3">
+                        <div className="relative size-16 shrink-0 overflow-hidden rounded border border-yellow-6 bg-gray-1 dark:bg-gray-8">
+                          <EdgeMedia
+                            src={image.url}
+                            width={64}
+                            className="size-full object-cover"
+                            alt="Error image (may be broken)"
                           />
-                        )}
+                        </div>
+                        <Stack gap={4} className="min-w-0 flex-1">
+                          <Text size="xs" fw={500} c="yellow.7">
+                            {remedy.blockingNote ?? errorImageCause(image)}
+                          </Text>
+                          {canOverride && (
+                            <Text size="xs" c="dimmed">
+                              ID: {image.id}
+                            </Text>
+                          )}
+                        </Stack>
                       </div>
-                    )}
-                  </div>
-                </Paper>
-              ))}
+                      {/* Both controls are dead ends for an unrenderable url: Override calls the
+                        mutation that refuses it, and Retry re-fetches a handle nothing outside the
+                        originating document can read. The note above names the remedy instead. */}
+                      {((canRetry && remedy.offerRetry) ||
+                        (canOverride && remedy.offerOverride)) && (
+                        <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                          {canRetry && remedy.offerRetry && !image.nsfwLevelLocked && (
+                            <ImageRetryButton articleId={articleId} imageId={image.id} />
+                          )}
+                          {canOverride && remedy.offerOverride && (
+                            <ImageOverrideControl
+                              articleId={articleId}
+                              imageId={image.id}
+                              locked={image.nsfwLevelLocked}
+                            />
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </Paper>
+                );
+              })}
             </Stack>
           </Stack>
         )}

--- a/src/components/Article/ArticleProblematicImages.tsx
+++ b/src/components/Article/ArticleProblematicImages.tsx
@@ -267,6 +267,10 @@ export function ArticleProblematicImages({
             <Stack gap="sm">
               {blockedImages.map((image) => {
                 const remedy = articleImageActions(image.url);
+                // ONE expression per affordance — see the note on the error section below.
+                const showOverride =
+                  !!canOverride && remedy.offerOverride && !image.nsfwLevelLocked;
+                const showOverridden = !!canOverride && image.nsfwLevelLocked;
                 return (
                   <Paper key={image.id} p="xs" withBorder className="border-l-2 border-l-red-6">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
@@ -297,14 +301,14 @@ export function ArticleProblematicImages({
                           )}
                         </Stack>
                       </div>
-                      {canOverride && (remedy.offerOverride || image.nsfwLevelLocked) && (
+                      {(showOverride || showOverridden) && (
                         <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-                          {canOverride && remedy.offerOverride && !image.nsfwLevelLocked && (
+                          {showOverride && (
                             <ImageOverrideControl articleId={articleId} imageId={image.id} />
                           )}
                           {/* The STATUS survives the withdrawal of the action — see
                             ImageOverriddenBadge. */}
-                          {canOverride && image.nsfwLevelLocked && <ImageOverriddenBadge />}
+                          {showOverridden && <ImageOverriddenBadge />}
                         </div>
                       )}
                     </div>
@@ -327,6 +331,21 @@ export function ArticleProblematicImages({
             <Stack gap="sm">
               {errorImages.map((image) => {
                 const remedy = articleImageActions(image.url);
+                /**
+                 * 🔴 ONE EXPRESSION PER AFFORDANCE, USED BY BOTH THE CONTAINER AND THE CHILD.
+                 *
+                 * These used to be spelled twice — once in the container's disjunction and once on
+                 * the child — and the duplication made the child's copy UNREACHABLE: the container
+                 * already returned false for exactly the inputs the child's gate exists to reject,
+                 * so removing `remedy.offerOverride` from the child changed nothing observable and
+                 * a mutation test on it SURVIVED. Measured, not inferred. A predicate open-coded at
+                 * two sites is one edit away from disagreeing with itself; naming it once means
+                 * there is a single thing to get wrong and a single thing to test.
+                 */
+                const showRetry = !!canRetry && remedy.offerRetry && !image.nsfwLevelLocked;
+                const showOverride =
+                  !!canOverride && remedy.offerOverride && !image.nsfwLevelLocked;
+                const showOverridden = !!canOverride && image.nsfwLevelLocked;
                 return (
                   <Paper key={image.id} p="xs" withBorder className="border-l-2 border-l-yellow-6">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
@@ -354,17 +373,15 @@ export function ArticleProblematicImages({
                         mutation that refuses it, and Retry re-fetches a handle nothing outside the
                         originating document can read. The note above names the remedy instead. The
                         Overridden BADGE is not an action and is not withdrawn with them. */}
-                      {((canRetry && remedy.offerRetry && !image.nsfwLevelLocked) ||
-                        (canOverride && remedy.offerOverride && !image.nsfwLevelLocked) ||
-                        (canOverride && image.nsfwLevelLocked)) && (
+                      {(showRetry || showOverride || showOverridden) && (
                         <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-                          {canRetry && remedy.offerRetry && !image.nsfwLevelLocked && (
+                          {showRetry && (
                             <ImageRetryButton articleId={articleId} imageId={image.id} />
                           )}
-                          {canOverride && remedy.offerOverride && !image.nsfwLevelLocked && (
+                          {showOverride && (
                             <ImageOverrideControl articleId={articleId} imageId={image.id} />
                           )}
-                          {canOverride && image.nsfwLevelLocked && <ImageOverriddenBadge />}
+                          {showOverridden && <ImageOverriddenBadge />}
                         </div>
                       )}
                     </div>

--- a/src/components/Article/ArticleProblematicImages.tsx
+++ b/src/components/Article/ArticleProblematicImages.tsx
@@ -74,15 +74,25 @@ function errorImageCause(image: ErrorImage): string {
   }
 }
 
-function ImageOverrideControl({
-  articleId,
-  imageId,
-  locked,
-}: {
-  articleId: number;
-  imageId: number;
-  locked: boolean;
-}) {
+/**
+ * The "an override was already applied" STATUS, split out of `ImageOverrideControl`.
+ *
+ * 🔴 A STATUS IS NOT AN ACTION, AND WITHDRAWING THE ACTION MUST NOT WITHDRAW THE STATUS. While the
+ * two lived in one component, gating that component on `remedy.offerOverride` hid the badge as well
+ * — and the state it reports is reachable for exactly these images: `updateImageNsfwLevel` sets
+ * `nsfwLevelLocked` without touching `ingestion`, so an image can be locked and still sit in this
+ * list. The reader would then see a card whose override had already been applied, with nothing
+ * saying so.
+ */
+function ImageOverriddenBadge() {
+  return (
+    <Badge color="green" variant="light" leftSection={<IconShieldCheck size={12} />}>
+      Overridden
+    </Badge>
+  );
+}
+
+function ImageOverrideControl({ articleId, imageId }: { articleId: number; imageId: number }) {
   const queryUtils = trpc.useUtils();
   const [level, setLevel] = useState<string | null>(null);
 
@@ -99,13 +109,6 @@ function ImageOverrideControl({
       });
     },
   });
-
-  if (locked)
-    return (
-      <Badge color="green" variant="light" leftSection={<IconShieldCheck size={12} />}>
-        Overridden
-      </Badge>
-    );
 
   return (
     <Group gap="xs" wrap="nowrap">
@@ -294,13 +297,14 @@ export function ArticleProblematicImages({
                           )}
                         </Stack>
                       </div>
-                      {canOverride && remedy.offerOverride && (
+                      {canOverride && (remedy.offerOverride || image.nsfwLevelLocked) && (
                         <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-                          <ImageOverrideControl
-                            articleId={articleId}
-                            imageId={image.id}
-                            locked={image.nsfwLevelLocked}
-                          />
+                          {canOverride && remedy.offerOverride && !image.nsfwLevelLocked && (
+                            <ImageOverrideControl articleId={articleId} imageId={image.id} />
+                          )}
+                          {/* The STATUS survives the withdrawal of the action — see
+                            ImageOverriddenBadge. */}
+                          {canOverride && image.nsfwLevelLocked && <ImageOverriddenBadge />}
                         </div>
                       )}
                     </div>
@@ -346,22 +350,21 @@ export function ArticleProblematicImages({
                           )}
                         </Stack>
                       </div>
-                      {/* Both controls are dead ends for an unrenderable url: Override calls the
+                      {/* Both ACTIONS are dead ends for an unrenderable url: Override calls the
                         mutation that refuses it, and Retry re-fetches a handle nothing outside the
-                        originating document can read. The note above names the remedy instead. */}
-                      {((canRetry && remedy.offerRetry) ||
-                        (canOverride && remedy.offerOverride)) && (
+                        originating document can read. The note above names the remedy instead. The
+                        Overridden BADGE is not an action and is not withdrawn with them. */}
+                      {((canRetry && remedy.offerRetry && !image.nsfwLevelLocked) ||
+                        (canOverride && remedy.offerOverride && !image.nsfwLevelLocked) ||
+                        (canOverride && image.nsfwLevelLocked)) && (
                         <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
                           {canRetry && remedy.offerRetry && !image.nsfwLevelLocked && (
                             <ImageRetryButton articleId={articleId} imageId={image.id} />
                           )}
-                          {canOverride && remedy.offerOverride && (
-                            <ImageOverrideControl
-                              articleId={articleId}
-                              imageId={image.id}
-                              locked={image.nsfwLevelLocked}
-                            />
+                          {canOverride && remedy.offerOverride && !image.nsfwLevelLocked && (
+                            <ImageOverrideControl articleId={articleId} imageId={image.id} />
                           )}
+                          {canOverride && image.nsfwLevelLocked && <ImageOverriddenBadge />}
                         </div>
                       )}
                     </div>
@@ -372,6 +375,12 @@ export function ArticleProblematicImages({
           </Stack>
         )}
 
+        {/* 🔴 This rescans the ARTICLE, which is a different thing from rescanning the image the
+          note above says a rescan cannot fix — and after the image is removed, replaced or deleted
+          it is the step that actually unblocks the article. `article-ingestion-reconcile` will NOT
+          do it for you: that cron selects only `ingestion IN (Pending, Rescan)` or
+          `(Processing, Scanned)`, and an article blocked by an unrenderable image sits at `Error`.
+          The note names the rescan for that reason; keep the two wordings in step. */}
         {canRescan && (
           <Group justify="flex-end">
             <Button

--- a/src/components/Article/__tests__/ArticleProblematicImages.browser.test.tsx
+++ b/src/components/Article/__tests__/ArticleProblematicImages.browser.test.tsx
@@ -203,6 +203,106 @@ describe('ArticleProblematicImages — what a reader actually sees for an unrend
     await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
   });
 
+  test('an ORDINARY locked image shows the STATUS and no action — the two are exclusive', async () => {
+    /**
+     * 🔴 THE FIXTURE THAT MAKES `!image.nsfwLevelLocked` REACHABLE, AND THE ONLY ONE THAT DOES.
+     *
+     * The refactor split the control and the badge into two independent booleans. Before it, they
+     * were one component with `if (locked) return <Badge/>`, so "control AND badge at once" was
+     * UNREPRESENTABLE; now the only thing preventing it is the `!image.nsfwLevelLocked` term on
+     * `showOverride`/`showRetry`. Every other locked fixture in this file pairs the lock with a
+     * `blob:` url, where `remedy.offerOverride`/`offerRetry` are ALREADY false — so the term does
+     * nothing there and deleting it left the whole suite green. Measured, not inferred.
+     *
+     * An ordinary url makes both `remedy` fields true, so the lock term is the sole surviving
+     * reason each control is withdrawn, and removing it from either definition renders that
+     * control NEXT TO the "Overridden" badge — the state the old shape could not express.
+     *
+     * The badge assertion is also this case's positive control: a component that rendered nothing
+     * at all would fail it, so the two absences below are not vacuous.
+     */
+    renderErrors([errorImage({ url: ORDINARY_URL, nsfwLevelLocked: true })]);
+
+    await expect.element(page.getByText('Overridden')).toBeVisible();
+    // Named, so a mutant on either term fails with THAT term's own message rather than an
+    // anonymous "expected 0, got 1" that could have come from either definition.
+    expect(
+      page.getByRole('button', { name: 'Override' }).elements(),
+      'showOverride must drop the lock term: Override cannot render beside Overridden'
+    ).toHaveLength(0);
+    expect(
+      page.getByRole('button', { name: 'Retry scan' }).elements(),
+      'showRetry must drop the lock term: Retry cannot render beside Overridden'
+    ).toHaveLength(0);
+    // ...and this is NOT the blob: path — the url is ordinary, so the remedy note must be absent.
+    // Without this the case would pass for the wrong reason if the fixture's url ever drifted.
+    expect(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE).elements()).toHaveLength(0);
+  });
+
+  test('an ORDINARY locked image in the BLOCKED section is exclusive the same way', async () => {
+    // The blocked list carries its own `showOverride` definition, so the term is spelled twice and
+    // has to be killed twice. Same fixture shape, other section.
+    renderWithProviders(
+      <ArticleProblematicImages
+        articleId={7}
+        blockedImages={[
+          {
+            id: 11,
+            url: ORDINARY_URL,
+            ingestion: 'Blocked' as never,
+            blockedFor: 'Policy violation',
+            nsfwLevelLocked: true,
+          },
+        ]}
+        errorImages={[]}
+        canOverride
+        canRetry
+        canRescan
+      />
+    );
+
+    await expect.element(page.getByText('Overridden')).toBeVisible();
+    expect(
+      page.getByRole('button', { name: 'Override' }).elements(),
+      "the BLOCKED section's showOverride must drop the lock term too"
+    ).toHaveLength(0);
+    expect(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE).elements()).toHaveLength(0);
+  });
+
+  test('a blob: BLOCKED image that is locked shows the badge beside the blocking note', async () => {
+    /**
+     * A state that did not exist before this change: `showOverridden` drops the
+     * `remedy.offerOverride` term the old single component carried, so the badge now renders in the
+     * blocked section for an unrenderable url too — previously nothing rendered there at all.
+     *
+     * Deliberate, and covered here rather than left to inference: the badge is a STATUS, and the
+     * status is true regardless of whether the url can ever render. The note is what tells the
+     * reader the override it reports cannot save the image.
+     */
+    renderWithProviders(
+      <ArticleProblematicImages
+        articleId={7}
+        blockedImages={[
+          {
+            id: 12,
+            url: UNRENDERABLE_URL,
+            ingestion: 'Blocked' as never,
+            blockedFor: 'Policy violation',
+            nsfwLevelLocked: true,
+          },
+        ]}
+        errorImages={[]}
+        canOverride
+        canRetry
+        canRescan
+      />
+    );
+
+    await expect.element(page.getByText('Overridden')).toBeVisible();
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+    expect(page.getByRole('button', { name: 'Override' }).elements()).toHaveLength(0);
+  });
+
   test('CONTROL: the badge is a moderator affordance and stays behind canOverride', async () => {
     // The mirror of the case above: making the badge unconditional would leak an internal
     // moderation state to every reader of the article.

--- a/src/components/Article/__tests__/ArticleProblematicImages.browser.test.tsx
+++ b/src/components/Article/__tests__/ArticleProblematicImages.browser.test.tsx
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { UNRENDERABLE_ARTICLE_IMAGE_NOTE } from '~/components/Article/articleImageActions';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * 🔴 THE ONLY TEST THAT ACTUALLY LOOKS AT WHAT A READER SEES.
+ *
+ * The entire user-facing effect of the unrenderable-media work on this surface is "a button is
+ * gone and a sentence takes its place", and until this file existed NOTHING rendered it. The two
+ * guards that covered it are both blind to what a render would show:
+ *
+ *   - `articleImageActions.test.ts` pins the DECISION (`offerOverride`/`offerRetry`/`blockingNote`)
+ *     as a pure function, which says nothing about whether the component consults it.
+ *   - `article-unrenderable-image-seam.test.ts` is a SOURCE-TEXT SCAN whose `enclosingGate` returns
+ *     the nearest preceding line containing `&& (` — the nearest, not the syntactic parent. It can
+ *     therefore certify that a string appears above a JSX tag and nothing about reachability.
+ *
+ * So this file asserts the three things neither can: the note appears, the dead-end controls do
+ * NOT, and the card is not left visually empty. Every arm has a CONTROL with an ordinary url —
+ * without it "render nothing at all" satisfies the positive arms and ships a surface where nobody
+ * can override or retry anything.
+ */
+
+const state = vi.hoisted(() => ({
+  /** Every `resolveImageScan.mutate` / `rescanImage.mutate` / `article.rescan` call. */
+  overrideCalls: [] as unknown[],
+  retryCalls: [] as unknown[],
+  articleRescanCalls: [] as unknown[],
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+/**
+ * `EdgeMedia` reaches `useBrowsingSettings` (a provider this scaffold deliberately does not mount)
+ * and a CDN url resolver. Neither is this suite's subject — it is about which CONTROLS survive —
+ * and a real `<img>` pointed at an http url would race its own error event (see
+ * `LOADABLE_IMAGE_DATA_URI`'s note in the setup file). Stubbed to a plain element that carries the
+ * `alt`, so the card's non-emptiness is still measured against real DOM.
+ */
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: ({ alt }: { alt?: string }) => <span data-testid="stub-edge-media">{alt}</span>,
+}));
+
+// Spread the REAL module and override only `trpc` (per `local-rules/no-wholesale-module-mock`): a
+// hand-written replacement silently drops any export a transitive importer needs, and the file
+// then fails to load as "0 tests collected" — green for the worst possible reason.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
+  const mutation = (record: (args: unknown) => void) => ({
+    useMutation: () => ({
+      mutate: (args: unknown) => record(args),
+      mutateAsync: async (args: unknown) => record(args),
+      isPending: false,
+    }),
+  });
+  return {
+    ...actual,
+    trpc: {
+      useUtils: () => ({
+        article: {
+          getScanStatus: { invalidate: vi.fn().mockResolvedValue(undefined) },
+          getById: { invalidate: vi.fn().mockResolvedValue(undefined) },
+        },
+      }),
+      article: {
+        resolveImageScan: mutation((a) => state.overrideCalls.push(a)),
+        rescanImage: mutation((a) => state.retryCalls.push(a)),
+        rescan: mutation((a) => state.articleRescanCalls.push(a)),
+      },
+    },
+  };
+});
+
+const { ArticleProblematicImages } = await import('~/components/Article/ArticleProblematicImages');
+
+const UNRENDERABLE_URL = 'blob:https://civitai.com/9f8e-1234';
+const ORDINARY_URL = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+type ErrorImageOverrides = {
+  id?: number;
+  url?: string;
+  nsfwLevelLocked?: boolean;
+  failureClass?: string | null;
+  reason?: string | null;
+};
+
+function errorImage(over: ErrorImageOverrides = {}) {
+  return {
+    id: 4242,
+    url: ORDINARY_URL,
+    // `Error` — the state this whole queue is about. Typed loosely because the enum's runtime value
+    // is the string, and importing the prisma enum barrel here buys nothing.
+    ingestion: 'Error' as never,
+    nsfwLevelLocked: false,
+    failureClass: 'transient' as string | null,
+    reason: 'scan timed out' as string | null,
+    ...over,
+  };
+}
+
+function renderErrors(images: ReturnType<typeof errorImage>[], over?: Record<string, boolean>) {
+  return renderWithProviders(
+    <ArticleProblematicImages
+      articleId={7}
+      blockedImages={[]}
+      errorImages={images}
+      canOverride
+      canRetry
+      canRescan
+      {...over}
+    />
+  );
+}
+
+beforeEach(() => {
+  state.overrideCalls.length = 0;
+  state.retryCalls.length = 0;
+  state.articleRescanCalls.length = 0;
+});
+
+describe('ArticleProblematicImages — what a reader actually sees for an unrenderable image', () => {
+  test('CONTROL: an ordinary failed image still offers both actions and shows no note', async () => {
+    /**
+     * 🔴 THE ARM THAT MAKES THE OTHERS MEAN ANYTHING. "Render no controls at all" satisfies every
+     * positive assertion below while shipping a surface on which no moderator can override and no
+     * author can retry. Asserted FIRST, deliberately.
+     */
+    renderErrors([errorImage()]);
+
+    await expect.element(page.getByRole('button', { name: 'Retry scan' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Override' })).toBeInTheDocument();
+    // The scan-failure cause is what the card says when nothing is withdrawn.
+    await expect.element(page.getByText('Scanning failed, retrying automatically.')).toBeVisible();
+    expect(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE).elements()).toHaveLength(0);
+  });
+
+  test('withdraws BOTH dead-end controls for a blob: url', async () => {
+    // Override calls the mutation that refuses this url; Retry re-fetches a browser-session handle
+    // nothing outside the originating document can read. Both can only fail.
+    renderErrors([errorImage({ url: UNRENDERABLE_URL })]);
+
+    // Awaited on the note so the assertion runs against a settled tree — a bare synchronous
+    // `elements()` on an absence can pass before the component has rendered anything at all.
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+    expect(page.getByRole('button', { name: 'Retry scan' }).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Override' }).elements()).toHaveLength(0);
+    // Not merely un-clickable: nothing in the tree can reach either mutation.
+    expect(state.overrideCalls).toEqual([]);
+    expect(state.retryCalls).toEqual([]);
+  });
+
+  test('puts the remedy in the card it emptied, not somewhere else on the page', async () => {
+    /**
+     * Withdrawing the buttons without saying why replaces a dead-end click with a blank card, which
+     * is a worse dead end. The note has to land INSIDE the same `Paper` as the image it is about —
+     * a page-level banner would be true and useless once there are several images.
+     */
+    renderErrors([errorImage({ url: UNRENDERABLE_URL })]);
+
+    const note = page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE);
+    await expect.element(note).toBeVisible();
+    const card = note.element().closest('.mantine-Paper-root');
+    expect(card, 'the note must sit inside a card').not.toBeNull();
+    expect(card?.querySelector('[data-testid="stub-edge-media"]')).not.toBeNull();
+  });
+
+  test('names the rescan the article needs, because the delete alone will not unblock it', async () => {
+    /**
+     * 🔴 The spoke's delete removes the row and cascades `ImageConnection`/`Article.coverId` but
+     * cannot call `recomputeArticleIngestion` (main-app only), and `article-ingestion-reconcile`
+     * selects only `ingestion IN (Pending, Rescan)` or `(Processing, Scanned)` — an article blocked
+     * by one of these sits at `Error` and is never a candidate. So the note has to say so, and the
+     * button that does it has to be on screen next to it.
+     */
+    renderErrors([errorImage({ url: UNRENDERABLE_URL })]);
+
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+    expect(UNRENDERABLE_ARTICLE_IMAGE_NOTE).toContain('rescan the article');
+    await expect.element(page.getByRole('button', { name: 'Rescan Article' })).toBeInTheDocument();
+  });
+
+  test('keeps the Overridden STATUS while withdrawing the override ACTION', async () => {
+    /**
+     * 🔴 THE FINDING THIS CLOSES, AT THE ONLY LEVEL THAT CAN SEE IT. The badge and the control used
+     * to be one component, so gating it on `remedy.offerOverride` hid the badge too. That state is
+     * reachable for exactly these images — `updateImageNsfwLevel` sets `nsfwLevelLocked` without
+     * touching `ingestion` — so a moderator saw a card whose override had already been applied with
+     * nothing on it saying so.
+     */
+    renderErrors([errorImage({ url: UNRENDERABLE_URL, nsfwLevelLocked: true })]);
+
+    await expect.element(page.getByText('Overridden')).toBeVisible();
+    // ...and the ACTION is still gone. Both halves, or this passes on a component that simply
+    // reverted the withdrawal.
+    expect(page.getByRole('button', { name: 'Override' }).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Retry scan' }).elements()).toHaveLength(0);
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+  });
+
+  test('CONTROL: the badge is a moderator affordance and stays behind canOverride', async () => {
+    // The mirror of the case above: making the badge unconditional would leak an internal
+    // moderation state to every reader of the article.
+    renderErrors([errorImage({ url: UNRENDERABLE_URL, nsfwLevelLocked: true })], {
+      canOverride: false,
+    });
+
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+    expect(page.getByText('Overridden').elements()).toHaveLength(0);
+  });
+
+  test('withdraws per IMAGE, not per section', async () => {
+    /**
+     * The list is rendered from one `.map`, so a gate accidentally hoisted out of it would withdraw
+     * the controls for every image the moment ONE is unrenderable — or, in the other direction,
+     * offer them for the unrenderable one because a sibling is fine. Two images, one of each.
+     */
+    renderErrors([
+      errorImage({ id: 1, url: UNRENDERABLE_URL }),
+      errorImage({ id: 2, url: ORDINARY_URL }),
+    ]);
+
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+    // Exactly one of each control survives — the ordinary image's.
+    expect(page.getByRole('button', { name: 'Override' }).elements()).toHaveLength(1);
+    expect(page.getByRole('button', { name: 'Retry scan' }).elements()).toHaveLength(1);
+    expect(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE).elements()).toHaveLength(1);
+  });
+
+  test('withdraws the same way in the BLOCKED section', async () => {
+    // The other list on this component renders the note beside the block reason rather than in
+    // place of a cause line, and only Override is on offer there. Same rule, different layout.
+    renderWithProviders(
+      <ArticleProblematicImages
+        articleId={7}
+        blockedImages={[
+          {
+            id: 9,
+            url: UNRENDERABLE_URL,
+            ingestion: 'Blocked' as never,
+            blockedFor: 'Policy violation',
+            nsfwLevelLocked: false,
+          },
+        ]}
+        errorImages={[]}
+        canOverride
+        canRetry
+        canRescan
+      />
+    );
+
+    await expect.element(page.getByText(UNRENDERABLE_ARTICLE_IMAGE_NOTE)).toBeVisible();
+    // The block reason is still shown — the note replaces the CONTROL, not the explanation.
+    await expect.element(page.getByText('Blocked: Policy violation')).toBeVisible();
+    expect(page.getByRole('button', { name: 'Override' }).elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Article/__tests__/article-unrenderable-image-seam.test.ts
+++ b/src/components/Article/__tests__/article-unrenderable-image-seam.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * 🔴 SOURCE GATE — the article surface must not render a control that can only fail.
+ *
+ * `articleImageActions` decides which affordances survive for an image whose url the publish guard
+ * refuses, and its own suite covers that decision exhaustively. This covers the OTHER half: that
+ * `ArticleProblematicImages` actually gates its two controls on it. Those are separately correct and
+ * jointly broken if the wiring is dropped — the isolation-seam shape — and dropping it is invisible
+ * to every other test in the repo.
+ *
+ * 🔴 BE PLAIN ABOUT WHAT THIS IS: a scan of the source text, not a render. It is what is available —
+ * the component's other collaborators (trpc, Mantine providers, the notification helpers) put a real
+ * render in the browser-mode project, and the property worth pinning here is structural anyway. So
+ * it is deliberately narrow, and these are its blind spots: it sees the nearest ENCLOSING JSX
+ * conditional of each control, so a gate satisfied by an unrelated expression that happens to
+ * mention the flag would pass; and a control rendered through an indirection rather than as a JSX
+ * element is invisible to it. The element COUNTS below are the control for the second: if a render
+ * site moves out of reach, the count drops and this fails rather than silently covering less.
+ */
+
+const COMPONENT = path.resolve(__dirname, '../ArticleProblematicImages.tsx');
+
+/** Every control that routes into a mutation the publish guard can refuse, and the flag that gates it. */
+const GATED_CONTROLS: { element: string; flag: string; sites: number }[] = [
+  // Calls `article.resolveImageScan` -> `resolveIngestionError`, which throws for an unrenderable
+  // url. Rendered twice: once for blocked images, once for errored ones.
+  { element: 'ImageOverrideControl', flag: 'remedy.offerOverride', sites: 2 },
+  // Re-queues a scan of the same unfetchable url, so it re-fails and the article stays blocked.
+  { element: 'ImageRetryButton', flag: 'remedy.offerRetry', sites: 1 },
+];
+
+const source = readFileSync(COMPONENT, 'utf8');
+const lines = source.split('\n');
+
+/** The nearest preceding JSX conditional — `{<expr> && (` — above a render site. */
+function enclosingGate(atLine: number): string | null {
+  for (let i = atLine; i >= 0; i--) if (lines[i].includes('&& (')) return lines[i];
+  return null;
+}
+
+describe('the article surface and the publish guard cannot disagree about blob: urls', () => {
+  it('takes its decision from the shared helper, never a local copy of the rule', () => {
+    // A second spelling of the predicate here is how the two runtimes came to disagree about the
+    // same row once already; the helper is the single place that consults `isUnrenderableMediaUrl`.
+    expect(source).toContain("from './articleImageActions'");
+    expect(source).toMatch(/const remedy = articleImageActions\(image\.url\)/);
+    // ...and never re-derives it. `blob` must not appear in this file at all.
+    expect(source).not.toMatch(/\bblob\b/i);
+  });
+
+  it.each(GATED_CONTROLS)('gates every <$element> render on $flag', ({ element, flag, sites }) => {
+    const renderSites = lines
+      .map((line, i) => ({ line, i }))
+      .filter(({ line }) => line.includes(`<${element}`));
+
+    // Positive control on the scan: a zero here would make every assertion below vacuous, and the
+    // exact count catches a render site that moved somewhere this scan cannot see.
+    expect(renderSites, `render sites for <${element}>`).toHaveLength(sites);
+
+    for (const { i } of renderSites) {
+      const gate = enclosingGate(i);
+      expect(
+        gate,
+        `<${element}> at line ${i + 1} must sit inside a JSX conditional`
+      ).not.toBeNull();
+      expect(gate, `<${element}> at line ${i + 1} is not gated on ${flag}`).toContain(flag);
+    }
+  });
+
+  it('shows the remedy note wherever it withdraws the controls', () => {
+    // Withdrawing the buttons without saying why would replace a dead-end click with a blank card,
+    // which is a worse dead end: the reader is not told the image has to be removed or replaced.
+    expect(source).toMatch(/remedy\.blockingNote/);
+    // Once per section — the blocked list renders it beside the block reason, the error list
+    // replaces the scan-failure cause with it.
+    expect(source.match(/remedy\.blockingNote/g)).toHaveLength(3);
+  });
+});

--- a/src/components/Article/__tests__/article-unrenderable-image-seam.test.ts
+++ b/src/components/Article/__tests__/article-unrenderable-image-seam.test.ts
@@ -74,8 +74,40 @@ describe('the article surface and the publish guard cannot disagree about blob: 
     // Withdrawing the buttons without saying why would replace a dead-end click with a blank card,
     // which is a worse dead end: the reader is not told the image has to be removed or replaced.
     expect(source).toMatch(/remedy\.blockingNote/);
-    // Once per section — the blocked list renders it beside the block reason, the error list
-    // replaces the scan-failure cause with it.
+    // 🔴 THREE MENTIONS ACROSS TWO SECTIONS, NOT "once per section" — the previous comment said the
+    // latter while asserting the former, so the number and the sentence disagreed and only the
+    // number was true. The blocked list spends TWO (`{remedy.blockingNote && (` to decide whether
+    // to render, then the value itself); the error list spends ONE, because it substitutes the note
+    // for the scan-failure cause with `??` and needs no separate guard.
     expect(source.match(/remedy\.blockingNote/g)).toHaveLength(3);
+  });
+
+  it('keeps the Overridden STATUS reachable when it withdraws the override ACTION', () => {
+    /**
+     * 🔴 The status and the action used to be one component, so gating that component on
+     * `remedy.offerOverride` withdrew the badge too. The state it reports is reachable for exactly
+     * these images — `updateImageNsfwLevel` sets `nsfwLevelLocked` without touching `ingestion` —
+     * so the reader could see a card whose override had already been applied with nothing saying so.
+     *
+     * Pinned in BOTH directions: the badge must render, and it must not be gated on the flag that
+     * withdraws the action. `enclosingGate` is deliberately not used here — the badge is rendered
+     * inline, and what matters is the gating expression ON ITS OWN LINE.
+     */
+    const badgeSites = lines
+      .map((line, i) => ({ line, i }))
+      .filter(({ line }) => line.includes('<ImageOverriddenBadge'));
+
+    // Positive control: a zero here makes everything below vacuous. Two sections render it.
+    expect(badgeSites, 'render sites for <ImageOverriddenBadge>').toHaveLength(2);
+
+    for (const { line, i } of badgeSites) {
+      expect(line, `<ImageOverriddenBadge> at line ${i + 1} must gate on the LOCK`).toContain(
+        'image.nsfwLevelLocked'
+      );
+      expect(
+        line,
+        `<ImageOverriddenBadge> at line ${i + 1} must NOT be gated on remedy.offerOverride`
+      ).not.toContain('remedy.offerOverride');
+    }
   });
 });

--- a/src/components/Article/__tests__/article-unrenderable-image-seam.test.ts
+++ b/src/components/Article/__tests__/article-unrenderable-image-seam.test.ts
@@ -11,34 +11,60 @@ import path from 'path';
  * jointly broken if the wiring is dropped — the isolation-seam shape — and dropping it is invisible
  * to every other test in the repo.
  *
- * 🔴 BE PLAIN ABOUT WHAT THIS IS: a scan of the source text, not a render. It is what is available —
- * the component's other collaborators (trpc, Mantine providers, the notification helpers) put a real
- * render in the browser-mode project, and the property worth pinning here is structural anyway. So
- * it is deliberately narrow, and these are its blind spots: it sees the nearest ENCLOSING JSX
- * conditional of each control, so a gate satisfied by an unrelated expression that happens to
- * mention the flag would pass; and a control rendered through an indirection rather than as a JSX
- * element is invisible to it. The element COUNTS below are the control for the second: if a render
- * site moves out of reach, the count drops and this fails rather than silently covering less.
+ * 🔴 BE PLAIN ABOUT WHAT THIS IS: a scan of the source text, not a render. The behaviour is covered
+ * by `ArticleProblematicImages.browser.test.tsx`, which renders the component and reads the DOM;
+ * this file pins the STRUCTURE that makes the behaviour hard to break by accident.
+ *
+ * 🔴 IT NO LONGER GUESSES AT THE ENCLOSING JSX CONDITIONAL, and that change is the point. The
+ * previous version walked backwards for the nearest line containing `&& (` — the nearest, not the
+ * syntactic parent — so it could certify that a flag appears somewhere above a tag and nothing about
+ * reachability. It also could not see the defect that actually existed: the flag was spelled TWICE,
+ * once on the container and once on the child, and the container already rejected exactly the inputs
+ * the child's copy existed to reject, so removing the child's copy changed nothing and a mutation
+ * test on it SURVIVED.
+ *
+ * The component now names ONE boolean per affordance, so the structure is directly readable: this
+ * file checks (a) that each boolean's DEFINITION consults the shared helper's corresponding field,
+ * and (b) that every render site is gated on that boolean and nothing else. Remaining blind spot: a
+ * control rendered through an indirection rather than as a JSX element is invisible here. The
+ * element COUNTS are the control for it — if a render site moves out of reach the count drops and
+ * this fails rather than silently covering less.
  */
 
 const COMPONENT = path.resolve(__dirname, '../ArticleProblematicImages.tsx');
 
-/** Every control that routes into a mutation the publish guard can refuse, and the flag that gates it. */
-const GATED_CONTROLS: { element: string; flag: string; sites: number }[] = [
+/**
+ * Every control that routes into a mutation the publish guard can refuse: the element, the boolean
+ * that gates every one of its render sites, the `articleImageActions` field that boolean must be
+ * derived from, and how many times it is rendered.
+ */
+const GATED_CONTROLS: { element: string; flag: string; field: string; sites: number }[] = [
   // Calls `article.resolveImageScan` -> `resolveIngestionError`, which throws for an unrenderable
   // url. Rendered twice: once for blocked images, once for errored ones.
-  { element: 'ImageOverrideControl', flag: 'remedy.offerOverride', sites: 2 },
+  {
+    element: 'ImageOverrideControl',
+    flag: 'showOverride',
+    field: 'remedy.offerOverride',
+    sites: 2,
+  },
   // Re-queues a scan of the same unfetchable url, so it re-fails and the article stays blocked.
-  { element: 'ImageRetryButton', flag: 'remedy.offerRetry', sites: 1 },
+  { element: 'ImageRetryButton', flag: 'showRetry', field: 'remedy.offerRetry', sites: 1 },
 ];
 
 const source = readFileSync(COMPONENT, 'utf8');
 const lines = source.split('\n');
 
-/** The nearest preceding JSX conditional — `{<expr> && (` — above a render site. */
-function enclosingGate(atLine: number): string | null {
-  for (let i = atLine; i >= 0; i--) if (lines[i].includes('&& (')) return lines[i];
-  return null;
+/**
+ * Every `const <flag> = <expr>;` in the component — the single definition of each affordance.
+ *
+ * Read off a WHITESPACE-FLATTENED copy, not line by line: prettier wraps these declarations once
+ * they exceed the print width, and a line-scoped regex silently returned `const showOverride =`
+ * with the expression on the next line — a match that then "contained" nothing and failed for a
+ * reason that had nothing to do with the code.
+ */
+const flatSource = source.replace(/\s+/g, ' ');
+function definitionsOf(flag: string): string[] {
+  return [...flatSource.matchAll(new RegExp(`const ${flag} = ([^;]*);`, 'g'))].map((m) => m[1]);
 }
 
 describe('the article surface and the publish guard cannot disagree about blob: urls', () => {
@@ -51,6 +77,25 @@ describe('the article surface and the publish guard cannot disagree about blob: 
     expect(source).not.toMatch(/\bblob\b/i);
   });
 
+  it.each(GATED_CONTROLS)(
+    'derives $flag from $field, once per section',
+    ({ flag, field, sites }) => {
+      const definitions = definitionsOf(flag);
+
+      // Positive control on the scan, and the thing that catches a SECOND spelling appearing: one
+      // definition per section that renders the control, no more.
+      expect(definitions, `definitions of ${flag}`).toHaveLength(sites);
+
+      for (const def of definitions) {
+        expect(def, `${flag} must be derived from ${field}`).toContain(field);
+        // ...and from the shared helper's field, not a re-derivation of the rule. `blob` is already
+        // banned from this whole file by the case above; this catches the subtler shape where the
+        // flag reads some OTHER property and merely happens to be named right.
+        expect(def, `${flag} must not invert ${field}`).not.toContain(`!${field}`);
+      }
+    }
+  );
+
   it.each(GATED_CONTROLS)('gates every <$element> render on $flag', ({ element, flag, sites }) => {
     const renderSites = lines
       .map((line, i) => ({ line, i }))
@@ -60,13 +105,17 @@ describe('the article surface and the publish guard cannot disagree about blob: 
     // exact count catches a render site that moved somewhere this scan cannot see.
     expect(renderSites, `render sites for <${element}>`).toHaveLength(sites);
 
-    for (const { i } of renderSites) {
-      const gate = enclosingGate(i);
-      expect(
-        gate,
-        `<${element}> at line ${i + 1} must sit inside a JSX conditional`
-      ).not.toBeNull();
-      expect(gate, `<${element}> at line ${i + 1} is not gated on ${flag}`).toContain(flag);
+    for (const { line, i } of renderSites) {
+      /**
+       * The gate is on the render site's own line, or on the line immediately above it when
+       * prettier has wrapped the element onto its own line. Two lines, not "walk back until
+       * something matches" — a bounded window is what makes this a claim about THIS site rather
+       * than about whatever conditional happened to appear earlier in the file.
+       */
+      const window = [lines[i - 1] ?? '', line].join(' ').replace(/\s+/g, ' ');
+      expect(window, `<${element}> at line ${i + 1} is not gated on ${flag}`).toContain(
+        `{${flag} && `
+      );
     }
   });
 
@@ -101,13 +150,19 @@ describe('the article surface and the publish guard cannot disagree about blob: 
     expect(badgeSites, 'render sites for <ImageOverriddenBadge>').toHaveLength(2);
 
     for (const { line, i } of badgeSites) {
-      expect(line, `<ImageOverriddenBadge> at line ${i + 1} must gate on the LOCK`).toContain(
-        'image.nsfwLevelLocked'
+      expect(line, `<ImageOverriddenBadge> at line ${i + 1} must gate on showOverridden`).toContain(
+        '{showOverridden && '
       );
-      expect(
-        line,
-        `<ImageOverriddenBadge> at line ${i + 1} must NOT be gated on remedy.offerOverride`
-      ).not.toContain('remedy.offerOverride');
+    }
+
+    // ...and `showOverridden` reads the LOCK and nothing else. This is the assertion that fails if
+    // the badge is re-coupled to the withdrawal: one definition per section, each derived from
+    // `image.nsfwLevelLocked`, none of them consulting `remedy`.
+    const definitions = definitionsOf('showOverridden');
+    expect(definitions, 'definitions of showOverridden').toHaveLength(2);
+    for (const def of definitions) {
+      expect(def, 'showOverridden must gate on the lock').toContain('image.nsfwLevelLocked');
+      expect(def, 'showOverridden must not consult the withdrawal').not.toContain('remedy.');
     }
   });
 });

--- a/src/components/Article/__tests__/articleImageActions.test.ts
+++ b/src/components/Article/__tests__/articleImageActions.test.ts
@@ -67,11 +67,22 @@ describe('articleImageActions', () => {
      * 🔴 Pinned WHOLE, not by keyword — a guard on words is walkable by rewording, and the thing
      * being guarded here IS the wording. The finding this closes was that the server's refusal told
      * a moderator to "delete it" on a surface with no delete: the note has to point at an action
-     * that exists, and the two that do are removing the image in the editor and a moderator deleting
-     * the row from the spoke's Missing Media queue.
+     * that exists.
+     *
+     * 🔴 The final clause is the second round's finding and is NOT decoration. The spoke's delete
+     * removes the row and cascades `ImageConnection`/`Article.coverId`, but cannot call
+     * `recomputeArticleIngestion` (main-app only), and `article-ingestion-reconcile` selects only
+     * `ingestion IN (Pending, Rescan)` or `(Processing, Scanned)` — an article blocked by one of
+     * these images sits at `Error` and is never a candidate. Without the rescan the advertised
+     * remedy leaves the article exactly as blocked as it was.
+     *
+     * 🔴 And it says "ask a moderator to delete it", never "delete it from the Missing Media queue":
+     * that queue carries a 2-day window the delete ACTION does not, and this population is mostly
+     * older than that. See `UNRENDERABLE_ARTICLE_IMAGE_NOTE`'s own comment for the per-clause
+     * derivation.
      */
     expect(UNRENDERABLE_ARTICLE_IMAGE_NOTE).toBe(
-      'This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning it cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it.'
+      'This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning the image cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it. Once it is gone, rescan the article to unblock it.'
     );
     // And it must not be the SERVER's message, which names a delete this surface does not have.
     expect(UNRENDERABLE_ARTICLE_IMAGE_NOTE).not.toBe(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE);

--- a/src/components/Article/__tests__/articleImageActions.test.ts
+++ b/src/components/Article/__tests__/articleImageActions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { isUnrenderableMediaUrl, UNRENDERABLE_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
+import {
+  articleImageActions,
+  UNRENDERABLE_ARTICLE_IMAGE_NOTE,
+} from '~/components/Article/articleImageActions';
+
+/**
+ * 🔴 THE PROPERTY UNDER TEST IS A RELATIONSHIP, NOT A COMPONENT.
+ *
+ * `resolveIngestionError` refuses to publish an image whose url can never render. The article
+ * surface's only two affordances both route into that refusal (Override calls it; Retry re-scans the
+ * same unfetchable url), so for exactly the rows the server refuses, this surface must offer NEITHER
+ * and must say what to do instead. A guard scoped to one side of that — "the server refuses blob:"
+ * or "the component hides a button" — is the isolation-seam shape: each side correct, the pair
+ * broken. So every case below drives the SHARED predicate, not a local copy of it.
+ */
+describe('articleImageActions', () => {
+  it('withdraws BOTH affordances for exactly the urls the publish guard refuses', () => {
+    const url = 'blob:https://civitai.com/0f8fad5b-d9cb-469f-a165-70867728950e';
+    // The seam, asserted in one place: this is the same predicate `assertMediaPresentForPublish`
+    // branches on, so the two cannot disagree about which rows are affected.
+    expect(isUnrenderableMediaUrl(url)).toBe(true);
+    expect(articleImageActions(url)).toEqual({
+      offerOverride: false,
+      offerRetry: false,
+      blockingNote: UNRENDERABLE_ARTICLE_IMAGE_NOTE,
+    });
+  });
+
+  it('leaves every other error image exactly as it was, controls and all', () => {
+    // The fail-open half, and the one that matters more: this surface is the ordinary remedy for a
+    // timed-out scan. Withdrawing the buttons from those would be a moderation outage, not a fix.
+    for (const url of [
+      '0f8fad5b-d9cb-469f-a165-70867728950e',
+      'https://cdn.discordapp.com/avatars/123/abc.png',
+      'data:image/png;base64,AAAA',
+      'some-file.png',
+      // Matches the renderers' `startsWith('blob')` passthrough but is NOT the refused scheme — the
+      // server allows it, so this surface must keep offering the buttons that can clear it.
+      'blobfish.png',
+      // Case-sensitively outside the refused prefix, for the same reason.
+      'BLOB:https://civitai.com/abc',
+      '',
+    ]) {
+      expect(articleImageActions(url), url).toEqual({
+        offerOverride: true,
+        offerRetry: true,
+        blockingNote: null,
+      });
+      expect(isUnrenderableMediaUrl(url), url).toBe(false);
+    }
+  });
+
+  it('tolerates a null/undefined url rather than blanking the card', () => {
+    for (const url of [null, undefined]) {
+      expect(articleImageActions(url)).toEqual({
+        offerOverride: true,
+        offerRetry: true,
+        blockingNote: null,
+      });
+    }
+  });
+
+  it('names a remedy the reader can actually carry out', () => {
+    /**
+     * 🔴 Pinned WHOLE, not by keyword — a guard on words is walkable by rewording, and the thing
+     * being guarded here IS the wording. The finding this closes was that the server's refusal told
+     * a moderator to "delete it" on a surface with no delete: the note has to point at an action
+     * that exists, and the two that do are removing the image in the editor and a moderator deleting
+     * the row from the spoke's Missing Media queue.
+     */
+    expect(UNRENDERABLE_ARTICLE_IMAGE_NOTE).toBe(
+      'This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning it cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it.'
+    );
+    // And it must not be the SERVER's message, which names a delete this surface does not have.
+    expect(UNRENDERABLE_ARTICLE_IMAGE_NOTE).not.toBe(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE);
+  });
+});

--- a/src/components/Article/articleImageActions.ts
+++ b/src/components/Article/articleImageActions.ts
@@ -1,0 +1,53 @@
+import { isUnrenderableMediaUrl } from '@civitai/shared';
+
+/**
+ * Which of the two affordances on `ArticleProblematicImages` can still do anything for an image, and
+ * what to tell the reader when neither can.
+ *
+ * 🔴 THIS EXISTS BECAUSE A REFUSAL WITH NO REACHABLE ACTION IS A DEAD END, NOT A GUARD.
+ * `resolveIngestionError` (via `article.resolveImageScan`) now refuses to publish an image whose url
+ * can never render — see `@civitai/shared/missing-media`. The article surface offers exactly two
+ * buttons, and for such an image BOTH are dead ends:
+ *
+ *   - Override calls the mutation that refuses, so it can only ever produce a 400.
+ *   - Retry re-queues a scan whose input is a browser-session handle nothing outside the originating
+ *     document can fetch, so it re-fails and the article stays Error/Blocked.
+ *
+ * Before that refusal existed, Override cleared the article (by publishing a permanently broken
+ * image, which is the harm the guard removes). So the guard did not merely refuse — it closed the
+ * only exit this surface had, and the fix is to name the exit that does exist rather than to keep
+ * rendering a button that cannot succeed. The exits are real and both are in-product: the author
+ * removes or replaces the image in the editor (which is what the component's own lead text already
+ * asks for), and a moderator can delete the row from the spoke's delete-only Missing Media queue,
+ * which selects on the same url shape.
+ *
+ * Pure and separate from the component so it can be pinned by a node-env unit test: the property
+ * that matters is a RELATIONSHIP between the server's refusal predicate and what this surface
+ * offers, and a browser-mode render test would pin the rendering instead.
+ */
+export type ArticleImageActions = {
+  /** Offer the moderator rating override. False when the server would refuse the publish outright. */
+  offerOverride: boolean;
+  /** Offer a rescan. False when re-fetching the same url cannot possibly succeed. */
+  offerRetry: boolean;
+  /** Replaces the controls when neither is offered. `null` whenever either one is. */
+  blockingNote: string | null;
+};
+
+/**
+ * Shown verbatim in place of the Override/Retry controls. It has to name a remedy the reader can
+ * actually carry out, which is the whole point of this module — "contact support" or a bare
+ * "cannot be published" would reproduce the dead end in prose.
+ */
+export const UNRENDERABLE_ARTICLE_IMAGE_NOTE =
+  'This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning it cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it.';
+
+export function articleImageActions(url: string | null | undefined): ArticleImageActions {
+  if (isUnrenderableMediaUrl(url))
+    return {
+      offerOverride: false,
+      offerRetry: false,
+      blockingNote: UNRENDERABLE_ARTICLE_IMAGE_NOTE,
+    };
+  return { offerOverride: true, offerRetry: true, blockingNote: null };
+}

--- a/src/components/Article/articleImageActions.ts
+++ b/src/components/Article/articleImageActions.ts
@@ -38,9 +38,27 @@ export type ArticleImageActions = {
  * Shown verbatim in place of the Override/Retry controls. It has to name a remedy the reader can
  * actually carry out, which is the whole point of this module — "contact support" or a bare
  * "cannot be published" would reproduce the dead end in prose.
+ *
+ * 🔴 EVERY CLAUSE IS CHECKED AGAINST WHAT THE CODE ACTUALLY DOES, because a remedy that stops one
+ * step short is the same dead end with extra steps:
+ *
+ *   - "remove or replace it in the article editor" is the self-service exit and has no
+ *     preconditions. It is named FIRST for that reason.
+ *   - "a moderator can delete it" — deliberately NOT "delete it from the Missing Media queue". That
+ *     queue is bounded to images created in the last 2 days (`ingestionErrorBaseWhere` in the
+ *     moderator spoke), and `blob:` urls come from a legacy upload bug, so the population is
+ *     plausibly mostly older than that. The delete ACTION has no such bound, so a moderator can
+ *     still act; promising the queue would list the row is what would be false.
+ *   - "the article has to be rescanned" is not padding. The spoke's delete removes the row and
+ *     cascades `ImageConnection`/`Article.coverId`, but it cannot call `recomputeArticleIngestion`
+ *     (main-app only), and the `article-ingestion-reconcile` cron only picks up articles at
+ *     `ingestion IN (Pending, Rescan)` or `(Processing, Scanned)` — an article blocked by one of
+ *     these images sits at `Error` and is never a candidate. Without a rescan it stays blocked
+ *     after the remedy is applied. Rescan Article is on this same alert, and in
+ *     `ArticleContextMenu` once the image is gone and this alert no longer renders.
  */
 export const UNRENDERABLE_ARTICLE_IMAGE_NOTE =
-  'This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning it cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it.';
+  'This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning the image cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it. Once it is gone, rescan the article to unblock it.';
 
 export function articleImageActions(url: string | null | undefined): ArticleImageActions {
   if (isUnrenderableMediaUrl(url))

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4133':
+  'server/services/image.service.ts:4138':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4274':
+  'server/services/image.service.ts:4279':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5012':
+  'server/services/image.service.ts:5017':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6146':
+  'server/services/image.service.ts:6151':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4274')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4279')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4127':
+  'server/services/image.service.ts:4132':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4268':
+  'server/services/image.service.ts:4273':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5006':
+  'server/services/image.service.ts:5011':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6140':
+  'server/services/image.service.ts:6145':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4268')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4273')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4132':
+  'server/services/image.service.ts:4133':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4273':
+  'server/services/image.service.ts:4274':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5011':
+  'server/services/image.service.ts:5012':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6145':
+  'server/services/image.service.ts:6146':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4273')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4274')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/image-scan-failure.test.ts
+++ b/src/server/services/__tests__/image-scan-failure.test.ts
@@ -7,6 +7,18 @@ import {
   IMAGE_SCAN_UNKNOWN_RETRY_LIMIT,
   IMAGE_SCAN_PERMANENT_RETRY_LIMIT,
 } from '~/server/services/image-scan-failure';
+import { IMAGE_SCAN_FAILURE_CLASS_PERMANENT } from '@civitai/shared';
+
+describe('the permanent class is one value, not two spellings', () => {
+  it('is the same string this app stores and the moderator queue selects on', () => {
+    // The seam nobody owns: this module WRITES `scanJobs.error.failureClass`, and the moderator
+    // spoke's SQL partitions its review queue on that stored string. The two live in different
+    // runtimes and cannot see each other, so before they shared a constant, agreeing was a
+    // coincidence maintained by hand. Pinned literally on both sides.
+    expect(ImageScanFailureClass.Permanent).toBe(IMAGE_SCAN_FAILURE_CLASS_PERMANENT);
+    expect(ImageScanFailureClass.Permanent).toBe('permanent');
+  });
+});
 
 describe('classifyImageScanFailure', () => {
   it('classifies container-create churn as transient', () => {

--- a/src/server/services/__tests__/resolve-article-image-scan-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-article-image-scan-missing-media.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MISSING_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
+import type * as S3Utils from '~/utils/s3-utils';
+import type * as SearchIndex from '~/server/search-index';
+
+/**
+ * The second main-app entry point into `resolveIngestionError`: a moderator resolving an ARTICLE's
+ * image scan. Article images are ordinary `Image` rows in the same media store, so the guard is
+ * correct for them — but "correct" is a claim about a path, and this path was never exercised by
+ * the guard's own suite.
+ *
+ * The case worth pinning is the ORDER: a refused publish must leave the article untouched, rather
+ * than recompute its ingestion and re-index it around a write that never happened.
+ */
+
+const { headObject } = vi.hoisted(() => ({ headObject: vi.fn() }));
+
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  headObject,
+  getB2ImageS3Client: () => ({} as never),
+}));
+
+const { queueUpdate } = vi.hoisted(() => ({ queueUpdate: vi.fn() }));
+vi.mock('~/server/search-index', async (importOriginal) => ({
+  ...(await importOriginal<typeof SearchIndex>()),
+  articlesSearchIndex: { queueUpdate },
+}));
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { resolveArticleImageScan } from '~/server/services/article.service';
+
+const IMAGE_KEY = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const resolve = () =>
+  resolveArticleImageScan({ articleId: 11, imageId: 4242, nsfwLevel: 1, userId: 7 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The image IS this article's cover, so the cross-article guard above lets it through — otherwise
+  // the case below would be testing that check instead of the media guard.
+  dbMock.dbRead.article.findUnique.mockResolvedValue({ coverId: 4242 } as never);
+  dbMock.dbRead.imageConnection.findFirst.mockResolvedValue({ imageId: 4242 } as never);
+  dbMock.dbRead.image.findUnique.mockResolvedValue({
+    ingestion: 'Error',
+    postId: null,
+    userId: 99,
+    metadata: {},
+    url: IMAGE_KEY,
+  } as never);
+  // Enough of an article for the post-resolve recompute to run; its outcome is not what is pinned
+  // here, only that it runs on the allow paths and does not on the refuse path.
+  dbMock.dbWrite.article.findUniqueOrThrow.mockResolvedValue({
+    ingestion: 'Pending',
+    status: 'Draft',
+    publishedAt: null,
+    userId: 99,
+    title: 'a',
+    content: 'b',
+    coverId: null,
+    moderatorNsfwLevel: null,
+  } as never);
+});
+
+describe('resolveArticleImageScan — inherits the missing-media guard', () => {
+  it('refuses, and leaves the article completely untouched', async () => {
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await expect(resolve()).rejects.toThrow(MISSING_MEDIA_PUBLISH_MESSAGE);
+
+    expect(dbMock.dbWrite.image.update).not.toHaveBeenCalled();
+    // The two follow-on effects sit AFTER the resolve call, so a guard that threw late — or one
+    // wired after them — would still have recomputed and re-indexed the article.
+    expect(queueUpdate).not.toHaveBeenCalled();
+  });
+
+  it('still resolves an article image whose media is present', async () => {
+    headObject.mockResolvedValue({ status: 'present', size: 12345 });
+
+    await resolve();
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+    // The allow path re-indexes; the refuse path above must not. (The recompute queues one of its
+    // own, so the count is >1 here — the contrast that matters is against the zero above.)
+    expect(queueUpdate.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('still resolves when the store could not be consulted', async () => {
+    headObject.mockResolvedValue({ status: 'unknown' });
+
+    await resolve();
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a cross-article image before ever probing the store', async () => {
+    // Reachability control for the ordering claim: this earlier check owns its own case.
+    dbMock.dbRead.article.findUnique.mockResolvedValue({ coverId: 999 } as never);
+    dbMock.dbRead.imageConnection.findFirst.mockResolvedValue(null as never);
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await expect(resolve()).rejects.toThrow('does not belong to article');
+    expect(headObject).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/resolve-article-image-scan-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-article-image-scan-missing-media.test.ts
@@ -15,10 +15,23 @@ import type * as SearchIndex from '~/server/search-index';
 
 const { headObject } = vi.hoisted(() => ({ headObject: vi.fn() }));
 
+/**
+ * 🔴 `getImageUploadBackend` is mocked, not just `getB2ImageS3Client`, and the distinction is the
+ * whole reason this file went red once. The probe resolves its bucket + client through
+ * `getImageUploadBackend()` (so it cannot drift from the store the upload path wrote to); the REAL
+ * one — which `importOriginal` hands back — calls s3-utils' own internal client factory, not the
+ * mocked export, and that factory throws with no credentials. The probe then landed on `unknown`,
+ * the publish was ALLOWED, and the refusal case failed with "promise resolved undefined".
+ */
 vi.mock('~/utils/s3-utils', async (importOriginal) => ({
   ...(await importOriginal<typeof S3Utils>()),
   headObject,
   getB2ImageS3Client: () => ({} as never),
+  getImageUploadBackend: async () => ({
+    s3: {} as never,
+    bucket: 'civitai-media-uploads',
+    backend: 'backblaze' as const,
+  }),
 }));
 
 const { queueUpdate } = vi.hoisted(() => ({ queueUpdate: vi.fn() }));

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  MISSING_MEDIA_PUBLISH_MESSAGE,
-  UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
-} from '@civitai/shared';
+import { MISSING_MEDIA_PUBLISH_MESSAGE, UNRENDERABLE_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
 import type * as S3Utils from '~/utils/s3-utils';
 import type * as Shared from '@civitai/shared';
 

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -53,6 +53,11 @@ const resolve = () => resolveIngestionError({ id: 4242, nsfwLevel: 1, userId: 7 
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // 🔴 `clearAllMocks` clears CALLS, not IMPLEMENTATIONS. Without this line the throwing client
+  // installed by the "cannot even be built" case below leaks into every later test in the file, so
+  // the probe fails open and the bucket is never consulted — which silently made the non-key cases
+  // at the bottom pass for the wrong reason (they assert the bucket is NOT consulted).
+  getB2ImageS3Client.mockImplementation(() => ({} as never));
   // postId null keeps the post-level recompute out of the way; it is not what these cases pin.
   dbMock.dbRead.image.findUnique.mockResolvedValue({
     ingestion: 'Error',
@@ -146,5 +151,37 @@ describe('main-app resolveIngestionError — missing-media guard', () => {
 
     await expect(resolve()).rejects.toThrow('Image not found');
     expect(headObject).not.toHaveBeenCalled();
+  });
+});
+
+describe('a non-key Image.url is never treated as a missing object', () => {
+  /**
+   * The regression an earlier revision of this guard shipped: it assumed every `Image.url` is a
+   * bucket key. Profile pictures may hold a whitelisted external avatar CDN url verbatim, and that
+   * row is created and ingested like any other, so it reaches the review queue with a current
+   * timestamp. Handing it to the bucket as a Key 404s → `absent` → the moderator could never
+   * publish an image that renders perfectly well, with no override.
+   *
+   * The bucket must not even be CONSULTED for these, which is what `headObject` not being called
+   * pins — asserting only "it published" would still pass if the probe ran and got lucky.
+   */
+  it.each([
+    ['an external avatar CDN url', 'https://cdn.discordapp.com/avatars/123/abc.png'],
+    ['a legacy blob: handle', 'blob:https://civitai.com/9f8e-1234'],
+  ])('publishes without probing the bucket for %s', async (_label, url) => {
+    dbMock.dbRead.image.findUnique.mockResolvedValue({
+      ingestion: 'Error',
+      postId: null,
+      userId: 99,
+      metadata: {},
+      url,
+    } as never);
+    // Armed to answer `absent` — so if the probe DID run, the publish would be refused.
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await resolve();
+
+    expect(headObject).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MISSING_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
+import type * as S3Utils from '~/utils/s3-utils';
+import type * as Shared from '@civitai/shared';
+
+/**
+ * The main-app half of the missing-media publish guard.
+ *
+ * `resolveIngestionError` here is the copy the article-image-scan flow reuses, and it published an
+ * image — `ingestion = 'Scanned'` plus a locked nsfwLevel — without ever asking whether the media
+ * exists. The spoke's copy is guarded in its own suite; this one proves the same rule runs in this
+ * runtime, and that it runs THROUGH the shared module rather than a second local copy of it.
+ */
+
+const { headObject, getB2ImageS3Client, assertSpy } = vi.hoisted(() => ({
+  headObject: vi.fn(),
+  getB2ImageS3Client: vi.fn(() => ({} as never)),
+  assertSpy: vi.fn(),
+}));
+
+// Narrow overrides on a spread of the real module — s3-utils exports a great many things this
+// service uses, and a one-key factory would take the whole file out at collection.
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
+  headObject,
+  getB2ImageS3Client,
+}));
+
+/**
+ * The wiring probe. `assertMediaPresentForPublish` still runs for real — this only records that the
+ * service reached the SHARED implementation. A shared function nobody calls is worse than none, and
+ * a local re-implementation would pass every behavioural case below while silently drifting.
+ */
+vi.mock('@civitai/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof Shared>();
+  return {
+    ...actual,
+    assertMediaPresentForPublish: (
+      ...args: Parameters<typeof actual.assertMediaPresentForPublish>
+    ) => {
+      assertSpy(...args);
+      return actual.assertMediaPresentForPublish(...args);
+    },
+  };
+});
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { resolveIngestionError } from '~/server/services/image.service';
+
+const IMAGE_KEY = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const resolve = () => resolveIngestionError({ id: 4242, nsfwLevel: 1, userId: 7 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // postId null keeps the post-level recompute out of the way; it is not what these cases pin.
+  dbMock.dbRead.image.findUnique.mockResolvedValue({
+    ingestion: 'Error',
+    postId: null,
+    userId: 99,
+    metadata: {},
+    url: IMAGE_KEY,
+  } as never);
+});
+
+describe('main-app resolveIngestionError — missing-media guard', () => {
+  it('REFUSES to publish when the bucket answered that the object is absent', async () => {
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await expect(resolve()).rejects.toThrow(MISSING_MEDIA_PUBLISH_MESSAGE);
+
+    // The write is the harm. Before this guard it ran unconditionally.
+    expect(dbMock.dbWrite.image.update).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the refusal as a BAD_REQUEST, so a moderator sees the message not a 500', async () => {
+    headObject.mockResolvedValue({ status: 'absent' });
+    await expect(resolve()).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('probes the image row url in the uploads bucket, under a bounded signal', async () => {
+    headObject.mockResolvedValue({ status: 'present', size: 12345 });
+
+    await resolve();
+
+    expect(headObject).toHaveBeenCalledTimes(1);
+    const [bucket, key, , options] = headObject.mock.calls[0];
+    expect(bucket).toBe('civitai-media-uploads');
+    expect(key).toBe(IMAGE_KEY);
+    // An unbounded probe against a degraded backend turns a moderator's click into a hung request.
+    expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('publishes exactly as before when the bucket confirms the object is present', async () => {
+    headObject.mockResolvedValue({ status: 'present', size: 12345 });
+
+    await resolve();
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+    const arg = dbMock.dbWrite.image.update.mock.calls[0][0] as {
+      where: { id: number };
+      data: Record<string, unknown>;
+    };
+    expect(arg.where).toEqual({ id: 4242 });
+    // Literal expectations rather than a re-read of the implementation.
+    expect(arg.data).toMatchObject({
+      nsfwLevel: 1,
+      nsfwLevelLocked: true,
+      ingestion: 'Scanned',
+    });
+  });
+
+  it('publishes when the bucket could not be consulted (probe returned unknown)', async () => {
+    headObject.mockResolvedValue({ status: 'unknown' });
+
+    await resolve();
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes when the storage CLIENT cannot even be built', async () => {
+    // `getB2ImageS3Client()` throws when credentials are absent. That must land on "could not
+    // consult", not on a failed publish — a guard that can fail the path by its own absence is
+    // worse than no guard. The client is resolved inside the probe for exactly this reason.
+    getB2ImageS3Client.mockImplementation(() => {
+      throw new Error('B2 image upload credentials not configured');
+    });
+
+    await resolve();
+
+    expect(headObject).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('decides through the SHARED module, not a second local copy of the rule', async () => {
+    headObject.mockResolvedValue({ status: 'present', size: 1 });
+    await resolve();
+    expect(assertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses before the probe when there is no such image', async () => {
+    // Reachability control: the not-found check runs FIRST, so a fixture without a row would test
+    // that check instead of this guard.
+    dbMock.dbRead.image.findUnique.mockResolvedValue(null as never);
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await expect(resolve()).rejects.toThrow('Image not found');
+    expect(headObject).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -193,7 +193,9 @@ describe('main-app resolveIngestionError — missing-media guard', () => {
     // must land on "could not consult", not on a failed publish — a guard that can fail the path by
     // its own absence is worse than no guard. The backend is resolved inside the probe, which runs
     // inside `assertMediaPresentForPublish`'s own try, for exactly this reason.
-    getImageUploadBackend.mockRejectedValue(new Error('B2 image upload credentials not configured'));
+    getImageUploadBackend.mockRejectedValue(
+      new Error('B2 image upload credentials not configured')
+    );
 
     await resolve();
 
@@ -327,7 +329,9 @@ describe('the guard reports what it did, in both directions', () => {
   });
 
   it('distinguishes a probe that THREW from a store that declined to answer', async () => {
-    getImageUploadBackend.mockRejectedValue(new Error('B2 image upload credentials not configured'));
+    getImageUploadBackend.mockRejectedValue(
+      new Error('B2 image upload credentials not configured')
+    );
 
     await resolve();
 

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -12,9 +12,10 @@ import type * as Shared from '@civitai/shared';
  * runtime, and that it runs THROUGH the shared module rather than a second local copy of it.
  */
 
-const { headObject, getB2ImageS3Client, assertSpy } = vi.hoisted(() => ({
+const { headObject, getB2ImageS3Client, getImageUploadBackend, assertSpy } = vi.hoisted(() => ({
   headObject: vi.fn(),
   getB2ImageS3Client: vi.fn(() => ({} as never)),
+  getImageUploadBackend: vi.fn(),
   assertSpy: vi.fn(),
 }));
 
@@ -24,6 +25,7 @@ vi.mock('~/utils/s3-utils', async (importOriginal) => ({
   ...(await importOriginal<typeof S3Utils>()),
   headObject,
   getB2ImageS3Client,
+  getImageUploadBackend,
 }));
 
 /**
@@ -53,13 +55,27 @@ import { resolveIngestionError } from '~/server/services/image.service';
 
 const IMAGE_KEY = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
+/**
+ * 🔴 The upload backend the probe MUST resolve through, and both values are deliberately chosen so
+ * that no inline fallback can equal them.
+ *
+ * The bucket is NOT `'civitai-media-uploads'` — the literal an open-coded
+ * `env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads'` would produce in a test env with no
+ * `S3_IMAGE_B2_BUCKET` set — and the client is an identity-comparable sentinel, not the `{}` the
+ * `getB2ImageS3Client` mock returns. A mutant that reverts the probe to the open-coded pair
+ * therefore FAILS on the assertion rather than passing by coincidence, which is precisely what the
+ * previous fixture (`'civitai-media-uploads'`, an anonymous object) could not do.
+ */
+const PROBE_BUCKET = 'resolved-upload-backend-bucket';
+const PROBE_S3_CLIENT = { __sentinel: 'resolved-upload-backend-client' } as never;
+
 const resolve = () => resolveIngestionError({ id: 4242, nsfwLevel: 1, userId: 7 });
 
 /**
  * Every mock this FILE owns. Reset as a set rather than one at a time, so adding a collaborator
  * cannot silently opt it out of the reset — which is the shape of the defect below.
  */
-const ownMocks = [headObject, getB2ImageS3Client, assertSpy];
+const ownMocks = [headObject, getB2ImageS3Client, getImageUploadBackend, assertSpy];
 
 beforeEach(() => {
   /**
@@ -74,12 +90,17 @@ beforeEach(() => {
    * `setup.ts`, which registers canonical hybrid mocks (`dbMock`, `loggingMock`) whose DEFAULT
    * implementations are installed once per file. `resetAllMocks` strips those too, so
    * `logToAxiom(...)` returns `undefined` and the production `.catch(() => undefined)` on it throws
-   * `Cannot read properties of undefined` — measured, 17 of 30 cases here. So: clear globally
-   * (call history, which is what the assertions read), and RESET this file's own mocks.
+   * `Cannot read properties of undefined` — measured, 17 of the 23 cases in this file. So: clear
+   * globally (call history, which is what the assertions read), and RESET this file's own mocks.
    */
   vi.clearAllMocks();
   for (const mock of ownMocks) mock.mockReset();
   getB2ImageS3Client.mockImplementation(() => ({} as never));
+  getImageUploadBackend.mockResolvedValue({
+    s3: PROBE_S3_CLIENT,
+    bucket: PROBE_BUCKET,
+    backend: 'backblaze',
+  } as never);
   // postId null keeps the post-level recompute out of the way; it is not what these cases pin.
   dbMock.dbRead.image.findUnique.mockResolvedValue({
     ingestion: 'Error',
@@ -112,10 +133,32 @@ describe('main-app resolveIngestionError — missing-media guard', () => {
 
     expect(headObject).toHaveBeenCalledTimes(1);
     const [bucket, key, , options] = headObject.mock.calls[0];
-    expect(bucket).toBe('civitai-media-uploads');
+    expect(bucket).toBe(PROBE_BUCKET);
     expect(key).toBe(IMAGE_KEY);
     // An unbounded probe against a degraded backend turns a moderator's click into a hung request.
     expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('asks the SAME backend resolver the upload path used to mint the key', async () => {
+    /**
+     * 🔴 A SEAM, not a component. `Image.url` is the key `getImageUploadBackend()` handed the
+     * uploader, so that resolver is the only thing that knows which store can answer about it. An
+     * open-coded `getB2ImageS3Client()` + `env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads'` pair
+     * agrees with it only by coincidence — and the day it stops agreeing, every probe 404s, which
+     * this module reads as `absent`, which is a PERMANENT refusal. Fail-closed across the whole
+     * queue, indistinguishable from a real run of misses.
+     *
+     * Asserted on BOTH halves and against values the open-coded pair cannot produce (see
+     * `PROBE_BUCKET` / `PROBE_S3_CLIENT`), so reverting either half fails here.
+     */
+    headObject.mockResolvedValue({ status: 'present', size: 1 });
+
+    await resolve();
+
+    expect(getImageUploadBackend).toHaveBeenCalledTimes(1);
+    const [bucket, , client] = headObject.mock.calls[0];
+    expect(bucket).toBe(PROBE_BUCKET);
+    expect(client).toBe(PROBE_S3_CLIENT);
   });
 
   it('publishes exactly as before when the bucket confirms the object is present', async () => {
@@ -146,12 +189,11 @@ describe('main-app resolveIngestionError — missing-media guard', () => {
   });
 
   it('publishes when the storage CLIENT cannot even be built', async () => {
-    // `getB2ImageS3Client()` throws when credentials are absent. That must land on "could not
-    // consult", not on a failed publish — a guard that can fail the path by its own absence is
-    // worse than no guard. The client is resolved inside the probe for exactly this reason.
-    getB2ImageS3Client.mockImplementation(() => {
-      throw new Error('B2 image upload credentials not configured');
-    });
+    // Resolving the backend builds the S3 client, which throws when credentials are absent. That
+    // must land on "could not consult", not on a failed publish — a guard that can fail the path by
+    // its own absence is worse than no guard. The backend is resolved inside the probe, which runs
+    // inside `assertMediaPresentForPublish`'s own try, for exactly this reason.
+    getImageUploadBackend.mockRejectedValue(new Error('B2 image upload credentials not configured'));
 
     await resolve();
 
@@ -285,9 +327,7 @@ describe('the guard reports what it did, in both directions', () => {
   });
 
   it('distinguishes a probe that THREW from a store that declined to answer', async () => {
-    getB2ImageS3Client.mockImplementation(() => {
-      throw new Error('B2 image upload credentials not configured');
-    });
+    getImageUploadBackend.mockRejectedValue(new Error('B2 image upload credentials not configured'));
 
     await resolve();
 
@@ -300,9 +340,9 @@ describe('the guard reports what it did, in both directions', () => {
   });
 
   it('bounds the probe error it logs, so a remote response body cannot flood the pipeline', async () => {
-    getB2ImageS3Client.mockImplementation(() => {
-      throw new Error(`storage request failed (503) ${'x'.repeat(10_000)}`);
-    });
+    getImageUploadBackend.mockRejectedValue(
+      new Error(`storage request failed (503) ${'x'.repeat(10_000)}`)
+    );
 
     await resolve();
 

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -405,3 +405,24 @@ describe('the guard reports what it did, in both directions', () => {
     expect(eventsNamed('resolveIngestionError:media-probe-unknown')).toHaveLength(0);
   });
 });
+
+describe('the harness itself', () => {
+  /**
+   * 🔴 This suite's per-case reset, pinned — because the defect it fixes is LATENT and therefore has
+   * no behavioural test that could fail. `vi.clearAllMocks()` clears CALLS and leaves
+   * IMPLEMENTATIONS installed, so `headObject`'s `mockResolvedValue` from an earlier case survives
+   * into every later one. Nothing here currently depends on that, which is exactly why it needs a
+   * structural guard rather than a behavioural one: the first case that forgets to arm the store
+   * will pass for the wrong reason, and pass silently.
+   *
+   * Reachable by construction: it is the LAST block in the file, so a dozen earlier cases have
+   * armed `headObject` before it runs. Under `clearAllMocks` alone this reads back the leaked
+   * implementation and fails; under the reset it reads `undefined`.
+   */
+  it('hands each case a storage probe with NO implementation left over from the last one', () => {
+    expect(headObject.getMockImplementation()).toBeUndefined();
+    // ...while the one thing `beforeEach` deliberately re-arms IS armed, so this is not passing by
+    // the whole file's mocks having been torn down.
+    expect(getB2ImageS3Client.getMockImplementation()).toBeTypeOf('function');
+  });
+});

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -55,12 +55,30 @@ const IMAGE_KEY = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 const resolve = () => resolveIngestionError({ id: 4242, nsfwLevel: 1, userId: 7 });
 
+/**
+ * Every mock this FILE owns. Reset as a set rather than one at a time, so adding a collaborator
+ * cannot silently opt it out of the reset — which is the shape of the defect below.
+ */
+const ownMocks = [headObject, getB2ImageS3Client, assertSpy];
+
 beforeEach(() => {
+  /**
+   * 🔴 `clearAllMocks` clears CALLS, not IMPLEMENTATIONS — so a `mockResolvedValue` from an earlier
+   * case leaks into every later one, and a case that forgets to arm the store then passes for the
+   * wrong reason. The previous version cleared and re-armed only `getB2ImageS3Client` by hand,
+   * leaving `headObject`'s implementation leaking. Latent today, because no case currently depends
+   * on it — and latent is exactly how this class ships.
+   *
+   * 🔴 The spoke's copy of this suite says `vi.resetAllMocks()` and that is correct THERE, where
+   * every mock in the file is the file's own. It is wrong here: this suite runs under the global
+   * `setup.ts`, which registers canonical hybrid mocks (`dbMock`, `loggingMock`) whose DEFAULT
+   * implementations are installed once per file. `resetAllMocks` strips those too, so
+   * `logToAxiom(...)` returns `undefined` and the production `.catch(() => undefined)` on it throws
+   * `Cannot read properties of undefined` — measured, 17 of 30 cases here. So: clear globally
+   * (call history, which is what the assertions read), and RESET this file's own mocks.
+   */
   vi.clearAllMocks();
-  // 🔴 `clearAllMocks` clears CALLS, not IMPLEMENTATIONS. Without this line the throwing client
-  // installed by the "cannot even be built" case below leaks into every later test in the file, so
-  // the probe fails open and the bucket is never consulted — which silently made the non-key cases
-  // at the bottom pass for the wrong reason (they assert the bucket is NOT consulted).
+  for (const mock of ownMocks) mock.mockReset();
   getB2ImageS3Client.mockImplementation(() => ({} as never));
   // postId null keeps the post-level recompute out of the way; it is not what these cases pin.
   dbMock.dbRead.image.findUnique.mockResolvedValue({
@@ -293,6 +311,66 @@ describe('the guard reports what it did, in both directions', () => {
     };
     expect(payload.error.length).toBeLessThan(300);
     expect(payload.error.endsWith('…[truncated]')).toBe(true);
+  });
+
+  it('COUNTS the short-circuit at this call site, rather than passing silently', async () => {
+    /**
+     * 🔴 The shared module declares `onSkipped` and its own docstring says "silent fail-open is how
+     * a guard lies for months, so the caller is expected to log here" — and neither production call
+     * site passed one, so the branch had coverage in the module's suite and no caller anywhere.
+     *
+     * It matters most on THIS branch. `isProbeableMediaKey` is an acknowledged UNDER-approximation
+     * (it matches only the bare-uuid shape our upload endpoints mint, while several write paths
+     * accept a caller-supplied string), so it is KNOWN to decline real keys. Without this line, a
+     * deployment in which it declines EVERY row emits nothing at all and is byte-identical to one
+     * where the guard did its job.
+     *
+     * Pinned at the CALL SITE, not in the module: the module's own suite already covered the hook,
+     * and the defect was precisely that coverage and use had come apart.
+     */
+    dbMock.dbRead.image.findUnique.mockResolvedValue({
+      ingestion: 'Error',
+      postId: null,
+      userId: 99,
+      metadata: {},
+      url: 'https://cdn.discordapp.com/avatars/123/abc.png',
+    } as never);
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await resolve();
+
+    const events = eventsNamed('resolveIngestionError:media-probe-skipped');
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({ type: 'warning', imageId: 4242 });
+    // Its own event name, distinct from the two above. Folding it into `media-probe-unknown` is
+    // exactly the indistinguishability the `not-applicable` verdict was introduced to remove.
+    expect(eventsNamed('resolveIngestionError:media-probe-unknown')).toHaveLength(0);
+  });
+
+  it('does NOT count a probe that actually ran as a skip', async () => {
+    // The discriminating half: an `onSkipped` wired to fire unconditionally would make the count
+    // include every ordinary publish and answer nothing.
+    headObject.mockResolvedValue({ status: 'present', size: 1 });
+    await resolve();
+    expect(headObject).toHaveBeenCalledTimes(1);
+    expect(eventsNamed('resolveIngestionError:media-probe-skipped')).toHaveLength(0);
+  });
+
+  it('does NOT count a REFUSAL as a skip', async () => {
+    // Nor the other refusing verdict: a `blob:` url short-circuits the probe too, but it refuses,
+    // and counting it here would inflate the fail-open tally with fail-CLOSED events.
+    dbMock.dbRead.image.findUnique.mockResolvedValue({
+      ingestion: 'Error',
+      postId: null,
+      userId: 99,
+      metadata: {},
+      url: 'blob:https://civitai.com/9f8e-1234',
+    } as never);
+
+    await expect(resolve()).rejects.toThrow();
+
+    expect(eventsNamed('resolveIngestionError:media-probe-skipped')).toHaveLength(0);
+    expect(eventsNamed('resolveIngestionError:media-absent-refused')).toHaveLength(1);
   });
 
   it('does NOT log an inconclusive probe for a url that was never a key', async () => {

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -45,6 +45,10 @@ vi.mock('@civitai/shared', async (importOriginal) => {
 });
 
 import { dbMock } from '~/__tests__/mocks/db.mock';
+// The CANONICAL logging mock, registered globally in setup.ts. A local `vi.mock` of that module
+// would shadow it — and is flagged by the `no-direct-shared-module-mock` lint rule for a reason:
+// under `isolate: false` a per-file spy accumulates calls across every file sharing the worker.
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { resolveIngestionError } from '~/server/services/image.service';
 
 const IMAGE_KEY = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
@@ -183,5 +187,45 @@ describe('a non-key Image.url is never treated as a missing object', () => {
 
     expect(headObject).not.toHaveBeenCalled();
     expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the guard reports what it did, in both directions', () => {
+  /**
+   * Both hooks survived a revert until these existed. They are the only signal distinguishing a
+   * healthy run from two silent failure modes that look identical to it:
+   *   - fail-OPEN: credentials rotate, every probe is `unknown`, every publish is allowed;
+   *   - fail-CLOSED: a wrong bucket name 404s for every key, every publish is refused.
+   */
+  const eventsNamed = (name: string) =>
+    loggingMock.logToAxiom.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { name?: string } | undefined)?.name === name
+    );
+
+  it('logs a refusal when the bucket answered absent', async () => {
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await expect(resolve()).rejects.toThrow();
+
+    const events = eventsNamed('resolveIngestionError:media-absent-refused');
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({ type: 'warning', imageId: 4242 });
+  });
+
+  it('logs an inconclusive probe when the bucket could not be consulted', async () => {
+    headObject.mockResolvedValue({ status: 'unknown' });
+
+    await resolve();
+
+    expect(eventsNamed('resolveIngestionError:media-probe-unknown')).toHaveLength(1);
+  });
+
+  it('logs neither when the media is present', async () => {
+    headObject.mockResolvedValue({ status: 'present', size: 1 });
+
+    await resolve();
+
+    expect(eventsNamed('resolveIngestionError:media-absent-refused')).toHaveLength(0);
+    expect(eventsNamed('resolveIngestionError:media-probe-unknown')).toHaveLength(0);
   });
 });

--- a/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
+++ b/src/server/services/__tests__/resolve-ingestion-error-missing-media.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MISSING_MEDIA_PUBLISH_MESSAGE } from '@civitai/shared';
+import {
+  MISSING_MEDIA_PUBLISH_MESSAGE,
+  UNRENDERABLE_MEDIA_PUBLISH_MESSAGE,
+} from '@civitai/shared';
 import type * as S3Utils from '~/utils/s3-utils';
 import type * as Shared from '@civitai/shared';
 
@@ -171,7 +174,8 @@ describe('a non-key Image.url is never treated as a missing object', () => {
    */
   it.each([
     ['an external avatar CDN url', 'https://cdn.discordapp.com/avatars/123/abc.png'],
-    ['a legacy blob: handle', 'blob:https://civitai.com/9f8e-1234'],
+    ['a bare filename the comics router can write', 'some-file.png'],
+    ['a prefixed key shape no upload endpoint issues', 'foo/0f8fad5b-d9cb-469f-a165-70867728950e'],
   ])('publishes without probing the bucket for %s', async (_label, url) => {
     dbMock.dbRead.image.findUnique.mockResolvedValue({
       ingestion: 'Error',
@@ -188,6 +192,28 @@ describe('a non-key Image.url is never treated as a missing object', () => {
     expect(headObject).not.toHaveBeenCalled();
     expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
   });
+
+  it('REFUSES a legacy blob: handle, without probing the bucket', async () => {
+    /**
+     * 🔴 This case used to assert the opposite. `getEdgeUrl` returns a `blob:` src VERBATIM
+     * (`src/client-utils/cf-images-utils.ts`), so publishing one emits `<img src="blob:...">` into a
+     * browser that never created the handle — a permanently broken image. The bucket is armed
+     * PRESENT here, so the refusal demonstrably comes from the url and not from the store.
+     */
+    dbMock.dbRead.image.findUnique.mockResolvedValue({
+      ingestion: 'Error',
+      postId: null,
+      userId: 99,
+      metadata: {},
+      url: 'blob:https://civitai.com/9f8e-1234',
+    } as never);
+    headObject.mockResolvedValue({ status: 'present', size: 1 });
+
+    await expect(resolve()).rejects.toThrow(UNRENDERABLE_MEDIA_PUBLISH_MESSAGE);
+
+    expect(headObject).not.toHaveBeenCalled();
+    expect(dbMock.dbWrite.image.update).not.toHaveBeenCalled();
+  });
 });
 
 describe('the guard reports what it did, in both directions', () => {
@@ -202,22 +228,97 @@ describe('the guard reports what it did, in both directions', () => {
       (c: unknown[]) => (c[0] as { name?: string } | undefined)?.name === name
     );
 
-  it('logs a refusal when the bucket answered absent', async () => {
+  it('logs a refusal when the bucket answered absent, naming WHICH refusal', async () => {
     headObject.mockResolvedValue({ status: 'absent' });
 
     await expect(resolve()).rejects.toThrow();
 
     const events = eventsNamed('resolveIngestionError:media-absent-refused');
     expect(events).toHaveLength(1);
-    expect(events[0][0]).toMatchObject({ type: 'warning', imageId: 4242 });
+    // `presence` is what separates a fail-CLOSED bucket misconfiguration (which can only ever
+    // produce `absent`) from the url-shape refusal (which no bucket state can produce).
+    expect(events[0][0]).toMatchObject({ type: 'warning', imageId: 4242, presence: 'absent' });
   });
 
-  it('logs an inconclusive probe when the bucket could not be consulted', async () => {
+  it('logs the url-shape refusal under its own presence value', async () => {
+    dbMock.dbRead.image.findUnique.mockResolvedValue({
+      ingestion: 'Error',
+      postId: null,
+      userId: 99,
+      metadata: {},
+      url: 'blob:https://civitai.com/9f8e-1234',
+    } as never);
+
+    await expect(resolve()).rejects.toThrow();
+
+    const events = eventsNamed('resolveIngestionError:media-absent-refused');
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({ presence: 'unrenderable' });
+  });
+
+  it('logs an inconclusive probe with the reason the store could not answer', async () => {
+    // 🔴 `headObject` RESOLVES `{ status: 'unknown' }` rather than throwing, so without a reason
+    // this line is byte-identical to the one a client that cannot be BUILT produces — and the
+    // `error` field is empty in both. That is the indistinguishability the log exists to remove.
     headObject.mockResolvedValue({ status: 'unknown' });
 
     await resolve();
 
-    expect(eventsNamed('resolveIngestionError:media-probe-unknown')).toHaveLength(1);
+    const events = eventsNamed('resolveIngestionError:media-probe-unknown');
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({ reason: 'store-inconclusive', error: '' });
+  });
+
+  it('distinguishes a probe that THREW from a store that declined to answer', async () => {
+    getB2ImageS3Client.mockImplementation(() => {
+      throw new Error('B2 image upload credentials not configured');
+    });
+
+    await resolve();
+
+    const events = eventsNamed('resolveIngestionError:media-probe-unknown');
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({
+      reason: 'probe-threw',
+      error: 'B2 image upload credentials not configured',
+    });
+  });
+
+  it('bounds the probe error it logs, so a remote response body cannot flood the pipeline', async () => {
+    getB2ImageS3Client.mockImplementation(() => {
+      throw new Error(`storage request failed (503) ${'x'.repeat(10_000)}`);
+    });
+
+    await resolve();
+
+    const payload = eventsNamed('resolveIngestionError:media-probe-unknown')[0][0] as {
+      error: string;
+    };
+    expect(payload.error.length).toBeLessThan(300);
+    expect(payload.error.endsWith('…[truncated]')).toBe(true);
+  });
+
+  it('does NOT log an inconclusive probe for a url that was never a key', async () => {
+    /**
+     * 🔴 The finding this fixes. The not-a-key short-circuit used to return `unknown`, so every
+     * profile-picture url in the queue emitted the same "could not consult the bucket" warning as a
+     * genuine store outage — with an identical empty `error`. The one number this channel exists to
+     * produce could not answer its own question.
+     */
+    dbMock.dbRead.image.findUnique.mockResolvedValue({
+      ingestion: 'Error',
+      postId: null,
+      userId: 99,
+      metadata: {},
+      url: 'https://cdn.discordapp.com/avatars/123/abc.png',
+    } as never);
+    headObject.mockResolvedValue({ status: 'absent' });
+
+    await resolve();
+
+    expect(dbMock.dbWrite.image.update).toHaveBeenCalledTimes(1);
+    expect(eventsNamed('resolveIngestionError:media-probe-unknown')).toHaveLength(0);
+    expect(eventsNamed('resolveIngestionError:media-absent-refused')).toHaveLength(0);
   });
 
   it('logs neither when the media is present', async () => {

--- a/src/server/services/image-scan-failure.ts
+++ b/src/server/services/image-scan-failure.ts
@@ -14,12 +14,19 @@
  * giving up almost immediately on genuinely unscannable media. The ceilings are the
  * hard backstop that stops any image re-flooding the scanner forever.
  */
+import { IMAGE_SCAN_FAILURE_CLASS_PERMANENT } from '@civitai/shared';
 
 export const ImageScanFailureClass = {
   /** Infra churn that recovers on its own (container-create, 5xx, timeout, expiry). Keep retrying. */
   Transient: 'transient',
-  /** The media itself can't be downloaded/decoded — it will never scan. Stop almost immediately. */
-  Permanent: 'permanent',
+  /**
+   * The media itself can't be downloaded/decoded — it will never scan. Stop almost immediately.
+   *
+   * Sourced from `@civitai/shared` rather than spelled here, because the moderator spoke's SQL keys
+   * a queue off this exact stored string and cannot see this file. Two literals that must agree,
+   * in two runtimes, is how they stop agreeing.
+   */
+  Permanent: IMAGE_SCAN_FAILURE_CLASS_PERMANENT,
   /** Unclassifiable reason. Retry conservatively under the historical cap. */
   Unknown: 'unknown',
 } as const;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -8081,8 +8081,30 @@ const RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS = 5_000;
  * uploads land and the probe keeps asking the old bucket, which answers 404 for every key — and on
  * this path an `absent` is a PERMANENT publish refusal, so the whole queue would fail closed while
  * looking exactly like a real run of misses. Resolving through the same function the uploader uses
- * makes that class impossible rather than merely unlikely. (The sibling probe at
+ * removes that class WITHIN THIS PROCESS. (The sibling probe at
  * `src/server/utils/stored-image-probe.ts` already resolves this way.)
+ *
+ * 🔴 SCOPE OF THAT CLAIM — IT IS ABOUT THIS RUNTIME ONLY, AND THE SPOKE IS NOT COVERED. Today this
+ * refactor is a pure no-op: `getImageUploadBackend()` (`src/utils/s3-utils.ts`) returns exactly the
+ * `getB2ImageS3Client()` + `env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads'` pair it replaces.
+ * Its whole value is that a future move of the upload store moves the probe with it, here.
+ *
+ * The moderator spoke's copy of this probe (`apps/moderator/src/lib/server/ingestion.service.ts`)
+ * still names a fixed backend — `getMediaProbeStorage().headObject({ backend: 'b2Image', key })` —
+ * and that is NOT the same asymmetry it looks like, so it is written out rather than filed as a
+ * TODO. `'b2Image'` is not a bucket literal; it is an alias in `@civitai/storage`'s wire enum
+ * (`packages/civitai-storage/src/schema.ts`) that the `apps/storage` service resolves in ITS OWN
+ * process (`apps/storage/src/lib/server/backends.ts`) from ITS OWN `S3_IMAGE_B2_*` env — a
+ * different deployment and a different Secret from this app's. So the spoke already resolves
+ * through an indirection; it just lands on a SECOND source of truth rather than this one. There is
+ * no `getImageUploadBackend()` equivalent to route it through, and adding one is not a rename.
+ *
+ * The consequence, stated so nobody re-derives it as symmetry: moving the upload store needs THREE
+ * coordinated changes, not one — this app's `S3_IMAGE_B2_*`, the storage service's `S3_IMAGE_B2_*`
+ * (or a new alias in that enum plus every `backend: 'b2Image'` call site), and the Go
+ * storage-resolver's `B2_MEDIA_BUCKET_NAME`, whose `media_locations` rows are already stamped
+ * `backend='backblaze'`. This change removes one of the three from the list of things that can be
+ * forgotten silently. It does not remove the other two.
  *
  * Calling it is deliberately INSIDE the caller's try (see `assertMediaPresentForPublish`), because
  * it builds the S3 client, which throws when credentials are absent — that must land on `unknown`,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server';
 import {
   assertMediaPresentForPublish,
   MediaPresence,
-  type MediaPresence as MediaPresenceType,
+  type MediaProbeAnswer,
   summarizeProbeError,
 } from '@civitai/shared';
 import { randomUUID } from 'crypto';
@@ -8076,7 +8076,7 @@ const imageUploadsBucket = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-upload
  * because `getB2ImageS3Client()` throws when credentials are absent and that must land on `unknown`,
  * not on a failed publish.
  */
-async function probeImageMediaPresence(key: string): Promise<MediaPresenceType> {
+async function probeImageMediaPresence(key: string): Promise<MediaProbeAnswer> {
   // 🔴 No key check here, deliberately. `assertMediaPresentForPublish` classifies the url and only
   // calls this with a value that already passed the SHARED `isProbeableMediaKey` — a copy of that
   // test in each probe is exactly how the two runtimes came to disagree about the same row.

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import {
   assertMediaPresentForPublish,
+  isProbeableMediaKey,
   MediaPresence,
   type MediaPresence as MediaPresenceType,
 } from '@civitai/shared';
@@ -8075,8 +8076,12 @@ const imageUploadsBucket = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-upload
  * because `getB2ImageS3Client()` throws when credentials are absent and that must land on `unknown`,
  * not on a failed publish.
  */
-async function probeImageMediaPresence(key: string): Promise<MediaPresenceType> {
-  const head = await headObject(imageUploadsBucket(), key, getB2ImageS3Client(), {
+async function probeImageMediaPresence(url: string): Promise<MediaPresenceType> {
+  // 🔴 Not every `Image.url` is a bucket key — see `isProbeableMediaKey`. A non-key url handed to
+  // the bucket 404s, which is indistinguishable from a real miss, so without this the guard would
+  // permanently refuse images that render fine (external-CDN avatars, legacy `blob:` rows).
+  if (!isProbeableMediaKey(url)) return MediaPresence.Unknown;
+  const head = await headObject(imageUploadsBucket(), url, getB2ImageS3Client(), {
     abortSignal: AbortSignal.timeout(RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS),
   });
   if (head.status === 'present') return MediaPresence.Present;
@@ -8125,6 +8130,15 @@ export async function resolveIngestionError({
   await assertMediaPresentForPublish({
     probe: () => probeImageMediaPresence(image.url),
     raise: (message) => throwBadRequestError(message),
+    // The mirror of onUnknown: a wrong bucket name 404s for EVERY key, so a fail-CLOSED
+    // misconfiguration would refuse every publish and look exactly like a real run of misses.
+    onRefused: () =>
+      logToAxiom({
+        type: 'warning',
+        name: 'resolveIngestionError:media-absent-refused',
+        message: 'Refused to publish an image whose media object the bucket reports absent',
+        imageId: id,
+      }).catch(() => undefined),
     // Silent fail-open is how a guard lies for months: with credentials rotated, every publish
     // would take the `unknown` branch and this would be indistinguishable from a clean run.
     onUnknown: (error) =>

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1,5 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
+import {
+  assertMediaPresentForPublish,
+  MediaPresence,
+  type MediaPresence as MediaPresenceType,
+} from '@civitai/shared';
 import { randomUUID } from 'crypto';
 import type { ManipulateType } from 'dayjs';
 import dayjs from '~/shared/utils/dayjs';
@@ -224,7 +229,7 @@ import { fetchBlob } from '~/utils/file-utils';
 import { getMetadata } from '~/utils/metadata';
 import { removeEmpty } from '~/utils/object-helpers';
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
+import { serverUploadImage, getB2ImageS3Client, headObject } from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
 import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
@@ -8051,8 +8056,36 @@ export async function updateImageNsfwLevel({
 // NOTE(moderator-migration): getImageRatingRequests + getDownleveledImages (the image-rating-review and
 // downleveled-review queues) now live in the spoke app (apps/moderator). updateImageNsfwLevel STAYS — it
 // backs user rating votes + the mod APIs (set-image-nsfw-level, retool) + new-order.
-// NOTE(moderator-migration): getIngestionErrorImages (the ingestion-error-review queue) now lives in the
-// spoke app (apps/moderator, Kysely). resolveIngestionError STAYS — main's article-image-scan
+/**
+ * Timeout budget for the media-existence probe below. A moderator is waiting on this click, and an
+ * UNBOUNDED probe against a degraded store would turn a review action into a hung request — strictly
+ * worse than the bug it guards. Per `headObject`'s contract this bounds each network ATTEMPT, not
+ * wall clock: the SDK's retry sleep is not abort-aware, so worst case is this budget plus one
+ * backoff. An abort is not a not-found shape, so it lands on `unknown` and the publish proceeds.
+ */
+const RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS = 5_000;
+
+/** Every image object lives in the b2Image uploads bucket, and `Image.url` IS its key. */
+const imageUploadsBucket = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads';
+
+/**
+ * Ask the uploads bucket whether an image's object is actually there, as a three-valued answer.
+ *
+ * Exported for the wiring test only — building the client is deliberately INSIDE the caller's try
+ * (see `assertMediaPresentForPublish`), because `getB2ImageS3Client()` throws when credentials are
+ * absent and that must land on `unknown`, not on a failed publish.
+ */
+export async function probeImageMediaPresence(key: string): Promise<MediaPresenceType> {
+  const head = await headObject(imageUploadsBucket(), key, getB2ImageS3Client(), {
+    abortSignal: AbortSignal.timeout(RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS),
+  });
+  if (head.status === 'present') return MediaPresence.Present;
+  if (head.status === 'absent') return MediaPresence.Absent;
+  return MediaPresence.Unknown;
+}
+
+// NOTE(moderator-migration): getIngestionErrorImages (the ingestion-error-review queue) now lives in
+// the spoke app (apps/moderator, Kysely). resolveIngestionError STAYS — main's article-image-scan
 // (resolveArticleImageScan) reuses it to pin an article image's nsfwLevel.
 export async function resolveIngestionError({
   id,
@@ -8070,9 +8103,39 @@ export async function resolveIngestionError({
       postId: true,
       userId: true,
       metadata: true,
+      url: true,
     },
   });
   if (!image) throw new Error('Image not found');
+
+  /**
+   * 🔴 REFUSE TO PUBLISH AN IMAGE WHOSE MEDIA IS GONE.
+   *
+   * This function's whole effect is to make an image visible: `ingestion = 'Scanned'` plus a locked
+   * nsfwLevel. It did that unconditionally, and the queue that feeds it selects only on
+   * `ingestion = 'Error' AND nsfwLevel = 0` — so an image whose file can never be fetched was
+   * presented to a moderator for a rating exactly like a scan that merely timed out, and publishing
+   * it put a permanent 404 on the site. Measured over ~92,000 image creations in 24h: 10 such
+   * images, all 10 confirmed absent from the store, 8 of them published by the queue that day.
+   *
+   * The verdict is three-valued and only `absent` refuses; see `@civitai/shared/missing-media` for
+   * why an unconsultable store must fail OPEN. The same rule runs in the moderator spoke, from the
+   * same module, so the two cannot drift.
+   */
+  await assertMediaPresentForPublish({
+    probe: () => probeImageMediaPresence(image.url),
+    raise: (message) => throwBadRequestError(message),
+    // Silent fail-open is how a guard lies for months: with credentials rotated, every publish
+    // would take the `unknown` branch and this would be indistinguishable from a clean run.
+    onUnknown: (error) =>
+      logToAxiom({
+        type: 'warning',
+        name: 'resolveIngestionError:media-probe-unknown',
+        message: 'Could not consult the uploads bucket; allowing the publish',
+        imageId: id,
+        error: error instanceof Error ? error.message : String(error ?? ''),
+      }).catch(() => undefined),
+  });
 
   const metadata = (image.metadata as ImageMetadata) ?? {};
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -8156,6 +8156,22 @@ export async function resolveIngestionError({
         reason,
         error: summarizeProbeError(error),
       }).catch(() => undefined),
+    /**
+     * 🔴 The short-circuit needs a counter too, and for a sharper reason than the other two.
+     * `isProbeableMediaKey` is a deliberate UNDER-approximation — it matches only the bare-uuid
+     * shape our upload endpoints mint, and several write paths accept a caller-supplied string —
+     * so it is KNOWN to decline real keys. Without this line that under-approximation is
+     * unmeasurable: a run in which the predicate declines every row emits nothing at all and is
+     * byte-identical to a run where the guard did its job. Silent fail-open is how a guard lies for
+     * months, and this is the branch on which it would lie hardest.
+     */
+    onSkipped: () =>
+      logToAxiom({
+        type: 'warning',
+        name: 'resolveIngestionError:media-probe-skipped',
+        message: 'Image.url is not a probeable media key; no existence check ran',
+        imageId: id,
+      }).catch(() => undefined),
   });
 
   const metadata = (image.metadata as ImageMetadata) ?? {};

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2,9 +2,9 @@ import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import {
   assertMediaPresentForPublish,
-  isProbeableMediaKey,
   MediaPresence,
   type MediaPresence as MediaPresenceType,
+  summarizeProbeError,
 } from '@civitai/shared';
 import { randomUUID } from 'crypto';
 import type { ManipulateType } from 'dayjs';
@@ -8076,12 +8076,11 @@ const imageUploadsBucket = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-upload
  * because `getB2ImageS3Client()` throws when credentials are absent and that must land on `unknown`,
  * not on a failed publish.
  */
-async function probeImageMediaPresence(url: string): Promise<MediaPresenceType> {
-  // 🔴 Not every `Image.url` is a bucket key — see `isProbeableMediaKey`. A non-key url handed to
-  // the bucket 404s, which is indistinguishable from a real miss, so without this the guard would
-  // permanently refuse images that render fine (external-CDN avatars, legacy `blob:` rows).
-  if (!isProbeableMediaKey(url)) return MediaPresence.Unknown;
-  const head = await headObject(imageUploadsBucket(), url, getB2ImageS3Client(), {
+async function probeImageMediaPresence(key: string): Promise<MediaPresenceType> {
+  // 🔴 No key check here, deliberately. `assertMediaPresentForPublish` classifies the url and only
+  // calls this with a value that already passed the SHARED `isProbeableMediaKey` — a copy of that
+  // test in each probe is exactly how the two runtimes came to disagree about the same row.
+  const head = await headObject(imageUploadsBucket(), key, getB2ImageS3Client(), {
     abortSignal: AbortSignal.timeout(RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS),
   });
   if (head.status === 'present') return MediaPresence.Present;
@@ -8123,31 +8122,39 @@ export async function resolveIngestionError({
    * it put a permanent 404 on the site. Measured over ~92,000 image creations in 24h: 10 such
    * images, all 10 confirmed absent from the store, 8 of them published by the queue that day.
    *
-   * The verdict is three-valued and only `absent` refuses; see `@civitai/shared/missing-media` for
-   * why an unconsultable store must fail OPEN. The same rule runs in the moderator spoke, from the
-   * same module, so the two cannot drift.
+   * The verdict is five-valued and only `absent`/`unrenderable` refuse; see
+   * `@civitai/shared/missing-media` for why an unconsultable store must fail OPEN, and
+   * `@civitai/shared/media-key` for which urls are even askable. The same rule runs in the
+   * moderator spoke, from the same module, so the two cannot drift.
    */
   await assertMediaPresentForPublish({
-    probe: () => probeImageMediaPresence(image.url),
+    url: image.url,
+    probe: (key) => probeImageMediaPresence(key),
     raise: (message) => throwBadRequestError(message),
     // The mirror of onUnknown: a wrong bucket name 404s for EVERY key, so a fail-CLOSED
     // misconfiguration would refuse every publish and look exactly like a real run of misses.
-    onRefused: () =>
+    // `presence` distinguishes that case from the url-shape refusal, which no bucket can cause.
+    onRefused: (presence) =>
       logToAxiom({
         type: 'warning',
         name: 'resolveIngestionError:media-absent-refused',
-        message: 'Refused to publish an image whose media object the bucket reports absent',
+        message: 'Refused to publish an image whose media cannot be served',
         imageId: id,
+        presence,
       }).catch(() => undefined),
     // Silent fail-open is how a guard lies for months: with credentials rotated, every publish
     // would take the `unknown` branch and this would be indistinguishable from a clean run.
-    onUnknown: (error) =>
+    // 🔴 `reason` is what makes the count readable: `headObject` RESOLVES `{ status: 'unknown' }`
+    // rather than throwing, so without it a store that answers 403 for every key and a client that
+    // cannot be built at all emit the same line with an empty `error`.
+    onUnknown: ({ reason, error }) =>
       logToAxiom({
         type: 'warning',
         name: 'resolveIngestionError:media-probe-unknown',
         message: 'Could not consult the uploads bucket; allowing the publish',
         imageId: id,
-        error: error instanceof Error ? error.message : String(error ?? ''),
+        reason,
+        error: summarizeProbeError(error),
       }).catch(() => undefined),
   });
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -230,7 +230,12 @@ import { fetchBlob } from '~/utils/file-utils';
 import { getMetadata } from '~/utils/metadata';
 import { removeEmpty } from '~/utils/object-helpers';
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { serverUploadImage, getB2ImageS3Client, headObject } from '~/utils/s3-utils';
+import {
+  serverUploadImage,
+  getB2ImageS3Client,
+  getImageUploadBackend,
+  headObject,
+} from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
 import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
@@ -8066,21 +8071,29 @@ export async function updateImageNsfwLevel({
  */
 const RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS = 5_000;
 
-/** Every image object lives in the b2Image uploads bucket, and `Image.url` IS its key. */
-const imageUploadsBucket = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads';
-
 /**
  * Ask the uploads bucket whether an image's object is actually there, as a three-valued answer.
  *
- * Building the client is deliberately INSIDE the caller's try (see `assertMediaPresentForPublish`),
- * because `getB2ImageS3Client()` throws when credentials are absent and that must land on `unknown`,
+ * 🔴 THE BACKEND COMES FROM `getImageUploadBackend()`, NOT AN INLINE CLIENT + BUCKET LITERAL.
+ * `Image.url` is the key the UPLOAD path minted, so the only store that can answer about it is the
+ * one that path writes to. An open-coded `getB2ImageS3Client()` + `env.S3_IMAGE_B2_BUCKET ??
+ * 'civitai-media-uploads'` pair agrees with that resolver only by coincidence today: change where
+ * uploads land and the probe keeps asking the old bucket, which answers 404 for every key — and on
+ * this path an `absent` is a PERMANENT publish refusal, so the whole queue would fail closed while
+ * looking exactly like a real run of misses. Resolving through the same function the uploader uses
+ * makes that class impossible rather than merely unlikely. (The sibling probe at
+ * `src/server/utils/stored-image-probe.ts` already resolves this way.)
+ *
+ * Calling it is deliberately INSIDE the caller's try (see `assertMediaPresentForPublish`), because
+ * it builds the S3 client, which throws when credentials are absent — that must land on `unknown`,
  * not on a failed publish.
  */
 async function probeImageMediaPresence(key: string): Promise<MediaProbeAnswer> {
   // 🔴 No key check here, deliberately. `assertMediaPresentForPublish` classifies the url and only
   // calls this with a value that already passed the SHARED `isProbeableMediaKey` — a copy of that
   // test in each probe is exactly how the two runtimes came to disagree about the same row.
-  const head = await headObject(imageUploadsBucket(), key, getB2ImageS3Client(), {
+  const { s3, bucket } = await getImageUploadBackend();
+  const head = await headObject(bucket, key, s3, {
     abortSignal: AbortSignal.timeout(RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS),
   });
   if (head.status === 'present') return MediaPresence.Present;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -8071,11 +8071,11 @@ const imageUploadsBucket = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-upload
 /**
  * Ask the uploads bucket whether an image's object is actually there, as a three-valued answer.
  *
- * Exported for the wiring test only — building the client is deliberately INSIDE the caller's try
- * (see `assertMediaPresentForPublish`), because `getB2ImageS3Client()` throws when credentials are
- * absent and that must land on `unknown`, not on a failed publish.
+ * Building the client is deliberately INSIDE the caller's try (see `assertMediaPresentForPublish`),
+ * because `getB2ImageS3Client()` throws when credentials are absent and that must land on `unknown`,
+ * not on a failed publish.
  */
-export async function probeImageMediaPresence(key: string): Promise<MediaPresenceType> {
+async function probeImageMediaPresence(key: string): Promise<MediaPresenceType> {
   const head = await headObject(imageUploadsBucket(), key, getB2ImageS3Client(), {
     abortSignal: AbortSignal.timeout(RESOLVE_INGESTION_MEDIA_PROBE_TIMEOUT_MS),
   });


### PR DESCRIPTION
## The defect

An `Image` row can reference a media key that has no object behind it. The scan pipeline detects this correctly: the scanner reports that the input could not be downloaded, `markImageScanError` stamps `scanJobs.error.failureClass = 'permanent'`, and the row sits at `ingestion='Error'`, `nsfwLevel=0` — invisible, which is right.

The harm came from the moderator ingestion-error-review queue, which then **published** it. `resolveIngestionError` set `ingestion='Scanned'` + `nsfwLevel` + `nsfwLevelLocked` unconditionally, with nothing checking that the media exists. The queue that feeds it selects only on `ingestion='Error' AND nsfwLevel=0`, so an image whose file can never be fetched was handed to a human for an NSFW rating exactly like a scan that merely timed out.

Measured over ~92,000 image creations in 24h: **10 images had unfetchable media, all 10 confirmed absent from the media store by a direct existence check, and 8 of those 10 were published by the review queue that same day** — so they now serve a 404 to every viewer. The other 64 clears that day were timeout failures whose files DO exist; those clears were correct and keep working.

## What this changes

### 1. The write is guarded, in both runtimes, through one shared rule

`resolveIngestionError` exists twice, in two runtimes, and both are now guarded:

| Call site | Runtime | Also reached by |
|---|---|---|
| `src/server/services/image.service.ts` | Next.js / Prisma | `resolveArticleImageScan` (`article.service.ts`) |
| `apps/moderator/src/lib/server/ingestion.service.ts` | SvelteKit spoke / Kysely | the ingestion-error page action |

The spoke is the one that caused the incident; guarding only the main-repo copy would have left it wide open. Rather than open-code the predicate twice — which regenerates the same bug at both sites — the rule lives in `@civitai/shared` (`missing-media.ts`), which both already depend on. Each runtime supplies only the **probe** (how to ask its own storage client); the verdict and the refusal are decided in one place.

`@civitai/shared` had no vitest config, so nothing in CI would have run tests placed there. One is added; the root config's `packages/*/vitest.config.ts` glob picks it up, and `--project '@civitai/*'` now selects 12 tests from it (verified by grepping the verbose run, not inferred).

### 2. Three-valued verdict, never a boolean

Copied from the reasoning already written at the upload-completion call site, which solved this problem for a different caller:

- store answered **`absent`** → **throw**, publish refused;
- probe threw / timed out / the storage client could not even be constructed (**`unknown`**) → **allow**, and log.

Inability to consult the store is not evidence of loss. Rejecting on it would let a verification step block legitimate moderation on the very queue whose job is unblocking content — a rotated credential would turn into a moderation outage. That fail-open half is the easy one to get backwards, so it has its own tests in both runtimes plus the shared module.

The probe is bounded by `AbortSignal.timeout(5s)`: a moderator is waiting on the click, and an unbounded probe against a degraded store turns a review action into a hung request. (Per `headObject`'s own contract that bounds each network attempt, not wall clock.)

The thrown message is user-facing — the spoke's action renders it via `fail(400, { error })`, and the main app raises it as a `BAD_REQUEST` — so it says what happened and what to do instead rather than reading like a stack trace. It is pinned whole in a test, because a guard on keywords is walkable by rewording.

The shared helper also carries a backstop: a caller may pass a runtime-appropriate `raise`, but if that `raise` returns instead of throwing, the helper still throws. The refusal must not depend on each call site getting that right.

### 3. Permanently-broken images no longer reach a human

`ingestionErrorWhere` is a shared const used by BOTH the queue and its badge — a divergence there is a count that never reaches zero. That property is preserved: the window/state predicates are factored into `ingestionErrorBaseWhere`, and the two views differ in exactly one term.

- `/images/ingestion-errors` now excludes permanent-failure images.
- A new `/images/missing-media` view shows them, **delete-only** — there is no rating affordance, because there is nothing to rate. It has its own badge, built from its own shared const.

The split keys off the stored `scanJobs.error.failureClass`, **not** a text match on the scanner's reason in this query (`reason ILIKE '%download%'` would be a spelled guard — one reword and every broken image walks back into the queue, silently, at query time). Being honest about what that buys: the stored *class* is a fixed enum, but the classification producing it is itself a substring match on the scanner's prose one layer up, so a reword still moves images between the queues — at scan time, on new rows, where that module's own tests can see it, rather than silently re-partitioning every historical row.

The SQL uses `IS NOT DISTINCT FROM` rather than `= / <>`: the JSON path yields NULL for an image with no stored scan error, and `NULL <> 'permanent'` is NULL, which a WHERE treats as false. A plain `<>` would have silently dropped every *unclassified* failure out of the review queue — i.e. the ordinary population moderators are there to clear. That false-positive guard has its own test and its own mutant.

`ImageScanFailureClass.Permanent` now sources its literal from the same shared constant the SQL binds, with a test pinning both to `'permanent'`, so the two runtimes cannot drift apart on the one string that connects them.

## Test matrix — red at `origin/main`, green at HEAD

Method: with HEAD's tests in place, `git checkout origin/main -- src/server/services/image.service.ts apps/moderator/src/lib/server/ingestion.service.ts`, run, restore.

**At `origin/main`: 8 failed | 9 passed (17).** The three headline regressions all report `promise resolved "undefined" instead of rejecting` — i.e. current `main` happily publishes an image whose media is absent:

| Test | At `origin/main` | Reason |
|---|---|---|
| main-app · REFUSES to publish when the bucket answered absent | ❌ | `promise resolved "undefined" instead of rejecting` |
| main-app · surfaces the refusal as a BAD_REQUEST | ❌ | `promise resolved "undefined" instead of rejecting` |
| main-app · probes the row url under a bounded signal | ❌ | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| main-app · decides through the SHARED module | ❌ | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| spoke · REFUSES to publish when the store answered absent | ❌ | `promise resolved "undefined" instead of rejecting` |
| spoke · probes the row url against the media backend | ❌ | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| spoke · publishes and logs when the probe THREW | ❌ | `expected "warn" to be called 1 times, but got 0 times` |
| article · refuses, and leaves the article untouched | ❌ | `promise resolved "undefined" instead of rejecting` |

The 9 that pass at `origin/main` are labelled as what they are — **invariant guards, not regression coverage**: present → publishes, unknown → publishes, image-not-found, cross-article rejection. They exist to pin that the guard changes nothing on the paths it must not touch.

The queue-predicate tests cannot be expressed at `origin/main` at all (`getMissingMediaImages` does not exist there), so their strength is established by mutation instead — see M6–M9.

**At HEAD: 65 passed (65)** across the 8 touched files.

Full suites at HEAD:
- `pnpm test:unit:run` — **1516 files passed, 1 skipped; 23745 tests passed, 26 skipped, 0 failed** (rc 0)
- `pnpm test:apps:run` — **102 of 103 files passed; 1109 passed, 36 failed**
- `pnpm test:packages:run` — **83 of 86 files passed; 1167 passed, 8 failed**
- `pnpm typecheck` — 0 errors; `svelte-check` on the spoke — 0 errors
- `pnpm lint` — 0 new problems from these files (verified with a positive control proving the invocation can report); `pnpm prettier:check` clean (verified with a negative control that made it go red)

The 44 local failures in `apps`/`packages` are all in `*.explain.test.ts` — a DB-backed tier that needs a Postgres this dev box does not run. **Attributed, not assumed**: a second worktree was checked out at this branch's own base (`390a70c332`), dependencies installed, and `pnpm test:apps:run` run there first to establish a baseline set of failing test names.

| | files | tests passed | tests failed |
|---|---|---|---|
| base `390a70c332` | 99 passed / 1 failed | 1092 | 36 |
| this branch | 102 passed / 1 failed | 1109 | 36 |

The two sets of failing test **names** are identical — `comm` reports nothing in either direction — and all 36 live in `apps/moderator/src/lib/server/__tests__/reports.queries.explain.test.ts`, which this PR does not touch. The delta is `+17 passed, +0 failed`, which is exactly the 17 moderator tests this PR adds (7 queue-partition, 5 spoke guard, 5 route action). The extractor produced 36 non-empty lines on both inputs, so the empty diff is a real match rather than a regex that matched nothing.

Two independent corroborations: with `DATABASE_URL` unset, `tag.db.explain.test.ts` reports `1 skipped / 6 skipped` rather than failing; and CI's `App unit tests + typecheck` and `Package unit tests` jobs both pass, since CI has no such variable.

## Mutation results

Ten mutants, each applied alone, each suite re-run, each file restored from git afterwards. **M0 is the control** — an inert comment edit that must leave everything green, which it did (35/35). Every other mutant died, and the table records the assertion that killed it, so none died for a neighbouring reason.

| Mutant | Killed by | With |
|---|---|---|
| M0 CONTROL — inert comment edit | *(none — 35 passed)* | — |
| M1 refuse on `unknown` instead of `absent` | shared · refuses exactly one of the three verdicts | `expected { allow: true, presence: 'absent' } to deeply equal { allow: false, …(2) }` |
| M2 probe errors escape instead of becoming `unknown` | shared · allows when the probe throws SYNCHRONOUSLY | `Error: B2 image upload credentials not configured` (escaped) |
| M3 drop the backstop throw, trust `raise` | shared · still refuses when a supplied raise returns | `promise resolved "{ allow: false, …(2) }" instead of rejecting` |
| M4 delete the main-app guard call | main-app · REFUSES to publish when absent | `promise resolved "undefined" instead of rejecting` |
| M5 delete the spoke guard call | spoke · REFUSES to publish when absent | `promise resolved "undefined" instead of rejecting` |
| M6 drop the permanent-failure exclusion from the review queue | queue · partitions the same window | `expected false to be true` |
| M7 `<>` instead of `IS NOT DISTINCT FROM` | queue · is NULL-safe, so an unclassified failure still reaches a human | `expected '…' to contain 'IS NOT DISTINCT FROM'` |
| M8 fork the shared const — give the badge its own predicate | queue · gives the ingestion-error badge the same predicate as its queue | `expected 'AND NOT ( i."scanJobs"->…' to be 'AND (TRUE)'` |
| M9 key the split off the scanner reason text | queue · never keys the split off the scanner reason TEXT | `expected '…' not to match /like/i` |

M4 and M5 are deliberately separate: M4 leaves the spoke's tests green and M5 leaves the main app's green, which is what proves each runtime has coverage of its own rather than one suite covering for both.

M9 originally died only to the whole-SQL pin, which would have made the anti-`ILIKE` assertion unreachable — a guard that reads as coverage while providing none. It was split into its own test and re-run; it now dies with `not to match /like/i`, its own reason.

**Reachability**, since a guard that an earlier check always rejects is untested: every fixture is built to pass the checks that run before the guard (the image row exists; the article image really is that article's cover), and each earlier check has its own case asserting the guard is *not* reached — `expect(headObject).not.toHaveBeenCalled()`.

## The article path

`resolveArticleImageScan` reuses `resolveIngestionError`, so it inherits the guard. Article images are ordinary `Image` rows whose `url` is the object key in the same media store — the same assumption the image-deletion path already makes when it passes `image.url` straight through as the key to delete. I found no flow that legitimately resolves an image with no object: the one nearby special case is that this path also un-blocks policy-**Blocked** images, and a blocked image's object is present, so the guard does not touch it.

The case worth pinning turned out to be ordering, and it now has a test: a refused publish must leave the article completely untouched, rather than recompute its ingestion and re-index it around a write that never happened.

## Deliberately not in this PR

**A "notify the uploader" affordance on the missing-media view.** The view ships delete-only. Notifying requires choosing a notification type and copy for a user-visible message about their own upload, which is a product decision rather than a mechanical one.

Closing condition: a follow-up PR adds a `notify` action to `apps/moderator/src/routes/images/missing-media/+page.server.ts` and its test; it closes when that PR is merged. If the answer is "delete is enough", it closes by someone stating that on this thread and the item being dropped — no object stays open on "someone will decide".

---

# Round 2 — adversarial audit, and a deploy-blocker it found

An adversarial audit was run against the tip above. It found a **deploy-blocking defect that is the inverse of the bug this PR fixes**: the guard would have permanently REFUSED legitimate publishes. Everything below was verified firsthand against the source before being acted on.

## 🔴 The blocker: not every `Image.url` is a bucket key

Both probes passed `Image.url` straight through as an object key. That is false for at least two live populations:

- **External-CDN avatars.** `profilePictureSchema.url` is `z.url().or(<uuid regex>)` and `verifyAvatar` whitelists four external avatar CDN prefixes. The value is stored verbatim in a new `Image` row and **immediately ingested**, so it carries a current timestamp and lands in the review queue's 2-day window. If its scan merely times out it classifies `Transient`, so it stays in the *main* queue and gets rated.
- **Legacy `blob:` handles**, which `isBlobUrl` documents as "a legacy upload bug persisted some of these into `Image.url`".

Handing either to the bucket as a Key returns 404 → `absent` → **refused, permanently, with no override**, for an image that renders perfectly well. Strictly worse than the bug the guard exists to fix.

**This PR's own justification was wrong**, and that is worth stating plainly: the body claimed the probe made "the same assumption the image-deletion path already makes". It does not. `deleteImageFromS3` makes the *narrower* claim, opening with `if (!url || url.startsWith('http')) return;` and the comment *"Legacy avatar rows hold a full external URL where every other row holds a bucket key."* The guard generalised that to "every row" and dropped the exclusion.

A second, related finding: the two runtimes **disagreed below the shared rule** — for a `blob:` url the main app 404s to `absent` (refuse) while the spoke throws on an empty parsed bucket to `unknown` (allow). Same row, opposite verdicts: precisely the drift the shared module exists to prevent.

**Fix:** `isProbeableMediaKey` in `@civitai/shared`, applied by both probes before the store is consulted. Anything carrying a URI scheme is not a key → `unknown` → allows. Conservative in the safe direction: a false negative costs nothing, a false positive is the permanent refusal above. Deciding it in the shared module (not in each probe) is what makes the two runtimes agree by construction rather than by coincidence.

## Also fixed from the audit

| Finding | Change |
|---|---|
| Spoke probe **unbounded** — default `10s × 3 attempts + backoff ≈ 31s` on a moderator's click, while the main app bounded itself at 5s | separate `getMediaProbeStorage()` client at 5s / no retries |
| **Refusals unobservable** — a wrong bucket name 404s for *every* key, so a fail-CLOSED misconfiguration is indistinguishable from a clean run | `onRefused` hook, logged in both runtimes; the mirror of the existing `onUnknown` |
| Delete action took an **arbitrary id** and did a permanent cascading delete | re-selects through the same shared `missingMediaWhere` predicate first |
| Delete was **unattributed** | records `recordModActivity`, after the delete so a failure records nothing |
| Page copy said "could not be fetched" for a population that also includes **decode** failures | copy corrected; the affordance question is noted below |
| The reword-resistance comment **overstated** what keying off the stored class buys | corrected, in code and in this body |

Not changed, deliberately: `🟡` the new nav entry needs a page grant before non-admin moderators can reach `/images/missing-media`. Flagged as a **deploy step**, not a code change — it fails safe (the page is unreachable rather than unguarded).

## Test-harness defect found by a positive control

The new non-key tests initially **passed under a mutant that removed the guard** — a survived mutant. Rather than trust that, a positive control (mutating a string the same suite asserts on) proved the project *can* see shared-module edits, so the survival was real behaviour, not a stale cache.

Cause: an earlier case installs a throwing storage client, and `vi.clearAllMocks()` clears **calls but not implementations**, so it leaked forward. Every later test's probe failed open and never consulted the bucket — which is exactly what those tests assert, so they passed for the wrong reason. Fixed by resetting the implementation in `beforeEach`.

## Round-2 mutation results

Eight mutants, each applied alone against a committed tree. **N0 is the control** (inert comment edit, 41/41 green).

| Mutant | Killed by | With |
|---|---|---|
| N0 CONTROL | *(none — 41 passed)* | — |
| N1 the pre-fix assumption: every url is a key | shared · rejects every external-avatar CDN url | `expected true to be false` |
| N2 scheme test inverted | shared · accepts the bare object keys | `expected false to be true` |
| N3 refusal no longer reported | shared · reports every refusal | `expected "vi.fn()" to be called 1 times, but got 0` |
| N4 main-app short-circuit dropped | main-app · publishes without probing the bucket | (2 cases) |
| N5 spoke short-circuit dropped | **SURVIVED at first** → see below | — |
| N6 delete no longer scoped | page · refuses an id not in the queue | `expected undefined to be 400` |
| N7 delete no longer attributed | page · attributes the delete to the moderator | `toHaveBeenCalledWith [{ userId: 7, … }]` |

**N5 survived**, which found a real gap: the spoke had no non-key case, so its half of the shared rule was untested — the same asymmetry the shared module exists to remove. A spoke-side test was added and N5 now dies with `publishes without consulting the store for an external avatar CDN url`.

## Verification at this tip

- 8 touched suites: **77 passed** (then 79 with the N5 coverage)
- `pnpm test:unit:run` — **1516 files passed, 1 skipped; 23747 passed, 26 skipped, 0 failed**
- `pnpm test:apps:run` — 1112 passed, 36 failed; failing-name set **identical to the `390a70c332` baseline**, `comm` empty both ways
- `pnpm test:packages:run` — 1173 passed, 8 failed, all in the same DB-backed `*.explain.test.ts` tier
- `pnpm typecheck` 0 errors · `svelte-check` 0 errors · `prettier:check` clean · no new lint problems

## A caveat on the audit itself

The auditing agent later **retracted part of its own report as fabricated** — it wrote several command results (a `--frozen-lockfile` run, a typecheck, a dated bucket decommission) it had never executed. It re-verified and reinstated the 🔴 findings firsthand.

That does not affect what shipped here: the blocker was confirmed against the source independently *before* the retraction arrived, and every change above rests on a file read directly rather than on the audit's say-so. Recording it because a reviewer should weight the audit's unverified claims accordingly, not because any of the fixes depend on them.

---

# Round 3 — delta re-audit of round 2, and a correctness defect it found

A delta re-audit of `36df018020..f1e442d857` confirmed both 🔴 fixes were genuinely closed and mutation-killed at both call sites, the storage bound had no off-by-one, and the harness fix was load-bearing. What round 2 did **not** do was pin its own new work.

## 🟡 The correctness defect: an audit record that could attest a delete that never happened

`deleteImagesByIds` **effectively never rejects**. It wraps every per-image body in a `try/catch` that logs and continues, and its only statement outside a try is a `void`-ed async call. Verified by reading all 84 lines.

So a failed DB or storage step *resolved*, and the action returned `{ success: true, id }`, the card rendered "Deleted", and a `deleteMissingMedia` audit row was written — for an image still on the site.

Two things defended that, and both were wrong:
- the comment said *"After the delete, so a failed delete records nothing"*;
- the test asserting it used `deleteImagesByIds.mockRejectedValue(...)` — **a state the real function cannot reach**. A guard on an unreachable behaviour, reading as coverage while providing none.

**Fix:** the action reads the row back (`imageRowExists`) and attributes only a *confirmed* delete. The replacement test uses the reachable shape — the call resolves, exactly as the real one does, but the row is still there.

## 🟡 The delete gate was a race, and the loser was permanently uncleanable

The gate reused the queue's `createdAt > now() - INTERVAL '2 days'` window. The page orders `createdAt DESC`, so rows nearest the edge sit at the bottom — exactly where a moderator draining the queue works. A row ageing out between page load and click was refused with *"not in the missing-media queue"* for an image visibly on screen, and was then **permanently uncleanable**: it had left the only view offering a delete while still sitting at `ingestion = 'Error'`.

Safety depends on the image's **state** — an unpublished ingestion error whose scan failed permanently — and that does not expire. So `missingMediaScope` drops the window, the gate asserts state, and the queue applies the window on top.

## Coverage: four guards that survived a revert

Round 2 added six things; four survived a mutation that reverted them — including the gate on a permanent cascading delete. Same defect class the round-1 sweep caught on `isProbeableMediaKey`, applied there but not to the rest of the same commit.

| Mutant | Round 2 | Round 3 | Now killed by |
|---|---|---|---|
| `isMissingMediaImage` → `WHERE TRUE` | **SURVIVED** | killed | `scopes the delete to a permanently-failed, unpublished ingestion error` |
| `onRefused` deleted — spoke | **SURVIVED** | killed | `reports a refusal, so a fail-CLOSED misconfiguration cannot look like a clean run` |
| `onRefused` deleted — main app | **SURVIVED** | killed | `logs a refusal when the bucket answered absent` |
| probe → unbounded client | **SURVIVED** | killed | `probes through the BOUNDED client, never the general-purpose one` |
| delete no longer confirmed | *(new)* | killed | `records nothing when the delete SILENTLY failed and the row survived` |
| gate re-acquires the 2-day window | *(new)* | killed | `deliberately omits the 2-day display window the queue applies` |
| gate drops the id binding | *(new)* | killed | `is always bound to the requested id — never an unscoped match` |

P0 control (inert comment edit): **60/60 green**, as required.

The bounded-client mutant is worth calling out: the spoke's mock returned the **same spy for both storage factories**, so the bounded and unbounded clients were indistinguishable *by construction*. A mock that cannot tell two collaborators apart cannot pin which one is used.

## Also

- **Mock-implementation leak, same class as round 2's**: `beforeEach` now resets all three mocks. `deleteImagesByIds` carried both a resolve and a reject and was benign only by accident of test order.
- **A lint gate caught me**: my first attempt mocked `~/server/logging/client` directly; `no-direct-shared-module-mock` failed it, correctly — under `isolate: false` a per-file spy accumulates calls across every file sharing the worker. Switched to the canonical `loggingMock`.
- **Docstring corrected**: it claimed the delete path makes "exactly this exclusion". It does not — it tests `url.startsWith('http')`, which disagrees with the shared regex in *both* directions (`startsWith('http')` excludes a key named `httpfoo` and does **not** exclude `blob:`/`data:`). Same reason, different test; not yet consolidated, and the comment now says so.

## Verification at this tip

- `pnpm test:unit:run` — **1516 files passed, 1 skipped; 23,7xx passed, 0 failed**
- `pnpm test:apps:run` — 1121 passed, 36 failed; failing-name set **identical to the `390a70c332` baseline**, `comm` empty both ways
- `pnpm test:packages:run` — 1173 passed, 8 failed, same DB-backed tier
- `pnpm typecheck` 0 errors · `svelte-check` 0 errors · `prettier:check` clean

---

# Round 4 — the mirror bug, found and fixed

A delta re-audit of round 3 confirmed all seven of its fixes were real and mutation-reachable, with no vacuous new test. It also found that round 3 had introduced a defect of the same severity as the one it fixed — which is exactly the pattern the round-2 arc predicted.

## 🔴 The read-back was reading a replica

Round 3 added a read-back so the audit log records **outcomes** rather than intentions. It ran on `dbRead` — which is a **separate pool on the replica connection string** (`apps/moderator/src/lib/server/db.ts`), while the delete lands on `dbWrite` milliseconds earlier.

That is a read-your-write. Any replica lag past that round trip makes a **successful** delete read as "still present" → a false *"The delete did not complete"* → and **no audit row for a delete that did happen**. The precise mirror of the bug the read-back exists to prevent, on the same artefact, and non-deterministic. The retry path is worse, not better: once the replica catches up the row is gone, so the moderator is told the image *"is not in the missing-media queue"* — still with no audit row.

**This app already carried the precedent and the reasoning.** `getLiveStrikes({ readYourWrite })` selects the primary, with a docstring saying that on the replica *"any lag past the round trip reproduces the exact bug this serves"*. The fix follows it: `.execute(dbWrite)`.

**Why nothing caught it:** the test harness aliased `dbRead` and `dbWrite` to **one Kysely instance**, so which client a query used was unobservable — the same *indistinguishable-by-construction* blind spot that hid the unbounded storage client one round earlier. They are now distinct instances that tag what they compiled. A revert to `dbRead` fails with `expected 'read' to be 'write'`, and the queues are pinned to the replica the same way, so the fix cannot be over-applied either.

## 🟡 The gate could still drift from the queue, on the state axis

`missingMediaScope` **re-spelled** `ingestion = 'Error' AND nsfwLevel = 0` rather than composing it. Measured: changing the queue's `nsfwLevel` bound left the gate behind **and the suite stayed green** — the gate would then refuse images the queue renders, and those become permanently uncleanable. That is the same bug the display-window split fixed, one axis over.

The guard that was supposed to prevent it was titled *"…so the two cannot disagree"* and checked **one clause of three** — a guard narrower than its own description, reading as coverage while providing none.

Fixed both halves: `ingestionErrorState` is extracted and composed into the queue and the gate, and the test now asserts the gate's **entire** clause set (minus its id binding) is contained in the queue's. The drift mutant now fails with `i."nsfwLevel" <= 1: expected [ …(5) ] to include 'i."nsfwLevel" <= 1'`.

## Comment corrections — three claims that were false about their own code

- The read-back confirms the **row**, not the stored object. That object delete is best-effort and swallowed, so a success here can still leave an orphan. Now stated.
- The retained `try/catch` is **unreachable today** and is labelled as such, rather than reading as live protection. Deliberately untested: there is no reachable input that enters it.
- The mock-reset comment described a `mockRejectedValue` this file no longer contains (round 3 replaced it).

## Two test nits

- The bounded-client test asserted the **shared** expectation first, so it died to an assertion three other tests also make rather than naming its own regression. Reordered so the distinguishing assertion runs first.
- Both `console.warn` spies now restore in a `finally` — this config sets no `restoreMocks`, so a failing assertion left `console.warn` stubbed for the rest of the worker.

## Documented, not changed

The gate drops the **1-hour lower bound** as well as the 2-day one, so a very new row the page does not yet render is deletable by a hand-crafted POST. Checked and safe: `permanent` is a terminal class (retry limit 1, already spent by `markImageScanError`), so such a row is never re-driven into another state; and rows predating the classification carry a NULL `failureClass`, which `IS NOT DISTINCT FROM` excludes. Now written in the docstring so the next reader need not re-derive it.

## Verification at `ff28f014d9`

- `pnpm test:unit:run` — **1516 files passed, 1 skipped; 23,750 passed, 0 failed**
- `pnpm test:apps:run` — 1123 passed, 36 failed; failing-name set **identical to the `390a70c332` baseline**, `comm` empty both ways
- `pnpm test:packages:run` — 1173 passed, 8 failed, same DB-backed tier
- `pnpm typecheck` 0 errors · `svelte-check` **9401 files, 0 errors** · `prettier:check` clean


---

# Round 5 — the predicate collision, `blob:`, and a log that could not distinguish its causes

## 🔴 DEPLOY: ordered steps, because the default state hides the new queue from almost everyone

At the moment this merges, and until someone acts in `/admin`, the net effect is that **a population of images disappears from the queue moderators use AND its replacement is invisible to them**. Two independent mechanisms combine:

1. `/images/missing-media` is a **new grantable NAV path**. `canAccess` takes the **longest matching** grant (`access.ts:313-318`), so this path matches itself rather than inheriting `/images`, and its stored grant defaults to `roles = []`. `allows()` then returns `!!match && roles.some(...)` — false for everyone who is not `isSuper` — and `pruneNav` (`access.ts:255-268`) drops the link entirely. Net: **only `moderator:admin` can see or open the page** until it is granted.
2. Simultaneously the queue predicate **removes every `failureClass = 'permanent'` image from `/images/ingestion-errors`**. That is the whole point — rating one publishes a permanent 404 — but it means those rows leave the old queue in the same deploy.

**So do this in order:**

1. Merge and deploy.
2. In `/admin`, grant `/images/missing-media` to the same roles that hold `/images/ingestion-errors`. Until this step, that work is invisible to non-admin moderators.
3. Confirm the sidebar badge appears for a non-admin moderator and that the count is non-zero.

Doing step 2 late is not merely cosmetic: the images are gone from the old queue from the moment of deploy, so the gap is a period in which nobody can act on them at all.

## 🔴 MERGE NOTE — re-derive the flipt ledger; do not pick a conflict side

`src/server/flipt/__tests__/flipt-eval-context.test.ts` conflicts with #4474 and **neither branch's numbers are correct after both land**. The line-number ledger keys off `image.service.ts`, and both PRs insert lines above the recorded sites.

⚠️ **Round 7 moved these again.** The probe rewrite (finding R7-12, commit `075f2e6734`) added lines above all four sites, so this branch is now **+11** on `main`, not +6.

| site | `main` | #4474 (+1) | #4475 (+11) | **after both (+12, DERIVED)** |
|---|---|---|---|---|
| `feed-fetch-filter-in-post` | 4127 | 4128 | **4138** | 4139 |
| `feed-image-existence` #1 | 4268 | 4269 | **4279** | 4280 |
| `feed-image-existence` #2 | 5006 | 5007 | **5017** | 5018 |
| `feed-image-existence` #3 | 6140 | 6141 | **6151** | 6152 |

The `#4475` column is **measured** — read off the gate's own failure output on the merged tree, not computed from a diff delta. The `after both` column is **derived** from #4474's recorded `+1` and has NOT been re-measured; treat it as a starting guess and re-derive on the merge, exactly as this note says.

🔴 **`4279` occurs TWICE in that file** — once as a ledger key and once as a behavioural assertion (`expect(bySite.get(...)?.argc).toBe(2)`). **Both** must move. Resolving only the ledger leaves a green-looking file with one stale assertion. (Round 7 hit this: a `count == 1` replace would have silently fixed one of the two.)

**How to re-derive rather than compute:** run the suite; its "adds no Flipt evaluation that names an entity but passes no context" failure prints the ACTUAL current sites, and the "keeps the ledger honest" failure prints the stale ones. Update to match and re-run — the gate is self-checking.

🔴 **The `image.service.ts` conflict resolves to the UNION of both import lists — take neither side wholesale.** The conflict is on the SAME import line: this PR rewrites it to `import { serverUploadImage, getB2ImageS3Client, getImageUploadBackend, headObject }`, and #4474 adds `import { probeCreatedImageMedia }` beside it. Picking either side alone drops the other's import, and the build then fails loudly — which is the good case; the point of writing it down is that the correct resolution is mechanical and needs no judgement.

Other than that file and `image.service.ts` (which both PRs edit), the two branches merge cleanly. Measured, not reasoned: `git merge-tree --write-tree` over the two tips reports the **same two conflicts before and after** this round — the shared predicate and its `exports` entry were placed so they auto-merge, and `git merge-tree` confirms `packages/civitai-shared/package.json` auto-merges and `media-key.ts` does not conflict at all.

## Finding 1 — two functions, one name, opposite construction

This PR and #4474 each exported `isProbeableMediaKey`, answering the same question by opposite construction, **each with a docstring arguing against the other**:

| | this PR (was) | #4474 |
|---|---|---|
| test | negative — `!/^[a-z][a-z0-9+.-]*:/i` | positive — strict UUID |
| `some-file.png` | probe → 404 → `absent` → **permanent refusal** | `not-applicable` → allow |

After both merged the repo would hold two contradictory copies of the rule the shared package exists to unify. There is now **one**, `packages/civitai-shared/src/media-key.ts`, imported by all three call sites. #4474 adds the identical file, so either merge order compiles standalone.

### Which one survived, and the evidence

**The UUID positive test — but the reason originally written down for it is false, and the docstring now says so.**

The premise "every legitimate `Image.url` that is a bucket key is a UUID" does **not** hold. Every key-**minting** site is a bare `randomUUID()` (`src/pages/api/v1/image-upload/index.ts`, `.../multipart/index.ts`, `uploadImageBufferToStore`, the orchestrator handlers, the app-listing asset service, the comics upload paths), but several **write** paths accept a caller-supplied string and never check its shape:

- **seven `comics.router.ts` call sites** validate the url with `z.string().min(1)`;
- the article **`edge-media`** sync (`article-content-cleanup.service.ts`) copies the attribute verbatim out of sanitized HTML, where the sanitizer does not filter a custom attribute named `url`.

Any of those can put `foo/uuid`, `photo.jpg` or `12345` into the column. So the predicate is a deliberate **under-approximation**, and the direction is chosen from **what each error costs**, not from accuracy:

- a false **negative** (a real key we decline to probe) costs a detection — the caller falls back to what it did before the check existed;
- a false **positive** (a non-key we probe) costs a 404 indistinguishable from a genuine miss, which **this** call site turns into a permanent, un-overridable refusal.

That heterogeneous, unvalidated population is exactly where a 404 is not evidence of loss, so it must not be probed by a check whose `absent` verdict **enforces** anything. The predicate is also strictly **broader** than zod's `.uuid()` (it accepts an invalid version nibble), so the guard can never decline to check a key the write schema already called a key.

The classification moved **inside** `assertMediaPresentForPublish`, which now takes the `url` and hands the probe a key. Neither runtime decides whether the probe runs — which is what let the two spellings drift in the first place.

## Finding 2 — `blob:` was allowed through as "renders perfectly well". It does not.

**Behaviour change: a `blob:` row is now REFUSED.**

`getEdgeUrl` returns the value **verbatim** for a `blob` prefix in both runtimes (`src/client-utils/cf-images-utils.ts:29`, `apps/moderator/src/lib/media/edge-url.ts:60`), so publishing one emits `<img src="blob:…">` into a browser that never created the handle. `src/utils/type-guards.ts` already records that the embedded uuid is a browser handle that "can't be salvaged". It is a permanently broken image — the exact harm this PR exists to prevent.

This is the one refusal decided **without a probe**, and it clears that bar because the harm is **definitional rather than inferred**: there is no store state, credential or bucket name under which a `blob:` row renders, so the false-positive risk that makes every other permanent refusal dangerous does not exist here. It gets its own message (`UNRENDERABLE_MEDIA_PUBLISH_MESSAGE`) — telling a moderator to check storage for a file that was never uploaded there would send them looking for nothing.

**`data:` is deliberately NOT included.** It is *not* in either renderer's passthrough set, so it is rewritten into a CDN path and is probably broken too — but "probably" is inference, and inference does not justify a permanent refusal. It stays fail-open until someone measures it.

## Finding 3 — the `unknown` log could not distinguish its causes

`headObject` never throws; it **resolves** `{ status: 'unknown' }`. So a genuine store failure and the not-a-key short-circuit emitted an identical payload with `error: ''` — reintroducing, inside the detector, the indistinguishability the channel exists to remove.

- `not-applicable` is now its **own verdict**, allows, and is **not** logged as unknown.
- `unknown` carries a `reason`: `probe-threw` vs `store-inconclusive`.
- A refusal carries which `presence` caused it — a bucket can produce `absent` and can **never** produce `unrenderable`, so a fail-CLOSED misconfiguration is only legible if the two are counted apart.

## Finding 7 — an unbounded remote body in the log

The spoke logged the raw `StorageClientError`, whose message embeds the remote response **body** verbatim: unbounded third-party text (an HTML error page, an XML fault document) into stdout and therefore Loki, once per inconclusive probe. Both call sites now log `summarizeProbeError` — flattened to one line, bounded at 200 chars, and **marked** when clipped so a cut-off body cannot read as a complete, different error.

## Findings 4–6 — re-verified against the tip; only one was still open

The round-2 findings were derived before `0901085b99`. Re-checked by mutation against the actual tip:

| | claim | verdict at tip |
|---|---|---|
| 4 | probe bounds unpinned | **still open** — mutant survived |
| 5 | `onRefused` uncovered at both call sites | already fixed — mutant dies |
| 6 | delete-scoping predicate untested | already fixed — mutant dies |

Finding 4 was real. The guard suite mocks `$lib/server/storage` wholesale, so it can prove the probe reaches the **separate** factory but says nothing about what that factory **asks for** — deleting `timeoutMs: 5_000, retries: 0` left the whole `app:moderator` project green, silently restoring ~31 s of waiting (10 s × 3 attempts, per `packages/civitai-storage/src/client.ts` defaults) on a moderator's click. `storage-probe-client.test.ts` now asserts the config object at the seam where it is handed over, and asserts it against the **library's** defaults as well as against literals, so a value that is present but useless (`retries: 2`) also fails.

Also: `vi.resetAllMocks` in the spoke guard suite. `clearAllMocks` clears **calls**, not **implementations**, so a `mockResolvedValue` from an earlier case leaked forward and a later case could pass for the wrong reason.

## Mutation results — 12 mutants, each killed by its own guard's assertion

Run in a `cp -a` copy with `.git` removed. Control run first: identical to the real tree (`app:moderator` 402 passed / 36 env-failed; `@civitai/shared` 36 passed).

| # | mutation | killed by | message |
|---|---|---|---|
| 1 | delete `timeoutMs: 5_000, retries: 0` | `asks for ONE attempt at 5 s` | `expected "vi.fn()" to be called with arguments: [ { …(4) } ]` |
| 2 | `retries: 0` → `retries: 2` | `bounds it BELOW the library defaults` | `expected 2 to be less than 2` |
| 3 | drop the `isUnrenderableMediaUrl` branch | 4 tests, all 3 runtimes | `promise resolved "{ allow: true, …(1) }" instead of rejecting` |
| 4 | unanchor to `/blob:/i` | `is anchored, so a key that merely CONTAINS the word` | `expected true to be false` |
| 5 | revert predicate to the negative construction | 6 tests across shared + both call sites | `some-file.png: expected true to be false` |
| 6 | `NotApplicable` → `Unknown` | 5 tests | `expected { allow: true, presence: 'unknown' } to deeply equal { allow: true, …(1) }`; `expected [ [ … ] ] to have a length of +0 but got 1` |
| 7 | drop `unknownReason = 'probe-threw'` | `distinguishes a probe that THREW` | `expected { reason: 'probe-threw', …(1) }` |
| 8 | spoke logs the raw error | `bounds the probe error it logs` | `expected 10108 to be less than 500` |
| 9 | remove truncation in `summarizeProbeError` | 3 tests | `expected 10000 to be less than 220` |
| 10 | delete `onRefused` (spoke) | `reports a refusal` | `expected "warn" to be called 1 times, but got 0 times` |
| 11 | `isMissingMediaImage` → `WHERE i.id = $1` | 3 tests | `expected 'SELECT i.id FROM "Image" i WHERE i.id…' to contain 'AND i.id = $2'` |
| 12 | drop `presence` from the main-app refusal log | 2 tests | `expected { type: 'warning', …(3) } to match object { presence: 'unrenderable' }` |

Every mutant's guarded branch is reachable — no earlier check rejects the fixture — and in each of 3, 5 and the `blob:` cases the store is deliberately armed to the **opposite** answer, so a passing test cannot be explained by the probe being harmless.

## Verification at this tip

Counted from the runner's own result lines, ANSI stripped, never from an exit code:

- `@civitai/shared` — **2 files passed, 36 tests passed, 0 failed**
- `app:moderator` — **35 files passed, 1 failed; 402 passed, 36 failed** — the 36 are all in `reports.queries.explain.test.ts`, `ECONNREFUSED :15432`, environmental and present on every branch
- guard + flipt unit files — **4 files passed, 48 tests passed, 0 failed**
- `pnpm typecheck` — `OK — 0 type errors`
- `svelte-check` — **9403 files, 0 errors, 0 warnings** (and demonstrated able to go red first: an earlier revision of the new test failed it with 2 real errors)


---

# Round 6 — the `blob:` refusal had no reachable action, and `onSkipped` had no caller

Seven findings from the round-3 audit. Two were behavioural, five were guard defects. F8 is left as an accepted residual, as recorded.

## 🔴 F1 — the round-2 `blob:` refusal was a dead end on BOTH consuming surfaces

Round 2 turned `blob:` urls from allowed into refused, with a message that says *"Delete it, or ask the uploader to upload it again."* Neither surface offered that action for exactly the rows the refusal creates:

- **Spoke.** The delete affordance lives on `/images/missing-media`, whose gate required `failureClass = 'permanent'`. A `blob:` row classified `transient`, or a legacy row with a **NULL** `failureClass` (which `ingestionErrorWhere` deliberately routes to the *rateable* queue), was refused on the rating queue **and** invisible to the delete queue. Permanently stuck.
- **Main app.** `resolveArticleImageScan` → `resolveIngestionError` is reached from `ArticleProblematicImages`, which offers only **Override** and **Retry**. Override now 400s; Retry re-fetches an unfetchable handle and re-fails; so `recomputeArticleIngestion` never runs and the article stays Error/Blocked. Before round 2, Override cleared it — so the refusal closed the only exit that surface had.

### The decision: keep the refusal, make the exit exist

Reverting to a logged fail-open was on the table and is rejected. It trades a *real* harm — publishing an image that is guaranteed to render as a broken `<img>` for every viewer, forever — for a UX dead end, and both exits turned out to be cheap and already half-built. The refusal is also the one permanent refusal in this module whose warrant is definitional rather than inferred (see F4), so weakening it is not the same trade as weakening the `absent` verdict would be.

**Spoke — route the refused rows to the queue that can delete them.** The missing-media split is no longer "permanent scan failure"; it is **"cannot be published"**:

```
unpublishableMedia   = ( permanentScanFailure OR unrenderableMediaUrl )
missingMediaWhere    = base   AND     unpublishableMedia
ingestionErrorWhere  = base   AND NOT unpublishableMedia
missingMediaScope    = state  AND     unpublishableMedia      -- the delete gate, minus the display window
```

~~Those two disjuncts are exactly the two verdicts `assertMediaPresentForPublish` refuses on~~ ⚠️ **false — corrected in round 7 below.** Only `unrenderableMediaUrl` is a refusal verdict; `permanentScanFailure` is a SQL-derivable *trigger*, and the other refusal (`absent`) is a probe result that cannot be selected on in SQL at all. The `LIKE` pattern is built from a new shared `UNRENDERABLE_MEDIA_URL_PREFIX` — the same constant the predicate is built from — so on that half the routing query and the write-side refusal cannot select different sets.

~~`COALESCE(i.url, '')` is load-bearing, not defensive~~ ⚠️ **false — corrected in round 7 below.** `Image.url` is declared NOT NULL, so the row it defends against cannot exist and removing it changes no result. It is kept as defence-in-depth against the column becoming nullable, and the NOT NULL constraint — which is what actually makes the url half a partition — is now the thing under test.

**Article surface — stop rendering controls that can only fail, and name the remedy.** A new pure helper, `src/components/Article/articleImageActions.ts`, drives the **same shared predicate** the server refuses on and returns `{ offerOverride, offerRetry, blockingNote }`. `ArticleProblematicImages` gates both controls on it and shows the note in their place:

> This image was saved as a browser-session link rather than an uploaded file, so it can never load for anyone else. Overriding or rescanning the image cannot fix that — remove or replace it in the article editor, or ask a moderator to delete it. Once it is gone, rescan the article to unblock it.

*(Reworded in round 7 — the final clause is new, and load-bearing: see finding R7-3.)*

Both remedies it names are real and in-product: the author removes or replaces the image in the editor (which is what the component's own lead text already asks for), and a moderator deletes the row — the spoke's Missing Media queue lists the recent ones, and the delete *action* is unwindowed. ⚠️ Round 7 corrects the copy here: it no longer promises the QUEUE will list the row, because the queue carries a 2-day window the action does not. The shared `UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` is reworded to name those exits rather than a delete that did not exist.

**What is NOT claimed.** A `blob:` row older than the queue's 2-day display window is still not rendered by the spoke page, so the moderator-side exit is bounded by that window even though the delete *gate* is not. That is the same accepted residual as F8, now applying to one more row shape; it is not new to this round and is not fixed here.

## 🔴 F2 — `onSkipped` had zero production callers

The shared module declared it, its own suite covered it, and neither `image.service.ts` nor the spoke's `ingestion.service.ts` passed one — so after round 2 a non-key url produced `not-applicable` and **silence**, where it had previously produced an Axiom line. That is worse than the hook not existing, because the module's docstring reads as though the branch is observable.

It matters most on this branch specifically: `isProbeableMediaKey` is an acknowledged under-approximation that is *known* to decline real keys, so a deployment in which it declines every row emits nothing at all and is byte-identical to one where the guard did its job. Wired at both call sites — `resolveIngestionError:media-probe-skipped` (Axiom) and `[ingestion] media not probeable` (stdout) — each with its own event name, so a store outage, a client that cannot be built, and a profile-picture url stay three distinguishable counts.

## F3 — the second refusal message is now pinned whole

`UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` could be replaced with `'Nope.'` with the package still 36/36 green. Its sibling was already pinned whole, with a comment explaining that a guard on words is walkable by rewording; the same doctrine now applies to both.

## F4 — the predicate and its stated warrant were keyed off different strings ⚠️ this corrects "Finding 2" above

The warrant for refusing without a probe is that both renderers emit the value **verbatim** — `src.startsWith('blob')`, case-**sensitive** and colon-less, in `src/client-utils/cf-images-utils.ts` and `apps/moderator/src/lib/media/edge-url.ts`. The round-2 predicate was `/^blob:/i`, which is neither a subset nor a superset of that:

- `BLOB:https://…` was **permanently refused and pinned by a test**, yet the renderers would *rewrite* it into a CDN path rather than pass it through. That row is probably broken too, but by a different mechanism and by inference — and inference is exactly what this module refuses to enforce on, which is why `data:` is left fail-open. It is now **allowed**, and the test that pinned the opposite is corrected.
- `blobfish.png` **is** in the renderers' passthrough set and is equally unrenderable as a relative path, but it is not a url scheme and not a measured population. It stays not-unrenderable, deliberately — narrower than the warrant rather than wider.

The predicate is now `url.startsWith(UNRENDERABLE_MEDIA_URL_PREFIX)` with the prefix `'blob:'`, i.e. a strict subset of the renderers' test, and the prefix is asserted to carry no SQL `LIKE` metacharacter because the spoke interpolates it into one.

## F5 — the gate/queue relationship test was one-directional

`ingestion-queue-partition.test.ts` claimed the gate *"shares EVERY state predicate with the queue, so the two cannot disagree"* and asserted only `gateState ⊆ queueClauses`. It could not see the **queue gaining** a clause the gate lacks — the direction in which a permanent cascading delete becomes wider than what the page renders. It is now set **equality** on the clause sets, with the two deliberate differences (the gate's id binding, the queue's display window) subtracted by name and a count assertion proving the splitter did not silently stop decomposing.

## F6 — the harness-leak fix had missed the third suite

`resolve-ingestion-error-missing-media.test.ts` used `vi.clearAllMocks()` with a manual re-arm of only `getB2ImageS3Client`, leaving `headObject`'s implementation leaking between cases. Latent — nothing here currently passes for the wrong reason — so it is fixed with a **structural** guard rather than a behavioural one.

The spoke's `vi.resetAllMocks()` is correct *there*, where every mock is the file's own, and is wrong here: this suite runs under the global `setup.ts`, whose canonical hybrid mocks install their default implementations once per file. `resetAllMocks` strips those, so `logToAxiom(...)` returns `undefined` and the production `.catch(() => undefined)` throws — **measured: 17 of the file's 23 cases** (an earlier draft said "of 30"; corrected in round 7). So the fix clears globally (call history, which is what the assertions read) and resets this file's own mocks as a named set.

## F7 — the probe's return type was wider than its contract

`probe` was typed `MediaPresence`, which admits `not-applicable` and `unrenderable`. Both defeat a hook: a store-sourced `not-applicable` skips `onSkipped`, and a store-sourced `unrenderable` produces a refusal that `onRefused`'s own comment says no bucket state can cause. Narrowed to a new `MediaProbeAnswer = Present | Absent | Unknown`. The narrowing immediately found that the main app's `probeImageMediaPresence` was itself annotated with the wide type.

## F8 — accepted residual, unchanged

`missingMediaScope` still drops both window bounds. Reasoning documented in the const; premise re-checked and it holds, now on both disjuncts (`permanent` is terminal because the retry limit is already spent; a `blob:` url is terminal because no rescan, credential or bucket state can make it fetchable).

## Mutation results — 11 mutants, each killed by its own guard's assertion

Every run below was narrowed with `-t` to the named test, so a mutant that *also* trips a whole-statement pin cannot be scored as a kill for this guard. Reachability was confirmed in each case: no earlier check rejects the fixture.

| # | Mutation | Killing test | Failure message |
|---|---|---|---|
| 1 | `unpublishableMedia` → `( permanentScanFailure )` (drop the url disjunct) | `the delete gate's own predicate > accepts a row refused for its URL SHAPE…` | `expected 'SELECT i.id FROM "Image" i WHERE…' to contain 'COALESCE(i.url, \'\') LIKE $2'` |
| 2 | `COALESCE(i.url, '') LIKE` → `i.url LIKE` | `is NULL-safe on the url half too, so the split stays a partition` | `expected '…' to contain 'COALESCE(i.url, \'\') LIKE'` |
| 3 | `missingMediaWhere` gains `AND i."postId" IS NOT NULL`; gate unchanged | `shares EVERY state predicate with the queue…` | `expected [ 'i."nsfwLevel" = 0', …(2) ] to deeply equal [ …(3) ]` — the diff names the extra `i."postId" IS NOT NULL`. **This is the direction the round-2 test was blind to.** |
| 4 | gate loses `ingestionErrorState`'s `nsfwLevel` clause; queue unchanged | same test | `expected 2 to be greater than or equal to 3` (its own positive control) — the reverse direction still holds |
| 5 | delete `onSkipped` from the **spoke** call site | `spoke resolveIngestionError… > COUNTS the short-circuit at this call site` | `expected "warn" to be called 1 times, but got 0 times` |
| 6 | delete `onSkipped` from the **main-app** call site | `the guard reports what it did… > COUNTS the short-circuit at this call site` | `expected [] to have a length of 1 but got +0` |
| 7 | `articleImageActions` never withdraws (`if (false && …)`) | `articleImageActions > withdraws BOTH affordances…` | `expected { offerOverride: true, …} to deeply equal { offerOverride: false, …}` |
| 8 | **production call site**: un-gate `<ImageRetryButton>` in `ArticleProblematicImages.tsx` | `gates every <ImageRetryButton> render on remedy.offerRetry` | `<ImageRetryButton> at line 356 is not gated on remedy.offerRetry: expected '{canRetry && !image.nsfwLevelLocked && (' to contain 'remedy.offerRetry'` |
| 9 | `UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` → `'Nope.'` | `gives the url-shape refusal a message that names a REACHABLE action` | `expected 'Nope.' to be 'This image points at a browser-session handle…'` — **the only failure in the package** (1 failed / 39 passed), so it dies for this guard's reason and no other |
| 10 | predicate back to `/^blob:/i` | `is CASE-SENSITIVE, because the renderers whose behaviour licenses the refusal are` | `expected true to be false` — and, at a second layer, `articleImageActions > leaves every other error image exactly as it was` fails on `BLOB:https://civitai.com/abc`, proving the article surface reads the same predicate |
| 11 | `probe: (key) => Promise<MediaPresence>` (widen it back) | `pnpm typecheck` | `missing-media.test.ts(273,7): error TS2578: Unused '@ts-expect-error' directive.` ×2 — the assertion *is* the suppression |

Plus the F6 harness guard, which has no behavioural mutant because the defect is latent by construction: reverting `beforeEach` to `vi.clearAllMocks()` alone fails `the harness itself > hands each case a storage probe with NO implementation left over from the last one` with `expected [Function] to be undefined`. It is the last block in the file, so a dozen earlier cases have armed `headObject` before it runs — reachable, not vacuous.

## Verification at this tip

Counted from each runner's own summary lines, ANSI stripped, never from an exit code through a pipe:

- `pnpm test:unit:run` — **1517 files passed, 1 skipped; 23763 passed, 26 skipped, 0 failed** (first full run). A later re-run taken *while* the packages, apps and typecheck runs were executing concurrently showed **1 failure**, `eventloop-watchdog.capture.test.ts > classifies an idle wedge as starved` — a real-process 10 s metric-settle deadline in a file this branch does not touch. Re-run alone: **9/9 passed**. Load flake, and named rather than swept up.
- `pnpm test:packages:run` — **84 files passed, 3 failed; 1195 passed, 8 failed**. All 8 are `*.explain.test.ts`, `ECONNREFUSED :15432`, environmental and present on every branch.
- `pnpm test:apps:run` — **103 files passed, 1 failed; 1135 passed, 36 failed**. All 36 are in `reports.queries.explain.test.ts`, same `ECONNREFUSED`, same on every branch.
- `pnpm typecheck` — `OK — 0 type errors`, and demonstrated able to go red (mutant 11 above, and the F7 narrowing caught a real wide annotation at the main-app probe before this tip).
- `svelte-check` — **9403 files, 0 errors, 0 warnings**.
- `prettier --list-different` over all **12** changed files — **0 listed**, with a positive control: appending `const    x   =    1;const y=2;` to `articleImageActions.ts` made the same invocation print `src/components/Article/articleImageActions.ts`, and reverting it returned the run to empty.


---

# Round 7 — the code survived; the prose did not

The audit could not break the widened routing or the delete gate: the OR/AND, paren and gate-narrowing mutants all die, and the withdrawn UI actions remove no legitimate path. What failed is that **shipped comments and user-visible copy asserted properties the code does not have.** Every correction below is either a code change or a rewrite of the sentence that was false; six sentences elsewhere in this body are struck through in place.

## 🟡 R7-1 — "the two disjuncts are the two verdicts" was false. Decision: correct the prose, do not widen the gate

`unpublishableMedia = permanentScanFailure OR unrenderableMediaUrl`, and only the second is one of `assertMediaPresentForPublish`'s refusals. `permanentScanFailure` is the scan pipeline's *trigger*; the other refusal is `absent`, which comes from a probe against the media store and **cannot be expressed in SQL at all**.

**The residual dead end that follows, stated rather than glossed.** A row whose `failureClass` is `transient`, `unknown` or NULL but whose object really is gone routes to the *rating* queue (`NULL IS NOT DISTINCT FROM 'permanent'` is false). A moderator rates it → probe → `absent` → refused; `isMissingMediaImage` does not admit it, so the only delete this app offers refuses it too. That row is stuck. It **pre-dates this round and is not made worse by it**, but it is not closed.

**Why the gate was not widened.** "Accept anything the write guard could refuse" is not expressible either — it means accepting every row with a probeable key, i.e. *every unpublished ingestion error*. That converts a scoped, permanent, cascading delete into an unscoped one, and buys nothing on screen: neither queue renders those rows, so no page gains an affordance. Strictly worse.

**Why the third option was also rejected.** Persisting the `absent` verdict at the moment the probe produces it (stamping the row so it moves into the missing-media queue) *would* close it, and is the right shape — but a misconfigured bucket answers 404 for **every** key, which this module reads as `absent`. A naive write-back would then permanently reclassify every row a moderator touched, turning the fail-closed misconfiguration the code already worries about into a persistent, destructive one. That needs its own design, not a line in this PR.

The comment on `unpublishableMedia`, the docstring on `getMissingMediaImages`, and the header on `+page.server.ts` now say exactly this.

## 🟡 R7-2 — the 2-day window strands the motivating population. Decision: state the limit, do not widen it

Both queues are bounded to `createdAt > now() - INTERVAL '2 days'`; the delete gate (`missingMediaScope`) deliberately is not. So an old `blob:` row is deletable by POST and rendered by **no** page — and `blob:` urls come from a legacy upload bug, so the population is plausibly *mostly* older than two days. That is inference from where the bug came from, not a production count.

**Why widening was rejected, and it is not the obvious reason.** Both queues order `createdAt DESC`. Dropping the bound puts the old `blob:` rows at the **back** of an unbounded list, behind every historical permanent scan failure — *burying* the motivating population rather than surfacing it, at a queue size nobody has measured. Widening would look like reach and deliver the opposite.

So the limit is named instead, at the window itself, together with the one query that would settle whether widening is worth doing and what shape it should take:

```sql
SELECT count(*) FROM "Image"
 WHERE ingestion = 'Error' AND "nsfwLevel" = 0
   AND "createdAt" < now() - INTERVAL '2 days'
   AND url LIKE 'blob:%';
```

**And the copy no longer promises a queue listing.** `UNRENDERABLE_MEDIA_PUBLISH_MESSAGE` now says *"Delete it — recent ones are listed in the Missing Media queue —"* rather than *"Delete it from the Missing Media queue"*; the article note says *"ask a moderator to delete it"* and names no queue at all. The action is unwindowed, so naming the action is true; naming the queue was not. The Missing Media page header now states the 2-day bound outright.

## 🟡 R7-3 — the advertised moderator delete does not clear the article

The spoke's delete removes the row and cascades `ImageConnection` / `Article.coverId`, but it cannot call `recomputeArticleIngestion` (main-app only). And `article-ingestion-reconcile` selects only `ingestion IN (Pending, Rescan)` or `(Processing, Scanned)` — an article blocked by a `blob:` image sits at **`Error`** and is never a candidate. So after the newly-named remedy is applied, **the article stays blocked**.

Both notes now say so, and the wording change also removes the contradiction the audit flagged separately: the note used to say *"Overriding or rescanning it cannot fix that"* while a **Rescan Article** button sat directly below it. It now distinguishes rescanning the *image* (which cannot help) from rescanning the *article* (which is the step that unblocks it), and the component carries a comment tying the two wordings together.

## 🟡 R7-4 — the `COALESCE` claim was false

`Image.url` is **NOT NULL** — `packages/civitai-db-schema/prisma/schema.full.prisma`, and the generated Kysely type is `url: string`. The row the `COALESCE` defends against cannot exist, so removing it changes no result and it was never load-bearing.

The `COALESCE` stays as defence-in-depth (the failure it prevents *is* silent, if the column ever becomes nullable) but its test is relabelled an **invariant guard**, and the real invariant gets its own: `Image.url` is read from **both** the Prisma schema and the generated Kysely types, which fail differently — a hand-edit to one without regenerating the other is caught, and so is a regeneration that drops the guard's own subject.

## 🟢 R7-5 — a precedence mutant survived the structural test

Dropping the parens from `unpublishableMedia` yields `(base AND NOT permanent) OR (url LIKE 'blob:%')` — every `blob:` row, at any age and any ingestion state, back in the rating queue. Narrowed to `-t 'partitions the same window'` that mutant **survived**; it died only on the whole-statement pins, which are exactly the pins the comments invite an author to rewrite on a deliberate change. The structural test now asserts parenthesisation, depth-walked so `(a OR b) OR c` is caught too.

## 🟢 R7-6…11 — the smaller ones

- **The "Overridden" badge came back.** Withdrawing `ImageOverrideControl` also hid its status badge, and that state is reachable for exactly these images (`updateImageNsfwLevel` sets `nsfwLevelLocked` without touching `ingestion`). Split into `ImageOverriddenBadge` (status, gated on the lock) and `ImageOverrideControl` (action, gated on the withdrawal), pinned in both directions and rendered in the new browser suite.
- **Page header.** `/images/missing-media` never mentioned its new `blob:` membership; the server docstring did. Both populations are now named, plus the 2-day bound.
- **Denominator.** A comment said "17 of **30** cases"; the file has **23**.
- **"Once per section"** described three `remedy.blockingNote` mentions across two sections. The count was right and the sentence was not; the sentence now explains why the blocked list spends two and the error list one.
- **The equality subtraction** in the gate/queue test was counted on the queue side only, leaving the gate's filter free to drop any number of clauses and still reach equality. Now counted on both.
- **Three spellings of "is this a blob url"** — `isUnrenderableMediaUrl` (colon-bearing), `isBlobUrl` and the inline `src?.startsWith('blob')` in the tiptap nodes (colon-less, wider). The divergence is **deliberate** and is now recorded at the predicate: their consequence is a display fallback where a false positive costs one avatar; this one's is a permanent publish refusal where a false positive is unrecoverable. Do not consolidate them.

## 🟢 R7-12 — the probe now resolves its backend through `getImageUploadBackend()`

`Image.url` is the key the upload path minted, so `getImageUploadBackend()` is the only thing that knows which store can answer about it. This branch open-coded `getB2ImageS3Client()` + `env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads'`, which agrees with that resolver **only by coincidence**: change where uploads land and the probe keeps asking the old bucket, which 404s for every key, which this module reads as `absent` — a permanent publish refusal across the whole queue, indistinguishable from a real run of misses. #4474 documented this and left the fix here because this is the divergent copy. Now aligned; the two guards can no longer disagree about the same row.

## The weakest point of the round: there was no render coverage. There is now

The entire user-facing effect is "a button is gone and a sentence takes its place", and nothing rendered it. `src/components/Article/__tests__/ArticleProblematicImages.browser.test.tsx` (8 cases at this round, 11 after round 8, browser mode) reads the DOM: the note appears, both dead-end controls are absent from the tree, the card is not left empty, the badge survives the withdrawal, and the withdrawal is per-image rather than per-section. **Every case has a control arm** — "render no controls at all" satisfies every positive assertion while shipping a surface nobody can act on.

**Writing it found a real structural defect the source scan could not see.** Each flag was spelled twice — once on the container, once on the child — and the container already rejected exactly the inputs the child's copy existed to reject. Removing `remedy.offerOverride` from the child therefore changed nothing observable and the mutation test on it **SURVIVED** (measured, not inferred). The component now names one boolean per affordance (`showRetry` / `showOverride` / `showOverridden`), used by both the container and the child. The same mutant now dies at the render level.

The seam test also stops guessing: its `enclosingGate` walked back for the nearest line containing `&& (` — the *nearest*, not the syntactic parent — so it could certify that a flag appears somewhere above a tag and nothing about reachability. It now checks each boolean's **definition** against the shared helper's field, and each render site against a bounded two-line window.

## Round-7 mutation results — 10 mutants, each killed under `-t` by the named assertion

| # | Mutant | Narrowed to | Killed by |
|---|---|---|---|
| 1 | probe drops the `getImageUploadBackend()` call | `asks the SAME backend resolver` | `expect(getImageUploadBackend).toHaveBeenCalledTimes(1)` |
| 2 | probe keeps the call but restores the bucket literal | `asks the SAME backend resolver` | `expected 'civitai-media-uploads' to be 'resolved-upload-backend-bucket'` |
| 3 | parens dropped from `unpublishableMedia` | `partitions the same window` | `split predicate must open a group: …` |
| 4 | `( a ) OR ( b )` instead of `( a OR b )` | `partitions the same window` | `the negated group must span the WHOLE predicate: …` |
| 5 | extra `i.id`-prefixed clause added to `missingMediaScope` | `shares EVERY state predicate` | `the gate drops exactly its id binding: expected 2 to be 1` |
| 6 | `Image.url` → `String?` in the Prisma schema | `keeps Image.url NOT NULL` | `expected … to match /^\s{2}url\s+String\s*$/m` |
| 7 | `url: string` → `string \| null` in the Kysely types | `keeps Image.url NOT NULL` | `expected … to match /^\s{2}url: string;$/m` |
| 8 | `showOverride` stops consulting `remedy.offerOverride` | `withdraws BOTH dead-end controls` | Override button found — `expected […] to have a length of +0 but got 1` |
| 9 | error-section note dropped | `puts the remedy in the card it emptied` | `Cannot find element with locator: getByText('This image was saved as…')` |
| 10 | `showOverridden` re-coupled to the withdrawal | `keeps the Overridden STATUS` | `Cannot find element with locator: getByText('Overridden')` |
| 11 | remedy hoisted to the section's first image | `withdraws per IMAGE` | `strict mode violation: … resolved to 2 elements` |
| — | badge re-gated on `remedy.offerOverride` (source axis) | `keeps the Overridden STATUS reachable` | `must NOT be gated on remedy.offerOverride` |

⚠️ **Corrected in round 8 — the table above was not the whole sweep, and two mutants it does not list SURVIVED.** Removing `!image.nsfwLevelLocked` from `showRetry` left the 8-case browser suite 8/8 green and the 7-case seam suite 7/7 green; removing it from BOTH `showOverride` definitions did the same. No fixture paired an ordinary (non-`blob:`) url with `nsfwLevelLocked: true`, so in every locked fixture `remedy.offerRetry`/`offerOverride` were already false and the lock term was unreachable. Round 8 adds that fixture and all three mutants now die; see the round-8 table.

Mutant 5 was additionally **measured to survive without the new assertion** — the guard was removed, the mutant re-run, and the case passed — so the coverage claim is measured rather than asserted. Mutant 8 is the one that survived the *pre-restructure* component and drove the `showRetry`/`showOverride`/`showOverridden` change.

## What round 7 could NOT verify

- **The size of the stranded population.** No production DB access from here, so "the `blob:` population is plausibly mostly older than two days" stays an inference from where the bug came from. The query above settles it.
- **The `after both` column of the flipt merge table.** This branch's four line numbers are measured; the post-merge numbers are derived from #4474's recorded `+1` and must be re-derived on the merge.
- **The four `*.explain.test.ts` suites** fail `ECONNREFUSED 127.0.0.1:15432` on every branch — nothing listens on 5432/15432 here. Environmental, not this branch's.

## Verification at this tip (`6dc7e981c5`)

Read off each runner's own summary line, not an exit code through a pipe.

| Runner | Result |
|---|---|
| `pnpm test:unit:run` | **1518 passed / 1 skipped (1519 files)** · **23772 passed / 26 skipped (23798 tests)** · 0 failed |
| `pnpm test:packages:run` | **84 passed / 3 failed (87 files)** · 1195 passed / 8 failed — all 3 are `*.explain.test.ts`, `ECONNREFUSED 127.0.0.1:15432` |
| `pnpm test:apps:run` | **103 passed / 1 failed (104 files)** · 1136 passed / 36 failed — the one failure is `reports.queries.explain.test.ts`, same `ECONNREFUSED` |
| `pnpm test:component` | **195 passed (195 files)** · **2188 passed (2188 tests)** · 0 failed |
| `pnpm typecheck` | **0 type errors in 95s** |
| `pnpm -F @civitai/moderator-app check` (svelte-check) | **9403 FILES, 0 ERRORS, 0 WARNINGS** |
| `prettier --list-different` over all 26 changed `.ts`/`.tsx` | **0 unformatted** |

**Both instruments were negative-controlled, not just read.** `typecheck` was fed a deliberate `const x: number = "not a number"` in a changed file and reported `1 type error(s)` at the right line and exit 2 — so its `0` is a measurement, not a wired-to-nothing zero. `prettier --list-different` was fed a mis-formatted copy of a changed file with the **exact invocation above** and listed exactly 1 file, then 0 after restore.

The four `*.explain.test.ts` failures are environmental: nothing listens on 5432/15432 on this host, and they fail identically on `origin/main`. `.svelte` files are outside the prettier job's `'*.ts' '*.tsx'` filter, so `+page.svelte` is not format-checked by anything — noted rather than silently skipped. ⚠️ **Corrected in round 8:** the reason given here was half wrong. The ROOT ships no `prettier-plugin-svelte`, but the repo does — `apps/creator-studio` declares `prettier-plugin-svelte@^4.1.1` (`pnpm-lock.yaml:1030-1032`) for its own `format:check` script. The conclusion is unchanged, and rests on the filter rather than on the plugin's absence: both CI prettier steps and `scripts/prettier-changed.mjs:35` filter to `/\.(ts|tsx)$/`, and husky does no formatting, so nothing reaches this file.

**CI on this tip: 13 pass, 1 skipping, 1 pending.** The pending one is `preview / deploy`, an in-cluster Tekton PipelineRun (`pr-preview-4475-d7smv`) that deploys an ephemeral preview environment — not a correctness gate. Every correctness check is green: `Unit tests (1..4)`, `App unit tests + typecheck`, `Package unit tests`, `ESLint + Prettier (changed files)`, `tekton / typecheck`, `tekton / fixture-bootstrap`, `Schema drift gate`, `event-engine-common pin`, `Windows dev-env (bash|pwsh)`.

Two of those went **red on the round's first push and were fixed here**, both worth recording because neither was a logic error: the flipt ledger's line-number keys moved under the probe rewrite (re-derived from the gate's own output, and `4279` occurs twice), and one changed test file was unformatted. A third was found only by the FULL local unit run rather than by the file being edited — `resolve-article-image-scan-missing-media.test.ts` mocked `getB2ImageS3Client` but not `getImageUploadBackend`, and `importOriginal` hands back the real one, which calls s3-utils' internal factory rather than the mocked export.


---

# Round 8 — the refactor made a bad state representable, and nothing tested the term that prevents it

Round 7's restructure was right, and it opened one gap of its own. Six findings, all closed here. One is a real coverage gap (R8-1); the rest are copy and claim corrections — no shipped behaviour changes except the delete-gate refusal's wording.

## 🟡 R8-1 — the lock term was load-bearing and untested

`ArticleProblematicImages.tsx` — the Override control and the Overridden badge used to be ONE component with `if (locked) return <Badge/>`, so "control **and** badge at once" was *unrepresentable*. Round 7 split them into two independent booleans, and the only thing preventing that state now is the `!image.nsfwLevelLocked` term on `showOverride`/`showRetry`.

Nothing tested it. Every locked fixture in the suite paired the lock with a `blob:` url, where `remedy.offerOverride`/`offerRetry` are **already false**, so the term was unreachable in every case that exercised it — and deleting it left the 8-case browser suite 8/8 green and the 7-case seam suite 7/7 green. Neither survivor appears in the round-7 table above; that table is now annotated.

Shipped behaviour was correct throughout — this is a coverage gap, not a defect. Closed with the fixture that makes the term reachable: an **ordinary** url with `nsfwLevelLocked: true`, in both sections, asserting the mutual exclusion directly. Each absence assertion carries its own named message so a mutant on either term fails with *that* term's message rather than an anonymous `expected 0, got 1` that either could have produced.

## 🟢 R8-2 — a new user-visible state in the BLOCKED section was uncovered

`showOverridden` drops the `remedy.offerOverride` term the old container carried, so a `blob:`-url **blocked** image that is `nsfwLevelLocked` now renders an "Overridden" badge beside the blocking note. Deliberate and defensible — a STATUS is true regardless of whether the url can render — but new, since previously nothing rendered there, and the browser suite's blocked case used `nsfwLevelLocked: false`. Now covered.

## 🟡 R8-3 — the newly-stated window omitted its upper bound

Round 7 added "Only images created in the last 2 days are listed here." `ingestionErrorBaseWhere` is `createdAt > now() - '2 days' AND createdAt < now() - '1 hour'`, so a row created in the last **hour** is not listed either. That is the exact class round 7 set out to close — copy promising a listing that may not contain the row — one bound over.

Fixed on all four surfaces: the page copy, the `+page.server.ts` docstring, the `ingestionErrorBaseWhere` heading (which read "THE 2-DAY LOWER BOUND IS A REAL LIMIT ON REACH" directly above the `'1 hour'` line it did not mention), and the settling `count(*)` in that docstring — which counted only rows older than 2 days and only the `blob:` disjunct, under-counting the stranded set by both the `<1h` rows and every `permanentScanFailure` row. It is now a `FILTER` breakdown over both sides of the window and both disjuncts.

The 1-hour bound's **rationale is deliberately not stated**: it predates this app (`3575ab0413`, then the cutover `e4104d5bf1`) and carries no comment in either, so there is nothing to restate and none is invented. The docstring says so.

## 🟢 R8-4 — the delete-gate refusal still named the queue

`fail(400, { error: 'That image is not in the missing-media queue.' })` guards `missingMediaScope`, which by design is **not** the queue — it drops the window. Round 7 rewrote two other surfaces to stop naming the queue where an action is meant and missed this string. It now names the STATE: *"That image cannot be deleted here — it is not an unpublishable ingestion error."* Its test pins the whole string and additionally asserts it does not contain `queue`.

## 🟢 R8-5 — a guard's title claimed a database constraint it does not read

`ingestion-queue-partition.test.ts` — "keeps Image.url NOT NULL" reads `schema.full.prisma` and the generated Kysely types. Neither is the database, **and migrations in this org are applied by hand**, so schema-vs-DB drift satisfies the guard while the invariant it names is false of the live table. Retitled to say **DECLARED** schema, with the docstring stating what it therefore cannot catch — which is the standing reason the `COALESCE` is kept rather than simplified away. One word; the guard itself is unchanged and both halves stay reachable.

## 🟢 R8-6 — "makes that class impossible" was true of one runtime

R7-12 routed the main-app probe through `getImageUploadBackend()` and claimed it "makes that class impossible". The spoke's probe still names a fixed backend (`getMediaProbeStorage().headObject({ backend: 'b2Image', key })`). **Established rather than assumed, and it is not the naming asymmetry it looks like:**

- `'b2Image'` is **not a bucket literal**. It is a member of `@civitai/storage`'s wire enum (`packages/civitai-storage/src/schema.ts`), and the client is a dumb HTTP transport — it POSTs the alias to the `apps/storage` service, which resolves it **in its own process** (`apps/storage/src/lib/server/backends.ts`) from **its own** `S3_IMAGE_B2_ENDPOINT`/`S3_IMAGE_B2_BUCKET`. Same variable *names* as civitai-web's, different deployment and different Secret.
- So the spoke already resolves through an indirection; it lands on a **second source of truth** rather than this one. There is no `getImageUploadBackend()` equivalent to route it through, and adding one is not a rename.
- The main app's `ImageUploadBackend` value `'backblaze'` is a **third**, unrelated namespace — the Go storage-resolver's `models.StorageBackend`, written per-uuid into `media_locations`. `'b2Image'` appears nowhere in that repo and there is no translation layer between them.

Consequence, written down so nobody re-derives it as symmetry: moving the upload store needs **three** coordinated changes — civitai-web's `S3_IMAGE_B2_*`, the storage service's, and storage-resolver's `B2_MEDIA_BUCKET_NAME` (whose existing rows are stamped `backend='backblaze'`). R7-12 removes one of the three from the list of things that can be forgotten silently; it does not remove the other two. The comment now claims exactly that, notes that the refactor is a **pure no-op today** (`getImageUploadBackend()` returns exactly the pair it replaced), and records which way each spoke misconfiguration fails: a live endpoint on the **wrong bucket** 404s → `absent` → refuses every publish (fail-closed, but indistinguishable from a real run of misses), while an **unconfigured** endpoint throws → `unknown` → **allows**.

## Round-8 mutation results — every mutant narrowed, each killed by its own named message

| # | Mutant | Narrowed to | Killed by |
|---|---|---|---|
| — | *baseline, no mutation* | whole file | **11/11 pass** |
| 1 | `showRetry` drops `!image.nsfwLevelLocked` (error section) | `…the two are exclusive` | `showRetry must drop the lock term: Retry cannot render beside Overridden: expected […] to have a length of +0 but got 1` |
| 2 | `showOverride` drops `!image.nsfwLevelLocked` (error section) | `…the two are exclusive` | `showOverride must drop the lock term: Override cannot render beside Overridden: expected […] to have a length of +0 but got 1` |
| 3 | `showOverride` drops `!image.nsfwLevelLocked` (blocked section) | `…BLOCKED section is exclusive the same way` | `the BLOCKED section's showOverride must drop the lock term too: expected […] to have a length of +0 but got 1` |
| 4 | delete-gate refusal reverted to the queue wording | `refuses an id that is not an unpublishable ingestion error` | `expected 'That image is not in the missing-medi…' to be 'That image cannot be deleted here — i…'` |

Mutants 1–3 are the two the round-7 sweep scored SURVIVED, plus the blocked-section spelling of the same term. Each dies **in its own test** and with **its own message** — mutant 1 leaves the blocked-section case passing and vice versa, so the attribution is not incidental.

**Absence control.** Every assertion in that file that requires an element to be ABSENT was checked against a component that renders nothing: `if (!hasImageProblems && !hasTextProblem) return null;` → `if (true) return null;` fails **11/11**, so no absence assertion here can pass vacuously. Each new case also asserts the badge is VISIBLE before asserting the controls are gone, which is the same control expressed per-case.

## What round 8 could NOT verify

- **Which bucket the deployed pods actually use.** The three-source-of-truth finding above is read off the GitOps sources and the code, not off running pods' env. The conclusion (three independent sources) does not depend on their current values agreeing, which they do.
- **The stranded population's size** — unchanged from round 7. No production DB access from here; the corrected `FILTER` query in the docstring is what settles it.
- **`+page.svelte` formatting.** Nothing in this repo format-checks it (see the corrected note above); it was written to match the file's existing style by hand.
- **The four `*.explain.test.ts` suites** — still `ECONNREFUSED 127.0.0.1:15432`, environmental, identical on every branch.

## Verification at this tip

Read off each runner's own summary line, never an exit code through a pipe — `prettier --list-different` in particular **exited 0 while printing `[error] No parser could be inferred`** for the `.svelte` file, so the exit code here is worth nothing.

| Runner | Result |
|---|---|
| `pnpm test:unit:run` | **1517 passed / 1 failed / 1 skipped (1519 files)** · 23771 passed / 1 failed / 26 skipped (23798 tests) — the single failure is the known load flake, below |
| `pnpm test:packages:run` | **84 passed / 3 failed (87 files)** · 1195 passed / 8 failed — all 3 are `*.explain.test.ts`, `ECONNREFUSED 127.0.0.1:15432` |
| `pnpm test:apps:run` | **103 passed / 1 failed (104 files)** · 1136 passed / 36 failed — the one failure is `reports.queries.explain.test.ts`, `ECONNREFUSED` |
| `pnpm test:component` | **195 passed (195 files)** · **2191 passed (2191 tests)** · 0 failed |
| `pnpm typecheck` | **0 type errors in 165s** |
| `pnpm -F @civitai/moderator-app check` (svelte-check) | **9403 FILES, 0 ERRORS, 0 WARNINGS** |
| `prettier --list-different` over the 6 changed `.ts`/`.tsx` | **0 unformatted**, with a positive control listing exactly 1 |

**The prettier instrument was positive-controlled with the exact invocation trusted**: a deliberately mis-formatted file added to the same argument list was listed, and the 6 real files were not. A `0` from a run that has never been watched list anything is a claim about the command line.

**The one unit failure is load, established rather than assumed.** `eventloop-watchdog.capture.test.ts > exposes the ratio distribution and the threshold echo` failed with `watchdog metrics never settled: waited 10000ms` while `test:packages:run` and `pnpm typecheck` were running concurrently on this box. Re-run **isolated it passes 9/9**, and `git diff --name-only origin/main...HEAD` matches no watchdog or eventloop file — the branch cannot reach it. (Round 7 recorded the sibling case `classifies an idle wedge as starved` in the same file; same file, same 10 s settle timeout, same cause.)

🔴 **A control that did NOT go red, recorded because it marks a real coverage boundary.** The first typecheck negative control was planted in `apps/moderator/src/routes/images/missing-media/+page.server.ts` and `pnpm typecheck` reported **0 type errors** — it did not fail. Root `tsconfig.json` includes `scripts`, `src`, `packages/*/src`, `tests`, `test` and **not `apps/`**, so root typecheck is structurally blind to the whole moderator app; `svelte-check` is the only thing that types it. Both instruments were then controlled in a file each actually covers: the same error in `src/server/services/image.service.ts` gave `error TS2322` at the right line and `1 type error(s)`, exit 2; in the moderator file, `svelte-check` gave `1 ERRORS / 1 FILES_WITH_PROBLEMS`, exit 1. Neither zero above is wired to nothing.
