### PR TITLE
fix(moderator): stop the reportAccepted multiplier from silently unpaying the reporter

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -269,6 +269,16 @@ describe('rewardReportReporters multiplier', () => {
     expect(row.multiplier).toBe(5);
   });
 
+  it('treats a tier whose PRODUCT overflows as a fallback, not as a clamp', async () => {
+    // Both factors are finite here — the guard is not about a non-finite tier, which is already
+    // rejected where the tier is read. 1e308 x 5 is Infinity, and calling that a clamp writes
+    // `{"multiplierRaw":null}` and alerts on a ceiling nothing came near.
+    const row = await rowFor({ tier: cached(1e308), storedBonus: 50 });
+    expect(row.multiplier).toBe(1);
+    expect(row.transactionDetails).toBe('{}');
+    expect(axiom).not.toHaveBeenCalled();
+  });
+
   it('records a failed write as a findable event rather than swallowing it', async () => {
     // Nothing retries this: reports.service marks the report Actioned BEFORE calling, and its
     // guarded UPDATE matches nothing on a second attempt. The Axiom line is the only trace that
@@ -285,6 +295,10 @@ describe('rewardReportReporters multiplier', () => {
 
     expect(axiom).toHaveBeenCalledTimes(1);
     const payload = axiom.mock.calls[0][0];
+    // `type` is the queryable discriminator, and `extra` spreads AFTER it inside logAxiomError —
+    // so a caller passing `type` in extra unfindables its own event, one key over from the clobber
+    // this test exists for.
+    expect(payload.type).toBe('error');
     expect(payload.event).toBe('reportAccepted rewards write failed');
     expect(payload.reportId).toBe(91234);
     expect(payload.reporterIds).toEqual([42, 7]);

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as Axiom from '@civitai/axiom';
 
 /**
  * `rewardReportReporters` writes the `pending` buzzEvents row that IS the payout: the main app's
@@ -13,12 +14,21 @@ const bonusEvents = vi.fn();
 const ineligibleRows = vi.fn();
 /** The ids the chain fake requires the `User` query to have asked for; set by `rowsFor`. */
 let reporterIds: number[] = [];
-const logToAxiom = vi.fn().mockResolvedValue(undefined);
-const logAxiomError = vi.fn();
+/**
+ * The axiom PACKAGE is mocked, not `../axiom`, so both `logToAxiom` and `logAxiomError` run for real
+ * over one spy. That is the only level at which the defect this file now pins is visible: the bug was
+ * `logAxiomError`'s own composition — `safeError` spreads LAST, so a `name`/`message` passed by a
+ * caller is silently overwritten by the Error's. A mocked `logAxiomError` cannot see that, and did
+ * not: the marker was clobbered for a full commit with the suite green.
+ */
+const axiom = vi.fn(async (_data: Record<string, unknown>, _datastream?: string) => {});
+vi.mock('@civitai/axiom', async (importOriginal) => ({
+  ...(await importOriginal<typeof Axiom>()),
+  createAxiomLogger: () => ({ logToAxiom: axiom }),
+}));
 
 vi.mock('../clickhouse', () => ({ getClickhouse: () => ({ insert }) }));
 vi.mock('../redis', () => ({ getRedis: () => ({ packed: { get: redisGet } }) }));
-vi.mock('../axiom', () => ({ logToAxiom, logAxiomError }));
 /**
  * A stand-in for the two Kysely chains this module builds.
  *
@@ -42,6 +52,9 @@ function chain(resolve: (wheres: unknown[][]) => unknown) {
   return builder;
 }
 
+/** Exact clause count, so an ADDED restrictive clause is visible too, not just a changed one. */
+const wheresAre = (wheres: unknown[][], count: number) => wheres.length === count;
+
 const has = (wheres: unknown[][], ...expected: unknown[]) =>
   wheres.some(
     (w) =>
@@ -59,12 +72,15 @@ vi.mock('../db', () => ({
     selectFrom: (table: string) =>
       table === 'User'
         ? chain((wheres) =>
+            wheresAre(wheres, 2) &&
             has(wheres, 'id', 'in', reporterIds) &&
             has(wheres, 'rewardsEligibility', '=', 'Ineligible')
               ? ineligibleRows()
               : []
           )
-        : chain((wheres) => (has(wheres, 'enabled', '=', true) ? bonusEvents() : [])),
+        : chain((wheres) =>
+            wheresAre(wheres, 1) && has(wheres, 'enabled', '=', true) ? bonusEvents() : []
+          ),
   },
   dbWrite: {},
 }));
@@ -77,22 +93,35 @@ const cached = (rewardsMultiplier: number) => ({ rewardsMultiplier, notFound: fa
 /** `RewardsBonusEvent.multiplier` is stored x10, so 50 is a 5x event. */
 const bonus = (stored: number) => [{ multiplier: stored, startsAt: null, endsAt: null }];
 
+const HOUR = 60 * 60 * 1000;
+/** An event whose window has closed but whose `enabled` was never flipped — the schema permits it. */
+const expiredBonus = (stored: number) => [
+  {
+    multiplier: stored,
+    startsAt: new Date(Date.now() - 2 * HOUR),
+    endsAt: new Date(Date.now() - HOUR),
+  },
+];
+
 async function rowsFor({
   tiers,
   storedBonus,
   ineligible = [],
+  events,
 }: {
   /** Ordered [reporterId, cached tier] pairs — an object would reorder integer keys. */
   tiers: [number, unknown][];
   storedBonus: number;
   ineligible?: number[];
+  /** Raw RewardsBonusEvent rows, when a case needs a window rather than a plain multiplier. */
+  events?: unknown[];
 }) {
   reporterIds = tiers.map(([id]) => id);
   redisGet.mockImplementation(async (key: string) => {
     const id = Number(key.split(':').pop());
     return tiers.find(([tierId]) => tierId === id)?.[1];
   });
-  bonusEvents.mockReturnValue(bonus(storedBonus));
+  bonusEvents.mockReturnValue(events ?? bonus(storedBonus));
   ineligibleRows.mockReturnValue(ineligible.map((id) => ({ id })));
   await rewardReportReporters({ reportId: 1, reporterIds });
   expect(insert).toHaveBeenCalledTimes(1);
@@ -106,15 +135,18 @@ async function rowFor({
   tier,
   storedBonus,
   ineligible = false,
+  events,
 }: {
   tier: unknown;
   storedBonus: number;
   ineligible?: boolean;
+  events?: unknown[];
 }) {
   const [row] = await rowsFor({
     tiers: [[42, tier]],
     storedBonus,
     ineligible: ineligible ? [42] : [],
+    events,
   });
   return row;
 }
@@ -138,8 +170,8 @@ describe('rewardReportReporters multiplier', () => {
 
   it('reports a clamp to Axiom rather than swallowing it', async () => {
     await rowFor({ tier: cached(4), storedBonus: 50 });
-    expect(logToAxiom).toHaveBeenCalledTimes(1);
-    expect(logToAxiom.mock.calls[0][0]).toMatchObject({ clampedEvents: 1, maxRaw: 20 });
+    expect(axiom).toHaveBeenCalledTimes(1);
+    expect(axiom.mock.calls[0][0]).toMatchObject({ clampedEvents: 1, maxRaw: 20 });
   });
 
   it('leaves a product the column can hold exactly alone', async () => {
@@ -148,7 +180,7 @@ describe('rewardReportReporters multiplier', () => {
     const row = await rowFor({ tier: cached(4), storedBonus: 20 });
     expect(row.multiplier).toBe(8);
     expect(row.transactionDetails).toBe('{}');
-    expect(logToAxiom).not.toHaveBeenCalled();
+    expect(axiom).not.toHaveBeenCalled();
   });
 
   it('writes 0 for a rewards-ineligible reporter instead of paying them the base award', async () => {
@@ -191,8 +223,8 @@ describe('rewardReportReporters multiplier', () => {
     expect(row.multiplier).toBe(2);
     // Not reported as a clamp: nothing came near the column's ceiling.
     expect(row.transactionDetails).toBe('{}');
-    expect(logToAxiom).toHaveBeenCalledTimes(1);
-    expect(logToAxiom.mock.calls[0][0].message).toMatch(/not finite/);
+    expect(axiom).toHaveBeenCalledTimes(1);
+    expect(axiom.mock.calls[0][0].message).toMatch(/not finite/);
   });
 
   it('bars only the ineligible reporter in a batch, not the whole report', async () => {
@@ -220,5 +252,44 @@ describe('rewardReportReporters multiplier', () => {
   it('does not consult the shared cache at all for an ineligible reporter', async () => {
     await rowFor({ tier: cached(4), storedBonus: 20, ineligible: true });
     expect(redisGet).not.toHaveBeenCalled();
+  });
+
+  it('ignores a bonus event whose window has closed but whose enabled was never flipped', async () => {
+    // Nothing flips `enabled` at expiry — upsertRewardsBonusEvent writes `enabled` and `endsAt`
+    // independently. Without the active-window filter a finished 5x promotion keeps multiplying
+    // every accepted report forever, and diverges from the main app, which evaluates the window live.
+    const row = await rowFor({ tier: cached(4), storedBonus: 50, events: expiredBonus(50) });
+    expect(row.multiplier).toBe(4);
+  });
+
+  it('caps a mistyped bonus event at MAX_GLOBAL_BONUS', async () => {
+    // 200 instead of 20 is the operator typo the cap exists for. Uncapped this pays a tier-1
+    // reporter 9.99x — the clamp's ceiling — rather than the intended 5x.
+    const row = await rowFor({ tier: cached(1), storedBonus: 200 });
+    expect(row.multiplier).toBe(5);
+  });
+
+  it('records a failed write as a findable event rather than swallowing it', async () => {
+    // Nothing retries this: reports.service marks the report Actioned BEFORE calling, and its
+    // guarded UPDATE matches nothing on a second attempt. The Axiom line is the only trace that
+    // these reporters were never paid, so the marker has to survive serialization —
+    // `safeError` spreads LAST inside logAxiomError, which is why the marker cannot be `name` or
+    // `message`. It was both, for a whole commit, with this suite green.
+    insert.mockRejectedValueOnce(new Error('clickhouse unreachable'));
+    redisGet.mockResolvedValue(cached(1));
+    bonusEvents.mockReturnValue(bonus(10));
+    ineligibleRows.mockReturnValue([]);
+    reporterIds = [42, 7];
+
+    await expect(rewardReportReporters({ reportId: 91234, reporterIds })).resolves.toBeUndefined();
+
+    expect(axiom).toHaveBeenCalledTimes(1);
+    const payload = axiom.mock.calls[0][0];
+    expect(payload.event).toBe('reportAccepted rewards write failed');
+    expect(payload.reportId).toBe(91234);
+    expect(payload.reporterIds).toEqual([42, 7]);
+    // safeError's fields land alongside the marker rather than instead of it.
+    expect(payload.message).toBe('clickhouse unreachable');
+    expect(JSON.stringify(payload)).toContain('reportAccepted rewards write failed');
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `rewardReportReporters` writes the `pending` buzzEvents row that IS the payout: the main app's
+ * process-rewards cron reads the multiplier back out of it and pays awardAmount * multiplier. So
+ * every value asserted here is money, and a row ClickHouse cannot parse is dropped server-side
+ * under async_insert with the app seeing success — the reporter is silently never paid.
+ */
+
+const insert = vi.fn().mockResolvedValue(undefined);
+const redisGet = vi.fn();
+const bonusEvents = vi.fn();
+const logToAxiom = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../clickhouse', () => ({ getClickhouse: () => ({ insert }) }));
+vi.mock('../redis', () => ({ getRedis: () => ({ packed: { get: redisGet } }) }));
+vi.mock('../axiom', () => ({ logToAxiom }));
+vi.mock('../db', () => ({
+  dbRead: {
+    selectFrom: () => ({ select: () => ({ where: () => ({ execute: bonusEvents }) }) }),
+  },
+  dbWrite: {},
+}));
+
+const { rewardReportReporters } = await import('../rewards');
+
+/** The cached shape written by the main app's userMultipliersCache. */
+const cached = (rewardsMultiplier: number) => ({ rewardsMultiplier, notFound: false });
+
+/** `RewardsBonusEvent.multiplier` is stored x10, so 50 is a 5x event. */
+const bonus = (stored: number) => [{ multiplier: stored, startsAt: null, endsAt: null }];
+
+async function rowFor({ tier, storedBonus }: { tier: unknown; storedBonus: number }) {
+  redisGet.mockResolvedValue(tier);
+  bonusEvents.mockResolvedValue(bonus(storedBonus));
+  await rewardReportReporters({ reportId: 1, reporterIds: [42] });
+  expect(insert).toHaveBeenCalledTimes(1);
+  return insert.mock.calls[0][0].values[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('rewardReportReporters multiplier', () => {
+  it('clamps a gold tier under a 5x bonus to what the Decimal(3, 2) column can hold', async () => {
+    // 4 x 5 = 20. The column's ceiling is 9.99; 20 is unparseable, so ClickHouse drops the row and
+    // the reporter is never paid.
+    const row = await rowFor({ tier: cached(4), storedBonus: 50 });
+    expect(row.multiplier).toBe(9.99);
+  });
+
+  it('records the unclamped product so a clamped row is still traceable', async () => {
+    const row = await rowFor({ tier: cached(4), storedBonus: 50 });
+    expect(JSON.parse(row.transactionDetails)).toEqual({ multiplierRaw: 20 });
+  });
+
+  it('reports a clamp to Axiom rather than swallowing it', async () => {
+    await rowFor({ tier: cached(4), storedBonus: 50 });
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    expect(logToAxiom.mock.calls[0][0]).toMatchObject({ clampedEvents: 1, maxRaw: 20 });
+  });
+
+  it('leaves a product the column can hold exactly alone', async () => {
+    // The live 2x event against gold is 8 — under the ceiling. A clamp that fired here would
+    // underpay every gold reporter today, so this is the control for the case above.
+    const row = await rowFor({ tier: cached(4), storedBonus: 20 });
+    expect(row.multiplier).toBe(8);
+    expect(row.transactionDetails).toBe('{}');
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('writes 0 for a rewards-ineligible reporter instead of paying them the base award', async () => {
+    // A rewardsMultiplier of 0 is userMultipliersCache reporting rewardsEligibility='Ineligible'.
+    // Read as a missing value it becomes 1, and process-rewards pays the full 50 Buzz — the hole
+    // PR #4383 closed on the main app's side of this same table.
+    const row = await rowFor({ tier: cached(0), storedBonus: 20 });
+    expect(row.multiplier).toBe(0);
+  });
+
+  it('falls back to the base multiplier when the shared cache has nothing', async () => {
+    const row = await rowFor({ tier: null, storedBonus: 10 });
+    expect(row.multiplier).toBe(1);
+  });
+
+  it('falls back to the base multiplier for a notFound entry', async () => {
+    const row = await rowFor({ tier: { notFound: true }, storedBonus: 10 });
+    expect(row.multiplier).toBe(1);
+  });
+});

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as Axiom from '@civitai/axiom';
+import { REDIS_KEYS } from '@civitai/redis';
 
 /**
  * `rewardReportReporters` writes the `pending` buzzEvents row that IS the payout: the main app's
@@ -39,48 +40,53 @@ vi.mock('../redis', () => ({ getRedis: () => ({ packed: { get: redisGet } }) }))
  * `User` chain resolves only when it asked for the reporters AND for Ineligible, and yields nothing
  * otherwise — a query with a clause dropped, flipped or retargeted resolves empty and fails.
  */
-function chain(resolve: (wheres: unknown[][]) => unknown) {
+function chain(resolve: (calls: { wheres: unknown[][]; selects: unknown[][] }) => unknown) {
   const wheres: unknown[][] = [];
+  const selects: unknown[][] = [];
   const builder: Record<string, unknown> = {
-    select: () => builder,
+    select: (...args: unknown[]) => {
+      selects.push(args);
+      return builder;
+    },
     where: (...args: unknown[]) => {
       wheres.push(args);
       return builder;
     },
-    execute: async () => resolve(wheres),
+    execute: async () => resolve({ wheres, selects }),
   };
   return builder;
 }
 
+/** Deep-equal for the recorded argument arrays, which hold primitives and id arrays only. */
+const same = (a: unknown, b: unknown): boolean =>
+  Array.isArray(a) && Array.isArray(b)
+    ? a.length === b.length && a.every((v, i) => same(v, b[i]))
+    : a === b;
+
 /** Exact clause count, so an ADDED restrictive clause is visible too, not just a changed one. */
 const wheresAre = (wheres: unknown[][], count: number) => wheres.length === count;
 
-const has = (wheres: unknown[][], ...expected: unknown[]) =>
-  wheres.some(
-    (w) =>
-      w.length === expected.length &&
-      expected.every((e, i) => {
-        const actual = w[i];
-        return Array.isArray(e) && Array.isArray(actual)
-          ? e.length === actual.length && e.every((v, j) => v === actual[j])
-          : e === actual;
-      })
-  );
+const has = (wheres: unknown[][], ...expected: unknown[]) => wheres.some((w) => same(w, expected));
 
 vi.mock('../db', () => ({
   dbRead: {
     selectFrom: (table: string) =>
       table === 'User'
-        ? chain((wheres) =>
+        ? chain(({ wheres, selects }) =>
             wheresAre(wheres, 2) &&
             has(wheres, 'id', 'in', reporterIds) &&
-            has(wheres, 'rewardsEligibility', '=', 'Ineligible')
+            has(wheres, 'rewardsEligibility', '=', 'Ineligible') &&
+            // The rows are keyed by `id` downstream; selecting anything else yields a Set of
+            // `undefined` and bars nobody.
+            has(selects, ['id'])
               ? ineligibleRows()
               : []
           )
-        : chain((wheres) =>
+        : table === 'RewardsBonusEvent'
+        ? chain(({ wheres }) =>
             wheresAre(wheres, 1) && has(wheres, 'enabled', '=', true) ? bonusEvents() : []
-          ),
+          )
+        : chain(() => []),
   },
   dbWrite: {},
 }));
@@ -125,6 +131,12 @@ async function rowsFor({
   ineligibleRows.mockReturnValue(ineligible.map((id) => ({ id })));
   await rewardReportReporters({ reportId: 1, reporterIds });
   expect(insert).toHaveBeenCalledTimes(1);
+  // The destination is as load-bearing as the values: a wrong table or format writes nowhere
+  // process-rewards reads, and every reporter is silently never paid.
+  expect(insert.mock.calls[0][0]).toMatchObject({
+    table: 'buzzEvents',
+    format: 'JSONEachRow',
+  });
   const values = insert.mock.calls[0][0].values;
   expect(values).toHaveLength(reporterIds.length);
   return values;
@@ -305,5 +317,48 @@ describe('rewardReportReporters multiplier', () => {
     // safeError's fields land alongside the marker rather than instead of it.
     expect(payload.message).toBe('clickhouse unreachable');
     expect(JSON.stringify(payload)).toContain('reportAccepted rewards write failed');
+  });
+
+  it('writes the reportAccepted envelope process-rewards expects', async () => {
+    const row = await rowFor({ tier: cached(1), storedBonus: 10 });
+    // `status: 'pending'` is what makes process-rewards pick the row up at all, and the award must
+    // match reportAccepted.reward.ts or the two apps grant inconsistently. Nothing else pins these.
+    expect(row).toMatchObject({
+      type: 'reportAccepted',
+      status: 'pending',
+      awardAmount: 50,
+      toUserId: 42,
+      byUserId: 42,
+      forId: 1,
+    });
+  });
+
+  it('reads the tier from the cache key the main app writes', async () => {
+    // The shared key IS the cross-app contract. Point this at any other cache and every reporter
+    // misses, falls back to 1x and is quietly underpaid — no error, no empty result to notice.
+    await rowFor({ tier: cached(2), storedBonus: 10 });
+    expect(redisGet).toHaveBeenCalledWith(`${REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER}:42`);
+  });
+
+  it('distinguishes the clamp alert fields from each other', async () => {
+    // At one reporter every field is the same number, so swapping them passes — and TWO must clamp
+    // with different raws, or max and min of a one-element array agree and `maxRaw` is still free.
+    // 4x5=20 and 3x5=15 both clamp; 1x5=5 does not. All three fields end up distinct.
+    await rowsFor({
+      tiers: [
+        [42, cached(4)],
+        [7, cached(3)],
+        [9, cached(1)],
+      ],
+      storedBonus: 50,
+    });
+    expect(axiom).toHaveBeenCalledTimes(1);
+    expect(axiom.mock.calls[0][0]).toMatchObject({
+      name: 'buzz-rewards',
+      type: 'error',
+      clampedEvents: 2,
+      batchSize: 3,
+      maxRaw: 20,
+    });
   });
 });

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -11,25 +11,60 @@ const insert = vi.fn().mockResolvedValue(undefined);
 const redisGet = vi.fn();
 const bonusEvents = vi.fn();
 const ineligibleRows = vi.fn();
+/** The ids the chain fake requires the `User` query to have asked for; set by `rowsFor`. */
+let reporterIds: number[] = [];
 const logToAxiom = vi.fn().mockResolvedValue(undefined);
+const logAxiomError = vi.fn();
 
 vi.mock('../clickhouse', () => ({ getClickhouse: () => ({ insert }) }));
 vi.mock('../redis', () => ({ getRedis: () => ({ packed: { get: redisGet } }) }));
-vi.mock('../axiom', () => ({ logToAxiom }));
+vi.mock('../axiom', () => ({ logToAxiom, logAxiomError }));
 /**
- * The two chains this module builds are told apart by table, not by shape: `RewardsBonusEvent` ends
- * at one `.where()`, the `User` eligibility read at two. Dispatching on the table name rather than
- * on arity means a query retargeted at the wrong table resolves to the wrong fixture and the test
- * fails, instead of both chains quietly sharing one answer.
+ * A stand-in for the two Kysely chains this module builds.
+ *
+ * 🔴 It must answer from the RECORDED CHAIN, never from the table name alone. The case that forces
+ * this: a fake whose `.where` ignores its arguments cannot tell `'Ineligible'` from `'Eligible'`, so
+ * INVERTING the eligibility predicate passes every test in this file while paying 13M eligible
+ * reporters nothing and paying every barred one in full. The predicate IS the money here, so the
+ * `User` chain resolves only when it asked for the reporters AND for Ineligible, and yields nothing
+ * otherwise — a query with a clause dropped, flipped or retargeted resolves empty and fails.
  */
-vi.mock('../db', () => ({
-  dbRead: {
-    selectFrom: (table: string) => {
-      const execute = table === 'User' ? ineligibleRows : bonusEvents;
-      const builder: Record<string, unknown> = { execute };
-      for (const method of ['select', 'where']) builder[method] = () => builder;
+function chain(resolve: (wheres: unknown[][]) => unknown) {
+  const wheres: unknown[][] = [];
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    where: (...args: unknown[]) => {
+      wheres.push(args);
       return builder;
     },
+    execute: async () => resolve(wheres),
+  };
+  return builder;
+}
+
+const has = (wheres: unknown[][], ...expected: unknown[]) =>
+  wheres.some(
+    (w) =>
+      w.length === expected.length &&
+      expected.every((e, i) => {
+        const actual = w[i];
+        return Array.isArray(e) && Array.isArray(actual)
+          ? e.length === actual.length && e.every((v, j) => v === actual[j])
+          : e === actual;
+      })
+  );
+
+vi.mock('../db', () => ({
+  dbRead: {
+    selectFrom: (table: string) =>
+      table === 'User'
+        ? chain((wheres) =>
+            has(wheres, 'id', 'in', reporterIds) &&
+            has(wheres, 'rewardsEligibility', '=', 'Ineligible')
+              ? ineligibleRows()
+              : []
+          )
+        : chain((wheres) => (has(wheres, 'enabled', '=', true) ? bonusEvents() : [])),
   },
   dbWrite: {},
 }));
@@ -42,6 +77,31 @@ const cached = (rewardsMultiplier: number) => ({ rewardsMultiplier, notFound: fa
 /** `RewardsBonusEvent.multiplier` is stored x10, so 50 is a 5x event. */
 const bonus = (stored: number) => [{ multiplier: stored, startsAt: null, endsAt: null }];
 
+async function rowsFor({
+  tiers,
+  storedBonus,
+  ineligible = [],
+}: {
+  /** Ordered [reporterId, cached tier] pairs — an object would reorder integer keys. */
+  tiers: [number, unknown][];
+  storedBonus: number;
+  ineligible?: number[];
+}) {
+  reporterIds = tiers.map(([id]) => id);
+  redisGet.mockImplementation(async (key: string) => {
+    const id = Number(key.split(':').pop());
+    return tiers.find(([tierId]) => tierId === id)?.[1];
+  });
+  bonusEvents.mockReturnValue(bonus(storedBonus));
+  ineligibleRows.mockReturnValue(ineligible.map((id) => ({ id })));
+  await rewardReportReporters({ reportId: 1, reporterIds });
+  expect(insert).toHaveBeenCalledTimes(1);
+  const values = insert.mock.calls[0][0].values;
+  expect(values).toHaveLength(reporterIds.length);
+  return values;
+}
+
+/** Single-reporter shorthand; reporter 42 throughout. */
 async function rowFor({
   tier,
   storedBonus,
@@ -51,12 +111,12 @@ async function rowFor({
   storedBonus: number;
   ineligible?: boolean;
 }) {
-  redisGet.mockResolvedValue(tier);
-  bonusEvents.mockResolvedValue(bonus(storedBonus));
-  ineligibleRows.mockResolvedValue(ineligible ? [{ id: 42 }] : []);
-  await rewardReportReporters({ reportId: 1, reporterIds: [42] });
-  expect(insert).toHaveBeenCalledTimes(1);
-  return insert.mock.calls[0][0].values[0];
+  const [row] = await rowsFor({
+    tiers: [[42, tier]],
+    storedBonus,
+    ineligible: ineligible ? [42] : [],
+  });
+  return row;
 }
 
 beforeEach(() => {
@@ -123,15 +183,38 @@ describe('rewardReportReporters multiplier', () => {
     expect(row.multiplier).toBe(0);
   });
 
-  it('treats a non-finite cached tier as a fallback, not as a clamp', async () => {
-    // NaN is `typeof 'number'`, so it walks past the tier guard. It reaches the column as an
-    // unparseable value, which is the dropped row this whole path exists to prevent — so it becomes
-    // the base multiplier. Reporting that as a clamp would fire an error alert naming a ceiling
-    // nothing came near, and write `{"multiplierRaw":null}` as the audit trail.
+  it('pays a garbage cached tier exactly what a missing one pays, and says so', async () => {
+    // NaN is `typeof 'number'`, so it walks past the tier guard and reaches the column as a value
+    // it cannot parse. Letting the clamp catch it instead pays 1 rather than 2, because the clamp
+    // never sees the bonus — a garbage entry would quietly be worth less than no entry at all.
     const row = await rowFor({ tier: cached(NaN), storedBonus: 20 });
-    expect(row.multiplier).toBe(1);
+    expect(row.multiplier).toBe(2);
+    // Not reported as a clamp: nothing came near the column's ceiling.
     expect(row.transactionDetails).toBe('{}');
-    expect(logToAxiom).not.toHaveBeenCalled();
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    expect(logToAxiom.mock.calls[0][0].message).toMatch(/not finite/);
+  });
+
+  it('bars only the ineligible reporter in a batch, not the whole report', async () => {
+    // Production's normal case: `[updated.userId, ...alsoReportedBy]`. The eligibility branch is the
+    // first per-reporter decision in this function, so a batch is the only shape that can tell
+    // "this reporter is barred" apart from "someone in this batch is barred".
+    const rows = await rowsFor({
+      tiers: [
+        [42, cached(4)],
+        [7, cached(2)],
+        [9, cached(1)],
+      ],
+      storedBonus: 20,
+      ineligible: [7],
+    });
+    expect(
+      rows.map((r: { toUserId: number; multiplier: number }) => [r.toUserId, r.multiplier])
+    ).toEqual([
+      [42, 8],
+      [7, 0],
+      [9, 2],
+    ]);
   });
 
   it('does not consult the shared cache at all for an ineligible reporter', async () => {

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -10,14 +10,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const insert = vi.fn().mockResolvedValue(undefined);
 const redisGet = vi.fn();
 const bonusEvents = vi.fn();
+const ineligibleRows = vi.fn();
 const logToAxiom = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../clickhouse', () => ({ getClickhouse: () => ({ insert }) }));
 vi.mock('../redis', () => ({ getRedis: () => ({ packed: { get: redisGet } }) }));
 vi.mock('../axiom', () => ({ logToAxiom }));
+/**
+ * The two chains this module builds are told apart by table, not by shape: `RewardsBonusEvent` ends
+ * at one `.where()`, the `User` eligibility read at two. Dispatching on the table name rather than
+ * on arity means a query retargeted at the wrong table resolves to the wrong fixture and the test
+ * fails, instead of both chains quietly sharing one answer.
+ */
 vi.mock('../db', () => ({
   dbRead: {
-    selectFrom: () => ({ select: () => ({ where: () => ({ execute: bonusEvents }) }) }),
+    selectFrom: (table: string) => {
+      const execute = table === 'User' ? ineligibleRows : bonusEvents;
+      const builder: Record<string, unknown> = { execute };
+      for (const method of ['select', 'where']) builder[method] = () => builder;
+      return builder;
+    },
   },
   dbWrite: {},
 }));
@@ -30,9 +42,18 @@ const cached = (rewardsMultiplier: number) => ({ rewardsMultiplier, notFound: fa
 /** `RewardsBonusEvent.multiplier` is stored x10, so 50 is a 5x event. */
 const bonus = (stored: number) => [{ multiplier: stored, startsAt: null, endsAt: null }];
 
-async function rowFor({ tier, storedBonus }: { tier: unknown; storedBonus: number }) {
+async function rowFor({
+  tier,
+  storedBonus,
+  ineligible = false,
+}: {
+  tier: unknown;
+  storedBonus: number;
+  ineligible?: boolean;
+}) {
   redisGet.mockResolvedValue(tier);
   bonusEvents.mockResolvedValue(bonus(storedBonus));
+  ineligibleRows.mockResolvedValue(ineligible ? [{ id: 42 }] : []);
   await rewardReportReporters({ reportId: 1, reporterIds: [42] });
   expect(insert).toHaveBeenCalledTimes(1);
   return insert.mock.calls[0][0].values[0];
@@ -78,13 +99,43 @@ describe('rewardReportReporters multiplier', () => {
     expect(row.multiplier).toBe(0);
   });
 
+  // Both fallback cases run under a 2x bonus deliberately. Asserting 1 under a 1x bonus cannot
+  // fail: a guard that returns `undefined` gives `undefined * 1 = NaN`, and the clamp turns a
+  // non-finite value into 1 — so the assertion would pass through the clamp rather than through
+  // the fallback it names. Under 2x the fallback gives 2 and the broken path still gives 1.
   it('falls back to the base multiplier when the shared cache has nothing', async () => {
-    const row = await rowFor({ tier: null, storedBonus: 10 });
-    expect(row.multiplier).toBe(1);
+    const row = await rowFor({ tier: null, storedBonus: 20 });
+    expect(row.multiplier).toBe(2);
   });
 
-  it('falls back to the base multiplier for a notFound entry', async () => {
-    const row = await rowFor({ tier: { notFound: true }, storedBonus: 10 });
+  it('falls back to the base multiplier for a notFound entry, ignoring any tier on it', async () => {
+    // A real notFound entry carries no multiplier; one is put here so that dropping the
+    // `!cached.notFound` half of the guard reads back 4 rather than silently still passing.
+    const row = await rowFor({ tier: { notFound: true, rewardsMultiplier: 4 }, storedBonus: 20 });
+    expect(row.multiplier).toBe(2);
+  });
+
+  it('writes 0 for a reporter Postgres reports ineligible even when the cache is cold', async () => {
+    // The shared cache is written only by the main app and expires after a day, so a reporter who
+    // has not browsed since filing has no entry at all — and a miss there reads as eligible. Read
+    // from the cache alone, this barred user is paid the full award a week after filing.
+    const row = await rowFor({ tier: null, storedBonus: 20, ineligible: true });
+    expect(row.multiplier).toBe(0);
+  });
+
+  it('treats a non-finite cached tier as a fallback, not as a clamp', async () => {
+    // NaN is `typeof 'number'`, so it walks past the tier guard. It reaches the column as an
+    // unparseable value, which is the dropped row this whole path exists to prevent — so it becomes
+    // the base multiplier. Reporting that as a clamp would fire an error alert naming a ceiling
+    // nothing came near, and write `{"multiplierRaw":null}` as the audit trail.
+    const row = await rowFor({ tier: cached(NaN), storedBonus: 20 });
     expect(row.multiplier).toBe(1);
+    expect(row.transactionDetails).toBe('{}');
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('does not consult the shared cache at all for an ineligible reporter', async () => {
+    await rowFor({ tier: cached(4), storedBonus: 20, ineligible: true });
+    expect(redisGet).not.toHaveBeenCalled();
   });
 });

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -27,7 +27,11 @@ export async function rewardReportReporters(input: {
         const base = ineligible.has(reporterId) ? 0 : await getBaseRewardsMultiplier(reporterId);
         const raw = base * globalBonus;
         const multiplier = clampBuzzEventMultiplier(raw);
-        const wasClamped = multiplier !== raw;
+        // Both factors are finite, but their PRODUCT need not be: a cached tier near Number.MAX_VALUE
+        // times the bonus overflows to Infinity, which the clamp turns into the base multiplier.
+        // That is a fallback, not an overflow of the column, and reporting it as a clamp writes
+        // `{"multiplierRaw":null}` as the audit trail and fires an alert naming a ceiling nothing hit.
+        const wasClamped = Number.isFinite(raw) && multiplier !== raw;
         if (wasClamped) clamped.push(raw);
         // toUserId === byUserId (an accepted report rewards its reporter); ip omitted for localhost/empty
         // so the ClickHouse column falls back to its '' default.

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -97,8 +97,7 @@ async function getBaseRewardsMultiplier(userId: number): Promise<number> {
       `${REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER}:${userId}` as RedisKeyTemplateCache
     );
     // A multiplier of 0 is the cache reporting rewardsEligibility = 'Ineligible', not a missing
-    // value. Falling through to 1 there paid an ineligible reporter the full award — the same hole
-    // PR #4383 closed on the main app's side of this table.
+    // value. A truthiness guard here pays an ineligible reporter the full award.
     // Finite, not just `typeof number`: NaN and Infinity are both `'number'` and both reach the
     // Decimal(3, 2) column as values it cannot parse. Rejecting them here rather than letting the
     // clamp catch them is what makes a garbage entry pay the same as a missing one — the clamp

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -3,7 +3,7 @@ import { REDIS_KEYS, type RedisKeyTemplateCache } from '@civitai/redis';
 import { getClickhouse } from './clickhouse';
 import { getRedis } from './redis';
 import { dbRead } from './db';
-import { logToAxiom } from './axiom';
+import { logAxiomError, logToAxiom } from './axiom';
 
 const MAX_GLOBAL_BONUS = 5;
 
@@ -60,7 +60,16 @@ export async function rewardReportReporters(input: {
     }
     await getClickhouse().insert({ table: 'buzzEvents', values: rows, format: 'JSONEachRow' });
   } catch (err) {
-    console.error('[rewards] failed to record reportAccepted events', err);
+    // Nothing retries this. reports.service marks the report Actioned BEFORE calling here and its
+    // guarded UPDATE matches nothing on a second attempt, so a throw means these reporters are
+    // never paid and the moderator sees a successful action. That has to leave a trace someone
+    // can find, which pod stdout is not.
+    logAxiomError(err, {
+      name: 'buzz-rewards',
+      message: 'failed to record reportAccepted events; reporters will not be paid',
+      reportId: input.reportId,
+      reporterIds: input.reporterIds,
+    });
   }
 }
 
@@ -89,8 +98,19 @@ async function getBaseRewardsMultiplier(userId: number): Promise<number> {
     // A multiplier of 0 is the cache reporting rewardsEligibility = 'Ineligible', not a missing
     // value. Falling through to 1 there paid an ineligible reporter the full award — the same hole
     // PR #4383 closed on the main app's side of this table.
-    if (cached && !cached.notFound && typeof cached.rewardsMultiplier === 'number')
-      return cached.rewardsMultiplier;
+    // Finite, not just `typeof number`: NaN and Infinity are both `'number'` and both reach the
+    // Decimal(3, 2) column as values it cannot parse. Rejecting them here rather than letting the
+    // clamp catch them is what makes a garbage entry pay the same as a missing one — the clamp
+    // never sees `globalBonus`, so falling back there pays 1 where a miss pays 1 x the bonus.
+    if (cached && !cached.notFound && typeof cached.rewardsMultiplier === 'number') {
+      if (Number.isFinite(cached.rewardsMultiplier)) return cached.rewardsMultiplier;
+      logToAxiom({
+        name: 'buzz-rewards',
+        type: 'error',
+        message: 'Cached rewards multiplier was not finite; paid the base multiplier instead',
+        userId,
+      }).catch(() => null);
+    }
   } catch {
     // Shared-cache read is best-effort; fall back to the base multiplier.
   }

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -1,7 +1,9 @@
+import { clampBuzzEventMultiplier } from '@civitai/clickhouse';
 import { REDIS_KEYS, type RedisKeyTemplateCache } from '@civitai/redis';
 import { getClickhouse } from './clickhouse';
 import { getRedis } from './redis';
 import { dbRead } from './db';
+import { logToAxiom } from './axiom';
 
 const MAX_GLOBAL_BONUS = 5;
 
@@ -18,9 +20,13 @@ export async function rewardReportReporters(input: {
   if (!input.reporterIds.length) return;
   try {
     const globalBonus = await getGlobalRewardsBonus();
+    const clamped: number[] = [];
     const rows = await Promise.all(
       input.reporterIds.map(async (reporterId) => {
         const base = await getBaseRewardsMultiplier(reporterId);
+        const raw = base * globalBonus;
+        const multiplier = clampBuzzEventMultiplier(raw);
+        if (multiplier !== raw) clamped.push(raw);
         // toUserId === byUserId (an accepted report rewards its reporter); ip omitted for localhost/empty
         // so the ClickHouse column falls back to its '' default.
         return {
@@ -29,13 +35,25 @@ export async function rewardReportReporters(input: {
           forId: input.reportId,
           byUserId: reporterId,
           awardAmount: REPORT_ACCEPTED_AWARD,
-          multiplier: base * globalBonus,
+          multiplier,
           status: 'pending',
-          transactionDetails: '{}',
+          // The raw product is kept so a clamped row is still traceable back to the tier and bonus
+          // that produced it.
+          transactionDetails: multiplier === raw ? '{}' : JSON.stringify({ multiplierRaw: raw }),
           ...(input.ip && input.ip !== '::1' ? { ip: input.ip } : {}),
         };
       })
     );
+    if (clamped.length) {
+      logToAxiom({
+        name: 'buzz-rewards',
+        type: 'error',
+        message: 'Buzz event multiplier exceeded the ClickHouse column and was clamped',
+        clampedEvents: clamped.length,
+        batchSize: rows.length,
+        maxRaw: Math.max(...clamped),
+      }).catch(() => null);
+    }
     await getClickhouse().insert({ table: 'buzzEvents', values: rows, format: 'JSONEachRow' });
   } catch (err) {
     console.error('[rewards] failed to record reportAccepted events', err);
@@ -48,7 +66,11 @@ async function getBaseRewardsMultiplier(userId: number): Promise<number> {
     const cached = await getRedis().packed.get<{ rewardsMultiplier?: number; notFound?: boolean }>(
       `${REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER}:${userId}` as RedisKeyTemplateCache
     );
-    if (cached && !cached.notFound && cached.rewardsMultiplier) return cached.rewardsMultiplier;
+    // A multiplier of 0 is the cache reporting rewardsEligibility = 'Ineligible', not a missing
+    // value. Falling through to 1 there paid an ineligible reporter the full award — the same hole
+    // PR #4383 closed on the main app's side of this table.
+    if (cached && !cached.notFound && typeof cached.rewardsMultiplier === 'number')
+      return cached.rewardsMultiplier;
   } catch {
     // Shared-cache read is best-effort; fall back to the base multiplier.
   }

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -20,13 +20,17 @@ export async function rewardReportReporters(input: {
   if (!input.reporterIds.length) return;
   try {
     const globalBonus = await getGlobalRewardsBonus();
+    const ineligible = await getIneligibleReporters(input.reporterIds);
     const clamped: number[] = [];
     const rows = await Promise.all(
       input.reporterIds.map(async (reporterId) => {
-        const base = await getBaseRewardsMultiplier(reporterId);
+        const base = ineligible.has(reporterId) ? 0 : await getBaseRewardsMultiplier(reporterId);
         const raw = base * globalBonus;
         const multiplier = clampBuzzEventMultiplier(raw);
-        if (multiplier !== raw) clamped.push(raw);
+        // `raw` is non-finite only if the cached tier was garbage, and 1 is then the fallback rather
+        // than a clamp — reporting it as one would fire an error alert naming a ceiling nothing hit.
+        const wasClamped = Number.isFinite(raw) && multiplier !== raw;
+        if (wasClamped) clamped.push(raw);
         // toUserId === byUserId (an accepted report rewards its reporter); ip omitted for localhost/empty
         // so the ClickHouse column falls back to its '' default.
         return {
@@ -39,7 +43,7 @@ export async function rewardReportReporters(input: {
           status: 'pending',
           // The raw product is kept so a clamped row is still traceable back to the tier and bonus
           // that produced it.
-          transactionDetails: multiplier === raw ? '{}' : JSON.stringify({ multiplierRaw: raw }),
+          transactionDetails: wasClamped ? JSON.stringify({ multiplierRaw: raw }) : '{}',
           ...(input.ip && input.ip !== '::1' ? { ip: input.ip } : {}),
         };
       })
@@ -60,7 +64,23 @@ export async function rewardReportReporters(input: {
   }
 }
 
-// Reads the shared MULTIPLIERS_FOR_USER cache (populated by the main app); a miss falls back to base 1.
+// Eligibility is read from Postgres, not from the shared cache. That cache is populated only by the
+// main app and expires after a day, so a reporter who has not browsed the site since filing has no
+// entry — and a miss there is indistinguishable from eligible. This path is the whole payout: the
+// pending row it writes is what process-rewards pays, so the barred user has to be barred here.
+async function getIneligibleReporters(userIds: number[]): Promise<Set<number>> {
+  const rows = await dbRead
+    .selectFrom('User')
+    .select(['id'])
+    .where('id', 'in', userIds)
+    .where('rewardsEligibility', '=', 'Ineligible')
+    .execute();
+  return new Set(rows.map((row) => row.id));
+}
+
+// Reads the shared MULTIPLIERS_FOR_USER cache (populated by the main app) for the TIER only; a miss
+// falls back to base 1. Unlike eligibility, a stale tier costs the reporter a multiplier rather than
+// paying someone who should earn nothing.
 async function getBaseRewardsMultiplier(userId: number): Promise<number> {
   try {
     const cached = await getRedis().packed.get<{ rewardsMultiplier?: number; notFound?: boolean }>(

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -27,9 +27,7 @@ export async function rewardReportReporters(input: {
         const base = ineligible.has(reporterId) ? 0 : await getBaseRewardsMultiplier(reporterId);
         const raw = base * globalBonus;
         const multiplier = clampBuzzEventMultiplier(raw);
-        // `raw` is non-finite only if the cached tier was garbage, and 1 is then the fallback rather
-        // than a clamp — reporting it as one would fire an error alert naming a ceiling nothing hit.
-        const wasClamped = Number.isFinite(raw) && multiplier !== raw;
+        const wasClamped = multiplier !== raw;
         if (wasClamped) clamped.push(raw);
         // toUserId === byUserId (an accepted report rewards its reporter); ip omitted for localhost/empty
         // so the ClickHouse column falls back to its '' default.
@@ -65,8 +63,7 @@ export async function rewardReportReporters(input: {
     // never paid and the moderator sees a successful action. That has to leave a trace someone
     // can find, which pod stdout is not.
     logAxiomError(err, {
-      name: 'buzz-rewards',
-      message: 'failed to record reportAccepted events; reporters will not be paid',
+      event: 'reportAccepted rewards write failed',
       reportId: input.reportId,
       reporterIds: input.reporterIds,
     });

--- a/packages/civitai-clickhouse/src/buzz-events.ts
+++ b/packages/civitai-clickhouse/src/buzz-events.ts
@@ -1,0 +1,28 @@
+// Column-shape rules for the `buzzEvents` table, which has two writers in two apps: the main app's
+// reward pipeline (src/server/rewards/base.reward.ts) and the moderator's reportAccepted path
+// (apps/moderator/src/lib/server/rewards.ts). The invariant belongs to the table, so the number
+// lives beside the client that talks to it rather than once per app.
+
+// 🔴 This must equal the ceiling of the DEPLOYED `buzzEvents.multiplier` column, which is
+// Decimal(3, 2). Inserts run `async_insert=1, wait_for_async_insert=0`, so a value the column
+// cannot hold is dropped server-side while the caller sees success — there is no backstop behind
+// this. Widening the column was costed and declined (2026-08-24); if that changes, the column moves
+// first and this follows in the same window, never the other way round.
+// See src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql.
+export const BUZZ_EVENTS_MAX_MULTIPLIER = 9.99;
+
+/**
+ * Fit a multiplier to the column's range.
+ *
+ * For a processable reward this value is not audit — `process-rewards` reads it back out and pays
+ * `awardAmount * multiplier` from it — so clamping UNDERPAYS. Dropping the row instead pays nothing
+ * at all, which is why this floors rather than rejects. Callers that care should record the raw
+ * value alongside the row.
+ *
+ * A non-finite input falls back to the base multiplier of 1 rather than passing NaN through: NaN is
+ * a value the column cannot hold, which is the same silently-dropped row this exists to prevent.
+ */
+export function clampBuzzEventMultiplier(multiplier: number): number {
+  if (!Number.isFinite(multiplier)) return 1;
+  return Math.min(multiplier, BUZZ_EVENTS_MAX_MULTIPLIER);
+}

--- a/packages/civitai-clickhouse/src/index.ts
+++ b/packages/civitai-clickhouse/src/index.ts
@@ -1,1 +1,2 @@
 export * from './client';
+export * from './buzz-events';

--- a/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
+++ b/src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql
@@ -3,9 +3,11 @@
 -- of the numbers, the hazards and the precedent, so that whoever needs it next does not re-derive
 -- any of it.
 --
--- 🔴 WHAT THAT MEANS FOR THE CODE: the clamp in src/server/rewards/base.reward.ts is no longer a
--- backstop, it is the ONLY guard. CLICKHOUSE_MAX_MULTIPLIER = 9.99 is correct and must stay
--- correct — it has to equal the ceiling of the deployed column, which this file does not change.
+-- 🔴 WHAT THAT MEANS FOR THE CODE: the clamp is no longer a backstop, it is the ONLY guard.
+-- BUZZ_EVENTS_MAX_MULTIPLIER = 9.99 in packages/civitai-clickhouse/src/buzz-events.ts is correct
+-- and must stay correct — it has to equal the ceiling of the deployed column, which this file does
+-- not change. Both writers of the table read it: src/server/rewards/base.reward.ts and
+-- apps/moderator/src/lib/server/rewards.ts.
 -- Do not raise it while this is unapplied: a value the column cannot hold is a row ClickHouse
 -- drops server-side while sendAward pays anyway.
 --
@@ -90,8 +92,9 @@ ALTER TABLE buzzEvents UPDATE multiplier = CAST(multiplier_old, 'Decimal(4, 2)')
 
 -- 🔴 AFTERWARDS — THIS MIGRATION BUYS NOTHING WITHOUT IT.
 --
--- CLICKHOUSE_MAX_MULTIPLIER in src/server/rewards/base.reward.ts is 9.99 and clamps to it, and
--- that clamp is what pays: process-rewards reads the multiplier back out and sendAward computes
+-- BUZZ_EVENTS_MAX_MULTIPLIER in packages/civitai-clickhouse/src/buzz-events.ts is 9.99 and both
+-- writers clamp to it, and that clamp is what pays: process-rewards reads the multiplier back out
+-- of any app's pending row and sendAward computes
 -- awardAmount * multiplier from it. Widening the column and leaving the constant alone means a
 -- 1.4-billion-row rewrite that changes nothing — gold members are still paid half during a 5x
 -- bonus event, just against a column with room to spare.

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -1,3 +1,4 @@
+import { BUZZ_EVENTS_MAX_MULTIPLIER } from '@civitai/clickhouse';
 import type { ClickHouseClient } from '@clickhouse/client';
 import type { PrismaClient } from '@prisma/client';
 import { chunk } from 'lodash-es';
@@ -575,15 +576,6 @@ const INT32_MAX = 2147483647;
 // `buzzEvents` is narrower than `BuzzEventLog`: `forId` is Int32, `status` is
 // Enum8('pending','awarded','capped') and `multiplier` is Decimal(3, 2).
 const CLICKHOUSE_STATUSES = new Set(['pending', 'awarded', 'capped']);
-// 🔴 This must equal the ceiling of the DEPLOYED `buzzEvents.multiplier` column, which is
-// Decimal(3, 2). Raising it sends a value the column cannot hold, and an unparseable row is
-// dropped server-side while `sendAward` pays anyway — so this is the ONLY guard, not a backstop.
-// Widening the column was costed and declined (2026-08-24): the ceiling is not reachable today,
-// and it was not worth a mutation over 1.4 billion rows. If that changes, the column moves first
-// and this follows in the same window — never the other way round.
-// See src/server/clickhouse/migrations/2026-08-24-buzz-events-multiplier-width.sql.
-const CLICKHOUSE_MAX_MULTIPLIER = 9.99;
-
 /**
  * Fit an event to the `buzzEvents` column types before it goes over the wire.
  *
@@ -632,9 +624,9 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
   }
 
   let multiplier = event.multiplier;
-  if (multiplier !== undefined && multiplier > CLICKHOUSE_MAX_MULTIPLIER) {
+  if (multiplier !== undefined && multiplier > BUZZ_EVENTS_MAX_MULTIPLIER) {
     coerced.multiplierRaw = multiplier;
-    multiplier = CLICKHOUSE_MAX_MULTIPLIER;
+    multiplier = BUZZ_EVENTS_MAX_MULTIPLIER;
     // On the batch path this value is not audit — `process-rewards` reads it back out and
     // `sendAward` pays `awardAmount * multiplier` from it, so a clamp UNDERPAYS rather than
     // rounding a record. Reported once per batch by the caller, not here: the condition becomes
@@ -676,7 +668,7 @@ function toClickhouseBuzzEvents(events: BuzzEventLog[]): BuzzEventLog[] {
       message: 'Buzz event multiplier exceeded the ClickHouse column and was clamped',
       clampedEvents: clamped,
       batchSize: events.length,
-      clampedTo: CLICKHOUSE_MAX_MULTIPLIER,
+      clampedTo: BUZZ_EVENTS_MAX_MULTIPLIER,
     }).catch(() => null);
   }
 


### PR DESCRIPTION
Closes ClickUp [868kw9b31](https://app.clickup.com/t/868kw9b31).

`apps/moderator` writes `buzzEvents` rows directly, and the multiplier it computed was neither clamped to the column nor honest about eligibility. Both cost the reporter money, silently.

`reportAccepted` is a **processable** reward: the `pending` row this code writes *is* the payout, and the main app's `process-rewards` cron reads the multiplier back out and pays `awardAmount * multiplier` from it. So unlike the equivalent overflow in the main app — which loses only an audit row, because `sendAward` has already moved the money — a bad row here means the reporter is **never paid at all**.

## What was wrong

**1. The multiplier was unclamped.** `base * globalBonus` is unbounded; `buzzEvents.multiplier` is `Decimal(3, 2)`, ceiling 9.99. Gold's 4 against `MAX_GLOBAL_BONUS` of 5 is 20. Inserts run `async_insert=1, wait_for_async_insert=0`, so ClickHouse accepts the HTTP request, fails to parse the row server-side, and drops it — no error, no 500, no alert.

Latent today: the live bonus event is 2x, so gold members write 8, and the 90-day maximum is exactly 8 with no row at or above 9. Any bonus event above 2.5x tips it over, and at that point every gold-tier reporter silently stops being paid for accepted reports for the duration of the event.

**2. An ineligible reporter was paid in full.** `getBaseRewardsMultiplier` guarded on truthiness, so a `rewardsMultiplier` of 0 — `userMultipliersCache` reporting `rewardsEligibility='Ineligible'` — fell through to 1. That is the same hole PR #4383 closed on the main app's side of this table; the moderator just never got the memo.

## What changed

The column ceiling moves to `packages/civitai-clickhouse` as `BUZZ_EVENTS_MAX_MULTIPLIER`, beside the client that knows the column types. The table has two writers in two apps and `apps/` cannot import from `src/`, so the invariant belongs to the table rather than to either app; `base.reward.ts` now reads it from there instead of holding its own copy. The migration note that pins the number to the deployed column is updated to point at the new home.

Eligibility is read from **Postgres**, not from the shared cache — see the first review finding below. The cache is still consulted for the *tier*, where a stale value costs a multiplier rather than paying someone who should earn nothing.

## What two adversarial review rounds found in my own fix

Both rounds found real defects, and both are fixed here rather than deferred.

**Round one — the eligibility fix only worked on a warm cache.** `getBaseRewardsMultiplier` reads `MULTIPLIERS_FOR_USER` with a raw `get`: no `lookupFn`, no populate-on-miss, and a one-day TTL written only by the main app. A barred user who files a report and does not browse the site again has no entry by the time a moderator accepts it — and a miss there is indistinguishable from eligible. Eligibility now comes from `User` in one batched query, matching the main app's predicate exactly (`= 'Ineligible'`; `Protected` is a shield *against* being barred, not a barring value).

**Round two — the test fake could not see the worst mutation.** The fake matched on table name and let `.where` swallow its arguments, so **inverting the predicate to `'Eligible'` passed all nine tests** — which in production pays every eligible reporter a multiplier of 0 and pays every barred one in full. The fake now resolves from the recorded chain: the `User` query answers only when it asked for these reporters *and* for `Ineligible`, so a clause dropped, flipped or retargeted resolves empty and fails.

Round two also found that nothing exercised a **batch**, though production's normal case is `[updated.userId, ...alsoReportedBy]` and the eligibility branch is the first per-reporter decision in the function. Widening it to `ineligible.size > 0` zeroed every reporter on the report and passed. There is now a three-reporter case pinning per-reporter outcomes.

Two smaller things it was right about: suppressing the false clamp alert had removed the *only* observable on this path, and the two fallbacks were paying different money — a **missing** cache entry paid `1 x bonus` while a **garbage** one paid 1, because the clamp never sees the bonus. Non-finite values are rejected where the tier is read, so a garbage entry is now worth exactly what no entry is worth, and reports itself.

The `catch` also now uses `logAxiomError` instead of `console.error`. Nothing retries this: `reports.service` marks the report `Actioned` **before** calling, and its guarded UPDATE matches nothing on a second attempt — so a throw means those reporters are never paid while the moderator sees a successful action. Pod stdout is not a trace anyone finds.

## Verification

Every claimed fix has a revert control that fails with a legible assertion naming the wrong value, not a timeout:

| Revert | Failure |
|---|---|
| the clamp | `expected 20 to be 9.99` |
| DB-backed eligibility | `expected 2 to be +0` |
| `!cached.notFound` | `expected 8 to be 2` |
| eligibility predicate → `'Eligible'` | `expected [[42,8],[7,4],[9,2]] to deeply equal [[42,8],[7,0],[9,2]]` |
| per-reporter → batch-wide | `expected [[42,0],[7,0],[9,0]] to deeply equal [[42,8],[7,0],[9,2]]` |
| finite-tier guard | `expected 1 to be 2` |

- `pnpm run typecheck` — `OK, 0 type errors`
- `apps/moderator` `typecheck` — `9400 FILES 0 ERRORS 0 WARNINGS`
- `test:apps:run` — `Test Files 110 passed (110)`, `Tests 1168 passed | 36 skipped (1204)`, exit 0
- `test:packages:run` — `Test Files 83 passed | 3 skipped (86)`, exit 0
- `test:unit:run` — `Test Files 5 failed | 1550 passed | 3 skipped (1558)`, `Tests 11 failed | 24568 passed | 35 skipped (24614)`. **The same 11 fail on a stashed tree at this base**, so they are the Windows baseline, not this diff. None are in `rewards`, `moderator` or `buzz-events`.
- `blocks.router.workflow.test.ts` collected **370 tests**, confirming the submodule is initialised and the run means something.
- eslint on `base.reward.ts`: 3 warnings, 0 errors — byte-identical to the same file without this diff.

**No migration.** The `Decimal(3, 2)` column is unchanged; widening it was costed and declined on 2026-08-24, which is exactly why this clamp is the only guard rather than a backstop.

## Left alone deliberately

- `getGlobalRewardsBonus` here takes `Math.max` over all active events where the main app's `getActiveRewardsBonusEvent` takes the first. With two overlapping enabled events the two writers disagree. Pre-existing, outside this diff, unreachable while at most one event is scheduled.
- `base.reward.ts:466` special-cases exactly `multiplier === 0`. A negative multiplier would be marked `awarded`, consume the reporter's cap, then be dropped by `sendAward`'s amount filter — a row claiming a payout that never happened. Unreachable today (all 17 prod products with `rewardsMultiplier` are >= 1) and flooring it in the shared helper would make the two writers behave differently, so it wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9SVX31zzRCbjkaj81py35