### PR TITLE
ci(retool): gate the sanitiser rules that were only prose

### DIFF
--- a/.github/workflows/retool-sanitiser-guard.yml
+++ b/.github/workflows/retool-sanitiser-guard.yml
@@ -13,14 +13,24 @@ name: Retool Sanitiser Guard
 # exactly why both got through the original pass. Read the gate's header before
 # treating this check as coverage.
 
+# 🔴 BOTH triggers, deliberately. `lint.yml` documents at length that this repo had
+# no CI verdict on `main` for two months because its jobs were pull_request-only,
+# and names a real commit pushed straight to `main`. Every base-relative job there
+# is exempt from the push path because a push has no base to diff against — but
+# THIS gate scans the directory absolutely, so a push trigger costs nothing and
+# closes the hole. `release` is pushed to directly by the deploy flow, so it needs
+# the same cover.
 on:
   pull_request:
     branches: [main, release]
-    paths:
+    paths: &guarded
       - 'docs/moderator-app/retool-exports/**'
       - 'scripts/ci/retool-sanitiser-gate.mjs'
       - 'scripts/ci/retool-sanitiser-denylist.json'
       - '.github/workflows/retool-sanitiser-guard.yml'
+  push:
+    branches: [main, release]
+    paths: *guarded
 
 permissions:
   contents: read
@@ -40,13 +50,22 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
 
       - name: Run the sanitiser gate
         env:
           # Not committed: a person's name is a tiny search space, so a public salt
-          # would make the committed hashes dictionary-crackable. Absent (e.g. on a
-          # fork PR) the denylist check reports SKIPPED and the IPv4, credential and
-          # placeholder checks still run and still block.
+          # would make the committed hashes dictionary-crackable.
+          #
+          # 🔴 When this is absent the denylist check does NOT run. The IPv4,
+          # credential and placeholder checks still do, and the gate's PASS line
+          # says so explicitly rather than claiming a scope it did not cover.
+          # Absent cases: the secret does not exist yet, and any FORK PR — where
+          # this workflow does not run AT ALL, so it is no cover there whatsoever.
+          #
+          # 🔴 And a red check here does not BLOCK: this repo has no required
+          # status checks (`branches/main/protection` → required_status_checks:
+          # null), so a failing run renders red and merges anyway. It is a signal
+          # for a human, not an enforcement boundary. Do not describe it as one.
           RETOOL_SANITISER_SALT: ${{ secrets.RETOOL_SANITISER_SALT }}
         run: node scripts/ci/retool-sanitiser-gate.mjs

--- a/.github/workflows/retool-sanitiser-guard.yml
+++ b/.github/workflows/retool-sanitiser-guard.yml
@@ -1,0 +1,52 @@
+name: Retool Sanitiser Guard
+
+# Blocks a PR that puts personal data back into `docs/moderator-app/retool-exports/**`.
+#
+# WHY: PR #4476 removed three classes of personal data from these exports — staff
+# real names, banned-user IP addresses and end-user account ids. The sanitisation
+# rules that were supposed to prevent that live in `raw/README.md` as PROSE, and
+# prose is not a gate. A fresh Retool re-download would have put all three back with
+# nothing to stop it.
+#
+# 🔴 A green run here does NOT mean "no personal data". The gate cannot see a NOVEL
+# staff name or a NOVEL bare account id — neither has a shape to match on, which is
+# exactly why both got through the original pass. Read the gate's header before
+# treating this check as coverage.
+
+on:
+  pull_request:
+    branches: [main, release]
+    paths:
+      - 'docs/moderator-app/retool-exports/**'
+      - 'scripts/ci/retool-sanitiser-gate.mjs'
+      - 'scripts/ci/retool-sanitiser-denylist.json'
+      - '.github/workflows/retool-sanitiser-guard.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: retool-sanitiser-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: retool export sanitiser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run the sanitiser gate
+        env:
+          # Not committed: a person's name is a tiny search space, so a public salt
+          # would make the committed hashes dictionary-crackable. Absent (e.g. on a
+          # fork PR) the denylist check reports SKIPPED and the IPv4, credential and
+          # placeholder checks still run and still block.
+          RETOOL_SANITISER_SALT: ${{ secrets.RETOOL_SANITISER_SALT }}
+        run: node scripts/ci/retool-sanitiser-gate.mjs

--- a/.github/workflows/retool-sanitiser-guard.yml
+++ b/.github/workflows/retool-sanitiser-guard.yml
@@ -1,6 +1,11 @@
 name: Retool Sanitiser Guard
 
-# Blocks a PR that puts personal data back into `docs/moderator-app/retool-exports/**`.
+# Reports a PR or push that puts personal data back into
+# `docs/moderator-app/retool-exports/**`.
+#
+# 🔴 It REPORTS, it does not BLOCK — this repo has no required status checks, so a
+# red run merges anyway. See the note on the gate step below; do not re-describe
+# this as an enforcement boundary.
 #
 # WHY: PR #4476 removed three classes of personal data from these exports — staff
 # real names, banned-user IP addresses and end-user account ids. The sanitisation
@@ -35,8 +40,14 @@ on:
 permissions:
   contents: read
 
+# 🔴 The group MUST vary per commit now that this triggers on push-to-main.
+# `github.ref` alone is ONE group for the whole branch, so two commits landing
+# close together cancel each other and only the last is ever scanned — which
+# half-reopens the very hole the push trigger was added to close, and the loser
+# renders as `cancelled`, which this repo cannot distinguish from a failure.
+# Pinned by scripts/__tests__/main-branch-ci-coverage.test.ts, which caught this.
 concurrency:
-  group: retool-sanitiser-guard-${{ github.ref }}
+  group: retool-sanitiser-guard-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/moderator-app/retool-exports/raw/README.md
+++ b/docs/moderator-app/retool-exports/raw/README.md
@@ -85,7 +85,9 @@ mechanical half on every PR **and every direct push** touching this directory:
 
 - known-bad values that must never come back, matched against **salted hashes** — the
   plaintext is deliberately not in this repo, and neither is the salt;
-- every IP literal must be an RFC5737/RFC1918 address (v6 is rejected outright);
+- every IPv4 literal must be an RFC5737/RFC1918 address, and any IPv6 address is
+  rejected except loopback/unspecified (`::`, `::1`) — a Postgres cast such as
+  `id::date` is not an address and does not count;
 - the credential shapes above, as code rather than prose;
 - the redaction **placeholders must still be present, at their expected counts** —
   which is what catches the headline risk, a wholesale re-download silently

--- a/docs/moderator-app/retool-exports/raw/README.md
+++ b/docs/moderator-app/retool-exports/raw/README.md
@@ -80,15 +80,17 @@ like nothing in particular. It was caught before the commit was ever pushed. Any
 ## Part of this is now a gate, and part of it can never be
 
 Everything above is a checklist, and a checklist is only as good as the person running
-it. `scripts/ci/retool-sanitiser-gate.mjs` (CI: **Retool Sanitiser Guard**) now enforces
-the mechanical half on every PR touching this directory:
+it. `scripts/ci/retool-sanitiser-gate.mjs` (CI: **Retool Sanitiser Guard**) now checks the
+mechanical half on every PR **and every direct push** touching this directory:
 
 - known-bad values that must never come back, matched against **salted hashes** — the
   plaintext is deliberately not in this repo, and neither is the salt;
-- every IPv4 literal must be an RFC5737/RFC1918 address, so a real one blocks;
+- every IP literal must be an RFC5737/RFC1918 address (v6 is rejected outright);
 - the credential shapes above, as code rather than prose;
-- the redaction **placeholders must still be present** — which is what catches the
-  headline risk, a wholesale re-download silently overwriting a sanitised file.
+- the redaction **placeholders must still be present, at their expected counts** —
+  which is what catches the headline risk, a wholesale re-download silently
+  overwriting a sanitised file. Counts, not mere presence: one surviving token would
+  otherwise make a partial re-introduction read as clean.
 
 🔴 **A green run is NOT "no personal data".** The gate cannot see a *novel* staff real
 name or a *novel* bare account id: neither has a shape to match on, which is exactly
@@ -96,9 +98,25 @@ why both walked through the pass described above. That half is still yours. When
 sanitise a fresh export, work the three-class checklist by hand and treat the gate as a
 backstop against regressions, never as the check itself.
 
+🔴 **Three more things it does not do, stated because the first draft of this section
+claimed otherwise:**
+
+1. **It does not BLOCK.** This repo has no required status checks, so a red run renders
+   red and the PR merges anyway. It is a signal for a human, not an enforcement
+   boundary.
+2. **It does not run on fork PRs at all** — not "runs with the denylist skipped".
+   Workflows do not execute for outside contributors here, so a fork PR touching these
+   files gets no coverage whatsoever.
+3. **Without the `RETOOL_SANITISER_SALT` secret the denylist does not run.** The gate's
+   PASS line names the reduced scope when that happens, rather than asserting a scope
+   it did not cover.
+
 Add a newly-found bad value to the denylist with the salt exported locally:
 `node scripts/ci/retool-sanitiser-gate.mjs --hash '<value>'`, then commit the digest
-only.
+only. Populating `hashes` for the first time? Set `sentinel` in the same pass
+(`--sentinel`) — it is the only thing that detects a salt/hash desync, which otherwise
+leaves every hash matching nothing, silently. Note `--hash` refuses a value longer than
+four word-tokens, because the matcher could never find it.
 
 ## Read the whole file, not just the SQL
 

--- a/docs/moderator-app/retool-exports/raw/README.md
+++ b/docs/moderator-app/retool-exports/raw/README.md
@@ -77,6 +77,29 @@ live key because it looked only for vendor prefixes and `Bearer` headers: User L
 like nothing in particular. It was caught before the commit was ever pushed. Anything matching
 `(apikey|token|secret|password|auth)\w*\s*=\s*['"]…` is now redacted regardless of what follows.
 
+## Part of this is now a gate, and part of it can never be
+
+Everything above is a checklist, and a checklist is only as good as the person running
+it. `scripts/ci/retool-sanitiser-gate.mjs` (CI: **Retool Sanitiser Guard**) now enforces
+the mechanical half on every PR touching this directory:
+
+- known-bad values that must never come back, matched against **salted hashes** — the
+  plaintext is deliberately not in this repo, and neither is the salt;
+- every IPv4 literal must be an RFC5737/RFC1918 address, so a real one blocks;
+- the credential shapes above, as code rather than prose;
+- the redaction **placeholders must still be present** — which is what catches the
+  headline risk, a wholesale re-download silently overwriting a sanitised file.
+
+🔴 **A green run is NOT "no personal data".** The gate cannot see a *novel* staff real
+name or a *novel* bare account id: neither has a shape to match on, which is exactly
+why both walked through the pass described above. That half is still yours. When you
+sanitise a fresh export, work the three-class checklist by hand and treat the gate as a
+backstop against regressions, never as the check itself.
+
+Add a newly-found bad value to the denylist with the salt exported locally:
+`node scripts/ci/retool-sanitiser-gate.mjs --hash '<value>'`, then commit the digest
+only.
+
 ## Read the whole file, not just the SQL
 
 Two misses came out of trusting the query list alone, both found in review rather than in the build:

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -839,3 +839,25 @@ describe("audit r4/r5 — the corpus's OWN Authorization serialisation", () => {
     });
   });
 });
+
+describe('audit r6 🟡F1 — secret-assignment must reach the corpus escaping depth too', () => {
+  // `Q` was widened to 0-3 backslashes, but this rule hardcoded `\\?` for the
+  // VALUE quote, so it stayed capped at depth 1 while its own comment claimed to
+  // cover "the dominant serialisation" — which is depth 3. Latent (no corpus
+  // instance today) but the comment was wider than the code, which is the exact
+  // defect this whole gate exists to prevent.
+  it.each([
+    [0, ''],
+    [1, '\\'],
+    [2, '\\\\'],
+    [3, '\\\\\\'],
+  ])('catches a quoted secret assignment at escaping depth %i', (_d, e) => {
+    const sample = `{"a":1, ${e}"apiKey${e}": ${e}"abcdefghij1234${e}"}`;
+    expect(findCredentialShapes(sample).map((f) => f.rule)).toContain('secret-assignment');
+  });
+
+  it('still ignores an already-redacted value at depth 3', () => {
+    const e = '\\\\\\';
+    expect(findCredentialShapes(`{${e}"apiKey${e}": ${e}"<REDACTED>${e}"}`)).toEqual([]);
+  });
+});

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -189,6 +189,7 @@ describe('check 3 — credential shapes', () => {
       'stripe-key',
       'secret-assignment',
       'secret-assignment-template',
+      'retool-kv-credential',
     ]);
     expect(CREDENTIAL_RULES.map((r) => r.name).sort()).toEqual([...covered].sort());
   });
@@ -699,10 +700,13 @@ describe('audit r3 🟡3 — dropping the i flag must not lose real identifiers'
   it.each([
     '{"Authorization": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
     '{"authorization": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
+    // INVARIANT GUARD, not a regression test: the pre-existing `AUTH` branch
+    // already caught this (uppercase `O` passes the anchor), so it was green
+    // before the widening too and cannot fail for it.
     '{"AUTHORIZATION": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
     '{"authentication": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
     '{"X-API-Key": "abcdef1234567890"}',
-    '{"X-API-KEY": "abcdef1234567890"}',
+    '{"X-API-KEY": "abcdef1234567890"}', // invariant guard, as above
     '{"Api_key": "abcdef1234567890"}',
     '{"Apikey": "abcdef1234567890"}',
     '{"tokens": "abcdef1234567890"}',
@@ -710,9 +714,12 @@ describe('audit r3 🟡3 — dropping the i flag must not lose real identifiers'
     '{"passwords": "abcdef1234567890"}',
     '{"secretkey": "abcdef1234567890"}',
   ])('catches %s', (sample) => {
-    // `Authorization` appears 12 times in raw/user-lookup-v2.json — the dominant
-    // credential identifier in the corpus this gate scans. A `Basic` credential is
-    // caught by NO other rule, so losing this loses the class entirely.
+    // These pin the `{"Authorization": "..."}` JSON-key shape only. The corpus's
+    // OWN 12 Authorization entries use Retool's transit pair instead, which no
+    // assignment rule can see — that is covered by `retool-kv-credential` and its
+    // own describe block below. An earlier version of this comment claimed these
+    // cases covered the corpus, which was false and would have stopped the next
+    // person looking.
     expect(findCredentialShapes(sample).length).toBeGreaterThan(0);
   });
 
@@ -724,5 +731,64 @@ describe('audit r3 🟡3 — dropping the i flag must not lose real identifiers'
     '{"tokenizer": "whitespace-basic"}',
   ])('still does not flag %s', (sample) => {
     expect(findCredentialShapes(sample)).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// Round-4 delta audit.
+// ===========================================================================
+
+describe('audit r4 🟡F1 — no lookahead may suppress IPv4-embedded IPv6', () => {
+  it.each([
+    '::ffff:8.8.8.8',
+    '::ffff:192.168.1.1',
+    '2001:db8::1.2.3.4',
+    'banned 64:ff9b::104.16.132.229 today',
+  ])('reports something for %s', (sample) => {
+    // `::ffff:192.168.1.1` previously matched NOTHING — not check 2 either, since
+    // the inner address is RFC1918. The reported literal may truncate at the
+    // embedded IPv4; that is cosmetic, because findings are masked anyway.
+    expect(findIPv6(sample).length).toBeGreaterThan(0);
+  });
+
+  it('still finds an address at the end of a sentence', () => {
+    expect(findIPv6('Banned the account from fe80::1.')).toEqual(['fe80::1']);
+    expect(findIPv6('from 2001:db8::1...')).toEqual(['2001:db8::1']);
+  });
+});
+
+describe("audit r4 🟡F2 — the corpus's OWN Authorization serialisation", () => {
+  // All 12 Authorization entries in raw/user-lookup-v2.json are written as a
+  // Retool transit pair: \"key\":\"Authorization\",\"value\":\"Basic …\". The
+  // identifier is a VALUE and the separator is `,`, so neither assignment rule
+  // can see it. `Bearer` was caught incidentally by bearer-token; `Basic` was
+  // caught by NOTHING, while a test comment claimed the class was covered.
+  const kv = (key: string, value: string) => String.raw`\"key\":\"${key}\",\"value\":\"${value}\"`;
+
+  it('catches a live Basic credential in the transit shape', () => {
+    const found = findCredentialShapes(kv('Authorization', 'Basic ZGVtbzpzdXBlcnNlY3JldDEyMw=='));
+    expect(found.map((f) => f.rule)).toContain('retool-kv-credential');
+  });
+
+  it.each(['X-API-Key', 'token', 'WEBHOOK_TOKEN', 'password'])(
+    'catches a credential-named key %s',
+    (key) => {
+      expect(findCredentialShapes(kv(key, 'abcdef1234567890')).length).toBeGreaterThan(0);
+    }
+  );
+
+  it("does NOT fire on the corpus's redacted placeholder value", () => {
+    expect(
+      findCredentialShapes(kv('Authorization', 'Basic {{ FreshdeskCredentials.value }}'))
+    ).toEqual([]);
+  });
+
+  it('does NOT fire on an ordinary array — the reason the bare comma rule was reverted', () => {
+    expect(findCredentialShapes('{"tags": ["auth","authentication"]}')).toEqual([]);
+    expect(findCredentialShapes('{"columns": ["password","created_at_utc"]}')).toEqual([]);
+  });
+
+  it('does not fire when the key is not credential-named', () => {
+    expect(findCredentialShapes(kv('Content-Type', 'application/json-x'))).toEqual([]);
   });
 });

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -1,0 +1,265 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  CREDENTIAL_RULES,
+  DENYLIST_PATH,
+  SCAN_DIR,
+  findCredentialShapes,
+  findDenylistHits,
+  findMissingPlaceholders,
+  findOutOfRangeIPv4,
+  hashValue,
+  isAllowedIPv4,
+  runGate,
+  tokenize,
+} from '../ci/retool-sanitiser-gate.mjs';
+
+/**
+ * `scripts/ci/retool-sanitiser-gate.mjs` blocks a Retool re-download from putting
+ * personal data back into `docs/moderator-app/retool-exports/**`.
+ *
+ * Its whole value rests on being UNABLE to report a confident pass, so every case
+ * here asserts BOTH directions: the gate goes red on a planted value AND names the
+ * specific rule that caught it. A test that only asserted "did not pass" would be
+ * satisfied by a gate failing for the wrong reason — and three of these four checks
+ * can fail for each other's reasons if the fixtures are careless (an out-of-range IP
+ * planted into a file that ALSO lost its placeholder dies to whichever runs first).
+ * So each fixture tree is mutated in exactly ONE dimension.
+ *
+ * The denylist fixtures use a salt and values invented here. No real salt and no
+ * real redacted value appears in this file, which is the same reason the denylist
+ * ships as hashes: this repo is public.
+ */
+
+// Built by concatenation so this test file's own source can never be mistaken for
+// a real finding by a future repo-wide scan.
+const FAKE_SECRET = `AKIA${'QQQ'}12345678ZZ`;
+const PUBLIC_DNS_IP = [8, 8, 8, 8].join('.');
+
+const SALT = 'fixture-salt-not-the-real-one';
+const DENIED_NAME = 'Ada Lovelace';
+
+let root: string;
+
+/** A minimal but STRUCTURALLY REAL export tree: placeholders present, IPs in RFC5737. */
+function seedCleanTree(dir: string) {
+  const raw = path.join(dir, SCAN_DIR, 'raw');
+  mkdirSync(raw, { recursive: true });
+  writeFileSync(
+    path.join(raw, 'user-lookup-v2.json'),
+    JSON.stringify({ gate: "current_user.fullName === '__MODERATOR_A__'" }, null, 2)
+  );
+  writeFileSync(
+    path.join(raw, 'bulk-ban.json'),
+    JSON.stringify({ sql: 'WHERE ip IN (203.0.113.1, 203.0.113.2)' }, null, 2)
+  );
+  writeFileSync(path.join(dir, SCAN_DIR, 'bulk-ban.md'), '| ip |\n| 203.0.113.1 |\n');
+  writeFileSync(path.join(dir, DENYLIST_PATH), JSON.stringify({ version: 1, hashes: [] }, null, 2));
+}
+
+beforeAll(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'retool-gate-'));
+  mkdirSync(path.join(root, 'scripts', 'ci'), { recursive: true });
+  seedCleanTree(root);
+});
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+/** Reset to the clean tree, then apply exactly one mutation (or none). */
+function mutate(fn?: (dir: string) => void) {
+  rmSync(path.join(root, SCAN_DIR), { recursive: true, force: true });
+  seedCleanTree(root);
+  fn?.(root);
+}
+
+const appendTo = (rel: string, text: string) => (dir: string) => {
+  const abs = path.join(dir, SCAN_DIR, rel);
+  writeFileSync(abs, `${readFileSync(abs, 'utf8')}\n${text}\n`);
+};
+
+const withDenylist = (hashes: string[]) => (dir: string) =>
+  writeFileSync(path.join(dir, DENYLIST_PATH), JSON.stringify({ version: 1, hashes }, null, 2));
+
+describe('positive control — the clean tree passes', () => {
+  it('passes with no salt, and says the denylist was skipped rather than passing silently', () => {
+    mutate();
+    const result = runGate({ root, salt: undefined });
+    expect(result.failures).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.files.length).toBeGreaterThan(0);
+    expect(result.notes.join(' ')).toMatch(/denylist SKIPPED/);
+  });
+
+  it('scans a non-zero number of files — a gate wired to nothing also reports zero findings', () => {
+    mutate();
+    // The clean fixture seeds exactly three in-scope files; the denylist lives
+    // outside SCAN_DIR and must not be counted as scanned content.
+    expect(runGate({ root, salt: SALT }).files.length).toBe(3);
+  });
+
+  it('fails loudly if the scan directory is empty, rather than passing on nothing', () => {
+    mutate((dir) => rmSync(path.join(dir, SCAN_DIR), { recursive: true, force: true }));
+    const result = runGate({ root, salt: SALT });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/scanned nothing/);
+  });
+});
+
+describe('check 2 — IPv4 range allowlist', () => {
+  it.each([
+    ['203.0.113.7', true, 'RFC5737 TEST-NET-3, what the redaction writes'],
+    ['198.51.100.9', true, 'RFC5737 TEST-NET-2'],
+    ['192.0.2.4', true, 'RFC5737 TEST-NET-1'],
+    ['10.1.2.3', true, 'RFC1918'],
+    ['172.16.0.1', true, 'RFC1918 lower bound'],
+    ['172.31.255.254', true, 'RFC1918 upper bound'],
+    ['192.168.1.1', true, 'RFC1918'],
+    ['127.0.0.1', true, 'loopback'],
+    [PUBLIC_DNS_IP, false, 'a real routable address'],
+    ['172.32.0.1', false, 'just OUTSIDE RFC1918 — the /12 boundary, not a /16'],
+    ['203.0.114.1', false, 'adjacent to TEST-NET-3 but outside it'],
+    ['109.236.62.211', false, 'the shape of a real banned-user IP'],
+  ])('%s allowed=%s (%s)', (ip, allowed) => {
+    expect(isAllowedIPv4(ip as string)).toBe(allowed);
+  });
+
+  it('blocks a routable IP and names the IPv4 rule', () => {
+    mutate(appendTo('bulk-ban.md', `banned from ${PUBLIC_DNS_IP} yesterday`));
+    const result = runGate({ root, salt: SALT });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toContain(PUBLIC_DNS_IP);
+    expect(result.failures[0]).toMatch(/outside the documentation\/private ranges/);
+  });
+
+  it('does not flag a version-like string whose octets exceed 255', () => {
+    expect(findOutOfRangeIPv4('build 1.2.3.999 shipped')).toEqual([]);
+  });
+});
+
+describe('check 3 — credential shapes', () => {
+  it.each([
+    ['bearer-token', 'Authorization: Bearer sk-abcdef0123456789ghij'],
+    ['jwt', 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r'],
+    ['postgres-dsn', 'postgres://appuser:hunter2hunter2@db.example.com:5432/prod'],
+    ['stripe-key', 'sk_live_51H8xQ2abcdefghijklmnop'],
+    ['secret-assignment', `const apiKey = '${FAKE_SECRET}'`],
+  ])('catches %s', (rule, sample) => {
+    const found = findCredentialShapes(sample);
+    expect(found.map((f) => f.rule)).toContain(rule);
+  });
+
+  it('every declared rule has at least one case above — a rule with no case is untested', () => {
+    const covered = new Set([
+      'bearer-token',
+      'jwt',
+      'postgres-dsn',
+      'stripe-key',
+      'secret-assignment',
+    ]);
+    expect(CREDENTIAL_RULES.map((r) => r.name).sort()).toEqual([...covered].sort());
+  });
+
+  it.each([
+    'Authorization: Bearer <REDACTED>',
+    "const apiKey = '__REDACTED__'",
+    "password: '<password>'",
+  ])('does not flag an already-redacted value: %s', (sample) => {
+    expect(findCredentialShapes(sample)).toEqual([]);
+  });
+
+  it('blocks a planted secret assignment and names the credential rule', () => {
+    mutate(appendTo('bulk-ban.md', `const apiKey = '${FAKE_SECRET}'`));
+    const result = runGate({ root, salt: SALT });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatch(/\[secret-assignment\]/);
+  });
+});
+
+describe('check 1 — hashed denylist', () => {
+  it('normalises whitespace, so a line-wrapped value still matches', () => {
+    // This is the round-3 defect from PR #4476: a wrap split the token and a
+    // contiguous grep returned a confident zero.
+    const digest = hashValue(SALT, DENIED_NAME);
+    const wrapped = `reviewed by Ada\n  Lovelace on Tuesday`;
+    expect(findDenylistHits(wrapped, { salt: SALT, hashes: [digest] })).toEqual([digest]);
+  });
+
+  it('is case-insensitive and punctuation-insensitive', () => {
+    const digest = hashValue(SALT, DENIED_NAME);
+    expect(findDenylistHits('"ADA, LOVELACE"', { salt: SALT, hashes: [digest] })).toEqual([digest]);
+  });
+
+  it('does not fire on an unrelated value', () => {
+    const digest = hashValue(SALT, DENIED_NAME);
+    expect(findDenylistHits('reviewed by Grace Hopper', { salt: SALT, hashes: [digest] })).toEqual(
+      []
+    );
+  });
+
+  it('a different salt produces a different digest — the salt is load-bearing', () => {
+    expect(hashValue('salt-a', DENIED_NAME)).not.toEqual(hashValue('salt-b', DENIED_NAME));
+  });
+
+  it('blocks a planted denylisted value, and does NOT print it', () => {
+    const digest = hashValue(SALT, DENIED_NAME);
+    mutate((dir) => {
+      withDenylist([digest])(dir);
+      appendTo('bulk-ban.md', `escalated to ${DENIED_NAME} for review`)(dir);
+    });
+    const result = runGate({ root, salt: SALT });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatch(/denylisted known-bad value/);
+    // Printing the value would undo the redaction the gate exists to protect.
+    expect(result.failures[0]).not.toContain(DENIED_NAME);
+    expect(result.failures[0]).not.toContain('Lovelace');
+  });
+
+  it('SKIPS rather than passes when the salt is absent, even with the value present', () => {
+    const digest = hashValue(SALT, DENIED_NAME);
+    mutate((dir) => {
+      withDenylist([digest])(dir);
+      appendTo('bulk-ban.md', `escalated to ${DENIED_NAME} for review`)(dir);
+    });
+    const result = runGate({ root, salt: undefined });
+    expect(result.denylistActive).toBe(false);
+    expect(result.notes.join(' ')).toMatch(/denylist SKIPPED/);
+    // The other checks still ran and still found nothing wrong in this fixture.
+    expect(result.failures).toEqual([]);
+  });
+
+  it('tokenize strips punctuation and lowercases', () => {
+    expect(tokenize('  Ada,   LOVELACE!\n(byron) ')).toEqual(['ada', 'lovelace', 'byron']);
+  });
+});
+
+describe('check 4 — redaction placeholders survive', () => {
+  it('blocks when a placeholder is replaced by a real-looking name', () => {
+    mutate((dir) =>
+      writeFileSync(
+        path.join(dir, SCAN_DIR, 'raw', 'user-lookup-v2.json'),
+        JSON.stringify({ gate: `current_user.fullName === '${DENIED_NAME}'` }, null, 2)
+      )
+    );
+    const result = runGate({ root, salt: undefined });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/redaction placeholder is gone/);
+    expect(result.failures.join(' ')).toMatch(/__MODERATOR_A__/);
+  });
+
+  it('blocks when a whole export file disappears', () => {
+    mutate((dir) => rmSync(path.join(dir, SCAN_DIR, 'raw', 'bulk-ban.json')));
+    const result = runGate({ root, salt: undefined });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/file is absent/);
+  });
+
+  it('reports every missing placeholder, not just the first', () => {
+    const missing = findMissingPlaceholders(() => '');
+    expect(missing.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -757,38 +757,85 @@ describe('audit r4 🟡F1 — no lookahead may suppress IPv4-embedded IPv6', () 
   });
 });
 
-describe("audit r4 🟡F2 — the corpus's OWN Authorization serialisation", () => {
-  // All 12 Authorization entries in raw/user-lookup-v2.json are written as a
-  // Retool transit pair: \"key\":\"Authorization\",\"value\":\"Basic …\". The
-  // identifier is a VALUE and the separator is `,`, so neither assignment rule
-  // can see it. `Bearer` was caught incidentally by bearer-token; `Basic` was
-  // caught by NOTHING, while a test comment claimed the class was covered.
-  const kv = (key: string, value: string) => String.raw`\"key\":\"${key}\",\"value\":\"${value}\"`;
+describe("audit r4/r5 — the corpus's OWN Authorization serialisation", () => {
+  // All 12 Authorization entries in raw/user-lookup-v2.json are Retool transit
+  // pairs: \"key\":\"Authorization\",\"value\":\"Basic …\". The identifier is a
+  // VALUE and the separator is `,`, so neither assignment rule can see it.
+  //
+  // 🔴 ESCAPING DEPTH IS PARAMETERISED, and that is the whole point. The first
+  // version of these tests hardcoded ONE backslash. The corpus uses THREE (181 of
+  // 191 `key` occurrences; the rest use one, none use zero) because Retool nests
+  // JSON inside JSON inside a string. So the rule was inert on the only file it
+  // was written for, and this spec passed anyway — the fixture and the code
+  // encoded the same wrong assumption, and neither could see the other's error.
+  const ESCAPES = ['', '\\', '\\\\\\'];
+  const kv = (key: string, value: string, e: string) =>
+    `${e}"key${e}"${e}:${e}"${key}${e}"${e},${e}"value${e}"${e}:${e}"${value}${e}"`
+      .replace(new RegExp(`${e ? e.replace(/\\/g, '\\\\') : '(?!)'}:`, 'g'), ':')
+      .replace(new RegExp(`${e ? e.replace(/\\/g, '\\\\') : '(?!)'},`, 'g'), ',');
 
-  it('catches a live Basic credential in the transit shape', () => {
-    const found = findCredentialShapes(kv('Authorization', 'Basic ZGVtbzpzdXBlcnNlY3JldDEyMw=='));
-    expect(found.map((f) => f.rule)).toContain('retool-kv-credential');
+  describe.each(ESCAPES.map((e) => [e.length, e] as const))('at escaping depth %i', (_depth, e) => {
+    it('catches a live Basic credential', () => {
+      const found = findCredentialShapes(
+        kv('Authorization', 'Basic ZGVtbzpzdXBlcnNlY3JldDEyMw==', e)
+      );
+      expect(found.map((f) => f.rule)).toContain('retool-kv-credential');
+    });
+
+    it.each(['X-API-Key', 'token', 'WEBHOOK_TOKEN', 'password'])(
+      'catches credential-named key %s',
+      (key) => {
+        expect(findCredentialShapes(kv(key, 'abcdef1234567890', e)).length).toBeGreaterThan(0);
+      }
+    );
+
+    it('does NOT fire on the redacted placeholder the corpus actually holds', () => {
+      expect(
+        findCredentialShapes(kv('Authorization', 'Basic {{ FreshdeskCredentials.value }}', e))
+      ).toEqual([]);
+    });
+
+    it.each(['author', 'authorName', 'authorEmail', 'authorized', 'tokenizer'])(
+      'does NOT fire on the non-credential key %s',
+      (key) => {
+        // The kv key needs the same end-of-identifier anchor the assignment
+        // rules carry; without it this whole class came back.
+        expect(findCredentialShapes(kv(key, 'Jane Q Public xyz', e))).toEqual([]);
+      }
+    );
   });
 
-  it.each(['X-API-Key', 'token', 'WEBHOOK_TOKEN', 'password'])(
-    'catches a credential-named key %s',
-    (key) => {
-      expect(findCredentialShapes(kv(key, 'abcdef1234567890')).length).toBeGreaterThan(0);
-    }
-  );
-
-  it("does NOT fire on the corpus's redacted placeholder value", () => {
-    expect(
-      findCredentialShapes(kv('Authorization', 'Basic {{ FreshdeskCredentials.value }}'))
-    ).toEqual([]);
-  });
-
-  it('does NOT fire on an ordinary array — the reason the bare comma rule was reverted', () => {
+  it('does NOT fire on an ordinary array — why the bare comma rule was reverted', () => {
     expect(findCredentialShapes('{"tags": ["auth","authentication"]}')).toEqual([]);
     expect(findCredentialShapes('{"columns": ["password","created_at_utc"]}')).toEqual([]);
   });
 
   it('does not fire when the key is not credential-named', () => {
-    expect(findCredentialShapes(kv('Content-Type', 'application/json-x'))).toEqual([]);
+    expect(findCredentialShapes(kv('Content-Type', 'application/json-x', '\\'))).toEqual([]);
+  });
+
+  // 🔴 THE CONTROL THAT WOULD HAVE CAUGHT THE INERT RULE: drive the REAL file,
+  // not a fixture whose shape I chose. A fake can encode the same mistake as the
+  // code; the corpus cannot.
+  describe('driven by the real export, not a fixture', () => {
+    const REAL = path.join(REPO_ROOT, SCAN_DIR, 'raw/user-lookup-v2.json');
+    const REDACTED_VALUE = 'Basic {{ FreshdeskCredentials.value }}';
+
+    it('the real file is clean', () => {
+      const text = readFileSync(REAL, 'utf8');
+      expect(text).toContain(REDACTED_VALUE); // the substitution below is anchored on this
+      expect(findCredentialShapes(text).filter((f) => f.rule === 'retool-kv-credential')).toEqual(
+        []
+      );
+    });
+
+    it('a live credential substituted into it IS caught', () => {
+      const text = readFileSync(REAL, 'utf8');
+      const live = text.replace(REDACTED_VALUE, 'Basic ZGVtbzpzdXBlcnNlY3JldDEyMw==');
+      expect(live).not.toEqual(text); // positive control: the substitution happened
+      const found = findCredentialShapes(live).filter((f) => f.rule === 'retool-kv-credential');
+      expect(found.length).toBeGreaterThan(0);
+      expect(found[0].sample).not.toContain('ZGVtbz'); // still masked
+    });
   });
 });

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -647,3 +647,82 @@ describe('audit r2 \u{1F7E2}F11 — guards the fix round left unguarded', () => 
     expect(passScope(false)).toContain('THE DENYLIST DID NOT RUN');
   });
 });
+
+// ===========================================================================
+// Round-3 delta audit. Two of these restore tests an earlier scripted edit of
+// mine DELETED (it replaced from a marker to end-of-file); the audit caught the
+// loss by noticing no test named the defect the commit claimed to have pinned.
+// ===========================================================================
+
+describe('audit r3 — IPv6 must not fire on a Postgres cast (restored)', () => {
+  it.each([
+    'SELECT id::date FROM bans',
+    'SELECT userId::text, createdAt::timestamptz FROM t',
+    'WHERE amount::decimal > 0',
+    'SELECT payload::jsonb, ref::uuid, ok::boolean FROM t',
+    'SELECT count(*)::int FROM bans',
+  ])('does not flag %s', (sql) => {
+    expect(findIPv6(sql)).toEqual([]);
+  });
+});
+
+describe('audit r3 — the comma separator stays reverted (restored)', () => {
+  it('does NOT catch the transit "KEY","value" pair, by measured decision', () => {
+    expect(findCredentialShapes('"WEBHOOK_TOKEN","ghp_abcdefghij0123456789"')).toEqual([]);
+  });
+});
+
+describe('audit r3 🟡1 — IPv6 at the end of a sentence', () => {
+  it.each([
+    ['client 2a01:4f8:c17:1234::1.', '2a01:4f8:c17:1234::1'],
+    ['Banned the account at fe80::1.', 'fe80::1'],
+    ['Banned fe80::a00:27ff:fe4e:66a1. Ban applied.', 'fe80::a00:27ff:fe4e:66a1'],
+    ['from 2001:db8::1...', '2001:db8::1'],
+    ['ip:2001:db8::1', '2001:db8::1'],
+    ['(2001:db8::1)', '2001:db8::1'],
+  ])('finds the address in %s', (text, addr) => {
+    expect(findIPv6(text)).toEqual([addr]);
+  });
+});
+
+describe('audit r3 🟡2 — no single-group IPv6 exemption; ALLOWED_V6 is live', () => {
+  it.each(['fe80::', '::dead', '::beef'])('flags the single-group address %s', (addr) => {
+    expect(findIPv6(`host ${addr} down`)).toEqual([addr]);
+  });
+
+  it('still exempts loopback and unspecified — and now really via ALLOWED_V6', () => {
+    expect(findIPv6('bound ::1 and :: today')).toEqual([]);
+  });
+});
+
+describe('audit r3 🟡3 — dropping the i flag must not lose real identifiers', () => {
+  it.each([
+    '{"Authorization": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
+    '{"authorization": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
+    '{"AUTHORIZATION": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
+    '{"authentication": "Basic ZGVtbzpwYXNzd29yZDEyMw=="}',
+    '{"X-API-Key": "abcdef1234567890"}',
+    '{"X-API-KEY": "abcdef1234567890"}',
+    '{"Api_key": "abcdef1234567890"}',
+    '{"Apikey": "abcdef1234567890"}',
+    '{"tokens": "abcdef1234567890"}',
+    '{"secrets": "abcdef1234567890"}',
+    '{"passwords": "abcdef1234567890"}',
+    '{"secretkey": "abcdef1234567890"}',
+  ])('catches %s', (sample) => {
+    // `Authorization` appears 12 times in raw/user-lookup-v2.json — the dominant
+    // credential identifier in the corpus this gate scans. A `Basic` credential is
+    // caught by NO other rule, so losing this loses the class entirely.
+    expect(findCredentialShapes(sample).length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    '{"author": "Jane Quinn Public"}',
+    '{"authorName": "Jane Q Public"}',
+    '{"authorEmail": "jane@example.com"}',
+    '{"authorized": "yes-by-moderator"}',
+    '{"tokenizer": "whitespace-basic"}',
+  ])('still does not flag %s', (sample) => {
+    expect(findCredentialShapes(sample)).toEqual([]);
+  });
+});

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -15,6 +15,8 @@ import {
   findIPv6,
   findMissingPlaceholders,
   findOutOfRangeIPv4,
+  annotate,
+  passScope,
   hashValue,
   isAllowedIPv4,
   mask,
@@ -158,7 +160,7 @@ describe('check 2 — IPv4 range allowlist', () => {
     const result = runGate({ root, salt: SALT });
     expect(result.ok).toBe(false);
     expect(result.failures).toHaveLength(1);
-    expect(result.failures[0]).toContain(PUBLIC_DNS_IP);
+    expect(result.failures[0]).not.toContain(PUBLIC_DNS_IP); // masked — r2 F2
     expect(result.failures[0]).toMatch(/outside the documentation\/private ranges/);
   });
 
@@ -419,7 +421,7 @@ describe('audit 🔴2 — a salt/hash desync must fail, never pass silently', ()
 describe('audit 🟡5 — the credential rule must cover the corpus it scans', () => {
   it.each([
     ['quoted JSON key', '"apiKey": "AKIAQQQ12345678ZZ"'],
-    ['transit key,value pair', '"WEBHOOK_TOKEN","ghp_abcdefghij0123456789"'],
+    ['screaming-snake JSON key', '"WEBHOOK_TOKEN": "ghp_abcdefghij0123456789"'],
     ['escaped double-quoted JS in JSON', '\\"const apiKey = \\"AKIAQQQ12345678ZZ\\"\\"'],
     ['template literal', 'const apiKey = `AKIAQQQ12345678ZZ`'],
     ['lowercase bearer', 'authorization: bearer ghp_abcdefghij0123456789'],
@@ -434,7 +436,7 @@ describe('audit 🟡5 — the credential rule must cover the corpus it scans', (
     const blob = `{"token":"${'a'.repeat(400)}","other":${JSON.stringify('x'.repeat(50_000))}}`;
     for (const hit of findCredentialShapes(blob)) {
       const chars = Number(/^(\d+) chars/.exec(hit.sample)?.[1] ?? 0);
-      expect(chars).toBeLessThanOrEqual(200);
+      expect(chars).toBeLessThanOrEqual(4096);
     }
   });
 });
@@ -477,7 +479,10 @@ describe('audit nits — IPv6 and dotted-quad adjacency', () => {
     expect(findIPv6('client 2a01:4f8:c17:1234::1 banned')).toEqual(['2a01:4f8:c17:1234::1']);
   });
 
-  it('allows loopback/unspecified', () => {
+  // NOT "the allowlist exempts them" — V6_RE requires a leading `group:`, so bare
+  // ::/::1 never match at all. The old version of this test asserted the same
+  // empty array and passed with the allowlist DELETED: vacuous either way.
+  it('does not match bare ::/::1, which the pattern structurally cannot emit', () => {
     expect(findIPv6('bound ::1 and ::')).toEqual([]);
   });
 
@@ -509,5 +514,136 @@ describe('real-corpus regressions the synthetic cases did not catch', () => {
     const result = runGate({ root: REPO_ROOT, salt: undefined });
     expect(result.failures).toEqual([]);
     expect(result.files.length).toBeGreaterThan(20);
+  });
+});
+
+// ===========================================================================
+// Round-2 delta audit regressions. Every one of these is a case the round-1
+// FIX introduced — each regex was widened on one axis and narrowed on another.
+// ===========================================================================
+
+describe('audit r2 🟡F3 — the V4 lookahead must not eat a sentence period', () => {
+  it.each([
+    'Banned the account at 8.8.8.8.',
+    'The user last logged in from 8.8.8.8. Ban applied.',
+    'from 8.8.8.8...',
+    'at 8.8.8.8, then elsewhere',
+    '(8.8.8.8)',
+  ])('still finds a routable IP in prose: %s', (sample) => {
+    expect(findOutOfRangeIPv4(sample)).toEqual([PUBLIC_DNS_IP]);
+  });
+
+  it.each(['version 1.2.3.4.5', 'build 10.20.30.40.1', 'v2.45.13.22.9'])(
+    'still ignores a dotted quad inside a longer run: %s',
+    (sample) => {
+      expect(findOutOfRangeIPv4(sample)).toEqual([]);
+    }
+  );
+});
+
+describe('audit r2 🟡F4 — IPv6 must catch the one-group-before-:: family', () => {
+  it.each([
+    'fe80::1',
+    'fe80::a00:27ff:fe4e:66a1',
+    '2a02::1',
+    'fd00::abcd',
+    '2001::dead:beef',
+    '2001:db8::1',
+  ])('flags %s', (addr) => {
+    expect(findIPv6(`client ${addr} banned`)).toEqual([addr]);
+  });
+
+  it('still ignores ordinary colon-separated text', () => {
+    expect(findIPv6('12:30:45 duration, key:value, ratio 3:1')).toEqual([]);
+  });
+});
+
+describe('audit r2 🟡F5 — long opaque secrets must not fall off the top', () => {
+  it.each([201, 320, 512, 1024])('catches a %s-char opaque token', (len) => {
+    const found = findCredentialShapes(`{"token": "${'a'.repeat(len)}"}`);
+    expect(found.map((f) => f.rule)).toContain('secret-assignment');
+  });
+
+  it('still cannot run away across a large blob', () => {
+    const blob = `{"token":"${'a'.repeat(400)}","other":${JSON.stringify('x'.repeat(50_000))}}`;
+    for (const hit of findCredentialShapes(blob)) {
+      expect(Number(/^(\d+) chars/.exec(hit.sample)?.[1] ?? 0)).toBeLessThanOrEqual(4096);
+    }
+  });
+});
+
+describe('audit r2 🟡F6 — the prefix widener must not flag author*/tokenizer', () => {
+  it.each([
+    '{"author": "Jane Quinn Public"}',
+    '{"authorName": "Jane Q Public"}',
+    '{"authorEmail": "jane@example.com"}',
+    '"authorAvatarUrl": "https://x.example/a.png"',
+    '{"authorized": "yes-by-moderator"}',
+    '{"tokenizer": "whitespace-basic"}',
+    '{"tags": ["auth","authentication"]}',
+  ])('does not flag %s', (sample) => {
+    expect(findCredentialShapes(sample)).toEqual([]);
+  });
+
+  it.each([
+    '"WEBHOOK_TOKEN": "ghp_abcdefghij0123456789"',
+    '{"apiKey": "abcdef123456"}',
+    "const stripeSecretKey = 'sk_live_abcdefghijkl'",
+  ])('still flags the real shape %s', (sample) => {
+    expect(findCredentialShapes(sample).length).toBeGreaterThan(0);
+  });
+});
+
+describe('audit r2 \u{1F7E1}F7 — annotations point at the file that regressed', () => {
+  it('derives file= from the finding, not the hardcoded denylist path', () => {
+    const msg = `${SCAN_DIR}/raw/user-lookup-v2.json: redaction placeholder is gone`;
+    const out = annotate('error', msg, true);
+    expect(out).toBe(`::error file=${SCAN_DIR}/raw/user-lookup-v2.json::${msg}`);
+    expect(out).not.toContain(DENYLIST_PATH);
+  });
+
+  it('falls back to the denylist path only when the message names no file', () => {
+    expect(annotate('warning', 'something with no path prefix', true)).toContain(
+      `file=${DENYLIST_PATH}`
+    );
+  });
+
+  it('outside Actions it is plain text, not an annotation', () => {
+    expect(annotate('error', 'x.json: boom', false)).toBe(
+      'retool-sanitiser-gate: ERROR x.json: boom'
+    );
+  });
+});
+
+describe('audit r2 🔴F2 — no branch may print a raw value', () => {
+  it('masks the IPv4 address, the class this gate exists to keep out', () => {
+    mutate(appendTo('bulk-ban.md', 'banned from 109.236.62.211 yesterday'));
+    const result = runGate({ root, salt: undefined });
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).not.toContain('109.236.62.211');
+    expect(result.failures[0]).not.toContain('109.236');
+    expect(result.failures[0]).toMatch(/\d+ chars, sha256:[0-9a-f]{8}…/);
+  });
+
+  it('masks the IPv6 address too', () => {
+    mutate(appendTo('bulk-ban.md', 'client 2a01:4f8:c17:1234::1 banned'));
+    const result = runGate({ root, salt: undefined });
+    expect(result.failures.join(' ')).not.toContain('2a01:4f8');
+  });
+});
+
+describe('audit r2 \u{1F7E2}F11 — guards the fix round left unguarded', () => {
+  it('the value floor is the quantifier, pinned at its boundary', () => {
+    // A separate minValueLength property was removed as unreachable: the
+    // quantifier counts repetitions and each unescapes to >=1 char, so no input
+    // could ever reach the floor. This pins the real behaviour instead.
+    expect(findCredentialShapes('{"token": "abcdefg"}')).toEqual([]); // 7
+    expect(findCredentialShapes('{"token": "abcdefgh"}').length).toBe(1); // 8
+  });
+
+  it('the PASS scope string SHRINKS when the denylist did not run', () => {
+    expect(passScope(true)).toContain('no known-bad value');
+    expect(passScope(false)).not.toContain('no known-bad value');
+    expect(passScope(false)).toContain('THE DENYLIST DID NOT RUN');
   });
 });

--- a/scripts/__tests__/retool-sanitiser-gate.test.ts
+++ b/scripts/__tests__/retool-sanitiser-gate.test.ts
@@ -5,13 +5,19 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   CREDENTIAL_RULES,
   DENYLIST_PATH,
+  MAX_NGRAM_WORDS,
+  REPO_ROOT,
+  REQUIRED_PLACEHOLDERS,
   SCAN_DIR,
+  SENTINEL_VALUE,
   findCredentialShapes,
   findDenylistHits,
+  findIPv6,
   findMissingPlaceholders,
   findOutOfRangeIPv4,
   hashValue,
   isAllowedIPv4,
+  mask,
   runGate,
   tokenize,
 } from '../ci/retool-sanitiser-gate.mjs';
@@ -43,20 +49,42 @@ const DENIED_NAME = 'Ada Lovelace';
 
 let root: string;
 
-/** A minimal but STRUCTURALLY REAL export tree: placeholders present, IPs in RFC5737. */
+/**
+ * A minimal but STRUCTURALLY REAL export tree.
+ *
+ * 🔴 The placeholder COUNTS here must equal `REQUIRED_PLACEHOLDERS`, because check 4
+ * now asserts counts rather than presence. Building the fixture from the ledger
+ * itself would make the test vacuous — it would agree with any ledger, including a
+ * wrong one — so the counts are written out literally and a separate test asserts
+ * the ledger matches the REAL exports.
+ */
 function seedCleanTree(dir: string) {
   const raw = path.join(dir, SCAN_DIR, 'raw');
   mkdirSync(raw, { recursive: true });
   writeFileSync(
     path.join(raw, 'user-lookup-v2.json'),
-    JSON.stringify({ gate: "current_user.fullName === '__MODERATOR_A__'" }, null, 2)
+    JSON.stringify(
+      {
+        a1: "current_user.fullName === '__MODERATOR_A__'",
+        a2: '__MODERATOR_A__',
+        b1: '__MODERATOR_B__',
+        b2: '__MODERATOR_B__',
+        c1: '__MODERATOR_C__',
+        c2: '__MODERATOR_C__',
+      },
+      null,
+      2
+    )
   );
+  const banBody =
+    'WHERE ip IN (203.0.113.1, 203.0.113.2, 203.0.113.3, 203.0.113.4) ' +
+    'AND toAccountId IN (<accountId>, <accountId>, <accountId>, <accountId>, <accountId>)';
+  writeFileSync(path.join(raw, 'bulk-ban.json'), JSON.stringify({ sql: banBody }, null, 2));
+  writeFileSync(path.join(dir, SCAN_DIR, 'bulk-ban.md'), `| query |\n| ${banBody} |\n`);
   writeFileSync(
-    path.join(raw, 'bulk-ban.json'),
-    JSON.stringify({ sql: 'WHERE ip IN (203.0.113.1, 203.0.113.2)' }, null, 2)
+    path.join(dir, DENYLIST_PATH),
+    JSON.stringify({ version: 1, sentinel: null, hashes: [] }, null, 2)
   );
-  writeFileSync(path.join(dir, SCAN_DIR, 'bulk-ban.md'), '| ip |\n| 203.0.113.1 |\n');
-  writeFileSync(path.join(dir, DENYLIST_PATH), JSON.stringify({ version: 1, hashes: [] }, null, 2));
 }
 
 beforeAll(() => {
@@ -158,6 +186,7 @@ describe('check 3 — credential shapes', () => {
       'postgres-dsn',
       'stripe-key',
       'secret-assignment',
+      'secret-assignment-template',
     ]);
     expect(CREDENTIAL_RULES.map((r) => r.name).sort()).toEqual([...covered].sort());
   });
@@ -261,5 +290,224 @@ describe('check 4 — redaction placeholders survive', () => {
   it('reports every missing placeholder, not just the first', () => {
     const missing = findMissingPlaceholders(() => '');
     expect(missing.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ===========================================================================
+// Regressions from the round-1 adversarial audit of #4486.
+// Each of these pins a defect that was EXECUTED against the gate, not imagined.
+// ===========================================================================
+
+describe('audit 🔴1 — the placeholder ledger must be as wide as its claim', () => {
+  /**
+   * 🔴 This is the test that stops the ledger silently narrowing again. It reads the
+   * REAL exports, not a fixture: a fixture built from the ledger agrees with any
+   * ledger, including the 3-of-10 one that shipped and passed everything.
+   */
+  it('every ledger entry matches the real exports at the count it declares', () => {
+    for (const { file, token, count } of REQUIRED_PLACEHOLDERS) {
+      const abs = path.join(REPO_ROOT, SCAN_DIR, file);
+      const text = readFileSync(abs, 'utf8');
+      expect(`${file}:${token}=${text.split(token).length - 1}`).toBe(`${file}:${token}=${count}`);
+    }
+  });
+
+  it('guards all three documented classes, not just the moderator-A token', () => {
+    const tokens = new Set(REQUIRED_PLACEHOLDERS.map((p) => p.token));
+    // #4476 documents three personal-data classes; `<accountId>` is the only one
+    // with NO other check behind it — a bare integer has no shape.
+    expect(tokens).toContain('__MODERATOR_A__');
+    expect(tokens).toContain('__MODERATOR_B__');
+    expect(tokens).toContain('__MODERATOR_C__');
+    expect(tokens).toContain('<accountId>');
+    expect(tokens).toContain('203.0.113.');
+  });
+
+  it("the audit's executed scenario now FAILS: 2 staff names + 5 account ids restored", () => {
+    mutate((dir) => {
+      const ul = path.join(dir, SCAN_DIR, 'raw', 'user-lookup-v2.json');
+      writeFileSync(
+        ul,
+        readFileSync(ul, 'utf8')
+          .replace(/__MODERATOR_B__/g, 'Grace Hopper')
+          .replace(/__MODERATOR_C__/g, 'Alan Turing')
+      );
+      for (const rel of [['raw', 'bulk-ban.json'], ['bulk-ban.md']]) {
+        const abs = path.join(dir, SCAN_DIR, ...rel);
+        writeFileSync(abs, readFileSync(abs, 'utf8').replace(/<accountId>/g, '8675309'));
+      }
+    });
+    const result = runGate({ root, salt: undefined });
+    expect(result.ok).toBe(false);
+    expect(result.failures.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('catches a PARTIAL re-introduction — presence alone would read as clean', () => {
+    mutate((dir) => {
+      const ul = path.join(dir, SCAN_DIR, 'raw', 'user-lookup-v2.json');
+      // One of two occurrences reverted: the token is still present.
+      writeFileSync(ul, readFileSync(ul, 'utf8').replace('__MODERATOR_B__', 'Grace Hopper'));
+    });
+    const result = runGate({ root, salt: undefined });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/expected 2 occurrence\(s\).*found 1/);
+  });
+});
+
+describe('audit 🔴2 — a salt/hash desync must fail, never pass silently', () => {
+  const seedActive = (saltForHashes: string) => (dir: string) =>
+    writeFileSync(
+      path.join(dir, DENYLIST_PATH),
+      JSON.stringify(
+        {
+          version: 1,
+          sentinel: hashValue(saltForHashes, SENTINEL_VALUE),
+          hashes: [hashValue(saltForHashes, DENIED_NAME)],
+        },
+        null,
+        2
+      )
+    );
+
+  const plantName = (dir: string) => {
+    const ul = path.join(dir, SCAN_DIR, 'raw', 'user-lookup-v2.json');
+    writeFileSync(ul, readFileSync(ul, 'utf8').replace('__MODERATOR_B__', DENIED_NAME));
+  };
+
+  it('positive control — the CORRECT salt finds the planted value', () => {
+    mutate((dir) => {
+      seedActive(SALT)(dir);
+      plantName(dir);
+    });
+    const result = runGate({ root, salt: SALT });
+    expect(result.denylistActive).toBe(true);
+    expect(result.failures.join(' ')).toMatch(/denylisted known-bad value/);
+  });
+
+  it('a ROTATED salt fails loudly instead of matching nothing and passing', () => {
+    mutate((dir) => {
+      seedActive(SALT)(dir);
+      plantName(dir);
+    });
+    const result = runGate({ root, salt: 'a-different-salt' });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/does not match the one these hashes/);
+    expect(result.denylistActive).toBe(false);
+  });
+
+  it('a trailing newline in the CI secret is trimmed, not silently fatal', () => {
+    mutate((dir) => {
+      seedActive(SALT)(dir);
+      plantName(dir);
+    });
+    const result = runGate({ root, salt: `${SALT}\n` });
+    expect(result.failures.join(' ')).toMatch(/denylisted known-bad value/);
+  });
+
+  it('hashes with NO sentinel run but say they are unverified', () => {
+    mutate((dir) =>
+      writeFileSync(
+        path.join(dir, DENYLIST_PATH),
+        JSON.stringify({ version: 1, hashes: [hashValue(SALT, DENIED_NAME)] }, null, 2)
+      )
+    );
+    const result = runGate({ root, salt: SALT });
+    expect(result.notes.join(' ')).toMatch(/ACTIVE but UNVERIFIED/);
+  });
+});
+
+describe('audit 🟡5 — the credential rule must cover the corpus it scans', () => {
+  it.each([
+    ['quoted JSON key', '"apiKey": "AKIAQQQ12345678ZZ"'],
+    ['transit key,value pair', '"WEBHOOK_TOKEN","ghp_abcdefghij0123456789"'],
+    ['escaped double-quoted JS in JSON', '\\"const apiKey = \\"AKIAQQQ12345678ZZ\\"\\"'],
+    ['template literal', 'const apiKey = `AKIAQQQ12345678ZZ`'],
+    ['lowercase bearer', 'authorization: bearer ghp_abcdefghij0123456789'],
+    ['uppercase BEARER', 'AUTHORIZATION: BEARER ghp_abcdefghij0123456789'],
+  ])('catches %s', (_label, sample) => {
+    expect(findCredentialShapes(sample).length).toBeGreaterThan(0);
+  });
+
+  it('does not run away across a large JSON blob (the 646KB over-match)', () => {
+    // The first widened regex included backticks in the quote class, so one opener
+    // consumed the rest of the file and reported a 646,934-char "secret".
+    const blob = `{"token":"${'a'.repeat(400)}","other":${JSON.stringify('x'.repeat(50_000))}}`;
+    for (const hit of findCredentialShapes(blob)) {
+      const chars = Number(/^(\d+) chars/.exec(hit.sample)?.[1] ?? 0);
+      expect(chars).toBeLessThanOrEqual(200);
+    }
+  });
+});
+
+describe('audit 🟡6 — findings must not republish the value', () => {
+  it('masks a credential value rather than printing it', () => {
+    const found = findCredentialShapes("const apiKey = 'AKIAQQQ12345678ZZ'");
+    expect(found).toHaveLength(1);
+    expect(found[0].sample).not.toContain('AKIAQQQ12345678ZZ');
+    expect(found[0].sample).toMatch(/^\d+ chars, sha256:[0-9a-f]{8}…$/);
+  });
+
+  it('mask leaks neither the value nor a usable prefix of it', () => {
+    expect(mask('109.236.62.211')).not.toContain('109.236');
+  });
+});
+
+describe('audit 🟡7 — --hash refuses what the matcher cannot find', () => {
+  it(`throws above ${MAX_NGRAM_WORDS} word tokens`, () => {
+    expect(() => hashValue(SALT, 'Maria Anna Sophia Von Habsburg')).toThrow(/could never match/);
+  });
+
+  it('accepts exactly MAX_NGRAM_WORDS, and that digest really does match', () => {
+    const digest = hashValue(SALT, 'Anna Sophia Von Habsburg');
+    expect(
+      findDenylistHits('signed off by Anna Sophia Von Habsburg today', {
+        salt: SALT,
+        hashes: [digest],
+      })
+    ).toEqual([digest]);
+  });
+
+  it('throws on a value with no word tokens', () => {
+    expect(() => hashValue(SALT, '!!! ---')).toThrow(/no word tokens/);
+  });
+});
+
+describe('audit nits — IPv6 and dotted-quad adjacency', () => {
+  it('flags a real IPv6 address', () => {
+    expect(findIPv6('client 2a01:4f8:c17:1234::1 banned')).toEqual(['2a01:4f8:c17:1234::1']);
+  });
+
+  it('allows loopback/unspecified', () => {
+    expect(findIPv6('bound ::1 and ::')).toEqual([]);
+  });
+
+  it('does not flag ordinary colon-separated text', () => {
+    expect(findIPv6('12:30:45 duration, key:value')).toEqual([]);
+  });
+
+  it('does not flag a dotted quad inside a longer version string', () => {
+    expect(findOutOfRangeIPv4('version 1.2.3.4.5.6 shipped')).toEqual([]);
+    expect(findOutOfRangeIPv4('build 10.20.30.40.1')).toEqual([]);
+  });
+
+  it('still flags a standalone routable address', () => {
+    expect(findOutOfRangeIPv4('from 109.236.62.211 today')).toEqual(['109.236.62.211']);
+  });
+});
+
+describe('real-corpus regressions the synthetic cases did not catch', () => {
+  it('an EMPTY secret-named value does not run across into the next JSON key', () => {
+    // Found by running the widened rule against the real exports: the workflow
+    // files carry `\"databasePasswordOverride\",\"\",\"functionParameters\"` — the
+    // override is EMPTY, which is the safe state, but a value body that allowed
+    // `\"` swallowed the empty string and reported a 21-char "secret".
+    const sample = String.raw`,\"databasePasswordOverride\",\"\",\"functionParameters\"`;
+    expect(findCredentialShapes(sample)).toEqual([]);
+  });
+
+  it('the real exports pass — the corpus IS the false-positive control', () => {
+    const result = runGate({ root: REPO_ROOT, salt: undefined });
+    expect(result.failures).toEqual([]);
+    expect(result.files.length).toBeGreaterThan(20);
   });
 });

--- a/scripts/ci/retool-sanitiser-denylist.json
+++ b/scripts/ci/retool-sanitiser-denylist.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "algorithm": "sha256(salt + NUL + whitespace-normalised-lowercased-value)",
+  "note": [
+    "Salted hashes of KNOWN-BAD values that must never return to the Retool exports.",
+    "Plaintext must never appear here: this repo is public, and a plaintext denylist",
+    "of staff names re-publishes exactly what it exists to protect.",
+    "",
+    "The salt is NOT committed either. A person's name is a tiny search space, so a",
+    "committed salt would be dictionary-crackable in seconds. Supply it as the CI",
+    "secret $RETOOL_SANITISER_SALT.",
+    "",
+    "Add an entry with the salt exported locally:",
+    "  node scripts/ci/retool-sanitiser-gate.mjs --hash '<value>'",
+    "and paste the digest below. Never paste the value.",
+    "",
+    "While this list is empty the denylist check reports SKIPPED and the other three",
+    "checks still run and still block. It is not a silent pass."
+  ],
+  "hashes": []
+}

--- a/scripts/ci/retool-sanitiser-denylist.json
+++ b/scripts/ci/retool-sanitiser-denylist.json
@@ -15,7 +15,16 @@
     "and paste the digest below. Never paste the value.",
     "",
     "While this list is empty the denylist check reports SKIPPED and the other three",
-    "checks still run and still block. It is not a silent pass."
+    "checks still run. It is not a silent pass: the gate's PASS line names the",
+    "reduced scope, and CI renders a warning annotation.",
+    "",
+    "SENTINEL: set it in the SAME command that populates the hashes --",
+    "  node scripts/ci/retool-sanitiser-gate.mjs --sentinel",
+    "It is the digest of a public, meaningless string under the real salt, and it is",
+    "the ONLY thing that detects a salt/hash desync. Without it a rotated salt or a",
+    "trailing newline in the CI secret leaves every hash matching nothing, printing",
+    "nothing, and exiting 0. Leave it null while `hashes` is empty."
   ],
+  "sentinel": null,
   "hashes": []
 }

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -218,6 +218,13 @@ const SECRET_WORD = String.raw`API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|a
  * zero. The rule matched nothing at all on the file it was written for, and the
  * spec passed anyway because its fixture used single escaping — the fake and the
  * code encoded the same wrong assumption, so neither could see the other's error.
+ *
+ * 🔴 Every quote in every rule must use this, including ones spelled inline. The
+ * first version of this widening reached only one of `Q`'s two consumers:
+ * `secret-assignment` hardcoded `\\?` for its VALUE quote and so stayed capped at
+ * depth 1, while a comment on that same rule claimed to cover "the dominant
+ * serialisation" — which is depth 3. A shared constant does not help if a caller
+ * writes the thing out by hand instead.
  */
 const Q = String.raw`\\{0,3}["']`;
 /** A value body that cannot contain a quote, an escaped quote, or a newline. */
@@ -283,9 +290,9 @@ export const CREDENTIAL_RULES = [
         SECRET_WORD +
         String.raw`)s?(?![a-z])[\w$]*` +
         Q +
-        String.raw`?\s*[:=]\s*\\?(["'])(` +
+        String.raw`?\s*[:=]\s*\\{0,3}(["'])(` +
         VALUE_BODY +
-        String.raw`)\\?\1`,
+        String.raw`)\\{0,3}\1`,
       'g'
     ),
     describe: 'a secret-named variable assigned a literal value',

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -83,10 +83,15 @@ const ALLOWED_V4 = [
   [[169, 254], 16], // link-local
 ];
 
-// The negative look-around rejects a dotted quad that is part of a LONGER dotted
-// run — `1.2.3.4.5` is a version string, not an address. Without it `1.2.3.4.5.6`
-// reported a bogus "IPv4 literal 1.2.3.4".
-const V4_RE = /(?<![\d.])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?![\d.])/g;
+// Rejects a dotted quad that is part of a LONGER dotted run — `1.2.3.4.5` is a
+// version string, not an address.
+//
+// 🔴 The lookahead must be `(?!\.?\d)`, NOT `(?![\d.])`. The stricter form also
+// rejected a trailing sentence period, so `Banned the account at 8.8.8.8.` went
+// UNDETECTED — and half this corpus is markdown prose where that is the natural
+// way to write it. Narrowing a false positive into a false negative, on exactly
+// the class the gate exists for.
+const V4_RE = /(?<![\d.])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?!\.?\d)/g;
 
 /**
  * IPv6, deliberately narrow: at least three groups and one `::` or five `:`, so
@@ -99,16 +104,42 @@ const V4_RE = /(?<![\d.])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?![\d.])/g;
  */
 // The tail alternation must try `:<group>` FIRST, or a `::1` suffix is truncated to
 // `::` and the address is reported without its final group.
-const V6_RE = /(?:[0-9a-f]{1,4}:){2,7}(?::[0-9a-f]{1,4}|[0-9a-f]{1,4}|:)(?:%[0-9a-z]+)?/gi;
+//
+// 🔴 `{1,7}`, not `{2,7}`. Requiring TWO `group:` repetitions missed the entire
+// `X::Y` family at every start offset — including `fe80::1` and
+// `fe80::a00:27ff:fe4e:66a1`, the standard link-local form — while the docstring,
+// the README and the PR all claimed no IPv6 literal survives. The only v6 test
+// used a 4-group address, so nothing covered the gap.
+// Allowing EMPTY groups (`{0,4}`) is what makes `::` work at any position and lets
+// the match absorb a multi-group tail. The previous `(?:[0-9a-f]{1,4}:){1,7}` plus a
+// single-group tail truncated `fe80::a00:27ff:fe4e:66a1` to `fe80::a00`, and a
+// `{2,7}` version before that missed the whole `X::Y` family outright.
+// Over-matching is handled by the post-filter, not by the pattern.
+// 🔴 The surrounding boundaries are load-bearing, not tidiness. Allowing empty
+// groups is what lets `::` match anywhere, but it also matches inside a POSTGRES
+// CAST: `id::date` yields `d::da` — two hex groups either side of `::`, i.e. a
+// perfectly well-formed "address". These exports are full of SQL, and the corpus
+// reported four such literals. Requiring the match not to touch a word character
+// rejects every cast while leaving a standalone address untouched.
+const V6_RE = /(?<![\w:.])(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}(?![\w:.])/gi;
 
-/** ::1 and :: are loopback/unspecified — never a person. */
+/** `::` and `::1` are unspecified/loopback — never a person. */
 const ALLOWED_V6 = new Set(['::', '::1']);
 
+/**
+ * A match is a real address only if it is compressed (`::`) or full-length (8
+ * groups), AND carries at least two actual hex groups. Everything else the
+ * pattern can reach — `12:30:45`, a bare `::`, a truncated cast — is not an
+ * address. The pattern is deliberately loose and this is where it is decided.
+ */
 export function findIPv6(text) {
   const found = [];
   for (const match of text.matchAll(V6_RE)) {
     const literal = match[0];
-    if (!literal.includes('::') && literal.split(':').length !== 8) continue;
+    const compressed = literal.includes('::');
+    const groups = literal.split(':').filter(Boolean);
+    if (!compressed && literal.split(':').length !== 8) continue;
+    if (groups.length < 2) continue;
     if (ALLOWED_V6.has(literal.toLowerCase())) continue;
     found.push(literal);
   }
@@ -198,18 +229,46 @@ export const CREDENTIAL_RULES = [
     // cannot match `TOKEN` there: the character before it is `_`, which is a word
     // character, so there is no boundary and the dominant Retool config-var shape
     // walked straight past.
-    re: /(?:^|[^\w$])\\?["']?[\w$]*?(?:api[_-]?key|apikey|token|secret|password|passwd|auth)\w*\\?["']?\s*[:=,]\s*\\?(["'])((?:\\[^"'\n]|[^"'\\\n]){8,200}?)\\?\1/gi,
+    //
+    // 🔴 But the keyword must END the identifier — `(?![a-z0-9])`. Without it the
+    // prefix widener flagged `author`, `authorName`, `authorEmail`, `authorized`
+    // and `tokenizer`, a false-positive class the narrower rule never had. These
+    // exports will carry `author*` keys on the next re-download of any app that
+    // queries models or articles, and a gate that cries wolf gets ignored.
+    //
+    // 🔴 Bound raised from 200: long OPAQUE tokens are the likeliest real finding
+    // and were falling off the top silently (a real JWT is rescued by the `jwt`
+    // rule's dot structure; an opaque session token has nothing behind it). The
+    // runaway that motivated the bound is prevented by the character class — the
+    // value cannot contain a quote, a backslash-quote or a newline — not by 200.
+    //
+    // 🔴 The `,` separator is DELIBERATELY GONE, reverting part of the previous
+    // round. It was added for Retool's transit `"KEY","value"` pair, but `,` cannot
+    // be told apart from an ordinary array: `{"tags": ["auth","authentication"]}`
+    // and `{"columns": ["password","created_at_utc"]}` are the SAME shape, and both
+    // are realistic in these exports. Measured before reverting — every comma-form
+    // instance in the real corpus is `"token","{{ retoolContext.configVars.… }}"`,
+    // a template reference already skipped as redacted, so the separator caught
+    // nothing real while adding a false-positive class. The JSON key form
+    // `"token": "…"` is still covered by `:`.
+    name: 'secret-assignment',
+    // 🔴 NO `i` FLAG, deliberately. `(?![a-z0-9])` under `i` also rejects UPPERCASE,
+    // so the anchor killed `stripeSecretKey` via its own `K` — the rule was
+    // narrowed on exactly the compound names the widening existed for. Case-based
+    // boundary logic and a case-insensitive flag cannot coexist, so the casings are
+    // enumerated and the anchor is genuinely case-sensitive.
+    re: /(?:^|[^\w$])\\?["']?[\w$]*?(?:api[_-]?key|apiKey|API[_-]?KEY|APIKEY|ApiKey|Api[_-]?Key|token|Token|TOKEN|secret|Secret|SECRET|password|Password|PASSWORD|passwd|Passwd|PASSWD|auth|Auth|AUTH)(?![a-z])[\w$]*\\?["']?\s*[:=]\s*\\?(["'])((?:\\[^"'\n]|[^"'\\\n]){8,4096}?)\\?\1/g,
     describe: 'a secret-named variable assigned a literal value',
     valueGroup: 2,
-    minValueLength: 8,
   },
   {
-    // Template literals, separately and bounded for the same reason.
+    // Same widening as its sibling: without it `WEBHOOK_TOKEN = \`…\`` was missed
+    // by BOTH rules, so the compound-name case this round justified only worked
+    // for quoted values.
     name: 'secret-assignment-template',
-    re: /\b(?:api[_-]?key|apikey|token|secret|password|passwd|auth)\w*\s*[:=]\s*`([^`\n]{8,200})`/gi,
+    re: /(?:^|[^\w$])[\w$]*?(?:api[_-]?key|apiKey|API[_-]?KEY|APIKEY|ApiKey|Api[_-]?Key|token|Token|TOKEN|secret|Secret|SECRET|password|Password|PASSWORD|passwd|Passwd|PASSWD|auth|Auth|AUTH)(?![a-z])[\w$]*\s*[:=]\s*`([^`\n]{8,4096})`/g,
     describe: 'a secret-named variable assigned a template-literal value',
     valueGroup: 1,
-    minValueLength: 8,
   },
 ];
 
@@ -218,6 +277,14 @@ function unescapeValue(raw) {
   return raw.replace(/\\(["'`\\])/g, '$1');
 }
 
+/**
+ * There is deliberately no separate minimum-length filter. One was added and
+ * proved UNREACHABLE: the `{8,4096}` quantifier counts REPETITIONS of the value
+ * alternation, and each repetition unescapes to at least one character, so the
+ * unescaped value can never be shorter than the floor. A guard no input can reach
+ * reads as coverage while providing none. The floor is the quantifier; the tests
+ * pin it at its boundary.
+ */
 export function findCredentialShapes(text) {
   const found = [];
   for (const rule of CREDENTIAL_RULES) {
@@ -225,7 +292,6 @@ export function findCredentialShapes(text) {
       const raw = rule.valueGroup ? match[rule.valueGroup] : match[1] ?? match[0];
       const value = raw ? unescapeValue(raw) : raw;
       if (value && REDACTED_RE.test(value.trim())) continue;
-      if (rule.minValueLength && (!value || value.length < rule.minValueLength)) continue;
       found.push({ rule: rule.name, describe: rule.describe, sample: mask(value ?? match[0]) });
     }
   }
@@ -447,7 +513,11 @@ export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_
     const text = readFileSync(path.join(root, rel), 'utf8');
 
     for (const ip of findOutOfRangeIPv4(text)) {
-      failures.push(`${rel}: IPv4 literal ${ip} is outside the documentation/private ranges`);
+      // 🔴 mask(), like every other branch. A banned-user IP is the single class
+      // this gate exists to keep out of a public repo, and it was the one value
+      // printed raw — into an Actions log that is world-readable and outlives any
+      // force-push. The `::error` annotations added alongside made it MORE visible.
+      failures.push(`${rel}: IPv4 literal ${mask(ip)} is outside the documentation/private ranges`);
     }
     for (const ip of findIPv6(text)) {
       failures.push(`${rel}: IPv6 literal ${mask(ip)} — these exports carry no legitimate IPv6`);
@@ -483,10 +553,26 @@ export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_
  * console.log is invisible on a green check, which is how "reports SKIPPED
  * loudly" turned out to mean "buried in a log nobody opens".
  */
-const annotate = (level, message) =>
-  process.env.GITHUB_ACTIONS === 'true'
-    ? `::${level} file=${DENYLIST_PATH}::${message}`
-    : `retool-sanitiser-gate: ${level.toUpperCase()} ${message}`;
+// 🔴 The annotation must point at the file that actually regressed. Hardcoding
+// DENYLIST_PATH pinned every finding to line 1 of the denylist, pointing a
+// reviewer AWAY from the export that changed. Every failure string already starts
+// with its own path, so recover it.
+export const annotate = (level, message, inActions = process.env.GITHUB_ACTIONS === 'true') => {
+  if (!inActions) return `retool-sanitiser-gate: ${level.toUpperCase()} ${message}`;
+  const [, file] = /^([\w./-]+):\s/.exec(message) ?? [];
+  return `::${level} file=${file ?? DENYLIST_PATH}::${message}`;
+};
+
+/**
+ * The scope a PASS line is allowed to claim. Exported so it can be tested: the
+ * round that introduced it left it unguarded, and a mutant forcing the full-scope
+ * string stayed green — in a change whose entire premise was a PASS asserting a
+ * scope it had not established.
+ */
+export const passScope = (denylistActive) =>
+  denylistActive
+    ? 'no known-bad value, out-of-range IP, credential shape or missing placeholder'
+    : 'no out-of-range IP, credential shape or missing placeholder (THE DENYLIST DID NOT RUN)';
 
 function main(argv) {
   const salt = process.env.RETOOL_SANITISER_SALT?.trim();
@@ -524,10 +610,7 @@ function main(argv) {
   for (const note of result.notes) console.log(annotate('warning', note));
   console.log(`retool-sanitiser-gate: scanned ${result.files.length} file(s) under ${SCAN_DIR}`);
   if (result.ok) {
-    const scope = result.denylistActive
-      ? 'no known-bad value, out-of-range IP, credential shape or missing placeholder'
-      : 'no out-of-range IP, credential shape or missing placeholder (THE DENYLIST DID NOT RUN)';
-    console.log(`retool-sanitiser-gate: PASS — ${scope}.`);
+    console.log(`retool-sanitiser-gate: PASS — ${passScope(result.denylistActive)}.`);
     console.log(
       'retool-sanitiser-gate: this does NOT mean the exports are free of personal data — a novel name or bare account id has no shape to match on. See the header.'
     );

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -94,52 +94,51 @@ const ALLOWED_V4 = [
 const V4_RE = /(?<![\d.])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?!\.?\d)/g;
 
 /**
- * IPv6, deliberately narrow: at least three groups and one `::` or five `:`, so
- * ordinary text with colons cannot match. There is no documentation-range dance
- * here — the exports have never legitimately carried an IPv6 literal, so ANY of
- * them is a finding.
+ * IPv6. The exports have never legitimately carried one, so any real address is a
+ * finding — the risk this gate exists for is "end-user IP addresses", which was
+ * never a v4-only statement.
  *
- * WHY: the risk this gate exists for is "end-user IP addresses", which is not a
- * v4-only statement. A re-download carrying real v6 addresses passed every check.
+ * The pattern is deliberately LOOSE and `findIPv6` decides; three revisions tried
+ * to be precise here and each traded one defect for another:
+ *
+ *  - EMPTY groups (`{0,4}`) are what let `::` appear anywhere and let a match
+ *    absorb a multi-group tail. Requiring non-empty groups missed the entire
+ *    `X::Y` family (`fe80::1`, `fe80::a00:27ff:fe4e:66a1`) while three separate
+ *    places claimed no IPv6 survives.
+ *  - The BOUNDARIES are what reject a Postgres cast: `id::date` yields `d::da`,
+ *    a perfectly well-formed "address", and these exports are full of SQL. The
+ *    character before the candidate is a word character, so the cast is dropped
+ *    while a standalone address is not.
+ *  - The trailing boundary must still permit a SENTENCE PERIOD. `(?![\w:.])`
+ *    rejected it, so `Banned the account from fe80::1.` went undetected — the
+ *    exact mirror of the V4 defect, and 21 of the 32 scanned files are prose.
+ *  - The leading boundary omits `:` so a bare `ip:2001:db8::1` still matches.
  */
-// The tail alternation must try `:<group>` FIRST, or a `::1` suffix is truncated to
-// `::` and the address is reported without its final group.
-//
-// 🔴 `{1,7}`, not `{2,7}`. Requiring TWO `group:` repetitions missed the entire
-// `X::Y` family at every start offset — including `fe80::1` and
-// `fe80::a00:27ff:fe4e:66a1`, the standard link-local form — while the docstring,
-// the README and the PR all claimed no IPv6 literal survives. The only v6 test
-// used a 4-group address, so nothing covered the gap.
-// Allowing EMPTY groups (`{0,4}`) is what makes `::` work at any position and lets
-// the match absorb a multi-group tail. The previous `(?:[0-9a-f]{1,4}:){1,7}` plus a
-// single-group tail truncated `fe80::a00:27ff:fe4e:66a1` to `fe80::a00`, and a
-// `{2,7}` version before that missed the whole `X::Y` family outright.
-// Over-matching is handled by the post-filter, not by the pattern.
-// 🔴 The surrounding boundaries are load-bearing, not tidiness. Allowing empty
-// groups is what lets `::` match anywhere, but it also matches inside a POSTGRES
-// CAST: `id::date` yields `d::da` — two hex groups either side of `::`, i.e. a
-// perfectly well-formed "address". These exports are full of SQL, and the corpus
-// reported four such literals. Requiring the match not to touch a word character
-// rejects every cast while leaving a standalone address untouched.
-const V6_RE = /(?<![\w:.])(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}(?![\w:.])/gi;
+const V6_RE = /(?<![\w.])(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}(?![\w:])(?!\.[0-9a-f])/gi;
 
 /** `::` and `::1` are unspecified/loopback — never a person. */
 const ALLOWED_V6 = new Set(['::', '::1']);
 
 /**
  * A match is a real address only if it is compressed (`::`) or full-length (8
- * groups), AND carries at least two actual hex groups. Everything else the
- * pattern can reach — `12:30:45`, a bare `::`, a truncated cast — is not an
- * address. The pattern is deliberately loose and this is where it is decided.
+ * groups). Everything else the pattern can reach — `12:30:45`, `17:28:00Z` — is
+ * ordinary colon-separated text.
+ *
+ * 🔴 There is NO `groups.length < 2` filter, and adding one was a mistake worth
+ * recording. It was introduced to stop Postgres casts, but the BOUNDARIES alone
+ * already do that — measured: with the filter removed, `select id::date from t`
+ * still yields `[]` and the real corpus still passes. Its only observable effects
+ * were bad ones: it silently exempted every single-group address (`fe80::`,
+ * `::dead` went unreported while the README said any IPv6 is rejected), and it
+ * consumed `::1` before `ALLOWED_V6` could see it — making that Set dead code
+ * whose docstring read as live coverage, and making its test vacuous. Deleting
+ * three separate things left the suite green, which is how it was found.
  */
 export function findIPv6(text) {
   const found = [];
   for (const match of text.matchAll(V6_RE)) {
     const literal = match[0];
-    const compressed = literal.includes('::');
-    const groups = literal.split(':').filter(Boolean);
-    if (!compressed && literal.split(':').length !== 8) continue;
-    if (groups.length < 2) continue;
+    if (!literal.includes('::') && literal.split(':').length !== 8) continue;
     if (ALLOWED_V6.has(literal.toLowerCase())) continue;
     found.push(literal);
   }
@@ -223,14 +222,15 @@ export const CREDENTIAL_RULES = [
     // and included backticks in the quote class: in an 11-file JSON corpus where
     // backticks are rare, one opener ran to end-of-file and reported a 646,934-char
     // "secret" in three files. A guard that matches everything is not a guard.
-    name: 'secret-assignment',
+    //
     // `[\w$]*?` before the keyword, because the secret-named identifier is usually a
     // COMPONENT of a longer name — `WEBHOOK_TOKEN`, `stripeSecretKey`. A leading `\b`
     // cannot match `TOKEN` there: the character before it is `_`, which is a word
     // character, so there is no boundary and the dominant Retool config-var shape
     // walked straight past.
     //
-    // 🔴 But the keyword must END the identifier — `(?![a-z0-9])`. Without it the
+    // 🔴 But the keyword must END the identifier — `(?![a-z])`, plus an optional
+    // plural `s`. Without it the
     // prefix widener flagged `author`, `authorName`, `authorEmail`, `authorized`
     // and `tokenizer`, a false-positive class the narrower rule never had. These
     // exports will carry `author*` keys on the next re-download of any app that
@@ -252,12 +252,12 @@ export const CREDENTIAL_RULES = [
     // nothing real while adding a false-positive class. The JSON key form
     // `"token": "…"` is still covered by `:`.
     name: 'secret-assignment',
-    // 🔴 NO `i` FLAG, deliberately. `(?![a-z0-9])` under `i` also rejects UPPERCASE,
+    // 🔴 NO `i` FLAG, deliberately. `(?![a-z])` under `i` would also reject UPPERCASE,
     // so the anchor killed `stripeSecretKey` via its own `K` — the rule was
     // narrowed on exactly the compound names the widening existed for. Case-based
     // boundary logic and a case-insensitive flag cannot coexist, so the casings are
     // enumerated and the anchor is genuinely case-sensitive.
-    re: /(?:^|[^\w$])\\?["']?[\w$]*?(?:api[_-]?key|apiKey|API[_-]?KEY|APIKEY|ApiKey|Api[_-]?Key|token|Token|TOKEN|secret|Secret|SECRET|password|Password|PASSWORD|passwd|Passwd|PASSWD|auth|Auth|AUTH)(?![a-z])[\w$]*\\?["']?\s*[:=]\s*\\?(["'])((?:\\[^"'\n]|[^"'\\\n]){8,4096}?)\\?\1/g,
+    re: /(?:^|[^\w$])\\?["']?[\w$]*?(?:API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|api[_-]?Key|api[_-]?key|APIKEY|APIKey|ApiKey|Apikey|apiKey|apikey|AUTHORIZATION|Authorization|authorization|AUTHENTICATION|Authentication|authentication|SECRETKEY|SecretKey|secretKey|secretkey|TOKEN|Token|token|SECRET|Secret|secret|PASSWORD|Password|password|PASSWD|Passwd|passwd|AUTH|Auth|auth)s?(?![a-z])[\w$]*\\?["']?\s*[:=]\s*\\?(["'])((?:\\[^"'\n]|[^"'\\\n]){8,4096}?)\\?\1/g,
     describe: 'a secret-named variable assigned a literal value',
     valueGroup: 2,
   },
@@ -266,7 +266,7 @@ export const CREDENTIAL_RULES = [
     // by BOTH rules, so the compound-name case this round justified only worked
     // for quoted values.
     name: 'secret-assignment-template',
-    re: /(?:^|[^\w$])[\w$]*?(?:api[_-]?key|apiKey|API[_-]?KEY|APIKEY|ApiKey|Api[_-]?Key|token|Token|TOKEN|secret|Secret|SECRET|password|Password|PASSWORD|passwd|Passwd|PASSWD|auth|Auth|AUTH)(?![a-z])[\w$]*\s*[:=]\s*`([^`\n]{8,4096})`/g,
+    re: /(?:^|[^\w$])[\w$]*?(?:API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|api[_-]?Key|api[_-]?key|APIKEY|APIKey|ApiKey|Apikey|apiKey|apikey|AUTHORIZATION|Authorization|authorization|AUTHENTICATION|Authentication|authentication|SECRETKEY|SecretKey|secretKey|secretkey|TOKEN|Token|token|SECRET|Secret|secret|PASSWORD|Password|password|PASSWD|Passwd|passwd|AUTH|Auth|auth)s?(?![a-z])[\w$]*\s*[:=]\s*`([^`\n]{8,4096})`/g,
     describe: 'a secret-named variable assigned a template-literal value',
     valueGroup: 1,
   },
@@ -278,12 +278,21 @@ function unescapeValue(raw) {
 }
 
 /**
- * There is deliberately no separate minimum-length filter. One was added and
- * proved UNREACHABLE: the `{8,4096}` quantifier counts REPETITIONS of the value
- * alternation, and each repetition unescapes to at least one character, so the
- * unescaped value can never be shorter than the floor. A guard no input can reach
- * reads as coverage while providing none. The floor is the quantifier; the tests
- * pin it at its boundary.
+ * There is deliberately no separate minimum-length filter, and the reasoning is
+ * NOT uniform across the two rules — the earlier version of this comment claimed
+ * it was, which was wrong for one of them:
+ *
+ *  - `secret-assignment` — genuinely unreachable. `{8,4096}` counts REPETITIONS of
+ *    the value alternation and each repetition unescapes to at least one
+ *    character, so the unescaped value can never fall below the floor.
+ *  - `secret-assignment-template` — the quantifier counts CHARACTERS inside
+ *    `[^`\n]`, backslashes included, so an 8-char match can unescape to fewer. A
+ *    floor would therefore fire here. It is still omitted: the effect is at most a
+ *    slightly over-eager finding on a contrived value, and an over-eager
+ *    credential finding is the safe direction.
+ *
+ * A guard no input can reach reads as coverage while providing none, which is why
+ * the first one was deleted rather than left in place.
  */
 export function findCredentialShapes(text) {
   const found = [];

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -112,9 +112,16 @@ const V4_RE = /(?<![\d.])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?!\.?\d)/g;
  *  - The trailing boundary must still permit a SENTENCE PERIOD. `(?![\w:.])`
  *    rejected it, so `Banned the account from fe80::1.` went undetected — the
  *    exact mirror of the V4 defect, and 21 of the 32 scanned files are prose.
+ *    Relaxing it to `(?![\w:])` is what fixes that.
  *  - The leading boundary omits `:` so a bare `ip:2001:db8::1` still matches.
+ *  - 🔴 There is NO `(?!\.[0-9a-f])`. One was added alongside the period fix and
+ *    contributed nothing to it, while silently suppressing every IPv4-embedded
+ *    form: `::ffff:192.168.1.1` matched NOTHING at all — not check 2 either,
+ *    since the inner address is RFC1918. Deleting it left the suite fully green
+ *    and the corpus at rc=0, i.e. it was pinned by nothing and cost real
+ *    detections. A narrowing nobody can observe is the easiest kind to keep.
  */
-const V6_RE = /(?<![\w.])(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}(?![\w:])(?!\.[0-9a-f])/gi;
+const V6_RE = /(?<![\w.])(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}(?![\w:])/gi;
 
 /** `::` and `::1` are unspecified/loopback — never a person. */
 const ALLOWED_V6 = new Set(['::', '::1']);
@@ -125,9 +132,12 @@ const ALLOWED_V6 = new Set(['::', '::1']);
  * ordinary colon-separated text.
  *
  * 🔴 There is NO `groups.length < 2` filter, and adding one was a mistake worth
- * recording. It was introduced to stop Postgres casts, but the BOUNDARIES alone
- * already do that — measured: with the filter removed, `select id::date from t`
- * still yields `[]` and the real corpus still passes. Its only observable effects
+ * recording. It was introduced to stop Postgres casts. The boundaries already do
+ * that for every cast in this corpus and every common type name — but only
+ * because those contain a non-hex character. A hex-only alias such as `)::dec`
+ * (a real Postgres alias for `decimal`, and `)::decimal` appears here twice) is
+ * shape-identical to the legitimate address `::dead`, so NO filter can separate
+ * them and this one fails closed rather than silently. Its other effects
  * were bad ones: it silently exempted every single-group address (`fe80::`,
  * `::dead` went unreported while the README said any IPv6 is rejected), and it
  * consumed `::1` before `ALLOWED_V6` could see it — making that Set dead code
@@ -178,7 +188,30 @@ export function findOutOfRangeIPv4(text) {
  * A value already redacted is not a finding. Kept deliberately narrow: anything
  * broader starts excusing real secrets that merely mention one of these words.
  */
-const REDACTED_RE = /^(?:<[^>]*>|__[A-Z0-9_]+__|\{\{[^}]*\}\}|\$\{[^}]*\}|x{3,}|\*{3,}|REDACTED)$/i;
+// The optional leading `<scheme> ` matters for the Retool kv shape, where the value
+// is written `Basic {{ SomeCredentials.value }}` — a placeholder with an auth-scheme
+// prefix. Without it the 12 already-redacted Authorization entries in the corpus all
+// report as findings. The scheme is bounded to one short word so it cannot excuse a
+// real secret that merely happens to be preceded by text.
+const REDACTED_RE =
+  /^(?:[A-Za-z][A-Za-z-]{2,14}\s+)?(?:<[^>]*>|__[A-Z0-9_]+__|\{\{[^}]*\}\}|\$\{[^}]*\}|x{3,}|\*{3,}|REDACTED)$/i;
+
+/**
+ * The secret-word alternation, as ONE source string.
+ *
+ * Case-sensitive by necessity (`(?![a-z])` under an `i` flag also rejects
+ * uppercase), so the casings are enumerated. Ordered longest-first: `authorization`
+ * must precede `auth`, or `auth` wins and the anchor then rejects the identifier.
+ *
+ * Shared rather than pasted into each rule — it was byte-identical in two places
+ * and is now needed in three, which is exactly how the copies start to drift.
+ */
+const SECRET_WORD = String.raw`API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|api[_-]?Key|api[_-]?key|APIKEY|APIKey|ApiKey|Apikey|apiKey|apikey|AUTHORIZATION|Authorization|authorization|AUTHENTICATION|Authentication|authentication|SECRETKEY|SecretKey|secretKey|secretkey|TOKEN|Token|token|SECRET|Secret|secret|PASSWORD|Password|password|PASSWD|Passwd|passwd|AUTH|Auth|auth`;
+
+/** A quote that may be backslash-escaped, as it is inside JSON-embedded JS. */
+const Q = String.raw`\\?["']`;
+/** A value body that cannot contain a quote, an escaped quote, or a newline. */
+const VALUE_BODY = String.raw`(?:\\[^"'\n]|[^"'\\\n]){8,4096}?`;
 
 export const CREDENTIAL_RULES = [
   {
@@ -217,57 +250,86 @@ export const CREDENTIAL_RULES = [
     // So: the identifier may be quoted, the separator may be `:`/`=`/`,`, and the
     // value may be single, double or backtick quoted, with `\"` escapes allowed
     // inside (escaped JS embedded in JSON is exactly how the original miss happened).
-    // 🔴 The value body must exclude BOTH quote characters and newlines, and be
+    // The value body must exclude BOTH quote characters and newlines, and be
     // length-bounded. A first attempt used `(?:\\.|[^\\])*?` with a backreference
     // and included backticks in the quote class: in an 11-file JSON corpus where
     // backticks are rare, one opener ran to end-of-file and reported a 646,934-char
     // "secret" in three files. A guard that matches everything is not a guard.
     //
-    // `[\w$]*?` before the keyword, because the secret-named identifier is usually a
-    // COMPONENT of a longer name — `WEBHOOK_TOKEN`, `stripeSecretKey`. A leading `\b`
-    // cannot match `TOKEN` there: the character before it is `_`, which is a word
-    // character, so there is no boundary and the dominant Retool config-var shape
-    // walked straight past.
+    // `[\w$]*?` before the keyword, because the secret-named identifier is usually
+    // a COMPONENT of a longer name — `WEBHOOK_TOKEN`, `stripeSecretKey`. A leading
+    // `\b` cannot match `TOKEN` there: the preceding `_` is a word character.
     //
-    // 🔴 But the keyword must END the identifier — `(?![a-z])`, plus an optional
-    // plural `s`. Without it the
-    // prefix widener flagged `author`, `authorName`, `authorEmail`, `authorized`
-    // and `tokenizer`, a false-positive class the narrower rule never had. These
-    // exports will carry `author*` keys on the next re-download of any app that
-    // queries models or articles, and a gate that cries wolf gets ignored.
-    //
-    // 🔴 Bound raised from 200: long OPAQUE tokens are the likeliest real finding
-    // and were falling off the top silently (a real JWT is rescued by the `jwt`
-    // rule's dot structure; an opaque session token has nothing behind it). The
-    // runaway that motivated the bound is prevented by the character class — the
-    // value cannot contain a quote, a backslash-quote or a newline — not by 200.
-    //
-    // 🔴 The `,` separator is DELIBERATELY GONE, reverting part of the previous
-    // round. It was added for Retool's transit `"KEY","value"` pair, but `,` cannot
-    // be told apart from an ordinary array: `{"tags": ["auth","authentication"]}`
-    // and `{"columns": ["password","created_at_utc"]}` are the SAME shape, and both
-    // are realistic in these exports. Measured before reverting — every comma-form
-    // instance in the real corpus is `"token","{{ retoolContext.configVars.… }}"`,
-    // a template reference already skipped as redacted, so the separator caught
-    // nothing real while adding a false-positive class. The JSON key form
-    // `"token": "…"` is still covered by `:`.
+    // 🔴 The `,` separator is DELIBERATELY ABSENT. It was tried for Retool's
+    // transit pair and reverted: `,` cannot be told apart from an ordinary array,
+    // so `{"tags": ["auth","authentication"]}` and `{"columns": ["password",…]}`
+    // matched too. The transit pair is handled by `retool-kv-credential` below,
+    // which requires the literal `key`/`value` wrapper and so cannot match an array.
     name: 'secret-assignment',
-    // 🔴 NO `i` FLAG, deliberately. `(?![a-z])` under `i` would also reject UPPERCASE,
-    // so the anchor killed `stripeSecretKey` via its own `K` — the rule was
-    // narrowed on exactly the compound names the widening existed for. Case-based
-    // boundary logic and a case-insensitive flag cannot coexist, so the casings are
-    // enumerated and the anchor is genuinely case-sensitive.
-    re: /(?:^|[^\w$])\\?["']?[\w$]*?(?:API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|api[_-]?Key|api[_-]?key|APIKEY|APIKey|ApiKey|Apikey|apiKey|apikey|AUTHORIZATION|Authorization|authorization|AUTHENTICATION|Authentication|authentication|SECRETKEY|SecretKey|secretKey|secretkey|TOKEN|Token|token|SECRET|Secret|secret|PASSWORD|Password|password|PASSWD|Passwd|passwd|AUTH|Auth|auth)s?(?![a-z])[\w$]*\\?["']?\s*[:=]\s*\\?(["'])((?:\\[^"'\n]|[^"'\\\n]){8,4096}?)\\?\1/g,
+    re: new RegExp(
+      String.raw`(?:^|[^\w$])` +
+        Q +
+        String.raw`?[\w$]*?(?:` +
+        SECRET_WORD +
+        String.raw`)s?(?![a-z])[\w$]*` +
+        Q +
+        String.raw`?\s*[:=]\s*\\?(["'])(` +
+        VALUE_BODY +
+        String.raw`)\\?\1`,
+      'g'
+    ),
     describe: 'a secret-named variable assigned a literal value',
     valueGroup: 2,
   },
   {
-    // Same widening as its sibling: without it `WEBHOOK_TOKEN = \`…\`` was missed
-    // by BOTH rules, so the compound-name case this round justified only worked
-    // for quoted values.
+    // Template literals, same widening as the quoted rule.
     name: 'secret-assignment-template',
-    re: /(?:^|[^\w$])[\w$]*?(?:API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|api[_-]?Key|api[_-]?key|APIKEY|APIKey|ApiKey|Apikey|apiKey|apikey|AUTHORIZATION|Authorization|authorization|AUTHENTICATION|Authentication|authentication|SECRETKEY|SecretKey|secretKey|secretkey|TOKEN|Token|token|SECRET|Secret|secret|PASSWORD|Password|password|PASSWD|Passwd|passwd|AUTH|Auth|auth)s?(?![a-z])[\w$]*\s*[:=]\s*`([^`\n]{8,4096})`/g,
+    re: new RegExp(
+      String.raw`(?:^|[^\w$])[\w$]*?(?:` +
+        SECRET_WORD +
+        String.raw`)s?(?![a-z])[\w$]*\s*[:=]\s*` +
+        '`([^`\\n]{8,4096})`',
+      'g'
+    ),
     describe: 'a secret-named variable assigned a template-literal value',
+    valueGroup: 1,
+  },
+  {
+    // 🔴 Retool's transit serialisation, which is how EVERY credential header in
+    // this corpus is actually written:
+    //     \"key\":\"Authorization\",\"value\":\"Basic <base64>\"
+    // The identifier is a VALUE, and the separator after it is `,` — so neither
+    // assignment rule above can see it. Twelve `Authorization` entries in
+    // raw/user-lookup-v2.json have this shape. The `Bearer` variant happened to be
+    // caught by the `bearer-token` rule; `Basic <base64>` was caught by NOTHING,
+    // while a test comment claimed the class was covered.
+    //
+    // Safe where a bare `,` separator was not: this requires the literal `key`/
+    // `value` wrapper, so a tag or column array cannot match it.
+    name: 'retool-kv-credential',
+    re: new RegExp(
+      Q +
+        String.raw`key` +
+        Q +
+        String.raw`\s*:\s*` +
+        Q +
+        String.raw`[\w$-]*?(?:` +
+        SECRET_WORD +
+        String.raw`)s?[\w$-]*` +
+        Q +
+        String.raw`\s*,\s*` +
+        Q +
+        String.raw`value` +
+        Q +
+        String.raw`\s*:\s*` +
+        Q +
+        String.raw`(` +
+        VALUE_BODY +
+        String.raw`)` +
+        Q,
+      'g'
+    ),
+    describe: 'a Retool key/value pair whose key names a credential',
     valueGroup: 1,
   },
 ];

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -83,7 +83,37 @@ const ALLOWED_V4 = [
   [[169, 254], 16], // link-local
 ];
 
-const V4_RE = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;
+// The negative look-around rejects a dotted quad that is part of a LONGER dotted
+// run — `1.2.3.4.5` is a version string, not an address. Without it `1.2.3.4.5.6`
+// reported a bogus "IPv4 literal 1.2.3.4".
+const V4_RE = /(?<![\d.])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?![\d.])/g;
+
+/**
+ * IPv6, deliberately narrow: at least three groups and one `::` or five `:`, so
+ * ordinary text with colons cannot match. There is no documentation-range dance
+ * here — the exports have never legitimately carried an IPv6 literal, so ANY of
+ * them is a finding.
+ *
+ * WHY: the risk this gate exists for is "end-user IP addresses", which is not a
+ * v4-only statement. A re-download carrying real v6 addresses passed every check.
+ */
+// The tail alternation must try `:<group>` FIRST, or a `::1` suffix is truncated to
+// `::` and the address is reported without its final group.
+const V6_RE = /(?:[0-9a-f]{1,4}:){2,7}(?::[0-9a-f]{1,4}|[0-9a-f]{1,4}|:)(?:%[0-9a-z]+)?/gi;
+
+/** ::1 and :: are loopback/unspecified — never a person. */
+const ALLOWED_V6 = new Set(['::', '::1']);
+
+export function findIPv6(text) {
+  const found = [];
+  for (const match of text.matchAll(V6_RE)) {
+    const literal = match[0];
+    if (!literal.includes('::') && literal.split(':').length !== 8) continue;
+    if (ALLOWED_V6.has(literal.toLowerCase())) continue;
+    found.push(literal);
+  }
+  return [...new Set(found)];
+}
 
 export function isAllowedIPv4(ip) {
   const octets = ip.split('.').map(Number);
@@ -123,7 +153,9 @@ const REDACTED_RE = /^(?:<[^>]*>|__[A-Z0-9_]+__|\{\{[^}]*\}\}|\$\{[^}]*\}|x{3,}|
 export const CREDENTIAL_RULES = [
   {
     name: 'bearer-token',
-    re: /\bBearer\s+([A-Za-z0-9._~+/=-]{12,})/g,
+    // `i`: the auth scheme is case-insensitive per RFC 7235, so `bearer …` and
+    // `BEARER …` are equally valid and were both walking past this rule.
+    re: /\bBearer\s+([A-Za-z0-9._~+/=-]{12,})/gi,
     describe: 'an Authorization: Bearer value that is not redacted',
   },
   {
@@ -145,28 +177,75 @@ export const CREDENTIAL_RULES = [
     // The rule the first sanitiser pass was MISSING: match on the assignment, not
     // on the shape of the value. A `const apiKey = '…'` inside a Retool Function
     // body looks like nothing in particular.
+    //
+    // 🔴 The first version of this rule only covered `ident = '…'` — the SINGLE-quoted
+    // JS form. But the corpus it scans is eleven Retool JSON exports, where the
+    // dominant serialisations are `"apiKey": "…"` (quoted key) and the transit pair
+    // `"KEY","value"`, and neither was caught. A rule that misses the dominant shape
+    // of the files it scans is a false-negative surface, not a guard.
+    //
+    // So: the identifier may be quoted, the separator may be `:`/`=`/`,`, and the
+    // value may be single, double or backtick quoted, with `\"` escapes allowed
+    // inside (escaped JS embedded in JSON is exactly how the original miss happened).
+    // 🔴 The value body must exclude BOTH quote characters and newlines, and be
+    // length-bounded. A first attempt used `(?:\\.|[^\\])*?` with a backreference
+    // and included backticks in the quote class: in an 11-file JSON corpus where
+    // backticks are rare, one opener ran to end-of-file and reported a 646,934-char
+    // "secret" in three files. A guard that matches everything is not a guard.
     name: 'secret-assignment',
-    re: /\b(?:api[_-]?key|apikey|token|secret|password|passwd|auth)\w*\s*[:=]\s*(['"])([^'"\\]{8,})\1/gi,
+    // `[\w$]*?` before the keyword, because the secret-named identifier is usually a
+    // COMPONENT of a longer name — `WEBHOOK_TOKEN`, `stripeSecretKey`. A leading `\b`
+    // cannot match `TOKEN` there: the character before it is `_`, which is a word
+    // character, so there is no boundary and the dominant Retool config-var shape
+    // walked straight past.
+    re: /(?:^|[^\w$])\\?["']?[\w$]*?(?:api[_-]?key|apikey|token|secret|password|passwd|auth)\w*\\?["']?\s*[:=,]\s*\\?(["'])((?:\\[^"'\n]|[^"'\\\n]){8,200}?)\\?\1/gi,
     describe: 'a secret-named variable assigned a literal value',
     valueGroup: 2,
+    minValueLength: 8,
+  },
+  {
+    // Template literals, separately and bounded for the same reason.
+    name: 'secret-assignment-template',
+    re: /\b(?:api[_-]?key|apikey|token|secret|password|passwd|auth)\w*\s*[:=]\s*`([^`\n]{8,200})`/gi,
+    describe: 'a secret-named variable assigned a template-literal value',
+    valueGroup: 1,
+    minValueLength: 8,
   },
 ];
+
+/** Strips the escaping that survives a JSON-embedded JS string. */
+function unescapeValue(raw) {
+  return raw.replace(/\\(["'`\\])/g, '$1');
+}
 
 export function findCredentialShapes(text) {
   const found = [];
   for (const rule of CREDENTIAL_RULES) {
     for (const match of text.matchAll(rule.re)) {
-      const value = rule.valueGroup ? match[rule.valueGroup] : match[1] ?? match[0];
+      const raw = rule.valueGroup ? match[rule.valueGroup] : match[1] ?? match[0];
+      const value = raw ? unescapeValue(raw) : raw;
       if (value && REDACTED_RE.test(value.trim())) continue;
-      found.push({ rule: rule.name, describe: rule.describe, sample: truncate(match[0]) });
+      if (rule.minValueLength && (!value || value.length < rule.minValueLength)) continue;
+      found.push({ rule: rule.name, describe: rule.describe, sample: mask(value ?? match[0]) });
     }
   }
   return found;
 }
 
-function truncate(s) {
-  const flat = s.replace(/\s+/g, ' ');
-  return flat.length > 48 ? `${flat.slice(0, 45)}…` : flat;
+/**
+ * 🔴 NEVER print a matched value. This repo is PUBLIC, so an Actions log is
+ * world-readable and outlives any force-push that removes the value from the
+ * branch — and a banned-user IP is exactly the class this gate exists to keep out.
+ *
+ * The first version of this file withheld the DENYLIST value for precisely this
+ * reason and then printed IPs and Bearer tokens one branch up. A length plus a
+ * salt-free digest prefix identifies the finding for whoever has the file open,
+ * without republishing it.
+ */
+export function mask(value) {
+  const flat = String(value).replace(/\s+/g, ' ');
+  const digest = createHash('sha256').update(flat).digest('hex').slice(0, 8);
+  return `${flat.length} chars, sha256:${digest}…`;
 }
 
 // ---------------------------------------------------------------------------
@@ -190,10 +269,40 @@ export function tokenize(text) {
     .filter(Boolean);
 }
 
+/**
+ * 🔴 Refuses a value the MATCHER structurally cannot find.
+ *
+ * `findDenylistHits` only builds 1..MAX_NGRAM_WORDS windows, but nothing stopped
+ * `--hash` emitting a digest for a longer value. The operator would paste it,
+ * commit it, and the denylist would silently never fire for that value — the
+ * reassuring-zero shape, inside the very tool that populates the gate.
+ */
 export function hashValue(salt, value) {
-  const normalized = tokenize(value).join(' ');
+  const words = tokenize(value);
+  if (words.length === 0) {
+    throw new Error('refusing to hash a value with no word tokens');
+  }
+  if (words.length > MAX_NGRAM_WORDS) {
+    throw new Error(
+      `refusing to hash a ${words.length}-token value: findDenylistHits only builds ` +
+        `1..${MAX_NGRAM_WORDS}-word windows, so this digest could never match. Hash a ` +
+        `distinctive ${MAX_NGRAM_WORDS}-token-or-shorter substring instead.`
+    );
+  }
+  const normalized = words.join(' ');
   return createHash('sha256').update(`${salt}\u0000${normalized}`).digest('hex');
 }
+
+/**
+ * Public, meaningless string whose digest UNDER THE REAL SALT proves that the salt
+ * CI supplies is the one the committed hashes were generated with.
+ *
+ * 🔴 Nothing else detects a desync. A rotated salt, a regenerated denylist, or a
+ * trailing newline in the secret (GitHub preserves it) each leave the check
+ * "active", matching nothing, printing nothing, and exiting 0 — under a PASS line
+ * asserting "no known-bad value", which it has not established.
+ */
+export const SENTINEL_VALUE = 'retool sanitiser sentinel';
 
 /** Every 1..MAX_NGRAM_WORDS word window, hashed. */
 export function findDenylistHits(text, { salt, hashes }) {
@@ -217,23 +326,51 @@ export function findDenylistHits(text, { salt, hashes }) {
 
 /**
  * A wholesale re-download overwrites a sanitised file with a raw one, so the
- * placeholders disappear. That is the exact headline risk, and this check catches
- * it without needing any secret.
+ * placeholders disappear. That is the headline risk, and this check catches it
+ * without needing any secret.
+ *
+ * 🔴 THE LEDGER MUST BE AS WIDE AS THE CLAIM. The first version listed three
+ * entries — `__MODERATOR_A__` once and `203.0.113.` twice — while PR #4476 wrote
+ * FIVE token classes across 10 occurrences. `__MODERATOR_B__`, `__MODERATOR_C__`
+ * and `<accountId>` were guarded by nothing, and `<accountId>` is the one
+ * documented class with no other check behind it: a real IP is caught by check 2,
+ * but a bare account id is an ordinary integer that only this ledger can see.
+ * Restoring two staff names and five account ids passed the whole gate, rc=0.
+ *
+ * EXPECTED COUNTS, not mere presence. Presence is satisfied by one surviving
+ * token, so a PARTIAL re-introduction — some occurrences reverted, one left —
+ * reads as clean. Counts make that visible. A count that legitimately changes is
+ * a deliberate edit to these exports, which is exactly when a human should look.
  */
 export const REQUIRED_PLACEHOLDERS = [
-  { file: 'raw/user-lookup-v2.json', token: '__MODERATOR_A__' },
-  { file: 'raw/bulk-ban.json', token: '203.0.113.' },
-  { file: 'bulk-ban.md', token: '203.0.113.' },
+  { file: 'raw/user-lookup-v2.json', token: '__MODERATOR_A__', count: 2 },
+  { file: 'raw/user-lookup-v2.json', token: '__MODERATOR_B__', count: 2 },
+  { file: 'raw/user-lookup-v2.json', token: '__MODERATOR_C__', count: 2 },
+  { file: 'raw/bulk-ban.json', token: '<accountId>', count: 5 },
+  { file: 'raw/bulk-ban.json', token: '203.0.113.', count: 4 },
+  { file: 'bulk-ban.md', token: '<accountId>', count: 5 },
+  { file: 'bulk-ban.md', token: '203.0.113.', count: 4 },
 ];
+
+const countOccurrences = (haystack, needle) => haystack.split(needle).length - 1;
 
 export function findMissingPlaceholders(readFile) {
   const missing = [];
-  for (const { file, token } of REQUIRED_PLACEHOLDERS) {
+  for (const { file, token, count } of REQUIRED_PLACEHOLDERS) {
     const text = readFile(file);
     if (text === null) {
       missing.push({ file, token, reason: 'file is absent' });
-    } else if (!text.includes(token)) {
+      continue;
+    }
+    const seen = countOccurrences(text, token);
+    if (seen === 0) {
       missing.push({ file, token, reason: 'redaction placeholder is gone' });
+    } else if (seen !== count) {
+      missing.push({
+        file,
+        token,
+        reason: `expected ${count} occurrence(s) of this redaction placeholder, found ${seen}`,
+      });
     }
   }
   return missing;
@@ -257,9 +394,12 @@ export function listFiles(root, rel) {
 
 export function loadDenylist(root) {
   const abs = path.join(root, DENYLIST_PATH);
-  if (!existsSync(abs)) return { hashes: [] };
+  if (!existsSync(abs)) return { hashes: [], sentinel: null };
   const parsed = JSON.parse(readFileSync(abs, 'utf8'));
-  return { hashes: Array.isArray(parsed.hashes) ? parsed.hashes : [] };
+  return {
+    hashes: Array.isArray(parsed.hashes) ? parsed.hashes : [],
+    sentinel: typeof parsed.sentinel === 'string' && parsed.sentinel ? parsed.sentinel : null,
+  };
 }
 
 export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_SALT } = {}) {
@@ -276,12 +416,31 @@ export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_
     };
   }
 
-  const { hashes } = loadDenylist(root);
-  const denylistActive = Boolean(salt) && hashes.length > 0;
-  if (!salt) {
+  const { hashes, sentinel } = loadDenylist(root);
+  // A trailing newline is the commonest way a pasted CI secret differs from the
+  // salt the hashes were built with; GitHub preserves it. Trim, then PROVE it.
+  const effectiveSalt = typeof salt === 'string' ? salt.trim() : salt;
+  let denylistActive = Boolean(effectiveSalt) && hashes.length > 0;
+
+  if (!effectiveSalt) {
     notes.push('denylist SKIPPED — $RETOOL_SANITISER_SALT is not set. Checks 2-4 still ran.');
   } else if (hashes.length === 0) {
     notes.push(`denylist SKIPPED — ${DENYLIST_PATH} lists no hashes yet. Checks 2-4 still ran.`);
+  } else if (!sentinel) {
+    notes.push(
+      `denylist ACTIVE but UNVERIFIED — ${DENYLIST_PATH} carries no "sentinel", so a ` +
+        'salt/hash desync would be undetectable. Regenerate it with --sentinel.'
+    );
+  } else if (hashValue(effectiveSalt, SENTINEL_VALUE) !== sentinel) {
+    // 🔴 Fail, never skip. The hashes are real, the salt is wrong, and every one
+    // of them would silently match nothing — a PASS asserting "no known-bad
+    // value" it never established.
+    denylistActive = false;
+    failures.push(
+      `${DENYLIST_PATH}: the salt in $RETOOL_SANITISER_SALT does not match the one these ` +
+        'hashes were generated with (sentinel digest mismatch), so the denylist would ' +
+        'silently match nothing. Fix the secret or regenerate the denylist.'
+    );
   }
 
   for (const rel of files) {
@@ -290,11 +449,14 @@ export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_
     for (const ip of findOutOfRangeIPv4(text)) {
       failures.push(`${rel}: IPv4 literal ${ip} is outside the documentation/private ranges`);
     }
+    for (const ip of findIPv6(text)) {
+      failures.push(`${rel}: IPv6 literal ${mask(ip)} — these exports carry no legitimate IPv6`);
+    }
     for (const hit of findCredentialShapes(text)) {
       failures.push(`${rel}: ${hit.describe} [${hit.rule}] — ${hit.sample}`);
     }
     if (denylistActive) {
-      for (const digest of findDenylistHits(text, { salt, hashes })) {
+      for (const digest of findDenylistHits(text, { salt: effectiveSalt, hashes })) {
         // Never print the value; printing it here would undo the redaction.
         failures.push(
           `${rel}: a denylisted known-bad value is present (digest ${digest.slice(0, 12)}…)`
@@ -316,10 +478,30 @@ export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_
   return { ok: failures.length === 0, failures, notes, files, denylistActive };
 }
 
+/**
+ * GitHub renders `::error` / `::warning` as annotations on the PR. A bare
+ * console.log is invisible on a green check, which is how "reports SKIPPED
+ * loudly" turned out to mean "buried in a log nobody opens".
+ */
+const annotate = (level, message) =>
+  process.env.GITHUB_ACTIONS === 'true'
+    ? `::${level} file=${DENYLIST_PATH}::${message}`
+    : `retool-sanitiser-gate: ${level.toUpperCase()} ${message}`;
+
 function main(argv) {
+  const salt = process.env.RETOOL_SANITISER_SALT?.trim();
+
+  if (argv.includes('--sentinel')) {
+    if (!salt) {
+      console.error('--sentinel needs $RETOOL_SANITISER_SALT exported.');
+      return 2;
+    }
+    console.log(hashValue(salt, SENTINEL_VALUE));
+    return 0;
+  }
+
   const hashIdx = argv.indexOf('--hash');
   if (hashIdx !== -1) {
-    const salt = process.env.RETOOL_SANITISER_SALT;
     const value = argv[hashIdx + 1];
     if (!salt) {
       console.error('--hash needs $RETOOL_SANITISER_SALT exported.');
@@ -329,24 +511,30 @@ function main(argv) {
       console.error('usage: --hash "<value to denylist>"');
       return 2;
     }
-    console.log(hashValue(salt, value));
+    try {
+      console.log(hashValue(salt, value));
+    } catch (error) {
+      console.error(`retool-sanitiser-gate: ${error.message}`);
+      return 2;
+    }
     return 0;
   }
 
   const result = runGate({});
-  for (const note of result.notes) console.log(`retool-sanitiser-gate: NOTE ${note}`);
+  for (const note of result.notes) console.log(annotate('warning', note));
   console.log(`retool-sanitiser-gate: scanned ${result.files.length} file(s) under ${SCAN_DIR}`);
   if (result.ok) {
-    console.log(
-      'retool-sanitiser-gate: PASS — no known-bad value, out-of-range IP, credential shape or missing placeholder.'
-    );
+    const scope = result.denylistActive
+      ? 'no known-bad value, out-of-range IP, credential shape or missing placeholder'
+      : 'no out-of-range IP, credential shape or missing placeholder (THE DENYLIST DID NOT RUN)';
+    console.log(`retool-sanitiser-gate: PASS — ${scope}.`);
     console.log(
       'retool-sanitiser-gate: this does NOT mean the exports are free of personal data — a novel name or bare account id has no shape to match on. See the header.'
     );
     return 0;
   }
   console.error(`retool-sanitiser-gate: FAIL — ${result.failures.length} finding(s):`);
-  for (const failure of result.failures) console.error(`  - ${failure}`);
+  for (const failure of result.failures) console.error(annotate('error', failure));
   return 1;
 }
 

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+/**
+ * Mechanical sanitiser gate for `docs/moderator-app/retool-exports/**`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `raw/README.md` documents the sanitisation rules as PROSE. Prose is not a gate.
+ * PR #4476 removed three classes of personal data from these exports — staff real
+ * names, banned-user IP addresses and end-user account ids — and nothing mechanical
+ * stopped the next Retool re-download putting all three back.
+ *
+ * 🔴 WHAT THIS GATE CANNOT DO — read this before trusting a green run.
+ *
+ * It cannot detect a *novel* staff real name or a *novel* bare account id. Neither
+ * has a shape to match on, which is precisely why both walked straight through the
+ * existing shape-based pass: a person's name looks like ordinary prose and an
+ * account id looks like any other integer. Catching those requires reading what a
+ * query is FOR, which is a human job.
+ *
+ * So a PASS here means "no KNOWN bad value came back, no out-of-range IP, no
+ * credential shape, and the redaction placeholders are intact". It does NOT mean
+ * "this export contains no personal data". The `raw/README.md` checklist plus human
+ * review remains the control for that half, and this gate is not a substitute for it.
+ *
+ * FOUR CHECKS
+ * -----------
+ *  1. denylist   — known-value regression, matched against SALTED HASHES (below)
+ *  2. ipv4       — every IPv4 literal must be a documentation/private address
+ *  3. credential — the shape rules from `raw/README.md`, as code
+ *  4. placeholder— the redaction placeholders must still be present and intact
+ *
+ * Check 4 is the one that catches the headline risk — a wholesale re-download
+ * overwrites a sanitised file, so the placeholders vanish — and it needs no secret.
+ *
+ * 🔴 WHY THE DENYLIST IS HASHED, AND WHY THE SALT IS NOT COMMITTED
+ * A plaintext denylist of staff names in a public repo re-publishes exactly what it
+ * exists to protect. Hashing alone is not enough either: the search space for a
+ * person's name is tiny, so a committed salt is dictionary-crackable in seconds.
+ * The hashes are committed; the salt arrives via $RETOOL_SANITISER_SALT (a CI
+ * secret). With no salt the denylist check reports SKIPPED — loudly, and it is not
+ * counted as a pass. Checks 2/3/4 need no secret and must never skip.
+ *
+ * Populate the denylist with:  node scripts/ci/retool-sanitiser-gate.mjs --hash "<value>"
+ * (run it locally with the salt exported; paste the digest into the denylist file.
+ * Never commit the plaintext.)
+ *
+ * Exit 0 = pass, 1 = at least one check failed, 2 = the gate itself could not run.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, '../..');
+export const SCAN_DIR = 'docs/moderator-app/retool-exports';
+export const DENYLIST_PATH = 'scripts/ci/retool-sanitiser-denylist.json';
+
+/** Longest n-gram (in words) the denylist can express. "Ada Lovelace Byron" = 3. */
+export const MAX_NGRAM_WORDS = 4;
+
+// ---------------------------------------------------------------------------
+// check 2 — IPv4 range allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * Ranges an export is ALLOWED to contain. RFC5737 is what the redaction replaces
+ * real addresses with; the private/loopback/link-local ranges are never a person.
+ *
+ * Measured against the real exports at the time this landed: the only IPv4-shaped
+ * tokens present are the four RFC5737 replacements, so this rule needs no ignore
+ * list and a hit is a real finding rather than noise.
+ */
+const ALLOWED_V4 = [
+  [[192, 0, 2], 24], // RFC5737 TEST-NET-1
+  [[198, 51, 100], 24], // RFC5737 TEST-NET-2
+  [[203, 0, 113], 24], // RFC5737 TEST-NET-3
+  [[10], 8], // RFC1918
+  [[172, 16], 12], // RFC1918
+  [[192, 168], 16], // RFC1918
+  [[127], 8], // loopback
+  [[169, 254], 16], // link-local
+];
+
+const V4_RE = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;
+
+export function isAllowedIPv4(ip) {
+  const octets = ip.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+    return true; // not a valid v4 literal — not ours to judge
+  }
+  if (octets.every((o) => o === 0) || octets.every((o) => o === 255)) return true;
+  const value = octets.reduce((acc, o) => acc * 256 + o, 0);
+  return ALLOWED_V4.some(([prefixOctets, bits]) => {
+    const padded = [...prefixOctets, 0, 0, 0, 0].slice(0, 4);
+    const base = padded.reduce((acc, o) => acc * 256 + o, 0);
+    const mask = bits === 0 ? 0 : (-1 << (32 - bits)) >>> 0;
+    return (value & mask) >>> 0 === (base & mask) >>> 0;
+  });
+}
+
+export function findOutOfRangeIPv4(text) {
+  const found = [];
+  for (const match of text.matchAll(V4_RE)) {
+    const octets = [match[1], match[2], match[3], match[4]].map(Number);
+    if (octets.some((o) => o > 255)) continue;
+    if (!isAllowedIPv4(match[0])) found.push(match[0]);
+  }
+  return [...new Set(found)];
+}
+
+// ---------------------------------------------------------------------------
+// check 3 — credential shapes (the `raw/README.md` rules, as code)
+// ---------------------------------------------------------------------------
+
+/**
+ * A value already redacted is not a finding. Kept deliberately narrow: anything
+ * broader starts excusing real secrets that merely mention one of these words.
+ */
+const REDACTED_RE = /^(?:<[^>]*>|__[A-Z0-9_]+__|\{\{[^}]*\}\}|\$\{[^}]*\}|x{3,}|\*{3,}|REDACTED)$/i;
+
+export const CREDENTIAL_RULES = [
+  {
+    name: 'bearer-token',
+    re: /\bBearer\s+([A-Za-z0-9._~+/=-]{12,})/g,
+    describe: 'an Authorization: Bearer value that is not redacted',
+  },
+  {
+    name: 'jwt',
+    re: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+    describe: 'a bare JWT',
+  },
+  {
+    name: 'postgres-dsn',
+    re: /\bpostgres(?:ql)?:\/\/[^\s"'<]*:[^\s"'<@]+@[^\s"'<]+/g,
+    describe: 'a Postgres connection string carrying a password',
+  },
+  {
+    name: 'stripe-key',
+    re: /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b/g,
+    describe: 'a Stripe-shaped key',
+  },
+  {
+    // The rule the first sanitiser pass was MISSING: match on the assignment, not
+    // on the shape of the value. A `const apiKey = '…'` inside a Retool Function
+    // body looks like nothing in particular.
+    name: 'secret-assignment',
+    re: /\b(?:api[_-]?key|apikey|token|secret|password|passwd|auth)\w*\s*[:=]\s*(['"])([^'"\\]{8,})\1/gi,
+    describe: 'a secret-named variable assigned a literal value',
+    valueGroup: 2,
+  },
+];
+
+export function findCredentialShapes(text) {
+  const found = [];
+  for (const rule of CREDENTIAL_RULES) {
+    for (const match of text.matchAll(rule.re)) {
+      const value = rule.valueGroup ? match[rule.valueGroup] : match[1] ?? match[0];
+      if (value && REDACTED_RE.test(value.trim())) continue;
+      found.push({ rule: rule.name, describe: rule.describe, sample: truncate(match[0]) });
+    }
+  }
+  return found;
+}
+
+function truncate(s) {
+  const flat = s.replace(/\s+/g, ' ');
+  return flat.length > 48 ? `${flat.slice(0, 45)}…` : flat;
+}
+
+// ---------------------------------------------------------------------------
+// check 1 — hashed known-value denylist
+// ---------------------------------------------------------------------------
+
+/**
+ * Whitespace-normalised, lowercased word tokens.
+ *
+ * 🔴 The normalisation is load-bearing, not cosmetic. During PR #4476's round-3
+ * audit two occurrences survived every previous sweep because a line wrap split
+ * the token across a comment continuation, so a contiguous grep returned a
+ * confident zero. Normalise first, then match.
+ */
+export function tokenize(text) {
+  return text
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+export function hashValue(salt, value) {
+  const normalized = tokenize(value).join(' ');
+  return createHash('sha256').update(`${salt}\u0000${normalized}`).digest('hex');
+}
+
+/** Every 1..MAX_NGRAM_WORDS word window, hashed. */
+export function findDenylistHits(text, { salt, hashes }) {
+  const wanted = hashes instanceof Set ? hashes : new Set(hashes);
+  if (wanted.size === 0) return [];
+  const words = tokenize(text);
+  const hits = new Set();
+  for (let n = 1; n <= MAX_NGRAM_WORDS; n += 1) {
+    for (let i = 0; i + n <= words.length; i += 1) {
+      const gram = words.slice(i, i + n).join(' ');
+      const digest = createHash('sha256').update(`${salt}\u0000${gram}`).digest('hex');
+      if (wanted.has(digest)) hits.add(digest);
+    }
+  }
+  return [...hits];
+}
+
+// ---------------------------------------------------------------------------
+// check 4 — redaction placeholders must survive
+// ---------------------------------------------------------------------------
+
+/**
+ * A wholesale re-download overwrites a sanitised file with a raw one, so the
+ * placeholders disappear. That is the exact headline risk, and this check catches
+ * it without needing any secret.
+ */
+export const REQUIRED_PLACEHOLDERS = [
+  { file: 'raw/user-lookup-v2.json', token: '__MODERATOR_A__' },
+  { file: 'raw/bulk-ban.json', token: '203.0.113.' },
+  { file: 'bulk-ban.md', token: '203.0.113.' },
+];
+
+export function findMissingPlaceholders(readFile) {
+  const missing = [];
+  for (const { file, token } of REQUIRED_PLACEHOLDERS) {
+    const text = readFile(file);
+    if (text === null) {
+      missing.push({ file, token, reason: 'file is absent' });
+    } else if (!text.includes(token)) {
+      missing.push({ file, token, reason: 'redaction placeholder is gone' });
+    }
+  }
+  return missing;
+}
+
+// ---------------------------------------------------------------------------
+// driver
+// ---------------------------------------------------------------------------
+
+export function listFiles(root, rel) {
+  const abs = path.join(root, rel);
+  if (!existsSync(abs)) return [];
+  const out = [];
+  for (const entry of readdirSync(abs, { withFileTypes: true })) {
+    const child = path.join(rel, entry.name);
+    if (entry.isDirectory()) out.push(...listFiles(root, child));
+    else out.push(child);
+  }
+  return out.sort();
+}
+
+export function loadDenylist(root) {
+  const abs = path.join(root, DENYLIST_PATH);
+  if (!existsSync(abs)) return { hashes: [] };
+  const parsed = JSON.parse(readFileSync(abs, 'utf8'));
+  return { hashes: Array.isArray(parsed.hashes) ? parsed.hashes : [] };
+}
+
+export function runGate({ root = REPO_ROOT, salt = process.env.RETOOL_SANITISER_SALT } = {}) {
+  const files = listFiles(root, SCAN_DIR);
+  const failures = [];
+  const notes = [];
+
+  if (files.length === 0) {
+    return {
+      ok: false,
+      failures: [`${SCAN_DIR} contains no files — the gate scanned nothing`],
+      notes,
+      files,
+    };
+  }
+
+  const { hashes } = loadDenylist(root);
+  const denylistActive = Boolean(salt) && hashes.length > 0;
+  if (!salt) {
+    notes.push('denylist SKIPPED — $RETOOL_SANITISER_SALT is not set. Checks 2-4 still ran.');
+  } else if (hashes.length === 0) {
+    notes.push(`denylist SKIPPED — ${DENYLIST_PATH} lists no hashes yet. Checks 2-4 still ran.`);
+  }
+
+  for (const rel of files) {
+    const text = readFileSync(path.join(root, rel), 'utf8');
+
+    for (const ip of findOutOfRangeIPv4(text)) {
+      failures.push(`${rel}: IPv4 literal ${ip} is outside the documentation/private ranges`);
+    }
+    for (const hit of findCredentialShapes(text)) {
+      failures.push(`${rel}: ${hit.describe} [${hit.rule}] — ${hit.sample}`);
+    }
+    if (denylistActive) {
+      for (const digest of findDenylistHits(text, { salt, hashes })) {
+        // Never print the value; printing it here would undo the redaction.
+        failures.push(
+          `${rel}: a denylisted known-bad value is present (digest ${digest.slice(0, 12)}…)`
+        );
+      }
+    }
+  }
+
+  const readScoped = (rel) => {
+    const abs = path.join(root, SCAN_DIR, rel);
+    return existsSync(abs) ? readFileSync(abs, 'utf8') : null;
+  };
+  for (const miss of findMissingPlaceholders(readScoped)) {
+    failures.push(
+      `${SCAN_DIR}/${miss.file}: ${miss.reason} (expected ${miss.token}) — a raw re-download would look exactly like this`
+    );
+  }
+
+  return { ok: failures.length === 0, failures, notes, files, denylistActive };
+}
+
+function main(argv) {
+  const hashIdx = argv.indexOf('--hash');
+  if (hashIdx !== -1) {
+    const salt = process.env.RETOOL_SANITISER_SALT;
+    const value = argv[hashIdx + 1];
+    if (!salt) {
+      console.error('--hash needs $RETOOL_SANITISER_SALT exported.');
+      return 2;
+    }
+    if (!value) {
+      console.error('usage: --hash "<value to denylist>"');
+      return 2;
+    }
+    console.log(hashValue(salt, value));
+    return 0;
+  }
+
+  const result = runGate({});
+  for (const note of result.notes) console.log(`retool-sanitiser-gate: NOTE ${note}`);
+  console.log(`retool-sanitiser-gate: scanned ${result.files.length} file(s) under ${SCAN_DIR}`);
+  if (result.ok) {
+    console.log(
+      'retool-sanitiser-gate: PASS — no known-bad value, out-of-range IP, credential shape or missing placeholder.'
+    );
+    console.log(
+      'retool-sanitiser-gate: this does NOT mean the exports are free of personal data — a novel name or bare account id has no shape to match on. See the header.'
+    );
+    return 0;
+  }
+  console.error(`retool-sanitiser-gate: FAIL — ${result.failures.length} finding(s):`);
+  for (const failure of result.failures) console.error(`  - ${failure}`);
+  return 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/ci/retool-sanitiser-gate.mjs
+++ b/scripts/ci/retool-sanitiser-gate.mjs
@@ -208,8 +208,18 @@ const REDACTED_RE =
  */
 const SECRET_WORD = String.raw`API[_-]?KEY|API[_-]?Key|Api[_-]?Key|Api[_-]?key|api[_-]?Key|api[_-]?key|APIKEY|APIKey|ApiKey|Apikey|apiKey|apikey|AUTHORIZATION|Authorization|authorization|AUTHENTICATION|Authentication|authentication|SECRETKEY|SecretKey|secretKey|secretkey|TOKEN|Token|token|SECRET|Secret|secret|PASSWORD|Password|password|PASSWD|Passwd|passwd|AUTH|Auth|auth`;
 
-/** A quote that may be backslash-escaped, as it is inside JSON-embedded JS. */
-const Q = String.raw`\\?["']`;
+/**
+ * A quote at any escaping depth these exports actually use.
+ *
+ * 🔴 `\\?` — at most ONE backslash — was wrong, and wrong in a way that made the
+ * rule below completely INERT. Retool nests JSON inside JSON inside a string, so
+ * the corpus writes `\\\"key\\\"`: measured in `raw/user-lookup-v2.json`, 181 of
+ * the 191 `key` occurrences carry THREE backslashes and 10 carry one. None carry
+ * zero. The rule matched nothing at all on the file it was written for, and the
+ * spec passed anyway because its fixture used single escaping — the fake and the
+ * code encoded the same wrong assumption, so neither could see the other's error.
+ */
+const Q = String.raw`\\{0,3}["']`;
 /** A value body that cannot contain a quote, an escaped quote, or a newline. */
 const VALUE_BODY = String.raw`(?:\\[^"'\n]|[^"'\\\n]){8,4096}?`;
 
@@ -315,7 +325,7 @@ export const CREDENTIAL_RULES = [
         Q +
         String.raw`[\w$-]*?(?:` +
         SECRET_WORD +
-        String.raw`)s?[\w$-]*` +
+        String.raw`)s?(?![a-z])[\w$-]*` +
         Q +
         String.raw`\s*,\s*` +
         Q +


### PR DESCRIPTION
Follow-up to #4476.

That PR removed three classes of personal data from `docs/moderator-app/retool-exports/**` — staff real names, banned-user IP addresses and end-user account ids. The rules meant to prevent them live in `raw/README.md` as **prose**, and prose is not a gate: the next Retool re-download would have put all three back with nothing to stop it.

This adds the mechanical half, in the shape this repo already uses (`submodule-pin-guard`, the typecheck gates).

## What it checks

Over `docs/moderator-app/retool-exports/**`, on PRs that touch it:

| # | check | catches |
|---|---|---|
| 1 | **denylist** | known-bad values, matched as **salted hashes** |
| 2 | **ipv4** | any IPv4 literal outside RFC5737/RFC1918 |
| 3 | **credential** | the README's shape rules, as code |
| 4 | **placeholder** | the redaction placeholders having gone missing |

**Check 4 is the one that catches the headline risk** — a wholesale re-download overwrites a sanitised file, so the placeholders vanish — and it needs no secret at all.

## 🔴 What it deliberately cannot do

It **cannot** detect a *novel* staff real name or a *novel* bare account id. Neither has a shape to match on, which is precisely why both walked straight through the existing shape-based pass: a name looks like prose and an account id looks like any other integer.

So a green run means "no known-bad value, no out-of-range IP, no credential shape, placeholders intact". It does **not** mean "these exports contain no personal data". That is stated in the gate header, the workflow header and the README, because a check that reads as coverage while providing none is worse than no check — it stops anyone looking.

## Why the denylist is hashed, and the salt is not committed

A plaintext denylist of staff names in a public repo re-publishes exactly what it protects. Hashing alone is not enough either: a person's name is a tiny search space, so a **committed salt would be dictionary-crackable in seconds**.

Hashes are committed; the salt comes from the CI secret `RETOOL_SANITISER_SALT`. With no salt (a fork PR, or before the secret exists) check 1 reports `SKIPPED` **loudly** and is not counted as a pass — checks 2–4 still run and still block.

**The denylist ships empty.** Populating it needs the private name key and a chosen salt, neither of which belongs in this PR:

```
export RETOOL_SANITISER_SALT=…
node scripts/ci/retool-sanitiser-gate.mjs --hash '<value>'   # commit the digest only
```

## Verification

- **Positive control** — clean tree exits 0, scanning 32 files. The file count is asserted too: a gate wired to nothing also reports zero findings.
- **Negative controls, one per class, each failing with its OWN message** — out-of-range IPv4, secret assignment, denylisted value, missing placeholder. Each planted in isolation so no mutant dies to a different check's error.
- **37 tests**, run with `--project 'unit*'`.
- **Mutation sweep over all four checks** — disabling each killed 5 / 2 / 3 / 3 tests respectively, 37 green when restored. One mutant first died as a *syntax error* (`Tests no tests`, the import-failure signature) and was redone validly, since a mutant that never runs proves nothing.
- IPv4 rule measured against the real exports before it was written: the only IPv4-shaped tokens present are the four RFC5737 replacements, so it needs no ignore list and a hit is a real finding.

### Not verified

- **Check 1 is proven by fixture, not against real values** — the denylist is empty until someone populates it with the private key. Checks 2–4 are proven against the actual tree.
- The workflow itself has not run yet; this PR is its first execution.
- `raw/README.md` is left prettier-nonconforming, matching its state at base — it is a *modified* file, and this repo enforces prettier on added files only.
