### PR TITLE
fix(moderator): present the narrow inbound token to the moderator app, with a fallback

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -371,6 +371,11 @@ export const serverSchema = z
     // Base URL of the standalone moderator app (apps/moderator). Migrated /moderator/* routes redirect
     // here via the moderator catchall page during the transition.
     MODERATOR_APP_URL: z.url().default('https://moderator.civitai.com'),
+    // Server-to-server base for the moderator app, for callers that never hand the URL to a browser.
+    // SEPARATE from MODERATOR_APP_URL on purpose: that one also feeds the /moderator/* redirect's
+    // Location header, so it must stay publicly resolvable. Optional — unset, moderator-app.service.ts
+    // falls back to MODERATOR_APP_URL and nothing changes.
+    MODERATOR_APP_INTERNAL_URL: z.url().optional(),
     // The narrow, inbound-only credential the moderator app accepts, and the one this app should
     // present when calling it. OPTIONAL on purpose — see moderator-app.service.ts for why the
     // fallback to WEBHOOK_TOKEN has to stay. (Named for the value, not for the direction of any one

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -371,6 +371,11 @@ export const serverSchema = z
     // Base URL of the standalone moderator app (apps/moderator). Migrated /moderator/* routes redirect
     // here via the moderator catchall page during the transition.
     MODERATOR_APP_URL: z.url().default('https://moderator.civitai.com'),
+    // The narrow, inbound-only credential the moderator app accepts, and the one this app should
+    // present when calling it. OPTIONAL on purpose — see moderator-app.service.ts for why the
+    // fallback to WEBHOOK_TOKEN has to stay. (Named for the value, not for the direction of any one
+    // caller: it is one secret, and the sibling jobs that call in already use this name.)
+    MOD_INBOUND_TOKEN: z.string().optional(),
     UNAUTHENTICATED_DOWNLOAD: zc.booleanString,
     UNAUTHENTICATED_LIST_NSFW: zc.booleanString,
     LOGGING: commaDelimitedStringArray(),

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -375,7 +375,12 @@ export const serverSchema = z
     // SEPARATE from MODERATOR_APP_URL on purpose: that one also feeds the /moderator/* redirect's
     // Location header, so it must stay publicly resolvable. Optional — unset, moderator-app.service.ts
     // falls back to MODERATOR_APP_URL and nothing changes.
-    MODERATOR_APP_INTERNAL_URL: z.url().optional(),
+    // '' is accepted as well as absent, and that is not sloppiness. This whole change is built so
+    // the app and the config that supplies this key can deploy in either order; a bare key added to
+    // a ConfigMap arrives as an EMPTY STRING, and a plain `z.url().optional()` rejects '' — which
+    // fails the WHOLE schema parse and the process refuses to boot. Turning a typo into an outage
+    // is the opposite of what the fallback is for. '' is falsy, so it takes the fallback branch.
+    MODERATOR_APP_INTERNAL_URL: z.union([z.url(), z.literal('')]).optional(),
     // The narrow, inbound-only credential the moderator app accepts, and the one this app should
     // present when calling it. OPTIONAL on purpose — see moderator-app.service.ts for why the
     // fallback to WEBHOOK_TOKEN has to stay. (Named for the value, not for the direction of any one

--- a/src/server/services/__tests__/moderator-app-token.test.ts
+++ b/src/server/services/__tests__/moderator-app-token.test.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises';
 import path from 'path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setEnv } from '~/__tests__/mocks';
+import { serverSchema } from '~/env/server-schema';
 
 /**
  * `moderator-app.service` builds the ONE client the main app uses to call the moderator spoke
@@ -110,6 +111,25 @@ describe('moderatorApp client endpoint', () => {
     setEnv({ MODERATOR_APP_INTERNAL_URL: undefined });
     const config = await loadClientConfig();
     expect(config.endpoint).toBe(PUBLIC_URL);
+  });
+
+  it('falls back to MODERATOR_APP_URL when MODERATOR_APP_INTERNAL_URL is present but empty', async () => {
+    setEnv({ MODERATOR_APP_INTERNAL_URL: '' });
+    const config = await loadClientConfig();
+    expect(config.endpoint).toBe(PUBLIC_URL);
+  });
+
+  it('accepts an empty MODERATOR_APP_INTERNAL_URL through the env SCHEMA, not just the client', async () => {
+    // The client-level fallback above is only reachable if the schema lets '' through at all.
+    // A bare `z.url().optional()` rejects '', which fails the whole parse and the process refuses
+    // to boot — so a key added to a ConfigMap with no value would be an outage, not a no-op.
+    // Asserted against the real schema field, so it cannot drift from what the app parses.
+    const field = serverSchema.shape.MODERATOR_APP_INTERNAL_URL;
+    expect(field.safeParse('').success).toBe(true);
+    expect(field.safeParse(undefined).success).toBe(true);
+    expect(field.safeParse(INTERNAL_URL).success).toBe(true);
+    // Still a URL check, not `z.string()`: a non-empty non-URL is rejected.
+    expect(field.safeParse('not a url').success).toBe(false);
   });
 
   it('leaves the browser-facing redirect base on the PUBLIC url', async () => {

--- a/src/server/services/__tests__/moderator-app-token.test.ts
+++ b/src/server/services/__tests__/moderator-app-token.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setEnv } from '~/__tests__/mocks';
+
+/**
+ * `moderator-app.service` builds the ONE client the main app uses to call the moderator spoke
+ * (`apps/moderator`). Which credential it presents is the whole subject of this file.
+ *
+ * The spoke is dropping the platform-wide `WEBHOOK_TOKEN` from its `acceptedTokens()`, so this
+ * caller has to start presenting the narrow `MOD_INBOUND_TOKEN`. The `||` fallback is what makes
+ * the two repos' deploy ORDER irrelevant, and it is the thing most likely to be "tidied away" by
+ * someone who reads it as a redundant default — so both arms are pinned here, plus the boundary
+ * case that decides which arm an EMPTY value takes.
+ *
+ * The assertion is on the `token` the service actually hands `createModeratorClient`, i.e. the
+ * expression that does the work. A test matching the variable NAME would also pass against a
+ * service that merely mentions it in a comment.
+ *
+ * The token is read at MODULE SCOPE, so each case needs a fresh evaluation of the module:
+ * `setEnv` first, then `vi.resetModules()`, then a dynamic import. (The shared env mock's
+ * per-file overrides cannot retroactively change a read that already happened at import.)
+ */
+
+const { createModeratorClientMock } = vi.hoisted(() => ({
+  createModeratorClientMock: vi.fn((config: Record<string, unknown>) => ({ config })),
+}));
+
+vi.mock('@civitai/moderation', () => ({
+  createModeratorClient: createModeratorClientMock,
+}));
+
+// Fixtures, not credentials. Deliberately distinct from each other so an assertion cannot pass
+// by both arms coincidentally producing the same string.
+const INBOUND = 'fixture-inbound-token';
+const LEGACY = 'fixture-legacy-webhook-token';
+
+async function loadClientConfig(): Promise<Record<string, unknown>> {
+  createModeratorClientMock.mockClear();
+  vi.resetModules();
+  await import('~/server/services/moderator-app.service');
+  // Positive control: if the module ever stops constructing the client here, every `token`
+  // assertion below would read `undefined` off an empty call list and could pass vacuously.
+  expect(createModeratorClientMock).toHaveBeenCalledTimes(1);
+  return createModeratorClientMock.mock.calls[0][0];
+}
+
+describe('moderatorApp client credential', () => {
+  beforeEach(() => {
+    setEnv({ MOD_INBOUND_TOKEN: undefined, WEBHOOK_TOKEN: LEGACY });
+  });
+
+  it('presents MOD_INBOUND_TOKEN when it is configured', async () => {
+    setEnv({ MOD_INBOUND_TOKEN: INBOUND, WEBHOOK_TOKEN: LEGACY });
+    const config = await loadClientConfig();
+    expect(config.token).toBe(INBOUND);
+    expect(config.token).not.toBe(LEGACY);
+  });
+
+  it('falls back to WEBHOOK_TOKEN when MOD_INBOUND_TOKEN is unset', async () => {
+    setEnv({ MOD_INBOUND_TOKEN: undefined, WEBHOOK_TOKEN: LEGACY });
+    const config = await loadClientConfig();
+    expect(config.token).toBe(LEGACY);
+  });
+
+  it('falls back to WEBHOOK_TOKEN when MOD_INBOUND_TOKEN is present but empty', async () => {
+    // An empty string is what a ConfigMap key added with no value produces. `||` treats it as
+    // absent, which is the behaviour we want: an empty credential authenticates nothing, so
+    // falling through to the legacy token keeps the call working. A `??` here would send `''`.
+    setEnv({ MOD_INBOUND_TOKEN: '', WEBHOOK_TOKEN: LEGACY });
+    const config = await loadClientConfig();
+    expect(config.token).toBe(LEGACY);
+  });
+});

--- a/src/server/services/__tests__/moderator-app-token.test.ts
+++ b/src/server/services/__tests__/moderator-app-token.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setEnv } from '~/__tests__/mocks';
 
@@ -32,6 +34,8 @@ vi.mock('@civitai/moderation', () => ({
 // by both arms coincidentally producing the same string.
 const INBOUND = 'fixture-inbound-token';
 const LEGACY = 'fixture-legacy-webhook-token';
+const PUBLIC_URL = 'https://fixture-public.example.com';
+const INTERNAL_URL = 'http://fixture-internal.example.invalid:3000';
 
 async function loadClientConfig(): Promise<Record<string, unknown>> {
   createModeratorClientMock.mockClear();
@@ -45,7 +49,12 @@ async function loadClientConfig(): Promise<Record<string, unknown>> {
 
 describe('moderatorApp client credential', () => {
   beforeEach(() => {
-    setEnv({ MOD_INBOUND_TOKEN: undefined, WEBHOOK_TOKEN: LEGACY });
+    setEnv({
+      MOD_INBOUND_TOKEN: undefined,
+      WEBHOOK_TOKEN: LEGACY,
+      MODERATOR_APP_URL: PUBLIC_URL,
+      MODERATOR_APP_INTERNAL_URL: undefined,
+    });
   });
 
   it('presents MOD_INBOUND_TOKEN when it is configured', async () => {
@@ -68,5 +77,51 @@ describe('moderatorApp client credential', () => {
     setEnv({ MOD_INBOUND_TOKEN: '', WEBHOOK_TOKEN: LEGACY });
     const config = await loadClientConfig();
     expect(config.token).toBe(LEGACY);
+  });
+});
+
+/**
+ * The endpoint half, which is a separate hazard from the credential half.
+ *
+ * MODERATOR_APP_URL has a SECOND consumer — src/pages/moderator/[...slug].tsx builds a
+ * getServerSideProps redirect `destination` from it, i.e. a Location header sent to a moderator's
+ * browser. So it must stay publicly resolvable, while THIS caller wants the private path. Pointing
+ * the one shared variable at a private address would speed up this call and silently break every
+ * migrated /moderator/* link at the same time. Hence two variables, and hence these cases.
+ */
+describe('moderatorApp client endpoint', () => {
+  beforeEach(() => {
+    setEnv({
+      MOD_INBOUND_TOKEN: INBOUND,
+      WEBHOOK_TOKEN: LEGACY,
+      MODERATOR_APP_URL: PUBLIC_URL,
+      MODERATOR_APP_INTERNAL_URL: undefined,
+    });
+  });
+
+  it('uses MODERATOR_APP_INTERNAL_URL when it is configured', async () => {
+    setEnv({ MODERATOR_APP_INTERNAL_URL: INTERNAL_URL });
+    const config = await loadClientConfig();
+    expect(config.endpoint).toBe(INTERNAL_URL);
+    expect(config.endpoint).not.toBe(PUBLIC_URL);
+  });
+
+  it('falls back to MODERATOR_APP_URL when MODERATOR_APP_INTERNAL_URL is unset', async () => {
+    setEnv({ MODERATOR_APP_INTERNAL_URL: undefined });
+    const config = await loadClientConfig();
+    expect(config.endpoint).toBe(PUBLIC_URL);
+  });
+
+  it('leaves the browser-facing redirect base on the PUBLIC url', async () => {
+    // The guard that makes the split mean something. It reads the redirect page's own source and
+    // pins which variable builds the `destination`: a private endpoint for the API client is only
+    // safe while this page keeps using the public one. Asserting on the source is deliberate —
+    // the failure mode is someone "consolidating" the two reads, and that is a textual edit here.
+    const source = await readFile(
+      path.resolve(__dirname, '../../../pages/moderator/[...slug].tsx'),
+      'utf8'
+    );
+    expect(source).toMatch(/const base = env\.MODERATOR_APP_URL\b/);
+    expect(source).not.toMatch(/MODERATOR_APP_INTERNAL_URL/);
   });
 });

--- a/src/server/services/moderator-app.service.ts
+++ b/src/server/services/moderator-app.service.ts
@@ -4,12 +4,24 @@ import { logToAxiom } from '~/server/logging/client';
 
 // The main app's single client for delegating moderator mutations to the moderator spoke (apps/moderator),
 // which owns that logic. Built on the shared @civitai/moderation client (typed against the same action
-// schemas the spoke's `/api/mod/*` endpoint validates), authenticated with the shared WEBHOOK_TOKEN — the
-// mirror of the spoke's syncSearchIndex call in the other direction. Import this instance; there should be
-// exactly one configured client. Failures are logged and rethrown (mutations aren't retried).
+// schemas the spoke's `/api/mod/*` endpoint validates) — the mirror of the spoke's syncSearchIndex call
+// in the other direction. Import this instance; there should be exactly one configured client. Failures
+// are logged and rethrown (mutations aren't retried).
+//
+// 🔴 THE `||` FALLBACK IS THE DESIGN, NOT A LEFTOVER — do not "clean it up" into a required var.
+// This app and the moderator app deploy from different pipelines, and the ConfigMap supplying
+// MOD_INBOUND_TOKEN lands from a third one (the infra repo). The fallback makes that ordering
+// irrelevant: config first and nothing changes; code first and the call keeps working on the legacy
+// token. Remove it and there is a window in which this call is simply broken.
+//
+// MOD_INBOUND_TOKEN is the narrow, inbound-only credential the moderator app accepts.
+// WEBHOOK_TOKEN is the platform-wide admin credential — it authenticates ~134 endpoints in this app,
+// so presenting it here is far more authority than this one call needs. The moderator app is dropping
+// it from its accepted set; once MOD_INBOUND_TOKEN is set in every environment, the fallback (and
+// then this comment) can go.
 export const moderatorApp = createModeratorClient({
   endpoint: env.MODERATOR_APP_URL,
-  token: env.WEBHOOK_TOKEN,
+  token: env.MOD_INBOUND_TOKEN || env.WEBHOOK_TOKEN,
   onFailure: (failure) =>
     logToAxiom(
       { type: 'error', name: 'moderator-app-request-failed', ...failure },

--- a/src/server/services/moderator-app.service.ts
+++ b/src/server/services/moderator-app.service.ts
@@ -19,8 +19,17 @@ import { logToAxiom } from '~/server/logging/client';
 // so presenting it here is far more authority than this one call needs. The moderator app is dropping
 // it from its accepted set; once MOD_INBOUND_TOKEN is set in every environment, the fallback (and
 // then this comment) can go.
+//
+// 🔴 THE ENDPOINT IS DELIBERATELY *NOT* `MODERATOR_APP_URL`, AND THE TWO ARE NOT INTERCHANGEABLE.
+// `MODERATOR_APP_URL` has a second consumer with the opposite requirement: `src/pages/moderator/
+// [...slug].tsx` builds a `getServerSideProps` REDIRECT DESTINATION from it, which is a Location
+// header sent to a moderator's BROWSER — so that value has to stay publicly resolvable. This call is
+// server-to-server and wants the shortest private path instead. Pointing the single shared variable
+// at a private address would silently break every migrated /moderator/* link while this call got
+// faster, so the two consumers get two variables. `MODERATOR_APP_INTERNAL_URL` is optional and falls
+// back to the public one, so an environment that sets neither behaves exactly as it does today.
 export const moderatorApp = createModeratorClient({
-  endpoint: env.MODERATOR_APP_URL,
+  endpoint: env.MODERATOR_APP_INTERNAL_URL || env.MODERATOR_APP_URL,
   token: env.MOD_INBOUND_TOKEN || env.WEBHOOK_TOKEN,
   onFailure: (failure) =>
     logToAxiom(


### PR DESCRIPTION
## What

The main app's one call into the moderator app — `moderatorApp.imageModerate(…)`, from `src/server/controllers/image.controller.ts` — authenticates with `WEBHOOK_TOKEN`, the platform-wide credential that also authenticates ~134 admin endpoints in this app.

`apps/moderator` accepts a second, narrow, inbound-only credential (`MOD_INBOUND_TOKEN`) and is in the middle of dropping `WEBHOOK_TOKEN` from its `acceptedTokens()`. `apps/moderator/src/lib/server/webhook-endpoint.ts` calls that state a migration seam and says outright: move each inbound caller to `MOD_INBOUND_TOKEN`. This is that move, for the last caller in this app.

- `MOD_INBOUND_TOKEN` joins `src/env/server-schema.ts` as an **optional** string.
- `src/server/services/moderator-app.service.ts` now sends `env.MOD_INBOUND_TOKEN || env.WEBHOOK_TOKEN`.
- `MODERATOR_APP_INTERNAL_URL` joins the same schema, also optional, and the client's `endpoint` becomes `env.MODERATOR_APP_INTERNAL_URL || env.MODERATOR_APP_URL`. See the next section — this one is not cosmetic.

`createModeratorClient` is constructed in exactly one place and `moderatorApp` has exactly one caller — both verified with `git grep` at `origin/main` — so this is the whole surface.

## 🔴 The `||` fallback is the design, not a leftover

Please don't tidy it into a required var. This app, the moderator app, and the deployment config that supplies the new variable ship from three different pipelines. The fallback makes their ordering irrelevant:

- config lands first → nothing changes, the app is still on the legacy token;
- code lands first → the call keeps working on the legacy token until the config arrives.

Make the variable required and there is a window in which this call is simply broken. There is a comment at the call site saying this, so the next reader has the reason and not just the shape.

## 🔴 Why the endpoint got a second variable rather than a new value

The companion infra change wants this call to stop leaving the cluster. The obvious way to do that is to set `MODERATOR_APP_URL` to a private address — and it would have **broken the moderator UI**.

`env.MODERATOR_APP_URL` has **two** server-side consumers, enumerated at `origin/main` with `git grep`, not sampled:

| consumer | what it does with the value |
|---|---|
| `src/server/services/moderator-app.service.ts` | server-to-server API base — wants the shortest private path |
| `src/pages/moderator/[...slug].tsx` | builds a `getServerSideProps` **redirect `destination`** — a `Location` header sent to a moderator's **browser**, so it must stay publicly resolvable |

One variable cannot satisfy both. Repointing it would have made the API call private and, in the same change, sent every moderator following a migrated `/moderator/*` link to a hostname their browser cannot resolve — a silent UI break, paid for by a latency win nobody would have connected to it.

Hence a second, optional variable used only by the API client, falling back to `MODERATOR_APP_URL`. An environment that sets neither behaves exactly as it does today. The redirect page is untouched.

## 🔴 An empty value must not be able to stop the app booting

`src/env/server.ts` runs `serverSchema.safeParse(process.env)` and **throws** on any failure, so one bad field takes down the whole process at startup — not the feature, the app.

A plain `z.url().optional()` rejects `''`, and `''` is exactly what a config key added with no value produces. The failure mode: someone adds `MODERATOR_APP_INTERNAL_URL` to the deployment config, forgets the value or lands the key before the value, and every pod that restarts after that refuses to boot. This change exists so the app and its config can deploy in either order — turning a blank key into an outage is the precise opposite of that.

So the field is `z.union([z.url(), z.literal('')]).optional()`: absent and empty both accepted, a non-empty non-URL still rejected, and `''` is falsy so it takes the same fallback branch as absent. The test asserts against `serverSchema.shape.MODERATOR_APP_INTERNAL_URL` itself rather than a restatement of it, so it cannot drift from what the app parses.

Several pre-existing optional URL fields in this schema have the same shape (`WEBHOOK_URL` among them). Those are untouched here — only the field this branch introduces is fixed. Worth someone's attention separately.

## On the name

It is `MOD_INBOUND_TOKEN` even though the value is *outbound* from this app's point of view. It is **one secret value**, and the sibling jobs that call into the same app already use that name. One name per value beats per-caller-accurate naming — two names for one secret is how a rotation goes half-done.

## Tests

`src/server/services/__tests__/moderator-app-token.test.ts` asserts on the `token` the service actually hands `createModeratorClient` — the expression that does the work, not a variable name that also appears in the prose beside it. Fixtures are two distinct made-up strings, so an arm cannot pass by both branches coincidentally producing the same value; no real credential appears. There is an in-band positive control (`createModeratorClient` called exactly once), without which every `token` assertion could pass vacuously off an empty call list.

**Red → green:**

| assertion | pre-change | post-change |
|---|---|---|
| presents `MOD_INBOUND_TOKEN` when configured | **RED** — `expected 'fixture-legacy-webhook-token' to be 'fixture-inbound-token'` | green |
| falls back when `MOD_INBOUND_TOKEN` is unset | green | green |
| falls back when `MOD_INBOUND_TOKEN` is empty | green | green |
| uses `MODERATOR_APP_INTERNAL_URL` when configured | **RED** — `expected 'https://fixture-public.example.com' to be 'http://fixture-internal…'` | green |
| falls back to `MODERATOR_APP_URL` when it is unset | green | green |
| the redirect page's base is still `MODERATOR_APP_URL` | green | green |
| falls back when `MODERATOR_APP_INTERNAL_URL` is present but empty | green | green |
| the env **schema** accepts `''` for `MODERATOR_APP_INTERNAL_URL` | n/a (field did not exist) | green |

Only 2 of 8 are red at base, and that is honest rather than a shortfall: the pre-change code always sends `WEBHOOK_TOKEN`, so the fallback arms *cannot* fail against it. Those, and the redirect-page guard, protect against a **future** regression — someone deleting a fallback, or "consolidating" the two URL reads — so they were **mutation-checked** rather than counted as regression coverage:

| mutant | result |
|---|---|
| `token: env.MOD_INBOUND_TOKEN` (fallback deleted) | both fallback arms RED, each with its own assertion (`expected undefined…`, `expected ''…`) |
| `token: env.MOD_INBOUND_TOKEN ?? env.WEBHOOK_TOKEN` | the empty-string arm alone RED; the other two survive, which is the correct discrimination |
| `endpoint: env.MODERATOR_APP_INTERNAL_URL` (fallback deleted) | the endpoint-fallback arm RED (`expected undefined…`) |
| the redirect page consolidated onto `MODERATOR_APP_INTERNAL_URL \|\| MODERATOR_APP_URL` | the redirect guard RED — i.e. it is reachable and pins the source, not just a spelling |
| `MODERATOR_APP_INTERNAL_URL: z.url().optional()` (tolerance removed) | the schema arm alone RED |

`pnpm typecheck`: **0 errors in 145 s**. (First run reported 12; all 12 were `Cannot find module '…/event-engine-common/…'` — a fresh worktree does not populate submodules. After `git submodule update --init`, clean. Nothing to do with this change.)

`eslint` and `prettier --check` clean on all three files, each confirmed against a deliberately-broken control file so the clean verdict is not a fact about an empty file list.

Full `unit*` project (1,516 files) run locally as well — see the checks on this PR for the authoritative result.

## Not verified

`/api/mod/image-moderate` was **not** invoked — it mutates. Credential acceptance is proven independently: `apps/moderator`'s hook authenticates every `/api/*` path through one code path, and a sibling scheduled job authenticates on `/api/mod/abuse-report` with this same credential daily.

A companion change in our private infrastructure repo supplies `MOD_INBOUND_TOKEN` and `MODERATOR_APP_INTERNAL_URL` to the deployment. Neither PR needs the other to land first — that is what the two fallbacks buy.
