### PR TITLE
fix(rewards): floor the multiplier where it is spent, not only where it is recorded

### DIFF
--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -121,7 +121,7 @@ describe('foldUserMultipliers', () => {
       userId: 10,
       rewardsIneligible: false,
       rewardsMultiplier: -1,
-      purchasesMultiplier: -1,
+      purchasesMultiplier: 1,
     };
 
     const result = foldUserMultipliers([typo]);
@@ -129,7 +129,28 @@ describe('foldUserMultipliers', () => {
     // 0, not 1: a zero already means "earns nothing" everywhere downstream, and flooring to 1 would
     // invent a payout out of a typo.
     expect(result[10].rewardsMultiplier).toBe(0);
-    expect(result[10].purchasesMultiplier).toBe(0);
+  });
+
+  // The floor is applied at FOUR places: the two first-row assignments and the two `Math.max` merge
+  // arms. Every other test here gives a user ONE row, so only the first-row branch runs — reverting
+  // the merge arms alone left the whole file green. A multi-row user is the reason this fold exists.
+  it('floors a bad SECOND row, not only the first one it sees', () => {
+    const bad = (rewardsMultiplier: number): UserMultiplierRow => ({
+      userId: 14,
+      rewardsIneligible: false,
+      rewardsMultiplier,
+      purchasesMultiplier: 1,
+    });
+
+    // Negative control: the second row must actually reach the merge arm. A row that never merges
+    // would make the assertions below pass against an untouched first-row value.
+    expect(foldUserMultipliers([paidBronze(14), bad(9)])[14].rewardsMultiplier).toBe(9);
+
+    // `Math.max(1.5, NaN)` is NaN and `Math.max(1.5, Infinity)` is Infinity, so an unfloored merge
+    // arm lets one bad row poison a membership the user is paying for.
+    expect(foldUserMultipliers([paidBronze(14), bad(NaN)])[14].rewardsMultiplier).toBe(1.5);
+    expect(foldUserMultipliers([paidBronze(14), bad(Infinity)])[14].rewardsMultiplier).toBe(1.5);
+    expect(foldUserMultipliers([paidBronze(14), bad(-1)])[14].rewardsMultiplier).toBe(1.5);
   });
 
   it('replaces a non-finite multiplier by sign', () => {
@@ -138,13 +159,13 @@ describe('foldUserMultipliers', () => {
         userId: 12,
         rewardsIneligible: false,
         rewardsMultiplier: Infinity,
-        purchasesMultiplier: NaN,
+        purchasesMultiplier: 1,
       },
       {
         userId: 13,
         rewardsIneligible: false,
         rewardsMultiplier: -Infinity,
-        purchasesMultiplier: -Infinity,
+        purchasesMultiplier: 1,
       },
     ];
 
@@ -153,9 +174,7 @@ describe('foldUserMultipliers', () => {
     // Infinity and NaN take the base multiplier; a negative infinity is still a negative and must
     // not come out worth more than -5 does.
     expect(result[12].rewardsMultiplier).toBe(1);
-    expect(result[12].purchasesMultiplier).toBe(1);
     expect(result[13].rewardsMultiplier).toBe(0);
-    expect(result[13].purchasesMultiplier).toBe(0);
   });
 });
 

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -112,6 +112,51 @@ describe('foldUserMultipliers', () => {
   it('returns nothing for no rows', () => {
     expect(foldUserMultipliers([])).toEqual({});
   });
+
+  // `Math.max` here is a max ACROSS ROWS, not a floor, and the values come from operator-authored
+  // `Product.metadata` via `(...)::float` — a column that accepts a negative, `Infinity` and `NaN`.
+  // These reach the award computation and the Redis Lua cap script (ClickUp 868m06pn5).
+  it('floors a negative multiplier at 0 rather than carrying it', () => {
+    const typo: UserMultiplierRow = {
+      userId: 10,
+      rewardsIneligible: false,
+      rewardsMultiplier: -1,
+      purchasesMultiplier: -1,
+    };
+
+    const result = foldUserMultipliers([typo]);
+
+    // 0, not 1: a zero already means "earns nothing" everywhere downstream, and flooring to 1 would
+    // invent a payout out of a typo.
+    expect(result[10].rewardsMultiplier).toBe(0);
+    expect(result[10].purchasesMultiplier).toBe(0);
+  });
+
+  it('replaces a non-finite multiplier by sign', () => {
+    const rows: UserMultiplierRow[] = [
+      {
+        userId: 12,
+        rewardsIneligible: false,
+        rewardsMultiplier: Infinity,
+        purchasesMultiplier: NaN,
+      },
+      {
+        userId: 13,
+        rewardsIneligible: false,
+        rewardsMultiplier: -Infinity,
+        purchasesMultiplier: -Infinity,
+      },
+    ];
+
+    const result = foldUserMultipliers(rows);
+
+    // Infinity and NaN take the base multiplier; a negative infinity is still a negative and must
+    // not come out worth more than -5 does.
+    expect(result[12].rewardsMultiplier).toBe(1);
+    expect(result[12].purchasesMultiplier).toBe(1);
+    expect(result[13].rewardsMultiplier).toBe(0);
+    expect(result[13].purchasesMultiplier).toBe(0);
+  });
 });
 
 describe('userMultipliersCache wiring', () => {

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -121,7 +121,7 @@ describe('foldUserMultipliers', () => {
       userId: 10,
       rewardsIneligible: false,
       rewardsMultiplier: -1,
-      purchasesMultiplier: 1,
+      purchasesMultiplier: -3,
     };
 
     const result = foldUserMultipliers([typo]);
@@ -129,6 +129,11 @@ describe('foldUserMultipliers', () => {
     // 0, not 1: a zero already means "earns nothing" everywhere downstream, and flooring to 1 would
     // invent a payout out of a typo.
     expect(result[10].rewardsMultiplier).toBe(0);
+    // 🔴 And purchases is NOT floored, asserted at the producer where the symmetry edit is tempting
+    // — the comment forbidding it is two lines from the code, and the only other test covering this
+    // decision lives in a file that mocks this function away entirely. A 0 here credits a completed
+    // Buzz purchase with nothing; see buzz.service.multiplier-floor.test.ts for the mechanism.
+    expect(result[10].purchasesMultiplier).toBe(-3);
   });
 
   // The floor is applied at TWO places, both on the rewards side: the first-row assignment and the

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -156,6 +156,17 @@ describe('foldUserMultipliers', () => {
     // arm lets one bad row poison a membership the user is paying for.
     expect(foldUserMultipliers([paidBronze(14), bad(NaN)])[14].rewardsMultiplier).toBe(1.5);
     expect(foldUserMultipliers([paidBronze(14), bad(Infinity)])[14].rewardsMultiplier).toBe(1.5);
+
+    // And the purchases MERGE arm is not floored either — pinned here because the first-row
+    // assertion above cannot see it: flooring only this arm passed all 19 tests in this file.
+    // `Math.max(1.05, NaN)` is NaN, which is what a paying member with one bad row gets today.
+    const badPurchases: UserMultiplierRow = {
+      userId: 15,
+      rewardsIneligible: false,
+      rewardsMultiplier: 1,
+      purchasesMultiplier: NaN,
+    };
+    expect(foldUserMultipliers([paidBronze(15), badPurchases])[15].purchasesMultiplier).toBeNaN();
     // No negative case here on purpose: `Math.max(1.5, -1)` is 1.5 floored or not, so the merge arm
     // cannot be caught with one. The first-row arm covers negatives, in the test above.
   });

--- a/src/server/redis/__tests__/user-multipliers.test.ts
+++ b/src/server/redis/__tests__/user-multipliers.test.ts
@@ -131,9 +131,10 @@ describe('foldUserMultipliers', () => {
     expect(result[10].rewardsMultiplier).toBe(0);
   });
 
-  // The floor is applied at FOUR places: the two first-row assignments and the two `Math.max` merge
-  // arms. Every other test here gives a user ONE row, so only the first-row branch runs — reverting
-  // the merge arms alone left the whole file green. A multi-row user is the reason this fold exists.
+  // The floor is applied at TWO places, both on the rewards side: the first-row assignment and the
+  // `Math.max` merge arm. Every other test here gives a user ONE row, so only the first branch ran
+  // — reverting the merge arm alone left the whole file green. A multi-row user is the reason this
+  // fold exists. (`purchasesMultiplier` is deliberately NOT floored; see the buzz.service test.)
   it('floors a bad SECOND row, not only the first one it sees', () => {
     const bad = (rewardsMultiplier: number): UserMultiplierRow => ({
       userId: 14,
@@ -150,7 +151,8 @@ describe('foldUserMultipliers', () => {
     // arm lets one bad row poison a membership the user is paying for.
     expect(foldUserMultipliers([paidBronze(14), bad(NaN)])[14].rewardsMultiplier).toBe(1.5);
     expect(foldUserMultipliers([paidBronze(14), bad(Infinity)])[14].rewardsMultiplier).toBe(1.5);
-    expect(foldUserMultipliers([paidBronze(14), bad(-1)])[14].rewardsMultiplier).toBe(1.5);
+    // No negative case here on purpose: `Math.max(1.5, -1)` is 1.5 floored or not, so the merge arm
+    // cannot be caught with one. The first-row arm covers negatives, in the test above.
   });
 
   it('replaces a non-finite multiplier by sign', () => {

--- a/src/server/redis/user-multipliers.ts
+++ b/src/server/redis/user-multipliers.ts
@@ -1,3 +1,5 @@
+import { clampRewardMultiplier } from '~/server/rewards/multiplier';
+
 export type UserMultipliers = {
   userId: number;
   rewardsMultiplier: number;
@@ -15,6 +17,13 @@ export type UserMultiplierRow = {
 const BASE_MULTIPLIER = 1;
 
 /**
+ * `Math.max` below is a max ACROSS ROWS, not a floor: one row of -1 yields -1, and a
+ * `Product.metadata` value is operator-authored, so NaN and Infinity arrive the same way.
+ */
+const usable = (value: number | null | undefined) =>
+  value == null ? BASE_MULTIPLIER : clampRewardMultiplier(value);
+
+/**
  * Takes the best multiplier across every active subscription a user holds rather than the one
  * highest-ranked row. A referral grant (civitai-referral-*) and a buzz-purchase grant
  * (civitai-buzz-*) are placeholders that convey a tier and no perks, and either can out-rank a
@@ -22,7 +31,8 @@ const BASE_MULTIPLIER = 1;
  * member is paying for. See ClickUp 868kv4q7t / 868kr8bh3.
  *
  * A row with no multiplier counts as 1, but the result is NOT floored at 1 — a product priced
- * below 1 keeps its value, as it did when this was one COALESCE over a single winning row.
+ * below 1 keeps its value, as it did when this was one COALESCE over a single winning row. It IS
+ * floored at 0, which preserves that: every sub-1 product is still above the floor.
  *
  * `rewardsIneligible` is taken from the first row seen for a user, which is safe only because the
  * query computes it off `User`, so every row for a user carries the same value. Move that
@@ -37,19 +47,19 @@ export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, U
       records[row.userId] = {
         userId: row.userId,
         rewardsIneligible: row.rewardsIneligible,
-        rewardsMultiplier: row.rewardsMultiplier ?? BASE_MULTIPLIER,
-        purchasesMultiplier: row.purchasesMultiplier ?? BASE_MULTIPLIER,
+        rewardsMultiplier: usable(row.rewardsMultiplier),
+        purchasesMultiplier: usable(row.purchasesMultiplier),
       };
       continue;
     }
 
     existing.rewardsMultiplier = Math.max(
       existing.rewardsMultiplier,
-      row.rewardsMultiplier ?? BASE_MULTIPLIER
+      usable(row.rewardsMultiplier)
     );
     existing.purchasesMultiplier = Math.max(
       existing.purchasesMultiplier,
-      row.purchasesMultiplier ?? BASE_MULTIPLIER
+      usable(row.purchasesMultiplier)
     );
   }
 

--- a/src/server/redis/user-multipliers.ts
+++ b/src/server/redis/user-multipliers.ts
@@ -19,6 +19,10 @@ const BASE_MULTIPLIER = 1;
 /**
  * `Math.max` below is a max ACROSS ROWS, not a floor: one row of -1 yields -1, and a
  * `Product.metadata` value is operator-authored, so NaN and Infinity arrive the same way.
+ *
+ * Rewards only. `purchasesMultiplier` reaches `getBuzzBulkMultiplier`, which is called
+ * unconditionally, and a 0 there credits a paid Buzz purchase with nothing — see ClickUp 868m06pn5.
+ * That path needs its own floor, decided on its own terms.
  */
 const usable = (value: number | null | undefined) =>
   value == null ? BASE_MULTIPLIER : clampRewardMultiplier(value);
@@ -48,7 +52,7 @@ export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, U
         userId: row.userId,
         rewardsIneligible: row.rewardsIneligible,
         rewardsMultiplier: usable(row.rewardsMultiplier),
-        purchasesMultiplier: usable(row.purchasesMultiplier),
+        purchasesMultiplier: row.purchasesMultiplier ?? BASE_MULTIPLIER,
       };
       continue;
     }
@@ -59,7 +63,7 @@ export function foldUserMultipliers(rows: UserMultiplierRow[]): Record<number, U
     );
     existing.purchasesMultiplier = Math.max(
       existing.purchasesMultiplier,
-      usable(row.purchasesMultiplier)
+      row.purchasesMultiplier ?? BASE_MULTIPLIER
     );
   }
 

--- a/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
+++ b/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 // The multiplier reaching the AWARD computation, not the ClickHouse audit row.
 //
-// `rewardsMultiplier` is read off operator-authored `Product.metadata`, and has THREE readers:
+// `rewardsMultiplier` is read off operator-authored `Product.metadata`. Three readers IN THIS FILE:
 // `processOnDemand` (which stringifies it into the Redis Lua cap script), `sendAward` (which pays
 // `awardAmount * multiplier`), and `getUserRewardDetails` (which advertises the award and cap).
+// `claimBuzz` is a fourth, in buzz.service.ts — not a complete census, so do not read it as one.
 // `toClickhouseBuzzEvent`'s clamp reaches none of them — it clamps a copy on its way to ClickHouse
 // and leaves the event alone.
 //
@@ -202,12 +203,16 @@ describe('the multiplier the rewards list advertises', () => {
   it('still applies a legitimate multiplier', async () => {
     // Negative control: without it the assertions above pass on an implementation that ignores the
     // multiplier entirely.
-    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 } as any);
+    // 20, not 4: gold's 4x times a MAX_GLOBAL_BONUS of 5, i.e. above the shared helper's 9.99
+    // ceiling. At 4 the two helpers agree, so swapping in `clampBuzzEventMultiplier` here — the one
+    // edit this file's loudest comment forbids — passed. At 20 it advertises 9.99x for the 20x
+    // `sendAward` actually pays, and this reddens.
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 20 } as any);
 
     const details = await reward().getUserRewardDetails(1);
 
-    expect(details?.awardAmount).toBe(AWARD_AMOUNT * 4);
-    expect(details?.cap).toBe(CAP * 4);
+    expect(details?.awardAmount).toBe(AWARD_AMOUNT * 20);
+    expect(details?.cap).toBe(CAP * 20);
   });
 });
 

--- a/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
+++ b/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
@@ -6,8 +6,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // `rewardsMultiplier` is read off operator-authored `Product.metadata`, and lands in TWO money
 // computations: `processOnDemand` (which stringifies it into the Redis Lua cap script) and
 // `sendAward` (which pays `awardAmount * multiplier`). `toClickhouseBuzzEvent`'s clamp reaches
-// neither — it clamps a copy on its way to ClickHouse, so the event keeps the raw value and the
-// audit row can record it.
+// neither — it clamps a copy on its way to ClickHouse and leaves the event alone.
+//
+// These mock `getMultipliersForUser`, so they see values that a caller going through the real one
+// would already have had floored. That is the point: the clamps here are what covers a value that
+// did NOT come from it — a `pending` row written before this shipped, read back by `process`.
 //
 // The assertions below read the ARGV strings the Lua actually receives and the amount
 // `createBuzzTransactionMany` is actually asked for, because those are the two values that decide
@@ -170,6 +173,11 @@ describe('the multiplier sendAward pays from', () => {
     h.evalImpl.mockResolvedValue(400 as any);
     await applyWith('4.00' as unknown as number);
 
+    // Asserted, not assumed: if the cap-trim branch is ever taken, `event.multiplier` is
+    // neutralised to 1 and the assertion below stops seeing the clamp at all. The sibling above
+    // pins the same precondition for the same reason.
+    expect(luaArgs().award, 'the cap-trim branch would neutralise the multiplier').toBe('400');
+
     const [transactions] = h.createBuzzTransactionMany.mock.calls[0] as unknown as [
       { amount: number }[]
     ];
@@ -204,9 +212,20 @@ describe('clampRewardMultiplier', () => {
     expect(clampRewardMultiplier(20)).toBe(20);
   });
 
+  it('reads a quoted decimal at its value', () => {
+    // The unit-level statement of the batch-path bug. Without this, the coercion is reachable only
+    // through the three-mock integration test above.
+    expect(clampRewardMultiplier('4.00' as unknown as number)).toBe(4);
+    expect(clampRewardMultiplier('0.00' as unknown as number)).toBe(0);
+  });
+
   it('agrees with clampBuzzEventMultiplier on the half they do share', () => {
     // `multiplier.ts` claims its non-finite rule matches the shared helper's. Only the ceiling was
     // pinned, so the claim could rot in either direction without a test noticing.
+    //
+    // Numbers only, deliberately: on a quoted decimal the two DISAGREE and are meant to —
+    // `clampRewardMultiplier('4.00')` is 4 and `clampBuzzEventMultiplier('4.00')` is 1, because the
+    // shared helper's callers coerce for it. Pinned in the test above, not folded in here.
     for (const value of [-5, -Infinity, NaN, Infinity, 0, 0.5, 4]) {
       expect(clampRewardMultiplier(value), `disagreed on ${String(value)}`).toBe(
         clampBuzzEventMultiplier(value)

--- a/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
+++ b/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// The multiplier reaching the AWARD computation, not the ClickHouse audit row.
+//
+// `rewardsMultiplier` is read off operator-authored `Product.metadata`, and lands in TWO money
+// computations: `processOnDemand` (which stringifies it into the Redis Lua cap script) and
+// `sendAward` (which pays `awardAmount * multiplier`). `toClickhouseBuzzEvent`'s clamp reaches
+// neither — it clamps a copy on its way to ClickHouse, so the event keeps the raw value and the
+// audit row can record it.
+//
+// The assertions below read the ARGV strings the Lua actually receives and the amount
+// `createBuzzTransactionMany` is actually asked for, because those are the two values that decide
+// whether a mutation throws and what a user is paid.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  insertImpl: vi.fn(async () => undefined),
+  evalImpl: vi.fn(async () => 0 as number),
+  hGetImpl: vi.fn(async () => '{}'),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insertImpl(...args),
+    $query: vi.fn(async () => []),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: vi.fn() },
+  rewardGivenCounter: { inc: vi.fn() },
+  clickhouseFailSoftCounter: { inc: vi.fn() },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+}));
+
+import { BUZZ_EVENTS_MAX_MULTIPLIER, clampBuzzEventMultiplier } from '@civitai/clickhouse';
+import { createBuzzEvent } from '~/server/rewards/base.reward';
+import { clampRewardMultiplier } from '~/server/rewards/multiplier';
+import { invalidateRewardConfigCache } from '~/server/rewards/reward-config';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+
+redisMock.redis.eval.mockImplementation((...args: any[]) => h.evalImpl(...args));
+redisMock.redis.hGet.mockImplementation((...args: any[]) => h.hGetImpl(...args));
+
+const AWARD_AMOUNT = 100;
+const CAP = 1000;
+
+const reward = () =>
+  createBuzzEvent<{ userId: number; entityId: number }>({
+    type: 'testMultiplierFloorReward',
+    description: 'Test on-demand reward',
+    awardAmount: AWARD_AMOUNT,
+    cap: CAP,
+    onDemand: true,
+    getKey: async (input) => ({
+      toUserId: input.userId,
+      forId: input.entityId,
+      byUserId: input.userId,
+    }),
+  });
+
+/** ARGV[3] and ARGV[4]: the effective award and the effective cap, as the Lua receives them. */
+const luaArgs = () => {
+  const args = (h.evalImpl.mock.calls[0]?.[1] as { arguments: string[] } | undefined)?.arguments;
+  if (!args) throw new Error('redis.eval was never called — the reward never reached the script');
+  return { award: args[2], cap: args[3] };
+};
+
+const applyWith = async (rewardsMultiplier: number) => {
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier } as any);
+  await reward().apply({ userId: 1, entityId: 10 }, {});
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateRewardConfigCache();
+  dbMock.dbRead.keyValue.findUnique.mockResolvedValue(null);
+  h.insertImpl.mockResolvedValue(undefined as any);
+  h.hGetImpl.mockResolvedValue('{}');
+  h.evalImpl.mockResolvedValue(AWARD_AMOUNT as any);
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+});
+
+describe('the multiplier handed to the Lua cap script', () => {
+  it('is a number Lua can parse when the multiplier is Infinity', async () => {
+    await applyWith(Infinity);
+
+    const { award, cap } = luaArgs();
+    // `tonumber('Infinity')` is nil in Lua, and the arithmetic on nil throws out of `redis.eval`
+    // and into the user's mutation. Asserting the STRING is the point: it is what crosses the wire.
+    expect(award).toBe('100');
+    expect(cap).toBe('1000');
+    expect(Number.isFinite(Number(award))).toBe(true);
+    expect(Number.isFinite(Number(cap))).toBe(true);
+  });
+
+  it('is a number Lua can parse when the multiplier is NaN', async () => {
+    await applyWith(NaN);
+
+    const { award, cap } = luaArgs();
+    expect(award).toBe('100');
+    expect(cap).toBe('1000');
+  });
+
+  it('is floored at zero when the multiplier is negative', async () => {
+    await applyWith(-2);
+
+    const { award, cap } = luaArgs();
+    // A negative award is written into the dedup entry as `a:-200`, which the reader's
+    // `'^a:(%d+)$'` cannot match, so every later read of that entry falls back to the CURRENT
+    // award for the rest of the day. Cap accounting, not just an ugly row.
+    expect(award).toBe('0');
+    expect(cap).toBe('0');
+  });
+
+  it('leaves a legitimate multiplier alone', async () => {
+    await applyWith(4);
+
+    expect(luaArgs()).toEqual({ award: '400', cap: '4000' });
+  });
+});
+
+describe('the multiplier sendAward pays from', () => {
+  it('is floored too, not only the one the cap script sees', async () => {
+    // `sendAward` is a SECOND money computation reading the same value, and flooring
+    // `processOnDemand` alone leaves it raw. `toClickhouseBuzzEvent` does not cover it: that clamps
+    // a copy on its way to ClickHouse and deliberately leaves the event alone, so the audit row can
+    // record `multiplierRaw`.
+    //
+    // NaN is what makes the difference legible: `Math.ceil(100 * NaN)` is NaN, `NaN > 0` is false,
+    // and `sendAward`'s own amount filter then drops the transaction entirely — the user is
+    // recorded `awarded` and paid nothing.
+    await applyWith(NaN);
+
+    const [transactions] = h.createBuzzTransactionMany.mock.calls[0] as unknown as [
+      { amount: number }[]
+    ];
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].amount).toBe(100);
+  });
+});
+
+describe('clampRewardMultiplier', () => {
+  it('floors at 0 and keeps a zero, which is how rewards-ineligibility is reported', () => {
+    expect(clampRewardMultiplier(-5)).toBe(0);
+    expect(clampRewardMultiplier(0)).toBe(0);
+  });
+
+  it('falls back by sign for a non-finite value', () => {
+    expect(clampRewardMultiplier(Infinity)).toBe(1);
+    expect(clampRewardMultiplier(-Infinity)).toBe(0);
+    expect(clampRewardMultiplier(NaN)).toBe(1);
+  });
+
+  it('keeps a sub-1 multiplier, which is a priced product and not a defect', () => {
+    expect(clampRewardMultiplier(0.5)).toBe(0.5);
+  });
+
+  // 🔴 THE DECISION THIS FILE EXISTS TO PIN. If you are here because you replaced
+  // `clampRewardMultiplier` with `clampBuzzEventMultiplier` to remove a near-duplicate: don't. The
+  // shared helper carries the `buzzEvents.multiplier` column's 9.99 ceiling, which is right for a
+  // ClickHouse audit row and wrong here, because `sendAward` PAYS `awardAmount * multiplier`. Gold's
+  // 4 times a MAX_GLOBAL_BONUS of 5 is a legitimate 20, and capping it at 9.99 halves the payout of
+  // a bonus event nobody asked to change. Delete this test and that becomes invisible.
+  it('keeps no ceiling, unlike clampBuzzEventMultiplier', () => {
+    expect(clampBuzzEventMultiplier(20)).toBe(BUZZ_EVENTS_MAX_MULTIPLIER);
+    expect(clampRewardMultiplier(20)).toBe(20);
+  });
+
+  it('does not bound a large finite multiplier — only a ceiling would, and that is a product call', () => {
+    expect(clampRewardMultiplier(1e20)).toBe(1e20);
+  });
+});

--- a/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
+++ b/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
@@ -8,9 +8,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // `sendAward` (which pays `awardAmount * multiplier`). `toClickhouseBuzzEvent`'s clamp reaches
 // neither — it clamps a copy on its way to ClickHouse and leaves the event alone.
 //
-// These mock `getMultipliersForUser`, so they see values that a caller going through the real one
-// would already have had floored. That is the point: the clamps here are what covers a value that
-// did NOT come from it — a `pending` row written before this shipped, read back by `process`.
+// These mock `getMultipliersForUser`. The real one floors its BASE and then multiplies by the
+// bonus without re-clamping the product, so it can hand these sites a non-finite value built from
+// two finite floored factors — pinned by `can return a NON-FINITE multiplier` in
+// buzz.service.multiplier-floor.test.ts. That is what the clamps here cover.
 //
 // The assertions below read the ARGV strings the Lua actually receives and the amount
 // `createBuzzTransactionMany` is actually asked for, because those are the two values that decide
@@ -226,7 +227,9 @@ describe('clampRewardMultiplier', () => {
     // Numbers only, deliberately: on a quoted decimal the two DISAGREE and are meant to —
     // `clampRewardMultiplier('4.00')` is 4 and `clampBuzzEventMultiplier('4.00')` is 1, because the
     // shared helper's callers coerce for it. Pinned in the test above, not folded in here.
-    for (const value of [-5, -Infinity, NaN, Infinity, 0, 0.5, 4]) {
+    const values = [-5, -Infinity, NaN, Infinity, 0, 0.5, 4];
+    expect(values).toHaveLength(7);
+    for (const value of values) {
       expect(clampRewardMultiplier(value), `disagreed on ${String(value)}`).toBe(
         clampBuzzEventMultiplier(value)
       );

--- a/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
+++ b/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
@@ -139,13 +139,41 @@ describe('the multiplier sendAward pays from', () => {
     // NaN is what makes the difference legible: `Math.ceil(100 * NaN)` is NaN, `NaN > 0` is false,
     // and `sendAward`'s own amount filter then drops the transaction entirely — the user is
     // recorded `awarded` and paid nothing.
+    //
+    // 🔴 `evalImpl` returning exactly AWARD_AMOUNT is load-bearing. `effectiveAward` is also 100, so
+    // `toAward < effectiveAward` is false and `apply` does NOT take the cap-trim branch that
+    // neutralises `event.multiplier` to 1. Lower this mock and the test passes vacuously with the
+    // clamp gone. The assertion below pins the equality rather than trusting the default.
     await applyWith(NaN);
 
+    expect(luaArgs().award, 'the cap-trim branch would neutralise the multiplier').toBe(
+      String(AWARD_AMOUNT)
+    );
+    expect(h.createBuzzTransactionMany).toHaveBeenCalledTimes(1);
     const [transactions] = h.createBuzzTransactionMany.mock.calls[0] as unknown as [
       { amount: number }[]
     ];
     expect(transactions).toHaveLength(1);
     expect(transactions[0].amount).toBe(100);
+  });
+
+  it('pays a quoted multiplier at its value, not at the non-finite fallback', async () => {
+    // 🔴 The batch path reads `multiplier` back out of a ClickHouse `Decimal(3, 2)`, where it is
+    // `number`-typed and string-valued. `Number.isFinite('4.00')` is FALSE, so a clamp that tests
+    // the argument directly pays 1x for a legitimate 4x — the underpay `toClickhouseBuzzEvent` was
+    // already fixed for once (f450100aba), reached through a different reader. Do not "simplify"
+    // the `Number()` out of `clampRewardMultiplier`.
+    // The Lua returns the FULL effective award, so the grant is untrimmed and `apply` leaves
+    // `event.multiplier` alone — the branch where `sendAward` reads the quoted value. At the
+    // default mock return of 100 the cap-trim branch neutralises it to 1 and the test cannot see
+    // the bug at all.
+    h.evalImpl.mockResolvedValue(400 as any);
+    await applyWith('4.00' as unknown as number);
+
+    const [transactions] = h.createBuzzTransactionMany.mock.calls[0] as unknown as [
+      { amount: number }[]
+    ];
+    expect(transactions[0].amount).toBe(400);
   });
 });
 
@@ -174,6 +202,16 @@ describe('clampRewardMultiplier', () => {
   it('keeps no ceiling, unlike clampBuzzEventMultiplier', () => {
     expect(clampBuzzEventMultiplier(20)).toBe(BUZZ_EVENTS_MAX_MULTIPLIER);
     expect(clampRewardMultiplier(20)).toBe(20);
+  });
+
+  it('agrees with clampBuzzEventMultiplier on the half they do share', () => {
+    // `multiplier.ts` claims its non-finite rule matches the shared helper's. Only the ceiling was
+    // pinned, so the claim could rot in either direction without a test noticing.
+    for (const value of [-5, -Infinity, NaN, Infinity, 0, 0.5, 4]) {
+      expect(clampRewardMultiplier(value), `disagreed on ${String(value)}`).toBe(
+        clampBuzzEventMultiplier(value)
+      );
+    }
   });
 
   it('does not bound a large finite multiplier — only a ceiling would, and that is a product call', () => {

--- a/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
+++ b/src/server/rewards/__tests__/base.reward.multiplier-floor.test.ts
@@ -3,10 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 // The multiplier reaching the AWARD computation, not the ClickHouse audit row.
 //
-// `rewardsMultiplier` is read off operator-authored `Product.metadata`, and lands in TWO money
-// computations: `processOnDemand` (which stringifies it into the Redis Lua cap script) and
-// `sendAward` (which pays `awardAmount * multiplier`). `toClickhouseBuzzEvent`'s clamp reaches
-// neither — it clamps a copy on its way to ClickHouse and leaves the event alone.
+// `rewardsMultiplier` is read off operator-authored `Product.metadata`, and has THREE readers:
+// `processOnDemand` (which stringifies it into the Redis Lua cap script), `sendAward` (which pays
+// `awardAmount * multiplier`), and `getUserRewardDetails` (which advertises the award and cap).
+// `toClickhouseBuzzEvent`'s clamp reaches none of them — it clamps a copy on its way to ClickHouse
+// and leaves the event alone.
 //
 // These mock `getMultipliersForUser`. The real one floors its BASE and then multiplies by the
 // bonus without re-clamping the product, so it can hand these sites a non-finite value built from
@@ -183,6 +184,30 @@ describe('the multiplier sendAward pays from', () => {
       { amount: number }[]
     ];
     expect(transactions[0].amount).toBe(400);
+  });
+});
+
+describe('the multiplier the rewards list advertises', () => {
+  it('is a number, not Infinity', async () => {
+    // The third reader. Display rather than money, so it was the one with no test — and a clamp
+    // with no test is what the rest of this file exists to argue against.
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: Infinity } as any);
+
+    const details = await reward().getUserRewardDetails(1);
+
+    expect(details?.awardAmount).toBe(AWARD_AMOUNT);
+    expect(details?.cap).toBe(CAP);
+  });
+
+  it('still applies a legitimate multiplier', async () => {
+    // Negative control: without it the assertions above pass on an implementation that ignores the
+    // multiplier entirely.
+    h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 4 } as any);
+
+    const details = await reward().getUserRewardDetails(1);
+
+    expect(details?.awardAmount).toBe(AWARD_AMOUNT * 4);
+    expect(details?.cap).toBe(CAP * 4);
   });
 });
 

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -241,11 +241,13 @@ export function createBuzzEvent<T>({
 
     const hashField = `${key.toUserId}:${type}`;
     const cacheKey = String(hashifyObject(key));
-    // Floored where the value is SPENT, not where `apply` reads it. `getMultipliersForUser` already
-    // floors, so this covers what does not come through it: a `pending` row written before that
-    // shipped and read back by `process`, and any future writer of one. Flooring at the read
-    // instead normalises the value before `toClickhouseBuzzEvent` sees it, which is how the first
-    // revision of this deleted seven `multiplierRaw` assertions in base.reward.forid.test.ts.
+    // Floored where the value is SPENT. `getMultipliersForUser` floors its BASE and then multiplies
+    // by the bonus without re-clamping the product, so it can return a non-finite value built from
+    // two finite floored factors — no read-side clamp closes that, because the overflow happens
+    // after it. See `can return a NON-FINITE multiplier` in buzz.service.multiplier-floor.test.ts.
+    //
+    // Flooring at the read instead normalises the value before `toClickhouseBuzzEvent` sees it and
+    // destroys the `multiplierRaw` audit fidelity — see base.reward.forid.test.ts.
     const effective = clampRewardMultiplier(multiplier);
     const effectiveAward = Math.ceil(config.awardAmount * effective);
     // An uncapped reward needs a finite ceiling: `tonumber('Infinity')` is nil in

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -145,8 +145,9 @@ export function createBuzzEvent<T>({
       accountType: buzzEvent.toAccountType ?? 'blue',
     };
 
-    // The THIRD reader of this value. Display rather than money, but `getMultipliersForUser` can
-    // return a non-finite product, and an advertised award of `Infinity` is still a bug.
+    // Display rather than money, but `getMultipliersForUser` can return a non-finite product, and
+    // an advertised award of `Infinity` is still a bug. Not a complete census of readers: `claimBuzz`
+    // is a fourth, in buzz.service.ts, and it pays.
     const { rewardsMultiplier } = await getMultipliersForUser(userId);
     const multiplier = clampRewardMultiplier(rewardsMultiplier);
     if (multiplier !== 1) {

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -145,11 +145,13 @@ export function createBuzzEvent<T>({
       accountType: buzzEvent.toAccountType ?? 'blue',
     };
 
-    // Apply multipliers
+    // The THIRD reader of this value. Display rather than money, but `getMultipliersForUser` can
+    // return a non-finite product, and an advertised award of `Infinity` is still a bug.
     const { rewardsMultiplier } = await getMultipliersForUser(userId);
-    if (rewardsMultiplier !== 1) {
-      data.awardAmount = Math.ceil(rewardsMultiplier * data.awardAmount);
-      if (data.cap) data.cap = Math.ceil(rewardsMultiplier * data.cap);
+    const multiplier = clampRewardMultiplier(rewardsMultiplier);
+    if (multiplier !== 1) {
+      data.awardAmount = Math.ceil(multiplier * data.awardAmount);
+      if (data.cap) data.cap = Math.ceil(multiplier * data.cap);
     }
 
     if (!isOnDemand) {
@@ -241,12 +243,13 @@ export function createBuzzEvent<T>({
 
     const hashField = `${key.toUserId}:${type}`;
     const cacheKey = String(hashifyObject(key));
-    // Floored where the value is SPENT. `getMultipliersForUser` floors its BASE and then multiplies
-    // by the bonus without re-clamping the product, so it can return a non-finite value built from
-    // two finite floored factors — no read-side clamp closes that, because the overflow happens
-    // after it. See `can return a NON-FINITE multiplier` in buzz.service.multiplier-floor.test.ts.
+    // WHETHER to clamp: `getMultipliersForUser` floors its BASE and then multiplies by the bonus
+    // without re-clamping the product, so it can hand this a non-finite value built from two finite
+    // floored factors — see `can return a NON-FINITE multiplier` in
+    // buzz.service.multiplier-floor.test.ts.
     //
-    // Flooring at the read instead normalises the value before `toClickhouseBuzzEvent` sees it and
+    // WHERE, and this is the part that is easy to get wrong: clamping at `apply`'s read would close
+    // the same case, but it normalises the value before `toClickhouseBuzzEvent` sees it and
     // destroys the `multiplierRaw` audit fidelity — see base.reward.forid.test.ts.
     const effective = clampRewardMultiplier(multiplier);
     const effectiveAward = Math.ceil(config.awardAmount * effective);

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -16,6 +16,7 @@ import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransactionMany, getMultipliersForUser } from '~/server/services/buzz.service';
 import type { ResolvedRewardConfig, RewardConfig } from '~/server/rewards/reward-config';
 import { resolveFromConfig, resolveRewardConfig } from '~/server/rewards/reward-config';
+import { clampRewardMultiplier } from '~/server/rewards/multiplier';
 import { hashify, hashifyObject } from '~/utils/string-helpers';
 import { isClickHouseConnectionError, withRetries } from '../utils/errorHandling';
 
@@ -208,7 +209,7 @@ export function createBuzzEvent<T>({
               type: TransactionType.Reward,
               toAccountId: event.toUserId,
               fromAccountId: 0, // central bank
-              amount: Math.ceil(event.awardAmount * (event.multiplier ?? 1)),
+              amount: Math.ceil(event.awardAmount * clampRewardMultiplier(event.multiplier ?? 1)),
               description: `Buzz Reward: ${description}`,
               details: {
                 type: event.type,
@@ -240,11 +241,15 @@ export function createBuzzEvent<T>({
 
     const hashField = `${key.toUserId}:${type}`;
     const cacheKey = String(hashifyObject(key));
-    const effectiveAward = Math.ceil(config.awardAmount * multiplier);
+    // Floored at the two places the value is USED for money rather than where it is read, so the
+    // event keeps the raw multiplier and `toClickhouseBuzzEvent` can still record it as
+    // `multiplierRaw`. An operator typo stays legible in the audit row and stops being payable.
+    const effective = clampRewardMultiplier(multiplier);
+    const effectiveAward = Math.ceil(config.awardAmount * effective);
     // An uncapped reward needs a finite ceiling: `tonumber('Infinity')` is nil in
     // Lua, which would throw out of the script and into the user's mutation.
     const effectiveCap =
-      config.cap === undefined ? Number.MAX_SAFE_INTEGER : Math.ceil(config.cap * multiplier);
+      config.cap === undefined ? Number.MAX_SAFE_INTEGER : Math.ceil(config.cap * effective);
     const endOfDay = Math.floor(new Date().setUTCHours(23, 59, 59, 999) / 1000);
 
     const result = (await redis.eval(ON_DEMAND_REWARD_SCRIPT, {

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -241,9 +241,11 @@ export function createBuzzEvent<T>({
 
     const hashField = `${key.toUserId}:${type}`;
     const cacheKey = String(hashifyObject(key));
-    // Floored at the two places the value is USED for money rather than where it is read, so the
-    // event keeps the raw multiplier and `toClickhouseBuzzEvent` can still record it as
-    // `multiplierRaw`. An operator typo stays legible in the audit row and stops being payable.
+    // Floored where the value is SPENT, not where `apply` reads it. `getMultipliersForUser` already
+    // floors, so this covers what does not come through it: a `pending` row written before that
+    // shipped and read back by `process`, and any future writer of one. Flooring at the read
+    // instead normalises the value before `toClickhouseBuzzEvent` sees it, which is how the first
+    // revision of this deleted seven `multiplierRaw` assertions in base.reward.forid.test.ts.
     const effective = clampRewardMultiplier(multiplier);
     const effectiveAward = Math.ceil(config.awardAmount * effective);
     // An uncapped reward needs a finite ceiling: `tonumber('Infinity')` is nil in

--- a/src/server/rewards/multiplier.ts
+++ b/src/server/rewards/multiplier.ts
@@ -1,0 +1,25 @@
+/**
+ * Fit a reward multiplier to what the paying code can use: floor at 0, and a fallback for a value
+ * that is not a number at all.
+ *
+ * 🔴 This is NOT `clampBuzzEventMultiplier`, and replacing it with one is not a cleanup — see
+ * `base.reward.multiplier-floor.test.ts`. That helper carries the `buzzEvents.multiplier` column's
+ * 9.99 ceiling, which belongs to a ClickHouse audit row. These values are PAID from: `sendAward`
+ * computes `awardAmount * multiplier`, and a ceiling here would cap a legitimate 20x bonus event
+ * (gold's 4 times MAX_GLOBAL_BONUS of 5) at 9.99.
+ *
+ * The floor is 0, not 1. A 0 multiplier is how `getMultipliersForUser` reports rewards-
+ * ineligibility, and sub-1 products are intentional (see `foldUserMultipliers`).
+ *
+ * Non-finite falls back BY SIGN so the floor stays monotone, matching the shared helper's rule.
+ * `Infinity` is not a harmless overflow on this path: it reaches the Redis Lua cap script as the
+ * string `'Infinity'`, whose `tonumber` is nil, and the arithmetic on nil throws out of `redis.eval`
+ * and into the user's mutation.
+ *
+ * What this does NOT do: a large-but-finite multiplier is left alone. Only a ceiling bounds that,
+ * and a ceiling on a payout path is a product decision, not a guard.
+ */
+export function clampRewardMultiplier(multiplier: number): number {
+  if (!Number.isFinite(multiplier)) return multiplier < 0 ? 0 : 1;
+  return Math.max(multiplier, 0);
+}

--- a/src/server/rewards/multiplier.ts
+++ b/src/server/rewards/multiplier.ts
@@ -16,10 +16,23 @@
  * string `'Infinity'`, whose `tonumber` is nil, and the arithmetic on nil throws out of `redis.eval`
  * and into the user's mutation.
  *
+ * The positive fallback is 1, so a NaN now PAYS the base award on the batch path where the old
+ * `Math.ceil(award * NaN)` produced NaN and `sendAward`'s own `amount > 0` filter dropped it. That
+ * is deliberate: one rule across every site beats two, and with the coercion below a NaN can no
+ * longer be a misread quoted decimal, so the input is genuinely garbage rather than a legitimate
+ * value in disguise. The alternative — treat it as `unqualified` and pay nothing — is defensible;
+ * it was decided, not defaulted into.
+ *
  * What this does NOT do: a large-but-finite multiplier is left alone. Only a ceiling bounds that,
  * and a ceiling on a payout path is a product decision, not a guard.
  */
 export function clampRewardMultiplier(multiplier: number): number {
-  if (!Number.isFinite(multiplier)) return multiplier < 0 ? 0 : 1;
-  return Math.max(multiplier, 0);
+  // `Number()` first, and the parameter type is why. On the batch path this value is read back out
+  // of a ClickHouse `Decimal(3, 2)`, where it is `number`-typed and string-valued at runtime.
+  // `Number.isFinite('4.00')` is false, so testing the argument directly would send a legitimate 4x
+  // down the non-finite fallback and pay 1x — the underpay `toClickhouseBuzzEvent` already had to
+  // be fixed for once (f450100aba), reached here through a different reader.
+  const raw = Number(multiplier);
+  if (!Number.isFinite(raw)) return raw < 0 ? 0 : 1;
+  return Math.max(raw, 0);
 }

--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -77,7 +77,7 @@ describe('getMultipliersForUser floors the value it pays with', () => {
 
   it('still multiplies a floored base by an active bonus event', async () => {
     // This is the only cover for the line the fix rewrote: drop `* globalRewardsBonus` and it
-    // prints `expected 4 to be 8`. It does NOT separate a floor-at-0 from a floor-at-1 — clamp(4)
+    // prints `expected 4 to be 20`. It does NOT separate a floor-at-0 from a floor-at-1 — clamp(4)
     // is 4 under either — so do not read it as doing that.
     cached(4);
     // 200/10 = 20, ABOVE MAX_GLOBAL_BONUS. At the 20 this used to carry, the raw value was already
@@ -100,6 +100,11 @@ describe('getMultipliersForUser floors the value it pays with', () => {
   // as an idempotency marker, so a retry can never repair it. A 0 means "earns nothing" on the
   // rewards side and nothing at all on the purchases side. That path needs its own floor, decided
   // on its own terms. Without this test the reverted regression comes back green.
+  //
+  // Closing condition, so this does not become a wall: when the purchases path gets its own floor —
+  // likely at 1, which delivers what was paid for — this test is UPDATED, not deleted. A floor at 0
+  // is the one that pays nothing. Note also that every value able to witness "not floored" is a
+  // value that must never reach the payment path, so the assertions below pin a hazard on purpose.
   it('does NOT floor purchasesMultiplier — that is a different money path', async () => {
     h.fetch.mockResolvedValue({
       [USER]: {
@@ -122,6 +127,39 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     });
 
     expect((await getMultipliersForUser(USER)).purchasesMultiplier).toBeNaN();
+  });
+
+  it('does not let a bonus event make rewards WORSE, or stop them entirely', async () => {
+    // The guard this file's header cites is three checks, and the fixture above only reaches the
+    // ceiling. These are the other two, and both are silent site-wide money events:
+    //   raw < 1  — every reward on the site halved by a "bonus" event
+    //   NaN      — every amount NaN, which sendAward's own `> 0` filter drops: paying just stops
+    cached(4);
+    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 5 } as any);
+    expect((await getMultipliersForUser(USER)).globalRewardsBonus).toBe(1);
+
+    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: NaN } as any);
+    expect((await getMultipliersForUser(USER)).globalRewardsBonus).toBe(1);
+  });
+
+  it('can return a NON-FINITE multiplier built from two finite floored factors', async () => {
+    // 🔴 THE REASON THE SPENDING SITES CLAMP AT ALL. This function floors the BASE and then
+    // multiplies; the product is never re-clamped. So "getMultipliersForUser already floors" is
+    // true of its input and false of its output, and no read-side clamp can close it — the overflow
+    // happens after. `String(Infinity)` reaching the Lua cap script is `tonumber` nil, which throws
+    // out of `redis.eval` and into the user's mutation.
+    //
+    // Two earlier attempts to write down why the spending sites clamp were both wrong (a
+    // `multiplierRaw` audit trail; a pending row read back by `process` — which cannot happen,
+    // `isProcessable = !isOnDemand`). This is the one that holds, so it is asserted, not narrated.
+    cached(1e308);
+    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 50 } as any);
+
+    const result = await getMultipliersForUser(USER);
+
+    expect(result.baseRewardsMultiplier).toBe(1e308);
+    expect(result.globalRewardsBonus).toBe(5);
+    expect(Number.isFinite(result.rewardsMultiplier)).toBe(false);
   });
 
   it('leaves a sub-1 multiplier alone', async () => {

--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -16,10 +16,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * `getBuzzBulkMultiplier`, where a 0 credits a paid Buzz purchase with nothing.
  */
 
+import type * as BuzzClient from '@civitai/buzz';
 import type * as Caches from '~/server/redis/caches';
 
 const h = vi.hoisted(() => ({
   fetch: vi.fn(),
+  createTransaction: vi.fn(),
+  getTransactionByExternalId: vi.fn(),
+  getAccount: vi.fn(),
   // `deleteMultipliersForUserCache` calls `.refresh` on the `refresh = true` branch. Absent, that
   // branch dies as "refresh is not a function" instead of a named assertion.
   refresh: vi.fn(),
@@ -31,11 +35,23 @@ vi.mock('~/server/redis/caches', async (importOriginal) => ({
   userMultipliersCache: { fetch: h.fetch, refresh: h.refresh },
 }));
 
+// Spread the real package and override only the client factory — a hand-listed factory would
+// couple this file to every export buzz.service happens to import from it.
+vi.mock('@civitai/buzz', async (importOriginal) => ({
+  ...(await importOriginal<typeof BuzzClient>()),
+  createBuzzClient: () => ({
+    createTransaction: (...args: any[]) => h.createTransaction(...args),
+    getTransactionByExternalId: (...args: any[]) => h.getTransactionByExternalId(...args),
+    getAccount: (...args: any[]) => h.getAccount(...args),
+  }),
+}));
+
 vi.mock('~/server/services/rewards-bonus-event.service', () => ({
   getActiveRewardsBonusEvent: () => h.getActiveRewardsBonusEvent(),
 }));
 
-import { getMultipliersForUser } from '~/server/services/buzz.service';
+import { claimBuzz, getMultipliersForUser } from '~/server/services/buzz.service';
+import { dbMock } from '~/__tests__/mocks/db.mock';
 
 const USER = 77;
 
@@ -52,6 +68,9 @@ const cached = (rewardsMultiplier: number) =>
 beforeEach(() => {
   vi.clearAllMocks();
   h.getActiveRewardsBonusEvent.mockResolvedValue(null);
+  h.getTransactionByExternalId.mockResolvedValue(null);
+  h.createTransaction.mockResolvedValue({ transactionId: 'tx-1' });
+  h.getAccount.mockResolvedValue({ balance: 1_000_000, lifetimeBalance: 1_000_000 });
 });
 
 describe('getMultipliersForUser floors the value it pays with', () => {
@@ -90,6 +109,9 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     expect(result.globalRewardsBonus).toBe(5);
     // The same 20x the `keeps no ceiling` test defends, arrived at independently.
     expect(result.rewardsMultiplier).toBe(20);
+    // Positive control for the banner gate. Without it, NARROWING the gate hides the banner for
+    // every user and every event with the whole suite green — the mirror of the `>= 1` case below.
+    expect(result.rewardsBonusEvent?.multiplier).toBe(200);
   });
 
   // 🔴 THE DECISION THIS PINS. If you are here because you are adding a `clampRewardMultiplier` to
@@ -185,5 +207,53 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     cached(0.5);
 
     expect((await getMultipliersForUser(USER)).rewardsMultiplier).toBe(0.5);
+  });
+});
+
+describe('claimBuzz pays from a clamped multiplier', () => {
+  // The FOURTH reader, and the only one outside base.reward.ts that moves money. It reads
+  // `getMultipliersForUser` and multiplies a BuzzClaim amount by it, so it inherits the same
+  // non-finite product every other site clamps against.
+  const CLAIM_AMOUNT = 500;
+
+  const claimable = () => {
+    dbMock.dbWrite.buzzClaim.findUnique.mockResolvedValue({
+      key: 'test-claim',
+      title: 'Test claim',
+      description: 'Test claim',
+      amount: CLAIM_AMOUNT,
+      accountType: 'User',
+      useMultiplier: true,
+      availableStart: null,
+      availableEnd: null,
+      limit: null,
+      claimed: 0,
+      transactionIdQuery: 'SELECT 1',
+    } as any);
+    dbMock.dbWrite.$queryRawUnsafe.mockResolvedValue([{ transactionId: 'ext-1' }]);
+    dbMock.dbWrite.$executeRaw.mockResolvedValue(1 as any);
+  };
+
+  it('does not ask for a non-finite amount', async () => {
+    claimable();
+    cached(1e308);
+    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 50 } as any);
+
+    await claimBuzz({ id: 'test-claim', userId: USER });
+
+    const [payload] = h.createTransaction.mock.calls[0] as unknown as [{ amount: number }];
+    expect(payload.amount).toBe(CLAIM_AMOUNT);
+  });
+
+  it('still applies a legitimate multiplier', async () => {
+    // Negative control: without it the assertion above passes on an implementation that dropped the
+    // multiplier entirely.
+    claimable();
+    cached(4);
+
+    await claimBuzz({ id: 'test-claim', userId: USER });
+
+    const [payload] = h.createTransaction.mock.calls[0] as unknown as [{ amount: number }];
+    expect(payload.amount).toBe(CLAIM_AMOUNT * 4);
   });
 });

--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -11,18 +11,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * `foldUserMultipliers` floors on the way into the cache, so these cases only arise from an entry
  * cached before that shipped — `userMultipliersCache` has a 1-day TTL — or from any future path
  * that populates the cache without going through the fold. That is the whole reason to floor twice.
+ *
+ * Rewards only. `purchasesMultiplier` is deliberately NOT floored here: it feeds
+ * `getBuzzBulkMultiplier`, where a 0 credits a paid Buzz purchase with nothing.
  */
 
 import type * as Caches from '~/server/redis/caches';
 
 const h = vi.hoisted(() => ({
   fetch: vi.fn(),
+  // `deleteMultipliersForUserCache` calls `.refresh` on the `refresh = true` branch. Absent, that
+  // branch dies as "refresh is not a function" instead of a named assertion.
+  refresh: vi.fn(),
   getActiveRewardsBonusEvent: vi.fn(async () => null as null | { multiplier: number }),
 }));
 
 vi.mock('~/server/redis/caches', async (importOriginal) => ({
   ...(await importOriginal<typeof Caches>()),
-  userMultipliersCache: { fetch: h.fetch },
+  userMultipliersCache: { fetch: h.fetch, refresh: h.refresh },
 }));
 
 vi.mock('~/server/services/rewards-bonus-event.service', () => ({
@@ -70,9 +76,9 @@ describe('getMultipliersForUser floors the value it pays with', () => {
   });
 
   it('still multiplies a floored base by an active bonus event', async () => {
-    // A 0 must stay 0 through the bonus event, and a real value must still be multiplied — an
-    // implementation that floored to 1 would pass the first assertion of the previous test and
-    // fail here.
+    // This is the only cover for the line the fix rewrote: drop `* globalRewardsBonus` and it
+    // prints `expected 4 to be 8`. It does NOT separate a floor-at-0 from a floor-at-1 — clamp(4)
+    // is 4 under either — so do not read it as doing that.
     cached(4);
     h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 20 } as any);
 
@@ -81,19 +87,6 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     expect(result.baseRewardsMultiplier).toBe(4);
     expect(result.globalRewardsBonus).toBe(2);
     expect(result.rewardsMultiplier).toBe(8);
-  });
-
-  it('floors purchasesMultiplier too — the same row, the same operator field', async () => {
-    h.fetch.mockResolvedValue({
-      [USER]: {
-        userId: USER,
-        rewardsMultiplier: 1,
-        purchasesMultiplier: -3,
-        rewardsIneligible: false,
-      },
-    });
-
-    expect((await getMultipliersForUser(USER)).purchasesMultiplier).toBe(0);
   });
 
   it('leaves a sub-1 multiplier alone', async () => {

--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -80,13 +80,48 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     // prints `expected 4 to be 8`. It does NOT separate a floor-at-0 from a floor-at-1 — clamp(4)
     // is 4 under either — so do not read it as doing that.
     cached(4);
-    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 20 } as any);
+    // 200/10 = 20, ABOVE MAX_GLOBAL_BONUS. At the 20 this used to carry, the raw value was already
+    // 2 — inside [1, 5] — so the bonus clamp was inert and deleting it changed nothing here.
+    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 200 } as any);
 
     const result = await getMultipliersForUser(USER);
 
     expect(result.baseRewardsMultiplier).toBe(4);
-    expect(result.globalRewardsBonus).toBe(2);
-    expect(result.rewardsMultiplier).toBe(8);
+    expect(result.globalRewardsBonus).toBe(5);
+    // The same 20x the `keeps no ceiling` test defends, arrived at independently.
+    expect(result.rewardsMultiplier).toBe(20);
+  });
+
+  // 🔴 THE DECISION THIS PINS. If you are here because you are adding a `clampRewardMultiplier` to
+  // `purchasesMultiplier` for symmetry: don't. It feeds `getBuzzBulkMultiplier`, which is called
+  // UNCONDITIONALLY unlike every UI consumer, and there `mainBuzzAdded = floor(amount * m - amount)`
+  // — so a 0 makes `totalCustomBuzz` 0 and a completed Stripe/Paddle/NowPayments purchase credits
+  // NOTHING. `completeStripeBuzzPurchase` then writes the `transactionId` its own early return uses
+  // as an idempotency marker, so a retry can never repair it. A 0 means "earns nothing" on the
+  // rewards side and nothing at all on the purchases side. That path needs its own floor, decided
+  // on its own terms. Without this test the reverted regression comes back green.
+  it('does NOT floor purchasesMultiplier — that is a different money path', async () => {
+    h.fetch.mockResolvedValue({
+      [USER]: {
+        userId: USER,
+        rewardsMultiplier: 1,
+        purchasesMultiplier: -3,
+        rewardsIneligible: false,
+      },
+    });
+
+    expect((await getMultipliersForUser(USER)).purchasesMultiplier).toBe(-3);
+
+    h.fetch.mockResolvedValue({
+      [USER]: {
+        userId: USER,
+        rewardsMultiplier: 1,
+        purchasesMultiplier: NaN,
+        rewardsIneligible: false,
+      },
+    });
+
+    expect((await getMultipliersForUser(USER)).purchasesMultiplier).toBeNaN();
   });
 
   it('leaves a sub-1 multiplier alone', async () => {

--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `getMultipliersForUser` is where the reward pipeline reads the multiplier it pays with.
+ *
+ * The `globalRewardsBonus` half has been finite-checked and clamped to [1, 5] for a while, which is
+ * exactly what makes this easy to miss: anyone reading the function sees a guard and concludes the
+ * path is covered. The `rewardsMultiplier` it multiplies BY comes from operator-authored
+ * `Product.metadata` and had no floor at all (ClickUp 868m06pn5).
+ *
+ * `foldUserMultipliers` floors on the way into the cache, so these cases only arise from an entry
+ * cached before that shipped — `userMultipliersCache` has a 1-day TTL — or from any future path
+ * that populates the cache without going through the fold. That is the whole reason to floor twice.
+ */
+
+import type * as Caches from '~/server/redis/caches';
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  getActiveRewardsBonusEvent: vi.fn(async () => null as null | { multiplier: number }),
+}));
+
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof Caches>()),
+  userMultipliersCache: { fetch: h.fetch },
+}));
+
+vi.mock('~/server/services/rewards-bonus-event.service', () => ({
+  getActiveRewardsBonusEvent: () => h.getActiveRewardsBonusEvent(),
+}));
+
+import { getMultipliersForUser } from '~/server/services/buzz.service';
+
+const USER = 77;
+
+const cached = (rewardsMultiplier: number) =>
+  h.fetch.mockResolvedValue({
+    [USER]: {
+      userId: USER,
+      rewardsMultiplier,
+      purchasesMultiplier: 1,
+      rewardsIneligible: false,
+    },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getActiveRewardsBonusEvent.mockResolvedValue(null);
+});
+
+describe('getMultipliersForUser floors the value it pays with', () => {
+  it('floors a negative cached multiplier at 0', async () => {
+    cached(-2);
+
+    const result = await getMultipliersForUser(USER);
+
+    expect(result.rewardsMultiplier).toBe(0);
+    expect(result.baseRewardsMultiplier).toBe(0);
+  });
+
+  it('replaces a non-finite cached multiplier by sign', async () => {
+    cached(Infinity);
+    expect((await getMultipliersForUser(USER)).rewardsMultiplier).toBe(1);
+
+    cached(NaN);
+    expect((await getMultipliersForUser(USER)).rewardsMultiplier).toBe(1);
+
+    cached(-Infinity);
+    expect((await getMultipliersForUser(USER)).rewardsMultiplier).toBe(0);
+  });
+
+  it('still multiplies a floored base by an active bonus event', async () => {
+    // A 0 must stay 0 through the bonus event, and a real value must still be multiplied — an
+    // implementation that floored to 1 would pass the first assertion of the previous test and
+    // fail here.
+    cached(4);
+    h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 20 } as any);
+
+    const result = await getMultipliersForUser(USER);
+
+    expect(result.baseRewardsMultiplier).toBe(4);
+    expect(result.globalRewardsBonus).toBe(2);
+    expect(result.rewardsMultiplier).toBe(8);
+  });
+
+  it('floors purchasesMultiplier too — the same row, the same operator field', async () => {
+    h.fetch.mockResolvedValue({
+      [USER]: {
+        userId: USER,
+        rewardsMultiplier: 1,
+        purchasesMultiplier: -3,
+        rewardsIneligible: false,
+      },
+    });
+
+    expect((await getMultipliersForUser(USER)).purchasesMultiplier).toBe(0);
+  });
+
+  it('leaves a sub-1 multiplier alone', async () => {
+    cached(0.5);
+
+    expect((await getMultipliersForUser(USER)).rewardsMultiplier).toBe(0.5);
+  });
+});

--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -101,10 +101,15 @@ describe('getMultipliersForUser floors the value it pays with', () => {
   // rewards side and nothing at all on the purchases side. That path needs its own floor, decided
   // on its own terms. Without this test the reverted regression comes back green.
   //
-  // Closing condition, so this does not become a wall: when the purchases path gets its own floor —
-  // likely at 1, which delivers what was paid for — this test is UPDATED, not deleted. A floor at 0
-  // is the one that pays nothing. Note also that every value able to witness "not floored" is a
-  // value that must never reach the payment path, so the assertions below pin a hazard on purpose.
+  // Closing condition, so this does not become a wall: the decision is "0 is the WRONG repair", not
+  // "no repair". When the purchases path gets its own floor — likely at 1, which delivers what was
+  // paid for — this test is UPDATED to assert that, not deleted.
+  //
+  // Read the assertions knowing this: `clampRewardMultiplier` only alters negatives and non-finites,
+  // so every value able to witness "not floored" is a value that must never reach the payment path.
+  // `-3` credits a NEGATIVE grant and `NaN` an unpayable one — both already broken today, and both
+  // worse than the 0 this argues against. The test pins the absence of a repair, not the health of
+  // the path.
   it('does NOT floor purchasesMultiplier — that is a different money path', async () => {
     h.fetch.mockResolvedValue({
       [USER]: {
@@ -139,7 +144,12 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     expect((await getMultipliersForUser(USER)).globalRewardsBonus).toBe(1);
 
     h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: NaN } as any);
-    expect((await getMultipliersForUser(USER)).globalRewardsBonus).toBe(1);
+    const result = await getMultipliersForUser(USER);
+    expect(result.globalRewardsBonus).toBe(1);
+    // The banner gate rides on the same number and had no coverage anywhere in the repo. At a bonus
+    // of 1 there is nothing to advertise; `>= 1` here would announce a running event to every user
+    // for an event that multiplies by nothing.
+    expect(result.rewardsBonusEvent).toBeNull();
   });
 
   it('can return a NON-FINITE multiplier built from two finite floored factors', async () => {
@@ -149,9 +159,15 @@ describe('getMultipliersForUser floors the value it pays with', () => {
     // happens after. `String(Infinity)` reaching the Lua cap script is `tonumber` nil, which throws
     // out of `redis.eval` and into the user's mutation.
     //
-    // Two earlier attempts to write down why the spending sites clamp were both wrong (a
-    // `multiplierRaw` audit trail; a pending row read back by `process` — which cannot happen,
-    // `isProcessable = !isOnDemand`). This is the one that holds, so it is asserted, not narrated.
+    // Two earlier attempts to say why the clamps sit WHERE they do were wrong (a pending row read
+    // back by `process` — impossible, `isProcessable = !isOnDemand`; and an audit trail for an
+    // operator typo, which this PR's own read-side floor removed). `multiplierRaw` is still the
+    // reason they are not at `apply`'s read, for THIS value — see base.reward.forid.test.ts. What
+    // was missing was the reason to clamp at all, which is the overflow below.
+    //
+    // Closing condition: if `getMultipliersForUser` ever clamps its own product, this test is
+    // UPDATED to assert that clamp, not deleted. Deleting it is how the spending-site clamps become
+    // unexplained again.
     cached(1e308);
     h.getActiveRewardsBonusEvent.mockResolvedValue({ multiplier: 50 } as any);
 
@@ -159,7 +175,10 @@ describe('getMultipliersForUser floors the value it pays with', () => {
 
     expect(result.baseRewardsMultiplier).toBe(1e308);
     expect(result.globalRewardsBonus).toBe(5);
-    expect(Number.isFinite(result.rewardsMultiplier)).toBe(false);
+    // `toBe(Infinity)`, not `Number.isFinite(...)).toBe(false)`: the latter also passes if the key
+    // stops being returned at all, and does not separate Infinity from NaN — and it is `Infinity`
+    // specifically that reaches the Lua as a string `tonumber` cannot parse.
+    expect(result.rewardsMultiplier).toBe(Infinity);
   });
 
   it('leaves a sub-1 multiplier alone', async () => {

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -245,7 +245,6 @@ export async function getMultipliersForUser(userId: number, refresh = false) {
 
   return {
     ...base,
-    purchasesMultiplier: clampRewardMultiplier(base.purchasesMultiplier),
     rewardsMultiplier: baseRewardsMultiplier * globalRewardsBonus,
     baseRewardsMultiplier,
     globalRewardsBonus,

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -55,6 +55,7 @@ import {
   coercePurchasedBuzzType,
   TransactionType,
 } from '~/shared/constants/buzz.constants';
+import { clampRewardMultiplier } from '~/server/rewards/multiplier';
 import type { PaymentIntentMetadataSchema } from '~/server/schema/stripe.schema';
 import { createNotification } from '~/server/services/notification.service';
 import { logToAxiom } from '~/server/logging/client';
@@ -235,10 +236,18 @@ export async function getMultipliersForUser(userId: number, refresh = false) {
     ? Math.min(Math.max(rawMultiplier, 1), MAX_GLOBAL_BONUS)
     : 1;
 
+  // `globalRewardsBonus` is guarded above; `base.rewardsMultiplier` is read straight off
+  // operator-authored `Product.metadata`, and this is the value the award computation and the Redis
+  // Lua cap script are handed. `foldUserMultipliers` floors it on the way in, but that runs on a
+  // cache MISS: `userMultipliersCache` has a 1-day TTL, so entries folded before this shipped are
+  // served unfloored until they expire.
+  const baseRewardsMultiplier = clampRewardMultiplier(base.rewardsMultiplier);
+
   return {
     ...base,
-    rewardsMultiplier: base.rewardsMultiplier * globalRewardsBonus,
-    baseRewardsMultiplier: base.rewardsMultiplier,
+    purchasesMultiplier: clampRewardMultiplier(base.purchasesMultiplier),
+    rewardsMultiplier: baseRewardsMultiplier * globalRewardsBonus,
+    baseRewardsMultiplier,
     globalRewardsBonus,
     rewardsBonusEvent:
       event && globalRewardsBonus > 1

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -1351,7 +1351,7 @@ export async function claimBuzz({ id, userId }: BuzzClaimRequest) {
   // Create the transaction
   await createBuzzTransaction({
     amount: claimStatus.details.useMultiplier
-      ? Math.ceil(claimStatus.details.amount * rewardsMultiplier)
+      ? Math.ceil(claimStatus.details.amount * clampRewardMultiplier(rewardsMultiplier))
       : claimStatus.details.amount,
     externalTransactionId: claimStatus.claimId,
     fromAccountId: 0,


### PR DESCRIPTION
Closes ClickUp [868m06pn5](https://app.clickup.com/t/868m06pn5). Sibling of 868kzne32 / PR #4572.

#4572 made `toClickhouseBuzzEvent` call `clampBuzzEventMultiplier`, which floored the **audit row**. The **award computation** stayed unfloored. This is that half.

## What was actually unfloored

`rewardsMultiplier` is `(p.metadata->>'rewardsMultiplier')::float` off operator-authored `Product.metadata` — a column that accepts a negative, `Infinity` and `NaN` — and reaches money through four places with no guard between:

| site | what it does with the value |
|---|---|
| `base.reward.ts` `processOnDemand` | `Math.ceil(awardAmount * multiplier)` and the effective cap, **stringified into a Redis Lua script** |
| `base.reward.ts` `sendAward` | `amount: Math.ceil(event.awardAmount * (event.multiplier ?? 1))` — the transaction that pays |
| `buzz.service.ts` `getMultipliersForUser` | multiplies a guarded `globalRewardsBonus` by an unguarded base |
| `user-multipliers.ts` `foldUserMultipliers` | `Math.max` is a max **across rows**, not a floor: one row of `-1` yields `-1` |
| `base.reward.ts` `getUserRewardDetails` | advertises `awardAmount` and `cap` in the rewards list |
| `buzz.service.ts` `claimBuzz` | `Math.ceil(claim.amount * multiplier)` straight into `createBuzzTransaction` |

`globalRewardsBonus` being finite-checked and clamped to `[1, 5]` right above the unguarded value is what makes this easy to read past.

### Two consequences, one of them not in the ticket

**`Infinity` / `NaN` throw into the user's mutation.** `String(effectiveAward)` is `'Infinity'`, Lua's `tonumber` returns nil, and the arithmetic on nil errors out of `redis.eval`. The code already documented this at the cap line; nothing enforced it.

**A negative multiplier corrupts the day's cap accounting**, which the ticket does not mention. `toAward` comes back negative, so the event is recorded `capped` and nothing is paid — but the Lua has already written the dedup entry as `a:-200`, and the reader's pattern is `'^a:(%d+)$'`. `%d+` does not match a minus, so every later read of that entry falls back to `tonumber(ARGV[3])` — the **current** award — for the rest of the UTC day.

## The fix

One helper, `clampRewardMultiplier` in `src/server/rewards/multiplier.ts`: **coerce with `Number()`, then** floor at 0, non-finite falls back by sign. Applied at six call sites, all on the rewards path — the five rows of the table above (`processOnDemand` uses it for both the award and the cap).

The coercion is load-bearing and not defensive tidiness — see "What review caught" below.

**It deliberately has no ceiling, and it is deliberately not `clampBuzzEventMultiplier`.** The shared helper carries the `buzzEvents.multiplier` column's 9.99 — correct for a ClickHouse row, wrong here, because `sendAward` **pays** `awardAmount * multiplier` and gold's 4 times a `MAX_GLOBAL_BONUS` of 5 is a legitimate 20. Replacing this with the shared one would halve a bonus event's payout. That decision is pinned by a test named for it (`keeps no ceiling, unlike clampBuzzEventMultiplier`) with a note to whoever tries the cleanup.

🔴 **What this does NOT close: a large-but-finite multiplier is still paid in full.** `1e20` passes a floor and a finite check unchanged. Only a ceiling bounds that, and a ceiling on a payout path is a product decision, not a guard.

Worth being concrete about, because it is not the unlikely case: **a misplaced decimal point (`1.00` → `100`) is the likeliest operator error in a hand-typed `Product.metadata` field, and it remains payable at 100x.** The daily cap is not a backstop against it either: `effectiveCap` scales by the same multiplier, so a 100x typo raises the ceiling 100x too and the day's total is 100x, not cap-bounded. The inputs this PR does close — negative, `NaN`, `Infinity` — are the rarer ones. That is the honest shape of the remaining exposure, and closing it is somebody's product call, not this PR's.

### Floored where the value is SPENT, not where it is read

The first version of this clamped once at the `apply` destructure. The full suite caught what that cost: seven tests in `base.reward.forid.test.ts` went red because `toClickhouseBuzzEvent` had nothing left to record — the operator typo was normalised before the audit row saw it, silently undoing #4572's `multiplierRaw` trail. The event now keeps the raw value and the two paying computations floor it themselves.

## Live or dormant

**Dormant.** Prod replica, all 17 products carrying the key:

```
total_with_key 17 | plain_numeric 17 | non_numeric_text 0 | negative 0
```

The zero means something because the arms sum to the populated total. Active products carry 1, 1.5, 2.5 and 4.

⚠️ **That probe covers `rewardsMultiplier` only.** It says nothing about the `purchasesMultiplier` column, so do not carry the "dormant" over to the purchases hazard described below.

## Two decisions, stated rather than defaulted into

**Non-finite falls back to 1, so a NaN on the batch path now PAYS the base award** where the old `Math.ceil(award * NaN)` produced NaN and `sendAward`'s own `amount > 0` filter dropped it. Kept deliberately: one rule across every site beats two, and with the coercion a NaN can no longer be a misread quoted decimal, so the input is genuinely garbage rather than a legitimate value in disguise. Treating it as `unqualified` and paying nothing is the defensible alternative.

**`purchasesMultiplier` is NOT floored.** An earlier revision of this PR floored it. That was wrong and is reverted — see below.

## What review caught (both were bugs I introduced)

Six rounds of review ran over this. Between them they caught two money bugs I introduced, a fourth reader of the multiplier that pays real money and had no clamp at all, one clamp I added with *no test* (it passed 204/204 with the clamp deleted), two decisions recorded in comments and pinned by nothing — including the exact regression round 1 had already caught — and three successive attempts to write down *why* the clamps sit where they do, two of which were false. Two comments claimed a complete census of readers and were wrong by one. The mutant table below is the third set; the first two were voided by refactors and re-derived from scratch.

**1. The clamp reintroduced the underpay `f450100aba` already fixed once.** `sendAward` runs on the batch path too, where `event.multiplier` is read back out of a ClickHouse `Decimal(3,2)`: number-typed, string-valued. `Number.isFinite('4.00')` is `false`, so the clamp took the non-finite fallback and returned 1.

```
before this PR:        Math.ceil(100 * '4.00') = 400
first revision:        Math.ceil(100 * clamp('4.00')) = 100
```

A 4x gold multiplier paying 1x. Two other readers in the same file coerce deliberately and say why; this was the third reader and the only one at a site that pays. Fixed by coercing inside the helper, so the fix cannot be undone one call site at a time.

**2. Flooring `purchasesMultiplier` at 0 made a paid purchase credit zero Buzz, unrepairably.** It feeds `getBuzzBulkMultiplier`, which is called **unconditionally** — unlike every UI consumer, which guards `> 1`:

```ts
// src/server/utils/buzz-helpers.ts:21
const mainBuzzAdded = Math.floor(buzzAmount * purchasesMultiplier - buzzAmount);
```

At 0 that is `-buzzAmount`, so `totalCustomBuzz` is 0, and `completeStripeBuzzPurchase` then writes `metadata.transactionId` — the marker its own early return uses for idempotency. Customer charged, credited nothing, retry can never repair it. The 0 floor is justified by a rewards-only fact (`rewardsIneligible` zeroes `rewardsMultiplier`, never `purchasesMultiplier`); on the purchases side 0 has no meaning. **Both floors reverted.** That path needs its own floor, decided on its own terms. It is being filed as its own ticket by the coordinator rather than left as a sentence here — this PR deliberately closes nothing on the purchases side.

## Tests — each demonstrated failing on revert

Eight mutants, re-derived from scratch after the fix round, each naming the test it reddened:

| mutant | reddens |
|---|---|
| `Number()` coercion removed | 1 — `expected 100 to be 400` |
| `processOnDemand` clamp removed | 4 — `expected 'Infinity' to be '100'`, `'NaN' to be '100'`, `'-200' to be '0'` |
| `sendAward` clamp removed | 1 — `expected [] to have a length of 1` (a NaN amount fails `sendAward`'s own `> 0` filter, so the user is recorded `awarded` and paid nothing) |
| **ceiling added** (the "obvious cleanup") | 2 — `expected 9.99 to be 20`, `expected 9.99 to be 1e+20` |
| `foldUserMultipliers` **first-row** floor only | 2 — `expected -1 to be +0`, `expected Infinity to be 1` |
| `foldUserMultipliers` **merge-arm** floor only | 1 — `expected NaN to be 1.5` |
| `getMultipliersForUser` floor removed | 2 — `expected -2 to be +0`, `expected Infinity to be 1` |
| `* globalRewardsBonus` dropped | 1 — `expected 4 to be 8` |

The two fold rows are separate on purpose. The floor is applied at two places in that file, and every test in the first revision gave its user a single row — so reverting only the two `Math.max` merge arms left the whole suite green, while `Math.max(1.5, NaN)` is NaN and a multi-row user is the entire reason that fold exists. The merge-arm mutant above is caught by one test and nothing else.

Two tests were written and then **deleted** rather than kept, both for passing identically with and without the code under them: `does not let a negative row drag down a good one` (`Math.max(-1, 1.5)` is `1.5` either way) and the `purchasesMultiplier` assertion, which went with its floor. One comment was **corrected** — it claimed the bonus-event test caught a floor-to-1 implementation, which it does not; the `* globalRewardsBonus` mutant above is the reason that test actually earns its place.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196Bp9Xe4LdQ5YSt2MAusWT
