### PR TITLE
fix(rewards): floor and non-finite guard on the main pipeline multiplier

### DIFF
--- a/src/server/rewards/__tests__/base.reward.forid.test.ts
+++ b/src/server/rewards/__tests__/base.reward.forid.test.ts
@@ -130,17 +130,45 @@ describe('buzzEvents columns narrower than BuzzEventLog', () => {
     ['NaN', NaN, 1],
     ['Infinity', Infinity, 1],
     ['-Infinity', -Infinity, 0],
-  ])('replaces a %s multiplier with a value the column can hold', async (label, raw, expected) => {
-    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: raw });
-    h.evalImpl.mockResolvedValue(raw as any);
+  ] as const)(
+    'replaces a %s multiplier with a value the column can hold',
+    async (label, raw, expected) => {
+      h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: raw });
+      h.evalImpl.mockResolvedValue(raw as any);
+
+      await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+      const row = insertedRow();
+      expect(row.multiplier).toBe(expected);
+      // Recorded as a string: `JSON.stringify` writes all three as `null`, which is
+      // indistinguishable from the raw having been absent.
+      expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: label });
+    }
+  );
+
+  // `Number.isFinite` does not coerce where the `> ceiling` test it replaced did, so a multiplier
+  // read back out of the ClickHouse `Decimal(3, 2)` as a quoted string would take the non-finite
+  // fallback. That is an underpay, not a dropped row: `sendAward` pays `awardAmount * multiplier`.
+  it('leaves a quoted in-range multiplier alone rather than reading it as non-finite', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: '4.00' } as any);
+    h.evalImpl.mockResolvedValue(16 as any);
 
     await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
 
     const row = insertedRow();
-    expect(row.multiplier).toBe(expected);
-    // Recorded as a string: `JSON.stringify` writes all three as `null`, which is indistinguishable
-    // from the raw having been absent.
-    expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: label });
+    expect(row.multiplier).toBe('4.00');
+    expect(JSON.parse(row.transactionDetails)).not.toHaveProperty('multiplierRaw');
+  });
+
+  it('clamps a quoted multiplier past the ceiling and records the raw as a number', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: '20.00' } as any);
+    h.evalImpl.mockResolvedValue(80 as any);
+
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    const row = insertedRow();
+    expect(row.multiplier).toBe(9.99);
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: 20 });
   });
 });
 

--- a/src/server/rewards/__tests__/base.reward.forid.test.ts
+++ b/src/server/rewards/__tests__/base.reward.forid.test.ts
@@ -160,6 +160,19 @@ describe('buzzEvents columns narrower than BuzzEventLog', () => {
     expect(JSON.parse(row.transactionDetails)).not.toHaveProperty('multiplierRaw');
   });
 
+  // The raw is recorded from the ORIGINAL value, not from its coercion: `String(Number('4x'))` is
+  // `'NaN'`, which loses the only thing that would tell an operator which product is misconfigured.
+  it('records the original text when the multiplier is not a number at all', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: '4x' } as any);
+    h.evalImpl.mockResolvedValue(NaN as any);
+
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    const row = insertedRow();
+    expect(row.multiplier).toBe(1);
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: '4x' });
+  });
+
   it('clamps a quoted multiplier past the ceiling and records the raw as a number', async () => {
     h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: '20.00' } as any);
     h.evalImpl.mockResolvedValue(80 as any);

--- a/src/server/rewards/__tests__/base.reward.forid.test.ts
+++ b/src/server/rewards/__tests__/base.reward.forid.test.ts
@@ -105,6 +105,43 @@ describe('buzzEvents columns narrower than BuzzEventLog', () => {
 
     expect(insertedRow().multiplier).toBe(4);
   });
+
+  // The ceiling above and the floor below are separate guards: `Math.max` does not bound a value
+  // from above and a `> ceiling` test does not bound one from below. A negative reaches here from
+  // one operator-typed `Product.metadata.rewardsMultiplier`, which the cache reads as a bare float.
+  it('floors a negative multiplier at 0 rather than recording the negative', async () => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: -1 });
+    h.evalImpl.mockResolvedValue(-4 as any);
+
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    const row = insertedRow();
+    // 0 is the value `process-rewards` already reads as unqualified: no payout, and the reporter's
+    // cap is left intact. A negative kept as a negative passes the ceiling check, is recorded
+    // `awarded`, eats the cap, and is then dropped by `sendAward`'s amount filter.
+    expect(row.multiplier).toBe(0);
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: -1 });
+  });
+
+  // `Math.max(0, NaN)` is `NaN`, so a floor alone does not cover this: Decimal(3, 2) cannot hold
+  // NaN, and the insert runs `wait_for_async_insert=0`, so the row is dropped server-side with the
+  // Buzz already paid — the same silent loss the ceiling exists to prevent.
+  it.each([
+    ['NaN', NaN, 1],
+    ['Infinity', Infinity, 1],
+    ['-Infinity', -Infinity, 0],
+  ])('replaces a %s multiplier with a value the column can hold', async (label, raw, expected) => {
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: raw });
+    h.evalImpl.mockResolvedValue(raw as any);
+
+    await stringKeyReward().apply({ userId: 7, jobId: 'job-abc' });
+
+    const row = insertedRow();
+    expect(row.multiplier).toBe(expected);
+    // Recorded as a string: `JSON.stringify` writes all three as `null`, which is indistinguishable
+    // from the raw having been absent.
+    expect(JSON.parse(row.transactionDetails)).toMatchObject({ multiplierRaw: label });
+  });
 });
 
 describe('buzzEvents forId must be an Int32 by the time it reaches ClickHouse', () => {

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -629,11 +629,19 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
     // holds. That shared floor is also why an already-written row cannot arrive here with a
     // `multiplierRaw` this function would then overwrite in the merge below: `process` never
     // recomputes `multiplier`, so a row the other writer clamped comes back already in range.
-    const clamped = clampBuzzEventMultiplier(multiplier);
-    if (clamped !== multiplier) {
+    // `Number()` for the same reason as the `status === 0` read below: this value comes back out
+    // of a ClickHouse `Decimal(3, 2)` on the process path, and `Number.isFinite` does not coerce
+    // where the `>` test it replaced did. A quoted `'4.00'` would otherwise take the non-finite
+    // fallback and rewrite a legitimate multiplier to 1 — an underpay, since `sendAward` pays
+    // from it.
+    const raw = Number(multiplier);
+    const clamped = clampBuzzEventMultiplier(raw);
+    if (clamped !== raw) {
       // `JSON.stringify` writes +/-Infinity and NaN as `null`, which reads as "the raw was absent"
-      // — the one case that most needs a legible audit trail records the least.
-      coerced.multiplierRaw = Number.isFinite(multiplier) ? multiplier : String(multiplier);
+      // — the one case that most needs a legible audit trail records the least. The moderator's
+      // writer omits the key instead; it can, because it builds its row fresh. Here an omitted key
+      // would leave `coerced` empty and return the unclamped event below.
+      coerced.multiplierRaw = Number.isFinite(raw) ? raw : String(multiplier);
       multiplier = clamped;
       // On the batch path this value is not audit — `process-rewards` reads it back out and
       // `sendAward` pays `awardAmount * multiplier` from it, so a clamp UNDERPAYS rather than
@@ -677,7 +685,7 @@ function toClickhouseBuzzEvents(events: BuzzEventLog[]): BuzzEventLog[] {
       message: 'Buzz event multiplier fell outside the ClickHouse column range and was coerced',
       clampedEvents: clamped,
       batchSize: events.length,
-      clampedTo: [0, BUZZ_EVENTS_MAX_MULTIPLIER],
+      clampedTo: BUZZ_EVENTS_MAX_MULTIPLIER,
     }).catch(() => null);
   }
 

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -1,4 +1,4 @@
-import { BUZZ_EVENTS_MAX_MULTIPLIER } from '@civitai/clickhouse';
+import { BUZZ_EVENTS_MAX_MULTIPLIER, clampBuzzEventMultiplier } from '@civitai/clickhouse';
 import type { ClickHouseClient } from '@clickhouse/client';
 import type { PrismaClient } from '@prisma/client';
 import { chunk } from 'lodash-es';
@@ -624,14 +624,23 @@ export function toClickhouseBuzzEvent(event: BuzzEventLog): BuzzEventLog {
   }
 
   let multiplier = event.multiplier;
-  if (multiplier !== undefined && multiplier > BUZZ_EVENTS_MAX_MULTIPLIER) {
-    coerced.multiplierRaw = multiplier;
-    multiplier = BUZZ_EVENTS_MAX_MULTIPLIER;
-    // On the batch path this value is not audit — `process-rewards` reads it back out and
-    // `sendAward` pays `awardAmount * multiplier` from it, so a clamp UNDERPAYS rather than
-    // rounding a record. Reported once per batch by the caller, not here: the condition becomes
-    // reachable when a site-wide bonus event switches on, which clamps every gold member's pending
-    // events at once, and this function runs per event per retry.
+  if (multiplier !== undefined) {
+    // Shared with the moderator's writer so the two apps cannot disagree about what the column
+    // holds. That shared floor is also why an already-written row cannot arrive here with a
+    // `multiplierRaw` this function would then overwrite in the merge below: `process` never
+    // recomputes `multiplier`, so a row the other writer clamped comes back already in range.
+    const clamped = clampBuzzEventMultiplier(multiplier);
+    if (clamped !== multiplier) {
+      // `JSON.stringify` writes +/-Infinity and NaN as `null`, which reads as "the raw was absent"
+      // — the one case that most needs a legible audit trail records the least.
+      coerced.multiplierRaw = Number.isFinite(multiplier) ? multiplier : String(multiplier);
+      multiplier = clamped;
+      // On the batch path this value is not audit — `process-rewards` reads it back out and
+      // `sendAward` pays `awardAmount * multiplier` from it, so a clamp UNDERPAYS rather than
+      // rounding a record. Reported once per batch by the caller, not here: the condition becomes
+      // reachable when a site-wide bonus event switches on, which clamps every gold member's pending
+      // events at once, and this function runs per event per retry.
+    }
   }
 
   if (Object.keys(coerced).length === 0) return event;
@@ -665,10 +674,10 @@ function toClickhouseBuzzEvents(events: BuzzEventLog[]): BuzzEventLog[] {
     logToAxiom({
       name: 'buzz-rewards',
       type: 'error',
-      message: 'Buzz event multiplier exceeded the ClickHouse column and was clamped',
+      message: 'Buzz event multiplier fell outside the ClickHouse column range and was coerced',
       clampedEvents: clamped,
       batchSize: events.length,
-      clampedTo: BUZZ_EVENTS_MAX_MULTIPLIER,
+      clampedTo: [0, BUZZ_EVENTS_MAX_MULTIPLIER],
     }).catch(() => null);
   }
 


### PR DESCRIPTION
Closes the closing condition of ClickUp [868kzne32](https://app.clickup.com/t/8459928/868kzne32): `toClickhouseBuzzEvent` now obtains its multiplier from `clampBuzzEventMultiplier` instead of its own `> BUZZ_EVENTS_MAX_MULTIPLIER` check.

### Why a ceiling was not enough

`Math.max(0, NaN)` is `NaN`, and a negative passes a `>` test untouched. The two guards are independent, and the main pipeline had only one of them — PR #4566 added the floor to the shared helper and to `apps/moderator`, but not here.

`rewardsMultiplier` originates as `(p.metadata->>'rewardsMultiplier')::float` off operator-authored `Product.metadata`. One product typed `-1` instead of `1` would have every processable reward for that product's subscribers recorded `awarded` — consuming each user's monthly cap — while `sendAward`'s amount filter paid nothing. Across every reward type, not only `reportAccepted`.

Not live today: all production products carrying `rewardsMultiplier` are >= 1 (per the ticket; not re-verified against the DB in this PR). This closes a missing guard, not a current loss.

### The gotcha the ticket flagged

`toClickhouseBuzzEvent` merges `{...details, ...coerced}`, so a `multiplierRaw` it writes would overwrite one the moderator wrote. Sharing the helper is what makes that unreachable rather than something to route around: `process` never recomputes `multiplier`, so a row the moderator already clamped comes back in range and this function coerces nothing. A comment at the site records that, because it is the reason the key name stayed the same.

### Non-finite raws are recorded as strings

`JSON.stringify` writes `NaN` and `±Infinity` as `null`, which is indistinguishable from the raw having been absent — the one case that most needs a legible audit trail would otherwise record the least. The batch Axiom line also no longer claims the value "exceeded the column", which is false for a floored row.

### Tests — three demonstrated mutants

Added to the existing end-to-end harness in `base.reward.forid.test.ts`, which asserts on what reaches `clickhouse.insert` rather than on the helper in isolation.

| Mutant at the call site | Caught by |
|---|---|
| revert to `multiplier > MAX ? MAX : multiplier` (ceiling only) | the 4 original new tests |
| `Math.min(Math.max(m, 0), MAX)` (floor + ceiling, no non-finite branch) | the `NaN` and `Infinity` cases only — the floor case correctly still passes |
| `coerced.multiplierRaw = multiplier` (drop the string fallback) | all 3 non-finite cases |
| `const raw = multiplier` (drop the `Number()` coercion, commit 2) | exactly the 2 quoted-multiplier tests |
| `String(raw)` instead of `String(multiplier)` (commit 3) | exactly the `'4x'` test |

Under every mutant the two **pre-existing** multiplier tests pass. That is the ticket's claim demonstrated: the old suite could not see the floor.

### Two rounds of review changed this PR

Five review lanes ran on the first commit; two of them independently found the same regression it introduced, and it is worth naming because the diff read as safe:

**`Number.isFinite` does not coerce, and the `> ceiling` test it replaced did.** A `Decimal(3, 2)` arriving quoted from ClickHouse would have taken the non-finite fallback and rewritten a legitimate `'4.00'` to `1` — an underpay, since `sendAward` pays from this value — and set a `multiplierRaw` that overwrites the other writer in the merge. This file already guards that exact read one client setting away, at the `Number(event.multiplier) === 0` check; commit 2 mirrors it and adds the two quoted-multiplier tests.

Commit 2 also reverted `clampedTo` from `[0, max]` back to the scalar. Changing an existing Axiom field's type on a shared log name with no known consumer was scope the ticket did not ask for. The message string stays corrected — it claimed the value "exceeded the column", which is false for a floored row.

Commit 3 is test-only: a re-review predicted that `String(multiplier)` → `String(raw)` would survive the whole file, because every non-finite fixture was already a number so the two spellings agreed. It did. The `'4x'` case closes it.

### Not in this PR

`foldUserMultipliers` and `getMultipliersForUser` also lack a floor. Neither is a one-line guard — applying the shared helper there would import the ClickHouse column's 9.99 ceiling into a value the UI displays and `apply` pays from, capping a real bonus-event multiplier of 20 at 9.99, which is a payout decision nobody has made. Filed separately rather than decided here.

### Verification

`pnpm run typecheck` 0 errors · `pnpm run lint` 0 errors on the changed files · `pnpm run prettier:write` touched only these two files · full `pnpm run test:unit:run` on each round, final: **1572 files, 25016 passed, 0 failed** (`blocks.router.workflow.test.ts` collected 370, so the worktree's submodule is present and the run is valid).

Refs ClickUp 868kzne32. Floor value ruled by Justin on 2026-09-01: "Negative should clamp to 0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cr5MqLxRvn9VNbPef6brfV
