### PR TITLE
feat(auto-feature): detect the job going silent from outside a run

### DIFF
--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -89,6 +89,7 @@ import { pushDiscordMetadata } from '~/server/jobs/push-discord-metadata';
 import { refreshAuctionCache } from '~/server/jobs/refresh-auction-cache';
 import { refreshFeaturedCollectionsEligibility } from '~/server/jobs/refresh-featured-collections-eligibility';
 import { autoFeatureImages } from '~/server/jobs/auto-feature-images';
+import { autoFeatureHealthCheckJob } from '~/server/jobs/auto-feature-health-check';
 import { reemitBitdexOps } from '~/server/jobs/reemit-bitdex-ops';
 import { removeOldDrafts } from '~/server/jobs/remove-old-drafts';
 import { reindexRecentScheduledImages } from '~/server/jobs/reindex-recent-scheduled-images';
@@ -159,6 +160,7 @@ export const jobs: Job[] = [
   updateCollectionItemRandomId,
   refreshFeaturedCollectionsEligibility,
   autoFeatureImages,
+  autoFeatureHealthCheckJob,
   ...metricJobs,
   ...searchIndexJobs,
   searchIndexUserCleanupJob,

--- a/src/server/common/auto-feature.ts
+++ b/src/server/common/auto-feature.ts
@@ -31,10 +31,16 @@ export const AUTO_FEATURE_JOB_DATE_KEY = 'job:auto-feature-images';
  * The default `intervalHours` re-exported from the schema rather than restated, so a health check
  * reasoning about the cadence of a job whose config has gone missing measures against the value
  * that job would actually have used.
+ *
+ * 🔴 Read per-field, not by parsing a synthetic object. This runs at module load and
+ * `collection.service.ts` imports this file, so a throw here fails that import rather than the job
+ * — and parsing the whole schema to read one default couples this line to all fifteen of its
+ * fields, on a schema that exists to be tuned. One added required field or `.refine()` would be
+ * enough. `shape.<field>.parse(undefined)` resolves a `ZodDefault` and cannot throw; the idiom is
+ * `env.mock.ts`'s. Compare `job.ts`, which wraps its module-scope metrics call for the same reason.
  */
-export const AUTO_FEATURE_DEFAULT_INTERVAL_HOURS = autoFeatureSchema.parse({
-  collectionId: 1,
-}).intervalHours;
+export const AUTO_FEATURE_DEFAULT_INTERVAL_HOURS =
+  autoFeatureSchema.shape.intervalHours.parse(undefined);
 
 /**
  * Resolved by username so the same code identifies the right account in dev, preview and prod

--- a/src/server/common/auto-feature.ts
+++ b/src/server/common/auto-feature.ts
@@ -34,10 +34,11 @@ export const AUTO_FEATURE_JOB_DATE_KEY = 'job:auto-feature-images';
  *
  * 🔴 Read per-field, not by parsing a synthetic object. This runs at module load and
  * `collection.service.ts` imports this file, so a throw here fails that import rather than the job
- * — and parsing the whole schema to read one default couples this line to all fifteen of its
- * fields, on a schema that exists to be tuned. One added required field or `.refine()` would be
- * enough. `shape.<field>.parse(undefined)` resolves a `ZodDefault` and cannot throw; the idiom is
- * `env.mock.ts`'s. Compare `job.ts`, which wraps its module-scope metrics call for the same reason.
+ * — and parsing the whole schema to read one default couples this line to every one of its
+ * thirteen fields, on a schema that exists to be tuned. One added required field or `.refine()`
+ * would be enough. `shape.<field>.parse(undefined)` resolves this field's own `ZodDefault` and so
+ * cannot throw while it keeps a `.default()` — removing that reinstates the same hazard, narrowed
+ * from thirteen triggers to one. The idiom is `env.mock.ts`'s. Compare `job.ts`, which wraps its module-scope metrics call for the same reason.
  */
 export const AUTO_FEATURE_DEFAULT_INTERVAL_HOURS =
   autoFeatureSchema.shape.intervalHours.parse(undefined);

--- a/src/server/common/auto-feature.ts
+++ b/src/server/common/auto-feature.ts
@@ -6,6 +6,13 @@ import { dbRead } from '~/server/db/client';
  * Their own module because both the job and the two collection-item removal paths need them,
  * and importing the service from collection.service.ts would pull the whole home-block graph in.
  */
+/**
+ * The `getJobDate` key `auto-feature-images` advances on. Shared so the health check watching that
+ * timestamp cannot drift from the job that writes it — a mismatch would read as a permanently
+ * silent job and page forever.
+ */
+export const AUTO_FEATURE_JOB_DATE_KEY = 'job:auto-feature-images';
+
 export const AUTO_FEATURE_USERNAME = 'CivitaiOfficial';
 export const AUTO_FEATURE_NOTE_PREFIX = 'auto-featured';
 export const autoFeatureNote = (sourceCollectionId: number) =>

--- a/src/server/common/auto-feature.ts
+++ b/src/server/common/auto-feature.ts
@@ -10,6 +10,12 @@ import { dbRead } from '~/server/db/client';
  * The `getJobDate` key `auto-feature-images` advances on. Shared so the health check watching that
  * timestamp cannot drift from the job that writes it — a mismatch would read as a permanently
  * silent job and page forever.
+ *
+ * 🔴 Do not normalise away the `job:` prefix. Every other `getJobDate` caller in the repo uses a
+ * bare name, so this one looks like the odd one out and tidying it is the obvious edit — but the
+ * key names a live row in the production `KeyValue` table. Renaming it orphans that row, and the
+ * job then reads epoch 0, believes it has never run, and fires once immediately.
+ * `auto-feature-health-check.test.ts` pins both sides against exactly this.
  */
 export const AUTO_FEATURE_JOB_DATE_KEY = 'job:auto-feature-images';
 

--- a/src/server/common/auto-feature.ts
+++ b/src/server/common/auto-feature.ts
@@ -19,8 +19,9 @@ export const autoFeatureNote = (sourceCollectionId: number) =>
  * timestamp cannot drift from the job that writes it — a mismatch would read as a permanently
  * silent job and page forever.
  *
- * 🔴 Do not normalise away the `job:` prefix. Every other `getJobDate` caller in the repo uses a
- * bare name, so this one looks like the odd one out and tidying it is the obvious edit — but the
+ * 🔴 Do not normalise away the `job:` prefix. No other `getJobDate` caller uses it — most pass a
+ * bare name, and the prefixed keys that do exist elsewhere use other namespaces (`metric:`,
+ * `rank:`, `searchIndex:`) — so this one looks like the odd one out and tidying it is obvious. But the
  * key names a live row in the production `KeyValue` table. Renaming it orphans that row, and the
  * job then reads epoch 0, believes it has never run, and fires once immediately.
  * `auto-feature-health-check.test.ts` pins both sides against exactly this.
@@ -64,9 +65,10 @@ export async function getAutoFeatureUserId() {
  * The system FeaturedCollections block and its parsed auto-feature config.
  *
  * 🔴 Here rather than in `auto-feature-images.service.ts` so the producer and the health check
- * watching it resolve the SAME block. There are four copies of this lookup in the repo and two of
- * them already disagree — `refresh-featured-collections-eligibility.ts` and `home-block.service.ts`
- * omit the `orderBy`, so if more than one system block ever exists they answer a different row.
+ * watching it resolve the SAME block. There are four copies of this lookup in the repo and this is
+ * the only one with an `orderBy` — `refresh-featured-collections-eligibility.ts` and both copies in
+ * `home-block.service.ts` omit it, so if more than one system block ever exists they answer an
+ * unspecified row, and one of them creates a block when none matches.
  * A watcher measuring one block's `intervalHours` against another block's writes reports a fault
  * that does not exist, and the same argument the `getJobDate` key above makes applies here.
  *

--- a/src/server/common/auto-feature.ts
+++ b/src/server/common/auto-feature.ts
@@ -1,4 +1,7 @@
 import { dbRead } from '~/server/db/client';
+import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
+import { autoFeatureSchema } from '~/server/schema/home-block.schema';
+import { HomeBlockType } from '~/shared/utils/prisma/enums';
 
 /**
  * Markers identifying a CollectionItem the auto-feature job added, rather than a curator.
@@ -6,6 +9,11 @@ import { dbRead } from '~/server/db/client';
  * Their own module because both the job and the two collection-item removal paths need them,
  * and importing the service from collection.service.ts would pull the whole home-block graph in.
  */
+export const AUTO_FEATURE_USERNAME = 'CivitaiOfficial';
+export const AUTO_FEATURE_NOTE_PREFIX = 'auto-featured';
+export const autoFeatureNote = (sourceCollectionId: number) =>
+  `${AUTO_FEATURE_NOTE_PREFIX}:${sourceCollectionId}`;
+
 /**
  * The `getJobDate` key `auto-feature-images` advances on. Shared so the health check watching that
  * timestamp cannot drift from the job that writes it — a mismatch would read as a permanently
@@ -19,10 +27,14 @@ import { dbRead } from '~/server/db/client';
  */
 export const AUTO_FEATURE_JOB_DATE_KEY = 'job:auto-feature-images';
 
-export const AUTO_FEATURE_USERNAME = 'CivitaiOfficial';
-export const AUTO_FEATURE_NOTE_PREFIX = 'auto-featured';
-export const autoFeatureNote = (sourceCollectionId: number) =>
-  `${AUTO_FEATURE_NOTE_PREFIX}:${sourceCollectionId}`;
+/**
+ * The default `intervalHours` re-exported from the schema rather than restated, so a health check
+ * reasoning about the cadence of a job whose config has gone missing measures against the value
+ * that job would actually have used.
+ */
+export const AUTO_FEATURE_DEFAULT_INTERVAL_HOURS = autoFeatureSchema.parse({
+  collectionId: 1,
+}).intervalHours;
 
 /**
  * Resolved by username so the same code identifies the right account in dev, preview and prod
@@ -39,6 +51,40 @@ export async function getAutoFeatureUserId() {
     select: { id: true },
   });
   return user?.id ?? null;
+}
+
+/**
+ * The system FeaturedCollections block and its parsed auto-feature config.
+ *
+ * 🔴 Here rather than in `auto-feature-images.service.ts` so the producer and the health check
+ * watching it resolve the SAME block. There are four copies of this lookup in the repo and two of
+ * them already disagree — `refresh-featured-collections-eligibility.ts` and `home-block.service.ts`
+ * omit the `orderBy`, so if more than one system block ever exists they answer a different row.
+ * A watcher measuring one block's `intervalHours` against another block's writes reports a fault
+ * that does not exist, and the same argument the `getJobDate` key above makes applies here.
+ *
+ * It lives in this leaf module rather than being exported from the service on purpose: the health
+ * check must not take a module-load dependency on the producer's graph, which reaches the home-block
+ * cache and the eligibility job. Independence from the producer is the point of the check.
+ *
+ * Parsed rather than cast: hand-edited JSON, and every default the job relies on — perRun, the decay
+ * constants, dryRun — exists only if the schema fills it in.
+ */
+export async function getAutoFeatureBlockConfig() {
+  const block = await dbRead.homeBlock.findFirst({
+    where: { userId: -1, type: HomeBlockType.FeaturedCollections },
+    select: { id: true, metadata: true },
+    orderBy: { id: 'asc' },
+  });
+  if (!block) return null;
+  const metadata = (block.metadata || {}) as HomeBlockMetaSchema;
+  const config = autoFeatureSchema.safeParse(metadata.featuredCollections?.autoFeature);
+  if (!config.success) return null;
+  return {
+    blockId: block.id,
+    config: config.data,
+    pool: metadata.featuredCollections?.collectionIds ?? [],
+  };
 }
 
 export function isAutoFeaturedRow(

--- a/src/server/common/mod-alert.ts
+++ b/src/server/common/mod-alert.ts
@@ -1,0 +1,34 @@
+import { env } from '~/env/server';
+
+/**
+ * Post a title/description alert to the moderator Discord channel.
+ *
+ * Extracted from the two health-check jobs, which had byte-identical copies. The reason to share it
+ * is not the ten lines: the fleet already disagrees about whether a hung webhook can stall its
+ * caller — `apps-shared.router.ts` passes `AbortSignal.timeout(5_000)` and the health checks pass
+ * nothing, while a job holds its lock for the duration. Whoever settles that should have one place
+ * to change, not five.
+ *
+ * Behaviour is deliberately unchanged from the copies this replaces, timeout included. Only the
+ * return value is new.
+ *
+ * The richer field-based embeds elsewhere (`git-push.ts`, `new-order-jobs.ts`,
+ * `publish-request.service.ts`) are a different shape and are not served by this.
+ *
+ * @returns whether the alert actually landed. A caller that reports "paged" off its own intent
+ * rather than this answer will keep claiming it alerted someone long after the webhook is revoked —
+ * which for a health check means the outage detector's own outage is invisible.
+ */
+export async function notifyModAlert(title: string, description: string): Promise<boolean> {
+  if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return false;
+
+  return fetch(env.DISCORD_WEBHOOK_MOD_ALERTS, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      embeds: [{ title, description, color: 0xf44336, timestamp: new Date().toISOString() }],
+    }),
+  })
+    .then((res) => res.ok)
+    .catch(() => false);
+}

--- a/src/server/common/mod-alert.ts
+++ b/src/server/common/mod-alert.ts
@@ -12,15 +12,23 @@ import { env } from '~/env/server';
  * Behaviour is deliberately unchanged from the copies this replaces, timeout included. Only the
  * return value is new.
  *
- * The richer field-based embeds elsewhere (`git-push.ts`, `new-order-jobs.ts`,
- * `publish-request.service.ts`) are a different shape and are not served by this.
- *
- * @returns whether the alert actually landed. A caller that reports "paged" off its own intent
- * rather than this answer will keep claiming it alerted someone long after the webhook is revoked —
- * which for a health check means the outage detector's own outage is invisible.
+ * `new-order-jobs.ts` posts this same title/description shape and differs only in `color`, so it is
+ * one optional parameter from being the third caller — take it when a third one arrives. The other
+ * three (`git-push.ts`, `publish-request.service.ts`, `apps-shared.router.ts`) build `fields[]`
+ * embeds with `url`/`footer` and are a genuinely different shape; the latter two also resolve `env`
+ * through `await import`, so they would not adopt this unchanged even if the shape matched.
  */
-export async function notifyModAlert(title: string, description: string): Promise<boolean> {
-  if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return false;
+export type ModAlertOutcome = 'delivered' | 'rejected' | 'unconfigured';
+
+/**
+ * @returns what happened, not merely whether it worked. `rejected` and `unconfigured` are different
+ * facts and a caller that collapses them reports a delivery failure in every environment that never
+ * had a webhook — which for a health check means its own alarm cries wolf exactly where nobody can
+ * act on it. A caller reporting "paged" off its own intent instead of this answer keeps claiming it
+ * alerted someone long after the webhook is revoked.
+ */
+export async function notifyModAlert(title: string, description: string): Promise<ModAlertOutcome> {
+  if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return 'unconfigured';
 
   return fetch(env.DISCORD_WEBHOOK_MOD_ALERTS, {
     method: 'POST',
@@ -29,6 +37,6 @@ export async function notifyModAlert(title: string, description: string): Promis
       embeds: [{ title, description, color: 0xf44336, timestamp: new Date().toISOString() }],
     }),
   })
-    .then((res) => res.ok)
-    .catch(() => false);
+    .then((res) => (res.ok ? ('delivered' as const) : ('rejected' as const)))
+    .catch(() => 'rejected' as const);
 }

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -164,6 +164,16 @@ describe('auto-feature-health-check reads state the producer does not have to be
     // so the ordered bind check below cannot see it, and `lastRow` would silently become the newest
     // CURATOR row instead. With `$queryRaw` mocked, the emitted SQL is the only observable there is.
     expect(rowQuery().sql).toMatch(/AND\s+ci\.note LIKE /);
+    // Structural, and the reason this is not a fourth clause-by-clause assertion: pinning the
+    // operator in front of each clause I could see left the `collectionId`/`addedById` conjunction
+    // unguarded, and `OR` there makes max() range over every row in the collection. Enumeration
+    // closes the clauses that exist today; this closes the ones added later too. The query
+    // legitimately contains no OR, so if one is ever needed this fails loudly and someone decides.
+    //
+    // String.raw is load-bearing. Written as a plain literal through a shell heredoc this became a
+    // regex with LITERAL BACKSPACE bytes where the word boundaries belong, matching nothing and
+    // passing forever. Caught only because the mutant was run rather than assumed.
+    expect(rowQuery().sql).not.toMatch(new RegExp(String.raw`\bOR\b`, 'i'));
   });
 
   it('derives the threshold from the configured interval rather than a constant', async () => {
@@ -289,11 +299,24 @@ describe('auto-feature-health-check alerting', () => {
     // file passes either way, because the mock ignores its argument.
     expect(mocks.isFlipt).toHaveBeenCalledWith('auto-feature-images');
 
+    // Read from source, because the line above is otherwise a tautology: the string it compares
+    // against comes from this file's own `vi.mock` of the flipt client, so renaming the REAL enum
+    // value leaves it green while prod goes double-silent — the producer stops on a flag Flipt does
+    // not know, and this check reports `skipped`. The KeyValue test above is sound for exactly this
+    // reason; `importActual` is not an option here, it pulls `~/env/server`.
+    const fliptClient = readFileSync(resolve(__dirname, '../../flipt/client.ts'), 'utf-8');
+    expect(fliptClient).toMatch(/AUTO_FEATURE_IMAGES = 'auto-feature-images'/);
+
     // One side only is not enough — the same asymmetry the KeyValue-key test above closes. Gate the
     // PRODUCER on a different flag and this check goes silent while the job keeps running, or stays
     // noisy while it is off, with every assertion in this file still green.
+    // First identifier only, same rationale as the getJobDate regex above: `isEnabled` takes
+    // (flag, entityId?, context?), so giving the producer a segment rollout is behaviour-preserving
+    // for WHICH flag it is, and anchoring on the closing paren would redden with a message saying
+    // the producer is ungated when it is not.
     const producer = readFileSync(resolve(__dirname, '../auto-feature-images.ts'), 'utf-8');
-    expect(producer).toMatch(/isFlipt\(\s*FLIPT_FEATURE_FLAGS\.AUTO_FEATURE_IMAGES\s*\)/);
+    const gate = producer.match(/isFlipt\(\s*([A-Za-z_$][\w$.]*)/);
+    expect(gate?.[1]).toBe('FLIPT_FEATURE_FLAGS.AUTO_FEATURE_IMAGES');
   });
 
   it('sends the page to the webhook, with the failure in the body', async () => {

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -11,10 +11,6 @@ vi.mock('~/server/flipt/client', () => ({
   isFlipt: mocks.isFlipt,
   FLIPT_FEATURE_FLAGS: { AUTO_FEATURE_IMAGES: 'auto-feature-images' },
 }));
-// LOGGING is read by createLogger at module load; the webhook is the only value asserted on.
-vi.mock('~/env/server', () => ({
-  env: { DISCORD_WEBHOOK_MOD_ALERTS: 'https://discord.test/webhook', LOGGING: [] },
-}));
 vi.mock('~/server/jobs/job', () => ({
   createJob: (name: string, cron: string, fn: () => Promise<unknown>) => ({ name, cron, run: fn }),
 }));
@@ -25,8 +21,12 @@ import {
   readAutoFeatureHealth,
 } from '~/server/jobs/auto-feature-health-check';
 import { AUTO_FEATURE_JOB_DATE_KEY } from '~/server/common/auto-feature';
+import { autoFeatureSchema } from '~/server/schema/home-block.schema';
+import { setEnv } from '~/__tests__/mocks/env.mock';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const WEBHOOK = 'https://discord.test/webhook';
 
 const NOW = new Date('2026-09-01T18:00:00Z');
 const hoursBefore = (h: number) => new Date(NOW.getTime() - h * 3_600_000);
@@ -74,7 +74,17 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal('fetch', mocks.fetch);
   mocks.isFlipt.mockResolvedValue(true);
+  // Declared rather than replacing the whole module: `~/env/server` exports one `env` object of
+  // ~200 keys, so a full replacement gives `undefined` for anything the graph later reads, which
+  // is silently wrong rather than a loud missing-export error.
+  setEnv({ DISCORD_WEBHOOK_MOD_ALERTS: WEBHOOK });
 });
+
+/** The request `notifyModAlert` actually emitted, rather than the fact that fetch was called. */
+function discordCall() {
+  const [url, init] = mocks.fetch.mock.calls[0] as [string, RequestInit];
+  return { url, init, body: JSON.parse(String(init.body)) };
+}
 
 describe('auto-feature-health-check reads state the producer does not have to be alive for', () => {
   it('watches the same KeyValue row the job advances', async () => {
@@ -99,7 +109,10 @@ describe('auto-feature-health-check reads state the producer does not have to be
     // is the odd one out and normalising it is the plausible edit. Both sides are read from source
     // here because the producer has no suite of its own to assert it in.
     const producer = readFileSync(resolve(__dirname, '../auto-feature-images.ts'), 'utf-8');
-    const call = producer.match(/getJobDate\(\s*([^)]+?)\s*\)/);
+    // First identifier only. `getJobDate(key, defaultValue?)` takes a second optional argument, so
+    // capturing to the closing paren reddens on a behaviour-neutral edit with a message that blames
+    // the edit rather than this regex.
+    const call = producer.match(/getJobDate\(\s*([A-Za-z_$][\w$]*)/);
 
     expect(call?.[1]).toBe('AUTO_FEATURE_JOB_DATE_KEY');
     expect(AUTO_FEATURE_JOB_DATE_KEY).toBe('job:auto-feature-images');
@@ -150,7 +163,12 @@ describe('auto-feature-health-check reads state the producer does not have to be
 
     // A vanished config is itself a fault the producer cannot report while it is not running.
     // Refusing to check without one would blind this job to precisely that case.
-    expect(result).toMatchObject({ healthy: false, staleAfterHours: 13 });
+    //
+    // Derived from the schema rather than written as 13: the fallback claims to match the cadence
+    // the job would itself have run at, and asserting a literal here cannot see the schema default
+    // moving out from under it — which is the only way that claim can become false.
+    const schemaDefault = autoFeatureSchema.parse({ collectionId: 1 }).intervalHours;
+    expect(result).toMatchObject({ healthy: false, staleAfterHours: schemaDefault * 2 + 1 });
   });
 });
 
@@ -236,6 +254,69 @@ describe('auto-feature-health-check alerting', () => {
     expect(result).toMatchObject({ healthy: false, paged: 1 });
   });
 
+  it('is gated on the SAME flag the producer is gated on', async () => {
+    stateIs({ lastRun: hoursBefore(1), lastRow: hoursBefore(1) });
+
+    await autoFeatureHealthCheckJob.run();
+
+    // Pinned as a literal. Gate this on any other flag and the check goes silent while the producer
+    // keeps running, or stays noisy while the producer is off — and every other assertion in this
+    // file passes either way, because the mock ignores its argument.
+    expect(mocks.isFlipt).toHaveBeenCalledWith('auto-feature-images');
+  });
+
+  it('sends the page to the webhook, with the failure in the body', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+
+    await autoFeatureHealthCheckJob.run();
+
+    // `toHaveBeenCalledOnce` describes the harness; the thing that matters is the request. An empty
+    // embed, a blank description, or a POST to the wrong host all satisfy a call-count assertion
+    // identically, and all three deliver a page that tells nobody anything.
+    const { url, init, body } = discordCall();
+    expect(url).toBe(WEBHOOK);
+    expect(init.method).toBe('POST');
+    expect(body.embeds[0].description).toContain('No completed run');
+    expect(body.embeds[0].title).toContain('Auto-feature');
+  });
+
+  it('does not fetch at all when no webhook is configured', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+    setEnv({ DISCORD_WEBHOOK_MOD_ALERTS: undefined });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // Every other test in this file sets the webhook, so the guard's absence is invisible to them —
+    // deleting it would only show up in an environment that has no webhook, as `fetch(undefined)`.
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    // The finding still has to survive to Axiom; only its delivery is missing.
+    expect(result).toMatchObject({ healthy: false, alerts: 1, paged: 0 });
+  });
+
+  it('reports paged: 0 when the webhook rejects the page', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+    mocks.fetch.mockResolvedValue(new Response(null, { status: 404 }));
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // A revoked webhook must not leave the job claiming it alerted someone. This job exists to make
+    // a silent failure visible; it must not have one of its own.
+    expect(result).toMatchObject({ healthy: false, alerts: 1, paged: 0 });
+    expect(axiom('warning').some((a) => a.message?.includes('reached nobody'))).toBe(true);
+  });
+
+  it('does not blame the caps when the attribution account is missing', async () => {
+    stateIs({ lastRun: hoursBefore(1), lastRow: null });
+    dbMock.dbRead.user.findFirst.mockResolvedValue(null);
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // lastRow is null because we could not look, not because the job wrote nothing. Reporting
+    // "running but not writing" here names the caps for a fault that is a missing user account.
+    expect(result).toMatchObject({ healthy: true });
+    expect(dbMock.dbRead.$queryRaw).not.toHaveBeenCalled();
+  });
+
   it('skips without paging when the auto-feature flag is off', async () => {
     stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
     mocks.isFlipt.mockResolvedValue(false);
@@ -266,8 +347,11 @@ describe('auto-feature-health-check heartbeat parsing', () => {
     // `KeyValue.value` is untyped Json and other keys in the table hold arrays and strings. Reading
     // one of those as epoch 0 rather than as null would page, which is the safe direction — but an
     // unparseable value must not become a plausible-looking date either.
-    for (const value of [null, {}, 'not-a-date', 0]) {
+    // `['1']` is here because `KeyValue` genuinely holds arrays for other keys and `Number(['1'])`
+    // is 1 — the one shape that becomes a plausible-looking 1970 date rather than obviously junk.
+    for (const value of [null, {}, 'not-a-date', 0, ['1']]) {
       vi.clearAllMocks();
+      setEnv({ DISCORD_WEBHOOK_MOD_ALERTS: WEBHOOK });
       stateIs({ lastRun: NOW, lastRow: NOW });
       dbMock.dbRead.keyValue.findUnique.mockResolvedValue({
         key: AUTO_FEATURE_JOB_DATE_KEY,

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   isFlipt: vi.fn(async () => true),
@@ -72,6 +72,13 @@ function axiom(type: 'warning' | 'info') {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `checkAutoFeatureHealth` reads the real clock, and every timestamp below is relative to a fixed
+  // literal — so without this the gap between them grows in real time and the tests asserting a
+  // healthy pipeline expire. They passed until 2026-09-02T00:00:00Z and would then have failed on
+  // their own, hours after the last commit, looking like a regression in the code they cover.
+  // Only Date is faked: faking timers wholesale would stall the async paths under test.
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(NOW);
   vi.stubGlobal('fetch', mocks.fetch);
   mocks.isFlipt.mockResolvedValue(true);
   // Restored, not just cleared. `vi.clearAllMocks()` drops call records but keeps implementations,
@@ -82,6 +89,10 @@ beforeEach(() => {
   // ~200 keys, so a full replacement gives `undefined` for anything the graph later reads, which
   // is silently wrong rather than a loud missing-export error.
   setEnv({ DISCORD_WEBHOOK_MOD_ALERTS: WEBHOOK });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 /** The request `notifyModAlert` actually emitted, rather than the fact that fetch was called. */
@@ -319,11 +330,11 @@ describe('auto-feature-health-check alerting', () => {
 
     const result = await autoFeatureHealthCheckJob.run();
 
-    // Ordering guard, and it is the only thing making the fetch restore in `beforeEach` do any
-    // work. `vi.clearAllMocks()` keeps implementations, so the 404 stubbed above would otherwise
-    // leak into every later test in this file — leaving the suite green because nothing after it
-    // happens to need a successful POST. Whoever removes that restore should fail HERE, not in a
-    // test they add months later that appears to break the code it is testing.
+    // Position matters: this must run after the test that stubs a 404, and asserts the stub was
+    // restored. `vi.clearAllMocks()` keeps implementations, so without the restore in `beforeEach`
+    // that 404 leaks into every later test. Reordering the file, or any invocation that shuffles
+    // test order, breaks it here rather than in a later test that would appear to break the code it
+    // is testing.
     expect(result).toMatchObject({ healthy: false, paged: 1 });
     expect(axiom('warning').some((a) => a.message?.includes('Discord rejected'))).toBe(false);
   });

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -88,6 +90,21 @@ describe('auto-feature-health-check reads state the producer does not have to be
     });
   });
 
+  it('reads the key the PRODUCER writes, not merely a key of its own', async () => {
+    // The assertion above pins one side. On its own it is satisfied by a health check that agrees
+    // with itself: point `auto-feature-images` at a different key and every suite here stays green
+    // while the check reads a row nothing writes and pages forever.
+    //
+    // Every other getJobDate caller in the repo uses a bare name with no `job:` prefix, so this key
+    // is the odd one out and normalising it is the plausible edit. Both sides are read from source
+    // here because the producer has no suite of its own to assert it in.
+    const producer = readFileSync(resolve(__dirname, '../auto-feature-images.ts'), 'utf-8');
+    const call = producer.match(/getJobDate\(\s*([^)]+?)\s*\)/);
+
+    expect(call?.[1]).toBe('AUTO_FEATURE_JOB_DATE_KEY');
+    expect(AUTO_FEATURE_JOB_DATE_KEY).toBe('job:auto-feature-images');
+  });
+
   it('dates a row the way the producer does, by COALESCE rather than one column', async () => {
     stateIs({ lastRun: hoursBefore(1), lastRow: hoursBefore(1) });
 
@@ -98,10 +115,20 @@ describe('auto-feature-health-check reads state the producer does not have to be
     // while reviewedAt happens to be null — which is exactly how this would pass in a test and
     // drift in production.
     expect(sql).toMatch(/max\(COALESCE\(ci\."reviewedAt", ci\."createdAt"\)\)/);
-    // Scoped to the job's own rows: a curator's manual feature must not answer "the job is alive".
-    expect(binds).toContain(107);
-    expect(binds).toContain(9001);
-    expect(binds).toContain('auto-featured:%');
+    // Ordered, not `toContain`: the collection id and the user id are both plain integers, so a
+    // membership assertion passes just as well with the two binds swapped into each other's column.
+    expect(binds).toEqual([107, 9001, 'auto-featured:%']);
+  });
+
+  it('ignores tombstoned rows, so removing a feature cannot pass for writing one', async () => {
+    stateIs({ lastRun: hoursBefore(1), lastRow: hoursBefore(1) });
+
+    await autoFeatureHealthCheckJob.run();
+
+    // Removal sets status REJECTED and stamps reviewedAt = now(), keeping addedById and the note.
+    // Without this filter a moderator clearing stale features — what someone does precisely while
+    // the pipeline is dry — moves lastRow to the present and silences the check for good.
+    expect(rowQuery().sql).toMatch(/ci\.status = 'ACCEPTED'::"CollectionItemStatus"/);
   });
 
   it('derives the threshold from the configured interval rather than a constant', async () => {
@@ -144,7 +171,7 @@ describe('auto-feature-health-check alerting', () => {
     const result = await autoFeatureHealthCheckJob.run();
 
     expect(result).toMatchObject({ healthy: false, paged: 1 });
-    expect(axiom('warning')[0].message).toContain('Not running');
+    expect(axiom('warning')[0].message).toContain('No completed run');
     expect(mocks.fetch).toHaveBeenCalledOnce();
   });
 
@@ -156,7 +183,7 @@ describe('auto-feature-health-check alerting', () => {
     const result = await autoFeatureHealthCheckJob.run();
 
     expect(result).toMatchObject({ healthy: false, paged: 1 });
-    expect(axiom('warning')[0].message).toContain('Not running');
+    expect(axiom('warning')[0].message).toContain('No completed run');
   });
 
   it('does not page on the ordinary 7-hour spacing between runs', async () => {
@@ -209,7 +236,7 @@ describe('auto-feature-health-check alerting', () => {
     expect(result).toMatchObject({ healthy: false, paged: 1 });
   });
 
-  it('skips entirely when the auto-feature flag is off', async () => {
+  it('skips without paging when the auto-feature flag is off', async () => {
     stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
     mocks.isFlipt.mockResolvedValue(false);
 
@@ -217,8 +244,49 @@ describe('auto-feature-health-check alerting', () => {
 
     // The flag off makes the producer return before it touches anything, by design.
     expect(result).toMatchObject({ skipped: true });
-    expect(dbMock.dbRead.keyValue.findUnique).not.toHaveBeenCalled();
+    expect(dbMock.dbRead.$queryRaw).not.toHaveBeenCalled();
     expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('still records the heartbeat age when the flag reads off', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+    mocks.isFlipt.mockResolvedValue(false);
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // `isFlipt` returns false for an unreachable Flipt too, so this path is also what a control-
+    // plane outage looks like — and it stops the producer and this check together. A flag reading
+    // off over a heartbeat that is 79h old is the only trace that case leaves.
+    expect(result).toMatchObject({ lastRun: hoursBefore(79).toISOString() });
+  });
+});
+
+describe('auto-feature-health-check heartbeat parsing', () => {
+  it('treats a KeyValue row that is not a millisecond number as no heartbeat', async () => {
+    // `KeyValue.value` is untyped Json and other keys in the table hold arrays and strings. Reading
+    // one of those as epoch 0 rather than as null would page, which is the safe direction — but an
+    // unparseable value must not become a plausible-looking date either.
+    for (const value of [null, {}, 'not-a-date', 0]) {
+      vi.clearAllMocks();
+      stateIs({ lastRun: NOW, lastRow: NOW });
+      dbMock.dbRead.keyValue.findUnique.mockResolvedValue({
+        key: AUTO_FEATURE_JOB_DATE_KEY,
+        value,
+      });
+
+      const health = await readAutoFeatureHealth();
+
+      expect(health.lastRun).toBeNull();
+    }
+  });
+
+  it('accepts the millisecond number getJobDate actually writes', async () => {
+    stateIs({ lastRun: NOW, lastRow: NOW });
+
+    const health = await readAutoFeatureHealth();
+
+    // Without this, the guard above could be satisfied by rejecting everything.
+    expect(health.lastRun).toEqual(NOW);
   });
 });
 

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isFlipt: vi.fn(async () => true),
+  fetch: vi.fn(async () => new Response(null, { status: 204 })),
+}));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mocks.isFlipt,
+  FLIPT_FEATURE_FLAGS: { AUTO_FEATURE_IMAGES: 'auto-feature-images' },
+}));
+// LOGGING is read by createLogger at module load; the webhook is the only value asserted on.
+vi.mock('~/env/server', () => ({
+  env: { DISCORD_WEBHOOK_MOD_ALERTS: 'https://discord.test/webhook', LOGGING: [] },
+}));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (name: string, cron: string, fn: () => Promise<unknown>) => ({ name, cron, run: fn }),
+}));
+
+import {
+  autoFeatureHealthCheckJob,
+  evaluateAutoFeatureHealth,
+  readAutoFeatureHealth,
+} from '~/server/jobs/auto-feature-health-check';
+import { AUTO_FEATURE_JOB_DATE_KEY } from '~/server/common/auto-feature';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
+
+const NOW = new Date('2026-09-01T18:00:00Z');
+const hoursBefore = (h: number) => new Date(NOW.getTime() - h * 3_600_000);
+
+/** Today's production config: 6h interval, live writes, target collection 107. */
+const CONFIG = { collectionId: 107, intervalHours: 6, dryRun: false, perRun: 5 };
+
+/**
+ * Drives the job's three reads: the home block's config, the `KeyValue` heartbeat, and the raw
+ * `max(...)` over the target collection. Declared per-test rather than defaulted to healthy, so a
+ * test that forgets to say what the database holds fails rather than inheriting a green.
+ */
+function stateIs({
+  config = CONFIG as Record<string, unknown> | null,
+  lastRun,
+  lastRow,
+}: {
+  config?: Record<string, unknown> | null;
+  lastRun: Date | null;
+  lastRow: Date | null;
+}) {
+  dbMock.dbRead.homeBlock.findFirst.mockResolvedValue(
+    config === null ? null : { metadata: { featuredCollections: { autoFeature: config } } }
+  );
+  dbMock.dbRead.user.findFirst.mockResolvedValue({ id: 9001 });
+  dbMock.dbRead.keyValue.findUnique.mockResolvedValue(
+    lastRun === null ? null : { key: AUTO_FEATURE_JOB_DATE_KEY, value: lastRun.getTime() }
+  );
+  dbMock.dbRead.$queryRaw.mockResolvedValue([{ lastRow }]);
+}
+
+/** The tagged-template args the job hands the database: [strings, ...binds]. */
+function rowQuery() {
+  const [strings, ...binds] = dbMock.dbRead.$queryRaw.mock.calls[0] as [string[], ...unknown[]];
+  return { sql: strings.join('?'), binds };
+}
+
+function axiom(type: 'warning' | 'info') {
+  return loggingMock.logToAxiom.mock.calls
+    .map(([arg]) => arg as { type?: string; name?: string; message?: string })
+    .filter((arg) => arg.name === 'auto-feature-health-check' && arg.type === type);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', mocks.fetch);
+  mocks.isFlipt.mockResolvedValue(true);
+});
+
+describe('auto-feature-health-check reads state the producer does not have to be alive for', () => {
+  it('watches the same KeyValue row the job advances', async () => {
+    stateIs({ lastRun: hoursBefore(1), lastRow: hoursBefore(1) });
+
+    await autoFeatureHealthCheckJob.run();
+
+    // Pinned as a literal, not as the shared constant: the value lives in a production table, so a
+    // rename has to be a deliberate edit here rather than a silent rename on both sides that
+    // leaves the check watching a key nothing writes.
+    expect(dbMock.dbRead.keyValue.findUnique).toHaveBeenCalledWith({
+      where: { key: 'job:auto-feature-images' },
+    });
+  });
+
+  it('dates a row the way the producer does, by COALESCE rather than one column', async () => {
+    stateIs({ lastRun: hoursBefore(1), lastRow: hoursBefore(1) });
+
+    await autoFeatureHealthCheckJob.run();
+
+    const { sql, binds } = rowQuery();
+    // max(reviewedAt) and max(createdAt) taken separately are a different value, and agree only
+    // while reviewedAt happens to be null — which is exactly how this would pass in a test and
+    // drift in production.
+    expect(sql).toMatch(/max\(COALESCE\(ci\."reviewedAt", ci\."createdAt"\)\)/);
+    // Scoped to the job's own rows: a curator's manual feature must not answer "the job is alive".
+    expect(binds).toContain(107);
+    expect(binds).toContain(9001);
+    expect(binds).toContain('auto-featured:%');
+  });
+
+  it('derives the threshold from the configured interval rather than a constant', async () => {
+    stateIs({ config: { ...CONFIG, intervalHours: 6 }, lastRun: NOW, lastRow: NOW });
+    const at6 = await readAutoFeatureHealth();
+
+    stateIs({ config: { ...CONFIG, intervalHours: 24 }, lastRun: NOW, lastRow: NOW });
+    const at24 = await readAutoFeatureHealth();
+
+    // The cadence is tunable without a deploy, so a hardcoded threshold silently stops matching it.
+    expect(at6.staleAfterHours).toBe(13);
+    expect(at24.staleAfterHours).toBe(49);
+  });
+
+  it('still checks when the config has gone missing, at the schema default cadence', async () => {
+    stateIs({ config: null, lastRun: hoursBefore(80), lastRow: hoursBefore(80) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // A vanished config is itself a fault the producer cannot report while it is not running.
+    // Refusing to check without one would blind this job to precisely that case.
+    expect(result).toMatchObject({ healthy: false, staleAfterHours: 13 });
+  });
+});
+
+describe('auto-feature-health-check alerting', () => {
+  it('stays quiet on a live pipeline', async () => {
+    stateIs({ lastRun: hoursBefore(0.7), lastRow: hoursBefore(0.7) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: true });
+    expect(axiom('warning')).toHaveLength(0);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('pages on a repeat of the 79-hour August outage', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, paged: 1 });
+    expect(axiom('warning')[0].message).toContain('Not running');
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('pages when the job has never run at all', async () => {
+    // A missing heartbeat and a months-old one are the same outage from the homepage's side.
+    // Treating null as inconclusive is how a check that cannot fire gets written.
+    stateIs({ lastRun: null, lastRow: null });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, paged: 1 });
+    expect(axiom('warning')[0].message).toContain('Not running');
+  });
+
+  it('does not page on the ordinary 7-hour spacing between runs', async () => {
+    // The producer wakes hourly and fires on a 6h interval, so 7h is the real observed gap. A
+    // threshold at or below it would page several times a day and be turned off.
+    stateIs({ lastRun: hoursBefore(7), lastRow: hoursBefore(7) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: true });
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('records a running-but-dry pipeline without paging for it', async () => {
+    stateIs({ lastRun: hoursBefore(1), lastRow: hoursBefore(40) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, alerts: 1, paged: 0 });
+    expect(axiom('info')[0].message).toContain('Running but not writing');
+    // Caps refusing everything is legitimate. Paging on it is how an alert gets muted.
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('blames a dead job once, not twice', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // The rows are stale BECAUSE the job is dead. A second line naming the caps would name a
+    // cause that is not the one, and send whoever reads it to the wrong place.
+    expect(result).toMatchObject({ alerts: 1 });
+    expect(axiom('warning')[0].message).not.toContain('Running but not writing');
+  });
+
+  it('does not treat a dry run as a stopped one', async () => {
+    stateIs({ config: { ...CONFIG, dryRun: true }, lastRun: hoursBefore(1), lastRow: null });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // dryRun writes nothing by design, so the row check has nothing to say. The heartbeat still does.
+    expect(result).toMatchObject({ healthy: true });
+  });
+
+  it('still pages a dry-run pipeline whose job has stopped', async () => {
+    stateIs({ config: { ...CONFIG, dryRun: true }, lastRun: hoursBefore(79), lastRow: null });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    expect(result).toMatchObject({ healthy: false, paged: 1 });
+  });
+
+  it('skips entirely when the auto-feature flag is off', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+    mocks.isFlipt.mockResolvedValue(false);
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // The flag off makes the producer return before it touches anything, by design.
+    expect(result).toMatchObject({ skipped: true });
+    expect(dbMock.dbRead.keyValue.findUnique).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('evaluateAutoFeatureHealth boundary', () => {
+  const base = { staleAfterHours: 13, dryRun: false, collectionId: 107 };
+
+  it('is quiet at the threshold and fires one hour past it', () => {
+    const at = evaluateAutoFeatureHealth(
+      { ...base, lastRun: hoursBefore(13), lastRow: hoursBefore(13) },
+      NOW
+    );
+    const past = evaluateAutoFeatureHealth(
+      { ...base, lastRun: hoursBefore(14), lastRow: hoursBefore(14) },
+      NOW
+    );
+
+    expect(at).toHaveLength(0);
+    expect(past.map((a) => a.severity)).toEqual(['page']);
+  });
+});

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -156,7 +156,14 @@ describe('auto-feature-health-check reads state the producer does not have to be
     // Removal sets status REJECTED and stamps reviewedAt = now(), keeping addedById and the note.
     // Without this filter a moderator clearing stale features — what someone does precisely while
     // the pipeline is dry — moves lastRow to the present and silences the check for good.
-    expect(rowQuery().sql).toMatch(/ci\.status = 'ACCEPTED'::"CollectionItemStatus"/);
+    // The operator is part of the assertion. Without `AND`, mutating it to `OR` matches this regex
+    // just as well while `max(...)` starts ranging over rows outside the collection and attribution
+    // filters — green, silent, and defeating the very thing this test is named for.
+    expect(rowQuery().sql).toMatch(/AND\s+ci\.status = 'ACCEPTED'::"CollectionItemStatus"/);
+    // Asserted as text, not via the binds: `LIKE` -> `NOT LIKE` leaves the bound values identical,
+    // so the ordered bind check below cannot see it, and `lastRow` would silently become the newest
+    // CURATOR row instead. With `$queryRaw` mocked, the emitted SQL is the only observable there is.
+    expect(rowQuery().sql).toMatch(/AND\s+ci\.note LIKE /);
   });
 
   it('derives the threshold from the configured interval rather than a constant', async () => {
@@ -182,7 +189,10 @@ describe('auto-feature-health-check reads state the producer does not have to be
     // Derived from the schema rather than written as 13: the fallback claims to match the cadence
     // the job would itself have run at, and asserting a literal here cannot see the schema default
     // moving out from under it — which is the only way that claim can become false.
-    const schemaDefault = autoFeatureSchema.parse({ collectionId: 1 }).intervalHours;
+    // Per-field, matching the 🔴 in `auto-feature.ts`: parsing the whole schema to read one default
+    // couples this assertion to all thirteen fields and reddens here, blaming the health check, the
+    // moment any of them gains a requirement.
+    const schemaDefault = autoFeatureSchema.shape.intervalHours.parse(undefined);
     expect(result).toMatchObject({ healthy: false, staleAfterHours: schemaDefault * 2 + 1 });
   });
 });
@@ -278,6 +288,12 @@ describe('auto-feature-health-check alerting', () => {
     // keeps running, or stays noisy while the producer is off — and every other assertion in this
     // file passes either way, because the mock ignores its argument.
     expect(mocks.isFlipt).toHaveBeenCalledWith('auto-feature-images');
+
+    // One side only is not enough — the same asymmetry the KeyValue-key test above closes. Gate the
+    // PRODUCER on a different flag and this check goes silent while the job keeps running, or stays
+    // noisy while it is off, with every assertion in this file still green.
+    const producer = readFileSync(resolve(__dirname, '../auto-feature-images.ts'), 'utf-8');
+    expect(producer).toMatch(/isFlipt\(\s*FLIPT_FEATURE_FLAGS\.AUTO_FEATURE_IMAGES\s*\)/);
   });
 
   it('sends the page to the webhook, with the failure in the body', async () => {
@@ -409,7 +425,10 @@ describe('auto-feature-health-check heartbeat parsing', () => {
 });
 
 describe('evaluateAutoFeatureHealth boundary', () => {
-  const base = { staleAfterHours: 13, dryRun: false, collectionId: 107 };
+  // `rowsReadable` is required by AutoFeatureHealth and was missing — nothing catches that, because
+  // tsconfig excludes `__tests__`. Its absence made the record branch unreachable here, so `record`
+  // severity had no boundary test at all.
+  const base = { staleAfterHours: 13, dryRun: false, collectionId: 107, rowsReadable: true };
 
   it('is quiet at the threshold and fires one hour past it', () => {
     const at = evaluateAutoFeatureHealth(
@@ -423,5 +442,22 @@ describe('evaluateAutoFeatureHealth boundary', () => {
 
     expect(at).toHaveLength(0);
     expect(past.map((a) => a.severity)).toEqual(['page']);
+  });
+
+  it('records, and does not page, when only the rows are stale', () => {
+    // The record branch has its own boundary and nothing exercised it: the fixture used to omit
+    // `rowsReadable`, so this arm was unreachable and `record` severity was covered only by the
+    // coarse 40h case elsewhere.
+    const at = evaluateAutoFeatureHealth(
+      { ...base, lastRun: hoursBefore(1), lastRow: hoursBefore(13) },
+      NOW
+    );
+    const past = evaluateAutoFeatureHealth(
+      { ...base, lastRun: hoursBefore(1), lastRow: hoursBefore(14) },
+      NOW
+    );
+
+    expect(at).toHaveLength(0);
+    expect(past.map((a) => a.severity)).toEqual(['record']);
   });
 });

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -120,8 +120,8 @@ describe('auto-feature-health-check reads state the producer does not have to be
     // with itself: point `auto-feature-images` at a different key and every suite here stays green
     // while the check reads a row nothing writes and pages forever.
     //
-    // Every other getJobDate caller in the repo uses a bare name with no `job:` prefix, so this key
-    // is the odd one out and normalising it is the plausible edit. Both sides are read from source
+    // No other getJobDate caller uses a `job:` prefix, so this key is the odd one out and
+    // normalising it is the plausible edit. Both sides are read from source
     // here because the producer has no suite of its own to assert it in.
     const producer = readFileSync(resolve(__dirname, '../auto-feature-images.ts'), 'utf-8');
     // First identifier only. `getJobDate(key, defaultValue?)` takes a second optional argument, so

--- a/src/server/jobs/__tests__/auto-feature-health-check.test.ts
+++ b/src/server/jobs/__tests__/auto-feature-health-check.test.ts
@@ -74,6 +74,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal('fetch', mocks.fetch);
   mocks.isFlipt.mockResolvedValue(true);
+  // Restored, not just cleared. `vi.clearAllMocks()` drops call records but keeps implementations,
+  // so a test that stubs a 404 leaks it into every test after it in this file and the suite goes
+  // green by ordering accident.
+  mocks.fetch.mockResolvedValue(new Response(null, { status: 204 }));
   // Declared rather than replacing the whole module: `~/env/server` exports one `env` object of
   // ~200 keys, so a full replacement gives `undefined` for anything the graph later reads, which
   // is silently wrong rather than a loud missing-export error.
@@ -291,9 +295,14 @@ describe('auto-feature-health-check alerting', () => {
     expect(mocks.fetch).not.toHaveBeenCalled();
     // The finding still has to survive to Axiom; only its delivery is missing.
     expect(result).toMatchObject({ healthy: false, alerts: 1, paged: 0 });
+    // An environment with no webhook is not a broken alarm. Reporting it as a delivery failure
+    // would fire this warning on every unhealthy run in dev and preview, which trains whoever
+    // eventually sees the real one to ignore it.
+    expect(axiom('warning').some((a) => a.message?.includes('Discord rejected'))).toBe(false);
+    expect(axiom('info').some((a) => a.message?.includes('No DISCORD_WEBHOOK'))).toBe(true);
   });
 
-  it('reports paged: 0 when the webhook rejects the page', async () => {
+  it('reports paged: 0 and warns when the webhook rejects the page', async () => {
     stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
     mocks.fetch.mockResolvedValue(new Response(null, { status: 404 }));
 
@@ -302,7 +311,21 @@ describe('auto-feature-health-check alerting', () => {
     // A revoked webhook must not leave the job claiming it alerted someone. This job exists to make
     // a silent failure visible; it must not have one of its own.
     expect(result).toMatchObject({ healthy: false, alerts: 1, paged: 0 });
-    expect(axiom('warning').some((a) => a.message?.includes('reached nobody'))).toBe(true);
+    expect(axiom('warning').some((a) => a.message?.includes('Discord rejected'))).toBe(true);
+  });
+
+  it('still delivers a page after an earlier test stubbed a rejection', async () => {
+    stateIs({ lastRun: hoursBefore(79), lastRow: hoursBefore(79) });
+
+    const result = await autoFeatureHealthCheckJob.run();
+
+    // Ordering guard, and it is the only thing making the fetch restore in `beforeEach` do any
+    // work. `vi.clearAllMocks()` keeps implementations, so the 404 stubbed above would otherwise
+    // leak into every later test in this file — leaving the suite green because nothing after it
+    // happens to need a successful POST. Whoever removes that restore should fail HERE, not in a
+    // test they add months later that appears to break the code it is testing.
+    expect(result).toMatchObject({ healthy: false, paged: 1 });
+    expect(axiom('warning').some((a) => a.message?.includes('Discord rejected'))).toBe(false);
   });
 
   it('does not blame the caps when the attribution account is missing', async () => {

--- a/src/server/jobs/auto-feature-health-check.ts
+++ b/src/server/jobs/auto-feature-health-check.ts
@@ -17,7 +17,18 @@
  * heartbeat over a stale output means it runs and picks nothing — legitimate when the caps are
  * doing their job, so that one is recorded rather than paged.
  *
- * Two limits worth knowing before tuning anything here:
+ * 🔴 **To verify this, do NOT turn off the `AUTO_FEATURE_IMAGES` flag.** That is the obvious reading
+ * of "suppress the job and observe the alert", and it produces no alert BY DESIGN — the flag gate
+ * below returns before anything is evaluated, and the Axiom "Skipped" line it leaves reads like a
+ * pass. What works, and what was used:
+ *
+ *   1. note the current value of `KeyValue['job:auto-feature-images']`
+ *   2. set it back a day
+ *   3. `GET /api/webhooks/run-jobs/auto-feature-health-check?token=$WEBHOOK_TOKEN` — the endpoint
+ *      selects one job by name, so this runs the check alone and immediately
+ *   4. observe the Discord page, then restore the value
+ *
+ * Three limits worth knowing before tuning anything here:
  *
  * - **The threshold's margin collapses at the bottom of the config's range.** The producer stamps
  *   its heartbeat during a run, so the next hourly wake is always fractionally short of the gate
@@ -25,24 +36,33 @@
  *   `2 * intervalHours + 1`. That leaves `intervalHours` hours of slack — six missed wakes at
  *   today's 6, but only one at the schema's minimum of 1. At the maximum of 168 the threshold is
  *   14 days, which would not have caught the 79-hour August outage at all.
- * - **This shares a control plane with the job it watches.** `isFlipt` returns false when Flipt is
- *   unreachable, so a Flipt outage stops the producer and silences this check in the same instant.
- *   The flag-off path logs the heartbeat age precisely so that case leaves a trace to search for.
+ * - **This shares two control planes with the job it watches.** `isFlipt` returns false when Flipt
+ *   is unreachable, so a Flipt outage stops the producer and silences this check in the same
+ *   instant; the flag-off path logs the heartbeat age so that case leaves a trace. More likely, it
+ *   rides the same scheduler and the same `run-jobs` endpoint, so a failure in *that* layer takes
+ *   both down together. For the August outage specifically that was not the cause — other crons
+ *   logged continuously through all 79 hours — but nothing here would catch a scheduler-wide stop.
+ * - **`job_duration_seconds_count` already detects half of this.** It increments on every
+ *   invocation and `seedJobMetrics` makes an absent series distinguishable from an idle one, so
+ *   `rate(...[6h]) == 0` catches a job that stopped executing with no code at all. It is not enough
+ *   on its own: it counts the `flag-off` and `interval-not-elapsed` early returns, so it cannot see
+ *   a job that runs but never scores, nor one that scores but writes nothing. This repo also cannot
+ *   ship a Prometheus alert rule — see `clickhouse-refresh-monitor.ts`, which hit the same wall and
+ *   wrote its PromQL in a comment.
  */
 
-import { env } from '~/env/server';
 import {
+  AUTO_FEATURE_DEFAULT_INTERVAL_HOURS,
   AUTO_FEATURE_JOB_DATE_KEY,
   AUTO_FEATURE_NOTE_PREFIX,
+  getAutoFeatureBlockConfig,
   getAutoFeatureUserId,
 } from '~/server/common/auto-feature';
+import { notifyModAlert } from '~/server/common/mod-alert';
 import { dbRead } from '~/server/db/client';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { createJob } from '~/server/jobs/job';
 import { logToAxiom } from '~/server/logging/client';
-import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
-import { autoFeatureSchema } from '~/server/schema/home-block.schema';
-import { HomeBlockType } from '~/shared/utils/prisma/enums';
 import { createLogger } from '~/utils/logging';
 
 const log = createLogger('jobs:auto-feature-health-check', 'yellow');
@@ -58,40 +78,30 @@ const log = createLogger('jobs:auto-feature-health-check', 'yellow');
 const STALE_INTERVALS = 2;
 const WAKE_SLACK_HOURS = 1;
 
-/**
- * Used only when the home block's config cannot be read. Matches `autoFeatureSchema`'s own default
- * so a missing config produces the threshold the job would itself have run at — a config that has
- * gone missing is a fault the producer cannot report while it is not running, and refusing to check
- * without one would blind this job to precisely that.
- */
-const DEFAULT_INTERVAL_HOURS = 6;
-
 type AutoFeatureHealth = {
   lastRow: Date | null;
   lastRun: Date | null;
+  /**
+   * Whether `lastRow` is an answer about the job's output at all. False when there is no config or
+   * no attribution account, where a null `lastRow` means "could not look" rather than "wrote
+   * nothing" — a distinction the record alert would otherwise blame the caps for.
+   */
+  rowsReadable: boolean;
   staleAfterHours: number;
   dryRun: boolean;
   collectionId: number | null;
 };
 
-async function readAutoFeatureConfig() {
-  const block = await dbRead.homeBlock.findFirst({
-    where: { userId: -1, type: HomeBlockType.FeaturedCollections },
-    select: { metadata: true },
-    orderBy: { id: 'asc' },
-  });
-  const metadata = (block?.metadata || {}) as HomeBlockMetaSchema;
-  const parsed = autoFeatureSchema.safeParse(metadata.featuredCollections?.autoFeature);
-  return parsed.success ? parsed.data : null;
-}
-
 async function readLastRun() {
   const row = await dbRead.keyValue.findUnique({ where: { key: AUTO_FEATURE_JOB_DATE_KEY } });
   if (!row) return null;
-  const ms = Number(row.value);
-  // `KeyValue.value` is untyped Json. A row holding anything but a millisecond number is not a
-  // timestamp this job can reason about, and treating it as epoch 0 would page forever.
-  return Number.isFinite(ms) && ms > 0 ? new Date(ms) : null;
+  // `KeyValue.value` is untyped Json and other keys in the table hold arrays and strings. The
+  // `typeof` test is load-bearing rather than defensive: `Number(['1'])` is `1`, so a coercion
+  // alone turns a one-element array into a plausible 1970 timestamp instead of rejecting it.
+  // `getJobDate` only ever writes `date.getTime()`, so anything that is not a number is not a
+  // heartbeat this job can reason about.
+  const ms = row.value;
+  return typeof ms === 'number' && Number.isFinite(ms) && ms > 0 ? new Date(ms) : null;
 }
 
 /**
@@ -119,21 +129,25 @@ async function readLastRow(collectionId: number, autoFeatureUserId: number) {
 }
 
 export async function readAutoFeatureHealth(): Promise<AutoFeatureHealth> {
-  const config = await readAutoFeatureConfig();
-  const intervalHours = config?.intervalHours ?? DEFAULT_INTERVAL_HOURS;
+  const resolved = await getAutoFeatureBlockConfig();
+  const config = resolved?.config ?? null;
+  const intervalHours = config?.intervalHours ?? AUTO_FEATURE_DEFAULT_INTERVAL_HOURS;
   const collectionId = config?.collectionId ?? null;
 
   const autoFeatureUserId = collectionId === null ? null : await getAutoFeatureUserId();
+  // Only meaningful when there is a collection to look in AND an account to attribute rows to.
+  // Without both, `lastRow` would be null for a reason that has nothing to do with the job's
+  // output, and a null read as "wrote nothing" names a cause that is not the one.
+  const canReadRows = collectionId !== null && autoFeatureUserId !== null;
   const [lastRun, lastRow] = await Promise.all([
     readLastRun(),
-    collectionId !== null && autoFeatureUserId !== null
-      ? readLastRow(collectionId, autoFeatureUserId)
-      : Promise.resolve(null),
+    canReadRows ? readLastRow(collectionId, autoFeatureUserId) : Promise.resolve(null),
   ]);
 
   return {
     lastRow,
     lastRun,
+    rowsReadable: canReadRows,
     staleAfterHours: intervalHours * STALE_INTERVALS + WAKE_SLACK_HOURS,
     dryRun: config?.dryRun ?? true,
     collectionId,
@@ -179,7 +193,12 @@ export function evaluateAutoFeatureHealth(
   // would be one outage described twice, and the second line names a cause that is not the one.
   const rowAge = hoursSince(health.lastRow, now);
   const heartbeatHealthy = runAge !== null && runAge <= staleAfterHours;
-  if (heartbeatHealthy && !health.dryRun && (rowAge === null || rowAge > staleAfterHours)) {
+  if (
+    heartbeatHealthy &&
+    health.rowsReadable &&
+    !health.dryRun &&
+    (rowAge === null || rowAge > staleAfterHours)
+  ) {
     alerts.push({
       severity: 'record',
       message:
@@ -192,18 +211,6 @@ export function evaluateAutoFeatureHealth(
   }
 
   return alerts;
-}
-
-async function alertDiscord(title: string, description: string) {
-  if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return;
-
-  await fetch(env.DISCORD_WEBHOOK_MOD_ALERTS, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      embeds: [{ title, description, color: 0xf44336, timestamp: new Date().toISOString() }],
-    }),
-  }).catch(() => null);
 }
 
 export async function checkAutoFeatureHealth() {
@@ -249,13 +256,29 @@ export async function checkAutoFeatureHealth() {
   }).catch(() => null);
 
   const paging = alerts.filter((a) => a.severity === 'page');
-  if (paging.length)
-    await alertDiscord(
+  // `paged` reports what LANDED, not what was attempted. A revoked or rotated webhook otherwise
+  // leaves this job returning `paged: 1` forever while nobody is being told — the outage detector
+  // having its own silent outage, which is the exact failure the job exists to make visible.
+  const delivered =
+    paging.length > 0 &&
+    (await notifyModAlert(
       `🚨 Auto-feature pipeline — ${paging.length} check(s) failing`,
       paging.map((a) => a.message).join('\n\n')
-    );
+    ));
 
-  return { healthy: false as const, alerts: alerts.length, paged: paging.length, ...details };
+  if (paging.length > 0 && !delivered)
+    await logToAxiom({
+      type: 'warning',
+      name: 'auto-feature-health-check',
+      message: 'Discord alert did not land — the page above reached nobody',
+    }).catch(() => null);
+
+  return {
+    healthy: false as const,
+    alerts: alerts.length,
+    paged: delivered ? paging.length : 0,
+    ...details,
+  };
 }
 
 /**

--- a/src/server/jobs/auto-feature-health-check.ts
+++ b/src/server/jobs/auto-feature-health-check.ts
@@ -1,0 +1,242 @@
+/**
+ * Alerts when the auto-feature job has silently stopped topping up the Featured Images collection.
+ *
+ * `auto-feature-images` logs a `job-summary` on every run, including a zero-pick one. That covers a
+ * run that came up short; it cannot cover a run that never happened. During the 79-hour silence
+ * ending 17 Aug 2026 nothing was emitted from anywhere, because nothing executed — and a job that
+ * never starts produces exactly the evidence a healthy quiet system produces.
+ *
+ * So this reads state the producer leaves behind rather than instrumenting the producer:
+ *
+ * - **`lastRow`** — the newest row the job wrote into its target collection. Its output.
+ * - **`lastRun`** — the `KeyValue` row `getJobDate` advances. Its heartbeat.
+ *
+ * Both are plain table reads, answerable with the job dead, which is the whole point. They fail
+ * differently and are reported differently: a stale heartbeat means the job is not executing (or is
+ * bailing before it scores, which `setLastRun` deliberately does not count as a run), while a fresh
+ * heartbeat over a stale output means it runs and picks nothing — legitimate when the caps are
+ * doing their job, so that one is recorded rather than paged.
+ */
+
+import { env } from '~/env/server';
+import {
+  AUTO_FEATURE_JOB_DATE_KEY,
+  AUTO_FEATURE_NOTE_PREFIX,
+  getAutoFeatureUserId,
+} from '~/server/common/auto-feature';
+import { dbRead } from '~/server/db/client';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
+import { createJob } from '~/server/jobs/job';
+import { logToAxiom } from '~/server/logging/client';
+import type { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
+import { autoFeatureSchema } from '~/server/schema/home-block.schema';
+import { HomeBlockType } from '~/shared/utils/prisma/enums';
+import { createLogger } from '~/utils/logging';
+
+const log = createLogger('jobs:auto-feature-health-check', 'yellow');
+
+/**
+ * How many configured intervals may pass before silence counts as a fault.
+ *
+ * The producer wakes hourly and fires on `intervalHours`, so a legitimate gap is up to one wake
+ * longer than the interval itself — measured at 6-7h in production against a 6h setting. Two
+ * intervals plus that wake is 13h at today's config: clear of the real spacing, and it catches a
+ * repeat of the 79-hour August outage inside its first day.
+ */
+const STALE_INTERVALS = 2;
+const WAKE_SLACK_HOURS = 1;
+
+/**
+ * Used only when the home block's config cannot be read. Matches `autoFeatureSchema`'s own default
+ * so a missing config produces the threshold the job would itself have run at — a config that has
+ * gone missing is a fault the producer cannot report while it is not running, and refusing to check
+ * without one would blind this job to precisely that.
+ */
+const DEFAULT_INTERVAL_HOURS = 6;
+
+type AutoFeatureHealth = {
+  lastRow: Date | null;
+  lastRun: Date | null;
+  staleAfterHours: number;
+  dryRun: boolean;
+  collectionId: number | null;
+};
+
+async function readAutoFeatureConfig() {
+  const block = await dbRead.homeBlock.findFirst({
+    where: { userId: -1, type: HomeBlockType.FeaturedCollections },
+    select: { metadata: true },
+    orderBy: { id: 'asc' },
+  });
+  const metadata = (block?.metadata || {}) as HomeBlockMetaSchema;
+  const parsed = autoFeatureSchema.safeParse(metadata.featuredCollections?.autoFeature);
+  return parsed.success ? parsed.data : null;
+}
+
+async function readLastRun() {
+  const row = await dbRead.keyValue.findUnique({ where: { key: AUTO_FEATURE_JOB_DATE_KEY } });
+  if (!row) return null;
+  const ms = Number(row.value);
+  // `KeyValue.value` is untyped Json. A row holding anything but a millisecond number is not a
+  // timestamp this job can reason about, and treating it as epoch 0 would page forever.
+  return Number.isFinite(ms) && ms > 0 ? new Date(ms) : null;
+}
+
+/**
+ * `COALESCE(reviewedAt, createdAt)` because that is the timestamp the producer itself treats as
+ * when a row landed. Taking `max` of the two columns separately is not the same value, and the two
+ * only agree while `reviewedAt` happens to be null.
+ */
+async function readLastRow(collectionId: number, autoFeatureUserId: number) {
+  const [row] = await dbRead.$queryRaw<{ lastRow: Date | null }[]>`
+    SELECT max(COALESCE(ci."reviewedAt", ci."createdAt")) AS "lastRow"
+    FROM "CollectionItem" ci
+    WHERE ci."collectionId" = ${collectionId}
+      AND ci."addedById" = ${autoFeatureUserId}
+      AND ci.note LIKE ${`${AUTO_FEATURE_NOTE_PREFIX}:%`}
+  `;
+  return row?.lastRow ?? null;
+}
+
+export async function readAutoFeatureHealth(): Promise<AutoFeatureHealth> {
+  const config = await readAutoFeatureConfig();
+  const intervalHours = config?.intervalHours ?? DEFAULT_INTERVAL_HOURS;
+  const collectionId = config?.collectionId ?? null;
+
+  const autoFeatureUserId = collectionId === null ? null : await getAutoFeatureUserId();
+  const [lastRun, lastRow] = await Promise.all([
+    readLastRun(),
+    collectionId !== null && autoFeatureUserId !== null
+      ? readLastRow(collectionId, autoFeatureUserId)
+      : Promise.resolve(null),
+  ]);
+
+  return {
+    lastRow,
+    lastRun,
+    staleAfterHours: intervalHours * STALE_INTERVALS + WAKE_SLACK_HOURS,
+    dryRun: config?.dryRun ?? true,
+    collectionId,
+  };
+}
+
+const hoursSince = (date: Date | null, now: Date) =>
+  date === null ? null : (now.getTime() - date.getTime()) / 3_600_000;
+
+const describeAge = (date: Date | null, now: Date) => {
+  const hours = hoursSince(date, now);
+  return hours === null ? 'never' : `${date!.toISOString()} (${hours.toFixed(1)}h ago)`;
+};
+
+export type AutoFeatureAlert = { severity: 'page' | 'record'; message: string };
+
+/**
+ * A missing timestamp is stale, not unknown. "The job has never run" and "the job last ran in
+ * March" are the same outage from the homepage's side, and treating null as inconclusive is how a
+ * check that cannot fire gets written.
+ */
+export function evaluateAutoFeatureHealth(
+  health: AutoFeatureHealth,
+  now: Date
+): AutoFeatureAlert[] {
+  const alerts: AutoFeatureAlert[] = [];
+  const { staleAfterHours } = health;
+
+  const runAge = hoursSince(health.lastRun, now);
+  if (runAge === null || runAge > staleAfterHours) {
+    alerts.push({
+      severity: 'page',
+      message:
+        `**Not running** — \`auto-feature-images\` has not completed a scoring run in ${staleAfterHours}h. ` +
+        `Last run: ${describeAge(health.lastRun, now)}. ` +
+        `The job either is not executing or is bailing before it scores; check its \`job-misconfigured\` events.`,
+    });
+  }
+
+  // Only meaningful once the heartbeat says the job is alive. Reporting both when the job is dead
+  // would be one outage described twice, and the second line names a cause that is not the one.
+  const rowAge = hoursSince(health.lastRow, now);
+  const heartbeatHealthy = runAge !== null && runAge <= staleAfterHours;
+  if (heartbeatHealthy && !health.dryRun && (rowAge === null || rowAge > staleAfterHours)) {
+    alerts.push({
+      severity: 'record',
+      message:
+        `**Running but not writing** — no auto-featured row in collection ${
+          health.collectionId ?? 'unknown'
+        } for ${staleAfterHours}h ` +
+        `while the job is still running. Last row: ${describeAge(health.lastRow, now)}. ` +
+        `Expected when the per-creator or per-collection caps refuse everything; a fault if candidates have dried up.`,
+    });
+  }
+
+  return alerts;
+}
+
+async function alertDiscord(title: string, description: string) {
+  if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return;
+
+  await fetch(env.DISCORD_WEBHOOK_MOD_ALERTS, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      embeds: [{ title, description, color: 0xf44336, timestamp: new Date().toISOString() }],
+    }),
+  }).catch(() => null);
+}
+
+export async function checkAutoFeatureHealth() {
+  // The flag being off makes the producer return before it touches anything, by design, so its
+  // silence is then expected rather than a fault. Still recorded: it is the likeliest explanation
+  // for a homepage that has stopped changing, and the person looking should be able to find it.
+  if (!(await isFlipt(FLIPT_FEATURE_FLAGS.AUTO_FEATURE_IMAGES))) {
+    log('Auto-feature flag off, skipping health check');
+    await logToAxiom({
+      type: 'info',
+      name: 'auto-feature-health-check',
+      message: 'Skipped: AUTO_FEATURE_IMAGES is off',
+    }).catch(() => null);
+    return { skipped: true as const };
+  }
+
+  const health = await readAutoFeatureHealth();
+  const alerts = evaluateAutoFeatureHealth(health, new Date());
+
+  const details = {
+    lastRun: health.lastRun?.toISOString() ?? null,
+    lastRow: health.lastRow?.toISOString() ?? null,
+    staleAfterHours: health.staleAfterHours,
+    dryRun: health.dryRun,
+    collectionId: health.collectionId,
+  };
+
+  if (alerts.length === 0) {
+    log('Auto-feature pipeline healthy');
+    return { healthy: true as const, ...details };
+  }
+
+  await logToAxiom({
+    type: alerts.some((a) => a.severity === 'page') ? 'warning' : 'info',
+    name: 'auto-feature-health-check',
+    details,
+    message: alerts.map((a) => a.message).join(' | '),
+  }).catch(() => null);
+
+  const paging = alerts.filter((a) => a.severity === 'page');
+  if (paging.length)
+    await alertDiscord(
+      `🚨 Auto-feature pipeline — ${paging.length} check(s) failing`,
+      paging.map((a) => a.message).join('\n\n')
+    );
+
+  return { healthy: false as const, alerts: alerts.length, paged: paging.length, ...details };
+}
+
+/**
+ * Every 3 hours: half the shortest cadence the config permits at today's setting, so a threshold
+ * crossing is noticed within one interval of it happening rather than a day later.
+ */
+export const autoFeatureHealthCheckJob = createJob(
+  'auto-feature-health-check',
+  '40 */3 * * *',
+  checkAutoFeatureHealth
+);

--- a/src/server/jobs/auto-feature-health-check.ts
+++ b/src/server/jobs/auto-feature-health-check.ts
@@ -20,7 +20,7 @@
  * 🔴 **To verify this, do NOT turn off the `AUTO_FEATURE_IMAGES` flag.** That is the obvious reading
  * of "suppress the job and observe the alert", and it produces no alert BY DESIGN — the flag gate
  * below returns before anything is evaluated, and the Axiom "Skipped" line it leaves reads like a
- * pass. What works, and what was used:
+ * pass. What works, and what is still OWED — this has not been run:
  *
  *   1. note the current value of `KeyValue['job:auto-feature-images']`
  *   2. set it back a day
@@ -42,6 +42,9 @@
  *   rides the same scheduler and the same `run-jobs` endpoint, so a failure in *that* layer takes
  *   both down together. For the August outage specifically that was not the cause — other crons
  *   logged continuously through all 79 hours — but nothing here would catch a scheduler-wide stop.
+ * - **The row half is inert whenever `dryRun` is on.** A dry run writes nothing and still advances
+ *   the heartbeat, so the record alert is suppressed by design; only the page remains. Prod runs
+ *   `dryRun: false`, so both halves are live there today.
  * - **`job_duration_seconds_count` already detects half of this.** It increments on every
  *   invocation and `seedJobMetrics` makes an absent series distinguishable from an idle one, so
  *   `rate(...[6h]) == 0` catches a job that stopped executing with no code at all. It is not enough
@@ -115,6 +118,13 @@ async function readLastRun() {
  * which is exactly what someone does while the pipeline is dry, would push `lastRow` to the present
  * and silence the check indefinitely. One such tombstone already exists in the target collection.
  * `buildWindowCountsQuery` filters the same way for the same reason.
+ *
+ * ⚠️ The `addedById` + `note LIKE` pair restates `isAutoFeaturedRow` in SQL, which the producer
+ * deliberately refuses to do — `buildWindowCountsQuery` classifies in JS through that helper
+ * precisely because expressing the predicate twice lets the two drift silently. This is the
+ * exception, taken because `max()` over an unbounded collection belongs in SQL. `isAutoFeaturedRow`
+ * remains the canonical definition: a change to what counts as auto-featured has to be made here
+ * too, and nothing enforces that.
  */
 async function readLastRow(collectionId: number, autoFeatureUserId: number) {
   const [row] = await dbRead.$queryRaw<{ lastRow: Date | null }[]>`

--- a/src/server/jobs/auto-feature-health-check.ts
+++ b/src/server/jobs/auto-feature-health-check.ts
@@ -46,9 +46,9 @@
  *   invocation and `seedJobMetrics` makes an absent series distinguishable from an idle one, so
  *   `rate(...[6h]) == 0` catches a job that stopped executing with no code at all. It is not enough
  *   on its own: it counts the `flag-off` and `interval-not-elapsed` early returns, so it cannot see
- *   a job that runs but never scores, nor one that scores but writes nothing. This repo also cannot
- *   ship a Prometheus alert rule — see `clickhouse-refresh-monitor.ts`, which hit the same wall and
- *   wrote its PromQL in a comment.
+ *   a job that runs but never scores, nor one that scores but writes nothing. A Prometheus rule for
+ *   the half it does cover belongs in the infra repo rather than here, the way
+ *   `clickhouse-refresh-monitor.ts` records its own — that route is open, not closed.
  */
 
 import {
@@ -259,24 +259,33 @@ export async function checkAutoFeatureHealth() {
   // `paged` reports what LANDED, not what was attempted. A revoked or rotated webhook otherwise
   // leaves this job returning `paged: 1` forever while nobody is being told — the outage detector
   // having its own silent outage, which is the exact failure the job exists to make visible.
-  const delivered =
-    paging.length > 0 &&
-    (await notifyModAlert(
-      `🚨 Auto-feature pipeline — ${paging.length} check(s) failing`,
-      paging.map((a) => a.message).join('\n\n')
-    ));
+  const outcome = paging.length
+    ? await notifyModAlert(
+        `🚨 Auto-feature pipeline — ${paging.length} check(s) failing`,
+        paging.map((a) => a.message).join('\n\n')
+      )
+    : null;
 
-  if (paging.length > 0 && !delivered)
+  // `rejected` and `unconfigured` are kept apart because only the first is a fault. An environment
+  // with no webhook is not a broken alarm, and collapsing the two would fire this warning on every
+  // unhealthy run in dev and preview — training whoever eventually sees the real one to ignore it.
+  if (outcome === 'rejected')
     await logToAxiom({
       type: 'warning',
       name: 'auto-feature-health-check',
-      message: 'Discord alert did not land — the page above reached nobody',
+      message: 'Discord rejected the page — the finding above reached nobody',
+    }).catch(() => null);
+  else if (outcome === 'unconfigured')
+    await logToAxiom({
+      type: 'info',
+      name: 'auto-feature-health-check',
+      message: 'No DISCORD_WEBHOOK_MOD_ALERTS configured — the finding above was recorded only',
     }).catch(() => null);
 
   return {
     healthy: false as const,
     alerts: alerts.length,
-    paged: delivered ? paging.length : 0,
+    paged: outcome === 'delivered' ? paging.length : 0,
     ...details,
   };
 }

--- a/src/server/jobs/auto-feature-health-check.ts
+++ b/src/server/jobs/auto-feature-health-check.ts
@@ -16,6 +16,18 @@
  * bailing before it scores, which `setLastRun` deliberately does not count as a run), while a fresh
  * heartbeat over a stale output means it runs and picks nothing — legitimate when the caps are
  * doing their job, so that one is recorded rather than paged.
+ *
+ * Two limits worth knowing before tuning anything here:
+ *
+ * - **The threshold's margin collapses at the bottom of the config's range.** The producer stamps
+ *   its heartbeat during a run, so the next hourly wake is always fractionally short of the gate
+ *   and gets skipped: real spacing is `intervalHours + 1`, against a threshold of
+ *   `2 * intervalHours + 1`. That leaves `intervalHours` hours of slack — six missed wakes at
+ *   today's 6, but only one at the schema's minimum of 1. At the maximum of 168 the threshold is
+ *   14 days, which would not have caught the 79-hour August outage at all.
+ * - **This shares a control plane with the job it watches.** `isFlipt` returns false when Flipt is
+ *   unreachable, so a Flipt outage stops the producer and silences this check in the same instant.
+ *   The flag-off path logs the heartbeat age precisely so that case leaves a trace to search for.
  */
 
 import { env } from '~/env/server';
@@ -86,6 +98,13 @@ async function readLastRun() {
  * `COALESCE(reviewedAt, createdAt)` because that is the timestamp the producer itself treats as
  * when a row landed. Taking `max` of the two columns separately is not the same value, and the two
  * only agree while `reviewedAt` happens to be null.
+ *
+ * 🔴 `status = 'ACCEPTED'` is what makes that safe. Removing an auto-featured image tombstones the
+ * row rather than deleting it — `status` goes REJECTED and `reviewedAt` is stamped `now()`, while
+ * `addedById` and the note survive. Without this clause a moderator clearing out stale features,
+ * which is exactly what someone does while the pipeline is dry, would push `lastRow` to the present
+ * and silence the check indefinitely. One such tombstone already exists in the target collection.
+ * `buildWindowCountsQuery` filters the same way for the same reason.
  */
 async function readLastRow(collectionId: number, autoFeatureUserId: number) {
   const [row] = await dbRead.$queryRaw<{ lastRow: Date | null }[]>`
@@ -93,6 +112,7 @@ async function readLastRow(collectionId: number, autoFeatureUserId: number) {
     FROM "CollectionItem" ci
     WHERE ci."collectionId" = ${collectionId}
       AND ci."addedById" = ${autoFeatureUserId}
+      AND ci.status = 'ACCEPTED'::"CollectionItemStatus"
       AND ci.note LIKE ${`${AUTO_FEATURE_NOTE_PREFIX}:%`}
   `;
   return row?.lastRow ?? null;
@@ -147,9 +167,11 @@ export function evaluateAutoFeatureHealth(
     alerts.push({
       severity: 'page',
       message:
-        `**Not running** — \`auto-feature-images\` has not completed a scoring run in ${staleAfterHours}h. ` +
+        `**No completed run** — \`auto-feature-images\` has not scored a run in ${staleAfterHours}h. ` +
         `Last run: ${describeAge(health.lastRun, now)}. ` +
-        `The job either is not executing or is bailing before it scores; check its \`job-misconfigured\` events.`,
+        `Either it is not executing, or it is executing and bailing first — most often \`no-eligible-collections\`, ` +
+        `where the whole featured pool has gone stale and the homepage block hides itself. ` +
+        `Its \`job-misconfigured\` events name which; an empty pool is fixed by curation, not by the job.`,
     });
   }
 
@@ -189,13 +211,18 @@ export async function checkAutoFeatureHealth() {
   // silence is then expected rather than a fault. Still recorded: it is the likeliest explanation
   // for a homepage that has stopped changing, and the person looking should be able to find it.
   if (!(await isFlipt(FLIPT_FEATURE_FLAGS.AUTO_FEATURE_IMAGES))) {
+    // `isFlipt` cannot tell "deliberately off" from "Flipt unreachable" — both are false. So the
+    // heartbeat goes out with it: a flag that reads off while the job last ran months ago is the
+    // shape of an outage in the control plane, and this line is the only trace of it.
+    const lastRun = await readLastRun().catch(() => null);
     log('Auto-feature flag off, skipping health check');
     await logToAxiom({
       type: 'info',
       name: 'auto-feature-health-check',
-      message: 'Skipped: AUTO_FEATURE_IMAGES is off',
+      message: 'Skipped: AUTO_FEATURE_IMAGES reads off (deliberately, or because Flipt is down)',
+      details: { lastRun: lastRun?.toISOString() ?? null },
     }).catch(() => null);
-    return { skipped: true as const };
+    return { skipped: true as const, lastRun: lastRun?.toISOString() ?? null };
   }
 
   const health = await readAutoFeatureHealth();

--- a/src/server/jobs/auto-feature-images.ts
+++ b/src/server/jobs/auto-feature-images.ts
@@ -1,3 +1,4 @@
+import { AUTO_FEATURE_JOB_DATE_KEY } from '~/server/common/auto-feature';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
 import { runAutoFeatureImages } from '~/server/services/auto-feature-images.service';
@@ -10,7 +11,7 @@ import { createJob, getJobDate } from './job';
 export const autoFeatureImages = createJob('auto-feature-images', '20 * * * *', async () => {
   if (!(await isFlipt(FLIPT_FEATURE_FLAGS.AUTO_FEATURE_IMAGES))) return { reason: 'flag-off' };
 
-  const [lastRun, setLastRun] = await getJobDate('job:auto-feature-images');
+  const [lastRun, setLastRun] = await getJobDate(AUTO_FEATURE_JOB_DATE_KEY);
   const result = await runAutoFeatureImages({ lastRun });
   // The flag being on is a statement of intent, so every bail below it is a fault rather than an
   // off switch — and each one is otherwise indistinguishable from the job working. A missing config
@@ -27,9 +28,8 @@ export const autoFeatureImages = createJob('auto-feature-images', '20 * * * *', 
   // run and a dead job must not produce the same evidence.
   //
   // ⚠️ It cannot detect the job not running at all — the 79-hour silence in August emitted nothing
-  // from anywhere, and nothing logged from inside a run ever will. That needs a separate health
-  // check against the collection's own state; filed as 868kz3ef5, with challenge-health-check.ts
-  // as the precedent.
+  // from anywhere, and nothing logged from inside a run ever will. `auto-feature-health-check.ts`
+  // covers that from outside, by reading this job's output rather than instrumenting it.
   if ('picked' in result)
     logToAxiom({
       type: 'job-summary',

--- a/src/server/jobs/challenge-health-check.ts
+++ b/src/server/jobs/challenge-health-check.ts
@@ -10,7 +10,7 @@
  * date that quietly failed inside a batch, or a job that was never invoked — and none of those raise.
  */
 
-import { env } from '~/env/server';
+import { notifyModAlert } from '~/server/common/mod-alert';
 import { dbRead } from '~/server/db/client';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { createJob } from '~/server/jobs/job';
@@ -67,18 +67,6 @@ async function readChallengeHealth() {
   return row;
 }
 
-async function alertDiscord(title: string, description: string) {
-  if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return;
-
-  await fetch(env.DISCORD_WEBHOOK_MOD_ALERTS, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      embeds: [{ title, description, color: 0xf44336, timestamp: new Date().toISOString() }],
-    }),
-  }).catch(() => null);
-}
-
 async function checkChallengeHealth() {
   // A disabled platform makes both producing jobs no-op by design, so paging on it is noise. It is
   // still the likeliest explanation for an empty schedule, so it goes to Axiom to be findable.
@@ -130,7 +118,7 @@ async function checkChallengeHealth() {
     message: failures.join(' | '),
   }).catch(() => null);
 
-  await alertDiscord(
+  await notifyModAlert(
     `🚨 Daily challenge pipeline — ${failures.length} check(s) failing`,
     failures.join('\n\n')
   );

--- a/src/server/jobs/clickhouse-refresh-monitor.ts
+++ b/src/server/jobs/clickhouse-refresh-monitor.ts
@@ -108,7 +108,7 @@ import { createJob } from './job';
  *
  *   (time() - max_over_time((max(monitor_last_run_timestamp_seconds != 0))[24h:1m])) > 900
  *
- * Both rules ship in talos-infra#1072 with promtool tests.
+ * Both rules ship from the infra repo, with promtool tests.
  */
 
 const HOUR = 3600;

--- a/src/server/services/auto-feature-images.service.ts
+++ b/src/server/services/auto-feature-images.service.ts
@@ -1,7 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
-import type { AutoFeatureSchema, HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
-import { autoFeatureSchema } from '~/server/schema/home-block.schema';
+import type { AutoFeatureSchema } from '~/server/schema/home-block.schema';
 import { homeBlockCacheBust } from '~/server/services/home-block-cache.service';
 import { getFeaturedCollectionsState } from '~/server/jobs/refresh-featured-collections-eligibility';
 import { CollectionItemStatus, HomeBlockType } from '~/shared/utils/prisma/enums';
@@ -10,6 +9,7 @@ import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constant
 import {
   AUTO_FEATURE_NOTE_PREFIX,
   autoFeatureNote,
+  getAutoFeatureBlockConfig,
   getAutoFeatureUserId,
   isAutoFeaturedRow,
 } from '~/server/common/auto-feature';
@@ -181,25 +181,6 @@ export function selectAutoFeaturePicks({
   return finish();
 }
 
-async function getAutoFeatureConfig() {
-  const block = await dbRead.homeBlock.findFirst({
-    where: { userId: -1, type: HomeBlockType.FeaturedCollections },
-    select: { id: true, metadata: true },
-    orderBy: { id: 'asc' },
-  });
-  if (!block) return null;
-  const metadata = (block.metadata || {}) as HomeBlockMetaSchema;
-  // Parsed rather than cast: hand-edited JSON, and every default the job relies on — perRun,
-  // the decay constants, dryRun — exists only if the schema fills it in.
-  const config = autoFeatureSchema.safeParse(metadata.featuredCollections?.autoFeature);
-  if (!config.success) return null;
-  return {
-    blockId: block.id,
-    config: config.data,
-    pool: metadata.featuredCollections?.collectionIds ?? [],
-  };
-}
-
 async function getEligibleCollectionIds(poolFallback: number[]) {
   const state = await getFeaturedCollectionsState();
   // A Redis miss means the eligibility job hasn't run yet. Bootstrapping from the full pool is
@@ -355,7 +336,7 @@ export async function runAutoFeatureImages({
   lastRun,
   dryRunOverride,
 }: { lastRun?: Date; dryRunOverride?: boolean } = {}) {
-  const resolved = await getAutoFeatureConfig();
+  const resolved = await getAutoFeatureBlockConfig();
   if (!resolved) return { reason: 'no-auto-feature-config' as const };
   const { config, pool } = resolved;
 


### PR DESCRIPTION
Closes the observability half of the featured-collections work: `868kz3ef5`.

## The gap

`auto-feature-images` logs a `job-summary` on every run, including a zero-pick one — added precisely because a stricter cap means the job can find nothing to pick. But that fires only from **inside** a run. During the 79-hour silence ending 17 Aug 2026, the only interruption in the job's history, it would have emitted nothing at all, because nothing executed.

A zero-pick run and a job that never ran produce identical evidence: silence.

## The shape

`challenge-health-check.ts` is the precedent — a separate job that queries output state rather than instrumenting the producer. Two signals, both plain table reads answerable with the producer dead:

- **`lastRow`** — newest row the job wrote into its target collection. Its output.
- **`lastRun`** — the `KeyValue` row `getJobDate` advances. Its heartbeat.

| State | Meaning | Action |
|---|---|---|
| heartbeat stale | not executing, or bailing before it scores | **pages Discord** |
| heartbeat fresh, output stale | runs and picks nothing — legitimate when the caps refuse everything | records to Axiom |

The split is Justin's call, not the author's. Threshold derives from the block's own `intervalHours`, so it tracks a cadence change without a deploy — **13h** at today's config, against a measured 6-7h real spacing.

## 🔴 How to verify this — NOT by turning off the flag

The ticket's closing condition says "suppress the job and observe the alert". The obvious suppression is turning off `AUTO_FEATURE_IMAGES`, and **that produces no alert by design**: the flag gate returns before anything is evaluated, and the Axiom "Skipped" line it leaves reads like a pass. Found by the intent lane; it would have left this ticket falsely closed.

What works:

1. note the current value of `KeyValue['job:auto-feature-images']`
2. set it back a day
3. `GET /api/webhooks/run-jobs/auto-feature-health-check?token=$WEBHOOK_TOKEN` — the endpoint selects one job by name, so this runs the check alone and immediately
4. observe the Discord page, then restore the value

**This has not been done yet.** The 26 tests and 25 mutation controls below establish that the logic is right and that a revert fails legibly; they are **not** an observation of the alert firing. That step is still owed after deploy, and the ticket does not close without it.

## Verified against production, and what that does not prove

Read-only replica. The job is currently alive: newest auto-featured row `2026-09-01 18:20:10 UTC`, heartbeat `18:20:09.901 UTC` — two independent signals agreeing to the second.

The clean reading is not a blind one: the same gap query over full history returns exactly one row, `2026-08-13 17:00 → 2026-08-17 00:00, 79.0 hours`.

⚠️ **That proves the query prints the outage. It does not prove the job would have run to ask it.** Different claims, and only the first is evidenced here.

`EXPLAIN ANALYZE` (perf lane, prod replica): warm 3.5 ms / 257 buffers, cold 6.6 ms. `CollectionItem` is 15 GB / 180M rows; this touches 257 buffers 8×/day. A `>= now() - interval` bound was measured and **rejected** — it lands as a Filter after the heap fetch, identical buffers and blocks, buying nothing while costing a correctness ambiguity.

## Review

Reviewed in four rounds across seven commits, not one. Five lanes at `1b09897909`, reuse + correctness at `247333d4db`, correctness at `b955dc476f`, five lanes again at `a4d9f9cbc5`, tests re-read at the head. Fixes are spread across commits three through seven.

🔴 **The most serious defect was found in the final round and would have surfaced on its own.** The suite read the real clock while pinning a literal `NOW`, so **5 of 25 tests were due to start failing at 2026-09-02T00:00:00Z** — hours after the last commit, in tests that look like they cover the code they would appear to indict. Fixed in `a4d9f9cbc5` by faking `Date` alone. Demonstrated both ways: shifting the pinned `NOW` two days fails 5 without the fix and passes 25 with it. Nothing in typecheck, lint or the suite could see it, because it passes right up until it does not.

- **Reuse** — `alertDiscord` was byte-identical across both health checks → `notifyModAlert`; the block-config lookup had four copies, two already disagreeing on `orderBy` → shared in the leaf module; the interval default is derived from the schema rather than restated.
- **Correctness** — a Discord failure was swallowed while the job returned `paged: 1`, so a revoked webhook would leave the outage detector claiming it alerted someone forever. `paged` now reports what landed. An unresolvable attribution account produced a null `lastRow` that read as "wrote nothing" and blamed the caps.
- **Tests** — nothing pinned *which* Flipt flag gates the check, nor the Discord payload; an empty embed or a POST to the wrong host passed a call-count assertion identically.
- **Perf** — no findings, and it refuted a mitigation the author had proposed.
- **Intent** — delivers the ticket, no scope creep; F1 above is its finding.

The round also produced a bug of its own, predicted by the test lane: `Number(['1'])` is `1`, and `KeyValue` really does hold arrays for other keys, so a one-element array slipped the heartbeat guard and became a 1970 date — while the comment above it claimed unparseable values became null.

## Tests

26 tests. 25 mutation controls. All but one fail with an assertion naming the wrong value rather than timing out — the exception is row 15 below, which is a *paired* control where the passing arm is the evidence:

| Mutation | Failure |
|---|---|
| threshold hardcoded | `expected 13 to be 49` |
| null heartbeat treated as inconclusive | `{ healthy: true }` vs `{ healthy: false, paged: 1 }` |
| drop the heartbeat-healthy guard | `alerts: 2` vs `alerts: 1` |
| `max(createdAt)` for `COALESCE` | SQL does not match `/COALESCE/` |
| dry pipeline pages instead of records | `paged: 1` vs `paged: 0` |
| drop the ACCEPTED filter | SQL does not match `/status = 'ACCEPTED'/` |
| producer's key diverges from consumer's | `expected undefined to be 'AUTO_FEATURE_JOB_DATE_KEY'` |
| drop the heartbeat `typeof` guard | `expected 2001-01-01T07:00:00.000Z to be null` |
| query binds swapped | `[9001, 9001, …]` vs `[107, 9001, …]` |
| gated on the wrong Flipt flag | `expected "vi.fn()" to be called with [ 'auto-feature-images' ]` |
| blank Discord description | `expected '' to contain 'No completed run'` |
| `paged` ignores delivery | `paged: 1` vs `paged: 0` |
| drop `rowsReadable` | `{ healthy: false }` vs `{ healthy: true }` |
| delete the webhook guard | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| schema default moves, code **derives** | passes — threshold follows |
| schema default moves, code **restates** | fails — the drift is caught |

The last two are a pair on purpose: substituting `6` for the derived default changes nothing *because the default is 6*, so the single-sided mutation was vacuous and had to be replaced.

## The last round, because it is the most instructive part

The terminating pass found that an assertion I had just written to fix vacuous assertions **was itself vacuous** — and it was invisible to reading.

The guard `not.toMatch(/OR/i)` reached the file through a shell heredoc that ate the escape, so the bytes were `/‹0x08›OR‹0x08›/i`: literal backspace characters where the word boundaries belong, matching nothing and passing forever. It renders as `` in every terminal. Typecheck, lint, prettier and a green suite all agreed it was fine. **The only thing in the chain that could see it was running the mutant rather than naming one** — the guard is now `new RegExp(String.raw`OR`, 'i')`, with `od -c` confirming a real backslash.

Two tautologies went with it. The flag assertion compared against the string this file's own `vi.mock` supplies, so renaming the real `FLIPT_FEATURE_FLAGS` value would have left it green while production went double-silent — producer stops on a flag Flipt does not know, health check reports `skipped`, nothing prints. And the producer-gate regex anchored on the closing paren, which the `getJobDate` regex 170 lines above documents as the thing to avoid.

The control set is four mutants where **three must fail and one must not**: giving the producer an `entityId` is behaviour-preserving and passes 26/26, which is what shows the fragility fix did not simply make the assertion stricter.

## Three limits, documented in the header rather than fixed

- **The threshold's margin collapses at the bottom of the config range.** Real spacing is `intervalHours + 1` against a threshold of `2 * intervalHours + 1`, so the slack is `intervalHours` — six missed wakes at today's 6, one at the schema minimum. At the maximum of 168 the threshold is 14 days, which would not have caught the August outage.
- **This shares two control planes with the job it watches.** `isFlipt` returns false for an unreachable Flipt. More likely, it rides the same scheduler and `run-jobs` endpoint. For August specifically that was not the cause — other crons logged continuously through all 79 hours — but nothing here catches a scheduler-wide stop. A dead-man's switch outside the cluster is infra work, not this PR.
- **`job_duration_seconds_count` already detects half of this** and would have caught the August silence with no code. It counts the `flag-off` and `interval-not-elapsed` early returns, so it cannot see a job that runs but never scores, nor one that scores but writes nothing — and a Prometheus rule for the half it does cover belongs in the infra repo rather than here — that route is open, not closed, as `clickhouse-refresh-monitor.ts` records for its own rules.

No migration. No schema change.

## Why `clickhouse-refresh-monitor.ts` is in a featured-collections PR

**One comment line**, reworded to drop a private repo name and a PR number while keeping the alert expressions. It is here because this PR's own header comment cited that file as evidence a Prometheus rule "cannot ship" — a claim that file disproves — so correcting the false claim while leaving the sentence it points at would have been odd. Approved separately by the repo owner.

🔴 **It is one instance of a wider class, not a sweep.** A repo-wide search finds **78 files** matching `talos|infra#|civitai-dp-|gitops` across `src apps packages scripts` (45 in `src/` alone), tracked on **`868kzkwy1`**. Do not read this line as the class being handled.

**How that number was reached, because the method matters more than the count.** My first enumeration said *three* — it came from `grep -rn 'talos-infra' src/`, which searches one directory for one repo name. A second pass gave eleven, a review lane gave ~40, and the coordinator's re-run gave 78 with a nonsense-token control returning 0 to show the pattern discriminates. The pattern is still a proxy somebody chose rather than a definition of the class: it would not find a different private repo, a bastion hostname, a kubectl context, or a namespace. `868kzkwy1` carries that caveat and its closing condition requires stating whether the search was widened.

## What has NOT been reviewed, and why

Two commits land after the last full review round, deliberately:

- **`c18f0c9f2b`** — comment-only. Verified mechanically: a filter for non-comment changed lines returns **zero** over this commit and **21** over the test commit, so the empty result is a check that could have failed rather than one that cannot fire.
- **`7aa79d01e1`** — test-only, one file.

**The tests lane re-read the head. Reuse, perf, correctness and intent did not.** That is a deliberate stopping point rather than an oversight: both commits touch only the tests lane's subject, and acting on a lane's findings always manufactures a new unreviewed head — so "the final SHA was reviewed by everyone" is a state only reachable by never fixing anything. What is true instead: the five lanes read `a4d9f9cbc5`, and everything that changed after it is listed above.

## Deferred, with tickets

- **`868kzm1ec`** — an unconfigured `DISCORD_WEBHOOK_MOD_ALERTS` logs at `info` in production too, where a missing webhook means a paging alert reached nobody. Raised by the correctness lane at `b955dc476f`; a behaviour change, so not bolted onto the last commit.
- **`868kzkwy1`** — the private-repo reference sweep above.

## Still owed before `868kz3ef5` closes

The live verification: set `KeyValue['job:auto-feature-images']` back a day, hit `/api/webhooks/run-jobs/auto-feature-health-check?token=…`, watch Discord, restore. **Not** by turning off the flag — that produces no alert by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01529s2vx4rHVEmEXUkMo4wV
