### PR TITLE
fix(admin): sweep only images that were actually in a post

### DIFF
--- a/src/pages/api/admin/temp/cleanup-orphaned-images-search.ts
+++ b/src/pages/api/admin/temp/cleanup-orphaned-images-search.ts
@@ -28,19 +28,23 @@ export default WebhookEndpoint(async (req, res) => {
         await pgDbRead.cancellableQuery<{ start: number; end: number }>(`
           SELECT MIN(id) as "start", MAX(id) as "end"
           FROM "Image"
-          WHERE "postId" IS NULL
+          WHERE "postId" IS NULL AND "index" IS NOT NULL
         `)
       ).result();
       return result ?? { start: 0, end: 0 };
     },
     processor: async ({ start, end, cancelFns }) => {
-      // Find images in this ID range that have postId NULL
+      // `index` is what separates an orphan from an upload that was simply never posted: it is
+      // only set once an image is placed in a post, and the feed index requires `postId IS NOT NULL`
+      // at build time, so a never-posted image was never indexed and has nothing to delete. On prod
+      // that is the difference between 81k rows and 1.28M, all against a shared Meilisearch queue.
       const fetchQuery = await pgDbRead.cancellableQuery<{ id: number }>(
         `
         SELECT id
         FROM "Image"
         WHERE id >= $1 AND id <= $2
           AND "postId" IS NULL
+          AND "index" IS NOT NULL
       `,
         [start, end]
       );


### PR DESCRIPTION
Follow-on to #4526. That PR named `cleanup-orphaned-images-search` as the way to clear orphans left by the old cascade. Sizing it on prod first turned up that it sweeps 15x more than the job needs.

### The numbers (prod)

| Set | Count | What it is |
|---|---|---|
| `postId IS NULL` | 1,276,364 | what the endpoint selects today |
| ├ `index IS NOT NULL` | **80,977** | real orphans — were in a post that got deleted |
| └ `index IS NULL` | 1,195,387 | uploads that were never posted |

The 1.2M never-posted images were never eligible for the feed index (it requires `postId IS NOT NULL` at build time), so a queued `Delete` for them is a no-op — but it still occupies a slot on a Meilisearch queue shared with every other index sync.

### Why `index` is the right discriminator

It's set when an image is placed in a post, and it survives the post's deletion: `Image.postId` is `ON DELETE SET NULL` and nothing clears `index`.

Validated against the false-negative direction — of a 566,682-row sample of images that *do* have a post, **106 (0.019%)** lack an `index`. So the filter loses a negligible tail and cuts the sweep 15x.

### Change

`AND "index" IS NOT NULL` on both queries — the `rangeFetcher` and the per-batch `processor`. No behaviour change otherwise; `dryRun` still defaults to `true`.

### Verification

- `pnpm run typecheck` — 0 errors
- `eslint` on the changed file — no issues
- No test suite covers this endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U28ASZaqHQ3ckZDshvQDZe