### PR TITLE
feat(app-blocks): stop full-page apps stretching edge-to-edge on wide displays

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -54,16 +54,16 @@ See `src/shared/constants/block-scope.constants.ts`. Each block scope maps
 to an OAuth bitmask bit (registration-time gate), plus a context-binding
 check at request time (`enforceContextBinding`).
 
-| Scope                            | Bind                                              | Notes                             |
-| -------------------------------- | ------------------------------------------------- | --------------------------------- |
-| `models:read:self`               | `query.id == ctx.modelId`                         |                                   |
-| `media:read:owned`               | non-anon `sub`                                    |                                   |
-| `buzz:read:self`                 | non-anon `sub`                                    |                                   |
-| `social:tip:self`                | non-anon `sub`                                    |                                   |
+| Scope                            | Bind                                              | Notes                                                                                                                                                                   |
+| -------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `models:read:self`               | `query.id == ctx.modelId`                         |                                                                                                                                                                         |
+| `media:read:owned`               | non-anon `sub`                                    |                                                                                                                                                                         |
+| `buzz:read:self`                 | non-anon `sub`                                    |                                                                                                                                                                         |
+| `social:tip:self`                | non-anon `sub`                                    |                                                                                                                                                                         |
 | `user:read:self`                 | non-anon `sub`                                    | viewer identity — read via the `useViewer()` hook (`GET_VIEWER` bridge → `blocks.getMyViewer`). Also gates the **deprecated** `/api/v1/blocks/me` REST route (retiring) |
-| `ai:write:budgeted`              | positive `buzzBudget`                             |                                   |
-| `block:settings:read` / `:write` | `query.blockInstanceId == claims.blockInstanceId` | + caller-is-installer at issuance; `SKIP_OAUTH_CHECK` |
-| `apps:storage:read` / `:write`   | scope present on `claims.scopes` per op           | per-app KV store (App Storage); no OAuth bit (`SKIP_OAUTH_CHECK`) — gated by the approved-scope snapshot + `resolveStorageContext` |
+| `ai:write:budgeted`              | positive `buzzBudget`                             |                                                                                                                                                                         |
+| `block:settings:read` / `:write` | `query.blockInstanceId == claims.blockInstanceId` | + caller-is-installer at issuance; `SKIP_OAUTH_CHECK`                                                                                                                   |
+| `apps:storage:read` / `:write`   | scope present on `claims.scopes` per op           | per-app KV store (App Storage); no OAuth bit (`SKIP_OAUTH_CHECK`) — gated by the approved-scope snapshot + `resolveStorageContext`                                      |
 
 Unknown scopes are rejected at runtime (deny-by-default in middleware).
 
@@ -74,14 +74,14 @@ Unknown scopes are rejected at runtime (deny-by-default in middleware).
 
 ## Routes
 
-| Route                                          | Auth                 | Scope required                  |
-| ---------------------------------------------- | -------------------- | ------------------------------- |
-| `POST /api/v1/block-tokens`                    | same-origin session  | — (any approved install)        |
-| `GET /api/v1/block-tokens/jwks`                | public               | —                               |
-| `GET /api/v1/blocks/me` _(deprecated, retiring)_ | block JWT          | `user:read:self` — superseded by the `useViewer()` hook (`GET_VIEWER` bridge). Kept live for now; migrate to the hook |
-| `GET /api/v1/models/[id]`                      | session OR block JWT | `models:read:self` (block path) |
-| `POST /api/v1/developer/block-manifests`       | `JOB_TOKEN`          | —                               |
-| `POST /api/internal/blocks/workflow-completed` | `JOB_TOKEN` + Flipt  | —                               |
+| Route                                            | Auth                 | Scope required                                                                                                        |
+| ------------------------------------------------ | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/v1/block-tokens`                      | same-origin session  | — (any approved install)                                                                                              |
+| `GET /api/v1/block-tokens/jwks`                  | public               | —                                                                                                                     |
+| `GET /api/v1/blocks/me` _(deprecated, retiring)_ | block JWT            | `user:read:self` — superseded by the `useViewer()` hook (`GET_VIEWER` bridge). Kept live for now; migrate to the hook |
+| `GET /api/v1/models/[id]`                        | session OR block JWT | `models:read:self` (block path)                                                                                       |
+| `POST /api/v1/developer/block-manifests`         | `JOB_TOKEN`          | —                                                                                                                     |
+| `POST /api/internal/blocks/workflow-completed`   | `JOB_TOKEN` + Flipt  | —                                                                                                                     |
 
 ## Feature flag
 
@@ -237,10 +237,10 @@ Two flows, both delivering the same wrapped-token shape:
    any `TOKEN_REFRESH_RESPONSE`, while the caller's promise sat there to its own
    timeout). Both hosts therefore branch on what arrived:
 
-   | `REQUEST_TOKEN` payload | host answers with |
-   |---|---|
-   | `{ requestId: '<string>' }` — any string, **`''` included** | `TOKEN_REFRESH_RESPONSE` echoing that exact `requestId` |
-   | `{}`, no `requestId`, or a non-string one | `TOKEN_REFRESH` **push** (no `requestId` — there is nothing to correlate to) |
+   | `REQUEST_TOKEN` payload                                     | host answers with                                                            |
+   | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+   | `{ requestId: '<string>' }` — any string, **`''` included** | `TOKEN_REFRESH_RESPONSE` echoing that exact `requestId`                      |
+   | `{}`, no `requestId`, or a non-string one                   | `TOKEN_REFRESH` **push** (no `requestId` — there is nothing to correlate to) |
 
    An empty-string `requestId` is echoed verbatim. It used to be dropped by a
    truthiness test, which silently turned a legitimate request into an
@@ -316,7 +316,7 @@ Civitai Buzz is split into spendable pools — **blue** (purchased), **green**
   an out-of-set pick is rejected, absent → Auto (see
   `resolveBlockCurrenciesForAccount`).
 - **Which pool actually paid**: the workflow status snapshot carries
-  `spentAccountType` — the `accountType` of the largest *realized* debit — so a
+  `spentAccountType` — the `accountType` of the largest _realized_ debit — so a
   block can attribute spend after the fact (internal-only accounts are omitted).
 
 ## Publish / review / deploy lifecycle (no trust on push)
@@ -359,6 +359,58 @@ manifest validation are all still enforced on the webhook.
 > contents.
 
 ## Publisher-side notes
+
+### How wide your app renders (`/apps/run/<slug>`)
+
+The page host gives your app a **centred column with a maximum width**, not the
+whole monitor. The value is `--app-page-max-width` (currently `1600px`), declared
+on `:root` in `src/styles/globals.css` and read by `PageBlockHost` as
+`max-width: var(--app-page-max-width, …); margin-inline: auto`.
+
+Practically:
+
+- **Below 1600px of viewport the cap does nothing.** Your iframe is exactly as
+  wide as it has always been — laptops, tablets and phones are unaffected.
+- **Above it your app is centred**, with civitai's page background either side.
+  On a 2560px display your app gets 1600px and a ~480px gutter per side.
+- Your app is still handed a **normal viewport** inside the iframe: your own
+  media queries, `100dvh`, `position: fixed` and so on all resolve against the
+  iframe, so nothing about writing the app changes. The only thing that changed
+  is how wide that iframe gets on a large display.
+
+Why: an App Block is a cross-origin guest and cannot see the monitor it is on,
+and nothing in `@civitai/blocks-react` gives you a container to lay out in (its
+only max-widths are modal-scoped). Left uncapped, an app on a 2560px display
+renders as a single ~2500px column. Most shipped apps already impose a well of
+their own between 640px and 1100px, so for those this changes only which
+background paints the far gutter.
+
+#### Asking for full bleed
+
+Some apps genuinely want the whole width — an infinite grid, a canvas, a
+timeline, a map, a fullscreen player. There is **no manifest field** for this
+(the manifest schema is mirrored across three repos and has to move in lockstep,
+and the host runs an older `@civitai/app-sdk` than guests do, so a new field
+would be untyped where the host reads it). Instead it is one CSS rule on the
+civitai side, keyed on the `data-block-id` the host stamps:
+
+```css
+[data-testid='app-page-frame'][data-block-id='your-app-slug'] {
+  --app-page-max-width: none;
+}
+```
+
+Those rules live in the **full-bleed opt-out ledger** in
+`src/styles/globals.css`, next to the `--app-page-max-width` declaration; the
+comment there carries the template and the review criteria. Open a PR adding
+your app's line with a one-line reason, or ask a maintainer to. A narrower value
+(`--app-page-max-width: 1100px`) is equally valid if your app wants a tighter
+frame than the default.
+
+The mechanism is measured, not just documented:
+`src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx` injects a rule
+of exactly this shape at a 2560px viewport and asserts the host goes back to full
+width, so the instructions above cannot rot into something that no longer works.
 
 ### Manifest re-publish behavior
 

--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -407,6 +407,14 @@ your app's line with a one-line reason, or ask a maintainer to. A narrower value
 (`--app-page-max-width: 1100px`) is equally valid if your app wants a tighter
 frame than the default.
 
+**Currently opted out:** `playable-collections` — a collection player whose three
+open-collection view modes (slideshow, ticker, wall) are all uncapped by the app
+itself, so a centred column shrinks the player and truncates the grids. Its own
+960px well applies only to the browse list, which sits behind an early return and
+is unaffected either way. Every entry is expected to carry a reason like this
+one; the ledger's membership is asserted in a test, so a rule cannot be added or
+removed here without that being a deliberate, reviewed change.
+
 The mechanism is measured, not just documented:
 `src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx` injects a rule
 of exactly this shape at a 2560px viewport and asserts the host goes back to full

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -285,6 +285,64 @@ const WILDCARD_REVIEW_NACK_CODE: WildcardPackErrorCode = 'forbidden';
  */
 export const FILL_MIN_HEIGHT_PX = 300;
 
+/**
+ * The width a full-page App Block stops growing at, in px. Above it the host is
+ * a CENTRED column with a neutral gutter either side; below it the cap is inert.
+ *
+ * 🔴 THIS IS THE `var()` FALLBACK, NOT THE SOURCE. The value the host actually
+ * uses comes from `--app-page-max-width`, declared once on `:root` in
+ * `src/styles/globals.css`, because that is the only spelling a per-app opt-out
+ * rule can override (an inline custom property on this element would beat every
+ * stylesheet rule and make the documented opt-out inert). CSS cannot import a TS
+ * constant, so the number exists twice; `__tests__/pageBlockHostMaxWidth.test.ts`
+ * asserts the two agree, exactly as the `--header-height`/`HEADER_HEIGHT_PX`
+ * guard in `__tests__/pageRunScrollContract.test.ts` does. The fallback is not
+ * decorative: it is what caps a host rendered in a context that has not loaded
+ * the app stylesheet, and it is exercised by a case in the browser suite.
+ *
+ * 🔴 WHY A CAP EXISTS AT ALL. The host sized the iframe `width: 100%` with no
+ * bound anywhere in the chain — the run page's wrapper is `width: '100%'`, the
+ * host root was `width: '100%'`, the iframe is `width: '100%'` — so on a 2560px
+ * display an app rendered as a single ~2500px column. The apps cannot defend
+ * themselves: an App Block is a cross-origin guest that is handed a viewport and
+ * told nothing about the monitor, and almost none of them declare a width of
+ * their own. So the defence has to be here.
+ *
+ * WHY 1600, AGAINST THE SURFACES THAT ACTUALLY EXIST. Two in-repo anchors bound
+ * the choice, and the number sits between them on purpose:
+ *
+ *   1288  the widest ORDINARY civitai content measure — Mantine `xl` (1320
+ *         border-box) is the widest container size in use across `src/pages`,
+ *         and `APPS_TWO_COLUMN_DETAIL_MEASURE` (the store-preview page an app is
+ *         usually launched FROM) is exactly it. An app capped below this would
+ *         render narrower than the page that linked to it, which reads as a
+ *         downgrade rather than a frame.
+ *   1920  `APPS_PAGE_CONTAINER_WIDTH` — the deliberate outlier, and it is an
+ *         outlier for a reason that does NOT transfer: it exists for card GRIDS
+ *         and wide TABLES (`appsPageWidths.ts` records the measurements), which
+ *         genuinely spend the space. An app block may be a grid, but it may just
+ *         as easily be a single form, and the host cannot tell which.
+ *
+ * 1600 is above every ordinary content measure on the site and below the grid
+ * container, i.e. no app is ever narrower than a civitai page and none is ever
+ * wider than the widest first-party surface. Concretely it holds five columns of
+ * a `minmax(300px, 1fr)` grid (1288 holds four, 1920 holds six) while keeping a
+ * single-column form off an unreadable measure.
+ *
+ * 🔴 STATE THE COST HONESTLY: this binds on a maximised browser on a 1080p
+ * monitor (~1905 CSS px of viewport), not only on ultrawides — that is a common
+ * desktop, and it gets a ~150px gutter either side. That is the deliberate
+ * trade. It does NOT bind on any laptop class (1280/1366/1440/1536), on any
+ * tablet, or on any phone in either orientation, which is where the traffic is
+ * and where the rendered geometry is unchanged to the pixel.
+ *
+ * The BAND this value may move in lives in the tests, not here — a band declared
+ * beside the value it bounds can be moved in the same edit (the lesson
+ * `FILL_MIN_HEIGHT_PX` records). The ARITHMETIC that justifies it is what lives
+ * here.
+ */
+export const APP_PAGE_MAX_WIDTH_PX = 1600;
+
 export interface PageBlockHostProps {
   /** AppBlock id (`apb_*`) — used to build the BLOCK_INIT ids + trust chrome. */
   appBlockId: string;
@@ -3668,6 +3726,32 @@ export function PageBlockHost({
         display: 'flex',
         flexDirection: 'column',
         width: '100%',
+        // ULTRAWIDE CAP — the app is a CENTRED column past `APP_PAGE_MAX_WIDTH_PX`,
+        // full width below it. See that constant for the value's justification and
+        // `--app-page-max-width` in globals.css for the per-app opt-out.
+        //
+        // 🔴 BOTH DECLARATIONS ARE INERT BELOW THE CAP, WHICH IS THE REQUIREMENT.
+        // `width: 100%` above already resolves narrower than the cap, so `max-width`
+        // clamps nothing; and `margin-inline: auto` distributes the LEFTOVER inline
+        // space, of which there is none on a box that fills its parent, so both
+        // margins resolve to 0. Nothing about the rendered geometry moves until the
+        // parent is wider than the cap — measured at 1024 and 1280 in
+        // `PageBlockHostMaxWidth.browser.test.tsx`.
+        //
+        // 🔴 IT IS APPLIED TO THE HOST ROOT, NOT TO THE `<iframe>`, so the trust
+        // chrome, the app and the failure card all take ONE measure. Capping the
+        // iframe alone would leave `AppBlockChrome` — the breadcrumb that vouches
+        // for the app — spanning a width the app it labels does not occupy, and
+        // would leave the `BlockFallback` card stretched to the monitor while the
+        // app beside it was not.
+        //
+        // 🔴 READ THROUGH `var()` DELIBERATELY. An inline custom property here
+        // (`'--app-page-max-width': …`) would win over any stylesheet rule on this
+        // same element, which is precisely the rule shape the opt-out ledger uses —
+        // so writing the value inline would silently make the opt-out inert while
+        // looking tidier.
+        maxWidth: `var(--app-page-max-width, ${APP_PAGE_MAX_WIDTH_PX}px)`,
+        marginInline: 'auto',
         // See the `fit` prop for why these are the two modes and why the
         // viewport arithmetic can never agree with its own scroll viewport.
         ...(fit === 'fill'
@@ -3693,6 +3777,14 @@ export function PageBlockHost({
       // WHICH branch a surface took rather than re-deriving it from computed
       // styles that jsdom does not resolve.
       data-fit={fit}
+      // 🔴 THE OPT-OUT LEDGER'S ANCHOR, not decoration. The full-bleed escape
+      // hatch documented on `--app-page-max-width` is a CSS rule keyed on this
+      // attribute, so removing it does not merely lose an observability hook —
+      // it makes every ledger rule match nothing, silently. `blockId` (the app's
+      // slug, the same value that builds `<slug>.civit.ai`) is the identifier an
+      // app author knows themselves by; `data-block-instance-id` below is the
+      // per-install id and is NOT stable across surfaces.
+      data-block-id={blockId}
       data-block-instance-id={blockInstanceId}
       // #3/#6: surface the consent signal as an observable attribute. The page
       // token still mints with the granted subset (so the block loads — consent

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -355,13 +355,29 @@ export const FILL_MIN_HEIGHT_PX = 300;
  * Concretely it holds five columns of a `minmax(300px, 1fr)` grid (1288 holds
  * four, 1920 holds six).
  *
- * 🔴 THE ONE APP THIS IS WRONG FOR, and it is why the opt-out ships with the cap
- * rather than after it: Playable Collections in PLAYER mode returns early past
- * its own 960px well and renders a `100dvh` slideshow whose media is
- * `object-fit: contain` — a centred column shrinks the player. That is exactly
- * the shape the ledger on `--app-page-max-width` is for. No ledger entry is
- * written today: the entry has to name a block id, and inventing one produces a
- * rule that matches nothing and looks like protection.
+ * 🔴 THE APP THIS IS PROBABLY WRONG FOR, and why the opt-out ships WITH the cap
+ * rather than after it: Playable Collections. Re-read at its DEPLOYED ref
+ * (`sync/deployed-0.2.2`, manifest `blockId: "playable-collections"`), because an
+ * earlier reading of this — that only its "player mode" is affected, the rest
+ * being governed by the app's own 960px well — is WRONG, and wrong in the
+ * direction that makes the opt-out look smaller than it is:
+ *
+ *   · the 960 well is `contentStyle` in `App.tsx:972`, applied at `App.tsx:789`
+ *     to the BROWSE shell only;
+ *   · opening a collection early-returns at `App.tsx:733` past that wrapper into
+ *     `CollectionViewer`, whose root (`CollectionViewer.tsx:582`) is
+ *     `width: 100%; min-height: 100dvh` with NO max-width;
+ *   · and that root serves THREE view modes — classic (`Player`), plus
+ *     continuous-horizontal and continuous-vertical (`ContinuousView`) — with an
+ *     ambient "cast" state on top. None of them is capped by the app.
+ *
+ * So an opt-out here is per-APP and would unbound all three modes, not tidy up
+ * one. That may well be right — a ticker and a wall want width, and the player's
+ * media is `object-fit: contain` so a centred column simply shrinks it — but it
+ * is a bigger product call than "the app already governs this", and it is not
+ * mine to make. NO LEDGER ENTRY IS WRITTEN TODAY, and the ledger's expected set
+ * in `__tests__/pageBlockHostMaxWidth.test.ts` is `[]` so that the first one has
+ * to be added deliberately.
  *
  * 🔴 STATE THE COST HONESTLY: this binds on a maximised browser on a 1080p
  * monitor (~1905 CSS px of viewport), not only on ultrawides — that is a common

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -303,13 +303,36 @@ export const FILL_MIN_HEIGHT_PX = 300;
  * 🔴 WHY A CAP EXISTS AT ALL. The host sized the iframe `width: 100%` with no
  * bound anywhere in the chain — the run page's wrapper is `width: '100%'`, the
  * host root was `width: '100%'`, the iframe is `width: '100%'` — so on a 2560px
- * display an app rendered as a single ~2500px column. The apps cannot defend
- * themselves: an App Block is a cross-origin guest that is handed a viewport and
- * told nothing about the monitor, and almost none of them declare a width of
- * their own. So the defence has to be here.
+ * display an app rendered as a single ~2500px column. An App Block is a
+ * cross-origin guest that is handed a viewport and told nothing about the
+ * display, so the defence has to be here.
  *
- * WHY 1600, AGAINST THE SURFACES THAT ACTUALLY EXIST. Two in-repo anchors bound
- * the choice, and the number sits between them on purpose:
+ * 🔴 WHO IS ACTUALLY UNDEFENDED — enumerated, because the obvious premise ("apps
+ * do not cap themselves") is only half true, and the half that is false is what
+ * decides where this value sits. Across the 13 first-party App Block repos — 11
+ * with a `page` surface; the other two are `model.sidebar_top` slot blocks and a
+ * PAGE cap cannot reach them:
+ *
+ *   · NINE of the eleven page apps DO cap themselves, at 640 / 720 / 720 / 760 /
+ *     820 / 880 / 900 / 960 / 1100 px — a hand-copied `contentStyle` well; median
+ *     860, max 1100. None renders content wider than 1100px, so this cap is a
+ *     no-op for their layout: it changes which background paints the far gutter
+ *     and nothing else.
+ *   · TWO do not cap at all — Notepad and Sensei, both `100dvh` two-pane app
+ *     shells (a fixed 280 / 240px sidebar beside an unbounded `flex: 1` pane).
+ *     Those are the shipped apps that genuinely stretched to the monitor.
+ *   · THE LONG TAIL IS UNBOUNDED BY CONSTRUCTION, which is the real reason for a
+ *     DEFAULT rather than a per-app fix. `@civitai/blocks-react` exports no
+ *     Container / AppShell / Page and declares no container width — its only
+ *     max-widths are modal-scoped (340 / 440 / 620) plus a 420px sign-in gate
+ *     card — and the official starter templates contain zero width declarations.
+ *     An app scaffolded today inherits whatever the host gives it. Nine
+ *     independently hand-picked numbers with nothing to coordinate on is the
+ *     argument for making the decision here instead of asking every app to make
+ *     it again.
+ *
+ * WHY 1600, AGAINST THOSE SURFACES. Two in-repo anchors bound the choice, and the
+ * number sits between them on purpose:
  *
  *   1288  the widest ORDINARY civitai content measure — Mantine `xl` (1320
  *         border-box) is the widest container size in use across `src/pages`,
@@ -325,9 +348,20 @@ export const FILL_MIN_HEIGHT_PX = 300;
  *
  * 1600 is above every ordinary content measure on the site and below the grid
  * container, i.e. no app is ever narrower than a civitai page and none is ever
- * wider than the widest first-party surface. Concretely it holds five columns of
- * a `minmax(300px, 1fr)` grid (1288 holds four, 1920 holds six) while keeping a
- * single-column form off an unreadable measure.
+ * wider than the widest first-party surface. It also clears the widest
+ * app-imposed well (1100) by ~45%, so the cap can never letterbox an app that has
+ * already thought about its own width, while leaving a two-pane shell like
+ * Notepad or Sensei a ~1350px content pane — the case the cap exists for.
+ * Concretely it holds five columns of a `minmax(300px, 1fr)` grid (1288 holds
+ * four, 1920 holds six).
+ *
+ * 🔴 THE ONE APP THIS IS WRONG FOR, and it is why the opt-out ships with the cap
+ * rather than after it: Playable Collections in PLAYER mode returns early past
+ * its own 960px well and renders a `100dvh` slideshow whose media is
+ * `object-fit: contain` — a centred column shrinks the player. That is exactly
+ * the shape the ledger on `--app-page-max-width` is for. No ledger entry is
+ * written today: the entry has to name a block id, and inventing one produces a
+ * rule that matches nothing and looks like protection.
  *
  * 🔴 STATE THE COST HONESTLY: this binds on a maximised browser on a 1080p
  * monitor (~1905 CSS px of viewport), not only on ultrawides — that is a common

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -321,9 +321,10 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
     expect(gutterRight, `at ${w}x${h} the host has been shifted left`).toBe(0);
 
     const cs = getComputedStyle(host);
-    expect([cs.marginLeft, cs.marginRight], `at ${w}x${h} the auto margins resolved non-zero`).toEqual(
-      ['0px', '0px']
-    );
+    expect(
+      [cs.marginLeft, cs.marginRight],
+      `at ${w}x${h} the auto margins resolved non-zero`
+    ).toEqual(['0px', '0px']);
   });
 
   /**
@@ -360,7 +361,9 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
    */
   test('an app can opt out of the cap with a CSS rule keyed on `data-block-id`', async () => {
     const { measure, hostWidth, parentWidth } = await mountAt(2560, 1080);
-    expect(hostWidth, 'the host is not capped at 2560x1080 to begin with').toBeLessThan(parentWidth);
+    expect(hostWidth, 'the host is not capped at 2560x1080 to begin with').toBeLessThan(
+      parentWidth
+    );
 
     injectCss(
       `[data-testid='app-page-frame'][data-block-id='${BLOCK_ID}'] { --app-page-max-width: none; }`

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import { cleanup } from 'vitest-browser-react';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+// Raw text, NOT a stylesheet import — the ledger's REAL rules are parsed out of
+// this and injected. See `ledgerFromGlobals` for why that indirection exists.
+import globalsCss from '~/styles/globals.css?raw';
 // Type-only namespace import for the `importOriginal` spread below (the repo's
 // local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
 // @typescript-eslint/consistent-type-imports rejects.
@@ -152,6 +156,48 @@ afterEach(() => {
 });
 
 /**
+ * The REAL full-bleed opt-out rules, parsed out of `globals.css` itself.
+ *
+ * 🔴 WHY THIS INDIRECTION EXISTS RATHER THAN JUST LOADING THE STYLESHEET. The
+ * component harness deliberately does NOT load the app cascade — `component-
+ * setup.tsx` extracts only the `:root` custom properties, because importing
+ * `globals.css` pulls Tailwind preflight and Mantine layer ordering and changes
+ * the rendered geometry of every existing test. So the ledger's rules are simply
+ * ABSENT here by default, and a test that wrote its own copy of the rule would be
+ * asserting against a fixture rather than against the ledger: deleting the real
+ * entry, or mistyping its selector, would leave that test green.
+ *
+ * Taking the rules from the file and injecting ONLY those keeps the cascade the
+ * suite has always had while making the assertions depend on the shipped text.
+ *
+ * 🔴 THE BROWSER PARSES IT, NOT A REGEX — the same decision, for the same reason,
+ * that `component-setup.tsx` records at length: three successive regex extractors
+ * there each shipped a defect (a comment glued to the next property, a `}` inside
+ * a string truncating the capture), because several regexes cannot agree on where
+ * a CSS block ends. `replaceSync` hands that to the engine that will evaluate it.
+ */
+function ledgerFromGlobals(): { css: string; ids: string[] } {
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(globalsCss);
+  const css: string[] = [];
+  const ids: string[] = [];
+  const walk = (rules: CSSRuleList) => {
+    for (const rule of Array.from(rules)) {
+      if (rule instanceof CSSStyleRule) {
+        if (!rule.selectorText.includes('data-block-id')) continue;
+        css.push(rule.cssText);
+        for (const m of rule.selectorText.matchAll(/\[data-block-id\s*=\s*['"]?([^'"\]]+)['"]?\]/g))
+          ids.push(m[1]);
+      } else if (typeof CSSLayerBlockRule !== 'undefined' && rule instanceof CSSLayerBlockRule) {
+        walk(rule.cssRules);
+      }
+    }
+  };
+  walk(sheet.cssRules);
+  return { css: css.join('\n'), ids };
+}
+
+/**
  * The production chain, reduced to what decides WIDTH.
  *
  * Mirrors `src/pages/apps/run/[slug]/[[...path]].tsx`: `AppLayout`'s no-scroll
@@ -159,7 +205,7 @@ afterEach(() => {
  * are `width: 100%` with no bound of their own — that is the chain the defect
  * lived in, and the reason the cap has to be on the host rather than on them.
  */
-function renderInPageChain() {
+function renderInPageChain(props: Partial<typeof baseProps> = {}) {
   return renderWithProviders(
     <div
       data-testid="layout-main"
@@ -181,15 +227,15 @@ function renderInPageChain() {
           width: '100%',
         }}
       >
-        <PageBlockHost {...baseProps} fit="fill" />
+        <PageBlockHost {...baseProps} {...props} fit="fill" />
       </div>
     </div>
   );
 }
 
-async function mountAt(width: number, height: number) {
+async function mountAt(width: number, height: number, props: Partial<typeof baseProps> = {}) {
   await page.viewport(width, height);
-  renderInPageChain();
+  renderInPageChain(props);
   await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
   const host = page.getByTestId('app-page-frame').element() as HTMLElement;
   const parent = page.getByTestId('page-wrapper').element() as HTMLElement;
@@ -375,6 +421,64 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
         'restore full-bleed at 2560x1080 — either `data-block-id` is no longer stamped or the ' +
         'cap is no longer overridable, and every opt-out in that ledger is inert'
     ).toBe(optedOut.parentWidth);
+  });
+
+  /**
+   * 🔴 THE LEDGER'S ONE REAL MEMBER, EXERCISED AGAINST THE SHIPPED RULE.
+   *
+   * `playable-collections` is opted out of the cap by an explicit product
+   * decision: every one of its open-collection surfaces is uncapped by the app
+   * (the 960px well it has applies only to its browse shell, behind an early
+   * return), so a centred column shrinks the player and truncates the ticker and
+   * wall grids. The reasoning, with file:line evidence, is on the rule itself in
+   * `globals.css`; the membership set is pinned in
+   * `__tests__/pageBlockHostMaxWidth.test.ts`.
+   *
+   * THIS IS A PAIR, and the second arm is what makes the first mean anything.
+   * Both arms render at 2560 with the SAME real ledger CSS injected and differ
+   * ONLY in `blockId`. Without the second arm, "the host is full width" is
+   * satisfied by a cap that stopped working for every app.
+   */
+  test('LEDGER — `playable-collections` is full-bleed at 2560x1080 while another app stays capped', async () => {
+    const ledger = ledgerFromGlobals();
+
+    // POSITIVE CONTROL on the extraction itself. If the parse returned nothing —
+    // a renamed property, a rule moved into an at-rule this walk skips, or a
+    // `?raw` import that silently resolved to an empty string — the green arm
+    // would fail with a confusing width mismatch instead of naming the cause.
+    expect(
+      ledger.ids,
+      'no `[data-block-id=…]` rules were parsed out of src/styles/globals.css. Either the ' +
+        'full-bleed ledger is empty (then this test should be deleted deliberately, together ' +
+        'with the membership expectation in __tests__/pageBlockHostMaxWidth.test.ts), or the ' +
+        'rules moved somewhere this walk does not reach.'
+    ).toContain('playable-collections');
+    injectCss(ledger.css);
+
+    // GREEN ARM — the opted-out app takes the full width of its parent.
+    const optedOut = await mountAt(2560, 1080, { blockId: 'playable-collections' });
+    expect(
+      optedOut.hostWidth,
+      'at 2560x1080 the app `playable-collections` is NOT full-bleed. Its ledger rule in ' +
+        'src/styles/globals.css is missing, mistyped, or no longer overrides ' +
+        '`--app-page-max-width` — so a collection player whose every view mode is uncapped by ' +
+        'the app is being letterboxed to the default cap again.'
+    ).toBe(optedOut.parentWidth);
+
+    // The two arms mount separately, so the first tree has to go: two mounted
+    // `app-page-frame` nodes would fail every `getByTestId` on the strict-mode
+    // single-match rule.
+    await cleanup();
+
+    // RED-PAIR ARM — an app NOT in the ledger, same cascade, still capped. This
+    // is what distinguishes "the ledger works" from "the cap stopped working".
+    const stillCapped = await mountAt(2560, 1080, { blockId: BLOCK_ID });
+    expect(
+      stillCapped.hostWidth,
+      `at 2560x1080 the app '${BLOCK_ID}' is full-bleed despite having NO ledger entry. The ` +
+        'opt-out is matching apps it should not — check the ledger selector is keyed on ' +
+        '`data-block-id` and not on something every host carries.'
+    ).toBeLessThan(stillCapped.parentWidth);
   });
 
   /**

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -1,0 +1,404 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only namespace import for the `importOriginal` spread below (the repo's
+// local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
+// @typescript-eslint/consistent-type-imports rejects.
+import type * as TrpcMod from '~/utils/trpc';
+
+/**
+ * ULTRAWIDE — a full-page App Block must stop growing, MEASURED.
+ *
+ * THE DEFECT. Nothing in the run page's chain bounded the app's width: the page
+ * wrapper is `width: '100%'`, the host root was `width: '100%'`, and the iframe
+ * is `width: '100%'`. On a 2560px monitor an app therefore rendered as a single
+ * ~2500px column. The apps cannot fix this themselves — an App Block is a
+ * cross-origin guest that is handed a viewport and told nothing about the
+ * display — so the cap lives on the host.
+ *
+ * 🔴 THIS FILE IMPORTS NOTHING NEW FROM THE HOST, ON PURPOSE.
+ *
+ * The obvious spelling — import `APP_PAGE_MAX_WIDTH_PX` and assert the rendered
+ * width equals it — is the self-referential trap `FILL_MIN_HEIGHT_PX` already
+ * recorded: it compares a measurement against the very constant that produced
+ * it, so it is true by construction for every value including a broken one. It
+ * has a second cost here that matters more: a file that imports a symbol which
+ * does not exist on the base revision fails to COLLECT, and a collection failure
+ * reports "no tests" rather than a red assertion — which is indistinguishable
+ * from a suite wired to nothing. Every expectation below is either a LITERAL
+ * bound or a comparison between two things measured in the same render, so this
+ * exact file runs on `origin/main` and fails there for the right reason.
+ *
+ * 🔴 EVERY VIEWPORT IS SET EXPLICITLY AND NAMED IN THE ASSERTION. The runner's
+ * default is 414px WIDE — narrower than a phone in landscape — so a width claim
+ * written without `page.viewport(...)` is not merely under-tested, it is
+ * measuring a viewport at which this feature is INERT and would pass whether or
+ * not the fix exists. (`AppsPageLayout.geometry.browser.test.tsx` pins 1440x900
+ * for the same reason: the harness fixes no viewport of its own, so any suite
+ * that cares about width has to state one.)
+ *
+ * NOTE ON REACH: the browser `component` project runs in CI as the
+ * `preview / component-tests` status — REPORT-ONLY, so a break here is visible
+ * but does not block a merge. This file is the EMPIRICAL half; the gating half
+ * is the source guard in `__tests__/pageBlockHostMaxWidth.test.ts`, which is in
+ * the node `unit` project. Neither can replace the other: only a real layout can
+ * see a width, and only the gating tier can stop a merge.
+ */
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically
+  // imports `setTrpcBatchingEnabled`; the spread keeps every other real export
+  // so a new one can't silently arrive as `undefined` and take the whole file
+  // down to "0 tests collected".
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+/** The app slug the fixture runs as — also the key an opt-out rule is written against. */
+const BLOCK_ID = 'max-width-app';
+
+const baseProps = {
+  appBlockId: 'apb_maxwidth',
+  blockId: BLOCK_ID,
+  appId: 'app_maxwidth',
+  blockInstanceId: 'page_apb_maxwidth',
+  appName: 'Max Width App',
+  iframeSrc: SAME_ORIGIN_SRC,
+  surface: 'page-run' as const,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: BLOCK_ID,
+  token: 'tok_maxwidth',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: [] as string[],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: null,
+  theme: 'light' as const,
+};
+
+/**
+ * Stylesheet injected by a test, removed after it.
+ *
+ * Without the teardown a `:root` override written by one test survives into the
+ * next one in this file (browser mode gives each FILE an iframe, not each test),
+ * which would silently re-point the cap for every case after it.
+ */
+let injected: HTMLStyleElement | null = null;
+function injectCss(css: string) {
+  injected = document.createElement('style');
+  injected.textContent = css;
+  document.head.appendChild(injected);
+}
+afterEach(() => {
+  injected?.remove();
+  injected = null;
+});
+
+/**
+ * The production chain, reduced to what decides WIDTH.
+ *
+ * Mirrors `src/pages/apps/run/[slug]/[[...path]].tsx`: `AppLayout`'s no-scroll
+ * `<main>` (a full-width flex column) and the run page's own wrapper Box. Both
+ * are `width: 100%` with no bound of their own — that is the chain the defect
+ * lived in, and the reason the cap has to be on the host rather than on them.
+ */
+function renderInPageChain() {
+  return renderWithProviders(
+    <div
+      data-testid="layout-main"
+      style={{
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        data-testid="page-wrapper"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          width: '100%',
+        }}
+      >
+        <PageBlockHost {...baseProps} fit="fill" />
+      </div>
+    </div>
+  );
+}
+
+async function mountAt(width: number, height: number) {
+  await page.viewport(width, height);
+  renderInPageChain();
+  await expect.element(page.getByTestId('app-page-frame')).toBeInTheDocument();
+  const host = page.getByTestId('app-page-frame').element() as HTMLElement;
+  const parent = page.getByTestId('page-wrapper').element() as HTMLElement;
+  // `measure` re-reads the live boxes, so a test can change the cascade and ask
+  // again WITHOUT a second `renderInPageChain()` — two mounted trees would leave
+  // two `app-page-frame` nodes in the document and every `getByTestId` after
+  // that fails the strict-mode single-match rule.
+  const measure = () => {
+    const hostRect = host.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+    return {
+      hostWidth: hostRect.width,
+      parentWidth: parentRect.width,
+      gutterLeft: hostRect.left - parentRect.left,
+      gutterRight: parentRect.right - hostRect.right,
+    };
+  };
+  return { host, measure, ...measure() };
+}
+
+describe('PageBlockHost — the app stops growing on a wide display', () => {
+  /**
+   * 🔴 GUARD THE INSTRUMENT FIRST. Every claim below is "the host is narrower
+   * than the space it was given", which is trivially satisfiable by a fixture
+   * that never got a wide space in the first place — a `page.viewport` call that
+   * silently did nothing would make the whole file pass while measuring a 414px
+   * window. So the parent width is asserted against a literal before any host
+   * width is believed.
+   */
+  test('POSITIVE CONTROL — the fixture really is 2560px wide at a 2560x1080 viewport', async () => {
+    const { parentWidth } = await mountAt(2560, 1080);
+    // Body margin + a possible scrollbar cost a few px; 2400 is far below any of
+    // those and far above the runner's 414px default, so this can only pass if the
+    // viewport call took effect.
+    expect(
+      parentWidth,
+      'the fixture parent is not wide at a 2560px viewport — `page.viewport` did not ' +
+        'take effect, and every width assertion in this file would pass vacuously'
+    ).toBeGreaterThan(2400);
+  });
+
+  test('at 2560x1080 the host is a centred column, NOT the full monitor width', async () => {
+    const { hostWidth, parentWidth, gutterLeft, gutterRight } = await mountAt(2560, 1080);
+
+    // THE REGRESSION CLAIM. Before the cap these two were equal, to the pixel.
+    expect(
+      hostWidth,
+      `at a 2560x1080 viewport the host spans its whole ${parentWidth}px parent — the ` +
+        'ultrawide cap is gone and an app is a single ~2500px column again'
+    ).toBeLessThan(parentWidth);
+
+    // LITERAL BOUNDS, deliberately not `APP_PAGE_MAX_WIDTH_PX` — see the header.
+    // Lower: below ~1280 the cap would be narrower than the widest ORDINARY
+    // civitai content measure (Mantine `xl`, 1320 border-box / 1288 content), i.e.
+    // an app would render narrower than the store page that launched it.
+    // Upper: above ~1920 (`APPS_PAGE_CONTAINER_WIDTH`) the cap would be wider than
+    // the widest first-party surface on the site and would stop being a cap at the
+    // sizes that motivated it.
+    expect(hostWidth, 'at 2560x1080 the capped host is implausibly narrow').toBeGreaterThanOrEqual(
+      1280
+    );
+    expect(hostWidth, 'at 2560x1080 the capped host is implausibly wide').toBeLessThanOrEqual(1920);
+
+    // CENTRED, not left-aligned with the whole gutter dumped on one side. A
+    // `max-width` WITHOUT `margin-inline: auto` gives exactly that, and it looks
+    // like a rendering bug rather than a frame.
+    expect(gutterLeft, 'at 2560x1080 there is no left gutter').toBeGreaterThan(0);
+    expect(
+      Math.abs(gutterLeft - gutterRight),
+      `at 2560x1080 the app is not centred: ${gutterLeft}px left vs ${gutterRight}px right`
+    ).toBeLessThanOrEqual(1);
+  });
+
+  test('at 3440x1440 (ultrawide) the cap still binds and the gutter grows with the display', async () => {
+    const { hostWidth, parentWidth, gutterLeft, gutterRight } = await mountAt(3440, 1440);
+
+    expect(
+      hostWidth,
+      `at a 3440x1440 viewport the host spans its whole ${parentWidth}px parent`
+    ).toBeLessThan(parentWidth);
+    expect(hostWidth, 'at 3440x1440 the capped host is implausibly wide').toBeLessThanOrEqual(1920);
+    // (3440 − 1920) / 2 = 760, so 700 holds for any cap inside the band above and
+    // is a literal the implementation cannot satisfy by construction.
+    expect(
+      gutterLeft,
+      'at 3440x1440 the gutter is far smaller than the cap implies — the host is not ' +
+        'obeying the cap on a genuinely ultrawide display'
+    ).toBeGreaterThan(700);
+    expect(
+      Math.abs(gutterLeft - gutterRight),
+      `at 3440x1440 the app is not centred: ${gutterLeft}px left vs ${gutterRight}px right`
+    ).toBeLessThanOrEqual(1);
+  });
+
+  /**
+   * 🔴 THE HALF THAT MATTERS MOST. Almost all traffic is below the cap, so a
+   * regression HERE is far worse than a suboptimal ultrawide. Both declarations
+   * the fix adds are supposed to be inert at these sizes: `max-width` clamps
+   * nothing because `width: 100%` already resolves narrower, and `margin-inline:
+   * auto` has no leftover inline space to distribute.
+   *
+   * Asserted as EXACT equality on the width AND on the left edge, plus `0px`
+   * computed margins. Equality is what "byte-identical geometry" means; a
+   * tolerance would hide a small clamp, and the margin read is what
+   * distinguishes "same width" from "same width, shifted".
+   *
+   * ⚠️ THESE THREE ARE GREEN ON THE BASE REVISION TOO, BY DESIGN — measured, 3/3.
+   * That is not a vacuous pass: base-green IS the reference, and the claim is
+   * that HEAD matches it. They are the only thing that would catch an
+   * implementation that got the ultrawide case right by spending width
+   * everywhere else (a percentage cap, a padded gutter, a `min()` on the width).
+   * Do not count them as evidence that the cap WORKS — the wide cases above are
+   * that, and they are the ones red at base.
+   */
+  test.each([
+    [1024, 768],
+    [1280, 900],
+    [1440, 900],
+  ])('below the cap (%ix%i) the geometry is unchanged — no clamp, no gutter', async (w, h) => {
+    const { host, hostWidth, parentWidth, gutterLeft, gutterRight } = await mountAt(w, h);
+
+    expect(
+      hostWidth,
+      `at a ${w}x${h} viewport the host is ${hostWidth}px inside a ${parentWidth}px parent — ` +
+        'the cap has started binding below its threshold, which changes the rendering for ' +
+        'the viewports that carry the traffic'
+    ).toBe(parentWidth);
+    expect(gutterLeft, `at ${w}x${h} the host has been shifted right`).toBe(0);
+    expect(gutterRight, `at ${w}x${h} the host has been shifted left`).toBe(0);
+
+    const cs = getComputedStyle(host);
+    expect([cs.marginLeft, cs.marginRight], `at ${w}x${h} the auto margins resolved non-zero`).toEqual(
+      ['0px', '0px']
+    );
+  });
+
+  /**
+   * 🔴 PROVE THE VALUE COMES FROM THE CUSTOM PROPERTY, NOT FROM A LITERAL IN THE
+   * COMPONENT. The whole opt-out design rests on the host reading
+   * `--app-page-max-width` through `var()` — if someone "simplified" it to an
+   * inline number, or wrote the property inline on the host (where it would beat
+   * every stylesheet rule), the two tests above would still pass and the
+   * documented escape hatch would be silently inert.
+   *
+   * This drives the property to a value no implementation would pick and checks
+   * the rendered width follows it exactly.
+   */
+  test('the cap is read from `--app-page-max-width` — overriding it moves the rendered width', async () => {
+    injectCss(':root { --app-page-max-width: 900px; }');
+    const { hostWidth } = await mountAt(2560, 1080);
+    expect(
+      hostWidth,
+      'the host did not follow a `--app-page-max-width: 900px` override at 2560x1080 — the ' +
+        'cap is not actually being read from the custom property, so no CSS opt-out can work'
+    ).toBe(900);
+  });
+
+  /**
+   * THE DOCUMENTED FULL-BLEED OPT-OUT, end to end: the ledger in `globals.css`
+   * keys on `data-block-id`, which the host stamps.
+   *
+   * Both halves are in ONE test on purpose. The second assertion alone is GREEN
+   * on the base revision (an uncapped host is full width for reasons that have
+   * nothing to do with the opt-out), so it would be an invariant guard rather
+   * than coverage. Pairing it with the capped measurement makes the test assert
+   * a DELTA — the rule changed something — which is only true once both the cap
+   * and the `data-block-id` anchor exist.
+   */
+  test('an app can opt out of the cap with a CSS rule keyed on `data-block-id`', async () => {
+    const { measure, hostWidth, parentWidth } = await mountAt(2560, 1080);
+    expect(hostWidth, 'the host is not capped at 2560x1080 to begin with').toBeLessThan(parentWidth);
+
+    injectCss(
+      `[data-testid='app-page-frame'][data-block-id='${BLOCK_ID}'] { --app-page-max-width: none; }`
+    );
+    const optedOut = measure();
+    expect(
+      optedOut.hostWidth,
+      'the ledger rule shape documented on `--app-page-max-width` in globals.css did not ' +
+        'restore full-bleed at 2560x1080 — either `data-block-id` is no longer stamped or the ' +
+        'cap is no longer overridable, and every opt-out in that ledger is inert'
+    ).toBe(optedOut.parentWidth);
+  });
+
+  /**
+   * ⚠️ INVARIANT GUARD, NOT REGRESSION COVERAGE — green on the base revision too,
+   * and labelled here so it is never counted as proof the cap works.
+   *
+   * The claim it pins is about the SAFE-AREA insets, which went live with
+   * `viewport-fit=cover`: in landscape on a notched device `--safe-area-inset-
+   * left`/`-right` are ~47px, and the shell pays only the TOP inset globally
+   * (`#__next { padding-top: … }` in globals.css), so left/right are unpaid for
+   * in-flow page content. The question this answers is whether the new gutter can
+   * interact with them — i.e. whether a viewport can be BOTH wider than the cap
+   * and carrying a non-zero inline inset. It cannot: the widest notched device in
+   * landscape is ~1000 CSS px, far below the cap, so the cap is inert wherever an
+   * inset exists and the two mechanisms never meet. Pinned rather than asserted
+   * in prose because "no device does both" is exactly the kind of claim that goes
+   * stale silently.
+   */
+  test('INVARIANT — at a notched phone landscape size (932x430) the cap is inert, so it cannot fight the safe-area insets', async () => {
+    injectCss(':root { --safe-area-inset-left: 47px; --safe-area-inset-right: 47px; }');
+    const { hostWidth, parentWidth, gutterLeft, gutterRight } = await mountAt(932, 430);
+    expect(
+      hostWidth,
+      'the cap has started binding at 932x430 — it now overlaps the viewport class where the ' +
+        'display-cutout insets are non-zero, and the gutter and the insets have to be reasoned ' +
+        'about together'
+    ).toBe(parentWidth);
+    expect([gutterLeft, gutterRight], 'at 932x430 the host is no longer flush').toEqual([0, 0]);
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -212,7 +212,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
         'same commit. If you did not, you have either uncentred the app, hardcoded the cap past ' +
         'its own opt-out, or removed the fallback that caps a host rendered without globals.css.'
     ).toBe(
-      'maxWidth: `var(--app-page-max-width, ${APP_PAGE_MAX_WIDTH_PX}px)`, marginInline: \'auto\','
+      "maxWidth: `var(--app-page-max-width, ${APP_PAGE_MAX_WIDTH_PX}px)`, marginInline: 'auto',"
     );
   });
 
@@ -239,7 +239,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
       root,
       'the host root no longer stamps `data-block-id={blockId}` between its testid and ' +
         '`data-needs-consent`. The full-bleed ledger in src/styles/globals.css selects on ' +
-        '`[data-testid=\'app-page-frame\'][data-block-id=\'…\']`, so every entry in it is now ' +
+        "`[data-testid='app-page-frame'][data-block-id='…']`, so every entry in it is now " +
         'inert. `blockId` (the app slug) is the required value — `blockInstanceId` is per-install ' +
         'and is NOT what an app author knows their app by.'
     ).toContain('data-block-id={blockId}');
@@ -278,7 +278,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
     expect(
       css,
       'src/styles/globals.css no longer documents the full-bleed opt-out against ' +
-        "`data-block-id`. The ledger is the ONLY way out of the cap; if it stops naming the " +
+        '`data-block-id`. The ledger is the ONLY way out of the cap; if it stops naming the ' +
         'attribute the host stamps, an app author following it writes a rule that matches nothing.'
     ).toContain('data-block-id');
   });

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -140,6 +140,8 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
     expect(files.length, 'the src/ walk matched no stylesheets or TS files').toBeGreaterThan(1000);
 
     const decls: { file: string; value: string }[] = [];
+    /** Declarations that sit under a `[data-block-id=…]` selector — the opt-out ledger. */
+    const ledgerOverrides: { file: string; value: string }[] = [];
     for (const file of files) {
       // 🔴 TEST FILES ARE OUT OF SCOPE, AND THE CLAIM IS NARROWED TO MATCH —
       // this counts declarations in SHIPPED source, not every occurrence under
@@ -162,20 +164,45 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
       ];
       for (const re of patterns) {
         for (const m of src.matchAll(re)) {
-          decls.push({
+          // 🔴 A LEDGER OVERRIDE IS NOT A DUPLICATE DEFAULT, and an earlier
+          // version of this guard could not tell them apart — it counted every
+          // declaration and demanded exactly one, so the FIRST real opt-out
+          // entry would have failed it. That is a guard that forbids the feature
+          // it is guarding, and it would have been discovered by whoever added
+          // the entry rather than by whoever wrote the guard.
+          //
+          // The discriminator is the SELECTOR this declaration sits under: read
+          // back to the nearest `{`, and the text between the previous `}` (or
+          // the start of file) and it is that rule's selector. A ledger entry is
+          // keyed on `[data-block-id=…]`; the default is on `:root`. Kept to a
+          // slice-and-look rather than a CSS parser deliberately — every
+          // declaration of this property lives in one flat, top-level region of
+          // globals.css, and the `--header-height` guard's own history records
+          // five audit rounds in which each parser added to close a hole shipped
+          // a new false PASS. If this property ever gains a declaration nested
+          // inside an at-rule, this needs revisiting rather than extending.
+          const before = src.slice(0, m.index ?? 0);
+          const open = before.lastIndexOf('{');
+          const selector = open === -1 ? '' : before.slice(before.lastIndexOf('}', open) + 1, open);
+          const entry = {
             file: repoPath(file),
             value: m[1].trim().replace(/^['"`]|['"`]$/g, ''),
-          });
+          };
+          if (/\[data-block-id\s*[=~|^$*]?=/.test(selector)) ledgerOverrides.push(entry);
+          else decls.push(entry);
         }
       }
     }
 
     expect(
       decls.map((d) => `${d.file}: ${d.value}`),
-      'expected exactly ONE `--app-page-max-width` declaration in shipped src/ (test files excluded). Zero means it was ' +
-        'renamed, removed or commented out — the host then falls back to its inline literal and ' +
-        'the documented CSS opt-out is inert. More than one means the cap is conditional or ' +
-        'duplicated, and binding it to a single TS constant is no longer a truthful claim.'
+      'expected exactly ONE DEFAULT `--app-page-max-width` declaration in shipped src/ (test ' +
+        'files excluded, and `[data-block-id=…]` ledger overrides excluded — those are the ' +
+        'documented opt-out and are counted separately below). Zero means it was renamed, ' +
+        'removed or commented out — the host then falls back to its inline literal and every ' +
+        'ledger rule overrides a property nothing else sets. More than one means the DEFAULT cap ' +
+        'is conditional or duplicated, and binding it to a single TS constant is no longer a ' +
+        'truthful claim.'
     ).toHaveLength(1);
     expect(decls[0].file, 'the `--app-page-max-width` declaration moved out of globals.css').toBe(
       'src/styles/globals.css'
@@ -186,6 +213,52 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
         'changed). The custom property is what actually ships; the constant is only the `var()` ' +
         'fallback, so a divergence means the code documents a cap the site does not use.'
     ).toBe(`${declared}px`);
+
+    // Every ledger override must live in globals.css beside the default. A rule
+    // of this shape in a CSS Module or a component stylesheet would work, but it
+    // would put the opt-out somewhere no one reviewing the ledger would look.
+    expect(
+      [...new Set(ledgerOverrides.map((d) => d.file))],
+      'a `[data-block-id=…]` override of `--app-page-max-width` was found outside globals.css. ' +
+        'The full-bleed ledger is meant to be one reviewable list; an entry elsewhere is invisible ' +
+        'to everyone reading it.'
+    ).toEqual(ledgerOverrides.length === 0 ? [] : ['src/styles/globals.css']);
+  });
+
+  /**
+   * 🔴 THE FULL-BLEED LEDGER IS A MEMBERSHIP LIST, AND BOTH DIRECTIONS ARE THE
+   * POINT — it fails when the set GROWS (an app was excused from the cap without
+   * anyone reading the criteria) and when it SHRINKS (an entry was dropped during
+   * an unrelated change and an app that needs full bleed is quietly letterboxed
+   * again). Modelled on the `fill` opt-in ledger in `pageRunScrollContract.test.ts`.
+   *
+   * 🔴 IT IS EMPTY TODAY, AND THAT IS A REAL ASSERTION, NOT A PLACEHOLDER. An
+   * empty expectation is exactly what makes the FIRST entry a deliberate,
+   * reviewed act: adding a rule to globals.css fails this test until someone
+   * writes the block id here too, with a reason. Adding a row is the intended
+   * maintenance path — deleting the assertion is not.
+   *
+   * The ids are read from the SELECTORS, not from a hand-kept list elsewhere, so
+   * a rule nobody told this test about is what it notices. `code()` strips
+   * comments first, so the template rule inside the ledger's own doc comment is
+   * not a member.
+   */
+  it('the full-bleed opt-out ledger — membership is explicit, and fails on growth AND shrink', () => {
+    const css = code(read(GLOBALS_CSS));
+    const members = [...css.matchAll(/\[data-block-id\s*=\s*['"]([^'"]+)['"]\]/g)]
+      .map((m) => m[1])
+      .sort();
+
+    expect(
+      members,
+      'the full-bleed opt-out ledger in src/styles/globals.css has changed. If you ADDED an ' +
+        'entry, add its block id to this expectation in the same commit, and make sure the ' +
+        "id is the app's `app_blocks.block_id` (what `PageBlockHost` stamps as `data-block-id`) " +
+        'rather than a listing slug — for an on-site app they are identical by construction ' +
+        '(`app-listing-mapper.ts` sets `slug: ab.blockId`), which is exactly the condition under ' +
+        'which the wrong one goes unnoticed. If you REMOVED one, an app that needed full bleed is ' +
+        'now capped again — confirm that is intended.'
+    ).toEqual([]);
   });
 
   /**

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -1,0 +1,285 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * THE ULTRAWIDE CAP — the GATING half.
+ *
+ * A full-page App Block had no width bound anywhere in its chain (page wrapper,
+ * host root and iframe are each `width: 100%`), so on a 2560px display an app
+ * rendered as a single ~2500px column. `PageBlockHost` now reads
+ * `max-width: var(--app-page-max-width, …)` with `margin-inline: auto` on its
+ * root.
+ *
+ * 🔴 WHY A SOURCE GUARD AS WELL AS A RENDERED ONE. The measurement lives in
+ * `PageBlockHostMaxWidth.browser.test.tsx`, which is the only tier that can see a
+ * width at all — but the browser `component` project runs in CI as the
+ * REPORT-ONLY `preview / component-tests` status, so nothing there can block a
+ * merge. This file is in the node `unit` project, which can. The same split, and
+ * the same reasoning, as `pageRunScrollContract.test.ts` (whose own header
+ * records the measured case where a fully-reverted floor left the gating tier
+ * 9/9 green and only the non-blocking tier red).
+ *
+ * WHAT IS PINNED HERE, and each is a thing whose absence is silent:
+ *   1. the constant exists, once, inside a band this file states as LITERALS
+ *   2. `--app-page-max-width` exists, once, in globals.css, and agrees with it
+ *   3. the host's two declarations, as one verbatim expression
+ *   4. `data-block-id` is stamped on the SAME element as the host testid — the
+ *      opt-out ledger's selector chains the two, so a rename makes every ledger
+ *      rule match nothing without changing anything visible
+ *   5. the value is read through `var()` and never written inline
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/PageBlockHost.tsx');
+const GLOBALS_CSS = path.join(REPO_ROOT, 'src/styles/globals.css');
+
+/**
+ * A repo-relative path with forward slashes on every platform — `path.relative`
+ * returns the platform separator, so a raw result compares unequal to the
+ * `src/...` literals below on Windows and the guard would fail for the platform
+ * rather than for the thing it guards.
+ */
+const repoPath = (file: string) => path.relative(REPO_ROOT, file).split(path.sep).join('/');
+
+function read(file: string): string {
+  // Prove the path before trusting a "no match": a comparison against an absent
+  // operand reports SAME, not MISSING, so a renamed file would otherwise turn
+  // every assertion below into a vacuous pass on an empty string.
+  expect(fs.existsSync(file), `${repoPath(file)} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/** Strip block + line comments so a rule can never be satisfied by prose ABOUT
+ *  the rule — every token searched for below is also discussed at length in the
+ *  comments of the file it is searched for in. */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** Collapse whitespace so an assertion pins the EXPRESSION, not its formatting. */
+function norm(src: string): string {
+  return src.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Pull one source region out by anchor regex and fail loudly if the anchor stops
+ * matching. An unmatched anchor must never read as "the rule is satisfied", and
+ * more than one match means the pin has become ambiguous and is grading an
+ * arbitrary occurrence.
+ */
+function region(src: string, anchor: RegExp, label: string): string {
+  const all = [...src.matchAll(new RegExp(anchor.source, `${anchor.flags.replace('g', '')}g`))];
+  expect(
+    all.length,
+    `${label}: expected exactly ONE match for ${anchor}, found ${all.length}. ` +
+      'Zero means the anchor rotted — update the pin deliberately rather than deleting it. ' +
+      'More than one means this pin is now ambiguous.'
+  ).toBe(1);
+  return norm(all[0][0]);
+}
+
+describe('the full-page App Block host caps its width, and the cap is overridable', () => {
+  /**
+   * 🔴 THE BOUNDS ARE LITERALS HERE, DELIBERATELY NOT READ FROM THE SOURCE. A
+   * band derived from `PageBlockHost.tsx` would be graded against the very file
+   * it bounds, so one edit could move the value and its own limits together —
+   * the self-referential trap `FILL_MIN_HEIGHT_PX` already records.
+   *
+   * Lower 1280: below this the cap would be narrower than the widest ORDINARY
+   * civitai content measure (Mantine `xl`, 1320 border-box / 1288 content — also
+   * `APPS_TWO_COLUMN_DETAIL_MEASURE`, the store-preview page an app is launched
+   * FROM), so an app would render narrower than the page that linked to it.
+   *
+   * Upper 1920: `APPS_PAGE_CONTAINER_WIDTH`, the widest first-party surface on
+   * the site, and it is that wide for card grids and wide tables specifically. At
+   * or above it the cap stops binding at the sizes that motivated it.
+   *
+   * The ARITHMETIC that picks a value inside the band lives on the constant's own
+   * doc comment; the NUMBERS live here.
+   */
+  it('`APP_PAGE_MAX_WIDTH_PX` is declared once and stays inside its documented band', () => {
+    const declared = /export const APP_PAGE_MAX_WIDTH_PX = (\d+);/.exec(code(read(HOST)))?.[1];
+    expect(
+      declared,
+      'APP_PAGE_MAX_WIDTH_PX declaration not found in PageBlockHost.tsx — if it was renamed or ' +
+        'derived, re-point this guard rather than deleting it: it is the only BLOCKING check on ' +
+        'the ultrawide cap.'
+    ).toBeDefined();
+
+    const cap = Number(declared);
+    expect(cap).toBeGreaterThanOrEqual(1280);
+    expect(cap).toBeLessThanOrEqual(1920);
+  });
+
+  /**
+   * 🔴 CSS CANNOT IMPORT A TS CONSTANT, so the number exists twice and this is
+   * the only thing keeping the two in step. Exactly the arrangement — and the
+   * failure mode — that `--header-height` / `HEADER_HEIGHT_PX` has in
+   * `pageRunScrollContract.test.ts`.
+   *
+   * The custom property is the LIVE value; the TS constant is the `var()`
+   * fallback. So a divergence is not cosmetic: it means the cap that ships and
+   * the cap the code claims are different numbers, and the fallback silently
+   * takes over anywhere the app stylesheet is not loaded.
+   */
+  it('`--app-page-max-width` is declared once in shipped `src/`, in globals.css, and agrees with the constant', () => {
+    const declared = /export const APP_PAGE_MAX_WIDTH_PX = (\d+);/.exec(code(read(HOST)))?.[1];
+    expect(declared).toBeDefined();
+
+    const SRC = path.join(REPO_ROOT, 'src');
+    const files = fs
+      .readdirSync(SRC, { recursive: true, encoding: 'utf8' })
+      .filter((f) => /\.(css|scss|ts|tsx)$/.test(f))
+      .map((f) => path.join(SRC, f))
+      // `readdirSync` yields directories too, and this repo has directories whose
+      // names end in a matching extension — reading one throws EISDIR.
+      .filter((f) => fs.statSync(f).isFile());
+    // Guard the walk itself: a glob matching nothing makes everything below
+    // vacuously true, which is the reassuring-zero failure mode.
+    expect(files.length, 'the src/ walk matched no stylesheets or TS files').toBeGreaterThan(1000);
+
+    const decls: { file: string; value: string }[] = [];
+    for (const file of files) {
+      // 🔴 TEST FILES ARE OUT OF SCOPE, AND THE CLAIM IS NARROWED TO MATCH —
+      // this counts declarations in SHIPPED source, not every occurrence under
+      // `src/`. Unlike the `--header-height` guard (which skips only itself),
+      // this property's own coverage REQUIRES a test to declare it: the browser
+      // suite proves the cap is really read from the custom property, and proves
+      // the ledger's rule shape works, by injecting overrides of exactly this
+      // form. Counting those as duplicates would make the guard forbid its own
+      // evidence. A declaration inside a `*.test.*` file cannot reach a user, so
+      // excluding them costs nothing the claim above needs.
+      if (/\.test\.tsx?$/.test(file)) continue;
+      const src = code(fs.readFileSync(file, 'utf8'));
+      // Three spellings, matching the `--header-height` guard: plain CSS, the
+      // CSS-in-JS object form (including a computed key), and the imperative
+      // setter. The second is the one that would silently defeat the opt-out.
+      const patterns = [
+        /--app-page-max-width\s*:\s*([^;}\n]+)/g,
+        /['"`]--app-page-max-width['"`]\s*\]?\s*:\s*([^,;}\n]+)/g,
+        /setProperty\(\s*['"`]--app-page-max-width['"`]\s*,\s*([^)]+)\)/g,
+      ];
+      for (const re of patterns) {
+        for (const m of src.matchAll(re)) {
+          decls.push({
+            file: repoPath(file),
+            value: m[1].trim().replace(/^['"`]|['"`]$/g, ''),
+          });
+        }
+      }
+    }
+
+    expect(
+      decls.map((d) => `${d.file}: ${d.value}`),
+      'expected exactly ONE `--app-page-max-width` declaration in shipped src/ (test files excluded). Zero means it was ' +
+        'renamed, removed or commented out — the host then falls back to its inline literal and ' +
+        'the documented CSS opt-out is inert. More than one means the cap is conditional or ' +
+        'duplicated, and binding it to a single TS constant is no longer a truthful claim.'
+    ).toHaveLength(1);
+    expect(decls[0].file, 'the `--app-page-max-width` declaration moved out of globals.css').toBe(
+      'src/styles/globals.css'
+    );
+    expect(
+      decls[0].value,
+      'globals.css `--app-page-max-width` and `APP_PAGE_MAX_WIDTH_PX` have DIVERGED (or the unit ' +
+        'changed). The custom property is what actually ships; the constant is only the `var()` ' +
+        'fallback, so a divergence means the code documents a cap the site does not use.'
+    ).toBe(`${declared}px`);
+  });
+
+  /**
+   * 🔴 PIN THE WHOLE EXPRESSION, NOT FEATURES OF IT — the lesson
+   * `pageRunScrollContract.test.ts` paid for. A presence check on the token
+   * `maxWidth` survives every mutation that matters here:
+   *
+   *   · dropping `marginInline: 'auto'` — the app is still capped, but the whole
+   *     gutter lands on the right and it reads as a rendering bug
+   *   · dropping the `var()` and hardcoding the number — the two tests above
+   *     still pass and every CSS opt-out silently stops working
+   *   · dropping the fallback — the cap disappears wherever globals.css is absent
+   *
+   * The accepted cost is that a cosmetic reformat of this exact pair fails this
+   * test. That is the trade for a machine-checkable claim, and `code()` runs
+   * first, so commenting a line out changes the string exactly as deleting it does.
+   */
+  it("pins the host's cap declarations verbatim — a dropped `auto` margin, `var()` or fallback all fail", () => {
+    const src = code(read(HOST));
+    expect(
+      region(src, /maxWidth: `var\(--app-page-max-width[\s\S]*?marginInline: 'auto',/, 'width cap'),
+      'This is a DELIBERATE verbatim pin, not an incidental string match. If you changed this ' +
+        'pair on purpose (including a pure reformat), update the expected string here in the ' +
+        'same commit. If you did not, you have either uncentred the app, hardcoded the cap past ' +
+        'its own opt-out, or removed the fallback that caps a host rendered without globals.css.'
+    ).toBe(
+      'maxWidth: `var(--app-page-max-width, ${APP_PAGE_MAX_WIDTH_PX}px)`, marginInline: \'auto\','
+    );
+  });
+
+  /**
+   * 🔴 THE OPT-OUT'S SELECTOR IS A RELATIONSHIP BETWEEN TWO ATTRIBUTES ON ONE
+   * ELEMENT, so that is what is asserted — not that each token appears somewhere
+   * in the file.
+   *
+   * The ledger in globals.css is written as
+   * `[data-testid='app-page-frame'][data-block-id='…']`. If `data-block-id` moves
+   * to a different element, or is renamed, or is fed the per-install
+   * `blockInstanceId` instead of the app's slug, every ledger rule matches
+   * nothing — and nothing about the page looks wrong, so no one finds out until
+   * an app that opted out is reported as still capped.
+   */
+  it('stamps `data-block-id` on the same element as the host testid — the opt-out ledger keys on both', () => {
+    const src = code(read(HOST));
+    const root = region(
+      src,
+      /data-testid="app-page-frame"[\s\S]*?data-needs-consent=/,
+      'host root attributes'
+    );
+    expect(
+      root,
+      'the host root no longer stamps `data-block-id={blockId}` between its testid and ' +
+        '`data-needs-consent`. The full-bleed ledger in src/styles/globals.css selects on ' +
+        '`[data-testid=\'app-page-frame\'][data-block-id=\'…\']`, so every entry in it is now ' +
+        'inert. `blockId` (the app slug) is the required value — `blockInstanceId` is per-install ' +
+        'and is NOT what an app author knows their app by.'
+    ).toContain('data-block-id={blockId}');
+  });
+
+  /**
+   * ⚠️ INVARIANT GUARD, NOT REGRESSION COVERAGE — this passes on the base
+   * revision too (where neither the property nor the cap existed), and is
+   * labelled so it is never counted as proof the cap works.
+   *
+   * What it protects is the opt-out's ONE structural precondition. An inline
+   * `style={{ '--app-page-max-width': … }}` on the host root would look like a
+   * tidier way to spell the same thing and would render identically — but an
+   * inline custom property beats every stylesheet rule on that element, which is
+   * exactly the rule shape the ledger uses. The opt-out would become inert with
+   * no visible change anywhere.
+   */
+  it('INVARIANT — the cap is never written as an inline custom property, which would beat the ledger', () => {
+    const src = code(read(HOST));
+    expect(
+      /['"`]--app-page-max-width['"`]\s*\]?\s*:/.test(src),
+      'PageBlockHost.tsx now sets `--app-page-max-width` as an inline style property. An inline ' +
+        'custom property wins over any stylesheet rule targeting the same element, so this makes ' +
+        'the full-bleed ledger in globals.css inert while rendering identically. Read the ' +
+        'property with `var()`; declare it in globals.css.'
+    ).toBe(false);
+  });
+
+  /**
+   * The ledger itself has to keep selecting the element the host renders. This
+   * asserts the two halves of that selector are the ones globals.css names —
+   * a rename on either side is caught by whichever guard sees it first.
+   */
+  it('globals.css documents the opt-out against the attributes the host actually stamps', () => {
+    const css = read(GLOBALS_CSS);
+    expect(
+      css,
+      'src/styles/globals.css no longer documents the full-bleed opt-out against ' +
+        "`data-block-id`. The ledger is the ONLY way out of the cap; if it stops naming the " +
+        'attribute the host stamps, an app author following it writes a rule that matches nothing.'
+    ).toContain('data-block-id');
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -232,11 +232,19 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * an unrelated change and an app that needs full bleed is quietly letterboxed
    * again). Modelled on the `fill` opt-in ledger in `pageRunScrollContract.test.ts`.
    *
-   * 🔴 IT IS EMPTY TODAY, AND THAT IS A REAL ASSERTION, NOT A PLACEHOLDER. An
-   * empty expectation is exactly what makes the FIRST entry a deliberate,
-   * reviewed act: adding a rule to globals.css fails this test until someone
-   * writes the block id here too, with a reason. Adding a row is the intended
-   * maintenance path — deleting the assertion is not.
+   * 🔴 THE EXPECTATION IS AN ENUMERATION, NOT A FLOOR. It was `[]` when the
+   * mechanism shipped, which is what forced the first entry to be argued for
+   * rather than appended; `playable-collections` was then added by an explicit
+   * product decision, with the reasoning recorded beside the rule in
+   * `globals.css`. Adding a row here is the intended maintenance path — relaxing
+   * this to a `toContain`, a length check or a superset test is not, and would
+   * throw away the shrink half. A second entry must fail this test first.
+   *
+   * WHY EACH MEMBER IS HERE (keep this list in step with the rules):
+   *   · `playable-collections` — a collection player whose three open-collection
+   *     view modes are all uncapped by the app; the 960px well it does have
+   *     applies only to its browse shell, behind an early return. Full reasoning
+   *     and the file:line evidence live on the rule in `globals.css`.
    *
    * The ids are read from the SELECTORS, not from a hand-kept list elsewhere, so
    * a rule nobody told this test about is what it notices. `code()` strips
@@ -258,7 +266,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
         '(`app-listing-mapper.ts` sets `slug: ab.blockId`), which is exactly the condition under ' +
         'which the wrong one goes unnoticed. If you REMOVED one, an app that needed full bleed is ' +
         'now capped again — confirm that is intended.'
-    ).toEqual([]);
+    ).toEqual(['playable-collections']);
   });
 
   /**

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -227,9 +227,21 @@ export const APPS_FULL_MEASURE_PAGES = [
 ] as const;
 
 /**
- * Routes that deliberately have NO container: they host a full-viewport iframe
- * (the block runtime / the moderator's live preview) or a full-bleed dev shell.
- * Capping these would letterbox the app being run/reviewed.
+ * Routes that deliberately have NO `AppsPageLayout` container: they host a
+ * full-viewport iframe (the block runtime / the moderator's live preview) or a
+ * full-bleed dev shell. Wrapping these in the apps container would letterbox the
+ * app being run/reviewed AND put a second chrome band over a third-party app.
+ *
+ * 🔴 "NO CONTAINER" IS NOT "NO WIDTH BOUND" — it stopped being that, and this
+ * comment used to assert the stronger claim. All three of these routes mount
+ * `PageBlockHost`, which caps ITSELF at `--app-page-max-width` (1600px, see
+ * `APP_PAGE_MAX_WIDTH_PX` in `~/components/AppBlocks/PageBlockHost`) and centres
+ * the app past that. Two different mechanisms at two very different thresholds:
+ * this module's container is 1920 and applies to the apps CHROME, the host's cap
+ * is 1600 and applies to the app itself, and an app can be excused from the
+ * host's via the CSS ledger in `src/styles/globals.css`. Nothing here changes —
+ * these routes still pass no `measure` and still render no `AppsPageLayout` — but
+ * do not read this list as evidence that a run page is unbounded.
  */
 export const APPS_FULL_BLEED_PAGES = [
   '/apps/run/[slug]/[[...path]]',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -102,7 +102,64 @@
      `footer`, so their own markup is the viewport edge at both ends. Every
      other route inherits 0 here and pays nothing, which is correct. */
   --safe-area-inset-bottom-page: var(--safe-area-inset-bottom);
+
+  /* THE ULTRAWIDE CAP FOR A FULL-PAGE APP BLOCK — `/apps/run/<slug>` and the
+     other `PageBlockHost` surfaces (the dev tunnel, the moderator preview).
+
+     WHAT IT IS. `PageBlockHost` reads this as
+     `max-width: var(--app-page-max-width, …)` on its root, with
+     `margin-inline: auto`, so the app renders as a centred column with a
+     neutral gutter either side once the viewport is wider than this. Below it
+     the declaration is INERT — the host is `width: 100%`, which is already
+     narrower than the cap, and `margin-inline: auto` resolves to 0 on a box
+     that fills its parent. That inertness is the point: the great majority of
+     traffic is below this width and must render byte-identically to before.
+
+     🔴 IT IS DECLARED HERE, AND ONLY HERE, SO THAT AN APP CAN OPT OUT — see the
+     ledger below. The host reads it through `var()` rather than writing it as
+     an inline value precisely so a stylesheet rule can override it; an inline
+     custom property on the host itself would beat every such rule and make the
+     opt-out inert. `APP_PAGE_MAX_WIDTH_PX` in `PageBlockHost.tsx` carries the
+     same number as the `var()` fallback (CSS cannot import a TS constant), and
+     `__tests__/pageBlockHostMaxWidth.test.ts` is what keeps the two in step —
+     the same arrangement `--header-height`/`HEADER_HEIGHT_PX` uses. The
+     justification for the VALUE lives on that constant. */
+  --app-page-max-width: 1600px;
 }
+
+/* FULL-BLEED OPT-OUT LEDGER — one rule per app, and the ONLY way out of the cap.
+   Empty today.
+
+   🔴 WHY THIS IS CSS AND NOT A MANIFEST FIELD. The App Block manifest schema is
+   byte-mirrored across three repos (`public/schemas/app-block/v1.json`, the Go
+   CLI, `@civitai/app-sdk`) and has to move in lockstep, and this host is pinned
+   to `@civitai/app-sdk@^0.14.0` while guests ship 0.35.x — so a new manifest
+   field would be UNTYPED at exactly the point the host consumes it. A rule here
+   is one line, needs no schema motion, and cannot be forged: the guest is
+   cross-origin and can never reach this cascade.
+
+   HOW TO ADD ONE. `PageBlockHost` stamps `data-block-id` (the app's slug — the
+   same value that builds `<slug>.civit.ai`) on its root, so:
+
+     [data-testid='app-page-frame'][data-block-id='my-canvas-app'] {
+       --app-page-max-width: none;
+     }
+
+   `none` is the full-bleed value; a narrower app can take a px value instead.
+   Add the rule together with a one-line reason, the way every other ledger in
+   this repo is kept — an entry with no stated reason cannot be reviewed later.
+
+   WHEN IT IS WARRANTED: an app whose surface is the canvas — an infinite grid, a
+   timeline, a map, a side-by-side compare — where a centred column is actively
+   worse. NOT for "it looks bigger". The default exists because an app cannot
+   know how wide the viewer's monitor is and almost none of them defend against
+   it themselves.
+
+   The mechanism is MEASURED, not merely written down: the "opt-out" cases in
+   `src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx` inject a
+   rule of exactly this shape at a 2560px viewport and assert the host goes back
+   to full width — so this block cannot rot into a comment describing something
+   that no longer works. */
 
 /* `data-adhesive-ad` is on the ad BAR itself (src/components/Ads/AdhesiveAd.tsx),
    not on a wrapper, so this matches only when the bar is really rendered and

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -128,7 +128,11 @@
 }
 
 /* FULL-BLEED OPT-OUT LEDGER — one rule per app, and the ONLY way out of the cap.
-   Empty today.
+   One member today: `playable-collections` (its reasoning is on the rule itself,
+   below). The membership set is ASSERTED in
+   `src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts` and fails if
+   it grows OR shrinks, so adding or removing a rule here without updating that
+   expectation is a test failure, not a silent change.
 
    🔴 WHY THIS IS CSS AND NOT A MANIFEST FIELD. The App Block manifest schema is
    byte-mirrored across three repos (`public/schemas/app-block/v1.json`, the Go
@@ -160,6 +164,33 @@
    rule of exactly this shape at a 2560px viewport and assert the host goes back
    to full width — so this block cannot rot into a comment describing something
    that no longer works. */
+
+/* Playable Collections (`playable-collections`) — a collection PLAYER, and every
+   one of its open-collection surfaces is uncapped by the app itself.
+
+   Read at the app's deployed ref (`sync/deployed-0.2.2`), whose manifest declares
+   this same `blockId`. The app does carry a 960px well, but it is `contentStyle`
+   (`App.tsx:972`) applied only to the BROWSE shell (`App.tsx:789`): opening a
+   collection early-returns at `App.tsx:733` past that wrapper into
+   `CollectionViewer`, whose root (`CollectionViewer.tsx:582`) is
+   `width: 100%; min-height: 100dvh` with no max-width — and that root serves all
+   THREE view modes (classic `Player`, continuous-horizontal, continuous-vertical)
+   plus the ambient "cast" state. So the cap would bind on all of them: the
+   slideshow's media is `object-fit: contain`, so a centred column simply shrinks
+   the player, and the ticker/wall modes are `repeat(cols, minmax(0, 1fr))` grids
+   that spend whatever width they are given.
+
+   The browse list is unaffected either way — it is behind that early return and
+   the app already caps it at 960, well under the default.
+
+   🔴 THIS ENTRY IS ALSO ASSERTED IN `__tests__/pageBlockHostMaxWidth.test.ts`,
+   which fails if this set GROWS OR SHRINKS, and it is EXERCISED by the red/green
+   pair in `PageBlockHostMaxWidth.browser.test.tsx` — that suite parses THIS file
+   and injects the rule below verbatim, so deleting or mistyping it fails a test
+   rather than silently letterboxing the app again. */
+[data-testid='app-page-frame'][data-block-id='playable-collections'] {
+  --app-page-max-width: none;
+}
 
 /* `data-adhesive-ad` is on the ad BAR itself (src/components/Ads/AdhesiveAd.tsx),
    not on a wrapper, so this matches only when the bar is really rendered and


### PR DESCRIPTION
## The problem

A full-page App Block had **no width bound anywhere in its chain**. The run page's
wrapper is `width: '100%'`, `PageBlockHost`'s root was `width: '100%'`, and the
iframe is `width: '100%'` — so on a 2560px display an app rendered as a single
~2500px column, and on a 3440px ultrawide as a ~3400px one.

The apps cannot fix this for us. An App Block is a cross-origin guest that is
handed a viewport and told nothing about the display, and the SDK gives it
nothing to lay out in: `@civitai/blocks-react` exports no Container / AppShell /
Page and declares no container width (its only max-widths are modal-scoped:
340 / 440 / 620, plus a 420px sign-in gate card), and the official starter
templates contain **zero** width declarations.

## What this does

`PageBlockHost` now renders its root as a **centred column with a maximum
width**:

```
maxWidth: `var(--app-page-max-width, ${APP_PAGE_MAX_WIDTH_PX}px)`,
marginInline: 'auto',
```

with `--app-page-max-width: 1600px` declared once on `:root` in `globals.css`.

Applied to the host **root**, not to the `<iframe>`, so the trust chrome, the app
and the failure card all take one measure — capping the iframe alone would leave
`AppBlockChrome` (the breadcrumb that vouches for the app) spanning a width the
app it labels does not occupy.

## Why 1600 — measured against the apps that actually exist

I enumerated the first-party App Block repos: 13 apps, **11 with a `page`
surface** (the other two are `model.sidebar_top` slot blocks that a page cap
cannot reach).

- **9 of the 11 already cap themselves**, at 640 / 720 / 720 / 760 / 820 / 880 /
  900 / 960 / **1100** px — a hand-copied `contentStyle` well; median 860, max
  1100. None renders content wider than 1100px, so this cap is a **no-op for
  their layout**: it changes which background paints the far gutter, nothing else.
- **2 do not cap at all** — Notepad and Sensei, both `100dvh` two-pane app shells
  (fixed 280 / 240px sidebar beside an unbounded `flex: 1` pane). These are the
  shipped apps that genuinely stretched to the monitor.
- **The long tail is unbounded by construction** (the SDK/starters point above),
  which is the real argument for a default rather than nine more hand-picked
  numbers.

Two in-repo anchors bound the choice, and 1600 sits between them:

| | |
|---|---|
| **1288** | the widest *ordinary* civitai content measure — Mantine `xl` (1320 border-box) is the widest container size used across `src/pages`, and `APPS_TWO_COLUMN_DETAIL_MEASURE` (the store-preview page an app is launched **from**) is exactly it. Cap below this and an app renders narrower than the page that linked to it. |
| **1920** | `APPS_PAGE_CONTAINER_WIDTH` — an outlier for a reason that does not transfer: it exists for card **grids** and wide **tables**, which genuinely spend the space. An app block may be a grid or may be one form, and the host cannot tell which. |

1600 also clears the widest app-imposed well (1100) by ~45%, so it can never
letterbox an app that has already thought about its width, and it leaves a
two-pane shell like Notepad or Sensei a ~1350px content pane.

**The cost, stated plainly:** this binds on a maximised browser on a 1080p
monitor (~1905 CSS px), not only on ultrawides — a common desktop, which gets a
~150px gutter per side. It does **not** bind on any laptop class
(1280/1366/1440/1536), tablet, or phone in either orientation.

## Opt-out — CSS, not a manifest field

No manifest field: the schema is byte-mirrored across three repos and must move
in lockstep, and this host is pinned to `@civitai/app-sdk@^0.14.0` while guests
ship 0.35.x, so a new field would be untyped exactly where the host consumes it.

Instead the host stamps `data-block-id` (the app's slug) and the cap is read
through `var()`, so a stylesheet rule can override it. The **full-bleed opt-out
ledger** lives beside the declaration in `globals.css`:

```css
[data-testid='app-page-frame'][data-block-id='your-app-slug'] {
  --app-page-max-width: none;
}
```

The ledger is **empty today** — see the flag at the bottom. Reading the cap
through `var()` rather than writing an inline custom property is load-bearing and
is guarded: an inline custom property would beat every stylesheet rule on the
same element and make every ledger entry inert while rendering identically.

Documented for app authors in `docs/features/app-blocks.md` → *Publisher-side
notes → How wide your app renders*, which carries the rule template, the review
criteria, and a pointer to the test that measures the mechanism.

## Constraints

1. **Byte-identical below the cap.** Both declarations are inert there: `width:
   100%` already resolves narrower than the cap, and `margin-inline: auto` has no
   leftover inline space to distribute. Asserted as **exact equality** of host
   width and parent width, flush left and right edges, and `0px` computed
   margins, at 1024 / 1280 / 1440 — green at base and at HEAD.
2. **`fit="fill"` vs `fit="viewport"` untouched.** This change is horizontal
   only; the `fit` ternary, the reveal wrapper and the run page wrapper are not
   edited. `pageRunScrollContract.test.ts` is **unmodified and green (10/10)**,
   including the `fill` opt-in ledger.
3. **Slot surface out of scope.** `IframeHost` (the model-page slot) is
   untouched. It sizes by `RESIZE_IFRAME` inside a ~300px sidebar column, so a
   width cap there would be meaningless; the two slot blocks are excluded from
   this change by construction.
4. **Safe-area insets do not interact.** The gutter appears only above 1600 CSS
   px; the inline insets are non-zero only on a notched device, whose widest
   landscape viewport is ~1000 CSS px. The two cannot co-occur, and that is
   pinned as an explicitly-labelled invariant guard at 932x430 with 47px insets
   injected rather than left as a prose claim. (The shell pays only the **top**
   inset globally; left/right are unpaid for in-flow page content, which is
   pre-existing and unchanged here.)

## Tests

Two tiers, because neither can do the other's job: only a real layout can see a
width, and only the node `unit` project can block a merge (the browser
`component` project is the report-only `preview / component-tests` status).

Neither file imports anything that does not exist on `main`, so **both run at
base and fail on assertions, not on collection**.

**`PageBlockHostMaxWidth.browser.test.tsx`** — 9 tests. Every viewport set
explicitly and named in the assertion message (the runner's default is 414px
*wide*, so an unqualified width claim measures a size at which this feature is
inert).

| test | at `dfdd2d3a1c` | at HEAD |
|---|---|---|
| POSITIVE CONTROL — fixture really is 2560px wide | ✓ (control) | ✓ |
| at 2560x1080 the host is a centred column, NOT the full monitor width | **×** | ✓ |
| at 3440x1440 the cap binds and the gutter grows (>700px) | **×** | ✓ |
| below the cap (1024x768) geometry unchanged | ✓ (reference) | ✓ |
| below the cap (1280x900) geometry unchanged | ✓ (reference) | ✓ |
| below the cap (1440x900) geometry unchanged | ✓ (reference) | ✓ |
| the cap is read from `--app-page-max-width` (override to 900px moves it) | **×** | ✓ |
| an app can opt out with a rule keyed on `data-block-id` | **×** | ✓ |
| INVARIANT — at 932x430 the cap is inert vs the safe-area insets | ✓ (labelled) | ✓ |

Base: **4 failed / 5 passed of 9**. HEAD: **9 passed of 9**. Every base-pass is
either a control, the byte-identity reference, or labelled in-file as an
invariant guard.

**`__tests__/pageBlockHostMaxWidth.test.ts`** — 6 tests, node `unit` (gating).
Pins the constant inside a band stated as **literals** (not read from the file it
bounds — the `FILL_MIN_HEIGHT_PX` self-reference trap), binds
`--app-page-max-width` to `APP_PAGE_MAX_WIDTH_PX` the way the `--header-height`
guard does, pins the two style declarations as one verbatim expression, and
requires `data-block-id` on the same element as the host testid.

Base: **5 failed / 1 passed of 6** — the single pass is the one labelled
INVARIANT. HEAD: **6 passed of 6**.

## Mutation battery — each guard watched to fail, for its own reason

Run against the real tree, one mutation at a time, restored and re-verified
between each (`git diff --stat HEAD` empty after the last restore; both suites
re-run green afterwards — 16/16 unit, 18/18 browser including
`PageBlockHostScrollFit`).

| mutation | killed by | reason it failed |
|---|---|---|
| **M1** drop `marginInline: 'auto'` | 3 tests — the verbatim source pin, and both wide-viewport cases | `AssertionError: at 2560x1080 there is no left gutter: expected 0 to be greater than 0` — i.e. the centring assertion specifically, not a bystander |
| **M2** hardcode `maxWidth: APP_PAGE_MAX_WIDTH_PX` (drop the `var()`) | 3 tests — the verbatim source pin, the `--app-page-max-width` override control, and the opt-out delta | the cap still binds (the two wide cases still pass, correctly), but the CSS opt-out is now inert — which is exactly the silent failure those two tests exist for |
| **M3** lower the cap to `800px` in globals.css | 6 tests — the CSS/TS agreement guard, all three below-cap byte-identity cases, the notch invariant, and the 2560 lower bound | proves the three below-cap cases are **not** vacuous: they are green at base *and* at HEAD, and they detect a cap that starts binding too low |

M3 is the one that matters most, because those three cases are the only evidence
for constraint 1 and they pass on the base revision — without a killing mutation
they would be unfalsifiable by construction.

## Verification run

- `node scripts/typecheck.mjs` → **0 errors in 53s** (heap cap 8192 MB).
- `eslint` on the 4 changed source files → **4 files linted, 0 errors, 0
  warnings** (JSON reporter, so the count is read rather than inferred from an
  exit code; the same binary reports 53 pre-existing problems across
  `src/components/AppBlocks/`, which is the positive control that it can go red).
- `prettier --check` on all 6 changed/added files → **all matched files use
  Prettier code style** (3 were reformatted first; added files are blocking in
  CI, and `prettier-changed.mjs` only scopes to uncommitted ones).
- `vitest --project unit src/components/AppBlocks/__tests__/
  src/components/Apps/__tests__/` → **103 files / 1864 tests passed**.
- `vitest --project component src/components/AppBlocks/PageBlockHost*` → **20
  files / 271 tests passed**, i.e. every existing PageBlockHost surface is
  unaffected (they all render at the 414px default, where the cap is inert).
- Branch is 0 commits behind `origin/main`, so this tree **is** the merged tree.

## Not verified

- No run against a real dev server / the live `/apps/run/<slug>` page. The
  browser fixture models the production chain (`AppLayout`'s no-scroll `<main>` +
  the run page's wrapper Box, both `width: 100%`), and that chain is itself
  pinned verbatim by `pageRunScrollContract.test.ts`, but "it looks right in a
  browser on a 2560px monitor" is a claim I have not made.
- The mod-review preview and the dev tunnel take the cap too (it is on the host,
  not the route). That is deliberate — a mod should review what users see — and
  their suites are green, but I have not looked at either surface on a wide
  display.

## 🔴 One product call left open, with evidence

Exactly **one** shipped app is actively worse under this cap:
**Playable Collections in player mode**. It returns early past its own 960px well
and renders a `100dvh` slideshow (`CollectionViewer.tsx:576`, `Player.tsx:628`)
whose media is `object-fit: contain`, so a centred column simply makes the player
smaller. Two more (Notepad, Sensei) are viewport-anchored two-pane shells that
will read as detached rather than broken — and Sensei's unbounded message column
is arguably *improved*.

I did **not** add a ledger entry for it: an entry has to name a block id, and
inventing one produces a rule that matches nothing and looks like protection.
The fix, once someone confirms the slug against the approved `app_blocks` row, is
one line in the ledger in `globals.css`. Flagging rather than filing — the closing
condition is a merged one-line PR, and the judgement (does the player want full
bleed?) is yours, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: the ledger is now addable, but no entry is written

The coordinator resolved the slug from production (`playable-collections`, block
+ listing both `approved`); the deployed manifest at `sync/deployed-0.2.2`
independently declares `"blockId": "playable-collections"`. **The entry was still
not added**, because the stated reasoning does not survive reading the deployed
app, and the brief said not to add it in exactly that case:

- **There are THREE view modes, not two** — classic (`Player`), plus
  continuous-horizontal and continuous-vertical (`ContinuousView`), with an
  ambient "cast" state on top (`CollectionViewer.tsx:1`, `:247`, `:474`).
- **The 960px well is conditional.** It is `contentStyle` (`App.tsx:972`) applied
  only to the browse shell (`App.tsx:789`). Opening a collection **early-returns
  at `App.tsx:733`** past that wrapper into `CollectionViewer`, whose root
  (`CollectionViewer.tsx:582`) is `width: 100%; min-height: 100dvh` with **no
  max-width in any mode**.

So "the opt-out changes nothing the app already governs" is false: it would
unbound all three open-collection modes, none of which the app caps. The
conclusion may still be right — a ticker and a wall want width, and the player's
media is `object-fit: contain` so a cap only shrinks it — but that is a larger
product call than the one authorised.

**Two things were fixed so the entry can be added safely when someone decides:**

1. **The first entry would have broken the guard.** `--app-page-max-width` was
   counted with a flat "exactly ONE declaration in shipped `src/`" — and a ledger
   entry is a second declaration. Measured with a real entry present, the guard as
   committed failed `expected [ …(2) ] to have a length of 1 but got 2`. The count
   now partitions by selector (`[data-block-id=…]` ⇒ ledger override, else
   default) and asserts exactly one *default*, still bound to the TS constant,
   plus that every override lives in `globals.css`.
2. **Added the membership ledger** the design implied but did not have: the set of
   opted-out block ids, read from the selectors rather than a hand-kept list,
   asserted equal to `[]`. Fails on **growth** and on **shrink**. Verified end to
   end — with an entry present it fails naming `playable-collections`; with the
   expectation updated to match, 7/7 green.

**On the key:** the ledger must key on `app_blocks.block_id`, which is what the
host stamps. `resolvePageBlockBySlug` queries `where: { blockId: slug }`
(`block-registry.service.ts:1823`) and the run page passes `blockId: page.blockId`,
so `data-block-id` is the block id. For an on-site app the listing slug is
*derived from* it (`app-listing-mapper.ts:194`, `slug: ab.blockId`), so the two
cannot diverge — which is precisely why keying on the wrong one would go
unnoticed. A listing slug can also exist with no block at all (off-site
listings), and those never mount `PageBlockHost`, so the listing slug is a
concept the host does not possess.

Counts after this change: unit `AppBlocks/__tests__` + `Apps/__tests__` **103
files / 1865 tests passed**; browser `PageBlockHostMaxWidth` + `ScrollFit`
**18 passed**; typecheck **0 errors**; eslint **2 files, 0/0**; prettier clean.

---

## Update: `playable-collections` is opted out (operator decision)

The ledger now has one member. The reasoning is recorded on the rule itself in
`globals.css` and summarised for authors in `docs/features/app-blocks.md`, so the
next person reading the ledger sees a reason rather than an id: the app's 960px
well is `contentStyle` (`App.tsx:972`) applied only to the browse shell
(`App.tsx:789`), and opening a collection early-returns at `App.tsx:733` into
`CollectionViewer`, whose root (`CollectionViewer.tsx:582`) is
`width: 100%; min-height: 100dvh` with no cap across all three view modes plus
the ambient cast state.

The membership expectation moved `[]` → `['playable-collections']`, keeping the
fail-on-growth-**and**-shrink property, with a per-member "why" list in the
docstring and an explicit note that relaxing it to `toContain` / a length / a
superset check is not the maintenance path.

**Red/green pair**, now assertable. It parses the REAL rules out of `globals.css`
(`?raw` + `CSSStyleSheet.replaceSync`) and injects only those — the harness loads
no app cascade, so a test writing its own copy of the rule would stay green with
the shipped entry deleted. Both arms render at 2560x1080 with that same CSS and
differ only in `blockId`.

Failure texts, measured rather than predicted:

| mutation | tier | assertion |
|---|---|---|
| delete the rule | gating | `expected [] to deeply equal [ 'playable-collections' ]` |
| delete the rule | browser | `no [data-block-id=…] rules were parsed out of src/styles/globals.css … expected [] to include 'playable-collections'` (the extraction control fires first, by design) |
| neuter the rule (`none` → `1600px`) | browser | `at 2560x1080 the app 'playable-collections' is NOT full-bleed. Its ledger rule in src/styles/globals.css is missing, mistyped, or no longer overrides '--app-page-max-width' …: expected 1600 to be 2560` |

**The selector-partitioned guard passes with the real member in the tree** — the
input on which the previous flat count failed `expected [ …(2) ] to have a length
of 1`.

Counts: unit `AppBlocks/__tests__` + `Apps/__tests__` **103 files / 1865 tests**;
browser `PageBlockHost*` **20 files / 272 tests** (+1, the ledger pair);
typecheck **0 errors**; eslint **2 files, 0/0**; prettier clean.
