### PR TITLE
fix(gallery): load the whole post in the detail modal, not just the seeded slice

### DIFF
--- a/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
@@ -48,10 +48,9 @@ import { isDefined } from '~/utils/type-guards';
 import { SimpleImageCarousel } from '~/components/SimpleImageCarousel/SimpleImageCarousel';
 import { Embla } from '~/components/EmblaCarousel/EmblaCarousel';
 import { watchTouchDrag } from '~/components/EmblaCarousel/watchTouchDrag';
-import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
-import { mergePostImages, shouldFetchPostTail } from '~/components/Image/AsPosts/lazyPostImages';
-import { POST_IMAGE_LIMIT } from '~/server/common/constants';
-import { trpc } from '~/utils/trpc';
+import { shouldFetchPostTail } from '~/components/Image/AsPosts/lazyPostImages';
+import type { PostTailDescriptor } from '~/components/Image/AsPosts/usePostImagesWithTail';
+import { usePostImagesWithTail } from '~/components/Image/AsPosts/usePostImagesWithTail';
 import classes from './ImagesAsPostsCard.module.css';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -378,16 +377,18 @@ const carouselIndicatorProps = {
  * One carousel slide's content (blur guard, remix, image, reactions, meta). Shared
  * by the static and lazy carousels so an appended (lazily-fetched) image renders
  * byte-identically to a seeded one. `dialogImages` seeds the detail modal with the
- * carousel's currently-loaded set.
+ * carousel's currently-loaded set; `postTail` lets it load the rest itself.
  */
 function PostCarouselSlide({
   image,
   postId,
   dialogImages,
+  postTail,
 }: {
   image: ImagesAsPostModel['images'][number];
   postId: number;
   dialogImages: ImagesAsPostModel['images'];
+  postTail?: PostTailDescriptor;
 }) {
   const features = useFeatureFlags();
   const handleRemixClick = (e: React.MouseEvent) => {
@@ -424,7 +425,7 @@ function PostCarouselSlide({
           <RoutedDialogLink
             name="imageDetail"
             state={{ imageId: image.id }}
-            getState={() => ({ imageId: image.id, images: dialogImages })}
+            getState={() => ({ imageId: image.id, images: dialogImages, postTail })}
             className={classes.link}
           >
             <>
@@ -571,8 +572,11 @@ export function StaticPostImagesCarousel({
  * N" immediately (indicators from `imageCount`); fetches the post's remaining
  * images via `trpc.image.getInfinite({ postId })` when the active slide approaches
  * the loaded edge, re-applies the feed's hidden preferences to the fetched tail
- * (content safety), and appends. The detail modal is seeded with whatever is
- * loaded at click time.
+ * (content safety), and appends.
+ *
+ * The detail modal is seeded with what is loaded at click time PLUS the descriptor
+ * it needs to load the rest itself — a click on the cover happens long before the
+ * approach threshold, so the seed alone is usually just the first slice.
  *
  * Exported for component tests.
  */
@@ -600,48 +604,27 @@ export function LazyPostImagesCarousel({
     [seed.length, total]
   );
 
-  // The tail = the WHOLE post (≤ POST_IMAGE_LIMIT), same version/browsing-level
-  // filters the gallery used, so the returned set matches `imageCount`. postId
-  // forces the DB path server-side (covered index, ~2ms).
-  const { data: tailData, isError: tailError } = trpc.image.getInfinite.useQuery(
-    {
-      ...filters,
-      postId,
-      browsingLevel,
-      limit: POST_IMAGE_LIMIT,
-      include: ['cosmetics', 'tagIds'],
-    },
-    {
-      // `postId != null` is the explicit invariant: a null postId must never broaden
-      // `getInfinite` to the model's general feed (it would append unrelated images).
-      enabled: fetchTail && postId != null,
-      trpc: { context: { skipBatch: true } },
-      staleTime: 5 * 60 * 1000,
-    }
-  );
-
-  // Content safety: re-apply the feed's hidden preferences to the fetched tail so
-  // it never surfaces images the feed slice would have dropped (owner/user-hidden,
-  // system-hidden tags, poi/minor). Browsing level is already applied server-side.
-  const { items: filteredTail } = useApplyHiddenPreferences({
-    type: 'images',
-    data: tailData?.items,
-    hiddenImages: hiddenImageIds,
-    hiddenUsers,
-    hiddenTags,
+  const {
+    images: loaded,
+    fetched,
+    isError: tailError,
+  } = usePostImagesWithTail({
+    seed,
+    postId,
+    filters,
     browsingLevel,
+    hiddenImageIds,
+    hiddenTags,
+    hiddenUsers,
+    enabled: fetchTail,
   });
 
-  const fetched = !!tailData;
-  const loaded = useMemo(
+  const postTail = useMemo<PostTailDescriptor | undefined>(
     () =>
-      fetched
-        ? (mergePostImages(
-            seed as { id: number }[],
-            (filteredTail ?? []) as { id: number }[]
-          ) as ImagesAsPostModel['images'])
-        : seed,
-    [fetched, seed, filteredTail]
+      postId != null
+        ? { postId, imageCount: total, filters, browsingLevel, hiddenImageIds, hiddenTags, hiddenUsers }
+        : undefined,
+    [postId, total, filters, browsingLevel, hiddenImageIds, hiddenTags, hiddenUsers]
   );
 
   // Before the tail resolves, advertise the true count so indicators read "1 of N".
@@ -665,6 +648,7 @@ export function LazyPostImagesCarousel({
             image={loaded[index]}
             postId={postId}
             dialogImages={loaded}
+            postTail={postTail}
           />
         ) : (
           <Center key={index} className="size-full">

--- a/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
@@ -58,6 +58,10 @@ const mocks = vi.hoisted(() => {
   });
   // Per-test knobs (reset in beforeEach).
   const state = { error: false };
+  // The active slide's `getState` — what its `RoutedDialogLink` hands the detail modal.
+  // Captured rather than clicked: the mocked slide leaves render at zero size, so a real
+  // click never passes playwright's actionability check.
+  const link = { getState: undefined as undefined | (() => any) };
   const ctx = {
     browsingLevel: 1,
     hiddenImageIds: [] as number[],
@@ -79,7 +83,7 @@ const mocks = vi.hoisted(() => {
       isError: false,
     };
   });
-  return { tailImage, state, ctx, getInfiniteUseQuery };
+  return { tailImage, state, ctx, link, getInfiniteUseQuery };
 });
 
 // --- tail fetch ---------------------------------------------------------------
@@ -182,7 +186,10 @@ vi.mock('~/components/Cards/components/HoverActionButton', () => ({ default: () 
 // in any pass/fail count. Spreading is immune to the next export added upstream.
 vi.mock('~/components/Dialog/RoutedDialogLink', async (importOriginal) => ({
   ...(await importOriginal<typeof RoutedDialogLinkModule>()),
-  RoutedDialogLink: ({ children }: any) => <a>{children}</a>,
+  RoutedDialogLink: ({ children, getState }: any) => {
+    mocks.link.getState = getState;
+    return <a>{children}</a>;
+  },
 }));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ imageGeneration: false }),
@@ -229,6 +236,7 @@ const walkToTail = async () => {
 
 beforeEach(() => {
   mocks.getInfiniteUseQuery.mockClear();
+  mocks.link.getState = undefined;
   mocks.state.error = false;
   mocks.ctx.browsingLevel = 1;
   mocks.ctx.hiddenImageIds = [];
@@ -322,6 +330,27 @@ describe('LazyPostImagesCarousel', () => {
       await expect.element(activeSlideId()).toBeInTheDocument();
       await clickNext();
     }
+  });
+
+  test('hands the detail modal the descriptor for the rest of the post, not just the seed', async () => {
+    // A cover click happens at index 0 — six slides short of the approach threshold —
+    // so the seed the modal receives is the bare first slice. Without the descriptor
+    // riding along, images 7..20 are unreachable by that route.
+    mocks.ctx.hiddenImageIds = [42];
+    const data = { postId: 100, imageCount: 20, images: slice(6) } as any;
+    renderWithProviders(<LazyPostImagesCarousel data={data} postId={100} />);
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+
+    const state = mocks.link.getState!();
+    expect(state.images).toHaveLength(6);
+    expect(state.postTail).toMatchObject({
+      postId: 100,
+      imageCount: 20,
+      browsingLevel: 1,
+      // The owner-curation lists travel too — `getInfinite` re-derives none of them.
+      hiddenImageIds: [42],
+      filters: { modelId: 1, modelVersionId: 2 },
+    });
   });
 
   test('never enables the tail query when postId is null (no broadening to the general feed)', async () => {

--- a/src/components/Image/AsPosts/usePostImagesWithTail.ts
+++ b/src/components/Image/AsPosts/usePostImagesWithTail.ts
@@ -50,7 +50,9 @@ export function usePostImagesWithTail<T extends { id: number }>({
 }: {
   seed: T[];
   enabled: boolean;
-} & Omit<PostTailDescriptor, 'postId' | 'imageCount'> & { postId?: number | null }) {
+} & Omit<PostTailDescriptor, 'postId' | 'imageCount'> & {
+    postId?: number | null;
+  }) {
   // The tail = the WHOLE post (≤ POST_IMAGE_LIMIT), same version/browsing-level
   // filters the gallery used, so the returned set matches `imageCount`. postId
   // forces the DB path server-side (covered index, ~2ms).
@@ -84,7 +86,10 @@ export function usePostImagesWithTail<T extends { id: number }>({
   const images = useMemo(
     () =>
       fetched
-        ? (mergePostImages(seed as { id: number }[], (filteredTail ?? []) as { id: number }[]) as T[])
+        ? (mergePostImages(
+            seed as { id: number }[],
+            (filteredTail ?? []) as { id: number }[]
+          ) as T[])
         : seed,
     [fetched, seed, filteredTail]
   );

--- a/src/components/Image/AsPosts/usePostImagesWithTail.ts
+++ b/src/components/Image/AsPosts/usePostImagesWithTail.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { mergePostImages } from '~/components/Image/AsPosts/lazyPostImages';
+import { POST_IMAGE_LIMIT } from '~/server/common/constants';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * Everything a consumer needs to fetch a gallery post's remaining images and
+ * filter them the way the GALLERY did — not the way a bare `getInfinite` would.
+ *
+ * 🔴 The three hidden-* lists are MODEL-OWNER curation (`gallerySettings`), not the
+ * viewer's own preferences, and `browsingLevel` is the gallery's `intersection`
+ * (viewer level ∩ domain cap ∩ the owner's `gallerySettings.level`). Nothing
+ * downstream of `image.getInfinite` re-derives any of them — `useQueryImages`
+ * applies the VIEWER's prefs only — so a consumer that drops them surfaces
+ * owner-hidden images and images above the owner's cap.
+ *
+ * Carried through the routed-dialog state so the detail modal, which renders
+ * outside `ImagesAsPostsInfiniteProvider`, can filter identically to the card.
+ */
+export type PostTailDescriptor = {
+  postId: number;
+  imageCount: number;
+  filters?: Record<string, unknown>;
+  browsingLevel?: number;
+  hiddenImageIds?: number[];
+  hiddenTags?: number[];
+  hiddenUsers?: number[];
+};
+
+/**
+ * Seed ⊕ lazily-fetched tail for one gallery post, filtered as the gallery filters.
+ *
+ * Shared by the card carousel and the detail modal it seeds, so both run ONE
+ * fetch policy and ONE filter policy. They also produce the same react-query key,
+ * so whichever asks second is a cache hit rather than a second request.
+ *
+ * `enabled` is the caller's: the carousel latches it on approach to the loaded
+ * edge, the modal sets it as soon as it knows its seed is partial.
+ */
+export function usePostImagesWithTail<T extends { id: number }>({
+  seed,
+  postId,
+  filters,
+  browsingLevel,
+  hiddenImageIds,
+  hiddenTags,
+  hiddenUsers,
+  enabled,
+}: {
+  seed: T[];
+  enabled: boolean;
+} & Omit<PostTailDescriptor, 'postId' | 'imageCount'> & { postId?: number | null }) {
+  // The tail = the WHOLE post (≤ POST_IMAGE_LIMIT), same version/browsing-level
+  // filters the gallery used, so the returned set matches `imageCount`. postId
+  // forces the DB path server-side (covered index, ~2ms).
+  const { data, isError } = trpc.image.getInfinite.useQuery(
+    {
+      ...filters,
+      postId: postId ?? undefined,
+      browsingLevel,
+      limit: POST_IMAGE_LIMIT,
+      include: ['cosmetics', 'tagIds'],
+    },
+    {
+      // `postId != null` is the explicit invariant: a null postId must never broaden
+      // `getInfinite` to the model's general feed (it would append unrelated images).
+      enabled: enabled && postId != null,
+      trpc: { context: { skipBatch: true } },
+      staleTime: 5 * 60 * 1000,
+    }
+  );
+
+  const { items: filteredTail } = useApplyHiddenPreferences({
+    type: 'images',
+    data: data?.items,
+    hiddenImages: hiddenImageIds,
+    hiddenUsers,
+    hiddenTags,
+    browsingLevel,
+  });
+
+  const fetched = !!data;
+  const images = useMemo(
+    () =>
+      fetched
+        ? (mergePostImages(seed as { id: number }[], (filteredTail ?? []) as { id: number }[]) as T[])
+        : seed,
+    [fetched, seed, filteredTail]
+  );
+
+  return { images, fetched, isError };
+}

--- a/src/components/Image/Detail/ImageDetailModal.tsx
+++ b/src/components/Image/Detail/ImageDetailModal.tsx
@@ -6,6 +6,8 @@ import { PageModal } from '~/components/Dialog/Templates/PageModal';
 import { ImageDetailProvider } from '~/components/Image/Detail/ImageDetailProvider';
 import { ImageDetail2 } from '~/components/Image/DetailV2/ImageDetail2';
 import { imagesQueryParamSchema } from '~/components/Image/image.utils';
+import type { PostTailDescriptor } from '~/components/Image/AsPosts/usePostImagesWithTail';
+import { usePostImagesWithTail } from '~/components/Image/AsPosts/usePostImagesWithTail';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
 import { removeEmpty } from '../../../utils/object-helpers';
 import type { ImageGetInfinite } from '~/types/router';
@@ -13,6 +15,7 @@ import type { ImageGetInfinite } from '~/types/router';
 export default function ImageDetailModal({
   imageId,
   images,
+  postTail,
   hideReactionCount,
   hideReactions,
   filters,
@@ -22,6 +25,7 @@ export default function ImageDetailModal({
   imageId: number;
   filters?: Record<string, unknown>;
   images?: ImageGetInfinite;
+  postTail?: PostTailDescriptor;
   hideReactionCount?: boolean;
   hideReactions?: boolean;
   collectionId?: number;
@@ -40,6 +44,19 @@ export default function ImageDetailModal({
   // Only do this so that we have it pre-fetched
   const { isLoading } = useCollection(collectionId as number, {
     enabled: !!collectionId,
+  });
+
+  // A lazy gallery card seeds the post's FIRST SLICE, not the post. Grow it here, or
+  // everything past the slice is unreachable from a gallery click (ClickUp 868kxypd0).
+  const { images: seededImages } = usePostImagesWithTail({
+    seed: images ?? [],
+    postId: postTail?.postId,
+    filters: postTail?.filters,
+    browsingLevel: postTail?.browsingLevel,
+    hiddenImageIds: postTail?.hiddenImageIds,
+    hiddenTags: postTail?.hiddenTags,
+    hiddenUsers: postTail?.hiddenUsers,
+    enabled: !!postTail && !!images && images.length < postTail.imageCount,
   });
 
   if (!query.imageId) return null;
@@ -61,7 +78,7 @@ export default function ImageDetailModal({
       <ImageDetailProvider
         imageId={imageId}
         filters={queryFilters}
-        images={images}
+        images={images ? seededImages : undefined}
         hideReactionCount={hideReactionCount}
         hideReactions={hideReactions}
         collectionId={collectionId}

--- a/src/components/Image/Detail/ImageDetailModalPostTail.browser.test.tsx
+++ b/src/components/Image/Detail/ImageDetailModalPostTail.browser.test.tsx
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// Type-only namespace imports for the `importOriginal` spreads below. Erased at compile
+// time, so they do not participate in mock hoisting. `consistent-type-imports` rejects the
+// `typeof import('...')` form, which is why these are named namespaces.
+import type * as TrpcUtils from '~/utils/trpc';
+import type * as CollectionUtils from '~/components/Collections/collection.utils';
+import type * as HiddenPreferences from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+
+// =============================================================================
+// The detail modal's half of the gallery lazy per-post load (`galleryLazyPostImages`).
+//
+// The card carousel lazy-loads a post's tail on APPROACH to the loaded edge. A click
+// on the cover is index 0 — six slides short of that — so the modal it seeds gets the
+// bare first slice, and before this it kept it forever: `ImageDetailProvider` only
+// fetches when the seed is EMPTY. Everything past image 6 was unreachable from a
+// gallery click (Freshdesk #69700, ClickUp 868kxypd0).
+//
+// Pinned here:
+//   * a partial seed + `postTail` grows to the post's full set,
+//   * the fetched tail is re-run through the REAL hidden-prefs filter using the
+//     OWNER-curation lists carried on the descriptor — `getInfinite` re-derives
+//     none of them, so dropping them would surface owner-hidden images,
+//   * a seed with no `postTail` (every other feed) still never fetches.
+// =============================================================================
+
+const mocks = vi.hoisted(() => {
+  const image = (id: number) => ({
+    id,
+    type: 'image',
+    url: `img-${id}.jpeg`,
+    name: null,
+    poi: false,
+    minor: false,
+    metadata: { width: 1, height: 1 },
+    reactions: [],
+    stats: {},
+    user: { id: 9 },
+    userId: 9,
+    nsfwLevel: 1,
+    tagIds: [] as number[],
+    prompt: '',
+  });
+  // Mirrors react-query gating: no data unless the query was actually enabled, so an
+  // assertion on the resulting image count also proves the enable wiring.
+  const getInfiniteUseQuery = vi.fn((_input: any, opts: any) => {
+    if (!opts?.enabled) return { data: undefined, isError: false };
+    return {
+      data: { items: Array.from({ length: 14 }, (_, i) => image(i + 7)), nextCursor: undefined },
+      isError: false,
+    };
+  });
+  return { image, getInfiniteUseQuery };
+});
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcUtils>()),
+  trpc: {
+    image: { getInfinite: { useQuery: mocks.getInfiniteUseQuery } },
+    useUtils: () => ({}),
+  },
+}));
+
+// The REAL `images` filter, not a pass-through — this is the branch that makes the
+// owner-curation assertion below load-bearing.
+vi.mock('~/components/HiddenPreferences/useApplyHiddenPreferences', async (importOriginal) => {
+  const actual = await importOriginal<typeof HiddenPreferences>();
+  return {
+    ...actual,
+    useApplyHiddenPreferences: ({
+      type,
+      data,
+      hiddenImages = [],
+      hiddenUsers = [],
+      hiddenTags = [],
+      browsingLevel,
+    }: any) => {
+      const { items } = actual.filterPreferences({
+        type,
+        data,
+        hiddenPreferences: {
+          hiddenUsers: new Map(hiddenUsers.map((id: number) => [id, true])),
+          hiddenTags: new Map(hiddenTags.map((id: number) => [id, true])),
+          hiddenModels: new Map(),
+          hiddenModel3Ds: new Map(),
+          hiddenImages: new Map(hiddenImages.map((id: number) => [id, true])),
+          hiddenLoading: false,
+          moderatedTags: [],
+          systemHiddenTags: new Map(),
+        } as any,
+        browsingLevel,
+        currentUser: null as any,
+        canViewNsfw: true,
+      });
+      return { items };
+    },
+  };
+});
+
+vi.mock('~/components/BrowserRouter/BrowserRouterProvider', () => ({
+  useBrowserRouter: () => ({ query: { imageId: 1 } }),
+}));
+vi.mock('~/components/Dialog/DialogProvider', () => ({ useDialogContext: () => ({}) }));
+vi.mock('~/components/Dialog/Templates/PageModal', () => ({
+  PageModal: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('~/components/Collections/collection.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof CollectionUtils>()),
+  useCollection: () => ({ collection: undefined, isLoading: false }),
+}));
+vi.mock('~/components/Image/DetailV2/ImageDetail2', () => ({ ImageDetail2: () => null }));
+
+// The seam under test: whatever reaches the provider is what the user can navigate.
+vi.mock('~/components/Image/Detail/ImageDetailProvider', () => ({
+  ImageDetailProvider: ({ images }: any) => (
+    <div data-testid="provider-images" data-ids={(images ?? []).map((x: any) => x.id).join(',')} />
+  ),
+}));
+
+// Import AFTER the mocks are registered.
+import { renderWithProviders } from '../../../../test/component-setup';
+import ImageDetailModal from '~/components/Image/Detail/ImageDetailModal';
+
+const seed = (n: number) => Array.from({ length: n }, (_, i) => mocks.image(i + 1)) as any;
+const providedIds = async () =>
+  ((await page.getByTestId('provider-images').element()).getAttribute('data-ids') ?? '')
+    .split(',')
+    .filter(Boolean)
+    .map(Number);
+
+const postTail = (overrides: Record<string, unknown> = {}) => ({
+  postId: 100,
+  imageCount: 20,
+  filters: { modelId: 1, modelVersionId: 2 },
+  browsingLevel: 1,
+  hiddenImageIds: [] as number[],
+  hiddenTags: [] as number[],
+  hiddenUsers: [] as number[],
+  ...overrides,
+});
+
+beforeEach(() => {
+  mocks.getInfiniteUseQuery.mockClear();
+});
+
+describe('ImageDetailModal seeded from a lazy gallery card', () => {
+  test('grows a partial seed to the whole post', async () => {
+    renderWithProviders(<ImageDetailModal imageId={1} images={seed(6)} postTail={postTail()} />);
+
+    // The seed alone is 6. Without the tail load this stays 6 forever — that is the bug.
+    await vi.waitFor(async () => expect(await providedIds()).toHaveLength(20));
+    expect(await providedIds()).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+
+    const call = mocks.getInfiniteUseQuery.mock.calls.find(([, opts]) => opts?.enabled)!;
+    expect(call[0]).toMatchObject({ postId: 100, browsingLevel: 1, modelVersionId: 2 });
+  });
+
+  test('applies the gallery-owner hidden lists to the tail (safety regression guard)', async () => {
+    // id 7 is hidden by the MODEL OWNER's gallery settings. `image.getInfinite` does not
+    // know about that list, and `useQueryImages` applies the VIEWER's prefs only — so it
+    // is filtered here or not at all.
+    renderWithProviders(
+      <ImageDetailModal imageId={1} images={seed(6)} postTail={postTail({ hiddenImageIds: [7] })} />
+    );
+
+    await vi.waitFor(async () => expect(await providedIds()).toHaveLength(19));
+    expect(await providedIds()).not.toContain(7);
+  });
+
+  test('a seed that already covers the post does not refetch', async () => {
+    renderWithProviders(
+      <ImageDetailModal imageId={1} images={seed(20)} postTail={postTail({ imageCount: 20 })} />
+    );
+
+    await vi.waitFor(async () => expect(await providedIds()).toHaveLength(20));
+    expect(mocks.getInfiniteUseQuery.mock.calls.every(([, opts]) => opts?.enabled === false)).toBe(
+      true
+    );
+  });
+
+  test('a seed with no descriptor is passed through untouched (every other feed)', async () => {
+    renderWithProviders(<ImageDetailModal imageId={1} images={seed(6)} />);
+
+    await vi.waitFor(async () => expect(await providedIds()).toHaveLength(6));
+    expect(mocks.getInfiniteUseQuery.mock.calls.every(([, opts]) => opts?.enabled === false)).toBe(
+      true
+    );
+  });
+});

--- a/src/server/utils/image-infinite-wire.ts
+++ b/src/server/utils/image-infinite-wire.ts
@@ -15,10 +15,10 @@
  *  - the feed card (`ImagesCard` / `Cards/ImageCard`) + its context menu,
  *  - the hidden-preferences `images` filter (`useApplyHiddenPreferences`),
  *  - the masonry grid + OG/SSR structured-data path,
- *  - AND the image-detail modal seeded from the card (`ImageDetail2`), which reads
- *    the SEEDED image objects directly (no refetch when the seed contains the
- *    clicked id — `ImageDetailProvider` uses `initialImages` as-is), so its
- *    read-set is load-bearing here and was traced explicitly.
+ *  - AND the image-detail modal seeded from the card (`ImageDetail2`), which renders
+ *    the SEEDED image objects directly, so its read-set is load-bearing here and was
+ *    traced explicitly. It reaches this shape twice over: as the seed, and as the
+ *    per-post tail a model-gallery modal loads via `usePostImagesWithTail`.
  *
  * The correctness of "these are unread" is enforced by the compiler, not asserted:
  * because `ImagesInfiniteModel` is defined from `getAllImages`' return type and the

--- a/src/server/utils/images-as-posts-wire.ts
+++ b/src/server/utils/images-as-posts-wire.ts
@@ -15,10 +15,11 @@
  *  - the shared image context menu (`ImageMenuItems` — its `ImageProps` type does
  *    not contain any of these fields),
  *  - the hidden-preferences `posts` branch (`useApplyHiddenPreferences`),
- *  - AND the image-detail modal seeded from the card (`ImageDetail2`), which reads
- *    the SEEDED image objects directly (no refetch when the seed contains the
- *    target id — `ImageDetailProvider` uses `initialImages` as-is), so its read-set
- *    is load-bearing here and was traced explicitly.
+ *  - AND the image-detail modal seeded from the card (`ImageDetail2`), which renders
+ *    these SEEDED objects as-is, so its read-set is load-bearing here and was traced
+ *    explicitly. It also loads the post's tail itself (`usePostImagesWithTail`), but
+ *    that arrives from `image.getInfinite` carrying the untrimmed shape — the trim
+ *    below constrains the seed only.
  *
  * 🔴 RETAINED deliberately — do NOT add these to the drop list:
  *  - `tagIds`  — the hidden-prefs `case 'posts'` branch filters on it


### PR DESCRIPTION
Fixes the gallery click-through losing every image past the 6th.

**ClickUp:** [868kxypd0](https://app.clickup.com/t/868kxypd0) · **Reported via** Freshdesk #69700

## The bug

`galleryLazyPostImages` has the server send a post's first `GALLERY_POST_IMAGE_SLICE` (6) images plus its true `imageCount`. The card carousel lazy-loads the tail — but only once the active slide comes within `POST_TAIL_PREFETCH_THRESHOLD` (2) of the loaded edge, i.e. index 4.

A click on the cover is index 0. So the detail modal was seeded with the bare 6-image slice, and `ImageDetailProvider` only fetches when the seed is *empty* (`shouldFetchMany = !initialImages?.length && ...`) — so it kept those 6 forever. On a 20-image showcase post, 14 images were unreachable from a gallery click, while the card's pips advertised all 20. "Show post" worked because the post page loads the full post.

Reproduced on production before the fix: a 12-pip card opened a modal with 6 indicators.

## The fix

Extract the carousel's tail fetch + hidden-preferences filter + merge into a shared `usePostImagesWithTail`, and run it from the modal too. The card puts a `PostTailDescriptor` into the routed-dialog state alongside the seed. Both call sites build the same react-query key, so whichever asks second is a cache hit, not a second request.

**Why the descriptor carries what it carries.** The obvious fix — have the modal call `image.getInfinite({ postId })` — leaks content. The gallery filters with **model-owner curation**, not viewer preferences:

- `browsingLevel` is the viewer's level ∩ the green-domain PG cap ∩ the owner's `gallerySettings.level`
- `hiddenImageIds` / `hiddenTags` / `hiddenUsers` come from `gallerySettings`

`useQueryImages` runs `useApplyHiddenPreferences` with the **viewer's** preferences only, and re-derives none of the above. The modal renders outside `ImagesAsPostsInfiniteProvider`, so those four values ride on the descriptor and the hook is the single place they are applied.

`ImageDetailProvider` is **unchanged** — a seed with no descriptor (every other feed: collections, profiles, post pages) behaves exactly as before, and there is a test pinning that it never fetches.

## Verification

**End-to-end in a real browser**, against a local dev server with the flag forced on via `FEATURE_FLAG_GALLERY_LAZY_POST_IMAGES=public`: a 20-image post's card opened a modal with **20** indicators (was 6), arrow-key navigation reached index **19 of 20** with a real image rendered and no stranded loaders.

**Mutation-tested, not just green** — each new test was confirmed to fail legibly when its fix is reverted:

| Mutation | Failure |
|---|---|
| modal passes the raw seed through | `expected [1,2,3,4,5,6] to have a length of 20 but got 6` |
| descriptor dropped from `getState()` | `expected undefined to match object { postId: 100, … }` |
| owner-hidden list not applied to the tail | `expected 20 to be 19` — 4 failures across both suites |

**Suites:** typecheck 0 errors · `test:lint-rules` 24 files / 359 passed · full node unit suite 1514 files / **23,733 passed, 0 failed** · component suite 2182 passed, 3 failed — all `src/components/Apps/*` pixel-geometry, confirmed failing identically on a tree without this change.

## Rollout

Flipt `gallery-lazy-post-images` is at **threshold 0** right now (turned off when this bug was confirmed), so the lazy path is dark in production and this change is inert until it is re-ramped. Re-ramp after this deploys, per the ramp discipline in `feature-flags.service.ts` — threshold-only, small → wide.

Note the flag reads as off in two misleading places: `availability: []` in code and `enabled: false` + `Status: DISABLED` from the Flipt CLI. The threshold rollout is what actually decides it.
