### PR TITLE
fix(app-blocks): iframe-aware chrome menus, and stop clipping the mod review preview

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -558,3 +558,93 @@ describe('AppBlockChrome platform-nav closes on window blur (iframe-aware)', () 
     await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).toBeInTheDocument();
   });
 });
+
+// The ⋮ OVERFLOW menu, same iframe-aware close — and this is the arm that was
+// MISSING. The platform-nav suite above has covered the blur close since the bug
+// was first reported; the ⋮ menu sitting inches away in the same component was a
+// bare uncontrolled `<Menu>` with no `opened`/`onChange` and no blur handling, so
+// clicking into the app left it open on top of the app. Both menus now share
+// `useIframeAwareMenu`, and this suite is what holds the ⋮ half down.
+//
+// 🔴 RED AT BASE: with the uncontrolled `<Menu>`, "Manage apps" is STILL in the
+// document after `window.dispatchEvent(new Event('blur'))`, so the
+// `not.toBeInTheDocument()` assertion below fails. The `data-testid` assertion
+// fails at base too — the trigger carried no testid.
+describe('AppBlockChrome ⋮ overflow menu closes on window blur (iframe-aware)', () => {
+  beforeEach(() => {
+    clearRecentlyOpenedApps();
+  });
+
+  // Distinct from the platform-nav trigger ("Apps menu"): this is the ⋮ one.
+  //
+  // 🔴 DELIBERATELY BY ACCESSIBLE NAME, NOT BY THE NEW TESTID. The testid does
+  // not exist at `origin/main`, so keying the open step on it would make the blur
+  // tests below fail at base with `Cannot find element` — red, but for the wrong
+  // reason, and they would say nothing about the close behaviour. Opening by a
+  // locator that resolves on BOTH trees is what makes the failing assertion at
+  // base the `not.toBeInTheDocument()` one. The testid gets its own test.
+  async function openOverflow() {
+    await page.getByRole('button', { name: 'App menu' }).click();
+    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+  }
+
+  test('the ⋮ trigger is addressable by testid, not only by accessible name', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-dots-testid" appName="Any App" slotId="app.page" />
+    );
+    // 🔴 AWAIT BEFORE READING. `render` returns before React has committed, so a
+    // synchronous `.element()` throws `Cannot find element` against an empty
+    // container — which is the SAME error a genuinely missing testid produces.
+    // Written that way first, this test was red at base for a reason unrelated to
+    // what it claims. Awaiting the retrying matcher makes the two distinguishable.
+    await expect.element(page.getByTestId('app-block-menu-trigger')).toBeInTheDocument();
+    // Same element the accessible-name query finds — the testid must be ON the
+    // trigger, not on some wrapper that merely contains it.
+    expect(page.getByTestId('app-block-menu-trigger').element()).toBe(
+      page.getByRole('button', { name: 'App menu' }).element()
+    );
+  });
+
+  test('opening works, and a window blur (click into the app iframe) closes the ⋮ menu', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-dots-blur" appName="Any App" slotId="app.page" />
+    );
+
+    await openOverflow();
+
+    // Simulate the click landing INSIDE the cross-origin iframe: the parent
+    // window loses focus → `blur`. The controlled menu must close.
+    window.dispatchEvent(new Event('blur'));
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Manage apps' }))
+      .not.toBeInTheDocument();
+
+    // The trigger still opens the menu again after the blur-close (the toggle is
+    // intact — a `useState` that got stuck `true` would fail here, and so would a
+    // fix that closed the menu by unmounting its target).
+    await openOverflow();
+  });
+
+  test('the two menus are independent — blurring closes both, and neither wedges the other', async () => {
+    // Both menus now read the same hook, but each must own its OWN state: a
+    // single shared `opened` flag would make one trigger close the other, and a
+    // module-level flag would leak between mounts. Open the ⋮ menu, close it by
+    // blur, then confirm the platform-nav menu still opens normally.
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-dots-both" appName="Any App" slotId="app.page" />
+    );
+
+    await openOverflow();
+    window.dispatchEvent(new Event('blur'));
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Manage apps' }))
+      .not.toBeInTheDocument();
+
+    await page.getByRole('button', { name: 'Apps menu' }).click();
+    await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).toBeInTheDocument();
+    // …and that one still closes on blur too (the pre-existing behaviour is not
+    // regressed by moving it onto the shared hook).
+    window.dispatchEvent(new Event('blur'));
+    await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -37,6 +37,7 @@ import {
   projectBlockInitViewer,
 } from './projectBlockInit';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { useIframeAwareMenu } from './useIframeAwareMenu';
 import { blockInitFragmentEnabled } from './blockInitFragmentGate';
 import { useBlockIframeSrc } from './useBlockIframeSrc';
 import { usePostMessage } from './usePostMessage';
@@ -223,28 +224,10 @@ export function AppBlockChrome({
   // appBlockId was threaded through).
   const [permsOpen, setPermsOpen] = useState(false);
 
-  // The platform-nav ("Civitai Apps") Menu is CONTROLLED so we can close it when
-  // the user clicks INTO the cross-origin app iframe. Mantine's default
-  // outside-click close CAN'T detect that: the iframe swallows the mousedown, so
-  // the parent document never sees it and Mantine can't tell the click was
-  // "outside" the dropdown — the menu appears stuck open (the reported bug).
-  // The fix is iframe-aware: while the menu is open, listen for the window
-  // `blur` event, which DOES fire when focus/pointer moves into a cross-origin
-  // iframe, and close on it. Normal same-document outside-clicks + item-clicks
-  // still close via Mantine's untouched defaults (closeOnClickOutside /
-  // closeOnItemClick).
-  const [menuOpened, setMenuOpened] = useState(false);
-  useEffect(() => {
-    if (!menuOpened) return;
-    const onBlur = () => setMenuOpened(false);
-    window.addEventListener('blur', onBlur);
-    return () => window.removeEventListener('blur', onBlur);
-  }, [menuOpened]);
-
   // Recently-run apps (client-only personalisation from localStorage). Seeded
   // empty so SSR + the first client render match (no hydration mismatch); the
   // real list loads in an effect after mount AND is refreshed every time the
-  // menu opens (see handleMenuChange) so a within-session client-nav
+  // menu opens (see `platformNavMenu` below) so a within-session client-nav
   // (app A → app B) shows the CURRENT list, not the list as of first mount.
   // Excludes the app currently being viewed (matched by appBlockId — the store's
   // stable id) and is capped to a short list for the compact dropdown.
@@ -268,17 +251,33 @@ export function AppBlockChrome({
     limit: RECENTLY_RUN_LIMIT,
   });
 
-  // Controlled-Menu change handler: mirror the open state AND re-read the recents
-  // store on the transition to open, so the "Recently run" list is fresh within
-  // an SPA session. Still SSR-safe — the read only happens on a user-driven open
-  // (never during render) and getRecentlyOpenedApps() self-guards `isClient`.
-  const handleMenuChange = useCallback(
-    (opened: boolean) => {
-      setMenuOpened(opened);
-      if (opened) setRecents(getRecentlyOpenedApps(recentsOwnerId));
-    },
-    [recentsOwnerId]
+  // 🔴 EVERY `<Menu>` IN THIS CHROME GOES THROUGH `useIframeAwareMenu`. That is a
+  // rule about the SURFACE, not about one menu: the chrome sits directly on top
+  // of a cross-origin app iframe, which swallows the `mousedown` of a click into
+  // the app, so Mantine's `closeOnClickOutside` never fires and a dropdown is
+  // left floating over the app the user just clicked into. The hook supplies
+  // controlled open state plus the one signal that DOES fire (window `blur`) and
+  // leaves every other close path (item click, Escape, same-document outside
+  // click) on Mantine's untouched defaults.
+  //
+  // It is SHARED, not copied. The behaviour was originally inline here for the
+  // platform-nav menu, and the ⋮ overflow menu — same component, same iframe —
+  // silently shipped without it and was stuck open for exactly that reason. A
+  // predicate open-coded at one site is how the second site is born wrong; the
+  // ledger in `__tests__/iframeAwareMenu.test.ts` now fails if a `<Menu>` appears
+  // in this chrome that is not on the hook.
+  //
+  // The platform-nav menu's own extra: on the transition to OPEN it re-reads the
+  // recents store, so the "Recently run" list is fresh within an SPA session.
+  // Still SSR-safe — the read only happens on a user-driven open (never during
+  // render) and `getRecentlyOpenedApps()` self-guards `isClient`.
+  const platformNavMenu = useIframeAwareMenu(() =>
+    setRecents(getRecentlyOpenedApps(recentsOwnerId))
   );
+  // The ⋮ overflow menu. No open-time side effect — its items are static — but
+  // it needs the identical iframe-aware close, which is the whole point of the
+  // shared hook.
+  const overflowMenu = useIframeAwareMenu();
   // The full-page run surface (`app.page`) has no model-page slot to hide the
   // block from — the page IS the block — so suppress the "Hide" item there.
   const isPage = slotId != null && isPageSlot(slotId);
@@ -337,8 +336,8 @@ export function AppBlockChrome({
           position="bottom-start"
           shadow="md"
           width={200}
-          opened={menuOpened}
-          onChange={handleMenuChange}
+          opened={platformNavMenu.opened}
+          onChange={platformNavMenu.onChange}
         >
           <Menu.Target>
             <ActionIcon
@@ -491,9 +490,30 @@ export function AppBlockChrome({
           </Group>
         )}
       </Group>
-      <Menu position="bottom-end" shadow="md" width={180}>
+      {/* The ⋮ overflow menu. CONTROLLED via the same `useIframeAwareMenu` the
+          platform-nav menu uses — see the hook call above for why this is shared
+          rather than a second copy of the effect. Without it a click into the app
+          leaves this dropdown open on top of the app. */}
+      <Menu
+        position="bottom-end"
+        shadow="md"
+        width={180}
+        opened={overflowMenu.opened}
+        onChange={overflowMenu.onChange}
+      >
         <Menu.Target>
-          <ActionIcon variant="subtle" color="gray" size="sm" aria-label="App menu">
+          {/* `data-testid` alongside the accessible name: the sibling controls in
+              this chrome (`app-platform-nav-trigger`, `app-block-name`,
+              `app-block-breadcrumb*`) are all addressable that way, and a test
+              reaching this trigger by accessible name alone breaks on a copy
+              change that is not a behaviour change. */}
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="sm"
+            aria-label="App menu"
+            data-testid="app-block-menu-trigger"
+          >
             <IconDots size={16} stroke={1.5} />
           </ActionIcon>
         </Menu.Target>

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -427,11 +427,20 @@ export interface PageBlockHostProps {
    *     it scroll.
    *     Correct ONLY for a mounter sitting inside a SCROLLING ancestor that does
    *     not otherwise bound its height: the dev tunnel (`/apps/dev/<blockId>`,
-   *     default `AppLayout` → `ScrollArea`) and the mod-review preview (inside a
-   *     modal). Without it those hosts would be sized only by
-   *     `FILL_MIN_HEIGHT_PX` — measured 300px of host, 31px of chrome, 269px of
-   *     iframe, regardless of how much room the page actually has. Usable, but
-   *     no longer FILLING anything.
+   *     default `AppLayout` → `ScrollArea`). Without it that host would be sized
+   *     only by `FILL_MIN_HEIGHT_PX` — measured 300px of host, 31px of chrome,
+   *     269px of iframe, regardless of how much room the page actually has.
+   *     Usable, but no longer FILLING anything.
+   *
+   *     ⚠️ This used to name the mod-review preview here too, and that was the
+   *     WRONG diagnosis of that surface: it is not in an unbounded scrolling
+   *     ancestor, it is in a box that bounds its height and CLIPS
+   *     (`height: 420; overflow: hidden` in the review modal;
+   *     `100dvh − header` on the full-page preview). Claiming
+   *     `100dvh − HEADER_HEIGHT_PX` inside a 420px panel put roughly 600px of app
+   *     out of reach on a 1080px screen, with nothing to scroll to it — and it
+   *     got worse the taller the viewport, because the claim grows while the
+   *     panel does not. `ReviewBlockPreviewHost` is on `'fill'` as of that fix.
    *
    *   'fill' — the host fills its parent (`flex: 1`, floored at
    *     `FILL_MIN_HEIGHT_PX`) and

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -425,10 +425,16 @@ describe('PageBlockHost — `fit` decides whether the page grows a SECOND scroll
     });
   });
 
-  test('the DEFAULT is `viewport`, so the three non-page mounters are unchanged', async () => {
-    // The dev tunnel and the mod-review preview both sit inside a SCROLLING
-    // ancestor that does not bound their height; on `fill` they would collapse.
-    // Pinning the default here is what lets this change be page-only.
+  test('the DEFAULT is `viewport`, so a mounter that has not opted in is unchanged', async () => {
+    // The dev tunnel sits inside a SCROLLING ancestor that does not bound its
+    // height; on `fill` it would collapse to the floor. Pinning the default here
+    // is what keeps every `fill` opt-in a deliberate one.
+    //
+    // ⚠️ This comment used to name the mod-review preview alongside the dev
+    // tunnel, and that was the wrong reading of that surface: it is not in an
+    // unbounded scrolling ancestor, it is in a box that bounds its height and
+    // then clips (a 420px modal panel / a `100dvh − header` page box). It is on
+    // `fill` as of the fix for that; see `ReviewPreviewFit.browser.test.tsx`.
     const { containerHeight } = layoutChainHeights();
     renderWithProviders(
       <div style={{ height: `${containerHeight}px`, overflowY: 'auto' }}>

--- a/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
@@ -1,0 +1,165 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * EVERY `<Menu>` in the app-block host chrome must be iframe-aware. Node `unit`
+ * project — the GATING tier. The behavioural proof lives in
+ * `AppBlockChrome.browser.test.tsx`, which runs in CI as the REPORT-ONLY
+ * `preview / component-tests` status; this is the copy that can block a merge.
+ *
+ * WHAT BROKE. `AppBlockChrome` renders two Mantine menus a hundred lines apart.
+ * The platform-nav one was made CONTROLLED with a window-`blur` close, because
+ * the cross-origin app iframe below swallows the `mousedown` of a click into the
+ * app and Mantine's `closeOnClickOutside` therefore never fires. The ⋮ overflow
+ * menu — same component, same iframe, same hazard — was left a bare uncontrolled
+ * `<Menu>` and stayed open on top of the app the user had just clicked into.
+ *
+ * Nothing about the second menu looked wrong; the rule simply lived at one site
+ * and the other site was written without it. So the cure is a shared hook
+ * (`useIframeAwareMenu`) plus this LEDGER, which fails when the set of menus in
+ * the chrome GROWS (a new control added without the hook) or SHRINKS (a menu
+ * removed, or the hook quietly reverted to inline state) — not a presence check
+ * that a third uncontrolled menu would sail past.
+ *
+ * 🔴 THIS IS A SOURCE SCAN, AND IT PINS A RELATIONSHIP, NOT A WORD. It asserts
+ * that the count of `<Menu …>` opening tags inside `AppBlockChrome` equals the
+ * count of hook calls AND that every one of those tags carries both `opened=` and
+ * `onChange=`. A menu that spells `opened` from some other state still fails the
+ * count, and a hook call with no menu fails it in the other direction.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/IframeHost.tsx');
+const HOOK = path.join(REPO_ROOT, 'src/components/AppBlocks/useIframeAwareMenu.ts');
+
+function read(file: string): string {
+  // Prove the path before trusting any "no match" below: a scan of an absent
+  // file reports zero of everything, which would read as a clean pass.
+  expect(fs.existsSync(file), `${path.relative(REPO_ROOT, file)} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/** Strip block + line comments — every token searched for below is also
+ *  discussed at length in the comments around it, so a rule must never be
+ *  satisfiable by prose ABOUT the rule. */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * The `AppBlockChrome` function body, bounded by the NEXT top-level
+ * `export function` in the file. `IframeHost.tsx` also exports `IframeHost`,
+ * which renders no chrome menus of its own — scoping keeps this guard about the
+ * chrome rather than about the whole 5k-line module.
+ */
+function chromeSource(): string {
+  const src = code(read(HOST));
+  const start = src.indexOf('export function AppBlockChrome');
+  expect(
+    start,
+    'the `AppBlockChrome` declaration was not found in IframeHost.tsx — if it moved or was ' +
+      'renamed, re-point this guard rather than deleting it: it is the only BLOCKING check that ' +
+      'every chrome menu is iframe-aware.'
+  ).toBeGreaterThan(-1);
+  const rest = src.slice(start + 'export function AppBlockChrome'.length);
+  const nextExport = rest.indexOf('\nexport function ');
+  return nextExport === -1 ? rest : rest.slice(0, nextExport);
+}
+
+/** Opening `<Menu …>` tags only — `<Menu.Item>` / `<Menu.Dropdown>` / `<Menu.Label>`
+ *  are sub-components, not menus, and closing tags are not openings. */
+function menuOpeningTags(src: string): string[] {
+  return [...src.matchAll(/<Menu(?![.\w])[\s\S]*?>/g)].map((m) => m[0]);
+}
+
+describe('every Menu in the app-block chrome is iframe-aware', () => {
+  it('the scanner can actually see a menu — positive control on the regex itself', () => {
+    // A ledger built on a regex that matches nothing reports a confident, empty,
+    // fully-green set. Feed the matcher a shape it MUST find before believing any
+    // count it returns from the real file.
+    const fixture = `
+      <Menu position="bottom-end" opened={x.opened} onChange={x.onChange}>
+        <Menu.Target><button /></Menu.Target>
+        <Menu.Dropdown><Menu.Item>a</Menu.Item></Menu.Dropdown>
+      </Menu>
+    `;
+    const found = menuOpeningTags(fixture);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain('position="bottom-end"');
+    // …and that it does NOT count the sub-components, which is the whole reason
+    // for the `(?![.\w])` guard.
+    expect(menuOpeningTags('<Menu.Item>x</Menu.Item><Menu.Dropdown />')).toHaveLength(0);
+  });
+
+  it('the shared hook exists and is the only place the blur listener lives', () => {
+    const hook = code(read(HOOK));
+    expect(hook).toMatch(/export function useIframeAwareMenu/);
+    expect(hook).toMatch(/addEventListener\(\s*'blur'/);
+
+    // 🔴 ONE listener, one place. The original defect was this effect existing at
+    // one site and not the other; a second inline copy in the chrome would be the
+    // same defect re-forming, so the chrome must not grow its own.
+    const chrome = chromeSource();
+    expect(
+      chrome.match(/addEventListener\(\s*'blur'/g) ?? [],
+      'a window `blur` listener has reappeared INSIDE AppBlockChrome. That is the copy this ' +
+        'consolidation removed — route the new control through `useIframeAwareMenu` instead.'
+    ).toHaveLength(0);
+  });
+
+  it('the chrome renders exactly TWO menus, and both are on the hook', () => {
+    const chrome = chromeSource();
+    const tags = menuOpeningTags(chrome);
+
+    // The LEDGER. Failing on GROWTH is the point: a third menu added to this
+    // chrome must be a deliberate edit here, which is the moment somebody reads
+    // the paragraph above and wires the hook. Failing on SHRINK catches a menu
+    // being removed or replaced with something this guard can no longer see.
+    expect(
+      tags.length,
+      'expected exactly TWO `<Menu>`s in AppBlockChrome — the platform-nav menu behind the app ' +
+        'icon and the ⋮ overflow menu. A THIRD means a new control was added: put it on ' +
+        '`useIframeAwareMenu` and update this count in the same commit, or it will be stuck open ' +
+        'the first time a user clicks into the app. FEWER means one was removed or restructured ' +
+        'past this scanner — re-point the guard deliberately.'
+    ).toBe(2);
+
+    // Every one of them is CONTROLLED. A count alone would pass two menus that
+    // both dropped their `opened`/`onChange`.
+    for (const tag of tags) {
+      const oneLine = tag.replace(/\s+/g, ' ');
+      expect(oneLine, `an uncontrolled <Menu> in AppBlockChrome: ${oneLine}`).toMatch(/opened=\{/);
+      expect(oneLine, `a <Menu> with no onChange in AppBlockChrome: ${oneLine}`).toMatch(
+        /onChange=\{/
+      );
+    }
+
+    // …and the control state comes from the SHARED hook, once per menu. Two menus
+    // and one hook call would mean they share a single `opened` flag (opening one
+    // would close the other); two menus and three calls means a dead one.
+    const hookCalls = chrome.match(/useIframeAwareMenu\(/g) ?? [];
+    expect(
+      hookCalls,
+      'the number of `useIframeAwareMenu()` calls must equal the number of `<Menu>`s in the ' +
+        'chrome — each menu owns its own open state.'
+    ).toHaveLength(tags.length);
+  });
+
+  it('the ⋮ overflow trigger is addressable by a stable testid, like its siblings', () => {
+    const chrome = chromeSource();
+    // Reachable only by accessible name, the ⋮ trigger broke every test that
+    // touched it whenever the copy changed. Its siblings all carry a testid.
+    expect(chrome).toContain('data-testid="app-block-menu-trigger"');
+    // Named alongside the sibling ledger so a rename of the family is visible
+    // here rather than only in a browser suite that does not gate a merge.
+    for (const id of [
+      'app-block-chrome',
+      'app-platform-nav-trigger',
+      'app-block-name',
+      'app-block-menu-trigger',
+    ]) {
+      expect(chrome, `chrome testid \`${id}\` is missing`).toContain(`data-testid="${id}"`);
+    }
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -214,14 +214,16 @@ describe('the run page and its host agree on who owns the height', () => {
     );
   });
 
-  it('the host still DEFAULTS to `viewport`, so the other three mounters are untouched', () => {
+  it('the host still DEFAULTS to `viewport`, so a mounter that has not opted in is untouched', () => {
     const src = code(read(HOST));
-    // The dev tunnel and the mod-review preview mount inside scrolling ancestors
-    // that bound nothing; flipping this default would collapse both.
+    // The dev tunnel mounts inside `AppLayout`'s ScrollArea, which bounds
+    // nothing; on `fill` its host would collapse to the `FILL_MIN_HEIGHT_PX`
+    // floor — a fixed slab whatever the viewport. Flipping this default would do
+    // that to every surface that has not made the choice deliberately.
     expect(src).toMatch(/\bfit\s*=\s*['"]viewport['"]/);
   });
 
-  it('only the run page opts into `fill` — a new mounter must opt in deliberately', () => {
+  it('the `fill` opt-in ledger — a new mounter must opt in deliberately', () => {
     // A directory walk, not a hand-kept list: the point is to notice a mounter
     // nobody told this test about.
     //
@@ -253,7 +255,26 @@ describe('the run page and its host agree on who owns the height', () => {
     };
     walk(path.join(REPO_ROOT, 'src'));
 
-    expect(offenders.sort()).toEqual(['src/pages/apps/run/[slug]/[[...path]].tsx']);
+    // 🔴 THIS IS A LEDGER, AND BOTH DIRECTIONS ARE THE POINT. It fails when the
+    // set GROWS (a mounter took `fill` without anyone reading the co-requisite)
+    // and when it SHRINKS (an opt-in was reverted during an unrelated change).
+    // Adding a row here is the intended maintenance path — deleting the
+    // assertion is not.
+    //
+    // `ReviewBlockPreviewHost` (the mod review preview, on both its mounters —
+    // the review modal's fixed 420px panel and the full-page preview's
+    // `100dvh − header` box) joined on the second entry. Its case is NOT the run
+    // page's: it never sat in an unbounded scrolling layout, it sat in a box that
+    // bounded its height and CLIPPED, while the host went on claiming
+    // `100dvh − header` for itself. So the co-requisite it needs is the mounter's
+    // wrapper being a bounded FLEX COLUMN (both are), not `scrollable: false` —
+    // that is a page-layout declaration and one of its two mounters is a modal,
+    // which has no page layout at all. The equivalence asserted above is
+    // therefore scoped to the run page on purpose.
+    expect(offenders.sort()).toEqual([
+      'src/components/Apps/ReviewBlockPreviewHost.tsx',
+      'src/pages/apps/run/[slug]/[[...path]].tsx',
+    ]);
   });
 
   it('the layout premise this all rests on still holds', () => {

--- a/src/components/AppBlocks/useIframeAwareMenu.ts
+++ b/src/components/AppBlocks/useIframeAwareMenu.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Controlled-open state for a Mantine `<Menu>` rendered in the app-block host
+ * chrome, which closes itself when focus leaves the parent document.
+ *
+ * 🔴 WHY THIS EXISTS AT ALL — Mantine's outside-click close is BLIND to the app.
+ * The chrome sits directly above a CROSS-ORIGIN iframe that fills the rest of the
+ * surface. A click landing inside that iframe is dispatched in the FRAME's
+ * document, so the parent document never sees the `mousedown` and Mantine's
+ * `closeOnClickOutside` can't tell the click was "outside" the dropdown. The menu
+ * stays open, floating over the app the user just clicked into. Clicking into the
+ * app IS the single most likely next action on this surface, so this is the
+ * common path, not an edge case.
+ *
+ * The signal that DOES fire is the window `blur` event — focus moving into a
+ * cross-origin frame blurs the parent window. So while the menu is open we listen
+ * for `blur` and close on it. Everything else keeps Mantine's untouched defaults:
+ * same-document outside-clicks still close via `closeOnClickOutside`, item clicks
+ * via `closeOnItemClick`, Escape via `closeOnEscape`. The listener is only
+ * attached while the menu is open, so a closed menu costs nothing.
+ *
+ * 🔴 WHY IT IS A HOOK RATHER THAN A SECOND COPY OF THE EFFECT. The chrome renders
+ * TWO menus — the platform-nav ("Civitai Apps") menu behind the app icon, and the
+ * ⋮ overflow menu. The behaviour above was originally written inline for the
+ * platform-nav menu only, and the ⋮ menu — added in the same component, reading
+ * the same iframe — silently did not get it: it was a bare uncontrolled `<Menu>`,
+ * so clicking into the app left it stuck open. One rule open-coded at one site is
+ * how the second site is born wrong. A new control added to this chrome now has a
+ * single obvious thing to call, and the ledger test in
+ * `__tests__/iframeAwareMenu.test.ts` fails if a `<Menu>` appears in the chrome
+ * without it.
+ *
+ * @param onOpen optional side effect to run on the transition to OPEN (the
+ *   platform-nav menu re-reads its localStorage recents list here so an in-SPA
+ *   navigation shows the current list rather than the list as of first mount).
+ *   Read through a ref, so the returned `onChange` is referentially stable and
+ *   the caller does not have to memoize the callback.
+ */
+export function useIframeAwareMenu(onOpen?: () => void): {
+  opened: boolean;
+  onChange: (opened: boolean) => void;
+} {
+  const [opened, setOpened] = useState(false);
+
+  // Keep the latest callback without making `onChange` depend on it. A caller
+  // passing an inline arrow would otherwise get a new `onChange` every render.
+  const onOpenRef = useRef(onOpen);
+  useEffect(() => {
+    onOpenRef.current = onOpen;
+  });
+
+  useEffect(() => {
+    // Only while open: a closed menu has nothing to close, and this keeps N
+    // menus from each holding a window listener for the whole page lifetime.
+    if (!opened) return;
+    const onBlur = () => setOpened(false);
+    window.addEventListener('blur', onBlur);
+    return () => window.removeEventListener('blur', onBlur);
+  }, [opened]);
+
+  const onChange = useCallback((next: boolean) => {
+    setOpened(next);
+    if (next) onOpenRef.current?.();
+  }, []);
+
+  return { opened, onChange };
+}

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -607,13 +607,34 @@ function ReviewPreviewPanel({
         // runs reviewMode (read-only NACKs). The `?mr=` entry-token URL keeps its
         // pickReviewIframeSrc stabilization here; PageBlockHost's own iframe sets
         // referrerPolicy="no-referrer" so the entry token never leaks via Referer.
+        // 🔴 THE FLEX COLUMN IS LOAD-BEARING, not styling. This panel is the only
+        // thing that bounds the preview's height, and `ReviewBlockPreviewHost`
+        // now passes `fit="fill"` to `PageBlockHost` — which resolves against
+        // this box. As a plain block container it bounded the height for
+        // `overflow: hidden` (i.e. it CLIPPED) without giving the host anything
+        // to fill, so the host sat at its `FILL_MIN_HEIGHT_PX` floor and left the
+        // rest of the panel empty. Drop `display: flex` and that is what comes
+        // back — a short preview in a tall box, which reads as a styling nit
+        // rather than a regression.
         <div
           style={{
             width: '100%',
             height: 420,
+            display: 'flex',
+            flexDirection: 'column',
             border: '1px solid var(--mantine-color-default-border)',
             borderRadius: 6,
-            overflow: 'hidden',
+            // 🔴 `auto`, NOT `hidden` — the scroll container of last resort.
+            // `fit="fill"` floors the host at `FILL_MIN_HEIGHT_PX`, so on a
+            // narrow window (where the read-only banner above it wraps to two or
+            // three rows) the host can still be a few px taller than the panel.
+            // Under `overflow: hidden` that residue was unreachable, which is the
+            // same class of defect as the original bug in a much narrower window
+            // — and the reason the run page's wrapper carries this too. It does
+            // not fire at ordinary modal widths: 420 minus a one-row banner
+            // leaves ~382, comfortably above the floor. Still clips to the
+            // rounded border, which is what `hidden` was here for.
+            overflow: 'auto',
           }}
         >
           <ReviewBlockPreviewHost

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -122,7 +122,15 @@ export function ReviewBlockPreviewHost({
   const buzzCap = mintData.buzzCap ?? REVIEW_RUN_FOR_REAL_BUZZ_CAP;
 
   return (
-    <Stack gap="xs">
+    // 🔴 A BOUNDED FLEX COLUMN, because `fit="fill"` below has to resolve against
+    // something. Both mounters wrap this component in a box of KNOWN height (the
+    // review modal's 420px panel, the full-page preview's `100dvh − header`), so
+    // this Stack takes that height and hands the host whatever the banner above
+    // does not use. `minHeight: 0` is what lets it shrink below its content —
+    // without it a flex item refuses to go under its automatic minimum and the
+    // host pushes out of the panel again. In a non-flex parent `flex: 1` is
+    // simply ignored, so this is inert rather than wrong for any future mounter.
+    <Stack gap="xs" style={{ flex: 1, minHeight: 0 }}>
       {runForRealActive ? (
         // PERSISTENT banner while run-for-real is active. Stays visible for the
         // whole run-for-real session so the mod is never unaware their OWN account
@@ -264,6 +272,28 @@ export function ReviewBlockPreviewHost({
         // missing either — including during an `appBlocks` kill-switch — gets no
         // dead links.)
         canOpenPage={!!(features.appBlocks && features.appBlocksPages)}
+        // 🔴 FILL THE PANEL, DON'T CLAIM THE VIEWPORT. Both review surfaces bound
+        // this component's height themselves, so the default `fit="viewport"` was
+        // wrong here in the way that matters: it claims
+        // `min-height: calc(100dvh - HEADER_HEIGHT_PX)` regardless of the box it
+        // is in. Inside the modal's `height: 420; overflow: hidden` panel that is
+        // ~600px of app crushed out of sight on a 1080px screen — clipped, with
+        // nothing to scroll to reach it — and it gets WORSE the taller the
+        // viewport, because the claim grows while the panel does not. The
+        // full-page preview has the same shape, milder: its wrapper is
+        // `100dvh − header`, and the host claimed all of that with the run-for-real
+        // banner still to fit above it.
+        //
+        // `fill` claims no height of its own (`flex: 1`, floored at
+        // `FILL_MIN_HEIGHT_PX`) and takes what the parent actually has, which is
+        // the correct question on both surfaces. The floor is inert here: 300 is
+        // well under the 420 panel.
+        //
+        // Deliberately opted in, not defaulted. `fit` still defaults to
+        // `viewport`, and the dev tunnel still takes that default — its ancestors
+        // bound nothing, so `fill` there would collapse the host to a fixed
+        // 300px slab. Enumerated in `AppBlocks/__tests__/pageRunScrollContract.test.ts`.
+        fit="fill"
       />
     </Stack>
   );

--- a/src/components/Apps/ReviewPreviewFit.browser.test.tsx
+++ b/src/components/Apps/ReviewPreviewFit.browser.test.tsx
@@ -1,0 +1,325 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace imports for the `importOriginal` spreads below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FlagsMod from '~/providers/FeatureFlagsProvider';
+import type { MintReviewBlockTokenResult } from '~/server/services/blocks/publish-request.service';
+
+/**
+ * THE MOD REVIEW PREVIEW WAS CLIPPED AND UNREACHABLE — measured.
+ *
+ * THE SYMPTOM. `OnsiteReviewModal` mounts the review preview in a panel of
+ * `height: 420; overflow: hidden`. `ReviewBlockPreviewHost` reused
+ * `PageBlockHost` and passed no `fit`, so the host took the default
+ * `fit="viewport"` and claimed `min-height: calc(100dvh - HEADER_HEIGHT_PX)` —
+ * roughly 1020px on a 1080px screen. 600px of the app was crushed out of the
+ * panel, `overflow: hidden` refused to let the moderator scroll to it, and the
+ * loss GREW with the viewport: the claim scales with `100dvh` while the panel is
+ * a constant 420.
+ *
+ * THE FIX. `fit="fill"` — the host claims no height of its own (`flex: 1`,
+ * floored at `FILL_MIN_HEIGHT_PX = 300`, comfortably under 420) and takes what
+ * the panel actually has. The panel and the full-page preview's box are flex
+ * columns so `flex: 1` has something to resolve against; without that the host
+ * lands ON its floor and leaves the rest of the panel empty, which is a
+ * different, quieter bug.
+ *
+ * 🔴 WHY THIS MEASURES INSTEAD OF READING STYLES. The defect is a LAYOUT
+ * outcome. An assertion on `style.minHeight` restates the implementation and
+ * passes whatever the browser then does with it. This runs in real Chromium and
+ * asks the only questions that matter: is content pushed outside the panel
+ * (`scrollHeight > clientHeight` on a box that will not scroll), and does the
+ * host actually fill the space it was given.
+ *
+ * 🔴 THE RED ARM IS THE REPRODUCTION AND MUST STAY. It renders the SAME host
+ * into the SAME panel with `fit="viewport"`, i.e. the state that shipped, and
+ * shows that panel really does hide content. Delete it and the green arm stops
+ * proving anything — a panel that silently had no bounded height would report
+ * "no overflow" in both arms. It is an INVARIANT GUARD, not regression coverage:
+ * it passes on `origin/main` too, by construction.
+ *
+ * NOTE ON REACH: this suite runs in CI as the REPORT-ONLY
+ * `preview / component-tests` status. The gating half of this contract is the
+ * `fill` opt-in ledger in `AppBlocks/__tests__/pageRunScrollContract.test.ts`.
+ * This file is the empirical half, and it is the one that can see layout at all.
+ */
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ id: 1, username: 'mod' }) }));
+
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FlagsMod>()),
+  // The real hook needs a provider this harness does not mount. Only the two
+  // flags `ReviewBlockPreviewHost` reads matter here, and neither affects layout.
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: true }),
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      // The mint the review host fires on mount. Resolves synchronously to a
+      // render-only token, which is the state the preview is in by default.
+      mintReviewBlockToken: {
+        useMutation: () => ({
+          data: RENDER_ONLY_MINT,
+          isPending: false,
+          isError: false,
+          mutate: vi.fn(),
+        }),
+      },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// Typed to the PRODUCTION mint shape so a field rename fails at compile time
+// rather than silently handing the host `undefined`.
+const RENDER_ONLY_MINT: MintReviewBlockTokenResult = {
+  token: 'review.render-only.jwt',
+  expiresAt: '2099-01-01T00:00:00Z',
+  scopes: ['user:read:self'],
+  domain: null,
+  maxBrowsingLevel: 1,
+  blockId: 'review-fit-app',
+  appId: 'pending-pubreq_FIT',
+  appBlockId: 'pubreq_FIT',
+  blockInstanceId: 'page_pubreq_FIT',
+  appName: 'Review Fit App',
+  sandbox: 'allow-scripts',
+  runForReal: false,
+  buzzCap: null,
+};
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+// eslint-disable-next-line import/first
+import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+/**
+ * The review modal's preview panel, kept in sync with the wrapper in
+ * `src/components/Apps/OnsiteReviewModal.tsx`. The two properties that decide
+ * this bug are the FIXED height and `overflow: hidden` — a box that bounds its
+ * children and then refuses to let anyone scroll to what it pushed out.
+ */
+const MODAL_PANEL_HEIGHT = 420;
+
+function renderInModalPanel(children: React.ReactNode, overflow: 'hidden' | 'auto') {
+  return renderWithProviders(
+    <div
+      data-testid="review-panel"
+      style={{
+        width: '100%',
+        height: `${MODAL_PANEL_HEIGHT}px`,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The direct-host props the RED ARM needs to restate the pre-fix mount. */
+const directHostProps = {
+  appBlockId: RENDER_ONLY_MINT.appBlockId,
+  blockId: RENDER_ONLY_MINT.blockId,
+  appId: RENDER_ONLY_MINT.appId,
+  blockInstanceId: RENDER_ONLY_MINT.blockInstanceId,
+  appName: RENDER_ONLY_MINT.appName,
+  iframeSrc: SAME_ORIGIN_SRC,
+  surface: 'review-preview' as const,
+  sandbox: RENDER_ONLY_MINT.sandbox,
+  trustTier: 'unverified' as const,
+  slug: RENDER_ONLY_MINT.blockId,
+  token: RENDER_ONLY_MINT.token,
+  expiresAt: RENDER_ONLY_MINT.expiresAt,
+  declaredScopes: RENDER_ONLY_MINT.scopes,
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  domain: RENDER_ONLY_MINT.domain,
+  maxBrowsingLevel: RENDER_ONLY_MINT.maxBrowsingLevel,
+  viewer: { id: 1, username: 'mod' },
+  theme: 'light' as const,
+  reviewMode: true,
+};
+
+function panel() {
+  return page.getByTestId('review-panel').element() as HTMLElement;
+}
+
+function hostFrame() {
+  return page.getByTestId('app-page-frame').element() as HTMLElement;
+}
+
+describe('the mod review preview fits its panel instead of being clipped out of it', () => {
+  test('RED ARM (invariant guard) — `fit="viewport"` really is pushed out of the 420px panel', async () => {
+    // The pre-fix mount, restated. This is the reproduction and it passes on
+    // `origin/main` too — it exists so the green arm's "no overflow" is a fact
+    // about the fix rather than about a fixture that never bounded anything.
+    // `overflow: 'hidden'` here restates the panel AS IT SHIPPED — both legs of
+    // the defect together: a claim far taller than the box, and a box that will
+    // not let anyone scroll to what it pushed out.
+    renderInModalPanel(<PageBlockHost {...directHostProps} fit="viewport" />, 'hidden');
+    await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+
+    const box = panel();
+    expect(box.clientHeight).toBeLessThanOrEqual(MODAL_PANEL_HEIGHT);
+    // Content pushed past the panel...
+    expect(box.scrollHeight).toBeGreaterThan(box.clientHeight);
+    // ...and the panel will NOT let the moderator scroll to it. Both halves are
+    // needed: `scrollHeight > clientHeight` alone is "there is overflow", which
+    // an `overflow: auto` box would satisfy while still being usable.
+    expect(getComputedStyle(box).overflowY).toBe('hidden');
+    // Name the SIZE of the loss. This is the number the fix has to move, and a
+    // bare "there is some overflow" would be satisfied by a few stray pixels.
+    // It is deliberately expressed against the viewport the runner opened rather
+    // than as a constant, because the loss IS `100dvh − header − panel`: that is
+    // what makes it grow with the screen.
+    expect(box.scrollHeight - box.clientHeight).toBeGreaterThan(
+      window.innerHeight - 60 - MODAL_PANEL_HEIGHT - 40
+    );
+  });
+
+  test('GREEN ARM — the real review host fits the panel, with nothing hidden', async () => {
+    // 🔴 THE REAL COMPONENT, not a hand-passed `fit`. The defect lived in the
+    // SEAM: `PageBlockHost` was fine, `OnsiteReviewModal` was fine, and the
+    // wiring between them dropped the prop. A test that passes `fit="fill"`
+    // itself would be green at `origin/main` and prove nothing.
+    renderInModalPanel(
+      <ReviewBlockPreviewHost
+        publishRequestId="pubreq_FIT"
+        slug="review-fit-app"
+        iframeSrc={SAME_ORIGIN_SRC}
+      />,
+      // Matches the shipped panel after this fix — see the wrapper in
+      // `OnsiteReviewModal.tsx` for why `auto` and not `hidden`.
+      'auto'
+    );
+    await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+
+    const box = panel();
+    const frame = hostFrame();
+
+    // 🔴 RED AT BASE, and this is the assertion that carries the fix: without
+    // `fit="fill"` the host claims `calc(100dvh - HEADER_HEIGHT_PX)`, so it
+    // reports the full viewport height here instead of the panel's.
+    expect(frame.getAttribute('data-fit')).toBe('fill');
+    expect(frame.getBoundingClientRect().height).toBeLessThanOrEqual(MODAL_PANEL_HEIGHT);
+
+    // 🔴 AND THE OTHER FAILURE DIRECTION — `fill` must not collapse the host, nor
+    // leave it sitting on its `FILL_MIN_HEIGHT_PX` floor in a 420px panel. That
+    // is the quieter bug a non-flex panel reintroduces: a short preview in a tall
+    // box, which reads as a styling nit. A zero-height host would also report
+    // "no overflow", so this is what stops the assertion above passing for the
+    // wrong reason.
+    expect(frame.getBoundingClientRect().height).toBeGreaterThan(320);
+
+    // Nothing is stranded. Stated as the DISJUNCTION the surface actually
+    // promises rather than a flat "no overflow": at ordinary modal widths the
+    // banner is one row and the host fits exactly, but this runner's viewport is
+    // ~414px WIDE, the banner wraps, and the floor legitimately binds — at which
+    // point the panel must be scrollable rather than clipping. The red arm's
+    // panel satisfies NEITHER branch, which is what makes this a real test and
+    // not a tautology.
+    const overflow = box.scrollHeight - box.clientHeight;
+    const reachable = ['auto', 'scroll'].includes(getComputedStyle(box).overflowY);
+    expect(
+      overflow === 0 || reachable,
+      `preview overflows its panel by ${overflow}px with overflowY=${
+        getComputedStyle(box).overflowY
+      } — that content is unreachable`
+    ).toBe(true);
+    // And whatever residue the floor leaves is SMALL — a fraction of the loss the
+    // red arm measures, not merely "some overflow".
+    expect(overflow).toBeLessThan(60);
+  });
+
+  /**
+   * SECOND MEASUREMENT POINT. The loss grows with the viewport, so one panel size
+   * is not a claim about the surface — it is a claim about 420px. The full-page
+   * preview (`/apps/review/preview/<id>`) mounts the SAME component in a box of
+   * `100dvh - header`, which is the tall end of the same axis, and it had the
+   * same shape of bug in a milder form: the host claimed the whole box for
+   * itself while the read-only banner still had to fit above it.
+   */
+  test('the tall mounter too — a full-height box shows no overflow either', async () => {
+    const boxHeight = window.innerHeight - 60;
+    renderWithProviders(
+      <div
+        data-testid="fullpage-box"
+        style={{
+          height: `${boxHeight}px`,
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <ReviewBlockPreviewHost
+          publishRequestId="pubreq_FIT"
+          slug="review-fit-app"
+          iframeSrc={SAME_ORIGIN_SRC}
+        />
+      </div>
+    );
+    await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+
+    const box = page.getByTestId('fullpage-box').element() as HTMLElement;
+    // Positive control on the fixture: a box that failed to take a height would
+    // report no overflow for a reason unrelated to the fix.
+    expect(box.clientHeight).toBeGreaterThan(200);
+    // RED AT BASE: the host claimed `100dvh - 60px` = the whole box, and the
+    // banner above it pushed the total past the box.
+    expect(box.scrollHeight).toBe(box.clientHeight);
+    expect(hostFrame().getAttribute('data-fit')).toBe('fill');
+  });
+});

--- a/src/pages/apps/review/preview/[publishRequestId].tsx
+++ b/src/pages/apps/review/preview/[publishRequestId].tsx
@@ -80,9 +80,25 @@ export default function ReviewPreviewPage({ publishRequestId, slug }: ReviewPrev
   return (
     <>
       <Meta title={`Review preview — ${slug}`} deIndex />
-      {/* Fill the viewport under the global 60px header so the mod reviews the
-          app full-size (the modal used a fixed 420px iframe). */}
-      <Box style={{ height: 'calc(100dvh - var(--header-height))', width: '100%' }}>
+      {/* Fill the viewport under the global header so the mod reviews the app
+          full-size (the modal uses a fixed 420px panel).
+
+          🔴 A FLEX COLUMN, for the same reason as the modal's panel:
+          `ReviewBlockPreviewHost` passes `fit="fill"`, so this box is what the
+          host resolves its height against. Before, the host claimed
+          `100dvh − header` for ITSELF while the run-for-real banner still had to
+          fit above it inside a box of exactly that height, so the content
+          overflowed by the banner's height and the page scrolled beside the
+          block's own scrollbar. Bounding here and letting the host take the
+          remainder removes the arithmetic instead of re-tuning it. */}
+      <Box
+        style={{
+          height: 'calc(100dvh - var(--header-height))',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
         {isLive && stableIframeSrc ? (
           <ReviewBlockPreviewHost
             publishRequestId={publishRequestId}


### PR DESCRIPTION
Two small, independent bug fixes in the App Blocks host frame, found while mapping it for an upcoming redesign. Shipping them first keeps the redesign PRs clean. One commit each; neither depends on the other.

## 1 — the ⋮ overflow menu stayed open when the user clicked into the app

`AppBlockChrome` renders two Mantine menus directly above a cross-origin app iframe. That iframe swallows the `mousedown` of a click into the app, so Mantine's `closeOnClickOutside` never fires and the dropdown is left floating over the app the user just clicked into.

The platform-nav menu already handled this — controlled, closing on the window `blur` event, which *does* fire when focus moves into a cross-origin frame. The ⋮ menu, a hundred lines away in the same component reading the same iframe, was a bare uncontrolled `<Menu>` with no `opened`/`onChange` and no blur handling. There was exactly one blur listener on the whole surface and it belonged to the other menu.

**Consolidated rather than copied.** The behaviour moved into `useIframeAwareMenu`; both menus call it, each owning its own open state. A predicate open-coded at one site is how the second site is born wrong, so the fix removes the possibility rather than patching the instance. A ledger guard in the gating node tier fails if a `<Menu>` appears in this chrome that is not on the hook — growth *or* shrink.

Also added `data-testid="app-block-menu-trigger"` to the ⋮ trigger, following its siblings (`app-block-chrome`, `app-platform-nav-trigger`, `app-block-name`, `app-block-breadcrumb*`). It was reachable only by accessible name.

No geometry change: `CHROME_BAR_PX` stays 35, no padding or icon size moves.

## 2 — the moderator review preview was clipped and unreachable

`ReviewBlockPreviewHost` reused `PageBlockHost` and passed no `fit`, so the host took the default `fit="viewport"` and claimed `min-height: calc(100dvh - HEADER_HEIGHT_PX)` regardless of the box it was in. The review modal mounts it in a panel of `height: 420; overflow: hidden`, so on a 1080px screen roughly 600px of the app was pushed out of the panel with no way to scroll to it — and it got **worse the taller the viewport**, because the claim scales with `100dvh` while the panel is a constant 420.

**Remedy: `fit="fill"`, not removing the fixed-height wrapper.** Removing the wrapper leaves the default in place, so the host would still claim `100dvh - header` — inside a modal, which is worse. `fill` makes the host claim no height of its own (`flex: 1`, floored at `FILL_MIN_HEIGHT_PX = 300`, well under 420) and take what the parent actually has, which is the right question on both of this component's mounters.

`flex: 1` needs something to resolve against, so the chain is completed rather than left half-done: the component's own `Stack` becomes a bounded flex child, and both wrappers — the modal panel and the full-page preview's `100dvh - header` box — become flex columns. Without that the host lands *on* its 300px floor and leaves the rest of the panel empty, a quieter bug that reads as a styling nit. The full-page preview had the same defect in a milder form: the host claimed the whole box while the read-only banner still had to fit above it.

The modal panel also moves from `overflow: hidden` to `overflow: auto`. When the floor binds — a narrow window where the banner wraps — `hidden` made that residue unreachable, i.e. the original defect in a much narrower window. Same scroll-of-last-resort the run page's wrapper carries; it does not fire at ordinary modal widths (420 minus a one-row banner leaves ~382).

### The dev tunnel is deliberately NOT changed

`src/pages/apps/dev/[blockId].tsx` has the identical missing-`fit` default, but the same remedy does not apply. Its wrapper is `<Box style={{ width: '100%' }}>` inside `AppLayout`'s default `ScrollArea` — nothing in its ancestor chain bounds the height, so `fit="fill"` alone would collapse it to a fixed 300px slab whatever the viewport. Fixing it needs the run page's full three-leg treatment (`Page(…, { scrollable: false })` + a bounded flex wrapper with an `overflowY: 'auto'` scroll of last resort + `fit="fill"`) — a layout change to a separate surface with its own risk, and out of scope here. The review surface needed none of that: it was never in an unbounded scrolling layout, it was in a box that bounded its height and clipped. The co-requisite equivalence in `pageRunScrollContract` is scoped to the run page for exactly this reason.

Two comments asserting the review preview belongs on `viewport` are corrected rather than left to read as still true.

## Test matrix — red at `origin/main`, green at HEAD

Measured by reverting the production sources in place and re-running, so each red is attributable to the assertion named.

| Suite | Tier | Base | HEAD | Failing assertion at base |
|---|---|---|---|---|
| `AppBlocks/__tests__/iframeAwareMenu.test.ts` | node `unit` (**gating**) | 3 fail / 1 pass of 4 | 4 pass | ``an uncontrolled <Menu> in AppBlockChrome: <Menu position="bottom-end" shadow="md" width={180}>: expected … to match /opened=\{/``; the hook module not existing; the missing testid |
| `AppBlocks/AppBlockChrome.browser.test.tsx` | component (report-only) | 3 fail / 21 pass of 24 | 24 pass | `expect(element).not.toBeInTheDocument()` for the "Manage apps" item after a dispatched `blur` (×2); the absent testid |
| `AppBlocks/__tests__/pageRunScrollContract.test.ts` | node `unit` (**gating**) | 1 fail / 9 pass of 10 | 10 pass | `expected [ Array(1) ] to deeply equal [ …(2) ]` — the `fill` opt-in ledger |
| `Apps/ReviewPreviewFit.browser.test.tsx` | component (report-only) | 2 fail / 1 pass of 3 | 3 pass | `expected 'viewport' to be 'fill'`; `expected 1022 to be 836` (186px of overflow on a full-height box) |

Two tests pass on **both** trees by construction and are labelled in-file as invariant guards / positive controls rather than counted as regression coverage: the scanner's own regex self-test in the ledger, and the RED ARM in `ReviewPreviewFit` that reproduces the pre-fix clipping so the green arm's "no overflow" is a fact about the fix rather than about the fixture.

Fix 2 is measured at **two points** on the axis that makes the bug grow — a 420px panel and a full-viewport box — because one panel size is a claim about 420px only.

Nothing in `pageRunScrollContract` is weakened. The run page's three verbatim pins, its `scrollable: false` ⟺ `fit="fill"` equivalence, the header-height ledger and the `FILL_MIN_HEIGHT_PX` band are untouched and green. The `fill` ledger gained a row, which is that guard's intended maintenance path — it fails on growth *and* on shrink.

## Verification

- `pnpm typecheck` — **0 type errors** in 87s (heap cap 8192 MB). Instrument validated: a deliberate `const zzNegControl: number = "not a number"` in `useIframeAwareMenu.ts` produced `error TS2322` naming that file, then reverted.
- `node scripts/test-unit-run.mjs` (full gating node tier) — **24,000 passed / 26 skipped, 0 failed** across 1522 files.
- `vitest run --project component src/components/AppBlocks src/components/Apps` — **1549 passed** across 111 files.
- `node scripts/ci/typecheck-tests-gate.mjs` — already red on `main`. **Base 1010 errors / 188 files; HEAD 1010 / 188.** Zero delta. Its own positive control moved 1466 → 1467 test files in the program, i.e. it does see the new `__tests__` file and that file contributes no errors.
- `eslint` over the 11 touched files — clean (0 problems). Instrument validated separately: a scratch file with an unused var and an explicit `any` produced the expected two reports.
- `prettier --check` — the three pre-existing files I touched (`IframeHost.tsx`, `ReviewBlockPreviewHost.tsx`, `AppBlockChrome.browser.test.tsx`) are already prettier-dirty at `origin/main`, verified by checking their base blobs in-repo; I did not reformat them (that would bury the diff). All three new files are prettier-clean.

## Not verified

Neither fix has been driven in a real browser against a running app or a real moderator review preview — the layout claims rest on the Chromium component tests, and the ⋮ blur close is exercised by a dispatched `blur` event rather than a genuine cross-origin iframe click. The production numbers in the commit messages (~600px on 1080, ~580 into 420 on a 360×640 phone) are arithmetic from the two `min-height` expressions, not measurements of the deployed page.
