### PR TITLE
fix(cosmetic-packs): enforce creator consent for resale

### DIFF
--- a/src/server/__tests__/cosmetic-pack-purchase.test.ts
+++ b/src/server/__tests__/cosmetic-pack-purchase.test.ts
@@ -180,10 +180,38 @@ describe('computePackPayouts', () => {
     expect(total).toBeLessThanOrEqual(Math.floor(PACK_PRICE * 0.7));
   });
 
-  it('splits a foreign members pool with its own reseller rather than the pack creator', () => {
+  it('pays the pack creator a seller share out of a foreign member they resell', () => {
     const { components } = computePackPayouts({
       packPrice: PACK_PRICE,
       packCreatorId: PACK_CREATOR,
+      members: [foreign()],
+      // The pack creator resells cosmetic 62 at a snapshotted 20%.
+      resaleShareByCosmeticId: new Map([[62, 20]]),
+    });
+    const seller = components.find((c) => c.userId === PACK_CREATOR);
+    const creator = components.find((c) => c.userId === FOREIGN_CREATOR);
+    expect(seller?.amount).toBe(Math.floor(2100 * 0.2));
+    expect(creator?.amount).toBe(Math.floor(2100 * 0.7) - Math.floor(2100 * 0.2));
+  });
+
+  it('reads the seller share from the resale snapshot, not the members current listing', () => {
+    const { components } = computePackPayouts({
+      packPrice: PACK_PRICE,
+      packCreatorId: PACK_CREATOR,
+      // Current listing offers 50%; the pack creator listed it for resale at 20%.
+      members: [foreign({ listingMeta: { purchases: 0, acceptsBlueBuzz: true, sellerShare: 50 } })],
+      resaleShareByCosmeticId: new Map([[62, 20]]),
+    });
+    const seller = components.find((c) => c.userId === PACK_CREATOR);
+    expect(seller?.amount).toBe(Math.floor(2100 * 0.2));
+  });
+
+  it('pays the foreign creator the whole pool when the pack creator does not resell it', () => {
+    const { components } = computePackPayouts({
+      packPrice: PACK_PRICE,
+      packCreatorId: PACK_CREATOR,
+      // A listing added by someone other than its creator is NOT a reseller —
+      // resale is by reference, so only a resale row grants a share.
       members: [
         foreign({
           addedById: RESELLER,
@@ -191,10 +219,8 @@ describe('computePackPayouts', () => {
         }),
       ],
     });
-    const seller = components.find((c) => c.userId === RESELLER);
-    const creator = components.find((c) => c.userId === FOREIGN_CREATOR);
-    expect(seller?.amount).toBe(Math.floor(2100 * 0.2));
-    expect(creator?.amount).toBe(Math.floor(2100 * 0.7) - Math.floor(2100 * 0.2));
+    expect(components.map((c) => c.userId)).toEqual([FOREIGN_CREATOR]);
+    expect(components[0]?.amount).toBe(Math.floor(2100 * 0.7));
   });
 
   it('does not pay the pack creator twice for their own members', () => {

--- a/src/server/__tests__/creator-shop-pack.test.ts
+++ b/src/server/__tests__/creator-shop-pack.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import {
+  assertMembersResellable,
+  isBundlableBy,
+} from '~/server/services/creator-shop-pack.service';
 import { cosmeticShopItemMeta } from '~/server/schema/cosmetic-shop.schema';
 import {
   computePackOwnershipDiscount,
@@ -197,6 +201,54 @@ describe('submitCreatorShopPackSchema', () => {
   it('defaults blue Buzz to off, since it is granted only if every member accepts', () => {
     const result = submitCreatorShopPackSchema.parse(valid);
     expect(result.acceptsBlueBuzz).toBe(false);
+  });
+});
+
+describe('pack member resale consent', () => {
+  const OWNER = 700;
+  const OTHER = 701;
+  const resolved = (over: { createdById: number; sellableByOthers: boolean; name?: string }) =>
+    ({ name: 'Item', ...over } as Parameters<typeof assertMembersResellable>[0][number]);
+
+  it('lets a creator bundle their own work regardless of the resale flag', () => {
+    expect(isBundlableBy({ createdById: OWNER, sellableByOthers: false }, OWNER)).toBe(true);
+  });
+
+  it('lets a creator bundle another creator item that opted into resale', () => {
+    expect(isBundlableBy({ createdById: OTHER, sellableByOthers: true }, OWNER)).toBe(true);
+  });
+
+  it('refuses another creator item that did not opt into resale', () => {
+    expect(isBundlableBy({ createdById: OTHER, sellableByOthers: false }, OWNER)).toBe(false);
+  });
+
+  it('exempts a platform item with no creator, like the official shop does', () => {
+    expect(isBundlableBy({ createdById: null, sellableByOthers: false }, OWNER)).toBe(true);
+  });
+
+  it('names the forbidden members it rejects', () => {
+    expect(() =>
+      assertMembersResellable(
+        [
+          resolved({ createdById: OWNER, sellableByOthers: false, name: 'Mine' }),
+          resolved({ createdById: OTHER, sellableByOthers: false, name: 'Off Limits' }),
+          resolved({ createdById: OTHER, sellableByOthers: true, name: 'Sellable' }),
+        ],
+        OWNER
+      )
+    ).toThrow(/Off Limits/);
+  });
+
+  it('passes a pack of only own and resale-enabled members', () => {
+    expect(() =>
+      assertMembersResellable(
+        [
+          resolved({ createdById: OWNER, sellableByOthers: false }),
+          resolved({ createdById: OTHER, sellableByOthers: true }),
+        ],
+        OWNER
+      )
+    ).not.toThrow();
   });
 });
 

--- a/src/server/__tests__/pack-detail-agreement.test.ts
+++ b/src/server/__tests__/pack-detail-agreement.test.ts
@@ -28,6 +28,7 @@ vi.mock('~/server/db/client', () => ({
     cosmeticShopItemCosmetic: { findMany: (...a: unknown[]) => packMemberFindMany(...a) },
     userCosmeticShopPurchaseCosmetic: { groupBy: (...a: unknown[]) => componentGroupBy(...a) },
     userCosmetic: { findMany: (...a: unknown[]) => ownedFindMany(...a) },
+    userCosmeticShopItemResale: { findMany: vi.fn().mockResolvedValue([]) },
   },
   dbWrite: {
     userCosmetic: { findMany: (...a: unknown[]) => ownedFindMany(...a) },

--- a/src/server/routers/creator-shop.router.ts
+++ b/src/server/routers/creator-shop.router.ts
@@ -129,6 +129,7 @@ export const creatorShopRouter = router({
     .query(({ input, ctx }) =>
       getBundlableCosmetics({
         ...input,
+        userId: ctx.user.id,
         // Stickers stay out of the picker while the flag is off; the submit
         // mutation refuses them regardless.
         types: ctx.features.stickers

--- a/src/server/services/cosmetic-pack.service.ts
+++ b/src/server/services/cosmetic-pack.service.ts
@@ -290,12 +290,20 @@ export const computePackPayouts = ({
   packCreatorId,
   members,
   buyerId,
+  resaleShareByCosmeticId,
 }: {
   /** What the buyer was actually charged, after any ownership discount. */
   packPrice: number;
   packCreatorId: number | null;
   members: PackMemberListing[];
   buyerId?: number;
+  /**
+   * cosmeticId → the seller share the pack creator snapshotted when they listed
+   * that member for resale (`UserCosmeticShopItemResale`). Present only for
+   * members the pack creator actually resells; the pack creator is then this
+   * member's reseller, paid out of the member's own pool.
+   */
+  resaleShareByCosmeticId?: Map<number, number>;
 }) => {
   const components: { cosmeticId: number; userId: number; amount: number; unitAmount: number }[] =
     [];
@@ -327,19 +335,20 @@ export const computePackPayouts = ({
     const basis = scale === 1 ? member.floorAmount : Math.floor(member.floorAmount * scale);
     if (basis <= 0) continue;
     foreignTotal += basis;
+    // A member is resold by the pack creator only when a resale row exists for
+    // it — resale is by reference (`UserCosmeticShopItemResale`), so the
+    // member's own listing is always its creator's and its `addedById` never
+    // names a reseller. The share comes from that snapshot, not the member's
+    // current listing: the creator can cut it, or withdraw resale, long after
+    // the pack was built on the terms they offered. The buyer can't be the
+    // reseller here — a creator can't buy their own pack.
+    const resaleShare = resaleShareByCosmeticId?.get(member.cosmeticId);
+    const isReseller = resaleShare !== undefined && packCreatorId != null;
     const { creatorPool, sellerAmount, creatorAmount } = computeCreatorShopSplit(
       basis,
-      member.listingMeta.sellerShare ?? 0
+      isReseller ? resaleShare : 0
     );
-    // The member's own reseller, if it has one, is paid out of that member's
-    // pool rather than the pack creator's — unless the reseller is the buyer,
-    // in which case the seller share would be a discount they fund for
-    // themselves. The single purchase refuses this in as many words; a pack
-    // reaches the same state through a member and needs the same answer.
-    const resellerId =
-      member.addedById && member.addedById !== member.createdById && member.addedById !== buyerId
-        ? member.addedById
-        : null;
+    const resellerId = isReseller ? packCreatorId : null;
     if (resellerId && sellerAmount > 0) {
       if (creatorAmount > 0)
         components.push({
@@ -372,6 +381,35 @@ export const computePackPayouts = ({
     packCreatorId && packCreatorId !== buyerId ? computeCreatorShopSplit(remainder).creatorPool : 0;
 
   return { components, foreignTotal, remainder, packCreatorAmount, scaled: scale !== 1 };
+};
+
+/**
+ * cosmeticId → the pack creator's snapshotted seller share, for the foreign
+ * members they resell. Keyed on the member's own listing (`listingId`), which is
+ * the creator listing a resale row references. Empty when the pack creator
+ * resells none of the members, which is the common case.
+ */
+export const packOwnerResaleShares = async (
+  packCreatorId: number | null,
+  members: PackMemberListing[]
+): Promise<Map<number, number>> => {
+  const shares = new Map<number, number>();
+  if (!packCreatorId) return shares;
+  const foreign = members.filter((m) => m.createdById !== packCreatorId);
+  if (!foreign.length) return shares;
+
+  const resales = await dbRead.userCosmeticShopItemResale.findMany({
+    where: { userId: packCreatorId, shopItemId: { in: foreign.map((m) => m.listingId) } },
+    select: { shopItemId: true, sellerShare: true },
+  });
+  if (!resales.length) return shares;
+
+  const shareByListing = new Map(resales.map((r) => [r.shopItemId, r.sellerShare]));
+  for (const member of foreign) {
+    const share = shareByListing.get(member.listingId);
+    if (share !== undefined) shares.set(member.cosmeticId, share);
+  }
+  return shares;
 };
 
 export const purchaseCosmeticPack = async ({
@@ -467,6 +505,10 @@ export const purchaseCosmeticPack = async ({
     .filter((t) => t.accountType === 'blue')
     .reduce((sum, t) => sum + t.amount, 0);
 
+  // Loaded once, before the write, and reused by both payout computations so the
+  // attribution written in the transaction and the payout after it agree.
+  const resaleShareByCosmeticId = await packOwnerResaleShares(shopItem.addedById, members);
+
   try {
     await dbWrite.$transaction(async (tx) => {
       await tx.userCosmeticShopPurchases.create({
@@ -485,6 +527,7 @@ export const purchaseCosmeticPack = async ({
         packCreatorId: shopItem.addedById,
         members,
         buyerId: userId,
+        resaleShareByCosmeticId,
       });
       const attributedByCosmetic = new Map<number, number>();
       for (const member of members) attributedByCosmetic.set(member.cosmeticId, member.floorAmount);
@@ -551,6 +594,7 @@ export const purchaseCosmeticPack = async ({
         packCreatorId: shopItem.addedById,
         members,
         buyerId: userId,
+        resaleShareByCosmeticId,
       });
       // Reaching this means a pack sold for less than its members' snapshots,
       // which the floor and the re-snapshot both exist to prevent. Everyone is

--- a/src/server/services/creator-shop-pack.service.ts
+++ b/src/server/services/creator-shop-pack.service.ts
@@ -31,6 +31,8 @@ type ResolvedMember = PackMemberPricing & {
   createdById: number | null;
   creatorUsername: string | null;
   acceptsBlueBuzz: boolean;
+  /** The resolved listing's resale opt-in — see `isBundlableBy`. */
+  sellableByOthers: boolean;
 };
 
 /**
@@ -85,6 +87,7 @@ export const resolvePackMembers = async (cosmeticIds: number[]): Promise<Resolve
       createdById: listing.cosmetic.createdById,
       creatorUsername: listing.cosmetic.creator?.username ?? null,
       acceptsBlueBuzz: !!meta.acceptsBlueBuzz,
+      sellableByOthers: !!meta.sellableByOthers,
     };
     if (!existing || candidate.listPrice > existing.listPrice)
       byCosmetic.set(listing.cosmeticId, {
@@ -121,6 +124,34 @@ const assertStickerMembersAllowed = (members: ResolvedMember[], stickersEnabled?
   if (stickersEnabled) return;
   if (members.some((m) => m.type === CosmeticType.Sticker))
     throw throwBadRequestError('Stickers cannot be bundled yet');
+};
+
+/**
+ * Who may bundle a member. A creator bundles their own work freely; another
+ * creator's only when its listing opted into resale (`sellableByOthers`) — the
+ * same consent the official shop enforces in `upsertCosmeticShopSection`. A pack
+ * is somebody else selling the item, so an opt-out has to block it here too.
+ *
+ * A member with no creator is a platform cosmetic, which the resale-consent rule
+ * doesn't govern — the official shop scopes its check to `createdById != null`
+ * for the same reason, so this stays in step with it. `resolvePackMembers`
+ * already restricts to Published, non-archived listings, so those guards aren't
+ * repeated here.
+ */
+export const isBundlableBy = (
+  member: { createdById: number | null; sellableByOthers: boolean },
+  ownerId: number
+) => member.createdById == null || member.createdById === ownerId || member.sellableByOthers;
+
+/** Refuses members whose creator has not allowed others to sell them. */
+export const assertMembersResellable = (members: ResolvedMember[], ownerId: number) => {
+  const forbidden = members.filter((m) => !isBundlableBy(m, ownerId));
+  if (forbidden.length)
+    throw throwBadRequestError(
+      `These items can't be bundled — their creator hasn't allowed other creators to sell them: ${forbidden
+        .map((m) => m.name)
+        .join(', ')}`
+    );
 };
 
 const withOwnership = (members: ResolvedMember[], userId: number) =>
@@ -167,6 +198,7 @@ export const submitCreatorShopPack = async ({
 
   const members = withOwnership(await resolvePackMembers(memberCosmeticIds), userId);
   assertMembersBundlable(memberCosmeticIds, members);
+  assertMembersResellable(members, userId);
   assertStickerMembersAllowed(members, stickersEnabled);
 
   const floor = packPriceFloor(members);
@@ -290,8 +322,10 @@ export const updateCreatorShopPack = async ({
   const memberIds = memberCosmeticIds ?? existing.members.map((m) => m.cosmeticId);
   // Re-resolved even when the contents didn't change: the price floor has to be
   // checked against today's list prices, not the ones the pack was built against.
-  const members = withOwnership(await resolvePackMembers(memberIds), existing.addedById ?? userId);
+  const packOwnerId = existing.addedById ?? userId;
+  const members = withOwnership(await resolvePackMembers(memberIds), packOwnerId);
   assertMembersBundlable(memberIds, members);
+  assertMembersResellable(members, packOwnerId);
   assertStickerMembersAllowed(members, stickersEnabled);
 
   const nextPrice = price ?? existing.unitAmount;
@@ -506,12 +540,19 @@ export const getPackDetail = async ({
   };
 };
 
-/** Cosmetics this creator may bundle: anything with a Published listing. */
+/**
+ * Cosmetics this creator may bundle: their own work, plus other creators' items
+ * whose listing opted into resale. Anything a creator placed off limits
+ * (`sellableByOthers` false) is never offered, so the composer can't stage a
+ * member the save would refuse — see `isBundlableBy`.
+ */
 export const getBundlableCosmetics = async ({
+  userId,
   query,
   limit = 50,
   types,
 }: {
+  userId: number;
   query?: string;
   limit?: number;
   types?: CosmeticType[];
@@ -537,6 +578,10 @@ export const getBundlableCosmetics = async ({
     take: limit * 2,
     select: { cosmeticId: true },
   });
-  const cosmeticIds = [...new Set(listings.map((l) => l.cosmeticId as number))].slice(0, limit);
-  return resolvePackMembers(cosmeticIds);
+  // Filter after resolving, on the same highest-priced listing the composer and
+  // payout price against: a cosmetic listed both sellable and not must be judged
+  // by the listing the pack would actually use, not by whichever row matched.
+  const cosmeticIds = [...new Set(listings.map((l) => l.cosmeticId as number))];
+  const resolved = await resolvePackMembers(cosmeticIds);
+  return resolved.filter((m) => isBundlableBy(m, userId)).slice(0, limit);
 };


### PR DESCRIPTION
Cosmetic packs were not validating the `sellableByOthers` permission, allowing
pack creators to resell items whose creators had disabled resale.

The permission is a creator's explicit opt-in for others to sell their work.
Since a pack is someone else selling the item, the consent must be enforced
both when composing packs (don't offer forbidden items) and when submitting
them (refuse members the creator placed off-limits).

Also fix payout logic to use snapshotted resale shares (`UserCosmeticShopItemResale`)
instead of current listing terms, so buyers pay per the pack creator's offered
terms at pack creation time, not current listing prices. Only explicit resale
rows grant the pack creator a reseller share—implicit `addedById` detection is
removed.

Refs: 868kxw1r7
