### PR TITLE
feat(bitdex-audit): compare baseModel against the checkpoint-only truth

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -319,6 +319,22 @@ export const bitdexAuditMismatchCounter = registerCounterWithLabels({
   help: 'PG<->BitDex disagreements found by the consistency audit, by sample stratum and failure kind',
   labelNames: ['stratum', 'kind'] as const,
 });
+// The denominators a mismatch count of zero has to be read against, on the SAME surface
+// an alert reads. `checked_total` counts rows SAMPLED; a row whose document is absent or
+// unpublished is skipped before any comparison, so a stratum that compared nothing emits
+// a mismatch zero indistinguishable from perfect agreement unless these are here too.
+// `opportunity` is the arm-specific count: compared documents on which that arm COULD
+// have fired at all.
+export const bitdexAuditComparedCounter = registerCounterWithLabels({
+  name: 'bitdex_audit_compared_total',
+  help: 'Sampled images the consistency audit actually compared (document present and published), by sample stratum',
+  labelNames: ['stratum'] as const,
+});
+export const bitdexAuditOpportunityCounter = registerCounterWithLabels({
+  name: 'bitdex_audit_opportunity_total',
+  help: 'Compared images on which a given audit failure kind could have fired, by sample stratum and failure kind — the denominator for that kind of zero',
+  labelNames: ['stratum', 'kind'] as const,
+});
 export const bitdexAuditRunsCounter = registerCounter({
   name: 'bitdex_audit_runs_total',
   help: 'BitDex consistency audit runs that completed SUCCESSFULLY (success-only; the liveness signal behind a mismatch alert being trustworthy)',

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -349,7 +349,7 @@ export const bitdexAuditStratumFailedCounter = registerCounterWithLabels({
 });
 export const bitdexAuditRunsCounter = registerCounter({
   name: 'bitdex_audit_runs_total',
-  help: 'BitDex consistency audit runs that completed SUCCESSFULLY (success-only; the liveness signal behind a mismatch alert being trustworthy)',
+  help: 'BitDex consistency audit runs that completed — the liveness signal. ⚠️ A run counts here even when ONE stratum failed and was caught, because it did complete for the others: pair it with stratum_failed_total before trusting a per-stratum zero',
 });
 export const bitdexAuditErrorsCounter = registerCounter({
   name: 'bitdex_audit_errors_total',

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -306,12 +306,16 @@ export const reemitScheduledImagesEmittedCounter = registerCounter({
 });
 
 // Metrics for the standing PG<->BitDex consistency audit (audit-bitdex-consistency).
-// checked_total is the liveness signal and the denominator; mismatch_total is the
-// alerting series. `stratum` is the sampled population, `kind` the failure mode —
-// both fixed low-cardinality enums (see MISMATCH_KINDS in the job).
+// mismatch_total is the alerting series. `stratum` is the sampled population, `kind` the
+// failure mode — both fixed low-cardinality enums (the `MismatchKind` union in the job).
+//
+// 🔴 `checked_total` is the LIVENESS signal, not a denominator: it counts rows SAMPLED.
+// Rows whose document is absent or unpublished are skipped before any comparison, so a
+// stratum that compared nothing still reports them. Use `compared_total` as the
+// denominator, and `opportunity_total{kind}` for a particular kind's zero.
 export const bitdexAuditCheckedCounter = registerCounterWithLabels({
   name: 'bitdex_audit_checked_total',
-  help: 'Images compared between PG and BitDex by the consistency audit, by sample stratum',
+  help: 'Images SAMPLED by the consistency audit, by sample stratum — the liveness signal, NOT a denominator (see compared_total)',
   labelNames: ['stratum'] as const,
 });
 export const bitdexAuditMismatchCounter = registerCounterWithLabels({
@@ -335,17 +339,25 @@ export const bitdexAuditOpportunityCounter = registerCounterWithLabels({
   help: 'Compared images on which a given audit failure kind could have fired, by sample stratum and failure kind — the denominator for that kind of zero',
   labelNames: ['stratum', 'kind'] as const,
 });
+// Which stratum died, when one is caught rather than taking the whole run down. Without
+// this, a stratum that has been failing for a week is invisible: runs_total still ticks
+// (the run completed for the others) and errors_total cannot say which one.
+export const bitdexAuditStratumFailedCounter = registerCounterWithLabels({
+  name: 'bitdex_audit_stratum_failed_total',
+  help: 'Consistency audit strata that failed and were caught, by sample stratum — the run continues for the others',
+  labelNames: ['stratum'] as const,
+});
 export const bitdexAuditRunsCounter = registerCounter({
   name: 'bitdex_audit_runs_total',
   help: 'BitDex consistency audit runs that completed SUCCESSFULLY (success-only; the liveness signal behind a mismatch alert being trustworthy)',
 });
 export const bitdexAuditErrorsCounter = registerCounter({
   name: 'bitdex_audit_errors_total',
-  help: 'BitDex consistency audit runs that threw (PG sample or BitDex fetch failed) before rethrowing',
+  help: 'BitDex consistency audit runs that hit an error — a whole-run throw, or a single stratum failing and being caught. Unlabelled: see stratum_failed_total for which one',
 });
 export const bitdexAuditRunDurationHistogram = registerHistogram({
   name: 'bitdex_audit_run_duration_seconds',
-  help: 'Wall-clock duration of a BitDex consistency audit run (both strata: PG sample + BitDex fetch + compare)',
+  help: 'Wall-clock duration of a BitDex consistency audit run (all three strata: PG sample + BitDex fetch + compare)',
   buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
 });
 

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -33,6 +33,8 @@ import {
   auditBitdexConsistency,
   buildPublishedSampleQuery,
   buildScheduledSampleQuery,
+  baseModelDenominators,
+  buildBaseModelSampleQuery,
   compareStratum,
   getAuditConfig,
   readDocState,
@@ -60,7 +62,7 @@ afterEach(clearEnv);
 
 // PG truth for one sampled image. NOW is arbitrary but fixed so drift math is exact.
 const NOW = 1_754_400_000;
-const row = (over: Partial<Record<string, number>> = {}) => ({
+const row = (over: Partial<Record<string, number | string[]>> = {}) => ({
   imageId: 1,
   postId: 10,
   publishedAtSecs: NOW,
@@ -147,7 +149,12 @@ describe('getAuditConfig', () => {
 
 describe('readDocState', () => {
   it('reports a missing doc as absent, not as unpublished-with-data', () => {
-    expect(readDocState(undefined)).toEqual({ present: false, published: false, sortAtSecs: null });
+    expect(readDocState(undefined)).toEqual({
+      present: false,
+      published: false,
+      sortAtSecs: null,
+      baseModel: null,
+    });
   });
 
   it('treats a bare { id } (no doc on disk) as absent', () => {
@@ -267,9 +274,142 @@ describe('compareStratum — published_recent', () => {
   });
 });
 
+describe('buildBaseModelSampleQuery', () => {
+  const sql = () =>
+    buildBaseModelSampleQuery({ sampleSize: 50, publishedWindowSecs: 86400, settleSecs: 120 }).sql;
+
+  // Truth for this stratum is the CHECKPOINT-only value, because that is the whole
+  // defect: 868ktxe1r was the filter matching an attached LoRA's base model. A query
+  // that dropped the type predicate would call the reported bug correct.
+  it('derives the expected value from Checkpoint resources only', () => {
+    expect(sql()).toContain(`m.type = 'Checkpoint'`);
+    expect(sql()).toContain('"ImageResourceNew"');
+    expect(sql()).toContain('"expectedBaseModels"');
+  });
+
+  it('samples published posts inside the window, past the settle belt', () => {
+    expect(sql()).toContain('"publishedAt" <= now()');
+    expect(sql()).toContain('make_interval');
+    expect(sql()).toContain('"updatedAt" <');
+  });
+
+  it('samples randomly, so repeated runs cover the population', () => {
+    expect(sql()).toContain('ORDER BY random()');
+  });
+});
+
+describe('compareStratum — basemodel (868ktxe1r / 868ku8x8k)', () => {
+  const compare = (docs: Record<string, unknown>[], rows: unknown[]) =>
+    compareStratum('basemodel', rows as never, docs as never, { sortAtToleranceSecs: 300 });
+
+  it('accepts a document whose baseModel is one of the image checkpoints', () => {
+    expect(
+      compare(
+        [{ id: 1, isPublished: true, baseModel: 'Pony' }],
+        [row({ expectedBaseModels: ['Pony'] })]
+      )
+    ).toEqual([]);
+  });
+
+  // 868ktxe1r exactly: an Illustrious checkpoint carrying a Pony LoRA, served under a
+  // Pony filter. Both sides go in the row so an alert can be opened from the log alone.
+  it('flags a baseModel that belongs to no checkpoint on the image', () => {
+    const found = compare(
+      [{ id: 1, isPublished: true, baseModel: 'Pony' }],
+      [row({ expectedBaseModels: ['Illustrious'] })]
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: 'basemodel_not_checkpoint', imageId: 1, postId: 10 });
+    expect(found[0].expected).toContain('Illustrious');
+    expect(found[0].actual).toContain('Pony');
+  });
+
+  it('flags a baseModel on an image that has no checkpoint at all', () => {
+    const found = compare(
+      [{ id: 1, isPublished: true, baseModel: 'Illustrious' }],
+      [row({ expectedBaseModels: [] })]
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('basemodel_not_checkpoint');
+    expect(found[0].expected).toContain('no checkpoint resource');
+  });
+
+  // 868ku8x8k: the value arriving late, so a recent image matches no filter at all.
+  it('flags a missing baseModel when PG has a checkpoint for the image', () => {
+    const found = compare([{ id: 1, isPublished: true }], [row({ expectedBaseModels: ['Anima'] })]);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: 'basemodel_missing' });
+    expect(found[0].expected).toContain('Anima');
+  });
+
+  // The negative control for the arm above: absent is the CORRECT answer here, so a
+  // guard that flagged every empty value would fire on every tool-generated image.
+  it('accepts a missing baseModel when the image has no checkpoint', () => {
+    expect(compare([{ id: 1, isPublished: true }], [row({ expectedBaseModels: [] })])).toEqual([]);
+  });
+
+  it('treats the empty-string encoding as no value, not as a wrong one', () => {
+    expect(
+      compare([{ id: 1, isPublished: true, baseModel: '' }], [row({ expectedBaseModels: [] })])
+    ).toEqual([]);
+    const found = compare(
+      [{ id: 1, isPublished: true, baseModel: '' }],
+      [row({ expectedBaseModels: ['Pony'] })]
+    );
+    expect(found.map((f) => f.kind)).toEqual(['basemodel_missing']);
+  });
+
+  it('leaves an absent or unpublished document to the published_recent stratum', () => {
+    expect(compare([], [row({ expectedBaseModels: ['Pony'] })])).toEqual([]);
+    expect(
+      compare([{ id: 1, isPublished: false }], [row({ expectedBaseModels: ['Pony'] })])
+    ).toEqual([]);
+  });
+
+  it('accepts any one of several checkpoints on the same image', () => {
+    expect(
+      compare(
+        [{ id: 1, isPublished: true, baseModel: 'SDXL 1.0' }],
+        [row({ expectedBaseModels: ['Pony', 'SDXL 1.0'] })]
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('baseModelDenominators', () => {
+  // What makes the mismatch count readable. A run that compared nothing produces the
+  // same zero as a run that agreed on everything.
+  it('counts only documents that were actually comparable', () => {
+    const rows = [
+      row({ imageId: 1, expectedBaseModels: ['Pony'] }),
+      row({ imageId: 2, expectedBaseModels: [] }),
+      row({ imageId: 3, expectedBaseModels: ['Anima'] }),
+      row({ imageId: 4, expectedBaseModels: ['Anima'] }),
+    ];
+    const docs = [
+      { id: 1, isPublished: true, baseModel: 'Pony' },
+      { id: 2, isPublished: true },
+      { id: 3, isPublished: false },
+      { id: 4 },
+    ];
+    expect(baseModelDenominators(rows as never, docs as never)).toEqual({
+      comparedDocs: 2,
+      withCheckpoint: 1,
+    });
+  });
+
+  it('is zero on both counts when BitDex holds none of the sample', () => {
+    expect(
+      baseModelDenominators([row({ expectedBaseModels: ['Pony'] })] as never, [] as never)
+    ).toEqual({ comparedDocs: 0, withCheckpoint: 0 });
+  });
+});
+
 describe('auditBitdexConsistency job body', () => {
   const scheduledRows = [row()];
   const publishedRows = [row({ imageId: 2, postId: 20 })];
+  const baseModelRows = [row({ imageId: 3, postId: 30, expectedBaseModels: ['Pony'] })];
+  const baseModelDocs = [{ id: 3, isPublished: true, baseModel: 'Pony' }];
 
   it('no-ops when the Flipt flag is OFF (default-off gate)', async () => {
     mockIsFlipt.mockResolvedValue(false);
@@ -283,20 +423,28 @@ describe('auditBitdexConsistency job body', () => {
 
   it('samples both strata, counts checks, and records a clean run', async () => {
     mockIsFlipt.mockResolvedValue(true);
-    mockDbWrite.$queryRaw.mockResolvedValueOnce(scheduledRows).mockResolvedValueOnce(publishedRows);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows)
+      .mockResolvedValueOnce(baseModelRows);
     mockFetchDocs
       .mockResolvedValueOnce([{ id: 1, isPublished: false }])
-      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }])
+      .mockResolvedValueOnce(baseModelDocs);
 
     const result = await runJob();
 
-    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(2);
-    expect(mockFetchDocs).toHaveBeenCalledTimes(2);
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(3);
+    expect(mockFetchDocs).toHaveBeenCalledTimes(3);
+    // The baseModel stratum asks for a different field set; requesting the default one
+    // would return documents with no baseModel key and read as a clean audit forever.
+    expect(mockFetchDocs.mock.calls[2][2]).toContain('baseModel');
     // Docs are requested by the sampled image ids, from the civitai index.
     expect(mockFetchDocs.mock.calls[0][0]).toBe('civitai');
     expect(mockFetchDocs.mock.calls[0][1]).toEqual([1]);
     expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
     expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'published_recent' }, 1);
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
     expect(mockCounters.mismatch.inc).not.toHaveBeenCalled();
     expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
     expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
@@ -305,15 +453,24 @@ describe('auditBitdexConsistency job body', () => {
       scheduledMismatches: 0,
       publishedChecked: 1,
       publishedMismatches: 0,
+      baseModelChecked: 1,
+      // The zero below means agreement only because these two are nonzero.
+      baseModelComparedDocs: 1,
+      baseModelWithCheckpoint: 1,
+      baseModelMismatches: 0,
     });
   });
 
   it('counts a mismatch under its stratum and kind', async () => {
     mockIsFlipt.mockResolvedValue(true);
-    mockDbWrite.$queryRaw.mockResolvedValueOnce(scheduledRows).mockResolvedValueOnce(publishedRows);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows)
+      .mockResolvedValueOnce(baseModelRows);
     mockFetchDocs
       .mockResolvedValueOnce([{ id: 1, isPublished: true }])
-      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }])
+      .mockResolvedValueOnce(baseModelDocs);
 
     const result = await runJob();
 
@@ -330,13 +487,39 @@ describe('auditBitdexConsistency job body', () => {
 
   it('skips the BitDex fetch when a stratum sampled nothing', async () => {
     mockIsFlipt.mockResolvedValue(true);
-    mockDbWrite.$queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce(publishedRows);
-    mockFetchDocs.mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(publishedRows)
+      .mockResolvedValueOnce(baseModelRows);
+    mockFetchDocs
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }])
+      .mockResolvedValueOnce(baseModelDocs);
 
     const result = await runJob();
 
-    expect(mockFetchDocs).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({ scheduledChecked: 0, publishedChecked: 1 });
+    expect(mockFetchDocs).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ scheduledChecked: 0, publishedChecked: 1, baseModelChecked: 1 });
+  });
+
+  // The failure this guard exists to not have: it must be impossible to read a clean
+  // baseModel audit off a run that compared nothing. Same mismatch count as the clean
+  // run above, and the denominators are what separate them.
+  it('reports zero denominators when BitDex holds none of the sampled images', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(baseModelRows);
+    mockFetchDocs.mockResolvedValueOnce([{ id: 3 }]);
+
+    const result = await runJob();
+
+    expect(result).toMatchObject({
+      baseModelChecked: 1,
+      baseModelComparedDocs: 0,
+      baseModelWithCheckpoint: 0,
+      baseModelMismatches: 0,
+    });
   });
 
   it('errors (does NOT report a clean audit) when the BitDex fetch fails', async () => {

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -7,6 +7,7 @@ const { mockIsFlipt, mockFetchDocs, mockCounters, mockHistogram } = vi.hoisted((
     checked: { inc: vi.fn() },
     compared: { inc: vi.fn() },
     opportunity: { inc: vi.fn() },
+    stratumFailed: { inc: vi.fn() },
     mismatch: { inc: vi.fn() },
     runs: { inc: vi.fn() },
     errors: { inc: vi.fn() },
@@ -23,6 +24,7 @@ vi.mock('~/server/prom/client', () => ({
   bitdexAuditCheckedCounter: mockCounters.checked,
   bitdexAuditComparedCounter: mockCounters.compared,
   bitdexAuditOpportunityCounter: mockCounters.opportunity,
+  bitdexAuditStratumFailedCounter: mockCounters.stratumFailed,
   bitdexAuditMismatchCounter: mockCounters.mismatch,
   bitdexAuditRunsCounter: mockCounters.runs,
   bitdexAuditErrorsCounter: mockCounters.errors,
@@ -524,9 +526,6 @@ describe('baseModelDenominators', () => {
       comparedDocs: 2,
       withCheckpoint: 1,
       withDocValue: 1,
-      // Image 1 has a checkpoint AND a value, so only the leak arm had an opportunity.
-      missingArmOpportunities: 0,
-      leakArmOpportunities: 1,
     });
   });
 
@@ -537,8 +536,6 @@ describe('baseModelDenominators', () => {
       comparedDocs: 0,
       withCheckpoint: 0,
       withDocValue: 0,
-      missingArmOpportunities: 0,
-      leakArmOpportunities: 0,
     });
   });
 
@@ -564,8 +561,6 @@ describe('baseModelDenominators', () => {
       comparedDocs: 2,
       withCheckpoint: 1,
       withDocValue: 1,
-      missingArmOpportunities: 1,
-      leakArmOpportunities: 1,
     });
   });
 });
@@ -692,9 +687,63 @@ describe('auditBitdexConsistency job body', () => {
       1
     );
     expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
-      { stratum: 'basemodel', kind: 'basemodel_missing' },
-      0
+      { stratum: 'basemodel', kind: 'basemodel_unfilterable' },
+      1
     );
+    // 🔴 The missing arm's denominator is compared-docs-WITH-a-checkpoint, not the count
+    // of documents missing a value — that second thing is the arm's own NUMERATOR, and a
+    // previous round shipped it as the denominator, giving a ratio of permanently 1 or
+    // 0/0. This fixture has one compared document that has both a checkpoint and a value,
+    // so the denominator is 1 while the arm cannot fire.
+    expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
+      { stratum: 'basemodel', kind: 'basemodel_missing' },
+      1
+    );
+  });
+
+  // The catch is for ONE failure, not for any failure. `fetchBitdexDocuments` throws on
+  // every error precisely so an unreachable index cannot be mistaken for a clean audit;
+  // swallowing that here would report a BitDex outage as a caught stratum failure on a
+  // run recorded as successful — the silent pass its contract forbids.
+  it('does not swallow a BitDex fetch failure in the baseModel stratum', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows)
+      .mockResolvedValueOnce(baseModelRows);
+    mockFetchDocs
+      .mockResolvedValueOnce([{ id: 1, isPublished: false }])
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }])
+      .mockRejectedValueOnce(new Error('BitDex documents fetch failed 503'));
+
+    await expect(runJob()).rejects.toThrow(/503/);
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+  });
+
+  // Split because `basemodel_unfilterable` is expected to be nonzero on a healthy system:
+  // folding it into the summary count puts the same permanent floor under the number a
+  // human reads that keeping it out of the alerting series was meant to avoid.
+  it('keeps unfilterable out of the mismatch summary and reports it separately', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        row({ imageId: 3, postId: 30, expectedBaseModels: ['Pony', 'SDXL 1.0'] }),
+      ]);
+    mockFetchDocs.mockResolvedValueOnce([{ id: 3, isPublished: true, baseModel: 'PonySDXL 1.0' }]);
+
+    const result = (await runJob()) as Record<string, unknown>;
+
+    expect(result.baseModelUnfilterable).toBe(1);
+    expect(result.baseModelMismatches).toBe(0);
+
+    // The Axiom line too, not only the return value: they are separate call sites and a
+    // mutation of the log alone left this test green until this assertion existed. The
+    // log is what a human actually reads when they go looking.
+    const payload = loggingMock.logToAxiom.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload.baseModelUnfilterable).toBe(1);
+    expect(payload.baseModelMismatches).toBe(0);
   });
 
   // 🔴 A column-shape problem in the NEWEST stratum must not silence the detector for the
@@ -723,7 +772,15 @@ describe('auditBitdexConsistency job body', () => {
     expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
     expect(result.baseModelChecked).toBe(0);
     expect(result.baseModelError).toMatch(/expectedBaseModels/);
-    expect(mockCounters.compared.inc).not.toHaveBeenCalledWith({ stratum: 'basemodel' }, 0);
+    // 🔴 The denominator series must still be CREATED, with zero. prom-client makes a
+    // labelled child on first `inc`, so skipping the call leaves the series absent, and
+    // `increase(...) == 0` over an absent series returns an empty vector — the alert
+    // silently never fires. An earlier round asserted the opposite and pinned that gap
+    // in place. Absence is worse than a flat line, not safer than one.
+    expect(mockCounters.compared.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 0);
+    // And the failure is attributable: errors_total is unlabelled and shared with
+    // whole-run throws, so this is the only series that says WHICH stratum died.
+    expect(mockCounters.stratumFailed.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
   });
 
   // 🔴 The one that pins the machinery. The two zero-denominator tests around it assert

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -34,6 +34,7 @@ import {
   buildPublishedSampleQuery,
   buildScheduledSampleQuery,
   baseModelDenominators,
+  baseModelIsExplained,
   buildBaseModelSampleQuery,
   compareStratum,
   getAuditConfig,
@@ -50,6 +51,7 @@ const AUDIT_ENV = [
   'BITDEX_AUDIT_PUBLISHED_WINDOW_SECS',
   'BITDEX_AUDIT_SORTAT_TOLERANCE_SECS',
   'BITDEX_AUDIT_SETTLE_SECS',
+  'BITDEX_AUDIT_BASEMODEL_SETTLE_SECS',
 ];
 
 const clearEnv = () => AUDIT_ENV.forEach((k) => delete process.env[k]);
@@ -125,13 +127,22 @@ describe('buildPublishedSampleQuery', () => {
 });
 
 describe('getAuditConfig', () => {
-  it('defaults to 50 samples / 24h window / 5m tolerance / 2m settle', () => {
+  it('defaults to 50 samples / 24h window / 5m tolerance / 2m settle / 15m baseModel settle', () => {
     expect(getAuditConfig()).toEqual({
       sampleSize: 50,
       publishedWindowSecs: 86400,
       sortAtToleranceSecs: 300,
       settleSecs: 120,
+      // Wider than the others on purpose: this stratum compares a value derived from
+      // ImageResourceNew, which a resource edit changes without moving Post."updatedAt".
+      baseModelSettleSecs: 900,
     });
+  });
+
+  it('honors the baseModel settle override independently of the shared one', () => {
+    process.env.BITDEX_AUDIT_SETTLE_SECS = '60';
+    process.env.BITDEX_AUDIT_BASEMODEL_SETTLE_SECS = '1800';
+    expect(getAuditConfig()).toMatchObject({ settleSecs: 60, baseModelSettleSecs: 1800 });
   });
 
   it('honors positive env overrides', () => {
@@ -296,6 +307,66 @@ describe('buildBaseModelSampleQuery', () => {
   it('samples randomly, so repeated runs cover the population', () => {
     expect(sql()).toContain('ORDER BY random()');
   });
+
+  it('reads only', () => {
+    expect(sql()).not.toMatch(/(INSERT|UPDATE|DELETE)/);
+  });
+
+  // Substring assertions alone stay green when the window and the settle belt are
+  // SWAPPED — both are `make_interval(secs => $n)` and both appear either way. Pinning
+  // the parameter order is what tells a 24h window from a 24h settle belt.
+  it('binds window, settle and limit in that order', () => {
+    const q = buildBaseModelSampleQuery({
+      sampleSize: 50,
+      publishedWindowSecs: 86400,
+      baseModelSettleSecs: 900,
+    });
+    expect(q.values).toEqual([86400, 900, 50]);
+  });
+});
+
+/**
+ * The rule the whole stratum rests on. It replaced a membership test that produced a
+ * measured 0.23% false-mismatch rate on correct data, because the index it treats as
+ * truth glues several checkpoints into one string with no delimiter.
+ */
+describe('baseModelIsExplained', () => {
+  it('accepts the single-checkpoint case', () => {
+    expect(baseModelIsExplained('Pony', ['Pony'])).toBe(true);
+  });
+
+  it('accepts a concatenation of the image checkpoints, in either order', () => {
+    expect(baseModelIsExplained('AnimaMiniMax H3', ['Anima', 'MiniMax H3'])).toBe(true);
+    expect(baseModelIsExplained('MiniMax H3Anima', ['Anima', 'MiniMax H3'])).toBe(true);
+  });
+
+  // Real values from the prod replica, the ones that made the membership rule fire on
+  // correct data: image 141436030 and 141433747.
+  it('accepts the two production values that broke the membership rule', () => {
+    expect(baseModelIsExplained('AnimaMiniMax H3', ['Anima', 'MiniMax H3'])).toBe(true);
+    expect(baseModelIsExplained('LTXV 2.3Krea 2', ['Krea 2', 'LTXV 2.3'])).toBe(true);
+  });
+
+  // The property that has to survive the fix: a base model from an attached LoRA rather
+  // than a checkpoint is still not explainable. Without this the rule accepts everything.
+  it('rejects a value belonging to no checkpoint on the image', () => {
+    expect(baseModelIsExplained('Pony', ['Illustrious'])).toBe(false);
+    expect(baseModelIsExplained('IllustriousPony', ['Illustrious'])).toBe(false);
+  });
+
+  it('rejects any value when the image has no checkpoint at all', () => {
+    expect(baseModelIsExplained('Illustrious', [])).toBe(false);
+  });
+
+  // A checkpoint name that is a PREFIX of the value must not be consumed greedily into a
+  // false accept, and one that is a prefix of another candidate must still backtrack.
+  it('does not accept a value that merely starts with a checkpoint name', () => {
+    expect(baseModelIsExplained('SD 1.5 Hyper', ['SD 1.5'])).toBe(false);
+  });
+
+  it('backtracks when one candidate is a prefix of another', () => {
+    expect(baseModelIsExplained('PonyPony XL', ['Pony', 'Pony XL'])).toBe(true);
+  });
 });
 
 describe('compareStratum — basemodel (868ktxe1r / 868ku8x8k)', () => {
@@ -366,13 +437,34 @@ describe('compareStratum — basemodel (868ktxe1r / 868ku8x8k)', () => {
     ).toEqual([]);
   });
 
-  it('accepts any one of several checkpoints on the same image', () => {
+  // The fixture is the CONCATENATION, because that is what the index emits for a
+  // multi-checkpoint image — `string_agg(..., '')`, no delimiter. A fixture holding one
+  // of the two would certify a document shape production never produces, and that is the
+  // test that blessed the membership bug rather than catching it.
+  it('accepts the glued value a multi-checkpoint image indexes as', () => {
     expect(
       compare(
-        [{ id: 1, isPublished: true, baseModel: 'SDXL 1.0' }],
+        [{ id: 1, isPublished: true, baseModel: 'PonySDXL 1.0' }],
         [row({ expectedBaseModels: ['Pony', 'SDXL 1.0'] })]
       )
     ).toEqual([]);
+  });
+
+  it('still flags a glued value carrying a base model from no checkpoint', () => {
+    const found = compare(
+      [{ id: 1, isPublished: true, baseModel: 'PonyIllustrious' }],
+      [row({ expectedBaseModels: ['Pony'] })]
+    );
+    expect(found.map((f) => f.kind)).toEqual(['basemodel_not_checkpoint']);
+  });
+
+  // The sample query is the only thing that supplies this column. Defaulting a missing
+  // one to `[]` would read as "no checkpoint anywhere" and silence both arms while the
+  // denominators stayed healthy — so it throws instead, and the run fails loudly.
+  it('throws rather than treating a missing expectedBaseModels as no checkpoint', () => {
+    expect(() => compare([{ id: 1, isPublished: true, baseModel: 'Pony' }], [row()])).toThrow(
+      /expectedBaseModels/
+    );
   });
 });
 
@@ -395,13 +487,33 @@ describe('baseModelDenominators', () => {
     expect(baseModelDenominators(rows as never, docs as never)).toEqual({
       comparedDocs: 2,
       withCheckpoint: 1,
+      withDocValue: 1,
     });
   });
 
-  it('is zero on both counts when BitDex holds none of the sample', () => {
+  it('is zero on every count when BitDex holds none of the sample', () => {
     expect(
       baseModelDenominators([row({ expectedBaseModels: ['Pony'] })] as never, [] as never)
-    ).toEqual({ comparedDocs: 0, withCheckpoint: 0 });
+    ).toEqual({ comparedDocs: 0, withCheckpoint: 0, withDocValue: 0 });
+  });
+
+  // The `not_checkpoint` arm's zero needs its own denominator: a sample where every
+  // compared document carried NO value can only produce `basemodel_missing`, so a zero
+  // on the other arm says nothing. One number covering both arms would hide that.
+  it('counts the two arms with separate denominators', () => {
+    const rows = [
+      row({ imageId: 1, expectedBaseModels: ['Pony'] }),
+      row({ imageId: 2, expectedBaseModels: [] }),
+    ];
+    const docs = [
+      { id: 1, isPublished: true },
+      { id: 2, isPublished: true, baseModel: 'Pony' },
+    ];
+    expect(baseModelDenominators(rows as never, docs as never)).toEqual({
+      comparedDocs: 2,
+      withCheckpoint: 1,
+      withDocValue: 1,
+    });
   });
 });
 
@@ -457,6 +569,7 @@ describe('auditBitdexConsistency job body', () => {
       // The zero below means agreement only because these two are nonzero.
       baseModelComparedDocs: 1,
       baseModelWithCheckpoint: 1,
+      baseModelWithDocValue: 1,
       baseModelMismatches: 0,
     });
   });
@@ -499,6 +612,30 @@ describe('auditBitdexConsistency job body', () => {
 
     expect(mockFetchDocs).toHaveBeenCalledTimes(2);
     expect(result).toMatchObject({ scheduledChecked: 0, publishedChecked: 1, baseModelChecked: 1 });
+  });
+
+  // 🔴 The one that pins the machinery. The two zero-denominator tests around it assert
+  // values IDENTICAL to the `?? 0` fallback the job reads them through, so deleting the
+  // whole `baseModelDenominators` spread from `auditStratum` leaves them green — measured.
+  // This one asserts a nonzero comparedDocs beside a zero withCheckpoint, which only the
+  // real computation produces. Do not "simplify" it back into the zero case.
+  it('reports denominators that a missing computation could not produce', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([row({ imageId: 3, postId: 30, expectedBaseModels: [] })]);
+    mockFetchDocs.mockResolvedValueOnce([{ id: 3, isPublished: true }]);
+
+    const result = await runJob();
+
+    expect(result).toMatchObject({
+      baseModelChecked: 1,
+      baseModelComparedDocs: 1,
+      baseModelWithCheckpoint: 0,
+      baseModelWithDocValue: 0,
+      baseModelMismatches: 0,
+    });
   });
 
   // The failure this guard exists to not have: it must be impossible to read a clean

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -5,6 +5,8 @@ const { mockIsFlipt, mockFetchDocs, mockCounters, mockHistogram } = vi.hoisted((
   mockFetchDocs: vi.fn(),
   mockCounters: {
     checked: { inc: vi.fn() },
+    compared: { inc: vi.fn() },
+    opportunity: { inc: vi.fn() },
     mismatch: { inc: vi.fn() },
     runs: { inc: vi.fn() },
     errors: { inc: vi.fn() },
@@ -19,6 +21,8 @@ vi.mock('~/server/flipt/client', () => ({
 }));
 vi.mock('~/server/prom/client', () => ({
   bitdexAuditCheckedCounter: mockCounters.checked,
+  bitdexAuditComparedCounter: mockCounters.compared,
+  bitdexAuditOpportunityCounter: mockCounters.opportunity,
   bitdexAuditMismatchCounter: mockCounters.mismatch,
   bitdexAuditRunsCounter: mockCounters.runs,
   bitdexAuditErrorsCounter: mockCounters.errors,
@@ -286,8 +290,15 @@ describe('compareStratum — published_recent', () => {
 });
 
 describe('buildBaseModelSampleQuery', () => {
+  // ⚠️ `baseModelSettleSecs`, NOT `settleSecs`. `tsconfig.json` excludes `__tests__`, so
+  // tsc never sees this call: passing the wrong key left the settle bound `undefined` and
+  // every substring assertion below still green — a helper that cannot fail.
   const sql = () =>
-    buildBaseModelSampleQuery({ sampleSize: 50, publishedWindowSecs: 86400, settleSecs: 120 }).sql;
+    buildBaseModelSampleQuery({
+      sampleSize: 50,
+      publishedWindowSecs: 86400,
+      baseModelSettleSecs: 900,
+    }).sql;
 
   // Truth for this stratum is the CHECKPOINT-only value, because that is the whole
   // defect: 868ktxe1r was the filter matching an attached LoRA's base model. A query
@@ -321,7 +332,9 @@ describe('buildBaseModelSampleQuery', () => {
       publishedWindowSecs: 86400,
       baseModelSettleSecs: 900,
     });
-    expect(q.values).toEqual([86400, 900, 50]);
+    // Two settle bindings, not one: the belt bounds `Post."updatedAt"` AND
+    // `Image."updatedAt"`, because a resource edit moves the second and not the first.
+    expect(q.values).toEqual([86400, 900, 900, 50]);
   });
 });
 
@@ -441,10 +454,33 @@ describe('compareStratum — basemodel (868ktxe1r / 868ku8x8k)', () => {
   // multi-checkpoint image — `string_agg(..., '')`, no delimiter. A fixture holding one
   // of the two would certify a document shape production never produces, and that is the
   // test that blessed the membership bug rather than catching it.
-  it('accepts the glued value a multi-checkpoint image indexes as', () => {
+  it('does not call a glued value a leak', () => {
+    const found = compare(
+      [{ id: 1, isPublished: true, baseModel: 'PonySDXL 1.0' }],
+      [row({ expectedBaseModels: ['Pony', 'SDXL 1.0'] })]
+    );
+    expect(found.map((f) => f.kind)).not.toContain('basemodel_not_checkpoint');
+  });
+
+  // 🔴 But it is not "correct" either: the base-model filter is exact string equality, so
+  // a glued value matches NO filter — 868ku8x8k's symptom by another route. The previous
+  // rule removed a false positive; accepting this silently would have removed a real
+  // defect with it. Its own kind, so the leak series keeps meaning what it says.
+  it('reports a glued value as unfilterable rather than as agreement', () => {
+    const found = compare(
+      [{ id: 1, isPublished: true, baseModel: 'PonySDXL 1.0' }],
+      [row({ expectedBaseModels: ['Pony', 'SDXL 1.0'] })]
+    );
+    expect(found.map((f) => f.kind)).toEqual(['basemodel_unfilterable']);
+    expect(found[0].actual).toContain('matches no base-model filter');
+  });
+
+  // The negative control for the arm above: one exact checkpoint is the clean case and
+  // must stay silent, or the new kind fires on every image on the site.
+  it('stays silent when the value is exactly one of the checkpoints', () => {
     expect(
       compare(
-        [{ id: 1, isPublished: true, baseModel: 'PonySDXL 1.0' }],
+        [{ id: 1, isPublished: true, baseModel: 'Pony' }],
         [row({ expectedBaseModels: ['Pony', 'SDXL 1.0'] })]
       )
     ).toEqual([]);
@@ -488,19 +524,34 @@ describe('baseModelDenominators', () => {
       comparedDocs: 2,
       withCheckpoint: 1,
       withDocValue: 1,
+      // Image 1 has a checkpoint AND a value, so only the leak arm had an opportunity.
+      missingArmOpportunities: 0,
+      leakArmOpportunities: 1,
     });
   });
 
   it('is zero on every count when BitDex holds none of the sample', () => {
     expect(
       baseModelDenominators([row({ expectedBaseModels: ['Pony'] })] as never, [] as never)
-    ).toEqual({ comparedDocs: 0, withCheckpoint: 0, withDocValue: 0 });
+    ).toEqual({
+      comparedDocs: 0,
+      withCheckpoint: 0,
+      withDocValue: 0,
+      missingArmOpportunities: 0,
+      leakArmOpportunities: 0,
+    });
   });
 
   // The `not_checkpoint` arm's zero needs its own denominator: a sample where every
   // compared document carried NO value can only produce `basemodel_missing`, so a zero
   // on the other arm says nothing. One number covering both arms would hide that.
-  it('counts the two arms with separate denominators', () => {
+  // 🔴 The marginals are IDENTICAL to the case above — same comparedDocs, withCheckpoint
+  // and withDocValue — while the comparison work is completely different: there, one
+  // image with both and one with neither, so only the leak arm could fire; here, one
+  // image with a checkpoint and no value and one with a value and no checkpoint, so BOTH
+  // arms could. Marginals cannot tell those apart, which is why the per-arm opportunity
+  // counts exist. If you are tempted to merge these two tests, that is the reason not to.
+  it('counts the two arms with separate opportunity denominators', () => {
     const rows = [
       row({ imageId: 1, expectedBaseModels: ['Pony'] }),
       row({ imageId: 2, expectedBaseModels: [] }),
@@ -513,6 +564,8 @@ describe('baseModelDenominators', () => {
       comparedDocs: 2,
       withCheckpoint: 1,
       withDocValue: 1,
+      missingArmOpportunities: 1,
+      leakArmOpportunities: 1,
     });
   });
 });
@@ -551,6 +604,11 @@ describe('auditBitdexConsistency job body', () => {
     // The baseModel stratum asks for a different field set; requesting the default one
     // would return documents with no baseModel key and read as a clean audit forever.
     expect(mockFetchDocs.mock.calls[2][2]).toContain('baseModel');
+    // `sortAt` is not decoration here. `publishedAt` is never a document field — the
+    // indexer destructures it out and emits `publishedAtUnix` — so without `sortAt`,
+    // document presence rests on `isPublished` alone, and a projection missing that one
+    // key would skip every row and report the stratum clean.
+    expect(mockFetchDocs.mock.calls[2][2]).toContain('sortAt');
     // Docs are requested by the sampled image ids, from the civitai index.
     expect(mockFetchDocs.mock.calls[0][0]).toBe('civitai');
     expect(mockFetchDocs.mock.calls[0][1]).toEqual([1]);
@@ -612,6 +670,60 @@ describe('auditBitdexConsistency job body', () => {
 
     expect(mockFetchDocs).toHaveBeenCalledTimes(2);
     expect(result).toMatchObject({ scheduledChecked: 0, publishedChecked: 1, baseModelChecked: 1 });
+  });
+
+  // The denominators have to reach the surface an ALERT reads, not only the Axiom line.
+  // `checked_total` counts rows SAMPLED; a row whose document is absent is skipped before
+  // any comparison, so without these a stratum that compared nothing emits the same
+  // mismatch zero as perfect agreement.
+  it('emits the compared and per-arm opportunity counts to prometheus', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(baseModelRows);
+    mockFetchDocs.mockResolvedValueOnce(baseModelDocs);
+
+    await runJob();
+
+    expect(mockCounters.compared.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
+    expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
+      { stratum: 'basemodel', kind: 'basemodel_not_checkpoint' },
+      1
+    );
+    expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
+      { stratum: 'basemodel', kind: 'basemodel_missing' },
+      0
+    );
+  });
+
+  // 🔴 A column-shape problem in the NEWEST stratum must not silence the detector for the
+  // 2026-08-06 incident class. Before this, the throw propagated out of runAudit and the
+  // already-computed scheduled/published results were discarded — no checked, no
+  // mismatch, no runs increment, on every run until someone noticed.
+  it('keeps the other two strata reporting when the baseModel stratum throws', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows)
+      // No expectedBaseModels — the shape `expectedBaseModelsOf` refuses.
+      .mockResolvedValueOnce([row({ imageId: 3, postId: 30 })]);
+    mockFetchDocs
+      .mockResolvedValueOnce([{ id: 1, isPublished: false }])
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }])
+      .mockResolvedValueOnce([{ id: 3, isPublished: true, baseModel: 'Pony' }]);
+
+    const result = (await runJob()) as Record<string, unknown>;
+
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'published_recent' }, 1);
+    expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
+    // Loud, not swallowed — and the failed stratum contributes no zero that reads as
+    // agreement: checked stays 0 and the error is on the record.
+    expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
+    expect(result.baseModelChecked).toBe(0);
+    expect(result.baseModelError).toMatch(/expectedBaseModels/);
+    expect(mockCounters.compared.inc).not.toHaveBeenCalledWith({ stratum: 'basemodel' }, 0);
   });
 
   // 🔴 The one that pins the machinery. The two zero-denominator tests around it assert

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -174,6 +174,17 @@ describe('readDocState', () => {
     });
   });
 
+  // `present` is a three-way OR and every other fixture in this file sets `isPublished`,
+  // so the `sortAt` disjunct was exercised by nothing. It is the reason the field is in
+  // every projection: without it, a response missing `isPublished` would skip every row
+  // and report the stratum clean.
+  it('counts sortAt alone as evidence the document exists', () => {
+    expect(readDocState({ id: 7, sortAt: NOW })).toMatchObject({
+      present: true,
+      published: false,
+    });
+  });
+
   it('treats a bare { id } (no doc on disk) as absent', () => {
     // The batch endpoint returns just the id for a slot with no stored document.
     expect(readDocState({ id: 7 })).toMatchObject({ present: false, published: false });
@@ -648,6 +659,46 @@ describe('auditBitdexConsistency job body', () => {
 
     expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(3);
     expect(mockFetchDocs).toHaveBeenCalledTimes(3);
+
+    // 🔴 Which BUILDER each stratum got. The three are wired to `auditStratum` by hand and
+    // `$queryRaw` is mocked to return fixtures whatever SQL it is handed, so without this
+    // swapping the scheduled and published builders leaves the whole suite green while the
+    // 2026-08-06 incident detector samples the wrong population and reports every row.
+    const sqlOf = (i: number) => (mockDbWrite.$queryRaw.mock.calls[i][0] as { sql: string }).sql;
+    expect(sqlOf(0)).toContain('"publishedAt" > now()');
+    expect(sqlOf(0)).not.toContain('"publishedAt" <= now()');
+    expect(sqlOf(1)).toContain('"publishedAt" <= now()');
+    expect(sqlOf(1)).not.toContain('"expectedBaseModels"');
+    expect(sqlOf(2)).toContain('"expectedBaseModels"');
+
+    // 🔴 And the projection for EVERY stratum, exactly — not `toContain`, which is what let
+    // the omission through for A and B. Dropping `isPublished` is invisible to a mocked
+    // fetch and makes `readDocState` report every document unpublished in production,
+    // which silences the scheduled-visible arm for good.
+    expect(mockFetchDocs.mock.calls[0][2]).toEqual(['id', 'isPublished', 'publishedAt', 'sortAt']);
+    expect(mockFetchDocs.mock.calls[1][2]).toEqual(['id', 'isPublished', 'publishedAt', 'sortAt']);
+    expect(mockFetchDocs.mock.calls[2][2]).toEqual([
+      'id',
+      'isPublished',
+      'publishedAt',
+      'sortAt',
+      'baseModel',
+    ]);
+
+    // Which flag gates the job. `mockIsFlipt` ignores its argument, so gating on a
+    // different existing flag typechecks and passes — and in production reads as off.
+    expect(mockIsFlipt).toHaveBeenCalledWith('bitdex-consistency-audit');
+
+    // Seeding is for EVERY stratum's kinds, not the newest arm's. A kind that has never
+    // fired has no series, and `increase(...) == 0` over an absent series is an empty
+    // vector — the older strata had that problem too and were left out of the first fix.
+    for (const [stratum, kinds] of [
+      ['scheduled', ['scheduled_visible']],
+      ['published_recent', ['published_missing', 'sortat_drift']],
+      ['basemodel', ['basemodel_not_checkpoint', 'basemodel_missing', 'basemodel_unfilterable']],
+    ] as const)
+      for (const kind of kinds)
+        expect(mockCounters.mismatch.inc).toHaveBeenCalledWith({ stratum, kind }, 0);
     // The baseModel stratum asks for a different field set; requesting the default one
     // would return documents with no baseModel key and read as a clean audit forever.
     expect(mockFetchDocs.mock.calls[2][2]).toContain('baseModel');
@@ -679,6 +730,9 @@ describe('auditBitdexConsistency job body', () => {
       baseModelWithCheckpoint: 1,
       baseModelWithDocValue: 1,
       baseModelMismatches: 0,
+      // Negative control for `countUnfilterable`, which is otherwise only ever asserted
+      // as 1 — a constant `() => 1` would pass every other test in this file.
+      baseModelUnfilterable: 0,
     });
   });
 
@@ -819,6 +873,60 @@ describe('auditBitdexConsistency job body', () => {
     expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
     expect(mockCounters.stratumFailed.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
     expect(result.baseModelError).toMatch(/does not exist/);
+  });
+
+  // 🔴 The log's id budget is per-stratum, not first-come. basemodel is logged last, so a
+  // flat 25-row cap meant a noisy stratum A could take every slot and leave the alerting
+  // stratum with a rate and no ids.
+  it('gives every stratum a share of the logged mismatch ids', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    const manyScheduled = Array.from({ length: 40 }, (_, i) => row({ imageId: 100 + i }));
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(manyScheduled)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        row({ imageId: 3, postId: 30, expectedBaseModels: ['Illustrious'] }),
+      ]);
+    mockFetchDocs
+      .mockResolvedValueOnce(manyScheduled.map((r) => ({ id: r.imageId, isPublished: true })))
+      .mockResolvedValueOnce([{ id: 3, isPublished: true, baseModel: 'Pony' }]);
+
+    await runJob();
+
+    const payload = loggingMock.logToAxiom.mock.calls.at(-1)?.[0] as {
+      mismatches: { stratum: string }[];
+      mismatchesTruncatedByStratum: Record<string, number>;
+    };
+    const strata = payload.mismatches.map((m) => m.stratum);
+    expect(strata).toContain('basemodel');
+    expect(strata.filter((x) => x === 'scheduled').length).toBeLessThan(40);
+    expect(payload.mismatchesTruncatedByStratum.scheduled).toBeGreaterThan(0);
+    expect(payload.mismatchesTruncatedByStratum.basemodel).toBe(0);
+  });
+
+  // 🔴 `baseModelMismatches` is asserted as 0 at every other job-level site, so a constant
+  // `countAlerting = () => 0` passed the whole suite. This is the one fixture where a real
+  // leak reaches the summary, and it also pins the mismatch counter firing with 1.
+  it('reports a real leak as a nonzero mismatch on the run and the counter', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        row({ imageId: 3, postId: 30, expectedBaseModels: ['Illustrious'] }),
+      ]);
+    mockFetchDocs.mockResolvedValueOnce([{ id: 3, isPublished: true, baseModel: 'Pony' }]);
+
+    const result = (await runJob()) as Record<string, unknown>;
+
+    expect(result.baseModelMismatches).toBe(1);
+    expect(result.baseModelUnfilterable).toBe(0);
+    expect(mockCounters.mismatch.inc).toHaveBeenCalledWith(
+      { stratum: 'basemodel', kind: 'basemodel_not_checkpoint' },
+      1
+    );
+    const payload = loggingMock.logToAxiom.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload.baseModelMismatches).toBe(1);
   });
 
   // Split because `basemodel_unfilterable` is expected to be nonzero on a healthy system:

--- a/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
+++ b/src/server/jobs/__tests__/audit-bitdex-consistency.test.ts
@@ -509,6 +509,59 @@ describe('compareStratum — basemodel (868ktxe1r / 868ku8x8k)', () => {
 describe('baseModelDenominators', () => {
   // What makes the mismatch count readable. A run that compared nothing produces the
   // same zero as a run that agreed on everything.
+  // 🔴 The four numbers must be DISTINCT in at least one fixture, or nothing tells them
+  // apart. Round 3 shipped a denominator that equalled its own numerator and round 4
+  // shipped assertions that could not have caught it, because every fixture made
+  // checked = comparedDocs = withCheckpoint = withDocValue = 1. Keep them different.
+  it('produces four distinct numbers, so no two can be swapped undetected', () => {
+    const rows = [
+      // compared, checkpoint + value
+      row({ imageId: 1, expectedBaseModels: ['Pony'] }),
+      // compared, checkpoint only
+      row({ imageId: 2, expectedBaseModels: ['Anima'] }),
+      // compared, value only
+      row({ imageId: 3, expectedBaseModels: [] }),
+      // compared, neither
+      row({ imageId: 4, expectedBaseModels: [] }),
+      // NOT compared — document unpublished
+      row({ imageId: 5, expectedBaseModels: ['Pony'] }),
+      // NOT compared — no document
+      row({ imageId: 6, expectedBaseModels: ['Pony'] }),
+    ];
+    const docs = [
+      { id: 1, isPublished: true, baseModel: 'Pony' },
+      { id: 2, isPublished: true },
+      { id: 3, isPublished: true, baseModel: 'Illustrious' },
+      { id: 4, isPublished: true },
+      { id: 5, isPublished: false, baseModel: 'Pony' },
+    ];
+    expect(baseModelDenominators(rows as never, docs as never)).toEqual({
+      comparedDocs: 4,
+      withCheckpoint: 2,
+      withDocValue: 2,
+    });
+  });
+
+  // …and they must count DIFFERENT documents, not merely land on the same total. Swapping
+  // the two accumulators passes any fixture where the counts happen to be equal.
+  it('does not confuse the checkpoint side with the value side', () => {
+    const rows = [
+      row({ imageId: 1, expectedBaseModels: ['Pony'] }),
+      row({ imageId: 2, expectedBaseModels: ['Pony'] }),
+      row({ imageId: 3, expectedBaseModels: [] }),
+    ];
+    const docs = [
+      { id: 1, isPublished: true },
+      { id: 2, isPublished: true },
+      { id: 3, isPublished: true, baseModel: 'Illustrious' },
+    ];
+    expect(baseModelDenominators(rows as never, docs as never)).toEqual({
+      comparedDocs: 3,
+      withCheckpoint: 2,
+      withDocValue: 1,
+    });
+  });
+
   it('counts only documents that were actually comparable', () => {
     const rows = [
       row({ imageId: 1, expectedBaseModels: ['Pony'] }),
@@ -542,13 +595,12 @@ describe('baseModelDenominators', () => {
   // The `not_checkpoint` arm's zero needs its own denominator: a sample where every
   // compared document carried NO value can only produce `basemodel_missing`, so a zero
   // on the other arm says nothing. One number covering both arms would hide that.
-  // 🔴 The marginals are IDENTICAL to the case above — same comparedDocs, withCheckpoint
-  // and withDocValue — while the comparison work is completely different: there, one
-  // image with both and one with neither, so only the leak arm could fire; here, one
-  // image with a checkpoint and no value and one with a value and no checkpoint, so BOTH
-  // arms could. Marginals cannot tell those apart, which is why the per-arm opportunity
-  // counts exist. If you are tempted to merge these two tests, that is the reason not to.
-  it('counts the two arms with separate opportunity denominators', () => {
+  // The two arms' denominators come apart here: one image has a checkpoint and no value
+  // (only `basemodel_missing` can fire on it) and the other has a value and no checkpoint
+  // (only the value-side arms can). `withCheckpoint` and `withDocValue` are each 1 and
+  // count DIFFERENT documents, which is what makes them denominators rather than one
+  // number wearing two names.
+  it('counts each arm against the documents that arm could fire on', () => {
     const rows = [
       row({ imageId: 1, expectedBaseModels: ['Pony'] }),
       row({ imageId: 2, expectedBaseModels: [] }),
@@ -610,7 +662,10 @@ describe('auditBitdexConsistency job body', () => {
     expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
     expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'published_recent' }, 1);
     expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
-    expect(mockCounters.mismatch.inc).not.toHaveBeenCalled();
+    // The basemodel kinds are SEEDED with zero every run so the mismatch/opportunity
+    // ratio is not an empty vector on a healthy system, so "no mismatches" is now "no
+    // inc with a nonzero amount", not "never called".
+    for (const [, amount] of mockCounters.mismatch.inc.mock.calls) expect(amount).toBe(0);
     expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
     expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
@@ -671,41 +726,60 @@ describe('auditBitdexConsistency job body', () => {
   // `checked_total` counts rows SAMPLED; a row whose document is absent is skipped before
   // any comparison, so without these a stratum that compared nothing emits the same
   // mismatch zero as perfect agreement.
+  // 🔴 Every number in this fixture is DIFFERENT — checked 4, compared 3, withCheckpoint
+  // 2, withDocValue 1 — because the previous version made them all 1, and a fixture where
+  // every quantity is 1 cannot catch a denominator wired to the wrong quantity. Two
+  // mutations that swap them passed 67/67 against that fixture. If you simplify this,
+  // that hole comes back.
   it('emits the compared and per-arm opportunity counts to prometheus', async () => {
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(baseModelRows);
-    mockFetchDocs.mockResolvedValueOnce(baseModelDocs);
+      .mockResolvedValueOnce([
+        row({ imageId: 3, postId: 30, expectedBaseModels: ['Pony'] }), // checkpoint, no value
+        row({ imageId: 4, postId: 30, expectedBaseModels: ['Anima'] }), // checkpoint, no value
+        row({ imageId: 5, postId: 30, expectedBaseModels: [] }), // value, no checkpoint
+        row({ imageId: 6, postId: 30, expectedBaseModels: ['Pony'] }), // not compared
+      ]);
+    mockFetchDocs.mockResolvedValueOnce([
+      { id: 3, isPublished: true },
+      { id: 4, isPublished: true },
+      { id: 5, isPublished: true, baseModel: 'Illustrious' },
+      { id: 6, isPublished: false },
+    ]);
 
     await runJob();
 
-    expect(mockCounters.compared.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
-    expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
-      { stratum: 'basemodel', kind: 'basemodel_not_checkpoint' },
-      1
-    );
-    expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
-      { stratum: 'basemodel', kind: 'basemodel_unfilterable' },
-      1
-    );
-    // 🔴 The missing arm's denominator is compared-docs-WITH-a-checkpoint, not the count
-    // of documents missing a value — that second thing is the arm's own NUMERATOR, and a
-    // previous round shipped it as the denominator, giving a ratio of permanently 1 or
-    // 0/0. This fixture has one compared document that has both a checkpoint and a value,
-    // so the denominator is 1 while the arm cannot fire.
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 4);
+    expect(mockCounters.compared.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 3);
+    // The value-side arms are denominated by documents that CARRY a value: 1 here, which
+    // is neither `checked` (4) nor `comparedDocs` (3) nor `withCheckpoint` (2).
+    for (const kind of ['basemodel_not_checkpoint', 'basemodel_unfilterable'])
+      expect(mockCounters.opportunity.inc).toHaveBeenCalledWith({ stratum: 'basemodel', kind }, 1);
+    // 🔴 The missing arm's denominator is compared-docs-WITH-a-checkpoint — 2 — not the
+    // count of documents missing a value, which is that arm's own NUMERATOR and was
+    // shipped as its denominator in an earlier round, giving a ratio of permanently 1
+    // or 0/0.
     expect(mockCounters.opportunity.inc).toHaveBeenCalledWith(
       { stratum: 'basemodel', kind: 'basemodel_missing' },
-      1
+      2
     );
+
+    // The NUMERATOR is seeded too. Without it, mismatch/opportunity divides an absent
+    // series on a healthy system and renders as "No data" — the same ambiguity the
+    // denominators were added to remove, one level along.
+    for (const kind of ['basemodel_not_checkpoint', 'basemodel_missing', 'basemodel_unfilterable'])
+      expect(mockCounters.mismatch.inc).toHaveBeenCalledWith({ stratum: 'basemodel', kind }, 0);
   });
 
-  // The catch is for ONE failure, not for any failure. `fetchBitdexDocuments` throws on
-  // every error precisely so an unreachable index cannot be mistaken for a clean audit;
-  // swallowing that here would report a BitDex outage as a caught stratum failure on a
-  // run recorded as successful — the silent pass its contract forbids.
-  it('does not swallow a BitDex fetch failure in the baseModel stratum', async () => {
+  // A BitDex outage in stratum C is CAUGHT — the other two strata must keep reporting,
+  // and gating the catch on one error class meant a Postgres error took them down with
+  // it. What the contract forbids is a SILENT pass, and this is not silent: the failure
+  // is labelled at the source, counted as an error, and named on the run. The denominator
+  // still goes out as zero, so the stratum reports "compared nothing" rather than
+  // "found nothing wrong".
+  it('reports a BitDex fetch failure in stratum C loudly, without taking A and B down', async () => {
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw
       .mockResolvedValueOnce(scheduledRows)
@@ -716,8 +790,35 @@ describe('auditBitdexConsistency job body', () => {
       .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }])
       .mockRejectedValueOnce(new Error('BitDex documents fetch failed 503'));
 
-    await expect(runJob()).rejects.toThrow(/503/);
-    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+    const result = (await runJob()) as Record<string, unknown>;
+
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'published_recent' }, 1);
+    // Labelled at the source, so it fires for a fetch failure and not only for the
+    // column-shape guard — incrementing it in the caller's catch missed exactly this.
+    expect(mockCounters.stratumFailed.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
+    expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
+    expect(result.baseModelError).toMatch(/503/);
+    expect(mockCounters.compared.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 0);
+  });
+
+  // The same for a Postgres error, which is the LIKELIER spelling of "the sample query is
+  // not delivering the column" and which a class-based catch let through.
+  it('keeps A and B reporting when stratum C hits a database error', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce(scheduledRows)
+      .mockResolvedValueOnce(publishedRows)
+      .mockRejectedValueOnce(new Error('column "expectedBaseModels" does not exist'));
+    mockFetchDocs
+      .mockResolvedValueOnce([{ id: 1, isPublished: false }])
+      .mockResolvedValueOnce([{ id: 2, isPublished: true, sortAt: NOW }]);
+
+    const result = (await runJob()) as Record<string, unknown>;
+
+    expect(mockCounters.checked.inc).toHaveBeenCalledWith({ stratum: 'scheduled' }, 1);
+    expect(mockCounters.stratumFailed.inc).toHaveBeenCalledWith({ stratum: 'basemodel' }, 1);
+    expect(result.baseModelError).toMatch(/does not exist/);
   });
 
   // Split because `basemodel_unfilterable` is expected to be nonzero on a healthy system:

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -42,6 +42,16 @@ const DEFAULT_SORTAT_TOLERANCE_SECS = 5 * 60;
 // settle belt, and deliberately larger — the audit has no reason to look at the edge.
 const DEFAULT_SETTLE_SECS = 120;
 
+// Stratum C's belt, and it is wider than the others for a reason that is NOT caution.
+// The other two compare publication state, which lives on `Post`, so `Post."updatedAt"`
+// moves with the thing they measure. This one compares a value derived from
+// `ImageResourceNew`, and `addResourceToImages` (post.service.ts) inserts those rows
+// WITHOUT touching `Post."updatedAt"` — so for a resource edit the belt is watching a
+// timestamp that never moved, and a wider window only shrinks the overlap with the
+// index's sync lag rather than closing it. A mismatch on a just-edited image is a known
+// false positive here; the row prints both sides so it can be recognised as one.
+const DEFAULT_BASEMODEL_SETTLE_SECS = 15 * 60;
+
 // Doc fields the comparison reads. publishedAt is fetched alongside isPublished
 // because isPublished is an exists_boolean derived FROM publishedAt in the index
 // config: if the boolean is ever absent from a doc payload, publishedAt still carries
@@ -74,6 +84,7 @@ export type AuditConfig = {
   publishedWindowSecs: number;
   sortAtToleranceSecs: number;
   settleSecs: number;
+  baseModelSettleSecs: number;
 };
 
 // Env-overridable so sample size and tolerance can be retuned without a redeploy —
@@ -90,6 +101,10 @@ export function getAuditConfig(): AuditConfig {
       DEFAULT_SORTAT_TOLERANCE_SECS
     ),
     settleSecs: parsePositiveInt(process.env.BITDEX_AUDIT_SETTLE_SECS, DEFAULT_SETTLE_SECS),
+    baseModelSettleSecs: parsePositiveInt(
+      process.env.BITDEX_AUDIT_BASEMODEL_SETTLE_SECS,
+      DEFAULT_BASEMODEL_SETTLE_SECS
+    ),
   };
 }
 
@@ -105,9 +120,11 @@ export type AuditSampleRow = {
   // audit compares against the same GREATEST semantics rather than reimplementing them.
   expectedSortAtSecs: number;
   // Distinct baseModels of the image's CHECKPOINT resources. Only the baseModel stratum
-  // selects it; a set rather than a scalar because an image can carry more than one
-  // checkpoint, and because the comparison is membership — which resource supplied the
-  // value is the whole question, and ordering is not.
+  // selects it, which is why the type says optional — but it is REQUIRED wherever it is
+  // read, and `auditStratum` throws rather than defaulting when a sampled row arrives
+  // without it. Coercing a lost column to `[]` would mean "this image has no checkpoint",
+  // which is a legitimate state for ~14% of images and would silence both arms while the
+  // denominators still looked healthy.
   expectedBaseModels?: string[] | null;
 };
 
@@ -174,8 +191,8 @@ export function buildPublishedSampleQuery({
 export function buildBaseModelSampleQuery({
   sampleSize,
   publishedWindowSecs,
-  settleSecs,
-}: Pick<AuditConfig, 'sampleSize' | 'publishedWindowSecs' | 'settleSecs'>): Prisma.Sql {
+  baseModelSettleSecs,
+}: Pick<AuditConfig, 'sampleSize' | 'publishedWindowSecs' | 'baseModelSettleSecs'>): Prisma.Sql {
   return Prisma.sql`
     SELECT
       i.id AS "imageId",
@@ -194,7 +211,7 @@ export function buildBaseModelSampleQuery({
     JOIN "Image" i ON i."postId" = p.id
     WHERE p."publishedAt" > now() - make_interval(secs => ${publishedWindowSecs})
       AND p."publishedAt" <= now()
-      AND p."updatedAt" < now() - make_interval(secs => ${settleSecs})
+      AND p."updatedAt" < now() - make_interval(secs => ${baseModelSettleSecs})
     ORDER BY random()
     LIMIT ${sampleSize}
   `;
@@ -232,6 +249,40 @@ export function readDocState(doc: BitdexDocument | undefined): BitdexDocState {
   };
 }
 
+/**
+ * Is the document's baseModel explainable by the image's checkpoints?
+ *
+ * NOT membership. The index this stratum treats as truth builds the value with
+ * `string_agg(..., '')` — no delimiter, no DISTINCT — so a multi-checkpoint image comes
+ * back as one glued string (`AnimaMiniMax H3`), and `includes()` would call that a
+ * mismatch. Measured on the prod replica over this stratum's exact window: 3000 rows,
+ * 2566 single-checkpoint, 427 with none, 7 multi. At 0.23% that is roughly 17 false
+ * mismatches a day — a permanent noise floor on the series meant to detect the leak.
+ *
+ * BitDex's own derivation is the thing we cannot observe from here, so this deliberately
+ * does not assume Meili's exact expression: a value is accepted when it can be consumed
+ * entirely by concatenating checkpoint base models, in any order, which holds whether the
+ * producer emits one value or glues several. A base model belonging to no checkpoint on
+ * the image — the reported leak — still cannot be consumed, which is the property that
+ * has to survive.
+ */
+export function baseModelIsExplained(value: string, expected: string[]): boolean {
+  if (!expected.length) return false;
+  const candidates = [...new Set(expected)].filter(Boolean);
+
+  const seen = new Set<number>();
+  const consume = (from: number): boolean => {
+    if (from === value.length) return true;
+    if (seen.has(from)) return false;
+    seen.add(from);
+    for (const c of candidates) {
+      if (value.startsWith(c, from) && consume(from + c.length)) return true;
+    }
+    return false;
+  };
+  return consume(0);
+}
+
 export type AuditMismatch = {
   stratum: AuditStratum;
   kind: MismatchKind;
@@ -264,7 +315,7 @@ export function compareStratum(
       // here would double-count one lost write as two defects in two places.
       if (!state.present || !state.published) continue;
 
-      const expected = row.expectedBaseModels ?? [];
+      const expected = expectedBaseModelsOf(row);
 
       if (state.baseModel == null) {
         // No checkpoint on the image means no base model is the CORRECT answer, so this
@@ -283,7 +334,7 @@ export function compareStratum(
         continue;
       }
 
-      if (!expected.includes(state.baseModel)) {
+      if (!baseModelIsExplained(state.baseModel, expected)) {
         mismatches.push({
           stratum,
           kind: 'basemodel_not_checkpoint',
@@ -356,7 +407,28 @@ export type AuditScopeResult = {
   // beside a zero denominator is not evidence of agreement.
   comparedDocs?: number;
   withCheckpoint?: number;
+  // The `not_checkpoint` arm's own denominator: compared documents that actually carried
+  // a value to disagree about. Its zero needs this the way the `missing` arm's zero needs
+  // `withCheckpoint`, and one number covering both arms would hide whichever is empty.
+  withDocValue?: number;
 };
+
+/**
+ * Reads the checkpoint set off a sampled row, and THROWS when the column is not there.
+ *
+ * The tempting `?? []` is the failure this whole guard exists to prevent: an empty set is
+ * a legitimate state for ~14% of images (no checkpoint resource), so a lost alias, a
+ * dropped COALESCE or a changed row shape would silence BOTH arms permanently while
+ * `comparedDocs` stayed healthy and nonzero. Throwing routes it to the error counter and
+ * fails the run, which is loud; defaulting would read as a clean audit forever.
+ */
+function expectedBaseModelsOf(row: AuditSampleRow): string[] {
+  if (!Array.isArray(row.expectedBaseModels))
+    throw new Error(
+      `baseModel stratum: image ${row.imageId} arrived without expectedBaseModels — the sample query is not delivering the column`
+    );
+  return row.expectedBaseModels;
+}
 
 /**
  * The denominators the baseModel stratum's zero has to be read against: how many sampled
@@ -370,13 +442,15 @@ export function baseModelDenominators(rows: AuditSampleRow[], docs: BitdexDocume
 
   let comparedDocs = 0;
   let withCheckpoint = 0;
+  let withDocValue = 0;
   for (const row of rows) {
     const state = readDocState(byId.get(row.imageId));
     if (!state.present || !state.published) continue;
     comparedDocs++;
-    if ((row.expectedBaseModels ?? []).length) withCheckpoint++;
+    if (expectedBaseModelsOf(row).length) withCheckpoint++;
+    if (state.baseModel != null) withDocValue++;
   }
-  return { comparedDocs, withCheckpoint };
+  return { comparedDocs, withCheckpoint, withDocValue };
 }
 
 // Samples one stratum and compares it. A BitDex fetch failure propagates:
@@ -478,6 +552,7 @@ export const auditBitdexConsistency = createJob(
         // and comparing none of them reports the same mismatch count as full agreement.
         baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
         baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
+        baseModelWithDocValue: result.baseModel.withDocValue ?? 0,
         baseModelMismatches: result.baseModel.mismatches.length,
         // Ids and expected-vs-actual, so a firing alert has a trail to pull on
         // instead of only a rate.
@@ -498,6 +573,7 @@ export const auditBitdexConsistency = createJob(
       baseModelChecked: result.baseModel.checked,
       baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
       baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
+      baseModelWithDocValue: result.baseModel.withDocValue ?? 0,
       baseModelMismatches: result.baseModel.mismatches.length,
       durationSec,
     };

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -221,6 +221,16 @@ export function buildBaseModelSampleQuery({
       extract(epoch FROM p."publishedAt")::double precision AS "publishedAtSecs",
       extract(epoch FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt"))::double precision
         AS "expectedSortAtSecs",
+      -- WARNING: safe by planner grace, not by construction. A correlated subquery in the
+      -- target list, under a random sort, is the shape Postgres can evaluate once per INPUT
+      -- row. Measured on the replica: Result -> Sort -> Gather with the SubPlan at loops=50,
+      -- because the projection is postponed above the top-N heapsort — 2,826 buffers, not
+      -- the ~81,700 executions the shape allows. Move this value into a filter, a sort key
+      -- or a de-duplication and it drops below the Sort; that version takes ~60s per run on
+      -- the primary, every 10 minutes.
+      --
+      -- Deliberately worded without the SQL keywords the builder's tests assert on: a
+      -- comment repeating them would satisfy those substring checks on its own.
       COALESCE((
         SELECT array_agg(DISTINCT mv."baseModel")
         FROM "ImageResourceNew" irn
@@ -382,11 +392,18 @@ export function compareStratum(
       // arriving by a different route, and accepting it silently is how the previous
       // rule's fix would have hidden a real defect while removing a false one.
       //
-      // 🔴 Its own kind on purpose, and it is NOT an alerting series: it is expected to
-      // be nonzero (measured ~0.2% of sampled images) because the index builds the value
-      // with `string_agg`. Alert on `basemodel_not_checkpoint` and `basemodel_missing`;
-      // watch this one for its RATE. Folding it into either of those would put a
-      // permanent floor under a series that has to mean something when it moves.
+      // 🔴 Its own kind on purpose, and NOT an alerting series — but read the reason
+      // carefully before trusting the floor. ~0.2% of sampled images have more than one
+      // checkpoint (measured in PG), and the MEILI indexer glues those with `string_agg`.
+      // Whether BITDEX glues them is unknown: its ingest is not in this repo, which is the
+      // whole reason this guard exists, and this file refuses the same cross-system
+      // inference elsewhere when it keeps `publishedAt`.
+      //
+      // So: if BitDex does NOT glue, every row on this kind is a real defect of
+      // 868ku8x8k's class, pre-labelled as noise. Whoever flips `bitdex-image-search`
+      // should treat a nonzero count here on the first real run as a FINDING until
+      // someone confirms BitDex glues the way Meili does. Alert on
+      // `basemodel_not_checkpoint` and `basemodel_missing`; watch this one's rate.
       if (!expected.includes(state.baseModel)) {
         mismatches.push({
           stratum,
@@ -450,11 +467,23 @@ export function compareStratum(
 
 // The three kinds this stratum can report. Named so the seeding loop and the reader
 // cannot drift from the `MismatchKind` union.
-const BASEMODEL_KINDS = [
+// The two arms denominated by documents that CARRY a value. `satisfies` for the same
+// reason KINDS_BY_STRATUM has it: an untyped string array here is the one place in this
+// file that can drift from `MismatchKind` without a type error.
+const VALUE_SIDE_KINDS = [
   'basemodel_not_checkpoint',
-  'basemodel_missing',
   'basemodel_unfilterable',
 ] as const satisfies readonly MismatchKind[];
+
+// Every stratum's kinds, so the seeding below is not applied to the newest arm alone.
+// The reuse lane caught exactly that: the three paragraphs arguing an absent series breaks
+// `increase(...) == 0` were true of `scheduled_visible`, `published_missing` and
+// `sortat_drift` too, and those were left absent.
+const KINDS_BY_STRATUM = {
+  scheduled: ['scheduled_visible'],
+  published_recent: ['published_missing', 'sortat_drift'],
+  basemodel: ['basemodel_not_checkpoint', 'basemodel_missing', 'basemodel_unfilterable'],
+} as const satisfies Record<AuditStratum, readonly MismatchKind[]>;
 
 const countUnfilterable = (m: AuditMismatch[]) =>
   m.filter((x) => x.kind === 'basemodel_unfilterable').length;
@@ -683,27 +712,31 @@ export const auditBitdexConsistency = createJob(
         );
         // Both value-side arms share this denominator: they can only fire on a compared
         // document that carried a value at all.
-        for (const kind of ['basemodel_not_checkpoint', 'basemodel_unfilterable'])
+        for (const kind of VALUE_SIDE_KINDS)
           bitdexAuditOpportunityCounter?.inc(
             { stratum: scope.stratum, kind },
             scope.withDocValue ?? 0
           );
-
-        // The NUMERATOR needs seeding for the same reason the denominator does. The ratio
-        // these counts exist to enable is mismatch/opportunity, and on a healthy system
-        // the mismatch series has never been inc'd — so the division returns an empty
-        // vector and Grafana renders "No data", which is the ambiguity being fixed rather
-        // than the answer "none". Seeding with zero costs nothing and makes the healthy
-        // case read as zero.
-        for (const kind of BASEMODEL_KINDS)
-          bitdexAuditMismatchCounter?.inc({ stratum: scope.stratum, kind }, 0);
       }
+
+      // The NUMERATOR needs seeding for the same reason the denominators do, and for EVERY
+      // stratum — on a healthy system a kind that has never fired has no series at all, so
+      // `increase(...) == 0` returns an empty vector and Grafana renders "No data" rather
+      // than "none". Outside the basemodel guard above, because the older strata have the
+      // same problem and were left absent.
+      for (const kind of KINDS_BY_STRATUM[scope.stratum])
+        bitdexAuditMismatchCounter?.inc({ stratum: scope.stratum, kind }, 0);
     }
 
     bitdexAuditRunsCounter?.inc();
     bitdexAuditRunDurationHistogram?.observe(durationSec);
 
     const allMismatches = scopes.flatMap((s) => s.mismatches);
+    const perStratumCap = Math.ceil(MAX_LOGGED_MISMATCHES / scopes.length);
+    const loggedMismatches = scopes.flatMap((s) => s.mismatches.slice(0, perStratumCap));
+    const truncatedByStratum = Object.fromEntries(
+      scopes.map((s) => [s.stratum, Math.max(0, s.mismatches.length - perStratumCap)])
+    );
 
     // Logged every run, not only on a finding: a run that checked 0 rows is not the
     // same as a run that found nothing wrong, and only the log distinguishes them.
@@ -733,8 +766,14 @@ export const auditBitdexConsistency = createJob(
         baseModelError: result.baseModelError,
         // Ids and expected-vs-actual, so a firing alert has a trail to pull on
         // instead of only a rate.
-        mismatches: allMismatches.slice(0, MAX_LOGGED_MISMATCHES),
-        mismatchesTruncated: Math.max(0, allMismatches.length - MAX_LOGGED_MISMATCHES),
+        // 🔴 Sliced PER STRATUM, not off one flat list. The strata are logged in order and
+        // basemodel is last, so a flat cap is a priority ordering: during the 2026-08-06
+        // incident class stratum A alone would fill all 25 rows and NO stratum-C image id
+        // would reach the log, while its counter moved and the alert fired. The on-call
+        // then has a rate and no evidence, which is what this field exists to prevent.
+        mismatches: loggedMismatches,
+        mismatchesTruncated: allMismatches.length - loggedMismatches.length,
+        mismatchesTruncatedByStratum: truncatedByStratum,
         durationSec,
         sampleSize: config.sampleSize,
         sortAtToleranceSecs: config.sortAtToleranceSecs,

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -8,6 +8,7 @@ import {
   bitdexAuditCheckedCounter,
   bitdexAuditComparedCounter,
   bitdexAuditOpportunityCounter,
+  bitdexAuditStratumFailedCounter,
   bitdexAuditErrorsCounter,
   bitdexAuditMismatchCounter,
   bitdexAuditRunDurationHistogram,
@@ -245,9 +246,13 @@ export type BitdexDocState = {
   baseModel: string | null;
 };
 
-// Reads BitDex's answer out of a doc payload. isPublished is the authority when the
-// key is present; publishedAt is the fallback, because the index derives isPublished
-// from it via exists_boolean and the two carry the same fact.
+// Reads BitDex's answer out of a doc payload.
+//
+// ⚠️ `publishedAt` reads like a fallback and is NOT one: the metrics indexer destructures
+// it out of the record and emits `publishedAtUnix`, so it is never a document field. That
+// leaves `published` resting on `isPublished` alone. `present` has `sortAt` as a second
+// witness; `published` has none, so a projection that omits `isPublished` reports every
+// document unpublished rather than reporting nothing.
 export function readDocState(doc: BitdexDocument | undefined): BitdexDocState {
   if (!doc) return { present: false, published: false, sortAtSecs: null, baseModel: null };
 
@@ -438,6 +443,11 @@ export function compareStratum(
   return mismatches;
 }
 
+const countUnfilterable = (m: AuditMismatch[]) =>
+  m.filter((x) => x.kind === 'basemodel_unfilterable').length;
+const countAlerting = (m: AuditMismatch[]) =>
+  m.filter((x) => x.kind !== 'basemodel_unfilterable').length;
+
 export type AuditScopeResult = {
   stratum: AuditStratum;
   checked: number;
@@ -448,12 +458,12 @@ export type AuditScopeResult = {
   // beside a zero denominator is not evidence of agreement.
   comparedDocs?: number;
   withCheckpoint?: number;
-  // Per-arm OPPORTUNITY counts: compared documents on which that arm could have fired at
-  // all. The three marginals below cannot recover these — a run that compared two
-  // documents with one checkpoint and one value between them reports the same marginals
-  // whether both arms had an opportunity or neither did.
-  missingArmOpportunities?: number;
-  leakArmOpportunities?: number;
+  // 🔴 `withCheckpoint` and `withDocValue` ARE the per-arm denominators — do not add
+  // "opportunity" counts beside them. A previous round did, and `missingArmOpportunities`
+  // came out as `hasCheckpoint && !hasValue`, which is the `basemodel_missing` PREDICATE:
+  // numerator and denominator identical, ratio permanently 1 or 0/0. The arm can only
+  // fire on a document that has a checkpoint, so the denominator is "compared documents
+  // WITH a checkpoint" — and the same for the leak arm and `withDocValue`.
   // The `not_checkpoint` arm's own denominator: compared documents that actually carried
   // a value to disagree about. Its zero needs this the way the `missing` arm's zero needs
   // `withCheckpoint`, and one number covering both arms would hide whichever is empty.
@@ -469,9 +479,11 @@ export type AuditScopeResult = {
  * `comparedDocs` stayed healthy and nonzero. Throwing routes it to the error counter and
  * fails the run, which is loud; defaulting would read as a clean audit forever.
  */
+export class MissingExpectedBaseModelsError extends Error {}
+
 function expectedBaseModelsOf(row: AuditSampleRow): string[] {
   if (!Array.isArray(row.expectedBaseModels))
-    throw new Error(
+    throw new MissingExpectedBaseModelsError(
       `baseModel stratum: image ${row.imageId} arrived without expectedBaseModels — the sample query is not delivering the column`
     );
   return row.expectedBaseModels;
@@ -490,29 +502,18 @@ export function baseModelDenominators(rows: AuditSampleRow[], docs: BitdexDocume
   let comparedDocs = 0;
   let withCheckpoint = 0;
   let withDocValue = 0;
-  let missingArmOpportunities = 0;
-  let leakArmOpportunities = 0;
   for (const row of rows) {
     const state = readDocState(byId.get(row.imageId));
     if (!state.present || !state.published) continue;
     comparedDocs++;
-    const hasCheckpoint = expectedBaseModelsOf(row).length > 0;
-    const hasValue = state.baseModel != null;
-    if (hasCheckpoint) withCheckpoint++;
-    if (hasValue) withDocValue++;
-    // `basemodel_missing` fires only where PG has a checkpoint AND the document has no
-    // value; `basemodel_not_checkpoint` only where the document HAS one. Each zero is
-    // read against its own count, not against the marginals.
-    if (hasCheckpoint && !hasValue) missingArmOpportunities++;
-    if (hasValue) leakArmOpportunities++;
+    // `basemodel_missing` can only fire on a compared document that HAS a checkpoint;
+    // `basemodel_not_checkpoint` and `basemodel_unfilterable` only on one that HAS a
+    // value. So these two marginals are the arms' denominators, and a ratio against
+    // either is bounded below 1 rather than being the numerator again.
+    if (expectedBaseModelsOf(row).length) withCheckpoint++;
+    if (state.baseModel != null) withDocValue++;
   }
-  return {
-    comparedDocs,
-    withCheckpoint,
-    withDocValue,
-    missingArmOpportunities,
-    leakArmOpportunities,
-  };
+  return { comparedDocs, withCheckpoint, withDocValue };
 }
 
 // Samples one stratum and compares it. A BitDex fetch failure propagates:
@@ -577,7 +578,12 @@ export async function runAudit(config: AuditConfig): Promise<AuditResult> {
       BASEMODEL_DOC_FIELDS
     );
   } catch (e) {
-    baseModelError = e instanceof Error ? e.message : String(e);
+    // ONLY the column-shape failure is survivable here. `fetchBitdexDocuments` throws on
+    // any failure precisely so an unreachable index can never be mistaken for a clean
+    // audit (bitdex/client.ts), and a swallowed 401 or timeout would be exactly that —
+    // reported as a caught stratum failure while the run records itself successful.
+    if (!(e instanceof MissingExpectedBaseModelsError)) throw e;
+    baseModelError = e.message;
     // checked stays 0 and the denominators stay undefined: a failed stratum must not
     // contribute a zero that reads as agreement.
     baseModel = { stratum: 'basemodel', checked: 0, mismatches: [] };
@@ -603,8 +609,16 @@ export const auditBitdexConsistency = createJob(
       throw e; // createJob logs job-error to Axiom and marks the run failed
     }
     // A caught stratum failure is still an error: the run continues so the other two
-    // strata keep reporting, but it must not look like a clean pass on the error series.
-    if (result.baseModelError) bitdexAuditErrorsCounter?.inc();
+    // strata keep reporting, but it must not look like a clean pass.
+    //
+    // `errors_total` is unlabelled and shared with whole-run failures, so on its own it
+    // cannot say WHICH stratum died — and `runs_total` still ticks, correctly, because
+    // the run did complete for the other two. The labelled series is the one an alert
+    // can use to notice that this stratum has been dead for a week.
+    if (result.baseModelError) {
+      bitdexAuditErrorsCounter?.inc();
+      bitdexAuditStratumFailedCounter?.inc({ stratum: 'basemodel' }, 1);
+    }
 
     const durationSec = (Date.now() - start) / 1000;
 
@@ -619,18 +633,27 @@ export const auditBitdexConsistency = createJob(
       // absent or unpublished is skipped before any comparison, so without these a
       // stratum that compared nothing emits a mismatch zero identical to one from
       // perfect agreement, which is the whole failure this guard exists to prevent.
-      if (scope.comparedDocs !== undefined)
-        bitdexAuditComparedCounter?.inc({ stratum: scope.stratum }, scope.comparedDocs);
-      if (scope.missingArmOpportunities !== undefined)
+      //
+      // 🔴 Emitted UNCONDITIONALLY, including zero, for the same reason `checked_total`
+      // is. prom-client creates a labelled child on first `inc`, so skipping the call
+      // when a stratum produced nothing leaves the series ABSENT rather than zero — and
+      // `increase(...) == 0` over an absent series returns an empty vector, so the
+      // denominator alert never fires. Absence is worse than a flat line: a flat line
+      // and a flat line look the same, but absence breaks the query.
+      if (scope.stratum === 'basemodel') {
+        bitdexAuditComparedCounter?.inc({ stratum: scope.stratum }, scope.comparedDocs ?? 0);
         bitdexAuditOpportunityCounter?.inc(
           { stratum: scope.stratum, kind: 'basemodel_missing' },
-          scope.missingArmOpportunities
+          scope.withCheckpoint ?? 0
         );
-      if (scope.leakArmOpportunities !== undefined)
-        bitdexAuditOpportunityCounter?.inc(
-          { stratum: scope.stratum, kind: 'basemodel_not_checkpoint' },
-          scope.leakArmOpportunities
-        );
+        // Both value-side arms share this denominator: they can only fire on a compared
+        // document that carried a value at all.
+        for (const kind of ['basemodel_not_checkpoint', 'basemodel_unfilterable'])
+          bitdexAuditOpportunityCounter?.inc(
+            { stratum: scope.stratum, kind },
+            scope.withDocValue ?? 0
+          );
+      }
     }
 
     bitdexAuditRunsCounter?.inc();
@@ -655,9 +678,12 @@ export const auditBitdexConsistency = createJob(
         baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
         baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
         baseModelWithDocValue: result.baseModel.withDocValue ?? 0,
-        baseModelMissingArmOpportunities: result.baseModel.missingArmOpportunities ?? 0,
-        baseModelLeakArmOpportunities: result.baseModel.leakArmOpportunities ?? 0,
-        baseModelMismatches: result.baseModel.mismatches.length,
+        // Split, because `basemodel_unfilterable` is expected to be nonzero on a healthy
+        // system (~0.2% of sampled images). Folding it into the summary count would put
+        // the same permanent floor under the number a human reads that keeping it out of
+        // the alerting series was meant to avoid.
+        baseModelMismatches: countAlerting(result.baseModel.mismatches),
+        baseModelUnfilterable: countUnfilterable(result.baseModel.mismatches),
         // Present only when the stratum threw. Without it a failed stratum and a clean
         // one are the same row of zeros.
         baseModelError: result.baseModelError,
@@ -681,9 +707,8 @@ export const auditBitdexConsistency = createJob(
       baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
       baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
       baseModelWithDocValue: result.baseModel.withDocValue ?? 0,
-      baseModelMissingArmOpportunities: result.baseModel.missingArmOpportunities ?? 0,
-      baseModelLeakArmOpportunities: result.baseModel.leakArmOpportunities ?? 0,
-      baseModelMismatches: result.baseModel.mismatches.length,
+      baseModelMismatches: countAlerting(result.baseModel.mismatches),
+      baseModelUnfilterable: countUnfilterable(result.baseModel.mismatches),
       baseModelError: result.baseModelError,
       durationSec,
     };

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -63,12 +63,17 @@ const DEFAULT_BASEMODEL_SETTLE_SECS = 15 * 60;
 
 // Doc fields the comparison reads.
 //
-// ⚠️ `publishedAt` is requested but is NOT a document field: the metrics indexer
+// ⚠️ `publishedAt` is requested and is NOT a field of the MEILI document: the metrics indexer
 // destructures it out of the record and emits `publishedAtUnix` instead
 // (metrics-images.search-index.ts). So the "publishedAt carries the same fact if the
 // boolean is missing" fallback this list used to claim is inert, and `sortAt` is the
-// only independent witness that a document exists at all. Keep it in every field list
-// for that reason, not for the value.
+// only independent witness that a document exists at all. Keep `sortAt` in every field
+// list for that reason.
+//
+// `publishedAt` stays too: these strata read BITDEX documents, and BitDex's document
+// shape is not in this repo, so the Meili evidence above does not establish that the key
+// is absent there. Requesting a field that does not exist costs nothing; dropping one
+// that does would silently remove a witness.
 const AUDIT_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'sortAt'];
 
 // The baseModel stratum needs the publication fields too, because a document that is
@@ -443,6 +448,14 @@ export function compareStratum(
   return mismatches;
 }
 
+// The three kinds this stratum can report. Named so the seeding loop and the reader
+// cannot drift from the `MismatchKind` union.
+const BASEMODEL_KINDS = [
+  'basemodel_not_checkpoint',
+  'basemodel_missing',
+  'basemodel_unfilterable',
+] as const satisfies readonly MismatchKind[];
+
 const countUnfilterable = (m: AuditMismatch[]) =>
   m.filter((x) => x.kind === 'basemodel_unfilterable').length;
 const countAlerting = (m: AuditMismatch[]) =>
@@ -525,6 +538,23 @@ async function auditStratum(
   config: AuditConfig,
   docFields: string[] = AUDIT_DOC_FIELDS
 ): Promise<AuditScopeResult> {
+  try {
+    return await auditStratumInner(stratum, query, config, docFields);
+  } catch (e) {
+    // Labelled at the SOURCE, so it fires however the stratum died — a BitDex outage, a
+    // Postgres error on the sample, or the column-shape guard. Incrementing it only in
+    // the caller's catch missed every failure the caller rethrows, which is most of them.
+    bitdexAuditStratumFailedCounter?.inc({ stratum }, 1);
+    throw e;
+  }
+}
+
+async function auditStratumInner(
+  stratum: AuditStratum,
+  query: Prisma.Sql,
+  config: AuditConfig,
+  docFields: string[] = AUDIT_DOC_FIELDS
+): Promise<AuditScopeResult> {
   // Primary, not the replica: this job's whole output is "PG and BitDex disagree",
   // and replica lag would manufacture exactly that disagreement. 100 sampled rows
   // every 10 minutes is nothing against the primary, and it removes a false-positive
@@ -578,14 +608,22 @@ export async function runAudit(config: AuditConfig): Promise<AuditResult> {
       BASEMODEL_DOC_FIELDS
     );
   } catch (e) {
-    // ONLY the column-shape failure is survivable here. `fetchBitdexDocuments` throws on
-    // any failure precisely so an unreachable index can never be mistaken for a clean
-    // audit (bitdex/client.ts), and a swallowed 401 or timeout would be exactly that —
-    // reported as a caught stratum failure while the run records itself successful.
-    if (!(e instanceof MissingExpectedBaseModelsError)) throw e;
-    baseModelError = e.message;
-    // checked stays 0 and the denominators stay undefined: a failed stratum must not
-    // contribute a zero that reads as agreement.
+    // EVERY stratum-C failure is caught, not just the column-shape one. Gating on that
+    // single class meant the likelier spelling of the same problem — a renamed column, a
+    // missing migration, anything Postgres reports rather than JS — rethrew and discarded
+    // the two already-computed results, silencing the detector for the 2026-08-06
+    // incident class on every run.
+    //
+    // This does NOT recreate the silent pass `fetchBitdexDocuments` throws to prevent.
+    // The failure is loud on three surfaces: `stratum_failed_total{stratum="basemodel"}`
+    // (labelled, incremented at the source), `errors_total`, and `baseModelError` on the
+    // run. What it must never do is report zero mismatches with nothing to say — and it
+    // does not, because a failed stratum still emits its denominators as zero, and a
+    // zero denominator beside a zero numerator is not agreement.
+    baseModelError = e instanceof Error ? e.message : String(e);
+    // checked stays 0 and the denominators are emitted as zero below — deliberately.
+    // An ABSENT series is worse than a zero one: `increase(...) == 0` over a series that
+    // does not exist returns an empty vector, so the alert silently never fires.
     baseModel = { stratum: 'basemodel', checked: 0, mismatches: [] };
   }
   return { scheduled, publishedRecent, baseModel, baseModelError };
@@ -615,10 +653,7 @@ export const auditBitdexConsistency = createJob(
     // cannot say WHICH stratum died — and `runs_total` still ticks, correctly, because
     // the run did complete for the other two. The labelled series is the one an alert
     // can use to notice that this stratum has been dead for a week.
-    if (result.baseModelError) {
-      bitdexAuditErrorsCounter?.inc();
-      bitdexAuditStratumFailedCounter?.inc({ stratum: 'basemodel' }, 1);
-    }
+    if (result.baseModelError) bitdexAuditErrorsCounter?.inc();
 
     const durationSec = (Date.now() - start) / 1000;
 
@@ -653,6 +688,15 @@ export const auditBitdexConsistency = createJob(
             { stratum: scope.stratum, kind },
             scope.withDocValue ?? 0
           );
+
+        // The NUMERATOR needs seeding for the same reason the denominator does. The ratio
+        // these counts exist to enable is mismatch/opportunity, and on a healthy system
+        // the mismatch series has never been inc'd — so the division returns an empty
+        // vector and Grafana renders "No data", which is the ambiguity being fixed rather
+        // than the answer "none". Seeding with zero costs nothing and makes the healthy
+        // case read as zero.
+        for (const kind of BASEMODEL_KINDS)
+          bitdexAuditMismatchCounter?.inc({ stratum: scope.stratum, kind }, 0);
       }
     }
 

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -48,12 +48,21 @@ const DEFAULT_SETTLE_SECS = 120;
 // the same fact, and disagreement between the two would itself be a finding.
 const AUDIT_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'sortAt'];
 
+// The baseModel stratum still needs the publication pair, because a document that is
+// absent or unpublished is stratum B's finding and must not be re-reported here.
+const BASEMODEL_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'baseModel'];
+
 // Cap on mismatch rows written to Axiom per run. The counters carry the rate; the log
 // only has to carry enough ids to start an investigation.
 const MAX_LOGGED_MISMATCHES = 25;
 
-export type AuditStratum = 'scheduled' | 'published_recent';
-export type MismatchKind = 'scheduled_visible' | 'published_missing' | 'sortat_drift';
+export type AuditStratum = 'scheduled' | 'published_recent' | 'basemodel';
+export type MismatchKind =
+  | 'scheduled_visible'
+  | 'published_missing'
+  | 'sortat_drift'
+  | 'basemodel_not_checkpoint'
+  | 'basemodel_missing';
 
 function parsePositiveInt(raw: string | undefined, fallback: number): number {
   const n = parseInt(raw ?? '', 10);
@@ -95,6 +104,11 @@ export type AuditSampleRow = {
   // publishedAt and existedAt (= max(scannedAt, createdAt)). Computed in PG so the
   // audit compares against the same GREATEST semantics rather than reimplementing them.
   expectedSortAtSecs: number;
+  // Distinct baseModels of the image's CHECKPOINT resources. Only the baseModel stratum
+  // selects it; a set rather than a scalar because an image can carry more than one
+  // checkpoint, and because the comparison is membership — which resource supplied the
+  // value is the whole question, and ordering is not.
+  expectedBaseModels?: string[] | null;
 };
 
 // Stratum A — the incident class. Images whose parent Post is scheduled to publish in
@@ -147,29 +161,74 @@ export function buildPublishedSampleQuery({
   `;
 }
 
+// Stratum C — what the two base-model filter reports were about (868ktxe1r, 868ku8x8k).
+// BitDex's `baseModel` decides whether an image matches `In(baseModel, [...])`, and the
+// two reported failures were the two directions of it being wrong: a value taken from an
+// attached LoRA rather than the checkpoint, so a Pony filter served an Illustrious image;
+// and no value at all on a fresh document, so a recent image matched no filter.
+//
+// Truth here is the CHECKPOINT-only derivation, which is what the Meilisearch index
+// builds (`CASE WHEN m.type = 'Checkpoint' THEN mv."baseModel"`, metrics-images.search-index.ts).
+// An image with no checkpoint resource legitimately has no base model, and that is a
+// distinct case rather than a missing one — see `compareStratum`.
+export function buildBaseModelSampleQuery({
+  sampleSize,
+  publishedWindowSecs,
+  settleSecs,
+}: Pick<AuditConfig, 'sampleSize' | 'publishedWindowSecs' | 'settleSecs'>): Prisma.Sql {
+  return Prisma.sql`
+    SELECT
+      i.id AS "imageId",
+      p.id AS "postId",
+      extract(epoch FROM p."publishedAt")::double precision AS "publishedAtSecs",
+      extract(epoch FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt"))::double precision
+        AS "expectedSortAtSecs",
+      COALESCE((
+        SELECT array_agg(DISTINCT mv."baseModel")
+        FROM "ImageResourceNew" irn
+        JOIN "ModelVersion" mv ON mv.id = irn."modelVersionId"
+        JOIN "Model" m ON m.id = mv."modelId"
+        WHERE irn."imageId" = i.id AND m.type = 'Checkpoint' AND mv."baseModel" IS NOT NULL
+      ), '{}') AS "expectedBaseModels"
+    FROM "Post" p
+    JOIN "Image" i ON i."postId" = p.id
+    WHERE p."publishedAt" > now() - make_interval(secs => ${publishedWindowSecs})
+      AND p."publishedAt" <= now()
+      AND p."updatedAt" < now() - make_interval(secs => ${settleSecs})
+    ORDER BY random()
+    LIMIT ${sampleSize}
+  `;
+}
+
 export type BitdexDocState = {
   // False when BitDex returned no row, or a bare `{ id }` — the batch endpoint's
   // encoding for "no document on disk for this slot".
   present: boolean;
   published: boolean;
   sortAtSecs: number | null;
+  // Empty string is the index's own "no checkpoint" encoding — the Meili side builds the
+  // value with `string_agg`, which yields '' rather than null when nothing matches. Both
+  // spellings mean the same thing here, so they collapse to null.
+  baseModel: string | null;
 };
 
 // Reads BitDex's answer out of a doc payload. isPublished is the authority when the
 // key is present; publishedAt is the fallback, because the index derives isPublished
 // from it via exists_boolean and the two carry the same fact.
 export function readDocState(doc: BitdexDocument | undefined): BitdexDocState {
-  if (!doc) return { present: false, published: false, sortAtSecs: null };
+  if (!doc) return { present: false, published: false, sortAtSecs: null, baseModel: null };
 
   const isPublished = doc.isPublished;
   const publishedAt = doc.publishedAt;
   const sortAt = doc.sortAt;
+  const baseModel = doc.baseModel;
   const present = isPublished !== undefined || publishedAt !== undefined || sortAt !== undefined;
 
   return {
     present,
     published: typeof isPublished === 'boolean' ? isPublished : publishedAt != null,
     sortAtSecs: typeof sortAt === 'number' ? sortAt : null,
+    baseModel: typeof baseModel === 'string' && baseModel !== '' ? baseModel : null,
   };
 }
 
@@ -199,6 +258,45 @@ export function compareStratum(
   const mismatches: AuditMismatch[] = [];
   for (const row of rows) {
     const state = readDocState(byId.get(row.imageId));
+
+    if (stratum === 'basemodel') {
+      // An absent or unpublished document is stratum B's finding. Reporting it again
+      // here would double-count one lost write as two defects in two places.
+      if (!state.present || !state.published) continue;
+
+      const expected = row.expectedBaseModels ?? [];
+
+      if (state.baseModel == null) {
+        // No checkpoint on the image means no base model is the CORRECT answer, so this
+        // arm can only fire where PG has one. That is also why the run reports how many
+        // sampled images had a checkpoint at all — see `baseModelDenominators`.
+        if (expected.length) {
+          mismatches.push({
+            stratum,
+            kind: 'basemodel_missing',
+            imageId: row.imageId,
+            postId: row.postId,
+            expected: `one of [${expected.join(', ')}]`,
+            actual: 'no baseModel on the document',
+          });
+        }
+        continue;
+      }
+
+      if (!expected.includes(state.baseModel)) {
+        mismatches.push({
+          stratum,
+          kind: 'basemodel_not_checkpoint',
+          imageId: row.imageId,
+          postId: row.postId,
+          expected: expected.length
+            ? `one of [${expected.join(', ')}]`
+            : 'no baseModel (image has no checkpoint resource)',
+          actual: `baseModel=${state.baseModel}`,
+        });
+      }
+      continue;
+    }
 
     if (stratum === 'scheduled') {
       // A doc that is absent, or present and unpublished, is the correct state — a
@@ -252,7 +350,34 @@ export type AuditScopeResult = {
   stratum: AuditStratum;
   checked: number;
   mismatches: AuditMismatch[];
+  // Only the baseModel stratum sets these. `checked` alone cannot tell a clean run from
+  // one that compared nothing: documents that are absent or unpublished are skipped, and
+  // the `basemodel_missing` arm can only fire on an image that HAS a checkpoint. A zero
+  // beside a zero denominator is not evidence of agreement.
+  comparedDocs?: number;
+  withCheckpoint?: number;
 };
+
+/**
+ * The denominators the baseModel stratum's zero has to be read against: how many sampled
+ * images BitDex held as published documents at all, and how many of those PG says have a
+ * checkpoint. Separate from `compareStratum` so both numbers exist whether or not any
+ * mismatch was found.
+ */
+export function baseModelDenominators(rows: AuditSampleRow[], docs: BitdexDocument[]) {
+  const byId = new Map<number, BitdexDocument>();
+  for (const doc of docs) byId.set(doc.id, doc);
+
+  let comparedDocs = 0;
+  let withCheckpoint = 0;
+  for (const row of rows) {
+    const state = readDocState(byId.get(row.imageId));
+    if (!state.present || !state.published) continue;
+    comparedDocs++;
+    if ((row.expectedBaseModels ?? []).length) withCheckpoint++;
+  }
+  return { comparedDocs, withCheckpoint };
+}
 
 // Samples one stratum and compares it. A BitDex fetch failure propagates:
 // fetchBitdexDocuments throws rather than returning null precisely so an unreachable
@@ -260,7 +385,8 @@ export type AuditScopeResult = {
 async function auditStratum(
   stratum: AuditStratum,
   query: Prisma.Sql,
-  config: AuditConfig
+  config: AuditConfig,
+  docFields: string[] = AUDIT_DOC_FIELDS
 ): Promise<AuditScopeResult> {
   // Primary, not the replica: this job's whole output is "PG and BitDex disagree",
   // and replica lag would manufacture exactly that disagreement. 100 sampled rows
@@ -272,29 +398,37 @@ async function auditStratum(
   const docs = await fetchBitdexDocuments(
     BITDEX_INDEX,
     rows.map((r) => r.imageId),
-    AUDIT_DOC_FIELDS
+    docFields
   );
 
-  return { stratum, checked: rows.length, mismatches: compareStratum(stratum, rows, docs, config) };
+  return {
+    stratum,
+    checked: rows.length,
+    mismatches: compareStratum(stratum, rows, docs, config),
+    ...(stratum === 'basemodel' ? baseModelDenominators(rows, docs) : {}),
+  };
 }
 
 export type AuditResult = {
   scheduled: AuditScopeResult;
   publishedRecent: AuditScopeResult;
+  baseModel: AuditScopeResult;
 };
 
 export async function runAudit(config: AuditConfig): Promise<AuditResult> {
-  const scheduled = await auditStratum(
-    'scheduled',
-    buildScheduledSampleQuery(config),
-    config
-  );
+  const scheduled = await auditStratum('scheduled', buildScheduledSampleQuery(config), config);
   const publishedRecent = await auditStratum(
     'published_recent',
     buildPublishedSampleQuery(config),
     config
   );
-  return { scheduled, publishedRecent };
+  const baseModel = await auditStratum(
+    'basemodel',
+    buildBaseModelSampleQuery(config),
+    config,
+    BASEMODEL_DOC_FIELDS
+  );
+  return { scheduled, publishedRecent, baseModel };
 }
 
 export const auditBitdexConsistency = createJob(
@@ -316,7 +450,7 @@ export const auditBitdexConsistency = createJob(
     }
     const durationSec = (Date.now() - start) / 1000;
 
-    const scopes = [result.scheduled, result.publishedRecent];
+    const scopes = [result.scheduled, result.publishedRecent, result.baseModel];
     for (const scope of scopes) {
       bitdexAuditCheckedCounter?.inc({ stratum: scope.stratum }, scope.checked);
       for (const mismatch of scope.mismatches)
@@ -339,6 +473,12 @@ export const auditBitdexConsistency = createJob(
         scheduledMismatches: result.scheduled.mismatches.length,
         publishedChecked: result.publishedRecent.checked,
         publishedMismatches: result.publishedRecent.mismatches.length,
+        baseModelChecked: result.baseModel.checked,
+        // The two denominators the baseModel zero must be read against: sampling 50 rows
+        // and comparing none of them reports the same mismatch count as full agreement.
+        baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
+        baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
+        baseModelMismatches: result.baseModel.mismatches.length,
         // Ids and expected-vs-actual, so a firing alert has a trail to pull on
         // instead of only a rate.
         mismatches: allMismatches.slice(0, MAX_LOGGED_MISMATCHES),
@@ -355,9 +495,13 @@ export const auditBitdexConsistency = createJob(
       scheduledMismatches: result.scheduled.mismatches.length,
       publishedChecked: result.publishedRecent.checked,
       publishedMismatches: result.publishedRecent.mismatches.length,
+      baseModelChecked: result.baseModel.checked,
+      baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
+      baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
+      baseModelMismatches: result.baseModel.mismatches.length,
       durationSec,
     };
   },
-  // Two sampled queries + one batch doc fetch; keep the single-runner lock short.
+  // Three sampled queries + a batch doc fetch each; keep the single-runner lock short.
   { lockExpiration: 5 * 60 }
 );

--- a/src/server/jobs/audit-bitdex-consistency.ts
+++ b/src/server/jobs/audit-bitdex-consistency.ts
@@ -6,6 +6,8 @@ import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
   bitdexAuditCheckedCounter,
+  bitdexAuditComparedCounter,
+  bitdexAuditOpportunityCounter,
   bitdexAuditErrorsCounter,
   bitdexAuditMismatchCounter,
   bitdexAuditRunDurationHistogram,
@@ -45,22 +47,34 @@ const DEFAULT_SETTLE_SECS = 120;
 // Stratum C's belt, and it is wider than the others for a reason that is NOT caution.
 // The other two compare publication state, which lives on `Post`, so `Post."updatedAt"`
 // moves with the thing they measure. This one compares a value derived from
-// `ImageResourceNew`, and `addResourceToImages` (post.service.ts) inserts those rows
-// WITHOUT touching `Post."updatedAt"` — so for a resource edit the belt is watching a
-// timestamp that never moved, and a wider window only shrinks the overlap with the
-// index's sync lag rather than closing it. A mismatch on a just-edited image is a known
-// false positive here; the row prints both sides so it can be recognised as one.
+// `ImageResourceNew`, which `addResourceToImages` (post.service.ts) writes without
+// touching `Post."updatedAt"` — so the query bounds `Image."updatedAt"` as well.
+//
+// ⚠️ That is a reduction, NOT a closure, and the residual is the same order of magnitude
+// as the false-mismatch class this stratum's comparison rule was written to remove.
+// Measured on the prod replica over this stratum's population (posts published in the
+// last 24h, past a 15-minute belt): 90.2% of images carry an `Image."updatedAt"` later
+// than their post's, and 0.28% were modified INSIDE the belt window. `ImageResourceNew`
+// carries no timestamp of its own, so a resource edit that moves neither row is
+// unbounded and unmeasurable after the fact. A mismatch on a just-edited image is a
+// known false positive here; the row prints both sides so it can be recognised as one.
 const DEFAULT_BASEMODEL_SETTLE_SECS = 15 * 60;
 
-// Doc fields the comparison reads. publishedAt is fetched alongside isPublished
-// because isPublished is an exists_boolean derived FROM publishedAt in the index
-// config: if the boolean is ever absent from a doc payload, publishedAt still carries
-// the same fact, and disagreement between the two would itself be a finding.
+// Doc fields the comparison reads.
+//
+// ⚠️ `publishedAt` is requested but is NOT a document field: the metrics indexer
+// destructures it out of the record and emits `publishedAtUnix` instead
+// (metrics-images.search-index.ts). So the "publishedAt carries the same fact if the
+// boolean is missing" fallback this list used to claim is inert, and `sortAt` is the
+// only independent witness that a document exists at all. Keep it in every field list
+// for that reason, not for the value.
 const AUDIT_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'sortAt'];
 
-// The baseModel stratum still needs the publication pair, because a document that is
-// absent or unpublished is stratum B's finding and must not be re-reported here.
-const BASEMODEL_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'baseModel'];
+// The baseModel stratum needs the publication fields too, because a document that is
+// absent or unpublished is not compared here — and it needs `sortAt` for the reason
+// above: without it, presence would rest on `isPublished` alone, and a projection that
+// omitted that one key would skip every row and report a clean stratum.
+const BASEMODEL_DOC_FIELDS = ['id', 'isPublished', 'publishedAt', 'sortAt', 'baseModel'];
 
 // Cap on mismatch rows written to Axiom per run. The counters carry the rate; the log
 // only has to carry enough ids to start an investigation.
@@ -72,7 +86,8 @@ export type MismatchKind =
   | 'published_missing'
   | 'sortat_drift'
   | 'basemodel_not_checkpoint'
-  | 'basemodel_missing';
+  | 'basemodel_missing'
+  | 'basemodel_unfilterable';
 
 function parsePositiveInt(raw: string | undefined, fallback: number): number {
   const n = parseInt(raw ?? '', 10);
@@ -212,6 +227,7 @@ export function buildBaseModelSampleQuery({
     WHERE p."publishedAt" > now() - make_interval(secs => ${publishedWindowSecs})
       AND p."publishedAt" <= now()
       AND p."updatedAt" < now() - make_interval(secs => ${baseModelSettleSecs})
+      AND i."updatedAt" < now() - make_interval(secs => ${baseModelSettleSecs})
     ORDER BY random()
     LIMIT ${sampleSize}
   `;
@@ -311,8 +327,10 @@ export function compareStratum(
     const state = readDocState(byId.get(row.imageId));
 
     if (stratum === 'basemodel') {
-      // An absent or unpublished document is stratum B's finding. Reporting it again
-      // here would double-count one lost write as two defects in two places.
+      // Not compared. Stratum B samples the same population independently and reports
+      // that class in aggregate — it is NOT handed this row, so do not read this as a
+      // deferral. It is a skip, which is why the run reports how many rows it actually
+      // compared rather than only how many it sampled.
       if (!state.present || !state.published) continue;
 
       const expected = expectedBaseModelsOf(row);
@@ -344,6 +362,29 @@ export function compareStratum(
             ? `one of [${expected.join(', ')}]`
             : 'no baseModel (image has no checkpoint resource)',
           actual: `baseModel=${state.baseModel}`,
+        });
+        continue;
+      }
+
+      // Explainable but not a single checkpoint — a glued value like `AnimaMiniMax H3`.
+      // The base-model filter is exact string equality (`_in('baseModel', …)` in
+      // image.service.ts), so a glued value matches NO filter: it is 868ku8x8k's symptom
+      // arriving by a different route, and accepting it silently is how the previous
+      // rule's fix would have hidden a real defect while removing a false one.
+      //
+      // 🔴 Its own kind on purpose, and it is NOT an alerting series: it is expected to
+      // be nonzero (measured ~0.2% of sampled images) because the index builds the value
+      // with `string_agg`. Alert on `basemodel_not_checkpoint` and `basemodel_missing`;
+      // watch this one for its RATE. Folding it into either of those would put a
+      // permanent floor under a series that has to mean something when it moves.
+      if (!expected.includes(state.baseModel)) {
+        mismatches.push({
+          stratum,
+          kind: 'basemodel_unfilterable',
+          imageId: row.imageId,
+          postId: row.postId,
+          expected: `exactly one of [${expected.join(', ')}]`,
+          actual: `baseModel=${state.baseModel} (concatenation; matches no base-model filter)`,
         });
       }
       continue;
@@ -407,6 +448,12 @@ export type AuditScopeResult = {
   // beside a zero denominator is not evidence of agreement.
   comparedDocs?: number;
   withCheckpoint?: number;
+  // Per-arm OPPORTUNITY counts: compared documents on which that arm could have fired at
+  // all. The three marginals below cannot recover these — a run that compared two
+  // documents with one checkpoint and one value between them reports the same marginals
+  // whether both arms had an opportunity or neither did.
+  missingArmOpportunities?: number;
+  leakArmOpportunities?: number;
   // The `not_checkpoint` arm's own denominator: compared documents that actually carried
   // a value to disagree about. Its zero needs this the way the `missing` arm's zero needs
   // `withCheckpoint`, and one number covering both arms would hide whichever is empty.
@@ -443,14 +490,29 @@ export function baseModelDenominators(rows: AuditSampleRow[], docs: BitdexDocume
   let comparedDocs = 0;
   let withCheckpoint = 0;
   let withDocValue = 0;
+  let missingArmOpportunities = 0;
+  let leakArmOpportunities = 0;
   for (const row of rows) {
     const state = readDocState(byId.get(row.imageId));
     if (!state.present || !state.published) continue;
     comparedDocs++;
-    if (expectedBaseModelsOf(row).length) withCheckpoint++;
-    if (state.baseModel != null) withDocValue++;
+    const hasCheckpoint = expectedBaseModelsOf(row).length > 0;
+    const hasValue = state.baseModel != null;
+    if (hasCheckpoint) withCheckpoint++;
+    if (hasValue) withDocValue++;
+    // `basemodel_missing` fires only where PG has a checkpoint AND the document has no
+    // value; `basemodel_not_checkpoint` only where the document HAS one. Each zero is
+    // read against its own count, not against the marginals.
+    if (hasCheckpoint && !hasValue) missingArmOpportunities++;
+    if (hasValue) leakArmOpportunities++;
   }
-  return { comparedDocs, withCheckpoint, withDocValue };
+  return {
+    comparedDocs,
+    withCheckpoint,
+    withDocValue,
+    missingArmOpportunities,
+    leakArmOpportunities,
+  };
 }
 
 // Samples one stratum and compares it. A BitDex fetch failure propagates:
@@ -487,6 +549,9 @@ export type AuditResult = {
   scheduled: AuditScopeResult;
   publishedRecent: AuditScopeResult;
   baseModel: AuditScopeResult;
+  // Set when the baseModel stratum threw. Its presence is the ONLY thing separating a
+  // stratum that failed from one that found nothing, since both report zero mismatches.
+  baseModelError?: string;
 };
 
 export async function runAudit(config: AuditConfig): Promise<AuditResult> {
@@ -496,13 +561,28 @@ export async function runAudit(config: AuditConfig): Promise<AuditResult> {
     buildPublishedSampleQuery(config),
     config
   );
-  const baseModel = await auditStratum(
-    'basemodel',
-    buildBaseModelSampleQuery(config),
-    config,
-    BASEMODEL_DOC_FIELDS
-  );
-  return { scheduled, publishedRecent, baseModel };
+  // Stratum C is caught SEPARATELY. It is the newest and the only one that throws on a
+  // column shape, and letting that propagate would discard the two already-computed
+  // results — no checked, no mismatch, no runs increment — so a problem in the newest
+  // stratum would silence the detector for the 2026-08-06 incident class on every run.
+  // The failure is still loud: the error counter fires and the run reports it, but C is
+  // marked failed rather than reported as clean.
+  let baseModel: AuditScopeResult;
+  let baseModelError: string | undefined;
+  try {
+    baseModel = await auditStratum(
+      'basemodel',
+      buildBaseModelSampleQuery(config),
+      config,
+      BASEMODEL_DOC_FIELDS
+    );
+  } catch (e) {
+    baseModelError = e instanceof Error ? e.message : String(e);
+    // checked stays 0 and the denominators stay undefined: a failed stratum must not
+    // contribute a zero that reads as agreement.
+    baseModel = { stratum: 'basemodel', checked: 0, mismatches: [] };
+  }
+  return { scheduled, publishedRecent, baseModel, baseModelError };
 }
 
 export const auditBitdexConsistency = createJob(
@@ -522,6 +602,10 @@ export const auditBitdexConsistency = createJob(
       bitdexAuditErrorsCounter?.inc();
       throw e; // createJob logs job-error to Axiom and marks the run failed
     }
+    // A caught stratum failure is still an error: the run continues so the other two
+    // strata keep reporting, but it must not look like a clean pass on the error series.
+    if (result.baseModelError) bitdexAuditErrorsCounter?.inc();
+
     const durationSec = (Date.now() - start) / 1000;
 
     const scopes = [result.scheduled, result.publishedRecent, result.baseModel];
@@ -529,6 +613,24 @@ export const auditBitdexConsistency = createJob(
       bitdexAuditCheckedCounter?.inc({ stratum: scope.stratum }, scope.checked);
       for (const mismatch of scope.mismatches)
         bitdexAuditMismatchCounter?.inc({ stratum: scope.stratum, kind: mismatch.kind }, 1);
+
+      // The denominators go to PROMETHEUS, not only to the Axiom line — an alert reads
+      // the series, and `checked_total` counts rows SAMPLED. A row whose document is
+      // absent or unpublished is skipped before any comparison, so without these a
+      // stratum that compared nothing emits a mismatch zero identical to one from
+      // perfect agreement, which is the whole failure this guard exists to prevent.
+      if (scope.comparedDocs !== undefined)
+        bitdexAuditComparedCounter?.inc({ stratum: scope.stratum }, scope.comparedDocs);
+      if (scope.missingArmOpportunities !== undefined)
+        bitdexAuditOpportunityCounter?.inc(
+          { stratum: scope.stratum, kind: 'basemodel_missing' },
+          scope.missingArmOpportunities
+        );
+      if (scope.leakArmOpportunities !== undefined)
+        bitdexAuditOpportunityCounter?.inc(
+          { stratum: scope.stratum, kind: 'basemodel_not_checkpoint' },
+          scope.leakArmOpportunities
+        );
     }
 
     bitdexAuditRunsCounter?.inc();
@@ -553,7 +655,12 @@ export const auditBitdexConsistency = createJob(
         baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
         baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
         baseModelWithDocValue: result.baseModel.withDocValue ?? 0,
+        baseModelMissingArmOpportunities: result.baseModel.missingArmOpportunities ?? 0,
+        baseModelLeakArmOpportunities: result.baseModel.leakArmOpportunities ?? 0,
         baseModelMismatches: result.baseModel.mismatches.length,
+        // Present only when the stratum threw. Without it a failed stratum and a clean
+        // one are the same row of zeros.
+        baseModelError: result.baseModelError,
         // Ids and expected-vs-actual, so a firing alert has a trail to pull on
         // instead of only a rate.
         mismatches: allMismatches.slice(0, MAX_LOGGED_MISMATCHES),
@@ -574,7 +681,10 @@ export const auditBitdexConsistency = createJob(
       baseModelComparedDocs: result.baseModel.comparedDocs ?? 0,
       baseModelWithCheckpoint: result.baseModel.withCheckpoint ?? 0,
       baseModelWithDocValue: result.baseModel.withDocValue ?? 0,
+      baseModelMissingArmOpportunities: result.baseModel.missingArmOpportunities ?? 0,
+      baseModelLeakArmOpportunities: result.baseModel.leakArmOpportunities ?? 0,
       baseModelMismatches: result.baseModel.mismatches.length,
+      baseModelError: result.baseModelError,
       durationSec,
     };
   },


### PR DESCRIPTION
Closes ClickUp [868kyze5d](https://app.clickup.com/t/868kyze5d). Related: [868ktxe1r](https://app.clickup.com/t/868ktxe1r) and [868ku8x8k](https://app.clickup.com/t/868ku8x8k), the two dormant defects this covers.

## Why

Both reports were the same field failing in opposite directions. BitDex's `baseModel` decides whether an image matches `In(baseModel, [...])`:

- **868ktxe1r** — the value came from **any** attached resource including LoRAs, so a Pony filter served an Illustrious-checkpoint image carrying a Pony LoRA.
- **868ku8x8k** — fresh documents carried **no** value, so a recent image matched no base-model filter at all.

Neither reproduces today: `bitdex-image-search` resolves to `off` at 100% for everyone, and every `image.getInfinite` response reports `source: "meili"`. BitDex's ingest is not in this repo, so whether it still derives the value the same way is unobservable from here — the defects are **dormant, not fixed**, and re-enabling the flag brings both back with a user noticing as the only detector.

## What this adds

A third stratum on the existing `audit-bitdex-consistency` job.

| kind | fires when | covers | alerting? |
|---|---|---|---|
| `basemodel_not_checkpoint` | value belongs to no checkpoint on the image | 868ktxe1r | yes |
| `basemodel_missing` | no value, PG has a checkpoint | 868ku8x8k | yes |
| `basemodel_unfilterable` | value is a concatenation — matches no filter | 868ku8x8k, other route | **no**, expected nonzero |

Truth is the checkpoint-only derivation. The comparison is **composability**, not membership: the Meili index builds the value with `string_agg(..., '')` — no delimiter, no DISTINCT — so a multi-checkpoint image indexes as one glued string. A set-membership test called that a mismatch at a measured **0.23%** of sampled rows (3000-row prod sample: 2566 single-checkpoint, 427 none, 7 multi), i.e. ~17 false mismatches a day forever on the exact series meant to detect the leak. `baseModelIsExplained` accepts a value that can be consumed entirely by concatenating the image's checkpoints, in any order — agnostic about whether BitDex emits one value or glues several, which matters because that derivation is the one thing we cannot observe from here.

## The denominators, which is most of what the review rounds were about

A zero mismatch count means nothing on its own, and it has to mean something **on the surface an alert reads**:

- `bitdex_audit_compared_total{stratum}` — sampled images actually compared. `checked_total` counts rows **sampled**; documents that are absent or unpublished are skipped before any comparison.
- `bitdex_audit_opportunity_total{stratum,kind}` — per-arm: `withCheckpoint` for the missing arm, `withDocValue` for the two value-side arms. Each arm's firing predicate is a strict subset of its denominator, so the ratio is bounded below 1.
- Emitted **unconditionally, including zero**. prom-client creates a labelled child on first `inc`, so skipping the call leaves the series *absent*, and `increase(...) == 0` over an absent series returns an empty vector — the alert silently never fires. The numerator is seeded the same way, or the ratio renders as "No data" on a healthy system.
- `bitdex_audit_stratum_failed_total{stratum}` — incremented **at the source**, so it fires however a stratum dies rather than only for the one class the caller catches.

## Verification

**Against production, read-only:** the sample query runs (50 rows, ~490ms on the replica at the 15-minute settle), and on image `140085888` — the leak support found by hand — it returns `['SDXL 1.0']` against the document's `'Pony'`, the exact row this stratum raises.

**Mutants, each failing by name**, across five review rounds: both arms silenced; the `Checkpoint` predicate dropped; the default doc field set requested (which would read clean forever); the denominators counting every sampled row; membership restored in place of composability; the window and settle arguments swapped **inside this builder**; the denominator spread deleted; the loud accessor defaulting; the unfilterable arm silenced; `sortAt` dropped; the numerator seeding removed; the accumulators swapped; and both denominators wired to the wrong quantity.

**Chain:** typecheck 0 errors. Lint — repo-wide already red on this base; zero lines naming any of the three files, verified against a positive control that finds other files in the same log. Full suite `Test Files 4 failed | 1523 passed | 2 skipped (1529)`, `Tests 10 failed | 24112 passed | 28 skipped (24150)`; the same 4 files / 10 tests fail on a clean base.

## Two things worth reading before changing this

🔑 **A guard whose observable half is a log line is not tested by asserting what the function returns.** One mutant survived until the test asserted on the Axiom payload *as well as* the return value — separate call sites.

🔑 **A fixture where every quantity equals 1 cannot catch a denominator wired to the wrong quantity.** Two mutants stayed alive through a fix round for exactly that reason. The prometheus fixture now makes `checked` 4, `comparedDocs` 3, `withCheckpoint` 2, `withDocValue` 1 — deliberately all different.

## A review finding NOT taken

Dropping `publishedAt` from `AUDIT_DOC_FIELDS` / `BASEMODEL_DOC_FIELDS` as a dead branch. The evidence that it is never emitted is about the **Meili** indexer; these strata read **BitDex** documents, whose shape is not in this repo. Removing a witness on evidence about a different system is not a cleanup. The edit was started and reverted; the comment now says why.

## Note

The job stays gated behind `bitdex-consistency-audit` and stays read-only — it never emits ops and never heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FrqGiMk5qMSj6i2WRd3ai