### PR TITLE
fix(tests): unbreak main — the redis-key guard and the reaction.toggle contract

### DIFF
--- a/src/server/redis/__tests__/queues.integration.test.ts
+++ b/src/server/redis/__tests__/queues.integration.test.ts
@@ -1,8 +1,10 @@
 import { PrismaClient } from '@prisma/client';
+import { REDIS_SYS_KEYS } from '@civitai/redis/client';
 import { createClient } from 'redis';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 // Top-level, not an inline `typeof import(...)` — that trips consistent-type-imports.
 import type * as SysReadDeadline from '~/server/redis/sys-read-deadline';
+import type * as RedisPackage from '@civitai/redis/client';
 
 /**
  * End-to-end proof for the dropped-enqueue parking lot, against a REAL Postgres and a
@@ -38,13 +40,26 @@ vi.mock('~/server/redis/client', async () => {
   const { withSysReadDeadline } = await vi.importActual<typeof SysReadDeadline>(
     '~/server/redis/sys-read-deadline'
   );
+  // The key CONSTANTS come from the package, never hand-typed: a literal copy drifts from
+  // production silently, and this suite asserts against a real Redis, so a stale copy would
+  // make it prove the wrong keys. Importing the package (not the `~/server/redis/client`
+  // shim) gets the constants without constructing a real client -- the same split
+  // `src/__tests__/setup.ts` relies on.
+  const actual = await vi.importActual<typeof RedisPackage>('@civitai/redis/client');
+  // Every key this suite writes derives from BUCKETS, so prefixing arg 0 of each command
+  // namespaces the whole run at the transport layer. That keeps the production key names
+  // in play -- the mirror of the scratch SCHEMA on the Postgres side, where the SQL stays
+  // unqualified and the isolation lives on the connection.
+  const nsKey = (key: unknown) =>
+    Array.isArray(key) ? key.map((k) => `${NS}:${k}`) : `${NS}:${key}`;
   const call =
     (fn: string) =>
-    (...args: never[]) =>
+    (key: unknown, ...rest: never[]) =>
       holder.backing
-        ? holder.backing[fn](...args)
+        ? holder.backing[fn](nsKey(key) as never, ...rest)
         : Promise.reject(new Error('sysRedis unavailable (test outage)'));
   return {
+    ...actual,
     sysRedis: {
       hGet: call('hGet'),
       hSet: call('hSet'),
@@ -54,8 +69,6 @@ vi.mock('~/server/redis/client', async () => {
       exists: call('exists'),
       set: call('set'),
     },
-    REDIS_SYS_KEYS: { QUEUES: { BUCKETS: `${NS}:buckets` } },
-    REDIS_SUB_KEYS: { QUEUES: { MERGING: 'merging' } },
     withSysReadDeadline,
   };
 });
@@ -127,9 +140,13 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
       `SELECT "key","value" FROM ${SCHEMA}."KeyValue" ORDER BY "key"`
     );
 
+  // Reads through the same `${NS}:` prefix the sysRedis stub applies, against the REAL
+  // key names. The bucket NAME stored in the hash is a value, not a key, so it is
+  // unprefixed on the way out and has to be prefixed again to be read back.
   const bucketMembers = async () => {
-    const bucket = await redis.hGet(`${NS}:buckets`, 'images_v6:Delete');
-    return bucket ? redis.sMembers(bucket) : [];
+    const bucketsKey = `${NS}:${REDIS_SYS_KEYS.QUEUES.BUCKETS}`;
+    const bucket = await redis.hGet(bucketsKey, 'images_v6:Delete');
+    return bucket ? redis.sMembers(`${NS}:${bucket}`) : [];
   };
 
   it('a healthy enqueue reaches redis and writes nothing to Postgres', async () => {

--- a/src/server/redis/__tests__/queues.integration.test.ts
+++ b/src/server/redis/__tests__/queues.integration.test.ts
@@ -2,9 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import { REDIS_SYS_KEYS } from '@civitai/redis/client';
 import { createClient } from 'redis';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-// Top-level, not an inline `typeof import(...)` — that trips consistent-type-imports.
-import type * as SysReadDeadline from '~/server/redis/sys-read-deadline';
-import type * as RedisPackage from '@civitai/redis/client';
+import { dbMock, redisMock } from '~/__tests__/mocks';
 
 /**
  * End-to-end proof for the dropped-enqueue parking lot, against a REAL Postgres and a
@@ -29,65 +27,39 @@ const redisUrl = process.env.QUEUES_IT_REDIS_URL;
 
 const SCHEMA = 'queues_it';
 
+const NS = `queues-it:${process.pid}`;
+
 // `backing = null` is the outage: every command rejects fast, which is the DOWN mode
 // queues.ts fails open on. Swapping it back is the recovery the drain has to survive.
-const { holder, NS } = vi.hoisted(() => ({
-  holder: { backing: null as null | Record<string, (...args: never[]) => Promise<unknown>> },
-  NS: `queues-it:${process.pid}`,
-}));
+let backing: typeof redis | null = null;
 
-vi.mock('~/server/redis/client', async () => {
-  const { withSysReadDeadline } = await vi.importActual<typeof SysReadDeadline>(
-    '~/server/redis/sys-read-deadline'
-  );
-  // The key CONSTANTS come from the package, never hand-typed: a literal copy drifts from
-  // production silently, and this suite asserts against a real Redis, so a stale copy would
-  // make it prove the wrong keys. Importing the package (not the `~/server/redis/client`
-  // shim) gets the constants without constructing a real client -- the same split
-  // `src/__tests__/setup.ts` relies on.
-  const actual = await vi.importActual<typeof RedisPackage>('@civitai/redis/client');
-  // Every key this suite writes derives from BUCKETS, so prefixing arg 0 of each command
-  // namespaces the whole run at the transport layer. That keeps the production key names
-  // in play -- the mirror of the scratch SCHEMA on the Postgres side, where the SQL stays
-  // unqualified and the isolation lives on the connection.
-  const nsKey = (key: unknown) =>
-    Array.isArray(key) ? key.map((k) => `${NS}:${k}`) : `${NS}:${key}`;
-  const call =
-    (fn: string) =>
-    (key: unknown, ...rest: never[]) =>
-      holder.backing
-        ? holder.backing[fn](nsKey(key) as never, ...rest)
-        : Promise.reject(new Error('sysRedis unavailable (test outage)'));
-  return {
-    ...actual,
-    sysRedis: {
-      hGet: call('hGet'),
-      hSet: call('hSet'),
-      sAdd: call('sAdd'),
-      sMembers: call('sMembers'),
-      del: call('del'),
-      exists: call('exists'),
-      set: call('set'),
-    },
-    withSysReadDeadline,
-  };
-});
+/**
+ * 🔴 This file drives the CANONICAL shared mocks rather than registering its own.
+ *
+ * `~/server/db/client`, `~/server/redis/client` and `~/server/logging/client` all have
+ * canonical mocks registered once in `src/__tests__/setup.ts`, and a per-file `vi.mock` of
+ * any of them freezes that shape into every later file in the same worker under
+ * `isolate: false` — which is what `no-direct-shared-module-mock` exists to stop, and why
+ * `gen-mock-allowlist.mjs` refuses to allowlist a new file.
+ *
+ * Being an INTEGRATION test is not an exemption from that, only a constraint on how the
+ * seam is used: the canonical nodes are `vi.fn()`s, so instead of declaring canned return
+ * values this file points them at the REAL Postgres and Redis clients it builds in
+ * `beforeAll`. That satisfies the guard and keeps the suite end-to-end.
+ *
+ * It also removes the hand-typed key constants this file used to carry — `setup.ts` spreads
+ * the real `@civitai/redis/client` into the canonical factory, so `REDIS_SYS_KEYS` and
+ * `REDIS_SUB_KEYS` are production's own values and cannot drift
+ * (`no-hand-typed-redis-key-constants`). `withSysReadDeadline` likewise defaults to the real
+ * implementation there, so queues.ts keeps running the real deadline wrapper.
+ */
 
+// `~/server/redis/fail-open-log` is a PENDING specifier: no canonical mock exists yet, so a
+// direct mock is counted rather than enforced. Stubbed because the real logger is noise here.
 vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
 
 let prisma: PrismaClient;
 let bootstrap: PrismaClient;
-// A getter, not a value: the client cannot exist until beforeAll has the URL, and
-// queues.ts captures the binding at import.
-vi.mock('~/server/db/client', () => ({
-  get dbWrite() {
-    return prisma;
-  },
-  get dbRead() {
-    return prisma;
-  },
-}));
 
 const { addToQueue, drainDroppedEnqueues } = await import('~/server/redis/queues');
 
@@ -113,6 +85,36 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
 
     redis = createClient({ url: redisUrl });
     await redis.connect();
+
+    // Point the canonical db mock at the REAL scratch-schema client. queues.ts calls these as
+    // TAGGED TEMPLATES, so the implementation forwards (strings, ...values) verbatim — which
+    // is exactly the binding this suite exists to prove (the `::jsonb` cast, and
+    // `jsonb_array_length` on what we actually store).
+    dbMock.dbWrite.$queryRaw.mockImplementation((sql: TemplateStringsArray, ...values: unknown[]) =>
+      prisma.$queryRaw(sql, ...values)
+    );
+    dbMock.dbWrite.$executeRaw.mockImplementation(
+      (sql: TemplateStringsArray, ...values: unknown[]) => prisma.$executeRaw(sql, ...values)
+    );
+
+    // Point the canonical sysRedis mock at the REAL redis. Every key this suite writes derives
+    // from BUCKETS, so prefixing arg 0 namespaces the whole run at the transport layer while
+    // leaving the PRODUCTION key names in play — the mirror of the scratch SCHEMA on the
+    // Postgres side, where the SQL stays unqualified and the isolation lives on the connection.
+    // `del` accepts an array of keys as well as one.
+    const nsKey = (key: unknown) =>
+      Array.isArray(key) ? key.map((k) => `${NS}:${k}`) : `${NS}:${key}`;
+    const COMMANDS = ['hGet', 'hSet', 'sAdd', 'sMembers', 'del', 'exists', 'set'] as const;
+    for (const cmd of COMMANDS) {
+      redisMock.sysRedis[cmd].mockImplementation((key: unknown, ...rest: unknown[]) =>
+        backing
+          ? (backing as unknown as Record<string, (...a: unknown[]) => Promise<unknown>>)[cmd](
+              nsKey(key),
+              ...rest
+            )
+          : Promise.reject(new Error('sysRedis unavailable (test outage)'))
+      );
+    }
   }, 30000);
 
   afterAll(async () => {
@@ -132,7 +134,7 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
     await prisma.$executeRawUnsafe(`TRUNCATE ${SCHEMA}."KeyValue"`);
     const keys = await redis.keys(`${NS}*`);
     if (keys.length) await redis.del(keys);
-    holder.backing = redis as never;
+    backing = redis;
   });
 
   const parked = () =>
@@ -157,7 +159,7 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
   });
 
   it('an outage parks the ids in Postgres instead of losing them', async () => {
-    holder.backing = null;
+    backing = null;
 
     await expect(addToQueue('images_v6:Delete', [10, 11])).resolves.toBe(false);
 
@@ -165,7 +167,7 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
   });
 
   it('successive drops during one outage accumulate under the same key', async () => {
-    holder.backing = null;
+    backing = null;
     await addToQueue('images_v6:Delete', [10, 11]);
     await addToQueue('images_v6:Delete', [12]);
 
@@ -173,9 +175,9 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
   });
 
   it('the drain replays them into redis once the outage ends, and clears the row', async () => {
-    holder.backing = null;
+    backing = null;
     await addToQueue('images_v6:Delete', [10, 11]);
-    holder.backing = redis as never;
+    backing = redis;
 
     await expect(drainDroppedEnqueues()).resolves.toEqual({ keys: 1, replayed: 2, reparked: 0 });
 
@@ -184,22 +186,22 @@ describe.skipIf(!databaseUrl || !redisUrl)('queues parking lot — real Postgres
   });
 
   it('the drain leaves the row parked while the outage continues, and never duplicates it', async () => {
-    holder.backing = null;
+    backing = null;
     await addToQueue('images_v6:Delete', [10, 11]);
 
     await expect(drainDroppedEnqueues()).resolves.toEqual({ keys: 1, replayed: 0, reparked: 2 });
     // Still exactly the two ids — a re-park would have appended a second copy.
     expect((await parked())[0].value).toEqual([10, 11]);
 
-    holder.backing = redis as never;
+    backing = redis;
     await expect(drainDroppedEnqueues()).resolves.toEqual({ keys: 1, replayed: 2, reparked: 0 });
     expect(await parked()).toHaveLength(0);
   });
 
   it('a drop landing between the drain read and its delete is not swallowed', async () => {
-    holder.backing = null;
+    backing = null;
     await addToQueue('images_v6:Delete', [10, 11]);
-    holder.backing = redis as never;
+    backing = redis;
 
     // The interleaving the length guard exists for: the drain has read [10,11] and is
     // about to delete when another pod parks id 12. The delete must refuse the grown row.

--- a/tests/preview-engagement.spec.ts
+++ b/tests/preview-engagement.spec.ts
@@ -22,13 +22,19 @@ import { trpcMutation, uniqueToken } from './preview-trpc';
  *  - reaction.toggle (reaction.router.ts:9 guardedProcedure .input(toggleReactionSchema))
  *    — toggleReactionSchema (reaction.schema.ts:37): { entityId: number;
  *    entityType: enum(reactableEntities incl. 'post'); reaction: enum(ReviewReactions) }.
- *    ReviewReactions.Like = 'Like' (enums.ts:355). The mutation is FIRE-AND-FORGET:
- *    the router calls toggleReactionHandler(...).catch(handleLogError) and returns
- *    nothing (reaction.router.ts:13-17), which superjson serializes as `json: null`
- *    over the wire (NOT undefined — confirmed against a live preview run). Success
- *    therefore = the call RESOLVES (the helper throws on any HTTP/tRPC error, so
- *    reaching past it means auth + rate-limit + handler-dispatch all accepted it);
- *    we assert the resolved value is nullish rather than a specific type.
+ *    ReviewReactions.Like = 'Like' (enums.ts:355). The mutation is AWAITED and
+ *    RESOLVES TO THE HANDLER RESULT: `.mutation(toggleReactionHandler)`
+ *    (reaction.router.ts:15) returns toggleReaction()'s discriminator, one of
+ *    'created' | 'removed' | 'noop' (reaction.service.ts:25,30 → controller :286).
+ *    This post is self-seeded in this same test and `tester` has never reacted to
+ *    it, so getReaction finds nothing and the create branch runs — the value is
+ *    deterministically 'created', which is what we pin.
+ *
+ *    🔴 It used to resolve to null, and this spec used to assert that. `ee376ea7d8`
+ *    (2026-03) made the router fire-and-forget for latency; #4516 / `1e810875c8`
+ *    reverted that because detaching the write from the request lifecycle dropped
+ *    reactions on pod drain. `src/server/routers/__tests__/reaction.router.awaited.test.ts`
+ *    is the unit-level contract test for the restored shape — keep the two in step.
  *  - commentv2.upsert (commentv2.router.ts:62 guardedProcedure .input(upsertCommentv2Schema))
  *    — upsertCommentv2Schema (commentv2.schema.ts) extends commentConnectorSchema
  *    ({ entityId: number; entityType: enum incl. 'post' }) with a non-empty sanitized
@@ -60,18 +66,20 @@ test.describe('tester self-seeds a post, reacts to it, and comments on it (mutat
     });
     expect(typeof post?.id, 'post.create should return a numeric post id').toBe('number');
 
-    // 2. React to that exact post. reaction.toggle is fire-and-forget: it resolves
-    // to null over the wire (superjson encodes the void return as json:null), so
-    // success = the call resolves without the helper throwing. A broken
-    // auth/rate-limit/dispatch path would surface as an HTTP/tRPC error here.
-    const reaction = await trpcMutation(page.request, 'reaction.toggle', {
-      entityId: post!.id,
-      entityType: 'post',
-      reaction: 'Like',
-    });
-    // `?? null` collapses null/undefined alike so the assertion is robust to the
-    // exact void encoding — the point is "it was accepted", not its serialized form.
-    expect(reaction ?? null, 'reaction.toggle should be accepted (resolve, not throw)').toBeNull();
+    // 2. React to that exact post. reaction.toggle is awaited and resolves to the
+    // handler's result, so this asserts the WRITE happened, not merely that the call
+    // was accepted: a first Like on a post nobody has reacted to takes the create
+    // branch and resolves to 'created'. A broken auth/rate-limit/dispatch path would
+    // surface as an HTTP/tRPC error before we get here.
+    const reaction = await trpcMutation<'created' | 'removed' | 'noop'>(
+      page.request,
+      'reaction.toggle',
+      { entityId: post!.id, entityType: 'post', reaction: 'Like' }
+    );
+    // Pinned to the exact discriminator rather than a truthiness check: 'noop' and
+    // 'removed' are also non-null, and both would mean the reaction did NOT get
+    // created — the regression this spec exists to catch.
+    expect(reaction, 'reaction.toggle should create the reaction and say so').toBe('created');
 
     // 3. Comment on that exact post. upsert returns the created comment row, so we
     // assert it came back with a numeric id and that our token survived sanitization


### PR DESCRIPTION
`main` is red and every open PR inherits it. This fixes it.

> **Correction to the framing this started from:** `Unit tests (1)` and `(2)` are **not the same
> failure**. They are two *different* guards tripped by the same file. I only found the second by
> running the whole `src/server/services/__tests__/` directory rather than the one named test — the
> brief attributed both shards to `no-hand-typed-redis-key-constants`, and shard 2 is actually
> `no-direct-shared-module-mock`. Both are fixed here.

**Three commits, two unrelated problems, one PR — deliberately.** They share no code and would
normally be separate, but `main` being red is urgent and extra review cycles are worse than one
slightly mixed PR. Commits 1+3 are the two unit shards (same file); commit 2 is the smoke test.
Review them independently.

In each case the test and the code disagreed. Neither fix was "make the test match the code" by
default — the direction was established first, and it came out differently in each.

| red check | cause | which side was wrong |
|---|---|---|
| `Unit tests (1)` | `no-hand-typed-redis-key-constants` | **the file** |
| `Unit tests (2)` | `no-direct-shared-module-mock` | **the file** |
| `preview / smoke-tests` | `reaction.toggle` returns `"created"` | **the test** |

---

## Commits 1 + 3 — the unit shards: the FILE was wrong, on two counts

Both shards went red at `54466eb231` (the sysRedis search-index fix), which added
`src/server/redis/__tests__/queues.integration.test.ts`. That one file trips two independent guards:

**(a) It hand-typed the key constants** inside its `~/server/redis/client` mock:

```ts
REDIS_SYS_KEYS: { QUEUES: { BUCKETS: `${NS}:buckets` } },
REDIS_SUB_KEYS: { QUEUES: { MERGING: 'merging' } },
```

`no-hand-typed-redis-key-constants` applies to test files *by construction* — its globs are
`**/*.test.{ts,tsx}` and nothing else, so "it should not apply to `__tests__/`" would empty the rule,
not narrow it. Its rationale documents 15 constants across 6 files that had already drifted silently
before #4400 (`'session:user-tokens'` for the real `'session:user-tokens2'`, and one key that existed
nowhere but the test that invented it). `MERGING: 'merging'` was a live instance of that shape —
identical to production today, free to drift tomorrow, unobservable if it did.

**(b) It directly mocked all three CANONICAL specifiers** — `~/server/db/client`,
`~/server/redis/client`, `~/server/logging/client`. Under `isolate: false` a per-file `vi.mock` of one
of those freezes that shape into every later file in the same worker, which is exactly what
`no-direct-shared-module-mock` exists to stop.

**No exemption was available, and I did not manufacture one.** No suppression comment; no baseline
entry (that list may only shrink); and the allowlist is not a route either —
`scripts/test-perf/gen-mock-allowlist.mjs` refuses on *membership* growth and exits 1:

```
Refusing to grow the CANONICAL allowlist (178 -> 179). New direct mocks:
  src/server/redis/__tests__/queues.integration.test.ts
```

Being an integration test is not an exemption — only a constraint on how the seam is used. The
canonical mock nodes are `vi.fn()`s, so instead of declaring canned return values the file now points
them at the **real** clients it builds in `beforeAll`:

| canonical node | pointed at |
|---|---|
| `dbMock.dbWrite.$queryRaw` / `$executeRaw` | the real scratch-schema `PrismaClient`, forwarding `(strings, ...values)` so the tagged-template binding this suite exists to prove is still exercised |
| `redisMock.sysRedis.<cmd>` | the real Redis client, prefixing arg 0 with the run-unique namespace |

That also subsumes (a) with no local override at all: `setup.ts` spreads the real
`@civitai/redis/client` into the canonical factory, so `REDIS_SYS_KEYS`/`REDIS_SUB_KEYS` are
production's own values and cannot drift. `withSysReadDeadline` defaults to the real implementation
there too, so `queues.ts` keeps running the real deadline wrapper.

Net effect: the suite now exercises the **production key names** instead of a copy of them —
strictly more coverage than before — with isolation moved onto the transport. That mirrors what the
Postgres half of the same suite already did: a scratch schema on the session `search_path`, SQL left
unqualified.

*Commit 3 supersedes commit 1's mechanism for this file. Commit 1 is left in place as the smaller,
independently-reviewable step; the final diff is what matters.*

The generated allowlist is deliberately **not** regenerated: it is not required (canonical stays at
178 and the file no longer appears there), and a regen sweeps in six unrelated pending-list entries
that accumulated on `main` — churn this PR should not carry.

## Commit 2 — `preview / smoke-tests`: the ASSERTION was stale

`tests/preview-engagement.spec.ts:74` asserted `reaction.toggle` resolves to `null`; it resolves to
`"created"`. **The code is right.** #4516 *restored* a contract rather than inventing one:

| commit | shape | resolves to |
|---|---|---|
| `f8756fb5dd` and earlier | `.mutation(toggleReactionHandler)` | the handler result |
| `ee376ea7d8` (2026-03) | `perf:` fire-and-forget | `undefined` / `null` |
| `1e810875c8` (#4516) | reverted to awaited | the handler result |

Deliberate on every available signal: the PR body says *"Add regression test confirming the mutation
returns the handler result"*, the router carries a `Must stay awaited` comment, and
`reaction.router.awaited.test.ts` pins `expect(result).toBe('created')`. Reverting the router would
reintroduce the bug #4516 fixed — the write detached from the request lifecycle, so a reaction could
be dropped on pod drain and not survive a refresh.

**Nothing in production consumes the return value**, so this is contained to test code:

- `ReactionButton.tsx` and `Questions/FavoriteBadge.tsx` are the only two call sites. Both destructure
  `mutate`/`isPending` only — no `onSuccess`/`onSettled`/`onError`, no `mutateAsync`. UI state is
  optimistic via zustand / `useState` and is never reconciled against the response.
- Not exposed via any tRPC→REST bridge, the moderator OpenAPI catalog, or the tier-1 public-route
  catalog. The only published surface is the `SocialWrite` OAuth scope, which documents the
  permission, never a payload shape.

Pinned to the exact discriminator rather than loosened to truthiness: the handler can also resolve
`'removed'` or `'noop'`, and both are non-null while meaning the reaction was **not** created — the
regression this spec exists to catch. The post is self-seeded in the same test and `tester` has never
reacted to it, so the create branch is deterministic.

---

## Verification

Every failure was reproduced **before** being fixed.

**`Unit tests (1)`** — before: `4 tests | 1 failed`, `+ "src/server/redis/__tests__/queues.integration.test.ts"`.
Matches CI (389 files / 6249 tests, 1 failed). After: **4 passed (4)**, positive control included.

**`Unit tests (2)`** — before, from CI at `main`:
`FAIL … no-direct-shared-module-mock > adds no new direct mock of a module that has a canonical mock`,
`+ "src/server/redis/__tests__/queues.integration.test.ts"` (387 passed / 1 failed / 1 skipped).
After: green.

**`preview / smoke-tests`** — before, from the Tekton `smoke-test` pod: `Received: "created"` at
`preview-engagement.spec.ts:74`, on the initial attempt and both retries; suite `66 tests`,
`1 failed`, `65 passed`.

**The integration suite actually ran.** It is `describe.skipIf` on two env vars, so CI has never
executed it and a rewrite could have broken it silently. I stood up a scratch Postgres + Redis and
ran it for real: **7 passed (7)** before and after — behaviour-preserving.

Confirmed by direct observation, not just by the suite going green — `redis MONITOR` during a run,
**identical** pre- and post-rewrite:

```
"HSET" "queues-it:<pid>:queues:buckets" "images_v6:Delete" "queues:buckets:images_v6:Delete:<ts>"
"SADD" "queues-it:<pid>:queues:buckets:images_v6:Delete:<ts>" "1" "2" "3"
"DEL"  "queues-it:<pid>:queues:buckets:images_v6:Delete:<ts>" "queues-it:<pid>:queues:buckets"
```

Real production key name, namespaced exactly once, bucket name stored unprefixed as a *value*, and
cleanup reaping everything it wrote.

**Mutation-tested**, so the new wiring is not passing vacuously:

| mutation | result |
|---|---|
| `nsKey` → identity | 2 tests fail on their own `arrayContaining` assertion |
| neuter the `$queryRaw` delegation | 6 tests fail |
| *(on commit 1's mechanism)* drop the `...actual` spread | 3 tests fail — proved the constants came from the package, not from the global `setup.ts` mock |

**Suites**

- `src/server/services/__tests__/` — **378 files, 5408 tests, 9 skipped, all passing** (was 1 failed).
  This is the directory that surfaced the second guard.
- `src/server/redis/__tests__/` — 14 files, 124 tests, all passing.
- With both env vars unset the integration suite still skips cleanly — **7 skipped**, not 0
  collected, so the added imports do not disturb the CI path.
- **The entire `unit` project, locally: 1550 files passed / 3 skipped (1553); 24,459 tests passed /
  33 skipped (24,492); zero failures.** Run because several other repo-scanning guards exist besides
  the two here, and a directory-scoped run cannot speak for them.

**Other checks** (all inside the repo's `nix develop` shell)

- `node scripts/typecheck.mjs` — **0 type errors**. `tests/` is in the base `include`, so this does
  cover the changed spec.
- `node scripts/typecheck.mjs -p tsconfig.tests.json` — covers `src/**/__tests__/**`, which the base
  config excludes. **Neither changed file produces a single error.**
- ESLint — 2 files processed, 0 errors, 0 warnings. Instrument validated: a deliberately bad file
  through the same invocation returns 2 errors / 2 warnings with real rule ids.
- Prettier — `--list-different` empty on both. Instrument validated: a deliberately mis-formatted
  copy is flagged. (Not read off the "All matched files use Prettier code style!" sentence, which is
  also what an empty file list prints.)

## Stated plainly, not implied

- **`preview / component-tests` is red on `main` and is NOT fixed here** — it is being handled in
  #4531. If it is red on this branch, that is inherited.
- **`scripts/ci/typecheck-tests-gate.mjs` exits 1 on this branch — and it exits 1 on a pristine
  `origin/main` worktree too, with the identical 9 files and identical counts.** None of them is a
  file this PR touches, and neither changed file contributes an error. Pre-existing and out of scope.
  (The gate calls itself a proof of concept and does not appear among this PR's checks, which is
  consistent with nobody having noticed.)
- **I could not run `preview / smoke-tests` myself** — it needs a deployed preview. The before-state
  is read from the Tekton pod logs quoted above; the after-state has to come from this PR's own
  preview run.
- All four `Unit tests` shards are **green in CI** on this branch, which is the authoritative check
  for the unit fixes.
- The `~/server/redis/fail-open-log` mock is kept. It is a PENDING specifier — counted, not enforced,
  with no canonical mock to migrate to.
