### PR TITLE
fix(challenges): stop the health check false-alarming at every handover

### DIFF
--- a/src/server/jobs/__tests__/challenge-health-check.test.ts
+++ b/src/server/jobs/__tests__/challenge-health-check.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isFlipt: vi.fn(async () => true),
+  fetch: vi.fn(async () => new Response(null, { status: 204 })),
+}));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mocks.isFlipt,
+  FLIPT_FEATURE_FLAGS: { CHALLENGE_PLATFORM_ENABLED: 'challenge-platform-enabled' },
+}));
+// LOGGING is read by createLogger at module load, so it has to be here even though the alert
+// webhook is the only value this suite cares about.
+vi.mock('~/env/server', () => ({
+  env: { DISCORD_WEBHOOK_MOD_ALERTS: 'https://discord.test/webhook', LOGGING: [] },
+}));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (name: string, cron: string, fn: () => Promise<unknown>) => ({ name, cron, run: fn }),
+}));
+
+import { challengeHealthCheckJob } from '~/server/jobs/challenge-health-check';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+type Health = {
+  hasUpcoming: boolean;
+  hasRecent: boolean;
+  nextScheduledAt: Date | null;
+  lastActivatedAt: Date | null;
+};
+
+const healthy: Health = {
+  hasUpcoming: true,
+  hasRecent: true,
+  nextScheduledAt: new Date('2026-09-01T00:00:00Z'),
+  lastActivatedAt: new Date('2026-08-31T00:00:00Z'),
+};
+
+function answerWith(row: Partial<Health>) {
+  dbMock.dbRead.$queryRaw.mockResolvedValue([{ ...healthy, ...row }]);
+}
+
+/** The tagged-template args the job actually hands the database: [strings, ...binds]. */
+function queryCall() {
+  const [strings, ...binds] = dbMock.dbRead.$queryRaw.mock.calls[0] as [string[], ...unknown[]];
+  return { sql: strings.join('?'), binds };
+}
+
+function warnings() {
+  return loggingMock.logToAxiom.mock.calls
+    .map(([arg]) => arg as { type?: string; name?: string; message?: string })
+    .filter((arg) => arg.name === 'challenge-health-check' && arg.type === 'warning');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', mocks.fetch);
+  mocks.isFlipt.mockResolvedValue(true);
+  answerWith({});
+});
+
+describe('challenge-health-check query shape', () => {
+  // The 2026-08-28..31 false alarms were entirely inside this SQL, so mocking $queryRaw cannot
+  // reach them. What IS reachable is the arguments the job sends: assert those, not the constants,
+  // so a revert of either decision fails here rather than in Discord four hours later.
+  it('gives the recent-start window more than the 24h challenge cadence', async () => {
+    await challengeHealthCheckJob.run();
+
+    const { binds } = queryCall();
+    const windowHours = binds.find((b) => typeof b === 'number' && b !== 48);
+    expect(windowHours).toBeGreaterThan(24);
+  });
+
+  it('counts a started challenge in any post-activation state, never Scheduled', async () => {
+    await challengeHealthCheckJob.run();
+
+    const statuses = queryCall().binds.find(Array.isArray) as string[];
+    // Scheduled past its own startsAt is the failure this job watches for — counting it would
+    // make the check unfalsifiable.
+    expect(statuses).not.toContain('Scheduled');
+    // The outgoing challenge is routinely mid-completion when this job reads at the 00:00 tick.
+    expect(statuses).toEqual(expect.arrayContaining(['Active', 'Completing', 'Completed']));
+  });
+
+  it('drives the recent-start check off that status list, not an Active literal', async () => {
+    await challengeHealthCheckJob.run();
+
+    const hasRecentArm = queryCall().sql.split('AS "hasUpcoming"')[1].split('AS "hasRecent"')[0];
+    expect(hasRecentArm).not.toMatch(/status\s*=\s*'Active'/);
+    expect(hasRecentArm).toMatch(/status::text\s*=\s*ANY\(/);
+  });
+});
+
+describe('challenge-health-check alerting', () => {
+  it('stays quiet when a challenge started and one is scheduled', async () => {
+    const result = await challengeHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: true });
+    expect(warnings()).toHaveLength(0);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('alerts when nothing started inside the window', async () => {
+    answerWith({ hasRecent: false, lastActivatedAt: null });
+
+    const result = await challengeHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, failures: 1 });
+    expect(warnings()[0].message).toContain('Not started');
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('alerts when the schedule ahead is empty', async () => {
+    answerWith({ hasUpcoming: false, nextScheduledAt: null });
+
+    const result = await challengeHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, failures: 1 });
+    expect(warnings()[0].message).toContain('Not prepared');
+  });
+
+  it('reports both conditions in one alert', async () => {
+    answerWith({ hasUpcoming: false, hasRecent: false });
+
+    const result = await challengeHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, failures: 2 });
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('skips entirely when the challenge platform is off', async () => {
+    mocks.isFlipt.mockResolvedValue(false);
+
+    const result = await challengeHealthCheckJob.run();
+
+    expect(result).toMatchObject({ skipped: true });
+    expect(dbMock.dbRead.$queryRaw).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/challenge-health-check.ts
+++ b/src/server/jobs/challenge-health-check.ts
@@ -20,7 +20,16 @@ import { createLogger } from '~/utils/logging';
 const log = createLogger('jobs:challenge-health-check', 'yellow');
 
 const UPCOMING_WINDOW_HOURS = 48;
-const RECENT_WINDOW_HOURS = 24;
+
+// Must exceed the 24h challenge cadence. This job shares the 00:00 tick with `challenge-activation`,
+// so the incoming challenge is still `Scheduled` while the outgoing one's `startsAt` is already
+// *exactly* 24h old — under a 24h window neither answers, which false-alarmed daily 2026-08-28..31.
+const RECENT_WINDOW_HOURS = 26;
+
+// A challenge that started and has since finished still answers "did one start" — the outgoing one
+// is often mid-completion at the handover. `Scheduled` stays out: past its own `startsAt`, that IS
+// the failure being watched for.
+const STARTED_STATUSES = ['Active', 'Completing', 'Completed'];
 
 type HealthRow = {
   hasUpcoming: boolean;
@@ -40,7 +49,7 @@ async function readChallengeHealth() {
       ) AS "hasUpcoming",
       EXISTS (
         SELECT 1 FROM "Challenge"
-        WHERE status = 'Active' AND source = 'System'
+        WHERE status::text = ANY(${STARTED_STATUSES}::text[]) AND source = 'System'
           AND "startsAt" <= now()
           AND "startsAt" > now() - (${RECENT_WINDOW_HOURS} || ' hours')::interval
       ) AS "hasRecent",
@@ -50,7 +59,8 @@ async function readChallengeHealth() {
       ) AS "nextScheduledAt",
       (
         SELECT max("startsAt") FROM "Challenge"
-        WHERE status = 'Active' AND source = 'System' AND "startsAt" <= now()
+        WHERE status::text = ANY(${STARTED_STATUSES}::text[]) AND source = 'System'
+          AND "startsAt" <= now()
       ) AS "lastActivatedAt"
   `;
 
@@ -95,7 +105,7 @@ async function checkChallengeHealth() {
 
   if (!health.hasRecent) {
     failures.push(
-      `**Not started** — no \`Active\` system challenge began in the last ${RECENT_WINDOW_HOURS}h. ` +
+      `**Not started** — no system challenge began in the last ${RECENT_WINDOW_HOURS}h. ` +
         `Check \`challenge-activation\` (0 * * * *). ` +
         `Last activated: ${health.lastActivatedAt?.toISOString() ?? 'never'}.`
     );


### PR DESCRIPTION
## The alarm

`challenge-health-check` posted **"Not started — no `Active` system challenge began in the last 24h"** to mod-alerts at 00:00 UTC on 2026-08-28, 29, 30 and 31.

The pipeline was healthy on every one of those days. Challenges 460, 467, 469 and 474 each started on time, were judged, and paid three winners.

## Why it fired

`hasRecent` required an `Active` system challenge whose `startsAt` fell inside a 24h window. Both halves fail at the daily handover — and this job shares the 00:00 tick with `challenge-activation`:

- **incoming** challenge — `startsAt` seconds in the past, still `Scheduled` because activation hadn't flipped it yet → fails `status = 'Active'`
- **outgoing** challenge — `startsAt` *exactly* 24h old, so `"startsAt" > now() - 24h` excludes it by however many seconds the job ran late (5.7s on Aug 31)

Nothing else is in range, so `hasRecent` goes false and the check pages.

Replaying the four alert instants against prod — the outgoing challenge each time:

| alert (UTC) | outgoing | state at that instant | inside 24h window |
|---|---|---|---|
| 2026-08-28 00:00:06.781 | 452 | Completing | ✗ |
| 2026-08-29 00:00:10.051 | 460 | Completing | ✗ |
| 2026-08-30 00:00:11.818 | 467 | Active | ✗ |
| 2026-08-31 00:00:05.679 | 469 | Active | ✗ |

Both changes below are load-bearing: Aug 30/31 needed only the window, Aug 28/29 also needed the status set because the outgoing challenge had already entered completion.

## Changes

`src/server/jobs/challenge-health-check.ts`

- `RECENT_WINDOW_HOURS` **24 → 26**. The window has to outlast the challenge cadence, or the outgoing challenge can never answer while the incoming one is mid-activation.
- `hasRecent` and `lastActivatedAt` now match `status::text = ANY(ARRAY['Active','Completing','Completed'])` instead of `status = 'Active'`. A challenge that started and has since finished still answers "did one start". **`Scheduled` stays excluded on purpose** — past its own `startsAt`, that is exactly the failure this job exists to catch.
- Alert text drops the now-inaccurate `` `Active` `` qualifier.

No schema change, no migration.

## Does it still catch a real outage?

Yes, marginally later. If activation dies, the last successful start ages out of the 26h window and the next 6-hourly run alerts — worst case ~8h later than before, traded against a false page every single day.

`hasUpcoming` is untouched and still covers an empty schedule ahead.

## Verification

- Ran the new query against prod: `hasRecent: true`, `lastActivatedAt: 2026-08-31T00:00:00Z`. The enum→text cast works.
- Reverted both decisions and re-ran the suite: fails with `expected 24 to be greater than 24` and the `hasRecent` arm printed showing `status = 'Active'`. Restored; diff is exactly these changes.
- New suite `src/server/jobs/__tests__/challenge-health-check.test.ts` — 8 tests. Neighbouring challenge suites: 59 passed. LSP clean.

**Known limit of the tests.** The defect lives entirely in the SQL, and a mocked `$queryRaw` cannot reach it. The suite therefore asserts the *arguments the job hands the database* — window value, status list, the shape of the `hasRecent` arm — which is what fails on a revert. Nothing in CI exercises the predicate against real rows; the prod replay above is the only thing that did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnFnLu369fHmf7dUQBHMXm
