### PR TITLE
feat(home): rotate featured collections instead of redrawing them

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2302,6 +2302,10 @@ const REDIS_KEYS_UNPREFIXED = {
   HOMEBLOCKS: {
     BASE: 'packed:home-blocks',
     FEATURED_COLLECTIONS_STATE: 'home-blocks:featured-collections:state',
+    // The current rotation pass: eligible collection ids that have not had their turn yet. At most
+    // one integer per eligible collection, consumed from the front, with an hour's TTL.
+    FEATURED_COLLECTIONS_CYCLE: 'home-blocks:featured-collections:cycle',
+    FEATURED_COLLECTIONS_CYCLE_LOCK: 'home-blocks:featured-collections:cycle-lock',
     FEATURED_COLLECTIONS_LAST_PICKED: 'home-blocks:featured-collections:last-picked',
   },
   CACHE_LOCKS: 'cache-lock',

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2306,7 +2306,6 @@ const REDIS_KEYS_UNPREFIXED = {
     // one integer per eligible collection, consumed from the front, with an hour's TTL.
     FEATURED_COLLECTIONS_CYCLE: 'home-blocks:featured-collections:cycle',
     FEATURED_COLLECTIONS_CYCLE_LOCK: 'home-blocks:featured-collections:cycle-lock',
-    FEATURED_COLLECTIONS_LAST_PICKED: 'home-blocks:featured-collections:last-picked',
   },
   CACHE_LOCKS: 'cache-lock',
   BUZZ: {

--- a/src/server/jobs/refresh-featured-collections-eligibility.ts
+++ b/src/server/jobs/refresh-featured-collections-eligibility.ts
@@ -8,7 +8,6 @@ import { createJob } from './job';
 const DEFAULT_STALE_DAYS = 5;
 const DEFAULT_MIN_RECENT_ITEMS = 3;
 const STATE_KEY = REDIS_KEYS.HOMEBLOCKS.FEATURED_COLLECTIONS_STATE;
-const LAST_PICKED_KEY = REDIS_KEYS.HOMEBLOCKS.FEATURED_COLLECTIONS_LAST_PICKED;
 
 export type FeaturedCollectionEntry = {
   recentCount: number;
@@ -40,18 +39,6 @@ export async function getFeaturedCollectionsState(): Promise<FeaturedCollections
 
 async function writeState(state: FeaturedCollectionsState) {
   await redis.set(STATE_KEY, JSON.stringify(state));
-}
-
-export async function getLastPickedId(): Promise<number | null> {
-  const raw = await redis.get(LAST_PICKED_KEY);
-  if (!raw) return null;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : null;
-}
-
-// Separate key (SET only) so concurrent hydration doesn't R-M-W the eligibility blob.
-export async function setLastPickedId(id: number) {
-  await redis.set(LAST_PICKED_KEY, String(id));
 }
 
 export async function computeFeaturedCollectionsState(): Promise<FeaturedCollectionsState | null> {

--- a/src/server/services/__tests__/featured-collections-rotation.test.ts
+++ b/src/server/services/__tests__/featured-collections-rotation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { takeFeaturedCollectionCycle } from '~/server/services/featured-collections-rotation';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import {
+  liveRotationDeps,
+  takeFeaturedCollectionCycle,
+} from '~/server/services/featured-collections-rotation';
 
 /**
  * An in-memory stand-in for the three list commands and the lock, so the tests exercise the real
@@ -10,29 +14,54 @@ import { takeFeaturedCollectionCycle } from '~/server/services/featured-collecti
  * would hide a branch.
  */
 function fakeRedis({ lockHeldByAnother = false }: { lockHeldByAnother?: boolean } = {}) {
-  const state = { list: [] as string[], ttl: null as number | null, locked: false };
+  // Key-addressed on purpose. A fake that ignores the key argument cannot tell a DEL of the lock
+  // from a DEL of the pass — and deleting the pass in the refill's `finally` would degrade the
+  // cycle to the random draw permanently, with every assertion still green.
+  const lists = new Map<string, string[]>();
+  const ttls = new Map<string, number>();
+  const locks = new Map<string, string>();
+  const list = (key: string) => lists.get(key) ?? [];
+
   const deps = {
-    lPopCount: vi.fn(async (_key: string, count: number) => {
-      if (state.list.length === 0) return null;
-      return state.list.splice(0, count);
+    lPopCount: vi.fn(async (key: string, count: number) => {
+      const held = list(key);
+      if (held.length === 0) return null;
+      const taken = held.splice(0, count);
+      lists.set(key, held);
+      return taken;
     }),
-    rPush: vi.fn(async (_key: string, values: string[]) => state.list.push(...values)),
-    expire: vi.fn(async (_key: string, seconds: number) => {
-      state.ttl = seconds;
+    lLen: vi.fn(async (key: string) => list(key).length),
+    rPush: vi.fn(async (key: string, values: string[]) => {
+      const held = list(key);
+      held.push(...values);
+      lists.set(key, held);
+      return held.length;
+    }),
+    expire: vi.fn(async (key: string, seconds: number) => {
+      // Real EXPIRE on a missing key sets nothing and returns 0, so an `expire` hoisted above the
+      // push would silently never apply.
+      if (list(key).length === 0) return 0;
+      ttls.set(key, seconds);
       return 1;
     }),
-    setLock: vi.fn(async () => {
-      if (lockHeldByAnother || state.locked) return null;
-      state.locked = true;
+    setLock: vi.fn(async (key: string, token: string) => {
+      if (lockHeldByAnother || locks.has(key)) return null;
+      locks.set(key, token);
       return 'OK';
     }),
-    del: vi.fn(async () => {
-      state.locked = false;
+    readKey: vi.fn(async (key: string) => locks.get(key) ?? null),
+    del: vi.fn(async (key: string) => {
+      locks.delete(key);
+      lists.delete(key);
+      ttls.delete(key);
       return 1;
     }),
   };
-  return { state, deps };
+  return { lists, ttls, locks, deps };
 }
+
+const CYCLE_KEY = 'home-blocks:featured-collections:cycle';
+const LOCK_KEY = 'home-blocks:featured-collections:cycle-lock';
 
 const ELIGIBLE = [11, 22, 33, 44, 55, 66, 77];
 
@@ -57,36 +86,35 @@ describe('takeFeaturedCollectionCycle', () => {
     // a re-added id only duplicates when it happens to land in the remaining pops, so asserting
     // on the result is a coin flip that passes most of the time with the exclusion removed.
     await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
-    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
-    deps.rPush.mockClear();
+    const second = await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
     const spanning = await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
 
     expect(spanning).toHaveLength(3);
     expect(new Set(spanning).size).toBe(3);
-    // The refill legitimately supplies the rest of this draw, so most of what it pushed WILL be in
-    // the result. The invariant is narrower: the id already taken before the refill — the first
-    // one, since picks accumulate in order — must not be pushed back into the new pass.
-    const pushed = (deps.rPush.mock.calls[0]?.[1] ?? []).map(Number);
+    // The draw that spans a refill must not repeat the one before it either: the new pass excludes
+    // what the refill's own draw took, and a rewritten pass cannot hold a queued duplicate.
+    expect(spanning.filter((id) => second.includes(id))).toEqual([]);
+    const pushed = (deps.rPush.mock.calls.at(-1)?.[1] ?? []).map(Number);
     expect(pushed).not.toHaveLength(0);
-    expect(pushed).not.toContain(spanning[0]);
+    expect(new Set(pushed).size).toBe(pushed.length);
   });
 
   it('puts an hour on the pass so an idle key cannot pin a stale ordering', async () => {
-    const { state, deps } = fakeRedis();
+    const { ttls, deps } = fakeRedis();
 
     await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
 
-    expect(state.ttl).toBe(60 * 60);
+    expect(ttls.get(CYCLE_KEY)).toBe(60 * 60);
   });
 
   it('drops ids that are no longer eligible and still fills the draw', async () => {
-    const { state, deps } = fakeRedis();
+    const { lists, deps } = fakeRedis();
     await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
 
     // Two collections go stale between draws; their ids are still sitting in the pass. The queue
     // holds strings, so these have to be compared as numbers — the first version of this test
     // compared them raw, filtered nothing, and passed for any implementation.
-    const stale = state.list.slice(0, 2).map(Number);
+    const stale = (lists.get(CYCLE_KEY) ?? []).slice(0, 2).map(Number);
     expect(stale).toHaveLength(2);
     const stillEligible = ELIGIBLE.filter((id) => !stale.includes(id));
     const picks = await takeFeaturedCollectionCycle(stillEligible, 3, deps);
@@ -112,6 +140,8 @@ describe('takeFeaturedCollectionCycle', () => {
       lPopCount: vi.fn(async () => {
         throw new Error('ECONNREFUSED');
       }),
+      lLen: vi.fn(async () => 0),
+      readKey: vi.fn(async () => null),
       rPush: vi.fn(async () => 0),
       expire: vi.fn(async () => 1),
       setLock: vi.fn(async () => null),
@@ -125,12 +155,75 @@ describe('takeFeaturedCollectionCycle', () => {
   });
 
   it('releases the refill lock even when the push fails', async () => {
-    const { deps } = fakeRedis();
+    const { locks, deps } = fakeRedis();
     deps.rPush.mockRejectedValueOnce(new Error('write failed'));
 
     await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
 
-    expect(deps.del).toHaveBeenCalled();
+    expect(deps.del).toHaveBeenCalledWith(LOCK_KEY);
+    expect(locks.has(LOCK_KEY)).toBe(false);
+  });
+
+  it('does not release a lock it no longer holds', async () => {
+    // A refill that overran the 10s TTL would otherwise delete whoever holds the lock now, and two
+    // concurrent rewrites are the thing the lock exists to prevent.
+    const { locks, deps } = fakeRedis();
+    deps.rPush.mockImplementationOnce(async () => {
+      locks.set(LOCK_KEY, 'someone-elses-token');
+      return 1;
+    });
+
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    expect(deps.del).not.toHaveBeenCalledWith(LOCK_KEY);
+    expect(locks.get(LOCK_KEY)).toBe('someone-elses-token');
+  });
+
+  // The pass empties EXACTLY whenever the eligible count is a multiple of the draw size, and the
+  // pool has sat at 10 eligible. Before the top-up, the next draw refilled with nothing excluded,
+  // so the fresh pass contained the five just shown — 10.3% odds of repeating 4 of 5, which is the
+  // scheme this replaces. ELIGIBLE is 7 and every other test draws 3, so none of them can see it.
+  it('does not repeat across a pass that empties exactly', async () => {
+    const tenEligible = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const { deps } = fakeRedis();
+
+    const first = await takeFeaturedCollectionCycle(tenEligible, 5, deps);
+    const second = await takeFeaturedCollectionCycle(tenEligible, 5, deps);
+    const third = await takeFeaturedCollectionCycle(tenEligible, 5, deps);
+
+    expect(new Set([...first, ...second]).size).toBe(10);
+    expect(third.filter((id) => second.includes(id))).toEqual([]);
+  });
+
+  // A fixed pass order would satisfy every other assertion here — same ids, same turns — while the
+  // homepage showed the same five in the same sequence forever. Two cold starts must differ.
+  it('shuffles each pass rather than dealing a fixed order', async () => {
+    const orders = new Set<string>();
+    for (let run = 0; run < 12; run++) {
+      const { deps } = fakeRedis();
+      orders.add((await takeFeaturedCollectionCycle(ELIGIBLE, 7, deps)).join(','));
+    }
+
+    expect(orders.size).toBeGreaterThan(1);
+  });
+
+  // A stale id at the head under-fills a draw WITHOUT emptying the pass, so the refill runs while
+  // entries are still queued. Appending there stacked two passes in one key: the queued ids appear
+  // again in the new pass, so a collection can be drawn twice and one shown this window can return
+  // in the next. Replacing the pass is what makes that impossible.
+  it('does not leave a queued id sitting in the pass twice', async () => {
+    const { lists, deps } = fakeRedis();
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    const queued = () => (lists.get(CYCLE_KEY) ?? []).map(Number);
+    const goneStale = queued()[0];
+    const stillEligible = ELIGIBLE.filter((id) => id !== goneStale);
+
+    const second = await takeFeaturedCollectionCycle(stillEligible, 3, deps);
+    const afterRefill = queued();
+
+    expect(new Set(afterRefill).size).toBe(afterRefill.length);
+    expect(afterRefill.filter((id) => second.includes(id))).toEqual([]);
   });
 
   it('asks for no more than the pool holds', async () => {
@@ -144,12 +237,31 @@ describe('takeFeaturedCollectionCycle', () => {
     // The pass is shared state. Popping `count` when only two collections are eligible would
     // discard the turns of everything else still queued behind them — invisible in the result,
     // and the next draw would skip those collections entirely.
-    const { state, deps } = fakeRedis();
+    const { lists, deps } = fakeRedis();
     await takeFeaturedCollectionCycle(ELIGIBLE, 1, deps);
-    const queuedBefore = state.list.length;
+    const queued = () => lists.get(CYCLE_KEY) ?? [];
+    const queuedBefore = queued().length;
 
-    await takeFeaturedCollectionCycle([Number(state.list[0])], 5, deps);
+    await takeFeaturedCollectionCycle([Number(queued()[0])], 5, deps);
 
-    expect(state.list.length).toBe(queuedBefore - 1);
+    expect(queued().length).toBe(queuedBefore - 1);
+  });
+
+  // The live bindings are otherwise unreachable: every other test injects its own deps, so
+  // `NX: true` becoming `NX: false` — every instance winning the lock and pushing its own pass —
+  // and RPUSH becoming LPUSH would both be invisible.
+  describe('live Redis bindings', () => {
+    it('takes the refill lock only when nobody holds it', async () => {
+      await liveRotationDeps.setLock('k', 'token', 10);
+
+      expect(redisMock.redis.set).toHaveBeenCalledWith('k', 'token', { NX: true, EX: 10 });
+    });
+
+    it('appends a new pass to the tail so it is consumed in order', async () => {
+      await liveRotationDeps.rPush('k', ['1', '2']);
+
+      expect(redisMock.redis.rPush).toHaveBeenCalledWith('k', ['1', '2']);
+      expect(redisMock.redis.lPush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/server/services/__tests__/featured-collections-rotation.test.ts
+++ b/src/server/services/__tests__/featured-collections-rotation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+import { takeFeaturedCollectionCycle } from '~/server/services/featured-collections-rotation';
+
+/**
+ * An in-memory stand-in for the three list commands and the lock, so the tests exercise the real
+ * cycle arithmetic rather than assertions about which commands were called.
+ *
+ * `lPopCount` pops from the front and returns `null` on an empty key, which is what node-redis
+ * does — the production code treats that as "the pass is spent", so a fake returning `[]` instead
+ * would hide a branch.
+ */
+function fakeRedis({ lockHeldByAnother = false }: { lockHeldByAnother?: boolean } = {}) {
+  const state = { list: [] as string[], ttl: null as number | null, locked: false };
+  const deps = {
+    lPopCount: vi.fn(async (_key: string, count: number) => {
+      if (state.list.length === 0) return null;
+      return state.list.splice(0, count);
+    }),
+    rPush: vi.fn(async (_key: string, values: string[]) => state.list.push(...values)),
+    expire: vi.fn(async (_key: string, seconds: number) => {
+      state.ttl = seconds;
+      return 1;
+    }),
+    setLock: vi.fn(async () => {
+      if (lockHeldByAnother || state.locked) return null;
+      state.locked = true;
+      return 'OK';
+    }),
+    del: vi.fn(async () => {
+      state.locked = false;
+      return 1;
+    }),
+  };
+  return { state, deps };
+}
+
+const ELIGIBLE = [11, 22, 33, 44, 55, 66, 77];
+
+describe('takeFeaturedCollectionCycle', () => {
+  it('gives every collection a turn before repeating any', async () => {
+    const { deps } = fakeRedis();
+    const seen: number[] = [];
+
+    // 7 eligible, 3 per draw: the first two draws plus one from the third complete a pass.
+    for (let draw = 0; draw < 2; draw++)
+      seen.push(...(await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps)));
+
+    expect(seen).toHaveLength(6);
+    expect(new Set(seen).size).toBe(6);
+  });
+
+  it('never shows the same collection twice in one draw, even across a pass boundary', async () => {
+    const { deps } = fakeRedis();
+
+    // Draws of 3 from a pool of 7 leave one item in the pass before the third draw, so that draw
+    // spans a refill. Asserted on what the refill PUSHED rather than on the ids that came back:
+    // a re-added id only duplicates when it happens to land in the remaining pops, so asserting
+    // on the result is a coin flip that passes most of the time with the exclusion removed.
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+    deps.rPush.mockClear();
+    const spanning = await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    expect(spanning).toHaveLength(3);
+    expect(new Set(spanning).size).toBe(3);
+    // The refill legitimately supplies the rest of this draw, so most of what it pushed WILL be in
+    // the result. The invariant is narrower: the id already taken before the refill — the first
+    // one, since picks accumulate in order — must not be pushed back into the new pass.
+    const pushed = (deps.rPush.mock.calls[0]?.[1] ?? []).map(Number);
+    expect(pushed).not.toHaveLength(0);
+    expect(pushed).not.toContain(spanning[0]);
+  });
+
+  it('puts an hour on the pass so an idle key cannot pin a stale ordering', async () => {
+    const { state, deps } = fakeRedis();
+
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    expect(state.ttl).toBe(60 * 60);
+  });
+
+  it('drops ids that are no longer eligible and still fills the draw', async () => {
+    const { state, deps } = fakeRedis();
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    // Two collections go stale between draws; their ids are still sitting in the pass. The queue
+    // holds strings, so these have to be compared as numbers — the first version of this test
+    // compared them raw, filtered nothing, and passed for any implementation.
+    const stale = state.list.slice(0, 2).map(Number);
+    expect(stale).toHaveLength(2);
+    const stillEligible = ELIGIBLE.filter((id) => !stale.includes(id));
+    const picks = await takeFeaturedCollectionCycle(stillEligible, 3, deps);
+
+    expect(picks).toHaveLength(3);
+    expect(picks.every((id) => stillEligible.includes(id))).toBe(true);
+  });
+
+  it('still returns a full draw when another instance is refilling', async () => {
+    // Several instances can miss the 3-minute cache together. Losing the refill race must not
+    // return a short list — the page renders either way, it just does not rotate this window.
+    const { deps } = fakeRedis({ lockHeldByAnother: true });
+
+    const picks = await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    expect(picks).toHaveLength(3);
+    expect(new Set(picks).size).toBe(3);
+    expect(deps.rPush).not.toHaveBeenCalled();
+  });
+
+  it('still returns a full draw when Redis is down', async () => {
+    const down = {
+      lPopCount: vi.fn(async () => {
+        throw new Error('ECONNREFUSED');
+      }),
+      rPush: vi.fn(async () => 0),
+      expire: vi.fn(async () => 1),
+      setLock: vi.fn(async () => null),
+      del: vi.fn(async () => 1),
+    };
+
+    const picks = await takeFeaturedCollectionCycle(ELIGIBLE, 3, down);
+
+    expect(picks).toHaveLength(3);
+    expect(new Set(picks).size).toBe(3);
+  });
+
+  it('releases the refill lock even when the push fails', async () => {
+    const { deps } = fakeRedis();
+    deps.rPush.mockRejectedValueOnce(new Error('write failed'));
+
+    await takeFeaturedCollectionCycle(ELIGIBLE, 3, deps);
+
+    expect(deps.del).toHaveBeenCalled();
+  });
+
+  it('asks for no more than the pool holds', async () => {
+    const { deps } = fakeRedis();
+
+    expect(await takeFeaturedCollectionCycle([11, 22], 5, deps)).toHaveLength(2);
+    expect(await takeFeaturedCollectionCycle([], 5, deps)).toEqual([]);
+  });
+
+  it('does not spend other collections turns to fill a short draw', async () => {
+    // The pass is shared state. Popping `count` when only two collections are eligible would
+    // discard the turns of everything else still queued behind them — invisible in the result,
+    // and the next draw would skip those collections entirely.
+    const { state, deps } = fakeRedis();
+    await takeFeaturedCollectionCycle(ELIGIBLE, 1, deps);
+    const queuedBefore = state.list.length;
+
+    await takeFeaturedCollectionCycle([Number(state.list[0])], 5, deps);
+
+    expect(state.list.length).toBe(queuedBefore - 1);
+  });
+});

--- a/src/server/services/featured-collections-rotation.ts
+++ b/src/server/services/featured-collections-rotation.ts
@@ -1,5 +1,6 @@
 import { redis, REDIS_KEYS } from '~/server/redis/client';
-import { shuffle } from '~/utils/array-helpers';
+import { logToAxiom } from '~/server/logging/client';
+import { withTimeoutFallback } from '~/server/utils/timeout-helpers';
 
 /**
  * One pass of the rotation: the eligible collections that have not had their turn yet, in a
@@ -15,6 +16,17 @@ import { shuffle } from '~/utils/array-helpers';
  * The whole memory is this list — at most one integer per eligible collection, shrinking as it is
  * consumed. Nothing per-viewer is stored, and nothing here is authoritative: if the key is lost,
  * the next draw reshuffles and the only cost is that one collection's turn comes round sooner.
+ *
+ * ⚠️ Two limits on how strongly this can be stated, both measured rather than assumed:
+ *
+ * - **The bound is per DRAW, not per wall-clock window.** The block's cache entry has no
+ *   single-flight, so every request arriving during a 3-minute miss runs its own draw and only one
+ *   result is kept. At three concurrent consumers the gap stretched from 4 windows to 23 in
+ *   simulation, and 4-of-5 repeats reappeared at 3.1%. Serialising that fill is a change to the
+ *   home-block cache, not to this file.
+ * - **A repeat is not structurally impossible, only rare.** A new pass excludes the draw that
+ *   built it, so a boundary cannot repeat — but the pass before that is fair game, and the random
+ *   fallback (lost lock, cold key, slow Redis) does not consume a turn at all.
  */
 const CYCLE_KEY = REDIS_KEYS.HOMEBLOCKS.FEATURED_COLLECTIONS_CYCLE;
 const REFILL_LOCK_KEY = REDIS_KEYS.HOMEBLOCKS.FEATURED_COLLECTIONS_CYCLE_LOCK;
@@ -34,19 +46,50 @@ const CYCLE_TTL_SECONDS = 60 * 60;
  */
 const REFILL_LOCK_SECONDS = 10;
 
+/**
+ * A whole draw, not one command. Long enough that a healthy round trip never trips it, short
+ * enough that a page render is never parked waiting to be told which collections to show.
+ */
+const ROTATION_DEADLINE_MS = 250;
+
+/**
+ * Fisher-Yates, locally, rather than `~/utils/array-helpers`'s `shuffle` — that one is
+ * `sort(() => Math.random() - 0.5)`, an inconsistent comparator whose permutation distribution is
+ * strongly biased under V8's sort. The ordering guarantee here survives a biased shuffle, but the
+ * fairness argument for the scheme does not, and the simulation behind it assumed a uniform one.
+ * Fixing the shared helper is a repo-wide change and not this PR's business.
+ */
+function shufflePass(ids: number[]) {
+  const out = [...ids];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
 type RotationDeps = {
   lPopCount: (key: string, count: number) => Promise<string[] | null>;
+  lLen: (key: string) => Promise<number>;
   rPush: (key: string, values: string[]) => Promise<number>;
   expire: (key: string, seconds: number) => Promise<unknown>;
-  setLock: (key: string, seconds: number) => Promise<string | null>;
+  setLock: (key: string, token: string, seconds: number) => Promise<string | null>;
+  readKey: (key: string) => Promise<string | null>;
   del: (key: string) => Promise<unknown>;
 };
 
-const liveDeps: RotationDeps = {
+/**
+ * Exported for tests. Every test passes its own `deps`, so without this the actual node-redis
+ * bindings — `NX: true` on the lock, RPUSH rather than LPUSH — are the one part of the file no
+ * assertion can reach, and a mutation there would be invisible.
+ */
+export const liveRotationDeps: RotationDeps = {
   lPopCount: (key, count) => redis.lPopCount(key as never, count),
+  lLen: (key) => redis.lLen(key as never),
   rPush: (key, values) => redis.rPush(key as never, values),
   expire: (key, seconds) => redis.expire(key as never, seconds),
-  setLock: (key, seconds) => redis.set(key as never, '1', { NX: true, EX: seconds }),
+  setLock: (key, token, seconds) => redis.set(key as never, token, { NX: true, EX: seconds }),
+  readKey: (key) => redis.get(key as never),
   del: (key) => redis.del(key as never),
 };
 
@@ -64,11 +107,26 @@ const liveDeps: RotationDeps = {
 export async function takeFeaturedCollectionCycle(
   eligible: number[],
   count: number,
-  deps: RotationDeps = liveDeps
+  deps: RotationDeps = liveRotationDeps
 ): Promise<number[]> {
   const want = Math.min(count, eligible.length);
   if (want <= 0) return [];
 
+  // The rotation is a nicety; the page is not. A stalled Redis is not a failed one, so the
+  // try/catch below never fires for it — the cluster client's own deadline is 15s per command and
+  // a refill serialises six of them. Race the whole thing instead and let the random draw win.
+  return withTimeoutFallback(
+    drawFromCycle(eligible, want, deps),
+    ROTATION_DEADLINE_MS,
+    shufflePass(eligible).slice(0, want)
+  );
+}
+
+async function drawFromCycle(
+  eligible: number[],
+  want: number,
+  deps: RotationDeps
+): Promise<number[]> {
   const eligibleIds = new Set(eligible);
   const picks: number[] = [];
 
@@ -85,14 +143,33 @@ export async function takeFeaturedCollectionCycle(
       if (picks.length >= want) break;
       if (attempt === 0) await refillCycle(eligible, picks, deps);
     }
-  } catch {
+
+    // Top the pass up if this draw drained it, excluding what this draw showed.
+    //
+    // Without this the exclusion has no memory across a draw boundary: when a pass empties
+    // EXACTLY — which happens whenever the eligible count is a multiple of the draw size, and 10
+    // of 5 sits inside the range the pool actually occupies — the next draw refills from scratch
+    // with nothing taken, so the new pass contains the five just shown. Hypergeometric odds of
+    // repeating 4 of 5 across that boundary: 10.3%, which is the scheme this replaces.
+    if (picks.length >= want && (await deps.lLen(CYCLE_KEY)) < want)
+      await refillCycle(eligible, picks, deps);
+  } catch (error) {
     // Redis unavailable or a command shape we do not expect: fall through to the random fill below
     // rather than failing the block. The homepage renders; it just does not rotate this window.
+    //
+    // Logged rather than swallowed, because the degraded state is invisible from the outside: a
+    // page that stopped rotating looks exactly like one that is rotating, so a silent catch here
+    // is a green nobody can falsify.
+    logToAxiom({
+      type: 'redis-degraded',
+      name: 'featured-collections-rotation',
+      message: error instanceof Error ? error.message : String(error),
+    }).catch(() => null);
   }
 
   if (picks.length < want) {
     // Whatever the cycle could not supply — a lost refill race, an empty key, a Redis fault.
-    const remainder = shuffle(eligible.filter((id) => !picks.includes(id)));
+    const remainder = shufflePass(eligible.filter((id) => !picks.includes(id)));
     picks.push(...remainder.slice(0, want - picks.length));
   }
 
@@ -100,23 +177,44 @@ export async function takeFeaturedCollectionCycle(
 }
 
 async function refillCycle(eligible: number[], taken: number[], deps: RotationDeps) {
-  const lock = await deps.setLock(REFILL_LOCK_KEY, REFILL_LOCK_SECONDS);
+  // Fenced with a token. `DistributedLock` in server/utils would also fence this, but it retries
+  // (10 attempts, 100ms apart) — correct for work that must happen, wrong inside a page render,
+  // where the right answer to a held lock is to skip the refill and draw at random.
+  const token = `${Date.now()}-${Math.random()}`;
+  const lock = await deps.setLock(REFILL_LOCK_KEY, token, REFILL_LOCK_SECONDS);
   // Somebody else is already building the next pass. Taking the random remainder is better than
   // waiting on them: the caller is inside a page render.
   if (!lock) return;
 
+  // The pass is REPLACED, not appended to. Appending stacked two passes whenever the list still
+  // held entries — a stale id at the head under-fills a draw without emptying the list — and the
+  // ids still queued then appeared in the new pass as well, so a collection could be drawn twice
+  // and one shown in this window could return in the next. Rewriting cannot lose a turn: anything
+  // still queued has not been shown, so it is in `eligible` and lands in the new pass anyway.
+  //
+  // The ids taken in THIS draw are excluded, which is what keeps a boundary-spanning draw and the
+  // draw after it from repeating.
+  const next = shufflePass(eligible.filter((id) => !taken.includes(id)));
+  if (next.length === 0) return;
+
   try {
-    // The ids taken in THIS draw are excluded from the pass being built, so a cycle boundary
-    // cannot show the same collection twice in one window.
-    const next = shuffle(eligible.filter((id) => !taken.includes(id)));
-    if (next.length > 0) {
-      await deps.rPush(
-        CYCLE_KEY,
-        next.map((id) => String(id))
-      );
-      await deps.expire(CYCLE_KEY, CYCLE_TTL_SECONDS);
-    }
+    await deps.del(CYCLE_KEY);
+    await deps.rPush(
+      CYCLE_KEY,
+      next.map((id) => String(id))
+    );
+    // EXPIRE on a missing key sets nothing and returns 0 — the pass would then live forever, which
+    // is the one invariant the docblock claims. Cheap to check, silent to assume.
+    if ((await deps.expire(CYCLE_KEY, CYCLE_TTL_SECONDS)) !== 1)
+      logToAxiom({
+        type: 'redis-degraded',
+        name: 'featured-collections-rotation',
+        message: 'cycle pass written without a TTL',
+      }).catch(() => null);
   } finally {
-    await deps.del(REFILL_LOCK_KEY);
+    // Released only if we still hold it. An unconditional delete is not fenced: a refill that
+    // overran the 10s TTL would delete whoever holds the lock NOW, and two concurrent rewrites are
+    // exactly what the lock exists to prevent.
+    if ((await deps.readKey(REFILL_LOCK_KEY)) === token) await deps.del(REFILL_LOCK_KEY);
   }
 }

--- a/src/server/services/featured-collections-rotation.ts
+++ b/src/server/services/featured-collections-rotation.ts
@@ -1,0 +1,122 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { shuffle } from '~/utils/array-helpers';
+
+/**
+ * One pass of the rotation: the eligible collections that have not had their turn yet, in a
+ * shuffled order, consumed from the front.
+ *
+ * The homepage draws every 3 minutes into a single shared cache entry, so the draw is per window
+ * rather than per viewer and a memoryless shuffle is what a visitor experiences as "the same five
+ * again". Measured over 200k simulated windows at 13 eligible: a uniform draw leaves a collection
+ * unshown for up to 99 minutes and repeats 4 of 5 on 3.1% of reloads (16.7% at 9 eligible). A
+ * cycle bounds the gap at `ceil((2n-1)/k)` windows and makes consecutive repeats structurally
+ * impossible.
+ *
+ * The whole memory is this list — at most one integer per eligible collection, shrinking as it is
+ * consumed. Nothing per-viewer is stored, and nothing here is authoritative: if the key is lost,
+ * the next draw reshuffles and the only cost is that one collection's turn comes round sooner.
+ */
+const CYCLE_KEY = REDIS_KEYS.HOMEBLOCKS.FEATURED_COLLECTIONS_CYCLE;
+const REFILL_LOCK_KEY = REDIS_KEYS.HOMEBLOCKS.FEATURED_COLLECTIONS_CYCLE_LOCK;
+
+/**
+ * An hour of no draws and the pass is abandoned. Long enough that ordinary traffic never loses a
+ * pass mid-way (a draw every 3 minutes touches the key 20 times an hour), short enough that an
+ * ordering built for a pool that has since changed does not linger.
+ */
+const CYCLE_TTL_SECONDS = 60 * 60;
+
+/**
+ * Held only across the reshuffle, and short: several instances can miss the 3-minute cache at the
+ * same moment, and without it each would push its own pass and the queue would hold several
+ * interleaved orderings. Losing the race is not an error — that caller takes what the list has and
+ * fills the rest randomly, which is exactly what it would have done on a cold key.
+ */
+const REFILL_LOCK_SECONDS = 10;
+
+type RotationDeps = {
+  lPopCount: (key: string, count: number) => Promise<string[] | null>;
+  rPush: (key: string, values: string[]) => Promise<number>;
+  expire: (key: string, seconds: number) => Promise<unknown>;
+  setLock: (key: string, seconds: number) => Promise<string | null>;
+  del: (key: string) => Promise<unknown>;
+};
+
+const liveDeps: RotationDeps = {
+  lPopCount: (key, count) => redis.lPopCount(key as never, count),
+  rPush: (key, values) => redis.rPush(key as never, values),
+  expire: (key, seconds) => redis.expire(key as never, seconds),
+  setLock: (key, seconds) => redis.set(key as never, '1', { NX: true, EX: seconds }),
+  del: (key) => redis.del(key as never),
+};
+
+/**
+ * Take the next `count` collections, in cycle order, filling from a fresh pass when the current
+ * one runs out.
+ *
+ * Ids that are no longer eligible are dropped as they surface rather than being swept up front:
+ * the list is at most a few dozen entries and a stale id costs one extra pop, where a read-filter-
+ * rewrite would need its own lock to be safe.
+ *
+ * Redis is not on the critical path for correctness — every failure mode here degrades to the
+ * random draw this replaces, because an unrotated homepage is a far better outcome than none.
+ */
+export async function takeFeaturedCollectionCycle(
+  eligible: number[],
+  count: number,
+  deps: RotationDeps = liveDeps
+): Promise<number[]> {
+  const want = Math.min(count, eligible.length);
+  if (want <= 0) return [];
+
+  const eligibleIds = new Set(eligible);
+  const picks: number[] = [];
+
+  try {
+    // Two attempts at most: what the current pass has left, then one refilled pass. A third would
+    // only ever fire if another instance drained the list in between, and looping on that is how a
+    // cold key turns into a spin.
+    for (let attempt = 0; attempt < 2 && picks.length < want; attempt++) {
+      const popped = (await deps.lPopCount(CYCLE_KEY, want - picks.length)) ?? [];
+      for (const raw of popped) {
+        const id = Number(raw);
+        if (eligibleIds.has(id) && !picks.includes(id)) picks.push(id);
+      }
+      if (picks.length >= want) break;
+      if (attempt === 0) await refillCycle(eligible, picks, deps);
+    }
+  } catch {
+    // Redis unavailable or a command shape we do not expect: fall through to the random fill below
+    // rather than failing the block. The homepage renders; it just does not rotate this window.
+  }
+
+  if (picks.length < want) {
+    // Whatever the cycle could not supply — a lost refill race, an empty key, a Redis fault.
+    const remainder = shuffle(eligible.filter((id) => !picks.includes(id)));
+    picks.push(...remainder.slice(0, want - picks.length));
+  }
+
+  return picks;
+}
+
+async function refillCycle(eligible: number[], taken: number[], deps: RotationDeps) {
+  const lock = await deps.setLock(REFILL_LOCK_KEY, REFILL_LOCK_SECONDS);
+  // Somebody else is already building the next pass. Taking the random remainder is better than
+  // waiting on them: the caller is inside a page render.
+  if (!lock) return;
+
+  try {
+    // The ids taken in THIS draw are excluded from the pass being built, so a cycle boundary
+    // cannot show the same collection twice in one window.
+    const next = shuffle(eligible.filter((id) => !taken.includes(id)));
+    if (next.length > 0) {
+      await deps.rPush(
+        CYCLE_KEY,
+        next.map((id) => String(id))
+      );
+      await deps.expire(CYCLE_KEY, CYCLE_TTL_SECONDS);
+    }
+  } finally {
+    await deps.del(REFILL_LOCK_KEY);
+  }
+}

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -36,6 +36,7 @@ import {
   computeFeaturedCollectionsState,
   getFeaturedCollectionsState,
 } from '~/server/jobs/refresh-featured-collections-eligibility';
+import { takeFeaturedCollectionCycle } from '~/server/services/featured-collections-rotation';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { GET_ALL_IMAGES_PER_MODEL_SLIM } from '~/server/utils/model-getall-images';
 import {
@@ -579,13 +580,10 @@ export const getHomeBlockData = async ({
         candidates.length
       );
 
-      // Fisher-Yates shuffle, take N.
-      const pool = [...candidates];
-      for (let i = pool.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [pool[i], pool[j]] = [pool[j], pool[i]];
-      }
-      const picks = pool.slice(0, renderCount);
+      // Round-robin over a shuffled pass rather than an independent draw each window. The block is
+      // cached for 3 minutes in one shared entry, so an uncorrelated shuffle shows every visitor in
+      // that window the same five and can repeat 4 of those 5 on the next one.
+      const picks = await takeFeaturedCollectionCycle(candidates, renderCount);
 
       const hydrated = await Promise.all(
         picks.map(async (id) => {

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -583,7 +583,11 @@ export const getHomeBlockData = async ({
       // Round-robin over a shuffled pass rather than an independent draw each window. The block is
       // cached for 3 minutes in one shared entry, so an uncorrelated shuffle shows every visitor in
       // that window the same five and can repeat 4 of those 5 on the next one.
-      const picks = await takeFeaturedCollectionCycle(candidates, renderCount);
+      // `withCoreData` renders no items — it is the admin block picker, not the homepage. Drawing
+      // from the shared pass there would spend the homepage's turns on a modal nobody is looking at.
+      const picks = input.withCoreData
+        ? candidates.slice(0, renderCount)
+        : await takeFeaturedCollectionCycle(candidates, renderCount);
 
       const hydrated = await Promise.all(
         picks.map(async (id) => {


### PR DESCRIPTION
## What

The homepage picks 5 of the eligible featured collections every 3 minutes into **one shared cache entry per domain**, so the draw is per window rather than per viewer. Each draw was an independent Fisher-Yates shuffle with no memory of the last one.

This replaces it with a shuffled-cycle pass: shuffle the eligible set once, hand out 5 per window, repeat nobody until everybody has had a turn.

## Why, with the numbers

200,000 simulated draw windows per scheme, worst cases re-checked across 25 seeds:

| | pure random (today) | shuffled cycle |
|---|---|---|
| worst gap, 13 eligible | 99 min (no ceiling) | 15 min (guaranteed) |
| worst gap, 9 eligible | 63 min | 12 min |
| reload repeats 4 of 5, 13 eligible | 3.1% | 0% |
| reload repeats 4 of 5, 9 eligible | **16.7%** | 0% |

⚠️ **Both cycle columns assume one draw per window and a healthy Redis.** Review found neither is guaranteed: `getHomeBlockCached` has no single-flight and `edgeCacheIt` opts out of batched tRPC requests, so concurrent renders each run a draw. Simulated at three concurrent consumers, the gap stretches to 23 windows and 4-of-5 repeats return at 3.1%. Serialising that fill is a change to the home-block cache, not to this file, and is not attempted here. The **ordering** property — nothing repeats until everything has had a turn — holds per draw regardless.

**What this does NOT do, stated plainly:** it does not change how often a given collection is seen. A visitor's odds are `renderCount / eligible` per visit under either scheme — 62.4% vs 62.0% across two visits. The lever that moved that number was raising `renderCount` from 3 to 5, which shipped separately. What changes here is the reload, and it matters most on a small pool, which is exactly when the complaint arrives.

Eligibility has ranged 9-13 over the last eight windows, so the 9-eligible row is the real case, not a hypothetical.

## How

One Redis list holds the current pass — at most one integer per eligible collection, consumed from the front, one hour TTL. Nothing per-viewer, nothing to prune, nothing authoritative: lose the key and the next draw reshuffles.

- **Concurrency:** several instances can miss the 3-minute cache together, so the refill is guarded with a **token-fenced** `SET NX` + `EX 10` — released only if the value still matches, because an unconditional delete from a refill that overran its TTL would delete the *next* holder's lock. Not `withDistributedLock`: it retries 10×100ms, and inside a page render the right answer to a held lock is to skip the refill.
- **The pass is replaced, not appended to.** Appending stacked two passes whenever a stale id under-filled a draw without emptying the list, queueing ids twice and letting this window's picks return in the next. Replacing cannot lose a turn — anything still queued has not been shown, so it is in `eligible` and lands in the new pass.
- **Pass boundaries:** the refill excludes ids already taken in the current draw, so one window can never show the same collection twice.
- **Deadline:** the whole draw is raced against 250ms with the random draw as fallback. The cluster client's own bound is 15s *per command* and a refill serialises six; a stall is not a failure, so the catch never fires for it.
- **Not silent:** the catch logs `redis-degraded` and the `EXPIRE` result is checked. A page that stopped rotating looks exactly like one that is rotating, and `EXPIRE` on a missing key sets nothing and returns 0.
- **Uniform shuffle:** Fisher-Yates locally, because the shared `shuffle` is `sort(() => Math.random() - 0.5)` and the fairness argument here assumes uniformity.
- **Shared state:** the pop is clamped to what is eligible. Popping more than needed would spend other collections' turns off the shared pass — invisible in the result, and it would skip them next draw.
- **Pool churn:** ids no longer eligible are dropped as they surface; a newly eligible collection joins the next pass.
- **Every failure path degrades to the draw this replaces** — cold key, lost lock, Redis down. An unrotated homepage beats no homepage.

## Verification

- `typecheck`: **0 errors** (470s)
- `eslint` on both new files: clean
- 15 unit tests, driving the real cycle arithmetic against a key-addressed in-memory fake rather than asserting which commands were called, plus coverage of the live node-redis bindings — `NX: true` and `rPush` were the only surfaces no injected-deps test could reach

Also removes `getLastPickedId` / `setLastPickedId` and their key: uncalled, and this is the change that decides a single last-picked id is the wrong shape for a rotation memory.

**Mutation-tested twice — 8 mutations before review, 7 after the fix round, each restored from a pristine copy with an unmutated control in the same loop.** In the first round three survived, and all three were defects in the tests rather than the code:

- the pass-boundary assertion was a coin flip (a re-added id only duplicates if it lands in the remaining pops) — it now asserts on what the refill pushed
- the eligibility-filter test compared numbers against the fake queue's strings, so it filtered nothing and passed for any implementation
- the clamp looked like an equivalent mutant until the shared-state consequence above; it is now its own test

A fourth apparent survivor was the harness mangling the file, not a gap — done with `sed` it kills 2 tests. A survivor is a claim about the harness until you check what it actually changed.

After the review fixes, one mutation survived again: replacing the pass with an append. Killing it needed a test that reproduces the real shape — a stale id under-filling a draw *without* emptying the pass. Reading the code, replace-versus-append looks like a style choice.

**What this PR does not close.** ClickUp 868kz05y7 asks for the bound to hold "over a measured window"; every number here is simulated. The bound also needs writing onto the ticket as the decision it asks for.

Branched from `origin/main`. Not stacked on #4538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iqUbhWct99j3o7iJFwDKn
