### PR TITLE
fix(cosmetic-shop): stop the similarity panel padding itself with noise

### DIFF
--- a/src/components/CreatorShop/SimilarArtworkCard.tsx
+++ b/src/components/CreatorShop/SimilarArtworkCard.tsx
@@ -97,9 +97,13 @@ export function SimilarArtworkCard({
         </Group>
       ) : (
         <>
+          {/* Not "the N closest" any more. The list is a threshold, not a rank —
+              anything too far away is dropped rather than padding it out, so a
+              short list means few were close and not that few were compared. */}
           <Text size="xs" c="dimmed" px="md" pt={9} pb={4}>
-            The {result.matches.length} closest of {result.comparedAgainst.toLocaleString()}{' '}
-            cosmetics, most alike first. Closeness is a prompt to look, not a verdict.
+            {result.matches.length} of {result.comparedAgainst.toLocaleString()} cosmetics{' '}
+            {result.matches.length === 1 ? 'was' : 'were'} close enough to be worth a look, most
+            alike first. Closeness is a prompt to look, not a verdict.
           </Text>
           <Stack gap={0}>
             {result.matches.map((match) => {

--- a/src/server/services/__tests__/cosmetic-phash.service.test.ts
+++ b/src/server/services/__tests__/cosmetic-phash.service.test.ts
@@ -17,7 +17,9 @@ vi.mock('~/server/services/orchestrator/orchestrator.service', () => ({
 import {
   COSMETIC_PHASH_LANE,
   COSMETIC_SIMILARITY_CLOSE_RATIO_KEY,
+  COSMETIC_SIMILARITY_MAX_RATIO_KEY,
   getCosmeticSimilarityCloseRatio,
+  getCosmeticSimilarityMaxRatio,
   getSimilarCosmetics,
   hammingDistanceHex,
   legacyBigIntHash,
@@ -28,7 +30,10 @@ import {
 } from '../cosmetic-phash.service';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import { dbMock } from '~/__tests__/mocks/db.mock';
-import { COSMETIC_SIMILARITY_CLOSE_RATIO } from '~/shared/constants/cosmetic-shop.constants';
+import {
+  COSMETIC_SIMILARITY_CLOSE_RATIO,
+  COSMETIC_SIMILARITY_MAX_RATIO,
+} from '~/shared/constants/cosmetic-shop.constants';
 dbMock.dbRead.keyValue.findUnique.mockImplementation((...args: unknown[]) =>
   (mocks.keyValueFindUnique as (...a: unknown[]) => unknown)(...args)
 );
@@ -60,6 +65,22 @@ const IMITATION_B = {
 
 // A fresh, comparable target: hashed, in the current lane, and the hash describes
 // the artwork the cosmetic actually uses.
+// Both ratios come from the same mocked `findUnique`, so a blanket
+// `mockResolvedValue` would move them together and hide the case that matters:
+// a close band that is wider than the display cutoff, or vice versa.
+const ratios = ({ close, max }: { close?: number; max?: number } = {}) =>
+  mocks.keyValueFindUnique.mockImplementation((args: { where: { key: string } }) =>
+    Promise.resolve(
+      args.where.key === COSMETIC_SIMILARITY_CLOSE_RATIO_KEY
+        ? close === undefined
+          ? null
+          : { value: close }
+        : max === undefined
+        ? null
+        : { value: max }
+    )
+  );
+
 const freshTarget = (pHashHex: string, url = 'artwork-1') => ({
   pHashHex,
   pHashUrl: url,
@@ -335,6 +356,61 @@ describe('getSimilarCosmetics', () => {
     });
   });
 
+  // The panel was a rank limit with no distance floor, so it always listed ten
+  // cosmetics however far away they were — routinely past the 1st percentile of
+  // unrelated artwork (94 of 256, measured over the 1,902-row corpus). A ranked
+  // list of noise is read as a ranking, which is worse than an empty panel.
+  //
+  // Three mutations die here: dropping the filter, hardcoding the cutoff to the
+  // built-in default so the row is inert, and cutting on the CLOSE ratio instead
+  // of the display one (which would show only what it also badges red).
+  //
+  // Moving the filter after `.slice(0, limit)` does NOT die, and should not be
+  // "fixed": the predicate is monotonic in the sort key, so the passing rows are
+  // a prefix of the sorted array and filter-then-take returns the same rows as
+  // take-then-filter. Filtering first is the cheaper order, not the correct one.
+  it('lists nothing rather than padding the list with distant cosmetics', async () => {
+    mocks.cosmeticFindUnique.mockResolvedValue(freshTarget('0000000000000001'));
+    // 63 bits apart at a 64-bit width — the shape that used to fill the panel.
+    mocks.queryRaw.mockResolvedValue([{ id: 2, pHashHex: '7ffffffffffffffe' }]);
+    mocks.cosmeticFindMany.mockResolvedValue([]);
+    ratios();
+
+    const result = await getSimilarCosmetics({ cosmeticId: 1 });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.matches).toEqual([]);
+    // Still an honest "we compared and found nothing", NOT "nothing was compared".
+    // The card renders these two differently and only one of them is reassuring.
+    expect(result.comparedAgainst).toBe(1);
+    // Nothing was fetched for a row that will never be shown.
+    expect(mocks.cosmeticFindMany).not.toHaveBeenCalled();
+  });
+
+  it('keeps a cosmetic the operator brings inside the cutoff', async () => {
+    mocks.cosmeticFindUnique.mockResolvedValue(freshTarget('0000000000000001'));
+    mocks.queryRaw.mockResolvedValue([{ id: 2, pHashHex: '7ffffffffffffffe' }]);
+    mocks.cosmeticFindMany.mockResolvedValue([
+      {
+        id: 2,
+        name: 'Far',
+        type: 'Badge',
+        data: { url: 'f' },
+        createdById: null,
+        creator: null,
+        cosmeticShopItems: [],
+      },
+    ]);
+    // 0.99 of 64 bits => 63.4, so the 63-bit row is admitted. Proves the cutoff
+    // is read from the row rather than compiled in.
+    ratios({ max: 0.99 });
+
+    const result = await getSimilarCosmetics({ cosmeticId: 1 });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.matches.map((m) => [m.id, m.distance, m.close])).toEqual([[2, 63, false]]);
+  });
+
   // The one link the moderator's badge now hangs on, and nothing else covers it:
   // `close` moved from the component to the server so a runtime-tuned threshold
   // could not disagree with a bundled constant, and the KeyValue read is the only
@@ -347,7 +423,7 @@ describe('getSimilarCosmetics', () => {
     mocks.cosmeticFindUnique.mockResolvedValue(freshTarget('0000000000000001'));
     mocks.queryRaw.mockResolvedValue([
       { id: 2, pHashHex: '0000000000000003' }, // 1 bit away
-      { id: 3, pHashHex: 'ffffff0000000001' }, // 24 bits away
+      { id: 3, pHashHex: '0000000000000ffe' }, // 12 bits away
     ]);
     mocks.cosmeticFindMany.mockResolvedValue(
       [2, 3].map((id) => ({
@@ -361,24 +437,24 @@ describe('getSimilarCosmetics', () => {
       }))
     );
 
-    mocks.keyValueFindUnique.mockResolvedValue(null);
+    ratios();
     const atDefault = await getSimilarCosmetics({ cosmeticId: 1 });
     expect(atDefault.status).toBe('ok');
     if (atDefault.status !== 'ok') return;
     expect(atDefault.matches.map((m) => [m.distance, m.close])).toEqual([
       [1, true],
-      [24, false],
+      [12, false],
     ]);
 
-    // Operator widens the band to 0.5 => close at or under 32 bits. The 24-bit
+    // Operator widens the band to 0.5 => close at or under 32 bits. The 12-bit
     // neighbour has to cross; nothing about the ranking may change with it.
-    mocks.keyValueFindUnique.mockResolvedValue({ value: 0.5 });
+    ratios({ close: 0.5 });
     const widened = await getSimilarCosmetics({ cosmeticId: 1 });
     expect(widened.status).toBe('ok');
     if (widened.status !== 'ok') return;
     expect(widened.matches.map((m) => [m.distance, m.close])).toEqual([
       [1, true],
-      [24, true],
+      [12, true],
     ]);
   });
 
@@ -412,7 +488,7 @@ describe('getSimilarCosmetics', () => {
     mocks.queryRaw.mockResolvedValue([
       { id: 55, pHashHex: 'a6e0c4c4cce8a4b7' }, // 1 bit away
       { id: 322, pHashHex: 'a6e0c4c4cce8a4b6' }, // identical
-      { id: 99, pHashHex: '0f1f2f3f4f5f6f7f' }, // unrelated
+      { id: 99, pHashHex: 'a6e0c4c4cce8ab49' }, // 12 bits away, still inside the cutoff
     ]);
     // Returned in a deliberately unhelpful order — the service must not inherit it.
     mocks.cosmeticFindMany.mockResolvedValue([
@@ -459,7 +535,7 @@ describe('getSimilarCosmetics', () => {
     expect(result.matches.map((m) => [m.id, m.distance])).toEqual([
       [322, 0],
       [55, 1],
-      [99, 43],
+      [99, 12],
     ]);
     // An official cosmetic has no creator; the panel says so rather than showing
     // a blank byline that reads like a missing username.

--- a/src/server/services/cosmetic-phash.service.ts
+++ b/src/server/services/cosmetic-phash.service.ts
@@ -6,6 +6,7 @@ import { getPerceptualHash } from '~/server/services/orchestrator/orchestrator.s
 import {
   COSMETIC_SIMILARITY_CLOSE_RATIO,
   COSMETIC_SIMILARITY_LIMIT,
+  COSMETIC_SIMILARITY_MAX_RATIO,
 } from '~/shared/constants/cosmetic-shop.constants';
 import type { CosmeticShopItemStatus, CosmeticType } from '~/shared/utils/prisma/enums';
 
@@ -173,6 +174,7 @@ export function queueCosmeticPerceptualHash({ id, url }: { id: number; url: stri
 }
 
 export const COSMETIC_SIMILARITY_CLOSE_RATIO_KEY = 'cosmetic-similarity-close-ratio';
+export const COSMETIC_SIMILARITY_MAX_RATIO_KEY = 'cosmetic-similarity-max-ratio';
 
 /**
  * The near-identical threshold, as a fraction of the hash width.
@@ -205,6 +207,21 @@ export const COSMETIC_SIMILARITY_CLOSE_RATIO_KEY = 'cosmetic-similarity-close-ra
 const closeRatioSchema = z.number().min(0).lt(1);
 
 export async function getCosmeticSimilarityCloseRatio(): Promise<number> {
+  return readTunableRatio(COSMETIC_SIMILARITY_CLOSE_RATIO_KEY, COSMETIC_SIMILARITY_CLOSE_RATIO);
+}
+
+/**
+ * How far away a cosmetic can be and still be listed at all.
+ *
+ * Separate from the close ratio and looser: that one decides a red badge on a
+ * row already on screen, this one decides whether the row exists. Conflating
+ * them would mean every listed cosmetic is also flagged near-identical.
+ */
+export async function getCosmeticSimilarityMaxRatio(): Promise<number> {
+  return readTunableRatio(COSMETIC_SIMILARITY_MAX_RATIO_KEY, COSMETIC_SIMILARITY_MAX_RATIO);
+}
+
+async function readTunableRatio(key: string, fallback: number): Promise<number> {
   let value: unknown;
 
   // The READ is guarded, not only the value it returns. This is awaited inside
@@ -214,31 +231,31 @@ export async function getCosmeticSimilarityCloseRatio(): Promise<number> {
   // the confusion the card exists to remove.
   try {
     const row = await dbRead.keyValue.findUnique({
-      where: { key: COSMETIC_SIMILARITY_CLOSE_RATIO_KEY },
+      where: { key },
     });
     value = row?.value;
   } catch (error) {
     logToAxiom({
       type: 'error',
       name: 'cosmetic-phash',
-      message: `Could not read KeyValue '${COSMETIC_SIMILARITY_CLOSE_RATIO_KEY}'; using the built-in ${COSMETIC_SIMILARITY_CLOSE_RATIO}.`,
+      message: `Could not read KeyValue '${key}'; using the built-in ${fallback}.`,
       error: error instanceof Error ? error.message : String(error),
     }).catch(() => null);
-    return COSMETIC_SIMILARITY_CLOSE_RATIO;
+    return fallback;
   }
 
   // An absent row is the ordinary "not configured" state, not a malformed one.
-  if (value === null || value === undefined) return COSMETIC_SIMILARITY_CLOSE_RATIO;
+  if (value === null || value === undefined) return fallback;
 
   if (!closeRatioSchema.safeParse(value).success) {
     logToAxiom({
       type: 'warning',
       name: 'cosmetic-phash',
-      message: `KeyValue '${COSMETIC_SIMILARITY_CLOSE_RATIO_KEY}' is not a fraction between 0 and 1 (got ${JSON.stringify(
+      message: `KeyValue '${key}' is not a fraction between 0 and 1 (got ${JSON.stringify(
         value
-      )}); using the built-in ${COSMETIC_SIMILARITY_CLOSE_RATIO}.`,
+      )}); using the built-in ${fallback}.`,
     }).catch(() => null);
-    return COSMETIC_SIMILARITY_CLOSE_RATIO;
+    return fallback;
   }
 
   return value as number;
@@ -350,23 +367,36 @@ export async function getSimilarCosmetics({
       AND id != ${cosmeticId}
   `;
 
-  const nearest = candidates
-    .map(({ id, pHashHex }) => ({ id, distance: hammingDistanceHex(targetHex, pHashHex) }))
-    .sort((a, b) => a.distance - b.distance)
-    .slice(0, limit);
-
   // "Nothing was close" and "there was nothing to be close to" are the same empty
   // list and completely different verdicts. Right after a lane bump the candidate
   // set is empty by construction while the sweep drains, so an `ok` here would
   // hand a moderator a green all-clear built on zero comparisons — a check that
   // cannot fail, which is the failure this whole panel exists to remove.
+  //
+  // Checked before the ratios are read so the no-corpus path still costs nothing.
   if (!candidates.length) return { status: 'unavailable', reason: 'no-corpus' };
+
+  const [closeRatio, maxRatio] = await Promise.all([
+    getCosmeticSimilarityCloseRatio(),
+    getCosmeticSimilarityMaxRatio(),
+  ]);
+  const closeAtOrUnder = bits * closeRatio;
+  const showAtOrUnder = bits * maxRatio;
+
+  // The distance filter runs BEFORE the rank limit, and that order is the whole
+  // fix. Ranking first and taking ten meant the panel always listed ten, padding
+  // the tail with whatever happened to be least-far — routinely neighbours past
+  // the 1st percentile of unrelated artwork. A moderator reads a ranked list as a
+  // ranking, so ten rows of noise is worse than no panel at all.
+  const nearest = candidates
+    .map(({ id, pHashHex }) => ({ id, distance: hammingDistanceHex(targetHex, pHashHex) }))
+    .filter(({ distance }) => distance <= showAtOrUnder)
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit);
 
   if (!nearest.length)
     return { status: 'ok', comparedAgainst: candidates.length, bits, matches: [] };
 
-  const closeRatio = await getCosmeticSimilarityCloseRatio();
-  const closeAtOrUnder = bits * closeRatio;
   const distanceById = new Map(nearest.map((n) => [n.id, n.distance]));
   const details = await dbRead.cosmetic.findMany({
     where: { id: { in: nearest.map((n) => n.id) } },

--- a/src/shared/constants/cosmetic-shop.constants.ts
+++ b/src/shared/constants/cosmetic-shop.constants.ts
@@ -27,3 +27,20 @@ export const COSMETIC_SIMILARITY_LIMIT = 10;
 // and it did: the same 0.125 selects the same five cross-creator pairs anywhere
 // between 8 and 40 of 256, so the value sits on a plateau rather than on an edge.
 export const COSMETIC_SIMILARITY_CLOSE_RATIO = 0.125;
+
+// Fraction of the hash width beyond which a cosmetic is not shown at all — 64
+// bits at the current 256.
+//
+// Without this the panel was a pure rank limit, so it always listed ten
+// cosmetics no matter how far away they were. Measured over the 1,902 hashed
+// cosmetics: the 1st percentile of UNRELATED pairs is 94 and the median is 124,
+// so a list padded out to ten routinely showed neighbours at 100+ — worse than
+// the 1st percentile of artwork chosen at random. A moderator reading that as a
+// ranking is reading noise, which is worse than showing nothing.
+//
+// 0.25 is where the corpus stops being sparse. Cross-creator pairs at or under
+// each cutoff: 7 at 48 bits, 15 at 56, 66 at 64, then 281 at 72 and 1,096 at 80.
+// The last value before that runaway is 64, and it also keeps the one confirmed
+// redrawn imitation (cosmetic 1426 vs official 107, at 60). Per cosmetic the
+// median is 0 and the max 20, so most submissions correctly show nothing.
+export const COSMETIC_SIMILARITY_MAX_RATIO = 0.25;


### PR DESCRIPTION
Reported from the live panel: it lists ten cosmetics every time, most of them 100+ bits away, so it reads as a list of random things. It was a rank limit with no distance floor — it always returned ten, padding the tail with whatever happened to be least-far.

Measured over the live 1,902-row corpus: the **1st percentile of unrelated pairs is 94 of 256**, median 124. So the tail of every list was routinely further away than artwork chosen at random. A moderator reads a ranked list as a ranking, which makes that worse than no panel at all.

## The change

A display cutoff applied **before** the rank limit. Anything past `COSMETIC_SIMILARITY_MAX_RATIO` of the hash width isn't listed, and a submission with nothing inside it renders the existing "compared against N, found nothing" state instead of a full list.

Simulated against the live corpus at 0.25:

| | |
|---|---|
| Cosmetics showing **nothing** | **1,418 of 1,902 (74.6%)** |
| Showing ≥1 | 484 (25.4%) |
| Still reaching the limit of 10 | 13 |

And for the confirmed imitation: **1426 "Master Generators (Temu Edition)" now shows exactly one row — official badge 107, the thing it copied.**

## Why 0.25

It's where the corpus stops being sparse. Cross-creator pairs at or under each cutoff:

| cutoff | 48 | 56 | **64** | 72 | 80 |
|---|---|---|---|---|---|
| pairs | 7 | 15 | **66** | 281 | 1,096 |

64 (= 0.25 × 256) is the last value before the runaway, and it keeps the one confirmed redraw (1426 vs 107, at 60).

## Known cost, chosen not overlooked

**The second imitation pair drops out entirely.** 1251 "SSS+" vs official 870 sits at 82, and at that distance it ties with five unrelated cosmetics — "Melting ice", "Tentacle Sea", "Golden Donut". It was never separable from noise even at 256 bits, so no cutoff recovers it without readmitting exactly what this change removes.

Tunable at runtime if that trade should change: a `cosmetic-similarity-max-ratio` KeyValue row, no deploy. It shares the reader the close-ratio knob already used — that reader is now parameterised rather than copied, so both ratios keep one tested set of fallback semantics.

## Copy

The header said "the N closest of M cosmetics". That's now false — the list is a threshold, not a rank. Reworded so a short list reads as "few were close" rather than "few were compared". The empty state already said the right thing and is unchanged.

## Verification

- 42 tests green across the three covering files; typecheck 0 errors
- Four mutants run against the new filter: removing it, hardcoding the cutoff to the built-in default, and cutting on the *close* ratio instead of the display one all die. Control green either side.
- Moving the filter after `.slice(0, limit)` **survives, and correctly so** — the predicate is monotonic in the sort key, so the passing rows are a prefix of the sorted array and the two orders return identical results. Recorded in the test comment so nobody "fixes" it later.
- Full suite: 24,125 pass. The 10 failures in 4 files (`trace-flush`, `appModeratorMessageForm.callSites`, `credential-detection-superset.guard`, `blocks/tools/registry`) are **pre-existing** — identical `10 failed | 99 passed` with this branch stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
