### PR TITLE
feat(models): say so when a template's retired model type is replaced

### DIFF
--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -66,7 +66,7 @@ import {
 import type { ModelById } from '~/types/router';
 import { showErrorNotification } from '~/utils/notifications';
 import { parseNumericString } from '~/utils/query-string-helpers';
-import { getModelUrl, splitUppercase, titleCase } from '~/utils/string-helpers';
+import { getDisplayName, getModelUrl, splitUppercase, titleCase } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
 import styles from './ModelUpsertForm.module.scss';
@@ -153,7 +153,7 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   // `grandfatheredType` that kept recomputing could drift from it if a caller ever mounted this
   // form before `model` arrived.
   const initialModel = useRef(model).current;
-  const { grandfatheredType, initialType } = resolveModelTypeDefaults(initialModel);
+  const { grandfatheredType, initialType, replacedType } = resolveModelTypeDefaults(initialModel);
   const defaultValues: ModelUpsertSchema = {
     ...model,
     name: model?.name ?? '',
@@ -348,6 +348,18 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
           <Stack>
             <InputText name="name" label="Name" placeholder="Name" withAsterisk />
             <Stack gap={5}>
+              {replacedType && (
+                <AlertWithIcon
+                  color="yellow"
+                  iconColor="yellow"
+                  icon={<IconExclamationMark />}
+                  size="sm"
+                >
+                  {`This template is ${getDisplayName(
+                    replacedType
+                  )}, which new models can no longer be. The type has been set to Other. Pick the one that fits before you publish.`}
+                </AlertWithIcon>
+              )}
               <Group gap="sm" grow>
                 <InputSelect
                   name="type"

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -127,6 +127,7 @@ describe('model type picker data', () => {
     expect(saved).toStrictEqual({
       grandfatheredType: ModelType.TextualInversion,
       initialType: ModelType.TextualInversion,
+      replacedType: null,
     });
     expect(getModelTypeSelectData(saved.grandfatheredType).map(({ value }) => value)).toContain(
       ModelType.TextualInversion
@@ -140,16 +141,20 @@ describe('model type picker data', () => {
     expect(fromTemplate).toStrictEqual({
       grandfatheredType: null,
       initialType: ModelType.Other,
+      // Named so the form can say what it dropped instead of substituting silently.
+      replacedType: ModelType.TextualInversion,
     });
 
     // A template on a type that is still offered is untouched.
     expect(resolveModelTypeDefaults({ type: ModelType.LORA })).toStrictEqual({
       grandfatheredType: null,
       initialType: ModelType.LORA,
+      replacedType: null,
     });
     expect(resolveModelTypeDefaults(undefined)).toStrictEqual({
       grandfatheredType: null,
       initialType: ModelType.Checkpoint,
+      replacedType: null,
     });
   });
 
@@ -186,6 +191,9 @@ describe('model type picker data', () => {
     expect(source).toMatch(/resolveModelTypeDefaults\(initialModel\)/);
     expect(source).toMatch(/getModelTypeSelectData\(grandfatheredType\)/);
     expect(source).toMatch(/type: initialType,/);
+    // The substitution has to be visible; Justin asked for the notice explicitly (2026-09-01).
+    expect(source).toMatch(/\{replacedType && \(/);
+    expect(source).toMatch(/The type has been set to Other/);
     expect(source).not.toContain('getModelTypeSelectData(type)');
     expect(source).not.toContain('resolveModelTypeDefaults(model)');
   });

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -106,19 +106,20 @@ export const defaultModelType = ModelType.Checkpoint;
  * value, which submits.
  *
  * A saved model keeps its type whatever it is, retired or not, and the picker re-offers it. A
- * template or bounty seeds a NEW model, so a retired type there falls back to `Other` rather than to
- * `Checkpoint` — the substitution is invisible either way, and `Other` is the one selectable type
- * that claims nothing about the model. Filing a pose pack as a fine-tune is the worse silent error.
+ * template or bounty seeds a NEW model, so a retired type there falls back to `Other`, the one
+ * selectable type that claims nothing about the model. `replacedType` names what was dropped, so the
+ * form can say so rather than substituting silently.
  */
 export function resolveModelTypeDefaults(model: ModelTypeSeed) {
   const seeded = (model?.type ?? null) as ModelType | null;
   const isSaved = !!model?.id;
 
-  if (isSaved && seeded) return { grandfatheredType: seeded, initialType: seeded };
-  if (!seeded) return { grandfatheredType: null, initialType: defaultModelType };
+  if (isSaved && seeded)
+    return { grandfatheredType: seeded, initialType: seeded, replacedType: null };
+  if (!seeded)
+    return { grandfatheredType: null, initialType: defaultModelType, replacedType: null };
+  if (selectableModelTypeSet.has(seeded))
+    return { grandfatheredType: null, initialType: seeded, replacedType: null };
 
-  return {
-    grandfatheredType: null,
-    initialType: selectableModelTypeSet.has(seeded) ? seeded : ModelType.Other,
-  };
+  return { grandfatheredType: null, initialType: ModelType.Other, replacedType: seeded };
 }


### PR DESCRIPTION
Follows #4521 (merged). Branched off `origin/main` after that merge, not off the merged branch.

#4521 stopped a template minting a retired model type by falling back to `Other`. Correct, but silent: someone using a `Poses` or embedding model as a template got a new model typed `Other` with nothing saying their template's type had been dropped. Justin asked for a notice.

`resolveModelTypeDefaults` now returns a third value, `replacedType`, naming what it replaced, and the form renders it above the picker:

> This template is Poses, which new models can no longer be. The type has been set to Other. Pick the one that fits before you publish.

`replacedType` is `null` on every other path — a saved model, a fresh create, and a template whose type is still offered — so the notice cannot appear when nothing was replaced.

## Verification

- `pnpm run typecheck` — `typecheck: OK — 0 type errors in 257s`, exit 0.
- `pnpm exec eslint` on the three changed files — **0 errors**, exit 0.
- `pnpm run test:unit:run` — `Test Files  6 failed | 1536 passed | 3 skipped (1545)`, `Tests  12 failed | 24225 passed | 35 skipped (24272)`, exit 1. **All six failures are pre-existing on this base**: stashing the change and re-running those six files alone on clean `origin/main` gives `Test Files  6 failed (6)` / `Tests  12 failed | 104 passed (116)` — the same twelve. They are `trace-flush`, `appModeratorMessageForm.callSites`, `credential-detection-superset.guard`, `no-direct-shared-module-mock`, `no-hand-typed-redis-key-constants` and `blocks/tools/registry`. Two of those are new since #4521's base; `main` moved under this branch, they are not from this diff.

Controls, both failing legibly:

| Mutation | Result |
|---|---|
| Resolver stops naming what it dropped (`replacedType: null`) | 1 failed — `expected { grandfatheredType: null, …(2) } to strictly equal { …(2) }` |
| Notice removed from the form (`{false && (`) | 1 failed — `expected … to match /\{replacedType && \(/` |

The second is a source-reading assertion on `ModelUpsertForm.tsx`, for the same reason as the guards in #4521: the resolver can return `replacedType` correctly while nothing renders it, and no data-level assertion can see that.

## Not covered

The notice has not been seen in a browser. It is asserted at the data layer and by reading the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JixurvMzNDe2C5fiRduwyj
