### PR TITLE
perf(shop): stop shop grids fetching every card's artwork on first paint

### DIFF
--- a/src/components/CreatorShop/Pack/PackCoverTiles.tsx
+++ b/src/components/CreatorShop/Pack/PackCoverTiles.tsx
@@ -14,12 +14,15 @@ export function PackCoverTiles({
   size = 256,
   className,
   fallbackIcon,
+  lazy,
 }: {
   tiles: string[];
   size?: number;
   className?: string;
   /** Render a package icon rather than nothing when there are no tiles. */
   fallbackIcon?: boolean;
+  /** Defer the fetch until near the viewport — see `CosmeticSample`. */
+  lazy?: boolean;
 }) {
   const shown = tiles.slice(0, 4);
   // Members without artwork (a NamePlate has no `url`) can leave a pack with no
@@ -46,6 +49,7 @@ export function PackCoverTiles({
             src={url}
             width={single ? size : Math.floor(size / 2)}
             alt=""
+            loading={lazy ? 'lazy' : undefined}
             className="max-h-full max-w-full object-contain"
           />
         </div>

--- a/src/components/Shop/CosmeticSample.tsx
+++ b/src/components/Shop/CosmeticSample.tsx
@@ -111,11 +111,9 @@ export const CosmeticSample = ({
             type={backgroundData.type}
             anim={true}
             width={450}
-            // Inert when `type` is video: EdgeMedia spreads imgProps into EdgeImage only, so
-            // EdgeVideo never sees this. Its poster is eager unconditionally, and the video
-            // itself is preload="none" everywhere EXCEPT Safari, which forces 'auto'. So the
-            // video path is not already-cheap on Safari. 17 of 24 live ProfileBackgrounds
-            // are video-typed (measured 2026-09-01; re-measure before relying on it).
+            // Inert when `type` is video: EdgeMedia spreads imgProps into EdgeImage only,
+            // so EdgeVideo never sees this. Its poster is eager regardless, and the video is
+            // preload="none" except on Safari, which forces 'auto'.
             loading={loading}
             style={{
               objectFit: 'cover',

--- a/src/components/Shop/CosmeticSample.tsx
+++ b/src/components/Shop/CosmeticSample.tsx
@@ -111,6 +111,9 @@ export const CosmeticSample = ({
             type={backgroundData.type}
             anim={true}
             width={450}
+            // Inert when `type` is video: EdgeMedia spreads imgProps into EdgeImage only, so
+            // EdgeVideo never sees this. The video itself is already preload="none"; its
+            // poster stays eager. 17 of 24 live ProfileBackgrounds are video-typed.
             loading={loading}
             style={{
               objectFit: 'cover',

--- a/src/components/Shop/CosmeticSample.tsx
+++ b/src/components/Shop/CosmeticSample.tsx
@@ -112,8 +112,10 @@ export const CosmeticSample = ({
             anim={true}
             width={450}
             // Inert when `type` is video: EdgeMedia spreads imgProps into EdgeImage only, so
-            // EdgeVideo never sees this. The video itself is already preload="none"; its
-            // poster stays eager. 17 of 24 live ProfileBackgrounds are video-typed.
+            // EdgeVideo never sees this. Its poster is eager unconditionally, and the video
+            // itself is preload="none" everywhere EXCEPT Safari, which forces 'auto'. So the
+            // video path is not already-cheap on Safari. 17 of 24 live ProfileBackgrounds
+            // are video-typed (measured 2026-09-01; re-measure before relying on it).
             loading={loading}
             style={{
               objectFit: 'cover',

--- a/src/components/Shop/CosmeticSample.tsx
+++ b/src/components/Shop/CosmeticSample.tsx
@@ -24,11 +24,21 @@ const cosmeticSampleSizeMap: Record<
 export const CosmeticSample = ({
   cosmetic,
   size = 'sm',
+  lazy,
 }: {
   cosmetic: Pick<CosmeticGetById, 'id' | 'data' | 'type' | 'name'>;
   size?: 'sm' | 'md' | 'lg';
+  /**
+   * Defer the fetch until the sample is near the viewport. Opt-in, because most
+   * callers are pickers and modals showing a handful of samples the user asked
+   * for; the shop grids render a whole section at once and are the reason this
+   * exists. Above-the-fold cards are unaffected — a lazy image already in the
+   * viewport is fetched immediately.
+   */
+  lazy?: boolean;
 }) => {
   const values = cosmeticSampleSizeMap[size];
+  const loading = lazy ? ('lazy' as const) : undefined;
 
   switch (cosmetic.type) {
     case CosmeticType.Badge:
@@ -38,7 +48,12 @@ export const CosmeticSample = ({
 
       return (
         <div style={{ width: values.badgeSize }}>
-          <EdgeMedia src={decorationData.url} alt={cosmetic.name} width={values.badgeSize} />
+          <EdgeMedia
+            src={decorationData.url}
+            alt={cosmetic.name}
+            width={values.badgeSize}
+            loading={loading}
+          />
         </div>
       );
     case CosmeticType.ContentDecoration:
@@ -66,6 +81,7 @@ export const CosmeticSample = ({
           alt={stickerData.slug ? `:${stickerData.slug}:` : cosmetic.name}
           width={values.badgeSize}
           anim={stickerData.animated}
+          loading={loading}
           style={{ width: values.badgeSize, height: values.badgeSize, objectFit: 'contain' }}
         />
       );
@@ -95,6 +111,7 @@ export const CosmeticSample = ({
             type={backgroundData.type}
             anim={true}
             width={450}
+            loading={loading}
             style={{
               objectFit: 'cover',
               // objectPosition: 'right bottom',

--- a/src/components/Shop/ShopItem.tsx
+++ b/src/components/Shop/ShopItem.tsx
@@ -199,23 +199,17 @@ export const ShopItem = ({
             <div className={classes.cardHeader}>
               <div className={clsx(classes.sampleWrapper, outOfStock && classes.dim)}>
                 {/*
-                  Shop grids render this card unvirtualised, so every card they paint fetches
-                  its `<img>` up front. Bounded, though — /shop and the storefront cosmetics
-                  grid page at `COSMETIC_SHOP_DEFAULT_PAGE_SIZE` (24), which the reader can
-                  raise to 48 via `COSMETIC_SHOP_PAGE_SIZES`; featured sections cap at 6, and
-                  the homepage block slices to `maxItems` (6 over a 4-item section, measured
-                  2026-09-01). So this is worth 24-48 cards at a time, not a whole 94-row
-                  section. These are catalogue-side numbers — re-measure before relying on
-                  them.
-
-                  Animated artwork is what makes even 24 expensive: measured 2026-09-01, an
-                  animated cover is 1.7-4.6 MB at width=450 against 43.8 KB for a static one,
-                  because resizing an animated WebP barely compresses it.
+                  Shop grids render this card unvirtualised, so each one fetches its `<img>`
+                  up front. Deferring here rather than at EdgeImage: that component backs
+                  every image on the site, and no `loading="eager"` opt-out exists in the
+                  tree to escape a flipped default with.
 
                   Covers the `<img>` branches only. A ContentDecoration paints its artwork as
-                  a CSS `background-image` (TwCosmeticWrapper's `--bgImage`), which no
-                  `loading` attribute can defer — measured 2026-09-01, 0 of the 92 placed
-                  ContentDecoration items carry a `texture.url`, so today that costs nothing.
+                  a CSS `background-image` (TwCosmeticWrapper's `--bgImage`), and a
+                  video-typed ProfileBackground routes to EdgeVideo, which never receives
+                  imgProps — neither is reachable by a `loading` attribute. Sizes and counts
+                  are in PR #4565; they are catalogue-side and decay, so they are not pinned
+                  here.
                 */}
                 {cosmetic ? (
                   <CosmeticSample cosmetic={cosmetic} size="lg" lazy />

--- a/src/components/Shop/ShopItem.tsx
+++ b/src/components/Shop/ShopItem.tsx
@@ -198,12 +198,19 @@ export const ShopItem = ({
           >
             <div className={classes.cardHeader}>
               <div className={clsx(classes.sampleWrapper, outOfStock && classes.dim)}>
+                {/*
+                  Every shop grid renders this card unvirtualised — the largest live section
+                  is 94 items — so without `lazy` the whole section's artwork is fetched on
+                  first paint. Animated cosmetics and covers are the expensive ones: measured
+                  2026-09-01, an animated cover is 1.7-4.6 MB at width=450 against 43.8 KB for
+                  a static one, because resizing an animated WebP barely compresses it.
+                */}
                 {cosmetic ? (
-                  <CosmeticSample cosmetic={cosmetic} size="lg" />
+                  <CosmeticSample cosmetic={cosmetic} size="lg" lazy />
                 ) : itemMeta.coverUrl ? (
-                  <EdgeMedia src={itemMeta.coverUrl} width={450} alt={item.title} />
+                  <EdgeMedia src={itemMeta.coverUrl} width={450} alt={item.title} loading="lazy" />
                 ) : (
-                  <PackCoverTiles tiles={itemMeta.coverTiles ?? []} size={220} fallbackIcon />
+                  <PackCoverTiles tiles={itemMeta.coverTiles ?? []} size={220} fallbackIcon lazy />
                 )}
               </div>
               <Text size="xs" c="dimmed" px={6} component="div" className={classes.type}>

--- a/src/components/Shop/ShopItem.tsx
+++ b/src/components/Shop/ShopItem.tsx
@@ -200,11 +200,13 @@ export const ShopItem = ({
               <div className={clsx(classes.sampleWrapper, outOfStock && classes.dim)}>
                 {/*
                   Shop grids render this card unvirtualised, so every card they paint fetches
-                  its `<img>` up front. Bounded, though — `COSMETIC_SHOP_PAGE_SIZES` pages
-                  /shop and the storefront cosmetics grid at 24, featured sections cap at 6,
-                  and the homepage block slices to `maxItems` (6 over a 4-item section,
-                  measured 2026-09-01). So this is worth ~24 cards at a time, not a whole
-                  94-row section.
+                  its `<img>` up front. Bounded, though — /shop and the storefront cosmetics
+                  grid page at `COSMETIC_SHOP_DEFAULT_PAGE_SIZE` (24), which the reader can
+                  raise to 48 via `COSMETIC_SHOP_PAGE_SIZES`; featured sections cap at 6, and
+                  the homepage block slices to `maxItems` (6 over a 4-item section, measured
+                  2026-09-01). So this is worth 24-48 cards at a time, not a whole 94-row
+                  section. These are catalogue-side numbers — re-measure before relying on
+                  them.
 
                   Animated artwork is what makes even 24 expensive: measured 2026-09-01, an
                   animated cover is 1.7-4.6 MB at width=450 against 43.8 KB for a static one,

--- a/src/components/Shop/ShopItem.tsx
+++ b/src/components/Shop/ShopItem.tsx
@@ -199,11 +199,21 @@ export const ShopItem = ({
             <div className={classes.cardHeader}>
               <div className={clsx(classes.sampleWrapper, outOfStock && classes.dim)}>
                 {/*
-                  Every shop grid renders this card unvirtualised — the largest live section
-                  is 94 items — so without `lazy` the whole section's artwork is fetched on
-                  first paint. Animated cosmetics and covers are the expensive ones: measured
-                  2026-09-01, an animated cover is 1.7-4.6 MB at width=450 against 43.8 KB for
-                  a static one, because resizing an animated WebP barely compresses it.
+                  Shop grids render this card unvirtualised, so every card they paint fetches
+                  its `<img>` up front. Bounded, though — `COSMETIC_SHOP_PAGE_SIZES` pages
+                  /shop and the storefront cosmetics grid at 24, featured sections cap at 6,
+                  and the homepage block slices to `maxItems` (6 over a 4-item section,
+                  measured 2026-09-01). So this is worth ~24 cards at a time, not a whole
+                  94-row section.
+
+                  Animated artwork is what makes even 24 expensive: measured 2026-09-01, an
+                  animated cover is 1.7-4.6 MB at width=450 against 43.8 KB for a static one,
+                  because resizing an animated WebP barely compresses it.
+
+                  Covers the `<img>` branches only. A ContentDecoration paints its artwork as
+                  a CSS `background-image` (TwCosmeticWrapper's `--bgImage`), which no
+                  `loading` attribute can defer — measured 2026-09-01, 0 of the 92 placed
+                  ContentDecoration items carry a `texture.url`, so today that costs nothing.
                 */}
                 {cosmetic ? (
                   <CosmeticSample cosmetic={cosmetic} size="lg" lazy />

--- a/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
+++ b/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
@@ -14,6 +14,8 @@ vi.mock('~/providers/BrowserSettingsProvider', () => ({
 }));
 
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { CosmeticSample } from '~/components/Shop/CosmeticSample';
 
 const repoRoot = path.resolve(__dirname, '../../../..');
 const read = (relative: string) =>
@@ -30,11 +32,26 @@ function renderImage(props: Record<string, unknown>) {
   return container.querySelector('img');
 }
 
+function renderMedia(props: Record<string, unknown>) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      createElement(EdgeMedia, { src: 'abc-123', width: 450, ...props } as never)
+    );
+  });
+  return container.querySelector('img');
+}
+
 /**
  * The whole change rests on `loading` surviving EdgeMedia's prop split and EdgeImage's
  * rest-spread onto the `<img>`. Neither component mentions `loading` by name — it rides in
  * `...imgProps` and then `...props` — so nothing else in the repo would notice if a future
  * refactor started destructuring it out, and the shop grids would silently go eager again.
+ *
+ * Both seams are rendered, not just the inner one: adding `loading` to EdgeMedia's
+ * destructured parameter list would leave an EdgeImage-only test green while every shop
+ * card went eager again, which is the precise failure this file exists to catch.
  */
 describe('EdgeImage forwards `loading` to the img element', () => {
   beforeEach(() => {
@@ -46,22 +63,90 @@ describe('EdgeImage forwards `loading` to the img element', () => {
   });
 
   // Control: the attribute is absent by default, so the assertion above is reading a value
-  // this prop produced rather than one the element carries anyway.
+  // this prop produced rather than one the element carries anyway. Asserts the element
+  // exists first — `null?.getAttribute()` is undefined, not null, but an absent <img> would
+  // otherwise be an easy way for this to pass while nothing rendered.
   it('sets no loading attribute when not asked', () => {
-    expect(renderImage({})?.getAttribute('loading')).toBeNull();
+    const img = renderImage({});
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('loading')).toBeNull();
+  });
+
+  // The outer seam. EdgeMedia is what every call site in this change actually uses.
+  it('survives EdgeMedia prop split', () => {
+    expect(renderMedia({ loading: 'lazy' })?.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('and EdgeMedia adds no loading attribute of its own', () => {
+    const img = renderMedia({});
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('loading')).toBeNull();
+  });
+});
+
+function renderSample(cosmetic: Record<string, unknown>, lazy?: boolean) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(createElement(CosmeticSample, { cosmetic, lazy } as never));
+  });
+  return container.querySelector('img');
+}
+
+const BADGE = { id: 1, name: 'b', type: 'Badge', data: { url: 'abc-123' } };
+const STICKER = { id: 2, name: 's', type: 'Sticker', data: { url: 'abc-123', animated: true } };
+
+/**
+ * Renders rather than greps, because the grep could not tell "applied" from "declared and
+ * ignored" — `toMatch(/lazy?: boolean/)` and `toMatch(/loading={/)` are two existence checks
+ * over one file, satisfied when `loading` reaches only ONE of CosmeticSample's branches.
+ * Each branch is asserted separately for the same reason.
+ */
+describe('CosmeticSample turns `lazy` into a loading attribute, per branch', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it.each([
+    ['badge', BADGE],
+    ['sticker', STICKER],
+  ])('defers the %s branch', (_label, cosmetic) => {
+    expect(renderSample(cosmetic, true)?.getAttribute('loading')).toBe('lazy');
+  });
+
+  // Control: without the prop the same branches render an img carrying no loading attribute,
+  // so the assertions above read a value `lazy` produced rather than a default.
+  it.each([
+    ['badge', BADGE],
+    ['sticker', STICKER],
+  ])('leaves the %s branch eager when not asked', (_label, cosmetic) => {
+    const img = renderSample(cosmetic, undefined);
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('loading')).toBeNull();
   });
 });
 
 /**
- * ⚠️ Pins a DECISION (868kzk7k7). Every shop grid renders `ShopItem` unvirtualised —
- * `Shop/ShopSection`, `CreatorShop/Storefront/ShopItemGrid`,
- * `HomeBlocks/CosmeticShopSectionHomeBlock` and `Profile/Sections/ShopSection` — and the
- * largest live section is 94 items with 16 animated (measured 2026-09-01). Without these,
- * the whole section's artwork is fetched on first paint.
+ * ⚠️ Pins a DECISION (868kzk7k7). Nine components render `ShopItem`; the grids that matter
+ * are `Shop/OfficialShopSection`, `CreatorShop/Storefront/ShopItemGrid`,
+ * `CosmeticShop/CommunityCosmeticsSection` and `Profile/Sections/ShopSection`. Measured on
+ * live prod 2026-09-01: `/shop` ships **68 cards / 41 `<img>` / 29.3 MB**, all eager, and at
+ * least 19.5 MB of that is in sections far below the fold.
  *
  * The card has THREE mutually exclusive artwork branches and all three must defer; covering
  * two of them leaves a whole class of shop item eager, which is invisible in any screenshot
  * because the difference is only in what the network did.
+ *
+ * Two scope limits, so this is not read as more than it is:
+ *  - A ContentDecoration paints its artwork as a CSS `background-image`, which no `loading`
+ *    attribute reaches. Costs nothing today — 0 of the 92 placed ContentDecoration items
+ *    carry a `texture.url`.
+ *  - A video-typed ProfileBackground routes to `EdgeVideo`, and `EdgeMedia` spreads
+ *    `imgProps` into `EdgeImage` ONLY, so `loading` is dropped there. The `<video>` itself is
+ *    already `preload="none"`, but its `poster` stays eager: 17 of 24 live ProfileBackgrounds
+ *    are video-typed, ~1.5 MB of posters. Not covered here.
+ *
+ * Re-measure all of the above before relying on it; these are CDN- and catalogue-side facts.
  *
  * Deliberately opt-in rather than a default on EdgeImage: that component backs every image
  * on the site, including feeds that already virtualise, and flipping its default is a much
@@ -70,34 +155,37 @@ describe('EdgeImage forwards `loading` to the img element', () => {
 describe('the shop card defers all three of its artwork branches', () => {
   const shopItem = () => read('src/components/Shop/ShopItem.tsx');
 
+  // `[^>]*\slazy` is satisfied by ` lazy={false}` — the negation contains the substring —
+  // so the negative lookahead rejects any `lazy=` form and requires the boolean shorthand.
+  // String.raw, not a plain template literal: `\s` in one collapses to a literal `s`, which
+  // silently produced `slazys*=` — a pattern that matches nothing and fails open.
+  const bare = (tag: string) => new RegExp(String.raw`<${tag}(?![^>]*\slazy\s*=)[^>]*\slazy[\s/>]`);
+
   it.each([
-    ['CosmeticSample', /<CosmeticSample[^>]*\slazy\b/],
-    ['EdgeMedia cover', /<EdgeMedia[^>]*\sloading="lazy"/],
-    ['PackCoverTiles', /<PackCoverTiles[^>]*\slazy\b/],
+    ['CosmeticSample', () => bare('CosmeticSample')],
+    ['PackCoverTiles', () => bare('PackCoverTiles')],
   ])('defers the %s branch', (_label, pattern) => {
-    expect(shopItem()).toMatch(pattern);
+    expect(shopItem()).toMatch(pattern());
   });
 
-  // Control for the three matchers above: each names a distinct component, so a pattern
-  // loose enough to match any lazy-ish attribute anywhere in the file would also match a
-  // component the card does not render.
-  it('does not match a component the card never renders', () => {
-    expect(shopItem()).not.toMatch(/<CosmeticThumb[^>]*\slazy\b/);
+  it('defers the cover branch', () => {
+    expect(shopItem()).toMatch(/<EdgeMedia[^>]*\sloading="lazy"/);
   });
-});
 
-/**
- * The two shared components the card leans on must actually accept the prop. A `lazy` that
- * TypeScript allows but the component ignores would pass the guards above while changing
- * nothing — the failure this whole file exists to prevent.
- */
-describe('the shared card components accept and apply lazy', () => {
+  /**
+   * The control, against fixtures rather than the repo. The previous version asserted the
+   * file did not match `<CosmeticThumb ... lazy>` — a component `ShopItem` never renders at
+   * all, so it passed against an empty string and controlled nothing.
+   */
   it.each([
-    ['src/components/Shop/CosmeticSample.tsx'],
-    ['src/components/CreatorShop/Pack/PackCoverTiles.tsx'],
-  ])('%s turns `lazy` into a loading attribute', (relative) => {
-    const source = read(relative);
-    expect(source).toMatch(/lazy\?: boolean/);
-    expect(source).toMatch(/loading=\{/);
+    ['<CosmeticSample cosmetic={c} size="lg" lazy={false} />'],
+    ['<CosmeticSample cosmetic={c} size="lg" lazy={enabled} />'],
+    ['<CosmeticSample cosmetic={c} size="lg" />'],
+  ])('rejects %j', (source) => {
+    expect(source).not.toMatch(bare('CosmeticSample'));
+  });
+
+  it('accepts the boolean shorthand', () => {
+    expect('<CosmeticSample cosmetic={c} size="lg" lazy />').toMatch(bare('CosmeticSample'));
   });
 });

--- a/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
+++ b/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
@@ -16,6 +16,7 @@ vi.mock('~/providers/BrowserSettingsProvider', () => ({
 import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { CosmeticSample } from '~/components/Shop/CosmeticSample';
+import { PackCoverTiles } from '~/components/CreatorShop/Pack/PackCoverTiles';
 
 const repoRoot = path.resolve(__dirname, '../../../..');
 const read = (relative: string) =>
@@ -93,7 +94,21 @@ function renderSample(cosmetic: Record<string, unknown>, lazy?: boolean) {
   return container.querySelector('img');
 }
 
+function renderTiles(lazy?: boolean) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      createElement(PackCoverTiles, { tiles: ['abc-123'], lazy } as never)
+    );
+  });
+  return container.querySelector('img');
+}
+
 const BADGE = { id: 1, name: 'b', type: 'Badge', data: { url: 'abc-123' } };
+// No `data.type`, so getInferredMediaType resolves 'image' and an <img> renders. The
+// video-typed case is the one deliberately NOT covered - see the scope note below.
+const BACKGROUND = { id: 3, name: 'bg', type: 'ProfileBackground', data: { url: 'abc-123' } };
 const STICKER = { id: 2, name: 's', type: 'Sticker', data: { url: 'abc-123', animated: true } };
 
 /**
@@ -110,6 +125,7 @@ describe('CosmeticSample turns `lazy` into a loading attribute, per branch', () 
   it.each([
     ['badge', BADGE],
     ['sticker', STICKER],
+    ['image-typed profile background', BACKGROUND],
   ])('defers the %s branch', (_label, cosmetic) => {
     expect(renderSample(cosmetic, true)?.getAttribute('loading')).toBe('lazy');
   });
@@ -119,6 +135,7 @@ describe('CosmeticSample turns `lazy` into a loading attribute, per branch', () 
   it.each([
     ['badge', BADGE],
     ['sticker', STICKER],
+    ['image-typed profile background', BACKGROUND],
   ])('leaves the %s branch eager when not asked', (_label, cosmetic) => {
     const img = renderSample(cosmetic, undefined);
     expect(img).not.toBeNull();
@@ -127,31 +144,44 @@ describe('CosmeticSample turns `lazy` into a loading attribute, per branch', () 
 });
 
 /**
- * ⚠️ Pins a DECISION (868kzk7k7). Nine components render `ShopItem`; the grids that matter
- * are `Shop/OfficialShopSection`, `CreatorShop/Storefront/ShopItemGrid`,
- * `CosmeticShop/CommunityCosmeticsSection` and `Profile/Sections/ShopSection`. Measured on
- * live prod 2026-09-01: `/shop` ships **68 cards / 41 `<img>` / 29.3 MB**, all eager, and at
- * least 19.5 MB of that is in sections far below the fold.
+ * PackCoverTiles was the branch a source grep alone still covered: deleting its
+ * `loading={lazy ? 'lazy' : undefined}` left every other assertion in this file green,
+ * because nothing rendered the component. Exactly the "declared and ignored" gap the
+ * CosmeticSample block above exists to close.
+ */
+describe('PackCoverTiles turns `lazy` into a loading attribute', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('defers its tiles when asked', () => {
+    expect(renderTiles(true)?.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('leaves them eager when not asked', () => {
+    const img = renderTiles(undefined);
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('loading')).toBeNull();
+  });
+});
+
+/**
+ * ⚠️ Pins a DECISION (868kzk7k7). Nine components render `ShopItem`, all unvirtualised, so
+ * without these the card's artwork is fetched before anyone scrolls to it. Measurements are
+ * in PR #4565 rather than here — they are catalogue- and CDN-side, they decay silently, and
+ * three of them were wrong in an earlier revision of this very comment.
  *
  * The card has THREE mutually exclusive artwork branches and all three must defer; covering
- * two of them leaves a whole class of shop item eager, which is invisible in any screenshot
- * because the difference is only in what the network did.
+ * two leaves a whole class of shop item eager, which is invisible in any screenshot because
+ * the difference is only in what the network did. Each is rendered below, not grepped.
  *
- * Two scope limits, so this is not read as more than it is:
- *  - A ContentDecoration paints its artwork as a CSS `background-image`, which no `loading`
- *    attribute reaches. Costs nothing today — 0 of the 92 placed ContentDecoration items
- *    carry a `texture.url`.
- *  - A video-typed ProfileBackground routes to `EdgeVideo`, and `EdgeMedia` spreads
- *    `imgProps` into `EdgeImage` ONLY, so `loading` is dropped there. The `<video>` itself is
- *    `preload="none"` everywhere except Safari, which forces `'auto'`, and its `poster` is
- *    eager unconditionally: 17 of 24 live ProfileBackgrounds are video-typed, ~1.5 MB of
- *    posters. Not covered here.
+ * Two limits, so this is not read as more than it is: a ContentDecoration paints via a CSS
+ * `background-image`, and a video-typed ProfileBackground routes to `EdgeVideo`, which never
+ * receives `imgProps`. No `loading` attribute reaches either.
  *
- * Re-measure all of the above before relying on it; these are CDN- and catalogue-side facts.
- *
- * Deliberately opt-in rather than a default on EdgeImage: that component backs every image
- * on the site, including feeds that already virtualise, and flipping its default is a much
- * broader change than this ticket.
+ * Deliberately opt-in rather than a default on EdgeImage: that component backs every image on
+ * the site, including feeds that already virtualise, and there is no `loading="eager"` opt-out
+ * anywhere in the tree to escape a flipped default with.
  */
 describe('the shop card defers all three of its artwork branches', () => {
   const shopItem = () => read('src/components/Shop/ShopItem.tsx');
@@ -160,6 +190,12 @@ describe('the shop card defers all three of its artwork branches', () => {
   // so the negative lookahead rejects any `lazy=` form and requires the boolean shorthand.
   // String.raw, not a plain template literal: `\s` in one collapses to a literal `s`, which
   // silently produced `slazys*=` — a pattern that matches nothing and fails open.
+  //
+  // Existential, not universal: asserts SOME mount is lazy, not every one. Inert today (the
+  // card has exactly one mount per component) but it would not notice a second, eager mount
+  // added beside the first. `[^>]*` also stops at a `>` inside a prop expression, so a prop
+  // like `cosmetic={a > b}` would fail this on a correct mount — over-strict, fails safe.
+  // The rendered tests above pin the behaviour; these only pin the call site.
   const bare = (tag: string) => new RegExp(String.raw`<${tag}(?![^>]*\slazy\s*=)[^>]*\slazy[\s/>]`);
 
   it.each([

--- a/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
+++ b/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import fs from 'fs';
+import path from 'path';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ currentUser: null as unknown }));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => mocks.currentUser }));
+vi.mock('~/providers/BrowserSettingsProvider', () => ({
+  useBrowsingSettings: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ autoplayGifs: true }),
+}));
+
+import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const read = (relative: string) =>
+  fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
+
+function renderImage(props: Record<string, unknown>) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      createElement(EdgeImage, { src: 'abc-123', options: { width: 450 }, ...props } as never)
+    );
+  });
+  return container.querySelector('img');
+}
+
+/**
+ * The whole change rests on `loading` surviving EdgeMedia's prop split and EdgeImage's
+ * rest-spread onto the `<img>`. Neither component mentions `loading` by name — it rides in
+ * `...imgProps` and then `...props` — so nothing else in the repo would notice if a future
+ * refactor started destructuring it out, and the shop grids would silently go eager again.
+ */
+describe('EdgeImage forwards `loading` to the img element', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('sets loading="lazy" when asked', () => {
+    expect(renderImage({ loading: 'lazy' })?.getAttribute('loading')).toBe('lazy');
+  });
+
+  // Control: the attribute is absent by default, so the assertion above is reading a value
+  // this prop produced rather than one the element carries anyway.
+  it('sets no loading attribute when not asked', () => {
+    expect(renderImage({})?.getAttribute('loading')).toBeNull();
+  });
+});
+
+/**
+ * ⚠️ Pins a DECISION (868kzk7k7). Every shop grid renders `ShopItem` unvirtualised —
+ * `Shop/ShopSection`, `CreatorShop/Storefront/ShopItemGrid`,
+ * `HomeBlocks/CosmeticShopSectionHomeBlock` and `Profile/Sections/ShopSection` — and the
+ * largest live section is 94 items with 16 animated (measured 2026-09-01). Without these,
+ * the whole section's artwork is fetched on first paint.
+ *
+ * The card has THREE mutually exclusive artwork branches and all three must defer; covering
+ * two of them leaves a whole class of shop item eager, which is invisible in any screenshot
+ * because the difference is only in what the network did.
+ *
+ * Deliberately opt-in rather than a default on EdgeImage: that component backs every image
+ * on the site, including feeds that already virtualise, and flipping its default is a much
+ * broader change than this ticket.
+ */
+describe('the shop card defers all three of its artwork branches', () => {
+  const shopItem = () => read('src/components/Shop/ShopItem.tsx');
+
+  it.each([
+    ['CosmeticSample', /<CosmeticSample[^>]*\slazy\b/],
+    ['EdgeMedia cover', /<EdgeMedia[^>]*\sloading="lazy"/],
+    ['PackCoverTiles', /<PackCoverTiles[^>]*\slazy\b/],
+  ])('defers the %s branch', (_label, pattern) => {
+    expect(shopItem()).toMatch(pattern);
+  });
+
+  // Control for the three matchers above: each names a distinct component, so a pattern
+  // loose enough to match any lazy-ish attribute anywhere in the file would also match a
+  // component the card does not render.
+  it('does not match a component the card never renders', () => {
+    expect(shopItem()).not.toMatch(/<CosmeticThumb[^>]*\slazy\b/);
+  });
+});
+
+/**
+ * The two shared components the card leans on must actually accept the prop. A `lazy` that
+ * TypeScript allows but the component ignores would pass the guards above while changing
+ * nothing — the failure this whole file exists to prevent.
+ */
+describe('the shared card components accept and apply lazy', () => {
+  it.each([
+    ['src/components/Shop/CosmeticSample.tsx'],
+    ['src/components/CreatorShop/Pack/PackCoverTiles.tsx'],
+  ])('%s turns `lazy` into a loading attribute', (relative) => {
+    const source = read(relative);
+    expect(source).toMatch(/lazy\?: boolean/);
+    expect(source).toMatch(/loading=\{/);
+  });
+});

--- a/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
+++ b/src/components/Shop/__tests__/shop-grid-lazy-loading.test.ts
@@ -143,8 +143,9 @@ describe('CosmeticSample turns `lazy` into a loading attribute, per branch', () 
  *    carry a `texture.url`.
  *  - A video-typed ProfileBackground routes to `EdgeVideo`, and `EdgeMedia` spreads
  *    `imgProps` into `EdgeImage` ONLY, so `loading` is dropped there. The `<video>` itself is
- *    already `preload="none"`, but its `poster` stays eager: 17 of 24 live ProfileBackgrounds
- *    are video-typed, ~1.5 MB of posters. Not covered here.
+ *    `preload="none"` everywhere except Safari, which forces `'auto'`, and its `poster` is
+ *    eager unconditionally: 17 of 24 live ProfileBackgrounds are video-typed, ~1.5 MB of
+ *    posters. Not covered here.
  *
  * Re-measure all of the above before relying on it; these are CDN- and catalogue-side facts.
  *


### PR DESCRIPTION
Part of `868kzk7k7` — **deliberately not `Closes`**, see the last section.

Justin ruled that animated shop covers keep animating, and that the cost gets fixed by not fetching everything up front.

## What live `/shop` does today — measured on prod, 2026-09-01

Fetched the real SSR HTML and every asset it references:

| element | count | eager bytes today | changed here? |
|---|---|---|---|
| `<img>` (card artwork) | 41 | **29,315,584 (29.3 MB)** | **yes → lazy** |
| `<video poster>` | 17 | 1,491,031 | no (see limits) |
| CSS `background-image` banners | 6 | 461,344 | no — not lazyable |

68 cards across 6 sections. `grep -c 'loading="lazy"'` on that HTML returns **0**. **At least 19.5 MB** sits in sections provably below the fold (Avatar Decorations + Badges, 4th and 6th in DOM order).

**Where the weight actually is** — corrected after review, because I originally attributed it to the wrong branch:

- **`CosmeticSample` / ProfileBackground** is the expensive branch. Two live non-video backgrounds measure **1,778,782 B** and **3,656,638 B** at `anim=true,width=450`; the other ten are 19–48 KB. Those two alone are ~5.4 MB of the 29.3 MB, and they are deferred by `<CosmeticSample … lazy />`.
- **The pack-cover branch is cheap and currently unused.** All 18 `CosmeticShopItem` rows carrying a `meta.coverUrl` measure **max 657.6 KB, median ~135 KB** at `width=450` — none reaches 1.7 MB — and **0 of the 18 are placed in any shop section**, published or not. An earlier revision of this PR credited that branch with the ProfileBackground numbers. It does not carry them.

Animated artwork is still the cost driver: resizing an animated WebP barely compresses it, because frame count dominates rather than canvas.

## The change

Defer at `ShopItem` — the card every shop grid renders. All three artwork branches:

```tsx
{cosmetic ? (
  <CosmeticSample cosmetic={cosmetic} size="lg" lazy />
) : itemMeta.coverUrl ? (
  <EdgeMedia src={itemMeta.coverUrl} width={450} alt={item.title} loading="lazy" />
) : (
  <PackCoverTiles tiles={itemMeta.coverTiles ?? []} size={220} fallbackIcon lazy />
)}
```

Opt-in via a `lazy` prop rather than flipping `EdgeImage`'s default. `loading="lazy"` is already the repo's idiom at 38 occurrences across 25 files including `ImagesCard`; and there is **zero** `loading="eager"` or `fetchPriority` anywhere in `src/`, so flipping the default would ship a change with no escape hatch in the tree.

**Not inert** — verified from CSS. `.cardHeader` is a fixed `height: 250px` with `overflow: hidden`, and the grids are ordinary `Grid`/`auto-fill` containers, so card N+1's position never depends on card N's image. That fixed height also means **no new CLS**.

**Bounding, stated correctly:** the grids page *per section* at `COSMETIC_SHOP_DEFAULT_PAGE_SIZE` (24, user-raisable to 48 via `COSMETIC_SHOP_PAGE_SIZES`), featured caps at 6, the home block slices to `maxItems`. Six sections is how 68 cards paint at once — an earlier revision quoted the per-section figure as a page-level bound.

## Scope limits

- **ContentDecoration** paints artwork as a CSS `background-image`, which no `loading` attribute reaches. Costs nothing today: **0 of the 92** placed ContentDecoration items carry a `texture.url`.
- **Video-typed ProfileBackgrounds** route to `EdgeVideo`, which never receives `imgProps`, so `loading` is dropped. Its poster is eager regardless, and the video is `preload="none"` **except on Safari, which forces `'auto'`** — so that branch is *not* already-cheap there, contrary to an earlier revision of this description. **17** live video-typed ProfileBackgrounds (of 29 live, not 24 — the earlier denominator matched no definition).
- **Not verified in a browser.** Everything above is measured from prod HTML/CDN and read from CSS; nobody has watched a scroll.

## Tests

The seams that matter are rendered, not grepped: `EdgeImage`, `EdgeMedia` (because `loading` is named by neither and rides `...imgProps` → `...props`), `CosmeticSample` per image branch, and `PackCoverTiles`. Each has an absent-by-default control.

Review found five assertions that could not fail across two rounds, now fixed: `\slazy\b` satisfied by `lazy={false}`; a "control" naming a component `ShopItem` never renders; two existence checks that passed when `loading` reached one branch of three; and `PackCoverTiles` + the ProfileBackground branch covered by grep alone while the docblock claimed otherwise. The regex uses `String.raw` — `\s` in a plain template literal collapses to a literal `s`, silently producing a pattern that matched nothing.

**No measurements are pinned in code comments.** Three separate rounds put dated figures in JSX and three of them were wrong. They are catalogue- and CDN-side facts that decay with nothing in the repo changing and cannot be type-checked, so per CLAUDE.md they live here instead.

## Review coverage — read this rather than assume it

The five lanes ran twice: first pinned to `fc113a17fb`, then again to `d00214c06c`. Every lane reported the SHA it read and its `git status --porcelain`; all confirm a **clean** tree, which is the only evidence none certified a SHA while measuring a dirty one — `git log -1` cannot see that.

The production diff between `fc113a17fb` and `d00214c06c` is **byte-identical**: every changed line in the three component files is comment prose. That was checked twice independently, and the first check was nearly wrong in a way that looked like agreement — piping `git diff` into a filter on this box returns empty while the patch is really there. The tell was a control: the same command minus the filter also reported 0 changed lines for a file `--stat` said had 20.

Later commits (`a1d9913759`, `4669ccc989`) are comment and test changes made in response to the second round. No production behaviour has changed since `fc113a17fb`.

## What this does NOT close

`868kzk7k7` stays open, and this PR does not auto-close it. Two reasons, both Justin's call:

1. Its condition asks for a devtools before/after on a real storefront. Not done.
2. He asked for virtualising **and** lazy loading; only lazy is here. The measurement argues virtualisation is unnecessary for `/shop` — 3,170 DOM nodes across 68 cards, grids already paging — but that measurement is at the *default* page size on *one* page, and whether the narrower delivery satisfies the ask is his to decide, not this PR's.

## Verification

- `pnpm run typecheck` — **0 type errors**
- `pnpm exec eslint` on the changed files — clean, exit 0
- `shop-grid-lazy-loading.test.ts` — `Test Files 1 passed (1)`, `Tests 19 passed (19)`, exit 0
- Full unit suite — `Test Files 5 failed | 1559 passed | 3 skipped (1567)`, `Tests 11 failed | 24830 passed | 35 skipped (24876)`, exit 1 from the log. **Both totals reconcile.** The 5 failing files are the local Windows baseline of 11, none in Shop or CreatorShop.
- `blocks.router.workflow.test.ts` collected **370 tests**, so the submodule is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwxwrD2QziuF8WqomP9S8S
