### PR TITLE
fix(app-blocks): repair main's typecheck after #4491 and #4493 landed together

### DIFF
--- a/src/components/Apps/__tests__/appListingDetailModActions.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailModActions.test.ts
@@ -507,3 +507,40 @@ describe('takedownConsequenceCopy', () => {
     }
   });
 });
+
+/**
+ * 🔴 REGRESSION — this surface must never offer `purge`, and the guard is the RELATIONSHIP
+ * between two independent facts, either of which could change alone.
+ *
+ * Why it exists: `listingModActions` gained an on-site orphan-draft `purge` branch (#4491)
+ * while this file was being written in parallel (#4493). Both PRs were individually green and
+ * their FILES were disjoint; together they broke `main`'s typecheck, because #4493 added a
+ * second caller of a function whose required inputs #4491 had widened. A clean git merge is
+ * not a clean merge.
+ *
+ * Two things independently keep `purge` off this surface — `detailListingStatus` never returns
+ * `'draft'`, and `DETAIL_SURFACE_MOD_ACTIONS` omits `purge` — so a test that only checked the
+ * output would still pass if ONE of them regressed. These check both, and the inputs the call
+ * site pins are chosen so the fail-safe direction is withhold.
+ */
+describe('appListingDetailModActions — purge is unreachable from the detail surface', () => {
+  it('never offers purge for a moderator on a live listing, either kind', () => {
+    for (const kind of ['onsite', 'offsite']) {
+      const actions = appListingDetailModActions({ isModerator: true, preview: false, kind });
+      expect(actions, `kind=${kind}`).not.toContain('purge');
+      // Positive control: the surface IS returning its real action set, not an empty array —
+      // otherwise "does not contain purge" is vacuously true.
+      expect(actions.length, `kind=${kind} returned nothing`).toBeGreaterThan(0);
+    }
+  });
+
+  it('the surface subset itself excludes purge', () => {
+    expect(DETAIL_SURFACE_MOD_ACTIONS).not.toContain('purge');
+  });
+
+  it('the surface status can never be the one the purge branch requires', () => {
+    // `purge` needs `status === 'draft'`; this surface only ever produces 'approved' or null.
+    expect(detailListingStatus({ preview: false })).toBe('approved');
+    expect(detailListingStatus({ preview: true })).toBeNull();
+  });
+});

--- a/src/components/Apps/appListingDetailModActions.ts
+++ b/src/components/Apps/appListingDetailModActions.ts
@@ -201,6 +201,20 @@ export function appListingDetailModActions(input: {
     kind: input.kind,
     // This surface never holds a publish REQUEST, so it can never offer `review`.
     hasPendingRequest: false,
+    // 🔴 THE PURGE-BRANCH INPUTS, PINNED FAIL-SAFE. This surface cannot reach that branch —
+    // `detailListingStatus` returns only `'approved' | null` and never `'draft'`, and `purge`
+    // is absent from DETAIL_SURFACE_MOD_ACTIONS so the filter below would drop it anyway. The
+    // values are still chosen for what happens if EITHER of those stops being true: a null
+    // `appBlockId` says "never approved" and `hasPendingBlockRequest: true` says "assume a
+    // submission is live", and the branch requires the latter to be FALSE. So the fail-safe
+    // direction is withhold, not offer.
+    //
+    // This surface has no honest source for either value — it is handed `{isModerator,
+    // preview, kind}` and nothing else. Do not invent one: a real value here would be a claim
+    // about a listing this function cannot see. Widening the input is the correct move if this
+    // surface ever needs to offer `purge`.
+    appBlockId: null,
+    hasPendingBlockRequest: true,
   }).filter(isDetailSurfaceModAction);
 }
 


### PR DESCRIPTION
## `main` is red. This repairs it.

`pnpm typecheck` fails on `main` at `3aa94344d0`:

```
src/components/Apps/appListingDetailModActions.ts(199,28): error TS2345:
  ... is missing the following properties: appBlockId, hasPendingBlockRequest
```

**Cause — two green PRs that break together.** #4491 widened `listingModActions`' required inputs (`appBlockId`, `hasPendingBlockRequest`) for its new on-site orphan-draft `purge` branch. #4493 added a **second caller** of that function in the listing detail surface. Both were individually green, their changed **files were disjoint**, and the merge had no textual conflict — so nothing flagged it. A clean git merge is not a clean merge.

**Mine specifically:** I tested the merged tree, #4493 landed in the ~90 seconds before I merged #4491, and I re-checked only for *file* overlap. File-disjointness does not cover a new **caller** of a signature I had changed.

## The fix

The detail surface **cannot** reach the purge branch, for two independent reasons:
- `detailListingStatus` returns only `'approved' | null` — never `'draft'`, which the branch requires.
- `DETAIL_SURFACE_MOD_ACTIONS` omits `purge`, so the filter drops it regardless.

So this passes the two required fields with **fail-safe** values rather than inventing data the function cannot see (it receives `{isModerator, preview, kind}` and nothing else): `appBlockId: null` and `hasPendingBlockRequest: true`. The branch needs the latter to be `false`, so if either structural reason above ever stops holding, the direction is **withhold**, not offer.

## Test

A regression test pinning **both** independent reasons, not just the output — either could regress alone and an output-only check would still pass. It carries a positive control so "does not contain purge" cannot be vacuously true on an empty array.

## Verification

- `pnpm typecheck`: **0 errors** (red on `main` before this).
- Full unit tier: **1604 files / 25159 tests pass**.
- Prettier clean.
