### PR TITLE
fix(creator-shop): let a pack cover accept what a cosmetic accepts

### DIFF
--- a/src/components/CreatorShop/Pack/CreatorShopPackModal.tsx
+++ b/src/components/CreatorShop/Pack/CreatorShopPackModal.tsx
@@ -42,6 +42,7 @@ import {
   type PackMemberPricing,
 } from '~/server/schema/creator-shop.schema';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { constants } from '~/server/common/constants';
 import { numberWithCommas } from '~/utils/number-helpers';
 import { getDisplayName } from '~/utils/string-helpers';
 import { showErrorNotification } from '~/utils/notifications';
@@ -54,8 +55,6 @@ type Bundlable = PackMemberPricing & {
   creatorUsername: string | null;
   acceptsBlueBuzz: boolean;
 };
-
-const MAX_COVER_SIZE = 2 * 1024 * 1024;
 
 const memberUses = (member: Bundlable) => stickerUsesFromCosmeticData(member.data);
 
@@ -186,7 +185,9 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
     setLocalUrl(URL.createObjectURL(file));
     setImageId(null);
     try {
-      const uploaded = await uploadToCF(file);
+      // Explicit, because `uploadToCF` otherwise defaults this to `isModerator` — which
+      // let animated covers through for staff and rejected the same file for creators.
+      const uploaded = await uploadToCF(file, undefined, { allowAnimatedWebP: true });
       setImageId(uploaded.id);
     } catch (error) {
       resetFiles();
@@ -261,7 +262,7 @@ export function CreatorShopPackModal({ item }: { item?: CreatorShopManageItem })
           imageId={imageId}
           uploading={uploading}
           tiles={coverTiles}
-          maxSize={MAX_COVER_SIZE}
+          maxSize={constants.mediaUpload.maxImageFileSize}
           onDrop={handleDrop}
           onClear={() => {
             setImageId(null);

--- a/src/components/CreatorShop/Pack/PackCoverField.tsx
+++ b/src/components/CreatorShop/Pack/PackCoverField.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@mantine/dropzone';
 import { IconUpload } from '@tabler/icons-react';
 import { ArtThumb } from '~/components/CreatorShop/Submit/ArtThumb';
 import { PackCoverTiles } from '~/components/CreatorShop/Pack/PackCoverTiles';
+import { notifyUploadRejection } from '~/components/CreatorShop/upload-rejection';
 
 /**
  * A pack's cover is a storefront image, not a cosmetic anyone receives — so it
@@ -53,6 +54,7 @@ export function PackCoverField({
             accept={['image/png', 'image/webp', 'image/jpeg']}
             maxFiles={1}
             maxSize={maxSize}
+            onReject={(rejections) => notifyUploadRejection(rejections, maxSize)}
             loading={uploading}
           >
             <Center mih={100}>

--- a/src/components/CreatorShop/Submit/ArtworkField.tsx
+++ b/src/components/CreatorShop/Submit/ArtworkField.tsx
@@ -3,6 +3,7 @@ import { Dropzone } from '@mantine/dropzone';
 import { IconUpload } from '@tabler/icons-react';
 import { ArtThumb } from '~/components/CreatorShop/Submit/ArtThumb';
 import { ChecksPanel } from '~/components/CreatorShop/Submit/ChecksPanel';
+import { notifyUploadRejection } from '~/components/CreatorShop/upload-rejection';
 import type { AutoCheck } from '~/server/schema/creator-shop.schema';
 import type { CosmeticType } from '~/shared/utils/prisma/enums';
 
@@ -55,6 +56,7 @@ export function ArtworkField({
           accept={['image/png', 'image/webp']}
           maxFiles={1}
           maxSize={maxSize}
+          onReject={(rejections) => notifyUploadRejection(rejections, maxSize)}
           loading={uploading}
         >
           <Center mih={120}>

--- a/src/components/CreatorShop/__tests__/upload-rejection.test.ts
+++ b/src/components/CreatorShop/__tests__/upload-rejection.test.ts
@@ -44,12 +44,16 @@ describe('notifyUploadRejection', () => {
   it('reports a wrong file type as a type problem, not a size one', () => {
     notifyUploadRejection(rejection(1 * MB, 'file-invalid-type'), 50 * MB);
 
+    // Asserted before destructuring so an early-return regression fails legibly here
+    // rather than dying on `Cannot destructure property 'error' of undefined`.
+    expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1);
     const { error } = mocks.showErrorNotification.mock.calls[0][0];
     expect(error.message).toContain('file type');
     expect(error.message).not.toContain('limit is');
   });
 
-  // Positive control for the assertions above: the same mock, and nothing to report.
+  // Proves the mock is not pre-populated, so the two assertions above are reading
+  // calls this function actually made.
   it('says nothing when no file was rejected', () => {
     notifyUploadRejection([] as never, 50 * MB);
     expect(mocks.showErrorNotification).not.toHaveBeenCalled();

--- a/src/components/CreatorShop/__tests__/upload-rejection.test.ts
+++ b/src/components/CreatorShop/__tests__/upload-rejection.test.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as Notifications from '~/utils/notifications';
+
+const mocks = vi.hoisted(() => ({ showErrorNotification: vi.fn() }));
+
+vi.mock('~/utils/notifications', async (importOriginal) => ({
+  ...(await importOriginal<typeof Notifications>()),
+  showErrorNotification: mocks.showErrorNotification,
+}));
+
+import { notifyUploadRejection } from '~/components/CreatorShop/upload-rejection';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const read = (relative: string) =>
+  fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
+
+const rejection = (size: number, code: string) =>
+  [{ file: { size, name: 'cover.webp' } as File, errors: [{ code, message: code }] }] as never;
+
+const MB = 1024 * 1024;
+
+/**
+ * A rejected file never reaches `onDrop`, so nothing downstream — including the size row in
+ * `validateCosmeticImage` — can report it. Without a handler the picker is silent, which is
+ * how the 2 MB pack-cover cap surfaced as "animated covers render as a still frame"
+ * (868kz1hnq) rather than as "your file was too big".
+ */
+describe('notifyUploadRejection', () => {
+  beforeEach(() => mocks.showErrorNotification.mockClear());
+
+  it('names both the file size and the limit when the file is too large', () => {
+    notifyUploadRejection(rejection(60 * MB, 'file-too-large'), 50 * MB);
+
+    expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1);
+    const { error } = mocks.showErrorNotification.mock.calls[0][0];
+    // Both numbers, because "too large" without the limit does not tell anyone what to do.
+    expect(error.message).toContain('60 MB');
+    expect(error.message).toContain('50 MB');
+  });
+
+  it('reports a wrong file type as a type problem, not a size one', () => {
+    notifyUploadRejection(rejection(1 * MB, 'file-invalid-type'), 50 * MB);
+
+    const { error } = mocks.showErrorNotification.mock.calls[0][0];
+    expect(error.message).toContain('file type');
+    expect(error.message).not.toContain('limit is');
+  });
+
+  // Positive control for the assertions above: the same mock, and nothing to report.
+  it('says nothing when no file was rejected', () => {
+    notifyUploadRejection([] as never, 50 * MB);
+    expect(mocks.showErrorNotification).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * ⚠️ These pin a DECISION (868kz1hnq), not an incidental shape — do not delete them to make
+ * an edit pass.
+ *
+ * A pack cover must accept what a cosmetic accepts. It used to carry its own hardcoded
+ * `MAX_COVER_SIZE = 2 * 1024 * 1024` while the cosmetic path read
+ * `constants.mediaUpload.maxImageFileSize` (50 MB), so the same animated WebP uploaded as a
+ * sticker and vanished as a cover. Re-introducing a separate literal recreates that exactly,
+ * and nothing else in the suite would notice — both files still compile and every other test
+ * still passes.
+ *
+ * The `allowAnimatedWebP` assertion matters for the same reason and is easier to lose: with
+ * the argument absent, `useCFImageUpload` falls back to `?? currentUser?.isModerator`, so the
+ * feature keeps working for whoever is testing it and silently fails for creators.
+ */
+describe('the pack cover matches the cosmetic upload settings', () => {
+  const modal = () => read('src/components/CreatorShop/Pack/CreatorShopPackModal.tsx');
+
+  it('sizes the cover dropzone from the shared constant, not a literal', () => {
+    const source = modal();
+    expect(source).toContain('maxSize={constants.mediaUpload.maxImageFileSize}');
+    expect(source).not.toMatch(/MAX_COVER_SIZE/);
+  });
+
+  it('asks for animated WebP explicitly rather than inheriting the moderator default', () => {
+    expect(modal()).toContain('allowAnimatedWebP: true');
+  });
+
+  // Positive control for the two matchers above: the cosmetic path is the thing being
+  // matched, so it must already satisfy the same properties. If this fails, the assertions
+  // are checking a spelling that the reference implementation does not itself use.
+  it('matches what the cosmetic submit path already does', () => {
+    const cosmetic = read('src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts');
+    expect(cosmetic).toContain('constants.mediaUpload.maxImageFileSize');
+    expect(cosmetic).toContain('allowAnimatedWebP:');
+  });
+});
+
+/**
+ * The silent-rejection bug was in BOTH pickers — the cover at 2 MB where it bit immediately,
+ * and the cosmetic artwork field at 50 MB where it just bit less often. They share one
+ * handler now; this is what stops a later edit from dropping it off one of them again.
+ */
+describe('both CreatorShop pickers report a rejected file', () => {
+  it.each([
+    ['src/components/CreatorShop/Pack/PackCoverField.tsx'],
+    ['src/components/CreatorShop/Submit/ArtworkField.tsx'],
+  ])('%s wires onReject', (relative) => {
+    const source = read(relative);
+    expect(source).toContain('notifyUploadRejection');
+    expect(source).toMatch(/onReject=\{/);
+  });
+});

--- a/src/components/CreatorShop/__tests__/upload-rejection.test.ts
+++ b/src/components/CreatorShop/__tests__/upload-rejection.test.ts
@@ -36,9 +36,10 @@ describe('notifyUploadRejection', () => {
 
     expect(mocks.showErrorNotification).toHaveBeenCalledTimes(1);
     const { error } = mocks.showErrorNotification.mock.calls[0][0];
-    // Both numbers, because "too large" without the limit does not tell anyone what to do.
-    expect(error.message).toContain('60 MB');
-    expect(error.message).toContain('50 MB');
+    // The WHOLE string, not two `toContain`s: the two numbers sit in fixed roles, and
+    // asserting them separately passes just as happily on "That file is 50 MB. The limit
+    // is 60 MB." — the message with the file size and the cap swapped.
+    expect(error.message).toBe('That file is 60 MB. The limit is 50 MB.');
   });
 
   it('reports a wrong file type as a type problem, not a size one', () => {
@@ -75,7 +76,7 @@ describe('notifyUploadRejection', () => {
  * the argument absent, `useCFImageUpload` falls back to `?? currentUser?.isModerator`, so the
  * feature keeps working for whoever is testing it and silently fails for creators.
  */
-describe('the pack cover matches the cosmetic upload settings', () => {
+describe('the pack cover reads the cosmetic size limit and asks for animation itself', () => {
   const modal = () => read('src/components/CreatorShop/Pack/CreatorShopPackModal.tsx');
 
   it('sizes the cover dropzone from the shared constant, not a literal', () => {
@@ -88,13 +89,22 @@ describe('the pack cover matches the cosmetic upload settings', () => {
     expect(modal()).toContain('allowAnimatedWebP: true');
   });
 
-  // Positive control for the two matchers above: the cosmetic path is the thing being
-  // matched, so it must already satisfy the same properties. If this fails, the assertions
-  // are checking a spelling that the reference implementation does not itself use.
-  it('matches what the cosmetic submit path already does', () => {
+  /**
+   * NOT a claim of parity, and the describe above is named to avoid implying one. The two
+   * paths agree on the size limit and disagree on animation ON PURPOSE: the cosmetic form
+   * passes `allowAnimatedWebP: supportsAnimated`, gated on cosmetic type, because a badge
+   * or decoration is worn across the site. A cover only appears on a shop card, so it
+   * always may animate — hence the hardcoded `true` pinned above.
+   *
+   * This asserts the disagreement rather than a similarity. The previous version checked
+   * that the cosmetic file contained `'allowAnimatedWebP:'`, which is satisfied by any
+   * value including `false`, and so could not fail.
+   */
+  it('deliberately differs from the cosmetic path on animation, and only there', () => {
     const cosmetic = read('src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts');
-    expect(cosmetic).toContain('constants.mediaUpload.maxImageFileSize');
-    expect(cosmetic).toContain('allowAnimatedWebP:');
+    expect(cosmetic).toContain('const maxSize = constants.mediaUpload.maxImageFileSize;');
+    expect(cosmetic).toContain('allowAnimatedWebP: supportsAnimated');
+    expect(cosmetic).not.toContain('allowAnimatedWebP: true');
   });
 });
 
@@ -107,9 +117,12 @@ describe('both CreatorShop pickers report a rejected file', () => {
   it.each([
     ['src/components/CreatorShop/Pack/PackCoverField.tsx'],
     ['src/components/CreatorShop/Submit/ArtworkField.tsx'],
-  ])('%s wires onReject', (relative) => {
-    const source = read(relative);
-    expect(source).toContain('notifyUploadRejection');
-    expect(source).toMatch(/onReject=\{/);
+  ])('%s wires onReject to the shared handler', (relative) => {
+    // The conjunction, in one matcher. Asserting `toContain('notifyUploadRejection')` and
+    // `/onReject=\{/` separately is satisfied by `onReject={() => {}}` with the IMPORT line
+    // supplying the name — i.e. by an inert handler, which is the exact bug this guards.
+    expect(read(relative)).toMatch(
+      /onReject=\{\s*\([^)]*\)\s*=>\s*notifyUploadRejection\(\s*\w+\s*,\s*maxSize\s*\)/
+    );
   });
 });

--- a/src/components/CreatorShop/upload-rejection.ts
+++ b/src/components/CreatorShop/upload-rejection.ts
@@ -1,0 +1,32 @@
+import type { FileRejection } from '@mantine/dropzone';
+import { formatBytes } from '~/utils/number-helpers';
+import { showErrorNotification } from '~/utils/notifications';
+
+/**
+ * Mantine's Dropzone routes a file failing `maxSize` or `accept` to `onReject` and never
+ * calls `onDrop`. Both CreatorShop pickers used to leave `onReject` unset, so an oversized
+ * pick did nothing at all — no upload, no message, no change on screen. That is how a 2 MB
+ * cap on pack covers reached a bug report as "animated covers don't animate" (868kz1hnq):
+ * the file was never uploaded, so the card kept showing whatever was there before.
+ *
+ * The size check inside `validateCosmeticImage` cannot cover this — it runs from `onDrop`,
+ * which a rejected file never reaches.
+ */
+export function notifyUploadRejection(rejections: FileRejection[], maxSize: number) {
+  const rejection = rejections[0];
+  if (!rejection) return;
+
+  const tooBig = rejection.errors.some((error) => error.code === 'file-too-large');
+  const wrongType = rejection.errors.some((error) => error.code === 'file-invalid-type');
+
+  const reason = tooBig
+    ? `That file is ${formatBytes(rejection.file.size)}. The limit is ${formatBytes(maxSize)}.`
+    : wrongType
+    ? 'That file type is not accepted here.'
+    : rejection.errors.map((error) => error.message).join('\n');
+
+  showErrorNotification({
+    title: "That file wasn't accepted",
+    error: new Error(reason),
+  });
+}


### PR DESCRIPTION
Closes `868kz1hnq`.

## The ticket's diagnosis was wrong

`868kz1hnq` blamed `EdgeImage.tsx:24-25` for destructuring `anim` out and never forwarding it. That is not what happens. `getEdgeUrl` emits the param as `anim: anim ? undefined : anim` — **only when it is false**. Passing `anim={true}` and passing nothing produce a byte-identical URL, so the destructure is a no-op for the animated case.

The render layer could not be the cause anyway: pack covers and animated badges both render through a plain `EdgeMedia` with no `anim` prop (`Shop/CosmeticSample.tsx` renders Badge/ProfileDecoration at a sub-450 width, so `optimized=true` is forced there exactly as on a 450px cover). Badges animate in production today. **So `optimized` does not defeat animation either** — a question I had initially flagged as unverified. Nothing in `EdgeImage` is touched by this PR.

## What was actually wrong — the upload path

The lead came from standup, not the ticket: a cover **over 2 MB** doesn't animate, while the *same file* uploaded as a sticker does.

1. **A hardcoded 2 MB cap that failed silently.** `CreatorShopPackModal` had `MAX_COVER_SIZE = 2 * 1024 * 1024` against `constants.mediaUpload.maxImageFileSize` (50 MB) on the cosmetic path. Mantine routes a file failing `maxSize` to `onReject` and never calls `onDrop` — and **neither** CreatorShop picker set `onReject`. So an oversized pick never uploaded and said nothing; the card kept the previous cover. That is how this reached a bug report as "renders as a still frame".

2. **Animated WebP was effectively moderator-only.** `handleDrop` called `uploadToCF(file)` with no options, and `useCFImageUpload` defaults `allowAnimatedWebP` to `?? currentUser?.isModerator`. The flag gates exactly one thing — the animated-WebP throw in `preprocessImage` — and skips no audit, ingestion or NSFW step (independently confirmed in review).

## Reuse

The cap reads the **shared constant** rather than a literal. The missing `onReject` was in **both** pickers, so `notifyUploadRejection` is one shared helper used by `PackCoverField` and `ArtworkField`.

## Correction to an earlier version of this description

An earlier draft said the widened cover surface is "mitigated by covers entering as `PendingReview`, so a human sees them." **That is wrong for the edit path**, and the correction matters more than the original claim:

```ts
// creator-shop-pack.service.ts — imageUrl is NOT a term
...(memberCosmeticIds || price !== undefined
  ? { status: CosmeticShopItemStatus.PendingReview } : {}),
```

`updateCreatorShopPack` also never destructures `rightsAffirmed`, while the submit path guards `if (imageUrl && !rightsAffirmed) throw`. So a cover-only update swaps artwork on an already-approved pack with no re-review and no affirmation. It is true today only because this modal always resends `price` and `memberCosmeticIds` — a client convention, not a service invariant.

All of that is **pre-existing on `main`**; this PR widens what fits through it. Merging with that known, at Justin's direction; being tracked as follow-up work.

## Known cost this enables, measured on prod

Animated covers are far more expensive than static ones at the same render width, because resizing an animated WebP barely compresses it — frame count dominates, not canvas:

- static cover: 464 KB original → **43.8 KB** at `width=450,optimized=true`
- animated covers sampled: 1.7–4.6 MB at the same variant
- the same animated asset with `anim=false`: 1,539,874 → **35,274 bytes**
- **3 of 12 animated assets sampled produce no variant at all** and 301 to `/original`, repeatedly across several minutes

So for that class the raise means a viewer can eagerly download the original. Exposure today is bounded: 18 `CosmeticShopItem` rows have a `coverUrl` and **0 are placed in any shop section**, so this is creator storefronts only, not the homepage block. The obvious lever — `anim={false}` on the card thumbnail in `ShopItem.tsx`, keeping animation in the preview modal — is one prop outside this PR's five files and is going in the follow-up rather than being smuggled in here.

## Deliberately not done

- **Frame/fps caps on covers** — those exist because badges and decorations animate beside people site-wide; a cover only appears on a shop card. Adding them means pulling `validateCosmeticImage` and a checks panel into the pack modal, and would reject covers that work today.
- **Dropping `image/jpeg`** — cosmetics exclude it because they need transparency; covers explicitly don't.
- **`useCFImageUpload`'s non-200 `resolve(success)`** — real, and the raise makes the 2–50 MB range newly reachable. The consequence is a **wedged modal, not a bad pack**: status stays `'uploading'` and `canSubmit` includes `!uploading`, so no phantom `coverUrl` is saved (a reviewer tried to refute this and could not). The one-line fix lives in a hook with ~25 call sites, two of which (`BountyEntryUpsertForm.tsx:112`, `BountyUpsertForm.tsx:151`) call it with no await and no catch, so making it reject would create unhandled rejections app-wide.

Note for accuracy: the cosmetic path passes `allowAnimatedWebP: supportsAnimated` (gated on cosmetic type); this passes a hardcoded `true`, deliberately, because a cover is never worn. The two paths agree on size and differ on animation on purpose, and the tests now assert that difference rather than implying parity.

## Verification

- `pnpm run typecheck` — **0 type errors**
- `pnpm exec eslint` on the changed files — clean, exit 0
- `upload-rejection.test.ts` — `Test Files 1 passed (1)`, `Tests 8 passed (8)`, exit 0
- Full unit suite — `Test Files 5 failed | 1556 passed | 3 skipped (1564)`, `Tests 11 failed | 24670 passed | 35 skipped (24716)`, exit 1 (read from the log; the harness completion notice claimed exit 0). Both totals reconcile, so no worker died. The 5 failing files (`appModeratorMessageForm.callSites`, `assert-component-suite-ran`, `credential-detection-superset.guard`, `session-registry`, `trace-flush`) are the local Windows baseline of 11 failures, none touch CreatorShop.
- `blocks.router.workflow.test.ts` collected **370 tests**, so the submodule is initialised and the suite run is real.

Reviewed by the five main-app lanes (reuse, correctness, perf, tests, intent), all pinned to `1ff248b9ce`. Three assertions they found could not fail were fixed in `8cee33683d`: the picker guard passed over an inert `onReject={() => {}}` because the import line supplied the name; the size message passed with its two numbers swapped; and a "positive control" asserted a substring satisfied by any value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwxwrD2QziuF8WqomP9S8S
