### PR TITLE
fix(app-blocks): let an approved zero-scope app mint its block token

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -976,7 +976,12 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // reports it as "no approved scopes", and the intersection immediately below
   // would independently reject every one of those scopes as outside the
   // snapshot. This branch is kept as the more precise diagnostic (and as a belt
-  // if the intersection is ever refactored).
+  // if the intersection is ever refactored) — but ONLY for the empty-snapshot
+  // half. It does NOT cover the PARTIAL-snapshot case: a manifest declaring
+  // `A`+`B` against a snapshot holding only `A` reaches this branch with
+  // `approvedScopes.size === 1`, passes it, and is caught solely by the
+  // intersection below. Deleting that intersection on the strength of this
+  // "belt" would sign `B` into the token. Both checks are load-bearing.
   const approvedScopes = new Set(block.approvedScopes ?? []);
   if (knownManifestScopes.length > 0 && approvedScopes.size === 0) {
     res.status(403).json({ error: 'block has no approved scopes' });

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -955,12 +955,30 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // H-2: intersect requested scopes with the approved-scope snapshot. An
   // approved manifest re-published with added scopes already loses approval
   // (status → 'pending', filtered above), but the approved_scopes column is
-  // the authoritative pinning. Empty array = fail-closed. Checked on the
-  // known-scope subset — an unknown scope was dropped above (capability-less),
-  // so an anti-swap check on it would only mislead; a KNOWN scope added outside
-  // the approved snapshot is still caught here.
+  // the authoritative pinning. An empty snapshot is fail-closed ONLY against a
+  // manifest that actually asks for something. Checked on the known-scope
+  // subset — an unknown scope was dropped above (capability-less), so an
+  // anti-swap check on it would only mislead; a KNOWN scope added outside the
+  // approved snapshot is still caught here.
+  //
+  // ZERO-SCOPE APPS: an app whose manifest declares `scopes: []` (or only
+  // removed/unknown scopes — see the INTENTIONAL note above) is legitimately
+  // approved with an EMPTY snapshot. It is asking for no capabilities, so there
+  // is nothing to fail closed on and it must mint a valid zero-scope token
+  // rather than be locked out of running at all. Guarding this branch on the
+  // manifest actually declaring known scopes is what restores that: with an
+  // empty manifest there is nothing to intersect, and the token that gets
+  // signed grants nothing (every scope-gated endpoint fails closed at the
+  // deny-by-default runtime gate).
+  //
+  // The dangerous shape — a manifest that DOES declare known scopes against an
+  // empty snapshot — is unchanged, and is in fact caught twice: this branch
+  // reports it as "no approved scopes", and the intersection immediately below
+  // would independently reject every one of those scopes as outside the
+  // snapshot. This branch is kept as the more precise diagnostic (and as a belt
+  // if the intersection is ever refactored).
   const approvedScopes = new Set(block.approvedScopes ?? []);
-  if (approvedScopes.size === 0) {
+  if (knownManifestScopes.length > 0 && approvedScopes.size === 0) {
     res.status(403).json({ error: 'block has no approved scopes' });
     return;
   }

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -935,6 +935,26 @@ describe('POST /api/v1/block-tokens — approved-scope snapshot gate', () => {
     expect(res._body.missingScopes).toEqual([]);
   });
 
+  // The SECOND producer of `knownManifestScopes.length === 0`, and the one the
+  // graceful-deprecation block above the gate exists for: a manifest that
+  // declares only scopes that have since been RETIRED. `catalog:read` is a real
+  // retired scope (dropped when catalog reads moved to "any valid block token"),
+  // so it survives in an old approved manifest but no longer passes
+  // `isKnownBlockScope` — it is filtered out, leaving an empty known set. Before
+  // this fix that whole class of app was unmintable: retiring a scope silently
+  // bricked every block whose manifest named only that scope.
+  it('MINTS (200) when the manifest declares ONLY retired scopes (deprecation path)', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BLOCK(['catalog:read'], [], 0));
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+    // The retired scope is DROPPED, not carried into the token.
+    expect(mockTokenService.sign.mock.calls[0][0].scopes).toEqual([]);
+  });
+
   // Same for the MODEL-slot path — the gate is shared, so the fix must not be
   // page-only.
   it('MINTS (200) a zero-scope token on the MODEL-slot path too (shared gate)', async () => {

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -872,3 +872,126 @@ describe('POST /api/v1/block-tokens — DEPLOY-GATE (never-deployed refusal)', (
     expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// APPROVED-SCOPE SNAPSHOT GATE — the zero-scope app must MINT, the
+// nothing-approved app must still 403.
+//
+// An app whose manifest declares `"scopes": []` is a legitimate, fully
+// approvable app: it asks for no capabilities and its approved snapshot is
+// therefore legitimately empty. The mint used to reject `approvedScopes.size
+// === 0` unconditionally, so such an app could never obtain a token at all and
+// its run page rendered the "Couldn't authenticate this app" fallback (a 403 is
+// terminal for the client's mint retry, so it failed instantly and forever).
+//
+// That contradicted the mint's own documented intent one screen above the gate:
+// filtering to an EMPTY scope set is supposed to sign a valid ZERO-scope token,
+// because "a useless-but-valid token is the right graceful outcome, not a 403".
+//
+// The fail-closed case the gate exists for — a manifest that DOES declare
+// capability-bearing scopes against an empty approved snapshot — must keep
+// 403ing. That is the invariant these tests pin in both directions.
+// ───────────────────────────────────────────────────────────────────────────
+describe('POST /api/v1/block-tokens — approved-scope snapshot gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.value = MOD;
+    mockBlockRegistry.resolveBlockInstance.mockReset();
+    mockBlockRegistry.resolvePageBlock.mockReset();
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['apps:storage:read', 'apps:storage:write'],
+      revokedAt: null,
+    });
+    mockRedis.incrBy.mockResolvedValue(1);
+    mockTokenService.checkRateLimit.mockResolvedValue(true);
+    (mockFlags.getFeatureFlags as any).mockImplementation(
+      ({ user }: { user?: { isModerator?: boolean } }) => ({
+        appBlocks: !!user?.isModerator,
+        appBlocksPages: !!user?.isModerator,
+      })
+    );
+  });
+
+  // REGRESSION (the bug): manifest `scopes: []` ⇒ approved snapshot `[]`.
+  // Nothing is being withheld and nothing is unapproved — the app simply wants
+  // no capabilities — so the mint must succeed and sign an empty scope array.
+  it('MINTS (200) a zero-scope token for an approved app whose manifest declares scopes: []', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BLOCK([], [], 0));
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    // A VALID token that grants nothing: every scope-gated endpoint still fails
+    // closed at the runtime scope gate because the claim is empty.
+    expect(signArg.scopes).toEqual([]);
+    expect(signArg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+    expect(signArg.buzzBudget).toBeUndefined();
+    // Nothing was withheld, so the host must NOT be told to prompt for consent.
+    expect(res._body.needsConsent).toBe(false);
+    expect(res._body.missingScopes).toEqual([]);
+  });
+
+  // Same for the MODEL-slot path — the gate is shared, so the fix must not be
+  // page-only.
+  it('MINTS (200) a zero-scope token on the MODEL-slot path too (shared gate)', async () => {
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: [],
+      revokedAt: null,
+    });
+    mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+      ...MODEL_INSTALL,
+      appBlock: {
+        ...MODEL_INSTALL.appBlock,
+        manifest: { scopes: [] },
+        approvedScopes: [],
+        app: { allowedScopes: 0 },
+      },
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: modelBody() }), res);
+
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+    expect(mockTokenService.sign.mock.calls[0][0].scopes).toEqual([]);
+  });
+
+  // FAIL-CLOSED (the invariant the gate exists for, and which the fix must not
+  // break): the manifest DOES declare a capability-bearing scope but the
+  // approved snapshot is empty ⇒ nothing about that scope was ever approved, so
+  // the mint must refuse. This case passes before AND after the fix — it is an
+  // invariant guard, not regression coverage.
+  it('still 403s (no token) when the manifest DECLARES a scope but the approved snapshot is EMPTY', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BLOCK(['apps:storage:read'], [], 0));
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(403);
+    expect((res._body as { error: string }).error).toBe('block has no approved scopes');
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  // Adjacent fail-closed direction, unchanged by the fix: a NON-empty approved
+  // snapshot that does not cover a declared scope is caught by the intersection
+  // check immediately after the gate above.
+  it('still 403s (no token) when a declared scope is absent from a NON-empty approved snapshot', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      PAGE_BLOCK(['apps:storage:read', 'apps:storage:write'], ['apps:storage:read'], 0)
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(403);
+    expect((res._body as { error: string }).error).toBe(
+      'block manifest carries scopes outside the approved snapshot'
+    );
+    expect((res._body as { rejected: string[] }).rejected).toEqual(['apps:storage:write']);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The bug

An App Block whose manifest declares `"scopes": []` cannot be used at all.

Such an app is fully approvable — it asks for no capabilities — and approval faithfully writes an **empty** approved-scope snapshot for it (`publish-request.service.ts` does `approvedScopes: manifestScopes`). The block-token mint then rejected that snapshot unconditionally:

```ts
const approvedScopes = new Set(block.approvedScopes ?? []);
if (approvedScopes.size === 0) {
  res.status(403).json({ error: 'block has no approved scopes' });
  return;
}
```

`403` is in `TERMINAL_MINT_STATUSES` (`src/components/AppBlocks/blockTokenRetry.ts`), so the client's mint retry gives up immediately and permanently. The host maps the failure to `token_error` and the run page renders the **"Couldn't authenticate this app"** fallback. There is no way for the app author to get out of it — the app is correctly approved and correctly published; it simply can never obtain a token.

This also contradicts the mint's own documented intent, stated ~20 lines above the gate:

> **INTENTIONAL:** if the manifest declared ONLY removed/unknown scopes this filters to an EMPTY set and we go on to sign a valid ZERO-scope token (not an error). That is correct — the app simply has no capabilities, and every scope-gated endpoint fails closed at the deny-by-default runtime gate. **A useless-but-valid token is the right graceful outcome, not a 403.**

## The fix

Condition the branch on the manifest actually declaring known scopes:

```ts
if (knownManifestScopes.length > 0 && approvedScopes.size === 0) { … }
```

**Why this is the correct predicate, not just a smaller one.** The gate has two input shapes:

| manifest declares | approved snapshot | before | after | who catches it |
|---|---|---|---|---|
| known scopes | empty | 403 | 403 | this branch — **and** the intersection 3 lines below would catch it independently |
| known scopes | non-empty, missing one | 403 | 403 | the intersection below (unchanged) |
| nothing | empty | **403 (the bug)** | 200, zero-scope token | nothing needs to — there is nothing to intersect |

So in the dangerous case the branch is **redundant**: `outsideApproved = knownManifestScopes.filter(s => !approvedScopes.has(s))` equals all of `knownManifestScopes` when the snapshot is empty, which is non-empty, which 403s. In the benign case it is simply wrong. I kept the branch rather than deleting it — it is the more precise diagnostic (`block has no approved scopes` vs `carries scopes outside the approved snapshot`) and a belt if the intersection is ever refactored — and documented the redundancy in place.

## Security analysis — what a zero-scope token grants

**Enforcement is keyed on the handler's declared requirement, not on the token's scope array being non-empty.** `withBlockScope` only checks when `opts.requiredScope !== undefined`, and `[].includes(x)` is always false, so an empty array denies **every** scope-gated surface. I grepped every server-side read of `claims.scopes`: all are `Array.isArray()` shape guards, unconditional `.includes()`, or the `for…of` in `enforceContextBinding`. There is **no** `scopes.length === 0 ⇒ allow` branch, no wildcard scope, and no "missing scopes ⇒ grant" path anywhere. (`enforceContextBinding` is a no-op on an empty array, but it is only ever reached *after* the `includes()` check, so that is not a hole.)

Still blocked with a zero-scope token — all nine scope-required REST routes (`blocks/me`, `blocks/tip`, `blocks/tip-allowance`, `blocks/collections` ×3, `blocks/shared-storage` ×2, `models/[id]`) and every scoped tRPC procedure (`submitWorkflow`, `estimateWorkflow`, `pollWorkflow`, `cancelWorkflow`, `publishGenerationOutputs`, `getMyViewer`, the buzz-ledger reads, all of `appsStorage.*` and the shared-storage router).

Reachable with a zero-scope token — exactly the "any valid block token" surface, which is **already reachable by every currently-mintable token**:

- `GET /api/v1/blocks/models`, `/blocks/images`, `/blocks/tools`, `/blocks/generation-resources` — read-only public catalog data, authoritatively clamped to the token's signed `maxBrowsingLevel`, rate-limited per block instance. These deliberately require no scope (`catalog:read` was retired in #2676 for exactly this reason).
- `blocks.getImagesByIds` — read-back of images **this app itself published**, clamped to the same ceiling.
- `blocks.getMyBuzzBalance` — the **token subject's own** blue/green/yellow balance. `userId` comes from the token `sub`, never from client input, and it is additionally behind `assertAppBlocksEnabledForTokenUser` + `assertViewerIsAppDeveloper`.
- `blocks.updateUserSettings` — a self-bound write of the viewer's own per-instance settings (checkpoint override), behind the same two gates plus a `resolveBlockInstance` re-validation.

**Judgement: acceptable.** The delta is *not* "a new capability" — it is "an app that asks for nothing gets the same floor as an app that asks for one harmless thing." Any approved app with a single scope already reaches all of the above today. No spend, no cross-user read, no mutation outside the viewer's own row. And zero-scope tokens are not even a new token class: the mint already produces them via the deprecated/unknown-scope pre-filter and via the anonymous consent strip, which is why the runtime was already written to handle them.

## Tests

`src/tests/api/v1/block-tokens/page-mint.test.ts`, both directions:

- **Regression (was red):** manifest `scopes: []` / approved `[]` → **200**, `sign()` called once with `scopes: []`, ctx unchanged, `needsConsent: false`. Added for the page slot **and** the model slot, since the gate is shared.
- **Invariant guard (passes before and after — labelled as such, not counted as regression coverage):** manifest declares a scope with an **empty** snapshot → still 403 `block has no approved scopes`, no token; and a declared scope absent from a **non-empty** snapshot → still 403 `block manifest carries scopes outside the approved snapshot` with the right `rejected` array.

Red-then-green matrix on this suite:

| tree | result |
|---|---|
| base (`main`, unfixed) | `Tests 2 failed \| 33 passed (35)` — both new mint tests fail with `AssertionError: expected 403 to be 200` |
| HEAD (fixed) | `Tests 35 passed (35)` |

Both invariant guards passed on the unfixed tree, which is the point of them.

Wider run: 8 files / **150 tests passed** across `src/tests/api/v1/block-tokens/`, `block-token.service`, `blockTokenRetry`, `scope-grant.service`. `pnpm typecheck` clean.

This also pays the outstanding "page-mint unit test with `scopes: []`" coverage debt.
