### PR TITLE
fix(model-page): request 800px previews in showcase and review carousels

### DIFF
--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -167,7 +167,7 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
                               >
                                 <ImagePreview
                                   image={image}
-                                  edgeImageProps={{ width: 450 }}
+                                  edgeImageProps={{ width: 800 }}
                                   aspectRatio={(image.width ?? 1) / (image.height ?? 1)}
                                   // radius="md"
                                   style={{ width: '100%' }}

--- a/src/components/ResourceReview/ResourceReviewCarousel.tsx
+++ b/src/components/ResourceReview/ResourceReviewCarousel.tsx
@@ -86,7 +86,7 @@ export function ResourceReviewCarousel({
                                 name={image.name ?? image.id.toString()}
                                 alt={image.name ?? undefined}
                                 type={image.type}
-                                width={450}
+                                width={800}
                                 placeholder="empty"
                                 style={{ width: '100%', objectPosition: 'top' }}
                               />


### PR DESCRIPTION
## Why

[Article 34280 ("Awfully Compressed")](https://civitai.com/articles/34280/awfully-compressed) — and a similar one three months earlier — reports that model-page showcase images look blurry/out-of-focus compared to the original, especially for detailed painting styles.

Investigated: the compression pipeline is behaving exactly as configured (the `450x<auto>_so` variant is WebP q80 — re-encoding the reported image at q80 reproduces our bytes almost exactly, and the NetVips migration changed no quality values). The actual cause is that `ModelCarousel` hardcodes `width: 450`, sized for feed cards, while the carousel renders much larger — so the browser upscales the preview ~2x on large/hi-DPI screens, and that upscale is what reads as blur.

## What

- `ModelCarousel` and `ResourceReviewCarousel` now request `width: 800` — an existing rung on the image-cacher width ladder, so variants generate lazily with no backend change.
- No explicit `optimized` flag: above the 450 auto-optimize threshold, the user's `imageFormat` profile preference applies, same as other content surfaces (explicit `optimized: true` is reserved for chrome assets like stickers/avatars/OG).
- `CollectionShowcase` deliberately left at 450: it renders small thumbnails in a 300px-tall scroll area.

Measured on the reported image via the live edge: optimized users get an 800px WebP q80 at ~29kB (vs 10.5kB at 450), unoptimized users an 800px JPEG q90 at ~110kB. Feed cards are unchanged.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run test:unit:run` — 23,701 passed (no suite covers these components; this is the full-suite gate)
- Fetched both 800px variants of the article's example image through the production edge to confirm dimensions, format, and size

🤖 Generated with [Claude Code](https://claude.com/claude-code)