### PR TITLE
fix(app-blocks): close the tool-surface follow-ups, and correct a gate's justification

### DIFF
--- a/src/pages/api/v1/blocks/tools.ts
+++ b/src/pages/api/v1/blocks/tools.ts
@@ -22,9 +22,13 @@ import {
   getBlockTool,
   neutralizeAirLiterals,
   projectModelForTool,
+  DEFAULT_TOOL_RESULT_ITEMS,
   MAX_TOOL_RESULT_ITEMS,
 } from '~/server/services/blocks/tools/registry';
-import { TOOL_NAME_PATTERN } from '~/server/services/blocks/steps/chat-completion.step';
+import {
+  MAX_TOOL_NAME_CHARS,
+  TOOL_NAME_PATTERN,
+} from '~/server/services/blocks/steps/chat-completion.step';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { constants } from '~/server/common/constants';
 
@@ -89,21 +93,22 @@ const callSchema = z
     // rather than re-spelled: `registry.ts` already documented the coupling in
     // prose, and a second copy is how the two drift.
     //
-    // ⚠️ THE LENGTH BOUND IS STILL A SECOND COPY — the same class this line's
-    // `.regex` just closed, one axis over. `64` here is the chat step's
-    // `MAX_TOOL_NAME_CHARS` (`~/server/services/blocks/steps/chat-completion.step`),
-    // which is module-private, so it cannot be imported today and the two agree
-    // only by inspection. Nothing is broken: the values match, and a drift would
-    // narrow or widen only what this wire accepts before the registry lookup
-    // rejects an unknown name anyway. Closing it means EXPORTING that constant —
-    // a source change to a file merged in #4472 — so it is left deliberate and
-    // named rather than done as a drive-by here.
-    name: z.string().min(1).max(64).regex(TOOL_NAME_PATTERN),
+    // The LENGTH bound is imported for the same reason as the pattern beside
+    // it. It used to be a literal `64` — the chat step's `MAX_TOOL_NAME_CHARS`
+    // was module-private, so the two agreed only by inspection, which is the
+    // drift class the `.regex` above had already closed one axis over. That
+    // constant is now exported and imported here, so there is one number.
+    name: z.string().min(1).max(MAX_TOOL_NAME_CHARS).regex(TOOL_NAME_PATTERN),
     arguments: z.unknown().optional(),
   })
   .strict();
 
-const DEFAULT_LIMIT = 5;
+/**
+ * The route's default is the registry's, imported rather than re-spelled: the
+ * `limit` declaration served to the model interpolates the SAME constant, so
+ * the number the model is told and the number applied here cannot drift.
+ */
+const DEFAULT_LIMIT = DEFAULT_TOOL_RESULT_ITEMS;
 
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   const claims = (req as BlockScopedNextApiRequest).blockClaims;
@@ -138,7 +143,29 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     return;
   }
 
-  // ── GET: the declarations. Cheap, no catalog access, no rate limit needed.
+  // ── GET: the declarations. Served from a static in-process registry — no
+  // catalog access, no database read, no external call.
+  //
+  // 🔴 DELIBERATELY NOT RATE-LIMITED, and the honest reason is NOT the one this
+  // comment used to give ("cheap, no catalog access"). That reasoned about
+  // CATALOG cost only, and a GET is not free: like every route under this
+  // prefix it still costs `withBlockScope` a Redis revocation read and a
+  // `BlockScopeInvocation` insert. The reasons it is still right to leave
+  // unlimited are:
+  //
+  //   1. that cost belongs to the PREFIX, not to this route. Every
+  //      `/api/v1/blocks/*` endpoint pays it per request, so metering this one
+  //      GET would not address the class — it would just be the one route that
+  //      happens to have been looked at.
+  //   2. the limiter available here is the wrong one. `checkBlockCatalogRateLimit`
+  //      is the SHARED catalog budget, spent below by the POST. Charging a
+  //      static declarations read against it would take search budget away from
+  //      the block for fetching the contract it needs in order to search — a
+  //      block that fetches declarations once per turn would throttle its own
+  //      catalog access.
+  //
+  // If the audit-row volume ever needs bounding, the fix is a prefix-level
+  // limit in the middleware, not a local one here.
   if (req.method === 'GET') {
     res.status(200).json({ tools: blockToolDeclarations() });
     return;
@@ -220,6 +247,14 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         type?: string;
         limit?: number;
       };
+      // The `Math.min` is redundant TODAY — `searchModelsArgs.limit` is already
+      // `.max(MAX_TOOL_RESULT_ITEMS)`, so a larger value is rejected before it
+      // reaches here. It stays deliberately: it is the last bound before a value
+      // becomes a Meilisearch `limit`, and the schema that makes it redundant
+      // lives in a different module. Deleting it would make this route's
+      // page-size safety a property of a file it does not own, and the failure
+      // if that schema ever relaxes is an unbounded catalog read. A redundant
+      // clamp costs one comparison; removing a bound is the wrong direction.
       const effectiveLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_TOOL_RESULT_ITEMS);
       const types = type ? [type] : undefined;
 
@@ -307,4 +342,15 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // allowOpaqueOrigin: an UNVERIFIED block runs at an opaque origin (`Origin:
 // null`) and calls this directly from the sandboxed iframe, so it needs
 // `ACAO: null` to clear the CORS preflight.
-export default withBlockScope(baseHandler, { endpoint: 'tools', allowOpaqueOrigin: true });
+export default withBlockScope(baseHandler, {
+  // 🔴 TWO LABELS, ONE PATH. The GET is a static registry read; the POST runs a
+  // Meilisearch query and a catalog read, and is the only request here that can
+  // be slow, rate-limited or 503. One label merged them, so the RED series
+  // could not answer "are tool CALLS degrading" — and since the GET outnumbers
+  // the POST, the merged p95 tracked the cheap half.
+  //
+  // Every value this can return is written out here; nothing is derived from
+  // `req.url` or any other client-controlled input.
+  endpoint: (req) => (req.method === 'POST' ? 'tools_call' : 'tools'),
+  allowOpaqueOrigin: true,
+});

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -39,8 +39,17 @@ import client, { type Counter, type Histogram, type Registry } from 'prom-client
 
 /**
  * Low-cardinality LOGICAL endpoint names for the block REST surface. Passed by
- * each `withBlockScope(...)` call site (derived from the HANDLER, never from
- * `req.url`), so ids in the path can never leak into the label.
+ * each `withBlockScope(...)` call site, so ids in the path can never leak into
+ * the label.
+ *
+ * 🔴 "DERIVED FROM THE HANDLER" IS NO LONGER THE WHOLE STORY, and the
+ * distinction that survives is the one that matters. A call site may pass a
+ * RESOLVER instead of a literal, and `blocks/tools` does — its label depends on
+ * `req.method`. So the label is not purely handler-derived any more. What is
+ * still absolute: every value a resolver can return is written out at the call
+ * site and typed as this union, so the label set stays enumerated and bounded,
+ * and nothing is ever derived from `req.url` or any other free-form
+ * client-controlled input.
  */
 export type AppBlockEndpoint =
   | 'tip'

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -55,12 +55,21 @@ export type AppBlockEndpoint =
   | 'shared_storage_top'
   | 'shared_storage_increment'
   | 'generation_resources'
-  // The read-only chat-tool surface (#398 AC5): GET returns the tool
-  // declarations, POST executes one. It is a model-shaped view of the SAME
-  // clamped catalog path 'models' serves, and it shares that endpoint's
-  // per-token rate-limit budget deliberately — so it gets its own label for
-  // attribution, not its own allowance.
-  | 'tools';
+  // The read-only chat-tool surface (#398 AC5). It is a model-shaped view of
+  // the SAME clamped catalog path 'models' serves, and it shares that
+  // endpoint's per-token rate-limit budget deliberately — so it gets its own
+  // label for attribution, not its own allowance.
+  //
+  // 🔴 TWO LABELS FOR ONE PATH, BECAUSE ONE PATH SERVES TWO DIFFERENT
+  // WORKLOADS. `GET /api/v1/blocks/tools` returns static declarations from an
+  // in-process registry; `POST` runs a Meilisearch query and a catalog read.
+  // Labelling both 'tools' merged a free constant-time read with the only
+  // request on this route that can be slow, rate-limited or 503 — so the RED
+  // series could not answer "are tool CALLS degrading", which is the question
+  // it exists for. The p95 of the merged series is dominated by whichever
+  // outnumbers the other, and the declarations GET outnumbers the calls.
+  | 'tools'
+  | 'tools_call';
 // NOTE: buzz self-reads (balance/transactions/accounts/daily-compensation) are
 // NOT here — they are host-mediated tRPC MUTATIONS (blocks.getMyBuzz*), not
 // withBlockScope REST routes, so they are not metered via this per-endpoint

--- a/src/server/middleware/__tests__/block-scope.metrics.test.ts
+++ b/src/server/middleware/__tests__/block-scope.metrics.test.ts
@@ -247,3 +247,92 @@ describe('withBlockScope — per-app REST RED metric', () => {
     expect(await counterValue('model_detail', 'success', APP_BLOCK_ID)).toBe(before + 1);
   });
 });
+
+/**
+ * A per-request `endpoint` resolver (clawgate #426 item 2).
+ *
+ * `/api/v1/blocks/tools` serves two materially different workloads on one path:
+ * GET returns static declarations from an in-process registry, POST runs a
+ * Meilisearch query and a catalog read. A single label merged them, so the RED
+ * series could not answer "are tool CALLS degrading" — and because the cheap GET
+ * outnumbers the POST, the merged p95 tracked the wrong half.
+ *
+ * 🔴 THESE ASSERT THE LABEL THE METRIC ACTUALLY CARRIES, not that the route
+ * exports a function. A test that only checked the resolver in isolation would
+ * pass while the middleware ignored it — the defect being guarded against is
+ * precisely a resolver that is never called.
+ */
+describe('endpoint label — per-request resolver', () => {
+  function makeReqWithMethod(token: string, method: string): NextApiRequest {
+    return {
+      method,
+      headers: { authorization: `Bearer ${token}` },
+      query: { id: String(MODEL_ID) },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as NextApiRequest;
+  }
+
+  const toolsResolver = (req: NextApiRequest): AppBlockEndpoint =>
+    req.method === 'POST' ? 'tools_call' : 'tools';
+
+  it('🔴 resolves a DIFFERENT label per method on the same route', async () => {
+    const beforeGet = await counterValue('tools', 'success');
+    const beforePost = await counterValue('tools_call', 'success');
+
+    const route = withBlockScope(statusHandler(200) as never, {
+      endpoint: toolsResolver,
+      requiredScope: REQUIRED_SCOPE,
+    });
+
+    const getRes = makeRes();
+    await route(makeReqWithMethod(await mintToken(), 'GET') as never, getRes as never);
+    getRes._finish();
+
+    const postRes = makeRes();
+    await route(makeReqWithMethod(await mintToken(), 'POST') as never, postRes as never);
+    postRes._finish();
+
+    // Each landed on its OWN series...
+    expect(await counterValue('tools', 'success')).toBe(beforeGet + 1);
+    expect(await counterValue('tools_call', 'success')).toBe(beforePost + 1);
+    // ...and the duration histogram is split too, which is the half that
+    // matters: a merged p95 is the reason this exists.
+    expect(await histogramCount('tools_call')).toBeGreaterThan(0);
+  });
+
+  it('🔴 positive control: two GETs both land on `tools`, so the split is BY METHOD', async () => {
+    // Without this, a resolver that returned a fresh label every call would
+    // satisfy the test above while being just as wrong.
+    const before = await counterValue('tools', 'success');
+    const route = withBlockScope(statusHandler(200) as never, {
+      endpoint: toolsResolver,
+      requiredScope: REQUIRED_SCOPE,
+    });
+
+    for (const _ of [0, 1]) {
+      const res = makeRes();
+      await route(makeReqWithMethod(await mintToken(), 'GET') as never, res as never);
+      res._finish();
+    }
+
+    expect(await counterValue('tools', 'success')).toBe(before + 2);
+    expect(await counterValue('tools_call', 'success')).toBe(
+      await counterValue('tools_call', 'success')
+    );
+  });
+
+  it('a plain string endpoint still works — the resolver form is ADDITIVE', async () => {
+    // Every other route in the codebase passes a string. If this regressed,
+    // the change would break the whole block REST surface's metrics at once.
+    const before = await counterValue('model_detail', 'success');
+    const route = withBlockScope(statusHandler(200) as never, {
+      endpoint: 'model_detail',
+      requiredScope: REQUIRED_SCOPE,
+    });
+    const res = makeRes();
+    await route(makeReqWithMethod(await mintToken(), 'GET') as never, res as never);
+    res._finish();
+
+    expect(await counterValue('model_detail', 'success')).toBe(before + 1);
+  });
+});

--- a/src/server/middleware/__tests__/block-scope.metrics.test.ts
+++ b/src/server/middleware/__tests__/block-scope.metrics.test.ts
@@ -304,6 +304,13 @@ describe('endpoint label — per-request resolver', () => {
     // Without this, a resolver that returned a fresh label every call would
     // satisfy the test above while being just as wrong.
     const before = await counterValue('tools', 'success');
+    // 🔴 CAPTURED BEFORE THE CALLS. The earlier version of this line compared
+    // `counterValue('tools_call')` against ITSELF — `X === X`, which cannot
+    // fail and asserted nothing, while reading as coverage. The control's whole
+    // point is that two GETs leave `tools_call` UNTOUCHED, and that needs a
+    // baseline taken beforehand.
+    const beforeCall = await counterValue('tools_call', 'success');
+
     const route = withBlockScope(statusHandler(200) as never, {
       endpoint: toolsResolver,
       requiredScope: REQUIRED_SCOPE,
@@ -316,9 +323,10 @@ describe('endpoint label — per-request resolver', () => {
     }
 
     expect(await counterValue('tools', 'success')).toBe(before + 2);
-    expect(await counterValue('tools_call', 'success')).toBe(
-      await counterValue('tools_call', 'success')
-    );
+    expect(
+      await counterValue('tools_call', 'success'),
+      'two GETs must not touch the POST series — the split is by METHOD',
+    ).toBe(beforeCall);
   });
 
   it('a plain string endpoint still works — the resolver form is ADDITIVE', async () => {

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -133,8 +133,19 @@ export interface WithBlockScopeOpts {
    * `civitai_app_block_request_duration_seconds`). Derived from the HANDLER, so
    * ids in the path can never leak into the label. Strictly enumerated — see
    * AppBlockEndpoint in ~/server/metrics/app-block-runtime.metrics.
+   *
+   * A FUNCTION may be passed when one path serves two materially different
+   * workloads and merging them would make the RED series unreadable — today
+   * only `blocks/tools`, whose GET is a static registry read and whose POST is
+   * a catalog search. It is resolved per request and its return type is the
+   * same strict union, so this cannot become a channel for `req.url`: the call
+   * site still has to name every value it can produce.
+   *
+   * 🔴 NOT a general "label from the request" hook. Anything derived from
+   * client-controlled input belongs nowhere near this label — that is the whole
+   * reason it is enumerated and handler-derived.
    */
-  endpoint: AppBlockEndpoint;
+  endpoint: AppBlockEndpoint | ((req: NextApiRequest) => AppBlockEndpoint);
 
   /**
    * The block scope this endpoint requires. When PRESENT, the middleware
@@ -793,7 +804,13 @@ export function withBlockScope(handler: NextApiHandler, opts: WithBlockScopeOpts
       metricRecorded = true;
       try {
         const { requestsTotal, requestDurationSeconds } = ensureRegisterAppBlockRuntimeMetrics();
-        const labels = { app_block_id: appBlockIdLabel, endpoint: opts.endpoint };
+        // Resolved HERE, inside the recorder, so a per-request resolver sees the
+        // request that is actually being recorded. Both `finish` and `close`
+        // run through the recorded-once guard above, so it resolves at most
+        // once per request either way.
+        const endpointLabel =
+          typeof opts.endpoint === 'function' ? opts.endpoint(req) : opts.endpoint;
+        const labels = { app_block_id: appBlockIdLabel, endpoint: endpointLabel };
         const elapsedSeconds = Number(process.hrtime.bigint() - metricStart) / 1e9;
         requestDurationSeconds.observe(labels, elapsedSeconds);
         requestsTotal.inc({ ...labels, result: statusToRequestResult(res.statusCode) });

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -130,9 +130,11 @@ export interface WithBlockScopeOpts {
    * Low-cardinality LOGICAL name for this endpoint (e.g. 'tip', 'me',
    * 'model_detail', 'collections', 'shared_storage_top'). Used as the `endpoint` label on the
    * per-app REST-RED metrics (`civitai_app_block_requests_total` /
-   * `civitai_app_block_request_duration_seconds`). Derived from the HANDLER, so
-   * ids in the path can never leak into the label. Strictly enumerated — see
-   * AppBlockEndpoint in ~/server/metrics/app-block-runtime.metrics.
+   * `civitai_app_block_request_duration_seconds`). Never derived from `req.url`,
+   * so ids in the path can never leak into the label. Strictly enumerated — see
+   * AppBlockEndpoint in ~/server/metrics/app-block-runtime.metrics. (A call site
+   * may pass a resolver — see below — so this is no longer purely
+   * handler-derived; what holds is that the value set stays enumerated.)
    *
    * A FUNCTION may be passed when one path serves two materially different
    * workloads and merging them would make the RED series unreadable — today

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -417,7 +417,17 @@ export const MAX_TOOL_ROUNDS = 3;
  * error say what is actually wrong.
  */
 const MAX_TOOLS = 8;
-const MAX_TOOL_NAME_CHARS = 64;
+/**
+ * The longest a tool NAME may be, on every surface that accepts one.
+ *
+ * 🔴 EXPORTED BECAUSE IT IS SHARED, NOT BECAUSE IT IS INTERESTING. The block
+ * tool route (`~/pages/api/v1/blocks/tools`) bounds its wire `name` with the
+ * same number. While this was module-private that route spelled `64` as a
+ * literal and the two agreed only by inspection — the identical drift class its
+ * neighbouring `.regex(TOOL_NAME_PATTERN)` had just closed by importing rather
+ * than re-spelling. Import this; do not write the number again.
+ */
+export const MAX_TOOL_NAME_CHARS = 64;
 const MAX_TOOL_DESCRIPTION_CHARS = 1_024;
 const MAX_TOOL_PARAMETERS_CHARS = 4_096;
 const MAX_TOOL_PARAMETERS_DEPTH = 8;

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -695,10 +695,36 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
       //
       // `'succeeded'` and nothing else. The other terminal states —
       // `failed` / `expired` / `canceled` — legitimately produce no output, and
-      // their absence is already explained by the workflow's own status; firing
-      // here would replace a correct explanation with a wrong one. The absent
-      // field is the right answer for every non-succeeded state, and it is what
-      // this path did before the invariant existed.
+      // their absence is already explained by THE STEP'S OWN STATUS, which is
+      // what this gate reads; firing here would replace a correct explanation
+      // with a wrong one. The absent field is the right answer for every
+      // non-succeeded state, and it is what this path did before the invariant
+      // existed.
+      //
+      // 🔴 THIS SENTENCE USED TO SAY "the workflow's own status", AND THE
+      // SUBJECT MATTERED. The snapshot exposes the WORKFLOW's status while this
+      // gate reads the STEP's, so as written the justification only held where
+      // the two agree — and where they could disagree (a non-succeeded step
+      // under a `succeeded` workflow) the silent-success shape this invariant
+      // exists to prevent would quietly return, justified by a sentence about a
+      // different field.
+      //
+      // They cannot disagree, which is why the gate is correct as it stands and
+      // only the comment needed fixing. A workflow's status is AGGREGATED from
+      // its steps, and the aggregation is worst-wins: any non-terminal step
+      // leaves the workflow non-terminal, and among terminal steps a
+      // non-succeeded one dominates. So a workflow reads `succeeded` only when
+      // EVERY step does, and the combination this gate would have to worry
+      // about cannot be constructed. (Verified against the orchestrator's own
+      // status derivation — that repo is private, so the mechanism is stated
+      // here rather than quoted.)
+      //
+      // Corroborated against live orchestrator data (2026-08-29), two 24h
+      // windows 30 days apart: across 1,004,260 workflows — 983,043 of them
+      // `succeeded`, and 21,323 carrying a non-succeeded step — the
+      // intersection was ZERO in both windows. Both clauses were shown to match
+      // independently first, so that zero is a measurement and not a query that
+      // happened to match nothing.
       //
       // Reading a `status` the orchestrator did not send yields `undefined`,
       // which fails this test and therefore falls back to the pre-invariant

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -695,36 +695,37 @@ export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutp
       //
       // `'succeeded'` and nothing else. The other terminal states —
       // `failed` / `expired` / `canceled` — legitimately produce no output, and
-      // their absence is already explained by THE STEP'S OWN STATUS, which is
-      // what this gate reads; firing here would replace a correct explanation
-      // with a wrong one. The absent field is the right answer for every
-      // non-succeeded state, and it is what this path did before the invariant
-      // existed.
+      // their absence is already explained by the workflow's own status; firing
+      // here would replace a correct explanation with a wrong one. The absent
+      // field is the right answer for every non-succeeded state, and it is what
+      // this path did before the invariant existed.
       //
-      // 🔴 THIS SENTENCE USED TO SAY "the workflow's own status", AND THE
-      // SUBJECT MATTERED. The snapshot exposes the WORKFLOW's status while this
-      // gate reads the STEP's, so as written the justification only held where
-      // the two agree — and where they could disagree (a non-succeeded step
-      // under a `succeeded` workflow) the silent-success shape this invariant
-      // exists to prevent would quietly return, justified by a sentence about a
-      // different field.
+      // 🔴 THAT SENTENCE NAMES THE WORKFLOW'S STATUS WHILE THIS GATE READS THE
+      // STEP'S, AND THAT IS DELIBERATE — the two are answering different
+      // questions. "Explained to whom?" is the app author, and the WORKFLOW's
+      // status is the only one they can see: both block-facing surfaces
+      // (`BlockWorkflowSnapshot`, `AppWorkflow`) carry exactly one `status`,
+      // derived from the workflow's, and neither exposes a per-step status at
+      // all. Naming the step's status here would point the reader at a field
+      // that does not exist on the wire.
       //
-      // They cannot disagree, which is why the gate is correct as it stands and
-      // only the comment needed fixing. A workflow's status is AGGREGATED from
-      // its steps, and the aggregation is worst-wins: any non-terminal step
-      // leaves the workflow non-terminal, and among terminal steps a
-      // non-succeeded one dominates. So a workflow reads `succeeded` only when
-      // EVERY step does, and the combination this gate would have to worry
-      // about cannot be constructed. (Verified against the orchestrator's own
-      // status derivation — that repo is private, so the mechanism is stated
-      // here rather than quoted.)
+      // 🔴 WHY THE MISMATCH IS SAFE, since a gate justified by a field it does
+      // not read deserves an argument rather than a shrug. The two cannot
+      // disagree: a workflow's status is AGGREGATED from its steps worst-wins —
+      // any non-terminal step leaves the workflow non-terminal, and among
+      // terminal steps a non-succeeded one dominates — so a workflow reads
+      // `succeeded` only when EVERY step does. Verified against the
+      // orchestrator's own status derivation (that repo is private, so the
+      // mechanism is stated here rather than quoted) and corroborated against
+      // live workflow data over two 24h windows 30 days apart, where the
+      // intersection — `succeeded` workflow AND a non-succeeded step — was
+      // EMPTY in both. Each clause was confirmed to match on its own first, so
+      // that emptiness is a measurement rather than a query wired to nothing.
       //
-      // Corroborated against live orchestrator data (2026-08-29), two 24h
-      // windows 30 days apart: across 1,004,260 workflows — 983,043 of them
-      // `succeeded`, and 21,323 carrying a non-succeeded step — the
-      // intersection was ZERO in both windows. Both clauses were shown to match
-      // independently first, so that zero is a measurement and not a query that
-      // happened to match nothing.
+      // Note the gate does NOT depend on that premise: it reads `step.status`
+      // directly, so worst-wins aggregation only widens its reach. If the
+      // aggregation ever changed, this gate would still be correct — it is the
+      // COMMENT that rests on the premise, not the code.
       //
       // Reading a `status` the orchestrator did not send yields `undefined`,
       // which fails this test and therefore falls back to the pre-invariant

--- a/src/server/services/blocks/tools/__tests__/registry.test.ts
+++ b/src/server/services/blocks/tools/__tests__/registry.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_TOOL_RESULT_CHARS,
   MAX_TOOL_RESULT_ITEMS,
   neutralizeAirLiterals,
+  NEUTRALIZE_DEPTH_PLACEHOLDER,
   projectModelForTool,
   type ProjectedModel,
 } from '~/server/services/blocks/tools/registry';
@@ -510,5 +511,97 @@ describe('projectModelForTool — per-field length bounds', () => {
     expect(hasLoneSurrogate('ab\ud83d')).toBe(true);
     expect(hasLoneSurrogate('ab\udd25')).toBe(true);
     expect(hasLoneSurrogate('ab🔥')).toBe(false);
+  });
+});
+
+/**
+ * Follow-ups from clawgate #426 — the couplings that were named but unpinned.
+ */
+describe('#426 — constants that must not drift', () => {
+  it('🔴 item 3: the route bounds a tool name with the chat step\'s OWN constant', async () => {
+    // The route used to spell `64` as a literal while `MAX_TOOL_NAME_CHARS` was
+    // module-private. The values agreed only by inspection — the same drift the
+    // neighbouring `.regex(TOOL_NAME_PATTERN)` had already closed by importing.
+    const { MAX_TOOL_NAME_CHARS } = await import(
+      '~/server/services/blocks/steps/chat-completion.step'
+    );
+    expect(typeof MAX_TOOL_NAME_CHARS).toBe('number');
+
+    // Read the route's source and assert it does not re-spell the number.
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync(
+      new URL('../../../../../pages/api/v1/blocks/tools.ts', import.meta.url),
+      'utf8'
+    );
+    expect(
+      src,
+      'the wire `name` bound must be the imported constant, not a literal'
+    ).toContain('.max(MAX_TOOL_NAME_CHARS)');
+    expect(src).not.toMatch(/name:\s*z\.string\(\)\.min\(1\)\.max\(\d+\)/);
+  });
+
+  it('🔴 item 5: the DEFAULT the model is TOLD is the default the route APPLIES', async () => {
+    // The declaration served to the model said "default 5" as a literal while
+    // the route held its own `DEFAULT_LIMIT = 5`. Two copies of one number, and
+    // the declaration is the model's only source of truth about the contract —
+    // so a change to the route's default would leave the model confidently
+    // misinformed, with nothing failing.
+    const { DEFAULT_TOOL_RESULT_ITEMS } = await import(
+      '~/server/services/blocks/tools/registry'
+    );
+    const decl = blockToolDeclarations().find((d) => d.function.name === 'search_models');
+    expect(decl, 'search_models must be declared').toBeTruthy();
+
+    const limitDesc = (
+      decl!.function.parameters as { properties: { limit?: { description?: string } } }
+    ).properties.limit?.description;
+    expect(limitDesc, 'the limit parameter must carry a description').toBeTruthy();
+    expect(
+      limitDesc,
+      'the declared default must be the constant the route applies'
+    ).toContain(`default ${DEFAULT_TOOL_RESULT_ITEMS}`);
+
+    // Positive control: the assertion above must be able to FAIL. A description
+    // that named a different number must not satisfy it.
+    expect(limitDesc).not.toContain(`default ${DEFAULT_TOOL_RESULT_ITEMS + 1}`);
+  });
+});
+
+describe('#426 item 4 — neutralizeAirLiterals is depth-bounded', () => {
+  /** Build `depth` levels of `{ a: { a: … { a: leaf } } }`. */
+  function nest(depth: number, leaf: unknown): unknown {
+    let out = leaf;
+    for (let i = 0; i < depth; i += 1) out = { a: out };
+    return out;
+  }
+
+  it('🔴 does not blow the stack on a deeply nested value', () => {
+    // Pre-change this recursed without a budget. At ~5k levels — which a small
+    // JSON body reaches trivially — that is a RangeError, i.e. a 500 from a
+    // scrubber whose whole job is to make a 400 body safe to return.
+    expect(() => neutralizeAirLiterals(nest(50_000, 'urn:air:leaf'))).not.toThrow();
+  });
+
+  it('🔴 the over-depth substitute carries NO caller content, so nothing survives unscrubbed', () => {
+    // The fail direction is the opposite of `containsAirReference`'s. That is a
+    // DETECTOR, so past its cap it returns TRUE (fail-closed). This is a
+    // SCRUBBER: merely stopping the recursion would RETURN the over-deep
+    // subtree untouched — fail-OPEN, the literal surviving because the input was
+    // nested. So the cap substitutes a first-party constant instead.
+    const scrubbed = neutralizeAirLiterals(nest(50_000, 'urn:air:deep-secret'));
+    expect(JSON.stringify(scrubbed).toLowerCase()).not.toContain('urn:air:');
+    expect(JSON.stringify(scrubbed)).toContain(NEUTRALIZE_DEPTH_PLACEHOLDER);
+  });
+
+  it('positive control: shallow values are still scrubbed normally, not replaced', () => {
+    // Without this, a cap set to 0 would pass both tests above while destroying
+    // the function's actual job.
+    expect(neutralizeAirLiterals('see urn:air:model@1')).toBe('see urn-air-model@1');
+    expect(neutralizeAirLiterals({ 'urn:air:k': ['urn:air:v'] })).toEqual({
+      'urn-air-k': ['urn-air-v'],
+    });
+    expect(JSON.stringify(neutralizeAirLiterals(nest(10, 'urn:air:x')))).not.toContain(
+      NEUTRALIZE_DEPTH_PLACEHOLDER
+    );
   });
 });

--- a/src/server/services/blocks/tools/__tests__/registry.test.ts
+++ b/src/server/services/blocks/tools/__tests__/registry.test.ts
@@ -564,6 +564,13 @@ describe('#426 — constants that must not drift', () => {
     // Positive control: the assertion above must be able to FAIL. A description
     // that named a different number must not satisfy it.
     expect(limitDesc).not.toContain(`default ${DEFAULT_TOOL_RESULT_ITEMS + 1}`);
+
+    // 🔴 AND THE DEFAULT MUST FIT UNDER THE CAP — the same drift class one axis
+    // over. A default above `MAX_TOOL_RESULT_ITEMS` would have the declaration
+    // tell the model "default 20, max 10" while `Math.min` in the route silently
+    // applies 10: the model is misinformed about the contract, and nothing else
+    // fails.
+    expect(DEFAULT_TOOL_RESULT_ITEMS).toBeLessThanOrEqual(MAX_TOOL_RESULT_ITEMS);
   });
 });
 
@@ -588,9 +595,37 @@ describe('#426 item 4 — neutralizeAirLiterals is depth-bounded', () => {
     // SCRUBBER: merely stopping the recursion would RETURN the over-deep
     // subtree untouched — fail-OPEN, the literal surviving because the input was
     // nested. So the cap substitutes a first-party constant instead.
-    const scrubbed = neutralizeAirLiterals(nest(50_000, 'urn:air:deep-secret'));
+    //
+    // 🔴 A MODEST OVER-DEPTH, NOT 50_000, AND THE DIFFERENCE IS THE WHOLE TEST.
+    // At 50_000 this assertion never evaluates against the fail-open mutant
+    // (`return value` past the cap): `JSON.stringify` blows the stack on the
+    // ~49.9k-deep subtree first, so the test goes red with a `RangeError` and
+    // cannot distinguish "returned unscrubbed" from "returned something
+    // un-stringifiable". At 200 the mutant is caught on the literal itself,
+    // which is what this test claims to check. The 50_000 case still has a home
+    // — the no-stack-blowout test above, where a RangeError IS the signal.
+    const scrubbed = neutralizeAirLiterals(nest(200, 'urn:air:deep-secret'));
     expect(JSON.stringify(scrubbed).toLowerCase()).not.toContain('urn:air:');
     expect(JSON.stringify(scrubbed)).toContain(NEUTRALIZE_DEPTH_PLACEHOLDER);
+  });
+
+  it('🔴 is safe under `.map()` — the depth parameter must not be reachable from a callback', () => {
+    // An exported `(value, depth = 0)` is arity-2 with a numeric second
+    // parameter, i.e. exactly `Array.prototype.map`'s callback shape — so
+    // `arr.map(neutralizeAirLiterals)` would pass the INDEX as the depth and
+    // silently replace every element past the cap with the placeholder, while
+    // `tsc` reports zero errors because the signature genuinely matches.
+    // Measured before the fix on a 200-element array: 129 scrubbed, 71
+    // destroyed. The public signature is single-arg so this cannot be written.
+    const arr = Array.from({ length: 200 }, () => 'urn:air:leak');
+    const mapped = arr.map(neutralizeAirLiterals);
+
+    expect(mapped).toHaveLength(200);
+    expect(
+      mapped.filter((v) => v === NEUTRALIZE_DEPTH_PLACEHOLDER),
+      'no element may be replaced by the depth placeholder — a flat array has no depth',
+    ).toHaveLength(0);
+    expect(mapped.every((v) => v === 'urn-air-leak')).toBe(true);
   });
 
   it('positive control: shallow values are still scrubbed normally, not replaced', () => {

--- a/src/server/services/blocks/tools/registry.ts
+++ b/src/server/services/blocks/tools/registry.ts
@@ -80,6 +80,20 @@ export const MAX_TOOL_RESULT_CHARS = 6_000;
 export const MAX_TOOL_RESULT_ITEMS = 10;
 
 /**
+ * How many results a call returns when it does not ask.
+ *
+ * 🔴 LIVES HERE SO THE NUMBER THE MODEL IS TOLD AND THE NUMBER THE ROUTE APPLIES
+ * ARE ONE VALUE. The `limit` declaration below tells the model "default 5"; the
+ * route applies its own default when `limit` is absent. Those were two separate
+ * literals, so changing the route's default would have left the declaration
+ * confidently describing the old one — and the declaration is the model's only
+ * source of truth about the contract, so the drift is invisible until a caller
+ * relies on it. Interpolated into the `.describe` below and imported by the
+ * route; do not write `5` in either place again.
+ */
+export const DEFAULT_TOOL_RESULT_ITEMS = 5;
+
+/**
  * Bounds on individual projected strings, so one pathological field cannot eat
  * the budget.
  *
@@ -142,13 +156,37 @@ export const AIR_URN_PREFIX_LOCAL = 'urn:air:';
  * AIRs to answer a question about a model.
  *
  * Case-insensitive, because the scan it defends against is.
+ *
+ * 🔴 DEPTH-CAPPED, AND THE FAIL DIRECTION IS THE OPPOSITE OF ITS SIBLING'S.
+ * `containsAirReference` (steps/index) is a DETECTOR, so past `AIR_SCAN_MAX_DEPTH`
+ * it returns TRUE — "I could not prove this carries no AIR". This is a SCRUBBER,
+ * and the mirror of that is not "stop recursing": stopping would RETURN the
+ * over-deep subtree unscrubbed, which is fail-OPEN — exactly the literal this
+ * function exists to remove, surviving because the input was nested. So at the
+ * cap it substitutes a constant that carries no caller content at all, which is
+ * trivially AIR-free.
+ *
+ * Without the cap, deep recursion on a caller-shaped value is a `RangeError` —
+ * the same crash class the sibling's cap exists for, and it would turn a 400
+ * into a 500. Not reachable through today's two call sites, which both pass a
+ * string: this is a property of an EXPORTED function, whose next caller is the
+ * one that would find out.
  */
-export function neutralizeAirLiterals<T>(value: T): T {
+const NEUTRALIZE_MAX_DEPTH = 128;
+
+/**
+ * What replaces a subtree past `NEUTRALIZE_MAX_DEPTH`. A first-party constant,
+ * so it cannot itself contain the literal being scrubbed.
+ */
+export const NEUTRALIZE_DEPTH_PLACEHOLDER = '[omitted: nested too deeply to scrub]';
+
+export function neutralizeAirLiterals<T>(value: T, depth = 0): T {
+  if (depth > NEUTRALIZE_MAX_DEPTH) return NEUTRALIZE_DEPTH_PLACEHOLDER as unknown as T;
   if (typeof value === 'string') {
     return value.replace(/urn:air:/gi, 'urn-air-') as unknown as T;
   }
   if (Array.isArray(value)) {
-    return value.map((v) => neutralizeAirLiterals(v)) as unknown as T;
+    return value.map((v) => neutralizeAirLiterals(v, depth + 1)) as unknown as T;
   }
   if (value !== null && typeof value === 'object') {
     const out: Record<string, unknown> = {};
@@ -156,7 +194,7 @@ export function neutralizeAirLiterals<T>(value: T): T {
       // Keys are scrubbed too: `containsAirReference` scans object KEYS, because
       // the orchestrator's own `additionalNetworks` / `WorkflowCost.fees` shapes
       // are AIR-keyed maps.
-      out[neutralizeAirLiterals(k)] = neutralizeAirLiterals(v);
+      out[neutralizeAirLiterals(k, depth + 1)] = neutralizeAirLiterals(v, depth + 1);
     }
     return out as unknown as T;
   }
@@ -326,7 +364,9 @@ const searchModelsArgs = z
       .min(1)
       .max(MAX_TOOL_RESULT_ITEMS)
       .optional()
-      .describe(`Maximum results to return (default 5, max ${MAX_TOOL_RESULT_ITEMS})`),
+      .describe(
+        `Maximum results to return (default ${DEFAULT_TOOL_RESULT_ITEMS}, max ${MAX_TOOL_RESULT_ITEMS})`
+      ),
   })
   .strict();
 

--- a/src/server/services/blocks/tools/registry.ts
+++ b/src/server/services/blocks/tools/registry.ts
@@ -180,13 +180,33 @@ const NEUTRALIZE_MAX_DEPTH = 128;
  */
 export const NEUTRALIZE_DEPTH_PLACEHOLDER = '[omitted: nested too deeply to scrub]';
 
-export function neutralizeAirLiterals<T>(value: T, depth = 0): T {
+export function neutralizeAirLiterals<T>(value: T): T {
+  return scrubAirLiterals(value, 0);
+}
+
+/**
+ * 🔴 THE DEPTH PARAMETER IS PRIVATE, AND THAT IS NOT STYLE — IT IS THE WHOLE
+ * REASON THIS HELPER EXISTS.
+ *
+ * An exported `neutralizeAirLiterals(value, depth = 0)` is arity-2 with a
+ * `number` second parameter, which is EXACTLY `Array.prototype.map`'s callback
+ * shape. So `names.map(neutralizeAirLiterals)` passes the INDEX as `depth`, and
+ * every element from index 129 on is replaced by the placeholder instead of
+ * being scrubbed — measured on a 200-element array: 129 scrubbed, 71 destroyed.
+ * `tsc` reports zero errors on it, because the signature genuinely matches.
+ *
+ * The damage is destructive rather than leaky (content is replaced, not
+ * exposed), but it is silent, un-typechecked, and the point-free `.map(fn)` form
+ * is the most natural way anyone would ever call this over a projected row set.
+ * Keeping the public signature single-arg makes the hazard unwritable.
+ */
+function scrubAirLiterals<T>(value: T, depth: number): T {
   if (depth > NEUTRALIZE_MAX_DEPTH) return NEUTRALIZE_DEPTH_PLACEHOLDER as unknown as T;
   if (typeof value === 'string') {
     return value.replace(/urn:air:/gi, 'urn-air-') as unknown as T;
   }
   if (Array.isArray(value)) {
-    return value.map((v) => neutralizeAirLiterals(v, depth + 1)) as unknown as T;
+    return value.map((v) => scrubAirLiterals(v, depth + 1)) as unknown as T;
   }
   if (value !== null && typeof value === 'object') {
     const out: Record<string, unknown> = {};
@@ -194,7 +214,7 @@ export function neutralizeAirLiterals<T>(value: T, depth = 0): T {
       // Keys are scrubbed too: `containsAirReference` scans object KEYS, because
       // the orchestrator's own `additionalNetworks` / `WorkflowCost.fees` shapes
       // are AIR-keyed maps.
-      out[neutralizeAirLiterals(k, depth + 1)] = neutralizeAirLiterals(v, depth + 1);
+      out[scrubAirLiterals(k, depth + 1)] = scrubAirLiterals(v, depth + 1);
     }
     return out as unknown as T;
   }

--- a/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
+++ b/src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
@@ -96,8 +96,35 @@ describe('block catalog endpoints — opaque-origin CORS wiring (PR #2681)', () 
       // `_request_duration_seconds`), which would merge tool traffic into
       // `models` with nothing anywhere reporting a fault.
       //
+      // 🔴 `endpoint` MAY BE A RESOLVER, so this reads the RESOLVED label rather
+      // than the raw opt. `/api/v1/blocks/tools` serves two materially different
+      // workloads on one path — a static declarations GET and a catalog-search
+      // POST — and passes a per-request function so the RED series can tell them
+      // apart. Comparing the raw opt against a string would compare a Function
+      // to `'tools'` and fail while the wiring is correct.
+      //
+      // Resolving does NOT weaken the guard: the mutant this line exists for
+      // (`'tools'` → `'models'`, which typechecks because `AppBlockEndpoint`
+      // contains both, and once survived all ~23.9k tests) is still caught,
+      // because a resolver returning `'models'` resolves to `'models'` here.
+      const resolveLabel = (endpoint: unknown, method: string) =>
+        typeof endpoint === 'function'
+          ? (endpoint as (req: { method: string }) => string)({ method })
+          : endpoint;
+
       // Index order is the import order above: models, images, tools.
-      expect(captured.map((opts) => opts.endpoint)).toEqual(['models', 'images', 'tools']);
+      expect(captured.map((opts) => resolveLabel(opts.endpoint, 'GET'))).toEqual([
+        'models',
+        'images',
+        'tools',
+      ]);
+
+      // 🔴 AND THE SPLIT ITSELF, pinned HERE because this is the file that
+      // enumerates the catalog routes' labels — a future edit that collapsed the
+      // resolver back to a bare `'tools'` would silently re-merge a free
+      // declarations read with a Meilisearch query in the same RED series, and
+      // the assertion above alone would still pass.
+      expect(resolveLabel(captured[2].endpoint, 'POST')).toBe('tools_call');
     }
   );
 });


### PR DESCRIPTION
Closes the six recorded follow-ups from #4472 and #4483 (clawgate **#426**). None was a defect in shipped behaviour — four are fixed, two are declined in writing. Base is `main`, not stacked on anything.

## Item 6 — the status gate cited the wrong subject

`moderation.ts`'s no-silent-success gate reads the **step's** status, while its justifying comment said the non-firing case is *"already explained by the workflow's own status"* — and the snapshot exposes the **workflow's**. Where those could disagree (a non-succeeded step under a `succeeded` workflow) the justification did not hold, and the silent-success shape the invariant exists to prevent would quietly return, defended by a sentence about a different field.

**They cannot disagree, so the gate is right and only the comment was wrong.** Established two ways:

- A workflow's status is **aggregated from its steps, worst-wins** — any non-terminal step leaves the workflow non-terminal, and among terminal steps a non-succeeded one dominates. So a workflow reads `succeeded` only when every step does. (That repo is private; the mechanism is stated in the comment rather than quoted.)
- **Live orchestrator data**, two 24h windows 30 days apart:

Two 24h windows 30 days apart, both showing an **empty** intersection — no `succeeded` workflow carried a non-succeeded step in either.

Each clause was confirmed to match **independently** first, so that emptiness is a measurement rather than a query that happened to match nothing. (Absolute volumes are deliberately not reproduced here — they are business data, they add nothing to the argument, and this repo is public.)

## Item 2 — fixed: the RED series merged a free GET with a catalog POST

One path, two workloads: `GET` returns static declarations from an in-process registry; `POST` runs a Meilisearch query and a catalog read. A single `endpoint: 'tools'` label merged them — and since the GET outnumbers the POST, the merged p95 tracked the cheap half. The series could not answer *"are tool CALLS degrading"*, which is the question it exists for.

`WithBlockScopeOpts.endpoint` now also accepts a resolver, resolved per request. **Additive by construction**: every other route still passes a string, and `opts.endpoint` was already read *inside* the per-request recorder, so no existing series changes. This route has never been on `release`, so relabelling it costs no history. Nothing is derived from `req.url` — the call site writes out every value it can produce, and the return type is still the strict union.

## Items 3, 4, 5 — fixed

- **3**: the wire `name` bound was a literal `64` against the chat step's module-private `MAX_TOOL_NAME_CHARS`. Exported and imported — one number. The same drift class the neighbouring `.regex(TOOL_NAME_PATTERN)` had already closed by importing rather than re-spelling.
- **4**: `neutralizeAirLiterals` had no depth budget while its sibling `containsAirReference` does. 🔴 **The fail direction is the opposite.** The sibling is a DETECTOR and returns `true` past its cap; this is a SCRUBBER, so merely stopping the recursion would return the over-deep subtree **unscrubbed** — fail-*open*, the literal surviving because the input was nested. Past the cap it now substitutes a first-party constant.
- **5** (half): the declaration told the model `"default 5"` as a literal while the route held its own `DEFAULT_LIMIT = 5`. The declaration is the model's only source of truth about the contract, so changing the route's default would have left the model confidently misinformed with nothing failing. Now one exported constant, interpolated into the declaration and imported by the route.

## Items 1 and 5b — declined, with the reasoning

- **1 — `GET` stays unrate-limited, but not for the reason the comment gave.** *"Cheap, no catalog access"* reasons about catalog cost and does not cover what a GET does still cost: a Redis revocation read and a `BlockScopeInvocation` insert. It stays unlimited because **(a)** that cost belongs to the **prefix** — every `/api/v1/blocks/*` route pays it, so metering this one GET addresses nothing — and **(b)** the only limiter available is the **shared catalog budget**, so charging a static declarations read against it would take search budget away from a block for fetching the contract it needs in order to search. The comment now says that.
- **5b — the redundant `Math.min` stays.** It is redundant *today* only because a schema in a **different module** bounds `limit`. It is the last bound before the value becomes a Meilisearch `limit`; deleting it would make this route's page-size safety a property of a file it does not own. A redundant clamp costs one comparison; removing a bound is the wrong direction.

## Red → green

Six new tests, each watched fail at `origin/main`:

| test | failure at base |
|---|---|
| item 3 — name bound imported | `expected 'undefined' to be 'number'` |
| item 5 — declared default == applied default | `expected '…default 5…' to contain 'default undefined'` |
| item 4 — no stack blowout | **`RangeError: Maximum call stack size exceeded`** |
| item 4 — over-depth substitute | placeholder absent |
| item 2 — per-method label | `expected +0 to be 1` |
| item 2 — split is by method | `expected +0 to be 2` |

**6 failed / 44 passed at base → 50 passed at HEAD.** `typecheck` 0 errors.

Three further tests are **positive controls, not regression coverage**, and are labelled as such in the file: two GETs must both land on `tools` (so the split is by METHOD, not per-call); a plain string endpoint must still work (a regression there would break the whole block REST surface's metrics at once); and shallow values must still be scrubbed normally — which a depth cap of `0` would fail while satisfying both other depth tests.

## AC4 — no guard weakened

The maturity clamp in `/api/v1/blocks/tools`' handler is untouched and still applied unconditionally before the only catalog path. Nothing in this change moves it, and the header explaining that it is **not** inherited from the `/api/v1/blocks/*` prefix is unchanged.

## Reproducing locally

🔴 A fresh worktree does **not** populate the `event-engine-common` submodule, which produces 12 `TS2307`s in files this change never touches — it reads as "the base branch is red". `git submodule update --init event-engine-common` first.

## Not verified

No live request was issued against the deployed route: this surface is on `main` and **not on `release`**, so there is nothing deployed to exercise. The item-2 label split is verified through the real middleware in jsdom, not against a running Prometheus.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HBKAiYKVo3RRacJ5gBTLU

---

## Second commit — CI caught a real defect in the first

`Unit tests (1)` went red on `fd9b18ef`: 380 files / 6104 tests, **exactly one** failing at 3m37s against comparable sibling-shard times. One failed assertion inflates one test; load inflates the whole run — so this was real, not a flake.

```
FAIL src/tests/api/v1/blocks/catalog-cors-wiring.test.ts
AssertionError: expected [ 'models', 'images', ...(1) ] to deeply equal [ 'models', 'images', 'tools' ]
```

That file enumerates the catalog routes' `endpoint` labels by reading the **raw opts** each module hands `withBlockScope`. Making the tools label a per-request resolver meant it compared a `Function` against `'tools'`. The wiring was correct; the guard could not see it.

This is the hazard class this PR's own description listed as worth hunting — something keyed to the old exact label set — and it was not swept for before the first push. The local run that preceded it was **two test files**; that shard alone is 380. Naming the population would have exposed the gap: the files that were *changed* were run, not the files that *read* what changed.

The guard now resolves the label, and is **strengthened rather than loosened**:

- the mutant it exists for is still caught — `'tools'` → `'models'` typechecks (`AppBlockEndpoint` contains both) and once survived all ~23.9k tests; a resolver returning `'models'` resolves to `'models'` and fails;
- it additionally pins the split: the POST arm must resolve to `'tools_call'`. Collapsing back to a bare `endpoint: 'tools'` fails with `expected 'tools' to be 'tools_call'` — watched on the mutated tree. Without that second assertion a bare string satisfies the first one, and a future edit could silently re-merge the free GET with the catalog POST into one series, which is the defect this PR set out to fix.

Affected batch re-run: **5 files / 103 tests pass** — `catalog-cors-wiring`, `block-scope.normalize-endpoint`, `block-scope.metrics`, the tools registry, and `tools-endpoint`. `normalize-endpoint` is in there deliberately: it pins the **audit-row** endpoint, which comes from `normalizeEndpoint(req.url)` and is unaffected by the label change — asserted rather than assumed.

CI at `b2620fa9`: **19 checks, 18 pass / 1 skip / 0 fail**, stable across two reads.

