### PR TITLE
feat(images): store the trainer's sshs hash so LoCon/LyCORIS resources match

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260901210000_model_file_hash_sshs_12/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260901210000_model_file_hash_sshs_12/migration.sql
@@ -1,0 +1,19 @@
+-- Adds the SSHS_12 hash type: left(sshs_model_hash, 12) from a safetensors header.
+--
+-- SAFE TO APPLY BEFORE THE DEPLOY, and that is the intended order.
+--   1. Apply this. The value exists; nothing writes it, because no shipped build knows it yet.
+--   2. Deploy. New scans start writing the row as files are scanned.
+--   3. Backfill the existing corpus, so already-scanned files get the row too. The value is in
+--      ModelFile.headerData, so that needs no file access — but the tooling for it is NOT in this
+--      commit, and until it lands only newly-scanned files carry SSHS_12.
+--
+-- WHY THIS ORDER AND NOT THE REVERSE. ModelHashType is Prisma-mapped and the ModelHash view has no
+-- type filter, so a row carrying a label the running client cannot decode throws on READ for every
+-- consumer of that view — the 2026-08-19 SHA256_12 incident. Adding the label creates no rows, so
+-- it cannot cause that. Deploying first is what would: a scan completing before the ALTER lands
+-- would try to write 'SSHS_12' into a type that has no such value and lose the file's hash rows.
+--
+-- The backfill is the step that must wait for the rollout to finish: it is the only one that
+-- writes rows in bulk, which is exactly what turned the 2026-08-19 ordering mistake into an outage.
+
+ALTER TYPE "ModelHashType" ADD VALUE IF NOT EXISTS 'SSHS_12';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1231,6 +1231,10 @@ enum ModelHashType {
   // SHA256 truncated to 12 — the width A1111/Forge write for LoRAs, which no other stored
   // hash matches. Same kind of derived truncation as AutoV2 (sha256[0:10]).
   SHA256_12
+  // left(sshs_model_hash, 12) from the safetensors header, stored verbatim — the 0x prefix some
+  // trainers write is part of the value A1111/Forge emit, and the hash under it is computed at
+  // training time, so it is not derivable from the file's bytes. See docs/image-resource-hash-matching.md.
+  SSHS_12
 }
 
 model RecommendedResource {

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -315,6 +315,7 @@ export const ModelHashType = {
   CRC32: 'CRC32',
   BLAKE3: 'BLAKE3',
   SHA256_12: 'SHA256_12',
+  SSHS_12: 'SSHS_12',
 } as const;
 
 export type ModelHashType = (typeof ModelHashType)[keyof typeof ModelHashType];

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -254,6 +254,7 @@ export const ModelHashType = {
   CRC32: 'CRC32',
   BLAKE3: 'BLAKE3',
   SHA256_12: 'SHA256_12',
+  SSHS_12: 'SSHS_12',
 } as const;
 export type ModelHashType = (typeof ModelHashType)[keyof typeof ModelHashType];
 export const ScanResultCode = {

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -60,7 +60,7 @@ export type LicensingFeeSettlementCurrency = "Buzz" | "Cash";
 
 export type ModelVersionEngagementType = "Notify";
 
-export type ModelHashType = "AutoV1" | "AutoV2" | "AutoV3" | "SHA256" | "CRC32" | "BLAKE3" | "SHA256_12";
+export type ModelHashType = "AutoV1" | "AutoV2" | "AutoV3" | "SHA256" | "CRC32" | "BLAKE3" | "SHA256_12" | "SSHS_12";
 
 export type ScanResultCode = "Pending" | "Success" | "Danger" | "Error";
 

--- a/src/pages/api/mod/reprocess-scan.ts
+++ b/src/pages/api/mod/reprocess-scan.ts
@@ -33,10 +33,12 @@ export default ModEndpoint(
 
     const modelFiles = await dbWrite.modelFile.findMany({
       where: { OR },
-      select: { rawScanResult: true, id: true },
+      // headerData carries sshs_model_hash; this rebuild deletes every row for the file, so
+      // without it a reprocessed file loses its SSHS_12 row the same way it would lose AutoV3.
+      select: { rawScanResult: true, id: true, headerData: true },
     });
 
-    for (const { rawScanResult, id: fileId } of modelFiles) {
+    for (const { rawScanResult, id: fileId, headerData } of modelFiles) {
       const scanResult = rawScanResult as Prisma.JsonObject;
       if (!scanResult?.hashes) continue;
 
@@ -49,13 +51,17 @@ export default ModEndpoint(
         if (type && typeof hash === 'string' && hash) scanned[type] = hash;
       }
 
+      // headerData is passed because rawScanResult never carried sshs_model_hash — the
+      // metadata-parse step writes it to its own column — so SSHS_12 is re-derived, not replayed.
+      const hashRows = (
+        Object.entries(normalizeScanHashes(scanned, headerData)) as Array<[ModelHashType, string]>
+      )
+        .filter(([, hash]) => Boolean(hash))
+        .map(([type, hash]) => ({ fileId, type, hash }));
+
       await dbWrite.$transaction([
         dbWrite.modelFileHash.deleteMany({ where: { fileId } }),
-        dbWrite.modelFileHash.createMany({
-          data: (Object.entries(normalizeScanHashes(scanned)) as Array<[ModelHashType, string]>)
-            .filter(([, hash]) => Boolean(hash))
-            .map(([type, hash]) => ({ fileId, type, hash })),
-        }),
+        dbWrite.modelFileHash.createMany({ data: hashRows }),
       ]);
     }
 

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -117,7 +117,9 @@ vi.mock('~/server/flipt/client', () => ({
 
 import {
   applyScanOutcome,
+  deriveSshsHash,
   examinePickleImports,
+  normalizeScanHashes,
   processModelFileScanResult,
   rescanModel,
   unpublishBlockedModel,
@@ -1436,6 +1438,69 @@ describe('model-file-scan.service', () => {
       });
 
       expect(mockCheckMinorHashOnScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SSHS_12 — the trainer hash from the safetensors header', () => {
+    // The real values from ClickUp 868kxvagd, model version 3120690. The 12-char form A1111/Forge
+    // write into image metadata is '0x7875fed548': the 0x occupies two of the twelve characters.
+    const SSHS_PREFIXED = '0x7875fed54803c0f6f23ec0b1e3ddc681f0bae3167dffef482054a68dfd5b172c';
+    const SSHS_PLAIN = '7f6de38cf1daa16be4caac096b158c7e92333a9523099418de028a2e60a4d95c';
+
+    it('keeps the 0x prefix, because that is what the generator writes', () => {
+      // 🔴 Stripping it is the fix that does NOT work: measured on prod, of 3,109 prefixed files
+      // exactly 1 matched AutoV3 after the prefix was removed. The prefix is not the defect.
+      expect(deriveSshsHash({ sshs_model_hash: SSHS_PREFIXED })).toBe('0x7875fed548');
+    });
+
+    it('ignores a header without the key, and a non-string or too-short value', () => {
+      expect(deriveSshsHash({ ss_v2: 'False' })).toBeUndefined();
+      expect(deriveSshsHash({ sshs_model_hash: 42 })).toBeUndefined();
+      expect(deriveSshsHash({ sshs_model_hash: '0xabc' })).toBeUndefined();
+      expect(deriveSshsHash(undefined)).toBeUndefined();
+      expect(deriveSshsHash(null)).toBeUndefined();
+      expect(deriveSshsHash('not an object')).toBeUndefined();
+    });
+
+    it('is added by normalizeScanHashes when no sibling row already carries the value', () => {
+      const out = normalizeScanHashes(
+        { SHA256: SHA256_FIXTURE, AutoV3: AUTOV3_FIXTURE },
+        { sshs_model_hash: SSHS_PREFIXED }
+      );
+
+      expect(out.SSHS_12).toBe('0x7875fed548');
+    });
+
+    it('🔴 is NOT added when AutoV3 already carries it — the ~98% case', () => {
+      // sshs_model_hash equals the addnet-safetensors hash for most files, so storing it again
+      // would add a row per file and match nothing AutoV3 does not already match. This is the
+      // whole reason the backfill is ~15k rows and not ~622k.
+      const out = normalizeScanHashes(
+        { SHA256: SHA256_FIXTURE, AutoV3: SSHS_PLAIN },
+        { sshs_model_hash: SSHS_PLAIN }
+      );
+
+      expect(out.SSHS_12).toBeUndefined();
+      expect(out.AutoV3).toBe(SSHS_PLAIN.slice(0, 12));
+    });
+
+    it('survives a hash-only rescan by falling back to the stored headerData', async () => {
+      // 🔴 The rebuild is deleteMany({ fileId }) + createMany, so a rescan carrying no headerData
+      // would drop the row entirely. Reverting the ?? fallback fails HERE and nowhere else.
+      mockDbWrite.modelFile.findUnique.mockResolvedValue({
+        id: 1,
+        type: 'Model',
+        modelVersionId: 10,
+        headerData: { sshs_model_hash: SSHS_PREFIXED },
+        modelVersion: { modelId: 100, model: { userId: 5 } },
+      });
+
+      await applyScanOutcome({
+        fileId: 1,
+        hashes: { SHA256: SHA256_FIXTURE, AutoV3: AUTOV3_FIXTURE },
+      });
+
+      expect(hashRowsWritten()).toContain('1:SSHS_12=0x7875fed548');
     });
   });
 });

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -135,6 +135,9 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
       id: true,
       type: true,
       modelVersionId: true,
+      // SSHS_12 comes from the metadata-parse step, but the hash rebuild below deletes every row
+      // for the file — so a hash-only rescan has to re-derive it from what is already stored.
+      headerData: true,
       modelVersion: { select: { modelId: true, model: { select: { userId: true } } } },
     },
   });
@@ -205,7 +208,11 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
   // Hash upsert (delete + createMany) — same pattern as legacy.
   if (outcome.hashes) {
     const hashRows = (
-      Object.entries(normalizeScanHashes(outcome.hashes)) as Array<[ModelHashType, string]>
+      Object.entries(
+        // outcome.headerData is absent on a hash-only rescan, and this rebuild deletes every row
+        // for the file — so the stored column is what keeps SSHS_12 from being dropped.
+        normalizeScanHashes(outcome.hashes, outcome.headerData ?? file.headerData)
+      ) as Array<[ModelHashType, string]>
     )
       .filter(([, hash]) => Boolean(hash))
       .map(([type, hash]) => ({ fileId, type, hash }));
@@ -423,6 +430,26 @@ type ModelScanStep =
 
 const AUTOV3_LENGTH = 12;
 const SHA256_12_LENGTH = 12;
+const SSHS_12_LENGTH = 12;
+
+/**
+ * `left(sshs_model_hash, 12)` from a safetensors header, or undefined when the file has no such key.
+ *
+ * Stored verbatim, prefix included. A1111/Forge read `sshs_model_hash` out of the header in
+ * preference to hashing the file and truncate it to 12 characters for the infotext, so when the
+ * trainer wrote a `0x` prefix only 10 hex digits survive — and the value under that prefix is
+ * computed at training time over a re-serialisation, so it is not derivable from the shipped file's
+ * bytes and does not equal AutoV3. Measured on prod: of 3,109 prefixed files, stripping `0x` and
+ * comparing against AutoV3 matched 1. See docs/image-resource-hash-matching.md.
+ */
+export function deriveSshsHash(headerData: unknown): string | undefined {
+  if (!headerData || typeof headerData !== 'object' || Array.isArray(headerData)) return undefined;
+  const raw = (headerData as Record<string, unknown>).sshs_model_hash;
+  if (typeof raw !== 'string') return undefined;
+
+  const short = raw.trim().toLowerCase().slice(0, SSHS_12_LENGTH);
+  return short.length === SSHS_12_LENGTH ? short : undefined;
+}
 
 const orchestratorHashFieldMap: Record<string, ModelHashType> = {
   sha256: ModelHashType.SHA256,
@@ -468,7 +495,8 @@ const orchestratorHashFieldMap: Record<string, ModelHashType> = {
  * authority for those, and re-deriving them here would put two systems in charge of one value.
  */
 export function normalizeScanHashes(
-  hashes: Partial<Record<ModelHashType, string>>
+  hashes: Partial<Record<ModelHashType, string>>,
+  headerData?: unknown
 ): Partial<Record<ModelHashType, string>> {
   const out: Partial<Record<ModelHashType, string>> = { ...hashes };
 
@@ -478,6 +506,11 @@ export function normalizeScanHashes(
   // from it would give every such file the same 12-char hash and make them match each other.
   const sha256 = out.SHA256;
   if (sha256 && !/^0+$/.test(sha256)) out.SHA256_12 = sha256.slice(0, SHA256_12_LENGTH);
+
+  // Only added when no other row already carries the value — sshs_model_hash equals AutoV3 for
+  // ~98% of files, and a duplicate row matches nothing the sibling would not have matched.
+  const sshs = deriveSshsHash(headerData);
+  if (sshs && !Object.values(out).some((hash) => hash?.toLowerCase() === sshs)) out.SSHS_12 = sshs;
 
   return out;
 }


### PR DESCRIPTION
A1111/Forge do not hash a LoRA to write its infotext entry — they read `sshs_model_hash` out of the safetensors header and truncate it to 12 chars. When the trainer wrote a `0x` prefix, two of those twelve characters are the prefix, and the value under it was computed at training time over a re-serialisation, so it equals none of the six hashes we store. The image cites a string that exists nowhere in ModelFileHash, and the resource silently fails to attach.

Measured on prod: 3,109 files carry a 0x-prefixed sshs value, and stripping the prefix to compare against AutoV3 matches exactly 1 of them — so this cannot be normalised away, the value has to be stored. Another 12,052 unprefixed files diverge from AutoV3 the same way with no `0x` to spot them by. Over a 300k-image window, 191 of 1,298 currently-unmatched hash references (14.7%) resolve once this row exists.

The value arrives in the scan payload's modelParseMetadata step, not modelHash, so it is derived from headerData rather than from outcome.hashes — there is no stored hash it is a prefix of. It is written only when no sibling row already carries it, which is the ~98% case where sshs equals AutoV3; that keeps this to ~15k rows instead of ~622k.

Ordering, since ModelHashType is Prisma-mapped and the ModelHash view has no type filter: the ALTER TYPE is safe to apply BEFORE this deploys and must be, because a scan completing before it lands would fail to write the file's hash rows at all. The migration is already applied. Backfill tooling for already-scanned files is not in this commit, so until it lands only newly-scanned files carry SSHS_12.

ClickUp 868kxvagd