### PR TITLE
feat(apps): let an app paint its own boot state (manifest bootSkeleton)

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://civitai.com/schemas/app-block/v1.json",
   "title": "Civitai App Block Manifest",
-  "description": "THE canonical, server-published schema for block.manifest.json \u2014 the ONLY mandatory file in a Civitai App Block. Published at https://civitai.com/schemas/app-block/v1.json. This is the single source of truth for the block manifest contract: the platform's server-side validator (src/server/services/block-manifest-validator.service.ts) and the `civitai` CLI both validate against these same rules. Set this URL as your manifest's `$schema` for editor validation.",
+  "description": "THE canonical, server-published schema for block.manifest.json — the ONLY mandatory file in a Civitai App Block. Published at https://civitai.com/schemas/app-block/v1.json. This is the single source of truth for the block manifest contract: the platform's server-side validator (src/server/services/block-manifest-validator.service.ts) and the `civitai` CLI both validate against these same rules. Set this URL as your manifest's `$schema` for editor validation.",
   "type": "object",
   "required": ["blockId", "version", "name", "contentRating", "scopes"],
   "properties": {
@@ -30,14 +30,14 @@
     },
     "tagline": {
       "type": "string",
-      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Must contain a non-whitespace character and is capped at 140 characters \u2014 the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). NOTE: the server measures the TRIMMED length, while this maxLength counts the raw string \u2014 so a value padded past 140 is rejected here but accepted server-side. That asymmetry is deliberate and one-directional: this schema is never more permissive than the server, so local validation can't green-light something submit would reject.",
+      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Must contain a non-whitespace character and is capped at 140 characters — the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). NOTE: the server measures the TRIMMED length, while this maxLength counts the raw string — so a value padded past 140 is rejected here but accepted server-side. That asymmetry is deliberate and one-directional: this schema is never more permissive than the server, so local validation can't green-light something submit would reject.",
       "minLength": 1,
       "maxLength": 140,
       "pattern": "\\S"
     },
     "repository": {
       "type": "string",
-      "description": "Optional PUBLIC SOURCE-REPOSITORY link for an open-source app, rendered as a `Source` row on the app's `/apps` store DETAIL page (never on a store grid card). Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version; remove the key and the link is cleared. This is NOT your app's internal Civitai repository \u2014 it is a link you publish. Must be an `https://` URL, carrying no embedded credentials and no port, whose host is EXACTLY one of github.com, gitlab.com or codeberg.org (an exact-host allowlist \u2014 `www.github.com`, `gist.github.com` and `raw.githubusercontent.com` are all rejected), and whose path is exactly `/<owner>/<repo>`, the repository ROOT (a deep link such as `/owner/repo/tree/main` is rejected). A trailing `/` or `.git`, a query string and a fragment are accepted and STRIPPED \u2014 the stored value is normalised to `https://<host>/<owner>/<repo>`. Capped at 200 characters, kept in lockstep with MAX_REPOSITORY_URL_LENGTH in src/server/schema/blocks/external-app.schema.ts (a drift-guard test enforces equality, and enforces that this description names exactly the hosts REPOSITORY_HOST_ALLOWLIST contains). NOTE: as with `tagline`, the server measures the TRIMMED string while this maxLength counts the raw one, so the LENGTH bound here is never looser than the server's. The `pattern`, however, is a coarse SHAPE check and NOT the whole rule, so unlike `tagline` this field CAN pass local validation and still be rejected at submit. The server additionally requires each of the two path segments to begin with an ASCII letter or digit and to contain only letters, digits, `.`, `-` and `_`, and it strips a trailing `.git` BEFORE applying that test. Values such as a repository segment that is only `.git`, one starting with a dash, one containing a percent-escape, and one containing a non-ASCII character all match this pattern and are refused by the server. The pattern is deliberately left coarse rather than tightened: the CLI and the starter templates byte-mirror this file, and a stricter regex would be a compatibility change for every vendored copy. Treat passing local validation as necessary, not sufficient \u2014 `validateRepositoryUrl` in src/server/schema/blocks/external-app.schema.ts is authoritative.",
+      "description": "Optional PUBLIC SOURCE-REPOSITORY link for an open-source app, rendered as a `Source` row on the app's `/apps` store DETAIL page (never on a store grid card). Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version; remove the key and the link is cleared. This is NOT your app's internal Civitai repository — it is a link you publish. Must be an `https://` URL, carrying no embedded credentials and no port, whose host is EXACTLY one of github.com, gitlab.com or codeberg.org (an exact-host allowlist — `www.github.com`, `gist.github.com` and `raw.githubusercontent.com` are all rejected), and whose path is exactly `/<owner>/<repo>`, the repository ROOT (a deep link such as `/owner/repo/tree/main` is rejected). A trailing `/` or `.git`, a query string and a fragment are accepted and STRIPPED — the stored value is normalised to `https://<host>/<owner>/<repo>`. Capped at 200 characters, kept in lockstep with MAX_REPOSITORY_URL_LENGTH in src/server/schema/blocks/external-app.schema.ts (a drift-guard test enforces equality, and enforces that this description names exactly the hosts REPOSITORY_HOST_ALLOWLIST contains). NOTE: as with `tagline`, the server measures the TRIMMED string while this maxLength counts the raw one, so the LENGTH bound here is never looser than the server's. The `pattern`, however, is a coarse SHAPE check and NOT the whole rule, so unlike `tagline` this field CAN pass local validation and still be rejected at submit. The server additionally requires each of the two path segments to begin with an ASCII letter or digit and to contain only letters, digits, `.`, `-` and `_`, and it strips a trailing `.git` BEFORE applying that test. Values such as a repository segment that is only `.git`, one starting with a dash, one containing a percent-escape, and one containing a non-ASCII character all match this pattern and are refused by the server. The pattern is deliberately left coarse rather than tightened: the CLI and the starter templates byte-mirror this file, and a stricter regex would be a compatibility change for every vendored copy. Treat passing local validation as necessary, not sufficient — `validateRepositoryUrl` in src/server/schema/blocks/external-app.schema.ts is authoritative.",
       "minLength": 1,
       "maxLength": 200,
       "pattern": "^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$"
@@ -54,7 +54,7 @@
     },
     "category": {
       "type": "string",
-      "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories \u2014 this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
+      "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories — this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
       "enum": ["generation", "games", "utility", "discovery", "moderation", "analytics", "other"]
     },
     "renderMode": {
@@ -64,7 +64,7 @@
     },
     "trustTier": {
       "type": "string",
-      "description": "SERVER-OWNED. Do NOT set this in your manifest \u2014 the platform assigns the trust tier during review. Present here only to reject dev-set values.",
+      "description": "SERVER-OWNED. Do NOT set this in your manifest — the platform assigns the trust tier during review. Present here only to reject dev-set values.",
       "$comment": "Rejected via 'not' below.",
       "enum": ["unverified", "verified", "internal"]
     },
@@ -91,7 +91,7 @@
     },
     "scopeJustifications": {
       "type": "object",
-      "description": "Per-scope justification: a map of scope-id \u2192 free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. REQUIRED for SENSITIVE scopes \u2014 any declared scope that can spend or read the viewer's Buzz, read the viewer's private data, or write data other users see (e.g. `ai:write:budgeted`, `social:tip:self`, `buzz:read:self`, `collections:read:private`, `apps:storage:shared:write`) MUST carry a non-empty justification here, or the manifest is rejected at submit time. OPTIONAL for non-sensitive scopes \u2014 omit those and the manifest stays valid. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. The requirement is enforced imperatively by the manifest validator (not expressed as JSON-Schema conditionals here). NOTE: the justification captures the developer's STATED rationale only; the platform does not verify the truth of the claims.",
+      "description": "Per-scope justification: a map of scope-id → free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. REQUIRED for SENSITIVE scopes — any declared scope that can spend or read the viewer's Buzz, read the viewer's private data, or write data other users see (e.g. `ai:write:budgeted`, `social:tip:self`, `buzz:read:self`, `collections:read:private`, `apps:storage:shared:write`) MUST carry a non-empty justification here, or the manifest is rejected at submit time. OPTIONAL for non-sensitive scopes — omit those and the manifest stays valid. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. The requirement is enforced imperatively by the manifest validator (not expressed as JSON-Schema conditionals here). NOTE: the justification captures the developer's STATED rationale only; the platform does not verify the truth of the claims.",
       "additionalProperties": {
         "type": "string",
         "minLength": 1,
@@ -116,30 +116,13 @@
       "minLength": 1,
       "maxLength": 256,
       "allOf": [
-        {
-          "$comment": "no leading '/' (absolute path)",
-          "not": {
-            "pattern": "^/"
-          }
-        },
+        { "$comment": "no leading '/' (absolute path)", "not": { "pattern": "^/" } },
         {
           "$comment": "no backslash separators (Windows / '\\..' traversal)",
-          "not": {
-            "pattern": "\\\\"
-          }
+          "not": { "pattern": "\\\\" }
         },
-        {
-          "$comment": "no '..' path-traversal segment",
-          "not": {
-            "pattern": "(^|/)\\.\\.(/|$)"
-          }
-        },
-        {
-          "$comment": "no Windows drive prefix (e.g. C:)",
-          "not": {
-            "pattern": "^[A-Za-z]:"
-          }
-        }
+        { "$comment": "no '..' path-traversal segment", "not": { "pattern": "(^|/)\\.\\.(/|$)" } },
+        { "$comment": "no Windows drive prefix (e.g. C:)", "not": { "pattern": "^[A-Za-z]:" } }
       ]
     },
     "publicSettingsKeys": {
@@ -154,17 +137,17 @@
     },
     "assetBundleUrl": {
       "type": "string",
-      "description": "Optional v2 surface \u2014 HTTPS URL to a hosted asset bundle. Must be a public https URL.",
+      "description": "Optional v2 surface — HTTPS URL to a hosted asset bundle. Must be a public https URL.",
       "format": "uri",
       "pattern": "^https://"
     },
     "iframe": {
       "type": "object",
-      "description": "iframe envelope. NOTE: iframe.src is SERVER-OWNED \u2014 do NOT set it; the platform stamps the canonical bundle URL during build/approve.",
+      "description": "iframe envelope. NOTE: iframe.src is SERVER-OWNED — do NOT set it; the platform stamps the canonical bundle URL during build/approve.",
       "additionalProperties": false,
       "properties": {
         "src": {
-          "description": "SERVER-OWNED. Do NOT set iframe.src \u2014 the platform assigns it. Present here only so the schema can reject dev-set values.",
+          "description": "SERVER-OWNED. Do NOT set iframe.src — the platform assigns it. Present here only so the schema can reject dev-set values.",
           "$comment": "Rejected via 'not' below."
         },
         "minHeight": {
@@ -193,7 +176,8 @@
     "bootSkeleton": {
       "type": "boolean",
       "default": false,
-      "description": "The app's shipped index.html paints its own themed loading state inside #root. The full-page run host then stands down its own branded overlay and shows the iframe from mount, so the app's boot state is visible at first paint and its React render replaces it in place with no cross-fade, no reveal transform and no theme change. Omit (or false) unless the app really ships one: without a veil an empty #root is a blank white iframe. The platform build fails a build that declares this with an empty #root."
+      "description": "The app's shipped index.html paints its own loading state inside #root. The full-page run host then stands down its own branded overlay and shows the iframe from mount, so the app's boot state is visible at first paint and its own render replaces it in place with no cross-fade and no reveal transform. Omit (or false) unless the app really ships one: with the overlay stood down, an empty #root is a blank iframe for the whole load. To paint in the HOST's theme rather than guessing from prefers-color-scheme, the app must also be enabled for the BLOCK_INIT URL fragment and read it before first paint; without that the theme is a guess that can disagree with the host and be corrected on BLOCK_INIT.",
+      "$comment": "Honoured by the full-page run host. Other block surfaces ignore it."
     },
     "page": {
       "type": "object",
@@ -221,7 +205,7 @@
         },
         "buzzBudgetPerGen": {
           "type": "integer",
-          "description": "Optional per-generation Buzz SAFETY CEILING for `ai:write:budgeted` tokens \u2014 the most a SINGLE generation this app requests is allowed to cost. It is a ceiling against a malicious or compromised app draining the viewer's Buzz, NOT a cost forecast: size it WELL ABOVE your worst-case generation (a good rule of thumb is several times your expected cost \u2014 e.g. 1000 when a run costs ~100), never at your estimate. Setting it to an estimate is the common mistake. The server re-prices every submit and compares that real price against this budget BEFORE anything runs, so a generation that comes in over budget is REJECTED outright with `insufficient buzz budget` \u2014 no workflow is created and no Buzz is spent, but the user gets nothing, and it stays broken for EVERY user until you ship a new manifest version and it is re-approved. So any upward drift in real cost (more steps, a bigger resolution, a pricier model or recipe, a colder cache) turns a budget sized to today's estimate into a hard outage. Positive integer. Omit it and the token is minted with a 10 Buzz default, which is below almost any real generation. Server-clamped to the platform per-gen cap (1000 today), so a generous value is safe. This bounds ONE generation only \u2014 cumulative spend is separately capped per viewer per day and per app, so a high per-gen ceiling does not widen total exposure.",
+          "description": "Optional per-generation Buzz SAFETY CEILING for `ai:write:budgeted` tokens — the most a SINGLE generation this app requests is allowed to cost. It is a ceiling against a malicious or compromised app draining the viewer's Buzz, NOT a cost forecast: size it WELL ABOVE your worst-case generation (a good rule of thumb is several times your expected cost — e.g. 1000 when a run costs ~100), never at your estimate. Setting it to an estimate is the common mistake. The server re-prices every submit and compares that real price against this budget BEFORE anything runs, so a generation that comes in over budget is REJECTED outright with `insufficient buzz budget` — no workflow is created and no Buzz is spent, but the user gets nothing, and it stays broken for EVERY user until you ship a new manifest version and it is re-approved. So any upward drift in real cost (more steps, a bigger resolution, a pricier model or recipe, a colder cache) turns a budget sized to today's estimate into a hard outage. Positive integer. Omit it and the token is minted with a 10 Buzz default, which is below almost any real generation. Server-clamped to the platform per-gen cap (1000 today), so a generous value is safe. This bounds ONE generation only — cumulative spend is separately capped per viewer per day and per app, so a high per-gen ceiling does not widen total exposure.",
           "exclusiveMinimum": 0
         }
       }

--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://civitai.com/schemas/app-block/v1.json",
   "title": "Civitai App Block Manifest",
-  "description": "THE canonical, server-published schema for block.manifest.json — the ONLY mandatory file in a Civitai App Block. Published at https://civitai.com/schemas/app-block/v1.json. This is the single source of truth for the block manifest contract: the platform's server-side validator (src/server/services/block-manifest-validator.service.ts) and the `civitai` CLI both validate against these same rules. Set this URL as your manifest's `$schema` for editor validation.",
+  "description": "THE canonical, server-published schema for block.manifest.json \u2014 the ONLY mandatory file in a Civitai App Block. Published at https://civitai.com/schemas/app-block/v1.json. This is the single source of truth for the block manifest contract: the platform's server-side validator (src/server/services/block-manifest-validator.service.ts) and the `civitai` CLI both validate against these same rules. Set this URL as your manifest's `$schema` for editor validation.",
   "type": "object",
   "required": ["blockId", "version", "name", "contentRating", "scopes"],
   "properties": {
@@ -30,14 +30,14 @@
     },
     "tagline": {
       "type": "string",
-      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Must contain a non-whitespace character and is capped at 140 characters — the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). NOTE: the server measures the TRIMMED length, while this maxLength counts the raw string — so a value padded past 140 is rejected here but accepted server-side. That asymmetry is deliberate and one-directional: this schema is never more permissive than the server, so local validation can't green-light something submit would reject.",
+      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Must contain a non-whitespace character and is capped at 140 characters \u2014 the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). NOTE: the server measures the TRIMMED length, while this maxLength counts the raw string \u2014 so a value padded past 140 is rejected here but accepted server-side. That asymmetry is deliberate and one-directional: this schema is never more permissive than the server, so local validation can't green-light something submit would reject.",
       "minLength": 1,
       "maxLength": 140,
       "pattern": "\\S"
     },
     "repository": {
       "type": "string",
-      "description": "Optional PUBLIC SOURCE-REPOSITORY link for an open-source app, rendered as a `Source` row on the app's `/apps` store DETAIL page (never on a store grid card). Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version; remove the key and the link is cleared. This is NOT your app's internal Civitai repository — it is a link you publish. Must be an `https://` URL, carrying no embedded credentials and no port, whose host is EXACTLY one of github.com, gitlab.com or codeberg.org (an exact-host allowlist — `www.github.com`, `gist.github.com` and `raw.githubusercontent.com` are all rejected), and whose path is exactly `/<owner>/<repo>`, the repository ROOT (a deep link such as `/owner/repo/tree/main` is rejected). A trailing `/` or `.git`, a query string and a fragment are accepted and STRIPPED — the stored value is normalised to `https://<host>/<owner>/<repo>`. Capped at 200 characters, kept in lockstep with MAX_REPOSITORY_URL_LENGTH in src/server/schema/blocks/external-app.schema.ts (a drift-guard test enforces equality, and enforces that this description names exactly the hosts REPOSITORY_HOST_ALLOWLIST contains). NOTE: as with `tagline`, the server measures the TRIMMED string while this maxLength counts the raw one, so the LENGTH bound here is never looser than the server's. The `pattern`, however, is a coarse SHAPE check and NOT the whole rule, so unlike `tagline` this field CAN pass local validation and still be rejected at submit. The server additionally requires each of the two path segments to begin with an ASCII letter or digit and to contain only letters, digits, `.`, `-` and `_`, and it strips a trailing `.git` BEFORE applying that test. Values such as a repository segment that is only `.git`, one starting with a dash, one containing a percent-escape, and one containing a non-ASCII character all match this pattern and are refused by the server. The pattern is deliberately left coarse rather than tightened: the CLI and the starter templates byte-mirror this file, and a stricter regex would be a compatibility change for every vendored copy. Treat passing local validation as necessary, not sufficient — `validateRepositoryUrl` in src/server/schema/blocks/external-app.schema.ts is authoritative.",
+      "description": "Optional PUBLIC SOURCE-REPOSITORY link for an open-source app, rendered as a `Source` row on the app's `/apps` store DETAIL page (never on a store grid card). Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version; remove the key and the link is cleared. This is NOT your app's internal Civitai repository \u2014 it is a link you publish. Must be an `https://` URL, carrying no embedded credentials and no port, whose host is EXACTLY one of github.com, gitlab.com or codeberg.org (an exact-host allowlist \u2014 `www.github.com`, `gist.github.com` and `raw.githubusercontent.com` are all rejected), and whose path is exactly `/<owner>/<repo>`, the repository ROOT (a deep link such as `/owner/repo/tree/main` is rejected). A trailing `/` or `.git`, a query string and a fragment are accepted and STRIPPED \u2014 the stored value is normalised to `https://<host>/<owner>/<repo>`. Capped at 200 characters, kept in lockstep with MAX_REPOSITORY_URL_LENGTH in src/server/schema/blocks/external-app.schema.ts (a drift-guard test enforces equality, and enforces that this description names exactly the hosts REPOSITORY_HOST_ALLOWLIST contains). NOTE: as with `tagline`, the server measures the TRIMMED string while this maxLength counts the raw one, so the LENGTH bound here is never looser than the server's. The `pattern`, however, is a coarse SHAPE check and NOT the whole rule, so unlike `tagline` this field CAN pass local validation and still be rejected at submit. The server additionally requires each of the two path segments to begin with an ASCII letter or digit and to contain only letters, digits, `.`, `-` and `_`, and it strips a trailing `.git` BEFORE applying that test. Values such as a repository segment that is only `.git`, one starting with a dash, one containing a percent-escape, and one containing a non-ASCII character all match this pattern and are refused by the server. The pattern is deliberately left coarse rather than tightened: the CLI and the starter templates byte-mirror this file, and a stricter regex would be a compatibility change for every vendored copy. Treat passing local validation as necessary, not sufficient \u2014 `validateRepositoryUrl` in src/server/schema/blocks/external-app.schema.ts is authoritative.",
       "minLength": 1,
       "maxLength": 200,
       "pattern": "^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$"
@@ -54,16 +54,8 @@
     },
     "category": {
       "type": "string",
-      "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories — this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
-      "enum": [
-        "generation",
-        "games",
-        "utility",
-        "discovery",
-        "moderation",
-        "analytics",
-        "other"
-      ]
+      "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories \u2014 this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
+      "enum": ["generation", "games", "utility", "discovery", "moderation", "analytics", "other"]
     },
     "renderMode": {
       "type": "string",
@@ -72,7 +64,7 @@
     },
     "trustTier": {
       "type": "string",
-      "description": "SERVER-OWNED. Do NOT set this in your manifest — the platform assigns the trust tier during review. Present here only to reject dev-set values.",
+      "description": "SERVER-OWNED. Do NOT set this in your manifest \u2014 the platform assigns the trust tier during review. Present here only to reject dev-set values.",
       "$comment": "Rejected via 'not' below.",
       "enum": ["unverified", "verified", "internal"]
     },
@@ -99,7 +91,7 @@
     },
     "scopeJustifications": {
       "type": "object",
-      "description": "Per-scope justification: a map of scope-id → free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. REQUIRED for SENSITIVE scopes — any declared scope that can spend or read the viewer's Buzz, read the viewer's private data, or write data other users see (e.g. `ai:write:budgeted`, `social:tip:self`, `buzz:read:self`, `collections:read:private`, `apps:storage:shared:write`) MUST carry a non-empty justification here, or the manifest is rejected at submit time. OPTIONAL for non-sensitive scopes — omit those and the manifest stays valid. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. The requirement is enforced imperatively by the manifest validator (not expressed as JSON-Schema conditionals here). NOTE: the justification captures the developer's STATED rationale only; the platform does not verify the truth of the claims.",
+      "description": "Per-scope justification: a map of scope-id \u2192 free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. REQUIRED for SENSITIVE scopes \u2014 any declared scope that can spend or read the viewer's Buzz, read the viewer's private data, or write data other users see (e.g. `ai:write:budgeted`, `social:tip:self`, `buzz:read:self`, `collections:read:private`, `apps:storage:shared:write`) MUST carry a non-empty justification here, or the manifest is rejected at submit time. OPTIONAL for non-sensitive scopes \u2014 omit those and the manifest stays valid. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. The requirement is enforced imperatively by the manifest validator (not expressed as JSON-Schema conditionals here). NOTE: the justification captures the developer's STATED rationale only; the platform does not verify the truth of the claims.",
       "additionalProperties": {
         "type": "string",
         "minLength": 1,
@@ -124,10 +116,30 @@
       "minLength": 1,
       "maxLength": 256,
       "allOf": [
-        { "$comment": "no leading '/' (absolute path)", "not": { "pattern": "^/" } },
-        { "$comment": "no backslash separators (Windows / '\\..' traversal)", "not": { "pattern": "\\\\" } },
-        { "$comment": "no '..' path-traversal segment", "not": { "pattern": "(^|/)\\.\\.(/|$)" } },
-        { "$comment": "no Windows drive prefix (e.g. C:)", "not": { "pattern": "^[A-Za-z]:" } }
+        {
+          "$comment": "no leading '/' (absolute path)",
+          "not": {
+            "pattern": "^/"
+          }
+        },
+        {
+          "$comment": "no backslash separators (Windows / '\\..' traversal)",
+          "not": {
+            "pattern": "\\\\"
+          }
+        },
+        {
+          "$comment": "no '..' path-traversal segment",
+          "not": {
+            "pattern": "(^|/)\\.\\.(/|$)"
+          }
+        },
+        {
+          "$comment": "no Windows drive prefix (e.g. C:)",
+          "not": {
+            "pattern": "^[A-Za-z]:"
+          }
+        }
       ]
     },
     "publicSettingsKeys": {
@@ -142,17 +154,17 @@
     },
     "assetBundleUrl": {
       "type": "string",
-      "description": "Optional v2 surface — HTTPS URL to a hosted asset bundle. Must be a public https URL.",
+      "description": "Optional v2 surface \u2014 HTTPS URL to a hosted asset bundle. Must be a public https URL.",
       "format": "uri",
       "pattern": "^https://"
     },
     "iframe": {
       "type": "object",
-      "description": "iframe envelope. NOTE: iframe.src is SERVER-OWNED — do NOT set it; the platform stamps the canonical bundle URL during build/approve.",
+      "description": "iframe envelope. NOTE: iframe.src is SERVER-OWNED \u2014 do NOT set it; the platform stamps the canonical bundle URL during build/approve.",
       "additionalProperties": false,
       "properties": {
         "src": {
-          "description": "SERVER-OWNED. Do NOT set iframe.src — the platform assigns it. Present here only so the schema can reject dev-set values.",
+          "description": "SERVER-OWNED. Do NOT set iframe.src \u2014 the platform assigns it. Present here only so the schema can reject dev-set values.",
           "$comment": "Rejected via 'not' below."
         },
         "minHeight": {
@@ -177,6 +189,11 @@
           "minLength": 1
         }
       }
+    },
+    "bootSkeleton": {
+      "type": "boolean",
+      "default": false,
+      "description": "The app's shipped index.html paints its own themed loading state inside #root. The full-page run host then stands down its own branded overlay and shows the iframe from mount, so the app's boot state is visible at first paint and its React render replaces it in place with no cross-fade, no reveal transform and no theme change. Omit (or false) unless the app really ships one: without a veil an empty #root is a blank white iframe. The platform build fails a build that declares this with an empty #root."
     },
     "page": {
       "type": "object",
@@ -204,7 +221,7 @@
         },
         "buzzBudgetPerGen": {
           "type": "integer",
-          "description": "Optional per-generation Buzz SAFETY CEILING for `ai:write:budgeted` tokens — the most a SINGLE generation this app requests is allowed to cost. It is a ceiling against a malicious or compromised app draining the viewer's Buzz, NOT a cost forecast: size it WELL ABOVE your worst-case generation (a good rule of thumb is several times your expected cost — e.g. 1000 when a run costs ~100), never at your estimate. Setting it to an estimate is the common mistake. The server re-prices every submit and compares that real price against this budget BEFORE anything runs, so a generation that comes in over budget is REJECTED outright with `insufficient buzz budget` — no workflow is created and no Buzz is spent, but the user gets nothing, and it stays broken for EVERY user until you ship a new manifest version and it is re-approved. So any upward drift in real cost (more steps, a bigger resolution, a pricier model or recipe, a colder cache) turns a budget sized to today's estimate into a hard outage. Positive integer. Omit it and the token is minted with a 10 Buzz default, which is below almost any real generation. Server-clamped to the platform per-gen cap (1000 today), so a generous value is safe. This bounds ONE generation only — cumulative spend is separately capped per viewer per day and per app, so a high per-gen ceiling does not widen total exposure.",
+          "description": "Optional per-generation Buzz SAFETY CEILING for `ai:write:budgeted` tokens \u2014 the most a SINGLE generation this app requests is allowed to cost. It is a ceiling against a malicious or compromised app draining the viewer's Buzz, NOT a cost forecast: size it WELL ABOVE your worst-case generation (a good rule of thumb is several times your expected cost \u2014 e.g. 1000 when a run costs ~100), never at your estimate. Setting it to an estimate is the common mistake. The server re-prices every submit and compares that real price against this budget BEFORE anything runs, so a generation that comes in over budget is REJECTED outright with `insufficient buzz budget` \u2014 no workflow is created and no Buzz is spent, but the user gets nothing, and it stays broken for EVERY user until you ship a new manifest version and it is re-approved. So any upward drift in real cost (more steps, a bigger resolution, a pricier model or recipe, a colder cache) turns a budget sized to today's estimate into a hard outage. Positive integer. Omit it and the token is minted with a 10 Buzz default, which is below almost any real generation. Server-clamped to the platform per-gen cap (1000 today), so a generous value is safe. This bounds ONE generation only \u2014 cumulative spend is separately capped per viewer per day and per app, so a high per-gen ceiling does not widen total exposure.",
           "exclusiveMinimum": 0
         }
       }

--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -55,7 +55,15 @@
     "category": {
       "type": "string",
       "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories — this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
-      "enum": ["generation", "games", "utility", "discovery", "moderation", "analytics", "other"]
+      "enum": [
+        "generation",
+        "games",
+        "utility",
+        "discovery",
+        "moderation",
+        "analytics",
+        "other"
+      ]
     },
     "renderMode": {
       "type": "string",
@@ -117,10 +125,7 @@
       "maxLength": 256,
       "allOf": [
         { "$comment": "no leading '/' (absolute path)", "not": { "pattern": "^/" } },
-        {
-          "$comment": "no backslash separators (Windows / '\\..' traversal)",
-          "not": { "pattern": "\\\\" }
-        },
+        { "$comment": "no backslash separators (Windows / '\\..' traversal)", "not": { "pattern": "\\\\" } },
         { "$comment": "no '..' path-traversal segment", "not": { "pattern": "(^|/)\\.\\.(/|$)" } },
         { "$comment": "no Windows drive prefix (e.g. C:)", "not": { "pattern": "^[A-Za-z]:" } }
       ]

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -224,6 +224,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -404,6 +404,24 @@ export interface PageBlockHostProps {
   /** The `<slug>.civit.ai` bundle URL (manifest.iframe.src), server-resolved. */
   iframeSrc: string;
   /**
+   * `manifest.bootSkeleton` — the app declares that its OWN shipped `index.html`
+   * paints a themed boot state, so the host must stand back and let it show.
+   *
+   * 🔴 This does three things, not one, and all three are required: without any
+   * of them the app's boot state is invisible and the declaration is a lie.
+   *   1. no branded veil (it is opaque, `inset: 0`, until BLOCK_READY);
+   *   2. the iframe is visible from mount rather than `opacity: 0` until ready;
+   *   3. no `translateY` settle on reveal — that IS a layout shift, and the
+   *      point of an app-painted skeleton is that hydration moves nothing.
+   *
+   * The host's own skeleton stays the default for every app that does NOT
+   * declare this: an app with an empty `#root` and no veil is a blank white
+   * iframe for 300-1200ms, which is worse than what we had. The platform build
+   * fails a build that declares this with an empty `#root`, so the claim cannot
+   * rot into that.
+   */
+  bootSkeleton?: boolean;
+  /**
    * Which surface mounted this host. REQUIRED, and passed explicitly by each
    * call site rather than inferred, because it is one of the two axes the
    * init-fragment gate keys on — and the axis that refuses the DEV TUNNEL
@@ -597,6 +615,7 @@ export function PageBlockHost({
   blockInstanceId,
   appName,
   iframeSrc,
+  bootSkeleton = false,
   surface,
   sandbox,
   trustTier,
@@ -3953,15 +3972,32 @@ export function PageBlockHost({
               // cross-fading with the branded overlay below. Under reduced motion
               // `revealMs` is 0 → no transition is emitted and the opacity flip is
               // instantaneous (the pre-animation behaviour).
-              opacity: isReady ? 1 : 0,
-              transform: isReady || revealMs === 0 ? 'none' : 'translateY(8px)',
+              //
+              // 🔴 `bootSkeleton` apps opt OUT of the whole reveal. They paint
+              // their own themed boot state in the HTML they ship, so hiding the
+              // iframe until BLOCK_READY would hide exactly that, and the
+              // translateY settle would move it on arrival — a layout shift, at
+              // the one moment the app is trying not to move. Visible from mount,
+              // no transform, no transition: the app's skeleton is on screen at
+              // first paint and its own React render replaces it in place.
+              // `pointerEvents` is deliberately NOT opted out — a skeleton is not
+              // interactive, and the block must stay inert until it has a token.
+              opacity: bootSkeleton || isReady ? 1 : 0,
+              transform: bootSkeleton || isReady || revealMs === 0 ? 'none' : 'translateY(8px)',
               transition:
-                revealMs === 0
+                bootSkeleton || revealMs === 0
                   ? undefined
                   : `opacity ${revealMs}ms ease-out, transform ${revealMs}ms ease-out`,
             }}
           />
-          {overlayMounted && (
+          {/* 🔴 Suppressed for a `bootSkeleton` app. This veil is opaque and
+              `inset: 0` until BLOCK_READY, so leaving it up would cover the very
+              boot state the app ships — the declaration would be inert and the
+              app author would have no way to tell. For every other app it stays
+              exactly as it was, and it is the reason NOT declaring the field is
+              the safe default: no veil plus an empty `#root` is a blank white
+              iframe. */}
+          {!bootSkeleton && overlayMounted && (
             <Center
               data-testid="app-page-loading"
               // Announce the loading state on the REGION: role="status" +

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -4010,7 +4010,9 @@ export function PageBlockHost({
               // instantaneous (the pre-animation behaviour).
               //
               // 🔴 `bootSkeleton` apps opt OUT of the whole reveal. They paint
-              // their own themed boot state in the HTML they ship, so hiding the
+              // their own boot state in the HTML they ship (themed only if they also
+              // read the BLOCK_INIT fragment; otherwise a prefers-color-scheme
+              // guess), so hiding the
               // iframe until BLOCK_READY would hide exactly that, and the
               // translateY settle would move it on arrival — a layout shift, at
               // the one moment the app is trying not to move. Visible from mount,

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -416,11 +416,23 @@ export interface PageBlockHostProps {
    *
    * The host's own skeleton stays the default for every app that does NOT
    * declare this: an app with an empty `#root` and no veil is a blank white
-   * iframe for 300-1200ms, which is worse than what we had. The platform build
-   * fails a build that declares this with an empty `#root`, so the claim cannot
-   * rot into that.
+   * iframe for 300-1200ms, which is worse than what we had.
+   *
+   * 🔴 NOTHING VALIDATES THE DECLARATION TODAY — do not rest a safety argument
+   * on a build gate that does not exist yet. An app may set this over an empty
+   * `#root` and the result is that blank iframe, with no rejection anywhere in
+   * submit, approve or build. A platform-build check is planned (talos-infra);
+   * until it lands, the only thing standing between a false declaration and a
+   * blank run page is the author looking at their own app.
    */
-  bootSkeleton?: boolean;
+  // REQUIRED, and passed explicitly by every call site — the same shape
+  // `surface` above uses, for the same reason. An optional prop with a
+  // `= false` default made the DEV route and the MODERATOR REVIEW preview
+  // silently render the veil: the author checking their own app and the
+  // moderator approving it both saw the pre-feature presentation, and the
+  // first person to see the real one would have been a user. Required means
+  // a new host is a type error until someone decides what it should do.
+  bootSkeleton: boolean;
   /**
    * Which surface mounted this host. REQUIRED, and passed explicitly by each
    * call site rather than inferred, because it is one of the two axes the
@@ -615,7 +627,7 @@ export function PageBlockHost({
   blockInstanceId,
   appName,
   iframeSrc,
-  bootSkeleton = false,
+  bootSkeleton,
   surface,
   sandbox,
   trustTier,
@@ -3962,6 +3974,16 @@ export function PageBlockHost({
             data-testid="app-page-iframe"
             data-block-instance-id={blockInstanceId}
             data-block-ready={isReady ? 'true' : 'false'}
+            /* 🔴 A11Y. The veil is the host's ONLY loading announcement
+                (role="status" + aria-busy). Standing it down for a bootSkeleton
+                app removed it with nothing in its place — measured, ZERO
+                elements matching [role="status"],[aria-busy],[role="alert"] —
+                and the host cannot borrow the app's, because that boot state is
+                inside a cross-origin frame it can never read. Marking the frame
+                itself busy restores a machine-readable "still loading" without
+                claiming to know what it says. Only while the veil is absent:
+                two busy regions would announce twice. */
+            aria-busy={bootSkeleton && !isReady ? true : undefined}
             style={{
               flex: 1,
               display: 'block',
@@ -3997,7 +4019,17 @@ export function PageBlockHost({
               exactly as it was, and it is the reason NOT declaring the field is
               the safe default: no veil plus an empty `#root` is a blank white
               iframe. */}
-          {!bootSkeleton && overlayMounted && (
+          {/* 🔴 `reloadNonce > 0` deliberately RE-ENABLES the veil for a
+              bootSkeleton app. The opt-out is about FIRST boot, where the app's
+              own skeleton is about to paint. A RETRY is the opposite situation:
+              `key={reloadNonce}` remounts the iframe, so the app's document is
+              being re-fetched and its skeleton is NOT on screen — and the
+              "Retrying …" copy lives inside this veil, so suppressing it left
+              the user with an empty region and no indication anything had
+              happened, for the manual attempt and every automatic one.
+              Measured: veil absent, iframe blank, the string "Retrying" nowhere
+              in the document. */}
+          {(!bootSkeleton || reloadNonce > 0) && overlayMounted && (
             <Center
               data-testid="app-page-loading"
               // Announce the loading state on the REGION: role="status" +

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -405,7 +405,9 @@ export interface PageBlockHostProps {
   iframeSrc: string;
   /**
    * `manifest.bootSkeleton` — the app declares that its OWN shipped `index.html`
-   * paints a themed boot state, so the host must stand back and let it show.
+   * paints its own boot state (THEMED only if the app is also enabled for the
+   * BLOCK_INIT fragment and reads it before first paint; otherwise it is
+   * guessing from prefers-color-scheme), so the host must stand back and let it show.
    *
    * 🔴 This does three things, not one, and all three are required: without any
    * of them the app's boot state is invisible and the declaration is a lie.
@@ -417,6 +419,15 @@ export interface PageBlockHostProps {
    * The host's own skeleton stays the default for every app that does NOT
    * declare this: an app with an empty `#root` and no veil is a blank white
    * iframe for 300-1200ms, which is worse than what we had.
+   *
+   * 🔴 IT ALSO WIDENS WHAT AN APP CAN PAINT, AND WHEN. Without this the block
+   * could put no pixels on screen before BLOCK_READY (opacity 0 + an opaque
+   * veil); with it, publisher-controlled content is visible from mount, before
+   * the host holds a token. `pointerEvents` still blocks the mouse and
+   * AppBlockChrome still sits above, and an app can already paint freely once
+   * ready — so the change is to TIMING, not capability. It is named here
+   * because the surrounding comments discuss anti-spoof posture and this is
+   * part of it.
    *
    * 🔴 NOTHING VALIDATES THE DECLARATION TODAY — do not rest a safety argument
    * on a build gate that does not exist yet. An app may set this over an empty
@@ -3932,7 +3943,8 @@ export function PageBlockHost({
         // non-interactive (pointerEvents:none). Overlay a centered branded
         // launch state (app initial + a content-shaped skeleton) on top
         // so the user sees a loading state instead of a blank page. The overlay
-        // is gated purely on `status === 'loading'`: it unmounts the instant the
+        // is gated on `(!bootSkeleton || reloadNonce > 0) && overlayMounted`
+        // inside `status === 'loading'`: it unmounts the instant the
         // status machine leaves loading — on BLOCK_READY (→ ready) AND on every
         // terminal path (timeout / fatal / no_token / error, which also flip
         // `showIframe` to false and render the BlockFallback below) — so it can
@@ -3981,9 +3993,11 @@ export function PageBlockHost({
                 and the host cannot borrow the app's, because that boot state is
                 inside a cross-origin frame it can never read. Marking the frame
                 itself busy restores a machine-readable "still loading" without
-                claiming to know what it says. Only while the veil is absent:
-                two busy regions would announce twice. */
-            aria-busy={bootSkeleton && !isReady ? true : undefined}
+                claiming to know what it says. `reloadNonce === 0` is what makes
+                "only while the veil is absent" TRUE rather than merely stated:
+                the retry path brings the veil (role="status") back, and without
+                that term both were busy at once — measured, 2 regions. */
+            aria-busy={bootSkeleton && reloadNonce === 0 && !isReady ? true : undefined}
             style={{
               flex: 1,
               display: 'block',

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -379,6 +379,28 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
     expect(iframeEl()?.getAttribute('data-block-ready')).toBe('false');
   });
 
+  test('a bootSkeleton app gets the retry surface on the AUTOMATIC attempt too', async () => {
+    // The manual button is covered in PageBlockHostLaunchReveal. Both paths run
+    // through `performRetry`, so this holds by construction — which is exactly
+    // why it is worth one case: a future change that bumps `reloadNonce` on only
+    // one of them would leave an automatically-retrying bootSkeleton app with a
+    // blank frame and no feedback, and nothing else here would notice.
+    useVirtualClock();
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        bootSkeleton
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    await driveToFatal();
+
+    await advance(FIRST_BACKOFF_MS + 100);
+    await pollFor('retry loading surface', () => loadingEl() !== null);
+    expect(page.getByText('Retrying Budgeted Generator…').query()).not.toBeNull();
+  });
+
   test('auto-retry also fires from the `timeout` terminal (block never acks BLOCK_READY)', async () => {
     useVirtualClock();
     renderWithProviders(

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -153,6 +153,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
@@ -64,7 +64,11 @@ vi.mock('~/utils/trpc', () => ({
           getCounts: { fetch: vi.fn() },
           get: { fetch: vi.fn() },
         },
-        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
       },
     }),
   },
@@ -78,7 +82,11 @@ function postFromBlock(type: string, payload?: unknown) {
   const cw = iframeEl.contentWindow;
   if (!cw) throw new Error('iframe contentWindow missing');
   window.dispatchEvent(
-    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
   );
 }
 
@@ -114,6 +122,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'benchmark-app',
@@ -246,7 +257,15 @@ describe('PageBlockHost GET_IMAGES_BY_IDS (per-viewer gated read)', () => {
 
   test('forwards the ids + token and replies the gated projection (visible + hidden)', async () => {
     const images = [
-      { imageId: 1, status: 'visible', nsfwLevel: 1, contentRating: 'g', url: 'edge:1', width: 512, height: 512 },
+      {
+        imageId: 1,
+        status: 'visible',
+        nsfwLevel: 1,
+        contentRating: 'g',
+        url: 'edge:1',
+        width: 512,
+        height: 512,
+      },
       { imageId: 2, status: 'hidden' },
     ];
     getImagesMutate.mockResolvedValue({ images });

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -184,6 +184,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',
@@ -269,12 +272,30 @@ describe('PageBlockHost checkpoint picker (dev:live↔prod parity with IframeHos
       selected: Record<string, unknown>;
     };
     const sel = payload.selected;
-    const sensitiveAbsent = ['availability', 'hasAccess', 'canGenerate', 'image', 'name',
-      'nsfw', 'nsfwLevel', 'poi', 'minor', 'sfwOnly', 'userId', 'trainedWords', 'model', 'modelType'];
+    const sensitiveAbsent = [
+      'availability',
+      'hasAccess',
+      'canGenerate',
+      'image',
+      'name',
+      'nsfw',
+      'nsfwLevel',
+      'poi',
+      'minor',
+      'sfwOnly',
+      'userId',
+      'trainedWords',
+      'model',
+      'modelType',
+    ];
     for (const k of sensitiveAbsent) expect(sel).not.toHaveProperty(k);
-    expect(Object.keys(sel).sort()).toEqual(
-      ['baseModel', 'modelId', 'modelName', 'versionId', 'versionName']
-    );
+    expect(Object.keys(sel).sort()).toEqual([
+      'baseModel',
+      'modelId',
+      'modelName',
+      'versionId',
+      'versionName',
+    ]);
     replies.stop();
   });
 
@@ -366,7 +387,8 @@ describe('PageBlockHost checkpoint picker (dev:live↔prod parity with IframeHos
     );
     await vi.waitFor(() => {
       const r = replies.last('CHECKPOINT_PICKER_RESULT');
-      if (!(r && (r.payload as any)?.requestId === 'rq_ck')) throw new Error('checkpoint not resolved');
+      if (!(r && (r.payload as any)?.requestId === 'rq_ck'))
+        throw new Error('checkpoint not resolved');
     });
     useDialogStore.getState().closeAll();
 
@@ -379,7 +401,8 @@ describe('PageBlockHost checkpoint picker (dev:live↔prod parity with IframeHos
     );
     await vi.waitFor(() => {
       const r = replies.last('RESOURCE_PICKER_RESULT');
-      if (!(r && (r.payload as any)?.requestId === 'rq_res')) throw new Error('resource not resolved');
+      if (!(r && (r.payload as any)?.requestId === 'rq_res'))
+        throw new Error('resource not resolved');
     });
 
     // Each result kept its own message type + requestId — the handlers don't cross.

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -137,6 +137,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -136,6 +136,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostInitContractV2.browser.test.tsx
@@ -153,6 +153,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'lanternfish-studio',

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -243,6 +243,51 @@ describe('PageBlockHost launch reveal — branded loading', () => {
     }
   });
 
+  // `bootSkeleton` stands down THREE separate things, and leaving any one of
+  // them in place makes the app's own boot state invisible — i.e. the flag is
+  // inert and the app author has no way to tell. One test each, so a failure
+  // names WHICH one regressed rather than just "the contract broke".
+  const renderBootSkeletonApp = async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} bootSkeleton onConsentGranted={vi.fn()} />);
+    await expect.element(page.getByTestId('app-page-iframe')).toBeInTheDocument();
+    // Every assertion below is about the PRE-ready window — the one the app
+    // paints its own skeleton in. If this ever went true the tests would be
+    // asserting the post-reveal state and would pass for the wrong reason.
+    expect(iframeEl().getAttribute('data-block-ready')).toBe('false');
+    return iframeEl();
+  };
+
+  test('bootSkeleton: the host renders NO veil over the app', async () => {
+    const frame = await renderBootSkeletonApp();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    expect(page.getByTestId('app-page-loading-skeleton').query()).toBeNull();
+    // Still inert until it has a token — a skeleton is not interactive.
+    expect(frame.style.pointerEvents).toBe('none');
+  });
+
+  test('bootSkeleton: the iframe is VISIBLE from mount, not opacity 0', async () => {
+    const frame = await renderBootSkeletonApp();
+    expect(frame.style.opacity).toBe('1');
+  });
+
+  test('bootSkeleton: no translateY settle and no reveal transition', async () => {
+    // The settle would move the app's skeleton on arrival — a layout shift at
+    // the exact moment an app-painted boot state exists to avoid one.
+    const frame = await renderBootSkeletonApp();
+    expect(frame.style.transform).toBe('none');
+    expect(frame.style.transition).toBe('');
+  });
+
+  test('an app that does NOT declare bootSkeleton keeps the veil (safe default)', async () => {
+    // The default matters more than the opt-in: no veil plus an empty #root is a
+    // blank white iframe, which is worse than what the veil was doing.
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-page-loading-skeleton')).toBeInTheDocument();
+    expect(iframeEl().style.opacity).toBe('0');
+  });
+
   test('the branded copy runs appName through the chrome sanitizer (control/bidi stripped)', async () => {
     // Same anti-spoof posture as the existing aria-label test: the publisher
     // controls appName, so every appName-derived string on this surface — now

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -305,6 +305,16 @@ describe('PageBlockHost launch reveal — branded loading', () => {
 
     await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
     await expect.element(page.getByText(/Retrying/)).toBeInTheDocument();
+
+    // 🔴 EXACTLY ONE busy region. The veil is role="status" and the iframe
+    // carries aria-busy while booting; during a retry BOTH are on screen, so
+    // without the `reloadNonce === 0` term the page announces twice. Measured
+    // at 2 before that term existed — and the comment claimed the exclusion
+    // while the code did not implement it, which is the shape that survives a
+    // reviewer.
+    const busy = document.querySelectorAll('[aria-busy="true"],[role="status"]');
+    expect(busy.length).toBe(1);
+    expect((busy[0] as HTMLElement).getAttribute('role')).toBe('status');
   });
 
   test('bootSkeleton: no translateY settle and no reveal transition', async () => {

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -120,6 +120,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. The DEFAULT (host-veil) presentation; the bootSkeleton tests
+  // below override it explicitly.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',
@@ -268,6 +271,40 @@ describe('PageBlockHost launch reveal — branded loading', () => {
   test('bootSkeleton: the iframe is VISIBLE from mount, not opacity 0', async () => {
     const frame = await renderBootSkeletonApp();
     expect(frame.style.opacity).toBe('1');
+  });
+
+  test('bootSkeleton: the frame is marked aria-busy while it boots', async () => {
+    // The veil was the host's ONLY loading announcement (role="status" +
+    // aria-busy). Standing it down removed it with nothing in its place — the
+    // app's boot state is cross-origin, so the host cannot borrow the app's.
+    const frame = await renderBootSkeletonApp();
+    expect(frame.getAttribute('aria-busy')).toBe('true');
+    // And it must not persist past the handshake, or the region claims to be
+    // loading forever.
+    await driveToReady();
+    expect(iframeEl().getAttribute('aria-busy')).toBeNull();
+  });
+
+  test('bootSkeleton: a RETRY brings the veil back, so the user gets feedback', async () => {
+    // `key={reloadNonce}` remounts the iframe, so on a retry the app's document
+    // is being re-fetched and its skeleton is NOT on screen. The "Retrying …"
+    // copy lives inside the veil, so suppressing the veil here left an empty
+    // region and no sign anything had happened.
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        bootSkeleton
+        token={null}
+        tokenError
+        onConsentGranted={vi.fn()}
+      />
+    );
+    // Terminal first — that is where Retry is offered.
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    await page.getByRole('button', { name: /Retry/i }).click();
+
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await expect.element(page.getByText(/Retrying/)).toBeInTheDocument();
   });
 
   test('bootSkeleton: no translateY settle and no reveal transition', async () => {

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -124,6 +124,9 @@ const baseProps = {
   appName: 'Max Width App',
   iframeSrc: SAME_ORIGIN_SRC,
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: BLOCK_ID,

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -189,6 +189,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',
@@ -289,13 +292,34 @@ describe('PageBlockHost resource picker (Design 1 host-chrome)', () => {
       selected: Record<string, unknown>;
     };
     const sel = payload.selected;
-    const sensitiveAbsent = ['availability', 'hasAccess', 'canGenerate', 'image', 'name',
-      'nsfw', 'nsfwLevel', 'poi', 'minor', 'sfwOnly', 'userId', 'model'];
+    const sensitiveAbsent = [
+      'availability',
+      'hasAccess',
+      'canGenerate',
+      'image',
+      'name',
+      'nsfw',
+      'nsfwLevel',
+      'poi',
+      'minor',
+      'sfwOnly',
+      'userId',
+      'model',
+    ];
     for (const k of sensitiveAbsent) expect(sel).not.toHaveProperty(k);
-    expect(Object.keys(sel).sort()).toEqual(
-      ['baseModel', 'clipSkip', 'maxStrength', 'minStrength', 'modelId', 'modelName',
-        'modelType', 'strength', 'trainedWords', 'versionId', 'versionName']
-    );
+    expect(Object.keys(sel).sort()).toEqual([
+      'baseModel',
+      'clipSkip',
+      'maxStrength',
+      'minStrength',
+      'modelId',
+      'modelName',
+      'modelType',
+      'strength',
+      'trainedWords',
+      'versionId',
+      'versionName',
+    ]);
     replies.stop();
   });
 
@@ -444,7 +468,11 @@ describe('PageBlockHost resource picker (Design 1 host-chrome)', () => {
     postFromBlock('OPEN_RESOURCE_PICKER', { requestId: 'rq_a', resourceType: 'Checkpoint' });
     await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
     lastResourceModalProps().onSelect(
-      fakeResource({ id: 111, baseModel: 'Flux.1 D', model: { id: 11, name: 'CK', type: 'Checkpoint' } as any })
+      fakeResource({
+        id: 111,
+        baseModel: 'Flux.1 D',
+        model: { id: 11, name: 'CK', type: 'Checkpoint' } as any,
+      })
     );
     await vi.waitFor(() => {
       const r = replies.last('RESOURCE_PICKER_RESULT');
@@ -456,7 +484,11 @@ describe('PageBlockHost resource picker (Design 1 host-chrome)', () => {
     postFromBlock('OPEN_RESOURCE_PICKER', { requestId: 'rq_b', resourceType: 'LORA' });
     await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
     lastResourceModalProps().onSelect(
-      fakeResource({ id: 222, baseModel: 'SDXL 1.0', model: { id: 22, name: 'LoRA', type: 'LORA' } as any })
+      fakeResource({
+        id: 222,
+        baseModel: 'SDXL 1.0',
+        model: { id: 22, name: 'LoRA', type: 'LORA' } as any,
+      })
     );
 
     await vi.waitFor(() => {

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -172,6 +172,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   // Pinned transport (internal) for deterministic delivery — reviewMode is
   // independent of trust tier. The opaque-origin path has its own test below.

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -120,6 +120,9 @@ const baseProps = {
   appName: 'Scroll Fit App',
   iframeSrc: SAME_ORIGIN_SRC,
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'scroll-fit-app',

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -140,6 +140,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -189,6 +189,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -125,6 +125,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -157,6 +157,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostThemeChange.browser.test.tsx
@@ -178,6 +178,9 @@ const baseProps = {
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -99,6 +99,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -77,7 +77,11 @@ vi.mock('~/utils/trpc', () => ({
           getCounts: { fetch: vi.fn() },
           get: { fetch: vi.fn() },
         },
-        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
       },
     }),
   },
@@ -100,7 +104,11 @@ function postFromBlock(type: string, payload?: unknown) {
   const cw = iframeEl.contentWindow;
   if (!cw) throw new Error('iframe contentWindow missing');
   window.dispatchEvent(
-    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
   );
 }
 
@@ -131,6 +139,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'wildcard-app',
@@ -180,7 +191,10 @@ describe('PageBlockHost wildcard-pack bridge (W13)', () => {
     // Harmless default so the BLOCK_READY analytics beacon (which also uses the
     // stubbed global fetch) gets a real Promise Response and never crashes the
     // test; each test overrides for the pack fetch.
-    mocks.fetch.mockResolvedValue({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) } as unknown as Response);
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as Response);
     vi.stubGlobal('fetch', mocks.fetch);
     useDialogStore.getState().closeAll();
   });
@@ -212,7 +226,10 @@ describe('PageBlockHost wildcard-pack bridge (W13)', () => {
       const payload = r.payload as { requestId: string; pack?: any; error?: string };
       expect(payload.requestId).toBe('rq_wp');
       expect(payload.error).toBeUndefined();
-      expect(payload.pack.lists).toEqual({ colors: ['red', 'blue', '#ffffff'], animals: ['cat', 'dog'] });
+      expect(payload.pack.lists).toEqual({
+        colors: ['red', 'blue', '#ffffff'],
+        animals: ['cat', 'dog'],
+      });
       expect(payload.pack.modelVersionId).toBe(100);
       expect(payload.pack.creatorUsername).toBe('creator');
       expect(payload.pack.maturity).toEqual(RESOLVED_MATURITY);

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -160,6 +160,9 @@ const baseProps = {
   iframeSrc: SAME_ORIGIN_SRC,
   // The public run surface. Required since the init-fragment gate keys on it.
   surface: 'page-run' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -423,10 +423,18 @@ export interface BlockManifest {
   name?: string;
   renderMode?: 'iframe' | 'inline' | 'hybrid';
   /**
-   * The app's shipped `index.html` paints its own themed boot state inside
-   * `#root`, so the run host stands down its branded veil and shows the iframe
-   * from mount. Declared here for discoverability — the index signature below
-   * would admit it anyway, which is exactly why it is easy to misspell.
+   * The app's shipped `index.html` paints its own boot state inside `#root`, so
+   * the run host stands down its branded veil and shows the iframe from mount.
+   *
+   * 🔴 NOT necessarily THEMED. To paint in the host's theme the app must also be
+   * enabled for the BLOCK_INIT URL fragment and read it before first paint; the
+   * allowlist is empty today, so a boot skeleton currently guesses from
+   * `prefers-color-scheme` and can disagree with the host until BLOCK_INIT
+   * lands. This is the type an author reads while writing a manifest, so the
+   * unqualified word "themed" is likeliest to be acted on here.
+   *
+   * Declared for discoverability — the index signature below would admit it
+   * anyway, which is exactly why it is easy to misspell.
    */
   bootSkeleton?: boolean;
   [key: string]: unknown;

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -422,6 +422,13 @@ export interface BlockManifest {
   contentRating?: string;
   name?: string;
   renderMode?: 'iframe' | 'inline' | 'hybrid';
+  /**
+   * The app's shipped `index.html` paints its own themed boot state inside
+   * `#root`, so the run host stands down its branded veil and shows the iframe
+   * from mount. Declared here for discoverability — the index signature below
+   * would admit it anyway, which is exactly why it is easy to misspell.
+   */
+  bootSkeleton?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -430,8 +430,14 @@ export interface BlockManifest {
    * enabled for the BLOCK_INIT URL fragment and read it before first paint; the
    * allowlist is empty today, so a boot skeleton currently guesses from
    * `prefers-color-scheme` and can disagree with the host until BLOCK_INIT
-   * lands. This is the type an author reads while writing a manifest, so the
-   * unqualified word "themed" is likeliest to be acted on here.
+  lands.
+   *
+   * (This type is HOST-INTERNAL — two consumers, both in this repo. The type an
+   * external app author actually reads is the canonical schema at
+   * `public/schemas/app-block/v1.json`, which already carries this
+   * qualification. Corrected here because the first version of this note
+   * claimed the opposite, and a wrong "this is the author-facing site" is the
+   * kind of sentence that later gets cited as coverage.)
    *
    * Declared for discoverability — the index signature below would admit it
    * anyway, which is exactly why it is easy to misspell.

--- a/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
@@ -25,10 +25,12 @@ vi.mock('~/components/AppBlocks/PageBlockHost', () => ({
     reviewRunForReal,
     canOpenPage,
     bootSkeleton,
+    trustTier,
   }: {
     reviewRunForReal?: boolean;
     canOpenPage?: boolean;
     bootSkeleton?: boolean;
+    trustTier?: string;
   }) => (
     <div
       data-testid="page-host"
@@ -42,6 +44,13 @@ vi.mock('~/components/AppBlocks/PageBlockHost', () => ({
       // reversible with a fully green gate — hardcoding `false` here again, or
       // dropping the key from the mint, killed nothing.
       data-boot-skeleton={String(!!bootSkeleton)}
+      // 🔴 The forced tier is DEFENCE LAYER 2 (this file's own header): it is
+      // what makes `intersectSandbox` drop `allow-same-origin`, so the review
+      // iframe runs at an opaque origin rather than the moderator's. It was
+      // unpinned — flipping it to 'internal' type-checks and survived 1151
+      // tests across every Apps browser suite. Pre-existing, closed here
+      // because the stub was open on the desk.
+      data-trust-tier={String(trustTier)}
     />
   ),
 }));
@@ -119,7 +128,10 @@ vi.mock('~/utils/trpc', async () => {
               mutate: (input: { publishRequestId: string; runForReal: boolean }) => {
                 mintCalls.inputs.push({ runForReal: input.runForReal });
                 const base = input.runForReal ? RUN_FOR_REAL_MINT : RENDER_ONLY_MINT;
-                setData({ ...base, bootSkeleton: mintCalls.bootSkeleton });
+                // `??` not a bare override: an unconditional overwrite makes the
+                // fixtures' own `bootSkeleton` field DEAD, so a future author who
+                // sets it there gets a silently-passing false result.
+                setData({ ...base, bootSkeleton: mintCalls.bootSkeleton ?? base.bootSkeleton });
               },
             };
           },
@@ -163,6 +175,10 @@ describe('ReviewBlockPreviewHost — run-for-real opt-in', () => {
     expect(page.getByTestId('page-host').element().getAttribute('data-boot-skeleton')).toBe(
       'false'
     );
+    // The forced-unverified tier, pinned for the first time.
+    expect(page.getByTestId('page-host').element().getAttribute('data-trust-tier')).toBe(
+      'unverified'
+    );
   });
 
   test('a mint that DECLARES bootSkeleton reaches the host', async () => {
@@ -170,9 +186,7 @@ describe('ReviewBlockPreviewHost — run-for-real opt-in', () => {
     mintCalls.bootSkeleton = true;
     mount();
     await expect.element(page.getByTestId('page-host')).toBeInTheDocument();
-    expect(page.getByTestId('page-host').element().getAttribute('data-boot-skeleton')).toBe(
-      'true'
-    );
+    expect(page.getByTestId('page-host').element().getAttribute('data-boot-skeleton')).toBe('true');
   });
 
   test('DEFAULT is render-only: host gets reviewRunForReal=false, no banner, opt-in offered', async () => {

--- a/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
@@ -71,6 +71,7 @@ const RENDER_ONLY_MINT: MintReviewBlockTokenResult = {
   blockInstanceId: 'page_pubreq_X',
   appName: 'My App',
   sandbox: 'allow-scripts',
+  bootSkeleton: false,
   runForReal: false,
   buzzCap: null,
 };

--- a/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
@@ -24,9 +24,11 @@ vi.mock('~/components/AppBlocks/PageBlockHost', () => ({
   PageBlockHost: ({
     reviewRunForReal,
     canOpenPage,
+    bootSkeleton,
   }: {
     reviewRunForReal?: boolean;
     canOpenPage?: boolean;
+    bootSkeleton?: boolean;
   }) => (
     <div
       data-testid="page-host"
@@ -35,6 +37,11 @@ vi.mock('~/components/AppBlocks/PageBlockHost', () => ({
       // must forward the VIEWER's `appBlocks && appBlocksPages`, not a
       // per-surface constant and not half the run route's predicate.
       data-can-open-page={String(!!canOpenPage)}
+      // Surfaced for the same reason: the moderator must review the SHIPPED
+      // presentation. Without this the whole review-preview plumbing was
+      // reversible with a fully green gate — hardcoding `false` here again, or
+      // dropping the key from the mint, killed nothing.
+      data-boot-skeleton={String(!!bootSkeleton)}
     />
   ),
 }));
@@ -87,7 +94,14 @@ const RUN_FOR_REAL_MINT: MintReviewBlockTokenResult = {
 // A REAL stateful useMutation stub: `mutate({ runForReal })` synchronously swaps
 // `data` between the two fixtures (mirrors a resolved re-mint), so the component
 // re-renders exactly as it would against the server.
-const mintCalls = vi.hoisted(() => ({ inputs: [] as Array<{ runForReal: boolean }> }));
+const mintCalls = vi.hoisted(() => ({
+  inputs: [] as Array<{ runForReal: boolean }>,
+  // Lets a test make the MINT declare bootSkeleton, which is the only way to
+  // prove the value travels manifest -> mint -> host rather than being a
+  // constant. Without a true case the negative one passes against a hardcoded
+  // `false`, which is exactly the state this coverage was missing.
+  bootSkeleton: false,
+}));
 vi.mock('~/utils/trpc', async () => {
   const React = await import('react');
   return {
@@ -104,7 +118,8 @@ vi.mock('~/utils/trpc', async () => {
               isError: false,
               mutate: (input: { publishRequestId: string; runForReal: boolean }) => {
                 mintCalls.inputs.push({ runForReal: input.runForReal });
-                setData(input.runForReal ? RUN_FOR_REAL_MINT : RENDER_ONLY_MINT);
+                const base = input.runForReal ? RUN_FOR_REAL_MINT : RENDER_ONLY_MINT;
+                setData({ ...base, bootSkeleton: mintCalls.bootSkeleton });
               },
             };
           },
@@ -119,6 +134,7 @@ import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost
 
 beforeEach(() => {
   mintCalls.inputs = [];
+  mintCalls.bootSkeleton = false;
   flagState.appBlocks = false;
   flagState.appBlocksPages = false;
 });
@@ -134,6 +150,31 @@ function mount() {
 }
 
 describe('ReviewBlockPreviewHost — run-for-real opt-in', () => {
+  test("forwards the app's OWN bootSkeleton so the moderator sees the shipped presentation", async () => {
+    // 🔴 THIS WAS UNGUARDED. The whole review-preview plumbing — the mint
+    // projection and this prop — was reversible with a fully green gate:
+    // hardcoding `false` here again, or dropping the key from the mint,
+    // killed nothing, because the stub above never surfaced it. Which put us
+    // back at a moderator approving a presentation the shipped app does not
+    // have: the defect the plumbing was added to fix.
+    mount();
+    await expect.element(page.getByTestId('page-host')).toBeInTheDocument();
+    // The default fixture does NOT declare it.
+    expect(page.getByTestId('page-host').element().getAttribute('data-boot-skeleton')).toBe(
+      'false'
+    );
+  });
+
+  test('a mint that DECLARES bootSkeleton reaches the host', async () => {
+    // The discriminating half: the value must travel, not be a constant.
+    mintCalls.bootSkeleton = true;
+    mount();
+    await expect.element(page.getByTestId('page-host')).toBeInTheDocument();
+    expect(page.getByTestId('page-host').element().getAttribute('data-boot-skeleton')).toBe(
+      'true'
+    );
+  });
+
   test('DEFAULT is render-only: host gets reviewRunForReal=false, no banner, opt-in offered', async () => {
     mount();
     // The mount effect mints render-only.

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -229,15 +229,9 @@ export function ReviewBlockPreviewHost({
         // Remount on a mode flip so the new (render-only ↔ run-for-real) token
         // re-handshakes the iframe cleanly instead of swapping a token mid-session.
         key={runForRealActive ? 'run-for-real' : 'render-only'}
-        // 🔴 EXPLICIT false, and it is a KNOWN GAP, not a decision that this
-        // surface should differ. The mint response does not carry the
-        // manifest's `bootSkeleton`, so a moderator reviewing an app that
-        // declares it sees the host veil while a user will not — the review
-        // preview is exactly where that divergence is most costly. Plumbing
-        // it needs a field on the mint output; until that lands this is
-        // false so the reviewer at least sees a defined, documented state
-        // rather than an accidental default.
-        bootSkeleton={false}
+        // The app's own declaration, from the manifest under review — so the
+        // moderator sees the presentation the approved app will actually have.
+        bootSkeleton={mintData.bootSkeleton === true}
         appBlockId={mintData.appBlockId}
         blockId={mintData.blockId}
         appId={mintData.appId}

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -143,8 +143,8 @@ export function ReviewBlockPreviewHost({
         >
           <Group justify="space-between" wrap="nowrap" gap="sm">
             <Text size="sm" fw={600}>
-              RUN FOR REAL is active — this UNAPPROVED app is running for real against YOUR
-              account and spending YOUR Buzz (capped at {buzzCap}). SFW enforced.
+              RUN FOR REAL is active — this UNAPPROVED app is running for real against YOUR account
+              and spending YOUR Buzz (capped at {buzzCap}). SFW enforced.
             </Text>
             <Button
               size="xs"
@@ -174,9 +174,9 @@ export function ReviewBlockPreviewHost({
         >
           <Stack gap="xs">
             <Text size="sm">
-              This runs an UNAPPROVED app for real against YOUR account and spends YOUR Buzz,
-              capped at {buzzCap}. SFW enforced. Generation, your own Buzz balance, and per-user
-              storage will use your real account; cross-user actions and money-out stay disabled.
+              This runs an UNAPPROVED app for real against YOUR account and spends YOUR Buzz, capped
+              at {buzzCap}. SFW enforced. Generation, your own Buzz balance, and per-user storage
+              will use your real account; cross-user actions and money-out stay disabled.
             </Text>
             <Group gap="xs">
               <Button
@@ -229,6 +229,15 @@ export function ReviewBlockPreviewHost({
         // Remount on a mode flip so the new (render-only ↔ run-for-real) token
         // re-handshakes the iframe cleanly instead of swapping a token mid-session.
         key={runForRealActive ? 'run-for-real' : 'render-only'}
+        // 🔴 EXPLICIT false, and it is a KNOWN GAP, not a decision that this
+        // surface should differ. The mint response does not carry the
+        // manifest's `bootSkeleton`, so a moderator reviewing an app that
+        // declares it sees the host veil while a user will not — the review
+        // preview is exactly where that divergence is most costly. Plumbing
+        // it needs a field on the mint output; until that lands this is
+        // false so the reviewer at least sees a defined, documented state
+        // rather than an accidental default.
+        bootSkeleton={false}
         appBlockId={mintData.appBlockId}
         blockId={mintData.blockId}
         appId={mintData.appId}

--- a/src/components/Apps/ReviewPreviewFit.browser.test.tsx
+++ b/src/components/Apps/ReviewPreviewFit.browser.test.tsx
@@ -160,6 +160,7 @@ const RENDER_ONLY_MINT: MintReviewBlockTokenResult = {
   blockInstanceId: 'page_pubreq_FIT',
   appName: 'Review Fit App',
   sandbox: 'allow-scripts',
+  bootSkeleton: false,
   runForReal: false,
   buzzCap: null,
 };

--- a/src/components/Apps/ReviewPreviewFit.browser.test.tsx
+++ b/src/components/Apps/ReviewPreviewFit.browser.test.tsx
@@ -205,6 +205,9 @@ const directHostProps = {
   appName: RENDER_ONLY_MINT.appName,
   iframeSrc: SAME_ORIGIN_SRC,
   surface: 'review-preview' as const,
+  // Required. These suites cover the DEFAULT (host-veil) presentation;
+  // the bootSkeleton path is covered in PageBlockHostLaunchReveal.
+  bootSkeleton: false,
   sandbox: RENDER_ONLY_MINT.sandbox,
   trustTier: 'unverified' as const,
   slug: RENDER_ONLY_MINT.blockId,

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -44,6 +44,8 @@ interface DevTunnelProps {
   scopes: string[];
   /** Set ONLY when an active tunnel exists — `https://<dev-host>/?dev=<token>`. */
   iframeSrc: string | null;
+  /** manifest.bootSkeleton — carried so the dev tunnel matches production. */
+  bootSkeleton: boolean;
   /** The assigned dev host (for the "no active tunnel" copy). */
   host: string | null;
 }
@@ -64,9 +66,8 @@ export const getServerSideProps = createServerSideProps<DevTunnelProps>({
         },
       };
     }
-    const { isAppBlocksDevTunnelEnabled, isAppBlocksDevTunnelUnsubmittedSpendEnabled } = await import(
-      '~/server/services/app-blocks-flag'
-    );
+    const { isAppBlocksDevTunnelEnabled, isAppBlocksDevTunnelUnsubmittedSpendEnabled } =
+      await import('~/server/services/app-blocks-flag');
     if (!(await isAppBlocksDevTunnelEnabled({ user }))) {
       return { notFound: true };
     }
@@ -130,6 +131,7 @@ export const getServerSideProps = createServerSideProps<DevTunnelProps>({
         sandbox: app.sandbox,
         scopes: app.scopes,
         iframeSrc,
+        bootSkeleton: app.bootSkeleton,
         host,
       },
     };
@@ -137,7 +139,18 @@ export const getServerSideProps = createServerSideProps<DevTunnelProps>({
 });
 
 export default function DevTunnelPage(props: DevTunnelProps) {
-  const { appBlockId, blockId, appId, appName, iframeSrc, sandbox, trustTier, scopes, host } = props;
+  const {
+    appBlockId,
+    blockId,
+    appId,
+    appName,
+    iframeSrc,
+    bootSkeleton,
+    sandbox,
+    trustTier,
+    scopes,
+    host,
+  } = props;
   const currentUser = useCurrentUser();
   const features = useFeatureFlags();
   const colorScheme = useComputedColorScheme('dark');
@@ -233,12 +246,10 @@ export default function DevTunnelPage(props: DevTunnelProps) {
             <Title order={3}>Can’t run this app in the dev tunnel</Title>
             <Alert color="red" variant="light">
               We couldn’t mint a dev token for <Code>{blockId}</Code>. This app isn’t runnable in
-              the dev tunnel — it may be suspended, pending review, or not owned by your account.
-              If you just started the tunnel, reload the page.
+              the dev tunnel — it may be suspended, pending review, or not owned by your account. If
+              you just started the tunnel, reload the page.
             </Alert>
-            <Text size="sm">
-              Restart your tunnel and reload if the problem persists:
-            </Text>
+            <Text size="sm">Restart your tunnel and reload if the problem persists:</Text>
             <Code block>civitai app dev:tunnel</Code>
           </Stack>
         ) : (
@@ -249,6 +260,7 @@ export default function DevTunnelPage(props: DevTunnelProps) {
             blockInstanceId={blockInstanceId}
             appName={appName}
             iframeSrc={iframeSrc}
+            bootSkeleton={bootSkeleton}
             // 🔴 The author dev tunnel. `resolveDevPageBlockForAuthor` applies NO
             // status filter, so this mounts ARBITRARY UNPUBLISHED code that no
             // query can enumerate. `blockInitFragmentEnabled` refuses this

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -42,6 +42,8 @@ interface PageProps {
   appName: string;
   pageTitle: string;
   iframeSrc: string;
+  /** manifest.bootSkeleton — the app paints its own boot state; the host stands back. */
+  bootSkeleton: boolean;
   sandbox: string;
   trustTier: 'unverified' | 'verified' | 'internal';
   slug: string;
@@ -122,6 +124,7 @@ export const getServerSideProps = createServerSideProps<PageProps>({
         appName: page.name,
         pageTitle: page.pageTitle,
         iframeSrc: page.iframeSrc,
+        bootSkeleton: page.bootSkeleton,
         sandbox: page.sandbox,
         trustTier: page.trustTier,
         slug: page.blockId,
@@ -142,6 +145,7 @@ function AppPage(props: PageProps) {
     appId,
     appName,
     iframeSrc,
+    bootSkeleton,
     sandbox,
     trustTier,
     slug,
@@ -343,6 +347,7 @@ function AppPage(props: PageProps) {
           blockInstanceId={blockInstanceId}
           appName={appName}
           iframeSrc={iframeSrc}
+          bootSkeleton={bootSkeleton}
           // The public full-page run surface.
           surface="page-run"
           // 🔴 THE DOUBLE-SCROLLBAR FIX, and it is only half of one — it is

--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -123,6 +123,47 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     );
   });
 
+  it('(d3) an owned-pending app surfaces its bootSkeleton so the DEV TUNNEL matches production', async () => {
+    // The dev tunnel is where an author checks their own app BEFORE approval —
+    // so hardcoding `false` here made the one surface built to show them the
+    // feature the one surface that could not. `pending.manifest` is already
+    // selected and already read for `scopes`; there was nothing to fetch.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
+      submittedByUserId: 555,
+      manifest: { scopes: [], bootSkeleton: true },
+    });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('my-pending', 555);
+    expect(res?.bootSkeleton).toBe(true);
+  });
+
+  it('(d4) the dev tunnel applies the SAME strict === true coercion', async () => {
+    // Publisher JSON. A truthy non-boolean must not switch a host behaviour on
+    // here either — the second coercion site the first round left untested.
+    for (const value of ['true', 1, {}, 'yes']) {
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+      mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
+        submittedByUserId: 555,
+        manifest: { scopes: [], bootSkeleton: value },
+      });
+      const res = await BlockRegistry.resolveDevPageBlockForAuthor('my-pending', 555);
+      expect(res?.bootSkeleton).toBe(false);
+    }
+  });
+
+  it('(d5) a brand-new (unclaimed) slug has no manifest, so it stays false', async () => {
+    // Control for d3: without it, d3 passing would not prove the manifest is
+    // what moved the value.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('brand-new', 555);
+    expect(res?.ephemeralSource).toBe('brand-new');
+    expect(res?.bootSkeleton).toBe(false);
+  });
+
   it('(d2) THE FIX: an owned-pending money app surfaces its budgeted scope (not the stale []) so the dev-page Generate gate is not falsely empty', async () => {
     // Regression guard for the "Grant access to generate" hang: pre-Phase-2 this
     // resolver hardcoded scopes:[], so the dev-page host told the block it had NO

--- a/src/server/services/__tests__/block-registry.resolve-page.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-page.test.ts
@@ -126,6 +126,40 @@ describe('BlockRegistry.resolvePageBlockBySlug — sandbox + scopes', () => {
     expect(res?.scopes).toEqual(['apps:storage:read', 'apps:storage:write']);
   });
 
+  // `bootSkeleton` makes the run host stand its branded veil down and show the
+  // iframe from mount. It is PUBLISHER-CONTROLLED JSON, so the coercion has to
+  // be strict — a truthy-but-not-boolean value must not switch a host behaviour
+  // on. These live in the UNIT tier deliberately: the browser suite that covers
+  // the rendering half is not run by CI (lint.yml excludes *.browser.test.tsx),
+  // so the coercion claim was previously untested in the only tier that gates.
+  it('bootSkeleton: true only for a literal boolean true', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: PAGE_MANIFEST({ bootSkeleton: true }), trustTier: 'verified' })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.bootSkeleton).toBe(true);
+  });
+
+  it('bootSkeleton: false when absent — the safe default', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.bootSkeleton).toBe(false);
+  });
+
+  it('bootSkeleton: a TRUTHY non-boolean does NOT enable it', async () => {
+    // The whole point of `=== true`. Each of these is truthy in JS, and each
+    // would otherwise let publisher JSON suppress the host's loading state.
+    for (const value of ['true', 'false', 1, {}, [], 'yes']) {
+      mockDbRead.appBlock.findFirst.mockResolvedValue(
+        pageRow({ manifest: PAGE_MANIFEST({ bootSkeleton: value }), trustTier: 'verified' })
+      );
+      const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+      expect(res?.bootSkeleton).toBe(false);
+    }
+  });
+
   it('returns scopes:[] when the manifest declares none', async () => {
     mockDbRead.appBlock.findFirst.mockResolvedValue(
       pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' })

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -366,8 +366,8 @@ export interface PageBlockSsr {
    *  column, set on approve). The SSR run-page gate 404s a mature (r/x) page app
    *  when the request host is not red-capable. NULL for pre-feature rows → SFW. */
   contentRating: string | null;
-  /** `manifest.bootSkeleton` — the app's shipped HTML paints its own themed boot
-   *  state, so the run host stands its veil down and shows the iframe from mount.
+  /** `manifest.bootSkeleton` — the app's shipped HTML paints its own boot state
+   *  (themed only if it also reads the BLOCK_INIT fragment; else a guess), so the run host stands its veil down and shows the iframe from mount.
    *  Publisher-controlled and read from the APPROVED manifest snapshot, so it is
    *  as trustworthy as the rest of that snapshot; the blast radius of a false
    *  declaration is cosmetic — a blank iframe on that app's own page. 🔴 Nothing
@@ -2091,9 +2091,22 @@ export class BlockRegistry {
     // keyCanSpend=true) is identical; the runtime author-flag re-check + per-call /
     // per-session / per-day Buzz caps remain the actual spend gates.
     let ephemeralScopes: string[] = [];
+    // 🔴 READ FROM THE PENDING MANIFEST. The dev tunnel is where an author
+    // checks their own app BEFORE approval, so hardcoding `false` here made the
+    // one surface that exists to show them the feature the one surface that
+    // could not — they set the flag, opened /apps/dev/<blockId>, saw the host
+    // veil and would reasonably conclude it does nothing. `pending.manifest` is
+    // already selected and already read below for `scopes`; there was nothing
+    // to fetch.
+    let ephemeralBootSkeleton = false;
     const ephemeralSource: 'pending' | 'brand-new' = pending ? 'pending' : 'brand-new';
     if (pending) {
-      const pendingManifest = (pending.manifest ?? {}) as { scopes?: unknown };
+      const pendingManifest = (pending.manifest ?? {}) as {
+        scopes?: unknown;
+        bootSkeleton?: unknown;
+      };
+      // Same strict `=== true` as every other read of this field.
+      ephemeralBootSkeleton = pendingManifest.bootSkeleton === true;
       const declared = Array.isArray(pendingManifest.scopes)
         ? pendingManifest.scopes.filter((s): s is string => typeof s === 'string')
         : [];
@@ -2113,11 +2126,12 @@ export class BlockRegistry {
       appBlockId: `ephemeral-${blockId}`,
       blockId,
       appId: `ephemeral-${blockId}`,
-      // No stored manifest on this path (unclaimed slug, or a pending request
-      // whose manifest is not the approved snapshot), so there is nothing to
-      // read a declaration from. False keeps the host veil, which is the safe
-      // side: it shows SOMETHING rather than trusting an empty #root.
-      bootSkeleton: false,
+      // From the PENDING manifest when there is one (an author's submitted app,
+      // pre-approval — the case the dev tunnel exists for). A truly unclaimed
+      // slug has no manifest at all and stays false, which keeps the host veil:
+      // the safe side, since it shows SOMETHING rather than trusting an empty
+      // #root.
+      bootSkeleton: ephemeralBootSkeleton,
       status: 'ephemeral',
       trustTier: 'unverified',
       name: blockId,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -12,10 +12,7 @@ import {
 } from '~/server/services/blocks/checkpoint.service';
 import { validateBlockSettings } from '~/server/services/blocks/settings-validator.service';
 import { clampTunnelDeclaredScopes } from '~/server/services/blocks/dev-scoped-mint.service';
-import {
-  newBlockInstanceId,
-  newBlockUserSubscriptionId,
-} from '~/server/utils/app-block-ids';
+import { newBlockInstanceId, newBlockUserSubscriptionId } from '~/server/utils/app-block-ids';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -42,7 +39,10 @@ import {
   invalidateAppCapLimits,
   normalizeCapOverrideInput,
 } from '~/server/services/blocks/app-cap-limits.service';
-import { toPublicBlockManifest, toPublicScreenshots } from '~/server/schema/blocks/subscription.schema';
+import {
+  toPublicBlockManifest,
+  toPublicScreenshots,
+} from '~/server/schema/blocks/subscription.schema';
 import { isLaunchSlot, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
 import { isMatureContentRating } from '~/server/utils/server-domain';
 
@@ -366,6 +366,13 @@ export interface PageBlockSsr {
    *  column, set on approve). The SSR run-page gate 404s a mature (r/x) page app
    *  when the request host is not red-capable. NULL for pre-feature rows → SFW. */
   contentRating: string | null;
+  /** `manifest.bootSkeleton` — the app's shipped HTML paints its own themed boot
+   *  state, so the run host stands its veil down and shows the iframe from mount.
+   *  Publisher-controlled and read from the APPROVED manifest snapshot, so it is
+   *  as trustworthy as the rest of that snapshot; the blast radius of a false
+   *  declaration is cosmetic (a blank iframe on that app's own page), and the
+   *  platform build refuses a build that declares it with an empty `#root`. */
+  bootSkeleton: boolean;
 }
 
 /**
@@ -1237,9 +1244,7 @@ export class BlockRegistry {
     if (!pinned) return live;
     const manifest = (pinned.manifest ?? {}) as Record<string, unknown>;
     const scopes = Array.isArray((manifest as { scopes?: unknown }).scopes)
-      ? ((manifest as { scopes: unknown[] }).scopes.filter(
-          (s): s is string => typeof s === 'string'
-        ))
+      ? (manifest as { scopes: unknown[] }).scopes.filter((s): s is string => typeof s === 'string')
       : [];
     return { manifest, approvedScopes: scopes };
   }
@@ -1847,9 +1852,10 @@ export class BlockRegistry {
     // gate on `typeof iframe.src === 'string'` was misleading (sandbox presence
     // has nothing to do with src being a string). Harmless before (src/sandbox
     // are written together) but wrong; gate on the field actually being read.
-    const sandbox = typeof iframe === 'object' && iframe !== null
-      ? (iframe as { sandbox?: unknown }).sandbox
-      : '';
+    const sandbox =
+      typeof iframe === 'object' && iframe !== null
+        ? (iframe as { sandbox?: unknown }).sandbox
+        : '';
     const page = (manifest.page ?? {}) as { title?: unknown; icon?: unknown };
     const name = typeof manifest.name === 'string' ? manifest.name : ab.blockId;
     // #3/#6: surface the page's declared scopes so the host can compute the
@@ -1857,15 +1863,16 @@ export class BlockRegistry {
     // IframeHost. Money/spend scopes are rejected at mint for a page, so this is
     // effectively the consent-exempt ambient set (apps:storage:*) once approved.
     const declaredScopes = Array.isArray((manifest as { scopes?: unknown }).scopes)
-      ? ((manifest as { scopes: unknown[] }).scopes.filter(
-          (s): s is string => typeof s === 'string'
-        ))
+      ? (manifest as { scopes: unknown[] }).scopes.filter((s): s is string => typeof s === 'string')
       : [];
     return {
       appBlockId: ab.id,
       blockId: ab.blockId,
       appId: ab.appId,
       iframeSrc,
+      // STRICT `=== true`: the manifest is publisher JSON, so a truthy-but-not-
+      // boolean value ("false", 0, {}) must not enable a host behaviour change.
+      bootSkeleton: (manifest as { bootSkeleton?: unknown }).bootSkeleton === true,
       sandbox: typeof sandbox === 'string' ? sandbox : '',
       // #2: use the COLUMN (authoritative), never `manifest.trustTier`.
       trustTier:
@@ -2269,16 +2276,14 @@ export class BlockRegistry {
     manifest: Record<string, unknown>;
     approvedScopes: string[];
   }): Promise<void> {
-    const { recordScopeGrant, consentGatedScopes } = await import(
-      './blocks/scope-grant.service'
-    );
+    const { recordScopeGrant, consentGatedScopes } = await import('./blocks/scope-grant.service');
     // The app's effective scope set = manifest.scopes ∩ approvedScopes (the
     // moderator-approved snapshot is the ceiling). Grant only the consent-
     // gated subset of that — exempt scopes never need a grant.
     const manifestScopes = Array.isArray((opts.manifest as { scopes?: unknown }).scopes)
-      ? ((opts.manifest as { scopes: unknown[] }).scopes.filter(
+      ? (opts.manifest as { scopes: unknown[] }).scopes.filter(
           (s): s is string => typeof s === 'string'
-        ))
+        )
       : [];
     const approved = new Set(opts.approvedScopes ?? []);
     const effective = manifestScopes.filter((s) => approved.has(s));
@@ -2718,9 +2723,7 @@ export class BlockRegistry {
         row.targetModelIds && row.targetModelIds.length > 0 ? row.targetModelIds : null;
       const pinnedModelNames =
         targetIds !== null
-          ? Object.fromEntries(
-              targetIds.map((id) => [id, modelNameById.get(id) ?? `Model ${id}`])
-            )
+          ? Object.fromEntries(targetIds.map((id) => [id, modelNameById.get(id) ?? `Model ${id}`]))
           : null;
       return {
         id: row.id,
@@ -2928,10 +2931,7 @@ export class BlockRegistry {
    * the row doesn't exist (idempotent for retries) but raises authorization
    * when the row exists and belongs to someone else.
    */
-  static async deleteSubscription(opts: {
-    subscriptionId: string;
-    userId: number;
-  }): Promise<void> {
+  static async deleteSubscription(opts: { subscriptionId: string; userId: number }): Promise<void> {
     const existing = await dbWrite.blockUserSubscription.findUnique({
       where: { id: opts.subscriptionId },
       select: { userId: true },
@@ -2998,9 +2998,7 @@ export class BlockRegistry {
       // nextCursor for a stable keyset scan. Text so one column fits all sorts.
       sort_key: string;
     };
-    const slotFilter = slotId
-      ? `{"targets":[{"slotId":"${slotId}"}]}`
-      : null;
+    const slotFilter = slotId ? `{"targets":[{"slotId":"${slotId}"}]}` : null;
     const queryLike = query ? `%${query.toLowerCase()}%` : null;
     const categoryFilter = category ?? null;
 
@@ -3353,7 +3351,7 @@ export class BlockRegistry {
                install_count DESC,
                ab.id ASC
       LIMIT ${limit}
-    ` ) as Row[];
+    `) as Row[];
     // Project to the SAME public allowlist as listAvailable (no widening).
     return rows.map((r) => ({
       id: r.id,
@@ -3425,17 +3423,12 @@ export class BlockRegistry {
    * Returns the updated MarketplaceMeta. Throws NOT_FOUND for a missing app and
    * BAD_REQUEST for an off-taxonomy category or featuring a non-approved app.
    */
-  static async setMarketplaceMeta(
-    input: SetMarketplaceMetaInput
-  ): Promise<MarketplaceMeta> {
+  static async setMarketplaceMeta(input: SetMarketplaceMetaInput): Promise<MarketplaceMeta> {
     const { appBlockId, category, featured, featuredOrder } = input;
 
     // Taxonomy belt (router already enums it; re-assert so no off-taxonomy value
     // can ever be written by any caller).
-    if (
-      category != null &&
-      !(MARKETPLACE_CATEGORIES as readonly string[]).includes(category)
-    ) {
+    if (category != null && !(MARKETPLACE_CATEGORIES as readonly string[]).includes(category)) {
       throwBadRequestError(`Unknown marketplace category: ${category}`);
     }
 
@@ -3448,9 +3441,7 @@ export class BlockRegistry {
     // Approved-only featuring: refuse to feature anything not approved (it would
     // otherwise appear in the anon-capable featured rail).
     if (featured === true && existing!.status !== 'approved') {
-      throwBadRequestError(
-        `Only an approved app can be featured (status="${existing!.status}").`
-      );
+      throwBadRequestError(`Only an approved app can be featured (status="${existing!.status}").`);
     }
 
     // Build the patch from ONLY the provided fields — an omitted (undefined)

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -370,8 +370,10 @@ export interface PageBlockSsr {
    *  state, so the run host stands its veil down and shows the iframe from mount.
    *  Publisher-controlled and read from the APPROVED manifest snapshot, so it is
    *  as trustworthy as the rest of that snapshot; the blast radius of a false
-   *  declaration is cosmetic (a blank iframe on that app's own page), and the
-   *  platform build refuses a build that declares it with an empty `#root`. */
+   *  declaration is cosmetic — a blank iframe on that app's own page. 🔴 Nothing
+   *  validates it yet: no strict manifest schema rejects it and no build check
+   *  exists, so a declaration over an empty `#root` reaches production. A
+   *  platform-build check is planned (talos-infra). */
   bootSkeleton: boolean;
 }
 
@@ -390,6 +392,11 @@ export interface DevPageBlockResolution {
   blockId: string;
   appId: string;
   status: string;
+  /** `manifest.bootSkeleton` — carried so the AUTHOR's dev tunnel renders the
+   *  same presentation a user will get. Without it the dev route showed the
+   *  host veil while production stood it down, i.e. the one surface an author
+   *  checks was the one that could not show them the feature. */
+  bootSkeleton: boolean;
   trustTier: 'unverified' | 'verified' | 'internal';
   name: string;
   pageTitle: string;
@@ -1973,6 +1980,8 @@ export class BlockRegistry {
       pageTitle: typeof page.title === 'string' ? page.title : name,
       sandbox: typeof iframe.sandbox === 'string' ? iframe.sandbox : '',
       scopes: declaredScopes,
+      // Same strict `=== true` as the SSR projection: publisher JSON.
+      bootSkeleton: (manifest as { bootSkeleton?: unknown }).bootSkeleton === true,
       contentRating: typeof ab.contentRating === 'string' ? ab.contentRating : null,
     };
   }
@@ -2104,6 +2113,11 @@ export class BlockRegistry {
       appBlockId: `ephemeral-${blockId}`,
       blockId,
       appId: `ephemeral-${blockId}`,
+      // No stored manifest on this path (unclaimed slug, or a pending request
+      // whose manifest is not the approved snapshot), so there is nothing to
+      // read a declaration from. False keeps the host veil, which is the safe
+      // side: it shows SOMETHING rather than trusting an empty #root.
+      bootSkeleton: false,
       status: 'ephemeral',
       trustTier: 'unverified',
       name: blockId,

--- a/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
@@ -157,6 +157,46 @@ describe('mintReviewBlockToken', () => {
     expect(res.appName).toBe('plain-app'); // falls back to slug
   });
 
+  it('carries the manifest bootSkeleton so the moderator reviews the SHIPPED presentation', async () => {
+    // Render fidelity, same class as `sandbox` above: the review preview mounts
+    // the real PageBlockHost, so a declaration the approved app will honour must
+    // reach it. Without this the moderator approves a presentation the shipped
+    // app does not have — and the projection was reversible with a green gate.
+    mockFindUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'pending',
+      slug: 'boot-app',
+      manifest: { scopes: ['models:read:self'], bootSkeleton: true },
+    });
+    const res = await mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID });
+    expect(res.bootSkeleton).toBe(true);
+  });
+
+  it('bootSkeleton defaults to false, and a TRUTHY non-boolean does not enable it', async () => {
+    // Publisher JSON on an UNREVIEWED manifest — the strictest place for the
+    // `=== true` coercion, since this value is read before any moderator has
+    // looked at it.
+    for (const [manifestValue, expected] of [
+      [undefined, false],
+      ['true', false],
+      [1, false],
+      [{}, false],
+      [true, true],
+    ] as const) {
+      mockFindUnique.mockResolvedValue({
+        id: PUBREQ,
+        status: 'pending',
+        slug: 'boot-app',
+        manifest:
+          manifestValue === undefined
+            ? { scopes: [] }
+            : { scopes: [], bootSkeleton: manifestValue },
+      });
+      const res = await mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID });
+      expect(res.bootSkeleton).toBe(expected);
+    }
+  });
+
   it('THROWS for a missing request (no oracle) and never signs', async () => {
     mockFindUnique.mockResolvedValue(null);
     await expect(

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -4465,6 +4465,11 @@ export type MintReviewBlockTokenResult = {
   /** The pending manifest's declared iframe sandbox (render fidelity). trustTier is
    *  forced 'unverified' at the host → allow-same-origin is dropped regardless. */
   sandbox: string;
+  /** The pending manifest's `bootSkeleton` (render fidelity, same reason as
+   *  `sandbox`): the app paints its own loading state, so the review host must
+   *  stand its veil down exactly as the run page will. Without this a moderator
+   *  approved against a presentation the shipped app does not have. */
+  bootSkeleton: boolean;
   /**
    * MOD REVIEW SANDBOX "run for real" (#2831) — true iff this token was minted
    * with `runForReal:true` (a mod's consent-gated opt-in to run the unapproved app
@@ -4555,6 +4560,13 @@ export async function mintReviewBlockToken(opts: {
     ? manifest.scopes.filter((s): s is string => typeof s === 'string')
     : [];
   const manifestName = typeof manifest.name === 'string' ? manifest.name : row.slug;
+  // 🔴 Carried so the MODERATOR reviews the presentation a user will get. The
+  // review preview mounts the real PageBlockHost; without this it rendered the
+  // host veil while the approved app will not, i.e. the one person deciding
+  // whether to ship it saw a different app. `manifest` is already loaded and
+  // already projected for name/sandbox/scopes — the key was simply omitted.
+  // Same strict `=== true` as every other read: publisher JSON.
+  const manifestBootSkeleton = (manifest as { bootSkeleton?: unknown }).bootSkeleton === true;
   const manifestSandbox =
     manifest.iframe && typeof manifest.iframe.sandbox === 'string'
       ? manifest.iframe.sandbox
@@ -4664,6 +4676,7 @@ export async function mintReviewBlockToken(opts: {
     blockInstanceId: `page_${row.id}`,
     appName: manifestName,
     sandbox: manifestSandbox,
+    bootSkeleton: manifestBootSkeleton,
     runForReal,
     buzzCap: runForReal ? REVIEW_RUN_FOR_REAL_BUZZ_CAP : null,
   };


### PR DESCRIPTION
Phase 1 of making the loading state come from the **app**, so hydration changes nothing: same theme, same geometry, no cross-fade, no settle.

## Why a host-drawn skeleton can't get there

#4549 gave `/apps/run` a shimmer skeleton, and it is a real improvement over the spinner — but it renders in the **host's** Mantine theme with **generic** geometry, then cross-fades to the app's own layout. That is a theme change and a layout shift by construction. Only a skeleton shipped by the app can be identical to the thing that replaces it.

## What was stopping an app from doing it

Three things hid an app-painted boot state, and standing down any two still leaves it unseen:

1. the branded veil — opaque, `inset: 0`, until `BLOCK_READY`
2. the **iframe itself** — `opacity: 0` until `BLOCK_READY`
3. the reveal `translateY(8px)` settle — which *is* a layout shift, at exactly the moment an app-painted skeleton exists to avoid one

`manifest.bootSkeleton: true` stands down all three, for that app only.

## Why it's opt-in, not the default

No veil plus an empty `#root` is a blank white iframe for 300–1200ms — worse than what the veil was doing. So **not** declaring it stays safe, and #4549's host skeleton remains the fallback for every app that doesn't opt in. A follow-up in the platform build refuses a build that declares `bootSkeleton` with an empty `#root`, so the claim can't rot into that blank iframe.

`pointerEvents` is deliberately **not** opted out — a skeleton isn't interactive and the block must stay inert until it holds a token.

Read from the approved manifest snapshot and coerced with a strict `=== true`, so publisher JSON carrying `"false"` / `0` / `{}` can't switch host behaviour on. A false declaration is cosmetic and scoped to that app's own page.

**This PR is inert** — no app declares the field yet.

## Tests

Three guards, one per behaviour, so a failure names *which* one regressed rather than "the contract broke" — the first draft asserted all three in one test and three different mutants all killed the same test. Plus a guard on the safe default.

| mutant | kills |
|---|---|
| veil-skip removed | only the veil test |
| `opacity: 0` restored | only the visibility test |
| `translateY` settle restored | only the transform test |
| prop default flipped to `true` | 9 tests, incl. the safe-default guard |

62/62 across LaunchReveal + PageBlockHost + AutoRetry · 49/49 across four schema-drift/gate unit suites · typecheck 0 · prettier clean · eslint unchanged (the two pre-existing `no-wholesale-module-mock` errors).

## Deliberately not here

The block is **not** added to `BLOCK_INIT_FRAGMENT_ALLOWLIST`. That gate's own rule is that an entry goes in only once the block ships an SDK that decodes the fragment, and `generate-from-model` still pins `@civitai/app-sdk ^0.7.0`. The decoder *has* shipped (`parseBlockInitFragment`, `app-sdk@0.36.0`) — that's what makes exact host-theme-at-parse-time possible — so the allowlist entry lands with the block's SDK bump.

Follow-ups: block-side rebuild (SDK bump + fragment read + `bootSkeleton: true` + bars reshaped toward the real UI), the platform build gate, and the byte-identical vendored schema sync in `civitai-app-starters` and `cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2wcms7C2Lg9GrHPmBz8oH
