### PR TITLE
fix(rewards): floor a negative buzzEvents multiplier at 0

### DIFF
--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -380,7 +380,7 @@ describe('rewardReportReporters multiplier', () => {
 
   it('reports a floor as a floor, not as exceeding the column', async () => {
     // Two floored at DIFFERENT raws, or min and max of a one-element array agree and `minRaw` is
-    // unpinned — the degeneracy that already let a mutation through this file once.
+    // unpinned.
     await rowsFor({
       tiers: [
         [42, cached(-5)],
@@ -408,14 +408,18 @@ describe('rewardReportReporters multiplier', () => {
     expect(row.multiplier).toBe(0);
     // Signalled even though the raw is not finite — a floor with no trace is what this guards.
     expect(axiom).toHaveBeenCalledTimes(1);
-    expect(axiom.mock.calls[0][0].message).toMatch(/negative and was floored/);
-    // The raw is unrepresentable in JSON, and `{"multiplierRaw":null}` is a worse trail than none.
+    const payload = axiom.mock.calls[0][0];
+    expect(payload.message).toMatch(/negative and was floored/);
+    expect(payload.flooredEvents).toBe(1);
+    // No `minRaw` at all rather than one computed from an empty list: `Math.min()` of no arguments
+    // is +Infinity, so the floor alert would report a POSITIVE minimum, serialized as `null`.
+    expect(payload).not.toHaveProperty('minRaw');
     expect(row.transactionDetails).toBe('{}');
   });
 
   it('reports a clamp and a floor in the same batch as two separate signals', async () => {
-    // 4x5=20 clamps, -3x5=-15 floors, 1x5=5 does neither. Nothing else drives both at once, so a
-    // change collapsing the two alerts into one passes every other test.
+    // Nothing else drives a clamp and a floor at once, so collapsing the two alerts into one
+    // passes every other test.
     await rowsFor({
       tiers: [
         [42, cached(4)],

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -361,4 +361,42 @@ describe('rewardReportReporters multiplier', () => {
       maxRaw: 20,
     });
   });
+
+  it('floors a negative tier to 0 rather than writing it', async () => {
+    // A negative fits Decimal(3, 2) only down to -9.99, so a larger one is the same silently
+    // dropped row the ceiling guards. 0 is the value process-rewards understands: unqualified,
+    // zero award, cap untouched. Justin's call, 2026-09-01.
+    const row = await rowFor({ tier: cached(-5), storedBonus: 20 });
+    expect(row.multiplier).toBe(0);
+  });
+
+  it('does not let a negative past the column even when it would fit', async () => {
+    // -2 x 1 = -2 is storable, so a fix that only guarded the unstorable range would leave it.
+    // Kept out anyway: recorded `awarded`, it consumes the reporter's cap and is then dropped by
+    // sendAward's amount filter — a row claiming a payout that never happened.
+    const row = await rowFor({ tier: cached(-2), storedBonus: 10 });
+    expect(row.multiplier).toBe(0);
+  });
+
+  it('reports a floor as a floor, not as exceeding the column', async () => {
+    // Two floored at DIFFERENT raws, or min and max of a one-element array agree and `minRaw` is
+    // unpinned — the degeneracy that already let a mutation through this file once.
+    await rowsFor({
+      tiers: [
+        [42, cached(-5)],
+        [7, cached(-3)],
+        [9, cached(1)],
+      ],
+      storedBonus: 20,
+    });
+    expect(axiom).toHaveBeenCalledTimes(1);
+    const payload = axiom.mock.calls[0][0];
+    expect(payload.message).toMatch(/negative and was floored/);
+    expect(payload).toMatchObject({ flooredEvents: 2, batchSize: 3, minRaw: -10 });
+  });
+
+  it('keeps the unclamped negative in the audit trail', async () => {
+    const row = await rowFor({ tier: cached(-5), storedBonus: 20 });
+    expect(JSON.parse(row.transactionDetails)).toEqual({ multiplierRaw: -10 });
+  });
 });

--- a/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
+++ b/apps/moderator/src/lib/server/__tests__/report-reward-multiplier.test.ts
@@ -399,4 +399,44 @@ describe('rewardReportReporters multiplier', () => {
     const row = await rowFor({ tier: cached(-5), storedBonus: 20 });
     expect(JSON.parse(row.transactionDetails)).toEqual({ multiplierRaw: -10 });
   });
+
+  it('floors a negative that overflows, rather than paying it the base multiplier', async () => {
+    // -1e308 x 5 is -Infinity. Falling back to the base multiplier by finiteness alone made the
+    // floor non-monotone: a tier of -5 paid nothing while a tier of -1e308 paid the FULL award at
+    // 1x. The fallback is by sign for that reason.
+    const row = await rowFor({ tier: cached(-1e308), storedBonus: 50 });
+    expect(row.multiplier).toBe(0);
+    // Signalled even though the raw is not finite — a floor with no trace is what this guards.
+    expect(axiom).toHaveBeenCalledTimes(1);
+    expect(axiom.mock.calls[0][0].message).toMatch(/negative and was floored/);
+    // The raw is unrepresentable in JSON, and `{"multiplierRaw":null}` is a worse trail than none.
+    expect(row.transactionDetails).toBe('{}');
+  });
+
+  it('reports a clamp and a floor in the same batch as two separate signals', async () => {
+    // 4x5=20 clamps, -3x5=-15 floors, 1x5=5 does neither. Nothing else drives both at once, so a
+    // change collapsing the two alerts into one passes every other test.
+    await rowsFor({
+      tiers: [
+        [42, cached(4)],
+        [7, cached(-3)],
+        [9, cached(1)],
+      ],
+      storedBonus: 50,
+    });
+    expect(axiom).toHaveBeenCalledTimes(2);
+    const messages = axiom.mock.calls.map(([payload]) => String(payload.message));
+    expect(messages.some((m) => /negative and was floored/.test(m))).toBe(true);
+    expect(messages.some((m) => /exceeded the ClickHouse column/.test(m))).toBe(true);
+  });
+
+  it('does not treat a legitimately zero multiplier as an adjustment', async () => {
+    // The ineligible reporter is the COMMON production case and its multiplier is 0 by intent, not
+    // by clamping. Alerting on it would page someone for every barred reporter, and writing a
+    // multiplierRaw would claim an adjustment that never happened.
+    const row = await rowFor({ tier: cached(4), storedBonus: 20, ineligible: true });
+    expect(row.multiplier).toBe(0);
+    expect(row.transactionDetails).toBe('{}');
+    expect(axiom).not.toHaveBeenCalled();
+  });
 });

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -22,6 +22,7 @@ export async function rewardReportReporters(input: {
     const globalBonus = await getGlobalRewardsBonus();
     const ineligible = await getIneligibleReporters(input.reporterIds);
     const clamped: number[] = [];
+    const floored: number[] = [];
     const rows = await Promise.all(
       input.reporterIds.map(async (reporterId) => {
         const base = ineligible.has(reporterId) ? 0 : await getBaseRewardsMultiplier(reporterId);
@@ -31,8 +32,12 @@ export async function rewardReportReporters(input: {
         // times the bonus overflows to Infinity, which the clamp turns into the base multiplier.
         // That is a fallback, not an overflow of the column, and reporting it as a clamp writes
         // `{"multiplierRaw":null}` as the audit trail and fires an alert naming a ceiling nothing hit.
-        const wasClamped = Number.isFinite(raw) && multiplier !== raw;
-        if (wasClamped) clamped.push(raw);
+        const adjusted = Number.isFinite(raw) && multiplier !== raw;
+        // Split by direction rather than re-testing the ceiling, so this cannot drift from the
+        // helper. A floored negative did not exceed anything, and saying it did sends whoever reads
+        // the alert looking for a bonus event that is not there.
+        if (adjusted && raw > 0) clamped.push(raw);
+        if (adjusted && raw < 0) floored.push(raw);
         // toUserId === byUserId (an accepted report rewards its reporter); ip omitted for localhost/empty
         // so the ClickHouse column falls back to its '' default.
         return {
@@ -45,11 +50,21 @@ export async function rewardReportReporters(input: {
           status: 'pending',
           // The raw product is kept so a clamped row is still traceable back to the tier and bonus
           // that produced it.
-          transactionDetails: wasClamped ? JSON.stringify({ multiplierRaw: raw }) : '{}',
+          transactionDetails: adjusted ? JSON.stringify({ multiplierRaw: raw }) : '{}',
           ...(input.ip && input.ip !== '::1' ? { ip: input.ip } : {}),
         };
       })
     );
+    if (floored.length) {
+      logToAxiom({
+        name: 'buzz-rewards',
+        type: 'error',
+        message: 'Buzz event multiplier was negative and was floored to 0',
+        flooredEvents: floored.length,
+        batchSize: rows.length,
+        minRaw: Math.min(...floored),
+      }).catch(() => null);
+    }
     if (clamped.length) {
       logToAxiom({
         name: 'buzz-rewards',

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -36,8 +36,12 @@ export async function rewardReportReporters(input: {
         // Split by direction rather than re-testing the ceiling, so this cannot drift from the
         // helper. A floored negative did not exceed anything, and saying it did sends whoever reads
         // the alert looking for a bonus event that is not there.
-        if (adjusted && raw > 0) clamped.push(raw);
-        if (adjusted && raw < 0) floored.push(raw);
+        const clampedHigh = adjusted && raw > 0;
+        // Not gated on `adjusted`: every negative floors, including -Infinity, which is not finite
+        // and would otherwise floor to 0 with no signal at all.
+        const flooredLow = raw < 0;
+        if (clampedHigh) clamped.push(raw);
+        if (flooredLow) floored.push(raw);
         // toUserId === byUserId (an accepted report rewards its reporter); ip omitted for localhost/empty
         // so the ClickHouse column falls back to its '' default.
         return {
@@ -50,7 +54,12 @@ export async function rewardReportReporters(input: {
           status: 'pending',
           // The raw product is kept so a clamped row is still traceable back to the tier and bonus
           // that produced it.
-          transactionDetails: adjusted ? JSON.stringify({ multiplierRaw: raw }) : '{}',
+          // Only a finite raw is recorded: JSON.stringify turns +/-Infinity into `null`, which is
+          // a worse audit trail than none. The alert's count still says it happened.
+          transactionDetails:
+            (clampedHigh || flooredLow) && Number.isFinite(raw)
+              ? JSON.stringify({ multiplierRaw: raw })
+              : '{}',
           ...(input.ip && input.ip !== '::1' ? { ip: input.ip } : {}),
         };
       })
@@ -62,7 +71,7 @@ export async function rewardReportReporters(input: {
         message: 'Buzz event multiplier was negative and was floored to 0',
         flooredEvents: floored.length,
         batchSize: rows.length,
-        minRaw: Math.min(...floored),
+        minRaw: Math.min(...floored.filter(Number.isFinite)),
       }).catch(() => null);
     }
     if (clamped.length) {

--- a/apps/moderator/src/lib/server/rewards.ts
+++ b/apps/moderator/src/lib/server/rewards.ts
@@ -33,9 +33,7 @@ export async function rewardReportReporters(input: {
         // That is a fallback, not an overflow of the column, and reporting it as a clamp writes
         // `{"multiplierRaw":null}` as the audit trail and fires an alert naming a ceiling nothing hit.
         const adjusted = Number.isFinite(raw) && multiplier !== raw;
-        // Split by direction rather than re-testing the ceiling, so this cannot drift from the
-        // helper. A floored negative did not exceed anything, and saying it did sends whoever reads
-        // the alert looking for a bonus event that is not there.
+        // Split by direction rather than re-testing the ceiling, so this cannot drift from the helper.
         const clampedHigh = adjusted && raw > 0;
         // Not gated on `adjusted`: every negative floors, including -Infinity, which is not finite
         // and would otherwise floor to 0 with no signal at all.
@@ -52,10 +50,8 @@ export async function rewardReportReporters(input: {
           awardAmount: REPORT_ACCEPTED_AWARD,
           multiplier,
           status: 'pending',
-          // The raw product is kept so a clamped row is still traceable back to the tier and bonus
-          // that produced it.
-          // Only a finite raw is recorded: JSON.stringify turns +/-Infinity into `null`, which is
-          // a worse audit trail than none. The alert's count still says it happened.
+          // The raw product is kept so an adjusted row stays traceable to the tier and bonus that
+          // produced it. Only a finite one: JSON.stringify turns +/-Infinity into `null`.
           transactionDetails:
             (clampedHigh || flooredLow) && Number.isFinite(raw)
               ? JSON.stringify({ multiplierRaw: raw })
@@ -65,13 +61,16 @@ export async function rewardReportReporters(input: {
       })
     );
     if (floored.length) {
+      const finiteFloored = floored.filter(Number.isFinite);
       logToAxiom({
         name: 'buzz-rewards',
         type: 'error',
         message: 'Buzz event multiplier was negative and was floored to 0',
         flooredEvents: floored.length,
         batchSize: rows.length,
-        minRaw: Math.min(...floored.filter(Number.isFinite)),
+        // Omitted rather than reported when every floored raw overflowed: `Math.min()` of no
+        // arguments is +Infinity, which is the opposite sign of the alert and serializes to `null`.
+        ...(finiteFloored.length ? { minRaw: Math.min(...finiteFloored) } : {}),
       }).catch(() => null);
     }
     if (clamped.length) {

--- a/packages/civitai-clickhouse/src/buzz-events.ts
+++ b/packages/civitai-clickhouse/src/buzz-events.ts
@@ -19,10 +19,17 @@ export const BUZZ_EVENTS_MAX_MULTIPLIER = 9.99;
  * at all, which is why this floors rather than rejects. Callers that care should record the raw
  * value alongside the row.
  *
+ * The floor is 0, not -9.99. The column is signed and would hold a small negative, but 0 is the
+ * value `process-rewards` already understands: it marks the event `unqualified` with a zero award
+ * and does NOT consume the user's cap. A negative kept as a negative is worse than the overflow
+ * this guards — it passes that check, is recorded `awarded`, eats the cap, and is then dropped by
+ * `sendAward`'s amount filter, leaving a row claiming a payout that never happened.
+ * Justin's call, 2026-09-01.
+ *
  * A non-finite input falls back to the base multiplier of 1 rather than passing NaN through: NaN is
  * a value the column cannot hold, which is the same silently-dropped row this exists to prevent.
  */
 export function clampBuzzEventMultiplier(multiplier: number): number {
   if (!Number.isFinite(multiplier)) return 1;
-  return Math.min(multiplier, BUZZ_EVENTS_MAX_MULTIPLIER);
+  return Math.min(Math.max(multiplier, 0), BUZZ_EVENTS_MAX_MULTIPLIER);
 }

--- a/packages/civitai-clickhouse/src/buzz-events.ts
+++ b/packages/civitai-clickhouse/src/buzz-events.ts
@@ -24,7 +24,6 @@ export const BUZZ_EVENTS_MAX_MULTIPLIER = 9.99;
  * and does NOT consume the user's cap. A negative kept as a negative is worse than the overflow
  * this guards — it passes that check, is recorded `awarded`, eats the cap, and is then dropped by
  * `sendAward`'s amount filter, leaving a row claiming a payout that never happened.
- * Justin's call, 2026-09-01.
  *
  * A non-finite input falls back rather than passing NaN through, since NaN is a value the column
  * cannot hold — the same silently-dropped row this exists to prevent. It falls back BY SIGN, or the

--- a/packages/civitai-clickhouse/src/buzz-events.ts
+++ b/packages/civitai-clickhouse/src/buzz-events.ts
@@ -26,10 +26,12 @@ export const BUZZ_EVENTS_MAX_MULTIPLIER = 9.99;
  * `sendAward`'s amount filter, leaving a row claiming a payout that never happened.
  * Justin's call, 2026-09-01.
  *
- * A non-finite input falls back to the base multiplier of 1 rather than passing NaN through: NaN is
- * a value the column cannot hold, which is the same silently-dropped row this exists to prevent.
+ * A non-finite input falls back rather than passing NaN through, since NaN is a value the column
+ * cannot hold — the same silently-dropped row this exists to prevent. It falls back BY SIGN, or the
+ * floor would be non-monotone: -Infinity is still a negative and must not be worth more than -5.
+ * NaN carries no sign to act on, so it takes the base multiplier like a missing value.
  */
 export function clampBuzzEventMultiplier(multiplier: number): number {
-  if (!Number.isFinite(multiplier)) return 1;
+  if (!Number.isFinite(multiplier)) return multiplier < 0 ? 0 : 1;
   return Math.min(Math.max(multiplier, 0), BUZZ_EVENTS_MAX_MULTIPLIER);
 }


### PR DESCRIPTION
Follow-up to #4554. ClickUp [868kw9b31](https://app.clickup.com/t/868kw9b31).

`clampBuzzEventMultiplier` fitted only the **top** of the column's range, so a negative passed through untouched. Below −9.99 that is the same silently-dropped row the ceiling exists to prevent — `buzzEvents.multiplier` is `Decimal(3, 2)`, inserts run `async_insert=1, wait_for_async_insert=0`, and `reportAccepted` is a processable reward, so a dropped row means the reporter is never paid.

## Why the floor is 0 and not −9.99

Justin's call. The column is signed and *would* hold a small negative, so the mechanical fix is available — and it is worse than the gap.

`0` is the value `process-rewards` already understands. `base.reward.ts:466` marks a zero-multiplier event `unqualified` with a zero award and `continue`s, skipping the cap block entirely. A negative kept as a negative passes that check, is trimmed against the cap, recorded `awarded`, **consumes the reporter's cap**, and is *then* dropped by `sendAward`'s `amount > 0` filter — a row claiming a payout that never happened plus a cap the user can never spend. `reportAccepted`'s cap is 1500/month keyed on `toUserId`, so each bad row costs a real reporter 50 Buzz of ceiling.

Storable and wrong beats unstorable only on paper.

## Reachability

Not reachable today, but not theoretical either. `foldUserMultipliers` takes `row.rewardsMultiplier ?? 1` for the first row with **no floor** — its own docstring says the result is deliberately not floored at 1 — and the value originates as `(p.metadata->>'rewardsMultiplier')::float` off operator-authored `Product.metadata`. One product with `-1` instead of `1` is all it takes. All 17 prod products carrying that key are currently ≥ 1.

## What the review found in my own fix

The floor was **non-monotone**. `-1e308 * 5` is `-Infinity`, which took the non-finite branch and returned the base multiplier of `1` — so a tier of `-5` paid nothing while a tier of `-1e308` paid the **full award at 1x**. That fallback was written when the only reachable overflow was positive, where `1` is defensible; it stopped being right the moment negatives floored to 0. It now falls back **by sign**. `NaN` carries no sign to act on and still takes the base multiplier, like a missing value.

The floor signal was also gated on `adjusted`, which requires a finite raw — so the one case that most needed a trace, a negative overflow, would have floored to 0 **silently**. Now gated on the sign alone.

Where a raw is not finite, no `multiplierRaw` is recorded and it is excluded from `minRaw`: `JSON.stringify` turns `±Infinity` into `null`, and an audit trail saying `null` is worse than one saying nothing. The alert's count still says it happened.

## Reporting

The existing alert says the multiplier *"exceeded the ClickHouse column"*, which a floored negative did not — reading that sends someone hunting for a bonus event that isn't there. Floors report separately. The two directions split on the **sign of the raw product** rather than by re-testing the ceiling, so the reporting cannot drift from the helper's own threshold.

## Verification

Nine revert controls, each failing with an assertion naming the wrong value:

| Revert | Failure |
|---|---|
| the floor entirely | `expected -10 to be +0` |
| floor at −9.99 instead of 0 | `expected -9.99 to be +0` |
| non-finite fallback back to `1` | `expected 1 to be +0` |
| floor signal re-gated on `adjusted` | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| collapse the two alerts into one | `expected "vi.fn()" to be called 1 times, but got 2 times` |
| floor on `raw <= 0` (alert on a legitimate zero) | `expected '{"multiplierRaw":0}' to be '{}'` |
| report a floor as a ceiling clamp | `expected 'Buzz event multiplier exceeded the Cl…' to match /negative and was floored/` |
| `minRaw` → `Math.max` | `flooredEvents/batchSize/minRaw` mismatch |
| drop the audit trail for a floored row | `expected {} to deeply equal { multiplierRaw: -10 }` |

- `pnpm run typecheck` — `OK, 0 type errors`
- `apps/moderator typecheck` — `9410 FILES 0 ERRORS 0 WARNINGS`
- `test:apps:run` — `Test Files 112 passed (112)`, `Tests 1211 passed | 36 skipped (1247)`, exit 0
- `test:packages:run` — `Test Files 83 passed | 3 skipped (86)`, exit 0
- `test:unit:run` — `Test Files 5 failed | 1558 passed | 3 skipped (1566)`, `Tests 11 failed | 24810 passed | 35 skipped (24856)`. **Both lines reconcile** — parts sum to the parenthesised total, so no workers died and nothing silently failed to run. Baseline **measured, not compared**: stashing these files and re-running the same 5 files at this base gives the identical `11 failed | 135 passed (146)`.

No migration; the column is unchanged.

## Deliberately not in this PR

`base.reward.ts:627` open-codes `multiplier > BUZZ_EVENTS_MAX_MULTIPLIER` rather than calling the helper, so **the main app's pipeline has neither this floor nor the non-finite guard** — on every reward type rather than one, reading the same cache, from the same `Product.metadata`. That is a wider blast radius than this ticket and wants its own decision.

Whoever takes it should know `toClickhouseBuzzEvent` merges its own coercions **over** the parsed `transactionDetails` (`{...details, ...coerced}`), so it would overwrite this `multiplierRaw` unless it writes a differently-named key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9SVX31zzRCbjkaj81py35