### PR TITLE
fix(jobs): fence remove-old-drafts on version and file activity

### DIFF
--- a/src/server/jobs/__tests__/remove-old-drafts-activity-filter.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts-activity-filter.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  filterModelsWithRecentActivity,
+  ACTIVITY_WINDOW_DAYS,
+  type ModelVersionActivityRow,
+} from '~/server/jobs/remove-old-drafts';
+
+/**
+ * Behavioural coverage of the activity fence.
+ *
+ * The rule also exists as SQL in the job's replica SELECT, and that copy cannot
+ * be exercised here — this repo has no DB-backed vitest project, so there is no
+ * engine to run `NOT EXISTS` against. `remove-old-drafts.test.ts` pins the SQL's
+ * text; these tests pin what the rule MEANS, on the copy that runs immediately
+ * before the delete.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-06-01T00:00:00.000Z');
+const daysBefore = (n: number) => new Date(NOW.getTime() - n * DAY_MS);
+
+// Both fixture ages are far off the 30-day boundary, on opposite sides: nothing
+// sits at the cutoff, so no clause can be skipped by landing exactly on it, and
+// a window widened to 300 days has a 200-day fixture to be caught by.
+const QUIET_DAYS = 200;
+const RECENT_DAYS = 5;
+const quiet = daysBefore(QUIET_DAYS);
+const recent = daysBefore(RECENT_DAYS);
+
+function row(over: Partial<ModelVersionActivityRow> = {}): ModelVersionActivityRow {
+  return { id: 100, modelId: 1, createdAt: quiet, updatedAt: quiet, latestFileAt: null, ...over };
+}
+
+const run = (rows: ModelVersionActivityRow[], candidates = [1]) =>
+  filterModelsWithRecentActivity(candidates, rows, NOW);
+
+describe('filterModelsWithRecentActivity', () => {
+  // POSITIVE CONTROL. Every "spared" assertion below is satisfied by an empty
+  // deletable list, so without this a fence that refuses everything — or a
+  // harness wired to nothing — reads green across the whole file.
+  it('lets a model through when every timestamp under it is long quiet', () => {
+    expect(
+      run([row()]),
+      'the quiet baseline must be DELETABLE, or every "spares" case below passes vacuously'
+    ).toEqual({ deletable: [1], skipped: [] });
+  });
+
+  it('keeps a candidate that has no versions at all', () => {
+    expect(run([])).toEqual({ deletable: [1], skipped: [] });
+  });
+
+  it('spares a model whose version was CREATED inside the window', () => {
+    expect(run([row({ createdAt: recent })]), 'clause: mv."createdAt" inside the window').toEqual({
+      deletable: [],
+      skipped: [1],
+    });
+  });
+
+  it('spares a model whose version was UPDATED inside the window', () => {
+    expect(run([row({ updatedAt: recent })]), 'clause: mv."updatedAt" inside the window').toEqual({
+      deletable: [],
+      skipped: [1],
+    });
+  });
+
+  // The reported exhibit: the model and its only version were created in the
+  // same minute and never touched again, and the trained resource arrived later
+  // as a file. This is the only clause that can see it.
+  it('spares a model whose FILE was created inside the window', () => {
+    expect(
+      run([row({ latestFileAt: recent })]),
+      'clause: mf."createdAt" inside the window'
+    ).toEqual({ deletable: [], skipped: [1] });
+  });
+
+  it('does not treat "no files" as activity', () => {
+    expect(run([row({ latestFileAt: null })])).toEqual({ deletable: [1], skipped: [] });
+  });
+
+  it('spares a model when a REQUIRED timestamp is unreadable', () => {
+    // createdAt / updatedAt are NOT NULL in the schema, so a missing value means
+    // the query shape drifted. Deleting is irreversible; sparing costs a night.
+    expect(
+      run([row({ createdAt: null })]),
+      'clause: unreadable required timestamp must fail CLOSED'
+    ).toEqual({ deletable: [], skipped: [1] });
+    expect(run([row({ updatedAt: 'not-a-date' })])).toEqual({ deletable: [], skipped: [1] });
+    expect(run([row({ latestFileAt: 'not-a-date' })])).toEqual({ deletable: [], skipped: [1] });
+  });
+
+  it('spares the WHOLE candidate set when a row carries no usable modelId', () => {
+    const orphan = { ...row(), modelId: undefined } as unknown as ModelVersionActivityRow;
+    expect(
+      run([orphan], [1, 2, 3]),
+      'clause: unattributable activity must fail CLOSED across the batch, not protect nothing'
+    ).toEqual({ deletable: [], skipped: [1, 2, 3] });
+  });
+
+  it('separates active from quiet models inside one candidate set', () => {
+    const result = run(
+      [
+        row({ id: 10, modelId: 1, latestFileAt: recent }),
+        row({ id: 20, modelId: 2 }),
+        row({ id: 30, modelId: 3, createdAt: recent }),
+        row({ id: 40, modelId: 4 }),
+      ],
+      [1, 2, 3, 4]
+    );
+    expect(result).toEqual({ deletable: [2, 4], skipped: [1, 3] });
+  });
+
+  it('protects a model when ANY of its versions is active', () => {
+    const result = run(
+      [row({ id: 10, modelId: 1 }), row({ id: 11, modelId: 1, updatedAt: recent })],
+      [1]
+    );
+    expect(result).toEqual({ deletable: [], skipped: [1] });
+  });
+
+  it('preserves the candidate order the caller supplied', () => {
+    // The SELECT orders by id for consistent lock ordering; the filter must not
+    // reshuffle what it hands to the DELETE.
+    expect(run([], [5, 1, 9])).toEqual({ deletable: [5, 1, 9], skipped: [] });
+  });
+
+  it('accepts the string timestamps a raw driver can hand back', () => {
+    expect(run([row({ latestFileAt: recent.toISOString() })])).toEqual({
+      deletable: [],
+      skipped: [1],
+    });
+    expect(run([row({ createdAt: quiet.toISOString(), updatedAt: quiet.toISOString() })])).toEqual({
+      deletable: [1],
+      skipped: [],
+    });
+  });
+
+  it('measures the window from the supplied clock, not the wall clock', () => {
+    // A row one day inside the window is active; the same row is quiet once the
+    // clock advances past it. This is what makes ACTIVITY_WINDOW_DAYS load-bearing
+    // rather than decorative.
+    const edgeIn = daysBefore(ACTIVITY_WINDOW_DAYS - 1);
+    expect(filterModelsWithRecentActivity([1], [row({ updatedAt: edgeIn })], NOW)).toEqual({
+      deletable: [],
+      skipped: [1],
+    });
+    const later = new Date(NOW.getTime() + 2 * DAY_MS);
+    expect(filterModelsWithRecentActivity([1], [row({ updatedAt: edgeIn })], later)).toEqual({
+      deletable: [1],
+      skipped: [],
+    });
+  });
+});

--- a/src/server/jobs/__tests__/remove-old-drafts.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts.test.ts
@@ -13,12 +13,62 @@ vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: mockD
 vi.mock('~/utils/logging', () => ({ createLogger: () => () => undefined }));
 vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
 
-import { removeOldDrafts } from '~/server/jobs/remove-old-drafts';
+import { removeOldDrafts, ACTIVITY_WINDOW_DAYS } from '~/server/jobs/remove-old-drafts';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 const mockDbRead = dbMock.dbRead;
 const mockDbWrite = dbMock.dbWrite;
 const mockLogToAxiom = loggingMock.logToAxiom;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number) => new Date(Date.now() - n * DAY_MS);
+
+// Fixture ages sit far off the 30-day boundary on BOTH sides — 200 days for
+// "long quiet", 5 days for "still in use". Nothing is built at 30, so no clause
+// can be reached (or missed) by landing exactly on its own cutoff, and a mutant
+// that widens the window to 300 days has somewhere to be caught.
+const QUIET_DAYS = 200;
+const RECENT_DAYS = 5;
+const quiet = () => daysAgo(QUIET_DAYS);
+const recent = () => daysAgo(RECENT_DAYS);
+
+/**
+ * A row shaped like the job's per-batch ModelVersion lookup actually returns.
+ * Defaults to "long quiet in every column" so each test names only the one
+ * timestamp it is exercising.
+ */
+function versionRow(over: { id: number; modelId: number } & Record<string, unknown>) {
+  return { createdAt: quiet(), updatedAt: quiet(), latestFileAt: null, ...over };
+}
+
+/** The tagged-template args the replica SELECT is handed: [strings, ...binds]. */
+function readSql() {
+  const [strings] = mockDbRead.$queryRaw.mock.calls[0] as [string[], ...unknown[]];
+  return strings.join('?');
+}
+
+/**
+ * The whole WHERE predicate of the replica SELECT, comments stripped and
+ * whitespace collapsed.
+ */
+function readPredicate() {
+  const flat = readSql()
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return flat.slice(flat.indexOf('WHERE '), flat.indexOf(' ORDER BY'));
+}
+
+/** Model ids handed to a given `DELETE FROM "Model"` call. */
+function deleteBatches() {
+  return mockDbWrite.$executeRaw.mock.calls.map((c) => c[1] as number[]);
+}
+
+function axiomEvents(message: string) {
+  return mockLogToAxiom.mock.calls
+    .map(([arg]) => arg as Record<string, unknown>)
+    .filter((arg) => arg.name === 'remove-old-drafts' && arg.message === message);
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -26,106 +76,332 @@ beforeEach(() => {
 });
 
 describe('removeOldDrafts', () => {
-  it('collects version ids pre-delete then deregisters them post-delete', async () => {
-    // Replica lookup: one old draft model (id 42).
-    mockDbRead.$queryRaw.mockResolvedValue([{ id: 42 }]);
-    // dbWrite.$queryRaw = the pre-delete version-id lookup.
-    mockDbWrite.$queryRaw.mockImplementation(async () => {
-      calls.push('collect-versions');
-      return [{ id: 100 }, { id: 101 }];
-    });
-    // dbWrite.$executeRaw = the cascade delete.
-    mockDbWrite.$executeRaw.mockImplementation(async () => {
-      calls.push('delete');
-      return 1;
-    });
-    mockDeregisterBatch.mockImplementation(async () => {
-      calls.push('deregister');
-      return { deleted: 2 };
-    });
+  describe('the replica SELECT predicate', () => {
+    // 🔴 This is a SPELLED guard, not a behavioural one. It pins the exact text
+    // of the predicate, so an equivalent reword — swapping the two NOT EXISTS
+    // clauses, aliasing the tables differently, writing `now() - '30 days'::interval`
+    // — fails it while changing nothing about which models get destroyed. It
+    // proves only that the predicate has not silently changed since someone last
+    // reasoned about it; it proves NOTHING about what the SQL does. The
+    // behavioural coverage of the same rule lives in the primary-side fence
+    // tests below and in remove-old-drafts-activity-filter.test.ts, because this
+    // repo has no DB-backed vitest project and the SQL itself cannot be run here.
+    it('pins the whole predicate, including both activity fences', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([]);
 
-    await (removeOldDrafts as unknown as () => Promise<void>)();
+      await (removeOldDrafts as unknown as () => Promise<void>)();
 
-    // versionIds gathered before the delete, deregister runs after it.
-    expect(calls).toEqual(['collect-versions', 'delete', 'deregister']);
-    expect(mockDeregisterBatch).toHaveBeenCalledWith([100, 101]);
-  });
-
-  it('does not call deregister when a batch has no versions', async () => {
-    mockDbRead.$queryRaw.mockResolvedValue([{ id: 42 }]);
-    mockDbWrite.$queryRaw.mockResolvedValue([]); // no versions on the model
-    mockDbWrite.$executeRaw.mockResolvedValue(1);
-
-    await (removeOldDrafts as unknown as () => Promise<void>)();
-
-    expect(mockDbWrite.$executeRaw).toHaveBeenCalledTimes(1);
-    expect(mockDeregisterBatch).not.toHaveBeenCalled();
-  });
-
-  it('does nothing when there are no old drafts to remove', async () => {
-    mockDbRead.$queryRaw.mockResolvedValue([]);
-
-    await (removeOldDrafts as unknown as () => Promise<void>)();
-
-    expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
-    expect(mockDeregisterBatch).not.toHaveBeenCalled();
-  });
-
-  it('does not deregister a batch whose delete fails, counts the error, and continues', async () => {
-    // 11 models → two batches (BATCH_SIZE=10): [1..10] then [11].
-    const modelIds = Array.from({ length: 11 }, (_, i) => i + 1);
-    mockDbRead.$queryRaw.mockResolvedValue(modelIds.map((id) => ({ id })));
-
-    // Per-batch version lookup — return ids keyed off which batch is asked for.
-    mockDbWrite.$queryRaw.mockImplementation(async (_strings: unknown, batch: number[]) =>
-      batch.includes(1) ? [{ id: 100 }, { id: 101 }] : [{ id: 200 }]
-    );
-    // The DELETE FROM "Model" rejects for the FIRST batch only; the second succeeds.
-    mockDbWrite.$executeRaw.mockImplementation(async (_strings: unknown, batch: number[]) => {
-      if (batch.includes(1)) throw new Error('deadlock detected');
-      return 1;
+      expect(readPredicate()).toBe(
+        `WHERE m.status IN ('Draft', 'Deleted') ` +
+          `AND m."updatedAt" < now() - INTERVAL '30 days' ` +
+          `AND mm."downloadCount" < 10 ` +
+          `AND m."availability" != 'Private'::"Availability" ` +
+          `AND NOT EXISTS (SELECT 1 FROM "ModelVersion" mv ` +
+          `WHERE mv."modelId" = m.id ` +
+          `AND (mv."createdAt" > now() - INTERVAL '30 days' ` +
+          `OR mv."updatedAt" > now() - INTERVAL '30 days')) ` +
+          `AND NOT EXISTS (SELECT 1 FROM "ModelVersion" mv2 ` +
+          `JOIN "ModelFile" mf ON mf."modelVersionId" = mv2.id ` +
+          `WHERE mv2."modelId" = m.id ` +
+          `AND mf."createdAt" > now() - INTERVAL '30 days')`
+      );
     });
 
-    // Job must not throw out — a failed batch is caught and the loop continues.
-    await expect((removeOldDrafts as unknown as () => Promise<void>)()).resolves.toBeUndefined();
+    // Seam guard: the SQL literal and the constant the TypeScript fence uses are
+    // two independent spellings of one rule. Nothing else makes them agree.
+    it('spells every interval with the same window the runtime fence uses', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([]);
 
-    // The failed batch's versions ([100, 101]) are NEVER deregistered — the delete
-    // never committed, so there are no orphaned file_locations to reap.
-    expect(mockDeregisterBatch).toHaveBeenCalledTimes(1);
-    expect(mockDeregisterBatch).toHaveBeenCalledWith([200]);
-    expect(mockDeregisterBatch).not.toHaveBeenCalledWith([100, 101]);
+      await (removeOldDrafts as unknown as () => Promise<void>)();
 
-    // errorCount increments → surfaced as the batch-failure Axiom error log.
-    expect(mockLogToAxiom).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'error',
-        name: 'remove-old-drafts',
-        message: 'Failed to remove batch of old draft models',
-      })
-    );
+      const sql = readSql();
+      const intervals = sql.match(/INTERVAL '\d+ days'/g) ?? [];
+      expect(intervals).toEqual(Array(4).fill(`INTERVAL '${ACTIVITY_WINDOW_DAYS} days'`));
+    });
+
+    // The selected columns are what makes a loss report answerable — see the
+    // "logs the ids" tests below, which are void if userId stops being selected.
+    it('selects the owning userId alongside the model id', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(readSql().replace(/\s+/g, ' ')).toContain('SELECT DISTINCT m.id, m."userId"');
+    });
   });
 
-  it('scopes each batch to its own version ids with no cross-batch bleed', async () => {
-    // 11 models → two batches (BATCH_SIZE=10): [1..10] then [11].
-    const modelIds = Array.from({ length: 11 }, (_, i) => i + 1);
-    mockDbRead.$queryRaw.mockResolvedValue(modelIds.map((id) => ({ id })));
+  describe('the primary-side activity fence', () => {
+    // POSITIVE CONTROL for every "spares" test below. Without it "0 models
+    // deleted" would satisfy all of them, and a harness wired to nothing — or a
+    // fence that refuses everything — would read green across the board.
+    it('deletes a candidate whose versions and files have all been quiet', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([versionRow({ id: 100, modelId: 42 })]);
+      mockDbWrite.$executeRaw.mockResolvedValue(1);
 
-    // Each batch's ModelVersion SELECT returns a disjoint set of version ids.
-    mockDbWrite.$queryRaw.mockImplementation(async (_strings: unknown, batch: number[]) =>
-      batch.includes(1) ? [{ id: 1000 }, { id: 1001 }] : [{ id: 2000 }]
-    );
-    mockDbWrite.$executeRaw.mockResolvedValue(1);
+      await (removeOldDrafts as unknown as () => Promise<void>)();
 
-    await (removeOldDrafts as unknown as () => Promise<void>)();
+      expect(
+        deleteBatches(),
+        'baseline fixtures must produce a NON-EMPTY delete list, or every "spares" assertion passes vacuously'
+      ).toEqual([[42]]);
+      expect(mockDeregisterBatch).toHaveBeenCalledWith([100]);
+    });
 
-    // The version SELECT is scoped to exactly one batch of model ids per call.
-    const selectBatches = mockDbWrite.$queryRaw.mock.calls.map((c) => c[1] as number[]);
-    expect(selectBatches).toEqual([Array.from({ length: 10 }, (_, i) => i + 1), [11]]);
+    it('spares a model whose version was CREATED inside the window', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        versionRow({ id: 100, modelId: 42, createdAt: recent() }),
+      ]);
 
-    // Deregister runs once per batch, each with only that batch's version ids —
-    // no cross-batch bleed (batch 1's [1000,1001] and batch 2's [2000] never mix).
-    expect(mockDeregisterBatch).toHaveBeenCalledTimes(2);
-    expect(mockDeregisterBatch).toHaveBeenNthCalledWith(1, [1000, 1001]);
-    expect(mockDeregisterBatch).toHaveBeenNthCalledWith(2, [2000]);
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(deleteBatches(), 'a version created inside the window must spare its model').toEqual(
+        []
+      );
+      expect(mockDeregisterBatch).not.toHaveBeenCalled();
+    });
+
+    it('spares a model whose version was UPDATED inside the window', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        versionRow({ id: 100, modelId: 42, updatedAt: recent() }),
+      ]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(deleteBatches(), 'a version updated inside the window must spare its model').toEqual(
+        []
+      );
+      expect(mockDeregisterBatch).not.toHaveBeenCalled();
+    });
+
+    // The reported exhibit, in fixture form: the model row and its only version
+    // were both created long ago and never touched again, and the finished
+    // resource landed as a ModelFile days ago. Neither Model."updatedAt" nor
+    // ModelVersion."createdAt" can see it — only the file timestamp can.
+    it('spares a model whose FILE was created inside the window, with an otherwise ancient version', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 2831418, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        versionRow({ id: 3194997, modelId: 2831418, latestFileAt: recent() }),
+      ]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(
+        deleteBatches(),
+        'a file created inside the window must spare its model even when the version is ancient'
+      ).toEqual([]);
+      expect(mockDeregisterBatch).not.toHaveBeenCalled();
+    });
+
+    it('deletes only the quiet models of a mixed batch and deregisters only their versions', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([
+        { id: 1, userId: 11 },
+        { id: 2, userId: 22 },
+      ]);
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        versionRow({ id: 100, modelId: 1, latestFileAt: recent() }), // still in use
+        versionRow({ id: 200, modelId: 2 }), // long quiet
+      ]);
+      mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(deleteBatches()).toEqual([[2]]);
+      // Deregistering the spared model's file_locations would drop its objects
+      // out of the quarantine allowlist — the same loss by another route.
+      expect(mockDeregisterBatch).toHaveBeenCalledTimes(1);
+      expect(mockDeregisterBatch).toHaveBeenCalledWith([200]);
+    });
+
+    it('spares the whole batch when a row cannot be attributed to a model', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([
+        { id: 1, userId: 11 },
+        { id: 2, userId: 22 },
+      ]);
+      // Query shape drifted: no modelId to hang the activity on.
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        { id: 100, createdAt: quiet(), updatedAt: quiet() },
+      ]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(
+        deleteBatches(),
+        'unattributable activity must fail CLOSED across the batch, not protect nothing'
+      ).toEqual([]);
+    });
+
+    it('reports the spared models to Axiom so the two fences disagreeing is visible', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        versionRow({ id: 100, modelId: 42, latestFileAt: recent() }),
+      ]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(axiomEvents('Skipped old draft models with recent version or file activity')).toEqual([
+        expect.objectContaining({ type: 'warning', modelIds: [42], userIds: [7] }),
+      ]);
+    });
+  });
+
+  describe('identifying what was destroyed', () => {
+    it('logs the deleted model ids and their owners', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([
+        { id: 1, userId: 11 },
+        { id: 2, userId: 22 },
+      ]);
+      mockDbWrite.$queryRaw.mockResolvedValue([
+        versionRow({ id: 100, modelId: 1 }),
+        versionRow({ id: 200, modelId: 2 }),
+      ]);
+      mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(axiomEvents('Removed old draft models')).toEqual([
+        expect.objectContaining({ type: 'info', modelIds: [1, 2], userIds: [11, 22] }),
+      ]);
+    });
+
+    it('keeps each id log bounded to one batch', async () => {
+      // 11 models → two batches (BATCH_SIZE=10), so two events of ≤10 ids each
+      // rather than one field carrying every id of a 1,000-model run.
+      const models = Array.from({ length: 11 }, (_, i) => ({ id: i + 1, userId: 900 + i }));
+      mockDbRead.$queryRaw.mockResolvedValue(models);
+      mockDbWrite.$queryRaw.mockImplementation(async (_s: unknown, batch: number[]) =>
+        batch.map((modelId) => versionRow({ id: modelId * 10, modelId }))
+      );
+      mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      const logged = axiomEvents('Removed old draft models').map((e) => e.modelIds as number[]);
+      expect(logged).toEqual([Array.from({ length: 10 }, (_, i) => i + 1), [11]]);
+      expect(Math.max(...logged.map((ids) => ids.length))).toBeLessThanOrEqual(10);
+    });
+
+    it('names the batch on the failure log so a failed delete is attributable too', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([versionRow({ id: 100, modelId: 42 })]);
+      mockDbWrite.$executeRaw.mockRejectedValue(new Error('deadlock detected'));
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(axiomEvents('Failed to remove batch of old draft models')).toEqual([
+        expect.objectContaining({ type: 'error', modelIds: [42] }),
+      ]);
+    });
+  });
+
+  describe('batching and the storage-resolver deregister', () => {
+    it('collects version ids pre-delete then deregisters them post-delete', async () => {
+      // Replica lookup: one old draft model (id 42).
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      // dbWrite.$queryRaw = the pre-delete version-id lookup.
+      mockDbWrite.$queryRaw.mockImplementation(async () => {
+        calls.push('collect-versions');
+        return [versionRow({ id: 100, modelId: 42 }), versionRow({ id: 101, modelId: 42 })];
+      });
+      // dbWrite.$executeRaw = the cascade delete.
+      mockDbWrite.$executeRaw.mockImplementation(async () => {
+        calls.push('delete');
+        return 1;
+      });
+      mockDeregisterBatch.mockImplementation(async () => {
+        calls.push('deregister');
+        return { deleted: 2 };
+      });
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      // versionIds gathered before the delete, deregister runs after it.
+      expect(calls).toEqual(['collect-versions', 'delete', 'deregister']);
+      expect(mockDeregisterBatch).toHaveBeenCalledWith([100, 101]);
+    });
+
+    it('does not call deregister when a batch has no versions', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([{ id: 42, userId: 7 }]);
+      mockDbWrite.$queryRaw.mockResolvedValue([]); // no versions on the model
+      mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(mockDbWrite.$executeRaw).toHaveBeenCalledTimes(1);
+      expect(mockDeregisterBatch).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there are no old drafts to remove', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+      expect(mockDeregisterBatch).not.toHaveBeenCalled();
+    });
+
+    it('does not deregister a batch whose delete fails, counts the error, and continues', async () => {
+      // 11 models → two batches (BATCH_SIZE=10): [1..10] then [11].
+      const models = Array.from({ length: 11 }, (_, i) => ({ id: i + 1, userId: 900 + i }));
+      mockDbRead.$queryRaw.mockResolvedValue(models);
+
+      // Per-batch version lookup — return ids keyed off which batch is asked for.
+      mockDbWrite.$queryRaw.mockImplementation(async (_strings: unknown, batch: number[]) =>
+        batch.includes(1)
+          ? [versionRow({ id: 100, modelId: 1 }), versionRow({ id: 101, modelId: 2 })]
+          : [versionRow({ id: 200, modelId: 11 })]
+      );
+      // The DELETE FROM "Model" rejects for the FIRST batch only; the second succeeds.
+      mockDbWrite.$executeRaw.mockImplementation(async (_strings: unknown, batch: number[]) => {
+        if (batch.includes(1)) throw new Error('deadlock detected');
+        return 1;
+      });
+
+      // Job must not throw out — a failed batch is caught and the loop continues.
+      await expect((removeOldDrafts as unknown as () => Promise<void>)()).resolves.toBeUndefined();
+
+      // The failed batch's versions ([100, 101]) are NEVER deregistered — the delete
+      // never committed, so there are no orphaned file_locations to reap.
+      expect(mockDeregisterBatch).toHaveBeenCalledTimes(1);
+      expect(mockDeregisterBatch).toHaveBeenCalledWith([200]);
+      expect(mockDeregisterBatch).not.toHaveBeenCalledWith([100, 101]);
+
+      // errorCount increments → surfaced as the batch-failure Axiom error log.
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          name: 'remove-old-drafts',
+          message: 'Failed to remove batch of old draft models',
+        })
+      );
+    });
+
+    it('scopes each batch to its own version ids with no cross-batch bleed', async () => {
+      // 11 models → two batches (BATCH_SIZE=10): [1..10] then [11].
+      const models = Array.from({ length: 11 }, (_, i) => ({ id: i + 1, userId: 900 + i }));
+      mockDbRead.$queryRaw.mockResolvedValue(models);
+
+      // Each batch's ModelVersion SELECT returns a disjoint set of version ids.
+      mockDbWrite.$queryRaw.mockImplementation(async (_strings: unknown, batch: number[]) =>
+        batch.includes(1)
+          ? [versionRow({ id: 1000, modelId: 1 }), versionRow({ id: 1001, modelId: 2 })]
+          : [versionRow({ id: 2000, modelId: 11 })]
+      );
+      mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      // The version SELECT is scoped to exactly one batch of model ids per call.
+      const selectBatches = mockDbWrite.$queryRaw.mock.calls.map((c) => c[1] as number[]);
+      expect(selectBatches).toEqual([Array.from({ length: 10 }, (_, i) => i + 1), [11]]);
+
+      // Deregister runs once per batch, each with only that batch's version ids —
+      // no cross-batch bleed (batch 1's [1000,1001] and batch 2's [2000] never mix).
+      expect(mockDeregisterBatch).toHaveBeenCalledTimes(2);
+      expect(mockDeregisterBatch).toHaveBeenNthCalledWith(1, [1000, 1001]);
+      expect(mockDeregisterBatch).toHaveBeenNthCalledWith(2, [2000]);
+    });
   });
 });

--- a/src/server/jobs/__tests__/remove-old-drafts.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts.test.ts
@@ -52,14 +52,30 @@ function readSql() {
 }
 
 /**
+ * The replica SELECT with `--` comments stripped and whitespace collapsed —
+ * i.e. the SQL the database actually executes.
+ *
+ * 🔴 EVERY guard that matches SQL text must read THIS, never raw `readSql()`.
+ * A `--` comment is not a clause, and matching against un-stripped text gets it
+ * wrong in both directions: a comment that merely MENTIONS a clause is counted
+ * as one (the interval-count guard below then reports an escaped clause that
+ * does not exist, for a change that only added documentation), and a comment
+ * quoting a clause's exact text SATISFIES a `toContain` guard with the real
+ * clause deleted. This SELECT already carries `--` comments, so both are live.
+ */
+function readExecutableSql() {
+  return readSql()
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
  * The whole WHERE predicate of the replica SELECT, comments stripped and
  * whitespace collapsed.
  */
 function readPredicate() {
-  const flat = readSql()
-    .replace(/--[^\n]*/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  const flat = readExecutableSql();
   return flat.slice(flat.indexOf('WHERE '), flat.indexOf(' ORDER BY'));
 }
 
@@ -111,8 +127,13 @@ describe('removeOldDrafts', () => {
       );
     });
 
-    // Seam guard: the SQL literals and the constants the TypeScript fence uses
-    // are two independent spellings of one rule. Nothing else makes them agree.
+    // Seam guard: the SQL literals and the two exported constants are independent
+    // spellings of one rule, and these tests are the only thing making them agree.
+    //
+    // The two constants are NOT symmetric, and the guards below are what makes the
+    // difference visible: ACTIVITY_WINDOW_DAYS is read at runtime, by
+    // filterModelsWithRecentActivity; REAP_AGE_DAYS has no runtime reader at all
+    // and is a documentation anchor for the m."updatedAt" literal.
     //
     // 🔴 The fence clauses and the abandonment threshold are asserted SEPARATELY,
     // against separate constants, even though both are 30 today. Pinning all four
@@ -120,14 +141,16 @@ describe('removeOldDrafts', () => {
     // maintainer narrowing the fence to 7 days would see it go red and "fix" it by
     // rewriting the m."updatedAt" clause too — which does not narrow the fence, it
     // widens what the reaper DESTROYS, from untouched-for-30-days to
-    // untouched-for-7-days, with the suite green. The guard must never point an
-    // edit at the deletion threshold.
+    // untouched-for-7-days. (The whole-predicate pin above would also have gone
+    // red in that world, so the hazard was one step longer than "suite green" —
+    // but the red it shows names no clause, and the repair it invites is the
+    // dangerous one.) The guard must never point an edit at the deletion threshold.
     it('spells the three fence intervals with the window the runtime fence uses', async () => {
       mockDbRead.$queryRaw.mockResolvedValue([]);
 
       await (removeOldDrafts as unknown as () => Promise<void>)();
 
-      const sql = readSql().replace(/\s+/g, ' ');
+      const sql = readExecutableSql();
       const w = ACTIVITY_WINDOW_DAYS;
       for (const clause of [
         `mv."createdAt" > now() - INTERVAL '${w} days'`,
@@ -144,19 +167,20 @@ describe('removeOldDrafts', () => {
       await (removeOldDrafts as unknown as () => Promise<void>)();
 
       expect(
-        readSql().replace(/\s+/g, ' '),
+        readExecutableSql(),
         'the age threshold is what the reaper DESTROYS on; it is not part of the fence'
       ).toContain(`m."updatedAt" < now() - INTERVAL '${REAP_AGE_DAYS} days'`);
     });
 
-    // Keeps the two assertions above exhaustive: a fifth interval appearing in
-    // this SELECT is a clause neither of them is looking at.
-    it('carries exactly four day intervals, so no clause escapes the two guards above', async () => {
+    // Keeps the interval guards above exhaustive: an interval appearing in this
+    // SELECT that none of them names is a clause nobody is looking at. Counted
+    // against comment-stripped SQL, so documenting a clause is not adding one.
+    it('carries no day interval that the guards above do not name', async () => {
       mockDbRead.$queryRaw.mockResolvedValue([]);
 
       await (removeOldDrafts as unknown as () => Promise<void>)();
 
-      expect(readSql().match(/INTERVAL '\d+ days'/g) ?? []).toHaveLength(4);
+      expect(readExecutableSql().match(/INTERVAL '\d+ days'/g) ?? []).toHaveLength(4);
     });
 
     // The selected columns are what makes a loss report answerable — see the
@@ -166,7 +190,7 @@ describe('removeOldDrafts', () => {
 
       await (removeOldDrafts as unknown as () => Promise<void>)();
 
-      expect(readSql().replace(/\s+/g, ' ')).toContain('SELECT DISTINCT m.id, m."userId"');
+      expect(readExecutableSql()).toContain('SELECT DISTINCT m.id, m."userId"');
     });
   });
 

--- a/src/server/jobs/__tests__/remove-old-drafts.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts.test.ts
@@ -52,8 +52,7 @@ function readSql() {
 }
 
 /**
- * The replica SELECT with `--` comments stripped and whitespace collapsed —
- * i.e. the SQL the database actually executes.
+ * The replica SELECT with `--` comments stripped and whitespace collapsed.
  *
  * 🔴 EVERY guard that matches SQL text must read THIS, never raw `readSql()`.
  * A `--` comment is not a clause, and matching against un-stripped text gets it
@@ -62,6 +61,16 @@ function readSql() {
  * does not exist, for a change that only added documentation), and a comment
  * quoting a clause's exact text SATISFIES a `toContain` guard with the real
  * clause deleted. This SELECT already carries `--` comments, so both are live.
+ *
+ * ⚠ This is an APPROXIMATION of what the database executes, not a SQL parser,
+ * and it is deliberately not one. `--` inside a quoted string literal is stripped
+ * here but is NOT a comment to PostgreSQL, so a clause written after one on the
+ * same line becomes invisible to every guard below — i.e. this trades the
+ * false-RED it exists to remove for a narrow false-GREEN. Reaching it takes a
+ * `--`-bearing string literal, on one line, before a new clause, OUTSIDE the
+ * `WHERE … ORDER BY` slice (inside it the whole-predicate pin still fails loudly).
+ * Nothing in this SELECT is near that shape. If one is ever added, assert that the
+ * raw SQL contains no quoted `--` rather than trying to parse it here.
  */
 function readExecutableSql() {
   return readSql()

--- a/src/server/jobs/__tests__/remove-old-drafts.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts.test.ts
@@ -13,7 +13,11 @@ vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: mockD
 vi.mock('~/utils/logging', () => ({ createLogger: () => () => undefined }));
 vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
 
-import { removeOldDrafts, ACTIVITY_WINDOW_DAYS } from '~/server/jobs/remove-old-drafts';
+import {
+  removeOldDrafts,
+  ACTIVITY_WINDOW_DAYS,
+  REAP_AGE_DAYS,
+} from '~/server/jobs/remove-old-drafts';
 import { dbMock } from '~/__tests__/mocks/db.mock';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 const mockDbRead = dbMock.dbRead;
@@ -107,16 +111,52 @@ describe('removeOldDrafts', () => {
       );
     });
 
-    // Seam guard: the SQL literal and the constant the TypeScript fence uses are
-    // two independent spellings of one rule. Nothing else makes them agree.
-    it('spells every interval with the same window the runtime fence uses', async () => {
+    // Seam guard: the SQL literals and the constants the TypeScript fence uses
+    // are two independent spellings of one rule. Nothing else makes them agree.
+    //
+    // 🔴 The fence clauses and the abandonment threshold are asserted SEPARATELY,
+    // against separate constants, even though both are 30 today. Pinning all four
+    // literals to ACTIVITY_WINDOW_DAYS made this guard actively dangerous: a
+    // maintainer narrowing the fence to 7 days would see it go red and "fix" it by
+    // rewriting the m."updatedAt" clause too — which does not narrow the fence, it
+    // widens what the reaper DESTROYS, from untouched-for-30-days to
+    // untouched-for-7-days, with the suite green. The guard must never point an
+    // edit at the deletion threshold.
+    it('spells the three fence intervals with the window the runtime fence uses', async () => {
       mockDbRead.$queryRaw.mockResolvedValue([]);
 
       await (removeOldDrafts as unknown as () => Promise<void>)();
 
-      const sql = readSql();
-      const intervals = sql.match(/INTERVAL '\d+ days'/g) ?? [];
-      expect(intervals).toEqual(Array(4).fill(`INTERVAL '${ACTIVITY_WINDOW_DAYS} days'`));
+      const sql = readSql().replace(/\s+/g, ' ');
+      const w = ACTIVITY_WINDOW_DAYS;
+      for (const clause of [
+        `mv."createdAt" > now() - INTERVAL '${w} days'`,
+        `mv."updatedAt" > now() - INTERVAL '${w} days'`,
+        `mf."createdAt" > now() - INTERVAL '${w} days'`,
+      ]) {
+        expect(sql, `fence clause must use ACTIVITY_WINDOW_DAYS (${w})`).toContain(clause);
+      }
+    });
+
+    it('spells the abandonment threshold with its own constant, not the fence window', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(
+        readSql().replace(/\s+/g, ' '),
+        'the age threshold is what the reaper DESTROYS on; it is not part of the fence'
+      ).toContain(`m."updatedAt" < now() - INTERVAL '${REAP_AGE_DAYS} days'`);
+    });
+
+    // Keeps the two assertions above exhaustive: a fifth interval appearing in
+    // this SELECT is a clause neither of them is looking at.
+    it('carries exactly four day intervals, so no clause escapes the two guards above', async () => {
+      mockDbRead.$queryRaw.mockResolvedValue([]);
+
+      await (removeOldDrafts as unknown as () => Promise<void>)();
+
+      expect(readSql().match(/INTERVAL '\d+ days'/g) ?? []).toHaveLength(4);
     });
 
     // The selected columns are what makes a loss report answerable — see the
@@ -213,6 +253,20 @@ describe('removeOldDrafts', () => {
       // out of the quarantine allowlist — the same loss by another route.
       expect(mockDeregisterBatch).toHaveBeenCalledTimes(1);
       expect(mockDeregisterBatch).toHaveBeenCalledWith([200]);
+
+      // The loss report has to be right in exactly this case — a batch where the
+      // fence actually fired. Every OTHER test of these two events uses a batch
+      // in which `deletable`, `skipped` and `batch` are the same list, so each
+      // one is satisfied by logging any of the three. Only here do they differ,
+      // which makes this the only place a mutant swapping them can be caught.
+      expect(
+        axiomEvents('Removed old draft models'),
+        'the destroyed-ids event must name the models actually deleted, not the whole batch'
+      ).toEqual([expect.objectContaining({ type: 'info', modelIds: [2], userIds: [22] })]);
+      expect(
+        axiomEvents('Skipped old draft models with recent version or file activity'),
+        'the spared-models warning must name the models actually spared, not the whole batch'
+      ).toEqual([expect.objectContaining({ type: 'warning', modelIds: [1], userIds: [11] })]);
     });
 
     it('spares the whole batch when a row cannot be attributed to a model', async () => {

--- a/src/server/jobs/remove-old-drafts.ts
+++ b/src/server/jobs/remove-old-drafts.ts
@@ -27,9 +27,17 @@ export const ACTIVITY_WINDOW_DAYS = 30;
 /**
  * How long a model's own row must have gone untouched before it is even a
  * deletion CANDIDATE — the abandonment threshold, not part of the fence.
+ * Lowering it WIDENS what the reaper destroys.
  *
- * Lowering this widens what the reaper destroys. It is read only by the
- * `m."updatedAt"` clause in the SELECT below.
+ * 🔴 This constant has NO runtime reader, and changing it alone changes NOTHING.
+ * The SELECT below spells the threshold as a SQL literal — a literal cannot read
+ * a TypeScript constant — so this is a documentation anchor that
+ * `remove-old-drafts.test.ts` pins the literal against, and nothing more. To
+ * actually move the threshold you must edit the `m."updatedAt"` literal in the
+ * SQL as well; the test will fail until you do.
+ *
+ * Note the asymmetry with `ACTIVITY_WINDOW_DAYS`, which IS read at runtime, by
+ * `filterModelsWithRecentActivity`. The two are not interchangeable.
  */
 export const REAP_AGE_DAYS = 30;
 

--- a/src/server/jobs/remove-old-drafts.ts
+++ b/src/server/jobs/remove-old-drafts.ts
@@ -8,15 +8,30 @@ import { chunk } from 'lodash-es';
 const log = createLogger('remove-old-drafts');
 
 /**
- * How long a model must go untouched before the reaper may delete it.
+ * How recently something under a model must have moved for the model to count as
+ * still in use, and therefore be SPARED.
  *
- * Two places have to agree on this number: the `INTERVAL '30 days'` literals in
+ * Two places have to agree on this number: the three fence `INTERVAL` literals in
  * the SELECT below, and `filterModelsWithRecentActivity`. A Prisma tagged
  * template cannot bind an interval without turning the predicate into an opaque
  * expression, so the SQL keeps the literal and `remove-old-drafts.test.ts` pins
  * the two together instead.
+ *
+ * 🔴 Deliberately SEPARATE from `REAP_AGE_DAYS` even though both are 30 today.
+ * Raising this spares more; lowering it spares fewer. It must never be the same
+ * symbol as the age threshold, or a maintainer narrowing the fence would be
+ * steered by a failing test into narrowing what the reaper deletes as well.
  */
 export const ACTIVITY_WINDOW_DAYS = 30;
+
+/**
+ * How long a model's own row must have gone untouched before it is even a
+ * deletion CANDIDATE — the abandonment threshold, not part of the fence.
+ *
+ * Lowering this widens what the reaper destroys. It is read only by the
+ * `m."updatedAt"` clause in the SELECT below.
+ */
+export const REAP_AGE_DAYS = 30;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -124,6 +139,8 @@ export const removeOldDrafts = createJob('remove-old-drafts', '43 2 * * *', asyn
     FROM "Model" m
     JOIN "ModelMetric" mm ON mm."modelId" = m.id
     WHERE m.status IN ('Draft', 'Deleted')
+      -- REAP_AGE_DAYS. Abandonment threshold: lowering this WIDENS what is
+      -- destroyed. Not part of the fence below, and not tied to its window.
       AND m."updatedAt" < now() - INTERVAL '30 days'
       AND mm."downloadCount" < 10
       -- Private models are a creator's own workspace rather than an abandoned

--- a/src/server/jobs/remove-old-drafts.ts
+++ b/src/server/jobs/remove-old-drafts.ts
@@ -7,17 +7,137 @@ import { chunk } from 'lodash-es';
 
 const log = createLogger('remove-old-drafts');
 
+/**
+ * How long a model must go untouched before the reaper may delete it.
+ *
+ * Two places have to agree on this number: the `INTERVAL '30 days'` literals in
+ * the SELECT below, and `filterModelsWithRecentActivity`. A Prisma tagged
+ * template cannot bind an interval without turning the predicate into an opaque
+ * expression, so the SQL keeps the literal and `remove-old-drafts.test.ts` pins
+ * the two together instead.
+ */
+export const ACTIVITY_WINDOW_DAYS = 30;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * One `ModelVersion` of a delete candidate, plus the newest `ModelFile` hanging
+ * off it. `latestFileAt` is legitimately `null` for a version that carries no
+ * files; `createdAt` / `updatedAt` are NOT NULL in the schema, so a missing
+ * value there means the query shape drifted, not that the row is quiet.
+ */
+export type ModelVersionActivityRow = {
+  id: number;
+  modelId: number;
+  createdAt: Date | string | null;
+  updatedAt: Date | string | null;
+  latestFileAt: Date | string | null;
+};
+
+/** Milliseconds, or `undefined` when the value is absent or unparseable. */
+function stampTime(value: unknown): number | undefined {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isNaN(t) ? undefined : t;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const t = new Date(value).getTime();
+    return Number.isNaN(t) ? undefined : t;
+  }
+  return undefined;
+}
+
+/**
+ * Second, independent activity fence, evaluated on the PRIMARY immediately
+ * before the cascade delete.
+ *
+ * The SQL fence in the job runs against the read replica minutes earlier, so it
+ * cannot see a version or file written during replica lag or in the window
+ * between the SELECT and the DELETE. This re-checks the same rule on rows the
+ * write database just handed back. Deleting a model cascades to every
+ * ModelVersion and ModelFile under it and is irreversible; sparing one costs a
+ * single night, so every ambiguous case resolves toward sparing it.
+ *
+ * Fails CLOSED, in both directions the shape can go wrong:
+ *  - a row whose `createdAt`/`updatedAt` cannot be read protects its model;
+ *  - a row whose `modelId` cannot be read cannot be attributed to any model, so
+ *    it protects the whole candidate set rather than silently protecting none.
+ */
+export function filterModelsWithRecentActivity(
+  candidateModelIds: number[],
+  rows: ModelVersionActivityRow[],
+  now: Date = new Date()
+): { deletable: number[]; skipped: number[] } {
+  const cutoff = now.getTime() - ACTIVITY_WINDOW_DAYS * MS_PER_DAY;
+  const active = new Set<number>();
+
+  for (const row of rows) {
+    const modelId = row?.modelId;
+    if (typeof modelId !== 'number' || !Number.isFinite(modelId)) {
+      // Unattributable activity. `active.add(undefined)` would quietly protect
+      // nothing, so refuse the entire batch instead.
+      return { deletable: [], skipped: [...candidateModelIds] };
+    }
+
+    const created = stampTime(row.createdAt);
+    const updated = stampTime(row.updatedAt);
+    if (created === undefined || updated === undefined) {
+      active.add(modelId);
+      continue;
+    }
+    if (created > cutoff || updated > cutoff) {
+      active.add(modelId);
+      continue;
+    }
+
+    // A null here means "this version has no files", which is quiet, not
+    // malformed — so it must not protect the model. A non-null value that will
+    // not parse is malformed and does.
+    if (row.latestFileAt !== null && row.latestFileAt !== undefined) {
+      const fileAt = stampTime(row.latestFileAt);
+      if (fileAt === undefined || fileAt > cutoff) active.add(modelId);
+    }
+  }
+
+  const deletable: number[] = [];
+  const skipped: number[] = [];
+  for (const id of candidateModelIds) (active.has(id) ? skipped : deletable).push(id);
+  return { deletable, skipped };
+}
+
 export const removeOldDrafts = createJob('remove-old-drafts', '43 2 * * *', async () => {
   // Step 1: Query replica (dbRead) for model IDs to delete
   // This offloads the read operation from the write database and prevents lock contention
   // Uses Model.status (indexed) instead of ModelMetric.status for faster lookups
-  const rows = await dbRead.$queryRaw<{ id: number }[]>`
-    SELECT DISTINCT m.id
+  //
+  // `Model."updatedAt"` is a Prisma `@updatedAt` column: it moves only when a
+  // client writes the Model ROW. Creating a version, finishing a training run
+  // and uploading a file all write ModelVersion/ModelFile and leave the Model
+  // row alone, so on a draft the clock freezes at "creator last edited the
+  // model's metadata" while the finished resource lands hours or weeks later.
+  // On its own the age test therefore reaps models that are actively being
+  // worked on, together with their training datasets. The two NOT EXISTS
+  // clauses below are the fence: a model is only quiet if nothing underneath it
+  // has moved either.
+  const rows = await dbRead.$queryRaw<{ id: number; userId: number }[]>`
+    SELECT DISTINCT m.id, m."userId"
     FROM "Model" m
     JOIN "ModelMetric" mm ON mm."modelId" = m.id
     WHERE m.status IN ('Draft', 'Deleted')
       AND m."updatedAt" < now() - INTERVAL '30 days'
       AND mm."downloadCount" < 10
+      -- Private models are a creator's own workspace rather than an abandoned
+      -- publish attempt, and are never publicly discoverable, so the abandoned-
+      -- draft rationale does not apply to them at all.
+      AND m."availability" != 'Private'::"Availability"
+      AND NOT EXISTS (SELECT 1 FROM "ModelVersion" mv
+                       WHERE mv."modelId" = m.id
+                         AND (mv."createdAt" > now() - INTERVAL '30 days'
+                           OR mv."updatedAt" > now() - INTERVAL '30 days'))
+      AND NOT EXISTS (SELECT 1 FROM "ModelVersion" mv2
+                       JOIN "ModelFile" mf ON mf."modelVersionId" = mv2.id
+                       WHERE mv2."modelId" = m.id
+                         AND mf."createdAt" > now() - INTERVAL '30 days')
     ORDER BY m.id  -- Consistent lock ordering to prevent deadlocks
   `;
 
@@ -30,9 +150,11 @@ export const removeOldDrafts = createJob('remove-old-drafts', '43 2 * * *', asyn
   // Step 2: Delete in batches using dbWrite to minimize lock duration
   // Small batch size (10) because each Model delete cascades to 20+ related tables
   const modelIds = rows.map((r) => r.id);
+  const userByModelId = new Map(rows.map((r) => [r.id, r.userId] as const));
   const BATCH_SIZE = 10;
   let deletedCount = 0;
   let errorCount = 0;
+  let skippedCount = 0;
 
   log(`Found ${modelIds.length} old draft models to remove`);
 
@@ -41,17 +163,59 @@ export const removeOldDrafts = createJob('remove-old-drafts', '43 2 * * *', asyn
     try {
       // Collect the version ids BEFORE the cascade nukes the ModelVersion rows —
       // once the Model delete cascades, this lookup returns nothing. These feed
-      // the post-delete storage-resolver deregister below.
-      const versionRows = await dbWrite.$queryRaw<{ id: number }[]>`
-        SELECT id FROM "ModelVersion" WHERE "modelId" = ANY(${batch})
+      // the post-delete storage-resolver deregister below, and the same rows
+      // carry the timestamps the primary-side activity fence re-checks.
+      const versionRows = await dbWrite.$queryRaw<ModelVersionActivityRow[]>`
+        SELECT mv.id,
+               mv."modelId",
+               mv."createdAt",
+               mv."updatedAt",
+               (SELECT max(mf."createdAt") FROM "ModelFile" mf
+                 WHERE mf."modelVersionId" = mv.id) AS "latestFileAt"
+        FROM "ModelVersion" mv
+        WHERE mv."modelId" = ANY(${batch})
       `;
-      const versionIds = versionRows.map((v) => v.id);
+
+      const { deletable, skipped } = filterModelsWithRecentActivity(batch, versionRows, new Date());
+
+      if (skipped.length > 0) {
+        // The replica fence and the primary fence disagreed. Either replica lag
+        // or a write that landed between the SELECT and here — both mean this
+        // model was still in use and would have been destroyed.
+        skippedCount += skipped.length;
+        logToAxiom({
+          type: 'warning',
+          name: 'remove-old-drafts',
+          message: 'Skipped old draft models with recent version or file activity',
+          modelIds: skipped,
+          userIds: skipped.map((id) => userByModelId.get(id) ?? null),
+        });
+      }
+
+      if (deletable.length === 0) continue;
+
+      const deletableSet = new Set(deletable);
+      // Only the versions of models we are actually about to delete. Deregistering
+      // a spared model's file_locations would drop its objects out of the
+      // dereference-quarantine allowlist — the same data loss by another route.
+      const versionIds = versionRows.filter((v) => deletableSet.has(v.modelId)).map((v) => v.id);
 
       await dbWrite.$executeRaw`
         DELETE FROM "Model"
-        WHERE id = ANY(${batch})
+        WHERE id = ANY(${deletable})
       `;
-      deletedCount += batch.length;
+      deletedCount += deletable.length;
+
+      // Identify what was destroyed. The delete is irreversible and cascades, so
+      // without the ids a later "my model vanished" report is unanswerable.
+      // Bounded by construction: one event per batch, so at most BATCH_SIZE ids.
+      logToAxiom({
+        type: 'info',
+        name: 'remove-old-drafts',
+        message: 'Removed old draft models',
+        modelIds: deletable,
+        userIds: deletable.map((id) => userByModelId.get(id) ?? null),
+      });
 
       // Post-delete: deregister storage-resolver file_locations for the reaped
       // versions. The FK cascade removes ModelVersion/ModelFile rows but leaves
@@ -82,10 +246,15 @@ export const removeOldDrafts = createJob('remove-old-drafts', '43 2 * * *', asyn
         message: `Failed to remove batch of old draft models`,
         error: e.message,
         stack: e.stack,
+        modelIds: batch,
       });
       // Continue with remaining batches even if one fails
     }
   }
 
-  log(`Removed ${deletedCount} old draft models${errorCount > 0 ? `, ${errorCount} failed` : ''}`);
+  log(
+    `Removed ${deletedCount} old draft models` +
+      `${skippedCount > 0 ? `, ${skippedCount} skipped for recent activity` : ''}` +
+      `${errorCount > 0 ? `, ${errorCount} failed` : ''}`
+  );
 });


### PR DESCRIPTION
## The defect

`remove-old-drafts` (nightly, `43 2 * * *`) selects every `Draft`/`Deleted` model where

```sql
m."updatedAt" < now() - INTERVAL '30 days' AND mm."downloadCount" < 10
```

and runs `DELETE FROM "Model"`, which cascades to every `ModelVersion` and `ModelFile` under it. There is no soft-delete and no recovery.

`Model.updatedAt` is a Prisma `@updatedAt` column, so it moves **only** when a client writes the `Model` row. None of the things that actually happen to a draft write that row:

| what happens | writes `Model`? |
|---|---|
| `upsertModelVersion` | no — `ModelVersion` only |
| training completion (`training.service.ts`) | no — `ModelVersion` only |
| file upload | no |
| `updateModelLastVersionAt` | returns early unless a **Published** version exists, so never for a draft |
| trainer UI (`TrainingBasicInfo`) | skips the model write when the form is not dirty |

That last one makes the miss the *default* rather than an edge case. So on a draft the clock freezes at "creator last edited the model's metadata", while the finished LoRA arrives much later as a `ModelFile` — and the job then reads a model that is actively being worked on as thirty days abandoned.

### Exhibit

Model **2831418**: `createdAt == updatedAt`, never touched again. Version **3194997** updated much later, `trainingStatus = Approved`. A 272 MB `Model` file created hours before the reap ran, plus a 113 MB `Training Data` file with `dataPurged = false`. It matched the predicate exactly.

### Blast radius (measured twice on a real candidate set)

- 1,103 models / 691 users selected per night
- **139** had version-or-file activity inside the 30-day window
- **138** of those still held a training dataset
- ~65 by the stricter "a file was created in the last 30 days" test

## What this changes

### 1. The activity fence, in the replica SELECT

```sql
AND m."availability" != 'Private'::"Availability"
AND NOT EXISTS (SELECT 1 FROM "ModelVersion" mv
                 WHERE mv."modelId" = m.id
                   AND (mv."createdAt" > now() - INTERVAL '30 days'
                     OR mv."updatedAt" > now() - INTERVAL '30 days'))
AND NOT EXISTS (SELECT 1 FROM "ModelVersion" mv2
                 JOIN "ModelFile" mf ON mf."modelVersionId" = mv2.id
                 WHERE mv2."modelId" = m.id
                   AND mf."createdAt" > now() - INTERVAL '30 days')
```

The `Private` exclusion is spelled the way `reset-to-draft-without-requirements.ts` already spells it, and `Availability` is confirmed against `schema.full.prisma`. Both `NOT EXISTS` resolve by index (`ModelVersion(modelId)` hash, `ModelFile(modelVersionId)` hash); measured cost on the real candidate set was **345 ms → 327 ms**.

Two fixes that look obvious and **do not work**, both refuted on the exhibit, whose version was created in the same minute as the model:

- fencing on the newest `ModelVersion."createdAt"` alone
- bumping `Model."updatedAt"` on version create

Only a fence that reads `ModelFile."createdAt"` or `ModelVersion."updatedAt"` catches it.

### 2. Log what was destroyed

The job previously logged counts only, which is why a user's loss report was unreconstructable. It now emits one Axiom event **per batch** carrying that batch's `modelIds` and `userIds` — bounded by `BATCH_SIZE`, so at most 10 ids per event rather than one field holding 1,100. Skipped models and failed batches are named the same way. `userId` is picked up from the SELECT that was already reading `Model`.

### 3. `filterModelsWithRecentActivity` — implemented, and why

The brief left this as a judgement call. **Implemented.** Three reasons:

1. **It is the only behavioural coverage that exists.** There is no DB-backed vitest project here (no `pg-mem`, no testcontainers), so the SQL cannot be executed in a test. Without a TypeScript copy of the rule, the entire fence is covered by a *spelled* string assertion and nothing more.
2. **It closes a hole the SQL cannot.** The SELECT runs against the **read replica**, minutes before the delete. It cannot see a version or file written during replica lag, or in the window between the SELECT and the DELETE. The helper re-checks the same rule on the **primary**, on rows read inside the batch loop, immediately before the `DELETE`. When the two fences disagree, that is logged as a warning — which is also the signal that this hole is real.
3. **The stated cost does not materialise.** The brief priced this at "an extra query per batch". It needs none: the loop already runs a per-batch `ModelVersion` lookup to collect version ids before the cascade, and that query now returns the timestamps too (plus a `max(ModelFile."createdAt")` correlated subquery, index-resolved).

It fails **closed** in both directions the row shape can go wrong: an unreadable required timestamp protects its model, and a row with no usable `modelId` cannot be attributed to anything, so it refuses the whole batch rather than silently protecting none. Sparing a model costs one night; deleting one cannot be undone.

Related correctness fix that falls out of this: only the versions of models **actually deleted** are handed to `deregisterFileLocationsBatch`. Deregistering a spared model's `file_locations` would drop its objects out of the dereference-quarantine allowlist — the same data loss by another route.

## Verification

**Red → green matrix**, `remove-old-drafts.test.ts` held at this branch with the job file reverted to `origin/main`:

| | `origin/main` job | HEAD |
|---|---|---|
| `remove-old-drafts.test.ts` | **12 failed / 6 passed (18)** | 18 passed |
| `remove-old-drafts-activity-filter.test.ts` | n/a — the helper is new | 13 passed |

The three data-loss regressions each failed at base with their own named assertion:

```
a version created inside the window must spare its model: expected [ [ 42 ] ] to deeply equal []
a version updated inside the window must spare its model: expected [ [ 42 ] ] to deeply equal []
a file created inside the window must spare its model even when the version is ancient:
  expected [ [ 2831418 ] ] to deeply equal []
```

No import abort — the file collected all 18 tests at base and every failure was a real assertion.

**Positive controls.** Both files open with a case asserting the baseline fixtures produce a **non-empty** delete list, so "0 models deleted" can never satisfy the `spares…` assertions vacuously. Both pass at `origin/main` *and* at HEAD, which is what a positive control should do. Mutant H7 (below) exists to prove they can fail.

**Mutation sweep — 14 mutants, each isolating one clause, all killed, none unapplied.** Every mutant asserted its own source-text change before running (a mutant that fails to apply otherwise "survives" for free).

| # | mutation | killed by |
|---|---|---|
| H1 | helper `created > cutoff` → `<` | `clause: mv."createdAt" inside the window` |
| H2 | helper `updated > cutoff` → `<` | `clause: mv."updatedAt" inside the window` |
| H3 | helper `fileAt > cutoff` → `<` | `clause: mf."createdAt" inside the window` (6 failures, no positive-control collateral) |
| H4 | `ACTIVITY_WINDOW_DAYS` 30 → 300 | seam guard: `expected [INTERVAL '30 days'…] to deeply equal [INTERVAL '300 days'…]` |
| H5 | drop the required-timestamp fail-closed | `clause: unreadable required timestamp must fail CLOSED` — **kills exactly 1 test** |
| H6 | drop the unattributable-row fail-closed | `clause: unattributable activity must fail CLOSED across the batch` — kills exactly 2 |
| H7 | treat a null `latestFileAt` as activity | the quiet-baseline positive control |
| S1–S3 | SQL `>` → `<` in each of the three date clauses | the predicate pin |
| S4 | SQL interval 30 → 300 in the version clause | predicate pin + seam guard |
| S5 | drop the `Private` exclusion | the predicate pin |
| S6 | drop the whole `ModelFile` `NOT EXISTS` clause | predicate pin + seam guard |
| S7 | drop `userId` from the select list | `selects the owning userId alongside the model id` — kills exactly 1 |

Fixtures are built at **5 days** and **200 days**, never at 30, so no clause is reached or missed by landing on its own boundary, and a window widened to 300 days has a 200-day fixture to be caught by.

## Two honest limitations

**The predicate pin is a spelled guard, and it is labelled as one in the code.** An equivalent reword — swapping the two `NOT EXISTS`, aliasing the tables differently, writing `now() - '30 days'::interval` — fails it while changing nothing about which models get destroyed. It proves the predicate has not silently changed; it proves nothing about what the SQL *does*. That limitation is why mutants **S1–S6 die only to a string comparison**: S6 in particular deletes a real data-loss guard and no behavioural test can see it. Closing that properly needs a DB-backed test project, which does not exist in this repo.

**H1, H2, H4 and H7 also kill the positive control**, so they die for more than one reason. H3, H5, H6 and S7 are cleanly isolated — they fail only their own named assertion. `ACTIVITY_WINDOW_DAYS` is deliberately one constant in one place, so its mutation is necessarily global and cannot be isolated further.

## Checks run

- `pnpm typecheck` — **0 errors**. (Instrument validated: it reported 10 errors minutes earlier, from an unpopulated `event-engine-common` submodule in the fresh worktree, and went to 0 once initialised.)
- `pnpm run test:unit:run src/server/jobs/__tests__` — **512 passed / 47 files**
- `pnpm run test:lint-rules` — **448 passed / 28 files**
- `eslint` on the three changed files — clean
- `prettier --check` — clean (it flagged all three before `--write`, so the check is live)

No SQL was run against production for this change; the cost and blast-radius numbers are from the prior investigation.

## Reviewer questions

1. **Should `Deleted` models be fenced too, or only `Draft`?** The fence currently applies to both. A `Deleted` model with a recent file upload is a stranger case and arguably should still be reaped.
2. **Is refusing the whole batch on an unattributable row too blunt?** It costs one night for the batch. The alternative (protect nothing) is how the fence would fail open if the query shape ever drifts.
3. **The `Private` exclusion narrows the reaper permanently.** Private drafts will now never be collected by this job. If they should be reaped on some other schedule, that is a separate change.
