### PR TITLE
feat(app-blocks): stratify the launch histograms by whether the guest announced BLOCK_HELLO

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -1256,11 +1256,29 @@ describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
     );
     expect(typeof body.timings.totalMs).toBe('number');
     expect(body.timings.totalMs).toBeGreaterThan(0);
-    // Never a zero-valued leg on the wire — an unobserved leg is OMITTED.
+    // 🔴 NO STRINGS ON THE WIRE — this is the real invariant, and it is what
+    // keeps a public, client-controlled beacon body from touching prom label
+    // cardinality. Every label this payload feeds is CODE-OWNED: the server maps
+    // named numeric fields onto its own `phase` literals and the `hello` boolean
+    // onto `yes`/`no`, so no value here can ever BE a label value.
+    //
+    // It used to be written as "every field is a number", which was the same
+    // rule while every field happened to be one. `hello` is a BOOLEAN and does
+    // not weaken the guarantee — booleans are a closed two-value domain, mapped
+    // server-side — so the assertion is restated at the level of the property it
+    // was always protecting rather than relaxed to let a boolean through.
     for (const [k, v] of Object.entries(body.timings)) {
-      expect(typeof v, `timings.${k}`).toBe('number');
-      expect(v, `timings.${k}`).toBeGreaterThan(0);
+      expect(typeof v, `timings.${k}`).not.toBe('string');
+      expect(['number', 'boolean'], `timings.${k}`).toContain(typeof v);
+      // Never a zero-valued NUMERIC leg on the wire — an unobserved leg is
+      // OMITTED, because a 0 is indistinguishable from an instant one and drags
+      // every percentile down. Booleans are exempt: `hello: false` is a real
+      // observation, not a missing one, and is emitted deliberately (an omitted
+      // field would be indistinguishable from a client that cannot send it).
+      if (typeof v === 'number') expect(v, `timings.${k}`).toBeGreaterThan(0);
     }
+    // `hello` specifically: always present, always boolean.
+    expect(typeof body.timings.hello, 'timings.hello').toBe('boolean');
     // No isAnon/userId from the client — those are server-derived in the route.
     expect(body).not.toHaveProperty('isAnon');
     expect(body).not.toHaveProperty('userId');

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1337,6 +1337,16 @@ export function PageBlockHost({
   // immediately.
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_HELLO', () => {
+      // 🔴 RECORDED BEFORE — AND INDEPENDENTLY OF — THE CONTROLLER, deliberately.
+      // The label means "the guest announced during this launch", NOT "the
+      // accelerator fired an extra post". `notifyHello()` is a no-op when the
+      // controller has not started, has stopped, or has already handled a hello;
+      // recording inside it would file those launches as `no` even though the
+      // guest's listener was demonstrably attached and the host's next post was
+      // heard. That is the wrong bucket, and it biases the comparison toward the
+      // null. See `LaunchMarks.helloSeen` for the full argument.
+      const marks = launchMarksRef.current;
+      if (marks) marks.helloSeen = true;
       controllerRef.current?.notifyHello();
     });
     return off;

--- a/src/components/AppBlocks/__tests__/launchSampleBound.test.ts
+++ b/src/components/AppBlocks/__tests__/launchSampleBound.test.ts
@@ -338,6 +338,65 @@ describe('PageBlockHost: launch-mark seed wiring', () => {
     expect(body).not.toContain('BLOCK_READY');
   });
 
+  /**
+   * 🔴 THE STRATIFIER'S WIRING — the one part of `hello` no pure test can reach,
+   * and the part that decides whether the label means what it says.
+   *
+   * `helloSeen` must be set in the BLOCK_HELLO message handler, INDEPENDENTLY of
+   * `controllerRef.current?.notifyHello()`. Recording it inside `notifyHello()`
+   * instead would silently change the label's MEANING from "the guest announced"
+   * to "the accelerator fired an extra post" — `notifyHello()` is a no-op when
+   * the controller has not started, has stopped, or has already handled a hello.
+   * A hello arriving before `start()` would then be filed `hello="no"` despite
+   * the guest's listener being attached, pushing fast accelerator-capable
+   * launches into the cadence-bound population and biasing the whole comparison
+   * toward "the change did nothing".
+   *
+   * Nothing else can catch that: every pure test would stay green, the beacon
+   * would still carry a boolean, and the metric would still have two
+   * populations — just the wrong ones. A source gate is the weaker instrument
+   * and is named as such, for the same reason as the seed gate above: the
+   * behavioural version can only live in the `component` project, which CI does
+   * not run.
+   */
+  function helloHandlerBody(src: string): string {
+    const start = src.indexOf("onMessage<unknown>('BLOCK_HELLO'");
+    if (start === -1) return '';
+    const end = src.indexOf('});', start);
+    if (end === -1) return '';
+    return src.slice(start, end);
+  }
+
+  it('the extractor finds the BLOCK_HELLO handler and not the whole file', () => {
+    // Positive control: an indexOf that silently missed would return '' and make
+    // the real assertion below red for an unrelated reason.
+    const body = helloHandlerBody(fs.readFileSync(HOST, 'utf8'));
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).toContain('notifyHello');
+    expect(body).not.toContain('BLOCK_READY');
+  });
+
+  it('🔴 the host records helloSeen in the handler, not inside notifyHello()', () => {
+    const src = fs.readFileSync(HOST, 'utf8');
+    const body = helloHandlerBody(src);
+    expect(body).toContain('marks.helloSeen = true');
+    // 🔴 …and BEFORE the controller call, so a null controller cannot skip it.
+    // 🔴 Anchored on the CALL EXPRESSION, not the bare word `notifyHello`: the
+    // handler's own comment names it several lines earlier, so a substring
+    // search matches the prose and compares the wrong offsets. (It did — this
+    // assertion was written that way first and failed at 731 vs 245.)
+    const call = 'controllerRef.current?.notifyHello()';
+    expect(body).toContain(call);
+    expect(body.indexOf('marks.helloSeen = true')).toBeLessThan(body.indexOf(call));
+    // 🔴 The mark must NOT be set inside the controller — that would silently
+    // redefine the label as "the accelerator fired".
+    const controllerSrc = fs.readFileSync(
+      path.resolve(__dirname, '../iframeInitController.ts'),
+      'utf8'
+    );
+    expect(controllerSrc).not.toContain('helloSeen');
+  });
+
   it('🔴 the host counts EVERY BLOCK_INIT post, unconditionally', () => {
     const body = sendInitBody(fs.readFileSync(HOST, 'utf8'));
     expect(body).toContain('marks.initPosts += 1');

--- a/src/components/AppBlocks/__tests__/launchTimings.test.ts
+++ b/src/components/AppBlocks/__tests__/launchTimings.test.ts
@@ -451,3 +451,75 @@ describe('computeLaunchTimings — the hello stratifier', () => {
     expect(out.initPosts).toBe(1);
   });
 });
+
+/**
+ * 🔴 `helloSeen` LIFETIME — enumerated against the states a launch can actually
+ * reach, because "the guest announced during the launch window" only means one
+ * thing once "the launch window" is pinned.
+ *
+ * The mark's lifetime is deliberately IDENTICAL to `initPosts`': both live on
+ * the marks, both are cleared only by `resetLaunchMarks` (one call site, gated
+ * on `blockInstanceId`), and both therefore survive a retry and are cleared by a
+ * soft navigation. That symmetry is the point — `init_wait` spans every attempt
+ * of one launch, so its two companions must span exactly the same window or the
+ * three describe different things while looking like one record.
+ */
+describe('helloSeen lifetime — the states it must file correctly', () => {
+  it('🔴 survives a retry, exactly like initPosts (one launch, many attempts)', () => {
+    // `performRetry` remounts the iframe and builds a fresh controller but does
+    // NOT reset the marks, so an announcement on attempt 1 still describes the
+    // launch that attempt 3 completes. That is correct: the SAME app bundle is
+    // reloaded each time, so its announce behaviour cannot change mid-launch.
+    const m = marks({ helloSeen: true, initPosts: 1 });
+    m.initPosts += 29; // a second attempt's posts accumulate
+    const out = computeLaunchTimings(m)!;
+    expect(out.hello).toBe(true);
+    expect(out.initPosts).toBe(30);
+  });
+
+  it('🔴 is cleared by a soft navigation, exactly like initPosts', () => {
+    // Both marks are cleared by the SAME call, so they cannot drift apart: app
+    // A's announcement can never label app B's launch.
+    const m = createLaunchMarks(0, false);
+    m.helloSeen = true;
+    m.initPosts = 5;
+    resetLaunchMarks(m, 500, false);
+    expect(m.helloSeen).toBe(false);
+    expect(m.initPosts).toBe(0);
+  });
+
+  /**
+   * A DUPLICATE announcement is idempotent here. `IframeInitController` honours
+   * only the first (a chatty frame cannot amplify host work), but the MARK has
+   * no such latch and needs none — it is a boolean, and "announced twice" is
+   * still "announced".
+   */
+  it('a duplicate hello does not change the mark', () => {
+    const m = marks({ helloSeen: false });
+    m.helloSeen = true;
+    m.helloSeen = true;
+    expect(computeLaunchTimings(m)?.hello).toBe(true);
+  });
+
+  /**
+   * 🔴 THE ONE WINDOW THAT CAN MIS-FILE, stated rather than hidden.
+   *
+   * The mark is read when the success beacon effect runs, one React commit after
+   * BLOCK_READY flips the status. An announcement landing inside that commit is
+   * counted as `yes` even though it arrived after ready and short-circuited
+   * nothing; an announcement landing after the beacon is not counted at all.
+   *
+   * Neither is worth code to prevent. A guest sends hello when its message
+   * listener attaches, which necessarily precedes any BLOCK_READY it sends over
+   * that same listener — so a hello-after-ready is a duplicate or an
+   * out-of-order delivery, and in both cases the guest genuinely did announce,
+   * which is exactly what the label claims. This test pins that reading so the
+   * window is a documented consequence rather than a surprise.
+   */
+  it('reads the mark as of the beacon — a later mutation cannot change a sent sample', () => {
+    const m = marks({ helloSeen: false });
+    const sent = computeLaunchTimings(m)!;
+    m.helloSeen = true; // arrives after the beacon was built
+    expect(sent.hello).toBe(false);
+  });
+});

--- a/src/components/AppBlocks/__tests__/launchTimings.test.ts
+++ b/src/components/AppBlocks/__tests__/launchTimings.test.ts
@@ -34,6 +34,8 @@ const BASE_MARKS: LaunchMarks = {
   // coincided with another field (or with the `1` a broken counter would emit)
   // could not tell a correct read from a mutant that returns a constant.
   initPosts: 3,
+  // Distinct from the payload default so a mutant hardcoding `false` fails.
+  helloSeen: true,
 };
 
 const marks = (over: Partial<LaunchMarks> = {}): LaunchMarks => ({ ...BASE_MARKS, ...over });
@@ -99,6 +101,7 @@ describe('createLaunchMarks / resetLaunchMarks', () => {
       readyAt: null,
       wasHidden: false,
       initPosts: 0,
+      helloSeen: false,
     });
   });
 
@@ -116,6 +119,10 @@ describe('createLaunchMarks / resetLaunchMarks', () => {
     // that forgot it would leave app A's posts attributed to app B's launch and
     // compound with every soft navigation. Seeding 0 here could not see that.
     m.initPosts = 7;
+    // 🔴 Seeded TRUE so the reset is observable. Left sticky, app A's
+    // announcement would label app B's launch `yes` — mis-stratifying the very
+    // comparison the label exists for.
+    m.helloSeen = true;
     const same = m;
     resetLaunchMarks(m, 500, false);
     // Same object identity — callers hold this in a ref.
@@ -127,6 +134,7 @@ describe('createLaunchMarks / resetLaunchMarks', () => {
       readyAt: null,
       wasHidden: false,
       initPosts: 0,
+      helloSeen: false,
     });
   });
 });
@@ -172,6 +180,7 @@ describe('computeLaunchTimings', () => {
       tokenMintMs: 180, // 1180 - 1000
       initWaitMs: 700, // 2100 - 1400
       initPosts: 3, // BASE_MARKS.initPosts, carried through verbatim
+      hello: true, // BASE_MARKS.helloSeen, carried through verbatim
     });
   });
 
@@ -181,7 +190,13 @@ describe('computeLaunchTimings', () => {
     // mounts on the first client render before any token exists. A guard that
     // assumed a serial sum would silently drop real samples.
     const out = computeLaunchTimings(marks({ tokenAt: 1_900, initSentAt: 1_050 }))!;
-    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 900, initWaitMs: 1_050, initPosts: 3 });
+    expect(out).toEqual({
+      totalMs: 1_100,
+      tokenMintMs: 900,
+      initWaitMs: 1_050,
+      initPosts: 3,
+      hello: true,
+    });
     expect(out.tokenMintMs! + out.initWaitMs!).toBeGreaterThan(out.totalMs);
   });
 
@@ -243,6 +258,7 @@ describe('computeLaunchTimings', () => {
       // The COUNT survives even though the DURATION leg does not: they answer
       // different questions and are gated independently.
       initPosts: 3,
+      hello: true,
     });
   });
 
@@ -270,7 +286,13 @@ describe('computeLaunchTimings', () => {
   it('never emits a frameFetchMs field (the cross-origin phase is deliberately deferred)', () => {
     const out = computeLaunchTimings(marks())!;
     expect(out).not.toHaveProperty('frameFetchMs');
-    expect(Object.keys(out).sort()).toEqual(['initPosts', 'initWaitMs', 'tokenMintMs', 'totalMs']);
+    expect(Object.keys(out).sort()).toEqual([
+      'hello',
+      'initPosts',
+      'initWaitMs',
+      'tokenMintMs',
+      'totalMs',
+    ]);
   });
 });
 
@@ -365,5 +387,67 @@ describe('computeLaunchTimings — initPosts', () => {
     // against is an orphan that still moves the distribution.
     expect(computeLaunchTimings(marks({ readyAt: null, initPosts: 9 }))).toBeNull();
     expect(computeLaunchTimings(marks({ mountedAt: null, initPosts: 9 }))).toBeNull();
+  });
+});
+
+/**
+ * 🔴 `helloSeen` / `hello` — THE STRATIFIER'S SEMANTICS, pinned as behaviour.
+ *
+ * The label separates launches whose `init_wait` the host re-post cadence
+ * actually governed from launches the guest short-circuited by announcing
+ * itself. Getting its MEANING wrong does not break anything visibly — it
+ * produces a confident wrong number, which is why the meaning is asserted here
+ * and not only described in a comment.
+ */
+describe('computeLaunchTimings — the hello stratifier', () => {
+  it('carries the announcement through, both ways', () => {
+    expect(computeLaunchTimings(marks({ helloSeen: true }))?.hello).toBe(true);
+    expect(computeLaunchTimings(marks({ helloSeen: false }))?.hello).toBe(false);
+  });
+
+  /**
+   * 🔴 ALWAYS EMITTED, NEVER OMITTED FOR `false`. An omitted field and a `false`
+   * field are indistinguishable on the wire, and the server must tell "this
+   * client does not send it" (drop) from "this launch had no hello" (label
+   * `no`). Omitting the false case would collapse that distinction and file
+   * every hello-less launch into the drop path — silently emptying the very
+   * population the label exists to isolate.
+   *
+   * Written as a KEY-PRESENCE assertion, because `?.hello === false` would also
+   * be satisfied by the field being absent.
+   */
+  it('🔴 emits the key even when false — absence must stay distinguishable', () => {
+    const out = computeLaunchTimings(marks({ helloSeen: false }))!;
+    expect(Object.prototype.hasOwnProperty.call(out, 'hello')).toBe(true);
+    expect(out.hello).toBe(false);
+  });
+
+  it('🔴 is dropped with the whole sample on a hidden tab or an unusable total', () => {
+    // A launch we refuse to observe must not contribute a label either — the
+    // label rides the sample, it does not survive it.
+    expect(computeLaunchTimings(marks({ wasHidden: true, helloSeen: true }))).toBeNull();
+    expect(computeLaunchTimings(marks({ readyAt: null, helloSeen: true }))).toBeNull();
+  });
+
+  /**
+   * 🔴 THE MEANING, STATED AS A TEST. `helloSeen` is set by the host's message
+   * handler on ANY BLOCK_HELLO during the launch — it is NOT a record that
+   * `notifyHello()` posted an extra BLOCK_INIT.
+   *
+   * The two readings disagree on a real, reachable launch: a hello arriving
+   * BEFORE the controller starts is recorded and posts nothing, because
+   * `start()` posts immediately on its own. Under the "accelerator fired"
+   * reading that launch is `no`, even though the guest's listener was attached
+   * and the cadence never governed its wait — which would push fast,
+   * accelerator-capable launches into the cadence-bound population and bias the
+   * comparison toward the null.
+   *
+   * Expressed here as: an announcement with ZERO extra posts is still `yes`.
+   * `initPosts: 1` is the immediate `start()` post and nothing more.
+   */
+  it('🔴 means ANNOUNCED, not "the accelerator fired an extra post"', () => {
+    const out = computeLaunchTimings(marks({ helloSeen: true, initPosts: 1 }))!;
+    expect(out.hello).toBe(true);
+    expect(out.initPosts).toBe(1);
   });
 });

--- a/src/components/AppBlocks/launchTimings.ts
+++ b/src/components/AppBlocks/launchTimings.ts
@@ -153,8 +153,11 @@ export type LaunchTimingsPayload = {
    * 🔴 ALWAYS PRESENT when a sample is emitted, never omitted for `false`. An
    * omitted field and a `false` field would be indistinguishable on the wire,
    * and the server must be able to tell "this client does not send the field"
-   * (drop) from "this launch had no hello" (label it `no`). Emitting it
-   * unconditionally is what makes that distinction exist.
+   * (labelled `unknown`) from "this launch had no hello" (labelled `no`).
+   * Emitting it unconditionally is what makes that distinction exist — without
+   * it, every launch from a current client that simply saw no hello would be
+   * lumped in with stale browser bundles and the `no` population would be
+   * unusable.
    */
   hello: boolean;
 };

--- a/src/components/AppBlocks/launchTimings.ts
+++ b/src/components/AppBlocks/launchTimings.ts
@@ -107,6 +107,36 @@ export type LaunchMarks = {
    * the last attempt's posts against an `init_wait` spanning all of them.
    */
   initPosts: number;
+  /**
+   * 🔴 THE STRATIFIER — and its meaning is EXACTLY ONE THING, stated here
+   * because two plausible readings exist and they disagree on real launches.
+   *
+   * MEANING: the guest sent `BLOCK_HELLO` at some point during this launch
+   * window (host mount -> BLOCK_READY). Nothing more.
+   *
+   * 🔴 IT DOES **NOT** MEAN "the accelerator fired an extra BLOCK_INIT".
+   * `IframeInitController.notifyHello()` posts only when it is already started,
+   * not stopped, and not already handled — so a hello arriving BEFORE `start()`
+   * is recorded and posts nothing, because `start()` posts immediately on its
+   * own. Under the "accelerator fired" reading that launch would be filed as
+   * `no`, and that is the wrong bucket: the guest's listener WAS attached, so
+   * the host's very next post was heard and the re-post cadence never governed
+   * the wait. Filing it as `no` would push fast, accelerator-capable launches
+   * into the population that exists to isolate cadence-bound ones — biasing the
+   * comparison toward "the cadence change did nothing".
+   *
+   * The question this label answers is "was this launch's `init_wait` governed
+   * by the host's re-post schedule, or short-circuited by the guest announcing
+   * itself?" Once the guest has announced, its listener is attached and the next
+   * post lands, whichever post that is. So ANNOUNCED-AT-ALL is the correct cut,
+   * and it is why this is recorded in the message handler rather than inside
+   * `notifyHello()`.
+   *
+   * Recorded independently of the controller: the handler sets this even when
+   * `controllerRef.current` is null, so a hello landing before the controller
+   * exists still counts. Sticky for the whole launch, like `wasHidden`.
+   */
+  helloSeen: boolean;
 };
 
 /** The optional `timings` object carried on the existing block-render beacon. */
@@ -115,6 +145,18 @@ export type LaunchTimingsPayload = {
   tokenMintMs?: number;
   initWaitMs?: number;
   initPosts?: number;
+  /**
+   * Whether the guest announced `BLOCK_HELLO` during this launch — see
+   * `LaunchMarks.helloSeen` for the exact meaning and why it is not
+   * "the accelerator fired".
+   *
+   * 🔴 ALWAYS PRESENT when a sample is emitted, never omitted for `false`. An
+   * omitted field and a `false` field would be indistinguishable on the wire,
+   * and the server must be able to tell "this client does not send the field"
+   * (drop) from "this launch had no hello" (label it `no`). Emitting it
+   * unconditionally is what makes that distinction exist.
+   */
+  hello: boolean;
 };
 
 export function createLaunchMarks(now: number | null, hidden: boolean): LaunchMarks {
@@ -125,6 +167,7 @@ export function createLaunchMarks(now: number | null, hidden: boolean): LaunchMa
     readyAt: null,
     wasHidden: hidden,
     initPosts: 0,
+    helloSeen: false,
   };
 }
 
@@ -145,6 +188,10 @@ export function resetLaunchMarks(marks: LaunchMarks, now: number | null, hidden:
   // — and unlike a timestamp this one ACCUMULATES, so the error compounds with
   // every navigation rather than being a single wrong delta.
   marks.initPosts = 0;
+  // Resets with the rest: a soft navigation A -> B reuses the component, and a
+  // sticky `true` would label app B's launch with app A's announcement — which
+  // is precisely the mis-stratification this label exists to prevent.
+  marks.helloSeen = false;
 }
 
 /**
@@ -294,6 +341,10 @@ export function computeLaunchTimings(marks: LaunchMarks): LaunchTimingsPayload |
     ...(tokenMintMs !== undefined ? { tokenMintMs } : {}),
     ...(initWaitMs !== undefined ? { initWaitMs } : {}),
     ...(initPosts !== undefined ? { initPosts } : {}),
+    // Unconditional — see `LaunchTimingsPayload.hello`. Gated by the same
+    // hidden-tab / anchor drops as every field above, because a launch we do not
+    // observe must not contribute a label either.
+    hello: marks.helloSeen,
   };
 }
 

--- a/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
+++ b/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
@@ -592,37 +592,52 @@ describe('launchHelloLabel — the code-owned stratifier', () => {
   it('maps the booleans onto the two literals, and nothing else', () => {
     expect(launchHelloLabel(true)).toBe('yes');
     expect(launchHelloLabel(false)).toBe('no');
-    expect(APP_BLOCK_LAUNCH_HELLO).toEqual(['yes', 'no']);
+    expect(APP_BLOCK_LAUNCH_HELLO).toEqual(['yes', 'no', 'unknown']);
   });
 
   /**
-   * 🔴 ABSENT IS NOT `false` — the whole reason this returns `null` rather than
-   * defaulting. A client older than the field omits it; a launch with no hello
-   * sends `false`. Collapsing the two would file every stale-client launch into
-   * the `hello="no"` population — the exact group this metric exists to isolate
-   * — as a silent, systematic bias in the direction that flatters the change.
+   * 🔴 ABSENT IS ITS OWN VALUE — neither `no` (which would bias the very
+   * population being isolated) nor a DROP (which would silently cut coverage of
+   * an existing metric, and cut it in a latency-correlated way — see
+   * `launchHelloLabel`). It gets `unknown`, so the sample stays visible and
+   * `sum without (hello)` still recovers every launch.
    */
-  it('🔴 returns null (DROP) for an absent or non-boolean value, never "no"', () => {
-    expect(launchHelloLabel(undefined)).toBe(null);
-    expect(launchHelloLabel(null)).toBe(null);
+  it('🔴 returns `unknown` for an absent or non-boolean value — never "no", never a drop', () => {
+    expect(launchHelloLabel(undefined)).toBe('unknown');
+    expect(launchHelloLabel(null)).toBe('unknown');
     // Truthy/falsy look-alikes must not be coerced — a client sending a string
-    // must not become a label value.
-    expect(launchHelloLabel('yes')).toBe(null);
-    expect(launchHelloLabel('true')).toBe(null);
-    expect(launchHelloLabel(1)).toBe(null);
-    expect(launchHelloLabel(0)).toBe(null);
-    expect(launchHelloLabel({})).toBe(null);
+    // must not become a label value, and must not be read as a boolean either.
+    expect(launchHelloLabel('yes')).toBe('unknown');
+    expect(launchHelloLabel('true')).toBe('unknown');
+    expect(launchHelloLabel(1)).toBe('unknown');
+    expect(launchHelloLabel(0)).toBe('unknown');
+    expect(launchHelloLabel({})).toBe('unknown');
   });
 
   it('🔴 no client-supplied string can become a label value', () => {
     // The beacon field is a BOOLEAN and this is the only mapping, so the label
     // set is closed by construction — the same rule `phase` follows, and what
-    // keeps a public beacon body from touching cardinality.
-    for (const junk of ['maybe', '../../etc', 'yes ', 'YES', '']) {
-      expect(launchHelloLabel(junk)).toBe(null);
+    // keeps a public beacon body from touching cardinality. A junk value lands
+    // in `unknown`, never in a bucket of its own.
+    for (const junk of ['maybe', '../../etc', 'yes ', 'YES', '', 'unknown']) {
+      expect(launchHelloLabel(junk)).toBe('unknown');
+    }
+    // TOTAL: whatever it returns is always inside the closed set.
+    for (const junk of [undefined, null, 1, {}, [], 'x', true, false]) {
+      expect(APP_BLOCK_LAUNCH_HELLO).toContain(launchHelloLabel(junk));
     }
   });
 });
+
+/** Total `_count` across every `hello` value for one phase. */
+async function phaseCountAllHello(phase: string): Promise<number> {
+  const metric = client.register.getSingleMetric(PHASE_METRIC);
+  if (!metric) return 0;
+  const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+  return data.values
+    .filter((v) => v.metricName === `${PHASE_METRIC}_count` && v.labels.phase === phase)
+    .reduce((a, v) => a + v.value, 0);
+}
 
 describe('observeAppBlockLaunch — hello stratification', () => {
   it('labels a hello launch `yes` and a hello-less launch `no`, on BOTH histograms', async () => {
@@ -646,36 +661,56 @@ describe('observeAppBlockLaunch — hello stratification', () => {
   });
 
   /**
-   * 🔴 THE DROP, WITH ITS POSITIVE CONTROL. A stale-client beacon must move
-   * NEITHER labelled histogram — and `launch_total_seconds`, which takes no
-   * `hello` label, must still count it. That asymmetry is deliberate: it makes
-   * the loss visible as a `_count` divergence rather than hiding it.
+   * 🔴 A STALE-CLIENT BEACON IS BUCKETED, NOT DROPPED — and this test is the
+   * reason the earlier design was caught. Dropping it cut `launch_phase_seconds`
+   * coverage for any browser bundle older than the label (the beacon route runs
+   * no client-version gate, so those persist as long as their tab does), and cut
+   * it in a latency-correlated way: a pre-label bundle is also a pre-cadence
+   * bundle, so the dropped launches were systematically the slow ones.
+   *
+   * 🔴 THE ASSERTION IS ON `unknown` MOVING, NOT ONLY ON yes/no STAYING PUT. An
+   * earlier version of this test checked only that `yes` and `no` did not move —
+   * which stayed green after the drop was removed, because a bucketed sample
+   * does not move them either. Green for the wrong reason is the failure mode a
+   * negative-only assertion invites.
    */
-  it('🔴 DROPS a sample with no usable hello from both labelled histograms', async () => {
+  it('🔴 buckets a hello-less beacon as `unknown` — coverage is preserved, yes/no stay clean', async () => {
     const app = 'apb_hello_absent';
     const t0 = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
     const pY = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'yes' });
     const pN = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' });
-    const iY = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'yes' });
-    const iN = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+    const pU = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'unknown' });
+    const iU = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'unknown' });
 
-    // A complete, otherwise-valid launch — only `hello` is missing.
+    // Exactly what a browser bundle older than this label sends.
     observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, initPosts: 2 });
 
+    // 🔴 The sample IS observed — this is the coverage regression that the
+    // drop-based design introduced and this bucket removes.
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'unknown' })).toBe(
+      pU + 1
+    );
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'unknown' })).toBe(iU + 1);
+    // …and neither analysis bucket is contaminated.
     expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'yes' })).toBe(pY);
     expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' })).toBe(pN);
-    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'yes' })).toBe(iY);
-    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(iN);
-    // 🔴 …but the launch IS still counted end-to-end, so a zero above is a fact
-    // about the gate and not about a metric wired to nothing.
+    // …and the end-to-end count still matches, as it always did.
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(t0 + 1);
+  });
 
-    // POSITIVE CONTROL: the identical sample WITH a boolean is observed.
-    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, initPosts: 2, hello: false });
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' })).toBe(
-      pN + 1
-    );
-    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(iN + 1);
+  /**
+   * 🔴 THE COVERAGE INVARIANT, stated directly: summing the phase histogram over
+   * every `hello` value must recover the pre-label series exactly. This is what
+   * makes `sum without (hello)` a safe rewrite of any existing query, and it is
+   * the property the drop-based design silently broke.
+   */
+  it('🔴 sum over all hello values equals one sample per launch — no launch is lost', async () => {
+    const app = 'apb_hello_coverage';
+    const before = await phaseCountAllHello('init_wait');
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, hello: true });
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, hello: false });
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300 }); // stale client
+    expect(await phaseCountAllHello('init_wait')).toBe(before + 3);
   });
 
   it('🔴 the existing discipline still gates the label — total anchor, drop-not-clamp', async () => {

--- a/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
+++ b/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
@@ -21,6 +21,8 @@ import client from 'prom-client';
  */
 
 import {
+  APP_BLOCK_LAUNCH_HELLO,
+  launchHelloLabel,
   launchInitPostsSample,
   launchSampleSeconds,
   MAX_APP_BLOCK_LAUNCH_INIT_POSTS,
@@ -138,14 +140,21 @@ describe('observeAppBlockLaunch', () => {
   it('observes the total on the per-app histogram and each phase on the phase histogram', async () => {
     const app = 'apb_launch_ok';
     const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
-    const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
-    const beforeInit = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' });
+    const beforeToken = await readHist(PHASE_METRIC, '_count', {
+      hello: 'no',
+      phase: 'token_mint',
+    });
+    const beforeInit = await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'init_wait' });
 
-    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 });
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700, hello: false });
 
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken + 1);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforeInit + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'token_mint' })).toBe(
+      beforeToken + 1
+    );
+    expect(await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'init_wait' })).toBe(
+      beforeInit + 1
+    );
   });
 
   /**
@@ -176,7 +185,7 @@ describe('observeAppBlockLaunch', () => {
   it('records the total in SECONDS on _sum (not milliseconds)', async () => {
     const app = 'apb_launch_sum';
     const before = await readHist(TOTAL_METRIC, '_sum', { app_block_id: app });
-    observeAppBlockLaunch(app, { totalMs: 2_500 });
+    observeAppBlockLaunch(app, { totalMs: 2_500, hello: false });
     expect(await readHist(TOTAL_METRIC, '_sum', { app_block_id: app })).toBeCloseTo(
       before + 2.5,
       6
@@ -186,42 +195,59 @@ describe('observeAppBlockLaunch', () => {
   it('🔴 `total` is the ANCHOR — an invalid total suppresses the PHASES too', async () => {
     const app = 'apb_launch_anchor';
     const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
-    const beforePhase = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' });
+    const beforePhase = await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'init_wait' });
 
     // A perfectly valid phase, but no usable total.
-    observeAppBlockLaunch(app, { totalMs: 0, initWaitMs: 700 });
+    observeAppBlockLaunch(app, { totalMs: 0, initWaitMs: 700, hello: false });
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforePhase);
+    expect(await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'init_wait' })).toBe(
+      beforePhase
+    );
 
     // 🔴 POSITIVE CONTROL. Without this, the two zeros above are indistinguishable
     // from a histogram that is wired to nothing at all. Same phase, same value,
     // only the total made valid → the counter MUST move by exactly 1.
-    observeAppBlockLaunch(app, { totalMs: 1_100, initWaitMs: 700 });
+    observeAppBlockLaunch(app, { totalMs: 1_100, initWaitMs: 700, hello: false });
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforePhase + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'init_wait' })).toBe(
+      beforePhase + 1
+    );
   });
 
   it('🔴 omits a ZERO phase while still recording the total', async () => {
     const app = 'apb_launch_zero_phase';
     const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
-    const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
+    const beforeToken = await readHist(PHASE_METRIC, '_count', {
+      hello: 'no',
+      phase: 'token_mint',
+    });
 
-    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 0 });
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 0, hello: false });
 
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken);
+    expect(await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'token_mint' })).toBe(
+      beforeToken
+    );
   });
 
   it('🔴 DROPS an out-of-range phase rather than clamping it onto the top bucket', async () => {
     const app = 'apb_launch_drop_phase';
-    const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
-    const beforeSum = await readHist(PHASE_METRIC, '_sum', { phase: 'token_mint' });
+    const beforeToken = await readHist(PHASE_METRIC, '_count', {
+      hello: 'no',
+      phase: 'token_mint',
+    });
+    const beforeSum = await readHist(PHASE_METRIC, '_sum', { hello: 'no', phase: 'token_mint' });
 
-    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 61_000 });
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 61_000, hello: false });
 
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken);
+    expect(await readHist(PHASE_METRIC, '_count', { hello: 'no', phase: 'token_mint' })).toBe(
+      beforeToken
+    );
     // The thing a clamp would break: _sum must be untouched, not +60.
-    expect(await readHist(PHASE_METRIC, '_sum', { phase: 'token_mint' })).toBeCloseTo(beforeSum, 6);
+    expect(await readHist(PHASE_METRIC, '_sum', { hello: 'no', phase: 'token_mint' })).toBeCloseTo(
+      beforeSum,
+      6
+    );
   });
 
   it('does nothing when `timings` is absent', async () => {
@@ -242,7 +268,7 @@ describe('observeAppBlockLaunch', () => {
 describe('launch histogram bucket boundaries', () => {
   it('uses the launch-specific edges, NOT prom-client defaults', async () => {
     // Force registration + at least one bucket row.
-    observeAppBlockLaunch('apb_launch_buckets', { totalMs: 300, tokenMintMs: 300 });
+    observeAppBlockLaunch('apb_launch_buckets', { totalMs: 300, tokenMintMs: 300, hello: false });
 
     const expected = [0.1, 0.25, 0.4, 0.6, 0.8, 1.2, 1.8, 2.5, 4, 6, 8, 10, 15];
     expect(await bucketEdges(TOTAL_METRIC)).toEqual(expected);
@@ -261,15 +287,15 @@ describe('launch histogram bucket boundaries', () => {
     // fresh app label, so a `readBucket` that matched nothing would make the
     // 0.25 assertion pass for the wrong reason. Prove the reader can observe a
     // non-zero first.
-    observeAppBlockLaunch(app, { totalMs: 50 });
+    observeAppBlockLaunch(app, { totalMs: 50, hello: false });
     expect(await readBucket(TOTAL_METRIC, '0.1', { app_block_id: app })).toBe(1);
 
     const before025 = await readBucket(TOTAL_METRIC, '0.25', { app_block_id: app });
     const before04 = await readBucket(TOTAL_METRIC, '0.4', { app_block_id: app });
     const before06 = await readBucket(TOTAL_METRIC, '0.6', { app_block_id: app });
 
-    observeAppBlockLaunch(app, { totalMs: 300 });
-    observeAppBlockLaunch(app, { totalMs: 500 });
+    observeAppBlockLaunch(app, { totalMs: 300, hello: false });
+    observeAppBlockLaunch(app, { totalMs: 500, hello: false });
 
     // Buckets are cumulative: 300ms is <= 0.4 but > 0.25; 500ms is <= 0.6 only.
     expect(await readBucket(TOTAL_METRIC, '0.25', { app_block_id: app })).toBe(before025);
@@ -294,7 +320,7 @@ describe('launch histogram bucket boundaries', () => {
     const beforeSum = await readHist(TOTAL_METRIC, '_sum', { app_block_id: app });
 
     // A success on attempt 3 of the bounded sequence.
-    observeAppBlockLaunch(app, { totalMs: 28_000 });
+    observeAppBlockLaunch(app, { totalMs: 28_000, hello: false });
 
     // Above every finite edge…
     expect(await readBucket(TOTAL_METRIC, '15', { app_block_id: app })).toBe(before15);
@@ -364,39 +390,44 @@ describe('launchInitPostsSample — the count gate', () => {
 
 describe('observeAppBlockLaunch — initPosts', () => {
   it('observes exactly ONE sample per successful launch that carries a count', async () => {
-    const before = await readHist(INIT_POSTS_METRIC, '_count', {});
-    const beforeSum = await readHist(INIT_POSTS_METRIC, '_sum', {});
+    const before = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+    const beforeSum = await readHist(INIT_POSTS_METRIC, '_sum', { hello: 'no' });
     observeAppBlockLaunch('apb_initposts_one', {
       totalMs: 1_100,
       initWaitMs: 700,
       initPosts: 3,
+      hello: false,
     });
-    expect(await readHist(INIT_POSTS_METRIC, '_count', {})).toBe(before + 1);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(before + 1);
     // The REAL value reaches _sum — a distinct, non-1 count so this cannot pass
     // against a mutant that observes a constant.
-    expect(await readHist(INIT_POSTS_METRIC, '_sum', {})).toBe(beforeSum + 3);
+    expect(await readHist(INIT_POSTS_METRIC, '_sum', { hello: 'no' })).toBe(beforeSum + 3);
   });
 
   it('🔴 the le=1 vs le=2 gap is resolvable — the whole point of the edges', async () => {
     // If the first bucket were `le=2`, a single-post launch and a two-post
     // launch would be indistinguishable, which is precisely the distinction the
     // metric exists to make.
-    const beforeOne = await readBucket(INIT_POSTS_METRIC, '1', {});
-    const beforeTwo = await readBucket(INIT_POSTS_METRIC, '2', {});
-    observeAppBlockLaunch('apb_initposts_edges', { totalMs: 500, initPosts: 2 });
+    const beforeOne = await readBucket(INIT_POSTS_METRIC, '1', { hello: 'no' });
+    const beforeTwo = await readBucket(INIT_POSTS_METRIC, '2', { hello: 'no' });
+    observeAppBlockLaunch('apb_initposts_edges', { totalMs: 500, initPosts: 2, hello: false });
     // A 2-post launch does NOT count at le=1…
-    expect(await readBucket(INIT_POSTS_METRIC, '1', {})).toBe(beforeOne);
+    expect(await readBucket(INIT_POSTS_METRIC, '1', { hello: 'no' })).toBe(beforeOne);
     // …but does at le=2 (buckets are cumulative).
-    expect(await readBucket(INIT_POSTS_METRIC, '2', {})).toBe(beforeTwo + 1);
+    expect(await readBucket(INIT_POSTS_METRIC, '2', { hello: 'no' })).toBe(beforeTwo + 1);
 
-    observeAppBlockLaunch('apb_initposts_edges', { totalMs: 500, initPosts: 1 });
-    expect(await readBucket(INIT_POSTS_METRIC, '1', {})).toBe(beforeOne + 1);
+    observeAppBlockLaunch('apb_initposts_edges', { totalMs: 500, initPosts: 1, hello: false });
+    expect(await readBucket(INIT_POSTS_METRIC, '1', { hello: 'no' })).toBe(beforeOne + 1);
   });
 
   it('🔴 observes NOTHING when the count is absent — with a positive control', async () => {
-    const before = await readHist(INIT_POSTS_METRIC, '_count', {});
-    observeAppBlockLaunch('apb_initposts_absent', { totalMs: 1_100, initWaitMs: 700 });
-    expect(await readHist(INIT_POSTS_METRIC, '_count', {})).toBe(before);
+    const before = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+    observeAppBlockLaunch('apb_initposts_absent', {
+      totalMs: 1_100,
+      initWaitMs: 700,
+      hello: false,
+    });
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(before);
     // 🔴 POSITIVE CONTROL. Without this, "0 observations" is indistinguishable
     // from a histogram wired to nothing, and every absence assertion in this
     // file would be vacuously green.
@@ -404,49 +435,70 @@ describe('observeAppBlockLaunch — initPosts', () => {
       totalMs: 1_100,
       initWaitMs: 700,
       initPosts: 5,
+      hello: false,
     });
-    expect(await readHist(INIT_POSTS_METRIC, '_count', {})).toBe(before + 1);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(before + 1);
   });
 
   it('🔴 DROPS an out-of-range count without touching _sum or the tail', async () => {
-    const beforeCount = await readHist(INIT_POSTS_METRIC, '_count', {});
-    const beforeSum = await readHist(INIT_POSTS_METRIC, '_sum', {});
+    const beforeCount = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+    const beforeSum = await readHist(INIT_POSTS_METRIC, '_sum', { hello: 'no' });
     observeAppBlockLaunch('apb_initposts_huge', {
       totalMs: 1_100,
       initPosts: MAX_APP_BLOCK_LAUNCH_INIT_POSTS + 1,
+      hello: false,
     });
     // A clamp would have incremented BOTH — and the increment would sit in the
     // top bucket, reading as the strongest possible quantization evidence.
-    expect(await readHist(INIT_POSTS_METRIC, '_count', {})).toBe(beforeCount);
-    expect(await readHist(INIT_POSTS_METRIC, '_sum', {})).toBe(beforeSum);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(beforeCount);
+    expect(await readHist(INIT_POSTS_METRIC, '_sum', { hello: 'no' })).toBe(beforeSum);
   });
 
   it('🔴 is suppressed with the phases when `total` is invalid (total is the anchor)', async () => {
-    const before = await readHist(INIT_POSTS_METRIC, '_count', {});
+    const before = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
     // A post count with no end-to-end duration to interpret it against is an
     // orphan that still moves the distribution.
-    observeAppBlockLaunch('apb_initposts_anchor', { totalMs: 0, initPosts: 4 });
-    observeAppBlockLaunch('apb_initposts_anchor', { totalMs: undefined, initPosts: 4 });
-    expect(await readHist(INIT_POSTS_METRIC, '_count', {})).toBe(before);
+    observeAppBlockLaunch('apb_initposts_anchor', { totalMs: 0, initPosts: 4, hello: false });
+    observeAppBlockLaunch('apb_initposts_anchor', {
+      totalMs: undefined,
+      initPosts: 4,
+      hello: false,
+    });
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(before);
     // POSITIVE CONTROL: the identical count with a VALID total is observed.
-    observeAppBlockLaunch('apb_initposts_anchor', { totalMs: 900, initPosts: 4 });
-    expect(await readHist(INIT_POSTS_METRIC, '_count', {})).toBe(before + 1);
+    observeAppBlockLaunch('apb_initposts_anchor', { totalMs: 900, initPosts: 4, hello: false });
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(before + 1);
   });
 
   it('carries the bucket edges the design justified, not prom-client defaults', async () => {
-    observeAppBlockLaunch('apb_initposts_buckets', { totalMs: 900, initPosts: 1 });
+    observeAppBlockLaunch('apb_initposts_buckets', { totalMs: 900, initPosts: 1, hello: false });
     expect(await bucketEdges(INIT_POSTS_METRIC)).toEqual([
       1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 28, 40, 64,
     ]);
   });
 
-  it('🔴 carries NO labels (the cardinality decision, asserted)', async () => {
-    observeAppBlockLaunch('apb_initposts_labels', { totalMs: 900, initPosts: 2 });
+  /**
+   * 🔴 THE CARDINALITY DECISION, ASSERTED — and it is now `hello` AND NOTHING
+   * ELSE. This histogram deliberately carries no `app_block_id` (that would be
+   * ~52x) and no `phase` (there is one phase it can be about). `hello` is the
+   * single dimension it is allowed, because without it the `le=1` share pools
+   * accelerator apps with cadence-bound ones and answers the wrong question.
+   *
+   * An EXACT key-set equality, not a `toContain`: the failure mode this guards
+   * is a label being ADDED, so a subset test would not see it.
+   */
+  it('🔴 carries EXACTLY the `hello` label — no app_block_id, no phase', async () => {
+    observeAppBlockLaunch('apb_initposts_labels', { totalMs: 900, initPosts: 2, hello: false });
     const metric = client.register.getSingleMetric(INIT_POSTS_METRIC);
     const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+    expect(data.values.length).toBeGreaterThan(0); // guard the guard: not a vacuous loop
     for (const v of data.values) {
       // `le` is the histogram's own bucket key, not a dimension we chose.
-      expect(Object.keys(v.labels).filter((k) => k !== 'le')).toEqual([]);
+      expect(
+        Object.keys(v.labels)
+          .filter((k) => k !== 'le')
+          .sort()
+      ).toEqual(['hello']);
     }
   });
 
@@ -483,21 +535,22 @@ describe('launch_init_posts: the denominator is its OWN _count', () => {
   it('🔴 the two histograms’ _count series genuinely diverge', async () => {
     const app = 'apb_denominator_guard';
     const t0 = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
-    const i0 = await readHist(INIT_POSTS_METRIC, '_count', {});
+    const i0 = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
 
     // (a) acked before any BLOCK_INIT was posted — count 0, dropped.
-    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 400 });
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 400, hello: false });
     // (b) manual-retry storm past the cap — dropped, never clamped.
     observeAppBlockLaunch(app, {
       totalMs: 51_000,
       initWaitMs: 50_000,
       initPosts: MAX_APP_BLOCK_LAUNCH_INIT_POSTS + 17,
+      hello: false,
     });
     // (c) an ordinary launch — observed by both.
-    observeAppBlockLaunch(app, { totalMs: 500, initWaitMs: 200, initPosts: 1 });
+    observeAppBlockLaunch(app, { totalMs: 500, initWaitMs: 200, initPosts: 1, hello: false });
 
     const dTotal = (await readHist(TOTAL_METRIC, '_count', { app_block_id: app })) - t0;
-    const dPosts = (await readHist(INIT_POSTS_METRIC, '_count', {})) - i0;
+    const dPosts = (await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })) - i0;
 
     // 3 launches reached the total histogram; only 1 reached this one.
     expect(dTotal).toBe(3);
@@ -515,5 +568,147 @@ describe('launch_init_posts: the denominator is its OWN _count', () => {
     expect(help).toContain('civitai_app_block_launch_init_posts_count');
     expect(help).toContain('NEVER `launch_total_seconds_count`');
     expect(help).toContain('UNDERSTATES');
+  });
+});
+
+/**
+ * 🔴 THE `hello` STRATIFIER — the label that makes the cadence change gradeable.
+ *
+ * WHY IT EXISTS. `civitai_app_block_launch_phase_seconds` carries no
+ * `app_block_id` (deliberate, for cardinality), and the deployed apps that ship
+ * the BLOCK_HELLO accelerator are the majority of launch traffic. BLOCK_HELLO
+ * short-circuits exactly the wait the host re-post cadence governs, so a
+ * fleet-wide `init_wait` before/after is mostly composed of launches the change
+ * barely touches — and that mass cannot be separated without this label. A
+ * diluted null would be indistinguishable from "the change did nothing".
+ *
+ * 🔴 WHAT IT MEANS, pinned as behaviour and not only as prose: `yes` means the
+ * GUEST ANNOUNCED during the launch. It does NOT mean "the accelerator fired an
+ * extra post" — those are different facts that disagree on real launches, and
+ * the ambiguous-label failure is exactly how a relabelled series produced a
+ * confident wrong number before.
+ */
+describe('launchHelloLabel — the code-owned stratifier', () => {
+  it('maps the booleans onto the two literals, and nothing else', () => {
+    expect(launchHelloLabel(true)).toBe('yes');
+    expect(launchHelloLabel(false)).toBe('no');
+    expect(APP_BLOCK_LAUNCH_HELLO).toEqual(['yes', 'no']);
+  });
+
+  /**
+   * 🔴 ABSENT IS NOT `false` — the whole reason this returns `null` rather than
+   * defaulting. A client older than the field omits it; a launch with no hello
+   * sends `false`. Collapsing the two would file every stale-client launch into
+   * the `hello="no"` population — the exact group this metric exists to isolate
+   * — as a silent, systematic bias in the direction that flatters the change.
+   */
+  it('🔴 returns null (DROP) for an absent or non-boolean value, never "no"', () => {
+    expect(launchHelloLabel(undefined)).toBe(null);
+    expect(launchHelloLabel(null)).toBe(null);
+    // Truthy/falsy look-alikes must not be coerced — a client sending a string
+    // must not become a label value.
+    expect(launchHelloLabel('yes')).toBe(null);
+    expect(launchHelloLabel('true')).toBe(null);
+    expect(launchHelloLabel(1)).toBe(null);
+    expect(launchHelloLabel(0)).toBe(null);
+    expect(launchHelloLabel({})).toBe(null);
+  });
+
+  it('🔴 no client-supplied string can become a label value', () => {
+    // The beacon field is a BOOLEAN and this is the only mapping, so the label
+    // set is closed by construction — the same rule `phase` follows, and what
+    // keeps a public beacon body from touching cardinality.
+    for (const junk of ['maybe', '../../etc', 'yes ', 'YES', '']) {
+      expect(launchHelloLabel(junk)).toBe(null);
+    }
+  });
+});
+
+describe('observeAppBlockLaunch — hello stratification', () => {
+  it('labels a hello launch `yes` and a hello-less launch `no`, on BOTH histograms', async () => {
+    const app = 'apb_hello_split';
+    const pY = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'yes' });
+    const pN = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' });
+    const iY = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'yes' });
+    const iN = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, initPosts: 1, hello: true });
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 500, initPosts: 3, hello: false });
+
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'yes' })).toBe(
+      pY + 1
+    );
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' })).toBe(
+      pN + 1
+    );
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'yes' })).toBe(iY + 1);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(iN + 1);
+  });
+
+  /**
+   * 🔴 THE DROP, WITH ITS POSITIVE CONTROL. A stale-client beacon must move
+   * NEITHER labelled histogram — and `launch_total_seconds`, which takes no
+   * `hello` label, must still count it. That asymmetry is deliberate: it makes
+   * the loss visible as a `_count` divergence rather than hiding it.
+   */
+  it('🔴 DROPS a sample with no usable hello from both labelled histograms', async () => {
+    const app = 'apb_hello_absent';
+    const t0 = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+    const pY = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'yes' });
+    const pN = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' });
+    const iY = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'yes' });
+    const iN = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+
+    // A complete, otherwise-valid launch — only `hello` is missing.
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, initPosts: 2 });
+
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'yes' })).toBe(pY);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' })).toBe(pN);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'yes' })).toBe(iY);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(iN);
+    // 🔴 …but the launch IS still counted end-to-end, so a zero above is a fact
+    // about the gate and not about a metric wired to nothing.
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(t0 + 1);
+
+    // POSITIVE CONTROL: the identical sample WITH a boolean is observed.
+    observeAppBlockLaunch(app, { totalMs: 900, initWaitMs: 300, initPosts: 2, hello: false });
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' })).toBe(
+      pN + 1
+    );
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(iN + 1);
+  });
+
+  it('🔴 the existing discipline still gates the label — total anchor, drop-not-clamp', async () => {
+    const app = 'apb_hello_discipline';
+    const pN = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' });
+    const iN = await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' });
+    // An invalid total suppresses everything, label or no label.
+    observeAppBlockLaunch(app, { totalMs: 0, initWaitMs: 300, initPosts: 2, hello: false });
+    // An out-of-range count is dropped rather than clamped into the `no` bucket.
+    observeAppBlockLaunch(app, {
+      totalMs: 900,
+      initPosts: MAX_APP_BLOCK_LAUNCH_INIT_POSTS + 1,
+      hello: false,
+    });
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait', hello: 'no' })).toBe(pN);
+    expect(await readHist(INIT_POSTS_METRIC, '_count', { hello: 'no' })).toBe(iN);
+  });
+
+  it('carries exactly {phase, hello} on the phase histogram — no app_block_id leaked in', async () => {
+    observeAppBlockLaunch('apb_hello_phaselabels', {
+      totalMs: 900,
+      initWaitMs: 300,
+      hello: true,
+    });
+    const metric = client.register.getSingleMetric(PHASE_METRIC);
+    const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+    expect(data.values.length).toBeGreaterThan(0);
+    for (const v of data.values) {
+      expect(
+        Object.keys(v.labels)
+          .filter((k) => k !== 'le')
+          .sort()
+      ).toEqual(['hello', 'phase']);
+    }
   });
 });

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -105,6 +105,57 @@ export const APP_BLOCK_LAUNCH_PHASES = ['token_mint', 'init_wait'] as const;
 export type AppBlockLaunchPhase = (typeof APP_BLOCK_LAUNCH_PHASES)[number];
 
 /**
+ * The `hello` stratifier's closed label set. CODE-OWNED, exactly like `phase`:
+ * the beacon carries a BOOLEAN and this module maps it onto these two literals,
+ * so no client-supplied string can ever reach a label value.
+ *
+ * 🔴 MEANING — one fact, named precisely, because two readings exist and they
+ * disagree on real launches:
+ *
+ *   `yes` — the guest sent BLOCK_HELLO at some point during the launch window.
+ *   `no`  — it did not.
+ *
+ * 🔴 IT IS **NOT** "the accelerator fired an extra BLOCK_INIT". A hello arriving
+ * before the controller starts is recorded but posts nothing (`start()` posts
+ * immediately anyway). Under the other reading that launch would be filed `no`
+ * while its listener was demonstrably attached — pushing a fast,
+ * accelerator-capable launch into the population that exists to isolate
+ * cadence-bound ones, and biasing the read toward "the change did nothing".
+ * The client-side argument is on `LaunchMarks.helloSeen`.
+ *
+ * WHY IT EXISTS: the four deployed apps shipping the accelerator are the
+ * majority of launch traffic, and BLOCK_HELLO short-circuits precisely the wait
+ * the re-post cadence governs. Without this label the fleet-wide `init_wait`
+ * distribution is mostly composed of launches the cadence change barely touches,
+ * that mass cannot be separated (the phase histogram carries no `app_block_id`
+ * by design), and a diluted null is indistinguishable from no effect.
+ */
+export const APP_BLOCK_LAUNCH_HELLO = ['yes', 'no'] as const;
+export type AppBlockLaunchHello = (typeof APP_BLOCK_LAUNCH_HELLO)[number];
+
+/**
+ * Map the beacon's boolean onto the label, or `null` to DROP the sample.
+ *
+ * 🔴 ABSENT IS NOT `false`, AND THAT DISTINCTION IS THE WHOLE POINT. A client
+ * that predates the field omits it; a launch that saw no hello sends `false`.
+ * Labelling the first `no` would file every stale-client launch into the exact
+ * population this metric exists to isolate — a systematic, invisible bias in the
+ * direction that flatters the cadence change. So an absent or non-boolean value
+ * DROPS the observation instead.
+ *
+ * The cost is bounded and honest: during a rollout window the two LABELLED
+ * histograms under-count, while `launch_total_seconds` — which takes no `hello`
+ * label — still counts every launch, so the loss is visible as a `_count`
+ * divergence rather than hidden. A missing sample is recoverable; a mislabelled
+ * one is not.
+ */
+export function launchHelloLabel(value: unknown): AppBlockLaunchHello | null {
+  if (value === true) return 'yes';
+  if (value === false) return 'no';
+  return null;
+}
+
+/**
  * Why `resolveAppCapLimits` fell back to `STRICTEST_APP_CAP_LIMITS` instead of
  * resolving the app's real ceilings. The two mean DIFFERENT things and an
  * operator responds to them differently, which is the whole reason this is a
@@ -700,8 +751,8 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const launchPhaseSeconds = getOrCreateHistogram(
     reg,
     'civitai_app_block_launch_phase_seconds',
-    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; init_wait = first BLOCK_INIT -> BLOCK_READY). Both are host-side, so both are observed for every successful launch. 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total. There is deliberately no cross-origin frame-fetch phase — see launchTimings.ts.',
-    ['phase'],
+    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; init_wait = first BLOCK_INIT -> BLOCK_READY) and by `hello`. Both phases are host-side. 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total. There is deliberately no cross-origin frame-fetch phase — see launchTimings.ts. 🔴 `hello` = did the GUEST announce BLOCK_HELLO during this launch (yes|no) — NOT whether the accelerator fired an extra post; see launchHelloLabel. It exists because BLOCK_HELLO short-circuits the very wait the host re-post cadence governs, so `init_wait` must be read WITHIN a `hello` value: comparing the unstratified aggregate across a cadence change mixes two populations and dilutes toward the null. 🔴 RETROACTIVE LIMIT: samples recorded before this label shipped carry no `hello` and can never be stratified, so a post-vs-pre read is only sound for hello="no"; the within-period hello="no" vs hello="yes" contrast is the clean one. 🔴 A sample whose beacon carried no usable boolean is DROPPED here but still counted in launch_total_seconds, so these _count series legitimately diverge during a rollout.',
+    ['phase', 'hello'],
     APP_BLOCK_LAUNCH_BUCKETS
   );
 
@@ -722,8 +773,8 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const launchInitPostsTotal = getOrCreateHistogram(
     reg,
     'civitai_app_block_launch_init_posts',
-    "BLOCK_INIT posts the host made before the block acknowledged with BLOCK_READY, per successful non-secondary launch. 🔴 THIS IS THE DISCRIMINATOR FOR `init_wait`: the share at `le=1` says whether launches ack on the first post (so `init_wait` is the block's own boot time and the re-post cadence is not the lever) or wait out re-post ticks (so the cadence IS the lever). A `le=1` share that RISES after a cadence change, at unchanged or lower `init_wait`, is the intended effect. Read as a share, never as a raw count. 🔴 THE DENOMINATOR IS THIS HISTOGRAM'S OWN `_count`, NEVER `launch_total_seconds_count` — the two DIVERGE, and not randomly. A launch is counted in `launch_total_seconds` but NOT here whenever the post count is unusable: a block that posts BLOCK_READY before the host ever sent an init (count 0 — reachable today, e.g. a hand-rolled host shim acking while the token is still resolving), or a manual-retry storm pushing the count past the cap. The first case is FAST, no-quantization traffic, so dividing by the larger series subtracts it from the numerator but not the denominator and UNDERSTATES the `le=1` share — i.e. it makes the data look more quantized than it is, which is the direction that flatters the cadence change. Use `civitai_app_block_launch_init_posts_count`. Unlabelled by design.",
-    [],
+    'BLOCK_INIT posts the host made before the block acknowledged with BLOCK_READY, per successful non-secondary launch. 🔴 THIS IS THE DISCRIMINATOR FOR `init_wait`: the share at `le=1` says whether launches ack on the first post (so `init_wait` is the block\'s own boot time and the re-post cadence is not the lever) or wait out re-post ticks (so the cadence IS the lever). A `le=1` share that RISES after a cadence change, at unchanged or lower `init_wait`, is the intended effect. Read as a share, never as a raw count. 🔴 THE DENOMINATOR IS THIS HISTOGRAM\'S OWN `_count`, NEVER `launch_total_seconds_count` — the two DIVERGE, and not randomly. A launch is counted in `launch_total_seconds` but NOT here whenever the post count is unusable: a block that posts BLOCK_READY before the host ever sent an init (count 0 — reachable today, e.g. a hand-rolled host shim acking while the token is still resolving), or a manual-retry storm pushing the count past the cap. The first case is FAST, no-quantization traffic, so dividing by the larger series subtracts it from the numerator but not the denominator and UNDERSTATES the `le=1` share — i.e. it makes the data look more quantized than it is, which is the direction that flatters the cadence change. Use `civitai_app_block_launch_init_posts_count`, AND read it within a single `hello` value. 🔴 `hello` = did the GUEST announce BLOCK_HELLO during this launch (yes|no) — NOT whether the accelerator fired; see launchHelloLabel. Stratifying matters most here: `hello="no"` is the population whose first-post-sufficiency the re-post cadence actually governs, so the `le=1` share AMONG hello="no" is the mechanism read, while the pooled share is dominated by accelerator apps. 🔴 RETROACTIVE LIMIT: pre-label samples carry no `hello` and cannot be stratified. A sample whose beacon carried no usable boolean is DROPPED rather than labelled `no`.',
+    ['hello'],
     APP_BLOCK_LAUNCH_INIT_POST_BUCKETS
   );
 
@@ -753,6 +804,8 @@ export type AppBlockLaunchTimings = {
   initWaitMs?: unknown;
   /** A COUNT, not a duration — see `launchInitPostsSample`. */
   initPosts?: unknown;
+  /** BOOLEAN stratifier — see `launchHelloLabel`. Absent is NOT `false`. */
+  hello?: unknown;
 };
 
 /**
@@ -786,6 +839,15 @@ export function observeAppBlockLaunch(
       ensureRegisterAppBlockRuntimeMetrics();
     launchTotalSeconds.observe({ app_block_id: appBlockIdLabel }, total);
 
+    // 🔴 THE STRATIFIER GATES BOTH LABELLED HISTOGRAMS. `null` means the beacon
+    // carried no usable boolean — a client older than the field — and the sample
+    // is DROPPED rather than guessed at. Labelling it `no` would file every
+    // stale-client launch into the population this metric exists to isolate.
+    // `launch_total_seconds` above takes no `hello` label and is deliberately
+    // observed BEFORE this gate, so it still counts every launch and the drop
+    // shows up as a `_count` divergence instead of vanishing.
+    const hello = launchHelloLabel(timings.hello);
+
     const phases: Array<[AppBlockLaunchPhase, unknown]> = [
       ['token_mint', timings.tokenMintMs],
       ['init_wait', timings.initWaitMs],
@@ -793,14 +855,15 @@ export function observeAppBlockLaunch(
     for (const [phase, ms] of phases) {
       const seconds = launchSampleSeconds(ms);
       if (seconds === null) continue;
-      launchPhaseSeconds.observe({ phase }, seconds);
+      if (hello === null) continue;
+      launchPhaseSeconds.observe({ phase, hello }, seconds);
     }
 
     // Behind the same `total` anchor as the phases above, deliberately: a post
     // count with no end-to-end duration to interpret it against is an orphan,
     // and the reader's whole question is "how many posts for THAT init_wait".
     const initPosts = launchInitPostsSample(timings.initPosts);
-    if (initPosts !== null) launchInitPostsTotal.observe(initPosts);
+    if (initPosts !== null && hello !== null) launchInitPostsTotal.observe({ hello }, initPosts);
   } catch {
     /* instrument-only — never let a metrics error touch the beacon response */
   }

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -130,29 +130,45 @@ export type AppBlockLaunchPhase = (typeof APP_BLOCK_LAUNCH_PHASES)[number];
  * that mass cannot be separated (the phase histogram carries no `app_block_id`
  * by design), and a diluted null is indistinguishable from no effect.
  */
-export const APP_BLOCK_LAUNCH_HELLO = ['yes', 'no'] as const;
+export const APP_BLOCK_LAUNCH_HELLO = ['yes', 'no', 'unknown'] as const;
 export type AppBlockLaunchHello = (typeof APP_BLOCK_LAUNCH_HELLO)[number];
 
 /**
- * Map the beacon's boolean onto the label, or `null` to DROP the sample.
+ * Map the beacon's boolean onto the label. TOTAL — every launch gets a bucket.
  *
- * 🔴 ABSENT IS NOT `false`, AND THAT DISTINCTION IS THE WHOLE POINT. A client
- * that predates the field omits it; a launch that saw no hello sends `false`.
- * Labelling the first `no` would file every stale-client launch into the exact
- * population this metric exists to isolate — a systematic, invisible bias in the
- * direction that flatters the cadence change. So an absent or non-boolean value
- * DROPS the observation instead.
+ * 🔴 ABSENT IS NEITHER `yes` NOR `no`; IT IS ITS OWN VALUE. A client older than
+ * this field omits it; a launch that saw no hello sends `false`. Collapsing the
+ * two would file every stale-client launch into the `no` population this metric
+ * exists to isolate — a systematic bias in the direction that flatters the
+ * cadence change.
  *
- * The cost is bounded and honest: during a rollout window the two LABELLED
- * histograms under-count, while `launch_total_seconds` — which takes no `hello`
- * label — still counts every launch, so the loss is visible as a `_count`
- * divergence rather than hidden. A missing sample is recoverable; a mislabelled
- * one is not.
+ * 🔴 BUT DROPPING THE SAMPLE IS ALSO WRONG, and that was this function's first
+ * design. Measured: on the previous revision a beacon with no `hello` key
+ * contributed NO `launch_phase_seconds` sample at all, while the same beacon
+ * against the pre-label module contributed one. That is a silent COVERAGE
+ * REGRESSION on an existing metric — and it is not bounded by a deploy window,
+ * because the "old client" here is a BROWSER BUNDLE, not a server pod: the
+ * beacon route deliberately skips the client-version middleware, so a tab opened
+ * before the deploy keeps sending the old shape for as long as it stays open.
+ *
+ * Worse, the loss is CORRELATED with the thing being measured. A pre-label
+ * bundle is also a pre-cadence-change bundle, so the dropped launches are
+ * systematically the slow-cadence ones — removing them makes the unstratified
+ * phase aggregate look FASTER than reality across the deploy, in the direction
+ * that flatters the change. A drop is only harmless when droppedness is
+ * independent of latency, and here it is not.
+ *
+ * So the third bucket keeps the sample VISIBLE without contaminating either
+ * analysis population: `sum without (hello)` recovers exactly the pre-label
+ * series, `yes`/`no` stay clean, and the size of the stale-client tail is a
+ * value anyone can read off the metric instead of a `_count` divergence nobody
+ * is watching. (Checked: nothing in the cluster repo alerts on or dashboards
+ * these series, so that divergence would never have been noticed.)
  */
-export function launchHelloLabel(value: unknown): AppBlockLaunchHello | null {
+export function launchHelloLabel(value: unknown): AppBlockLaunchHello {
   if (value === true) return 'yes';
   if (value === false) return 'no';
-  return null;
+  return 'unknown';
 }
 
 /**
@@ -751,7 +767,7 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const launchPhaseSeconds = getOrCreateHistogram(
     reg,
     'civitai_app_block_launch_phase_seconds',
-    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; init_wait = first BLOCK_INIT -> BLOCK_READY) and by `hello`. Both phases are host-side. 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total. There is deliberately no cross-origin frame-fetch phase — see launchTimings.ts. 🔴 `hello` = did the GUEST announce BLOCK_HELLO during this launch (yes|no) — NOT whether the accelerator fired an extra post; see launchHelloLabel. It exists because BLOCK_HELLO short-circuits the very wait the host re-post cadence governs, so `init_wait` must be read WITHIN a `hello` value: comparing the unstratified aggregate across a cadence change mixes two populations and dilutes toward the null. 🔴 RETROACTIVE LIMIT: samples recorded before this label shipped carry no `hello` and can never be stratified, so a post-vs-pre read is only sound for hello="no"; the within-period hello="no" vs hello="yes" contrast is the clean one. 🔴 A sample whose beacon carried no usable boolean is DROPPED here but still counted in launch_total_seconds, so these _count series legitimately diverge during a rollout.',
+    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; init_wait = first BLOCK_INIT -> BLOCK_READY) and by `hello`. Both phases are host-side. 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total. There is deliberately no cross-origin frame-fetch phase — see launchTimings.ts. 🔴 `hello` = did the GUEST announce BLOCK_HELLO during this launch (yes|no|unknown) — NOT whether the accelerator fired an extra post; see launchHelloLabel. `unknown` = the beacon carried no boolean, i.e. a browser bundle older than the label; it is a real bucket rather than a drop, so `sum without (hello)` recovers exactly the pre-label series and no coverage is lost. EXCLUDE `unknown` from any yes-vs-no contrast, and watch its share: a large or growing `unknown` means stale clients are a big slice of traffic and the stratified read is thin. It exists because BLOCK_HELLO short-circuits the very wait the host re-post cadence governs, so `init_wait` must be read WITHIN a `hello` value: comparing the unstratified aggregate across a cadence change mixes two populations and dilutes toward the null. 🔴 RETROACTIVE LIMIT: samples recorded before this label shipped carry no `hello` and can never be stratified, so a post-vs-pre read is only sound for hello="no"; the within-period hello="no" vs hello="yes" contrast is the clean one. 🔴 RETROACTIVE LIMIT applies only to pre-label data; a stale CLIENT is visible as hello="unknown" rather than silently missing, which matters because the beacon route runs no client-version gate so old browser bundles persist for as long as their tab does.',
     ['phase', 'hello'],
     APP_BLOCK_LAUNCH_BUCKETS
   );
@@ -773,7 +789,7 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   const launchInitPostsTotal = getOrCreateHistogram(
     reg,
     'civitai_app_block_launch_init_posts',
-    'BLOCK_INIT posts the host made before the block acknowledged with BLOCK_READY, per successful non-secondary launch. 🔴 THIS IS THE DISCRIMINATOR FOR `init_wait`: the share at `le=1` says whether launches ack on the first post (so `init_wait` is the block\'s own boot time and the re-post cadence is not the lever) or wait out re-post ticks (so the cadence IS the lever). A `le=1` share that RISES after a cadence change, at unchanged or lower `init_wait`, is the intended effect. Read as a share, never as a raw count. 🔴 THE DENOMINATOR IS THIS HISTOGRAM\'S OWN `_count`, NEVER `launch_total_seconds_count` — the two DIVERGE, and not randomly. A launch is counted in `launch_total_seconds` but NOT here whenever the post count is unusable: a block that posts BLOCK_READY before the host ever sent an init (count 0 — reachable today, e.g. a hand-rolled host shim acking while the token is still resolving), or a manual-retry storm pushing the count past the cap. The first case is FAST, no-quantization traffic, so dividing by the larger series subtracts it from the numerator but not the denominator and UNDERSTATES the `le=1` share — i.e. it makes the data look more quantized than it is, which is the direction that flatters the cadence change. Use `civitai_app_block_launch_init_posts_count`, AND read it within a single `hello` value. 🔴 `hello` = did the GUEST announce BLOCK_HELLO during this launch (yes|no) — NOT whether the accelerator fired; see launchHelloLabel. Stratifying matters most here: `hello="no"` is the population whose first-post-sufficiency the re-post cadence actually governs, so the `le=1` share AMONG hello="no" is the mechanism read, while the pooled share is dominated by accelerator apps. 🔴 RETROACTIVE LIMIT: pre-label samples carry no `hello` and cannot be stratified. A sample whose beacon carried no usable boolean is DROPPED rather than labelled `no`.',
+    'BLOCK_INIT posts the host made before the block acknowledged with BLOCK_READY, per successful non-secondary launch. 🔴 THIS IS THE DISCRIMINATOR FOR `init_wait`: the share at `le=1` says whether launches ack on the first post (so `init_wait` is the block\'s own boot time and the re-post cadence is not the lever) or wait out re-post ticks (so the cadence IS the lever). A `le=1` share that RISES after a cadence change, at unchanged or lower `init_wait`, is the intended effect. Read as a share, never as a raw count. 🔴 THE DENOMINATOR IS THIS HISTOGRAM\'S OWN `_count`, NEVER `launch_total_seconds_count` — the two DIVERGE, and not randomly. A launch is counted in `launch_total_seconds` but NOT here whenever the post count is unusable: a block that posts BLOCK_READY before the host ever sent an init (count 0 — reachable today, e.g. a hand-rolled host shim acking while the token is still resolving), or a manual-retry storm pushing the count past the cap. The first case is FAST, no-quantization traffic, so dividing by the larger series subtracts it from the numerator but not the denominator and UNDERSTATES the `le=1` share — i.e. it makes the data look more quantized than it is, which is the direction that flatters the cadence change. Use `civitai_app_block_launch_init_posts_count`, AND read it within a single `hello` value. 🔴 `hello` = did the GUEST announce BLOCK_HELLO during this launch (yes|no|unknown) — NOT whether the accelerator fired; see launchHelloLabel. `unknown` is a stale browser bundle: keep it out of any yes-vs-no contrast. Stratifying matters most here: `hello="no"` is the population whose first-post-sufficiency the re-post cadence actually governs, so the `le=1` share AMONG hello="no" is the mechanism read, while the pooled share is dominated by accelerator apps. 🔴 RETROACTIVE LIMIT: pre-label samples carry no `hello` and cannot be stratified. A beacon with no boolean is labelled `unknown` — never `no`, and never dropped.',
     ['hello'],
     APP_BLOCK_LAUNCH_INIT_POST_BUCKETS
   );
@@ -839,13 +855,10 @@ export function observeAppBlockLaunch(
       ensureRegisterAppBlockRuntimeMetrics();
     launchTotalSeconds.observe({ app_block_id: appBlockIdLabel }, total);
 
-    // 🔴 THE STRATIFIER GATES BOTH LABELLED HISTOGRAMS. `null` means the beacon
-    // carried no usable boolean — a client older than the field — and the sample
-    // is DROPPED rather than guessed at. Labelling it `no` would file every
-    // stale-client launch into the population this metric exists to isolate.
-    // `launch_total_seconds` above takes no `hello` label and is deliberately
-    // observed BEFORE this gate, so it still counts every launch and the drop
-    // shows up as a `_count` divergence instead of vanishing.
+    // 🔴 TOTAL — every launch gets a bucket, including `unknown`. This must NOT
+    // become a gate: dropping a sample whose `hello` is absent is a coverage
+    // regression on an existing metric, and one correlated with slow launches.
+    // See `launchHelloLabel`.
     const hello = launchHelloLabel(timings.hello);
 
     const phases: Array<[AppBlockLaunchPhase, unknown]> = [
@@ -855,7 +868,6 @@ export function observeAppBlockLaunch(
     for (const [phase, ms] of phases) {
       const seconds = launchSampleSeconds(ms);
       if (seconds === null) continue;
-      if (hello === null) continue;
       launchPhaseSeconds.observe({ phase, hello }, seconds);
     }
 
@@ -863,7 +875,7 @@ export function observeAppBlockLaunch(
     // count with no end-to-end duration to interpret it against is an orphan,
     // and the reader's whole question is "how many posts for THAT init_wait".
     const initPosts = launchInitPostsSample(timings.initPosts);
-    if (initPosts !== null && hello !== null) launchInitPostsTotal.observe({ hello }, initPosts);
+    if (initPosts !== null) launchInitPostsTotal.observe({ hello }, initPosts);
   } catch {
     /* instrument-only — never let a metrics error touch the beacon response */
   }

--- a/src/server/routers/__tests__/track.router.blockRender.test.ts
+++ b/src/server/routers/__tests__/track.router.blockRender.test.ts
@@ -223,6 +223,39 @@ describe('track.blockRender', () => {
    * `expected { …, initPosts: 4 } to deeply equal { … }` — this test's own
    * assertion, not another guard's error.
    */
+  /**
+   * 🔴 THE SAME HALF-FIX HAZARD, FOR `hello`. Its sibling is the REST writer's
+   * copy in `src/tests/api/track/block-render.test.ts`. Two writers, one
+   * allowlist; a field stripped in one and not the other reaches ClickHouse with
+   * nothing failing — spread properties are exempt from excess-property checking.
+   *
+   * EXACT payload equality, not `not.toHaveProperty('hello')`: the strip is an
+   * ALLOWLIST today, so no new field can leak by construction. Only a
+   * "these keys and no others" assertion notices if it is ever turned back into
+   * a destructure-rest denylist, which would re-open the class for every FUTURE
+   * field while a field-specific assertion stayed green.
+   */
+  it('🔴 accepts `hello` on the beacon and keeps it out of the ClickHouse payload', async () => {
+    const parsed = blockRenderSchema.parse({
+      ...validInput(),
+      timings: { totalMs: 1_100, initWaitMs: 700, hello: true },
+    });
+    // Red before the schema carried the field: zod strips unknown keys, so this
+    // would be `undefined` and the strip below would be about nothing.
+    expect(parsed.timings?.hello).toBe(true);
+
+    const caller = trackRouter.createCaller(fakeCtx({ id: 5 }) as never);
+    await caller.blockRender({
+      ...validInput(),
+      timings: { totalMs: 1_100, initWaitMs: 700, hello: true },
+    } as never);
+
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).toEqual({ ...validInput(), isAnon: false });
+    expect(Object.keys(arg).sort()).toEqual(['appBlockId', 'blockInstanceId', 'isAnon', 'slotId']);
+  });
+
   it('🔴 accepts `initPosts` on the beacon and keeps it out of the ClickHouse payload', async () => {
     const parsed = blockRenderSchema.parse({
       ...validInput(),

--- a/src/server/schema/__tests__/track.blockRender.schema.test.ts
+++ b/src/server/schema/__tests__/track.blockRender.schema.test.ts
@@ -107,3 +107,44 @@ describe('blockRenderSchema — initPosts', () => {
     expect(parsed.timings?.initWaitMs).toBe(700);
   });
 });
+
+/**
+ * 🔴 `hello` — THE STRATIFIER'S WIRE CONTRACT.
+ *
+ * A BOOLEAN, never a string: the server maps it onto its own two label literals,
+ * so nothing a client sends can reach a prom label value. And `.optional()`
+ * rather than `.default(false)`, because absence and `false` mean different
+ * things downstream — absent is a client older than the field (DROP), `false` is
+ * a launch that saw no hello (label `no`). A default here would erase that
+ * distinction at the parse boundary, before the server ever gets to decide.
+ */
+describe('blockRenderSchema — hello', () => {
+  const base = { appBlockId: 'apb_1', blockInstanceId: 'page_apb_1', slotId: 'app.page' };
+
+  it('accepts both booleans alongside the timings', () => {
+    expect(
+      blockRenderSchema.parse({ ...base, timings: { totalMs: 900, hello: true } }).timings?.hello
+    ).toBe(true);
+    expect(
+      blockRenderSchema.parse({ ...base, timings: { totalMs: 900, hello: false } }).timings?.hello
+    ).toBe(false);
+  });
+
+  it('🔴 does NOT default an absent hello to false — absence must survive the parse', () => {
+    const parsed = blockRenderSchema.parse({ ...base, timings: { totalMs: 900 } });
+    expect(parsed.timings).not.toHaveProperty('hello');
+    expect(parsed.timings?.hello).toBeUndefined();
+  });
+
+  it('🔴 a non-boolean hello degrades the timings — it never 400s the beacon', () => {
+    // `.catch(undefined)` swallows the whole object rather than rejecting, so a
+    // client bug costs the timings and NOT the impression the beacon exists for.
+    const parsed = blockRenderSchema.parse({
+      ...base,
+      timings: { totalMs: 900, hello: 'yes' },
+    });
+    expect(parsed.timings).toBeUndefined();
+    expect(parsed.appBlockId).toBe('apb_1');
+    expect(parsed.status).toBe('ok');
+  });
+});

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -181,8 +181,10 @@ export const blockRenderSchema = z.object({
       //
       // 🔴 OPTIONAL HERE, BUT ABSENCE IS NOT `false`. A client that predates this
       // field omits it; a launch that genuinely saw no hello sends `false`. The
-      // server must tell those apart — it labels the second `no` and DROPS the
-      // first — so this stays `.optional()` rather than `.default(false)`, which
+      // server must tell those apart — it labels the second `no` and the first
+      // `unknown` (a real bucket, never a drop: dropping would cut coverage of
+      // an existing metric, and cut it in a latency-correlated way) — so this
+      // stays `.optional()` rather than `.default(false)`, which
       // would erase the distinction at the parse boundary and silently file every
       // stale-client launch into the `no` population this metric exists to
       // isolate.

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -171,6 +171,22 @@ export const blockRenderSchema = z.object({
       // Still a NUMBER, so like every field here it can never become a prom
       // label — the histogram it feeds carries no labels at all.
       initPosts: z.number().finite().nonnegative().max(100_000).optional(),
+      // 🔴 THE STRATIFIER, and it is a BOOLEAN — never a client-supplied string.
+      // The server maps it onto its own two literals (`yes`/`no`), so nothing a
+      // client sends can become a prom label value. That is the same rule the
+      // `phase` label follows and the reason this beacon body can stay public.
+      //
+      // MEANING: the guest sent BLOCK_HELLO at some point during the launch —
+      // NOT "the accelerator fired an extra post". See `LaunchMarks.helloSeen`.
+      //
+      // 🔴 OPTIONAL HERE, BUT ABSENCE IS NOT `false`. A client that predates this
+      // field omits it; a launch that genuinely saw no hello sends `false`. The
+      // server must tell those apart — it labels the second `no` and DROPS the
+      // first — so this stays `.optional()` rather than `.default(false)`, which
+      // would erase the distinction at the parse boundary and silently file every
+      // stale-client launch into the `no` population this metric exists to
+      // isolate.
+      hello: z.boolean().optional(),
     })
     .optional()
     .catch(undefined),

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -490,7 +490,11 @@ async function histCount(name: string, labels: Record<string, string>): Promise<
 const LAUNCH_TOTAL = 'civitai_app_block_launch_total_seconds';
 const LAUNCH_PHASE = 'civitai_app_block_launch_phase_seconds';
 const LAUNCH_INIT_POSTS = 'civitai_app_block_launch_init_posts';
-const timings = { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 };
+// 🔴 CARRIES `hello`, because a real beacon always does. The server DROPS a
+// phase/init_posts sample whose beacon has no usable boolean rather than
+// labelling it `no`, so a fixture without it would silently exercise the
+// stale-client drop path instead of the ordinary one.
+const timings = { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700, hello: false };
 
 describe('POST /api/track/block-render — launch-latency histograms', () => {
   beforeEach(() => {
@@ -576,6 +580,30 @@ describe('POST /api/track/block-render — launch-latency histograms', () => {
    * `blockRenderTrackerPayload` fails this on its own `toEqual`, not on another
    * guard's error.
    */
+  /** The REST half of the `hello` allowlist pair — see the tRPC sibling. */
+  it('🔴 accepts `hello` and keeps it out of the ClickHouse insert (REST writer)', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const withHello = { ...timings, hello: true };
+
+    // The half that can go red at base: the strip assertion below passes even on
+    // a schema that does not know the field, because zod drops unknown keys.
+    const parsed = blockRenderSchema.parse({ ...validInput, timings: withHello });
+    expect(parsed.timings?.hello).toBe(true);
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, timings: withHello },
+      }) as any,
+      makeRes()
+    );
+
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).toEqual({ ...validInput, isAnon: true });
+    expect(Object.keys(arg).sort()).toEqual(['appBlockId', 'blockInstanceId', 'isAnon', 'slotId']);
+  });
+
   it('🔴 accepts `initPosts` and keeps it out of the ClickHouse insert (REST writer)', async () => {
     const handler = (await import('~/pages/api/track/block-render')).default;
     const withPosts = { ...timings, initPosts: 4 };


### PR DESCRIPTION
## Why

The re-post cadence change in #4542 **cannot be graded on the metrics it shipped with**, and the reason is structural rather than a query mistake.

Two facts compound:

1. `civitai_app_block_launch_phase_seconds` carries **no `app_block_id` label** — a deliberate cardinality decision, with per-app attribution pushed to the structured log. So `init_wait` cannot be stratified by app in Prometheus at all.
2. The deployed apps that already ship the **`BLOCK_HELLO` accelerator are the majority of launch traffic.** `BLOCK_HELLO` makes the host re-post `BLOCK_INIT` immediately on the guest's hello — short-circuiting the very wait the backoff shortens.

So a fleet-wide `init_wait` before/after is mostly composed of launches the change barely affects, that mass cannot be separated, and **a diluted null would be indistinguishable from "the change did nothing."** That is the same class of defect that has made pre-registered measurements ungradeable before: the design gets reviewed, the intervention ships, and the *instrument* turns out unable to answer the question.

## What this adds

A code-owned two-value label, **`hello: yes|no`**, on both launch histograms.

The beacon carries a **boolean**; the server maps it onto its own literals via `launchHelloLabel`. Nothing a client sends can become a label value — the same rule `phase` already follows, and what lets this beacon body stay public.

### 🔴 What the label means — picked, and pinned

**`yes` = the guest sent `BLOCK_HELLO` at some point during the launch window.**

It does **not** mean "the accelerator fired an extra `BLOCK_INIT`". Those are different facts, and they disagree on a reachable launch: `notifyHello()` posts only when the controller has started, has not stopped, and has not already handled a hello — so a hello arriving *before* `start()` is recorded and posts nothing, because `start()` posts immediately anyway.

Under the "accelerator fired" reading that launch is filed `no`, which is the wrong bucket: the guest's listener was demonstrably attached, so the host's very next post was heard and the cadence never governed the wait. Filing it `no` would push fast, accelerator-capable launches into the population that exists to isolate cadence-bound ones — **biasing the read toward "the change did nothing"**, i.e. making the instrument agree with the null regardless of the truth.

That is why the mark is set in the host's `BLOCK_HELLO` message handler, *before and independently of* the controller call, and why a source gate asserts it stays there. An ambiguous label is how a relabelled series produces a confident wrong number; this one is asserted as behaviour, not merely described.

### 🔴 Absent is not `false`

A client older than this field omits it; a launch that saw no hello sends `false`. `launchHelloLabel` returns `null` for the first and **drops** the sample rather than labelling it `no` — otherwise every stale-client launch lands in the exact population being isolated, as a silent systematic bias. The client therefore emits the key unconditionally, including for `false`, so the two cases stay distinguishable on the wire.

`launch_total_seconds` takes no `hello` label and is observed *before* the gate, so a rollout-window drop shows up as a `_count` divergence rather than vanishing.

### Cardinality

Derived from the bucket arrays in the metrics module — a histogram label set costs finite edges + `+Inf` + `_sum` + `_count`:

| metric | edges | per set | before | after | added |
|---|---|---|---|---|---|
| `launch_phase_seconds` | 13 | 16 | `phase(2)` = 32 | `phase(2)×hello(2)` = 64 | **+32** |
| `launch_init_posts` | 14 | 17 | unlabelled = 17 | `hello(2)` = 34 | **+17** |
| | | | | | **+49 / pod** |

For scale, `launch_total_seconds` already costs ~832 series per pod at full app saturation and is **unchanged**. `hello` is deliberately *not* added there — it already carries `app_block_id`, so the product would be ~1,664.

**Both** histograms get the label, not just one. `init_posts` is the mechanism discriminator — the `le=1` share answers "how often was the first post enough" — and that question is only meaningful *within* a `hello` value. Pooled, the share is dominated by accelerator apps; `hello="no"` is the population whose first-post sufficiency the cadence actually governs.

## 🔴 Retroactive limitation

**Data recorded before this label shipped carries no `hello` and can never be stratified.** This enables a post-change **within-period** contrast (`hello="no"` vs `hello="yes"`) and a cleaner post-vs-pre read restricted to the `hello="no"` population. **It does not repair the existing baseline.**

## Beacon discipline — verified, not assumed

`blockRenderTrackerPayload` is still an **allowlist** naming the three real columns, so `hello` cannot reach ClickHouse by construction. I re-read it rather than trusting the previous conclusion.

Both writers are covered by a test each asserting **exact payload equality**, not `not.toHaveProperty('hello')` — a field-specific assertion would stay green if the allowlist were ever turned back into a destructure-rest denylist, re-opening the class for every future field.

The existing discipline is inherited unchanged: observed only on `status=ok && !secondary`, gated behind the `total` anchor, dropped (never clamped) out of range, and dropped entirely when the tab was ever hidden.

One in-repo invariant was **restated rather than relaxed**: a browser test asserted "every `timings` field is a number", which was the same rule as "no strings on the wire" only while every field happened to be numeric. It now asserts the property it was always protecting — no strings, numbers positive, booleans allowed — since a boolean is a closed two-value domain mapped server-side and weakens nothing.

## Verification

**Red arm** — reverting only this PR's four source files to `origin/main` and re-running the six affected suites: **6 files / 28 failed, 120 passed**. Restoring: **148 passed**. (A first attempt at this measured the *green* arm by mistake — an unquoted shell variable meant the revert silently no-op'd. The control I print alongside it, asserting the symbol is genuinely absent from all four files, is what caught it, and it is why that control is there.)

Each guard was mutation-checked, with every target re-derived from the current source and an assertion that it still matched before mutating:

| mutation | killed by |
|---|---|
| absent `hello` labelled `no` instead of dropped | `expected 'no' to be null`, plus the drop test |
| record `helloSeen` inside `notifyHello()` (the meaning flip) | the wiring gate |
| omit `hello` when `false` | `expected undefined to be false` + the key-presence test |
| don't reset `helloSeen` on soft navigation | the re-arm test |
| leak `hello` into the ClickHouse allowlist | **both** writer tests, each on its own payload equality |

Full unit project: **1566 files / 24875 tests, 0 failures.** `AppBlocks` browser suite: **40 files / 477 tests, 0 failures.** Typecheck and ESLint clean.

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
