### PR TITLE
fix(creator-program): send stage notifications at actual boundaries

### DIFF
--- a/docs/features/creator-program.md
+++ b/docs/features/creator-program.md
@@ -172,8 +172,8 @@ Tiered: e.g., 200,000 buzz = 0% on first 100k + 5% on next 100k = 5,000 fee.
 | `creatorsProgramInviteTipalti` | `50 23 L * *` | Creates Tipalti payee for users above $50 threshold |
 | `creatorsProgramRollover` | `0 0 1 * *` | Flushes all caches for new month |
 | `creatorsProgramSettleCash` | `0 0 15 * *` | Moves `cashPending` -> `cashSettled`, notifies users |
-| `bankingPhaseEndingNotification` | `0 0 L-4 * *` | Notifies users banking phase is ending |
-| `extractionPhaseStartedNotification` | `0 0 L-3 * *` | Notifies extraction phase started |
+| `bankingPhaseEndingNotification` | `0 0 L-3 * *` | Notifies users on the last banking day (banking closes end of L-3) |
+| `extractionPhaseStartedNotification` | `0 0 L-2 * *` | Notifies users on the first extraction day (L-2) |
 | `extractionPhaseEndingNotification` | `0 0 L * *` | Notifies extraction phase ending |
 
 ### Distribution Logic

--- a/src/server/jobs/creators-program-jobs.ts
+++ b/src/server/jobs/creators-program-jobs.ts
@@ -297,7 +297,9 @@ const getCreatorProgramUsers = async ({
 
 export const bankingPhaseEndingNotification = createJob(
   'creator-program-banking-phase-ending',
-  `0 0 L-${EXTRACTION_PHASE_DURATION + 1} * *`,
+  // Banking ends at the end of day L-EXTRACTION_PHASE_DURATION (see getPhases), so L-3
+  // is the last day people can still bank — fire the "last day" nudge that morning.
+  `0 0 L-${EXTRACTION_PHASE_DURATION} * *`,
   async () => {
     const month = dayjs().format('YYYY-MM');
     // Banking nudge — only people who can actually still bank.
@@ -315,7 +317,9 @@ export const bankingPhaseEndingNotification = createJob(
 
 export const extractionPhaseStartedNotification = createJob(
   'creator-program-extraction-phase-started',
-  `0 0 L-${EXTRACTION_PHASE_DURATION} * *`,
+  // Extraction begins on day L-(EXTRACTION_PHASE_DURATION-1) (= L-2), the first of the
+  // last EXTRACTION_PHASE_DURATION days — fire "has begun" that morning, not a day early.
+  `0 0 L-${EXTRACTION_PHASE_DURATION - 1} * *`,
   async () => {
     const month = dayjs().format('YYYY-MM');
     const users = await getCreatorProgramUsers();


### PR DESCRIPTION
Banking and extraction phase notifications were being sent 24 hours before
the stages actually changed, causing users to receive misleading messages
(e.g., "banking phase has ended" while the phase was still open).

Updated job schedules to fire at stage boundaries:
- bankingPhaseEndingNotification: day L-4 → L-3
- extractionPhaseStartedNotification: day L-3 → L-2

Updated documentation to clarify the relationship between scheduled jobs and
actual stage transitions.

Refs: 868kyuh3k