### PR TITLE
fix(crypto-deposit): never render the minimum label with nothing after it

### DIFF
--- a/src/components/Buzz/CryptoDeposit/CurrencySelector.browser.test.tsx
+++ b/src/components/Buzz/CryptoDeposit/CurrencySelector.browser.test.tsx
@@ -1,0 +1,47 @@
+import { page } from '@vitest/browser/context';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/component-setup';
+
+import type { CurrencySelectionState } from '~/components/Buzz/CryptoDeposit/CurrencySelector';
+import { MinDepositInfo } from '~/components/Buzz/CryptoDeposit/CurrencySelector';
+
+// This line is the only thing between a depositor and a sub-minimum send, which NowPayments neither
+// sweeps nor refunds. `fiat_equivalent` is nullish in the NowPayments response, so the fiat branch
+// can be missing while the crypto amount is present — and rendering nothing after "Minimum BTC
+// deposit:" reads as "no minimum" rather than as "we could not fetch it".
+
+function state(minData: { minAmount: number | null; fiatEquivalent: number | null } | undefined) {
+  return {
+    selectedTicker: 'btc',
+    networkLabel: null,
+    loadingMin: false,
+    minData,
+    selectedFiat: 'usd',
+    onFiatChange: vi.fn(),
+  } as unknown as CurrencySelectionState;
+}
+
+describe('MinDepositInfo', () => {
+  it('shows the fiat minimum when the response carries one', async () => {
+    renderWithProviders(
+      <MinDepositInfo state={state({ minAmount: 0.0002, fiatEquivalent: 17.44 })} />
+    );
+    // $17.45, not $17.44: the line ceils to the next cent, deliberately rounding a minimum UP.
+    await expect.element(page.getByText('Minimum BTC deposit: $17.45 USD ▾')).toBeInTheDocument();
+  });
+
+  it('falls back to the crypto amount when fiat_equivalent is absent', async () => {
+    renderWithProviders(
+      <MinDepositInfo state={state({ minAmount: 0.0002, fiatEquivalent: null })} />
+    );
+    await expect.element(page.getByText(/Minimum BTC deposit:\s*0\.0002 BTC/)).toBeInTheDocument();
+  });
+
+  it('never renders the label with an amount-shaped gap after it', async () => {
+    renderWithProviders(
+      <MinDepositInfo state={state({ minAmount: null, fiatEquivalent: null })} />
+    );
+    await expect.element(page.getByText(/Minimum BTC deposit:\s*unavailable/)).toBeInTheDocument();
+  });
+});

--- a/src/components/Buzz/CryptoDeposit/CurrencySelector.tsx
+++ b/src/components/Buzz/CryptoDeposit/CurrencySelector.tsx
@@ -1,12 +1,4 @@
-import {
-  Badge,
-  Group,
-  Menu,
-  Skeleton,
-  Stack,
-  Text,
-  UnstyledButton,
-} from '@mantine/core';
+import { Badge, Group, Menu, Skeleton, Stack, Text, UnstyledButton } from '@mantine/core';
 import React, { useCallback, useMemo, useState } from 'react';
 import { getFiatDisplay } from '~/components/Buzz/CryptoDeposit/crypto-deposit.constants';
 import { useSupportedCurrencies } from '~/components/Buzz/CryptoDeposit/crypto-deposit.hooks';
@@ -133,9 +125,7 @@ export function CurrencyBadges({ state }: { state: CurrencySelectionState }) {
                     className="cursor-pointer"
                   >
                     {group.ticker.toUpperCase()}
-                    <span className="ml-0.5 opacity-60">
-                      ·{group.networks.length}
-                    </span>
+                    <span className="ml-0.5 opacity-60">·{group.networks.length}</span>
                   </Badge>
                 </UnstyledButton>
               </Menu.Target>
@@ -191,8 +181,7 @@ export function MinDepositInfo({ state }: { state: CurrencySelectionState }) {
     <Group gap={4} align="center">
       <Text component="div" size="xs" c="dimmed">
         Minimum {selectedTicker.toUpperCase()} deposit
-        {networkLabel ? ` on ${networkLabel}` : ''}
-        :{' '}
+        {networkLabel ? ` on ${networkLabel}` : ''}:{' '}
         {loadingMin ? (
           <Skeleton height={12} width={40} radius="sm" className="inline-block align-middle" />
         ) : minData?.fiatEquivalent != null ? (
@@ -200,8 +189,21 @@ export function MinDepositInfo({ state }: { state: CurrencySelectionState }) {
             {fiatSymbol}
             {(Math.ceil(minData.fiatEquivalent * 100) / 100).toFixed(2)}
           </Text>
-        ) : null}
-        {' '}
+        ) : minData?.minAmount != null ? (
+          // NowPayments returns `fiat_equivalent` as a nullish field; the crypto amount is the one
+          // that is always there. Falling back to it keeps a number on the line rather than an
+          // amount-shaped gap.
+          <Text span fw={600}>
+            {minData.minAmount} {selectedTicker.toUpperCase()}
+          </Text>
+        ) : (
+          // Never render the label with nothing after it. This line is the only thing between a
+          // depositor and a sub-minimum send, which NowPayments does not sweep and does not refund,
+          // and a blank reads as "no minimum" rather than as "we could not fetch it".
+          <Text span fw={600}>
+            unavailable — check before sending
+          </Text>
+        )}{' '}
         <FiatMenu selectedFiat={selectedFiat} onFiatChange={onFiatChange} />
       </Text>
     </Group>


### PR DESCRIPTION
## What was wrong

`MinDepositInfo` rendered the amount only when `fiat_equivalent` was present, with no fallback and no error state:

```tsx
) : minData?.fiatEquivalent != null ? (
  <Text span fw={600}>{fiatSymbol}{…}</Text>
) : null}
```

NowPayments returns `fiat_equivalent` as a **nullish** field (`z.number().nullish()` in our own schema), so the line could render as `Minimum BTC deposit:` followed by nothing.

That line is the only thing standing between a depositor and a sub-minimum send. Below NowPayments' floor the deposit is not swept and not refunded; below roughly $11 in BTC it cannot be completed manually either. **A blank reads as "no minimum", not as "we could not fetch it."**

## The fix

Falls back to `min_amount` — the crypto figure, which the response always carries — and to an explicit `unavailable — check before sending` when neither is available. Three branches, no other behaviour changed.

## What this is NOT

The minimum itself is **correct and per-network**, and has been since 2026-03-11. Measured on production 2026-08-31 ~21:00 UTC: BTC **$16.71**, USDT-TRC20 **$14.31**, ETH $0.41, USDC-Base $0.05, one `getMinAmount` call per selected network — and the rendered page updates on every currency selection. CU `868kx7mvn` reported a flat ~$0.02 default regardless of selection; that does not reproduce at either layer, and the `$0.05` floor has been in the code since 2026-03-13, so this path has not produced $0.02 since before the ticket was filed. This PR fixes only the empty case.

The bigger problem the investigation surfaced — the minimum is displayed on a page a returning depositor never reloads, because the deposit address is permanent by design — is a product decision, filed as CU `868kz1paw`.

## Verification

| Check | Result |
|---|---|
| `pnpm run typecheck` | **0 errors**, unfiltered |
| `pnpm exec eslint`, both files | **0 errors, 0 warnings** |
| `pnpm exec prettier --write` | clean |
| `--project component`, this file | **3 passed (3)** |
| Full unit suite | `Test Files 4 failed \| 1530 passed \| 2 skipped (1536)`, `Tests 10 failed \| 24123 passed \| 28 skipped (24161)`, exit 1 |
| `blocks.router.workflow.test.ts` | **370 tests** collected |

The 4 failing files are the same 4 that fail on this base with nothing of mine in the tree — `trace-flush`, `appModeratorMessageForm.callSites`, `credential-detection-superset.guard`, `blocks/tools/registry`. Two are Windows-path artifacts; one opens `C:\C:\Dev\...`.

### The tests can fail

Not "I added an assertion and it passes". Reverted the fix and re-ran:

| Mutant | Result |
|---|---|
| both new branches collapsed back to `: null` (the pre-fix code) | **2 failed \| 1 passed** — `Cannot find element with locator: getByText(/Minimum BTC deposit:\s*0\.0002 BTC/)` and the same for `unavailable` |
| crypto-amount fallback dropped, `unavailable` kept | **1 failed \| 2 passed** |
| pristine control, before and after | 3 passed (3) |

Each assertion matches the **label and the value together**, so a blank cannot satisfy one. The first test expects `$17.45` from an input of `17.44`, which is not a typo: the line ceils to the next cent, rounding a minimum up.

CU `868kx7mvn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
