### PR TITLE
fix(browsing-level): scope other people's content to the viewer, and intersect caps

### DIFF
--- a/src/components/BrowsingLevel/BrowsingLevelProvider.tsx
+++ b/src/components/BrowsingLevel/BrowsingLevelProvider.tsx
@@ -65,7 +65,11 @@ export function BrowsingLevelProvider({
   );
   const blurNsfw = useBrowsingSettings((x) => x.blurNsfw);
   const [childBrowsingLevelOverride, setBrowsingLevelOverride] = useState<number | undefined>();
-  const [forcedBrowsingLevel, setForcedBrowsingLevel] = useState(parentForcedBrowsingLevel);
+  // 🔴 State holds ONLY what `setForcedBrowsingLevel` put there. Seeding it from
+  // the prop froze the cap at first mount, so a collection whose ceiling was
+  // raised left mounted viewers on the older, WIDER one — the prop is read live
+  // below instead.
+  const [imperativeForcedBrowsingLevel, setForcedBrowsingLevel] = useState<number | undefined>();
 
   // Cap rules mirror the server middleware (src/server/trpc.ts applyDomainFeature):
   //   anonymous (any domain)     → publicBrowsingLevelsFlag (PG)
@@ -88,7 +92,8 @@ export function BrowsingLevelProvider({
         // took whichever was set first, which let a wider cap from a nearer
         // provider erase a tighter one further out.
         forcedBrowsingLevel: intersectBrowsingCaps(
-          forcedBrowsingLevel,
+          imperativeForcedBrowsingLevel,
+          parentForcedBrowsingLevel,
           domainForcedLevel,
           ctx.forcedBrowsingLevel
         ),

--- a/src/components/BrowsingLevel/BrowsingLevelProvider.tsx
+++ b/src/components/BrowsingLevel/BrowsingLevelProvider.tsx
@@ -5,6 +5,7 @@ import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
   BROWSING_LEVEL_FALLBACK,
+  intersectBrowsingCaps,
   resolvePageBrowsingLevel,
   resolveViewerBrowsingLevel,
 } from '~/components/BrowsingLevel/resolve-browsing-level';
@@ -82,7 +83,15 @@ export function BrowsingLevelProvider({
   return (
     <BrowsingModeOverrideCtx.Provider
       value={{
-        forcedBrowsingLevel: forcedBrowsingLevel ?? domainForcedLevel ?? ctx.forcedBrowsingLevel,
+        // 🔴 Intersected, not shadowed. Every one of these is a ceiling nobody
+        // below may lift, so the effective cap is what ALL of them allow. `??`
+        // took whichever was set first, which let a wider cap from a nearer
+        // provider erase a tighter one further out.
+        forcedBrowsingLevel: intersectBrowsingCaps(
+          forcedBrowsingLevel,
+          domainForcedLevel,
+          ctx.forcedBrowsingLevel
+        ),
         userBrowsingLevel: userBrowsingLevel,
         browsingLevelOverride:
           childBrowsingLevelOverride ?? parentBrowsingLevelOverride ?? ctx.browsingLevelOverride,

--- a/src/components/BrowsingLevel/__tests__/browsing-level-hooks.test.ts
+++ b/src/components/BrowsingLevel/__tests__/browsing-level-hooks.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  BrowsingLevelProvider,
   BrowsingModeOverrideCtx,
   useBrowsingLevelDebounced,
   useViewerBrowsingLevelDebounced,
@@ -10,8 +11,27 @@ import {
 import { NsfwLevel } from '~/server/common/enums';
 import {
   allBrowsingLevelsFlag,
+  publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
+
+/**
+ * The three things the provider computes its cap FROM. Mocked so the cap's value
+ * can be driven, which the hand-built-context cases below deliberately cannot do
+ * — supplying the context is what makes the hooks testable and is exactly what
+ * hides this computation from them.
+ */
+const currentUser = { value: null as { id: number } | null };
+const canViewNsfw = { value: true };
+const settings = { showNsfw: true, browsingLevel: allBrowsingLevelsFlag, blurNsfw: false };
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => currentUser.value }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ canViewNsfw: canViewNsfw.value }),
+}));
+vi.mock('~/providers/BrowserSettingsProvider', () => ({
+  useBrowsingSettings: (select: (state: typeof settings) => unknown) => select(settings),
+}));
 
 /**
  * The two hooks, tested where the bug can actually live: in how each one MAPS
@@ -110,5 +130,73 @@ describe('browsing level hooks', () => {
 
     expect(page, 'a page override must still scope the page hook').toBe(NsfwLevel.PG);
     expect(viewer, 'the viewer hook must ignore the page override').toBe(allBrowsingLevelsFlag);
+  });
+});
+
+/**
+ * The provider's own cap computation, which the two cases above cannot see.
+ *
+ * These render the REAL `BrowsingLevelProvider` so the domain rules and the cap
+ * merge are exercised rather than supplied. They mirror `applyDomainFeature` in
+ * `src/server/trpc.ts` — anonymous is PG anywhere, a logged-in viewer on a
+ * domain that cannot serve mature content is PG+PG-13 — and that mirror is the
+ * thing nothing checked before.
+ */
+function renderUnderProvider(props: { forcedBrowsingLevel?: number; browsingLevel?: number }) {
+  const result = { page: 0, viewer: 0 };
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  function Probe() {
+    result.page = useBrowsingLevelDebounced();
+    result.viewer = useViewerBrowsingLevelDebounced();
+    return null;
+  }
+
+  act(() => {
+    root.render(createElement(BrowsingLevelProvider, props, createElement(Probe)));
+  });
+  act(() => root.unmount());
+  return result;
+}
+
+describe('BrowsingLevelProvider caps', () => {
+  it('caps a logged-in viewer on a domain that cannot serve mature content', () => {
+    currentUser.value = { id: 1 };
+    canViewNsfw.value = false;
+
+    const { viewer } = renderUnderProvider({});
+
+    expect(viewer, 'a saved preference must not lift the domain cap').toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('caps an anonymous viewer harder than a logged-in one', () => {
+    currentUser.value = null;
+    canViewNsfw.value = false;
+
+    expect(renderUnderProvider({}).viewer).toBe(publicBrowsingLevelsFlag);
+  });
+
+  /**
+   * 🔴 The cap merge. A page passing its own ceiling must not be able to LIFT the
+   * domain cap by being nearer — `??` did exactly that, and a collection ceiling
+   * of PG+PG-13 over an anonymous domain cap of PG is the live shape.
+   */
+  it('intersects a page ceiling with the domain cap rather than replacing it', () => {
+    currentUser.value = null;
+    canViewNsfw.value = false;
+
+    const { viewer } = renderUnderProvider({ forcedBrowsingLevel: sfwBrowsingLevelsFlag });
+
+    expect(viewer, 'a wider page ceiling must not lift the anonymous cap').toBe(
+      publicBrowsingLevelsFlag
+    );
+  });
+
+  it('leaves an uncapped viewer on their own preference', () => {
+    currentUser.value = { id: 1 };
+    canViewNsfw.value = true;
+
+    expect(renderUnderProvider({}).viewer).toBe(allBrowsingLevelsFlag);
   });
 });

--- a/src/components/BrowsingLevel/__tests__/browsing-level-hooks.test.ts
+++ b/src/components/BrowsingLevel/__tests__/browsing-level-hooks.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
-import { act, createElement } from 'react';
+import { act, createElement, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { describe, expect, it, vi } from 'vitest';
 import {
   BrowsingLevelProvider,
   BrowsingModeOverrideCtx,
+  useBrowsingLevelContext,
   useBrowsingLevelDebounced,
   useViewerBrowsingLevelDebounced,
 } from '~/components/BrowsingLevel/BrowsingLevelProvider';
@@ -198,5 +199,139 @@ describe('BrowsingLevelProvider caps', () => {
     canViewNsfw.value = true;
 
     expect(renderUnderProvider({}).viewer).toBe(allBrowsingLevelsFlag);
+  });
+
+  /**
+   * 🔴 A CAP THAT FAILS OPEN. Do not "simplify" the provider by seeding
+   * `useState` from the `forcedBrowsingLevel` prop — that is what this pins.
+   *
+   * `Collection.tsx` keeps the provider mounted across a refetch of the same
+   * collection, so a moderator raising the ceiling only ever reaches viewers
+   * through a re-render with a new prop. Seeded state freezes the cap at first
+   * mount, and every direction of that staleness is toward WIDER: a ceiling set
+   * for the first time never applies at all.
+   *
+   * Read off the context rather than a hook because `useDebouncedValue` holds
+   * the previous value for 500ms after a change; the cap itself is not debounced.
+   */
+  it('applies a ceiling that arrives after mount, and every later change to it', () => {
+    currentUser.value = { id: 1 };
+    canViewNsfw.value = true;
+
+    const seen: (number | undefined)[] = [];
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    function Probe() {
+      seen.push(useBrowsingLevelContext().forcedBrowsingLevel);
+      return null;
+    }
+
+    const render = (forcedBrowsingLevel?: number) =>
+      act(() => {
+        root.render(
+          createElement(BrowsingLevelProvider, { forcedBrowsingLevel }, createElement(Probe))
+        );
+      });
+
+    render(undefined);
+    render(sfwBrowsingLevelsFlag);
+    render(publicBrowsingLevelsFlag);
+    // 🔴 WIDENING, and then clearing. Without these two a cap that only ever
+    // ratchets tighter — `intersect(previous, prop)` held in a ref — passes,
+    // and a moderator RAISING a ceiling still never reaches a mounted viewer,
+    // which is the direction that motivated the whole case.
+    render(sfwBrowsingLevelsFlag);
+    render(undefined);
+    act(() => root.unmount());
+
+    // One equality over the whole sequence rather than per-index reads: `.at(0)`
+    // is satisfied by an empty array, and an extra render pass would shift every
+    // index and report the wrong assertion.
+    expect(seen).toEqual([
+      undefined,
+      sfwBrowsingLevelsFlag,
+      publicBrowsingLevelsFlag,
+      sfwBrowsingLevelsFlag,
+      undefined,
+    ]);
+  });
+
+  /**
+   * 🔴 The OTHER half of the cap, and the one a rename can drop silently.
+   *
+   * `PostDetail.tsx:110-115` pushes a contest collection's ceiling into the
+   * ancestor provider imperatively rather than as a prop. Nothing else in these
+   * files calls the setter, so removing that argument from the intersect list
+   * leaves every other case green while the ceiling stops applying.
+   */
+  it('applies a ceiling set through setForcedBrowsingLevel, intersected with the prop', () => {
+    currentUser.value = { id: 1 };
+    canViewNsfw.value = true;
+
+    const seen: (number | undefined)[] = [];
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    function Probe() {
+      const { forcedBrowsingLevel, setForcedBrowsingLevel } = useBrowsingLevelContext();
+      seen.push(forcedBrowsingLevel);
+      useEffect(() => {
+        setForcedBrowsingLevel?.(publicBrowsingLevelsFlag);
+      }, [setForcedBrowsingLevel]);
+      return null;
+    }
+
+    act(() => {
+      root.render(
+        createElement(
+          BrowsingLevelProvider,
+          { forcedBrowsingLevel: sfwBrowsingLevelsFlag },
+          createElement(Probe)
+        )
+      );
+    });
+    act(() => root.unmount());
+
+    expect(seen.at(0), 'the prop ceiling applies before the setter runs').toBe(
+      sfwBrowsingLevelsFlag
+    );
+    expect(seen.at(-1), 'an imperative ceiling must tighten the prop ceiling').toBe(
+      publicBrowsingLevelsFlag
+    );
+  });
+
+  /**
+   * 🔴 A ceiling from an OUTER provider. `Collection.tsx:650` sets one with
+   * `BrowsingLevelProviderOptional` and the image-detail providers nested below
+   * it, and an inner provider recomputes the domain cap from scratch — so
+   * dropping `ctx.forcedBrowsingLevel` from the merge loses the collection's
+   * ceiling everywhere it is nested, with nothing else red.
+   */
+  it('keeps an outer provider ceiling through a nested provider', () => {
+    currentUser.value = { id: 1 };
+    canViewNsfw.value = true;
+
+    let inner: number | undefined;
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    function Probe() {
+      inner = useBrowsingLevelContext().forcedBrowsingLevel;
+      return null;
+    }
+
+    act(() => {
+      root.render(
+        createElement(
+          BrowsingLevelProvider,
+          { forcedBrowsingLevel: sfwBrowsingLevelsFlag },
+          createElement(BrowsingLevelProvider, {}, createElement(Probe))
+        )
+      );
+    });
+    act(() => root.unmount());
+
+    expect(inner, 'a nested provider must not drop the outer ceiling').toBe(sfwBrowsingLevelsFlag);
   });
 });

--- a/src/components/BrowsingLevel/__tests__/resolve-browsing-level.test.ts
+++ b/src/components/BrowsingLevel/__tests__/resolve-browsing-level.test.ts
@@ -184,18 +184,20 @@ const VIEWER_SCOPED = [
   },
 ];
 
-describe.each(VIEWER_SCOPED)('$file reads the viewer, not the page', ({ file, why }) => {
-  // Throws rather than passing if the file moves. A guard whose subject has
-  // vanished must go red, not quietly become vacuous.
-  const source = readFileSync(path.resolve(__dirname, ...file), 'utf-8');
+// Throws rather than passing if the file moves. A guard whose subject has
+// vanished must go red, not quietly become vacuous — read inside each `it` so
+// that red is one failing guard rather than a collection error that also stops
+// the resolver tests in this file from reporting.
+const read = (...file: string[]) => readFileSync(path.resolve(__dirname, ...file), 'utf-8');
 
+describe.each(VIEWER_SCOPED)('$file reads the viewer, not the page', ({ file, why }) => {
   it('uses the viewer hook', () => {
-    expect(source, why).toContain('useViewerBrowsingLevelDebounced()');
+    expect(read(...file), why).toContain('useViewerBrowsingLevelDebounced()');
   });
 
   it('does NOT inherit a page override', () => {
     expect(
-      source.includes('useBrowsingLevelDebounced()'),
+      read(...file).includes('useBrowsingLevelDebounced()'),
       `${file.join('/')} must not inherit a page browsing-level override: ${why}`
     ).toBe(false);
   });
@@ -207,19 +209,44 @@ describe.each(VIEWER_SCOPED)('$file reads the viewer, not the page', ({ file, wh
  * applying to each component above the moment they adopted the viewer hook.
  */
 describe('a collection ceiling is a cap, not an override', () => {
-  const source = readFileSync(
-    path.resolve(__dirname, '..', '..', 'Collections', 'Collection.tsx'),
-    'utf-8'
-  );
+  const collection = () => read('..', '..', 'Collections', 'Collection.tsx');
 
   it('passes it as forcedBrowsingLevel', () => {
-    expect(source).toContain('forcedBrowsingLevel={collection.metadata.forcedBrowsingLevel');
+    expect(collection()).toContain('forcedBrowsingLevel={collection.metadata.forcedBrowsingLevel');
   });
 
   it('does not pass it through the override slot', () => {
     expect(
-      source.includes('browsingLevel={collection.metadata.forcedBrowsingLevel'),
+      collection().includes('browsingLevel={collection.metadata.forcedBrowsingLevel'),
       'the override slot is one any component may decline to read'
+    ).toBe(false);
+  });
+});
+
+/**
+ * 🔴 A cap that is SET imperatively must also be CLEARED imperatively.
+ *
+ * `PostDetail` pushes a contest collection's ceiling into the ancestor provider
+ * rather than passing it as a prop, and `resolvePageBrowsingLevel` puts `forced`
+ * AHEAD of the viewer's preference rather than intersecting with it. So a
+ * ceiling left behind after the collection goes away does not merely linger, it
+ * REPLACES a narrower viewer preference — an escalated contest cap including R
+ * outliving the post that carried it, for a viewer who never opted in.
+ *
+ * The truthy guard this pins the absence of looks protective and is not. Do not
+ * restore it: with it, the only way the cap ever drops is a full remount.
+ */
+describe('a post ceiling is cleared when the post has none', () => {
+  const postDetail = () => read('..', '..', 'Post', 'Detail', 'PostDetail.tsx');
+
+  it('sets the cap unconditionally', () => {
+    expect(postDetail()).toContain('setForcedBrowsingLevel?.(forcedBrowsingLevel);');
+  });
+
+  it('does not skip the call when there is no ceiling', () => {
+    expect(
+      postDetail().includes('if (forcedBrowsingLevel) {'),
+      'guarding the set means a stale ceiling outlives the collection that set it'
     ).toBe(false);
   });
 });

--- a/src/components/BrowsingLevel/__tests__/resolve-browsing-level.test.ts
+++ b/src/components/BrowsingLevel/__tests__/resolve-browsing-level.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import {
+  intersectBrowsingCaps,
   resolvePageBrowsingLevel,
   resolveViewerBrowsingLevel,
 } from '~/components/BrowsingLevel/resolve-browsing-level';
@@ -31,6 +32,46 @@ describe('resolvePageBrowsingLevel', () => {
 
   it('falls back to the viewer when no page asked for anything', () => {
     expect(resolvePageBrowsingLevel({ user: sfwBrowsingLevelsFlag })).toBe(sfwBrowsingLevelsFlag);
+  });
+});
+
+describe('intersectBrowsingCaps', () => {
+  /**
+   * 🔴 The reason this exists. The provider used to merge caps with `??`, which
+   * takes the first one SET rather than the tighter of the two. A collection
+   * ceiling of PG+PG-13 sitting nearer than an anonymous domain cap of PG would
+   * therefore have erased it — a nearer provider lifting a ceiling further out,
+   * which is the one thing a cap must never permit.
+   *
+   * If this fails, do not adjust the expectation.
+   */
+  it('takes the TIGHTER of two caps, never the nearer one', () => {
+    expect(
+      intersectBrowsingCaps(sfwBrowsingLevelsFlag, publicBrowsingLevelsFlag),
+      'a wider nearer cap must not lift a tighter outer one'
+    ).toBe(publicBrowsingLevelsFlag);
+    // Order must not matter. `??` passes one of these two and fails the other,
+    // which is exactly how the old behaviour looked correct half the time.
+    expect(intersectBrowsingCaps(publicBrowsingLevelsFlag, sfwBrowsingLevelsFlag)).toBe(
+      publicBrowsingLevelsFlag
+    );
+  });
+
+  it('skips absent caps rather than treating them as a ceiling of nothing', () => {
+    expect(intersectBrowsingCaps(undefined, sfwBrowsingLevelsFlag, undefined)).toBe(
+      sfwBrowsingLevelsFlag
+    );
+  });
+
+  /** No cap at all means no ceiling — the caller falls through to the viewer. */
+  it('returns undefined when nothing caps anything', () => {
+    expect(intersectBrowsingCaps(undefined, undefined)).toBeUndefined();
+  });
+
+  it('intersects three, not just the first pair', () => {
+    expect(
+      intersectBrowsingCaps(allBrowsingLevelsFlag, sfwBrowsingLevelsFlag, publicBrowsingLevelsFlag)
+    ).toBe(publicBrowsingLevelsFlag);
   });
 });
 
@@ -106,49 +147,79 @@ describe('resolveViewerBrowsingLevel', () => {
 });
 
 /**
- * The call site, not the function.
+ * The call sites, not the function.
  *
- * Everything above tests a pure resolver that `RemixGalleryCard` merely has to
- * CHOOSE to use. The bug was never in the resolver — it was one hook name at one
- * call site, and unit-testing the resolver would have proved nothing about it.
- * The hooks are React, so a render test lands in the `component` project, which
- * runs in no CI job; this reads the source instead.
+ * Everything above tests pure resolvers that these components merely have to
+ * CHOOSE to use. Every defect in this area so far has been one hook name at one
+ * call site, and no test of a resolver can reach that. The hooks are React, so a
+ * render test lands in the `component` project, which runs in no CI job; this
+ * reads the sources instead.
  *
- * ⚠️ What this does and does not catch, stated because a source guard flatters
- * itself: it catches reverting to `useBrowsingLevelDebounced`, which is the
- * regression that actually happened. It would NOT catch someone reading
- * `useBrowsingLevelContext()` and resolving the level by hand. It pins a
- * spelling, and the spelling it pins is the likely one.
+ * ⚠️ What a source guard is worth, stated because it flatters itself: it catches
+ * a revert to `useBrowsingLevelDebounced`, which is the regression that keeps
+ * happening. It would NOT catch someone reading `useBrowsingLevelContext()` and
+ * resolving by hand. It pins a spelling, and the spelling it pins is the likely
+ * one.
+ *
+ * 🔴 Deliberately NOT comparing path strings. `appModeratorMessageForm.callSites`
+ * does, and it fails on Windows only, because it compares `a/b` against `a\b`.
+ * Paths here are built with `path.resolve` and only ever used to READ.
  */
-describe('the remix gallery reads the viewer, not the page', () => {
-  const cardPath = path.resolve(__dirname, '..', '..', 'RemixGallery', 'RemixGalleryCard.tsx');
-  // Throws rather than passing if the file moves or is renamed. A guard whose
-  // subject has vanished must go red, not quietly become vacuous.
-  const source = readFileSync(cardPath, 'utf-8');
+const VIEWER_SCOPED = [
+  {
+    file: ['..', '..', 'RemixGallery', 'RemixGalleryCard.tsx'],
+    why: 'lists other people’s images beside an image scoped to its own rating',
+  },
+  {
+    file: ['..', '..', 'RemixGallery', 'RemixGalleryBatchProvider.tsx'],
+    why: 'its count must match the gallery that count opens',
+  },
+  {
+    file: ['..', '..', 'UserAvatar', 'UserAvatar.tsx'],
+    why: 'a profile picture belongs to its owner, not to the page it appears on',
+  },
+  {
+    file: ['..', '..', 'UserAvatar', 'UserAvatarSimple.tsx'],
+    why: 'a profile picture belongs to its owner, not to the page it appears on',
+  },
+];
 
-  it('is reading the file it thinks it is', () => {
-    expect(source, 'wrong file — this guard is pointed at nothing').toContain('RemixGalleryCard');
-  });
+describe.each(VIEWER_SCOPED)('$file reads the viewer, not the page', ({ file, why }) => {
+  // Throws rather than passing if the file moves. A guard whose subject has
+  // vanished must go red, not quietly become vacuous.
+  const source = readFileSync(path.resolve(__dirname, ...file), 'utf-8');
 
   it('uses the viewer hook', () => {
-    expect(source).toContain('useViewerBrowsingLevelDebounced()');
+    expect(source, why).toContain('useViewerBrowsingLevelDebounced()');
   });
 
-  /**
-   * 🔴 `ImageDetail2` wraps this card in a provider set to the HOST image's
-   * rating. The ordinary hook inherits that, which scopes a list of other
-   * people's images to the rating of the image they hang beside — entries above
-   * the host cannot intersect it and vanish for every viewer, including the owner
-   * who approved and was paid for them. Measured on prod 2026-08-29: 161 of 488
-   * approved entries invisible that way, 160 of them paid.
-   *
-   * Do not "simplify" this back. The domain cap is still honoured by the viewer
-   * hook; skipping the page override is the entire point.
-   */
-  it('does NOT use the page-scoped hook', () => {
+  it('does NOT inherit a page override', () => {
     expect(
       source.includes('useBrowsingLevelDebounced()'),
-      'RemixGalleryCard must not inherit the detail page browsing-level override'
+      `${file.join('/')} must not inherit a page browsing-level override: ${why}`
+    ).toBe(false);
+  });
+});
+
+/**
+ * The other direction. A collection's ceiling is policy, not preference, so it
+ * must ride the slot every hook honours — as an override it silently stopped
+ * applying to each component above the moment they adopted the viewer hook.
+ */
+describe('a collection ceiling is a cap, not an override', () => {
+  const source = readFileSync(
+    path.resolve(__dirname, '..', '..', 'Collections', 'Collection.tsx'),
+    'utf-8'
+  );
+
+  it('passes it as forcedBrowsingLevel', () => {
+    expect(source).toContain('forcedBrowsingLevel={collection.metadata.forcedBrowsingLevel');
+  });
+
+  it('does not pass it through the override slot', () => {
+    expect(
+      source.includes('browsingLevel={collection.metadata.forcedBrowsingLevel'),
+      'the override slot is one any component may decline to read'
     ).toBe(false);
   });
 });

--- a/src/components/BrowsingLevel/resolve-browsing-level.ts
+++ b/src/components/BrowsingLevel/resolve-browsing-level.ts
@@ -47,5 +47,29 @@ export function resolveViewerBrowsingLevel({
   return forced ?? user;
 }
 
+/**
+ * The tightest of several caps, as one flag set.
+ *
+ * 🔴 Caps INTERSECT; they do not shadow. `a ?? b` takes the first one that is
+ * set, which is only the tighter of the two by luck — a collection ceiling of
+ * PG+PG-13 written over an anonymous domain cap of PG would LIFT it. Bitwise AND
+ * is the actual "both must allow it" test, and the levels are single flags, so
+ * it is the right operator rather than a clever one.
+ *
+ * Absent caps are skipped, so no cap at all returns `undefined` and the caller
+ * falls through to the viewer's preference.
+ *
+ * ⚠️ Two disjoint caps intersect to 0, which means nothing is servable. Both
+ * hooks then hit `BROWSING_LEVEL_FALLBACK` and serve PG, which is a WIDENING
+ * from nothing to PG. Not reachable today — every cap in the app includes PG —
+ * and stated because the fallback was written for "the debounce has not settled
+ * yet", not for this.
+ */
+export function intersectBrowsingCaps(...caps: (number | undefined)[]) {
+  const present = caps.filter((cap): cap is number => cap != null);
+  if (!present.length) return undefined;
+  return present.reduce((a, b) => a & b);
+}
+
 /** What both hooks fall back to once debouncing has settled on nothing. */
 export const BROWSING_LEVEL_FALLBACK = NsfwLevel.PG;

--- a/src/components/BrowsingLevel/resolve-browsing-level.ts
+++ b/src/components/BrowsingLevel/resolve-browsing-level.ts
@@ -1,4 +1,5 @@
 import { NsfwLevel } from '~/server/common/enums';
+import { Flags } from '~/shared/utils/flags';
 
 /**
  * Which browsing level a read should run at, given the three the provider holds.
@@ -68,7 +69,7 @@ export function resolveViewerBrowsingLevel({
 export function intersectBrowsingCaps(...caps: (number | undefined)[]) {
   const present = caps.filter((cap): cap is number => cap != null);
   if (!present.length) return undefined;
-  return present.reduce((a, b) => a & b);
+  return present.reduce((a, b) => Flags.intersection(a, b));
 }
 
 /** What both hooks fall back to once debouncing has settled on nothing. */

--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -639,7 +639,16 @@ export function Collection({
   if (!collection) return null;
 
   return (
-    <BrowsingLevelProvider browsingLevel={collection.metadata.forcedBrowsingLevel ?? undefined}>
+    /* 🔴 `forcedBrowsingLevel`, not `browsingLevel`. This is a policy ceiling —
+       the same value `Gated` below treats as a gate, bypassed only for mods and
+       owners — and the override slot it used to sit in is one any component may
+       decline to read. `useViewerBrowsingLevelDebounced` does exactly that by
+       design, so as an override this cap silently stopped applying to the remix
+       gallery and to avatars. Caps are intersected by the provider, so this
+       cannot lift the domain cap either. */
+    <BrowsingLevelProvider
+      forcedBrowsingLevel={collection.metadata.forcedBrowsingLevel ?? undefined}
+    >
       <BrowsingSettingsAddonsProvider>
         <Gated
           contentNsfwLevel={collection.metadata.forcedBrowsingLevel || collection.nsfwLevel}

--- a/src/components/Post/Detail/PostDetail.tsx
+++ b/src/components/Post/Detail/PostDetail.tsx
@@ -108,10 +108,15 @@ export function PostDetailContent({ postId }: Props) {
   const forcedBrowsingLevel = collection?.metadata?.forcedBrowsingLevel ?? undefined;
 
   const { setForcedBrowsingLevel } = useBrowsingLevelContext();
+  // 🔴 Set unconditionally so the cap is CLEARED when a post has no collection.
+  // Guarding on a truthy value latched the last contest ceiling into the ancestor
+  // provider, and `resolvePageBrowsingLevel` puts `forced` AHEAD of the viewer's
+  // preference rather than intersecting with it — so a PG-only viewer kept an
+  // escalated R ceiling after moving to a post that never had one. Safe to clear
+  // only because the provider no longer keeps its `forcedBrowsingLevel` prop in
+  // the same state slot.
   useEffect(() => {
-    if (forcedBrowsingLevel) {
-      setForcedBrowsingLevel?.(forcedBrowsingLevel);
-    }
+    setForcedBrowsingLevel?.(forcedBrowsingLevel);
   }, [forcedBrowsingLevel]);
 
   const {

--- a/src/components/RemixGallery/RemixGalleryBatchProvider.tsx
+++ b/src/components/RemixGallery/RemixGalleryBatchProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 import type { RemixGalleryCardSummary } from '~/server/services/remix-gallery.service';
 import { chunkStickerIds } from '~/components/Sticker/sticker.util';
-import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { useViewerBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { trpc } from '~/utils/trpc';
 
@@ -44,16 +44,19 @@ export function RemixGalleryBatchProvider({
   // `EdgeMedia` with no ImageGuard, came back at every level the viewer had
   // turned off.
   //
-  // ⚠️ The PAGE level, while `RemixGalleryCard` reads the VIEWER's. They agree
-  // wherever no page sets an override, which is every ordinary feed. Where one
-  // does — the site root, the home blocks, a collection — this count is scoped
-  // to the page and the gallery it opens is scoped to the viewer, so the two can
-  // disagree. Deliberate for now rather than overlooked: this is a count on a
-  // card inside a page-scoped feed, and widening it would show a number for
-  // content the page narrowed on purpose. Raised with Justin 2026-08-30; if he
-  // decides the count should follow the viewer instead, the change is this one
-  // line and the reasoning above is what has to be re-argued.
-  const browsingLevel = useBrowsingLevelDebounced();
+  // 🔴 The VIEWER's level, matching `RemixGalleryCard`. This count and the
+  // gallery it opens are one concept and were reading two different numbers:
+  // wherever a page set an override — the site root, the home blocks, a
+  // collection — the count was page-scoped while the gallery was viewer-scoped,
+  // which is the count-versus-contents mismatch #4497 fixed on the other side.
+  // Justin's call, 2026-08-30.
+  //
+  // ⚠️ The consequence, since it is the argument against: on a page that
+  // deliberately narrows itself, the count and its thumbnails now follow the
+  // viewer rather than the page. Domain and policy caps still apply — they ride
+  // `forcedBrowsingLevel`, which this hook honours — so what widens is a page's
+  // curation choice, never a ceiling.
+  const browsingLevel = useViewerBrowsingLevelDebounced();
 
   // The sticker batch's chunker, not a third copy of it. Its own tests pin the
   // property both providers depend on and neither spells out in code: chunking

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -31,7 +31,7 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { useViewerBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { decorationFrameStyle } from '~/components/UserAvatar/decoration-frame.util';
 import { UserHoverCard } from '~/components/UserAvatar/UserHoverCard';
@@ -106,7 +106,13 @@ export function UserAvatar({
   const colorScheme = useComputedColorScheme('dark');
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
-  const browsingLevel = useBrowsingLevelDebounced();
+  // 🔴 The VIEWER's level, not the page's. A profile picture belongs to the
+  // person in the avatar, not to whatever this page happens to be about — and
+  // `ImageDetail2` sets a page override to the IMAGE's rating, so on a PG image
+  // every commenter's PG-13 avatar was suppressed for viewers who accept PG-13.
+  // Same defect as the remix gallery beside it (#4497); this is the other half.
+  // Domain and policy caps still apply, only the page override is skipped.
+  const browsingLevel = useViewerBrowsingLevelDebounced();
 
   const { data: fallbackUser, isInitialLoading } = trpc.user.getById.useQuery(
     { id: userId as number },

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -36,6 +36,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { decorationFrameStyle } from '~/components/UserAvatar/decoration-frame.util';
 import { UserHoverCard } from '~/components/UserAvatar/UserHoverCard';
 import { isBlobUrl } from '~/utils/type-guards';
+import { Flags } from '~/shared/utils/flags';
 
 const mapAvatarTextSize: Record<MantineSize, { textSize: MantineSize; subTextSize: MantineSize }> =
   {
@@ -154,7 +155,7 @@ export function UserAvatar({
   const blockedProfilePicture =
     avatarUser.profilePicture?.ingestion === 'Blocked' ||
     (!isPendingOwnerPreview &&
-      (!features.canViewNsfw ? !passesSfwGate : nsfwLevel > browsingLevel));
+      (!features.canViewNsfw ? !passesSfwGate : !Flags.hasFlag(browsingLevel, nsfwLevel)));
   const avatarBgColor = colorScheme === 'dark' ? 'rgba(255,255,255,0.31)' : 'rgba(0,0,0,0.31)';
 
   const image = avatarUser.profilePicture;

--- a/src/components/UserAvatar/UserAvatarSimple.tsx
+++ b/src/components/UserAvatar/UserAvatarSimple.tsx
@@ -1,7 +1,7 @@
 import { Text, Tooltip, UnstyledButton } from '@mantine/core';
 import { IconUser } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
-import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { useViewerBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { UserAvatarProfilePicture } from '~/components/UserAvatar/UserAvatarProfilePicture';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -43,7 +43,13 @@ export function UserAvatarSimple({
 }) {
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
-  const browsingLevel = useBrowsingLevelDebounced();
+  // 🔴 The VIEWER's level, not the page's. A profile picture belongs to the
+  // person in the avatar, not to whatever this page happens to be about — and
+  // `ImageDetail2` sets a page override to the IMAGE's rating, so on a PG image
+  // every commenter's PG-13 avatar was suppressed for viewers who accept PG-13.
+  // Same defect as the remix gallery beside it (#4497); this is the other half.
+  // Domain and policy caps still apply, only the page override is skipped.
+  const browsingLevel = useViewerBrowsingLevelDebounced();
   const displayProfilePicture =
     !deletedAt && profilePicture && profilePicture.ingestion !== 'Blocked';
   const router = useRouter();


### PR DESCRIPTION
Items 1–3 from the #4497 review round, plus the one that made #3 unsafe to ship as a one-liner, plus a fix round over my own first draft.

## What changed

| # | Where | Why |
|---|---|---|
| 1 | `UserAvatar`, `UserAvatarSimple` | A profile picture belongs to the person in it. `ImageDetail2` sets the page override to the image's rating, so on a PG image every commenter's PG-13 avatar was suppressed for viewers who accept PG-13 — the same defect #4497 fixed for the gallery beside them. |
| 2 | `RemixGalleryBatchProvider` | After #4497 the flyout count and the gallery it opens read the same procedure at two different levels. They are one concept and now read one number. |
| 3 | `Collections/Collection.tsx` | `collection.metadata.forcedBrowsingLevel` is policy — the same value `Gated` treats as a gate — and it rode the *override* slot, which the viewer hook ignores by design. Now `forcedBrowsingLevel`. |
| 4 | `BrowsingLevelProvider` | 🔴 See below. |

## 🔴 Why #3 could not ship as the one-liner

The provider merged caps with `forcedBrowsingLevel ?? domainForcedLevel ?? ctx.forcedBrowsingLevel` — **first set, not tightest**. A wider, nearer cap could **erase the domain cap**: a collection ceiling of PG+PG-13 over an anonymous cap of PG.

That hazard is **live today, not dormant**. `PostDetail.tsx` pushes `collection.metadata.forcedBrowsingLevel` into the ancestor provider's forced slot through `setForcedBrowsingLevel`, which under `??` sat *ahead* of `domainForcedLevel`. So this PR closes a real cap lift on contest post pages, and #3 would have added a second path to it.

`intersectBrowsingCaps` bitwise-ANDs the present caps, which is the actual "both must allow it" test rather than a clever one — levels are single flags.

Edge written down rather than papered over: two disjoint caps intersect to `0`, and the hooks' fallback turns `0` into PG — a widening from *nothing* to PG. Not reachable today; every cap in the app includes PG.

## 🔴 Fix round — three of these are defects in my own first draft

| # | Where | What |
|---|---|---|
| D1 | `BrowsingLevelProvider.tsx` | **A cap of mine that failed open.** The first draft kept `forcedBrowsingLevel` in `useState(parentForcedBrowsingLevel)` — seeded once, never re-synced, where the `browsingLevel` slot it replaced was forwarded live on every render. `Collection.tsx` only unmounts the provider when `collection` is falsy, which a refetch of the same id is not, so a moderator raising a collection's ceiling left mounted viewers on the older, **wider** one, and a ceiling set for the first time never applied at all. State now holds only what `setForcedBrowsingLevel` put there; the prop is intersected live beside it. |
| D2 | `UserAvatar.tsx` | Gated with `nsfwLevel > browsingLevel`, a numeric threshold, while its sibling `UserAvatarSimple` correctly uses `Flags.hasFlag`. A flag set is not ordered: with a viewer level of PG-13 alone, `1 > 2` is false, so a PG picture showed through a set that excludes PG. Pre-existing, but this diff feeds it the viewer's whole set on far more pages, which is exactly the input it mishandles. |
| D5 | `resolve-browsing-level.ts` | Raw `&` inside the function named "intersect" → `Flags.intersection`. Literally the same operator; no behaviour. |
| D7 | `PostDetail.tsx` | **A cap that could be set but never cleared.** The effect was guarded `if (forcedBrowsingLevel)`, so a contest ceiling stayed in the ancestor provider after the viewer moved to a post that has none. That is not a harmless stale ceiling: `resolvePageBrowsingLevel` puts `forced` **ahead of** the viewer's preference rather than intersecting with it, so an escalated contest cap including R **replaces** a PG-only viewer's own level. Now set unconditionally, which is safe to do only because D1 took the prop out of that state slot. |

⚠️ D2 is a visible change for one viewer class, said out loud rather than buried: levels are individually togglable, so a viewer can deselect PG while keeping higher levels. A PG profile picture was previously shown to them and is now blocked. That matches how every feed filters — flag intersection, not a threshold — so it is the intended semantic, but it is a change.

## The consequence of #2, since it is the argument against

On a page that deliberately narrows itself, the flyout count and its thumbnails now follow the viewer rather than the page. Domain and policy caps still apply — they ride `forcedBrowsingLevel`, which the viewer hook honours — so what widens is a page's *curation choice*, never a ceiling.

⚠️ **A correction to an earlier claim in this body.** I wrote that `home/index.tsx:65` and `tools/[slug].tsx:68` are "curation, not ceilings" and left them alone. `tools/[slug].tsx:68`, `home/index.tsx:130,262` and `pages/index.tsx:24` pass `publicBrowsingLevelsFlag`, the tightest set, so they can only narrow — those really are safe. `home/index.tsx:65` passes `sfwBrowsingLevelsFlag` in the **override** slot, and `resolvePageBrowsingLevel` is `forced ?? override ?? user`: a viewer with `showNsfw: false` has `userBrowsingLevel = publicBrowsingLevelsFlag`, so that override **widens** them from PG to PG+PG-13 in the home-block subtree. Pre-existing and untouched here; whether a downstream feed re-narrows before the query has not been traced. Flagged rather than changed, because narrowing the site root is a product call.

## Named, not fixed here

- **`forced` and `override` REPLACE the viewer's preference; they do not intersect with it.** So any page or policy level wider than a viewer's own lifts that viewer for the whole subtree. That is the mechanism behind D7 and behind the `home/index.tsx:65` correction above, and it is the shape of this subsystem on `main` rather than anything this PR introduces. Changing it would move every call site at once and wants its own PR.
- `ImageRemixesDetails` has the same page-vs-viewer defect as #1 and #2 and ships **inert** — commented out in `ImageDetail2`'s sidebar, so nothing renders it and the call-site ledger does not reach it. Whoever re-enables it should switch it to `useViewerBrowsingLevelDebounced` at the same time.

## Testing

`Tests 33 passed (33)` across the two browsing-level files. Every change has a mutation that fails it, each one run against a backup and restored with `diff -q`:

| mutation | result |
|---|---|
| caps shadow instead of intersect (`present[0]`) | 3 failed — *a wider page ceiling must not lift the anonymous cap: expected 3 to be 1* |
| avatar back on the page hook | 2 failed — *a profile picture belongs to its owner, not to the page it appears on* |
| flyout back on the page hook | 2 failed — *its count must match the gallery that count opens* |
| collection back to the override slot | 2 failed — *expected … to contain 'forcedBrowsingLevel={collection.metadata…'* |
| **D1: seed forced state from the prop again** | 1 failed — *a ceiling set after mount must apply: expected undefined to be 3* |
| **D1: a cap that only ever ratchets tighter** | 1 failed — *expected [ undefined, 3, 1, 1, 1 ] to deeply equal [ undefined, 3, 1, 3, undefined ]* |
| **drop the imperative cap from the merge** | 1 failed — *an imperative ceiling must tighten the prop ceiling: expected 3 to be 1* |
| **drop the outer provider's cap from the merge** | 1 failed — *a nested provider must not drop the outer ceiling: expected undefined to be 3* |
| **D7: restore the truthy guard** | 1 failed — *guarding the set means a stale ceiling outlives the collection that set it* |

The last four exist because a test review attacked the first three and found them insufficient — in particular the D1 control originally only ever **narrowed** the ceiling (`undefined → PG+PG13 → PG`), so an implementation that ratchets tighter and never widens passed it while still failing the exact scenario the test was written for: a moderator **raising** a ceiling. It now asserts the whole sequence, including a widening step and a clear.

Four of the cases are a **call-site ledger**, added because every defect in this area so far has been one hook name at one call site and no resolver test can reach that. Its limits are written beside it: it catches a revert to `useBrowsingLevelDebounced`, not a hand-rolled `useBrowsingLevelContext()` resolution. Its file reads now happen inside each `it` rather than in the `describe` body, so a moved file reddens one guard instead of taking the twelve resolver tests down as a collection error.

⚠️ Three things NOT pinned, said so they are not read as covered:
- The D2 gate has no test. `UserAvatar` is a heavy component to render for a one-line predicate, and its sibling already carries the correct shape.
- The provider's `showNsfw ? browsingLevel : publicBrowsingLevelsFlag` clamp is never exercised — the shared fixture sets `showNsfw: true` for every case.
- The three `vi.mock` factories hand-list their exports rather than spreading `importOriginal`, and none of the three modules is in the `no-wholesale-module-mock` allowlist. The graph under them is small today; if it grows, the failure mode is zero tests collected with nothing red.

⚠️ Also not a valid control, said so it is not counted: I tried replacing the intersect call with an undefined `firstOf(`, which fails at runtime rather than on the property. The `present[0]` mutation above is the real one.

`typecheck: OK — 0 type errors`. eslint over the touched directories: `0 errors`. Full suite `Test Files 3 failed | 1521 passed | 1 skipped (1525)`, `Tests 9 failed | 24027 passed | 28 skipped (24064)`, exit 1 — the same three files as the run before this diff, at exactly +4 tests, which are the four cases added here. None of the three is touched by this PR: two fail on Windows path separators (every message is literally `components\Apps\…` against an expected `components/Apps/…`), and `trace-flush` spawns a nested vitest child that produces no output under this runner. `blocks.router.workflow.test.ts` alone collects `370 passed (370)`, so the submodule is initialised and the run means something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
