### PR TITLE
fix(creator-shop): check the submission fee against the account the server bills

### DIFF
--- a/src/components/CreatorShop/CreatorShopSubmitModal.tsx
+++ b/src/components/CreatorShop/CreatorShopSubmitModal.tsx
@@ -525,7 +525,7 @@ export function CreatorShopSubmitModal({ item }: { item?: CreatorShopManageItem 
             <BuzzTransactionButton
               buzzAmount={submissionFee ?? 0}
               priceReplacement={submissionFee === undefined ? '…' : undefined}
-              accountTypes={[buzzType]}
+              exactAccountTypes={[buzzType]}
               colorType={buzzType}
               label="Submit for review"
               loading={pending}

--- a/src/components/CreatorShop/Submit/__tests__/fee-balance-check.test.ts
+++ b/src/components/CreatorShop/Submit/__tests__/fee-balance-check.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔒 The submission-fee button must check the balance of the PICKED account only.
+ *
+ * `BuzzTransactionButton` has two props here and they are not synonyms:
+ * `accountTypes` runs through `useAvailableBuzz`, which STRIPS yellow/green from
+ * what it is given and appends the domain's own currency; `exactAccountTypes`
+ * skips that. So `accountTypes={[buzzType]}` checks a different account than the
+ * one the server bills, and the two only coincide when the pick happens to equal
+ * the domain currency.
+ *
+ * The consequence is a blocked submit, not a wrong charge: a short balance sends
+ * `conditionalPerformTransaction` to the Buy Buzz modal instead of the mutation.
+ * A green-domain creator holding 5,000 yellow who picks yellow is checked against
+ * their green balance, and is told to buy Buzz they already have.
+ *
+ * `CreatorShopPackModal` was fixed when packs shipped and carries a comment saying
+ * why. `CreatorShopSubmitModal` kept the bare prop, and the pack's own guard could
+ * not see it because that guard reads only the pack file. Hence this one, which
+ * reads both.
+ *
+ * 🔴 IF YOU ARE HERE TO DELETE THIS: `exactAccountTypes` is deliberate at both call
+ * sites. The fee is charged with `fromAccountType: buzzType` and nothing else
+ * (`creator-shop.service.ts`, `creator-shop-pack.service.ts`), so any balance check
+ * that widens past the pick is checking the wrong account. Reverting to
+ * `accountTypes` because it reads more naturally restores the bug silently — the
+ * button still renders, and no other test fails.
+ *
+ * Source-gate rather than a render: the defect is a prop NAME, which is what a
+ * source read sees and what a mocked render sails past.
+ */
+const MODALS = [
+  ['CreatorShopSubmitModal', '../../CreatorShopSubmitModal.tsx'],
+  ['CreatorShopPackModal', '../../Pack/CreatorShopPackModal.tsx'],
+] as const;
+
+describe.each(MODALS)('%s fee button', (name, relativePath) => {
+  const source = fs.readFileSync(path.resolve(__dirname, relativePath), 'utf-8');
+
+  it('checks the picked account alone', () => {
+    expect(source).toContain('exactAccountTypes={[buzzType]}');
+  });
+
+  it('does not widen the check to the domain currency', () => {
+    // Read the PREFIX rather than searching for the bare spelling: `accountTypes`
+    // is a substring of `exactAccountTypes`, so a plain `not.toContain` would fail
+    // against the fix itself.
+    const widened = [...source.matchAll(/(\w*)accountTypes=\{\[buzzType\]\}/gi)].filter(
+      (match) => match[1].toLowerCase() !== 'exact'
+    );
+
+    expect(
+      widened.map((match) => match[0]),
+      `${name} passes ${widened[0]?.[0]} to BuzzTransactionButton, so the fee button checks ` +
+        'the domain currency instead of the account the server bills. Use exactAccountTypes.'
+    ).toEqual([]);
+  });
+});

--- a/src/components/CreatorShop/Submit/__tests__/fee-balance-check.test.ts
+++ b/src/components/CreatorShop/Submit/__tests__/fee-balance-check.test.ts
@@ -18,9 +18,11 @@ import { describe, expect, it } from 'vitest';
  * their green balance, and is told to buy Buzz they already have.
  *
  * `CreatorShopPackModal` was fixed when packs shipped and carries a comment saying
- * why. `CreatorShopSubmitModal` kept the bare prop, and the pack's own guard could
- * not see it because that guard reads only the pack file. Hence this one, which
- * reads both.
+ * why; `CreatorShopSubmitModal` kept the bare prop, and nothing was watching it.
+ * This file exists for the Submit modal. The pack arm duplicates
+ * `Pack/__tests__/pack-fee-currency.test.ts`, which already covers the pack file
+ * — kept so the invariant has one statement covering every fee button rather than
+ * one per modal, at the cost of a pack regression reddening two files.
  *
  * 🔴 IF YOU ARE HERE TO DELETE THIS: `exactAccountTypes` is deliberate at both call
  * sites. The fee is charged with `fromAccountType: buzzType` and nothing else


### PR DESCRIPTION
## The defect

`CreatorShopSubmitModal.tsx:528` passed `accountTypes={[buzzType]}` to `BuzzTransactionButton`. That prop is not a synonym for the one beside it:

```ts
// BuzzTransactionButton.tsx:60-61
const domainAccountTypes = useAvailableBuzz(accountTypes);
const allowedAccountTypes = exactAccountTypes ?? domainAccountTypes;
```

`useAvailableBuzz` **strips** `yellow`/`green` from the array it is handed, then appends the domain's own currency. So the balance check ran against a different account than the server bills â€” `submitCreatorShopItem` charges `fromAccountType: buzzType` and nothing else (`creator-shop.service.ts:359`).

`FeeSection` offers all three currencies unconditionally on every domain, so this is reachable on civitai.com and not only on the green one:

| Pick | Domain | Checked | Billed |
|---|---|---|---|
| green | yellow | **yellow** | green |
| yellow | green | **green** | yellow |
| blue | either | **blue + domain** | blue |
| yellow | yellow | yellow | yellow |
| green | green | green | green |

Correct only when the pick happens to equal the domain currency.

**Symptom is a blocked submit, not a wrong charge.** `canSubmit` gates on `canAffordFee`, which is computed from the picked account (`useSubmitCreatorShopForm.ts:222-231`), so nothing short of the fee reaches the mutation. What broke is the other direction: with the picked account funded and the domain account short, `canSubmit` is true, `onClick` runs, and `conditionalPerformTransaction` (`buzz.utils.ts:96-113`) diverts to the Buy Buzz modal. A creator was told to buy Buzz they already held.

`CreatorShopPackModal` was fixed when packs shipped and carries a comment explaining exactly this. The single-item path never got it, and the pack's own guard could not see it because it reads only the pack file.

## The guard

`Submit/__tests__/fee-balance-check.test.ts` reads **both** modals. Source-gate rather than a render, matching `sticker-review-nav-link` and the pack guard next door â€” the defect is a prop *name*, which is what a source read sees and what a mocked render sails past.

## Verification

**Positive control** â€” fix reverted, guard run:

```
FAIL src/components/CreatorShop/Submit/__tests__/fee-balance-check.test.ts
AssertionError: CreatorShopSubmitModal passes accountTypes={[buzzType]} to
BuzzTransactionButton, so the fee button checks the domain currency instead of
the account the server bills. Use exactAccountTypes.:
expected [ 'accountTypes={[buzzType]}' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)     exit 1
```

The 2 that passed are the pack arm, so the guard discriminates rather than failing uniformly.

| Check | Result |
|---|---|
| Both guards, fix applied | `Test Files 2 passed (2)`, `Tests 8 passed (8)`, exit 0 |
| `pnpm run typecheck` | exit 0 â€” `0 type errors in 183s` |
| `pnpm run lint` | exit 1 at 358 errors repo-wide; **zero on either file in this PR** |
| `prettier --write` on both files | no reformatting |
| `pnpm run test:unit:run` | exit 1 â€” `Test Files 5 failed \| 1554 passed \| 3 skipped (1562)`, `Tests 11 failed \| 24648 passed \| 35 skipped (24694)` |
| Baseline control, changes stashed | same 5 files, `Tests 11 failed \| 135 passed (146)` â€” **identical, pre-existing** |
| Submodule canary | `blocks.router.workflow.test.ts` collected **370 tests** |

Both suite totals account for every file, so no workers died.

## Reviewed

An adversarial review over this diff, prompted to refute, could not. It confirmed the symptom is reachable on the main yellow domain (which I had scoped too narrowly to green), and checked two things worth recording: the blue pick no longer resolving to `['blue', domain]` is a fix rather than a regression â€” a combined pass would have failed at the charge anyway, and `canBuyMore` now correctly goes false for an unbuyable account â€” and no other call site in `src/` passes a user-picked single currency through the bare prop. `SendTipModal`, `AppealDialog` and the rest pass domain-derived arrays where widening is the intended semantics.

Two things it raised that are **not** addressed here, both pre-existing and outside this diff:

1. `canAffordFee` being a term in `canSubmit` disables the button on a shortfall, taking the top-up path with it. `pack-fee-currency.test.ts:79-92` pins the *opposite* decision for the pack modal, so the two surfaces now behave differently for the same user. That is a product call, not mine.
2. The submission-fee transaction's `externalTransactionId` is derived from `Date.now()`, so it is not an idempotency key across retries. Money-shaped and worth its own look.

Kept deliberately: the new guard's pack arm overlaps the pack file's own assertions, so one pack regression reddens two files. Left in because the guard is named for the invariant across *both* modals, and dropping the pack arm would make its name a lie.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D8NRZoqNUhACpn2kNfubj

---

## Relationship to CU 868kyzpkn â€” this PR is NOT that ticket

The assigned work was `868kyzpkn`, "creator-shop fee currency is not checked against the domain's allowed accounts", which proposed intersecting `buzzType` against `getAllowedAccountTypes(ctx.features)` server-side.

**Justin ruled: stay permissive.** Creator-shop fees are deliberately payable in any currency the creator holds, regardless of domain. No server guard, and after review the picker needed no change either â€” that ticket is closed as already-shipped, with the ruling recorded on it so the next reader does not build the declined design from its still-live closing condition.

This PR is a separate defect found while auditing for that ticket. It adds no domain scoping; `FeeSection.tsx`, the schema, the router and the service are all untouched, and the three-way picker still offers every currency on every domain.

Writers of the submission-fee currency, enumerated before any change and independently re-enumerated in review: **2** â€” `creator-shop.service.ts:357-364` (items) and `creator-shop-pack.service.ts:228-235` (packs). No `apps/*` or `packages/*` caller, no REST route that charges the fee.

## Five-lane review

Run per the standing instruction. **All five lanes read `33b924ffe8f6a8ca5cc2edee75a59ebd196f3383` and each reported the tree clean.**

| Lane | Verdict |
|---|---|
| correctness | No defect. Confirmed 2 writers by independent enumeration; confirmed no charge change (three gates, not one); blue case strictly better â€” it removes a latent buy-modal for an unbuyable currency |
| tests | Sound. 10-mutation battery; the two assertions are complementary, neither vacuous; collection nonzero (4 tests) |
| reuse | Source change rebuilds nothing |
| perf | No impact â€” `useQueryBuzz` is input-independent, so narrowing the array cannot miss cache or add a request |
| intent | Ticket correctly not implemented; no sneaking of the declined design; body claims verified line by line |

**Head is now `0d5211ecba7ba80d4a0d64c6ccc9e4686551611e`, one commit past what the lanes read.** That commit touches **one file — `Submit/__tests__/fee-balance-check.test.ts`, 5 insertions / 3 deletions — and every changed line is inside its docstring** (each begins with ` * `). No assertion, no production code, no other file. Recording it that precisely because "comment-only" and "test-only" are different claims and a reader may rely on either: the test lane found the guard's docstring claimed the pack guard "could not see" the defect, which is false â€” it does cover the pack file. The pack arm is duplication kept on purpose, and the docstring now says so. No assertion, no source line changed; both guards re-run green (`Test Files 2 passed (2)`, `Tests 8 passed (8)`).

Three findings deliberately **not** fixed here, all pre-existing:

1. The fee's `externalTransactionId` is `Date.now()`-derived, so not an idempotency key across retries. Items are protected incidentally by the duplicate-artwork check running before the charge; **packs have no pre-charge uniqueness check at all**. Raised by three lanes independently.
2. `canAffordFee` gating `canSubmit` on the Submit modal contradicts the decision pinned for the Pack modal, where excluding it is deliberate and commented.
3. `BuzzTransactionButton.tsx:61` is a chokepoint that no test renders â€” mutating it to `useAvailableBuzz(exactAccountTypes ?? accountTypes)` restores the bug at all three call sites and reddens nothing, typecheck included. Filed as follow-up.

**Full suite re-run at head** (`0d5211ecba7ba80d4a0d64c6ccc9e4686551611e`, clean tree), after the test daemon was restarted: `Test Files 5 failed | 1554 passed | 3 skipped (1562)`, `Tests 11 failed | 24648 passed | 35 skipped (24694)`, exit 1, 272.86s. Both totals account for every file. Counts are identical to the run at `33b924f` and to the stashed-changes control, and the five failing files are the same pre-existing set in all three â€” none of them in this diff.

Read from the log, not the completion notification: the notification reported exit 0 while the log reported exit 1.

