### PR TITLE
feat(app-blocks): widen the page resource picker to the LoRA family (LoCon + DoRA)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -3040,8 +3040,10 @@ export function PageBlockHost({
   // ── OPEN_RESOURCE_PICKER → RESOURCE_PICKER_RESULT (Design 1 host-chrome) ────
   //
   // Generalizes the model-slot OPEN_CHECKPOINT_PICKER (IframeHost) to the page
-  // surface and widens it from Checkpoint-only to a typed allowlist (v1:
-  // Checkpoint + LoRA only). The block asks the HOST to open its OWN native
+  // surface and widens it from Checkpoint-only to a typed allowlist (Checkpoint
+  // plus the generator's LoRA family: LORA, LoCon, DoRA — the exact set the
+  // spend-time page-LoRA gate already accepts, so the picker offers nothing
+  // submit would refuse). The block asks the HOST to open its OWN native
   // ResourceSelectModal as host chrome; the viewer searches in host chrome (NOT
   // the iframe); the host posts back ONLY the single chosen resource. The
   // untrusted iframe NEVER receives a list, the search API, or the catalog — it
@@ -3079,10 +3081,13 @@ export function PageBlockHost({
   // (resource-select.types.ts) exposes NO browsing-level / sfwOnly / nsfw
   // constraint — only `canGenerate`, `resources`, `excludeIds`. NSFW filtering
   // is done purely client-side in the SHARED `ResourceHitList` via
-  // `useApplyHiddenPreferences`, which defaults to the site-wide
-  // `useBrowsingLevelDebounced()` context (the Meili query in
-  // useResourceSelectFilters doesn't filter by browsing level at all). Passing a
-  // block-SFW ceiling in would require adding a new option to
+  // `useApplyHiddenPreferences`, which is passed NO `browsingLevel` override and
+  // so defaults to the site-wide `useBrowsingLevelDebounced()` context (the
+  // server-side list query behind it — the tRPC `model.getResourceSelect`
+  // procedure, service `resource-select.service.ts` — doesn't filter by browsing
+  // level at all; the older `useResourceSelectFilters` hook this note used to
+  // name no longer exists). Passing a block-SFW ceiling in would require adding
+  // a new option to
   // `ResourceSelectOptions`, threading it through `ResourceSelectProvider` /
   // `useResourceSelectContext`, and feeding it to that `useApplyHiddenPreferences`
   // call — i.e. modifying the shared modal's filtering internals (higher blast

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -15,7 +15,8 @@ import { renderWithProviders } from '../../../test/component-setup';
  * ResourceSelectModal as host chrome (the iframe never sees the catalog), and
  * posts back ONLY the single picked resource via RESOURCE_PICKER_RESULT. This
  * generalizes the model-slot OPEN_CHECKPOINT_PICKER to pages + widens it from
- * Checkpoint-only to a typed allowlist (v1: Checkpoint + LoRA).
+ * Checkpoint-only to a typed allowlist (Checkpoint + the LoRA family: LORA,
+ * LoCon, DoRA — the same set the spend-time page-LoRA gate already accepted).
  *
  * These tests mount the REAL PageBlockHost and drive the actual postMessage
  * bridge, asserting:
@@ -26,9 +27,12 @@ import { renderWithProviders } from '../../../test/component-setup';
  *      user-picked resource, plus the body-building IDs; NO catalog, NO list,
  *      NO private/early-access/availability internals;
  *   3. on cancel (close without pick) it posts a cancelled result (no `selected`);
- *   4. an UNSUPPORTED requested type (not Checkpoint/LoRA) is rejected — the
+ *   4. an UNSUPPORTED requested type (outside the allowlist) is rejected — the
  *      modal never opens and no reply is posted;
- *   5. concurrent requestIds don't cross.
+ *   5. concurrent requestIds don't cross;
+ *   6. every allowlisted type passes the SAME options bag to the shared modal —
+ *      only the `type` filter varies — so widening the allowlist changes WHICH
+ *      types are offered and NOT what maturity a viewer can be shown.
  *
  * The native modal is a dynamic import that needs real providers, so — exactly
  * like the OPEN_BUZZ_PURCHASE test — we assert against the shared dialogStore
@@ -337,6 +341,66 @@ describe('PageBlockHost resource picker (Design 1 host-chrome)', () => {
     );
     expect(all).toHaveLength(1);
     replies.stop();
+  });
+
+  test('a LoRA-family type (LoCon) opens the native modal filtered to THAT type', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+
+    postFromBlock('OPEN_RESOURCE_PICKER', { requestId: 'rq_locon', resourceType: 'LoCon' });
+
+    await vi.waitFor(() => {
+      expect(useDialogStore.getState().dialogs).toHaveLength(1);
+    });
+    const props = lastResourceModalProps();
+    expect(props.options?.resources).toHaveLength(1);
+    expect(props.options?.resources?.[0].type).toBe('LoCon');
+    expect(props.options?.canGenerate).toBe(true);
+  });
+
+  // The widening changes WHICH TYPES are offered — and nothing about maturity.
+  //
+  // This is the seam between the host (which decides the filter) and the SHARED
+  // ResourceSelectModal (which decides what a viewer is shown). The host's only
+  // lever over that modal is the `options` bag, and `ResourceSelectOptions`
+  // carries no maturity control at all: NSFW filtering happens client-side in
+  // the shared `ResourceHitList` via `useApplyHiddenPreferences`, which is handed
+  // no `browsingLevel` override and therefore falls through to the site-wide
+  // `useBrowsingLevelDebounced()` ceiling.
+  //
+  // So the guard that means something is a WHOLE-SET assertion on the bag the
+  // host actually passes, evaluated for EVERY allowlisted type: the only thing
+  // that varies across types is `resources[0].type`. A maturity/browsing/sfwOnly
+  // key introduced here — for the new types or for the old ones — goes red.
+  test('every allowlisted type passes the SAME options bag — only `type` varies, no maturity knob', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+
+    const seen: Record<string, unknown>[] = [];
+    for (const [i, resourceType] of ['Checkpoint', 'LORA', 'LoCon', 'DoRA'].entries()) {
+      useDialogStore.getState().closeAll();
+      postFromBlock('OPEN_RESOURCE_PICKER', { requestId: `rq_opt_${i}`, resourceType });
+      await vi.waitFor(() => {
+        expect(useDialogStore.getState().dialogs).toHaveLength(1);
+      });
+      const options = lastResourceModalProps().options as Record<string, unknown>;
+      // The bag itself: exactly the UX floor + the type filter. Nothing else.
+      expect(Object.keys(options).sort()).toEqual(['canGenerate', 'resources']);
+      const resources = options.resources as Record<string, unknown>[];
+      expect(resources).toHaveLength(1);
+      expect(Object.keys(resources[0]).sort()).toEqual(['baseModels', 'type']);
+      expect(resources[0].type).toBe(resourceType);
+      seen.push(options);
+    }
+
+    // ...and the ONLY difference across the four is the type token: every other
+    // field is byte-identical, so the widened set cannot have changed what a
+    // viewer is shown for any of them.
+    const withoutType = seen.map((o) => ({
+      ...o,
+      resources: (o.resources as Record<string, unknown>[]).map(({ type: _type, ...rest }) => rest),
+    }));
+    for (const o of withoutType) expect(o).toEqual(withoutType[0]);
   });
 
   test('an UNSUPPORTED requested type (VAE) is rejected — modal never opens, no reply', async () => {

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -421,6 +421,27 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
     });
   });
 
+  // The picker's allowlist is widened from {Checkpoint, LORA} to the generator's
+  // whole LoRA family {LORA, LoCon, DoRA}. This closes a gap that already
+  // existed rather than opening a new one: the SPEND-time gate
+  // (`PAGE_LORA_MODEL_TYPES` in workflow.service, enforced by
+  // `resolvePageLoraGates`) has always accepted LoCon + DoRA, so those two types
+  // were already spend-legal while being unpickable — an author could only reach
+  // them by hard-coding a version id. Nothing about the spend gate moves here.
+  it('accepts a LoCon request (LoRA family) and returns the canonical token', () => {
+    expect(resolveResourcePickerRequest({ requestId: 'r8', resourceType: 'LoCon' })).toEqual({
+      requestId: 'r8',
+      resourceType: 'LoCon',
+    });
+  });
+
+  it('accepts a DoRA request (LoRA family) and returns the canonical token', () => {
+    expect(resolveResourcePickerRequest({ requestId: 'r9', resourceType: 'DoRA' })).toEqual({
+      requestId: 'r9',
+      resourceType: 'DoRA',
+    });
+  });
+
   it('is case-insensitive on the wire but returns the canonical token', () => {
     expect(
       resolveResourcePickerRequest({ requestId: 'r3', resourceType: 'lora' })?.resourceType
@@ -431,6 +452,12 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
     expect(
       resolveResourcePickerRequest({ requestId: 'r5', resourceType: '  LoRA  ' })?.resourceType
     ).toBe('LORA');
+    expect(
+      resolveResourcePickerRequest({ requestId: 'r5a', resourceType: 'locon' })?.resourceType
+    ).toBe('LoCon');
+    expect(
+      resolveResourcePickerRequest({ requestId: 'r5b', resourceType: '  DORA ' })?.resourceType
+    ).toBe('DoRA');
   });
 
   it('passes through an optional baseModelGroup family hint', () => {
@@ -454,15 +481,7 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
   });
 
   it('REJECTS an unsupported type (VAE / embeddings / wildcards) → null (modal never opens)', () => {
-    for (const t of [
-      'VAE',
-      'TextualInversion',
-      'Wildcards',
-      'Upscaler',
-      'LoCon',
-      'DoRA',
-      'Hypernetwork',
-    ]) {
+    for (const t of ['VAE', 'TextualInversion', 'Wildcards', 'Upscaler', 'Hypernetwork']) {
       expect(resolveResourcePickerRequest({ requestId: 'r', resourceType: t })).toBeNull();
     }
   });
@@ -486,8 +505,40 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
     expect(resolveResourcePickerRequest(123)).toBeNull();
   });
 
-  it('the v1 allowlist is exactly Checkpoint + LoRA (guards against scope creep)', () => {
-    expect([...PAGE_RESOURCE_PICKER_TYPES].sort()).toEqual(['Checkpoint', 'LORA']);
+  // Scope-creep guard. UPDATED (not deleted) when the allowlist widened from
+  // {Checkpoint, LORA} to Checkpoint + the whole LoRA family. It still asserts an
+  // EXACT set, so adding a type this list does not name — VAE, TextualInversion,
+  // Wildcards, Upscaler, Hypernetwork, anything — goes red here, in BOTH
+  // directions (a growth AND a silent removal).
+  it('the allowlist is exactly Checkpoint + the LoRA family (guards against scope creep)', () => {
+    expect([...PAGE_RESOURCE_PICKER_TYPES].sort()).toEqual(['Checkpoint', 'DoRA', 'LORA', 'LoCon']);
+  });
+
+  // The widening must change WHICH TYPES are offered and nothing else. The
+  // resolved request is the entire payload the host derives from an untrusted
+  // iframe message, and it is what the caller turns into the native modal's
+  // filter — so pinning its whole key set is what proves no maturity /
+  // browsing-level / sfwOnly knob was smuggled in alongside the new types.
+  it('a resolved request carries ONLY {requestId, resourceType, baseModelGroup?} — no maturity knob', () => {
+    for (const resourceType of PAGE_RESOURCE_PICKER_TYPES) {
+      const bare = resolveResourcePickerRequest({ requestId: 'rk', resourceType });
+      expect(Object.keys(bare ?? {}).sort()).toEqual(['requestId', 'resourceType']);
+
+      const hinted = resolveResourcePickerRequest({
+        requestId: 'rk',
+        resourceType,
+        baseModelGroup: 'SDXL',
+        // Fields an untrusted block might try to smuggle through. None is read.
+        browsingLevel: 28,
+        sfwOnly: false,
+        nsfw: true,
+      });
+      expect(Object.keys(hinted ?? {}).sort()).toEqual([
+        'baseModelGroup',
+        'requestId',
+        'resourceType',
+      ]);
+    }
   });
 });
 

--- a/src/components/AppBlocks/__tests__/resourcePickerMaturitySeam.test.ts
+++ b/src/components/AppBlocks/__tests__/resourcePickerMaturitySeam.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { PAGE_RESOURCE_PICKER_TYPES } from '../pageBlockHostLogic';
+
+/**
+ * SEAM guard for the page resource picker's TYPE allowlist vs the shared
+ * ResourceSelectModal's MATURITY filtering.
+ *
+ * Widening `PAGE_RESOURCE_PICKER_TYPES` changes WHICH resource types an App
+ * Block may ask the host to open a picker for. It must not change WHAT MATURITY
+ * a viewer can be shown. Those two live in different files owned by different
+ * features, which is exactly the shape a per-component test cannot see: the host
+ * suite proves the host passes no maturity option, the modal suite proves the
+ * modal filters correctly, and neither notices if the host GAINS a maturity
+ * lever or the modal LOSES its ceiling.
+ *
+ * So this pins the RELATIONSHIP, as an asserted ledger that fails when either
+ * side's set GROWS or SHRINKS:
+ *
+ *   1. `ResourceSelectOptions` — the ONLY thing the host can hand the shared
+ *      modal — declares no maturity/browsing/sfwOnly control at all. If one is
+ *      ever added, this goes red and the host's picker call site must be
+ *      re-reviewed before the option can silently become reachable from a block.
+ *   2. `ResourceHitList` — where the shared modal actually filters — calls
+ *      `useApplyHiddenPreferences` with NO `browsingLevel` override, so it falls
+ *      through to the site-wide `useBrowsingLevelDebounced()` ceiling. A
+ *      `browsingLevel` argued in there would let this surface diverge from the
+ *      site-wide ceiling, in either direction.
+ *
+ * These are structural claims about source text, which is what a cross-file
+ * ledger can assert cheaply. The BEHAVIOURAL half — that the host in fact passes
+ * the same maturity-free options bag for every allowlisted type — is asserted in
+ * PageBlockHostResourcePicker.browser.test.tsx against the real component.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const read = (rel: string) => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+const OPTIONS_FILE = 'src/components/ImageGeneration/GenerationForm/resource-select.types.ts';
+const HIT_LIST_FILE =
+  'src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceHitList.tsx';
+
+/** Field names declared at the TOP level of a `type X = { … }` declaration. */
+function topLevelFieldNames(source: string, typeName: string): string[] {
+  const start = source.indexOf(`export type ${typeName} = {`);
+  expect(start, `${typeName} declaration not found`).toBeGreaterThanOrEqual(0);
+  let i = source.indexOf('{', start);
+  let depth = 0;
+  const fields: string[] = [];
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') {
+      depth++;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
+    if (depth !== 1) continue;
+    // A top-level field starts at a line beginning (after whitespace).
+    const m = /^\s*\n\s*([A-Za-z_$][\w$]*)\??\s*:/.exec(source.slice(i - 1, i + 40));
+    if (m) fields.push(m[1]);
+  }
+  return [...new Set(fields)].sort();
+}
+
+/** Argument keys of the first `fn({ … })` object-literal call in `source`. */
+function objectArgKeys(source: string, fn: string): string[] {
+  const start = source.indexOf(`${fn}({`);
+  expect(start, `${fn}({…}) call not found`).toBeGreaterThanOrEqual(0);
+  let i = source.indexOf('{', start);
+  let depth = 0;
+  const keys: string[] = [];
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth += ch === '{' ? 1 : 0;
+      if (ch !== '{') continue;
+      continue;
+    }
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
+    if (depth !== 1) continue;
+    const m = /^[\s,{]\s*([A-Za-z_$][\w$]*)\s*:/.exec(source.slice(i - 1, i + 40));
+    if (m) keys.push(m[1]);
+  }
+  return [...new Set(keys)].sort();
+}
+
+describe('page resource picker ⇄ shared modal maturity seam', () => {
+  it('the allowlist is Checkpoint + the LoRA family (the set this seam is asserted for)', () => {
+    expect([...PAGE_RESOURCE_PICKER_TYPES].sort()).toEqual(['Checkpoint', 'DoRA', 'LORA', 'LoCon']);
+  });
+
+  it('ResourceSelectOptions exposes NO maturity/browsing/sfwOnly control', () => {
+    // Exact ledger, not a "does not contain" check: a NEW option is a change to
+    // what the host could pass, and must be reviewed at this seam either way.
+    expect(topLevelFieldNames(read(OPTIONS_FILE), 'ResourceSelectOptions')).toEqual([
+      'canGenerate',
+      'excludeIds',
+      'resources',
+    ]);
+  });
+
+  it('ResourceHitList applies hidden preferences with NO browsingLevel override', () => {
+    // No override ⇒ useApplyHiddenPreferences falls through to the site-wide
+    // useBrowsingLevelDebounced() ceiling, which is the guarantee the picker
+    // inherits and which widening the TYPE allowlist must not disturb.
+    expect(objectArgKeys(read(HIT_LIST_FILE), 'useApplyHiddenPreferences')).toEqual([
+      'data',
+      'type',
+    ]);
+  });
+});

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -301,13 +301,28 @@ export function buildReviewConsentNotification(opts: {
 // RESOURCE_PICKER_RESULT. This generalizes the model-slot OPEN_CHECKPOINT_PICKER
 // (IframeHost) from Checkpoint-only to a typed allowlist.
 //
-// v1 type allowlist: Checkpoint + LoRA ONLY (matches the page-LoRA v1 body
-// contract — model.type LORA → additionalResources, Checkpoint → modelVersionId).
-// Any other requested type is REJECTED (the request is dropped, the modal never
-// opens) so a block can't open an embeddings/VAE/wildcards picker on a page.
+// Type allowlist: Checkpoint + the generator's LoRA FAMILY (LORA, LoCon, DoRA).
+// Matches the page-LoRA body contract — a LoRA-family model.type goes to
+// additionalResources, Checkpoint to modelVersionId. Any other requested type is
+// REJECTED (the request is dropped, the modal never opens) so a block can't open
+// an embeddings/VAE/wildcards picker on a page.
+//
+// Why LoCon + DoRA belong here and nothing else does — this CLOSES a gap rather
+// than opening one. The SPEND-time gate `PAGE_LORA_MODEL_TYPES`
+// (server/services/blocks/workflow.service, enforced by `resolvePageLoraGates`)
+// has always been {LORA, LoCon, DoRA} — the same set the platform's
+// compatibility model groups as the LoRA family (basemodel.constants'
+// `fullAddonTypes` / `sdxlCrossAddonTypes` / `sdxlSiblingAddonTypes` each list
+// all three side by side). So LoCon and DoRA were already spend-legal while
+// being unpickable: an author could only reach them by hard-coding a version id.
+// Widening the picker to exactly that set adds no type the submit path would
+// then reject, and moves NO gate — the spend-time set is untouched by this
+// change. Adding a type OUTSIDE the LoRA family (VAE, TextualInversion,
+// Wildcards, Upscaler, Hypernetwork, …) would be the opposite: a picker offering
+// resources `resolvePageLoraGates` refuses with BAD_REQUEST.
 
-/** Canonical model-type tokens the page resource picker accepts in v1. */
-export const PAGE_RESOURCE_PICKER_TYPES = ['Checkpoint', 'LORA'] as const;
+/** Canonical model-type tokens the page resource picker accepts. */
+export const PAGE_RESOURCE_PICKER_TYPES = ['Checkpoint', 'LORA', 'LoCon', 'DoRA'] as const;
 export type PageResourcePickerType = (typeof PAGE_RESOURCE_PICKER_TYPES)[number];
 
 export type ResourcePickerRequest = {
@@ -326,8 +341,13 @@ export type ResourcePickerRequest = {
  * whether to, and with what type/family filter.
  *
  * Type acceptance is case-insensitive on the wire (a block may send 'lora' or
- * 'LoRA'); the returned `resourceType` is the canonical token the native modal
- * filter expects ('Checkpoint' | 'LORA').
+ * 'LoRA'); the returned `resourceType` is the canonical `ModelType` token the
+ * native modal filter expects ('Checkpoint' | 'LORA' | 'LoCon' | 'DoRA').
+ *
+ * The returned shape is deliberately CLOSED: requestId, the canonical type and
+ * an optional family hint. There is no maturity / browsing-level / sfwOnly knob
+ * here and none is read off the raw payload, so widening the TYPE allowlist
+ * cannot widen what a viewer is shown.
  */
 export function resolveResourcePickerRequest(raw: unknown): ResourcePickerRequest | null {
   if (!raw || typeof raw !== 'object') return null;


### PR DESCRIPTION
## What

Widens the App Blocks **page resource picker** (`OPEN_RESOURCE_PICKER`) allowlist from `['Checkpoint', 'LORA']` to `['Checkpoint', 'LORA', 'LoCon', 'DoRA']`.

Nothing else moves. This is a platform change — the picker is a shared host capability every page block sees — so the review question is not "is this type nice to have" but "does offering it change any gate". It does not, and the reason is the whole point of the change.

## Why this set, and why nothing wider

`LoCon` and `DoRA` were **already spend-legal and simply not pickable.**

- The spend-time gate on a page block's additional resources (`PAGE_LORA_MODEL_TYPES` in `src/server/services/blocks/workflow.service.ts`, enforced by `resolvePageLoraGates` in `src/server/routers/blocks.router.ts`) is already `{LORA, LoCon, DoRA}`, and has been since that path shipped.
- The platform's own generation-compatibility model groups the three together everywhere it enumerates addon types — `fullAddonTypes`, `sdxlCrossAddonTypes` and `sdxlSiblingAddonTypes` in `basemodel.constants` each list `LORA`, `LoCon` and `DoRA` side by side.

So an author could already spend on a LoCon or a DoRA — but only by hard-coding a version id, because the picker refused to offer one. This closes that gap. **`PAGE_LORA_MODEL_TYPES` is not touched by this PR**; if it had needed widening, that would have been a different and much larger change.

Adding a type *outside* the family (VAE, TextualInversion, Wildcards, Upscaler, Hypernetwork, …) would be the opposite trade: a picker offering resources the submit path then rejects with `BAD_REQUEST`. The scope-creep guard below is what keeps that from happening by accident.

### What LoCon and DoRA resolve to under the compatibility model

`getResourceGenerationSupport` uses the resource's `modelType` in exactly one place — matching a **cross-ecosystem** rule's `modelTypes` list. Same-ecosystem pairs short-circuit to `full` before `modelType` is consulted at all. So:

- **Same ecosystem** — identical to `LORA` today. No new acceptance.
- **Cross ecosystem** — LoCon/DoRA are accepted only by the SDXL family rules, which name all three explicitly. The 25 cross-ecosystem rules whose `modelTypes` is `[LORA]` do **not** match a LoCon or a DoRA, so those pairs resolve to `null` and are **rejected**. Strictly more restrictive than `LORA`, never less.

The `'Other'`-group fail-closed guard is unaffected: it is keyed on the resolved `baseModel` group of the checkpoint and of the resource, with no `modelType` term on either side, and both rejects sit before/independent of the support call. A widened *type* cannot reach it differently. The two unknown-`baseModel` rejects are likewise type-independent.

## Maturity is unchanged — and now pinned on both sides

The picker's list is the shared `ResourceSelectModal`. The host's only lever over it is the `options` bag, and `ResourceSelectOptions` declares no maturity control at all; filtering happens client-side in the shared `ResourceHitList` via `useApplyHiddenPreferences`, which is passed **no** `browsingLevel` override and so falls through to the site-wide `useBrowsingLevelDebounced()` ceiling. Widening a *type* list cannot change that — but "cannot" was previously asserted by nobody, so this PR asserts it:

- **Behavioural** (`PageBlockHostResourcePicker.browser.test.tsx`): drives the real host for **every** allowlisted type and asserts the options bag it hands the modal is byte-identical apart from the `type` token — exact key sets on the bag and on `resources[0]`, then an equality check across all four with `type` stripped. A maturity key added at that call site goes red.
- **Structural seam** (`__tests__/resourcePickerMaturitySeam.test.ts`, new): an asserted ledger over the two files that own the other half — the exact field set of `ResourceSelectOptions`, and the exact argument keys of the `useApplyHiddenPreferences` call in `ResourceHitList`. Fails when either set **grows or shrinks**.

Unchanged and re-checked, not re-derived: the `RESOURCE_PICKER_RESULT` projection (name/id + public recommended settings only — the existing leak test still passes untouched), the host-chrome boundary (the iframe still never receives a list, the search API or the catalog), and the per-resource entitlement re-gate that runs on every picked id at estimate and submit. No server file is modified by this PR.

## Red → green

The scope-creep guard was **updated, not deleted** — it still asserts an exact set, just the new one. Watched fail on pre-change code:

```
FAIL  src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts > the allowlist is exactly Checkpoint + the LoRA family (guards against scope creep)
AssertionError: expected [ 'Checkpoint', 'LORA' ] to deeply equal [ 'Checkpoint', 'DoRA', 'LORA', …(1) ]
```

Unit, at `origin/main`: **4 failed | 83 passed**, the other three being the LoCon accept, the DoRA accept and the case-insensitivity case. At HEAD: **87 passed**.

Browser, with the allowlist reverted in place: **2 failed | 7 passed** — `a LoRA-family type (LoCon) opens the native modal filtered to THAT type` and `every allowlisted type passes the SAME options bag`, both `expected [] to have a length of 1` (the modal never opened). At HEAD: **9 passed**.

The seam ledger was mutation-tested rather than assumed. Adding `browsingLevel?: number` to `ResourceSelectOptions` and `browsingLevel: 28` to the `useApplyHiddenPreferences` call each killed **its own** assertion with the added key visible in the received value (`expected [ 'browsingLevel', 'data', 'type' ] to deeply equal [ 'data', 'type' ]`); an isolated shrink — removing only `excludeIds` — killed the other one. Both directions, each for its own reason.

The rejection loop still rejects everything outside the set (VAE, TextualInversion, Wildcards, Upscaler, Hypernetwork); LoCon and DoRA moved out of it and into explicit accept cases.

## SDK coupling — this can land alone

`@civitai/app-sdk` v0.14.0 declares `BlockResourcePickerType = 'Checkpoint' | 'LORA'`. That is a **compile-time declaration only**: `dist/blocks/types.js` is `export {}`, the package ships no code that sends `OPEN_RESOURCE_PICKER`, and its one runtime helper (`isMessage`) checks `data.type` and explicitly does not validate payloads. Measured, not inferred — a `tsc` probe confirms the literal `'LoCon'` is rejected against the SDK type while `'LORA'` assigns cleanly, and the new browser test posts a raw untyped `{ resourceType: 'LoCon' }` message and the picker opens.

**So a block built against v0.14.0 that requests `LoCon` at runtime works today.** The SDK follow-up is an authoring-ergonomics release (widen the union so block authors don't need a cast), not a co-requisite for enforcement. It is not in this PR — separate repo.

## Testing

- `pnpm typecheck` — 0 errors.
- Unit: 39 files / 1188 tests green across the full `src/components/AppBlocks` tree plus the two suites that own the spend-time gate (`workflow.service.test.ts`, `blocks.router.workflow.test.ts`).
- Browser: `PageBlockHostResourcePicker.browser.test.tsx`, 9/9.
- Population chosen by grepping the **consumers** of the widened symbol, not the files edited: `PAGE_RESOURCE_PICKER_TYPES` has three (the module, its unit test, the browser test), `resolveResourcePickerRequest` has one more (`PageBlockHost.tsx`), and `hostHandlerParity.ts` carries no type list for this message.

## Also in this PR

Corrects a stale in-code note next to the picker handler that cited `useResourceSelectFilters` — a symbol that no longer exists anywhere in the repo. The picker's list now comes from the `model.getResourceSelect` procedure. The surrounding analysis is load-bearing and predates this work; only the wrong name is replaced.

## In-flight overlap

Five open PRs touch the resource picker (#3500–#3504). None modifies `PAGE_RESOURCE_PICKER_TYPES` or any App Blocks file. Two touch files this PR's **seam ledger reads** — #3502 and #3504 (`ResourceHitList.tsx`; #3504 also `resource-select.types.ts`) — so they were **test-merged**, not reasoned about: an octopus merge of this branch with both is textually clean, and the seam ledger plus the picker suite are green on the merged tree (90/90). #3504 appends a function to `resource-select.types.ts` without touching `ResourceSelectOptions`; neither PR changes the `useApplyHiddenPreferences` call.

## Not verified

- The picker was not exercised against a live catalog — no manual QA of an actual LoCon/DoRA search result. The type reaches the modal filter and `getResourceSelect` accepts it (`z.enum(ModelType)`), but nobody watched a real LoCon card render.
- No end-to-end submit of a LoCon or DoRA through estimate/submit was run. The claim that the spend path already accepts them is read from the gate and its existing tests, not from a live workflow.
- The `'Other'` fail-open analysis is a read of the compatibility functions, not a new test; the existing guards for it are untouched and still green.
