### PR TITLE
fix(model-scan): a skipped scan is not a passed scan

### DIFF
--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -126,13 +126,6 @@ export enum FLIPT_FEATURE_FLAGS {
   // context, so a segment rule here returns the flag default and looks exactly like "blurbs are
   // off". The site is recorded in ENTITY_WITHOUT_CONTEXT_LEDGER (flipt-eval-context.test.ts).
   TEXT_BLURBS = 'text-blurbs',
-  // Arms the "hold this model for moderator review" action when the scanner reports that a
-  // file's declared container format is contradicted by its bytes (skipReason
-  // "format-mismatch"). Default-off: the mismatch is RECORDED as a non-clean scan result
-  // regardless — that part needs no flag and is what actually closes the bypass — and this
-  // gates only the unpublish-and-notify side effect, so it can be flipped once the moderator
-  // queue has been watched for a day.
-  SCAN_FORMAT_MISMATCH_HOLD = 'scan-format-mismatch-hold',
   // 🔴 DO NOT ENABLE BEFORE THE SPINE-CONTROLLER SCANNER CHANGE IS DEPLOYED EVERYWHERE.
   //
   // Makes a pickle-scan SKIP count as a pass only when the scanner verified the container from

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -136,9 +136,8 @@ export enum FLIPT_FEATURE_FLAGS {
   // 🔴 DO NOT ENABLE BEFORE THE SPINE-CONTROLLER SCANNER CHANGE IS DEPLOYED EVERYWHERE.
   //
   // Makes a pickle-scan SKIP count as a pass only when the scanner verified the container from
-  // its magic bytes ("safetensors-magic" / "gguf-magic"). Turning it on before the worker fleet
-  // is fully updated would mark ordinary uploads Error, so it stays off until the fleet is on
-  // the new build. Ordering detail is in the internal ticket.
+  // its magic bytes ("safetensors-magic" / "gguf-magic"). Deployment ordering against the
+  // worker fleet matters here; the constraint and its reasoning are in the internal ticket.
   SCAN_STRICT_SKIP_VERIFICATION = 'scan-strict-skip-verification',
 }
 

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -136,10 +136,9 @@ export enum FLIPT_FEATURE_FLAGS {
   // 🔴 DO NOT ENABLE BEFORE THE SPINE-CONTROLLER SCANNER CHANGE IS DEPLOYED EVERYWHERE.
   //
   // Makes a pickle-scan SKIP count as a pass only when the scanner verified the container from
-  // its magic bytes ("safetensors-magic" / "gguf-magic"). Older workers report other skip
-  // reasons, which this treats as unverified, so turning it on while any of them are still
-  // serving would mark a large share of normal uploads Error. It stays off until the fleet is
-  // on the new build.
+  // its magic bytes ("safetensors-magic" / "gguf-magic"). Older workers report different skip
+  // reasons, so turning this on before the worker fleet is fully updated would mark a large
+  // share of normal uploads Error. It stays off until the fleet is on the new build.
   SCAN_STRICT_SKIP_VERIFICATION = 'scan-strict-skip-verification',
 }
 

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -136,9 +136,9 @@ export enum FLIPT_FEATURE_FLAGS {
   // 🔴 DO NOT ENABLE BEFORE THE SPINE-CONTROLLER SCANNER CHANGE IS DEPLOYED EVERYWHERE.
   //
   // Makes a pickle-scan SKIP count as a pass only when the scanner verified the container from
-  // its magic bytes ("safetensors-magic" / "gguf-magic"). Older workers report different skip
-  // reasons, so turning this on before the worker fleet is fully updated would mark a large
-  // share of normal uploads Error. It stays off until the fleet is on the new build.
+  // its magic bytes ("safetensors-magic" / "gguf-magic"). Turning it on before the worker fleet
+  // is fully updated would mark ordinary uploads Error, so it stays off until the fleet is on
+  // the new build. Ordering detail is in the internal ticket.
   SCAN_STRICT_SKIP_VERIFICATION = 'scan-strict-skip-verification',
 }
 

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -126,6 +126,21 @@ export enum FLIPT_FEATURE_FLAGS {
   // context, so a segment rule here returns the flag default and looks exactly like "blurbs are
   // off". The site is recorded in ENTITY_WITHOUT_CONTEXT_LEDGER (flipt-eval-context.test.ts).
   TEXT_BLURBS = 'text-blurbs',
+  // Arms the "hold this model for moderator review" action when the scanner reports that a
+  // file's declared container format is contradicted by its bytes (skipReason
+  // "format-mismatch"). Default-off: the mismatch is RECORDED as a non-clean scan result
+  // regardless — that part needs no flag and is what actually closes the bypass — and this
+  // gates only the unpublish-and-notify side effect, so it can be flipped once the moderator
+  // queue has been watched for a day.
+  SCAN_FORMAT_MISMATCH_HOLD = 'scan-format-mismatch-hold',
+  // 🔴 DO NOT ENABLE BEFORE THE SPINE-CONTROLLER SCANNER CHANGE IS DEPLOYED EVERYWHERE.
+  //
+  // Makes a pickle-scan SKIP count as a pass only when the scanner verified the container from
+  // its magic bytes ("safetensors-magic" / "gguf-magic"). Older workers report other skip
+  // reasons, which this treats as unverified, so turning it on while any of them are still
+  // serving would mark a large share of normal uploads Error. It stays off until the fleet is
+  // on the new build.
+  SCAN_STRICT_SKIP_VERIFICATION = 'scan-strict-skip-verification',
 }
 
 // Flags exempt from caching: incident kill-switches where an operator expects a

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -1537,51 +1537,7 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.pickleScanMessage).not.toContain('does not match file contents');
     });
 
-    it('holds the model for moderator review, without issuing a violation strike', async () => {
-      onlyFlags('scan-format-mismatch-hold');
-
-      await runWithSteps([pickleStep(formatMismatchOutput)]);
-
-      expect(mockUnpublishModelById).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 200,
-          isModerator: true,
-          // Hold, not a strike: reversible and queued for a human.
-          reason: 'other',
-          meta: expect.objectContaining({ needsReview: true }),
-        })
-      );
-      expect(mockCreateNotification).toHaveBeenCalledWith(
-        expect.objectContaining({ userId: 42, key: 'model-format-mismatch:200:1' })
-      );
-    });
-
-    it('does not hold when the kill switch is off', async () => {
-      onlyFlags(); // every flag off
-
-      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
-
-      expect(mockUnpublishModelById).not.toHaveBeenCalled();
-      // The recorded verdict is independent of the flag — that is what closes the bypass.
-      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
-    });
-
-    it('does not re-hold a model a moderator has already taken down', async () => {
-      onlyFlags('scan-format-mismatch-hold');
-      mockDbWrite.model.findUnique.mockResolvedValue({
-        id: 200,
-        name: 'Test Model',
-        meta: {},
-        userId: 42,
-        status: 'UnpublishedViolation',
-      });
-
-      await runWithSteps([pickleStep(formatMismatchOutput)]);
-
-      expect(mockUnpublishModelById).not.toHaveBeenCalled();
-    });
-
-    it('leaves a byte-verified safetensors skip passing, and does not hold it', async () => {
+    it('leaves a byte-verified safetensors skip passing', async () => {
       // The false-positive control: the overwhelming majority of real uploads are genuine
       // safetensors, and under the new scanner they arrive with this skipReason.
       const updateCall = await runWithSteps([
@@ -1597,7 +1553,6 @@ describe('model-file-scan.service', () => {
       ]);
 
       expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Success);
-      expect(mockUnpublishModelById).not.toHaveBeenCalled();
     });
 
     it('a legacy metadata-based skip still passes while strict verification is off', async () => {
@@ -1717,30 +1672,6 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
     });
 
-    it('blocks a Draft model from being published, via a flag that is actually enforced', async () => {
-      // 🔴 The guard against writing an INERT flag. A previous revision set meta.needsReview and
-      // called that "putting it in front of a moderator". It was neither: /moderator/models
-      // filters status [UnpublishedViolation, Published] so a Draft never appears, AND the
-      // publish handler destructures needsReview out of meta before writing it back — the flag
-      // was erased by the very action it was meant to guard. `cannotPublish` is the one the
-      // publish path actually throws on.
-      onlyFlags('scan-format-mismatch-hold');
-      mockDbWrite.model.findUnique.mockResolvedValue({
-        id: 200,
-        name: 'Test Model',
-        meta: {},
-        userId: 42,
-        status: 'Draft',
-      });
-
-      await runWithSteps([pickleStep(formatMismatchOutput)]);
-
-      expect(mockUnpublishModelById).not.toHaveBeenCalled();
-      const sql = mockDbWrite.$executeRaw.mock.calls[0][0];
-      expect(sql.join('?')).toContain('cannotPublish');
-      expect(sql.join('?')).not.toContain('needsReview');
-    });
-
     it('logs a mismatch even when the enforcement flag is OFF', async () => {
       // The rollout plan is "flip the flag, then watch". That is impossible without telemetry
       // from BEFORE the flip. Detection is ungated; only enforcement is gated.
@@ -1756,58 +1687,16 @@ describe('model-file-scan.service', () => {
       expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
     });
 
-    it('does not touch meta on an already-unpublished model', async () => {
-      // 🔴 Stamping needsReview on an UnpublishedViolation model DISABLES the creator's
-      // "Request a Review" button, so a background rescan of an already-actioned model would
-      // silently remove its owner's only route of appeal. The log is the whole action here.
-      onlyFlags('scan-format-mismatch-hold');
-      mockDbWrite.model.findUnique.mockResolvedValue({
-        id: 200,
-        name: 'Test Model',
-        meta: {},
-        userId: 42,
-        status: 'UnpublishedViolation',
-      });
+    it('records a mismatch as telemetry regardless of any flag, and touches no model', async () => {
+      // 🔴 The scope guard for this PR. Four audit rounds went into an automated hold and each
+      // found the lever attached to something unchecked — a queue excluding the flagged status,
+      // a publish handler stripping the field, and finally a flag the model's OWNER can clear.
+      // The hold moved to a follow-up; what stays is the recorded verdict plus the population
+      // signal needed to size the problem before any enforcement is switched on. If a later
+      // change reintroduces a model mutation here, this test is what should stop it.
+      onlyFlags(); // every flag off — the shipping state
 
-      await runWithSteps([pickleStep(formatMismatchOutput)]);
-
-      expect(mockUnpublishModelById).not.toHaveBeenCalled();
-      expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
-      expect(mockDbWrite.model.update).not.toHaveBeenCalled();
-      expect(mockLogToAxiom).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'scan-format-mismatch',
-          modelStatus: 'UnpublishedViolation',
-        }),
-        'webhooks'
-      );
-    });
-
-    it('holds a Scheduled model, not only a Published one', async () => {
-      // KILLING FIXTURE for the Scheduled arm of the allow-list. Every other fixture in this
-      // block uses Published/Draft/UnpublishedViolation, so dropping `|| Scheduled` previously
-      // left the suite fully green while silently ceasing to hold scheduled models.
-      onlyFlags('scan-format-mismatch-hold');
-      mockDbWrite.model.findUnique.mockResolvedValue({
-        id: 200,
-        name: 'Test Model',
-        meta: {},
-        userId: 42,
-        status: 'Scheduled',
-      });
-
-      await runWithSteps([pickleStep(formatMismatchOutput)]);
-
-      expect(mockUnpublishModelById).toHaveBeenCalled();
-    });
-
-    it('sends the scanner explanation to the operator log, not the public constant', async () => {
-      // The log is the only place a moderator can see WHICH format was declared and what was
-      // detected. An earlier revision passed the public fixed string here, leaving the queue
-      // with nothing actionable.
-      onlyFlags('scan-format-mismatch-hold');
-
-      await runWithSteps([pickleStep(formatMismatchOutput)]);
+      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
 
       expect(mockLogToAxiom).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1816,27 +1705,13 @@ describe('model-file-scan.service', () => {
         }),
         'webhooks'
       );
-    });
-
-    it('does not hold a Draft model', async () => {
-      // Scans are driven with no model-status predicate and models are Draft during the upload
-      // wizard, so this is the ordinary case. Holding one would push a never-published draft to
-      // a mod-only status and lock its own creator out of it.
-      onlyFlags('scan-format-mismatch-hold');
-      mockDbWrite.model.findUnique.mockResolvedValue({
-        id: 200,
-        name: 'Test Model',
-        meta: {},
-        userId: 42,
-        status: 'Draft',
-      });
-
-      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
-
+      // The verdict is recorded...
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+      // ...and nothing is done TO the model.
       expect(mockUnpublishModelById).not.toHaveBeenCalled();
       expect(mockCreateNotification).not.toHaveBeenCalled();
-      // The verdict is still recorded — only the side effect is withheld.
-      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+      expect(mockDbWrite.model.update).not.toHaveBeenCalled();
+      expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
     });
 
     it('does not leak the detector verdict into the public scan message', async () => {

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -1466,6 +1466,10 @@ describe('model-file-scan.service', () => {
       return { body } as unknown as Parameters<typeof processModelFileScanResult>[0];
     }
 
+    // Any skip reason NOT in the byte-verified set. The specific legacy strings are an
+    // implementation detail of the scanner build and are deliberately not named here.
+    const LEGACY_UNVERIFIED_SKIP_REASON = 'legacy-unverified-skip';
+
     const pickleStep = (output: Record<string, unknown>) => ({
       $type: 'modelPickleScan',
       output,
@@ -1597,9 +1601,9 @@ describe('model-file-scan.service', () => {
     });
 
     it('a legacy metadata-based skip still passes while strict verification is off', async () => {
-      // Deployment-ordering guard: older workers emit "safetensors-resource-info" for a large
-      // share of uploads. Until SCAN_STRICT_SKIP_VERIFICATION is flipped on those must keep
-      // passing, or shipping the web app ahead of the scanner fleet would flag many of them.
+      // Deployment-ordering guard: until SCAN_STRICT_SKIP_VERIFICATION is flipped on, a skip
+      // reason this build does not recognize must keep passing, or shipping the web app ahead
+      // of the scanner fleet would flag ordinary uploads. See the flag's note.
       onlyFlags(); // strict verification OFF
 
       const updateCall = await runWithSteps([
@@ -1607,7 +1611,7 @@ describe('model-file-scan.service', () => {
           exitCode: 0,
           status: 'SkippedSafetensors',
           skipped: true,
-          skipReason: 'safetensors-resource-info',
+          skipReason: LEGACY_UNVERIFIED_SKIP_REASON,
           globalImports: [],
           dangerousImports: [],
           dangerousImportsFound: false,
@@ -1625,7 +1629,7 @@ describe('model-file-scan.service', () => {
           exitCode: 0,
           status: 'SkippedSafetensors',
           skipped: true,
-          skipReason: 'safetensors-resource-info',
+          skipReason: LEGACY_UNVERIFIED_SKIP_REASON,
           globalImports: [],
           dangerousImports: [],
           dangerousImportsFound: false,
@@ -1713,7 +1717,73 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
     });
 
-    it('does not hold a Draft model — the common state when a file is scanned', async () => {
+    it('flags a Draft model for review instead of unpublishing it, and always logs', async () => {
+      // 🔴 The mirror-bug guard. An earlier revision returned early for any non-published
+      // model, which meant the MOST COMMON case — a mismatch found while the model is still a
+      // draft — produced no hold, no queue entry and no log at all, and the creator could then
+      // publish it with nothing re-checking. Draft must be flagged (needsReview) without being
+      // unpublished, and the detection must always be recorded.
+      onlyFlags('scan-format-mismatch-hold');
+      mockDbWrite.model.findUnique.mockResolvedValue({
+        id: 200,
+        name: 'Test Model',
+        meta: {},
+        userId: 42,
+        status: 'Draft',
+      });
+      mockDbWrite.model.update.mockResolvedValue({});
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+      expect(mockDbWrite.model.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 200 },
+          data: expect.objectContaining({ meta: expect.objectContaining({ needsReview: true }) }),
+        })
+      );
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'scan-format-mismatch', modelStatus: 'Draft' }),
+        'webhooks'
+      );
+    });
+
+    it('holds a Scheduled model, not only a Published one', async () => {
+      // KILLING FIXTURE for the Scheduled arm of the allow-list. Every other fixture in this
+      // block uses Published/Draft/UnpublishedViolation, so dropping `|| Scheduled` previously
+      // left the suite fully green while silently ceasing to hold scheduled models.
+      onlyFlags('scan-format-mismatch-hold');
+      mockDbWrite.model.findUnique.mockResolvedValue({
+        id: 200,
+        name: 'Test Model',
+        meta: {},
+        userId: 42,
+        status: 'Scheduled',
+      });
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).toHaveBeenCalled();
+    });
+
+    it('sends the scanner explanation to the operator log, not the public constant', async () => {
+      // The log is the only place a moderator can see WHICH format was declared and what was
+      // detected. An earlier revision passed the public fixed string here, leaving the queue
+      // with nothing actionable.
+      onlyFlags('scan-format-mismatch-hold');
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'scan-format-mismatch',
+          detail: expect.stringContaining('does not match file contents'),
+        }),
+        'webhooks'
+      );
+    });
+
+    it('does not hold a Draft model', async () => {
       // Scans are driven with no model-status predicate and models are Draft during the upload
       // wizard, so this is the ordinary case. Holding one would push a never-published draft to
       // a mod-only status and lock its own creator out of it.

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -110,10 +110,22 @@ vi.mock('~/server/services/minor-hash.service', () => ({
 
 // Default ON so the existing wiring tests exercise the real path; the gate's
 // off-state is asserted explicitly below.
+// Flag VALUES must be real here, not a single-key stub. The service gates three independent
+// things on Flipt (minor-hash auto-flag, strict skip verification, format-mismatch hold), and
+// with only one key in this map the others resolve to `undefined` — every gate would then be
+// asking about the same flag and a test could not turn one on while leaving another off.
 vi.mock('~/server/flipt/client', () => ({
   isFlipt: mockIsFlipt,
-  FLIPT_FEATURE_FLAGS: { MINOR_HASH_AUTO_FLAG: 'minor-hash-auto-flag' },
+  FLIPT_FEATURE_FLAGS: {
+    MINOR_HASH_AUTO_FLAG: 'minor-hash-auto-flag',
+    SCAN_STRICT_SKIP_VERIFICATION: 'scan-strict-skip-verification',
+    SCAN_FORMAT_MISMATCH_HOLD: 'scan-format-mismatch-hold',
+  },
 }));
+
+/** Turn named flags on and leave every other flag off. */
+const onlyFlags = (...on: string[]) =>
+  mockIsFlipt.mockImplementation(async (flag: string) => on.includes(flag));
 
 import {
   applyScanOutcome,
@@ -840,7 +852,13 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.virusScanMessage).toBe('EICAR signature detected');
     });
 
-    it('treats pickleScan skipped=true (safetensors) as Success with null message', async () => {
+    // skipReason was 'safetensors-extension' until 2026-08-28. That is an extension-based
+    // skip — the scanner trusting the filename — and it is the behaviour the format-conformance
+    // fix removes, so it no longer belongs in a test asserting a PASS. The case this test
+    // actually exists for (a genuine safetensors skip yields Success and a null message) is
+    // preserved by moving it to the byte-verified reason. Both legacy-skip regimes are covered
+    // explicitly in the 'scan format conformance' block below.
+    it('treats a byte-verified pickleScan skip (safetensors) as Success with null message', async () => {
       mockGetWorkflow.mockResolvedValue({
         data: {
           metadata: { fileId: 1 },
@@ -855,7 +873,7 @@ describe('model-file-scan.service', () => {
                 status: 'skippedSafetensors',
                 dangerousImportsFound: false,
                 skipped: true,
-                skipReason: 'safetensors-extension',
+                skipReason: 'safetensors-magic',
               },
             },
           ],
@@ -1436,6 +1454,214 @@ describe('model-file-scan.service', () => {
       });
 
       expect(mockCheckMinorHashOnScan).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------------------
+  // Regression cover for an upload-scanner bypass in which a file whose contents did not
+  // match its declared container format was recorded as having passed both scans.
+  //
+  // The web app's half of the defect is here: `skipped === true` was mapped straight to
+  // Success, so the scanner saying "I did not look at this file" became "this file is clean".
+  // Incident record and measurements are in the internal ticket.
+  // -------------------------------------------------------------------------------------
+  describe('scan format conformance', () => {
+    function makeReq(body: unknown) {
+      return { body } as unknown as Parameters<typeof processModelFileScanResult>[0];
+    }
+
+    const pickleStep = (output: Record<string, unknown>) => ({
+      $type: 'modelPickleScan',
+      output,
+    });
+
+    /** The pickle step exactly as the scanner emits it for a declared/actual disagreement. */
+    const formatMismatchOutput = {
+      exitCode: 2,
+      status: 'ParseError',
+      skipped: false,
+      skipReason: 'format-mismatch',
+      output:
+        "Declared format 'Safetensors' does not match file contents (detected: Unknown). " +
+        'The file does not carry a valid header for the container type it claims to be.',
+      globalImports: [],
+      dangerousImports: [],
+      dangerousImportsFound: false,
+    };
+
+    async function runWithSteps(steps: unknown[]) {
+      mockGetWorkflow.mockResolvedValue({
+        data: { metadata: { fileId: 1, modelVersionId: 100 }, steps },
+      });
+      await processModelFileScanResult(
+        makeReq({ workflowId: 'wf-fmt', type: 'workflow', status: 'succeeded' })
+      );
+      return mockDbWrite.modelFile.update.mock.calls[0][0];
+    }
+
+    beforeEach(() => {
+      mockDbWrite.modelFile.findUnique.mockResolvedValue({
+        id: 1,
+        modelVersionId: 100,
+        modelVersion: { modelId: 200, model: { userId: 42 } },
+      });
+      mockDbWrite.modelFile.update.mockResolvedValue({});
+      mockDbWrite.$transaction.mockResolvedValue([]);
+      mockDbWrite.modelFileHash.findMany.mockResolvedValue([]);
+      mockDbWrite.model.findUnique.mockResolvedValue({
+        id: 200,
+        name: 'Test Model',
+        meta: {},
+        userId: 42,
+        status: 'Published',
+      });
+      mockSetNxKeepTtlWithEx.mockResolvedValue(true);
+    });
+
+    it('a format mismatch is never recorded as a clean pickle scan', async () => {
+      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(updateCall.data.pickleScanResult).not.toBe(ScanResultCode.Success);
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('surfaces the scanner explanation as the message a moderator reads', async () => {
+      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(updateCall.data.pickleScanMessage).toContain('does not match file contents');
+    });
+
+    it('holds the model for moderator review, without issuing a violation strike', async () => {
+      onlyFlags('scan-format-mismatch-hold');
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 200,
+          isModerator: true,
+          // Hold, not a strike: reversible and queued for a human.
+          reason: 'other',
+          meta: expect.objectContaining({ needsReview: true }),
+        })
+      );
+      expect(mockCreateNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 42, key: 'model-format-mismatch:200:1' })
+      );
+    });
+
+    it('does not hold when the kill switch is off', async () => {
+      onlyFlags(); // every flag off
+
+      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+      // The recorded verdict is independent of the flag — that is what closes the bypass.
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('does not re-hold a model a moderator has already taken down', async () => {
+      onlyFlags('scan-format-mismatch-hold');
+      mockDbWrite.model.findUnique.mockResolvedValue({
+        id: 200,
+        name: 'Test Model',
+        meta: {},
+        userId: 42,
+        status: 'UnpublishedViolation',
+      });
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+    });
+
+    it('leaves a byte-verified safetensors skip passing, and does not hold it', async () => {
+      // The false-positive control. 99.2% of metadata-skipped files measured on 2026-08-28
+      // were genuine safetensors; under the new scanner they arrive with this skipReason.
+      const updateCall = await runWithSteps([
+        pickleStep({
+          exitCode: 0,
+          status: 'SkippedSafetensors',
+          skipped: true,
+          skipReason: 'safetensors-magic',
+          globalImports: [],
+          dangerousImports: [],
+          dangerousImportsFound: false,
+        }),
+      ]);
+
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Success);
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+    });
+
+    it('a legacy metadata-based skip still passes while strict verification is off', async () => {
+      // Deployment-ordering guard: older workers emit "safetensors-resource-info" for a large
+      // share of uploads. Until SCAN_STRICT_SKIP_VERIFICATION is flipped on those must keep
+      // passing, or shipping the web app ahead of the scanner fleet would flag many of them.
+      onlyFlags(); // strict verification OFF
+
+      const updateCall = await runWithSteps([
+        pickleStep({
+          exitCode: 0,
+          status: 'SkippedSafetensors',
+          skipped: true,
+          skipReason: 'safetensors-resource-info',
+          globalImports: [],
+          dangerousImports: [],
+          dangerousImportsFound: false,
+        }),
+      ]);
+
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Success);
+    });
+
+    it('a legacy metadata-based skip stops passing once strict verification is on', async () => {
+      onlyFlags('scan-strict-skip-verification');
+
+      const updateCall = await runWithSteps([
+        pickleStep({
+          exitCode: 0,
+          status: 'SkippedSafetensors',
+          skipped: true,
+          skipReason: 'safetensors-resource-info',
+          globalImports: [],
+          dangerousImports: [],
+          dangerousImportsFound: false,
+        }),
+      ]);
+
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('ClamAV limits-exceeded is Error, never Success and never Danger', async () => {
+      // A >4 GB file ClamAV refused to open. Not clean (nothing was read) and not infected
+      // (nothing was found) — and NOT Pending, which would re-queue it to be retried forever.
+      const updateCall = await runWithSteps([
+        {
+          $type: 'modelClamScan',
+          output: {
+            exitCode: 2,
+            status: 'Error',
+            infected: false,
+            limitsExceeded: true,
+            maxScanSizeMb: 4000,
+            output: 'Heuristics.Limits.Exceeded FOUND',
+          },
+        },
+      ]);
+
+      expect(updateCall.data.virusScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('a normal clean ClamAV pass is still Success', async () => {
+      const updateCall = await runWithSteps([
+        {
+          $type: 'modelClamScan',
+          output: { exitCode: 0, status: 'clean', infected: false, limitsExceeded: false },
+        },
+      ]);
+
+      expect(updateCall.data.virusScanResult).toBe(ScanResultCode.Success);
     });
   });
 });

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -1717,12 +1717,13 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
     });
 
-    it('flags a Draft model for review instead of unpublishing it, and always logs', async () => {
-      // 🔴 The mirror-bug guard. An earlier revision returned early for any non-published
-      // model, which meant the MOST COMMON case — a mismatch found while the model is still a
-      // draft — produced no hold, no queue entry and no log at all, and the creator could then
-      // publish it with nothing re-checking. Draft must be flagged (needsReview) without being
-      // unpublished, and the detection must always be recorded.
+    it('blocks a Draft model from being published, via a flag that is actually enforced', async () => {
+      // 🔴 The guard against writing an INERT flag. A previous revision set meta.needsReview and
+      // called that "putting it in front of a moderator". It was neither: /moderator/models
+      // filters status [UnpublishedViolation, Published] so a Draft never appears, AND the
+      // publish handler destructures needsReview out of meta before writing it back — the flag
+      // was erased by the very action it was meant to guard. `cannotPublish` is the one the
+      // publish path actually throws on.
       onlyFlags('scan-format-mismatch-hold');
       mockDbWrite.model.findUnique.mockResolvedValue({
         id: 200,
@@ -1731,19 +1732,53 @@ describe('model-file-scan.service', () => {
         userId: 42,
         status: 'Draft',
       });
-      mockDbWrite.model.update.mockResolvedValue({});
 
       await runWithSteps([pickleStep(formatMismatchOutput)]);
 
       expect(mockUnpublishModelById).not.toHaveBeenCalled();
-      expect(mockDbWrite.model.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 200 },
-          data: expect.objectContaining({ meta: expect.objectContaining({ needsReview: true }) }),
-        })
-      );
+      const sql = mockDbWrite.$executeRaw.mock.calls[0][0];
+      expect(sql.join('?')).toContain('cannotPublish');
+      expect(sql.join('?')).not.toContain('needsReview');
+    });
+
+    it('logs a mismatch even when the enforcement flag is OFF', async () => {
+      // The rollout plan is "flip the flag, then watch". That is impossible without telemetry
+      // from BEFORE the flip. Detection is ungated; only enforcement is gated.
+      onlyFlags(); // every flag off
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
       expect(mockLogToAxiom).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'scan-format-mismatch', modelStatus: 'Draft' }),
+        expect.objectContaining({ name: 'scan-format-mismatch' }),
+        'webhooks'
+      );
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+      expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+    });
+
+    it('does not touch meta on an already-unpublished model', async () => {
+      // 🔴 Stamping needsReview on an UnpublishedViolation model DISABLES the creator's
+      // "Request a Review" button, so a background rescan of an already-actioned model would
+      // silently remove its owner's only route of appeal. The log is the whole action here.
+      onlyFlags('scan-format-mismatch-hold');
+      mockDbWrite.model.findUnique.mockResolvedValue({
+        id: 200,
+        name: 'Test Model',
+        meta: {},
+        userId: 42,
+        status: 'UnpublishedViolation',
+      });
+
+      await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+      expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+      expect(mockDbWrite.model.update).not.toHaveBeenCalled();
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'scan-format-mismatch',
+          modelStatus: 'UnpublishedViolation',
+        }),
         'webhooks'
       );
     });
@@ -1805,9 +1840,8 @@ describe('model-file-scan.service', () => {
     });
 
     it('does not leak the detector verdict into the public scan message', async () => {
-      // pickleScanMessage is served by the public v1 model-versions API. Echoing the scanner's
-      // "detected: X" text there gives an uploader a per-attempt readout to tune a disguise
-      // against — and it is reachable while the hold flag is off and the model stays published.
+      // pickleScanMessage is served by the public v1 model-versions API, so operator-facing
+      // detail must not appear in it.
       const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
 
       expect(updateCall.data.pickleScanMessage).not.toContain('detected');

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -852,12 +852,11 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.virusScanMessage).toBe('EICAR signature detected');
     });
 
-    // skipReason was 'safetensors-extension' until 2026-08-28. That is an extension-based
-    // skip — the scanner trusting the filename — and it is the behaviour the format-conformance
-    // fix removes, so it no longer belongs in a test asserting a PASS. The case this test
-    // actually exists for (a genuine safetensors skip yields Success and a null message) is
-    // preserved by moving it to the byte-verified reason. Both legacy-skip regimes are covered
-    // explicitly in the 'scan format conformance' block below.
+    // This previously used an extension-derived skipReason, which the format-conformance change
+    // no longer treats as verified, so it no longer belongs in a test asserting a PASS. The case
+    // this test exists for — a genuine skip yields Success with a null message — is preserved by
+    // moving it to the byte-verified reason. Both regimes are covered in the
+    // 'scan format conformance' block below.
     it('treats a byte-verified pickleScan skip (safetensors) as Success with null message', async () => {
       mockGetWorkflow.mockResolvedValue({
         data: {
@@ -1458,12 +1457,9 @@ describe('model-file-scan.service', () => {
   });
 
   // -------------------------------------------------------------------------------------
-  // Regression cover for an upload-scanner bypass in which a file whose contents did not
-  // match its declared container format was recorded as having passed both scans.
-  //
-  // The web app's half of the defect is here: `skipped === true` was mapped straight to
-  // Success, so the scanner saying "I did not look at this file" became "this file is clean".
-  // Incident record and measurements are in the internal ticket.
+  // Regression cover: a file whose contents do not match its declared container format must
+  // never be recorded as having passed the scans. Incident record, mechanism and measurements
+  // are in the internal ticket — deliberately not restated here.
   // -------------------------------------------------------------------------------------
   describe('scan format conformance', () => {
     function makeReq(body: unknown) {
@@ -1525,10 +1521,16 @@ describe('model-file-scan.service', () => {
       expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
     });
 
-    it('surfaces the scanner explanation as the message a moderator reads', async () => {
+    it('keeps the scanner explanation in rawScanResult, not in the public message', async () => {
+      // The detail must survive for forensics and for the moderator-facing log, but NOT in
+      // pickleScanMessage, which the public v1 API serves. Both halves asserted together so a
+      // future change cannot quietly move it from one to the other.
       const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
 
-      expect(updateCall.data.pickleScanMessage).toContain('does not match file contents');
+      expect(JSON.stringify(updateCall.data.rawScanResult)).toContain(
+        'does not match file contents'
+      );
+      expect(updateCall.data.pickleScanMessage).not.toContain('does not match file contents');
     });
 
     it('holds the model for moderator review, without issuing a violation strike', async () => {
@@ -1576,8 +1578,8 @@ describe('model-file-scan.service', () => {
     });
 
     it('leaves a byte-verified safetensors skip passing, and does not hold it', async () => {
-      // The false-positive control. 99.2% of metadata-skipped files measured on 2026-08-28
-      // were genuine safetensors; under the new scanner they arrive with this skipReason.
+      // The false-positive control: the overwhelming majority of real uploads are genuine
+      // safetensors, and under the new scanner they arrive with this skipReason.
       const updateCall = await runWithSteps([
         pickleStep({
           exitCode: 0,
@@ -1651,6 +1653,98 @@ describe('model-file-scan.service', () => {
       ]);
 
       expect(updateCall.data.virusScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('ClamAV limits-exceeded is Error even when the status is unrecognized', async () => {
+      // KILLING FIXTURE for the limitsExceeded guard. The other limits test also sets
+      // status:'Error', which independently reaches Error via status.includes('error') — so
+      // deleting the guard leaves that test green and the guard untested. This payload has NO
+      // status, which is exactly the case the guard exists for: an unrecognized status becomes
+      // null at the orchestrator, the code falls through to exitCodeToScanResult, and a limits
+      // bail-out exits 1 — which would score as Danger, a false virus detection.
+      const updateCall = await runWithSteps([
+        {
+          $type: 'modelClamScan',
+          output: { exitCode: 1, infected: false, limitsExceeded: true },
+        },
+      ]);
+
+      expect(updateCall.data.virusScanResult).toBe(ScanResultCode.Error);
+      expect(updateCall.data.virusScanResult).not.toBe(ScanResultCode.Danger);
+    });
+
+    it('a byte-verified GGUF skip passes under strict verification', async () => {
+      // KILLING FIXTURE for the gguf-magic member of BYTE_VERIFIED_SKIP_REASONS. Without this,
+      // narrowing the set to just safetensors-magic marks every legitimate GGUF upload Error
+      // and no test notices.
+      onlyFlags('scan-strict-skip-verification');
+
+      const updateCall = await runWithSteps([
+        pickleStep({
+          exitCode: 0,
+          status: 'SkippedGguf',
+          skipped: true,
+          skipReason: 'gguf-magic',
+          globalImports: [],
+          dangerousImports: [],
+          dangerousImportsFound: false,
+        }),
+      ]);
+
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Success);
+    });
+
+    it('a skipped-* STATUS with no skipped flag is not a pass under strict verification', async () => {
+      // KILLING FIXTURE for the status.startsWith('skipped') branch. Reachable on in-flight
+      // legacy workflows where `skipped` is unset but the status string still says skipped —
+      // the same "we did not look" answer, and previously always Success.
+      onlyFlags('scan-strict-skip-verification');
+
+      const updateCall = await runWithSteps([
+        pickleStep({
+          exitCode: 0,
+          status: 'skippedSafetensors',
+          globalImports: [],
+          dangerousImports: [],
+          dangerousImportsFound: false,
+        }),
+      ]);
+
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('does not hold a Draft model — the common state when a file is scanned', async () => {
+      // Scans are driven with no model-status predicate and models are Draft during the upload
+      // wizard, so this is the ordinary case. Holding one would push a never-published draft to
+      // a mod-only status and lock its own creator out of it.
+      onlyFlags('scan-format-mismatch-hold');
+      mockDbWrite.model.findUnique.mockResolvedValue({
+        id: 200,
+        name: 'Test Model',
+        meta: {},
+        userId: 42,
+        status: 'Draft',
+      });
+
+      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(mockUnpublishModelById).not.toHaveBeenCalled();
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+      // The verdict is still recorded — only the side effect is withheld.
+      expect(updateCall.data.pickleScanResult).toBe(ScanResultCode.Error);
+    });
+
+    it('does not leak the detector verdict into the public scan message', async () => {
+      // pickleScanMessage is served by the public v1 model-versions API. Echoing the scanner's
+      // "detected: X" text there gives an uploader a per-attempt readout to tune a disguise
+      // against — and it is reachable while the hold flag is off and the model stays published.
+      const updateCall = await runWithSteps([pickleStep(formatMismatchOutput)]);
+
+      expect(updateCall.data.pickleScanMessage).not.toContain('detected');
+      expect(updateCall.data.pickleScanMessage).not.toContain('Safetensors');
+      expect(updateCall.data.pickleScanMessage).toBe(
+        'File format could not be verified. This file is under review.'
+      );
     });
 
     it('a normal clean ClamAV pass is still Success', async () => {

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -61,6 +61,15 @@ export type ScanOutcome = {
    * disguise, so it is the signal the moderator-hold path keys on.
    */
   formatMismatch?: boolean;
+  /**
+   * The scanner's own explanation of the mismatch, for the operator log ONLY.
+   *
+   * Kept separate from `pickleScan.message` on purpose: that field is served by the public v1
+   * API and is therefore a fixed string. An earlier revision passed the public constant to the
+   * log as well, which left a moderator working the queue with no idea which format was
+   * declared or what was actually detected.
+   */
+  formatMismatchDetail?: string | null;
   /** Full upstream payload (orchestrator step outputs or legacy ScanResult) for forensics. */
   rawScanResult?: unknown;
 };
@@ -336,7 +345,7 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
     await holdModelForFormatMismatch({
       modelId: file.modelVersion.modelId,
       fileId,
-      detail: outcome.pickleScan?.message ?? null,
+      detail: outcome.formatMismatchDetail ?? null,
     }).catch((err) =>
       logToAxiom(
         {
@@ -407,24 +416,48 @@ async function holdModelForFormatMismatch({
     where: { id: modelId },
     select: { id: true, name: true, meta: true, userId: true, status: true },
   });
-  // 🔴 ALLOW-LIST, NOT A DENY-LIST. Only a model that is actually reachable by users can be
-  // "held" in any meaningful sense, and holding anything else does real harm.
+  if (!model) return;
+
+  // 🔴 LOGGED BEFORE ANY STATUS BRANCH, DELIBERATELY. An earlier revision returned above this
+  // line for every non-published model, which meant the single most common case — a mismatch
+  // found while the model is still a Draft — produced NO hold, NO queue entry and NO log. It
+  // was invisible. Whatever we decide to do about the model, the detection itself is always
+  // recorded.
+  logToAxiom(
+    {
+      type: 'warning',
+      name: 'scan-format-mismatch',
+      message: `File ${fileId} on model ${modelId} does not match its declared format`,
+      modelId,
+      fileId,
+      modelStatus: model.status,
+      detail,
+    },
+    'webhooks'
+  ).catch();
+
+  // 🔴 UNPUBLISHING IS ONLY MEANINGFUL FOR SOMETHING THAT IS PUBLISHED, and doing it to
+  // anything else causes real harm — a never-published Draft would be pushed to
+  // UnpublishedViolation, which its own creator cannot undo (mod-only republish).
   //
-  // A deny-list of {Unpublished, UnpublishedViolation, Deleted} looks equivalent and is not:
-  // it lets `Draft` through, and Draft is the COMMON case here, not an edge case. Files are
-  // scanned by scan-files.ts, whose WHERE clause is virusScanResult/exists/scanRequestedAt with
-  // NO model-status predicate, and models are created Draft with files attached during the
-  // upload wizard — so a brand-new upload is normally scanned while still a draft, minutes
-  // before it is ever published. Holding one would push a never-published draft to
-  // UnpublishedViolation, lock its own creator out of it (mod-only republish), and fire the
-  // generic "your version was unpublished" notification — which selects on meta alone, with no
-  // status predicate — about a version that was never published, on top of the message below.
+  // But "don't unpublish a Draft" must not become "ignore a Draft". Files are scanned by
+  // scan-files.ts, which has NO model-status predicate, and models are created Draft with
+  // files attached during the upload wizard — so the FIRST upload of a disguised file is
+  // normally scanned while still a draft. Nothing re-scans it later, and the publish path does
+  // not consult scan results, so simply returning here would let it be published afterwards
+  // with no further checks. That is the mirror of the bug this branch was added to fix.
   //
-  // Published and Scheduled are the only states where a hold both means something and is safe.
-  if (
-    !model ||
-    (model.status !== ModelStatus.Published && model.status !== ModelStatus.Scheduled)
-  ) {
+  // (For the record: the per-VERSION unpublish notification is already status-scoped in
+  // model.service.ts and would not fire for a draft's versions. The harm that motivates this
+  // branch is the model-level UnpublishedViolation lockout, not that notification.)
+  //
+  // So a non-published model is FLAGGED but not unpublished: meta.needsReview is what the
+  // moderator queue keys on, and setting it costs the creator nothing.
+  if (model.status !== ModelStatus.Published && model.status !== ModelStatus.Scheduled) {
+    await dbWrite.model.update({
+      where: { id: modelId },
+      data: { meta: { ...(model.meta as ModelMeta), needsReview: true } as Prisma.InputJsonValue },
+    });
     return;
   }
 
@@ -433,7 +466,8 @@ async function holdModelForFormatMismatch({
     userId: -1,
     reason: 'other',
     // Same reasoning as FORMAT_MISMATCH_PUBLIC_MESSAGE — this reaches the uploader, who is the
-    // one party we must not hand a detector readout to. `detail` is logged, not echoed.
+    // one party we must not hand a detector readout to. The scanner's text goes to the log
+    // above via `detail`; it is never echoed to the creator or to the public API.
     customMessage:
       'Model held for review: an uploaded file could not be verified as the file type it declares.',
     meta: { ...(model.meta as ModelMeta), needsReview: true },
@@ -665,7 +699,8 @@ export const FORMAT_MISMATCH_SKIP_REASON = 'format-mismatch';
  * What a mismatch shows publicly. Deliberately says nothing about what the scanner detected:
  * this string is served by the public v1 model-versions API, so anything specific here is an
  * oracle an uploader can iterate against. The scanner's full explanation stays in
- * `rawScanResult` and in the moderator-facing log.
+ * `rawScanResult` and reaches the operator log via ScanOutcome.formatMismatchDetail, which is
+ * deliberately a different field from this one.
  */
 export const FORMAT_MISMATCH_PUBLIC_MESSAGE =
   'File format could not be verified. This file is under review.';
@@ -832,6 +867,8 @@ export async function processModelFileScanResult(req: NextApiRequest) {
       dangerousImports: pickleOut.dangerousImports ?? undefined,
     };
     outcome.formatMismatch = isFormatMismatch(pickleOut);
+    // The scanner's text, never the public constant — see formatMismatchDetail.
+    outcome.formatMismatchDetail = isFormatMismatch(pickleOut) ? pickleOut.output ?? null : null;
   }
 
   if (hashStep?.output) {

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -26,7 +26,7 @@ import { constants } from '~/server/common/constants';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type { ModelMeta } from '~/server/schema/model.schema';
 import type { ModelType } from '~/shared/utils/prisma/enums';
-import { ModelHashType, ModelStatus, ScanResultCode } from '~/shared/utils/prisma/enums';
+import { ModelHashType, ScanResultCode } from '~/shared/utils/prisma/enums';
 import { primaryModelFileTypes } from '~/utils/file-display-helpers';
 import type { ModelFileType } from '~/server/common/constants';
 import { addLinkedComponent } from '~/server/services/model-version.service';
@@ -58,16 +58,16 @@ export type ScanOutcome = {
   /**
    * The file's declared container format is contradicted by its bytes — it is not the kind of
    * file it claims to be. Distinct from a generic scan Error: this one names a deliberate
-   * disguise, so it is the signal the moderator-hold path keys on.
+   * disguise rather than a transient scanner fault.
    */
   formatMismatch?: boolean;
   /**
    * The scanner's own explanation of the mismatch, for the operator log ONLY.
    *
    * Kept separate from `pickleScan.message` on purpose: that field is served by the public v1
-   * API and is therefore a fixed string. An earlier revision passed the public constant to the
-   * log as well, which left a moderator working the queue with no idea which format was
-   * declared or what was actually detected.
+   * API and is therefore a fixed string. Without a distinct field the operator log would carry
+   * the same constant and tell a responder nothing about which format was declared or what was
+   * actually detected.
    */
   formatMismatchDetail?: string | null;
   /** Full upstream payload (orchestrator step outputs or legacy ScanResult) for forensics. */
@@ -337,28 +337,32 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
     });
   }
 
-  // A file that is not the kind of file it claims to be. The scan result above already records
-  // this as non-clean, so the model cannot show a Verified shield either way; this adds the
-  // human-in-the-loop step. Gated, and deliberately AFTER the result is persisted, so a failure
-  // here can never swallow the recorded verdict.
-  if (outcome.formatMismatch && file.modelVersion?.modelId) {
-    await holdModelForFormatMismatch({
-      modelId: file.modelVersion.modelId,
-      fileId,
-      detail: outcome.formatMismatchDetail ?? null,
-    }).catch((err) =>
-      logToAxiom(
-        {
-          type: 'error',
-          name: 'apply-scan-outcome',
-          message: 'format-mismatch hold failed',
-          fileId,
-          modelId: file.modelVersion?.modelId,
-          error: err instanceof Error ? err.message : String(err),
-        },
-        'webhooks'
-      ).catch()
-    );
+  // A file that is not the kind of file it claims to be. The scan RESULT above already records
+  // this as non-clean, which is what closes the gap — the model cannot show a Verified shield.
+  //
+  // 🔴 THIS DELIBERATELY TAKES NO ACTION ON THE MODEL, only telemetry. Four audit rounds went
+  // into an automated hold here and each one found the lever was attached to something not
+  // checked: a queue that excludes the status being flagged, a publish handler that strips the
+  // field, and finally a flag the model's own OWNER can clear with one `model.upsert` (it is
+  // absent from MODERATION_OWNED_META_KEYS). An automated hold needs moderator surfaces that do
+  // not exist yet — a queue that lists flagged drafts, a clearing path, and copy that states the
+  // real cause — so it is being designed separately rather than patched in here. Recording the
+  // verdict does not depend on any of that.
+  //
+  // Ungated on purpose: this is the population signal needed to size the problem and validate
+  // the detector BEFORE any enforcement is switched on.
+  if (outcome.formatMismatch) {
+    logToAxiom(
+      {
+        type: 'warning',
+        name: 'scan-format-mismatch',
+        message: `File ${fileId} does not match its declared format`,
+        fileId,
+        modelId: file.modelVersion?.modelId,
+        detail: outcome.formatMismatchDetail ?? null,
+      },
+      'webhooks'
+    ).catch();
   }
 
   // Search index + cache invalidation. modelId comes from the initial lookup so
@@ -374,160 +378,6 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
     // D5: refresh (proactive re-warm) matches legacy behavior.
     await dataForModelsCache.refresh(modelId);
   }
-}
-
-/**
- * Puts a model whose file contradicts its declared format in front of a moderator.
- *
- * Uses the existing Hold semantics (`unpublishModelById` + `meta.needsReview`) — the same path
- * `ModerationRuleAction.Hold` takes, so the uploader gets the "under review" banner.
- *
- * 🔴 BE PRECISE ABOUT WHAT THIS DOES. `unpublishModelById` sets `UnpublishedViolation` whenever
- * a `reason` is passed — ANY truthy reason, `'other'` included; see the
- * `status: reason ? UnpublishedViolation : …` ternary in model.service.ts — and it applies to
- * the model AND every one of its versions. `UnpublishedViolation` is in
- * `constants.modPublishOnlyStatuses`, so the CREATOR CANNOT REPUBLISH; only a moderator can.
- * An earlier revision of this comment claimed this was "not an UnpublishedViolation" and
- * "non-punitive". That was simply false.
- *
- * It is worth naming, because the obvious correction is worse than the defect: dropping
- * `reason` to obtain a plain `Unpublished` would remove the model from the moderator queue at
- * /moderator/models, which selects on `[UnpublishedViolation, Published]` — it would be held
- * where no reviewer can find it. The mod-only status and the review queue are one mechanism.
- *
- * The model does come down while it waits. That is deliberate: leaving it published pending
- * review is precisely the window in which a disguised file is still reachable by users.
- *
- * Expected volume is small — the magic-byte check distinguishes legitimate containers from
- * genuine mismatches, so only the latter reach this path. Sizing is in the internal ticket.
- */
-async function holdModelForFormatMismatch({
-  modelId,
-  fileId,
-  detail,
-}: {
-  modelId: number;
-  fileId: number;
-  detail: string | null;
-}) {
-  const model = await dbWrite.model.findUnique({
-    where: { id: modelId },
-    select: { id: true, name: true, meta: true, userId: true, status: true },
-  });
-
-  // 🔴 LOGGED FIRST — ABOVE THE FEATURE FLAG AND ABOVE EVERY STATUS BRANCH.
-  //
-  // Two earlier revisions buried this. One returned above it for any non-published model, so
-  // the most common case produced no record at all; the next left it below the flag gate, so
-  // in the shipping state (flag off) a mismatch emitted nothing anywhere. The rollout plan is
-  // "flip the flag, then watch" — which is impossible without telemetry from BEFORE the flip,
-  // both to size the population and to see whether the detector is right. Detection and
-  // enforcement are separate concerns; only enforcement is gated.
-  logToAxiom(
-    {
-      type: 'warning',
-      name: 'scan-format-mismatch',
-      message: `File ${fileId} on model ${modelId} does not match its declared format`,
-      modelId,
-      fileId,
-      modelStatus: model?.status ?? 'unknown',
-      detail,
-    },
-    'webhooks'
-  ).catch();
-
-  if (!model) return;
-  if (!(await isFlipt(FLIPT_FEATURE_FLAGS.SCAN_FORMAT_MISMATCH_HOLD))) return;
-
-  // 🔴 UNPUBLISHING IS ONLY MEANINGFUL FOR SOMETHING THAT IS PUBLISHED, and doing it to
-  // anything else causes real harm — a never-published Draft would be pushed to
-  // UnpublishedViolation, which its own creator cannot undo (mod-only republish).
-  //
-  // But "don't unpublish a Draft" must not become "ignore a Draft". Files are scanned by
-  // scan-files.ts, which has NO model-status predicate, and models are created Draft with
-  // files attached during the upload wizard — so the FIRST upload of a disguised file is
-  // normally scanned while still a draft, and nothing re-scans it later.
-  //
-  // 🔴 THE FLAG WRITTEN HERE MUST BE ONE SOMETHING ACTUALLY BRANCHES ON. A previous revision
-  // wrote `meta.needsReview` and described it as putting the model in front of a moderator. It
-  // did neither: /moderator/models filters `status: [UnpublishedViolation, Published]`, which
-  // excludes Draft before `needsReview` is ever evaluated, AND publishModelHandler destructures
-  // `needsReview` out of meta before writing it back — so the flag was erased by the very
-  // action it was supposed to guard against. A field that exists is not a guard; only a branch
-  // on it is.
-  //
-  // `cannotPublish` is that branch, and it already exists: publishModelById throws
-  // ("This model cannot be published due to moderation restrictions") when it is set, and the
-  // publish handler's destructure preserves it. So a disguised file uploaded as a draft cannot
-  // be published until a moderator clears the flag — which is the human-in-the-loop this path
-  // is for, achieved through an enforced mechanism rather than an advisory one.
-  if (model.status === ModelStatus.Draft || model.status === ModelStatus.Training) {
-    // Raw jsonb merge rather than a read-modify-write of the whole column: this fires per
-    // scanned file and would otherwise silently drop any concurrent meta write (a moderator
-    // setting cannotPromote, a text-moderation stamp) landing between the read above and here.
-    await dbWrite.$executeRaw`
-      UPDATE "Model"
-      SET meta = COALESCE(meta, '{}'::jsonb) || '{"cannotPublish":true}'::jsonb
-      WHERE id = ${modelId}
-    `;
-    return;
-  }
-
-  // Unpublished / UnpublishedViolation / Deleted: already down, and a moderator owns them.
-  // 🔴 Deliberately NO meta write here. Stamping `needsReview` on an UnpublishedViolation model
-  // DISABLES the creator's "Request a Review" button (ModelVersionDetails gates it on
-  // `model.meta?.needsReview`), so a background rescan of an already-actioned model would
-  // silently remove its owner's only route of appeal. The log above is the whole action.
-  if (model.status !== ModelStatus.Published && model.status !== ModelStatus.Scheduled) {
-    return;
-  }
-
-  await unpublishModelById({
-    id: modelId,
-    userId: -1,
-    reason: 'other',
-    // Same reasoning as FORMAT_MISMATCH_PUBLIC_MESSAGE — this reaches the uploader, who is the
-    // one party we must not hand a detector readout to. The scanner's text goes to the log
-    // above via `detail`; it is never echoed to the creator or to the public API.
-    customMessage:
-      'Model held for review: an uploaded file could not be verified as the file type it declares.',
-    meta: { ...(model.meta as ModelMeta), needsReview: true },
-    isModerator: true,
-  });
-
-  logToAxiom(
-    {
-      type: 'warning',
-      name: 'scan-format-mismatch-hold',
-      message: `Model ${modelId} held: file ${fileId} does not match its declared format`,
-      modelId,
-      fileId,
-      detail,
-    },
-    'webhooks'
-  ).catch();
-
-  await createNotification({
-    category: NotificationCategory.System,
-    key: `model-format-mismatch:${modelId}:${fileId}`,
-    type: 'system-message',
-    userId: model.userId,
-    details: {
-      message: `Your model "${model.name}" has been put on hold because an uploaded file does not appear to be the file type it claims to be. A moderator will review it shortly.`,
-      url: `/models/${modelId}`,
-    },
-  }).catch((error) =>
-    logToAxiom(
-      {
-        type: 'error',
-        name: 'scan-format-mismatch-hold',
-        message: 'Could not notify uploader of format-mismatch hold',
-        modelId,
-        error: error.message,
-      },
-      'webhooks'
-    ).catch()
-  );
 }
 
 async function notifyHashFix(modelVersionId: number, fileId: number) {
@@ -718,9 +568,9 @@ export const FORMAT_MISMATCH_SKIP_REASON = 'format-mismatch';
 
 /**
  * What a mismatch shows publicly. Deliberately says nothing about what the scanner detected —
- * this string is served by the public v1 model-versions API. The scanner's full explanation
- * stays in `rawScanResult` and reaches the operator log via ScanOutcome.formatMismatchDetail,
- * which is deliberately a different field from this one.
+ * this string is served by the public v1 model-versions API. The scanner's explanation stays in
+ * `rawScanResult` and reaches the operator log via ScanOutcome.formatMismatchDetail, which is
+ * deliberately a different field from this one.
  */
 export const FORMAT_MISMATCH_PUBLIC_MESSAGE =
   'File format could not be verified. This file is under review.';

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -410,19 +410,19 @@ async function holdModelForFormatMismatch({
   fileId: number;
   detail: string | null;
 }) {
-  if (!(await isFlipt(FLIPT_FEATURE_FLAGS.SCAN_FORMAT_MISMATCH_HOLD))) return;
-
   const model = await dbWrite.model.findUnique({
     where: { id: modelId },
     select: { id: true, name: true, meta: true, userId: true, status: true },
   });
-  if (!model) return;
 
-  // 🔴 LOGGED BEFORE ANY STATUS BRANCH, DELIBERATELY. An earlier revision returned above this
-  // line for every non-published model, which meant the single most common case — a mismatch
-  // found while the model is still a Draft — produced NO hold, NO queue entry and NO log. It
-  // was invisible. Whatever we decide to do about the model, the detection itself is always
-  // recorded.
+  // 🔴 LOGGED FIRST — ABOVE THE FEATURE FLAG AND ABOVE EVERY STATUS BRANCH.
+  //
+  // Two earlier revisions buried this. One returned above it for any non-published model, so
+  // the most common case produced no record at all; the next left it below the flag gate, so
+  // in the shipping state (flag off) a mismatch emitted nothing anywhere. The rollout plan is
+  // "flip the flag, then watch" — which is impossible without telemetry from BEFORE the flip,
+  // both to size the population and to see whether the detector is right. Detection and
+  // enforcement are separate concerns; only enforcement is gated.
   logToAxiom(
     {
       type: 'warning',
@@ -430,11 +430,14 @@ async function holdModelForFormatMismatch({
       message: `File ${fileId} on model ${modelId} does not match its declared format`,
       modelId,
       fileId,
-      modelStatus: model.status,
+      modelStatus: model?.status ?? 'unknown',
       detail,
     },
     'webhooks'
   ).catch();
+
+  if (!model) return;
+  if (!(await isFlipt(FLIPT_FEATURE_FLAGS.SCAN_FORMAT_MISMATCH_HOLD))) return;
 
   // 🔴 UNPUBLISHING IS ONLY MEANINGFUL FOR SOMETHING THAT IS PUBLISHED, and doing it to
   // anything else causes real harm — a never-published Draft would be pushed to
@@ -443,21 +446,39 @@ async function holdModelForFormatMismatch({
   // But "don't unpublish a Draft" must not become "ignore a Draft". Files are scanned by
   // scan-files.ts, which has NO model-status predicate, and models are created Draft with
   // files attached during the upload wizard — so the FIRST upload of a disguised file is
-  // normally scanned while still a draft. Nothing re-scans it later, and the publish path does
-  // not consult scan results, so simply returning here would let it be published afterwards
-  // with no further checks. That is the mirror of the bug this branch was added to fix.
+  // normally scanned while still a draft, and nothing re-scans it later.
   //
-  // (For the record: the per-VERSION unpublish notification is already status-scoped in
-  // model.service.ts and would not fire for a draft's versions. The harm that motivates this
-  // branch is the model-level UnpublishedViolation lockout, not that notification.)
+  // 🔴 THE FLAG WRITTEN HERE MUST BE ONE SOMETHING ACTUALLY BRANCHES ON. A previous revision
+  // wrote `meta.needsReview` and described it as putting the model in front of a moderator. It
+  // did neither: /moderator/models filters `status: [UnpublishedViolation, Published]`, which
+  // excludes Draft before `needsReview` is ever evaluated, AND publishModelHandler destructures
+  // `needsReview` out of meta before writing it back — so the flag was erased by the very
+  // action it was supposed to guard against. A field that exists is not a guard; only a branch
+  // on it is.
   //
-  // So a non-published model is FLAGGED but not unpublished: meta.needsReview is what the
-  // moderator queue keys on, and setting it costs the creator nothing.
+  // `cannotPublish` is that branch, and it already exists: publishModelById throws
+  // ("This model cannot be published due to moderation restrictions") when it is set, and the
+  // publish handler's destructure preserves it. So a disguised file uploaded as a draft cannot
+  // be published until a moderator clears the flag — which is the human-in-the-loop this path
+  // is for, achieved through an enforced mechanism rather than an advisory one.
+  if (model.status === ModelStatus.Draft || model.status === ModelStatus.Training) {
+    // Raw jsonb merge rather than a read-modify-write of the whole column: this fires per
+    // scanned file and would otherwise silently drop any concurrent meta write (a moderator
+    // setting cannotPromote, a text-moderation stamp) landing between the read above and here.
+    await dbWrite.$executeRaw`
+      UPDATE "Model"
+      SET meta = COALESCE(meta, '{}'::jsonb) || '{"cannotPublish":true}'::jsonb
+      WHERE id = ${modelId}
+    `;
+    return;
+  }
+
+  // Unpublished / UnpublishedViolation / Deleted: already down, and a moderator owns them.
+  // 🔴 Deliberately NO meta write here. Stamping `needsReview` on an UnpublishedViolation model
+  // DISABLES the creator's "Request a Review" button (ModelVersionDetails gates it on
+  // `model.meta?.needsReview`), so a background rescan of an already-actioned model would
+  // silently remove its owner's only route of appeal. The log above is the whole action.
   if (model.status !== ModelStatus.Published && model.status !== ModelStatus.Scheduled) {
-    await dbWrite.model.update({
-      where: { id: modelId },
-      data: { meta: { ...(model.meta as ModelMeta), needsReview: true } as Prisma.InputJsonValue },
-    });
     return;
   }
 
@@ -696,11 +717,10 @@ function deriveClamScanResult(output: NonNullable<ModelClamScanStep['output']>):
 export const FORMAT_MISMATCH_SKIP_REASON = 'format-mismatch';
 
 /**
- * What a mismatch shows publicly. Deliberately says nothing about what the scanner detected:
- * this string is served by the public v1 model-versions API, so anything specific here is an
- * oracle an uploader can iterate against. The scanner's full explanation stays in
- * `rawScanResult` and reaches the operator log via ScanOutcome.formatMismatchDetail, which is
- * deliberately a different field from this one.
+ * What a mismatch shows publicly. Deliberately says nothing about what the scanner detected —
+ * this string is served by the public v1 model-versions API. The scanner's full explanation
+ * stays in `rawScanResult` and reaches the operator log via ScanOutcome.formatMismatchDetail,
+ * which is deliberately a different field from this one.
  */
 export const FORMAT_MISMATCH_PUBLIC_MESSAGE =
   'File format could not be verified. This file is under review.';
@@ -858,11 +878,9 @@ export async function processModelFileScanResult(req: NextApiRequest) {
       result: hasDanger ? ScanResultCode.Danger : baseResult,
       // A format mismatch carries no import list, so examinePickleImports produces nothing to
       // show — but the scanner's own explanation must NOT go here. `pickleScanMessage` is
-      // returned by the PUBLIC v1 model-versions API, and the scanner's text names what it
-      // detected ("detected: Unknown"), which hands an uploader a per-attempt readout of the
-      // detector's verdict — a free oracle for tuning a disguise, and one that is reachable
-      // while SCAN_FORMAT_MISMATCH_HOLD is off and the model therefore stays published.
-      // A fixed string here; the detail is already preserved in rawScanResult for forensics.
+      // returned by the PUBLIC v1 model-versions API, and operator-facing detail does not
+      // belong on a public surface. A fixed string here; the detail is preserved in
+      // rawScanResult for forensics and reaches the log via formatMismatchDetail.
       message: isFormatMismatch(pickleOut) ? FORMAT_MISMATCH_PUBLIC_MESSAGE : pickleScanMessage,
       dangerousImports: pickleOut.dangerousImports ?? undefined,
     };

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -26,7 +26,7 @@ import { constants } from '~/server/common/constants';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type { ModelMeta } from '~/server/schema/model.schema';
 import type { ModelType } from '~/shared/utils/prisma/enums';
-import { ModelHashType, ScanResultCode } from '~/shared/utils/prisma/enums';
+import { ModelHashType, ModelStatus, ScanResultCode } from '~/shared/utils/prisma/enums';
 import { primaryModelFileTypes } from '~/utils/file-display-helpers';
 import type { ModelFileType } from '~/server/common/constants';
 import { addLinkedComponent } from '~/server/services/model-version.service';
@@ -55,6 +55,12 @@ export type ScanOutcome = {
   hashes?: Partial<Record<ModelHashType, string>>;
   /** Parsed safetensors header. May be unset if the file isn't safetensors. */
   headerData?: unknown;
+  /**
+   * The file's declared container format is contradicted by its bytes — it is not the kind of
+   * file it claims to be. Distinct from a generic scan Error: this one names a deliberate
+   * disguise, so it is the signal the moderator-hold path keys on.
+   */
+  formatMismatch?: boolean;
   /** Full upstream payload (orchestrator step outputs or legacy ScanResult) for forensics. */
   rawScanResult?: unknown;
 };
@@ -322,6 +328,30 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
     });
   }
 
+  // A file that is not the kind of file it claims to be. The scan result above already records
+  // this as non-clean, so the model cannot show a Verified shield either way; this adds the
+  // human-in-the-loop step. Gated, and deliberately AFTER the result is persisted, so a failure
+  // here can never swallow the recorded verdict.
+  if (outcome.formatMismatch && file.modelVersion?.modelId) {
+    await holdModelForFormatMismatch({
+      modelId: file.modelVersion.modelId,
+      fileId,
+      detail: outcome.pickleScan?.message ?? null,
+    }).catch((err) =>
+      logToAxiom(
+        {
+          type: 'error',
+          name: 'apply-scan-outcome',
+          message: 'format-mismatch hold failed',
+          fileId,
+          modelId: file.modelVersion?.modelId,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        'webhooks'
+      ).catch()
+    );
+  }
+
   // Search index + cache invalidation. modelId comes from the initial lookup so
   // there's no second round-trip per webhook callback.
   const modelVersionId = outcome.modelVersionId ?? file.modelVersionId;
@@ -335,6 +365,92 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
     // D5: refresh (proactive re-warm) matches legacy behavior.
     await dataForModelsCache.refresh(modelId);
   }
+}
+
+/**
+ * Puts a model whose file contradicts its declared format in front of a moderator.
+ *
+ * Uses the existing Hold semantics (`unpublishModelById` + `meta.needsReview`), the same path a
+ * ModerationRuleAction.Hold takes: reversible, non-punitive, surfaced in the moderator review
+ * queue, and the uploader is told it is under review rather than accused of anything. It is not
+ * an UnpublishedViolation — an automated format check should not issue a strike on its own.
+ *
+ * The model does come down while it waits. That is deliberate: leaving it published pending
+ * review is precisely the window in which a disguised file is still reachable by users.
+ *
+ * Expected volume is small — the magic-byte check separates legitimate containers that simply
+ * carry no `__metadata__` key from genuine mismatches, so only the latter reach this path.
+ * Sizing measurements are in the internal incident ticket.
+ */
+async function holdModelForFormatMismatch({
+  modelId,
+  fileId,
+  detail,
+}: {
+  modelId: number;
+  fileId: number;
+  detail: string | null;
+}) {
+  if (!(await isFlipt(FLIPT_FEATURE_FLAGS.SCAN_FORMAT_MISMATCH_HOLD))) return;
+
+  const model = await dbWrite.model.findUnique({
+    where: { id: modelId },
+    select: { id: true, name: true, meta: true, userId: true, status: true },
+  });
+  // Nothing to hold if a moderator already took it down, or it never went up.
+  if (
+    !model ||
+    model.status === ModelStatus.Unpublished ||
+    model.status === ModelStatus.UnpublishedViolation ||
+    model.status === ModelStatus.Deleted
+  ) {
+    return;
+  }
+
+  await unpublishModelById({
+    id: modelId,
+    userId: -1,
+    reason: 'other',
+    customMessage: `Model held for review: uploaded file does not match its declared format${
+      detail ? ` (${detail})` : ''
+    }`,
+    meta: { ...(model.meta as ModelMeta), needsReview: true },
+    isModerator: true,
+  });
+
+  logToAxiom(
+    {
+      type: 'warning',
+      name: 'scan-format-mismatch-hold',
+      message: `Model ${modelId} held: file ${fileId} does not match its declared format`,
+      modelId,
+      fileId,
+      detail,
+    },
+    'webhooks'
+  ).catch();
+
+  await createNotification({
+    category: NotificationCategory.System,
+    key: `model-format-mismatch:${modelId}:${fileId}`,
+    type: 'system-message',
+    userId: model.userId,
+    details: {
+      message: `Your model "${model.name}" has been put on hold because an uploaded file does not appear to be the file type it claims to be. A moderator will review it shortly.`,
+      url: `/models/${modelId}`,
+    },
+  }).catch((error) =>
+    logToAxiom(
+      {
+        type: 'error',
+        name: 'scan-format-mismatch-hold',
+        message: 'Could not notify uploader of format-mismatch hold',
+        modelId,
+        error: error.message,
+      },
+      'webhooks'
+    ).catch()
+  );
 }
 
 async function notifyHashFix(modelVersionId: number, fileId: number) {
@@ -377,6 +493,15 @@ type ModelClamScanStep = {
     infected?: boolean | null;
     infectedFileCount?: number | null;
     scannedFileCount?: number | null;
+    /**
+     * ClamAV refused the file for exceeding its size limits, so nothing was inspected.
+     * Reported by the scanner as status "Error" (NOT a new status string — the orchestrator
+     * parses that field with Enum.TryParse and an unknown value becomes null, which sends the
+     * web app to the raw exit code, and a limits bail-out exits 1 exactly like a real
+     * detection). This flag carries the true cause for forensics and dashboards.
+     */
+    limitsExceeded?: boolean | null;
+    maxScanSizeMb?: number | null;
   };
 };
 
@@ -488,6 +613,10 @@ export function normalizeScanHashes(
 // in-flight workflows that pre-date the orchestrator update.
 function deriveClamScanResult(output: NonNullable<ModelClamScanStep['output']>): ScanResultCode {
   if (output.infected === true) return ScanResultCode.Danger;
+  // Nothing was inspected, so this is neither clean nor infected. Terminal (Error), not
+  // Pending: Pending would put the file back in scan-files-fallback's queue to be retried
+  // forever, and the retry cannot succeed — the file is simply larger than ClamAV can scan.
+  if (output.limitsExceeded === true) return ScanResultCode.Error;
   const status = output.status?.toLowerCase();
   if (status) {
     if (status === 'clean') return ScanResultCode.Success;
@@ -498,14 +627,58 @@ function deriveClamScanResult(output: NonNullable<ModelClamScanStep['output']>):
   return exitCodeToScanResult(output.exitCode);
 }
 
+/**
+ * Marker the scanner writes to `skipReason` when a file's declared container format is
+ * contradicted by its bytes — e.g. a shell script uploaded as `.safetensors`.
+ *
+ * Cross-repo contract with spine-controller's ModelPickleScanMiddleware.FormatMismatchReason.
+ * The scanner reports the mismatch as ParseError with `skipped: false` and exit code 2, so
+ * this string is NOT what makes the result non-clean — it is what tells us the cause was a
+ * disguised file rather than a transient scanner fault, which is the difference between
+ * "retry it" and "put it in front of a moderator".
+ */
+export const FORMAT_MISMATCH_SKIP_REASON = 'format-mismatch';
+
+/**
+ * The only skip reasons that represent a container verified from its MAGIC BYTES. A skip for
+ * any other reason means the scanner decided from uploader-controlled metadata (the AIR, the
+ * resource registry, the filename) and never looked inside the file.
+ */
+const BYTE_VERIFIED_SKIP_REASONS = new Set(['safetensors-magic', 'gguf-magic']);
+
+export function isFormatMismatch(
+  output: NonNullable<ModelPickleScanStep['output']> | undefined
+): boolean {
+  return output?.skipReason === FORMAT_MISMATCH_SKIP_REASON;
+}
+
 function derivePickleScanResult(
-  output: NonNullable<ModelPickleScanStep['output']>
+  output: NonNullable<ModelPickleScanStep['output']>,
+  { strictSkipVerification }: { strictSkipVerification: boolean }
 ): ScanResultCode {
   if (output.dangerousImportsFound === true) return ScanResultCode.Danger;
-  if (output.skipped === true) return ScanResultCode.Success;
+
+  // 🔴 A SKIP IS NOT A PASS. A skip means the scanner did not inspect the file; mapping that
+  // non-answer to an affirmative clean result is wrong however the skip arose.
+  //
+  // Under strict verification only a byte-verified skip passes. Left off until every worker is
+  // on the new scanner build: older workers emit skip reasons this treats as unverified, and
+  // flipping it early would mark a large share of normal uploads Error.
+  if (output.skipped === true) {
+    if (!strictSkipVerification) return ScanResultCode.Success;
+    return output.skipReason && BYTE_VERIFIED_SKIP_REASONS.has(output.skipReason)
+      ? ScanResultCode.Success
+      : ScanResultCode.Error;
+  }
+
   const status = output.status?.toLowerCase();
   if (status) {
-    if (status === 'clean' || status.startsWith('skipped')) return ScanResultCode.Success;
+    // `startsWith('skipped')` is deliberately NOT treated as clean here any more. It is
+    // reachable with `skipped` unset, and it is the same "we did not look" answer.
+    if (status === 'clean') return ScanResultCode.Success;
+    if (status.startsWith('skipped')) {
+      return strictSkipVerification ? ScanResultCode.Error : ScanResultCode.Success;
+    }
     if (status.includes('danger') || status.includes('infect')) return ScanResultCode.Danger;
     if (status.includes('error') || status.includes('fail')) return ScanResultCode.Error;
     return ScanResultCode.Pending;
@@ -600,6 +773,7 @@ export async function processModelFileScanResult(req: NextApiRequest) {
 
   if (pickleScan?.output) {
     const pickleOut = pickleScan.output;
+    const strictSkipVerification = await isFlipt(FLIPT_FEATURE_FLAGS.SCAN_STRICT_SKIP_VERIFICATION);
     // Skipped (e.g. safetensors) means picklescan never inspected imports —
     // don't synthesize a "No Pickle imports" message; the Success result code
     // is the source of truth.
@@ -614,13 +788,16 @@ export async function processModelFileScanResult(req: NextApiRequest) {
           globalImports: pickleOut.globalImports,
         });
 
-    const baseResult = derivePickleScanResult(pickleOut);
+    const baseResult = derivePickleScanResult(pickleOut, { strictSkipVerification });
     const hasDanger = pickleOut.dangerousImportsFound === true || importsDanger;
     outcome.pickleScan = {
       result: hasDanger ? ScanResultCode.Danger : baseResult,
-      message: pickleScanMessage,
+      // A format mismatch carries no import list, so examinePickleImports produces nothing to
+      // show. Give the moderator the scanner's own explanation instead of a blank message.
+      message: isFormatMismatch(pickleOut) ? pickleOut.output ?? null : pickleScanMessage,
       dangerousImports: pickleOut.dangerousImports ?? undefined,
     };
+    outcome.formatMismatch = isFormatMismatch(pickleOut);
   }
 
   if (hashStep?.output) {

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -370,17 +370,27 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
 /**
  * Puts a model whose file contradicts its declared format in front of a moderator.
  *
- * Uses the existing Hold semantics (`unpublishModelById` + `meta.needsReview`), the same path a
- * ModerationRuleAction.Hold takes: reversible, non-punitive, surfaced in the moderator review
- * queue, and the uploader is told it is under review rather than accused of anything. It is not
- * an UnpublishedViolation — an automated format check should not issue a strike on its own.
+ * Uses the existing Hold semantics (`unpublishModelById` + `meta.needsReview`) — the same path
+ * `ModerationRuleAction.Hold` takes, so the uploader gets the "under review" banner.
+ *
+ * 🔴 BE PRECISE ABOUT WHAT THIS DOES. `unpublishModelById` sets `UnpublishedViolation` whenever
+ * a `reason` is passed — ANY truthy reason, `'other'` included; see the
+ * `status: reason ? UnpublishedViolation : …` ternary in model.service.ts — and it applies to
+ * the model AND every one of its versions. `UnpublishedViolation` is in
+ * `constants.modPublishOnlyStatuses`, so the CREATOR CANNOT REPUBLISH; only a moderator can.
+ * An earlier revision of this comment claimed this was "not an UnpublishedViolation" and
+ * "non-punitive". That was simply false.
+ *
+ * It is worth naming, because the obvious correction is worse than the defect: dropping
+ * `reason` to obtain a plain `Unpublished` would remove the model from the moderator queue at
+ * /moderator/models, which selects on `[UnpublishedViolation, Published]` — it would be held
+ * where no reviewer can find it. The mod-only status and the review queue are one mechanism.
  *
  * The model does come down while it waits. That is deliberate: leaving it published pending
  * review is precisely the window in which a disguised file is still reachable by users.
  *
- * Expected volume is small — the magic-byte check separates legitimate containers that simply
- * carry no `__metadata__` key from genuine mismatches, so only the latter reach this path.
- * Sizing measurements are in the internal incident ticket.
+ * Expected volume is small — the magic-byte check distinguishes legitimate containers from
+ * genuine mismatches, so only the latter reach this path. Sizing is in the internal ticket.
  */
 async function holdModelForFormatMismatch({
   modelId,
@@ -397,12 +407,23 @@ async function holdModelForFormatMismatch({
     where: { id: modelId },
     select: { id: true, name: true, meta: true, userId: true, status: true },
   });
-  // Nothing to hold if a moderator already took it down, or it never went up.
+  // 🔴 ALLOW-LIST, NOT A DENY-LIST. Only a model that is actually reachable by users can be
+  // "held" in any meaningful sense, and holding anything else does real harm.
+  //
+  // A deny-list of {Unpublished, UnpublishedViolation, Deleted} looks equivalent and is not:
+  // it lets `Draft` through, and Draft is the COMMON case here, not an edge case. Files are
+  // scanned by scan-files.ts, whose WHERE clause is virusScanResult/exists/scanRequestedAt with
+  // NO model-status predicate, and models are created Draft with files attached during the
+  // upload wizard — so a brand-new upload is normally scanned while still a draft, minutes
+  // before it is ever published. Holding one would push a never-published draft to
+  // UnpublishedViolation, lock its own creator out of it (mod-only republish), and fire the
+  // generic "your version was unpublished" notification — which selects on meta alone, with no
+  // status predicate — about a version that was never published, on top of the message below.
+  //
+  // Published and Scheduled are the only states where a hold both means something and is safe.
   if (
     !model ||
-    model.status === ModelStatus.Unpublished ||
-    model.status === ModelStatus.UnpublishedViolation ||
-    model.status === ModelStatus.Deleted
+    (model.status !== ModelStatus.Published && model.status !== ModelStatus.Scheduled)
   ) {
     return;
   }
@@ -411,9 +432,10 @@ async function holdModelForFormatMismatch({
     id: modelId,
     userId: -1,
     reason: 'other',
-    customMessage: `Model held for review: uploaded file does not match its declared format${
-      detail ? ` (${detail})` : ''
-    }`,
+    // Same reasoning as FORMAT_MISMATCH_PUBLIC_MESSAGE — this reaches the uploader, who is the
+    // one party we must not hand a detector readout to. `detail` is logged, not echoed.
+    customMessage:
+      'Model held for review: an uploaded file could not be verified as the file type it declares.',
     meta: { ...(model.meta as ModelMeta), needsReview: true },
     isModerator: true,
   });
@@ -629,7 +651,7 @@ function deriveClamScanResult(output: NonNullable<ModelClamScanStep['output']>):
 
 /**
  * Marker the scanner writes to `skipReason` when a file's declared container format is
- * contradicted by its bytes — e.g. a shell script uploaded as `.safetensors`.
+ * contradicted by its bytes.
  *
  * Cross-repo contract with spine-controller's ModelPickleScanMiddleware.FormatMismatchReason.
  * The scanner reports the mismatch as ParseError with `skipped: false` and exit code 2, so
@@ -640,9 +662,17 @@ function deriveClamScanResult(output: NonNullable<ModelClamScanStep['output']>):
 export const FORMAT_MISMATCH_SKIP_REASON = 'format-mismatch';
 
 /**
- * The only skip reasons that represent a container verified from its MAGIC BYTES. A skip for
- * any other reason means the scanner decided from uploader-controlled metadata (the AIR, the
- * resource registry, the filename) and never looked inside the file.
+ * What a mismatch shows publicly. Deliberately says nothing about what the scanner detected:
+ * this string is served by the public v1 model-versions API, so anything specific here is an
+ * oracle an uploader can iterate against. The scanner's full explanation stays in
+ * `rawScanResult` and in the moderator-facing log.
+ */
+export const FORMAT_MISMATCH_PUBLIC_MESSAGE =
+  'File format could not be verified. This file is under review.';
+
+/**
+ * The only skip reasons that represent a container verified from its MAGIC BYTES. Any other
+ * skip reason is one the scanner produced without verifying the file's contents.
  */
 const BYTE_VERIFIED_SKIP_REASONS = new Set(['safetensors-magic', 'gguf-magic']);
 
@@ -658,12 +688,11 @@ function derivePickleScanResult(
 ): ScanResultCode {
   if (output.dangerousImportsFound === true) return ScanResultCode.Danger;
 
-  // 🔴 A SKIP IS NOT A PASS. A skip means the scanner did not inspect the file; mapping that
-  // non-answer to an affirmative clean result is wrong however the skip arose.
+  // 🔴 A SKIP IS NOT A PASS. A skip means the scanner did not inspect the file, and that
+  // non-answer must not be recorded as an affirmative clean result.
   //
   // Under strict verification only a byte-verified skip passes. Left off until every worker is
-  // on the new scanner build: older workers emit skip reasons this treats as unverified, and
-  // flipping it early would mark a large share of normal uploads Error.
+  // on the new scanner build — see the flag's own note for the ordering constraint.
   if (output.skipped === true) {
     if (!strictSkipVerification) return ScanResultCode.Success;
     return output.skipReason && BYTE_VERIFIED_SKIP_REASONS.has(output.skipReason)
@@ -793,8 +822,13 @@ export async function processModelFileScanResult(req: NextApiRequest) {
     outcome.pickleScan = {
       result: hasDanger ? ScanResultCode.Danger : baseResult,
       // A format mismatch carries no import list, so examinePickleImports produces nothing to
-      // show. Give the moderator the scanner's own explanation instead of a blank message.
-      message: isFormatMismatch(pickleOut) ? pickleOut.output ?? null : pickleScanMessage,
+      // show — but the scanner's own explanation must NOT go here. `pickleScanMessage` is
+      // returned by the PUBLIC v1 model-versions API, and the scanner's text names what it
+      // detected ("detected: Unknown"), which hands an uploader a per-attempt readout of the
+      // detector's verdict — a free oracle for tuning a disguise, and one that is reachable
+      // while SCAN_FORMAT_MISMATCH_HOLD is off and the model therefore stays published.
+      // A fixed string here; the detail is already preserved in rawScanResult for forensics.
+      message: isFormatMismatch(pickleOut) ? FORMAT_MISMATCH_PUBLIC_MESSAGE : pickleScanMessage,
       dangerousImports: pickleOut.dangerousImports ?? undefined,
     };
     outcome.formatMismatch = isFormatMismatch(pickleOut);


### PR DESCRIPTION
Web-app half of a model-upload scanner fix. Scanner side is in the private `civitai-spine-controller` repo; incident record, mechanism and measurements are in internal ticket **868ky8j7f**.

> This repository is public and the mitigation is not deployed, so this description deliberately omits the mechanism.

## 🔴 Read the deploy-ordering section before merging

This change is inert on its own: with the flag off — the shipping state — the result mapping is unchanged from `main`. It takes effect only once the scanner side is deployed.

## What this changes

The pickle-scan result mapping treated one class of non-answer from the scanner as an affirmative clean result. It no longer does — the model cannot show a Verified shield on that basis.

- **`derivePickleScanResult`** — a skip counts as a pass only when the scanner verified the container from its magic bytes. Behind `SCAN_STRICT_SKIP_VERIFICATION`, **default-off**.
- **`deriveClamScanResult`** — an explicit `limitsExceeded` is `Error`, not `Pending` (`Pending` would re-queue the file in `scan-files.ts` forever, and the retry cannot succeed).
- The scanner's verdict text is kept off the public v1 API surface; the detail goes to `rawScanResult` and the operator log.
- A format mismatch is recorded as **ungated telemetry** — no flag, no model mutation.

## Scope: the automated hold was removed, deliberately

Earlier revisions of this PR tried to put the model on hold automatically. Four adversarial audit rounds each found the hold broken in a new way, always the same shape — a lever reached for without owning its whole lifecycle:

| round | what the hold did wrong |
|---|---|
| 1 | fired on `Draft` models, locking creators out of never-published drafts |
| 2 | the allow-list fixing that was the mirror bug — the *first* upload is scanned while a Draft, so the dominant path was uncovered, with no hold, no queue entry and no log |
| 3 | the flag it wrote was **inert twice over**: the moderator queue excludes `Draft`, and the publish handler strips `needsReview` |
| 4 | the replacement flag is **owner-writable** — absent from `MODERATION_OWNED_META_KEYS`, so the model's own owner clears it with one `model.upsert`, API key included |

Round 4 also found that a flagged `Draft` reaches **no** moderator queue, and the only surface that toggles that flag filters on `uploadType='Trained'` while wizard uploads are `Created`. Those compound badly: the adversary can clear it, the moderator cannot find it, and an honest creator hitting a false positive is stuck.

🔴 **And fixing only the owner-writable half would have made it worse** — locking the flag down without a clearing surface turns a self-clearable false positive into a permanent lockout with no appeal. False positives are real: several legitimate container shapes are unverifiable by the scanner and detect as unknown.

An automated hold needs product surfaces that do not exist yet: a queue that lists flagged drafts, a clearing path, correct owner-facing copy (today's only message for that flag blames "training data", which is wrong for a format mismatch), and a notification. That is a feature, not a patch to the scan service — so it is a **follow-up**, tracked on the internal ticket.

What is left here is the part that is correct, verified and actually closes the gap. The ungated telemetry is deliberate: it is the population signal needed to size the problem and validate the detector *before* any enforcement is designed.

A test pins this scope directly — a mismatch must log and must touch no model — and is mutation-checked both ways, so a later change cannot quietly put enforcement back here.

## 🔴 Deploy ordering

`SCAN_STRICT_SKIP_VERIFICATION` **must stay off until the scanner change is deployed fleet-wide.** Enabling it before the worker fleet is updated would mark ordinary uploads `Error`. A test pins both regimes so this cannot regress silently.

⚠️ The scanner work is **two** PRs, both owned by @Koen: `civitai-spine-controller#231` is the format-conformance half that this PR's mismatch handling pairs with; **`#232`** is the ClamAV size-limit half, which is what the `limitsExceeded` branch pairs with. That branch is dead against both `main` and #231 — it needs #232.

Order: **#231 → this PR → flip `scan-strict-skip-verification`.** The flag does not exist in `flipt-state` yet; an unknown flag resolves `false`, so the default is safe.

⚠️ **The flag is not a kill switch for its own effects.** Verdicts are persisted, and turning it back off does not repair rows: `scan-files.ts` re-queues only on `virusScanResult: Pending`, and pickle results are never re-driven. A premature flip leaves a population of `pickleScanResult: Error` needing a manual rescan.

## Also unchanged

Neither a regression — both identical on `main`: two scan-related fields remain on the public v1 API surface. This PR narrows what they expose; it does not remove them. Detail in the internal ticket.

## Tests

80 in the target file. Every guard has a killing mutation, each re-verified rather than trusted:

| mutation | test killed |
|---|---|
| error statuses → `Success` | mismatch-is-not-clean |
| delete the `limitsExceeded` guard | limits-with-unrecognized-status |
| strict `skipped`-status branch → `Success` | skipped-status-is-not-a-pass |
| drop `gguf-magic` from the verified set | byte-verified GGUF skip |
| reintroduce a model mutation on mismatch | the scope guard |
| drop the telemetry log | the scope guard + flag-off logging |

Suite: **412 files / 5,742 tests**; typecheck **0 errors**; prettier clean (positive-controlled).
