### PR TITLE
HOLD: fix(crypto-deposit): settle a stale row when the buzz was already granted

### DIFF
--- a/src/pages/api/mod/reconcile-nowpayments.ts
+++ b/src/pages/api/mod/reconcile-nowpayments.ts
@@ -38,7 +38,7 @@ export default ModEndpoint(
       logToAxiom({
         type: 'info',
         name: 'reconcile-nowpayments',
-        message: `Reconciliation complete: ${results.newlyProcessed} processed, ${results.alreadyProcessed} already done, ${results.failed} failed`,
+        message: `Reconciliation complete: ${results.newlyProcessed} processed, ${results.alreadyProcessed} already done, ${results.repairedRows} rows repaired, ${results.failed} failed`,
         dateFrom,
         dateTo,
         paymentIds,
@@ -46,6 +46,7 @@ export default ModEndpoint(
         completedPayments: results.completedPayments,
         alreadyProcessed: results.alreadyProcessed,
         newlyProcessed: results.newlyProcessed,
+        repairedRows: results.repairedRows,
         failed: results.failed,
         skipped: results.skipped,
       });

--- a/src/server/jobs/reconcile-nowpayments.ts
+++ b/src/server/jobs/reconcile-nowpayments.ts
@@ -35,13 +35,14 @@ export const reconcileNowpaymentsJob = createJob(
       logToAxiom({
         name: 'reconcile-nowpayments-job',
         type: 'info',
-        message: `Reconciliation complete: ${results.newlyProcessed} processed, ${results.alreadyProcessed} already done, ${results.failed} failed`,
+        message: `Reconciliation complete: ${results.newlyProcessed} processed, ${results.alreadyProcessed} already done, ${results.repairedRows} rows repaired, ${results.failed} failed`,
         dateFrom,
         dateTo,
         totalPayments: results.totalPayments,
         completedPayments: results.completedPayments,
         alreadyProcessed: results.alreadyProcessed,
         newlyProcessed: results.newlyProcessed,
+        repairedRows: results.repairedRows,
         failed: results.failed,
         skipped: results.skipped,
       });
@@ -72,7 +73,15 @@ export const reconcileNowpaymentsJob = createJob(
     return {
       dateFrom,
       dateTo,
-      ...(results ?? { totalPayments: 0, completedPayments: 0, alreadyProcessed: 0, newlyProcessed: 0, failed: 0, skipped: 0 }),
+      ...(results ?? {
+        totalPayments: 0,
+        completedPayments: 0,
+        alreadyProcessed: 0,
+        newlyProcessed: 0,
+        repairedRows: 0,
+        failed: 0,
+        skipped: 0,
+      }),
       retryResults,
     };
   },

--- a/src/server/services/__tests__/nowpayments.service.test.ts
+++ b/src/server/services/__tests__/nowpayments.service.test.ts
@@ -634,14 +634,65 @@ describe('reconcileDeposits', () => {
 
     const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
 
-    expect(mockDbWrite.cryptoDeposit.update).toHaveBeenCalledWith({
-      where: { paymentId: BigInt(555) },
+    // The `status` predicate is part of the assertion, not incidental: the read above it
+    // comes from the replica, so without it in the WHERE the `failed` exclusion is only
+    // ever as fresh as that snapshot.
+    expect(mockDbWrite.cryptoDeposit.updateMany).toHaveBeenCalledWith({
+      where: { paymentId: BigInt(555), status: { not: 'failed' } },
       data: { status: 'finished', buzzCredited: 9886 },
     });
+    // `toHaveBeenCalledWith` cannot see a doubled call and `repairedRow` is a boolean, so
+    // without this a call-site that repaired twice would pass.
+    expect(mockDbWrite.cryptoDeposit.updateMany).toHaveBeenCalledTimes(1);
     expect(result.repairedRows).toBe(1);
     expect(result.alreadyProcessed).toBe(1);
     // The buzz is already in the account; re-granting is the one thing this must not do.
     expect(mockGrantBuzzPurchase).not.toHaveBeenCalled();
+  });
+
+  // 🔴 `finished` with a null `buzzCredited` is a REACHABLE row shape, not a contradiction:
+  // `processDeposit` sets the status and the credit independently (`buzzCredited: buzzAmount
+  // > 0 && !buzzGrantFailed ? ... : null`), so a grant that reported nothing back still
+  // advances the status. It is one of the two shapes this repair exists for, which is why
+  // the guard is `finished && buzzCredited != null` and not `finished`. Widening it to the
+  // status alone turns these rows permanently unrepairable — the exact bug this PR fixes —
+  // and every other test here passes when you do.
+  it('settles a finished row that never recorded its credit', async () => {
+    mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
+      data: [makePayment({ payment_id: 559 })],
+    });
+    mockGetTransactionByExternalId.mockResolvedValueOnce({ amount: 9886 });
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'finished',
+      buzzCredited: null,
+    });
+
+    const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
+
+    expect(mockDbWrite.cryptoDeposit.updateMany).toHaveBeenCalledWith({
+      where: { paymentId: BigInt(559), status: { not: 'failed' } },
+      data: { status: 'finished', buzzCredited: 9886 },
+    });
+    expect(result.repairedRows).toBe(1);
+  });
+
+  // The comment on the amount guard states the stake — settling a row that credits nothing
+  // is worse than leaving it visibly stuck — so the guard needs a test that fails when it
+  // is deleted. A ledger entry with no usable amount is the shape that reaches it.
+  it('refuses to settle a row when the ledger reports no credit', async () => {
+    mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
+      data: [makePayment({ payment_id: 560 })],
+    });
+    mockGetTransactionByExternalId.mockResolvedValueOnce({ amount: 0 });
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'confirming',
+      buzzCredited: null,
+    });
+
+    const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
+
+    expect(mockDbWrite.cryptoDeposit.updateMany).not.toHaveBeenCalled();
+    expect(result.repairedRows).toBe(0);
   });
 
   // The stale row's own `outcomeAmount` can predate the final conversion — 5416277437
@@ -659,7 +710,7 @@ describe('reconcileDeposits', () => {
 
     await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
 
-    const written = mockDbWrite.cryptoDeposit.update.mock.calls[0]?.[0];
+    const written = mockDbWrite.cryptoDeposit.updateMany.mock.calls[0]?.[0];
     expect(written?.data.buzzCredited).toBe(9886);
     // 42190360 is what deriving it from the row's own outcome would have produced.
     expect(written?.data.buzzCredited).not.toBe(42190360);
@@ -677,7 +728,7 @@ describe('reconcileDeposits', () => {
 
     const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
 
-    expect(mockDbWrite.cryptoDeposit.update).not.toHaveBeenCalled();
+    expect(mockDbWrite.cryptoDeposit.updateMany).not.toHaveBeenCalled();
     expect(result.repairedRows).toBe(0);
   });
 
@@ -695,7 +746,7 @@ describe('reconcileDeposits', () => {
 
     const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
 
-    expect(mockDbWrite.cryptoDeposit.update).not.toHaveBeenCalled();
+    expect(mockDbWrite.cryptoDeposit.updateMany).not.toHaveBeenCalled();
     expect(result.repairedRows).toBe(0);
   });
 

--- a/src/server/services/__tests__/nowpayments.service.test.ts
+++ b/src/server/services/__tests__/nowpayments.service.test.ts
@@ -615,6 +615,90 @@ describe('reconcileDeposits', () => {
     expect(mockGrantBuzzPurchase).not.toHaveBeenCalled();
   });
 
+  // 🔴 IF YOU ARE HERE TO DELETE THESE: the early return above is what made a stale row
+  // permanent. `processDeposit` grants buzz before it writes the row and the two are not
+  // in one transaction, so a failure between them leaves the buzz paid and the row on
+  // `confirming` — and a granted deposit never reaches `processDeposit` again, so nothing
+  // ever fixed it. Payment 5416277437 sat that way for two weeks with its 9,886 buzz
+  // already in the user's account, showing "confirming" on the Buy Buzz page the whole
+  // time. Repairing from the ledger is deliberate; so is NOT re-granting.
+  it('settles a stale row when the buzz was already granted', async () => {
+    mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
+      data: [makePayment({ payment_id: 555 })],
+    });
+    mockGetTransactionByExternalId.mockResolvedValueOnce({ amount: 9886 });
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'confirming',
+      buzzCredited: null,
+    });
+
+    const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
+
+    expect(mockDbWrite.cryptoDeposit.update).toHaveBeenCalledWith({
+      where: { paymentId: BigInt(555) },
+      data: { status: 'finished', buzzCredited: 9886 },
+    });
+    expect(result.repairedRows).toBe(1);
+    expect(result.alreadyProcessed).toBe(1);
+    // The buzz is already in the account; re-granting is the one thing this must not do.
+    expect(mockGrantBuzzPurchase).not.toHaveBeenCalled();
+  });
+
+  // The stale row's own `outcomeAmount` can predate the final conversion — 5416277437
+  // stored 42190.36 against a real credit of 9,886 — so the ledger is the only source
+  // that says what the user actually got.
+  it('records the amount the ledger paid, not the one the stale row stored', async () => {
+    mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
+      data: [makePayment({ payment_id: 556, outcome_amount: 42190.36 })],
+    });
+    mockGetTransactionByExternalId.mockResolvedValueOnce({ amount: 9886 });
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'confirming',
+      buzzCredited: null,
+    });
+
+    await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
+
+    const written = mockDbWrite.cryptoDeposit.update.mock.calls[0]?.[0];
+    expect(written?.data.buzzCredited).toBe(9886);
+    // 42190360 is what deriving it from the row's own outcome would have produced.
+    expect(written?.data.buzzCredited).not.toBe(42190360);
+  });
+
+  it('leaves a row that is already settled alone', async () => {
+    mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
+      data: [makePayment({ payment_id: 557 })],
+    });
+    mockGetTransactionByExternalId.mockResolvedValueOnce({ amount: 9886 });
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'finished',
+      buzzCredited: 9886,
+    });
+
+    const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
+
+    expect(mockDbWrite.cryptoDeposit.update).not.toHaveBeenCalled();
+    expect(result.repairedRows).toBe(0);
+  });
+
+  // `failed` outranks `finished` in processDeposit's status ladder and is written by the
+  // retry sweep on exhaustion — a deliberate terminal state, not a stale one.
+  it('does not resurrect a row that was deliberately marked failed', async () => {
+    mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
+      data: [makePayment({ payment_id: 558 })],
+    });
+    mockGetTransactionByExternalId.mockResolvedValueOnce({ amount: 9886 });
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'failed',
+      buzzCredited: null,
+    });
+
+    const result = await reconcileDeposits({ dateFrom: '2026-03-01', dateTo: '2026-03-31' });
+
+    expect(mockDbWrite.cryptoDeposit.update).not.toHaveBeenCalled();
+    expect(result.repairedRows).toBe(0);
+  });
+
   it('skips payments with invalid order_id', async () => {
     mockNowpaymentsCaller.getListPayments.mockResolvedValueOnce({
       data: [makePayment({ payment_id: 333, order_id: 'bad-format' })],

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -536,37 +536,56 @@ async function fetchPaymentsByDateRange(
  * outcome can predate the final conversion — that row held 42190.36 against a real
  * credit of 9,886.
  *
- * `failed` is left alone: it outranks `finished` in `processDeposit`'s status ladder
- * and is written by the retry sweep on exhaustion, so it is a deliberate terminal
- * state rather than a stale one.
+ * `failed` is left alone because `processDeposit` treats it as the one status that may
+ * override `finished` — "finished is immutable except via failed (manual)" — i.e. it is
+ * how a takedown or refund is recorded, and resurrecting one would undo that by hand.
+ * Note the retry-sweep-on-exhaustion route to `failed` is NOT the reason: that route
+ * means buzz was never granted, and this function only runs on a ledger hit, so the
+ * only `failed` row it can ever see is the contradictory one. Skipping is deliberate
+ * and silent; whether such a row should instead be surfaced is an open question.
  */
 async function repairCreditedRow(
   paymentId: string | number,
   buzzCredited: number
 ): Promise<boolean> {
-  // Without a real amount there is nothing to record, and settling the row anyway
-  // would replace a visibly-stuck deposit with one that looks complete and credits
-  // nothing — worse than leaving it for the next run.
-  if (!Number.isFinite(buzzCredited)) return false;
-
-  const id = BigInt(typeof paymentId === 'string' ? parseInt(paymentId, 10) : paymentId);
   try {
+    const id = BigInt(typeof paymentId === 'string' ? parseInt(paymentId, 10) : paymentId);
     const local = await dbRead.cryptoDeposit.findUnique({
       where: { paymentId: id },
       select: { status: true, buzzCredited: true },
     });
+    // No row at all means the upsert never ran, and creating one here would need
+    // deposit data this function does not have. Left for `processDeposit`.
     if (!local) return false;
     if (local.status === 'finished' && local.buzzCredited != null) return false;
     if (local.status === 'failed') return false;
 
-    await dbWrite.cryptoDeposit.update({
-      where: { paymentId: id },
+    // Checked after the row read, not before it: a guard that returns early can only be
+    // tested against a row it never looked at, and `!local` then absorbs the mutation —
+    // so the test for it would pass with the guard deleted.
+    // Without a real credit there is nothing to record, and settling the row anyway would
+    // replace a visibly-stuck deposit with one that looks complete and credits nothing.
+    if (!(buzzCredited > 0)) return false;
+
+    // `updateMany` for the `status` predicate: the read above is from the replica, so
+    // the `failed` check is made against a snapshot that can already be stale. Repeating
+    // it in the write makes the exclusion structural rather than a race we happen to win.
+    const { count } = await dbWrite.cryptoDeposit.updateMany({
+      where: { paymentId: id, status: { not: 'failed' } },
       data: { status: 'finished', buzzCredited },
     });
-    return true;
-  } catch {
-    // Never fail reconciliation over the repair — the buzz is already granted, which
-    // is the part that matters; the row gets another chance on the next run.
+    return count > 0;
+  } catch (e) {
+    // Never fail reconciliation over the repair — the buzz is already granted, which is
+    // the part that matters. Logged rather than swallowed: silence here is
+    // indistinguishable from "nothing needed repairing", and a row that reliably throws
+    // falls out of the job's 72h window with no trace.
+    await log({
+      message: 'Failed to repair a credited deposit row',
+      paymentId,
+      buzzCredited,
+      error: e instanceof Error ? e.message : String(e),
+    });
     return false;
   }
 }
@@ -1016,7 +1035,15 @@ export const reconcileUserDeposits = async (userId: number) => {
         select: { status: true, buzzCredited: true },
       });
 
-      if (existingTx || (existingDeposit?.status === 'finished' && existingDeposit.buzzCredited)) {
+      // Same repair as the reconcile job. This is the "check my deposits" button, so it
+      // is where someone staring at a stale `confirming` row actually goes — skipping
+      // here without settling the row left the one path a user can trigger telling them
+      // nothing was wrong.
+      if (existingTx) {
+        await repairCreditedRow(numericId, existingTx.amount);
+        continue;
+      }
+      if (existingDeposit?.status === 'finished' && existingDeposit.buzzCredited) {
         continue;
       }
 

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -423,6 +423,8 @@ type ReconcileDetail = {
   error?: string;
   userId?: number;
   buzzAmount?: number;
+  /** The buzz was already granted, and a stale local row was settled to match. */
+  repairedRow?: boolean;
 };
 
 /**
@@ -463,10 +465,12 @@ export const reconcileDeposits = async ({
     newlyProcessed: 0,
     failed: 0,
     skipped: 0,
+    repairedRows: 0,
     details,
   };
 
   for (const d of details) {
+    if (d.repairedRow) results.repairedRows++;
     if (d.action === 'already_processed') results.alreadyProcessed++;
     else if (d.action === 'processed') results.newlyProcessed++;
     else if (d.action === 'failed') results.failed++;
@@ -517,6 +521,56 @@ async function fetchPaymentsByDateRange(
   return allPayments;
 }
 
+/**
+ * Settle a deposit whose buzz was granted but whose row never caught up.
+ *
+ * `processDeposit` grants the buzz before it writes the row, and the two are not in
+ * one transaction — so anything that throws in between leaves the buzz paid and the
+ * row on `confirming` with a null `buzzCredited`. Nothing then repaired it: the
+ * ledger check above returns early for exactly these rows, so they never reach
+ * `processDeposit` again and stay pending to the user for good. Payment 5416277437
+ * sat that way for two weeks with its 9,886 buzz already in the account.
+ *
+ * The amount comes from the ledger rather than from `outcome_amount`, because the
+ * ledger records what the user was actually credited while a stale row's stored
+ * outcome can predate the final conversion — that row held 42190.36 against a real
+ * credit of 9,886.
+ *
+ * `failed` is left alone: it outranks `finished` in `processDeposit`'s status ladder
+ * and is written by the retry sweep on exhaustion, so it is a deliberate terminal
+ * state rather than a stale one.
+ */
+async function repairCreditedRow(
+  paymentId: string | number,
+  buzzCredited: number
+): Promise<boolean> {
+  // Without a real amount there is nothing to record, and settling the row anyway
+  // would replace a visibly-stuck deposit with one that looks complete and credits
+  // nothing — worse than leaving it for the next run.
+  if (!Number.isFinite(buzzCredited)) return false;
+
+  const id = BigInt(typeof paymentId === 'string' ? parseInt(paymentId, 10) : paymentId);
+  try {
+    const local = await dbRead.cryptoDeposit.findUnique({
+      where: { paymentId: id },
+      select: { status: true, buzzCredited: true },
+    });
+    if (!local) return false;
+    if (local.status === 'finished' && local.buzzCredited != null) return false;
+    if (local.status === 'failed') return false;
+
+    await dbWrite.cryptoDeposit.update({
+      where: { paymentId: id },
+      data: { status: 'finished', buzzCredited },
+    });
+    return true;
+  } catch {
+    // Never fail reconciliation over the repair — the buzz is already granted, which
+    // is the part that matters; the row gets another chance on the next run.
+    return false;
+  }
+}
+
 /** Process a single payment: check idempotency, validate, grant buzz. */
 async function reconcileSinglePayment(
   payment: NOWPayments.CreatePaymentResponse
@@ -528,7 +582,13 @@ async function reconcileSinglePayment(
   try {
     const existing = await getTransactionByExternalId(externalId);
     if (existing) {
-      return { paymentId, status: payment.payment_status, action: 'already_processed' };
+      const repairedRow = await repairCreditedRow(paymentId, existing.amount);
+      return {
+        paymentId,
+        status: payment.payment_status,
+        action: 'already_processed',
+        repairedRow,
+      };
     }
   } catch {
     // If lookup fails, proceed to process (processDeposit is idempotent)


### PR DESCRIPTION
## The defect

`processDeposit` grants the buzz at `nowpayments.service.ts:196` and does not write the `CryptoDeposit` row until `:302`. The two are not in one transaction, and the grant is first â€” so anything that throws in between (the referral-kickback block at `:245-265` among others) leaves the buzz **paid** and the row on `confirming` with a null `buzzCredited`.

Nothing then repaired it, and that is the part worth fixing. `reconcileSinglePayment` checks the buzz ledger first:

```ts
const existing = await getTransactionByExternalId(externalId);
if (existing) {
  return { paymentId, status: payment.payment_status, action: 'already_processed' };
}
```

Once the grant exists, that early return fires forever and the deposit never reaches `processDeposit` again. A transient write failure became a permanent one, and the user sees "confirming" on the Buy Buzz page indefinitely while their buzz is already in the account.

**Measured on production.** Payment `5416277437`: NowPayments finished it at `2026-08-18T16:21:14Z`, the buzz service granted 9,886 buzz at `16:21:18Z` â€” four seconds later â€” and the row still read `confirming` with `updatedAt` identical to `createdAt` two weeks on. It sits inside the reconciler's own 72-hour window on a job that runs every 10 minutes, so this was not a window gap.

~~Four support tickets in one week describe exactly this symptom.~~ **CORRECTED: they do not.** The pragmatic review resolved each requester (71299, 71350, 71358, 71428) to their Civitai account and ledger-checked every stuck deposit they own — all five returned 404, buzz **never granted**. Those users are missing money, which is a different defect (see `868kyct02`, owner Luis); this PR does nothing for them. The ticket text agrees on re-reading: "Please credit my account", "I have not received my Buzz". The original claim was mine and it was wrong.

## The fix

`repairCreditedRow` settles the row when the ledger says the buzz was granted. Three deliberate choices:

**The amount comes from the ledger, not `outcome_amount`.** A stale row's stored outcome can predate the final conversion â€” `5416277437` held `42190.36` against a real credit of 9,886. The ledger is the only record of what the user actually received. There is a test named for this.

**`failed` is left alone.** It outranks `finished` in `processDeposit`'s `statusRank` ladder and is written by the retry sweep on exhaustion, so it is a deliberate terminal state rather than a stale one.

**It never re-grants.** The buzz is already there; re-granting is the one thing this must not do, and a test asserts `grantBuzzPurchase` is not called.

A `repairedRows` count is threaded to the job's Axiom line so the drain is observable rather than silent.

## Scope â€” deliberately excluded

This stops the bug **recurring**. It does not drain the existing backlog: `reconcileDeposits` only sees payments inside the job's 72-hour window, so the ~774 older stuck rows are untouched. Draining those is a separate one-off pass over a payment-id list, it is a money path, and it needs an owner named before anyone runs it.

## Verification

**Two controls, because one is not enough here.** The two negative tests assert `update` was *not* called, so they pass for free against the first mutation â€” they can only fail against a repair that is too broad.

| Mutation | Result |
|---|---|
| Remove the `repairCreditedRow` call | `Tests 2 failed \| 46 passed (48)`, exit 1 â€” `settles a stale row when the buzz was already granted`, `records the amount the ledger paid, not the one the stale row stored` |
| Strip the `finished` / `failed` guards | `Tests 2 failed \| 46 passed (48)`, exit 1 â€” `leaves a row that is already settled alone`, `does not resurrect a row that was deliberately marked failed` |

After each, the file was restored and confirmed by sha256 against a pre-mutation copy, with zero mutation markers left.

| Check | Result |
|---|---|
| `pnpm run typecheck` | exit 0 â€” `0 type errors in 410s` |
| `pnpm run test:lint-rules` | exit 0 â€” `Test Files 27 passed (27)`, `Tests 433 passed (433)` |
| `pnpm run lint` | exit 1 repo-wide; on the files in this PR only 3 **pre-existing** `no-explicit-any` warnings at test lines 29/70, none from the added code |
| nowpayments suite | `Tests 48 passed (48)` â€” 44 before the 4 added here |

## A formatting note, disclosed because it changes how the diff should be read

An earlier revision of this branch ran `prettier --write` over `nowpayments.service.ts` and produced a 263-insertion diff, five of whose nine hunks were reformatting of untouched code. That was reverted: the file was restored to its base and the four edits re-applied by hand, with the one over-long line wrapped manually.

Control confirming the file was already unformatted rather than made so by this change: running Prettier against the base version, with this change **absent**, rewrites **191 lines**. Per `CLAUDE.md` the repo is not Prettier-clean and CI gates only on added files, so the remaining `prettier --check` warning on this file is pre-existing and correct to leave.

The diff is now 156 insertions / 3 deletions across three files.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D8NRZoqNUhACpn2kNfubj

## Full suite, with a control that is actually a control

At head `6b335751ba7b0a737dca5ea9b85f428b303a9a83`, clean tree:

```
Test Files  5 failed | 1558 passed | 3 skipped (1566)    5+1558+3 = 1566 âœ“
Tests      11 failed | 24814 passed | 35 skipped (24860)  11+24814+35 = 24860 âœ“
Duration  286.12s     exit 1
```

Base control, the same three files reverted to `HEAD~1`:

```
Test Files  5 failed | 1558 passed | 3 skipped (1566)
Tests      11 failed | 24810 passed | 35 skipped (24856)  11+24810+35 = 24856 âœ“
```

**+4 tests, exactly the four added here** â€” so they demonstrably execute in the full run rather than merely passing when named directly. The same 5 files fail on both sides, none of them touched by this PR:
`assert-component-suite-ran`, `trace-flush`, `appModeratorMessageForm.callSites`, `blocks/tools/registry`, `credential-detection-superset.guard`.

Worth recording how that control was got wrong the first time, because the wrong version looked right: I initially removed the changes with `git stash push`, which only stashes **uncommitted** work â€” and these changes were already committed. That "base" run was my own commit, both sides came back 24860, and the identical totals read like evidence when they were an artifact of comparing a thing to itself. Reverting the three files to `HEAD~1` is what actually removes the change.

Both suite runs were read from the log file. The completion notification reported exit 0 while the log reported exit 1, on every backgrounded suite run in this session.

---

# Five-lane review, and the fix round it produced

**All five lanes read `6b335751ba7b0a737dca5ea9b85f428b303a9a83` and each independently reported the tree clean.** Head is now `841891daeb256beb30a6420ce0b092ca76f2fb92` â€” one commit past what they read, containing the fixes below. Everything above this line describes the reviewed commit; this section is the delta.

## Disclosure the intent lane was right to demand

**`CryptoDeposit` 5416277437 â€” the row this PR cites as its central evidence â€” was written in production by me, today at 20:22Z, before this branch was committed.** It was one of three `/api/mod/reprocess-order` calls made under Justin's explicit approval ("Run reprocess on all three"), verified not to double-credit: its Buzz-ledger entry is still the original `2026-08-18T16:21:18Z` / 9,886 record.

The consequence for this PR is that **its evidence is no longer reproducible**. The row now reads `finished` / `buzzCredited 9886` / `outcomeAmount 9.886955`. When measured at ~19:40Z it read `confirming` / `buzzCredited null` / `outcomeAmount 42190.3627503`, which is where the "the ledger, not `outcome_amount`" argument comes from. Both readings were true when taken; the reprocess refreshed the row between them.

The general argument stands â€” a stale row's stored outcome can predate the final conversion â€” but a reviewer cannot now verify it on this row, and that is my fault for not carrying the disclosure into the PR when I wrote it. The reprocess was authorised; failing to say I had touched the evidence was not.

## What the lanes changed

| Fix | Raised by | What it was |
|---|---|---|
| `reconcileUserDeposits` now repairs too | reuse | **The user-triggered "check my deposits" path was left unfixed** â€” same early return, one call site away |
| `status: { not: 'failed' }` in the write's WHERE | perf + correctness, independently | The guard was enforced against a stale replica snapshot |
| `BigInt()` moved inside the `try` | correctness | A throw escaped into a re-grant on a known-granted deposit |
| `log()` in the `catch` | correctness | Silence was indistinguishable from "nothing to repair" |
| `buzzCredited > 0`, moved after the row read | correctness + tests | The guard did not do what its comment said, **and could not fail** |
| `repairedRows` on the mod endpoint's log | reuse | Only the job's copy had been updated |
| `failed` carve-out rationale rewritten | intent | The recorded reason argued *against* the carve-out |

Two lanes proposed conflicting predicates for the write guard â€” `not: 'finished'` (correctness) versus what the tests showed. `finished` with a null `buzzCredited` is a reachable shape and one of the two this repair exists for, so `not: 'finished'` would have broken the case the test lane proved matters. Went with `not: 'failed'`.

**A defect I introduced during the fix round and caught before committing:** the amount guard originally returned before the row read, which left its test's `mockResolvedValueOnce` unconsumed and cascaded a wrong fixture into two later tests. Moving the guard after the read fixed the leak and made the guard testable at the same time.

## Controls at head, including one that does not fire

| Mutation | Result |
|---|---|
| Widen the `finished` guard to status alone | `1 failed | 49 passed (50)` â€” `settles a finished row that never recorded its credit` |
| Delete the `failed` guard | `1 failed | 49 passed (50)` â€” `does not resurrect a row that was deliberately marked failed` |
| Delete the amount guard | `1 failed | 49 passed (50)` â€” `refuses to settle a row when the ledger reports no credit` |
| Drop `status: { not: 'failed' }` from the WHERE | `2 failed | 48 passed (50)` |
| **Double the repair call** | **`50 passed (50)` â€” NOT caught** |

The last is reported as a gap, not a pass. `toHaveBeenCalledTimes(1)` cannot see it because the fake's `mockResolvedValueOnce` is consumed by the first call, so the second reads `null` and returns early. The assertion is kept because it would catch a genuine double write, but it does not provide the control its presence implies.

## On the flakiness the intent lane reported

That lane reported this suite failing 2 runs in 22 at `6b33575`, one failure byte-identical to a mutation control. **I could not reproduce it: 20 runs at `6b33575` and 20 at the fix-round state, 40 total, 0 failures.** The lane's own report states it applied and restored six source mutations in that worktree while testing, and the failure shapes it saw match its own mutations â€” so the likeliest explanation is that it observed its own in-flight edits. Recorded rather than dropped, because if it is right the control evidence above is worthless.

## Full suite at the fix round

```
Test Files  5 failed | 1558 passed | 3 skipped (1566)    5+1558+3 = 1566 âœ“
Tests      11 failed | 24816 passed | 35 skipped (24862)  11+24816+35 = 24862 âœ“
```

**+6 over the 24856 base** â€” the six repair tests, so they execute in the full run. Same 5 pre-existing failing files, none in this diff. `typecheck` exit 0. `test:lint-rules` `27 files / 433 tests`. Lint: 3 pre-existing `no-explicit-any` warnings at test lines 29/70, zero errors from added code.

Prettier checked per file against base rather than run over them, after an earlier revision of this branch pulled in 191 lines of unrelated reformatting: the test file and the mod endpoint are clean on both sides; `nowpayments.service.ts` was already unformatted at base and is no worse.

## Open questions the lanes raised, not resolved here

- **Should a `failed` row that has a ledger grant be skipped, repaired, or surfaced?** Today it is skipped silently. Production has 0 rows in `failed` and 0 in `buzz_failed`, so nothing is affected now. Product call.
- **`868kyct02`** (owner Luis) â€” "NowPayments failed events dropped â€” deposits read 'confirming' forever" â€” is the same user-visible symptom from a different cause. Possibly complementary, possibly a second lane. Raised with the coordinator.
- A deposit whose row was never created at all (grant landed, upsert threw before insert) is still not repaired â€” `if (!local) return false`. Same failure class, not closed here.


---

# ⛔ HOLD — do not merge. Recommended by the author.

A sixth "pragmatic lane", added at Justin's request with the sole job of deciding whether this PR is needed at all, largely undermined its premise. Read that verdict before anything else here.

**3 users are affected. The job half of this PR fixes 0 of them.**

A full census of all 778 `confirming` rows against the Buzz ledger — not a sample, positive and negative controls both firing — found **3 granted-but-stale rows and 775 never granted**. I re-verified all three independently. They date from 2026-04-19, 2026-06-08 and 2026-06-08. The reconcile job sweeps a **72-hour** window, so it cannot reach a single one. This PR already said so under "Scope — deliberately excluded"; what it never did was join that sentence to the population it excludes.

Three further corrections to this PR's reasoning:

- **`processDeposit` already self-heals this.** Any later NowPayments webhook hits the buzz-service 409, maps to `already_granted`, and the `statusRank` ladder advances the row. **18 of 21 historical instances repaired themselves with no code change.** "A transient write failure became a permanent one" holds only in the remaining 14%.
- **Rate: ~4.2/month enter the state, ~0.7/month stay stuck.** The job half spends roughly **7.7M extra replica reads per month to prevent ~0.7 permanent stalls** — about eleven million reads per repair — because it polls NowPayments payments to find a needle that lives in a 778-row local table.
- The support tickets are a different bug, corrected inline above.

**Two CONFIRMED findings at head, left open rather than fixed:**

1. **`nowpayments.service.ts:1042-1045` + `DepositHistory.tsx:437,444`** — the user-path repair succeeds, then `continue`s without incrementing `processed`. The client keys both its label and its list refresh on `processed > 0`, so the row **is** repaired while the button reports **"No missing deposits found"** and the list never refreshes. That is precisely the state this commit's own comment claims to fix. Needs a counter and a client change.
2. **`nowpayments.service.ts:573-576`** — `buzzCredited` is written as the ledger amount, which is `totalCustomBuzz` (base **plus** membership/bulk bonus), while `processDeposit` writes base only and puts the bonus in `bonusBuzz`. **12,395 of 75,777** finished rows carry a bonus (~16%). No money moves wrongly; the column would hold two different quantities depending on which path wrote it.

Correctness cleared everything else explicitly: no double-credit, no cross-user write, the `failed` skip sound and correctly repeated in the write predicate, `updateMany`/`count > 0` right, the guard covers NaN, `await log` cannot stall.

**What should happen instead needs no deploy.** `/api/mod/reprocess-order` on the three ids fixes 100% of the currently affected population, with 0 new ledger entries since all three are already granted. That is prepared and with the coordinator for Justin.

Whether the recurrence protection is worth building at all — and if so, driven off the 778-row local table rather than the payment sweep — is a product question with the numbers above attached, not a review finding.
