### PR TITLE
fix(civitai-link): don't call a Link host that can't authenticate this origin

### DIFF
--- a/src/components/CivitaiLink/CivitaiLinkProvider.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkProvider.tsx
@@ -262,7 +262,11 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
       return { promise: Promise.resolve(undefined), id: payload.id, cancel: () => {} };
     }
 
-    // Setup promise for later resolution
+    // Setup promise for later resolution. Note the `timeout` clock now arms
+    // AFTER the worker is ready rather than before it — `getWorker()` above is
+    // the wait that moved. Unobservable today (`timeout` is not on the context
+    // type and no caller passes one), but it is the semantics whoever first
+    // passes a timeout will get.
     const promise = new Promise((resolve, reject) => {
       commandPromises[payload.id] = { resolve, reject };
       if (timeout <= 0) return;
@@ -273,7 +277,12 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
       }, timeout);
     });
 
-    worker.port.postMessage({ type: 'command', payload });
+    // Deliberately still routed through `workerReq`, not a direct
+    // `worker.port.postMessage(...)`: `postMessage` takes `any`, so posting
+    // directly drops the `WorkerIncomingMessage` check on the one message that
+    // carries every resource add/remove/cancel. `getWorker()` is idempotent, so
+    // the second call here is just the cached promise.
+    await workerReq({ type: 'command', payload });
     const cancel = () => {
       if (!commandPromises[payload.id]) return;
       runCommand({ type: 'activities:cancel', activityId: payload.id });

--- a/src/components/CivitaiLink/CivitaiLinkProvider.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkProvider.tsx
@@ -249,6 +249,19 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
     const payload = command as Command;
     payload.id = uuid();
 
+    // No reachable Link host: deliver nothing and hand back an already-settled
+    // promise. Registering in `commandPromises` first would leak the entry
+    // forever — nothing can complete it, and the default `timeout = 0` arms no
+    // rejection timer, so `.promise` would stay pending for the page's life.
+    // Settle rather than reject: callers `await runCommand(...)` (the outer
+    // call) and none attach a handler to `.promise`, so a rejection here would
+    // surface as an unhandled rejection.
+    const worker = await getWorker();
+    if (!worker) {
+      setError(UNAVAILABLE_ON_DOMAIN);
+      return { promise: Promise.resolve(undefined), id: payload.id, cancel: () => {} };
+    }
+
     // Setup promise for later resolution
     const promise = new Promise((resolve, reject) => {
       commandPromises[payload.id] = { resolve, reject };
@@ -260,7 +273,7 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
       }, timeout);
     });
 
-    await workerReq({ type: 'command', payload });
+    worker.port.postMessage({ type: 'command', payload });
     const cancel = () => {
       if (!commandPromises[payload.id]) return;
       runCommand({ type: 'activities:cancel', activityId: payload.id });

--- a/src/components/CivitaiLink/CivitaiLinkProvider.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkProvider.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { CivitaiLinkInstance } from '~/components/CivitaiLink/civitai-link-api';
+import { getCivitaiLinkBaseUrl } from '~/components/CivitaiLink/civitai-link-api';
 import type {
   Command,
   ResponseResourcesList,
@@ -64,6 +65,12 @@ type CivitaiLinkState = {
 };
 
 const CivitaiLinkCtx = createContext<CivitaiLinkState>({} as any);
+
+// Shown when the current origin can't reach a Link host that would accept its
+// session cookie (see `getCivitaiLinkBaseUrl`). Distinct from the
+// 'Civitai Link is not enabled' flag message: the feature IS enabled for this
+// user, it just cannot work from this domain.
+export const UNAVAILABLE_ON_DOMAIN = 'Civitai Link is not available on this domain';
 // #endregion
 
 // #region zu store
@@ -149,9 +156,16 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
 
   //TODO.civitai-link - timeout when setting active instance
 
-  const getWorker = () => {
+  const getWorker = (): Promise<SharedWorker | undefined> => {
     if (workerPromise.current) return workerPromise.current;
     if (workerRef.current) return Promise.resolve(workerRef.current);
+    // The Link service authenticates ONLY via the civitai session cookie, which
+    // never reaches it from an origin on a different registrable domain (PR
+    // previews on *.civitaic.com, civitai.green). Spawning the worker there buys
+    // nothing but a confusing `request failed (401 )` and a socket pointed at a
+    // host that will never accept us — so don't. Checked here rather than in
+    // render so SSR and hydration can't disagree.
+    if (!getCivitaiLinkBaseUrl()) return Promise.resolve(undefined);
     // Built by `pnpm build:workers` (scripts/build-workers.mjs) → public/workers.
     // Static path (not new URL(import.meta.url)) to bypass Turbopack's broken
     // .ts SharedWorker compilation — see vercel/next.js#74842.
@@ -216,12 +230,13 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
 
   const boot = async () => {
     const worker = await getWorker();
+    if (!worker) setError(UNAVAILABLE_ON_DOMAIN);
     return worker;
   };
 
   const workerReq = async (req: WorkerIncomingMessage) => {
     const worker = await getWorker();
-    worker.port.postMessage(req);
+    worker?.port.postMessage(req);
   };
 
   const selectInstance = (id: number) => workerReq({ type: 'join', id });

--- a/src/components/CivitaiLink/__tests__/CivitaiLinkProvider.browser.test.tsx
+++ b/src/components/CivitaiLink/__tests__/CivitaiLinkProvider.browser.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type * as CivitaiLinkApi from '~/components/CivitaiLink/civitai-link-api';
+
+// =============================================================================
+// The provider half of the cross-domain guard.
+//
+// `getCivitaiLinkBaseUrl` returning undefined is only half the fix — it does
+// nothing unless the provider BRANCHES on it. These tests pin that branch:
+// on an origin with no reachable Link host the SharedWorker must never be
+// constructed, and the failure must be reported as a domain problem rather
+// than left as the bare "Cannot Connect" this change exists to replace.
+//
+// Both directions are asserted. The available case is the positive control:
+// without it, a provider that never spawns a worker at all would pass the
+// unavailable case for entirely the wrong reason.
+// =============================================================================
+
+const mocks = vi.hoisted(() => ({
+  /** What `getCivitaiLinkBaseUrl` returns for the test at hand. */
+  baseUrl: undefined as string | undefined,
+  /** How many times the provider constructed a SharedWorker. */
+  workerConstructions: 0,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ civitaiLink: true }),
+}));
+
+vi.mock('~/components/CivitaiLink/civitai-link-api', async (importOriginal) => ({
+  ...(await importOriginal<typeof CivitaiLinkApi>()),
+  getCivitaiLinkBaseUrl: () => mocks.baseUrl,
+}));
+
+vi.mock('@okikio/sharedworker', () => ({
+  default: class FakeSharedWorker {
+    port = {
+      postMessage: () => undefined,
+      onmessage: null as ((e: { data: unknown }) => void) | null,
+    };
+    constructor() {
+      mocks.workerConstructions += 1;
+    }
+  },
+}));
+
+import { renderWithProviders } from '../../../../test/component-setup';
+import {
+  CivitaiLinkProvider,
+  UNAVAILABLE_ON_DOMAIN,
+  useCivitaiLink,
+} from '~/components/CivitaiLink/CivitaiLinkProvider';
+
+/**
+ * Renders the context's whole observable state as attributes. State is asserted
+ * via attributes, never via rendered prose — a sentence can be reworded while
+ * the behaviour regresses.
+ */
+function Probe() {
+  const { error, status } = useCivitaiLink();
+  return <div data-testid="probe" data-status={status} data-error={error ?? ''} />;
+}
+
+const renderProvider = () =>
+  renderWithProviders(
+    <CivitaiLinkProvider>
+      <Probe />
+    </CivitaiLinkProvider>
+  );
+
+describe('CivitaiLinkProvider — cross-domain guard', () => {
+  beforeEach(() => {
+    mocks.baseUrl = undefined;
+    mocks.workerConstructions = 0;
+  });
+
+  test('spawns no worker and reports the domain when no Link host is reachable', async () => {
+    mocks.baseUrl = undefined;
+    renderProvider();
+
+    await expect
+      .element(page.getByTestId('probe'))
+      .toHaveAttribute('data-error', UNAVAILABLE_ON_DOMAIN);
+    // The point of the fix: no request is ever issued, because no worker exists
+    // to issue it. A worker here would 401 exactly as before.
+    expect(mocks.workerConstructions).toBe(0);
+  });
+
+  test('leaves the status not-connected rather than claiming a socket problem', async () => {
+    mocks.baseUrl = undefined;
+    renderProvider();
+
+    await expect.element(page.getByTestId('probe')).toHaveAttribute('data-status', 'not-connected');
+  });
+
+  // Positive control: the guard must be selective, not simply always-off.
+  test('spawns the worker when a Link host on this origin IS reachable', async () => {
+    mocks.baseUrl = 'https://link.civitai.com';
+    renderProvider();
+
+    await vi.waitFor(() => expect(mocks.workerConstructions).toBe(1));
+    await expect.element(page.getByTestId('probe')).toHaveAttribute('data-error', '');
+  });
+});

--- a/src/components/CivitaiLink/__tests__/CivitaiLinkProvider.browser.test.tsx
+++ b/src/components/CivitaiLink/__tests__/CivitaiLinkProvider.browser.test.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type * as CivitaiLinkApi from '~/components/CivitaiLink/civitai-link-api';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
 
 // =============================================================================
 // The provider half of the cross-domain guard.
 //
 // `getCivitaiLinkBaseUrl` returning undefined is only half the fix — it does
-// nothing unless the provider BRANCHES on it. These tests pin that branch:
-// on an origin with no reachable Link host the SharedWorker must never be
-// constructed, and the failure must be reported as a domain problem rather
-// than left as the bare "Cannot Connect" this change exists to replace.
+// nothing unless the provider BRANCHES on it. These tests pin that branch: on an
+// origin with no reachable Link host the SharedWorker must never be constructed,
+// and the context must carry the domain-specific message rather than being left
+// on the generic connection failure.
 //
 // Both directions are asserted. The available case is the positive control:
 // without it, a provider that never spawns a worker at all would pass the
@@ -24,7 +25,15 @@ const mocks = vi.hoisted(() => ({
   workerConstructions: 0,
 }));
 
-vi.mock('~/providers/FeatureFlagsProvider', () => ({
+// `importOriginal` spread, NOT a bare replacement naming only `useFeatureFlags`.
+// A wholesale mock of this module is a known silent-zero shape here: when
+// something in the graph starts importing another of its exports, the file fails
+// to IMPORT, collects 0 tests and reports 0 failures — see
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`,
+// which records six suites that went quietly to zero exactly this way. The tier
+// that runs this file is report-only, so that would be silent.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
   useFeatureFlags: () => ({ civitaiLink: true }),
 }));
 
@@ -52,6 +61,11 @@ import {
   useCivitaiLink,
 } from '~/components/CivitaiLink/CivitaiLinkProvider';
 
+// Pinned as a LITERAL, deliberately not as the imported constant. Asserting
+// `toHaveAttribute('data-error', UNAVAILABLE_ON_DOMAIN)` passes even when the
+// constant is emptied — that pins the wiring and lets the message say anything.
+const UNAVAILABLE_MESSAGE = 'Civitai Link is not available on this domain';
+
 /**
  * Renders the context's whole observable state as attributes. State is asserted
  * via attributes, never via rendered prose — a sentence can be reworded while
@@ -75,23 +89,22 @@ describe('CivitaiLinkProvider — cross-domain guard', () => {
     mocks.workerConstructions = 0;
   });
 
+  test('the exported constant still says what these tests assert', () => {
+    expect(UNAVAILABLE_ON_DOMAIN).toBe(UNAVAILABLE_MESSAGE);
+  });
+
   test('spawns no worker and reports the domain when no Link host is reachable', async () => {
     mocks.baseUrl = undefined;
     renderProvider();
 
-    await expect
-      .element(page.getByTestId('probe'))
-      .toHaveAttribute('data-error', UNAVAILABLE_ON_DOMAIN);
+    const probe = page.getByTestId('probe');
+    // The literal, so emptying or rewording the constant is red. It also
+    // separates this from the feature-flag-off path, whose message differs.
+    await expect.element(probe).toHaveAttribute('data-error', UNAVAILABLE_MESSAGE);
+    await expect.element(probe).toHaveAttribute('data-status', 'not-connected');
     // The point of the fix: no request is ever issued, because no worker exists
     // to issue it. A worker here would 401 exactly as before.
     expect(mocks.workerConstructions).toBe(0);
-  });
-
-  test('leaves the status not-connected rather than claiming a socket problem', async () => {
-    mocks.baseUrl = undefined;
-    renderProvider();
-
-    await expect.element(page.getByTestId('probe')).toHaveAttribute('data-status', 'not-connected');
   });
 
   // Positive control: the guard must be selective, not simply always-off.

--- a/src/components/CivitaiLink/__tests__/civitai-link-api.test.ts
+++ b/src/components/CivitaiLink/__tests__/civitai-link-api.test.ts
@@ -30,6 +30,11 @@ describe('getCivitaiLinkBaseUrl', () => {
     expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
   });
 
+  it('uses the .com Link host on a .com subdomain', () => {
+    setHostname('internal.civitai.com');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
+  });
+
   it('rewrites to the .red Link host on civitai.red', () => {
     setHostname('civitai.red');
     expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.red');
@@ -45,13 +50,39 @@ describe('getCivitaiLinkBaseUrl', () => {
     expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.red');
   });
 
-  it('does not match a lookalike host that merely contains civitai.red', () => {
-    setHostname('civitai.red.evil.com');
+  it('falls back to the baked .com host when no location is available (SSR)', () => {
+    setHostname(undefined);
     expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
   });
 
-  it('falls back to the baked .com host when no location is available', () => {
-    setHostname(undefined);
-    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
+  // The Link service authenticates only via the civitai session cookie, which is
+  // Domain-scoped to the page's registrable domain. On any other registrable
+  // domain no credential is sent and the service answers 401 — which is what
+  // surfaced as "Error loading instances: Civitai Link request failed (401 )".
+  // Returning undefined lets the provider disable the feature instead.
+  describe('refuses an origin whose cookie cannot reach the Link host', () => {
+    it('returns undefined on a PR preview host', () => {
+      setHostname('pr-4251.civitaic.com');
+      expect(getCivitaiLinkBaseUrl()).toBeUndefined();
+    });
+
+    it('returns undefined on the bare preview domain', () => {
+      setHostname('civitaic.com');
+      expect(getCivitaiLinkBaseUrl()).toBeUndefined();
+    });
+
+    // No link.civitai.green host exists, and the .red rewrite does not cover it.
+    it('returns undefined on civitai.green', () => {
+      setHostname('civitai.green');
+      expect(getCivitaiLinkBaseUrl()).toBeUndefined();
+    });
+
+    // Doubles as the lookalike guard: the .red rewrite must not fire for a host
+    // that merely CONTAINS civitai.red, and the resulting .com base must then be
+    // refused because evil.com is a different registrable domain.
+    it('returns undefined for a lookalike host that merely contains civitai.red', () => {
+      setHostname('civitai.red.evil.com');
+      expect(getCivitaiLinkBaseUrl()).toBeUndefined();
+    });
   });
 });

--- a/src/components/CivitaiLink/__tests__/civitai-link-api.test.ts
+++ b/src/components/CivitaiLink/__tests__/civitai-link-api.test.ts
@@ -50,6 +50,16 @@ describe('getCivitaiLinkBaseUrl', () => {
     expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.red');
   });
 
+  // Pins the NARROWNESS of the .red matcher, on a host that stays on civitai.com
+  // so the same-registrable-domain check cannot mask the result. Widening
+  // `endsWith('.civitai.red')` to `includes('civitai.red')` sends this host to
+  // link.civitai.red, which is then refused as cross-domain and returns
+  // undefined — so this case, and only this case, goes red for that mutant.
+  it('does not treat a .com host containing "civitai.red" as a .red host', () => {
+    setHostname('civitai.redirect.civitai.com');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
+  });
+
   it('falls back to the baked .com host when no location is available (SSR)', () => {
     setHostname(undefined);
     expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');

--- a/src/components/CivitaiLink/civitai-link-api.ts
+++ b/src/components/CivitaiLink/civitai-link-api.ts
@@ -15,11 +15,13 @@ export type CivitaiLinkInstance = {
  *
  * This is a COMPARISON KEY for "would one host's cookie reach the other?", not a
  * cookie Domain, and it deliberately does NOT mirror `cookieDomainForHost`
- * (`~/server/auth/civ-cookie`): that returns undefined (host-only cookie) for
- * `localhost` and bare IPv4, where this returns the last two labels. Safe here
- * because BOTH sides of the comparison go through this same function, so an
- * identical host still compares equal and a host-only cookie is still shared —
- * `localhost` page + `http://localhost:3000` Link host resolves normally.
+ * (`~/server/auth/civ-cookie`). That function returns undefined (host-only
+ * cookie) for `localhost`, for bare IPv4, and for ANY single-label host; this
+ * one returns the last two labels, or the whole thing when there are fewer than
+ * two. Safe here because BOTH sides of the comparison go through this same
+ * function, so an identical host still compares equal and a host-only cookie is
+ * still shared — `localhost` page + `http://localhost:3000` Link host resolves
+ * normally.
  *
  * Known imprecision, deliberately not fixed: two DIFFERENT private IPv4 hosts
  * (`10.0.0.1`, `192.168.0.1`) both key to `0.1` and so compare equal. That is a
@@ -75,11 +77,15 @@ export const getCivitaiLinkBaseUrl = (): string | undefined => {
   try {
     resolvedHost = new URL(resolved).hostname.toLowerCase();
   } catch {
-    // A malformed NEXT_PUBLIC_CIVITAI_LINK is a CONFIG error, but it lands the
-    // caller in the same `undefined` branch as an unreachable domain and so gets
-    // reported as "not available on this domain". Say which it really is — the
-    // env var is only schema-validated as a URL in prod, so dev can hit this.
-    console.error(`Civitai Link: NEXT_PUBLIC_CIVITAI_LINK is not a valid URL (${base})`);
+    // Defence in depth on a branch that should be UNREACHABLE: `~/env/client`
+    // parses this var with `z.url()` and throws on failure in EVERY environment
+    // (the dev schema's `.optional()` widens presence, not format), and zod's
+    // `z.url()` is itself `new URL(...)` — the same constructor as here. So any
+    // value that reaches this line has already been proven to parse, and the
+    // `.civitai.com`→`.civitai.red` substitution cannot invalidate it.
+    // Deliberately no special-case reporting here: an earlier revision logged a
+    // "config error" on the theory that dev skips URL validation, which is
+    // false, so the log could never fire.
     return undefined;
   }
   if (registrableDomain(host) !== registrableDomain(resolvedHost)) return undefined;

--- a/src/components/CivitaiLink/civitai-link-api.ts
+++ b/src/components/CivitaiLink/civitai-link-api.ts
@@ -10,7 +10,16 @@ export type CivitaiLinkInstance = {
 };
 
 /**
- * Resolve the Civitai Link service base URL for the current host.
+ * Registrable domain (last two labels) of a hostname — `link.civitai.com` →
+ * `civitai.com`. Assumes a 2-label registrable domain, which is all we deploy;
+ * mirrors `cookieDomainForHost` in `~/server/auth/civ-cookie`, which is what
+ * decides the Domain the session cookie is actually set on.
+ */
+const registrableDomain = (hostname: string): string => hostname.split('.').slice(-2).join('.');
+
+/**
+ * Resolve the Civitai Link service base URL for the current host, or
+ * `undefined` when the service cannot authenticate this origin at all.
  *
  * `NEXT_PUBLIC_CIVITAI_LINK` (e.g. https://link.civitai.com) is baked at build
  * time and identical for the .com and .red builds. But the Link service
@@ -20,14 +29,46 @@ export type CivitaiLinkInstance = {
  * generation hangs forever (ClickUp 868k49796). Target the same-registrable-
  * domain link.civitai.red instead so the .civitai.red cookie is sent.
  *
+ * The `.red` rewrite only covers the one color we happen to run a Link host
+ * for. Every OTHER origin this app is served from hits the same cookie problem
+ * with no rewrite to save it, so refuse to build a URL we know cannot carry a
+ * credential:
+ *   - PR previews (`pr-N.civitaic.com`) — the session cookie is scoped to
+ *     `civitaic.com` and `SameSite=Lax`, so neither the preview's own cookie nor
+ *     a civitai.com cookie in the same browser is sent to link.civitai.com. A
+ *     preview's civ-token is also minted by a different auth hub than the one
+ *     the Link service verifies against, so it would be rejected even if it
+ *     arrived.
+ *   - `civitai.green` — no `link.civitai.green` host exists.
+ * Both surfaced as `Error loading instances: Civitai Link request failed
+ * (401 )`. Returning undefined lets callers disable the feature cleanly instead
+ * of firing a request that can never succeed.
+ *
  * Runs in both window and SharedWorker contexts (`globalThis.location`).
  */
 export const getCivitaiLinkBaseUrl = (): string | undefined => {
   const base = env.NEXT_PUBLIC_CIVITAI_LINK;
   if (!base) return base;
-  const host = (globalThis as { location?: { hostname?: string } }).location?.hostname?.toLowerCase();
-  const isRed = host === 'civitai.red' || (host?.endsWith('.civitai.red') ?? false);
-  return isRed ? base.replace('.civitai.com', '.civitai.red') : base;
+  const host = (
+    globalThis as { location?: { hostname?: string } }
+  ).location?.hostname?.toLowerCase();
+  // No location (SSR / node): keep the baked value. The same-domain check below
+  // is a CLIENT decision — deciding it server-side would make SSR and hydration
+  // disagree about whether the feature exists.
+  if (!host) return base;
+
+  const isRed = host === 'civitai.red' || host.endsWith('.civitai.red');
+  const resolved = isRed ? base.replace('.civitai.com', '.civitai.red') : base;
+
+  let resolvedHost: string;
+  try {
+    resolvedHost = new URL(resolved).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+  if (registrableDomain(host) !== registrableDomain(resolvedHost)) return undefined;
+
+  return resolved;
 };
 
 const clFetch = async (url: string, options: RequestInit = {}) => {

--- a/src/components/CivitaiLink/civitai-link-api.ts
+++ b/src/components/CivitaiLink/civitai-link-api.ts
@@ -11,9 +11,20 @@ export type CivitaiLinkInstance = {
 
 /**
  * Registrable domain (last two labels) of a hostname — `link.civitai.com` →
- * `civitai.com`. Assumes a 2-label registrable domain, which is all we deploy;
- * mirrors `cookieDomainForHost` in `~/server/auth/civ-cookie`, which is what
- * decides the Domain the session cookie is actually set on.
+ * `civitai.com`. Assumes a 2-label registrable domain, which is all we deploy.
+ *
+ * This is a COMPARISON KEY for "would one host's cookie reach the other?", not a
+ * cookie Domain, and it deliberately does NOT mirror `cookieDomainForHost`
+ * (`~/server/auth/civ-cookie`): that returns undefined (host-only cookie) for
+ * `localhost` and bare IPv4, where this returns the last two labels. Safe here
+ * because BOTH sides of the comparison go through this same function, so an
+ * identical host still compares equal and a host-only cookie is still shared —
+ * `localhost` page + `http://localhost:3000` Link host resolves normally.
+ *
+ * Known imprecision, deliberately not fixed: two DIFFERENT private IPv4 hosts
+ * (`10.0.0.1`, `192.168.0.1`) both key to `0.1` and so compare equal. That is a
+ * false ACCEPT, which merely degrades to the pre-existing behaviour of issuing
+ * the request and getting a 401 — never a false refusal of a working origin.
  */
 const registrableDomain = (hostname: string): string => hostname.split('.').slice(-2).join('.');
 
@@ -64,6 +75,11 @@ export const getCivitaiLinkBaseUrl = (): string | undefined => {
   try {
     resolvedHost = new URL(resolved).hostname.toLowerCase();
   } catch {
+    // A malformed NEXT_PUBLIC_CIVITAI_LINK is a CONFIG error, but it lands the
+    // caller in the same `undefined` branch as an unreachable domain and so gets
+    // reported as "not available on this domain". Say which it really is — the
+    // env var is only schema-validated as a URL in prod, so dev can hit this.
+    console.error(`Civitai Link: NEXT_PUBLIC_CIVITAI_LINK is not a valid URL (${base})`);
     return undefined;
   }
   if (registrableDomain(host) !== registrableDomain(resolvedHost)) return undefined;

--- a/src/components/CivitaiLink/civitai-link-api.ts
+++ b/src/components/CivitaiLink/civitai-link-api.ts
@@ -80,9 +80,13 @@ export const getCivitaiLinkBaseUrl = (): string | undefined => {
     // Defence in depth on a branch that should be UNREACHABLE: `~/env/client`
     // parses this var with `z.url()` and throws on failure in EVERY environment
     // (the dev schema's `.optional()` widens presence, not format), and zod's
-    // `z.url()` is itself `new URL(...)` — the same constructor as here. So any
-    // value that reaches this line has already been proven to parse, and the
-    // `.civitai.com`→`.civitai.red` substitution cannot invalidate it.
+    // `z.url()` is itself `new URL(...)` — the same constructor as here. The
+    // load-bearing step is that zod validates the TRIMMED string and writes that
+    // trimmed value BACK, so what lands in `env` is exactly the string it
+    // proved; without the write-back a leading NBSP or BOM would pass `z.url()`
+    // and still throw here. The `.civitai.com`→`.civitai.red` substitution
+    // cannot invalidate it either. KEEP THE CATCH: "unreachable" rests on that
+    // zod behaviour, not on anything this file controls.
     // Deliberately no special-case reporting here: an earlier revision logged a
     // "config error" on the theory that dev skips URL validation, which is
     // false, so the log could never fire.


### PR DESCRIPTION
## The bug

Civitai Link fails on every PR preview with:

```
Error loading instances: Civitai Link request failed (401 )
```

It works on production, which is what makes it look mysterious.

## Why

The preview build bakes `NEXT_PUBLIC_CIVITAI_LINK=https://link.civitai.com`, but a preview is served from `pr-N.civitaic.com`. The Link service authenticates **only** via the civitai session cookie, and that cookie is `Domain`-scoped to the page's registrable domain (`cookieDomainForHost`, `~/server/auth/civ-cookie`) and set `SameSite=Lax`. So on a preview:

- the preview's own cookie is scoped to `civitaic.com` and never reaches `link.civitai.com`;
- a `civitai.com` cookie sitting in the same browser is withheld anyway, because a cross-site `fetch()` is not a Lax-eligible request;
- and a preview's civ-token is minted by a different auth hub than the one the Link service verifies against, so it would be rejected even if it arrived.

The request is unauthenticated by construction, and 401s every time.

Two incidental details that made this hard to read:

- it surfaces as a *readable* 401 rather than a CORS error, because the Link service reflects any origin (`@fastify/cors` with `origin: true, credentials: true`);
- the empty `statusText` in `(401 )` is just HTTP/2.

## The fix

`getCivitaiLinkBaseUrl` already had a rewrite for exactly this failure mode on the `.com`/`.red` split — but it only covers the one other color we happen to run a Link host for. This generalises it: after resolving the host, refuse to return a URL whose registrable domain differs from the page's.

That also covers **`civitai.green`**, which has no `link.civitai.green` host and has been silently 401ing the same way. (Verified: `link.civitai.com` and `link.civitai.red` resolve and answer 200 on `/healthcheck`; `link.civitai.green` does not resolve.)

With no reachable Link host, `CivitaiLinkProvider` no longer spawns the SharedWorker at all — it would only produce the confusing 401 and a socket aimed at a host that will never accept us — and shows `Civitai Link is not available on this domain` instead.

The check lives in `getWorker` rather than in render, and `getCivitaiLinkBaseUrl` keeps returning the baked value when there is no `location` (SSR/node), so SSR and hydration cannot disagree about whether the feature exists. There are only three call sites and none is in a render path.

## Tests

Four new cases (PR preview host, bare `civitaic.com`, `civitai.green`, and the lookalike `civitai.red.evil.com`), plus a new `internal.civitai.com` case guarding against over-refusal.

- **Red at `origin/main`**: 4 failed / 6 passed, failing with the bug's exact signature — `expected 'https://link.civitai.com' to be undefined`.
- **Green here**: 10/10.

The six pre-existing cases passing in the same red run are the positive control that the suite is actually wired to the code.

`pnpm typecheck` is clean (0 errors). ESLint reports 0 errors across the three changed files; the single warning is the pre-existing `createContext<CivitaiLinkState>({} as any)`.

## Note on scope

This makes the failure honest rather than making Link *work* on previews. Genuinely working Link on a preview would need a Link service on `*.civitaic.com` that trusts the preview auth hub — a real deployment, not a config tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DAdpNNx6bpcp3F5ZNHbmo
