### PR TITLE
fix(cosmetic-shop): creator keeps full payout when buying own item

### DIFF
--- a/src/server/services/__tests__/cosmetic-shop-payout.service.test.ts
+++ b/src/server/services/__tests__/cosmetic-shop-payout.service.test.ts
@@ -177,15 +177,13 @@ describe('purchaseCosmeticShopItem payouts', () => {
     );
   });
 
-  it('own-storefront purchase (shop enabled) pays the creator the full 70% pool: 7000', async () => {
-    mocks.userFindUnique.mockResolvedValue({ settings: { creatorShop: { enabled: true } } });
-
+  it('own-storefront purchase pays the creator the full 70% pool: 7000 (no shop-settings lookup)', async () => {
     await purchase(CREATOR_ID);
 
-    expect(mocks.userFindUnique).toHaveBeenCalledWith({
-      where: { id: CREATOR_ID },
-      select: { settings: true },
-    });
+    // The creator selling their own item is the full-pool case on its own —
+    // the shop's `enabled` flag is visibility, not a payout term — so there is
+    // no settings blob to consult.
+    expect(mocks.userFindUnique).not.toHaveBeenCalled();
     expect(sellCalls()).toEqual([
       expect.objectContaining({
         fromAccountId: 0,
@@ -196,13 +194,18 @@ describe('purchaseCosmeticShopItem payouts', () => {
     ]);
   });
 
-  it('spoofed own-shop claim (shop NOT enabled) pays the creator only their 50% cut: 5000', async () => {
+  // Regression guard for 868kxwtn3: a creator selling their own sellable item on
+  // their own storefront kept only ~50% because the payout gated the full pool on
+  // `creatorShop.enabled`. Own-store sales pay the full 70% pool regardless of
+  // that flag — there is no other creator reselling, so no seller share is
+  // diverted to the platform.
+  it('own-storefront purchase pays the full 70% pool even when the shop is not enabled: 7000', async () => {
     mocks.userFindUnique.mockResolvedValue({ settings: { creatorShop: { enabled: false } } });
 
     await purchase(CREATOR_ID);
 
     expect(sellCalls()).toEqual([
-      expect.objectContaining({ toAccountId: CREATOR_ID, amount: 5000 }),
+      expect.objectContaining({ toAccountId: CREATOR_ID, amount: 7000 }),
     ]);
   });
 

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -1139,14 +1139,16 @@ export const purchaseCosmeticShopItem = async ({
         // the kickback would be a self-discount.
         // Every purchase declares its shop context: CIVITAI_SHOP_ATTRIBUTION
         // (-1) = the official Civitai shop (platform acts as the reseller and
-        // keeps the seller share), a user id = that user's storefront. Positive
-        // attributions are verified against the shop owner's settings; anything
-        // unverified, missing, or spoofed falls back to the official-shop split
-        // so bad attribution can never dodge the platform's share.
+        // keeps the seller share), a user id = that user's storefront. A positive
+        // attribution to another creator only diverts a share when a resale
+        // listing backs it; anything unverified, missing, or spoofed falls back to
+        // the official-shop split so bad attribution can never dodge the platform's
+        // share.
         //
-        // Verified attributions that keep the creator on the full pool: their
-        // own open shop, and a buyer purchasing through their OWN resell
-        // listing (no kickback — the seller share would be a self-discount).
+        // Attributions that keep the creator on the full pool: their own
+        // storefront (their own item, no reseller to pay), and a buyer purchasing
+        // through their OWN resell listing (no kickback — the seller share would
+        // be a self-discount).
         let resellerId: number | undefined;
         let creatorKeepsPool = false;
         // A reseller is paid the share recorded on their listing, not the item's
@@ -1157,13 +1159,11 @@ export const purchaseCosmeticShopItem = async ({
         let payoutShare = meta?.sellerShare ?? 0;
         if (creatorId && viaShopUserId && viaShopUserId > 0) {
           if (viaShopUserId === creatorId) {
-            const viaUser = await dbRead.user.findUnique({
-              where: { id: viaShopUserId },
-              select: { settings: true },
-            });
-            const viaShop = (viaUser?.settings as { creatorShop?: { enabled?: boolean } } | null)
-              ?.creatorShop;
-            creatorKeepsPool = viaShop?.enabled === true;
+            // A creator selling their own item on their own storefront keeps the
+            // full 70% pool by default — there is no other creator reselling, so
+            // no seller share is diverted (the shop's `enabled` flag is a
+            // visibility setting, not a payout term).
+            creatorKeepsPool = true;
           } else if (resaleListing) {
             payoutShare = resaleListing.sellerShare;
             if (viaShopUserId === userId) creatorKeepsPool = true;


### PR DESCRIPTION
When a creator purchased their own cosmetic shop item from their own
storefront, the payout incorrectly applied the resale split (~50%)
instead of the creator's full pool share (70%).

Root cause: The payout logic gated the full-pool payment on the
`creatorShop.enabled` setting, conflating shop visibility with payout
terms. When a creator sells their own item with no reseller involved,
they keep the full creator pool regardless of visibility state.

Fix: Remove the shop-settings lookup and always set `creatorKeepsPool = true`
when `viaShopUserId === creatorId`.

Test: Add regression guard for purchases when shop visibility is disabled,
and remove the now-unnecessary settings mock.

Refs: 868kxwtn3