### PR TITLE
feat(app-blocks): review entry points in the host chrome (F4)

### DIFF
--- a/src/components/AppBlocks/AppNameCrumb.tsx
+++ b/src/components/AppBlocks/AppNameCrumb.tsx
@@ -12,9 +12,9 @@ import { IconBuildingStore } from '@tabler/icons-react';
 import { getListingDetailHref, getRecommendLabel } from '~/components/Apps/appListingCardView';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
-import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
-import { trpc } from '~/utils/trpc';
+import { ChromeReviewPopoverAction } from './ChromeReviewEntry';
+import { useChromeListingDetail } from './useChromeListingDetail';
 import { useIframeAwareMenu } from './useIframeAwareMenu';
 
 /**
@@ -74,6 +74,7 @@ export function AppNameCrumb({
   name,
   slug,
   maxWidth,
+  onOpenReview,
 }: {
   /**
    * The app's display name, ALREADY SANITIZED by the caller
@@ -98,6 +99,13 @@ export function AppNameCrumb({
    * (the `xl` tier).
    */
   maxWidth: number | undefined;
+  /**
+   * F4 — open the review modal for this listing. The popover offers the action; the
+   * CHROME owns the modal, because a `Popover.Dropdown` is unmounted when it closes
+   * and would destroy a modal rendered inside it. Omitted → no review action in the
+   * popover (the crumb keeps doing everything else it did).
+   */
+  onOpenReview?: (appListingId: string) => void;
 }) {
   const features = useOptionalFeatureFlags();
   const canSeeStore = hasAppsStoreAccess(features);
@@ -171,7 +179,23 @@ export function AppNameCrumb({
             the fetch lazy — STRUCTURALLY, not via an `enabled` flag that has to be
             kept correct. See the card's own header for why that distinction earned
             its own component. */}
-        <AppNameCrumbCard name={name} slug={slug} />
+        <AppNameCrumbCard
+          name={name}
+          slug={slug}
+          // 🔴 THE POPOVER CLOSES BEFORE THE MODAL OPENS, AND THE CLOSE IS EXPLICIT.
+          // A `Popover` has no `closeOnItemClick` equivalent, so nothing closes it
+          // for us; leaving it open would park a dropdown behind a focus-trapping
+          // modal with `aria-expanded="true"` still on the crumb. Order matters only
+          // in the sense that both happen in one handler — React batches them into a
+          // single commit.
+          onOpenReview={
+            onOpenReview &&
+            ((appListingId: string) => {
+              popover.onChange(false);
+              onOpenReview(appListingId);
+            })
+          }
+        />
       </Popover.Dropdown>
     </Popover>
   );
@@ -196,16 +220,23 @@ export function AppNameCrumb({
  * never instantiates it, and a closed popover never fetches. `enabled` is gone,
  * so there is no flag left to get wrong.
  */
-function AppNameCrumbCard({ name, slug }: { name: string; slug: string }) {
-  // `retry: false` matches `/apps/store-preview/<slug>`'s own call — a listing that
-  // is missing, unapproved or scope-gated 404s server-side and should settle into
-  // the unavailable state rather than being retried three times. React Query caches
-  // the result, so re-opening the popover is instant.
-  const { data, isLoading, error } = trpc.appListings.getAppDetail.useQuery(
-    { slug },
-    { retry: false }
-  );
-  const detail = data as ListingDetail | undefined;
+function AppNameCrumbCard({
+  name,
+  slug,
+  onOpenReview,
+}: {
+  name: string;
+  slug: string;
+  onOpenReview?: (appListingId: string) => void;
+}) {
+  // 🔴 THE READ GOES THROUGH THE CHROME'S SHARED HOOK, NOT A LOCAL `useQuery`. F4
+  // added a SECOND surface in this same bar that needs the same listing row (the ⋮
+  // menu's review item, which needs the id/owner/kind). React Query dedupes by KEY,
+  // so two call sites are one request only while their inputs and options serialise
+  // identically — a property of two pieces of code that nothing was checking. There
+  // is now exactly one call site (`useChromeListingDetail`) and a guard that fails if
+  // a second appears. `retry: false` and the laziness rationale live there.
+  const { detail, isLoading, error } = useChromeListingDetail(slug);
 
   return (
     <Stack gap={6}>
@@ -254,6 +285,15 @@ function AppNameCrumbCard({ name, slug }: { name: string; slug: string }) {
           >
             View in App Store
           </Button>
+          {/* F4 — the second review entry point. Sits under the store link because
+              it is the action about THIS app rather than a way to leave for the
+              store, and because the rollup directly above it is what prompts the
+              thought. It renders only for a viewer the server would accept
+              (`useCanReviewListing`, inside the component) and only on this success
+              branch, so it can never be offered against a listing that 404'd. */}
+          {onOpenReview && (
+            <ChromeReviewPopoverAction detail={detail} onOpenReview={onOpenReview} />
+          )}
         </>
       )}
     </Stack>

--- a/src/components/AppBlocks/ChromeReviewEntry.browser.test.tsx
+++ b/src/components/AppBlocks/ChromeReviewEntry.browser.test.tsx
@@ -1,0 +1,482 @@
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * F4 — the App Blocks host chrome's two REVIEW ENTRY POINTS: an item in the ⋮
+ * overflow menu and an action in the app-name popover, both opening the existing
+ * `ReviewListingModal`.
+ *
+ * 🔴 EVERY TEST MOUNTS `AppBlockChrome`, NOT THE ENTRY-POINT COMPONENTS. Three of
+ * the five claims this file makes are about the SEAM rather than about a component:
+ * that the chrome threads the slug down, that the chrome owns the modal state both
+ * triggers write to, and that opening the modal closes the surface the trigger lives
+ * in. A suite that rendered `ChromeReviewMenuItem` on its own would verify a correct
+ * component behind a host wiring it to nothing — the failure mode RULES calls the
+ * isolation seam, and the exact one F2's own suite calls out.
+ *
+ * 🔴 THE tRPC MOCK IS BACKED BY REAL REACT QUERY, WHICH IS WHAT MAKES THE
+ * "ONE REQUEST" CLAIM MEAN ANYTHING. A hand-rolled `useQuery: () => ({data})` stub
+ * counts HOOK CALLS, and hook calls are not requests — a stub like that reports "2"
+ * for correctly deduped code and "1" for code that fires twice through one shared
+ * component, i.e. it cannot see the defect either way. Here each procedure is a thin
+ * wrapper over the real `useQuery` with a counting `queryFn`, so the counter is the
+ * number of times the cache actually went and fetched, under the real key-hashing
+ * and the real staleness rules.
+ *
+ * 🔴 …AND THE CLIENT IS CONFIGURED LIKE PRODUCTION'S, NOT LIKE THE SHARED HARNESS'S.
+ * `renderWithProviders` builds a `QueryClient` with `gcTime: 0` and React Query's
+ * default `staleTime: 0`, whereas `src/utils/trpc.ts` ships `staleTime: Infinity`.
+ * Under the harness defaults an unmount/remount refetches, so the dedupe assertion
+ * would measure the harness rather than the app and would fail against correct code.
+ * The local wrapper below mirrors the app's `queryClientConfig`; the divergence is
+ * pinned by `chromeListingQueryIsSingleSourced.test.ts`, which reads the real number
+ * out of `trpc.ts`.
+ */
+
+const mocks = vi.hoisted(() => ({
+  // `appListings` OR `appBlocks` OR `appListingsPublicExternal` → store access.
+  features: { appListings: true } as Record<string, boolean>,
+  user: { id: 7, username: 'viewer', isModerator: false } as unknown,
+  detail: null as unknown,
+  myReview: null as unknown,
+  /** How many times the cache actually FETCHED the listing. Not hook calls. */
+  detailFetches: 0,
+  myReviewFetches: 0,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => mocks.user }));
+
+// Both flag hooks, to the same flags: `useCanReviewListing` and the store-access gate
+// read `useOptionalFeatureFlags` (fail-closed outside a provider), while the chrome's
+// host half reads `useFeatureFlags`. Overriding only one leaves the other resolving
+// the real null-outside-provider value, which silently hides the whole affordance and
+// makes every test below fail for a reason unrelated to what it asserts.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsMod>()),
+  useFeatureFlags: () => mocks.features,
+  useOptionalFeatureFlags: () => mocks.features,
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const invalidate = vi.fn().mockResolvedValue(undefined);
+  return {
+    ...(await importOriginal<typeof TrpcMod>()),
+    trpc: {
+      appListings: {
+        getAppDetail: {
+          useQuery: (input: unknown, opts?: Record<string, unknown>) =>
+            useQuery({
+              // The same shape tRPC builds, so React Query's own hashing decides
+              // whether two call sites collide — which is the property under test.
+              queryKey: [['appListings', 'getAppDetail'], { input, type: 'query' }],
+              queryFn: async () => {
+                mocks.detailFetches += 1;
+                return mocks.detail;
+              },
+              ...opts,
+            }),
+        },
+        getMyReview: {
+          useQuery: (input: unknown, opts?: Record<string, unknown>) =>
+            useQuery({
+              queryKey: [['appListings', 'getMyReview'], { input, type: 'query' }],
+              queryFn: async () => {
+                mocks.myReviewFetches += 1;
+                return mocks.myReview;
+              },
+              ...opts,
+            }),
+        },
+        // Only reached once the modal is mounted; the modal's own submit path has its
+        // own suite (`ReviewListingButton.browser.test.tsx`).
+        upsertReview: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      },
+      useUtils: () => ({
+        appListings: {
+          getMyReview: { invalidate },
+          listReviews: { invalidate },
+          getAppDetail: { invalidate },
+        },
+      }),
+    },
+  };
+});
+
+// eslint-disable-next-line import/first
+import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import { useChromeListingDetail } from '~/components/AppBlocks/useChromeListingDetail';
+
+const APP_NAME = 'Budgeted Generator';
+const SLUG = 'budgeted-generator';
+const OWNER_ID = 4242;
+
+/** A `ListingDetail`-shaped fixture — only the fields these paths read. */
+function detailFixture(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_01HZ',
+    slug: SLUG,
+    name: APP_NAME,
+    kind: 'onsite',
+    creator: { id: OWNER_ID, username: 'publisher', image: null },
+    recommend: { recommendedCount: 9, notRecommendedCount: 1, recommendPct: 0.9 },
+    reviewCount: 10,
+    ...over,
+  };
+}
+
+/**
+ * Providers mirroring the APP's query configuration (`queryClientConfig` in
+ * `src/utils/trpc.ts`), not the shared harness's. See the file header.
+ */
+function ProdishProviders({ children }: { children: React.ReactNode }) {
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { refetchOnWindowFocus: false, retry: false, staleTime: Infinity },
+          mutations: { retry: false },
+        },
+      })
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider>{children}</MantineProvider>
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * A second observer of the SAME listing query, rendering a marker once the row has
+ * landed.
+ *
+ * 🔴 IT EXISTS BECAUSE "THE ITEM IS ABSENT" IS UNFALSIFIABLE WITHOUT IT — MEASURED,
+ * NOT ANTICIPATED. `expect.element(x).not.toBeInTheDocument()` POLLS UNTIL IT PASSES,
+ * and at the instant the dropdown opens the item is legitimately absent for everyone,
+ * because its data has not arrived. So the assertion passed at t0 whether the gate
+ * worked or not: three mutants that DELETED a gate term outright (the owner term, the
+ * `listingKind` term, and the signed-out term inverted to `true`) all SURVIVED a fully
+ * green run of this file. Adding a fixed `setTimeout` would swap the hole for a
+ * timing dependency; this is a real happens-before instead — React Query notifies
+ * every observer of one key inside a single `notifyManager` batch, so by the time
+ * this marker is in the document the entry point has had its data in the SAME commit.
+ * All three mutants die now.
+ *
+ * It shares the key, so it adds an observer and NOT a request; the "no store access →
+ * zero requests" test therefore does not mount it.
+ */
+function ListingProbe({ slug }: { slug: string }) {
+  const { detail } = useChromeListingDetail(slug);
+  return detail ? <span data-testid="listing-probe-resolved" /> : null;
+}
+
+function renderChrome(props: Record<string, unknown> = {}) {
+  return render(
+    <AppBlockChrome
+      blockInstanceId="inst-f4"
+      appName={APP_NAME}
+      slug={SLUG}
+      slotId="app.page"
+      {...props}
+    />,
+    { wrapper: ProdishProviders }
+  );
+}
+
+/** The chrome plus the probe — for any test whose claim is that the item is ABSENT. */
+function renderChromeWithProbe(props: Record<string, unknown> = {}) {
+  const slug = (props.slug as string | undefined) ?? SLUG;
+  return render(
+    <>
+      <AppBlockChrome
+        blockInstanceId="inst-f4"
+        appName={APP_NAME}
+        slug={SLUG}
+        slotId="app.page"
+        {...props}
+      />
+      <ListingProbe slug={slug} />
+    </>,
+    { wrapper: ProdishProviders }
+  );
+}
+
+/** The listing row has landed AND been rendered — see {@link ListingProbe}. */
+async function awaitListingResolved() {
+  await expect.element(page.getByTestId('listing-probe-resolved')).toBeInTheDocument();
+}
+
+/** Open the ⋮ overflow menu and wait for a permanent item, so the dropdown mounted. */
+async function openOverflow() {
+  await page.getByTestId('app-block-menu-trigger').click();
+  await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+}
+
+/** Open the app-name crumb popover and wait for its body. */
+async function openNamePopover() {
+  await page.getByTestId('app-block-breadcrumb-name').click();
+  await expect.element(page.getByTestId('app-block-name-popover')).toBeInTheDocument();
+}
+
+const reviewItem = () => page.getByTestId('app-block-review-menu-item');
+const popoverAction = () => page.getByTestId('app-block-name-popover-review');
+const modalHeading = () => page.getByText('Would you recommend this app to others?');
+
+beforeEach(async () => {
+  mocks.features = { appListings: true };
+  mocks.user = { id: 7, username: 'viewer', isModerator: false };
+  mocks.detail = detailFixture();
+  mocks.myReview = null;
+  mocks.detailFetches = 0;
+  mocks.myReviewFetches = 0;
+  // Desktop unless a test says otherwise — the modal's `fullScreen` is a viewport
+  // media query, so leaving the viewport wherever the previous test left it would
+  // make that pair of tests order-dependent.
+  await page.viewport(1280, 900);
+});
+
+describe('the ⋮ overflow menu offers a review entry point', () => {
+  test('an eligible viewer gets "Rate this app", alongside the existing items', async () => {
+    renderChrome({ appBlockId: 'ab-1' });
+    await openOverflow();
+
+    await expect.element(reviewItem()).toBeInTheDocument();
+    expect((reviewItem().element().textContent ?? '').trim()).toBe('Rate this app');
+
+    // It reads as one of the chrome's own app actions, not as a route link: the
+    // existing permanent items are still there and it sits among them.
+    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Permissions & activity' }))
+      .toBeInTheDocument();
+    // An ACTION, not a destination — no `href`, which is what keeps it out of the
+    // ONE ROUTE, ONE ICON extractor in `chromeNavAlignsWithSubNav.test.ts`.
+    expect(reviewItem().element().getAttribute('href')).toBeNull();
+  });
+
+  test('the label switches to "Edit your review" when the viewer already has one', async () => {
+    mocks.myReview = { id: 'rev_1', recommended: true, details: 'good' };
+    renderChrome();
+    await openOverflow();
+
+    await expect.element(reviewItem()).toBeInTheDocument();
+    // Polls: the label depends on a real async query resolving, so a synchronous
+    // read here would sample the pre-fetch render and pass for the wrong reason.
+    await expect.element(reviewItem()).toHaveTextContent('Edit your review');
+    expect(mocks.myReviewFetches).toBeGreaterThan(0);
+  });
+});
+
+describe('the item appears only when the SERVER would accept the review', () => {
+  test('it is ABSENT for the listing owner (a self-review is 403d)', async () => {
+    mocks.user = { id: OWNER_ID, username: 'publisher', isModerator: false };
+    renderChromeWithProbe();
+    await openOverflow();
+
+    // The listing DID resolve and HAS rendered — so this is the gate refusing, not
+    // the data merely not having arrived yet. Without this the absence assertion
+    // passes at t0 for everyone (see `ListingProbe`).
+    await awaitListingResolved();
+    expect(mocks.detailFetches).toBe(1);
+    expect(reviewItem().elements()).toHaveLength(0);
+  });
+
+  test('it is ABSENT for a signed-out viewer (the write proc is protected)', async () => {
+    mocks.user = null;
+    renderChromeWithProbe();
+    await openOverflow();
+    await awaitListingResolved();
+    expect(reviewItem().elements()).toHaveLength(0);
+  });
+
+  test('it is ABSENT when the viewer’s store scope does not admit the listing KIND', async () => {
+    // The external-only cohort: `public-external` scope, reaching an ONSITE listing.
+    // This is the exact pair the server NOT_FOUNDs, and the mirror image of the
+    // defect `useCanReviewListing`'s kind term was added to close.
+    mocks.features = { appListingsPublicExternal: true };
+    renderChromeWithProbe();
+    await openOverflow();
+
+    await awaitListingResolved();
+    expect(reviewItem().elements()).toHaveLength(0);
+  });
+
+  test('the SAME viewer IS offered it on an OFFSITE listing — the kind term, not a blanket refusal', async () => {
+    // Positive control on the test above: without this, "absent" there would be
+    // indistinguishable from "this cohort never sees the item at all", and a gate
+    // that hid the affordance from everyone would pass both.
+    mocks.features = { appListingsPublicExternal: true };
+    mocks.detail = detailFixture({ kind: 'offsite' });
+    renderChrome();
+    await openOverflow();
+    await expect.element(reviewItem()).toBeInTheDocument();
+  });
+
+  test('a viewer with NO store access gets no item AND no listing request at all', async () => {
+    // Every term of `hasAppsStoreAccess` off — the cohort for which `getAppDetail`
+    // resolves a `none` scope and throws NOT_FOUND. The affordance is withheld
+    // before the query is even instantiated, so this asserts the FETCH COUNT and not
+    // just the absent DOM.
+    mocks.features = {};
+    renderChrome();
+    await openOverflow();
+
+    await expect.element(reviewItem()).not.toBeInTheDocument();
+    expect(mocks.detailFetches).toBe(0);
+    expect(mocks.myReviewFetches).toBe(0);
+  });
+
+  test('with no slug threaded there is no entry point (nothing to review)', async () => {
+    renderChrome({ slug: undefined, slotId: 'model.sidebar_top' });
+    await openOverflow();
+    await expect.element(reviewItem()).not.toBeInTheDocument();
+    expect(mocks.detailFetches).toBe(0);
+  });
+});
+
+describe('each entry point closes ITS OWN opener when the modal opens', () => {
+  test('the ⋮ menu closes, and the modal opens', async () => {
+    renderChrome({ appBlockId: 'ab-1' });
+    await openOverflow();
+    await expect.element(reviewItem()).toBeInTheDocument();
+
+    await reviewItem().click();
+
+    // 🔴 THE DROPDOWN IS GONE, not merely visually behind the modal. A dropdown left
+    // mounted under a focus-trapping modal keeps `aria-expanded="true"` on its
+    // trigger and re-appears when the modal closes — the visible half of the defect
+    // F0 fixed, one surface further along.
+    await expect.element(modalHeading()).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Manage apps' }))
+      .not.toBeInTheDocument();
+    expect(page.getByTestId('app-block-menu-trigger').element().getAttribute('aria-expanded')).toBe(
+      'false'
+    );
+  });
+
+  test('the name popover closes, and the modal opens', async () => {
+    renderChrome();
+    await openNamePopover();
+    await expect.element(popoverAction()).toBeInTheDocument();
+
+    await popoverAction().click();
+
+    await expect.element(modalHeading()).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-block-name-popover')).not.toBeInTheDocument();
+    expect(
+      page.getByTestId('app-block-breadcrumb-name').element().getAttribute('aria-expanded')
+    ).toBe('false');
+  });
+
+  test('the popover action is withheld from a viewer who may not review', async () => {
+    mocks.user = { id: OWNER_ID, username: 'publisher', isModerator: false };
+    renderChrome();
+    await openNamePopover();
+    // The store link IS there — so the popover resolved its listing and this is the
+    // review gate refusing, not an empty card.
+    await expect.element(page.getByTestId('app-block-name-popover-store-link')).toBeInTheDocument();
+    await expect.element(popoverAction()).not.toBeInTheDocument();
+  });
+});
+
+describe('the two entry points share ONE listing request', () => {
+  test('opening the ⋮ menu and then the name popover fetches the listing once', async () => {
+    renderChrome();
+
+    await openOverflow();
+    await expect.element(reviewItem()).toBeInTheDocument();
+    expect(mocks.detailFetches, 'the ⋮ menu should have fetched the listing exactly once').toBe(1);
+
+    // Close the menu (Escape) and open the OTHER surface. The ⋮ dropdown unmounts,
+    // so this is a genuine second mount of the same query — the case in which a
+    // differently-shaped input would show up as a second fetch.
+    await page.getByTestId('app-block-menu-trigger').click();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Manage apps' }))
+      .not.toBeInTheDocument();
+
+    await openNamePopover();
+    await expect.element(popoverAction()).toBeInTheDocument();
+    // The popover renders the rollup from the SAME row — proof it got the data, so a
+    // "1" below cannot mean "the second surface never asked".
+    await expect
+      .element(page.getByTestId('app-block-name-popover-recommend'))
+      .toHaveTextContent('90% recommend (10)');
+
+    expect(
+      mocks.detailFetches,
+      'both chrome surfaces must resolve to ONE listing query key — a second fetch means the ' +
+        'two call sites are keying it differently'
+    ).toBe(1);
+  });
+
+  test('POSITIVE CONTROL — the counter does move when the key genuinely differs', async () => {
+    // A dedupe assertion whose counter can only ever read 1 measures nothing. Two
+    // chromes on DIFFERENT slugs are two keys and must fetch twice; if this reads 1,
+    // the counter is wired to nothing and the test above is vacuous.
+    render(
+      <>
+        <AppBlockChrome blockInstanceId="a" appName="A" slug="app-a" slotId="app.page" />
+        <AppBlockChrome blockInstanceId="b" appName="B" slug="app-b" slotId="app.page" />
+      </>,
+      { wrapper: ProdishProviders }
+    );
+
+    const triggers = page.getByTestId('app-block-menu-trigger');
+    await triggers.nth(0).click();
+    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+    await vi.waitFor(() => expect(mocks.detailFetches).toBe(1));
+
+    await triggers.nth(0).click();
+    await triggers.nth(1).click();
+    await vi.waitFor(() => expect(mocks.detailFetches).toBe(2));
+  });
+});
+
+describe('the review modal is full-screen on a phone', () => {
+  // 🔴 A REAL VIEWPORT CHANGE, NOT A MOCKED HOOK. The claim is that the modal sizes
+  // itself against the VIEWPORT rather than against the page container the chrome
+  // sits in (see `ReviewListingModal`'s header), and only driving the actual viewport
+  // can tell those two apart — a stubbed `useIsMobile` would pass either way.
+  async function openModalAt(width: number, height: number) {
+    await page.viewport(width, height);
+    renderChrome();
+    await openOverflow();
+    await expect.element(reviewItem()).toBeInTheDocument();
+    await reviewItem().click();
+    await expect.element(modalHeading()).toBeInTheDocument();
+    const content = document.querySelector('.mantine-Modal-content') as HTMLElement | null;
+    expect(content, 'the modal content element was not found').not.toBeNull();
+    return content as HTMLElement;
+  }
+
+  // 🔴 THE ASSERTION IS ON WHAT MANTINE *EMITS*, NOT ON A MEASURED WIDTH. This
+  // harness deliberately loads no Mantine stylesheet (see `test/component-setup.tsx`),
+  // so `size="md"`'s max-width never applies and a rendered-width comparison reads
+  // 1280px at BOTH viewports — measured: the first draft of the desktop control
+  // failed with `expected 1280 to be less than 1280` against correct code. What the
+  // component itself produces is `data-full-screen` plus an INLINE `max-height`
+  // (`100dvh` vs `calc(100dvh - …)`, `Modal/ModalContent.mjs`), and those are real
+  // outputs of the prop rather than a word in the source.
+  test('at a 375px phone viewport the modal renders full-screen', async () => {
+    const content = await openModalAt(375, 720);
+    expect(content.getAttribute('data-full-screen')).toBe('true');
+  });
+
+  test('CONTROL — at a 1280px desktop viewport it does NOT', async () => {
+    // Without this arm, the test above cannot tell "full-screen on a phone" from
+    // "full-screen always", and a hardcoded `fullScreen` would pass it. The pair is
+    // also what makes this a test of the VIEWPORT axis: the only thing that differs
+    // between the two runs is `page.viewport`.
+    const content = await openModalAt(1280, 900);
+    expect(content.getAttribute('data-full-screen')).toBeNull();
+  });
+});

--- a/src/components/AppBlocks/ChromeReviewEntry.tsx
+++ b/src/components/AppBlocks/ChromeReviewEntry.tsx
@@ -1,0 +1,181 @@
+import { Button, Menu } from '@mantine/core';
+import { IconThumbUp } from '@tabler/icons-react';
+
+import { useCanReviewListing } from '~/components/Apps/ReviewListingButton';
+import { useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
+import { trpc } from '~/utils/trpc';
+import { useChromeListingDetail } from './useChromeListingDetail';
+
+/**
+ * F4 — the app-block host chrome's REVIEW ENTRY POINTS.
+ *
+ * Until now the only way to review an app was to already be standing on its store
+ * listing. The one place a user is guaranteed to have an opinion about an app is
+ * while the app is running in front of them, and that surface offered nothing. This
+ * module supplies the two affordances the chrome mounts — an item in the ⋮ overflow
+ * menu and an action in the app-name popover — both of which open the SAME existing
+ * `ReviewListingModal`.
+ *
+ * 🔴 IT BUILDS NO REVIEW SYSTEM. The gate (`useCanReviewListing`), the form and the
+ * mutation (`ReviewListingModal`) already exist and are imported, not re-derived.
+ * The review model is thumbs + free text (`recommended` / `details`); there are no
+ * stars anywhere in this path.
+ *
+ * 🔴 NEITHER ENTRY POINT OWNS THE MODAL, AND THAT IS FORCED, NOT STYLISTIC. Mantine
+ * unmounts a `Menu.Dropdown` and a `Popover.Dropdown` when they close, so a modal
+ * rendered beside its trigger would be destroyed by the very click that opens it —
+ * the same constraint that made `ReviewListingModal` a caller-controlled component
+ * in the first place, and the reason `AppListingDetailBody` owns its copy too. Both
+ * components here take an `onOpenReview(appListingId)` and hand the id UP to
+ * `AppBlockChrome`, which mounts the modal outside every floating surface.
+ *
+ * 🔴 EACH ENTRY POINT CLOSES ITS OWN OPENER. A dropdown left hanging behind a modal
+ * is the visible half of the defect F0 fixed (`useIframeAwareMenu`), and it is worse
+ * here than a stray dropdown: the modal takes focus while the menu keeps its
+ * `aria-expanded="true"`. The ⋮ item gets that for free from Mantine
+ * (`closeOnItemClick` runs `closeDropdownImmediately`, which in a CONTROLLED menu
+ * calls our `onChange(false)` — verified against @mantine/core 7.17.8
+ * `Menu/MenuItem/MenuItem.mjs` and pinned behaviourally in
+ * `ChromeReviewEntry.browser.test.tsx`); the popover action has no such default and
+ * closes itself explicitly.
+ */
+
+/**
+ * The label for a review entry point: "Rate this app" for a viewer who has not
+ * reviewed, "Edit your review" for one who has.
+ *
+ * 🔴 A SEPARATE HOOK SO THE TWO ENTRY POINTS CANNOT DISAGREE. They sit a few pixels
+ * apart in one bar; one saying "Rate this app" while the other says "Edit your
+ * review" would be a straightforward lie about the viewer's own state. Same query,
+ * same input, so React Query serves both from one cache entry.
+ *
+ * The query is mounted only by an ELIGIBLE viewer's entry point (both call sites sit
+ * behind `useCanReviewListing`), so an ineligible or signed-out viewer never issues
+ * it — `getMyReview` is a protected procedure.
+ */
+export function useChromeReviewLabel(appListingId: string): string {
+  const { data: myReview } = trpc.appListings.getMyReview.useQuery({ appListingId });
+  return myReview ? 'Edit your review' : 'Rate this app';
+}
+
+/**
+ * The ⋮ overflow-menu item. Renders `null` for a viewer the server would refuse.
+ *
+ * 🔴 THE GATE IS SPLIT ACROSS TWO COMPONENTS BECAUSE THE RULES OF HOOKS MAKE A
+ * ONE-COMPONENT VERSION FIRE THE QUERY ANYWAY. An `if (!eligible) return null` above
+ * a `useQuery` is not legal, and an `enabled:` flag is a rule someone has to keep
+ * correct. Mounting the query-bearing half only once the cheap synchronous gates
+ * (store access, a threaded slug) have passed makes the laziness structural — the
+ * same split F2 used for `AppNameCrumb` → `AppNameCrumbCard`, and for the same
+ * measured reason: a hook instantiated on every chrome render reaches contexts the
+ * chrome does not own.
+ *
+ * 🔴 THE STORE-ACCESS TERM IS `hasAppsStoreAccess`, READ THROUGH
+ * `useOptionalFeatureFlags`. `useFeatureFlags` THROWS outside its provider, and this
+ * chrome is deliberately renderable in isolation; the optional hook returns `null`
+ * there and `hasAppsStoreAccess(null)` is `false`, so missing flags REMOVE the
+ * affordance rather than granting it. It is the same predicate the store itself
+ * gates on, which matters because `getAppDetail` resolves a `none` scope for this
+ * cohort and throws NOT_FOUND — an item here would open a modal that can never load.
+ */
+export function ChromeReviewMenuItem({
+  slug,
+  onOpenReview,
+}: {
+  /** The app's STORE slug (`AppListing.slug`). Omitted → no entry point. */
+  slug: string | undefined;
+  onOpenReview: (appListingId: string) => void;
+}) {
+  const features = useOptionalFeatureFlags();
+  if (!slug || !hasAppsStoreAccess(features)) return null;
+  return <ChromeReviewMenuItemBody slug={slug} onOpenReview={onOpenReview} />;
+}
+
+function ChromeReviewMenuItemBody({
+  slug,
+  onOpenReview,
+}: {
+  slug: string;
+  onOpenReview: (appListingId: string) => void;
+}) {
+  const { detail } = useChromeListingDetail(slug);
+  // `creator` is the listing owner chip; a self-review is 403'd server-side, so the
+  // affordance is withheld from the owner rather than offered and refused. `kind` is
+  // the store-scope term — an external-only viewer must not be offered a control on
+  // an onsite listing the server will NOT_FOUND (and vice versa).
+  const canReview = useCanReviewListing({
+    ownerUserId: detail?.creator?.id ?? null,
+    listingKind: detail?.kind,
+  });
+  // No listing row yet (in flight, 404, scope-gated) → nothing to review. The item
+  // appears when the data arrives; it is never rendered against a listing id we do
+  // not have, which is what would produce a modal whose submit 403s.
+  if (!detail || !canReview) return null;
+  return <ChromeReviewMenuItemLabelled appListingId={detail.id} onOpenReview={onOpenReview} />;
+}
+
+function ChromeReviewMenuItemLabelled({
+  appListingId,
+  onOpenReview,
+}: {
+  appListingId: string;
+  onOpenReview: (appListingId: string) => void;
+}) {
+  const label = useChromeReviewLabel(appListingId);
+  return (
+    <Menu.Item
+      leftSection={<IconThumbUp size={14} stroke={1.5} />}
+      onClick={() => onOpenReview(appListingId)}
+      data-testid="app-block-review-menu-item"
+    >
+      {label}
+    </Menu.Item>
+  );
+}
+
+/**
+ * The app-name popover's review action, rendered beside "View in App Store".
+ *
+ * Takes the ALREADY-RESOLVED `detail` rather than re-reading it: the popover card
+ * only renders this on its success branch, so it has the row in hand. One less
+ * observer on the query, and — more to the point — it cannot key the read
+ * differently from its own parent.
+ */
+export function ChromeReviewPopoverAction({
+  detail,
+  onOpenReview,
+}: {
+  detail: ListingDetail;
+  /** Called with the listing id. The caller closes the popover; see the module header. */
+  onOpenReview: (appListingId: string) => void;
+}) {
+  const canReview = useCanReviewListing({
+    ownerUserId: detail.creator?.id ?? null,
+    listingKind: detail.kind,
+  });
+  if (!canReview) return null;
+  return <ChromeReviewPopoverButton appListingId={detail.id} onOpenReview={onOpenReview} />;
+}
+
+function ChromeReviewPopoverButton({
+  appListingId,
+  onOpenReview,
+}: {
+  appListingId: string;
+  onOpenReview: (appListingId: string) => void;
+}) {
+  const label = useChromeReviewLabel(appListingId);
+  return (
+    <Button
+      size="xs"
+      variant="subtle"
+      leftSection={<IconThumbUp size={14} stroke={1.5} />}
+      onClick={() => onOpenReview(appListingId)}
+      data-testid="app-block-name-popover-review"
+    >
+      {label}
+    </Button>
+  );
+}

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -20,6 +20,8 @@ import { selectChromeRecentApps } from '~/components/Apps/recentAppsRail';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { AppNameCrumb } from './AppNameCrumb';
+import { ChromeReviewMenuItem } from './ChromeReviewEntry';
+import { ReviewListingModal } from '~/components/Apps/ReviewListingButton';
 import { AppPermissionsActivityDrawer } from './AppPermissionsActivityDrawer';
 import { BlockFallback } from './BlockFallback';
 import { failureSnapshot } from './failureSnapshot';
@@ -238,6 +240,19 @@ export function AppBlockChrome({
   // Per-app "Permissions & activity" drawer open state (only reachable when
   // appBlockId was threaded through).
   const [permsOpen, setPermsOpen] = useState(false);
+  // F4 — the review modal's target listing, `null` while closed.
+  //
+  // 🔴 THE CHROME OWNS THIS STATE BECAUSE NEITHER ENTRY POINT CAN. Both triggers
+  // live inside a floating surface Mantine UNMOUNTS on close (a `Menu.Dropdown` and
+  // a `Popover.Dropdown`), so a modal rendered beside either one would be destroyed
+  // by the click that opens it — it could never appear. Hoisting the state here is
+  // the same shape `AppListingDetailBody` uses for the same reason, and it is why
+  // `ReviewListingModal` takes `opened` from its caller instead of owning it.
+  //
+  // Storing the LISTING ID rather than a boolean is what lets the modal be mounted
+  // only when there is something to review: an id is what the entry point resolved
+  // and handed up, so there is no window in which the modal exists without one.
+  const [reviewListingId, setReviewListingId] = useState<string | null>(null);
 
   // Recently-run apps (client-only personalisation from localStorage). Seeded
   // empty so SSR + the first client render match (no hydration mismatch); the
@@ -579,7 +594,12 @@ export function AppBlockChrome({
                 in App Store" action. The whole cluster is gated on
                 `hasAppsStoreAccess` INSIDE that component — a viewer without store
                 access gets the static text this used to be. */}
-            <AppNameCrumb name={label} slug={slug} maxWidth={geometry.nameMaxWidth} />
+            <AppNameCrumb
+              name={label}
+              slug={slug}
+              maxWidth={geometry.nameMaxWidth}
+              onOpenReview={setReviewListingId}
+            />
           </Group>
         )}
       </Group>
@@ -640,6 +660,24 @@ export function AppBlockChrome({
           >
             Manage apps
           </Menu.Item>
+          {/* F4 — the permanent review entry point. An ACTION, not a route link:
+              it carries no `href`, so the ONE ROUTE, ONE ICON guard in
+              `__tests__/chromeNavAlignsWithSubNav.test.ts` (which extracts only
+              literal-href items) correctly does not treat it as a destination the
+              store subnav must also list.
+
+              Placed directly under "Manage apps" so the two whole-app actions that
+              are ALWAYS about the running app ("rate it", "see what it can do") sit
+              together above the dismissal, and "Hide app" stays last.
+
+              🔴 THE ITEM RENDERS ITS OWN GATES AND MAY RETURN NULL. It is offered
+              only to a viewer the server would accept: signed in, not the owner,
+              holding a store scope that admits this listing's kind, and with store
+              access at all (`hasAppsStoreAccess`). Offering a control whose submit
+              403s is the anti-goal `useCanReviewListing` exists to prevent, so the
+              gate is IMPORTED from the review module rather than re-derived here.
+              The query behind it is mounted only while this dropdown is open. */}
+          <ChromeReviewMenuItem slug={slug} onOpenReview={setReviewListingId} />
           {appBlockId && (
             <Menu.Item
               leftSection={<IconShieldLock size={14} stroke={1.5} />}
@@ -675,6 +713,19 @@ export function AppBlockChrome({
         appName={sanitizedName ?? undefined}
         opened={permsOpen}
         onClose={() => setPermsOpen(false)}
+      />
+    )}
+    {/* F4 — the review form, mounted OUTSIDE both floating surfaces (see
+        `reviewListingId` above for why that is forced rather than tidy). Mounted only
+        once an entry point has handed up a listing id, so a chrome nobody has asked
+        to review issues no `getMyReview` and renders no modal DOM. The modal applies
+        no eligibility gate of its own by design — the entry points did, and
+        duplicating the rule would put it in two places. */}
+    {reviewListingId && (
+      <ReviewListingModal
+        appListingId={reviewListingId}
+        opened
+        onClose={() => setReviewListingId(null)}
       />
     )}
     </>

--- a/src/components/AppBlocks/__tests__/chromeListingQueryIsSingleSourced.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeListingQueryIsSingleSourced.test.ts
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The app-block host chrome reads `appListings.getAppDetail` from exactly ONE place.
+ * Node `unit` project — the GATING tier (the Vitest browser-mode `component` project
+ * is report-only in CI, so `ChromeReviewEntry.browser.test.tsx`, which proves the
+ * same property behaviourally against real React Query, cannot block a merge).
+ *
+ * WHY IT EXISTS. F2 gave the chrome one consumer of that listing row (the app-name
+ * crumb's store popover). F4 added a second (the ⋮ menu's review item, which needs
+ * the listing `id` plus the `creator`/`kind` its eligibility gate reads). React Query
+ * dedupes by KEY, so two consumers are one network request only while their inputs
+ * AND options serialise identically — and that is a property of two separate pieces
+ * of code, which nothing checks. `useQuery({ slug }, { retry: false })` and
+ * `useQuery({ slug, kind: undefined }, {})` both compile, both render, both look
+ * right, and the second doubles the chrome's traffic on a surface that renders on
+ * every model page carrying a block.
+ *
+ * 🔴 SO THE RULE IS STRUCTURAL, NOT A COMPARISON OF TWO ARGUMENT LISTS. There is one
+ * call site; a second one anywhere in the chrome fails this. That is strictly
+ * stronger than checking that two call sites agree, because it also fails the
+ * ALMOST-identical second call site that a diff-based check would have to be exactly
+ * right about.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const HOOK = 'src/components/AppBlocks/useChromeListingDetail.ts';
+const TRPC = 'src/utils/trpc.ts';
+
+/**
+ * Every source that renders into the app-block host chrome. A file added here is a
+ * file whose listing reads this rule now governs.
+ */
+const CHROME_SOURCES = [
+  HOOK,
+  'src/components/AppBlocks/IframeHost.tsx',
+  'src/components/AppBlocks/AppNameCrumb.tsx',
+  'src/components/AppBlocks/ChromeReviewEntry.tsx',
+];
+
+function read(rel: string): string {
+  const file = path.join(REPO_ROOT, rel);
+  // Prove the path before trusting any "no match" below: a scan of an absent file
+  // reports zero of everything, which reads as a clean pass.
+  expect(fs.existsSync(file), `${rel} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/** Strip block + line comments — every token searched for below is also discussed at
+ *  length in the prose around it, and a rule must never be satisfiable by prose ABOUT
+ *  the rule. (This module's own header names `getAppDetail.useQuery` twice.) */
+function code(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+}
+
+function countCallSites(src: string): number {
+  return (src.match(/getAppDetail\.useQuery\s*\(/g) ?? []).length;
+}
+
+describe('the chrome reads the listing from one place', () => {
+  it('the matcher can actually see a call site, and ignores prose about one — positive control', () => {
+    // A guard built on a regex that matches nothing reports a confident, empty,
+    // fully-green set. Feed it a shape it MUST find, and the two shapes that would
+    // make it lie: a call spread across lines, and the same token inside a comment.
+    expect(countCallSites('const x = trpc.appListings.getAppDetail.useQuery({ slug });')).toBe(1);
+    expect(
+      countCallSites('trpc.appListings.getAppDetail.useQuery(\n  { slug },\n  { retry: false }\n)')
+    ).toBe(1);
+    expect(countCallSites(code('// see getAppDetail.useQuery( for why\nconst y = 1;'))).toBe(0);
+    expect(countCallSites(code('/* getAppDetail.useQuery({slug}) */ const y = 1;'))).toBe(0);
+    expect(countCallSites('trpc.appListings.listReviews.useQuery({ id });')).toBe(0);
+  });
+
+  it('there is exactly ONE getAppDetail call site across every chrome source, and it is the shared hook', () => {
+    const perFile = CHROME_SOURCES.map((rel) => [rel, countCallSites(code(read(rel)))] as const);
+    const total = perFile.reduce((n, [, c]) => n + c, 0);
+
+    expect(
+      total,
+      'the chrome must read `appListings.getAppDetail` from exactly one place. Found: ' +
+        JSON.stringify(Object.fromEntries(perFile)) +
+        '. A second call site is one network request per chrome render more than the first, ' +
+        'and it only stays deduped while its input and options serialise identically to the ' +
+        'other one — route it through `useChromeListingDetail` instead.'
+    ).toBe(1);
+
+    expect(
+      Object.fromEntries(perFile)[HOOK],
+      `the single call site must live in ${HOOK}, not in a component`
+    ).toBe(1);
+  });
+
+  it('both consumers reach the query through the shared hook', () => {
+    // The count above would also be satisfied by a consumer that stopped reading the
+    // listing altogether — which is a behaviour change, not a consolidation. Pin that
+    // both surfaces still go through the hook.
+    for (const rel of [
+      'src/components/AppBlocks/AppNameCrumb.tsx',
+      'src/components/AppBlocks/ChromeReviewEntry.tsx',
+    ]) {
+      const src = code(read(rel));
+      expect(src, `${rel} no longer calls useChromeListingDetail`).toMatch(
+        /useChromeListingDetail\s*\(/
+      );
+    }
+  });
+
+  it('the hook passes `retry: false`, matching the store-preview page it mirrors', () => {
+    // A listing that is missing, unapproved or scope-gated 404s server-side. Retrying
+    // it three times is three requests for an answer that cannot change, on a surface
+    // that renders on every model page carrying a block.
+    expect(code(read(HOOK))).toMatch(/retry:\s*false/);
+  });
+
+  it("the app's own query defaults are what the browser suite mirrors — staleTime: Infinity", () => {
+    // 🔴 THIS PINS A CROSS-FILE PREMISE, NOT A CONSTANT FOR ITS OWN SAKE.
+    // `ChromeReviewEntry.browser.test.tsx` builds its QueryClient with
+    // `staleTime: Infinity` because that is what `src/utils/trpc.ts` ships; the shared
+    // component harness uses React Query's default 0 instead. If the app ever drops to
+    // a finite staleTime, remounting the second chrome surface would refetch in
+    // PRODUCTION while the browser suite kept reporting one request — the dedupe test
+    // would go quietly vacuous with nothing to indicate it. Change both together.
+    const trpcSrc = code(read(TRPC));
+    expect(
+      trpcSrc,
+      'src/utils/trpc.ts no longer defaults queries to `staleTime: Infinity` — re-read the ' +
+        'dedupe assertion in ChromeReviewEntry.browser.test.tsx before believing it.'
+    ).toMatch(/staleTime:\s*Infinity/);
+  });
+});

--- a/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
@@ -33,6 +33,7 @@ const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/IframeHost.tsx');
 const HOOK = path.join(REPO_ROOT, 'src/components/AppBlocks/useIframeAwareMenu.ts');
 const CRUMB = path.join(REPO_ROOT, 'src/components/AppBlocks/AppNameCrumb.tsx');
+const REVIEW_ENTRY = path.join(REPO_ROOT, 'src/components/AppBlocks/ChromeReviewEntry.tsx');
 
 function read(file: string): string {
   // Prove the path before trusting any "no match" below: a scan of an absent
@@ -167,6 +168,19 @@ describe('every Menu in the app-block chrome is iframe-aware', () => {
         'the breadcrumb app-name crumb’s store popover (full name + recommend rollup + "View ' +
         'in App Store"). It renders directly over the app iframe like every other floating ' +
         'surface in this chrome, so it is on the same hook.',
+    },
+    {
+      what: 'ChromeReviewEntry.tsx',
+      source: () => code(read(REVIEW_ENTRY)),
+      surfaces: 0,
+      detail:
+        'F4’s two review entry points. ZERO is the correct count and this row is not filler: ' +
+        'both are plain controls rendered INTO surfaces their hosts already own (a `Menu.Item` ' +
+        'inside the chrome’s ⋮ dropdown, a `Button` inside the crumb’s popover), and the modal ' +
+        'they open is mounted by `AppBlockChrome` OUTSIDE both. A `<Menu>` or `<Popover>` ' +
+        'appearing here means this file grew a floating surface of its own — put it on ' +
+        '`useIframeAwareMenu` and raise this number in the same commit, or it will hang over ' +
+        'the app the first time a user clicks into it.',
     },
   ];
 

--- a/src/components/AppBlocks/useChromeListingDetail.ts
+++ b/src/components/AppBlocks/useChromeListingDetail.ts
@@ -1,0 +1,45 @@
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * THE app-block host chrome's one and only read of `appListings.getAppDetail`.
+ *
+ * 🔴 IT EXISTS TO MAKE "ONE LISTING, ONE REQUEST" STRUCTURAL RATHER THAN HOPEFUL.
+ * Two separate surfaces in one bar now need the same listing row: F2's app-name
+ * crumb popover (full name + recommend rollup + "View in App Store") and F4's
+ * review entry points (the listing `id` to review, plus the `creator`/`kind` the
+ * eligibility gate reads). React Query dedupes by KEY, so two call sites are one
+ * network request only while their inputs serialise identically — and "identically"
+ * is a property of two pieces of code that nothing checks. A second call site
+ * written as `useQuery({ slug }, { retry: false, enabled: true })`, or one that
+ * passes `{ slug, kind: undefined }`, or one that simply forgets `retry: false`,
+ * still compiles, still renders, still looks right, and doubles the chrome's
+ * traffic on a surface that renders on every model page carrying a block.
+ *
+ * So there is exactly ONE call site, here, and both surfaces reach the query
+ * through it. The key cannot drift because there is nothing to drift from.
+ * `__tests__/chromeListingQueryIsSingleSourced.test.ts` pins that: it fails if a
+ * second `getAppDetail.useQuery(` appears anywhere in the chrome's sources.
+ *
+ * 🔴 CALL IT LAZILY — it carries NO `enabled` flag on purpose. Both callers mount
+ * it inside a floating surface Mantine does not render until the user opens it
+ * (`Popover.Dropdown` / `Menu.Dropdown`, neither `keepMounted`), so a closed chrome
+ * issues no request at all. That is the same structural-laziness decision F2 made
+ * when it moved the query out of `AppNameCrumb` and into `AppNameCrumbCard`; an
+ * `enabled` flag would move the rule back into something a caller can get wrong.
+ *
+ * `retry: false` matches `/apps/store-preview/<slug>`'s own call: a listing that is
+ * missing, unapproved or scope-gated 404s server-side and should settle into an
+ * unavailable state rather than being retried.
+ */
+export function useChromeListingDetail(slug: string): {
+  detail: ListingDetail | undefined;
+  isLoading: boolean;
+  error: unknown;
+} {
+  const { data, isLoading, error } = trpc.appListings.getAppDetail.useQuery(
+    { slug },
+    { retry: false }
+  );
+  return { detail: data as ListingDetail | undefined, isLoading, error };
+}

--- a/src/components/Apps/ReviewListingButton.tsx
+++ b/src/components/Apps/ReviewListingButton.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 
 import { useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useIsMobile } from '~/hooks/useIsMobile';
 import { LISTING_REVIEW_DETAILS_MAX } from '~/server/schema/blocks/app-listing-review.schema';
 import { resolveClientStoreScope } from '~/shared/utils/app-blocks-access';
 import {
@@ -100,6 +101,21 @@ export function useCanReviewListing({
  * 🔴 Applies NO eligibility gate of its own: a caller that mounts this has already
  * decided the viewer may review (via {@link useCanReviewListing}), and duplicating
  * the rule here would put it in two places. The server gate is the real one.
+ *
+ * 🔴 `fullScreen` ON MOBILE IS DRIVEN BY A VIEWPORT MEDIA QUERY, NOT BY
+ * `useIsMobile`'s DEFAULT CONTAINER QUERY, AND THE CHOICE IS DELIBERATE. F4 made this
+ * modal reachable from the App Blocks host chrome, which is the one surface where the
+ * default is actively wrong for two independent reasons. (1) The container default
+ * resolves against the nearest `ContainerProvider` — `main`, the page's content
+ * column — and the chrome is deliberately renderable in isolation, where there is no
+ * such provider at all. (2) Even where one exists, `main` describes neither this
+ * modal nor the screen: a Mantine `Modal` is portalled to `document.body` and
+ * `fullScreen` means the VIEWPORT (100vw/100vh), so the viewport is the box the
+ * question is actually about. That is the mirror image of the call F1 made for the
+ * chrome's own geometry (`chromeGeometry.ts`): there the viewport was wrong because
+ * the bar can sit in a 320px sidebar inside a wide page; here the container is wrong
+ * because the modal is not inside the container at all. Same lesson — measure the box
+ * that the thing is laid out against.
  */
 export function ReviewListingModal({
   appListingId,
@@ -112,6 +128,8 @@ export function ReviewListingModal({
 }) {
   const currentUser = useCurrentUser();
   const queryUtils = trpc.useUtils();
+  // See the header: viewport, not the container default.
+  const isMobile = useIsMobile({ type: 'media' });
   const [recommended, setRecommended] = useState<boolean | null>(null);
   const [details, setDetails] = useState('');
   const close = onClose;
@@ -176,6 +194,8 @@ export function ReviewListingModal({
         title={isEditing ? 'Edit your review' : 'Review this app'}
         size="md"
         centered
+        fullScreen={isMobile}
+        data-testid="app-listing-review-modal"
       >
         <Stack gap="md">
           <Text size="sm" c="dimmed">


### PR DESCRIPTION
## What

F4 of the App Blocks frame redesign: **review entry points in the host chrome.** The one moment a user reliably has an opinion about an app is while it is running in front of them, and until now that surface offered no way to say so — you had to already be standing on the app's store listing.

Two affordances, both opening the **existing** `ReviewListingModal`:

1. **A permanent item in the ⋮ overflow menu**, under "Manage apps".
2. **An action in the app-name popover** (F2), under the recommend rollup that prompts the thought.

Labelled from `getMyReview`: **"Rate this app"** with no existing review, **"Edit your review"** with one. Both entry points read the same label hook, so they cannot disagree about the viewer's own state.

This builds **no** review system. The gate (`useCanReviewListing`), the form and the mutation already existed and are imported, not re-derived. Thumbs + text, no stars, no install/run requirement.

## Gating

Offered only to a viewer the **server** would accept — offering a control whose submit 403s is the anti-goal `useCanReviewListing` exists to prevent:

- signed in · not the listing owner · store scope admits the listing's `kind` — all via the imported `useCanReviewListing`;
- plus `hasAppsStoreAccess` (flag-only, read through `useOptionalFeatureFlags` so absent flags **remove** the affordance rather than granting it), matching the gate F2 applied to the crumb. For that cohort `getAppDetail` resolves a `none` scope and throws NOT_FOUND, so the item would open a modal that can never load.

The store-access and slug terms are checked **before** the query-bearing half mounts, so an ineligible viewer never instantiates the hook at all — the same split F2 used for `AppNameCrumb` → `AppNameCrumbCard`.

## Three constraints this shape is forced by

**The chrome owns the modal.** Mantine unmounts a `Menu.Dropdown` and a `Popover.Dropdown` when they close, so a modal rendered beside either trigger would be destroyed by the click that opens it. Both entry points hand a listing id *up* to `AppBlockChrome`, which mounts the modal outside every floating surface — the same reason `ReviewListingModal` takes `opened` from its caller.

**Each opener closes itself.** A dropdown left hanging behind a focus-trapping modal keeps `aria-expanded="true"` on its trigger — the visible half of the defect F0 fixed. The ⋮ item gets that from Mantine's `closeOnItemClick`; a `Popover` has no equivalent, so the crumb closes itself explicitly. Both are pinned behaviourally (mutants M5/M6).

**One listing, one request.** F2 gave the chrome one consumer of `appListings.getAppDetail`; this adds a second. React Query dedupes by **key**, so two call sites are one request only while their inputs and options serialise identically — a property of two pieces of code that nothing was checking. There is now exactly **one** call site (`useChromeListingDetail`), reached by both surfaces, and `chromeListingQueryIsSingleSourced.test.ts` fails if a second appears anywhere in the chrome.

## Mobile

`fullScreen={isMobile}` on the modal, per the per-site idiom — but on a **viewport** media query (`useIsMobile({ type: 'media' })`), not `useIsMobile`'s default container query. Two independent reasons: the container default resolves against `main`, and this chrome is deliberately renderable with no `ContainerProvider` at all; and a Mantine `Modal` is portalled to `document.body`, where `fullScreen` means 100vw/100vh — the viewport *is* the box the question is about. That is the mirror of F1's call in `chromeGeometry.ts`: there the viewport was wrong because the bar can sit in a 320px sidebar inside a wide page; here the container is wrong because the modal is not inside the container.

## The ONE ROUTE, ONE ICON guard

Untouched and still green (5 literal-href items, unchanged). The new item is an **action**, not a route link: it carries no `href`, so `parseAllChromeLinks` correctly does not treat it as a destination the store subnav must also list. No weakening was needed.

## Test coverage

**15 browser tests** (`ChromeReviewEntry.browser.test.tsx`) + **5 node-tier guards** + a third row in the `iframeAwareMenu` ledger.

Every browser test mounts `AppBlockChrome`, never the entry-point components alone: three of the claims are about the **seam** (slug threading, chrome-owned modal state, opener-closes-on-open), which a component-scoped suite structurally cannot see.

The tRPC mock wraps **real** React Query with a counting `queryFn`, so the "one request" number counts *fetches*, not hook calls — a `useQuery: () => ({data})` stub cannot see that defect in either direction. Its client mirrors the app's `staleTime: Infinity` rather than the shared harness's `0`, and a node guard pins that premise so the dedupe test cannot go quietly vacuous if `trpc.ts` changes.

### Red at base

Whole suite run against `origin/main` (clean worktree, own `node_modules`): **10 of 15 red.** The 5 that passed were absence assertions, vacuous at base because the feature does not exist — so they are carried by mutation instead. Node guard: **3 of 5 red** (`useChromeListingDetail.ts does not exist`; `AppNameCrumb.tsx no longer calls useChromeListingDetail`).

### Mutation matrix — 10/10 killed, each in exactly one named test

| # | mutation | test killed |
|---|---|---|
| M0 | *no-op control* | **survived, 15 green** — kills below are attributable |
| M1 | `hasAppsStoreAccess` term dropped | no-store-access → `expected 1 to be +0` (fetch count) |
| M2 | menu `ownerUserId` term dropped | owner → `length +0 but got 1` |
| M3 | `listingKind` term dropped | kind-refusal → `length +0 but got 1` |
| M4 | label hardcoded | label switch → `toHaveTextContent()` |
| M5 | popover not closed on open | popover closes → `not.toBeInTheDocument()` |
| M6 | `closeMenuOnClick={false}` | ⋮ closes → `not.toBeInTheDocument()` |
| M7 | second call site keyed differently | one-request → `expected 2 to be 1` |
| M8 | signed-out term inverted | signed-out → `length +0 but got 1` |
| M9 | `fullScreen={false}` | phone → `expected null to be 'true'` |
| M10 | `fullScreen` always | desktop control → `expected 'true' to be null` |
| M11 | popover `ownerUserId` dropped | popover withheld → `not.toBeInTheDocument()` |

**M2, M3 and M8 SURVIVED the first sweep** — `expect.element(x).not.toBeInTheDocument()` *polls until it passes*, and at t0 the item is legitimately absent for everyone because its data has not arrived. So three mutants that deleted a gate term outright passed a fully green run. Fixed with a `ListingProbe`: a second observer of the same key, whose marker gives a real happens-before (React Query notifies all observers of one key in a single `notifyManager` batch) rather than a `setTimeout`.

### Counts

- `pnpm typecheck` — **0 errors**; instrument validated (a planted `const _control: number = 'x'` produced `TS2322`, exit 2).
- node `unit` tier, whole project — **1533 files / 24,134 tests, 0 failed**.
- browser `component`, `src/components/AppBlocks` + `src/components/Apps` — **114 files / 1588 tests, 0 failed**, against a base of **113 / 1573**. Delta = exactly this PR's one file and 15 tests; nothing stopped collecting.
- `eslint --max-warnings=0` on all 8 touched files — clean; instrument validated (a planted `any` reported 1 problem, rc 1).
- `prettier` — clean on every added file. `IframeHost.tsx` is pre-existing prettier-dirty on `main` and modified files are warn-only in CI, so its whole-file reformat was reverted to keep this diff readable.
- `scripts/ci/typecheck-tests-gate.mjs` — already red on `main`. Base **80** offending files, HEAD **79**; the set difference in the HEAD direction is **empty**, so this PR adds none.
- Verified on the **merged** tree (`origin/main` merged in, not rebased): typecheck 0 errors, all suites re-run green.

### Not verified

- `preview / component-tests` is red on `main` itself and collects nothing; a green there would not be evidence either way.
- No production/preview click-through — this is browser-mode-in-Chromium coverage plus a merged-tree run, not a real deployed surface.
- The 5 absence tests that pass at base are labelled invariant-at-base in-file; their coverage claim rests entirely on M1/M2/M3/M8/M11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
