### PR TITLE
fix(licensing): judge the stored per-image fee stamp on saves that omit it

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/migration.sql
@@ -1,5 +1,5 @@
--- The other half of 20260831200000_clear_orphaned_licensing_source: the same predicate, with the
--- bound inverted, for the versions that one deliberately left alone.
+-- The other half of 20260831200000_clear_orphaned_licensing_source: the versions that one
+-- deliberately left alone.
 --
 -- That migration scoped itself to versions created on or after the LicensingRoot table's first rows
 -- (2026-07-15 21:56:17 UTC) because an older version may have been offered a checkpoint's root by a
@@ -7,21 +7,46 @@
 -- ruled on 2026-09-02 that the state is wrong regardless and is to be corrected, so the carve-out
 -- goes (CU 868kwf2fd).
 --
--- Measured on prod the same day: 23 rows match, unchanged from the 23 that migration left. All 23
--- predate the table, all are model-type mismatches only (0 have a base model that disagrees with
--- their source), none lands on a Checkpoint model, and none has been touched since 2026-07-14. The
--- in-scope half is still 0, i.e. nothing has re-entered the state the earlier migration cleared.
+-- Measured on prod 2026-09-02: exactly the 23 ids below, out of 1,217,366 versions and 2,128 that
+-- carry a source at all. All 23 predate the LicensingRoot table, all are model-type mismatches only
+-- (0 also have a base model disagreeing with their source), none lands on a Checkpoint model, and
+-- none has been touched since 2026-07-14.
 --
--- `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC, so the bound must be a
+-- 🔴 The id list is the scope, and the `NOT EXISTS` is the rule. Both, deliberately:
+--
+-- A predicate alone does not pin the row set to what was measured. `createdAt` is immutable, so a
+-- date bound caps the CANDIDATE POOL, but membership is decided by the subquery, which reads
+-- `LicensingRoot` and `Model."type"` at whatever moment a human runs this -- days after the count in
+-- this header was taken. Nothing in this workspace writes `LicensingRoot`; its rows are inserted and
+-- corrected out of band, during work like this ticket. So one root deleted or one root's `modelType`
+-- corrected makes pre-cutoff stamps that pass today stop passing, and a bounded-but-unlisted
+-- statement would sweep them with no version and no model having moved.
+--
+-- The subquery is kept anyway rather than trusting the ids alone: a row that the app repaired in the
+-- meantime -- this ticket's own guard now coerces a stored source on saves that omit it -- simply
+-- fails `IS NOT NULL` and is skipped. So the statement can only ever clear FEWER than 23, never
+-- more, whenever it is run.
+--
+-- Re-count before applying. If it is not 23, that is a real change in the data and worth
+-- understanding before proceeding, not a number to update in place.
+--
+-- `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC, so a date bound must be a
 -- TIMESTAMP literal -- a TIMESTAMPTZ one resolves through the applying session's unpinned TimeZone.
+-- The bound is gone from the statement below; the note is kept because the sibling migration has one
+-- and the next person writing a variant of this will need it.
 --
 -- Raw SQL does not fire Prisma's `@updatedAt`, so nothing invalidates the caches the fee is read
--- from. POST the repaired ids to /api/v1/model-versions/bust-cache as one `versionIds` array (max
--- 500) after applying, as a moderator -- a non-moderator session only busts its own versions.
+-- from. POST the ids this actually cleared to /api/v1/model-versions/bust-cache as one `versionIds`
+-- array (max 500) after applying, as a moderator -- a non-moderator session only busts its own
+-- versions.
 UPDATE "ModelVersion" mv
 SET "licensingSourceVersionId" = NULL
 WHERE mv."licensingSourceVersionId" IS NOT NULL
-  AND mv."createdAt" < TIMESTAMP '2026-07-15 21:56:17'
+  AND mv.id IN (
+    3001834, 3122576, 3122651, 3122705, 3123614, 3123669, 3123677, 3123778,
+    3124300, 3124306, 3124342, 3124358, 3124413, 3124424, 3124444, 3124466,
+    3124481, 3124505, 3125207, 3126724, 3126789, 3128798, 3129603
+  )
   AND NOT EXISTS (
     SELECT 1
     FROM "LicensingRoot" lr

--- a/packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/migration.sql
@@ -17,15 +17,16 @@
 -- A predicate alone does not pin the row set to what was measured. `createdAt` is immutable, so a
 -- date bound caps the CANDIDATE POOL, but membership is decided by the subquery, which reads
 -- `LicensingRoot` and `Model."type"` at whatever moment a human runs this -- days after the count in
--- this header was taken. Nothing in this workspace writes `LicensingRoot`; its rows are inserted and
--- corrected out of band, during work like this ticket. So one root deleted or one root's `modelType`
--- corrected makes pre-cutoff stamps that pass today stop passing, and a bounded-but-unlisted
--- statement would sweep them with no version and no model having moved.
+-- this header was taken. No APPLICATION code writes `LicensingRoot` -- the only writes in this repo
+-- are the one-shot seed in 20260715130000_add_licensing_root_table, so ongoing curation happens out
+-- of band, invisibly to `git grep`. One root deleted or one root's `modelType` corrected makes
+-- pre-cutoff stamps that pass today stop passing, and a bounded-but-unlisted statement would sweep
+-- them with no version and no model having moved.
 --
 -- The subquery is kept anyway rather than trusting the ids alone: a row that the app repaired in the
 -- meantime -- this ticket's own guard now coerces a stored source on saves that omit it -- simply
--- fails `IS NOT NULL` and is skipped. So the statement can only ever clear FEWER than 23, never
--- more, whenever it is run.
+-- fails `IS NOT NULL` and is skipped. So the statement clears AT MOST 23, never more, whenever it is
+-- run. 23 is the expected result, not a warning sign.
 --
 -- Re-count before applying. If it is not 23, that is a real change in the data and worth
 -- understanding before proceeding, not a number to update in place.

--- a/packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/migration.sql
@@ -1,0 +1,32 @@
+-- The other half of 20260831200000_clear_orphaned_licensing_source: the same predicate, with the
+-- bound inverted, for the versions that one deliberately left alone.
+--
+-- That migration scoped itself to versions created on or after the LicensingRoot table's first rows
+-- (2026-07-15 21:56:17 UTC) because an older version may have been offered a checkpoint's root by a
+-- retired picker, and clearing one would take income from a creator who chose to earn it. Justin
+-- ruled on 2026-09-02 that the state is wrong regardless and is to be corrected, so the carve-out
+-- goes (CU 868kwf2fd).
+--
+-- Measured on prod the same day: 23 rows match, unchanged from the 23 that migration left. All 23
+-- predate the table, all are model-type mismatches only (0 have a base model that disagrees with
+-- their source), none lands on a Checkpoint model, and none has been touched since 2026-07-14. The
+-- in-scope half is still 0, i.e. nothing has re-entered the state the earlier migration cleared.
+--
+-- `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC, so the bound must be a
+-- TIMESTAMP literal -- a TIMESTAMPTZ one resolves through the applying session's unpinned TimeZone.
+--
+-- Raw SQL does not fire Prisma's `@updatedAt`, so nothing invalidates the caches the fee is read
+-- from. POST the repaired ids to /api/v1/model-versions/bust-cache as one `versionIds` array (max
+-- 500) after applying, as a moderator -- a non-moderator session only busts its own versions.
+UPDATE "ModelVersion" mv
+SET "licensingSourceVersionId" = NULL
+WHERE mv."licensingSourceVersionId" IS NOT NULL
+  AND mv."createdAt" < TIMESTAMP '2026-07-15 21:56:17'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "LicensingRoot" lr
+    JOIN "Model" m ON m.id = mv."modelId"
+    WHERE lr."modelVersionId" = mv."licensingSourceVersionId"
+      AND lr."baseModel" = mv."baseModel"
+      AND lr."modelType" = m."type"
+  );

--- a/src/server/common/entity-change.constants.ts
+++ b/src/server/common/entity-change.constants.ts
@@ -10,6 +10,10 @@ export const watchedEntityFields = {
   Model: [
     'name',
     'description',
+    // Changing it clears every stamped version's `licensingSourceVersionId` beneath it, so without a
+    // row here the sweep that goes looking for why a fee moved finds the clears and nothing that
+    // caused them — 31 of 36 rows in the last one were unexplainable for exactly this reason.
+    'type',
     'nsfw',
     'poi',
     'minor',

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -57,6 +57,8 @@ const call = async ({
   baseModel = 'Anima',
   root = animaRoot as Root,
   licensingSourceVersionId = ANIMA_ROOT_VERSION_ID as number | null,
+  omitSource = false,
+  storedLicensingSourceVersionId = null as number | null,
 }: {
   modelTypes: Record<number, string | null>;
   id?: number;
@@ -64,6 +66,14 @@ const call = async ({
   baseModel?: string;
   root?: Root;
   licensingSourceVersionId?: number | null;
+  /**
+   * Leave the key off the payload entirely. Not `licensingSourceVersionId: undefined` — a
+   * destructuring default fires on `undefined`, so that spelling would quietly send the default
+   * source instead of omitting it, and every test below would be testing the ordinary path.
+   */
+  omitSource?: boolean;
+  /** What the row being edited already holds — what a payload that omits the field falls back to. */
+  storedLicensingSourceVersionId?: number | null;
 }) => {
   dbMock.dbWrite.licensingRoot.findUnique.mockResolvedValue(root);
   // Keyed on the argument, NOT a flat `mockResolvedValue`. A mock that ignores its `where` hands
@@ -72,7 +82,13 @@ const call = async ({
   // mock, changing the guard to read `input.modelId` left all nine tests green.
   dbMock.dbWrite.modelVersion.findUnique.mockImplementation(
     async (args: { where: { id: number } }) =>
-      args.where.id === VERSION_ID ? { usageControl: 'Download', modelId: STORED_MODEL_ID } : null
+      args.where.id === VERSION_ID
+        ? {
+            usageControl: 'Download',
+            modelId: STORED_MODEL_ID,
+            licensingSourceVersionId: storedLicensingSourceVersionId,
+          }
+        : null
   );
   dbMock.dbWrite.model.findUnique.mockImplementation(async (args: { where: { id: number } }) => {
     const type = modelTypes[args.where.id];
@@ -92,7 +108,7 @@ const call = async ({
       // tier-cap branch out. Neither is what this file is about.
       usageControl: 'Download',
       licensingFee: null,
-      licensingSourceVersionId,
+      ...(omitSource ? {} : { licensingSourceVersionId }),
     },
     ctx: {
       user: { id: OWNER_ID, isModerator: false, meta: {} },
@@ -230,6 +246,66 @@ describe('upsertModelVersionHandler — licensing lineage scope', () => {
   // whole block deleted. Dropped rather than left in as apparent coverage.
   it('leaves an unset source alone without reading the root table', async () => {
     await call({ ...creating('LORA'), licensingSourceVersionId: null });
+    expect(dbMock.dbWrite.licensingRoot.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 A save does not have to NAME the stamp to invalidate it. `licensingSourceVersionId` is nullish
+ * in the schema while `baseModel` and `modelId` are required, and a field absent from the payload
+ * leaves the column untouched — so the guard, gated on the submitted value, never ran on the save
+ * that broke the row. `TrainingSubmit` sends exactly that shape: it updates the first version with a
+ * newly chosen `baseModel` and no stamp field, so a creator who stamped that version and then re-ran
+ * training on a different base kept a third party's per-image fee.
+ *
+ * Measured on prod 2026-09-02 before the fix: 0 rows in that state (2,124 stamped versions, 0 with a
+ * base model disagreeing with their root), and 0 base-model coercions in `entityChangeEvents` ever.
+ * Reachable and unguarded, not an incident — sized accordingly.
+ */
+describe('upsertModelVersionHandler — a save that omits the stamp', () => {
+  const omitting = (overrides: Partial<Parameters<typeof call>[0]> = {}) => ({
+    id: VERSION_ID,
+    modelTypes: { [PAYLOAD_MODEL_ID]: 'Checkpoint', [STORED_MODEL_ID]: 'Checkpoint' },
+    omitSource: true,
+    storedLicensingSourceVersionId: ANIMA_ROOT_VERSION_ID,
+    ...overrides,
+  });
+
+  it('coerces a stored source the save has moved the base model away from', async () => {
+    const written = await call(omitting({ baseModel: 'Illustrious' }));
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(written.licensingSourceCoercedReason).toBe('base-model-mismatch');
+  });
+
+  // The control, and the only thing that makes the test above worth anything: same call, same omitted
+  // field, base model still matching the root. A fix that cleared the stamp on every stamp-omitting
+  // save — which is what "coerce whenever the client didn't send it" would do — fails here.
+  it('keeps a stored source the save leaves matching', async () => {
+    const written = await call(omitting());
+    expect(written.licensingSourceVersionId).toBe(ANIMA_ROOT_VERSION_ID);
+    expect(written.licensingSourceCoercedReason).toBeUndefined();
+  });
+
+  // Judging the stored value means the model-type half of the same guard now fires on these saves
+  // too. That is a deliberate widening beyond the base-model path — the same repair the guard already
+  // performs on a full save, now reached by a partial one. It is pinned here so that removing it is a
+  // decision rather than an accident.
+  it('coerces a stored source whose model type no longer matches, not only its base model', async () => {
+    const written = await call(omitting({ modelTypes: { [PAYLOAD_MODEL_ID]: 'LORA' } }));
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(written.licensingSourceCoercedReason).toBe('model-type-mismatch');
+  });
+
+  // `undefined` is "the client said nothing"; `null` is the owner clearing the stamp. Seeding on
+  // anything looser than `=== undefined` restores a source the creator just removed.
+  it('does not restore a stored source over an explicit null', async () => {
+    const written = await call(omitting({ omitSource: false, licensingSourceVersionId: null }));
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(dbMock.dbWrite.licensingRoot.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('reads no root table when the stored row carries no source either', async () => {
+    await call(omitting({ storedLicensingSourceVersionId: null }));
     expect(dbMock.dbWrite.licensingRoot.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.licensing-lineage.test.ts
@@ -296,6 +296,20 @@ describe('upsertModelVersionHandler — a save that omits the stamp', () => {
     expect(written.licensingSourceCoercedReason).toBe('model-type-mismatch');
   });
 
+  // The seed opens the whole rejection ladder to partial saves, not only its base-model rung, so the
+  // other rungs are pinned here too rather than left to be discovered by whoever changes one.
+  it('coerces a stored source that is no longer a registered root', async () => {
+    const written = await call(omitting({ root: null }));
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(written.licensingSourceCoercedReason).toBe('not-a-root');
+  });
+
+  it('coerces a stored source when the destination model cannot be read', async () => {
+    const written = await call(omitting({ modelTypes: { [STORED_MODEL_ID]: 'Checkpoint' } }));
+    expect(written.licensingSourceVersionId).toBeNull();
+    expect(written.licensingSourceCoercedReason).toBe('model-not-found');
+  });
+
   // `undefined` is "the client said nothing"; `null` is the owner clearing the stamp. Seeding on
   // anything looser than `=== undefined` restores a source the creator just removed.
   it('does not restore a stored source over an explicit null', async () => {

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -592,6 +592,11 @@ export const upsertModelVersionHandler = async ({
     const seededLicensingSource =
       input.licensingSourceVersionId === undefined &&
       storedVersion?.licensingSourceVersionId != null;
+    // The `?? null` is unreachable — the condition already established the column is non-null — and is
+    // here only because a `const` boolean does not narrow `storedVersion` for TypeScript. It makes the
+    // line look safe to lift out from under the condition; relaxing that to "seed whenever the client
+    // said nothing" would then write an explicit null and CLEAR the stamp, where without the `??` it
+    // would not compile.
     if (seededLicensingSource)
       input.licensingSourceVersionId = storedVersion?.licensingSourceVersionId ?? null;
 

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -585,11 +585,15 @@ export const upsertModelVersionHandler = async ({
     // TrainingSubmit does exactly this shape: it updates the first version with a newly chosen
     // `baseModel` and no stamp field. Seeding the stored value makes the guard judge what the row will
     // actually hold. Only `undefined` is seeded — an explicit `null` is the owner clearing the stamp.
-    if (
+    //
+    // This opens the WHOLE ladder below to partial saves, not only its base-model rung: a stored source
+    // that is no longer a registered root, or whose model type no longer matches, now coerces on a save
+    // that never mentioned it.
+    const seededLicensingSource =
       input.licensingSourceVersionId === undefined &&
-      storedVersion?.licensingSourceVersionId != null
-    )
-      input.licensingSourceVersionId = storedVersion.licensingSourceVersionId;
+      storedVersion?.licensingSourceVersionId != null;
+    if (seededLicensingSource)
+      input.licensingSourceVersionId = storedVersion?.licensingSourceVersionId ?? null;
 
     if (input.licensingSourceVersionId != null) {
       const [source, destinationModel] = await Promise.all([
@@ -641,11 +645,14 @@ export const upsertModelVersionHandler = async ({
         : null;
       if (rejectedReason) {
         // A coercion leaves no trace in the row it corrected, so emit the deciding branch. This is
-        // also the only signal that the client is still sending bad values.
+        // also the only signal that the client is still sending bad values — which is what `seeded`
+        // separates: a seeded row is the server repairing a stored value on a save that never named
+        // it, so counting it as a client submission reads the signal backwards.
         logToAxiom({
           name: 'model-version-licensing-source-rejected',
           type: 'info',
           reason: rejectedReason,
+          seeded: seededLicensingSource,
           userId,
           // `modelId` is where this save puts the version, and `modelType` is that model's type — the
           // two have to name the same row or the log stops being evidence.

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -423,6 +423,7 @@ export const upsertModelVersionHandler = async ({
             usageControl: true,
             licensingFee: true,
             licensingFeeSettlementCurrency: true,
+            licensingSourceVersionId: true,
             baseModel: true,
           },
         })
@@ -578,6 +579,18 @@ export const upsertModelVersionHandler = async ({
     // deliberate selection cannot reach the coercion. It is also not a way to dodge a fee — sending
     // `null` outright has always been allowed, and 99.77% of Anima and Krea 2 LoRAs do exactly that
     // (107 of 46,994 and 45 of 19,999 carry a source at all).
+    // `licensingSourceVersionId` is nullish in the schema while `baseModel` and `modelId` are required,
+    // so a save can move everything the stamp depends on without ever naming it — and an absent field
+    // leaves the column untouched, which is a stored stamp surviving a change that invalidates it.
+    // TrainingSubmit does exactly this shape: it updates the first version with a newly chosen
+    // `baseModel` and no stamp field. Seeding the stored value makes the guard judge what the row will
+    // actually hold. Only `undefined` is seeded — an explicit `null` is the owner clearing the stamp.
+    if (
+      input.licensingSourceVersionId === undefined &&
+      storedVersion?.licensingSourceVersionId != null
+    )
+      input.licensingSourceVersionId = storedVersion.licensingSourceVersionId;
+
     if (input.licensingSourceVersionId != null) {
       const [source, destinationModel] = await Promise.all([
         // `dbWrite`, matching the destination read below rather than sitting one line above it under the

--- a/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
+++ b/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
@@ -174,6 +174,13 @@ function versionAuditRows() {
     .filter((row) => row.entityType === 'ModelVersion');
 }
 
+/** The Model-level rows, which `versionAuditRows` filters out. */
+function modelAuditRows() {
+  return entityChanges.mock.calls
+    .flatMap((call) => call[0] as unknown as Record<string, unknown>[])
+    .filter((row) => row.entityType === 'Model');
+}
+
 function clearCall() {
   return mockDbWrite.modelVersion.updateMany.mock.calls[0]?.[0] as
     | { where: { id: { in: number[] } }; data: Record<string, unknown> }
@@ -231,6 +238,34 @@ describe('upsertModel — licensing lineage on a model type change', () => {
       where: { id: { in: [VERSION_ID] } },
       data: { licensingSourceVersionId: null },
     });
+  });
+
+  /**
+   * 🔴 The audit's before-side type must come from the WRITER's read, not `beforeUpdate`'s `dbRead`
+   * one. The fixture is the divergent state on purpose — `dbRead` says Checkpoint, the writer says
+   * LORA, the payload says Checkpoint — so a replica-sourced before-side sees Checkpoint→Checkpoint,
+   * emits nothing, and the type change that clears every stamped fee beneath this model goes
+   * unrecorded on exactly the save whose clears need explaining.
+   *
+   * This is the behavioural half of the source-text guard in
+   * `src/server/utils/__tests__/entity-change.licensing-source.test.ts`, which can only pin the
+   * variable's NAME: `typeBeforeUpdate = beforeUpdate?.type` keeps that string and passes there,
+   * and fails here.
+   */
+  it('audits the type change against the writer read, not the replica', async () => {
+    storedTypeOnWriter(ModelType.LORA);
+
+    await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });
+
+    expect(modelAuditRows()).toEqual([
+      expect.objectContaining({
+        entityType: 'Model',
+        entityId: MODEL_ID,
+        field: 'type',
+        oldValue: '"LORA"',
+        newValue: '"Checkpoint"',
+      }),
+    ]);
   });
 
   it('keeps a root the new type supports', async () => {

--- a/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
+++ b/src/server/services/__tests__/model-licensing-source-on-type-change.test.ts
@@ -253,6 +253,11 @@ describe('upsertModel — licensing lineage on a model type change', () => {
    * and fails here.
    */
   it('audits the type change against the writer read, not the replica', async () => {
+    // The DIVERGENCE is the test, and only half of it used to be visible here: the replica side came
+    // from the shared `storedModel`. Normalising that fixture to LORA would have left this assertion
+    // passing AND the mutation passing, with no other case in the file noticing, since nothing else
+    // reads `storedModel.type`. Pinned locally so a distant edit cannot reach it.
+    mockDbRead.model.findUnique.mockResolvedValue({ ...storedModel, type: ModelType.Checkpoint });
     storedTypeOnWriter(ModelType.LORA);
 
     await upsert({ id: MODEL_ID, userId: OWNER_ID, type: ModelType.Checkpoint });

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2655,14 +2655,14 @@ export const upsertModel = async (
     const prevMeta = beforeUpdate.meta as ModelMeta | null;
 
     let clearedLicensingSources: { id: number; licensingSourceVersionId: number }[] = [];
+    let typeBeforeUpdate: ModelType | undefined;
 
     const result = await dbWrite.$transaction(
       async (tx) => {
         // Not `beforeUpdate.type` — that is a `dbRead` read, and a stale replica reads as "type
         // unchanged", skipping the repair below on exactly the save that needed it.
-        const typeBeforeUpdate = (
-          await tx.model.findUnique({ where: { id }, select: { type: true } })
-        )?.type;
+        typeBeforeUpdate = (await tx.model.findUnique({ where: { id }, select: { type: true } }))
+          ?.type;
 
         const updated = await tx.model.update({
           select: {
@@ -2782,7 +2782,10 @@ export const upsertModel = async (
         entityType: 'Model',
         entityId: id as number,
         ownerId: beforeUpdate.userId,
-        before: beforeUpdate,
+        // `type` off the transaction's own read, not the `dbRead` one beside it: a stale replica
+        // reads as "type unchanged" and emits no row, on exactly the save whose fee clears need
+        // explaining. Same reason the repair above does not use `beforeUpdate.type`.
+        before: { ...beforeUpdate, type: typeBeforeUpdate ?? beforeUpdate.type },
         after: data as Record<string, unknown>,
         actorRole: resolveActorRole({
           actorUserId: userId,

--- a/src/server/utils/__tests__/entity-change.licensing-source.test.ts
+++ b/src/server/utils/__tests__/entity-change.licensing-source.test.ts
@@ -80,9 +80,11 @@ describe('licensingSourceVersionId — the settings audit', () => {
    */
 
   /**
-   * 🔴 `diffEntityChanges` compares `before[field]` to `after[field]`, so a watched field the
-   * service never selects is `undefined` on the before side and silently produces no row — the audit
-   * reads as wired up and records nothing.
+   * 🔴 `diffEntityChanges` compares `before[field]` to `after[field]`, and its skip at
+   * `entity-change-helpers.ts:107` guards the AFTER side only. So a watched field the service never
+   * selects is `undefined` on the before side, `stableStringify` encodes that as `''`, and the row is
+   * written with a BLANK `oldValue` — a corrupt record of the change, not a missing one, and nothing
+   * throws either way.
    *
    * Asserted over the whole watched list, because the next field added will have the same trap and
    * nobody will remember this test exists.
@@ -177,8 +179,8 @@ describe('Model.type — the audit trail for what clears a lineage fee', () => {
 
   /**
    * 🔴 Same silent trap as the ModelVersion select above: a watched field the service never reads on
-   * the before side is `undefined` there and produces no row, so the audit reads as wired up and
-   * records nothing. `upsertModel`'s `beforeUpdate` is that read.
+   * the before side lands in the row as a blank `oldValue`, so the audit reads as wired up and
+   * records a change from nothing. `upsertModel`'s `beforeUpdate` is that read.
    */
   it('selects every watched Model column for the audit before-side', () => {
     const service = readFileSync(
@@ -190,7 +192,12 @@ describe('Model.type — the audit trail for what clears a lineage fee', () => {
       at,
       "upsertModel's before-read moved; re-anchor this test, do not delete it"
     ).toBeGreaterThan(-1);
-    const select = service.slice(at, service.indexOf(': null;', at));
+    const end = service.indexOf(': null;', at);
+    // The end marker is the ternary's own `: null;`. If that ever becomes `: undefined`, `indexOf`
+    // silently finds the next one hundreds of lines down, the span swallows unrelated selects, and
+    // some other `type: true` satisfies every field — the guard passes while checking nothing.
+    expect(end - at, 'the beforeUpdate span no longer ends at its own ternary').toBeLessThan(1200);
+    const select = service.slice(at, end);
 
     const missing = watchedEntityFields.Model.filter(
       (field) => !new RegExp(`\\b${field.split('.')[0]}: (true|\\{)`).test(select)

--- a/src/server/utils/__tests__/entity-change.licensing-source.test.ts
+++ b/src/server/utils/__tests__/entity-change.licensing-source.test.ts
@@ -206,20 +206,15 @@ describe('Model.type — the audit trail for what clears a lineage fee', () => {
   });
 
   /**
-   * 🔴 `beforeUpdate` is a `dbRead` read. On a replica that lags the previous save it reports the type
-   * as unchanged, and the differ then emits NO row — on precisely the save whose fee clears need
-   * explaining. The repair inside the transaction already re-reads the type for this reason; the audit
-   * has to use the same value or it records the absence of the event it exists for.
+   * The source-text test that used to sit here — asserting `upsertModel`'s audit call contains the
+   * literal `type: typeBeforeUpdate` — is deliberately gone, per this file's own rule two blocks up:
+   * when the behavioural test exists, delete the source-text one rather than keeping both. It lives at
+   * `src/server/services/__tests__/model-licensing-source-on-type-change.test.ts`, named
+   * `audits the type change against the writer read, not the replica`.
+   *
+   * Measured before deleting, so this is not a guess about coverage: the behavioural test fails on the
+   * plain revert (`before: beforeUpdate`) that the source-text one caught, AND on a spread-order swap
+   * (`before: { type: …, ...beforeUpdate }`) that the source-text one passes, because the literal is
+   * still present while the spread overwrites it. Strictly stronger, on the mutation that matters.
    */
-  it('audits the type off the transaction read, not the replica one', () => {
-    const service = readFileSync(
-      path.join(REPO_ROOT, 'src/server/services/model.service.ts'),
-      'utf8'
-    );
-    const at = service.indexOf('const changeRows = diffEntityChanges({');
-    expect(at, 'the Model audit diff moved; re-anchor this test').toBeGreaterThan(-1);
-    const block = service.slice(at, service.indexOf('});', at));
-    expect(block).toContain("entityType: 'Model'");
-    expect(block).toContain('type: typeBeforeUpdate');
-  });
 });

--- a/src/server/utils/__tests__/entity-change.licensing-source.test.ts
+++ b/src/server/utils/__tests__/entity-change.licensing-source.test.ts
@@ -131,3 +131,88 @@ describe('licensingSourceVersionId — the settings audit', () => {
     expect(block).toContain('licensingSourceVersionId:');
   });
 });
+
+/**
+ * `Model.type` is the other end of the same money path: changing it clears `licensingSourceVersionId`
+ * on every stamped version beneath the model (`upsertModel`'s repair, attributed `model-type-changed`).
+ * Unwatched, the sweep that goes looking for why a fee moved finds the clears and nothing that caused
+ * them — 31 of 36 rows in the last one were unexplainable for exactly that reason. CU 868kzk4rr.
+ */
+describe('Model.type — the audit trail for what clears a lineage fee', () => {
+  const MODEL_ID = 2790719;
+
+  const diffModel = (before: Record<string, unknown>, after: Record<string, unknown>) =>
+    diffEntityChanges({
+      entityType: 'Model',
+      entityId: MODEL_ID,
+      ownerId: OWNER_ID,
+      before,
+      after,
+      actorRole: 'owner',
+    });
+
+  it('is watched at all', () => {
+    expect(watchedEntityFields.Model).toContain('type');
+  });
+
+  it('records the change that clears every stamped version under it', () => {
+    const rows = diffModel({ type: 'Checkpoint' }, { type: 'LORA' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      entityType: 'Model',
+      field: 'type',
+      oldValue: '"Checkpoint"',
+      newValue: '"LORA"',
+    });
+  });
+
+  // The control: an ordinary save resubmits the stored type, and a row on every model edit would bury
+  // the ones that mean something.
+  it('emits nothing when the type is resubmitted unchanged', () => {
+    const rows = diffModel({ type: 'Checkpoint', name: 'v1' }, { type: 'Checkpoint', name: 'v2' });
+    // The changed sibling is the point: a differ that emitted nothing at all would pass a bare
+    // length-0 assertion here while recording no type change either.
+    expect(rows.map((r) => r.field)).toEqual(['name']);
+  });
+
+  /**
+   * 🔴 Same silent trap as the ModelVersion select above: a watched field the service never reads on
+   * the before side is `undefined` there and produces no row, so the audit reads as wired up and
+   * records nothing. `upsertModel`'s `beforeUpdate` is that read.
+   */
+  it('selects every watched Model column for the audit before-side', () => {
+    const service = readFileSync(
+      path.join(REPO_ROOT, 'src/server/services/model.service.ts'),
+      'utf8'
+    );
+    const at = service.indexOf('const beforeUpdate =');
+    expect(
+      at,
+      "upsertModel's before-read moved; re-anchor this test, do not delete it"
+    ).toBeGreaterThan(-1);
+    const select = service.slice(at, service.indexOf(': null;', at));
+
+    const missing = watchedEntityFields.Model.filter(
+      (field) => !new RegExp(`\\b${field.split('.')[0]}: (true|\\{)`).test(select)
+    );
+    expect(missing, `watched but not selected, so they audit nothing: ${missing}`).toEqual([]);
+  });
+
+  /**
+   * 🔴 `beforeUpdate` is a `dbRead` read. On a replica that lags the previous save it reports the type
+   * as unchanged, and the differ then emits NO row — on precisely the save whose fee clears need
+   * explaining. The repair inside the transaction already re-reads the type for this reason; the audit
+   * has to use the same value or it records the absence of the event it exists for.
+   */
+  it('audits the type off the transaction read, not the replica one', () => {
+    const service = readFileSync(
+      path.join(REPO_ROOT, 'src/server/services/model.service.ts'),
+      'utf8'
+    );
+    const at = service.indexOf('const changeRows = diffEntityChanges({');
+    expect(at, 'the Model audit diff moved; re-anchor this test').toBeGreaterThan(-1);
+    const block = service.slice(at, service.indexOf('});', at));
+    expect(block).toContain("entityType: 'Model'");
+    expect(block).toContain('type: typeBeforeUpdate');
+  });
+});


### PR DESCRIPTION
Three linked items on the licensing per-image-fee money path. Same files, one PR.

## What I measured before writing anything

Both shipped licensing fixes (#4411, #4533) and the 20260831 cleanup migration are live and working. Prod, across **all stamped versions**:

```
stamped_total 2124 | not_a_root 0 | base_model_mismatch 0 | model_type_mismatch 23
```

The `model_type_mismatch` column coming back 23 in that same pass is the control: a sibling column could return nonzero, so the zeros are measured rather than vacuous. The perf lane re-measured a few hours later and got **2,128** stamped — the table moves; the zeros did not.

ClickHouse `entityChangeEvents` holds 8 `licensingSourceVersionId` rows ever — three owner stamps, one `system` / `cleared: model-type-mismatch` (#4411's coercion), two `system` / `model-type-changed` (#4533's sweep), two more owner stamps. **Zero base-model coercions, ever.**

So the hole below is **reachable and unguarded, not a live population**. Sized accordingly.

## 1. The guard did not run on saves that omit the stamp (CU 868kzk4qn)

`licensingSourceVersionId` is `z.number().nullish()` while `baseModel` and `modelId` are required on every version write, and the lineage guard was gated on `input.licensingSourceVersionId != null`. A payload that omits the stamp skipped the guard entirely, and an absent field leaves the column alone in Prisma — so a stored stamp survived the change that invalidated it.

The caller that does exactly that is `src/components/Training/Form/TrainingSubmit.tsx:863-898`: on `idx === 0` it updates the existing version with `baseModel: baseModelConvert` — the newly chosen training base — and no stamp field. A creator who stamped a version and then re-ran training on a different base kept a third party's per-image fee, charged to everyone generating with their model and settled to the root's owner.

The fix reads `licensingSourceVersionId` in the handler's existing `storedVersion` query (one more column, no new query) and seeds it into the guard **only when the caller sent `undefined`**. An explicit `null` is still the owner clearing the stamp and is untouched.

The version editor form pre-clears the stamp client-side on a base-model change, which is why the base-model half of this guard has never had to fire. That client-side clear is not the enforcement point and never was.

## 🔴 Deliberate widening beyond the ticket: the WHOLE rejection ladder now fires on partial saves

Judging the **stored** value does not reopen only the base-model rung. The ladder is `not-a-root` then `base-model-mismatch` then `model-not-found` then `model-type-mismatch`, and the seed puts a value in ahead of the `!= null` gate, so **every** rung is now reachable from a save that never named the stamp.

This is the same repair #4411 already performs on a full save, reached by a partial one — but it is a behaviour change beyond this ticket's text and a reviewer should not have to infer it. Each rung has its own test named for it, so removing one is a decision rather than an accident. Live exposure on three of the four rungs is nil: prod reads `not_a_root 0` and `base_model_mismatch 0`, and `model-not-found` cannot persist anything because `upsertModelVersion` opens with a `findUniqueOrThrow` on the same `modelId`, so that save throws a few statements later either way. **`model-type-mismatch` is the rung that can bite** — it is the 23 rows in item 2, and the next paragraph is about exactly that.

The rows this can reach are the 23 in item 2. ⚠️ **It does not clear them on its own, and the ordering matters:** the code ships on a deploy while the migration is run by hand at some other time. If the code lands first, some of those 23 are cleared by their owners' next partial save, and the migration then matches **fewer than 23** when it runs. That is a fine outcome — the same rows, repaired earlier — but it gives the "23" a shelf life, so re-count at apply time rather than trusting the number in the file. The migration is written so that this movement can only ever shrink its match set, never grow it.

## 2. Clear the 23 pre-`LicensingRoot` rows (CU 868kwf2fd)

`packages/civitai-db-schema/prisma/migrations/20260902190000_clear_pre_licensing_root_orphaned_source/` — the same predicate as 20260831200000, with the bound inverted, for the rows that one deliberately carved out pending Justin's call. He ruled today that the state is wrong and is to be corrected.

Re-measured before writing it, same day: 23 rows match, all created before the `LicensingRoot` table's first rows, all model-type mismatches only (0 also have a base model disagreeing with their source), none lands on a Checkpoint model, none touched since 2026-07-14. Total ModelVersion rows 1,217,366. The in-scope half of the earlier migration is still 0 — nothing has re-entered the state it cleared.

🔴 **The statement pins the 23 ids explicitly, and keeps the predicate.** My first version reused the sibling migration's `createdAt` bound with the comparison inverted, and the PR said that bound pinned the scope to the measured rows. That was wrong, and the review caught it. `createdAt` is immutable, so a date bound caps the *candidate pool*; membership is decided by the `NOT EXISTS`, which reads `LicensingRoot` and `Model."type"` at whatever moment a human runs the file — days after the count was taken. **No application code writes `LicensingRoot`** — the only writes in this repo are the three `INSERT`s in the one-shot seed migration `20260715130000_add_licensing_root_table`, so ongoing curation happens out of band, invisibly to `git grep`. One root deleted or one root's `modelType` corrected, and pre-cutoff stamps that pass today stop passing, with no version and no model having moved — and a bounded-but-unlisted statement would sweep them.

So the id list is the scope and the subquery is the rule. Together the statement clears **at most 23**, never more, whenever it runs: a row the app already repaired fails `IS NOT NULL` and is skipped. 23 is the expected result, not a warning sign. Verified as a `SELECT` against prod — the id-pinned predicate matches 23, and injecting a legitimately-stamped version id into the list still returns 23 rather than 24, which is the control that the `NOT EXISTS` is doing real work rather than decorating an id list.

🔴 **This needs applying by hand** (we do not run `prisma migrate deploy`), and the repaired ids then POSTing to `/api/v1/model-versions/bust-cache` as one `versionIds` array **as a moderator** — raw SQL does not fire Prisma's `@updatedAt`, so nothing invalidates the caches the fee is read from. The bound is a TIMESTAMP literal, not TIMESTAMPTZ: `ModelVersion."createdAt"` is `timestamp without time zone` holding UTC.

## 3. `Model.type` is now audited (CU 868kzk4rr)

Changing a model's type clears `licensingSourceVersionId` on every stamped version beneath it. Unwatched, the sweep that goes looking for why a fee moved finds the clears and nothing that caused them — 31 of 36 rows in the last one were unexplainable for exactly that reason.

The audit reads the type from the transaction's own read rather than the `dbRead` one beside it: a lagging replica reports the type unchanged, and the differ then emits **no row at all**, on precisely the save whose clears need explaining. The repair inside the transaction already re-reads it for this reason.

## Every test here fails on revert — demonstrated

Each control was run with the rest of the change intact, and each file was md5'd before mutating and after restoring, because `git status` reads clean over a same-length substitution.

| Reverted | Result | Failing tests |
|---|---|---|
| the `storedVersion` seed | `Tests 5 failed / 18 passed (23)` | all five `a save that omits the stamp` cases — moved-base-model (`expected undefined to be null`), `keeps a stored source the save leaves matching` (`expected undefined to be 2945208`), model-type, not-a-root, destination-unreadable |
| `'type'` out of `watchedEntityFields.Model` | `Tests 2 failed / 9 passed (11)` | `is watched at all` (`expected [ Array(13) ] to include 'type'`), `records the change that clears every stamped version under it` |
| the audit before-side back to plain `before: beforeUpdate` | `Tests 1 failed / 10 passed (11)` | `audits the type change against the writer read, not the replica` |
| spread-order swap at the audit call: `before: { type: …, ...beforeUpdate }`, so the spread overwrites `type` with the replica value | `Tests 1 failed / 21 passed (22)` | `audits the type change against the writer read, not the replica`, alone (`expected [] to deeply equal [ObjectContaining]`) |
| `type: true` out of `upsertModel`'s `beforeUpdate` select | `Tests 1 failed / 10 passed (11)` | `selects every watched Model column for the audit before-side` (`watched but not selected, so they audit nothing: type`) |

Every failure names a wrong value; none is a timeout or a hang.

Two honest notes on that table rather than leaving them to be found:

- **A source-text test was deleted, not just added to.** `audits the type off the transaction read, not the replica one` is gone from `entity-change.licensing-source.test.ts`, per that file's own rule that the behavioural test replaces the source-text one rather than joining it. Measured before deleting: the behavioural test fails on the plain revert the deleted one caught **and** on the spread-order swap it passed. Strictly stronger, so keeping both would have been noise. A comment in its place names its replacement.
- **The fourth control is the second one I tried, and the first one was worthless.** I first ran `typeBeforeUpdate = beforeUpdate?.type` and got `Tests 4 failed / 18 passed (22)` — the new test *and* three pre-existing ones, because that mutates the variable's **source** and the repair gate reads the same variable, so it fires first no matter what the audit does. It proved the suite catches the mutant, not that the new test does. The spread-order swap in the table is the honest discriminator: it hits the audit site alone, the source-text test still finds the literal `type: typeBeforeUpdate` and passes, all three repair tests pass, and only the new behavioural test fails. It is a one-token reordering of an object literal — an ordinary edit — and it is the class the source-text test structurally cannot see.
- **The fifth control mutates a line that was already on `main`** (`type: true` was in `beforeUpdate`'s select before this PR). It demonstrates the new guard test can fail; it is not a revert of anything this PR changed.

One more control, run as a **pair**, because the review pointed out the behavioural test's discriminator was half-invisible: the writer's type was set in the test, the replica's inherited from a shared fixture. Normalising that fixture to `LORA` and applying the spread swap together gives `11 passed (11)` — mutant survives, test green and vacuous, and nothing else in the file notices because `storedModel.type` feeds only this before-side. Pinning the replica side inside the test gives `1 failed | 10 passed (11)` on the same pair. That is the difference the pin buys, measured rather than argued.

`keeps a stored source the save leaves matching` is the control that makes the first row worth anything: a fix that cleared the stamp on every stamp-omitting save would pass the coercion tests and fail that one.

## Verification

- `pnpm run typecheck` — `0 type errors`, exit 0
- `pnpm exec eslint` over the six touched files — **0 errors**, 13 warnings, all pre-existing `no-unused-vars` / `no-explicit-any`. The repo-wide baseline is red (358 errors) and none of them are here.
- `pnpm run test:unit:run` — `Test Files 1566 passed | 3 skipped (1569)`, `Tests 24865 passed | 35 skipped (24900)`, exit 0
- `blocks.router.workflow.test.ts` collected **370 tests**, so the submodule is initialised and the run means something
- CI at the first commit: **14 rows**, 13 pass + 1 `skipping` by design, every run on that commit's own `head_sha`

## Review

Five lanes (`civitai-review`) read `1a1f5131701ab47b7d28caf450bff33011ad1c69`. The correctness lane opened with a money finding — that a stamp cleared by this path never busts the orchestrator's cached fee — and **withdrew it** after checking: `upsertModelVersion` calls `writeModelVersionGateAndGoal` unconditionally at `model-version.service.ts:975`, which reaches `bustMvCache` and then `bustOrchestratorModelCache` on every update. The fee-gated bust it had read only adds a `userId` query param to the same DELETE. It also confirmed `mini/[id]`, where the `fees[]` array is computed, reads `dbWrite`, so there is no replica race for the fee either.

Everything else the lanes confirmed is fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJUGFrqYuNWTWCyTARTf4h
