### PR TITLE
fix(upload): relay an image upload through our own origin when the direct PUT cannot resolve the storage host

### DIFF
--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -1,67 +1,124 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Readable } from 'stream';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import type * as EnvOther from '~/env/other';
+import type * as AuthSession from '~/server/auth/get-server-auth-session';
+import type * as S3Utils from '~/utils/s3-utils';
+import type * as HttpErrors from '~/server/prom/http-errors';
+import type * as OriginHelpers from '~/server/utils/origin-helpers';
 
 // Covers the FALLBACK image-upload relay (`/api/v1/image-upload/relay`).
 //
 // These are NEW-FEATURE tests, not regression guards: the route did not exist before
 // this change, so there is no pre-change revision at which they could be shown red.
 // Stated explicitly so nobody later reads them as evidence that a specific defect was
-// reproduced and fixed.
+// reproduced and fixed. The exceptions are the three cases marked AUDIT-*, which DO
+// pin defects an adversarial audit found in the first draft of this route and which
+// are red against that draft.
 //
-// The properties worth pinning are the ones where getting it wrong is silent:
-//  - the key is minted SERVER-SIDE and no caller-supplied key is honoured (an
-//    earlier draft echoed the presign's id back, which lets a caller overwrite
-//    another user's object)
-//  - the size cap trips on the RUNNING total, so an oversized body cannot be
-//    buffered in full first
-//  - an unauthenticated or banned caller never reaches the store at all
+// Mocks are SURGICAL (spread `importOriginal`, override one symbol). A one-key
+// wholesale factory for `~/utils/s3-utils` — which exports ~30 runtime symbols —
+// collapses the whole file to "no tests" the moment the route imports a second
+// symbol from it, which is the silent-zero shape `local-rules/no-wholesale-module-mock`
+// exists to prevent.
 
-const { mockGetServerAuthSession, mockUploadImageBufferToStore } = vi.hoisted(() => ({
+const {
+  mockGetServerAuthSession,
+  mockUploadImageBufferToStore,
+  mockIsAllowedOriginRequest,
+  prodFlag,
+} = vi.hoisted(() => ({
   mockGetServerAuthSession: vi.fn(),
   mockUploadImageBufferToStore: vi.fn(),
+  mockIsAllowedOriginRequest: vi.fn(),
+  // A getter-backed box, so a single test can flip `isProd` without a second file.
+  prodFlag: { value: false },
 }));
 
-vi.mock('~/server/auth/get-server-auth-session', () => ({
+vi.mock('~/env/other', async (importOriginal) => ({
+  ...(await importOriginal<typeof EnvOther>()),
+  get isProd() {
+    return prodFlag.value;
+  },
+}));
+
+vi.mock('~/server/auth/get-server-auth-session', async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthSession>()),
   getServerAuthSession: mockGetServerAuthSession,
 }));
 
-vi.mock('~/utils/s3-utils', () => ({
+vi.mock('~/utils/s3-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof S3Utils>()),
   uploadImageBufferToStore: mockUploadImageBufferToStore,
 }));
 
-vi.mock('~/server/prom/http-errors', () => ({
+vi.mock('~/server/prom/http-errors', async (importOriginal) => ({
+  ...(await importOriginal<typeof HttpErrors>()),
   instrumentApiResponse: vi.fn(),
 }));
 
-import handler, { MAX_RELAY_BYTES } from '~/pages/api/v1/image-upload/relay';
+vi.mock('~/server/utils/origin-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof OriginHelpers>()),
+  isAllowedOriginRequest: mockIsAllowedOriginRequest,
+}));
+
+import handler, {
+  MAX_RELAY_BYTES,
+  MAX_CONCURRENT_RELAYS,
+  __getInFlightForTest,
+} from '~/pages/api/v1/image-upload/relay';
+
+/** Records the order in which the handler wrote a status vs destroyed the request. */
+type Trace = string[];
 
 function makeReq(
-  body: Buffer,
-  opts?: { method?: string; contentType?: string }
+  chunks: Buffer[],
+  opts?: { method?: string; contentType?: string; trace?: Trace }
 ): NextApiRequest {
-  const stream = Readable.from([body]) as unknown as NextApiRequest;
+  return decorate(Readable.from(chunks) as unknown as NextApiRequest, opts);
+}
+
+function decorate(
+  stream: NextApiRequest,
+  opts?: { method?: string; contentType?: string; trace?: Trace }
+): NextApiRequest {
   stream.method = opts?.method ?? 'POST';
   stream.headers = { 'content-type': opts?.contentType ?? 'image/png' };
   stream.query = {};
+  const trace = opts?.trace;
+  const realDestroy = stream.destroy.bind(stream);
+  stream.destroy = ((...args: unknown[]) => {
+    trace?.push('destroy');
+    return (realDestroy as (...a: unknown[]) => unknown)(...args);
+  }) as typeof stream.destroy;
   return stream;
 }
 
-function makeRes() {
+function makeRes(trace?: Trace) {
   const res = {
     statusCode: 0,
     body: undefined as unknown,
     headers: {} as Record<string, string>,
+    headersSent: false,
     status(code: number) {
+      trace?.push(`status:${code}`);
       this.statusCode = code;
       return this;
     },
     json(payload: unknown) {
       this.body = payload;
+      this.headersSent = true;
+      return this;
+    },
+    end() {
+      this.headersSent = true;
       return this;
     },
     setHeader(k: string, v: string) {
       this.headers[k] = v;
+    },
+    getHeader(k: string) {
+      return this.headers[k];
     },
   };
   return res as unknown as NextApiResponse & typeof res;
@@ -71,13 +128,21 @@ const authed = { user: { id: 7, bannedAt: null } };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  prodFlag.value = false;
   mockGetServerAuthSession.mockResolvedValue(authed);
-  mockUploadImageBufferToStore.mockResolvedValue({ key: 'server-minted-uuid', backend: 'backblaze' });
+  mockUploadImageBufferToStore.mockResolvedValue({
+    key: 'server-minted-uuid',
+    backend: 'backblaze',
+  });
+  // Default to an allowed origin; the CSRF cases override it. In test `isProd` is
+  // false, so the guard is exempt anyway — these assertions pin the call, and the
+  // prod behaviour is pinned by the dedicated case below.
+  mockIsAllowedOriginRequest.mockReturnValue(true);
 });
 
 describe('image-upload relay', () => {
   it('uploads the body and returns the SERVER-minted key', async () => {
-    const req = makeReq(Buffer.from('image-bytes'));
+    const req = makeReq([Buffer.from('image-bytes')]);
     const res = makeRes();
 
     await handler(req, res);
@@ -85,17 +150,25 @@ describe('image-upload relay', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ id: 'server-minted-uuid' });
 
-    // The bytes reached the store intact, with the caller's content type.
     expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
     const [buf, opts] = mockUploadImageBufferToStore.mock.calls[0];
     expect(Buffer.from(buf).toString()).toBe('image-bytes');
     expect(opts).toEqual({ contentType: 'image/png' });
   });
 
+  it('reassembles a MULTI-CHUNK body in order', async () => {
+    const req = makeReq([Buffer.from('abc'), Buffer.from('def'), Buffer.from('ghi')]);
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const [buf] = mockUploadImageBufferToStore.mock.calls[0];
+    expect(Buffer.from(buf).toString()).toBe('abcdefghi');
+  });
+
   it('ignores any caller-supplied key — the store mints it', async () => {
-    // A caller trying to name the object it writes. `uploadImageBufferToStore` takes
-    // only (bytes, {contentType}); if a future edit threads a key through, this fails.
-    const req = makeReq(Buffer.from('bytes'));
+    const req = makeReq([Buffer.from('bytes')]);
     (req as unknown as { query: Record<string, string> }).query = {
       key: 'victim-uuid',
       id: 'victim-uuid',
@@ -106,13 +179,16 @@ describe('image-upload relay', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ id: 'server-minted-uuid' });
-    const [, opts] = mockUploadImageBufferToStore.mock.calls[0];
-    expect(opts).not.toHaveProperty('key');
     expect(JSON.stringify(mockUploadImageBufferToStore.mock.calls[0])).not.toContain('victim-uuid');
   });
 
-  it('rejects a body over the cap without buffering it whole', async () => {
-    const req = makeReq(Buffer.alloc(MAX_RELAY_BYTES + 1));
+  // Chunks each UNDER the cap that only exceed it in sum. NOTE this asserts the
+  // OUTCOME only — see the next test for the one that pins the running-total
+  // property itself. Kept separate because the 413 and the property are different
+  // claims and a reader should not mistake this one for the stronger one.
+  it('rejects a body whose chunks each fit but which sums past the cap', async () => {
+    const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
+    const req = makeReq([Buffer.alloc(half), Buffer.alloc(half)]);
     const res = makeRes();
 
     await handler(req, res);
@@ -121,10 +197,39 @@ describe('image-upload relay', () => {
     expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
   });
 
+  // AUDIT-F5 + AUDIT-F6, and this single trace pins BOTH — deliberately, because
+  // neither is expressible on its own here.
+  //
+  //  * F5: `req.destroy()` tears down the socket, so a status written afterwards
+  //    goes into a dead socket and the client sees a transport error, never the 413.
+  //    Hence `status:413` must precede `destroy`.
+  //  * F6: the running-total property. Asserting the 413 alone does NOT pin it — a
+  //    measure-at-the-end implementation returns the same 413, which is why the
+  //    first draft's cap test left that mutant alive. The tell is the LEADING
+  //    entry: measure-at-end consumes to EOF, and a stream that ends auto-destroys,
+  //    producing ['destroy', 'status:413', 'destroy']. A running total throws before
+  //    EOF, so no destroy precedes the status. Confirmed by mutation.
+  //
+  // ⚠ What does NOT work, so nobody re-derives it: counting how many chunks the
+  // async source yielded. Node's Readable reads AHEAD of the consumer, so the real
+  // running-total implementation still pulls the chunk after the one that trips the
+  // cap. Generator-pull count measures the stream's buffering, not the handler's.
+  it('writes the 413 before destroying, and does not consume the stream to EOF', async () => {
+    const trace: Trace = [];
+    const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
+    const req = makeReq([Buffer.alloc(half), Buffer.alloc(half)], { trace });
+    const res = makeRes(trace);
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(413);
+    expect(trace).toEqual(['status:413', 'destroy']);
+  });
+
   it('accepts a body exactly AT the cap — the boundary is inclusive', async () => {
     // Guards the off-by-one directly: `>` not `>=`. A fixture one byte under would
     // pass against either spelling and prove nothing about the boundary.
-    const req = makeReq(Buffer.alloc(MAX_RELAY_BYTES));
+    const req = makeReq([Buffer.alloc(MAX_RELAY_BYTES)]);
     const res = makeRes();
 
     await handler(req, res);
@@ -134,7 +239,7 @@ describe('image-upload relay', () => {
   });
 
   it('rejects an empty body', async () => {
-    const req = makeReq(Buffer.alloc(0));
+    const req = makeReq([Buffer.alloc(0)]);
     const res = makeRes();
 
     await handler(req, res);
@@ -145,7 +250,7 @@ describe('image-upload relay', () => {
 
   it('rejects an unauthenticated caller before touching the store', async () => {
     mockGetServerAuthSession.mockResolvedValue(null);
-    const req = makeReq(Buffer.from('bytes'));
+    const req = makeReq([Buffer.from('bytes')]);
     const res = makeRes();
 
     await handler(req, res);
@@ -158,7 +263,7 @@ describe('image-upload relay', () => {
     mockGetServerAuthSession.mockResolvedValue({
       user: { id: 7, bannedAt: new Date('2026-01-01') },
     });
-    const req = makeReq(Buffer.from('bytes'));
+    const req = makeReq([Buffer.from('bytes')]);
     const res = makeRes();
 
     await handler(req, res);
@@ -168,7 +273,7 @@ describe('image-upload relay', () => {
   });
 
   it('rejects a non-POST method', async () => {
-    const req = makeReq(Buffer.from('bytes'), { method: 'GET' });
+    const req = makeReq([Buffer.from('bytes')], { method: 'GET' });
     const res = makeRes();
 
     await handler(req, res);
@@ -177,14 +282,107 @@ describe('image-upload relay', () => {
     expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
   });
 
-  it('surfaces a store failure as a 500 rather than a silent success', async () => {
-    mockUploadImageBufferToStore.mockRejectedValue(new Error('b2 exploded'));
-    const req = makeReq(Buffer.from('bytes'));
+  // AUDIT-F2. The first draft returned `error.message` verbatim. Those messages come
+  // from the AWS SDK and carry bucket names, endpoint hostnames, request ids and
+  // signature detail. The assertion is on the WIRE BODY, not on "handleEndpointError
+  // was called" — a structural check would pass against a call that still leaked.
+  // AUDIT-F3. This route is cookie-authenticated, accepts a raw body and an arbitrary
+  // Content-Type — which makes a cross-site POST a CORS-*simple* request, so no
+  // preflight protects it. Without an origin check any third-party page could make a
+  // logged-in visitor write attacker-chosen bytes into the media bucket. The direct
+  // presign route is not exposed this way (its presigned URL is unreadable
+  // cross-origin), so this is new surface rather than parity.
+  it('blocks a cross-origin request in production, before touching the store', async () => {
+    prodFlag.value = true;
+    mockIsAllowedOriginRequest.mockReturnValue(false);
+    const req = makeReq([Buffer.from('bytes')]);
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    // Before auth too: an unauthenticated cross-origin probe must not even reach the
+    // session lookup.
+    expect(mockGetServerAuthSession).not.toHaveBeenCalled();
+  });
+
+  it('allows a same-origin request in production', async () => {
+    prodFlag.value = true;
+    mockIsAllowedOriginRequest.mockReturnValue(true);
+    const req = makeReq([Buffer.from('bytes')]);
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockIsAllowedOriginRequest).toHaveBeenCalled();
+  });
+
+  // AUDIT-F4. The route buffers whole, so unbounded concurrency is an OOMKill of the
+  // pod — taking every unrelated request on it down, not just uploads.
+  it('sheds with 503 once MAX_CONCURRENT_RELAYS are in flight', async () => {
+    // Hold every slot open by never resolving the store call.
+    let release: () => void = () => undefined;
+    mockUploadImageBufferToStore.mockImplementation(
+      () =>
+        new Promise((r) => {
+          const prev = release;
+          release = () => {
+            prev();
+            r({ key: 'server-minted-uuid', backend: 'backblaze' });
+          };
+        })
+    );
+
+    const held = Array.from({ length: MAX_CONCURRENT_RELAYS }, () =>
+      handler(makeReq([Buffer.from('bytes')]), makeRes())
+    );
+    // Let each occupy its slot before the one that should be shed arrives.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(__getInFlightForTest()).toBe(MAX_CONCURRENT_RELAYS);
+
+    const shedRes = makeRes();
+    await handler(makeReq([Buffer.from('bytes')]), shedRes);
+    expect(shedRes.statusCode).toBe(503);
+    expect(shedRes.headers['Retry-After']).toBe('5');
+
+    release();
+    await Promise.all(held);
+    // Every slot handed back.
+    expect(__getInFlightForTest()).toBe(0);
+  });
+
+  it('releases its slot on EVERY exit path, not just success', async () => {
+    // A leaked slot is permanent: the route wedges at 503 until the pod restarts,
+    // which is worse than the OOM the cap prevents. Drive each early return.
+    const before = __getInFlightForTest();
+
+    mockUploadImageBufferToStore.mockRejectedValue(new Error('store down'));
+    await handler(makeReq([Buffer.from('bytes')]), makeRes());
+    expect(__getInFlightForTest()).toBe(before);
+
+    await handler(makeReq([Buffer.alloc(0)]), makeRes()); // empty-body 400
+    expect(__getInFlightForTest()).toBe(before);
+
+    const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
+    await handler(makeReq([Buffer.alloc(half), Buffer.alloc(half)]), makeRes()); // 413
+    expect(__getInFlightForTest()).toBe(before);
+  });
+
+  it('does NOT put the store error message on the wire', async () => {
+    mockUploadImageBufferToStore.mockRejectedValue(
+      new Error('bucket EXAMPLE-BUCKET endpoint s3.example.invalid reqId REQ-123')
+    );
+    const req = makeReq([Buffer.from('bytes')]);
     const res = makeRes();
 
     await handler(req, res);
 
     expect(res.statusCode).toBe(500);
-    expect(res.body).toEqual({ error: 'b2 exploded' });
+    const wire = JSON.stringify(res.body);
+    expect(wire).not.toContain('EXAMPLE-BUCKET');
+    expect(wire).not.toContain('s3.example.invalid');
+    expect(wire).not.toContain('REQ-123');
   });
 });

--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -99,6 +99,16 @@ function decorate(
     trace?.push('destroy');
     return (realDestroy as (...a: unknown[]) => unknown)(...args);
   }) as typeof stream.destroy;
+  // Pass-THROUGH spy, deliberately not a stub. An earlier version replaced `resume`
+  // outright, which could only observe the call and not its effect — and that is how a
+  // `resume()` that was inert (a no-op while the async iterator holds a `'readable'`
+  // listener) survived a green suite. Calling through keeps the real behaviour
+  // observable while still recording that it happened.
+  const realResume = stream.resume.bind(stream);
+  stream.resume = ((...args: unknown[]) => {
+    trace?.push('resume');
+    return (realResume as (...a: unknown[]) => unknown)(...args);
+  }) as typeof stream.resume;
   return stream;
 }
 
@@ -210,47 +220,46 @@ describe('image-upload relay', () => {
 
   // AUDIT-F5 + AUDIT-F6. Two properties of the oversize path.
   //
-  //  * F5: the 413 must reach the client. Two earlier attempts did not — `req.destroy()`
-  //    RSTs the socket, and `Connection: close` makes `res.end()` call
-  //    `socket.destroySoon()` which RSTs it too when inbound data is unread. Measured
-  //    against a real HTTP client, only DRAINING delivers the status. So: no
-  //    `Connection` header, and the request IS resumed.
+  //  * F5: the 413 must reach the client. Three earlier attempts did not deliver it or
+  //    delivered it for the wrong reason — `req.destroy()` RSTs the socket;
+  //    `Connection: close` makes `res.end()` call `socket.destroySoon()` which RSTs it
+  //    too when inbound data is unread; and a `req.resume()` "drain" turned out to be a
+  //    no-op, because driving the stream's async iterator keeps a `'readable'` listener
+  //    registered and `Readable.resume()` does nothing while `readableListening` is
+  //    true. Measured against a real socket, NOT closing the connection is the whole
+  //    fix. So: no `Connection` header, no destroy, and no resume call.
   //  * F6: the running-total property. Asserting the 413 alone does NOT pin it — a
-  //    measure-at-the-end implementation returns the same 413, which is why the first
-  //    draft's cap test left that mutant alive. What discriminates is that a running
-  //    total STOPS READING: it throws on the chunk that crosses the limit, so the
-  //    stream never reaches EOF. `readableEnded` is that fact directly.
+  //    measure-at-the-end implementation returns the same 413. What discriminates is
+  //    that a running total STOPS READING, so the stream never reaches EOF.
   //
-  // 🔴 THIS TEST CANNOT SEE F5's ACTUAL PROPERTY. `makeReq` is a `Readable.from` and
-  // `makeRes` is an object literal — there is no socket, so "the client received the
-  // status" is unobservable here. It pins the CALLS that the real-socket measurement
-  // showed are necessary (drain yes, Connection header no); delivery itself was
-  // established by that measurement, not by this. Do not read a green here as proof
-  // the client got the 413.
+  // 🔴 THIS TEST CANNOT SEE DELIVERY. `makeReq` is a `Readable.from` and `makeRes` an
+  // object literal — no socket. It pins the calls the real-socket measurement showed
+  // matter. An earlier version ALSO stubbed `req.resume` to assert it was called, which
+  // could only ever observe the call and not its effect — which is exactly how an inert
+  // line survived a green suite. The stub is gone; `readableFlowing` below is a state
+  // assertion the fixture genuinely supports.
   //
-  // ⚠ What does NOT work, so nobody re-derives it: counting how many chunks the async
-  // source yielded. Node's Readable reads AHEAD of the consumer, so the real
-  // running-total implementation still pulls the chunk after the one that trips the
-  // cap. Generator-pull count measures the stream's buffering, not the handler's.
-  it('writes the 413, drains rather than closing, and stops reading before EOF', async () => {
+  // ⚠ What does NOT work: counting chunks the async source yielded. Node's Readable
+  // reads AHEAD of the consumer, so the running-total implementation still pulls the
+  // chunk after the one that trips the cap.
+  it('writes the 413 without closing or draining, and stops reading before EOF', async () => {
     const trace: Trace = [];
     const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
     const req = makeReq([Buffer.alloc(half), Buffer.alloc(half)], { trace });
     const res = makeRes(trace);
-    let resumed = false;
-    (req as unknown as { resume: () => void }).resume = () => {
-      resumed = true;
-    };
 
     await handler(req, res);
 
     expect(res.statusCode).toBe(413);
     // F5: `Connection: close` is what destroyed the socket before the status landed.
     expect(res.headers['Connection']).toBeUndefined();
-    // F5: the drain is the only arm measured to deliver the status.
-    expect(resumed).toBe(true);
-    // F5: and nothing may destroy the request.
-    expect(trace).toEqual(['status:413']);
+    // F5: and nothing may destroy the request either.
+    expect(trace).toEqual(['status:413']); // no 'destroy', no 'resume'
+    // F5: no drain is attempted at all. `readableFlowing`/`readableEnded` CANNOT pin
+    // this — `resume()` schedules its reads asynchronously, so on this fixture a real
+    // drain has moved neither by the time the handler returns (measured: a
+    // `removeAllListeners('readable') + resume()` mutant passes both). The trace above
+    // is what pins it, via a pass-through spy rather than a stub.
     // F6: a measure-at-the-end implementation consumes to EOF and fails here while
     // still returning the same 413.
     expect((req as unknown as { readableEnded: boolean }).readableEnded).toBe(false);

--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -70,6 +70,7 @@ vi.mock('~/server/utils/origin-helpers', async (importOriginal) => ({
 
 import handler, {
   MAX_RELAY_BYTES,
+  NEXT_BODY_TRUNCATION_BYTES,
   MAX_CONCURRENT_RELAYS,
   RELAY_RETRY_AFTER_SECONDS,
   __getInFlightForTest,
@@ -81,17 +82,49 @@ type Trace = string[];
 
 function makeReq(
   chunks: Buffer[],
-  opts?: { method?: string; contentType?: string; trace?: Trace }
+  opts?: { method?: string; contentType?: string; trace?: Trace; contentLength?: number }
 ): NextApiRequest {
   return decorate(Readable.from(chunks) as unknown as NextApiRequest, opts);
 }
 
+/**
+ * A request whose body records how many chunks were actually pulled from it.
+ *
+ * Needed because "rejected without reading the body" is a claim about CONSUMPTION,
+ * and a status code cannot witness it — the route could read everything and still
+ * answer 413. `pulled` is the observable, so a mutant that drops the pre-read
+ * rejection and falls through to the running-total check is caught by a count rather
+ * than by the status it happens to share.
+ */
+function makeCountingReq(
+  chunks: Buffer[],
+  opts?: { contentLength?: number }
+): { req: NextApiRequest; pulled: Buffer[] } {
+  const pulled: Buffer[] = [];
+  const gen = (function* () {
+    for (const c of chunks) {
+      pulled.push(c);
+      yield c;
+    }
+  })();
+  return {
+    req: decorate(Readable.from(gen) as unknown as NextApiRequest, opts),
+    pulled,
+  };
+}
+
 function decorate(
   stream: NextApiRequest,
-  opts?: { method?: string; contentType?: string; trace?: Trace }
+  opts?: { method?: string; contentType?: string; trace?: Trace; contentLength?: number }
 ): NextApiRequest {
   stream.method = opts?.method ?? 'POST';
-  stream.headers = { 'content-type': opts?.contentType ?? 'image/png' };
+  stream.headers = {
+    'content-type': opts?.contentType ?? 'image/png',
+    // Omitted unless a case asks for it, so every pre-existing case keeps exercising
+    // the no-declared-length path (a chunked sender) rather than silently switching
+    // to the Content-Length guards added for the truncation fix.
+    ...(opts?.contentLength !== undefined ? { 'content-length': String(opts.contentLength) } : {}),
+  };
   stream.query = {};
   const trace = opts?.trace;
   const realDestroy = stream.destroy.bind(stream);
@@ -411,6 +444,87 @@ describe('image-upload relay', () => {
     const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
     await handler(makeReq([Buffer.alloc(half), Buffer.alloc(half)]), makeRes()); // 413
     expect(__getInFlightForTest()).toBe(before);
+  });
+
+  // AUDIT-5 — these ARE regression guards, and they are red against f47b17e9ff.
+  //
+  // Verified on a deployed preview (Next 16.3.1): the framework truncates a request
+  // body at 10MB and ENDS the stream, so the route saw a clean end-of-body, stored the
+  // fragment and returned 200 with an id. A valid 14,523,378-byte PNG came back as a
+  // 10,485,209-byte object with no IEND terminator. The unit tier could not see it
+  // because these fixtures drive `Readable.from`, which never truncates — so the
+  // guards are what is pinned here, not the framework behaviour.
+  describe('truncated and over-size bodies never reach the store', () => {
+    it('refuses a declared Content-Length over the cap WITHOUT reading the body', async () => {
+      const { req, pulled } = makeCountingReq([Buffer.from('a'), Buffer.from('b')], {
+        contentLength: MAX_RELAY_BYTES + 1,
+      });
+      const res = makeRes();
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(413);
+      // The point of rejecting early: nothing was buffered.
+      expect(pulled).toHaveLength(0);
+      expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    });
+
+    it('rejects a body that ends short of its declared length', async () => {
+      // 10 bytes promised, 4 delivered — the shape Next's truncation produces.
+      const req = makeReq([Buffer.from('abcd')], { contentLength: 10 });
+      const res = makeRes();
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ error: 'Upload body was incomplete' });
+      // 🔴 The assertion that matters. A 400 with the object still written would be
+      // the same corruption wearing a different status.
+      expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    });
+
+    it('accepts a body that matches its declared length', async () => {
+      // Positive control for BOTH guards above: without it, a mutant that rejects
+      // unconditionally would pass every case in this block.
+      const req = makeReq([Buffer.from('abc'), Buffer.from('de')], { contentLength: 5 });
+      const res = makeRes();
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
+      const [sent] = mockUploadImageBufferToStore.mock.calls[0] as [Buffer];
+      expect(sent.toString()).toBe('abcde');
+    });
+
+    it('still accepts a complete body when no Content-Length is declared', async () => {
+      // Chunked senders declare nothing; the guards must not turn that into a refusal.
+      const req = makeReq([Buffer.from('abcde')]);
+      const res = makeRes();
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps MAX_RELAY_BYTES at or below the point where Next truncates', () => {
+      // 🔴 A RELATIONSHIP, not a value. Raising MAX_RELAY_BYTES above the framework's
+      // truncation point silently restores the original defect: bodies between the two
+      // are cut mid-stream, and the running-total cap never fires because the stream
+      // ends before it is exceeded. Whoever raises it must raise
+      // `middlewareClientMaxBodySize` in next.config.mjs in the same change — this
+      // fails until they do.
+      expect(MAX_RELAY_BYTES).toBeLessThanOrEqual(NEXT_BODY_TRUNCATION_BYTES);
+    });
+
+    it('releases the in-flight slot after refusing a truncated body', async () => {
+      // The refusal returns through the same `finally`; a leaked slot would wedge the
+      // route into shedding every later request with 429 until the pod restarts.
+      const before = __getInFlightForTest();
+      await handler(makeReq([Buffer.from('ab')], { contentLength: 99 }), makeRes());
+      expect(__getInFlightForTest()).toBe(before);
+    });
   });
 
   it('does NOT put the store error message on the wire', async () => {

--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -208,35 +208,48 @@ describe('image-upload relay', () => {
     expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
   });
 
-  // AUDIT-F5 + AUDIT-F6. Two properties, both about the oversize path.
+  // AUDIT-F5 + AUDIT-F6. Two properties of the oversize path.
   //
-  //  * F5: the client must actually RECEIVE the 413. An earlier draft wrote the
-  //    status and then called `req.destroy()`, which tears down the shared socket
-  //    and discards queued writes — the client got a transport error instead. The
-  //    route no longer destroys the request at all; it sets `Connection: close` and
-  //    lets the response flush. So: a status is written, and the request is NOT
-  //    destroyed.
+  //  * F5: the 413 must reach the client. Two earlier attempts did not — `req.destroy()`
+  //    RSTs the socket, and `Connection: close` makes `res.end()` call
+  //    `socket.destroySoon()` which RSTs it too when inbound data is unread. Measured
+  //    against a real HTTP client, only DRAINING delivers the status. So: no
+  //    `Connection` header, and the request IS resumed.
   //  * F6: the running-total property. Asserting the 413 alone does NOT pin it — a
-  //    measure-at-the-end implementation returns the same 413, which is why the
-  //    first draft's cap test left that mutant alive. What discriminates is that a
-  //    running total STOPS READING: it throws on the chunk that crosses the limit,
-  //    so the stream never reaches EOF. `readableEnded` is that fact directly.
+  //    measure-at-the-end implementation returns the same 413, which is why the first
+  //    draft's cap test left that mutant alive. What discriminates is that a running
+  //    total STOPS READING: it throws on the chunk that crosses the limit, so the
+  //    stream never reaches EOF. `readableEnded` is that fact directly.
   //
-  // ⚠ What does NOT work, so nobody re-derives it: counting how many chunks the
-  // async source yielded. Node's Readable reads AHEAD of the consumer, so the real
+  // 🔴 THIS TEST CANNOT SEE F5's ACTUAL PROPERTY. `makeReq` is a `Readable.from` and
+  // `makeRes` is an object literal — there is no socket, so "the client received the
+  // status" is unobservable here. It pins the CALLS that the real-socket measurement
+  // showed are necessary (drain yes, Connection header no); delivery itself was
+  // established by that measurement, not by this. Do not read a green here as proof
+  // the client got the 413.
+  //
+  // ⚠ What does NOT work, so nobody re-derives it: counting how many chunks the async
+  // source yielded. Node's Readable reads AHEAD of the consumer, so the real
   // running-total implementation still pulls the chunk after the one that trips the
   // cap. Generator-pull count measures the stream's buffering, not the handler's.
-  it('writes the 413 without destroying the request, and stops reading before EOF', async () => {
+  it('writes the 413, drains rather than closing, and stops reading before EOF', async () => {
     const trace: Trace = [];
     const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
     const req = makeReq([Buffer.alloc(half), Buffer.alloc(half)], { trace });
     const res = makeRes(trace);
+    let resumed = false;
+    (req as unknown as { resume: () => void }).resume = () => {
+      resumed = true;
+    };
 
     await handler(req, res);
 
     expect(res.statusCode).toBe(413);
-    expect(res.headers['Connection']).toBe('close');
-    // F5: a destroy must not race the write we just made.
+    // F5: `Connection: close` is what destroyed the socket before the status landed.
+    expect(res.headers['Connection']).toBeUndefined();
+    // F5: the drain is the only arm measured to deliver the status.
+    expect(resumed).toBe(true);
+    // F5: and nothing may destroy the request.
     expect(trace).toEqual(['status:413']);
     // F6: a measure-at-the-end implementation consumes to EOF and fails here while
     // still returning the same 413.
@@ -374,7 +387,8 @@ describe('image-upload relay', () => {
   });
 
   it('releases its slot on EVERY exit path, not just success', async () => {
-    // A leaked slot is permanent: the route wedges at 503 until the pod restarts,
+    // A leaked slot is permanent: the route wedges, shedding every request with 429
+    // until the pod restarts,
     // which is worse than the OOM the cap prevents. Drive each early return.
     const before = __getInFlightForTest();
 

--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -17,10 +17,16 @@ import type * as OriginHelpers from '~/server/utils/origin-helpers';
 // are red against that draft.
 //
 // Mocks are SURGICAL (spread `importOriginal`, override one symbol). A one-key
-// wholesale factory for `~/utils/s3-utils` — which exports ~30 runtime symbols —
-// collapses the whole file to "no tests" the moment the route imports a second
-// symbol from it, which is the silent-zero shape `local-rules/no-wholesale-module-mock`
-// exists to prevent.
+// wholesale factory for `~/utils/s3-utils` — which exports 31 runtime symbols —
+// collapses the whole file to "no tests" the moment the route imports a second symbol
+// from it: a silent zero, not a failure.
+//
+// ⚠ NOTHING ENFORCES THIS. An earlier version of this comment said the shape is what
+// `local-rules/no-wholesale-module-mock` "exists to prevent", implying that rule
+// covers this file. Measured in a round-2 audit: it does NOT — the rule is configured
+// with an explicit five-module allowlist and none of the modules mocked here is on
+// it. Planting the wholesale factory produces zero errors from that rule. Keep the
+// mocks surgical by hand; no lint will catch you.
 
 const {
   mockGetServerAuthSession,
@@ -65,7 +71,9 @@ vi.mock('~/server/utils/origin-helpers', async (importOriginal) => ({
 import handler, {
   MAX_RELAY_BYTES,
   MAX_CONCURRENT_RELAYS,
+  RELAY_RETRY_AFTER_SECONDS,
   __getInFlightForTest,
+  __resetInFlightForTest,
 } from '~/pages/api/v1/image-upload/relay';
 
 /** Records the order in which the handler wrote a status vs destroyed the request. */
@@ -128,6 +136,9 @@ const authed = { user: { id: 7, bannedAt: null } };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // A case that leaves a slot held would otherwise make the NEXT case fail for an
+  // unrelated reason — measured as a false cascading failure during round-2 mutation.
+  __resetInFlightForTest();
   prodFlag.value = false;
   mockGetServerAuthSession.mockResolvedValue(authed);
   mockUploadImageBufferToStore.mockResolvedValue({
@@ -197,24 +208,25 @@ describe('image-upload relay', () => {
     expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
   });
 
-  // AUDIT-F5 + AUDIT-F6, and this single trace pins BOTH — deliberately, because
-  // neither is expressible on its own here.
+  // AUDIT-F5 + AUDIT-F6. Two properties, both about the oversize path.
   //
-  //  * F5: `req.destroy()` tears down the socket, so a status written afterwards
-  //    goes into a dead socket and the client sees a transport error, never the 413.
-  //    Hence `status:413` must precede `destroy`.
+  //  * F5: the client must actually RECEIVE the 413. An earlier draft wrote the
+  //    status and then called `req.destroy()`, which tears down the shared socket
+  //    and discards queued writes — the client got a transport error instead. The
+  //    route no longer destroys the request at all; it sets `Connection: close` and
+  //    lets the response flush. So: a status is written, and the request is NOT
+  //    destroyed.
   //  * F6: the running-total property. Asserting the 413 alone does NOT pin it — a
   //    measure-at-the-end implementation returns the same 413, which is why the
-  //    first draft's cap test left that mutant alive. The tell is the LEADING
-  //    entry: measure-at-end consumes to EOF, and a stream that ends auto-destroys,
-  //    producing ['destroy', 'status:413', 'destroy']. A running total throws before
-  //    EOF, so no destroy precedes the status. Confirmed by mutation.
+  //    first draft's cap test left that mutant alive. What discriminates is that a
+  //    running total STOPS READING: it throws on the chunk that crosses the limit,
+  //    so the stream never reaches EOF. `readableEnded` is that fact directly.
   //
   // ⚠ What does NOT work, so nobody re-derives it: counting how many chunks the
   // async source yielded. Node's Readable reads AHEAD of the consumer, so the real
   // running-total implementation still pulls the chunk after the one that trips the
   // cap. Generator-pull count measures the stream's buffering, not the handler's.
-  it('writes the 413 before destroying, and does not consume the stream to EOF', async () => {
+  it('writes the 413 without destroying the request, and stops reading before EOF', async () => {
     const trace: Trace = [];
     const half = Math.floor(MAX_RELAY_BYTES / 2) + 1;
     const req = makeReq([Buffer.alloc(half), Buffer.alloc(half)], { trace });
@@ -223,7 +235,12 @@ describe('image-upload relay', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(413);
-    expect(trace).toEqual(['status:413', 'destroy']);
+    expect(res.headers['Connection']).toBe('close');
+    // F5: a destroy must not race the write we just made.
+    expect(trace).toEqual(['status:413']);
+    // F6: a measure-at-the-end implementation consumes to EOF and fails here while
+    // still returning the same 413.
+    expect((req as unknown as { readableEnded: boolean }).readableEnded).toBe(false);
   });
 
   it('accepts a body exactly AT the cap — the boundary is inclusive', async () => {
@@ -321,7 +338,7 @@ describe('image-upload relay', () => {
 
   // AUDIT-F4. The route buffers whole, so unbounded concurrency is an OOMKill of the
   // pod — taking every unrelated request on it down, not just uploads.
-  it('sheds with 503 once MAX_CONCURRENT_RELAYS are in flight', async () => {
+  it('sheds with 429 once MAX_CONCURRENT_RELAYS are in flight', async () => {
     // Hold every slot open by never resolving the store call.
     let release: () => void = () => undefined;
     mockUploadImageBufferToStore.mockImplementation(
@@ -344,8 +361,11 @@ describe('image-upload relay', () => {
 
     const shedRes = makeRes();
     await handler(makeReq([Buffer.from('bytes')]), shedRes);
-    expect(shedRes.statusCode).toBe(503);
-    expect(shedRes.headers['Retry-After']).toBe('5');
+    // 429, NOT 503: `instrumentApiResponse` counts every status >= 500 as an app
+    // error, so shedding with a 5xx would report deliberate healthy load-shedding as
+    // a server fault in this route's own attribution.
+    expect(shedRes.statusCode).toBe(429);
+    expect(shedRes.headers['Retry-After']).toBe(String(RELAY_RETRY_AFTER_SECONDS));
 
     release();
     await Promise.all(held);

--- a/src/__tests__/pages/api/v1/image-upload/relay.test.ts
+++ b/src/__tests__/pages/api/v1/image-upload/relay.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'stream';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Covers the FALLBACK image-upload relay (`/api/v1/image-upload/relay`).
+//
+// These are NEW-FEATURE tests, not regression guards: the route did not exist before
+// this change, so there is no pre-change revision at which they could be shown red.
+// Stated explicitly so nobody later reads them as evidence that a specific defect was
+// reproduced and fixed.
+//
+// The properties worth pinning are the ones where getting it wrong is silent:
+//  - the key is minted SERVER-SIDE and no caller-supplied key is honoured (an
+//    earlier draft echoed the presign's id back, which lets a caller overwrite
+//    another user's object)
+//  - the size cap trips on the RUNNING total, so an oversized body cannot be
+//    buffered in full first
+//  - an unauthenticated or banned caller never reaches the store at all
+
+const { mockGetServerAuthSession, mockUploadImageBufferToStore } = vi.hoisted(() => ({
+  mockGetServerAuthSession: vi.fn(),
+  mockUploadImageBufferToStore: vi.fn(),
+}));
+
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: mockGetServerAuthSession,
+}));
+
+vi.mock('~/utils/s3-utils', () => ({
+  uploadImageBufferToStore: mockUploadImageBufferToStore,
+}));
+
+vi.mock('~/server/prom/http-errors', () => ({
+  instrumentApiResponse: vi.fn(),
+}));
+
+import handler, { MAX_RELAY_BYTES } from '~/pages/api/v1/image-upload/relay';
+
+function makeReq(
+  body: Buffer,
+  opts?: { method?: string; contentType?: string }
+): NextApiRequest {
+  const stream = Readable.from([body]) as unknown as NextApiRequest;
+  stream.method = opts?.method ?? 'POST';
+  stream.headers = { 'content-type': opts?.contentType ?? 'image/png' };
+  stream.query = {};
+  return stream;
+}
+
+function makeRes() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+  };
+  return res as unknown as NextApiResponse & typeof res;
+}
+
+const authed = { user: { id: 7, bannedAt: null } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetServerAuthSession.mockResolvedValue(authed);
+  mockUploadImageBufferToStore.mockResolvedValue({ key: 'server-minted-uuid', backend: 'backblaze' });
+});
+
+describe('image-upload relay', () => {
+  it('uploads the body and returns the SERVER-minted key', async () => {
+    const req = makeReq(Buffer.from('image-bytes'));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ id: 'server-minted-uuid' });
+
+    // The bytes reached the store intact, with the caller's content type.
+    expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
+    const [buf, opts] = mockUploadImageBufferToStore.mock.calls[0];
+    expect(Buffer.from(buf).toString()).toBe('image-bytes');
+    expect(opts).toEqual({ contentType: 'image/png' });
+  });
+
+  it('ignores any caller-supplied key — the store mints it', async () => {
+    // A caller trying to name the object it writes. `uploadImageBufferToStore` takes
+    // only (bytes, {contentType}); if a future edit threads a key through, this fails.
+    const req = makeReq(Buffer.from('bytes'));
+    (req as unknown as { query: Record<string, string> }).query = {
+      key: 'victim-uuid',
+      id: 'victim-uuid',
+    };
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ id: 'server-minted-uuid' });
+    const [, opts] = mockUploadImageBufferToStore.mock.calls[0];
+    expect(opts).not.toHaveProperty('key');
+    expect(JSON.stringify(mockUploadImageBufferToStore.mock.calls[0])).not.toContain('victim-uuid');
+  });
+
+  it('rejects a body over the cap without buffering it whole', async () => {
+    const req = makeReq(Buffer.alloc(MAX_RELAY_BYTES + 1));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(413);
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+  });
+
+  it('accepts a body exactly AT the cap — the boundary is inclusive', async () => {
+    // Guards the off-by-one directly: `>` not `>=`. A fixture one byte under would
+    // pass against either spelling and prove nothing about the boundary.
+    const req = makeReq(Buffer.alloc(MAX_RELAY_BYTES));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an empty body', async () => {
+    const req = makeReq(Buffer.alloc(0));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthenticated caller before touching the store', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null);
+    const req = makeReq(Buffer.from('bytes'));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+  });
+
+  it('rejects a banned user before touching the store', async () => {
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { id: 7, bannedAt: new Date('2026-01-01') },
+    });
+    const req = makeReq(Buffer.from('bytes'));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-POST method', async () => {
+    const req = makeReq(Buffer.from('bytes'), { method: 'GET' });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a store failure as a 500 rather than a silent success', async () => {
+    mockUploadImageBufferToStore.mockRejectedValue(new Error('b2 exploded'));
+    const req = makeReq(Buffer.from('bytes'));
+    const res = makeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'b2 exploded' });
+  });
+});

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -86,6 +86,13 @@ export const useCFImageUpload: UseCFImageUpload = () => {
 
     const { id, uploadURL: url } = data;
 
+    // The relay fallback (below) mints its OWN key server-side, so the id this call
+    // resolves with is not necessarily the one the presign handed us. Everything that
+    // reports an id — the tracked file's `url`, the return value — reads this, not the
+    // `id` const, so a fallback upload is reported under the key that actually holds
+    // the bytes.
+    let resolvedId = id;
+
     const xhr = new XMLHttpRequest();
     setFiles((x) => [
       ...x,
@@ -93,7 +100,7 @@ export const useCFImageUpload: UseCFImageUpload = () => {
         ...pendingTrackedFile,
         ...imageData,
         abort: xhr.abort.bind(xhr),
-        url: id,
+        url: resolvedId,
       },
     ]);
 
@@ -104,10 +111,32 @@ export const useCFImageUpload: UseCFImageUpload = () => {
           return {
             ...y,
             ...trackedFile,
-            url: id,
+            url: resolvedId,
           } as TrackedFile;
         })
       );
+    }
+
+    /**
+     * Relay the file through our own origin when the direct PUT cannot reach the
+     * storage host at all.
+     *
+     * Scoped deliberately to the `error` event, which is the network-layer failure —
+     * DNS, TLS, connection refused. A non-2xx `loadend` is NOT retried here: that
+     * means we reached the storage backend and it rejected us, and replaying the same
+     * bytes through a second route would mask a real fault rather than route around
+     * an unreachable host.
+     */
+    async function relayUpload() {
+      const relayRes = await fetch('/api/v1/image-upload/relay', {
+        method: 'POST',
+        headers: { 'Content-Type': file.type || 'application/octet-stream' },
+        body: file,
+      });
+      if (!relayRes.ok) throw new Error(`Upload fallback failed (status ${relayRes.status})`);
+      const relayData: { id?: string; error?: unknown } = await relayRes.json();
+      if (!relayData.id) throw new Error('Upload fallback returned no id');
+      return relayData.id;
     }
 
     await new Promise((resolve, reject) => {
@@ -144,8 +173,20 @@ export const useCFImageUpload: UseCFImageUpload = () => {
         resolve(success);
       });
       xhr.addEventListener('error', () => {
-        updateFile({ status: 'error' });
-        reject(new Error(`Upload failed (status ${xhr.status})`));
+        // Direct-to-storage PUT could not reach the host. Try our own origin, which
+        // the browser has demonstrably resolved — it just fetched the presign from it.
+        relayUpload()
+          .then((relayedId) => {
+            resolvedId = relayedId;
+            updateFile({ status: 'success' });
+            resolve(true);
+          })
+          .catch(() => {
+            // Report the ORIGINAL failure. The fallback is a recovery attempt, and
+            // surfacing its error instead would rename the user's problem.
+            updateFile({ status: 'error' });
+            reject(new Error(`Upload failed (status ${xhr.status})`));
+          });
       });
       xhr.addEventListener('abort', () => {
         updateFile({ status: 'aborted' });
@@ -155,7 +196,12 @@ export const useCFImageUpload: UseCFImageUpload = () => {
       xhr.send(file);
     });
 
-    return { url: url.split('?')[0], id, objectUrl: imageData.objectUrl, type: imageData.type };
+    return {
+      url: url.split('?')[0],
+      id: resolvedId,
+      objectUrl: imageData.objectUrl,
+      type: imageData.type,
+    };
   };
 
   const removeImage = (imageUrl: string) => {

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -7,6 +7,7 @@ import { showErrorNotification } from '~/utils/notifications';
 import { isDefined } from '~/utils/type-guards';
 import { v4 as uuidv4 } from 'uuid';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { attachUploadSettlement } from '~/utils/upload-settlement';
 
 type TrackedFileStatus = 'pending' | 'error' | 'success' | 'uploading' | 'aborted' | 'blocked';
 type TrackedFile = AsyncReturnType<typeof getDataFromFile> & {
@@ -94,12 +95,20 @@ export const useCFImageUpload: UseCFImageUpload = () => {
     let resolvedId = id;
 
     const xhr = new XMLHttpRequest();
+
+    // The relay is a `fetch`, not the xhr, so `xhr.abort()` is a spec no-op once the
+    // xhr is DONE. Cancelling during a fallback has to cancel this instead.
+    const relayController = new AbortController();
+
     setFiles((x) => [
       ...x,
       {
         ...pendingTrackedFile,
         ...imageData,
-        abort: xhr.abort.bind(xhr),
+        abort: () => {
+          xhr.abort();
+          relayController.abort();
+        },
         url: resolvedId,
       },
     ]);
@@ -127,11 +136,12 @@ export const useCFImageUpload: UseCFImageUpload = () => {
      * bytes through a second route would mask a real fault rather than route around
      * an unreachable host.
      */
-    async function relayUpload() {
+    async function relayUpload(signal: AbortSignal) {
       const relayRes = await fetch('/api/v1/image-upload/relay', {
         method: 'POST',
         headers: { 'Content-Type': file.type || 'application/octet-stream' },
         body: file,
+        signal,
       });
       if (!relayRes.ok) throw new Error(`Upload fallback failed (status ${relayRes.status})`);
       const relayData: { id?: string; error?: unknown } = await relayRes.json();
@@ -164,34 +174,21 @@ export const useCFImageUpload: UseCFImageUpload = () => {
           });
         }
       });
-      xhr.addEventListener('loadend', () => {
-        const success = xhr.readyState === 4 && xhr.status === 200;
-        if (success) {
-          updateFile({ status: 'success' });
-          // URL.revokeObjectURL(imageData.objectUrl);
-        }
-        resolve(success);
-      });
-      xhr.addEventListener('error', () => {
-        // Direct-to-storage PUT could not reach the host. Try our own origin, which
-        // the browser has demonstrably resolved — it just fetched the presign from it.
-        relayUpload()
-          .then((relayedId) => {
-            resolvedId = relayedId;
-            updateFile({ status: 'success' });
-            resolve(true);
-          })
-          .catch(() => {
-            // Report the ORIGINAL failure. The fallback is a recovery attempt, and
-            // surfacing its error instead would rename the user's problem.
-            updateFile({ status: 'error' });
-            reject(new Error(`Upload failed (status ${xhr.status})`));
-          });
-      });
-      xhr.addEventListener('abort', () => {
-        updateFile({ status: 'aborted' });
-        reject(new Error('Upload canceled'));
-      });
+      // Terminal-event handling — including the relay fallback and which side is
+      // allowed to settle — lives in `attachUploadSettlement`, so the ordering rule
+      // is real code a unit test can drive rather than logic duplicated in a test.
+      attachUploadSettlement(xhr, () => relayUpload(relayController.signal), {
+        onRelayed: (relayedId) => {
+          resolvedId = relayedId;
+        },
+        onSuccess: () => updateFile({ status: 'success' }),
+        onError: () => updateFile({ status: 'error' }),
+        onAborted: () => updateFile({ status: 'aborted' }),
+      }).then(
+        (outcome) => resolve(outcome.kind === 'relayed' ? true : outcome.success),
+        (error) => reject(error)
+      );
+
       xhr.open('PUT', url);
       xhr.send(file);
     });

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -7,7 +7,7 @@ import { showErrorNotification } from '~/utils/notifications';
 import { isDefined } from '~/utils/type-guards';
 import { v4 as uuidv4 } from 'uuid';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { attachUploadSettlement } from '~/utils/upload-settlement';
+import { attachUploadSettlement, relayWithRetry } from '~/utils/upload-settlement';
 
 type TrackedFileStatus = 'pending' | 'error' | 'success' | 'uploading' | 'aborted' | 'blocked';
 type TrackedFile = AsyncReturnType<typeof getDataFromFile> & {
@@ -136,13 +136,24 @@ export const useCFImageUpload: UseCFImageUpload = () => {
      * bytes through a second route would mask a real fault rather than route around
      * an unreachable host.
      */
-    async function relayUpload(signal: AbortSignal) {
-      const relayRes = await fetch('/api/v1/image-upload/relay', {
+    async function postToRelay(signal: AbortSignal) {
+      return fetch('/api/v1/image-upload/relay', {
         method: 'POST',
         headers: { 'Content-Type': file.type || 'application/octet-stream' },
         body: file,
         signal,
       });
+    }
+
+    async function relayUpload(signal: AbortSignal) {
+      // Retry-on-429 lives in `relayWithRetry` so it can be tested; see its comment
+      // for why a shed must not be terminal.
+      const relayRes = await relayWithRetry(() => postToRelay(signal), {
+        signal,
+        sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+        defaultRetryAfterSeconds: 2,
+      });
+
       if (!relayRes.ok) throw new Error(`Upload fallback failed (status ${relayRes.status})`);
       const relayData: { id?: string; error?: unknown } = await relayRes.json();
       if (!relayData.id) throw new Error('Upload fallback returned no id');

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -1,0 +1,129 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { uploadImageBufferToStore } from '~/utils/s3-utils';
+
+// FALLBACK upload path, for clients that cannot reach the storage host directly.
+//
+// The normal path is browser-direct: `/api/v1/image-upload` mints a key and returns
+// a presigned PUT URL, and the browser PUTs straight at the storage endpoint. That
+// endpoint is a raw storage hostname, not a civitai.com one, so a client whose DNS
+// cannot resolve it gets `ERR_NAME_NOT_RESOLVED` on the PUT while every other
+// request on the page succeeds — it presents as "uploads are broken for me
+// specifically" (see the six reported instances behind this change).
+//
+// This route relays the bytes through an origin the client has demonstrably already
+// resolved — it is talking to us — and performs the store write server-side. Same
+// bucket, same backend, same storage-resolver registration, so the resulting object
+// is servable exactly as a direct upload would be.
+//
+// 🔴 FALLBACK ONLY. Do NOT wire this in as the default upload path: every relayed
+// byte transits the app servers, so making it the default moves the entire image
+// upload bandwidth off the browser-to-storage path and onto us. The client only
+// reaches for it after a direct PUT has already failed at the network layer.
+//
+// 🔴 The key is minted SERVER-SIDE (inside `uploadImageBufferToStore`) and this route
+// deliberately accepts NO caller-supplied key. An earlier draft reused the id from
+// the presign call so the two paths would agree; that lets a caller name any uuid it
+// likes and overwrite another user's object, because the id travels through the
+// browser. Minting here costs one orphaned zero-byte registration from the presign
+// that preceded the fallback — which the storage-resolver orphan reconciliation
+// already sweeps — and closes the overwrite entirely.
+//
+// POST /api/v1/image-upload/relay   body: raw image bytes
+// -> { id: <uuid key> }
+
+export const config = {
+  api: {
+    // Raw bytes: the body is the file. `bodyParser` would try to parse it.
+    bodyParser: false,
+  },
+};
+
+// Matches `constants.richTextEditor.maxFileSize` (50MB), the largest media size the
+// app already accepts elsewhere. NOTE this is a cap the DIRECT path does not have —
+// a presigned PUT is bounded by the storage backend, not by us — so a file above
+// this size cannot use the fallback. That is a deliberate limit on a relay that
+// buffers in memory, not a general upload limit.
+export const MAX_RELAY_BYTES = 1024 * 1024 * 50;
+
+export default async function imageUploadRelay(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution, matching the direct presign route.
+  instrumentApiResponse(req, res);
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await getServerAuthSession({ req, res });
+  const userId = session?.user?.id;
+  if (!userId || session.user?.bannedAt) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  let body: Buffer;
+  try {
+    body = await readCappedBody(req, MAX_RELAY_BYTES);
+  } catch (e) {
+    if (e instanceof PayloadTooLargeError) {
+      res.status(413).json({ error: 'File too large for the upload fallback' });
+      return;
+    }
+    res.status(400).json({ error: 'Failed to read upload body' });
+    return;
+  }
+
+  if (body.length === 0) {
+    res.status(400).json({ error: 'Empty upload body' });
+    return;
+  }
+
+  const contentTypeHeader = req.headers['content-type'];
+  const contentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
+
+  try {
+    // `uploadImageBufferToStore` returns { key, backend }; the direct presign route
+    // calls the same value `id` in its response, so keep the wire shape identical.
+    const { key } = await uploadImageBufferToStore(body, { contentType });
+    res.status(200).json({ id: key });
+  } catch (e) {
+    const error = e as Error;
+    res.status(500).json({ error: error.message ?? 'Upload failed' });
+  }
+}
+
+export class PayloadTooLargeError extends Error {
+  constructor() {
+    super('Payload too large');
+    this.name = 'PayloadTooLargeError';
+  }
+}
+
+/**
+ * Buffer the request body, aborting as soon as it exceeds `limit`.
+ *
+ * The check is on the RUNNING total rather than on the finished buffer: the point is
+ * to stop allocating, so a caller cannot spend our memory by streaming an
+ * arbitrarily large body that we only measure at the end. `Content-Length` is not
+ * trusted for this — it is caller-supplied and may be absent under chunked encoding.
+ */
+async function readCappedBody(req: NextApiRequest, limit: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > limit) {
+      // Stop the client from continuing to send into a request we have abandoned.
+      req.destroy();
+      throw new PayloadTooLargeError();
+    }
+    chunks.push(buf);
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -49,17 +49,55 @@ export const config = {
   },
 };
 
-// Bounds what this route will buffer in memory. NOT a general upload limit and NOT
-// "the largest media the app accepts" — `constants.mediaUpload.maxVideoFileSize` is
-// 750MB. It matches `constants.mediaUpload.maxImageFileSize`, which is what the
-// DROPZONE callers of `useCFImageUpload` enforce client-side (`ImageUpload.tsx`,
-// `SimpleImageUpload.tsx`) — THAT is the constant this must stay in sync with, not
-// `richTextEditor.maxFileSize`, which happens to hold the same value today but is
-// used by the rich-text editor rather than by any dropzone. The programmatic callers that upload
-// generated blobs enforce nothing, so this is their only bound. Exists because this
-// route buffers whole. A file above it cannot use the fallback; the direct path is
-// unaffected.
-export const MAX_RELAY_BYTES = 1024 * 1024 * 50;
+/**
+ * The size at which Next TRUNCATES a request body, silently.
+ *
+ * 🔴 This is a property of the framework, not a choice of ours, and it is the reason
+ * this route cannot simply pick its own limit. Next 16 caps the body it will hand a
+ * route at 10MB by default and then just ENDS the stream — the route sees a clean
+ * end-of-body, not an error. `next.config.mjs` does not set
+ * `middlewareClientMaxBodySize`, so the default applies.
+ *
+ * Measured on a deployed preview (Next 16.3.1), sent vs what actually reached the
+ * store, reproduced BOTH through the ingress and by POSTing from inside the container
+ * straight at the app port — so it is the framework, not a proxy in front:
+ *
+ *     sent 10,485,760 -> stored 10,485,760   intact
+ *     sent 12,000,000 -> stored 10,438,916   TRUNCATED
+ *     sent 20,000,000 -> stored 10,483,999   TRUNCATED
+ *     sent 55,000,000 -> stored 10,479,830   TRUNCATED
+ *
+ * The cut is ragged, which is the tell that it is a stream ending early rather than a
+ * fixed-size cap. Before the guards below, a valid 14,523,378-byte PNG relayed as a
+ * 10,485,209-byte object with no `IEND` terminator — `magick` rejects it with
+ * `unexpected end-of-file` — while the route returned `200 {"id": …}`. A corrupt image
+ * reported to the user as a successful upload.
+ */
+export const NEXT_BODY_TRUNCATION_BYTES = 1024 * 1024 * 10;
+
+/**
+ * Bounds what this route will buffer in memory, and what it will accept at all.
+ *
+ * 🔴 Pinned to `NEXT_BODY_TRUNCATION_BYTES` deliberately. It used to be 50MB, to match
+ * `constants.mediaUpload.maxImageFileSize` (what the DROPZONE callers of
+ * `useCFImageUpload` enforce client-side — `ImageUpload.tsx`, `SimpleImageUpload.tsx`).
+ * That constant was UNREACHABLE: Next truncated at 10MB first, so the cap never bound
+ * and the 413 branch below was dead code.
+ *
+ * Raising this above the truncation point requires raising
+ * `middlewareClientMaxBodySize` in `next.config.mjs` IN THE SAME CHANGE — that is a
+ * repo-wide widening of how large a body every route may receive, so it was not done
+ * here. It buys little: sampled 111,097 rows of `Image.metadata->>'size'`, **0.679%**
+ * of images exceed 10MB (p99 = 7.63MB), and this is a fallback that only fires for
+ * clients who cannot resolve the storage host at all. Those few now get an honest 413
+ * instead of a silently corrupted file.
+ *
+ * ⚠ Video is a different population — 17.1% of sampled videos exceed 10MB — so if this
+ * route is ever put on a video path, revisit this and the config knob together.
+ *
+ * A file above this cannot use the fallback; the direct path is unaffected.
+ */
+export const MAX_RELAY_BYTES = NEXT_BODY_TRUNCATION_BYTES;
 
 /**
  * Ceiling on relays held in memory at once, PER POD.
@@ -187,8 +225,10 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
     try {
       body = await readCappedBody(req, res, MAX_RELAY_BYTES);
     } catch (e) {
-      if (e instanceof PayloadTooLargeError) {
-        // The 413 was already written by `readCappedBody` — see the note there.
+      if (e instanceof PayloadTooLargeError || e instanceof TruncatedBodyError) {
+        // The 413 / 400 was already written by `readCappedBody` — see the notes there.
+        // 🔴 Returning here is what skips the store write: neither a refused nor an
+        // incomplete body may reach `uploadImageBufferToStore`.
         return;
       }
       res.status(400).json({ error: 'Failed to read upload body' });
@@ -231,6 +271,20 @@ export class PayloadTooLargeError extends Error {
   constructor() {
     super('Payload too large');
     this.name = 'PayloadTooLargeError';
+  }
+}
+
+/**
+ * The request body ended before the client's declared `Content-Length`.
+ *
+ * Distinct from `PayloadTooLargeError` on purpose: that one means we refused the
+ * request, this one means we could not trust what we received. Both must skip the
+ * store write, and both have already written their own status.
+ */
+export class TruncatedBodyError extends Error {
+  constructor() {
+    super('Request body was truncated');
+    this.name = 'TruncatedBodyError';
   }
 }
 
@@ -291,6 +345,32 @@ async function readCappedBody(
   const chunks: Buffer[] = [];
   let total = 0;
 
+  // Declared length, when the client sends one. `fetch` with a `File`/`Blob` body
+  // always does, which is every real caller of this route; chunked senders will not,
+  // hence every use below is conditional.
+  const declaredRaw = req.headers['content-length'];
+  const declared = Number(Array.isArray(declaredRaw) ? declaredRaw[0] : declaredRaw);
+  const hasDeclared = Number.isInteger(declared) && declared >= 0;
+
+  // 🔴 Reject an over-size body BEFORE reading a byte of it.
+  //
+  // This is what makes the 413 reachable at all. Next truncates at
+  // `NEXT_BODY_TRUNCATION_BYTES` (see that constant), so once `limit` is at the
+  // truncation point the running-total check below can never trip — the stream ends
+  // at the cap instead of exceeding it. Reading the DECLARED length gets us the
+  // refusal before the framework silently cuts anything, and costs no buffering.
+  //
+  // Trusting `Content-Length` to REJECT is safe in a way trusting it to ACCEPT is not:
+  // a client that under-declares still gets caught by the running-total check, and a
+  // client that over-declares only harms itself. That asymmetry is why this does not
+  // contradict the note about not trusting the header for the cap.
+  if (hasDeclared && declared > limit) {
+    if (!res.headersSent) {
+      res.status(413).json({ error: 'File too large for the upload fallback' });
+    }
+    throw new PayloadTooLargeError();
+  }
+
   // 🔴 Iterated MANUALLY rather than with `for await`. Breaking out of a `for await`
   // invokes the iterator's `return()`, which DESTROYS the underlying stream — the
   // exact socket teardown that loses the status, applied by the language rather than
@@ -315,6 +395,30 @@ async function readCappedBody(
       throw new PayloadTooLargeError();
     }
     chunks.push(buf);
+  }
+
+  // 🔴 The body ended EARLY — never store a partial object.
+  //
+  // Next's truncation is indistinguishable from a clean end-of-body at the stream
+  // level: no error, no event, the iterator simply reports `done`. Without this check
+  // the route buffers the fragment, treats it as the whole file, PUTs it and returns
+  // `200 {"id": …}` — the caller is told the upload succeeded and gets a permanently
+  // corrupt image. That is strictly worse than the failure this route exists to fix,
+  // because a failed direct PUT is at least visible.
+  //
+  // Comparing against the declared length is the only signal available here. It also
+  // catches a client that died mid-upload, which deserves the same treatment: we did
+  // not receive the file, so we must not write one.
+  //
+  // 400 rather than 413 — the request was not too large (that is refused above,
+  // before reading), it was incomplete. Distinguishing them keeps a truncation
+  // regression from hiding inside the size-limit case.
+  if (hasDeclared && total < declared) {
+    if (!res.headersSent) {
+      res.status(400).json({ error: 'Upload body was incomplete' });
+    }
+    chunks.length = 0;
+    throw new TruncatedBodyError();
   }
 
   return Buffer.concat(chunks);

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -1,6 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { isProd } from '~/env/other';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { isAllowedOriginRequest } from '~/server/utils/origin-helpers';
 import { uploadImageBufferToStore } from '~/utils/s3-utils';
 
 // FALLBACK upload path, for clients that cannot reach the storage host directly.
@@ -26,9 +29,15 @@ import { uploadImageBufferToStore } from '~/utils/s3-utils';
 // deliberately accepts NO caller-supplied key. An earlier draft reused the id from
 // the presign call so the two paths would agree; that lets a caller name any uuid it
 // likes and overwrite another user's object, because the id travels through the
-// browser. Minting here costs one orphaned zero-byte registration from the presign
-// that preceded the fallback — which the storage-resolver orphan reconciliation
-// already sweeps — and closes the overwrite entirely.
+// browser. Minting here closes the overwrite entirely.
+//
+// ⚠ COST, not swept: when the fallback fires, the presign that preceded it has
+// already registered its own key with `sizeBytes: 0` and no object was ever written
+// to it. That row is NOT reclaimed by the existing orphan reconciliation, which
+// lists bucket OBJECTS and diffs them against the registry — a registry row with no
+// object is not in its universe. One stranded row per fallback. Left deliberately
+// rather than deleted here, because the direct path also registers `sizeBytes: 0`
+// for every SUCCESSFUL upload, so nothing may key a sweep on size alone.
 //
 // POST /api/v1/image-upload/relay   body: raw image bytes
 // -> { id: <uuid key> }
@@ -40,12 +49,35 @@ export const config = {
   },
 };
 
-// Matches `constants.richTextEditor.maxFileSize` (50MB), the largest media size the
-// app already accepts elsewhere. NOTE this is a cap the DIRECT path does not have —
-// a presigned PUT is bounded by the storage backend, not by us — so a file above
-// this size cannot use the fallback. That is a deliberate limit on a relay that
-// buffers in memory, not a general upload limit.
+// Bounds what this route will buffer in memory. NOT a general upload limit and NOT
+// "the largest media the app accepts" — `constants.mediaUpload.maxVideoFileSize` is
+// far larger. It matches the ceiling every current caller of `useCFImageUpload`
+// already enforces client-side, and exists because this route buffers whole.
+// A file above it cannot use the fallback; the direct path is unaffected.
 export const MAX_RELAY_BYTES = 1024 * 1024 * 50;
+
+/**
+ * Ceiling on relays held in memory at once, PER POD.
+ *
+ * At `MAX_RELAY_BYTES` and ~2x peak amplification this bounds the route at roughly
+ * 400MB — survivable beside a steady-state heap on the pod's limit, where an
+ * unbounded queue is not. Deliberately small: this is a fallback that only fires for
+ * clients who cannot reach the storage host, so sustained high concurrency here is
+ * itself the anomaly rather than the expected load.
+ *
+ * NOT env-configurable, which means it is not a runtime kill switch — changing it
+ * needs a deploy. Left that way on purpose rather than adding an env var to the
+ * repo-wide schema in this change; noted as a known gap.
+ */
+export const MAX_CONCURRENT_RELAYS = 8;
+
+/** In-flight relay count for this process. Module-scoped: per pod, not per cluster. */
+let inFlight = 0;
+
+/** Test seam — asserting the cap requires observing the counter. */
+export function __getInFlightForTest() {
+  return inFlight;
+}
 
 export default async function imageUploadRelay(req: NextApiRequest, res: NextApiResponse) {
   // 5xx attribution, matching the direct presign route.
@@ -57,6 +89,19 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
     return;
   }
 
+  // CSRF guard. This raw route is cookie-authenticated and bypasses the tRPC
+  // pipeline, so it never gets createContext's same-origin check. It also accepts an
+  // arbitrary Content-Type, which makes a cross-site POST a CORS-*simple* request —
+  // no preflight — so without this any third-party page could make a logged-in
+  // visitor write attacker-chosen bytes into the media bucket. The direct presign
+  // route is not exposed this way (its presigned URL is unreadable cross-origin), so
+  // this is new surface rather than parity. Mirrors the posture and the !isProd
+  // exemption of `blocks/submit-version.ts`, which is the in-repo precedent.
+  if (isProd && !isAllowedOriginRequest(req)) {
+    res.status(403).json({ error: 'Cross-origin request blocked' });
+    return;
+  }
+
   const session = await getServerAuthSession({ req, res });
   const userId = session?.user?.id;
   if (!userId || session.user?.bannedAt) {
@@ -64,34 +109,62 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
     return;
   }
 
-  let body: Buffer;
+  // 🔴 Bound the memory this route can hold at once. It buffers whole, and
+  // `Buffer.concat` allocates a second copy while the chunk array is still live, so
+  // peak is ~2x the body — Buffers are external, so `--max-old-space-size` does not
+  // bound them and only the pod's memory limit does. Without a cap, N concurrent
+  // max-size relays are an OOMKill of the whole pod, taking every unrelated request
+  // on it down too. Shedding here is strictly better: the client keeps its original
+  // error and the direct path is untouched.
+  if (inFlight >= MAX_CONCURRENT_RELAYS) {
+    res.setHeader('Retry-After', '5');
+    res.status(503).json({ error: 'Upload fallback is busy' });
+    return;
+  }
+
+  inFlight += 1;
   try {
-    body = await readCappedBody(req, MAX_RELAY_BYTES);
-  } catch (e) {
-    if (e instanceof PayloadTooLargeError) {
-      res.status(413).json({ error: 'File too large for the upload fallback' });
+    let body: Buffer;
+    try {
+      body = await readCappedBody(req, res, MAX_RELAY_BYTES);
+    } catch (e) {
+      if (e instanceof PayloadTooLargeError) {
+        // The 413 was already written by `readCappedBody`, before the socket was torn
+        // down — see the comment there for why the order matters.
+        return;
+      }
+      res.status(400).json({ error: 'Failed to read upload body' });
       return;
     }
-    res.status(400).json({ error: 'Failed to read upload body' });
-    return;
-  }
 
-  if (body.length === 0) {
-    res.status(400).json({ error: 'Empty upload body' });
-    return;
-  }
+    if (body.length === 0) {
+      res.status(400).json({ error: 'Empty upload body' });
+      return;
+    }
 
-  const contentTypeHeader = req.headers['content-type'];
-  const contentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
+    const contentTypeHeader = req.headers['content-type'];
+    const contentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
 
-  try {
-    // `uploadImageBufferToStore` returns { key, backend }; the direct presign route
-    // calls the same value `id` in its response, so keep the wire shape identical.
-    const { key } = await uploadImageBufferToStore(body, { contentType });
-    res.status(200).json({ id: key });
-  } catch (e) {
-    const error = e as Error;
-    res.status(500).json({ error: error.message ?? 'Upload failed' });
+    try {
+      // `uploadImageBufferToStore` returns { key, backend }; the direct presign route
+      // calls the same value `id` in its response, so keep the wire shape identical.
+      const { key } = await uploadImageBufferToStore(body, { contentType });
+      res.status(200).json({ id: key });
+    } catch (e) {
+      // 🔴 NOT `error.message`. This path's errors come from the AWS SDK's
+      // PutObjectCommand, whose messages carry bucket names, endpoint hostnames,
+      // request ids and signature detail — returning them verbatim discloses
+      // infrastructure to any logged-in caller, and puts this route on the
+      // rest-error-envelope ledger's offender set. `handleEndpointError` genericises
+      // the wire body, logs the real cause, and maps a client disconnect to 499 so it
+      // stays out of the 5xx SLO.
+      handleEndpointError(res, e);
+    }
+  } finally {
+    // `finally`, not a tail decrement: every early `return` above is inside the try,
+    // and a leaked slot is permanent — the route would wedge at 503 until the pod
+    // restarts, which is a worse failure than the one the cap prevents.
+    inFlight -= 1;
   }
 }
 
@@ -109,8 +182,18 @@ export class PayloadTooLargeError extends Error {
  * to stop allocating, so a caller cannot spend our memory by streaming an
  * arbitrarily large body that we only measure at the end. `Content-Length` is not
  * trusted for this — it is caller-supplied and may be absent under chunked encoding.
+ *
+ * 🔴 The 413 is written HERE, before `req.destroy()`. Destroying the request tears
+ * down the socket, and a `res.status(413)` afterwards writes into a dead socket: it
+ * does not throw, it reports `headersSent`, and the client sees a transport-level
+ * connection error instead of the status. Ordering is the whole fix — the caller
+ * must learn the file was too large, not that the connection broke.
  */
-async function readCappedBody(req: NextApiRequest, limit: number): Promise<Buffer> {
+async function readCappedBody(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  limit: number
+): Promise<Buffer> {
   const chunks: Buffer[] = [];
   let total = 0;
 
@@ -118,7 +201,10 @@ async function readCappedBody(req: NextApiRequest, limit: number): Promise<Buffe
     const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     total += buf.length;
     if (total > limit) {
-      // Stop the client from continuing to send into a request we have abandoned.
+      if (!res.headersSent) {
+        res.status(413).json({ error: 'File too large for the upload fallback' });
+      }
+      // Only now stop the client from streaming into a request we have abandoned.
       req.destroy();
       throw new PayloadTooLargeError();
     }

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -242,39 +242,46 @@ export class PayloadTooLargeError extends Error {
  * arbitrarily large body that we only measure at the end. `Content-Length` is not
  * trusted for this — it is caller-supplied and may be absent under chunked encoding.
  *
- * 🔴 The 413 is written HERE, and then the remainder is DRAINED. Both halves are
- * required, and this is the third attempt at it — the first two were measured wrong.
+ * 🔴 The 413 is written HERE, and NOTHING is done to the socket afterwards. Both
+ * halves matter, and this is the fourth attempt — the first three were each measured
+ * wrong, so the arms are recorded rather than the conclusion.
  *
- * Attempt 1 wrote the status and then called `req.destroy()`. `IncomingMessage`'s
- * destroy tears down the SHARED socket, and `socket.destroy()` DISCARDS queued writes
- * rather than flushing them, so the client got ECONNRESET instead of the status.
+ * Attempt 1 wrote the status then called `req.destroy()`. That tears down the SHARED
+ * socket and discards queued writes rather than flushing them: ECONNRESET, no status.
  *
- * Attempt 2 removed the destroy and set `Connection: close` instead, reasoning that
- * the response would flush and the close would tell the client to stop. It does not:
- * `res.end()` on a `Connection: close` response sets `_last`, `resOnFinish` calls
- * `socket.destroySoon()`, and closing a socket that still has unread inbound data
- * RSTs — losing the status the same way, with a different errno.
+ * Attempt 2 removed the destroy and set `Connection: close`. Also loses it: `res.end()`
+ * on a close-delimited response sets `_last`, `resOnFinish` calls `socket.destroySoon()`,
+ * and closing a socket with unread inbound data RSTs. EPIPE, no status.
  *
- * Measured against a real HTTP client, 5 runs per arm, chunked and Content-Length:
+ * Attempt 3 kept `Connection: close` off AND added `req.resume()` to drain, believing
+ * the drain was what delivered the status. It is not, and the resume was INERT:
+ * `readCappedBody` drives the stream's async iterator, which keeps a `'readable'`
+ * listener registered, and `Readable.resume()` is a no-op while `readableListening` is
+ * true — it sets `flowing = false` and the stream stays paused.
  *
- *     req.destroy()                    -> ECONNRESET, no 413        5/5
- *     Connection: close, stop reading  -> EPIPE,      no 413        5/5
- *     Connection: close + resume       -> EPIPE,      no 413        3/3
- *     req.resume()                     -> 413 + JSON body           5/5
+ * Measured against a real HTTP client, Node 24.19.0, 5 runs per arm, 64MB body / 1MB
+ * limit — note the middle two rows are IDENTICAL, which is what settles it:
  *
- * So the drain is the ONLY arm that delivers the status, and `Connection: close` is
- * the ingredient that breaks it. An earlier version of this comment refused the drain
- * on cost grounds; that reasoning conflated two costs. Draining does NOT buffer —
- * `resume()` reads and discards, so memory stays flat, which is the cost the cap
- * exists to bound. What it does spend is time on the wire for bytes we are throwing
- * away, and the in-flight slot is held while we do it. That is the trade being made
- * knowingly: a bounded bandwidth cost on an already-rejected request, in exchange for
- * the caller learning WHY it was rejected.
+ *     req.destroy()                      -> ECONNRESET, no 413      5/5
+ *     Connection: close                  -> EPIPE,      no 413      5/5
+ *     neither (this code)                -> 413 + body              5/5, 3.7MB read
+ *     neither + req.resume()             -> 413 + body              5/5, 3.7MB read
+ *     neither + a REAL drain             -> 413 + body              5/5, 64MB read
  *
- * ⚠ Measured at the pod hop only. In production Traefik sits in front, and
- * `Connection` is hop-by-hop, so what a browser finally sees is NOT established here.
- * The unit test cannot see any of this either — it drives a `Readable.from` and an
- * object literal, which have no socket — so it pins the CALL, never the delivery.
+ * So: NOT closing the connection is the entire fix. The drain was removed because it
+ * bought nothing — and a real one (clearing the iterator's listener first) would pull
+ * the whole rejected body over the wire, which is a cost worth NOT paying for a request
+ * we have already refused. The client gets its status either way; the unread remainder
+ * simply back-pressures and the socket closes on the keep-alive path a few seconds later.
+ *
+ * ⚠ The in-flight slot is NOT held for any of this: the throw below returns through the
+ * `finally` that releases it, measured at ~2ms. A slow client cannot hold a slot by
+ * dribbling a rejected body.
+ *
+ * ⚠ Measured at the pod hop only. Traefik sits in front in production and `Connection`
+ * is hop-by-hop, so what a browser finally sees is NOT established here. The unit test
+ * cannot see delivery either — it drives a `Readable.from` and an object literal — so it
+ * pins the calls this measurement showed matter, and nothing more.
  */
 async function readCappedBody(
   req: NextApiRequest,
@@ -298,16 +305,13 @@ async function readCappedBody(
     total += buf.length;
     if (total > limit) {
       if (!res.headersSent) {
-        // NO `Connection: close` — measured, it is what destroys the socket before
-        // the status reaches the client. See the note above.
+        // NO `Connection: close`, and NO drain. Measured: the close is what destroys
+        // the socket before the status reaches the client, and the drain is inert here
+        // (and pointless if made real). See the note above.
         res.status(413).json({ error: 'File too large for the upload fallback' });
       }
-      // Release the buffered chunks BEFORE draining: the drain can take a while on a
-      // large body and there is no reason to hold what we already rejected.
+      // Drop what we buffered — we have rejected it and are about to unwind.
       chunks.length = 0;
-      // Drain and discard, so the response can be delivered rather than RST away.
-      // `resume()` does not buffer.
-      req.resume();
       throw new PayloadTooLargeError();
     }
     chunks.push(buf);

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -51,8 +51,11 @@ export const config = {
 
 // Bounds what this route will buffer in memory. NOT a general upload limit and NOT
 // "the largest media the app accepts" — `constants.mediaUpload.maxVideoFileSize` is
-// 750MB. It matches the ceiling the DROPZONE callers of `useCFImageUpload` enforce
-// client-side (`richTextEditor.maxFileSize`); the programmatic callers that upload
+// 750MB. It matches `constants.mediaUpload.maxImageFileSize`, which is what the
+// DROPZONE callers of `useCFImageUpload` enforce client-side (`ImageUpload.tsx`,
+// `SimpleImageUpload.tsx`) — THAT is the constant this must stay in sync with, not
+// `richTextEditor.maxFileSize`, which happens to hold the same value today but is
+// used by the rich-text editor rather than by any dropzone. The programmatic callers that upload
 // generated blobs enforce nothing, so this is their only bound. Exists because this
 // route buffers whole. A file above it cannot use the fallback; the direct path is
 // unaffected.
@@ -67,12 +70,19 @@ export const MAX_RELAY_BYTES = 1024 * 1024 * 50;
  * is not. Buffers are external, so `--max-old-space-size` does not bound them and
  * this constant is the only thing that does.
  *
- * 🔴 This is a MEMORY bound, not a throughput target, and it is deliberately BELOW
- * the batch sizes callers use — the image dropzone defaults to 10 files and uploads
- * them concurrently. Shedding a legitimate request is therefore EXPECTED, not
- * exceptional, which is why the shed must not be terminal: the client retries once,
- * honouring `Retry-After`. If you raise this, raise it for a measured memory reason;
- * do not raise it to stop clients seeing 429s.
+ * 🔴 This is a MEMORY bound, not a throughput target. ⚠ An earlier version of this
+ * comment claimed a dropzone batch of 10 against a cap of 8 routinely sheds two, and
+ * that shedding is therefore EXPECTED. That was wrong, and it inverted the action it
+ * prescribed: the cap is PER POD (see below), `/api/v1/*` is served by a pool whose
+ * replica floor is in the dozens, and there is no session affinity — so one browser's
+ * concurrent POSTs are spread across pods and would all have to land on the SAME pod
+ * to collide. A shed means ~8 concurrent relays hit one pod, which — for a fallback
+ * that only fires for clients who cannot resolve the storage host — is an ANOMALY
+ * worth investigating, not routine backpressure.
+ *
+ * The client still retries once on a shed, because a retry is cheap and a lost upload
+ * is not. But do not read a 429 as normal, and if you raise this constant, raise it
+ * for a measured memory reason rather than to make 429s go away.
  *
  * NOT env-configurable, which means it is not a runtime kill switch — changing it
  * needs a deploy. Left that way on purpose rather than adding an env var to the
@@ -126,6 +136,10 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
   // under the public `/api/v1/` namespace. `blocks/submit-version.ts` uses the same
   // expression but IS cookie-only (`ModEndpoint`), which is why its comment says no
   // bearer exemption is needed — that justification does NOT transfer here.
+  // 🔴 FULL PATH, because there are two: `src/pages/api/blocks/submit-version.ts` is
+  // the one meant. Its `/api/v1/` sibling is BEARER-only and deliberately OMITS the
+  // origin guard entirely (it would break the headless CLI, which sends no Origin) —
+  // i.e. the nearer-looking precedent argues the OPPOSITE of this paragraph.
   // `createContext.ts` does exempt bearer callers, deriving `isBearerAuth` from an
   // apiKeyId that only exists AFTER the session lookup.
   //
@@ -206,8 +220,9 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
     }
   } finally {
     // `finally`, not a tail decrement: every early `return` above is inside the try,
-    // and a leaked slot is permanent — the route would wedge at 503 until the pod
-    // restarts, which is a worse failure than the one the cap prevents.
+    // and a leaked slot is permanent — the route would wedge, shedding every request
+    // with 429 until the pod restarts, which is a worse failure than the one the cap
+    // prevents.
     inFlight -= 1;
   }
 }
@@ -227,21 +242,39 @@ export class PayloadTooLargeError extends Error {
  * arbitrarily large body that we only measure at the end. `Content-Length` is not
  * trusted for this — it is caller-supplied and may be absent under chunked encoding.
  *
- * 🔴 The 413 is written HERE, and the request is NOT destroyed.
+ * 🔴 The 413 is written HERE, and then the remainder is DRAINED. Both halves are
+ * required, and this is the third attempt at it — the first two were measured wrong.
  *
- * An earlier draft wrote the status and then called `req.destroy()`. Ordering was
- * necessary — a status written AFTER a destroy goes into a dead socket, does not
- * throw, reports `headersSent`, and the client sees a transport error instead of the
- * 413 — but it is not sufficient: `IncomingMessage.destroy()` tears down the SHARED
- * socket, and `socket.destroy()` DISCARDS queued writes rather than flushing them
- * (unlike `socket.end()`). On an idle socket a ~60-byte body usually lands inline, so
- * it looks fine; under backpressure the client still loses the status.
+ * Attempt 1 wrote the status and then called `req.destroy()`. `IncomingMessage`'s
+ * destroy tears down the SHARED socket, and `socket.destroy()` DISCARDS queued writes
+ * rather than flushing them, so the client got ECONNRESET instead of the status.
  *
- * Instead: set `Connection: close` and let the response flush, then simply stop
- * reading. Node closes the socket once the response is written, which is what tells
- * the client to stop sending — without racing the write we just made. We deliberately
- * do NOT drain the remainder with `req.resume()`: draining a body we rejected for
- * being too large is exactly the cost the cap exists to avoid.
+ * Attempt 2 removed the destroy and set `Connection: close` instead, reasoning that
+ * the response would flush and the close would tell the client to stop. It does not:
+ * `res.end()` on a `Connection: close` response sets `_last`, `resOnFinish` calls
+ * `socket.destroySoon()`, and closing a socket that still has unread inbound data
+ * RSTs — losing the status the same way, with a different errno.
+ *
+ * Measured against a real HTTP client, 5 runs per arm, chunked and Content-Length:
+ *
+ *     req.destroy()                    -> ECONNRESET, no 413        5/5
+ *     Connection: close, stop reading  -> EPIPE,      no 413        5/5
+ *     Connection: close + resume       -> EPIPE,      no 413        3/3
+ *     req.resume()                     -> 413 + JSON body           5/5
+ *
+ * So the drain is the ONLY arm that delivers the status, and `Connection: close` is
+ * the ingredient that breaks it. An earlier version of this comment refused the drain
+ * on cost grounds; that reasoning conflated two costs. Draining does NOT buffer —
+ * `resume()` reads and discards, so memory stays flat, which is the cost the cap
+ * exists to bound. What it does spend is time on the wire for bytes we are throwing
+ * away, and the in-flight slot is held while we do it. That is the trade being made
+ * knowingly: a bounded bandwidth cost on an already-rejected request, in exchange for
+ * the caller learning WHY it was rejected.
+ *
+ * ⚠ Measured at the pod hop only. In production Traefik sits in front, and
+ * `Connection` is hop-by-hop, so what a browser finally sees is NOT established here.
+ * The unit test cannot see any of this either — it drives a `Readable.from` and an
+ * object literal, which have no socket — so it pins the CALL, never the delivery.
  */
 async function readCappedBody(
   req: NextApiRequest,
@@ -253,11 +286,10 @@ async function readCappedBody(
 
   // 🔴 Iterated MANUALLY rather than with `for await`. Breaking out of a `for await`
   // invokes the iterator's `return()`, which DESTROYS the underlying stream — the
-  // exact socket teardown this function is trying to avoid, applied by the language
-  // rather than by us. Measured: with `for await`, a destroy still lands right after
-  // the 413 write. Driving `next()` by hand and simply not calling `return()` leaves
-  // the socket intact so the response can flush; `Connection: close` then closes it
-  // once the write is out.
+  // exact socket teardown that loses the status, applied by the language rather than
+  // by us. Measured: with `for await`, a destroy lands right after the 413 write.
+  // Driving `next()` by hand and never calling `return()` leaves the socket intact so
+  // the response can flush and the drain below can run.
   const iterator = req[Symbol.asyncIterator]();
   for (;;) {
     const { value, done } = await iterator.next();
@@ -266,9 +298,16 @@ async function readCappedBody(
     total += buf.length;
     if (total > limit) {
       if (!res.headersSent) {
-        res.setHeader('Connection', 'close');
+        // NO `Connection: close` — measured, it is what destroys the socket before
+        // the status reaches the client. See the note above.
         res.status(413).json({ error: 'File too large for the upload fallback' });
       }
+      // Release the buffered chunks BEFORE draining: the drain can take a while on a
+      // large body and there is no reason to hold what we already rejected.
+      chunks.length = 0;
+      // Drain and discard, so the response can be delivered rather than RST away.
+      // `resume()` does not buffer.
+      req.resume();
       throw new PayloadTooLargeError();
     }
     chunks.push(buf);

--- a/src/pages/api/v1/image-upload/relay.ts
+++ b/src/pages/api/v1/image-upload/relay.ts
@@ -51,19 +51,28 @@ export const config = {
 
 // Bounds what this route will buffer in memory. NOT a general upload limit and NOT
 // "the largest media the app accepts" — `constants.mediaUpload.maxVideoFileSize` is
-// far larger. It matches the ceiling every current caller of `useCFImageUpload`
-// already enforces client-side, and exists because this route buffers whole.
-// A file above it cannot use the fallback; the direct path is unaffected.
+// 750MB. It matches the ceiling the DROPZONE callers of `useCFImageUpload` enforce
+// client-side (`richTextEditor.maxFileSize`); the programmatic callers that upload
+// generated blobs enforce nothing, so this is their only bound. Exists because this
+// route buffers whole. A file above it cannot use the fallback; the direct path is
+// unaffected.
 export const MAX_RELAY_BYTES = 1024 * 1024 * 50;
 
 /**
  * Ceiling on relays held in memory at once, PER POD.
  *
- * At `MAX_RELAY_BYTES` and ~2x peak amplification this bounds the route at roughly
- * 400MB — survivable beside a steady-state heap on the pod's limit, where an
- * unbounded queue is not. Deliberately small: this is a fallback that only fires for
- * clients who cannot reach the storage host, so sustained high concurrency here is
- * itself the anomaly rather than the expected load.
+ * 8 x `MAX_RELAY_BYTES` is 400MB of body, and `Buffer.concat` roughly doubles that at
+ * peak (see `readCappedBody`), so the real bound this sets is **~800MB** — survivable
+ * beside a steady-state heap under the pod's memory limit, where an unbounded queue
+ * is not. Buffers are external, so `--max-old-space-size` does not bound them and
+ * this constant is the only thing that does.
+ *
+ * 🔴 This is a MEMORY bound, not a throughput target, and it is deliberately BELOW
+ * the batch sizes callers use — the image dropzone defaults to 10 files and uploads
+ * them concurrently. Shedding a legitimate request is therefore EXPECTED, not
+ * exceptional, which is why the shed must not be terminal: the client retries once,
+ * honouring `Retry-After`. If you raise this, raise it for a measured memory reason;
+ * do not raise it to stop clients seeing 429s.
  *
  * NOT env-configurable, which means it is not a runtime kill switch — changing it
  * needs a deploy. Left that way on purpose rather than adding an env var to the
@@ -71,12 +80,27 @@ export const MAX_RELAY_BYTES = 1024 * 1024 * 50;
  */
 export const MAX_CONCURRENT_RELAYS = 8;
 
+/** Seconds advertised in `Retry-After` when shedding, and honoured by the client. */
+export const RELAY_RETRY_AFTER_SECONDS = 2;
+
 /** In-flight relay count for this process. Module-scoped: per pod, not per cluster. */
 let inFlight = 0;
 
 /** Test seam — asserting the cap requires observing the counter. */
 export function __getInFlightForTest() {
   return inFlight;
+}
+
+/**
+ * Test seam — reset the counter between cases.
+ *
+ * Without this a case that leaves a slot held (a timeout, a mutant under test) makes
+ * the NEXT case fail for a reason that has nothing to do with it. Measured during
+ * round-2 mutation: a stuck shed test produced a false cascading failure in an
+ * unrelated case two tests later.
+ */
+export function __resetInFlightForTest() {
+  inFlight = 0;
 }
 
 export default async function imageUploadRelay(req: NextApiRequest, res: NextApiResponse) {
@@ -89,14 +113,29 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
     return;
   }
 
-  // CSRF guard. This raw route is cookie-authenticated and bypasses the tRPC
-  // pipeline, so it never gets createContext's same-origin check. It also accepts an
-  // arbitrary Content-Type, which makes a cross-site POST a CORS-*simple* request —
-  // no preflight — so without this any third-party page could make a logged-in
-  // visitor write attacker-chosen bytes into the media bucket. The direct presign
-  // route is not exposed this way (its presigned URL is unreadable cross-origin), so
-  // this is new surface rather than parity. Mirrors the posture and the !isProd
-  // exemption of `blocks/submit-version.ts`, which is the in-repo precedent.
+  // CSRF guard. This raw route bypasses the tRPC pipeline, so it never gets
+  // createContext's same-origin check. It also accepts an arbitrary Content-Type,
+  // which makes a cross-site POST a CORS-*simple* request — no preflight — so
+  // without this any third-party page could make a logged-in visitor write
+  // attacker-chosen bytes into the media bucket. The direct presign route is not
+  // exposed this way (its presigned URL is unreadable cross-origin), so this is new
+  // surface rather than parity.
+  //
+  // ⚠ NOT cookie-only, and the distinction matters. `getServerAuthSession` also
+  // accepts `Authorization: Bearer <api key>` and `?token=`, and this route lives
+  // under the public `/api/v1/` namespace. `blocks/submit-version.ts` uses the same
+  // expression but IS cookie-only (`ModEndpoint`), which is why its comment says no
+  // bearer exemption is needed — that justification does NOT transfer here.
+  // `createContext.ts` does exempt bearer callers, deriving `isBearerAuth` from an
+  // apiKeyId that only exists AFTER the session lookup.
+  //
+  // So this check is deliberately WIDER than either precedent: it 403s an API-key
+  // client with no Origin. Chosen on purpose — the relay exists to rescue BROWSERS
+  // whose DNS cannot resolve the storage host, and a non-browser client has neither
+  // that failure mode nor any reason to push bytes through us instead of straight at
+  // the store. It runs BEFORE the session lookup so an unauthenticated cross-origin
+  // probe costs nothing. Revisit both the placement and this paragraph together if a
+  // bearer client ever needs the fallback.
   if (isProd && !isAllowedOriginRequest(req)) {
     res.status(403).json({ error: 'Cross-origin request blocked' });
     return;
@@ -117,8 +156,14 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
   // on it down too. Shedding here is strictly better: the client keeps its original
   // error and the direct path is untouched.
   if (inFlight >= MAX_CONCURRENT_RELAYS) {
-    res.setHeader('Retry-After', '5');
-    res.status(503).json({ error: 'Upload fallback is busy' });
+    // 🔴 429, NOT 503. `instrumentApiResponse` counts every `status >= 500` into
+    // `civitai_app_http_errors_total`, so shedding with a 5xx makes deliberate,
+    // healthy load-shedding indistinguishable from a server fault in this route's
+    // own error attribution — the same reasoning that makes `handleEndpointError`
+    // map a client disconnect to 499. 429 is also the honest semantic: the request
+    // was fine, there was no capacity for it right now.
+    res.setHeader('Retry-After', String(RELAY_RETRY_AFTER_SECONDS));
+    res.status(429).json({ error: 'Upload fallback is busy' });
     return;
   }
 
@@ -129,8 +174,7 @@ export default async function imageUploadRelay(req: NextApiRequest, res: NextApi
       body = await readCappedBody(req, res, MAX_RELAY_BYTES);
     } catch (e) {
       if (e instanceof PayloadTooLargeError) {
-        // The 413 was already written by `readCappedBody`, before the socket was torn
-        // down — see the comment there for why the order matters.
+        // The 413 was already written by `readCappedBody` — see the note there.
         return;
       }
       res.status(400).json({ error: 'Failed to read upload body' });
@@ -183,11 +227,21 @@ export class PayloadTooLargeError extends Error {
  * arbitrarily large body that we only measure at the end. `Content-Length` is not
  * trusted for this — it is caller-supplied and may be absent under chunked encoding.
  *
- * 🔴 The 413 is written HERE, before `req.destroy()`. Destroying the request tears
- * down the socket, and a `res.status(413)` afterwards writes into a dead socket: it
- * does not throw, it reports `headersSent`, and the client sees a transport-level
- * connection error instead of the status. Ordering is the whole fix — the caller
- * must learn the file was too large, not that the connection broke.
+ * 🔴 The 413 is written HERE, and the request is NOT destroyed.
+ *
+ * An earlier draft wrote the status and then called `req.destroy()`. Ordering was
+ * necessary — a status written AFTER a destroy goes into a dead socket, does not
+ * throw, reports `headersSent`, and the client sees a transport error instead of the
+ * 413 — but it is not sufficient: `IncomingMessage.destroy()` tears down the SHARED
+ * socket, and `socket.destroy()` DISCARDS queued writes rather than flushing them
+ * (unlike `socket.end()`). On an idle socket a ~60-byte body usually lands inline, so
+ * it looks fine; under backpressure the client still loses the status.
+ *
+ * Instead: set `Connection: close` and let the response flush, then simply stop
+ * reading. Node closes the socket once the response is written, which is what tells
+ * the client to stop sending — without racing the write we just made. We deliberately
+ * do NOT drain the remainder with `req.resume()`: draining a body we rejected for
+ * being too large is exactly the cost the cap exists to avoid.
  */
 async function readCappedBody(
   req: NextApiRequest,
@@ -197,15 +251,24 @@ async function readCappedBody(
   const chunks: Buffer[] = [];
   let total = 0;
 
-  for await (const chunk of req) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+  // 🔴 Iterated MANUALLY rather than with `for await`. Breaking out of a `for await`
+  // invokes the iterator's `return()`, which DESTROYS the underlying stream — the
+  // exact socket teardown this function is trying to avoid, applied by the language
+  // rather than by us. Measured: with `for await`, a destroy still lands right after
+  // the 413 write. Driving `next()` by hand and simply not calling `return()` leaves
+  // the socket intact so the response can flush; `Connection: close` then closes it
+  // once the write is out.
+  const iterator = req[Symbol.asyncIterator]();
+  for (;;) {
+    const { value, done } = await iterator.next();
+    if (done) break;
+    const buf = Buffer.isBuffer(value) ? value : Buffer.from(value);
     total += buf.length;
     if (total > limit) {
       if (!res.headersSent) {
+        res.setHeader('Connection', 'close');
         res.status(413).json({ error: 'File too large for the upload fallback' });
       }
-      // Only now stop the client from streaming into a request we have abandoned.
-      req.destroy();
       throw new PayloadTooLargeError();
     }
     chunks.push(buf);

--- a/src/utils/__tests__/relay-with-retry.test.ts
+++ b/src/utils/__tests__/relay-with-retry.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { relayWithRetry } from '~/utils/upload-settlement';
+
+// AUDIT round-2 F1. The relay sheds with 429 once its per-pod memory cap is full, and
+// that cap sits deliberately BELOW the batch sizes callers use — the image dropzone
+// defaults to 10 files uploaded concurrently against a cap of 8. So a shed is an
+// expected outcome for exactly the population this fallback exists to rescue, and it
+// must not be terminal: the settlement rule reports the ORIGINAL upload error rather
+// than the relay's, so an unretried shed fails the file permanently while the server
+// was saying "try again shortly".
+//
+// `sleep` is injected so these run instantly and assert the DELAY VALUE rather than
+// waiting for it — the advertised `Retry-After` being honoured is the property, and a
+// test that merely waited could not tell 2s from the default.
+
+const headers = (retryAfter?: string) => ({
+  get: (n: string) => (n === 'Retry-After' && retryAfter !== undefined ? retryAfter : null),
+});
+const liveSignal = () => new AbortController().signal;
+
+describe('relayWithRetry', () => {
+  it('retries once on 429 and returns the second response', async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: headers('2') })
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: headers() });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const res = await relayWithRetry(post, {
+      signal: liveSignal(),
+      sleep,
+      defaultRetryAfterSeconds: 9,
+    });
+
+    expect(res.status).toBe(200);
+    expect(post).toHaveBeenCalledTimes(2);
+    // Honours the ADVERTISED delay (2s), not the injected default (9s). Those are
+    // deliberately different so the assertion cannot pass on the wrong one.
+    expect(sleep).toHaveBeenCalledWith(2000);
+  });
+
+  it('falls back to the default delay when Retry-After is absent or unusable', async () => {
+    for (const bad of [undefined, 'soon', '0', '-3']) {
+      const post = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 429, headers: headers(bad) })
+        .mockResolvedValueOnce({ ok: true, status: 200, headers: headers() });
+      const sleep = vi.fn().mockResolvedValue(undefined);
+
+      await relayWithRetry(post, { signal: liveSignal(), sleep, defaultRetryAfterSeconds: 7 });
+
+      expect(sleep, `Retry-After: ${String(bad)}`).toHaveBeenCalledWith(7000);
+    }
+  });
+
+  it('does NOT retry a non-429 failure — that is a real error, not backpressure', async () => {
+    const post = vi.fn().mockResolvedValue({ ok: false, status: 500, headers: headers() });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const res = await relayWithRetry(post, {
+      signal: liveSignal(),
+      sleep,
+      defaultRetryAfterSeconds: 2,
+    });
+
+    expect(res.status).toBe(500);
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('does not retry at all when the first attempt succeeds', async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: headers() });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await relayWithRetry(post, { signal: liveSignal(), sleep, defaultRetryAfterSeconds: 2 });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('aborts during the backoff instead of spending a second upload', async () => {
+    const controller = new AbortController();
+    const post = vi.fn().mockResolvedValue({ ok: false, status: 429, headers: headers('1') });
+    // Cancel while we are waiting out the backoff — the realistic timing.
+    const sleep = vi.fn().mockImplementation(async () => controller.abort());
+
+    await expect(
+      relayWithRetry(post, { signal: controller.signal, sleep, defaultRetryAfterSeconds: 2 })
+    ).rejects.toThrow('aborted');
+
+    // The point of the check: a cancelled upload must not push the bytes anyway.
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/__tests__/relay-with-retry.test.ts
+++ b/src/utils/__tests__/relay-with-retry.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
-import { relayWithRetry } from '~/utils/upload-settlement';
+import { relayWithRetry, MAX_RETRY_AFTER_SECONDS } from '~/utils/upload-settlement';
 
 // AUDIT round-2 F1. The relay sheds with 429 once its per-pod memory cap is full, and
-// that cap sits deliberately BELOW the batch sizes callers use — the image dropzone
-// defaults to 10 files uploaded concurrently against a cap of 8. So a shed is an
-// expected outcome for exactly the population this fallback exists to rescue, and it
-// must not be terminal: the settlement rule reports the ORIGINAL upload error rather
-// than the relay's, so an unretried shed fails the file permanently while the server
-// was saying "try again shortly".
+// an unretried shed is TERMINAL: the settlement rule reports the ORIGINAL upload error
+// rather than the relay's, so the file fails permanently while the server was saying
+// "try again shortly".
+//
+// ⚠ An earlier version of this comment justified the retry by claiming a dropzone batch
+// of 10 against a cap of 8 routinely sheds two. A round-3 audit refuted that: the cap is
+// per POD, the serving pool's replica floor is in the dozens, and there is no session
+// affinity, so one browser's concurrent POSTs spread across pods rather than colliding.
+// A shed is an ANOMALY. The retry is still worth having — it is cheap and a lost upload
+// is not — but its justification is "cheap insurance", not "this happens constantly".
 //
 // `sleep` is injected so these run instantly and assert the DELAY VALUE rather than
 // waiting for it — the advertised `Retry-After` being honoured is the property, and a
@@ -89,6 +93,75 @@ describe('relayWithRetry', () => {
     ).rejects.toThrow('aborted');
 
     // The point of the check: a cancelled upload must not push the bytes anyway.
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  // AUDIT round-3 F3. `Retry-After` is remote input, and this retry fires on ANY 429 —
+  // including one from a CDN or edge rate-limiter in front of us, which can legitimately
+  // say "an hour". Unclamped, the hook would hold the user's File that long with the
+  // tracked file stuck at `uploading`.
+  it('clamps an absurd Retry-After to MAX_RETRY_AFTER_SECONDS', async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: headers('3600') })
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: headers() });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await relayWithRetry(post, {
+      signal: liveSignal(),
+      sleep,
+      defaultRetryAfterSeconds: 2,
+    });
+
+    expect(sleep).toHaveBeenCalledWith(MAX_RETRY_AFTER_SECONDS * 1000);
+    // Not the advertised hour, and not the 2s default either — the clamp specifically.
+    expect(sleep).not.toHaveBeenCalledWith(3600 * 1000);
+    expect(sleep).not.toHaveBeenCalledWith(2000);
+  });
+
+  it('still honours a Retry-After that is under the clamp', async () => {
+    // Guards the clamp from becoming a flat override — `Math.min`, not a constant.
+    const under = MAX_RETRY_AFTER_SECONDS - 1;
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, headers: headers(String(under)) })
+      .mockResolvedValueOnce({ ok: true, status: 200, headers: headers() });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await relayWithRetry(post, { signal: liveSignal(), sleep, defaultRetryAfterSeconds: 2 });
+
+    expect(sleep).toHaveBeenCalledWith(under * 1000);
+  });
+
+  // AUDIT round-3 F3, second half. The abort check used to run only AFTER the sleep
+  // resolved, so a cancel during a long backoff was invisible until the timer expired —
+  // the cancel button was inert for the whole wait. The wait now races the signal.
+  it('rejects as soon as the signal aborts, without waiting out the backoff', async () => {
+    const controller = new AbortController();
+    const post = vi.fn().mockResolvedValue({ ok: false, status: 429, headers: headers('10') });
+    // A sleep that never resolves: only the abort race can settle this.
+    const sleep = vi.fn().mockImplementation(() => new Promise<void>(() => undefined));
+
+    const pending = relayWithRetry(post, {
+      signal: controller.signal,
+      sleep,
+      defaultRetryAfterSeconds: 2,
+    });
+    controller.abort();
+
+    await expect(pending).rejects.toThrow('aborted');
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects immediately when the signal is ALREADY aborted at backoff time', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const post = vi.fn().mockResolvedValue({ ok: false, status: 429, headers: headers('10') });
+    const sleep = vi.fn().mockImplementation(() => new Promise<void>(() => undefined));
+
+    await expect(
+      relayWithRetry(post, { signal: controller.signal, sleep, defaultRetryAfterSeconds: 2 })
+    ).rejects.toThrow('aborted');
     expect(post).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/__tests__/upload-settlement.test.ts
+++ b/src/utils/__tests__/upload-settlement.test.ts
@@ -163,7 +163,12 @@ describe('attachUploadSettlement', () => {
     expect(relay).not.toHaveBeenCalled();
   });
 
-  it('settles exactly once even if terminal events fire more than once', async () => {
+  // Renamed after a round-2 audit: this used to be called "settles exactly once" and
+  // was attributed to a `settled` latch, which was measured INERT and has been
+  // removed. What actually protects this is `relayPending` — a later `loadend` yields
+  // to the relay that already settled. Naming the real mechanism so the next reader
+  // does not go looking for a latch that is not there.
+  it('ignores a later loadend once a relay has already settled', async () => {
     const xhr = new StubXhr();
     const cb = callbacks();
     const relay = vi.fn(() => Promise.resolve('RELAYED-ID'));

--- a/src/utils/__tests__/upload-settlement.test.ts
+++ b/src/utils/__tests__/upload-settlement.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { attachUploadSettlement } from '~/utils/upload-settlement';
+import type { SettlementXhr } from '~/utils/upload-settlement';
+
+// AUDIT-F1 regression guard — the defect the first draft of the upload relay shipped,
+// and the one nothing in the tree could see.
+//
+// Per the XHR spec, an `error` at the XHR object is followed by `loadend` at the XHR
+// object IN THE SAME DISPATCH. The first draft moved the `error` handler's
+// synchronous `reject(...)` into a promise chain but left `loadend` settling
+// unconditionally, so `loadend` won the race, computed `success = false`, and
+// resolved BEFORE the relay's fetch could finish. Two consequences, the second worse
+// than the bug the relay exists to fix:
+//
+//   1. the caller received the PRESIGN id — a key holding no bytes, because the PUT
+//      that would have written them is the thing that just failed;
+//   2. the pre-existing throw on a failed upload disappeared, turning a visible
+//      upload failure into a silent success carrying a bad id.
+//
+// These drive the REAL exported function that `useCFImageUpload` calls — not a model
+// of it. An earlier draft of this test re-implemented the rule inline, which would
+// have stayed green against a broken hook; the logic was extracted into
+// `attachUploadSettlement` specifically so the guard could bind to production code.
+//
+// Red against the pre-fix rule: delete the `if (relayPending) return;` line in
+// `attachUploadSettlement` and the first two cases fail.
+
+/** Minimal XHR stub that dispatches terminal events in the spec's order. */
+class StubXhr implements SettlementXhr {
+  readyState = 0;
+  status = 0;
+  private handlers: Record<string, Array<() => void>> = {};
+
+  addEventListener(type: string, fn: EventListenerOrEventListenerObject) {
+    (this.handlers[type] ??= []).push(fn as () => void);
+  }
+
+  private fire(type: string) {
+    for (const fn of this.handlers[type] ?? []) fn();
+  }
+
+  /** A network-layer failure: `error` then `loadend`, same dispatch. */
+  networkFailure() {
+    this.readyState = 4;
+    this.status = 0;
+    this.fire('error');
+    this.fire('loadend');
+  }
+
+  /** A response that reached the backend and was rejected by it. */
+  finishedWithStatus(status: number) {
+    this.readyState = 4;
+    this.status = status;
+    this.fire('loadend');
+  }
+
+  userAbort() {
+    this.fire('abort');
+  }
+}
+
+function callbacks() {
+  return {
+    onRelayed: vi.fn(),
+    onSuccess: vi.fn(),
+    onError: vi.fn(),
+    onAborted: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('attachUploadSettlement', () => {
+  it('resolves with the RELAYED id, not the presign id, when the direct PUT fails', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    // A relay is a network call: it can never complete inside the dispatch that
+    // `loadend` runs in, which is exactly what made the original bug reachable.
+    const relay = vi.fn(() => new Promise<string>((r) => setTimeout(() => r('RELAYED-ID'), 5)));
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.networkFailure();
+
+    await expect(settled).resolves.toEqual({ kind: 'relayed', id: 'RELAYED-ID' });
+    expect(cb.onRelayed).toHaveBeenCalledWith('RELAYED-ID');
+    expect(cb.onSuccess).toHaveBeenCalledTimes(1);
+    expect(cb.onError).not.toHaveBeenCalled();
+  });
+
+  it('does not settle from loadend while a relay is in flight', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    let release: (id: string) => void = () => undefined;
+    const relay = vi.fn(() => new Promise<string>((r) => (release = r)));
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.networkFailure();
+
+    // Both terminal events have fired. Nothing may have settled yet.
+    const raced = await Promise.race([
+      settled.then(() => 'settled' as const),
+      new Promise<'pending'>((r) => setTimeout(() => r('pending'), 20)),
+    ]);
+    expect(raced).toBe('pending');
+
+    release('RELAYED-ID');
+    await expect(settled).resolves.toEqual({ kind: 'relayed', id: 'RELAYED-ID' });
+  });
+
+  it('reports the ORIGINAL failure — not the relay error — when the relay also fails', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn().mockRejectedValue(new Error('Upload fallback failed (status 500)'));
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.networkFailure();
+
+    // The failure signal the pre-fix draft silently deleted.
+    await expect(settled).rejects.toThrow('Upload failed (status 0)');
+    expect(cb.onError).toHaveBeenCalledTimes(1);
+    expect(cb.onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('treats a cancel DURING the relay as a cancel, not an upload failure', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi
+      .fn()
+      .mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'));
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.networkFailure();
+
+    await expect(settled).rejects.toThrow('Upload canceled');
+    expect(cb.onAborted).toHaveBeenCalledTimes(1);
+    expect(cb.onError).not.toHaveBeenCalled();
+  });
+
+  it('does NOT relay a non-2xx response — that means the backend rejected us', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn();
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.finishedWithStatus(403);
+
+    await expect(settled).resolves.toEqual({ kind: 'direct', success: false });
+    expect(relay).not.toHaveBeenCalled();
+  });
+
+  it('settles the ordinary success path unchanged', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn();
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.finishedWithStatus(200);
+
+    await expect(settled).resolves.toEqual({ kind: 'direct', success: true });
+    expect(cb.onSuccess).toHaveBeenCalledTimes(1);
+    expect(relay).not.toHaveBeenCalled();
+  });
+
+  it('settles exactly once even if terminal events fire more than once', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn(() => Promise.resolve('RELAYED-ID'));
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.networkFailure();
+    await settled;
+    // A second dispatch must not re-settle or re-report.
+    xhr.finishedWithStatus(200);
+
+    await expect(settled).resolves.toEqual({ kind: 'relayed', id: 'RELAYED-ID' });
+    expect(cb.onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects on a user abort of the direct upload', async () => {
+    const xhr = new StubXhr();
+    const cb = callbacks();
+    const relay = vi.fn();
+
+    const settled = attachUploadSettlement(xhr, relay, cb);
+    xhr.userAbort();
+
+    await expect(settled).rejects.toThrow('Upload canceled');
+    expect(cb.onAborted).toHaveBeenCalledTimes(1);
+    expect(relay).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/upload-settlement.ts
+++ b/src/utils/upload-settlement.ts
@@ -1,0 +1,96 @@
+/**
+ * Settlement rule for a browser-direct upload that may fall back to a server relay.
+ *
+ * Extracted from `useCFImageUpload` so it can be tested for real. The defect this
+ * exists to prevent is an ORDERING one, and ordering is not visible to any test that
+ * re-implements the rule: per the XHR spec an `error` at the XHR object is followed
+ * by `loadend` at the XHR object IN THE SAME DISPATCH, so a `loadend` handler that
+ * settles unconditionally wins the race against an in-flight relay and resolves with
+ * the presign id — a key holding no bytes — while also deleting the failure signal
+ * the caller used to receive.
+ *
+ * The hook owns React state; this owns "who settles, and with what".
+ */
+
+/** The surface of XMLHttpRequest this rule touches — so a test can supply a stub. */
+export type SettlementXhr = Pick<XMLHttpRequest, 'addEventListener' | 'readyState' | 'status'>;
+
+export type SettlementOutcome =
+  | { kind: 'direct'; success: boolean }
+  | { kind: 'relayed'; id: string };
+
+export type SettlementCallbacks = {
+  /** Called when the relay produced the key that actually holds the bytes. */
+  onRelayed: (id: string) => void;
+  onSuccess: () => void;
+  onError: () => void;
+  onAborted: () => void;
+};
+
+/**
+ * Wire the terminal XHR events and return a promise that settles exactly once.
+ *
+ * Resolves with the outcome, or rejects with the error the caller should surface.
+ * `relay` is invoked only on a network-layer `error` — never on a non-2xx
+ * `loadend`, which means we reached the backend and it rejected us; replaying those
+ * bytes through a second route would mask a real fault rather than route around an
+ * unreachable host.
+ */
+export function attachUploadSettlement(
+  xhr: SettlementXhr,
+  relay: () => Promise<string>,
+  callbacks: SettlementCallbacks
+): Promise<SettlementOutcome> {
+  return new Promise<SettlementOutcome>((resolve, reject) => {
+    // Set SYNCHRONOUSLY inside the `error` handler, so the `loadend` that follows in
+    // the same dispatch observes it and yields. This flag is the entire fix.
+    let relayPending = false;
+    let settled = false;
+
+    const settleResolve = (outcome: SettlementOutcome) => {
+      if (settled) return;
+      settled = true;
+      resolve(outcome);
+    };
+    const settleReject = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    xhr.addEventListener('loadend', () => {
+      // A relay is in flight and owns settlement.
+      if (relayPending) return;
+      const success = xhr.readyState === 4 && xhr.status === 200;
+      if (success) callbacks.onSuccess();
+      settleResolve({ kind: 'direct', success });
+    });
+
+    xhr.addEventListener('error', () => {
+      relayPending = true;
+      relay()
+        .then((relayedId) => {
+          callbacks.onRelayed(relayedId);
+          callbacks.onSuccess();
+          settleResolve({ kind: 'relayed', id: relayedId });
+        })
+        .catch((relayError: unknown) => {
+          // A cancel during the fallback is a cancel, not an upload failure.
+          if (relayError instanceof DOMException && relayError.name === 'AbortError') {
+            callbacks.onAborted();
+            settleReject(new Error('Upload canceled'));
+            return;
+          }
+          // Otherwise report the ORIGINAL failure. The fallback is a recovery
+          // attempt; surfacing its error instead would rename the user's problem.
+          callbacks.onError();
+          settleReject(new Error(`Upload failed (status ${xhr.status})`));
+        });
+    });
+
+    xhr.addEventListener('abort', () => {
+      callbacks.onAborted();
+      settleReject(new Error('Upload canceled'));
+    });
+  });
+}

--- a/src/utils/upload-settlement.ts
+++ b/src/utils/upload-settlement.ts
@@ -44,26 +44,20 @@ export function attachUploadSettlement(
   return new Promise<SettlementOutcome>((resolve, reject) => {
     // Set SYNCHRONOUSLY inside the `error` handler, so the `loadend` that follows in
     // the same dispatch observes it and yields. This flag is the entire fix.
+    //
+    // ⚠ There is deliberately NO second `settled` latch here. An earlier draft had
+    // one; a round-2 audit measured it INERT — `resolve`/`reject` are already
+    // idempotent, and the callbacks are gated by `relayPending`, so deleting the
+    // latch left every test green. A guard that cannot fail is worse than none: it
+    // reads as protection and stops the next person looking for the real one.
     let relayPending = false;
-    let settled = false;
-
-    const settleResolve = (outcome: SettlementOutcome) => {
-      if (settled) return;
-      settled = true;
-      resolve(outcome);
-    };
-    const settleReject = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
-    };
 
     xhr.addEventListener('loadend', () => {
       // A relay is in flight and owns settlement.
       if (relayPending) return;
       const success = xhr.readyState === 4 && xhr.status === 200;
       if (success) callbacks.onSuccess();
-      settleResolve({ kind: 'direct', success });
+      resolve({ kind: 'direct', success });
     });
 
     xhr.addEventListener('error', () => {
@@ -72,25 +66,66 @@ export function attachUploadSettlement(
         .then((relayedId) => {
           callbacks.onRelayed(relayedId);
           callbacks.onSuccess();
-          settleResolve({ kind: 'relayed', id: relayedId });
+          resolve({ kind: 'relayed', id: relayedId });
         })
         .catch((relayError: unknown) => {
           // A cancel during the fallback is a cancel, not an upload failure.
           if (relayError instanceof DOMException && relayError.name === 'AbortError') {
             callbacks.onAborted();
-            settleReject(new Error('Upload canceled'));
+            reject(new Error('Upload canceled'));
             return;
           }
           // Otherwise report the ORIGINAL failure. The fallback is a recovery
           // attempt; surfacing its error instead would rename the user's problem.
           callbacks.onError();
-          settleReject(new Error(`Upload failed (status ${xhr.status})`));
+          reject(new Error(`Upload failed (status ${xhr.status})`));
         });
     });
 
     xhr.addEventListener('abort', () => {
       callbacks.onAborted();
-      settleReject(new Error('Upload canceled'));
+      reject(new Error('Upload canceled'));
     });
   });
+}
+
+/**
+ * POST to the relay, retrying ONCE if it sheds with 429.
+ *
+ * The relay's memory cap sits deliberately below the batch sizes callers use, so a
+ * 429 is an expected outcome for the very users this fallback exists for — a dropzone
+ * batch of 10 against a cap of 8 sheds two. Without a retry the shed is terminal,
+ * because the settlement rule reports the ORIGINAL upload error rather than the
+ * relay's, so those files would fail permanently while the server was saying "try
+ * again shortly".
+ *
+ * Retries ONCE and only on 429. Any other non-ok status is a real failure and is
+ * surfaced; retrying it would just double the load that produced it.
+ */
+/** The bits of a response this helper reads. Generic so callers keep `Response`. */
+type RetryableResponse = {
+  ok: boolean;
+  status: number;
+  headers: { get(name: string): string | null };
+};
+
+export async function relayWithRetry<T extends RetryableResponse>(
+  post: () => Promise<T>,
+  opts: {
+    signal: AbortSignal;
+    sleep: (ms: number) => Promise<void>;
+    defaultRetryAfterSeconds: number;
+  }
+): Promise<T> {
+  let response = await post();
+  if (response.status === 429) {
+    const advertised = Number(response.headers.get('Retry-After'));
+    const seconds =
+      Number.isFinite(advertised) && advertised > 0 ? advertised : opts.defaultRetryAfterSeconds;
+    await opts.sleep(seconds * 1000);
+    // A cancel during the backoff must not be spent on a second upload.
+    if (opts.signal.aborted) throw new DOMException('The operation was aborted.', 'AbortError');
+    response = await post();
+  }
+  return response;
 }

--- a/src/utils/upload-settlement.ts
+++ b/src/utils/upload-settlement.ts
@@ -89,19 +89,6 @@ export function attachUploadSettlement(
   });
 }
 
-/**
- * POST to the relay, retrying ONCE if it sheds with 429.
- *
- * The relay's memory cap sits deliberately below the batch sizes callers use, so a
- * 429 is an expected outcome for the very users this fallback exists for — a dropzone
- * batch of 10 against a cap of 8 sheds two. Without a retry the shed is terminal,
- * because the settlement rule reports the ORIGINAL upload error rather than the
- * relay's, so those files would fail permanently while the server was saying "try
- * again shortly".
- *
- * Retries ONCE and only on 429. Any other non-ok status is a real failure and is
- * surfaced; retrying it would just double the load that produced it.
- */
 /** The bits of a response this helper reads. Generic so callers keep `Response`. */
 type RetryableResponse = {
   ok: boolean;
@@ -109,6 +96,33 @@ type RetryableResponse = {
   headers: { get(name: string): string | null };
 };
 
+/** Upper bound on an honoured `Retry-After`. A fallback upload is interactive. */
+export const MAX_RETRY_AFTER_SECONDS = 10;
+
+/**
+ * POST to the relay, retrying ONCE if it sheds with 429.
+ *
+ * Without a retry a shed is TERMINAL: the settlement rule deliberately reports the
+ * ORIGINAL upload error rather than the relay's, so a shed file would fail
+ * permanently while the server was saying "try again shortly".
+ *
+ * ⚠ An earlier version of this comment justified the retry by claiming a dropzone
+ * batch of 10 against a per-pod cap of 8 routinely sheds two. That was wrong — the
+ * cap is per POD, the pool's replica floor is in the dozens, and there is no session
+ * affinity, so one browser's concurrent POSTs spread across pods. A shed is an
+ * ANOMALY, not routine. The retry is still worth having (it is cheap, and a lost
+ * upload is not), but do not read a 429 here as business as usual.
+ *
+ * Retries ONCE and only on 429. Any other non-ok status is a real failure and is
+ * surfaced; retrying it would just double the load that produced it.
+ *
+ * 🔴 The delay is CLAMPED, and the wait is CANCELLABLE. `Retry-After` is remote input
+ * and this retry fires on ANY 429, not only our own relay's shed — a CDN or an edge
+ * rate-limiter in front of us can answer 429 with a `Retry-After` of an hour. Without
+ * the clamp the hook would sit on the user's `File` for that hour with the tracked
+ * file stuck at `uploading`; without the abort race the cancel button would be inert
+ * for the whole wait, because the abort check only runs AFTER the sleep resolves.
+ */
 export async function relayWithRetry<T extends RetryableResponse>(
   post: () => Promise<T>,
   opts: {
@@ -120,12 +134,27 @@ export async function relayWithRetry<T extends RetryableResponse>(
   let response = await post();
   if (response.status === 429) {
     const advertised = Number(response.headers.get('Retry-After'));
-    const seconds =
+    const requested =
       Number.isFinite(advertised) && advertised > 0 ? advertised : opts.defaultRetryAfterSeconds;
-    await opts.sleep(seconds * 1000);
-    // A cancel during the backoff must not be spent on a second upload.
-    if (opts.signal.aborted) throw new DOMException('The operation was aborted.', 'AbortError');
+    const seconds = Math.min(requested, MAX_RETRY_AFTER_SECONDS);
+
+    // Race the wait against cancellation, so an abort mid-backoff is observed when it
+    // happens rather than whenever the timer would have expired.
+    await Promise.race([
+      opts.sleep(seconds * 1000),
+      new Promise<void>((_, rejectWait) => {
+        if (opts.signal.aborted) return rejectWait(abortError());
+        opts.signal.addEventListener('abort', () => rejectWait(abortError()), { once: true });
+      }),
+    ]);
+
+    // Also covers a sleep that resolved normally on an already-aborted signal.
+    if (opts.signal.aborted) throw abortError();
     response = await post();
   }
   return response;
+}
+
+function abortError() {
+  return new DOMException('The operation was aborted.', 'AbortError');
 }


### PR DESCRIPTION
> **Draft.** Two adversarial audit rounds have run; round 2 was not clean, so a round 3 is in flight. Round-by-round findings are in the comments — including a correction of this description's original claims, which were wrong.

## The problem

Image uploads are browser-direct: `/api/v1/image-upload` mints a key and returns a presigned PUT URL, and the browser PUTs straight at the storage endpoint. That endpoint is a **raw storage hostname, not a civitai.com one**.

So a user whose DNS cannot resolve it gets `ERR_NAME_NOT_RESOLVED` on the PUT while everything else on the page works — the presign call itself succeeds, because that one goes to us. It presents as *"uploads are broken for me specifically"*, and **six reported tickets share this signature**.

## The fix

A fallback the client reaches for **only after the direct PUT has already failed at the network layer**: POST the bytes to `/api/v1/image-upload/relay` — an origin the browser has demonstrably resolved, since it just fetched the presign from it — and do the store write server-side through the existing `uploadImageBufferToStore`.

Same bucket, same backend, same media-location registration, so the resulting object is servable exactly as a direct upload would be. **No new storage backend, no config change, no DNS or infrastructure change.**

## Decisions worth reviewing

**The key is minted server-side; no caller-supplied key is honoured.** An earlier draft echoed the presign's `id` back so both paths would agree — but that id travels through the browser, so honouring it lets a caller name any uuid and **overwrite another user's object**.

**Shedding is survivable, and rare.** `MAX_CONCURRENT_RELAYS = 8` is a memory bound (~800MB peak, since the route buffers whole and `Buffer.concat` roughly doubles it). ⚠️ An earlier version of this description said a shed is *routine* because the dropzone uploads 10 concurrent files against a cap of 8. **That was wrong** and it inverted the action it implied: the cap is per **pod**, the serving pool's replica floor is in the dozens, and there is no session affinity, so one browser's concurrent POSTs spread across pods rather than colliding. A shed means ~8 concurrent relays hit one pod — for a fallback that only fires for DNS-broken clients, an **anomaly worth investigating**, not business as usual. The client still retries once honouring `Retry-After` (cheap insurance, not a routine necessity), and it sheds with **429**, not 503, so deliberate backpressure is not counted as a server fault in the route's own 5xx attribution.

**The origin check is wider than either in-repo precedent.** It 403s an API-key client with no `Origin`. Deliberate: the relay exists to rescue *browsers* whose DNS cannot resolve the storage host, and a non-browser client has neither that failure mode nor a reason to push bytes through us. Note this route is **not** cookie-only — `getServerAuthSession` accepts Bearer and `?token=` — so `submit-version.ts`'s "no bearer exemption needed" reasoning does not transfer.

**Not the default path.** Every relayed byte transits the app servers. There is a comment saying so at the route.

## Known gaps, not fixed here

- **The presign leaves a stranded registry row** when the fallback fires — a key registered with `sizeBytes: 0` that no object was written to. ⚠️ An earlier version of this description claimed existing orphan reconciliation sweeps it. **That was wrong**: the reconcilers list bucket *objects* and diff them against the registry, so a row with no object is not in their universe. Documented at the route as an unswept cost. One row per fallback. A size-keyed sweep would be unsafe, because the direct path also registers `sizeBytes: 0` for every *successful* upload.
- **No metric and no runtime kill switch.** The cap is a module constant, so changing it needs a deploy.
- **The multipart path is untouched** and has no fallback.

## Tests

`relay.test.ts` (15), `upload-settlement.test.ts` (8), `relay-with-retry.test.ts` (5) — **28 cases**. Cases marked `AUDIT-*` pin defects an audit found and are red against the draft that had them.

**Eight mutants, each killed by its own tests and no others** — the point being that each guard is reachable and fails for its own reason, not that "a test failed":

| mutant | result |
|---|---|
| measure-at-end cap | 1 failed / 22 passed |
| re-added `req.destroy()` | 1 / 22 |
| shed with 503 | 1 / 22 |
| `relayPending` yield removed | 5 / 18 |
| never retry on 429 | 3 / 25 |
| retry on any status | 1 / 27 |
| ignore `Retry-After` | 1 / 27 |
| skip abort-during-backoff | 1 / 27 |

Full unit tier **1569 files / 24873 tests, 0 failures**. Cold typecheck (`tsconfig.tsbuildinfo` deleted) **0 errors** — it caught a real one first. Prettier + ESLint clean on all changed files.

## 🔴 Explicitly NOT verified

- **No end-to-end upload against a real backend.** The store call is mocked. The ticket's closing condition asks for a preview-environment upload; that has not been done.
- **The browser tier was NOT run** — the flake's pinned Playwright driver build does not match the installed browser package on this host. Not run is not a claim that it passes, and those are the tests that would exercise the changed hook in a real DOM.
- **The DNS failure itself was not reproduced.** The six referenced tickets are taken at face value.
- **The memory arithmetic behind the cap is reasoned from manifests, not load-tested.**
- **The 413-under-backpressure mechanism is reasoned from Node socket semantics**, not reproduced against a real socket.
- **What share of affected uploads are large or multipart is unmeasured**, so how much of the reported problem the 50MB cap actually covers is unknown.

