### PR TITLE
fix(training): invert label preference logic for base model types

### DIFF
--- a/src/components/Training/Form/TrainingImagesTagViewer.tsx
+++ b/src/components/Training/Form/TrainingImagesTagViewer.tsx
@@ -52,7 +52,7 @@ export const labelDescriptions: { [p in LabelTypes]: React.ReactNode } = {
       <Text fs="italic">Ex: &quot;dolphin, ocean, jumping, gorgeous scenery&quot;</Text>
       <Text component="div" mt="sm">
         Preferred for <Badge color="violet">SD1</Badge> and <Badge color="grape">SDXL</Badge>{' '}
-        models.
+        models only.
       </Text>
     </Stack>
   ),
@@ -64,8 +64,8 @@ export const labelDescriptions: { [p in LabelTypes]: React.ReactNode } = {
         a setting sun.&quot;
       </Text>
       <Text component="div" mt="sm">
-        Preferred for <Badge color="red">Flux</Badge>, <Badge color="pink">SD3</Badge>, and{' '}
-        <Badge color="teal">Video</Badge> models.
+        Preferred for <Badge color="red">Flux</Badge>, <Badge color="pink">SD3</Badge>,{' '}
+        <Badge color="teal">Video</Badge>, <Badge color="cyan">Audio</Badge>, and all newer models.
       </Text>
     </Stack>
   ),

--- a/src/components/Training/Form/TrainingSubmit.tsx
+++ b/src/components/Training/Form/TrainingSubmit.tsx
@@ -81,6 +81,7 @@ import type { TrainingModelData } from '~/types/router';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { abbreviateNumber, numberWithCommas } from '~/utils/number-helpers';
 import {
+  baseTypePrefersCaptions,
   formatTrainingValidationError,
   getTrainingFields,
   getAiToolkitEcosystem,
@@ -102,21 +103,6 @@ import { isDefined } from '~/utils/type-guards';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
 
 const maxRuns = 5;
-
-const prefersCaptions: TrainingBaseModelType[] = [
-  'flux',
-  'flux2',
-  'flux2klein',
-  'sd35',
-  'hunyuan',
-  'wan',
-  'chroma',
-  'zimage',
-  'ernie',
-  'hidream-o1',
-  'acestep15',
-  'acestep15xl',
-];
 
 export const TrainingFormSubmit = ({ model }: { model: NonNullable<TrainingModelData> }) => {
   const thisModelVersion = model.modelVersions[0];
@@ -1170,7 +1156,7 @@ export const TrainingFormSubmit = ({ model }: { model: NonNullable<TrainingModel
         </Stack>
       )}
 
-      {prefersCaptions.includes(selectedRun.baseType) &&
+      {baseTypePrefersCaptions(selectedRun.baseType) &&
         thisMetadata?.labelType !== 'caption' &&
         (thisMetadata?.numCaptions ?? 0) > 0 && (
           <AlertWithIcon
@@ -1199,7 +1185,7 @@ export const TrainingFormSubmit = ({ model }: { model: NonNullable<TrainingModel
           </AlertWithIcon>
         )}
 
-      {!prefersCaptions.includes(selectedRun.baseType) &&
+      {!baseTypePrefersCaptions(selectedRun.baseType) &&
         thisMetadata?.labelType !== 'tag' &&
         (thisMetadata?.numCaptions ?? 0) > 0 && (
           <AlertWithIcon

--- a/src/utils/training.ts
+++ b/src/utils/training.ts
@@ -696,6 +696,15 @@ export const isAiToolkitEnabled = (
   return flagKey ? !!features[flagKey] : false;
 };
 
+// Base model types trained on short, comma-separated tags (legacy kohya SD1.5/SDXL).
+// Every other base type — the AI-Toolkit image ecosystems, video, and audio — trains on
+// natural-language captions, so caption preference is the complement rather than a second
+// hand-maintained list that would drift as models are added.
+export const tagLabelBaseTypes: TrainingBaseModelType[] = ['sd15', 'sdxl'];
+
+export const baseTypePrefersCaptions = (baseType: TrainingBaseModelType): boolean =>
+  !(tagLabelBaseTypes as readonly string[]).includes(baseType);
+
 // Check if base model supports AI Toolkit
 export const isAiToolkitSupported = (baseType: TrainingBaseModelType): boolean => {
   // AI Toolkit supports these base model types (flux2 is not included - it only uses rapid)

--- a/src/utils/training/__tests__/label-preference.test.ts
+++ b/src/utils/training/__tests__/label-preference.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { baseTypePrefersCaptions } from '~/utils/training';
+
+describe('baseTypePrefersCaptions', () => {
+  it('classifies only the legacy kohya SD1.5/SDXL base types as tag-based', () => {
+    expect(baseTypePrefersCaptions('sd15')).toBe(false);
+    expect(baseTypePrefersCaptions('sdxl')).toBe(false);
+  });
+
+  it('classifies AI-Toolkit, video, and audio base types as caption-based', () => {
+    // These were all absent from the old hand-maintained `prefersCaptions` allowlist and
+    // therefore showed the inverted alert — the regression this change fixes.
+    for (const baseType of [
+      'krea2',
+      'flux',
+      'qwen',
+      'anima',
+      'boogu',
+      'mageflow',
+      'ideogram4',
+      'wan',
+      'ltx25',
+      'minimaxh3',
+      'acestep15',
+    ] as const) {
+      expect(baseTypePrefersCaptions(baseType)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
The training form used an incomplete allowlist to identify models preferring
captions. New models not on this list (e.g., Krea2) incorrectly showed alerts
recommending tags instead of captions.

Inverted the logic: only sd15 and sdxl use tag-based labels (legacy kohya).
All other model types—including newer AI-Toolkit, video, and audio models—now
correctly use captions. This eliminates fragile list maintenance and
automatically supports new models.

Updated UI label descriptions to clarify preferences. Extracted the
baseTypePrefersCaptions helper to src/utils/training.ts with comprehensive
test coverage.

Refs: 868kyujc6