### PR TITLE
feat(civitai-link): the wizard waits for the desktop app to sign in instead of handing out a code

### DIFF
--- a/src/components/CivitaiLink/CivitaiLinkPopover.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkPopover.tsx
@@ -45,7 +45,7 @@ import {
   IconPlayerPlay,
   IconRefresh,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useLayoutEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import {
@@ -483,7 +483,9 @@ function GetReconnected() {
     useCivitaiLink();
   const oauthPaired = !!instances?.find((x) => x.id === instance?.id)?.oauthPaired;
 
-  useEffect(() => {
+  // Layout, not passive: the cancel this same cleanup fires broadcasts a
+  // terminal status back, so a passive arm renders one frame of it on reopen.
+  useLayoutEffect(() => {
     if (!oauthPaired) return;
     awaitPairing();
     return () => {

--- a/src/components/CivitaiLink/CivitaiLinkPopover.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkPopover.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Tooltip,
   List,
+  Loader,
   Menu,
   TextInput,
 } from '@mantine/core';
@@ -44,7 +45,7 @@ import {
   IconPlayerPlay,
   IconRefresh,
 } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import {
@@ -478,7 +479,18 @@ function GetStarted({ onClose }: { onClose: () => void }) {
 }
 
 function GetReconnected() {
-  const { instance, createInstance } = useCivitaiLink();
+  const { instance, instances, createInstance, awaitPairing, cancelAwaitPairing, pairingStatus } =
+    useCivitaiLink();
+  const oauthPaired = !!instances?.find((x) => x.id === instance?.id)?.oauthPaired;
+
+  useEffect(() => {
+    if (!oauthPaired) return;
+    awaitPairing();
+    return () => {
+      cancelAwaitPairing();
+    };
+  }, [oauthPaired]); // eslint-disable-line
+
   const handleGenerateKey = () => createInstance(instance?.id ?? undefined);
 
   return (
@@ -496,45 +508,72 @@ function GetReconnected() {
           {`${instance?.name ?? 'This app'} hasn't checked in. Sending is paused until it's back.`}
         </Text>
       </Group>
-      {instance?.key && (
-        <Stack align="center" gap={6} px="xs" pt="sm">
-          <Text fz={11} c="dimmed">
-            Pair with this code
+      {oauthPaired ? (
+        <Stack px="xs" py="sm" gap={8}>
+          <Text size="sm" fw={500}>
+            Open Civitai Link and sign in again
           </Text>
-          <CopyButton value={instance.key}>
-            {({ copied, copy }) => (
-              <Tooltip label="Copy" withinPortal>
-                <Button
-                  variant="default"
-                  onClick={copy}
-                  px="sm"
-                  rightSection={copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
-                >
-                  {!copied ? instance.key : 'Copied'}
-                </Button>
-              </Tooltip>
-            )}
-          </CopyButton>
+          <List type="unordered" size="xs" spacing={6} c="dimmed">
+            <List.Item>Open the Civitai Link app on that machine.</List.Item>
+            <List.Item>
+              Click <b>Sign in with Civitai</b> and approve it in your browser.
+            </List.Item>
+          </List>
+          <Group gap={8} pt={2}>
+            {pairingStatus !== 'timeout' && <Loader size="xs" />}
+            <Text fz="xs" c="dimmed">
+              {pairingStatus === 'timeout'
+                ? 'Still waiting? Make sure the app is running.'
+                : 'Waiting for the app…'}
+            </Text>
+          </Group>
         </Stack>
+      ) : (
+        <>
+          {instance?.key && (
+            <Stack align="center" gap={6} px="xs" pt="sm">
+              <Text fz={11} c="dimmed">
+                Pair with this code
+              </Text>
+              <CopyButton value={instance.key}>
+                {({ copied, copy }) => (
+                  <Tooltip label="Copy" withinPortal>
+                    <Button
+                      variant="default"
+                      onClick={copy}
+                      px="sm"
+                      rightSection={copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+                    >
+                      {!copied ? instance.key : 'Copied'}
+                    </Button>
+                  </Tooltip>
+                )}
+              </CopyButton>
+            </Stack>
+          )}
+          <Stack px="xs" py="sm" gap={6}>
+            <Text size="sm" fw={500}>
+              Try this
+            </Text>
+            <List type="unordered" size="xs" spacing={6} c="dimmed">
+              <List.Item>Make sure the app is running on that machine.</List.Item>
+              <List.Item>{`Open its Civitai Link panel and check it's still paired.`}</List.Item>
+              <List.Item>{`Still stuck? Reconnect for a fresh code, then paste it into the app.`}</List.Item>
+            </List>
+            <Text fz={11} c="dimmed">
+              Using the desktop app? Sign in from the app instead.
+            </Text>
+          </Stack>
+          <Button
+            leftSection={<IconRefresh size={18} />}
+            radius={0}
+            fullWidth
+            onClick={handleGenerateKey}
+          >
+            Reconnect
+          </Button>
+        </>
       )}
-      <Stack px="xs" py="sm" gap={6}>
-        <Text size="sm" fw={500}>
-          Try this
-        </Text>
-        <List type="unordered" size="xs" spacing={6} c="dimmed">
-          <List.Item>Make sure the app is running on that machine.</List.Item>
-          <List.Item>{`Open its Civitai Link panel and check it's still paired.`}</List.Item>
-          <List.Item>{`Still stuck? Reconnect for a fresh code, then paste it into the app.`}</List.Item>
-        </List>
-      </Stack>
-      <Button
-        leftSection={<IconRefresh size={18} />}
-        radius={0}
-        fullWidth
-        onClick={handleGenerateKey}
-      >
-        Reconnect
-      </Button>
     </>
   );
 }

--- a/src/components/CivitaiLink/CivitaiLinkProvider.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkProvider.tsx
@@ -20,6 +20,7 @@ import type {
   WorkerOutgoingMessage,
   WorkerIncomingMessage,
   Instance,
+  PairingStatus,
 } from '~/workers/civitai-link-worker-types';
 import type { MantineColor } from '@mantine/core';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -52,11 +53,14 @@ type CivitaiLinkState = {
   resources: ResponseResourcesList['resources'];
   error?: string;
   status: CivitaiLinkStatus;
+  pairingStatus?: PairingStatus;
   createInstance: (id?: number) => Promise<void>;
   deleteInstance: (id: number) => Promise<void>;
   renameInstance: (id: number, name: string) => Promise<void>;
   selectInstance: (id: number) => Promise<void>;
   deselectInstance: () => Promise<void>;
+  awaitPairing: () => Promise<void>;
+  cancelAwaitPairing: () => Promise<void>;
   runCommand: (command: CommandRequest) => Promise<{
     promise: Promise<unknown>;
     id: string;
@@ -152,6 +156,7 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
   const [resources, setResources] = useState<ResponseResourcesList['resources']>([]);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string>();
+  const [pairingStatus, setPairingStatus] = useState<PairingStatus>();
   const setActivities = useCivitaiLinkStore((state) => state.setActivities);
 
   //TODO.civitai-link - timeout when setting active instance
@@ -222,6 +227,7 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
         else if (data.type === 'activitiesUpdate') handleActivities(data.payload);
         else if (data.type === 'commandComplete') handleCommandComplete(data.payload);
         else if (data.type === 'socketConnection') setSocketConnected(data.payload);
+        else if (data.type === 'pairing') setPairingStatus(data.status);
       };
     });
 
@@ -244,6 +250,19 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
   const createInstance = (id?: number) => workerReq({ type: 'create', id });
   const deleteInstance = (id: number) => workerReq({ type: 'delete', id });
   const renameInstance = (id: number, name: string) => workerReq({ type: 'rename', id, name });
+  const awaitPairing = () => {
+    const known = instances ?? [];
+    setPairingStatus('waiting');
+    return workerReq({
+      type: 'awaitPairing',
+      knownIds: known.map((x) => x.id),
+      knownKeys: Object.fromEntries(known.map((x) => [x.id, x.key])),
+    });
+  };
+  const cancelAwaitPairing = () => {
+    setPairingStatus(undefined);
+    return workerReq({ type: 'cancelAwaitPairing' });
+  };
 
   const runCommand = async (command: CommandRequest, timeout = 0) => {
     const payload = command as Command;
@@ -314,11 +333,14 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
         resources,
         error,
         status,
+        pairingStatus,
         createInstance,
         deleteInstance,
         renameInstance,
         selectInstance,
         deselectInstance,
+        awaitPairing,
+        cancelAwaitPairing,
         runCommand,
       }}
     >
@@ -342,11 +364,14 @@ export function CivitaiLinkProvider({ children }: { children: React.ReactElement
         resources: [],
         error: 'Civitai Link is not enabled',
         status: 'not-connected',
+        pairingStatus: undefined,
         createInstance: () => Promise.resolve(),
         deleteInstance: () => Promise.resolve(),
         renameInstance: () => Promise.resolve(),
         selectInstance: () => Promise.resolve(),
         deselectInstance: () => Promise.resolve(),
+        awaitPairing: () => Promise.resolve(),
+        cancelAwaitPairing: () => Promise.resolve(),
         runCommand: () => Promise.resolve({ promise: Promise.resolve(), id: '', cancel: () => {} }),
       }}
     >

--- a/src/components/CivitaiLink/CivitaiLinkProvider.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkProvider.tsx
@@ -323,6 +323,14 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
     boot();
   }, []); // eslint-disable-line
 
+  // The SharedWorker outlives this tab, so an un-cancelled poll keeps hitting
+  // GET /api/link and can join an instance on every other tab's behalf.
+  useEffect(() => {
+    return () => {
+      cancelAwaitPairing();
+    };
+  }, []); // eslint-disable-line
+
   return (
     <CivitaiLinkCtx.Provider
       value={{

--- a/src/components/CivitaiLink/CivitaiLinkProvider.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkProvider.tsx
@@ -323,14 +323,6 @@ const Provider = ({ children }: { children: React.ReactNode }) => {
     boot();
   }, []); // eslint-disable-line
 
-  // The SharedWorker outlives this tab, so an un-cancelled poll keeps hitting
-  // GET /api/link and can join an instance on every other tab's behalf.
-  useEffect(() => {
-    return () => {
-      cancelAwaitPairing();
-    };
-  }, []); // eslint-disable-line
-
   return (
     <CivitaiLinkCtx.Provider
       value={{

--- a/src/components/CivitaiLink/CivitaiLinkWizard.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkWizard.tsx
@@ -27,7 +27,7 @@ import {
   IconLink,
   IconRefresh,
 } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AppRow } from '~/components/CivitaiLink/CivitaiLinkAppRow';
 import { useCivitaiLink } from '~/components/CivitaiLink/CivitaiLinkProvider';
 import type { CivitaiLinkConnectPath } from '~/components/CivitaiLink/civitai-link-paths';
@@ -260,12 +260,20 @@ export default function CivitaiLinkWizardModal() {
     pairingStatus,
   } = useCivitaiLink();
   const [name, setName] = useState('');
+  // `instance` is a provider-global, cross-tab broadcast, so latch the id we
+  // actually paired with — otherwise a join in another tab takes our typed name.
+  const pairedIdRef = useRef<number | null>(null);
   const isNodePack = path === 'nodepack';
 
   const handleAdvance = () => {
     nextStep();
     if (isNodePack) createInstance();
     else awaitPairing();
+  };
+
+  const handleRetryPairing = () => {
+    pairedIdRef.current = null;
+    awaitPairing();
   };
 
   const commitName = () => {
@@ -280,12 +288,15 @@ export default function CivitaiLinkWizardModal() {
   useEffect(() => {
     if (active !== 2 || isNodePack) return;
     return () => {
+      pairedIdRef.current = null;
       cancelAwaitPairing();
     };
   }, [active, isNodePack]); // eslint-disable-line
 
   useEffect(() => {
-    if (active === 2 && !isNodePack && pairingStatus === 'paired') commitName();
+    if (active !== 2 || isNodePack || pairingStatus !== 'paired') return;
+    if (pairedIdRef.current === null && instance?.id != null) pairedIdRef.current = instance.id;
+    if (instance?.id === pairedIdRef.current) commitName();
   }, [active, isNodePack, pairingStatus, instance?.id]); // eslint-disable-line
 
   useEffect(() => {
@@ -594,7 +605,7 @@ export default function CivitaiLinkWizardModal() {
                   Approve the request in the browser tab that opens.
                 </NumberedStep>
               </Stack>
-              <PairingState status={pairingStatus} onRetry={awaitPairing} />
+              <PairingState status={pairingStatus} onRetry={handleRetryPairing} />
             </>
           )}
           <TextInput

--- a/src/components/CivitaiLink/CivitaiLinkWizard.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkWizard.tsx
@@ -260,19 +260,24 @@ export default function CivitaiLinkWizardModal() {
     pairingStatus,
   } = useCivitaiLink();
   const [name, setName] = useState('');
-  // `instance` is a provider-global, cross-tab broadcast, so latch the id we
-  // actually paired with — otherwise a join in another tab takes our typed name.
+  // `instance` and `pairingStatus` are both provider-global, cross-tab broadcasts.
+  // Latch the id we paired with, or a join in another tab takes our typed name;
+  // latch that we saw 'paired', or another tab arming its own wait sends this step
+  // back to the spinner it never leaves.
   const pairedIdRef = useRef<number | null>(null);
+  const [sawPaired, setSawPaired] = useState(false);
   const isNodePack = path === 'nodepack';
 
   const handleAdvance = () => {
     nextStep();
+    setSawPaired(false);
     if (isNodePack) createInstance();
     else awaitPairing();
   };
 
   const handleRetryPairing = () => {
     pairedIdRef.current = null;
+    setSawPaired(false);
     awaitPairing();
   };
 
@@ -295,6 +300,7 @@ export default function CivitaiLinkWizardModal() {
 
   useEffect(() => {
     if (active !== 2 || isNodePack || pairingStatus !== 'paired') return;
+    setSawPaired(true);
     if (pairedIdRef.current === null && instance?.id != null) pairedIdRef.current = instance.id;
     if (instance?.id === pairedIdRef.current) commitName();
   }, [active, isNodePack, pairingStatus, instance?.id]); // eslint-disable-line
@@ -605,7 +611,10 @@ export default function CivitaiLinkWizardModal() {
                   Approve the request in the browser tab that opens.
                 </NumberedStep>
               </Stack>
-              <PairingState status={pairingStatus} onRetry={handleRetryPairing} />
+              <PairingState
+                status={sawPaired ? 'paired' : pairingStatus}
+                onRetry={handleRetryPairing}
+              />
             </>
           )}
           <TextInput

--- a/src/components/CivitaiLink/CivitaiLinkWizard.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkWizard.tsx
@@ -336,8 +336,8 @@ export default function CivitaiLinkWizardModal() {
               How do you want to connect?
             </Text>
             <Text fz="sm" c="dimmed" lh={1.55}>
-              Civitai Link sends models straight from the site to the machine you generate on — no
-              downloads, no file shuffling. Pick whichever you already run.
+              Civitai Link sends models straight from the site to the machine you generate on — it
+              downloads them and files them where your app expects. Pick whichever you already run.
             </Text>
           </Stack>
           <Flex direction={{ base: 'column', sm: 'row' }} gap="sm" align="stretch">

--- a/src/components/CivitaiLink/CivitaiLinkWizard.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkWizard.tsx
@@ -199,41 +199,41 @@ function WizardFooter({ left, right }: { left: React.ReactNode; right?: React.Re
 }
 
 function PairingState({ status, onRetry }: { status?: PairingStatus; onRetry: () => void }) {
-  if (status === 'paired')
-    return (
-      <Group justify="center" gap={10} my="md">
-        <Center
-          w={40}
-          h={40}
-          style={{ borderRadius: 999, background: 'var(--mantine-color-green-light)' }}
-        >
-          <IconCheck size={20} className="text-green-6" />
-        </Center>
-        <Text fz="md" fw={600} c="var(--mantine-color-bright)">
-          Signed in — this app is connected
-        </Text>
-      </Group>
-    );
-
-  if (status === 'timeout')
-    return (
-      <Stack align="center" gap="xs" my="md">
-        <Text fz="sm" c="dimmed" ta="center" maw={420}>
-          Still waiting? Make sure the app is running.
-        </Text>
-        <Button variant="default" onClick={onRetry} leftSection={<IconRefresh size={16} />}>
-          Retry
-        </Button>
-      </Stack>
-    );
-
+  // A live region added alongside its own content announces unreliably, so one
+  // wrapper spans all three states.
   return (
-    <Group justify="center" gap={10} my="md">
-      <Loader size="sm" />
-      <Text fz="md" fw={600} c="var(--mantine-color-bright)">
-        Waiting for the app…
-      </Text>
-    </Group>
+    <div role="status">
+      {status === 'paired' ? (
+        <Group justify="center" gap={10} my="md">
+          <Center
+            w={40}
+            h={40}
+            style={{ borderRadius: 999, background: 'var(--mantine-color-green-light)' }}
+          >
+            <IconCheck size={20} className="text-green-6" />
+          </Center>
+          <Text fz="md" fw={600} c="var(--mantine-color-bright)">
+            Signed in — this app is connected
+          </Text>
+        </Group>
+      ) : status === 'timeout' ? (
+        <Stack align="center" gap="xs" my="md">
+          <Text fz="sm" c="dimmed" ta="center" maw={420}>
+            Still waiting? Make sure the app is running.
+          </Text>
+          <Button variant="default" onClick={onRetry} leftSection={<IconRefresh size={16} />}>
+            Retry
+          </Button>
+        </Stack>
+      ) : (
+        <Group justify="center" gap={10} my="md">
+          <Loader size="sm" />
+          <Text fz="md" fw={600} c="var(--mantine-color-bright)">
+            Waiting for the app…
+          </Text>
+        </Group>
+      )}
+    </div>
   );
 }
 
@@ -285,8 +285,8 @@ export default function CivitaiLinkWizardModal() {
   }, [active, isNodePack]); // eslint-disable-line
 
   useEffect(() => {
-    if (pairingStatus === 'paired') commitName();
-  }, [pairingStatus, instance?.id]); // eslint-disable-line
+    if (active === 2 && !isNodePack && pairingStatus === 'paired') commitName();
+  }, [active, isNodePack, pairingStatus, instance?.id]); // eslint-disable-line
 
   useEffect(() => {
     if (path !== 'desktop') return;

--- a/src/components/CivitaiLink/CivitaiLinkWizard.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkWizard.tsx
@@ -25,11 +25,13 @@ import {
   IconDownload,
   IconInfoCircle,
   IconLink,
+  IconRefresh,
 } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { AppRow } from '~/components/CivitaiLink/CivitaiLinkAppRow';
 import { useCivitaiLink } from '~/components/CivitaiLink/CivitaiLinkProvider';
 import type { CivitaiLinkConnectPath } from '~/components/CivitaiLink/civitai-link-paths';
+import type { PairingStatus } from '~/workers/civitai-link-worker-types';
 import {
   CIVITAI_LINK_COMFYUI_DOWNLOAD,
   CIVITAI_LINK_DESKTOP_RELEASES,
@@ -196,6 +198,45 @@ function WizardFooter({ left, right }: { left: React.ReactNode; right?: React.Re
   );
 }
 
+function PairingState({ status, onRetry }: { status?: PairingStatus; onRetry: () => void }) {
+  if (status === 'paired')
+    return (
+      <Group justify="center" gap={10} my="md">
+        <Center
+          w={40}
+          h={40}
+          style={{ borderRadius: 999, background: 'var(--mantine-color-green-light)' }}
+        >
+          <IconCheck size={20} className="text-green-6" />
+        </Center>
+        <Text fz="md" fw={600} c="var(--mantine-color-bright)">
+          Signed in — this app is connected
+        </Text>
+      </Group>
+    );
+
+  if (status === 'timeout')
+    return (
+      <Stack align="center" gap="xs" my="md">
+        <Text fz="sm" c="dimmed" ta="center" maw={420}>
+          Still waiting? Make sure the app is running.
+        </Text>
+        <Button variant="default" onClick={onRetry} leftSection={<IconRefresh size={16} />}>
+          Retry
+        </Button>
+      </Stack>
+    );
+
+  return (
+    <Group justify="center" gap={10} my="md">
+      <Loader size="sm" />
+      <Text fz="md" fw={600} c="var(--mantine-color-bright)">
+        Waiting for the app…
+      </Text>
+    </Group>
+  );
+}
+
 export default function CivitaiLinkWizardModal() {
   const dialog = useDialogContext();
 
@@ -209,16 +250,24 @@ export default function CivitaiLinkWizardModal() {
   const nextStep = () => setActive((current) => (current < 2 ? current + 1 : current));
   const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
 
-  const { connected, instance, createInstance, renameInstance } = useCivitaiLink();
+  const {
+    connected,
+    instance,
+    createInstance,
+    renameInstance,
+    awaitPairing,
+    cancelAwaitPairing,
+    pairingStatus,
+  } = useCivitaiLink();
   const [name, setName] = useState('');
+  const isNodePack = path === 'nodepack';
 
-  const handleCreateInstance = () => {
+  const handleAdvance = () => {
     nextStep();
-    createInstance();
+    if (isNodePack) createInstance();
+    else awaitPairing();
   };
 
-  // The instance exists from the moment the code is generated, so an abandoned
-  // wizard leaves an app under whatever default name the Link server assigned.
   const commitName = () => {
     const trimmed = name.trim();
     if (instance?.id && trimmed && trimmed !== instance.name) renameInstance(instance.id, trimmed);
@@ -227,6 +276,17 @@ export default function CivitaiLinkWizardModal() {
   useEffect(() => {
     if (connected) setActive(2);
   }, [connected]);
+
+  useEffect(() => {
+    if (active !== 2 || isNodePack) return;
+    return () => {
+      cancelAwaitPairing();
+    };
+  }, [active, isNodePack]); // eslint-disable-line
+
+  useEffect(() => {
+    if (pairingStatus === 'paired') commitName();
+  }, [pairingStatus, instance?.id]); // eslint-disable-line
 
   useEffect(() => {
     if (path !== 'desktop') return;
@@ -239,7 +299,6 @@ export default function CivitaiLinkWizardModal() {
     fetchReleases();
   }, [path]);
 
-  const isNodePack = path === 'nodepack';
   const otherOses = downloadableOses.filter((os) => os !== release.os);
 
   return (
@@ -426,7 +485,7 @@ export default function CivitaiLinkWizardModal() {
               </Button>
             }
             right={
-              <Button onClick={handleCreateInstance} rightSection={<IconChevronRight size={16} />}>
+              <Button onClick={handleAdvance} rightSection={<IconChevronRight size={16} />}>
                 {`I've installed it`}
               </Button>
             }
@@ -459,14 +518,14 @@ export default function CivitaiLinkWizardModal() {
                 </Center>
               </Center>
             </>
-          ) : (
+          ) : isNodePack ? (
             <>
               <Stack gap={4}>
                 <Text fz={24} fw={700} c="var(--mantine-color-bright)" lh={1.25}>
-                  Sign in from the app
+                  Pair with this code
                 </Text>
                 <Text fz="sm" c="dimmed" lh={1.55}>
-                  Enter this code in the app once. The connection sticks — you won&apos;t need it
+                  Enter this code in ComfyUI once. The connection sticks — you won&apos;t need it
                   again.
                 </Text>
               </Stack>
@@ -485,9 +544,6 @@ export default function CivitaiLinkWizardModal() {
                     <IconLink size={26} className="text-blue-6" />
                   </Center>
                 </div>
-                <Text fz="lg" fw={600} c="var(--mantine-color-bright)" mt="xs">
-                  Pair with this code
-                </Text>
                 {instance?.key ? (
                   <CopyButton value={instance.key}>
                     {({ copied, copy }) => (
@@ -513,11 +569,32 @@ export default function CivitaiLinkWizardModal() {
                   </Button>
                 )}
                 <Text size="sm" c="dimmed" ta="center" maw={420}>
-                  {isNodePack
-                    ? `In ComfyUI, open the Civitai panel and paste the code. We'll pick it up here automatically.`
-                    : `In the Link app, open the Civitai Link panel and paste the code. We'll pick it up here automatically.`}
+                  {`In ComfyUI, open the Civitai panel and paste the code. We'll pick it up here automatically.`}
                 </Text>
               </Stack>
+            </>
+          ) : (
+            <>
+              <Stack gap={4}>
+                <Text fz={24} fw={700} c="var(--mantine-color-bright)" lh={1.25}>
+                  Sign in from the app
+                </Text>
+                <Text fz="sm" c="dimmed" lh={1.55}>
+                  No code to copy. Approve the sign-in in your browser and this page picks it up.
+                </Text>
+              </Stack>
+              <Stack gap={16} pt={4}>
+                <NumberedStep index={1}>
+                  Open <b>Civitai Link</b> on that machine.
+                </NumberedStep>
+                <NumberedStep index={2}>
+                  Click <b>Sign in with Civitai</b>.
+                </NumberedStep>
+                <NumberedStep index={3} caption="It opens in your default browser.">
+                  Approve the request in the browser tab that opens.
+                </NumberedStep>
+              </Stack>
+              <PairingState status={pairingStatus} onRetry={awaitPairing} />
             </>
           )}
           <TextInput
@@ -539,7 +616,9 @@ export default function CivitaiLinkWizardModal() {
                 <IconAlertTriangle size={15} className={clsx('mt-0.5 shrink-0', classes.dimIcon)} />
               }
             >
-              Nothing after a minute? Make sure the app is running, then reload this page.
+              {isNodePack
+                ? `Nothing after a minute? Make sure ComfyUI is running, then reload this page.`
+                : `Nothing after a minute? Make sure the Link app is running on that machine.`}
             </NoteStrip>
           )}
           <WizardFooter

--- a/src/components/CivitaiLink/__tests__/CivitaiLinkProvider.browser.test.tsx
+++ b/src/components/CivitaiLink/__tests__/CivitaiLinkProvider.browser.test.tsx
@@ -23,6 +23,10 @@ const mocks = vi.hoisted(() => ({
   baseUrl: undefined as string | undefined,
   /** How many times the provider constructed a SharedWorker. */
   workerConstructions: 0,
+  /** Every message the provider posted to the worker, in order. */
+  posted: [] as unknown[],
+  /** The live fake port, so a test can push worker messages back. */
+  port: null as { onmessage: ((e: { data: unknown }) => void) | null } | null,
 }));
 
 // `importOriginal` spread, NOT a bare replacement naming only `useFeatureFlags`.
@@ -45,11 +49,14 @@ vi.mock('~/components/CivitaiLink/civitai-link-api', async (importOriginal) => (
 vi.mock('@okikio/sharedworker', () => ({
   default: class FakeSharedWorker {
     port = {
-      postMessage: () => undefined,
+      postMessage: (message: unknown) => {
+        mocks.posted.push(message);
+      },
       onmessage: null as ((e: { data: unknown }) => void) | null,
     };
     constructor() {
       mocks.workerConstructions += 1;
+      mocks.port = this.port;
     }
   },
 }));
@@ -72,8 +79,20 @@ const UNAVAILABLE_MESSAGE = 'Civitai Link is not available on this domain';
  * the behaviour regresses.
  */
 function Probe() {
-  const { error, status } = useCivitaiLink();
-  return <div data-testid="probe" data-status={status} data-error={error ?? ''} />;
+  const { error, status, instances, pairingStatus, awaitPairing } = useCivitaiLink();
+  return (
+    <div
+      data-testid="probe"
+      data-status={status}
+      data-error={error ?? ''}
+      data-instances={(instances ?? []).map((x) => x.id).join(',')}
+      data-pairing={pairingStatus ?? ''}
+    >
+      <button type="button" data-testid="await-pairing" onClick={() => awaitPairing()}>
+        await
+      </button>
+    </div>
+  );
 }
 
 const renderProvider = () =>
@@ -87,6 +106,8 @@ describe('CivitaiLinkProvider — cross-domain guard', () => {
   beforeEach(() => {
     mocks.baseUrl = undefined;
     mocks.workerConstructions = 0;
+    mocks.posted = [];
+    mocks.port = null;
   });
 
   test('the exported constant still says what these tests assert', () => {
@@ -114,5 +135,52 @@ describe('CivitaiLinkProvider — cross-domain guard', () => {
 
     await vi.waitFor(() => expect(mocks.workerConstructions).toBe(1));
     await expect.element(page.getByTestId('probe')).toHaveAttribute('data-error', '');
+  });
+
+  // The worker half is untestable (module-scope `io()` + `self.onconnect`), so
+  // this pins the contract between them: the snapshot the provider sends, and
+  // the status it surfaces. Every state asserted here is absorbing — it arrives
+  // and stays — so no matcher is racing a state that deletes itself.
+  test('awaitPairing snapshots the instance list and surfaces the worker status', async () => {
+    mocks.baseUrl = 'https://link.civitai.com';
+    renderProvider();
+
+    await vi.waitFor(() => expect(mocks.port).not.toBeNull());
+    const port = mocks.port!;
+    // The provider only resolves its worker promise on `ready`; without this,
+    // every `workerReq` stays pending forever.
+    port.onmessage?.({ data: { type: 'ready' } });
+    port.onmessage?.({
+      data: {
+        type: 'instancesUpdate',
+        payload: [
+          {
+            id: 7,
+            key: 'abcdef',
+            name: 'Workstation',
+            activated: true,
+            origin: null,
+            oauthPaired: true,
+            createdAt: new Date('2026-09-01T00:00:00Z'),
+          },
+        ],
+      },
+    });
+
+    const probe = page.getByTestId('probe');
+    await expect.element(probe).toHaveAttribute('data-instances', '7');
+
+    await page.getByTestId('await-pairing').click();
+    await vi.waitFor(() =>
+      expect(mocks.posted).toContainEqual({
+        type: 'awaitPairing',
+        knownIds: [7],
+        knownKeys: { 7: 'abcdef' },
+      })
+    );
+    await expect.element(probe).toHaveAttribute('data-pairing', 'waiting');
+
+    port.onmessage?.({ data: { type: 'pairing', status: 'paired' } });
+    await expect.element(probe).toHaveAttribute('data-pairing', 'paired');
   });
 });

--- a/src/components/CivitaiLink/__tests__/pairing-detect.test.ts
+++ b/src/components/CivitaiLink/__tests__/pairing-detect.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { CivitaiLinkInstance } from '~/components/CivitaiLink/civitai-link-api';
+import { detectPairing } from '~/components/CivitaiLink/pairing-detect';
+
+const inst = (id: number, key: string): CivitaiLinkInstance => ({
+  id,
+  key,
+  name: `app-${id}`,
+  activated: true,
+  origin: null,
+  oauthPaired: true,
+  createdAt: new Date('2026-09-01T00:00:00Z'),
+});
+
+describe('detectPairing', () => {
+  it('returns null when the list is unchanged', () => {
+    const prev = { ids: [1, 2], keys: { 1: 'aaa', 2: 'bbb' } };
+    expect(detectPairing(prev, [inst(1, 'aaa'), inst(2, 'bbb')])).toBeNull();
+  });
+
+  it('returns the instance whose id was not in the snapshot', () => {
+    const prev = { ids: [1], keys: { 1: 'aaa' } };
+    expect(detectPairing(prev, [inst(1, 'aaa'), inst(9, 'ccc')])?.id).toBe(9);
+  });
+
+  it('returns a known instance whose key changed', () => {
+    const prev = { ids: [1, 2], keys: { 1: 'aaa', 2: 'bbb' } };
+    expect(detectPairing(prev, [inst(1, 'aaa'), inst(2, 'rekeyed')])?.id).toBe(2);
+  });
+
+  // A brand-new install and a re-key can land in the same poll. Preferring the
+  // new id keeps the wizard on the app the user just installed.
+  it('prefers a new id over a re-key when both appear at once', () => {
+    const prev = { ids: [1], keys: { 1: 'aaa' } };
+    expect(detectPairing(prev, [inst(1, 'rekeyed'), inst(9, 'ccc')])?.id).toBe(9);
+  });
+
+  // An id we knew but never held a key for (list loaded, never joined) is not a
+  // re-key signal — treating `undefined !== key` as a change fires on the first poll.
+  it('does not resolve for a known id whose key was never snapshotted', () => {
+    const prev = { ids: [1], keys: {} };
+    expect(detectPairing(prev, [inst(1, 'aaa')])).toBeNull();
+  });
+
+  it('returns null when an instance disappears', () => {
+    const prev = { ids: [1, 2], keys: { 1: 'aaa', 2: 'bbb' } };
+    expect(detectPairing(prev, [inst(1, 'aaa')])).toBeNull();
+  });
+
+  it('returns null for an empty list', () => {
+    expect(detectPairing({ ids: [1], keys: { 1: 'aaa' } }, [])).toBeNull();
+  });
+});

--- a/src/components/CivitaiLink/__tests__/pairing-detect.test.ts
+++ b/src/components/CivitaiLink/__tests__/pairing-detect.test.ts
@@ -35,6 +35,12 @@ describe('detectPairing', () => {
     expect(detectPairing(prev, [inst(1, 'rekeyed'), inst(9, 'ccc')])?.id).toBe(9);
   });
 
+  // Everything is new against an empty snapshot, which is why the worker seeds it
+  // from a fresh GET /api/link before arming the poll instead of trusting the tab.
+  it('returns the first instance when the snapshot is empty', () => {
+    expect(detectPairing({ ids: [], keys: {} }, [inst(1, 'aaa')])?.id).toBe(1);
+  });
+
   // An id we knew but never held a key for (list loaded, never joined) is not a
   // re-key signal — treating `undefined !== key` as a change fires on the first poll.
   it('does not resolve for a known id whose key was never snapshotted', () => {

--- a/src/components/CivitaiLink/civitai-link-api.ts
+++ b/src/components/CivitaiLink/civitai-link-api.ts
@@ -6,6 +6,7 @@ export type CivitaiLinkInstance = {
   name: string | null;
   activated: boolean;
   origin: string | null;
+  oauthPaired: boolean;
   createdAt: Date;
 };
 

--- a/src/components/CivitaiLink/pairing-detect.ts
+++ b/src/components/CivitaiLink/pairing-detect.ts
@@ -1,0 +1,18 @@
+import type { CivitaiLinkInstance } from '~/components/CivitaiLink/civitai-link-api';
+
+export type PairingSnapshot = { ids: number[]; keys: Record<number, string> };
+
+export function detectPairing(
+  prev: PairingSnapshot,
+  next: CivitaiLinkInstance[]
+): CivitaiLinkInstance | null {
+  const known = new Set(prev.ids);
+  const added = next.find((instance) => !known.has(instance.id));
+  if (added) return added;
+
+  const rekeyed = next.find((instance) => {
+    const previousKey = prev.keys[instance.id];
+    return previousKey !== undefined && instance.key !== previousKey;
+  });
+  return rekeyed ?? null;
+}

--- a/src/workers/civitai-link-worker-types.ts
+++ b/src/workers/civitai-link-worker-types.ts
@@ -15,6 +15,8 @@ export type Instance = {
   sdConnected: boolean; // if the sd instance is available to connect to
 };
 
+export type PairingStatus = 'waiting' | 'paired' | 'timeout';
+
 export type WorkerOutgoingMessage =
   | { type: 'ready' }
   | { type: 'socketConnection'; payload: boolean }
@@ -24,7 +26,8 @@ export type WorkerOutgoingMessage =
   | { type: 'instancesUpdate'; payload: CivitaiLinkInstance[] | undefined }
   | { type: 'resourcesUpdate'; payload: ResponseResourcesList['resources'] }
   | { type: 'commandComplete'; payload: Response }
-  | { type: 'instance'; payload: Instance };
+  | { type: 'instance'; payload: Instance }
+  | { type: 'pairing'; status: PairingStatus };
 
 export type WorkerIncomingMessage =
   | { type: 'create'; id?: number }
@@ -32,4 +35,6 @@ export type WorkerIncomingMessage =
   | { type: 'rename'; id: number; name: string }
   | { type: 'join'; id: number }
   | { type: 'leave' }
-  | { type: 'command'; payload: Command };
+  | { type: 'command'; payload: Command }
+  | { type: 'awaitPairing'; knownIds: number[]; knownKeys: Record<number, string> }
+  | { type: 'cancelAwaitPairing' };

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -345,13 +345,20 @@ let pairingSnapshot: PairingSnapshot | null = null;
 let pairingDeadline = 0;
 let pairingGeneration = 0;
 let pairingSeeded = false;
+let pairingArmed = false;
 
-const stopPairingPoll = () => {
+// There is one poll for every tab, so a cancel from one of them strands the
+// rest on 'waiting' unless they are told. Callers that re-arm or emit their own
+// terminal status next pass `null`.
+const stopPairingPoll = (status: PairingStatus | null = 'timeout') => {
+  const wasArmed = pairingArmed;
+  pairingArmed = false;
   pairingGeneration += 1;
   if (pairingTimer !== null) clearInterval(pairingTimer);
   pairingTimer = null;
   pairingSnapshot = null;
   pairingSeeded = false;
+  if (wasArmed && status) emitPairing(status);
 };
 
 const mergeSnapshot = (base: PairingSnapshot, list: CivitaiLinkInstance[]): PairingSnapshot => {
@@ -369,7 +376,6 @@ const pollPairing = async () => {
   if (!snapshot) return;
   if (Date.now() >= pairingDeadline) {
     stopPairingPoll();
-    emitPairing('timeout');
     return;
   }
 
@@ -394,16 +400,17 @@ const pollPairing = async () => {
   const paired = detectPairing(snapshot, result);
   if (!paired) return;
 
-  stopPairingPoll();
+  stopPairingPoll(null);
   updateSharedValue({ type: 'instances', value: result });
   handleJoin(paired.id, true);
   emitPairing('paired');
 };
 
 const handleAwaitPairing = async (knownIds: number[], knownKeys: Record<number, string>) => {
-  stopPairingPoll();
+  stopPairingPoll(null);
   const generation = pairingGeneration;
   pairingDeadline = Date.now() + PAIRING_TIMEOUT_MS;
+  pairingArmed = true;
   emitPairing('waiting');
 
   let current: CivitaiLinkInstance[] | null = null;

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -346,6 +346,7 @@ let pairingDeadline = 0;
 let pairingGeneration = 0;
 let pairingSeeded = false;
 let pairingArmed = false;
+let pairingInFlight = false;
 
 // One poll is shared by every tab, so a cancel from one strands the rest on
 // 'waiting' unless they are told. Callers that re-arm, or that emit their own
@@ -358,6 +359,7 @@ const stopPairingPoll = (status: PairingStatus | null = 'timeout') => {
   pairingTimer = null;
   pairingSnapshot = null;
   pairingSeeded = false;
+  pairingInFlight = false;
   if (wasArmed && status) emitPairing(status);
 };
 
@@ -379,11 +381,19 @@ const pollPairing = async () => {
     return;
   }
 
+  // setInterval fires on a fixed period, so a list request slower than the
+  // period would otherwise start a second poll against the same snapshot and
+  // both would detect — and re-join — the same pairing.
+  if (pairingInFlight) return;
+
   let result: CivitaiLinkInstance[];
+  pairingInFlight = true;
   try {
     result = await getLinkInstances();
   } catch {
     return;
+  } finally {
+    pairingInFlight = false;
   }
   // Cancelled or resolved while the request was in flight.
   if (pairingSnapshot !== snapshot) return;

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -257,8 +257,8 @@ socket.on('roomPresence', ({ client, sd }) => {
 // --------------------------------
 // Handle Incoming Messages
 // --------------------------------
-const handleJoin = (id: number) => {
-  if (instance.id === id && instance.connected) return;
+const handleJoin = (id: number, force = false) => {
+  if (!force && instance.id === id && instance.connected) return;
 
   const targetInstance = instances?.find((i) => i.id === id);
   if (!targetInstance) {
@@ -343,11 +343,25 @@ const PAIRING_TIMEOUT_MS = 15 * 60 * 1000;
 let pairingTimer: ReturnType<typeof setInterval> | null = null;
 let pairingSnapshot: PairingSnapshot | null = null;
 let pairingDeadline = 0;
+let pairingGeneration = 0;
+let pairingSeeded = false;
 
 const stopPairingPoll = () => {
+  pairingGeneration += 1;
   if (pairingTimer !== null) clearInterval(pairingTimer);
   pairingTimer = null;
   pairingSnapshot = null;
+  pairingSeeded = false;
+};
+
+const mergeSnapshot = (base: PairingSnapshot, list: CivitaiLinkInstance[]): PairingSnapshot => {
+  const ids = new Set(base.ids);
+  const keys = { ...base.keys };
+  for (const item of list) {
+    ids.add(item.id);
+    keys[item.id] = item.key;
+  }
+  return { ids: [...ids], keys };
 };
 
 const pollPairing = async () => {
@@ -368,20 +382,47 @@ const pollPairing = async () => {
   // Cancelled or resolved while the request was in flight.
   if (pairingSnapshot !== snapshot) return;
 
+  // The arming fetch failed, so this is the first list we have seen. It is the
+  // baseline, not a pairing — detectPairing matches every row of it otherwise.
+  if (!pairingSeeded) {
+    pairingSnapshot = mergeSnapshot(snapshot, result);
+    pairingSeeded = true;
+    updateSharedValue({ type: 'instances', value: result });
+    return;
+  }
+
   const paired = detectPairing(snapshot, result);
   if (!paired) return;
 
   stopPairingPoll();
   updateSharedValue({ type: 'instances', value: result });
-  handleJoin(paired.id);
+  handleJoin(paired.id, true);
   emitPairing('paired');
 };
 
-const handleAwaitPairing = (knownIds: number[], knownKeys: Record<number, string>) => {
+const handleAwaitPairing = async (knownIds: number[], knownKeys: Record<number, string>) => {
   stopPairingPoll();
-  pairingSnapshot = { ids: knownIds, keys: knownKeys };
-  pairingDeadline = Date.now() + PAIRING_TIMEOUT_MS;
+  const generation = pairingGeneration;
   emitPairing('waiting');
+
+  let current: CivitaiLinkInstance[] | null = null;
+  try {
+    current = await getLinkInstances();
+  } catch {
+    // Fall back to the tab's list; the first poll establishes the baseline.
+  }
+  // Cancelled while the arming request was in flight.
+  if (pairingGeneration !== generation) return;
+
+  let snapshot: PairingSnapshot = { ids: knownIds, keys: knownKeys };
+  if (current) {
+    snapshot = mergeSnapshot(snapshot, current);
+    pairingSeeded = true;
+    updateSharedValue({ type: 'instances', value: current });
+  }
+
+  pairingSnapshot = snapshot;
+  pairingDeadline = Date.now() + PAIRING_TIMEOUT_MS;
   pairingTimer = setInterval(pollPairing, PAIRING_POLL_MS);
 };
 

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -382,9 +382,9 @@ const pollPairing = async () => {
   // Cancelled or resolved while the request was in flight.
   if (pairingSnapshot !== snapshot) return;
 
-  // The arming fetch failed, so this is the first list we have seen. It is the
+  // The arming fetch failed and left us no baseline, so this first list is the
   // baseline, not a pairing — detectPairing matches every row of it otherwise.
-  if (!pairingSeeded) {
+  if (!pairingSeeded && snapshot.ids.length === 0) {
     pairingSnapshot = mergeSnapshot(snapshot, result);
     pairingSeeded = true;
     updateSharedValue({ type: 'instances', value: result });
@@ -403,6 +403,7 @@ const pollPairing = async () => {
 const handleAwaitPairing = async (knownIds: number[], knownKeys: Record<number, string>) => {
   stopPairingPoll();
   const generation = pairingGeneration;
+  pairingDeadline = Date.now() + PAIRING_TIMEOUT_MS;
   emitPairing('waiting');
 
   let current: CivitaiLinkInstance[] | null = null;
@@ -422,7 +423,6 @@ const handleAwaitPairing = async (knownIds: number[], knownKeys: Record<number, 
   }
 
   pairingSnapshot = snapshot;
-  pairingDeadline = Date.now() + PAIRING_TIMEOUT_MS;
   pairingTimer = setInterval(pollPairing, PAIRING_POLL_MS);
 };
 

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -17,10 +17,13 @@ import {
   getLinkInstances,
   updateLinkInstance,
 } from '~/components/CivitaiLink/civitai-link-api';
+import type { PairingSnapshot } from '~/components/CivitaiLink/pairing-detect';
+import { detectPairing } from '~/components/CivitaiLink/pairing-detect';
 import type {
   WorkerIncomingMessage,
   Instance,
   WorkerOutgoingMessage,
+  PairingStatus,
 } from '~/workers/civitai-link-worker-types';
 import { get, set, del } from 'idb-keyval';
 
@@ -76,6 +79,7 @@ const sharedCallbacks = {
   instances: [] as (() => void)[],
   error: [] as ((msg: string) => void)[],
   message: [] as ((msg: string) => void)[],
+  pairing: [] as ((status: PairingStatus) => void)[],
   completion: [] as ((response: Response) => void)[],
   socketConnection: [] as ((connected: boolean) => void)[],
 };
@@ -138,6 +142,14 @@ const onMessage = (cb: (msg: string) => void) => {
 const emitMessage = (msg: string) => {
   console.log('emitMessage', { msg });
   sharedCallbacks.message.forEach((cb) => cb(msg));
+};
+
+const onPairing = (cb: (status: PairingStatus) => void) => {
+  sharedCallbacks.pairing.push(cb);
+};
+const emitPairing = (status: PairingStatus) => {
+  console.log('emitPairing', { status });
+  sharedCallbacks.pairing.forEach((cb) => cb(status));
 };
 
 // Storage
@@ -326,6 +338,53 @@ const handleCreate = async (id?: number) => {
   }
 };
 
+const PAIRING_POLL_MS = 3000;
+const PAIRING_TIMEOUT_MS = 15 * 60 * 1000;
+let pairingTimer: ReturnType<typeof setInterval> | null = null;
+let pairingSnapshot: PairingSnapshot | null = null;
+let pairingDeadline = 0;
+
+const stopPairingPoll = () => {
+  if (pairingTimer !== null) clearInterval(pairingTimer);
+  pairingTimer = null;
+  pairingSnapshot = null;
+};
+
+const pollPairing = async () => {
+  const snapshot = pairingSnapshot;
+  if (!snapshot) return;
+  if (Date.now() >= pairingDeadline) {
+    stopPairingPoll();
+    emitPairing('timeout');
+    return;
+  }
+
+  let result: CivitaiLinkInstance[];
+  try {
+    result = await getLinkInstances();
+  } catch {
+    return;
+  }
+  // Cancelled or resolved while the request was in flight.
+  if (pairingSnapshot !== snapshot) return;
+
+  const paired = detectPairing(snapshot, result);
+  if (!paired) return;
+
+  stopPairingPoll();
+  updateSharedValue({ type: 'instances', value: result });
+  handleJoin(paired.id);
+  emitPairing('paired');
+};
+
+const handleAwaitPairing = (knownIds: number[], knownKeys: Record<number, string>) => {
+  stopPairingPoll();
+  pairingSnapshot = { ids: knownIds, keys: knownKeys };
+  pairingDeadline = Date.now() + PAIRING_TIMEOUT_MS;
+  emitPairing('waiting');
+  pairingTimer = setInterval(pollPairing, PAIRING_POLL_MS);
+};
+
 const handleInitialization = () => {
   if (!instance.id || initialized === instance.id) return;
 
@@ -346,6 +405,7 @@ const start = async (port: MessagePort) => {
 
   onError((msg) => portReq({ type: 'error', msg }));
   onMessage((msg) => portReq({ type: 'message', msg }));
+  onPairing((status) => portReq({ type: 'pairing', status }));
   onCompletion((payload) => portReq({ type: 'commandComplete', payload }));
   portReq({ type: 'instance', payload: instance });
   onUpdate('instance', () => {
@@ -374,6 +434,8 @@ const start = async (port: MessagePort) => {
     else if (data.type === 'delete') handleDelete(data.id);
     else if (data.type === 'rename') handleRename(data.id, data.name);
     else if (data.type === 'leave') handleLeave();
+    else if (data.type === 'awaitPairing') handleAwaitPairing(data.knownIds, data.knownKeys);
+    else if (data.type === 'cancelAwaitPairing') stopPairingPoll();
     else if (data.type === 'command') handleCommand(data.payload);
   };
 

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -347,9 +347,9 @@ let pairingGeneration = 0;
 let pairingSeeded = false;
 let pairingArmed = false;
 
-// There is one poll for every tab, so a cancel from one of them strands the
-// rest on 'waiting' unless they are told. Callers that re-arm or emit their own
-// terminal status next pass `null`.
+// One poll is shared by every tab, so a cancel from one strands the rest on
+// 'waiting' unless they are told. Callers that re-arm, or that emit their own
+// terminal status next, pass `null`.
 const stopPairingPoll = (status: PairingStatus | null = 'timeout') => {
   const wasArmed = pairingArmed;
   pairingArmed = false;


### PR DESCRIPTION
The site half of "the Civitai Link desktop app signs in with OAuth instead of a six-character pairing code". The desktop app now creates its own instance server-side, so the site's job changes from handing out a code to noticing that pairing happened.

ClickUp: [868kyynkb](https://app.clickup.com/t/868kyynkb) · Hub PR: #4571

## 🔴 Merge last

This PR is safe to merge whenever, but the copy only makes sense once **Civitai Link desktop 1.21.0** is released, and the "sign in again" branch needs link-service to be serving `oauthPaired`. Order: hub → link-service → desktop release → this.

Shipping it early is not dangerous — `oauthPaired` has one runtime read behind a `!!`, so an absent field reads as `false` and the popover falls back to the existing code panel. Two things to expect in that window: an OAuth-paired instance that goes offline gets the legacy **Reconnect** button, which re-keys it to a six-character code a 1.21.0 app will not consume (recoverable by signing in from the app again); and the wizard's desktop step shows the sign-in flow unconditionally, so someone on an older build is told to press a button their app does not have.

## What is here

**The wizard's desktop step 2 becomes "Sign in from the app"** — instructions, a waiting state, a success state, and a timeout with retry. It no longer calls `POST /api/link` on the way in, because there is no code to mint. The ComfyUI node-pack path is unchanged and still shows a code.

**The popover offers re-authentication** for an instance that paired over OAuth, instead of generating a fresh code.

**A poll in the SharedWorker** notices the pairing: `GET /api/link` every 3 s for up to 15 minutes, seeded from its own fetch, resolving on a new instance id or a re-keyed known one, then joining it. The decision is a pure function, `detectPairing`, with unit tests; the plumbing around it is not unit-testable, because the worker cannot be imported (module-scope `io()` and `self.onconnect`).

**`oauthPaired`** on the instance type, from link-service.

## The part that took the most care

The SharedWorker holds **one** pairing poll and **one** `instance`, both broadcast to every tab. Per-caller polls would be the real fix and are deliberately not built here — that is a worker-architecture change this work did not fund. What is built instead makes the shared state honest:

- Cancelling in one tab stops the shared poll for all of them, so it now emits a terminal status rather than leaving the others spinning forever with no timeout.
- The wizard latches the instance id it paired with, so a join in another tab cannot redirect its rename.
- The wizard latches that it saw success, so another tab arming its own wait cannot send a finished step back to the spinner.

Each of those was a real bug found in review, not a hypothetical.

## Testing

Unit suite green (`detectPairing`, 8 cases). The provider browser test pins the await-pairing message contract and is non-vacuous — two mutations each turn it red. `pnpm build:workers` and typecheck clean.

The worker-side logic has no automated coverage for the reason above, so the manual checklist below is its only gate. Cases 9, 10 and 11 exist specifically because reverting the three fixes named above each fails exactly one of them.

## Known, accepted

- A concurrent second-tab join whose socket ack lands inside the pairing handshake can be latched instead of the real one. Window is one socket round-trip; closing it properly means giving the worker's pairing result its own identity.
- After a timeout the popover's OAuth branch has no Retry button — recovery is closing and reopening it, which nothing signposts.

## Manual verification

Requires the **Part B** link-service deploy (`oauthPaired` on `GET /api/link`, `POST /api/link/self`)
and **Civitai Link desktop 1.21.0**.

### 0. Setup (do all of this before walking the cases)

1. **Link service** — start a local link-service carrying **Part B**. Note the URL it serves on.
2. **Auth hub** — start the local auth hub (the `/dev-server` skill starts it for you).
3. **Site** — set `NEXT_PUBLIC_CIVITAI_LINK` in `.env.development` to the link-service URL, then
   start the site with the **`/dev-server` skill** (never `pnpm run dev`). If a dev server for this
   worktree was already running, **restart it** — `predev` rebuilds `public/workers/*.js`, but a
   running server keeps the old bundle and this branch's worker changes will not load.
   - The site host and the link-service host must share a **registrable domain** (last two labels),
     or the feature disables itself with "Civitai Link is not available on this domain". Both on
     `localhost` is fine.
4. **Desktop app** — run **Civitai Link desktop 1.21.0 from source**, pointed at the same
   link-service and the same local auth hub.
5. **Browser** — sign in, open DevTools → **Network**, filter on `link`, and leave it open for the
   whole walk. The entry point is the **chain-link icon in the site header**; clicking it opens the
   popover.

Each case is pass/fail on what you can see. 🔴 marks the point of the case.

### 1. Fresh desktop pairing — no instance is minted up front

1. Header link icon → **Set up Civitai Link**.
2. "How do you want to connect?" → **Link desktop app** → **Continue**.
3. "Install the Link desktop app" → **I've installed it**.

- [ ] Heading reads **"Sign in from the app"**, subtitle "No code to copy. Approve the sign-in in
      your browser and this page picks it up."
- [ ] Three numbered steps: *Open Civitai Link on that machine* / *Click Sign in with Civitai* /
      *Approve the request in the browser tab that opens*.
- [ ] A spinner with **"Waiting for the app…"**.
- [ ] 🔴 In Network: **no `POST /api/link`** on the step 2 → 3 transition. (A `POST` here is the old
      behaviour — it minted a code the desktop app no longer needs.)
- [ ] 🔴 `GET /api/link` repeats roughly **every 3 seconds** while the step is open.

### 2. The desktop app signs in

1. In the desktop app click **Sign in with Civitai**; approve it in the browser tab that opens.

- [ ] Within **one poll (~3 s)** the step flips to a green check and
      **"Signed in — this app is connected"**.
- [ ] The header link indicator turns **green**.
- [ ] The Civitai Link **success modal** opens.

### 3. A name typed while waiting still lands

1. Repeat cases 1–2, typing a name (e.g. `Workstation`) into **"Name this app"** *while the spinner
   is still showing*; do not click away.
2. Complete the sign-in from the desktop app.

- [ ] After pairing, the app is listed under **that name** (check the popover's instance picker).
- [ ] Exactly **one `PUT /api/link`** fires, after pairing — not before.

### 4. The node-pack path is unchanged

1. **Set up Civitai Link** → **ComfyUI node pack** → **Continue** → **I've installed it**.

- [ ] Step 3 still reads **"Pair with this code"** and shows a six-character code.
- [ ] 🔴 `POST /api/link` **does** fire on the step 2 → 3 transition (this path still needs a code).
- [ ] Entering that code in the ComfyUI Civitai panel still pairs the instance.
- [ ] No `GET /api/link` 3-second polling on this path.

### 5. Cancellation stops the poll

On the **desktop** step 3, with the spinner showing:

1. Click **Go back**.
   - [ ] `GET /api/link` polling **stops** (watch Network for ~10 s: no new requests).
2. Return to step 3 (**I've installed it**), confirm polling resumes, then **close the modal**
   (X or Escape).
   - [ ] Polling **stops** again.

### 6. Timeout

1. Quit the desktop app so nothing can pair.
2. Re-enter the desktop step 3 and leave the tab open for **15 minutes**.

- [ ] The spinner is replaced by **"Still waiting? Make sure the app is running."** and a **Retry**
      button.
- [ ] **Retry** restores the spinner and `GET /api/link` polling resumes.

### 7. Popover re-auth for an OAuth-paired app

1. With a desktop-paired instance selected and connected, **kill the desktop app** so the instance
   goes to the yellow `link-pending` state.
2. Open the header popover.

- [ ] A yellow strip: *"&lt;name&gt; hasn't checked in. Sending is paused until it's back."*
- [ ] Below it: **"Open Civitai Link and sign in again"**, a two-item list, a spinner and
      **"Waiting for the app…"**.
- [ ] 🔴 **No pairing code** anywhere in the popover.
3. Restart the desktop app and sign in again.
- [ ] The popover flips to the activity list **on its own**, no reload.

### 8. Popover for a code-paired (node-pack) app is unchanged

Repeat case 7 with a **node-pack** instance:

- [ ] The popover still shows the **pairing code**, the "Try this" list, the line *"Using the desktop
      app? Sign in from the app instead."*, and a working **Reconnect** button.

### 9. 🔴 A cancel elsewhere no longer hangs a waiter

The worker runs **one** pairing poll shared by every tab, so a cancel in one tab stops it for all of
them. It must end the others legibly instead of leaving them spinning.

1. **Tab A**: reach case 7's state — popover open, spinner, "Waiting for the app…".
2. **Tab B**: wizard, desktop path, step 3 — spinner, "Waiting for the app…".
3. **Tab A**: dismiss the popover (click elsewhere on the page).

- [ ] 🔴 Within a moment, **tab B** leaves the spinner for **"Still waiting? Make sure the app is
      running."** with a **Retry** button. *(Previously it spun forever, and never even timed out.)*
- [ ] **Retry** in tab B restores the spinner and restarts `GET /api/link` polling.

### 10. 🔴 A cancel with nothing armed must not repaint a success as a failure

1. **Tab A** and **tab B**: open the wizard in each, desktop path, both sitting on step 3 with the
   spinner.
2. Sign in from the desktop app once.
   - [ ] **Both tabs** show **"Signed in — this app is connected"**.
3. In **tab A** only, click **Go back**.

- [ ] 🔴 **Tab B** still reads **"Signed in — this app is connected"**. It must **not** flip to
      "Still waiting? Make sure the app is running." with a Retry button. *(Tab A's cancel has
      nothing left to cancel — the pairing already finished — so it must be silent.)*

### 11. 🔴 Reopening the popover shows the spinner, never a flash of the timeout copy

1. Reach case 7's state: popover open on an OAuth-paired `link-pending` instance, spinner showing.
2. Dismiss the popover, then reopen it. Repeat three or four times.

- [ ] 🔴 On every reopen the first thing painted is the **spinner** with "Waiting for the app…".
      Any flash of **"Still waiting? Make sure the app is running."** — the state with no spinner and
      no Retry — is a fail. *(It reproduced on every reopen before the fix, so it is a full frame of
      wrong text, not a subtle one.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAJA2T7boHxHCWrR2ze2Vu
