### PR TITLE
fix(licensing): a model type change left the old per-image fee on its versions

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql
@@ -1,0 +1,36 @@
+-- Applied by hand. This repo does not run `prisma migrate deploy`.
+--
+-- Clears ModelVersion."licensingSourceVersionId" where the stored source is no longer a valid
+-- licensing root for that version: no LicensingRoot row for it, its baseModel differs from the
+-- version's, or its modelType differs from the type of the Model the version now lives on.
+--
+-- Such a row charges the ROOT owner's per-image licence fee to everyone who generates with the
+-- derivative, on a line labelled with the derivative's own name, and no surface on the site can
+-- clear it. The predicate below is the same rule upsertModelVersionHandler already coerces against,
+-- so every row it touches is one the application would refuse to write today.
+--
+-- Scoped to versions created on or after the LicensingRoot table's own rows (2026-07-15 21:56:17
+-- UTC). Versions older than that predate the table, when a retired picker may legitimately have
+-- offered a checkpoint's root to a non-Checkpoint version — clearing one of those would take income
+-- from a creator who chose to earn it. 23 such rows are deliberately left alone for a human call.
+--
+-- Measured on prod 2026-08-31: 52 rows fail the predicate, 29 of them on or after the cutoff
+-- (22 LORA, 1 Other, 1 ComfyWorkflows, 5 Checkpoints whose baseModel no longer matches their root).
+--
+-- Idempotent: re-running it matches nothing new.
+--
+-- `updatedAt` is deliberately NOT bumped — this repairs a field the owner never set, and bumping it
+-- would surface every touched version as freshly updated. The caches this bypasses are cleared with
+-- POST /api/v1/model-versions/bust-cache (moderator-scoped) for each affected id afterwards.
+UPDATE "ModelVersion" mv
+SET "licensingSourceVersionId" = NULL
+WHERE mv."licensingSourceVersionId" IS NOT NULL
+  AND mv."createdAt" >= TIMESTAMPTZ '2026-07-15 21:56:17+00'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "LicensingRoot" lr
+    JOIN "Model" m ON m.id = mv."modelId"
+    WHERE lr."modelVersionId" = mv."licensingSourceVersionId"
+      AND lr."baseModel" = mv."baseModel"
+      AND lr."modelType" = m."type"
+  );

--- a/packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql
@@ -19,13 +19,19 @@
 --
 -- Idempotent: re-running it matches nothing new.
 --
--- `updatedAt` is deliberately NOT bumped — this repairs a field the owner never set, and bumping it
--- would surface every touched version as freshly updated. The caches this bypasses are cleared with
--- POST /api/v1/model-versions/bust-cache (moderator-scoped) for each affected id afterwards.
+-- `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC wall-clock, so the bound is
+-- written as TIMESTAMP, not TIMESTAMPTZ. A TIMESTAMPTZ literal is resolved through the APPLYING
+-- SESSION's TimeZone, which is unpinned when a human runs this by hand — and the boundary is the one
+-- thing this migration has to get exactly right.
+--
+-- Raw SQL does not fire Prisma's `@updatedAt`, so the repaired rows keep their timestamps and do not
+-- all surface as freshly updated at once. That also means nothing invalidates the caches the fee is
+-- read from: run POST /api/v1/model-versions/bust-cache (moderator-scoped) for each affected id
+-- after applying. The application path does its own bust, one owner save at a time.
 UPDATE "ModelVersion" mv
 SET "licensingSourceVersionId" = NULL
 WHERE mv."licensingSourceVersionId" IS NOT NULL
-  AND mv."createdAt" >= TIMESTAMPTZ '2026-07-15 21:56:17+00'
+  AND mv."createdAt" >= TIMESTAMP '2026-07-15 21:56:17'
   AND NOT EXISTS (
     SELECT 1
     FROM "LicensingRoot" lr

--- a/packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql
@@ -1,33 +1,24 @@
--- Applied by hand. This repo does not run `prisma migrate deploy`.
---
 -- Clears ModelVersion."licensingSourceVersionId" where the stored source is no longer a valid
 -- licensing root for that version: no LicensingRoot row for it, its baseModel differs from the
 -- version's, or its modelType differs from the type of the Model the version now lives on.
 --
 -- Such a row charges the ROOT owner's per-image licence fee to everyone who generates with the
--- derivative, on a line labelled with the derivative's own name, and no surface on the site can
--- clear it. The predicate below is the same rule upsertModelVersionHandler already coerces against,
--- so every row it touches is one the application would refuse to write today.
+-- derivative, on a line labelled with the derivative's own name. upsertModelVersionHandler coerces
+-- this same predicate, but only on the owner's next save of that version, which may never come --
+-- hence this one-shot repair. Every row it touches is one the app would refuse to write today.
 --
--- Scoped to versions created on or after the LicensingRoot table's own rows (2026-07-15 21:56:17
--- UTC). Versions older than that predate the table, when a retired picker may legitimately have
--- offered a checkpoint's root to a non-Checkpoint version — clearing one of those would take income
--- from a creator who chose to earn it. 23 such rows are deliberately left alone for a human call.
+-- Scoped to versions created on or after the LicensingRoot table's first rows (2026-07-15 21:56:17
+-- UTC). Older versions predate the table, when a retired picker may legitimately have offered a
+-- checkpoint's root to a non-Checkpoint version -- clearing one takes income from a creator who
+-- chose to earn it. Measured on prod 2026-08-31: 29 rows in scope, 23 older ones left alone
+-- pending Justin's decision, tracked on CU 868kwf2fd.
 --
--- Measured on prod 2026-08-31: 52 rows fail the predicate, 29 of them on or after the cutoff
--- (22 LORA, 1 Other, 1 ComfyWorkflows, 5 Checkpoints whose baseModel no longer matches their root).
+-- `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC, so the bound must be a
+-- TIMESTAMP literal -- a TIMESTAMPTZ one resolves through the applying session's unpinned TimeZone.
 --
--- Idempotent: re-running it matches nothing new.
---
--- `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC wall-clock, so the bound is
--- written as TIMESTAMP, not TIMESTAMPTZ. A TIMESTAMPTZ literal is resolved through the APPLYING
--- SESSION's TimeZone, which is unpinned when a human runs this by hand — and the boundary is the one
--- thing this migration has to get exactly right.
---
--- Raw SQL does not fire Prisma's `@updatedAt`, so the repaired rows keep their timestamps and do not
--- all surface as freshly updated at once. That also means nothing invalidates the caches the fee is
--- read from: run POST /api/v1/model-versions/bust-cache (moderator-scoped) for each affected id
--- after applying. The application path does its own bust, one owner save at a time.
+-- Raw SQL does not fire Prisma's `@updatedAt`, so nothing invalidates the caches the fee is read
+-- from. POST the repaired ids to /api/v1/model-versions/bust-cache as one `versionIds` array (max
+-- 500) after applying, as a moderator -- a non-moderator session only busts its own versions.
 UPDATE "ModelVersion" mv
 SET "licensingSourceVersionId" = NULL
 WHERE mv."licensingSourceVersionId" IS NOT NULL

--- a/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
+++ b/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// upsertModel must re-check its versions' licensing lineage when the model's TYPE changes.
+// A version inherits a per-image licence fee from a LicensingRoot, every root is a Checkpoint, and
+// the type stays editable after the versions exist — so a version stamped while the model was a
+// Checkpoint went on charging that checkpoint's fee once the model became a LoRA (CU 868kwf2fd).
+// model.service.ts has a very large import graph, so its transitive dependencies are stubbed below;
+// the scaffold mirrors model-locked-properties.service.test.ts.
+
+const { mockEvaluateContent, mockThrowOnBlockedLinkDomain, mockGetHighestTierSubscription } =
+  vi.hoisted(() => ({
+    mockEvaluateContent: vi.fn(),
+    mockThrowOnBlockedLinkDomain: vi.fn(),
+    mockGetHighestTierSubscription: vi.fn(),
+  }));
+
+vi.mock('~/libs/profanity-simple', () => ({
+  createProfanityFilter: () => ({ evaluateContent: mockEvaluateContent }),
+}));
+
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  preventReplicationLag: vi.fn(),
+  getDbWithoutLag: vi.fn(async () => mockDbRead),
+  preventModelVersionLagBatch: vi.fn(),
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null, Tracker: class {} }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(() => false), FLIPT_FEATURE_FLAGS: {} }));
+vi.mock('~/server/metrics', () => ({ modelMetrics: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { refresh: vi.fn() },
+  modelTagCache: { refresh: vi.fn() },
+  modelVotableTagsCache: { bust: vi.fn() },
+  userBasicCache: {},
+  userModelCountCache: { refresh: vi.fn() },
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/auction.service', () => ({
+  deleteBidsForModel: vi.fn(),
+  getLastAuctionReset: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: mockThrowOnBlockedLinkDomain,
+}));
+vi.mock('~/server/services/collection.service', () => ({
+  getAvailableCollectionItemsFilterForUser: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  saveItemInCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn(),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getUnavailableResources: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: {},
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(() => Promise.resolve()),
+  bustPublicModelResponseCache: vi.fn(),
+  createModelVersionPostFromTraining: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/moderator.service', () => ({ trackModActivity: vi.fn() }));
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getHighestTierSubscription: mockGetHighestTierSubscription,
+}));
+vi.mock('~/server/services/system-cache', () => ({ getCategoryTags: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn(),
+  getProfilePicturesForUsers: vi.fn(),
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  bustFetchThroughCache: vi.fn(),
+  fetchThroughCache: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
+
+import { upsertModel } from '~/server/services/model.service';
+import type { ModelUpsertInput } from '~/server/schema/model.schema';
+import { ModelStatus, ModelType, ModelUploadType } from '~/shared/utils/prisma/enums';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+const mockDbRead = dbMock.dbRead;
+const mockDbWrite = dbMock.dbWrite;
+
+const OWNER_ID = 101;
+const MODEL_ID = 42;
+const VERSION_ID = 3144879;
+const ANIMA_ROOT_VERSION_ID = 2945208;
+
+const storedModel = {
+  name: 'Test Model',
+  description: 'A description',
+  poi: false,
+  userId: OWNER_ID,
+  minor: false,
+  sfwOnly: false,
+  nsfw: false,
+  lockedProperties: [] as string[],
+  gallerySettings: { level: 1, users: [] as number[], tags: [] as number[] },
+  meta: null as Record<string, unknown> | null,
+  type: ModelType.Checkpoint,
+};
+
+const entityChanges = vi.fn(() => Promise.resolve());
+
+function upsert(input: Partial<ModelUpsertInput> & { userId: number }) {
+  return upsertModel({
+    name: 'Test Model',
+    description: 'A description',
+    uploadType: ModelUploadType.Created,
+    status: ModelStatus.Draft,
+    tracker: { entityChanges } as never,
+    ...input,
+  } as Parameters<typeof upsertModel>[0]);
+}
+
+function stampedVersions(
+  rows: { id: number; baseModel: string; licensingSourceVersionId: number }[]
+) {
+  mockDbWrite.modelVersion.findMany.mockResolvedValue(rows);
+}
+
+function licensingRoots(
+  rows: { modelVersionId: number; baseModel: string; modelType: ModelType }[]
+) {
+  mockDbWrite.licensingRoot.findMany.mockResolvedValue(rows);
+}
+
+/** Only the ModelVersion rows — the Model-level tracker call always fires, empty or not. */
+function versionAuditRows() {
+  return entityChanges.mock.calls
+    .flatMap((call) => call[0] as Record<string, unknown>[])
+    .filter((row) => row.entityType === 'ModelVersion');
+}
+
+function clearCall() {
+  return mockDbWrite.modelVersion.updateMany.mock.calls[0]?.[0] as
+    | { where: { id: { in: number[] } }; data: Record<string, unknown> }
+    | undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEvaluateContent.mockReturnValue({
+    shouldMarkNSFW: false,
+    reason: 'No profanity detected',
+    suggestedLevel: 1,
+    metrics: { matchCount: 0, uniqueWords: 0, totalWords: 2, density: 0 },
+    matchedWords: [] as string[],
+  });
+  mockGetHighestTierSubscription.mockResolvedValue({ tier: 'gold' });
+  mockDbRead.model.findUnique.mockResolvedValue(storedModel);
+  mockDbRead.model.count.mockResolvedValue(0);
+  mockDbWrite.$queryRaw.mockResolvedValue([]);
+  stampedVersions([]);
+  licensingRoots([]);
+  mockDbWrite.model.update.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+    Promise.resolve({
+      id: MODEL_ID,
+      name: 'Test Model',
+      description: 'A description',
+      nsfwLevel: 1,
+      poi: false,
+      minor: false,
+      sfwOnly: false,
+      nsfw: false,
+      gallerySettings: { level: 1, users: [], tags: [] },
+      status: ModelStatus.Draft,
+      meta: null,
+      availability: 'Public',
+      ...data,
+      modelVersions: [],
+    })
+  );
+});
+
+describe('upsertModel — licensing lineage on a model type change', () => {
+  it('clears a checkpoint root off the versions when the model becomes a LoRA', async () => {
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+    ]);
+    licensingRoots([
+      {
+        modelVersionId: ANIMA_ROOT_VERSION_ID,
+        baseModel: 'Anima',
+        modelType: ModelType.Checkpoint,
+      },
+    ]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
+
+    // Asserted on the ARGUMENT, not on a returned row. The db mock ignores `data` and echoes the
+    // payload back, so a repair that wrote the wrong column — or wrote nothing — returns a result
+    // indistinguishable from a correct one.
+    expect(clearCall()).toEqual({
+      where: { id: { in: [VERSION_ID] } },
+      data: { licensingSourceVersionId: null },
+    });
+  });
+
+  it('keeps a root the new type still supports', async () => {
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+    ]);
+    licensingRoots([
+      {
+        modelVersionId: ANIMA_ROOT_VERSION_ID,
+        baseModel: 'Anima',
+        modelType: ModelType.Checkpoint,
+      },
+    ]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+
+    expect(mockDbWrite.modelVersion.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('clears a root whose base model no longer matches the version', async () => {
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Flux.1 D', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+    ]);
+    licensingRoots([
+      {
+        modelVersionId: ANIMA_ROOT_VERSION_ID,
+        baseModel: 'Anima',
+        modelType: ModelType.Checkpoint,
+      },
+    ]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+
+    expect(clearCall()?.where).toEqual({ id: { in: [VERSION_ID] } });
+  });
+
+  it('clears a source that is not a registered root at all', async () => {
+    stampedVersions([{ id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: 999999 }]);
+    licensingRoots([]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+
+    expect(clearCall()?.where).toEqual({ id: { in: [VERSION_ID] } });
+  });
+
+  // The `where` filters these out, but a Prisma mock does not apply a `where` — and neither would a
+  // future caller that hands this helper a wider row set. A version with no source has nothing to
+  // repair, and counting one as repaired emits an audit row and a cache bust for a change that
+  // never happened.
+  it('ignores versions that carry no licensing source', async () => {
+    mockDbWrite.modelVersion.findMany.mockResolvedValue([
+      { id: 900, baseModel: 'Anima', licensingSourceVersionId: null },
+      { id: 901, baseModel: 'Anima', licensingSourceVersionId: null },
+    ]);
+    licensingRoots([]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
+
+    expect(mockDbWrite.modelVersion.updateMany).not.toHaveBeenCalled();
+    expect(versionAuditRows()).toEqual([]);
+  });
+
+  // Named for the decision: the repair is attributed to the RULE, not to the creator, who changed a
+  // type and never touched a fee. Drop the attribution and the first rows this audit trail ever
+  // produces for the field are automated repairs wearing an owner's name.
+  it('attributes the cleared source to the rule, not to the owner', async () => {
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+    ]);
+    licensingRoots([
+      {
+        modelVersionId: ANIMA_ROOT_VERSION_ID,
+        baseModel: 'Anima',
+        modelType: ModelType.Checkpoint,
+      },
+    ]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
+
+    expect(versionAuditRows()).toEqual([
+      expect.objectContaining({
+        entityId: VERSION_ID,
+        field: 'licensingSourceVersionId',
+        oldValue: String(ANIMA_ROOT_VERSION_ID),
+        newValue: 'null',
+        actorRole: 'system',
+        reason: 'model-type-changed',
+      }),
+    ]);
+  });
+});

--- a/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
+++ b/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// upsertModel must re-check its versions' licensing lineage when the model's TYPE changes.
-// A version inherits a per-image licence fee from a LicensingRoot, every root is a Checkpoint, and
-// the type stays editable after the versions exist — so a version stamped while the model was a
-// Checkpoint went on charging that checkpoint's fee once the model became a LoRA (CU 868kwf2fd).
-// model.service.ts has a very large import graph, so its transitive dependencies are stubbed below;
-// the scaffold mirrors model-locked-properties.service.test.ts.
+// model.service.ts has a very large import graph; scaffold mirrors
+// model-locked-properties.service.test.ts.
 
 const { mockEvaluateContent, mockThrowOnBlockedLinkDomain, mockGetHighestTierSubscription } =
   vi.hoisted(() => ({
@@ -223,9 +219,8 @@ describe('upsertModel — licensing lineage on a model type change', () => {
 
     await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
 
-    // Asserted on the ARGUMENT, not on a returned row. The db mock echoes the payload back, so a
-    // repair that wrote the wrong column — or wrote nothing — returns a result indistinguishable
-    // from a correct one.
+    // Assert the ARGUMENT: the db mock echoes the payload back, so a repair that wrote the wrong
+    // column, or nothing, returns a result indistinguishable from a correct one.
     expect(clearCall()).toEqual({
       where: { id: { in: [VERSION_ID] } },
       data: { licensingSourceVersionId: null },
@@ -244,9 +239,8 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     expect(mockDbWrite.modelVersion.updateMany).not.toHaveBeenCalled();
   });
 
-  // The direction that costs a creator money. Clearing the whole stamped set instead of the failing
-  // subset takes a per-image fee off a version whose root is still valid, and every single-version
-  // fixture passes while doing it.
+  // Multi-version on purpose: clearing the whole stamped set instead of the failing subset passes
+  // every single-version fixture while taking a fee off a version whose root is still valid.
   it('clears only the failing version, not every stamped version on the model', async () => {
     storedTypeOnWriter(ModelType.LORA);
     stampedVersions([
@@ -265,10 +259,7 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     expect(versionAuditRows()).toHaveLength(1);
   });
 
-  // 🔴 Named for the decision. `type` is REQUIRED by modelUpsertSchema, so it is present on every
-  // save — a rename, a tag edit. Gating on its presence rather than on the value changing coerces
-  // sources no type change invalidated, including the pre-LicensingRoot rows the migration beside
-  // this deliberately spares for a human decision.
+  // A rename must not clear anything — see the gate comment in upsertModel.
   it('does not touch lineage on a save that leaves the type alone', async () => {
     storedTypeOnWriter(ModelType.LORA);
     stampedVersions([
@@ -302,9 +293,7 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     expect(clearCall()?.where).toEqual({ id: { in: [VERSION_ID] } });
   });
 
-  // The `where` filters these out, but a Prisma mock does not apply a `where` — and neither would a
-  // future caller handing this a wider row set. A version with no source has nothing to repair, and
-  // counting one as repaired emits an audit row and a cache bust for a change that never happened.
+  // A Prisma mock does not apply the `where`, and a future caller could hand this a wider set.
   it('ignores versions that carry no licensing source', async () => {
     stampedVersions([
       { id: 900, baseModel: 'Anima', licensingSourceVersionId: null },
@@ -318,9 +307,7 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     expect(versionAuditRows()).toEqual([]);
   });
 
-  // Named for the decision: the repair is attributed to the RULE, not to the creator, who changed a
-  // type and never touched a fee. Drop the attribution and the first rows this audit trail ever
-  // produces for the field are automated repairs wearing an owner's name.
+  // The clear is attributed to the rule, not the owner.
   it('attributes the cleared source to the rule, not to the owner', async () => {
     stampedVersions([
       { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
@@ -341,10 +328,8 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     ]);
   });
 
-  // 🔴 The fixture is mixed on purpose. `type` is one of `coverageModelFields`, so a type change
-  // ALREADY busts this model's version caches further down — with every version id. On a
-  // single-version fixture that call is argument-for-argument identical to this one, so deleting
-  // the bust here passes. Only the cleared SUBSET distinguishes them.
+  // Mixed on purpose: `type` is in `coverageModelFields`, so a type change already busts every
+  // version id below. Only the cleared SUBSET distinguishes that call from this one.
   it('busts the version caches for the versions it cleared', async () => {
     storedTypeOnWriter(ModelType.LORA);
     stampedVersions([
@@ -360,8 +345,7 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
 
     expect(bustMvCache).toHaveBeenCalledWith([OTHER_VERSION_ID], MODEL_ID, OWNER_ID);
-    // Order matters as much as presence: bust first and a concurrent feed read inside the
-    // replication window refills the same caches from the replica's pre-clear row.
+    // Order, not just presence: bust first and the replica refills the same caches pre-clear.
     expect(preventModelVersionLagBatch).toHaveBeenCalledWith(MODEL_ID, [OTHER_VERSION_ID]);
     expect(
       (preventModelVersionLagBatch as unknown as { mock: { invocationCallOrder: number[] } }).mock
@@ -372,12 +356,9 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     );
   });
 
-  // 🔴 The one assertion that pins the repair to the TRANSACTION. The shared db mock hands the same
-  // client back as `tx`, so `tx.modelVersion.updateMany` and `dbWrite.modelVersion.updateMany` are
-  // the same function and lifting the block out of the callback is invisible to every other test
-  // here. This test swaps in a tx object of its own and records what was called on it, so a repair
-  // that runs outside the transaction — where the type change and the clear can be observed apart —
-  // reaches `dbWrite` instead and this fails.
+  // 🔴 The only assertion pinning the repair to the TRANSACTION. The shared db mock returns the
+  // same client as `tx`, so lifting the block out of the callback is invisible to every other test
+  // here. This one passes its own tx object and fails if the write lands on `dbWrite`.
   it('does the clearing inside the model-update transaction', async () => {
     stampedVersions([
       { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },

--- a/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
+++ b/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
@@ -98,6 +98,8 @@ vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
 
 import { upsertModel } from '~/server/services/model.service';
+import { bustMvCache } from '~/server/services/model-version.service';
+import { preventModelVersionLagBatch } from '~/server/db/db-lag-helpers';
 import type { ModelUpsertInput } from '~/server/schema/model.schema';
 import { ModelStatus, ModelType, ModelUploadType } from '~/shared/utils/prisma/enums';
 import { dbMock } from '~/__tests__/mocks/db.mock';
@@ -107,6 +109,7 @@ const mockDbWrite = dbMock.dbWrite;
 const OWNER_ID = 101;
 const MODEL_ID = 42;
 const VERSION_ID = 3144879;
+const OTHER_VERSION_ID = 3144880;
 const ANIMA_ROOT_VERSION_ID = 2945208;
 
 const storedModel = {
@@ -125,6 +128,14 @@ const storedModel = {
 
 const entityChanges = vi.fn(() => Promise.resolve());
 
+/**
+ * The type the WRITER reports before the update. Read inside the transaction, so it is a separate
+ * call from `dbRead.model.findUnique` and has to be declared separately.
+ */
+function storedTypeOnWriter(type: ModelType) {
+  mockDbWrite.model.findUnique.mockResolvedValue({ type });
+}
+
 function upsert(input: Partial<ModelUpsertInput> & { userId: number }) {
   return upsertModel({
     name: 'Test Model',
@@ -137,7 +148,7 @@ function upsert(input: Partial<ModelUpsertInput> & { userId: number }) {
 }
 
 function stampedVersions(
-  rows: { id: number; baseModel: string; licensingSourceVersionId: number }[]
+  rows: { id: number; baseModel: string; licensingSourceVersionId: number | null }[]
 ) {
   mockDbWrite.modelVersion.findMany.mockResolvedValue(rows);
 }
@@ -148,10 +159,16 @@ function licensingRoots(
   mockDbWrite.licensingRoot.findMany.mockResolvedValue(rows);
 }
 
+const animaCheckpointRoot = {
+  modelVersionId: ANIMA_ROOT_VERSION_ID,
+  baseModel: 'Anima',
+  modelType: ModelType.Checkpoint,
+};
+
 /** Only the ModelVersion rows — the Model-level tracker call always fires, empty or not. */
 function versionAuditRows() {
   return entityChanges.mock.calls
-    .flatMap((call) => call[0] as Record<string, unknown>[])
+    .flatMap((call) => call[0] as unknown as Record<string, unknown>[])
     .filter((row) => row.entityType === 'ModelVersion');
 }
 
@@ -174,6 +191,7 @@ beforeEach(() => {
   mockDbRead.model.findUnique.mockResolvedValue(storedModel);
   mockDbRead.model.count.mockResolvedValue(0);
   mockDbWrite.$queryRaw.mockResolvedValue([]);
+  storedTypeOnWriter(ModelType.Checkpoint);
   stampedVersions([]);
   licensingRoots([]);
   mockDbWrite.model.update.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
@@ -201,55 +219,76 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     stampedVersions([
       { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
     ]);
-    licensingRoots([
-      {
-        modelVersionId: ANIMA_ROOT_VERSION_ID,
-        baseModel: 'Anima',
-        modelType: ModelType.Checkpoint,
-      },
-    ]);
+    licensingRoots([animaCheckpointRoot]);
 
     await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
 
-    // Asserted on the ARGUMENT, not on a returned row. The db mock ignores `data` and echoes the
-    // payload back, so a repair that wrote the wrong column — or wrote nothing — returns a result
-    // indistinguishable from a correct one.
+    // Asserted on the ARGUMENT, not on a returned row. The db mock echoes the payload back, so a
+    // repair that wrote the wrong column — or wrote nothing — returns a result indistinguishable
+    // from a correct one.
     expect(clearCall()).toEqual({
       where: { id: { in: [VERSION_ID] } },
       data: { licensingSourceVersionId: null },
     });
   });
 
-  it('keeps a root the new type still supports', async () => {
+  it('keeps a root the new type supports', async () => {
+    storedTypeOnWriter(ModelType.LORA);
     stampedVersions([
       { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
     ]);
-    licensingRoots([
-      {
-        modelVersionId: ANIMA_ROOT_VERSION_ID,
-        baseModel: 'Anima',
-        modelType: ModelType.Checkpoint,
-      },
-    ]);
+    licensingRoots([animaCheckpointRoot]);
 
     await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
 
     expect(mockDbWrite.modelVersion.updateMany).not.toHaveBeenCalled();
   });
 
+  // The direction that costs a creator money. Clearing the whole stamped set instead of the failing
+  // subset takes a per-image fee off a version whose root is still valid, and every single-version
+  // fixture passes while doing it.
+  it('clears only the failing version, not every stamped version on the model', async () => {
+    storedTypeOnWriter(ModelType.LORA);
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+      {
+        id: OTHER_VERSION_ID,
+        baseModel: 'Krea 2',
+        licensingSourceVersionId: ANIMA_ROOT_VERSION_ID,
+      },
+    ]);
+    licensingRoots([animaCheckpointRoot]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+
+    expect(clearCall()?.where).toEqual({ id: { in: [OTHER_VERSION_ID] } });
+    expect(versionAuditRows()).toHaveLength(1);
+  });
+
+  // 🔴 Named for the decision. `type` is REQUIRED by modelUpsertSchema, so it is present on every
+  // save — a rename, a tag edit. Gating on its presence rather than on the value changing coerces
+  // sources no type change invalidated, including the pre-LicensingRoot rows the migration beside
+  // this deliberately spares for a human decision.
+  it('does not touch lineage on a save that leaves the type alone', async () => {
+    storedTypeOnWriter(ModelType.LORA);
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+    ]);
+    licensingRoots([animaCheckpointRoot]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA, name: 'Renamed' });
+
+    expect(mockDbWrite.modelVersion.updateMany).not.toHaveBeenCalled();
+    expect(versionAuditRows()).toEqual([]);
+  });
+
   it('clears a root whose base model no longer matches the version', async () => {
     stampedVersions([
       { id: VERSION_ID, baseModel: 'Flux.1 D', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
     ]);
-    licensingRoots([
-      {
-        modelVersionId: ANIMA_ROOT_VERSION_ID,
-        baseModel: 'Anima',
-        modelType: ModelType.Checkpoint,
-      },
-    ]);
+    licensingRoots([animaCheckpointRoot]);
 
-    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
 
     expect(clearCall()?.where).toEqual({ id: { in: [VERSION_ID] } });
   });
@@ -258,17 +297,16 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     stampedVersions([{ id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: 999999 }]);
     licensingRoots([]);
 
-    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
 
     expect(clearCall()?.where).toEqual({ id: { in: [VERSION_ID] } });
   });
 
   // The `where` filters these out, but a Prisma mock does not apply a `where` — and neither would a
-  // future caller that hands this helper a wider row set. A version with no source has nothing to
-  // repair, and counting one as repaired emits an audit row and a cache bust for a change that
-  // never happened.
+  // future caller handing this a wider row set. A version with no source has nothing to repair, and
+  // counting one as repaired emits an audit row and a cache bust for a change that never happened.
   it('ignores versions that carry no licensing source', async () => {
-    mockDbWrite.modelVersion.findMany.mockResolvedValue([
+    stampedVersions([
       { id: 900, baseModel: 'Anima', licensingSourceVersionId: null },
       { id: 901, baseModel: 'Anima', licensingSourceVersionId: null },
     ]);
@@ -287,13 +325,7 @@ describe('upsertModel — licensing lineage on a model type change', () => {
     stampedVersions([
       { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
     ]);
-    licensingRoots([
-      {
-        modelVersionId: ANIMA_ROOT_VERSION_ID,
-        baseModel: 'Anima',
-        modelType: ModelType.Checkpoint,
-      },
-    ]);
+    licensingRoots([animaCheckpointRoot]);
 
     await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
 
@@ -307,5 +339,83 @@ describe('upsertModel — licensing lineage on a model type change', () => {
         reason: 'model-type-changed',
       }),
     ]);
+  });
+
+  // 🔴 The fixture is mixed on purpose. `type` is one of `coverageModelFields`, so a type change
+  // ALREADY busts this model's version caches further down — with every version id. On a
+  // single-version fixture that call is argument-for-argument identical to this one, so deleting
+  // the bust here passes. Only the cleared SUBSET distinguishes them.
+  it('busts the version caches for the versions it cleared', async () => {
+    storedTypeOnWriter(ModelType.LORA);
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+      {
+        id: OTHER_VERSION_ID,
+        baseModel: 'Krea 2',
+        licensingSourceVersionId: ANIMA_ROOT_VERSION_ID,
+      },
+    ]);
+    licensingRoots([animaCheckpointRoot]);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+
+    expect(bustMvCache).toHaveBeenCalledWith([OTHER_VERSION_ID], MODEL_ID, OWNER_ID);
+    // Order matters as much as presence: bust first and a concurrent feed read inside the
+    // replication window refills the same caches from the replica's pre-clear row.
+    expect(preventModelVersionLagBatch).toHaveBeenCalledWith(MODEL_ID, [OTHER_VERSION_ID]);
+    expect(
+      (preventModelVersionLagBatch as unknown as { mock: { invocationCallOrder: number[] } }).mock
+        .invocationCallOrder[0]
+    ).toBeLessThan(
+      (bustMvCache as unknown as { mock: { invocationCallOrder: number[] } }).mock
+        .invocationCallOrder[0]
+    );
+  });
+
+  // 🔴 The one assertion that pins the repair to the TRANSACTION. The shared db mock hands the same
+  // client back as `tx`, so `tx.modelVersion.updateMany` and `dbWrite.modelVersion.updateMany` are
+  // the same function and lifting the block out of the callback is invisible to every other test
+  // here. This test swaps in a tx object of its own and records what was called on it, so a repair
+  // that runs outside the transaction — where the type change and the clear can be observed apart —
+  // reaches `dbWrite` instead and this fails.
+  it('does the clearing inside the model-update transaction', async () => {
+    stampedVersions([
+      { id: VERSION_ID, baseModel: 'Anima', licensingSourceVersionId: ANIMA_ROOT_VERSION_ID },
+    ]);
+    licensingRoots([animaCheckpointRoot]);
+
+    const calledOnTx: string[] = [];
+    mockDbWrite.$transaction.mockImplementation(async (arg: unknown) => {
+      if (typeof arg !== 'function') return undefined;
+      const tx: unknown = new Proxy(
+        {},
+        {
+          get(_t, model: string) {
+            return new Proxy(
+              {},
+              {
+                get(_m, method: string) {
+                  return (...args: unknown[]) => {
+                    calledOnTx.push(`${model}.${method}`);
+                    return (
+                      mockDbWrite as unknown as Record<
+                        string,
+                        Record<string, (...a: unknown[]) => unknown>
+                      >
+                    )[model][method](...args);
+                  };
+                },
+              }
+            );
+          },
+        }
+      );
+      return (arg as (tx: unknown) => unknown)(tx);
+    });
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.LORA });
+
+    expect(clearCall()?.where).toEqual({ id: { in: [VERSION_ID] } });
+    expect(calledOnTx).toContain('modelVersion.updateMany');
   });
 });

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2550,6 +2550,13 @@ export const upsertModel = async (
 
     const result = await dbWrite.$transaction(
       async (tx) => {
+        // Read on the WRITER, inside the transaction, rather than off `beforeUpdate` — that is a
+        // `dbRead` snapshot, and a stale or missed replica row reads as "type unchanged", which
+        // would skip the repair below on exactly the save that needed it.
+        const typeBeforeUpdate = (
+          await tx.model.findUnique({ where: { id }, select: { type: true } })
+        )?.type;
+
         const updated = await tx.model.update({
           select: {
             id: true,
@@ -2613,7 +2620,13 @@ export const upsertModel = async (
         //
         // In the transaction so the type change and the repair cannot be observed apart: a reader
         // between them would price generations against a lineage the model no longer supports.
-        if (data.type !== undefined) {
+        //
+        // 🔴 Gated on the type actually CHANGING, not on the payload carrying one. `type` is
+        // required by `modelUpsertSchema`, so `data.type !== undefined` is true on every save — a
+        // rename, a tag edit — and coercing on those would clear sources no type change
+        // invalidated, including the pre-LicensingRoot rows the accompanying migration
+        // deliberately spares for a human decision.
+        if (updated.type !== typeBeforeUpdate) {
           const stamped = await tx.modelVersion.findMany({
             where: { modelId: updated.id, licensingSourceVersionId: { not: null } },
             select: { id: true, baseModel: true, licensingSourceVersionId: true },
@@ -2720,12 +2733,13 @@ export const upsertModel = async (
         modelType: result.type,
         modelVersionIds: clearedLicensingSources.map((v) => v.id),
       }).catch(() => null);
-      // The fee is read from caches the direct write above does not reach.
-      await bustMvCache(
-        clearedLicensingSources.map((v) => v.id),
-        result.id,
-        userId
-      ).catch(() => undefined);
+      // The fee is read from caches the write above does not reach — and the lag flag has to be set
+      // BEFORE the bust, matching publishModelById: without it a concurrent feed read inside the
+      // replication window refills those caches from the replica's pre-clear row and the fee stays
+      // live for the whole TTL.
+      const clearedVersionIds = clearedLicensingSources.map((v) => v.id);
+      await preventModelVersionLagBatch(result.id, clearedVersionIds);
+      await bustMvCache(clearedVersionIds, result.id, userId).catch(() => undefined);
     }
 
     const modelMeta = result.meta as ModelMeta | null;

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2544,6 +2544,10 @@ export const upsertModel = async (
     const prevGallerySettings = beforeUpdate.gallerySettings as ModelGallerySettingsSchema;
     const prevMeta = beforeUpdate.meta as ModelMeta | null;
 
+    // Versions whose licensing source the type change invalidated, cleared inside the transaction
+    // below and reported outside it.
+    let clearedLicensingSources: { id: number; licensingSourceVersionId: number }[] = [];
+
     const result = await dbWrite.$transaction(
       async (tx) => {
         const updated = await tx.model.update({
@@ -2560,6 +2564,7 @@ export const upsertModel = async (
             status: true,
             meta: true,
             availability: true,
+            type: true,
           },
           where: { id },
           data: {
@@ -2597,6 +2602,56 @@ export const upsertModel = async (
           },
         });
 
+        // A model's type decides which licensing roots its versions may inherit a per-image fee
+        // from, and the type stays editable after the versions exist. The rule is enforced on a
+        // VERSION write (upsertModelVersionHandler coerces a mismatched source to null); nothing
+        // re-checked the versions when the model moved under them. So a version stamped while its
+        // model was a Checkpoint went on charging that checkpoint's fee — to everyone who
+        // generated with it, settled to the CHECKPOINT owner, on a line carrying the derivative's
+        // own name — once the model became a LoRA, and no surface on the site could clear it.
+        // Same rule, same coercion, on the other write that can break it (CU 868kwf2fd).
+        //
+        // In the transaction so the type change and the repair cannot be observed apart: a reader
+        // between them would price generations against a lineage the model no longer supports.
+        if (data.type !== undefined) {
+          const stamped = await tx.modelVersion.findMany({
+            where: { modelId: updated.id, licensingSourceVersionId: { not: null } },
+            select: { id: true, baseModel: true, licensingSourceVersionId: true },
+          });
+          // Narrowed in code as well as in the `where`: a version with no source has nothing to
+          // repair, and treating one as repaired would emit an audit row and a cache bust for a
+          // change that never happened.
+          const stampedWithSource = stamped.filter(
+            (v): v is typeof v & { licensingSourceVersionId: number } =>
+              v.licensingSourceVersionId != null
+          );
+          if (stampedWithSource.length) {
+            const roots = await tx.licensingRoot.findMany({
+              where: {
+                modelVersionId: {
+                  in: uniq(stampedWithSource.map((v) => v.licensingSourceVersionId)),
+                },
+              },
+              select: { modelVersionId: true, baseModel: true, modelType: true },
+            });
+            const rootByVersionId = new Map(roots.map((r) => [r.modelVersionId, r]));
+            clearedLicensingSources = stampedWithSource
+              .filter((v) => {
+                const root = rootByVersionId.get(v.licensingSourceVersionId);
+                return !root || root.baseModel !== v.baseModel || root.modelType !== updated.type;
+              })
+              .map((v) => ({
+                id: v.id,
+                licensingSourceVersionId: v.licensingSourceVersionId,
+              }));
+            if (clearedLicensingSources.length)
+              await tx.modelVersion.updateMany({
+                where: { id: { in: clearedLicensingSources.map((v) => v.id) } },
+                data: { licensingSourceVersionId: null },
+              });
+          }
+        }
+
         if (descriptionSupplied && expansion.evaluated)
           await reconcileBlurbReferences({
             entityType: 'Model',
@@ -2629,6 +2684,48 @@ export const upsertModel = async (
           : undefined,
       });
       tracker.entityChanges(changeRows).catch(() => null);
+    }
+
+    if (clearedLicensingSources.length) {
+      // Attributed to the rule, not to the creator: they changed a type, not a fee. Without
+      // `systemFields` the first rows this trail ever produces for the field are automated repairs
+      // wearing an owner's name.
+      const actorRole = resolveActorRole({
+        actorUserId: userId,
+        ownerId: beforeUpdate.userId,
+        isModerator,
+      });
+      if (tracker)
+        tracker
+          .entityChanges(
+            clearedLicensingSources.flatMap((v) =>
+              diffEntityChanges({
+                entityType: 'ModelVersion',
+                entityId: v.id,
+                ownerId: beforeUpdate.userId,
+                before: { licensingSourceVersionId: v.licensingSourceVersionId },
+                after: { licensingSourceVersionId: null },
+                actorRole,
+                systemFields: { licensingSourceVersionId: 'model-type-changed' },
+              })
+            )
+          )
+          .catch(() => null);
+      logToAxiom({
+        name: 'model-version-licensing-source-cleared',
+        type: 'info',
+        reason: 'model-type-changed',
+        userId,
+        modelId: result.id,
+        modelType: result.type,
+        modelVersionIds: clearedLicensingSources.map((v) => v.id),
+      }).catch(() => null);
+      // The fee is read from caches the direct write above does not reach.
+      await bustMvCache(
+        clearedLicensingSources.map((v) => v.id),
+        result.id,
+        userId
+      ).catch(() => undefined);
     }
 
     const modelMeta = result.meta as ModelMeta | null;

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2544,15 +2544,12 @@ export const upsertModel = async (
     const prevGallerySettings = beforeUpdate.gallerySettings as ModelGallerySettingsSchema;
     const prevMeta = beforeUpdate.meta as ModelMeta | null;
 
-    // Versions whose licensing source the type change invalidated, cleared inside the transaction
-    // below and reported outside it.
     let clearedLicensingSources: { id: number; licensingSourceVersionId: number }[] = [];
 
     const result = await dbWrite.$transaction(
       async (tx) => {
-        // Read on the WRITER, inside the transaction, rather than off `beforeUpdate` — that is a
-        // `dbRead` snapshot, and a stale or missed replica row reads as "type unchanged", which
-        // would skip the repair below on exactly the save that needed it.
+        // Not `beforeUpdate.type` — that is a `dbRead` read, and a stale replica reads as "type
+        // unchanged", skipping the repair below on exactly the save that needed it.
         const typeBeforeUpdate = (
           await tx.model.findUnique({ where: { id }, select: { type: true } })
         )?.type;
@@ -2609,31 +2606,21 @@ export const upsertModel = async (
           },
         });
 
-        // A model's type decides which licensing roots its versions may inherit a per-image fee
-        // from, and the type stays editable after the versions exist. The rule is enforced on a
-        // VERSION write (upsertModelVersionHandler coerces a mismatched source to null); nothing
-        // re-checked the versions when the model moved under them. So a version stamped while its
-        // model was a Checkpoint went on charging that checkpoint's fee — to everyone who
-        // generated with it, settled to the CHECKPOINT owner, on a line carrying the derivative's
-        // own name — once the model became a LoRA, and no surface on the site could clear it.
-        // Same rule, same coercion, on the other write that can break it (CU 868kwf2fd).
+        // The same lineage rule `upsertModelVersionHandler` coerces on a version write, applied to
+        // the other write that can break the pairing: the model's type (CU 868kwf2fd).
         //
-        // In the transaction so the type change and the repair cannot be observed apart: a reader
-        // between them would price generations against a lineage the model no longer supports.
+        // Inside the transaction: a reader between the type change and the repair would price
+        // generations against a lineage the model no longer supports.
         //
-        // 🔴 Gated on the type actually CHANGING, not on the payload carrying one. `type` is
-        // required by `modelUpsertSchema`, so `data.type !== undefined` is true on every save — a
-        // rename, a tag edit — and coercing on those would clear sources no type change
-        // invalidated, including the pre-LicensingRoot rows the accompanying migration
-        // deliberately spares for a human decision.
+        // 🔴 Gate on the type CHANGING, not on the payload carrying one: `type` is required by
+        // `modelUpsertSchema`, so `data.type !== undefined` is true on every save — a rename, a
+        // tag edit.
         if (updated.type !== typeBeforeUpdate) {
           const stamped = await tx.modelVersion.findMany({
             where: { modelId: updated.id, licensingSourceVersionId: { not: null } },
             select: { id: true, baseModel: true, licensingSourceVersionId: true },
           });
-          // Narrowed in code as well as in the `where`: a version with no source has nothing to
-          // repair, and treating one as repaired would emit an audit row and a cache bust for a
-          // change that never happened.
+          // Type-narrowing only; the `where` above already excludes nulls.
           const stampedWithSource = stamped.filter(
             (v): v is typeof v & { licensingSourceVersionId: number } =>
               v.licensingSourceVersionId != null
@@ -2700,9 +2687,7 @@ export const upsertModel = async (
     }
 
     if (clearedLicensingSources.length) {
-      // Attributed to the rule, not to the creator: they changed a type, not a fee. Without
-      // `systemFields` the first rows this trail ever produces for the field are automated repairs
-      // wearing an owner's name.
+      // `systemFields` attributes the clear to the rule, not the owner, who changed a type, not a fee.
       const actorRole = resolveActorRole({
         actorUserId: userId,
         ownerId: beforeUpdate.userId,
@@ -2733,10 +2718,9 @@ export const upsertModel = async (
         modelType: result.type,
         modelVersionIds: clearedLicensingSources.map((v) => v.id),
       }).catch(() => null);
-      // The fee is read from caches the write above does not reach — and the lag flag has to be set
-      // BEFORE the bust, matching publishModelById: without it a concurrent feed read inside the
-      // replication window refills those caches from the replica's pre-clear row and the fee stays
-      // live for the whole TTL.
+      // Flag lag BEFORE the bust (as publishModelById does): otherwise a concurrent read inside the
+      // replication window refills these caches from the replica's pre-clear row and the fee stays
+      // live. A type change already busts every version id below — the ordering is what this adds.
       const clearedVersionIds = clearedLicensingSources.map((v) => v.id);
       await preventModelVersionLagBatch(result.id, clearedVersionIds);
       await bustMvCache(clearedVersionIds, result.id, userId).catch(() => undefined);


### PR DESCRIPTION
## What is still wrong

PR #4411 fixed the version-write half of `868kwf2fd` and **the stamping did not stop**.

`ModelVersion.licensingSourceVersionId` makes a version inherit a `LicensingRoot`'s per-image licence fee. The fee is charged to **everyone who generates with the derivative**, settled to the **root's** owner, on a line labelled with the **derivative's** name. Every `LicensingRoot` row is a Checkpoint.

Measured on prod today:

| | |
|---|---|
| Rows whose stored source fails the rule the app already enforces | **52** |
| Of those, created while a prod image containing #4411 was serving | **10** |
| Most recent | created today, 16:41 UTC |
| Stamped LoRA versions since 2026-08-29 20:42 UTC | **10 of 6,027 = 0.166%** |
| Rate #4411 measured before it shipped | 0.23% |

The fix is deployed — I checked every prod primary ReplicaSet back to Aug-29 (`194aa35`, `04afb77`, `e0e8516`, `44e0598`) and each contains `2c90a3c81c`. It simply does not cover this path.

## Why the shipped guard never fires

`model-version-licensing-source-rejected` has **zero** events in Axiom across `civitai-prod`, `civitai-next` and `webhooks` since 2026-08-26. Positive control on the same query: `model-version-usage-control-gate`, emitted from the same handler in the same file through the same `logToAxiom`, returns **33,795** over the same window. So the handler runs and the log path works — the coercion branch is simply never reached. `entityChangeEvents` agrees: two `licensingSourceVersionId` changes exist in the entire audit, both on Checkpoints, both legitimate.

The version writes are legal when they happen. For a LoRA that is only possible if the model was a **Checkpoint at the time**, which puts the hole on the other write — the model's type.

`upsertModel` changes `Model.type` and revalidates nothing. `#4411` declined to guard this path on the grounds that *"the server coerces a mismatched source regardless"*. That is true on a version write and false on a model-type write, which is the case that was actually happening. Stated plainly because the next reader will otherwise re-derive the same assumption from the same comment.

The chain, and what each link rests on:

- The Type field stays editable after versions exist — `disabled={isTrained}` only, and every stamped row is `uploadType: 'Created'`.
- Changing it is a handled flow on the client: `handleModelTypeChange` clears `checkpointType` on every switch. The client tidies the field it knows about; nothing tidies the versions' licensing lineage.
- `upsertModel` is the only writer of `Model.type` from user input, and nothing anywhere writes `licensingSourceVersionId` outside the version handler.
- Prod fingerprint: of the ten recently-stamped LoRA models, two have a second version, and in both the **older** version carries the stamp while the **newer** one — written after the model became a LoRA — is clean (`3280377`/`3282671`, `3281311`/`3284941`). That is the prediction this mechanism makes and I could not construct another that makes it.

**This is not a keystroke-level reproduction.** n=2 on the fingerprint. Treat the mechanism as strongly corroborated, not proven.

## The fix

`upsertModel` re-checks its versions' lineage inside the same `$transaction` as the type change, clears the sources the new type no longer supports, and records each repair against the rule (`actorRole: 'system'`, `reason: 'model-type-changed'`) rather than against the creator, who changed a type and never touched a fee.

Three decisions worth not optimising back, each pinned by a test:

- **The previous type is read on the writer, inside the transaction — not from `beforeUpdate`.** `beforeUpdate.type` is sitting right there and is the obvious thing to use, which is why this says so: it is a `dbRead` replica read, and a stale or missed row there reads as "type unchanged", skipping the repair on exactly the save that needed it. Reading it on the writer gets change-detection and freshness with no trade between them.
- **It gates on the type actually changing, not on the payload carrying one.** `type` is required by `modelUpsertSchema`, so `data.type !== undefined` is true on every save — a rename, a tag edit. Gating on presence would clear sources no type change invalidated, including the rows the migration below deliberately spares.
- **`preventModelVersionLagBatch` runs before `bustMvCache`**, matching `publishModelById`. Bust first and a concurrent feed read inside the replication window refills the same caches from the replica's pre-clear row, and the fee stays live for the whole TTL.

## The migration — applied BY HAND

`packages/civitai-db-schema/prisma/migrations/20260831200000_clear_orphaned_licensing_source/migration.sql` is **not** auto-applied. This repo does not run `prisma migrate deploy`. It needs running by a human against each environment, and each affected version id then needs `POST /api/v1/model-versions/bust-cache` (moderator-scoped), because a direct write reaches none of the caches the fee is read from.

It clears the **29** rows created on or after the `LicensingRoot` table's own rows (`2026-07-15 21:56:17`) whose source fails the rule the app already enforces: 22 LORA, 1 Other, 1 ComfyWorkflows, and 5 Checkpoints whose `baseModel` no longer matches their root. Those last 5 are the rows #4411 described as unsaveable by their owners under the older base-model throw — clearing them lets those creators save again.

Idempotent. Dry-run against prod: 29. Control with the `modelType` clause removed: 5 — so that clause carries 24 of the 29. The bound is written as `TIMESTAMP`, not `TIMESTAMPTZ`: `createdAt` is `timestamp without time zone` holding UTC wall-clock, and a TIMESTAMPTZ literal resolves through the applying session's `TimeZone`, which is unpinned when a human runs this by hand.

### 23 rows are deliberately left alone

23 rows across 18 models and 5 creators, created 2026-06-03 to 2026-07-14, predate the `LicensingRoot` table — a period when a since-retired picker may legitimately have offered a checkpoint's root to a LoRA. Clearing one could take income from a creator who chose to earn it, and a wrong row costs a small ongoing fee that can be refunded while a wrongly-cleared one takes money with no record of what it was. **The call is Justin's, not this PR's.** Full analysis is a comment on CU `868kwf2fd`.

## Verification

| Check | Result |
|---|---|
| `pnpm run typecheck` | **0 errors**, unfiltered |
| `pnpm run lint`, the two files touched | **0 errors**, 9 warnings, all pre-existing and outside the edit |
| `pnpm exec prettier --write` | clean |
| Full unit suite | `Test Files 4 failed \| 1524 passed \| 2 skipped (1530)`, `Tests 10 failed \| 24085 passed \| 28 skipped (24123)`, exit 1 |
| `blocks.router.workflow.test.ts` | **370 tests** collected — so the suite result means something |

An earlier run of the same tree reported `(1529)` with `Worker exited unexpectedly` in the tail — a worker died and ~34 tests never ran. The internal totals add up either way, so the only tell is the file count moving between runs of the same tree. Discarded and re-run.

The 4 failing files are pre-existing on this base. Verified by control, not assumed: source change stashed, new test file moved out of the tree, `git status` checked, those 4 files re-run — same 4 files and same 10 tests failing without this change in the tree. Two are Windows-path artifacts (one opens `C:\C:\Dev\...`).

### Mutation testing

Every guard mutated deliberately, one at a time, pristine control green first and restored between each. **13 of 13 killed**, every one with a legible assertion rather than a hang or a timeout:

| Mutant | Killed by |
|---|---|
| guard removed entirely | 7 tests |
| gate on `data.type !== undefined` (presence, not change) | "does not touch lineage on a save that leaves the type alone" |
| compare against the `dbRead` snapshot | 3 tests |
| `modelType` check dropped | 3 tests |
| `baseModel` check dropped | 2 tests |
| clear unconditionally | 3 tests |
| clear every stamped version, not the failing subset | "clears only the failing version" |
| null-source filter dropped | 4 tests |
| system attribution dropped | the attribution test |
| cache bust removed | the bust test |
| lag flag removed | the bust test |
| lag flag moved after the bust | the ordering assertion |
| repair lifted out of the transaction | the transaction test |

Three of those tests exist because a mutant survived first and the tests changed rather than the code:

- **The bust assertion was vacuous.** `type` is one of `coverageModelFields`, so a type change already busts this model's version caches further down — with every version id. On a single-version fixture that call is argument-for-argument identical to the new one, so deleting the new bust passed. The fixture is now mixed, and only the cleared subset distinguishes them.
- **Nothing pinned that only the failing subset is cleared.** Clearing the whole stamped set takes a fee off a version whose root is still valid, and every single-version fixture passed while doing it.
- **The transaction claim could not fail.** The shared db mock hands the same client back as `tx`, so lifting the block out of the callback was invisible. One test now swaps in a `tx` of its own and records what was called on it.

A defect in the hardening pass was also caught by a **pre-existing** test nobody had touched: `upsert-model-coverage-cache-bust.service.test.ts` went red because a Prisma mock does not apply a `where`, so versions carrying no source at all came back and were counted as repaired — firing a cache bust and an audit row for a change that never happened. In production the `where` would have hidden it. The set is now narrowed in code as well as in the query.

Assertions are on the **argument** to `modelVersion.updateMany`, not on a returned row: the db mock echoes the payload back, so a repair that wrote the wrong column returns something indistinguishable from a correct one.

CU `868kwf2fd` · follows #4411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
