### PR TITLE
feat(app-blocks): read-only chat-tool surface backed by the clamped catalog path (#398 AC5)

### DIFF
--- a/src/pages/api/v1/blocks/tools.ts
+++ b/src/pages/api/v1/blocks/tools.ts
@@ -20,9 +20,11 @@ import {
   blockToolDeclarations,
   boundToolResult,
   getBlockTool,
+  neutralizeAirLiterals,
   projectModelForTool,
   MAX_TOOL_RESULT_ITEMS,
 } from '~/server/services/blocks/tools/registry';
+import { TOOL_NAME_PATTERN } from '~/server/services/blocks/steps/chat-completion.step';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { constants } from '~/server/common/constants';
 
@@ -74,7 +76,19 @@ export const config = { api: { bodyParser: { sizeLimit: '8kb' } } };
  */
 const callSchema = z
   .object({
-    name: z.string().min(1).max(64),
+    // 🔴 PATTERN-BOUNDED AT THE WIRE, and not merely for tidiness. Both 400
+    // bodies below REFLECT this value back to the caller, and the caller is an
+    // untrusted sandboxed iframe that will hand our reply to a chat model as a
+    // `role:'tool'` message. `containsAirReference` (the chat step's entitlement
+    // guard) throws FORBIDDEN on the literal `urn:air:` ANYWHERE in a submitted
+    // step input — so an unbounded `name` lets a caller compose a 400 body it can
+    // never replay, with no diagnostic explaining why. The pattern makes the
+    // reflection structurally inert instead of relying on the scrub below.
+    //
+    // Same pattern the chat step enforces on a declared tool name, IMPORTED
+    // rather than re-spelled: `registry.ts` already documented the coupling in
+    // prose, and a second copy is how the two drift.
+    name: z.string().min(1).max(64).regex(TOOL_NAME_PATTERN),
     arguments: z.unknown().optional(),
   })
   .strict();
@@ -84,8 +98,16 @@ const DEFAULT_LIMIT = 5;
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   const claims = (req as BlockScopedNextApiRequest).blockClaims;
   if (!claims) {
-    // withBlockScope only invokes this handler with a valid block JWT; defense
-    // in depth, mirroring blocks/models.ts.
+    // 🔴 THIS IS THE GATE, NOT A BACKSTOP — the previous comment here said
+    // "defense in depth", and that was wrong in the direction that matters.
+    // `withBlockScope` does NOT reject and return on its own in two cases: when
+    // no bearer token is present, and when the `app-blocks-runtime-enabled`
+    // flag is off. In BOTH it FALLS THROUGH to the wrapped handler with
+    // `blockClaims` unset. So deleting these five lines does not lose a
+    // redundant check — it serves the tool declarations unauthenticated.
+    //
+    // Pinned by its own test; a mutant that removes it previously survived the
+    // whole suite, which is why the comment is now explicit about what it holds.
     res.status(401).json({ error: 'Block token required' });
     return;
   }
@@ -103,7 +125,16 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
   const parsed = callSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    // 🔴 `.message`, NOT the ZodError object. Measured: `JSON.stringify({error:
+    // zodError})` emits `{"name":"ZodError","message":"[…issues…]"}`, and those
+    // issues echo the caller's own keys verbatim (`"keys":["<their key>"]`). That
+    // is caller input rather than server internals — no Prisma table/column, no pg
+    // row value — so it is not the disclosure the ledger is named for. It is still
+    // an error OBJECT on the wire, and the scrub below is what makes the echo safe
+    // to replay rather than the shape being harmless.
+    res.status(400).json({
+      error: neutralizeAirLiterals(`invalid request body: ${parsed.error.message}`),
+    });
     return;
   }
 
@@ -113,6 +144,10 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   // inherited value.
   const tool = getBlockTool(parsed.data.name);
   if (!tool) {
+    // Not scrubbed, and it does not need to be: `name` cleared
+    // `TOOL_NAME_PATTERN` above, which admits no `:` and therefore cannot carry
+    // `urn:air:`. The scrub on the two bodies that CAN echo free text is what
+    // does the work; adding one here would imply this reflection is unbounded.
     res.status(400).json({
       error: `unknown tool '${parsed.data.name}'`,
     });
@@ -124,8 +159,14 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   // contract this route does not enforce.
   const args = tool.argsSchema.safeParse(parsed.data.arguments ?? {});
   if (!args.success) {
+    // SCRUBBED: unlike `name`, an argument value is free text (`query`), and zod
+    // echoes offending values and unrecognized keys into `.message`. A caller
+    // that sends `query: "urn:air:…"` would otherwise get a 400 body it cannot
+    // replay as a `role:'tool'` message.
     res.status(400).json({
-      error: `invalid arguments for tool '${tool.name}': ${args.error.message}`,
+      error: neutralizeAirLiterals(
+        `invalid arguments for tool '${tool.name}': ${args.error.message}`
+      ),
     });
     return;
   }
@@ -168,7 +209,21 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       } catch (e) {
         if (e instanceof ModelSearchMeiliTimeoutError) {
           res.setHeader('Retry-After', '2');
-          res.status(503).json({ error: e.message });
+          // 🔴 A LITERAL, NOT `e.message`, AND THAT IS THE POINT — CI caught the
+          // difference. `rest-error-envelope-ledger` flags `{ error: <ident>.message }`
+          // as a class, because the shape is indistinguishable from serving a
+          // DRIVER-authored message (a Prisma error carries table + column; a pg
+          // 23505 carries the offending ROW VALUE). Here the value happens to be
+          // our own first-party string, so this was over-reporting rather than a
+          // live disclosure — but the ledger's own docstring says the remedy for
+          // that is a baseline entry, and a brand-new route does not belong in a
+          // list of PRE-EXISTING unfixed offenders. Writing the string here costs
+          // nothing, removes the offence instead of recording it, and cannot
+          // drift if `ModelSearchMeiliTimeoutError`'s text changes.
+          //
+          // `blocks/models.ts` has the identical `e.message` line and IS
+          // baselined. Do not copy it back.
+          res.status(503).json({ error: 'Model search is temporarily overloaded — please retry.' });
           return;
         }
         throw e;

--- a/src/pages/api/v1/blocks/tools.ts
+++ b/src/pages/api/v1/blocks/tools.ts
@@ -88,6 +88,16 @@ const callSchema = z
     // Same pattern the chat step enforces on a declared tool name, IMPORTED
     // rather than re-spelled: `registry.ts` already documented the coupling in
     // prose, and a second copy is how the two drift.
+    //
+    // ⚠️ THE LENGTH BOUND IS STILL A SECOND COPY — the same class this line's
+    // `.regex` just closed, one axis over. `64` here is the chat step's
+    // `MAX_TOOL_NAME_CHARS` (`~/server/services/blocks/steps/chat-completion.step`),
+    // which is module-private, so it cannot be imported today and the two agree
+    // only by inspection. Nothing is broken: the values match, and a drift would
+    // narrow or widen only what this wire accepts before the registry lookup
+    // rejects an unknown name anyway. Closing it means EXPORTING that constant —
+    // a source change to a file merged in #4472 — so it is left deliberate and
+    // named rather than done as a drive-by here.
     name: z.string().min(1).max(64).regex(TOOL_NAME_PATTERN),
     arguments: z.unknown().optional(),
   })
@@ -104,7 +114,13 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     // redundant check, it serves the tool declarations unauthenticated:
     //
     //   1. no bearer token present;
-    //   2. a bearer that is NOT a 3-part JWS — the legacy opaque API-key path.
+    //   2. a bearer `isBlockJwt` rejects. READ THAT FUNCTION, it is wider than
+    //      "not a 3-part JWS": it returns false for anything that is not three
+    //      NON-EMPTY dot-separated segments, for a header that fails to
+    //      base64url-decode or JSON.parse, AND for a decodable header whose
+    //      `alg` is not `RS256` or whose `typ` is not `JWT`. So a well-formed
+    //      JWS signed with the wrong alg falls through here too — the legacy
+    //      opaque API-key path is one instance of this case, not its definition.
     //      (1) and (2) are one branch, `if (!bearer || !isBlockJwt(bearer))`,
     //      which is why they are easy to count as one;
     //   3. `app-blocks-runtime-enabled` off — including absent, and Flipt down,

--- a/src/pages/api/v1/blocks/tools.ts
+++ b/src/pages/api/v1/blocks/tools.ts
@@ -98,16 +98,26 @@ const DEFAULT_LIMIT = 5;
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   const claims = (req as BlockScopedNextApiRequest).blockClaims;
   if (!claims) {
-    // 🔴 THIS IS THE GATE, NOT A BACKSTOP — the previous comment here said
-    // "defense in depth", and that was wrong in the direction that matters.
-    // `withBlockScope` does NOT reject and return on its own in two cases: when
-    // no bearer token is present, and when the `app-blocks-runtime-enabled`
-    // flag is off. In BOTH it FALLS THROUGH to the wrapped handler with
-    // `blockClaims` unset. So deleting these five lines does not lose a
-    // redundant check — it serves the tool declarations unauthenticated.
+    // 🔴 THIS IS THE GATE, NOT A BACKSTOP. `withBlockScope` does NOT reject and
+    // return on its own in THREE cases — in each it FALLS THROUGH to the wrapped
+    // handler with `blockClaims` unset, so deleting these lines does not lose a
+    // redundant check, it serves the tool declarations unauthenticated:
+    //
+    //   1. no bearer token present;
+    //   2. a bearer that is NOT a 3-part JWS — the legacy opaque API-key path.
+    //      (1) and (2) are one branch, `if (!bearer || !isBlockJwt(bearer))`,
+    //      which is why they are easy to count as one;
+    //   3. `app-blocks-runtime-enabled` off — including absent, and Flipt down,
+    //      which the middleware resolves as false by design.
+    //
+    // 🔴 COUNT THEM IN THE MIDDLEWARE, NOT HERE. This comment has now been wrong
+    // TWICE about this same gate: first calling it "defense in depth", then
+    // naming two of the three fall-throughs. Both times the error was restating
+    // a remembered shape instead of reading `withBlockScope`. If you touch this,
+    // go read the branches.
     //
     // Pinned by its own test; a mutant that removes it previously survived the
-    // whole suite, which is why the comment is now explicit about what it holds.
+    // whole suite, which is why the comment is explicit about what it holds.
     res.status(401).json({ error: 'Block token required' });
     return;
   }

--- a/src/pages/api/v1/blocks/tools.ts
+++ b/src/pages/api/v1/blocks/tools.ts
@@ -1,0 +1,229 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import * as z from 'zod';
+
+import {
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { getNextPage } from '~/server/utils/pagination-helpers';
+import {
+  ModelSearchMeiliTimeoutError,
+  resolveModelSearchIds,
+  runModelSearch,
+} from '~/server/services/model-search.service';
+import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
+import {
+  blockToolDeclarations,
+  boundToolResult,
+  getBlockTool,
+  projectModelForTool,
+  MAX_TOOL_RESULT_ITEMS,
+} from '~/server/services/blocks/tools/registry';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+import { constants } from '~/server/common/constants';
+
+/**
+ * App Blocks TOOL SURFACE (#398 AC5).
+ *
+ *   GET  /api/v1/blocks/tools   → the read-only tool definitions a block may
+ *                                 declare to a chat model.
+ *   POST /api/v1/blocks/tools   → body `{ name, arguments }`; executes one
+ *                                 registered tool and returns a projected result.
+ *
+ * Auth: ANY valid block token, no required scope — identical reasoning to
+ * `blocks/models.ts`, which this endpoint is a thin, model-shaped view of. The
+ * data is public, maturity-clamped catalog content; the token is required for
+ * its signed `maxBrowsingLevel` claim, not for authorization.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 THE CLAMP IS APPLIED HERE, IN THIS HANDLER. It is NOT inherited from the
+ * `/api/v1/blocks/*` prefix.
+ *
+ * `withBlockScope` gives this route the JWT gate, revocation, `private,
+ * no-store`, the opaque-origin CORS and the audit row. It does NOT give it the
+ * maturity clamp — `blocks/models.ts` states this in its own words, that
+ * `resolveCatalogBrowsingLevel` "remains the whole authority surface". A route
+ * added under this prefix that forgets the call is UNCLAMPED while looking
+ * exactly as protected as its neighbours, and nothing in the wrapper would say
+ * so. That is the single most important line in this file, and it is why the
+ * suite asserts the clamped level reaches `runModelSearch` with a positive
+ * control rather than merely asserting a 200.
+ *
+ * 🔴 WHY THIS IS NOT AN MCP PROXY. `mcp.civitai.com` exposes the same catalog
+ * search, and proxying it would look like less work. Measured: its
+ * `search_models` takes no maturity parameter and is `additionalProperties:
+ * false`, so the viewer's ceiling cannot be passed IN; and its results carry
+ * only `air`/`id`/`name`/`type`, with no maturity metadata, so the ceiling
+ * cannot be applied to what comes BACK either. Combined with the clamp not
+ * riding on the prefix, a proxy under this path would be an unclamped catalog
+ * read. The full reasoning lives in
+ * `~/server/services/blocks/tools/registry`'s header.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+export const config = { api: { bodyParser: { sizeLimit: '8kb' } } };
+
+/**
+ * The wire body. `arguments` is deliberately `unknown` here: the per-tool schema
+ * in the registry is the real contract, and validating it twice — once loosely
+ * at the wire and once strictly per tool — is how the two drift.
+ */
+const callSchema = z
+  .object({
+    name: z.string().min(1).max(64),
+    arguments: z.unknown().optional(),
+  })
+  .strict();
+
+const DEFAULT_LIMIT = 5;
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    // withBlockScope only invokes this handler with a valid block JWT; defense
+    // in depth, mirroring blocks/models.ts.
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  // ── GET: the declarations. Cheap, no catalog access, no rate limit needed.
+  if (req.method === 'GET') {
+    res.status(200).json({ tools: blockToolDeclarations() });
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const parsed = callSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+
+  // ── THE ALLOWLIST. An unregistered name never reaches a handler. `getBlockTool`
+  // reads a null-prototype map, so a prototype key (`toString`, `constructor`)
+  // returns undefined and is rejected here rather than resolving to a truthy
+  // inherited value.
+  const tool = getBlockTool(parsed.data.name);
+  if (!tool) {
+    res.status(400).json({
+      error: `unknown tool '${parsed.data.name}'`,
+    });
+    return;
+  }
+
+  // ── PER-TOOL ARGUMENT CONTRACT, strict. This is the SAME schema the served
+  // declaration's `parameters` is derived from, so the model cannot be shown a
+  // contract this route does not enforce.
+  const args = tool.argsSchema.safeParse(parsed.data.arguments ?? {});
+  if (!args.success) {
+    res.status(400).json({
+      error: `invalid arguments for tool '${tool.name}': ${args.error.message}`,
+    });
+    return;
+  }
+
+  // Per-token rate limit, keyed on the stable blockInstanceId — same limiter the
+  // catalog endpoint uses, and shared with it deliberately: a block cannot get a
+  // second catalog budget by calling the same search through the tool surface.
+  // Runs BEFORE the expensive search.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+    return;
+  }
+
+  // 🔴 AUTHORITATIVE CLAMP — see the header. Never the client's; the tool
+  // argument schema does not even carry a maturity field to ignore.
+  const regionRestricted = isRegionRestricted(getRegion(req));
+  const { browsingLevel, isSfwCeiling } = resolveCatalogBrowsingLevel(claims, { regionRestricted });
+
+  try {
+    if (tool.name === 'search_models') {
+      const { query, type, limit } = args.data as {
+        query: string;
+        type?: string;
+        limit?: number;
+      };
+      const effectiveLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_TOOL_RESULT_ITEMS);
+      const types = type ? [type] : undefined;
+
+      let searchIds: number[] = [];
+      try {
+        const meili = await resolveModelSearchIds({
+          query,
+          limit: effectiveLimit,
+          browsingLevel,
+          types,
+        });
+        searchIds = meili.searchIds;
+      } catch (e) {
+        if (e instanceof ModelSearchMeiliTimeoutError) {
+          res.setHeader('Retry-After', '2');
+          res.status(503).json({ error: e.message });
+          return;
+        }
+        throw e;
+      }
+
+      const baseUrlOrigin = getNextPage({ req }).baseUrl.origin;
+      const { items } = await runModelSearch(
+        {
+          types: types as never,
+          sort: constants.modelFilterDefaults.sort as never,
+          period: MetricTimeframe.AllTime,
+          limit: effectiveLimit,
+          query,
+          searchIds,
+          // Same strictness as the catalog endpoint: blocks stay strict on both
+          // the minor and the maturity axis.
+          disableMinor: true,
+        },
+        {
+          // CLAMPED — never the client's, and no passthrough that could widen it.
+          browsingLevel,
+          nsfwImagePassthrough: false,
+          user: undefined,
+          baseUrlOrigin,
+        }
+      );
+
+      const projected = items
+        .map((item) => projectModelForTool(item))
+        .filter((m): m is NonNullable<typeof m> => m !== null);
+      const bounded = boundToolResult(projected);
+
+      res.status(200).json({
+        tool: tool.name,
+        result: bounded,
+        // Advisory, exactly as the catalog endpoint echoes it — the clamp itself
+        // is authoritative and already applied.
+        maturity: { browsingLevel, sfwOnly: isSfwCeiling },
+      });
+      return;
+    }
+
+    // Unreachable while the registry has one entry, and a compile-visible place
+    // to notice when a second is added without a dispatch arm.
+    res.status(500).json({ error: `tool '${tool.name}' has no dispatch implementation` });
+    return;
+  } catch (e) {
+    handleEndpointError(res, e);
+    return;
+  }
+});
+
+// No requiredScope — any valid block token, exactly as blocks/models.ts. The
+// maturity clamp in the handler is the whole authority surface.
+// allowOpaqueOrigin: an UNVERIFIED block runs at an opaque origin (`Origin:
+// null`) and calls this directly from the sandboxed iframe, so it needs
+// `ACAO: null` to clear the CORS preflight.
+export default withBlockScope(baseHandler, { endpoint: 'tools', allowOpaqueOrigin: true });

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -54,7 +54,13 @@ export type AppBlockEndpoint =
   | 'collection_follow'
   | 'shared_storage_top'
   | 'shared_storage_increment'
-  | 'generation_resources';
+  | 'generation_resources'
+  // The read-only chat-tool surface (#398 AC5): GET returns the tool
+  // declarations, POST executes one. It is a model-shaped view of the SAME
+  // clamped catalog path 'models' serves, and it shares that endpoint's
+  // per-token rate-limit budget deliberately — so it gets its own label for
+  // attribution, not its own allowance.
+  | 'tools';
 // NOTE: buzz self-reads (balance/transactions/accounts/daily-compensation) are
 // NOT here — they are host-mediated tRPC MUTATIONS (blocks.getMyBuzz*), not
 // withBlockScope REST routes, so they are not metered via this per-endpoint

--- a/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
+++ b/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
@@ -252,6 +252,10 @@ describe('KNOWN_STATIC_ENDPOINT_SEGMENTS ⇄ withBlockScope route files drift gu
       'shared-storage',
       'tip',
       'tip-allowance',
+      // The read-only chat-tool surface (#398 AC5). Added deliberately: this
+      // pin is what makes a new withBlockScope route a conscious edit rather
+      // than something that silently widens the audit-log segment allowlist.
+      'tools',
       'top',
       'v1',
     ]);

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -988,6 +988,7 @@ export const KNOWN_STATIC_ENDPOINT_SEGMENTS = new Set([
   'shared-storage',
   'tip',
   'tip-allowance',
+  'tools',
   'top',
 ]);
 

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -434,7 +434,7 @@ const MAX_TOOL_PARAMETERS_DEPTH = 8;
  * one OpenAI documents for function names, so a bounded name is not a
  * civitai-specific restriction a caller has to discover.
  */
-const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+export const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 /**
  * A tool's JSON-Schema `parameters` object — bounded, and NORMALISED THROUGH

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -327,7 +327,18 @@ export const CHAT_COMPLETION_ASSUMED_CHARS_PER_TOKEN = 4;
  * additive; narrowing is breaking.
  */
 const MAX_MESSAGES = 32;
-const MAX_MESSAGE_CHARS = 8_000;
+/**
+ * EXPORTED so the tool surface's result budget can be asserted against it.
+ *
+ * `~/server/services/blocks/tools/registry` bounds a tool RESULT to a value that
+ * must stay strictly below this, because the block replays that result as a
+ * `role: 'tool'` message whose `content` this cap bounds — a larger result is
+ * un-replayable and therefore useless. That module is deliberately
+ * server-import-free and so cannot import this one; the link is asserted in its
+ * test instead, which imports BOTH and goes red if either constant moves. Same
+ * technique this file already uses for its link to `MAX_SCANNED_CONTENT_CHARS`.
+ */
+export const MAX_MESSAGE_CHARS = 8_000;
 
 /** Sampling temperature bounds, taken from `ChatCompletionInput.temperature`'s own documented range. */
 const TEMPERATURE_MIN = 0;

--- a/src/server/services/blocks/tools/__tests__/registry.test.ts
+++ b/src/server/services/blocks/tools/__tests__/registry.test.ts
@@ -358,3 +358,80 @@ describe('block tool registry — the result is bounded so it can be replayed', 
     expect(bounded.truncated).toBe(0);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PER-FIELD LENGTH BOUNDS. Every one of these was uncovered: an audit widened
+// each bound to 100000 and deleted `str()`'s truncation branch outright, and all
+// four mutants SURVIVED — because every fixture in the file sat comfortably
+// UNDER each bound, so the truncation never executed. The docstring's claim
+// ("one pathological field cannot eat the budget") had zero coverage.
+//
+// 🔴 EACH FIXTURE IS BUILT FROM THE EXPORTED CONSTANT, not from a magic number,
+// so it stays REACHING if the bound is later retuned. A fixture with a hardcoded
+// length silently stops reaching the branch the moment the constant grows — which
+// is exactly how these came to be uncovered.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('projectModelForTool — per-field length bounds', () => {
+  // 🔴 THE EXPECTED LENGTHS ARE LITERALS, NOT THE CONSTANTS. A first version of
+  // this block built both the fixture AND the expectation from the exported
+  // constant — and all three widen-the-bound mutants SURVIVED, because widening
+  // the constant moved the assertion with it. That is "never derive a test's
+  // expectation from the implementation it tests", reproduced while fixing the
+  // very gap it describes. A literal makes a retune a deliberate test edit.
+  const OVERSHOOT = 400; // comfortably over every bound below
+
+  it('🔴 truncates an over-long NAME to 120', () => {
+    const p = projectModelForTool({ id: 1, name: 'N'.repeat(OVERSHOOT) }) as ProjectedModel;
+    expect(p.name).toHaveLength(120);
+    expect(p.name.endsWith('…')).toBe(true);
+  });
+
+  it('🔴 truncates an over-long CREATOR to 60', () => {
+    const p = projectModelForTool({
+      id: 1,
+      name: 'ok',
+      creator: { username: 'U'.repeat(OVERSHOOT) },
+    }) as ProjectedModel;
+    expect(p.creator).toHaveLength(60);
+    expect(p.creator?.endsWith('…')).toBe(true);
+  });
+
+  it('🔴 truncates an over-long TAG to 40', () => {
+    const p = projectModelForTool({
+      id: 1,
+      name: 'ok',
+      tags: ['T'.repeat(OVERSHOOT)],
+    }) as ProjectedModel;
+    expect(p.tags?.[0]).toHaveLength(40);
+    expect(p.tags?.[0].endsWith('…')).toBe(true);
+  });
+
+  it('the literals above ARE the shipped constants (drift guard)', async () => {
+    const m = await import('~/server/services/blocks/tools/registry');
+    expect(m.MAX_PROJECTED_NAME_CHARS).toBe(120);
+    expect(m.MAX_PROJECTED_CREATOR_CHARS).toBe(60);
+    expect(m.MAX_PROJECTED_TAG_CHARS).toBe(40);
+  });
+
+  it('POSITIVE CONTROL — a field UNDER its bound is passed through untouched', () => {
+    const exact = 'N'.repeat(120);
+    const p = projectModelForTool({ id: 1, name: exact }) as ProjectedModel;
+    // At exactly the bound there is nothing to cut, so no ellipsis — this is what
+    // distinguishes "the bound is applied" from "every string is mangled".
+    expect(p.name).toBe(exact);
+    expect(p.name.endsWith('…')).toBe(false);
+  });
+
+  // 🔴 `slice` counts UTF-16 CODE UNITS. An astral character occupies two, so a
+  // cut between them emits a LONE SURROGATE — valid JSON (`\udXXX`), nothing
+  // throws, and the model just reads mojibake. Catalog names are user-authored
+  // and routinely emoji-laden, so this is the ordinary case.
+  it('🔴 never cuts through a surrogate pair', () => {
+    const p = projectModelForTool({ id: 1, name: '🔥'.repeat(OVERSHOOT) }) as ProjectedModel;
+    expect(p.name.length).toBeLessThanOrEqual(120);
+    // A lone surrogate does not survive a JSON round trip intact.
+    expect(JSON.parse(JSON.stringify(p.name))).toBe(p.name);
+    expect(/[\ud800-\udbff](?![\udc00-\udfff])/.test(p.name)).toBe(false);
+    expect(/(?<![\ud800-\udbff])[\udc00-\udfff]/.test(p.name)).toBe(false);
+  });
+});

--- a/src/server/services/blocks/tools/__tests__/registry.test.ts
+++ b/src/server/services/blocks/tools/__tests__/registry.test.ts
@@ -17,6 +17,7 @@ import { AIR_URN_PREFIX, containsAirReference } from '~/server/services/blocks/s
 import {
   chatCompletionStep,
   MAX_MESSAGE_CHARS,
+  TOOL_NAME_PATTERN,
 } from '~/server/services/blocks/steps/chat-completion.step';
 
 /**
@@ -77,10 +78,15 @@ function rawSearchRow(over: Record<string, unknown> = {}): Record<string, unknow
 describe('block tool registry — the allowlist', () => {
   it('registers exactly the read-only catalog tools, and every name is chat-tool legal', () => {
     expect(BLOCK_TOOL_NAMES).toEqual(['search_models']);
-    // The name must satisfy the chat step's own tool-name pattern, or a block
-    // could never declare it in the first place.
+    // 🔴 THE PATTERN IS IMPORTED, NOT RE-SPELLED, and this assertion is the only
+    // thing standing between a registered tool name and a wire schema that would
+    // reject it. `tools.ts` validates the POSTed `name` against this same
+    // `TOOL_NAME_PATTERN`. With a local copy of the regex, a future tightening of
+    // the real pattern would make a registered tool unreachable over POST while
+    // GET happily kept declaring it — and this test would stay green, because it
+    // would be checking the old shape.
     for (const name of BLOCK_TOOL_NAMES) {
-      expect(name).toMatch(/^[a-zA-Z0-9_-]+$/);
+      expect(name).toMatch(TOOL_NAME_PATTERN);
     }
   });
 
@@ -366,10 +372,13 @@ describe('block tool registry — the result is bounded so it can be replayed', 
 // UNDER each bound, so the truncation never executed. The docstring's claim
 // ("one pathological field cannot eat the budget") had zero coverage.
 //
-// 🔴 EACH FIXTURE IS BUILT FROM THE EXPORTED CONSTANT, not from a magic number,
-// so it stays REACHING if the bound is later retuned. A fixture with a hardcoded
-// length silently stops reaching the branch the moment the constant grows — which
-// is exactly how these came to be uncovered.
+// 🔴 THE FIXTURES ARE NOT BUILT FROM THE CONSTANTS — an earlier version of this
+// note claimed they were, and that was false in the shipped commit. They
+// overshoot by a LITERAL (`OVERSHOOT` below) and a drift guard keeps them
+// reaching. That is the deliberate choice, for the reason spelled out on
+// `OVERSHOOT`: a constant-derived fixture moves WITH a widen-the-bound mutant
+// and stops discriminating, which is how these came to be uncovered in the first
+// place.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('projectModelForTool — per-field length bounds', () => {
   // 🔴 THE EXPECTED LENGTHS ARE LITERALS, NOT THE CONSTANTS. A first version of
@@ -406,11 +415,37 @@ describe('projectModelForTool — per-field length bounds', () => {
     expect(p.tags?.[0].endsWith('…')).toBe(true);
   });
 
+  it('🔴 truncates an over-long TYPE to 40', () => {
+    const p = projectModelForTool({
+      id: 1,
+      name: 'ok',
+      type: 'Y'.repeat(OVERSHOOT),
+    }) as ProjectedModel;
+    expect(p.type).toHaveLength(40);
+    expect(p.type?.endsWith('…')).toBe(true);
+  });
+
+  it('🔴 truncates an over-long BASE MODEL to 40', () => {
+    const p = projectModelForTool({
+      id: 1,
+      name: 'ok',
+      modelVersions: [{ baseModel: 'B'.repeat(OVERSHOOT) }],
+    }) as ProjectedModel;
+    expect(p.baseModel).toHaveLength(40);
+    expect(p.baseModel?.endsWith('…')).toBe(true);
+  });
+
+  // 🔴 ALL FIVE, not the three that were exported first. `type` and `baseModel`
+  // were left as a bare `40` at their call sites while the other three were
+  // converted, so an audit widened either to 100000 and the suite stayed green.
+  // A bound that is a magic number at its call site cannot be reached by name.
   it('the literals above ARE the shipped constants (drift guard)', async () => {
     const m = await import('~/server/services/blocks/tools/registry');
     expect(m.MAX_PROJECTED_NAME_CHARS).toBe(120);
     expect(m.MAX_PROJECTED_CREATOR_CHARS).toBe(60);
     expect(m.MAX_PROJECTED_TAG_CHARS).toBe(40);
+    expect(m.MAX_PROJECTED_TYPE_CHARS).toBe(40);
+    expect(m.MAX_PROJECTED_BASE_MODEL_CHARS).toBe(40);
   });
 
   it('POSITIVE CONTROL — a field UNDER its bound is passed through untouched', () => {
@@ -426,12 +461,54 @@ describe('projectModelForTool — per-field length bounds', () => {
   // cut between them emits a LONE SURROGATE — valid JSON (`\udXXX`), nothing
   // throws, and the model just reads mojibake. Catalog names are user-authored
   // and routinely emoji-laden, so this is the ordinary case.
+  const hasLoneSurrogate = (s: string) =>
+    /[\ud800-\udbff](?![\udc00-\udfff])/.test(s) || /(?<![\ud800-\udbff])[\udc00-\udfff]/.test(s);
+
   it('🔴 never cuts through a surrogate pair', () => {
     const p = projectModelForTool({ id: 1, name: '🔥'.repeat(OVERSHOOT) }) as ProjectedModel;
     expect(p.name.length).toBeLessThanOrEqual(120);
-    // A lone surrogate does not survive a JSON round trip intact.
-    expect(JSON.parse(JSON.stringify(p.name))).toBe(p.name);
-    expect(/[\ud800-\udbff](?![\udc00-\udfff])/.test(p.name)).toBe(false);
-    expect(/(?<![\ud800-\udbff])[\udc00-\udfff]/.test(p.name)).toBe(false);
+    expect(hasLoneSurrogate(p.name)).toBe(false);
+  });
+
+  // 🔴 A PURE-ASTRAL FIXTURE CANNOT REACH HALF OF THE GUARD, and the case above
+  // is pure astral. `str()` tests `charCodeAt(cut - 1)` against the HIGH range
+  // `0xd800..0xdbff`; in an all-emoji string the high surrogates always land on
+  // even indices, so that read is ALWAYS a high surrogate and the range's UPPER
+  // bound never executes. An audit widened it to `0xdfff` — admitting LOW
+  // surrogates, which retreats a unit that did not need retreating — and the
+  // mutant SURVIVED the whole suite.
+  //
+  // One leading BMP character shifts the parity and makes the upper bound
+  // load-bearing. Measured on this fixture: HEAD yields length 120 with no lone
+  // surrogate; the widened mutant yields 119 ending in an orphaned high
+  // surrogate. Same discrimination at the 40-char tag bound.
+  //
+  // The lesson generalises past this guard: a fixture whose constants put the
+  // guarded branch exactly on its own boundary proves nothing about the branch.
+  it('🔴 the surrogate RANGE is bounded on both ends — odd-parity astral input', () => {
+    const shifted = `A${'🔥'.repeat(OVERSHOOT)}`;
+
+    const p = projectModelForTool({ id: 1, name: shifted }) as ProjectedModel;
+    expect(p.name).toHaveLength(120);
+    expect(hasLoneSurrogate(p.name)).toBe(false);
+
+    const t = projectModelForTool({ id: 1, name: 'ok', tags: [shifted] }) as ProjectedModel;
+    expect(t.tags?.[0]).toHaveLength(40);
+    expect(hasLoneSurrogate(t.tags?.[0] ?? '')).toBe(false);
+  });
+
+  // 🔴 NOT a JSON round-trip assertion. An earlier version asserted
+  // `JSON.parse(JSON.stringify(name)) === name` under the comment "a lone
+  // surrogate does not survive a JSON round trip intact". That comment is FALSE
+  // — measured: ES2019 well-formed `JSON.stringify` escapes a lone surrogate as
+  // `\udXXX` and `JSON.parse` restores it exactly, so the assertion held for
+  // EVERY string and carried no information. It also contradicted the source
+  // comment on `str()`, which correctly says the lone surrogate is valid JSON and
+  // that the harm is mojibake rather than a serialization failure. The regex
+  // checks above are what do the work.
+  it('POSITIVE CONTROL — the detector fires on a deliberately broken string', () => {
+    expect(hasLoneSurrogate('ab\ud83d')).toBe(true);
+    expect(hasLoneSurrogate('ab\udd25')).toBe(true);
+    expect(hasLoneSurrogate('ab🔥')).toBe(false);
   });
 });

--- a/src/server/services/blocks/tools/__tests__/registry.test.ts
+++ b/src/server/services/blocks/tools/__tests__/registry.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect } from 'vitest';
+import * as z from 'zod';
+
+import {
+  AIR_URN_PREFIX_LOCAL,
+  BLOCK_TOOL_NAMES,
+  blockToolDeclarations,
+  boundToolResult,
+  getBlockTool,
+  MAX_TOOL_RESULT_CHARS,
+  MAX_TOOL_RESULT_ITEMS,
+  neutralizeAirLiterals,
+  projectModelForTool,
+  type ProjectedModel,
+} from '~/server/services/blocks/tools/registry';
+import { AIR_URN_PREFIX, containsAirReference } from '~/server/services/blocks/steps';
+import {
+  chatCompletionStep,
+  MAX_MESSAGE_CHARS,
+} from '~/server/services/blocks/steps/chat-completion.step';
+
+/**
+ * Unit tests for the App Blocks read-only tool registry (#398 AC5).
+ *
+ * The module under test is server-import-free by design, so these run without a
+ * Prisma client. The ROUTE wiring (clamp, rate limit, dispatch) is covered in
+ * `src/tests/api/v1/blocks/tools-endpoint.test.ts`.
+ */
+
+/**
+ * A raw `runModelSearch` row, shaped after the real one.
+ *
+ * 🔴 IT CARRIES AIRs, FILES, HASHES AND DOWNLOAD URLS ON PURPOSE. A fixture
+ * that never contained those could not tell an allowlist projection from a
+ * passthrough — every "the projection does not leak X" assertion would pass
+ * vacuously. The positive control below asserts the fixture really does contain
+ * the thing the projection is supposed to remove.
+ */
+function rawSearchRow(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 4384,
+    name: 'DreamShaper',
+    type: 'Checkpoint',
+    nsfw: false,
+    tags: ['photorealistic', 'woman', 'base model', 'portraits', 'art style', 'a', 'b', 'c', 'd'],
+    creator: { username: 'Lykon', image: 'https://example.invalid/avatar.png' },
+    stats: { downloadCount: 1_700_000, thumbsUpCount: 42, favoriteCount: 7 },
+    modelVersions: [
+      {
+        id: 128713,
+        name: '8',
+        baseModel: 'SD 1.5',
+        air: 'urn:air:sd1:checkpoint:civitai:4384@128713',
+        files: [
+          {
+            id: 1,
+            name: 'dreamshaper.safetensors',
+            hashes: { SHA256: 'deadbeef'.repeat(8) },
+            downloadUrl: 'https://civitai.com/api/download/models/128713',
+          },
+        ],
+        images: [{ id: 9, url: 'https://example.invalid/img.jpeg', nsfwLevel: 1 }],
+      },
+      {
+        id: 252914,
+        name: '7',
+        baseModel: 'SD 1.5',
+        air: 'urn:air:sd1:checkpoint:civitai:4384@252914',
+        files: [],
+        images: [],
+      },
+    ],
+    ...over,
+  };
+}
+
+describe('block tool registry — the allowlist', () => {
+  it('registers exactly the read-only catalog tools, and every name is chat-tool legal', () => {
+    expect(BLOCK_TOOL_NAMES).toEqual(['search_models']);
+    // The name must satisfy the chat step's own tool-name pattern, or a block
+    // could never declare it in the first place.
+    for (const name of BLOCK_TOOL_NAMES) {
+      expect(name).toMatch(/^[a-zA-Z0-9_-]+$/);
+    }
+  });
+
+  it('resolves a registered tool', () => {
+    expect(getBlockTool('search_models')?.name).toBe('search_models');
+  });
+
+  it('🔴 rejects an unregistered name', () => {
+    expect(getBlockTool('delete_everything')).toBeUndefined();
+  });
+
+  it('🔴 rejects PROTOTYPE keys — the null-prototype map is the control', () => {
+    // With a plain object literal these resolve to Object.prototype members,
+    // which are TRUTHY, so an `if (!tool) reject` guard would fail OPEN and
+    // dispatch on an inherited function.
+    for (const key of ['toString', 'constructor', 'hasOwnProperty', '__proto__', 'valueOf']) {
+      expect(getBlockTool(key), `prototype key '${key}' must not resolve`).toBeUndefined();
+    }
+  });
+
+  it('POSITIVE CONTROL — the same lookup DOES resolve a real name', () => {
+    // Without this, "everything returns undefined" would also pass the case
+    // above, including a lookup wired to nothing.
+    expect(getBlockTool('search_models')).toBeDefined();
+  });
+});
+
+describe('block tool registry — the argument contract is strict', () => {
+  const tool = getBlockTool('search_models')!;
+
+  it('accepts a valid argument object', () => {
+    const parsed = tool.argsSchema.safeParse({ query: 'DreamShaper checkpoint', limit: 3 });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('🔴 rejects an UNKNOWN key rather than dropping it', () => {
+    const parsed = tool.argsSchema.safeParse({ query: 'x', nsfw: true });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('🔴 rejects a maturity-shaped key specifically — the clamp is not negotiable', () => {
+    // The tool schema deliberately carries no maturity field at all, so there is
+    // nothing for a caller to set and nothing for the handler to ignore.
+    for (const key of ['browsingLevel', 'nsfw', 'maxBrowsingLevel']) {
+      expect(tool.argsSchema.safeParse({ query: 'x', [key]: 31 }).success).toBe(false);
+    }
+  });
+
+  it('rejects a missing query, an empty query, and an over-cap limit', () => {
+    expect(tool.argsSchema.safeParse({}).success).toBe(false);
+    expect(tool.argsSchema.safeParse({ query: '' }).success).toBe(false);
+    expect(
+      tool.argsSchema.safeParse({ query: 'x', limit: MAX_TOOL_RESULT_ITEMS + 1 }).success
+    ).toBe(false);
+  });
+});
+
+describe('block tool registry — the model is shown the schema the route enforces', () => {
+  it('🔴 `parameters` is DERIVED from the same argsSchema, not a hand-written twin', () => {
+    const declared = blockToolDeclarations();
+    expect(declared).toHaveLength(BLOCK_TOOL_NAMES.length);
+
+    for (const entry of declared) {
+      const tool = getBlockTool(entry.function.name)!;
+      const derived = z.toJSONSchema(tool.argsSchema, { io: 'input', unrepresentable: 'any' });
+      // Identity, not "looks similar": the served document must BE the
+      // projection of the enforcing schema. A hand-written twin is how a model
+      // gets shown a contract the route does not enforce.
+      expect(entry.function.parameters).toEqual(derived);
+    }
+  });
+
+  it('the declaration is shaped as the chat step accepts it', () => {
+    // A declaration a block cannot actually pass to `tools[]` is useless, so
+    // pin it against the step's own param schema rather than by eye.
+    const parsed = chatCompletionStep.paramSchema.safeParse({
+      model: 'openai/gpt-4o-mini',
+      messages: [{ role: 'user', content: 'which checkpoint should I use?' }],
+      maxTokens: 256,
+      tools: blockToolDeclarations(),
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('block tool registry — projection is an ALLOWLIST', () => {
+  it('keeps only the fields a chat model needs', () => {
+    const projected = projectModelForTool(rawSearchRow())!;
+    expect(projected).toEqual({
+      id: 4384,
+      name: 'DreamShaper',
+      type: 'Checkpoint',
+      baseModel: 'SD 1.5',
+      creator: 'Lykon',
+      downloads: 1_700_000,
+      tags: ['photorealistic', 'woman', 'base model', 'portraits', 'art style', 'a', 'b', 'c'],
+      url: 'https://civitai.com/models/4384',
+    });
+  });
+
+  it('🔴 drops files, hashes, download urls and image urls — POSITIVE CONTROL first', () => {
+    const raw = rawSearchRow();
+    const rawJson = JSON.stringify(raw);
+    // POSITIVE CONTROL: the fixture really does carry each thing, so the
+    // assertions below are not vacuous.
+    expect(rawJson).toContain('safetensors');
+    expect(rawJson).toContain('SHA256');
+    expect(rawJson).toContain('/api/download/models/');
+    expect(rawJson).toContain('img.jpeg');
+
+    const projectedJson = JSON.stringify(projectModelForTool(raw));
+    expect(projectedJson).not.toContain('safetensors');
+    expect(projectedJson).not.toContain('SHA256');
+    expect(projectedJson).not.toContain('/api/download/models/');
+    expect(projectedJson).not.toContain('img.jpeg');
+  });
+
+  it('returns null for a row missing an id or a name rather than a half-row', () => {
+    expect(projectModelForTool(rawSearchRow({ id: undefined }))).toBeNull();
+    expect(projectModelForTool(rawSearchRow({ name: '   ' }))).toBeNull();
+    expect(projectModelForTool(null)).toBeNull();
+    expect(projectModelForTool('not an object')).toBeNull();
+  });
+});
+
+describe('🔴 block tool registry — AIR literals cannot reach a tool result', () => {
+  it('🔴 POSITIVE CONTROL — the raw row DOES carry the literal the projection must remove', () => {
+    // Without this the next assertion passes on any fixture that never had an
+    // AIR, which is the both-wrong-blind shape: the test and the code agreeing
+    // on a case neither has seen.
+    const rawJson = JSON.stringify(rawSearchRow());
+    expect(rawJson).toContain(AIR_URN_PREFIX_LOCAL);
+    expect(rawJson.match(/urn:air:/gi)?.length).toBe(2);
+  });
+
+  it('🔴 the projected row carries NO air literal', () => {
+    const projectedJson = JSON.stringify(projectModelForTool(rawSearchRow()));
+    expect(projectedJson.toLowerCase()).not.toContain(AIR_URN_PREFIX_LOCAL);
+  });
+
+  it('🔴 an AIR in a USER-AUTHORED name is neutralised, not passed through', () => {
+    // The allowlist alone does not cover this: `name` is a field we DO copy.
+    const projected = projectModelForTool(
+      rawSearchRow({ name: 'my urn:air:sd1:checkpoint:civitai:1@2 model' })
+    )!;
+    expect(projected.name).not.toContain('urn:air:');
+    expect(projected.name).toContain('urn-air-');
+  });
+
+  it('🔴 the scrub is CASE-INSENSITIVE, because the scan it defends against is', () => {
+    const scrubbed = neutralizeAirLiterals({ a: 'URN:AIR:x', b: ['UrN:aIr:y'] });
+    expect(JSON.stringify(scrubbed).toLowerCase()).not.toContain('urn:air:');
+  });
+
+  it('🔴 the scrub covers object KEYS, not just values', () => {
+    const scrubbed = neutralizeAirLiterals({ 'urn:air:sd1:checkpoint:civitai:1@2': 'v' });
+    expect(Object.keys(scrubbed)[0]).not.toContain('urn:air:');
+  });
+
+  it('🔴 our local prefix constant matches the registry it defends against', () => {
+    // The duplication is deliberate (keeping this module server-import-free);
+    // this is what stops the two drifting.
+    expect(AIR_URN_PREFIX_LOCAL).toBe(AIR_URN_PREFIX);
+  });
+});
+
+describe('🔴 block tool registry — the ROUND TRIP actually closes', () => {
+  it('a projected result survives containsAirReference AND the chat param schema', () => {
+    const bounded = boundToolResult(
+      [rawSearchRow(), rawSearchRow({ id: 5, name: 'urn:air: sneaky' })]
+        .map((r) => projectModelForTool(r))
+        .filter((m): m is ProjectedModel => m !== null)
+    );
+    const toolContent = JSON.stringify(bounded);
+
+    // 1. The guard that would otherwise throw FORBIDDEN at submit.
+    expect(containsAirReference({ content: toolContent })).toBe(false);
+
+    // 2. The step's own param schema, with the result replayed as a tool message.
+    const parsed = chatCompletionStep.paramSchema.safeParse({
+      model: 'openai/gpt-4o-mini',
+      messages: [
+        { role: 'user', content: 'which checkpoint?' },
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'search_models', arguments: '{"query":"dreamshaper"}' },
+            },
+          ],
+        },
+        { role: 'tool', content: toolContent, tool_call_id: 'call_1' },
+      ],
+      maxTokens: 256,
+      tools: blockToolDeclarations(),
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('🔴 POSITIVE CONTROL — an UNPROJECTED result is refused by that same guard', () => {
+    // Proves the round-trip case above is not passing because the guard is
+    // inert: feed it the raw row and it must reject.
+    const rawContent = JSON.stringify(rawSearchRow());
+    expect(containsAirReference({ content: rawContent })).toBe(true);
+  });
+});
+
+describe('block tool registry — the result is bounded so it can be replayed', () => {
+  it('🔴 stays under the char budget, and the budget stays under the MESSAGE cap', () => {
+    // The link that makes the budget meaningful: a result at or above
+    // MAX_MESSAGE_CHARS cannot be replayed as a tool message at all.
+    expect(MAX_TOOL_RESULT_CHARS).toBeLessThan(MAX_MESSAGE_CHARS);
+  });
+
+  it('🔴 the CHAR BUDGET binds before the item cap — drops whole rows, stays valid JSON', () => {
+    // 🔴 THE FIXTURE MUST BE MAXIMAL, AND THAT IS THE WHOLE POINT OF THIS CASE.
+    // An earlier version of this test used ordinary rows (~339 chars each), so
+    // ten of them came to ~3,400 — under the 6,000 budget. The ITEM CAP was
+    // doing all the work, the char-budget branch never executed, and deleting
+    // that branch left the whole suite GREEN (mutant M7 survived). Measured, not
+    // guessed: at 691 chars/row the budget binds at 8 rows (5,547 fits, 6,239
+    // does not), which is strictly below MAX_TOOL_RESULT_ITEMS.
+    const fatTag = (i: number) => `tag${i}`.padEnd(40, 'z');
+    const fat = Array.from({ length: 40 }, (_, i) =>
+      projectModelForTool(
+        rawSearchRow({
+          id: 1000 + i,
+          name: `Model ${'x'.repeat(200)}`,
+          type: 'TextualInversion',
+          creator: { username: 'c'.repeat(60) },
+          tags: [0, 1, 2, 3, 4, 5, 6, 7].map(fatTag),
+          modelVersions: [{ id: 1, baseModel: 'Stable Diffusion XL 1.0' }],
+        })
+      )
+    ).filter((m): m is ProjectedModel => m !== null);
+
+    const bounded = boundToolResult(fat);
+    const json = JSON.stringify(bounded);
+
+    // 🔴 THE ISOLATING ASSERTION. Fewer than the item cap can ONLY happen if the
+    // char budget stopped it — the item cap alone would have returned exactly
+    // MAX_TOOL_RESULT_ITEMS. This is what kills M7.
+    expect(bounded.items.length).toBeLessThan(MAX_TOOL_RESULT_ITEMS);
+    expect(bounded.items.length).toBeGreaterThan(0);
+
+    expect(JSON.stringify({ items: bounded.items }).length).toBeLessThanOrEqual(
+      MAX_TOOL_RESULT_CHARS
+    );
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(bounded.truncated).toBe(fat.length - bounded.items.length);
+    // Every kept row is a COMPLETE row — the bound drops rows, never truncates.
+    for (const item of bounded.items) {
+      expect(item.id).toBeTypeOf('number');
+      expect(item.url).toContain('/models/');
+      expect(item.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never returns more than the item cap even when rows are tiny', () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      id: i,
+      name: 'm',
+      url: `https://civitai.com/models/${i}`,
+    })) as ProjectedModel[];
+    expect(boundToolResult(many).items.length).toBeLessThanOrEqual(MAX_TOOL_RESULT_ITEMS);
+  });
+
+  it('POSITIVE CONTROL — a small list is returned whole with nothing truncated', () => {
+    // Without this, a bound that returned [] always would pass every case above.
+    const small = [projectModelForTool(rawSearchRow())!];
+    const bounded = boundToolResult(small);
+    expect(bounded.items).toHaveLength(1);
+    expect(bounded.truncated).toBe(0);
+  });
+});

--- a/src/server/services/blocks/tools/registry.ts
+++ b/src/server/services/blocks/tools/registry.ts
@@ -88,12 +88,24 @@ export const MAX_TOOL_RESULT_ITEMS = 10;
  * `str()`'s truncation branch outright — because every fixture in the suite sat
  * comfortably UNDER each bound, so the truncation never executed and the
  * docstring's "one pathological field cannot eat the budget" had zero coverage.
- * A test that builds its fixture from the constant is the only kind that stays
- * reaching when the constant moves.
+ *
+ * 🔴 ALL FIVE PROJECTED STRING FIELDS ARE NAMED HERE, and that is the point of
+ * the list rather than tidiness. A LATER audit found `type` and `baseModel` had
+ * been left on a bare `40` while the other three were converted — so two of the
+ * five sat outside the block whose docstring claimed to cover "individual
+ * projected strings", and widening either survived the suite. A bound that is a
+ * magic number at its call site cannot be reached from a test by name.
+ *
+ * The fixtures do NOT derive their length from these constants — they overshoot
+ * by a literal, and the drift guard in the test file is what keeps them reaching
+ * if a constant moves. See that file's own note for why a constant-derived
+ * fixture is the weaker choice: it moves WITH the mutant and stops discriminating.
  */
 export const MAX_PROJECTED_NAME_CHARS = 120;
 export const MAX_PROJECTED_TAG_CHARS = 40;
 export const MAX_PROJECTED_CREATOR_CHARS = 60;
+export const MAX_PROJECTED_TYPE_CHARS = 40;
+export const MAX_PROJECTED_BASE_MODEL_CHARS = 40;
 export const MAX_PROJECTED_TAGS = 8;
 
 /**
@@ -247,9 +259,11 @@ export function projectModelForTool(raw: unknown): ProjectedModel | null {
   const projected: ProjectedModel = {
     id,
     name,
-    ...(str(row.type, 40) !== undefined ? { type: str(row.type, 40) } : {}),
-    ...(latest && str(latest.baseModel, 40) !== undefined
-      ? { baseModel: str(latest.baseModel, 40) }
+    ...(str(row.type, MAX_PROJECTED_TYPE_CHARS) !== undefined
+      ? { type: str(row.type, MAX_PROJECTED_TYPE_CHARS) }
+      : {}),
+    ...(latest && str(latest.baseModel, MAX_PROJECTED_BASE_MODEL_CHARS) !== undefined
+      ? { baseModel: str(latest.baseModel, MAX_PROJECTED_BASE_MODEL_CHARS) }
       : {}),
     ...(creatorRecord && str(creatorRecord.username, MAX_PROJECTED_CREATOR_CHARS) !== undefined
       ? { creator: str(creatorRecord.username, MAX_PROJECTED_CREATOR_CHARS) }

--- a/src/server/services/blocks/tools/registry.ts
+++ b/src/server/services/blocks/tools/registry.ts
@@ -79,9 +79,22 @@ export const MAX_TOOL_RESULT_CHARS = 6_000;
 /** Hard cap on results returned in one call, independent of the char budget. */
 export const MAX_TOOL_RESULT_ITEMS = 10;
 
-/** Bounds on individual projected strings, so one pathological field cannot eat the budget. */
-const MAX_PROJECTED_NAME_CHARS = 120;
-const MAX_PROJECTED_TAGS = 8;
+/**
+ * Bounds on individual projected strings, so one pathological field cannot eat
+ * the budget.
+ *
+ * 🔴 EXPORTED SO THE TESTS CAN REACH THE BRANCH THEY CLAIM TO COVER. An audit
+ * killed four mutants here — widening any of these to 100000, and deleting
+ * `str()`'s truncation branch outright — because every fixture in the suite sat
+ * comfortably UNDER each bound, so the truncation never executed and the
+ * docstring's "one pathological field cannot eat the budget" had zero coverage.
+ * A test that builds its fixture from the constant is the only kind that stays
+ * reaching when the constant moves.
+ */
+export const MAX_PROJECTED_NAME_CHARS = 120;
+export const MAX_PROJECTED_TAG_CHARS = 40;
+export const MAX_PROJECTED_CREATOR_CHARS = 60;
+export const MAX_PROJECTED_TAGS = 8;
 
 /**
  * The AIR URN prefix, lowercase.
@@ -138,12 +151,29 @@ export function neutralizeAirLiterals<T>(value: T): T {
   return value;
 }
 
-/** Read a string field defensively off an `unknown` search item. */
+/**
+ * Read a string field defensively off an `unknown` search item.
+ *
+ * 🔴 THE CUT IS SURROGATE-AWARE. `String.prototype.slice` counts UTF-16 CODE
+ * UNITS, and an astral character (emoji, and every non-BMP script) occupies two.
+ * Cutting between them emits a LONE SURROGATE: still valid JSON — it serializes
+ * as `\udXXX` — so nothing downstream errors, and the model simply reads
+ * mojibake at the boundary. Measured on an emoji-heavy name before this guard
+ * existed. Catalog names are user-authored and routinely emoji-laden, so this is
+ * the ordinary case rather than a pathological one.
+ */
 function str(value: unknown, max: number): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   if (trimmed.length === 0) return undefined;
-  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+  if (trimmed.length <= max) return trimmed;
+  let cut = max - 1;
+  // The last retained unit is at `cut - 1`. If it is a HIGH surrogate its
+  // partner sits at `cut` and would be dropped, so retreat one unit and let the
+  // ellipsis take the slack.
+  const last = trimmed.charCodeAt(cut - 1);
+  if (last >= 0xd800 && last <= 0xdbff) cut -= 1;
+  return `${trimmed.slice(0, cut)}…`;
 }
 
 /** Read a finite number field defensively off an `unknown` search item. */
@@ -209,7 +239,7 @@ export function projectModelForTool(raw: unknown): ProjectedModel | null {
 
   const tags = Array.isArray(row.tags)
     ? row.tags
-        .map((t) => str(t, 40))
+        .map((t) => str(t, MAX_PROJECTED_TAG_CHARS))
         .filter((t): t is string => t !== undefined)
         .slice(0, MAX_PROJECTED_TAGS)
     : undefined;
@@ -221,8 +251,8 @@ export function projectModelForTool(raw: unknown): ProjectedModel | null {
     ...(latest && str(latest.baseModel, 40) !== undefined
       ? { baseModel: str(latest.baseModel, 40) }
       : {}),
-    ...(creatorRecord && str(creatorRecord.username, 60) !== undefined
-      ? { creator: str(creatorRecord.username, 60) }
+    ...(creatorRecord && str(creatorRecord.username, MAX_PROJECTED_CREATOR_CHARS) !== undefined
+      ? { creator: str(creatorRecord.username, MAX_PROJECTED_CREATOR_CHARS) }
       : {}),
     ...(statsRecord && num(statsRecord.downloadCount) !== undefined
       ? { downloads: num(statsRecord.downloadCount) }

--- a/src/server/services/blocks/tools/registry.ts
+++ b/src/server/services/blocks/tools/registry.ts
@@ -1,0 +1,356 @@
+import * as z from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks READ-ONLY TOOL REGISTRY (#398 AC5).
+//
+// WHAT THIS IS. The code-enumerated allowlist of tools an App Block may declare
+// to a chat model, plus — for each — the ONE schema that is both (a) handed to
+// the model as its JSON-Schema `parameters` and (b) used to validate the
+// arguments the model sends back. AC5 requires the allowlist be "enumerated in
+// code"; this module is that enumeration.
+//
+// 🔴 THIS MODULE IS SERVER-IMPORT-FREE, and that is deliberate rather than
+// tidy. It mirrors the reasoning `~/server/utils/block-catalog-maturity` states
+// for the maturity clamp: the security-relevant parts (the allowlist, the
+// argument bounds, the projection, the AIR scrub) must be unit-testable without
+// dragging the Prisma client, and the only backing implementation available
+// today statically imports a search service which eagerly loads Prisma. The
+// DISPATCH — the part that actually talks to the catalog — lives in the route.
+//
+// 🔴 READ-ONLY AND FIRST-PARTY ONLY. Every entry must be a read of Civitai's own
+// catalog. That is not a style rule, it is what makes the moderation answer for
+// #398 hold: tool RESULTS are not scanned by any text scanner, and the argument
+// for that being acceptable is precisely that they are first-party, already
+// published, already moderated, and maturity-clamped to the viewer's own
+// ceiling. A non-first-party tool (a web fetch, a third-party API) breaks that
+// argument and needs its own scan before it can be listed here. A WRITE tool
+// breaks something worse: it would let a model's own output take an action.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 WHY THIS IS NOT AN MCP PROXY, which is what #398 AC5's prose asks for.
+//
+// `mcp.civitai.com` exposes `search_models` over the same catalog, and routing a
+// block to it through `/api/v1/blocks/*` LOOKS like the smaller change. It is
+// not viable, measured rather than reasoned:
+//
+//   - its `search_models` input schema has NO nsfw / browsingLevel / maturity
+//     parameter and is `additionalProperties: false`, so a proxy cannot pass the
+//     viewer's ceiling through; and
+//   - its results carry only `air` / `id` / `name` / `type` — no maturity
+//     metadata at all — so a proxy cannot filter what comes BACK either, short
+//     of re-resolving every returned id against our own database.
+//
+// 🔴 And the trap that makes the proxy look safe: THE MATURITY CLAMP IS NOT
+// INHERITED FROM THE `/api/v1/blocks/*` PREFIX. `withBlockScope` gives a route
+// the JWT gate, the opaque-origin CORS, the rate limit and the audit row. It
+// does NOT give it the clamp — `blocks/models.ts` says so in its own words, that
+// `resolveCatalogBrowsingLevel` "remains the whole authority surface". A new
+// route under that prefix that forgets to call it is unclamped while looking
+// exactly as protected as its neighbours.
+//
+// So the tools are backed by the SAME clamped path `/api/v1/blocks/models`
+// already uses. That endpoint is strictly better than the MCP one for this
+// purpose: the ceiling is applied server-side from the token claim and the
+// client cannot widen it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The serialized-character budget for one tool RESULT.
+ *
+ * 🔴 THIS EXISTS BECAUSE THE RESULT HAS TO SURVIVE A ROUND TRIP. The block feeds
+ * it back to the model as a `role: 'tool'` message, and that message's `content`
+ * is bounded by `MAX_MESSAGE_CHARS` (8,000) in the chat-completion step's param
+ * schema. A result larger than that cannot be replayed at all — the submit is a
+ * BAD_REQUEST — so an unbounded projection is not "generous", it is a result the
+ * caller can never use.
+ *
+ * Set BELOW the message cap, not equal to it, so a block can prepend its own
+ * framing ("Results for X:") without pushing the message over.
+ *
+ * 🔴 THE LINK TO `MAX_MESSAGE_CHARS` IS ASSERTED IN A TEST, NOT IMPORTED. This
+ * module is server-import-free on purpose (see the header); importing
+ * `chat-completion.step` here would drag the step registry onto its load path
+ * and defeat that. `__tests__/registry.test.ts` imports BOTH and goes red if
+ * either constant moves — the same technique `chat-completion.step` already uses
+ * for its own link to `MAX_SCANNED_CONTENT_CHARS`.
+ */
+export const MAX_TOOL_RESULT_CHARS = 6_000;
+
+/** Hard cap on results returned in one call, independent of the char budget. */
+export const MAX_TOOL_RESULT_ITEMS = 10;
+
+/** Bounds on individual projected strings, so one pathological field cannot eat the budget. */
+const MAX_PROJECTED_NAME_CHARS = 120;
+const MAX_PROJECTED_TAGS = 8;
+
+/**
+ * The AIR URN prefix, lowercase.
+ *
+ * 🔴 DUPLICATED FROM `steps/index`'s `AIR_URN_PREFIX` ON PURPOSE, and the
+ * duplication is asserted in the tests rather than left to drift. Importing it
+ * would pull the step registry onto this module's load path, which the
+ * server-import-free property forbids. The test imports both and fails if they
+ * diverge — the same trade this file makes for `MAX_MESSAGE_CHARS`.
+ */
+export const AIR_URN_PREFIX_LOCAL = 'urn:air:';
+
+/**
+ * Replace any AIR URN prefix appearing in a string with an inert spelling.
+ *
+ * 🔴 WHY A TOOL RESULT MUST NOT CARRY `urn:air:` AT ALL. The block puts this
+ * result into `messages` and submits it. `containsAirReference` (steps/index)
+ * is a case-insensitive SUBSTRING scan over every string, array element, object
+ * value AND object key of the built step input, and the router throws FORBIDDEN
+ * on a hit — on the estimate path and the submit path both. So a result carrying
+ * the literal does not degrade, it makes the round trip impossible.
+ *
+ * This is not hypothetical: measured against the live MCP server, a single
+ * `search_models` call at `limit: 1` returned THIRTY-ONE `urn:air:` literals, in
+ * both its human-readable text and its structured content.
+ *
+ * 🔴 SCRUB, DO NOT DROP. The projection below is an allowlist and never copies
+ * an AIR field, so in the ordinary case there is nothing here to do. What this
+ * catches is the residual: a user-authored model NAME (or tag) that happens to
+ * contain the literal. Dropping such a model would silently hide a real catalog
+ * entry from the model's view for a cosmetic reason; neutralising the prefix
+ * keeps the row and costs the reader nothing, because the block does not need
+ * AIRs to answer a question about a model.
+ *
+ * Case-insensitive, because the scan it defends against is.
+ */
+export function neutralizeAirLiterals<T>(value: T): T {
+  if (typeof value === 'string') {
+    return value.replace(/urn:air:/gi, 'urn-air-') as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => neutralizeAirLiterals(v)) as unknown as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      // Keys are scrubbed too: `containsAirReference` scans object KEYS, because
+      // the orchestrator's own `additionalNetworks` / `WorkflowCost.fees` shapes
+      // are AIR-keyed maps.
+      out[neutralizeAirLiterals(k)] = neutralizeAirLiterals(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
+/** Read a string field defensively off an `unknown` search item. */
+function str(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+/** Read a finite number field defensively off an `unknown` search item. */
+function num(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/** One projected catalog row, as the model sees it. */
+export type ProjectedModel = {
+  id: number;
+  name: string;
+  type?: string;
+  baseModel?: string;
+  creator?: string;
+  downloads?: number;
+  tags?: string[];
+  url: string;
+};
+
+/**
+ * Project ONE raw search item down to what a chat model needs.
+ *
+ * 🔴 AN ALLOWLIST, NEVER A DENYLIST, and that is the load-bearing choice. The
+ * raw row from `runModelSearch` is a full model record: every published version,
+ * every file, file hashes, download URLs, image URLs — and AIR identifiers. A
+ * denylist ("strip the air fields") is one upstream field addition away from
+ * leaking, and the upstream shape is typed `unknown` precisely because it is not
+ * this module's contract. Building the output from named fields means a new
+ * upstream field is invisible here by construction.
+ *
+ * The size argument is the same one: the raw row is orders of magnitude larger
+ * than the round-trip budget, so a passthrough could never be replayed anyway.
+ *
+ * Returns `null` for a row without the two fields that make a result useful at
+ * all (a numeric id and a name), rather than emitting a half-row the model would
+ * have to reason about.
+ */
+export function projectModelForTool(raw: unknown): ProjectedModel | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const row = raw as Record<string, unknown>;
+
+  const id = num(row.id);
+  const name = str(row.name, MAX_PROJECTED_NAME_CHARS);
+  if (id === undefined || name === undefined) return null;
+
+  const creatorRecord =
+    row.creator !== null && typeof row.creator === 'object'
+      ? (row.creator as Record<string, unknown>)
+      : undefined;
+
+  // The newest published version is the only one a "which model should I use"
+  // answer needs; the full version list is both noise and budget.
+  const versions = Array.isArray(row.modelVersions) ? row.modelVersions : [];
+  const latest =
+    versions.length > 0 && versions[0] !== null && typeof versions[0] === 'object'
+      ? (versions[0] as Record<string, unknown>)
+      : undefined;
+
+  const statsRecord =
+    row.stats !== null && typeof row.stats === 'object'
+      ? (row.stats as Record<string, unknown>)
+      : undefined;
+
+  const tags = Array.isArray(row.tags)
+    ? row.tags
+        .map((t) => str(t, 40))
+        .filter((t): t is string => t !== undefined)
+        .slice(0, MAX_PROJECTED_TAGS)
+    : undefined;
+
+  const projected: ProjectedModel = {
+    id,
+    name,
+    ...(str(row.type, 40) !== undefined ? { type: str(row.type, 40) } : {}),
+    ...(latest && str(latest.baseModel, 40) !== undefined
+      ? { baseModel: str(latest.baseModel, 40) }
+      : {}),
+    ...(creatorRecord && str(creatorRecord.username, 60) !== undefined
+      ? { creator: str(creatorRecord.username, 60) }
+      : {}),
+    ...(statsRecord && num(statsRecord.downloadCount) !== undefined
+      ? { downloads: num(statsRecord.downloadCount) }
+      : {}),
+    ...(tags && tags.length > 0 ? { tags } : {}),
+    url: `https://civitai.com/models/${id}`,
+  };
+
+  // Belt and braces over the allowlist: a user-authored name or tag can still
+  // carry the literal. See `neutralizeAirLiterals`.
+  return neutralizeAirLiterals(projected);
+}
+
+/**
+ * Bound a projected list to the serialized-character budget.
+ *
+ * 🔴 DROPS WHOLE ROWS, NEVER TRUNCATES THE SERIALISED STRING. Cutting a JSON
+ * string at a byte offset produces invalid JSON, which the block then cannot
+ * parse and the model cannot read — a failure mode strictly worse than fewer
+ * results. So rows are added while they fit and the remainder is reported as a
+ * count, which also tells the model that more exist.
+ */
+export function boundToolResult(items: ProjectedModel[]): {
+  items: ProjectedModel[];
+  truncated: number;
+} {
+  const kept: ProjectedModel[] = [];
+  for (const item of items.slice(0, MAX_TOOL_RESULT_ITEMS)) {
+    const candidate = [...kept, item];
+    if (JSON.stringify({ items: candidate }).length > MAX_TOOL_RESULT_CHARS) break;
+    kept.push(item);
+  }
+  return { items: kept, truncated: items.length - kept.length };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE REGISTRY.
+//
+// 🔴 ONE SCHEMA PER TOOL, AND THE JSON SCHEMA IS DERIVED FROM IT. The
+// `parameters` object handed to the model is `z.toJSONSchema(argsSchema)`, not a
+// hand-written twin. That makes "the model was shown a contract the route does
+// not enforce" structurally impossible rather than test-enforced: there is only
+// one definition, and the served document is a projection of it. (The repo
+// already uses `z.toJSONSchema` this way in `~/server/utils/moderator-endpoint`.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const searchModelsArgs = z
+  .object({
+    query: z.string().min(1).max(200).describe('Free-text search over model names and keywords'),
+    type: z
+      .enum(['Checkpoint', 'LORA', 'LoCon', 'TextualInversion', 'VAE', 'Controlnet'])
+      .optional()
+      .describe('Restrict to one model type'),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_TOOL_RESULT_ITEMS)
+      .optional()
+      .describe(`Maximum results to return (default 5, max ${MAX_TOOL_RESULT_ITEMS})`),
+  })
+  .strict();
+
+export type SearchModelsArgs = z.infer<typeof searchModelsArgs>;
+
+export type BlockToolDefinition = {
+  /** The tool name the model calls. Must satisfy the chat step's `TOOL_NAME_PATTERN`. */
+  name: string;
+  /** Shown to the model. */
+  description: string;
+  /** The argument contract — the ONE definition. */
+  argsSchema: z.ZodType;
+};
+
+const TOOLS: readonly BlockToolDefinition[] = [
+  {
+    name: 'search_models',
+    description:
+      "Search Civitai's model catalog by free text. Returns matching models with their id, " +
+      'name, type, base model, creator and download count. Results are restricted to what ' +
+      'this viewer is allowed to see.',
+    argsSchema: searchModelsArgs,
+  },
+] as const;
+
+/**
+ * The allowlist, frozen, with a null prototype.
+ *
+ * The null prototype is a control, not a style choice — the same one the step
+ * registry documents for `STEP_TYPE_ACCEPTABLE_POSTURES`. With a plain object a
+ * lookup for the tool name `toString` returns `Object.prototype.toString`, which
+ * is TRUTHY, so an `if (!tool) reject` guard fails OPEN on a prototype key. With
+ * a null prototype every non-own key reads `undefined` and is rejected.
+ */
+const TOOLS_BY_NAME: Readonly<Record<string, BlockToolDefinition>> = Object.freeze(
+  Object.assign(
+    Object.create(null) as Record<string, BlockToolDefinition>,
+    Object.fromEntries(TOOLS.map((t) => [t.name, t]))
+  )
+);
+
+/** The registered tool names, in declaration order. */
+export const BLOCK_TOOL_NAMES: readonly string[] = TOOLS.map((t) => t.name);
+
+/** Look up a tool by name. Returns `undefined` for anything not registered. */
+export function getBlockTool(name: string): BlockToolDefinition | undefined {
+  return TOOLS_BY_NAME[name];
+}
+
+/**
+ * The tool definitions as a block declares them to the model — the exact
+ * `tools[]` payload shape the chat-completion step accepts.
+ *
+ * Derived, never hand-written: `parameters` is `z.toJSONSchema` of the same
+ * `argsSchema` the route validates against.
+ */
+export function blockToolDeclarations(): Array<{
+  type: 'function';
+  function: { name: string; description: string; parameters: unknown };
+}> {
+  return TOOLS.map((tool) => ({
+    type: 'function' as const,
+    function: {
+      name: tool.name,
+      description: tool.description,
+      // `io: 'input'` because this describes what the model SENDS; matches the
+      // call form already used elsewhere in the repo.
+      parameters: z.toJSONSchema(tool.argsSchema, { io: 'input', unrepresentable: 'any' }),
+    },
+  }));
+}

--- a/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
+++ b/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
@@ -54,26 +54,30 @@ describe('block catalog endpoints — opaque-origin CORS wiring (PR #2681)', () 
   // The two `await import(...)` cold-transform a Next API page graph (~10s on a
   // loaded box) — right at the 10s global default, so worker-pool contention pushed
   // it over and flaked. Give this import-bound test a generous explicit budget.
-  it('all of /api/v1/blocks/{models,images,tools} opt into allowOpaqueOrigin', { timeout: 60000 }, async () => {
-    // Import order: models, images, tools → captured in that order.
-    await import('~/pages/api/v1/blocks/models');
-    await import('~/pages/api/v1/blocks/images');
-    // The tool surface (#398 AC5) is called DIRECTLY from the sandboxed iframe
-    // during a tool-calling loop, so it needs the same opaque-origin opt-in —
-    // and, like the other two, it would fail only in prod (405 on the CORS
-    // preflight) with every test still green.
-    await import('~/pages/api/v1/blocks/tools');
+  it(
+    'all of /api/v1/blocks/{models,images,tools} opt into allowOpaqueOrigin',
+    { timeout: 60000 },
+    async () => {
+      // Import order: models, images, tools → captured in that order.
+      await import('~/pages/api/v1/blocks/models');
+      await import('~/pages/api/v1/blocks/images');
+      // The tool surface (#398 AC5) is called DIRECTLY from the sandboxed iframe
+      // during a tool-calling loop, so it needs the same opaque-origin opt-in —
+      // and, like the other two, it would fail only in prod (405 on the CORS
+      // preflight) with every test still green.
+      await import('~/pages/api/v1/blocks/tools');
 
-    expect(captured).toHaveLength(3);
-    // Every catalog endpoint must opt in — else an unverified (opaque-origin)
-    // block's direct catalog fetch 405s on the CORS preflight again.
-    for (const opts of captured) {
-      expect(opts.allowOpaqueOrigin).toBe(true);
+      expect(captured).toHaveLength(3);
+      // Every catalog endpoint must opt in — else an unverified (opaque-origin)
+      // block's direct catalog fetch 405s on the CORS preflight again.
+      for (const opts of captured) {
+        expect(opts.allowOpaqueOrigin).toBe(true);
+      }
+      // And neither catalog endpoint declares a requiredScope ("any valid block
+      // token" mode) — the maturity clamp is the whole authority surface.
+      for (const opts of captured) {
+        expect(opts.requiredScope).toBeUndefined();
+      }
     }
-    // And neither catalog endpoint declares a requiredScope ("any valid block
-    // token" mode) — the maturity clamp is the whole authority surface.
-    for (const opts of captured) {
-      expect(opts.requiredScope).toBeUndefined();
-    }
-  });
+  );
 });

--- a/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
+++ b/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
@@ -54,12 +54,17 @@ describe('block catalog endpoints — opaque-origin CORS wiring (PR #2681)', () 
   // The two `await import(...)` cold-transform a Next API page graph (~10s on a
   // loaded box) — right at the 10s global default, so worker-pool contention pushed
   // it over and flaked. Give this import-bound test a generous explicit budget.
-  it('both /api/v1/blocks/{models,images} opt into allowOpaqueOrigin', { timeout: 60000 }, async () => {
-    // Import order: models then images → captured = [modelsOpts, imagesOpts].
+  it('all of /api/v1/blocks/{models,images,tools} opt into allowOpaqueOrigin', { timeout: 60000 }, async () => {
+    // Import order: models, images, tools → captured in that order.
     await import('~/pages/api/v1/blocks/models');
     await import('~/pages/api/v1/blocks/images');
+    // The tool surface (#398 AC5) is called DIRECTLY from the sandboxed iframe
+    // during a tool-calling loop, so it needs the same opaque-origin opt-in —
+    // and, like the other two, it would fail only in prod (405 on the CORS
+    // preflight) with every test still green.
+    await import('~/pages/api/v1/blocks/tools');
 
-    expect(captured).toHaveLength(2);
+    expect(captured).toHaveLength(3);
     // Every catalog endpoint must opt in — else an unverified (opaque-origin)
     // block's direct catalog fetch 405s on the CORS preflight again.
     for (const opts of captured) {

--- a/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
+++ b/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
@@ -14,7 +14,11 @@ import { describe, it, expect, vi } from 'vitest';
  * in prod (405 on the CORS preflight).
  *
  * This test captures the exact opts each endpoint module passes to
- * `withBlockScope` at import time and asserts the opaque-origin opt is present.
+ * `withBlockScope` at import time and asserts THREE things about them: the
+ * opaque-origin opt is present, no `requiredScope` is declared, and each route
+ * carries its OWN `endpoint` label. The last one is here for the same reason as
+ * the first — it is invisible to the endpoint-behavior tests (which mock
+ * `withBlockScope` away entirely) and would degrade only in prod telemetry.
  */
 
 // Capture the opts each endpoint hands to withBlockScope at module-eval time.
@@ -55,7 +59,7 @@ describe('block catalog endpoints — opaque-origin CORS wiring (PR #2681)', () 
   // loaded box) — right at the 10s global default, so worker-pool contention pushed
   // it over and flaked. Give this import-bound test a generous explicit budget.
   it(
-    'all of /api/v1/blocks/{models,images,tools} opt into allowOpaqueOrigin',
+    'all of /api/v1/blocks/{models,images,tools} opt into allowOpaqueOrigin, declare no requiredScope, and carry their own endpoint label',
     { timeout: 60000 },
     async () => {
       // Import order: models, images, tools → captured in that order.
@@ -78,6 +82,22 @@ describe('block catalog endpoints — opaque-origin CORS wiring (PR #2681)', () 
       for (const opts of captured) {
         expect(opts.requiredScope).toBeUndefined();
       }
+      // 🔴 EACH ENDPOINT DECLARES ITS OWN `endpoint` LABEL, asserted per-route
+      // rather than in the loops above — the loops check a property they SHARE,
+      // this checks the one thing that must DIFFER between them.
+      //
+      // Why it is pinned here and not left to the endpoint tests: a delta audit
+      // found `endpoint: 'tools'` → `'models'` typechecks (`AppBlockEndpoint` is
+      // a union containing both) and survived all ~23.9k tests — the sole
+      // surviving mutant in the suite. The blast radius is narrow but real and
+      // SILENT: the audit row takes its endpoint from `normalizeEndpoint(req.url)`
+      // in the middleware, NOT from these opts, so the rows stay correct; what
+      // breaks is the Prometheus RED pair (`civitai_app_block_requests_total` /
+      // `_request_duration_seconds`), which would merge tool traffic into
+      // `models` with nothing anywhere reporting a fault.
+      //
+      // Index order is the import order above: models, images, tools.
+      expect(captured.map((opts) => opts.endpoint)).toEqual(['models', 'images', 'tools']);
     }
   );
 });

--- a/src/tests/api/v1/blocks/tools-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tools-endpoint.test.ts
@@ -320,3 +320,141 @@ describe('/api/v1/blocks/tools — rate limit', () => {
     expect(mockCheckRateLimit).toHaveBeenCalledWith('bki_test');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GAPS AN AUDIT FOUND BY MUTATION. Each case below corresponds to a mutant that
+// SURVIVED the original 42-test suite — i.e. the guard could be deleted and
+// nothing went red. They are grouped rather than scattered so the reason they
+// exist stays legible.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('🔴 /api/v1/blocks/tools — guards that were unpinned', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    regionBox.restricted = false;
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
+    mockResolveModelSearchIds.mockResolvedValue({ searchIds: [], nextCursor: undefined });
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  // 🔴 NOT defence in depth. `withBlockScope` falls through to the wrapped
+  // handler — rather than rejecting — both when no bearer token is present and
+  // when `app-blocks-runtime-enabled` is off. Deleting the handler's own `!claims`
+  // check therefore serves the declarations UNAUTHENTICATED. It previously
+  // survived the whole suite.
+  it('🔴 a request with NO claims is 401, on GET and on POST', async () => {
+    claimsBox.claims = undefined;
+
+    const get = await invoke('GET');
+    expect(get.statusCode).toBe(401);
+    expect(get.body).toEqual({ error: 'Block token required' });
+    // The declarations must not leak through the unauthenticated path.
+    expect(get.body.tools).toBeUndefined();
+
+    const post = await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+    expect(post.statusCode).toBe(401);
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL — the same GET succeeds once claims are present', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    const res = await invoke('GET');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.tools).toBeDefined();
+  });
+
+  // 🔴 THE SEAM. `boundToolResult` was unit-tested in isolation and the endpoint
+  // never asserted its OUTPUT was bounded, so replacing the call with a
+  // passthrough survived every test. Losing it produces a result the block
+  // CANNOT replay — the chat step rejects an over-length `role:'tool'` message —
+  // with no diagnostic. The fixture is deliberately maximal so the CHAR budget
+  // binds before the item cap; asserting `< MAX_TOOL_RESULT_ITEMS` can only hold
+  // if the budget actually ran.
+  it('🔴 the char budget is applied AT THE SEAM, not merely unit-tested', async () => {
+    const { MAX_TOOL_RESULT_ITEMS, MAX_TOOL_RESULT_CHARS } = await import(
+      '~/server/services/blocks/tools/registry'
+    );
+    const fat = Array.from({ length: MAX_TOOL_RESULT_ITEMS }, (_, i) => ({
+      ...rawRow(1000 + i),
+      name: 'N'.repeat(300),
+      creator: { username: 'U'.repeat(200) },
+      tags: Array.from({ length: 8 }, () => 'T'.repeat(80)),
+    }));
+    mockRunModelSearch.mockResolvedValue({ items: fat, nextCursor: undefined });
+
+    const res = await invoke('POST', {
+      name: 'search_models',
+      arguments: { query: 'x', limit: MAX_TOOL_RESULT_ITEMS },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.result.items.length).toBeLessThan(MAX_TOOL_RESULT_ITEMS);
+    expect(res.body.result.truncated).toBeGreaterThan(0);
+    expect(JSON.stringify(res.body.result.items).length).toBeLessThanOrEqual(MAX_TOOL_RESULT_CHARS);
+  });
+
+  // The meili timeout arm: mutating its 503 to a 200 previously survived.
+  it('🔴 a meili timeout is a 503 with Retry-After, not a 200', async () => {
+    const { ModelSearchMeiliTimeoutError } = await import('~/server/services/model-search.service');
+    mockResolveModelSearchIds.mockRejectedValue(new ModelSearchMeiliTimeoutError());
+
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('2');
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+    // 🔴 A LITERAL, never `e.message`. `rest-error-envelope-ledger` flags
+    // `{ error: <ident>.message }` as a class regardless of whose text it is, and
+    // a brand-new route must not land in that baseline.
+    expect(typeof res.body.error).toBe('string');
+    expect(res.body.error).toBe('Model search is temporarily overloaded — please retry.');
+  });
+
+  it('🔴 the wire body is STRICT — an unknown top-level key is rejected', async () => {
+    const res = await invoke('POST', {
+      name: 'search_models',
+      arguments: { query: 'x' },
+      extra: 'nope',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  // nit 8: both 400 bodies reflect caller input, and the block hands our reply to
+  // a chat model as a `role:'tool'` message — where `containsAirReference` throws
+  // FORBIDDEN on the literal `urn:air:`. The wire pattern makes the `name`
+  // reflection structurally inert; the scrub covers the free-text argument path.
+  it('🔴 a tool NAME carrying an AIR literal is rejected, and the reply is replayable', async () => {
+    const res = await invoke('POST', {
+      name: 'urn:air:sd1:checkpoint:civitai:4384@128713',
+      arguments: { query: 'x' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.stringify(res.body).toLowerCase()).not.toContain('urn:air:');
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  // 🔴 THE FIXTURE HAS TO REACH THE SCRUB, AND THE OBVIOUS ONE DOES NOT. A first
+  // version sent `limit: 'urn:air:…'` — an invalid VALUE — and the mutant that
+  // deletes the scrub SURVIVED, because zod reports "expected number, received
+  // string" without echoing the value, so no AIR was ever in the message to
+  // scrub. `.strict()`'s `unrecognized_keys` DOES echo the offending KEY
+  // (measured: `Unrecognized key: "<key>"`), which is the path that reaches it.
+  it('🔴 an ARGUMENT carrying an AIR literal yields a replayable 400 body', async () => {
+    const res = await invoke('POST', {
+      name: 'search_models',
+      arguments: { query: 'x', 'urn:air:sd1:checkpoint:civitai:4384@128713': 1 },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.stringify(res.body).toLowerCase();
+
+    // POSITIVE CONTROL — the key WAS echoed, so the reflection path is live and
+    // this assertion is not passing merely because nothing was reflected.
+    expect(body).toContain('unrecognized key');
+    expect(body).toContain('checkpoint:civitai:4384');
+
+    // …and the AIR prefix within that echo is neutralised, so the block can
+    // replay this body as a `role:'tool'` message without a FORBIDDEN.
+    expect(body).not.toContain('urn:air:');
+  });
+});

--- a/src/tests/api/v1/blocks/tools-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tools-endpoint.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  sfwBrowsingLevelsFlag,
+  allBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Endpoint-wiring tests for /api/v1/blocks/tools (#398 AC5).
+ *
+ * 🔴 THE POINT OF THIS FILE IS THE CLAMP. `withBlockScope` does NOT supply the
+ * maturity clamp — it gives a route the JWT gate, CORS, the rate limit and the
+ * audit row, and nothing else. A route added under `/api/v1/blocks/*` that never
+ * calls `resolveCatalogBrowsingLevel` is UNCLAMPED while looking exactly as
+ * protected as its neighbours, and no wrapper-level test would notice. So the
+ * clamp assertions here carry a positive control: a RED token must produce a
+ * DIFFERENT browsing level from a GREEN one, which is what distinguishes "the
+ * clamp is applied" from "the search is wired to a constant".
+ *
+ * withBlockScope is mocked as a passthrough that stamps req.blockClaims (the
+ * real token path is covered by the middleware's own tests); the search service
+ * is mocked so no Prisma client loads. The opaque-origin CORS opt-in is pinned
+ * separately in catalog-cors-wiring.test.ts, because a passthrough mock here
+ * cannot see it.
+ */
+
+const { mockRunModelSearch, mockResolveModelSearchIds, mockCheckRateLimit } = vi.hoisted(() => ({
+  mockRunModelSearch: vi.fn(),
+  mockResolveModelSearchIds: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+}));
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+
+vi.mock('~/server/services/model-search.service', () => ({
+  runModelSearch: mockRunModelSearch,
+  resolveModelSearchIds: mockResolveModelSearchIds,
+  ModelSearchMeiliTimeoutError: class extends Error {},
+}));
+
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockCheckRateLimit,
+}));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+}));
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (handler: any) => handler }));
+
+const regionBox = { restricted: false };
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({
+    countryCode: regionBox.restricted ? 'GB' : 'US',
+    regionCode: null,
+    fullLocationCode: regionBox.restricted ? 'GB' : 'US',
+  }),
+  isRegionRestricted: () => regionBox.restricted,
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  handleEndpointError: (res: any, e: any) => res.status(500).json({ error: String(e) }),
+}));
+
+vi.mock('~/server/utils/pagination-helpers', () => ({
+  getNextPage: () => ({ baseUrl: { origin: 'https://civitai.com' }, nextPage: undefined }),
+}));
+
+function fakeClaims(over: Partial<BlockTokenClaims>): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti',
+    blockId: 'blk',
+    appId: 'app',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    ctx: {},
+    scopes: [],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+function fakeRes() {
+  const res: any = {
+    headers: {},
+    setHeader(k: string, v: unknown) {
+      this.headers[k] = v;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(b: unknown) {
+      this.body = b;
+      return this;
+    },
+  };
+  return res as NextApiResponse & { statusCode?: number; body?: any; headers: any };
+}
+
+async function invoke(method: 'GET' | 'POST' | 'DELETE', body?: unknown) {
+  const mod = await import('~/pages/api/v1/blocks/tools');
+  const handler = mod.default as (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
+  const req = {
+    method,
+    query: {},
+    body,
+    headers: {},
+    url: '/api/v1/blocks/tools',
+  } as unknown as NextApiRequest;
+  const res = fakeRes();
+  await handler(req, res);
+  return res;
+}
+
+/** A raw search row carrying the fields the projection must strip. */
+function rawRow(id = 4384) {
+  return {
+    id,
+    name: 'DreamShaper',
+    type: 'Checkpoint',
+    creator: { username: 'Lykon' },
+    stats: { downloadCount: 10 },
+    tags: ['photorealistic'],
+    modelVersions: [
+      {
+        id: 128713,
+        baseModel: 'SD 1.5',
+        air: `urn:air:sd1:checkpoint:civitai:${id}@128713`,
+        files: [{ name: 'x.safetensors', hashes: { SHA256: 'abc' } }],
+      },
+    ],
+  };
+}
+
+describe('/api/v1/blocks/tools — the allowlist and the argument contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    regionBox.restricted = false;
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
+    mockResolveModelSearchIds.mockResolvedValue({ searchIds: [], nextCursor: undefined });
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  it('GET returns the tool declarations', async () => {
+    const res = await invoke('GET');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.tools.map((t: any) => t.function.name)).toEqual(['search_models']);
+    expect(res.body.tools[0].function.parameters).toBeDefined();
+  });
+
+  it('🔴 POST with an UNKNOWN tool name is rejected, and never reaches the catalog', async () => {
+    const res = await invoke('POST', { name: 'delete_everything', arguments: {} });
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toContain('unknown tool');
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  it('🔴 POST with a PROTOTYPE key as the tool name is rejected', async () => {
+    for (const name of ['toString', 'constructor']) {
+      const res = await invoke('POST', { name, arguments: {} });
+      expect(res.statusCode, `tool name '${name}'`).toBe(400);
+    }
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  it('🔴 POST with arguments failing the tool schema is rejected before the catalog', async () => {
+    const res = await invoke('POST', { name: 'search_models', arguments: { nope: 1 } });
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toContain('invalid arguments');
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL — a VALID call does reach the catalog', async () => {
+    // Without this, a handler that rejected everything would pass all three
+    // cases above.
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'dream' } });
+    expect(res.statusCode).toBe(200);
+    expect(mockRunModelSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-GET/POST method is rejected', async () => {
+    expect((await invoke('DELETE')).statusCode).toBe(405);
+  });
+});
+
+describe('🔴 /api/v1/blocks/tools — the maturity clamp is applied IN THIS HANDLER', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    regionBox.restricted = false;
+    mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
+    mockResolveModelSearchIds.mockResolvedValue({ searchIds: [], nextCursor: undefined });
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  it('GREEN token → the CLAMPED SFW level reaches the search, passthrough false', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+
+    expect(res.statusCode).toBe(200);
+    const [args, ctx] = mockRunModelSearch.mock.calls[0];
+    expect(ctx.browsingLevel).toBe(sfwBrowsingLevelsFlag);
+    expect(ctx.nsfwImagePassthrough).toBe(false);
+    expect(ctx.user).toBeUndefined();
+    expect(args.disableMinor).toBe(true);
+    // No mature bits leak.
+    expect(ctx.browsingLevel & (4 | 8 | 16)).toBe(0);
+    expect(res.body.maturity.sfwOnly).toBe(true);
+  });
+
+  it('🔴 POSITIVE CONTROL — a RED token yields a DIFFERENT level', async () => {
+    // This is what separates "the clamp is applied" from "the search is wired to
+    // a constant". Without it, a handler that hardcoded the SFW flag would pass
+    // the green case above.
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: allBrowsingLevelsFlag });
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+
+    const [, ctx] = mockRunModelSearch.mock.calls[0];
+    expect(ctx.browsingLevel).toBe(allBrowsingLevelsFlag);
+    expect(ctx.browsingLevel).not.toBe(sfwBrowsingLevelsFlag);
+    expect(res.body.maturity.sfwOnly).toBe(false);
+  });
+
+  it('🔴 a MISSING claim FAILS CLOSED to SFW', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: undefined });
+    await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+    const [, ctx] = mockRunModelSearch.mock.calls[0];
+    expect(ctx.browsingLevel).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('🔴 a region-restricted viewer is clamped DOWN even on a RED token', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: allBrowsingLevelsFlag });
+    regionBox.restricted = true;
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+    const [, ctx] = mockRunModelSearch.mock.calls[0];
+    expect(ctx.browsingLevel).toBe(sfwBrowsingLevelsFlag);
+    expect(res.body.maturity.sfwOnly).toBe(true);
+  });
+
+  it('the clamped level is also what the meili id resolution is given', async () => {
+    // The clamp has to reach BOTH calls; a search that resolved ids at an
+    // unclamped level would surface mature ids before the second filter.
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+    expect(mockResolveModelSearchIds.mock.calls[0][0].browsingLevel).toBe(sfwBrowsingLevelsFlag);
+  });
+});
+
+describe('/api/v1/blocks/tools — the result is projected, scrubbed and bounded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    regionBox.restricted = false;
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    mockResolveModelSearchIds.mockResolvedValue({ searchIds: [4384], nextCursor: undefined });
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
+  });
+
+  it('🔴 the response carries no AIR literal — POSITIVE CONTROL on the source first', async () => {
+    mockRunModelSearch.mockResolvedValue({ items: [rawRow()], nextCursor: undefined });
+    // POSITIVE CONTROL: the upstream row really does carry one.
+    expect(JSON.stringify(rawRow())).toContain('urn:air:');
+
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'dream' } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.stringify(res.body).toLowerCase()).not.toContain('urn:air:');
+  });
+
+  it('🔴 the response carries no files, hashes or download urls', async () => {
+    mockRunModelSearch.mockResolvedValue({ items: [rawRow()], nextCursor: undefined });
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'dream' } });
+    const json = JSON.stringify(res.body);
+    expect(json).not.toContain('safetensors');
+    expect(json).not.toContain('SHA256');
+    // POSITIVE CONTROL — the useful fields ARE present, so this is not passing
+    // because the response is empty.
+    expect(res.body.result.items[0]).toMatchObject({ id: 4384, name: 'DreamShaper' });
+  });
+
+  it('the response respects the caller limit', async () => {
+    mockRunModelSearch.mockResolvedValue({
+      items: [rawRow(1), rawRow(2), rawRow(3)],
+      nextCursor: undefined,
+    });
+    await invoke('POST', { name: 'search_models', arguments: { query: 'd', limit: 2 } });
+    expect(mockRunModelSearch.mock.calls[0][0].limit).toBe(2);
+  });
+});
+
+describe('/api/v1/blocks/tools — rate limit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    regionBox.restricted = false;
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
+    mockResolveModelSearchIds.mockResolvedValue({ searchIds: [], nextCursor: undefined });
+  });
+
+  it('🔴 429s and never reaches the catalog when the per-token limit trips', async () => {
+    mockCheckRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 7 });
+    const res = await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['Retry-After']).toBe('7');
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  it('🔴 the limiter is keyed on the blockInstanceId', async () => {
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
+    await invoke('POST', { name: 'search_models', arguments: { query: 'x' } });
+    expect(mockCheckRateLimit).toHaveBeenCalledWith('bki_test');
+  });
+});

--- a/src/tests/api/v1/blocks/tools-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tools-endpoint.test.ts
@@ -410,27 +410,103 @@ describe('🔴 /api/v1/blocks/tools — guards that were unpinned', () => {
     expect(res.body.error).toBe('Model search is temporarily overloaded — please retry.');
   });
 
-  it('🔴 the wire body is STRICT — an unknown top-level key is rejected', async () => {
+  // 🔴 THE UNKNOWN KEY IS AN AIR LITERAL, AND THAT IS THE POINT OF THIS FIXTURE.
+  // This test drives the WIRE 400 (`invalid request body: …`), which is the only
+  // path that reaches the scrub on that body. With a benign key (`extra`) the
+  // mutant that DELETES `neutralizeAirLiterals` from the wire 400 survived the
+  // whole suite — nothing else in the file ever put an AIR into that message.
+  // Measured: zod's `unrecognized_keys` echoes the offending KEY verbatim
+  // (`Unrecognized key: "urn:air:…"`), so this fixture reaches the scrub where an
+  // invalid VALUE would not have.
+  it('🔴 the wire body is STRICT, and its 400 is replayable', async () => {
     const res = await invoke('POST', {
       name: 'search_models',
       arguments: { query: 'x' },
-      extra: 'nope',
+      'urn:air:sd1:checkpoint:civitai:4384@128713': 1,
     });
     expect(res.statusCode).toBe(400);
     expect(mockRunModelSearch).not.toHaveBeenCalled();
+
+    const body = JSON.stringify(res.body).toLowerCase();
+    // POSITIVE CONTROL — the key WAS echoed, so the reflection path is live and
+    // the scrub assertion below is not passing merely because nothing reflected.
+    expect(body).toContain('unrecognized key');
+    expect(body).toContain('checkpoint:civitai:4384');
+    // …and the prefix is neutralised, so a block can replay this body as a
+    // `role:'tool'` message without tripping `containsAirReference`.
+    expect(body).not.toContain('urn:air:');
   });
 
   // nit 8: both 400 bodies reflect caller input, and the block hands our reply to
   // a chat model as a `role:'tool'` message — where `containsAirReference` throws
   // FORBIDDEN on the literal `urn:air:`. The wire pattern makes the `name`
   // reflection structurally inert; the scrub covers the free-text argument path.
-  it('🔴 a tool NAME carrying an AIR literal is rejected, and the reply is replayable', async () => {
+  // 🔴 PINNED AS A LITERAL, AND THE LIMIT OF THIS TEST IS STATED RATHER THAN
+  // IMPLIED. Next enforces `bodyParser.sizeLimit` in its own request pipeline,
+  // which `node-mocks-http` does not run — so NO unit test in this repo can
+  // observe the limit actually rejecting an oversized body, and a previous round
+  // reported this branch as "covered" when nothing mentioned `sizeLimit`
+  // anywhere in the suite (enumerated across every `*.test.ts(x)`, not sampled).
+  //
+  // What this DOES buy: widening the value becomes a deliberate test edit rather
+  // than a silent change. The route is an unauthenticated-until-`!claims`,
+  // iframe-facing POST, and dropping the field reverts it to Next's 1 MB default.
+  // That is worth a tripwire even though the enforcement itself is untested here.
+  it("🔴 the POST body limit is pinned at 8kb (enforcement is Next's, not exercised)", async () => {
+    const mod = await import('~/pages/api/v1/blocks/tools');
+    expect(mod.config).toEqual({ api: { bodyParser: { sizeLimit: '8kb' } } });
+  });
+
+  // 🔴 ASSERTS THE LENGTH BOUND'S OWN ERROR, NOT THE STATUS. A first version of
+  // this test asserted only `statusCode === 400`, and the mutant that widens
+  // `.max(64)` to `.max(640)` SURVIVED: a 65-char name then PARSES, falls through
+  // to the allowlist, and 400s as an unknown tool. Both arms returned 400, so the
+  // assertion fired identically on its own control and attributed nothing.
+  //
+  // The discriminator is the zod issue: HEAD emits `too_big` with `"maximum": 64`;
+  // under the mutant the body says `unknown tool` instead.
+  it('🔴 an over-long tool NAME is rejected BY THE LENGTH BOUND', async () => {
+    const res = await invoke('POST', {
+      name: 'a'.repeat(65),
+      arguments: { query: 'x' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+
+    // 🔴 THE RAW FIELD, not `JSON.stringify(res.body)` — stringifying escapes the
+    // inner quotes of the embedded zod issue (`\"maximum\": 64`), so a substring
+    // match against the un-escaped form silently never fires. Caught by watching
+    // this assertion fail on UNMUTATED code.
+    const err = String(res.body.error);
+    expect(err).toContain('too_big');
+    expect(err).toContain('"maximum": 64');
+    // …and NOT the next gate's message, which is what a widened bound would give.
+    expect(err).not.toContain('unknown tool');
+  });
+
+  // ⚠️ WHAT THIS PINS IS THE PATTERN, NOT THE SCRUB — and saying so matters,
+  // because an earlier version of this test was cited as covering the scrub and
+  // did not. `name` fails `.regex(TOOL_NAME_PATTERN)`, and zod's `invalid_format`
+  // does NOT echo the offending input (measured), so no AIR ever enters the body
+  // and `not.toContain('urn:air:')` would hold with the scrub deleted. The scrub
+  // is covered by the two unrecognized-key tests, which do echo.
+  //
+  // It is kept because the property it DOES pin is real and load-bearing: the
+  // wire pattern makes this reflection structurally inert, so the scrub is not
+  // the only thing standing between a caller-chosen name and a 400 body the
+  // block cannot replay.
+  it('🔴 a tool NAME carrying an AIR literal is rejected by the PATTERN, unreflected', async () => {
     const res = await invoke('POST', {
       name: 'urn:air:sd1:checkpoint:civitai:4384@128713',
       arguments: { query: 'x' },
     });
     expect(res.statusCode).toBe(400);
-    expect(JSON.stringify(res.body).toLowerCase()).not.toContain('urn:air:');
+    const body = JSON.stringify(res.body).toLowerCase();
+    // The pattern rejected it, and zod did not echo the value — so the body is
+    // free of the literal WITHOUT the scrub having been involved.
+    expect(body).toContain('must match pattern');
+    expect(body).not.toContain('urn:air:');
+    expect(body).not.toContain('checkpoint:civitai:4384');
     expect(mockRunModelSearch).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Adds the block-surface tool route for App Blocks chat tool calling (#398 AC5), so the loop landed in #4472 has something to call, plus the code-enumerated read-only allowlist AC5 asks for.

## 🔴 This deliberately does NOT build an MCP proxy

AC5's prose says *"Tool transport reaches MCP through a block-surface route."* A reviewer will expect a proxy in front of `mcp.civitai.com`. Measured against the live server, that design cannot be made safe:

- its `search_models` input schema has **no** `nsfw` / `browsingLevel` / maturity parameter and is `additionalProperties: false` — a proxy cannot pass the viewer's ceiling **in**;
- its results carry only `air` / `id` / `name` / `type` — **no maturity metadata at all** — so a proxy cannot filter what comes **back** either, short of re-resolving every returned id against our own database.

So a proxy under this path would be an unclamped catalog read. Instead the tools are backed by the same clamped path `/api/v1/blocks/models` already uses, which is strictly better for this purpose: the ceiling is applied server-side from the token claim and the client cannot widen it.

## 🔴 The maturity clamp is NOT inherited from the `/api/v1/blocks/*` prefix

This is the trap that makes the proxy *look* safe, and it is the single most important line in the change.

`withBlockScope` gives a route the JWT gate, revocation, `private, no-store`, opaque-origin CORS, the rate limit and the audit row. It does **not** give it the maturity clamp — `blocks/models.ts` says so in its own words, that `resolveCatalogBrowsingLevel` *"remains the whole authority surface"*. A route added under this prefix that forgets the call is unclamped while looking exactly as protected as its neighbours, and no wrapper-level test would notice.

This handler calls it itself, and the suite pins that with a **positive control**: a RED token must produce a *different* browsing level from a GREEN one. Without that control, "the clamp is applied" is indistinguishable from "the search is wired to a constant" — a handler that hardcoded the SFW flag would pass a green-only test.

## What is here

- **`services/blocks/tools/registry.ts`** — the read-only, first-party allowlist. Server-import-free (mirroring the stated rationale for `block-catalog-maturity`) so the security-relevant parts are unit-testable without dragging Prisma. Null-prototype lookup map, so a prototype key (`toString`) cannot resolve to a truthy inherited value and fail the guard open.
- **`pages/api/v1/blocks/tools.ts`** — `GET` returns the declarations, `POST { name, arguments }` executes one. Unknown name rejected; arguments validated **strictly** against that entry's own schema; rate limit shared with the catalog endpoint deliberately, so a block cannot get a second budget by routing the same search through here.
- **Single-sourced schema.** The `parameters` handed to the model is `z.toJSONSchema` of the *same* zod schema the route validates against (the call form the repo already uses in `moderator-endpoint`). A model cannot be shown a contract *this route* does not enforce, structurally rather than by test. ⚠️ **Narrower than it first read, and corrected after review:** that holds for what the GET *serves*. `blockToolDeclarations()` has no consumer other than this route's GET, so nothing constrains what a block puts in the chat step's `tools[]` — it can declare `search_models` to its own model with a different schema. The route still enforces its own contract; the claim is about the served declaration, not about every declaration a block can make.

## The AIR strip, and what it unblocks

`containsAirReference` throws FORBIDDEN on the literal `urn:air:` anywhere in a submitted step input — on the estimate path and the submit path both. A tool result is replayed as a `role:'tool'` message, so a result carrying the literal doesn't degrade, it makes the round trip **impossible**. A live MCP `search_models` call at `limit: 1` returned **31** of them.

Results are therefore projected through an **allowlist, never a denylist** — the raw search row carries every version, file, hash, download url and AIR, so a denylist is one upstream field addition away from leaking, and the raw row could never fit the replay budget anyway. AIR literals are then scrubbed as a residual pass (a user-authored model *name* can contain one), case-insensitively and including object keys, because the scan it defends against is both.

The result is bounded to stay replayable within `MAX_MESSAGE_CHARS`, dropping **whole rows** rather than truncating a serialized string into invalid JSON.

## Test coverage

**44 new tests** (26 registry + 16 endpoint + 2 drift-guard updates). Full run: **6276 passed / 270 files** across `services/blocks`, `tests/api/v1/blocks`, `middleware/__tests__`, `schema/blocks`, `routers/__tests__`. `pnpm typecheck` 0 errors.

Red→green is not meaningful for a module that did not exist, so every guard was **mutation-tested** instead. ⚠️ **The original claim of "16 mutants, no survivors" was a claim about the mutants imagined, not about the guards.** A blind audit ran 39 and **7 survived**; those gaps are closed in the round below, and the mutants are now 12 with no survivors. The original 16, each confirmed to fail with *that guard's own* error:

| mutant | killed by |
|---|---|
| plain-prototype lookup map | prototype-keys test |
| args schema not `.strict()` | unknown-key + maturity-key tests |
| no AIR scrub on projection | user-authored-name + round-trip |
| scrub made case-sensitive | case-insensitivity test |
| scrub skips object keys | keys test |
| projection passthrough | both allowlist tests |
| char budget removed | char-budget test *(see below)* |
| budget raised above the message cap | constant-link test |
| `parameters` hand-written | derivation test |
| clamp removed from handler | 4 clamp tests |
| allowlist check removed | unknown-name + prototype-key |
| args validation skipped | invalid-arguments test |
| rate limit ignored | 429 test |
| projection skipped in route | AIR + files tests |
| meili given an unclamped level | meili-clamp test |
| `allowOpaqueOrigin` dropped | CORS wiring guard |

**No survivors — but one mutant survived the first time and the fix was to the test, not the code.** Removing the char-budget break left the whole suite green: the fixture rows were ~339 chars, so ten came to ~3,400 against a 6,000 budget, and the **item cap** was doing all the work while the budget branch never executed. The test named "drops whole rows" was passing for a reason other than its name. Rebuilt with maximal rows (691 chars each, measured — budget binds at 8, below the item cap of 10) and an isolating assertion that fewer than the item cap came back, which can only be true if the budget bound. The mutant then dies to exactly that test.

**Positive controls**, because three of these tests would otherwise pass vacuously:

- the clamp test (RED must differ from GREEN, else "clamped" ≡ "wired to a constant");
- the AIR test (the raw fixture is asserted to *contain* `urn:air:` before asserting the projection does not — otherwise it passes on any fixture that never had one);
- the round-trip test's mirror (an **unprojected** result must be *refused* by `containsAirReference`, proving the guard is not inert).

**The round-trip test is the one that matters most:** a projected result placed in a `role:'tool'` message clears `containsAirReference` **and** the chat-completion param schema. Each half passing alone would not show the loop closes.

## Two of the repo's own drift guards fired, and both were actioned

Worth recording because they did their job:

1. **`KNOWN_STATIC_ENDPOINT_SEGMENTS`** — the new route's path segment was not in the audit-log allowlist. Two tests fired: one derives the set from the route files, and a second **pins the literal list** so adding a route is a deliberate edit rather than a silent widening. Both updated.
2. **The catalog opaque-origin CORS wiring guard**, which asserted exactly two endpoints opt in. The tool surface is called directly from the sandboxed iframe, so it needs the same opt-in — and, as that test's own comment says, dropping it would fail only in prod (405 on the preflight) with every test still green.

## Not done

- **No sensei integration** (#398 AC6) and no demonstration against the deployed app (AC7).
- **Only `search_models` is registered.** More read-only catalog tools are additive; each new one needs its backing route confirmed maturity-clamped **individually**, because the clamp is per-handler.
- **`@civitai/app-sdk` is not updated.** If a block should get these declarations through the SDK rather than the `GET`, that is a follow-up mirror.
- One pre-existing eslint error in `catalog-cors-wiring.test.ts` (`acquireBulkheadSlot: () => () => {}`, `no-empty-function`) is **not** introduced here — verified by running eslint against the `origin/main` copy of that file, which reports the identical error at the same line. Left alone as out of scope.



---

## Round 2 — CI was red, and an audit found seven guards unpinned

### The CI failure: `rest-error-envelope-ledger`

`Unit tests (3)` failed on a repo-wide guard that fails when any route under `src/pages/api` serializes an error object or its text into a response body.

🔴 **The local run structurally could not see it.** The suite was globbed over the blocks paths; **CI runs the whole `unit*` project**. So a green local number was a claim about a *different population* — and it happened to match the PR's own figure, which made it look like full coverage.

The offender was `{ error: e.message }` on the meili-timeout arm, matched by the ledger's `error|message: <ident>.message` shape. Established by mutation rather than by reading: reverting only that line reproduces the exact CI diff (`+ v1/blocks/tools.ts`), restoring it goes green.

That value is our own first-party string, not driver text — so this was the ledger **over-reporting**, not a live disclosure. The ledger's own docstring says the remedy for over-reporting is a baseline entry. **It is deliberately not taken:** a brand-new route does not belong in a list of *pre-existing* unfixed offenders, and writing the literal removes the offence instead of recording it. `blocks/models.ts` has the identical line and *is* baselined; it was not copied back.

### Guards that were unpinned (each now fails with its own assertion)

| guard | why it mattered |
|---|---|
| char budget **at the seam** | `boundToolResult` was unit-tested in isolation; no endpoint test asserted the response was bounded, so a passthrough survived all 42 tests. Losing it yields a result the block **cannot replay**, with no diagnostic. |
| `!claims` → 401 | **This is the gate, not defence in depth.** `withBlockScope` falls through to the wrapped handler both when no bearer is present and when the runtime flag is off — so deleting it serves the declarations **unauthenticated**. The comment claiming otherwise is corrected. |
| meili-timeout 503 + `Retry-After` | mutating the status to 200 survived |
| wire `.strict()` | an unknown top-level key was unrejected-and-untested |
| name / creator / tag length bounds, and `str()`'s truncation branch | all four widened to 100000 with the suite still green |

### Two defects introduced *while writing those tests*, recorded rather than quietly fixed

Both are the same shape the audit exists to catch:

1. The bound tests first derived their expected length **from the exported constant**, so widening the constant moved the assertion with it and all three mutants still survived. Expectations are now **literals**, with a drift guard asserting the literals are the shipped constants.
2. The AIR-in-arguments test first sent an invalid **value**, which zod reports without echoing — so no AIR ever reached the scrub and that mutant survived too. It now sends an unrecognized **key**, which zod does echo, with a positive control asserting the echo happened.

### Also in this round

- The wire `name` is pattern-bounded via the chat step's **exported** `TOOL_NAME_PATTERN` (imported, not re-spelled), which makes both 400 reflections structurally unable to carry `urn:air:`; the free-text argument reflection is scrubbed.
- `str()` no longer cuts through a **surrogate pair** — emoji names previously emitted lone surrogates.

### Not done / still open

- **`preview / component-tests` is failing and I could not attribute it.** It is marked *"report-only, not blocking"*. `preview / deploy` **passed**, so it is not a deploy cascade; the same check **succeeds** on PRs #4476 and #4477, so it is not blanket-broken. It cannot be reproduced locally (no Playwright browser in this environment — the run reports `Tests no tests`), and the status is posted by the preview pipeline with the site as its target URL, so there is no log to read. **Stated as unresolved rather than assumed unrelated.**
- Nits left as follow-ups: GET is unrate-limited; the rate-limit docstring still lists only `models`/`images`; the metrics label cannot separate the free GET from the catalog POST; `neutralizeAirLiterals` has no recursion budget (unreachable today).


---

## Round 3 (`66f6024214`) — a delta re-audit found six survivors and four false comments

The delta audit of round 2 found **no behavioural defect**, and confirmed the ledger fix, the seam pin, the 401 pin, the `TOOL_NAME_PATTERN` narrowing and the surrogate fix all hold. What it did find was **6 surviving mutants out of 27** against a round-2 body that claimed *"12 mutants, no survivors"* — a reminder that the number is a claim about the mutants *imagined*, not about the guards.

### The two that mattered — both "the fixture cannot reach the branch"

| mutant | why it survived | fix |
|---|---|---|
| delete `neutralizeAirLiterals` from the **wire** 400 | the test sent a `name` failing `.regex(...)`, and zod does **not** echo the input on `invalid_format` — so no AIR was ever produced and the assertion passed without the scrub running | the strict-key test now uses an **AIR literal as the unrecognized key** (zod *does* echo those), with a positive control asserting the echo happened |
| widen `str()`'s surrogate range to admit **low** surrogates | the only astral fixture was pure emoji, where high surrogates always land on even indices — so `charCodeAt(cut-1)` is *always* high and the range's upper bound never executes | one leading BMP char shifts the parity. Measured: HEAD → 120 chars, no lone surrogate; mutant → 119 ending in an orphan. Added at the name **and** tag bounds |

🔴 The first is the **same defect fixed one call site over in round 2**, reproduced at the neighbouring call site in the same commit.

### The rest

- **`type` and `baseModel` were left on a bare `40`** while the other three projected-string bounds were exported — so two of five sat outside the block whose docstring claimed to cover "individual projected strings", and widening either survived. Now named constants with reaching fixtures; all five are in the drift guard.
- **`bodyParser sizeLimit` was reported covered and was not** — nothing in the suite mentioned it. Next enforces it in a pipeline `node-mocks-http` does not run, so **no unit test here can observe the limit rejecting a body**. Pinned as a literal instead, with that limitation stated in the test rather than implied.
- **The wire `name` length bound now asserts its own zod issue.** A first version checked only for a 400 — and the widen-the-bound mutant survived, because an over-long name then parses and 400s as an *unknown tool*. Both arms returned 400, so the probe fired identically on its own control.

### Comments corrected — each measured, not reasoned

- The `!claims` gate names **three** fall-throughs, not two: `if (!bearer || !isBlockJwt(bearer))` is two conditions (the second being the legacy opaque API-key path) plus the runtime flag. 🔴 This comment had now been wrong **twice** about the same gate, so it says so and says to count them in the middleware.
- A test comment claimed each fixture is built from the exported constant. They are not — deliberately, because a constant-derived fixture moves *with* a widen-the-bound mutant and stops discriminating. Both copies corrected.
- An assertion claimed *"a lone surrogate does not survive a JSON round trip intact."* **Measured false**: well-formed `JSON.stringify` escapes it as `\udXXX` and `JSON.parse` restores it exactly, so it held for every string and carried no information — and it contradicted the source comment on `str()`. Replaced with a positive control on the detector itself.

### Verification

- **Mutation: 14 mutants, 0 survivors.** Baseline confirmed green before scoring; harness validated with a bad-mutant guard on occurrence count, and verdicts read from the runner's own result lines rather than an exit code.
- **Not mutated**, stated so the number is not read as coverage: the projection field allowlist, the rate-limit and audit-row wiring, and anything behind the passthrough `withBlockScope` mock.
- **Full `unit*` project as CI runs it: 1517 files / 23873 tests passed, 0 failures** (+6 tests). Round 2's local run globbed only the blocks paths and structurally could not see the ledger failure CI caught; this is the CI population, named.
- `pnpm typecheck` **0 errors**. ESLint **0 errors** (10 pre-existing `no-explicit-any` warnings). Prettier clean, **with a negative control** confirming the check can go red.



---

## Round 4 (`7759fa6bd9`) — the last delta audit was CLEAN; this is a tidy, not a fix

The delta re-audit of round 3 found **no behavioural defect** and ended the audit ladder. It proved the point mechanically rather than by reading: the **comment-stripped diff of `tools.ts` was empty** (all 18+/8− were comment) and `registry.ts`'s only semantic change was two constants replacing four literal `40`s — so round 3's source delta was behaviour-preserving *by construction*.

This round closes the three low findings that audit surfaced. It is **comment- and test-only**, and the same comment-stripped-diff proof is re-run below: **zero payload lines changed**, which is why no further audit round follows it.

### 1. The endpoint label — the sole surviving mutant in the entire suite

`endpoint: 'tools'` → `'models'` typechecks (`AppBlockEndpoint` is a union carrying both) and survived **all ~23.9k tests**.

The blast radius is narrow but silent, and worth stating precisely: the audit row takes its endpoint from `normalizeEndpoint(req.url)` in the middleware, **not** from these opts — so `BlockScopeInvocation` rows stay correct. What degrades is the Prometheus RED pair (`civitai_app_block_requests_total` / `_request_duration_seconds`), which would merge tool traffic into `models` with nothing anywhere reporting a fault.

`catalog-cors-wiring.test.ts` already asserted `allowOpaqueOrigin` and `requiredScope` across all three catalog routes — but both are `for` loops over a property the routes **share**, so the one value that must **differ** between them was never checked. Now asserted per-route in import order.

Mutant **killed**, by the new assertion's own message:

```
AssertionError: expected [ 'models', 'images', 'models' ] to deeply equal [ 'models', 'images', 'tools' ]
```

🔴 This is the area round 3 named as *unmutated*. Naming an uncovered area honestly does not cover it.

### 2. The `!claims` fall-through comment — third revision, now read from the function

Round 3 fixed the **count** (three, not two) but described case 2 as *"a bearer that is NOT a 3-part JWS — the legacy opaque API-key path"*, which is narrower than the branch. Read directly against `isBlockJwt`, it returns false for:

- anything that is not three **non-empty** dot-separated segments;
- a header that fails to base64url-decode or `JSON.parse`;
- a decodable header whose `alg` is not `RS256` **or** whose `typ` is not `JWT`.

So a well-formed JWS signed with the wrong alg falls through too, and the opaque API-key path is *one instance* of the case rather than its definition. The error direction was always safe — it **understated** the fall-through set, so it could only make the gate look more necessary — but this comment has now been wrong twice and imprecise once, so it is written from the function instead of from a remembered shape.

### 3. The `.max(64)` coupling — recorded, deliberately not closed

The wire spells the length bound as a literal against the chat step's `MAX_TOOL_NAME_CHARS`, which is **module-private** and therefore cannot be imported — so the two agree only by inspection. This is the same class the `TOOL_NAME_PATTERN` import closed, one axis over.

Closing it requires **exporting** that constant: a source change to a file merged in #4472. Left deliberate and named at the call site, identifying both sides, so the next person closes it on purpose rather than rediscovering it.

### Verification

- **Comment-stripped source delta is EMPTY**, re-proved with a **negative control** (appending a real statement makes the strip emit it). This is the property that makes another audit round unnecessary — proved, not assumed.
- Endpoint mutant **killed** with its own assertion message (above); baseline confirmed green **before** scoring, on an isolated `cp -a` copy with `.git` removed.
- **Full `unit*` project as CI runs it: 1517 files passed / 1 skipped (1518); 23873 passed / 26 skipped (23899), zero failures.** Unchanged count — an existing test was strengthened rather than a new one added.
- `pnpm typecheck` **0 errors**. Prettier clean on both files, **with a negative control** confirming the check can go red (its success line also prints on zero matches).
- ESLint reports **one pre-existing** `no-empty-function` error on an untouched mock line. Confirmed pre-existing by running eslint against the `origin/main` copy of that file, which reports the identical error — this commit only shifted its line number.

### Open items after this round

**Closed here:** the endpoint-label pin; the `!claims` comment's precision; the `.max(64)` coupling recorded.

**Still open, all pre-existing and none blocking:**

- **`preview / component-tests` remains unattributed** (see round 2) — report-only, not a deploy cascade, succeeds on #4476/#4477, not locally reproducible. Stated as unresolved rather than assumed unrelated.
- GET is unrate-limited (the expensive POST path is limited; each GET still costs a revocation read and an audit row).
- The rate-limit docstring still lists only `models`/`images` as the bucket's callers.
- The metrics label cannot separate the free GET from the catalog POST.
- `neutralizeAirLiterals` has no recursion budget — unreachable today (called only on a flat projected row), but the function is exported.
- `Math.min(limit ?? DEFAULT_LIMIT, MAX_TOOL_RESULT_ITEMS)` is redundant behind the args schema's own `.max(MAX_TOOL_RESULT_ITEMS)`; and `DEFAULT_LIMIT = 5` is unpinned against the literal `"default 5"` shown to the model in the tool declaration. Both judged harmless by the audit and left as-is.
- `@civitai/app-sdk` is not updated — a follow-up mirror if blocks should get the declarations through the SDK rather than the `GET`.
