### PR TITLE
fix(notifications): cosmetic-shop-item-sold recipients from recorded payouts

### DIFF
--- a/src/server/notifications/__tests__/cosmetic-shop-sold.notification.test.ts
+++ b/src/server/notifications/__tests__/cosmetic-shop-sold.notification.test.ts
@@ -35,6 +35,8 @@ describe('cosmetic-shop-item-sold recipient resolution', () => {
   it('keys the notification per recipient so one transaction fanning out to several owners does not collapse', () => {
     // send-notifications merges additions by `key` alone and shares one details
     // blob; without ownerId in the key, every seller but one loses their sale.
-    expect(query).toMatch(/CONCAT\('cosmetic-shop-item-sold:',\s*"buzzTransactionId",\s*':',\s*"ownerId"\)/);
+    expect(query).toMatch(
+      /CONCAT\('cosmetic-shop-item-sold:',\s*"buzzTransactionId",\s*':',\s*"ownerId"\)/
+    );
   });
 });

--- a/src/server/notifications/__tests__/cosmetic-shop-sold.notification.test.ts
+++ b/src/server/notifications/__tests__/cosmetic-shop-sold.notification.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { notificationProcessors } from '~/server/notifications/utils.notifications';
+
+// The processor's SQL is raw and never executed in unit tests, so these pin the
+// shape a revert would break. The defect (868kxcdrx) was that recipients came
+// from `si.meta->'paidToUserIds'`, unset on ~1,076 of 1,381 items, so
+// `jsonb_array_elements(NULL)` yielded no rows and ~18,000 sales notified no one.
+// The fix reads the authoritative payout record both purchase paths write.
+const query = notificationProcessors['cosmetic-shop-item-sold'].prepareQuery?.({
+  lastSent: '2026-01-01',
+  lastSentDate: new Date('2026-01-01'),
+  clickhouse: undefined,
+}) as string;
+
+describe('cosmetic-shop-item-sold recipient resolution', () => {
+  it('resolves recipients from the recorded payout, not the legacy paidToUserIds field', () => {
+    expect(query).toContain(`cp.meta->'payouts'`);
+    // The bug source is gone: reading it again would silence the same ~1,076 items.
+    expect(query).not.toContain('paidToUserIds');
+  });
+
+  it('sums the per-color split rows per owner so a recipient is notified once for their total', () => {
+    expect(query).toContain(`SUM((payout->>'amount')::int)`);
+    expect(query).toMatch(/GROUP BY[\s\S]*\(payout->>'userId'\)::int/);
+  });
+
+  it('normalizes a null/non-array payouts value to an empty array before expanding it', () => {
+    // The recurrence guard: jsonb_array_elements ERRORS on a scalar/object json and
+    // yields no rows on SQL NULL. Without this CASE a row whose meta.payouts is absent
+    // or malformed reintroduces the defect — either a silent no-notification or a
+    // throw that fails the whole cron batch.
+    expect(query).toMatch(/jsonb_typeof\(cp\.meta->'payouts'\)\s*=\s*'array'/);
+  });
+
+  it('keys the notification per recipient so one transaction fanning out to several owners does not collapse', () => {
+    // send-notifications merges additions by `key` alone and shares one details
+    // blob; without ownerId in the key, every seller but one loses their sale.
+    expect(query).toMatch(/CONCAT\('cosmetic-shop-item-sold:',\s*"buzzTransactionId",\s*':',\s*"ownerId"\)/);
+  });
+});

--- a/src/server/notifications/cosmetic-shop.notifications.ts
+++ b/src/server/notifications/cosmetic-shop.notifications.ts
@@ -137,25 +137,32 @@ export const cosmeticShopNotifications = createNotificationProcessor({
     }),
     prepareQuery: ({ lastSent }) => `
       WITH sold_items AS (
-        SELECT DISTINCT
+        SELECT
           cp."buzzTransactionId",
-          CAST(jsonb_array_elements(si.meta->'paidToUserIds') as INT) "ownerId",
-          JSONB_BUILD_OBJECT(
-            'shopItemTitle', si."title",
-            'buzzAmount', FLOOR(si."unitAmount" / jsonb_array_length(si.meta->'paidToUserIds')),
-			      'buyer', u.username
-          ) "details"
+          (payout->>'userId')::int "ownerId",
+          si."title" "shopItemTitle",
+          u.username "buyer",
+          SUM((payout->>'amount')::int) "buzzAmount"
         FROM "UserCosmeticShopPurchases" cp
         JOIN "CosmeticShopItem" si ON si.id = cp."shopItemId"
-		    LEFT JOIN "User" u ON u.id = cp."userId"
-        WHERE cp."purchasedAt" > '${lastSent}'::timestamp - INTERVAL '5 minutes' AND
-        cp."purchasedAt" <= NOW() - INTERVAL '5 minutes'
+        LEFT JOIN "User" u ON u.id = cp."userId"
+        CROSS JOIN LATERAL jsonb_array_elements(
+          CASE WHEN jsonb_typeof(cp.meta->'payouts') = 'array' THEN cp.meta->'payouts' ELSE '[]'::jsonb END
+        ) payout
+        WHERE cp."purchasedAt" > '${lastSent}'::timestamp - INTERVAL '5 minutes'
+          AND cp."purchasedAt" <= NOW() - INTERVAL '5 minutes'
+          AND (payout->>'amount')::int > 0
+        GROUP BY cp."buzzTransactionId", (payout->>'userId')::int, si."title", u.username
       )
       SELECT
-        CONCAT('cosmetic-shop-item-sold:',"buzzTransactionId") "key",
+        CONCAT('cosmetic-shop-item-sold:', "buzzTransactionId", ':', "ownerId") "key",
         "ownerId"    "userId",
         'cosmetic-shop-item-sold' "type",
-        details
+        JSONB_BUILD_OBJECT(
+          'shopItemTitle', "shopItemTitle",
+          'buzzAmount', "buzzAmount",
+          'buyer', "buyer"
+        ) "details"
       FROM sold_items
       -- One line: the polarity guard matches this clause as a literal.
       WHERE NOT EXISTS (SELECT 1 FROM "UserNotificationSettings" WHERE "userId" = sold_items."ownerId" AND type = 'cosmetic-shop-item-sold')


### PR DESCRIPTION
## Problem
`cosmetic-shop-item-sold` resolved its recipients from `si.meta->'paidToUserIds'`, a field left unset on the large majority of shop items. `jsonb_array_elements(NULL)` yields no rows, so those sales notified no one — sellers were paid but never told.

## Fix
Resolve recipients from the payout record both purchase paths actually write (`cp.meta->'payouts'`):
- sum the per-owner split rows so each owner is notified once for their total,
- normalize a null/non-array `payouts` to an empty array before expanding it (a scalar/object would otherwise throw and fail the whole cron batch),
- key the notification per recipient (`buzzTransactionId + ownerId`) so a transaction paying several owners notifies each instead of collapsing to one.

## Test
Adds a unit test pinning the query shape (recipient source, per-owner sum, null-guard, per-recipient key) so a revert fails legibly.

Refs: ClickUp 868kxcdrx
