### PR TITLE
fix(creator-shop): let a pack submission fee be paid in any currency the server takes

### DIFF
--- a/src/components/CreatorShop/Pack/CreatorShopPackModal.tsx
+++ b/src/components/CreatorShop/Pack/CreatorShopPackModal.tsx
@@ -21,6 +21,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconAlertTriangle, IconPlus, IconX } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
+import { useQueryBuzz } from '~/components/Buzz/useBuzz';
 import { CosmeticThumb } from '~/components/CreatorShop/CosmeticThumb';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { PackCoverField } from '~/components/CreatorShop/Pack/PackCoverField';
@@ -30,6 +31,7 @@ import {
   FEE_UNAVAILABLE_MESSAGE,
   useCreatorShopFees,
 } from '~/components/CreatorShop/useCreatorShopFees';
+import { FeeSection } from '~/components/CreatorShop/Submit/FeeSection';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { stickerUsesFromCosmeticData } from '~/shared/utils/sticker-token';
 import {
@@ -71,6 +73,9 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
     item?.availableQuantity ?? undefined
   );
   const [acceptsBlueBuzz, setAcceptsBlueBuzz] = useState(false);
+  // Which account pays the submission fee — not `acceptsBlueBuzz` above, which
+  // is what buyers may pay this pack with.
+  const [buzzType, setBuzzType] = useState<'yellow' | 'green' | 'blue'>('yellow');
   const [rightsAffirmed, setRightsAffirmed] = useState(false);
   const [selected, setSelected] = useState<Bundlable[]>([]);
   const [search, setSearch] = useState('');
@@ -146,6 +151,24 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
   const tooMany = selected.length > PACK_MAX_MEMBERS;
   const priceTooLow = (price ?? 0) < floor;
   const packFee = useCreatorShopFees()?.pack;
+  const { data: buzz, isLoading: loadingBuzz } = useQueryBuzz(['yellow', 'green', 'blue']);
+  const yellowBalance = buzz.accounts.find((a) => a.type === 'yellow')?.balance ?? 0;
+  const greenBalance = buzz.accounts.find((a) => a.type === 'green')?.balance ?? 0;
+  const blueBalance = buzz.accounts.find((a) => a.type === 'blue')?.balance ?? 0;
+  const feeAccountBalance =
+    buzzType === 'yellow' ? yellowBalance : buzzType === 'green' ? greenBalance : blueBalance;
+  // A KNOWN shortfall only. Both the fee and the balances read as zero until they
+  // resolve, and "your balance doesn't cover the fee" said before either is known
+  // is a false claim about the creator's money — and a permanent one if the fee
+  // read fails.
+  //
+  // 🔴 Deliberately NOT a term in `canSubmit`. Disabling the button on a shortfall
+  // takes the top-up path away with it: `BuzzTransactionButton` answers a short
+  // balance by opening the purchase modal and submitting on success, and a
+  // disabled button never reaches its own onClick. The warning informs; the
+  // button still works.
+  const feeShortfall =
+    !isEdit && !loadingBuzz && packFee !== undefined && feeAccountBalance < packFee;
   const canSubmit =
     !!name.trim() &&
     (isEdit || packFee !== undefined) &&
@@ -200,7 +223,7 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
         memberCosmeticIds,
         price,
         availableQuantity: quantity ?? null,
-        buzzType: 'yellow',
+        buzzType,
         acceptsBlueBuzz,
         ...(imageId ? { imageUrl: imageId } : {}),
         // Only claimed when artwork was actually supplied.
@@ -391,6 +414,19 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
           />
         )}
 
+        {!isEdit && (
+          <FeeSection
+            buzzType={buzzType}
+            onBuzzTypeChange={setBuzzType}
+            yellowBalance={yellowBalance}
+            greenBalance={greenBalance}
+            blueBalance={blueBalance}
+            feeAccountBalance={feeAccountBalance}
+            canAffordFee={!feeShortfall}
+            submissionFee={packFee}
+          />
+        )}
+
         <Group justify="flex-end">
           <Button variant="default" onClick={dialog.onClose}>
             Cancel
@@ -400,11 +436,16 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
               Save pack
             </Button>
           ) : (
+            // `exactAccountTypes`, not `accountTypes`: that one appends the domain
+            // currency, so a blue pick would clear its balance check on yellow and
+            // then fail the charge, which bills `buzzType` alone.
             <BuzzTransactionButton
               disabled={!canSubmit}
               loading={submitPack.isPending}
               buzzAmount={packFee ?? 0}
               priceReplacement={packFee === undefined ? '…' : undefined}
+              exactAccountTypes={[buzzType]}
+              colorType={buzzType}
               label="Submit pack"
               onPerformTransaction={handleSubmit}
             />

--- a/src/components/CreatorShop/Pack/__tests__/pack-fee-currency.test.ts
+++ b/src/components/CreatorShop/Pack/__tests__/pack-fee-currency.test.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { submitCreatorShopPackSchema } from '~/server/schema/creator-shop.schema';
+
+/**
+ * 🔒 The pack submission fee is paid from an account the lister PICKS.
+ *
+ * `submitCreatorShopPack` charges `fromAccountType: buzzType`, and the schema
+ * below has accepted green/yellow/blue since packs shipped — but the modal sent
+ * a hardcoded `'yellow'`, so the other two were unreachable from the only UI
+ * that submits a pack. A creator holding blue read that as "packs cost Yellow
+ * Buzz", reported it as a missing option (Murf, #civitai-testers 2026-08-21),
+ * and nothing on the screen said otherwise.
+ *
+ * Source-gate rather than a render, the idiom of `sticker-review-nav-link` next
+ * door: the defect was a literal in the payload, which is exactly what a source
+ * read sees and what a mocked render would sail past.
+ *
+ * 🔴 IF YOU ARE HERE TO DELETE THIS: the fee currency being the lister's choice
+ * is deliberate, and it is parity with the single-item path
+ * (`CreatorShopSubmitModal` → `FeeSection`), not an accident. Narrowing packs
+ * back to one currency is a product decision — take it deliberately and delete
+ * this test in the same commit, rather than restoring the literal because a
+ * refactor made it convenient.
+ *
+ * NOT covered here, deliberately: which currency is CORRECT for a given
+ * creator, and `acceptsBlueBuzz`, which is a different question — what buyers
+ * may pay with, vetoed by any member whose creator opted out.
+ */
+const modalSource = fs.readFileSync(
+  path.resolve(__dirname, '../CreatorShopPackModal.tsx'),
+  'utf-8'
+);
+
+describe('the pack submission fee currency', () => {
+  it('reaches the mutation as the picked value, not a hardcoded one', () => {
+    const hardcoded = modalSource.match(/buzzType:\s*'(yellow|green|blue)'/);
+
+    expect(
+      hardcoded?.[1],
+      `CreatorShopPackModal sends buzzType: '${hardcoded?.[1]}' to submitPack, so the fee is ` +
+        'charged from that account whatever the lister picked. Pass the buzzType state instead.'
+    ).toBeUndefined();
+
+    // Anchored to the PAYLOAD, not to the file. A bare `toContain('buzzType,')`
+    // is satisfied by the `useState` declaration, so deleting the field from the
+    // mutation — and letting the schema's `.default('yellow')` supply it — would
+    // restore the whole bug with the picker still on screen and this test green.
+    expect(modalSource).toMatch(/submitPack\.mutateAsync\(\{[\s\S]*?\n\s+buzzType,/);
+  });
+
+  it('offers every currency the server would accept', () => {
+    // Asked of the server's own schema rather than a hand-typed list: if it is
+    // ever narrowed to yellow, this fails here instead of leaving the picker
+    // offering what the server would refuse.
+    const accepted = submitCreatorShopPackSchema.shape.buzzType;
+    expect(accepted.safeParse('blue').success).toBe(true);
+    expect(accepted.safeParse('green').success).toBe(true);
+
+    expect(modalSource).toContain('<FeeSection');
+    expect(modalSource).toContain('buzzType={buzzType}');
+  });
+
+  it('checks the balance of the picked account ALONE', () => {
+    // `accountTypes` appends the domain currency (`useAvailableBuzz`), so with it
+    // a blue pick passes the button's check on a yellow balance and then fails
+    // the charge — the server bills `buzzType` and nothing else.
+    expect(modalSource).toContain('exactAccountTypes={[buzzType]}');
+
+    // Read the prefix rather than searching for the bare spelling: the string
+    // being refused is a SUBSTRING of the one required, so a plain `not.toContain`
+    // would fail against the fix itself.
+    const bare = [...modalSource.matchAll(/(\w*)accountTypes=\{\[buzzType\]\}/gi)].filter(
+      (match) => match[1].toLowerCase() !== 'exact'
+    );
+    expect(bare.map((match) => match[0])).toEqual([]);
+  });
+
+  it('warns about a short balance without disabling the way to fix it', () => {
+    // 🔴 THE DECISION, so it is not quietly undone: a fee shortfall must NOT be a
+    // term in `canSubmit`. Disabling the button takes the top-up path with it —
+    // `BuzzTransactionButton` answers a short balance by opening the purchase
+    // modal and submitting on success, and a disabled button never reaches its
+    // own onClick. It was written that way once and reviewed back out.
+    const canSubmitBlock = modalSource.match(/const canSubmit =[\s\S]*?;\n/)?.[0] ?? '';
+    expect(canSubmitBlock).not.toMatch(/feeShortfall|canAffordFee/);
+
+    // And the warning itself is only claimed once the fee AND the balances are
+    // known — both read as zero while loading, which would state a falsehood
+    // about the creator's money on first paint.
+    expect(modalSource).toMatch(/feeShortfall =[\s\S]{0,200}!loadingBuzz/);
+    expect(modalSource).toMatch(/feeShortfall =\s*!isEdit/);
+    expect(modalSource).toContain('canAffordFee={!feeShortfall}');
+  });
+});


### PR DESCRIPTION
Closes the reported half of [868kv5d8g](https://app.clickup.com/t/868kv5d8g).

## What was reported, and where the bug actually is

Murf, #civitai-testers 2026-08-21:

> When Building a Pack you can only do so with Yellow Buzz. There is no Blue option.

The ticket read this as the buyer side — the sticker tray's `use | pack` mode. It is the creator side. "Build a pack" is the title of `CreatorShopPackModal`, and the tray's `pack` mode is not a multi-member pack at all: it is a batch of uses of one sticker, whose `acceptsBlue` comes from that sticker's own listing, so `packBlueBuzzVeto` never runs on it.

The defect is the pack **submission fee**. `CreatorShopPackModal` sent a hardcoded `buzzType: 'yellow'`, while everything under it already took all three currencies:

- `submitCreatorShopPackSchema.buzzType` — `z.enum(['green','yellow','blue']).default('yellow')`
- `submitCreatorShopPack` — `createBuzzTransaction({ fromAccountType: buzzType })`
- the single-item path — `CreatorShopSubmitModal` renders `FeeSection`, a yellow/green/blue picker with live balances

So the modal was the only place narrowing it, and it said nothing about why. If yellow-only were the rule, the schema would be `z.literal('yellow')` and the service would not take the parameter.

## The change

`CreatorShopPackModal` gets the fee picker the single-item submission already has — `FeeSection`, on submit only, since an edit pays no fee — and the picked value replaces the literal.

**`exactAccountTypes`, not `accountTypes`.** `accountTypes` runs through `useAvailableBuzz`, which appends the domain currency and strips a `green` pick outright. With it, a blue pick clears the button's balance check against a yellow balance and then fails the charge, which bills `buzzType` alone. `exactAccountTypes` exists for this case and its docblock says so.

**A short balance warns; it does not disable the button — deliberately, and please do not "fix" it.** An earlier revision of this PR added the shortfall to `canSubmit`, on the reasoning that a creator should not press Submit and eat a server-side failure after the modal has closed. That reasoning was wrong about what it cost. `disabled` means `onClick` never fires, and `onClick` is the *only* route to the top-up flow: `BuzzTransactionButton` answers a short balance by opening the purchase modal with `onPurchaseSuccess: onPerformTransaction`, so the creator buys Buzz and the submission proceeds. Gating on the shortfall replaces "buy Buzz and continue" with a red message and a dead button. The original concern is still handled, by the button refusing before it submits rather than by the form refusing to enable. `pack-fee-currency.test.ts` pins this so it is not re-added as an obvious improvement.

**The shortfall is only claimed once it is known.** `packFee` is undefined and all three balances read `0` until their queries settle, so an ungated check states "your balance doesn't cover the fee" on first paint beside a fee still rendering as `…`, and permanently if the fee read fails.

## Deliberately not in scope

**The buyer-facing tray reason.** The ticket also asks for an explanation when Blue is unavailable in the tray. Nobody has reported hitting that state — Murf was not on that surface — and writing copy for a case with no report is how a UI fills with explanations for states that do not occur. Recorded as unreported rather than dismissed.

**The fee picker is not domain-constrained.** `useAvailableBuzz` says only one of yellow/green is spendable on a given domain, while `FeeSection` offers all three. Real, but pre-existing and not made worse here: before this PR the pack fee was *always* yellow, so a green-domain creator had no escape at all; now they can pick green. The default is unchanged. Fixing it client-side alone would be theatre, because `creator-shop.router.ts` passes `input.buzzType` straight to `fromAccountType` with no allow-list while every other Buzz router derives it from `getAllowedAccountTypes(ctx.features)` — and that file has an open PR (#4482). Filed as a follow-up: both submit paths intersect `buzzType` against `getAllowedAccountTypes(ctx.features)` and refuse the rest.

## Verification

- `pnpm run typecheck` — `0 type errors in 137s`
- `pnpm exec eslint` on both changed files — exit 0, no output. (Repo-wide `pnpm run lint` is red on `main` with 357 pre-existing errors; none in these files.)
- `pnpm exec prettier --write` on both — formatted.
- `pnpm run test:unit:run` — `4 failed | 1523 passed | 2 skipped (1529)` files, `10 failed | 24077 passed | 28 skipped (24115)` tests. **Those 4 files are pre-existing failures, not this PR**, and that was measured rather than assumed: stashed to a clean `origin/main` base and re-ran those four alone — `Test Files 4 failed (4)`, `Tests 10 failed | 99 passed (109)`, identical, on a tree containing none of this work. They are `blocks/tools/__tests__/registry.test.ts`, `Apps/__tests__/appModeratorMessageForm.callSites.test.ts`, `server/utils/__tests__/credential-detection-superset.guard.test.ts` and `scripts/test-perf/__tests__/trace-flush.test.ts`, and the assertions carry Windows path separators (`'env\server.ts'`), putting them in the known Windows-only path-guard family.
- `blocks.router.workflow.test.ts` collected **370 tests**, so the submodule is initialised and the run means something.

### The new tests were checked against a revert, not assumed

Six mutations, each failing with a message that names the wrong value, each green again on restore:

| mutation | failure |
|---|---|
| delete `buzzType,` from the `submitPack.mutateAsync` payload (schema `.default('yellow')` then supplies it silently) | `to match /submitPack\.mutateAsync\(\{[\s\S]*?\n\s+buzzType,/` |
| restore the `buzzType: 'yellow'` literal | `expected 'yellow' to be undefined`, message naming the literal |
| `exactAccountTypes` → `accountTypes` | `to contain 'exactAccountTypes={[buzzType]}'` |
| remove the `FeeSection` block | `to contain '<FeeSection'` |
| put the shortfall back into `canSubmit` | `not to match /feeShortfall|canAffordFee/` |
| drop the `!loadingBuzz` guard | `to match /feeShortfall =[\s\S]{0,200}!loadingBuzz/` |

The first of those is here because an earlier version of this test asserted `toContain('buzzType,')`, which the `useState` declaration satisfies — so deleting the field from the payload restored the entire reported bug with the suite green. A source-gate rather than a render, the idiom of `sticker-review-nav-link.test.ts` next door: the defect was a literal in a mutation payload, which is what a source read sees and what a mocked render sails past.

No overlap with #4482, which touches `cosmetic-pack.service.ts`, `creator-shop-pack.service.ts` and `creator-shop.router.ts`. This touches none of them.
