### PR TITLE
fix(tags): give every ?tags= feed a way back out

### DIFF
--- a/src/components/Image/Filters/ImageFeedTagBar.tsx
+++ b/src/components/Image/Filters/ImageFeedTagBar.tsx
@@ -38,7 +38,7 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
 
   // `!!` is load-bearing: FeatureAccess is sparse, so an off flag is `undefined` rather
   // than `false`, and react-query reads `enabled: undefined` as enabled.
-  const { data } = trpc.tag.getFeedTagBar.useQuery(undefined, {
+  const { data, isLoading: chipsLoading } = trpc.tag.getFeedTagBar.useQuery(undefined, {
     enabled: !!features.feedTagBar,
   });
   const { items: tags, loadingPreferences } = useApplyHiddenPreferences({
@@ -81,16 +81,25 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
   // reservation and NO chips in that state — the All chip included.
   const chipsHeld = loadingPreferences || !tags.length;
 
+  // SETTLED and still empty — a failed or empty chip fetch, which is permanent, not the
+  // in-flight state. `chipsHeld` alone would put the control on screen for every viewer's
+  // first paint (`loadingPreferences` is the preferences query's `isLoading`, true on
+  // mount for everyone) and take it away again a moment later.
+  const chipsGone = !chipsLoading && !loadingPreferences && !tags.length;
+
   return (
-    <>
-      <TagChipRow
-        items={tags.map((tag) => ({ id: tag.id, label: tag.name }))}
-        activeId={activeId}
-        onSelect={handleSelect}
-        onClear={handleClear}
-        loading={chipsHeld}
-      />
-      {chipsHeld && <ActiveTagFilter tagIds={tagIds} />}
-    </>
+    <TagChipRow
+      items={tags.map((tag) => ({ id: tag.id, label: tag.name }))}
+      activeId={activeId}
+      onSelect={handleSelect}
+      onClear={handleClear}
+      loading={chipsHeld}
+      // Inside the reservation, so standing in for the chips costs no extra height.
+      // Uninstrumented on purpose: `Feed_TagBar_Click` measures the BAR, and the bar's
+      // fate is being decided on that series (868kv1b9m). Counting a press of a control
+      // that appears only when the bar has no chips would inflate the number the decision
+      // reads.
+      placeholder={chipsGone ? <ActiveTagFilter tagIds={tagIds} /> : null}
+    />
   );
 }

--- a/src/components/Image/Filters/ImageFeedTagBar.tsx
+++ b/src/components/Image/Filters/ImageFeedTagBar.tsx
@@ -2,6 +2,7 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { useImageQueryParams } from '~/components/Image/image.utils';
 import type { TagChipRowItem } from '~/components/Tags/TagChipRow';
 import { TagChipRow } from '~/components/Tags/TagChipRow';
+import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { trpc } from '~/utils/trpc';
@@ -15,10 +16,13 @@ type FeedTagBarFeed = 'images' | 'videos';
  * is an AND across tags, which lands on an empty feed for most pairs here, and it was
  * undiscoverable anyway.
  *
- * The `All` chip is not decoration — it is the only UI on these feeds that can widen a
- * `?tags=` deep link back out (`ActiveTagFilter`, written for that job, is mounted
- * nowhere; ClickUp 868kuq3jk). It clears whatever is in `?tags=`, including ids that are
- * not chips on this bar.
+ * The `All` chip is not decoration — it is what widens a `?tags=` deep link back out on
+ * these feeds. It clears whatever is in `?tags=`, including ids that are not chips on
+ * this bar.
+ *
+ * `feedTagBar` is a kill switch for a bar that may yet be removed, so the off branch
+ * falls back to `ActiveTagFilter` rather than rendering nothing: turning the bar off must
+ * not take the only escape hatch from a `?tags=` deep link with it (ClickUp 868kuq3jk).
  */
 export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
   const { trackAction } = useTrackEvent();
@@ -68,7 +72,7 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
     replace({ tags: [] });
   };
 
-  if (!features.feedTagBar) return null;
+  if (!features.feedTagBar) return <ActiveTagFilter />;
 
   return (
     <TagChipRow

--- a/src/components/Image/Filters/ImageFeedTagBar.tsx
+++ b/src/components/Image/Filters/ImageFeedTagBar.tsx
@@ -20,9 +20,10 @@ type FeedTagBarFeed = 'images' | 'videos';
  * these feeds. It clears whatever is in `?tags=`, including ids that are not chips on
  * this bar.
  *
- * `feedTagBar` is a kill switch for a bar that may yet be removed, so the off branch
- * falls back to `ActiveTagFilter` rather than rendering nothing: turning the bar off must
- * not take the only escape hatch from a `?tags=` deep link with it (ClickUp 868kuq3jk).
+ * So `ActiveTagFilter` stands in wherever that chip is NOT on the page — the flag being
+ * off, and the chip row being held for its loading reservation, which is also the state a
+ * failed chip-list fetch leaves the bar in permanently. Neither may take the only escape
+ * hatch from a `?tags=` deep link with it (ClickUp 868kuq3jk).
  */
 export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
   const { trackAction } = useTrackEvent();
@@ -72,18 +73,24 @@ export function ImageFeedTagBar({ feed }: { feed: FeedTagBarFeed }) {
     replace({ tags: [] });
   };
 
-  if (!features.feedTagBar) return <ActiveTagFilter />;
+  if (!features.feedTagBar) return <ActiveTagFilter tagIds={tagIds} />;
+
+  // Holding the row until preferences resolve keeps a tag the viewer has personally
+  // hidden from flashing as a chip: the chip list is edge-cached and the preferences are
+  // a per-user fetch, so the list usually wins the race. `TagChipRow` draws the height
+  // reservation and NO chips in that state — the All chip included.
+  const chipsHeld = loadingPreferences || !tags.length;
 
   return (
-    <TagChipRow
-      items={tags.map((tag) => ({ id: tag.id, label: tag.name }))}
-      activeId={activeId}
-      onSelect={handleSelect}
-      onClear={handleClear}
-      // Holding the row until preferences resolve keeps a tag the viewer has personally
-      // hidden from flashing as a chip: the chip list is edge-cached and the preferences
-      // are a per-user fetch, so the list usually wins the race.
-      loading={loadingPreferences || !tags.length}
-    />
+    <>
+      <TagChipRow
+        items={tags.map((tag) => ({ id: tag.id, label: tag.name }))}
+        activeId={activeId}
+        onSelect={handleSelect}
+        onClear={handleClear}
+        loading={chipsHeld}
+      />
+      {chipsHeld && <ActiveTagFilter tagIds={tagIds} />}
+    </>
   );
 }

--- a/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
+++ b/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   // Sparse, exactly as FeatureAccess is: an off flag is ABSENT, so it reads `undefined`.
   // Driving the off case with `false` would test a state production never produces.
   feedTagBar: true as boolean | undefined,
+  chipsLoading: false,
   getFeedTagBar: vi.fn(),
 }));
 
@@ -40,7 +41,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
         // markup would still be caught here rather than looking like a skipped fetch.
         useQuery: (input: unknown, options?: { enabled?: boolean }) => {
           mocks.getFeedTagBar(input, options);
-          return { data: mocks.tags };
+          return { data: mocks.tags, isLoading: mocks.chipsLoading };
         },
       },
     },
@@ -136,6 +137,7 @@ describe('ImageFeedTagBar', () => {
     mocks.hiddenTagIds = [];
     mocks.maxNsfwLevel = 1;
     mocks.loadingPreferences = false;
+    mocks.chipsLoading = false;
     mocks.tags = [
       { id: 4, name: 'anime', nsfwLevel: 1 },
       { id: 5248, name: 'realistic', nsfwLevel: 1 },
@@ -196,18 +198,58 @@ describe('ImageFeedTagBar', () => {
     expect(mocks.getFeedTagBar).toHaveBeenCalledWith(undefined, { enabled: true });
   });
 
-  // The other state with no `All` chip, and the one that is NOT transient: `TagChipRow`
-  // draws the reservation and no children while `loading`, and the bar holds it whenever
-  // the chip list is empty — which is where a failed or empty `getFeedTagBar` leaves it
-  // for good. The reservation must survive too, or fixing the dead end reintroduces the
-  // CLS the reservation exists for.
-  it('falls back to the clear control while the chip row is held', () => {
+  // The other state with no `All` chip: `TagChipRow` draws the reservation and no
+  // children while `loading`, and a failed or empty `getFeedTagBar` leaves the bar there
+  // for good. The control goes INSIDE the reservation, so it costs no extra height.
+  it('falls back to the clear control once the chip fetch has settled empty', () => {
     mocks.tags = [];
     mocks.query = { tags: ['999999'], sort: 'Newest' };
     const container = render();
 
     expect(buttonLabels(container)).toEqual(['Clear 1 tag filter']);
     expect(reservedRows(container)).toHaveLength(1);
+    // Inside the reserved row, not beside it — beside it is a shift on a page whose
+    // whole reason for reserving 26px is not to have one.
+    expect(reservedRows(container)[0].querySelector('button')).not.toBeNull();
+  });
+
+  // 🔴 The two states this must NOT fire in, and why the flag is `chipsGone` rather than
+  // `chipsHeld`: both are in-flight, both end with chips on screen, and rendering the
+  // control in either one puts a button on first paint and takes it away again.
+  // `loadingPreferences` is the preferences query's `isLoading` — true on mount for
+  // EVERY viewer — so the naive version flashes on every `?tags=` deep link, not just
+  // the failure case.
+  it('does not render the clear control while the chip fetch is in flight', () => {
+    mocks.tags = [];
+    mocks.chipsLoading = true;
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual([]);
+  });
+
+  it('does not render the clear control while hidden preferences are loading', () => {
+    mocks.loadingPreferences = true;
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual([]);
+  });
+
+  // A decision, not an oversight: `Feed_TagBar_Click` is the series the bar's removal is
+  // being decided on (868kv1b9m), and it measures the BAR. A press of a control that only
+  // appears when the bar has no chips is not a press of the bar. Whoever reads that number
+  // should not have to wonder whether it includes these.
+  it('does not report a fallback clear as a tag-bar click', () => {
+    mocks.tags = [];
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    clickButton(container, 'Clear 1 tag filter');
+
+    expect(mocks.trackAction).not.toHaveBeenCalled();
+    // Control for the assertion above, which passes for free if nothing was pressed.
+    expect(mocks.replace).toHaveBeenCalledTimes(1);
   });
 
   // Negative control: chips present, same deep link. The All chip is the escape hatch

--- a/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
+++ b/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
@@ -150,7 +150,7 @@ describe('ImageFeedTagBar', () => {
   // Gated so the bar can be switched off without a deploy, after its click-through came
   // in under the floor it shipped on (868kv1b9m). `feedTagBar` fails OPEN, so the case
   // that needs pinning is that OFF actually removes it.
-  it('renders nothing when the feedTagBar flag is off', () => {
+  it('renders nothing when the feedTagBar flag is off and no tag filter is active', () => {
     mocks.feedTagBar = undefined;
     const container = render();
 
@@ -158,6 +158,23 @@ describe('ImageFeedTagBar', () => {
     // The reserved row too, not just the chips: the bar holds height while its tags load,
     // so a gate that only emptied the chip list would still push the feed down by 26px.
     expect(reservedRows(container)).toHaveLength(0);
+  });
+
+  // The flag is a kill switch for the bar, not for the escape hatch. Switching it off
+  // must not put /images and /videos back in the state 868kuq3jk describes, where a
+  // `?tags=` deep link narrows the feed with no UI that can widen it. The test above is
+  // this one's negative control: same flag state, no `tags`, no button.
+  it('falls back to the clear control when the flag is off and ?tags= is set', () => {
+    mocks.feedTagBar = undefined;
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual(['Clear 1 tag filter']);
+
+    clickButton(container, 'Clear 1 tag filter');
+
+    expect(mocks.replace).toHaveBeenCalledTimes(1);
+    expect(lastReplacedQuery()).toEqual({ sort: 'Newest' });
   });
 
   it('does not request the chip list when the flag is off, and does when it is on', () => {

--- a/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
+++ b/src/components/Image/Filters/__tests__/ImageFeedTagBar.test.ts
@@ -196,6 +196,29 @@ describe('ImageFeedTagBar', () => {
     expect(mocks.getFeedTagBar).toHaveBeenCalledWith(undefined, { enabled: true });
   });
 
+  // The other state with no `All` chip, and the one that is NOT transient: `TagChipRow`
+  // draws the reservation and no children while `loading`, and the bar holds it whenever
+  // the chip list is empty — which is where a failed or empty `getFeedTagBar` leaves it
+  // for good. The reservation must survive too, or fixing the dead end reintroduces the
+  // CLS the reservation exists for.
+  it('falls back to the clear control while the chip row is held', () => {
+    mocks.tags = [];
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual(['Clear 1 tag filter']);
+    expect(reservedRows(container)).toHaveLength(1);
+  });
+
+  // Negative control: chips present, same deep link. The All chip is the escape hatch
+  // here, and a second one beside it would be the bug this pair is checking for.
+  it('does not add the clear control when the All chip is on the page', () => {
+    mocks.query = { tags: ['999999'], sort: 'Newest' };
+    const container = render();
+
+    expect(buttonLabels(container)).toEqual(['All', 'anime', 'realistic']);
+  });
+
   it('writes ?tags=<id> on select, preserving the rest of the query', () => {
     mocks.query = { sort: 'Newest' };
     const container = render();
@@ -225,9 +248,9 @@ describe('ImageFeedTagBar', () => {
     expect(lastReplacedQuery()).not.toHaveProperty('tags');
   });
 
-  // The reason the All chip is not decoration: ActiveTagFilter is mounted nowhere
-  // (868kuq3jk), so before this bar a ?tags= deep link on /images could not be widened
-  // by any UI. An id that is not a chip here is exactly that case.
+  // The reason the All chip is not decoration: it is what widens a ?tags= deep link on
+  // /images, and an id that is not a chip here is exactly that case. `ActiveTagFilter`
+  // covers only the states where this chip is absent — see the two tests below.
   it('clears a ?tags= deep link whose id is not one of the chips', () => {
     mocks.query = { tags: ['999999'], sort: 'Newest' };
     const container = render();

--- a/src/components/Tags/ActiveTagFilter.tsx
+++ b/src/components/Tags/ActiveTagFilter.tsx
@@ -2,8 +2,6 @@ import { Button } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 
-import { parseNumericStringArray } from '~/utils/query-string-helpers';
-
 function ClearButton({ label, onClear }: { label: string; onClear: () => void }) {
   return (
     <div className="flex">
@@ -25,10 +23,15 @@ function ClearButton({ label, onClear }: { label: string; onClear: () => void })
  * The category scroller used to be the only thing that could unset `?tags=`. The param
  * still filters these feeds and is still linked to from elsewhere, so without this a
  * deep link narrows the feed with no way back to everything.
+ *
+ * `tagIds` is required rather than read from `router.query` here, so the control and the
+ * feed beside it always answer to ONE parser. Every mount reads the param the way its own
+ * feed does — and `useZodRouteParams` fails WHOLESALE on any one bad param, so a feed
+ * whose `?sort=` is junk is not tag-filtered at all. Parsing the param here as well would
+ * put a `Clear 1 tag filter` button over that unfiltered feed.
  */
-export function ActiveTagFilter() {
+export function ActiveTagFilter({ tagIds }: { tagIds: number[] }) {
   const router = useRouter();
-  const tagIds = parseNumericStringArray(router.query.tags) ?? [];
 
   if (!tagIds.length) return null;
 

--- a/src/components/Tags/TagChipRow.tsx
+++ b/src/components/Tags/TagChipRow.tsx
@@ -1,5 +1,6 @@
 import { Button, useComputedColorScheme } from '@mantine/core';
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
 
 import { TwScrollX } from '~/components/TwScrollX/TwScrollX';
 
@@ -56,6 +57,7 @@ export function TagChipRow({
   onClear,
   includeAll = true,
   loading = false,
+  placeholder = null,
 }: {
   items: TagChipRowItem[];
   /** `undefined` means nothing is selected, which is what fills the All chip. */
@@ -70,6 +72,13 @@ export function TagChipRow({
    * `CategoryTags` did before this row was extracted.
    */
   loading?: boolean;
+  /**
+   * What to draw in the reservation while `loading`. It goes INSIDE the reserved height
+   * rather than beside the row, so a caller substituting a control for the chips does not
+   * add height the reservation was sized without — which is the shift this row exists to
+   * prevent, arriving by the other door.
+   */
+  placeholder?: ReactNode;
 }) {
   // The reservation sits on ONE wrapper both branches share, rather than on the
   // placeholder and the scroller separately. Two elements holding the same height is a
@@ -81,7 +90,9 @@ export function TagChipRow({
   // `min-width: 0` that lets the row shrink and scroll instead of pushing its siblings out.
   return (
     <div className={clsx('min-w-0', CHIP_ROW_MIN_HEIGHT)}>
-      {!loading && (
+      {loading ? (
+        placeholder
+      ) : (
         <TwScrollX className="flex gap-1">
           {includeAll && <TagChip label="All" active={activeId === undefined} onClick={onClear} />}
           {items.map((item) => (

--- a/src/components/Tags/__tests__/ActiveTagFilter.test.ts
+++ b/src/components/Tags/__tests__/ActiveTagFilter.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment happy-dom
+import fs from 'fs';
+import path from 'path';
 import { act, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -71,4 +73,38 @@ describe('ActiveTagFilter', () => {
     expect(target.query).toEqual({ sort: 'Newest', period: 'Week' });
     expect(target.query).not.toHaveProperty('tags');
   });
+});
+
+/**
+ * Every test above renders the component directly, so all of them stay green while it is
+ * mounted nowhere — which is exactly how it shipped in #4141 and sat unused until
+ * 868kuq3jk. These are the only assertions that anything in the app renders it.
+ *
+ * /images and /videos are not in this list: there the escape hatch is the `All` chip on
+ * ImageFeedTagBar, with this component as its flag-off fallback. Both of those are
+ * covered in ImageFeedTagBar's own suite — the mount guard there, and the flag-off
+ * fallback test beside it.
+ */
+describe('the feeds that filter on ?tags= mount the clear control', () => {
+  it.each([['src/pages/posts/index.tsx'], ['src/pages/articles/index.tsx']])(
+    '%s renders <ActiveTagFilter />',
+    (relative) => {
+      const repoRoot = path.resolve(__dirname, '../../../..');
+      const source = fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
+
+      // Commenting the mount out leaves the string in place, so strip comments first —
+      // block comments because that is what an editor produces over a selection.
+      //
+      // Known limit, same as the ImageFeedTagBar guard: `{someFlag && <ActiveTagFilter/>}`
+      // passes this while rendering for nobody. Scanning source cannot see that.
+      const code = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+      const mounted = code
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.includes('<ActiveTagFilter') && !line.startsWith('//'));
+
+      expect(source).toContain("from '~/components/Tags/ActiveTagFilter'");
+      expect(mounted).toHaveLength(1);
+    }
+  );
 });

--- a/src/components/Tags/__tests__/ActiveTagFilter.test.ts
+++ b/src/components/Tags/__tests__/ActiveTagFilter.test.ts
@@ -18,12 +18,12 @@ import { MantineProvider } from '@mantine/core';
 
 import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 
-function render() {
+function render(tagIds: number[] = []) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   act(() => {
     createRoot(container).render(
-      createElement(MantineProvider, null, createElement(ActiveTagFilter))
+      createElement(MantineProvider, null, createElement(ActiveTagFilter, { tagIds }))
     );
   });
   return container;
@@ -42,27 +42,34 @@ describe('ActiveTagFilter', () => {
   });
 
   it('renders nothing when no tag filter is active', () => {
-    const container = render();
+    const container = render([]);
     expect(container.querySelector('button')).toBeNull();
   });
 
   // Positive control for the assertion above: same matcher, tags present.
   it('renders a clear control when a tag filter is active', () => {
-    mocks.query = { tags: '5' };
-    const container = render();
+    const container = render([5]);
     expect(container.querySelector('button')).not.toBeNull();
     expect(container.textContent).toContain('Clear 1 tag filter');
   });
 
   it('pluralises for several tags', () => {
-    mocks.query = { tags: ['5', '9'] };
-    const container = render();
+    const container = render([5, 9]);
     expect(container.textContent).toContain('Clear 2 tag filters');
+  });
+
+  // The caller owns the parse, so a `?tags=` the FEED did not accept must not raise a
+  // control here. `useZodRouteParams` fails wholesale on one bad param, which is how a
+  // url carrying `tags` reaches a feed that is not tag-filtered.
+  it('renders nothing when the url carries tags the caller did not accept', () => {
+    mocks.query = { tags: ['5'], sort: 'bogus' };
+    const container = render([]);
+    expect(container.querySelector('button')).toBeNull();
   });
 
   it('drops `tags` and keeps every other query param', () => {
     mocks.query = { tags: ['5', '9'], sort: 'Newest', period: 'Week' };
-    const container = render();
+    const container = render([5, 9]);
 
     act(() => {
       container.querySelector('button')?.click();
@@ -80,31 +87,34 @@ describe('ActiveTagFilter', () => {
  * mounted nowhere — which is exactly how it shipped in #4141 and sat unused until
  * 868kuq3jk. These are the only assertions that anything in the app renders it.
  *
- * /images and /videos are not in this list: there the escape hatch is the `All` chip on
- * ImageFeedTagBar, with this component as its flag-off fallback. Both of those are
- * covered in ImageFeedTagBar's own suite — the mount guard there, and the flag-off
- * fallback test beside it.
+ * /images and /videos are not in this list because their escape hatch is normally the
+ * `All` chip on ImageFeedTagBar; this component stands in only where that chip is absent,
+ * and both of those states are pinned in ImageFeedTagBar's own suite, beside the mount
+ * guard for the bar itself.
  */
 describe('the feeds that filter on ?tags= mount the clear control', () => {
-  it.each([['src/pages/posts/index.tsx'], ['src/pages/articles/index.tsx']])(
-    '%s renders <ActiveTagFilter />',
-    (relative) => {
-      const repoRoot = path.resolve(__dirname, '../../../..');
-      const source = fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
+  it.each([
+    ['src/pages/posts/index.tsx'],
+    ['src/pages/articles/index.tsx'],
+    // Read-only `?tags=` since its category scroller was removed, and it reads the param
+    // with `parseNumericStringArray` — the same dead end, on a flag-gated feed.
+    ['src/pages/3d-models/index.tsx'],
+  ])('%s renders <ActiveTagFilter />', (relative) => {
+    const repoRoot = path.resolve(__dirname, '../../../..');
+    const source = fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
 
-      // Commenting the mount out leaves the string in place, so strip comments first —
-      // block comments because that is what an editor produces over a selection.
-      //
-      // Known limit, same as the ImageFeedTagBar guard: `{someFlag && <ActiveTagFilter/>}`
-      // passes this while rendering for nobody. Scanning source cannot see that.
-      const code = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
-      const mounted = code
-        .split('\n')
-        .map((line) => line.trim())
-        .filter((line) => line.includes('<ActiveTagFilter') && !line.startsWith('//'));
+    // Commenting the mount out leaves the string in place, so strip comments first —
+    // block comments because that is what an editor produces over a selection.
+    //
+    // Known limit, same as the ImageFeedTagBar guard: `{someFlag && <ActiveTagFilter/>}`
+    // passes this while rendering for nobody. Scanning source cannot see that.
+    const code = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    const mounted = code
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.includes('<ActiveTagFilter') && !line.startsWith('//'));
 
-      expect(source).toContain("from '~/components/Tags/ActiveTagFilter'");
-      expect(mounted).toHaveLength(1);
-    }
-  );
+    expect(source).toContain("from '~/components/Tags/ActiveTagFilter'");
+    expect(mounted).toHaveLength(1);
+  });
 });

--- a/src/components/Tags/__tests__/ActiveTagFilter.test.ts
+++ b/src/components/Tags/__tests__/ActiveTagFilter.test.ts
@@ -91,8 +91,13 @@ describe('ActiveTagFilter', () => {
  * `All` chip on ImageFeedTagBar; this component stands in only where that chip is absent,
  * and both of those states are pinned in ImageFeedTagBar's own suite, beside the mount
  * guard for the bar itself.
+ *
+ * ⚠️ Named for the three pages it pins, not for the property, because it is NOT a closed
+ * set: `/user/[username]/posts`, `/user/[username]/articles` and `/tools/[slug]` all pass
+ * `?tags=` through to their feed with no control that can clear it. They were out of scope
+ * for 868kuq3jk. Do not read a green run here as "every tag-filtered feed is covered".
  */
-describe('the feeds that filter on ?tags= mount the clear control', () => {
+describe('/posts, /articles and /3d-models mount the clear control', () => {
   it.each([
     ['src/pages/posts/index.tsx'],
     ['src/pages/articles/index.tsx'],
@@ -116,5 +121,10 @@ describe('the feeds that filter on ?tags= mount the clear control', () => {
 
     expect(source).toContain("from '~/components/Tags/ActiveTagFilter'");
     expect(mounted).toHaveLength(1);
+    // `tagIds` became required in the same change that added these mounts, which makes
+    // `tagIds={[]}` a one-token edit that mounts the control and renders it for nobody —
+    // a guard stopping at "it is on the page" passes over exactly that.
+    expect(mounted[0]).toMatch(/tagIds=\{/);
+    expect(mounted[0]).not.toContain('tagIds={[]}');
   });
 });

--- a/src/pages/3d-models/index.tsx
+++ b/src/pages/3d-models/index.tsx
@@ -12,6 +12,7 @@ import { InViewLoader } from '~/components/InView/InViewLoader';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { MasonryGridVirtual } from '~/components/MasonryColumns/MasonryGridVirtual';
 import { Meta } from '~/components/Meta/Meta';
+import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 import { NoContent } from '~/components/NoContent/NoContent';
 import { useDomainColor } from '~/hooks/useDomainColor';
 import { Model3DSort } from '~/server/schema/model3d.schema';
@@ -132,6 +133,7 @@ function Model3DsPage() {
 
       <MasonryContainer>
         <Stack gap="md">
+          <ActiveTagFilter tagIds={tagIds} />
           {isLoading || loadingPreferences ? (
             <Center p="xl">
               <Loader size="xl" />

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -35,7 +35,7 @@ function ArticlesPage() {
       <MasonryContainer>
         <Stack gap="xs">
           {query.favorites && <Title>Your Bookmarked Articles</Title>}
-          <ActiveTagFilter />
+          <ActiveTagFilter tagIds={query.tags ?? []} />
           <ArticlesInfinite filters={query} />
         </Stack>
       </MasonryContainer>

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -4,6 +4,7 @@ import { Page } from '~/components/AppLayout/Page';
 import { useArticleQueryParams } from '~/components/Article/article.utils';
 import { ArticlesInfinite } from '~/components/Article/Infinite/ArticlesInfinite';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
+import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 
@@ -34,6 +35,7 @@ function ArticlesPage() {
       <MasonryContainer>
         <Stack gap="xs">
           {query.favorites && <Title>Your Bookmarked Articles</Title>}
+          <ActiveTagFilter />
           <ArticlesInfinite filters={query} />
         </Stack>
       </MasonryContainer>

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -6,6 +6,7 @@ import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import PostsInfinite from '~/components/Post/Infinite/PostsInfinite';
 import { usePostQueryParams } from '~/components/Post/post.utils';
+import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 
 function PostsPage() {
   const { query } = usePostQueryParams();
@@ -19,6 +20,7 @@ function PostsPage() {
       />
       <MasonryContainer>
         <Stack gap="xs">
+          <ActiveTagFilter />
           <IsClient>
             <PostsInfinite filters={query} showEof showAds />
           </IsClient>

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -20,7 +20,7 @@ function PostsPage() {
       />
       <MasonryContainer>
         <Stack gap="xs">
-          <ActiveTagFilter />
+          <ActiveTagFilter tagIds={query.tags ?? []} />
           <IsClient>
             <PostsInfinite filters={query} showEof showAds />
           </IsClient>


### PR DESCRIPTION
Closes ClickUp [868kuq3jk](https://app.clickup.com/t/868kuq3jk).

## What was wrong

`ActiveTagFilter` shipped in #4141 as the replacement for the category scroller — its own docstring calls itself the only way to unset `?tags=` — and was mounted nowhere. On `/posts`, `/articles` and `/3d-models` a `?tags=` deep link narrows the feed with no UI that can widen it again.

`/images` and `/videos` are covered today by `ImageFeedTagBar`'s `All` chip, but that chip is absent in two states: the `feedTagBar` flag being off — and that flag exists specifically so the bar can be removed after it came in under its click-through floor (868kv1b9m) — and `TagChipRow` holding its reservation with no children, which is where a failed or empty `getFeedTagBar` leaves the bar for good.

## What this does

- mounts `<ActiveTagFilter />` on `/posts`, `/articles` and `/3d-models`
- makes `ImageFeedTagBar` render it wherever the `All` chip is not on the page, through a new `placeholder` slot on `TagChipRow` so the control sits **inside** the 26px reservation and costs no extra height
- makes `tagIds` a required prop

## Two decisions worth reading before changing them

**`tagIds` is a prop, not a parse.** `useZodRouteParams` fails **wholesale** on one bad param, so `/posts?tags=5&sort=bogus` is not tag-filtered at all. A component parsing `router.query` itself would draw `Clear 1 tag filter` over an unfiltered feed. Every mount now reads the param the way its own feed does.

**The fallback deliberately emits no `Feed_TagBar_Click`.** That series is what the bar's removal is being decided on, and it measures the *bar*. A press of a control that appears only when the bar has no chips would inflate the number the decision reads. Pinned by a test rather than left in a thread.

## Why the tests are shaped this way

Every pre-existing test renders the component directly, so all of them stayed green through the whole period it was mounted nowhere — that is how #4141 shipped. Added:

- a source-scanning mount guard per page, which also asserts the prop: `<ActiveTagFilter tagIds={[]} />` is a one-token edit that mounts the control and renders it for nobody, and a guard stopping at "it is on the page" passes over exactly that
- the flag-off and settled-empty fallbacks, each with the state it must **not** fire in as a negative control

Mutation controls, run individually, each failing by the named test:

| mutation | fails |
|---|---|
| posts / articles / 3d-models mount removed | `src/pages/<page>/index.tsx renders <ActiveTagFilter />` |
| posts mount neutered to `tagIds={[]}` | same guard |
| flag-off branch back to `return null` | `falls back to the clear control when the flag is off and ?tags= is set` |
| placeholder gated on `chipsHeld` instead of `chipsGone` | `does not render the clear control while the chip fetch is in flight` (+1) |
| `TagChipRow` drops the placeholder slot | `falls back to the clear control once the chip fetch has settled empty` (+1) |
| `ActiveTagFilter` reads the url instead of the prop | `renders nothing when the url carries tags the caller did not accept` (+2) |

## Not covered, and named as such

`/user/[username]/posts`, `/user/[username]/articles` and `/tools/[slug]` also pass `?tags=` through with no control that can clear it. Out of scope for the ticket; the guard is named for the three pages it pins and lists these, so a green run is not mistaken for full coverage.

Known limit inherited from the existing `ImageFeedTagBar` guard: `{someFlag && <ActiveTagFilter/>}` passes a source scan while rendering for nobody.

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — repo-wide is already red on this base (357 errors); zero lines naming any of the eight files touched, against a positive control that finds other files in the same log
- `pnpm run test:unit:run` — `Test Files 4 failed | 1521 passed | 2 skipped (1527)`, `Tests 10 failed | 24075 passed | 28 skipped (24113)`. The same 4 files / 10 tests fail on a clean stash of this base (`credential-detection-superset.guard`, `blocks/tools/registry`, `test-perf/trace-flush`, `appModeratorMessageForm.callSites`) — pre-existing.
- `blocks.router.workflow.test.ts` collected 370 tests, so the submodule is initialised.
- `CategoryTags`, the other `TagChipRow` caller, passes unchanged — `placeholder` defaults to `null`.

Two adversarial review rounds; the second caught a regression the first fix introduced (the fallback gated on `loadingPreferences`, true on mount for every viewer, so the button would have flashed on every deep link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FrqGiMk5qMSj6i2WRd3ai