### PR TITLE
fix(stickers): stop the draft editor chrome rotating onto the sticker

### DIFF
--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -797,7 +797,10 @@ describe('the pack purchase key across one session', () => {
 describe('the clearance reaches the element', () => {
   const sizeArtwork = () => {
     const style = document.createElement('style');
-    // 120px square, so the sticker has a height for the knob term to scale off.
+    // Gives the artwork a size so the draft has a height at all. It is NOT the
+    // height the standoff is derived from — the root measures taller, and by how
+    // much varies with the machine — so the test pins that separately below
+    // rather than trusting this number.
     style.textContent = '.sticker-sized img { width: 120px !important; height: 120px !important; }';
     document.head.appendChild(style);
     return () => style.remove();
@@ -839,9 +842,16 @@ describe('the clearance reaches the element', () => {
       const upright = await renderAt(0);
       await expect.poll(() => upright.style.marginTop).not.toBe('');
 
-      // On the side it is actually on. The swap mutant reddens here.
-      expect(upright.style.marginBottom).toBe('');
       expect(parseFloat(upright.style.marginTop)).toBeGreaterThan(0);
+
+      // The precondition the inequality below rests on, pinned rather than
+      // assumed: the knob term only exceeds the handle outset once the sticker
+      // is taller than HANDLE_OUTSET / KNOB_OFFSET. Under that, both angles give
+      // the same standoff and the comparison fails against correct code. The
+      // injected rule sizes the artwork; the root ends up taller still, so this
+      // reads the number the code actually used rather than the one in the CSS.
+      const root = upright.parentElement as HTMLElement;
+      expect(root.offsetHeight).toBeGreaterThan(6 / 0.22);
 
       const turned = await renderAt(180);
       await expect.poll(() => turned.style.marginTop).not.toBe('');
@@ -858,3 +868,39 @@ describe('the clearance reaches the element', () => {
     }
   });
 });
+
+/**
+ * The two halves of `measure` that shipped unproven, and were each shown green
+ * under a mutation that deleted them.
+ *
+ * Neither can be reached by rendering a draft in isolation: the flipped arm
+ * needs an obstacle to flip away from, and the zero-size guard needs a sticker
+ * that HAD a size and then lost it. Both are set up here rather than asserted
+ * into existence.
+ */
+
+/**
+ * 🔴 TWO HALVES OF `measure` SHIP UNPROVEN. Both were measured as uncovered —
+ * each can be deleted with every test in this file still green — and an attempt
+ * to cover them was made and abandoned rather than faked.
+ *
+ * **The flipped arm.** `flipped` is never true here: with no tray and no
+ * clipping ancestor `shouldFlipPlaceButton` always answers false, so
+ * `marginBottom: above` is written by nothing. Seeding a tray does not help,
+ * because the harness lays the container out near the top of the viewport and
+ * the ABOVE candidate then lands at a negative y, which the function rejects
+ * outright. Pushing the container down the page moves the candidate from -305
+ * to +155 and the flip still does not fire, for a reason not established.
+ *
+ * **The zero-size guard.** A test that renders a sized draft, takes its height
+ * away and asserts the standoff is held was written and DELETED: it passed with
+ * the guard removed. The `ResizeObserver` does not deliver a re-measure inside
+ * the test's window, so the assertion observed a value nothing had recomputed —
+ * coverage in appearance only.
+ *
+ * Do not close either gap by asserting something weaker about the side that
+ * already works. A green test over the unflipped arm is worse than the gap,
+ * because it reads as coverage. What would actually close them is a harness
+ * that positions the draft in a viewport-realistic place and a deterministic
+ * way to drive a second measure.
+ */

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -8,7 +8,6 @@ import type * as Trpc from '~/utils/trpc';
 import { renderWithProviders } from '../../../test/component-setup';
 import { resolveTreatment } from '~/components/Sticker/treatments/sticker-treatments';
 import { stickerArtworkStyle } from '~/components/Sticker/placement-appearance';
-import { PANEL_LEFT_CONTROLS } from '~/components/Sticker/place-button-position';
 import type { StickerDraft } from '~/store/sticker-placement-draft.store';
 import { useStickerPlacementDraftStore } from '~/store/sticker-placement-draft.store';
 
@@ -168,7 +167,7 @@ const renderDraft = async (
  * through the ordinary locator with its full actionability check.
  *
  * (A locator click on the stub does not succeed in this harness: the cluster is
- * absolutely positioned inside the rotated draft, and the measured failure was a
+ * absolutely positioned inside the draft, and the measured failure was a
  * negative **x**. Nothing in the component moves it horizontally —
  * `shouldFlipPlaceButton` is vertical only, as `DraftSticker.tsx` says where it is
  * used — so the flip is not the cause. Beyond that the mechanism is unestablished,
@@ -348,107 +347,114 @@ describe('the free option is a price, not a process', () => {
 });
 
 /**
- * The note and the payout line are the two pieces of PROSE in the draft's chrome,
- * and every one of its children is inside the element carrying `rotate(...)` —
- * so without a counter-rotation a sticker turned any distance leaves both of them
- * sideways, and at a half turn upside down. Placed stickers already counter-rotate
- * their marks; this is the draft's half.
+ * 🔴 THE FIX, AS A CLAIM ABOUT THE DOM. The rotation lives on an inner element
+ * and the chrome is that element's SIBLING, so nothing can turn the toolbar, the
+ * note or the payout line — and, more to the point, nothing can swing the point
+ * they are anchored to across the artwork.
  *
- * The fixture sits at 15 degrees, so the assertion is a specific angle rather
- * than "some transform": a counter-rotation by the wrong sign is the failure that
- * looks most like a fix.
+ * The previous shape held them level with a counter-rotation while leaving them
+ * inside the rotated element. That reads the same at a glance and is not the
+ * same thing: they were still anchored to the sticker's rotated bottom edge, so
+ * past about a quarter turn the anchor came round over the artwork and the
+ * upright cluster painted on top of the sticker being edited. A counter-rotation
+ * fixes which way up something reads; it does not move where it lands.
+ *
+ * So this asserts CONTAINMENT and the absence of any rotation in the chain,
+ * rather than an angle. An angle assertion passes against the shape that had the
+ * bug.
+ *
+ * Structural on purpose: component tests load no stylesheet, so any position or
+ * width measured in this harness is a lie.
  */
-describe('the note and the payout caption stay upright', () => {
-  test('counter-rotates by exactly the sticker angle', async () => {
-    await renderDraft(null, { ownerShare: 1 });
+describe('the editing chrome is outside the rotation', () => {
+  const rotatedElement = () =>
+    [...document.querySelectorAll<HTMLElement>('[style*="rotate"]')].find((element) =>
+      element.style.transform.includes('rotate(')
+    );
 
-    const note = (await page.getByRole('button', { name: /Add a note/ }).element()) as HTMLElement;
-    const caption = (await page.getByText(/proceeds go to/).element()) as HTMLElement;
-    // Anchored on the CAPTION, so both containment checks below are real. Taking
-    // the cluster from `note.closest(...)` made the note's own check true by
-    // construction — the anchor moves with the element, so a note relocated out
-    // of the cluster still "contains" itself in whatever its new home is.
-    const cluster = caption.closest<HTMLElement>('.w-max');
+  // The negative control for the pair below: both would pass against a component
+  // that had no rotation anywhere, and `draft.rotation` is a fixture anyone may
+  // edit.
+  test('the sticker really is rotated', async () => {
+    await renderDraft(null);
 
-    expect(cluster?.style.transform).toBe('translateX(-50%) rotate(-15deg)');
-    expect(cluster?.contains(note)).toBe(true);
-    expect(cluster?.contains(caption)).toBe(true);
+    expect(rotatedElement()?.style.transform).toContain('rotate(15deg)');
   });
 
-  /**
-   * 🔴 BOTH HALVES OF THE MECHANISM, because either one alone is a real bug.
-   *
-   * The first version of this counter-rotation wrote the individual `rotate`
-   * property and left the Tailwind `-translate-x-1/2` class in place, on the
-   * reasoning that the two compose. They do — as `translate · rotate · scale ·
-   * transform` — so the class's `transform` applies first and the element then
-   * orbits its already-shifted box. Measured in Chromium on a 200px cluster:
-   * 29px right and 71px down at 45 degrees, and a full cluster width to the side
-   * at 180. The other way to get it wrong is to write the combined transform and
-   * FORGET to drop the class, which doubles the centring.
-   *
-   * So: one `transform` carrying both, and no translate class beside it.
-   *
-   * ⚠️ A STRUCTURAL PIN, NOT A MEASUREMENT, and deliberately. The honest check is
-   * where the cluster's box actually lands, and this harness cannot give it: a
-   * rotated draft renders at negative coordinates outside the iframe (the note
-   * on `renderDraft` above records the same problem for clicks), so the rects
-   * come back describing a layout nobody would see. A geometric assertion here
-   * would be measuring the harness. The displacement was confirmed in a real
-   * browser instead; this holds the shape that fix depends on.
-   */
-  test('carries the centring and the counter-rotation in one transform', async () => {
+  test('the cluster is not a descendant of the rotated element', async () => {
+    await renderDraft(null, { ownerShare: 1 });
+
+    const caption = (await page.getByText(/proceeds go to/).element()) as HTMLElement;
+    // Anchored on the CAPTION rather than on the cluster, so the containment
+    // check below is about a real child: taking the cluster from an element that
+    // moved out of it would make its own membership true by construction.
+    const cluster = caption.closest<HTMLElement>('.w-max') as HTMLElement;
+    const rotated = rotatedElement() as HTMLElement;
+
+    expect(rotated.contains(cluster)).toBe(false);
+    expect(cluster.contains(caption)).toBe(true);
+  });
+
+  test('no element between the cluster and the media box rotates', async () => {
     await renderDraft(null, { ownerShare: 1 });
 
     const caption = (await page.getByText(/proceeds go to/).element()) as HTMLElement;
     const cluster = caption.closest<HTMLElement>('.w-max') as HTMLElement;
 
-    expect(cluster.style.transform).toBe('translateX(-50%) rotate(-15deg)');
-    // The class would compose with the inline transform and centre it twice.
-    expect(cluster.className).not.toContain('-translate-x-1/2');
-  });
+    const rotations: string[] = [];
+    for (
+      let node: HTMLElement | null = cluster;
+      node && node !== document.body;
+      node = node.parentElement
+    ) {
+      if (node.style.transform.includes('rotate(')) rotations.push(node.style.transform);
+    }
 
-  // The negative control for the pair above: they would both pass against a
-  // component that counter-rotated nothing if the sticker itself were never
-  // rotated, and `draft.rotation` is a fixture anyone may edit.
-  test('the sticker it sits in really is rotated', async () => {
-    await renderDraft(null);
-
-    const note = (await page.getByRole('button', { name: /Add a note/ }).element()) as HTMLElement;
-    const root = note.closest<HTMLElement>('.cursor-move');
-
-    expect(root?.style.transform).toContain('rotate(15deg)');
+    // Names what it found, so putting the chrome back inside the rotation fails
+    // with the offending transform rather than with a bare boolean.
+    expect(rotations).toEqual([]);
   });
 });
 
 /**
- * The left panel's width is what `STICKER_PANEL_MIN_WIDTH_PX` is derived from,
- * and the bug this PR fixed was that derivation going stale: Copy joined the
- * panel as a third icon and the constant stayed at the width computed for two,
- * so the panel painted over the rotate knob on a whole band of sticker widths.
+ * One toolbar, under the sticker, holding everything.
  *
- * The constant now moves with `PANEL_LEFT_CONTROLS`, but nothing tied that to
- * the JSX — a fourth control could be added and every test stay green while the
- * panel ate the knob again. This is that tie. It COUNTS rather than measures,
- * deliberately: component tests load no stylesheet, so every Tailwind width in
- * this environment is a lie and a measured assertion here would be worse than
- * none.
+ * It used to be two pills bracketing the sticker's top corners, which is where
+ * this ticket came from: children of the rotated element, so they turned with
+ * the sticker onto the artwork; a fixed band while everything else up there
+ * scales with the sticker, so on a small draft they converged on the rotate knob
+ * and on each other; and keeping the buy button clear of them needed a second
+ * derived offset that went stale the first time a control was added to one.
+ *
+ * 🔴 If you are about to split these back into two panels for the reason the old
+ * comment gave — that Delete should not sit a thumb's width from the controls
+ * you press while arranging — that was weighed and Justin chose one bar on
+ * 2026-09-02. Move Delete within the bar; do not put it back on the sticker.
+ *
+ * COUNTS AND GROUPS, never measures: no stylesheet loads here.
  */
-describe('the left control panel', () => {
-  test('holds exactly the number of controls the width constant assumes', async () => {
+describe('the control toolbar', () => {
+  const CONTROLS = [
+    'Duplicate this sticker',
+    'Flip this sticker',
+    "Set this sticker's opacity",
+    'Remove this sticker',
+  ];
+
+  test('holds every control in one bar, and that bar is in the cluster', async () => {
+    // Rendered directly rather than through `renderDraft`, which supplies no
+    // `onDuplicate` — without a handler that control is deliberately absent, and
+    // this is the test that says all four live together.
     renderWithProviders(
-      // Wide enough that the panels are drawn against the sticker's own edges at
-      // all: below STICKER_PANEL_MIN_WIDTH_PX the controls move into the buy
-      // cluster and there is no panel to count. 0.6 of 400 is 240.
-      <div style={{ position: 'relative', width: 400, height: 600 }}>
+      <div style={{ position: 'relative', width: 380, height: 600 }}>
         <DraftSticker
-          draft={{ ...draft, scale: 0.6 }}
+          draft={draft}
           art={art}
           selected
           dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
           price={PRICE}
           freeOffer={null}
-          ownerShare={undefined}
+          ownerShare={1}
           ownerUsername="creator"
           onGesture={() => true}
           onDuplicate={() => null}
@@ -456,16 +462,30 @@ describe('the left control panel', () => {
       </div>
     );
 
-    await expect
-      .element(page.getByRole('button', { name: 'Duplicate this sticker' }))
-      .toBeInTheDocument();
+    // `element()` does not poll, so the render has to be awaited on a matcher
+    // first or every lookup below races the first paint.
+    await expect.element(page.getByRole('button', { name: CONTROLS[0] })).toBeInTheDocument();
 
-    const left = document.querySelector('[data-left-panel]');
+    const buttons = await Promise.all(
+      CONTROLS.map(
+        async (name) => (await page.getByRole('button', { name }).element()) as HTMLElement
+      )
+    );
 
-    // Present at all, so a panel that stopped being drawn reads as a failure
-    // here rather than as a count of zero matching a constant somebody zeroed.
-    expect(left).not.toBeNull();
-    expect(left?.querySelectorAll('button').length).toBe(PANEL_LEFT_CONTROLS);
+    // Present at all, so a control that stopped being rendered fails here rather
+    // than passing as an empty set that trivially shares a parent.
+    expect(buttons).toHaveLength(CONTROLS.length);
+
+    const bars = new Set(buttons.map((button) => button.closest('.rounded-full.bg-dark-7')));
+    expect(bars.size).toBe(1);
+
+    const caption = (await page.getByText(/proceeds go to/).element()) as HTMLElement;
+    const cluster = caption.closest<HTMLElement>('.w-max') as HTMLElement;
+    const [bar] = [...bars] as HTMLElement[];
+
+    expect(cluster.contains(bar)).toBe(true);
+    // First in the cluster, so it is the part nearest the sticker it acts on.
+    expect(cluster.firstElementChild).toBe(bar);
   });
 });
 
@@ -531,14 +551,10 @@ const removeIsSiblingOfDuplicate = async () => {
 
 describe('the duplicate control', () => {
   /**
-   * ⚠️ THE NARROW FIXTURE PUTS THE CONTROL IN THE BUY CLUSTER, NOT THE PILL.
-   *
-   * `panelsInside` needs the sticker to be at least 124px wide; the shared
-   * fixture is 0.25 of a 380px container, so 95px — the controls go to the buy
-   * cluster, which this file documents as landing at a negative x here. That is
-   * why this one is pressed through the DOM. The test below covers the pill
-   * branch with a wide draft and an ordinary locator click, so both render paths
-   * are exercised rather than one being described and neither checked.
+   * ⚠️ Pressed through the DOM: the whole draft renders at negative
+   * coordinates in this harness — measured at x = -73 for this control — so no
+   * locator click lands, and a passing "it is clickable" test would be a
+   * fiction.
    */
   test('asks the host for another copy, and places nothing', async () => {
     const duplicated: string[] = [];
@@ -568,8 +584,8 @@ describe('the duplicate control', () => {
     ((await locator.element()) as HTMLElement).click();
 
     expect(duplicated).toEqual([draft.id]);
-    // Pins WHICH branch this covers: at 95px the controls are in the buy
-    // cluster, where remove sits beside duplicate.
+    // One toolbar at every size, so remove is duplicate's sibling here and at
+    // any other scale. Two containers means the corner pills are back.
     expect(await removeIsSiblingOfDuplicate()).toBe(true);
     // 🔴 The half that matters for money: duplicating must not reach the
     // placement mutation.
@@ -580,49 +596,6 @@ describe('the duplicate control', () => {
     // mock would certify "charges nothing" forever.
     await pressPaid();
     expect(placed).toHaveLength(1);
-  });
-
-  /**
-   * The OTHER render path. Below 124px of sticker width the controls go to the
-   * buy cluster; above it they go to the pill. Both have to actually render the
-   * duplicate control, and only one of them was being exercised — deleting
-   * `{duplicateControl}` from the pill left every test green.
-   *
-   * ⚠️ What this does NOT assert is reachability. Measured in this harness, the
-   * control sits at x = -95 in the pill branch and x = -73 in the cluster
-   * branch: the whole draft renders at negative coordinates here, so no locator
-   * click succeeds on either path and a passing "it is clickable" test would be
-   * a fiction. Presence is what this harness can honestly check.
-   */
-  test('renders in the pill branch as well as the buy cluster', async () => {
-    renderWithProviders(
-      <div style={{ position: 'relative', width: 380, height: 600 }}>
-        <DraftSticker
-          // 0.5 of 380 is 190px, past the 124px threshold, so the controls sit
-          // in the pill above the sticker rather than in the buy cluster.
-          draft={{ ...draft, scale: 0.5, y: 0.5 }}
-          art={art}
-          selected
-          dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
-          price={PRICE}
-          freeOffer={null}
-          ownerShare={undefined}
-          ownerUsername="creator"
-          onGesture={() => true}
-          onDuplicate={() => null}
-        />
-      </div>
-    );
-
-    await expect
-      .element(page.getByRole('button', { name: 'Duplicate this sticker' }))
-      .toBeInTheDocument();
-
-    // 🔴 The assertion that makes this a DIFFERENT test rather than a second
-    // copy of the one above. Both branches render a button of the same name, so
-    // presence alone is satisfied by the cluster; the pill keeps remove in its
-    // own container.
-    expect(await removeIsSiblingOfDuplicate()).toBe(false);
   });
 
   /**

--- a/src/components/Sticker/DraftSticker.browser.test.tsx
+++ b/src/components/Sticker/DraftSticker.browser.test.tsx
@@ -775,3 +775,86 @@ describe('the pack purchase key across one session', () => {
     );
   });
 });
+
+/**
+ * 🔴 THE JOIN BETWEEN THE ARITHMETIC AND THE DOM.
+ *
+ * `chromeClearance` is proven as a pure function in its own suite, and the
+ * describes above prove the tree shape. Neither sees the wire between them:
+ * swapping `marginTop` and `marginBottom` at the call site, or deleting the
+ * margins outright, left every one of those tests green while the toolbar sat
+ * on the artwork. That gap is the actual ticket, so it gets its own case.
+ *
+ * ⚠️ THIS TEST INJECTS A STYLESHEET, AND THAT IS THE POINT. Component tests here
+ * load none, so `EdgeImage` has no intrinsic size, the draft measures 0 tall,
+ * and `measure` correctly refuses to derive anything from it — no margin is ever
+ * written. One rule giving the artwork a size is what makes the layout real
+ * enough to answer the question.
+ *
+ * It still asserts a RELATIONSHIP, never a pixel count: the absolute numbers
+ * depend on the injected rule, the comparison does not.
+ */
+describe('the clearance reaches the element', () => {
+  const sizeArtwork = () => {
+    const style = document.createElement('style');
+    // 120px square, so the sticker has a height for the knob term to scale off.
+    style.textContent = '.sticker-sized img { width: 120px !important; height: 120px !important; }';
+    document.head.appendChild(style);
+    return () => style.remove();
+  };
+
+  const renderAt = async (rotation: number) => {
+    renderWithProviders(
+      <div className="sticker-sized" style={{ position: 'relative', width: 380, height: 600 }}>
+        <DraftSticker
+          draft={{ ...draft, rotation, y: 0.4 }}
+          art={art}
+          selected
+          dressed={resolveTreatment({ treatment: 'none', surface: 'detail', isPending: false })}
+          price={PRICE}
+          freeOffer={null}
+          ownerShare={undefined}
+          ownerUsername="creator"
+          onGesture={() => true}
+          onDuplicate={() => null}
+        />
+      </div>
+    );
+
+    // `.last()`, because this test renders twice and the harness only cleans up
+    // between tests — the second render leaves both drafts mounted, and a bare
+    // locator is a strict-mode violation rather than the newest one.
+    // `element()` does not poll either, so the render has to be awaited on a
+    // matcher first or the lookup below races the first paint.
+    const locator = page.getByRole('button', { name: 'Remove this sticker' }).last();
+    await expect.element(locator).toBeInTheDocument();
+
+    const remove = (await locator.element()) as HTMLElement;
+    return remove.closest<HTMLElement>('.w-max') as HTMLElement;
+  };
+
+  test('puts the standoff on the side the cluster is on, and scales it with the sticker', async () => {
+    const cleanup = sizeArtwork();
+    try {
+      const upright = await renderAt(0);
+      await expect.poll(() => upright.style.marginTop).not.toBe('');
+
+      // On the side it is actually on. The swap mutant reddens here.
+      expect(upright.style.marginBottom).toBe('');
+      expect(parseFloat(upright.style.marginTop)).toBeGreaterThan(0);
+
+      const turned = await renderAt(180);
+      await expect.poll(() => turned.style.marginTop).not.toBe('');
+
+      // 🔴 A RELATIONSHIP, NOT A MEASUREMENT. At half a turn the rotate knob
+      // hangs BELOW the sticker on screen, so the below-standoff has to grow
+      // from clearing the handles to clearing the knob. A constant offset — the
+      // thing this ticket forbids — gives the same number at both angles.
+      expect(parseFloat(turned.style.marginTop)).toBeGreaterThan(
+        parseFloat(upright.style.marginTop)
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -25,9 +25,7 @@ import type { Gesture, StartGesture } from '~/components/Sticker/draft-gesture';
 import { KNOB_OFFSET, rotate } from '~/components/Sticker/draft-gesture';
 import {
   candidateDistance,
-  flippedButtonOffset,
-  panelBandFor,
-  panelsFitInsideEdges,
+  chromeClearance,
   placeButtonBoxes,
   shouldFlipPlaceButton,
 } from '~/components/Sticker/place-button-position';
@@ -68,8 +66,15 @@ const BUY_BUTTON_MIN_WIDTH = 132;
  */
 const NOTE_WIDTH = 220;
 
-/** `mt-2`, in pixels, and the clearance the flipped side is built from. */
+/** Clear air between the sticker and the chrome, on whichever side it lands. */
 const BUY_BUTTON_GAP = 8;
+
+/**
+ * How far the corner handles stick out past the sticker's own box: `size-3` at
+ * `-1.5`, so 6px on every side. Part of what the chrome has to clear — a
+ * clearance measured to the artwork's edge puts the toolbar on the handles.
+ */
+const HANDLE_OUTSET = 6;
 
 /**
  * The nearest ancestor that clips — the carousel's viewport on the image detail
@@ -303,19 +308,13 @@ export function DraftSticker({
   const rootRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
 
-  // Both the tray and the carousel's clipped viewport can swallow the button, so
-  // it moves above the sticker when that is the better of the two positions.
-  // `panelsInside` rides along because it is decided from the same measurement:
-  // the panels sit against the sticker's edges while there is room for them
-  // there, and a narrower draft hands its controls to the buy cluster instead.
-  const [{ flipped, flippedOffset, panelsInside }, setPosition] = useState({
+  // Both the tray and the carousel's clipped viewport can swallow the cluster,
+  // so it moves above the sticker when that is the better of the two positions.
+  // The two standoffs ride along because they come from the same measurement.
+  const [{ flipped, below, above }, setPosition] = useState({
     flipped: false,
-    flippedOffset: 0,
-    // Starts false, which puts the controls in the buy cluster — the layout
-    // that is correct at any size. The real value lands from the layout effect
-    // before paint, so this is never seen; it is the safe direction to be wrong
-    // in if that ever stops being true.
-    panelsInside: false,
+    below: 0,
+    above: 0,
   });
   const trayElement = useStickerPlacementDraftStore((state) => state.tray);
 
@@ -335,53 +334,51 @@ export function DraftSticker({
 
     const { flipped, rotation } = frame.current;
     const tray = useStickerPlacementDraftStore.getState().tray;
+    // Layout size, not the bounding box. This element no longer rotates — the
+    // artwork inside it does — so its own box is the sticker's unrotated one,
+    // which is what the chrome is laid out against and what the clearance turns
+    // into the rotated extent.
     const height = element.offsetHeight;
-    // Layout size, not the bounding box: `offsetWidth` ignores the CSS rotation,
-    // and the panels are children of the rotated element — they are laid out
-    // against the sticker's own width whatever angle it is at.
     const width = element.offsetWidth;
-    const offset = flippedButtonOffset({
-      stickerHeight: height,
+    const clearance = chromeClearance({
+      width,
+      height,
+      rotation,
       knobOffset: KNOB_OFFSET,
+      outset: HANDLE_OUTSET,
       gap: BUY_BUTTON_GAP,
-      // The panels are the other thing above the sticker, and the only one that
-      // does not scale with it — and on a narrow draft they are not drawn at
-      // all, so there is nothing there to clear. Clearing a band that is not
-      // there only costs the button a flip it could have taken.
-      panelBand: panelBandFor(width),
     });
-    // From the button's own measured rect, both times: the pair that comes out
-    // is the same whichever side the button is currently on, which is what stops
-    // a flip from removing its own cause and oscillating.
-    const { below, above } = placeButtonBoxes({
+    // From the cluster's own measured rect, both times: the pair that comes out
+    // is the same whichever side it is currently on, which is what stops a flip
+    // from removing its own cause and oscillating.
+    const boxes = placeButtonBoxes({
       current: button.getBoundingClientRect(),
       flipped,
-      rotationDeg: rotation,
       distance: candidateDistance({
-        stickerHeight: height,
-        buttonHeight: button.offsetHeight,
-        flippedOffset: offset,
-        gap: BUY_BUTTON_GAP,
+        height,
+        clusterHeight: button.offsetHeight,
+        below: clearance.below,
+        above: clearance.above,
       }),
     });
 
     const next = {
       flipped: shouldFlipPlaceButton({
-        below,
-        above,
+        below: boxes.below,
+        above: boxes.above,
         tray: tray?.getBoundingClientRect() ?? null,
         clip: clip.current?.getBoundingClientRect() ?? null,
       }),
-      flippedOffset: offset,
-      panelsInside: panelsFitInsideEdges(width),
+      below: clearance.below,
+      above: clearance.above,
     };
 
     // Every pointer move re-measures, so bail on an unchanged result rather
     // than handing React a new object to re-render for.
     setPosition((current) =>
       current.flipped === next.flipped &&
-      current.flippedOffset === next.flippedOffset &&
-      current.panelsInside === next.panelsInside
+      current.below === next.below &&
+      current.above === next.above
         ? current
         : next
     );
@@ -439,14 +436,9 @@ export function DraftSticker({
   // The cheap half, and the only one a gesture reaches: rect and offset reads,
   // no style recalc. Which ancestor clips is a property of the tree, not of the
   // sticker's own transform, so none of these deps can change it.
-  //
-  // `panelsInside` is in here because it moves the controls between the panels
-  // and the cluster, which changes the cluster's height — an input to the flip
-  // decision. The ResizeObserver would catch it a beat later; this measures on
-  // the same commit that moved them.
   useLayoutEffect(() => {
     measure();
-  }, [measure, draft.x, draft.y, draft.scale, draft.rotation, flipped, panelsInside]);
+  }, [measure, draft.x, draft.y, draft.scale, draft.rotation, flipped]);
 
   const begin =
     (mode: Gesture['mode'], corner?: { sx: number; sy: number }) => (event: React.PointerEvent) => {
@@ -511,9 +503,8 @@ export function DraftSticker({
       } else if (mode === 'resize' && corner) {
         const { bounds } = point;
         const width = draft.scale * bounds.width;
-        // Layout size, not the bounding box: `offsetWidth` ignores the CSS
-        // rotation, so this is the sticker's own aspect ratio rather than the
-        // ratio of the box its rotated form happens to occupy.
+        // `rootRef` is the unrotated frame, so this is the sticker's own aspect
+        // ratio rather than the ratio of the box its rotated form occupies.
         const aspect = element.offsetWidth / element.offsetHeight;
         const anchor = rotate(
           (-corner.sx * width) / 2,
@@ -570,33 +561,6 @@ export function DraftSticker({
       ...(note.trim() ? { comment: note } : {}),
     },
   });
-
-  /**
-   * Holds the caption cluster level while the artwork turns.
-   *
-   * Every child of the wrapper inherits its `rotate(...)`, so the note field,
-   * the payout line and the Buzz button all tilt with the sticker — a textarea
-   * at 40 degrees is awkward to read and worse to type into, and past a half
-   * turn the prose is upside down. The resize handles and the knob keep
-   * rotating: those belong to the box, and the caption is the part that reads
-   * wrong.
-   *
-   * 🔴 THE CENTRING AND THE ROTATION MUST BE ONE `transform`, IN THIS ORDER.
-   * The first version of this used the individual `rotate` property and left the
-   * Tailwind `-translate-x-1/2` class in place, on the reasoning that the two
-   * compose. They do compose — in the order `translate · rotate · scale ·
-   * transform` — so the class's `transform` applies FIRST and the element then
-   * orbits its already-shifted box about the original centre. Measured in
-   * Chromium on a 200px box: the painted centre moved 29px right and 71px down
-   * at 45 degrees, and at 180 degrees the cluster sits a full cluster width to
-   * the side of the sticker it belongs to. Offset is `w/2·(1-cos θ)` across and
-   * `w/2·sin θ` down.
-   *
-   * `offsetHeight` and the anchor are unaffected either way, so the flip
-   * geometry reads the same numbers — which is exactly why the wrong version was
-   * self-consistent about a wrong position rather than obviously broken.
-   */
-  const upright = `translateX(-50%)${draft.rotation ? ` rotate(${-draft.rotation}deg)` : ''}`;
 
   /**
    * A second copy of this sticker, already arranged.
@@ -715,107 +679,86 @@ export function DraftSticker({
   );
 
   return (
+    /**
+     * 🔴 THE ROTATION LIVES ON THE INNER ELEMENT, AND THAT IS THE WHOLE FIX.
+     *
+     * This outer box is the sticker's unrotated frame: it carries the position,
+     * the size and the stacking, and nothing else. Only the artwork and the
+     * handles that belong to the artwork's own box are inside the rotated child.
+     * The toolbar, the note, the payout caption and the Buzz button are its
+     * SIBLING, so no amount of rotation can reach them.
+     *
+     * They used to be inside it, held level by a counter-rotation. That is not
+     * the same thing: the cluster was still ANCHORED to the sticker's rotated
+     * bottom edge, so past about a quarter turn the anchor swung over the
+     * artwork and the upright cluster painted on top of the thing being edited.
+     * Un-rotating something anchored in a rotated frame fixes how it reads and
+     * not where it lands.
+     *
+     * Do not move the chrome back inside, and do not put the rotation back on
+     * this element — either one restores the bug.
+     */
     <div
       ref={rootRef}
-      className="pointer-events-auto absolute cursor-move"
+      className="pointer-events-none absolute"
       style={{
         left: `${draft.x * 100}%`,
         top: `${draft.y * 100}%`,
         width: `${draft.scale * 100}%`,
-        transform: `translate(-50%, -50%) rotate(${draft.rotation}deg)`,
-        touchAction: 'none',
+        transform: 'translate(-50%, -50%)',
         // Above the owner's pending controls (see placement-layers.ts).
         // Selection still decides between two drafts — close together they have
         // overlapping buy buttons, and the one just touched should be the one
         // the next click reaches.
         zIndex: selected ? DRAFT_STICKER_Z + 1 : DRAFT_STICKER_Z,
       }}
-      onPointerDown={begin('move')}
     >
-      {/* The wrapper's own transform makes it a stacking context, so a negative
-          z-index here stays behind the sticker without reaching behind the
-          artwork the sticker sits on. */}
-      {dressed.behind && (
+      <div
+        className="pointer-events-auto relative cursor-move"
+        style={{
+          transform: `rotate(${draft.rotation}deg)`,
+          touchAction: 'none',
+        }}
+        onPointerDown={begin('move')}
+      >
+        {/* The rotated wrapper's own transform makes it a stacking context, so a
+            negative z-index here stays behind the sticker without reaching
+            behind the artwork the sticker sits on. */}
+        {dressed.behind && (
+          <span
+            aria-hidden
+            className={dressed.behind.className}
+            style={{ zIndex: -1, ...dressed.behind.style, opacity: draft.opacity }}
+          />
+        )}
+
+        {/* Dressed exactly as it will be once bought. A draft drawn bare is a
+            preview of something else: the treatment changes the silhouette — a
+            die-cut edge and a plate both grow the sticker's apparent bounds — so
+            positioning against the undressed version means moving it again after
+            paying. */}
+        {dressed.animationClassName ? (
+          <div className={dressed.animationClassName}>{artworkImage}</div>
+        ) : (
+          artworkImage
+        )}
+
+        <span className="pointer-events-none absolute inset-0 border-2 border-dashed border-blue-5" />
+
+        {CORNERS.map((corner) => (
+          <span
+            key={corner.className}
+            onPointerDown={begin('resize', corner)}
+            className={`absolute size-3 rounded-full border-2 border-white bg-blue-5 ${corner.className}`}
+          />
+        ))}
+
         <span
-          aria-hidden
-          className={dressed.behind.className}
-          style={{ zIndex: -1, ...dressed.behind.style, opacity: draft.opacity }}
+          onPointerDown={begin('rotate')}
+          className="absolute left-1/2 size-4 -translate-x-1/2 cursor-grab rounded-full border-2 border-white bg-blue-5"
+          style={{ top: `-${KNOB_OFFSET * 100}%` }}
         />
-      )}
-
-      {/* Dressed exactly as it will be once bought. A draft drawn bare is a
-          preview of something else: the treatment changes the silhouette — a
-          die-cut edge and a plate both grow the sticker's apparent bounds — so
-          positioning against the undressed version means moving it again after
-          paying. */}
-      {dressed.animationClassName ? (
-        <div className={dressed.animationClassName}>{artworkImage}</div>
-      ) : (
-        artworkImage
-      )}
-
-      <span className="pointer-events-none absolute inset-0 border-2 border-dashed border-blue-5" />
-
-      {CORNERS.map((corner) => (
-        <span
-          key={corner.className}
-          onPointerDown={begin('resize', corner)}
-          className={`absolute size-3 rounded-full border-2 border-white bg-blue-5 ${corner.className}`}
-        />
-      ))}
-
-      <span
-        onPointerDown={begin('rotate')}
-        className="absolute left-1/2 size-4 -translate-x-1/2 cursor-grab rounded-full border-2 border-white bg-blue-5"
-        style={{ top: `-${KNOB_OFFSET * 100}%` }}
-      />
-
-      {/* Two panels, one per top corner, and the split is the point: removing
-          the draft throws work away, and it should not sit a thumb's width from
-          the two controls you press while arranging one.
-
-          Each is flush with its own edge and grows inward, so the pair reads as
-          bracketing the box. They clear the corner handles — all four resize, so
-          none can be spent on a button — and the buy button clears their band
-          through `flippedButtonOffset`. Dark rather than the handles' blue:
-          these act on the sticker, they are not part of positioning it.
-
-          Only while the sticker is wide enough to hold them. Every other piece
-          of chrome up here is a FRACTION of the sticker (the knob at
-          `KNOB_OFFSET` of the height, the flipped button derived from it) while
-          these are a fixed band, so on a small sticker all three converge: the
-          knob ends up under a panel and DELETE lands on opacity, because it
-          paints later. Narrow drafts hand their controls to the buy cluster
-          instead — the `!panelsInside` row inside `buttonRef` below. */}
-      {panelsInside && (
-        <>
-          {/* 🔴 Its width decides STICKER_PANEL_MIN_WIDTH_PX, which is what keeps
-              it off the rotate knob. Adding a control here without raising
-              PANEL_LEFT_CONTROLS in `place-button-position.ts` puts the panel
-              back over the knob on a new band of sticker widths — that is the
-              bug this file was fixed for. `data-left-panel` is what the browser
-              test counts to catch it. */}
-          <div
-            data-left-panel
-            className="absolute -top-9 left-0 flex cursor-auto items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
-            onPointerDown={pressPanel}
-          >
-            {duplicateControl}
-            {flipControl}
-            {opacityControl}
-          </div>
-
-          <div
-            // Padding equal on both axes, unlike the multi-icon panel beside it:
-            // a single icon in a pill sized `px`/`py` comes out wider than it is
-            // tall, so `rounded-full` reads as a lozenge rather than a circle.
-            className="absolute -top-9 right-0 flex cursor-auto items-center rounded-full bg-dark-7 p-0.5"
-            onPointerDown={pressPanel}
-          >
-            {removeControl}
-          </div>
-        </>
-      )}
+      </div>
 
       <div
         ref={buttonRef}
@@ -828,49 +771,45 @@ export function DraftSticker({
         // than the button, and a `w-max` box sized by whichever is longer leaves
         // the other one off-centre.
         className={clsx(
-          'absolute left-1/2 flex w-max cursor-auto flex-col items-center gap-1 whitespace-nowrap',
-          flipped ? 'bottom-full' : 'top-full mt-2'
+          'pointer-events-auto absolute left-1/2 flex w-max -translate-x-1/2 cursor-auto flex-col items-center gap-1 whitespace-nowrap',
+          flipped ? 'bottom-full' : 'top-full'
         )}
         style={{
-          // Not `-translate-x-1/2`: the centring has to share one `transform`
-          // with the counter-rotation. See `upright` above.
-          transform: upright,
           minWidth: BUY_BUTTON_MIN_WIDTH,
-          // Clears whichever obstacle is taller: the knob, which scales with the
-          // sticker, or the panel band, which does not. Below ~164px the
-          // constant wins, so this does NOT simply scale.
-          ...(flipped ? { marginBottom: flippedOffset } : null),
+          // The standoff from the sticker's own box out to the rotated artwork,
+          // the knob and the handles. Measured and derived — see
+          // `chromeClearance` — because no constant is right at both ends of the
+          // scale range or at both ends of the rotation range.
+          ...(flipped ? { marginBottom: above } : { marginTop: below }),
         }}
-        // The button is inside the draggable body, so without this every press
-        // on it would also start a move and the click would land mid-drag.
+        // Outside the rotated body but still inside the draft, and the layer
+        // starts a move from a press anywhere on it, so without this every press
+        // on the toolbar would also start a drag.
         onPointerDown={(event) => event.stopPropagation()}
       >
-        {/* Where a narrow draft's controls live, rather than a second position
-            for the panels above it.
+        {/* Every control, in one bar, always underneath — the arrangement Justin
+            asked for on 2026-09-02, replacing two pills bracketing the sticker's
+            top corners.
 
-            Anything anchored to a small sticker's own box is in trouble twice
-            over: inside it, the panels reach past each other and the knob;
-            outside it, they hang off the sticker and the carousel's viewport
-            clips them away near the image edges — which on a phone-width media
-            box is most of the frame, because almost every draft there is narrow.
-            This cluster is the one piece of chrome that already knows where it
-            is on screen: it measures itself against the tray and the clipping
-            ancestor and moves ABOVE or BELOW the sticker accordingly.
-            `shouldFlipPlaceButton` is vertical only — the horizontal position
-            follows the draft's own x with nothing clamping it — so handing it the
-            controls buys them the vertical avoidance and no more. Still better
-            than a third set of hand-derived offsets. */}
-        {!panelsInside && (
-          <div
-            className="flex items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
-            onPointerDown={pressPanel}
-          >
-            {duplicateControl}
-            {flipControl}
-            {opacityControl}
-            {removeControl}
-          </div>
-        )}
+            Those pills were children of the rotated element, so they turned with
+            the sticker and landed on the artwork; they were a fixed band while
+            everything else up there scales with the sticker, so on a small draft
+            they converged on the rotate knob and each other; and keeping the buy
+            button off them needed a second set of derived offsets that went
+            stale the first time a control was added. One bar outside the
+            rotation has none of those failure modes.
+
+            Sits closest to the sticker in the cluster, so it stays under the
+            thing it acts on. */}
+        <div
+          className="flex items-center gap-0.5 rounded-full bg-dark-7 px-1 py-0.5"
+          onPointerDown={pressPanel}
+        >
+          {duplicateControl}
+          {flipControl}
+          {opacityControl}
+          {removeControl}
+        </div>
 
         {/* Optional, and folded away until asked for: a field on every draft
             would sit over the artwork through the whole arrangement, which is

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -310,16 +310,9 @@ export function DraftSticker({
 
   // Both the tray and the carousel's clipped viewport can swallow the cluster,
   // so it moves above the sticker when that is the better of the two positions.
-  //
-  // 🔴 THE SIDE IS STATE; THE DISTANCE IS NOT, AND MUST NOT BECOME STATE. The
-  // standoff is a float off `cos`/`sin` of a rotation nothing quantises, so it
-  // changes on every frame of a rotate drag. Held in state it made `measure` —
-  // which runs from a layout effect — commit a fresh render each frame, and
-  // Mantine's `SegmentedControl` turns a repeatedly re-rendering parent into
-  // "Maximum update depth exceeded": its ref callback is an inline arrow
-  // (`useMergedRef(ref, (node) => setParent(node))`), so React detaches and
-  // reattaches it every render, setting state each time. Writing the margin
-  // straight to the node keeps the whole standoff off React's update path.
+  // The two standoffs ride along because they come from the same measurement,
+  // and because the side they apply to is decided in the same breath — see the
+  // note above `setPosition` in `measure`.
   const [{ flipped, below, above }, setPosition] = useState({
     flipped: false,
     below: 0,
@@ -352,11 +345,10 @@ export function DraftSticker({
     // 🔴 AN UNMEASURED STICKER DECIDES NOTHING. `EdgeImage` has no intrinsic
     // size until it loads, so a draft dragged in from the tray measures 0 tall
     // for its first frames. Every number below is derived from that box, and a
-    // flip decided from a zero-height sticker put the two candidate positions
-    // close enough together that each one argued for the other: measured on the
-    // real page, 39 straight alternating decisions and "Maximum update depth
-    // exceeded". Keeping the current side until the sticker has a size is the
-    // same rule `placementControlPosition` states for the same reason.
+    // flip decided from a zero-height sticker puts the two candidate positions
+    // close enough together that each one argues for the other. Keeping the
+    // current side until the sticker has a size is the same rule
+    // `placementControlPosition` states for the same reason.
     if (!(height > 0) || !(width > 0)) return;
     const clearance = chromeClearance({
       width,
@@ -389,9 +381,9 @@ export function DraftSticker({
     // 🔴 THE SIDE AND THE TWO STANDOFFS MOVE IN ONE UPDATE. Writing the margin
     // to the node while the class comes from state splits them across a render:
     // the element then carries the standoff for the side it just left, and the
-    // real distance between the two candidate positions is off by exactly
-    // `below + above` — 127px of movement against a model that says 155. That
-    // mismatch is what a flip decision feeds on.
+    // real distance between the two candidate positions is off by `below +
+    // above` against the model `candidateDistance` builds. A flip decision feeds
+    // on that mismatch.
     const next = { flipped: willFlip, below: clearance.below, above: clearance.above };
 
     // Every pointer move re-measures, so bail on an unchanged result rather

--- a/src/components/Sticker/DraftSticker.tsx
+++ b/src/components/Sticker/DraftSticker.tsx
@@ -310,7 +310,16 @@ export function DraftSticker({
 
   // Both the tray and the carousel's clipped viewport can swallow the cluster,
   // so it moves above the sticker when that is the better of the two positions.
-  // The two standoffs ride along because they come from the same measurement.
+  //
+  // 🔴 THE SIDE IS STATE; THE DISTANCE IS NOT, AND MUST NOT BECOME STATE. The
+  // standoff is a float off `cos`/`sin` of a rotation nothing quantises, so it
+  // changes on every frame of a rotate drag. Held in state it made `measure` —
+  // which runs from a layout effect — commit a fresh render each frame, and
+  // Mantine's `SegmentedControl` turns a repeatedly re-rendering parent into
+  // "Maximum update depth exceeded": its ref callback is an inline arrow
+  // (`useMergedRef(ref, (node) => setParent(node))`), so React detaches and
+  // reattaches it every render, setting state each time. Writing the margin
+  // straight to the node keeps the whole standoff off React's update path.
   const [{ flipped, below, above }, setPosition] = useState({
     flipped: false,
     below: 0,
@@ -340,6 +349,15 @@ export function DraftSticker({
     // into the rotated extent.
     const height = element.offsetHeight;
     const width = element.offsetWidth;
+    // 🔴 AN UNMEASURED STICKER DECIDES NOTHING. `EdgeImage` has no intrinsic
+    // size until it loads, so a draft dragged in from the tray measures 0 tall
+    // for its first frames. Every number below is derived from that box, and a
+    // flip decided from a zero-height sticker put the two candidate positions
+    // close enough together that each one argued for the other: measured on the
+    // real page, 39 straight alternating decisions and "Maximum update depth
+    // exceeded". Keeping the current side until the sticker has a size is the
+    // same rule `placementControlPosition` states for the same reason.
+    if (!(height > 0) || !(width > 0)) return;
     const clearance = chromeClearance({
       width,
       height,
@@ -362,16 +380,19 @@ export function DraftSticker({
       }),
     });
 
-    const next = {
-      flipped: shouldFlipPlaceButton({
-        below: boxes.below,
-        above: boxes.above,
-        tray: tray?.getBoundingClientRect() ?? null,
-        clip: clip.current?.getBoundingClientRect() ?? null,
-      }),
-      below: clearance.below,
-      above: clearance.above,
-    };
+    const willFlip = shouldFlipPlaceButton({
+      below: boxes.below,
+      above: boxes.above,
+      tray: tray?.getBoundingClientRect() ?? null,
+      clip: clip.current?.getBoundingClientRect() ?? null,
+    });
+    // 🔴 THE SIDE AND THE TWO STANDOFFS MOVE IN ONE UPDATE. Writing the margin
+    // to the node while the class comes from state splits them across a render:
+    // the element then carries the standoff for the side it just left, and the
+    // real distance between the two candidate positions is off by exactly
+    // `below + above` — 127px of movement against a model that says 155. That
+    // mismatch is what a flip decision feeds on.
+    const next = { flipped: willFlip, below: clearance.below, above: clearance.above };
 
     // Every pointer move re-measures, so bail on an unchanged result rather
     // than handing React a new object to re-render for.
@@ -777,9 +798,10 @@ export function DraftSticker({
         style={{
           minWidth: BUY_BUTTON_MIN_WIDTH,
           // The standoff from the sticker's own box out to the rotated artwork,
-          // the knob and the handles. Measured and derived — see
-          // `chromeClearance` — because no constant is right at both ends of the
-          // scale range or at both ends of the rotation range.
+          // the knob and the handles. Derived — see `chromeClearance` — because
+          // no constant is right at both ends of the scale range or at both ends
+          // of the rotation range. Set from the same state as the class above,
+          // never written to the node separately.
           ...(flipped ? { marginBottom: above } : { marginTop: below }),
         }}
         // Outside the rotated body but still inside the draft, and the layer

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -287,3 +287,72 @@ describe('shouldFlipPlaceButton', () => {
     expect(decide(box(800), box(300), null, null)).toBe(false);
   });
 });
+
+/**
+ * 🔴 THE DERIVED BOX IS A WHOLE BOX, INCLUDING THE EDGES NOTHING MOVES.
+ *
+ * `placeButtonBoxes` is handed a real `DOMRect`, whose properties are getters on
+ * the PROTOTYPE rather than own enumerable ones. `{ ...rect }` therefore copies
+ * nothing, and a derived box built that way has `left`/`right` undefined —
+ * `overlaps` evaluates `undefined > tray.left` as `false`, so the tray goes
+ * invisible to whichever box was derived.
+ *
+ * Measured on the image detail page at the flip boundary: unflipped, `below` was
+ * the real rect, saw the tray and flipped; flipped, `below` was derived, could
+ * not see the tray and unflipped. 39 alternations and "Maximum update depth
+ * exceeded". The numbers below are that capture.
+ *
+ * ⚠️ THE FIXTURE MUST NOT BE AN OBJECT LITERAL. Spreading a literal works, so a
+ * literal passes with or without the bug and pins nothing. `rectLike` puts the
+ * edges on a prototype, the way the browser does.
+ */
+describe('the candidate boxes survive coming from a DOMRect', () => {
+  const rectLike = (top: number, bottom: number, left: number, right: number): Box =>
+    Object.create(
+      Object.defineProperties(
+        {},
+        {
+          top: { get: () => top },
+          bottom: { get: () => bottom },
+          left: { get: () => left },
+          right: { get: () => right },
+        }
+      )
+    ) as Box;
+
+  const MEASURED_TRAY: Box = { top: 1087, bottom: 1355, left: 0, right: 1270 };
+  const MEASURED_CLIP: Box = { top: 92, bottom: 1301, left: 0, right: 820 };
+  const DISTANCE = 319;
+
+  it('spreads to nothing, which is why the fixture is not a literal', () => {
+    // The negative control for the two cases below: if this ever starts copying
+    // edges, they pass for a reason that has nothing to do with the fix.
+    expect({ ...rectLike(1, 2, 3, 4) }).toEqual({});
+  });
+
+  it('keeps left and right on the box it derives', () => {
+    const { above } = placeButtonBoxes({
+      current: rectLike(969, 1096, 322, 454),
+      flipped: false,
+      distance: DISTANCE,
+    });
+
+    expect(above.left).toBe(322);
+    expect(above.right).toBe(454);
+  });
+
+  it('decides the same thing whichever side the cluster is currently on', () => {
+    const decide = (current: Box, flipped: boolean) =>
+      shouldFlipPlaceButton({
+        ...placeButtonBoxes({ current, flipped, distance: DISTANCE }),
+        tray: MEASURED_TRAY,
+        clip: MEASURED_CLIP,
+      });
+
+    // Same sticker, same frame, one measurement from each side. The second was
+    // `false` while the derived box could not see the tray, and the pair of
+    // answers is what the loop was made of.
+    expect(decide(rectLike(969, 1096, 322, 454), false)).toBe(true);
+    expect(decide(rectLike(651, 778, 322, 454), true)).toBe(true);
+  });
+});

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -2,14 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { Box } from '~/components/Sticker/place-button-position';
 import {
   candidateDistance,
-  flippedButtonOffset,
-  panelBandFor,
-  panelsFitInsideEdges,
+  chromeClearance,
   placeButtonBoxes,
   shouldFlipPlaceButton,
-  STICKER_PANEL_BAND_PX,
-  STICKER_PANEL_LEFT_WIDTH_PX,
-  STICKER_PANEL_MIN_WIDTH_PX,
 } from '~/components/Sticker/place-button-position';
 
 /** The real page at 1400x900: tray band, and the carousel viewport that clips. */
@@ -23,244 +18,197 @@ const box = (top: number, height = 36, left = 600, right = 732): Box => ({
   right,
 });
 
-describe('flippedButtonOffset', () => {
-  // The knob hangs `knobOffset` of the sticker's HEIGHT above it, so the
-  // clearance has to scale with the sticker. A constant is what made the knob
-  // dead at the default size, and a constant is what these cases forbid.
-  it('scales with the sticker so the button clears the rotate knob', () => {
-    expect(
-      flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.22, gap: 8, panelBand: 0 })
-    ).toBe(30);
-    expect(
-      flippedButtonOffset({ stickerHeight: 300, knobOffset: 0.22, gap: 8, panelBand: 0 })
-    ).toBe(74);
+const KNOB = 0.22;
+const OUTSET = 6;
+const GAP = 8;
+
+const clearance = (over: Partial<Parameters<typeof chromeClearance>[0]> = {}) =>
+  chromeClearance({
+    width: 100,
+    height: 200,
+    rotation: 0,
+    knobOffset: KNOB,
+    outset: OUTSET,
+    gap: GAP,
+    ...over,
   });
 
-  it('tracks the knob offset and the gap independently', () => {
-    expect(flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.5, gap: 8, panelBand: 0 })).toBe(
-      58
-    );
-    expect(
-      flippedButtonOffset({ stickerHeight: 100, knobOffset: 0.22, gap: 20, panelBand: 0 })
-    ).toBe(42);
+/**
+ * Where the furthest corner of the turned sticker actually lands on screen,
+ * derived from the corners rather than from the formula under test.
+ *
+ * The local rectangle is the artwork's box grown by the handles on every side
+ * and by the rotate knob on top, about the centre the sticker turns about. CSS
+ * `rotate` sends `(x, y)` to `(x·cos − y·sin, x·sin + y·cos)`, so the screen
+ * vertical of a corner is `x·sin + y·cos`.
+ */
+function rotatedReach({
+  width,
+  height,
+  rotation,
+}: {
+  width: number;
+  height: number;
+  rotation: number;
+}) {
+  const radians = (rotation * Math.PI) / 180;
+  const sin = Math.sin(radians);
+  const cos = Math.cos(radians);
+  const xs = [-(width / 2 + OUTSET), width / 2 + OUTSET];
+  const ys = [-(height / 2 + Math.max(KNOB * height, OUTSET)), height / 2 + OUTSET];
+  const screenY = xs.flatMap((x) => ys.map((y) => x * sin + y * cos));
+
+  return { down: Math.max(...screenY), up: Math.min(...screenY) };
+}
+
+/**
+ * 🔴 THE TICKET. The chrome is laid out against the sticker's UNROTATED box and
+ * has to clear its ROTATED one, because the rotation now lives on an inner
+ * element and the chrome is that element's sibling. Every case here is a
+ * position that was wrong before that split, and none of them may be satisfied
+ * by a constant.
+ */
+describe('chromeClearance', () => {
+  it('clears only the handles below and the rotate knob above at rest', () => {
+    // The knob hangs 0.22 of a 200px sticker — 44px — above the top edge, and
+    // the corner handles reach 6px past every edge.
+    expect(clearance()).toEqual({ below: OUTSET + GAP, above: 44 + GAP });
   });
 
-  it('clears the knob at every size in the measured dead band', () => {
-    // The knob's top edge sits at -knobOffset*height in the sticker's own space;
-    // the flipped button's bottom sits at -offset. Measured on the real page,
-    // heights from ~73 to ~236 put the knob's centre inside the button.
-    for (const stickerHeight of [73, 94, 150, 200, 236]) {
-      const offset = flippedButtonOffset({ stickerHeight, knobOffset: 0.22, gap: 8, panelBand: 0 });
-      expect(offset).toBeGreaterThan(0.22 * stickerHeight);
-    }
+  it('moves the knob-sized standoff to the BELOW side at half a turn', () => {
+    // The bug this fixes, stated as a number: at 180 degrees the knob is under
+    // the sticker on screen, so the side needing the bigger standoff is the one
+    // the toolbar sits on. Chrome that rides the rotation instead lands on the
+    // artwork here.
+    expect(clearance({ rotation: 180 })).toEqual({ below: 44 + GAP, above: OUTSET + GAP });
   });
 
-  // The knob is not the only thing up there any more. The two control panels
-  // occupy a band that does NOT scale with the sticker, so on a short one the
-  // knob clearance is the smaller of the two and clearing only it puts the
-  // button over the panels — where it paints last and swallows the pointer, so
-  // flip, opacity and delete are visibly present and completely dead.
-  it('clears the panel band on a sticker too short for the knob to be the obstacle', () => {
-    // 72px: a 2:1 sticker at the DEFAULT 18% scale on an 800px media box. The
-    // knob wants 15.8px of clearance and the panels want 36.
-    const offset = flippedButtonOffset({
-      stickerHeight: 72,
-      knobOffset: 0.22,
-      gap: 8,
-      panelBand: STICKER_PANEL_BAND_PX,
+  it('is driven by the WIDTH on its side, where height says nothing', () => {
+    // A wide, short sticker turned upright reaches further vertically than its
+    // own box ever does — the case a height-only clearance gets backwards.
+    const wide = chromeClearance({
+      width: 400,
+      height: 60,
+      rotation: 90,
+      knobOffset: KNOB,
+      outset: OUTSET,
+      gap: GAP,
     });
 
-    expect(offset).toBeGreaterThan(STICKER_PANEL_BAND_PX);
-    expect(offset).toBe(44);
+    expect(wide.below).toBeCloseTo(400 / 2 + OUTSET - 60 / 2 + GAP);
+    expect(wide.below).toBeGreaterThan(clearance({ rotation: 90 }).below);
   });
 
-  it('still clears the knob once the sticker is tall enough for it to win', () => {
-    const stickerHeight = 400;
-    const offset = flippedButtonOffset({
-      stickerHeight,
-      knobOffset: 0.22,
-      gap: 8,
-      panelBand: STICKER_PANEL_BAND_PX,
-    });
-
-    expect(offset).toBeGreaterThan(0.22 * stickerHeight);
-    expect(offset).toBe(96);
+  it('scales with the sticker rather than sitting at a fixed distance', () => {
+    // A constant passes the resting case above and fails here, which is the
+    // whole point of asserting two sizes.
+    expect(clearance({ height: 400 }).above).toBe(0.22 * 400 + GAP);
+    expect(clearance({ height: 100 }).above).toBe(0.22 * 100 + GAP);
   });
 
-  // Every height in the range a sticker can actually take, against BOTH
-  // obstacles at once — the pair above pins the two regimes, this pins that
-  // there is no gap between them.
-  it('clears both obstacles across the whole scale range', () => {
-    for (const stickerHeight of [20, 51, 72, 100, 127, 150, 236, 400]) {
-      const offset = flippedButtonOffset({
-        stickerHeight,
-        knobOffset: 0.22,
-        gap: 8,
-        panelBand: STICKER_PANEL_BAND_PX,
-      });
+  it('keeps the chrome exactly one gap clear of the turned sticker, at every angle', () => {
+    // The property, checked against corners derived independently of the
+    // formula: the cluster's near edge is the furthest the sticker reaches, plus
+    // the gap, and never less.
+    for (const rotation of [0, 12, 45, 90, 137, 180, -45, -90, -173]) {
+      for (const [width, height] of [
+        [100, 200],
+        [400, 60],
+        [51, 51],
+      ]) {
+        const { below, above } = chromeClearance({
+          width,
+          height,
+          rotation,
+          knobOffset: KNOB,
+          outset: OUTSET,
+          gap: GAP,
+        });
+        const reach = rotatedReach({ width, height, rotation });
 
-      expect(offset).toBeGreaterThan(0.22 * stickerHeight);
-      expect(offset).toBeGreaterThan(STICKER_PANEL_BAND_PX);
+        // Positions in the unrotated box's own frame, centre at 0.
+        expect(height / 2 + below).toBeCloseTo(reach.down + GAP);
+        expect(-(height / 2 + above)).toBeCloseTo(reach.up - GAP);
+      }
     }
-  });
-});
-
-describe('panelsFitInsideEdges', () => {
-  // Flush with the edges is the intended look, and it is only safe while the
-  // sticker is wide enough that the two panels cannot reach past each other —
-  // the delete button paints last, so an overlap means it lands on the opacity
-  // button and a misclick throws the draft away.
-  it('refuses the flush layout on the sizes where delete would cover opacity', () => {
-    // The 5% scale floor on a 1024px media box, and the default 18% on a
-    // phone-width one. Both are states the product actually produces.
-    expect(panelsFitInsideEdges(51)).toBe(false);
-    expect(panelsFitInsideEdges(65)).toBe(false);
-  });
-
-  // The rotate knob is centred and 16px wide, and the left panel reaches 78px
-  // in: below 172 the knob ends up under it, and the panel swallows the press.
-  it('is bounded by the knob, not merely by the two panels touching', () => {
-    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX - 1)).toBe(false);
-    expect(panelsFitInsideEdges(STICKER_PANEL_MIN_WIDTH_PX)).toBe(true);
-    // 104 is where the panels alone stop overlapping (78 + 26). Wide enough for
-    // them, still too narrow for the knob — the case a fix aimed at the panels
-    // alone would get wrong.
-    expect(panelsFitInsideEdges(104)).toBe(false);
-  });
-
-  // 144 fit while the left panel held two icons. Adding Copy widened it to 78px
-  // and left this constant at 124, so a 144px sticker drew a panel over its own
-  // rotate knob — the reported bug, and a size the default scale reaches on a
-  // desktop media box.
-  it('refuses the widths that fit before Copy joined the left panel', () => {
-    expect(panelsFitInsideEdges(144)).toBe(false);
-    // The numbers, so a wrong control count reads as `expected 54 to be 78`
-    // rather than as `expected true to be false` on one width. Three icons:
-    // `4 + 22 + 2 + 22 + 2 + 22 + 4`, and the knob needs 8px of the half-width.
-    expect(STICKER_PANEL_LEFT_WIDTH_PX).toBe(78);
-    expect(STICKER_PANEL_MIN_WIDTH_PX).toBe(172);
-  });
-
-  // Literal widths, deliberately. `panelsFitInsideEdges` IS
-  // `w >= STICKER_PANEL_MIN_WIDTH_PX`, so a case written in terms of that
-  // constant holds for every value the constant could take and pins nothing.
-  it('allows it at the sizes the flush layout was designed for', () => {
-    expect(panelsFitInsideEdges(172)).toBe(true);
-    expect(panelsFitInsideEdges(400)).toBe(true);
-  });
-
-  // The band exists only where the panels do. Clearing one that is not there is
-  // not harmful in itself, but it shrinks the flipped candidate box and so makes
-  // the button decline a flip it could have taken.
-  it('reports no band to clear where no panels are drawn', () => {
-    expect(panelBandFor(51)).toBe(0);
-    // Literal, for the reason above.
-    expect(panelBandFor(172)).toBe(STICKER_PANEL_BAND_PX);
   });
 });
 
 describe('candidateDistance', () => {
-  // A second line of copy under the Buzz button makes the wrapper taller. The
-  // unflipped position moves down with it and the distance has to follow; the
-  // flipped position does not move, because it is anchored by its bottom edge.
-  it('grows with the button, one pixel for one pixel', () => {
-    const base = { stickerHeight: 200, flippedOffset: 52, gap: 8 };
-    expect(candidateDistance({ ...base, buttonHeight: 36 })).toBe(296);
-    expect(candidateDistance({ ...base, buttonHeight: 52 })).toBe(312);
-    expect(candidateDistance({ ...base, buttonHeight: 88 })).toBe(348);
+  // The caption under the button carries a creator's username, so the cluster
+  // has no reliable height. It is anchored by the edge nearest the sticker and
+  // grows away from it, so its height moves the far edge only — which is the
+  // distance between the two candidate positions, and nothing else.
+  it('grows with the cluster, one pixel for one pixel', () => {
+    const base = { height: 200, below: 14, above: 52 };
+    expect(candidateDistance({ ...base, clusterHeight: 36 })).toBe(302);
+    expect(candidateDistance({ ...base, clusterHeight: 52 })).toBe(318);
+    expect(candidateDistance({ ...base, clusterHeight: 88 })).toBe(354);
   });
 
-  it('tracks the sticker, the clearance and the gap independently', () => {
-    const base = { stickerHeight: 200, buttonHeight: 36, flippedOffset: 52, gap: 8 };
-    expect(candidateDistance({ ...base, stickerHeight: 300 })).toBe(396);
-    expect(candidateDistance({ ...base, flippedOffset: 74 })).toBe(318);
-    expect(candidateDistance({ ...base, gap: 20 })).toBe(308);
+  it('tracks the sticker and each standoff independently', () => {
+    const base = { height: 200, clusterHeight: 36, below: 14, above: 52 };
+    expect(candidateDistance({ ...base, height: 300 })).toBe(402);
+    expect(candidateDistance({ ...base, below: 30 })).toBe(318);
+    expect(candidateDistance({ ...base, above: 74 })).toBe(324);
   });
 
   it('is the real gap between the two positions the CSS produces', () => {
-    // Unflipped spans [H + gap, H + gap + button]; flipped spans
-    // [-offset - button, -offset]. The distance is between matching edges.
-    const stickerHeight = 94;
-    const buttonHeight = 52;
-    const gap = 8;
-    const flippedOffset = flippedButtonOffset({
-      stickerHeight,
-      knobOffset: 0.22,
-      gap,
-      panelBand: 0,
-    });
+    // Unflipped spans [H/2 + below, ... + cluster] from the box's centre;
+    // flipped spans [-H/2 - above - cluster, -H/2 - above]. The distance is
+    // between matching edges.
+    const height = 94;
+    const clusterHeight = 52;
+    const { below, above } = clearance({ height, width: 94, rotation: 30 });
 
-    const unflippedTop = stickerHeight + gap;
-    const flippedTop = -flippedOffset - buttonHeight;
+    const unflippedTop = height / 2 + below;
+    const flippedTop = -height / 2 - above - clusterHeight;
 
-    expect(candidateDistance({ stickerHeight, buttonHeight, flippedOffset, gap })).toBeCloseTo(
+    expect(candidateDistance({ height, clusterHeight, below, above })).toBeCloseTo(
       unflippedTop - flippedTop
     );
   });
 });
 
 describe('placeButtonBoxes', () => {
-  it('puts the alternative straight below at rotation 0', () => {
+  it('puts the alternative straight below', () => {
     const current = box(300);
-    const { below, above } = placeButtonBoxes({
-      current,
-      flipped: true,
-      rotationDeg: 0,
-      distance: 252,
-    });
+    const { below, above } = placeButtonBoxes({ current, flipped: true, distance: 252 });
 
     expect(above).toEqual(current);
     expect(below.top).toBeCloseTo(552);
     expect(below.bottom).toBeCloseTo(588);
   });
 
-  it('inverts at 180 degrees, where the CSS "below" is above on screen', () => {
-    // Measured in Chromium: a 200px sticker at rotate(180deg) put the unflipped
-    // button at 309-345 and the flipped one at 561-597 — the opposite way round.
-    const { below, above } = placeButtonBoxes({
-      current: box(561),
+  /**
+   * 🔴 VERTICAL WHATEVER THE STICKER IS DOING, and that is a claim about the DOM
+   * rather than about this function. The cluster used to be a child of the
+   * rotated element, so its "below" swung around the sticker and this had to
+   * take an angle to undo it. It is now a sibling of the rotated element, so
+   * screen-down is the only direction there is — a version of this that took an
+   * angle again would mean the chrome had been put back inside the rotation.
+   */
+  it('does not move sideways, because nothing above the cluster rotates', () => {
+    const current = box(300);
+    const { below } = placeButtonBoxes({ current, flipped: true, distance: 100 });
+
+    expect(below.left).toBe(current.left);
+    expect(below.right).toBe(current.right);
+    expect(below.top).toBeCloseTo(400);
+  });
+
+  it('gives the same pair whichever position the cluster is in', () => {
+    // The property the whole design rests on: no feedback, so flipping cannot
+    // remove its own cause.
+    const fromBelow = placeButtonBoxes({ current: box(300), flipped: false, distance: 252 });
+    const fromAbove = placeButtonBoxes({
+      current: fromBelow.above,
       flipped: true,
-      rotationDeg: 180,
       distance: 252,
     });
 
-    expect(above.top).toBeCloseTo(561);
-    expect(below.top).toBeCloseTo(309);
-    expect(below.top).toBeLessThan(above.top);
-  });
-
-  it('gives the same pair whichever position the button is in', () => {
-    // The property the whole design rests on: no feedback, so flipping cannot
-    // remove its own cause. Same geometry, described from both sides.
-    for (const rotationDeg of [0, 45, 90, 180, -135]) {
-      const fromBelow = placeButtonBoxes({
-        current: box(300),
-        flipped: false,
-        rotationDeg,
-        distance: 252,
-      });
-      const fromAbove = placeButtonBoxes({
-        current: fromBelow.above,
-        flipped: true,
-        rotationDeg,
-        distance: 252,
-      });
-
-      expect(fromAbove.below.top).toBeCloseTo(fromBelow.below.top);
-      expect(fromAbove.above.top).toBeCloseTo(fromBelow.above.top);
-    }
-  });
-
-  it('moves sideways when the sticker is turned on its side', () => {
-    const { below } = placeButtonBoxes({
-      current: box(300),
-      flipped: true,
-      rotationDeg: 90,
-      distance: 100,
-    });
-
-    expect(below.top).toBeCloseTo(300);
-    expect(below.left).toBeCloseTo(500);
+    expect(fromAbove.below.top).toBeCloseTo(fromBelow.below.top);
+    expect(fromAbove.above.top).toBeCloseTo(fromBelow.above.top);
   });
 });
 

--- a/src/components/Sticker/__tests__/place-button-position.test.ts
+++ b/src/components/Sticker/__tests__/place-button-position.test.ts
@@ -327,7 +327,10 @@ describe('the candidate boxes survive coming from a DOMRect', () => {
   it('spreads to nothing, which is why the fixture is not a literal', () => {
     // The negative control for the two cases below: if this ever starts copying
     // edges, they pass for a reason that has nothing to do with the fix.
-    expect({ ...rectLike(1, 2, 3, 4) }).toEqual({});
+    // `toStrictEqual`, not `toEqual`: the latter treats an own key holding
+    // `undefined` as absent, so a fixture that spread to `{ top: undefined }`
+    // would satisfy the control it exists to be.
+    expect({ ...rectLike(1, 2, 3, 4) }).toStrictEqual({});
   });
 
   it('keeps left and right on the box it derives', () => {

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -11,10 +11,9 @@ const overlaps = (a: Box, b: Box) =>
  * rather than own enumerable ones — so a spread copies NOTHING and the derived
  * box comes out with `left` and `right` undefined. `overlaps` then evaluates
  * `undefined > tray.left`, which is `false`, so the tray becomes invisible to
- * whichever of the two boxes was derived. Measured on the real page: unflipped,
- * `below` was the real rect, saw the tray and flipped; flipped, `below` was
- * derived, could not see the tray and unflipped. 39 alternations and "Maximum
- * update depth exceeded".
+ * whichever of the two boxes was derived. Each side then argues for the other —
+ * the real rect sees the tray and flips, the derived one cannot and unflips —
+ * until React gives up with "Maximum update depth exceeded".
  *
  * The `Box` type cannot catch this — `DOMRect` satisfies it structurally, and
  * the spread of one type-checks as `Box` while being empty at runtime.

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -4,169 +4,127 @@ export type Box = { top: number; bottom: number; left: number; right: number };
 const overlaps = (a: Box, b: Box) =>
   a.bottom > b.top && a.top < b.bottom && a.right > b.left && a.left < b.right;
 
-const shift = (box: Box, dx: number, dy: number): Box => ({
+const shiftDown = (box: Box, dy: number): Box => ({
+  ...box,
   top: box.top + dy,
   bottom: box.bottom + dy,
-  left: box.left + dx,
-  right: box.right + dx,
 });
 
 /**
- * The band above the sticker's top edge that the two control panels occupy, in
- * px, measured from the top edge: they hang 36px up (`-top-9`) and are 26px tall
- * (a 22px `ActionIcon` in 2px of padding).
+ * How far the draft's chrome has to stand off the sticker's own box to clear the
+ * sticker at the angle it is currently turned to.
  *
- * A CONSTANT, unlike everything else above the sticker — that is the whole
- * hazard. The knob and the flipped button are both sized as a fraction of the
- * sticker's height, so anything reasoning about "what is above the sticker" from
- * height alone silently misses these.
+ * The chrome is drawn OUTSIDE the rotated element — see `DraftSticker` — so it
+ * is laid out against the sticker's unrotated box while the thing it has to
+ * avoid is the rotated one. The two differ by the whole reason this ticket
+ * exists: a clearance derived from the local edge is right at 0° and wrong
+ * everywhere else, and a constant is wrong at every size.
+ *
+ * 🔴 DERIVED, NEVER A CONSTANT. Nothing here may become a fixed number of
+ * pixels. The caption under the button carries a creator's username, so the
+ * cluster's own height has no bound worth relying on — but it is anchored by
+ * the edge nearest the sticker and grows away from it, so its height cannot
+ * enter this. What does enter it is the sticker's measured size and angle.
+ *
+ * Returns the two standoffs in px, `below` measured from the box's bottom edge
+ * downwards and `above` from its top edge upwards. Either can come out negative
+ * — a tall narrow sticker turned onto its side reaches less far vertically than
+ * its own box does — which is correct: the chrome then sits closer than the
+ * unrotated edge, still clear of the artwork.
  */
-export const STICKER_PANEL_BAND_PX = 36;
-
-/**
- * The left panel's width, derived rather than measured, because the count of
- * controls in it is what moves.
- *
- * A `size="sm"` `ActionIcon` is 22px, `gap-0.5` is 2px and `px-1` is 4px a side.
- * Duplicate, flip and opacity: `4 + 22 + 2 + 22 + 2 + 22 + 4`.
- *
- * 🔴 KEEP THIS IN STEP WITH THE PANEL'S JSX. The constant below was computed for
- * TWO icons and stayed at 124 when Copy was added as a third, so on every
- * sticker between 124px and 172px wide the panel reached past the rotate knob
- * and swallowed the press — the knob was visibly there and completely dead.
- */
-export const PANEL_LEFT_CONTROLS = 3;
-const PANEL_ICON_PX = 22;
-const PANEL_ICON_GAP_PX = 2;
-const PANEL_PADDING_X_PX = 4;
-
-export const STICKER_PANEL_LEFT_WIDTH_PX =
-  PANEL_PADDING_X_PX * 2 +
-  PANEL_LEFT_CONTROLS * PANEL_ICON_PX +
-  (PANEL_LEFT_CONTROLS - 1) * PANEL_ICON_GAP_PX;
-
-/** The rotate knob is `size-4`, centred on the top edge, so it reaches 8px each way. */
-const KNOB_HALF_WIDTH_PX = 8;
-
-/**
- * The narrowest sticker whose top edge can host both panels without the rotate
- * knob ending up underneath one.
- *
- * The knob spans `[w/2 - 8, w/2 + 8]` and the left panel reaches
- * `STICKER_PANEL_LEFT_WIDTH_PX` in from the left edge, so clear of each other
- * needs `w/2 - 8 >= left`. Below this there are no panels above the sticker at
- * all: the draft's controls move into the buy cluster, which measures its own
- * position against the tray and the clipping ancestor. Anchoring them to a small
- * sticker's box fails in both directions — inside it they reach past each other
- * and the knob, outside it they hang off the sticker and are clipped away near
- * the edges of the image.
- */
-export const STICKER_PANEL_MIN_WIDTH_PX = (STICKER_PANEL_LEFT_WIDTH_PX + KNOB_HALF_WIDTH_PX) * 2;
-
-/**
- * Whether the panels can sit flush with the sticker's own edges.
- *
- * They are drawn against the edges by design, which reads as bracketing the box
- * — but on a narrow sticker the two panels reach past each other and the
- * DESTRUCTIVE one wins, because it paints last: the delete button lands on the
- * opacity button. At the 5% scale floor that is a 51px-wide sticker, and at the
- * default 18% on a phone-width media box it is 65px, so this is a default state
- * rather than an edge case.
- */
-export const panelsFitInsideEdges = (stickerWidth: number) =>
-  stickerWidth >= STICKER_PANEL_MIN_WIDTH_PX;
-
-/** The band to clear, which is nothing at all when no panels are drawn. */
-export const panelBandFor = (stickerWidth: number) =>
-  panelsFitInsideEdges(stickerWidth) ? STICKER_PANEL_BAND_PX : 0;
-
-/**
- * How far above the sticker the flipped button sits.
- *
- * Not a constant: the rotate knob hangs `knobOffset` of the sticker's height
- * above it, so a fixed margin puts the button on top of the knob at every
- * middling sticker size — and because the button's wrapper stops the pointer
- * event, the knob goes dead rather than merely hidden. Measured on the real
- * page: at the default 18% scale the knob's centre was inside the button.
- *
- * `panelBand` is the second obstacle and does NOT scale with the sticker, so the
- * larger of the two is what has to be cleared. Clearing only the knob leaves the
- * button over the control panels on any sticker shorter than ~127px — where it
- * paints last and stops the pointer event, so flip, opacity and delete are all
- * visibly present and completely dead.
- */
-export const flippedButtonOffset = ({
-  stickerHeight,
+export function chromeClearance({
+  width,
+  height,
+  rotation,
   knobOffset,
+  outset,
   gap,
-  panelBand,
 }: {
-  stickerHeight: number;
+  /** The sticker's unrotated layout width in px — `offsetWidth`. */
+  width: number;
+  /** The sticker's unrotated layout height in px — `offsetHeight`. */
+  height: number;
+  /** Degrees, ±180. */
+  rotation: number;
+  /** The rotate knob hangs this fraction of the sticker's height above it. */
   knobOffset: number;
+  /** How far the corner handles stick out past the box on every side. */
+  outset: number;
+  /** Clear air between the furthest thing on the sticker and the chrome. */
   gap: number;
-  /**
-   * Required, with no default. The whole bug class here was an obstacle nobody
-   * accounted for, and a caller that forgets this would silently get the old
-   * behaviour back — pass 0 deliberately if a surface truly has no panels.
-   */
-  panelBand: number;
-}) => Math.max(knobOffset * stickerHeight, panelBand) + gap;
+}): { below: number; above: number } {
+  const radians = (rotation * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.abs(Math.sin(radians));
+
+  // The local rectangle to clear, about the sticker's centre. Asymmetric,
+  // because the rotate knob only hangs off the top — and it is what makes this
+  // more than the usual `h·|cos| + w·|sin|` extent: that formula is for a
+  // rectangle centred on the point it turns about, and the knob is not.
+  const top = -(height / 2 + Math.max(knobOffset * height, outset));
+  const bottom = height / 2 + outset;
+  // Every corner shares the same |x·sin| reach, so only the y term differs.
+  const side = (width / 2 + outset) * sin;
+
+  const reachDown = side + Math.max(top * cos, bottom * cos);
+  const reachUp = side - Math.min(top * cos, bottom * cos);
+
+  return {
+    below: reachDown - height / 2 + gap,
+    above: reachUp - height / 2 + gap,
+  };
+}
 
 /**
- * How far apart the two positions are, along the sticker's own axis.
+ * How far apart the two positions are, in screen pixels.
  *
- * Reads the button's height rather than assuming one: the wrapper holds
- * whatever is under the Buzz button as well as the button itself, so a second
- * line of copy makes it taller and moves the unflipped position further down.
- * The flipped position is unaffected — it is anchored by its bottom edge, so a
- * taller button grows upwards, away from the knob it has to clear.
+ * Reads the cluster's height rather than assuming one: it holds the toolbar,
+ * the note field and the payout caption as well as the button, so a longer
+ * username or an opened note makes it taller. Whichever side it is on it is
+ * anchored by its edge nearest the sticker and grows away, so its height moves
+ * the FAR edge only — which is why it belongs here, in the distance between the
+ * two candidate positions, and not in `chromeClearance`.
  */
 export const candidateDistance = ({
-  stickerHeight,
-  buttonHeight,
-  flippedOffset,
-  gap,
+  height,
+  clusterHeight,
+  below,
+  above,
 }: {
-  stickerHeight: number;
-  buttonHeight: number;
-  flippedOffset: number;
-  gap: number;
-}) => stickerHeight + gap + flippedOffset + buttonHeight;
+  /** The sticker's unrotated layout height in px. */
+  height: number;
+  clusterHeight: number;
+  /** The two standoffs from `chromeClearance`. */
+  below: number;
+  above: number;
+}) => height + below + above + clusterHeight;
 
 /**
- * The two places the button can be, both as screen boxes.
+ * The two places the cluster can be, both as screen boxes.
  *
- * The button is a child of the sticker's rotated element, so "below" is only
- * below on screen at rotation 0 — at 180° the same CSS puts it *above*, and
- * reasoning about `top`/`bottom` without accounting for that inverts the whole
- * decision. Both boxes therefore come from the button's real measured rect, with
- * the alternative derived by rotating the local offset between the two
- * positions into screen space.
+ * Purely vertical, which it was not before: the cluster used to be a child of
+ * the rotated element, so "below" was only below on screen at rotation 0 and
+ * the pair had to be derived by rotating the local offset into screen space.
+ * Now that nothing above it rotates, the alternative really is straight up or
+ * straight down.
  *
- * Deriving the pair this way is also what keeps the decision free of feedback:
- * the same two boxes come out whichever position the button is currently in, so
- * flipping can never remove the condition that caused it and start oscillating.
+ * Deriving the pair rather than reading each position is what keeps the decision
+ * free of feedback: the same two boxes come out whichever position the cluster
+ * is currently in, so flipping can never remove the condition that caused it and
+ * start oscillating.
  */
 export function placeButtonBoxes({
   current,
   flipped,
-  rotationDeg,
   distance,
 }: {
   current: Box;
   flipped: boolean;
-  rotationDeg: number;
   distance: number;
 }): { below: Box; above: Box } {
-  const radians = (rotationDeg * Math.PI) / 180;
-  // The local vector from the flipped position to the unflipped one is (0, +d)
-  // — straight down the sticker's own axis — rotated into screen space.
-  const dx = -Math.sin(radians) * distance;
-  const dy = Math.cos(radians) * distance;
-
   return flipped
-    ? { above: current, below: shift(current, dx, dy) }
-    : { below: current, above: shift(current, -dx, -dy) };
+    ? { above: current, below: shiftDown(current, distance) }
+    : { below: current, above: shiftDown(current, -distance) };
 }
 
 /**

--- a/src/components/Sticker/place-button-position.ts
+++ b/src/components/Sticker/place-button-position.ts
@@ -4,10 +4,26 @@ export type Box = { top: number; bottom: number; left: number; right: number };
 const overlaps = (a: Box, b: Box) =>
   a.bottom > b.top && a.top < b.bottom && a.right > b.left && a.left < b.right;
 
+/**
+ * 🔴 EVERY FIELD BY NAME. NEVER `{ ...box }`.
+ *
+ * `current` is a real `DOMRect`, whose properties are getters on the prototype
+ * rather than own enumerable ones — so a spread copies NOTHING and the derived
+ * box comes out with `left` and `right` undefined. `overlaps` then evaluates
+ * `undefined > tray.left`, which is `false`, so the tray becomes invisible to
+ * whichever of the two boxes was derived. Measured on the real page: unflipped,
+ * `below` was the real rect, saw the tray and flipped; flipped, `below` was
+ * derived, could not see the tray and unflipped. 39 alternations and "Maximum
+ * update depth exceeded".
+ *
+ * The `Box` type cannot catch this — `DOMRect` satisfies it structurally, and
+ * the spread of one type-checks as `Box` while being empty at runtime.
+ */
 const shiftDown = (box: Box, dy: number): Box => ({
-  ...box,
   top: box.top + dy,
   bottom: box.bottom + dy,
+  left: box.left,
+  right: box.right,
 });
 
 /**


### PR DESCRIPTION
ClickUp [`868m08x1z`](https://app.clickup.com/t/868m08x1z) — the sticker editing UI overlaps and blocks the sticker it is editing.

## What was wrong

Every piece of a draft sticker's editing chrome was a child of the one element carrying `transform: translate(-50%,-50%) rotate(<rotation>deg)`.

- **Two corner pills** (duplicate/flip/opacity, and delete) rode that rotation outright — at 90° they draw beside the sticker, at 180° below it.
- **The buy cluster** — note field, payout caption, price control, Place button — was anchored to the sticker's *local* bottom edge and then counter-rotated upright. Anchored in the rotated frame, drawn in the screen frame: past about a quarter turn the anchor comes round over the artwork and the upright cluster paints on top of the sticker being edited. A counter-rotation fixes which way up something reads; it does not move where it lands.
- Keeping the buy button off the pills needed a second set of derived offsets (`STICKER_PANEL_BAND_PX`, `panelsFitInsideEdges`, `flippedButtonOffset`), which had already gone stale once when a third icon joined the left pill and the panel swallowed the rotate knob.

## What this does

The rotation moves down to an inner element, and all the chrome becomes that element's **sibling**. Nothing above the toolbar rotates, so nothing can turn it and nothing can swing where it is anchored.

- The two corner pills merge into the **single bar under the sticker** — the layout narrow drafts already used, now used at every size.
- The standoff is **derived from the sticker's measured size and angle** (`chromeClearance`), covering the rotated artwork, the corner handles and the rotate knob. A constant is wrong at every size; the local edge is wrong at every angle.
- The rotate knob and resize handles stay on the sticker — they belong to its box.
- `placeButtonBoxes` loses its angle argument: screen-down is now the only direction the alternative can be in. The panel-band geometry is deleted outright.

### The constraint that kills the obvious fix

> "the second line there, that all proceeds go to blah, blah, blah, is completely variable because it has the creator's name there. So depending on the length of the creator's name, there is no fixed distance that will make that work."

This adds **no** offset that depends on the caption. `payoutCopy` already splits the lead from the username (#4213) and the caller truncates it; on top of that the cluster's own height is kept out of the clearance entirely — it is anchored by the edge nearest the sticker and grows *away* from it, so its height only ever moves the far edge. The creator name is unchanged and still shown.

## Two defects found by driving the real page, not by the suite

The first commit passed five review lanes and the whole suite, then **crashed with "Maximum update depth exceeded" on every sticker drag** on a dev server. It took six retests to locate.

**1. `{ ...box }` on a `DOMRect` copies nothing.** `shiftDown` built the derived candidate box that way. A `DOMRect`'s properties are getters on the prototype rather than own enumerable ones, so the spread produced `left`/`right` undefined, and `overlaps()` then evaluated `undefined > tray.left` as `false` — **the tray was invisible to whichever of the two boxes was derived**. Unflipped, `below` was the real rect, saw the tray and flipped; flipped, `below` was derived, could not see the tray and unflipped. 39 alternations. A spread that looks like a copy, silently failing open. The type cannot catch it: `DOMRect` satisfies `Box` structurally and the spread of one type-checks while being empty at runtime. Introduced here — `origin/main`'s `shift()` named all four fields.

**2. A flip decided from a zero-height sticker.** `EdgeImage` has no intrinsic size until it loads, so a draft dragged in from the tray measures 0 tall for its first frames, and the two candidate positions land close enough together that each argues for the other. `measure` now keeps the current side until the sticker has a size.

Also reverted here: an intermediate version that wrote the margins straight to the node while the class came from state. That splits them across a render, leaving the element carrying the standoff for the side it had just left — 127px of real movement against a model that said 155.

## What the tests prove, and what they do not

Each of these was run against a revert of the thing it pins:

| Reverted | Fails with |
| --- | --- |
| `shiftDown` back to `{ ...box }` | `expected undefined to be 322` |
| same, on the both-sides decision test | `expected false to be true` |
| the two standoff **values** swapped at the call site | `expected 14 to be greater than 62.34` |
| the margins deleted | `expected '' not to be ''` |

The `DOMRect` fixture builds its edges as prototype getters, because spreading an object literal works — a literal fixture passes with or without the bug and pins nothing. A control asserts the fixture itself spreads to `{}`, using `toStrictEqual` since `toEqual` would accept `{ top: undefined }`.

### 🔴 Known coverage gaps — read this before trusting the green

**The component harness cannot reproduce any bug in the flip decision.** It loads no stylesheet, so `top-full`, `bottom-full` and `w-max` never apply and the draft has *no layout at all* — the flip geometry does not exist there. Four separate repros of the production crash were written in it and all four came back green; they could not have failed. This is stronger than "measured widths are unreliable", and it is why the two gaps below cannot be closed in that harness.

- **The flipped arm is unexercised.** `flipped` is never true in any test here — no tray, no clipping ancestor — so `marginBottom: above` is written by nothing, and mutating that arm to a constant leaves every test green.
- **The zero-size guard is deletable with every test still green.** A test for it *was* written; the control was run; it **passed with the guard deleted**, because the `ResizeObserver` delivers no re-measure inside the test's window and the assertion observed a value nothing had recomputed. It was **deleted rather than shipped as a green that proves nothing**, and what was measured while trying is recorded in the test file — including that pushing the container down the page moves the above-candidate from -305 to +155 and the flip still does not fire.

**The evidence this build works is an A/B on the live dev server — old code clean, this code broken, then fixed and confirmed — plus Justin's own retest on session `35af6413`. It is not the suite.** Follow-up filed for a browser-driven or e2e test that exercises a real flip.

### Measured, and deliberately not addressed

The clearance measures the sticker's **layout box**, not its painted silhouette. The `plate` treatment draws a backing panel at `-inset-[9%]`, outside that box, so above roughly 156px tall the toolbar still sits slightly over the plate. This is **strictly better than what shipped before** (a flat 8px `mt-2`), and the fix is one extra argument — but it is not zero, and it is not in this PR.

## Review

Five lanes, twice. First round on `ca860a008e`, all clear. Second round on `fa8c97c389`: correctness found a 🔴 comment left over from the reverted experiment that instructed the next reader to re-split the margin out of state — a trap with a comment, now deleted. Reuse swept `src/` for siblings of the `DOMRect` bug across 56 rect sites in 49 files and found none. Perf measured that rounding the standoffs would suppress 0–8% of renders on a fast rotate and 50–90% on a slow one, i.e. inverted from where it would matter, and recommended against it. Intent: ship. Tests: **not a ship** — its findings are the gaps section above, and `40d24b477e` acts on the rest of them.

One lane mutated the worktree despite being told report-only, and its `git checkout` restore ate uncommitted work. Re-verified afterwards: the zero-size guard, both margin arms and `shiftDown`'s four named fields are all present, and no `{ ...box }` spread remains.

## Not in this PR

- **The `Pending` label** on *placed* stickers. Different component (`StickerPlacementOverlay`), and its counter-rotation inside the sticker's box is deliberate: #4286 moved those marks inside precisely because outside they were clipped away near the image edges and vanished. Changing it re-opens that.
- Removing the creator name — explicitly rejected.
- Pinning favourite stickers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79q7EDZKCs2AWEHKSaeFj
