### PR TITLE
fix(creator-program): clamp forecast to banked value after deposit deadl

### DIFF
--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -115,6 +115,7 @@ import {
   joinCreatorsProgram,
   withdrawCash,
 } from '~/server/services/creator-program.service';
+import { getCurrentValue, getForecastedValue } from '~/server/utils/creator-program.utils';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 // Globally stubbed in `src/__tests__/setup.ts` — imported here only to drive its rejection.
@@ -605,6 +606,52 @@ describe('getCompensationPool', () => {
     expect(result.phases).toBeDefined();
     expect(result.phases.bank).toBeDefined();
     expect(result.phases.extraction).toBeDefined();
+  });
+
+  it('clamps forecasted size to current once the banking deadline has passed', async () => {
+    // System time is pinned to 2026-04-15; the 2025-04 cycle's banking phase is long closed.
+    // getPoolForecast halves the raw balance (CREATOR_POOL_FORECAST_PORTION=50): 4M -> 2M > 1M current.
+    // Pool value is kept small (5k -> $400 after taxes/portion) so the per-buzz value stays under the
+    // $1/1000 cap — otherwise both projections pin to the cap and the closing-condition assertion below
+    // can't tell clamped from unclamped.
+    mockClickhouse.$query
+      .mockResolvedValueOnce([{ balance: 5000 }]) // pool value -> $400, below the cap at this size
+      .mockResolvedValueOnce([{ balance: 4000000 }]); // pool forecast -> 2M, above current
+    mockGetUserBuzzAccount.mockResolvedValueOnce([{ balance: 1000000 }]); // pool size (current)
+
+    const pool = await getCompensationPool({ month: new Date('2025-04-01') });
+
+    expect(pool.size.current).toBe(1000000);
+    expect(pool.size.forecasted).toBe(1000000);
+    // Closing condition: after the deposit deadline the forecast can't fall below the banked value.
+    // Reverting the clamp (forecasted stays 2M) drops the forecast to $200 vs the current $400 and fails.
+    const banked = pool.size.current;
+    expect(getForecastedValue(banked, pool)).toBeGreaterThanOrEqual(getCurrentValue(banked, pool));
+  });
+
+  it('leaves forecasted size untouched during the banking phase', async () => {
+    // 2026-04 cycle: banking runs 1st–27th and the pinned clock is the 15th, so it's still open.
+    mockClickhouse.$query
+      .mockResolvedValueOnce([{ balance: 50000 }]) // pool value
+      .mockResolvedValueOnce([{ balance: 4000000 }]); // pool forecast -> 2M, above current
+    mockGetUserBuzzAccount.mockResolvedValueOnce([{ balance: 1000000 }]); // pool size (current)
+
+    const pool = await getCompensationPool({ month: new Date('2026-04-01') });
+
+    expect(pool.size.forecasted).toBe(2000000);
+  });
+
+  it('leaves forecasted untouched on the cached (no-month) path before the deadline', async () => {
+    // No month -> cached current-month path; the April 2026 banking window is still open on the pinned clock.
+    mockClickhouse.$query
+      .mockResolvedValueOnce([{ balance: 50000 }]) // pool value
+      .mockResolvedValueOnce([{ balance: 4000000 }]); // pool forecast -> 2M, above current
+    mockGetUserBuzzAccount.mockResolvedValueOnce([{ balance: 1000000 }]); // pool size (current)
+
+    const pool = await getCompensationPool({});
+
+    expect(pool.size.current).toBe(1000000);
+    expect(pool.size.forecasted).toBe(2000000);
   });
 
   it('uses cache for current month queries', async () => {

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -375,17 +375,34 @@ async function getPoolForecast(month?: Date) {
   return result.balance * (env.CREATOR_POOL_FORECAST_PORTION / 100);
 }
 
+function isBankingClosed(phases: ReturnType<typeof getPhases>) {
+  return dayjs.utc().isAfter(dayjs.utc(phases.bank[1]));
+}
+
+// After the deadline no new Buzz can be banked, so the pool can only shrink; the forecasted size
+// can't exceed current, keeping every derived forecast at or above the banked value.
+function clampForecastAfterBankingDeadline(
+  size: { current: number; forecasted: number },
+  phases: ReturnType<typeof getPhases>
+) {
+  if (!isBankingClosed(phases)) return size;
+  return { ...size, forecasted: Math.min(size.forecasted, size.current) };
+}
+
 export async function getCompensationPool({ month }: CompensationPoolInput = {}) {
   if (month) {
     // Skip caching if fetching specific month
+    const phases = getPhases({ month, flip: (await getFlippedPhaseStatus()) === 'true' });
     return {
       value: await getPoolValue(month),
-      size: {
-        current: await getPoolSize(month),
-        forecasted: await getPoolForecast(month),
-      },
-
-      phases: getPhases({ month, flip: (await getFlippedPhaseStatus()) === 'true' }),
+      size: clampForecastAfterBankingDeadline(
+        {
+          current: await getPoolSize(month),
+          forecasted: await getPoolForecast(month),
+        },
+        phases
+      ),
+      phases,
     };
   }
 
@@ -404,14 +421,13 @@ export async function getCompensationPool({ month }: CompensationPoolInput = {})
     { ttl: CacheTTL.day }
   );
 
+  // TODO: Remove flip when we're ready to go live
+  const phases = getPhases({ flip: (await getFlippedPhaseStatus()) === 'true' });
+
   return {
     value,
-    size: {
-      current,
-      forecasted,
-    },
-    // TODO: Remove flip when we're ready to go live
-    phases: getPhases({ flip: (await getFlippedPhaseStatus()) === 'true' }),
+    size: clampForecastAfterBankingDeadline({ current, forecasted }, phases),
+    phases,
   };
 }
 
@@ -469,7 +485,7 @@ export async function bankBuzz(userId: number, amount: number, buzzType: BuzzSpe
 
   // TODO: Remove flip when we're ready to go live
   const phases = getPhases({ flip: (await getFlippedPhaseStatus()) === 'true' });
-  if (new Date() > phases.bank[1]) throw new Error('Banking phase is closed');
+  if (isBankingClosed(phases)) throw new Error('Banking phase is closed');
 
   // Adjust to not exceed cap (unified cap across all buzz types)
   const banked = await getBanked(userId);


### PR DESCRIPTION
After the banking deadline passes, no additional Buzz can be deposited into the
compensation pool. Extraction becomes the only remaining downward pressure, and
extraction fees disincentivize large withdrawals. The forecasted pool size should
therefore never display lower than the currently banked value, as it represents
a ceiling on what remains available.

This commit adds isBankingClosed() and clampForecastAfterBankingDeadline()
utilities that apply the floor constraint to both the month-specific and cached
query paths in getCompensationPool(). The clamping is applied only after the
banking deadline has passed; forecasts during the active banking window remain
unaffected. Three new tests verify the behavior: forecasts are clamped
post-deadline, left untouched during the banking phase, and untouched on the
cached path before the deadline.

Closing condition: after the deposit deadline, the displayed forecast cannot
be lower than the currently banked value. Verified via new test cases covering
all three paths.

Refs: 868kyuh4m