### PR TITLE
docs(app-blocks): four host comments still asserted the removed reply-drop rule

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -2017,9 +2017,11 @@ export function IframeHost({
 
   // SHARED_UPDATE → apps.shared.update → SHARED_UPDATE_RESULT (author-scoped
   // in-place edit; #3146). Reply is `{ ok, error? }` (SHARED_WITHDRAW-style, NOT
-  // SHARED_APPEND's `{ key }`) — the SDK 0.24 hook rejects on `!ok || error` and
-  // its isValidSharedUpdateResult REQUIRES a boolean `ok`, so BOTH paths send one
-  // (the error path MUST carry `ok: false` or the reply is dropped → block hangs).
+  // SHARED_APPEND's `{ key }`) — the SDK hook rejects on `!ok || error !== undefined`
+  // and isValidSharedUpdateResult accepts an error reply whether or not it carries
+  // `ok` (every `{ ok, error }` validator early-accepts on a PRESENT `error`), so
+  // an error reply is never dropped. Both paths still send `ok` because it is the
+  // clearer signal, NOT because omitting it would hang.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
       'SHARED_UPDATE',
@@ -2152,8 +2154,10 @@ export function IframeHost({
 
   // SHARED_REPORT → apps.shared.report → SHARED_REPORT_RESULT. User reports a
   // posted row for mod review (server trust-gates + rate-limits + files it).
-  // Reply is SHARED_WITHDRAW-style `{ ok, error? }` — the error path MUST carry
-  // ok:false or the SDK drops it (→ hang).
+  // Reply is SHARED_WITHDRAW-style `{ ok, error? }`. The SDK accepts an error reply
+  // whether or not it carries `ok` (every `{ ok, error }` validator early-accepts on
+  // a PRESENT `error`), so we send `ok: false` because it is the clearer signal, NOT
+  // because omitting it would hang.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown; reason?: unknown } | undefined>(
       'SHARED_REPORT',

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -2922,8 +2922,11 @@ export function PageBlockHost({
   // SHARED_REPORT → apps.shared.report → SHARED_REPORT_RESULT (mutation). A user
   // reports a posted row for mod review; the server already trust-gates + rate-
   // limits + files the report (endpoint pre-exists). Reply is SHARED_WITHDRAW-
-  // style `{ ok, error? }` — the error path MUST carry ok:false or the SDK drops
-  // it (→ hang). reviewMode NACK: report is a shared:write-trust op, never granted
+  // style `{ ok, error? }`. The SDK accepts an error reply whether or not it
+  // carries `ok` (every `{ ok, error }` validator early-accepts on a PRESENT
+  // `error`), so we send `ok: false` because it is the clearer signal, NOT
+  // because omitting it would hang. reviewMode NACK: report is a
+  // shared:write-trust op, never granted
   // in run-for-real (mirrors the other shared writes).
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown; reason?: unknown } | undefined>(

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -472,8 +472,11 @@ export const INVENTORY = {
   // REQUEST-style hang class + same host placement as SHARED_APPEND — the shared
   // datastore is a per-APP surface a model-slot block can also edit, so BOTH real
   // hosts wire it. Reply is the SHARED_WITHDRAW-style `{ ok, error? }` (NOT
-  // SHARED_APPEND's `{ key }`): the SDK's isValidSharedUpdateResult REQUIRES a
-  // boolean `ok`, so the error reply MUST carry `ok: false` or it's dropped.
+  // SHARED_APPEND's `{ key }`). The SDK's isValidSharedUpdateResult accepts an
+  // error reply whether or not it carries `ok` — every `{ ok, error }` validator
+  // early-accepts on a PRESENT `error`, so an error reply is never dropped. The
+  // hosts still send `ok: false` because it is the clearer signal, NOT because
+  // omitting it would hang.
   SHARED_UPDATE: {
     request: true,
     reply: 'SHARED_UPDATE_RESULT',


### PR DESCRIPTION
Comment-only. No executable line changes — filtering the diff for non-comment `+`/`-` lines returns empty.

## What was wrong

`civitai-app-starters` #273 normalized the block-side `{ ok, error }` reply validators so every one early-accepts on a **present** `error`. An error reply is therefore never dropped, whether or not it carries `ok`.

Four host comments still told the reader the opposite — that the error path **must** carry `ok: false` "or the reply is dropped → block hangs":

| file | site |
|---|---|
| `IframeHost.tsx` | `SHARED_UPDATE`, `SHARED_REPORT` |
| `PageBlockHost.tsx` | `SHARED_REPORT` |
| `hostHandlerParity.ts` | `SHARED_UPDATE` inventory entry |

True when written; not true now. **The hosts still send `ok: false` and should keep doing so** — it is the clearer signal — but the reason is no longer that omitting it hangs the block. No code changed at any of the four sites.

## Why four and not three

An adversarial audit of #273 named three such comments and stated its own closing condition as a grep for the literal ``MUST carry `ok: false` ``. Two of the four spell it differently — ``MUST carry `ok: false` or it's dropped`` and `MUST carry ok:false` — so that grep returned clean over sites that were still wrong. A guard on **words**, walked by **rewording**.

A first pass inherited that enumeration and fixed only the named files. Sweeping the **class** instead — `REQUIRES a boolean` / `or it's dropped` / `SDK drops it` / `MUST carry`, across the whole `src/components/AppBlocks` tree — surfaced the two in `IframeHost.tsx` that nothing had looked at. The re-sweep after this change returns zero.

## Verification

The change is comment-only by construction, so behaviour is unchanged. Typecheck and the suites are left to CI — a comment edit cannot alter them, and I did not run the local 157s typecheck to claim otherwise.
