### PR TITLE
feat(collections): sort a collection by when things were added to it

### DIFF
--- a/docs/features/collaborative-collections.md
+++ b/docs/features/collaborative-collections.md
@@ -266,9 +266,9 @@ separately everywhere else too.
 `pendingReviewCount` on `collection.getById`. The count is computed only for `manage` holders, and
 it is an exact `count` with **no cap and no mode exclusion** — resist adding either.
 
-The reason that is safe is not in `schema.full.prisma`. That file declares only
-`@@index([collectionId], type: Hash)` on `CollectionItem`, which would make a status-filtered count
-walk the whole collection. Production actually carries
+The reason that is safe is not in `schema.full.prisma`. The only `CollectionItem` index that file
+declares that a status-filtered count could use is `@@index([collectionId], type: Hash)`, which
+would make the count walk the whole collection. Production actually carries
 `CollectionItem_collectionId_status_covered` — a btree on `(collectionId, status, createdAt DESC)`
 — so the count is an index-only scan: measured at **0.5 ms / 4 buffers** on a 190k-item collection
 and **0.8 ms / 73 buffers** for a real 466-row review backlog. This is the same

--- a/packages/civitai-db-schema/prisma/migrations/20260831120000_collection_item_recently_added_idx/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260831120000_collection_item_recently_added_idx/migration.sql
@@ -1,29 +1,24 @@
--- Serves the collection feeds' new "Recently Added" sort, which orders on the
--- CollectionItem row's own id:
---   WHERE "collectionId" = $1 AND <status/entity filters> ORDER BY id DESC LIMIT $2
+-- Serves the collection feeds' "Recently Added" sort, which orders on the CollectionItem
+-- row's own id rather than the entity's. No existing index can produce that order: the
+-- closest, CollectionItem_image_idx ("collectionId", "imageId"), is why the pre-existing
+-- Newest sort on images is cheap — imageId order IS id order there — and it says nothing
+-- about the order items were added in.
 --
--- No existing index can produce that order. The closest, CollectionItem_image_idx
--- ("collectionId", "imageId"), is why the pre-existing Newest sort is cheap — it
--- yields imageId order, which for images IS id order. Ordering on the item id
--- instead makes the planner read every row of the collection and sort: measured on
--- the prod replica against the largest image collection (163,624 items), 246ms
--- versus 19ms for the same page under Newest.
+-- Not partial on an entity column, unlike the four ("collectionId", <entity>Id) uniques
+-- beside it. Collection.tsx dispatches a collection to exactly one feed by Collection.type,
+-- so within a single collectionId the entity filter drops nothing in practice, and one
+-- index serves images, models, posts and articles instead of four over the same table.
 --
--- What this index buys, measured on a 44,367-item collection with an equivalent
--- index scoped to that one collectionId: 42.2ms -> 1.8ms, and the Sort node
--- disappears. The point is the shape rather than the ratio — the scan reads 102
--- rows and stops at the LIMIT instead of reading all 44,367, so the page cost stops
--- scaling with the size of the collection.
+-- Cost of the full feed query without it, prod replica, most-viewed image collection
+-- (~16.5k items): 448ms warm, 1.4s cold, against 2-3ms for Newest. On a collection whose
+-- newest item is far behind the table's max id the planner switches to a backward scan of
+-- CollectionItem_pkey and the cost is unbounded — one 191k-item model collection did not
+-- return in 45s.
 --
--- Not partial on an entity column, unlike the four ("collectionId", <entity>Id)
--- uniques beside it. A collection holds one entity type (Collection.type), so
--- within a single collectionId the entity filter drops nothing and the ordered
--- scan still stops at the window — one index serves images, models, posts and
--- articles rather than four partial ones over the same 204M rows.
---
--- CONCURRENTLY, because the table is 15 GB / ~204M rows and this index adds ~6 GB
--- to the 82 GB already on it. Run it OUTSIDE a transaction: psql's -c with two
--- statements opens one implicitly and the server refuses. A cancelled CONCURRENTLY
--- build leaves an INVALID index that must be dropped before retrying.
+-- CONCURRENTLY, because the table is 15 GB / ~204M rows. Run it OUTSIDE a transaction:
+-- psql's -c with two statements opens one implicitly and the server refuses. A cancelled
+-- CONCURRENTLY build leaves an INVALID index; IF NOT EXISTS will then skip creation and
+-- exit 0 with the invalid index still in place, so check indisvalid before trusting a
+-- successful re-run.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "CollectionItem_collectionId_id_idx"
   ON "CollectionItem" ("collectionId", id DESC);

--- a/packages/civitai-db-schema/prisma/migrations/20260831120000_collection_item_recently_added_idx/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260831120000_collection_item_recently_added_idx/migration.sql
@@ -1,0 +1,29 @@
+-- Serves the collection feeds' new "Recently Added" sort, which orders on the
+-- CollectionItem row's own id:
+--   WHERE "collectionId" = $1 AND <status/entity filters> ORDER BY id DESC LIMIT $2
+--
+-- No existing index can produce that order. The closest, CollectionItem_image_idx
+-- ("collectionId", "imageId"), is why the pre-existing Newest sort is cheap — it
+-- yields imageId order, which for images IS id order. Ordering on the item id
+-- instead makes the planner read every row of the collection and sort: measured on
+-- the prod replica against the largest image collection (163,624 items), 246ms
+-- versus 19ms for the same page under Newest.
+--
+-- What this index buys, measured on a 44,367-item collection with an equivalent
+-- index scoped to that one collectionId: 42.2ms -> 1.8ms, and the Sort node
+-- disappears. The point is the shape rather than the ratio — the scan reads 102
+-- rows and stops at the LIMIT instead of reading all 44,367, so the page cost stops
+-- scaling with the size of the collection.
+--
+-- Not partial on an entity column, unlike the four ("collectionId", <entity>Id)
+-- uniques beside it. A collection holds one entity type (Collection.type), so
+-- within a single collectionId the entity filter drops nothing and the ordered
+-- scan still stops at the window — one index serves images, models, posts and
+-- articles rather than four partial ones over the same 204M rows.
+--
+-- CONCURRENTLY, because the table is 15 GB / ~204M rows and this index adds ~6 GB
+-- to the 82 GB already on it. Run it OUTSIDE a transaction: psql's -c with two
+-- statements opens one implicitly and the server refuses. A cancelled CONCURRENTLY
+-- build leaves an INVALID index that must be dropped before retrying.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "CollectionItem_collectionId_id_idx"
+  ON "CollectionItem" ("collectionId", id DESC);

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -4700,6 +4700,7 @@ model CollectionItem {
   @@index([modelId], type: Hash)
   @@index([model3dId], type: Hash)
   @@index([collectionId], type: Hash)
+  @@index([collectionId, id(sort: Desc)])
 }
 
 model CollectionItemScore {

--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -47,6 +47,16 @@ import {
   useCollection,
   useCollectionEntryCount,
 } from '~/components/Collections/collection.utils';
+import {
+  articleCollectionSortOptions,
+  contestArticleSorts,
+  contestModelSorts,
+  contestPostSorts,
+  imageCollectionSortOptions,
+  modelCollectionSortOptions,
+  postCollectionSortOptions,
+  toSortMenuOptions,
+} from '~/components/Collections/collection-sort';
 import { CollectionInvitePrompt } from '~/components/Collections/CollectionCollaborators/CollectionInvitePrompt';
 import { usePendingInviteFor } from '~/components/Collections/CollectionCollaborators/collectionInvite.util';
 import { CollectionCollaboratorsSummary } from '~/components/Collections/CollectionCollaboratorsSummary';
@@ -115,8 +125,8 @@ const ModelCollection = ({
   const { set, ...query } = useModelQueryParams();
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const sort = isContestCollection
-    ? getRandom(Object.values(ModelSort))
-    : query.sort ?? ModelSort.Newest;
+    ? getRandom(contestModelSorts)
+    : query.sort ?? ModelSort.RecentlyAdded;
   const currentUser = useCurrentUser();
 
   // For contest collections, we need to keep the filters clean from outside intervention.
@@ -180,6 +190,7 @@ const ModelCollection = ({
                   type="models"
                   value={sort}
                   onChange={(x) => set({ sort: x as ModelSort })}
+                  options={toSortMenuOptions(modelCollectionSortOptions)}
                 />
                 <ModelFiltersDropdown
                   filterMode="query"
@@ -204,7 +215,6 @@ const ModelCollection = ({
   );
 };
 
-const imageCollectionSortOptions = [ImageSort.Newest, ImageSort.Oldest];
 const ImageCollection = ({
   collection,
   permissions,
@@ -215,7 +225,9 @@ const ImageCollection = ({
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const { replace, query } = useImageQueryParams();
   const defaultSort =
-    query.sort && imageCollectionSortOptions.includes(query.sort) ? query.sort : ImageSort.Newest;
+    query.sort && imageCollectionSortOptions.includes(query.sort)
+      ? query.sort
+      : ImageSort.RecentlyAdded;
   const sort = isContestCollection ? ImageSort.Random : defaultSort;
   const period = query.period ?? MetricTimeframe.AllTime;
   const updateCollectionCoverImage = useUpdateCollectionCoverImage();
@@ -305,7 +317,7 @@ const ImageCollection = ({
                   type="images"
                   value={sort}
                   onChange={(x) => replace({ sort: x as ImageSort })}
-                  options={imageCollectionSortOptions.map((x) => ({ label: x, value: x }))}
+                  options={toSortMenuOptions(imageCollectionSortOptions)}
                   ignoreNsfwLevel
                 />
                 <MediaFiltersDropdown
@@ -366,16 +378,13 @@ const ImageCollection = ({
     </ImageContextMenuProvider>
   );
 };
-// Contest rotation randomises the sort on each render to spread entry visibility. Oldest is
-// held out of that pool deliberately: it is the only ascending sort, so a roll landing on it
-// pins the earliest submissions to the top of every contest feed for that render.
-const contestPostSorts = Object.values(PostSort).filter((sort) => sort !== PostSort.Oldest);
-
 const PostCollection = ({ collection }: { collection: NonNullable<CollectionByIdModel> }) => {
   const { replace, query } = usePostQueryParams();
   const period = query.period ?? MetricTimeframe.AllTime;
   const isContestCollection = collection.mode === CollectionMode.Contest;
-  const sort = isContestCollection ? getRandom(contestPostSorts) : query.sort ?? PostSort.Newest;
+  const sort = isContestCollection
+    ? getRandom(contestPostSorts)
+    : query.sort ?? PostSort.RecentlyAdded;
 
   const filters = isContestCollection
     ? {
@@ -409,6 +418,7 @@ const PostCollection = ({ collection }: { collection: NonNullable<CollectionById
                 type="posts"
                 value={sort}
                 onChange={(sort) => replace({ sort: sort as PostSort })}
+                options={toSortMenuOptions(postCollectionSortOptions)}
               />
               <PostFiltersDropdown query={filters} onChange={(value) => replace(value)} />
             </Group>
@@ -427,8 +437,8 @@ const ArticleCollection = ({ collection }: { collection: NonNullable<CollectionB
   const period = query.period ?? MetricTimeframe.AllTime;
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const sort = isContestCollection
-    ? getRandom(Object.values(ArticleSort))
-    : query.sort ?? ArticleSort.Newest;
+    ? getRandom(contestArticleSorts)
+    : query.sort ?? ArticleSort.RecentlyAdded;
 
   // For contest collections, we need to keep the filters clean from outside intervention.
   const filters = isContestCollection
@@ -460,6 +470,7 @@ const ArticleCollection = ({ collection }: { collection: NonNullable<CollectionB
                 type="articles"
                 value={sort}
                 onChange={(x) => replace({ sort: x as ArticleSort })}
+                options={toSortMenuOptions(articleCollectionSortOptions)}
               />
               <ArticleFiltersDropdown query={filters} onChange={(value) => replace(value)} />
             </Group>

--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -55,6 +55,7 @@ import {
   imageCollectionSortOptions,
   modelCollectionSortOptions,
   postCollectionSortOptions,
+  resolveImageCollectionSort,
   toSortMenuOptions,
 } from '~/components/Collections/collection-sort';
 import { CollectionInvitePrompt } from '~/components/Collections/CollectionCollaborators/CollectionInvitePrompt';
@@ -126,7 +127,7 @@ const ModelCollection = ({
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const sort = isContestCollection
     ? getRandom(contestModelSorts)
-    : query.sort ?? ModelSort.RecentlyAdded;
+    : query.sort ?? ModelSort.Newest;
   const currentUser = useCurrentUser();
 
   // For contest collections, we need to keep the filters clean from outside intervention.
@@ -224,11 +225,10 @@ const ImageCollection = ({
 }) => {
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const { replace, query } = useImageQueryParams();
-  const defaultSort =
-    query.sort && imageCollectionSortOptions.includes(query.sort)
-      ? query.sort
-      : ImageSort.RecentlyAdded;
-  const sort = isContestCollection ? ImageSort.Random : defaultSort;
+  const sort = resolveImageCollectionSort({
+    querySort: query.sort,
+    isContest: isContestCollection,
+  });
   const period = query.period ?? MetricTimeframe.AllTime;
   const updateCollectionCoverImage = useUpdateCollectionCoverImage();
   const currentUser = useCurrentUser();
@@ -384,7 +384,7 @@ const PostCollection = ({ collection }: { collection: NonNullable<CollectionById
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const sort = isContestCollection
     ? getRandom(contestPostSorts)
-    : query.sort ?? PostSort.RecentlyAdded;
+    : query.sort ?? PostSort.Newest;
 
   const filters = isContestCollection
     ? {
@@ -438,7 +438,7 @@ const ArticleCollection = ({ collection }: { collection: NonNullable<CollectionB
   const isContestCollection = collection.mode === CollectionMode.Contest;
   const sort = isContestCollection
     ? getRandom(contestArticleSorts)
-    : query.sort ?? ArticleSort.RecentlyAdded;
+    : query.sort ?? ArticleSort.Newest;
 
   // For contest collections, we need to keep the filters clean from outside intervention.
   const filters = isContestCollection

--- a/src/components/Collections/__tests__/collection-sort.test.ts
+++ b/src/components/Collections/__tests__/collection-sort.test.ts
@@ -56,9 +56,12 @@ const feeds = [
 describe('collection sort options', () => {
   // SortFilter's `sortOptions` map is module-private, so this asserts the input it
   // subtracts — a dropped `.filter` there is not covered.
-  it.each(feeds)('$name hides Recently Added from the general feed menu via *SortHidden', (feed) => {
-    expect(feed.hidden).toContain(feed.recentlyAdded);
-  });
+  it.each(feeds)(
+    '$name hides Recently Added from the general feed menu via *SortHidden',
+    (feed) => {
+      expect(feed.hidden).toContain(feed.recentlyAdded);
+    }
+  );
 
   it.each(feeds)('$name offers Recently Added first inside a collection', (feed) => {
     expect(feed.collectionOptions[0]).toBe(feed.recentlyAdded);

--- a/src/components/Collections/__tests__/collection-sort.test.ts
+++ b/src/components/Collections/__tests__/collection-sort.test.ts
@@ -77,18 +77,21 @@ describe('collection sort options', () => {
     }
   );
 
-  // The one behaviour the feature exists for: a viewer who asks for nothing gets add order.
-  // Only images default to it — models, posts and articles keep Newest.
-  it('defaults an image collection to Recently Added', () => {
-    expect(resolveImageCollectionSort({})).toBe(ImageSort.RecentlyAdded);
+  // Recently Added is opt-in for every collection type, images included: no viewer gets a
+  // reordered feed without asking.
+  it('defaults an image collection to Newest, like the other three types', () => {
+    expect(resolveImageCollectionSort({})).toBe(ImageSort.Newest);
   });
 
   it('lets the URL override the default, but only with a sort this menu serves', () => {
     expect(resolveImageCollectionSort({ querySort: ImageSort.Oldest })).toBe(ImageSort.Oldest);
+    expect(resolveImageCollectionSort({ querySort: ImageSort.RecentlyAdded })).toBe(
+      ImageSort.RecentlyAdded
+    );
     // MostReactions is a real ImageSort the collection menu does not offer, so it falls back
     // rather than reaching a service that would order on a column the CTE never selected.
     expect(resolveImageCollectionSort({ querySort: ImageSort.MostReactions })).toBe(
-      ImageSort.RecentlyAdded
+      ImageSort.Newest
     );
   });
 

--- a/src/components/Collections/__tests__/collection-sort.test.ts
+++ b/src/components/Collections/__tests__/collection-sort.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  articleCollectionSortOptions,
+  contestArticleSorts,
+  contestModelSorts,
+  contestPostSorts,
+  imageCollectionSortOptions,
+  modelCollectionSortOptions,
+  postCollectionSortOptions,
+} from '~/components/Collections/collection-sort';
+import {
+  ArticleSort,
+  ArticleSortHidden,
+  ImageSort,
+  ImageSortHidden,
+  ModelSort,
+  ModelSortHidden,
+  PostSort,
+  PostSortHidden,
+} from '~/server/common/enums';
+
+// `Recently Added` orders on CollectionItem.id, and every service throws a 400 when it
+// arrives without a collectionId. Two things therefore have to stay true together, and
+// each is broken by a different half-finished edit: the general feed menus must not offer
+// it (a `*SortHidden` entry that was never added), and the collection menus must
+// (a `*CollectionSortOptions` list that was never extended).
+const feeds = [
+  {
+    name: 'images',
+    all: Object.values(ImageSort),
+    hidden: Object.values(ImageSortHidden),
+    collectionOptions: imageCollectionSortOptions,
+    recentlyAdded: ImageSort.RecentlyAdded,
+  },
+  {
+    name: 'models',
+    all: Object.values(ModelSort),
+    hidden: Object.values(ModelSortHidden),
+    collectionOptions: modelCollectionSortOptions,
+    recentlyAdded: ModelSort.RecentlyAdded,
+  },
+  {
+    name: 'posts',
+    all: Object.values(PostSort),
+    hidden: Object.values(PostSortHidden),
+    collectionOptions: postCollectionSortOptions,
+    recentlyAdded: PostSort.RecentlyAdded,
+  },
+  {
+    name: 'articles',
+    all: Object.values(ArticleSort),
+    hidden: Object.values(ArticleSortHidden),
+    collectionOptions: articleCollectionSortOptions,
+    recentlyAdded: ArticleSort.RecentlyAdded,
+  },
+] as const;
+
+describe('collection sort options', () => {
+  it.each(feeds)('$name withholds Recently Added from the general feed menu', (feed) => {
+    // `SortFilter`'s `sortOptions` is `all` minus `hidden`; assert on that difference
+    // rather than on the map, so dropping the filter there is caught too.
+    const generalMenu = feed.all.filter((x) => !feed.hidden.includes(x as never));
+    expect(generalMenu).not.toContain(feed.recentlyAdded);
+  });
+
+  it.each(feeds)('$name offers Recently Added first inside a collection', (feed) => {
+    expect(feed.collectionOptions[0]).toBe(feed.recentlyAdded);
+  });
+
+  it.each(feeds)('$name collection menu still offers every general sort', (feed) => {
+    const generalMenu = feed.all.filter((x) => !feed.hidden.includes(x as never));
+    // Images are the exception: that menu was already an explicit two-sort subset
+    // before this sort existed, so it is asserted on its own below.
+    if (feed.name === 'images') return;
+    for (const sort of generalMenu) expect(feed.collectionOptions).toContain(sort);
+  });
+
+  it('keeps the image collection menu to the three sorts it can serve', () => {
+    expect(imageCollectionSortOptions).toEqual([
+      ImageSort.RecentlyAdded,
+      ImageSort.Newest,
+      ImageSort.Oldest,
+    ]);
+  });
+});
+
+describe('contest sort pools', () => {
+  // A contest re-rolls its sort every render. Recently Added is deterministic, so a draw
+  // landing on it pins the newest entries to the top — the visibility spread the rotation
+  // exists for is gone for that render, and nothing about the feed looks wrong.
+  it.each([
+    { name: 'models', pool: contestModelSorts as readonly string[], sort: ModelSort.RecentlyAdded },
+    { name: 'posts', pool: contestPostSorts as readonly string[], sort: PostSort.RecentlyAdded },
+    {
+      name: 'articles',
+      pool: contestArticleSorts as readonly string[],
+      sort: ArticleSort.RecentlyAdded,
+    },
+  ])('$name pool cannot draw Recently Added', ({ pool, sort }) => {
+    expect(pool.length).toBeGreaterThan(0);
+    expect(pool).not.toContain(sort);
+  });
+
+  it('post pool still withholds Oldest', () => {
+    expect(contestPostSorts).not.toContain(PostSort.Oldest);
+  });
+});

--- a/src/components/Collections/__tests__/collection-sort.test.ts
+++ b/src/components/Collections/__tests__/collection-sort.test.ts
@@ -7,6 +7,7 @@ import {
   imageCollectionSortOptions,
   modelCollectionSortOptions,
   postCollectionSortOptions,
+  resolveImageCollectionSort,
 } from '~/components/Collections/collection-sort';
 import {
   ArticleSort,
@@ -19,11 +20,8 @@ import {
   PostSortHidden,
 } from '~/server/common/enums';
 
-// `Recently Added` orders on CollectionItem.id, and every service throws a 400 when it
-// arrives without a collectionId. Two things therefore have to stay true together, and
-// each is broken by a different half-finished edit: the general feed menus must not offer
-// it (a `*SortHidden` entry that was never added), and the collection menus must
-// (a `*CollectionSortOptions` list that was never extended).
+// Every service 400s `Recently Added` when it arrives without a collectionId, so the general
+// menus must never offer it and the collection menus must.
 const feeds = [
   {
     name: 'images',
@@ -56,23 +54,46 @@ const feeds = [
 ] as const;
 
 describe('collection sort options', () => {
-  it.each(feeds)('$name withholds Recently Added from the general feed menu', (feed) => {
-    // `SortFilter`'s `sortOptions` is `all` minus `hidden`; assert on that difference
-    // rather than on the map, so dropping the filter there is caught too.
-    const generalMenu = feed.all.filter((x) => !feed.hidden.includes(x as never));
-    expect(generalMenu).not.toContain(feed.recentlyAdded);
+  // SortFilter's `sortOptions` map is module-private, so this asserts the input it
+  // subtracts — a dropped `.filter` there is not covered.
+  it.each(feeds)('$name hides Recently Added from the general feed menu via *SortHidden', (feed) => {
+    expect(feed.hidden).toContain(feed.recentlyAdded);
   });
 
   it.each(feeds)('$name offers Recently Added first inside a collection', (feed) => {
     expect(feed.collectionOptions[0]).toBe(feed.recentlyAdded);
   });
 
-  it.each(feeds)('$name collection menu still offers every general sort', (feed) => {
-    const generalMenu = feed.all.filter((x) => !feed.hidden.includes(x as never));
-    // Images are the exception: that menu was already an explicit two-sort subset
-    // before this sort existed, so it is asserted on its own below.
-    if (feed.name === 'images') return;
-    for (const sort of generalMenu) expect(feed.collectionOptions).toContain(sort);
+  // The image collection menu was a deliberate two-sort subset before this sort existed;
+  // it is asserted exactly, below.
+  it.each(feeds.filter((f) => f.name !== 'images'))(
+    '$name collection menu still offers every general sort',
+    (feed) => {
+      const generalMenu = feed.all.filter((x) => !feed.hidden.includes(x as never));
+      for (const sort of generalMenu) expect(feed.collectionOptions).toContain(sort);
+    }
+  );
+
+  // The one behaviour the feature exists for: a viewer who asks for nothing gets add order.
+  // Only images default to it — models, posts and articles keep Newest.
+  it('defaults an image collection to Recently Added', () => {
+    expect(resolveImageCollectionSort({})).toBe(ImageSort.RecentlyAdded);
+  });
+
+  it('lets the URL override the default, but only with a sort this menu serves', () => {
+    expect(resolveImageCollectionSort({ querySort: ImageSort.Oldest })).toBe(ImageSort.Oldest);
+    // MostReactions is a real ImageSort the collection menu does not offer, so it falls back
+    // rather than reaching a service that would order on a column the CTE never selected.
+    expect(resolveImageCollectionSort({ querySort: ImageSort.MostReactions })).toBe(
+      ImageSort.RecentlyAdded
+    );
+  });
+
+  it('gives a contest collection Random, whatever the URL says', () => {
+    expect(resolveImageCollectionSort({ isContest: true })).toBe(ImageSort.Random);
+    expect(resolveImageCollectionSort({ querySort: ImageSort.Newest, isContest: true })).toBe(
+      ImageSort.Random
+    );
   });
 
   it('keeps the image collection menu to the three sorts it can serve', () => {
@@ -85,9 +106,8 @@ describe('collection sort options', () => {
 });
 
 describe('contest sort pools', () => {
-  // A contest re-rolls its sort every render. Recently Added is deterministic, so a draw
-  // landing on it pins the newest entries to the top — the visibility spread the rotation
-  // exists for is gone for that render, and nothing about the feed looks wrong.
+  // Nothing here filters Recently Added explicitly — it is out of the pools only because
+  // `visible()` drops `*SortHidden`, so removing it from those maps re-admits it silently.
   it.each([
     { name: 'models', pool: contestModelSorts as readonly string[], sort: ModelSort.RecentlyAdded },
     { name: 'posts', pool: contestPostSorts as readonly string[], sort: PostSort.RecentlyAdded },

--- a/src/components/Collections/collection-sort.ts
+++ b/src/components/Collections/collection-sort.ts
@@ -50,9 +50,7 @@ export const resolveImageCollectionSort = ({
   isContest?: boolean;
 }): ImageSort => {
   if (isContest) return ImageSort.Random;
-  return querySort && imageCollectionSortOptions.includes(querySort)
-    ? querySort
-    : ImageSort.Newest;
+  return querySort && imageCollectionSortOptions.includes(querySort) ? querySort : ImageSort.Newest;
 };
 
 export const contestModelSorts = visible(Object.values(ModelSort), ModelSortHidden);

--- a/src/components/Collections/collection-sort.ts
+++ b/src/components/Collections/collection-sort.ts
@@ -39,9 +39,8 @@ export const toSortMenuOptions = <T extends string>(options: T[]) =>
   options.map((value) => ({ label: value, value }));
 
 /**
- * The sort an image collection is served. A contest re-rolls at random; otherwise the URL wins
- * when it names one of this menu's sorts, and Recently Added is the default — the sort a viewer
- * gets without asking, which is the whole point of the feature.
+ * A contest re-rolls at random. Otherwise the URL wins only when it names one of this menu's
+ * sorts: the ImageSorts left out order on columns the collection query never selects.
  */
 export const resolveImageCollectionSort = ({
   querySort,
@@ -53,7 +52,7 @@ export const resolveImageCollectionSort = ({
   if (isContest) return ImageSort.Random;
   return querySort && imageCollectionSortOptions.includes(querySort)
     ? querySort
-    : ImageSort.RecentlyAdded;
+    : ImageSort.Newest;
 };
 
 export const contestModelSorts = visible(Object.values(ModelSort), ModelSortHidden);

--- a/src/components/Collections/collection-sort.ts
+++ b/src/components/Collections/collection-sort.ts
@@ -12,9 +12,8 @@ import {
 const visible = <T extends string>(all: T[], hidden: Record<string, T>) =>
   all.filter((x) => !Object.values(hidden).includes(x));
 
-// `Recently Added` orders by CollectionItem.id, so it is meaningless — and rejected by the
-// services — outside a collection. It is held out of every feed's menu via the `*SortHidden`
-// maps and added back here, which is the only place a collectionId is guaranteed.
+// `Recently Added` orders on CollectionItem.id, so every service 400s it without a
+// collectionId. That is why it lives in `*SortHidden` and is added back only here.
 export const imageCollectionSortOptions = [
   ImageSort.RecentlyAdded,
   ImageSort.Newest,
@@ -39,11 +38,29 @@ export const articleCollectionSortOptions = [
 export const toSortMenuOptions = <T extends string>(options: T[]) =>
   options.map((value) => ({ label: value, value }));
 
-// A contest feed re-rolls its sort on every render to spread entry visibility, so the pool must
-// hold only sorts that shuffle. `Recently Added` is deterministic and would pin the newest entries
-// to the top for whichever renders draw it — the same reason Oldest is held out of the post pool.
+/**
+ * The sort an image collection is served. A contest re-rolls at random; otherwise the URL wins
+ * when it names one of this menu's sorts, and Recently Added is the default — the sort a viewer
+ * gets without asking, which is the whole point of the feature.
+ */
+export const resolveImageCollectionSort = ({
+  querySort,
+  isContest,
+}: {
+  querySort?: ImageSort;
+  isContest?: boolean;
+}): ImageSort => {
+  if (isContest) return ImageSort.Random;
+  return querySort && imageCollectionSortOptions.includes(querySort)
+    ? querySort
+    : ImageSort.RecentlyAdded;
+};
+
 export const contestModelSorts = visible(Object.values(ModelSort), ModelSortHidden);
 export const contestArticleSorts = visible(Object.values(ArticleSort), ArticleSortHidden);
+// Contest feeds re-roll their sort each render to spread entry visibility, and Oldest is the
+// only ascending post sort: a roll landing on it pins the earliest submissions to the top for
+// that render.
 export const contestPostSorts = visible(Object.values(PostSort), PostSortHidden).filter(
   (sort) => sort !== PostSort.Oldest
 );

--- a/src/components/Collections/collection-sort.ts
+++ b/src/components/Collections/collection-sort.ts
@@ -1,0 +1,49 @@
+import {
+  ArticleSort,
+  ArticleSortHidden,
+  ImageSort,
+  ImageSortHidden,
+  ModelSort,
+  ModelSortHidden,
+  PostSort,
+  PostSortHidden,
+} from '~/server/common/enums';
+
+const visible = <T extends string>(all: T[], hidden: Record<string, T>) =>
+  all.filter((x) => !Object.values(hidden).includes(x));
+
+// `Recently Added` orders by CollectionItem.id, so it is meaningless — and rejected by the
+// services — outside a collection. It is held out of every feed's menu via the `*SortHidden`
+// maps and added back here, which is the only place a collectionId is guaranteed.
+export const imageCollectionSortOptions = [
+  ImageSort.RecentlyAdded,
+  ImageSort.Newest,
+  ImageSort.Oldest,
+];
+
+export const modelCollectionSortOptions = [
+  ModelSort.RecentlyAdded,
+  ...visible(Object.values(ModelSort), ModelSortHidden),
+];
+
+export const postCollectionSortOptions = [
+  PostSort.RecentlyAdded,
+  ...visible(Object.values(PostSort), PostSortHidden),
+];
+
+export const articleCollectionSortOptions = [
+  ArticleSort.RecentlyAdded,
+  ...visible(Object.values(ArticleSort), ArticleSortHidden),
+];
+
+export const toSortMenuOptions = <T extends string>(options: T[]) =>
+  options.map((value) => ({ label: value, value }));
+
+// A contest feed re-rolls its sort on every render to spread entry visibility, so the pool must
+// hold only sorts that shuffle. `Recently Added` is deterministic and would pin the newest entries
+// to the top for whichever renders draw it — the same reason Oldest is held out of the post pool.
+export const contestModelSorts = visible(Object.values(ModelSort), ModelSortHidden);
+export const contestArticleSorts = visible(Object.values(ArticleSort), ArticleSortHidden);
+export const contestPostSorts = visible(Object.values(PostSort), PostSortHidden).filter(
+  (sort) => sort !== PostSort.Oldest
+);

--- a/src/components/Filters/SortFilter.tsx
+++ b/src/components/Filters/SortFilter.tsx
@@ -7,6 +7,7 @@ import type { FilterSubTypes } from '~/providers/FiltersProvider';
 import { useFiltersContext, useSetFilters } from '~/providers/FiltersProvider';
 import {
   ArticleSort,
+  ArticleSortHidden,
   BountySort,
   BuzzWithdrawalRequestSort,
   CollectionSort,
@@ -14,7 +15,9 @@ import {
   ImageSort,
   ImageSortHidden,
   ModelSort,
+  ModelSortHidden,
   PostSort,
+  PostSortHidden,
   QuestionSort,
   ThreadSort,
   ToolSort,
@@ -30,12 +33,12 @@ type SortFilterComponentProps = {
 type SortFilterProps = StatefulProps | DumbProps;
 
 const sortOptions = {
-  models: Object.values(ModelSort),
-  posts: Object.values(PostSort),
+  models: Object.values(ModelSort).filter((x) => !Object.values(ModelSortHidden).includes(x)),
+  posts: Object.values(PostSort).filter((x) => !Object.values(PostSortHidden).includes(x)),
   images: Object.values(ImageSort).filter((x) => !Object.values(ImageSortHidden).includes(x)),
   modelImages: Object.values(ImageSort).filter((x) => !Object.values(ImageSortHidden).includes(x)),
   questions: Object.values(QuestionSort),
-  articles: Object.values(ArticleSort),
+  articles: Object.values(ArticleSort).filter((x) => !Object.values(ArticleSortHidden).includes(x)),
   collections: Object.values(CollectionSort),
   bounties: Object.values(BountySort),
   videos: Object.values(ImageSort).filter((x) => !Object.values(ImageSortHidden).includes(x)),

--- a/src/components/Filters/__tests__/sort-availability.test.ts
+++ b/src/components/Filters/__tests__/sort-availability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { isSortAvailable, resolveFeedSort } from '~/components/Filters/sort-availability';
-import { ImageSort, ModelSort } from '~/server/common/enums';
+import { ImageSort, ImageSortHidden, ModelSort } from '~/server/common/enums';
 
 // The three availabilities the rule distinguishes. `.green` is the domain that
 // withholds Newest and Oldest outright; SFW-by-choice withholds Newest on the
@@ -49,7 +49,8 @@ describe('resolveFeedSort', () => {
   it('never returns a sort the menu would hide', () => {
     // The property the whole thing exists for, over every images sort the menu
     // can offer and all three availabilities.
-    const sorts = Object.values(ImageSort).filter((s) => s !== ImageSort.Random);
+    const hidden = Object.values(ImageSortHidden);
+    const sorts = Object.values(ImageSort).filter((s) => !hidden.includes(s));
     expect(sorts).toHaveLength(5);
 
     for (const availability of [green, sfwByChoice, moderator]) {

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -17,7 +17,12 @@ export enum ModelSort {
   ImageCount = 'Most Images',
   Newest = 'Newest',
   Oldest = 'Oldest',
+  RecentlyAdded = 'Recently Added',
 }
+
+export const ModelSortHidden = {
+  RecentlyAdded: ModelSort.RecentlyAdded,
+};
 
 export enum ReviewSort {
   Newest = 'newest',
@@ -50,10 +55,12 @@ export enum ImageSort {
   Newest = 'Newest',
   Oldest = 'Oldest',
   Random = 'Random',
+  RecentlyAdded = 'Recently Added',
 }
 
 export const ImageSortHidden = {
   Random: ImageSort.Random,
+  RecentlyAdded: ImageSort.RecentlyAdded,
 };
 
 export enum PostSort {
@@ -62,7 +69,12 @@ export enum PostSort {
   MostCollected = 'Most Collected',
   Newest = 'Newest',
   Oldest = 'Oldest',
+  RecentlyAdded = 'Recently Added',
 }
+
+export const PostSortHidden = {
+  RecentlyAdded: PostSort.RecentlyAdded,
+};
 
 export enum ImageType {
   txt2img = 'txt2img',
@@ -108,7 +120,12 @@ export enum ArticleSort {
   MostCollected = 'Most Collected',
   Newest = 'Newest',
   RecentlyUpdated = 'Recently Updated',
+  RecentlyAdded = 'Recently Added',
 }
+
+export const ArticleSortHidden = {
+  RecentlyAdded: ArticleSort.RecentlyAdded,
+};
 
 export enum CheckpointType {
   Trained = 'Trained',

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4127':
+  'server/services/image.service.ts:4134':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4268':
+  'server/services/image.service.ts:4275':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5006':
+  'server/services/image.service.ts:5013':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6140':
+  'server/services/image.service.ts:6147':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4268')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4275')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -152,14 +152,14 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   'server/services/article-rating-review.helpers.ts:482':
     'article-rating-dispute has no segment rollouts; background path with no SessionUser',
   // flag `feed-fetch-filter-in-post`: enabled=true, 0 rules, 0 rollouts.
-  'server/services/image.service.ts:4134':
+  'server/services/image.service.ts:4136':
     'feed-fetch-filter-in-post has no segment rollouts; hot feed path',
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
-  'server/services/image.service.ts:4275':
+  'server/services/image.service.ts:4277':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:5013':
+  'server/services/image.service.ts:5015':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:6147':
+  'server/services/image.service.ts:6149':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on
@@ -219,7 +219,7 @@ describe('flipt evaluation context — source gate', () => {
     // these and fail the second, and vice versa.
     const bySite = new Map(calls.map((c) => [c.site, c]));
     expect(bySite.get('server/services/feedback.service.ts:43')?.argc).toBe(3);
-    expect(bySite.get('server/services/image.service.ts:4275')?.argc).toBe(2);
+    expect(bySite.get('server/services/image.service.ts:4277')?.argc).toBe(2);
   });
 
   it('adds no Flipt evaluation that names an entity but passes no context', () => {

--- a/src/server/services/__tests__/post-sort-keyset.test.ts
+++ b/src/server/services/__tests__/post-sort-keyset.test.ts
@@ -17,7 +17,6 @@ type Row = {
   id: number;
   publishedAt: Date | null;
   createdAt: Date;
-  /** The post's "CollectionItem".id — set only on the collection feed rows below. */
   collectionItemId?: number;
 };
 
@@ -56,10 +55,8 @@ const publishedFeed: Row[] = [
   { id: 7, publishedAt: d('2025-01-09T10:00:00.000Z'), createdAt: d('2025-01-09T09:00:00.000Z') },
 ];
 
-// Added to the collection in an order unrelated to publication: 501 is the oldest post but
-// the most recently added item, 504 the newest post but the earliest added. Newest and
-// Recently Added therefore produce exactly reversed feeds, so a Recently Added that quietly
-// falls through to the publishedAt branch cannot pass by coincidence.
+// Publication order is deliberately the inverse of add order, so Newest and Recently Added
+// produce exactly reversed feeds and a fall-through to the publishedAt branch cannot pass.
 const collectionFeed: Row[] = [
   {
     id: 501,
@@ -292,12 +289,11 @@ describe('getPostSortClauses', () => {
     );
   });
 
-  it('falls back to publishedAt when the caller did not join the collection', () => {
-    // getPostsInfinite rejects this combination before it reaches here, so the fallback is
-    // a second line rather than the contract — but emitting ci."id" against a FROM that has
-    // no ci would be a 500 rather than a wrong order.
-    expect(getPostSortClauses({ sort: PostSort.RecentlyAdded }).primarySortProp).toBe(
-      'p."publishedAt"'
+  it('throws rather than silently ordering by publishedAt when the collection was not joined', () => {
+    // The silent fallback IS the regression: dropping `collectionJoined = true` in the service
+    // would reorder the feed by publication date with nothing to read. Assert it is loud.
+    expect(() => getPostSortClauses({ sort: PostSort.RecentlyAdded })).toThrow(
+      /requires the caller to join/
     );
   });
 
@@ -311,8 +307,7 @@ describe('getPostSortClauses', () => {
     expect(recentlyAdded.seen).toEqual([501, 502, 503, 504]);
     expect(recentlyAdded.pages).toBeGreaterThan(1);
 
-    // The negative control: same rows, publication order, reversed. Without it a pager that
-    // ignored primarySortProp entirely could still satisfy the assertion above.
+    // Negative control: a pager that ignored primarySortProp would satisfy the assertion above.
     expect(drain({ rows: collectionFeed, sort: PostSort.Newest, limit: 2 }).seen).toEqual([
       504, 503, 502, 501,
     ]);

--- a/src/server/services/__tests__/post-sort-keyset.test.ts
+++ b/src/server/services/__tests__/post-sort-keyset.test.ts
@@ -13,7 +13,13 @@ import {
 // tests drive the real clause builders through a bounded in-memory pager so that flipping
 // either half back to DESC fails on the first repeated row instead of hanging the runner.
 
-type Row = { id: number; publishedAt: Date | null; createdAt: Date };
+type Row = {
+  id: number;
+  publishedAt: Date | null;
+  createdAt: Date;
+  /** The post's "CollectionItem".id — set only on the collection feed rows below. */
+  collectionItemId?: number;
+};
 
 const d = (iso: string) => new Date(iso);
 
@@ -50,6 +56,37 @@ const publishedFeed: Row[] = [
   { id: 7, publishedAt: d('2025-01-09T10:00:00.000Z'), createdAt: d('2025-01-09T09:00:00.000Z') },
 ];
 
+// Added to the collection in an order unrelated to publication: 501 is the oldest post but
+// the most recently added item, 504 the newest post but the earliest added. Newest and
+// Recently Added therefore produce exactly reversed feeds, so a Recently Added that quietly
+// falls through to the publishedAt branch cannot pass by coincidence.
+const collectionFeed: Row[] = [
+  {
+    id: 501,
+    publishedAt: d('2020-01-01T00:00:00.000Z'),
+    createdAt: d('2020-01-01T00:00:00.000Z'),
+    collectionItemId: 94,
+  },
+  {
+    id: 502,
+    publishedAt: d('2022-01-01T00:00:00.000Z'),
+    createdAt: d('2022-01-01T00:00:00.000Z'),
+    collectionItemId: 93,
+  },
+  {
+    id: 503,
+    publishedAt: d('2024-01-01T00:00:00.000Z'),
+    createdAt: d('2024-01-01T00:00:00.000Z'),
+    collectionItemId: 92,
+  },
+  {
+    id: 504,
+    publishedAt: d('2026-01-01T00:00:00.000Z'),
+    createdAt: d('2026-01-01T00:00:00.000Z'),
+    collectionItemId: 91,
+  },
+];
+
 /**
  * Evaluate one of the sort expressions the module emits against an in-memory row. The
  * `default` throw is deliberate: if `getPostSortClauses` starts emitting an expression this
@@ -65,6 +102,10 @@ const evalSortKey = (expr: string, row: Row): number => {
       return (row.publishedAt ?? row.createdAt).getTime();
     case `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`:
       return (row.publishedAt ?? plusCentury(row.createdAt)).getTime();
+    case 'ci."id"':
+      if (row.collectionItemId === undefined)
+        throw new Error(`row ${row.id} has no collectionItemId under ${expr}`);
+      return row.collectionItemId;
     default:
       throw new Error(`post-sort pager cannot evaluate sort expression: ${expr}`);
   }
@@ -72,11 +113,18 @@ const evalSortKey = (expr: string, row: Row): number => {
 
 const parseDirection = (orderBy: string) => {
   const match = orderBy.match(/^(.+?)\s+(ASC|DESC),\s*p\.id\s+(ASC|DESC)$/);
-  if (!match) throw new Error(`unparseable orderBy: ${orderBy}`);
-  const [, , primaryDir, idDir] = match;
-  if (primaryDir !== idDir)
-    throw new Error(`orderBy mixes directions, keyset cursor cannot be single-tuple: ${orderBy}`);
-  return primaryDir === 'ASC' ? 1 : -1;
+  if (match) {
+    const [, , primaryDir, idDir] = match;
+    if (primaryDir !== idDir)
+      throw new Error(`orderBy mixes directions, keyset cursor cannot be single-tuple: ${orderBy}`);
+    return primaryDir === 'ASC' ? 1 : -1;
+  }
+
+  // Recently Added carries no p.id tiebreaker: the join is through a unique
+  // ("collectionId", "postId") index, so ci."id" is already total over the feed.
+  const single = orderBy.match(/^(.+?)\s+(ASC|DESC)$/);
+  if (!single) throw new Error(`unparseable orderBy: ${orderBy}`);
+  return single[2] === 'ASC' ? 1 : -1;
 };
 
 type ParsedCursor =
@@ -107,18 +155,21 @@ const fetchPage = ({
   rows,
   sort,
   draftOnly,
+  collectionJoined,
   limit,
   cursor,
 }: {
   rows: Row[];
   sort: PostSort;
   draftOnly?: boolean;
+  collectionJoined?: boolean;
   limit: number;
   cursor?: string;
 }) => {
   const { orderBy, primarySortProp, isDateSort, ascending } = getPostSortClauses({
     sort,
     draftOnly,
+    collectionJoined,
   });
   const direction = parseDirection(orderBy);
   const cursorClause = buildPostCursorClause({ cursor, primarySortProp, isDateSort, ascending });
@@ -160,11 +211,13 @@ const drain = ({
   rows,
   sort,
   draftOnly,
+  collectionJoined,
   limit,
 }: {
   rows: Row[];
   sort: PostSort;
   draftOnly?: boolean;
+  collectionJoined?: boolean;
   limit: number;
 }) => {
   const seen: number[] = [];
@@ -172,7 +225,14 @@ const drain = ({
   let pages = 0;
 
   while (pages < PAGE_CAP) {
-    const { items, nextCursor } = fetchPage({ rows, sort, draftOnly, limit, cursor });
+    const { items, nextCursor } = fetchPage({
+      rows,
+      sort,
+      draftOnly,
+      collectionJoined,
+      limit,
+      cursor,
+    });
     pages += 1;
     for (const id of items) {
       // A comparison pointing against the ORDER BY re-serves rows it already served. Fail on
@@ -219,6 +279,43 @@ describe('getPostSortClauses', () => {
     expect(getPostSortClauses({ sort: PostSort.Newest, draftOnly: true }).primarySortProp).toBe(
       `COALESCE(p."publishedAt", p."createdAt" + interval '100 years')`
     );
+  });
+
+  it('orders on the collection item, not the post, under Recently Added', () => {
+    expect(getPostSortClauses({ sort: PostSort.RecentlyAdded, collectionJoined: true })).toMatchObject(
+      {
+        orderBy: 'ci."id" DESC',
+        primarySortProp: 'ci."id"',
+        isDateSort: false,
+        ascending: false,
+      }
+    );
+  });
+
+  it('falls back to publishedAt when the caller did not join the collection', () => {
+    // getPostsInfinite rejects this combination before it reaches here, so the fallback is
+    // a second line rather than the contract — but emitting ci."id" against a FROM that has
+    // no ci would be a 500 rather than a wrong order.
+    expect(getPostSortClauses({ sort: PostSort.RecentlyAdded }).primarySortProp).toBe(
+      'p."publishedAt"'
+    );
+  });
+
+  it('pages a collection feed in add order, opposite to the publication order', () => {
+    const recentlyAdded = drain({
+      rows: collectionFeed,
+      sort: PostSort.RecentlyAdded,
+      collectionJoined: true,
+      limit: 2,
+    });
+    expect(recentlyAdded.seen).toEqual([501, 502, 503, 504]);
+    expect(recentlyAdded.pages).toBeGreaterThan(1);
+
+    // The negative control: same rows, publication order, reversed. Without it a pager that
+    // ignored primarySortProp entirely could still satisfy the assertion above.
+    expect(drain({ rows: collectionFeed, sort: PostSort.Newest, limit: 2 }).seen).toEqual([
+      504, 503, 502, 501,
+    ]);
   });
 
   it('adds no `> 0` filter for Oldest — it is a date sort, not a count sort', () => {

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -202,6 +202,11 @@ export const getArticles = async ({
       (!ids && !username && !collectionId && !followed && !hidden && !favorites && !userIds);
 
     const AND: Prisma.Sql[] = [];
+    let collectionJoin = Prisma.empty;
+
+    if (sort === ArticleSort.RecentlyAdded && !collectionId) {
+      throw throwBadRequestError('Recently Added sort requires a collectionId');
+    }
 
     if (query) {
       AND.push(Prisma.sql`a."title" ILIKE ${'%' + query + '%'}`);
@@ -264,13 +269,22 @@ export const getArticles = async ({
         userId: sessionUser?.id,
       });
 
-      AND.push(
-        Prisma.sql`EXISTS (
+      // `RecentlyAdded` orders on ci."id", which a semi-join cannot expose. The partial unique
+      // index on ("collectionId", "articleId") means the join cannot multiply rows, so the two
+      // shapes select the same articles.
+      if (sort === ArticleSort.RecentlyAdded) {
+        collectionJoin = Prisma.sql`JOIN "CollectionItem" ci ON ci."articleId" = a."id"
+          AND ci."collectionId" = ${collectionId}
+          AND ${Prisma.join(collectionItemModelsRawAND, ' AND ')}`;
+      } else {
+        AND.push(
+          Prisma.sql`EXISTS (
         SELECT 1 FROM "CollectionItem" ci
         WHERE ci."articleId" = a."id"
         AND ci."collectionId" = ${collectionId}
         AND ${Prisma.join(collectionItemModelsRawAND, ' AND ')})`
-      );
+        );
+      }
     }
 
     if (!isOwnerRequest) {
@@ -385,6 +399,10 @@ export const getArticles = async ({
         sortExpr = `extract(epoch from a."updatedAt")`;
         sortDir = 'DESC';
         break;
+      case ArticleSort.RecentlyAdded:
+        sortExpr = `ci."id"`;
+        sortDir = 'DESC';
+        break;
       case ArticleSort.Newest:
       default:
         sortExpr = `extract(epoch from a."publishedAt")`;
@@ -411,6 +429,7 @@ export const getArticles = async ({
       FROM "Article" a
       LEFT JOIN "User" u ON a."userId" = u.id
       LEFT JOIN "ArticleRank" rank ON rank."articleId" = a.id
+      ${collectionJoin}
       WHERE ${Prisma.join(AND, ' AND ')}
     `;
     const articles = await dbRead.$queryRaw<(ArticleRaw & { cursorV: number })[]>`

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -269,9 +269,9 @@ export const getArticles = async ({
         userId: sessionUser?.id,
       });
 
-      // `RecentlyAdded` orders on ci."id", which a semi-join cannot expose. The partial unique
-      // index on ("collectionId", "articleId") means the join cannot multiply rows, so the two
-      // shapes select the same articles.
+      // A semi-join cannot expose ci."id" to the ORDER BY. Safe to widen: CollectionItem_article_idx
+      // is unique on ("collectionId", "articleId"), so the join cannot multiply rows.
+      // schema.full.prisma does not declare it — see containers/db/docker-init/02_all_dll.sql.
       if (sort === ArticleSort.RecentlyAdded) {
         collectionJoin = Prisma.sql`JOIN "CollectionItem" ci ON ci."articleId" = a."id"
           AND ci."collectionId" = ${collectionId}

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1665,6 +1665,12 @@ export const getAllImages = async (
       new Error('getAllImages cannot serve a hub; hub queries must use the index path')
     );
 
+  // Ahead of every early empty return below: the point of throwing rather than falling back is
+  // that the misuse is legible, and an empty page from one of those branches hides it.
+  if (input.sort === ImageSort.RecentlyAdded && !input.collectionId) {
+    throw throwBadRequestError('Recently Added sort requires a collectionId');
+  }
+
   const blockedEnforcement = await enforceBlockedBrowsingTags(input, {
     id: input.user?.id,
     username: input.user?.username,
@@ -2047,10 +2053,6 @@ export const getAllImages = async (
 
   if (sort === ImageSort.Random && !collectionId) {
     throw throwBadRequestError('Random sort requires a collectionId');
-  }
-
-  if (sort === ImageSort.RecentlyAdded && !collectionId) {
-    throw throwBadRequestError('Recently Added sort requires a collectionId');
   }
 
   if (collectionTagId && !collectionId) {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2049,6 +2049,10 @@ export const getAllImages = async (
     throw throwBadRequestError('Random sort requires a collectionId');
   }
 
+  if (sort === ImageSort.RecentlyAdded && !collectionId) {
+    throw throwBadRequestError('Recently Added sort requires a collectionId');
+  }
+
   if (collectionTagId && !collectionId) {
     throw throwBadRequestError('collectionTagId requires a collectionId');
   }
@@ -2103,13 +2107,14 @@ export const getAllImages = async (
     WITH.push(
       Prisma.sql`
         ct AS (
-          SELECT "imageId", note, status, "addedById", "sortKey"
+          SELECT "imageId", note, status, "addedById", "collectionItemId", "sortKey"
           FROM (
             SELECT
               ci."imageId",
               ci.note,
               ci.status,
               ci."addedById",
+              ci.id as "collectionItemId",
               abs(mod(hashtext(concat(ci.id::text, '${Prisma.raw(
                 seedStr
               )}')), 1000000000)) as "sortKey"
@@ -2160,6 +2165,8 @@ export const getAllImages = async (
     if (sort === ImageSort.Random) {
       isPersonalized = true; // random ordering should not be pinned by a cache
       orderBy = 'ct."sortKey" DESC, i."id" DESC';
+    } else if (sort === ImageSort.RecentlyAdded) {
+      orderBy = 'ct."collectionItemId" DESC';
     }
     // TODO this causes the app to spike
     // else if (sort === ImageSort.Oldest) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -350,6 +350,12 @@ export const getModelsRaw = async ({
   /** For testing only: force the ModelBaseModelMetric query path regardless of feature flag */
   _forceBaseModelMetrics?: boolean;
 }) => {
+  // Ahead of every early empty return below, including the Meilisearch no-hits one: the point of
+  // throwing rather than falling back is that the misuse is legible, and an empty page hides it.
+  if (input.sort === ModelSort.RecentlyAdded && !input.collectionId) {
+    throw throwBadRequestError('Recently Added sort requires a collectionId');
+  }
+
   const blockedEnforcement = await enforceBlockedBrowsingTagsForModels(
     input,
     {
@@ -484,10 +490,6 @@ export const getModelsRaw = async ({
   let isPrivate = false;
   const AND: Prisma.Sql[] = [];
   let collectionJoin = Prisma.empty;
-
-  if (sort === ModelSort.RecentlyAdded && !collectionId) {
-    throw throwBadRequestError('Recently Added sort requires a collectionId');
-  }
 
   const userId = sessionUser?.id;
   const isModerator = sessionUser?.isModerator ?? false;
@@ -837,9 +839,10 @@ export const getModelsRaw = async ({
     const { rawAND: collectionItemModelsAND }: { rawAND: Prisma.Sql[] } =
       getAvailableCollectionItemsFilterForUser({ permissions, userId: sessionUser?.id });
 
-    // `RecentlyAdded` orders on ci."id", which a semi-join cannot expose. The partial unique
-    // index on ("collectionId", "modelId") means the join cannot multiply rows, so the two
-    // shapes select the same models.
+    // A semi-join cannot expose ci."id" to the ORDER BY. Safe to widen: CollectionItem is unique on
+    // ("collectionId", "modelId"), so the join cannot multiply rows. schema.full.prisma does not
+    // declare it, and the name has drifted — CollectionItem_model_idx in
+    // containers/db/docker-init/02_all_dll.sql, CollectionItem_model on prod.
     if (sort === ModelSort.RecentlyAdded) {
       collectionJoin = Prisma.sql`JOIN "CollectionItem" ci ON ci."modelId" = mm."modelId"
         AND ci."collectionId" = ${collectionId}

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -483,6 +483,11 @@ export const getModelsRaw = async ({
 
   let isPrivate = false;
   const AND: Prisma.Sql[] = [];
+  let collectionJoin = Prisma.empty;
+
+  if (sort === ModelSort.RecentlyAdded && !collectionId) {
+    throw throwBadRequestError('Recently Added sort requires a collectionId');
+  }
 
   const userId = sessionUser?.id;
   const isModerator = sessionUser?.isModerator ?? false;
@@ -832,15 +837,25 @@ export const getModelsRaw = async ({
     const { rawAND: collectionItemModelsAND }: { rawAND: Prisma.Sql[] } =
       getAvailableCollectionItemsFilterForUser({ permissions, userId: sessionUser?.id });
 
-    AND.push(
-      Prisma.sql`EXISTS (
+    // `RecentlyAdded` orders on ci."id", which a semi-join cannot expose. The partial unique
+    // index on ("collectionId", "modelId") means the join cannot multiply rows, so the two
+    // shapes select the same models.
+    if (sort === ModelSort.RecentlyAdded) {
+      collectionJoin = Prisma.sql`JOIN "CollectionItem" ci ON ci."modelId" = mm."modelId"
+        AND ci."collectionId" = ${collectionId}
+        AND ${Prisma.join(collectionItemModelsAND, ' AND ')}
+        ${collectionTagId ? Prisma.sql`AND ci."tagId" = ${collectionTagId}` : Prisma.empty}`;
+    } else {
+      AND.push(
+        Prisma.sql`EXISTS (
         SELECT 1 FROM "CollectionItem" ci
         WHERE ci."modelId" = mm."modelId"
         AND ci."collectionId" = ${collectionId}
         AND ${Prisma.join(collectionItemModelsAND, ' AND ')}
         ${collectionTagId ? Prisma.sql`AND ci."tagId" = ${collectionTagId}` : Prisma.empty}
       )`
-    );
+      );
+    }
 
     isPrivate = !permissions.publicCollection;
   }
@@ -867,6 +882,7 @@ export const getModelsRaw = async ({
   else if (sort === ModelSort.ImageCount)
     orderBy = `${pAlias}."imageCount" DESC, ${pAlias}."thumbsUpCount" DESC, ${pAlias}."modelId"`;
   else if (sort === ModelSort.Oldest) orderBy = `mm."lastVersionAt" ASC, ${pAlias}."modelId"`;
+  else if (sort === ModelSort.RecentlyAdded) orderBy = `ci."id" DESC`;
 
   // Cursor predicate split (perf): we build two branches that are combined with
   // UNION ALL when there is a multi-field sort + cursor. The OR-form predicate
@@ -999,7 +1015,8 @@ export const getModelsRaw = async ({
       mm."userId",
       ${Prisma.raw(cursorProp ? cursorProp : 'null')} as "cursorId"`;
 
-  const fromAndJoin = fromClause;
+  const fromAndJoin = Prisma.sql`${fromClause}
+      ${collectionJoin}`;
 
   const limitValue = (take ?? 100) + 1;
   const orderByRaw = Prisma.raw(orderBy);

--- a/src/server/services/post-sort.ts
+++ b/src/server/services/post-sort.ts
@@ -19,10 +19,22 @@ export type PostSortClauses = {
 export const getPostSortClauses = ({
   sort,
   draftOnly,
+  collectionJoined,
 }: {
   sort: PostSort;
   draftOnly?: boolean;
+  /** Whether the caller joined "CollectionItem" as `ci`, which `RecentlyAdded` orders on. */
+  collectionJoined?: boolean;
 }): PostSortClauses => {
+  if (sort === PostSort.RecentlyAdded && collectionJoined) {
+    return {
+      orderBy: 'ci."id" DESC',
+      primarySortProp: 'ci."id"',
+      isDateSort: false,
+      ascending: false,
+    };
+  }
+
   switch (sort) {
     case PostSort.MostComments:
       return {

--- a/src/server/services/post-sort.ts
+++ b/src/server/services/post-sort.ts
@@ -7,6 +7,13 @@ export type PostSortClauses = {
   isDateSort: boolean;
   ascending: boolean;
   filter?: Prisma.Sql;
+  /**
+   * Emit `prop < cursor` instead of the `(prop, p.id) <= (…)` row comparison. A row comparison
+   * spanning two tables cannot be pushed into an Index Cond on either, so every page after the
+   * first re-scans the whole collection; a single-column predicate lands on the `ci` scan.
+   * Only legal when the prop is already unique per row.
+   */
+  singleColumnCursor?: boolean;
 };
 
 /**
@@ -26,12 +33,21 @@ export const getPostSortClauses = ({
   /** Whether the caller joined "CollectionItem" as `ci`, which `RecentlyAdded` orders on. */
   collectionJoined?: boolean;
 }): PostSortClauses => {
-  if (sort === PostSort.RecentlyAdded && collectionJoined) {
+  if (sort === PostSort.RecentlyAdded) {
+    // Unreachable from getPostsInfinite, which 400s the sort without a collectionId before it
+    // gets here. Throwing rather than falling through to publishedAt because that fallback is
+    // exactly what a dropped `collectionJoined` would produce: a silently wrong order.
+    if (!collectionJoined)
+      throw new Error('PostSort.RecentlyAdded requires the caller to join "CollectionItem" as ci');
+
+    // The join is through a unique ("collectionId", "postId") index, so ci."id" is already
+    // total over the feed and needs no p.id tiebreaker in the ORDER BY or the cursor.
     return {
       orderBy: 'ci."id" DESC',
       primarySortProp: 'ci."id"',
       isDateSort: false,
       ascending: false,
+      singleColumnCursor: true,
     };
   }
 
@@ -97,11 +113,13 @@ export const buildPostCursorClause = ({
   primarySortProp,
   isDateSort,
   ascending,
+  singleColumnCursor,
 }: {
   cursor?: string | number;
   primarySortProp: string;
   isDateSort: boolean;
   ascending: boolean;
+  singleColumnCursor?: boolean;
 }): Prisma.Sql | undefined => {
   if (!cursor) return undefined;
 
@@ -119,6 +137,13 @@ export const buildPostCursorClause = ({
 
   const sortProp = Prisma.raw(primarySortProp);
 
+  // Non-strict, to match the row-comparison branch: the caller sets nextCursor from the popped
+  // lookahead row, so that row must be re-served as the first row of the next page.
+  if (singleColumnCursor)
+    return ascending
+      ? Prisma.sql`${sortProp} >= ${primaryValue}`
+      : Prisma.sql`${sortProp} <= ${primaryValue}`;
+
   if (cursorId !== null) {
     // Row-comparison form lets postgres push the predicate into Index Cond on a
     // (primarySortProp, id) index. Equivalent to
@@ -133,9 +158,12 @@ export const buildPostCursorClause = ({
     : Prisma.sql`${sortProp} < ${primaryValue}`;
 };
 
-export const encodePostCursor = (row: { id: number; cursorId: Date | number | null }) => {
+export const encodePostCursor = (
+  row: { id: number; cursorId: Date | number | null },
+  singleColumnCursor?: boolean
+) => {
   if (row.cursorId === null || row.cursorId === undefined) return undefined;
   const cursorValue =
     row.cursorId instanceof Date ? row.cursorId.toISOString() : String(row.cursorId);
-  return `${cursorValue}|${row.id}`;
+  return singleColumnCursor ? cursorValue : `${cursorValue}|${row.id}`;
 };

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -4,7 +4,7 @@ import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
 import { isImageMetaOnSite } from '~/server/utils/image-onsite';
 import { env } from '~/env/server';
-import { BlockedReason, SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { BlockedReason, PostSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
   getDbWithoutLag,
@@ -302,6 +302,7 @@ export const getPostsInfinite = async ({
   const canSeeUnpublished = canSeePostDrafts({ isOwnerRequest, isModerator, targetUser });
 
   const joins: string[] = [];
+  let collectionJoined = false;
   if (!canSeeUnpublished) {
     if (scheduled && userId) {
       // Surface own scheduled posts alongside the public published feed. Mirrors
@@ -366,6 +367,10 @@ export const getPostsInfinite = async ({
     }
   }
 
+  if (sort === PostSort.RecentlyAdded && !collectionId) {
+    throw throwBadRequestError('Recently Added sort requires a collectionId');
+  }
+
   if (ids) AND.push(Prisma.sql`p.id IN (${Prisma.join(ids)})`);
   if (collectionId) {
     cacheTime = CacheTTL.day;
@@ -383,12 +388,22 @@ export const getPostsInfinite = async ({
       ? `OR (ci."status" = 'REVIEW' AND ci."addedById" = ${user?.id})`
       : '';
 
-    AND.push(Prisma.sql`EXISTS (
-      SELECT 1 FROM "CollectionItem" ci
-      WHERE ci."collectionId" = ${collectionId}
-        AND ci."postId" = p.id
-        AND (ci."status" = 'ACCEPTED' ${Prisma.raw(displayReviewItems)})
-    )`);
+    // `RecentlyAdded` orders on ci."id", which a semi-join cannot expose. The partial unique
+    // index on ("collectionId", "postId") means the join cannot multiply rows, so the two
+    // shapes select the same posts.
+    if (sort === PostSort.RecentlyAdded) {
+      collectionJoined = true;
+      joins.push(
+        `JOIN "CollectionItem" ci ON ci."postId" = p.id AND ci."collectionId" = ${collectionId} AND (ci."status" = 'ACCEPTED' ${displayReviewItems})`
+      );
+    } else {
+      AND.push(Prisma.sql`EXISTS (
+        SELECT 1 FROM "CollectionItem" ci
+        WHERE ci."collectionId" = ${collectionId}
+          AND ci."postId" = p.id
+          AND (ci."status" = 'ACCEPTED' ${Prisma.raw(displayReviewItems)})
+      )`);
+    }
   }
 
   if (excludedUserIds && targetUser && excludedUserIds.includes(targetUser)) {
@@ -405,6 +420,7 @@ export const getPostsInfinite = async ({
   const { orderBy, primarySortProp, isDateSort, ascending, filter } = getPostSortClauses({
     sort,
     draftOnly,
+    collectionJoined,
   });
   if (filter) AND.push(filter);
 

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -40,6 +40,7 @@ import {
 import { withSpan } from '~/server/utils/otel-helpers';
 import {
   getCollectionById,
+  getAvailableCollectionItemsFilterForUser,
   getUserCollectionPermissionsById,
 } from '~/server/services/collection.service';
 import { Limiter } from '~/server/utils/concurrency-helpers';
@@ -303,6 +304,7 @@ export const getPostsInfinite = async ({
 
   const joins: string[] = [];
   let collectionJoined = false;
+  let collectionJoin = Prisma.empty;
   if (!canSeeUnpublished) {
     if (scheduled && userId) {
       // Surface own scheduled posts alongside the public published feed. Mirrors
@@ -388,14 +390,19 @@ export const getPostsInfinite = async ({
       ? `OR (ci."status" = 'REVIEW' AND ci."addedById" = ${user?.id})`
       : '';
 
-    // `RecentlyAdded` orders on ci."id", which a semi-join cannot expose. The partial unique
-    // index on ("collectionId", "postId") means the join cannot multiply rows, so the two
-    // shapes select the same posts.
+    // A semi-join cannot expose ci."id" to the ORDER BY. Safe to widen: CollectionItem_post_idx is
+    // unique on ("collectionId", "postId"), so the join cannot multiply rows. schema.full.prisma
+    // does not declare it — it lives in containers/db/docker-init/02_all_dll.sql.
     if (sort === PostSort.RecentlyAdded) {
+      const { rawAND: collectionItemAND } = getAvailableCollectionItemsFilterForUser({
+        permissions,
+        userId: user?.id,
+      });
       collectionJoined = true;
-      joins.push(
-        `JOIN "CollectionItem" ci ON ci."postId" = p.id AND ci."collectionId" = ${collectionId} AND (ci."status" = 'ACCEPTED' ${displayReviewItems})`
-      );
+      collectionJoin = Prisma.sql`JOIN "CollectionItem" ci
+        ON ci."postId" = p.id
+        AND ci."collectionId" = ${collectionId}
+        AND ${Prisma.join(collectionItemAND, ' AND ')}`;
     } else {
       AND.push(Prisma.sql`EXISTS (
         SELECT 1 FROM "CollectionItem" ci
@@ -417,14 +424,21 @@ export const getPostsInfinite = async ({
   }
 
   // sorting - always include id as tiebreaker for stable pagination
-  const { orderBy, primarySortProp, isDateSort, ascending, filter } = getPostSortClauses({
-    sort,
-    draftOnly,
-    collectionJoined,
-  });
+  const { orderBy, primarySortProp, isDateSort, ascending, filter, singleColumnCursor } =
+    getPostSortClauses({
+      sort,
+      draftOnly,
+      collectionJoined,
+    });
   if (filter) AND.push(filter);
 
-  const cursorClause = buildPostCursorClause({ cursor, primarySortProp, isDateSort, ascending });
+  const cursorClause = buildPostCursorClause({
+    cursor,
+    primarySortProp,
+    isDateSort,
+    ascending,
+    singleColumnCursor,
+  });
   if (cursorClause) AND.push(cursorClause);
 
   const postsRawQuery = Prisma.sql`
@@ -440,6 +454,7 @@ export const getPostsInfinite = async ({
       ${Prisma.raw(primarySortProp)} "cursorId"
     FROM "Post" p
     ${Prisma.raw(joins.join('\n'))}
+    ${collectionJoin}
     WHERE ${Prisma.join(AND, ' AND ')}
     ORDER BY ${Prisma.raw(orderBy)}
     LIMIT ${limit + 1}`;
@@ -473,7 +488,7 @@ export const getPostsInfinite = async ({
   let nextCursor: string | undefined;
   if (postsRaw.length > limit) {
     const nextItem = postsRaw.pop();
-    if (nextItem) nextCursor = encodePostCursor(nextItem);
+    if (nextItem) nextCursor = encodePostCursor(nextItem, singleColumnCursor);
   }
 
   // Filter to published model versions:

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -302,7 +302,6 @@ export const getPostsInfinite = async ({
 
   const canSeeUnpublished = canSeePostDrafts({ isOwnerRequest, isModerator, targetUser });
 
-  const joins: string[] = [];
   let collectionJoined = false;
   let collectionJoin = Prisma.empty;
   if (!canSeeUnpublished) {
@@ -423,7 +422,8 @@ export const getPostsInfinite = async ({
     AND.push(Prisma.sql`p."userId" NOT IN (${Prisma.raw(`${excluded.join(',')}`)})`);
   }
 
-  // sorting - always include id as tiebreaker for stable pagination
+  // Every sort carries a p.id tiebreaker except Recently Added, whose ci."id" is already unique
+  // per row through the ("collectionId", "postId") join.
   const { orderBy, primarySortProp, isDateSort, ascending, filter, singleColumnCursor } =
     getPostSortClauses({
       sort,
@@ -453,7 +453,6 @@ export const getPostsInfinite = async ({
       ${include?.includes('detail') ? Prisma.sql`p."detail",` : Prisma.sql``}
       ${Prisma.raw(primarySortProp)} "cursorId"
     FROM "Post" p
-    ${Prisma.raw(joins.join('\n'))}
     ${collectionJoin}
     WHERE ${Prisma.join(AND, ' AND ')}
     ORDER BY ${Prisma.raw(orderBy)}


### PR DESCRIPTION
Fixes [868kyuehg](https://app.clickup.com/t/8459928/868kyuehg).

## The report

> Seems like 'Newest' in collection sorts by upload date and not published date. Was a bit confusing to add a recent image and then see it far down in the collection (probably because uploader scheduled the post?).

Correct. A collection sorted by Newest orders on `i."id" DESC`, which is **upload** order. Schedule a post and the upload happens weeks before publication, so adding a freshly published image to a collection drops it far down the feed.

## What this does instead of the literal fix

The task's closing condition was "Newest uses published date". **I did not do that, because it is a 20–300x regression on the collection feed.** Measured on the prod replica:

| ORDER BY | 4,500-item collection | 163,624-item collection |
|---|---|---|
| `i."id" DESC` (today) | 15 ms | 19 ms |
| `i."sortAt" DESC` (published date) | 334 ms | **5,738 ms** |
| `ct."id" DESC` (this PR, no index) | — | 246 ms |
| `ct."id" DESC` (this PR, with index) | — | see below |

`i."id" DESC` is cheap only because `CollectionItem_image_idx ("collectionId", "imageId")` already yields that order for free. Ordering on any `Image` column forces the planner to materialise every item in the collection and sort it — there is no index that avoids this without denormalising `sortAt` onto `CollectionItem` (85M+ rows, a new trigger, a full backfill). The commented-out `sortAt` branch in `image.service.ts` and its `// TODO this causes the app to spike` note were right.

So this adds a **`Recently Added`** sort ordering on `CollectionItem.id`, and makes it the **default** for collections. That is what the reporter actually expected — add something, see it at the top — and it costs about what Newest costs. `Newest` keeps its current meaning.

Scale for context: 954,537 image collections, 85M items, p50 = 8 / p99 = 1,384 / max = 163,624. 6.7% of recent collection items were published more than a day after upload, so the confusion is not rare.

## Scope

Applied to all four collection types. Only **images** had the bug — posts and articles already sort Newest on `publishedAt`, models on `lastVersionAt` — so for those three this is a new capability, added so the four types behave alike.

The three services that filtered with `EXISTS (SELECT 1 FROM "CollectionItem" ...)` needed a real JOIN to expose `ci."id"` to `ORDER BY`. The partial unique indexes on `("collectionId", <entity>Id)` mean the join cannot multiply rows, so both shapes select the same entities.

Two guards worth reviewing:

- `Recently Added` is withheld from every general feed menu via the `*SortHidden` maps, and every service returns a 400 when it arrives without a `collectionId` — mirroring the existing `Random` guard.
- It is held out of the **contest random-sort pools**. Contest feeds re-roll their sort each render to spread entry visibility; a deterministic sort in the pool would pin the newest entries to the top for whichever renders draw it, and nothing about the feed would look wrong.

## ⚠️ Migration is NOT applied

`packages/civitai-db-schema/prisma/migrations/20260831120000_collection_item_recently_added_idx/`

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "CollectionItem_collectionId_id_idx"
  ON "CollectionItem" ("collectionId", id DESC);
```

**This needs a decision before anyone runs it.** `CollectionItem` is **204M rows / 15 GB heap / 82 GB of existing indexes**, and this adds roughly **6 GB**.

What it buys, measured rather than assumed — I built an equivalent index scoped to a single `collectionId` on dev, then dropped it: the same page went **42.2 ms → 1.8 ms**, and the `Sort` node disappeared entirely. The ratio matters less than the shape: the scan reads **102 rows and stops at the LIMIT** instead of reading all 44,367, so page cost stops scaling with collection size.

Without it the feature still works, at 246 ms on the largest collection. Run `CONCURRENTLY`, outside a transaction; a cancelled build leaves an INVALID index that must be dropped before retrying. Full operator notes are in the migration file.

## Verification

Exercised all four feeds live against the dev database. The one that actually proves it — a collection where add order and upload order diverge:

```
Recently Added → 124995538, 86127674, 96212893
Newest         → 124995538, 96212893, 86127674
```

The `CollectionItem` ids confirm the first is the true add order: image `96212893` was uploaded later but added earlier. That is exactly the reporter's case.

- Full unit suite: **1528 files / 24,106 tests passed, 0 failed**
- `pnpm typecheck`: 0 errors
- `db:check-generated`: clean

New tests fail loudly on a revert — verified by mutation, not by assuming. Disabling the `RecentlyAdded` branch produces `expected [504, 503, 502, 501] to deeply equal [501, 502, 503, 504]` rather than a hang, because the fixture is built so Newest and Recently Added are exact reversals of each other and cannot agree by coincidence.

## Things a reviewer should look at

- **Articles could not be exercised end-to-end.** The dev DB throws `permission denied for table ArticleRank` on *both* `Newest` and `Recently Added`, so it is a pre-existing grant issue rather than this change. I validated that SQL shape directly against the prod replica instead, and it returns correctly add-ordered rows — but it has not run through the real service.
- **`post.service.ts` interpolates `collectionId` into a raw join string** rather than binding it, because `joins` is a `string[]`. It is `z.number()`-validated upstream and matches the `displayReviewItems` line immediately above it, but it is the one spot in the diff I would flag. Parameterising it means converting that array to `Prisma.Sql[]`, which is wider than this fix.
- **The default sort changes for all four collection types**, not just images. Contest collections are unaffected.
- **`flipt-eval-context.test.ts` ledger rows move by +7 lines.** That ledger is keyed on `file:line` and this change inserts lines above four `getFliptBoolean` sites in `image.service.ts`. The sites themselves are unchanged; I updated the rows rather than exempting anything.

## Not done

`Newest` and `Oldest` are not relabelled to say "upload date". `DumbSortFilter` passes the enum *value* as the button label, so custom option labels would appear in the dropdown but not on the button — inconsistent rather than clearer. Worth a separate change if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnFnLu369fHmf7dUQBHMXm
