### PR TITLE
feat(observability): time the external prompt-moderation call

### DIFF
--- a/src/server/integrations/__tests__/moderation.instrumentation.test.ts
+++ b/src/server/integrations/__tests__/moderation.instrumentation.test.ts
@@ -73,6 +73,20 @@ async function histSum(source: string, outcome: string) {
   );
 }
 
+/** Cumulative bucket value at boundary `le` (prom histogram buckets are cumulative). */
+async function histBucket(source: string, outcome: string, le: number) {
+  const vals = await samples(HIST);
+  return (
+    vals.find(
+      (v) =>
+        v.metricName === `${HIST}_bucket` &&
+        v.labels.source === source &&
+        v.labels.outcome === outcome &&
+        Number(v.labels.le) === le
+    )?.value ?? 0
+  );
+}
+
 async function skippedCount(source: string) {
   const vals = await samples(SKIPPED);
   return vals.find((v) => v.labels.source === source)?.value ?? 0;
@@ -252,6 +266,78 @@ describe('moderatePrompt instrumentation — failure paths', () => {
     expect(await histCount('preset', 'ok')).toBe(1);
     expect(await histCount('generate', 'error')).toBe(1);
   });
+});
+
+describe('a FIRED deadline is observed ABOVE the bucket boundary that equals the deadline', () => {
+  /**
+   * 🔴 THE ONE CLAIM THE BUCKET SET IS DESIGNED AROUND, DRIVEN END TO END.
+   *
+   * `external-moderation.metrics.test.ts` pins that the boundaries `5` and `7.5` both exist and
+   * that a 4.9 s and a 5.02 s observation land on opposite sides of `le=5`. But it hand-feeds those
+   * two numbers to `observeExternalModeration`, so it never runs the code that PRODUCES the number
+   * and cannot see a regression that makes a real fired deadline observe at or below 5 s. Every
+   * operator-facing sentence about this family — the help text's "those observations land just above
+   * the cap (le=7.5 at the 5s default), never in le=5" — is a claim about the produced value, not
+   * about the bucket list.
+   *
+   * WHY IT HOLDS TODAY, mechanically: `start` is taken in `moderatePrompt` BEFORE `withSpan`, and
+   * `AbortSignal.timeout(EXTERNAL_MODERATION_TIMEOUT_MS)` is constructed later, inside the callback.
+   * The deadline therefore starts counting strictly AFTER `start`, so elapsed-at-record is strictly
+   * greater than the deadline. Reorder those two — or clamp the recorded duration to the deadline,
+   * or start the timer inside the callback — and a capped call starts landing in `le=5`,
+   * indistinguishable from a gateway that answered just in time. That is the exact distinction the
+   * `timeout` outcome and the 5/7.5 boundary pair exist to draw.
+   *
+   * 🔴 THE WALL TIME IS THE POINT, AND IS PAID DELIBERATELY. `AbortSignal.timeout` is a Node-native
+   * timer that vitest's fake timers do not drive, and running this at a shortened deadline would
+   * test a boundary pair (`le=3`/`le=5`) that no deployment uses — the claim in the help text is
+   * about the 5 s DEFAULT. So this case really does park for ~5 s. It is one test.
+   *
+   * The assertion is written as `le=5 is EMPTY` rather than `le=7.5 is 1` on purpose: a loaded
+   * runner can stretch the observation past 7.5, which would make the tighter form flaky without
+   * making it stronger. "Never counted as sub-cap" is the whole property.
+   */
+  it('a real 5s abort lands strictly above le=5, never in it', async () => {
+    env.EXTERNAL_MODERATION_TIMEOUT_MS = 5000; // the production default, explicitly
+    // A gateway that never answers: only the abort can settle this promise.
+    vi.stubGlobal('fetch', (_url: string, opts: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () =>
+          reject((opts.signal as AbortSignal).reason ?? new Error('aborted'))
+        );
+      });
+    });
+
+    await expect(extModeration.moderatePrompt('a hanging prompt', 'generate')).rejects.toBeTruthy();
+
+    // Preconditions — without these the bucket assertion below could pass vacuously by observing
+    // nothing at all, or by landing on a different series.
+    expect(
+      await histCount('generate', 'timeout'),
+      'the fired deadline must be recorded exactly once, as outcome=timeout'
+    ).toBe(1);
+    expect(await histTotalCount()).toBe(1);
+
+    // 🔴 THE PIN. le is INCLUSIVE, so a duration of exactly 5.000 would count here.
+    expect(
+      await histBucket('generate', 'timeout', 5),
+      'a call cut by the 5s deadline must NOT be counted at or below le=5. If it is, a capped ' +
+        "call and a call that answered just under the cap share a bucket, the help text's " +
+        '"never in le=5" becomes false, and "is the gateway slow or are we cutting it off?" ' +
+        'stops being answerable — check that `start` is still taken BEFORE the AbortSignal is ' +
+        'constructed, and that the recorded duration is the real elapsed time, unclamped.'
+    ).toBe(0);
+    expect(
+      await histSum('generate', 'timeout'),
+      'the recorded duration must be the real elapsed wall time, which exceeds the deadline'
+    ).toBeGreaterThan(5);
+    // …and it must still land in a FINITE bucket rather than being swallowed by +Inf, which is
+    // the other half of why the top boundary sits at 20 and not at the cap.
+    expect(
+      await histBucket('generate', 'timeout', 20),
+      'a capped call must land in a finite bucket, not in +Inf alongside pathological ones'
+    ).toBe(1);
+  }, 20_000);
 });
 
 describe('moderatePrompt instrumentation — not configured', () => {

--- a/src/server/integrations/__tests__/moderation.instrumentation.test.ts
+++ b/src/server/integrations/__tests__/moderation.instrumentation.test.ts
@@ -268,37 +268,48 @@ describe('moderatePrompt instrumentation — failure paths', () => {
   });
 });
 
-describe('a FIRED deadline is observed ABOVE the bucket boundary that equals the deadline', () => {
+describe('a call cut by the REAL abort deadline, at the production default', () => {
+  /** The production default deadline, in seconds (`EXTERNAL_MODERATION_TIMEOUT_MS` = 5000). */
+  const CAP_SECONDS = 5;
+
   /**
-   * 🔴 THE ONE CLAIM THE BUCKET SET IS DESIGNED AROUND, DRIVEN END TO END.
+   * 🔴 WHAT THIS CASE PINS, AND THE CLAIM IT USED TO PIN AND NO LONGER DOES.
    *
-   * `external-moderation.metrics.test.ts` pins that the boundaries `5` and `7.5` both exist and
-   * that a 4.9 s and a 5.02 s observation land on opposite sides of `le=5`. But it hand-feeds those
-   * two numbers to `observeExternalModeration`, so it never runs the code that PRODUCES the number
-   * and cannot see a regression that makes a real fired deadline observe at or below 5 s. Every
-   * operator-facing sentence about this family — the help text's "those observations land just above
-   * the cap (le=7.5 at the 5s default), never in le=5" — is a claim about the produced value, not
-   * about the bucket list.
+   * It used to assert "a real 5s abort lands strictly above le=5, never in it" — i.e. that a capped
+   * call is identifiable by which BUCKET it falls in. That assertion is deleted because the claim is
+   * FALSE, not because it was inconvenient. Measured at the commit that introduced it, isolated and
+   * unloaded, it failed 2 of 8 and 2 of 10 runs, with wall time identical (5.23-5.27 s) across
+   * passing and failing runs — a boundary problem, not a load flake.
    *
-   * WHY IT HOLDS TODAY, mechanically: `start` is taken in `moderatePrompt` BEFORE `withSpan`, and
-   * `AbortSignal.timeout(EXTERNAL_MODERATION_TIMEOUT_MS)` is constructed later, inside the callback.
-   * The deadline therefore starts counting strictly AFTER `start`, so elapsed-at-record is strictly
-   * greater than the deadline. Reorder those two — or clamp the recorded duration to the deadline,
-   * or start the timer inside the callback — and a capped call starts landing in `le=5`,
-   * indistinguishable from a gateway that answered just in time. That is the exact distinction the
-   * `timeout` outcome and the 5/7.5 boundary pair exist to draw.
+   * THE MECHANISM. `le` is INCLUSIVE. `AbortSignal.timeout()` fires off a libuv timer while the
+   * recorded duration is a `performance.now()` delta, and those two clocks disagree by a small fixed
+   * offset — so the elapsed time measured at the moment the deadline fires can land just BELOW the
+   * deadline and be counted in `le=5`. Directly measured on one host: 3/60 samples at a 100 ms
+   * deadline and 3/8 at 5000 ms came in EARLY, worst case 0.63 ms; the same magnitude at both
+   * deadlines, i.e. a constant offset rather than a clock-rate difference. Taking `start` before the
+   * `AbortSignal` is constructed (which `moderatePrompt` does) biases the other way by a few
+   * microseconds — nowhere near enough to win that race.
    *
-   * 🔴 THE WALL TIME IS THE POINT, AND IS PAID DELIBERATELY. `AbortSignal.timeout` is a Node-native
-   * timer that vitest's fake timers do not drive, and running this at a shortened deadline would
-   * test a boundary pair (`le=3`/`le=5`) that no deployment uses — the claim in the help text is
-   * about the 5 s DEFAULT. So this case really does park for ~5 s. It is one test.
+   * AND IT IS NOT FIXABLE BY MOVING THE BOUNDARY. Two calls, one that answered a microsecond under
+   * the cap and one cut BY the cap, are arbitrarily close in duration; no bucket edge lies between
+   * them. The deadline is env-tunable (`.min(100).max(60000)`), so no fixed bucket set can hold any
+   * boundary relationship to it across deployments either. `outcome="timeout"` separates the two
+   * populations perfectly and deterministically — it is a branch on the abort error
+   * (`isAbortDeadlineError`), never on the duration — and it always did. The bucket boundary was
+   * never load-bearing for that question, which is why the help text no longer claims it is.
    *
-   * The assertion is written as `le=5 is EMPTY` rather than `le=7.5 is 1` on purpose: a loaded
-   * runner can stretch the observation past 7.5, which would make the tighter form flaky without
-   * making it stronger. "Never counted as sub-cap" is the whole property.
+   * SO WHAT IS LEFT HERE IS WHAT IS ACTUALLY TRUE AND STABLE: a call cut by the deadline is recorded
+   * exactly once, classified `timeout` (not `error`), carrying the real parked wall time, in a
+   * FINITE bucket. `external-moderation.metrics.test.ts` pins the bucket SET by hand-feeding numbers
+   * and so cannot see any of this; the two files together are the claim.
+   *
+   * 🔴 THE WALL TIME IS THE POINT AND IS PAID DELIBERATELY. `AbortSignal.timeout` is a Node-native
+   * timer that vitest's fake timers do not drive, so the park is real. Running it at a shortened
+   * deadline would exercise a value no deployment uses; at 5000 it drives the configured production
+   * default, which is what makes the finite-bucket assertion below meaningful. It is one test.
    */
-  it('a real 5s abort lands strictly above le=5, never in it', async () => {
-    env.EXTERNAL_MODERATION_TIMEOUT_MS = 5000; // the production default, explicitly
+  it('is recorded once as outcome=timeout, with the real parked duration, in a finite bucket', async () => {
+    env.EXTERNAL_MODERATION_TIMEOUT_MS = CAP_SECONDS * 1000; // the production default, explicitly
     // A gateway that never answers: only the abort can settle this promise.
     vi.stubGlobal('fetch', (_url: string, opts: RequestInit) => {
       return new Promise((_resolve, reject) => {
@@ -310,29 +321,48 @@ describe('a FIRED deadline is observed ABOVE the bucket boundary that equals the
 
     await expect(extModeration.moderatePrompt('a hanging prompt', 'generate')).rejects.toBeTruthy();
 
-    // Preconditions — without these the bucket assertion below could pass vacuously by observing
-    // nothing at all, or by landing on a different series.
+    // 🔴 THE CLASSIFICATION IS THE WHOLE SEPARATOR NOW, so it is pinned from both sides: the
+    // timeout series moved, and the error series did not. Asserting only the first would still pass
+    // if a fired deadline were ALSO counted as an error.
     expect(
       await histCount('generate', 'timeout'),
-      'the fired deadline must be recorded exactly once, as outcome=timeout'
+      'a call cut by the abort deadline must be recorded exactly once as outcome=timeout — that ' +
+        'label is the only thing that distinguishes a capped call from a slow one, since their ' +
+        'durations are arbitrarily close and no bucket edge separates them'
     ).toBe(1);
-    expect(await histTotalCount()).toBe(1);
-
-    // 🔴 THE PIN. le is INCLUSIVE, so a duration of exactly 5.000 would count here.
     expect(
-      await histBucket('generate', 'timeout', 5),
-      'a call cut by the 5s deadline must NOT be counted at or below le=5. If it is, a capped ' +
-        "call and a call that answered just under the cap share a bucket, the help text's " +
-        '"never in le=5" becomes false, and "is the gateway slow or are we cutting it off?" ' +
-        'stops being answerable — check that `start` is still taken BEFORE the AbortSignal is ' +
-        'constructed, and that the recorded duration is the real elapsed time, unclamped.'
+      await histCount('generate', 'error'),
+      'a fired deadline must NOT also land on outcome=error: the two call for opposite responses ' +
+        '(re-size the deadline vs. fix the gateway), so merging them makes the label useless'
     ).toBe(0);
     expect(
-      await histSum('generate', 'timeout'),
-      'the recorded duration must be the real elapsed wall time, which exceeds the deadline'
-    ).toBeGreaterThan(5);
-    // …and it must still land in a FINITE bucket rather than being swallowed by +Inf, which is
-    // the other half of why the top boundary sits at 20 and not at the cap.
+      await histTotalCount(),
+      'exactly one observation across EVERY series — a fired deadline reaches the recorder through ' +
+        'the catch path only, never additionally through a finally'
+    ).toBe(1);
+
+    // The recorded duration must be the REAL parked wall time. Expressed as a band around the
+    // deadline rather than a strict `> CAP`: the clock offset documented above means a genuine
+    // fired deadline legitimately measures a fraction of a millisecond short, so `> 5` is the
+    // flaky assertion this case used to carry, in another spelling. The floor is 50 ms of slack —
+    // ~80x the worst offset measured (0.63 ms), and load can only push this number UP (a jammed
+    // event loop makes the abort land late, never early), so the floor is not load-exposed.
+    const seconds = await histSum('generate', 'timeout');
+    expect(
+      seconds,
+      `the recorded duration must be the real elapsed wall time of the full ${CAP_SECONDS}s park; ` +
+        'a placeholder, a zero, or a timer started after the request was issued reads far below this'
+    ).toBeGreaterThanOrEqual(CAP_SECONDS - 0.05);
+    expect(
+      seconds,
+      'the duration must be recorded in SECONDS, not milliseconds — a ms-valued observation reads ' +
+        `~${CAP_SECONDS * 1000} here and would silently place every call in +Inf`
+    ).toBeLessThan(CAP_SECONDS * 2);
+
+    // 🔴 THE BUCKET PROPERTY THAT IS SOUND, driven end to end at the real cap: a capped call must
+    // land in a FINITE bucket. This one does not depend on any clock — it is why the top finite
+    // boundary sits at 20 and not at the deadline. If it ever fails, every capped call is in +Inf
+    // alongside every pathological one and the tail is unreadable.
     expect(
       await histBucket('generate', 'timeout', 20),
       'a capped call must land in a finite bucket, not in +Inf alongside pathological ones'

--- a/src/server/integrations/__tests__/moderation.instrumentation.test.ts
+++ b/src/server/integrations/__tests__/moderation.instrumentation.test.ts
@@ -32,6 +32,7 @@ const env = vi.hoisted(() => ({
 }));
 vi.mock('~/env/server', () => ({ env }));
 
+import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
 
 const HIST = 'civitai_app_external_moderation_duration_seconds';
@@ -109,6 +110,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
   env.EXTERNAL_MODERATION_ENDPOINT = 'https://moderation.example/v1/moderations';
   env.EXTERNAL_MODERATION_TOKEN = 'tok';
+  // The MOCK's baseline, not a pin on the schema default: no case that leaves this value alone ever
+  // reaches the deadline, so nothing here depends on the number. The one case that does depend on
+  // it sets it from the derived `CAP_SECONDS` instead.
   env.EXTERNAL_MODERATION_TIMEOUT_MS = 5000;
   env.EXTERNAL_MODERATION_CATEGORIES = undefined;
 });
@@ -269,8 +273,15 @@ describe('moderatePrompt instrumentation — failure paths', () => {
 });
 
 describe('a call cut by the REAL abort deadline, at the production default', () => {
-  /** The production default deadline, in seconds (`EXTERNAL_MODERATION_TIMEOUT_MS` = 5000). */
-  const CAP_SECONDS = 5;
+  /**
+   * The production default deadline, in SECONDS, DERIVED from the schema that defines it
+   * (`EXTERNAL_MODERATION_TIMEOUT_MS`, `.catch(5000)`) rather than written here as a literal —
+   * `.parse(undefined)` yields the same fallback production gets when the env var is absent. This
+   * case sets the env mock FROM this value, so deriving it keeps the deadline actually exercised in
+   * step with the configured default instead of pinning whatever number was true when it was
+   * written. Same derivation, same reasoning, in `external-moderation.metrics.test.ts`.
+   */
+  const CAP_SECONDS = serverSchema.shape.EXTERNAL_MODERATION_TIMEOUT_MS.parse(undefined) / 1000;
 
   /**
    * 🔴 WHAT THIS CASE PINS, AND THE CLAIM IT USED TO PIN AND NO LONGER DOES.
@@ -303,6 +314,15 @@ describe('a call cut by the REAL abort deadline, at the production default', () 
    * FINITE bucket. `external-moderation.metrics.test.ts` pins the bucket SET by hand-feeding numbers
    * and so cannot see any of this; the two files together are the claim.
    *
+   * 🔴 "THE REAL PARKED WALL TIME" IS TWO CLAIMS, AND ONE OF THEM WAS MISSING FOR A ROUND. A floor
+   * at `CAP - 0.05` pins the MAGNITUDE but carries 50 ms of slack, so it cannot see a systematic
+   * bias below that — measured: subtracting 5 ms from every observation left this file 13/13 green
+   * while the assertion's own message claimed it caught exactly that ("a timer started after the
+   * request was issued reads far below this" — it does not; `AbortSignal.timeout` is constructed at
+   * fetch time, so a `start` taken after it still measures ~5000 ms). The floor is kept, its message
+   * is now scoped to what it checks, and a second assertion compares the recorded duration against
+   * this test's OWN `performance.now()` window. See the comments on both.
+   *
    * 🔴 THE WALL TIME IS THE POINT AND IS PAID DELIBERATELY. `AbortSignal.timeout` is a Node-native
    * timer that vitest's fake timers do not drive, so the park is real. Running it at a shortened
    * deadline would exercise a value no deployment uses; at 5000 it drives the configured production
@@ -319,7 +339,14 @@ describe('a call cut by the REAL abort deadline, at the production default', () 
       });
     });
 
+    const t0 = performance.now();
     await expect(extModeration.moderatePrompt('a hanging prompt', 'generate')).rejects.toBeTruthy();
+    // Read the test's OWN clock the instant the call settles — ahead of the registry reads below,
+    // so those stay out of the window. What the window DOES contain beyond the timed region is
+    // enumerated with the assertion that uses it. Both this and the production timer are
+    // `performance.now()` deltas on the same clock, which is what makes that comparison a
+    // subtraction rather than a race between two clocks.
+    const testObservedSeconds = (performance.now() - t0) / 1000;
 
     // 🔴 THE CLASSIFICATION IS THE WHOLE SEPARATOR NOW, so it is pinned from both sides: the
     // timeout series moved, and the error series did not. Asserting only the first would still pass
@@ -341,23 +368,61 @@ describe('a call cut by the REAL abort deadline, at the production default', () 
         'the catch path only, never additionally through a finally'
     ).toBe(1);
 
-    // The recorded duration must be the REAL parked wall time. Expressed as a band around the
-    // deadline rather than a strict `> CAP`: the clock offset documented above means a genuine
-    // fired deadline legitimately measures a fraction of a millisecond short, so `> 5` is the
-    // flaky assertion this case used to carry, in another spelling. The floor is 50 ms of slack —
-    // ~80x the worst offset measured (0.63 ms), and load can only push this number UP (a jammed
-    // event loop makes the abort land late, never early), so the floor is not load-exposed.
+    // The recorded duration must be the REAL parked wall time. That is pinned by TWO assertions
+    // below, which cover different failures and are both needed:
+    //   · MAGNITUDE (`>= CAP - 0.05`) — the call parked for the configured deadline rather than
+    //     returning a placeholder or a constant. Expressed as a band rather than a strict `> CAP`
+    //     because the clock offset documented above means a genuine fired deadline legitimately
+    //     measures a fraction of a millisecond short; `> 5` is the flaky assertion this case used to
+    //     carry, in another spelling.
+    //   · CLOCK CONSISTENCY (`>= testObserved - 0.001`) — the recorder measured the whole window,
+    //     not merely a number of roughly the right size. The magnitude floor's own 50 ms of slack
+    //     makes it blind to any systematic bias below that, which is a real class: a 5 ms bias
+    //     applied to every observation passed this file 13/13 while it carried only the floor.
     const seconds = await histSum('generate', 'timeout');
     expect(
       seconds,
-      `the recorded duration must be the real elapsed wall time of the full ${CAP_SECONDS}s park; ` +
-        'a placeholder, a zero, or a timer started after the request was issued reads far below this'
+      `the recorded duration must have the MAGNITUDE of the full ${CAP_SECONDS}s park — a ` +
+        'placeholder, a zero, or a constant reads far below this. Its 50 ms of slack is what makes ' +
+        'it immune to the clock offset documented above (~80x the worst measured 0.63 ms) and load ' +
+        'can only push the number UP, so it is not load-exposed. That slack is also its LIMIT: a ' +
+        'systematic under-measurement smaller than 50 ms passes here, which is what the ' +
+        'clock-consistency assertion below exists to catch'
     ).toBeGreaterThanOrEqual(CAP_SECONDS - 0.05);
     expect(
       seconds,
       'the duration must be recorded in SECONDS, not milliseconds — a ms-valued observation reads ' +
         `~${CAP_SECONDS * 1000} here and would silently place every call in +Inf`
     ).toBeLessThan(CAP_SECONDS * 2);
+
+    // 🔴 THE GUARD AGAINST A SMALL SYSTEMATIC BIAS, which the magnitude floor above cannot see.
+    // The recorder and this test both read `performance.now()`, so the recorded duration must
+    // account for essentially the WHOLE window this test measured around the call — the only
+    // difference is the handful of statements outside the timed region (the source clamp and the
+    // prompt preparation before `start`; the histogram observe, the span attribute and the promise
+    // unwinding after the last read).
+    //
+    // Measured on this host over 12 runs, that residue was 0.10-0.18 ms. The 1 ms bound is ~5.7x
+    // the worst of those, and it fails on any bias at the milliseconds scale: a timer started a few
+    // ms late, or a constant subtracted from the delta, moves this by exactly that amount.
+    //
+    // ⚠️ UNLIKE THE MAGNITUDE FLOOR ABOVE, THIS ONE IS LOAD-EXPOSED, and in the honest direction: a
+    // jammed event loop delays the post-settle path more than it delays the recorder's own read, so
+    // heavy load grows the residue. If this ever fails while the recorder is demonstrably correct,
+    // widen the bound and say by how much — do not delete it, and do not restate the residue figure
+    // above without re-measuring it.
+    const CLOCK_CONSISTENCY_SLACK_SECONDS = 0.001;
+    expect(
+      seconds,
+      `the recorded duration must cover the whole ${(testObservedSeconds * 1000).toFixed(1)}ms ` +
+        'window this test measured around the call, to within ' +
+        `${CLOCK_CONSISTENCY_SLACK_SECONDS * 1000}ms — it read ` +
+        `${((testObservedSeconds - seconds) * 1000).toFixed(3)}ms short. Both numbers are ` +
+        '`performance.now()` deltas on one clock, so a gap this size is not a race: it is the ' +
+        'recorder systematically under-measuring (a timer started after the request was issued, or ' +
+        'a constant subtracted from the delta). The 50 ms magnitude floor above cannot see a bias ' +
+        'this small'
+    ).toBeGreaterThanOrEqual(testObservedSeconds - CLOCK_CONSISTENCY_SLACK_SECONDS);
 
     // 🔴 THE BUCKET PROPERTY THAT IS SOUND, driven end to end at the real cap: a capped call must
     // land in a FINITE bucket. This one does not depend on any clock — it is why the top finite

--- a/src/server/integrations/__tests__/moderation.instrumentation.test.ts
+++ b/src/server/integrations/__tests__/moderation.instrumentation.test.ts
@@ -337,7 +337,12 @@ describe('a FIRED deadline is observed ABOVE the bucket boundary that equals the
       await histBucket('generate', 'timeout', 20),
       'a capped call must land in a finite bucket, not in +Inf alongside pathological ones'
     ).toBe(1);
-  }, 20_000);
+    // 🔴 NO PER-TEST TIMEOUT HERE ON PURPOSE. This test parks 5s of REAL time, so it is the one
+    // most exposed to a tight bound — and the `unit` project's `testTimeout: 60000` exists
+    // precisely because a shorter one produced "a PASS→FAIL that tracked CI load, not code"
+    // (see the comment on that setting in `vitest.config.mts`). A third argument here would opt
+    // this test DOWN out of that protection. Leave it on the project default.
+  });
 });
 
 describe('moderatePrompt instrumentation — not configured', () => {

--- a/src/server/integrations/__tests__/moderation.instrumentation.test.ts
+++ b/src/server/integrations/__tests__/moderation.instrumentation.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Instrumentation contract for `extModeration.moderatePrompt`.
+ *
+ * WHY these exist: the call is an outbound HTTP request to a third-party classifier, it runs inline
+ * and serially on the generation submission path, it is bounded by a 5 s abort deadline, and it is
+ * FAIL-SOFT — the caller catches, logs one Axiom line and proceeds with `flagged:false`. That last
+ * property is what made it invisible: a fully-down moderation gateway and a healthy one produce the
+ * same user-visible behaviour and the same (absent) metrics, so "how long does this take", "how
+ * often does it fail" and "how often does it hit its cap" had no answers at all.
+ *
+ * These tests read back the REAL prom-client registry (`@civitai/telemetry/client` is not stubbed by
+ * src/__tests__/setup.ts, which replaces only `~/server/prom/client`), so they assert what is
+ * actually recorded on the registry /api/metrics scrapes rather than that we called our own wrapper.
+ *
+ * 🔴 THE ASSERTION THAT MATTERS MOST IS THE TOTAL COUNT. Every failure path here is reachable two
+ * ways (a `finally` plus a `catch`, or an observation in both the wrapper and the callee), and a
+ * double-counted hot-path histogram is worse than no histogram — it inflates the very rate the
+ * metric exists to produce while looking perfectly healthy. So each case asserts the count across
+ * EVERY series, not only the one it expects to move.
+ */
+import promClient from 'prom-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable env mock so each test can set the timeout / endpoint. `vi.hoisted` so it exists before
+// the hoisted `vi.mock` factory references it. Overrides the global stub in src/__tests__/setup.ts.
+const env = vi.hoisted(() => ({
+  EXTERNAL_MODERATION_ENDPOINT: 'https://moderation.example/v1/moderations' as string,
+  EXTERNAL_MODERATION_TOKEN: 'tok' as string,
+  EXTERNAL_MODERATION_THRESHOLD: 0.5,
+  EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
+  EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
+}));
+vi.mock('~/env/server', () => ({ env }));
+
+import { extModeration } from '~/server/integrations/moderation';
+
+const HIST = 'civitai_app_external_moderation_duration_seconds';
+const SKIPPED = 'civitai_app_external_moderation_skipped_total';
+
+type Sample = { metricName?: string; labels: Record<string, string | number>; value: number };
+
+async function samples(name: string): Promise<Sample[]> {
+  const metric = promClient.register.getSingleMetric(name);
+  if (!metric) throw new Error(`metric ${name} is not registered`);
+  return (await metric.get()).values as Sample[];
+}
+
+async function histCount(source: string, outcome: string) {
+  const vals = await samples(HIST);
+  return (
+    vals.find(
+      (v) =>
+        v.metricName === `${HIST}_count` &&
+        v.labels.source === source &&
+        v.labels.outcome === outcome
+    )?.value ?? 0
+  );
+}
+
+/** Observations across EVERY (source, outcome) series — the double-count guard. */
+async function histTotalCount() {
+  const vals = await samples(HIST);
+  return vals.filter((v) => v.metricName === `${HIST}_count`).reduce((acc, v) => acc + v.value, 0);
+}
+
+async function histSum(source: string, outcome: string) {
+  const vals = await samples(HIST);
+  return (
+    vals.find(
+      (v) =>
+        v.metricName === `${HIST}_sum` && v.labels.source === source && v.labels.outcome === outcome
+    )?.value ?? 0
+  );
+}
+
+async function skippedCount(source: string) {
+  const vals = await samples(SKIPPED);
+  return vals.find((v) => v.labels.source === source)?.value ?? 0;
+}
+
+const okResponse = (flagged: boolean) => ({
+  ok: true,
+  json: async () => ({
+    results: [{ flagged, category_scores: {}, categories: {} }],
+  }),
+});
+
+beforeEach(() => {
+  promClient.register.getSingleMetric(HIST)?.reset();
+  promClient.register.getSingleMetric(SKIPPED)?.reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  env.EXTERNAL_MODERATION_ENDPOINT = 'https://moderation.example/v1/moderations';
+  env.EXTERNAL_MODERATION_TOKEN = 'tok';
+  env.EXTERNAL_MODERATION_TIMEOUT_MS = 5000;
+  env.EXTERNAL_MODERATION_CATEGORIES = undefined;
+});
+
+describe('moderatePrompt instrumentation — success path', () => {
+  it('records exactly one observation with outcome=ok on the declared source', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse(false))
+    );
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+
+    expect(await histCount('generate', 'ok')).toBe(1);
+    expect(await histTotalCount()).toBe(1);
+  });
+
+  it('records the WALL-CLOCK duration, not a placeholder', async () => {
+    // A classifier that takes ~30ms. Asserting a floor (rather than ">= 0") is what separates a
+    // real timer from an implementation that records a constant: a hardcoded 0 passes ">= 0".
+    vi.stubGlobal('fetch', async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      return okResponse(false);
+    });
+
+    await extModeration.moderatePrompt('a cat', 'generate');
+
+    const seconds = await histSum('generate', 'ok');
+    expect(seconds).toBeGreaterThanOrEqual(0.02);
+    // Sanity ceiling: this catches a ms/seconds unit inversion — recording 30 (ms) instead of
+    // 0.03 (s) sails past the floor above. Set well clear of both sides (a 30ms sleep cannot
+    // stretch to 5s even on a loaded runner; a ms-valued observation is >= 30) so the guard is
+    // decided by the unit, not by scheduling noise.
+    expect(seconds).toBeLessThan(5);
+  });
+
+  it('defaults an undeclared caller to source=other rather than to generate', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse(false))
+    );
+
+    await extModeration.moderatePrompt('a cat');
+
+    expect(await histCount('other', 'ok')).toBe(1);
+    expect(await histCount('generate', 'ok')).toBe(0);
+  });
+
+  it('clamps a source outside the vocabulary to other', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse(false))
+    );
+
+    await extModeration.moderatePrompt('a cat', 'generateFromGraph' as never);
+
+    expect(await histCount('other', 'ok')).toBe(1);
+    expect(await histCount('generateFromGraph', 'ok')).toBe(0);
+  });
+
+  it('does not change the verdict it returns', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse(true))
+    );
+
+    const r = await extModeration.moderatePrompt('x', 'generate');
+
+    expect(r.flagged).toBe(true);
+  });
+});
+
+describe('moderatePrompt instrumentation — failure paths', () => {
+  it('records outcome=error WITH a duration when the classifier returns a non-2xx, and still throws', async () => {
+    vi.stubGlobal('fetch', async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      return {
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: async () => 'upstream connect error',
+      };
+    });
+
+    await expect(extModeration.moderatePrompt('x', 'generate')).rejects.toThrow(/503/);
+
+    expect(await histCount('generate', 'error')).toBe(1);
+    // A failed call still consumed wall time on the generation path — the whole point of labelling
+    // by outcome rather than dropping failures is that their latency is not free.
+    expect(await histSum('generate', 'error')).toBeGreaterThanOrEqual(0.02);
+    expect(await histCount('generate', 'timeout')).toBe(0);
+    expect(await histTotalCount()).toBe(1);
+  });
+
+  it('records outcome=timeout — NOT error — when the abort deadline fires', async () => {
+    env.EXTERNAL_MODERATION_TIMEOUT_MS = 25;
+    // A gateway that never answers: only the abort resolves this.
+    vi.stubGlobal('fetch', (_url: string, opts: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () =>
+          reject((opts.signal as AbortSignal).reason ?? new Error('aborted'))
+        );
+      });
+    });
+
+    await expect(extModeration.moderatePrompt('a hanging prompt', 'generate')).rejects.toBeTruthy();
+
+    expect(await histCount('generate', 'timeout')).toBe(1);
+    expect(await histCount('generate', 'error')).toBe(0);
+    expect(await histTotalCount()).toBe(1);
+  });
+
+  it('classifies a network-level fetch rejection as error, not timeout', async () => {
+    vi.stubGlobal('fetch', async () => {
+      throw new TypeError('fetch failed');
+    });
+
+    await expect(extModeration.moderatePrompt('x', 'generate')).rejects.toThrow(/fetch failed/);
+
+    expect(await histCount('generate', 'error')).toBe(1);
+    expect(await histCount('generate', 'timeout')).toBe(0);
+  });
+
+  it('records exactly one observation when the caller wraps the call in its own fail-soft catch', async () => {
+    // The real shape at the call site (promptAuditing.auditPromptServer): the rejection is caught
+    // and swallowed. A `finally`-based recorder alongside a `catch`-based one would show 2 here
+    // while every other assertion in this file still passed.
+    vi.stubGlobal('fetch', async () => {
+      throw new Error('External moderation failed: 500 Internal Server Error');
+    });
+
+    const result = await extModeration
+      .moderatePrompt('x', 'generate')
+      .catch(() => ({ flagged: false, categories: [] as string[] }));
+
+    expect(result).toEqual({ flagged: false, categories: [] });
+    expect(await histTotalCount()).toBe(1);
+  });
+
+  it('records one observation per call across a mixed sequence — never more', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse(false))
+    );
+    await extModeration.moderatePrompt('a', 'generate');
+    await extModeration.moderatePrompt('b', 'preset');
+
+    vi.stubGlobal('fetch', async () => {
+      throw new Error('boom');
+    });
+    await extModeration.moderatePrompt('c', 'generate').catch(() => null);
+
+    expect(await histTotalCount()).toBe(3);
+    expect(await histCount('generate', 'ok')).toBe(1);
+    expect(await histCount('preset', 'ok')).toBe(1);
+    expect(await histCount('generate', 'error')).toBe(1);
+  });
+});
+
+describe('moderatePrompt instrumentation — not configured', () => {
+  it('counts the short-circuit separately and leaves the duration histogram untouched', async () => {
+    env.EXTERNAL_MODERATION_ENDPOINT = '' as unknown as string;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const r = await extModeration.moderatePrompt('x', 'generate');
+
+    expect(r).toEqual({ flagged: false, categories: [] });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await skippedCount('generate')).toBe(1);
+    // Folding a no-I/O call into the latency histogram would drag every quantile toward zero.
+    expect(await histTotalCount()).toBe(0);
+  });
+
+  it('also short-circuits (and counts) when only the token is missing', async () => {
+    env.EXTERNAL_MODERATION_TOKEN = '' as unknown as string;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await extModeration.moderatePrompt('x', 'remixAudit');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await skippedCount('remixAudit')).toBe(1);
+    expect(await histTotalCount()).toBe(0);
+  });
+});

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -1,4 +1,12 @@
 import { env } from '~/env/server';
+import {
+  clampExternalModerationSource,
+  isAbortDeadlineError,
+  observeExternalModeration,
+  recordExternalModerationSkipped,
+  type ExternalModerationSource,
+} from '~/server/prom/external-moderation.metrics';
+import { setActiveSpanAttributes, withSpan } from '~/server/utils/otel-helpers';
 
 const falsePositiveTriggers = Object.entries({
   '\\d*girl': 'woman',
@@ -15,58 +23,126 @@ function removeFalsePositiveTriggers(prompt: string) {
   return prompt;
 }
 
-async function moderatePrompt(prompt: string): Promise<{ flagged: false; categories: string[] }> {
-  if (!env.EXTERNAL_MODERATION_TOKEN || !env.EXTERNAL_MODERATION_ENDPOINT)
+/**
+ * Call the external prompt classifier.
+ *
+ * `source` is OBSERVABILITY ONLY — it selects the `source` label on
+ * `civitai_app_external_moderation_duration_seconds` and changes nothing about the request, the
+ * deadline or the verdict. It is optional and defaults to `other` so an undeclared caller can never
+ * inflate the `generate` population; see `external-moderation.metrics.ts` for what each value means.
+ */
+async function moderatePrompt(
+  prompt: string,
+  source: ExternalModerationSource = 'other'
+): Promise<{ flagged: false; categories: string[] }> {
+  // Clamp once, here, so every instrument below shares one bounded value regardless of what a
+  // spread-built options object handed us.
+  const metricSource = clampExternalModerationSource(source);
+
+  // Read once, into locals, so the guard below narrows them for the fetch. The fetch now runs inside
+  // a callback, and TS cannot carry a narrowing of a mutable object property across a closure
+  // boundary — the values themselves are identical to what the straight-line version read.
+  const endpoint = env.EXTERNAL_MODERATION_ENDPOINT;
+  const token = env.EXTERNAL_MODERATION_TOKEN;
+
+  if (!token || !endpoint) {
+    // Counted, not observed on the histogram: no request is issued, so this is not a latency
+    // sample. Recorded before the span opens — a deployment with the integration switched off
+    // should pay nothing beyond a counter increment.
+    recordExternalModerationSkipped(metricSource);
     return { flagged: false, categories: [] };
+  }
 
   const preparedPrompt = removeFalsePositiveTriggers(prompt);
-  // Hard timeout via AbortSignal. Node's undici `fetch` has NO request timeout by
-  // default (~300s headers/body), so a slow/hanging moderation gateway would park
-  // this await — and since it runs inline on every generation submission
-  // (`generateFromGraph` → `auditPromptServer`), that parks the whole tRPC request
-  // off-CPU for minutes (observed ~194s api-primary tail during a moderation 503/504
-  // wave). The call is already FAIL-SOFT (the caller catches and proceeds with
-  // flagged:false) and the local regex audit still gates regardless, so aborting a
-  // slow call only drops the secondary external layer for that one request — it does
-  // not weaken the primary block. Abort → throws → caller's existing catch fails soft.
-  const res = await fetch(env.EXTERNAL_MODERATION_ENDPOINT, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${env.EXTERNAL_MODERATION_TOKEN}`,
-    },
-    body: JSON.stringify({
-      input: preparedPrompt,
-      model: 'omni-moderation-latest',
-    }),
-    signal: AbortSignal.timeout(env.EXTERNAL_MODERATION_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    let message = `External moderation failed: ${res.status} ${res.statusText}`;
-    try {
-      const body = await res.text();
-      message += `\n${body}`;
-    } catch (err) {}
-    throw new Error(message);
-  }
 
-  const { results } = await res.json();
-  let flagged = results[0].flagged;
-  let categories = Object.entries(results[0].category_scores)
-    .filter(([, v]) => (v as number) > env.EXTERNAL_MODERATION_THRESHOLD)
-    .map(([k]) => k);
+  // Wall-clock timing of the whole classifier call — the interval the generation submission actually
+  // parks on. Started before the span so the observation cannot be biased by span setup, and read
+  // exactly once per exit path below (resolve XOR throw), never in a `finally`, which could not see
+  // the outcome the label needs.
+  const start = performance.now();
+  const elapsedSeconds = () => (performance.now() - start) / 1000;
 
-  // If we have categories
-  // Only flag if any of them are found in the results
-  if (env.EXTERNAL_MODERATION_CATEGORIES) {
-    categories = [];
-    for (const [k, v] of Object.entries(env.EXTERNAL_MODERATION_CATEGORIES)) {
-      if (results[0].categories[k]) categories.push(v ?? k);
+  return await withSpan(
+    'moderation:external-prompt',
+    { 'moderation.source': metricSource },
+    async () => {
+      try {
+        // Hard timeout via AbortSignal. Node's undici `fetch` has NO request timeout by
+        // default (~300s headers/body), so a slow/hanging moderation gateway would park
+        // this await — and since it runs inline on every generation submission
+        // (`generateFromGraph` → `auditPromptServer`), that parks the whole tRPC request
+        // off-CPU for minutes (observed ~194s api-primary tail during a moderation 503/504
+        // wave). The call is already FAIL-SOFT (the caller catches and proceeds with
+        // flagged:false) and the local regex audit still gates regardless, so aborting a
+        // slow call only drops the secondary external layer for that one request — it does
+        // not weaken the primary block. Abort → throws → caller's existing catch fails soft.
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            input: preparedPrompt,
+            model: 'omni-moderation-latest',
+          }),
+          signal: AbortSignal.timeout(env.EXTERNAL_MODERATION_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          let message = `External moderation failed: ${res.status} ${res.statusText}`;
+          try {
+            const body = await res.text();
+            message += `\n${body}`;
+          } catch (err) {}
+          throw new Error(message);
+        }
+
+        const { results } = await res.json();
+        let flagged = results[0].flagged;
+        let categories = Object.entries(results[0].category_scores)
+          .filter(([, v]) => (v as number) > env.EXTERNAL_MODERATION_THRESHOLD)
+          .map(([k]) => k);
+
+        // If we have categories
+        // Only flag if any of them are found in the results
+        if (env.EXTERNAL_MODERATION_CATEGORIES) {
+          categories = [];
+          for (const [k, v] of Object.entries(env.EXTERNAL_MODERATION_CATEGORIES)) {
+            if (results[0].categories[k]) categories.push(v ?? k);
+          }
+          flagged = categories.length > 0;
+        }
+
+        recordOutcome(metricSource, 'ok', elapsedSeconds());
+        return { flagged, categories };
+      } catch (e) {
+        // Exactly one observation per call — here on the throw path, XOR on the resolve path above.
+        // A fired `AbortSignal.timeout` is its own outcome: it costs a full deadline of wall time
+        // and calls for a different fix than a gateway that rejects immediately.
+        recordOutcome(
+          metricSource,
+          isAbortDeadlineError(e) ? 'timeout' : 'error',
+          elapsedSeconds()
+        );
+        throw e;
+      }
     }
-    flagged = categories.length > 0;
-  }
+  );
+}
 
-  return { flagged, categories };
+/**
+ * Record the histogram observation and stamp the same outcome on the active span, so a trace and the
+ * metric can never disagree about how one call settled. Called from INSIDE the `withSpan` callback,
+ * where `moderation:external-prompt` is the active span — outside it the attribute would land on the
+ * caller's span instead.
+ */
+function recordOutcome(
+  source: ExternalModerationSource,
+  outcome: 'ok' | 'error' | 'timeout',
+  durationSeconds: number
+) {
+  observeExternalModeration(source, outcome, durationSeconds);
+  setActiveSpanAttributes({ 'moderation.outcome': outcome });
 }
 
 export const extModeration = {

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -42,8 +42,9 @@ async function moderatePrompt(
   // `moderatePrompt` is EXPORTED, so this argument is reachable from callers `tsc` does not
   // constrain: a value already widened to `string` (a cast, a `JSON.parse`), and the test tree,
   // which `tsconfig.json` excludes. An unbounded label value on a hot-path histogram is a
-  // cardinality incident — prom-client retains every distinct label set in the Node heap forever,
-  // across ~130 scraped pods — and it arrives with a green suite and no error anywhere.
+  // cardinality incident — prom-client retains every distinct label set in the Node heap until the
+  // metric is reset, independently in every scraped pod — and it arrives with a green suite and no
+  // error anywhere.
   const metricSource = clampExternalModerationSource(source);
 
   // Read once, into locals, so the guard below narrows them for the fetch. The fetch now runs inside

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -35,8 +35,15 @@ async function moderatePrompt(
   prompt: string,
   source: ExternalModerationSource = 'other'
 ): Promise<{ flagged: false; categories: string[] }> {
-  // Clamp once, here, so every instrument below shares one bounded value regardless of what a
-  // spread-built options object handed us.
+  // Clamp once, here, so every instrument below shares one bounded value.
+  //
+  // 🔴 NOT because callers build these options by spread — none do, and that rationale was fiction;
+  // it is corrected in full at `~/server/prom/external-moderation.metrics`. The real reason is that
+  // `moderatePrompt` is EXPORTED, so this argument is reachable from callers `tsc` does not
+  // constrain: a value already widened to `string` (a cast, a `JSON.parse`), and the test tree,
+  // which `tsconfig.json` excludes. An unbounded label value on a hot-path histogram is a
+  // cardinality incident — prom-client retains every distinct label set in the Node heap forever,
+  // across ~130 scraped pods — and it arrives with a green suite and no error anywhere.
   const metricSource = clampExternalModerationSource(source);
 
   // Read once, into locals, so the guard below narrows them for the fetch. The fetch now runs inside

--- a/src/server/jobs/audit-remix-sources.ts
+++ b/src/server/jobs/audit-remix-sources.ts
@@ -98,7 +98,14 @@ export const auditRemixSourcesJob = createJob(
         // External moderation (only if regex passed)
         if (!isProblematic) {
           try {
-            const { flagged: extFlagged } = await extModeration.moderatePrompt(prompt);
+            // 'remixAudit' is observability only — it keeps this batch job's latency out of the
+            // request-path population on the external-moderation histogram. Nobody is waiting on
+            // these calls, so blending them into `generate` would distort the one figure that
+            // metric exists to produce.
+            const { flagged: extFlagged } = await extModeration.moderatePrompt(
+              prompt,
+              'remixAudit'
+            );
             if (extFlagged) isProblematic = true;
           } catch {
             // If external moderation fails, skip — don't flag based on unavailability

--- a/src/server/jobs/process-enqueued-comic-panels.ts
+++ b/src/server/jobs/process-enqueued-comic-panels.ts
@@ -200,6 +200,13 @@ export const processEnqueuedComicPanelsJob = createJob(
               userId,
               isGreen,
               isModerator: sessionUser.isModerator,
+              // Observability only — see `~/server/prom/external-moderation.metrics`. This job makes
+              // TWO external-moderation calls per panel: this explicit pre-submit gate, and a second
+              // one inside `submitPresetImageGen` → `generateFromGraph`, which labels itself `preset`
+              // via the surface mapping. Leaving this one undeclared would default it to `other`,
+              // so `preset` would undercount this cron by exactly half while `other` — documented as
+              // "every OTHER auditPromptServer caller" — carried the difference.
+              moderationSource: 'preset',
             });
 
             // Submit to orchestrator via the generation graph. `versionIdOverride`

--- a/src/server/jobs/process-enqueued-comic-panels.ts
+++ b/src/server/jobs/process-enqueued-comic-panels.ts
@@ -200,12 +200,15 @@ export const processEnqueuedComicPanelsJob = createJob(
               userId,
               isGreen,
               isModerator: sessionUser.isModerator,
-              // Observability only — see `~/server/prom/external-moderation.metrics`. This job makes
-              // TWO external-moderation calls per panel: this explicit pre-submit gate, and a second
-              // one inside `submitPresetImageGen` → `generateFromGraph`, which labels itself `preset`
-              // via the surface mapping. Leaving this one undeclared would default it to `other`,
-              // so `preset` would undercount this cron by exactly half while `other` — documented as
-              // "every OTHER auditPromptServer caller" — carried the difference.
+              // Observability only — see `~/server/prom/external-moderation.metrics`. There are two
+              // places this job can reach the external classifier per panel: this explicit
+              // pre-submit gate, and a second one inside `submitPresetImageGen` →
+              // `generateFromGraph`, which labels itself `preset` via the surface mapping. A panel
+              // contributes 0, 1 or 2 observations, NOT a fixed 2 — `auditPromptServer` returns
+              // before reaching the classifier on an empty prompt, and a hard regex block throws
+              // ahead of it, which also skips the submit below and with it the second call.
+              // Leaving this one undeclared would default it to `other`, moving this job's gate off
+              // `preset` and onto a mixture the metric documents as unreadable as any single path.
               moderationSource: 'preset',
             });
 

--- a/src/server/prom/__tests__/external-moderation.metrics.test.ts
+++ b/src/server/prom/__tests__/external-moderation.metrics.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Contract tests for the external prompt-moderation metric family.
+ *
+ * These pin the three properties that make the family usable rather than merely present:
+ *   1. the `source` label is CLOSED at runtime, not just in the type system — an options object
+ *      built by spread can carry any string, and an unbounded label on a hot-path histogram is a
+ *      cardinality incident, not a cosmetic bug;
+ *   2. the BUCKET BOUNDARIES actually resolve the `EXTERNAL_MODERATION_TIMEOUT_MS` deadline — a
+ *      call cut at the 5 s cap must land in a DIFFERENT bucket from one that answered just under
+ *      it, which is the whole question ("slow gateway, or are we cutting it off?");
+ *   3. the not-configured short-circuit is counted SEPARATELY and never lands on the duration
+ *      histogram, so it cannot drag the latency distribution toward zero.
+ *
+ * Read against the REAL prom-client registry (`@civitai/telemetry/client` is not stubbed by
+ * src/__tests__/setup.ts, which only replaces `~/server/prom/client`), so every assertion below is
+ * about what is actually recorded on the registry /api/metrics scrapes — not about whether we
+ * called our own wrapper.
+ */
+import promClient from 'prom-client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clampExternalModerationSource,
+  isAbortDeadlineError,
+  observeExternalModeration,
+  recordExternalModerationSkipped,
+} from '~/server/prom/external-moderation.metrics';
+
+const HIST = 'civitai_app_external_moderation_duration_seconds';
+const SKIPPED = 'civitai_app_external_moderation_skipped_total';
+
+type Sample = { metricName?: string; labels: Record<string, string | number>; value: number };
+
+async function samples(name: string): Promise<Sample[]> {
+  const metric = promClient.register.getSingleMetric(name);
+  if (!metric) throw new Error(`metric ${name} is not registered`);
+  return (await metric.get()).values as Sample[];
+}
+
+async function histCount(source: string, outcome: string) {
+  const vals = await samples(HIST);
+  return (
+    vals.find(
+      (v) =>
+        v.metricName === `${HIST}_count` &&
+        v.labels.source === source &&
+        v.labels.outcome === outcome
+    )?.value ?? 0
+  );
+}
+
+async function histSum(source: string, outcome: string) {
+  const vals = await samples(HIST);
+  return (
+    vals.find(
+      (v) =>
+        v.metricName === `${HIST}_sum` && v.labels.source === source && v.labels.outcome === outcome
+    )?.value ?? 0
+  );
+}
+
+/** Cumulative bucket value at boundary `le` (prom histogram buckets are cumulative). */
+async function histBucket(source: string, outcome: string, le: number) {
+  const vals = await samples(HIST);
+  return (
+    vals.find(
+      (v) =>
+        v.metricName === `${HIST}_bucket` &&
+        v.labels.source === source &&
+        v.labels.outcome === outcome &&
+        Number(v.labels.le) === le
+    )?.value ?? 0
+  );
+}
+
+async function skippedCount(source: string) {
+  const vals = await samples(SKIPPED);
+  return vals.find((v) => v.labels.source === source)?.value ?? 0;
+}
+
+beforeEach(() => {
+  promClient.register.getSingleMetric(HIST)?.reset();
+  promClient.register.getSingleMetric(SKIPPED)?.reset();
+});
+
+describe('clampExternalModerationSource', () => {
+  it.each(['generate', 'preset', 'remixAudit', 'other'] as const)('keeps the member %s', (s) => {
+    expect(clampExternalModerationSource(s)).toBe(s);
+  });
+
+  it.each([
+    ['an unknown string', 'generateFromGraph'],
+    ['a near-miss of a member', 'Generate'],
+    ['an empty string', ''],
+    // The shape a spread-built options object produces: a value from somewhere else entirely.
+    ['a user-supplied-looking value', 'prompt: a cat'],
+  ])('clamps %s to other', (_label, value) => {
+    expect(clampExternalModerationSource(value)).toBe('other');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a number', 3],
+    ['an object', { source: 'generate' }],
+    // Object.prototype keys are the classic fails-open key: `'toString' in {}` is true, so a
+    // membership test written against a plain object rather than a Set would let this through.
+    ['a prototype key', 'toString'],
+    ['constructor', 'constructor'],
+  ])('clamps %s to other', (_label, value) => {
+    expect(clampExternalModerationSource(value)).toBe('other');
+  });
+});
+
+describe('isAbortDeadlineError', () => {
+  it('recognises a fired AbortSignal.timeout (TimeoutError)', () => {
+    const e = new Error('The operation was aborted due to timeout');
+    e.name = 'TimeoutError';
+    expect(isAbortDeadlineError(e)).toBe(true);
+  });
+
+  it('recognises a manual/composed abort (AbortError)', () => {
+    const e = new Error('aborted');
+    e.name = 'AbortError';
+    expect(isAbortDeadlineError(e)).toBe(true);
+  });
+
+  it('recognises a deadline nested under .cause, as undici reports it', () => {
+    const inner = new Error('The operation was aborted due to timeout');
+    inner.name = 'TimeoutError';
+    const outer = new Error('fetch failed', { cause: inner });
+    expect(isAbortDeadlineError(outer)).toBe(true);
+  });
+
+  it('does NOT classify an ordinary upstream failure as a deadline', () => {
+    // The exact shape moderatePrompt throws on a non-2xx — this must be `error`, not `timeout`,
+    // or the two failure modes the outcome label exists to separate get merged.
+    expect(
+      isAbortDeadlineError(new Error('External moderation failed: 503 Service Unavailable'))
+    ).toBe(false);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', 'TimeoutError'],
+  ])('returns false for %s rather than throwing', (_label, value) => {
+    expect(isAbortDeadlineError(value)).toBe(false);
+  });
+
+  it('terminates on a self-referential cause chain', () => {
+    const e: { name: string; cause?: unknown } = { name: 'Error' };
+    e.cause = e;
+    expect(isAbortDeadlineError(e)).toBe(false);
+  });
+});
+
+describe('observeExternalModeration', () => {
+  it('records one observation on the labelled series, carrying the duration', async () => {
+    observeExternalModeration('generate', 'ok', 0.123);
+
+    expect(await histCount('generate', 'ok')).toBe(1);
+    // The VALUE, not only the count: the deliverable of this instrument is a duration number, so a
+    // test that only counted calls would pass against an implementation recording zeros.
+    expect(await histSum('generate', 'ok')).toBeCloseTo(0.123, 6);
+    expect(await histCount('generate', 'error')).toBe(0);
+    expect(await histCount('other', 'ok')).toBe(0);
+  });
+
+  it('clamps an out-of-vocabulary source at the recording site, not only at the call site', async () => {
+    observeExternalModeration('nonsense' as never, 'ok', 0.2);
+
+    expect(await histCount('other', 'ok')).toBe(1);
+    expect(await histCount('nonsense', 'ok')).toBe(0);
+  });
+
+  it('never throws, so a metrics fault cannot fail a generation', () => {
+    // A NaN duration is what prom-client rejects; the wrapper must swallow it.
+    expect(() => observeExternalModeration('generate', 'ok', Number.NaN)).not.toThrow();
+    expect(() => observeExternalModeration('generate', 'ok', 'x' as never)).not.toThrow();
+  });
+});
+
+describe('bucket boundaries resolve the EXTERNAL_MODERATION_TIMEOUT_MS deadline', () => {
+  // The default deadline, in seconds (env: EXTERNAL_MODERATION_TIMEOUT_MS, default 5000).
+  const CAP_SECONDS = 5;
+
+  it('separates a call cut AT the deadline from one that answered just under it', async () => {
+    observeExternalModeration('generate', 'ok', 4.9); // answered just under the cap
+    observeExternalModeration('generate', 'ok', 5.02); // cut by the abort, observed just over
+
+    // Buckets are cumulative: le=5 holds only the sub-cap call.
+    expect(await histBucket('generate', 'ok', CAP_SECONDS)).toBe(1);
+    // The next finite boundary above the cap holds both — i.e. exactly one landed between them.
+    expect(await histBucket('generate', 'ok', 7.5)).toBe(2);
+    expect(
+      (await histBucket('generate', 'ok', 7.5)) - (await histBucket('generate', 'ok', CAP_SECONDS))
+    ).toBe(1);
+  });
+
+  it('has a finite boundary ABOVE the deadline, so a capped call is not swallowed by +Inf', async () => {
+    // prom-client only emits bucket samples for label sets that have an observation, so materialise
+    // the series first. Reading the boundaries back off the REGISTRY (rather than off an exported
+    // constant) is deliberate: it is the set that will actually be scraped.
+    observeExternalModeration('generate', 'ok', 0.001);
+    const vals = await samples(HIST);
+    const boundaries = [
+      ...new Set(
+        vals
+          .filter((v) => v.metricName === `${HIST}_bucket`)
+          .map((v) => Number(v.labels.le))
+          .filter((n) => Number.isFinite(n))
+      ),
+    ].sort((a, b) => a - b);
+
+    expect(boundaries.length).toBeGreaterThan(0);
+    // This is the failure the family was designed against: a top finite bucket at or below the cap
+    // drops every capped call into +Inf alongside every pathological one, saturating precisely the
+    // region the metric was added to read.
+    expect(Math.max(...boundaries)).toBeGreaterThan(CAP_SECONDS);
+    // …and there must be a boundary strictly between the cap and the top, or "capped" and
+    // "pathologically over the cap" still share a bucket.
+    expect(boundaries.filter((b) => b > CAP_SECONDS).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('resolves the healthy sub-second population instead of collapsing it into one bucket', async () => {
+    observeExternalModeration('generate', 'ok', 0.001);
+    const vals = await samples(HIST);
+    const boundaries = [
+      ...new Set(
+        vals
+          .filter((v) => v.metricName === `${HIST}_bucket`)
+          .map((v) => Number(v.labels.le))
+          .filter((n) => Number.isFinite(n))
+      ),
+    ];
+    // A single outbound HTTPS POST lives in tens-to-hundreds of ms; apportioning a per-call budget
+    // of that size needs boundaries below 100ms, not a first boundary at half a second.
+    expect(boundaries.filter((b) => b <= 0.1).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('recordExternalModerationSkipped', () => {
+  it('counts the not-configured short-circuit on its own counter', async () => {
+    recordExternalModerationSkipped('generate');
+    recordExternalModerationSkipped('generate');
+
+    expect(await skippedCount('generate')).toBe(2);
+  });
+
+  it('does NOT touch the duration histogram (no I/O happened, so it is not a latency sample)', async () => {
+    recordExternalModerationSkipped('generate');
+
+    expect(await histCount('generate', 'ok')).toBe(0);
+    expect(await histCount('generate', 'error')).toBe(0);
+    expect(await histCount('generate', 'timeout')).toBe(0);
+  });
+
+  it('clamps its source and never throws', async () => {
+    expect(() => recordExternalModerationSkipped('nope' as never)).not.toThrow();
+    expect(await skippedCount('other')).toBe(1);
+  });
+});

--- a/src/server/prom/__tests__/external-moderation.metrics.test.ts
+++ b/src/server/prom/__tests__/external-moderation.metrics.test.ts
@@ -5,9 +5,12 @@
  *   1. the `source` label is CLOSED at runtime, not just in the type system — an options object
  *      built by spread can carry any string, and an unbounded label on a hot-path histogram is a
  *      cardinality incident, not a cosmetic bug;
- *   2. the BUCKET BOUNDARIES actually resolve the `EXTERNAL_MODERATION_TIMEOUT_MS` deadline — a
- *      call cut at the 5 s cap must land in a DIFFERENT bucket from one that answered just under
- *      it, which is the whole question ("slow gateway, or are we cutting it off?");
+ *   2. the BUCKET BOUNDARIES keep the deadline region readable — a finite boundary sits ABOVE the
+ *      `EXTERNAL_MODERATION_TIMEOUT_MS` cap so a capped call is not swallowed by `+Inf`, and NO
+ *      finite boundary sits ON the default cap, which would split the one `outcome=timeout`
+ *      population across two buckets. ⚠️ NOT that a boundary tells a capped call apart from one that
+ *      answered just under the cap — it cannot, and this file used to assert that it did; the
+ *      separator is the `outcome` label. See the block comment above that describe;
  *   3. the not-configured short-circuit is counted SEPARATELY and never lands on the duration
  *      histogram, so it cannot drag the latency distribution toward zero.
  *
@@ -59,19 +62,11 @@ async function histSum(source: string, outcome: string) {
   );
 }
 
-/** Cumulative bucket value at boundary `le` (prom histogram buckets are cumulative). */
-async function histBucket(source: string, outcome: string, le: number) {
-  const vals = await samples(HIST);
-  return (
-    vals.find(
-      (v) =>
-        v.metricName === `${HIST}_bucket` &&
-        v.labels.source === source &&
-        v.labels.outcome === outcome &&
-        Number(v.labels.le) === le
-    )?.value ?? 0
-  );
-}
+// NOTE: no `histBucket` helper here any more. Reading a single named boundary was only ever needed
+// by the removed "a bucket edge separates a capped call from a sub-cap one" case; what survives
+// reads the whole boundary LIST off the registry instead (see `finiteBoundaries` below). The
+// per-boundary helper still lives in `moderation.instrumentation.test.ts`, which needs it to assert
+// that a real capped call lands in a finite bucket rather than in `+Inf`.
 
 async function skippedCount(source: string) {
   const vals = await samples(SKIPPED);
@@ -182,44 +177,38 @@ describe('observeExternalModeration', () => {
 });
 
 /**
- * ⚠️ WHAT THIS BLOCK DOES AND DOES NOT COVER — the description used to overstate it.
+ * ⚠️ WHAT THIS BLOCK DOES AND DOES NOT COVER — the description has now overstated it twice.
  *
  * These cases hand `observeExternalModeration` its numbers directly, so what they pin is the BUCKET
- * SET: that boundaries exist on both sides of the cap, that they are far enough apart to separate a
- * capped call from a sub-cap one, and that the sub-second population is resolved. They never run the
- * code that PRODUCES a duration, so no regression that makes a fired deadline observe at or below
- * 5 s is visible from here — a guard reading as coverage while providing none is worse than none.
+ * SET: that a finite boundary sits above the cap, that no finite boundary sits ON the default cap,
+ * and that the sub-second population is resolved. They never run the code that PRODUCES a duration.
  *
- * That other half — a real `AbortSignal.timeout` firing and landing strictly above `le=5` — is
- * driven end to end in
- * `src/server/integrations/__tests__/moderation.instrumentation.test.ts`
- * ("a real 5s abort lands strictly above le=5, never in it"). The two together are the claim; keep
- * them together if either moves.
+ * 🔴 WHAT THIS BLOCK USED TO ASSERT AND NO LONGER DOES: that a bucket edge tells a capped call apart
+ * from one that answered just under the cap. It cannot. `le` is inclusive, the deadline fires off a
+ * libuv timer while the duration is a `performance.now()` delta, and the two clocks disagree by a
+ * small fixed offset — so a real fired 5 s deadline lands at or below 5.000 s a fair fraction of the
+ * time (measured: worst case 0.63 ms early; the end-to-end test asserting otherwise failed ~20-25%
+ * of runs). Even with perfect clocks the two populations are arbitrarily close in duration, and the
+ * deadline is env-tunable, so no fixed bucket set can separate them for every deployment. The
+ * separator is `outcome="timeout"`, which is a branch on the abort error, not on the duration.
+ *
+ * The end-to-end half — a real `AbortSignal.timeout` firing, classified `timeout`, recorded with the
+ * real parked duration, landing in a FINITE bucket — is driven in
+ * `src/server/integrations/__tests__/moderation.instrumentation.test.ts`. The two together are the
+ * claim; keep them together if either moves.
  */
-describe('the bucket SET straddles the EXTERNAL_MODERATION_TIMEOUT_MS deadline', () => {
+describe('the bucket SET keeps the EXTERNAL_MODERATION_TIMEOUT_MS deadline region readable', () => {
   // The default deadline, in seconds (env: EXTERNAL_MODERATION_TIMEOUT_MS, default 5000).
   const CAP_SECONDS = 5;
 
-  it('separates a call cut AT the deadline from one that answered just under it', async () => {
-    observeExternalModeration('generate', 'ok', 4.9); // answered just under the cap
-    observeExternalModeration('generate', 'ok', 5.02); // cut by the abort, observed just over
-
-    // Buckets are cumulative: le=5 holds only the sub-cap call.
-    expect(await histBucket('generate', 'ok', CAP_SECONDS)).toBe(1);
-    // The next finite boundary above the cap holds both — i.e. exactly one landed between them.
-    expect(await histBucket('generate', 'ok', 7.5)).toBe(2);
-    expect(
-      (await histBucket('generate', 'ok', 7.5)) - (await histBucket('generate', 'ok', CAP_SECONDS))
-    ).toBe(1);
-  });
-
-  it('has a finite boundary ABOVE the deadline, so a capped call is not swallowed by +Inf', async () => {
+  /** The finite boundaries actually registered, read back off the REGISTRY that gets scraped. */
+  async function finiteBoundaries() {
     // prom-client only emits bucket samples for label sets that have an observation, so materialise
     // the series first. Reading the boundaries back off the REGISTRY (rather than off an exported
     // constant) is deliberate: it is the set that will actually be scraped.
     observeExternalModeration('generate', 'ok', 0.001);
     const vals = await samples(HIST);
-    const boundaries = [
+    return [
       ...new Set(
         vals
           .filter((v) => v.metricName === `${HIST}_bucket`)
@@ -227,31 +216,55 @@ describe('the bucket SET straddles the EXTERNAL_MODERATION_TIMEOUT_MS deadline',
           .filter((n) => Number.isFinite(n))
       ),
     ].sort((a, b) => a - b);
+  }
+
+  it('puts NO finite boundary on the default deadline, so one timeout mode is not split in two', async () => {
+    const boundaries = await finiteBoundaries();
 
     expect(boundaries.length).toBeGreaterThan(0);
-    // This is the failure the family was designed against: a top finite bucket at or below the cap
-    // drops every capped call into +Inf alongside every pathological one, saturating precisely the
-    // region the metric was added to read.
-    expect(Math.max(...boundaries)).toBeGreaterThan(CAP_SECONDS);
+    expect(
+      boundaries.filter((b) => b === CAP_SECONDS),
+      `a boundary sitting exactly on the ${CAP_SECONDS}s default deadline splits the single ` +
+        'outcome=timeout population across two buckets by a sub-millisecond clock race, so a ' +
+        'dashboard renders one mode as two. Boundaries near the cap are deliberately OFF-ROUND ' +
+        '(4.5, 7.5) because configured deadlines are round millisecond values. This is a ' +
+        'dashboard-readability guard ONLY: it cannot hold for an arbitrary env-tuned deadline, and ' +
+        'nothing about CLASSIFYING a capped call depends on it — that is the outcome label.'
+    ).toEqual([]);
+  });
+
+  it('has a finite boundary ABOVE the deadline, so a capped call is not swallowed by +Inf', async () => {
+    const boundaries = await finiteBoundaries();
+
+    expect(boundaries.length).toBeGreaterThan(0);
+    // 🔴 THE PROPERTY THAT IS SOUND AND STAYS SOUND. Unlike the separate-the-two-populations claim
+    // this file used to make, this one does not depend on any clock: a top finite bucket at or below
+    // the cap drops EVERY capped call into +Inf alongside every pathological one, saturating
+    // precisely the region the metric was added to read, whatever the durations happen to be.
+    expect(
+      Math.max(...boundaries),
+      `the top finite boundary must exceed the ${CAP_SECONDS}s deadline, or every capped call is ` +
+        'swallowed by +Inf together with every pathological one and the tail becomes unreadable'
+    ).toBeGreaterThan(CAP_SECONDS);
     // …and there must be a boundary strictly between the cap and the top, or "capped" and
     // "pathologically over the cap" still share a bucket.
-    expect(boundaries.filter((b) => b > CAP_SECONDS).length).toBeGreaterThanOrEqual(2);
+    expect(
+      boundaries.filter((b) => b > CAP_SECONDS).length,
+      'at least two finite boundaries must sit above the deadline, or a capped call and a ' +
+        'pathologically-over-the-cap call share the last finite bucket'
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it('resolves the healthy sub-second population instead of collapsing it into one bucket', async () => {
-    observeExternalModeration('generate', 'ok', 0.001);
-    const vals = await samples(HIST);
-    const boundaries = [
-      ...new Set(
-        vals
-          .filter((v) => v.metricName === `${HIST}_bucket`)
-          .map((v) => Number(v.labels.le))
-          .filter((n) => Number.isFinite(n))
-      ),
-    ];
+    const boundaries = await finiteBoundaries();
+
     // A single outbound HTTPS POST lives in tens-to-hundreds of ms; apportioning a per-call budget
     // of that size needs boundaries below 100ms, not a first boundary at half a second.
-    expect(boundaries.filter((b) => b <= 0.1).length).toBeGreaterThanOrEqual(3);
+    expect(
+      boundaries.filter((b) => b <= 0.1).length,
+      'at least three boundaries must sit at or below 100ms, or the healthy tens-to-hundreds-of-ms ' +
+        'population collapses into one bucket and the metric cannot apportion a per-call budget'
+    ).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/src/server/prom/__tests__/external-moderation.metrics.test.ts
+++ b/src/server/prom/__tests__/external-moderation.metrics.test.ts
@@ -181,7 +181,22 @@ describe('observeExternalModeration', () => {
   });
 });
 
-describe('bucket boundaries resolve the EXTERNAL_MODERATION_TIMEOUT_MS deadline', () => {
+/**
+ * ⚠️ WHAT THIS BLOCK DOES AND DOES NOT COVER — the description used to overstate it.
+ *
+ * These cases hand `observeExternalModeration` its numbers directly, so what they pin is the BUCKET
+ * SET: that boundaries exist on both sides of the cap, that they are far enough apart to separate a
+ * capped call from a sub-cap one, and that the sub-second population is resolved. They never run the
+ * code that PRODUCES a duration, so no regression that makes a fired deadline observe at or below
+ * 5 s is visible from here — a guard reading as coverage while providing none is worse than none.
+ *
+ * That other half — a real `AbortSignal.timeout` firing and landing strictly above `le=5` — is
+ * driven end to end in
+ * `src/server/integrations/__tests__/moderation.instrumentation.test.ts`
+ * ("a real 5s abort lands strictly above le=5, never in it"). The two together are the claim; keep
+ * them together if either moves.
+ */
+describe('the bucket SET straddles the EXTERNAL_MODERATION_TIMEOUT_MS deadline', () => {
   // The default deadline, in seconds (env: EXTERNAL_MODERATION_TIMEOUT_MS, default 5000).
   const CAP_SECONDS = 5;
 

--- a/src/server/prom/__tests__/external-moderation.metrics.test.ts
+++ b/src/server/prom/__tests__/external-moderation.metrics.test.ts
@@ -2,9 +2,14 @@
  * Contract tests for the external prompt-moderation metric family.
  *
  * These pin the three properties that make the family usable rather than merely present:
- *   1. the `source` label is CLOSED at runtime, not just in the type system — an options object
- *      built by spread can carry any string, and an unbounded label on a hot-path histogram is a
- *      cardinality incident, not a cosmetic bug;
+ *   1. the `source` label is CLOSED at runtime, not just in the type system. ⚠️ NOT because "an
+ *      options object built by spread can carry any string" — that rationale was fiction and is
+ *      retracted in full at `~/server/prom/external-moderation.metrics`: every production
+ *      `auditPromptServer` call site builds an inline object literal, so excess-property checking
+ *      applies to all of them. The real reason is that `moderatePrompt` is EXPORTED, so its second
+ *      argument is reachable from callers `tsc` does not constrain — a value already widened to
+ *      `string` (a cast, a `JSON.parse`), and the test tree, which `tsconfig.json` excludes. An
+ *      unbounded label on a hot-path histogram is a cardinality incident, not a cosmetic bug;
  *   2. the BUCKET BOUNDARIES keep the deadline region readable — a finite boundary sits ABOVE the
  *      `EXTERNAL_MODERATION_TIMEOUT_MS` cap so a capped call is not swallowed by `+Inf`, and NO
  *      finite boundary sits ON the default cap, which would split the one `outcome=timeout`
@@ -22,12 +27,32 @@
 import promClient from 'prom-client';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { serverSchema } from '~/env/server-schema';
 import {
   clampExternalModerationSource,
   isAbortDeadlineError,
   observeExternalModeration,
   recordExternalModerationSkipped,
 } from '~/server/prom/external-moderation.metrics';
+
+/**
+ * The default `EXTERNAL_MODERATION_TIMEOUT_MS` deadline, in SECONDS, DERIVED from the schema that
+ * defines it rather than written here as a literal.
+ *
+ * 🔴 WHY THIS IS NOT A `const CAP_SECONDS = 5`. The bucket guards below forbid a finite boundary on
+ * the default deadline. Against a literal, that guard only ever forbids the number 5 — so if the
+ * schema default became 3000, `src/env/__tests__/server-schema-moderation-timeout.test.ts` would go
+ * red and be updated while this guard stayed green, and `3` IS a live boundary in
+ * `EXTERNAL_MODERATION_BUCKETS`. The guard would then be passing while the exact split-timeout
+ * defect it exists to prevent was reinstated. MEASURED: with the schema default temporarily set to
+ * 3000, this derivation fails naming `[3]`. (The old literal `5` would stay green there by
+ * inspection rather than by measurement — `EXTERNAL_MODERATION_BUCKETS` contains no `5`.)
+ *
+ * `.parse(undefined)` yields the `.catch(5000)` fallback — the same value production gets when the
+ * env var is absent, which is what "the default deadline" means, and the same accessor that
+ * schema test already uses.
+ */
+const CAP_SECONDS = serverSchema.shape.EXTERNAL_MODERATION_TIMEOUT_MS.parse(undefined) / 1000;
 
 const HIST = 'civitai_app_external_moderation_duration_seconds';
 const SKIPPED = 'civitai_app_external_moderation_skipped_total';
@@ -87,7 +112,7 @@ describe('clampExternalModerationSource', () => {
     ['an unknown string', 'generateFromGraph'],
     ['a near-miss of a member', 'Generate'],
     ['an empty string', ''],
-    // The shape a spread-built options object produces: a value from somewhere else entirely.
+    // The shape a value widened to `string` produces: something from somewhere else entirely.
     ['a user-supplied-looking value', 'prompt: a cat'],
   ])('clamps %s to other', (_label, value) => {
     expect(clampExternalModerationSource(value)).toBe('other');
@@ -198,9 +223,6 @@ describe('observeExternalModeration', () => {
  * claim; keep them together if either moves.
  */
 describe('the bucket SET keeps the EXTERNAL_MODERATION_TIMEOUT_MS deadline region readable', () => {
-  // The default deadline, in seconds (env: EXTERNAL_MODERATION_TIMEOUT_MS, default 5000).
-  const CAP_SECONDS = 5;
-
   /** The finite boundaries actually registered, read back off the REGISTRY that gets scraped. */
   async function finiteBoundaries() {
     // prom-client only emits bucket samples for label sets that have an observation, so materialise
@@ -226,10 +248,11 @@ describe('the bucket SET keeps the EXTERNAL_MODERATION_TIMEOUT_MS deadline regio
       boundaries.filter((b) => b === CAP_SECONDS),
       `a boundary sitting exactly on the ${CAP_SECONDS}s default deadline splits the single ` +
         'outcome=timeout population across two buckets by a sub-millisecond clock race, so a ' +
-        'dashboard renders one mode as two. Boundaries near the cap are deliberately OFF-ROUND ' +
-        '(4.5, 7.5) because configured deadlines are round millisecond values. This is a ' +
-        'dashboard-readability guard ONLY: it cannot hold for an arbitrary env-tuned deadline, and ' +
-        'nothing about CLASSIFYING a capped call depends on it — that is the outcome label.'
+        'dashboard renders one mode as two. The boundaries around the cap (4.5, 7.5) are placed to ' +
+        'CLEAR the default deadline, not because any value is intrinsically safe — 4.5s is 4500ms, ' +
+        'which a deployment can configure. This is a dashboard-readability guard ONLY: it cannot ' +
+        'hold for an arbitrary env-tuned deadline, and nothing about CLASSIFYING a capped call ' +
+        'depends on it — that is the outcome label.'
     ).toEqual([]);
   });
 

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -43,27 +43,53 @@ import { registerCounterWithLabels, registerHistogram } from '@civitai/telemetry
  *                   generator latency: App Blocks submissions are in it too. An ABSENT surface
  *                   falls to `other`, never to here. This is the population the metric exists to
  *                   size: the number to divide against that procedure's own wall time.
- * - `preset`      — the SAME `generateFromGraph` code reached through preset/comics generation,
- *                   which includes the `process-enqueued-comic-panels` CRON JOB. Split out for
- *                   exactly the reason its sibling on the submit metric is: a background job blended
- *                   into `generate` would corrupt the one division this metric supports.
- *                   🔴 That cron makes TWO external-moderation calls per panel and BOTH are labelled
- *                   here: its explicit pre-submit `auditPromptServer` gate, which declares
- *                   `moderationSource: 'preset'` by hand, and the one inside `submitPresetImageGen`
- *                   → `generateFromGraph`, which derives the same value from surface `preset`. So a
- *                   per-panel rate on this series is 2× the panel rate, by construction. (Until the
- *                   round-1 fix the explicit gate declared nothing and fell to `other`, which halved
- *                   this series' count for that cron and inflated `other` by the same amount.)
+ * - `preset`      — surface `preset`: the SAME `generateFromGraph` code reached through
+ *                   `submitPresetImageGen`. Split out for exactly the reason its sibling on the
+ *                   submit metric is: a background job blended into `generate` would corrupt the one
+ *                   division this metric supports.
+ *                   🔴 THIS SERIES COUNTS CALLS, NOT SUBMISSIONS, AND NO CONSTANT CONVERTS ONE INTO
+ *                   THE OTHER. `submitPresetImageGen` has THREE callers which contribute at
+ *                   DIFFERENT rates, and nothing on the series distinguishes them:
+ *                     · `orchestrator.router.ts`, the `iterateGenerate` procedure — interactive
+ *                       tRPC, 1 call per submission;
+ *                     · `comics.router.ts`, via the `submitComicGeneration` helper that several of
+ *                       that router's procedures share — interactive tRPC, 1 call per submission;
+ *                     · `process-enqueued-comic-panels.ts` — the CRON JOB, up to 2 calls per panel:
+ *                       its explicit pre-submit `auditPromptServer` gate, which declares
+ *                       `moderationSource: 'preset'` by hand, plus the one inside
+ *                       `generateFromGraph`, which derives the same value from the surface.
+ *                   So the series is `interactive + up-to-2×cron`, and it CANNOT be divided by 2.
+ *                   The cron's own share is not a fixed 2 either: `auditPromptServer` returns early
+ *                   on an empty prompt (`promptAuditing.ts:244`) and a HARD regex block throws at
+ *                   `:288`, both BEFORE `moderatePrompt` at `:295` — so a blocked panel contributes
+ *                   0 or 1, never 2.
+ *                   (The ACE Audio creative-field audit in `generateFromGraph` derives `preset`
+ *                   too, but `buildPresetGraphInput` emits only txt2img/img2img input, so as of
+ *                   today it contributes nothing here. A preset graph that ever carried
+ *                   `musicDescription`/`lyrics` would add a fourth, again-different rate.)
+ *                   🔴 THE TRADE THIS PR MADE, so nobody re-derives it as a bug: before it, the
+ *                   cron's explicit gate declared nothing and fell to `other` — which inflated
+ *                   `other` and undercounted the cron here, but left `preset` at exactly one
+ *                   observation per preset submission. Labelling the gate `preset` fixed the `other`
+ *                   inflation and cost `preset` that 1:1 relationship. Read it as a call rate on
+ *                   preset work; to recover a per-panel figure you need a label that separates the
+ *                   cron from the two interactive routes, which does not exist today.
  * - `remixAudit`  — the `audit-remix-sources` background job, which calls `moderatePrompt` directly
  *                   rather than through `auditPromptServer`. Batch work, no user waiting on it.
  * - `other`       — every other `auditPromptServer` caller (App Blocks host-side audits, prompt
  *                   enhancement, shared content-safety). The DEFAULT, so a caller that declares
  *                   nothing can never silently inflate `generate`.
  *
- * 🔴 `other` is a genuine mixture, not a residue worth attributing: it is deliberately NOT split
- * further, because doing so means threading a source through `AuditPromptOptions` to nine call
- * sites. If a figure for one of those funnels is ever needed, that plumbing is the change — do not
- * read `other` as any single path.
+ * 🔴 `other` is a genuine mixture, not a residue worth attributing — do not read it as any single
+ * path. It is deliberately NOT split further, but the PLUMBING IS NO LONGER THE REASON: this PR put
+ * `moderationSource` on `AuditPromptOptions` and it already reaches all nine `auditPromptServer`
+ * call sites, every one of which can declare a value today. What splitting a funnel out still costs
+ * is vocabulary and a decision per site: a new member added BOTH to this union and to
+ * `EXTERNAL_MODERATION_SOURCES` below (the clamp is a closed set — a union member missing from the
+ * set falls silently to `other`), the literal written at the site being split, and that site's row
+ * updated in `moderation-source-wiring.test.ts`. That is cheap per funnel and is why it is done one
+ * funnel at a time, on evidence that the funnel is worth its own series — not because `other` is
+ * hard to reach.
  */
 export type ExternalModerationSource = 'generate' | 'preset' | 'remixAudit' | 'other';
 

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -168,22 +168,46 @@ export function isAbortDeadlineError(e: unknown): boolean {
  * that size, so a bucket set whose first boundary sat at 0.5 s would put the entire healthy
  * population in one bucket and answer nothing.
  *
- * 🔴 THE TOP END IS THE PART THAT IS EASY TO GET WRONG, AND `5` IS NOT THE TOP. A boundary is
- * inclusive (`le`), and `AbortSignal.timeout(5000)` fires AT 5000 ms — so an aborted call is observed
- * at slightly MORE than 5 s and lands in `le=7.5`, while a call that answered just under the deadline
- * lands in `le=5`. Those two are the distinction this metric exists to draw ("is the gateway slow, or
- * are we cutting it off?"), and they are only distinguishable because a finite boundary sits ABOVE
- * the cap. A family whose top finite bucket sat AT the cap would drop every capped call into `+Inf`
- * together with every pathological one, saturating exactly the region being asked about — the
- * boundary a bucket-based quantile cannot see past.
+ * 🔴 THE TOP END IS THE PART THAT IS LOAD-BEARING: the top finite boundary must sit ABOVE the
+ * configured deadline. A family whose top finite bucket sat AT or below the cap would drop every
+ * capped call into `+Inf` together with every pathological one, saturating exactly the region being
+ * asked about — the boundary a bucket-based quantile cannot see past. `10` and `20` carry two
+ * further things: the deadline is an env knob that can be re-tuned upward, so the tail keeps some
+ * resolution if it is; and under the default cap a NON-EMPTY `+Inf` is itself a finding (nothing
+ * should ever exceed the deadline by 15 s — that would mean the abort did not take effect), which a
+ * bucket set stopping at the cap could not express. `external-moderation.metrics.test.ts` pins this.
  *
- * `10` and `20` carry two further things: the deadline is an env knob that can be re-tuned upward, so
- * the tail keeps some resolution if it is; and under the default cap a NON-EMPTY `+Inf` is itself a
- * finding (nothing should ever exceed the deadline by 15 s — that would mean the abort did not take
- * effect), which a bucket set stopping at the cap could not express.
+ * 🔴 NO BOUNDARY SEPARATES A CAPPED CALL FROM ONE THAT ANSWERED JUST UNDER THE CAP, AND NONE CAN.
+ * This comment and the help text below used to claim the opposite — that a fired deadline is observed
+ * at slightly MORE than 5 s and so lands in `le=7.5` while a sub-cap call lands in `le=5`, "adjacent
+ * but separate". That is FALSE, and it was measurable:
+ *   · `le` is INCLUSIVE, `AbortSignal.timeout()` fires off a libuv timer, and the recorded duration
+ *     is a `performance.now()` delta. Those two clocks disagree by a small fixed offset, so the
+ *     elapsed time measured when the deadline fires can land just BELOW the deadline. Measured on one
+ *     host: 3/60 samples at a 100 ms deadline and 3/8 at a 5000 ms deadline came in EARLY, worst case
+ *     0.63 ms — the same magnitude at both, i.e. a constant offset, not a clock-rate difference. The
+ *     end-to-end test asserting "never in le=5" therefore failed ~20-25% of the time.
+ *   · Perfect clocks would not rescue it either: a call that answered a microsecond under the cap and
+ *     one cut BY the cap are arbitrarily close in duration, so no bucket edge can lie between them.
+ *   · And the deadline is an env knob (`.min(100).max(60000)`), so NO FIXED BUCKET SET can guarantee
+ *     any boundary relationship to it across deployments.
+ * `outcome="timeout"` separates those two populations, deterministically, and always did: it is a
+ * branch on the abort error (`isAbortDeadlineError`), not a race between two clocks. Classify by that
+ * label. The bucket set's job is resolution, not classification.
+ *
+ * 🔴 WHY `4.5` AND NOT `5` — this set used to carry `5`, exactly the default deadline in seconds.
+ * Given the above, a boundary sitting on the deadline buys nothing, and it costs something: it splits
+ * the single `outcome="timeout"` mode across `le=5` and `le=7.5` on that same sub-millisecond coin
+ * flip, so a dashboard renders one population as two. `4.5` is deliberately OFF-ROUND — configured
+ * deadlines are round millisecond values (5000, 3000, 10000), so a non-round second boundary cannot
+ * coincide with one — and it sits 500 ms clear of the default cap, ~800x the measured clock offset,
+ * so nothing races it. This is a MITIGATION, NOT A GUARANTEE: a deployment that sets 4500 ms puts the
+ * boundary back on its own cap, and there only `outcome` remains correct. That is precisely why
+ * correctness rests on `outcome` and not on this number. Only this one boundary moved; the rest of
+ * the set is unchanged, because nothing else about it was wrong.
  */
 const EXTERNAL_MODERATION_BUCKETS = [
-  0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 20,
+  0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 4.5, 7.5, 10, 20,
 ] as const;
 
 const durationHistogram = registerHistogram({
@@ -194,8 +218,10 @@ const durationHistogram = registerHistogram({
     'source (generate|preset|remixAudit|other) + outcome (ok|error|timeout). The call sits inline and ' +
     'serially on the generation submission path and is FAIL-SOFT, so a rising error rate here is ' +
     'invisible to every user-facing signal — it means prompts are being generated with only the local ' +
-    'regex gate applied. outcome=timeout is the EXTERNAL_MODERATION_TIMEOUT_MS deadline firing; those ' +
-    'observations land just above the cap (le=7.5 at the 5s default), never in le=5. Filter on source ' +
+    'regex gate applied. outcome=timeout is the EXTERNAL_MODERATION_TIMEOUT_MS deadline firing, ' +
+    'branched off the abort error rather than off the duration: IDENTIFY CAPPED CALLS BY THAT LABEL, ' +
+    'never by which bucket they land in — a capped call and one that answered a hair under the cap are ' +
+    'arbitrarily close in duration, so no bucket edge separates them. Filter on source ' +
     'before attributing a figure to a procedure: source=generate is the orchestrator.generateFromGraph ' +
     'prompt gate for EVERY surface except preset — onsite, api AND block (App Blocks), so it is not ' +
     'on-site-only — while remixAudit is batch work with nobody waiting.',

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -36,13 +36,24 @@ import { registerCounterWithLabels, registerHistogram } from '@civitai/telemetry
  * The label is load-bearing rather than decorative. `moderatePrompt` is reached from two very
  * different kinds of caller, and mixing them makes the headline figure meaningless:
  *
- * - `generate`    — the request-path prompt gate reached from `orchestrator.generateFromGraph`
- *                   (surface `onsite`/`api`). This is the population the metric exists to size: the
- *                   number to divide against that procedure's own wall time.
+ * - `generate`    — the request-path prompt gate reached from `orchestrator.generateFromGraph`.
+ *                   🔴 That is EVERY `GenerationSurface` EXCEPT `preset` — `onsite`, `api` AND
+ *                   `block` (the App Blocks bridge) — because `submitSourceForSurface` maps
+ *                   everything but `preset` to `generate`. Do not read a rise here as on-site
+ *                   generator latency: App Blocks submissions are in it too. An ABSENT surface
+ *                   falls to `other`, never to here. This is the population the metric exists to
+ *                   size: the number to divide against that procedure's own wall time.
  * - `preset`      — the SAME `generateFromGraph` code reached through preset/comics generation,
  *                   which includes the `process-enqueued-comic-panels` CRON JOB. Split out for
  *                   exactly the reason its sibling on the submit metric is: a background job blended
  *                   into `generate` would corrupt the one division this metric supports.
+ *                   🔴 That cron makes TWO external-moderation calls per panel and BOTH are labelled
+ *                   here: its explicit pre-submit `auditPromptServer` gate, which declares
+ *                   `moderationSource: 'preset'` by hand, and the one inside `submitPresetImageGen`
+ *                   → `generateFromGraph`, which derives the same value from surface `preset`. So a
+ *                   per-panel rate on this series is 2× the panel rate, by construction. (Until the
+ *                   round-1 fix the explicit gate declared nothing and fell to `other`, which halved
+ *                   this series' count for that cron and inflated `other` by the same amount.)
  * - `remixAudit`  — the `audit-remix-sources` background job, which calls `moderatePrompt` directly
  *                   rather than through `auditPromptServer`. Batch work, no user waiting on it.
  * - `other`       — every other `auditPromptServer` caller (App Blocks host-side audits, prompt
@@ -57,10 +68,24 @@ import { registerCounterWithLabels, registerHistogram } from '@civitai/telemetry
 export type ExternalModerationSource = 'generate' | 'preset' | 'remixAudit' | 'other';
 
 /**
- * Runtime narrowing for the `source` label. The TYPE is a compile-time guarantee only, and
- * `AuditPromptOptions.source` travels inside an options object that call sites build by spread —
- * excess-property checking does not apply to spread properties, so one stray string would mint an
- * unbounded label value on a hot-path histogram, silently and with a green suite.
+ * Runtime narrowing for the `source` label.
+ *
+ * ⚠️ THE RATIONALE HERE WAS WRONG TWICE and is corrected rather than deleted, because the clamp
+ * itself is worth keeping. It used to name the field `AuditPromptOptions.source` (it is
+ * `moderationSource`) and justify itself by "an options object that call sites build by spread" —
+ * but NO production caller spreads: all nine `auditPromptServer` call sites build an explicit object
+ * literal, so excess-property checking does apply to every one of them, and spread appears only in
+ * tests. That argument was fiction.
+ *
+ * THE REAL REASON. `moderatePrompt` is EXPORTED (`extModeration.moderatePrompt`) and its second
+ * argument is reachable from any future caller, including one outside the `auditPromptServer` funnel
+ * — `audit-remix-sources.ts` already is one. The type is a compile-time guarantee about the callers
+ * that exist today under `tsc`, and two populations sit outside that: values that arrive already
+ * widened to `string` (a cast, a `JSON.parse`, an `as never` in a test), and the test tree, which
+ * `tsconfig.json` EXCLUDES (`src/**\/__tests__/**`) and where a helper CAN spread. What the clamp
+ * buys is that none of those can mint an unbounded label value on a hot-path histogram — prom-client
+ * retains every distinct label set in the Node heap forever, across ~130 scraped pods, so one stray
+ * string is a cardinality incident with a green suite and no error anywhere.
  */
 const EXTERNAL_MODERATION_SOURCES: ReadonlySet<string> = new Set<ExternalModerationSource>([
   'generate',
@@ -145,8 +170,9 @@ const durationHistogram = registerHistogram({
     'invisible to every user-facing signal — it means prompts are being generated with only the local ' +
     'regex gate applied. outcome=timeout is the EXTERNAL_MODERATION_TIMEOUT_MS deadline firing; those ' +
     'observations land just above the cap (le=7.5 at the 5s default), never in le=5. Filter on source ' +
-    'before attributing a figure to a procedure: source=generate is exactly the ' +
-    'orchestrator.generateFromGraph prompt gate, while remixAudit is batch work with nobody waiting.',
+    'before attributing a figure to a procedure: source=generate is the orchestrator.generateFromGraph ' +
+    'prompt gate for EVERY surface except preset — onsite, api AND block (App Blocks), so it is not ' +
+    'on-site-only — while remixAudit is batch work with nobody waiting.',
   labelNames: ['source', 'outcome'] as const,
   buckets: [...EXTERNAL_MODERATION_BUCKETS],
 });

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -1,0 +1,197 @@
+// EXTERNAL PROMPT-MODERATION observability — the timer on `extModeration.moderatePrompt`.
+//
+// WHY this exists: `moderatePrompt` is an OUTBOUND HTTP call to a third-party classifier that runs
+// INLINE and SERIALLY on the generation submission path (`generateFromGraph` → `auditPromptServer` →
+// here). It is bounded by `AbortSignal.timeout(EXTERNAL_MODERATION_TIMEOUT_MS)` (default 5 s), and it
+// is FAIL-SOFT: the caller catches, logs, and proceeds with `flagged:false`. Those two properties
+// together are what made it invisible. Nothing timed it, nothing counted its failures, and because a
+// failure is swallowed, a fully-down moderation gateway and a healthy one look identical from every
+// instrument the app had — the only trace was a one-line Axiom event per failure, which carries no
+// duration and cannot be aggregated into a rate or a quantile.
+//
+// So three questions that decide whether this call is a latency problem had no answer at all:
+//   1. how long does a moderation call take, per call;
+//   2. how often does it fail (i.e. how often is the secondary moderation layer silently absent);
+//   3. how often does it reach its abort deadline, as opposed to merely being slow.
+// This module answers all three with one histogram plus one counter for the not-configured case.
+//
+// SCOPE. Recorded inside `moderatePrompt` itself, which is the LOWEST funnel — every caller reaches
+// it and none can bypass it. Instrumenting a level up (at `auditPromptServer`) would have blended the
+// regex audit, the benign-phrase Redis reads and the ClickHouse/notification work into the same
+// number, none of which is the external call.
+//
+// Imports the prom helpers from `@civitai/telemetry/client` DIRECTLY rather than through
+// `~/server/prom/client`, matching `model-moderation.metrics.ts` and unlike
+// `orchestrator-submit-metrics.ts`. Both register onto the same prom-client default registry that
+// /api/metrics scrapes, so the choice is invisible in the output — but `~/server/prom/client`
+// constructs the pg pool gauges at module load, and this module is reachable from a cron job
+// (`audit-remix-sources`) and from the deliberately-light `moderation.ts`. The lighter edge keeps
+// that import graph unchanged.
+import { registerCounterWithLabels, registerHistogram } from '@civitai/telemetry/client';
+
+/**
+ * WHICH moderation population an observation belongs to. Bounded and closed — never derived from
+ * anything a user or the upstream classifier controls.
+ *
+ * The label is load-bearing rather than decorative. `moderatePrompt` is reached from two very
+ * different kinds of caller, and mixing them makes the headline figure meaningless:
+ *
+ * - `generate`    — the request-path prompt gate reached from `orchestrator.generateFromGraph`
+ *                   (surface `onsite`/`api`). This is the population the metric exists to size: the
+ *                   number to divide against that procedure's own wall time.
+ * - `preset`      — the SAME `generateFromGraph` code reached through preset/comics generation,
+ *                   which includes the `process-enqueued-comic-panels` CRON JOB. Split out for
+ *                   exactly the reason its sibling on the submit metric is: a background job blended
+ *                   into `generate` would corrupt the one division this metric supports.
+ * - `remixAudit`  — the `audit-remix-sources` background job, which calls `moderatePrompt` directly
+ *                   rather than through `auditPromptServer`. Batch work, no user waiting on it.
+ * - `other`       — every other `auditPromptServer` caller (App Blocks host-side audits, prompt
+ *                   enhancement, shared content-safety). The DEFAULT, so a caller that declares
+ *                   nothing can never silently inflate `generate`.
+ *
+ * 🔴 `other` is a genuine mixture, not a residue worth attributing: it is deliberately NOT split
+ * further, because doing so means threading a source through `AuditPromptOptions` to nine call
+ * sites. If a figure for one of those funnels is ever needed, that plumbing is the change — do not
+ * read `other` as any single path.
+ */
+export type ExternalModerationSource = 'generate' | 'preset' | 'remixAudit' | 'other';
+
+/**
+ * Runtime narrowing for the `source` label. The TYPE is a compile-time guarantee only, and
+ * `AuditPromptOptions.source` travels inside an options object that call sites build by spread —
+ * excess-property checking does not apply to spread properties, so one stray string would mint an
+ * unbounded label value on a hot-path histogram, silently and with a green suite.
+ */
+const EXTERNAL_MODERATION_SOURCES: ReadonlySet<string> = new Set<ExternalModerationSource>([
+  'generate',
+  'preset',
+  'remixAudit',
+  'other',
+]);
+
+export function clampExternalModerationSource(source: unknown): ExternalModerationSource {
+  return typeof source === 'string' && EXTERNAL_MODERATION_SOURCES.has(source)
+    ? (source as ExternalModerationSource)
+    : 'other';
+}
+
+/**
+ * `ok` = the classifier answered and the response was parsed. `timeout` = the call was cut by its own
+ * `AbortSignal.timeout(EXTERNAL_MODERATION_TIMEOUT_MS)` deadline. `error` = every other failure — a
+ * non-2xx from the classifier, a connection failure, a malformed body.
+ *
+ * The `timeout`/`error` split is the point of the label, not a refinement of it: from the caller's
+ * side both are "fail soft, proceed unmoderated", but they cost completely different amounts of wall
+ * time (a full deadline vs. an immediate reject) and they call for opposite responses (re-size the
+ * deadline vs. fix or route around the gateway).
+ */
+export type ExternalModerationOutcome = 'ok' | 'error' | 'timeout';
+
+/**
+ * A fired abort deadline, as distinct from any other failure.
+ *
+ * `AbortSignal.timeout()` surfaces as a DOMException named `TimeoutError`; a composed or manual
+ * abort surfaces as `AbortError`. undici nests the original under `.cause`, so walk a short chain
+ * rather than testing only the outermost error.
+ *
+ * 🔴 There is an equivalent private predicate in `workflows.ts` (`isOrchestratorReadTimeout`). It was
+ * deliberately not consolidated with this one: it is module-private to a heavy orchestrator module,
+ * and importing across that boundary to reach it would pull the orchestrator client's import graph
+ * into `moderation.ts`, which is imported by a cron job and today pulls in nothing but `env`.
+ */
+export function isAbortDeadlineError(e: unknown): boolean {
+  let cur = e as { name?: string; cause?: unknown } | undefined;
+  for (let depth = 0; depth < 4 && cur && typeof cur === 'object'; depth++) {
+    if (cur.name === 'TimeoutError' || cur.name === 'AbortError') return true;
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
+/**
+ * 10 ms → 20 s, straddling the `EXTERNAL_MODERATION_TIMEOUT_MS` deadline (default 5 s, env-clamped to
+ * [100 ms, 60 s]).
+ *
+ * THE LOW END exists because this is a single outbound HTTPS POST whose healthy population lives in
+ * tens-to-hundreds of milliseconds. The whole reason to time it is to apportion a per-call budget of
+ * that size, so a bucket set whose first boundary sat at 0.5 s would put the entire healthy
+ * population in one bucket and answer nothing.
+ *
+ * 🔴 THE TOP END IS THE PART THAT IS EASY TO GET WRONG, AND `5` IS NOT THE TOP. A boundary is
+ * inclusive (`le`), and `AbortSignal.timeout(5000)` fires AT 5000 ms — so an aborted call is observed
+ * at slightly MORE than 5 s and lands in `le=7.5`, while a call that answered just under the deadline
+ * lands in `le=5`. Those two are the distinction this metric exists to draw ("is the gateway slow, or
+ * are we cutting it off?"), and they are only distinguishable because a finite boundary sits ABOVE
+ * the cap. A family whose top finite bucket sat AT the cap would drop every capped call into `+Inf`
+ * together with every pathological one, saturating exactly the region being asked about — the
+ * boundary a bucket-based quantile cannot see past.
+ *
+ * `10` and `20` carry two further things: the deadline is an env knob that can be re-tuned upward, so
+ * the tail keeps some resolution if it is; and under the default cap a NON-EMPTY `+Inf` is itself a
+ * finding (nothing should ever exceed the deadline by 15 s — that would mean the abort did not take
+ * effect), which a bucket set stopping at the cap could not express.
+ */
+const EXTERNAL_MODERATION_BUCKETS = [
+  0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 20,
+] as const;
+
+const durationHistogram = registerHistogram({
+  name: 'external_moderation_duration_seconds',
+  help:
+    'Duration (seconds) of an external prompt-moderation call (extModeration.moderatePrompt) as the ' +
+    'CALLER experiences it: the whole outbound classifier request, including body parse. Labeled by ' +
+    'source (generate|preset|remixAudit|other) + outcome (ok|error|timeout). The call sits inline and ' +
+    'serially on the generation submission path and is FAIL-SOFT, so a rising error rate here is ' +
+    'invisible to every user-facing signal — it means prompts are being generated with only the local ' +
+    'regex gate applied. outcome=timeout is the EXTERNAL_MODERATION_TIMEOUT_MS deadline firing; those ' +
+    'observations land just above the cap (le=7.5 at the 5s default), never in le=5. Filter on source ' +
+    'before attributing a figure to a procedure: source=generate is exactly the ' +
+    'orchestrator.generateFromGraph prompt gate, while remixAudit is batch work with nobody waiting.',
+  labelNames: ['source', 'outcome'] as const,
+  buckets: [...EXTERNAL_MODERATION_BUCKETS],
+});
+
+const skippedCounter = registerCounterWithLabels({
+  name: 'external_moderation_skipped_total',
+  help:
+    'Count of extModeration.moderatePrompt calls that returned without contacting the classifier ' +
+    'because EXTERNAL_MODERATION_ENDPOINT / EXTERNAL_MODERATION_TOKEN are not configured. Labeled by ' +
+    'source. Deliberately a SEPARATE counter rather than a fourth outcome on the duration histogram: ' +
+    'these calls do no I/O, so folding their ~0s observations in would drag every quantile toward ' +
+    'zero and make the healthy latency distribution unreadable. It exists at all because otherwise a ' +
+    'zero rate on the histogram is indistinguishable from a deployment where external moderation is ' +
+    'switched off — the reassuring reading and the alarming one would look the same.',
+  labelNames: ['source'] as const,
+});
+
+/**
+ * Record ONE external moderation call — exactly one call per `moderatePrompt` invocation that
+ * actually issued a request, whichever way it settled. Cheap + TOTAL (never throws): it runs on the
+ * generation hot path, so a metrics-layer hiccup must not be able to fail a generation.
+ */
+export function observeExternalModeration(
+  source: ExternalModerationSource,
+  outcome: ExternalModerationOutcome,
+  durationSeconds: number
+): void {
+  try {
+    durationHistogram.observe(
+      { source: clampExternalModerationSource(source), outcome },
+      durationSeconds
+    );
+  } catch {
+    // Observability must never break the moderation path. Swallow any prom-client error.
+  }
+}
+
+/**
+ * Record ONE `moderatePrompt` call that short-circuited because the integration is not configured.
+ * Cheap + TOTAL (never throws), same reasoning as above.
+ */
+export function recordExternalModerationSkipped(source: ExternalModerationSource): void {
+  try {
+    skippedCounter.inc({ source: clampExternalModerationSource(source) });
+  } catch {
+    // Observability must never break the moderation path. Swallow any prom-client error.
+  }
+}

--- a/src/server/prom/external-moderation.metrics.ts
+++ b/src/server/prom/external-moderation.metrics.ts
@@ -36,13 +36,19 @@ import { registerCounterWithLabels, registerHistogram } from '@civitai/telemetry
  * The label is load-bearing rather than decorative. `moderatePrompt` is reached from two very
  * different kinds of caller, and mixing them makes the headline figure meaningless:
  *
- * - `generate`    — the request-path prompt gate reached from `orchestrator.generateFromGraph`.
+ * - `generate`    — the request-path audits inside `orchestrator.generateFromGraph`.
  *                   🔴 That is EVERY `GenerationSurface` EXCEPT `preset` — `onsite`, `api` AND
  *                   `block` (the App Blocks bridge) — because `submitSourceForSurface` maps
  *                   everything but `preset` to `generate`. Do not read a rise here as on-site
  *                   generator latency: App Blocks submissions are in it too. An ABSENT surface
  *                   falls to `other`, never to here. This is the population the metric exists to
- *                   size: the number to divide against that procedure's own wall time.
+ *                   size: the series to divide against that procedure's own wall time.
+ *                   🔴 IT COUNTS CALLS, NOT SUBMISSIONS — the same caveat `preset` carries below,
+ *                   and it applies here too. `generateFromGraph` audits TWICE and BOTH sites derive
+ *                   this label: the prompt gate on `data.prompt`, and the ACE Audio creative-field
+ *                   audit on `musicDescription`/`lyrics`. So a submission carrying both contributes
+ *                   2, an ordinary image submission 1, and one whose prompt is blank 0 — the gates
+ *                   are enumerated in the `preset` note below. Divide with that in mind.
  * - `preset`      — surface `preset`: the SAME `generateFromGraph` code reached through
  *                   `submitPresetImageGen`. Split out for exactly the reason its sibling on the
  *                   submit metric is: a background job blended into `generate` would corrupt the one
@@ -51,27 +57,37 @@ import { registerCounterWithLabels, registerHistogram } from '@civitai/telemetry
  *                   THE OTHER. `submitPresetImageGen` has THREE callers which contribute at
  *                   DIFFERENT rates, and nothing on the series distinguishes them:
  *                     · `orchestrator.router.ts`, the `iterateGenerate` procedure — interactive
- *                       tRPC, 1 call per submission;
+ *                       tRPC, AT MOST 1 call per submission;
  *                     · `comics.router.ts`, via the `submitComicGeneration` helper that several of
- *                       that router's procedures share — interactive tRPC, 1 call per submission;
- *                     · `process-enqueued-comic-panels.ts` — the CRON JOB, up to 2 calls per panel:
- *                       its explicit pre-submit `auditPromptServer` gate, which declares
+ *                       that router's procedures share — interactive tRPC, AT MOST 1 call per
+ *                       submission;
+ *                     · `process-enqueued-comic-panels.ts` — the CRON JOB, AT MOST 2 calls per
+ *                       panel: its explicit pre-submit `auditPromptServer` gate, which declares
  *                       `moderationSource: 'preset'` by hand, plus the one inside
  *                       `generateFromGraph`, which derives the same value from the surface.
- *                   So the series is `interactive + up-to-2×cron`, and it CANNOT be divided by 2.
- *                   The cron's own share is not a fixed 2 either: `auditPromptServer` returns early
- *                   on an empty prompt (`promptAuditing.ts:244`) and a HARD regex block throws at
- *                   `:288`, both BEFORE `moderatePrompt` at `:295` — so a blocked panel contributes
- *                   0 or 1, never 2.
+ *                   🔴 EVERY NUMBER ABOVE IS A CEILING, NOT A RATE — which is the whole reason the
+ *                   series cannot be divided back into submissions. Three things stand between a
+ *                   submission and a classifier call, all of them ahead of `moderatePrompt`
+ *                   (`promptAuditing.ts:295`): `auditPromptServer` returns early on an empty prompt
+ *                   (`:244`), a HARD regex block throws (`:288`), and `generateFromGraph` audits
+ *                   only when `data.prompt` is a non-blank string — which a preset submission need
+ *                   not carry, since `buildPresetGraphInput` omits an empty prompt
+ *                   (`preset-image-gen.service.ts:218`) and `iterateGenerate` hands it
+ *                   `fullPrompt || undefined`. So an empty-prompt interactive submission contributes
+ *                   0, and a cron panel contributes 0, 1 or 2.
+ *                   ⚠️ NOT "a blocked panel contributes 0 or 1, never 2", which is what this comment
+ *                   claimed a round ago. That holds only for a REGEX block. An external flag is
+ *                   raised AFTER the classifier answers (`promptAuditing.ts:301`), so a panel the
+ *                   second gate blocks has already paid both calls and contributes 2.
  *                   (The ACE Audio creative-field audit in `generateFromGraph` derives `preset`
  *                   too, but `buildPresetGraphInput` emits only txt2img/img2img input, so as of
  *                   today it contributes nothing here. A preset graph that ever carried
  *                   `musicDescription`/`lyrics` would add a fourth, again-different rate.)
  *                   🔴 THE TRADE THIS PR MADE, so nobody re-derives it as a bug: before it, the
  *                   cron's explicit gate declared nothing and fell to `other` — which inflated
- *                   `other` and undercounted the cron here, but left `preset` at exactly one
+ *                   `other` and undercounted the cron here, but held `preset` to no more than one
  *                   observation per preset submission. Labelling the gate `preset` fixed the `other`
- *                   inflation and cost `preset` that 1:1 relationship. Read it as a call rate on
+ *                   inflation and cost `preset` that ceiling. Read it as a call rate on
  *                   preset work; to recover a per-panel figure you need a label that separates the
  *                   cron from the two interactive routes, which does not exist today.
  * - `remixAudit`  — the `audit-remix-sources` background job, which calls `moderatePrompt` directly
@@ -110,8 +126,9 @@ export type ExternalModerationSource = 'generate' | 'preset' | 'remixAudit' | 'o
  * widened to `string` (a cast, a `JSON.parse`, an `as never` in a test), and the test tree, which
  * `tsconfig.json` EXCLUDES (`src/**\/__tests__/**`) and where a helper CAN spread. What the clamp
  * buys is that none of those can mint an unbounded label value on a hot-path histogram — prom-client
- * retains every distinct label set in the Node heap forever, across ~130 scraped pods, so one stray
- * string is a cardinality incident with a green suite and no error anywhere.
+ * retains every distinct label set in the Node heap until the metric is reset, independently in
+ * every scraped pod, so one stray string is a cardinality incident with a green suite and no error
+ * anywhere.
  */
 const EXTERNAL_MODERATION_SOURCES: ReadonlySet<string> = new Set<ExternalModerationSource>([
   'generate',
@@ -198,13 +215,19 @@ export function isAbortDeadlineError(e: unknown): boolean {
  * 🔴 WHY `4.5` AND NOT `5` — this set used to carry `5`, exactly the default deadline in seconds.
  * Given the above, a boundary sitting on the deadline buys nothing, and it costs something: it splits
  * the single `outcome="timeout"` mode across `le=5` and `le=7.5` on that same sub-millisecond coin
- * flip, so a dashboard renders one population as two. `4.5` is deliberately OFF-ROUND — configured
- * deadlines are round millisecond values (5000, 3000, 10000), so a non-round second boundary cannot
- * coincide with one — and it sits 500 ms clear of the default cap, ~800x the measured clock offset,
- * so nothing races it. This is a MITIGATION, NOT A GUARANTEE: a deployment that sets 4500 ms puts the
- * boundary back on its own cap, and there only `outcome` remains correct. That is precisely why
- * correctness rests on `outcome` and not on this number. Only this one boundary moved; the rest of
- * the set is unchanged, because nothing else about it was wrong.
+ * flip, so a dashboard renders one population as two. What `4.5` buys is 500 ms of clearance from
+ * the DEFAULT cap — ~800x the measured 0.63 ms clock offset — so at the default nothing races it.
+ *
+ * ⚠️ That clearance is the whole argument, and an earlier version of this comment claimed more than
+ * it: that `4.5` is "OFF-ROUND" and so "cannot coincide" with a configured deadline, because those
+ * are round millisecond values. That is false twice over — 4.5 s IS 4500 ms, a perfectly round
+ * millisecond value, and the next sentence already conceded a deployment can set it. There is no
+ * roundness property here to lean on. This is a MITIGATION FOR THE DEFAULT DEPLOYMENT, NOT A
+ * GUARANTEE FOR ANY: the deadline is an env knob over [100 ms, 60 s], and every boundary in the set
+ * below from `0.1` to `20` inclusive falls inside that range — so a deployment can land its deadline
+ * exactly on any of them, 4500 ms included. Wherever that happens, only `outcome` remains correct —
+ * which is precisely why correctness rests on that label and not on this number. Only this one
+ * boundary moved; the rest of the set is unchanged, because nothing else about it was wrong.
  */
 const EXTERNAL_MODERATION_BUCKETS = [
   0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 4.5, 7.5, 10, 20,
@@ -223,8 +246,10 @@ const durationHistogram = registerHistogram({
     'never by which bucket they land in — a capped call and one that answered a hair under the cap are ' +
     'arbitrarily close in duration, so no bucket edge separates them. Filter on source ' +
     'before attributing a figure to a procedure: source=generate is the orchestrator.generateFromGraph ' +
-    'prompt gate for EVERY surface except preset — onsite, api AND block (App Blocks), so it is not ' +
-    'on-site-only — while remixAudit is batch work with nobody waiting.',
+    'audits (the prompt gate AND the ACE Audio creative fields) for EVERY surface except preset — ' +
+    'onsite, api AND block (App Blocks), so it is not on-site-only — while remixAudit is batch work ' +
+    'with nobody waiting. Every series counts CALLS, not submissions: one submission can audit ' +
+    'twice, and a blocked or blank-prompt one may never reach the classifier at all.',
   labelNames: ['source', 'outcome'] as const,
   buckets: [...EXTERNAL_MODERATION_BUCKETS],
 });

--- a/src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts
@@ -1,0 +1,406 @@
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import { clampExternalModerationSource } from '~/server/prom/external-moderation.metrics';
+import { submitSourceForSurface } from '~/server/services/orchestrator/orchestrator-submit-metrics';
+import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substitution';
+
+/**
+ * 🔴 POPULATION + WIRING GUARD for the `source` label of
+ * `civitai_app_external_moderation_duration_seconds`.
+ *
+ * The label is decided at the CALL SITE, travels through `auditPromptServer` as an
+ * observability-only option, and is only read again inside `moderatePrompt`. Nothing about the
+ * verdict, the deadline or the control flow depends on it — which is exactly why it can rot without
+ * a single behavioural test noticing. Measured in the round-1 audit: hardcoding `'preset'` at the
+ * `generateFromGraph` call site survived the entire unit suite, as did dropping the argument
+ * altogether one level down. `tsc` cannot see either: `moderationSource` is optional, so `undefined`
+ * is assignable, and `'preset'` is a legal member of the union.
+ *
+ * This file pins the two halves a behavioural test cannot reach:
+ *
+ *   1. THE MAPPING — what a `GenerationSurface` must become. Executed, not asserted about, so a
+ *      change to `submitSourceForSurface` that re-buckets a surface fails here.
+ *   2. THE LEDGER — every production `auditPromptServer` call site in `src/`, enumerated from the
+ *      TREE rather than from a list someone maintains, each pinned to the `moderationSource`
+ *      expression it must pass. It fails when the set GROWS (a new caller labelled by whatever was
+ *      nearest to hand, or left undeclared and silently inflating `other`), when it SHRINKS (a stale
+ *      row that has stopped guarding anything), and when any pinned site's expression changes.
+ *
+ * MECHANISM, and why it is the TypeScript AST rather than a regex: call sites are matched by
+ * IDENTIFIER (so a `mockAuditPromptServer(...)` is not a call site), the option is read as an
+ * object-literal PROPERTY (so a `moderationSource` appearing in a comment or a string cannot
+ * satisfy it), and comments/string literals are excluded by construction. Same design as
+ * `generation-surface-wiring.test.ts`, which guards the sibling `surface` label; read that file's
+ * header for the full rationale on why the key is `file::enclosingFunction` and not the file.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+
+const NEEDLE = 'auditPromptServer';
+
+/** The declaration itself — not a call site. */
+const DEFINITION_FILE = 'src/server/services/orchestrator/promptAuditing.ts';
+/** This guard's own source: it mentions the needle only in comments and strings. */
+const GUARD_FILE = 'src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts';
+
+/** The approved derivation, and the ONE module each half may be imported from. */
+const CLAMP = 'clampExternalModerationSource';
+const CLAMP_MODULE = '~/server/prom/external-moderation.metrics';
+const MAPPER = 'submitSourceForSurface';
+const MAPPER_MODULE = '~/server/services/orchestrator/orchestrator-submit-metrics';
+
+type CallSiteKey = string;
+
+type SourceArg =
+  /** No `moderationSource` property at all — the caller takes the `other` default on purpose. */
+  | { kind: 'absent' }
+  /** A `ExternalModerationSource` string literal written at the call site. */
+  | { kind: 'literal'; value: string }
+  /** `clampExternalModerationSource(submitSourceForSurface(...))` — the surface-derived form. */
+  | { kind: 'derived' }
+  /** Anything else: a variable, a ternary, a cast, a different call, a shorthand property. */
+  | { kind: 'other'; text: string };
+
+interface CallSite {
+  file: string;
+  fn: string;
+  line: number;
+  sourceArg: SourceArg;
+  /** Does this FILE import both halves of the derivation from the modules that define them? */
+  importsDerivation: boolean;
+}
+
+const describeArg = (a: SourceArg): string =>
+  a.kind === 'absent'
+    ? 'no moderationSource property'
+    : a.kind === 'literal'
+    ? `the literal '${a.value}'`
+    : a.kind === 'derived'
+    ? `${CLAMP}(${MAPPER}(...))`
+    : a.text;
+
+/**
+ * What each production caller must declare.
+ *
+ * 🔴 ADDING A ROW IS THE REVIEWABLE ACT. `'absent'` is a real choice, not a gap: it says "this
+ * funnel is deliberately part of the `other` mixture", which the metric's own doc comment describes
+ * as a mixture that must not be read as any single path. Choosing it for a HIGH-VOLUME caller is
+ * what dilutes `other` into uselessness, so it has to be written down rather than defaulted into.
+ */
+const EXPECTED_SOURCE_BY_CALL_SITE: Record<CallSiteKey, SourceArg> = {
+  // 🔴 DERIVED, NOT LITERAL. Both audits inside `generateFromGraph` (the prompt gate and the ACE
+  // Audio creative fields) serve every surface the procedure serves — `onsite`, `api`, `block` and
+  // `preset` — and which one it is is a property of the REQUEST. Hardcoding any member here is the
+  // round-1 mutant: `'preset'` files every on-site generation under the cron's population, and
+  // `'generate'` files the comics cron under the request path. Either way the one division this
+  // metric supports is corrupted, and nothing else in the suite moves.
+  'src/server/services/orchestrator/orchestration-new.service.ts::generateFromGraph': {
+    kind: 'derived',
+  },
+  // The comics cron's explicit pre-submit gate. It runs OUTSIDE the tRPC request path and is the
+  // second of the two external-moderation calls this job makes per panel — the other one is the
+  // derived site above, reached through `submitPresetImageGen`. A literal is correct here precisely
+  // because there is no request and therefore no surface to derive from; leaving it absent (which is
+  // what shipped before round 1) made `preset` undercount this cron by half.
+  'src/server/jobs/process-enqueued-comic-panels.ts::processEnqueuedComicPanelsJob': {
+    kind: 'literal',
+    value: 'preset',
+  },
+  // ── Deliberately part of the `other` mixture ────────────────────────────────────────────────
+  // The App Blocks host-side audits. These are pre-checks the block host runs before it ever
+  // reaches `generateFromGraph`; the generation they precede is labelled `generate` at the derived
+  // site above, via surface `block`. Labelling them `generate` too would double-count the block
+  // population against one submission.
+  'src/server/routers/blocks.router.ts::submitWorkflow': { kind: 'absent' },
+  'src/server/routers/blocks.router.ts::submitCustomComfyWorkflow': { kind: 'absent' },
+  // Shared app content safety, block moderation steps and prompt enhancement: none of these is a
+  // generation submission, so none belongs in a population that gets divided against
+  // `generateFromGraph`'s wall time.
+  'src/server/services/apps/shared-content-safety.ts::assertSharedTextSafe': { kind: 'absent' },
+  'src/server/services/blocks/steps/moderation.ts::submit': { kind: 'absent' },
+  'src/server/services/orchestrator/promptEnhancement.ts::enhancePrompt': { kind: 'absent' },
+};
+
+function candidateFiles(): string[] {
+  const found: string[] = [];
+  const walk = (rel: string) => {
+    for (const entry of readdirSync(path.join(REPO_ROOT, rel), { withFileTypes: true })) {
+      const child = `${rel}/${entry.name}`;
+      if (entry.isDirectory()) walk(child);
+      else if (
+        /\.tsx?$/.test(entry.name) &&
+        readFileSync(path.join(REPO_ROOT, child), 'utf8').includes(NEEDLE)
+      )
+        found.push(child);
+    }
+  };
+  walk('src');
+  return found
+    .filter((f) => f !== DEFINITION_FILE && f !== GUARD_FILE)
+    .filter((f) => !(f.includes('__tests__') || f.endsWith('.test.ts')));
+}
+
+/** Nearest named enclosing function/method/`const fn = …`/object property. */
+function enclosingFunctionName(node: ts.Node): string {
+  let sawFunctionBoundary = false;
+  let cur: ts.Node | undefined = node.parent;
+  while (cur) {
+    if (ts.isFunctionDeclaration(cur)) {
+      if (cur.name) return cur.name.text;
+      sawFunctionBoundary = true;
+    } else if (ts.isMethodDeclaration(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    } else if (ts.isFunctionExpression(cur)) {
+      if (cur.name) return cur.name.text;
+      sawFunctionBoundary = true;
+    } else if (ts.isArrowFunction(cur)) {
+      sawFunctionBoundary = true;
+    } else if (sawFunctionBoundary && ts.isVariableDeclaration(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    } else if (sawFunctionBoundary && ts.isPropertyAssignment(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    }
+    cur = cur.parent;
+  }
+  return '<module scope>';
+}
+
+const calleeNameOf = (expr: ts.Expression): string | null =>
+  ts.isIdentifier(expr)
+    ? expr.text
+    : ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.name)
+    ? expr.name.text
+    : null;
+
+/**
+ * Classify the `moderationSource` value at one call site.
+ *
+ * Conservative by construction: only the two approved shapes are recognised. A shorthand property,
+ * a variable, a ternary, an `as` cast, a bare `MAPPER(...)` without the clamp, or a clamp wrapping
+ * anything other than the mapper all land in `{ kind: 'other' }` and fail every pin — including
+ * `clampExternalModerationSource('preset')`, which is the hardcode mutant wearing the right hat.
+ */
+function describeSourceArg(call: ts.CallExpression, src: ts.SourceFile): SourceArg {
+  const arg = call.arguments[0];
+  if (!arg || !ts.isObjectLiteralExpression(arg))
+    return { kind: 'other', text: 'a non-literal options object' };
+
+  const prop = arg.properties.find(
+    (p) => p.name && ts.isIdentifier(p.name) && p.name.text === 'moderationSource'
+  );
+  if (!prop) return { kind: 'absent' };
+  if (!ts.isPropertyAssignment(prop))
+    return { kind: 'other', text: `a ${ts.SyntaxKind[prop.kind]} property` };
+
+  const init = prop.initializer;
+  if (ts.isStringLiteral(init)) return { kind: 'literal', value: init.text };
+  if (ts.isCallExpression(init) && calleeNameOf(init.expression) === CLAMP) {
+    const inner = init.arguments[0];
+    if (inner && ts.isCallExpression(inner) && calleeNameOf(inner.expression) === MAPPER)
+      return { kind: 'derived' };
+    return {
+      kind: 'other',
+      text: `${CLAMP}(...) wrapping ${inner ? inner.getText(src).slice(0, 60) : 'nothing'}`,
+    };
+  }
+  return { kind: 'other', text: ts.SyntaxKind[init.kind] };
+}
+
+/**
+ * 🔴 NAME EQUALITY IS NOT ENOUGH — an identifier is just a name in scope. A module-local
+ * `function submitSourceForSurface() { return 'preset'; }` shadowing the import would satisfy the
+ * AST shape above and reinstate the exact mutant this guard exists for, with `tsc` clean. Requiring
+ * the EXPORTED name to be imported from the module that DEFINES it closes that without a Program.
+ * It fails CLOSED: a namespace import or a relative specifier for the same module fails too. That is
+ * deliberate — if you hit it while adding a call site, switch to the `~/`-aliased named import
+ * rather than loosening this.
+ */
+function importsNamedFrom(source: ts.SourceFile, moduleSpecifier: string, name: string): boolean {
+  return source.statements.some((st) => {
+    if (!ts.isImportDeclaration(st)) return false;
+    if (!ts.isStringLiteral(st.moduleSpecifier)) return false;
+    if (st.moduleSpecifier.text !== moduleSpecifier) return false;
+    const named = st.importClause?.namedBindings;
+    if (!named || !ts.isNamedImports(named)) return false;
+    // The EXPORTED name, not the local binding: on `import { a as b }`, `propertyName` is `a`.
+    return named.elements.some((el) => (el.propertyName ?? el.name).text === name);
+  });
+}
+
+function callSitesIn(file: string): CallSite[] {
+  const text = readFileSync(path.join(REPO_ROOT, file), 'utf8');
+  const source = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const importsDerivation =
+    importsNamedFrom(source, CLAMP_MODULE, CLAMP) &&
+    importsNamedFrom(source, MAPPER_MODULE, MAPPER);
+  const found: CallSite[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && calleeNameOf(node.expression) === NEEDLE) {
+      found.push({
+        file,
+        fn: enclosingFunctionName(node),
+        line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+        sourceArg: describeSourceArg(node, source),
+        importsDerivation,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
+}
+
+const keyOf = (c: CallSite): CallSiteKey => `${c.file}::${c.fn}`;
+
+/**
+ * PART 1 — the mapping, executed.
+ *
+ * The AST ledger below can only prove that the derived call sites call this pair; it cannot know
+ * what the pair RETURNS. That is what these cases pin, and they are what make the `derived` pin mean
+ * something rather than merely being a shape.
+ */
+describe('surface → external-moderation source mapping', () => {
+  const derive = (surface: Parameters<typeof submitSourceForSurface>[0]) =>
+    clampExternalModerationSource(submitSourceForSurface(surface));
+
+  it.each([
+    ['onsite', 'generate'],
+    ['api', 'generate'],
+    // 🔴 `block` — the App Blocks bridge — maps to `generate`, NOT to a surface of its own. This is
+    // the row the metric's doc comment used to contradict (it described `generate` as "surface
+    // onsite/api"), and getting it wrong in the other direction means attributing App Blocks
+    // latency to the on-site generator.
+    ['block', 'generate'],
+    ['preset', 'preset'],
+  ] as const)('maps surface %s to source %s', (surface, expected) => {
+    expect(
+      derive(surface),
+      `surface '${surface}' must be recorded as source '${expected}' on ` +
+        `civitai_app_external_moderation_duration_seconds. Re-bucketing it silently moves an entire ` +
+        `population between two series that operators divide against each other.`
+    ).toBe(expected);
+  });
+
+  it('falls an ABSENT surface to other, never to generate', () => {
+    expect(
+      derive(undefined),
+      'an unknown caller inflating the headline `generate` population is the failure nobody would ' +
+        'notice; an absent surface must take the `other` default.'
+    ).toBe('other');
+  });
+
+  it('covers every declared GenerationSurface (no surface left unmapped)', () => {
+    // Guard the guard: a surface added later with no row above would otherwise be silently
+    // untested, and would reach the histogram through the derived call sites regardless.
+    const mapped = new Set(GENERATION_SURFACES.map((s) => derive(s)));
+    expect(
+      [...GENERATION_SURFACES].sort(),
+      'every GENERATION_SURFACES member must appear in the table above'
+    ).toEqual(['api', 'block', 'onsite', 'preset']);
+    // …and each must land inside the bounded vocabulary, not on the clamp's fallback by accident.
+    expect([...mapped].sort()).toEqual(['generate', 'preset']);
+  });
+});
+
+/** PART 2 — the ledger of production call sites. */
+describe('auditPromptServer moderationSource wiring', () => {
+  let sites: CallSite[] = [];
+  let enumerationError: unknown;
+  try {
+    sites = candidateFiles().flatMap(callSitesIn);
+  } catch (e) {
+    // A throw in the describe BODY happens during registration, so no `it` below would be declared
+    // and the file would collect zero tests while reading green. Catch it and report it from a test.
+    enumerationError = e;
+  }
+
+  it('finds the call sites at all (guard the guard)', () => {
+    if (enumerationError) throw enumerationError;
+    expect(
+      sites.length,
+      'a broken enumeration would make every assertion below pass vacuously over an empty list'
+    ).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SOURCE_BY_CALL_SITE).length);
+    expect(
+      sites.filter((c) => c.fn === '<module scope>'),
+      'a call site with no named enclosing function would collapse distinct callers onto one key'
+    ).toEqual([]);
+  });
+
+  it('🔴 every function that audits a prompt is a pinned call site (the set cannot GROW silently)', () => {
+    const unexpected = sites
+      .filter((c) => !(keyOf(c) in EXPECTED_SOURCE_BY_CALL_SITE))
+      .map((c) => `${c.file}:${c.line} inside ${c.fn}() passes ${describeArg(c.sourceArg)}`);
+    expect(
+      unexpected,
+      'a new auditPromptServer caller must declare its moderationSource on purpose — add a row to ' +
+        'EXPECTED_SOURCE_BY_CALL_SITE. Left undeclared it joins the `other` mixture, which the ' +
+        'metric documents as unreadable as any single path; labelled `generate` by reflex it ' +
+        'inflates the one population the histogram exists to size.'
+    ).toEqual([]);
+  });
+
+  it('no pinned call site has disappeared (the set cannot SHRINK silently)', () => {
+    const live = new Set(sites.map(keyOf));
+    const missing = Object.keys(EXPECTED_SOURCE_BY_CALL_SITE).filter((k) => !live.has(k));
+    expect(
+      missing,
+      'a stale row guards nothing, and keeps this table reading as coverage while providing none'
+    ).toEqual([]);
+  });
+
+  it('🔴 every pinned call site passes the moderationSource expression it must', () => {
+    const wrong = sites
+      .filter((c) => keyOf(c) in EXPECTED_SOURCE_BY_CALL_SITE)
+      .map((c) => {
+        const pin = EXPECTED_SOURCE_BY_CALL_SITE[keyOf(c)];
+        const at = `${c.file}:${c.line} inside ${c.fn}()`;
+        const got = describeArg(c.sourceArg);
+        if (pin.kind === 'derived') {
+          if (c.sourceArg.kind !== 'derived')
+            return (
+              `${at} passes ${got} in the moderationSource slot, expected ` +
+              `${CLAMP}(${MAPPER}(<request surface>)). This call site serves EVERY surface, so any ` +
+              `literal here files one population under another's series — the exact mutation this ` +
+              `guard was added for.`
+            );
+          if (!c.importsDerivation)
+            return (
+              `${at} calls ${CLAMP}(${MAPPER}(...)), but ${c.file} does not import BOTH ` +
+              `\`${CLAMP}\` from '${CLAMP_MODULE}' and \`${MAPPER}\` from '${MAPPER_MODULE}'. ` +
+              `Either one of those names is bound to something else locally (a shadowing function ` +
+              `or an alias of a different export) — which is the bug this checks for — or the ` +
+              `import is written in a shape this guard deliberately does not accept (a namespace ` +
+              `import, or a relative specifier). If it is the latter, switch to the ` +
+              `'~/'-aliased named import; do not loosen this check.`
+            );
+          return null;
+        }
+        if (pin.kind === 'literal') {
+          if (c.sourceArg.kind === 'literal' && c.sourceArg.value === pin.value) return null;
+          return (
+            `${at} passes ${got} in the moderationSource slot, expected the literal ` +
+            `'${pin.value}'. This caller has no request surface to derive from, so the label is ` +
+            `only ever as correct as this literal; dropping it sends the caller to 'other'.`
+          );
+        }
+        if (c.sourceArg.kind === 'absent') return null;
+        return (
+          `${at} passes ${got}, but is pinned as deliberately UNDECLARED (part of the 'other' ` +
+          `mixture). If this caller should now be labelled, change its row on purpose — a label ` +
+          `added here moves observations into a series operators divide against a procedure's ` +
+          `wall time.`
+        );
+      })
+      .filter((m): m is string => m !== null);
+    expect(wrong).toEqual([]);
+  });
+});

--- a/src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts
@@ -28,6 +28,9 @@ import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substi
  *      expression it must pass. It fails when the set GROWS (a new caller labelled by whatever was
  *      nearest to hand, or left undeclared and silently inflating `other`), when it SHRINKS (a stale
  *      row that has stopped guarding anything), and when any pinned site's expression changes.
+ *      🔴 A row pins a COUNT of call sites, not just a key. The key is `file::enclosingFunction`,
+ *      which is coarser than a call site — `generateFromGraph` and `enhancePrompt` each audit
+ *      TWICE — so key-presence alone cannot see a deletion INSIDE a key. See `ExpectedCallSite`.
  *
  * MECHANISM, and why it is the TypeScript AST rather than a regex: call sites are matched by
  * IDENTIFIER (so a `mockAuditPromptServer(...)` is not a call site), the option is read as an
@@ -61,6 +64,14 @@ type SourceArg =
   | { kind: 'literal'; value: string }
   /** `clampExternalModerationSource(submitSourceForSurface(...))` — the surface-derived form. */
   | { kind: 'derived' }
+  /**
+   * The call's first argument is not an INLINE object literal — a hoisted `const opts = {...}`, a
+   * spread, a variable, a function call. Behaviour-identical for the app; opaque to this guard,
+   * which reads `moderationSource` as a property of the literal at the call site. Kept distinct
+   * from `other` because the two need OPPOSITE remedies: `other` means "the value you declared is
+   * not one of the approved shapes", this means "I cannot see what you declared at all".
+   */
+  | { kind: 'unreadable'; text: string }
   /** Anything else: a variable, a ternary, a cast, a different call, a shorthand property. */
   | { kind: 'other'; text: string };
 
@@ -80,7 +91,31 @@ const describeArg = (a: SourceArg): string =>
     ? `the literal '${a.value}'`
     : a.kind === 'derived'
     ? `${CLAMP}(${MAPPER}(...))`
+    : a.kind === 'unreadable'
+    ? `options this guard cannot read (${a.text})`
     : a.text;
+
+interface ExpectedCallSite {
+  /**
+   * 🔴 HOW MANY `auditPromptServer` CALLS THIS KEY COVERS — and the reason this field exists.
+   *
+   * A key is `file::enclosingFunction`, which is NOT 1:1 with call sites: a function may audit more
+   * than once. Without a count, every check in this file degrades to "does the key still exist",
+   * and a DELETION INSIDE an existing key is invisible. Measured in the round-2 audit: deleting the
+   * ACE Audio `auditPromptServer` call from `generateFromGraph` — which silently stops moderating
+   * `musicDescription` and `lyrics` — took the ledger from 9 live sites to 8 and left it 10/10
+   * GREEN, because `generateFromGraph` still had its other call.
+   */
+  sites: number;
+  /**
+   * What the `sites` calls under this key ARE, in source order. Purely for the failure message: a
+   * count mismatch can only report "expected N, found M", so this is what lets the message name the
+   * call that vanished instead of sending the reader to diff the function by hand.
+   */
+  siteNote: string;
+  /** The expression EVERY call under this key must pass in the `moderationSource` slot. */
+  arg: SourceArg;
+}
 
 /**
  * What each production caller must declare.
@@ -89,8 +124,11 @@ const describeArg = (a: SourceArg): string =>
  * funnel is deliberately part of the `other` mixture", which the metric's own doc comment describes
  * as a mixture that must not be read as any single path. Choosing it for a HIGH-VOLUME caller is
  * what dilutes `other` into uselessness, so it has to be written down rather than defaulted into.
+ *
+ * 🔴 CHANGING A `sites` COUNT IS EQUALLY REVIEWABLE. Lowering one is how a removed audit gets
+ * waved through; do it only when the removal itself is the intended change.
  */
-const EXPECTED_SOURCE_BY_CALL_SITE: Record<CallSiteKey, SourceArg> = {
+const EXPECTED_SOURCE_BY_CALL_SITE: Record<CallSiteKey, ExpectedCallSite> = {
   // 🔴 DERIVED, NOT LITERAL. Both audits inside `generateFromGraph` (the prompt gate and the ACE
   // Audio creative fields) serve every surface the procedure serves — `onsite`, `api`, `block` and
   // `preset` — and which one it is is a property of the REQUEST. Hardcoding any member here is the
@@ -98,7 +136,12 @@ const EXPECTED_SOURCE_BY_CALL_SITE: Record<CallSiteKey, SourceArg> = {
   // `'generate'` files the comics cron under the request path. Either way the one division this
   // metric supports is corrupted, and nothing else in the suite moves.
   'src/server/services/orchestrator/orchestration-new.service.ts::generateFromGraph': {
-    kind: 'derived',
+    sites: 2,
+    siteNote:
+      '(1) the prompt gate on `data.prompt`, and (2) the ACE Audio creative-field audit on ' +
+      '`musicDescription` + `lyrics`. Losing (2) stops moderating audio prompts entirely and ' +
+      'changes NOTHING that any behavioural test observes',
+    arg: { kind: 'derived' },
   },
   // The comics cron's explicit pre-submit gate. It runs OUTSIDE the tRPC request path and is the
   // second of the two external-moderation calls this job makes per panel — the other one is the
@@ -106,23 +149,52 @@ const EXPECTED_SOURCE_BY_CALL_SITE: Record<CallSiteKey, SourceArg> = {
   // because there is no request and therefore no surface to derive from; leaving it absent (which is
   // what shipped before round 1) made `preset` undercount this cron by half.
   'src/server/jobs/process-enqueued-comic-panels.ts::processEnqueuedComicPanelsJob': {
-    kind: 'literal',
-    value: 'preset',
+    sites: 1,
+    siteNote: 'the explicit pre-submit gate, before `submitPresetImageGen`',
+    arg: { kind: 'literal', value: 'preset' },
   },
   // ── Deliberately part of the `other` mixture ────────────────────────────────────────────────
   // The App Blocks host-side audits. These are pre-checks the block host runs before it ever
   // reaches `generateFromGraph`; the generation they precede is labelled `generate` at the derived
   // site above, via surface `block`. Labelling them `generate` too would double-count the block
   // population against one submission.
-  'src/server/routers/blocks.router.ts::submitWorkflow': { kind: 'absent' },
-  'src/server/routers/blocks.router.ts::submitCustomComfyWorkflow': { kind: 'absent' },
+  'src/server/routers/blocks.router.ts::submitWorkflow': {
+    sites: 1,
+    siteNote: "the block host's pre-check on the submitted workflow prompt",
+    arg: { kind: 'absent' },
+  },
+  'src/server/routers/blocks.router.ts::submitCustomComfyWorkflow': {
+    sites: 1,
+    siteNote: "the block host's pre-check on the custom-comfy prompt",
+    arg: { kind: 'absent' },
+  },
   // Shared app content safety, block moderation steps and prompt enhancement: none of these is a
   // generation submission, so none belongs in a population that gets divided against
   // `generateFromGraph`'s wall time.
-  'src/server/services/apps/shared-content-safety.ts::assertSharedTextSafe': { kind: 'absent' },
-  'src/server/services/blocks/steps/moderation.ts::submit': { kind: 'absent' },
-  'src/server/services/orchestrator/promptEnhancement.ts::enhancePrompt': { kind: 'absent' },
+  'src/server/services/apps/shared-content-safety.ts::assertSharedTextSafe': {
+    sites: 1,
+    siteNote: 'the shared-text safety audit',
+    arg: { kind: 'absent' },
+  },
+  'src/server/services/blocks/steps/moderation.ts::submit': {
+    sites: 1,
+    siteNote: "the 'promptAudit' step's submit-phase audit",
+    arg: { kind: 'absent' },
+  },
+  'src/server/services/orchestrator/promptEnhancement.ts::enhancePrompt': {
+    sites: 2,
+    siteNote:
+      '(1) the audit of `prompt` + `negativePrompt`, and (2) the audit of the user-supplied ' +
+      '`input.instruction`, which is separately user-controlled free text',
+    arg: { kind: 'absent' },
+  },
 };
+
+/** Total `auditPromptServer` calls the ledger claims to cover — sites, not keys. */
+const EXPECTED_SITE_TOTAL = Object.values(EXPECTED_SOURCE_BY_CALL_SITE).reduce(
+  (n, e) => n + e.sites,
+  0
+);
 
 function candidateFiles(): string[] {
   const found: string[] = [];
@@ -182,11 +254,23 @@ const calleeNameOf = (expr: ts.Expression): string | null =>
  * a variable, a ternary, an `as` cast, a bare `MAPPER(...)` without the clamp, or a clamp wrapping
  * anything other than the mapper all land in `{ kind: 'other' }` and fail every pin — including
  * `clampExternalModerationSource('preset')`, which is the hardcode mutant wearing the right hat.
+ *
+ * Separately from those: an argument that is not an inline object literal at all yields
+ * `{ kind: 'unreadable' }`, which is a claim about this guard's VISIBILITY rather than about the
+ * caller's label, and carries its own failure message.
  */
 function describeSourceArg(call: ts.CallExpression, src: ts.SourceFile): SourceArg {
   const arg = call.arguments[0];
-  if (!arg || !ts.isObjectLiteralExpression(arg))
-    return { kind: 'other', text: 'a non-literal options object' };
+  // 🔴 `unreadable`, NOT `other`. An argument that is not an inline object literal (a hoisted
+  // `const opts = {...}`, a spread, a variable) is behaviour-identical for the app but opaque to
+  // this AST guard — it is a statement about what this FILE can see, not about what the caller
+  // declared. Reporting it as `other` sent a maintainer looking for a label that was never removed.
+  if (!arg) return { kind: 'unreadable', text: 'called with no arguments at all' };
+  if (!ts.isObjectLiteralExpression(arg))
+    return {
+      kind: 'unreadable',
+      text: `its first argument is a ${ts.SyntaxKind[arg.kind]}, not an inline object literal`,
+    };
 
   const prop = arg.properties.find(
     (p) => p.name && ts.isIdentifier(p.name) && p.name.text === 'moderationSource'
@@ -328,7 +412,7 @@ describe('auditPromptServer moderationSource wiring', () => {
     expect(
       sites.length,
       'a broken enumeration would make every assertion below pass vacuously over an empty list'
-    ).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SOURCE_BY_CALL_SITE).length);
+    ).toBeGreaterThanOrEqual(EXPECTED_SITE_TOTAL);
     expect(
       sites.filter((c) => c.fn === '<module scope>'),
       'a call site with no named enclosing function would collapse distinct callers onto one key'
@@ -348,11 +432,47 @@ describe('auditPromptServer moderationSource wiring', () => {
     ).toEqual([]);
   });
 
-  it('no pinned call site has disappeared (the set cannot SHRINK silently)', () => {
-    const live = new Set(sites.map(keyOf));
-    const missing = Object.keys(EXPECTED_SOURCE_BY_CALL_SITE).filter((k) => !live.has(k));
+  it('🔴 every pinned key covers EXACTLY the number of call sites it claims (no silent SHRINK, and no add hiding inside a key)', () => {
+    // 🔴 COUNTED PER KEY, NOT MERELY PRESENT. The key is `file::enclosingFunction`, so a function
+    // that audits twice occupies ONE key: a set-membership check goes green the moment ANY of its
+    // calls survives. That is not a hypothetical — deleting `generateFromGraph`'s ACE Audio audit
+    // (dropping `musicDescription`/`lyrics` moderation entirely) left the previous version of this
+    // ledger fully green. The count is what makes a within-key deletion fail.
+    const liveByKey = new Map<CallSiteKey, CallSite[]>();
+    for (const c of sites) {
+      const k = keyOf(c);
+      const bucket = liveByKey.get(k);
+      if (bucket) bucket.push(c);
+      else liveByKey.set(k, [c]);
+    }
+
+    const wrong = Object.entries(EXPECTED_SOURCE_BY_CALL_SITE)
+      .map(([key, pin]) => {
+        const live = liveByKey.get(key) ?? [];
+        if (live.length === pin.sites) return null;
+        const where = live.length
+          ? `remaining at line(s) ${live.map((c) => c.line).join(', ')}`
+          : 'NONE remain';
+        if (live.length < pin.sites)
+          return (
+            `${key} — pinned as covering ${pin.sites} ${NEEDLE} call(s), found ${live.length}. ` +
+            `${where}. The pinned calls are: ${pin.siteNote}. An audit was DELETED from inside ` +
+            `this function: the key still exists, so nothing else in this file or the suite can ` +
+            `see it. If the removal is intended, lower \`sites\` on this row in the same change ` +
+            `and say why — do not lower it to make this pass.`
+          );
+        return (
+          `${key} — pinned as covering ${pin.sites} ${NEEDLE} call(s), found ${live.length} ` +
+          `(at line(s) ${live.map((c) => c.line).join(', ')}). The pinned calls are: ` +
+          `${pin.siteNote}. A new audit was added inside an ALREADY-pinned function, so the ` +
+          `"set cannot GROW" check above did not see it — its moderationSource is still pinned ` +
+          `by this row, which may or may not be the label it wants. Raise \`sites\` on purpose.`
+        );
+      })
+      .filter((m): m is string => m !== null);
+
     expect(
-      missing,
+      wrong,
       'a stale row guards nothing, and keeps this table reading as coverage while providing none'
     ).toEqual([]);
   });
@@ -361,9 +481,26 @@ describe('auditPromptServer moderationSource wiring', () => {
     const wrong = sites
       .filter((c) => keyOf(c) in EXPECTED_SOURCE_BY_CALL_SITE)
       .map((c) => {
-        const pin = EXPECTED_SOURCE_BY_CALL_SITE[keyOf(c)];
+        const pin = EXPECTED_SOURCE_BY_CALL_SITE[keyOf(c)].arg;
         const at = `${c.file}:${c.line} inside ${c.fn}()`;
         const got = describeArg(c.sourceArg);
+        // 🔴 ITS OWN MESSAGE, ahead of every pin branch. This is not "the declared label is wrong";
+        // it is "this guard cannot READ the declaration". Folding it into the branches below
+        // reported a hoisted `const opts = {...}` — behaviour-identical to the inline literal — as
+        // a caller "pinned as deliberately UNDECLARED", which sends a maintainer hunting for a
+        // label nobody removed.
+        if (c.sourceArg.kind === 'unreadable')
+          return (
+            `${at} does not pass its options as an INLINE OBJECT LITERAL — ${c.sourceArg.text}. ` +
+            `NOTHING IS NECESSARILY WRONG WITH THE LABEL: this guard reads \`moderationSource\` ` +
+            `as a property of the literal written at the call site, so against a hoisted object ` +
+            `(\`const opts = {...}; await ${NEEDLE}(opts)\`), a spread, or a variable it cannot ` +
+            `see what this caller declares at all — and a ledger that cannot read a site cannot ` +
+            `pin it. Do not go looking for a missing label. Inline the object literal at the call ` +
+            `site (hoisting it is behaviour-identical, so nothing is lost by inlining it back). ` +
+            `If this caller genuinely must build its options dynamically, that changes what this ` +
+            `ledger can guarantee about it and needs a deliberate row design — not a loosened check.`
+          );
         if (pin.kind === 'derived') {
           if (c.sourceArg.kind !== 'derived')
             return (

--- a/src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/moderation-source-wiring.test.ts
@@ -144,10 +144,12 @@ const EXPECTED_SOURCE_BY_CALL_SITE: Record<CallSiteKey, ExpectedCallSite> = {
     arg: { kind: 'derived' },
   },
   // The comics cron's explicit pre-submit gate. It runs OUTSIDE the tRPC request path and is the
-  // second of the two external-moderation calls this job makes per panel — the other one is the
-  // derived site above, reached through `submitPresetImageGen`. A literal is correct here precisely
-  // because there is no request and therefore no surface to derive from; leaving it absent (which is
-  // what shipped before round 1) made `preset` undercount this cron by half.
+  // FIRST of the two places this job can reach the external classifier per panel — the other is the
+  // derived site above, reached through `submitPresetImageGen`. (Two PLACES, not two calls: a panel
+  // contributes 0, 1 or 2 observations depending on which gate short-circuits, as the metric's own
+  // doc comment sets out.) A literal is correct here precisely because there is no request and
+  // therefore no surface to derive from; leaving it absent (which is what shipped before round 1)
+  // sent this gate's observations to `other` instead of `preset`.
   'src/server/jobs/process-enqueued-comic-panels.ts::processEnqueuedComicPanelsJob': {
     sites: 1,
     siteNote: 'the explicit pre-submit gate, before `submitPresetImageGen`',

--- a/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.accents.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.accents.test.ts
@@ -71,15 +71,19 @@ describe('auditPromptServer — a whitelisted phrase stays whitelisted when acce
   // last consumer of the audited copy, so its argument IS that copy — which pins that exactly
   // the phrase was blanked. `resolves` alone stays green if a future strip swallows the whole
   // prompt, and an empty audited prompt short-circuits the detector into success for anything.
+  // The second argument is the OBSERVABILITY-ONLY `moderationSource` label. It is `undefined`
+  // here because these options declare none, which is the point: an undeclared caller must not
+  // be labelled `generate`. Asserted at full arity rather than relaxed to a first-argument
+  // check, so this still pins exactly what `moderatePrompt` is handed.
   it('allows the plain spelling (control — green with and without the fix)', async () => {
     await expect(auditPromptServer(optionsFor('emma stone portrait'))).resolves.toBeUndefined();
-    expect(mockModeratePrompt).toHaveBeenCalledWith(AUDITED);
+    expect(mockModeratePrompt).toHaveBeenCalledWith(AUDITED, undefined);
     expect(mockProhibited).not.toHaveBeenCalled();
   });
 
   it('allows the accented spelling', async () => {
     await expect(auditPromptServer(optionsFor('émma stone portrait'))).resolves.toBeUndefined();
-    expect(mockModeratePrompt).toHaveBeenCalledWith(AUDITED);
+    expect(mockModeratePrompt).toHaveBeenCalledWith(AUDITED, undefined);
     expect(mockProhibited).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.benign-phrases.test.ts
@@ -97,7 +97,10 @@ describe('auditPromptServer — benign-phrase stripping', () => {
     expect(auditedPrompt).not.toContain('teen titans');
     expect(auditedNegative).not.toContain('mature content');
     // External moderation sees the same cleaned text as the regex audit.
-    expect(mockModeratePrompt).toHaveBeenCalledWith(auditedPrompt);
+    // Second argument = the observability-only `moderationSource` label, `undefined` because
+    // these options declare none. Asserted at full arity so this keeps pinning exactly what
+    // `moderatePrompt` is handed, not merely its first argument.
+    expect(mockModeratePrompt).toHaveBeenCalledWith(auditedPrompt, undefined);
   });
 
   it('a prompt that only trips on a benign phrase is no longer blocked', async () => {

--- a/src/server/services/orchestrator/__tests__/promptAuditing.moderation-source.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.moderation-source.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as AuditModule from '~/utils/metadata/audit';
+
+/**
+ * 🔴 SEAM GUARD for the `moderationSource` label — `auditPromptServer` → `extModeration.moderatePrompt`.
+ *
+ * WHY THIS FILE EXISTS. Every other test around this feature is scoped to ONE side of the seam:
+ * `external-moderation.metrics.test.ts` proves the histogram records whatever source it is handed,
+ * and `moderation.instrumentation.test.ts` proves `moderatePrompt` labels an observation with
+ * whatever source IT is handed. Neither loads the code that decides which source to hand over, so
+ * both stay green when the value stops being passed at all. Measured in the round-1 audit:
+ * substituting a literal `undefined` for `moderationSource` at the `moderatePrompt` call site in
+ * `promptAuditing.ts` survived the ENTIRE unit suite — every file green, an identical pass count.
+ * Re-run against THIS file, the same mutant fails five of its six cases.
+ *
+ * WHAT THAT MUTANT DOES IN PRODUCTION. `source="generate"` and `source="preset"` go permanently
+ * empty and 100 % of observations pile onto `other`. That is worse than a wrong number: an empty
+ * `generate` series is INDISTINGUISHABLE from "no generations happened", and reading
+ * `source=generate` is exactly the query the metric's own help text tells an operator to run.
+ * `tsc` cannot see it either — `moderationSource` is optional, so `undefined` is assignable.
+ *
+ * WHY THE EXISTING ASSERTIONS DID NOT COVER IT. Two sibling tests assert
+ * `toHaveBeenCalledWith(auditedPrompt, undefined)`. That pins the DEFAULT and the ARITY — both
+ * worth having — but `undefined` is precisely the mutant's value, so it can only ever agree with
+ * it. Nothing anywhere pinned a DECLARED source travelling end to end. This file does, over the
+ * whole vocabulary, so a mutant that drops the argument or hardcodes any one value fails here and
+ * names the source it failed on.
+ *
+ * The mock preamble follows `promptAuditing.benign-phrases.test.ts` MINUS its redis block (see the
+ * note beside the mocks) — it only keeps the heavy module graph inert so `promptAuditing` imports;
+ * nothing below depends on any of it beyond `stripBenignPhrases` and `moderatePrompt`.
+ */
+
+const { mockStripBenignPhrases, mockAuditPromptEnriched, mockModeratePrompt, mockProhibited } =
+  vi.hoisted(() => ({
+    mockStripBenignPhrases: vi.fn(),
+    mockAuditPromptEnriched: vi.fn(),
+    mockModeratePrompt: vi.fn(async () => ({ flagged: false, categories: [] as string[] })),
+    mockProhibited: vi.fn(),
+  }));
+
+vi.mock('~/server/services/blocklist.service', () => ({
+  stripBenignPhrases: mockStripBenignPhrases,
+}));
+vi.mock('~/utils/metadata/audit', async (importOriginal) => ({
+  ...(await importOriginal<typeof AuditModule>()),
+  auditPromptEnriched: mockAuditPromptEnriched,
+}));
+vi.mock('~/server/integrations/moderation', () => ({
+  extModeration: { moderatePrompt: mockModeratePrompt },
+}));
+
+// The redis client is NOT mocked here on purpose: `src/__tests__/setup.ts` registers the CANONICAL
+// mock for it globally, and both `no-direct-shared-module-mock` and
+// `no-hand-typed-redis-key-constants` fail a NEW file that declares its own (a hand-typed
+// REDIS_KEYS drifts from production silently — 15 had, before #4400). The sibling
+// benign-phrases file carries such a block only because it predates those guards. Note that both
+// guards match TEXTUALLY, so do not spell the mock call for that module anywhere in this file,
+// comments included.
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ updateUserById: vi.fn() }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: vi.fn(),
+  bustFetchThroughCache: vi.fn(),
+}));
+
+// The db + logging clients are mocked GLOBALLY in src/__tests__/setup.ts, so nothing needs to be
+// imported here to get them; this file only declares the module-graph stubs above that setup.ts
+// does not own.
+import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
+
+/**
+ * The strip below removes ` marker`, so the audited copy differs from the raw prompt. That is
+ * deliberate: the assertions pin BOTH arguments at once, so a mutant that swapped the audited copy
+ * for the raw one would fail here too rather than being masked by an identical pair.
+ */
+const PROMPT = 'a serene landscape marker';
+const AUDITED = 'a serene landscape';
+
+const baseOptions = {
+  prompt: PROMPT,
+  negativePrompt: '',
+  userId: 5,
+  isGreen: false,
+  track: { prohibitedRequest: mockProhibited },
+};
+
+/**
+ * The full `ExternalModerationSource` vocabulary. Every member is swept, not just `generate`: a
+ * mutant that hardcodes ANY one of them must fail on the other three.
+ */
+const ALL_SOURCES = ['generate', 'preset', 'remixAudit', 'other'] as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuditPromptEnriched.mockReturnValue({ triggers: [], success: true });
+  mockStripBenignPhrases.mockImplementation(async (text: string | undefined) =>
+    text?.replace(/ marker/gi, '')
+  );
+});
+
+describe('auditPromptServer — a DECLARED moderationSource reaches moderatePrompt', () => {
+  it.each(ALL_SOURCES)(
+    'hands the classifier the audited prompt AND the declared source %s',
+    async (source) => {
+      await expect(
+        auditPromptServer({ ...baseOptions, moderationSource: source })
+      ).resolves.toBeUndefined();
+
+      // 🔴 THE ASSERTION THIS FILE EXISTS FOR. `moderationSource` is observability-only, so nothing
+      // about the verdict, the timeout or the control flow changes when it stops being passed —
+      // which is why every behavioural test in the repo stayed green while the label died. The
+      // DECLARED value must arrive at `moderatePrompt`'s second parameter, per source, or the
+      // `source` label collapses onto `other` in production.
+      expect(
+        mockModeratePrompt,
+        `auditPromptServer({ moderationSource: '${source}' }) must call ` +
+          `extModeration.moderatePrompt(<audited prompt>, '${source}'). Anything else — most likely ` +
+          `the second argument being dropped or hardcoded at promptAuditing.ts's moderatePrompt ` +
+          `call site — empties the '${source}' series on ` +
+          `civitai_app_external_moderation_duration_seconds and files its calls under 'other'.`
+      ).toHaveBeenCalledWith(AUDITED, source);
+    }
+  );
+
+  it('carries a DIFFERENT declared source on each call, so no single hardcoded value can pass', async () => {
+    // The `it.each` above resets mocks between cases, so a mutant hardcoding one member would fail
+    // three of four rows but each in isolation. This case puts two sources in ONE mock history:
+    // a constant in the source slot cannot produce both entries, whatever constant it is.
+    await auditPromptServer({ ...baseOptions, moderationSource: 'generate' });
+    await auditPromptServer({ ...baseOptions, moderationSource: 'preset' });
+
+    const sourceArgs = mockModeratePrompt.mock.calls.map((c) => (c as unknown[])[1]);
+    expect(
+      sourceArgs,
+      'two auditPromptServer calls declaring different sources must produce two different ' +
+        "source arguments; a hardcoded or dropped label yields ['generate','generate'] or " +
+        '[undefined, undefined] instead.'
+    ).toEqual(['generate', 'preset']);
+  });
+
+  it('passes undefined — NOT a source — when the caller declares none, so the default stays with moderatePrompt', async () => {
+    // The complement of the cases above, and the reason they are not enough on their own: the
+    // default must be decided in ONE place (`moderatePrompt`'s `= 'other'` parameter default), so
+    // an undeclared caller can never be labelled `generate`. A future "helpful" `?? 'generate'` at
+    // the auditPromptServer call site would pass every assertion above and fail here.
+    await auditPromptServer({ ...baseOptions });
+
+    expect(
+      mockModeratePrompt,
+      'an options object declaring no moderationSource must hand moderatePrompt `undefined` and ' +
+        'let its own parameter default decide (`other`), never a source picked at the call site.'
+    ).toHaveBeenCalledWith(AUDITED, undefined);
+  });
+});

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -96,6 +96,7 @@ import { MAX_RANDOM_SEED } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
 import { createXGuardModerationRequest } from '~/server/services/orchestrator/orchestrator.service';
 import { submitSourceForSurface } from '~/server/services/orchestrator/orchestrator-submit-metrics';
+import { clampExternalModerationSource } from '~/server/prom/external-moderation.metrics';
 import { logToAxiom } from '~/server/logging/client';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { expandSnippetsToTargets } from '~/server/services/wildcard-set-resolver.service';
@@ -1543,6 +1544,15 @@ export async function generateFromGraph({
         inputImages,
         inputVideo,
         acknowledgedSoftBlock,
+        // Observability only — see `~/server/prom/external-moderation.metrics`. Reuses the ONE
+        // surface→source mapping that already exists for the submit metric rather than inventing a
+        // parallel vocabulary, so the two families can never disagree about which requests are
+        // preset/cron work. The clamp is the type-safe bridge between the two label sets: any value
+        // the submit family gains that this one does not have falls to `other` instead of failing
+        // to compile or minting an unbounded label.
+        moderationSource: clampExternalModerationSource(
+          submitSourceForSurface(externalCtx.modelSubstitutions?.surface)
+        ),
       });
     } catch (err) {
       // Legacy regex/external audit blocked the prompt. Fire-and-forget an
@@ -1583,6 +1593,12 @@ export async function generateFromGraph({
       isModerator,
       track,
       acknowledgedSoftBlock,
+      // Same population as the prompt audit above — the ACE Audio creative fields go through the
+      // same auditor on the same submission, so they must carry the same label or the `generate`
+      // count would undercount its own calls.
+      moderationSource: clampExternalModerationSource(
+        submitSourceForSurface(externalCtx.modelSubstitutions?.surface)
+      ),
     });
   }
 

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -2,6 +2,7 @@ import { constants } from '~/server/common/constants';
 import { BlocklistType } from '~/server/common/enums';
 import { extModeration } from '~/server/integrations/moderation';
 import { logToAxiom } from '~/server/logging/client';
+import type { ExternalModerationSource } from '~/server/prom/external-moderation.metrics';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { stripBenignPhrases } from '~/server/services/blocklist.service';
@@ -204,6 +205,11 @@ export interface AuditPromptOptions {
   inputVideo?: string; // Source video URL (vid2vid)
   // Only honored when every trigger is soft — see `isSoftBlock`.
   acknowledgedSoftBlock?: boolean;
+  // OBSERVABILITY ONLY. Selects the `source` label on the external-moderation duration histogram so
+  // the request-path prompt gate can be told apart from background work; changes no behaviour, no
+  // deadline and no verdict. Absent ⇒ `other`, so a caller that declares nothing can never inflate
+  // the `generate` population. See `~/server/prom/external-moderation.metrics`.
+  moderationSource?: ExternalModerationSource;
 }
 
 /**
@@ -230,6 +236,7 @@ export async function auditPromptServer(options: AuditPromptOptions): Promise<vo
     inputImages,
     inputVideo,
     acknowledgedSoftBlock,
+    moderationSource,
   } = options;
 
   // Skip auditing if prompt is empty (will be caught by validation elsewhere)
@@ -285,7 +292,7 @@ export async function auditPromptServer(options: AuditPromptOptions): Promise<vo
 
     // Run external moderation service
     const { flagged, categories } = await extModeration
-      .moderatePrompt(auditedPrompt ?? prompt)
+      .moderatePrompt(auditedPrompt ?? prompt, moderationSource)
       .catch((error) => {
         logToAxiom({ name: 'external-moderation-error', type: 'error', message: error.message });
         return { flagged: false, categories: [] as string[] };


### PR DESCRIPTION
## The gap

`extModeration.moderatePrompt` is an outbound HTTP call to a third-party classifier that runs
**inline and serially** on the generation submission path (`generateFromGraph` → `auditPromptServer`
→ here). It is bounded by `AbortSignal.timeout(EXTERNAL_MODERATION_TIMEOUT_MS)` (default 5 s), and it
is **fail-soft**: the caller catches, writes one Axiom line and proceeds with `flagged: false`.

Those last two properties are what made it invisible. Nothing timed the call, nothing counted its
failures, and because a failure is swallowed, a fully-down moderation gateway and a perfectly healthy
one produce the same user-visible behaviour and the same (absent) metrics. The only trace of a
failure was a single log line carrying no duration, which cannot be aggregated into a rate or a
quantile.

So three questions that decide whether this call is a latency problem had no answer at all:

1. how long does a moderation call take, per call;
2. how often does it fail — i.e. how often are prompts generated with only the local regex gate
   applied, the secondary layer silently absent;
3. how often does it reach its abort deadline, as opposed to merely being slow.

## What this adds

Pure observability. **No behaviour, timeout, control-flow or verdict change** — the request, the
deadline, the fail-soft catch and the returned value are all byte-for-byte what they were.

* `civitai_app_external_moderation_duration_seconds{source, outcome}` — wall-clock duration of the
  whole classifier call as the caller experiences it, including body parse.
  * `outcome` ∈ `ok | error | timeout`. The `timeout`/`error` split is the point of the label rather
    than a refinement of it: from the caller's side both are "fail soft, proceed unmoderated", but
    they cost completely different amounts of wall time and they call for opposite fixes (re-size the
    deadline vs. fix or route around the gateway).
  * `source` ∈ `generate | preset | remixAudit | other`, so the request-path prompt gate can be
    divided against the submission procedure's own wall time without a background job blended into
    it. `other` is the default, so a caller that declares nothing can never inflate `generate`.
* `civitai_app_external_moderation_skipped_total{source}` — calls that returned without contacting
  the classifier because the endpoint/token are not configured. Deliberately a separate counter
  rather than a fourth outcome: those calls do no I/O, so folding their ~0 s observations into the
  histogram would drag every quantile toward zero. It exists because otherwise a zero rate on the
  histogram is indistinguishable from a deployment where external moderation is simply switched off
  — the reassuring reading and the alarming one would look identical.
* A `moderation:external-prompt` span carrying the same `source` and `outcome`, so a trace and the
  metric can never disagree about how one call settled.

Both instruments are total (they never throw) and are recorded **inside `moderatePrompt`** — the
lowest funnel, which every caller reaches and none can bypass. Recording a level up, at
`auditPromptServer`, would have blended the regex audit, the benign-phrase lookups and the reporting
work into the same number, none of which is the external call.

## Bucket boundaries

`[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 20]`

The low end exists because this is a single outbound HTTPS POST whose healthy population lives in
tens-to-hundreds of milliseconds; the whole reason to time it is to apportion a per-call budget of
that size, so a first boundary at half a second would put the entire healthy population in one bucket
and answer nothing.

The top end is the part that is easy to get wrong, and **`5` is deliberately not the top**. A
boundary is inclusive (`le`) and `AbortSignal.timeout(5000)` fires *at* 5000 ms, so an aborted call is
observed at slightly more than 5 s and lands in `le=7.5`, while a call that answered just under the
deadline lands in `le=5`. Those two are exactly the distinction this metric exists to draw, and they
are only distinguishable because a finite boundary sits *above* the cap. A family whose top finite
bucket sat at the cap would drop every capped call into `+Inf` together with every pathological one,
saturating precisely the region being asked about. `10` and `20` carry two further things: the
deadline is an env knob that can be re-tuned upward, so the tail keeps resolution if it is; and under
the default cap a non-empty `+Inf` is itself a finding (it would mean the abort did not take effect),
which a bucket set stopping at the cap could not express.

All three properties are pinned by test, not only by this description.

## Pattern

Mirrors `orchestrator-submit-metrics.ts` — duration histogram + `outcome` label, a bounded `source`
label with a runtime clamp (not only a compile-time type, since options objects are built by spread),
a companion span, total record helpers, and the surface→source mapping reused from that module rather
than a parallel vocabulary invented here.

## Tests

`src/server/prom/__tests__/external-moderation.metrics.test.ts` and
`src/server/integrations/__tests__/moderation.instrumentation.test.ts`, read back against the **real**
prom-client registry rather than a stub, so the assertions are about what is actually recorded.

Covered: the success path records a duration under the success outcome (value asserted, with a unit
sanity ceiling, not just a count); a thrown error records the error outcome and still records a
non-zero duration; a fired deadline records `timeout` and not `error`; a network-level rejection
records `error` and not `timeout`; the not-configured short-circuit counts separately and never
touches the histogram; the `source` label is closed at runtime; and — asserted on every failure case
— the observation count across **every** series moves by exactly one per call, including when the
caller wraps the call in its own fail-soft catch.

Every assertion above was mutation-checked: the implementation was broken on purpose (drop the
timeout classification; observe twice on the failure path; move the top finite bucket down to the
cap; record milliseconds instead of seconds; fold the short-circuit into the histogram; make the
clamp return its raw input; record a zero duration on failure) and each mutant was confirmed to turn
the corresponding assertion red for its own reason, with the tree restored byte-identical afterwards.
