### PR TITLE
fix(app-blocks): a reject no longer deletes the developer's draft listing

### DIFF
--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -334,6 +334,9 @@ export function AppListingsModerationTable({
               kind: row.kind,
               hasPendingRequest: row.pendingRequest != null,
               appBlockId: row.appBlockId,
+              // NOT `pendingRequest != null` — that reads the AppListingPublishRequest
+              // relation, which is structurally null for an on-site pre-approval draft.
+              hasPendingBlockRequest: row.hasPendingBlockRequest,
             });
             return (
               <Fragment key={row.id}>
@@ -682,8 +685,9 @@ function ListingModActionModal({
       destructive={destructive}
       destructiveWarning={
         <Text size="sm">
-          Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
-          (with the slug snapshot) is kept. This cannot be undone.
+          Purge PERMANENTLY deletes this listing and its screenshots + reports, and{' '}
+          <b>releases the store address &quot;{row.slug}&quot; for anyone else to claim</b>. The
+          audit event (with the slug snapshot) is kept. This cannot be undone.
         </Text>
       }
       confirmSlug={destructive ? row.slug : undefined}

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -336,7 +336,14 @@ export function AppListingsModerationTable({
               appBlockId: row.appBlockId,
               // NOT `pendingRequest != null` — that reads the AppListingPublishRequest
               // relation, which is structurally null for an on-site pre-approval draft.
-              hasPendingBlockRequest: row.hasPendingBlockRequest,
+              //
+              // `?? true` because ABSENT MUST MEAN "assume under review". The field is new, so
+              // a client holding a bundle from either side of a deploy — or any future producer
+              // of this DTO — can hand us `undefined`, and `!undefined` is truthy, i.e. the
+              // permissive direction on the input to a DESTRUCTIVE affordance. The service
+              // makes the same choice one boundary in (its empty-set default is documented as
+              // permissive and restricted to this caller); this is that reasoning applied here.
+              hasPendingBlockRequest: row.hasPendingBlockRequest ?? true,
             });
             return (
               <Fragment key={row.id}>

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -28,7 +28,7 @@ import {
   isDestructiveListingModAction,
   listingKindChip,
   listingModActionLabel,
-  listingModActions,
+  listingModActionsForRow,
   type ListingModAction,
 } from '~/components/Apps/appListingModerationTableView';
 import {
@@ -329,22 +329,10 @@ export function AppListingsModerationTable({
             // Badge reads the EFFECTIVE status ("Pending" for a draft-with-pending),
             // matching the bucket. Actions below intentionally keep the REAL status.
             const statusChip = listingStatusChip(effectiveModerationStatus(row));
-            const actions = listingModActions({
-              status: row.status,
-              kind: row.kind,
-              hasPendingRequest: row.pendingRequest != null,
-              appBlockId: row.appBlockId,
-              // NOT `pendingRequest != null` — that reads the AppListingPublishRequest
-              // relation, which is structurally null for an on-site pre-approval draft.
-              //
-              // `?? true` because ABSENT MUST MEAN "assume under review". The field is new, so
-              // a client holding a bundle from either side of a deploy — or any future producer
-              // of this DTO — can hand us `undefined`, and `!undefined` is truthy, i.e. the
-              // permissive direction on the input to a DESTRUCTIVE affordance. The service
-              // makes the same choice one boundary in (its empty-set default is documented as
-              // permissive and restricted to this caller); this is that reasoning applied here.
-              hasPendingBlockRequest: row.hasPendingBlockRequest ?? true,
-            });
+            // Row-shaped so the field mapping and its safe defaults live in a PURE function the
+            // unit tier can reach — inline here, nothing could test them (see the 🔴 note on
+            // `listingModActionsForRow`).
+            const actions = listingModActionsForRow(row);
             return (
               <Fragment key={row.id}>
                 <Table.Tr data-testid={`apps-mod-listing-row-${row.slug}`}>

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -333,6 +333,7 @@ export function AppListingsModerationTable({
               status: row.status,
               kind: row.kind,
               hasPendingRequest: row.pendingRequest != null,
+              appBlockId: row.appBlockId,
             });
             return (
               <Fragment key={row.id}>

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -1574,8 +1574,9 @@ function ReportActionModal({
       destructive={destructive}
       destructiveWarning={
         <Text size="sm">
-          Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
-          (with the slug snapshot) is kept. This cannot be undone.
+          Purge PERMANENTLY deletes this listing and its screenshots + reports, and{' '}
+          <b>releases its store address for anyone else to claim</b>. The audit event (with the slug
+          snapshot) is kept. This cannot be undone.
         </Text>
       }
       extraSlot={

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -9,6 +9,7 @@ import {
   listingKindChip,
   listingModActionLabel,
   listingModActions,
+  listingModActionsForRow,
   type ListingModAction,
 } from '~/components/Apps/appListingModerationTableView';
 
@@ -435,5 +436,65 @@ describe('effectiveModerationStatus', () => {
     expect(effectiveModerationStatus({ status: 'removed', pendingRequest: pendingReq })).toBe(
       'removed'
     );
+  });
+});
+
+/**
+ * 🔴 `listingModActionsForRow` — the DTO→args mapping and its SAFE DEFAULT.
+ *
+ * This lived inline in `AppListingsModerationTable.tsx` and was untestable there: the browser
+ * tier is the only suite that renders that component, it has no on-site orphan-draft fixture,
+ * and on this host it cannot run at all. Measured — inverting the default to the permissive
+ * direction left 1601 files / 25,069 tests green. These are the tests that make the mutation die.
+ */
+describe('listingModActionsForRow — DTO mapping and the fail-safe default', () => {
+  const draftRow = (over: Record<string, unknown> = {}) => ({
+    status: 'draft',
+    kind: 'onsite',
+    appBlockId: null,
+    pendingRequest: null,
+    hasPendingBlockRequest: false,
+    ...over,
+  });
+
+  it('offers Purge for an orphan draft with the flag explicitly FALSE', () => {
+    expect(listingModActionsForRow(draftRow())).toEqual(['message-owner', 'purge']);
+  });
+
+  it('withholds it when the flag is TRUE', () => {
+    expect(listingModActionsForRow(draftRow({ hasPendingBlockRequest: true }))).toEqual([
+      'message-owner',
+    ]);
+  });
+
+  /**
+   * 🔴 THE DEFAULT, and the only case that distinguishes `?? true` from `?? false`. A client
+   * bundle from either side of a deploy can hand us a row without this field; `!undefined` is
+   * truthy, so an unnormalized read would OFFER the destructive action on a listing that may be
+   * under live review.
+   */
+  it('withholds it when the flag is ABSENT — absent means assume under review', () => {
+    expect(listingModActionsForRow(draftRow({ hasPendingBlockRequest: undefined }))).toEqual([
+      'message-owner',
+    ]);
+  });
+
+  it('withholds it when the flag is NULL (a DTO that serialised the absence)', () => {
+    expect(listingModActionsForRow(draftRow({ hasPendingBlockRequest: null }))).toEqual([
+      'message-owner',
+    ]);
+  });
+
+  it('derives hasPendingRequest from the pendingRequest object, not a boolean field', () => {
+    // Off-site pending row: the mapping must turn a non-null object into `true` so Review shows.
+    expect(
+      listingModActionsForRow({
+        status: 'pending',
+        kind: 'offsite',
+        appBlockId: null,
+        pendingRequest: { id: 'alpr_1' },
+        hasPendingBlockRequest: false,
+      })
+    ).toEqual(['review', 'message-owner']);
   });
 });

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -34,6 +34,7 @@ describe('listingModActions — off-site rows', () => {
         status: 'pending',
         kind: 'offsite',
         hasPendingRequest: true,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['review', 'message-owner']);
@@ -45,6 +46,7 @@ describe('listingModActions — off-site rows', () => {
         status: 'approved',
         kind: 'offsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner', 'reset-to-pending', 'hide']);
@@ -56,6 +58,7 @@ describe('listingModActions — off-site rows', () => {
         status: 'removed',
         kind: 'offsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner', 'relist', 'claim', 'purge']);
@@ -67,6 +70,7 @@ describe('listingModActions — off-site rows', () => {
         status: 'draft',
         kind: 'offsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner']);
@@ -75,6 +79,7 @@ describe('listingModActions — off-site rows', () => {
         status: 'draft',
         kind: 'offsite',
         hasPendingRequest: true,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['review', 'message-owner']);
@@ -86,6 +91,7 @@ describe('listingModActions — off-site rows', () => {
         status: 'rejected',
         kind: 'offsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner']);
@@ -99,6 +105,7 @@ describe('listingModActions — on-site rows hide the off-site-only actions', ()
         status: 'approved',
         kind: 'onsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: 'ablk_live',
       })
     ).toEqual(['message-owner', 'reset-to-pending', 'hide']);
@@ -110,6 +117,7 @@ describe('listingModActions — on-site rows hide the off-site-only actions', ()
         status: 'removed',
         kind: 'onsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: 'ablk_live',
       })
     ).toEqual(['message-owner', 'relist']);
@@ -121,6 +129,7 @@ describe('listingModActions — on-site rows hide the off-site-only actions', ()
         status: 'pending',
         kind: 'onsite',
         hasPendingRequest: true,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner']);
@@ -147,20 +156,50 @@ describe('listingModActions — on-site orphan pre-approval draft offers Purge',
         status: 'draft',
         kind: 'onsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner', 'purge']);
   });
 
-  it('NOT while a request is still pending — that submission is under review', () => {
+  /**
+   * 🔴 THE TERM THAT WAS INERT. `hasPendingRequest` comes from the
+   * `AppListingPublishRequest` relation, whose `appListingId` is "On-site: NULL until
+   * approve" — so for an on-site pre-approval draft it is ALWAYS false, and an earlier
+   * revision of this branch gated on it. That guard could never fire, and the mod table
+   * offered Purge on submissions under active review. The real signal is
+   * `hasPendingBlockRequest`, hydrated by a slug-keyed lookup against
+   * `AppBlockPublishRequest`.
+   *
+   * The two cases below are the proof: gating on the WRONG field would let case 1 through.
+   */
+  it('NOT while the BLOCK request is still pending — that submission is under review', () => {
+    expect(
+      listingModActions({
+        status: 'draft',
+        kind: 'onsite',
+        // The inert field says "nothing pending"…
+        hasPendingRequest: false,
+        // …while the real one says otherwise. Purge must be withheld.
+        hasPendingBlockRequest: true,
+        appBlockId: null,
+      })
+    ).toEqual(['message-owner']);
+  });
+
+  it('`hasPendingRequest` alone does NOT withhold purge — it is the wrong table', () => {
+    // Not an endorsement of the state (it is unreachable for this shape); it pins that the
+    // branch keys on `hasPendingBlockRequest` and nothing else, so a future edit that swaps
+    // the fields back is a red test rather than a silent regression.
     expect(
       listingModActions({
         status: 'draft',
         kind: 'onsite',
         hasPendingRequest: true,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
-    ).toEqual(['message-owner']);
+    ).toEqual(['message-owner', 'purge']);
   });
 
   it('NOT once it has a backing AppBlock — it reached approve', () => {
@@ -169,6 +208,7 @@ describe('listingModActions — on-site orphan pre-approval draft offers Purge',
         status: 'draft',
         kind: 'onsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: 'ablk_live',
       })
     ).toEqual(['message-owner']);
@@ -180,6 +220,7 @@ describe('listingModActions — on-site orphan pre-approval draft offers Purge',
         status: 'draft',
         kind: 'offsite',
         hasPendingRequest: false,
+        hasPendingBlockRequest: false,
         appBlockId: null,
       })
     ).toEqual(['message-owner']);
@@ -208,7 +249,7 @@ describe('listingModActions — the owner-message action is offered on EVERY row
   const STATUSES = ['draft', 'pending', 'approved', 'rejected', 'removed'] as const;
   const KINDS = ['onsite', 'offsite'] as const;
 
-  it('appears for every status × kind × pending-request × backing-block combination', () => {
+  it('appears for every status × kind × pending-request × block-request × backing-block combination', () => {
     const missing: string[] = [];
     let walked = 0;
     for (const status of STATUSES) {
@@ -218,19 +259,29 @@ describe('listingModActions — the owner-message action is offered on EVERY row
           // part of the cross product too — otherwise the sweep would pin only one of the
           // two shapes the new branch distinguishes.
           for (const appBlockId of [null, 'ablk_live']) {
-            walked++;
-            const actions = listingModActions({ status, kind, hasPendingRequest, appBlockId });
-            if (!actions.includes('message-owner')) {
-              missing.push(`${kind}/${status}/pending=${hasPendingRequest}/block=${appBlockId}`);
+            for (const hasPendingBlockRequest of [true, false]) {
+              walked++;
+              const actions = listingModActions({
+                status,
+                kind,
+                hasPendingRequest,
+                hasPendingBlockRequest,
+                appBlockId,
+              });
+              if (!actions.includes('message-owner')) {
+                missing.push(
+                  `${kind}/${status}/pending=${hasPendingRequest}/blockReq=${hasPendingBlockRequest}/block=${appBlockId}`
+                );
+              }
             }
           }
         }
       }
     }
-    // Positive control on the enumeration itself: 5 statuses × 2 kinds × 2 × 2 = 40 cases
+    // Positive control on the enumeration itself: 5 statuses × 2 kinds × 2 × 2 × 2 = 80 cases
     // were actually walked, so an empty `missing` is a real sweep and not an empty loop.
-    expect(walked).toBe(40);
-    expect(STATUSES.length * KINDS.length * 2 * 2).toBe(40);
+    expect(walked).toBe(80);
+    expect(STATUSES.length * KINDS.length * 2 * 2 * 2).toBe(80);
     expect(missing).toEqual([]);
   });
 

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -30,34 +30,64 @@ const pendingReq = {
 describe('listingModActions — off-site rows', () => {
   it('pending (with a pending request) → Review + Message owner', () => {
     expect(
-      listingModActions({ status: 'pending', kind: 'offsite', hasPendingRequest: true })
+      listingModActions({
+        status: 'pending',
+        kind: 'offsite',
+        hasPendingRequest: true,
+        appBlockId: null,
+      })
     ).toEqual(['review', 'message-owner']);
   });
 
   it('approved → Reset to pending + Hide', () => {
     expect(
-      listingModActions({ status: 'approved', kind: 'offsite', hasPendingRequest: false })
+      listingModActions({
+        status: 'approved',
+        kind: 'offsite',
+        hasPendingRequest: false,
+        appBlockId: null,
+      })
     ).toEqual(['message-owner', 'reset-to-pending', 'hide']);
   });
 
   it('removed → Relist + Claim + Purge', () => {
     expect(
-      listingModActions({ status: 'removed', kind: 'offsite', hasPendingRequest: false })
+      listingModActions({
+        status: 'removed',
+        kind: 'offsite',
+        hasPendingRequest: false,
+        appBlockId: null,
+      })
     ).toEqual(['message-owner', 'relist', 'claim', 'purge']);
   });
 
   it('draft → no lifecycle action (unless a pending request offers Review)', () => {
     expect(
-      listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: false })
+      listingModActions({
+        status: 'draft',
+        kind: 'offsite',
+        hasPendingRequest: false,
+        appBlockId: null,
+      })
     ).toEqual(['message-owner']);
     expect(
-      listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: true })
+      listingModActions({
+        status: 'draft',
+        kind: 'offsite',
+        hasPendingRequest: true,
+        appBlockId: null,
+      })
     ).toEqual(['review', 'message-owner']);
   });
 
   it('rejected → read-only apart from Message owner', () => {
     expect(
-      listingModActions({ status: 'rejected', kind: 'offsite', hasPendingRequest: false })
+      listingModActions({
+        status: 'rejected',
+        kind: 'offsite',
+        hasPendingRequest: false,
+        appBlockId: null,
+      })
     ).toEqual(['message-owner']);
   });
 });
@@ -65,20 +95,98 @@ describe('listingModActions — off-site rows', () => {
 describe('listingModActions — on-site rows hide the off-site-only actions', () => {
   it('approved on-site → Reset to pending + Hide (reset is now dual-kind, #3165)', () => {
     expect(
-      listingModActions({ status: 'approved', kind: 'onsite', hasPendingRequest: false })
+      listingModActions({
+        status: 'approved',
+        kind: 'onsite',
+        hasPendingRequest: false,
+        appBlockId: 'ablk_live',
+      })
     ).toEqual(['message-owner', 'reset-to-pending', 'hide']);
   });
 
   it('removed on-site → Relist ONLY (no claim / purge)', () => {
     expect(
-      listingModActions({ status: 'removed', kind: 'onsite', hasPendingRequest: false })
+      listingModActions({
+        status: 'removed',
+        kind: 'onsite',
+        hasPendingRequest: false,
+        appBlockId: 'ablk_live',
+      })
     ).toEqual(['message-owner', 'relist']);
   });
 
   it('pending on-site → NO Review (approve/reject is off-site only; onsite uses its own queue)', () => {
     expect(
-      listingModActions({ status: 'pending', kind: 'onsite', hasPendingRequest: true })
+      listingModActions({
+        status: 'pending',
+        kind: 'onsite',
+        hasPendingRequest: true,
+        appBlockId: null,
+      })
     ).toEqual(['message-owner']);
+  });
+});
+
+/**
+ * 🔴 THE ON-SITE ORPHAN PRE-APPROVAL DRAFT — the one on-site shape that DOES offer Purge, and
+ * the reason this branch exists at all (clawgate #302).
+ *
+ * `rejectRequest` no longer deletes the pre-approval draft, so a rejected-and-abandoned first
+ * submission sits in this table holding its slug forever. `delistListing` is status-guarded to
+ * `{approved, removed}` and cannot touch a `draft`, so Purge here is the ONLY way a moderator
+ * can reclaim that slug. A row offering nothing but "message owner" is the state the
+ * reject-time delete used to prevent — the service arm existing is not enough if the operator
+ * cannot reach it.
+ *
+ * The three refusals below are one-term-off from the purgeable shape, so each pins its own term.
+ */
+describe('listingModActions — on-site orphan pre-approval draft offers Purge', () => {
+  it('draft + never approved + no pending request → Purge', () => {
+    expect(
+      listingModActions({
+        status: 'draft',
+        kind: 'onsite',
+        hasPendingRequest: false,
+        appBlockId: null,
+      })
+    ).toEqual(['message-owner', 'purge']);
+  });
+
+  it('NOT while a request is still pending — that submission is under review', () => {
+    expect(
+      listingModActions({
+        status: 'draft',
+        kind: 'onsite',
+        hasPendingRequest: true,
+        appBlockId: null,
+      })
+    ).toEqual(['message-owner']);
+  });
+
+  it('NOT once it has a backing AppBlock — it reached approve', () => {
+    expect(
+      listingModActions({
+        status: 'draft',
+        kind: 'onsite',
+        hasPendingRequest: false,
+        appBlockId: 'ablk_live',
+      })
+    ).toEqual(['message-owner']);
+  });
+
+  it('NOT for an off-site draft — that arm is unchanged and gated on `removed`', () => {
+    expect(
+      listingModActions({
+        status: 'draft',
+        kind: 'offsite',
+        hasPendingRequest: false,
+        appBlockId: null,
+      })
+    ).toEqual(['message-owner']);
+  });
+
+  it('Purge stays the confirm-gated destructive action', () => {
+    expect(isDestructiveListingModAction('purge')).toBe(true);
   });
 });
 
@@ -100,21 +208,29 @@ describe('listingModActions — the owner-message action is offered on EVERY row
   const STATUSES = ['draft', 'pending', 'approved', 'rejected', 'removed'] as const;
   const KINDS = ['onsite', 'offsite'] as const;
 
-  it('appears for every status × kind × pending-request combination', () => {
+  it('appears for every status × kind × pending-request × backing-block combination', () => {
     const missing: string[] = [];
+    let walked = 0;
     for (const status of STATUSES) {
       for (const kind of KINDS) {
         for (const hasPendingRequest of [true, false]) {
-          const actions = listingModActions({ status, kind, hasPendingRequest });
-          if (!actions.includes('message-owner')) {
-            missing.push(`${kind}/${status}/pending=${hasPendingRequest}`);
+          // `appBlockId` joined the input for the orphan-draft Purge branch, so it is now
+          // part of the cross product too — otherwise the sweep would pin only one of the
+          // two shapes the new branch distinguishes.
+          for (const appBlockId of [null, 'ablk_live']) {
+            walked++;
+            const actions = listingModActions({ status, kind, hasPendingRequest, appBlockId });
+            if (!actions.includes('message-owner')) {
+              missing.push(`${kind}/${status}/pending=${hasPendingRequest}/block=${appBlockId}`);
+            }
           }
         }
       }
     }
-    // Positive control on the enumeration itself: 5 statuses × 2 kinds × 2 = 20 cases
+    // Positive control on the enumeration itself: 5 statuses × 2 kinds × 2 × 2 = 40 cases
     // were actually walked, so an empty `missing` is a real sweep and not an empty loop.
-    expect(STATUSES.length * KINDS.length * 2).toBe(20);
+    expect(walked).toBe(40);
+    expect(STATUSES.length * KINDS.length * 2 * 2).toBe(40);
     expect(missing).toEqual([]);
   });
 

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -84,6 +84,8 @@ export function listingModActions(input: {
   status: string;
   kind: string;
   hasPendingRequest: boolean;
+  /** `null` ⇒ never approved. Only used to identify an on-site orphan draft (see below). */
+  appBlockId: string | null;
 }): ListingModAction[] {
   const offsite = input.kind === 'offsite';
   const actions: ListingModAction[] = [];
@@ -106,6 +108,30 @@ export function listingModActions(input: {
       actions.push('claim');
       actions.push('purge');
     }
+  }
+
+  // 🔴 ON-SITE ORPHAN PRE-APPROVAL DRAFT — the ONLY on-site shape `purgeListing` accepts, and
+  // the only way a moderator can reclaim its slug.
+  //
+  // A `rejectRequest` no longer deletes this row (clawgate #302), so a rejected-and-abandoned
+  // first submission sits here holding `app_listings_slug_key` forever. `delistListing` is
+  // status-guarded to `{approved, removed}` and cannot touch a `draft`, so WITHOUT this branch
+  // the row is visible in this table with no action but "message owner" — which is exactly the
+  // state the reject-time delete used to prevent. The service arm existing is not enough; the
+  // operator has to be able to reach it.
+  //
+  // The three terms mirror the service predicate. `appBlockId === null` means never approved;
+  // `!hasPendingRequest` means not under review (purging a live submission would release the
+  // slug out from under a request joined to it only by slug). Shadow revisions need no term
+  // here — `listAllListingsForModeration` already filters `revisionOfId: null`, so one can
+  // never be a row in this table.
+  if (
+    !offsite &&
+    input.status === 'draft' &&
+    input.appBlockId === null &&
+    !input.hasPendingRequest
+  ) {
+    actions.push('purge');
   }
   return actions;
 }

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -11,8 +11,12 @@
  *     `resetListingToPending`, on-site through `resetOnsiteListingToPending` (which
  *     suspends the backing block + re-queues the block review). The caller routes by
  *     kind; the action is offered for an approved listing of EITHER kind.
- *   - `claim` / `purge` are OFF-SITE ONLY (the service raises NOT_FOUND for an
- *     on-site listing).
+ *   - `claim` is OFF-SITE ONLY (the service raises NOT_FOUND for an on-site listing).
+ *   - `purge` is OFF-SITE at `removed`, PLUS one on-site shape: an ORPHAN PRE-APPROVAL
+ *     DRAFT (never approved, not a shadow, no live block request). That arm exists
+ *     because `rejectRequest` no longer deletes the draft (clawgate #302), so it is the
+ *     only way to reclaim an abandoned submission's slug. Every OTHER on-site listing
+ *     still raises NOT_FOUND.
  *   - `hide` (delist) / `relist` are DUAL-KIND (they flip the on-site AppBlock too).
  *   - `review` opens the existing off-site review modal (approve/reject the pending
  *     request) → off-site only, and only when a pending request exists.
@@ -62,9 +66,11 @@ export type ListingModAction =
  *   - `message-owner`: EVERY row, EVERY status, BOTH kinds. See below.
  *   - `approved` → `reset-to-pending` (dual-kind — off-site + on-site re-queue) +
  *     `hide` (delist, dual-kind).
- *   - `removed`  → `relist` (dual-kind) + `claim` + `purge` (both off-site only).
- *   - `draft` / `rejected` → no LIFECYCLE action (read-only) beyond `message-owner`,
- *     unless a pending request makes `review` available.
+ *   - `removed`  → `relist` (dual-kind) + `claim` + `purge` (both off-site only here).
+ *   - `draft` → `purge` for an ON-SITE orphan pre-approval draft (never approved, no live
+ *     block request); otherwise no LIFECYCLE action beyond `message-owner`, unless a
+ *     pending request makes `review` available.
+ *   - `rejected` → no LIFECYCLE action beyond `message-owner`.
  *
  * 🔴 `message-owner` IS UNCONDITIONAL, and that is a claim about the SERVER, not a
  * preference. `appListings.messageAppOwner` resolves its recipient through
@@ -86,6 +92,11 @@ export function listingModActions(input: {
   hasPendingRequest: boolean;
   /** `null` ⇒ never approved. Only used to identify an on-site orphan draft (see below). */
   appBlockId: string | null;
+  /**
+   * A live `AppBlockPublishRequest` for this slug — the ON-SITE "under review" signal, which
+   * `hasPendingRequest` structurally cannot carry. See the 🔴 note at the purge branch.
+   */
+  hasPendingBlockRequest: boolean;
 }): ListingModAction[] {
   const offsite = input.kind === 'offsite';
   const actions: ListingModAction[] = [];
@@ -120,16 +131,21 @@ export function listingModActions(input: {
   // state the reject-time delete used to prevent. The service arm existing is not enough; the
   // operator has to be able to reach it.
   //
-  // The three terms mirror the service predicate. `appBlockId === null` means never approved;
-  // `!hasPendingRequest` means not under review (purging a live submission would release the
-  // slug out from under a request joined to it only by slug). Shadow revisions need no term
-  // here — `listAllListingsForModeration` already filters `revisionOfId: null`, so one can
-  // never be a row in this table.
+  // The terms mirror the service. `appBlockId === null` means never approved. Shadow
+  // revisions need no term — `listAllListingsForModeration` already filters
+  // `revisionOfId: null`, so one can never be a row in this table.
+  //
+  // 🔴 "NOT UNDER REVIEW" READS `hasPendingBlockRequest`, **NOT** `hasPendingRequest`, and the
+  // difference is the whole guard. `hasPendingRequest` is derived from the
+  // `AppListingPublishRequest` relation, whose `appListingId` is "On-site: NULL until approve"
+  // — so for an on-site pre-approval draft it is ALWAYS false, and gating on it offered Purge
+  // on submissions that were actively under review. The live submission behind such a row is
+  // an `AppBlockPublishRequest` joined by SLUG, which is what `hasPendingBlockRequest` carries.
   if (
     !offsite &&
     input.status === 'draft' &&
     input.appBlockId === null &&
-    !input.hasPendingRequest
+    !input.hasPendingBlockRequest
   ) {
     actions.push('purge');
   }

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -152,6 +152,40 @@ export function listingModActions(input: {
   return actions;
 }
 
+/**
+ * 🔴 THE ROW-SHAPED ENTRY POINT, and the reason it exists is testability, not convenience.
+ *
+ * The normalization below used to live inline in `AppListingsModerationTable.tsx`. Nothing could
+ * test it there: the browser tier is the only suite that renders that component, it has no
+ * on-site orphan-draft fixture, and (on this host) it cannot run at all. Measured — inverting
+ * the default to the PERMISSIVE direction left the entire unit tier, 1601 files and 25,069
+ * tests, green. A guard nothing can kill is not a guard.
+ *
+ * Moving it here makes it a pure function the unit tier reaches, so the mutation dies.
+ *
+ * 🔴 ABSENT MEANS "ASSUME UNDER REVIEW". `hasPendingBlockRequest` is newer than some clients
+ * that will call this — a bundle from either side of a deploy, or any future producer of the
+ * DTO — and `!undefined` is truthy, i.e. the permissive direction on the input to a DESTRUCTIVE
+ * affordance. Defaulting to `true` withholds Purge when we cannot tell, which is the only safe
+ * direction: the cost of a wrongly-withheld Purge is a moderator retrying after a refresh; the
+ * cost of a wrongly-offered one is a hard delete of a listing under live review.
+ */
+export function listingModActionsForRow(row: {
+  status: string;
+  kind: string;
+  appBlockId: string | null;
+  pendingRequest: unknown | null;
+  hasPendingBlockRequest?: boolean | null;
+}): ListingModAction[] {
+  return listingModActions({
+    status: row.status,
+    kind: row.kind,
+    hasPendingRequest: row.pendingRequest != null,
+    appBlockId: row.appBlockId,
+    hasPendingBlockRequest: row.hasPendingBlockRequest ?? true,
+  });
+}
+
 /** Whether an action is the destructive one that must be confirmed before firing. */
 export function isDestructiveListingModAction(action: ListingModAction): boolean {
   return action === 'purge';

--- a/src/server/notifications/__tests__/app-listing.emit-union-seam.test.ts
+++ b/src/server/notifications/__tests__/app-listing.emit-union-seam.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { appListingNotifications } from '~/server/notifications/app-listing.notifications';
+
+/**
+ * 🔴 THE SEAM: `AppListingOwnerNotificationType` (what the services are ALLOWED to emit) and
+ * the key set of `appListingNotifications` (what can be RENDERED) are related by nothing but
+ * hand-editing.
+ *
+ * `notifyAppListingOwner` types its `type` against that union, but `createNotification` takes a
+ * free-form string — so a member added to the union with no processor entry compiles,
+ * typechecks, and emits a notification with no `prepareMessage`. Both halves also live in
+ * different files, so no single review diff necessarily shows both.
+ *
+ * This is a RELATIONSHIP guard, and it fails in BOTH directions on purpose: a union member with
+ * no processor (emit something unrenderable) and a processor key outside the union (dead entry,
+ * or a rename that silently orphaned its emitter). A one-directional check would pass while
+ * half the drift it exists to catch sat in the tree.
+ *
+ * Written when `app-listing-purged` took the set from four to five by hand and got it right —
+ * i.e. before it cost anything, not after.
+ */
+
+const NOTIFY_SRC = path.resolve(__dirname, '../../services/blocks/app-listing-notify.ts');
+
+/**
+ * The union is a TYPE, so it is erased at runtime and cannot be read by import. Parse it out of
+ * the source instead.
+ *
+ * 🔴 The parse is itself asserted below rather than trusted: a regex that silently matched
+ * nothing would yield an empty union, every `⊆` check would pass vacuously, and the guard would
+ * report success while comparing nothing. That is the failure mode this whole file exists to
+ * prevent, so it must not be the failure mode of the file.
+ */
+function parseEmitUnion(): string[] {
+  const src = readFileSync(NOTIFY_SRC, 'utf8');
+  const decl = /export type AppListingOwnerNotificationType\s*=([\s\S]*?);/.exec(src);
+  if (!decl) throw new Error(`could not locate the union declaration in ${NOTIFY_SRC}`);
+  return [...decl[1].matchAll(/'([a-z0-9-]+)'/g)].map((m) => m[1]);
+}
+
+describe('app-listing owner notifications — the emit union and the processor keys agree', () => {
+  it('POSITIVE CONTROL: the union actually parsed, and the processor set is non-empty', () => {
+    // Without this, both set comparisons below are claims about empty sets.
+    const union = parseEmitUnion();
+    expect(union.length).toBeGreaterThanOrEqual(4);
+    expect(union).toContain('app-listing-approved');
+    expect(Object.keys(appListingNotifications).length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('every EMITTABLE type has a processor entry (else it emits unrenderable)', () => {
+    const processors = new Set(Object.keys(appListingNotifications));
+    const missing = parseEmitUnion().filter((t) => !processors.has(t));
+    expect(missing, 'union members with no notification processor').toEqual([]);
+  });
+
+  it('every PROCESSOR key is emittable (else it is dead, or its emitter was renamed)', () => {
+    const union = new Set(parseEmitUnion());
+    // `appListingNotifications` is the app-listing FAMILY only; `new-app-listing-comment`
+    // lives in comment.notifications.ts and is emitted through a different helper, so it is
+    // legitimately outside this union.
+    const orphaned = Object.keys(appListingNotifications).filter(
+      (k) => !union.has(k) && k !== 'new-app-listing-comment'
+    );
+    expect(orphaned, 'processor entries nothing is allowed to emit').toEqual([]);
+  });
+
+  it('every processor renders a non-empty message and a url for a minimal payload', () => {
+    // A `details` with only the required `slug` — the terse shape `appLabel` falls back on.
+    for (const [type, processor] of Object.entries(appListingNotifications)) {
+      const prepared = processor.prepareMessage?.({
+        details: { slug: 'some-app' },
+      } as never);
+      expect(prepared, `${type} produced no message`).toBeTruthy();
+      expect(prepared?.message?.length, `${type} rendered an empty message`).toBeGreaterThan(0);
+      expect(prepared?.url, `${type} rendered no url`).toBeTruthy();
+    }
+  });
+});

--- a/src/server/notifications/__tests__/app-listing.emit-union-seam.test.ts
+++ b/src/server/notifications/__tests__/app-listing.emit-union-seam.test.ts
@@ -41,17 +41,24 @@ const NOTIFY_SRC = path.resolve(__dirname, '../../services/blocks/app-listing-no
  * processor-less member truncated the parse to drop exactly that member, and ALL FOUR tests
  * passed — including the positive control, which only checks the union is non-empty and
  * contains a long-standing member. The guard read as coverage for the case most likely to
- * arise (a member appended at the end) while providing none. The two-sided count assertion
- * below is the second half of the fix: a truncated parse now disagrees with the processor
- * count even when both `⊆` directions pass.
+ * arise (a member appended at the end) while providing none.
+ *
+ * ⚠ NOTHING DOWNSTREAM CAN CATCH THAT — a claim an earlier revision of this comment got wrong
+ * in the same way. A truncated parse is a SUBSET of the processor set, so both `⊆` tests pass;
+ * set equality being forced, the size comparison passes too. Measured green against exactly
+ * that scenario. **The stripping IS the guard**, so it is pinned directly by
+ * `parseUnionFrom`'s own tests at the bottom of this file, against synthetic sources whose
+ * answer is known without reading the file under audit.
  */
-function parseEmitUnion(): string[] {
-  const src = readFileSync(NOTIFY_SRC, 'utf8')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/[^\n]*/g, '');
+export function parseUnionFrom(source: string): string[] {
+  const src = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
   const decl = /export type AppListingOwnerNotificationType\s*=([\s\S]*?);/.exec(src);
-  if (!decl) throw new Error(`could not locate the union declaration in ${NOTIFY_SRC}`);
+  if (!decl) throw new Error('could not locate the union declaration');
   return [...decl[1].matchAll(/'([a-z0-9-]+)'/g)].map((m) => m[1]);
+}
+
+function parseEmitUnion(): string[] {
+  return parseUnionFrom(readFileSync(NOTIFY_SRC, 'utf8'));
 }
 
 describe('app-listing owner notifications — the emit union and the processor keys agree', () => {
@@ -80,12 +87,20 @@ describe('app-listing owner notifications — the emit union and the processor k
   });
 
   /**
-   * 🔴 THE TWO-SIDED COUNT. Both `⊆` checks above can pass while the parse silently dropped
-   * members — a truncated union is a SUBSET of the processors, and every surviving member
-   * still has an entry. Only comparing the sizes catches it.
+   * ⚠ THIS CATCHES DUPLICATES, NOT TRUNCATION — and the name says so because an earlier
+   * revision claimed the opposite and was wrong.
+   *
+   * The two `⊆` tests above already force `set(parsed) === set(processors)`. Given that,
+   * comparing sizes can only fail when `parsed` holds a DUPLICATE — a truncation removes
+   * members and never creates one, so this assertion is structurally incapable of seeing it.
+   * The comment that used to sit here said it was "the second half of the fix" for truncation;
+   * it was measured as green against exactly that scenario. Truncation is caught by the
+   * comment-stripping in the parser, which is why the parser now has its own tests below
+   * instead of being trusted through this one.
    */
-  it('the two sets are the same SIZE — a silently truncated parse cannot pass', () => {
-    expect(parseEmitUnion().length).toBe(Object.keys(appListingNotifications).length);
+  it('no DUPLICATE union member (this does NOT catch a truncated parse — see below)', () => {
+    const union = parseEmitUnion();
+    expect(new Set(union).size).toBe(union.length);
   });
 
   it('every processor renders a non-empty message and a url for a minimal payload', () => {
@@ -98,5 +113,47 @@ describe('app-listing owner notifications — the emit union and the processor k
       expect(prepared?.message?.length, `${type} rendered an empty message`).toBeGreaterThan(0);
       expect(prepared?.url, `${type} rendered no url`).toBeTruthy();
     }
+  });
+});
+
+/**
+ * 🔴 THE PARSER GETS ITS OWN TESTS, because every assertion above is downstream of it and
+ * therefore cannot see it fail in the direction that matters.
+ *
+ * A parse that silently DROPS a member produces a union that is a subset of the processor set —
+ * so both `⊆` checks pass, and (set equality being forced) so does the size comparison. Measured:
+ * with the comment-stripping reverted, round 3's exact scenario left all five tests above green.
+ * The only thing standing between that and a shipped, unrenderable notification type is the
+ * stripping, so the stripping is what has to be pinned — directly, against synthetic sources,
+ * where the expected answer is known independently of the file under audit.
+ */
+describe('parseUnionFrom — the parse itself, against sources with known answers', () => {
+  const union = (members: string, extra = '') =>
+    `export type AppListingOwnerNotificationType =\n${extra}${members};\n`;
+
+  it('POSITIVE CONTROL: reads a plain union', () => {
+    expect(parseUnionFrom(union(`  | 'a-one'\n  | 'a-two'`))).toEqual(['a-one', 'a-two']);
+  });
+
+  it('🔴 a semicolon inside a // comment does NOT truncate the union', () => {
+    const src = union(`  | 'a-one'\n  // NOTE: emitted by the new sweep; see #1234.\n  | 'a-two'`);
+    // Pre-fix this returned ['a-one'] — dropping exactly the appended member, which is the
+    // member most likely to be the new, processor-less one.
+    expect(parseUnionFrom(src)).toEqual(['a-one', 'a-two']);
+  });
+
+  it('🔴 a semicolon inside a block comment does NOT truncate it either', () => {
+    const src = union(`  | 'a-one'\n  /* first; second */\n  | 'a-two'`);
+    expect(parseUnionFrom(src)).toEqual(['a-one', 'a-two']);
+  });
+
+  it('a // inside a string elsewhere in the file does not corrupt the parse', () => {
+    const src = `const DOCS = 'https://civitai.com/docs';\n` + union(`  | 'a-one'\n  | 'a-two'`);
+    expect(parseUnionFrom(src)).toEqual(['a-one', 'a-two']);
+  });
+
+  it('throws loudly when the declaration is absent, rather than returning []', () => {
+    // An empty return would make every ⊆ check above vacuously true.
+    expect(() => parseUnionFrom('export type Something = string;')).toThrow(/union declaration/);
   });
 });

--- a/src/server/notifications/__tests__/app-listing.emit-union-seam.test.ts
+++ b/src/server/notifications/__tests__/app-listing.emit-union-seam.test.ts
@@ -33,9 +33,22 @@ const NOTIFY_SRC = path.resolve(__dirname, '../../services/blocks/app-listing-no
  * nothing would yield an empty union, every `⊆` check would pass vacuously, and the guard would
  * report success while comparing nothing. That is the failure mode this whole file exists to
  * prevent, so it must not be the failure mode of the file.
+ *
+ * 🔴 COMMENTS ARE STRIPPED BEFORE THE MATCH, AND THAT IS NOT TIDINESS. The first version
+ * terminated on the first `;`, which a `//` comment inside the union can contain — the union
+ * already carries multi-line commentary between members, so a semicolon there is an ordinary
+ * authoring act. Measured: a `;` in a trailing comment immediately before a newly appended,
+ * processor-less member truncated the parse to drop exactly that member, and ALL FOUR tests
+ * passed — including the positive control, which only checks the union is non-empty and
+ * contains a long-standing member. The guard read as coverage for the case most likely to
+ * arise (a member appended at the end) while providing none. The two-sided count assertion
+ * below is the second half of the fix: a truncated parse now disagrees with the processor
+ * count even when both `⊆` directions pass.
  */
 function parseEmitUnion(): string[] {
-  const src = readFileSync(NOTIFY_SRC, 'utf8');
+  const src = readFileSync(NOTIFY_SRC, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
   const decl = /export type AppListingOwnerNotificationType\s*=([\s\S]*?);/.exec(src);
   if (!decl) throw new Error(`could not locate the union declaration in ${NOTIFY_SRC}`);
   return [...decl[1].matchAll(/'([a-z0-9-]+)'/g)].map((m) => m[1]);
@@ -58,13 +71,21 @@ describe('app-listing owner notifications — the emit union and the processor k
 
   it('every PROCESSOR key is emittable (else it is dead, or its emitter was renamed)', () => {
     const union = new Set(parseEmitUnion());
-    // `appListingNotifications` is the app-listing FAMILY only; `new-app-listing-comment`
-    // lives in comment.notifications.ts and is emitted through a different helper, so it is
-    // legitimately outside this union.
-    const orphaned = Object.keys(appListingNotifications).filter(
-      (k) => !union.has(k) && k !== 'new-app-listing-comment'
-    );
+    // 🔴 NO EXCLUSION LIST. An earlier revision carved out `new-app-listing-comment` on the
+    // belief that it lived in this processor set; it does not — it is registered in
+    // `comment.notifications.ts` — so the carve-out was DEAD, and a dead exclusion is a
+    // permanent hole for whichever key it names.
+    const orphaned = Object.keys(appListingNotifications).filter((k) => !union.has(k));
     expect(orphaned, 'processor entries nothing is allowed to emit').toEqual([]);
+  });
+
+  /**
+   * 🔴 THE TWO-SIDED COUNT. Both `⊆` checks above can pass while the parse silently dropped
+   * members — a truncated union is a SUBSET of the processors, and every surviving member
+   * still has an entry. Only comparing the sizes catches it.
+   */
+  it('the two sets are the same SIZE — a silently truncated parse cannot pass', () => {
+    expect(parseEmitUnion().length).toBe(Object.keys(appListingNotifications).length);
   });
 
   it('every processor renders a non-empty message and a url for a minimal payload', () => {

--- a/src/server/notifications/app-listing.notifications.ts
+++ b/src/server/notifications/app-listing.notifications.ts
@@ -5,8 +5,8 @@ import { createNotificationProcessor } from '~/server/notifications/base.notific
  * App Store Listings (W13) — owner-facing moderation notifications.
  *
  * The listing owner (an app developer) has no other signal today that a moderator
- * acted on their off-site listing. These four IMPERATIVE notification types are
- * emitted directly from the off-site listing/moderation services (via
+ * acted on their listing. These IMPERATIVE notification types are
+ * emitted directly from the listing/moderation services (via
  * `createNotification`) — NOT from a scheduled `prepareQuery` scan — so they carry
  * NO `prepareQuery`, only a `prepareMessage` (mirrors the auction / challenge
  * imperative notifications). Each carries the acting reason (where a mod supplied
@@ -34,11 +34,15 @@ export type AppListingModerationNotificationDetails = {
 /**
  * Every owner-facing app-listing notification points the owner at their submissions/history view.
  *
- * Exported because `new-app-listing-comment` (in `comment.notifications.ts`) is the fifth such
+ * Exported because `new-app-listing-comment` (in `comment.notifications.ts`) is another such
  * notification and must land on the same page for the same reason: `/apps/mine` gates on
  * `appBlocksAuthor`, the developer cohort a listing owner is in by construction, whereas the
  * public detail page gates on `hasAppsStoreAccess` and 404s for owners outside it. One constant,
- * so a route rename moves all five.
+ * so a route rename moves every one of them.
+ *
+ * (Deliberately count-free: this comment said "the fifth" and "all five" until
+ * `app-listing-purged` made it six, which is the doc-rot a stated total always eventually
+ * becomes. The set is enumerable from the object below; the number is not worth maintaining.)
  */
 export const OWNER_SUBMISSIONS_URL = '/apps/mine';
 
@@ -86,6 +90,31 @@ export const appListingNotifications = createNotificationProcessor({
       return {
         message: withReason(
           `${appLabel(details)} was hidden from the app store by a moderator`,
+          details.reason
+        ),
+        url: OWNER_SUBMISSIONS_URL,
+      };
+    },
+  },
+  /**
+   * A moderator hard-deleted an unapproved store listing (`purgeListing`'s on-site
+   * orphan-pre-approval-draft arm). The listing row, its screenshots and its slug are gone —
+   * so unlike `hidden` this is not reversible by a relist, and the copy must not imply it is.
+   *
+   * The owner may already have had `app-block-rejected` for the SUBMISSION; this is about the
+   * store listing itself, which is a different object and survived that rejection.
+   */
+  'app-listing-purged': {
+    displayName: 'App listing removed',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppListingModerationNotificationDetails;
+      return {
+        message: withReason(
+          `${appLabel(
+            details
+          )} store listing was removed by a moderator, and its store address is no longer reserved`,
           details.reason
         ),
         url: OWNER_SUBMISSIONS_URL,

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -1142,11 +1142,18 @@ export const appListingsRouter = router({
    *
    * 🔴 THE ONE DELIBERATELY SUBMITTER-SCOPED READ ON THIS PAGE, and the exception proves
    * the rule. Every other read here is ownership∪seat because an app exists to key on; a
-   * first version that was rejected or withdrawn had its pre-approval DRAFT listing
-   * DELETED (the slug release), so there is no app row left and `submitted_by_user_id` is
-   * the only identity the surviving record carries. Without this proc that population is
-   * unreachable from anywhere in the product — including from the "your app was rejected"
-   * notification, which now points here.
+   * first version whose pre-approval DRAFT listing was DELETED leaves no app row, so
+   * `submitted_by_user_id` is the only identity the surviving record carries. Without this
+   * proc that population is unreachable from anywhere in the product.
+   *
+   * 🔴 A REJECT NO LONGER PUTS A SUBMISSION HERE (clawgate #302). `rejectRequest` keeps the
+   * draft, so a newly rejected first version has a listing the caller owns and renders on the
+   * APP-KEYED table instead, via `blockRequestWhereForListing`'s null-FK slug branch — the
+   * de-dup in `listMyOrphanedSubmissions` excludes it from this read on purpose. The
+   * population that still lands here: first versions the developer WITHDREW (which does
+   * delete the draft), anything a mod `purgeListing`d, and the rows rejected before that
+   * change. The "your app was rejected" notification points at `/apps/mine`, which renders
+   * both surfaces, so it is correct either way.
    *
    * Same `appBlocksAuthor`-only gate as the page and `listingHistory`.
    */

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -1419,8 +1419,16 @@ export const appListingsRouter = router({
   }),
 
   /**
-   * MOD hard-delete (purge) an off-site listing — the final expunge + the
-   * self-clean primitive. Writes the audit event BEFORE the delete so the event row
+   * MOD hard-delete (purge) a listing — the final expunge + the self-clean primitive.
+   * Valid targets are any OFF-SITE listing, or an ON-SITE **orphan pre-approval draft**
+   * (never approved, not a shadow revision). The on-site arm exists because
+   * `rejectRequest` no longer deletes that draft as a side-effect (clawgate #302), so a
+   * mod who genuinely wants a rejected submission's slug and media gone asks for it here
+   * — with a reason and an audit event — instead of it riding on every reject.
+   * Anything else (an approved/removed on-site listing, a shadow revision, a missing
+   * row) raises the same generic NOT_FOUND, so a caller cannot probe kind or status.
+   *
+   * Writes the audit event BEFORE the delete so the event row
    * survives at the ROW level for audit/compliance (SetNull FK + slug snapshot). It
    * is NOT retrievable via the per-listing history read (`listModerationEvents`)
    * once purged — the FK is nulled, so post-purge it's reachable only via the actor

--- a/src/server/services/blocks/__tests__/app-listing-history.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-history.service.test.ts
@@ -363,10 +363,14 @@ describe('🔴 blockRequestWhereForListing — the null-FK branch', () => {
   });
 
   /**
-   * 🔴 THE OWNER SCOPE IS NOT DECORATION. A rejected/withdrawn first version DELETES its
-   * draft listing to release the slug, so the same slug can later belong to someone else.
-   * An unscoped slug match would hand that new owner the previous applicant's rejection
-   * reason — which is why the branch carries BOTH clauses.
+   * 🔴 THE OWNER SCOPE IS NOT DECORATION. A first version that is WITHDRAWN deletes its draft
+   * listing to release the slug, and a mod `purgeListing` on an orphan draft does the same, so
+   * the slug can later belong to someone else. An unscoped slug match would hand that new
+   * owner the previous applicant's rejection reason — which is why the branch carries BOTH
+   * clauses.
+   *
+   * (A REJECT no longer releases the slug — clawgate #302 — but that shrinks the population
+   * this guard protects, it does not retire the guard: withdraw and purge still do.)
    */
   it('never emits a bare slug match', () => {
     const where = blockRequestWhereForListing({ ...ONSITE, appBlockId: null }) as Record<

--- a/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
@@ -16,6 +16,13 @@ const { mockDbRead } = vi.hoisted(() => ({
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
+    // The slug-keyed ON-SITE "is this draft under review?" lookup. It has no FK to include,
+    // so it is a second batched query rather than a relation — and until this mock existed
+    // the branch was unreachable in tests: every fixture was off-site, so `onsiteSlugs` was
+    // empty and the call short-circuited before touching an undefined mock.
+    appBlockPublishRequest: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
   },
 }));
 
@@ -206,5 +213,84 @@ describe('listAllListingsForModeration — filters, keyset + pagination', () => 
     const { items, nextCursor } = await listAllListingsForModeration({ limit: 25 });
     expect(items).toHaveLength(1);
     expect(nextCursor).toBeNull();
+  });
+});
+
+/**
+ * 🔴 `hasPendingBlockRequest` — the ON-SITE "is this draft under review?" signal, and the ONE
+ * thing standing between the mod table and offering a destructive Purge on a live submission.
+ *
+ * It cannot come from a relation: an on-site pre-approval draft's request is an
+ * `AppBlockPublishRequest` joined to the listing by the shared `@unique` SLUG with no foreign
+ * key (`AppListingPublishRequest.appListingId` is "On-site: NULL until approve"). So it is a
+ * second, batched, slug-keyed query — and that is precisely why it needs its own tests: an
+ * `include` would have been type-checked, a hand-rolled second query is not.
+ *
+ * 🔴 THESE EXIST BECAUSE THE SIGNAL SHIPPED WITH ZERO COVERAGE. Hardwiring the projection to
+ * `false` AND breaking the query's status filter left 315 files / 7209 tests green, because
+ * every fixture in this file was off-site, so `onsiteSlugs` was empty and the branch
+ * short-circuited before the (then missing) mock was touched. A fixture that never reaches the
+ * code proves nothing about it.
+ */
+describe('listAllListingsForModeration — the on-site pending-block-request signal', () => {
+  beforeEach(() => {
+    mockDbRead.appListing.findMany.mockReset();
+    mockDbRead.appListing.findMany.mockResolvedValue([]);
+    mockDbRead.appBlockPublishRequest.findMany.mockReset();
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
+  });
+
+  it('flags the on-site row whose slug HAS a pending block request, and only that row', async () => {
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      modRow({ id: 'apl_live', slug: 'under-review', kind: 'onsite', status: 'draft' }),
+      modRow({ id: 'apl_dead', slug: 'abandoned', kind: 'onsite', status: 'draft' }),
+    ]);
+    // Only one of the two slugs comes back — so a mutant that ignores the result and returns a
+    // constant cannot satisfy both rows.
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValueOnce([{ slug: 'under-review' }]);
+
+    const { items } = await listAllListingsForModeration({ limit: 25 });
+    expect(items.map((i) => [i.slug, i.hasPendingBlockRequest])).toEqual([
+      ['under-review', true],
+      ['abandoned', false],
+    ]);
+  });
+
+  it('queries the RIGHT table with the page’s on-site slugs and the pending status', async () => {
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      modRow({ id: 'apl_a', slug: 'onsite-a', kind: 'onsite', status: 'draft' }),
+      modRow({ id: 'apl_b', slug: 'offsite-b', kind: 'offsite' }),
+    ]);
+    await listAllListingsForModeration({ limit: 25 });
+
+    // Literal, not built from the implementation. Pins the table, the key and the status — the
+    // three things that were wrong the first time this guard was written.
+    expect(mockDbRead.appBlockPublishRequest.findMany).toHaveBeenCalledWith({
+      where: { slug: { in: ['onsite-a'] }, status: 'pending' },
+      select: { slug: true },
+    });
+  });
+
+  it('issues NO second query when the page has no on-site rows', async () => {
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([modRow({ kind: 'offsite' })]);
+    const { items } = await listAllListingsForModeration({ limit: 25 });
+    expect(mockDbRead.appBlockPublishRequest.findMany).not.toHaveBeenCalled();
+    expect(items[0].hasPendingBlockRequest).toBe(false);
+  });
+
+  it('never flags an OFF-SITE row, even when its slug collides with a pending block request', async () => {
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      modRow({ id: 'apl_off', slug: 'shared-slug', kind: 'offsite' }),
+      modRow({ id: 'apl_on', slug: 'onsite-x', kind: 'onsite', status: 'draft' }),
+    ]);
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValueOnce([
+      { slug: 'shared-slug' },
+      { slug: 'onsite-x' },
+    ]);
+    const { items } = await listAllListingsForModeration({ limit: 25 });
+    expect(items.map((i) => [i.id, i.hasPendingBlockRequest])).toEqual([
+      ['apl_off', false],
+      ['apl_on', true],
+    ]);
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -177,11 +177,6 @@ function offsiteListing(status: string, kind = 'offsite') {
     // through the on-site arm) — a fixture that left it `undefined` would be asserting
     // against a shape the DB cannot produce.
     revisionOfId: null,
-    // …and `publishRequests`, filtered to `status:'pending'` with `take: 1`, which is how the
-    // "not under review" half of "orphan draft" is projected. Empty = no live submission.
-    // Omitting it does not fail OPEN: the guard reads `.length` and throws, so a malformed
-    // fixture refuses the destructive op rather than permitting it.
-    publishRequests: [],
     externalUrl: EXTERNAL_URL,
     connectClientId: null,
   };
@@ -1248,13 +1243,7 @@ describe('purgeListing', () => {
         // appBlockId:null); see offsite-moderation.service.purge-onsite-draft.test.ts.
         OR: [
           { kind: 'offsite' },
-          {
-            kind: 'onsite',
-            status: 'draft',
-            appBlockId: null,
-            revisionOfId: null,
-            publishRequests: { none: { status: 'pending' } },
-          },
+          { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
         ],
       },
     });
@@ -1282,7 +1271,6 @@ describe('purgeListing', () => {
       slug: 'stale-slug',
       appBlockId: null,
       revisionOfId: null,
-      publishRequests: [],
     });
     mockWrite.appListing.findUnique.mockResolvedValueOnce({
       status: 'removed',
@@ -1291,7 +1279,6 @@ describe('purgeListing', () => {
       name: null,
       appBlockId: null,
       revisionOfId: null,
-      publishRequests: [],
     });
     await purgeListing({
       input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
@@ -1314,7 +1301,6 @@ describe('purgeListing', () => {
         // The relation term's projection. Without it `isPurgeableListing` would read
         // `undefined` for the pending-request count — which THROWS rather than defaulting
         // to "not under review", so the destructive op refuses instead of proceeding.
-        publishRequests: { where: { status: 'pending' }, take: 1, select: { id: true } },
       },
     });
     const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -177,6 +177,11 @@ function offsiteListing(status: string, kind = 'offsite') {
     // through the on-site arm) — a fixture that left it `undefined` would be asserting
     // against a shape the DB cannot produce.
     revisionOfId: null,
+    // …and `publishRequests`, filtered to `status:'pending'` with `take: 1`, which is how the
+    // "not under review" half of "orphan draft" is projected. Empty = no live submission.
+    // Omitting it does not fail OPEN: the guard reads `.length` and throws, so a malformed
+    // fixture refuses the destructive op rather than permitting it.
+    publishRequests: [],
     externalUrl: EXTERNAL_URL,
     connectClientId: null,
   };
@@ -1243,7 +1248,13 @@ describe('purgeListing', () => {
         // appBlockId:null); see offsite-moderation.service.purge-onsite-draft.test.ts.
         OR: [
           { kind: 'offsite' },
-          { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
+          {
+            kind: 'onsite',
+            status: 'draft',
+            appBlockId: null,
+            revisionOfId: null,
+            publishRequests: { none: { status: 'pending' } },
+          },
         ],
       },
     });
@@ -1269,13 +1280,18 @@ describe('purgeListing', () => {
       kind: 'offsite',
       status: 'approved',
       slug: 'stale-slug',
+      appBlockId: null,
+      revisionOfId: null,
+      publishRequests: [],
     });
     mockWrite.appListing.findUnique.mockResolvedValueOnce({
       status: 'removed',
       slug: 'fresh-slug',
       kind: 'offsite',
+      name: null,
       appBlockId: null,
       revisionOfId: null,
+      publishRequests: [],
     });
     await purgeListing({
       input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
@@ -1291,8 +1307,14 @@ describe('purgeListing', () => {
         status: true,
         slug: true,
         kind: true,
+        userId: true,
+        name: true,
         appBlockId: true,
         revisionOfId: true,
+        // The relation term's projection. Without it `isPurgeableListing` would read
+        // `undefined` for the pending-request count — which THROWS rather than defaulting
+        // to "not under review", so the destructive op refuses instead of proceeding.
+        publishRequests: { where: { status: 'pending' }, take: 1, select: { id: true } },
       },
     });
     const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -173,6 +173,10 @@ function offsiteListing(status: string, kind = 'offsite') {
     name: 'Cool App',
     userId: OWNER,
     appBlockId: null,
+    // Purge's predicate reads `revisionOfId` (a shadow revision must never be purgeable
+    // through the on-site arm) — a fixture that left it `undefined` would be asserting
+    // against a shape the DB cannot produce.
+    revisionOfId: null,
     externalUrl: EXTERNAL_URL,
     connectClientId: null,
   };
@@ -1229,7 +1233,19 @@ describe('purgeListing', () => {
       before: { status: 'removed' },
     });
     expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
-      where: { id: APP_ID, kind: 'offsite' },
+      where: {
+        id: APP_ID,
+        // 🔴 LITERAL, not the service's own exported constant — an assertion built from
+        // the implementation cannot notice the implementation changing. The delete is
+        // guarded to the two purgeable shapes: any off-site row, or an on-site ORPHAN
+        // PRE-APPROVAL DRAFT. `revisionOfId: null` is the term that keeps a shadow media
+        // revision of a LIVE app out of it (a shadow is also kind-of-parent + draft +
+        // appBlockId:null); see offsite-moderation.service.purge-onsite-draft.test.ts.
+        OR: [
+          { kind: 'offsite' },
+          { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
+        ],
+      },
     });
   });
 
@@ -1258,22 +1274,38 @@ describe('purgeListing', () => {
       status: 'removed',
       slug: 'fresh-slug',
       kind: 'offsite',
+      appBlockId: null,
+      revisionOfId: null,
     });
     await purgeListing({
       input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
       reviewerUserId: REVIEWER,
     });
-    // The in-tx primary read is what feeds the snapshot.
+    // The in-tx primary read is what feeds the snapshot. It must SELECT every field the
+    // purgeability predicate reads — a select that omitted `appBlockId`/`revisionOfId`
+    // would hand `isPurgeableListing` `undefined` for them, so an on-site row would fail
+    // the guard for the wrong reason (or pass it, if the terms were ever inverted).
     expect(mockWrite.appListing.findUnique).toHaveBeenCalledWith({
       where: { id: APP_ID },
-      select: { status: true, slug: true, kind: true },
+      select: {
+        status: true,
+        slug: true,
+        kind: true,
+        appBlockId: true,
+        revisionOfId: true,
+      },
     });
     const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
     expect(data.before).toEqual({ status: 'removed' });
     expect(data.slug).toBe('fresh-slug');
   });
 
-  it('the kind guard rejects an on-site listing at the replica classify (no tx)', async () => {
+  // An `approved`/`removed` on-site listing has a backing AppBlock whose runtime serving
+  // gate reads `app_blocks.status` — deleting the listing row would hide the store card
+  // while leaving the hosted app serving. `delistListing` is the correct action for those.
+  // Only an on-site ORPHAN PRE-APPROVAL DRAFT is purgeable; that arm is covered in
+  // offsite-moderation.service.purge-onsite-draft.test.ts.
+  it('rejects a NON-DRAFT on-site listing at the replica classify (no tx)', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed', 'onsite'));
     await expect(
       purgeListing({ input: { appListingId: APP_ID, reason: 'spam expunge' }, reviewerUserId: REVIEWER })

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { purgeListing } from '~/server/services/blocks/offsite-moderation.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
 /**
  * `purgeListing` — the ON-SITE ORPHAN PRE-APPROVAL DRAFT arm (clawgate #302 / ClickUp
  * 868kuam02).
@@ -24,27 +27,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * media revision of a LIVE, approved on-site app — which is why the refusal cases below
  * are the point of this file, not the happy path.
  *
- * DB fully mocked. `$transaction` runs its callback against the same write mock, so a
- * test can assert that a guarded refusal throws BEFORE any audit event is written.
+ * DB deps come from the canonical `dbMock` — no real Prisma, and no per-file mock of the db
+ * client, which `no-direct-shared-module-mock` forbids: under `isolate: false` a per-file db
+ * mock freezes its own shape into every later file in the same worker. `$transaction`'s
+ * canonical default runs its callback against `dbWrite`, which is exactly the tx client these
+ * assertions read — so a test can assert that a guarded refusal throws BEFORE any audit event
+ * is written.
+ *
+ * 🔴 Do not name that specifier inside a `vi.mock(...)` call shape ANYWHERE in this file,
+ * prose included. The guard is a regex over the file's source text, so a mention in a comment
+ * is indistinguishable from a real registration and fails the build. (It did.)
  */
 
-const { mockRead, mockWrite, ids } = vi.hoisted(() => {
-  const ids = { n: 0 };
-  const mockWrite = {
-    $transaction: vi.fn(),
-    appListing: {
-      findUnique: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-    appListingModerationEvent: { create: vi.fn() },
-    appListingReport: { updateMany: vi.fn() },
-  };
-  const mockRead = { appListing: { findUnique: vi.fn() } };
-  return { mockRead, mockWrite, ids };
-});
+const { ids } = vi.hoisted(() => ({ ids: { n: 0 } }));
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingReportId: () => `alrp_test_${++ids.n}`,
   newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
@@ -55,7 +51,8 @@ vi.mock('~/server/services/blocks/app-listing-notify', () => ({
   notifyAppListingOwner: vi.fn(async () => undefined),
 }));
 
-const { purgeListing } = await import('~/server/services/blocks/offsite-moderation.service');
+const mockRead = dbMock.dbRead;
+const mockWrite = dbMock.dbWrite;
 
 const REVIEWER = 1001;
 const APP_ID = 'apl_target';
@@ -79,11 +76,16 @@ function orphanDraft(over: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   ids.n = 0;
-  mockWrite.$transaction.mockImplementation(async (fn: unknown) =>
-    typeof fn === 'function' ? (fn as (tx: unknown) => unknown)(mockWrite) : undefined
-  );
-  mockWrite.appListing.deleteMany.mockResolvedValue({ count: 1 });
-  mockWrite.appListingModerationEvent.create.mockResolvedValue({});
+  // 🔴 `mockReset()`, not just `clearAllMocks()`. `clearAllMocks` clears CALLS but leaves a
+  // queued `mockResolvedValueOnce` in place, and the refusal tests below deliberately throw
+  // BEFORE reaching the in-tx read — so an unconsumed `Once` value would survive into the
+  // next test and decide it. Reset then re-apply, so every default is set explicitly here.
+  mockRead.appListing.findUnique.mockReset();
+  mockWrite.appListing.findUnique.mockReset();
+  mockWrite.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+  mockWrite.appListingModerationEvent.create.mockReset().mockResolvedValue({});
+  // `$transaction` is deliberately NOT reset — that would discard the canonical default
+  // (run the callback against `dbWrite`), which is the behaviour these tests rely on.
 });
 
 describe('purgeListing — on-site orphan pre-approval draft (the purgeable shape)', () => {

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `purgeListing` — the ON-SITE ORPHAN PRE-APPROVAL DRAFT arm (clawgate #302 / ClickUp
+ * 868kuam02).
+ *
+ * 🔴 WHY THIS ARM EXISTS, because it reads like new destructive power and is the opposite.
+ * `rejectRequest` used to run `deleteOnsiteDraftListingForSlug` on EVERY reject, so
+ * rejecting a first-time developer over a fixable problem hard-deleted the store listing
+ * they had built and released their slug — invisibly, with no reason recorded and no way
+ * for the reviewer to decline it. That call is gone. The same delete now happens only when
+ * a mod ASKS for it, here, with a required reason and an `action:'purge'` audit event.
+ *
+ * Removing this arm without replacing it would strand every rejected first submission:
+ * `delistListing` is status-guarded to `{approved, removed}` and cannot touch a `draft`,
+ * so an orphan draft would hold its slug with NO recourse.
+ *
+ * 🔴 THE PREDICATE IS NARROW ON PURPOSE, and the term that carries the most weight is
+ * `revisionOfId: null`. A SHADOW media revision (`beginListingRevision`) is created with
+ * the PARENT's `kind`, `status:'draft'` and `appBlockId: null` — it matches every OTHER
+ * term of the on-site arm. `deleteOnsiteDraftListingForSlug` gets away without that term
+ * only because it resolves BY SLUG and a shadow's slug is a synthetic `rev-<ulid>`; a
+ * purge resolves BY ID. Without `revisionOfId: null` a mod could hard-delete an in-flight
+ * media revision of a LIVE, approved on-site app — which is why the refusal cases below
+ * are the point of this file, not the happy path.
+ *
+ * DB fully mocked. `$transaction` runs its callback against the same write mock, so a
+ * test can assert that a guarded refusal throws BEFORE any audit event is written.
+ */
+
+const { mockRead, mockWrite, ids } = vi.hoisted(() => {
+  const ids = { n: 0 };
+  const mockWrite = {
+    $transaction: vi.fn(),
+    appListing: {
+      findUnique: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    appListingModerationEvent: { create: vi.fn() },
+    appListingReport: { updateMany: vi.fn() },
+  };
+  const mockRead = { appListing: { findUnique: vi.fn() } };
+  return { mockRead, mockWrite, ids };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingReportId: () => `alrp_test_${++ids.n}`,
+  newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
+  newAppOwnershipEventId: () => `aoe_test_${++ids.n}`,
+}));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: vi.fn(async () => undefined),
+}));
+
+const { purgeListing } = await import('~/server/services/blocks/offsite-moderation.service');
+
+const REVIEWER = 1001;
+const APP_ID = 'apl_target';
+const SLUG = 'cool-app';
+const REASON = 'confirmed spam submission, expunging';
+
+/** The purgeable on-site shape: never approved, not a shadow. */
+function orphanDraft(over: Record<string, unknown> = {}) {
+  return {
+    id: APP_ID,
+    kind: 'onsite',
+    status: 'draft',
+    slug: SLUG,
+    appBlockId: null,
+    revisionOfId: null,
+    userId: 77,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ids.n = 0;
+  mockWrite.$transaction.mockImplementation(async (fn: unknown) =>
+    typeof fn === 'function' ? (fn as (tx: unknown) => unknown)(mockWrite) : undefined
+  );
+  mockWrite.appListing.deleteMany.mockResolvedValue({ count: 1 });
+  mockWrite.appListingModerationEvent.create.mockResolvedValue({});
+});
+
+describe('purgeListing — on-site orphan pre-approval draft (the purgeable shape)', () => {
+  it('purges it, writing the audit event BEFORE the delete', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+
+    const res = await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, purged: true });
+
+    const createOrder = mockWrite.appListingModerationEvent.create.mock.invocationCallOrder[0];
+    const deleteOrder = mockWrite.appListing.deleteMany.mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(deleteOrder);
+
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'purge',
+      slug: SLUG,
+      actorUserId: REVIEWER,
+      reason: REASON,
+      before: { status: 'draft' },
+    });
+  });
+
+  it('guards the delete with the full purgeable predicate, not just the id', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+
+    // Literal, not the service's own constant — an expectation built from the
+    // implementation cannot notice the implementation changing.
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: APP_ID,
+        OR: [
+          { kind: 'offsite' },
+          { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
+        ],
+      },
+    });
+  });
+});
+
+/**
+ * 🔴 THE REFUSALS ARE THE POINT. Each row below differs from the purgeable shape in
+ * exactly ONE term, so a mutant that drops that term is caught by exactly one case and the
+ * others stay green — the failure names the missing term instead of "purge is broken".
+ */
+describe('purgeListing — refuses every on-site shape that is NOT an orphan draft', () => {
+  const cases: Array<{ what: string; row: Record<string, unknown>; why: string }> = [
+    {
+      what: 'a SHADOW media revision of a live app',
+      row: orphanDraft({ revisionOfId: 'apl_parent_live' }),
+      why: 'same kind + draft + null appBlockId as an orphan; only revisionOfId separates them',
+    },
+    {
+      what: 'a draft that already has a backing AppBlock',
+      row: orphanDraft({ appBlockId: 'ablk_live' }),
+      why: 'it reached approve — deleting it would orphan a hosted app',
+    },
+    {
+      what: 'an APPROVED on-site listing',
+      row: orphanDraft({ status: 'approved' }),
+      why: 'delistListing is the correct action; purge must not hide a card while the block serves',
+    },
+    {
+      what: 'a REMOVED on-site listing',
+      row: orphanDraft({ status: 'removed' }),
+      why: 'already delisted; still not purgeable through the on-site arm',
+    },
+  ];
+
+  for (const { what, row, why } of cases) {
+    it(`refuses ${what} at the replica classify, with no tx opened — ${why}`, async () => {
+      mockRead.appListing.findUnique.mockResolvedValueOnce(row);
+      await expect(
+        purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+      expect(mockWrite.$transaction).not.toHaveBeenCalled();
+      expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+    });
+  }
+
+  it('gives a MISSING row and a non-purgeable row the SAME message (no kind/status probing)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(null);
+    const missing = await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    }).catch((e: Error) => e.message);
+
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft({ status: 'approved' }));
+    const refused = await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    }).catch((e: Error) => e.message);
+
+    expect(missing).toBe(refused);
+  });
+});
+
+/**
+ * 🔴 THE RACE THAT MATTERS FOR THIS ARM. `approveRequest` turns exactly this row from an
+ * orphan draft into an APPROVED listing with a backing AppBlock. A purge that classified
+ * against a lagging REPLICA and then deleted would take out a live app's store card, so
+ * the predicate is re-evaluated on the PRIMARY inside the tx — and again in the delete.
+ */
+describe('purgeListing — the classify→delete race on the on-site arm', () => {
+  it('replica says orphan draft, primary says approved → NOT_FOUND with ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(
+      orphanDraft({ status: 'approved', appBlockId: 'ablk_live' })
+    );
+
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('a raced 0-count delete → NOT_FOUND (the tx, event included, rolls back)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.deleteMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('still requires a mod reason (the floor is not bypassed by the new arm)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: '  ' }, reviewerUserId: REVIEWER })
+    ).rejects.toThrow();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
@@ -265,9 +265,15 @@ describe('purgeListing — refuses every on-site shape that is NOT an orphan dra
     mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
     stageLiveSubmission(true);
 
-    await expect(
-      purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    // 🔴 NOT the generic NOT_FOUND the other refusals use. This surface is mod-only and the mod
+    // table already shows this exact fact, so hiding it conceals nothing and would leave the
+    // moderator at "not found" for a row visibly on screen. The message must say what to do.
+    const err = await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    }).catch((e: Error & { code?: string }) => e);
+    expect(err).toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect((err as Error).message).toMatch(/reject or withdraw/i);
 
     // Refused at the replica classify — no tx, no event, no delete, no notification.
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
@@ -292,7 +298,7 @@ describe('purgeListing — refuses every on-site shape that is NOT an orphan dra
 
     await expect(
       purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
 
     // The tx opened, then rolled back BEFORE the audit event — zero events on a guarded refusal.
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
@@ -39,7 +39,10 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
  * is indistinguishable from a real registration and fails the build. (It did.)
  */
 
-const { ids } = vi.hoisted(() => ({ ids: { n: 0 } }));
+const { ids, mockNotify } = vi.hoisted(() => ({
+  ids: { n: 0 },
+  mockNotify: vi.fn(async () => undefined),
+}));
 
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingReportId: () => `alrp_test_${++ids.n}`,
@@ -48,7 +51,7 @@ vi.mock('~/server/utils/app-block-ids', () => ({
   newAppOwnershipEventId: () => `aoe_test_${++ids.n}`,
 }));
 vi.mock('~/server/services/blocks/app-listing-notify', () => ({
-  notifyAppListingOwner: vi.fn(async () => undefined),
+  notifyAppListingOwner: mockNotify,
 }));
 
 const mockRead = dbMock.dbRead;
@@ -59,16 +62,26 @@ const APP_ID = 'apl_target';
 const SLUG = 'cool-app';
 const REASON = 'confirmed spam submission, expunging';
 
-/** The purgeable on-site shape: never approved, not a shadow. */
+const OWNER = 77;
+const APP_NAME = 'Cool App';
+
+/**
+ * The purgeable on-site shape: never approved, not a shadow, not under review.
+ *
+ * `publishRequests` is the relation term's projection — the reads select it filtered to
+ * `status:'pending'` with `take: 1`, so `[]` means "no live submission".
+ */
 function orphanDraft(over: Record<string, unknown> = {}) {
   return {
     id: APP_ID,
     kind: 'onsite',
     status: 'draft',
     slug: SLUG,
+    name: APP_NAME,
     appBlockId: null,
     revisionOfId: null,
-    userId: 77,
+    userId: OWNER,
+    publishRequests: [],
     ...over,
   };
 }
@@ -84,6 +97,7 @@ beforeEach(() => {
   mockWrite.appListing.findUnique.mockReset();
   mockWrite.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
   mockWrite.appListingModerationEvent.create.mockReset().mockResolvedValue({});
+  mockNotify.mockReset().mockResolvedValue(undefined);
   // `$transaction` is deliberately NOT reset — that would discard the canonical default
   // (run the callback against `dbWrite`), which is the behaviour these tests rely on.
 });
@@ -127,10 +141,62 @@ describe('purgeListing — on-site orphan pre-approval draft (the purgeable shap
         id: APP_ID,
         OR: [
           { kind: 'offsite' },
-          { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
+          {
+            kind: 'onsite',
+            status: 'draft',
+            appBlockId: null,
+            revisionOfId: null,
+            publishRequests: { none: { status: 'pending' } },
+          },
         ],
       },
     });
+  });
+
+  /**
+   * 🔴 The developer's listing, its media and their slug are being hard-deleted. Unlike the
+   * off-site arm — only reachable on an already-`removed` listing, i.e. after a `delistListing`
+   * that notified — this arm fires straight off a `draft`, so without this it is a silent
+   * deletion of a user's content.
+   */
+  it('notifies the OWNER, post-commit, carrying the mod reason', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify.mock.calls[0][0]).toMatchObject({
+      type: 'app-listing-purged',
+      userId: OWNER,
+      // Keyed by LISTING id, never slug: this delete RELEASES the slug, so a slug key could
+      // dedup a later, different developer's notification away.
+      key: `app-listing-purged:${APP_ID}`,
+      details: { slug: SLUG, name: APP_NAME, reason: REASON },
+    });
+  });
+
+  it('the purge STANDS if the notification throws (post-commit, best-effort)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockNotify.mockRejectedValueOnce(new Error('notification backend down'));
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
+    ).resolves.toEqual({ appListingId: APP_ID, purged: true });
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalled();
+  });
+
+  it('an OFF-SITE purge still notifies NOBODY — that arm follows a delist that already did', async () => {
+    const offsiteRow = orphanDraft({ kind: 'offsite', status: 'removed' });
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteRow);
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(offsiteRow);
+    await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 });
 
@@ -160,6 +226,11 @@ describe('purgeListing — refuses every on-site shape that is NOT an orphan dra
       what: 'a REMOVED on-site listing',
       row: orphanDraft({ status: 'removed' }),
       why: 'already delisted; still not purgeable through the on-site arm',
+    },
+    {
+      what: 'a draft whose submission is still PENDING review',
+      row: orphanDraft({ publishRequests: [{ id: 'pubreq_live' }] }),
+      why: 'the request is joined to the listing by SLUG only, so purging releases the slug out from under a live review',
     },
   ];
 

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.purge-onsite-draft.test.ts
@@ -66,10 +66,8 @@ const OWNER = 77;
 const APP_NAME = 'Cool App';
 
 /**
- * The purgeable on-site shape: never approved, not a shadow, not under review.
- *
- * `publishRequests` is the relation term's projection — the reads select it filtered to
- * `status:'pending'` with `take: 1`, so `[]` means "no live submission".
+ * The purgeable on-site shape: never approved, not a shadow. "Not under review" is NOT a field
+ * on this row — it is a separate slug-keyed lookup, staged by {@link stageLiveSubmission}.
  */
 function orphanDraft(over: Record<string, unknown> = {}) {
   return {
@@ -81,9 +79,32 @@ function orphanDraft(over: Record<string, unknown> = {}) {
     appBlockId: null,
     revisionOfId: null,
     userId: OWNER,
-    publishRequests: [],
     ...over,
   };
+}
+
+/**
+ * 🔴 STAGE THE "UNDER REVIEW" SIGNAL ON THE RIGHT TABLE.
+ *
+ * The live submission behind an on-site pre-approval draft is an `AppBlockPublishRequest`
+ * joined to the listing by the shared `@unique` SLUG — there is NO foreign key.
+ * `AppListing.publishRequests` is the `AppListingPublishRequest` relation, whose `appListingId`
+ * the schema documents as "On-site: NULL until approve", so for this shape it is provably
+ * always empty.
+ *
+ * An earlier revision of this file staged `publishRequests: [{ id: 'pubreq_live' }]` on the
+ * listing fixture and asserted the purge was refused. That state cannot exist in the database,
+ * so the test certified a guard that was a tautology — it passed, and a mutation of the guard
+ * "died" against it, while the production path deleted listings under active review. Fixtures
+ * that can only produce the shape the guard already assumes prove nothing.
+ */
+function stageLiveSubmission(present: boolean) {
+  mockRead.appBlockPublishRequest.findFirst.mockResolvedValue(
+    present ? { id: 'pubreq_live' } : null
+  );
+  mockWrite.appBlockPublishRequest.findFirst.mockResolvedValue(
+    present ? { id: 'pubreq_live' } : null
+  );
 }
 
 beforeEach(() => {
@@ -98,6 +119,8 @@ beforeEach(() => {
   mockWrite.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
   mockWrite.appListingModerationEvent.create.mockReset().mockResolvedValue({});
   mockNotify.mockReset().mockResolvedValue(undefined);
+  mockRead.appBlockPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+  mockWrite.appBlockPublishRequest.findFirst.mockReset().mockResolvedValue(null);
   // `$transaction` is deliberately NOT reset — that would discard the canonical default
   // (run the callback against `dbWrite`), which is the behaviour these tests rely on.
 });
@@ -141,13 +164,7 @@ describe('purgeListing — on-site orphan pre-approval draft (the purgeable shap
         id: APP_ID,
         OR: [
           { kind: 'offsite' },
-          {
-            kind: 'onsite',
-            status: 'draft',
-            appBlockId: null,
-            revisionOfId: null,
-            publishRequests: { none: { status: 'pending' } },
-          },
+          { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
         ],
       },
     });
@@ -227,11 +244,6 @@ describe('purgeListing — refuses every on-site shape that is NOT an orphan dra
       row: orphanDraft({ status: 'removed' }),
       why: 'already delisted; still not purgeable through the on-site arm',
     },
-    {
-      what: 'a draft whose submission is still PENDING review',
-      row: orphanDraft({ publishRequests: [{ id: 'pubreq_live' }] }),
-      why: 'the request is joined to the listing by SLUG only, so purging releases the slug out from under a live review',
-    },
   ];
 
   for (const { what, row, why } of cases) {
@@ -244,6 +256,60 @@ describe('purgeListing — refuses every on-site shape that is NOT an orphan dra
       expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
     });
   }
+
+  /**
+   * 🔴 THE ONE THAT WAS VACUOUS. See {@link stageLiveSubmission} — the refusal is driven by an
+   * `AppBlockPublishRequest` looked up BY SLUG, not by anything on the listing row.
+   */
+  it('refuses an on-site draft whose block request is still PENDING — by slug, on the right table', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    stageLiveSubmission(true);
+
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    // Refused at the replica classify — no tx, no event, no delete, no notification.
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+
+    // 🔴 Pins WHICH TABLE and WHICH PREDICATE. A guard that queried the listing relation
+    // instead would satisfy "refuses when a request is pending" against an impossible fixture
+    // while permitting the real case — which is exactly what shipped before.
+    expect(mockRead.appBlockPublishRequest.findFirst).toHaveBeenCalledWith({
+      where: { slug: SLUG, status: 'pending' },
+      select: { id: true },
+    });
+  });
+
+  it('re-checks it on the PRIMARY inside the tx, not only on the replica', async () => {
+    // Replica says no live submission; the primary sees one that landed in between.
+    mockRead.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(orphanDraft());
+    mockRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    mockWrite.appBlockPublishRequest.findFirst.mockResolvedValue({ id: 'pubreq_raced' });
+
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    // The tx opened, then rolled back BEFORE the audit event — zero events on a guarded refusal.
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('does NOT run the slug lookup for an OFF-SITE purge (its requests carry a real FK)', async () => {
+    const offsiteRow = orphanDraft({ kind: 'offsite', status: 'removed' });
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteRow);
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(offsiteRow);
+    await purgeListing({
+      input: { appListingId: APP_ID, reason: REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(mockRead.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
+    expect(mockWrite.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
+  });
 
   it('gives a MISSING row and a non-purgeable row the SAME message (no kind/status probing)', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(null);

--- a/src/server/services/blocks/__tests__/publish-request.draftAtSubmit.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.draftAtSubmit.test.ts
@@ -1,16 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * W13 draft-at-submit — REJECT / WITHDRAW cleanup of the pre-approval on-site DRAFT
- * `AppListing`.
+ * W13 draft-at-submit — what REJECT and WITHDRAW each do to the pre-approval on-site
+ * DRAFT `AppListing`, and the fact that they DISAGREE.
  *
- * On reject or withdraw of a first-version on-site publish request, the draft listing
- * minted at submit must be DELETED (release the slug + drop unreviewed media),
- * mirroring the off-site `closeTerminalListing` draft branch: a status-guarded
- * `deleteMany({ status:'draft' })` — the DB FKs then cascade `AppListingScreenshot`
- * and SetNull the `Image` rows (verified structurally, not in this mock). Resolved BY
- * SLUG (the on-site request has no appListingId FK). A subsequent-version / legacy
- * pre-ship request has no such draft → the `deleteMany` is a harmless 0-row no-op.
+ * WITHDRAW deletes it (release the slug + drop unreviewed media), mirroring the off-site
+ * `closeTerminalListing` draft branch: a status-guarded `deleteMany({ status:'draft' })`
+ * — the DB FKs then cascade `AppListingScreenshot` and SetNull the `Image` rows (verified
+ * structurally, not in this mock). Resolved BY SLUG (the on-site request has no
+ * appListingId FK). A subsequent-version / legacy pre-ship request has no such draft → the
+ * `deleteMany` is a harmless 0-row no-op.
+ *
+ * REJECT does NOT — see the 🔴 block above that describe (clawgate #302). The deliberate,
+ * mod-initiated version of that delete now lives in `purgeListing`'s on-site orphan-draft
+ * arm (`offsite-moderation.service.ts`), covered by
+ * `offsite-moderation.service.purge-onsite-draft.test.ts`.
  *
  * DB fully mocked — only the reads/writes reject/withdraw make are stubbed.
  */
@@ -27,6 +31,9 @@ const { db } = vi.hoisted(() => {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       // the draft cleanup.
       deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      // Not used by either path today — stubbed so the reject block can assert the
+      // ABSENCE of a status flip (e.g. draft → removed) as well as of a delete.
+      updateMany: vi.fn(async () => ({ count: 0 })),
     },
     appReviewAgentReport: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -84,7 +91,26 @@ function draftDeleteCalls() {
   });
 }
 
-describe('rejectRequest — deletes the pre-approval draft (status-guarded, by slug)', () => {
+/**
+ * 🔴 REGRESSION — clawgate #302 / ClickUp 868kuam02.
+ *
+ * `rejectRequest` USED to call `deleteOnsiteDraftListingForSlug`. That made a
+ * first-version reject destructive in a way no reviewer could see or decline: rejecting a
+ * first-time developer over a fixable problem (the reported case was a missing screenshot)
+ * hard-deleted the store listing they had built AND released their slug. Reject is the only
+ * "please fix this" signal the review path has — there is no `changes-requested` outcome —
+ * so the destructive branch fired precisely on the cases it should not have.
+ *
+ * These tests are RED on the pre-change code: it deleted, so every "no delete" assertion
+ * below fails there.
+ *
+ * The invariant is a RELATIONSHIP, not a property of one function — reject and withdraw
+ * must DISAGREE. Withdraw is the developer abandoning their own submission (releasing the
+ * slug is what they asked for); reject is a moderator verdict on a submission the developer
+ * still wants. The `withdrawRequest` block below is the other half of this guard, and a
+ * mutant that restores the delete in `rejectRequest` is caught here while leaving it green.
+ */
+describe('rejectRequest — KEEPS the pre-approval draft (clawgate #302)', () => {
   beforeEach(() => {
     db.read.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'req_1',
@@ -97,7 +123,7 @@ describe('rejectRequest — deletes the pre-approval draft (status-guarded, by s
     });
   });
 
-  it('flips the request → rejected AND deletes the on-site draft for the slug (cascade screenshots, SetNull images)', async () => {
+  it('flips the request → rejected WITHOUT deleting the on-site draft for the slug', async () => {
     await rejectRequest({
       publishRequestId: 'req_1',
       reviewerUserId: 9,
@@ -107,24 +133,39 @@ describe('rejectRequest — deletes the pre-approval draft (status-guarded, by s
     expect(db.write.appBlockPublishRequest.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ status: 'rejected' }) })
     );
-    const deletes = draftDeleteCalls();
-    expect(deletes).toHaveLength(1);
-    // Status-guarded delete (can never remove an approved/removed row).
-    expect(deletes[0][0]).toEqual({
-      where: { slug: SLUG, kind: 'onsite', appBlockId: null, status: 'draft' },
-    });
+    expect(draftDeleteCalls()).toHaveLength(0);
   });
 
-  it('reject STANDS even if the draft cleanup throws (best-effort)', async () => {
-    db.write.appListing.deleteMany.mockRejectedValueOnce(new Error('db blip'));
-    await expect(
-      rejectRequest({
-        publishRequestId: 'req_1',
-        reviewerUserId: 9,
-        rejectionReason: 'not good enough for production',
-      })
-    ).resolves.toBeUndefined();
-    expect(db.write.appBlockPublishRequest.update).toHaveBeenCalled();
+  /**
+   * Deliberately WIDER than `draftDeleteCalls()`. That helper matches the exact old
+   * predicate, so a mutant that restores the delete with any OTHER shape — a different
+   * `where`, a `delete` instead of `deleteMany` — would walk straight through it. This
+   * asserts the reject path performs NO destructive `AppListing` write at all, which is
+   * the claim that actually protects the developer's listing.
+   */
+  it('performs NO AppListing delete of any shape', async () => {
+    await rejectRequest({
+      publishRequestId: 'req_1',
+      reviewerUserId: 9,
+      rejectionReason: 'not good enough for production',
+    });
+    expect(db.write.appListing.deleteMany).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The slug must still be RESERVED after the reject — that is the half a "we stopped
+   * deleting" test cannot see on its own. Nothing in the reject path may release it, so
+   * the developer's chosen slug is still theirs when they fix the problem and re-submit
+   * (`submitVersion` then REUSES the surviving draft, owner-scoped).
+   */
+  it('leaves the listing row — and therefore the slug — untouched', async () => {
+    await rejectRequest({
+      publishRequestId: 'req_1',
+      reviewerUserId: 9,
+      rejectionReason: 'missing a screenshot',
+    });
+    expect(db.write.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(db.write.appListing.updateMany).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/blocks/app-listing-history.service.ts
+++ b/src/server/services/blocks/app-listing-history.service.ts
@@ -101,9 +101,13 @@ export const LISTING_HISTORY_LIMIT = 50;
  * 🔴 THE FALLBACK IS `slug`, AND IT MUST BE OWNER-SCOPED. `slug` is the identity that
  * carries a first request across its whole lifecycle (it is NOT NULL on the request and
  * `app_listings_slug_key` is unconditionally UNIQUE), so it is the only join left when the
- * FK is null. But a slug is RELEASED when a first version is rejected or withdrawn — the
- * draft listing is deleted — so the same slug can later belong to a DIFFERENT user. An
- * unscoped slug match would hand that new owner the previous applicant's rejection reason.
+ * FK is null. But a slug can be RELEASED — a first version that is WITHDRAWN deletes its
+ * draft listing, and a mod `purgeListing` on an orphan draft does the same — so the slug
+ * can later belong to a DIFFERENT user. An unscoped slug match would hand that new owner
+ * the previous applicant's rejection reason.
+ *
+ * (A REJECT no longer releases the slug — clawgate #302 — but that shrinks the population
+ * this guard protects, it does not retire the guard: withdraw and purge still do.)
  * Scoping to the listing's CANONICAL OWNER (never to the viewer) closes that without
  * re-introducing the submitter-scoping bug: an accepted collaborator still sees the
  * owner's history, because the scope names the owner and not the caller.
@@ -348,13 +352,23 @@ export const ORPHAN_SCAN_LIMIT = ORPHANED_SUBMISSIONS_LIMIT * 4;
  *
  * 🔴 WHY A SECOND, SUBMITTER-SCOPED READ EXISTS AT ALL, in a PR whose whole point is that
  * submitter-scoping is the bug. Because for THIS population there is no app to key on. A
- * first version that is rejected or withdrawn has its pre-approval DRAFT listing DELETED —
- * `deleteOnsiteDraftListingForSlug` runs in both `rejectRequest` and `withdrawRequest` — so
- * the row `/apps/mine` would hang the history off is gone, while the request itself
- * survives with its `slug`, `status`, `rejection_reason` and `submitted_by_user_id` intact.
- * Measured on production 2026-08-20: **3 of 3 rejected** and **27 of 33 withdrawn** block
- * requests are in exactly this state. Submitter-scoping is not a policy choice here; it is
- * the only identity left on the record.
+ * first version whose pre-approval DRAFT listing was DELETED leaves no row for `/apps/mine`
+ * to hang the history off, while the request itself survives with its `slug`, `status`,
+ * `rejection_reason` and `submitted_by_user_id` intact. Measured on production 2026-08-20:
+ * **3 of 3 rejected** and **27 of 33 withdrawn** block requests were in exactly this state.
+ * Submitter-scoping is not a policy choice here; it is the only identity left on the record.
+ *
+ * 🔴 THE REJECTED HALF OF THAT POPULATION STOPS GROWING (clawgate #302). `rejectRequest` no
+ * longer runs `deleteOnsiteDraftListingForSlug`, so a NEWLY rejected first version keeps its
+ * draft — its slug then resolves to a listing the caller owns, the de-dup below EXCLUDES it,
+ * and it renders on the app-keyed table instead via {@link blockRequestWhereForListing}'s
+ * null-FK slug branch (which matches it: `kind:'onsite'`, owner === submitter). That is a
+ * strictly better home — it hangs off the listing they can now fix and re-submit.
+ *
+ * This function is NOT dead as a result, and must not be deleted on that reasoning: the 3
+ * historically-rejected rows above have no listing to come back to, WITHDRAWN first versions
+ * still delete their draft (27 of 33, the larger half), and a mod `purgeListing` on an orphan
+ * draft creates a fresh one every time it is used.
  *
  * 🔴 THE DELETION IS DELIBERATELY LEFT ALONE. `app_listings_slug_key` is an UNCONDITIONAL
  * UNIQUE index, so deleting the draft is the cleanest slug release available; a partial

--- a/src/server/services/blocks/app-listing-notify.ts
+++ b/src/server/services/blocks/app-listing-notify.ts
@@ -20,6 +20,10 @@ export type AppListingOwnerNotificationType =
   | 'app-listing-approved'
   | 'app-listing-rejected'
   | 'app-listing-hidden'
+  // Emitted ONLY by `purgeListing`'s on-site orphan-pre-approval-draft arm. The off-site
+  // arm deliberately stays silent: it is only reachable on an already-`removed` listing,
+  // i.e. after a `delistListing` that already notified. See the 🔴 note at the call site.
+  | 'app-listing-purged'
   | 'app-listing-reset-to-pending';
 
 export async function notifyAppListingOwner(opts: {

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -843,6 +843,20 @@ export type ModerationListingRow = {
     changelog: string | null;
     submittedBy: ModerationUserChip | null;
   } | null;
+  /**
+   * 🔴 ON-SITE ONLY, AND NOT THE SAME THING AS `pendingRequest`.
+   *
+   * `pendingRequest` above comes from the `AppListingPublishRequest` relation, whose
+   * `appListingId` the schema documents as "On-site: NULL until approve". So for an on-site
+   * PRE-APPROVAL DRAFT it is `null` no matter what — the live submission behind that row is an
+   * `AppBlockPublishRequest`, joined to the listing by the shared `@unique` SLUG and by no
+   * foreign key at all.
+   *
+   * This flag is that missing signal, resolved by a slug-keyed lookup. Without it the table
+   * cannot tell an ABANDONED draft from one under active review, and offered the destructive
+   * Purge action on both. Always `false` for an off-site row (whose requests do carry the FK).
+   */
+  hasPendingBlockRequest: boolean;
 };
 
 /**
@@ -879,10 +893,22 @@ type HydratedModerationRow = Prisma.AppListingGetPayload<{
   select: typeof moderationListingSelect;
 }>;
 
-/** Project a hydrated moderation row → the {@link ModerationListingRow} DTO. */
-export function projectModerationListing(row: HydratedModerationRow): ModerationListingRow {
+/**
+ * Project a hydrated moderation row → the {@link ModerationListingRow} DTO.
+ *
+ * `pendingBlockRequestSlugs` is the set of slugs with a live `AppBlockPublishRequest`,
+ * resolved by the caller in one batched query (there is no FK to include). A caller that
+ * cannot resolve it passes an empty set — see the 🔴 note on `hasPendingBlockRequest`, and
+ * note that an empty set is the PERMISSIVE direction, so only the mod-table read (which does
+ * resolve it) may drive a destructive affordance from this field.
+ */
+export function projectModerationListing(
+  row: HydratedModerationRow,
+  pendingBlockRequestSlugs: ReadonlySet<string> = new Set()
+): ModerationListingRow {
   const pending = row.publishRequests[0] ?? null;
   return {
+    hasPendingBlockRequest: row.kind === 'onsite' && pendingBlockRequestSlugs.has(row.slug),
     id: row.id,
     slug: row.slug,
     name: row.name,
@@ -984,6 +1010,24 @@ export async function listAllListingsForModeration(
 
   const hasNext = rows.length > limit;
   const page = hasNext ? rows.slice(0, limit) : rows;
-  const items = page.map(projectModerationListing);
+
+  // 🔴 The on-site "is this draft under review?" signal, which no `include` can supply: an
+  // on-site `AppBlockPublishRequest` is joined to its listing by the shared `@unique` SLUG
+  // and carries no FK (`AppListingPublishRequest.appListingId` is "On-site: NULL until
+  // approve"). One batched query over just this page's on-site slugs, so it stays O(1) reads
+  // regardless of page size and costs nothing on an all-off-site page.
+  const onsiteSlugs = page.filter((r) => r.kind === 'onsite').map((r) => r.slug);
+  const pendingBlockRequestSlugs = new Set<string>(
+    onsiteSlugs.length
+      ? (
+          await dbRead.appBlockPublishRequest.findMany({
+            where: { slug: { in: onsiteSlugs }, status: 'pending' },
+            select: { slug: true },
+          })
+        ).map((r: { slug: string }) => r.slug)
+      : []
+  );
+
+  const items = page.map((r) => projectModerationListing(r, pendingBlockRequestSlugs));
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
 }

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -315,8 +315,82 @@ async function classifyOffsiteListing(
 }
 
 /**
- * Load + classify a listing for the DUAL-KIND delist/relist actions (which apply to
- * BOTH kinds, unlike claim/purge which stay offsite-only via `classifyOffsiteListing`).
+ * The Prisma predicate for "a listing a mod may PURGE".
+ *
+ * Two disjoint shapes:
+ *   - any OFF-SITE listing (unchanged — purge has always been the off-site final expunge);
+ *   - an ON-SITE **orphan pre-approval draft**: `status:'draft'` + `appBlockId: null`
+ *     (never approved, so no backing `AppBlock`) + `revisionOfId: null`.
+ *
+ * 🔴 `revisionOfId: null` IS LOAD-BEARING — it is the whole difference between this and
+ * `deleteOnsiteDraftListingForSlug`'s clause, which looks identical and is NOT safe to
+ * reuse here. A SHADOW media revision (`beginListingRevision`) is created with the
+ * PARENT's `kind`, `status:'draft'` and `appBlockId: null` — so it matches every other
+ * term. That clause gets away with it only because it resolves BY SLUG and a shadow's
+ * slug is a synthetic `rev-<ulid>`; a purge resolves BY ID, so without this term a mod
+ * could hard-delete an in-flight media revision of a LIVE, approved on-site app.
+ *
+ * 🔴 And the on-site arm must NEVER widen past `draft`: an `approved`/`removed` on-site
+ * listing has a backing `AppBlock` whose runtime serving gate reads `app_blocks.status`,
+ * so deleting the listing row would hide the store card while leaving the hosted app
+ * serving. `delistListing` is the correct action for those, and it is deliberately
+ * status-guarded to `{approved, removed}` — the two sets do not overlap.
+ */
+const PURGEABLE_LISTING_WHERE = {
+  OR: [
+    { kind: 'offsite' },
+    { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
+  ],
+} satisfies Prisma.AppListingWhereInput;
+
+/** Does an already-loaded row satisfy {@link PURGEABLE_LISTING_WHERE}? Kept beside it so
+ * the in-memory guard and the SQL guard can only drift together. */
+function isPurgeableListing(row: {
+  kind: string;
+  status: string;
+  appBlockId: string | null;
+  revisionOfId: string | null;
+}): boolean {
+  if (row.kind === 'offsite') return true;
+  return (
+    row.kind === 'onsite' &&
+    row.status === 'draft' &&
+    row.appBlockId === null &&
+    row.revisionOfId === null
+  );
+}
+
+/**
+ * Load + classify a listing for PURGE. A missing listing, and any listing outside
+ * {@link PURGEABLE_LISTING_WHERE}, BOTH raise the SAME generic NOT_FOUND — same
+ * info-leak parity as `classifyOffsiteListing`, so a mod caller cannot probe a
+ * listing's kind, status or existence through this surface.
+ */
+async function classifyPurgeableListing(
+  appListingId: string
+): Promise<{ id: string; kind: string; status: string; slug: string }> {
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: {
+      id: true,
+      kind: true,
+      status: true,
+      slug: true,
+      appBlockId: true,
+      revisionOfId: true,
+    },
+  });
+  if (!listing || !isPurgeableListing(listing)) {
+    throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
+  }
+  return { id: listing.id, kind: listing.kind, status: listing.status, slug: listing.slug };
+}
+
+/**
+ * Load + classify a listing for the DUAL-KIND delist/relist actions (which apply to BOTH
+ * kinds at any status, unlike `claim` — still offsite-only via `classifyOffsiteListing` —
+ * and `purge`, which takes any off-site listing but only ONE on-site shape, the orphan
+ * pre-approval draft, via `classifyPurgeableListing`).
  * Returns the fields those actions need: kind (to branch the on-site dual-table flip),
  * status/slug, the backing `appBlockId` (on-site: flip the block's status too), and
  * the owner `userId` (the hide-notification target, for either kind). A missing listing →
@@ -816,8 +890,20 @@ export async function claimListing(opts: {
 export type PurgeListingResult = { appListingId: string; purged: true };
 
 /**
- * MOD hard-delete (purge) an off-site listing — the genuine final expunge that
- * also makes the delist round-trip self-cleaning.
+ * MOD hard-delete (purge) a listing — the genuine final expunge that also makes the
+ * delist round-trip self-cleaning. Targets are {@link PURGEABLE_LISTING_WHERE}: any
+ * OFF-SITE listing, or an ON-SITE orphan pre-approval draft.
+ *
+ * 🔴 THE ON-SITE ARM IS THE DELIBERATE REPLACEMENT FOR A SILENT SIDE-EFFECT, NOT NEW
+ * DESTRUCTIVE POWER. `rejectRequest` used to run `deleteOnsiteDraftListingForSlug` on
+ * every reject, so rejecting a first-time developer over a fixable problem destroyed the
+ * store listing they had built and released their slug — invisibly, with no reason
+ * recorded and no way for a reviewer to decline it. That call is gone (clawgate #302).
+ * The same delete now happens only when a mod ASKS for it, through this path: explicit
+ * target, required reason, and an `action:'purge'` audit event. Same bytes removed, but
+ * chosen and attributable. Removing this arm without restoring some other on-site
+ * removal path would leave an orphan draft holding its slug with NO recourse —
+ * `delistListing` is status-guarded to `{approved, removed}` and cannot touch a draft.
  *
  * 🔴 ORDER MATTERS: the audit event is written FIRST (capturing the slug snapshot +
  * the pre-delete status), THEN the `AppListing` row is deleted. The event's
@@ -845,21 +931,34 @@ export async function purgeListing(opts: {
 }): Promise<PurgeListingResult> {
   const { input, reviewerUserId } = opts;
   const reason = requireModReason(input.reason);
-  // Fail-fast + info-leak parity (replica): a missing OR on-site listing throws the
-  // same generic NOT_FOUND before any tx is opened. The authoritative snapshot is
-  // re-read on the primary inside the tx below.
-  await classifyOffsiteListing(input.appListingId);
+  // Fail-fast + info-leak parity (replica): a missing listing, and any listing outside
+  // PURGEABLE_LISTING_WHERE, both throw the same generic NOT_FOUND before any tx is
+  // opened. The authoritative snapshot is re-read on the primary inside the tx below.
+  await classifyPurgeableListing(input.appListingId);
 
   await dbWrite.$transaction(async (tx) => {
     // Authoritative pre-delete snapshot from the PRIMARY (not the replica classify),
-    // so `before.status` + `slug` reflect the true current row and the kind guard is
-    // re-checked on the primary. A row that vanished (or turned non-offsite) between
-    // classify and here → generic NOT_FOUND, tx rolls back with no event written.
+    // so `before.status` + `slug` reflect the true current row and the purgeability
+    // guard is re-checked on the primary. A row that vanished (or moved out of the
+    // purgeable set) between classify and here → generic NOT_FOUND, tx rolls back with
+    // no event written.
+    //
+    // 🔴 RE-CHECKING ON THE PRIMARY IS NOT REDUNDANT FOR THE ON-SITE ARM — it is the
+    // race that matters. `approveRequest` turns exactly this row from an orphan draft
+    // into an APPROVED listing with a backing AppBlock, so a purge that classified
+    // against a lagging replica could otherwise delete a live app's store card. The
+    // predicate is re-evaluated here and AGAIN in the `deleteMany` below.
     const current = await tx.appListing.findUnique({
       where: { id: input.appListingId },
-      select: { status: true, slug: true, kind: true },
+      select: {
+        status: true,
+        slug: true,
+        kind: true,
+        appBlockId: true,
+        revisionOfId: true,
+      },
     });
-    if (!current || current.kind !== 'offsite') {
+    if (!current || !isPurgeableListing(current)) {
       throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
     // Event FIRST (so the slug/state snapshot is captured before the row is gone).
@@ -875,12 +974,13 @@ export async function purgeListing(opts: {
       },
     });
     // THEN the hard delete (nulls the event's appListingId via SetNull; cascades
-    // screenshots + reports). The inline `kind: 'offsite'` guard mirrors delist/relist
-    // for defense-in-depth on a DESTRUCTIVE op — a 0-count delete (raced, or a
-    // non-offsite row slipping past classify) throws → the tx (incl. the event) rolls
-    // back.
+    // screenshots + reports). The inline purgeability guard mirrors delist/relist for
+    // defense-in-depth on a DESTRUCTIVE op — a 0-count delete (raced, or a row slipping
+    // past both classify AND the primary re-read) throws → the tx (incl. the event)
+    // rolls back. This is the SQL twin of `isPurgeableListing` above; they are kept
+    // next to each other so they can only drift together.
     const deleted = await tx.appListing.deleteMany({
-      where: { id: input.appListingId, kind: 'offsite' },
+      where: { id: input.appListingId, ...PURGEABLE_LISTING_WHERE },
     });
     if (deleted.count === 0) {
       // Raced (concurrently purged between the snapshot and here) → roll the event back.

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -335,30 +335,70 @@ async function classifyOffsiteListing(
  * so deleting the listing row would hide the store card while leaving the hosted app
  * serving. `delistListing` is the correct action for those, and it is deliberately
  * status-guarded to `{approved, removed}` — the two sets do not overlap.
+ *
+ * 🔴 `publishRequests: { none: { status: 'pending' } }` is the ORPHAN half of "orphan draft",
+ * and it is not decoration either. A first-version draft whose request is still `pending` is
+ * a submission UNDER REVIEW, not an abandoned one: purging it deletes the listing out from
+ * under a live request that has no FK to it (the two are joined by slug alone), so the slug
+ * is released while the request still points at it. Approving that request afterwards falls
+ * back to the legacy approve-time create path and re-mints the listing — on a slug another
+ * user may have taken in the meantime, which is the collision this whole predicate exists to
+ * avoid. The correct order is reject-or-withdraw first, THEN purge, and this term enforces
+ * it. It also makes the predicate agree exactly with what the mod table already calls a
+ * "draft" (`moderationStatusWhere`: `status:'draft'` + no pending request).
  */
 const PURGEABLE_LISTING_WHERE = {
   OR: [
     { kind: 'offsite' },
-    { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
+    {
+      kind: 'onsite',
+      status: 'draft',
+      appBlockId: null,
+      revisionOfId: null,
+      publishRequests: { none: { status: 'pending' } },
+    },
   ],
 } satisfies Prisma.AppListingWhereInput;
 
-/** Does an already-loaded row satisfy {@link PURGEABLE_LISTING_WHERE}? Kept beside it so
- * the in-memory guard and the SQL guard can only drift together. */
+/**
+ * Does an already-loaded row satisfy {@link PURGEABLE_LISTING_WHERE}? Kept beside it so the
+ * in-memory guard and the SQL guard can only drift together.
+ *
+ * `pendingRequestCount` is the caller's projection of the relation term above — both reads
+ * select `publishRequests` filtered to `status:'pending'` with `take: 1`, so a non-empty
+ * array means "under review". It is a REQUIRED field rather than an optional one on purpose:
+ * an optional would default to "no pending request" for a caller that forgot to select it,
+ * which is the permissive direction on a destructive op.
+ */
 function isPurgeableListing(row: {
   kind: string;
   status: string;
   appBlockId: string | null;
   revisionOfId: string | null;
+  pendingRequestCount: number;
 }): boolean {
   if (row.kind === 'offsite') return true;
   return (
     row.kind === 'onsite' &&
     row.status === 'draft' &&
     row.appBlockId === null &&
-    row.revisionOfId === null
+    row.revisionOfId === null &&
+    row.pendingRequestCount === 0
   );
 }
+
+/** The `select` both purge reads use — every field {@link isPurgeableListing} inspects, so
+ * neither call site can hand it an `undefined` the guard would then judge. */
+const PURGE_CLASSIFY_SELECT = {
+  kind: true,
+  status: true,
+  slug: true,
+  userId: true,
+  appBlockId: true,
+  revisionOfId: true,
+  name: true,
+  publishRequests: { where: { status: 'pending' }, take: 1, select: { id: true } },
+} satisfies Prisma.AppListingSelect;
 
 /**
  * Load + classify a listing for PURGE. A missing listing, and any listing outside
@@ -368,22 +408,18 @@ function isPurgeableListing(row: {
  */
 async function classifyPurgeableListing(
   appListingId: string
-): Promise<{ id: string; kind: string; status: string; slug: string }> {
+): Promise<{ kind: string; status: string; slug: string }> {
   const listing = await dbRead.appListing.findUnique({
     where: { id: appListingId },
-    select: {
-      id: true,
-      kind: true,
-      status: true,
-      slug: true,
-      appBlockId: true,
-      revisionOfId: true,
-    },
+    select: PURGE_CLASSIFY_SELECT,
   });
-  if (!listing || !isPurgeableListing(listing)) {
+  if (
+    !listing ||
+    !isPurgeableListing({ ...listing, pendingRequestCount: listing.publishRequests.length })
+  ) {
     throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
   }
-  return { id: listing.id, kind: listing.kind, status: listing.status, slug: listing.slug };
+  return { kind: listing.kind, status: listing.status, slug: listing.slug };
 }
 
 /**
@@ -936,7 +972,11 @@ export async function purgeListing(opts: {
   // opened. The authoritative snapshot is re-read on the primary inside the tx below.
   await classifyPurgeableListing(input.appListingId);
 
-  await dbWrite.$transaction(async (tx) => {
+  // RETURNED by the tx (rather than captured in a `let`) when the purged row was an ON-SITE
+  // orphan draft; drives the post-commit owner notification below. Null for the off-site arm
+  // — see the 🔴 note there. Returning it also means a tx that THROWS yields no value at all,
+  // so a rolled-back purge can never reach the notification.
+  const purgedOnsiteDraft = await dbWrite.$transaction(async (tx) => {
     // Authoritative pre-delete snapshot from the PRIMARY (not the replica classify),
     // so `before.status` + `slug` reflect the true current row and the purgeability
     // guard is re-checked on the primary. A row that vanished (or moved out of the
@@ -950,17 +990,21 @@ export async function purgeListing(opts: {
     // predicate is re-evaluated here and AGAIN in the `deleteMany` below.
     const current = await tx.appListing.findUnique({
       where: { id: input.appListingId },
-      select: {
-        status: true,
-        slug: true,
-        kind: true,
-        appBlockId: true,
-        revisionOfId: true,
-      },
+      select: PURGE_CLASSIFY_SELECT,
     });
-    if (!current || !isPurgeableListing(current)) {
+    if (
+      !current ||
+      !isPurgeableListing({ ...current, pendingRequestCount: current.publishRequests.length })
+    ) {
       throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
+    // Read INSIDE the tx, from the row we are about to delete, for the post-commit
+    // notification below — after the delete there is nothing left to read it from. Held in a
+    // local and returned at the end of the callback, AFTER the delete has been confirmed.
+    const onsiteDraftOwner =
+      current.kind === 'onsite'
+        ? { userId: current.userId, slug: current.slug, name: current.name }
+        : null;
     // Event FIRST (so the slug/state snapshot is captured before the row is gone).
     await tx.appListingModerationEvent.create({
       data: {
@@ -986,7 +1030,45 @@ export async function purgeListing(opts: {
       // Raced (concurrently purged between the snapshot and here) → roll the event back.
       throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
+    return onsiteDraftOwner;
   });
+
+  // POST-COMMIT, best-effort — tell the owner their pre-approval draft was removed.
+  //
+  // 🔴 ON-SITE ARM ONLY, and the asymmetry is deliberate rather than an oversight. An
+  // off-site purge is only ever offered on an already-`removed` listing, i.e. AFTER a
+  // `delistListing` that notified the owner itself — so notifying again would double up on
+  // an event they have already been told about. The on-site orphan-draft arm has no such
+  // predecessor: it is reachable directly from a `draft` row, so without this the
+  // developer's listing, its media and their slug would vanish with nothing sent at all.
+  // (They were told their SUBMISSION was rejected — `app-block-rejected` — which is a
+  // different event about a different object, and says nothing about the listing going away.)
+  //
+  // Best-effort and post-commit, mirroring every other notify in this file: the purge has
+  // already committed, so a notification failure must never affect the outcome.
+  if (purgedOnsiteDraft) {
+    try {
+      await notifyAppListingOwner({
+        type: 'app-listing-purged',
+        userId: purgedOnsiteDraft.userId,
+        // Keyed by LISTING id, not slug: the slug is released by this very delete and can
+        // legitimately belong to someone else later, so a slug key could dedup a different
+        // developer's notification away.
+        key: `app-listing-purged:${input.appListingId}`,
+        details: {
+          slug: purgedOnsiteDraft.slug,
+          name: purgedOnsiteDraft.name,
+          reason,
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[purgeListing] owner notification failed (id=${input.appListingId}); purge STANDS: ` +
+          `${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
 
   return { appListingId: input.appListingId, purged: true };
 }

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -390,6 +390,18 @@ function isPurgeableListing(row: {
  * not by the delete's own predicate. That is a genuinely weaker guarantee than the other terms
  * have, and it is stated here rather than papered over.
  *
+ * 🔴 RESIDUAL RACE, KNOWN AND NOT CLOSED. This is a plain read under READ COMMITTED with no row
+ * lock, so a `submitVersion` that commits between this check and the `deleteMany` yields exactly
+ * the state the check exists to prevent: a pending request whose listing is gone and whose slug
+ * is released. Window is milliseconds.
+ *
+ * 🔴 And the obvious fix does NOT work as a one-sided change. A slug-scoped
+ * `pg_advisory_xact_lock` taken here excludes nothing unless `submitVersion` takes the SAME
+ * lock — a lock is mutual exclusion only between parties that both acquire it, and that path
+ * currently takes none. Closing this properly means touching the submit path too, which is why
+ * it is disclosed rather than half-fixed: a lock added on this side alone would read like a fix
+ * and change nothing, which is the failure mode this whole guard already had once.
+ *
  * Off-site is exempt by construction: an off-site draft's request DOES carry `appListingId`,
  * its purge arm is reachable only at `status:'removed'`, and the pre-existing behaviour there
  * is deliberately unchanged.
@@ -404,9 +416,19 @@ async function assertNoLivePendingSubmission(
     select: { id: true },
   });
   if (live) {
-    // Same generic NOT_FOUND as every other purge refusal — a mod caller must not be able to
-    // probe whether a slug has a live submission through this surface.
-    throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
+    // 🔴 ACTIONABLE, not the generic NOT_FOUND the other refusals use — and the difference is
+    // deliberate. The generic message exists so a caller cannot PROBE a listing's kind or
+    // status; that rationale does not apply here, because this surface is
+    // `moderatorProcedure` + an `isModerator` recheck and the mod table now ships this very
+    // fact to that very audience as `ModerationListingRow.hasPendingBlockRequest`. Hiding it
+    // in the error would conceal nothing and would leave the moderator staring at "not found"
+    // for a listing visibly on their screen — reachable from ordinary replica lag between the
+    // table read and the click. Mirrors `resetOnsiteListingToPending`'s wording for the same
+    // condition.
+    throw new OffsiteModerationError(
+      'NOT_TRANSITIONABLE',
+      'A review is already pending for this app — reject or withdraw it before purging.'
+    );
   }
 }
 

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -336,55 +336,78 @@ async function classifyOffsiteListing(
  * serving. `delistListing` is the correct action for those, and it is deliberately
  * status-guarded to `{approved, removed}` — the two sets do not overlap.
  *
- * 🔴 `publishRequests: { none: { status: 'pending' } }` is the ORPHAN half of "orphan draft",
- * and it is not decoration either. A first-version draft whose request is still `pending` is
- * a submission UNDER REVIEW, not an abandoned one: purging it deletes the listing out from
- * under a live request that has no FK to it (the two are joined by slug alone), so the slug
- * is released while the request still points at it. Approving that request afterwards falls
- * back to the legacy approve-time create path and re-mints the listing — on a slug another
- * user may have taken in the meantime, which is the collision this whole predicate exists to
- * avoid. The correct order is reject-or-withdraw first, THEN purge, and this term enforces
- * it. It also makes the predicate agree exactly with what the mod table already calls a
- * "draft" (`moderationStatusWhere`: `status:'draft'` + no pending request).
+ * 🔴 "NOT UNDER REVIEW" IS **NOT** IN THIS PREDICATE, AND CANNOT BE. It is enforced
+ * separately by {@link assertNoLivePendingSubmission}. An earlier revision of this code put
+ * `publishRequests: { none: { status: 'pending' } }` right here, which reads correctly and is
+ * INERT: `AppListing.publishRequests` is the `AppListingPublishRequest` relation, whose
+ * `appListingId` is documented in the schema as "On-site: NULL until approve". The live
+ * submission behind an on-site pre-approval draft is an **`AppBlockPublishRequest`**, joined to
+ * the listing by the shared `@unique` SLUG and by nothing else — there is no FK for a Prisma
+ * relation filter to traverse. So on the one shape this arm accepts, that relation is provably
+ * always empty, `none` is trivially true, and the guard permitted exactly what it claimed to
+ * forbid. Do not "restore" it here.
  */
 const PURGEABLE_LISTING_WHERE = {
   OR: [
     { kind: 'offsite' },
-    {
-      kind: 'onsite',
-      status: 'draft',
-      appBlockId: null,
-      revisionOfId: null,
-      publishRequests: { none: { status: 'pending' } },
-    },
+    { kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null },
   ],
 } satisfies Prisma.AppListingWhereInput;
 
-/**
- * Does an already-loaded row satisfy {@link PURGEABLE_LISTING_WHERE}? Kept beside it so the
- * in-memory guard and the SQL guard can only drift together.
- *
- * `pendingRequestCount` is the caller's projection of the relation term above — both reads
- * select `publishRequests` filtered to `status:'pending'` with `take: 1`, so a non-empty
- * array means "under review". It is a REQUIRED field rather than an optional one on purpose:
- * an optional would default to "no pending request" for a caller that forgot to select it,
- * which is the permissive direction on a destructive op.
- */
+/** Does an already-loaded row satisfy {@link PURGEABLE_LISTING_WHERE}? Kept beside it so the
+ * in-memory guard and the SQL guard can only drift together. The "not under review" half is
+ * NOT here — see {@link assertNoLivePendingSubmission}. */
 function isPurgeableListing(row: {
   kind: string;
   status: string;
   appBlockId: string | null;
   revisionOfId: string | null;
-  pendingRequestCount: number;
 }): boolean {
   if (row.kind === 'offsite') return true;
   return (
     row.kind === 'onsite' &&
     row.status === 'draft' &&
     row.appBlockId === null &&
-    row.revisionOfId === null &&
-    row.pendingRequestCount === 0
+    row.revisionOfId === null
   );
+}
+
+/**
+ * 🔴 THE ORPHAN HALF OF "ORPHAN DRAFT", and the reason it is a separate READ rather than a
+ * term of {@link PURGEABLE_LISTING_WHERE}.
+ *
+ * A first-version on-site draft whose `AppBlockPublishRequest` is still `pending` is a
+ * submission UNDER REVIEW, not an abandoned one. Purging it hard-deletes the listing out from
+ * under a live request and RELEASES THE SLUG, while the request still names it; approving that
+ * request afterwards falls back to the legacy approve-time create path and re-mints the listing
+ * on a slug another developer may have taken in between. The correct order is
+ * reject-or-withdraw first, THEN purge.
+ *
+ * It cannot live in the `where`: the join is `AppBlockPublishRequest.slug === AppListing.slug`
+ * with no foreign key, and Prisma relation filters can only traverse declared relations. So
+ * this is an explicit query, and the consequence is that the `deleteMany` guard CANNOT carry
+ * this term — the delete is protected by this check running earlier in the SAME transaction,
+ * not by the delete's own predicate. That is a genuinely weaker guarantee than the other terms
+ * have, and it is stated here rather than papered over.
+ *
+ * Off-site is exempt by construction: an off-site draft's request DOES carry `appListingId`,
+ * its purge arm is reachable only at `status:'removed'`, and the pre-existing behaviour there
+ * is deliberately unchanged.
+ */
+async function assertNoLivePendingSubmission(
+  client: Pick<typeof dbWrite, 'appBlockPublishRequest'>,
+  listing: { kind: string; slug: string }
+): Promise<void> {
+  if (listing.kind !== 'onsite') return;
+  const live = await client.appBlockPublishRequest.findFirst({
+    where: { slug: listing.slug, status: 'pending' },
+    select: { id: true },
+  });
+  if (live) {
+    // Same generic NOT_FOUND as every other purge refusal — a mod caller must not be able to
+    // probe whether a slug has a live submission through this surface.
+    throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
+  }
 }
 
 /** The `select` both purge reads use — every field {@link isPurgeableListing} inspects, so
@@ -397,7 +420,6 @@ const PURGE_CLASSIFY_SELECT = {
   appBlockId: true,
   revisionOfId: true,
   name: true,
-  publishRequests: { where: { status: 'pending' }, take: 1, select: { id: true } },
 } satisfies Prisma.AppListingSelect;
 
 /**
@@ -413,12 +435,11 @@ async function classifyPurgeableListing(
     where: { id: appListingId },
     select: PURGE_CLASSIFY_SELECT,
   });
-  if (
-    !listing ||
-    !isPurgeableListing({ ...listing, pendingRequestCount: listing.publishRequests.length })
-  ) {
+  if (!listing || !isPurgeableListing(listing)) {
     throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
   }
+  // Fail-fast on the replica. The authoritative repeat runs inside the tx on the PRIMARY.
+  await assertNoLivePendingSubmission(dbRead, listing);
   return { kind: listing.kind, status: listing.status, slug: listing.slug };
 }
 
@@ -992,12 +1013,14 @@ export async function purgeListing(opts: {
       where: { id: input.appListingId },
       select: PURGE_CLASSIFY_SELECT,
     });
-    if (
-      !current ||
-      !isPurgeableListing({ ...current, pendingRequestCount: current.publishRequests.length })
-    ) {
+    if (!current || !isPurgeableListing(current)) {
       throw new OffsiteModerationError('NOT_FOUND', 'Standalone listing not found.');
     }
+    // 🔴 AUTHORITATIVE, on the PRIMARY, inside the tx — and this is the ONLY place the
+    // "not under review" rule is actually enforced against the delete, because it cannot be
+    // expressed in the `deleteMany` predicate below (no FK to traverse; see the fn's note).
+    // A throw here rolls the tx back before the audit event is written.
+    await assertNoLivePendingSubmission(tx, current);
     // Read INSIDE the tx, from the row we are about to delete, for the post-commit
     // notification below — after the delete there is nothing left to read it from. Held in a
     // local and returned at the end of the callback, AFTER the delete has been confirmed.
@@ -1059,6 +1082,12 @@ export async function purgeListing(opts: {
           slug: purgedOnsiteDraft.slug,
           name: purgedOnsiteDraft.name,
           reason,
+          // 🔴 CARRIED FOR THE SAME REASON THE KEY IS ID-SCOPED, and it matters more here
+          // than at the sibling call sites: this delete RELEASES the slug, so `slug` above
+          // can legitimately belong to a DIFFERENT developer later. `details` is written
+          // once and never repaired, so a payload whose only identifier is a recycled slug
+          // would resolve to a stranger's listing the moment anything reads it.
+          listingId: input.appListingId,
         },
       });
     } catch (err) {

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -5200,6 +5200,21 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
   //
   // `withdrawRequest` KEEPS its delete: that is the developer's own act of abandoning the
   // submission, so releasing their slug is what they asked for.
+  //
+  // ⚠ KNOWN AND NOT FIXED HERE: the OFF-SITE reject still deletes its draft
+  // (`offsite-listing.service.ts` → `closeTerminalListing`'s `draft` branch). Every word of
+  // the argument above applies there verbatim — `rejectExternalRequest` is that reviewer's
+  // only rejection verb too — so an off-site developer rejected over a fixable problem still
+  // loses their listing and their slug. That is scope, not a justification for the
+  // divergence, and it is the obvious follow-up.
+  //
+  // ⚠ ALSO KNOWN: a reused draft keeps the scalars minted from the REJECTED manifest until the
+  // re-submit is approved. `submitVersion`'s reuse branch writes nothing, so if name/tagline/
+  // description/category/contentRating changed between the two submits, `/apps/mine` shows the
+  // old copy for the re-review window. Bounded and cosmetic — `approveRequest`'s draft→approved
+  // transition re-syncs every manifest-governed scalar and re-floors the rating, so the
+  // APPROVED card is correct, and the asset-attach path does not gate on the listing's
+  // `contentRating`, so a stale rating is NOT an NSFW-gate bypass.
 
   // MOD REVIEW SANDBOX (#2831) — tear down any review env the mod spun up.
   // Best-effort + non-blocking: the reject has landed, so a teardown failure

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1187,7 +1187,8 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
   // status='draft', appBlockId=NULL) so the author can set listing media
   // (icon/cover/screenshots) WHILE the app is still pending review (they carry
   // forward on approve). Mirrors the proven off-site `submitExternalListing` shape (a
-  // draft listing minted at submit, deleted on reject/withdraw). Only a first-version
+  // draft listing minted at submit, deleted on withdraw — NOT on reject, which keeps it
+  // so a rejected developer can fix and re-submit; see `rejectRequest`). Only a first-version
   // submit (`existingApp == null`) is meaningful: a subsequent version already has an
   // approved listing whose media edits go through the shadow-revision path.
   //
@@ -1195,8 +1196,15 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
   // already taken in `app_listings` by a NON-reusable listing — the draft reserves
   // `AppListing.slug @unique`, and the friendly error mirrors `submitExternalListing`'s
   // slug pre-check. An existing on-site pre-approval DRAFT for this slug (no backing
-  // AppBlock) is a REUSABLE orphan (a prior submit whose reject/withdraw cleanup didn't
-  // run) — reuse it idempotently rather than error, so a re-submit never duplicates.
+  // AppBlock) is a REUSABLE orphan — reuse it idempotently rather than error, so a
+  // re-submit never duplicates.
+  //
+  // 🔴 THIS REUSE IS NOW THE LOAD-BEARING HALF OF THE REJECT→RE-SUBMIT LOOP, not just a
+  // tidy-up for a cleanup that didn't run. `rejectRequest` deliberately LEAVES the draft
+  // standing (clawgate #302), so the ordinary path for a developer rejected over a
+  // fixable problem is: fix it, re-submit the same slug, land HERE, and get their own
+  // listing back with its media intact. Narrowing this predicate — or restoring the
+  // reject-time delete — silently reintroduces "rejected once ⇒ lost your listing".
   //
   // 🔴 Reuse is OWNER-SCOPED (`userId === submittedByUserId`). An orphan draft keeps its
   // original owner, and the approve transition carries that `userId` FORWARD untouched —
@@ -1556,10 +1564,19 @@ async function closeOnsiteResetListingOnWithdraw(opts: {
 }
 
 /**
- * W13 draft-at-submit cleanup — on REJECT or WITHDRAW of a first-version on-site
- * publish request, delete the pre-approval DRAFT `AppListing` minted at submit so the
- * store slug is released and the unreviewed media is discarded. Mirrors the off-site
- * `closeTerminalListing` draft branch: a status-guarded `deleteMany` (`status:'draft'`)
+ * W13 draft-at-submit cleanup — on WITHDRAW of a first-version on-site publish request,
+ * delete the pre-approval DRAFT `AppListing` minted at submit so the store slug is
+ * released and the unreviewed media is discarded.
+ *
+ * 🔴 WITHDRAW ONLY. A REJECT no longer calls this — see the 🔴 block in `rejectRequest`
+ * (clawgate #302). Withdraw is the DEVELOPER abandoning their own submission, so
+ * releasing their slug is what they asked for; a reject is a MODERATOR verdict on a
+ * submission the developer still wants, and destroying their listing as a side-effect of
+ * "please fix your screenshot" is the harm that change removed. The deliberate,
+ * mod-initiated version of this delete is `purgeListing`'s on-site orphan-draft branch.
+ *
+ * Mirrors the off-site `closeTerminalListing` draft branch: a status-guarded
+ * `deleteMany` (`status:'draft'`)
  * can never remove an approved/removed row; `AppListingScreenshot` is
  * `onDelete: Cascade` so screenshots go with it, and the underlying `Image` rows are
  * `onDelete: SetNull` (DETACHED, not hard-deleted — same as off-site). Resolved BY SLUG
@@ -5158,20 +5175,31 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
     },
   });
 
-  // W13 draft-at-submit — a first-version REJECT discards the pre-approval DRAFT
-  // listing (release the slug + drop unreviewed media), mirroring the off-site
-  // `closeTerminalListing` draft branch. No-op for a subsequent version (no draft) or a
-  // legacy pre-ship pending request. Best-effort: the reject has already committed, so a
-  // cleanup failure must never fail the outcome.
-  try {
-    await deleteOnsiteDraftListingForSlug({ slug: row.slug });
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[rejectRequest] pre-approval draft cleanup failed (id=${params.publishRequestId}, slug=${row.slug}); ` +
-        `reject STANDS: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
+  // 🔴 A REJECT DELIBERATELY DOES **NOT** DELETE THE PRE-APPROVAL DRAFT LISTING.
+  //
+  // It used to (`deleteOnsiteDraftListingForSlug`, released the slug + dropped the
+  // unreviewed media, mirroring the off-site `closeTerminalListing` draft branch). That
+  // made a FIRST-version reject destructive in a way reviewers could not see: rejecting a
+  // first-time developer for a fixable problem — a missing screenshot was the reported
+  // case — deleted the store listing they had built AND released the slug they chose for
+  // anyone else to take. Reject is the only "please fix this" signal the review path has
+  // (there is no `changes-requested` outcome), so the destructive branch fired precisely
+  // on the fixable cases it should not have. See clawgate #302 / ClickUp 868kuam02.
+  //
+  // Keeping the draft is what makes a re-submit whole: `submitVersion`'s pre-check REUSES
+  // an existing on-site pre-approval draft for the slug, OWNER-SCOPED
+  // (`userId === submittedByUserId`), so the rejected developer fixes the problem,
+  // re-submits, and lands on the same listing with its media intact. Neither submit
+  // pre-check blocks them — the rejected request is no longer `pending`, and no listing
+  // review is open.
+  //
+  // The destructive action did not disappear, it became EXPLICIT: `purgeListing` now
+  // accepts an on-site ORPHAN DRAFT, so a mod who genuinely wants the slug and media gone
+  // ("this app is not welcome") purges it deliberately, with a required reason and an
+  // audit event — instead of it happening as an invisible side-effect of every reject.
+  //
+  // `withdrawRequest` KEEPS its delete: that is the developer's own act of abandoning the
+  // submission, so releasing their slug is what they asked for.
 
   // MOD REVIEW SANDBOX (#2831) — tear down any review env the mod spun up.
   // Best-effort + non-blocking: the reject has landed, so a teardown failure


### PR DESCRIPTION
Rejecting a first-time developer's app **deleted the store listing they had built and released their chosen slug.** This stops that, and moves the delete to an explicit moderator action.

Refs: clawgate #302 / ClickUp [868kuam02](https://app.clickup.com/t/868kuam02). Raised by Ellie while reviewing a submission — her question was whether Reject is a hard reject, and whether anything lets a reviewer ask for a fix, a missing screenshot being the example.

## The problem

`rejectRequest` ran `deleteOnsiteDraftListingForSlug` on **every** reject. On a first submission that hard-deletes the pre-approval `draft` `AppListing` minted at submit — so the developer loses the listing they built, their unreviewed media goes with it, and the slug they chose is released for anyone to take. On a subsequent version it is a no-op (no draft to discard).

The reason this bites is that **reject is the only "please fix this" signal the review path has.** There is no `changes-requested` outcome; statuses are `pending | approved | rejected | withdrawn`. So the destructive branch fired precisely on the fixable cases it should not have — and it was invisible: nothing in the review UI said the listing would be destroyed, and no reviewer could decline that part.

## What changed

**1. `rejectRequest` no longer deletes the draft.**

`submitVersion`'s pre-check already **reuses** an existing on-site pre-approval draft for the slug, owner-scoped (`userId === submittedByUserId`). So keeping the draft is what makes a re-submit whole: the developer fixes the problem, re-submits, and lands on the same listing with its media intact. Neither submit pre-check blocks them — the rejected request is no longer `pending`, and no listing review is open.

`withdrawRequest` **keeps** its delete. That is the developer's own act of abandoning the submission, so releasing their slug is what they asked for. The reject/withdraw disagreement is now the asserted invariant rather than an accident.

**2. `purgeListing` accepts an on-site orphan pre-approval draft.**

This is the counterpart, not scope creep. `rejectRequest`'s delete was the **only** path in the codebase that could ever remove an on-site draft listing — `purgeListing` was `kind:'offsite'`-only, and `delistListing` is status-guarded to `{approved, removed}` and cannot touch a `draft`. Dropping the reject-time delete without replacing it would leave a rejected submission holding its slug with no recourse at all.

So the destructive action did not disappear, it became **explicit**: a mod who genuinely wants a rejected submission's slug and media gone asks for it, with a required reason and an `action:'purge'` audit event. Same bytes removed, but chosen and attributable.

## 🔴 The purge predicate is narrower than the one it replaces

```
{ kind: 'onsite', status: 'draft', appBlockId: null, revisionOfId: null }
```

`revisionOfId: null` is the term `deleteOnsiteDraftListingForSlug` does **not** have, and it is load-bearing. A **shadow media revision** (`beginListingRevision`) is created with the parent's `kind`, `status: 'draft'` and `appBlockId: null` — it matches every other term. The old clause is safe without it only because it resolves **by slug**, and a shadow's slug is a synthetic `rev-<ulid>`. A purge resolves **by id**. Without that term a mod could hard-delete an in-flight media revision of a live, approved app.

The on-site arm also must never widen past `draft`: an `approved`/`removed` on-site listing has a backing `AppBlock` whose runtime serving gate reads `app_blocks.status`, so deleting the listing row would hide the store card while leaving the hosted app serving. `delistListing` is the correct action there, and the two guarded sets do not overlap.

The predicate is checked three times: at the replica classify (fail-fast, no tx), again on the **primary** inside the tx, and again in the `deleteMany`. The primary re-check is not redundant for the new arm — `approveRequest` turns exactly this row into an approved listing with a backing block, so a purge classified against a lagging replica could otherwise delete a live app's store card.

A missing row and a non-purgeable row raise the **same** generic `NOT_FOUND`, so a caller still cannot probe a listing's kind or status through this surface.

## Where a rejected submission shows up now

It moves, and both destinations already existed:

- **Before:** reject deleted the draft ⇒ no listing owned that slug ⇒ the request rendered in `listMyOrphanedSubmissions`.
- **After:** the draft survives ⇒ the caller owns a listing for that slug ⇒ the orphan read's de-dup excludes it, and it renders on the app-keyed table via `blockRequestWhereForListing`'s null-FK slug branch, which matches it (`kind:'onsite'`, owner === submitter).

That is a strictly better home — it hangs off the listing they can now fix and re-submit. `listMyOrphanedSubmissions` is **not** dead as a result and must not be deleted on that reasoning: the historically-rejected rows have no listing to come back to, withdrawn first versions still delete their draft (the larger half of that population), and every future purge creates a fresh one.

The comments in `app-listing-history.service.ts` that stated a reject releases the slug are corrected — the guard they justify is still needed, because withdraw and purge still release it.

## Not in scope

The product question this ticket also raises — **should there be a `changes-requested` outcome at all?** — is Ellie/Justin's call and is untouched here. This is the half that is contained and does not depend on that decision.

## Verification

- **Red at base, green at HEAD.** With the two source files reverted to `origin/main` and the tests at HEAD, 5 fail: all 3 reject-regression cases, plus the 2 purge happy-path cases (the arm does not exist at base).
- **Mutation-tested, and each mutant dies for its own reason.** Dropping `revisionOfId` from the predicate kills exactly the shadow-revision refusal (`$transaction` opened when it must not be) and leaves the other three refusals green. Dropping `status === 'draft'` kills exactly the `approved` and `removed` refusals. The refusal cases pass vacuously at base — every on-site row was refused outright — so this is what shows they are reachable and isolating.
- `pnpm typecheck` — 0 errors.
- Unit tier: **220 files / 5027 tests pass** across `src/server/services/blocks/__tests__/` and `src/server/routers/__tests__/`.
- ESLint on the changed files: 0 errors (the 9 warnings are pre-existing patterns, present on `main`).

**Not run locally:** the `component` (browser) tier. This host's flake pins Playwright browser build 1228 while the installed `@vitest/browser-playwright` wants 1200, and the generic-linux download will not run on NixOS — a pre-existing environment drift unrelated to this change. The diff touches no component source; every changed file is under `src/server/`.

**No migration.** No schema change — `revisionOfId`, `appBlockId` and `status` all already exist on `AppListing`.
