### PR TITLE
fix(app-blocks): review-preview wildcard NACK must send an enum code, not free text

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -53,6 +53,7 @@ import {
   exceedsPreDownloadCap,
   resolveGetWildcardPackRequest,
   WILDCARD_MAX_CONCURRENT,
+  type WildcardPackErrorCode,
 } from './wildcardPackParse';
 import { resolveRequestConsent } from './requestConsentGate';
 import { resolveRequestSignIn } from './requestSignInGate';
@@ -209,6 +210,22 @@ type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token' | 'error';
 // understands why a side-effect refused, rather than the block silently hanging
 // (gotcha #73). Module-scope so referencing it in a handler adds no effect dep.
 const REVIEW_NACK_MESSAGE = 'not available in review preview';
+
+// 🔴 The ONE reviewMode NACK that must NOT use REVIEW_NACK_MESSAGE.
+// WILDCARD_PACK_RESULT's `error` is a DISCRIMINATED ENUM, not free text: the
+// block-side `isValidWildcardPackResult` rejects any value outside
+// not-found | forbidden | too-large | parse-failed | busy, and a rejected reply
+// is DROPPED by the SDK transport (console.warn only) — so a free-text NACK here
+// never settles the block's pending request and the caller hangs until the
+// transport timeout, the exact opposite of the fail-fast the handler promises.
+// `forbidden` is the in-set code: review preview genuinely is a permission
+// context, and it is the closest member semantically.
+//
+// The annotation is the GUARD — `WildcardPackErrorCode` is the repo's local
+// mirror of the SDK's `BlockWildcardPackErrorCode` (see wildcardPackParse.ts;
+// the pinned @civitai/app-sdk dist does not export the wildcard union yet), so
+// tsc rejects any future edit that swaps in a non-member string.
+const WILDCARD_REVIEW_NACK_CODE: WildcardPackErrorCode = 'forbidden';
 
 /**
  * The floor a `fit="fill"` host will not shrink below, in px.
@@ -2705,17 +2722,19 @@ export function PageBlockHost({
   // Author-scoped in-place edit of an OWN row: the auth/author-gate/belt/quota all
   // live in apps.shared.update (server, #3146); the host only forwards {key, value}
   // and relays the result. Reply is `{ ok, error? }` (SHARED_WITHDRAW-style, NOT
-  // SHARED_APPEND's `{ key }`) — the SDK 0.24 hook treats `!ok || error` as reject,
-  // and its isValidSharedUpdateResult REQUIRES a boolean `ok`, so BOTH paths send
-  // one (the error path MUST carry `ok: false` or the reply is dropped → hang).
+  // SHARED_APPEND's `{ key }`) — the SDK hook treats `!ok || error` as reject.
+  // isValidSharedUpdateResult now ACCEPTS an error reply with or without `ok`, so
+  // omitting it would no longer be dropped; both paths still send `ok` because an
+  // explicit `ok: false` is the clearer signal, not because it is required.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
       'SHARED_UPDATE',
       async (raw) => {
         if (reviewMode) {
           // Cross-user shared datastore WRITE (author-scoped edit) — NACK even in
-          // run-for-real (never a cross-user write). Reply MUST carry ok:false or the
-          // SDK drops it (→ hang). See handler doc.
+          // run-for-real (never a cross-user write). The validator accepts an error
+          // reply with or without `ok`; we send `ok: false` as the clearer signal.
+          // See handler doc.
           if (raw && typeof raw.requestId === 'string') {
             send('SHARED_UPDATE_RESULT', {
               requestId: raw.requestId,
@@ -3454,8 +3473,11 @@ export function PageBlockHost({
         // pending block could drive the MOD's real download entitlements to
         // resolve+fetch+unzip+parse an arbitrary modelVersionId's wildcard pack and
         // read the contents into the sandboxed iframe. NACK before resolving or
-        // downloading anything (fail-fast, never a hang).
-        send('WILDCARD_PACK_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+        // downloading anything (fail-fast, never a hang) — with the ENUM code, not
+        // REVIEW_NACK_MESSAGE: this reply's `error` is validated against a closed
+        // set block-side, so free text would be dropped and hang. See
+        // WILDCARD_REVIEW_NACK_CODE.
+        send('WILDCARD_PACK_RESULT', { requestId, error: WILDCARD_REVIEW_NACK_CODE });
         return;
       }
       // Concurrency cap (host-side backpressure): bound the per-tab memory. The

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -7,6 +7,10 @@ import { renderWithProviders } from '../../../test/component-setup';
 // `importOriginal` generic below be written without an inline `import()` type,
 // which the repo's `consistent-type-imports` rule forbids.
 import type * as MantineNotifications from '@mantine/notifications';
+// Type-only too (erased, so it cannot defeat vi.mock hoisting) — the repo's local
+// mirror of the SDK's `BlockWildcardPackErrorCode` union, used below so the
+// permitted-code list in this file cannot silently drift from the union.
+import type { WildcardPackErrorCode } from '~/components/AppBlocks/wildcardPackParse';
 
 /**
  * MOD REVIEW SANDBOX (#2831) — PageBlockHost `reviewMode` read-only gate.
@@ -144,6 +148,17 @@ function listenForReply() {
     stop: () => cw.removeEventListener('message', handler),
   };
 }
+
+// The closed set WILDCARD_PACK_RESULT.error is validated against block-side.
+// `satisfies` ties it to the union: adding/removing a member of
+// `WildcardPackErrorCode` without updating this list is a compile error.
+const WILDCARD_PACK_ERROR_CODES = [
+  'not-found',
+  'forbidden',
+  'too-large',
+  'parse-failed',
+  'busy',
+] as const satisfies readonly WildcardPackErrorCode[];
 
 const SAME_ORIGIN_SRC = `${window.location.origin}/`;
 const REVIEW_TOKEN = 'review.jwt.self-bound';
@@ -285,7 +300,7 @@ describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, n
     l.stop();
   });
 
-  test('GET_WILDCARD_PACK (session-authed, token-INDEPENDENT) → NACK, resolveWildcardPack NOT called', async () => {
+  test('GET_WILDCARD_PACK (session-authed, token-INDEPENDENT) → NACK with an IN-SET enum code, resolveWildcardPack NOT called', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
     await driveToReady();
     const l = listenForReply();
@@ -295,7 +310,15 @@ describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, n
     await vi.waitFor(() => expect(l.last('WILDCARD_PACK_RESULT')).toBeTruthy());
     const reply = l.last('WILDCARD_PACK_RESULT')!.payload as { requestId: string; error: string };
     expect(reply.requestId).toBe('wp1');
-    expect(reply.error).toBe('not available in review preview');
+    // 🔴 REGRESSION GUARD. Unlike every other reviewMode NACK, this reply's `error`
+    // is a DISCRIMINATED ENUM the block-side `isValidWildcardPackResult` checks
+    // against a closed set. A free-text NACK (e.g. REVIEW_NACK_MESSAGE) is rejected
+    // by that validator and DROPPED by the transport, so the block's pending
+    // request never settles — a spinner until the transport timeout, which is the
+    // opposite of the fail-fast this handler promises. Assert BOTH: membership in
+    // the five permitted codes, and the specific code we chose.
+    expect(WILDCARD_PACK_ERROR_CODES).toContain(reply.error);
+    expect(reply.error).toBe('forbidden');
     // The mod's session-authed download entitlement is NEVER exercised in review.
     expect(mocks.wildcard).not.toHaveBeenCalled();
     l.stop();

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -518,8 +518,10 @@ export const INVENTORY = {
   // User report of a posted shared row (Batch-D item 5) — the server procedure
   // `apps.shared.report` already exists; this is the postMessage seam. Same both-
   // host placement as SHARED_WITHDRAW (its reply is the SHARED_WITHDRAW-style
-  // `{ ok, error? }`: the error path MUST carry `ok: false` or the SDK drops it →
-  // hang). Ahead of the published SDK dist union — forward-looking coverage.
+  // `{ ok, error? }`: the validator accepts an error reply with or without `ok`,
+  // and the hosts send `ok: false` because it is the clearer signal, not because
+  // omitting it would hang). Ahead of the published SDK dist union — forward-
+  // looking coverage.
   SHARED_REPORT: {
     request: true,
     reply: 'SHARED_REPORT_RESULT',

--- a/src/components/AppBlocks/wildcardPackParse.ts
+++ b/src/components/AppBlocks/wildcardPackParse.ts
@@ -79,6 +79,13 @@ export function resolveGetWildcardPackRequest(raw: unknown): GetWildcardPackRequ
 
 // ── Error discriminants ──────────────────────────────────────────────────────
 
+// The CLOSED set WILDCARD_PACK_RESULT.error is validated against block-side —
+// this is the local mirror of the SDK's `BlockWildcardPackErrorCode`. The mirror
+// exists because the pinned @civitai/app-sdk dist does not export the wildcard
+// union yet (it predates the bridge); keep the two in step. Consumers SWITCH on
+// the code, so this is an enum, not free text — a reply carrying anything outside
+// this set is rejected by `isValidWildcardPackResult` and dropped by the
+// transport, leaving the block's pending request unsettled.
 export type WildcardPackErrorCode =
   | 'not-found'
   | 'forbidden'


### PR DESCRIPTION
## The bug

`WILDCARD_PACK_RESULT`'s `error` is a **discriminated enum**, not free text. The permitted values are `not-found | forbidden | too-large | parse-failed | busy`; consumers switch on the code, and the block-side `isValidWildcardPackResult` rejects anything outside that set. A rejected reply is dropped by the SDK transport with only a `console.warn`.

The `reviewMode` branch of `PageBlockHost`'s `GET_WILDCARD_PACK` handler was replying with `REVIEW_NACK_MESSAGE` — the free-text `'not available in review preview'` that every *other* review NACK correctly uses, because every other one answers a free-text validator.

So the one path whose own comment promises *"NACK before resolving or downloading anything (fail-fast, never a hang)"* produced exactly a hang:

> a moderator opens App review preview on a page app that calls `useWildcardPack()` → the host NACKs → the block-side validator rejects the free-text error → the transport drops it → the hook never settles → a ~30-second spinner, then a generic transport-timeout error.

## The fix

Send `'forbidden'` — review preview genuinely is a permission context, and it is the closest member of the set semantically. The validator is deliberately **not** loosened: the enum is load-bearing.

The change is **structural, not spelled**. The literal is not swapped inline; it goes through a new constant annotated with the union, so `tsc` rejects any future edit that puts a non-member string there:

```ts
const WILDCARD_REVIEW_NACK_CODE: WildcardPackErrorCode = 'forbidden';
```

`WildcardPackErrorCode` (in `wildcardPackParse.ts`) is this repo's **local mirror** of the SDK's `BlockWildcardPackErrorCode`. That type is *not* importable: the pinned `@civitai/app-sdk@0.14.0` dist contains no wildcard symbols at all — the bridge postdates it. The mirror's declaration now says so, and names the SDK type it mirrors.

`REVIEW_NACK_MESSAGE` is untouched; every other NACK site keeps using it.

## Also: three stale comments

Three comments asserted that a `SHARED_*` error reply **must** carry `ok: false` or be dropped → hang. The block-side validators now accept an error reply with or without `ok`, so that is no longer true. Rewritten to say what holds today: the hosts keep sending `ok: false` because it is the clearer signal, not because omitting it would hang. **No code changed at those sites** — `PageBlockHost.tsx` (×2), `hostHandlerParity.ts` (×1).

## Verification

**Regression test** — the existing review-mode `GET_WILDCARD_PACK` case now asserts membership in the five permitted codes *and* the specific code, with the permitted list tied to the union via `satisfies` so it cannot drift.

| | result |
|---|---|
| red at `origin/main` | `1 failed \| 1 passed \| 24 skipped` — `AssertionError: expected [ 'not-found', 'forbidden', …(3) ] to include 'not available in review preview'` |
| green at HEAD | `Test Files 1 passed (1)` / `Tests 26 passed (26)` |

**Mutation check** — both mutants die, each with its *own* assertion message, so neither assertion is riding on the other:

| mutant | failing assertion |
|---|---|
| revert to `REVIEW_NACK_MESSAGE` (free text) | `expected [ 'not-found', 'forbidden', …(3) ] to include 'not available in review preview'` |
| in-set but wrong code (`'busy'`) | `expected 'busy' to be 'forbidden'` |

Sources restored and confirmed byte-identical with `cmp` after each.

**Typecheck** — `pnpm typecheck`: `typecheck: OK — 0 type errors in 157s (heap cap 8192 MB)`.

Two positive controls, because a green typecheck proves nothing until it has been watched go red:

- setting the constant to a non-member string → `PageBlockHost.tsx(228,7): error TS2322: Type '"definitely-not-a-member"' is not assignable to type 'WildcardPackErrorCode'` — the annotation really is the guard.
- a deliberate type error planted in the browser test file → `PageBlockHostReviewMode.browser.test.tsx(163,7): error TS2322` — this file **is** in the typecheck graph. (`tsconfig` excludes `src/**/__tests__/**`; a `*.browser.test.tsx` sitting beside its component is not under that path, so it is covered.)

**Other suites**

- `vitest run --project component` over the three related host suites: `Test Files 3 passed (3)` / `Tests 71 passed (71)`.
- `vitest run --project unit src/components/AppBlocks`: `Test Files 36 passed (36)` / `Tests 635 passed (635)`.

## Stated plainly, not folded in as covered

- **Not verified against a real block or a live review preview.** The failure mode is reproduced at the host's postMessage seam, not end-to-end through the SDK's own validator — that validator lives in another repo and was read, not executed.
- Two pre-existing findings, present identically on `origin/main` and untouched here: `hostHandlerParity.ts` and `wildcardPackParse.ts` both fail `prettier --check` before this change, and this test file already trips `local-rules/no-wholesale-module-mock` at its `vi.mock('~/utils/trpc')` (line 59 before, 63 after — same single error). Both confirmed by re-running against the pristine `origin/main` files.
