### PR TITLE
fix(blocks): use a text-tuned score threshold for the SFW withhold tier

### DIFF
--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -94,7 +94,9 @@ import {
   VERDICT_CACHE_MAX_ENTRIES,
   __clearTextOutputVerdictCacheForTests,
 } from '~/server/services/blocks/steps/text-output-moderation';
-// 🔴 A NAMESPACE IMPORT, ON PURPOSE, AND ONLY FOR `erroredRequestedLabels`.
+// 🔴 A NAMESPACE IMPORT, ON PURPOSE, FOR `erroredRequestedLabels` AND
+// `SFW_ONLY_TEXT_SCORE_THRESHOLD` — the two symbols this suite asserts on that
+// did not exist on the commit each was written against.
 // A NAMED import of a symbol the module does not export is a LINK-TIME failure
 // under vitest's ESM transform: the whole file fails to COLLECT and reports
 // `Tests no tests`, which reads as "nothing to see" rather than as a failure.
@@ -734,6 +736,262 @@ describe('textOutput — the approved label policy', () => {
       requestedLabels: NONE,
     });
     expect(verdict.released).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the SFW-tier TEXT score threshold', () => {
+  /**
+   * A minimal one-label fixture with FULL control of the three fields that
+   * decide this tier: the SCORE, the `triggered` bit the scanner computed, and
+   * the THRESHOLD it echoes back. `scanOutput` cannot express the cases below —
+   * it derives `triggered` from membership and always echoes `0.5` — and the
+   * whole point here is to drive those three apart.
+   *
+   * `requestedLabels: NONE` throughout, so the drift guard is vacuous and every
+   * assertion reads the tier logic rather than a label-drift withhold. See the
+   * `ALL` / `NONE` note above for why picking the wrong one makes a test pass
+   * for the wrong reason.
+   */
+  function labelResult(over: {
+    label: string;
+    score?: number | string | null;
+    triggered?: boolean;
+    threshold?: number;
+  }) {
+    const { label, score = 0, triggered = true, threshold = 0.5 } = over;
+    return {
+      triggeredLabels: triggered ? [label] : [],
+      results: [{ label, action: 'Scan', threshold, score, triggered, modelReason: '' }],
+    };
+  }
+  const onSfwHost = { isGreen: true, requestedLabels: NONE };
+
+  /**
+   * Two real measured scores, used as the below/above pair everywhere here.
+   * BELOW sits between the scanner's image-tuned threshold and the text one —
+   * the band this change moves — and ABOVE is several lattice steps clear of the
+   * text threshold, so neither is a value the scorer's replicate spread could
+   * push across the line.
+   */
+  const BELOW_TEXT_THRESHOLD = 0.6311;
+  const ABOVE_TEXT_THRESHOLD = 0.918;
+  /**
+   * 🔴 A LITERAL, NOT THE MODULE'S OWN CONSTANT. Building the fixtures out of
+   * the value under test would make every case below tautological — and, on the
+   * pre-change tree where the export does not exist, would feed each fixture a
+   * `NaN` score and send it down the fail-closed branch, so the cases would go
+   * red for a reason that has nothing to do with the threshold. The module's
+   * export is compared against this literal in one place, below.
+   */
+  const TEXT_THRESHOLD = 0.75;
+
+  it('the TEXT threshold is 0.75 — the value the corpus measurement selected', () => {
+    // 🔴 INVARIANT GUARD, NOT REGRESSION COVERAGE. It pins a chosen number so a
+    // drift has to be deliberate. The behavioural cases below are what catch the
+    // defect. Read through the NAMESPACE so a tree without the export fails HERE
+    // rather than failing to collect the whole file.
+    expect(TextOutputModeration.SFW_ONLY_TEXT_SCORE_THRESHOLD).toBe(TEXT_THRESHOLD);
+    // …and it is STRICTLY ABOVE the image-tuned threshold the scanner echoes for
+    // this tier, which is the entire content of the change.
+    expect(TEXT_THRESHOLD).toBeGreaterThan(0.5);
+    expect(BELOW_TEXT_THRESHOLD).toBeLessThan(TEXT_THRESHOLD);
+    expect(ABOVE_TEXT_THRESHOLD).toBeGreaterThan(TEXT_THRESHOLD);
+  });
+
+  it('🔴 RELEASES a SFW-tier trigger whose score is below the TEXT threshold', () => {
+    // The reply that produced this policy: a catalog-backed answer scoring
+    // `Suggestive` over the scanner's image-tuned threshold and under the text
+    // one. Before the change this withheld.
+    const verdict = decideTextOutputVerdict(
+      labelResult({ label: 'Suggestive', score: BELOW_TEXT_THRESHOLD }),
+      onSfwHost
+    );
+    expect(verdict.released).toBe(true);
+    expect(verdict.withholdingLabels).toEqual([]);
+    // …and the trigger is still REPORTED. The telemetry must not go quiet just
+    // because the policy stopped acting on it.
+    expect(verdict.triggeredLabels).toEqual(['Suggestive']);
+    expect(verdict.scores.Suggestive).toBe(BELOW_TEXT_THRESHOLD);
+  });
+
+  it('🔴 still WITHHOLDS a SFW-tier trigger whose score is above the TEXT threshold', () => {
+    // 🔴 THE OTHER DIRECTION, AND IT IS NOT OPTIONAL. A suite asserting only the
+    // release above passes with the threshold set to anything up to 1, i.e. with
+    // the maturity-gated tier switched off entirely.
+    const verdict = decideTextOutputVerdict(
+      labelResult({ label: 'Suggestive', score: ABOVE_TEXT_THRESHOLD }),
+      onSfwHost
+    );
+    expect(verdict.released).toBe(false);
+    expect(verdict.withholdingLabels).toEqual(['Suggestive']);
+  });
+
+  it.each(SFW_ONLY_WITHHOLD_LABELS.map((l) => [l]))(
+    "'%s' releases BELOW and withholds ABOVE the text threshold — the whole tier moved, not one label",
+    (label) => {
+      expect(
+        decideTextOutputVerdict(labelResult({ label, score: BELOW_TEXT_THRESHOLD }), onSfwHost)
+          .released
+      ).toBe(true);
+      expect(
+        decideTextOutputVerdict(labelResult({ label, score: ABOVE_TEXT_THRESHOLD }), onSfwHost)
+          .released
+      ).toBe(false);
+    }
+  );
+
+  it('🔴 the comparison is `>=` — a score EXACTLY on the threshold withholds', () => {
+    // Pins the OPERATOR; the literal value is pinned separately above. A `>`
+    // would release a score sitting on the line.
+    expect(
+      decideTextOutputVerdict(
+        labelResult({ label: 'Suggestive', score: TEXT_THRESHOLD }),
+        onSfwHost
+      ).released
+    ).toBe(false);
+    expect(
+      decideTextOutputVerdict(
+        labelResult({ label: 'Suggestive', score: TEXT_THRESHOLD - 0.0001 }),
+        onSfwHost
+      ).released
+    ).toBe(true);
+  });
+
+  it('🔴 the ENFORCED threshold governs when the scanner echoes a LOWER one', () => {
+    // The scanner states, in the same payload, that it applied its own threshold
+    // and that the label triggered. Both are true, and both are ignored — the
+    // echoed value and the enforced value disagree ON PURPOSE, and this is where
+    // that stops being silent.
+    const output = labelResult({
+      label: 'Suggestive',
+      score: BELOW_TEXT_THRESHOLD,
+      triggered: true,
+      threshold: 0.5,
+    });
+    expect(output.results[0].threshold).toBeLessThan(TEXT_THRESHOLD);
+    expect(output.results[0].triggered).toBe(true);
+    expect(decideTextOutputVerdict(output, onSfwHost).released).toBe(true);
+  });
+
+  it('🔴 the ENFORCED threshold governs when the scanner echoes a HIGHER one', () => {
+    // The direction that would let this file's constant go quietly INERT: raise
+    // the orchestrator registry's threshold above ours and every score in the gap
+    // arrives `triggered: false` and never enters the trigger set. Our threshold
+    // must still bite, or the policy silently reverts to the scanner's.
+    const output = labelResult({
+      label: 'Suggestive',
+      score: 0.9,
+      triggered: false,
+      threshold: 0.99,
+    });
+    expect(output.results[0].threshold).toBeGreaterThan(TEXT_THRESHOLD);
+    expect(output.results[0].triggered).toBe(false);
+    expect(output.triggeredLabels).toEqual([]);
+    const verdict = decideTextOutputVerdict(output, onSfwHost);
+    expect(verdict.released).toBe(false);
+    expect(verdict.withholdingLabels).toEqual(['Suggestive']);
+    // …and it is NOT reported as triggered, because the scanner did not say so.
+    // `withholdingLabels` is deliberately not a subset of `triggeredLabels`.
+    expect(verdict.triggeredLabels).toEqual([]);
+  });
+
+  it.each([
+    ['no `results[]` entry at all', [] as unknown[]],
+    ['an entry with no `score` field', [{ label: 'Suggestive', triggered: true }]],
+    ['a non-numeric `score`', [{ label: 'Suggestive', triggered: true, score: 'high' }]],
+    ['a NaN `score`', [{ label: 'Suggestive', triggered: true, score: Number.NaN }]],
+  ])('🔴 FAILS CLOSED on a SFW-tier trigger with %s', (_name, results) => {
+    // The threshold cannot be applied to a score we cannot read, and "we could
+    // not evaluate it" must never read as "clean". This is also the only branch
+    // that can decide a label present ONLY in the top-level array, which is what
+    // keeps the union-of-two-signals property fail-closed.
+    const verdict = decideTextOutputVerdict(
+      { triggeredLabels: ['Suggestive'], results },
+      onSfwHost
+    );
+    expect(verdict.released).toBe(false);
+    expect(verdict.withholdingLabels).toEqual(['Suggestive']);
+  });
+
+  it.each(ALWAYS_WITHHOLD_LABELS.map((l) => [l]))(
+    "🔴 '%s' is NOT thresholded — the always-withhold tier withholds at a LOW score, on either host",
+    (label) => {
+      // 🔴 THE GUARD THAT MUST NOT MOVE. The text threshold is scoped to the
+      // maturity-gated tier. A change that applied it to this tier would release
+      // a low-scoring `Young` / `Grooming` / `Sex Trafficking` trigger.
+      for (const isGreen of [true, false]) {
+        const verdict = decideTextOutputVerdict(labelResult({ label, score: 0.1 }), {
+          isGreen,
+          requestedLabels: NONE,
+        });
+        expect(verdict.released).toBe(false);
+        expect(verdict.withholdingLabels).toEqual([label]);
+      }
+    }
+  );
+
+  it('a MATURE-allowed host releases the SFW tier at ANY score', () => {
+    // The threshold is a change to WHEN the maturity-gated tier bites, never to
+    // WHETHER the gate applies. The mature side is untouched.
+    for (const score of [BELOW_TEXT_THRESHOLD, ABOVE_TEXT_THRESHOLD, 0.9999]) {
+      expect(
+        decideTextOutputVerdict(labelResult({ label: 'Suggestive', score }), {
+          isGreen: false,
+          requestedLabels: NONE,
+        }).released
+      ).toBe(true);
+    }
+  });
+
+  it('looks the score up CASE-INSENSITIVELY', () => {
+    // Label spelling is orchestrator-side config. An exact-match score lookup
+    // would miss, fall into the fail-closed branch and withhold a benign reply —
+    // the change would be inert for a purely cosmetic reason.
+    const verdict = decideTextOutputVerdict(
+      {
+        triggeredLabels: ['suggestive'],
+        results: [{ label: 'Suggestive', score: BELOW_TEXT_THRESHOLD, triggered: true }],
+      },
+      onSfwHost
+    );
+    expect(verdict.released).toBe(true);
+    expect(verdict.withholdingLabels).toEqual([]);
+  });
+
+  it('🔴 END TO END — a below-threshold SFW trigger releases the text through `screenGeneratedText`', async () => {
+    // The pure decision function is where the logic lives, but the defect users
+    // saw was a withheld reply on the read path. Drive it.
+    scannerReturns(scanOutput(['Suggestive'], { Suggestive: BELOW_TEXT_THRESHOLD }));
+    const released = await screenGeneratedText({
+      ...CTX,
+      isGreen: true,
+      texts: [GENERATED_TEXT],
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(released).toEqual({ released: true, texts: [GENERATED_TEXT] });
+    // No `stage: 'withheld'` line, because nothing was withheld.
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('🔴 END TO END — an above-threshold SFW trigger still withholds through `screenGeneratedText`', async () => {
+    // The positive control for the pair above. Without it the end-to-end release
+    // is indistinguishable from a scan that never ran.
+    scannerReturns(scanOutput(['Suggestive'], { Suggestive: ABOVE_TEXT_THRESHOLD }));
+    const withheld = await screenGeneratedText({
+      ...CTX,
+      isGreen: true,
+      texts: [GENERATED_TEXT],
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(withheld).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({
+      stage: 'withheld',
+      withholdingLabels: ['Suggestive'],
+    });
   });
 });
 

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -104,6 +104,60 @@ export const SFW_ONLY_WITHHOLD_LABELS: readonly string[] = [
 ] as const;
 
 /**
+ * The score at or above which a {@link SFW_ONLY_WITHHOLD_LABELS} label withholds
+ * TEXT output. It replaces the scanner's own per-label threshold, which is tuned
+ * for IMAGE moderation.
+ *
+ * 🔴 THIS IS THE SAME DECISION THIS FILE ALREADY MADE ABOUT `blocked`, ONE STEP
+ * FURTHER. `decideTextOutputVerdict` already refuses the orchestrator's
+ * image-tuned ACTION config (see its comment on `blocked`) because this policy
+ * decides what to do about text. `triggered` is the other half of that same
+ * config — it is nothing but `score >= <the registry's image-tuned threshold>`
+ * — so taking the score and applying a text-tuned threshold here is the
+ * consistent position, not a new kind of move.
+ *
+ * 🔴 WHY 0.75, AND WHAT IT COSTS. Measured on a corpus of catalog-style block
+ * replies (48 texts, 240 scans, each text replicated), scored by the deployed
+ * text scanner:
+ *
+ *   - At the image-tuned 0.5 a large majority of benign catalog answers withheld
+ *     — the format a catalog-backed block emits (a numbered list of real model
+ *     titles, links and attribute bullets) sits in the middle of the score
+ *     distribution, so ordinary answers were being suppressed.
+ *   - The score is NOT deterministic on identical bytes. It is quantised onto a
+ *     fixed log-odds lattice (adjacent-mode spacing 0.1219 ± 0.0020 in log-odds,
+ *     n=17 gaps), and a text near a threshold lands on either side of it across
+ *     repeats of the SAME input. At 0.5 roughly a third of the corpus flipped
+ *     verdict nondeterministically; at 0.75 that falls to ~2%.
+ *   - 0.60 was REJECTED: it roughly halves the withhold rate while buying NO
+ *     reduction in the nondeterministic fraction, because the lattice is dense
+ *     where the corpus piles up.
+ *   - 0.85 was REJECTED: it buys ~1.7 points of withhold rate over 0.75 and
+ *     TRIPLES the nondeterministic fraction, because two corpus texts sit
+ *     essentially ON 0.85 (within one lattice step) and straddle it. That is the
+ *     same failure that ruled out 0.60 — a threshold landing INSIDE a lattice
+ *     band is a coin flip on identical input.
+ *   - At 0.75 every text that still withholds is at least four lattice steps
+ *     clear of the line, and none was observed to straddle.
+ *
+ * THE GUARD IS WEAKENED BY CONSTRUCTION, and that is the accepted cost: ~15% of
+ * realistic catalog replies still withhold, all of them the population whose
+ * catalog-assigned tags carry a sexuality token. The considered alternative —
+ * dropping `Suggestive` from {@link SFW_ONLY_WITHHOLD_LABELS} — was rejected
+ * because it takes the corpus withhold rate to ZERO: across the corpus's
+ * three-label scans `Explicit` and `NSFW` never triggered without `Suggestive`,
+ * so removing it leaves the SFW tier inert for text. The threshold moves; the
+ * label set does not.
+ *
+ * 🔴 IMAGE MODERATION IS NOT AFFECTED. This constant is read in exactly one
+ * place — `decideTextOutputVerdict`, which is called only from
+ * `screenGeneratedText` on the block text-output path. The scan REQUEST is
+ * unchanged (no `labelOverrides`), so the orchestrator scores text exactly as it
+ * did and every other consumer of that scan sees exactly what it saw before.
+ */
+export const SFW_ONLY_TEXT_SCORE_THRESHOLD = 0.75;
+
+/**
  * Labels scanned but deliberately NOT acted on — recorded here so the set is
  * enumerable and the tests can assert the three sets PARTITION the scan list
  * (no label silently drops out of the policy when someone edits one array).
@@ -156,6 +210,23 @@ export type XGuardLabelResultLike = {
   triggered?: unknown;
   error?: unknown;
   finishReason?: unknown;
+  /**
+   * 🔴 DECLARED SO THE DISAGREEMENT IS VISIBLE, AND DELIBERATELY NOT READ.
+   * The scanner echoes the threshold IT applied when it computed `triggered`,
+   * and for the {@link SFW_ONLY_WITHHOLD_LABELS} tier that value is image-tuned
+   * and is NOT the threshold this policy enforces — see
+   * {@link SFW_ONLY_TEXT_SCORE_THRESHOLD}. Reading it would re-import the very
+   * calibration the text policy exists to replace, and a future registry edit
+   * would then silently move a text verdict.
+   *
+   * The two therefore DO differ, on purpose, and the way that is kept from being
+   * silent is behavioural rather than cosmetic: for the SFW tier
+   * `decideTextOutputVerdict` decides from `score` against this file's own
+   * constant in BOTH directions, so the echoed value cannot change a verdict
+   * whether it is lower OR higher than ours. Pinned by tests that feed a result
+   * whose echoed `threshold` disagrees with the enforced one each way.
+   */
+  threshold?: unknown;
 };
 
 /** The scan output shape this policy reads. */
@@ -168,7 +239,15 @@ export type XGuardScanOutputLike = {
 export type TextOutputScanVerdict = {
   /** True when the text may be released to the block. */
   released: boolean;
-  /** The POLICY-ACTIONED labels that triggered. Empty on a release. */
+  /**
+   * The POLICY-ACTIONED labels. Empty on a release.
+   *
+   * 🔴 NOT A SUBSET OF `triggeredLabels`. For the maturity-gated tier this
+   * policy applies its OWN threshold to the score
+   * ({@link SFW_ONLY_TEXT_SCORE_THRESHOLD}), so a label the scanner flagged can
+   * be absent here (score below our threshold) and a label it did not flag can
+   * be present (score at or above ours, scanner threshold higher).
+   */
   withholdingLabels: string[];
   /** Every label that triggered, actioned or not — telemetry, not policy. */
   triggeredLabels: string[];
@@ -436,6 +515,16 @@ export function erroredRequestedLabels(
  * ever disagree, the union withholds and the intersection releases. Union is
  * the fail-closed direction, so union is what this does.
  *
+ * 🔴 THE MATURITY-GATED TIER IS DECIDED ON THE SCORE, NOT ON `triggered`.
+ * `triggered` is `score >= <the orchestrator registry's threshold>`, and that
+ * threshold is image-tuned — the same calibration this function already refuses
+ * when it ignores `blocked`. For {@link SFW_ONLY_WITHHOLD_LABELS} the score is
+ * compared against {@link SFW_ONLY_TEXT_SCORE_THRESHOLD} instead, in BOTH
+ * directions, so the echoed `results[].threshold` cannot move a text verdict
+ * whether it is lower or higher than ours. A SFW-tier label that triggered but
+ * carries NO readable score FAILS CLOSED. {@link ALWAYS_WITHHOLD_LABELS} is
+ * untouched by this and still withholds on `triggered` alone.
+ *
  * `modelReason` is NOT read: it came back EMPTY on every probe call against the
  * deployed scanner, so anything built on it would be built on a constant.
  */
@@ -477,12 +566,70 @@ export function decideTextOutputVerdict(
   }
 
   const triggeredLabels = [...triggered];
-  const withholdingLabels = triggeredLabels.filter((label) => {
+
+  // Which labels came back with a READABLE score, by normalized key. The key is
+  // normalized for the same reason every other comparison in this file is: a
+  // label arrives spelled by the orchestrator, and an exact-match lookup would
+  // miss on a casing this side does not control — which here would land in the
+  // fail-closed branch below and withhold a benign reply for a cosmetic reason.
+  const scoredKeys = new Set<string>(Object.keys(scores).map(normalizeLabel));
+
+  // Deduped by normalized key so two spellings of one label produce one entry;
+  // the spelling kept is the first seen, which preserves `triggeredLabels` order.
+  const withholding = new Map<string, string>();
+  const addWithhold = (label: string) => {
     const key = normalizeLabel(label);
-    if (ALWAYS_WITHHOLD_KEYS.has(key)) return true;
+    if (!withholding.has(key)) withholding.set(key, label);
+  };
+
+  for (const label of triggeredLabels) {
+    const key = normalizeLabel(label);
+    if (ALWAYS_WITHHOLD_KEYS.has(key)) {
+      // 🔴 UNCHANGED, AND NOT THRESHOLDED. This tier withholds on the scanner's
+      // own `triggered` bit, on either host. The text threshold below applies to
+      // the maturity-gated tier ONLY; extending it here would weaken a guard
+      // that is not the subject of this policy.
+      addWithhold(label);
+      continue;
+    }
     // 🔴 The maturity-gated tier. `isGreen` true == the token's ceiling is SFW.
-    return opts.isGreen && SFW_ONLY_WITHHOLD_KEYS.has(key);
-  });
+    if (!opts.isGreen || !SFW_ONLY_WITHHOLD_KEYS.has(key)) continue;
+    // 🔴 FAIL CLOSED WHEN THERE IS NO READABLE SCORE, AND DECIDE NOTHING ELSE
+    // HERE. The scanner said this label triggered; if we cannot read a number we
+    // cannot apply our own threshold to it, and "we could not evaluate it" must
+    // never read as "clean" — the same invariant `missingRequestedLabels` and
+    // `erroredRequestedLabels` state. This is also the only path by which a
+    // label present ONLY in the top-level `triggeredLabels` array (no
+    // `results[]` entry, hence no score) can be decided, and it decides it the
+    // safe way, which keeps the union-of-two-signals property fail-closed.
+    //
+    // 🔴 THE THRESHOLD COMPARISON IS DELIBERATELY NOT REPEATED HERE. An earlier
+    // draft also compared the score in this loop, which read as belt-and-braces
+    // and was in fact a REDUNDANT SECOND COPY of the same predicate — the
+    // mutation sweep caught it: flipping this loop's `>=` to `>` left the whole
+    // suite GREEN, because the single-site loop below rescued every case. One
+    // rule, one place; the score is compared exactly once, below.
+    if (!scoredKeys.has(key)) addWithhold(label);
+  }
+
+  // 🔴 THE ONE PLACE A SFW-TIER SCORE IS COMPARED TO THE TEXT THRESHOLD — and it
+  // deliberately does NOT consult `triggered`. That is what makes
+  // {@link SFW_ONLY_TEXT_SCORE_THRESHOLD} the enforced threshold in BOTH
+  // directions rather than a filter layered on top of the scanner's verdict.
+  // Filtering `triggeredLabels` alone could only ever be MORE permissive than
+  // the registry: raise the scanner's `Suggestive` threshold above ours and
+  // every score in the gap would arrive `triggered: false`, never enter the
+  // trigger set, and this file's constant would go quietly inert. Iterating the
+  // scores instead is inert while the registry's thresholds sit at or below ours
+  // — the state today — and load-bearing the moment one moves above.
+  if (opts.isGreen) {
+    for (const [label, score] of Object.entries(scores)) {
+      if (!SFW_ONLY_WITHHOLD_KEYS.has(normalizeLabel(label))) continue;
+      if (score >= SFW_ONLY_TEXT_SCORE_THRESHOLD) addWithhold(label);
+    }
+  }
+
+  const withholdingLabels = [...withholding.values()];
 
   // 🔴 A LABEL WE ASKED FOR AND DID NOT GET AN ANSWER FOR WITHHOLDS, on its own,
   // even when nothing triggered. This is the rename/typo fail-open the generated


### PR DESCRIPTION
## The defect

App Block text output is scanned before it reaches the block. The scanner returns per-label `{ score, threshold, triggered }`, and `decideTextOutputVerdict` acted on `triggered`. But `triggered` is exactly `score >= <the scanner registry's threshold>`, and for the maturity-gated tier (`SFW_ONLY_WITHHOLD_LABELS` — `NSFW`, `Suggestive`, `Explicit`) that threshold is **tuned for image moderation**.

The result: benign catalog-backed chat replies were routinely withheld with *"This response was withheld because it did not pass Civitai's content policy."* A block whose job is to answer questions about the model catalog emits numbered lists of real model titles, links and attribute bullets — a format that sits in the middle of the text scorer's distribution — so ordinary, correct answers were being suppressed.

This file already refuses the orchestrator's image-tuned **action** config (it deliberately ignores `output.blocked`, with a documented measurement behind it: a 0.99-confidence `Explicit` came back `blocked: false` because that label's action is `Scan`). `triggered` is the other half of the same config. This change takes the consistent next step.

## The change

For the maturity-gated tier only, the score is compared against this file's own `SFW_ONLY_TEXT_SCORE_THRESHOLD = 0.75`.

**What is NOT changed, deliberately:**

- The **label set** is unchanged. `Suggestive` stays in `SFW_ONLY_WITHHOLD_LABELS`.
- The **always-withhold tier** is unchanged and is still not thresholded.
- The **scan request** is unchanged — no `labelOverrides`.
- The **image path** is untouched.
- No catalog-field change. `projectModelForTool` and the tags projection are not in this diff.

### Which seam, and why

There were two ways to effect a text-specific threshold.

**(a) Send `labelOverrides` on the scan request** so the scanner applies 0.75 itself. **Rejected**, for three independent reasons:

1. `XGuardLabelOverride` requires all four of `label`, `action`, `threshold`, `policy`. `policy` is the orchestrator-side judging prompt — configuration this codebase does not own and holds no copy of. Sending a threshold override means hardcoding a snapshot of someone else's registry prompt here, which then drifts silently.
2. It changes what is **cached**. Overrides are folded into the request's content hash on this side, and they are part of the scan's blob-cache key on the other side. Every block text scan would stop sharing cached results and become a fresh model call — at a scorer whose output is measurably nondeterministic near a threshold (see below), that is the worst place to add fresh draws.
3. No production caller sends overrides today. Only a debug endpoint (disabled in prod) and a policy-test service do.

**(b) Have `decideTextOutputVerdict` compare `score` against its own text-specific threshold.** **Chosen.** It keeps the change entirely inside this repo, in the pure decision function that is already the declared policy owner ("this policy decides what to do, not the orchestrator's image-tuned config" — the function's own comment). The request, the cache key, the cost and every other consumer of that scan are untouched.

### The echoed threshold vs. the enforced threshold

The scanner echoes back the threshold **it** applied. That value and the value this policy enforces now genuinely differ, on purpose — so the change is built so they cannot *silently* differ:

- `results[].threshold` is **declared** in the read shape (`XGuardLabelResultLike`) with a comment saying it is deliberately not read, mirroring how `finishReason` is handled.
- The comparison **iterates the per-label scores** rather than filtering `triggeredLabels`. Filtering the trigger set could only ever be *more* permissive than the registry: raise the registry's `Suggestive` threshold above ours and every score in the gap would arrive `triggered: false`, never enter the set, and this constant would go quietly inert with no test able to see it. Iterating the scores makes 0.75 the enforced threshold in **both** directions.
- Two tests pin exactly that: one feeds a result whose echoed threshold is *lower* than ours (releases anyway), one whose echoed threshold is *higher* than ours with `triggered: false` (withholds anyway).

### Why 0.75

Measured against the deployed text scanner on a constructed corpus of catalog-style block replies — 48 texts, 240 scans, every text replicated:

| threshold | withhold rate (by scan) | corpus fraction that flips verdict on identical bytes |
|---|---|---|
| 0.50 (image-tuned) | 56.7% | ~29% (est.), 5 observed straddles |
| 0.60 | 30.0% | ~29% (est.), 5 observed straddles |
| **0.75** | **15.0%** | **~2.1% (est.), 0 observed straddles** |
| 0.85 | 13.3% | ~6.2% (est.), 2 observed straddles |

The score is **not** a deterministic function of the text. It is quantised onto a fixed log-odds lattice (adjacent-mode spacing 0.1219 ± 0.0020 in log-odds across 17 measured gaps), and a text sitting inside a lattice band lands on either side of the threshold across repeats of the *same bytes*.

- **0.60 rejected**: roughly halves the withhold rate while buying **no** reduction in nondeterminism — the lattice is dense exactly where the corpus piles up.
- **0.85 rejected**: buys ~1.7 points of withhold rate over 0.75 and **triples** the coin-flip fraction, because two corpus texts sit essentially on it and were observed to straddle.
- At **0.75** every text that still withholds is at least four lattice steps clear of the line, and none was observed to straddle.

### 🔴 This weakens a guard, and that is the decision

Raising the threshold **does** weaken the SFW-tier withhold guard. Roughly 15% of realistic catalog replies still withhold, and they are the population whose catalog-assigned tags carry a sexuality token; the rest now release. That is the sanctioned trade, stated plainly rather than glossed.

The considered alternative — **removing `Suggestive` from the label set** — was rejected because it is worse: across the corpus's three-label scans, `Explicit` and `NSFW` **never** triggered without `Suggestive`. Removing it takes the corpus withhold rate to zero and leaves the SFW tier inert for text. The threshold moves; the set does not.

No **other** guard is weakened. In particular the maturity clamp applied unconditionally ahead of the catalog path in the block tools handler is untouched — `resolveCatalogBrowsingLevel` and `resourceExceedsCatalogCeiling` appear nowhere in this diff, and neither does `projectModelForTool`. The always-withhold tier still withholds on the scanner's own `triggered` bit, at any score, on either host; seven `it.each` cases pin that.

## Tests

### Red → green, watched

Base sha **`04afb7753e702b143083a9a8234297204da36887`**.

The new tests were run against the base source file with the new test file in place:

```
Tests  10 failed | 137 passed (147)
```

Literal failing assertion on the headline case:

```
FAIL … > 🔴 RELEASES a SFW-tier trigger whose score is below the TEXT threshold
AssertionError: expected false to be true // Object.is equality
- Expected  true
+ Received  false
  step-text-output-moderation.test.ts:810:30  →  expect(verdict.released).toBe(true);
```

With the change applied: `Tests 159 passed (159)` across this suite and the router suite that also exercises the path.

The suite **collected** at base (147 tests ran) rather than failing to link — the new export is read through the file's existing namespace import, which is there precisely so a red-at-base measurement stays possible.

### Isolated mutation results

Each mutant changes the **narrowest** expression, never a guard together with its enclosing condition, and each is named with the assertion that killed it.

| mutant | result | killed by |
|---|---|---|
| `0.75` → `0.5` (constant only) | **DIED**, 9 failures | *"🔴 RELEASES a SFW-tier trigger whose score is below the TEXT threshold"* — `expected false to be true` |
| `0.75` → `0.99` (constant only) | **DIED**, 12 failures | *"🔴 still WITHHOLDS a SFW-tier trigger whose score is above the TEXT threshold"* |
| `>=` → `>` | **DIED**, 1 failure | *"🔴 the comparison is `>=` — a score EXACTLY on the threshold withholds"* |
| drop the score-iterating withhold | **DIED**, 12 failures | *"🔴 the ENFORCED threshold governs when the scanner echoes a HIGHER one"* |
| drop the no-readable-score fail-closed branch | **DIED**, 4 failures | the four *"🔴 FAILS CLOSED on a SFW-tier trigger with …"* cases |
| leak the threshold into the always-withhold tier | **DIED**, 10 failures | the seven *"🔴 '<label>' is NOT thresholded …"* cases |

Positive control that the mutants actually ran: the constant-value assertion moved with each edit (`expected 0.5 to be 0.75`), and the failure count moved from 0 in every case.

**🔴 The sweep found a real defect in the first draft and it was fixed.** An earlier version compared the score in *two* places — once while walking the trigger set and once while walking the scores. Flipping the first `>=` to `>` left the suite **fully green**, because the second site rescued every case: a redundant copy of the same predicate, dying for the other guard's reason. The threshold is now compared exactly once, and the mutant dies.

### Both directions of the boundary are pinned

A test asserting only *"0.63 releases"* passes with the threshold set to anything up to 1. So the suite also asserts that a score above the threshold **still withholds**, that a score exactly **on** it withholds (pinning `>=` rather than `>`), and that a score just below it releases — plus the whole tier via `it.each` over `SFW_ONLY_WITHHOLD_LABELS`, so the change cannot be right for one label and wrong for the others.

### Existing tests touched

Nothing was deleted or loosened.

- Added one import (via the existing namespace import; the named-import list is unchanged).
- Extended the comment on that namespace import to name the second symbol it now serves.
- Added one `describe` block.

`SFW_ONLY_WITHHOLD_LABELS` is still pinned at `toHaveLength(3)`; the three-tier partition assertion is unchanged; the existing `it.each` cases over the label set are unchanged and still pass (their fixture scores sit above the new threshold, so they exercise the withhold direction exactly as before).

### Population run

- `step-text-output-moderation.test.ts` — 147 tests (read from the runner's own count lines, not an exit code).
- Wider sweep around the change — `src/server/services/blocks`, `src/server/routers/__tests__`, the orchestrator moderation-request tests, the model-moderation adapter and the daily-challenge text scan: **288 files / 6227 tests, all passing**.
- Repo invariant suite `pnpm test:lint-rules`: **24 files / 359 tests, passing**.
- `pnpm typecheck`: **0 type errors**.
- Prettier on both changed files: clean, verified with a positive control (a deliberately mis-formatted copy was correctly listed).
- ESLint on both changed files: 0 errors; one pre-existing unused-import warning that this diff does not touch.

## Consumers checked

Grepped for everything that reads what changed, not just what was edited:

- `decideTextOutputVerdict` — one production caller (`screenGeneratedText`, same file) plus the two test suites, both green.
- `SFW_ONLY_WITHHOLD_LABELS`, `TextOutputScanVerdict`, `withholdingLabels` — no production consumer outside this file.
- `XGuardLabelResultLike` — referenced only in prose comments elsewhere.
- The model / image / prompt moderation paths use a different decision function entirely and are not reachable from this diff.

## Not verified

- **The production effect is not measured.** The withhold rates above come from a **constructed** corpus — real catalog rows drawn through the block tool route's own catalog step and rendered into two output formats recovered verbatim from real replies (one rendering reproduces a real reply byte-for-byte), but the 16 queries and the rendering rules were chosen. There is no observational corpus to validate it against.
- **Why the scorer's output is multimodal** is characterised, not diagnosed. The serving-layer cause is named only.
- The residual after this change is not eliminated: with the threshold at 0.75 a minority of catalog replies still withhold. The catalog-field lever that would address that population was measured and deliberately deferred; it is not in this PR.
- **The nondeterminism figures are estimates** from a straddle estimator calibrated on 10 deeply-replicated texts. Observed straddle counts are hard lower bounds; the estimates are upper bounds.
- No live production request was driven through the changed code. Verification here is the test suite, the typecheck and the mutation sweep — not a production observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHDAkX5qWemsyxSfZVWvsj
