### PR TITLE
chore(bitdex): drop the eight BitDex ops write triggers (decommission phase 1)

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260901190000_drop_bitdex_write_triggers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260901190000_drop_bitdex_write_triggers/migration.sql
@@ -23,12 +23,64 @@
 -- NOT touched, and must not be: `image_sort_at_before` and `post_published_at_change`
 -- maintain the real `Image."sortAt"` column and are unrelated to BitDex despite
 -- sitting on the same two tables.
+--
+-- 🔴 Each DROP takes an ACCESS EXCLUSIVE lock on its table, and four of these are
+-- "Image", "Post", "ModelVersion" and "TagsOnImageNew" — among the hottest tables on
+-- the site. The drop itself is instant; ACQUIRING the lock is not. It waits behind
+-- every in-flight query on that table and, while it waits, queues in front of all new
+-- traffic to it, so one slow feed query turns this into a site-wide write stall.
+--
+-- Hence the per-statement `lock_timeout`: failing fast and retrying costs nothing,
+-- queueing costs the site. Same shape as the 20260827150000_thread_mute FK adds.
+--
+-- Apply these ONE STATEMENT AT A TIME and read each result. A multi-statement run
+-- through the postgres-query skill prints a formatter error and applies anyway, so its
+-- exit status cannot tell you whether the set is half-applied.
 
-DROP TRIGGER IF EXISTS bitdex_image_45edf6c8 ON "Image";
-DROP TRIGGER IF EXISTS bitdex_imageresourcenew_d84d15a8 ON "ImageResourceNew";
-DROP TRIGGER IF EXISTS bitdex_imagetechnique_ee2b2860 ON "ImageTechnique";
-DROP TRIGGER IF EXISTS bitdex_imagetool_f87e1fc4 ON "ImageTool";
-DROP TRIGGER IF EXISTS bitdex_model_a13d0fe3 ON "Model";
-DROP TRIGGER IF EXISTS bitdex_modelversion_22dd59b3 ON "ModelVersion";
-DROP TRIGGER IF EXISTS bitdex_post_54f0a619 ON "Post";
-DROP TRIGGER IF EXISTS bitdex_tagsonimagenew_bcbef3c3 ON "TagsOnImageNew";
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_image_45edf6c8 ON "Image";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_imageresourcenew_d84d15a8 ON "ImageResourceNew";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_imagetechnique_ee2b2860 ON "ImageTechnique";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_imagetool_f87e1fc4 ON "ImageTool";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_model_a13d0fe3 ON "Model";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_modelversion_22dd59b3 ON "ModelVersion";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_post_54f0a619 ON "Post";
+END $$;
+
+DO $$
+BEGIN
+  SET LOCAL lock_timeout = '5s';
+  DROP TRIGGER IF EXISTS bitdex_tagsonimagenew_bcbef3c3 ON "TagsOnImageNew";
+END $$;

--- a/packages/civitai-db-schema/prisma/migrations/20260901190000_drop_bitdex_write_triggers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260901190000_drop_bitdex_write_triggers/migration.sql
@@ -1,0 +1,34 @@
+-- BitDex decommission, phase 1 of 2: stop the ops write path.
+--
+-- BitDex is being replaced by a Postgres-backed single-table image index, and it
+-- already serves no traffic — the `bitdex-image-search` flag resolves to `off` for
+-- every segment. These eight triggers fire on write to eight of the hottest tables
+-- in the database and append rows to "BitdexOps" at ~3,219 rows/min (~4.6M/day,
+-- measured on the prod replica 2026-09-01).
+--
+-- Phase 1 drops only the triggers, not the functions or the tables. That is
+-- deliberate and the ordering is load-bearing:
+--
+--   * `trg_cleanup_bitdex_ops` on `bitdex_cursors` is what DELETES consumed ops, and
+--     it runs when the BitDex engine advances its cursor. It is left in place here so
+--     the ~152K-row backlog drains itself once these triggers stop feeding it.
+--   * Dropping these triggers while the engine is still up is safe: the engine simply
+--     sees no new ops. Tearing the engine down FIRST is what is unsafe — the drain
+--     stops and "BitdexOps" then grows without limit.
+--
+-- Phase 2 (separate migration, after the engine is torn down and the app code that
+-- calls bitdex_post_fanout_ops / bitdex_image_sortat_ops is removed) drops the
+-- functions, the cursor trigger, and the five bitdex_* tables.
+--
+-- NOT touched, and must not be: `image_sort_at_before` and `post_published_at_change`
+-- maintain the real `Image."sortAt"` column and are unrelated to BitDex despite
+-- sitting on the same two tables.
+
+DROP TRIGGER IF EXISTS bitdex_image_45edf6c8 ON "Image";
+DROP TRIGGER IF EXISTS bitdex_imageresourcenew_d84d15a8 ON "ImageResourceNew";
+DROP TRIGGER IF EXISTS bitdex_imagetechnique_ee2b2860 ON "ImageTechnique";
+DROP TRIGGER IF EXISTS bitdex_imagetool_f87e1fc4 ON "ImageTool";
+DROP TRIGGER IF EXISTS bitdex_model_a13d0fe3 ON "Model";
+DROP TRIGGER IF EXISTS bitdex_modelversion_22dd59b3 ON "ModelVersion";
+DROP TRIGGER IF EXISTS bitdex_post_54f0a619 ON "Post";
+DROP TRIGGER IF EXISTS bitdex_tagsonimagenew_bcbef3c3 ON "TagsOnImageNew";


### PR DESCRIPTION
Phase 1 of 2 of the BitDex decommission, approved by Justin 2026-09-01. **One new migration file, no code changes.**

## Why

BitDex is being replaced by a Postgres-backed single-table image index (ClickUp `868kzfj06`). It already serves **no traffic** — `bitdex-image-search` resolves to `off` for every segment including moderators and testers, and the code path requires `shadow`/`primary`.

Eight triggers fire on write to eight of the hottest tables in the database and append to `"BitdexOps"`:

| table | trigger |
|---|---|
| `Image` | `bitdex_image_45edf6c8` |
| `ImageResourceNew` | `bitdex_imageresourcenew_d84d15a8` |
| `ImageTechnique` | `bitdex_imagetechnique_ee2b2860` |
| `ImageTool` | `bitdex_imagetool_f87e1fc4` |
| `Model` | `bitdex_model_a13d0fe3` |
| `ModelVersion` | `bitdex_modelversion_22dd59b3` |
| `Post` | `bitdex_post_54f0a619` |
| `TagsOnImageNew` | `bitdex_tagsonimagenew_bcbef3c3` |

Measured on the prod replica 2026-09-01: **3,219 rows/min ≈ 4.6M rows/day** into `"BitdexOps"`.

## Ordering — this is the load-bearing part

`trg_cleanup_bitdex_ops` on `bitdex_cursors` is what **deletes** consumed ops, and it runs when the BitDex engine advances its cursor. It is **deliberately left in place** so the backlog drains itself once these triggers stop feeding it (currently 152,442 rows / 158 MB, oldest row 898 s, zero rows older than 1 h — the engine is actively consuming).

Dropping these triggers while the engine is still up is safe: the engine simply sees no new ops. **Tearing the engine down first is the unsafe order** — the drain stops and `"BitdexOps"` grows without limit on the primary. The infra-side teardown PR in `talos-infra` is being held until this has been applied and the table has drained.

## Not touched, on purpose

`image_sort_at_before` and `post_published_at_change` maintain the real `Image."sortAt"` column. They sit on two of the same tables and are **unrelated to BitDex**. I enumerated every trigger on `Image` and `Post` to make sure the split was clean rather than assuming it from the names.

## Phase 2 (separate PR, later)

After the engine is torn down and the app code calling `bitdex_post_fanout_ops` / `bitdex_image_sortat_ops` is removed: drop the 27 `bitdex_*` functions, `trg_cleanup_bitdex_ops`, and the five tables (`BitdexOps`, `bitdex_cursors`, `bitdex_fanout_capture`, `bitdex_post_publish_capture`, `bitdex_zm_log`).

## 🔴 Needs applying by hand

Migrations here are never auto-run. This wants applying to prod once civitai/flipt-state#80 has merged (which turns off the two BitDex cron jobs).

## Verification

Every `DROP` was checked against the **live prod catalog** by parsing the trigger and table names back out of the committed file — so the check reads what will actually run, not what I meant to write. All 8 found.

`DROP TRIGGER IF EXISTS` makes a typo a silent no-op, so that check needs a control: one wrong character in the trigger name reports `found=0`, one wrong character in the table name reports `found=0`, the correct pair reports `1`. It can fail.

**What I did not run, stated plainly:** `pnpm typecheck` / the unit suite. This worktree has no `node_modules` and populating it is a ~7-minute fleet-wide `pnpm install` on a shared box. The diff is a single `.sql` file that no TypeScript and no test imports. I read the three migration-reading guards (`app-collaborator.migration-shape`, `app-listing-mod-action.constants`, `app-listing-status.constants`) rather than executing them — each reads specifically named migration directories, so a new unrelated one cannot affect them. `drift-baseline.json` contains no `bitdex` entries, so no baseline regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYrq2ighNp2rABTAvpzhj9