### PR TITLE
fix(tags): give the two user feeds a way out of a ?tags= deep link

### DIFF
--- a/src/components/Tags/__tests__/ActiveTagFilter.test.ts
+++ b/src/components/Tags/__tests__/ActiveTagFilter.test.ts
@@ -99,9 +99,16 @@ describe('ActiveTagFilter', () => {
  * runs. `?tags=` reaches that page and goes nowhere. Mounting the control there would
  * offer to clear a filter the feed never applied.
  *
- * ⚠️ Named for the pages it pins, not for the property. Still NOT a closed set — a new
- * feed that spreads its parsed query into `filters` inherits the same defect and nothing
- * here will notice. Do not read a green run as "every tag-filtered feed is covered".
+ * ⚠️ Named for the pages it pins, not for the property, and NOT a closed set. Two
+ * surfaces have the same defect right now and are deliberately absent because they were
+ * out of scope for 868kz0qq6, not because they are covered: `/user/[username]/images` and
+ * `/user/[username]/videos`, both backed by `UserMediaInfinite`, which spreads `...query`
+ * (retaining `tags`) into `ImagesInfinite` and renders no tag control at all, while
+ * `getAllImages` applies its tag clause for every viewer. Do not read a green run here as
+ * "every tag-filtered feed is covered" — read it as "these five".
+ *
+ * The note above about /images and /videos means the ROOT feeds, whose escape hatch is the
+ * `All` chip on ImageFeedTagBar. That bar is not on the profile tabs.
  */
 describe('the tag-filtered feeds mount the clear control', () => {
   it.each([
@@ -164,42 +171,71 @@ describe('the tag-filtered feeds mount the clear control', () => {
  * reads source lines, and its own comment records that a flag-gated mount passes it.
  */
 describe('each user feed gates the clear control on where its filter really applies', () => {
-  const mountLine = (relative: string) =>
-    read(relative)
-      .split('\n')
-      .map((l) => l.trim())
-      .find((l) => l.includes('<ActiveTagFilter'));
-
   const read = (relative: string) =>
     fs.readFileSync(
       path.join(path.resolve(__dirname, '../../../..'), ...relative.split('/')),
       'utf-8'
     );
 
-  it('gates the posts mount on !selfView, not on the draft section', () => {
-    const line = mountLine('src/pages/user/[username]/posts.tsx');
-    expect(line).toBeDefined();
-    expect(line).toContain('!selfView &&');
-    // The gate that looks right and is not: drafts are not the axis, ownership is.
-    expect(line).not.toContain('viewingDraft');
-  });
+  /**
+   * Returns the gate expression guarding the mount — `!selfView`, `viewingPublished` — or
+   * undefined if the mount is absent, commented out, or written in some other shape.
+   *
+   * Whitespace is collapsed before matching so a Prettier re-wrap (both mount lines are
+   * within ~25 columns of printWidth, so one added prop wraps them) moves the gate onto
+   * its own line without reddening this.
+   */
+  const mountGate = (source: string) => {
+    const stripped = source
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join(' ')
+      .replace(/\s+/g, ' ');
 
-  it('gates the articles mount on viewingPublished, not on ownership', () => {
-    const line = mountLine('src/pages/user/[username]/articles.tsx');
-    expect(line).toBeDefined();
-    expect(line).toContain('viewingPublished &&');
-    expect(line).not.toContain('selfView');
-  });
+    return stripped.match(/\{ ?([^{}]*?) ?&& ?<ActiveTagFilter/)?.[1];
+  };
 
   /**
-   * The control for both assertions above. Each page asserts the OTHER page's gate is
-   * absent, so a matcher loose enough to be satisfied by any `<ActiveTagFilter …/>` line
-   * would have to fail one of the four. This is also the assertion that fails first if
-   * someone unifies the two gates on the theory that they ought to match.
+   * The control for every assertion below, and the reason they are exact-equality rather
+   * than `toContain`.
+   *
+   * `toContain('viewingPublished &&')` is satisfied by `'!viewingPublished &&'` — the
+   * substring is a prefix of its own negation — so the ONE mutation this block exists to
+   * catch, mounting the control on the section where the filter is not applied, passed
+   * silently. Same for an extra conjunct narrowing the gate. Both are pinned here against
+   * fixtures rather than against the repo, so the discrimination is demonstrated without
+   * mutating a page.
    */
-  it('does not use the same gate on both pages', () => {
-    const posts = mountLine('src/pages/user/[username]/posts.tsx');
-    const articles = mountLine('src/pages/user/[username]/articles.tsx');
-    expect(posts).not.toEqual(articles);
+  it.each([
+    ['{viewingPublished && <ActiveTagFilter tagIds={x} />}', 'viewingPublished'],
+    ['{!viewingPublished && <ActiveTagFilter tagIds={x} />}', '!viewingPublished'],
+    ['{!selfView && <ActiveTagFilter tagIds={x} />}', '!selfView'],
+    ['{selfView && <ActiveTagFilter tagIds={x} />}', 'selfView'],
+    [
+      '{canViewDrafts && !selfView && <ActiveTagFilter tagIds={x} />}',
+      'canViewDrafts && !selfView',
+    ],
+    // Prettier re-wrapped across lines: same gate, still found.
+    ['{viewingPublished &&\n  <ActiveTagFilter tagIds={x} />}', 'viewingPublished'],
+  ])('reads the gate out of %j', (source, expected) => {
+    expect(mountGate(source)).toBe(expected);
+  });
+
+  it.each([
+    ['// {!selfView && <ActiveTagFilter tagIds={x} />}'],
+    ['{/* {!selfView && <ActiveTagFilter tagIds={x} />} */}'],
+    ['<ActiveTagFilter tagIds={x} />'],
+  ])('reports no gate for %j', (source) => {
+    expect(mountGate(source)).toBeUndefined();
+  });
+
+  it('gates the posts mount on ownership, and on nothing else', () => {
+    expect(mountGate(read('src/pages/user/[username]/posts.tsx'))).toBe('!selfView');
+  });
+
+  it('gates the articles mount on the published section, and on nothing else', () => {
+    expect(mountGate(read('src/pages/user/[username]/articles.tsx'))).toBe('viewingPublished');
   });
 });

--- a/src/components/Tags/__tests__/ActiveTagFilter.test.ts
+++ b/src/components/Tags/__tests__/ActiveTagFilter.test.ts
@@ -92,18 +92,28 @@ describe('ActiveTagFilter', () => {
  * and both of those states are pinned in ImageFeedTagBar's own suite, beside the mount
  * guard for the bar itself.
  *
- * ⚠️ Named for the three pages it pins, not for the property, because it is NOT a closed
- * set: `/user/[username]/posts`, `/user/[username]/articles` and `/tools/[slug]` all pass
- * `?tags=` through to their feed with no control that can clear it. They were out of scope
- * for 868kuq3jk. Do not read a green run here as "every tag-filtered feed is covered".
+ * `/tools/[slug]` was named alongside the two `/user/*` pages as a third gap (868kz0qq6)
+ * and is deliberately NOT here: it destructures a fixed field list out of
+ * `useImageQueryParams()` that omits `tags`, and passes `disableStoreFilters`, so the
+ * merge in `ImagesInfiniteContent` that would otherwise supply `tags` from the url never
+ * runs. `?tags=` reaches that page and goes nowhere. Mounting the control there would
+ * offer to clear a filter the feed never applied.
+ *
+ * ⚠️ Named for the pages it pins, not for the property. Still NOT a closed set — a new
+ * feed that spreads its parsed query into `filters` inherits the same defect and nothing
+ * here will notice. Do not read a green run as "every tag-filtered feed is covered".
  */
-describe('/posts, /articles and /3d-models mount the clear control', () => {
+describe('the tag-filtered feeds mount the clear control', () => {
   it.each([
     ['src/pages/posts/index.tsx'],
     ['src/pages/articles/index.tsx'],
     // Read-only `?tags=` since its category scroller was removed, and it reads the param
     // with `parseNumericStringArray` — the same dead end, on a flag-gated feed.
     ['src/pages/3d-models/index.tsx'],
+    // Both spread the whole parsed query into their feed, and `tags` is in both route
+    // schemas, so `?tags=` genuinely filters them. Added by 868kz0qq6.
+    ['src/pages/user/[username]/posts.tsx'],
+    ['src/pages/user/[username]/articles.tsx'],
   ])('%s renders <ActiveTagFilter />', (relative) => {
     const repoRoot = path.resolve(__dirname, '../../../..');
     const source = fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
@@ -126,5 +136,52 @@ describe('/posts, /articles and /3d-models mount the clear control', () => {
     // a guard stopping at "it is on the page" passes over exactly that.
     expect(mounted[0]).toMatch(/tagIds=\{/);
     expect(mounted[0]).not.toContain('tagIds={[]}');
+  });
+});
+
+/**
+ * A decision, not an accident — do not "fix" this by ungating the mount.
+ *
+ * `/user/[username]/articles` renders `ArticlesInfinite` (which receives `tags`) only in
+ * the published section; the draft section renders `UserDraftArticles`, which takes no
+ * filters at all. So in drafts there is no tag filter in force, and an ungated control
+ * would offer to clear one that was never applied — the same falsehood that kept
+ * `/tools/[slug]` out of the list above.
+ *
+ * The sibling posts page is deliberately NOT gated: it renders `PostsInfinite` in both
+ * sections and spreads `tags` into the filters either way, so the control is honest in
+ * drafts there too.
+ *
+ * The mount guard above cannot see this — it reads source lines, and its own comment
+ * records that a flag-gated mount passes it. This is the assertion that does.
+ */
+describe('the articles clear control is gated on the published section', () => {
+  const read = (relative: string) =>
+    fs.readFileSync(
+      path.join(path.resolve(__dirname, '../../../..'), ...relative.split('/')),
+      'utf-8'
+    );
+
+  it('gates the mount on viewingPublished', () => {
+    const line = read('src/pages/user/[username]/articles.tsx')
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.includes('<ActiveTagFilter'));
+
+    expect(line).toBeDefined();
+    expect(line).toContain('viewingPublished &&');
+  });
+
+  // Positive control for the matcher above: the posts page mounts the same component on
+  // the same kind of line and must NOT carry that gate, so a match here would mean the
+  // assertion passes on any mount rather than on the gate.
+  it('does not gate the posts mount', () => {
+    const line = read('src/pages/user/[username]/posts.tsx')
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.includes('<ActiveTagFilter'));
+
+    expect(line).toBeDefined();
+    expect(line).not.toContain('viewingPublished');
   });
 });

--- a/src/components/Tags/__tests__/ActiveTagFilter.test.ts
+++ b/src/components/Tags/__tests__/ActiveTagFilter.test.ts
@@ -110,8 +110,9 @@ describe('the tag-filtered feeds mount the clear control', () => {
     // Read-only `?tags=` since its category scroller was removed, and it reads the param
     // with `parseNumericStringArray` — the same dead end, on a flag-gated feed.
     ['src/pages/3d-models/index.tsx'],
-    // Both spread the whole parsed query into their feed, and `tags` is in both route
-    // schemas, so `?tags=` genuinely filters them. Added by 868kz0qq6.
+    // Both spread the whole parsed query into their feed and `tags` is in both route
+    // schemas, so `?tags=` reaches the server on each. Added by 868kz0qq6. Whether the
+    // server then APPLIES it differs per viewer — see the gating block below.
     ['src/pages/user/[username]/posts.tsx'],
     ['src/pages/user/[username]/articles.tsx'],
   ])('%s renders <ActiveTagFilter />', (relative) => {
@@ -140,48 +141,65 @@ describe('the tag-filtered feeds mount the clear control', () => {
 });
 
 /**
- * A decision, not an accident — do not "fix" this by ungating the mount.
+ * ⚠️ These gates pin a DECISION (868kz0qq6) about SERVER behaviour that neither page's
+ * source reveals. Do not "tidy" either mount by ungating it.
  *
- * `/user/[username]/articles` renders `ArticlesInfinite` (which receives `tags`) only in
- * the published section; the draft section renders `UserDraftArticles`, which takes no
- * filters at all. So in drafts there is no tag filter in force, and an ungated control
- * would offer to clear one that was never applied — the same falsehood that kept
+ * The control must only appear where the feed actually applied the tag filter, otherwise it
+ * offers to clear something that was never in force — the same falsehood that kept
  * `/tools/[slug]` out of the list above.
  *
- * The sibling posts page is deliberately NOT gated: it renders `PostsInfinite` in both
- * sections and spreads `tags` into the filters either way, so the control is honest in
- * drafts there too.
+ * `/user/[username]/posts` is gated on `!selfView` because `getPostsInfinite` puts the tag
+ * clause behind `if (!isOwnerRequest)` (`post.service.ts`, "these are discovery filters, not
+ * publication ones"), and the page always sends `username`. So an owner viewing their own
+ * profile gets an UNFILTERED feed in both the published and draft sections, however much
+ * `?tags=` the url carries. Moderators are not owners there, so they keep both the filter
+ * and the control.
  *
- * The mount guard above cannot see this — it reads source lines, and its own comment
- * records that a flag-gated mount passes it. This is the assertion that does.
+ * `/user/[username]/articles` is gated on `viewingPublished` instead, for an unrelated
+ * reason: `getInfiniteArticles` applies its tag clause unconditionally, so every viewer is
+ * filtered — but the draft section renders `UserDraftArticles`, which takes no filters at
+ * all.
+ *
+ * Two different gates, two different causes. The mount guard above cannot see either: it
+ * reads source lines, and its own comment records that a flag-gated mount passes it.
  */
-describe('the articles clear control is gated on the published section', () => {
+describe('each user feed gates the clear control on where its filter really applies', () => {
+  const mountLine = (relative: string) =>
+    read(relative)
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.includes('<ActiveTagFilter'));
+
   const read = (relative: string) =>
     fs.readFileSync(
       path.join(path.resolve(__dirname, '../../../..'), ...relative.split('/')),
       'utf-8'
     );
 
-  it('gates the mount on viewingPublished', () => {
-    const line = read('src/pages/user/[username]/articles.tsx')
-      .split('\n')
-      .map((l) => l.trim())
-      .find((l) => l.includes('<ActiveTagFilter'));
-
+  it('gates the posts mount on !selfView, not on the draft section', () => {
+    const line = mountLine('src/pages/user/[username]/posts.tsx');
     expect(line).toBeDefined();
-    expect(line).toContain('viewingPublished &&');
+    expect(line).toContain('!selfView &&');
+    // The gate that looks right and is not: drafts are not the axis, ownership is.
+    expect(line).not.toContain('viewingDraft');
   });
 
-  // Positive control for the matcher above: the posts page mounts the same component on
-  // the same kind of line and must NOT carry that gate, so a match here would mean the
-  // assertion passes on any mount rather than on the gate.
-  it('does not gate the posts mount', () => {
-    const line = read('src/pages/user/[username]/posts.tsx')
-      .split('\n')
-      .map((l) => l.trim())
-      .find((l) => l.includes('<ActiveTagFilter'));
-
+  it('gates the articles mount on viewingPublished, not on ownership', () => {
+    const line = mountLine('src/pages/user/[username]/articles.tsx');
     expect(line).toBeDefined();
-    expect(line).not.toContain('viewingPublished');
+    expect(line).toContain('viewingPublished &&');
+    expect(line).not.toContain('selfView');
+  });
+
+  /**
+   * The control for both assertions above. Each page asserts the OTHER page's gate is
+   * absent, so a matcher loose enough to be satisfied by any `<ActiveTagFilter …/>` line
+   * would have to fail one of the four. This is also the assertion that fails first if
+   * someone unifies the two gates on the theory that they ought to match.
+   */
+  it('does not use the same gate on both pages', () => {
+    const posts = mountLine('src/pages/user/[username]/posts.tsx');
+    const articles = mountLine('src/pages/user/[username]/articles.tsx');
+    expect(posts).not.toEqual(articles);
   });
 });

--- a/src/pages/user/[username]/articles.tsx
+++ b/src/pages/user/[username]/articles.tsx
@@ -17,6 +17,7 @@ import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { postgresSlugify } from '~/utils/string-helpers';
 import { FeedContentToggle } from '~/components/FeedContentToggle/FeedContentToggle';
 import { ArticleFiltersDropdown } from '~/components/Article/Infinite/ArticleFiltersDropdown';
+import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 import { UserProfileLayout } from '~/components/Profile/ProfileLayout2';
 import { Page } from '~/components/AppLayout/Page';
 import { dbRead } from '~/server/db/client';
@@ -86,6 +87,7 @@ function UserArticlesPage() {
                   }}
                 />
               )}
+              {viewingPublished && <ActiveTagFilter tagIds={query.tags ?? []} />}
               {viewingPublished && (
                 <Group gap={8} ml="auto" wrap="nowrap">
                   <SortFilter

--- a/src/pages/user/[username]/posts.tsx
+++ b/src/pages/user/[username]/posts.tsx
@@ -100,7 +100,7 @@ function UserPostsPage() {
                   }}
                 />
               )}
-              <ActiveTagFilter tagIds={query.tags ?? []} />
+              {!selfView && <ActiveTagFilter tagIds={query.tags ?? []} />}
               <Group gap={8} ml="auto" wrap="nowrap">
                 <SortFilter
                   type="posts"

--- a/src/pages/user/[username]/posts.tsx
+++ b/src/pages/user/[username]/posts.tsx
@@ -15,6 +15,7 @@ import { postgresSlugify } from '~/utils/string-helpers';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { FeedContentToggle } from '~/components/FeedContentToggle/FeedContentToggle';
 import { PostFiltersDropdown } from '~/components/Post/Infinite/PostFiltersDropdown';
+import { ActiveTagFilter } from '~/components/Tags/ActiveTagFilter';
 import { UserProfileLayout } from '~/components/Profile/ProfileLayout2';
 import { Page } from '~/components/AppLayout/Page';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -99,6 +100,7 @@ function UserPostsPage() {
                   }}
                 />
               )}
+              <ActiveTagFilter tagIds={query.tags ?? []} />
               <Group gap={8} ml="auto" wrap="nowrap">
                 <SortFilter
                   type="posts"


### PR DESCRIPTION
Closes the real half of `868kz0qq6` — the deferred follow-on to #4517.

## What was broken

`/user/[username]/posts` and `/user/[username]/articles` both spread their whole parsed query straight into their feed, and `tags` is in both route schemas, so a `?tags=` deep link reaches the server with no control anywhere on the page that can clear it. Same defect and same fix shape as #4517.

## The control only mounts where the filter is actually applied

That turned out to be the whole difficulty, and it differs per page for unrelated reasons. Both gates are load-bearing:

**`/user/[username]/posts` — gated on `!selfView`.** `getPostsInfinite` puts its tag clause behind `if (!isOwnerRequest)` (`post.service.ts`, commented "these are discovery filters, not publication ones"), and the page always sends `username`. So an owner viewing their own profile gets an **unfiltered** feed in both the published and draft sections however much `?tags=` the url carries. An ungated control would have said "Clear 1 tag filter" to every creator on their own page over a feed that was never filtered. Moderators are not owners there, so they keep both the filter and the control.

**`/user/[username]/articles` — gated on `viewingPublished`.** `getInfiniteArticles` applies its tag clause unconditionally, so every viewer *is* filtered; but the draft section renders `UserDraftArticles`, which takes no filters at all.

The first of those two was caught by an adversarial review of the first commit, not by me — the original version mounted the posts control ungated and justified it with a client-side fact (`PostsInfinite` spreads `tags` either way) that is true but does not certify the server behaviour. Fixed in `6703cb4683`.

## The third surface in the ticket is not broken

`868kz0qq6` also named `/tools/[slug]`. It does **not** have this defect and is deliberately untouched. That page destructures a fixed field list out of `useImageQueryParams()` that omits `tags`, and passes `disableStoreFilters` — which makes `ImagesInfiniteContent` use `filterOverrides` alone instead of merging `useImageFilters()`, the only thing in that graph that spreads the raw URL query (it is how `/images` gets them). So `?tags=` reaches that page, is parsed, and goes nowhere. `ToolBanner` and `FeedLayout` have no tag surface either. Confirmed with Justin before dropping it; the reason is recorded in the guard's comment so it does not get re-filed.

## Tests

The two gates are pinned by a test named for the decision, because neither page's source reveals the server behaviour that motivates it — the next competent reviewer would otherwise correctly recommend unifying them. Each page's assertion uses the other page's gate as its control (posts must contain `!selfView` and not `viewingDraft`; articles must contain `viewingPublished` and not `selfView`), plus a third assertion that the two lines are not equal — so a matcher loose enough to be satisfied by any `<ActiveTagFilter …/>` line would have to fail one of them.

## Verification

- `pnpm run typecheck` — **0 type errors**
- `pnpm exec eslint` on the changed files — clean, exit 0. Positive control: the same command on `src/workers/civitai-link.worker.ts` reports `✖ 5 problems`, so it is capable of reporting.
- `ActiveTagFilter.test.ts` — `Test Files 1 passed (1)`, `Tests 13 passed (13)`, exit 0 (was 8 before this branch)
- Full unit suite on the final commit — `Test Files 5 failed | 1553 passed | 3 skipped (1561)`, `Tests 11 failed | 24649 passed | 35 skipped (24695)`, exit 1. Both totals reconcile, so no worker died. The 5 failing files are `appModeratorMessageForm.callSites`, `assert-component-suite-ran`, `credential-detection-superset.guard`, `session-registry`, `trace-flush` — identical set and count to the run before these changes, none reference `ActiveTagFilter` or either page, and it is under the known Windows local baseline.
- `blocks.router.workflow.test.ts` collected **370 tests**, so the submodule is initialised and the suite runs above are real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwxwrD2QziuF8WqomP9S8S
