### PR TITLE
feat(app-blocks): F3 — a native mobile shell for the app frame below `sm`

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -30,6 +30,30 @@ import {
 // eslint-disable-next-line import/first
 import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/component-setup';
 
+/**
+ * 🔴 THIS FILE PINS A DESKTOP VIEWPORT, AND UNTIL F3 IT PINNED NONE — WHICH MEANT
+ * IT HAD BEEN RUNNING ON A PHONE ALL ALONG WITHOUT SAYING SO.
+ *
+ * `test/component-setup.tsx` sets no viewport, so every test here inherited Vitest's
+ * default of **414×896** (`resolved.browser.viewport.width ??= 414` in
+ * `vitest/dist/chunks/coverage.*.js`). Nothing depended on that while the chrome was
+ * width-blind, so nothing said which width these claims were about. F3 makes the
+ * page-surface chrome swap its whole structure below the `sm` breakpoint (768), and
+ * 414 is below it — so the breadcrumb, the platform-nav trigger and the ⋮ DROPDOWN
+ * that this file asserts are, at the inherited viewport, the mobile shell's back
+ * chevron, folded nav and bottom SHEET instead.
+ *
+ * Every assertion in this file is about the DESKTOP chrome, so it says so now. The
+ * mobile shell has its own suite (`AppBlockChromeMobileShell.browser.test.tsx`) that
+ * names its viewport in the same way. Naming the viewport is the fix; leaving it
+ * unnamed and adjusting the assertions to whatever 414 produces would have quietly
+ * moved this file's subject.
+ */
+const DESKTOP: [number, number] = [1440, 900];
+beforeEach(async () => {
+  await page.viewport(...DESKTOP);
+});
+
 // H2: the host-rendered "trust frame" around an in-model app block must NAME the
 // app (host-side, spoof-proof) — not just carry it in the invisible iframe
 // `title`. `AppBlockChrome` is exported from IframeHost solely so this renders in

--- a/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
@@ -196,6 +196,37 @@ async function renderShell({
 }
 
 /**
+ * Open the ⋮ and wait for its contents, at EITHER rendering.
+ *
+ * 🔴 IT WAITS ON A LABEL BOTH REVISIONS RENDER, NOT ON THE NEW SURFACE'S TESTID —
+ * because a test that dies looking for something F3 introduced is red for a reason
+ * that says nothing about behaviour. "Manage apps" is the ⋮'s own item at
+ * `origin/main` and a sheet row here, so waiting on it means the assertions that
+ * follow run against a populated surface at BOTH revisions, and the red lands on the
+ * claim rather than on the lookup. Measured: the first draft waited on
+ * `app-block-menu-dropdown` and every one of these tests failed at `origin/main` as a
+ * 15-second timeout instead of an assertion.
+ */
+async function openOverflow() {
+  await page.getByTestId('app-block-menu-trigger').click();
+  await expect.element(page.getByText('Manage apps')).toBeInTheDocument();
+}
+
+/**
+ * The ⋮'s content box, whichever rendering it got — a Drawer content box below `sm`,
+ * a Menu dropdown above it (and at `origin/main`, at every width). Keyed on Mantine's
+ * STATIC classes, which this app guarantees (`withStaticClasses` defaults true and is
+ * not overridden), so the lookup does not depend on anything F3 added.
+ */
+function overflowBox(): HTMLElement | null {
+  return q('.mantine-Drawer-content') ?? q('.mantine-Menu-dropdown');
+}
+
+/** The activatable rows of a surface, by their visible label. */
+const rowLabels = (box: HTMLElement) =>
+  [...box.querySelectorAll('a, button')].map((el) => (el.textContent ?? '').trim());
+
+/**
  * Guard-the-guard. Without `@mantine/core/styles.css` the `Group` is not a flex row,
  * every width and height below reads as something other than what ships, and the
  * assertions can still pass. Asserted first in every test that measures anything.
@@ -300,6 +331,53 @@ describe('AppBlockChrome mobile shell', () => {
     ).toBeNull();
   });
 
+  test(`INVARIANT GUARD — at ${PHONE[0]}x${PHONE[1]} the MODEL-slot chrome is untouched, narrow though it is`, async () => {
+    // 🔴 NOT REGRESSION COVERAGE — green at `origin/main`. It is the SURFACE control,
+    // and it is the only thing that kills the most tempting mutation in this change:
+    // dropping the `isPage &&` term from `const compact = isPage && geometry.compact`.
+    // Every other test in this file passes with that term gone, because they all render
+    // the page surface — and the model slot would silently acquire a back chevron
+    // pointing at the Marketplace from a model page nobody reached the store from,
+    // plus a folded nav in place of its own.
+    //
+    // The distinction is real and deliberate: `geometry.compact` is TRUE here (a 360px
+    // bar is narrow by any measure, and the model sidebar is narrower still). What
+    // gates the shell is the SURFACE, because the shell replaces a breadcrumb only the
+    // full-page surface has. See `chromeGeometry.ts`'s `compact` doc comment.
+    await page.viewport(...PHONE);
+    // No `slotId` → the model surface (the chrome's documented back-compat default).
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-model-narrow" appName={APP_NAME} />
+    );
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    const root = page.getByTestId('app-block-chrome').element() as HTMLElement;
+    // Let the ResizeObserver measure and commit, so this is a claim about the SETTLED
+    // render rather than about the first paint (where nothing is compact anyway).
+    await frame();
+    await frame();
+    await frame();
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    expect(
+      root.getAttribute('data-chrome-compact'),
+      `a ${PHONE[0]}px MODEL-slot bar must not take the mobile shell — the shell replaces a ` +
+        'breadcrumb this surface does not have, and "back to the Marketplace" is not a ' +
+        'meaningful action from a model page'
+    ).toBe('false');
+    expect(
+      q('[data-testid="app-block-back"]'),
+      'the model slot must have no back chevron at any width'
+    ).toBeNull();
+    expect(
+      q('[data-testid="app-platform-nav-trigger"]'),
+      'the model slot keeps its own platform-nav trigger at any width'
+    ).not.toBeNull();
+    expect(
+      q('[data-testid="app-block-name"]'),
+      'the model slot keeps its badge app-name label at any width'
+    ).not.toBeNull();
+  });
+
   test(`REGRESSION — at ${PHONE[0]}x${PHONE[1]} the platform nav is inside the ⋮ sheet`, async () => {
     // 🔴 RED AT `origin/main`, BEHAVIOURALLY. The failing assertion is the presence of
     // "Installed apps" after opening the ⋮. That label exists ONLY in the platform-nav
@@ -314,16 +392,15 @@ describe('AppBlockChrome mobile shell', () => {
     const root = await renderShell({ viewport: PHONE, expectCompact: true });
     expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
 
-    await page.getByTestId('app-block-menu-trigger').click();
-    // Happens-before for everything below: the surface's own content box, whichever
-    // rendering it is. Waiting on this (rather than on the item under test) is what
-    // stops the assertions from being satisfied by a retry window.
-    await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
-    const sheet = q('[data-testid="app-block-menu-dropdown"]') as HTMLElement;
+    // Happens-before for everything below: a label the ⋮ carries at BOTH revisions.
+    // Waiting on that (rather than on the item under test) is what stops the
+    // assertions from being satisfied by a retry window, and what keeps the red
+    // behavioural.
+    await openOverflow();
+    const sheet = overflowBox();
+    expect(sheet, 'the ⋮ must have opened SOME surface').not.toBeNull();
 
-    const labels = [...sheet.querySelectorAll('a, button')].map((el) =>
-      (el.textContent ?? '').trim()
-    );
+    const labels = rowLabels(sheet as HTMLElement);
     for (const label of ['Marketplace', 'Installed apps', 'My apps']) {
       expect(
         labels,
@@ -346,10 +423,9 @@ describe('AppBlockChrome mobile shell', () => {
       `at ${PHONE[0]}px the ⋮ must open a Drawer (the site's bottom-sheet idiom), not a dropdown`
     ).not.toBeNull();
     expect(
-      (content as HTMLElement).contains(sheet),
-      'the ⋮ contents must be INSIDE the drawer content box — that is the box the global ' +
-        'safe-area rule pays, so a sheet rendered outside it would be unpaid'
-    ).toBe(true);
+      q('.mantine-Menu-dropdown'),
+      `at ${PHONE[0]}px the ⋮ must NOT also render a dropdown — the sheet replaces it`
+    ).toBeNull();
   });
 
   test(`INVARIANT GUARD — at ${DESKTOP[0]}x${DESKTOP[1]} the nav stays in its own menu and the ⋮ does not absorb it`, async () => {
@@ -361,18 +437,15 @@ describe('AppBlockChrome mobile shell', () => {
     const root = await renderShell({ viewport: DESKTOP, expectCompact: false });
     expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
 
-    await page.getByTestId('app-block-menu-trigger').click();
     // Wait for an item that IS in this menu at both revisions. That is the
     // happens-before: once "Manage apps" is present the dropdown has rendered its
     // children, so the absence below is measured against a populated surface rather
     // than an empty one.
-    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
-    const overflow = q('[data-testid="app-block-menu-dropdown"]') as HTMLElement;
-    const overflowLabels = [...overflow.querySelectorAll('a, button')].map((el) =>
-      (el.textContent ?? '').trim()
-    );
+    await openOverflow();
+    const overflow = overflowBox();
+    expect(overflow, 'the ⋮ must have opened SOME surface').not.toBeNull();
     expect(
-      overflowLabels,
+      rowLabels(overflow as HTMLElement),
       `at ${DESKTOP[0]}px the ⋮ must NOT carry the platform nav — it has its own trigger here`
     ).not.toContain('Marketplace');
 
@@ -444,11 +517,20 @@ describe('AppBlockChrome mobile shell', () => {
     // the same `ChromeSurfaceItem` close path with nothing to navigate to.
     await renderShell({ viewport: PHONE, expectCompact: true, appBlockId: 'ab_1' });
 
-    await page.getByTestId('app-block-menu-trigger').click();
-    await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
+    await openOverflow();
+    // 🔴 A POSITIVE PRECONDITION, NOT DECORATION. The assertion at the end of this
+    // test is an ABSENCE, and an absence is trivially satisfied by a surface that
+    // never opened — at `origin/main` there is no sheet at all, so without this line
+    // the test would pass there while proving nothing. Requiring the sheet FIRST is
+    // what makes the later `toBeNull()` mean "it closed" rather than "it never was".
+    const sheet = q('.mantine-Drawer-content');
+    expect(
+      sheet,
+      `at ${PHONE[0]}px the ⋮ must open a bottom sheet before this test can say anything about ` +
+        'the sheet closing'
+    ).not.toBeNull();
 
-    const sheet = q('[data-testid="app-block-menu-dropdown"]') as HTMLElement;
-    const action = [...sheet.querySelectorAll('a, button')].find(
+    const action = [...(sheet as HTMLElement).querySelectorAll('a, button')].find(
       (el) => (el.textContent ?? '').trim() === 'Permissions & activity'
     ) as HTMLElement | undefined;
     expect(
@@ -565,8 +647,7 @@ describe('AppBlockChrome mobile shell', () => {
       const style = injectInset(34);
       try {
         await renderShell({ viewport: PHONE, expectCompact: true });
-        await page.getByTestId('app-block-menu-trigger').click();
-        await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
+        await openOverflow();
 
         const content = q('.mantine-Drawer-content');
         expect(
@@ -627,13 +708,13 @@ describe('AppBlockChrome mobile shell', () => {
       const root = await renderShell({ viewport, expectCompact });
       expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
 
-      // The decision actually flipped between the two cases — otherwise this pair
-      // would be measuring one shell twice and reporting it as two viewports.
-      expect(
-        root.getAttribute('data-chrome-compact'),
-        `the ${viewport[0]}px case must actually resolve compact=${expectCompact}`
-      ).toBe(String(expectCompact));
-
+      // 🔴 THIS PAIR DELIBERATELY DOES NOT ASSERT `data-chrome-compact`, EVEN THOUGH
+      // AN EARLIER DRAFT DID. That attribute does not exist at `origin/main`, so
+      // asserting it turned an invariant guard — a test whose whole value is that it
+      // is green on BOTH sides — into one that fails at base for want of an attribute.
+      // A guard that cannot be green at base cannot tell you the height did not move.
+      // Which shell each viewport renders is established by the two structural tests
+      // at the top of this file, so this pair is not measuring one shell twice.
       expect(
         Math.round(rect(root).height),
         `the chrome bar's resting height must not move at ${viewport[0]}px — it is the model ` +

--- a/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
@@ -346,9 +346,7 @@ describe('AppBlockChrome mobile shell', () => {
     // full-page surface has. See `chromeGeometry.ts`'s `compact` doc comment.
     await page.viewport(...PHONE);
     // No `slotId` → the model surface (the chrome's documented back-compat default).
-    renderWithProviders(
-      <AppBlockChrome blockInstanceId="inst-model-narrow" appName={APP_NAME} />
-    );
+    renderWithProviders(<AppBlockChrome blockInstanceId="inst-model-narrow" appName={APP_NAME} />);
     await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
     const root = page.getByTestId('app-block-chrome').element() as HTMLElement;
     // Let the ResizeObserver measure and commit, so this is a claim about the SETTLED
@@ -494,7 +492,10 @@ describe('AppBlockChrome mobile shell', () => {
         'disagree about one app'
     ).toContain('90%');
     const storeLink = q('[data-testid="app-block-name-popover-store-link"]');
-    expect(storeLink, 'the "View in App Store" action must survive inside the sheet').not.toBeNull();
+    expect(
+      storeLink,
+      'the "View in App Store" action must survive inside the sheet'
+    ).not.toBeNull();
     expect((storeLink as HTMLElement).getAttribute('href')).toContain(SLUG);
   });
 
@@ -598,7 +599,10 @@ describe('AppBlockChrome mobile shell', () => {
         for (const rule of Array.from(rules)) {
           if (rule instanceof CSSStyleRule) {
             if (rule.selectorText.includes('.mantine-Drawer-content')) found.push(rule.cssText);
-          } else if (typeof CSSLayerBlockRule !== 'undefined' && rule instanceof CSSLayerBlockRule) {
+          } else if (
+            typeof CSSLayerBlockRule !== 'undefined' &&
+            rule instanceof CSSLayerBlockRule
+          ) {
             // `@layer` only orders the cascade — descend. `@media`/`@supports` are
             // conditional and are deliberately not descended into: a rule that only
             // applies under a condition is not evidence of an unconditional payment.
@@ -607,7 +611,9 @@ describe('AppBlockChrome mobile shell', () => {
         }
       };
       walk(sheet.cssRules);
-      const paying = found.filter((t) => /padding-bottom:\s*var\(--safe-area-inset-bottom\)/.test(t));
+      const paying = found.filter((t) =>
+        /padding-bottom:\s*var\(--safe-area-inset-bottom\)/.test(t)
+      );
       if (paying.length === 0) {
         throw new Error(
           'src/styles/globals.css no longer pays `padding-bottom: var(--safe-area-inset-bottom)` ' +

--- a/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
@@ -1,0 +1,656 @@
+/**
+ * F3 — the app-block frame's NATIVE MOBILE SHELL, measured in a real browser at two
+ * named viewports.
+ *
+ * Below the `sm` breakpoint (768, px scale) the full-page chrome stops being a
+ * breadcrumb bar: a back chevron replaces the trail, the app name moves to the centre
+ * and stays tappable, and the ⋮ becomes a bottom sheet that also carries the platform
+ * nav folded into it. Above `sm` — and on the model-slot surface at every width —
+ * nothing changes.
+ *
+ * 🔴 THE HARNESS WAS BLIND TO THIS DIMENSION AND WIDENING IT IS PART OF THE WORK.
+ * `test/component-setup.tsx` sets no viewport, so every component test inherits
+ * Vitest's default of **414×896** (`resolved.browser.viewport.width ??= 414`,
+ * `vitest/dist/chunks/coverage.*.js`) — a phone, silently, in every suite that never
+ * says otherwise. `AppsPageLayout.geometry.browser.test.tsx` pins 1440×900. So a
+ * mobile spec written into either config would have passed or failed for reasons
+ * nothing in the file named. Every test here states its viewport in its own title AND
+ * in each assertion message, and the two sibling suites that assert the DESKTOP chrome
+ * (`AppBlockChrome.browser.test.tsx`, `AppBlockChromePlatformNav.browser.test.tsx`)
+ * were given an explicit desktop pin in the same change, for the same reason.
+ *
+ * 🔴 WHICH TESTS ARE REGRESSION COVERAGE AND WHICH ARE NOT — LABELLED PER TEST, AND
+ * THE DISTINCTION IS NOT COSMETIC. Four fail at `origin/main` against the shipped
+ * component for a BEHAVIOURAL reason (named in each). Several pass at `origin/main`
+ * and are invariant guards — above all the resting-height pair, which is the whole
+ * point of constraint 1 and would be worthless if it were counted as coverage of the
+ * shell. Two more fail at `origin/main` only because the sheet does not exist there,
+ * which proves nothing about behaviour; they are labelled SEAM/PARITY GUARD and are
+ * explicitly not counted.
+ *
+ * 🔴 WHY THIS FILE LOADS `@mantine/core/styles.css`. Same reason the F1 responsive
+ * suite does: the shared scaffold omits it on purpose, but every number here — the
+ * bar's resting height, the `ActionIcon`'s `--ai-size-sm`, the Drawer's content box —
+ * comes FROM that stylesheet, and without it each computes to something meaningless
+ * while the assertions still pass. Vitest browser mode gives each file its own iframe,
+ * so the import does not leak into sibling suites.
+ */
+import '@mantine/core/styles.css';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
+import type * as TrpcMod from '~/utils/trpc';
+// Raw text, not a stylesheet import — see `safeAreaRuleText()` for why.
+import globalsCss from '~/styles/globals.css?raw';
+
+const mocks = vi.hoisted(() => ({
+  features: { appListings: true } as Record<string, boolean>,
+  detail: undefined as unknown,
+}));
+
+// The chrome gates its platform-nav "Review" item on the viewer's moderator flag and
+// would otherwise throw for want of a CivitaiSessionContext. Anon, non-mod.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// 🔴 BOTH FLAG HOOKS, TO THE SAME OBJECT. `AppNameCrumb` and `ChromeReviewEntry` read
+// through `useOptionalFeatureFlags` (fail-closed outside a provider); overriding only
+// `useFeatureFlags` would leave them resolving the real null and every store-card
+// assertion below would fail against a static `<Text>` for a reason unrelated to what
+// it asserts. `importOriginal` spread rather than a wholesale object
+// (local-rules/no-wholesale-module-mock): a hand-written module silently breaks every
+// importer the day the real one grows an export this factory omits.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsMod>()),
+  useFeatureFlags: () => mocks.features,
+  useOptionalFeatureFlags: () => mocks.features,
+}));
+
+// The `blocks.*` namespace is reached by `AppPermissionsActivityDrawer`, which the
+// parity test opens from a sheet row. Empty fixtures — its data-driven behaviour has
+// its own suite; here it is only the target of an ACTION row.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      getAppDetail: { useQuery: () => ({ data: mocks.detail, isLoading: false, error: null }) },
+      // Reached only by F4's entry points, which this file does not drive (that path
+      // has its own suite). Present so a render cannot die on an undefined namespace.
+      getMyReview: { useQuery: () => ({ data: null }) },
+    },
+    blocks: {
+      listMyScopeGrants: { useQuery: () => ({ data: [], isLoading: false }) },
+      listMyAppActivity: {
+        useInfiniteQuery: () => ({
+          data: { pages: [{ items: [], nextCursor: null }] },
+          isLoading: false,
+          hasNextPage: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+        }),
+      },
+      listMyScopeInvocations: {
+        useInfiniteQuery: () => ({
+          data: { pages: [{ items: [], nextCursor: null }] },
+          isLoading: false,
+          hasNextPage: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+        }),
+      },
+    },
+    modelVersion: { getVersionsByIds: { useQuery: () => ({ data: undefined }) } },
+    useQueries: () => [],
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import { CHROME_BAR_PX } from '~/components/AppBlocks/slotReservation';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+// eslint-disable-next-line import/first
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The two measurement points, named here and named again in every assertion message
+ * so a failure says WHICH width it is about. A single point could not catch this
+ * defect class in either direction: a shell that never appears and a shell that
+ * appears everywhere both pass at one viewport.
+ */
+const PHONE: [number, number] = [360, 780];
+const DESKTOP: [number, number] = [1440, 900];
+
+const APP_NAME = 'Budgeted Generator';
+const SLUG = 'budgeted-generator';
+
+/** `ActionIcon size="sm"` at rest — `@mantine/core` 7.17.8's `--ai-size-sm` is 1.375rem. */
+const RESTING_ICON_PX = 22;
+/** 22 (ActionIcon sm) + 8 (`py={4}` ×2) + 1 (bottom border). See the height test. */
+const CHROME_BAR_RENDERED_PX = RESTING_ICON_PX + 8 + 1;
+
+const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+const rect = (el: Element) => el.getBoundingClientRect();
+const q = (sel: string) => document.querySelector(sel) as HTMLElement | null;
+
+function detailFixture() {
+  return {
+    id: 'apl_01',
+    slug: SLUG,
+    name: APP_NAME,
+    recommend: { recommendedCount: 9, notRecommendedCount: 1, recommendPct: 0.9 },
+    reviewCount: 10,
+  };
+}
+
+/**
+ * Render the page-surface chrome at `viewport` and wait until its `ResizeObserver` has
+ * measured the bar and committed the resulting shell decision.
+ *
+ * 🔴 THE WAIT IS ON `data-chrome-compact`, WHICH IS THE HAPPENS-BEFORE EVERY ABSENCE
+ * ASSERTION IN THIS FILE RESTS ON. An absence checked with a POLLING matcher is
+ * vacuous against async-gated UI — `expect.element(x).not.toBeInTheDocument()` retries
+ * until it holds, and at t0 the element is legitimately absent for everyone, so it can
+ * pass with the feature deleted. (That is exactly how three F4 mutants survived a
+ * fully green file.) Here the chrome publishes its resolved decision as an attribute,
+ * so waiting for that attribute to reach the expected value is a real observation of
+ * the same state the assertion is about — after which every absence check below is a
+ * SYNCHRONOUS `document.querySelector`, with no retry window to hide in.
+ *
+ * The poll is bounded (1.5s) rather than open-ended so that a run against code with no
+ * such attribute at all — `origin/main` — falls through quickly to the behavioural
+ * assertion instead of dying on a missing attribute and reporting a timeout where a
+ * real failure message belongs.
+ */
+async function renderShell({
+  viewport,
+  expectCompact,
+  ...props
+}: {
+  viewport: [number, number];
+  expectCompact: boolean;
+  slotId?: string;
+  slug?: string;
+  appBlockId?: string;
+}) {
+  await page.viewport(...viewport);
+  renderWithProviders(
+    <AppBlockChrome
+      blockInstanceId="inst-mobile-shell"
+      appName={APP_NAME}
+      slotId="app.page"
+      {...props}
+    />
+  );
+  await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+  const root = page.getByTestId('app-block-chrome').element() as HTMLElement;
+
+  const want = expectCompact ? 'true' : 'false';
+  const deadline = Date.now() + 1500;
+  while (Date.now() < deadline && root.getAttribute('data-chrome-compact') !== want) {
+    await frame();
+  }
+  // Two more frames so the re-render the measurement triggered has laid out.
+  await frame();
+  await frame();
+  return root;
+}
+
+/**
+ * Guard-the-guard. Without `@mantine/core/styles.css` the `Group` is not a flex row,
+ * every width and height below reads as something other than what ships, and the
+ * assertions can still pass. Asserted first in every test that measures anything.
+ */
+const styleSheetLoaded = (root: HTMLElement) => getComputedStyle(root).display === 'flex';
+
+beforeEach(() => {
+  mocks.features = { appListings: true };
+  mocks.detail = detailFixture();
+});
+
+describe('AppBlockChrome mobile shell', () => {
+  test(`REGRESSION — at ${PHONE[0]}x${PHONE[1]} the page chrome is a back chevron + centered name + ⋮, with NO breadcrumb`, async () => {
+    // 🔴 RED AT `origin/main`, AND THE FAILING ASSERTION IS THE BREADCRUMB-ABSENCE
+    // ONE — deliberately, because that is the half that fails BEHAVIOURALLY rather
+    // than for want of a testid. At main the page surface renders
+    // `app-block-breadcrumb` at every width, so `toBeNull()` fails there against a
+    // real element. The chevron-presence assertions below it would also fail at main,
+    // but only because the element does not exist yet, which says nothing about
+    // behaviour — they are here to say WHAT replaced the trail, not to carry the red.
+    const root = await renderShell({ viewport: PHONE, expectCompact: true });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    expect(
+      q('[data-testid="app-block-breadcrumb"]'),
+      `at ${PHONE[0]}px the desktop breadcrumb trail must be GONE — the mobile shell replaces ` +
+        'it, it does not sit alongside it'
+    ).toBeNull();
+
+    // …and the platform-nav trigger with it: the operator's call is that the nav
+    // folds into the ⋮, so a second trigger in a 360px bar would be the thing this
+    // change exists to remove.
+    expect(
+      q('[data-testid="app-platform-nav-trigger"]'),
+      `at ${PHONE[0]}px there must be no separate platform-nav trigger — it folds into the ⋮`
+    ).toBeNull();
+
+    const back = q('[data-testid="app-block-back"]');
+    expect(back, `at ${PHONE[0]}px the bar must offer a back affordance`).not.toBeNull();
+    // A real anchor to the same destination the crumb pointed at. `getAttribute`
+    // rather than `.href` so this reads the authored value, not a resolved absolute
+    // URL that would also match a different route on a different origin.
+    expect(
+      (back as HTMLElement).getAttribute('href'),
+      `at ${PHONE[0]}px the back chevron must point at the Marketplace, exactly as the crumb did`
+    ).toBe('/apps');
+    expect(
+      (back as HTMLElement).getAttribute('aria-label'),
+      'the back chevron is icon-only, so its accessible name is the only thing naming it'
+    ).toBe('Back to Marketplace');
+
+    // The name is still here, still the sanitized host-rendered one, and still a
+    // control — the shell moves it, it does not drop it.
+    const name = q('[data-testid="app-block-breadcrumb-name"]');
+    expect(name, `at ${PHONE[0]}px the app name must still be rendered by the host`).not.toBeNull();
+    expect((name as HTMLElement).textContent).toContain(APP_NAME);
+
+    expect(
+      q('[data-testid="app-block-menu-trigger"]'),
+      `at ${PHONE[0]}px the ⋮ overflow must still be reachable`
+    ).not.toBeNull();
+
+    // Provenance survives the loss of the platform-nav trigger it used to live in.
+    // This is the spoof-proofing the whole bar exists for, and it is the thing most
+    // likely to be dropped silently by a layout change.
+    const provenance = [...root.querySelectorAll('[aria-label="App"]')];
+    expect(
+      provenance.length,
+      `at ${PHONE[0]}px exactly one element must carry the "App" provenance label`
+    ).toBe(1);
+
+    // The row still does not overflow: three items, one line, 360px.
+    expect(root.scrollWidth, `no horizontal overflow at ${PHONE[0]}px`).toBeLessThanOrEqual(
+      root.clientWidth + 1
+    );
+  });
+
+  test(`INVARIANT GUARD — at ${DESKTOP[0]}x${DESKTOP[1]} the breadcrumb chrome is untouched and there is no chevron`, async () => {
+    // 🔴 NOT REGRESSION COVERAGE — `origin/main` passes every line of this, and that
+    // is the point: it is the "do not change desktop behaviour" constraint written
+    // down. Its killing mutation is dropping the `geometry.compact` term (or the
+    // `isPage &&` in front of it) so the shell renders at every width, which this
+    // catches and the phone test above cannot.
+    const root = await renderShell({ viewport: DESKTOP, expectCompact: false });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    expect(
+      q('[data-testid="app-block-breadcrumb"]'),
+      `at ${DESKTOP[0]}px the breadcrumb trail must still render`
+    ).not.toBeNull();
+    expect(
+      q('[data-testid="app-block-breadcrumb-apps"]')?.getAttribute('href'),
+      `at ${DESKTOP[0]}px the leading crumb must still link to /apps`
+    ).toBe('/apps');
+    expect(
+      q('[data-testid="app-platform-nav-trigger"]'),
+      `at ${DESKTOP[0]}px the platform-nav trigger must still be its own control`
+    ).not.toBeNull();
+    expect(
+      q('[data-testid="app-block-back"]'),
+      `at ${DESKTOP[0]}px there must be NO back chevron — the breadcrumb is the back affordance`
+    ).toBeNull();
+  });
+
+  test(`REGRESSION — at ${PHONE[0]}x${PHONE[1]} the platform nav is inside the ⋮ sheet`, async () => {
+    // 🔴 RED AT `origin/main`, BEHAVIOURALLY. The failing assertion is the presence of
+    // "Installed apps" after opening the ⋮. That label exists ONLY in the platform-nav
+    // section — the ⋮ menu's own item for the same route is worded "Manage apps" — so
+    // at main, where the ⋮ carries app actions only, it is not reachable from this
+    // trigger at any width.
+    //
+    // 🔴 IT IS ASSERTED BY LABEL, NOT BY A TESTID, ON PURPOSE. A testid on the new
+    // sheet would go red at main merely by not existing, which proves nothing. A user-
+    // visible label that main renders behind a DIFFERENT trigger is a claim about
+    // where the nav lives, which is what the operator actually decided.
+    const root = await renderShell({ viewport: PHONE, expectCompact: true });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    await page.getByTestId('app-block-menu-trigger').click();
+    // Happens-before for everything below: the surface's own content box, whichever
+    // rendering it is. Waiting on this (rather than on the item under test) is what
+    // stops the assertions from being satisfied by a retry window.
+    await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
+    const sheet = q('[data-testid="app-block-menu-dropdown"]') as HTMLElement;
+
+    const labels = [...sheet.querySelectorAll('a, button')].map((el) =>
+      (el.textContent ?? '').trim()
+    );
+    for (const label of ['Marketplace', 'Installed apps', 'My apps']) {
+      expect(
+        labels,
+        `at ${PHONE[0]}px "${label}" must be reachable from the ⋮ — the platform nav folds into ` +
+          'it because the mobile bar has no second trigger'
+      ).toContain(label);
+    }
+    // …and the ⋮'s own items are still there beside them, so the fold ADDED rather
+    // than replaced. Without this the test would pass on a ⋮ that had become a
+    // platform-nav menu and lost its app actions.
+    expect(
+      labels,
+      `at ${PHONE[0]}px the ⋮ must still carry its own app actions alongside the folded nav`
+    ).toContain('Manage apps');
+
+    // The sheet is a real bottom-sheet Drawer, not a dropdown wearing a testid.
+    const content = q('.mantine-Drawer-content');
+    expect(
+      content,
+      `at ${PHONE[0]}px the ⋮ must open a Drawer (the site's bottom-sheet idiom), not a dropdown`
+    ).not.toBeNull();
+    expect(
+      (content as HTMLElement).contains(sheet),
+      'the ⋮ contents must be INSIDE the drawer content box — that is the box the global ' +
+        'safe-area rule pays, so a sheet rendered outside it would be unpaid'
+    ).toBe(true);
+  });
+
+  test(`INVARIANT GUARD — at ${DESKTOP[0]}x${DESKTOP[1]} the nav stays in its own menu and the ⋮ does not absorb it`, async () => {
+    // 🔴 NOT REGRESSION COVERAGE — green at `origin/main`. It is the control arm for
+    // the test above: without it, "the nav is in the ⋮" cannot be told apart from "the
+    // nav is in the ⋮ at every width", and a mutant that dropped the `compact &&` in
+    // front of the folded section would pass the phone test and ship a duplicated nav
+    // on desktop.
+    const root = await renderShell({ viewport: DESKTOP, expectCompact: false });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    await page.getByTestId('app-block-menu-trigger').click();
+    // Wait for an item that IS in this menu at both revisions. That is the
+    // happens-before: once "Manage apps" is present the dropdown has rendered its
+    // children, so the absence below is measured against a populated surface rather
+    // than an empty one.
+    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+    const overflow = q('[data-testid="app-block-menu-dropdown"]') as HTMLElement;
+    const overflowLabels = [...overflow.querySelectorAll('a, button')].map((el) =>
+      (el.textContent ?? '').trim()
+    );
+    expect(
+      overflowLabels,
+      `at ${DESKTOP[0]}px the ⋮ must NOT carry the platform nav — it has its own trigger here`
+    ).not.toContain('Marketplace');
+
+    // …and that trigger opens a menu which does.
+    await page.getByTestId('app-platform-nav-trigger').click();
+    await expect.element(page.getByRole('menuitem', { name: 'Marketplace' })).toBeInTheDocument();
+  });
+
+  test(`REGRESSION — at ${PHONE[0]}x${PHONE[1]} the app name opens the store card as a bottom SHEET`, async () => {
+    // 🔴 RED AT `origin/main`, AND THE STRUCTURAL HALF IS WHAT CARRIES THE RED. Main
+    // renders the same card with the same testids at 360px — as a POPOVER. So the
+    // content assertions below pass at main and are NOT the coverage; the assertion
+    // that the card's box is inside `.mantine-Drawer-content` is, and it fails at main
+    // against a `.mantine-Popover-dropdown`.
+    //
+    // The content assertions are here because a structural check alone would be
+    // satisfied by an empty sheet — F2's rollup and store link have to still work
+    // INSIDE the new surface, which is constraint 4.
+    const root = await renderShell({ viewport: PHONE, expectCompact: true, slug: SLUG });
+    expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+    await page.getByTestId('app-block-breadcrumb-name').click();
+    await expect.element(page.getByTestId('app-block-name-popover')).toBeInTheDocument();
+    const card = q('[data-testid="app-block-name-popover"]') as HTMLElement;
+
+    const drawer = q('.mantine-Drawer-content');
+    expect(
+      drawer,
+      `at ${PHONE[0]}px the app-name card must be delivered as a bottom sheet, not a popover`
+    ).not.toBeNull();
+    expect(
+      (drawer as HTMLElement).contains(card),
+      `at ${PHONE[0]}px the app-name card must render INSIDE the drawer content box`
+    ).toBe(true);
+    expect(
+      q('.mantine-Popover-dropdown'),
+      `at ${PHONE[0]}px no popover may be rendered — the sheet replaces it`
+    ).toBeNull();
+
+    // F2 still works in there: the full name, the shared recommend rollup, and the
+    // store link built by `getListingDetailHref`.
+    expect(q('[data-testid="app-block-name-popover-name"]')?.textContent).toBe(APP_NAME);
+    expect(
+      q('[data-testid="app-block-name-popover-recommend"]')?.textContent,
+      'the rollup must come from the SHARED store formatter, so the frame and the store cannot ' +
+        'disagree about one app'
+    ).toContain('90%');
+    const storeLink = q('[data-testid="app-block-name-popover-store-link"]');
+    expect(storeLink, 'the "View in App Store" action must survive inside the sheet').not.toBeNull();
+    expect((storeLink as HTMLElement).getAttribute('href')).toContain(SLUG);
+  });
+
+  test(`PARITY GUARD — at ${PHONE[0]}x${PHONE[1]} activating a sheet row closes the sheet`, async () => {
+    // 🔴 NOT COUNTED AS REGRESSION COVERAGE: it fails at `origin/main` only because
+    // there is no sheet there, which says nothing about behaviour. What it pins is a
+    // PARITY the sheet has to supply for itself — Mantine's `closeOnItemClick` closes
+    // a `Menu` on item activation and a `Drawer` has no equivalent, so without the
+    // explicit close in `ChromeSurfaceItem` a tap would leave a full-height sheet
+    // sitting over the app, and (on the review row) behind a focus-trapping modal.
+    //
+    // Its killing mutation is deleting that `close()` call, which nothing else here
+    // would notice.
+    //
+    // 🔴 THE ROW CLICKED IS AN ACTION, NOT A LINK, AND THAT IS FORCED RATHER THAN
+    // ARBITRARY. `NextLink` renders a REAL anchor; clicking one in browser mode
+    // navigates the test iframe and the run dies with "Cannot connect to the iframe"
+    // — measured, on the first draft of this test with "My apps". An action row
+    // ("Permissions & activity", which needs `appBlockId` threaded) exercises exactly
+    // the same `ChromeSurfaceItem` close path with nothing to navigate to.
+    await renderShell({ viewport: PHONE, expectCompact: true, appBlockId: 'ab_1' });
+
+    await page.getByTestId('app-block-menu-trigger').click();
+    await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
+
+    const sheet = q('[data-testid="app-block-menu-dropdown"]') as HTMLElement;
+    const action = [...sheet.querySelectorAll('a, button')].find(
+      (el) => (el.textContent ?? '').trim() === 'Permissions & activity'
+    ) as HTMLElement | undefined;
+    expect(
+      action,
+      'the "Permissions & activity" row must be present to click — it is threaded via `appBlockId`'
+    ).not.toBeUndefined();
+    (action as HTMLElement).click();
+
+    // Real happens-before for the absence: Mantine unmounts a closed Drawer's content
+    // after its exit transition, so poll the same node until it is gone rather than
+    // asserting immediately (which would pass on a sheet that never closes if the
+    // check ran before any commit) or with a bare polling matcher.
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline && q('[data-testid="app-block-menu-dropdown"]') !== null) {
+      await frame();
+    }
+    expect(
+      q('[data-testid="app-block-menu-dropdown"]'),
+      'activating a row must close the sheet — a Drawer has no `closeOnItemClick`, so the row ' +
+        'has to close it explicitly'
+    ).toBeNull();
+  });
+
+  /**
+   * 🔴 NOT REGRESSION COVERAGE — a SEAM GUARD, and the seam is between two things
+   * neither of which this change wrote. `src/styles/globals.css` already pays the
+   * bottom inset for every Mantine drawer in the app at the LIBRARY seam
+   * (`@layer mantine { .mantine-Drawer-content { padding-bottom:
+   * var(--safe-area-inset-bottom) } }`), so the correct thing for a new sheet to do is
+   * NOTHING — paying it again would double it on a notched phone. That makes "the
+   * sheet respects the inset" a claim about COVERAGE rather than about code this
+   * change contains, and a claim of that shape is exactly the kind that goes stale
+   * invisibly: the sheet stays covered right up until someone gives it a `styles`
+   * override for its content slot.
+   *
+   * So the test asserts the resolved outcome on the real rendered sheet, and it
+   * asserts it in a way that dies if EITHER side moves: the rule is read out of
+   * `globals.css` itself (deleting it there fails the extraction), and the padding is
+   * measured on the live element (overriding it in `ChromeSurface` fails the
+   * measurement). The repo-wide `viewport-fit-cover.test.ts` owns the complementary
+   * half — that nothing outranks that rule anywhere in `src`, in the real cascade.
+   *
+   * It fails at `origin/main` only because no sheet exists there. Not counted.
+   */
+  describe('the sheet respects --safe-area-inset-bottom', () => {
+    /**
+     * The `.mantine-Drawer-content` declaration block, read out of `globals.css`.
+     *
+     * 🔴 PARSED BY THE BROWSER, NOT BY A REGEX, for the reason `test/component-setup.tsx`
+     * gives at length: several successive regex attempts to carve a block out of that
+     * same file each shipped a defect, because comments, strings and nesting make
+     * "where does this block end" a question only the engine can answer.
+     *
+     * 🔴 AND IT THROWS RATHER THAN RETURNING EMPTY. A missing rule would otherwise
+     * inject nothing, the padding would measure `0px`, and the test would fail with a
+     * number — reading as "the sheet lost its inset" when the truth is "the global
+     * payment was deleted". Those are different repairs, so they get different
+     * failures.
+     */
+    function safeAreaRuleText(): string {
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(globalsCss);
+      const found: string[] = [];
+      const walk = (rules: CSSRuleList) => {
+        for (const rule of Array.from(rules)) {
+          if (rule instanceof CSSStyleRule) {
+            if (rule.selectorText.includes('.mantine-Drawer-content')) found.push(rule.cssText);
+          } else if (typeof CSSLayerBlockRule !== 'undefined' && rule instanceof CSSLayerBlockRule) {
+            // `@layer` only orders the cascade — descend. `@media`/`@supports` are
+            // conditional and are deliberately not descended into: a rule that only
+            // applies under a condition is not evidence of an unconditional payment.
+            walk(rule.cssRules);
+          }
+        }
+      };
+      walk(sheet.cssRules);
+      const paying = found.filter((t) => /padding-bottom:\s*var\(--safe-area-inset-bottom\)/.test(t));
+      if (paying.length === 0) {
+        throw new Error(
+          'src/styles/globals.css no longer pays `padding-bottom: var(--safe-area-inset-bottom)` ' +
+            'on `.mantine-Drawer-content`. That rule is what covers EVERY bottom sheet in the app, ' +
+            'including the app-block chrome’s. If it moved, re-point this guard; if it was ' +
+            'deleted, the last row of ~26 bottom drawers now sits under the home indicator.'
+        );
+      }
+      return paying.join('\n');
+    }
+
+    /**
+     * Apply the real rule plus a NON-ZERO inset. `env(safe-area-inset-bottom)` is 0 in
+     * a headless desktop Chromium with no display cutout, so measuring the shipped
+     * value would compare `0px` against `0px` — green with the whole mechanism
+     * removed, the reassuring-zero shape. Overriding the custom property is what makes
+     * the measurement able to fail.
+     *
+     * 🔴 INJECTED UNLAYERED, AND THAT IS A DELIBERATE FIDELITY LIMIT WORTH STATING.
+     * The app imports `@mantine/core/styles.layer.css`; this harness imports the
+     * UNLAYERED `@mantine/core/styles.css`, so re-injecting the rule inside
+     * `@layer mantine` here would lose to Mantine's own unlayered declarations and
+     * measure the wrong thing. This test therefore proves "the rule, applied, reaches
+     * this sheet and nothing in our component overrides it" — NOT "it wins the real
+     * cascade". That second claim is `viewport-fit-cover.test.ts`'s, which reads the
+     * actual layer order out of the real files.
+     */
+    function injectInset(px: number): HTMLStyleElement {
+      const style = document.createElement('style');
+      style.setAttribute('data-source', 'AppBlockChromeMobileShell:safe-area');
+      style.textContent = `:root { --safe-area-inset-bottom: ${px}px; }\n${safeAreaRuleText()}`;
+      document.head.appendChild(style);
+      return style;
+    }
+
+    test(`at ${PHONE[0]}x${PHONE[1]} the ⋮ sheet's content box pays the bottom inset, and TRACKS it`, async () => {
+      const style = injectInset(34);
+      try {
+        await renderShell({ viewport: PHONE, expectCompact: true });
+        await page.getByTestId('app-block-menu-trigger').click();
+        await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
+
+        const content = q('.mantine-Drawer-content');
+        expect(
+          content,
+          'the ⋮ sheet must be a Mantine Drawer — the global inset rule is keyed on that class, ' +
+            'so a hand-rolled sheet would be silently unpaid'
+        ).not.toBeNull();
+
+        expect(
+          getComputedStyle(content as HTMLElement).paddingBottom,
+          `at ${PHONE[0]}px the sheet must pay the full ${34}px inset, so its last row is not ` +
+            'under the home indicator where iOS eats the tap'
+        ).toBe('34px');
+
+        // 🔴 THE CONTROL THAT MAKES THE NUMBER ABOVE MEAN SOMETHING. A component that
+        // hardcoded `paddingBottom: 34` would pass the assertion above and fail here.
+        // Changing the custom property needs no re-render — the cascade re-resolves —
+        // so this measures the SAME element twice with only the inset varied.
+        style.textContent = `:root { --safe-area-inset-bottom: 12px; }\n${safeAreaRuleText()}`;
+        await frame();
+        expect(
+          getComputedStyle(content as HTMLElement).paddingBottom,
+          'the sheet’s bottom padding must TRACK `--safe-area-inset-bottom` rather than ' +
+            'happening to equal it — a fixed value passes the first assertion and fails this one'
+        ).toBe('12px');
+      } finally {
+        style.remove();
+      }
+    });
+  });
+
+  /**
+   * 🔴 CONSTRAINT 1, AND NOT REGRESSION COVERAGE — both cases pass at `origin/main`
+   * and are supposed to. `CHROME_BAR_PX` in `slotReservation.ts` pins the bar's
+   * resting height as the model slot's CLS reservation and is asserted in a GATING
+   * node-tier test, so the mobile shell must not move it. This checks that at a
+   * rendered-pixel level, at both viewports, rather than by reading a constant back.
+   *
+   * 🔴 IT PINS THE MEASURED HEIGHT, NOT `CHROME_BAR_PX`, AND THOSE TWO DISAGREE — a
+   * PRE-EXISTING divergence F1 found and deliberately did not fix. `slotReservation.ts`
+   * derives 35 from `--ai-size-sm = 26px`; the installed `@mantine/core` 7.17.8 ships
+   * `--ai-size-sm: calc(1.375rem * var(--mantine-scale))` = 22px and this repo
+   * overrides neither, so the real height is 22 + 8 + 1 = 31 and the slot
+   * OVER-reserves by 4px. Over-reserving is the safe direction for a CLS reserve (a
+   * small dead gap, never a shift). `CHROME_BAR_PX` is untouched by this change; the
+   * inequality below is what stops the gap silently inverting into an UNDER-reserve.
+   *
+   * Two cases, not one loop: `cleanup()` runs per TEST, so two renders inside one test
+   * would leave two chrome bars in the document and every document-scoped query would
+   * be ambiguous.
+   */
+  test.each([
+    ['phone (mobile shell)', PHONE, true],
+    ['desktop (breadcrumb chrome)', DESKTOP, false],
+  ] as const)(
+    `INVARIANT GUARD — the bar's resting height is ${CHROME_BAR_RENDERED_PX}px at the %s viewport`,
+    async (_label, viewport, expectCompact) => {
+      const root = await renderShell({ viewport, expectCompact });
+      expect(styleSheetLoaded(root), '@mantine/core/styles.css must be loaded').toBe(true);
+
+      // The decision actually flipped between the two cases — otherwise this pair
+      // would be measuring one shell twice and reporting it as two viewports.
+      expect(
+        root.getAttribute('data-chrome-compact'),
+        `the ${viewport[0]}px case must actually resolve compact=${expectCompact}`
+      ).toBe(String(expectCompact));
+
+      expect(
+        Math.round(rect(root).height),
+        `the chrome bar's resting height must not move at ${viewport[0]}px — it is the model ` +
+          'slot’s CLS reservation (`CHROME_BAR_PX`)'
+      ).toBe(CHROME_BAR_RENDERED_PX);
+      expect(
+        CHROME_BAR_PX,
+        'the reservation must stay an OVER-reservation, never an under-reservation'
+      ).toBeGreaterThanOrEqual(CHROME_BAR_RENDERED_PX);
+
+      // The bar's own controls are still at their resting size at both widths — the
+      // shell must not have bought its layout by shrinking the tap targets.
+      const trailing = q('[data-testid="app-block-menu-trigger"]') as HTMLElement;
+      expect(
+        Math.round(rect(trailing).width),
+        `the ⋮ trigger must render at its resting ActionIcon size="sm" at ${viewport[0]}px`
+      ).toBe(RESTING_ICON_PX);
+    }
+  );
+});

--- a/src/components/AppBlocks/AppBlockChromePlatformNav.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromePlatformNav.browser.test.tsx
@@ -54,8 +54,21 @@ import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
 // eslint-disable-next-line import/first
 import { renderWithProviders } from '../../../test/component-setup';
 
-beforeEach(() => {
+/**
+ * 🔴 A DESKTOP VIEWPORT, PINNED — every render below is `slotId="app.page"`, and F3
+ * gives that surface a different chrome below the `sm` breakpoint (768): no separate
+ * platform-nav trigger at all, because the nav folds into the ⋮ bottom sheet.
+ *
+ * This file pinned no viewport before F3 and therefore inherited Vitest's default of
+ * **414×896**, which is below `sm` — so without this line every test here would be
+ * asserting the desktop dropdown against the mobile shell. The claims are about the
+ * dropdown, so the viewport that produces a dropdown is now named. The folded-nav
+ * behaviour has its own coverage in `AppBlockChromeMobileShell.browser.test.tsx`.
+ */
+const DESKTOP: [number, number] = [1440, 900];
+beforeEach(async () => {
   holder.user = null;
+  await page.viewport(...DESKTOP);
 });
 
 async function openPlatformNav() {

--- a/src/components/AppBlocks/AppBlockChromeRecentsClamp.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeRecentsClamp.browser.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * THE "Recently run" ROW IS ONE LINE ON THE DESKTOP DROPDOWN, MEASURED.
+ *
+ * 🔴 WHY A WHOLE FILE FOR ONE CLAIM. It is the claim F3's primitive is FOR. Merging
+ * the chrome's two dropdowns and its bottom sheets onto one `ChromeSurface` is only
+ * worth doing if the desktop rendering comes out unchanged, and this is the one place
+ * it silently did not: `ChromeSurfaceItem` wraps children in
+ * `<Text size="sm" lineClamp={1}>` in its SHEET branch and rendered them raw in its
+ * MENU branch, so the publisher-controlled app name lost the clamp the pre-primitive
+ * chrome gave it. Nothing caught it — the full gating tier and all seven touched
+ * browser suites were green with the defect present — because every existing test
+ * either uses a short fixture name or asserts attributes rather than geometry.
+ *
+ * So the guard is a MEASUREMENT, not a source-text pin. `__tests__/chromeItemClamp.ts`
+ * carries the structural half in the gating node tier; this is the half that would
+ * still fail if `clamp` were threaded correctly and rendered something that does not
+ * actually clamp.
+ *
+ * 🔴 THE ASSERTION IS RELATIONAL, AND NOT A PIXEL LITERAL. "The long name renders on
+ * one line" is really "this row is the same height as a row that cannot wrap", so the
+ * reference is a sibling item in the SAME dropdown ("Marketplace"). A `< 40px` bound
+ * would be a fact about this Mantine version's line-height; the relationship is a fact
+ * about the layout.
+ *
+ * 🔴 IT LOADS `@mantine/core/styles.css`. The shared scaffold omits it on purpose, and
+ * without it `lineClamp` (which is `-webkit-line-clamp` + `display: -webkit-box`) is
+ * not applied at all, so both arms measure the same wrapped height and the test passes
+ * against the defect. Vitest browser mode gives each file its own iframe, so this does
+ * not leak into sibling suites.
+ */
+import '@mantine/core/styles.css';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// eslint-disable-next-line import/first
+import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import {
+  clearRecentlyOpenedApps,
+  recordRecentlyOpenedApp,
+} from '~/components/Apps/recentlyOpenedAppsStore';
+// eslint-disable-next-line import/first
+import { renderWithProviders } from '../../../test/component-setup';
+
+/** Desktop — the ONLY path with the defect. The sheet clamps every row already. */
+const DESKTOP: [number, number] = [1440, 900];
+
+/**
+ * 63 characters — one under `APP_CHROME_NAME_MAX` (64), so the SANITIZER is not the
+ * thing doing the trimming and the clamp is the only mechanism under test. At Mantine
+ * `size="sm"` this is comfortably wider than the dropdown, so it wraps to two lines
+ * unless clamped. A short name would make both arms identical and the test vacuous.
+ */
+const LONG_NAME = 'Background Remover Pro Max Ultra Deluxe Special Edition Reissue';
+
+const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+const rect = (el: Element) => el.getBoundingClientRect();
+
+beforeEach(() => {
+  clearRecentlyOpenedApps();
+});
+
+describe('the desktop "Recently run" row does not wrap', () => {
+  test(`at ${DESKTOP[0]}x${DESKTOP[1]} a ${LONG_NAME.length}-char app name renders on ONE line`, async () => {
+    // 🔴 RED AT THIS PR'S OWN TIP (9bd9addf16), GREEN AT `origin/main` AND AT HEAD.
+    // That three-way matrix is the point and it is stronger than a normal red/green
+    // pair: `origin/main` passes because the pre-primitive chrome carried the clamp,
+    // so this test is pinning RESTORED PARITY rather than new behaviour. The failing
+    // assertion at the PR tip is the height comparison below — measured 56.69px
+    // against the reference row's 33.61px.
+    await page.viewport(...DESKTOP);
+    // `null` owner: `useCurrentUser` is mocked to null above, so this is the bucket
+    // the chrome will read back (the store is keyed per account, #4048).
+    recordRecentlyOpenedApp({ id: 'ab-other', blockId: 'other-app', name: LONG_NAME }, null);
+
+    renderWithProviders(
+      <AppBlockChrome
+        blockInstanceId="inst-clamp"
+        appName="Host App"
+        appBlockId="ab-current"
+        slotId="app.page"
+        canOpenPage
+      />
+    );
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+
+    await page.getByTestId('app-platform-nav-trigger').click();
+    await expect.element(page.getByRole('menuitem', { name: 'Marketplace' })).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-recently-run-item')).toBeInTheDocument();
+    await frame();
+    await frame();
+
+    const recents = page.getByTestId('app-recently-run-item').element() as HTMLElement;
+    // Guard-the-guard: without the stylesheet `lineClamp` is inert and BOTH arms
+    // measure the same wrapped height, so this test would pass against the defect.
+    expect(
+      getComputedStyle(recents).display === 'flex' ||
+        getComputedStyle(recents).display === 'block',
+      '@mantine/core/styles.css must be loaded — a Menu.Item with no stylesheet is not laid out'
+    ).toBe(true);
+
+    // The reference: a sibling row in the SAME dropdown whose label cannot wrap.
+    const reference = page.getByRole('menuitem', { name: 'Marketplace' }).element() as HTMLElement;
+
+    // 🔴 `+2` IS AN ICON ALLOWANCE, NOT A FUDGE, AND IT DOES NOT BLUNT THE GUARD. The
+    // recents row's leftSection is a 16px `Avatar` where the reference row's is a 14px
+    // icon, so the two one-line rows measure 34 and 35 — the first draft asserted
+    // exact equality and failed 34-vs-35 against CORRECT code. The defect this test
+    // exists for is a SECOND LINE, worth ~23px; a 2px allowance is an order of
+    // magnitude below that, so the mutant still dies.
+    const referenceHeight = Math.round(rect(reference).height);
+    expect(
+      Math.round(rect(recents).height),
+      `at ${DESKTOP[0]}px the "Recently run" row must be within 2px of a one-line sibling ` +
+        `(${referenceHeight}px) — an unclamped publisher name wraps to two lines and grows the ` +
+        'dropdown by ~23px per row, ×5 rows'
+    ).toBeLessThanOrEqual(referenceHeight + 2);
+
+    // 🔴 THE FIXTURE-IS-LONG-ENOUGH CONTROL, MEASURED ON THE **BLOCK** AXIS, AND
+    // DELIBERATELY AFTER THE ASSERTION ABOVE. Two things were wrong with the first
+    // draft of it. It compared `scrollWidth > clientWidth` and failed 222 vs 222
+    // against CORRECT code: `lineClamp` is `display: -webkit-box` +
+    // `-webkit-line-clamp`, which clips VERTICALLY — the text still wraps inside its
+    // box and never overflows horizontally, so that probe can never fire. And it ran
+    // FIRST, so when the clamp was removed as a mutation this file went red on "the
+    // clamped row must render a Mantine Text wrapper" — a precondition failing for
+    // want of an element, which says nothing about layout. Ordered here, the mutant
+    // dies on the height comparison, which is the behavioural claim.
+    //
+    // What it guards is the other direction: that a future shortening of `LONG_NAME`
+    // cannot make the height comparison vacuously true. `scrollHeight > clientHeight`
+    // is exactly "the content is taller than the one line it is being held to".
+    const label = recents.querySelector('.mantine-Text-root') as HTMLElement | null;
+    expect(label, 'the clamped row must render a Mantine Text wrapper').not.toBeNull();
+    expect(
+      (label as HTMLElement).scrollHeight,
+      `the ${LONG_NAME.length}-char fixture must be TALLER than the one line it is clamped to, ` +
+        'or the height comparison above would hold for a name that fits on one line anyway'
+    ).toBeGreaterThan((label as HTMLElement).clientHeight);
+
+    // And the dropdown as a whole did not grow. Stated separately because the row
+    // equality above could in principle hold while some other box absorbed the height.
+    const dropdown = document.querySelector('.mantine-Menu-dropdown') as HTMLElement | null;
+    expect(dropdown, 'the platform-nav dropdown must be in the document once opened').not.toBeNull();
+    expect(
+      Math.round(rect(dropdown as HTMLElement).height),
+      'the dropdown must not be taller than the sum of one-line rows plus its two labels'
+    ).toBeLessThan(215);
+  });
+});

--- a/src/components/AppBlocks/AppBlockChromeRecentsClamp.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeRecentsClamp.browser.test.tsx
@@ -11,10 +11,10 @@
  * browser suites were green with the defect present — because every existing test
  * either uses a short fixture name or asserts attributes rather than geometry.
  *
- * So the guard is a MEASUREMENT, not a source-text pin. `__tests__/chromeItemClamp.ts`
- * carries the structural half in the gating node tier; this is the half that would
- * still fail if `clamp` were threaded correctly and rendered something that does not
- * actually clamp.
+ * So the guard is a MEASUREMENT, not a source-text pin.
+ * `__tests__/chromeItemClamp.test.ts` carries the structural half in the gating node
+ * tier; this is the half that would still fail if `clamp` were threaded correctly and
+ * rendered something that does not actually clamp.
  *
  * 🔴 THE ASSERTION IS RELATIONAL, AND NOT A PIXEL LITERAL. "The long name renders on
  * one line" is really "this row is the same height as a row that cannot wrap", so the
@@ -68,8 +68,10 @@ describe('the desktop "Recently run" row does not wrap', () => {
     // That three-way matrix is the point and it is stronger than a normal red/green
     // pair: `origin/main` passes because the pre-primitive chrome carried the clamp,
     // so this test is pinning RESTORED PARITY rather than new behaviour. The failing
-    // assertion at the PR tip is the height comparison below — measured 56.69px
-    // against the reference row's 33.61px.
+    // assertion at the PR tip is the height comparison below — measured HERE as 78px
+    // against the reference row's 35px, i.e. three lines. (The audit reported 56.7 vs
+    // 33.6 for the same defect; the gap is the fixture, not a disagreement — this file
+    // uses a 63-char name where the audit used a shorter one. Both are the same bug.)
     await page.viewport(...DESKTOP);
     // `null` owner: `useCurrentUser` is mocked to null above, so this is the bucket
     // the chrome will read back (the store is keyed per account, #4048).
@@ -96,8 +98,7 @@ describe('the desktop "Recently run" row does not wrap', () => {
     // Guard-the-guard: without the stylesheet `lineClamp` is inert and BOTH arms
     // measure the same wrapped height, so this test would pass against the defect.
     expect(
-      getComputedStyle(recents).display === 'flex' ||
-        getComputedStyle(recents).display === 'block',
+      getComputedStyle(recents).display === 'flex' || getComputedStyle(recents).display === 'block',
       '@mantine/core/styles.css must be loaded — a Menu.Item with no stylesheet is not laid out'
     ).toBe(true);
 
@@ -143,7 +144,10 @@ describe('the desktop "Recently run" row does not wrap', () => {
     // And the dropdown as a whole did not grow. Stated separately because the row
     // equality above could in principle hold while some other box absorbed the height.
     const dropdown = document.querySelector('.mantine-Menu-dropdown') as HTMLElement | null;
-    expect(dropdown, 'the platform-nav dropdown must be in the document once opened').not.toBeNull();
+    expect(
+      dropdown,
+      'the platform-nav dropdown must be in the document once opened'
+    ).not.toBeNull();
     expect(
       Math.round(rect(dropdown as HTMLElement).height),
       'the dropdown must not be taller than the sum of one-line rows plus its two labels'

--- a/src/components/AppBlocks/AppNameCrumb.browser.test.tsx
+++ b/src/components/AppBlocks/AppNameCrumb.browser.test.tsx
@@ -373,7 +373,10 @@ describe("F1's responsive geometry is threaded through the control, not dropped"
     // did" — so the reference node is what the assertion should be against.
     renderWithProviders(
       <>
-        <AppNameCrumb name={APP_NAME} slug={SLUG} maxWidth={240} />
+        {/* `compact={false}` — this pair is about the DESKTOP crumb's width cap. The
+            mobile shell's own geometry is covered in
+            `AppBlockChromeMobileShell.browser.test.tsx`. */}
+        <AppNameCrumb name={APP_NAME} slug={SLUG} maxWidth={240} compact={false} />
         <Text data-testid="ref-cap-240" truncate maw={240} />
         <Text data-testid="ref-cap-560" truncate maw={560} />
       </>
@@ -395,7 +398,9 @@ describe("F1's responsive geometry is threaded through the control, not dropped"
   });
 
   test('an UNCAPPED tier (xl) sets no max-width — the wide bar is not re-capped', async () => {
-    renderWithProviders(<AppNameCrumb name={APP_NAME} slug={SLUG} maxWidth={undefined} />);
+    renderWithProviders(
+      <AppNameCrumb name={APP_NAME} slug={SLUG} maxWidth={undefined} compact={false} />
+    );
     const inner = (await trigger()).querySelector('[data-truncate]') as HTMLElement | null;
     expect(inner).not.toBeNull();
     expect((inner as HTMLElement).style.maxWidth).toBe('');

--- a/src/components/AppBlocks/AppNameCrumb.tsx
+++ b/src/components/AppBlocks/AppNameCrumb.tsx
@@ -1,19 +1,11 @@
-import {
-  Button,
-  Divider,
-  Group,
-  Loader,
-  Popover,
-  Stack,
-  Text,
-  UnstyledButton,
-} from '@mantine/core';
+import { Button, Divider, Group, Loader, Stack, Text, UnstyledButton } from '@mantine/core';
 import { IconBuildingStore } from '@tabler/icons-react';
 import { getListingDetailHref, getRecommendLabel } from '~/components/Apps/appListingCardView';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { ChromeReviewPopoverAction } from './ChromeReviewEntry';
+import { ChromeSurface } from './ChromeSurface';
 import { useChromeListingDetail } from './useChromeListingDetail';
 import { useIframeAwareMenu } from './useIframeAwareMenu';
 
@@ -62,19 +54,29 @@ import { useIframeAwareMenu } from './useIframeAwareMenu';
  * here as well as in the chrome, so a fourth floating surface cannot be added
  * without wiring it.
  *
- * 🔴 A CONTROLLED `Popover.Target` GETS NO `onClick` FROM MANTINE — the toggle
- * below is REQUIRED, not belt-and-braces. `PopoverTarget` clones its child with
+ * 🔴 A CONTROLLED `Popover.Target` GETS NO `onClick` FROM MANTINE — the toggle is
+ * REQUIRED, not belt-and-braces. `PopoverTarget` clones its child with
  * `...(!ctx.controlled ? { onClick: ctx.onToggle } : null)`
  * (@mantine/core 7.17.8, `Popover/PopoverTarget/PopoverTarget.mjs`), so passing
  * `opened` — which is what putting it on the hook does — silently removes the
- * click handler Mantine would otherwise attach. Dropping our own `onClick` leaves a
- * button that looks right, carries every ARIA attribute, and opens nothing.
+ * click handler Mantine would otherwise attach. Dropping it leaves a button that
+ * looks right, carries every ARIA attribute, and opens nothing. F3 moved that
+ * handler into `ChromeSurface` (which clones the target in `popover` AND `sheet`
+ * mode for the same reason); the hazard did not go away, it acquired one owner.
+ *
+ * 🔴 F3 — BELOW `sm` THE POPOVER BECOMES A BOTTOM SHEET, AND NOTHING ELSE ABOUT
+ * THIS COMPONENT CHANGES. The gate, the lazy card, the rollup, "View in App Store"
+ * and the review action are all rendered into whichever surface `ChromeSurface`
+ * resolved — they do not know which one they are in, which is the property that
+ * makes F2 and F4 keep working on the mobile shell without being re-implemented
+ * for it.
  */
 export function AppNameCrumb({
   name,
   slug,
   maxWidth,
   onOpenReview,
+  compact,
 }: {
   /**
    * The app's display name, ALREADY SANITIZED by the caller
@@ -106,6 +108,13 @@ export function AppNameCrumb({
    * popover (the crumb keeps doing everything else it did).
    */
   onOpenReview?: (appListingId: string) => void;
+  /**
+   * F3 — render the store card as a BOTTOM SHEET rather than a popover. Resolved by
+   * the chrome from `chromeGeometry.compact` (the bar's own measured inline size), and
+   * passed down rather than re-derived here for the reason the chrome's own comment
+   * gives: two mechanisms answering "is this narrow?" is how they come to disagree.
+   */
+  compact: boolean;
 }) {
   const features = useOptionalFeatureFlags();
   const canSeeStore = hasAppsStoreAccess(features);
@@ -138,28 +147,30 @@ export function AppNameCrumb({
   }
 
   return (
-    <Popover
+    <ChromeSurface
+      compact={compact}
+      kind="popover"
+      control={popover}
+      // Host-authored, and deliberately NOT the app's name: the sheet's BODY already
+      // renders the full publisher-controlled name as its heading (that is the whole
+      // reason to open it), so putting it in the header too would say it twice and put
+      // an untrusted string in a second place.
+      title="App details"
       width={260}
       position="bottom-start"
-      shadow="md"
-      withArrow
-      opened={popover.opened}
-      onChange={popover.onChange}
-    >
-      <Popover.Target>
-        {/* `UnstyledButton` renders a real `<button type="button">` with Mantine's
-            `focusable` styles applied, so the control is keyboard-operable (Enter /
-            Space fire `click` natively) and carries a VISIBLE focus ring via the
-            `mantine-focus-auto` class rather than a suppressed outline. A `div` with
-            an `onClick` — the shape this deliberately is not — would have neither.
-            `Popover.Target` adds `aria-haspopup="dialog"`, `aria-expanded` and
-            `aria-controls` on top (`withRoles` is on by default). */}
+      dropdownTestId="app-block-name-popover"
+      target={
+        /* `UnstyledButton` renders a real `<button type="button">` with Mantine's
+           `focusable` styles applied, so the control is keyboard-operable (Enter /
+           Space fire `click` natively) and carries a VISIBLE focus ring via the
+           `mantine-focus-auto` class rather than a suppressed outline. A `div` with
+           an `onClick` — the shape this deliberately is not — would have neither.
+           `Popover.Target` adds `aria-haspopup="dialog"`, `aria-expanded` and
+           `aria-controls` on top (`withRoles` is on by default); in sheet mode
+           `ChromeSurface` sets the first two itself, since there is no Mantine
+           target wrapper there to do it. */
         <UnstyledButton
           data-testid="app-block-breadcrumb-name"
-          // See the 🔴 note in the component header: a CONTROLLED Popover.Target is
-          // cloned WITHOUT Mantine's own onClick, so this is the only thing that
-          // opens the popover.
-          onClick={() => popover.onChange(!popover.opened)}
           style={{
             // The crumb is a flex item in a `nowrap` row that must stay one line
             // (`CHROME_BAR_PX`); `minWidth: 0` lets the truncating child actually
@@ -172,32 +183,32 @@ export function AppNameCrumb({
         >
           {crumbText}
         </UnstyledButton>
-      </Popover.Target>
-      <Popover.Dropdown data-testid="app-block-name-popover">
-        {/* Mantine mounts a dropdown's children only while it is OPEN (`keepMounted`
-            is off by default), so putting the query inside this child is what makes
-            the fetch lazy — STRUCTURALLY, not via an `enabled` flag that has to be
-            kept correct. See the card's own header for why that distinction earned
-            its own component. */}
-        <AppNameCrumbCard
-          name={name}
-          slug={slug}
-          // 🔴 THE POPOVER CLOSES BEFORE THE MODAL OPENS, AND THE CLOSE IS EXPLICIT.
-          // A `Popover` has no `closeOnItemClick` equivalent, so nothing closes it
-          // for us; leaving it open would park a dropdown behind a focus-trapping
-          // modal with `aria-expanded="true"` still on the crumb. Order matters only
-          // in the sense that both happen in one handler — React batches them into a
-          // single commit.
-          onOpenReview={
-            onOpenReview &&
-            ((appListingId: string) => {
-              popover.onChange(false);
-              onOpenReview(appListingId);
-            })
-          }
-        />
-      </Popover.Dropdown>
-    </Popover>
+      }
+    >
+      {/* Mantine mounts a floating surface's children only while it is OPEN
+          (`keepMounted` is off by default on BOTH `Popover` and `Drawer`), so putting
+          the query inside this child is what makes the fetch lazy — STRUCTURALLY, not
+          via an `enabled` flag that has to be kept correct. That property survives the
+          F3 swap precisely because both renderings share the default. See the card's
+          own header for why the distinction earned its own component. */}
+      <AppNameCrumbCard
+        name={name}
+        slug={slug}
+        // 🔴 THE SURFACE CLOSES BEFORE THE MODAL OPENS, AND THE CLOSE IS EXPLICIT.
+        // Neither a `Popover` nor a `Drawer` has a `closeOnItemClick` equivalent, so
+        // nothing closes it for us; leaving it open would park a dropdown — or, on a
+        // phone, a full bottom sheet — behind a focus-trapping modal with
+        // `aria-expanded="true"` still on the crumb. Order matters only in the sense
+        // that both happen in one handler; React batches them into a single commit.
+        onOpenReview={
+          onOpenReview &&
+          ((appListingId: string) => {
+            popover.onChange(false);
+            onOpenReview(appListingId);
+          })
+        }
+      />
+    </ChromeSurface>
   );
 }
 

--- a/src/components/AppBlocks/ChromeReviewEntry.browser.test.tsx
+++ b/src/components/AppBlocks/ChromeReviewEntry.browser.test.tsx
@@ -491,3 +491,60 @@ describe('the review modal is full-screen on a phone', () => {
     expect(content.getAttribute('data-full-screen')).toBeNull();
   });
 });
+
+/**
+ * F3 — IS THE BOTTOM SHEET AS LAZY AS THE DROPDOWN?
+ *
+ * 🔴 THE QUESTION IS NOT ANSWERABLE FROM MANTINE'S DEFAULT, WHICH IS WHY THIS IS A
+ * TEST AND NOT A COMMENT. F4's laziness is STRUCTURAL: the listing query lives inside
+ * the ⋮ surface's children, and Mantine unmounts a closed `Menu.Dropdown`'s children,
+ * so a chrome nobody has opened issues no `getAppDetail`. F3 swaps that surface for a
+ * `Drawer` below the `sm` breakpoint. `Drawer` and `Menu` do share a `keepMounted`
+ * default of `false` — but "two components document the same default" is an argument
+ * about the library, not a measurement of this chrome, and the whole point of a
+ * structural gate is that it must be re-checked when the structure changes. If the
+ * sheet kept its children mounted, every mobile chrome render would fire a listing
+ * request for an affordance nobody asked for.
+ *
+ * 🔴 THE ABSENCE IS REPORTED AS A PAIR, NEVER ALONE. A `0` while closed is
+ * indistinguishable from a counter wired to nothing, so the same test opens the sheet
+ * and watches the number move to `1`. The "after" is what licenses the "before".
+ */
+describe('the mobile ⋮ SHEET is as lazy as the desktop dropdown', () => {
+  const PHONE: [number, number] = [375, 720];
+
+  test(`at ${PHONE[0]}px a CLOSED sheet issues no listing request, and opening it issues exactly one`, async () => {
+    await page.viewport(...PHONE);
+    renderChrome();
+
+    // Happens-before for the absence: the chrome has measured itself and COMMITTED
+    // the sheet decision. Asserting the count before this would be asserting it at a
+    // moment when the ⋮ surface has not been resolved at all, which is a green every
+    // implementation earns.
+    // `render` returns before React has committed, so a synchronous `.element()`
+    // throws against an EMPTY body — the trap this file's own header records.
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    const root = page.getByTestId('app-block-chrome').element() as HTMLElement;
+    await vi.waitFor(() => expect(root.getAttribute('data-chrome-compact')).toBe('true'));
+    // Two frames past the commit, so a mount-time effect would have run.
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    expect(
+      mocks.detailFetches,
+      'a CLOSED bottom sheet must not fetch the listing — the sheet is the mobile rendering of ' +
+        'the ⋮ surface, and F4’s laziness is structural (the query lives inside the surface’s ' +
+        'children, which Mantine unmounts while it is closed). A non-zero here means every ' +
+        'mobile chrome render issues a request for an affordance nobody opened.'
+    ).toBe(0);
+
+    // …and the counter is live, which is what makes the zero above mean something.
+    await openOverflow();
+    await expect.element(reviewItem()).toBeInTheDocument();
+    expect(
+      mocks.detailFetches,
+      'opening the sheet must fetch exactly once — a zero here would mean the assertion above ' +
+        'was measuring a probe wired to nothing'
+    ).toBe(1);
+  });
+});

--- a/src/components/AppBlocks/ChromeReviewEntry.browser.test.tsx
+++ b/src/components/AppBlocks/ChromeReviewEntry.browser.test.tsx
@@ -214,9 +214,20 @@ async function awaitListingResolved() {
 }
 
 /** Open the ⋮ overflow menu and wait for a permanent item, so the dropdown mounted. */
+/**
+ * Open the ⋮ overflow and wait for its contents.
+ *
+ * 🔴 WAITS ON THE SURFACE'S CONTENT BOX, NOT ON A `menuitem` ROLE — because F3 gave
+ * this control two renderings and only one of them has that role. Above the `sm`
+ * breakpoint the ⋮ is a `Menu` whose items are `menuitem`s; below it, it is a bottom
+ * sheet whose rows are buttons. `app-block-menu-dropdown` is the testid
+ * `ChromeSurface` puts on whichever content box it rendered, so this helper reads the
+ * same thing at both widths — which is what lets the 375px full-screen-modal test
+ * below exercise F4 THROUGH the sheet rather than needing a parallel helper.
+ */
 async function openOverflow() {
   await page.getByTestId('app-block-menu-trigger').click();
-  await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+  await expect.element(page.getByTestId('app-block-menu-dropdown')).toBeInTheDocument();
 }
 
 /** Open the app-name crumb popover and wait for its body. */

--- a/src/components/AppBlocks/ChromeReviewEntry.tsx
+++ b/src/components/AppBlocks/ChromeReviewEntry.tsx
@@ -1,4 +1,4 @@
-import { Button, Menu } from '@mantine/core';
+import { Button } from '@mantine/core';
 import { IconThumbUp } from '@tabler/icons-react';
 
 import { useCanReviewListing } from '~/components/Apps/ReviewListingButton';
@@ -6,6 +6,7 @@ import { useOptionalFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 import { hasAppsStoreAccess } from '~/shared/utils/app-blocks-access';
 import { trpc } from '~/utils/trpc';
+import { ChromeSurfaceItem } from './ChromeSurface';
 import { useChromeListingDetail } from './useChromeListingDetail';
 
 /**
@@ -40,6 +41,15 @@ import { useChromeListingDetail } from './useChromeListingDetail';
  * `Menu/MenuItem/MenuItem.mjs` and pinned behaviourally in
  * `ChromeReviewEntry.browser.test.tsx`); the popover action has no such default and
  * closes itself explicitly.
+ *
+ * 🔴 F3 — THE ⋮ ITEM IS A `ChromeSurfaceItem`, NOT A `Menu.Item`, AND THAT IS WHAT
+ * MAKES IT WORK ON THE MOBILE SHELL. Below `sm` the ⋮ overflow is a bottom sheet, and
+ * a `Menu.Item` calls `useMenuContext()` — which THROWS outside a `<Menu>`. So this
+ * item could not simply be re-parented; the primitive renders a `Menu.Item` in a
+ * dropdown and a sheet row otherwise, and supplies the close on the sheet side that
+ * Mantine supplies on the menu side. Nothing about the GATES moved: the same
+ * `hasAppsStoreAccess` + `useCanReviewListing` chain decides whether this renders at
+ * all, in both surfaces.
  */
 
 /**
@@ -125,13 +135,13 @@ function ChromeReviewMenuItemLabelled({
 }) {
   const label = useChromeReviewLabel(appListingId);
   return (
-    <Menu.Item
+    <ChromeSurfaceItem
       leftSection={<IconThumbUp size={14} stroke={1.5} />}
       onClick={() => onOpenReview(appListingId)}
       data-testid="app-block-review-menu-item"
     >
       {label}
-    </Menu.Item>
+    </ChromeSurfaceItem>
   );
 }
 

--- a/src/components/AppBlocks/ChromeSurface.tsx
+++ b/src/components/AppBlocks/ChromeSurface.tsx
@@ -1,0 +1,343 @@
+import { Drawer, Group, Menu, Popover, Stack, Text, UnstyledButton } from '@mantine/core';
+import type { ReactElement, ReactNode } from 'react';
+import { cloneElement, createContext, useContext, useMemo } from 'react';
+
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+
+/**
+ * F3 — THE ONE ADAPTIVE FLOATING SURFACE THE APP-BLOCK CHROME USES.
+ *
+ * The chrome opens three things off one 31px bar: the platform-nav menu behind the
+ * app icon, the ⋮ overflow menu, and the app-name card. On a desktop-width bar those
+ * are a `Menu`, a `Menu` and a `Popover`; below the `sm` breakpoint all three become
+ * the same thing — a `Drawer position="bottom"`, the site's bottom-sheet idiom.
+ *
+ * 🔴 WHY ONE PRIMITIVE RATHER THAN THREE `mobile ? <Drawer> : <Menu>` BRANCHES. The
+ * repo already has ~20 hand-rolled bottom sheets and no shared component, and the two
+ * best of them (`AdaptiveFiltersDropdown`, `SelectMenuV2`) disagree with each other
+ * about `zIndex`, about which slot gets the padding, and about whether the sheet sizes
+ * to its content. Writing a third, fourth and fifth copy inside one 35-line bar is how
+ * the desktop/mobile predicate ends up spelled three ways and wrong in two of them —
+ * the exact shape `useIframeAwareMenu` (F0) was extracted to stop, one layer up. Here
+ * the branch is written ONCE and every chrome surface inherits it.
+ *
+ * 🔴 IT OWNS THE ITEMS TOO, AND THAT IS THE LOAD-BEARING HALF. A `Menu.Item` calls
+ * `useMenuContext()`, which THROWS outside a `<Menu>` — so the platform-nav items
+ * cannot simply be re-parented into a Drawer, and neither can F4's review entry point,
+ * which is a `Menu.Item`-rendering COMPONENT with its own hooks and gates that the
+ * chrome does not get to restructure. `ChromeSurfaceItem` renders a `Menu.Item` in
+ * menu mode and a full-width sheet row otherwise, so one call site serves both and
+ * `ChromeReviewMenuItem` keeps working inside the sheet unchanged.
+ *
+ * 🔴 THE OPEN STATE IS STILL `useIframeAwareMenu`, INCLUDING FOR THE DRAWER — and the
+ * reason is NOT that a Drawer needs it. It does not: a Drawer draws a scrim over the
+ * whole viewport, so a click aimed at the app iframe lands on the scrim in the PARENT
+ * document and Mantine's own `onClose` fires. The window-`blur` close is inert there.
+ * It is shared anyway because this component is ONE component with a mode switch: the
+ * `menu` and `popover` modes are the surfaces that genuinely need the blur close, and
+ * giving the sheet its own `useState` would mean the desktop path's control state came
+ * from a different place depending on a viewport measurement — a difference with no
+ * behavioural justification and one more thing for a future control to get wrong. The
+ * ledger in `__tests__/iframeAwareMenu.test.ts` pins it: every floating surface in this
+ * file is controlled, and every chrome call site holds exactly one hook per surface.
+ *
+ * 🔴 THE BOTTOM SAFE-AREA INSET IS NOT PAID HERE, DELIBERATELY. `src/styles/globals.css`
+ * pays it at the LIBRARY SEAM — `@layer mantine { .mantine-Drawer-content { padding-bottom:
+ * var(--safe-area-inset-bottom) } }` — so every Drawer in the app is covered on the day
+ * it is written rather than 41 call sites being edited one at a time. Paying it a second
+ * time here would double it on a notched phone. What this component must do instead is
+ * stay COVERED by that rule: it must not override the `content` slot's padding. The
+ * repo-wide sweep in `src/components/Meta/__tests__/viewport-fit-cover.test.ts` fails if
+ * it ever does, and `AppBlockChromeMobileShell.browser.test.tsx` measures the resolved
+ * `padding-bottom` on the real rendered sheet against a non-zero injected inset.
+ */
+
+type ChromeSurfaceMode = 'menu' | 'popover' | 'sheet';
+
+/**
+ * The control shape `useIframeAwareMenu()` returns. Declared structurally rather than
+ * imported as a `ReturnType<>` so a test can hand in a plain object.
+ */
+export interface ChromeSurfaceControl {
+  opened: boolean;
+  onChange: (opened: boolean) => void;
+}
+
+interface ChromeSurfaceContextValue {
+  mode: ChromeSurfaceMode;
+  /** Close the surface. A `Menu` closes itself on item click; a Drawer does not. */
+  close: () => void;
+}
+
+/**
+ * Defaults to `menu` so a `ChromeSurfaceItem` rendered outside any surface behaves
+ * exactly as the `Menu.Item` it replaced. That is the conservative default: the
+ * failure mode of guessing `menu` wrongly is a Mantine context error at the call
+ * site, which is loud, whereas guessing `sheet` wrongly renders a plausible-looking
+ * row inside a dropdown and nobody notices.
+ */
+const ChromeSurfaceContext = createContext<ChromeSurfaceContextValue>({
+  mode: 'menu',
+  close: () => undefined,
+});
+
+/** Exported for tests and for a future item that needs to branch on the rendering. */
+export function useChromeSurfaceMode(): ChromeSurfaceMode {
+  return useContext(ChromeSurfaceContext).mode;
+}
+
+export function ChromeSurface({
+  compact,
+  kind,
+  control,
+  target,
+  title,
+  width,
+  position,
+  dropdownTestId,
+  children,
+}: {
+  /**
+   * Render the mobile shell (a bottom sheet) rather than the desktop floating surface.
+   * Resolved by the CALLER from `chromeGeometry`'s `compact`, which is measured off the
+   * bar's own inline size — never off the viewport, and never off the page's `main`
+   * container query. See `chromeGeometry.ts` for why that distinction is load-bearing
+   * on a bar that renders both in a 320px model sidebar and as a 2560px page header.
+   */
+  compact: boolean;
+  /** What this surface is on a DESKTOP-width bar. Ignored when `compact`. */
+  kind: 'menu' | 'popover';
+  /** Controlled open state — `useIframeAwareMenu()`. See the header. */
+  control: ChromeSurfaceControl;
+  /**
+   * The trigger. A single element; it is cloned with an `onClick` in `popover` and
+   * `sheet` modes and passed through untouched in `menu` mode.
+   *
+   * 🔴 THE CLONE IS REQUIRED, NOT BELT-AND-BRACES, AND ONLY IN THOSE TWO MODES.
+   * `PopoverTarget` clones its child with
+   * `...(!ctx.controlled ? { onClick: ctx.onToggle } : null)` (@mantine/core 7.17.8),
+   * so a CONTROLLED popover target gets NO click handler from Mantine — the result is
+   * a real button with every correct ARIA attribute that opens nothing, and neither a
+   * type error nor a lint error can see it. `MenuTarget` has no such guard, so `menu`
+   * mode keeps Mantine's own handler and stays byte-identical to what shipped.
+   */
+  target: ReactElement;
+  /** Sheet header text. Host-authored and short — never the publisher's app name. */
+  title: string;
+  /** Desktop dropdown width (px). Ignored in sheet mode, which is full-bleed. */
+  width: number;
+  /** Desktop floating-surface placement. Ignored in sheet mode. */
+  position: 'bottom-start' | 'bottom-end';
+  /**
+   * Testid for the surface's CONTENT box, so one query addresses the dropdown and the
+   * sheet alike and a test does not have to know which one it is looking at.
+   */
+  dropdownTestId: string;
+  children: ReactNode;
+}) {
+  const mode: ChromeSurfaceMode = compact ? 'sheet' : kind;
+  const { onChange } = control;
+  // `onChange` is referentially stable (`useIframeAwareMenu` memoizes it with an empty
+  // dep list), so this value only changes when the mode does.
+  const context = useMemo<ChromeSurfaceContextValue>(
+    () => ({ mode, close: () => onChange(false) }),
+    [mode, onChange]
+  );
+
+  if (mode === 'sheet') {
+    return (
+      <ChromeSurfaceContext.Provider value={context}>
+        {cloneElement(target, {
+          onClick: () => onChange(!control.opened),
+          'aria-haspopup': 'dialog',
+          'aria-expanded': control.opened,
+        } as Partial<Record<string, unknown>>)}
+        <Drawer
+          opened={control.opened}
+          onClose={() => onChange(false)}
+          position="bottom"
+          title={title}
+          // Above the chrome bar and above the app iframe. 400 is what `SelectMenuV2`
+          // uses for the same job; the chrome has no z-index of its own to clear.
+          zIndex={400}
+          closeButtonProps={{ 'aria-label': `Close ${title}` }}
+          styles={{
+            // Size to the content instead of Mantine's fixed `size="md"`, capped so a
+            // long "Recently run" list scrolls rather than covering the whole app.
+            // 🔴 NOT the `padding` of this slot — that is where the global
+            // `--safe-area-inset-bottom` payment lands, and overriding it here would
+            // un-pay the home-indicator strip for these two sheets alone.
+            content: { height: 'auto', maxHeight: '75dvh' },
+            body: { paddingTop: 4, paddingLeft: 8, paddingRight: 8 },
+            header: { paddingTop: 8, paddingBottom: 8 },
+          }}
+        >
+          <Stack gap={2} data-testid={dropdownTestId}>
+            {children}
+          </Stack>
+        </Drawer>
+      </ChromeSurfaceContext.Provider>
+    );
+  }
+
+  if (mode === 'popover') {
+    return (
+      <ChromeSurfaceContext.Provider value={context}>
+        <Popover
+          width={width}
+          position={position}
+          shadow="md"
+          withArrow
+          opened={control.opened}
+          onChange={onChange}
+        >
+          <Popover.Target>
+            {cloneElement(target, {
+              onClick: () => onChange(!control.opened),
+            } as Partial<Record<string, unknown>>)}
+          </Popover.Target>
+          <Popover.Dropdown data-testid={dropdownTestId}>{children}</Popover.Dropdown>
+        </Popover>
+      </ChromeSurfaceContext.Provider>
+    );
+  }
+
+  return (
+    <ChromeSurfaceContext.Provider value={context}>
+      <Menu
+        position={position}
+        shadow="md"
+        width={width}
+        opened={control.opened}
+        onChange={onChange}
+      >
+        <Menu.Target>{target}</Menu.Target>
+        <Menu.Dropdown data-testid={dropdownTestId}>{children}</Menu.Dropdown>
+      </Menu>
+    </ChromeSurfaceContext.Provider>
+  );
+}
+
+/**
+ * One row of a chrome surface — a `Menu.Item` in a dropdown, a full-width tappable row
+ * in a bottom sheet.
+ *
+ * 🔴 THE SHEET ROW CLOSES ITS OWN SURFACE; THE MENU ITEM MUST NOT. Mantine's
+ * `closeOnItemClick` already runs `closeDropdownImmediately` on a `Menu.Item`, which in
+ * a CONTROLLED menu calls our `onChange(false)` — so adding a close here would be a
+ * second, redundant call on the desktop path and a behaviour change on a surface this
+ * change is not supposed to touch. A `Drawer` has no equivalent default, so the row
+ * supplies it. Without that, tapping "Rate this app" in the sheet parks a bottom sheet
+ * behind a focus-trapping modal — the visible half of the defect F0 fixed, arriving
+ * through the other rendering.
+ */
+export function ChromeSurfaceItem({
+  href,
+  onClick,
+  leftSection,
+  children,
+  'data-testid': dataTestId,
+}: {
+  /** A literal route. Renders a real anchor in both modes (keyboard / middle-click). */
+  href?: string;
+  onClick?: () => void;
+  leftSection?: ReactNode;
+  children: ReactNode;
+  'data-testid'?: string;
+}) {
+  const { mode, close } = useContext(ChromeSurfaceContext);
+
+  if (mode === 'menu') {
+    return (
+      <Menu.Item
+        component={href ? Link : undefined}
+        href={href}
+        leftSection={leftSection}
+        onClick={onClick}
+        data-testid={dataTestId}
+      >
+        {children}
+      </Menu.Item>
+    );
+  }
+
+  const handleClick = () => {
+    close();
+    onClick?.();
+  };
+  const rowStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    width: '100%',
+    // A comfortable touch row. The BAR's 31px resting height is a pinned CLS
+    // contract (`CHROME_BAR_PX`) and is untouched by this; the SHEET is a
+    // portaled overlay with no such constraint, so its rows can be finger-sized.
+    minHeight: 44,
+    padding: '8px 10px',
+    borderRadius: 'var(--mantine-radius-sm)',
+  } as const;
+  const body = (
+    <>
+      {leftSection}
+      <Text size="sm" lineClamp={1}>
+        {children}
+      </Text>
+    </>
+  );
+
+  // 🔴 TWO BRANCHES RATHER THAN `component={href ? Link : 'button'}`. Mantine's
+  // polymorphic `component` prop is typed against ONE component at a time, so the
+  // ternary widens to a union it will not accept — and casting it away would take
+  // the `href` prop's own checking with it. Two explicit branches keep both.
+  if (href) {
+    return (
+      <UnstyledButton
+        component={Link}
+        href={href}
+        onClick={handleClick}
+        data-testid={dataTestId}
+        style={rowStyle}
+      >
+        {body}
+      </UnstyledButton>
+    );
+  }
+  return (
+    <UnstyledButton onClick={handleClick} data-testid={dataTestId} style={rowStyle}>
+      {body}
+    </UnstyledButton>
+  );
+}
+
+/** A section heading — `Menu.Label` in a dropdown, a dimmed row label in a sheet. */
+export function ChromeSurfaceLabel({ children }: { children: ReactNode }) {
+  const { mode } = useContext(ChromeSurfaceContext);
+  if (mode === 'menu') return <Menu.Label>{children}</Menu.Label>;
+  return (
+    <Text size="xs" c="dimmed" fw={500} px={10} pt={8} pb={2} tt="uppercase">
+      {children}
+    </Text>
+  );
+}
+
+/**
+ * A group wrapper for the sheet/menu that needs a testid of its own (the "Recently run"
+ * section). Exists only so the chrome does not have to render a bare `<div>` whose
+ * `display: block` breaks the sheet's row rhythm.
+ */
+export function ChromeSurfaceGroup({
+  children,
+  'data-testid': dataTestId,
+}: {
+  children: ReactNode;
+  'data-testid'?: string;
+}) {
+  const { mode } = useContext(ChromeSurfaceContext);
+  if (mode === 'menu') return <div data-testid={dataTestId}>{children}</div>;
+  return (
+    <Group gap={2} data-testid={dataTestId} style={{ flexDirection: 'column', width: '100%' }}>
+      {children}
+    </Group>
+  );
+}

--- a/src/components/AppBlocks/ChromeSurface.tsx
+++ b/src/components/AppBlocks/ChromeSurface.tsx
@@ -230,11 +230,30 @@ export function ChromeSurface({
  * supplies it. Without that, tapping "Rate this app" in the sheet parks a bottom sheet
  * behind a focus-trapping modal — the visible half of the defect F0 fixed, arriving
  * through the other rendering.
+ *
+ * 🔴 `clamp` EXISTS BECAUSE THE TWO BRANCHES DID NOT AGREE, AND THE DISAGREEMENT SHIPPED
+ * SILENTLY. The sheet row wraps its children in `<Text size="sm" lineClamp={1}>`
+ * unconditionally; the menu item renders them raw. That is right for the six items whose
+ * labels are short, fixed and host-authored ("Marketplace", "Manage apps", …) — they were
+ * raw children before this primitive existed and must stay that way — and WRONG for the
+ * one item whose label is PUBLISHER-CONTROLLED: the "Recently run" app name, which the
+ * pre-primitive chrome wrapped in exactly that `Text`, with the comment "`lineClamp={1}`
+ * keeps a pathologically long name from blowing out the dropdown at ANY of its widths".
+ * Consolidating the two call sites lost it. Measured at 1440×900 with a 63-char name
+ * (`APP_CHROME_NAME_MAX` is 64): the row goes 33.6px → 56.7px and the dropdown 201.6px →
+ * 228.9px, ×`RECENTLY_RUN_LIMIT` = 5 rows.
+ *
+ * So the clamp is OPT-IN rather than universal, and the opt-in is keyed to the DATA, not
+ * to a layout preference: pass it wherever the label reaches this row from a publisher.
+ * `__tests__/chromeItemClamp.test.ts` fails if an item whose children pass through
+ * `sanitizeAppChromeName` — the repo's marker for exactly that — omits it, and
+ * `AppBlockChromeRecentsClamp.browser.test.tsx` measures the rendered row.
  */
 export function ChromeSurfaceItem({
   href,
   onClick,
   leftSection,
+  clamp = false,
   children,
   'data-testid': dataTestId,
 }: {
@@ -242,6 +261,14 @@ export function ChromeSurfaceItem({
   href?: string;
   onClick?: () => void;
   leftSection?: ReactNode;
+  /**
+   * The label is PUBLISHER-CONTROLLED and must be held to one line. See the 🔴 note in
+   * the component header. No-op in sheet mode, which clamps every row already — stated
+   * rather than "fixed" by clamping the menu universally, because the six host-authored
+   * menu labels were raw children before the primitive existed and changing them would
+   * be a desktop behaviour change this work is not entitled to make.
+   */
+  clamp?: boolean;
   children: ReactNode;
   'data-testid'?: string;
 }) {
@@ -256,7 +283,13 @@ export function ChromeSurfaceItem({
         onClick={onClick}
         data-testid={dataTestId}
       >
-        {children}
+        {clamp ? (
+          <Text size="sm" lineClamp={1}>
+            {children}
+          </Text>
+        ) : (
+          children
+        )}
       </Menu.Item>
     );
   }

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1,10 +1,11 @@
 import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { ActionIcon, Avatar, Box, Group, Menu, Text } from '@mantine/core';
+import { ActionIcon, Avatar, Box, Group, Text } from '@mantine/core';
 import {
   IconApps,
   IconBuildingStore,
+  IconChevronLeft,
   IconDots,
   IconEyeOff,
   IconGavel,
@@ -20,6 +21,13 @@ import { selectChromeRecentApps } from '~/components/Apps/recentAppsRail';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { AppNameCrumb } from './AppNameCrumb';
+import {
+  ChromeSurface,
+  ChromeSurfaceGroup,
+  ChromeSurfaceItem,
+  ChromeSurfaceLabel,
+} from './ChromeSurface';
+import type { ChromeSurfaceControl } from './ChromeSurface';
 import { ChromeReviewMenuItem } from './ChromeReviewEntry';
 import { ReviewListingModal } from '~/components/Apps/ReviewListingButton';
 import { AppPermissionsActivityDrawer } from './AppPermissionsActivityDrawer';
@@ -33,6 +41,7 @@ import { hideBlock } from './hiddenBlocks';
 import { isPageSlot } from '~/shared/constants/slot-registry';
 import { sanitizeAppChromeName } from './appChromeName';
 import { resolveChromeGeometry } from './chromeGeometry';
+import type { ChromeGeometry } from './chromeGeometry';
 import { useResizeObserver } from '~/hooks/useResizeObserver';
 import { sendBlockRender } from './sendBlockRender';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
@@ -294,8 +303,18 @@ export function AppBlockChrome({
   // platform-nav menu, and the ⋮ overflow menu — same component, same iframe —
   // silently shipped without it and was stuck open for exactly that reason. A
   // predicate open-coded at one site is how the second site is born wrong; the
-  // ledger in `__tests__/iframeAwareMenu.test.ts` now fails if a `<Menu>` appears
-  // in this chrome that is not on the hook.
+  // ledger in `__tests__/iframeAwareMenu.test.ts` now fails if a floating surface
+  // appears in this chrome that is not on the hook.
+  //
+  // 🔴 F3 MOVED THE ACTUAL `<Menu>` / `<Popover>` / `<Drawer>` INTO
+  // `ChromeSurface`, AND THE HOOK STAYED HERE. That split is deliberate: the
+  // primitive owns the RENDERING (which of the three a given bar width gets), the
+  // chrome owns the STATE (one control per trigger). Keeping the hook at the call
+  // site is what stops two surfaces from sharing one `opened` flag, which is the
+  // failure a primitive that owned its own state would make easy. Below `sm` the
+  // platform-nav control is simply unused — its trigger is not rendered, because
+  // the nav folds into the ⋮ sheet — and calling the hook unconditionally is the
+  // rules-of-hooks-legal way to say that.
   //
   // The platform-nav menu's own extra: on the transition to OPEN it re-reads the
   // recents store, so the "Recently run" list is fresh within an SPA session.
@@ -359,6 +378,181 @@ export function AppBlockChrome({
   });
   const geometry = resolveChromeGeometry(chromeWidth);
 
+  // 🔴 F3 — THE MOBILE SHELL, AND THE `isPage` TERM IS NOT A HEDGE. Below the `sm`
+  // breakpoint the page-surface chrome stops being a breadcrumb bar and becomes a
+  // native mobile shell: a back chevron to the Marketplace, the app name centered and
+  // tappable, and a ⋮ that carries the platform nav folded into it. It is gated on the
+  // PAGE surface because that is the only surface that HAS a breadcrumb to replace —
+  // the model-slot chrome is a badge and a ⋮ menu with no trail, and "back to the
+  // Marketplace" is not a meaningful action from a model page you did not arrive at
+  // through the store. A narrow model sidebar therefore resolves `geometry.compact`
+  // TRUE (it is genuinely narrow) and still renders exactly the chrome it always has.
+  const compact = isPage && geometry.compact;
+  // The platform-nav destinations, authored ONCE and rendered into whichever surface
+  // is carrying them: their own dropdown on a desktop-width bar, the ⋮ sheet below
+  // `sm`. `ChromeSurfaceItem` is what makes one authoring serve both — see its header
+  // for why a `Menu.Item` cannot simply be re-parented into a Drawer.
+  //
+  // 🔴 DEFINED BEFORE `appMenuItems` ON PURPOSE. `__tests__/chromeNavAlignsWithSubNav.ts`
+  // slices this section out by anchoring on the `Civitai Apps` label and stopping at the
+  // NEXT `<ChromeSurfaceLabel>`, so that the ⋮ menu's own `/apps/installed` item is not
+  // keyed onto the platform nav's. Reordering these two consts silently widens that
+  // slice.
+  const platformNavItems = (
+    <>
+      <ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>
+      {/* 🔴 THE ICONS AND THE "Marketplace" LABEL ARE MIRRORED FROM THE STORE
+          SUBNAV, WHICH IS THE SOURCE OF TRUTH — `SUB_NAV_LINKS` in
+          `~/components/Apps/AppsSubNav`. This section and that tab bar are two
+          renderings of ONE platform navigation: a user who opens an app from the
+          store and then reaches for this menu is looking for the same four
+          destinations they just left, and until now every shared concept was drawn
+          with a DIFFERENT glyph here (grid vs storefront, apps vs plug, upload vs
+          apps, shield vs gavel) — four out of four, so the disagreement was the
+          rule rather than an oversight.
+
+          When you add or re-icon an entry here, change `SUB_NAV_LINKS` first (or
+          confirm it already says what you are about to write) and follow it. The
+          alignment is pinned by `__tests__/chromeNavAlignsWithSubNav.test.ts`,
+          which reads BOTH tables and fails when they drift — including when the
+          subnav changes and this menu does not.
+
+          The LABELS are deliberately NOT all identical: the subnav's tabs sit under
+          an "Apps" heading and can afford one-word labels ("Installed", "Review"),
+          whereas these items stand alone over a running app and need the noun
+          ("Installed apps"). "Marketplace" is the one label that is shared verbatim,
+          because "Apps home" named a destination the store itself stopped calling
+          that. */}
+      <ChromeSurfaceItem href="/apps" leftSection={<IconBuildingStore size={14} stroke={1.5} />}>
+        Marketplace
+      </ChromeSurfaceItem>
+      <ChromeSurfaceItem
+        href="/apps/installed"
+        leftSection={<IconPlugConnected size={14} stroke={1.5} />}
+      >
+        Installed apps
+      </ChromeSurfaceItem>
+      <ChromeSurfaceItem href="/apps/mine" leftSection={<IconApps size={14} stroke={1.5} />}>
+        My apps
+      </ChromeSurfaceItem>
+      {isModerator && (
+        <ChromeSurfaceItem href="/apps/review" leftSection={<IconGavel size={14} stroke={1.5} />}>
+          Review
+        </ChromeSurfaceItem>
+      )}
+      {/* "Recently run" — a 1-click return to apps the viewer recently ran,
+          sourced from the client-only localStorage recents store (read
+          after mount so SSR + first client render match). Excludes the app
+          currently being viewed and the whole label+section is omitted when
+          there's nothing else to show (a first-time / single-app viewer).
+          Each item shows the app icon (persisted `iconUrl`, else a generic
+          app icon) + name, linking to the full-page run route. */}
+      {recentApps.length > 0 && (
+        <ChromeSurfaceGroup data-testid="app-recently-run">
+          <ChromeSurfaceLabel>Recently run</ChromeSurfaceLabel>
+          {recentApps.map((r) => (
+            <ChromeSurfaceItem
+              key={r.id}
+              // Non-null by `selectChromeRecentApps` (ChromeRecentApp).
+              href={`/apps/run/${r.blockId}`}
+              data-testid="app-recently-run-item"
+              leftSection={
+                r.iconUrl ? (
+                  <Avatar src={r.iconUrl} size={16} radius="sm" alt="" />
+                ) : (
+                  <IconApps size={14} stroke={1.5} />
+                )
+              }
+            >
+              {/* The persisted `name` is the SAME publisher-controlled string
+                  the trust label above laundered through localStorage — so
+                  route it through the identical sanitizer (strips bidi
+                  RLO/LRO overrides, zero-width/format + control chars, caps
+                  Zalgo combining runs, bounds length). `||` (not `??`) so an
+                  empty/whitespace sanitized result falls back to the blockId
+                  handle. */}
+              {sanitizeAppChromeName(r.name) || r.blockId}
+            </ChromeSurfaceItem>
+          ))}
+        </ChromeSurfaceGroup>
+      )}
+    </>
+  );
+  // The ⋮ overflow's own items — the actions that are about the RUNNING app rather
+  // than about the platform. Unchanged in content from what shipped; only the element
+  // that renders them moved.
+  const appMenuItems = (
+    <>
+      <ChromeSurfaceLabel>App</ChromeSurfaceLabel>
+      {/* 🔴 SAME ROUTE ⇒ SAME ICON, ACROSS BOTH SURFACES. This item and the
+          platform nav's "Installed apps" are different WORDS for the same
+          destination (`/apps/installed`), so they must not be different
+          PICTURES: on a desktop bar the two dropdowns open a few pixels apart, and
+          below `sm` they are literally rows of ONE sheet — a user who sees a plug in
+          one and a grid in the other has to work out whether they lead to the same
+          place. The glyph comes from the store subnav's row for this route
+          (`SUB_NAV_LINKS`), exactly as the platform nav's does — the labels stay
+          different on purpose ("Manage apps" is the action from inside a running app;
+          "Installed apps" is the destination), because the rule is about the ROUTE,
+          not the copy.
+
+          Pinned by `__tests__/chromeNavAlignsWithSubNav.test.ts`, which checks
+          EVERY literal-href item in the whole chrome, not just the platform-nav
+          section — this item is the reason that check is repo-wide rather than
+          scoped, since scoping it to one dropdown is what let this site drift. */}
+      <ChromeSurfaceItem
+        href="/apps/installed"
+        leftSection={<IconPlugConnected size={14} stroke={1.5} />}
+      >
+        Manage apps
+      </ChromeSurfaceItem>
+      {/* F4 — the permanent review entry point. An ACTION, not a route link:
+          it carries no `href`, so the ONE ROUTE, ONE ICON guard in
+          `__tests__/chromeNavAlignsWithSubNav.test.ts` (which extracts only
+          literal-href items) correctly does not treat it as a destination the
+          store subnav must also list.
+
+          Placed directly under "Manage apps" so the two whole-app actions that
+          are ALWAYS about the running app ("rate it", "see what it can do") sit
+          together above the dismissal, and "Hide app" stays last.
+
+          🔴 THE ITEM RENDERS ITS OWN GATES AND MAY RETURN NULL. It is offered
+          only to a viewer the server would accept: signed in, not the owner,
+          holding a store scope that admits this listing's kind, and with store
+          access at all (`hasAppsStoreAccess`). Offering a control whose submit
+          403s is the anti-goal `useCanReviewListing` exists to prevent, so the
+          gate is IMPORTED from the review module rather than re-derived here.
+          The query behind it is mounted only while this surface is open — in a
+          dropdown AND in the sheet, since Mantine unmounts a closed `Drawer`'s
+          children exactly as it unmounts a closed `Menu.Dropdown`'s. */}
+      <ChromeReviewMenuItem slug={slug} onOpenReview={setReviewListingId} />
+      {appBlockId && (
+        <ChromeSurfaceItem
+          leftSection={<IconShieldLock size={14} stroke={1.5} />}
+          onClick={() => setPermsOpen(true)}
+        >
+          Permissions & activity
+        </ChromeSurfaceItem>
+      )}
+      {showHide && (
+        <ChromeSurfaceItem
+          leftSection={<IconEyeOff size={14} stroke={1.5} />}
+          onClick={() =>
+            hideBlock({
+              blockInstanceId,
+              appName,
+              modelId,
+              modelName,
+              hiddenAt: Date.now(),
+            })
+          }
+        >
+          Hide app
+        </ChromeSurfaceItem>
+      )}
+    </>
+  );
+
   return (
     <>
     <Group
@@ -381,11 +575,191 @@ export function AppBlockChrome({
       // Machine-readable resolved tier, so a test can assert the decision rather
       // than re-deriving it from pixels.
       data-chrome-tier={geometry.tier}
+      // …and the F3 shell decision, for the same reason. `compact` is NOT derivable
+      // from the tier alone (a model sidebar is `base` and never compact), so a test
+      // that read the tier would be asserting a different question.
+      data-chrome-compact={compact ? 'true' : 'false'}
       style={{
         borderBottom: '1px solid var(--mantine-color-default-border)',
         background: 'var(--mantine-color-default-hover)',
       }}
     >
+      {compact ? (
+        <>
+          {/* F3 — the back affordance. It REPLACES the breadcrumb rather than
+              shrinking it: a two-crumb trail costs ~90px of a 360px bar to say one
+              thing, and the thing it says ("up to the Marketplace") is exactly what a
+              back chevron says in a third of the space. It is a real anchor
+              (`NextLink`), so middle-click / long-press / keyboard all behave, and it
+              points at the SAME `/apps` the crumb did — the destination did not move,
+              only its rendering.
+
+              `ActionIcon size="sm"` is not a style choice here: it is what keeps the
+              row at its pinned 31px resting height (`CHROME_BAR_PX`), the same as the
+              icon buttons the desktop bar has always used. */}
+          <ActionIcon
+            component={Link}
+            href="/apps"
+            variant="subtle"
+            color="gray"
+            size="sm"
+            aria-label="Back to Marketplace"
+            data-testid="app-block-back"
+            style={{ flexShrink: 0 }}
+          >
+            <IconChevronLeft size={16} stroke={1.5} />
+          </ActionIcon>
+          {/* The centered app name. `flex: 1 1 auto` between two 22px icon buttons is
+              what centers it, and `minWidth: 0` is what lets the name truncate rather
+              than push a control off the row.
+
+              The provenance icon rides along rather than being dropped with the
+              platform-nav trigger it used to live in. That trigger is GONE on this
+              surface (the nav folded into ⋮), and it was the only thing carrying the
+              "App" accessible name — losing it would have quietly removed the
+              spoof-proof signal this whole bar exists for. */}
+          <Group gap={6} wrap="nowrap" justify="center" style={{ minWidth: 0, flex: '1 1 auto' }}>
+            <IconApps
+              size={14}
+              stroke={1.5}
+              role="img"
+              aria-label="App"
+              style={{ flexShrink: 0 }}
+            />
+            <AppNameCrumb
+              name={label}
+              slug={slug}
+              maxWidth={geometry.nameMaxWidth}
+              onOpenReview={setReviewListingId}
+              compact
+            />
+          </Group>
+        </>
+      ) : (
+        <ChromeDesktopLeadingGroup
+          geometry={geometry}
+          platformNavMenu={platformNavMenu}
+          platformNavItems={platformNavItems}
+          iconProvenance={iconProvenance}
+          showBadgeName={showBadgeName}
+          label={label}
+          isPage={isPage}
+          slug={slug}
+          onOpenReview={setReviewListingId}
+        />
+      )}
+      {/* The ⋮ overflow. On a desktop-width bar it is the same dropdown it always
+          was. Below `sm` it becomes a bottom sheet AND absorbs the platform nav,
+          because the mobile bar has no second trigger to hang that behind — the
+          operator's call, and the reason `platformNavItems` is authored as a fragment
+          rather than inline in its own dropdown.
+
+          Order: the running app's own actions first (that is what ⋮ has always
+          meant), then the platform destinations. The back chevron already covers the
+          most common of those, so the folded-in nav is the secondary half of the
+          sheet, not its headline. */}
+      <ChromeSurface
+        compact={compact}
+        kind="menu"
+        control={overflowMenu}
+        title="App menu"
+        width={180}
+        position="bottom-end"
+        dropdownTestId="app-block-menu-dropdown"
+        target={
+          /* `data-testid` alongside the accessible name: the sibling controls in
+             this chrome (`app-block-back`, `app-block-name`, `app-block-breadcrumb*`)
+             are all addressable that way, and a test reaching this trigger by
+             accessible name alone breaks on a copy change that is not a behaviour
+             change. */
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="sm"
+            aria-label="App menu"
+            data-testid="app-block-menu-trigger"
+            // The row is `wrap="nowrap"` (it must stay one line — CHROME_BAR_PX).
+            // Without this the ⋯ trigger is a shrinkable flex item and a long name
+            // at a narrow width can squeeze it below its resting `ActionIcon
+            // size="sm"` (22px in @mantine/core 7.17.8); its sibling on the left
+            // has carried `flexShrink: 0` all along.
+            style={{ flexShrink: 0 }}
+          >
+            <IconDots size={16} stroke={1.5} />
+          </ActionIcon>
+        }
+      >
+        {appMenuItems}
+        {compact && platformNavItems}
+      </ChromeSurface>
+    </Group>
+    {/* Per-app transparency drawer (Part B). Rendered only when the caller
+        threaded an appBlockId; the body's queries fire only once opened. */}
+    {appBlockId && (
+      <AppPermissionsActivityDrawer
+        appBlockId={appBlockId}
+        appName={sanitizedName ?? undefined}
+        opened={permsOpen}
+        onClose={() => setPermsOpen(false)}
+      />
+    )}
+    {/* F4 — the review form, mounted OUTSIDE every floating surface (see
+        `reviewListingId` above for why that is forced rather than tidy). Mounted only
+        once an entry point has handed up a listing id, so a chrome nobody has asked
+        to review issues no `getMyReview` and renders no modal DOM. The modal applies
+        no eligibility gate of its own by design — the entry points did, and
+        duplicating the rule would put it in two places.
+
+        🔴 IT ALREADY GOES FULL-SCREEN ON A PHONE AND THAT IS NOT THIS COMPONENT'S
+        DECISION: `ReviewListingModal` sets `fullScreen={isMobile}` from a VIEWPORT
+        media query of its own. That is the right box for a modal (a modal IS the
+        viewport, unlike this bar, which can be 320px wide inside a 2560px window), so
+        it is deliberately NOT re-derived from `geometry.compact` here — two mechanisms
+        answering one question is how they come to disagree. */}
+    {reviewListingId && (
+      <ReviewListingModal
+        appListingId={reviewListingId}
+        opened
+        onClose={() => setReviewListingId(null)}
+      />
+    )}
+    </>
+  );
+}
+
+/**
+ * The desktop bar's leading cluster: the platform-nav trigger, the badge app name and
+ * the `Marketplace / <app name>` breadcrumb.
+ *
+ * 🔴 EXTRACTED PURELY TO KEEP THE COMPACT/DESKTOP BRANCH READABLE — every element
+ * inside it is byte-for-byte what shipped, including the testids, the ARIA and the
+ * responsive caps. F3 changes what renders BELOW `sm` on the page surface; above it,
+ * and on the model surface at every width, this is the whole chrome and it is
+ * untouched.
+ */
+function ChromeDesktopLeadingGroup({
+  geometry,
+  platformNavMenu,
+  platformNavItems,
+  iconProvenance,
+  showBadgeName,
+  label,
+  isPage,
+  slug,
+  onOpenReview,
+}: {
+  geometry: ChromeGeometry;
+  platformNavMenu: ChromeSurfaceControl;
+  platformNavItems: ReactNode;
+  iconProvenance: boolean;
+  showBadgeName: boolean;
+  label: string;
+  isPage: boolean;
+  slug: string | undefined;
+  onOpenReview: (appListingId: string) => void;
+}) {
+  return (
+    <>
       {/* minWidth:0 lets the truncating name shrink instead of pushing the
           ⋯ menu out of the narrow sidebar layout; `flex: 1 1 auto` lets it CLAIM
           the row's slack on a wide surface, which is what makes an uncapped name
@@ -399,18 +773,22 @@ export function AppBlockChrome({
             (role="img" + aria-label "App") — required so a bare tabler <svg>'s
             label is announced; on the fallback the visible "App" Text carries
             provenance instead, so the icon is marked decorative there. */}
-        <Menu
-          position="bottom-start"
-          shadow="md"
+        <ChromeSurface
+          compact={false}
+          kind="menu"
+          control={platformNavMenu}
+          // Never reached: this surface renders only on the non-compact branch, so
+          // `compact` is hard-false and the sheet's header text is dead. Passed
+          // because the prop is required — one primitive, one contract.
+          title="Civitai Apps"
           // Responsive: this dropdown renders publisher-controlled app names in
           // its "Recently run" section, so its useful width tracks the surface.
-          // (The ⋮ overflow menu below keeps a fixed width on purpose — every
-          // label in it is short, fixed and host-authored.)
+          // (The ⋮ overflow keeps a fixed width on purpose — every label in it is
+          // short, fixed and host-authored.)
           width={geometry.navMenuWidth}
-          opened={platformNavMenu.opened}
-          onChange={platformNavMenu.onChange}
-        >
-          <Menu.Target>
+          position="bottom-start"
+          dropdownTestId="app-platform-nav-dropdown"
+          target={
             <ActionIcon
               variant="subtle"
               color="gray"
@@ -427,103 +805,10 @@ export function AppBlockChrome({
                 aria-hidden={iconProvenance ? undefined : true}
               />
             </ActionIcon>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Label>Civitai Apps</Menu.Label>
-            {/* 🔴 THE ICONS AND THE "Marketplace" LABEL ARE MIRRORED FROM THE STORE
-                SUBNAV, WHICH IS THE SOURCE OF TRUTH — `SUB_NAV_LINKS` in
-                `~/components/Apps/AppsSubNav`. This dropdown and that tab bar are two
-                renderings of ONE platform navigation: a user who opens an app from the
-                store and then reaches for this menu is looking for the same four
-                destinations they just left, and until now every shared concept was drawn
-                with a DIFFERENT glyph here (grid vs storefront, apps vs plug, upload vs
-                apps, shield vs gavel) — four out of four, so the disagreement was the
-                rule rather than an oversight.
-
-                When you add or re-icon an entry here, change `SUB_NAV_LINKS` first (or
-                confirm it already says what you are about to write) and follow it. The
-                alignment is pinned by `__tests__/chromeNavAlignsWithSubNav.test.ts`,
-                which reads BOTH tables and fails when they drift — including when the
-                subnav changes and this menu does not.
-
-                The LABELS are deliberately NOT all identical: the subnav's tabs sit under
-                an "Apps" heading and can afford one-word labels ("Installed", "Review"),
-                whereas these menu items stand alone in a dropdown over a running app and
-                need the noun ("Installed apps"). "Marketplace" is the one label that is
-                shared verbatim, because "Apps home" named a destination the store itself
-                stopped calling that. */}
-            <Menu.Item
-              component={Link}
-              href="/apps"
-              leftSection={<IconBuildingStore size={14} stroke={1.5} />}
-            >
-              Marketplace
-            </Menu.Item>
-            <Menu.Item
-              component={Link}
-              href="/apps/installed"
-              leftSection={<IconPlugConnected size={14} stroke={1.5} />}
-            >
-              Installed apps
-            </Menu.Item>
-            <Menu.Item
-              component={Link}
-              href="/apps/mine"
-              leftSection={<IconApps size={14} stroke={1.5} />}
-            >
-              My apps
-            </Menu.Item>
-            {isModerator && (
-              <Menu.Item
-                component={Link}
-                href="/apps/review"
-                leftSection={<IconGavel size={14} stroke={1.5} />}
-              >
-                Review
-              </Menu.Item>
-            )}
-            {/* "Recently run" — a 1-click return to apps the viewer recently ran,
-                sourced from the client-only localStorage recents store (read
-                after mount so SSR + first client render match). Excludes the app
-                currently being viewed and the whole label+section is omitted when
-                there's nothing else to show (a first-time / single-app viewer).
-                Each item shows the app icon (persisted `iconUrl`, else a generic
-                app icon) + name, linking to the full-page run route. */}
-            {recentApps.length > 0 && (
-              <div data-testid="app-recently-run">
-                <Menu.Label>Recently run</Menu.Label>
-                {recentApps.map((r) => (
-                  <Menu.Item
-                    key={r.id}
-                    component={Link}
-                    // Non-null by `selectChromeRecentApps` (ChromeRecentApp).
-                    href={`/apps/run/${r.blockId}`}
-                    data-testid="app-recently-run-item"
-                    leftSection={
-                      r.iconUrl ? (
-                        <Avatar src={r.iconUrl} size={16} radius="sm" alt="" />
-                      ) : (
-                        <IconApps size={14} stroke={1.5} />
-                      )
-                    }
-                  >
-                    {/* The persisted `name` is the SAME publisher-controlled string
-                        the trust label above laundered through localStorage — so
-                        route it through the identical sanitizer (strips bidi
-                        RLO/LRO overrides, zero-width/format + control chars, caps
-                        Zalgo combining runs, bounds length). `||` (not `??`) so an
-                        empty/whitespace sanitized result falls back to the blockId
-                        handle. `lineClamp={1}` keeps a pathologically long name
-                        from blowing out the dropdown at ANY of its widths. */}
-                    <Text size="sm" lineClamp={1}>
-                      {sanitizeAppChromeName(r.name) || r.blockId}
-                    </Text>
-                  </Menu.Item>
-                ))}
-              </div>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+          }
+        >
+          {platformNavItems}
+        </ChromeSurface>
         {/* Host-rendered (spoof-proof) app-name label. Truncates with an
             ellipsis so a long name never wraps or shoves the menu off the row in
             the narrow model.sidebar_top slot. The cap is now RESPONSIVE to the
@@ -598,139 +883,16 @@ export function AppBlockChrome({
               name={label}
               slug={slug}
               maxWidth={geometry.nameMaxWidth}
-              onOpenReview={setReviewListingId}
+              onOpenReview={onOpenReview}
+              compact={false}
             />
           </Group>
         )}
       </Group>
-      {/* The ⋮ overflow menu. CONTROLLED via the same `useIframeAwareMenu` the
-          platform-nav menu uses — see the hook call above for why this is shared
-          rather than a second copy of the effect. Without it a click into the app
-          leaves this dropdown open on top of the app. */}
-      <Menu
-        position="bottom-end"
-        shadow="md"
-        width={180}
-        opened={overflowMenu.opened}
-        onChange={overflowMenu.onChange}
-      >
-        <Menu.Target>
-          {/* `data-testid` alongside the accessible name: the sibling controls in
-              this chrome (`app-platform-nav-trigger`, `app-block-name`,
-              `app-block-breadcrumb*`) are all addressable that way, and a test
-              reaching this trigger by accessible name alone breaks on a copy
-              change that is not a behaviour change. */}
-          <ActionIcon
-            variant="subtle"
-            color="gray"
-            size="sm"
-            aria-label="App menu"
-            data-testid="app-block-menu-trigger"
-            // The row is `wrap="nowrap"` (it must stay one line — CHROME_BAR_PX).
-            // Without this the ⋯ trigger is a shrinkable flex item and a long name
-            // at a narrow width can squeeze it below its resting `ActionIcon
-            // size="sm"` (22px in @mantine/core 7.17.8); its sibling on the left
-            // has carried `flexShrink: 0` all along.
-            style={{ flexShrink: 0 }}
-          >
-            <IconDots size={16} stroke={1.5} />
-          </ActionIcon>
-        </Menu.Target>
-        <Menu.Dropdown>
-          <Menu.Label>App</Menu.Label>
-          {/* 🔴 SAME ROUTE ⇒ SAME ICON, ACROSS BOTH MENUS. This item and the
-              platform nav's "Installed apps" are different WORDS for the same
-              destination (`/apps/installed`), so they must not be different
-              PICTURES: the two dropdowns open a few pixels apart in one bar, and a
-              user who sees a plug in one and a grid in the other has to work out
-              whether they lead to the same place. The glyph comes from the store
-              subnav's row for this route (`SUB_NAV_LINKS`), exactly as the platform
-              nav's does — the labels stay different on purpose ("Manage apps" is
-              the action from inside a running app; "Installed apps" is the
-              destination), because the rule is about the ROUTE, not the copy.
-
-              Pinned by `__tests__/chromeNavAlignsWithSubNav.test.ts`, which checks
-              EVERY literal-href item in the whole chrome, not just the platform-nav
-              dropdown — this item is the reason that check is repo-wide rather than
-              scoped, since scoping it to one dropdown is what let this site drift. */}
-          <Menu.Item
-            component={Link}
-            href="/apps/installed"
-            leftSection={<IconPlugConnected size={14} stroke={1.5} />}
-          >
-            Manage apps
-          </Menu.Item>
-          {/* F4 — the permanent review entry point. An ACTION, not a route link:
-              it carries no `href`, so the ONE ROUTE, ONE ICON guard in
-              `__tests__/chromeNavAlignsWithSubNav.test.ts` (which extracts only
-              literal-href items) correctly does not treat it as a destination the
-              store subnav must also list.
-
-              Placed directly under "Manage apps" so the two whole-app actions that
-              are ALWAYS about the running app ("rate it", "see what it can do") sit
-              together above the dismissal, and "Hide app" stays last.
-
-              🔴 THE ITEM RENDERS ITS OWN GATES AND MAY RETURN NULL. It is offered
-              only to a viewer the server would accept: signed in, not the owner,
-              holding a store scope that admits this listing's kind, and with store
-              access at all (`hasAppsStoreAccess`). Offering a control whose submit
-              403s is the anti-goal `useCanReviewListing` exists to prevent, so the
-              gate is IMPORTED from the review module rather than re-derived here.
-              The query behind it is mounted only while this dropdown is open. */}
-          <ChromeReviewMenuItem slug={slug} onOpenReview={setReviewListingId} />
-          {appBlockId && (
-            <Menu.Item
-              leftSection={<IconShieldLock size={14} stroke={1.5} />}
-              onClick={() => setPermsOpen(true)}
-            >
-              Permissions & activity
-            </Menu.Item>
-          )}
-          {showHide && (
-            <Menu.Item
-              leftSection={<IconEyeOff size={14} stroke={1.5} />}
-              onClick={() =>
-                hideBlock({
-                  blockInstanceId,
-                  appName,
-                  modelId,
-                  modelName,
-                  hiddenAt: Date.now(),
-                })
-              }
-            >
-              Hide app
-            </Menu.Item>
-          )}
-        </Menu.Dropdown>
-      </Menu>
-    </Group>
-    {/* Per-app transparency drawer (Part B). Rendered only when the caller
-        threaded an appBlockId; the body's queries fire only once opened. */}
-    {appBlockId && (
-      <AppPermissionsActivityDrawer
-        appBlockId={appBlockId}
-        appName={sanitizedName ?? undefined}
-        opened={permsOpen}
-        onClose={() => setPermsOpen(false)}
-      />
-    )}
-    {/* F4 — the review form, mounted OUTSIDE both floating surfaces (see
-        `reviewListingId` above for why that is forced rather than tidy). Mounted only
-        once an entry point has handed up a listing id, so a chrome nobody has asked
-        to review issues no `getMyReview` and renders no modal DOM. The modal applies
-        no eligibility gate of its own by design — the entry points did, and
-        duplicating the rule would put it in two places. */}
-    {reviewListingId && (
-      <ReviewListingModal
-        appListingId={reviewListingId}
-        opened
-        onClose={() => setReviewListingId(null)}
-      />
-    )}
     </>
   );
 }
+
 
 export function IframeHost({
   install,

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -13,10 +13,7 @@ import {
   IconShieldLock,
 } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import {
-  getRecentlyOpenedApps,
-  type RecentApp,
-} from '~/components/Apps/recentlyOpenedAppsStore';
+import { getRecentlyOpenedApps, type RecentApp } from '~/components/Apps/recentlyOpenedAppsStore';
 import { selectChromeRecentApps } from '~/components/Apps/recentAppsRail';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
@@ -555,38 +552,38 @@ export function AppBlockChrome({
 
   return (
     <>
-    <Group
-      ref={chromeRef}
-      justify="space-between"
-      gap="xs"
-      px="xs"
-      py={4}
-      // 🔴 `nowrap` STAYS, and it is not the breakpoint-blind bit. The bar's
-      // resting height is a pinned contract — `CHROME_BAR_PX = 35` in
-      // `slotReservation.ts`, the model slot's CLS reservation — and letting this
-      // row wrap to a second line at a narrow width would break it on exactly the
-      // surface the reservation exists for. The fix for narrow widths is that both
-      // flex children can SHRINK (`minWidth: 0` on the growing side, an explicit
-      // `flexShrink: 0` on each icon button so the controls are never crushed),
-      // which keeps the row one line tall at every width. This change is
-      // width-only; `CHROME_BAR_PX` is unchanged.
-      wrap="nowrap"
-      data-testid="app-block-chrome"
-      // Machine-readable resolved tier, so a test can assert the decision rather
-      // than re-deriving it from pixels.
-      data-chrome-tier={geometry.tier}
-      // …and the F3 shell decision, for the same reason. `compact` is NOT derivable
-      // from the tier alone (a model sidebar is `base` and never compact), so a test
-      // that read the tier would be asserting a different question.
-      data-chrome-compact={compact ? 'true' : 'false'}
-      style={{
-        borderBottom: '1px solid var(--mantine-color-default-border)',
-        background: 'var(--mantine-color-default-hover)',
-      }}
-    >
-      {compact ? (
-        <>
-          {/* F3 — the back affordance. It REPLACES the breadcrumb rather than
+      <Group
+        ref={chromeRef}
+        justify="space-between"
+        gap="xs"
+        px="xs"
+        py={4}
+        // 🔴 `nowrap` STAYS, and it is not the breakpoint-blind bit. The bar's
+        // resting height is a pinned contract — `CHROME_BAR_PX = 35` in
+        // `slotReservation.ts`, the model slot's CLS reservation — and letting this
+        // row wrap to a second line at a narrow width would break it on exactly the
+        // surface the reservation exists for. The fix for narrow widths is that both
+        // flex children can SHRINK (`minWidth: 0` on the growing side, an explicit
+        // `flexShrink: 0` on each icon button so the controls are never crushed),
+        // which keeps the row one line tall at every width. This change is
+        // width-only; `CHROME_BAR_PX` is unchanged.
+        wrap="nowrap"
+        data-testid="app-block-chrome"
+        // Machine-readable resolved tier, so a test can assert the decision rather
+        // than re-deriving it from pixels.
+        data-chrome-tier={geometry.tier}
+        // …and the F3 shell decision, for the same reason. `compact` is NOT derivable
+        // from the tier alone (a model sidebar is `base` and never compact), so a test
+        // that read the tier would be asserting a different question.
+        data-chrome-compact={compact ? 'true' : 'false'}
+        style={{
+          borderBottom: '1px solid var(--mantine-color-default-border)',
+          background: 'var(--mantine-color-default-hover)',
+        }}
+      >
+        {compact ? (
+          <>
+            {/* F3 — the back affordance. It REPLACES the breadcrumb rather than
               shrinking it: a two-crumb trail costs ~90px of a 360px bar to say one
               thing, and the thing it says ("up to the Marketplace") is exactly what a
               back chevron says in a third of the space. It is a real anchor
@@ -597,19 +594,19 @@ export function AppBlockChrome({
               `ActionIcon size="sm"` is not a style choice here: it is what keeps the
               row at its pinned 31px resting height (`CHROME_BAR_PX`), the same as the
               icon buttons the desktop bar has always used. */}
-          <ActionIcon
-            component={Link}
-            href="/apps"
-            variant="subtle"
-            color="gray"
-            size="sm"
-            aria-label="Back to Marketplace"
-            data-testid="app-block-back"
-            style={{ flexShrink: 0 }}
-          >
-            <IconChevronLeft size={16} stroke={1.5} />
-          </ActionIcon>
-          {/* The centered app name. `flex: 1 1 auto` between two 22px icon buttons is
+            <ActionIcon
+              component={Link}
+              href="/apps"
+              variant="subtle"
+              color="gray"
+              size="sm"
+              aria-label="Back to Marketplace"
+              data-testid="app-block-back"
+              style={{ flexShrink: 0 }}
+            >
+              <IconChevronLeft size={16} stroke={1.5} />
+            </ActionIcon>
+            {/* The centered app name. `flex: 1 1 auto` between two 22px icon buttons is
               what centers it, and `minWidth: 0` is what lets the name truncate rather
               than push a control off the row.
 
@@ -618,37 +615,37 @@ export function AppBlockChrome({
               surface (the nav folded into ⋮), and it was the only thing carrying the
               "App" accessible name — losing it would have quietly removed the
               spoof-proof signal this whole bar exists for. */}
-          <Group gap={6} wrap="nowrap" justify="center" style={{ minWidth: 0, flex: '1 1 auto' }}>
-            <IconApps
-              size={14}
-              stroke={1.5}
-              role="img"
-              aria-label="App"
-              style={{ flexShrink: 0 }}
-            />
-            <AppNameCrumb
-              name={label}
-              slug={slug}
-              maxWidth={geometry.nameMaxWidth}
-              onOpenReview={setReviewListingId}
-              compact
-            />
-          </Group>
-        </>
-      ) : (
-        <ChromeDesktopLeadingGroup
-          geometry={geometry}
-          platformNavMenu={platformNavMenu}
-          platformNavItems={platformNavItems}
-          iconProvenance={iconProvenance}
-          showBadgeName={showBadgeName}
-          label={label}
-          isPage={isPage}
-          slug={slug}
-          onOpenReview={setReviewListingId}
-        />
-      )}
-      {/* The ⋮ overflow. On a desktop-width bar it is the same dropdown it always
+            <Group gap={6} wrap="nowrap" justify="center" style={{ minWidth: 0, flex: '1 1 auto' }}>
+              <IconApps
+                size={14}
+                stroke={1.5}
+                role="img"
+                aria-label="App"
+                style={{ flexShrink: 0 }}
+              />
+              <AppNameCrumb
+                name={label}
+                slug={slug}
+                maxWidth={geometry.nameMaxWidth}
+                onOpenReview={setReviewListingId}
+                compact
+              />
+            </Group>
+          </>
+        ) : (
+          <ChromeDesktopLeadingGroup
+            geometry={geometry}
+            platformNavMenu={platformNavMenu}
+            platformNavItems={platformNavItems}
+            iconProvenance={iconProvenance}
+            showBadgeName={showBadgeName}
+            label={label}
+            isPage={isPage}
+            slug={slug}
+            onOpenReview={setReviewListingId}
+          />
+        )}
+        {/* The ⋮ overflow. On a desktop-width bar it is the same dropdown it always
           was. Below `sm` it becomes a bottom sheet AND absorbs the platform nav,
           because the mobile bar has no second trigger to hang that behind — the
           operator's call, and the reason `platformNavItems` is authored as a fragment
@@ -658,52 +655,52 @@ export function AppBlockChrome({
           meant), then the platform destinations. The back chevron already covers the
           most common of those, so the folded-in nav is the secondary half of the
           sheet, not its headline. */}
-      <ChromeSurface
-        compact={compact}
-        kind="menu"
-        control={overflowMenu}
-        title="App menu"
-        width={180}
-        position="bottom-end"
-        dropdownTestId="app-block-menu-dropdown"
-        target={
-          /* `data-testid` alongside the accessible name: the sibling controls in
+        <ChromeSurface
+          compact={compact}
+          kind="menu"
+          control={overflowMenu}
+          title="App menu"
+          width={180}
+          position="bottom-end"
+          dropdownTestId="app-block-menu-dropdown"
+          target={
+            /* `data-testid` alongside the accessible name: the sibling controls in
              this chrome (`app-block-back`, `app-block-name`, `app-block-breadcrumb*`)
              are all addressable that way, and a test reaching this trigger by
              accessible name alone breaks on a copy change that is not a behaviour
              change. */
-          <ActionIcon
-            variant="subtle"
-            color="gray"
-            size="sm"
-            aria-label="App menu"
-            data-testid="app-block-menu-trigger"
-            // The row is `wrap="nowrap"` (it must stay one line — CHROME_BAR_PX).
-            // Without this the ⋯ trigger is a shrinkable flex item and a long name
-            // at a narrow width can squeeze it below its resting `ActionIcon
-            // size="sm"` (22px in @mantine/core 7.17.8); its sibling on the left
-            // has carried `flexShrink: 0` all along.
-            style={{ flexShrink: 0 }}
-          >
-            <IconDots size={16} stroke={1.5} />
-          </ActionIcon>
-        }
-      >
-        {appMenuItems}
-        {compact && platformNavItems}
-      </ChromeSurface>
-    </Group>
-    {/* Per-app transparency drawer (Part B). Rendered only when the caller
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
+              aria-label="App menu"
+              data-testid="app-block-menu-trigger"
+              // The row is `wrap="nowrap"` (it must stay one line — CHROME_BAR_PX).
+              // Without this the ⋯ trigger is a shrinkable flex item and a long name
+              // at a narrow width can squeeze it below its resting `ActionIcon
+              // size="sm"` (22px in @mantine/core 7.17.8); its sibling on the left
+              // has carried `flexShrink: 0` all along.
+              style={{ flexShrink: 0 }}
+            >
+              <IconDots size={16} stroke={1.5} />
+            </ActionIcon>
+          }
+        >
+          {appMenuItems}
+          {compact && platformNavItems}
+        </ChromeSurface>
+      </Group>
+      {/* Per-app transparency drawer (Part B). Rendered only when the caller
         threaded an appBlockId; the body's queries fire only once opened. */}
-    {appBlockId && (
-      <AppPermissionsActivityDrawer
-        appBlockId={appBlockId}
-        appName={sanitizedName ?? undefined}
-        opened={permsOpen}
-        onClose={() => setPermsOpen(false)}
-      />
-    )}
-    {/* F4 — the review form, mounted OUTSIDE every floating surface (see
+      {appBlockId && (
+        <AppPermissionsActivityDrawer
+          appBlockId={appBlockId}
+          appName={sanitizedName ?? undefined}
+          opened={permsOpen}
+          onClose={() => setPermsOpen(false)}
+        />
+      )}
+      {/* F4 — the review form, mounted OUTSIDE every floating surface (see
         `reviewListingId` above for why that is forced rather than tidy). Mounted only
         once an entry point has handed up a listing id, so a chrome nobody has asked
         to review issues no `getMyReview` and renders no modal DOM. The modal applies
@@ -716,13 +713,13 @@ export function AppBlockChrome({
         viewport, unlike this bar, which can be 320px wide inside a 2560px window), so
         it is deliberately NOT re-derived from `geometry.compact` here — two mechanisms
         answering one question is how they come to disagree. */}
-    {reviewListingId && (
-      <ReviewListingModal
-        appListingId={reviewListingId}
-        opened
-        onClose={() => setReviewListingId(null)}
-      />
-    )}
+      {reviewListingId && (
+        <ReviewListingModal
+          appListingId={reviewListingId}
+          opened
+          onClose={() => setReviewListingId(null)}
+        />
+      )}
     </>
   );
 }
@@ -892,7 +889,6 @@ function ChromeDesktopLeadingGroup({
     </>
   );
 }
-
 
 export function IframeHost({
   install,

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -453,6 +453,12 @@ export function AppBlockChrome({
               // Non-null by `selectChromeRecentApps` (ChromeRecentApp).
               href={`/apps/run/${r.blockId}`}
               data-testid="app-recently-run-item"
+              // 🔴 THE ONE PUBLISHER-CONTROLLED LABEL IN EITHER SURFACE, so the one
+              // that must be held to a single line. Its five siblings above are
+              // host-authored and deliberately do NOT carry this — see the `clamp`
+              // note in `ChromeSurface.tsx` for why it is opt-in rather than
+              // universal.
+              clamp
               leftSection={
                 r.iconUrl ? (
                   <Avatar src={r.iconUrl} size={16} radius="sm" alt="" />

--- a/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
@@ -93,8 +93,59 @@ describe('resolveChromeGeometry', () => {
     // what makes this safe without an `useIsClient` hydration gate.
     expect(resolveChromeGeometry(0)).toEqual({
       tier: 'base',
+      // 🔴 F3: FALSE at an unmeasured width, and this is the assertion that pins it.
+      // `compact` drives a STRUCTURAL swap (breadcrumb ⇄ back chevron + centered
+      // name), so resolving it `true` here would make the server render the mobile
+      // shell for every viewer and then replace it one frame later on every desktop
+      // page load. See the `compact` doc comment in `chromeGeometry.ts`.
+      compact: false,
       nameMaxWidth: 160, // was `maw={160}` on the app-name Text
       navMenuWidth: 200, // was `width={200}` on the platform-nav Menu
+    });
+  });
+
+  describe('compact — the F3 mobile-shell decision', () => {
+    it('is true below sm and false at sm and above, on both sides of the boundary', () => {
+      // Tailwind semantics, same as the tier table: `sm` (768) is the first
+      // DESKTOP width, so 767 is compact and 768 is not. An off-by-one in the
+      // comparison flips exactly one of these two and nothing else.
+      expect(resolveChromeGeometry(CHROME_BREAKPOINTS.sm - 1).compact).toBe(true);
+      expect(resolveChromeGeometry(CHROME_BREAKPOINTS.sm).compact).toBe(false);
+      expect(resolveChromeGeometry(360).compact).toBe(true);
+      expect(resolveChromeGeometry(2560).compact).toBe(false);
+    });
+
+    it('is FALSE for an unmeasured bar even though the tier is `base`', () => {
+      // 🔴 THE ONE THAT WOULD BE WRONG IF `compact` WERE DERIVED FROM `tier`. Width
+      // 0 — SSR, and the first client render before the ResizeObserver fires —
+      // resolves to `base` because `base` carries the pre-F1 pinned widths, which
+      // is what keeps the server HTML unchanged. `compact` must NOT follow it there.
+      // A `tier === 'base' || tier === 'xs'` implementation passes every other test
+      // in this file and fails only this one.
+      expect(resolveChromeTier(0)).toBe('base');
+      expect(resolveChromeGeometry(0).compact).toBe(false);
+      // …and the same for the other unmeasurable inputs the resolver clamps to 0.
+      for (const w of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+        expect(resolveChromeGeometry(w).compact, `width ${w} must not be compact`).toBe(false);
+      }
+    });
+
+    it('is TRUE for a narrow model sidebar, which is why the SURFACE gate is the caller’s', () => {
+      // A 340px desktop model sidebar is genuinely narrow, so `compact` says so.
+      // The chrome still does not give it the mobile shell — it gates on
+      // `isPage && compact`, because the shell replaces a breadcrumb only the
+      // full-page surface has. Pinned here so a future reader does not "fix" this
+      // module to answer the surface question it deliberately does not answer.
+      expect(resolveChromeGeometry(340)).toMatchObject({ tier: 'base', compact: true });
+    });
+
+    it('is not a restatement of any other field — it moves where nothing else does', () => {
+      // Positive control on the whole block: between 480 and 767 the tier CHANGES
+      // (base→xs) while `compact` does not, and between 767 and 768 `compact`
+      // changes. A field hardwired to one value satisfies none of this.
+      expect(resolveChromeGeometry(479).tier).not.toBe(resolveChromeGeometry(480).tier);
+      expect(resolveChromeGeometry(479).compact).toBe(resolveChromeGeometry(480).compact);
+      expect(resolveChromeGeometry(767).compact).not.toBe(resolveChromeGeometry(768).compact);
     });
   });
 

--- a/src/components/AppBlocks/__tests__/chromeItemClamp.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeItemClamp.test.ts
@@ -18,7 +18,9 @@ import { describe, expect, it } from 'vitest';
  * ANY of its widths". The consolidation dropped it on the desktop path only, and
  * nothing noticed: the whole gating tier and all seven touched browser suites stayed
  * green. Measured at 1440×900 with a 63-char name (`APP_CHROME_NAME_MAX` is 64), the
- * row went 33.6px → 56.7px, ×`RECENTLY_RUN_LIMIT` = 5.
+ * row went 35px → 78px — three lines — ×`RECENTLY_RUN_LIMIT` = 5. (The audit reported
+ * 33.6 → 56.7 for the same defect with a shorter fixture; the gap is the name length,
+ * not a disagreement.)
  *
  * 🔴 THE RULE IS KEYED ON THE DATA, NOT ON A LAYOUT PREFERENCE, AND THAT IS WHAT MAKES
  * IT A RELATIONSHIP RATHER THAN A SPELLING. `sanitizeAppChromeName` is this repo's
@@ -154,7 +156,9 @@ describe('a publisher-controlled chrome row is clamped to one line', () => {
     for (const item of plain) {
       expect(
         item.head.replace(/\s+/g, ' '),
-        `a host-authored row gained \`clamp\`: ${item.children.trim().slice(0, 40)}. Those labels ` +
+        `a host-authored row gained \`clamp\`: ${item.children
+          .trim()
+          .slice(0, 40)}. Those labels ` +
           'are short, fixed and were raw children before `ChromeSurface` existed; wrapping them ' +
           'in a `Text` changes the desktop dropdown for no reason.'
       ).not.toMatch(/(^|\s)clamp(\s|>|=)/);

--- a/src/components/AppBlocks/__tests__/chromeItemClamp.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeItemClamp.test.ts
@@ -1,0 +1,182 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A PUBLISHER-CONTROLLED LABEL IN THE APP-BLOCK CHROME MUST BE HELD TO ONE LINE.
+ * Node `unit` project — the GATING tier. The rendered proof lives in
+ * `AppBlockChromeRecentsClamp.browser.test.tsx`; this is the copy that can block a
+ * merge.
+ *
+ * WHAT BROKE. F3 consolidated the chrome's two dropdowns and its bottom sheets onto
+ * one primitive (`ChromeSurface`). Its sheet row wraps children in
+ * `<Text size="sm" lineClamp={1}>`; its menu item rendered them RAW. That is correct
+ * for the six host-authored labels ("Marketplace", "Manage apps", …), which were raw
+ * children before the primitive existed — and wrong for the "Recently run" app name,
+ * which the pre-primitive chrome wrapped in exactly that `Text`, with the comment
+ * "`lineClamp={1}` keeps a pathologically long name from blowing out the dropdown at
+ * ANY of its widths". The consolidation dropped it on the desktop path only, and
+ * nothing noticed: the whole gating tier and all seven touched browser suites stayed
+ * green. Measured at 1440×900 with a 63-char name (`APP_CHROME_NAME_MAX` is 64), the
+ * row went 33.6px → 56.7px, ×`RECENTLY_RUN_LIMIT` = 5.
+ *
+ * 🔴 THE RULE IS KEYED ON THE DATA, NOT ON A LAYOUT PREFERENCE, AND THAT IS WHAT MAKES
+ * IT A RELATIONSHIP RATHER THAN A SPELLING. `sanitizeAppChromeName` is this repo's
+ * marker for "this string came from a publisher and is being laundered before it is
+ * rendered" — every spoof-proof label in the chrome goes through it, and nothing else
+ * does. So the invariant is: an item whose children pass through that sanitizer
+ * carries `clamp`. A future publisher-controlled row cannot be added without either
+ * tripping this or skipping the sanitizer, and skipping the sanitizer is a louder
+ * defect with its own guard (`appChromeName.test.ts`).
+ *
+ * A presence check ("some item carries `clamp`") would have been walkable by adding a
+ * second unclamped publisher label beside the first, so the check is over the SET.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/IframeHost.tsx');
+const SURFACE = path.join(REPO_ROOT, 'src/components/AppBlocks/ChromeSurface.tsx');
+
+function read(file: string): string {
+  // Prove the path before trusting any "no match" below: a scan of an absent file
+  // reports zero of everything, which reads as a clean pass.
+  expect(fs.existsSync(file), `${path.relative(REPO_ROOT, file)} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/**
+ * Strip JSX comments whole (braces included), then block and line comments. Every
+ * token searched for below is also discussed at length in the prose around it —
+ * including, in the chrome, a comment that names `clamp` and one that names
+ * `sanitizeAppChromeName` — so a rule must never be satisfiable by prose ABOUT the
+ * rule. Leaving the `{}` of a JSX comment behind would also glue an empty expression
+ * into the element's children and corrupt the parse.
+ */
+function code(src: string): string {
+  return src
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** Every `<ChromeSurfaceItem …>children</ChromeSurfaceItem>` as `{ head, children }`. */
+function items(src: string): Array<{ head: string; children: string }> {
+  return [...src.matchAll(/<ChromeSurfaceItem\b([\s\S]*?)<\/ChromeSurfaceItem>/g)].map((m) => {
+    const block = m[1];
+    // The opening tag's `>` is the first one at brace depth 0 — `leftSection={<Icon
+    // … />}` contains a `>` that is NOT the end of the tag, so a naive `indexOf('>')`
+    // truncates the item and loses the children entirely.
+    let depth = 0;
+    let tagEnd = -1;
+    for (let i = 0; i < block.length; i += 1) {
+      const ch = block[i];
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      else if (ch === '>' && depth === 0) {
+        tagEnd = i;
+        break;
+      }
+    }
+    return {
+      head: tagEnd === -1 ? block : block.slice(0, tagEnd + 1),
+      children: tagEnd === -1 ? '' : block.slice(tagEnd + 1),
+    };
+  });
+}
+
+const chromeSource = () => code(read(HOST));
+
+describe('a publisher-controlled chrome row is clamped to one line', () => {
+  it('the parser separates an opening tag from its children — positive control', () => {
+    // A guard built on a regex that matches nothing reports a confident, empty,
+    // fully-green set. Feed it the two shapes that break naive versions: a
+    // `leftSection` whose JSX carries a `>` of its own, and a boolean prop written
+    // without a value.
+    const parsed = items(`
+      <ChromeSurfaceItem
+        href="/apps"
+        leftSection={<IconBuildingStore size={14} stroke={1.5} />}
+        clamp
+      >
+        {sanitizeAppChromeName(r.name) || r.blockId}
+      </ChromeSurfaceItem>
+    `);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].head, 'the leftSection JSX must not truncate the opening tag').toContain(
+      'clamp'
+    );
+    expect(parsed[0].children.trim()).toBe('{sanitizeAppChromeName(r.name) || r.blockId}');
+
+    // …and the children of a plain item are NOT mistaken for its head.
+    const plain = items('<ChromeSurfaceItem href="/apps">Marketplace</ChromeSurfaceItem>');
+    expect(plain[0].head).not.toContain('Marketplace');
+    expect(plain[0].children).toBe('Marketplace');
+  });
+
+  it('EVERY item whose label passes through the publisher sanitizer carries `clamp`', () => {
+    const all = items(chromeSource());
+    // The chrome really was read. A zero here is indistinguishable from a parser
+    // wired to nothing, so it must never be the thing that makes this pass.
+    expect(all.length, 'parsed no `<ChromeSurfaceItem>` out of the chrome').toBeGreaterThanOrEqual(
+      5
+    );
+
+    const publisherControlled = all.filter((i) => i.children.includes('sanitizeAppChromeName'));
+    expect(
+      publisherControlled.length,
+      'no chrome row renders a `sanitizeAppChromeName(...)` label any more. If the "Recently run" ' +
+        'section was removed, delete this guard deliberately; if the label stopped going through ' +
+        'the sanitizer, that is a SPOOFING regression, not a reason to relax this.'
+    ).toBe(1);
+
+    for (const item of publisherControlled) {
+      expect(
+        item.head.replace(/\s+/g, ' '),
+        'a chrome row renders a publisher-controlled label WITHOUT `clamp`. On the desktop menu ' +
+          'path `ChromeSurfaceItem` renders children raw, so an unclamped name wraps to two ' +
+          'lines and grows the dropdown by ~23px per row (×5 rows). Add `clamp`.'
+      ).toMatch(/(^|\s)clamp(\s|>|=)/);
+    }
+  });
+
+  it('the HOST-authored labels are deliberately NOT clamped — the fix is not over-applied', () => {
+    // 🔴 THE OTHER DIRECTION, AND IT IS NOT SYMMETRY FOR ITS OWN SAKE. Clamping the
+    // whole menu would have been the tempting one-line "fix", and it would have
+    // changed the rendering of six labels that were raw children before this
+    // primitive existed — a desktop behaviour change smuggled in as a bug fix, on the
+    // exact surface F3 promises not to touch. This fails if someone reaches for it.
+    const plain = items(chromeSource()).filter(
+      (i) => !i.children.includes('sanitizeAppChromeName')
+    );
+    expect(plain.length, 'expected the host-authored rows to still be here').toBeGreaterThanOrEqual(
+      4
+    );
+    for (const item of plain) {
+      expect(
+        item.head.replace(/\s+/g, ' '),
+        `a host-authored row gained \`clamp\`: ${item.children.trim().slice(0, 40)}. Those labels ` +
+          'are short, fixed and were raw children before `ChromeSurface` existed; wrapping them ' +
+          'in a `Text` changes the desktop dropdown for no reason.'
+      ).not.toMatch(/(^|\s)clamp(\s|>|=)/);
+    }
+  });
+
+  it('`clamp` actually renders the one-line wrapper on the MENU path', () => {
+    // The prop could exist, be threaded, be asserted above — and do nothing, which is
+    // the shape of a guard that reads as coverage while providing none. Pin that the
+    // menu branch consumes it, and that the sheet branch clamps unconditionally (the
+    // asymmetry `clamp` exists to document rather than hide).
+    const surface = code(read(SURFACE));
+    expect(
+      surface.replace(/\s+/g, ' '),
+      '`ChromeSurfaceItem`’s menu branch must render `clamp`ed children inside a ' +
+        '`<Text lineClamp={1}>` — otherwise the prop is inert and every assertion above passes ' +
+        'over a label that still wraps.'
+    ).toMatch(/clamp \? \( <Text size="sm" lineClamp=\{1\}>/);
+    expect(
+      (surface.match(/lineClamp=\{1\}/g) ?? []).length,
+      'expected TWO `lineClamp={1}` sites in the primitive: the menu branch (opt-in, via ' +
+        '`clamp`) and the sheet branch (unconditional). One means a branch lost its clamp.'
+    ).toBe(2);
+  });
+});

--- a/src/components/AppBlocks/__tests__/chromeNavAlignsWithSubNav.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeNavAlignsWithSubNav.test.ts
@@ -96,31 +96,46 @@ function parseSubNav(src: string): NavEntry[] {
 }
 
 /**
- * The chrome's PLATFORM-NAV `<Menu.Item>`s, as `{href, label, icon}` rows.
+ * The chrome's PLATFORM-NAV items, as `{href, label, icon}` rows.
  *
- * 🔴 SCOPED TO THE PLATFORM-NAV DROPDOWN, WHICH IS NOT COSMETIC. The chrome renders
- * a SECOND dropdown (the ⋮ overflow menu) whose "Manage apps" item also points at
- * `/apps/installed` — with a different, deliberate icon. A whole-file scan would
- * key both onto one href and either compare the wrong row or clobber it. The slice
- * is anchored on the `Civitai Apps` menu label, which is the dropdown's own
- * heading.
+ * 🔴 SCOPED TO THE PLATFORM-NAV SECTION, WHICH IS NOT COSMETIC. The chrome also
+ * renders the ⋮ overflow's "Manage apps", which points at the SAME
+ * `/apps/installed` with a different, deliberate label. A whole-file scan would key
+ * both onto one href and either compare the wrong row or clobber it. The slice is
+ * anchored on the `Civitai Apps` label, which is the section's own heading.
+ *
+ * 🔴 F3 RE-POINTED BOTH ENDS OF THE SLICE, AND CHANGED WHAT BOUNDS IT. The items are
+ * `<ChromeSurfaceItem>`s now, not `<Menu.Item>`s: below the `sm` breakpoint this
+ * section is rendered as rows of a bottom sheet rather than a dropdown, and a
+ * `Menu.Item` THROWS outside a `<Menu>` context, so it could not be re-parented (see
+ * `ChromeSurface.tsx`). The rule this guard pins — the chrome and the store subnav
+ * draw a shared route with a shared glyph — is completely unchanged; only the element
+ * carrying it moved.
+ *
+ * The bound moved for a related reason. `</Menu.Dropdown>` no longer exists in this
+ * file (the primitive owns it), so the section is bounded by the NEXT
+ * `<ChromeSurfaceLabel>` instead — which is `Recently run`, whose items build their
+ * hrefs from a template literal and are correctly skipped by the literal-href filter
+ * below either way. That is a TIGHTER bound than the old one, not a looser one.
  */
 function parsePlatformNav(src: string): NavEntry[] {
-  const anchor = '<Menu.Label>Civitai Apps</Menu.Label>';
+  const anchor = '<ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>';
   const start = src.indexOf(anchor);
   expect(
     start,
-    `the platform-nav anchor \`${anchor}\` was not found in IframeHost.tsx — the dropdown was ` +
+    `the platform-nav anchor \`${anchor}\` was not found in IframeHost.tsx — the section was ` +
       'restructured past this scanner. Re-point the anchor; do not delete the guard.'
   ).toBeGreaterThan(-1);
   const rest = src.slice(start + anchor.length);
-  const end = rest.indexOf('</Menu.Dropdown>');
-  expect(end, 'the platform-nav dropdown never closes — the slice is unbounded.').toBeGreaterThan(
-    -1
-  );
+  const end = rest.indexOf('<ChromeSurfaceLabel');
+  expect(
+    end,
+    'the platform-nav section is not followed by another `<ChromeSurfaceLabel>` — the slice is ' +
+      'unbounded and would swallow the ⋮ overflow’s own items.'
+  ).toBeGreaterThan(-1);
   const region = rest.slice(0, end);
 
-  return [...region.matchAll(/<Menu\.Item\b([\s\S]*?)<\/Menu\.Item>/g)]
+  return [...region.matchAll(/<ChromeSurfaceItem\b([\s\S]*?)<\/ChromeSurfaceItem>/g)]
     .map((m) => {
       const block = m[1];
       // A literal string href only. The "Recently run" items build theirs from a
@@ -151,8 +166,8 @@ function parsePlatformNav(src: string): NavEntry[] {
 }
 
 /**
- * EVERY `<Menu.Item>` in the whole chrome that carries a LITERAL href, across both
- * dropdowns — not just the platform-nav one.
+ * EVERY chrome item that carries a LITERAL href, across both surfaces — not just the
+ * platform-nav one.
  *
  * 🔴 THIS IS THE REPO-WIDE HALF, AND IT EXISTS BECAUSE THE SCOPED HALF MISSED A
  * SITE. The platform-nav-scoped parser above deliberately ignores the ⋮ overflow
@@ -184,7 +199,7 @@ function chromeBody(): string {
 }
 
 function parseAllChromeLinks(src: string): NavEntry[] {
-  return [...src.matchAll(/<Menu\.Item\b([\s\S]*?)<\/Menu\.Item>/g)]
+  return [...src.matchAll(/<ChromeSurfaceItem\b([\s\S]*?)<\/ChromeSurfaceItem>/g)]
     .map((m) => {
       const block = m[1];
       const href = /href="([^"]+)"/.exec(block)?.[1];
@@ -231,15 +246,14 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     ]);
 
     const chrome = parsePlatformNav(`
-      <Menu.Label>Civitai Apps</Menu.Label>
-      <Menu.Item
-        component={Link}
+      <ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>
+      <ChromeSurfaceItem
         href="/apps"
         leftSection={<IconBuildingStore size={14} stroke={1.5} />}
       >
         Marketplace
-      </Menu.Item>
-      </Menu.Dropdown>
+      </ChromeSurfaceItem>
+      <ChromeSurfaceLabel>Recently run</ChromeSurfaceLabel>
     `);
     expect(chrome).toEqual([{ href: '/apps', label: 'Marketplace', icon: 'IconBuildingStore' }]);
 
@@ -250,12 +264,16 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     expect(code('<Text>{/* explain */}Marketplace</Text>')).toBe('<Text>Marketplace</Text>');
     expect(code('a /* block */ b\n  // line\nc')).toBe('a  b\n\nc');
 
-    // …and the scope control: an item in a LATER dropdown must not be picked up.
+    // …and the scope control: an item in a LATER section must not be picked up. This
+    // is the fixture that would catch the F3 bound going wrong — the ⋮ overflow's own
+    // `/apps/installed` sits after its own `<ChromeSurfaceLabel>App</…>`, and if the
+    // slice ran past that label the two entries for one route would be keyed onto
+    // each other and the icon comparison would be against the wrong row.
     const scoped = parsePlatformNav(`
-      <Menu.Label>Civitai Apps</Menu.Label>
-      <Menu.Item component={Link} href="/apps" leftSection={<IconBuildingStore />}>Marketplace</Menu.Item>
-      </Menu.Dropdown>
-      <Menu.Item component={Link} href="/apps/installed" leftSection={<IconApps />}>Manage apps</Menu.Item>
+      <ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>
+      <ChromeSurfaceItem href="/apps" leftSection={<IconBuildingStore />}>Marketplace</ChromeSurfaceItem>
+      <ChromeSurfaceLabel>App</ChromeSurfaceLabel>
+      <ChromeSurfaceItem href="/apps/installed" leftSection={<IconApps />}>Manage apps</ChromeSurfaceItem>
     `);
     expect(scoped.map((e) => e.href)).toEqual(['/apps']);
   });
@@ -370,23 +388,22 @@ describe('the app-block chrome platform nav agrees with the store subnav', () =>
     expect(new Set(installed.map((l) => l.icon)).size).toBe(1);
   });
 
-  it('the whole-chrome parser sees BOTH dropdowns — positive control', () => {
-    // The scoped parser stops at the first `</Menu.Dropdown>` by design. If this one
-    // inherited that bound it would silently score the ⋮ menu as absent and the rule
-    // above would pass over exactly the site it was written for.
+  it('the whole-chrome parser sees BOTH sections — positive control', () => {
+    // The scoped parser stops at the next `<ChromeSurfaceLabel>` by design. If this
+    // one inherited that bound it would silently score the ⋮ overflow's items as
+    // absent and the rule above would pass over exactly the site it was written for.
     const found = parseAllChromeLinks(`
-      <Menu.Label>Civitai Apps</Menu.Label>
-      <Menu.Item component={Link} href="/apps/installed" leftSection={<IconPlugConnected />}>Installed apps</Menu.Item>
-      </Menu.Dropdown>
-      <Menu.Label>App</Menu.Label>
-      <Menu.Item component={Link} href="/apps/installed" leftSection={<IconApps />}>Manage apps</Menu.Item>
+      <ChromeSurfaceLabel>Civitai Apps</ChromeSurfaceLabel>
+      <ChromeSurfaceItem href="/apps/installed" leftSection={<IconPlugConnected />}>Installed apps</ChromeSurfaceItem>
+      <ChromeSurfaceLabel>App</ChromeSurfaceLabel>
+      <ChromeSurfaceItem href="/apps/installed" leftSection={<IconApps />}>Manage apps</ChromeSurfaceItem>
     `);
     expect(found).toHaveLength(2);
     expect(found.map((f) => f.label)).toEqual(['Installed apps', 'Manage apps']);
     // …and it skips a template-literal href (the "Recently run" shape).
     expect(
       parseAllChromeLinks(
-        '<Menu.Item component={Link} href={`/apps/run/${r.blockId}`} leftSection={<IconApps />}>x</Menu.Item>'
+        '<ChromeSurfaceItem href={`/apps/run/${r.blockId}`} leftSection={<IconApps />}>x</ChromeSurfaceItem>'
       )
     ).toHaveLength(0);
   });

--- a/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
@@ -345,10 +345,22 @@ describe('every Menu in the app-block chrome is iframe-aware', () => {
     // components.
     let hooks = 0;
     let triggers = 0;
+    const controls: string[] = [];
     for (const row of LEDGER) {
       const src = row.source();
       hooks += (src.match(/useIframeAwareMenu\(/g) ?? []).length;
-      triggers += chromeSurfaceUses(src).length;
+      const uses = chromeSurfaceUses(src);
+      triggers += uses.length;
+      for (const tag of uses) {
+        const named = /control=\{\s*([A-Za-z_$][\w$]*)\s*\}/.exec(tag.replace(/\s+/g, ' '));
+        expect(
+          named,
+          `a \`<ChromeSurface>\` in ${row.what} passes no simple \`control={identifier}\`. Pass the ` +
+            'variable a `useIframeAwareMenu()` call was assigned to, so the check below can see ' +
+            'WHICH control each surface holds.'
+        ).not.toBeNull();
+        controls.push(`${row.what}::${(named as RegExpExecArray)[1]}`);
+      }
     }
     // Positive control: a zero on BOTH sides would satisfy the equality while
     // proving that neither pattern matched anything in the real tree.
@@ -361,6 +373,18 @@ describe('every Menu in the app-block chrome is iframe-aware', () => {
         'Every `<ChromeSurface>` needs its OWN `useIframeAwareMenu()`; sharing one makes opening ' +
         'either surface close the other.'
     ).toBe(triggers);
+
+    // 🔴 THE COUNT ALONE IS NOT THE RULE, AND A MUTATION PROVED IT. Pointing the
+    // platform-nav surface at `overflowMenu` leaves BOTH numbers at two — two hook
+    // calls, two triggers — while the two surfaces share one `opened` flag, so opening
+    // either closes the other and one hook call is dead. The equality above scores that
+    // clean. The rule is that the controls are DISTINCT, so that is what is asserted.
+    expect(
+      new Set(controls).size,
+      `two chrome surfaces are driven by the SAME control (${controls.join(', ')}). They would ` +
+        'share one `opened` flag: opening either would close the other, and one ' +
+        '`useIframeAwareMenu()` call would be dead while every count still balanced.'
+    ).toBe(controls.length);
   });
 
   it('the primitive takes its open state from the caller rather than owning any', () => {

--- a/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
@@ -34,6 +34,7 @@ const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/IframeHost.tsx');
 const HOOK = path.join(REPO_ROOT, 'src/components/AppBlocks/useIframeAwareMenu.ts');
 const CRUMB = path.join(REPO_ROOT, 'src/components/AppBlocks/AppNameCrumb.tsx');
 const REVIEW_ENTRY = path.join(REPO_ROOT, 'src/components/AppBlocks/ChromeReviewEntry.tsx');
+const SURFACE = path.join(REPO_ROOT, 'src/components/AppBlocks/ChromeSurface.tsx');
 
 function read(file: string): string {
   // Prove the path before trusting any "no match" below: a scan of an absent
@@ -70,9 +71,9 @@ function chromeSource(): string {
 }
 
 /**
- * Opening `<Menu …>` / `<Popover …>` tags only — `<Menu.Item>`, `<Menu.Dropdown>`,
- * `<Popover.Target>` etc. are sub-components, not floating surfaces, and closing
- * tags are not openings.
+ * Opening `<Menu …>` / `<Popover …>` / `<Drawer …>` tags only — `<Menu.Item>`,
+ * `<Menu.Dropdown>`, `<Popover.Target>` etc. are sub-components, not floating
+ * surfaces, and closing tags are not openings.
  *
  * 🔴 THE HAZARD IS THE FLOATING SURFACE, NOT THE COMPONENT NAME. The rule this
  * ledger enforces is a fact about the SURFACE — the chrome sits on a cross-origin
@@ -80,11 +81,18 @@ function chromeSource(): string {
  * anything Mantine renders in a floating layer with a click-outside close, not just
  * to `<Menu>`. F2 added a `<Popover>` (the app-name crumb's store card), which the
  * `<Menu>`-only matcher would have counted as zero and passed clean while the
- * popover hung over the app exactly like the ⋮ menu once did. Widen this union
- * before adding a `HoverCard`, `Combobox` or `Drawer` to the chrome.
+ * popover hung over the app exactly like the ⋮ menu once did. F3 added `<Drawer>`
+ * (the bottom sheets below `sm`) — the previous revision of this comment named
+ * `Drawer` as the next thing to widen for, and this is that widening. Widen it again
+ * before adding a `HoverCard` or `Combobox`.
+ *
+ * 🔴 `(?![.\w])` IS WHAT KEEPS `<AppPermissionsActivityDrawer …>` OUT. That element
+ * is rendered by the chrome and its NAME ends in "Drawer", but it is a component of
+ * ours whose own `<Drawer>` lives in its own file — matching it here would count one
+ * surface twice and demand a hook call the chrome does not make for it.
  */
 function menuOpeningTags(src: string): string[] {
-  return [...src.matchAll(/<(?:Menu|Popover)(?![.\w])[\s\S]*?>/g)].map((m) => m[0]);
+  return [...src.matchAll(/<(?:Menu|Popover|Drawer)(?![.\w])[\s\S]*?>/g)].map((m) => m[0]);
 }
 
 describe('every Menu in the app-block chrome is iframe-aware', () => {
@@ -114,6 +122,18 @@ describe('every Menu in the app-block chrome is iframe-aware', () => {
     expect(
       menuOpeningTags('<Popover.Target><button /></Popover.Target><Popover.Dropdown />')
     ).toHaveLength(0);
+
+    // The `<Drawer>` third of the union (F3's bottom sheets), with the same
+    // sub-component control — and, crucially, the OTHER-COMPONENT control: the chrome
+    // renders `<AppPermissionsActivityDrawer>`, whose name ends in "Drawer" and whose
+    // own sheet lives in its own file. A matcher that counted it here would demand a
+    // hook call for a surface this file does not render.
+    expect(
+      menuOpeningTags('<Drawer opened={d.opened} onClose={d.close} position="bottom">x</Drawer>')
+    ).toHaveLength(1);
+    expect(menuOpeningTags('<AppPermissionsActivityDrawer opened={x} onClose={y} />')).toHaveLength(
+      0
+    );
   });
 
   it('the shared hook exists and is the only place the blur listener lives', () => {
@@ -144,93 +164,225 @@ describe('every Menu in the app-block chrome is iframe-aware', () => {
    * third dropdown hung over the app. Every new file that renders into this chrome
    * belongs in this table.
    */
+  /**
+   * 🔴 F3 SPLIT THE ONE NUMBER INTO TWO, AND THE SPLIT IS THE POINT. Until F3 every
+   * chrome source both RENDERED its floating surfaces and OWNED their state, so one
+   * count could pin both ("N surfaces, N hook calls"). F3 moved the rendering into a
+   * single primitive (`ChromeSurface`, which picks `Menu` / `Popover` / `Drawer` from
+   * the bar's measured width) while leaving the state at the CALL SITES — deliberately,
+   * so two triggers can never come to share one `opened` flag.
+   *
+   * A single number can no longer express that: `ChromeSurface.tsx` renders three
+   * surfaces and calls the hook ZERO times (it receives a control), while
+   * `AppBlockChrome` renders zero raw surfaces and calls the hook TWICE. Collapsing
+   * those back into one column would force one of the two files to lie.
+   *
+   * So each row states both, and the invariant that still ties them together is
+   * asserted separately below: `sum(hookCalls) === sum(chromeSurfaceUses)` across the
+   * whole chrome — one control per trigger, no matter which file each half lives in.
+   */
   const LEDGER: ReadonlyArray<{
     what: string;
     source: () => string;
+    /** RAW Mantine floating surfaces (`<Menu>`/`<Popover>`/`<Drawer>`) rendered here. */
     surfaces: number;
+    /** `useIframeAwareMenu()` calls — i.e. open-state owners — declared here. */
+    hookCalls: number;
+    /** `<ChromeSurface>` uses — i.e. triggers wired to the primitive — declared here. */
+    chromeSurfaces: number;
     detail: string;
   }> = [
     {
+      what: 'ChromeSurface.tsx (the primitive)',
+      source: () => code(read(SURFACE)),
+      surfaces: 3,
+      hookCalls: 0,
+      chromeSurfaces: 0,
+      detail:
+        'THE ONLY file in the chrome allowed to render a raw Mantine floating surface, and it ' +
+        'renders exactly three: the `Menu` and `Popover` a desktop-width bar gets, and the ' +
+        'bottom-sheet `Drawer` below `sm`. A FOURTH means a new rendering was added — check it ' +
+        'is controlled from the same `control` prop. FEWER means one mode was dropped, which ' +
+        'silently sends that bar width to whichever branch remains. It calls the hook ZERO ' +
+        'times ON PURPOSE: the state belongs to the call site, so two triggers cannot end up ' +
+        'sharing one `opened` flag.',
+    },
+    {
       what: 'AppBlockChrome (IframeHost.tsx)',
       source: chromeSource,
-      surfaces: 2,
+      surfaces: 0,
+      hookCalls: 2,
+      chromeSurfaces: 2,
       detail:
-        'the platform-nav menu behind the app icon and the ⋮ overflow menu. A THIRD means a ' +
-        'new control was added: put it on `useIframeAwareMenu` and update this count in the ' +
-        'same commit, or it will be stuck open the first time a user clicks into the app. ' +
-        'FEWER means one was removed or restructured past this scanner.',
+        'the platform-nav trigger behind the app icon and the ⋮ overflow trigger — each a ' +
+        '`<ChromeSurface>` with its own control. ZERO raw surfaces is the F3 contract: a bare ' +
+        '`<Menu>` or `<Drawer>` reappearing here is the primitive being bypassed, which is how ' +
+        'the mobile shell would silently regain a dropdown that hangs over the app. A THIRD ' +
+        'trigger means a new control was added: give it its own `useIframeAwareMenu()` and ' +
+        'raise BOTH numbers in the same commit.',
     },
     {
       what: 'AppNameCrumb.tsx',
       source: () => code(read(CRUMB)),
-      surfaces: 1,
+      surfaces: 0,
+      hookCalls: 1,
+      chromeSurfaces: 1,
       detail:
-        'the breadcrumb app-name crumb’s store popover (full name + recommend rollup + "View ' +
-        'in App Store"). It renders directly over the app iframe like every other floating ' +
-        'surface in this chrome, so it is on the same hook.',
+        'the app-name crumb’s store card (full name + recommend rollup + "View in App Store" + ' +
+        'F4’s review action) — a popover on a desktop bar, a bottom sheet below `sm`, one ' +
+        '`<ChromeSurface>` either way.',
     },
     {
       what: 'ChromeReviewEntry.tsx',
       source: () => code(read(REVIEW_ENTRY)),
       surfaces: 0,
+      hookCalls: 0,
+      chromeSurfaces: 0,
       detail:
-        'F4’s two review entry points. ZERO is the correct count and this row is not filler: ' +
-        'both are plain controls rendered INTO surfaces their hosts already own (a `Menu.Item` ' +
-        'inside the chrome’s ⋮ dropdown, a `Button` inside the crumb’s popover), and the modal ' +
-        'they open is mounted by `AppBlockChrome` OUTSIDE both. A `<Menu>` or `<Popover>` ' +
-        'appearing here means this file grew a floating surface of its own — put it on ' +
-        '`useIframeAwareMenu` and raise this number in the same commit, or it will hang over ' +
-        'the app the first time a user clicks into it.',
+        'F4’s two review entry points. ALL THREE ZEROES are the correct counts and this row is ' +
+        'not filler: both entry points are plain controls rendered INTO surfaces their hosts ' +
+        'already own (a `ChromeSurfaceItem` inside the ⋮ surface, a `Button` inside the crumb’s ' +
+        'card), and the modal they open is mounted by `AppBlockChrome` OUTSIDE both. Any of ' +
+        'these going non-zero means this file grew a surface of its own — wire it and raise the ' +
+        'number in the same commit, or it will hang over the app the first time a user clicks ' +
+        'into it.',
     },
   ];
 
-  it.each(LEDGER)('$what renders exactly $surfaces floating surface(s), all on the hook', (row) => {
-    const src = row.source();
-    const tags = menuOpeningTags(src);
+  /** `<ChromeSurface …>` uses — the compound sub-components are not surfaces. */
+  function chromeSurfaceUses(src: string): string[] {
+    return [...src.matchAll(/<ChromeSurface(?![.\w])[\s\S]*?>/g)].map((m) => m[0]);
+  }
 
-    // Failing on GROWTH is the point: a new floating surface must be a deliberate
-    // edit here, which is the moment somebody reads the paragraph above and wires
-    // the hook. Failing on SHRINK catches one being removed or restructured past
-    // this scanner.
+  it('the ChromeSurface matcher can see a use and skips its item siblings — positive control', () => {
+    // Same reasoning as the `<Menu>` control above: a matcher that silently sees
+    // nothing turns every count below into a fact about the regex.
     expect(
-      tags.length,
-      `expected exactly ${row.surfaces} floating surface(s) in ${row.what} — ${row.detail}`
-    ).toBe(row.surfaces);
-
-    // Every one of them is CONTROLLED. A count alone would pass surfaces that all
-    // dropped their `opened`/`onChange`.
-    for (const tag of tags) {
-      const oneLine = tag.replace(/\s+/g, ' ');
-      expect(oneLine, `an uncontrolled floating surface in ${row.what}: ${oneLine}`).toMatch(
-        /opened=\{/
-      );
-      expect(oneLine, `a floating surface with no onChange in ${row.what}: ${oneLine}`).toMatch(
-        /onChange=\{/
-      );
-    }
-
-    // …and the control state comes from the SHARED hook, once per surface. Two
-    // surfaces and one hook call would mean they share a single `opened` flag
-    // (opening one would close the other); two surfaces and three calls means a
-    // dead one.
-    const hookCalls = src.match(/useIframeAwareMenu\(/g) ?? [];
+      chromeSurfaceUses('<ChromeSurface compact={c} control={m}>x</ChromeSurface>')
+    ).toHaveLength(1);
+    // 🔴 THE SIBLINGS ARE THE TRAP. `ChromeSurfaceItem` / `ChromeSurfaceLabel` /
+    // `ChromeSurfaceGroup` all START with the string `ChromeSurface`, and the chrome
+    // renders a dozen of them — without the `(?![.\w])` guard every one would be
+    // counted as a trigger and the hook-call equality below would demand a dozen
+    // controls that must not exist.
     expect(
-      hookCalls,
-      `the number of \`useIframeAwareMenu()\` calls must equal the number of floating surfaces ` +
-        `in ${row.what} — each owns its own open state.`
-    ).toHaveLength(tags.length);
-
-    // 🔴 ONE listener, one place — checked per source, not just for the chrome.
-    // The original defect was this effect existing at one site and not the other;
-    // an inline copy in ANY chrome source is that defect re-forming.
-    expect(
-      src.match(/addEventListener\(\s*'blur'/g) ?? [],
-      `a window \`blur\` listener has reappeared inside ${row.what}. That is the copy this ` +
-        'consolidation removed — route the new control through `useIframeAwareMenu` instead.'
+      chromeSurfaceUses(
+        '<ChromeSurfaceItem href="/apps">a</ChromeSurfaceItem><ChromeSurfaceLabel>b</ChromeSurfaceLabel><ChromeSurfaceGroup />'
+      )
     ).toHaveLength(0);
   });
 
-  it('a CONTROLLED Popover gets no onClick from Mantine, so the crumb wires its own', () => {
+  it.each(LEDGER)(
+    '$what: $surfaces raw floating surface(s), $chromeSurfaces ChromeSurface use(s), $hookCalls hook call(s)',
+    (row) => {
+      const src = row.source();
+      const tags = menuOpeningTags(src);
+
+      // Failing on GROWTH is the point: a new floating surface must be a deliberate
+      // edit here, which is the moment somebody reads the paragraph above and wires
+      // the hook. Failing on SHRINK catches one being removed or restructured past
+      // this scanner.
+      expect(
+        tags.length,
+        `expected exactly ${row.surfaces} raw Mantine floating surface(s) in ${row.what} — ${row.detail}`
+      ).toBe(row.surfaces);
+
+      // Every one of them is CONTROLLED. A count alone would pass surfaces that all
+      // dropped their `opened`/`onChange`.
+      //
+      // 🔴 A `Drawer` CLOSES THROUGH `onClose`, NOT `onChange` — it has no `onChange`
+      // prop at all. Requiring `onChange` of every surface would have made the F3
+      // sheet unrepresentable and invited someone to drop the check rather than
+      // widen it, so the close-handler assertion branches on the component while the
+      // `opened=` half stays universal.
+      for (const tag of tags) {
+        const oneLine = tag.replace(/\s+/g, ' ');
+        expect(oneLine, `an uncontrolled floating surface in ${row.what}: ${oneLine}`).toMatch(
+          /opened=\{/
+        );
+        const closeProp = /^<Drawer\b/.test(oneLine) ? /onClose=\{/ : /onChange=\{/;
+        expect(
+          oneLine,
+          `a floating surface with no close handler in ${row.what}: ${oneLine}`
+        ).toMatch(closeProp);
+      }
+
+      expect(
+        chromeSurfaceUses(src).length,
+        `expected exactly ${row.chromeSurfaces} \`<ChromeSurface>\` use(s) in ${row.what} — ${row.detail}`
+      ).toBe(row.chromeSurfaces);
+
+      // …and the control state comes from the SHARED hook, once per TRIGGER. Two
+      // triggers and one hook call would mean they share a single `opened` flag
+      // (opening one would close the other); two triggers and three calls means a
+      // dead one.
+      const hookCalls = src.match(/useIframeAwareMenu\(/g) ?? [];
+      expect(
+        hookCalls,
+        `the number of \`useIframeAwareMenu()\` calls in ${row.what} must be ${row.hookCalls} — ` +
+          'each trigger owns its own open state, and the primitive owns none.'
+      ).toHaveLength(row.hookCalls);
+
+      // 🔴 ONE listener, one place — checked per source, not just for the chrome.
+      // The original defect was this effect existing at one site and not the other;
+      // an inline copy in ANY chrome source is that defect re-forming.
+      expect(
+        src.match(/addEventListener\(\s*'blur'/g) ?? [],
+        `a window \`blur\` listener has reappeared inside ${row.what}. That is the copy this ` +
+          'consolidation removed — route the new control through `useIframeAwareMenu` instead.'
+      ).toHaveLength(0);
+    }
+  );
+
+  it('ONE CONTROL PER TRIGGER, summed across the whole chrome', () => {
+    // 🔴 THE SEAM THE PER-ROW COUNTS CANNOT SEE. Every number above is a fact about
+    // ONE file, and F3 put the two halves of this rule in different files: a trigger
+    // is declared where its `useIframeAwareMenu()` lives, and rendered by a primitive
+    // somewhere else. A per-file ledger is satisfied by "2 and 2 here, 1 and 1 there"
+    // — and would stay satisfied if a future file declared a `<ChromeSurface>` with a
+    // control borrowed from a sibling, which is exactly the shared-`opened` bug the
+    // per-surface count was written to prevent. This is the relationship, not the
+    // components.
+    let hooks = 0;
+    let triggers = 0;
+    for (const row of LEDGER) {
+      const src = row.source();
+      hooks += (src.match(/useIframeAwareMenu\(/g) ?? []).length;
+      triggers += chromeSurfaceUses(src).length;
+    }
+    // Positive control: a zero on BOTH sides would satisfy the equality while
+    // proving that neither pattern matched anything in the real tree.
+    expect(triggers, 'the ledger found no `<ChromeSurface>` in the chrome at all').toBeGreaterThan(
+      0
+    );
+    expect(
+      hooks,
+      'the chrome declares a different number of open-state controls than it has triggers. ' +
+        'Every `<ChromeSurface>` needs its OWN `useIframeAwareMenu()`; sharing one makes opening ' +
+        'either surface close the other.'
+    ).toBe(triggers);
+  });
+
+  it('the primitive takes its open state from the caller rather than owning any', () => {
+    // The counts above say `ChromeSurface.tsx` calls the hook zero times. That is
+    // consistent with it holding its own `useState` instead, which would be the same
+    // defect wearing different clothes — the state would be per-PRIMITIVE-INSTANCE
+    // either way, but nothing would stop a future caller from reading `opened` for a
+    // decision the primitive no longer exposes. Pin the actual contract.
+    const surface = code(read(SURFACE));
+    expect(
+      surface,
+      '`ChromeSurface` must accept a `control` (the `useIframeAwareMenu()` return) rather than ' +
+        'deriving open state internally.'
+    ).toMatch(/control\s*[,:}]/);
+    expect(
+      surface.match(/useState\(/g) ?? [],
+      '`ChromeSurface` grew its own `useState`. Open state belongs to the CALL SITE — see the ' +
+        'ledger note above for why that split is load-bearing rather than stylistic.'
+    ).toHaveLength(0);
+  });
+
+  it('a CONTROLLED Popover gets no onClick from Mantine, so the primitive wires its own', () => {
     // 🔴 THIS IS THE ONE THAT WOULD SHIP A DEAD BUTTON. `PopoverTarget` clones its
     // child with `...(!ctx.controlled ? { onClick: ctx.onToggle } : null)` — so the
     // moment the popover is put on `useIframeAwareMenu` (which is what supplying
@@ -254,25 +406,50 @@ describe('every Menu in the app-block chrome is iframe-aware', () => {
         'crumb’s own onClick before trusting either.'
     ).toContain('!ctx.controlled ? { onClick: ctx.onToggle } : null');
 
+    // 🔴 F3 MOVED THIS HANDLER FROM `AppNameCrumb` INTO `ChromeSurface`, WHICH IS WHY
+    // THE ASSERTION MOVED WITH IT — and the hazard got WIDER rather than narrower.
+    // The primitive now clones its target in TWO modes that both need it: `popover`
+    // (Mantine withholds `onClick` from a controlled target, as pinned above) and
+    // `sheet` (there is no Mantine target wrapper at all, so nothing would attach
+    // one). A crumb-scoped check would now be looking at a file that no longer owns
+    // the behaviour and would pass by finding nothing.
+    const surface = code(read(SURFACE));
     expect(
-      code(read(CRUMB)),
-      'AppNameCrumb’s Popover.Target must carry its OWN onClick — a controlled Popover.Target ' +
-        'gets none from Mantine, so without it the trigger opens nothing.'
-    ).toMatch(/onClick=\{[^}]*popover\.onChange/);
+      surface,
+      '`ChromeSurface` must clone its target with its OWN onClick — a controlled Popover.Target ' +
+        'gets none from Mantine, and a bare sheet trigger has no wrapper to get one from, so ' +
+        'without it the trigger opens nothing in either mode.'
+    ).toMatch(/cloneElement\([\s\S]{0,200}?onClick:/);
+    // Both cloning sites, not just one: the count is what catches a refactor that
+    // keeps the popover clone and drops the sheet's (or vice versa) — either of which
+    // ships a real button, correctly labelled, that does nothing.
+    expect(
+      surface.match(/cloneElement\(/g) ?? [],
+      '`ChromeSurface` must clone its target in BOTH the `popover` and `sheet` modes. `menu` ' +
+        'mode deliberately does NOT — `MenuTarget` has no `!ctx.controlled` guard, so Mantine ' +
+        'attaches the handler there and a second one would be a behaviour change on the ' +
+        'desktop path this work is not supposed to touch.'
+    ).toHaveLength(2);
   });
 
-  it('the ⋮ overflow trigger is addressable by a stable testid, like its siblings', () => {
+  it('the chrome’s controls are addressable by stable testids, across both shells', () => {
     const chrome = chromeSource();
     // Reachable only by accessible name, the ⋮ trigger broke every test that
     // touched it whenever the copy changed. Its siblings all carry a testid.
     expect(chrome).toContain('data-testid="app-block-menu-trigger"');
     // Named alongside the sibling ledger so a rename of the family is visible
     // here rather than only in a browser suite that does not gate a merge.
+    //
+    // 🔴 `app-block-back` IS THE F3 ADDITION AND IT IS NOT COSMETIC: the mobile
+    // shell's back chevron is the ONLY way off the run page once the breadcrumb is
+    // gone, so a rename that silently orphaned every test reaching for it would
+    // leave that route unguarded in the tier that gates merges.
     for (const id of [
       'app-block-chrome',
       'app-platform-nav-trigger',
       'app-block-name',
       'app-block-menu-trigger',
+      'app-block-back',
     ]) {
       expect(chrome, `chrome testid \`${id}\` is missing`).toContain(`data-testid="${id}"`);
     }

--- a/src/components/AppBlocks/chromeGeometry.ts
+++ b/src/components/AppBlocks/chromeGeometry.ts
@@ -64,6 +64,34 @@ export type ChromeSizeTier = 'base' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export interface ChromeGeometry {
   tier: ChromeSizeTier;
   /**
+   * F3 — render the NATIVE MOBILE SHELL (back chevron · centered tappable app name ·
+   * ⋮ that also carries the platform nav) instead of the desktop breadcrumb chrome.
+   * True when the bar's own measured inline size is below `sm` (768).
+   *
+   * 🔴 IT IS NOT `tier === 'base' || tier === 'xs'`, AND THE DIFFERENCE IS THE WHOLE
+   * POINT: AN UNMEASURED BAR IS NOT COMPACT. `tier` resolves an unmeasured width (0 —
+   * SSR, and the first client render before the `ResizeObserver` fires) to `base`,
+   * which is correct for `tier`'s job: `base` reproduces the pre-F1 pinned name/menu
+   * widths, so the server HTML is byte-identical to what it always was. Reusing that
+   * for `compact` would make the SERVER render the mobile shell for everyone and then
+   * swap it for a breadcrumb one frame later on every desktop page load — a
+   * structural DOM swap, not a `max-width` change, on the majority surface.
+   *
+   * So `compact` is false at width 0 and the unmeasured render is the DESKTOP one.
+   * The cost is the mirror image and it is the one worth paying: a phone paints the
+   * breadcrumb for the single frame before the observer reports, then swaps. The
+   * measurement lands in the `requestAnimationFrame` `useResizeObserver` batches into,
+   * so it is one frame, and it lands on the smaller audience.
+   *
+   * Consequence worth stating because it is easy to misread from the tier table: a
+   * 340px MODEL SIDEBAR is `tier: 'base'` AND `compact: true`. The chrome still does
+   * not give it the mobile shell — the caller gates on `isPage && compact`, because
+   * the shell REPLACES a breadcrumb that only the full-page surface has, and "back to
+   * the Marketplace" is not a meaningful action from a model page. `compact` answers
+   * "is this bar narrow"; the surface question is the caller's.
+   */
+  compact: boolean;
+  /**
    * `max-width` (px) for the host-rendered app-name label and for the
    * breadcrumb's trailing app-name crumb — the two places a publisher-controlled
    * string is rendered in the bar. `undefined` means UNCAPPED: at `xl` the row
@@ -96,7 +124,13 @@ export interface ChromeGeometry {
  * And the narrow model sidebar, the common case, keeps exactly the geometry it
  * shipped with.
  */
-const TIERS: ReadonlyArray<{ tier: ChromeSizeTier; min: number } & Omit<ChromeGeometry, 'tier'>> = [
+// `compact` is omitted from the row shape on purpose: it is NOT a tier property. It is
+// derived from the raw width in `resolveChromeGeometry`, because it has to distinguish
+// "measured narrow" from "not measured yet" and both of those resolve to the `base`
+// row. Putting it in the table would collapse that distinction.
+const TIERS: ReadonlyArray<
+  { tier: ChromeSizeTier; min: number } & Omit<ChromeGeometry, 'tier' | 'compact'>
+> = [
   { tier: 'xl', min: CHROME_BREAKPOINTS.xl, nameMaxWidth: undefined, navMenuWidth: 280 },
   { tier: 'lg', min: CHROME_BREAKPOINTS.lg, nameMaxWidth: 560, navMenuWidth: 280 },
   { tier: 'md', min: CHROME_BREAKPOINTS.md, nameMaxWidth: 440, navMenuWidth: 260 },
@@ -118,13 +152,22 @@ export function resolveChromeTier(inlineSize: number): ChromeSizeTier {
 /** Resolve the whole geometry set from the chrome's own measured inline size. */
 export function resolveChromeGeometry(inlineSize: number): ChromeGeometry {
   const width = Number.isFinite(inlineSize) && inlineSize > 0 ? inlineSize : 0;
+  // 🔴 `width > 0` is the UNMEASURED guard, not defensive noise — see the `compact`
+  // doc comment. `0` means "nobody has measured this bar yet", which must resolve to
+  // the desktop chrome so SSR and the first client paint are unchanged.
+  const compact = width > 0 && width < CHROME_BREAKPOINTS.sm;
   // TIERS is ordered widest-first, so the first match is the largest breakpoint
   // at or below `width`; the `base` row's min of 0 makes the loop total.
   for (const row of TIERS) {
     if (width >= row.min) {
-      return { tier: row.tier, nameMaxWidth: row.nameMaxWidth, navMenuWidth: row.navMenuWidth };
+      return {
+        tier: row.tier,
+        compact,
+        nameMaxWidth: row.nameMaxWidth,
+        navMenuWidth: row.navMenuWidth,
+      };
     }
   }
   /* istanbul ignore next — unreachable: the `base` row matches every width >= 0 */
-  return { tier: 'base', nameMaxWidth: 160, navMenuWidth: 200 };
+  return { tier: 'base', compact, nameMaxWidth: 160, navMenuWidth: 200 };
 }

--- a/src/components/Apps/ReviewPreviewFit.browser.test.tsx
+++ b/src/components/Apps/ReviewPreviewFit.browser.test.tsx
@@ -298,24 +298,29 @@ describe('the mod review preview fits its panel instead of being clipped out of 
     // wrong reason.
     expect(frame.getBoundingClientRect().height).toBeGreaterThan(320);
 
-    // Nothing is stranded. Stated as the DISJUNCTION the surface actually
-    // promises rather than a flat "no overflow": at ordinary modal widths the
-    // banner is one row and the host fits exactly, but this runner's viewport is
-    // ~414px WIDE, the banner wraps, and the floor legitimately binds — at which
-    // point the panel must be scrollable rather than clipping. The red arm's
-    // panel satisfies NEITHER branch, which is what makes this a real test and
-    // not a tautology.
+    // 🔴 NOTHING IS STRANDED — AND THIS IS NOW A FLAT ZERO, NOT A DISJUNCTION.
+    //
+    // It used to read "overflow === 0 OR the panel scrolls", with the justification
+    // that "this runner's viewport is ~414px WIDE, the banner wraps, and the floor
+    // legitimately binds". That sentence described a viewport this file had merely
+    // INHERITED from Vitest's default and never chosen — and it is now false twice
+    // over: the viewport is pinned to 1440 (see the file header), so the banner does
+    // not wrap, and the stylesheet is loaded, so `flex: 1` resolves against the real
+    // panel and the `FILL_MIN_HEIGHT_PX` floor does not bind. Measured here: the host
+    // is 380px inside the 420px panel and the overflow is 0.
+    //
+    // Keeping the weakened form would have been the worse outcome of the two: a
+    // disjunction whose second branch can no longer occur is satisfied entirely by
+    // its first, so it reads as tolerance the surface no longer needs while quietly
+    // accepting any amount of clipping that a scrollbar happens to make reachable.
     const overflow = box.scrollHeight - box.clientHeight;
-    const reachable = ['auto', 'scroll'].includes(getComputedStyle(box).overflowY);
     expect(
-      overflow === 0 || reachable,
-      `preview overflows its panel by ${overflow}px with overflowY=${
+      overflow,
+      `preview overflows its 420px panel by ${overflow}px (overflowY=${
         getComputedStyle(box).overflowY
-      } — that content is unreachable`
-    ).toBe(true);
-    // And whatever residue the floor leaves is SMALL — a fraction of the loss the
-    // red arm measures, not merely "some overflow".
-    expect(overflow).toBeLessThan(60);
+      }). At a pinned 1440px viewport with the stylesheet loaded the host fits exactly — any ` +
+        'residue means the fit regressed, not that the banner wrapped.'
+    ).toBe(0);
   });
 
   /**

--- a/src/components/Apps/ReviewPreviewFit.browser.test.tsx
+++ b/src/components/Apps/ReviewPreviewFit.browser.test.tsx
@@ -1,6 +1,34 @@
-import { describe, expect, test, vi } from 'vitest';
+/**
+ * 🔴 THIS FILE LOADS MANTINE'S STYLESHEET AND PINS A VIEWPORT, AND UNTIL F3 IT DID
+ * NEITHER — WHICH IS WHY ONE OF ITS NUMBERS WAS MEASURING A HARNESS ARTIFACT.
+ *
+ * Everything below is a LAYOUT measurement, and the shared scaffold
+ * (`test/component-setup.tsx`) deliberately loads no component stylesheet. Without
+ * it a Mantine `Group` is not a flex row, so the app-block chrome bar inside
+ * `app-page-frame` stacked its children and measured **200px** tall here against
+ * **31px** in production. The `> 320` floor check below was green only because of
+ * those 200 phantom pixels: F3 made the narrow-width chrome a single compact row,
+ * the artifact shrank toward the real number, and the host landed exactly on its
+ * `FILL_MIN_HEIGHT_PX = 300` floor — a red that was entirely about this harness and
+ * not about the panel, the fit prop, or the mobile shell.
+ *
+ * Loading the stylesheet makes every number here the number production produces.
+ * Vitest browser mode runs each file in its own iframe, so this does not leak into
+ * sibling suites. (Same reasoning, stated at length, in
+ * `src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx`.)
+ *
+ * The viewport is pinned for the second half of the same reason: the file inherited
+ * Vitest's 414×896 default and then reasoned about it in prose ("this runner's
+ * viewport is ~414px WIDE"), which is an observation of a default rather than a
+ * choice. 414 is below the `sm` breakpoint, so the preview now renders the mobile
+ * chrome there; naming a desktop viewport keeps this file's subject — a moderator
+ * reviewing an app in a desktop modal — the thing it was always about.
+ */
+import '@mantine/core/styles.css';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+// eslint-disable-next-line import/first
 import { renderWithProviders } from '../../../test/component-setup';
 // Type-only namespace imports for the `importOriginal` spreads below (the repo's
 // local-rules/no-wholesale-module-mock cure). NOT `typeof import(...)`, which
@@ -200,6 +228,12 @@ function panel() {
 function hostFrame() {
   return page.getByTestId('app-page-frame').element() as HTMLElement;
 }
+
+/** A desktop modal, which is the only place this preview is opened. See the header. */
+const DESKTOP: [number, number] = [1440, 900];
+beforeEach(async () => {
+  await page.viewport(...DESKTOP);
+});
 
 describe('the mod review preview fits its panel instead of being clipped out of it', () => {
   test('RED ARM (invariant guard) — `fit="viewport"` really is pushed out of the 420px panel', async () => {


### PR DESCRIPTION
## F3 — a native mobile shell for the App Blocks frame

Below the `sm` breakpoint (768, px scale) the full-page app frame stops being a
breadcrumb bar and becomes a mobile shell:

| | desktop (≥ sm) | mobile (< sm) |
|---|---|---|
| left | app icon → platform-nav dropdown | **← back chevron** → `/apps` |
| middle | `Marketplace / <app name>` trail | **app name, centered, tappable** → bottom sheet |
| right | ⋮ dropdown (app actions) | **⋮ bottom sheet** (app actions **+ the platform nav, folded in**) |

Desktop is unchanged — labels, icons, the breadcrumb, the popover and the ONE
ROUTE, ONE ICON guard all still resolve exactly as they did.

### The adaptive primitive

`src/components/AppBlocks/ChromeSurface.tsx` — **one** component, used at **three**
call sites, replacing what would otherwise have been three hand-rolled
`mobile ? <Drawer> : <X>` branches inside one 31px bar.

- `ChromeSurface` renders a `Menu`, a `Popover` or a bottom-sheet `Drawer` from one
  `compact` + `kind` pair. Call sites: the platform-nav trigger and the ⋮ trigger
  (`IframeHost.tsx`), and the app-name card (`AppNameCrumb.tsx`).
- `ChromeSurfaceItem` / `Label` / `Group` render the rows. **This is the
  load-bearing half**: `Menu.Item` calls `useMenuContext()`, which *throws* outside a
  `<Menu>`, so the platform-nav items and F4's `ChromeReviewMenuItem` could not
  simply be re-parented into a Drawer. One authoring, two renderings.

The repo has ~20 bottom sheets and no shared component; the two best exemplars
(`AdaptiveFiltersDropdown`, `SelectMenuV2`) already disagree with each other about
`zIndex`, which slot gets the padding, and whether the sheet sizes to content.

### Open state (constraint 3)

The sheets stay on `useIframeAwareMenu`, and **not** because a Drawer needs it — it
doesn't: a Drawer draws a scrim, so a click aimed at the app iframe lands on the
scrim in the *parent* document and Mantine's own `onClose` fires. The window-`blur`
close is inert there. It is shared because `ChromeSurface` is one component with a
mode switch: the `menu` and `popover` modes genuinely need it, and giving the sheet
its own `useState` would mean the desktop path's control state came from a different
place depending on a viewport measurement. The rendering moved into the primitive;
the **state stayed at the call sites**, so two triggers can never share one `opened`.

### Safe-area inset (constraint: `--safe-area-inset-bottom`)

The sheets pay it by **not** paying it. `src/styles/globals.css` already pays at the
library seam — `@layer mantine { .mantine-Drawer-content { padding-bottom:
var(--safe-area-inset-bottom) } }` — so a new Drawer is covered on the day it is
written and a second payment here would *double* it on a notched phone. What the
component must do is stay covered: not override the `content` slot's padding. Both
sides are now asserted (see the seam guard below).

### `CHROME_BAR_PX` (constraint 1)

Untouched, and still valid. The bar's rendered resting height is **31px at both
360×780 and 1440×900** — measured, not derived — and `CHROME_BAR_PX = 35 ≥ 31`, so
the model slot's CLS reservation stays an over-reservation. The known 35-vs-31
divergence is left exactly as F1 documented it.

### The harness was blind, and widening it is part of this

`test/component-setup.tsx` sets no viewport, so every chrome suite had been running
at Vitest's default **414×896** — a phone — without saying so. Nothing depended on
that while the chrome was width-blind. Now that it isn't, `AppBlockChrome` and
`AppBlockChromePlatformNav` declare the desktop viewport their claims were always
about, and `ChromeReviewEntry`'s overflow helper reads a surface-agnostic testid so
its existing 375px case now exercises **F4 through the sheet**.

### Red at base / green at HEAD

Measured by reverting only the four source files to `origin/main` and re-running the
new suite (5 red / 4 green, no timeouts — every red lands on a named assertion):

| test | at `origin/main` | failing assertion |
|---|---|---|
| REGRESSION mobile shell @360 | **RED** | `the desktop breadcrumb trail must be GONE` — breadcrumb present at base |
| REGRESSION nav in ⋮ sheet @360 | **RED** | `expected [ 'Manage apps' ] to include 'Marketplace'` |
| REGRESSION name card is a sheet @360 | **RED** | `must be delivered as a bottom sheet, not a popover` |
| PARITY GUARD sheet closes on row tap | RED *(no sheet at base — **not counted**)* | precondition: `the ⋮ must open a bottom sheet` |
| SEAM GUARD safe-area inset | RED *(no sheet at base — **not counted**)* | precondition: `the ⋮ sheet must be a Mantine Drawer` |
| INVARIANT model slot @360 keeps desktop chrome | GREEN | — |
| INVARIANT breadcrumb @1440, no chevron | GREEN | — |
| INVARIANT nav stays in own menu @1440 | GREEN | — |
| INVARIANT resting height 31px ×2 | GREEN | — |

### Mutation battery (each killed, each by its own message)

| mutant | killed by |
|---|---|
| drop `width > 0` from `compact` | `chromeGeometry` — `{compact: true} to deeply equal {compact: false}` at width 0 |
| drop `isPage &&` from the shell gate | model-slot invariant — `expected 'true' to be 'false'` |
| drop the sheet row's `close()` | parity guard — `activating a row must close the sheet` |
| un-pay the **global** drawer inset in `globals.css` | seam guard's own throw, naming the rule |
| fold the nav at every width | desktop invariant — `expected [...] to not include 'Marketplace'` |
| point both surfaces at one control | ledger — `two chrome surfaces are driven by the SAME control` |

The unmutated positive control was green (17/17) in the same battery.

### Guards re-pointed (not weakened)

- **`iframeAwareMenu.test.ts`** — the single "surfaces == hook calls" number split
  into three per-row columns, because F3 put the rendering and the state in different
  files and one number can no longer express both without one file lying. The
  relationship they encoded is now a **sum across the whole chrome**, plus a
  distinct-controls check that a mutation proved the sum alone could not catch.
  `Drawer` joins the surface union (its close handler is `onClose`, not `onChange`).
- **`chromeNavAlignsWithSubNav.test.ts`** — re-pointed to `ChromeSurfaceItem` /
  `ChromeSurfaceLabel`; the platform-nav slice is now bounded by the next label
  rather than a `</Menu.Dropdown>` that no longer exists in this file. Tighter bound,
  identical rule.

### One real find from running the FULL projects

`src/components/Apps/ReviewPreviewFit.browser.test.tsx` went **red at HEAD, green at
`origin/main`** — a genuine regression *of that test*, and the discriminating
measurement says it is not a production one. That file measures layout while the
shared scaffold loads no component stylesheet, so a Mantine `Group` is not a flex row
and the chrome bar inside `app-page-frame` measured **200px** there against **31px**
in production. Its `> 320` floor check was green only because of those 200 phantom
pixels; F3 makes the narrow chrome a single compact row, the artifact shrank toward
the real number, and the host landed exactly on its `FILL_MIN_HEIGHT_PX = 300` floor.

Fixed by loading `@mantine/core/styles.css` there and pinning the desktop viewport it
had only ever inherited — **not** by softening the threshold. Its RED ARM (the
negative control proving the suite can still see a host pushed out of the panel)
still passes.

This is the failure the brief predicted: it is invisible in the directory you edited
and only the whole-project run finds it.

### Verification

| | result |
|---|---|
| `node scripts/typecheck.mjs` | **0 errors** |
| `--project unit` (gating tier) | **1549 files / 24,448 tests passed, 33 skipped (24,481 collected), 0 failures** |
| `--project component` | **205 files / 2281 tests, 0 failures** |
| Prettier, ADDED files (blocking in CI) | clean |
| Prettier, MODIFIED files (report-only) | `IframeHost.tsx` was already unformatted on `main`; a full `--write` produced 23 hunks, 14 in code this change never touches, so the formatting is spliced to the chrome regions only |
| ESLint, changed files | 1 error, **pre-existing at `origin/main`** — `AppBlockChromePlatformNav.browser.test.tsx`'s wholesale `vi.mock('~/utils/trpc')`. Untouched deliberately: reshaping it is exactly the "add an import, break sibling suites" hazard, and it is out of scope here. |

Verified on the tree rebased onto current `origin/main`.

### Not verified

- No real device. The safe-area behaviour is asserted against an **injected**
  non-zero `--safe-area-inset-bottom` (34px, then 12px to prove it tracks), because
  `env(safe-area-inset-bottom)` is 0 in headless Chromium. That the rule wins the
  real cascade is `viewport-fit-cover.test.ts`'s claim, not this suite's.
- No touch-target enlargement in the bar itself: the chevron and ⋮ stay at
  `ActionIcon size="sm"` (22px) because constraint 1 pins the resting height. The
  SHEET rows are 44px. If a bigger bar tap target is wanted, that is a
  `CHROME_BAR_PX` change with its own before/after on the model surface.

---

## Post-audit revisions

The adversarial audit found no deploy-blockers and two findings. Both fixed.

### 1 🟡 — the primitive had silently dropped the desktop "Recently run" one-line clamp

`ChromeSurfaceItem` wraps children in `<Text size="sm" lineClamp={1}>` in its **sheet**
branch and rendered them raw in its **menu** branch. Right for the six host-authored
labels (raw children before the primitive existed, and they must stay that way); wrong
for the one **publisher-controlled** label — the recents app name, which the
pre-primitive chrome wrapped in exactly that `Text`.

This is the primitive's central claim (desktop parity) failing silently, and it *was*
silent: the whole gating tier and all seven touched browser suites were green with it
gone, because every existing test uses a short fixture name or asserts attributes
rather than geometry.

Restored as an **opt-in prop keyed to the data**, not to a layout preference. Clamping
the whole menu would have been the tempting one-liner and would have changed six
labels on the exact surface this work promises not to touch — so a guard asserts the
inverse too.

**Three-way matrix** (stronger than a red/green pair — `origin/main` passing is what
shows this pins *restored parity* rather than new behaviour):

| arm | result |
|---|---|
| `origin/main` (pre-primitive, clamp always present) | **GREEN** |
| this PR's tip `9bd9addf16` (clamp dropped) | **RED** — `the "Recently run" row must be within 2px of a one-line sibling (35px): expected 78 to be less than or equal to 37` |
| HEAD (clamp restored) | **GREEN** |

78px is three lines at a 63-char fixture (`APP_CHROME_NAME_MAX` is 64, so the sanitizer
is not the thing trimming). The audit's 56.7-vs-33.6 is the same bug at a shorter
fixture.

Two guards, because the failure was silent:

- **`__tests__/chromeItemClamp.test.ts`** (node, **gating**). Pins the *relationship*,
  not a spelling: an item whose children pass through `sanitizeAppChromeName` — the
  repo's marker for "this string came from a publisher" — must carry `clamp`, checked
  over the **set** so a second unclamped publisher row cannot be added beside the
  first. Also asserts host-authored rows do **not** gain it, and that the prop is not
  inert. Killed by the mutant with its own message.
- **`AppBlockChromeRecentsClamp.browser.test.tsx`**. The rendered measurement, stated
  relationally against a one-line sibling in the same dropdown rather than as a pixel
  literal, with `@mantine/core/styles.css` loaded — without it `lineClamp` is inert and
  both arms measure the same wrapped height.

Two drafts of that measurement were wrong and both are recorded in the file: a
`scrollWidth > clientWidth` control that can *never* fire (`lineClamp` clips
vertically, so the text never overflows horizontally — it failed 222-vs-222 against
correct code), and that control running *first*, which made the mutant die on a
missing-element precondition instead of on the height.

### 2 🟢 — the stale 414px justification is gone, and the assertion is tightened

`ReviewPreviewFit.browser.test.tsx` still said *"this runner's viewport is ~414px
WIDE, the banner wraps, and the floor legitimately binds"* — the prose defect this PR's
own header quotes as the thing being corrected. It was the stated justification for a
disjunctive assertion and a `< 60` slack, and at HEAD neither condition can occur.

Deleted, and tightened to `expect(overflow).toBe(0)`. **Confirmed stable rather than
assumed:** 5 consecutive runs of the file at load average ~14, 3/3 each time; host
380px inside the 420px panel, overflow 0.

### Open question answered: the sheet **is** as lazy as the dropdown

The audit could not verify whether sheet-mode ⋮ suppresses F4's listing fetch while
closed, and argued from Mantine's shared `keepMounted` default. That is an argument
about the library, not a measurement of this chrome — and a *structural* gate has to be
re-checked when the structure changes.

Measured, at 375px: a **closed sheet issues 0 listing requests, and opening it issues
exactly 1**. Reported as a pair on purpose — a zero alone is indistinguishable from a
counter wired to nothing, so the "after" is what licenses the "before" — with a real
happens-before for the absence (`data-chrome-compact="true"` committed, plus two
frames), not a polling matcher.

### Re-verification after the fixes

| | result |
|---|---|
| `--project unit` (gating) | **1550 files / 24,452 passed, 33 skipped (24,485 collected), 0 failures** |
| `--project component` | **206 files / 2283 passed, 0 failures** |
| `node scripts/typecheck.mjs` | 0 errors |
| Prettier, all 4 ADDED files | clean |
