### PR TITLE
fix(transactions): correct transaction direction labels

### DIFF
--- a/src/pages/user/transactions.tsx
+++ b/src/pages/user/transactions.tsx
@@ -303,7 +303,7 @@ export default function UserTransactions() {
                     {fromUser && fromUser.id !== currentUser?.id && (
                       <Text c="dimmed">
                         <Group gap={4}>
-                          {isDebit ? 'To: ' : 'From: '}
+                          {'From: '}
                           <Text fw="500" span>
                             {fromUser.username}
                           </Text>
@@ -313,7 +313,7 @@ export default function UserTransactions() {
                     {toUser && toUser.id !== currentUser?.id && (
                       <Text c="dimmed">
                         <Group gap={4}>
-                          {isDebit ? 'From: ' : 'To: '}
+                          {'To: '}
                           <Text fw="500" span>
                             {toUser.username}
                           </Text>


### PR DESCRIPTION
Remove inverted ternaries on counterparty blocks. The logic was showing
'To:' on debits and 'From:' on credits, the opposite of the actual
transaction direction. Since fromUser is always the sender and toUser
is always the recipient, simplify to semantic labels: 'From: ' for
fromUser and 'To: ' for toUser.

Refs: 868kzcnh2