### PR TITLE
fix(articles): stop borrowing the model copy for an article's take-down reason

### DIFF
--- a/docs/moderator-app-package-extraction-plan.md
+++ b/docs/moderator-app-package-extraction-plan.md
@@ -19,7 +19,7 @@ Derived from a full sweep of every domain-vocabulary import across the 22 in-sco
 | File | Bucket · why it belongs here | `~/` import closure |
 |---|---|---|
 | `src/server/common/enums.ts` (450 lines) | **Contract.** Non-Prisma domain enums keying shared columns: `BlocklistType` (`Blocklist`), `NotificationCategory` (`Notification`), `NsfwLevel`, `BlockedReason`, `TagSort`, report/scan status. **Also absorbs `ReportEntity`** (Q1 — see member extractions). | **none** (0 imports) |
-| `src/server/common/moderation-helpers.ts` (204 lines) | **Contract.** `unpublishReasons`/`articleUnpublishReasons` codes written by moderator, read/displayed by main. Mis-filed under `server/common/`. | **none** (pure) |
+| `src/server/common/moderation-helpers.ts` (235 lines) | **Contract.** `unpublishReasons`/`articleUnpublishReasons` codes written by moderator, read/displayed by main; `legacyArticleUnpublishReasons` is read-only copy for keys the picker retired. Mis-filed under `server/common/`. | **none** (pure) |
 | `src/shared/constants/mime-types.ts` (72 lines) | **Contract.** `MIME_TYPES`/`MEDIA_TYPE` map file-ext ↔ `MediaType`; both apps categorize uploaded files (csam/training) into shared columns. | `@civitai/db-schema/enums` |
 | `src/shared/constants/basemodel.constants.ts` (V2 ecosystem schema) | **Vocabulary.** Shared base-model / ecosystem identity — generation config both apps must agree on. | `./lazy`, `./type-guards`, `@civitai/db-schema/enums` |
 | `src/utils/type-guards.ts` | **Pure leaf dep** of basemodel. **174 consumers** app-wide → strong single-source argument. *(Generic, not strictly "domain" — could relocate to a future `@civitai/utils`.)* | **none** (pure) |
@@ -164,7 +164,7 @@ export * from '@civitai/domain/enums';
 export { ReportEntity } from '@civitai/domain/enums';
 ```
 ```ts
-// src/server/common/moderation-helpers.ts  (11 consumers)
+// src/server/common/moderation-helpers.ts  (12 consumers)
 export * from '@civitai/domain/moderation-helpers';
 ```
 ```ts

--- a/src/components/Article/ArticleUnpublishedAlert.browser.test.tsx
+++ b/src/components/Article/ArticleUnpublishedAlert.browser.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'vitest';
 import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../test/component-setup';
 import { ArticleUnpublishedAlert } from './ArticleUnpublishedAlert';
-import { articleUnpublishReasons, unpublishReasons } from '~/server/common/moderation-helpers';
+import {
+  articleUnpublishReasons,
+  legacyArticleUnpublishReasons,
+} from '~/server/common/moderation-helpers';
 
 describe('ArticleUnpublishedAlert', () => {
   test('does not accuse the author of a violation over a quality take-down', async () => {
@@ -27,21 +30,44 @@ describe('ArticleUnpublishedAlert', () => {
       .toBeInTheDocument();
   });
 
-  test('keeps a legacy reason readable without heading it with model vocabulary', async () => {
+  test('gives a legacy reason article wording rather than the model copy', async () => {
     renderWithProviders(<ArticleUnpublishedAlert reason="no-posts" />);
 
-    // Await the body first: it renders in both the fixed and the broken variant, so the heading
-    // checks below fail in milliseconds rather than timing out waiting for text that never arrives.
     await expect
-      .element(page.getByText(unpublishReasons['no-posts'].notificationMessage))
+      .element(page.getByText(legacyArticleUnpublishReasons['no-posts'].notificationMessage))
       .toBeInTheDocument();
+    expect(page.getByText(/\bmodel\b/i).elements()).toHaveLength(0);
+  });
 
-    // `no-posts` is quality, so the heading must not accuse — but "Missing images" is the MODEL
-    // list's label and has no business heading an article's banner.
+  test('neither accuses nor invents a reason for a key it has no copy for', async () => {
+    renderWithProviders(<ArticleUnpublishedAlert reason="retired-reason" />);
+
+    // Await only the heading prefix, which both the fixed and the broken variant render. Everything
+    // that discriminates them is then read synchronously, so a regression fails in milliseconds
+    // instead of polling out the 15s browser timeout.
+    await expect.element(page.getByText(/This article has been unpublished/)).toBeInTheDocument();
     expect(
       page.getByText('This article has been unpublished', { exact: true }).elements()
     ).toHaveLength(1);
-    expect(page.getByText(/Missing images/).elements()).toHaveLength(0);
+    expect(page.getByText('A moderator unpublished this article.').elements()).toHaveLength(1);
+    expect(page.getByText(/violation/i).elements()).toHaveLength(0);
+  });
+
+  test('keeps the moderator note to the reason it was written for', async () => {
+    const { rerender } = await renderWithProviders(
+      <ArticleUnpublishedAlert reason="other" customMessage="Written assuming it stays internal" />
+    );
+
+    await expect
+      .element(page.getByText(/Written assuming it stays internal/))
+      .toBeInTheDocument();
+
+    await rerender(
+      <ArticleUnpublishedAlert reason="spam" customMessage="Written assuming it stays internal" />
+    );
+
+    await expect.element(page.getByText(articleUnpublishReasons.spam.notificationMessage)).toBeInTheDocument();
+    expect(page.getByText(/Written assuming it stays internal/).elements()).toHaveLength(0);
   });
 
   test('shows the support hint only to a non-moderator', async () => {

--- a/src/components/Article/ArticleUnpublishedAlert.tsx
+++ b/src/components/Article/ArticleUnpublishedAlert.tsx
@@ -1,10 +1,7 @@
 import { Alert, Stack, Text } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 
-import {
-  getArticleUnpublishReason,
-  isArticleUnpublishReason,
-} from '~/server/common/moderation-helpers';
+import { getArticleUnpublishReason } from '~/server/common/moderation-helpers';
 
 export function ArticleUnpublishedAlert({
   reason,
@@ -16,12 +13,10 @@ export function ArticleUnpublishedAlert({
   showSupportHint?: boolean;
 }) {
   const detail = reason ? getArticleUnpublishReason(reason) : undefined;
-  const isPolicy = detail?.type !== 'quality';
+  // An unknown reason resolves no detail, and `!== 'quality'` would then head the banner as a ToS violation.
+  const isPolicy = detail?.type === 'policy';
   const color = isPolicy ? 'red' : 'yellow';
-  // Only the article list's labels are written for an author. A legacy key falls back to the model
-  // copy for its body, but heading the banner "Missing images" would put a model's vocabulary in the
-  // most prominent line on the page.
-  const label = reason && isArticleUnpublishReason(reason) ? detail?.optionLabel : undefined;
+  const isOther = reason === 'other';
 
   return (
     <Alert
@@ -35,21 +30,27 @@ export function ArticleUnpublishedAlert({
       title={
         isPolicy
           ? 'This article has been unpublished due to a Terms of Service violation'
-          : `This article has been unpublished${label ? `: ${label}` : ''}`
+          : `This article has been unpublished${detail ? `: ${detail.optionLabel}` : ''}`
       }
     >
       <Stack gap={6} maw="65ch">
-        {detail?.notificationMessage && (
+        {!detail && (
+          <Text size="sm" fw={500}>
+            A moderator unpublished this article.
+          </Text>
+        )}
+        {detail && !isOther && (
           <Text size="sm" fw={500}>
             {detail.notificationMessage}
           </Text>
         )}
-        {customMessage && (
+        {/* `other` has no canned copy, so the moderator's note is the only reason the author gets. */}
+        {isOther && (
           <Text size="sm">
             <Text span fw={600} inherit>
-              Additional details:
+              Removal reason:
             </Text>{' '}
-            {customMessage}
+            {customMessage || 'No reason provided.'}
           </Text>
         )}
         {showSupportHint && (

--- a/src/components/Modals/ArticleUnpublishModal.tsx
+++ b/src/components/Modals/ArticleUnpublishModal.tsx
@@ -64,7 +64,7 @@ export default function ArticleUnpublishModal({ articleId }: { articleId: number
           <>
             <Textarea
               name="customMessage"
-              label="Reason"
+              label={reason === 'other' ? 'Reason (shown to the author)' : 'Reason (internal)'}
               placeholder="Why is this being unpublished?"
               rows={2}
               value={customMessage}

--- a/src/server/common/__tests__/article-unpublish-reasons.test.ts
+++ b/src/server/common/__tests__/article-unpublish-reasons.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   articleUnpublishReasons,
   getArticleUnpublishReason,
-  isArticleUnpublishReason,
+  legacyArticleUnpublishReasons,
   unpublishReasons,
 } from '~/server/common/moderation-helpers';
 import { articleUnpublishNotifications } from '~/server/notifications/article-unpublish.notifications';
@@ -21,7 +21,10 @@ const MODEL_WORDS = /\b(model|models|resource|resources|version|versions|example
 
 describe('articleUnpublishReasons', () => {
   it('speaks about articles, never models or resources', () => {
-    const offenders = Object.entries(articleUnpublishReasons)
+    const offenders = Object.entries({
+      ...articleUnpublishReasons,
+      ...legacyArticleUnpublishReasons,
+    })
       .filter(([, { notificationMessage }]) => MODEL_WORDS.test(notificationMessage))
       .map(([key]) => key);
 
@@ -29,20 +32,16 @@ describe('articleUnpublishReasons', () => {
   });
 
   it('offers no reason that describes an uploaded resource', () => {
-    const modelOnly = [
-      'no-posts',
-      'no-versions',
-      'no-files',
-      'nudify',
-      'non-generated-image',
-      'unintenteded-use',
-    ];
+    const modelOnly = ['no-posts', 'no-versions', 'no-files', 'nudify', 'non-generated-image'];
 
     for (const key of modelOnly) expect(articleUnpublishReasons).not.toHaveProperty(key);
   });
 
   it('reuses the model reason keys so stored metadata stays readable by both lists', () => {
-    for (const key of Object.keys(articleUnpublishReasons))
+    for (const key of [
+      ...Object.keys(articleUnpublishReasons),
+      ...Object.keys(legacyArticleUnpublishReasons),
+    ])
       expect(unpublishReasons).toHaveProperty(key);
   });
 });
@@ -58,10 +57,17 @@ describe('getArticleUnpublishReason', () => {
     expect(getArticleUnpublishReason('mature-underage')?.type).toBe('policy');
   });
 
-  it('falls back to the model copy for reasons already stored on live articles', () => {
-    expect(getArticleUnpublishReason('unintenteded-use')?.notificationMessage).toBe(
-      unpublishReasons['unintenteded-use'].notificationMessage
-    );
+  // Both keys are still stored on live articles (2026-09-02: 6 `unintenteded-use`, 1 `no-posts`), so neither entry is dead.
+  it('resolves a reason stored on live articles without borrowing the model copy', () => {
+    for (const key of ['unintenteded-use', 'no-posts']) {
+      const detail = getArticleUnpublishReason(key);
+
+      expect(detail?.notificationMessage).toBeTruthy();
+      expect(detail?.notificationMessage).not.toBe(
+        unpublishReasons[key as keyof typeof unpublishReasons].notificationMessage
+      );
+      expect(detail?.notificationMessage).not.toMatch(MODEL_WORDS);
+    }
   });
 
   it('returns nothing for a reason that was never a reason', () => {
@@ -69,10 +75,8 @@ describe('getArticleUnpublishReason', () => {
   });
 
   it('does not resolve a reason off Object.prototype', () => {
-    for (const inherited of ['toString', 'constructor', 'hasOwnProperty']) {
+    for (const inherited of ['toString', 'constructor', 'hasOwnProperty'])
       expect(getArticleUnpublishReason(inherited)).toBeUndefined();
-      expect(isArticleUnpublishReason(inherited)).toBe(false);
-    }
   });
 });
 
@@ -90,13 +94,24 @@ describe('article-unpublished notification', () => {
     expect(message).not.toMatch(MODEL_WORDS);
   });
 
-  it('does not blank out a legacy reason it no longer offers', () => {
+  it('does not blank out a legacy reason the picker no longer offers', () => {
     const message = prepare({
       articleId: 1,
       articleTitle: 'How I fixed a bug',
-      reason: 'unintenteded-use',
+      reason: 'no-posts',
     })!.message;
 
-    expect(message).toContain(unpublishReasons['unintenteded-use'].notificationMessage);
+    expect(message).toContain(legacyArticleUnpublishReasons['no-posts'].notificationMessage);
+    expect(message).not.toMatch(MODEL_WORDS);
+  });
+
+  it('does not trail a colon when it has no copy for the reason', () => {
+    const message = prepare({
+      articleId: 1,
+      articleTitle: 'How I fixed a bug',
+      reason: 'not-a-reason',
+    })!.message;
+
+    expect(message).toBe('Your article "How I fixed a bug" has been unpublished.');
   });
 });

--- a/src/server/common/moderation-helpers.ts
+++ b/src/server/common/moderation-helpers.ts
@@ -114,9 +114,10 @@ export type UnpublishReason = keyof typeof unpublishReasons;
 /**
  * The reasons a moderator may unpublish an ARTICLE, with copy addressed to an article's author.
  *
- * Deliberately a subset. Every omitted reason describes an uploaded resource rather than a piece of
- * writing — its files, versions or example images, what it does when it is run, or why it was uploaded
- * as a model — and none of those is a thing an article can be.
+ * Deliberately a subset. The omitted reasons describe an uploaded resource rather than a piece of
+ * writing — its files, its versions, where its example images came from, or what it does when it is
+ * run. `no-posts` is the exception: never offered, but stored on live articles, so
+ * `legacyArticleUnpublishReasons` below carries article wording for it.
  *
  * The declaration order is the picker's order: policy reasons, then the two quality ones, then `other`.
  * Grouping them means a misclick between neighbours can only swap two reasons that say roughly the same
@@ -171,6 +172,12 @@ export const articleUnpublishReasons = {
       'Spam, or advertisements disguised as articles, are strictly prohibited under our Terms of Service.',
     type: 'policy',
   },
+  'unintenteded-use': {
+    optionLabel: 'Unintended site use',
+    notificationMessage:
+      'Articles must be genuine written content intended for the community. Articles published solely for testing are prohibited.',
+    type: 'policy',
+  },
   'insufficient-description': {
     optionLabel: 'Insufficient content',
     notificationMessage:
@@ -193,6 +200,20 @@ export const articleUnpublishReasons = {
 export type ArticleUnpublishReason = keyof typeof articleUnpublishReasons;
 
 /**
+ * Reason keys stored on live articles that the picker no longer offers, worded for an article's
+ * author. Resolving these against `unpublishReasons` instead is what put "Your model does not
+ * include example images" on an article page in production.
+ */
+export const legacyArticleUnpublishReasons = {
+  'no-posts': {
+    optionLabel: 'Missing images',
+    notificationMessage:
+      "Your article's images are missing, or were removed for violating our Terms of Service. Please add images that adhere to our guidelines.",
+    type: 'quality',
+  },
+} as const satisfies Partial<Record<UnpublishReason, UnpublishReasonDetail>>;
+
+/**
  * `Object.hasOwn`, not a bare index: these are plain objects, so a reason like 'constructor' or
  * 'toString' resolves off `Object.prototype` and `??` does not reject the function it returns.
  */
@@ -207,11 +228,10 @@ export function getUnpublishReason(reason: string): UnpublishReasonDetail | unde
   return lookupReason(unpublishReasons, reason);
 }
 
-export function isArticleUnpublishReason(reason: string): reason is ArticleUnpublishReason {
-  return Object.hasOwn(articleUnpublishReasons, reason);
-}
-
-/** Articles unpublished before this list existed store model-list reason keys, so fall back to that copy. */
+/** Never falls back to `unpublishReasons` — everything it returns is safe to show an article's author. */
 export function getArticleUnpublishReason(reason: string): UnpublishReasonDetail | undefined {
-  return lookupReason(articleUnpublishReasons, reason) ?? lookupReason(unpublishReasons, reason);
+  return (
+    lookupReason(articleUnpublishReasons, reason) ??
+    lookupReason(legacyArticleUnpublishReasons, reason)
+  );
 }

--- a/src/server/notifications/article-unpublish.notifications.ts
+++ b/src/server/notifications/article-unpublish.notifications.ts
@@ -7,20 +7,21 @@ export const articleUnpublishNotifications = createNotificationProcessor({
     displayName: 'Article unpublished',
     category: NotificationCategory.System,
     toggleable: false,
-    prepareMessage: ({ details }) =>
-      details
-        ? {
-            message:
-              details.reason !== 'other'
-                ? `Your article "${details.articleTitle}" has been unpublished: ${
-                    getArticleUnpublishReason(details.reason)?.notificationMessage ?? ''
-                  }`
-                : `Your article "${details.articleTitle}" has been unpublished: ${
-                    details.customMessage ?? ''
-                  }`,
-            url: `/articles/${details.articleId}`,
-          }
-        : undefined,
+    prepareMessage: ({ details }) => {
+      if (!details) return undefined;
+
+      const reasonCopy =
+        details.reason !== 'other'
+          ? getArticleUnpublishReason(details.reason)?.notificationMessage
+          : details.customMessage;
+
+      return {
+        message: reasonCopy
+          ? `Your article "${details.articleTitle}" has been unpublished: ${reasonCopy}`
+          : `Your article "${details.articleTitle}" has been unpublished.`,
+        url: `/articles/${details.articleId}`,
+      };
+    },
     prepareQuery: ({ lastSent }) => `
       WITH unpublished AS (
         SELECT DISTINCT


### PR DESCRIPTION
Follow-up to #4564. That PR fixed the article take-down banner's heading but left the **body** falling back to the model reason list, so model vocabulary was still reaching article authors in production.

### The bug

[civitai.com/articles/31595](https://civitai.com/articles/31595) stores `unpublishedReason: "no-posts"` — a model-only key. `getArticleUnpublishReason` fell back to `unpublishReasons`, so the banner told the author:

> Your model does not include example images, or the provided images were removed for violating our Terms of Service. Please upload new example images that adhere to our guidelines.

The heading was already correct, which is how you can tell #4564 itself deployed fine — this is the fallback it shipped on purpose.

Seven live articles hit it: `no-posts` on one, `unintenteded-use` on six. `unintenteded-use` was in active moderator use until two days before #4564 merged, which dropped it from the picker.

### Changes

- **`unintenteded-use` back in `articleUnpublishReasons`**, with article wording. Moderators keep the option; the six rows read correctly.
- **New `legacyArticleUnpublishReasons`** carrying `no-posts`. Article wording that renders on the existing row but is never offered, since an article has no posts to be missing.
- **Model-map fallback removed.** `getArticleUnpublishReason` now only ever returns copy written for an article's author, so a caller can render whatever it gets without a guard — which is what `isArticleUnpublishReason` existed to be, and it goes.

All twelve reason keys stored on live articles now resolve to article wording.

### Two defects in the same banner, found while confirming that

- **`isPolicy` was `detail?.type !== 'quality'`**, so a key with no entry was headed *"unpublished due to a Terms of Service violation"* on the strength of having no entry. Inverted to `=== 'policy'`; a key with no copy now gets a neutral heading and a neutral body.
- **The moderator's note rendered for every reason**, not just `other` — the invariant `ModelUnpublishedAlert` already holds. It was showing on two live articles. Now gated, and the modal labels the field **"Reason (internal)"** unless the reason is `other`, since moderators were never told the note stops at the banner.

### Verification

| check | result |
|---|---|
| `pnpm run typecheck` | 0 errors |
| `pnpm run test:unit:run` | 24,782 passed / 0 failed |
| `ArticleUnpublishedAlert.browser.test.tsx` | 6/6 |
| prod reason-key coverage | 12/12 stored keys resolve to article wording |

Revert-checked rather than assumed. Restoring the model fallback fails two unit tests printing the exact model sentence. For the browser test, the first attempt failed at **14997 ms** — an `expect.element` poll timing out, not an assertion — so the discriminating checks were moved to synchronous `.elements()` reads after a single both-variant `await`. The same mutation now fails at **123 ms** with `expected [] to have a length of 1`.

### Deliberately not in this PR

Two findings, both worth their own change:

- **`other` heads 64 live articles as a ToS violation.** `other` is `type: 'policy'`, so every one of those banners asserts a violation regardless of the note beside it; a keyword pass matches only ~9 of 64. Same bug class, 8x the rows, but it's a copy/policy call.
- **`ModelUnpublishedAlert.tsx:19` has the identical accuse-by-default.** Latent — no live model rows reach it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hbyPW1XDB6HV3U8wXLXYf
