### PR TITLE
fix(model): restore search-indexed images on model republish

### DIFF
--- a/src/server/services/__tests__/model-republish-image-index-sql.test.ts
+++ b/src/server/services/__tests__/model-republish-image-index-sql.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { buildRepublishImageIndexTouch } from '~/server/services/model-republish-image-index.sql';
+
+/**
+ * Structure gate for the republish image-index recovery bump.
+ *
+ * This statement is a fail-open recovery path: its only job is to move
+ * `Image."updatedAt"` so a LATER delta scan rebuilds documents an unpublish
+ * deleted. Every failure mode is silent — if the WHERE never matches, rows
+ * just don't get bumped, the direct enqueue fails open too, and the documents
+ * stay deleted while the model is public. There is no error to observe, so the
+ * emitted statement is pinned here instead. Asserts the SQL text + bind values,
+ * not `.mock.calls`, because both a correct and a scrambled statement would
+ * satisfy a call-shape assertion.
+ */
+describe('buildRepublishImageIndexTouch', () => {
+  it('emits numbered Postgres placeholders on .text', () => {
+    const { text } = buildRepublishImageIndexTouch({ userId: 1, versionIds: [10] });
+    expect(text).toContain('$1');
+  });
+
+  it('bumps Image.updatedAt, scoped by owner AND version list, joined through Post', () => {
+    const statement = buildRepublishImageIndexTouch({ userId: 4944, versionIds: [10, 20, 30] });
+    const text = statement.text.replace(/\s+/g, ' ').trim();
+
+    // The table it writes and the column it moves. A wrong table/column is
+    // silent — the delta scan keys on Image."updatedAt", so bumping anything
+    // else re-derives nothing.
+    expect(text).toMatch(/UPDATE "Image" i\b/);
+    expect(text).toMatch(/SET "updatedAt" = NOW\(\)/);
+
+    // The join and BOTH scoping predicates. Dropping the join or either
+    // predicate widens the write to images the republish never affected
+    // (other owners' images, other models' versions) — the exact over-broad
+    // form a shape check exists to reject.
+    expect(text).toMatch(/FROM "Post" p/);
+    expect(text).toMatch(/i\."postId" = p\.id/);
+    expect(text).toMatch(/p\."userId" = \$\d+/);
+    expect(text).toMatch(/p\."modelVersionId" IN \(/);
+  });
+
+  it('binds userId then every version id, and nothing else', () => {
+    // Order and contents pinned: userId is $1, the version ids follow. A swap
+    // would scope by version-as-user (or vice versa); a dropped id would
+    // silently under-scope the bump.
+    const { values } = buildRepublishImageIndexTouch({ userId: 4944, versionIds: [10, 20, 30] });
+    expect(values).toEqual([4944, 10, 20, 30]);
+  });
+
+  it('parameterizes the version ids rather than inlining them', () => {
+    // Prisma.join must produce one placeholder per id. If the list were
+    // interpolated as text it would both risk injection and defeat the bind
+    // assertion above.
+    const { text, values } = buildRepublishImageIndexTouch({
+      userId: 7,
+      versionIds: [101, 202],
+    });
+    expect(text).toContain('$1');
+    expect(text).toContain('$2');
+    expect(text).toContain('$3');
+    expect(values).toEqual([7, 101, 202]);
+  });
+});

--- a/src/server/services/model-republish-image-index.sql.ts
+++ b/src/server/services/model-republish-image-index.sql.ts
@@ -1,0 +1,40 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Bumps `Image."updatedAt"` for a republished model's own images, isolated from
+ * `model.service` so a test can assert the emitted statement without importing
+ * the service (which pulls the Prisma client, Axiom and the search index in at
+ * module scope). Extracting the helper is the repo's preferred fix over a
+ * shape-only assertion on an inline template. See
+ * `__tests__/model-republish-image-index-sql.test.ts`.
+ *
+ * WHY THE STATEMENT EXISTS: `publishModelById` queues an image search-index
+ * Update, but that enqueue fails open on a degraded sysRedis. The only recovery
+ * for a dropped Update is each image index's delta scan, keyed on rows whose
+ * `Image."updatedAt"` moved past the last watermark — and a republish otherwise
+ * never touches the image rows, so a republished model's images keep the stale
+ * `updatedAt` from the unpublish and no delta scan can re-derive them. Moving
+ * `updatedAt` here is that missing anchor.
+ *
+ * Both predicates are load-bearing: `p."userId" = userId` scopes the bump to the
+ * publisher's own images (the set the unpublish deleted from the index), and the
+ * version-id list scopes it to this model. Widening either re-indexes images the
+ * republish never affected. Set-based via `Post` so image ids stay out of the
+ * bind list (65535-param limit); the version-id list is small.
+ */
+export function buildRepublishImageIndexTouch({
+  userId,
+  versionIds,
+}: {
+  userId: number;
+  versionIds: number[];
+}): Prisma.Sql {
+  return Prisma.sql`
+    UPDATE "Image" i
+    SET "updatedAt" = NOW()
+    FROM "Post" p
+    WHERE i."postId" = p.id
+      AND p."userId" = ${userId}
+      AND p."modelVersionId" IN (${Prisma.join(versionIds, ',')})
+  `;
+}

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -107,6 +107,7 @@ import {
   queueImageSearchIndexUpdate,
 } from '~/server/services/image.service';
 import { getFilesForModelVersionCache } from '~/server/services/model-file.service';
+import { buildRepublishImageIndexTouch } from '~/server/services/model-republish-image-index.sql';
 import {
   expandBlurbs,
   getReferencedBlurbIds,
@@ -3205,6 +3206,18 @@ export const publishModelById = async ({
     where: { postId: { in: posts.map((x) => x.id) } },
     select: { id: true },
   });
+
+  // Republish only: a dropped Update on this path has no recovery without an updatedAt bump (both
+  // image indexes re-derive a missing Update solely from a delta scan of moved rows, and a
+  // republish otherwise never touches the image rows — see buildRepublishImageIndexTouch). A
+  // first/scheduled publish's images were just created, so they carry a fresh updatedAt the delta
+  // scan already sees; bumping thousands of rows there is pure duplicate work against the direct
+  // queueUpdate below.
+  if (republishing && allVersionIds.length > 0) {
+    await dbWrite.$executeRaw(
+      buildRepublishImageIndexTouch({ userId: model.userId, versionIds: allVersionIds })
+    );
+  }
 
   // Update search index for model
   await modelsSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);


### PR DESCRIPTION
When a model is unpublished, its images are deleted from both search indexes.
Republishing queues a search index Update, but that enqueue fails silently if
sysRedis is degraded — there is no error to observe. The only recovery path
for a dropped Update is each index's delta scan, which re-derives documents
for rows where `Image."updatedAt"` moved past the last watermark.

The bug: republish never touches image rows, so `Image."updatedAt"` stays
stale from the unpublish, and delta scans cannot distinguish a missing Update
from a missing row. Images remain deleted from the indexes.

The fix: bump `Image."updatedAt"` for the republished model's own images,
scoped by owner userId and version ids to avoid re-indexing unrelated images.
This anchors the delta scan to re-derive the missing documents.

The bump is isolated to republish (not first/scheduled publish, which creates
fresh images with current `updatedAt` already visible to delta scans).
Extracted as a separate module with dedicated tests to pin the SQL structure
and bind parameter order — both are silent-failure if wrong.

Refs: 868kz18pa