### PR TITLE
fix(app-blocks): make the host chrome responsive from phone to ultrawide (F1)

### DIFF
--- a/src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * `AppBlockChrome` — RESPONSIVE GEOMETRY, measured in a real browser at named
+ * viewports.
+ *
+ * 🔴 WHY THIS FILE EXISTS AT ALL. The chrome was the only breakpoint-blind
+ * surface in the app: a fixed `maw={160}` on the app-name label, a fixed
+ * `maw={200}` on the breadcrumb crumb and a fixed `width={200}` on the
+ * platform-nav dropdown, on a bar that renders both inside a ~320px model
+ * sidebar and as the header of a 2560px full-page app frame. The existing
+ * suites could not see any of that: `AppBlockChrome.browser.test.tsx` sets no
+ * viewport at all and `AppsPageLayout.geometry.browser.test.tsx` pins
+ * `page.viewport(1440, 900)`, so a width-dependent defect passes vacuously in
+ * both. Widening the harness — running the same component at a phone width AND
+ * at an ultrawide width, and naming the viewport in each assertion — is part of
+ * the fix, not extra work.
+ *
+ * 🔴 WHICH TESTS ARE REGRESSION COVERAGE AND WHICH ARE NOT. Labelled per test.
+ * Two of these fail at `origin/main` against the shipped component (named in
+ * each). The other three pass at `origin/main` — they are invariant guards and a
+ * discriminating control, and they are deliberately NOT counted as regression
+ * coverage.
+ *
+ * 🔴 WHY THIS FILE LOADS `@mantine/core/styles.css` AND ITS SIBLINGS MUST NOT.
+ * Same reason `AppsPageLayout.geometry.browser.test.tsx` does: the shared
+ * component scaffold omits Mantine's stylesheet on purpose, so the sibling
+ * suites assert attributes and ARIA. But every number here — the `Group`'s flex
+ * row, `ActionIcon`'s `--ai-size-sm`, the `Text`'s truncation box — comes FROM
+ * that stylesheet, and without it each computes to something meaningless while
+ * the assertions still pass. Vitest browser mode runs each test file in its own
+ * iframe, so the import does not leak into the sibling suites.
+ *
+ * 🔴 THIS PROJECT IS NOT A GATE. The Vitest browser-mode `component` project is
+ * report-only in CI. The gating half of this change is the node-tier
+ * `__tests__/chromeGeometry.test.ts` (which is unit coverage of a new module,
+ * not regression coverage — see its own header).
+ */
+import '@mantine/core/styles.css';
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+// The chrome calls `useCurrentUser()` (moderator gate on the platform-nav "Review"
+// item) and there is no `CivitaiSessionProvider` here — same stub the sibling
+// chrome suite uses, for the same reason.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// eslint-disable-next-line import/first
+import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import { CHROME_BAR_PX } from '~/components/AppBlocks/slotReservation';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+// eslint-disable-next-line import/first
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The two measurement points. Named, and named again in every assertion message,
+ * so a failure says WHICH width it is about. A single point could not have caught
+ * this defect class in either direction.
+ */
+const PHONE: [number, number] = [360, 780];
+const ULTRAWIDE: [number, number] = [2560, 1200];
+
+/**
+ * Width of the model-page sidebar the chrome renders in. Not a viewport — the
+ * point of the third test is that the bar's OWN box, not the window, decides.
+ */
+const MODEL_SIDEBAR_PX = 340;
+
+/**
+ * Long enough that the label genuinely needs more than the legacy 160px cap
+ * (~46 chars at Mantine `size="xs"` is ~270px), but under `sanitizeAppChromeName`'s
+ * 64-char bound so the sanitizer is not the thing doing the trimming.
+ */
+const LONG_NAME = 'Background Remover Pro Max Ultra Deluxe Edition';
+
+const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+
+/**
+ * Render the chrome and wait for its `ResizeObserver` to have measured itself.
+ *
+ * `useResizeObserver` batches its callback into a `requestAnimationFrame`, which
+ * then drives a `setState`, so the resolved tier is not available on the first
+ * paint. Polling on the resolved tier is bounded (1.5s) rather than open-ended so
+ * that a run against code that never resolves one — `origin/main`, which has no
+ * tier at all — falls through quickly to the BEHAVIOURAL assertion instead of
+ * timing out on a missing attribute.
+ */
+async function renderChrome({
+  viewport,
+  wrapperWidth,
+  expectTier,
+  ...props
+}: {
+  viewport: [number, number];
+  wrapperWidth?: number;
+  expectTier: string;
+  appName?: string;
+  slotId?: string;
+}) {
+  await page.viewport(...viewport);
+  const chrome = <AppBlockChrome blockInstanceId="inst-responsive" {...props} />;
+  renderWithProviders(
+    wrapperWidth != null ? <div style={{ width: wrapperWidth }}>{chrome}</div> : chrome
+  );
+  await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+  const root = page.getByTestId('app-block-chrome').element() as HTMLElement;
+
+  const deadline = Date.now() + 1500;
+  while (Date.now() < deadline && root.getAttribute('data-chrome-tier') !== expectTier) {
+    await frame();
+  }
+  // Two more frames so the re-render the measurement triggered has laid out.
+  await frame();
+  await frame();
+  return root;
+}
+
+/**
+ * Guard-the-guard. Without `@mantine/core/styles.css` the `Group` is not a flex
+ * row and every width below reads as something other than what ships, while the
+ * assertions can still pass. Asserted first in every test.
+ */
+const styleSheetLoaded = (root: HTMLElement) => getComputedStyle(root).display === 'flex';
+
+const rect = (el: Element) => el.getBoundingClientRect();
+
+describe('AppBlockChrome responsive geometry', () => {
+  test(`REGRESSION — at ${ULTRAWIDE[0]}x${ULTRAWIDE[1]} the app name is not clamped to the legacy 160px cap`, async () => {
+    // 🔴 RED AT `origin/main`. The failing assertion there is the `maxWidth`
+    // computed-style one below: main pins `maw={160}` unconditionally, so at a
+    // 2560px-wide bar the name box computes `160px` instead of `none`, and its
+    // rendered width is exactly 160 rather than the ~270px the text needs.
+    const root = await renderChrome({
+      viewport: ULTRAWIDE,
+      expectTier: 'xl',
+      appName: LONG_NAME,
+    });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    const name = page.getByTestId('app-block-name').element();
+    expect(
+      getComputedStyle(name).maxWidth,
+      `at ${ULTRAWIDE[0]}px the app name must not carry a fixed max-width`
+    ).toBe('none');
+    expect(
+      Math.round(rect(name).width),
+      `at ${ULTRAWIDE[0]}px the app name must render wider than the legacy 160px cap`
+    ).toBeGreaterThan(160);
+
+    // The bar itself still does not overflow — an uncapped name is only safe
+    // because the label truncates inside a `minWidth: 0` flex parent.
+    expect(root.scrollWidth, `no horizontal overflow at ${ULTRAWIDE[0]}px`).toBeLessThanOrEqual(
+      root.clientWidth + 1
+    );
+    expect(root.getAttribute('data-chrome-tier')).toBe('xl');
+  });
+
+  test(`REGRESSION — at ${ULTRAWIDE[0]}x${ULTRAWIDE[1]} the platform-nav dropdown is wider than its legacy fixed 200px`, async () => {
+    // 🔴 RED AT `origin/main`. The failing assertion is the dropdown-width one:
+    // main pins `width={200}` on the Menu, so the measured dropdown is exactly
+    // 200px at every viewport and `> 200` fails.
+    const root = await renderChrome({
+      viewport: ULTRAWIDE,
+      expectTier: 'xl',
+      appName: LONG_NAME,
+    });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    await page.getByTestId('app-platform-nav-trigger').click();
+    await expect.element(page.getByText('Apps home')).toBeInTheDocument();
+
+    const dropdown = document.querySelector('.mantine-Menu-dropdown') as HTMLElement | null;
+    // Positive control on the lookup: a null here would make every width
+    // assertion below unreachable, which is the reassuring-zero shape.
+    expect(dropdown, 'the platform-nav dropdown must be in the document once opened').not.toBeNull();
+    expect(
+      Math.round(rect(dropdown as HTMLElement).width),
+      `at ${ULTRAWIDE[0]}px the platform-nav dropdown must be wider than the legacy 200px`
+    ).toBeGreaterThan(200);
+  });
+
+  test(`CONTROL (passes at origin/main) — a ${MODEL_SIDEBAR_PX}px bar stays narrow even at a ${ULTRAWIDE[0]}px viewport`, async () => {
+    // 🔴 NOT REGRESSION COVERAGE — `origin/main` passes this, because main caps at
+    // 160 everywhere. It is the DISCRIMINATING CONTROL for the mechanism choice:
+    // the model-slot chrome lives in a sidebar that is narrow no matter how wide
+    // the window is, so the geometry must follow the BAR's own inline size. Had
+    // this been built on a viewport media query — or on the page's `main`
+    // ContainerProvider, which measures the whole content column — this test would
+    // go red while the two REGRESSION tests above stayed green. That is exactly
+    // the mutation it is here to kill.
+    const root = await renderChrome({
+      viewport: ULTRAWIDE,
+      wrapperWidth: MODEL_SIDEBAR_PX,
+      expectTier: 'base',
+      appName: LONG_NAME,
+    });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    expect(
+      Math.round(rect(root).width),
+      `the bar must be ${MODEL_SIDEBAR_PX}px wide despite the ${ULTRAWIDE[0]}px viewport`
+    ).toBe(MODEL_SIDEBAR_PX);
+    const name = page.getByTestId('app-block-name').element();
+    expect(
+      Math.round(rect(name).width),
+      `a ${MODEL_SIDEBAR_PX}px bar must keep the narrow 160px name cap`
+    ).toBeLessThanOrEqual(160);
+    expect(root.scrollWidth, `no horizontal overflow in a ${MODEL_SIDEBAR_PX}px bar`).toBeLessThanOrEqual(
+      root.clientWidth + 1
+    );
+  });
+
+  test(`at ${PHONE[0]}x${PHONE[1]} the row stays on one line, does not overflow, and keeps its controls at full size`, async () => {
+    const root = await renderChrome({
+      viewport: PHONE,
+      expectTier: 'base',
+      appName: LONG_NAME,
+    });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    expect(root.scrollWidth, `no horizontal overflow at ${PHONE[0]}px`).toBeLessThanOrEqual(
+      root.clientWidth + 1
+    );
+
+    // Both icon buttons keep their resting 26px (`ActionIcon size="sm"`). The ⋯
+    // trigger is the one that gained an explicit `flexShrink: 0` in this change;
+    // its left-hand sibling already had one. In a `wrap="nowrap"` row a shrinkable
+    // button is what gets crushed first when the name is long.
+    const navTrigger = page.getByTestId('app-platform-nav-trigger').element();
+    const overflowTrigger = page.getByTestId('app-block-menu-trigger').element();
+    expect(
+      Math.round(rect(navTrigger).width),
+      `the apps-menu trigger must keep its 26px size at ${PHONE[0]}px`
+    ).toBe(26);
+    expect(
+      Math.round(rect(overflowTrigger).width),
+      `the ⋯ trigger must keep its 26px size at ${PHONE[0]}px`
+    ).toBe(26);
+
+    // One line: the two triggers share a row.
+    expect(
+      Math.round(rect(navTrigger).top),
+      `the row must not wrap at ${PHONE[0]}px`
+    ).toBe(Math.round(rect(overflowTrigger).top));
+  });
+
+  // 🔴 NOT REGRESSION COVERAGE — both cases pass at `origin/main`, and they are
+  // supposed to. `CHROME_BAR_PX` is the model slot's CLS reservation, pinned in
+  // `slotReservation.ts` and asserted in `__tests__/slotReservation.test.ts`. This
+  // change is width-only and must not move it; this is the check that says so at a
+  // rendered pixel level rather than by reading the constant back. Two cases, not
+  // one loop: `cleanup()` runs per TEST, so two renders inside one test would leave
+  // two chrome bars in the document and every document-scoped query would be
+  // ambiguous.
+  test.each([
+    ['phone', PHONE, 'base'],
+    ['ultrawide', ULTRAWIDE, 'xl'],
+  ] as const)(
+    `INVARIANT GUARD — the bar's resting height is CHROME_BAR_PX (${CHROME_BAR_PX}) at the %s viewport`,
+    async (_label, viewport, expectTier) => {
+      const root = await renderChrome({ viewport, expectTier, appName: LONG_NAME });
+      expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+      expect(
+        Math.round(rect(root).height),
+        `the chrome bar must be exactly CHROME_BAR_PX tall at ${viewport[0]}px`
+      ).toBe(CHROME_BAR_PX);
+    }
+  );
+});

--- a/src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx
@@ -72,6 +72,21 @@ const MODEL_SIDEBAR_PX = 340;
  */
 const LONG_NAME = 'Background Remover Pro Max Ultra Deluxe Edition';
 
+/**
+ * `ActionIcon size="sm"` at rest. `@mantine/core` 7.17.8 ships
+ * `--ai-size-sm: calc(1.375rem * var(--mantine-scale))`; this repo overrides
+ * neither the ActionIcon sizes nor `--mantine-scale`, so 1.375rem = 22px.
+ */
+const RESTING_ICON_PX = 22;
+
+/**
+ * The bar's rendered resting height: 22 (ActionIcon sm) + 8 (`py={4}` ×2) + 1
+ * (bottom border). See the long note on the height guard at the bottom of this
+ * file for why this is NOT `CHROME_BAR_PX` and why that is a pre-existing finding
+ * rather than something this change caused.
+ */
+const CHROME_BAR_RENDERED_PX = RESTING_ICON_PX + 8 + 1;
+
 const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
 
 /**
@@ -171,7 +186,10 @@ describe('AppBlockChrome responsive geometry', () => {
     const dropdown = document.querySelector('.mantine-Menu-dropdown') as HTMLElement | null;
     // Positive control on the lookup: a null here would make every width
     // assertion below unreachable, which is the reassuring-zero shape.
-    expect(dropdown, 'the platform-nav dropdown must be in the document once opened').not.toBeNull();
+    expect(
+      dropdown,
+      'the platform-nav dropdown must be in the document once opened'
+    ).not.toBeNull();
     expect(
       Math.round(rect(dropdown as HTMLElement).width),
       `at ${ULTRAWIDE[0]}px the platform-nav dropdown must be wider than the legacy 200px`
@@ -204,9 +222,10 @@ describe('AppBlockChrome responsive geometry', () => {
       Math.round(rect(name).width),
       `a ${MODEL_SIDEBAR_PX}px bar must keep the narrow 160px name cap`
     ).toBeLessThanOrEqual(160);
-    expect(root.scrollWidth, `no horizontal overflow in a ${MODEL_SIDEBAR_PX}px bar`).toBeLessThanOrEqual(
-      root.clientWidth + 1
-    );
+    expect(
+      root.scrollWidth,
+      `no horizontal overflow in a ${MODEL_SIDEBAR_PX}px bar`
+    ).toBeLessThanOrEqual(root.clientWidth + 1);
   });
 
   test(`at ${PHONE[0]}x${PHONE[1]} the row stays on one line, does not overflow, and keeps its controls at full size`, async () => {
@@ -221,48 +240,69 @@ describe('AppBlockChrome responsive geometry', () => {
       root.clientWidth + 1
     );
 
-    // Both icon buttons keep their resting 26px (`ActionIcon size="sm"`). The ⋯
-    // trigger is the one that gained an explicit `flexShrink: 0` in this change;
-    // its left-hand sibling already had one. In a `wrap="nowrap"` row a shrinkable
-    // button is what gets crushed first when the name is long.
+    // Both icon buttons keep their resting size. The ⋯ trigger is the one that
+    // gained an explicit `flexShrink: 0` in this change; its left-hand sibling has
+    // carried one all along. In a `wrap="nowrap"` row a shrinkable button is what
+    // gets crushed first when the name is long, so the load-bearing claim is the
+    // RELATIONAL one — the two triggers must be the same size as each other.
     const navTrigger = page.getByTestId('app-platform-nav-trigger').element();
     const overflowTrigger = page.getByTestId('app-block-menu-trigger').element();
     expect(
       Math.round(rect(navTrigger).width),
-      `the apps-menu trigger must keep its 26px size at ${PHONE[0]}px`
-    ).toBe(26);
+      `the apps-menu trigger must render at its resting ActionIcon size="sm" at ${PHONE[0]}px`
+    ).toBe(RESTING_ICON_PX);
     expect(
       Math.round(rect(overflowTrigger).width),
-      `the ⋯ trigger must keep its 26px size at ${PHONE[0]}px`
-    ).toBe(26);
+      `the ⋯ trigger must not be squeezed below the apps-menu trigger at ${PHONE[0]}px`
+    ).toBe(Math.round(rect(navTrigger).width));
 
     // One line: the two triggers share a row.
-    expect(
-      Math.round(rect(navTrigger).top),
-      `the row must not wrap at ${PHONE[0]}px`
-    ).toBe(Math.round(rect(overflowTrigger).top));
+    expect(Math.round(rect(navTrigger).top), `the row must not wrap at ${PHONE[0]}px`).toBe(
+      Math.round(rect(overflowTrigger).top)
+    );
   });
 
   // 🔴 NOT REGRESSION COVERAGE — both cases pass at `origin/main`, and they are
-  // supposed to. `CHROME_BAR_PX` is the model slot's CLS reservation, pinned in
-  // `slotReservation.ts` and asserted in `__tests__/slotReservation.test.ts`. This
-  // change is width-only and must not move it; this is the check that says so at a
-  // rendered pixel level rather than by reading the constant back. Two cases, not
-  // one loop: `cleanup()` runs per TEST, so two renders inside one test would leave
-  // two chrome bars in the document and every document-scoped query would be
-  // ambiguous.
+  // supposed to. This change is WIDTH-ONLY, and the bar's resting height is the
+  // model slot's CLS reservation, so this is the check that says the height did
+  // not move — at a rendered pixel level, rather than by reading a constant back.
+  //
+  // 🔴 IT PINS THE MEASURED HEIGHT, NOT `CHROME_BAR_PX`, AND THOSE TWO DISAGREE.
+  // This test was written asserting `CHROME_BAR_PX` (35) and failed at 31 — at BOTH
+  // viewports, and identically before and after this change, so it is a
+  // PRE-EXISTING divergence this test found rather than one it caused. The
+  // derivation comment on `CHROME_BAR_PX` in `slotReservation.ts` states
+  // "`--ai-size-sm` = rem(26px) = 26px"; the installed `@mantine/core` 7.17.8 ships
+  // `--ai-size-sm: calc(1.375rem * var(--mantine-scale))` = 22px, and this repo
+  // overrides neither the ActionIcon sizes nor `--mantine-scale`
+  // (`src/providers/ThemeProvider.tsx` sets only `color`/`variant` defaults). So the
+  // real resting height is 22 + 8 (`py={4}` ×2) + 1 (border) = 31, and the slot
+  // over-reserves by 4px.
+  //
+  // Deliberately NOT fixed here. Changing `CHROME_BAR_PX` changes the model-page
+  // slot's server-seeded reservation height — a behavioural change on a different
+  // surface, with its own before/after to measure — and F1 is a width-only pass.
+  // Left as a reported finding; `CHROME_BAR_PX` is untouched by this change.
+  //
+  // Two cases, not one loop: `cleanup()` runs per TEST, so two renders inside one
+  // test would leave two chrome bars in the document and every document-scoped
+  // query would be ambiguous.
   test.each([
     ['phone', PHONE, 'base'],
     ['ultrawide', ULTRAWIDE, 'xl'],
   ] as const)(
-    `INVARIANT GUARD — the bar's resting height is CHROME_BAR_PX (${CHROME_BAR_PX}) at the %s viewport`,
+    `INVARIANT GUARD — the bar's resting height is unchanged (${CHROME_BAR_RENDERED_PX}px) at the %s viewport`,
     async (_label, viewport, expectTier) => {
       const root = await renderChrome({ viewport, expectTier, appName: LONG_NAME });
       expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
       expect(
         Math.round(rect(root).height),
-        `the chrome bar must be exactly CHROME_BAR_PX tall at ${viewport[0]}px`
-      ).toBe(CHROME_BAR_PX);
+        `the chrome bar's resting height must not move at ${viewport[0]}px`
+      ).toBe(CHROME_BAR_RENDERED_PX);
+      // The constant this height is SUPPOSED to equal, restated so the divergence
+      // above is visible in the file rather than only in a commit message. It is an
+      // over-reservation (35 > 31), which is the safe direction for a CLS reserve.
+      expect(CHROME_BAR_PX).toBeGreaterThanOrEqual(CHROME_BAR_RENDERED_PX);
     }
   );
 });

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -29,6 +29,8 @@ import { resolveRequestConsent } from './requestConsentGate';
 import { hideBlock } from './hiddenBlocks';
 import { isPageSlot } from '~/shared/constants/slot-registry';
 import { sanitizeAppChromeName } from './appChromeName';
+import { resolveChromeGeometry } from './chromeGeometry';
+import { useResizeObserver } from '~/hooks/useResizeObserver';
 import { sendBlockRender } from './sendBlockRender';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
 import {
@@ -308,23 +310,60 @@ export function AppBlockChrome({
   // visible fallback "App" Text is present to carry provenance itself —
   // avoiding an unlabeled SVG / a double-reading "App".
   const iconProvenance = hasName || !showBadgeName;
+
+  // 🔴 RESPONSIVE GEOMETRY IS DRIVEN BY THE CHROME'S OWN INLINE SIZE — see
+  // `chromeGeometry.ts` for the full rationale and the breakpoint scale. Short
+  // version: this bar renders both in a ~320px model sidebar and as the header of
+  // a 2560px full-page app frame, so neither the viewport nor the page's `main`
+  // ContainerProvider (which DOES exist on both surfaces, via BaseLayout, and is
+  // therefore not the reason we don't use it) describes the space this row
+  // actually has. `useResizeObserver` is the same primitive `ContainerProvider`
+  // itself uses; we just point it at this element.
+  //
+  // Before the observer fires — SSR, and the first client render — the width is 0,
+  // which resolves to the `base` tier whose values ARE the pre-change hard-coded
+  // ones. So the server HTML and the first client paint are unchanged and there is
+  // no hydration mismatch to guard with `useIsClient`.
+  const [chromeWidth, setChromeWidth] = useState(0);
+  const chromeRef = useResizeObserver<HTMLDivElement>((entry) => {
+    const next = entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+    setChromeWidth((prev) => (prev === next ? prev : next));
+  });
+  const geometry = resolveChromeGeometry(chromeWidth);
+
   return (
     <>
     <Group
+      ref={chromeRef}
       justify="space-between"
       gap="xs"
       px="xs"
       py={4}
+      // 🔴 `nowrap` STAYS, and it is not the breakpoint-blind bit. The bar's
+      // resting height is a pinned contract — `CHROME_BAR_PX = 35` in
+      // `slotReservation.ts`, the model slot's CLS reservation — and letting this
+      // row wrap to a second line at a narrow width would break it on exactly the
+      // surface the reservation exists for. The fix for narrow widths is that both
+      // flex children can SHRINK (`minWidth: 0` on the growing side, an explicit
+      // `flexShrink: 0` on each icon button so the controls are never crushed),
+      // which keeps the row one line tall at every width. This change is
+      // width-only; `CHROME_BAR_PX` is unchanged.
       wrap="nowrap"
       data-testid="app-block-chrome"
+      // Machine-readable resolved tier, so a test can assert the decision rather
+      // than re-deriving it from pixels.
+      data-chrome-tier={geometry.tier}
       style={{
         borderBottom: '1px solid var(--mantine-color-default-border)',
         background: 'var(--mantine-color-default-hover)',
       }}
     >
       {/* minWidth:0 lets the truncating name shrink instead of pushing the
-          ⋯ menu out of the narrow sidebar layout. */}
-      <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+          ⋯ menu out of the narrow sidebar layout; `flex: 1 1 auto` lets it CLAIM
+          the row's slack on a wide surface, which is what makes an uncapped name
+          at the `xl` tier actually use the space instead of sitting at its
+          content width. */}
+      <Group gap={6} wrap="nowrap" style={{ minWidth: 0, flex: '1 1 auto' }}>
         {/* The provenance app icon doubles as a quick-nav Menu of the Civitai
             App PLATFORM's own pages (NOT the sandboxed app's internal routes —
             apps self-route as SPAs inside the iframe; the host has no list of
@@ -335,7 +374,11 @@ export function AppBlockChrome({
         <Menu
           position="bottom-start"
           shadow="md"
-          width={200}
+          // Responsive: this dropdown renders publisher-controlled app names in
+          // its "Recently run" section, so its useful width tracks the surface.
+          // (The ⋮ overflow menu below keeps a fixed width on purpose — every
+          // label in it is short, fixed and host-authored.)
+          width={geometry.navMenuWidth}
           opened={platformNavMenu.opened}
           onChange={platformNavMenu.onChange}
         >
@@ -421,7 +464,7 @@ export function AppBlockChrome({
                         Zalgo combining runs, bounds length). `||` (not `??`) so an
                         empty/whitespace sanitized result falls back to the blockId
                         handle. `lineClamp={1}` keeps a pathologically long name
-                        from blowing out the width={200} dropdown. */}
+                        from blowing out the dropdown at ANY of its widths. */}
                     <Text size="sm" lineClamp={1}>
                       {sanitizeAppChromeName(r.name) || r.blockId}
                     </Text>
@@ -432,12 +475,21 @@ export function AppBlockChrome({
           </Menu.Dropdown>
         </Menu>
         {/* Host-rendered (spoof-proof) app-name label. Truncates with an
-            ellipsis at a bounded width so a long name never wraps or shoves
-            the menu off the row in the narrow model.sidebar_top slot. On the
-            page surface this is suppressed (the breadcrumb crumb below carries
-            the name once) — see `showBadgeName`. */}
+            ellipsis so a long name never wraps or shoves the menu off the row in
+            the narrow model.sidebar_top slot. The cap is now RESPONSIVE to the
+            bar's own width (`chromeGeometry.ts`) instead of a fixed 160px: 160 in
+            a narrow sidebar / on a phone exactly as before, wider as the bar gets
+            wider, and uncapped once the bar is `xl`. On the page surface this is
+            suppressed (the breadcrumb crumb below carries the name once) — see
+            `showBadgeName`. */}
         {showBadgeName && (
-          <Text size="xs" c="dimmed" truncate maw={160} data-testid="app-block-name">
+          <Text
+            size="xs"
+            c="dimmed"
+            truncate
+            maw={geometry.nameMaxWidth}
+            data-testid="app-block-name"
+          >
             {label}
           </Text>
         )}
@@ -477,12 +529,15 @@ export function AppBlockChrome({
             <Text size="xs" c="dimmed" aria-hidden>
               /
             </Text>
+            {/* Same responsive cap as the badge name — it is the same
+                publisher-controlled string, just rendered on the page surface
+                instead of the model surface, so one tier table serves both. */}
             <Text
               size="xs"
               c="dimmed"
               fw={500}
               truncate
-              maw={200}
+              maw={geometry.nameMaxWidth}
               data-testid="app-block-breadcrumb-name"
             >
               {label}
@@ -513,6 +568,11 @@ export function AppBlockChrome({
             size="sm"
             aria-label="App menu"
             data-testid="app-block-menu-trigger"
+            // The row is `wrap="nowrap"` (it must stay one line — CHROME_BAR_PX).
+            // Without this the ⋯ trigger is a shrinkable flex item and a long name
+            // at a narrow width squeezes it below its 26px resting size; its
+            // sibling on the left has carried `flexShrink: 0` all along.
+            style={{ flexShrink: 0 }}
           >
             <IconDots size={16} stroke={1.5} />
           </ActionIcon>

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -570,8 +570,9 @@ export function AppBlockChrome({
             data-testid="app-block-menu-trigger"
             // The row is `wrap="nowrap"` (it must stay one line — CHROME_BAR_PX).
             // Without this the ⋯ trigger is a shrinkable flex item and a long name
-            // at a narrow width squeezes it below its 26px resting size; its
-            // sibling on the left has carried `flexShrink: 0` all along.
+            // at a narrow width can squeeze it below its resting `ActionIcon
+            // size="sm"` (22px in @mantine/core 7.17.8); its sibling on the left
+            // has carried `flexShrink: 0` all along.
             style={{ flexShrink: 0 }}
           >
             <IconDots size={16} stroke={1.5} />

--- a/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
@@ -28,7 +28,7 @@ import {
 import { breakpoints } from '~/utils/tailwind';
 
 describe('CHROME_BREAKPOINTS', () => {
-  it('is the px scale from breakpoints.json, not Mantine\'s stock em scale', () => {
+  it("is the px scale from breakpoints.json, not Mantine's stock em scale", () => {
     // Single-source drift guard. `breakpoints.json` is also what tailwind.config.js
     // require()s, so this pins the chrome to the SAME numbers the utility classes
     // use. Literals are restated here deliberately: a test that only compared the
@@ -114,8 +114,9 @@ describe('resolveChromeGeometry', () => {
     // Monotonicity is the property a hand-edited table loses first. Sampled at
     // every boundary AND at a midpoint of every band, since a table edit can break
     // ordering between two rows without moving a boundary.
-    const widths = [0, 240, 479, 480, 600, 767, 768, 900, 1023, 1024, 1100, 1183, 1184,
-      1300, 1439, 1440, 2560];
+    const widths = [
+      0, 240, 479, 480, 600, 767, 768, 900, 1023, 1024, 1100, 1183, 1184, 1300, 1439, 1440, 2560,
+    ];
     let previousName = -1;
     let previousMenu = -1;
     for (const w of widths) {

--- a/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit coverage for the App Blocks chrome's responsive geometry resolver.
+ *
+ * 🔴 THIS FILE IS **NOT** REGRESSION COVERAGE, and saying so is the point.
+ * `chromeGeometry.ts` is NEW in the same change, so every test here fails at
+ * `origin/main` for the trivial reason that the module does not resolve — which
+ * proves nothing about behaviour. The regression coverage for the defect this
+ * change fixes (a fixed 160px name cap and a fixed 200px nav-menu width on a bar
+ * that renders from 320px to 2560px wide) is the rendered-DOM suite
+ * `AppBlockChromeResponsive.browser.test.tsx`, whose assertions fail at
+ * `origin/main` against the SHIPPED component.
+ *
+ * What this file is for: the resolver is a table, and a table is exactly the
+ * thing a rendered test samples rather than enumerates. These tests enumerate
+ * both sides of every boundary and pin the two properties the table must have
+ * (monotonic, and `base` == the pre-change constants) that no single rendered
+ * viewport can express.
+ *
+ * It lives in the node `unit` project on purpose: that tier is GATING in CI,
+ * while the browser `component` project is report-only.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  CHROME_BREAKPOINTS,
+  resolveChromeGeometry,
+  resolveChromeTier,
+} from '~/components/AppBlocks/chromeGeometry';
+import { breakpoints } from '~/utils/tailwind';
+
+describe('CHROME_BREAKPOINTS', () => {
+  it('is the px scale from breakpoints.json, not Mantine\'s stock em scale', () => {
+    // Single-source drift guard. `breakpoints.json` is also what tailwind.config.js
+    // require()s, so this pins the chrome to the SAME numbers the utility classes
+    // use. Literals are restated here deliberately: a test that only compared the
+    // module to its own import would pass with both sides wrong.
+    expect(CHROME_BREAKPOINTS).toEqual({ xs: 480, sm: 768, md: 1024, lg: 1184, xl: 1440 });
+    expect(CHROME_BREAKPOINTS).toEqual({
+      xs: parseInt(breakpoints.xs, 10),
+      sm: parseInt(breakpoints.sm, 10),
+      md: parseInt(breakpoints.md, 10),
+      lg: parseInt(breakpoints.lg, 10),
+      xl: parseInt(breakpoints.xl, 10),
+    });
+
+    // Mantine's own (never-overridden) responsive scale is 576/768/992/1200/1408.
+    // Only `sm` coincides. If a future edit swapped this module onto that scale,
+    // four of these five would move — so this is the check that the two scales
+    // have not been quietly blended.
+    expect(CHROME_BREAKPOINTS.xs).not.toBe(576);
+    expect(CHROME_BREAKPOINTS.md).not.toBe(992);
+    expect(CHROME_BREAKPOINTS.lg).not.toBe(1200);
+    expect(CHROME_BREAKPOINTS.xl).not.toBe(1408);
+  });
+});
+
+describe('resolveChromeTier', () => {
+  it('puts a 360px phone bar and a 320px model sidebar in the SAME tier', () => {
+    // The whole design premise: those two are one layout problem, not two.
+    expect(resolveChromeTier(360)).toBe('base');
+    expect(resolveChromeTier(320)).toBe('base');
+  });
+
+  it.each([
+    ['xs', CHROME_BREAKPOINTS.xs],
+    ['sm', CHROME_BREAKPOINTS.sm],
+    ['md', CHROME_BREAKPOINTS.md],
+    ['lg', CHROME_BREAKPOINTS.lg],
+    ['xl', CHROME_BREAKPOINTS.xl],
+  ] as const)('applies %s AT its breakpoint and not one px below', (tier, width) => {
+    // Tailwind semantics (`>=`), not Mantine's. Both sides of every boundary —
+    // an off-by-one in the comparison flips exactly one of these two.
+    expect(resolveChromeTier(width)).toBe(tier);
+    expect(resolveChromeTier(width - 1)).not.toBe(tier);
+  });
+
+  it('treats an unmeasured / nonsensical width as the most conservative tier', () => {
+    // 0 is what SSR and the first client render see, before the ResizeObserver has
+    // fired. Negative / non-finite are defensive: a detached or display:none node.
+    // Non-finite is included deliberately: a `ResizeObserver` never reports one, so
+    // an Infinity reaching here means the caller is broken, and the safe answer is
+    // the narrow tier — NOT the widest, which is what a bare `>=` ladder would give.
+    for (const width of [0, -1, -1000, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveChromeTier(width)).toBe('base');
+    }
+  });
+});
+
+describe('resolveChromeGeometry', () => {
+  it('reproduces the pre-change hard-coded values at the base tier', () => {
+    // 🔴 LOAD-BEARING, not a snapshot. Because `base` is what an unmeasured chrome
+    // resolves to, these two numbers being the OLD ones is what makes the server
+    // HTML and the first client paint byte-identical to before this change — i.e.
+    // what makes this safe without an `useIsClient` hydration gate.
+    expect(resolveChromeGeometry(0)).toEqual({
+      tier: 'base',
+      nameMaxWidth: 160, // was `maw={160}` on the app-name Text
+      navMenuWidth: 200, // was `width={200}` on the platform-nav Menu
+    });
+  });
+
+  it('uncaps the app name only once the bar is xl-wide', () => {
+    // The 2560px full-page frame is the case this exists for: a 160px cap there is
+    // absurd. Below xl every tier still states a number, so the name can never eat
+    // an unbounded share of a mid-width bar.
+    expect(resolveChromeGeometry(2560).nameMaxWidth).toBeUndefined();
+    expect(resolveChromeGeometry(CHROME_BREAKPOINTS.xl).nameMaxWidth).toBeUndefined();
+    expect(resolveChromeGeometry(CHROME_BREAKPOINTS.xl - 1).nameMaxWidth).toBe(560);
+    for (const w of [0, 360, 480, 768, 1024, 1184]) {
+      expect(typeof resolveChromeGeometry(w).nameMaxWidth).toBe('number');
+    }
+  });
+
+  it('never truncates harder as the bar gets wider', () => {
+    // Monotonicity is the property a hand-edited table loses first. Sampled at
+    // every boundary AND at a midpoint of every band, since a table edit can break
+    // ordering between two rows without moving a boundary.
+    const widths = [0, 240, 479, 480, 600, 767, 768, 900, 1023, 1024, 1100, 1183, 1184,
+      1300, 1439, 1440, 2560];
+    let previousName = -1;
+    let previousMenu = -1;
+    for (const w of widths) {
+      const g = resolveChromeGeometry(w);
+      const name = g.nameMaxWidth ?? Number.POSITIVE_INFINITY;
+      expect(name).toBeGreaterThanOrEqual(previousName);
+      expect(g.navMenuWidth).toBeGreaterThanOrEqual(previousMenu);
+      previousName = name;
+      previousMenu = g.navMenuWidth;
+    }
+    // Positive control on the loop above: it must actually MOVE, or a table that
+    // returned one constant everywhere would satisfy every comparison.
+    expect(resolveChromeGeometry(2560).navMenuWidth).toBeGreaterThan(
+      resolveChromeGeometry(0).navMenuWidth
+    );
+    expect(resolveChromeGeometry(1024).nameMaxWidth).toBeGreaterThan(
+      resolveChromeGeometry(0).nameMaxWidth as number
+    );
+  });
+
+  it('keeps the nav dropdown narrower than the narrowest bar it can render in', () => {
+    // The dropdown is portaled to <body>, so it is bounded by the viewport rather
+    // than by the bar — but the narrowest viewport we support (360px, minus the
+    // page gutters) is the real floor, and the base-tier width must clear it.
+    expect(resolveChromeGeometry(0).navMenuWidth).toBeLessThan(360 - 2 * 16);
+  });
+
+  it('agrees with resolveChromeTier', () => {
+    for (const w of [0, 480, 768, 1024, 1184, 1440, 4000]) {
+      expect(resolveChromeGeometry(w).tier).toBe(resolveChromeTier(w));
+    }
+  });
+});

--- a/src/components/AppBlocks/chromeGeometry.ts
+++ b/src/components/AppBlocks/chromeGeometry.ts
@@ -1,0 +1,130 @@
+/**
+ * Responsive geometry for the App Blocks host chrome (`AppBlockChrome`, exported
+ * from `src/components/AppBlocks/IframeHost.tsx`).
+ *
+ * WHY A SEPARATE PURE MODULE. The chrome is the one piece of App Blocks UI that
+ * renders on two surfaces with wildly different widths — the narrow
+ * `model.sidebar_top` slot and the full-page `/apps/run/<slug>` frame — and it
+ * used to carry hard-coded pixel caps for both. Putting the decision in a pure
+ * function keeps it testable in the node `unit` project, which is the GATING
+ * tier here (the Vitest browser-mode `component` project is report-only in CI),
+ * exactly as `slotReservation.ts` and `selectChromeRecentApps` already do.
+ *
+ * 🔴 ONE BREAKPOINT SCALE, AND IT IS THE PX SCALE. This repo has two scales that
+ * agree on exactly one key:
+ *   - the px scale — `src/utils/breakpoints.json`, mirrored by Tailwind and by
+ *     `mantineContainerSizes` in `src/utils/mantine-css-helpers.ts`:
+ *     xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440
+ *   - Mantine's own stock em scale, which this repo never overrode and which
+ *     every Mantine responsive prop (`visibleFrom`, `hiddenFrom`, the `Grid`
+ *     breakpoints) uses: 576 · 768 · 992 · 1200 · 1408
+ * Only `sm` (768) is the same in both. This module adopts the PX scale and
+ * imports it from `breakpoints.json` rather than restating it, so there is
+ * nothing to drift. Nothing in the chrome may use a Mantine responsive prop —
+ * mixing the two inside one component means two different numbers wearing the
+ * same name.
+ *
+ * 🔴 THE MEASURED BOX IS THE CHROME'S OWN ELEMENT, NOT THE VIEWPORT AND NOT THE
+ * `main` CONTAINER. A `ContainerProvider` ancestor does exist on both surfaces
+ * (`BaseLayout` wraps every page in `<ContainerProvider containerName="main">`),
+ * so `useIsMobile()`'s container default would not throw — but `main` is the
+ * page's whole content column. On the model surface the chrome sits in a sidebar
+ * three to eight times narrower than that, so a query against `main` reports
+ * "desktop" for a 320px-wide bar. A viewport media query is wrong for the same
+ * reason in the other direction. The chrome's own inline size is the only box
+ * that answers the question the chrome is actually asking, on BOTH surfaces —
+ * so the caller measures it with the repo's `useResizeObserver` and feeds it
+ * here. That is the same mechanism `useContainerQuery` uses (a `ResizeObserver`
+ * `inlineSize` compared against the px scale), pointed at the right box.
+ */
+import { breakpoints } from '~/utils/tailwind';
+
+/**
+ * The px breakpoint scale, parsed from the single-sourced JSON. Exported so a
+ * test can pin that this module and Tailwind cannot drift apart.
+ */
+export const CHROME_BREAKPOINTS = {
+  xs: parseInt(breakpoints.xs, 10),
+  sm: parseInt(breakpoints.sm, 10),
+  md: parseInt(breakpoints.md, 10),
+  lg: parseInt(breakpoints.lg, 10),
+  xl: parseInt(breakpoints.xl, 10),
+} as const;
+
+/**
+ * Width tier of the chrome bar itself. `base` is "narrower than the smallest
+ * named breakpoint" — the 360px phone AND the desktop model sidebar both land
+ * there, which is the point: they are the same layout problem.
+ *
+ * Tier semantics follow Tailwind's (a tier applies AT its breakpoint and above),
+ * not Mantine's `hiddenFrom`/`visibleFrom`.
+ */
+export type ChromeSizeTier = 'base' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface ChromeGeometry {
+  tier: ChromeSizeTier;
+  /**
+   * `max-width` (px) for the host-rendered app-name label and for the
+   * breadcrumb's trailing app-name crumb — the two places a publisher-controlled
+   * string is rendered in the bar. `undefined` means UNCAPPED: at `xl` the row
+   * has more slack than any sanitized name can consume, and overflow is still
+   * impossible because both nodes carry Mantine's `truncate`
+   * (`overflow: hidden`, which zeroes a flex item's automatic minimum size) inside
+   * a `minWidth: 0` flex parent.
+   */
+  nameMaxWidth: number | undefined;
+  /**
+   * Width (px) of the platform-nav dropdown. It renders publisher-controlled app
+   * names ("Recently run"), so it is the one dropdown whose useful width depends
+   * on how much room the surface has. The ⋮ overflow menu deliberately keeps its
+   * fixed width — every label in it is short, host-authored and fixed, so there is
+   * nothing width-dependent about it.
+   */
+  navMenuWidth: number;
+}
+
+/**
+ * The tier table. `nameMaxWidth` is non-decreasing across tiers by construction;
+ * a unit test pins that so a future edit cannot make a wider bar truncate harder.
+ *
+ * 🔴 `base` REPRODUCES THE PRE-CHANGE PINNED VALUES (name 160, menu 200). That is
+ * deliberate and load-bearing in two ways: an unmeasured chrome (SSR, and the
+ * first client render before the `ResizeObserver` has fired) resolves to `base`,
+ * so the server HTML and the first client paint are byte-identical to what they
+ * were before this module existed — no hydration mismatch, and no need to pair
+ * this with `useIsClient` the way a `useMediaQuery`-driven value would need to be.
+ * And the narrow model sidebar, the common case, keeps exactly the geometry it
+ * shipped with.
+ */
+const TIERS: ReadonlyArray<{ tier: ChromeSizeTier; min: number } & Omit<ChromeGeometry, 'tier'>> = [
+  { tier: 'xl', min: CHROME_BREAKPOINTS.xl, nameMaxWidth: undefined, navMenuWidth: 280 },
+  { tier: 'lg', min: CHROME_BREAKPOINTS.lg, nameMaxWidth: 560, navMenuWidth: 280 },
+  { tier: 'md', min: CHROME_BREAKPOINTS.md, nameMaxWidth: 440, navMenuWidth: 260 },
+  { tier: 'sm', min: CHROME_BREAKPOINTS.sm, nameMaxWidth: 320, navMenuWidth: 240 },
+  { tier: 'xs', min: CHROME_BREAKPOINTS.xs, nameMaxWidth: 240, navMenuWidth: 220 },
+  { tier: 'base', min: 0, nameMaxWidth: 160, navMenuWidth: 200 },
+];
+
+/**
+ * Resolve the chrome's width tier from its own measured inline size.
+ *
+ * `0` (and anything non-finite or negative — an unmeasured ref, an SSR render,
+ * a `display: none` ancestor) resolves to `base`, the most conservative tier.
+ */
+export function resolveChromeTier(inlineSize: number): ChromeSizeTier {
+  return resolveChromeGeometry(inlineSize).tier;
+}
+
+/** Resolve the whole geometry set from the chrome's own measured inline size. */
+export function resolveChromeGeometry(inlineSize: number): ChromeGeometry {
+  const width = Number.isFinite(inlineSize) && inlineSize > 0 ? inlineSize : 0;
+  // TIERS is ordered widest-first, so the first match is the largest breakpoint
+  // at or below `width`; the `base` row's min of 0 makes the loop total.
+  for (const row of TIERS) {
+    if (width >= row.min) {
+      return { tier: row.tier, nameMaxWidth: row.nameMaxWidth, navMenuWidth: row.navMenuWidth };
+    }
+  }
+  /* istanbul ignore next — unreachable: the `base` row matches every width >= 0 */
+  return { tier: 'base', nameMaxWidth: 160, navMenuWidth: 200 };
+}

--- a/src/components/AppBlocks/slotReservation.ts
+++ b/src/components/AppBlocks/slotReservation.ts
@@ -32,6 +32,24 @@ import type { BlockManifest } from './types';
  *
  * Update alongside any chrome-bar padding / ActionIcon size change in
  * IframeHost.tsx — the slot-reservation test pins this value to catch drift.
+ *
+ * 🔴 THE DERIVATION ABOVE IS WRONG BY 4px, AND THE VALUE IS DELIBERATELY LEFT AT
+ * 35 ANYWAY. Measured 2026-08-31 by rendering the real chrome in Chromium at both
+ * a 360px and a 2560px viewport (`AppBlockChromeResponsive.browser.test.tsx`): the
+ * bar is **31px** tall, not 35, at every width. `--ai-size-sm` is not 26px — the
+ * installed `@mantine/core` 7.17.8 ships
+ * `--ai-size-sm: calc(1.375rem * var(--mantine-scale))` = 22px, and this repo
+ * overrides neither the ActionIcon sizes nor `--mantine-scale`
+ * (`src/providers/ThemeProvider.tsx` sets only `color` / `variant` defaults). So
+ * the true sum is 22 + 8 (`py={4}` ×2) + 1 (border) = 31.
+ *
+ * Left as-is on purpose: 35 > 31 means the slot OVER-reserves, which is the safe
+ * direction for a CLS reservation (a small dead gap, never a shift), and lowering
+ * it changes the server-seeded height of every model-page slot — a behavioural
+ * change on a different surface that wants its own before/after measurement, not a
+ * drive-by edit inside a width-only chrome pass. The browser test asserts the
+ * measured 31 and asserts `CHROME_BAR_PX >= ` it, so the gap stays visible and
+ * cannot silently invert into an UNDER-reservation.
  */
 export const CHROME_BAR_PX = 35;
 
@@ -64,9 +82,7 @@ export interface ReservableInstall {
  *  - only inline blocks   → hasInstall true but reservedHeight 0 (inline
  *    content lays out in-flow and sizes itself; no iframe reserve needed).
  */
-export function computeSlotReservation(
-  installs: ReservableInstall[]
-): SlotReservation {
+export function computeSlotReservation(installs: ReservableInstall[]): SlotReservation {
   if (installs.length === 0) return { hasInstall: false, reservedHeight: 0 };
   let maxMinHeight = 0;
   for (const install of installs) {


### PR DESCRIPTION
## What

**F1 of the App Blocks frame redesign: make the host chrome responsive from phone to ultrawide.**

`AppBlockChrome` (exported from `src/components/AppBlocks/IframeHost.tsx`) is shared by both host surfaces — the model-page `model.sidebar_top` slot and the full-page app frame at `/apps/run/<slug>` — and was the only part of the site with no breakpoint awareness at all: 100% inline style, zero uses of `useIsMobile` / `useContainerQuery` / `visibleFrom` / responsive Tailwind prefixes, while the adjacent `src/components/Apps/` store UI uses `useIsMobile` in ~70 files.

Fixed:

| Before | After |
|---|---|
| app-name `Text` pinned `maw={160}` | responsive cap; **uncapped** once the bar itself is ≥1440px |
| breadcrumb name `Text` pinned `maw={200}` | same responsive cap (it is the same publisher-controlled string) |
| platform-nav `Menu` pinned `width={200}` | 200 → 280 across the scale |
| left group only `minWidth: 0` | `minWidth: 0` **+** `flex: 1 1 auto`, so it claims the row's slack |
| ⋯ trigger had no `flexShrink` | `flexShrink: 0`, matching the sibling it sits opposite |

`wrap="nowrap"` on the root row **stays**, deliberately — see "CHROME_BAR_PX" below.

Deliberately out of scope: no label/icon/breadcrumb-IA changes (F2), no drawer/bottom-sheet swap (F3), no iframe max-width or centering (F5), no change to `useIframeAwareMenu`.

## The breakpoint mechanism, and the `ContainerProvider` determination

**A `ContainerProvider` ancestor does exist on both surfaces.** `src/pages/_app.tsx` wraps `getLayout(<Component/>)` in `<BaseLayout>`, and `BaseLayout` renders `<ContainerProvider id="main" containerName="main">` around every page. Neither host page opts out: the run page is `Page(AppPage, { scrollable: false, subNav: null })` — no `getLayout`, no `standalone` — and the model page likewise. So `useIsMobile()`'s container default would **not** throw and would **not** be silently inert here.

**It is still the wrong box, so this does not use it.** `containerName="main"` measures the page's whole content column. On the model surface the chrome sits in a sidebar three to eight times narrower than that, so a query against `main` reports "desktop" for a ~320px-wide bar — the exact case the fixed 160px cap exists for. A viewport media query is wrong the same way. There is one box that answers the question the chrome is actually asking, on both surfaces: **the chrome's own element.**

So the chrome measures itself with the repo's `useResizeObserver` — the same primitive `ContainerProvider` itself uses — and feeds the inline size to a pure resolver in the new `chromeGeometry.ts`. That is `useContainerQuery`'s mechanism (a `ResizeObserver` `inlineSize` compared against the px scale), pointed at the right element.

Two corroborating facts:
- The existing `AppBlockChrome.browser.test.tsx` renders the chrome with no `ContainerProvider`; `useIsMobile()` there would throw `missing ContainerProvider`. `AppListingsMarketplaceBody.browser.test.tsx` already mocks `useIsMobile` for precisely this reason.
- Because the unmeasured width (`0`) resolves to the `base` tier, whose values **are** the pre-change constants (160 / 200), SSR and the first client paint are byte-identical to before. No hydration mismatch, so no `useIsClient` gate is needed — unlike a `useMediaQuery`-driven value, which would need one.

**The px scale, single-sourced.** `chromeGeometry.ts` imports `breakpoints` from `src/utils/tailwind.ts` (which reads `src/utils/breakpoints.json`, the same file `tailwind.config.js` `require()`s): `xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440`. Mantine's own never-overridden em scale (576/768/992/1200/1408) agrees on `sm` only, which is why `useIsMobile`'s `'sm'` default is safe by coincidence. A unit test pins the five numbers against `breakpoints.json` **and** asserts four of them differ from Mantine's, so the two scales cannot be quietly blended. Nothing in the chrome uses a Mantine responsive prop.

## `CHROME_BAR_PX` — unchanged at 35, and a pre-existing 4px error found

The change is width-only; the bar's resting height does not move, asserted at a rendered pixel level at both viewports.

Writing that guard surfaced a **pre-existing** defect. `slotReservation.ts` derives `CHROME_BAR_PX = 35` from "`--ai-size-sm` = rem(26px) = 26px". The installed `@mantine/core` **7.17.8** ships `--ai-size-sm: calc(1.375rem * var(--mantine-scale))` = **22px**, and this repo overrides neither the ActionIcon sizes nor `--mantine-scale` (`ThemeProvider.tsx` sets only `color`/`variant` defaults). The bar measures **31px**, at both 360px and 2560px, identically before and after this change.

Left at 35 on purpose: 35 > 31 is an **over**-reservation, the safe direction for a CLS reserve, and lowering it changes the server-seeded height of every model-page slot — a behavioural change on a different surface that deserves its own before/after, not a drive-by edit inside a width-only pass. The derivation comment is corrected in place, the browser guard pins the measured 31, and it asserts `CHROME_BAR_PX >= 31` so the gap can never silently invert into an under-reservation.

## Coverage, and the harness

**The existing suites were structurally blind to this dimension.** `AppsPageLayout.geometry.browser.test.tsx` pins `page.viewport(1440, 900)` and `test/component-setup.tsx` sets no viewport at all, so a width-dependent defect passes vacuously in both. The new suite runs the same component at **360×780** and **2560×1200**, names the viewport in every assertion message, and adds a third point that is not a viewport at all: the chrome constrained to a **340px** wrapper *at* the 2560px viewport.

Red-at-base measured by restoring **only** `IframeHost.tsx` to `dd8b18354e` and re-running the new suite unchanged — so the red is attributable to the component's behaviour, not to a module or selector that does not exist at base.

| Test | Base | HEAD | Failing assertion at base |
|---|---|---|---|
| `REGRESSION — at 2560x1200 the app name is not clamped to the legacy 160px cap` | 🔴 | ✅ | `at 2560px the app name must not carry a fixed max-width: expected '160px' to be 'none'` |
| `REGRESSION — at 2560x1200 the platform-nav dropdown is wider than its legacy fixed 200px` | 🔴 | ✅ | `at 2560px the platform-nav dropdown must be wider than the legacy 200px: expected 200 to be greater than 200` |
| `CONTROL — a 340px bar stays narrow even at a 2560px viewport` | ✅ | ✅ | — passes at base; **not** regression coverage |
| `at 360x780 the row stays on one line, does not overflow, keeps its controls at full size` | ✅ | ✅ | — invariant guard |
| `INVARIANT GUARD — resting height unchanged` (phone, ultrawide) | ✅ | ✅ | — invariant guard |

The 340px control is the one that earns its keep despite passing at base: it is the **discriminating control on the mechanism**. Had this been built on a viewport media query, or on the `main` `ContainerProvider`, that test would go red while both regression tests stayed green.

`__tests__/chromeGeometry.test.ts` (13 tests, node `unit` tier — the **gating** tier; the browser `component` project is report-only) enumerates both sides of every breakpoint, the unmeasured/non-finite fallbacks, monotonicity with a positive control that the table actually moves, and the scale drift guard. Its header states plainly that it is **not** regression coverage: the module is new, so it fails at base for the trivial reason that it does not resolve.

## Verification

Run in the repo's `nix develop` shell (node 24.19.0 / pnpm 10.34.5), submodule initialised, `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` pointed at the nix-store chromium 1228 headless shell.

- `pnpm typecheck` — **0 type errors** (119s). Instrument validated: a planted `const planted: number = '…'` in `chromeGeometry.ts` produced `src/components/AppBlocks/chromeGeometry.ts(115,9): error TS2322`, exit 2, then was reverted.
- `scripts/ci/typecheck-tests-gate.mjs` (already red on `main`) — **base 1010 errors / 188 files → HEAD 1010 / 188**. Unchanged; the new `__tests__` file contributes 0. Positive control reported 1467 test files at base, 1468 at HEAD.
- Node `unit`, all of `src/components/AppBlocks/` — **39 files / 658 tests passed**, including `pageRunScrollContract.test.ts`, `slotReservation.test.ts` and the `iframeAwareMenu` ledger.
- Browser `component`, all of `src/components/AppBlocks/` — **35 files / 420 tests passed** (collected count read, not an exit code).
  - Two intermediate runs of this project on a heavily loaded dev box (load average 42–46 on 24 cores) failed as `Failed to connect to the browser session … within the timeout` and once as `Test Files (35) / Tests no tests` — a collection failure, i.e. zero tests executed, not zero failures. Discriminated as load rather than a defect: capping workers left the same tree green under the same load (3 files / 36 tests), and the full 35/420 above was re-run at load 17 on the exact pushed commit.
- New responsive suite — **6/6 at HEAD**; **2 failed / 4 passed** against the base component.
- `eslint` on the four changed paths — 0 problems, with the file count (`files=4`) read to confirm word-splitting, and a negative control on a scratch file that correctly reported 1 problem.
- **Prettier** — the three ADDED files (`chromeGeometry.ts`, `chromeGeometry.test.ts`, `AppBlockChromeResponsive.browser.test.tsx`) are clean; that is the set the lint workflow gates as **BLOCKING**. The two MODIFIED files are `continue-on-error` by design, and `IframeHost.tsx` is one of the ~789 `src` files already failing `prettier --check` on `main` — running `--write` on it rewrites 641 lines of untouched code, so it is deliberately left alone.
  - This was caught by CI, not locally, and the reason is worth recording: `scripts/prettier-changed.mjs` scopes itself to **uncommitted** files, so it reports clean the moment you commit. Checking a committed change needs `npx prettier --check <paths>` directly.

**CI** settled at 18/18 checks terminal — 17 SUCCESS, 1 SKIPPED (`Typecheck (main pushes / fork PRs / non-main base)`, skipped by design on a `main`-based PR), 0 failures. That includes `preview / component-tests`, so the browser tier is green in CI too. The rollup grew 4 → 13 → 15 → 18 during polling, so the settle was gated on a minimum count as well as on every check holding a terminal conclusion.

## Not verified

- **No real-browser check against a running app.** Everything here is component-level in Chromium under the Vitest browser harness. That harness loads `@mantine/core/styles.css` but not Tailwind or the full app cascade, so the chrome's geometry inside the actual model-page sidebar and the actual `/apps/run` frame has not been observed end to end — including whether the model sidebar is wide enough at 2560px to leave the `base` tier at all.
- **The 31px measurement is harness-derived.** It follows from the installed Mantine token and the absence of any theme/scale override, both checked in source, but it was not measured against production HTML.
