### PR TITLE
feat(models): group the model type picker, retire dead types, rename Checkpoint to Fine-tune

### DIFF
--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -66,7 +66,7 @@ export interface AppSettingsModalProps {
 }
 
 const MODEL_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: ModelType.Checkpoint, label: 'Checkpoint' },
+  { value: ModelType.Checkpoint, label: 'Fine-tune' },
   { value: ModelType.LORA, label: 'LoRA' },
   { value: ModelType.LoCon, label: 'LoCon' },
   { value: ModelType.TextualInversion, label: 'Embedding' },

--- a/src/components/Auction/AuctionInfo.tsx
+++ b/src/components/Auction/AuctionInfo.tsx
@@ -256,7 +256,7 @@ export const AuctionTopSection = ({
                   <Badge color="green" mr="xs">
                     Generation
                   </Badge>
-                  Checkpoints will be enabled for use in generation.
+                  Fine-tunes will be enabled for use in generation.
                 </Text>
               </Stack>
             </Stack>

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -175,6 +175,9 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   const queryUtils = trpc.useUtils();
 
   const [type, allowDerivatives] = form.watch(['type', 'allowDerivatives']);
+  // Only a saved model grandfathers a retired type. A template seeds `type` without an `id`, and
+  // minting a new model on a retired type is what retiring it was meant to stop.
+  const grandfatheredType = model?.id ? model.type : null;
   const [nsfw, poi, sfwOnly, minor] = form.watch(['nsfw', 'poi', 'sfwOnly', 'minor']);
   const watchedTags = form.watch('tagsOnModels') ?? [];
   const allowCommercialUse = form.watch('allowCommercialUse') as CommercialUse[] | undefined;
@@ -345,7 +348,7 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
                   name="type"
                   label="Type"
                   placeholder="Type"
-                  data={getModelTypeSelectData(type)}
+                  data={getModelTypeSelectData(grandfatheredType)}
                   onChange={handleModelTypeChange}
                   disabled={isTrained}
                   allowDeselect={false}

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -21,7 +21,7 @@ import {
 import { IconClockCheck, IconExclamationMark, IconGlobe } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import * as z from 'zod';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
@@ -149,14 +149,18 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   const colorScheme = useComputedColorScheme('dark');
 
   const defaultCategory = result.success ? result.data.category ?? 0 : 0;
-  const { grandfatheredType, initialType } = resolveModelTypeDefaults(model);
+  // One snapshot feeds both: `initialType` reaches the form once through defaultValues, so a
+  // `grandfatheredType` that kept recomputing could drift from it if a caller ever mounted this
+  // form before `model` arrived.
+  const initialModel = useRef(model).current;
+  const { grandfatheredType, initialType } = resolveModelTypeDefaults(initialModel);
   const defaultValues: ModelUpsertSchema = {
     ...model,
     name: model?.name ?? '',
     description: model?.description ?? '',
     tagsOnModels: model?.tagsOnModels?.filter((tag) => !tag.isCategory) ?? [],
     status: model?.status ?? 'Draft',
-    type: initialType ?? 'Checkpoint',
+    type: initialType,
     checkpointType: model?.checkpointType,
     uploadType: model?.uploadType ?? 'Created',
     poi: model?.poi == null ? '' : model?.poi ? 'true' : 'false',

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -59,7 +59,10 @@ import {
   ModelUploadType,
   TagTarget,
 } from '~/shared/utils/prisma/enums';
-import { getModelTypeSelectData } from '~/shared/constants/model-type.constants';
+import {
+  getModelTypeSelectData,
+  resolveModelTypeDefaults,
+} from '~/shared/constants/model-type.constants';
 import type { ModelById } from '~/types/router';
 import { showErrorNotification } from '~/utils/notifications';
 import { parseNumericString } from '~/utils/query-string-helpers';
@@ -146,13 +149,14 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   const colorScheme = useComputedColorScheme('dark');
 
   const defaultCategory = result.success ? result.data.category ?? 0 : 0;
+  const { grandfatheredType, initialType } = resolveModelTypeDefaults(model);
   const defaultValues: ModelUpsertSchema = {
     ...model,
     name: model?.name ?? '',
     description: model?.description ?? '',
     tagsOnModels: model?.tagsOnModels?.filter((tag) => !tag.isCategory) ?? [],
     status: model?.status ?? 'Draft',
-    type: model?.type ?? 'Checkpoint',
+    type: initialType ?? 'Checkpoint',
     checkpointType: model?.checkpointType,
     uploadType: model?.uploadType ?? 'Created',
     poi: model?.poi == null ? '' : model?.poi ? 'true' : 'false',
@@ -175,9 +179,6 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   const queryUtils = trpc.useUtils();
 
   const [type, allowDerivatives] = form.watch(['type', 'allowDerivatives']);
-  // Only a saved model grandfathers a retired type. A template seeds `type` without an `id`, and
-  // minting a new model on a retired type is what retiring it was meant to stop.
-  const grandfatheredType = model?.id ? model.type : null;
   const [nsfw, poi, sfwOnly, minor] = form.watch(['nsfw', 'poi', 'sfwOnly', 'minor']);
   const watchedTags = form.watch('tagsOnModels') ?? [];
   const allowCommercialUse = form.watch('allowCommercialUse') as CommercialUse[] | undefined;

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -50,19 +50,20 @@ import { TagSort } from '~/server/common/enums';
 import type { ModelUpsertInput } from '~/server/schema/model.schema';
 import { modelUpsertSchema } from '~/server/schema/model.schema';
 import { getSanitizedStringSchema } from '~/server/schema/utils.schema';
+import type { ModelType } from '~/shared/utils/prisma/enums';
 import {
   Availability,
   CheckpointType,
   CommercialUse,
   ModelStatus,
-  ModelType,
   ModelUploadType,
   TagTarget,
 } from '~/shared/utils/prisma/enums';
+import { getModelTypeSelectData } from '~/shared/constants/model-type.constants';
 import type { ModelById } from '~/types/router';
 import { showErrorNotification } from '~/utils/notifications';
 import { parseNumericString } from '~/utils/query-string-helpers';
-import { getDisplayName, getModelUrl, splitUppercase, titleCase } from '~/utils/string-helpers';
+import { getModelUrl, splitUppercase, titleCase } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
 import styles from './ModelUpsertForm.module.scss';
@@ -344,12 +345,10 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
                   name="type"
                   label="Type"
                   placeholder="Type"
-                  data={Object.values(ModelType).map((type) => ({
-                    label: getDisplayName(type),
-                    value: type,
-                  }))}
+                  data={getModelTypeSelectData(type)}
                   onChange={handleModelTypeChange}
                   disabled={isTrained}
+                  allowDeselect={false}
                   withAsterisk
                 />
                 {type === 'Checkpoint' && (

--- a/src/components/Tours/tours/auction.tour.tsx
+++ b/src/components/Tours/tours/auction.tour.tsx
@@ -27,7 +27,7 @@ export const auctionTour: StepWithData[] = [
           You can bid ⚡ Buzz to feature models on the homepage and resource selection areas of the
           site. Higher bids = better spots!
         </Text>
-        <Text>Checkpoints will also be enabled for generation until the auction cycle ends.</Text>
+        <Text>Fine-tunes will also be enabled for generation until the auction cycle ends.</Text>
       </Stack>
     ),
     disableBeacon: true,

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  currentlySelectedGroupLabel,
+  getModelTypeSelectData,
+  modelTypeGroups,
+  retiredModelTypes,
+  selectableModelTypes,
+} from '~/shared/constants/model-type.constants';
+import { ModelType } from '~/shared/utils/prisma/enums';
+import { getDisplayName } from '~/utils/string-helpers';
+
+describe('model type picker data', () => {
+  it('covers every ModelType exactly once, as selectable or retired', () => {
+    const all = [...selectableModelTypes, ...retiredModelTypes].sort();
+
+    expect(all).toStrictEqual([...Object.values(ModelType)].sort());
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('offers only the types the 2026-08-31 cleanup kept', () => {
+    expect(selectableModelTypes).toStrictEqual([
+      ModelType.Checkpoint,
+      ModelType.LORA,
+      ModelType.LoCon,
+      ModelType.DoRA,
+      ModelType.VAE,
+      ModelType.TextEncoder,
+      ModelType.UNet,
+      ModelType.Upscaler,
+      ModelType.Workflows,
+      ModelType.Wildcards,
+      ModelType.Controlnet,
+      ModelType.Other,
+    ]);
+  });
+
+  it('groups Controlnet with the workflow additives, not the adapters', () => {
+    const groupOf = (type: ModelType) =>
+      modelTypeGroups.find(({ types }) => types.includes(type))?.group;
+
+    expect(groupOf(ModelType.Controlnet)).toBe('Workflow additives');
+    expect(groupOf(ModelType.LORA)).toBe('Adapters');
+  });
+
+  it('keeps a retired type selectable while it is the current value', () => {
+    // A model already set to a retired type must survive an edit of any other field. If the picker
+    // drops the value, Mantine renders an empty Type field and the next save writes whatever the
+    // user re-picks.
+    for (const retired of retiredModelTypes) {
+      const values = getModelTypeSelectData(retired).map(({ value }) => value);
+
+      expect(values, `${retired} is missing from its own picker`).toContain(retired);
+    }
+  });
+
+  it('shows the grandfathered value first, under its own group, exactly once', () => {
+    const data = getModelTypeSelectData(ModelType.ComfyWorkflows);
+
+    expect(data[0]).toStrictEqual({
+      value: ModelType.ComfyWorkflows,
+      label: getDisplayName(ModelType.ComfyWorkflows),
+      group: currentlySelectedGroupLabel,
+    });
+    expect(data.filter(({ value }) => value === ModelType.ComfyWorkflows)).toHaveLength(1);
+  });
+
+  it('does not add a grandfather group for a type that is still offered', () => {
+    const data = getModelTypeSelectData(ModelType.Checkpoint);
+
+    expect(data.map(({ group }) => group)).not.toContain(currentlySelectedGroupLabel);
+    expect(data.filter(({ value }) => value === ModelType.Checkpoint)).toHaveLength(1);
+  });
+
+  it('offers no retired type when nothing is selected yet', () => {
+    const values = getModelTypeSelectData(null).map(({ value }) => value);
+
+    for (const retired of retiredModelTypes) {
+      expect(values, `${retired} is still offered to new models`).not.toContain(retired);
+    }
+    expect(values).toStrictEqual(selectableModelTypes);
+  });
+
+  it('emits flat items carrying a group, the shape SelectWrapper expects', () => {
+    // Pre-grouped `{ group, items }` objects survive typecheck and render options with no value.
+    for (const item of getModelTypeSelectData(ModelType.Hypernetwork)) {
+      expect(Object.keys(item).sort()).toStrictEqual(['group', 'label', 'value']);
+      expect(typeof item.value).toBe('string');
+      expect(item.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('labels Checkpoint as Fine-tune', () => {
+    expect(getDisplayName(ModelType.Checkpoint)).toBe('Fine-tune');
+  });
+});

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -8,6 +8,7 @@ import {
   resolveModelTypeDefaults,
   retiredModelTypes,
   selectableModelTypes,
+  ungroupedModelTypes,
 } from '~/shared/constants/model-type.constants';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
@@ -104,11 +105,20 @@ describe('model type picker data', () => {
   it('emits flat items carrying a group, the shape SelectWrapper expects', () => {
     // SelectWrapper does the grouping itself; pre-grouped `{ group, items }` renders valueless
     // options.
-    for (const item of getModelTypeSelectData(ModelType.Hypernetwork)) {
-      expect(Object.keys(item).sort()).toStrictEqual(['group', 'label', 'value']);
+    const data = getModelTypeSelectData(ModelType.Hypernetwork);
+
+    for (const item of data) {
+      expect(Object.keys(item).sort()).toStrictEqual(
+        item.group ? ['group', 'label', 'value'] : ['label', 'value']
+      );
       expect(typeof item.value).toBe('string');
       expect(item.label.length).toBeGreaterThan(0);
     }
+
+    // Only the trailing ungrouped types have no heading; a group of one would repeat its own name.
+    expect(data.filter(({ group }) => !group).map(({ value }) => value)).toStrictEqual([
+      ...ungroupedModelTypes,
+    ]);
   });
 
   it('grandfathers a saved model, and offers a template only what is still offered', () => {
@@ -125,8 +135,12 @@ describe('model type picker data', () => {
     // A template seeds `type` with no `id`, so it is a NEW model. Dropping the option alone is not
     // enough: the form would still hold the retired value behind a blank required field, and the
     // submit would create a model on it.
+    // Falling back to Checkpoint would file it as a fine-tune; Other claims nothing.
     const fromTemplate = resolveModelTypeDefaults({ type: ModelType.TextualInversion });
-    expect(fromTemplate).toStrictEqual({ grandfatheredType: null, initialType: null });
+    expect(fromTemplate).toStrictEqual({
+      grandfatheredType: null,
+      initialType: ModelType.Other,
+    });
 
     // A template on a type that is still offered is untouched.
     expect(resolveModelTypeDefaults({ type: ModelType.LORA })).toStrictEqual({
@@ -135,7 +149,7 @@ describe('model type picker data', () => {
     });
     expect(resolveModelTypeDefaults(undefined)).toStrictEqual({
       grandfatheredType: null,
-      initialType: null,
+      initialType: ModelType.Checkpoint,
     });
   });
 
@@ -153,12 +167,11 @@ describe('model type picker data', () => {
     for (const seed of seeds) {
       const { grandfatheredType, initialType } = resolveModelTypeDefaults(seed);
       const offered = getModelTypeSelectData(grandfatheredType).map(({ value }) => value);
-      const startsOn = initialType ?? ModelType.Checkpoint;
 
       expect(
         offered,
-        `${JSON.stringify(seed)} starts on ${startsOn}, absent from its picker`
-      ).toContain(startsOn);
+        `${JSON.stringify(seed)} starts on ${initialType}, absent from its picker`
+      ).toContain(initialType);
     }
   });
 
@@ -170,9 +183,11 @@ describe('model type picker data', () => {
       'utf8'
     );
 
-    expect(source).toMatch(/resolveModelTypeDefaults\(model\)/);
+    expect(source).toMatch(/resolveModelTypeDefaults\(initialModel\)/);
     expect(source).toMatch(/getModelTypeSelectData\(grandfatheredType\)/);
-    expect(source).toMatch(/type: initialType \?\? 'Checkpoint'/);
+    expect(source).toMatch(/type: initialType,/);
+    expect(source).not.toContain('getModelTypeSelectData(type)');
+    expect(source).not.toContain('resolveModelTypeDefaults(model)');
   });
 
   it('labels Checkpoint as Fine-tune', () => {

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -5,6 +5,7 @@ import {
   currentlySelectedGroupLabel,
   getModelTypeSelectData,
   modelTypeGroups,
+  resolveModelTypeDefaults,
   retiredModelTypes,
   selectableModelTypes,
 } from '~/shared/constants/model-type.constants';
@@ -110,20 +111,68 @@ describe('model type picker data', () => {
     }
   });
 
-  it('reads the grandfathered type from the saved model, never from the form', () => {
-    // This has to be asserted at the call site: both ways of getting it wrong type-check and pass
-    // every test above. Passing the watched `type` drops the grandfathered option the moment the
-    // user clicks another one, so the original becomes unrecoverable; and a template seeds `type`
-    // with no `id`, so keying off anything but `model?.id` lets `/models/create?templateId=` mint a
-    // new model on a retired type — the thing retiring it was meant to stop.
+  it('grandfathers a saved model, and offers a template only what is still offered', () => {
+    // A saved model keeps a retired type and the picker re-offers it.
+    const saved = resolveModelTypeDefaults({ id: 7, type: ModelType.TextualInversion });
+    expect(saved).toStrictEqual({
+      grandfatheredType: ModelType.TextualInversion,
+      initialType: ModelType.TextualInversion,
+    });
+    expect(getModelTypeSelectData(saved.grandfatheredType).map(({ value }) => value)).toContain(
+      ModelType.TextualInversion
+    );
+
+    // A template seeds `type` with no `id`, so it is a NEW model. Dropping the option alone is not
+    // enough: the form would still hold the retired value behind a blank required field, and the
+    // submit would create a model on it.
+    const fromTemplate = resolveModelTypeDefaults({ type: ModelType.TextualInversion });
+    expect(fromTemplate).toStrictEqual({ grandfatheredType: null, initialType: null });
+
+    // A template on a type that is still offered is untouched.
+    expect(resolveModelTypeDefaults({ type: ModelType.LORA })).toStrictEqual({
+      grandfatheredType: null,
+      initialType: ModelType.LORA,
+    });
+    expect(resolveModelTypeDefaults(undefined)).toStrictEqual({
+      grandfatheredType: null,
+      initialType: null,
+    });
+  });
+
+  it('never leaves the form holding a type the picker will not show', () => {
+    // The pairing is the invariant, not either half: whatever the form starts on must be in the
+    // picker's data, or Mantine renders a blank input over a value the submit still sends.
+    const seeds = [
+      { id: 7, type: ModelType.ComfyWorkflows },
+      { id: 7, type: ModelType.Checkpoint },
+      { type: ModelType.Hypernetwork },
+      { type: ModelType.LORA },
+      undefined,
+    ];
+
+    for (const seed of seeds) {
+      const { grandfatheredType, initialType } = resolveModelTypeDefaults(seed);
+      const offered = getModelTypeSelectData(grandfatheredType).map(({ value }) => value);
+      const startsOn = initialType ?? ModelType.Checkpoint;
+
+      expect(
+        offered,
+        `${JSON.stringify(seed)} starts on ${startsOn}, absent from its picker`
+      ).toContain(startsOn);
+    }
+  });
+
+  it('wires the picker to the resolver rather than to the form value', () => {
+    // Both halves have to come from the same call: passing the watched form value type-checks and
+    // passes every assertion above, while dropping the grandfathered option on the first click.
     const source = readFileSync(
       path.resolve(__dirname, '../../../components/Resource/Forms/ModelUpsertForm.tsx'),
       'utf8'
     );
 
-    expect(source).toContain('const grandfatheredType = model?.id ? model.type : null;');
-    expect(source).toContain('data={getModelTypeSelectData(grandfatheredType)}');
-    expect(source).not.toContain('getModelTypeSelectData(type)');
+    expect(source).toMatch(/resolveModelTypeDefaults\(model\)/);
+    expect(source).toMatch(/getModelTypeSelectData\(grandfatheredType\)/);
+    expect(source).toMatch(/type: initialType \?\? 'Checkpoint'/);
   });
 
   it('labels Checkpoint as Fine-tune', () => {

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import {
   currentlySelectedGroupLabel,
@@ -71,6 +73,24 @@ describe('model type picker data', () => {
     expect(data.filter(({ value }) => value === ModelType.Checkpoint)).toHaveLength(1);
   });
 
+  it('lists both partitions explicitly, so a new ModelType cannot become silently unpickable', () => {
+    // retiredModelTypes is written out rather than derived as the complement of the selectable set.
+    // Derived, a ModelType added later would land in it and this file would stay green.
+    expect([...retiredModelTypes]).toStrictEqual([
+      ModelType.TextualInversion,
+      ModelType.Hypernetwork,
+      ModelType.AestheticGradient,
+      ModelType.MotionModule,
+      ModelType.Poses,
+      ModelType.Detection,
+      ModelType.ComfyWorkflows,
+      ModelType.CLIP,
+      ModelType.CLIPVision,
+      ModelType.LLM,
+      ModelType.VisionLanguage,
+    ]);
+  });
+
   it('offers no retired type when nothing is selected yet', () => {
     const values = getModelTypeSelectData(null).map(({ value }) => value);
 
@@ -81,12 +101,29 @@ describe('model type picker data', () => {
   });
 
   it('emits flat items carrying a group, the shape SelectWrapper expects', () => {
-    // Pre-grouped `{ group, items }` objects survive typecheck and render options with no value.
+    // SelectWrapper does the grouping itself; pre-grouped `{ group, items }` renders valueless
+    // options.
     for (const item of getModelTypeSelectData(ModelType.Hypernetwork)) {
       expect(Object.keys(item).sort()).toStrictEqual(['group', 'label', 'value']);
       expect(typeof item.value).toBe('string');
       expect(item.label.length).toBeGreaterThan(0);
     }
+  });
+
+  it('reads the grandfathered type from the saved model, never from the form', () => {
+    // This has to be asserted at the call site: both ways of getting it wrong type-check and pass
+    // every test above. Passing the watched `type` drops the grandfathered option the moment the
+    // user clicks another one, so the original becomes unrecoverable; and a template seeds `type`
+    // with no `id`, so keying off anything but `model?.id` lets `/models/create?templateId=` mint a
+    // new model on a retired type — the thing retiring it was meant to stop.
+    const source = readFileSync(
+      path.resolve(__dirname, '../../../components/Resource/Forms/ModelUpsertForm.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain('const grandfatheredType = model?.id ? model.type : null;');
+    expect(source).toContain('data={getModelTypeSelectData(grandfatheredType)}');
+    expect(source).not.toContain('getModelTypeSelectData(type)');
   });
 
   it('labels Checkpoint as Fine-tune', () => {

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -43,7 +43,9 @@ type UncategorisedModelType = Exclude<
 
 /**
  * Both lists are written out rather than one being the other's complement, so that a ModelType added
- * later is a compile error here instead of silently becoming unpickable.
+ * later is caught instead of silently becoming unpickable. Dropping `as const` above widens
+ * `types` and makes this check pass vacuously, so the runtime test that the two lists cover the enum
+ * is the durable half of the pair, not this.
  */
 const _everyModelTypeIsCategorised: [UncategorisedModelType] extends [never]
   ? true
@@ -64,10 +66,9 @@ const toItem = (type: ModelType, group: string): ModelTypeSelectItem => ({
 });
 
 /**
- * `currentType` must be the saved type of an existing model, never the live form value: re-deriving
- * it from the form would drop the grandfathered option the moment the user clicked another type,
- * making the original unrecoverable. Passing it for a new model (a template seeds one) would let a
- * retired type be minted afresh.
+ * `currentType` must come from {@link resolveModelTypeDefaults}, never from the live form value:
+ * re-deriving it from the form would drop the grandfathered option the moment the user clicked
+ * another type, making the original unrecoverable.
  *
  * Returns flat items carrying a `group`, which is what SelectWrapper collapses into Mantine's
  * grouped data.
@@ -82,4 +83,25 @@ export function getModelTypeSelectData(
   if (!currentType || selectableModelTypeSet.has(currentType)) return offered;
 
   return [toItem(currentType as ModelType, currentlySelectedGroupLabel), ...offered];
+}
+
+type ModelTypeSeed = { id?: number | null; type?: ModelType | string | null } | null | undefined;
+
+/**
+ * Splits what the form starts on from what the picker has to keep offering.
+ *
+ * A saved model keeps its type whatever it is, retired or not, and the picker re-offers it. A model
+ * being seeded from someone's template or bounty is a NEW model, so it may only start on a type that
+ * is still offered: leaving a retired one in place renders a blank required field while the form
+ * still holds the retired value, and the submit then creates a model on it.
+ */
+export function resolveModelTypeDefaults(model: ModelTypeSeed) {
+  const seeded = (model?.type ?? null) as ModelType | null;
+  const isSaved = !!model?.id;
+  const seededIsOffered = !!seeded && selectableModelTypeSet.has(seeded);
+
+  return {
+    grandfatheredType: isSaved ? seeded : null,
+    initialType: isSaved || seededIsOffered ? seeded : null,
+  };
 }

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -12,10 +12,15 @@ export const modelTypeGroups = [
     group: 'Workflow additives',
     types: [ModelType.Workflows, ModelType.Wildcards, ModelType.Controlnet],
   },
-  { group: 'Other', types: [ModelType.Other] },
 ] as const satisfies readonly { group: string; types: readonly ModelType[] }[];
 
-export const selectableModelTypes = modelTypeGroups.flatMap(({ types }) => types);
+/** Offered after the groups, under no heading — a group of one repeats its own name as a header. */
+export const ungroupedModelTypes = [ModelType.Other] as const satisfies readonly ModelType[];
+
+export const selectableModelTypes = [
+  ...modelTypeGroups.flatMap(({ types }) => types),
+  ...ungroupedModelTypes,
+] as ModelType[];
 
 /**
  * Types no longer offered when picking a type. They stay valid everywhere else: a model already set
@@ -35,7 +40,9 @@ export const retiredModelTypes = [
   ModelType.VisionLanguage,
 ] as const satisfies readonly ModelType[];
 
-type SelectableModelType = (typeof modelTypeGroups)[number]['types'][number];
+type SelectableModelType =
+  | (typeof modelTypeGroups)[number]['types'][number]
+  | (typeof ungroupedModelTypes)[number];
 type UncategorisedModelType = Exclude<
   ModelType,
   SelectableModelType | (typeof retiredModelTypes)[number]
@@ -49,20 +56,22 @@ type UncategorisedModelType = Exclude<
  */
 const _everyModelTypeIsCategorised: [UncategorisedModelType] extends [never]
   ? true
-  : { error: 'Add it to modelTypeGroups or retiredModelTypes'; missing: UncategorisedModelType } =
-  true;
+  : {
+      error: 'Add it to modelTypeGroups, ungroupedModelTypes or retiredModelTypes';
+      missing: UncategorisedModelType;
+    } = true;
 void _everyModelTypeIsCategorised;
 
 const selectableModelTypeSet = new Set<string>(selectableModelTypes);
 
 export const currentlySelectedGroupLabel = 'Currently selected';
 
-type ModelTypeSelectItem = { value: ModelType; label: string; group: string };
+type ModelTypeSelectItem = { value: ModelType; label: string; group?: string };
 
-const toItem = (type: ModelType, group: string): ModelTypeSelectItem => ({
+const toItem = (type: ModelType, group?: string): ModelTypeSelectItem => ({
   value: type,
   label: getDisplayName(type),
-  group,
+  ...(group ? { group } : {}),
 });
 
 /**
@@ -76,9 +85,10 @@ const toItem = (type: ModelType, group: string): ModelTypeSelectItem => ({
 export function getModelTypeSelectData(
   currentType?: ModelType | string | null
 ): ModelTypeSelectItem[] {
-  const offered = modelTypeGroups.flatMap(({ group, types }) =>
-    types.map((type) => toItem(type, group))
-  );
+  const offered = [
+    ...modelTypeGroups.flatMap(({ group, types }) => types.map((type) => toItem(type, group))),
+    ...ungroupedModelTypes.map((type) => toItem(type)),
+  ];
 
   if (!currentType || selectableModelTypeSet.has(currentType)) return offered;
 
@@ -87,21 +97,28 @@ export function getModelTypeSelectData(
 
 type ModelTypeSeed = { id?: number | null; type?: ModelType | string | null } | null | undefined;
 
+/** What a form with nothing to go on starts on. */
+export const defaultModelType = ModelType.Checkpoint;
+
 /**
- * Splits what the form starts on from what the picker has to keep offering.
+ * Splits what the form starts on from what the picker has to keep offering. Both must come from one
+ * call: a value the form holds that the picker will not render is a blank required input over a live
+ * value, which submits.
  *
- * A saved model keeps its type whatever it is, retired or not, and the picker re-offers it. A model
- * being seeded from someone's template or bounty is a NEW model, so it may only start on a type that
- * is still offered: leaving a retired one in place renders a blank required field while the form
- * still holds the retired value, and the submit then creates a model on it.
+ * A saved model keeps its type whatever it is, retired or not, and the picker re-offers it. A
+ * template or bounty seeds a NEW model, so a retired type there falls back to `Other` rather than to
+ * `Checkpoint` — the substitution is invisible either way, and `Other` is the one selectable type
+ * that claims nothing about the model. Filing a pose pack as a fine-tune is the worse silent error.
  */
 export function resolveModelTypeDefaults(model: ModelTypeSeed) {
   const seeded = (model?.type ?? null) as ModelType | null;
   const isSaved = !!model?.id;
-  const seededIsOffered = !!seeded && selectableModelTypeSet.has(seeded);
+
+  if (isSaved && seeded) return { grandfatheredType: seeded, initialType: seeded };
+  if (!seeded) return { grandfatheredType: null, initialType: defaultModelType };
 
   return {
-    grandfatheredType: isSaved ? seeded : null,
-    initialType: isSaved || seededIsOffered ? seeded : null,
+    grandfatheredType: null,
+    initialType: selectableModelTypeSet.has(seeded) ? seeded : ModelType.Other,
   };
 }

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -1,9 +1,7 @@
 import { ModelType } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
 
-export type ModelTypeGroup = { group: string; types: ModelType[] };
-
-export const modelTypeGroups: ModelTypeGroup[] = [
+export const modelTypeGroups = [
   { group: 'Fine-tunes', types: [ModelType.Checkpoint] },
   { group: 'Adapters', types: [ModelType.LORA, ModelType.LoCon, ModelType.DoRA] },
   {
@@ -15,18 +13,45 @@ export const modelTypeGroups: ModelTypeGroup[] = [
     types: [ModelType.Workflows, ModelType.Wildcards, ModelType.Controlnet],
   },
   { group: 'Other', types: [ModelType.Other] },
-];
+] as const satisfies readonly { group: string; types: readonly ModelType[] }[];
 
 export const selectableModelTypes = modelTypeGroups.flatMap(({ types }) => types);
 
 /**
  * Types no longer offered when picking a type. They stay valid everywhere else: a model already set
- * to one keeps the value, keeps displaying it, and must keep it through an edit of any other field
- * — which is why the picker re-adds the current value rather than filtering it out.
+ * to one keeps the value and keeps displaying it.
  */
-export const retiredModelTypes = Object.values(ModelType).filter(
-  (type) => !selectableModelTypes.includes(type)
-);
+export const retiredModelTypes = [
+  ModelType.TextualInversion,
+  ModelType.Hypernetwork,
+  ModelType.AestheticGradient,
+  ModelType.MotionModule,
+  ModelType.Poses,
+  ModelType.Detection,
+  ModelType.ComfyWorkflows,
+  ModelType.CLIP,
+  ModelType.CLIPVision,
+  ModelType.LLM,
+  ModelType.VisionLanguage,
+] as const satisfies readonly ModelType[];
+
+type SelectableModelType = (typeof modelTypeGroups)[number]['types'][number];
+type UncategorisedModelType = Exclude<
+  ModelType,
+  SelectableModelType | (typeof retiredModelTypes)[number]
+>;
+
+/**
+ * Both lists are written out rather than one being the other's complement, so that a ModelType added
+ * later is a compile error here instead of silently becoming unpickable.
+ */
+const _everyModelTypeIsCategorised: [UncategorisedModelType] extends [never]
+  ? true
+  : { error: 'Add it to modelTypeGroups or retiredModelTypes'; missing: UncategorisedModelType } =
+  true;
+void _everyModelTypeIsCategorised;
+
+const selectableModelTypeSet = new Set<string>(selectableModelTypes);
 
 export const currentlySelectedGroupLabel = 'Currently selected';
 
@@ -39,8 +64,13 @@ const toItem = (type: ModelType, group: string): ModelTypeSelectItem => ({
 });
 
 /**
- * Flat items carrying a `group`, which is the shape SelectWrapper collapses into Mantine's grouped
- * data — handing it pre-grouped `{ group, items }` objects instead produces options with no value.
+ * `currentType` must be the saved type of an existing model, never the live form value: re-deriving
+ * it from the form would drop the grandfathered option the moment the user clicked another type,
+ * making the original unrecoverable. Passing it for a new model (a template seeds one) would let a
+ * retired type be minted afresh.
+ *
+ * Returns flat items carrying a `group`, which is what SelectWrapper collapses into Mantine's
+ * grouped data.
  */
 export function getModelTypeSelectData(
   currentType?: ModelType | string | null
@@ -49,7 +79,7 @@ export function getModelTypeSelectData(
     types.map((type) => toItem(type, group))
   );
 
-  if (!currentType || selectableModelTypes.includes(currentType as ModelType)) return offered;
+  if (!currentType || selectableModelTypeSet.has(currentType)) return offered;
 
   return [toItem(currentType as ModelType, currentlySelectedGroupLabel), ...offered];
 }

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -1,0 +1,55 @@
+import { ModelType } from '~/shared/utils/prisma/enums';
+import { getDisplayName } from '~/utils/string-helpers';
+
+export type ModelTypeGroup = { group: string; types: ModelType[] };
+
+export const modelTypeGroups: ModelTypeGroup[] = [
+  { group: 'Fine-tunes', types: [ModelType.Checkpoint] },
+  { group: 'Adapters', types: [ModelType.LORA, ModelType.LoCon, ModelType.DoRA] },
+  {
+    group: 'Component replacements',
+    types: [ModelType.VAE, ModelType.TextEncoder, ModelType.UNet, ModelType.Upscaler],
+  },
+  {
+    group: 'Workflow additives',
+    types: [ModelType.Workflows, ModelType.Wildcards, ModelType.Controlnet],
+  },
+  { group: 'Other', types: [ModelType.Other] },
+];
+
+export const selectableModelTypes = modelTypeGroups.flatMap(({ types }) => types);
+
+/**
+ * Types no longer offered when picking a type. They stay valid everywhere else: a model already set
+ * to one keeps the value, keeps displaying it, and must keep it through an edit of any other field
+ * — which is why the picker re-adds the current value rather than filtering it out.
+ */
+export const retiredModelTypes = Object.values(ModelType).filter(
+  (type) => !selectableModelTypes.includes(type)
+);
+
+export const currentlySelectedGroupLabel = 'Currently selected';
+
+type ModelTypeSelectItem = { value: ModelType; label: string; group: string };
+
+const toItem = (type: ModelType, group: string): ModelTypeSelectItem => ({
+  value: type,
+  label: getDisplayName(type),
+  group,
+});
+
+/**
+ * Flat items carrying a `group`, which is the shape SelectWrapper collapses into Mantine's grouped
+ * data — handing it pre-grouped `{ group, items }` objects instead produces options with no value.
+ */
+export function getModelTypeSelectData(
+  currentType?: ModelType | string | null
+): ModelTypeSelectItem[] {
+  const offered = modelTypeGroups.flatMap(({ group, types }) =>
+    types.map((type) => toItem(type, group))
+  );
+
+  if (!currentType || selectableModelTypes.includes(currentType as ModelType)) return offered;
+
+  return [toItem(currentType as ModelType, currentlySelectedGroupLabel), ...offered];
+}

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -42,6 +42,7 @@ export function getStripeCurrencyDisplay(unitAmount: number, currency: string) {
 }
 
 const nameOverrides: Record<string, string> = {
+  Checkpoint: 'Fine-tune',
   LoCon: 'LyCORIS',
   LORA: 'LoRA',
   DoRA: 'DoRA',


### PR DESCRIPTION
Closes the picker half of [868kyynk6](https://app.clickup.com/t/868kyynk6). Scope is deliberately narrow: **nothing downstream of the type picker changes** — not base models, not model file types, not the filter dropdowns, not the public `/api/v1/enums` list, not the search service. Only the type picker on the model upsert form.

## What changed

**Grouped picker.** `src/shared/constants/model-type.constants.ts` defines the groups — fine-tunes / adapters / component replacements / workflow additives / other — and builds the picker's data. ControlNet sits with the workflow additives rather than the adapters, per Justin.

**Eleven types retired from the picker**, grandfathered everywhere else: Hypernetwork, Aesthetic Gradient, Embedding, Motion, Poses, Detection, ComfyWorkflows, CLIP, CLIP Vision, LLM, Vision Language.

Retirement is picker-only and reversible. A model already set to a retired type keeps the value, keeps displaying it, and `getModelTypeSelectData` re-adds that value to the picker under a `Currently selected` group, so an edit of any other field cannot silently change or drop it. That is the failure this PR is most careful about, and it is what the tests are pointed at.

**Checkpoint now displays as "Fine-tune".** One line in the existing `nameOverrides` map in `src/utils/string-helpers.ts`, which already does exactly this for `LoCon` → LyCORIS and `TextualInversion` → Embedding.

🔴 **The `ModelType` enum value stays `Checkpoint`, deliberately — do not "finish the job" later.** Beyond the DB migration, `src/components/CivitaiLink/shared-types.ts` carries `'Checkpoint'` inside a wire-protocol union shared with the Civitai Link client, so renaming the enum value is a breaking protocol change against software whose deploy we do not control. The display rename gets the whole user-visible benefit at none of that cost. Audit backing this: nothing in `src/` compares `getDisplayName`'s output, and there is no reverse label-to-type lookup anywhere in the workspace, so the display map is safe to extend.

**Click-to-unselect bug fixed.** Mantine 7 `Select` defaults `allowDeselect` to `true`, so clicking the already-selected option fired `onChange(null)` and emptied the Type field. Thirty-plus other Selects in the repo already pass `allowDeselect={false}`; this one did not.

**Three copy edits** where "Checkpoint" named the model type in prose or a hand-written label: the app-settings resource-type option, the auction info panel, and the auction tour.

## Decisions recorded here on purpose

**The retired ComfyWorkflows type is currently the *growing* one, and it was retired knowingly.** 98 models published all-time, all 98 within the last year and 95 within the last 90 days. Justin made the call having read that number, on the grounds that a Comfy workflow is a workflow and one label should serve both. It is written down here so that whoever finds it in six months reads a decision rather than an oversight.

**LyCORIS and DoRA were deliberately NOT folded into LoRA.** Folding them "as file types" would require adding model file types, which this scope forbids, and the downstream work was judged not worth it at current volumes. Both stay in the picker unchanged.

**`FileInfo`'s `componentTypeDisplayNames` map still says "Checkpoint"** and was left alone — it names a model *file component*, not a model type.

⚠️ **Two labels now read oddly and need a copy decision that is not mine:** "Checkpoint Type" in `ModelUpsertForm` and "Checkpoint type" in `ModelFiltersDropdown`. Both name the separate `CheckpointType` enum (Trained / Merged), which is out of scope, so they were left exactly as they are rather than guessed at.

## Verification

- `pnpm run typecheck` — `typecheck: OK — 0 type errors in 436s`, exit 0.
- `pnpm run lint` — the five files touched plus the two new ones produce **zero** eslint errors (the repo-wide run has a large pre-existing baseline). One error this change did introduce — `ModelType` becoming type-only in `ModelUpsertForm` — was caught by lint and fixed.
- `pnpm exec prettier --write` over the seven files.
- `pnpm run test:unit:run` — `Test Files  4 failed | 1524 passed | 2 skipped (1530)`, `Tests  10 failed | 24084 passed | 28 skipped (24122)`, exit 1. **All four failures are pre-existing on this base**: stashing the change and re-running those four files alone gives the identical `Test Files  4 failed (4)` / `Tests  10 failed | 99 passed (109)`. They are `trace-flush`, `appModeratorMessageForm.callSites`, `credential-detection-superset.guard` and `blocks/tools/registry` — none of them touch model types.
- `blocks.router.workflow.test.ts` collected **370** tests (nonzero, so the submodule is initialised and the run means something).

**The new tests were checked against reverts, not just run.** Three mutations, each producing a legible failure naming the wrong value rather than a hang or a timeout:

| Mutation | Result |
|---|---|
| Drop the grandfathering branch | 2 failed — `AssertionError: TextualInversion is missing from its own picker` |
| Remove `Checkpoint: 'Fine-tune'` from the override map | 1 failed — `expected 'Checkpoint' to be 'Fine-tune'` |
| Return pre-grouped `{ group, items }` instead of flat items | 3 failed — `expected [ 'group', 'items' ] to strictly equal [ 'group', 'label', 'value' ]` |

That third one is a real bug this caught during development. `SelectWrapper` takes a **flat** array whose items each carry a `group` field, and does the grouping itself; handing it pre-grouped objects typechecks and renders options with no value. The test now pins the shape.

## Not covered

No browser-level reproduction of the unselect bug or of the grandfathered picker. The diagnosis is from the installed Mantine source and the call site, and the grandfathering is covered at the data layer rather than through a rendered Select.


---

## Review round (commit 2)

An adversarial review of the first commit found three real defects. All three were silent — they type-checked and passed every test in the first commit.

**The grandfathered option was derived from the watched form value.** On a model set to a retired type, one click on another type removed the original from the list for the rest of the form session, so a mis-click was unrecoverable and the next save wrote the new type. Before this PR the full enum was always present, so this was a regression the PR introduced. It now reads the saved model's type.

**A template could mint a new model on a retired type.** `/models/create?templateId=…` seeds `ModelUpsertForm` through `modelData = model ?? templateFields ?? bountyFields`, and `getModelTemplateFieldsHandler` selects `type` while `templateOmittableFields` is only `['description','tags']`. The template payload carries no `id`, so keying the grandfathering off `model?.id` is what separates "editing a saved model" from "seeded from someone else's". Same one-line fix as above.

**`retiredModelTypes` was the complement of the selectable set.** A `ModelType` added later would have landed in it and become silently unpickable, with the whole suite green. Both lists are now written out, plus a compile-time check that they cover the enum.

Verified the compile check is not inert: deleting `ModelType.Poses` from `retiredModelTypes` gives `error TS2322: Type 'boolean' is not assignable to type '{ error: "Add it to modelTypeGroups or retiredModelTypes"; missing: "Poses"; }'` and `typecheck: 1 type error(s)`, exit 2. Restored, it is `typecheck: OK — 0 type errors`, exit 0.

The call site is guarded by reading the source of `ModelUpsertForm.tsx`, because both ways of getting it wrong type-check and pass every data-level assertion. Controls on the fix round, each failing legibly:

| Mutation | Result |
|---|---|
| Call site back to `getModelTypeSelectData(type)` | 1 failed — `expected … to contain 'data={getModelTypeSelectData(grandfat…'` |
| Derivation ignores `model?.id` | 1 failed — `expected … to contain 'const grandfatheredType = model?.id ?…'` |
| A `ModelType` in neither partition | 2 failed — `expected [ 'TextualInversion', …(9) ] to strictly equal [ 'TextualInversion', …(10) ]` |

Re-ran after the fixes: `Test Files  4 failed | 1524 passed | 2 skipped (1530)`, `Tests  10 failed | 24086 passed | 28 skipped (24124)` — same four pre-existing files, and the test count moved by exactly the two tests added.

## Two things the review raised that are decisions, not defects

**Embedding is retired from publishing while remaining first-class in generation.** `src/shared/data-graph/generation/common.ts` defaults generation addon `resourceTypes` to `['TextualInversion','LORA','LoCon','DoRA']`, and embeddings keep their own primary file types. So existing embeddings stay fully usable; only new ones can no longer be published. That follows from the usage data the retirement was decided on — 327 published in the last year, 38 in the last 90 days — but it is the one retirement that touches a live flow, so it is called out rather than buried.

**The rename is global, not picker-only, and that is intended** — `nameOverrides` feeds the model page title, the "new version" notification and the PDF template alike. One visible seam: the auction copy now says "Fine-tunes will be enabled for use in generation" while the auction itself is still named from `auctionBase` with the slug `featured-checkpoints`. Renaming the auction is a data change outside this scope; flagging it so it is a decision rather than an oversight.

## Review round 2 (commit 3) — the first fix was incomplete

Re-reviewing the fix found that hiding the option did not stop a template minting a retired type; it made the failure quieter. A template seeds `type` with **no** `id`, so the form started on the retired value while the picker omitted it. Mantine 7 resolves the selected option by lookup, finds nothing, and finalises the input's search value to `''` — a **blank required field with no error**, `onChange` never fires, react-hook-form still holds the retired type, `z.enum(ModelType)` accepts it server-side, and the submit creates a brand-new model on a retired type. Worse than the bug it replaced, and every test in commit 2 passed over it.

`resolveModelTypeDefaults` now returns the two things separately: what the form **starts on**, and what the picker must **keep offering**. A saved model (`id` present) keeps a retired type in both. Anything seeding a new model — template or bounty — falls back to `Checkpoint`, the same default a fresh create already gets, so the picker shows a real selection the user can change rather than a blank box over a hidden value.

⚠️ **User-visible consequence worth knowing:** using an embedding (or any retired-type model) as a template now starts the new model on Fine-tune instead of carrying the retired type over. That follows directly from "retired types are not offered to new models"; flagging it because it is the one place this PR changes what an existing flow does.

The tests now assert **the pairing** — whatever the form starts on must be present in the picker's data for that same seed — rather than either half, because a value the form holds and the picker will not show is the actual failure mode. Controls:

| Mutation | Result |
|---|---|
| Template keeps its seeded retired type (the defect as it was) | 2 failed — `{"type":"Hypernetwork"} starts on Hypernetwork, absent from its picker: expected [ 'Checkpoint', 'LORA', 'LoCon', …(9) ] to include 'Hypernetwork'` |
| Template also grandfathers its type | 1 failed — `expected { …(2) } to strictly equal { grandfatheredType: null, …(1) }` |

Also from that round: the compile-time exhaustiveness check goes vacuous if `as const` is ever dropped from `modelTypeGroups` (widening `types` makes the `Exclude` `never`), so the comment now says the runtime test is the durable half of that pair.

`typecheck: OK — 0 type errors`, exit 0. Full suite `Test Files  4 failed | 1524 passed | 2 skipped (1530)`, `Tests  10 failed | 24088 passed | 28 skipped (24126)` — the same four pre-existing files throughout, and the test count has moved only by the tests added.

## Review round 3 (commit 4)

The third pass cleared the entry points — it verified that neither template handler selects `id`, that the edit page, the wizard, the trained path and the bounty path all gate on load, and that `allowDeselect={false}` reaches Mantine through `SelectWrapper`'s prop spread. It found that the previous fix had traded a visible failure for an invisible one, plus three smaller things.

**Falling back to `Checkpoint` silently reclassified a templated model.** Using a `Poses` or `TextualInversion` model as a template opened the form showing Type = "Fine-tune", with no notice the type had been dropped, *and* a newly-required "Checkpoint Type" control the user never asked for (a retired-type template has no `checkpointType`). Filing a pose pack as a fine-tune is a worse silent error than the blank field it replaced. The fallback is now `ModelType.Other`, the one selectable type that claims nothing about the model.

**The two halves could drift.** `initialType` reaches react-hook-form once through `defaultValues`; `grandfatheredType` recomputed every render. They were in step only because of two loading gates and a `formKey` that happens to include the template loading flag — none of which mentions the constraint. A future mount site passing `model` asynchronously would have left the form on `Checkpoint` while the picker grandfathered a saved retired type, and the next save would have rewritten it. Both now come from one `useRef` snapshot taken on first render, so they cannot disagree.

**`Other` was a group of one repeating its own name** as a heading. It is now offered after the groups with no heading.

**The source guard's negative assertion is back** — `not.toContain('getModelTypeSelectData(type)')` and `not.toContain('resolveModelTypeDefaults(model)')`. The `toMatch` regexes alone would pass on a file holding both a commented-out correct line and a live wrong one.

Controls on this round:

| Mutation | Result |
|---|---|
| Retired template falls back to `Checkpoint` again | 1 failed — `expected { grandfatheredType: null, …(1) } to strictly equal { …(1) }` |
| `Other` put back inside a group of one | 1 failed — `expected [] to strictly equal [ 'Other' ]` |
| Form recomputes the snapshot every render | 1 failed — `expected … to match /resolveModelTypeDefaults\(initialMode…/` |

`typecheck: OK — 0 type errors`, exit 0. Full suite `Test Files  4 failed | 1524 passed | 2 skipped (1530)`, `Tests  10 failed | 24088 passed | 28 skipped (24126)` — the same four pre-existing files in all four runs of this branch.

## ⚠️ One thing for the reviewer to weigh: the retirement list is based on PUBLICATIONS, not creations

The proposal this PR implements counted models *published* in a window. Models *created* is what actually flows through the picker, and it tells a different story for three of the retirements. Both columns, prod replica, last 90 days:

| Type | Created | Published |
|---|---|---|
| ComfyWorkflows — retiring | 123 | 95 |
| Embedding — retiring | 75 | 38 |
| Poses — retiring | 36 | 3 |
| Detection — retiring | 13 | 8 |
| Motion — retiring | 11 | 0 |
| Text Encoder — kept | 20 | 15 |
| VAE — kept | 18 | 10 |
| UNet — kept | 11 | 9 |
| Controlnet — kept | 10 | 6 |
| Upscaler — kept | 9 | 3 |

Three retired types are created more often than five kept ones. Poses at 36 creations for 3 publications is mostly abandoned drafts, which is arguably its own argument for retiring it; Embedding at 75 creations a quarter is not nothing. This does not contradict the decision — it was made on the publication numbers, and those were correct — but the question asked was "does anyone still make these", and creation is the better column for that. Raised with Justin; retirement is picker-only and reversible, so any of these is a one-line restore.

## Other copy drift the review found, deliberately not fixed here

`"Please select the checkpoint type"` (`ModelUpsertForm` validation) and `"Choose a checkpoint"` (`PageBlockHost`) still say checkpoint. The first belongs with the two `"Checkpoint Type"` labels already flagged above — same field, same out-of-scope enum. The second is outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixurvMzNDe2C5fiRduwyj
