### PR TITLE
feat(apps): store card CTA fills the row, and Edit moves into a shared overflow menu

### DIFF
--- a/src/components/Apps/AppListingActionsMenu.tsx
+++ b/src/components/Apps/AppListingActionsMenu.tsx
@@ -1,0 +1,461 @@
+import { ActionIcon, Box, Menu, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+  IconDotsVertical,
+  IconEyeOff,
+  IconFlag,
+  IconMail,
+  IconPencil,
+  IconRefresh,
+  IconShieldCheck,
+  IconThumbUp,
+} from '@tabler/icons-react';
+import Link from 'next/link';
+import { type MouseEvent, useState } from 'react';
+import {
+  DETAIL_TAKEDOWN_ACTIONS,
+  REVIEW_QUEUE_MANAGE_HREF,
+  TAKEDOWN_TESTID_STEM,
+  appListingDetailModActions,
+  detailModActionLabel,
+  type DetailTakedownAction,
+} from '~/components/Apps/appListingDetailModActions';
+import { canOwnerEditListing, getOwnerEditHref } from '~/components/Apps/appListingCardView';
+import { ListingTakedownModal } from '~/components/Apps/ListingTakedownModal';
+import { MessageAppOwnerModal } from '~/components/Apps/MessageAppOwnerModal';
+import {
+  ReportListingModal,
+  useCanReportListing,
+  useReportListingAffordance,
+} from '~/components/Apps/ReportListingModal';
+import { ReviewListingModal, useCanReviewListing } from '~/components/Apps/ReviewListingButton';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { isAppReviewer } from '~/shared/utils/app-blocks-access';
+
+/**
+ * App Store Listings — the SHARED `⋮` secondary-action menu, over BOTH listing
+ * surfaces (the store CARD and the listing DETAIL body).
+ *
+ * 🔴 THIS MODULE EXISTS BECAUSE THESE TWO SURFACES HAVE ALREADY DRIFTED ONCE.
+ * The CTA glyph mapping was written twice — once on the card and once on the
+ * detail — and had to be pulled out into `appListingActionGlyph.ts` after they
+ * disagreed; the card's own CTA comment says so in as many words. The menu is a
+ * strictly bigger surface to duplicate: an item SET, an ORDER, six labels, four
+ * eligibility predicates and four modals whose mount site is load-bearing. So it
+ * is written once, here, and both surfaces render THIS component. A second copy
+ * is the defect this file is the fix for.
+ *
+ * WHAT IS PARAMETERISED, and nothing else: the trigger's size / variant / glyph
+ * size / `data-testid`, and whether the trigger stops click propagation. The item
+ * set, its order, its labels, its gating and its modals are IDENTICAL on both
+ * surfaces by construction — that is the point.
+ *
+ * 🔴 THE MODALS ARE OWNED HERE, AS SIBLINGS OF THE `Menu`, NOT OF A `Menu.Item`.
+ * A Mantine `Menu.Dropdown` is UNMOUNTED when the menu closes, so a modal
+ * rendered inside the dropdown is destroyed by the very click that opens it.
+ * This is the hard-won rule the detail body carried; moving the menu without
+ * moving that rule would have reintroduced the bug on both surfaces at once.
+ *
+ * 🔴 THE MODALS MOUNT LAZILY — only once the menu has been opened at least once
+ * ({@link everOpened}). This is not a micro-optimisation: the store grid renders
+ * ~24 of these at a time, and the four modals between them pull the tRPC client
+ * (`reportListing` / `upsertReview` / `messageAppOwner` / the takedown pair) and
+ * a `matchMedia` subscription each. Mounting them per card would put ~96 modal
+ * subtrees and ~24 media-query listeners on a page whose viewer will open at most
+ * one of them. Nothing is lost: every one of these modals is reachable ONLY from
+ * an item inside this menu, so "the menu has never been opened" implies "no modal
+ * can be open". The gates are unchanged — each modal is still `&&`-ed to the same
+ * predicate as its trigger.
+ */
+
+/** The listing fields this menu needs — satisfied by BOTH `ListingCard` and `ListingDetail`. */
+export type AppListingMenuTarget = {
+  id: string;
+  slug: string;
+  /** `'onsite' | 'offsite'` — threaded into the review scope + mod state machine. */
+  kind: string;
+  /** Only `kind` + `appBlockId` are read (see `getOwnerEditHref`). */
+  kindData: { kind: 'onsite'; appBlockId: string | null } | { kind: 'offsite' };
+  /** The listing owner's user id, or null when the DTO carries no creator. */
+  creatorUserId: number | null;
+};
+
+export type AppListingActionsMenuProps = {
+  listing: AppListingMenuTarget;
+  /**
+   * Moderator listing-media review renders a listing READ-ONLY over an
+   * UNAPPROVED shadow row. The whole menu is suppressed there — see
+   * `appListingDetailModActions.detailListingStatus` for why no action on this
+   * surface can be honestly offered against a listing whose status and whose
+   * `id` are both unguaranteed.
+   */
+  preview?: boolean;
+  /** Trigger geometry. Defaults are the DETAIL page's (Mantine default size, 20px glyph). */
+  triggerSize?: number | string;
+  triggerVariant?: string;
+  triggerIconSize?: number;
+  triggerTestId?: string;
+  /** Accessible name for the icon-only trigger. */
+  triggerLabel?: string;
+  /**
+   * Wrap the trigger in a `Tooltip` carrying the same string as its `aria-label`.
+   *
+   * 🔴 THE `aria-label` IS THE ACCESSIBLE NAME EITHER WAY — the glyph alone is not
+   * one (the `CategoryFilterButtons` precedent). The tooltip is the SIGHTED
+   * equivalent, and it is opt-in because the two surfaces differ: on the DETAIL
+   * page the trigger sits alone in a spacious header, while on the CARD it sits in
+   * a dense action row where an unlabelled glyph beside a labelled CTA reads as
+   * decoration.
+   */
+  triggerTooltip?: boolean;
+  /**
+   * Stop click propagation on the trigger AND the dropdown.
+   *
+   * 🔴 THE DROPDOWN HALF IS NOT REDUNDANT WITH `withinPortal`. A React portal
+   * moves the DOM node, but events still propagate along the REACT tree — so a
+   * click inside a portalled dropdown reaches an ancestor's `onClick` exactly as
+   * if it were a DOM descendant. On a clickable card that is a navigation the
+   * viewer did not ask for, fired by opening a menu.
+   */
+  stopPropagation?: boolean;
+};
+
+/** Everything the menu's visibility and item set depend on, resolved once. */
+type AppListingMenuGates = {
+  showEdit: boolean;
+  editHref: string | null;
+  canReview: boolean;
+  canReport: boolean;
+  modActions: ReturnType<typeof appListingDetailModActions>;
+  /** Would the menu hold at least one item? */
+  showMenu: boolean;
+};
+
+/**
+ * The menu's gates — ONE definition, used by the component AND by
+ * {@link useAppListingActionsMenuVisible}.
+ *
+ * 🔴 WRITTEN ONCE ON PURPOSE. `showMenu` is a four-term disjunction over four
+ * separately-defined predicates, and the card needs the ANSWER before it can lay
+ * out its action row while the component needs the TERMS to render the items. A
+ * second copy of the expression at either site is a predicate duplicated across
+ * call sites, which is the shape that gets fixed at one site and stays wrong at
+ * the other.
+ *
+ * 🔴 DELIBERATELY STATE-FREE, so it is safe to call TWICE in one render (the card
+ * does). Every input is a pure read of the current user, the feature flags and the
+ * mod state machine; nothing here owns a `useDisclosure` or a `useState`, so a
+ * second call cannot fork a second copy of anything.
+ */
+function useAppListingMenuGates(
+  listing: AppListingMenuTarget,
+  preview: boolean
+): AppListingMenuGates {
+  const currentUser = useCurrentUser();
+
+  // Owner "Edit" deep-link — owner + editable status (both surfaces read an
+  // approved-only path that carries no status field → editable); the href builder
+  // returns null when there is no editable target (an on-site listing with no
+  // backing appBlockId).
+  const isOwner = !!currentUser?.id && currentUser.id === listing.creatorUserId;
+  const editHref = getOwnerEditHref(listing.kindData, listing.id);
+  const showEdit = canOwnerEditListing({ isOwner }) && !!editHref;
+
+  // 🔴 The gates are the SAME predicates each affordance defines, imported rather
+  // than re-derived, so the menu cannot disagree with them about who may act.
+  // `listing.kind` is threaded in so the review affordance obeys the store-scope
+  // kind rule the write gate applies — an external-only viewer is not offered a
+  // review control on an onsite listing the server would NOT_FOUND.
+  const canReview = useCanReviewListing({
+    ownerUserId: listing.creatorUserId,
+    listingKind: listing.kind as never,
+  });
+  const canReport = useCanReportListing();
+
+  // MODERATOR section. The action SET is derived, never hand-rolled:
+  // `appListingDetailModActions` intersects the shared lifecycle state machine
+  // (`listingModActions`, which the /apps/review mgmt table also depends on) with
+  // the subset these surfaces implement, and answers empty for a non-moderator and
+  // in preview. The gate is `isAppReviewer` — the existing named predicate — and it
+  // is COSMETIC: every proc behind these items is `moderatorProcedure` plus an
+  // inner `isModerator` recheck, which is the actual boundary.
+  const modActions = appListingDetailModActions({
+    isModerator: isAppReviewer(currentUser),
+    preview,
+    kind: listing.kind,
+  });
+
+  return {
+    showEdit,
+    editHref,
+    canReview,
+    canReport,
+    modActions,
+    // `modActions` is already empty in preview, so the leading `!preview` is not
+    // what suppresses the mod section — it is the clause that suppresses the WHOLE
+    // menu, on every surface.
+    showMenu: !preview && (showEdit || canReview || canReport || modActions.length > 0),
+  };
+}
+
+/**
+ * Would {@link AppListingActionsMenu} render anything for this viewer?
+ *
+ * 🔴 EXISTS SO A CALLER CAN LAY OUT AROUND THE TRIGGER WITHOUT GUESSING. The store
+ * card's action row hides its recommend rollup below a container width derived from
+ * how wide the action cluster is, and the trigger's 36px is exactly what makes it
+ * wide — so the card has to know whether the trigger is there.
+ */
+export function useAppListingActionsMenuVisible(
+  listing: AppListingMenuTarget,
+  preview = false
+): boolean {
+  return useAppListingMenuGates(listing, preview).showMenu;
+}
+
+/**
+ * The `⋮` overflow menu: owner Edit, review, report, and the moderator section.
+ *
+ * Returns `null` when it would hold NO items — the same predicate the detail body
+ * has always applied. Two consequences worth stating because they are decisions:
+ *
+ *   - a viewer with nothing to do sees no control at all, rather than an empty
+ *     menu that punishes the click; and
+ *   - the trigger's ~36px therefore enters a surface's layout only for viewers
+ *     who have an action. On the store card that means a MODERATOR viewing
+ *     someone else's card gets a different action-row geometry from an anonymous
+ *     shopper. That is accepted (see `AppListingCard`'s action-row note).
+ */
+export function AppListingActionsMenu({
+  listing,
+  preview = false,
+  triggerSize,
+  triggerVariant = 'light',
+  triggerIconSize = 20,
+  triggerTestId = 'apps-listing-actions-menu',
+  triggerLabel = 'App options',
+  triggerTooltip = false,
+  stopPropagation = false,
+}: AppListingActionsMenuProps) {
+  const { showEdit, editHref, canReview, canReport, modActions, showMenu } = useAppListingMenuGates(
+    listing,
+    preview
+  );
+
+  // 🔴 The report affordance's STATE comes from `useReportListingAffordance`, not a
+  // bare `useDisclosure`: the server allows one open report per reporter, so once a
+  // report lands the trigger has to go spent ("Reported", disabled) or the next
+  // click returns a CONFLICT the user reads as a failure. Spread BOTH prop bags —
+  // `triggerProps` on the item, `modalProps` on the modal — never hand-roll either.
+  const report = useReportListingAffordance();
+  const [reviewOpened, reviewModal] = useDisclosure(false);
+
+  const modListing = { appListingId: listing.id, slug: listing.slug, kind: listing.kind };
+  const [messageOpened, messageModal] = useDisclosure(false);
+  // 🔴 The TAKEDOWN pair shares ONE piece of state holding WHICH action is open,
+  // rather than a boolean each. Two booleans can both be true; this cannot, so "the
+  // hide confirm and the unpublish confirm are open at once" is unrepresentable
+  // instead of merely unlikely — and the two confirms differ only in which mutation
+  // they fire, so a viewer seeing both would have no way to tell which one they
+  // were about to submit.
+  const [takedown, setTakedown] = useState<DetailTakedownAction | null>(null);
+  // See the header: the modals mount only after the menu has been opened once.
+  const [everOpened, setEverOpened] = useState(false);
+
+  if (!showMenu) return null;
+
+  const stop = stopPropagation ? (e: MouseEvent) => e.stopPropagation() : undefined;
+
+  const trigger = (
+    <ActionIcon
+      color="gray"
+      variant={triggerVariant}
+      size={triggerSize}
+      aria-label={triggerLabel}
+      data-testid={triggerTestId}
+      onClick={stop}
+    >
+      <IconDotsVertical size={triggerIconSize} />
+    </ActionIcon>
+  );
+
+  return (
+    <>
+      <Box style={{ flexShrink: 0 }}>
+        <Menu
+          position="bottom-end"
+          transitionProps={{ transition: 'pop-top-right' }}
+          withinPortal
+          onOpen={() => setEverOpened(true)}
+        >
+          {/* 🔴 THE `Tooltip` WRAPS `Menu.Target`, NOT THE OTHER WAY ROUND, AND THE
+              ORDER IS LOAD-BEARING — the intuitive nesting SILENTLY BREAKS THE
+              MENU. `Menu.Target` clones its child to attach the toggle handler and
+              its ref; `Tooltip` also clones ITS child and overrides the ref, so
+              `Menu.Target > Tooltip > ActionIcon` hands the menu a ref to nothing
+              and the trigger stops opening it. Measured, not reasoned: a 2x2 probe
+              (tooltip x stopPropagation) in this exact environment passed both
+              no-tooltip arms and failed both tooltip-inside arms, with the dropdown
+              never mounting. This nesting passes all four.
+
+              ⚠️ SEVERAL OTHER FILES IN THIS REPO USE THE BROKEN ORDER
+              (`ComicExportButton`, `GeneratedImageActions`, `DrawingToolbar`, the
+              comics page's moderator menus). Out of scope here and NOT fixed — but
+              `GeneratedOutputRemixMenu` already carries a comment about the same
+              ref hop, so it has been hit before. Do not "tidy" this back. */}
+          {triggerTooltip ? (
+            <Tooltip label={triggerLabel} withArrow>
+              <Menu.Target>{trigger}</Menu.Target>
+            </Tooltip>
+          ) : (
+            <Menu.Target>{trigger}</Menu.Target>
+          )}
+          <Menu.Dropdown onClick={stop}>
+            {/* Owner-only "Edit" deep-link, gated by owner + editable status
+                (mod-removed listings hide it). Routes by kind (manifest editor for
+                on-site, submit editor for off-site). */}
+            {showEdit && editHref && (
+              <Menu.Item
+                component={Link}
+                href={editHref}
+                leftSection={<IconPencil size={14} stroke={1.5} />}
+                data-testid="apps-listing-owner-edit"
+              >
+                Edit
+              </Menu.Item>
+            )}
+            {/* Review affordance (thumbs/recommend) — hidden for the owner, signed-out
+                viewers, AND viewers whose resolved store scope does not admit this
+                listing's kind, all by `useCanReviewListing`. The write proc is
+                protected + STORE-SCOPE-gated + self-review-blocked server-side. */}
+            {canReview && (
+              <Menu.Item
+                leftSection={<IconThumbUp size={14} stroke={1.5} />}
+                onClick={reviewModal.open}
+                data-testid="apps-listing-review-action"
+              >
+                Leave a review
+              </Menu.Item>
+            )}
+            {/* Report affordance — the proc is protected + rate-limited +
+                reporter-bound server-side. 🔴 `triggerProps` carries BOTH the click
+                and the spent `disabled` state; the modal below carries its
+                `onReported` counterpart. The pair is what stops a second report
+                returning the server's one-open-report-per-reporter CONFLICT as an
+                error toast. */}
+            {canReport && (
+              <Menu.Item
+                color="red"
+                leftSection={<IconFlag size={14} stroke={1.5} />}
+                {...report.triggerProps}
+                data-testid="apps-listing-report-action"
+              >
+                {report.label}
+              </Menu.Item>
+            )}
+            {/* MODERATOR section — divided and labelled so a mod action is never one
+                slot away from a reader's "Leave a review". The set comes from
+                `appListingDetailModActions`; the ORDER is that function's (Contact
+                before the lifecycle action), and the review-queue link is last
+                because it navigates away rather than acting. */}
+            {modActions.length > 0 && (
+              <>
+                <Menu.Divider />
+                <Menu.Label>Moderator</Menu.Label>
+                {modActions.includes('message-owner') && (
+                  <Menu.Item
+                    leftSection={<IconMail size={14} stroke={1.5} />}
+                    onClick={messageModal.open}
+                    data-testid="apps-listing-mod-message-owner"
+                  >
+                    {detailModActionLabel('message-owner')}
+                  </Menu.Item>
+                )}
+                {/* The TAKEDOWN pair, rendered by mapping the canonical order rather
+                    than as two hand-written branches: the two items differ only in
+                    which action they carry, so writing them out twice is how one of
+                    them ends up wired to the other's label or testid. Each still
+                    renders only if `modActions` admits it. */}
+                {DETAIL_TAKEDOWN_ACTIONS.filter((a) => modActions.includes(a)).map((action) => (
+                  <Menu.Item
+                    key={action}
+                    color="red"
+                    leftSection={
+                      action === 'hide' ? (
+                        <IconEyeOff size={14} stroke={1.5} />
+                      ) : (
+                        <IconRefresh size={14} stroke={1.5} />
+                      )
+                    }
+                    onClick={() => setTakedown(action)}
+                    data-testid={`${TAKEDOWN_TESTID_STEM[action]}-menu-item`}
+                  >
+                    {detailModActionLabel(action)}
+                  </Menu.Item>
+                ))}
+                {/* 🔴 THE INVERSE AFFORDANCE, AND IT IS A LINK RATHER THAN A BUTTON ON
+                    PURPOSE. There is no relist/republish control here because there
+                    cannot be one: `relistListing` acts on a `removed` listing, both
+                    surfaces read approved-only, and a removed listing 404s before
+                    either mounts. So the honest way back is the surface that CAN see
+                    a removed listing — the /apps/review mgmt table, which already
+                    carries Relist (and Claim/Purge) for exactly that state.
+
+                    🔴 THE `?tab=manage` IS LOAD-BEARING — a bare `/apps/review`
+                    resolves to the PENDING tab, and Relist is on the manage tab. The
+                    href is a named constant so the destination this menu promises is
+                    pinned in the blocking tier rather than typed inline. */}
+                <Menu.Item
+                  component={Link}
+                  href={REVIEW_QUEUE_MANAGE_HREF}
+                  leftSection={<IconShieldCheck size={14} stroke={1.5} />}
+                  data-testid="apps-listing-mod-manage"
+                >
+                  Manage in review queue
+                </Menu.Item>
+              </>
+            )}
+          </Menu.Dropdown>
+        </Menu>
+      </Box>
+
+      {/* The action modals, mounted OUTSIDE the dropdown — see the header. Each is
+          gated by the same predicate as its menu item, so an ineligible viewer
+          mounts neither the trigger nor the form. `preview` needs no clause of its
+          own here: this whole subtree is unreachable when `showMenu` is false, and
+          `showMenu` carries `!preview`. */}
+      {everOpened && (
+        <>
+          {canReview && (
+            <ReviewListingModal
+              appListingId={listing.id}
+              opened={reviewOpened}
+              onClose={reviewModal.close}
+            />
+          )}
+          {canReport && <ReportListingModal appListingId={listing.id} {...report.modalProps} />}
+          {/* `MessageAppOwnerModal` is REUSED, not forked: it names no recipient by
+              design (the owner is resolved server-side, and for an on-site listing
+              that resolution can disagree with the listing's own `userId` column). */}
+          {modActions.includes('message-owner') && (
+            <MessageAppOwnerModal
+              listing={messageOpened ? modListing : null}
+              onClose={messageModal.close}
+            />
+          )}
+          {/* ONE takedown confirm, for whichever of the pair is open. Mounted only
+              when `modActions` still admits that action, so the state alone cannot
+              open a confirm for something this viewer or this listing state does not
+              offer. */}
+          {takedown && modActions.includes(takedown) && (
+            <ListingTakedownModal
+              action={takedown}
+              listing={modListing}
+              onClose={() => setTakedown(null)}
+            />
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/Apps/AppListingActionsMenu.tsx
+++ b/src/components/Apps/AppListingActionsMenu.tsx
@@ -29,6 +29,10 @@ import {
   useReportListingAffordance,
 } from '~/components/Apps/ReportListingModal';
 import { ReviewListingModal, useCanReviewListing } from '~/components/Apps/ReviewListingButton';
+import {
+  type AppListingMenuSurface,
+  surfaceOffersViewerActions,
+} from '~/components/Apps/appListingMenuSurface';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 
@@ -46,9 +50,20 @@ import { isAppReviewer } from '~/shared/utils/app-blocks-access';
  * is the defect this file is the fix for.
  *
  * WHAT IS PARAMETERISED, and nothing else: the trigger's size / variant / glyph
- * size / `data-testid`, and whether the trigger stops click propagation. The item
- * set, its order, its labels, its gating and its modals are IDENTICAL on both
- * surfaces by construction — that is the point.
+ * size / `data-testid`, whether the trigger stops click propagation, and — via
+ * {@link AppListingMenuSurface} — the ONE item-set difference between the two
+ * surfaces. The ORDER, the labels, the eligibility predicates and the modals are
+ * identical on both by construction; that is still the point.
+ *
+ * 🔴 THE ONE DIFFERENCE IS NAMED, CLOSED AND POLICED FROM A SINGLE MODULE, WHICH IS
+ * WHAT KEEPS IT FROM BECOMING THE DRIFT THIS FILE EXISTS TO PREVENT. It is not a
+ * per-call-site boolean: the caller says WHERE it is (`surface="card"` /
+ * `surface="detail"`) and `appListingMenuSurface.ts` decides what that means, so
+ * the answer cannot be spelled two ways. Today it decides exactly one thing —
+ * whether "Leave a review" and "Report" are offered — and the card says no: those
+ * two are about one app the viewer has chosen to look at, and the card is one tile
+ * of ~24 being scanned. Everything else, Edit and the whole moderator section
+ * included, is the same on both surfaces.
  *
  * 🔴 THE MODALS ARE OWNED HERE, AS SIBLINGS OF THE `Menu`, NOT OF A `Menu.Item`.
  * A Mantine `Menu.Dropdown` is UNMOUNTED when the menu closes, so a modal
@@ -82,6 +97,18 @@ export type AppListingMenuTarget = {
 
 export type AppListingActionsMenuProps = {
   listing: AppListingMenuTarget;
+  /**
+   * WHICH surface this menu is on — see `appListingMenuSurface.ts` for the single
+   * difference it makes and why it is a surface NAME rather than a feature boolean.
+   *
+   * 🔴 REQUIRED, WITH NO DEFAULT, ON PURPOSE. A default would silently pick one
+   * surface's policy for a new call site, and the wrong direction is the expensive
+   * one: defaulting to `'detail'` hands the viewer actions to any surface whose
+   * author never thought about it. Making it required means `tsc` asks the question
+   * at the moment a third surface is added, which is the only moment anyone knows
+   * the answer.
+   */
+  surface: AppListingMenuSurface;
   /**
    * Moderator listing-media review renders a listing READ-ONLY over an
    * UNAPPROVED shadow row. The whole menu is suppressed there — see
@@ -149,6 +176,7 @@ type AppListingMenuGates = {
  */
 function useAppListingMenuGates(
   listing: AppListingMenuTarget,
+  surface: AppListingMenuSurface,
   preview: boolean
 ): AppListingMenuGates {
   const currentUser = useCurrentUser();
@@ -166,11 +194,23 @@ function useAppListingMenuGates(
   // `listing.kind` is threaded in so the review affordance obeys the store-scope
   // kind rule the write gate applies — an external-only viewer is not offered a
   // review control on an onsite listing the server would NOT_FOUND.
-  const canReview = useCanReviewListing({
+  //
+  // 🔴 BOTH HOOKS ARE CALLED UNCONDITIONALLY AND THE SURFACE TERM IS APPLIED AFTER.
+  // `offersViewerActions && useCanReportListing()` would SHORT-CIRCUIT PAST A HOOK —
+  // legal-looking, and a rules-of-hooks violation the moment anything makes the left
+  // side vary. The surface is constant per call site today, which is exactly the
+  // property that would make such a bug invisible until it was not.
+  const offersViewerActions = surfaceOffersViewerActions(surface);
+  const viewerMayReview = useCanReviewListing({
     ownerUserId: listing.creatorUserId,
     listingKind: listing.kind as never,
   });
-  const canReport = useCanReportListing();
+  const viewerMayReport = useCanReportListing();
+  // 🔴 THE SURFACE TERM NARROWS; IT NEVER WIDENS. `&&`, so the card can only DROP an
+  // item the affordance's own predicate already admitted — an eligibility rule can
+  // never be bypassed by naming a surface. See `appListingMenuSurface.ts`.
+  const canReview = offersViewerActions && viewerMayReview;
+  const canReport = offersViewerActions && viewerMayReport;
 
   // MODERATOR section. The action SET is derived, never hand-rolled:
   // `appListingDetailModActions` intersects the shared lifecycle state machine
@@ -208,9 +248,10 @@ function useAppListingMenuGates(
  */
 export function useAppListingActionsMenuVisible(
   listing: AppListingMenuTarget,
+  surface: AppListingMenuSurface,
   preview = false
 ): boolean {
-  return useAppListingMenuGates(listing, preview).showMenu;
+  return useAppListingMenuGates(listing, surface, preview).showMenu;
 }
 
 /**
@@ -222,12 +263,14 @@ export function useAppListingActionsMenuVisible(
  *   - a viewer with nothing to do sees no control at all, rather than an empty
  *     menu that punishes the click; and
  *   - the trigger's ~36px therefore enters a surface's layout only for viewers
- *     who have an action. On the store card that means a MODERATOR viewing
- *     someone else's card gets a different action-row geometry from an anonymous
- *     shopper. That is accepted (see `AppListingCard`'s action-row note).
+ *     who have an action. On the store CARD, where the viewer actions are not
+ *     offered, that population is exactly the OWNER and a MODERATOR — so those two
+ *     get a different action-row geometry from everybody else, signed in or not.
+ *     That is accepted (see `AppListingCard`'s action-row note).
  */
 export function AppListingActionsMenu({
   listing,
+  surface,
   preview = false,
   triggerSize,
   triggerVariant = 'light',
@@ -239,6 +282,7 @@ export function AppListingActionsMenu({
 }: AppListingActionsMenuProps) {
   const { showEdit, editHref, canReview, canReport, modActions, showMenu } = useAppListingMenuGates(
     listing,
+    surface,
     preview
   );
 
@@ -327,7 +371,8 @@ export function AppListingActionsMenu({
             {/* Review affordance (thumbs/recommend) — hidden for the owner, signed-out
                 viewers, AND viewers whose resolved store scope does not admit this
                 listing's kind, all by `useCanReviewListing`. The write proc is
-                protected + STORE-SCOPE-gated + self-review-blocked server-side. */}
+                protected + STORE-SCOPE-gated + self-review-blocked server-side.
+                🔴 DETAIL SURFACE ONLY — see `appListingMenuSurface.ts`. */}
             {canReview && (
               <Menu.Item
                 leftSection={<IconThumbUp size={14} stroke={1.5} />}
@@ -338,7 +383,12 @@ export function AppListingActionsMenu({
               </Menu.Item>
             )}
             {/* Report affordance — the proc is protected + rate-limited +
-                reporter-bound server-side. 🔴 `triggerProps` carries BOTH the click
+                reporter-bound server-side. 🔴 DETAIL SURFACE ONLY (see
+                `appListingMenuSurface.ts`): `useCanReportListing` is
+                `!!useCurrentUser()`, so on the card this item alone would give every
+                signed-in shopper a menu — which is the geometry regression the
+                surface gate exists to stop.
+                🔴 `triggerProps` carries BOTH the click
                 and the spent `disabled` state; the modal below carries its
                 `onReported` counterpart. The pair is what stops a second report
                 returning the server's one-open-report-per-reporter CONFLICT as an

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -611,19 +611,60 @@ describe('AppListingCard', () => {
     await expect.element(edit).toHaveAttribute('href', '/apps/submit?edit=l1');
   });
 
-  test('🔴 a non-owner gets a menu WITHOUT an Edit item', async () => {
-    // A signed-in shopper DOES get a menu (Report, and Leave a review) — the
-    // predicate is "would it hold at least one item", not "is this the owner". What
-    // they must never get is Edit.
+  /**
+   * 🔴 THE CARD DOES NOT OFFER THE VIEWER ACTIONS — the narrowing, asserted on the
+   * viewer it is about.
+   *
+   * `useCanReportListing` is `!!useCurrentUser()`, so before `surface="card"` this
+   * viewer — an ordinary signed-in shopper, the single most common real visitor to
+   * the store — got a `⋮` holding Report and Leave a review, and the wider action
+   * row that comes with it. Both items now live only on the listing DETAIL page
+   * (`appListingMenuSurface.ts`), so this viewer's menu holds nothing and the
+   * trigger is suppressed.
+   *
+   * 🔴 THIS IS THE CASE THE SUITE COULD NOT SEE. The action-row width guard that
+   * was supposed to cover this pinned a SIGNED-OUT viewer, who has no menu either
+   * way — so it stayed green across the whole change. A guard that cannot reach the
+   * case it appears to cover is worse than no guard, which is why the geometry half
+   * below is now run over BOTH viewers from one assertion body.
+   */
+  test('🔴 a signed-in NON-owner, NON-moderator gets NO menu on the CARD', async () => {
     mocks.currentUser = SHOPPER;
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
-    await openCardMenu();
-    // Positive control FIRST: the dropdown really did open, so "no Edit" cannot be
-    // satisfied by a menu that rendered nothing.
-    await expect.element(page.getByTestId('apps-listing-report-action')).toBeInTheDocument();
+    // Render barrier — the card is really on screen, so the zeros below are about
+    // the menu and not about an empty document.
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
     // 🔴 `.elements()).toHaveLength(0)`, NOT `expect.element(...).not.toBeInTheDocument()`
     // — the latter is INERT in this repo (civitai/civitai#4197).
+    expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+    // 🔴 AND THE ITEMS THEMSELVES, not only the trigger. A Mantine `Menu.Dropdown`
+    // renders no DOM while closed, so these three zeros are weak on their own — they
+    // are here so a future change that keeps the trigger but empties it, or renders
+    // the items somewhere other than behind the trigger, still fails.
+    expect(page.getByTestId('apps-listing-report-action').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-review-action').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 THE POSITIVE CONTROL FOR THE TEST ABOVE, AND IT IS NOT OPTIONAL. "No menu for
+   * a signed-in shopper" is also what a card renders when the menu is broken for
+   * everyone, when the fixture is malformed, or when the harness stopped mounting
+   * the component at all. The OWNER arm proves the card can still produce a menu
+   * from the very same fixture and the very same render path, so the zeros above are
+   * attributable to the viewer rather than to the machinery.
+   */
+  test('🔴 …while the OWNER, on the same fixture, still gets one', async () => {
+    mocks.currentUser = OWNER;
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await openCardMenu();
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
+    // …and the narrowing reaches INSIDE an open menu, not just the trigger: the
+    // owner is signed in, so `useCanReportListing` admits them, and Report is absent
+    // here only because the CARD does not offer it. On the detail page the same
+    // viewer does get it — `AppListingDetailBody.browser.test.tsx` pins that.
+    expect(page.getByTestId('apps-listing-report-action').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-review-action').elements()).toHaveLength(0);
   });
 
   test('🔴 a signed-out viewer gets NO menu at all', async () => {
@@ -640,9 +681,14 @@ describe('AppListingCard', () => {
   });
 
   test('🔴 a MODERATOR viewing someone else’s card gets the moderator section', async () => {
-    // Accepted geometry consequence, asserted rather than left implicit: this viewer
-    // gets a `⋮` (and therefore a wider action cluster) on a card an anonymous
-    // shopper sees without one.
+    // Accepted geometry consequence, asserted rather than left implicit: with the
+    // viewer actions gone from this surface, the owner and a moderator are the ONLY
+    // viewers who get a `⋮` (and therefore a wider action cluster) on a card every
+    // other viewer sees without one.
+    //
+    // 🔴 THIS IS ALSO THE SUITE'S "a menu WITHOUT Edit" CASE. It used to be a signed-in
+    // shopper's; that viewer now has no menu at all, and a claim about what is inside a
+    // menu has to be made on a viewer who HAS one.
     mocks.currentUser = MODERATOR;
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
     await openCardMenu();
@@ -690,7 +736,15 @@ describe('AppListingCard', () => {
     // PORTALLED — which moves the DOM node but NOT React's event path, so a click
     // inside it still reaches an ancestor's `onClick`. A menu that navigates the
     // card when you open it is the obvious failure of this change.
-    mocks.currentUser = OWNER;
+    // 🔴 AN OWNER WHO IS ALSO A MODERATOR, AND THE COMBINATION IS FORCED BY THE
+    // NARROWING RATHER THAN CHOSEN. This test needs two things in one open dropdown:
+    // something to prove it opened, and a NON-NAVIGATING item to click, because a
+    // click on a `Link` would leave "did the card navigate?" unanswerable. It used to
+    // use Edit for the first and `Report` for the second — but the card no longer
+    // offers Report to anyone (`surface="card"`), and the only non-navigating items
+    // left on this surface are the moderator section's. So: Edit for the open proof,
+    // "Contact owner" for the propagation click.
+    mocks.currentUser = { ...OWNER, isModerator: true };
     const onCardClick = vi.fn();
     renderWithProviders(
       <div onClick={onCardClick}>
@@ -704,11 +758,8 @@ describe('AppListingCard', () => {
     // …and the click that opened it never reached the card.
     expect(onCardClick).toHaveBeenCalledTimes(0);
 
-    // A click INSIDE the dropdown must not reach it either. Asserted on a
-    // NON-NAVIGATING item so the assertion is about propagation rather than about a
-    // route change: `Report` is a plain button, and it is present for any signed-in
-    // viewer including the owner.
-    await page.getByTestId('apps-listing-report-action').click();
+    // A click INSIDE the dropdown must not reach it either.
+    await page.getByTestId('apps-listing-mod-message-owner').click();
     expect(onCardClick).toHaveBeenCalledTimes(0);
   });
 
@@ -1010,6 +1061,13 @@ describe('AppListingCard', () => {
      * details"), no reviews — the SHORTEST label the rollup can carry, so a
      * deficit here is structural rather than an artefact of a long string:
      *
+     * 🔴 WHICH VIEWERS EACH TABLE DESCRIBES — the numbers did not move when the card
+     * stopped offering Review/Report, but the POPULATIONS did, and a table whose
+     * caption is wrong is the kind of prose that gets cited instead of re-measured.
+     * "With a menu" is now exactly {owner, moderator}; "with no menu" is EVERY other
+     * viewer, signed in or signed out. Before `surface="card"` the split was
+     * {owner, moderator, any signed-in viewer} against {signed-out} alone.
+     *
      *   | card | container | actions nat/rendered | rollup | row h | rollup    |
      *   |------|-----------|----------------------|--------|-------|-----------|
      *   |  280 |       248 | 184 /  248 (grown)   |    0   |    46 | HIDDEN    |
@@ -1017,8 +1075,9 @@ describe('AppListingCard', () => {
      *   |  314 |       282 | 184 /  184           |   88.1 |    46 | clamped   |
      *   |  494 |       462 | 184 /  356.3 (grown) |   95.7 |    46 | natural   |
      *
-     * and the same widths with NO menu (an anonymous shopper), which is what the
-     * byte-unchanged claim below rests on:
+     * and the same widths with NO menu — a signed-OUT viewer OR an ordinary
+     * signed-IN one, which is what the byte-unchanged claim below rests on and why
+     * that claim is now asserted over both:
      *
      *   | card | container | actions nat/rendered | rollup (reviewed) | row h |
      *   |------|-----------|----------------------|-------------------|-------|
@@ -1352,71 +1411,63 @@ describe('AppListingCard', () => {
       });
 
       /**
-       * ⚠️ INVARIANT GUARD, NOT regression coverage — an anonymous viewer's card
-       * measured 95.7px here before the change and measures 95.7px after. It is here
-       * because the hide is scoped to cards that HAVE a menu, and a version that
-       * dropped that condition would delete the rollup from every anonymous
-       * shopper's card at the single most common desktop geometry — a failure no
-       * other test in this file could see.
+       * 🔴 THE MENU-LESS VIEWERS, MEASURED FROM ONE ASSERTION BODY — AND THAT SHAPE
+       * IS THE FIX, NOT A TIDY-UP.
        *
-       * 🔴 SIGNED-OUT, and that is load-bearing rather than incidental: a signed-IN
-       * shopper now gets a `⋮` (Report, and Leave a review), so their card is on the
-       * OTHER side of this invariant. See the signed-in test below, which measures it
-       * rather than leaving it to be discovered.
+       * This used to be two tests making two different claims: a SIGNED-OUT arm
+       * asserting the full rollup survives at the store's tightest real geometry, and
+       * a SIGNED-IN arm asserting the opposite, because `useCanReportListing` is
+       * `!!useCurrentUser()` and every signed-in shopper therefore got a `⋮`. With
+       * `surface="card"` the viewer actions are gone from this surface, so the two
+       * viewers are now the SAME case — and "the same" is a claim about a
+       * RELATIONSHIP, which two independently-written tests cannot make. Two literal
+       * tables drift; one body run twice cannot.
+       *
+       * 🔴 THE POPULATION THIS COVERS IS EVERY VIEWER EXCEPT {owner, moderator}. That
+       * is the whole point of running it over both: a narrowing implemented as "hide
+       * the menu when signed out" rather than "do not offer these items on the card"
+       * passes the signed-out arm and fails the signed-in one.
+       *
+       * ⚠️ STILL AN INVARIANT GUARD ON THE SIGNED-OUT ARM — that card measured 95.7px
+       * before this whole branch and measures 95.7px after. The SIGNED-IN arm is
+       * genuine regression coverage: it is red on `5a6d111a19`.
        */
-      test('⚠️ INVARIANT: at the SAME 1200 geometry a SIGNED-OUT card keeps its full rollup', async () => {
-        mocks.currentUser = null;
-        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        const { row, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(248);
-        expect(getComputedStyle(rollup).display).toBe('flex');
-        // Literal pin from the measured table: 95.7px, i.e. the full natural width,
-        // because a menu-less action set is 137.9px rather than 184px.
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
-        const text = rollup.querySelector('[data-truncate]') as HTMLElement;
-        expect(text.scrollWidth).toBeLessThanOrEqual(text.clientWidth);
-        // …and no trigger is what makes that true.
-        expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
-      });
-
-      /**
-       * 🔴 THE GEOMETRY CONSEQUENCE OF THE MENU'S PREDICATE, MEASURED RATHER THAN
-       * ASSUMED — and it is NOT what the change was pitched as.
-       *
-       * The menu renders when it would hold at least one item, and
-       * `useCanReportListing` is `!!useCurrentUser()`. So an ORDINARY SIGNED-IN
-       * SHOPPER — the most common real viewer of the store — gets a `⋮`, and their
-       * action cluster goes from a 137.9px natural width to 184px, exactly like an
-       * owner's. Only a SIGNED-OUT viewer keeps the pre-change geometry.
-       *
-       * That is a real behaviour change on the most common path, so it is pinned
-       * here explicitly instead of being left to be discovered from a screenshot.
-       * Narrowing it — dropping review/report from the CARD's copy of the menu and
-       * leaving them on the detail page — is a one-line change to
-       * `useAppListingActionsMenuVisible`, and this test is where that decision
-       * would show up.
-       */
-      test('🔴 a SIGNED-IN shopper gets the menu, and the wider action cluster with it', async () => {
-        mocks.currentUser = SHOPPER;
-        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        const { row, actions, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(248);
-        await expect
-          .element(page.getByTestId('apps-listing-card-actions-menu'))
-          .toBeInTheDocument();
-        // Same cluster width as an owner's, and the same consequence: below the
-        // threshold the rollup goes rather than being crushed.
-        expect(Math.round(actions.getBoundingClientRect().width)).toBe(248); // grown to fill
-        expect(getComputedStyle(rollup).display).toBe('none');
-        expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+      describe('🔴 a menu-less viewer keeps the full rollup at the 1200 geometry', () => {
+        // One test per viewer rather than a loop with `unmount()` — same reason as
+        // the floor sweep above.
+        for (const [label, user] of [
+          ['signed-out', null],
+          ['signed-in non-owner, non-moderator', SHOPPER],
+        ] as const) {
+          test(`${label}`, async () => {
+            mocks.currentUser = user;
+            renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+            await expect
+              .element(page.getByRole('link', { name: 'View details', exact: true }))
+              .toBeInTheDocument();
+            const { row, actions, rollup } = actionRow('View details');
+            assertLayoutIsReal(row);
+            expect(Math.round(row.clientWidth)).toBe(248);
+            // No trigger is what makes everything below true.
+            expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+            expect(getComputedStyle(rollup).display).toBe('flex');
+            // Literal pin from the measured table: 95.7px, i.e. the full natural
+            // width, because a menu-less action set is 137.9px rather than 184px.
+            expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
+            const text = rollup.querySelector('[data-truncate]') as HTMLElement;
+            expect(text.scrollWidth).toBeLessThanOrEqual(text.clientWidth);
+            // 🔴 AND THE CLUSTER, BOUNDED RATHER THAN PINNED, BECAUSE THIS WIDTH IS
+            // NOT IN DEFICIT. 137.9 + 10 + 95.7 = 243.6 against a 248px row, so there
+            // are ~4px of slack for the CTA to grow into and the cluster's rendered
+            // width is legitimately a little over its 137.9 natural. What the bound
+            // excludes is the state the signed-in card was actually in before the
+            // narrowing — a cluster grown to the full 248 with the rollup gone. The
+            // exact 138 pin lives in the deficit-width test below, where growth is
+            // structurally impossible.
+            expect(actions.getBoundingClientRect().width).toBeLessThan(160);
+            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+          });
+        }
       });
 
       test('a menu card + "Open" (the narrower CTA) also keeps the rollup legible', async () => {
@@ -1430,29 +1481,51 @@ describe('AppListingCard', () => {
         expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
       });
 
-      test('🔴 SIGNED-OUT cards are byte-unchanged — no menu, same actions width', async () => {
-        // The `⋮` is what widens the row, and an anonymous viewer has no menu at all,
-        // so this card's geometry must be exactly what it was before this change.
-        //
-        // 🔴 IT SURVIVES `flex-grow` ONLY BECAUSE THIS WIDTH IS IN DEFICIT, which is
-        // worth stating rather than being quietly lucky about: at 282 the reviewed
-        // rollup's natural 139.1 + 10 + 137.9 = 287 exceeds the row, so there is no
-        // free space for the CTA to grow into and the cluster stays at its natural
-        // 137.9. The same card at 462 measures 312.9 — the CTA filling the slack, on
-        // an anonymous card, which is the whole S7 change and is NOT a regression.
-        mocks.currentUser = null;
-        renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        const { row, actions, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
-        expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
-        // Measured pre-change values, pinned so a menu-side change cannot leak.
-        expect(Math.round(actions.getBoundingClientRect().width)).toBe(138);
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(130);
-        expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+      /**
+       * 🔴 THE 138 PIN — AND THE REASON IT IS NOW RUN OVER TWO VIEWERS.
+       *
+       * This is the guard that was supposed to say "a shopper's action row did not
+       * move", and for one branch it did not say that at all: it ran SIGNED-OUT only,
+       * and a signed-out viewer had no menu before the change and none after, so the
+       * assertion was structurally incapable of seeing the 137.9 → 184 shift that had
+       * just landed on every SIGNED-IN shopper. It stayed green through exactly the
+       * regression it reads as covering. A guard that cannot reach its own case is
+       * worse than no guard, because it stops anyone looking.
+       *
+       * The repair is not a second copy of the numbers — that reproduces the same
+       * failure one viewer over. It is the SAME body, run over both viewers, so the
+       * claim being made is "these two measure identically" rather than two
+       * independent claims that happen to be written with the same literals.
+       *
+       * 🔴 IT SURVIVES `flex-grow` ONLY BECAUSE THIS WIDTH IS IN DEFICIT, which is
+       * worth stating rather than being quietly lucky about: at 282 the reviewed
+       * rollup's natural 139.1 + 10 + 137.9 = 287 exceeds the row, so there is no
+       * free space for the CTA to grow into and the cluster stays at its natural
+       * 137.9. That is what makes an EXACT pin honest here. The same card at 462
+       * measures 312.9 — the CTA filling the slack, which is the S7 change and NOT a
+       * regression.
+       */
+      describe('🔴 a menu-less card is byte-unchanged — no menu, actions exactly 138', () => {
+        for (const [label, user] of [
+          ['signed-out', null],
+          ['signed-in non-owner, non-moderator', SHOPPER],
+        ] as const) {
+          test(`${label}`, async () => {
+            mocks.currentUser = user;
+            renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
+            await expect
+              .element(page.getByRole('link', { name: 'View details', exact: true }))
+              .toBeInTheDocument();
+            const { row, actions, rollup } = actionRow('View details');
+            assertLayoutIsReal(row);
+            expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
+            expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+            // Measured pre-change values, pinned so a menu-side change cannot leak.
+            expect(Math.round(actions.getBoundingClientRect().width)).toBe(138);
+            expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(130);
+            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+          });
+        }
       });
 
       /**

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
+import type * as TrpcMod from '~/utils/trpc';
+import type * as FeatureFlagsMod from '~/providers/FeatureFlagsProvider';
 /**
  * 🔴 THE APP'S REAL STYLESHEET CASCADE, imported ON PURPOSE — without it every
  * geometry assertion in this file is a lie.
@@ -39,6 +41,12 @@ import '~/styles/globals.css';
 import '@mantine/core/styles.layer.css';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/component-setup';
+import {
+  LISTING_ACTIONS_WIDEST_PX,
+  LISTING_ACTION_ROW_GAP_PX,
+  LISTING_ROLLUP_HIDE_BELOW_PX,
+  LISTING_ROLLUP_MIN_WIDTH_PX,
+} from '~/components/Apps/appListingCardView';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -50,11 +58,118 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  */
 
 const mocks = vi.hoisted(() => ({
-  currentUser: null as null | { id: number; username: string },
+  // `isModerator` is what `isAppReviewer` reads — the gate on the `⋮` menu's
+  // moderator section. Optional so every pre-existing fixture keeps its exact
+  // meaning (absent → falsy → not a moderator).
+  currentUser: null as null | { id: number; username: string; isModerator?: boolean },
+  // Store-visibility flags, MUTABLE per test — `useCanReviewListing` resolves the
+  // client store scope from them, so a fixed literal would make this suite
+  // structurally unable to construct a viewer who may review.
+  features: { appBlocks: true, appListings: true, appBlocksPages: false } as Record<
+    string,
+    boolean
+  >,
+  reportMutate: vi.fn(),
+  upsertMutate: vi.fn(),
+  messageOwnerMutate: vi.fn(),
+  delistMutate: vi.fn(),
+  resetOffsiteMutate: vi.fn(),
+  resetOnsiteMutate: vi.fn(),
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => mocks.currentUser,
+}));
+
+/**
+ * 🔴 BOTH FLAG HOOKS ARE OVERRIDDEN, AND THEY MUST RETURN THE SAME OBJECT.
+ * `useCanReviewListing` reads `useOptionalFeatureFlags` (it must not throw outside a
+ * provider); overriding only `useFeatureFlags` leaves the optional one resolving to
+ * the real null-outside-provider value, i.e. store scope `none`, which silently hides
+ * the review affordance. `importOriginal` is SPREAD rather than replaced wholesale
+ * (local-rules/no-wholesale-module-mock).
+ */
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsMod>()),
+  useFeatureFlags: () => mocks.features,
+  useOptionalFeatureFlags: () => mocks.features,
+}));
+
+/**
+ * 🔴 tRPC IS REACHED ONLY THROUGH THE `⋮` MENU'S MODALS, AND ONLY AFTER IT IS OPENED.
+ *
+ * The card itself makes no request. The shared `AppListingActionsMenu` mounts its four
+ * modals lazily — the first time the menu opens — so a test that never opens it needs
+ * none of this. It is mocked anyway because several tests below DO open the menu, and
+ * because a suite that would explode the moment someone adds such a test is a trap.
+ *
+ * Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock):
+ * a hand-written replacement silently breaks every importer the day `~/utils/trpc` grows
+ * an export this factory omits.
+ */
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      getMyReview: { useQuery: () => ({ data: null, isLoading: false }) },
+      upsertReview: { useMutation: () => ({ mutate: mocks.upsertMutate, isPending: false }) },
+      reportListing: {
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (input: unknown) => {
+            mocks.reportMutate(input);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+      messageAppOwner: {
+        useMutation: (opts?: {
+          onSuccess?: (r: { recipientCount: number }) => void | Promise<void>;
+        }) => ({
+          mutate: (input: unknown) => {
+            mocks.messageOwnerMutate(input);
+            void opts?.onSuccess?.({ recipientCount: 1 });
+          },
+          mutateAsync: vi.fn(),
+          isPending: false,
+        }),
+      },
+      delistListing: {
+        useMutation: (opts?: { onSuccess?: () => void | Promise<void> }) => ({
+          mutate: (input: unknown) => {
+            mocks.delistMutate(input);
+            void opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+      resetListingToPending: {
+        useMutation: (opts?: { onSuccess?: () => void | Promise<void> }) => ({
+          mutate: (input: unknown) => {
+            mocks.resetOffsiteMutate(input);
+            void opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+      resetOnsiteListingToPending: {
+        useMutation: (opts?: { onSuccess?: () => void | Promise<void> }) => ({
+          mutate: (input: unknown) => {
+            mocks.resetOnsiteMutate(input);
+            void opts?.onSuccess?.();
+          },
+          isPending: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: async () => undefined },
+        listReviews: { invalidate: async () => undefined },
+        getAppDetail: { invalidate: async () => undefined },
+      },
+    }),
+  },
 }));
 
 // Import AFTER the mock is declared (vi.mock is hoisted, imports are not).
@@ -62,7 +177,45 @@ const { AppListingCard } = await import('./AppListingCard');
 
 beforeEach(() => {
   mocks.currentUser = null;
+  mocks.features = { appBlocks: true, appListings: true, appBlocksPages: false };
 });
+
+/** A signed-in moderator who is NOT the fixture's owner (`base().creator.id === 5`). */
+const MODERATOR = { id: 999, username: 'mod', isModerator: true };
+/** An ordinary signed-in viewer who is not the owner. */
+const SHOPPER = { id: 999, username: 'bob' };
+/** The fixture's owner. */
+const OWNER = { id: 5, username: 'alice' };
+
+/**
+ * Open the card's `⋮` menu and wait for the dropdown to mount.
+ *
+ * 🔴 EVERY MENU ITEM IS UNMOUNTED WHILE THE MENU IS CLOSED — a Mantine
+ * `Menu.Dropdown` renders no DOM at all until it opens. So a query for `Edit` (or any
+ * other item) before this has run reports absence for a control that is present and
+ * correct, which is a false negative rather than a finding.
+ */
+async function openCardMenu() {
+  const trigger = page.getByTestId('apps-listing-card-actions-menu');
+  await expect.element(trigger).toBeInTheDocument();
+  await trigger.click();
+  return trigger;
+}
+
+/**
+ * Every INTERACTIVE element in the document whose accessible name is exactly "Edit".
+ *
+ * 🔴 COUNTS NODES, NOT VISIBLE NODES, ON PURPOSE. The pre-change card rendered two
+ * Edit controls and hid one with `display: none`; a check that filtered on visibility
+ * would have scored that arrangement as "exactly one" and could never go red on it.
+ * Non-interactive descendants (Mantine wraps a `Menu.Item`'s label in a `span`) are
+ * excluded, so this counts affordances rather than DOM depth.
+ */
+function editAffordances(): Element[] {
+  return Array.from(
+    document.querySelectorAll('a, button, [role="menuitem"], [role="button"]')
+  ).filter((el) => (el.getAttribute('aria-label') ?? el.textContent ?? '').trim() === 'Edit');
+}
 
 function base(over: Partial<ListingCard>): ListingCard {
   return {
@@ -426,16 +579,25 @@ describe('AppListingCard', () => {
     // player-play / external-link / eye, pinned across the three tests above.
   });
 
+  // ── The `⋮` overflow menu ───────────────────────────────────────────────────
+  //
+  // Edit used to be TWO controls in the action row — a text `Button` and an
+  // icon-only `ActionIcon`, swapped by an `@[360px]` container query. Both are
+  // gone, and so is that breakpoint: Edit is now one `Menu.Item` inside the
+  // SHARED `AppListingActionsMenu` (see that module), reached through a fixed
+  // 36px `⋮` trigger.
+
   test('owner sees the Edit deep-link → on-site manifest editor', async () => {
-    mocks.currentUser = { id: 5, username: 'alice' }; // matches base().creator.id
+    mocks.currentUser = OWNER; // matches base().creator.id
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await openCardMenu();
     const edit = page.getByTestId('apps-listing-owner-edit');
     await expect.element(edit).toBeInTheDocument();
     await expect.element(edit).toHaveAttribute('href', '/apps/blk-1/edit');
   });
 
   test('owner of an off-site listing → Edit routes to the submit editor by listing id', async () => {
-    mocks.currentUser = { id: 5, username: 'alice' };
+    mocks.currentUser = OWNER;
     renderWithProviders(
       <AppListingCard
         card={base({
@@ -444,20 +606,110 @@ describe('AppListingCard', () => {
         })}
       />
     );
+    await openCardMenu();
     const edit = page.getByTestId('apps-listing-owner-edit');
     await expect.element(edit).toHaveAttribute('href', '/apps/submit?edit=l1');
   });
 
-  test('non-owner does NOT see the Edit deep-link', async () => {
-    mocks.currentUser = { id: 999, username: 'bob' };
+  test('🔴 a non-owner gets a menu WITHOUT an Edit item', async () => {
+    // A signed-in shopper DOES get a menu (Report, and Leave a review) — the
+    // predicate is "would it hold at least one item", not "is this the owner". What
+    // they must never get is Edit.
+    mocks.currentUser = SHOPPER;
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
-    await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+    await openCardMenu();
+    // Positive control FIRST: the dropdown really did open, so "no Edit" cannot be
+    // satisfied by a menu that rendered nothing.
+    await expect.element(page.getByTestId('apps-listing-report-action')).toBeInTheDocument();
+    // 🔴 `.elements()).toHaveLength(0)`, NOT `expect.element(...).not.toBeInTheDocument()`
+    // — the latter is INERT in this repo (civitai/civitai#4197).
+    expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
   });
 
-  test('signed-out viewer does NOT see the Edit deep-link', async () => {
+  test('🔴 a signed-out viewer gets NO menu at all', async () => {
+    // Nothing in the menu is available to an anonymous viewer: Edit is owner-only,
+    // review and report both require a session, and the mod section requires
+    // `isModerator`. An empty menu that punishes the click is worse than no control,
+    // so the trigger itself is absent — which is also what keeps an anonymous
+    // shopper's action row byte-identical to what it was before this change.
     mocks.currentUser = null;
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
-    await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
+  });
+
+  test('🔴 a MODERATOR viewing someone else’s card gets the moderator section', async () => {
+    // Accepted geometry consequence, asserted rather than left implicit: this viewer
+    // gets a `⋮` (and therefore a wider action cluster) on a card an anonymous
+    // shopper sees without one.
+    mocks.currentUser = MODERATOR;
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await openCardMenu();
+    await expect.element(page.getByTestId('apps-listing-mod-message-owner')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-listing-mod-manage')).toBeInTheDocument();
+    // …and still no Edit: they are not the owner.
+    expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
+  });
+
+  test('🔴 `preview` suppresses the whole menu, moderator included', async () => {
+    // The moderator listing-media review renders this card READ-ONLY over an
+    // UNAPPROVED shadow listing. Without the prop, the reviewer — who is by
+    // definition a moderator — would be offered live takedown actions against a
+    // listing whose status and whose `id` are both unguaranteed.
+    mocks.currentUser = MODERATOR;
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage preview />);
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+  });
+
+  test('🔴 EXACTLY ONE Edit affordance in the accessibility tree', async () => {
+    // The pre-change card rendered TWO Edit controls and relied on `display: none`
+    // to keep one of them out of the accessibility tree — a property its comment
+    // called out and which must survive the move into a menu. It does, more
+    // strongly: there is now one node, not two with one hidden.
+    mocks.currentUser = OWNER;
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await openCardMenu();
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
+    // By ACCESSIBLE NAME over the whole document (the dropdown is portalled), not by
+    // testid — the claim is about what a screen reader is offered, and a second Edit
+    // added without the testid would be invisible to a testid count.
+    expect(editAffordances().map((el) => el.getAttribute('data-testid'))).toEqual([
+      'apps-listing-owner-edit',
+    ]);
+  });
+
+  test('🔴 the `⋮` trigger has a real accessible name and does not navigate the card', async () => {
+    // Icon-only → the glyph alone is not an accessible name (the
+    // `CategoryFilterButtons` precedent), so `aria-label` supplies it and a Tooltip
+    // supplies the sighted equivalent.
+    //
+    // 🔴 THE CARD-CLICK HALF IS THE POINT. Every action on this card stops
+    // propagation because the card is a click target, and a Mantine dropdown is
+    // PORTALLED — which moves the DOM node but NOT React's event path, so a click
+    // inside it still reaches an ancestor's `onClick`. A menu that navigates the
+    // card when you open it is the obvious failure of this change.
+    mocks.currentUser = OWNER;
+    const onCardClick = vi.fn();
+    renderWithProviders(
+      <div onClick={onCardClick}>
+        <AppListingCard card={base({})} canOpenPage />
+      </div>
+    );
+    const trigger = await openCardMenu();
+    await expect.element(trigger).toHaveAttribute('aria-label', 'App options');
+    // The dropdown opened…
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
+    // …and the click that opened it never reached the card.
+    expect(onCardClick).toHaveBeenCalledTimes(0);
+
+    // A click INSIDE the dropdown must not reach it either. Asserted on a
+    // NON-NAVIGATING item so the assertion is about propagation rather than about a
+    // route change: `Report` is a plain button, and it is present for any signed-in
+    // viewer including the owner.
+    await page.getByTestId('apps-listing-report-action').click();
+    expect(onCardClick).toHaveBeenCalledTimes(0);
   });
 
   test('OWNER sees an "Incomplete" indicator when the card is below the floor (missing icon/cover)', async () => {
@@ -620,31 +872,42 @@ describe('AppListingCard', () => {
     // line with one item sits at flex-start under `justify="space-between"`, and
     // (b) make an OWNER card (Edit + CTA) wrap at a wider column than a non-owner
     // card, growing the height of the whole `h-full` grid row for everyone.
-    mocks.currentUser = { id: 5, username: 'alice' }; // owner → widest action set
+    mocks.currentUser = OWNER; // → the `⋮` menu, i.e. the widest action set
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
-    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-listing-card-actions-menu')).toBeInTheDocument();
 
-    const edit = page.getByTestId('apps-listing-owner-edit').element() as HTMLElement;
-    // The group holding Edit + the primary CTA.
-    const actions = edit.parentElement as HTMLElement;
+    const trigger = page.getByTestId('apps-listing-card-actions-menu').element() as HTMLElement;
+    // The group holding the primary CTA + the `⋮` trigger. The trigger sits inside a
+    // `flexShrink: 0` Box the shared menu renders, so climb one more level.
+    const actions = trigger.parentElement!.parentElement as HTMLElement;
     expect(actions.style.getPropertyValue('--group-wrap')).toBe('nowrap');
     // The actions are the rigid side: they never shrink…
     expect(actions.style.flexShrink).toBe('0');
+    // …but they DO grow, which is what lets the CTA fill the row (S7).
+    expect(actions.style.flexGrow).toBe('1');
     // …and the row itself never wraps, so the actions can't jump to the left.
     const row = actions.parentElement as HTMLElement;
     expect(row.style.getPropertyValue('--group-wrap')).toBe('nowrap');
-    // The recommend rollup is the flexible side that absorbs the pressure.
+    // 🔴 The recommend rollup is the flexible side — DOWN TO A FLOOR. It used to
+    // carry `minWidth: 0` ("shrink to nothing"); that is exactly what a growing CTA
+    // would exploit, so the floor is now a constraint the layout engine enforces.
     const rollup = row.firstElementChild as HTMLElement;
     expect(rollup).not.toBe(actions);
-    expect(rollup.style.minWidth).toBe('0px');
+    expect(rollup.style.minWidth).toBe(`${LISTING_ROLLUP_MIN_WIDTH_PX}px`);
   });
 
-  test('the owner "Edit" secondary CTA also renders at size "sm"', async () => {
-    mocks.currentUser = { id: 5, username: 'alice' };
-    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
-    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
-    const edit = page.getByTestId('apps-listing-owner-edit').element() as HTMLElement;
-    expect(edit.style.getPropertyValue('--button-height')).toBe('var(--button-height-sm)');
+  test('🔴 the `⋮` trigger is 36px — the row-height contract', async () => {
+    // The row is `pt="xs"` (10px) + a 36px control = 46px, and it lives in an
+    // `h-full` grid row, so a taller control here grows every card in that row
+    // across the store. The trigger must therefore match the `sm` CTA button
+    // exactly. (The control it replaced — the icon-only Edit — was also 36.)
+    mocks.currentUser = OWNER;
+    renderWithProviders(<Sized width={314} card={base({})} />);
+    await expect.element(page.getByTestId('apps-listing-card-actions-menu')).toBeInTheDocument();
+    const trigger = page.getByTestId('apps-listing-card-actions-menu').element() as HTMLElement;
+    const box = trigger.getBoundingClientRect();
+    expect(Math.round(box.width)).toBe(36);
+    expect(Math.round(box.height)).toBe(36);
   });
 
   /**
@@ -735,35 +998,52 @@ describe('AppListingCard', () => {
     });
 
     /**
-     * 🔴 THE 280px OWNER REGRESSION.
+     * 🔴 THE ACTION-ROW GEOMETRY, RE-MEASURED ON THIS BRANCH.
      *
-     * A 280px card content box is what a **1200px viewport** produces at the
-     * store's 4-column `xl` grid — a very common laptop width, and one my
-     * original 390/768/1440/2560 sweep skipped entirely.
+     * A 280px card is what a **1200px viewport** produces at the store's 4-column
+     * `xl` grid — the narrowest geometry the store can actually produce, and a
+     * very common laptop width.
      *
-     * Measured there (content box px, `Group gap="xs"` between the two sides):
+     * Every number below was taken from a real render in this environment, with
+     * the app's real stylesheet cascade, at the widths named. It is NOT the
+     * pre-change table carried forward. Card with a `⋮` menu, widest CTA ("View
+     * details"), no reviews — the SHORTEST label the rollup can carry, so a
+     * deficit here is structural rather than an artefact of a long string:
      *
-     *   | case @280                  | actions | rollup | rollup text |
-     *   |----------------------------|---------|--------|-------------|
-     *   | non-owner + "Open"         |      94 |    139 |         122 |
-     *   | non-owner + "View details" |     138 |    132 |         115 |
-     *   | owner + "Open"             |     188 |     82 |          65 |
-     *   | owner + "View details"     |     232 |     38 |          21 |
+     *   | card | container | actions nat/rendered | rollup | row h | rollup    |
+     *   |------|-----------|----------------------|--------|-------|-----------|
+     *   |  280 |       248 | 184 /  248 (grown)   |    0   |    46 | HIDDEN    |
+     *   |  296 |       264 | 184 /  184           |   70.1 |    46 | at FLOOR  |
+     *   |  314 |       282 | 184 /  184           |   88.1 |    46 | clamped   |
+     *   |  494 |       462 | 184 /  356.3 (grown) |   95.7 |    46 | natural   |
      *
-     * The rollup's natural width is 139 / 122. In the last row it is 38 — the
-     * "91% recommend (100)" text and even the 13px thumb glyph are gone. The
-     * `leftSection` icons cost ~44px and that is exactly the deficit, so my PR
-     * body's "the rollup absorbs the extra width by truncating, as designed" was
-     * wrong for the owner case: below ~360 it does not truncate, it disappears.
+     * and the same widths with NO menu (an anonymous shopper), which is what the
+     * byte-unchanged claim below rests on:
      *
-     * 🔴 THE FIX IS NOT TO LET THE ROW WRAP. Row height is a constant 46px in
-     * every cell above, and nothing overflows — the nowrap + `flexShrink: 0`
-     * design is correct and the file documents why wrapping breaks alignment and
-     * grid-row heights. The fix is to shrink the OWNER-ONLY Edit control to an
-     * icon below a container-query breakpoint, which is the only part of the row
-     * that is optional.
+     *   | card | container | actions nat/rendered | rollup (reviewed) | row h |
+     *   |------|-----------|----------------------|-------------------|-------|
+     *   |  280 |       248 | 137.9 / 137.9        |             100.1 |    46 |
+     *   |  314 |       282 | 137.9 / 137.9        |             134.1 |    46 |
+     *   |  494 |       462 | 137.9 / 312.9        |             139.1 |    46 |
+     *
+     * TWO THINGS THE TABLES SAY THAT PROSE WOULD NOT:
+     *
+     *   1. `actions` is now TWO numbers. The CTA grows into the row's free space
+     *      (S7), so the cluster's rendered width exceeds its natural width wherever
+     *      there is slack. Where the row is in DEFICIT there is no growth and the
+     *      two coincide — which is why the two middle rows of the first table, and
+     *      the first two rows of the second, are unchanged from before this branch.
+     *   2. The 264 row is the threshold doing its job: 70.1px is exactly
+     *      `LISTING_ROLLUP_MIN_WIDTH_PX`, and 264 = 184 + 10 + 70 is exactly the
+     *      arithmetic `LISTING_ROLLUP_HIDE_BELOW_PX` computes. The model and the
+     *      measurement agree to 0.1px, which is why the threshold is stated as
+     *      arithmetic rather than as a round number that happened to look right.
+     *
+     * 🔴 THE FIX IS STILL NOT TO LET THE ROW WRAP. Row height is a constant 46px in
+     * every cell above — nowrap + `flexShrink: 0` is what holds it, and the file
+     * documents why wrapping breaks alignment and grid-row heights.
      */
-    describe('owner cards at a 280px content box (1200px viewport, xl grid)', () => {
+    describe("the action row at the store's real container widths", () => {
       /**
        * 🔴 A REVIEWED card, deliberately. The shared `base()` fixture has no
        * reviews, so its rollup reads "No reviews yet" — only ~96px natural, which
@@ -816,8 +1096,8 @@ describe('AppListingCard', () => {
         } satisfies ListingCard['kindData'],
       };
 
-      test('🔴 owner + "View details" keeps a LEGIBLE recommend rollup', async () => {
-        mocks.currentUser = { id: 5, username: 'alice' };
+      test('🔴 menu card + "View details" keeps a LEGIBLE recommend rollup', async () => {
+        mocks.currentUser = OWNER;
         renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
         await expect
           .element(page.getByRole('link', { name: 'View details', exact: true }))
@@ -829,9 +1109,13 @@ describe('AppListingCard', () => {
 
         // 80px is grounded in the measurements above, not invented: the glyph is
         // 13px + a 4px gap, so 80 leaves ~63px of text — enough for "91% recom…"
-        // to read as a recommendation figure. Pre-fix this is 38 (text 21), which
-        // shows nothing at all; post-fix the icon-only Edit returns ~50px.
+        // to read as a recommendation figure. Measured here: 88.1.
         expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
+        // …and never below the floor while it is displayed — the property the
+        // growing CTA could otherwise take away.
+        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+          LISTING_ROLLUP_MIN_WIDTH_PX
+        );
 
         // The thumb glyph specifically must survive — it is the affordance that
         // says "this number is a rating" at a glance.
@@ -856,24 +1140,19 @@ describe('AppListingCard', () => {
        * box the action row actually gets is 248, and a 314px wrapper (content box
        * 282) corresponds to roughly a 1345 viewport.
        *
-       * 🔴 THIS TEST'S EXPECTATION WAS INVERTED (rollup-floor pass, on main+#3547).
-       * It used to assert the rollup SURVIVES here at >= 50px, and it passed: the
-       * measured value on this tree is 54.1px. That IS the defect. At 54px the
-       * rollup is a 13px thumb glyph, a 4px gap and 37px of 12px text, so the
-       * shortest label it can carry — "No reviews yet", 79px natural — renders as a
-       * ~5-character stub. A stub is strictly worse than nothing: it holds the
-       * slot, reads as a rendering bug, and communicates nothing. Below a 264px
-       * container the rollup is now HIDDEN instead, and the actions keep the right
-       * edge.
+       * Below the 264px threshold the rollup is HIDDEN rather than crushed, and the
+       * actions keep the right edge. A stub is strictly worse than nothing: it holds
+       * the slot, reads as a rendering bug, and communicates nothing.
        *
-       * Measured on main+#3547 (owner, widest CTA, no reviews), pre-change:
-       *   container 248 -> rollup 54 (text 37 / 79 natural, TRUNCATED)
-       *   container 268 -> rollup 74 (text 57 / 79, truncated)
-       *   container 282 -> rollup 88 (text 71 / 79, truncated)
-       *   container 298 -> rollup 96 (text 79 / 79, full)
+       * Re-measured on THIS branch (menu card, widest CTA, no reviews):
+       *   container 248 -> rollup 0    (hidden by the query)
+       *   container 264 -> rollup 70.1 (AT the floor)
+       *   container 266 -> rollup 72.1
+       *   container 282 -> rollup 88.1
+       *   container 462 -> rollup 95.7 (natural; the CTA takes the other 260)
        */
-      test('🔴 at the REAL 1200 geometry an owner card DROPS the rollup instead of crushing it', async () => {
-        mocks.currentUser = { id: 5, username: 'alice' };
+      test('🔴 at the REAL 1200 geometry a menu card DROPS the rollup instead of crushing it', async () => {
+        mocks.currentUser = OWNER;
         // 🔴 NO reviews — the label the live report caught, and the SHORT one (79px
         // of text vs 122px for "91% recommend (100)"). Using the short label is
         // what makes this structural rather than an artefact of a long string:
@@ -915,8 +1194,8 @@ describe('AppListingCard', () => {
        * Without it, widening the threshold to "hide it on any narrow owner card"
        * would pass unnoticed.
        */
-      test('⚠️ INVARIANT: just ABOVE the 264px threshold the owner rollup is back and legible', async () => {
-        mocks.currentUser = { id: 5, username: 'alice' };
+      test('⚠️ INVARIANT: just ABOVE the 264px threshold the rollup is back and legible', async () => {
+        mocks.currentUser = OWNER;
         renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
         await expect
           .element(page.getByRole('link', { name: 'View details', exact: true }))
@@ -933,14 +1212,159 @@ describe('AppListingCard', () => {
       });
 
       /**
-       * ⚠️ INVARIANT GUARD, NOT regression coverage — a non-owner card measured
-       * 95.7px here before the change and measures 95.7px after. It is here because
-       * the whole fix is owner-scoped (`showEdit`), and a version that dropped that
-       * condition would delete the rollup from every public shopper's card at the
-       * single most common desktop geometry — a failure no other test in this file
-       * could see.
+       * 🔴 THE THRESHOLD IS EXACTLY WHERE THE FLOOR FIRST FITS — the assertion the
+       * arithmetic makes, checked at the arithmetic's own boundary rather than
+       * somewhere comfortably inside the band.
+       *
+       * `LISTING_ROLLUP_HIDE_BELOW_PX` = actions(184) + gap(10) + floor(70) = 264. At
+       * a 264px container the rollup must therefore be present and measure EXACTLY
+       * the floor: one pixel of slack anywhere in that sum and it would be more, one
+       * pixel of deficit and the query would have hidden it. Measured: 70.1.
+       *
+       * This is the case an off-by-a-few threshold survives everywhere else — 282 is
+       * 18px inside the band and 248 is 16px outside it, so both stay green against a
+       * threshold of, say, 250 or 276.
+       *
+       * ⚠️ INVARIANT GUARD, NOT regression coverage for THIS change: measured, it
+       * passes on pre-change code too, because at a 264px container the available
+       * space happens to equal the floor whether or not a floor is enforced. It is
+       * regression coverage for the THRESHOLD — move 264 and it goes red — and the
+       * clamp itself is pinned by the menu-less test above, which is the only width
+       * at which the two differ.
        */
-      test('⚠️ INVARIANT: at the SAME 1200 geometry a NON-owner card keeps its full rollup', async () => {
+      test('🔴 AT the threshold the rollup is present and sits exactly on its floor', async () => {
+        mocks.currentUser = OWNER;
+        // 296 outer - 2x16 padding = a 264px container, i.e. the threshold itself.
+        renderWithProviders(<Sized width={296} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+        await expect
+          .element(page.getByRole('link', { name: 'View details', exact: true }))
+          .toBeInTheDocument();
+        const { row, rollup, actions } = actionRow('View details');
+        assertLayoutIsReal(row);
+        expect(Math.round(row.clientWidth)).toBe(LISTING_ROLLUP_HIDE_BELOW_PX);
+        expect(getComputedStyle(rollup).display).toBe('flex');
+        // Exactly the floor, to sub-pixel: 70.1 measured against a 70 constant.
+        expect(rollup.getBoundingClientRect().width).toBeCloseTo(LISTING_ROLLUP_MIN_WIDTH_PX, 0);
+        // …and the other two terms of the sum are what the constants say they are, so
+        // a green result here cannot be three compensating errors.
+        expect(actions.getBoundingClientRect().width).toBeCloseTo(LISTING_ACTIONS_WIDEST_PX, 0);
+        expect(getComputedStyle(row).columnGap).toBe(`${LISTING_ACTION_ROW_GAP_PX}px`);
+        expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
+      });
+
+      /**
+       * 🔴 THE ROLLUP IS NEVER SQUEEZED BELOW ITS FLOOR WHILE DISPLAYED — swept, not
+       * spot-checked, because the failure this guards is width-dependent by nature.
+       *
+       * 248 is included deliberately: there the rollup is HIDDEN, and a floor claim
+       * must not be satisfied by a zero. The sweep therefore asserts the disjunction
+       * (hidden, or >= floor) and separately asserts that at least one width in the
+       * sweep is on each side of it — a positive control against a sweep that
+       * silently tests only one arm.
+       */
+      /**
+       * 🔴 THE ONE PLACE THE FLOOR IS OBSERVABLE — and finding it is the difference
+       * between a guard and a decoration.
+       *
+       * MEASURED, and it is the uncomfortable result: at every container width the
+       * store can produce, `minWidth: 70` changes NOTHING. The rollup only shrinks
+       * under deficit, and a deficit deep enough to push it under 70 arrives at
+       * exactly the width where the container query hides it — so on a card WITH a
+       * menu the clamp and the query bite at the same point by construction. Every
+       * other floor assertion in this file therefore passes on pre-change code too;
+       * they are INVARIANT guards, and they say so.
+       *
+       * The clamp is observable on a card with NO menu, which carries no container
+       * query at all (see the action row's `hasMenu` gate). Its cluster is 137.9, so
+       * it needs 137.9 + 10 + 70 = 218px of container to hold both. Below that:
+       *   pre-change  → the rollup shrinks freely; at a 168px container it measures
+       *                 168 − 10 − 137.9 ≈ 20, a stub of two or three characters;
+       *   post-change → it stops at 70 and the ROW overflows instead (scrollWidth
+       *                 218 vs clientWidth 168).
+       *
+       * 🔴 THE OVERFLOW IS THE ACCEPTED COST, ASSERTED RATHER THAN HIDDEN. Trading a
+       * meaningless 20px stub for an overflow is only defensible because no store
+       * surface goes below 218: the 4-column `lg` grid bottoms out at 248, `base` is
+       * one wide column, and the moderator preview card is capped at 340 (308
+       * content). The width used here is a synthetic one no user reaches, chosen
+       * because it is the only width at which the constraint is visible at all.
+       */
+      test('🔴 the floor CLAMPS a menu-less rollup that would otherwise be a stub', async () => {
+        mocks.currentUser = null; // no menu → no container query → the clamp is the only guard
+        renderWithProviders(<Sized width={200} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+        await expect
+          .element(page.getByRole('link', { name: 'View details', exact: true }))
+          .toBeInTheDocument();
+        const { row, rollup } = actionRow('View details');
+        assertLayoutIsReal(row);
+        expect(Math.round(row.clientWidth)).toBe(168);
+        // No menu here — otherwise the query, not the clamp, would be what we measured.
+        expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+        expect(getComputedStyle(rollup).display).toBe('flex');
+        // 🔴 THE DISCRIMINATOR. Pre-change this measures ~20; the clamp holds it at 70.
+        expect(rollup.getBoundingClientRect().width).toBeCloseTo(LISTING_ROLLUP_MIN_WIDTH_PX, 0);
+        // …and the declared consequence, so nobody discovers it from a screenshot.
+        expect(row.scrollWidth).toBeGreaterThan(row.clientWidth);
+        expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+      });
+
+      /**
+       * 🔴 THE FLOOR SWEEP — one test PER WIDTH, deliberately, not a loop with
+       * `unmount()` between renders. This file already learned that the hard way:
+       * `.unmount()` fights the scaffold's global `afterEach(cleanup)` over the
+       * shared container and leaves EVERY subsequent test in the file rendering into
+       * an empty body. Separate tests also let each width fail independently instead
+       * of the first short-circuiting the rest.
+       *
+       * ⚠️ INVARIANT GUARD on the floor half — see the menu-less test above for why
+       * a card WITH a menu cannot distinguish "clamped at 70" from "70 is all there
+       * was". What it does pin as regression coverage is the hidden/displayed
+       * BOUNDARY and the 46px row height at every width.
+       */
+      describe('🔴 displayed ⇒ at or above the floor, swept across store widths', () => {
+        // 280 is the one width where the rollup is HIDDEN. It is in the sweep on
+        // purpose: a floor claim must not be satisfiable by a zero, so that arm
+        // asserts the zero explicitly and the others assert the floor.
+        const HIDDEN_AT = 280;
+        for (const width of [280, 296, 298, 314, 494]) {
+          test(`@${width} (container ${width - 32})`, async () => {
+            mocks.currentUser = OWNER;
+            renderWithProviders(<Sized width={width} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+            await expect
+              .element(page.getByRole('link', { name: 'View details', exact: true }))
+              .toBeInTheDocument();
+            const { row, rollup } = actionRow('View details');
+            assertLayoutIsReal(row);
+            expect(Math.round(row.clientWidth)).toBe(width - 32);
+            if (width === HIDDEN_AT) {
+              expect(getComputedStyle(rollup).display).toBe('none');
+              expect(rollup.getBoundingClientRect().width).toBe(0);
+            } else {
+              expect(getComputedStyle(rollup).display).toBe('flex');
+              expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+                LISTING_ROLLUP_MIN_WIDTH_PX - 0.5
+              );
+            }
+            // Row height is the other invariant every width has to hold.
+            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+          });
+        }
+      });
+
+      /**
+       * ⚠️ INVARIANT GUARD, NOT regression coverage — an anonymous viewer's card
+       * measured 95.7px here before the change and measures 95.7px after. It is here
+       * because the hide is scoped to cards that HAVE a menu, and a version that
+       * dropped that condition would delete the rollup from every anonymous
+       * shopper's card at the single most common desktop geometry — a failure no
+       * other test in this file could see.
+       *
+       * 🔴 SIGNED-OUT, and that is load-bearing rather than incidental: a signed-IN
+       * shopper now gets a `⋮` (Report, and Leave a review), so their card is on the
+       * OTHER side of this invariant. See the signed-in test below, which measures it
+       * rather than leaving it to be discovered.
+       */
+      test('⚠️ INVARIANT: at the SAME 1200 geometry a SIGNED-OUT card keeps its full rollup', async () => {
         mocks.currentUser = null;
         renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
         await expect
@@ -951,14 +1375,52 @@ describe('AppListingCard', () => {
         expect(Math.round(row.clientWidth)).toBe(248);
         expect(getComputedStyle(rollup).display).toBe('flex');
         // Literal pin from the measured table: 95.7px, i.e. the full natural width,
-        // because a non-owner action set is 138px rather than 184px.
+        // because a menu-less action set is 137.9px rather than 184px.
         expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
         const text = rollup.querySelector('[data-truncate]') as HTMLElement;
         expect(text.scrollWidth).toBeLessThanOrEqual(text.clientWidth);
+        // …and no trigger is what makes that true.
+        expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
       });
 
-      test('owner + "Open" (the narrower CTA) also keeps the rollup legible', async () => {
-        mocks.currentUser = { id: 5, username: 'alice' };
+      /**
+       * 🔴 THE GEOMETRY CONSEQUENCE OF THE MENU'S PREDICATE, MEASURED RATHER THAN
+       * ASSUMED — and it is NOT what the change was pitched as.
+       *
+       * The menu renders when it would hold at least one item, and
+       * `useCanReportListing` is `!!useCurrentUser()`. So an ORDINARY SIGNED-IN
+       * SHOPPER — the most common real viewer of the store — gets a `⋮`, and their
+       * action cluster goes from a 137.9px natural width to 184px, exactly like an
+       * owner's. Only a SIGNED-OUT viewer keeps the pre-change geometry.
+       *
+       * That is a real behaviour change on the most common path, so it is pinned
+       * here explicitly instead of being left to be discovered from a screenshot.
+       * Narrowing it — dropping review/report from the CARD's copy of the menu and
+       * leaving them on the detail page — is a one-line change to
+       * `useAppListingActionsMenuVisible`, and this test is where that decision
+       * would show up.
+       */
+      test('🔴 a SIGNED-IN shopper gets the menu, and the wider action cluster with it', async () => {
+        mocks.currentUser = SHOPPER;
+        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+        await expect
+          .element(page.getByRole('link', { name: 'View details', exact: true }))
+          .toBeInTheDocument();
+        const { row, actions, rollup } = actionRow('View details');
+        assertLayoutIsReal(row);
+        expect(Math.round(row.clientWidth)).toBe(248);
+        await expect
+          .element(page.getByTestId('apps-listing-card-actions-menu'))
+          .toBeInTheDocument();
+        // Same cluster width as an owner's, and the same consequence: below the
+        // threshold the rollup goes rather than being crushed.
+        expect(Math.round(actions.getBoundingClientRect().width)).toBe(248); // grown to fill
+        expect(getComputedStyle(rollup).display).toBe('none');
+        expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+      });
+
+      test('a menu card + "Open" (the narrower CTA) also keeps the rollup legible', async () => {
+        mocks.currentUser = OWNER;
         renderWithProviders(<Sized width={314} card={base(REVIEWED)} />);
         await expect
           .element(page.getByRole('link', { name: 'Open', exact: true }))
@@ -968,9 +1430,16 @@ describe('AppListingCard', () => {
         expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
       });
 
-      test('🔴 NON-owner cards are byte-unchanged — no icon Edit, same actions width', async () => {
-        // The whole change is owner-only. A non-owner card has no Edit control at
-        // all, so its geometry must be exactly what it was before this fix.
+      test('🔴 SIGNED-OUT cards are byte-unchanged — no menu, same actions width', async () => {
+        // The `⋮` is what widens the row, and an anonymous viewer has no menu at all,
+        // so this card's geometry must be exactly what it was before this change.
+        //
+        // 🔴 IT SURVIVES `flex-grow` ONLY BECAUSE THIS WIDTH IS IN DEFICIT, which is
+        // worth stating rather than being quietly lucky about: at 282 the reviewed
+        // rollup's natural 139.1 + 10 + 137.9 = 287 exceeds the row, so there is no
+        // free space for the CTA to grow into and the cluster stays at its natural
+        // 137.9. The same card at 462 measures 312.9 — the CTA filling the slack, on
+        // an anonymous card, which is the whole S7 change and is NOT a regression.
         mocks.currentUser = null;
         renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
         await expect
@@ -979,41 +1448,55 @@ describe('AppListingCard', () => {
         const { row, actions, rollup } = actionRow('View details');
         assertLayoutIsReal(row);
         expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
-        expect(page.getByTestId('apps-listing-owner-edit-icon').elements()).toHaveLength(0);
-        // Measured pre-fix values, pinned so an owner-side change cannot leak.
+        expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+        // Measured pre-change values, pinned so a menu-side change cannot leak.
         expect(Math.round(actions.getBoundingClientRect().width)).toBe(138);
         expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(130);
+        expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
       });
 
-      test('the icon-only Edit keeps a real accessible name and its href', async () => {
-        mocks.currentUser = { id: 5, username: 'alice' };
-        renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
-        const edit = page.getByTestId('apps-listing-owner-edit-icon');
-        await expect.element(edit).toBeInTheDocument();
-        // The glyph alone is not an accessible name (the CategoryFilterButtons
-        // precedent) — and the icon form must go to the SAME place as the text one.
-        await expect.element(edit).toHaveAttribute('aria-label', 'Edit');
-        await expect.element(edit).toHaveAttribute('href', '/apps/submit?edit=l1');
-        // …and it must not repeat the recents rail's `<a type="button">` leak.
-        // This one uses the polymorphic `component={Link}` rather than
-        // `renderRoot`, so Mantine knows the root is not a <button> and omits
-        // `type` — asserted rather than assumed, since the two paths differ.
-        expect((edit.element() as HTMLElement).getAttribute('type')).toBeNull();
-      });
-
-      test('the icon form is the one SHOWN at 280 and the text form at 460', async () => {
-        // The container query is what decides, so assert on rendered visibility
-        // rather than on which nodes exist.
-        mocks.currentUser = { id: 5, username: 'alice' };
-        const { rerender } = await renderWithProviders(
-          <Sized width={314} card={base(OFFSITE_CONNECT)} />
-        );
-        await expect.element(page.getByTestId('apps-listing-owner-edit-icon')).toBeVisible();
-        await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeVisible();
-
-        await rerender(<Sized width={494} card={base(OFFSITE_CONNECT)} />);
-        await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeVisible();
-        await expect.element(page.getByTestId('apps-listing-owner-edit-icon')).not.toBeVisible();
+      /**
+       * 🔴 THE CTA FILLS THE ROW — the S7 change itself, asserted where there IS free
+       * space, since the byte-unchanged test above deliberately sits where there is
+       * none.
+       *
+       * Pre-change the CTA was at its natural 137.9px at every width and the row's
+       * slack was simply empty. Measured on this branch at a 462px container: the
+       * anonymous card's cluster is 312.9 and the owner's CTA is 310.3, i.e. every
+       * pixel the rollup's natural width does not need.
+       */
+      describe('🔴 the primary CTA GROWS into the row', () => {
+        // Split by viewer rather than looped for the same `unmount()` reason as the
+        // sweep above. Both arms matter: a grow implemented on the menu's cluster
+        // only would leave every anonymous card unchanged.
+        for (const [label, user] of [
+          ['anonymous', null],
+          ['owner', OWNER],
+        ] as const) {
+          test(`${label} viewer at a 462px container`, async () => {
+            mocks.currentUser = user;
+            renderWithProviders(<Sized width={494} card={base(OFFSITE_CONNECT)} />);
+            await expect
+              .element(page.getByRole('link', { name: 'View details', exact: true }))
+              .toBeInTheDocument();
+            const { row, cta, rollup, actions } = actionRow('View details');
+            assertLayoutIsReal(row);
+            expect(Math.round(row.clientWidth)).toBe(462);
+            // Natural CTA width is 137.9; anything near that means it did not grow.
+            expect(cta.getBoundingClientRect().width).toBeGreaterThan(250);
+            // …and it grew into SLACK, not into the rollup: the rollup is at its full
+            // natural width here, well above the floor.
+            expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
+            // The row is exactly filled — no overflow, no gap at the right edge.
+            expect(actions.getBoundingClientRect().right).toBeCloseTo(
+              row.getBoundingClientRect().right,
+              0
+            );
+            expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
+            // The one thing growth must NOT do.
+            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+          });
+        }
       });
     });
 
@@ -1027,10 +1510,38 @@ describe('AppListingCard', () => {
       // attribute, because `textOverflow` computed to `clip` regardless.)
       expect(rollup.getAttribute('data-truncate')).toBe('end');
       expect(getComputedStyle(rollup).textOverflow).toBe('ellipsis');
-      // …and its container is the shrinkable side (`minWidth: 0` is what lets a
-      // flex item shrink below its content width at all), which is the actual
-      // mechanism that keeps the widened action buttons at natural size.
-      expect((rollup.parentElement as HTMLElement).style.minWidth).toBe('0px');
+      // …and its container is still the shrinkable side — but now with a FLOOR
+      // rather than `minWidth: 0`. Truncation is unaffected: the label sits inside
+      // the clamped box and ellipsises there. What changed is where the shrinking
+      // stops, and that is the property the growing CTA would otherwise erase.
+      expect((rollup.parentElement as HTMLElement).style.minWidth).toBe(
+        `${LISTING_ROLLUP_MIN_WIDTH_PX}px`
+      );
+    });
+
+    test('🔴 the clamped rollup still TRUNCATES rather than overflowing its box', async () => {
+      // The companion to the assertion above, and the half a style read cannot make:
+      // at the threshold the rollup is clamped to exactly its 70px floor, which is
+      // narrower than "No reviews yet" (79px natural) — so this is a width where the
+      // ellipsis has to be doing real work. A floor that stopped the label
+      // truncating would spill it out of the card instead.
+      mocks.currentUser = OWNER; // → a menu, → the clamp is reachable
+      renderWithProviders(
+        <Sized
+          width={296}
+          card={base({ kind: 'offsite', kindData: { kind: 'offsite', externalUrl: null } })}
+        />
+      );
+      await expect.element(page.getByText('No reviews yet')).toBeInTheDocument();
+      const text = page.getByText('No reviews yet').element() as HTMLElement;
+      const box = text.parentElement as HTMLElement;
+      assertLayoutIsReal(box);
+      expect(box.getBoundingClientRect().width).toBeCloseTo(LISTING_ROLLUP_MIN_WIDTH_PX, 0);
+      // The label is wider than the box it is in, and is clipped rather than spilling.
+      expect(text.scrollWidth).toBeGreaterThan(text.clientWidth);
+      expect(text.getBoundingClientRect().right).toBeLessThanOrEqual(
+        box.getBoundingClientRect().right + 1
+      );
     });
   });
 

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -281,7 +281,7 @@ export function AppListingCard({
   };
   // Whether the trigger occupies the action row. Read from the shared predicate
   // rather than re-derived — see its comment.
-  const hasMenu = useAppListingActionsMenuVisible(menuTarget, preview);
+  const hasMenu = useAppListingActionsMenuVisible(menuTarget, 'card', preview);
 
   // OWNER-ONLY incompleteness hint. The public store DTO carries only nullable
   // iconUrl/coverUrl (no screenshot count), so this is scoped to a below-floor
@@ -678,15 +678,27 @@ export function AppListingCard({
                 click target; a portalled dropdown still propagates along the REACT
                 tree, so opening the menu would otherwise navigate the card.
 
+                🔴 THE CARD DOES NOT OFFER THE VIEWER ACTIONS — `surface="card"`,
+                and `appListingMenuSurface.ts` owns that decision. Review and
+                Report stay on the listing DETAIL page, where the viewer has
+                chosen to look at one app; on a grid of ~24 tiles they are an
+                invitation to review something nobody opened. The narrowing is
+                declared by NAMING the surface, not by re-deriving a predicate
+                here — re-deriving one is precisely the drift the shared module
+                exists to prevent.
+
                 🔴 GEOMETRY CONSEQUENCE, ACCEPTED AND STATED: the menu's predicate
-                is "would it hold at least one item", not "is the viewer the
-                owner". So a MODERATOR viewing someone else's card gets a `⋮` and
-                therefore a different action-row geometry from an anonymous
-                shopper. That is the same predicate the detail page has always
-                applied, and re-deriving a narrower one here is precisely the
-                drift this shared module exists to prevent. */}
+                is still "would it hold at least one item", not "is the viewer the
+                owner". With the viewer actions gone from this surface, the items
+                that remain are the owner's Edit and the moderator section — so
+                the population that gets a `⋮`, and therefore the wider action
+                row, is exactly {owner, moderator}. Every other viewer, signed in
+                or signed out, gets the identical menu-less row. That equality is
+                pinned in `AppListingCard.browser.test.tsx` by running one
+                assertion body over both viewers. */}
             <AppListingActionsMenu
               listing={menuTarget}
+              surface="card"
               preview={preview}
               triggerSize={36}
               triggerVariant="default"

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -1,5 +1,4 @@
 import {
-  ActionIcon,
   Anchor,
   Avatar,
   Badge,
@@ -12,19 +11,22 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconApps, IconPencil, IconThumbUp } from '@tabler/icons-react';
+import { IconApps, IconThumbUp } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { type MouseEvent, useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import {
-  canOwnerEditListing,
+  LISTING_ROLLUP_MIN_WIDTH_PX,
   getListingCta,
   getListingDetailHref,
-  getOwnerEditHref,
   getRecommendLabel,
 } from '~/components/Apps/appListingCardView';
+import {
+  AppListingActionsMenu,
+  useAppListingActionsMenuVisible,
+} from '~/components/Apps/AppListingActionsMenu';
 import { ACTION_GLYPH_ICONS, cardActionGlyph } from '~/components/Apps/appListingActionGlyph';
 import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
@@ -236,9 +238,22 @@ export interface AppListingCardProps {
    * dead "Open" link (the `/apps/run/<slug>` route 404s without the flag).
    */
   canOpenPage?: boolean;
+  /**
+   * Moderator listing-media review renders this card READ-ONLY, over an
+   * UNAPPROVED shadow listing (`OffsiteReviewQueue`). Suppresses the `⋮` menu, for
+   * exactly the reason `AppListingDetailBody` takes the same prop: the reviewer IS
+   * a moderator, so without it a preview card would offer live takedown actions
+   * against a listing whose status — and whose `id` — are not guaranteed. See
+   * `appListingDetailModActions.detailListingStatus`.
+   */
+  preview?: boolean;
 }
 
-export function AppListingCard({ card, canOpenPage = false }: AppListingCardProps) {
+export function AppListingCard({
+  card,
+  canOpenPage = false,
+  preview = false,
+}: AppListingCardProps) {
   const currentUser = useCurrentUser();
   const cta = getListingCta(card, { canOpenPage });
   // 🔴 S6b — ONE glyph vocabulary, read from the shared module rather than a
@@ -251,13 +266,22 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
   const detailHref = getListingDetailHref(card.slug);
   const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
 
-  // Owner "Edit" deep-link (Item 2). The public store DTO is approved-only + has
-  // no status field, so gating is owner + editable-status (status omitted →
-  // editable); the href builder returns null when there's no editable target
-  // (an on-site listing with no backing appBlockId) → the button is hidden.
   const isOwner = !!currentUser?.id && currentUser.id === card.creator?.id;
-  const editHref = getOwnerEditHref(card.kindData, card.id);
-  const showEdit = canOwnerEditListing({ isOwner }) && !!editHref;
+
+  // The `⋮` overflow menu's target. Owner Edit — which used to be two hand-rolled
+  // buttons right here — now lives inside the SHARED `AppListingActionsMenu`,
+  // alongside review / report / the moderator section, so the card and the listing
+  // detail cannot drift apart about what the menu holds.
+  const menuTarget = {
+    id: card.id,
+    slug: card.slug,
+    kind: card.kind,
+    kindData: card.kindData,
+    creatorUserId: card.creator?.id ?? null,
+  };
+  // Whether the trigger occupies the action row. Read from the shared predicate
+  // rather than re-derived — see its comment.
+  const hasMenu = useAppListingActionsMenuVisible(menuTarget, preview);
 
   // OWNER-ONLY incompleteness hint. The public store DTO carries only nullable
   // iconUrl/coverUrl (no screenshot count), so this is scoped to a below-floor
@@ -270,8 +294,8 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
   ].filter((v): v is string => v != null);
   const showOwnerIncomplete = isOwner && missingFloorAssets.length > 0;
 
-  // `@container` makes THIS card the query basis for the owner-Edit breakpoint in
-  // the action row below (see the long note there). It is
+  // `@container` makes THIS card the query basis for the recommend-rollup floor
+  // breakpoint in the action row below (see the long note there). It is
   // `container-type: inline-size`, i.e. inline-axis containment only, so the
   // card's height still follows its content and `h-full` is unaffected.
   // 🔴 S4 — CHROME MATCHES THE SITE'S CARD, and every property below is
@@ -418,82 +442,120 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
           </Text>
         )}
 
-        {/* Feedback #2: the action row's buttons stepped up a notch on the Mantine
-            size scale (xs → sm), so the primary CTA reads as the card's call to
-            action rather than a footnote.
+        {/* ── THE ACTION ROW ────────────────────────────────────────────────
+            Feedback #2: the buttons sit one notch up the Mantine size scale (xs
+            → sm), so the primary CTA reads as the card's call to action rather
+            than a footnote. S7 then made the CTA FILL the row instead of
+            stepping up the size scale again — see the CTA's own note below.
+
             🔴 The row deliberately stays `nowrap`. Letting it wrap looks like the
             obvious way to stop the taller buttons overflowing a narrow column, but
             it breaks two things: (1) under `justify="space-between"` a wrapped line
             holding a single item sits at flex-START, so the actions would jump from
-            right-aligned to LEFT-aligned; and (2) an OWNER card (Edit + CTA) wraps
-            at a wider column than a non-owner card, so inside a `h-full` grid row
-            one owner card would grow the height of the whole row. Instead the
-            actions never shrink and the recommend rollup absorbs the pressure by
-            truncating — so every card in a row keeps the same geometry regardless
-            of who is looking at it. */}
+            right-aligned to LEFT-aligned; and (2) a card WITH a `⋮` menu wraps at a
+            wider column than one without, so inside a `h-full` grid row one such
+            card would grow the height of the whole row. Instead the actions never
+            shrink and the recommend rollup absorbs the pressure — down to a floor.
+
+            🔴 ROW HEIGHT IS A CONSTANT 46px AND MUST STAY ONE. `pt="xs"` (10px) +
+            a 36px control. Every control in the row is 36px: the `sm` CTA button
+            and the `size={36}` menu trigger. The row lives in an `h-full` grid
+            row, so a taller control here propagates to every card in that row
+            across the whole store — which is why the CTA grows HORIZONTALLY
+            rather than up the size scale. Re-measured after this change at
+            container 248 / 282 / 462: 46px in every cell. */}
         <Group justify="space-between" mt="auto" pt="xs" gap="xs" wrap="nowrap">
           {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". This is the
               flexible side: it may truncate so the actions never do.
 
-              🔴 …but ONLY DOWN TO A FLOOR. Truncation is the designed behaviour and
-              stays; what this container query removes is the state BELOW it, where
-              the rollup is squeezed so hard that the surviving glyphs say nothing.
-              Measured on this tree (main + #3547), OWNER card, the widest CTA
-              ("View details"), the store's real 4-column geometry:
+              🔴 …but ONLY DOWN TO A FLOOR, AND THE FLOOR IS NOW ENFORCED. It used
+              to be `minWidth: 0` — "shrink to nothing" — with the floor existing
+              only as the arithmetic behind the container query below. That was
+              survivable while nothing competed for the free space. It is not
+              survivable now that the CTA GROWS into it: a `flex-grow` on the CTA
+              with a zero-floor rollup starves the rollup at EVERY width, not just
+              the narrow ones the query was built for — i.e. the obvious
+              implementation of "make the CTA fill the row" destroys the exact
+              thing the query exists to protect. So the floor is stated as a
+              constraint the layout engine enforces (`minWidth:
+              LISTING_ROLLUP_MIN_WIDTH_PX`), and the CTA takes only the remainder.
 
-                | card | container | actions | rollup | text px / natural | truncated |
-                |------|-----------|---------|--------|-------------------|-----------|
-                |  280 |       248 |     184 |     54 |          37 / 79  | YES       |
-                |  300 |       268 |     184 |     74 |          57 / 79  | yes       |
-                |  314 |       282 |     184 |     88 |          71 / 79  | yes       |
-                |  330 |       298 |     184 |     96 |          79 / 79  | no        |
+              🔴 THE TABLE BELOW WAS RE-MEASURED ON THIS BRANCH — it is not the
+              pre-change one carried forward. A card WITH a menu, the widest CTA
+              ("View details"), no reviews (the SHORTEST label the rollup can
+              carry, so a deficit here is structural rather than an artefact of a
+              long string). Widths are `getBoundingClientRect`:
 
-              (Widths are `getBoundingClientRect`; "truncated" is `scrollWidth >
-              clientWidth` on the `<Text truncate>`. Character counts below are
-              DERIVED from the text px at 12px, not read off a screenshot — the
-              live report is what confirmed the top row renders as "No ...".)
+                | card | container | actions nat/rendered | rollup | row h | rollup    |
+                |------|-----------|----------------------|--------|-------|-----------|
+                |  280 |       248 | 184 /  248 (grown)   |    0   |    46 | HIDDEN    |
+                |  296 |       264 | 184 /  184           |   70.1 |    46 | at FLOOR  |
+                |  314 |       282 | 184 /  184           |   88.1 |    46 | clamped   |
+                |  494 |       462 | 184 /  356.3 (grown) |   95.7 |    46 | natural   |
 
-              A 37px stub of "No reviews yet" is strictly worse than no rollup: it
-              occupies the slot, reads as a rendering bug, and carries no
-              information. 54px is the state the live 1200px-viewport store is in
-              today: card 280 is `(1200 − 32 container padding − 3×16 gutter) / 4`,
-              i.e. the 4-column `lg` span at a 1200px viewport.
+              Two columns for the actions because they are now two different
+              numbers: 184 is the cluster's NATURAL width (36px `⋮` + 10px gap +
+              137.9px CTA), which is what the threshold arithmetic below is built
+              from; the RENDERED width is larger wherever the row has free space
+              for the CTA to grow into. In the two middle rows the row is in
+              DEFICIT, so there is no growth and the two coincide.
 
-              🔴 THRESHOLD 264px, DERIVED NOT GUESSED. The floor we want is a rollup
-              box of ~70px = the 13px thumb glyph + its 4px gap + ~53px of 12px text,
-              which is ~9 characters — enough for "No reviews…" / "91% recom…" to
-              read as a phrase rather than as debris. The owner action set at its
-              WIDEST (icon-only Edit + "View details") measures 184px, and the row
-              gap is 8px, so the container width at which the rollup hits that floor
-              is 184 + 8 + 70 = 262 → 264. The model predicts the measured table
-              above to within ~2px at every row, which is why it is stated as
-              arithmetic instead of as a round number that happened to look right.
+              The 264 row is the one that matters: 70.1px is
+              `LISTING_ROLLUP_MIN_WIDTH_PX` doing work, not a coincidence of the
+              content. The same card at 462 leaves the rollup at its natural 95.7
+              and gives the CTA the other 260 — which is the whole point of the
+              change: the CTA grows into the slack, it does not eat the floor.
 
-              🔴 A CONTAINER query, for the same reason the owner-Edit swap below is
-              one: card width is NOT monotonic in viewport width (at `base` the grid
-              is ONE column, so a 390px phone gives a ~356px card — wider than the
-              280px a 1200px laptop gets at four columns). A `max-width` media query
-              would hide the rollup on exactly the viewports with the most room.
+              ⚠️ A CORNER THIS CREATES, on the record: an enforced floor means a
+              row can OVERFLOW instead of crushing the rollup. A card with no menu
+              needs 137.9 + 10 + 70 = 218px of container to hold both; measured at
+              a synthetic 168px container the row's `scrollWidth` is 218 against a
+              `clientWidth` of 168. No store surface produces that — the 4-column
+              `lg` grid bottoms out at 248, the `base` grid is one wide column, and
+              the moderator preview card is capped at 340 (308 content) — and a
+              card WITH a menu already overflowed at that width before this change
+              (its 184px cluster alone exceeds 168). Pinned at 248, the narrowest
+              width the store can actually produce, rather than left to prose.
 
-              🔴 OWNER CARDS ONLY (`showEdit`). A non-owner card has no Edit control,
-              so its actions are 138px and the rollup never drops below 96px at any
-              width the store produces — it is byte-unchanged by this and must stay
-              that way.
+              🔴 THRESHOLD 264px, DERIVED NOT GUESSED, AND NOW MACHINE-CHECKED.
+              `LISTING_ROLLUP_HIDE_BELOW_PX` in `appListingCardView.ts` computes
+              it as actions(184) + row gap(10) + floor(70) = 264, and
+              `__tests__/appListingCardView.test.ts` asserts this file's
+              `@[264px]` class spells the same number — a Tailwind arbitrary
+              variant cannot read a JS constant, so the duplication is
+              unavoidable and the drift is what gets gated instead.
 
-              ⚠️ ACCEPTED COLLATERAL, on the record rather than discovered later: the
-              query cannot see WHICH CTA rendered, and the narrow "Open" CTA (actions
-              140px) leaves the rollup its full 96px even at container 248 — measured,
-              untruncated at every width in the sweep. So an owner card
-              whose CTA is "Open"/"Visit" loses a rollup that would have fit, across
-              container 248–264 (viewport ~1200–1264 at four columns). Encoding a
-              second per-CTA threshold to reclaim that 64px band buys a second magic
-              number and a CTA-width classification in the render path; one rule that
-              is occasionally conservative is the better trade. */}
+              The 184 is MEASURED, not modelled: a 36px `⋮` trigger + the row's
+              10px `gap="xs"` + the widest CTA at its natural 138px. It happens to
+              equal the pre-change value, because the control the menu replaced was
+              an icon-only Edit `ActionIcon` at the same `size={36}` — worth naming,
+              because "the number did not move" is also what a measurement nobody
+              took looks like.
+
+              🔴 A CONTAINER query, not a media query: card width is NOT monotonic
+              in viewport width (at `base` the grid is ONE column, so a 390px phone
+              gives a ~356px card — wider than the 280px a 1200px laptop gets at
+              four columns). A `max-width` media query would hide the rollup on
+              exactly the viewports with the most room.
+
+              🔴 GATED ON `hasMenu`, NOT ON OWNERSHIP. It used to be `showEdit`,
+              because the Edit button was the only thing that widened the row.
+              The `⋮` trigger is now that thing, and it appears for anyone the menu
+              has an item for. A card with NO menu keeps its 138px action cluster
+              and its rollup never approaches the floor at any width the store
+              produces — byte-unchanged, and pinned as such.
+
+              ⚠️ ACCEPTED COLLATERAL, on the record rather than discovered later:
+              the query cannot see WHICH CTA rendered, so a card whose CTA is the
+              narrow "Open" loses a rollup that would have fit, across container
+              248–264. Encoding a second per-CTA threshold buys a second magic
+              number and a CTA-width classification in the render path; one rule
+              that is occasionally conservative is the better trade. */}
           <Group
             gap={4}
             wrap="nowrap"
-            style={{ minWidth: 0 }}
-            className={showEdit ? 'hidden @[264px]:flex' : undefined}
+            style={{ minWidth: LISTING_ROLLUP_MIN_WIDTH_PX }}
+            className={hasMenu ? 'hidden @[264px]:flex' : undefined}
           >
             <IconThumbUp
               size={13}
@@ -505,95 +567,42 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             </Text>
           </Group>
 
-          {/* 🔴 `marginLeft: 'auto'` is what keeps the actions RIGHT-ALIGNED when the
-              rollup above is `display: none`. `justify="space-between"` distributes
-              a SINGLE remaining flex item to flex-START, so without this the whole
-              action group jumps to the left edge of the card the moment the rollup
-              is hidden — the exact left-alignment failure the block comment above
-              warns wrapping would cause, reintroduced by a different mechanism.
-              With BOTH children present it is a no-op: auto margins absorb free
-              space before `justify-content` is applied, and one auto margin on the
-              second of two items lands them in precisely the space-between
-              positions. Verified by measurement at both container widths, not
-              assumed. */}
-          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0, marginLeft: 'auto' }}>
-            {/* Owner-only "Edit" deep-link — subtle secondary action, gated by
-                owner + editable status (mod-removed listings hide it). Routes by
-                kind (manifest editor for on-site, submit editor for off-site).
+          {/* 🔴 `flexGrow: 1` IS WHAT MAKES THE CTA FILL THE ROW, and it is on the
+              CLUSTER rather than on the button alone because the button is not a
+              direct child of the row — the `⋮` trigger shares the cluster with it.
+              The cluster grows, the fixed-width trigger does not, so the whole
+              remainder lands on the CTA (which carries its own `flexGrow: 1`).
 
-                🔴 TWO FORMS, ONE CHOSEN BY A CONTAINER QUERY. Measured at a 280px
-                card content box — what a 1200px viewport produces at the store's
-                4-column `xl` grid:
+              🔴 `flexShrink: 0` STAYS. Growth and shrink are independent here and
+              only growth is wanted: the actions are the rigid side, and the rollup
+              — clamped at its floor — is the side that gives. Below the container
+              query's threshold the rollup leaves layout entirely rather than the
+              actions being squeezed.
 
-                  | case @280                  | actions | rollup | rollup text |
-                  |----------------------------|---------|--------|-------------|
-                  | non-owner + "Open"         |      94 |    139 |         122 |
-                  | non-owner + "View details" |     138 |    132 |         115 |
-                  | owner + "Open"             |     188 |     82 |          65 |
-                  | owner + "View details"     |     232 |     38 |          21 |
-
-                The rollup's natural width is 139. In the last row the CTA icons'
-                ~44px pushed it to 38 and "91% recommend (100)" — glyph included —
-                simply vanished. Collapsing the OWNER-ONLY Edit to an icon returns
-                ~50px, which is the difference between truncated and absent.
-
-                🔴 A CONTAINER query, not a media query: the card's width is NOT
-                monotonic in viewport width. At `base` the grid is ONE column, so a
-                390px phone gives a WIDER card (~356) than a 1200px laptop at four
-                columns (280). A `max-width` media query would collapse the button
-                on exactly the viewports where there is the most room. `@container`
-                asks the only question that matters — how wide is THIS card.
-
-                Breakpoint 360px, read off the table: the owner "View details" cell
-                is the binding one, and its rollup clears ~120px (legible, merely
-                truncated) at container widths from ~360 up. Below that the text
-                button is what breaks it, so below that it becomes an icon.
-
-                🔴 The row stays `nowrap` with `flexShrink: 0`. Row height is a
-                constant 46px in every cell above and nothing overflows — letting
-                the row wrap would left-align the actions and grow the height of a
-                whole `h-full` grid row (see the block comment above). The fix is
-                to make the optional control smaller, not to change the layout. */}
-            {showEdit && editHref && (
-              <>
-                <Button
-                  component={Link}
-                  href={editHref}
-                  size="sm"
-                  variant="default"
-                  leftSection={<IconPencil size={16} />}
-                  data-testid="apps-listing-owner-edit"
-                  className="hidden @[360px]:flex"
-                  onClick={(e: MouseEvent) => e.stopPropagation()}
-                >
-                  Edit
-                </Button>
-                {/* The narrow form. Icon-only, so it needs a REAL accessible name
-                    — `aria-label` + `Tooltip`, the `CategoryFilterButtons`
-                    precedent ("the icon alone is not an accessible name"). Only
-                    ONE of the two is ever displayed, and `display: none` removes
-                    the other from the accessibility tree, so a screen reader is
-                    offered exactly one "Edit" control, not two. */}
-                <Tooltip label="Edit" withArrow>
-                  <ActionIcon
-                    component={Link}
-                    href={editHref}
-                    size={36}
-                    variant="default"
-                    aria-label="Edit"
-                    data-testid="apps-listing-owner-edit-icon"
-                    className="@[360px]:hidden"
-                    onClick={(e: MouseEvent) => e.stopPropagation()}
-                  >
-                    <IconPencil size={16} />
-                  </ActionIcon>
-                </Tooltip>
-              </>
-            )}
-
+              🔴 `marginLeft: 'auto'` is RETAINED THOUGH NOW REDUNDANT, deliberately.
+              With `flexGrow: 1` the cluster already reaches the row's right edge, so
+              the auto margin currently absorbs zero free space (flexible lengths are
+              resolved BEFORE auto margins). It stays because it is the thing that
+              keeps the actions right-aligned if the grow is ever removed: under
+              `justify="space-between"` a SINGLE remaining flex item sits at
+              flex-START, so with the rollup hidden and no grow and no auto margin,
+              the whole CTA cluster jumps to the card's left edge. Two independent
+              mechanisms for one invariant, both cheap. */}
+          <Group
+            gap="xs"
+            wrap="nowrap"
+            style={{ flexShrink: 0, flexGrow: 1, minWidth: 0, marginLeft: 'auto' }}
+          >
             {/* Kind-aware CTA — always has a working target (a direct Open / Visit,
                 or the unified detail). External Visit → new-tab anchor; everything
                 else → an internal Link.
+
+                🔴 IT FILLS THE ROW RATHER THAN STEPPING UP THE SIZE SCALE. The ask
+                was a bigger primary action; the next Mantine size (`md`) is 42px
+                tall, and this row's height is load-bearing (see the row note
+                above), so the only free axis is horizontal. `flexGrow: 1` inside a
+                cluster that itself grows gives the CTA every pixel the rollup's
+                floor and the `⋮` trigger do not need.
 
                 ICONS (product-feedback pass). Each action carries its own glyph so
                 the three CTAs are distinguishable at a glance in a dense grid
@@ -611,15 +620,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 name. Tabler icons render `<svg>` with no `<title>`, so they
                 contribute nothing to the name; the button's name is still
                 exactly "Open" / "Visit" / "View details". Asserted in
-                `AppListingCard.browser.test.tsx`.
-
-                🔴 WIDTH: `leftSection` makes each button ~22px wider, and the row
-                is `wrap="nowrap"` with `flexShrink: 0` on the actions (see the
-                block comment above — wrapping breaks alignment AND row height).
-                The pressure is absorbed where it was designed to be: the
-                recommend rollup on the left is the flexible side and truncates.
-                The tight case is `md`/`lg` (3–4 columns), not `base` (one wide
-                column); verified at 390/768/1440/2560 in the PR's viewport sweep. */}
+                `AppListingCard.browser.test.tsx`. */}
             {cta.external ? (
               <Button
                 component="a"
@@ -628,6 +629,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 rel="noopener noreferrer"
                 size="sm"
                 variant="light"
+                style={{ flexGrow: 1 }}
                 rightSection={<CtaGlyph size={16} />}
                 // "Opened" = actually opened. An OFF-SITE app is opened the
                 // moment this Visit CTA is followed — there is no on-platform
@@ -648,11 +650,51 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 href={cta.href}
                 size="sm"
                 variant={cta.action === 'open' ? 'filled' : 'light'}
+                style={{ flexGrow: 1 }}
                 leftSection={<CtaGlyph size={16} />}
               >
                 {cta.label}
               </Button>
             )}
+
+            {/* The `⋮` overflow menu — owner Edit, review, report, moderator
+                actions. SHARED with the listing detail body; see
+                `AppListingActionsMenu`.
+
+                🔴 IT REPLACED A DUAL EDIT APPARATUS AND A WHOLE BREAKPOINT. The
+                card used to carry BOTH a text `Button` ("Edit") and an icon-only
+                `ActionIcon`, with an `@[360px]` container query choosing between
+                them — a query that existed for no other reason. A `⋮` trigger is a
+                fixed 36px at every width, so that query had nothing left to decide
+                and is DELETED rather than kept as a constant nothing needs.
+
+                🔴 `size={36}` IS THE ROW-HEIGHT CONTRACT, not a style choice — it
+                matches the `sm` CTA button exactly, which is what keeps the row at
+                46px (see the row note above). `variant="default"` matches the
+                control it replaced.
+
+                🔴 `stopPropagation` covers the trigger AND the dropdown. Every
+                other action on this card stops propagation because the card is a
+                click target; a portalled dropdown still propagates along the REACT
+                tree, so opening the menu would otherwise navigate the card.
+
+                🔴 GEOMETRY CONSEQUENCE, ACCEPTED AND STATED: the menu's predicate
+                is "would it hold at least one item", not "is the viewer the
+                owner". So a MODERATOR viewing someone else's card gets a `⋮` and
+                therefore a different action-row geometry from an anonymous
+                shopper. That is the same predicate the detail page has always
+                applied, and re-deriving a narrower one here is precisely the
+                drift this shared module exists to prevent. */}
+            <AppListingActionsMenu
+              listing={menuTarget}
+              preview={preview}
+              triggerSize={36}
+              triggerVariant="default"
+              triggerIconSize={16}
+              triggerTestId="apps-listing-card-actions-menu"
+              triggerTooltip
+              stopPropagation
+            />
           </Group>
         </Group>
       </Stack>

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -504,6 +504,18 @@ describe('AppListingDetailBody', () => {
     ).toBe('/apps/submit?edit=l1');
   });
 
+  /**
+   * 🔴 THIS IS ALSO THE SURFACE GUARD, AND IT IS THE HALF THAT MUST NOT REGRESS.
+   *
+   * The store CARD stopped offering these two items — `surface="card"`, decided in
+   * `appListingMenuSurface.ts` — because on a grid of ~24 tiles they invite a viewer
+   * to review an app they have not opened. The DETAIL page is the surface those
+   * items are FOR, and the narrowing is only correct if it left this one alone. So
+   * this test is the other side of `AppListingCard.browser.test.tsx`'s "a signed-in
+   * NON-owner, NON-moderator gets NO menu on the CARD": the same viewer, the same
+   * two items, opposite expected answers. A change that tightened the gate globally
+   * — the obvious wrong implementation — passes the card test and fails this one.
+   */
   test('🔴 a signed-in NON-owner gets Review + Report, and NO Edit', async () => {
     mocks.currentUser = { id: 999, username: 'bob' };
     const { within } = await renderScoped(<AppListingDetailBody detail={base({})} />);

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -10,28 +10,19 @@ import {
   Divider,
   Group,
   Image,
-  Menu,
   SimpleGrid,
   Stack,
   Text,
   Title,
   UnstyledButton,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import {
   IconApps,
   IconArrowLeft,
-  IconDotsVertical,
   IconDownload,
-  IconEyeOff,
-  IconFlag,
   IconFlask,
   IconInfoCircle,
-  IconMail,
-  IconPencil,
   IconPlugConnected,
-  IconRefresh,
-  IconShieldCheck,
   IconThumbUp,
 } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
@@ -47,24 +38,12 @@ import { ACTION_GLYPH_ICONS, detailActionGlyph } from '~/components/Apps/appList
 import { buildListingDetailRows } from '~/components/Apps/appListingDetailRows';
 import { buildListingStatChips, type ListingStatChip } from '~/components/Apps/appListingStatChips';
 import {
-  canOwnerEditListing,
   type DetailActionMode,
   getDetailPrimaryAction,
-  getOwnerEditHref,
   shouldShowConnectCapability,
   shouldShowOffsiteDisclosure,
 } from '~/components/Apps/appListingDetailView';
-import {
-  DETAIL_TAKEDOWN_ACTIONS,
-  REVIEW_QUEUE_MANAGE_HREF,
-  TAKEDOWN_TESTID_STEM,
-  appListingDetailModActions,
-  detailModActionLabel,
-  type DetailTakedownAction,
-} from '~/components/Apps/appListingDetailModActions';
-import { MessageAppOwnerModal } from '~/components/Apps/MessageAppOwnerModal';
-import { ListingTakedownModal } from '~/components/Apps/ListingTakedownModal';
-import { isAppReviewer } from '~/shared/utils/app-blocks-access';
+import { AppListingActionsMenu } from '~/components/Apps/AppListingActionsMenu';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
 import { recordRecentlyOpenedApp } from '~/components/Apps/recentlyOpenedAppsStore';
 import { AppListingScreenshotViewer } from '~/components/Apps/AppListingScreenshotViewer';
@@ -78,12 +57,6 @@ import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { ListingCollaboratorByline } from '~/components/Apps/ListingCollaboratorByline';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AppListingComments } from '~/components/Apps/AppListingComments';
-import {
-  ReportListingModal,
-  useCanReportListing,
-  useReportListingAffordance,
-} from '~/components/Apps/ReportListingModal';
-import { ReviewListingModal, useCanReviewListing } from '~/components/Apps/ReviewListingButton';
 import { AppListingDescription } from '~/components/Apps/AppListingDescription';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
@@ -91,7 +64,6 @@ import { ContainerGrid2 } from '~/components/ContainerGrid/ContainerGrid';
 import { ContentClamp } from '~/components/ContentClamp/ContentClamp';
 import { SmartCreatorCard } from '~/components/CreatorCard/CreatorCard';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
-import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { StatHoverCard } from '~/components/Stats/StatHoverCard';
 import {
   isMarketplaceCategory,
@@ -884,72 +856,18 @@ export function AppListingDetailBody({
   canOpenPage = false,
   preview = false,
 }: AppListingDetailBodyProps) {
-  const currentUser = useCurrentUser();
-
-  // Owner "Edit" deep-link (Item 2) — owner + editable status (approved-only read
-  // path carries no status → editable); the href builder returns null when there
-  // is no editable target (on-site listing with no backing appBlockId).
-  const isOwner = !!currentUser?.id && currentUser.id === detail.creator?.id;
-  const editHref = getOwnerEditHref(detail.kindData, detail.id);
-  const showEdit = canOwnerEditListing({ isOwner }) && !!editHref;
-
-  // 🔴 The review / report modals are owned HERE, not by their trigger. A Mantine
-  // `Menu.Dropdown` is unmounted when the menu closes, so a modal rendered as a
-  // sibling of its `Menu.Item` would be destroyed by the click that opens it. The
-  // gates are the SAME predicates each affordance defines (`useCanReviewListing` /
-  // `useCanReportListing`), imported rather than re-derived, so the menu cannot
-  // disagree with them about who may act.
+  // 🔴 THE `⋮` MENU — ITEM SET, ORDER, LABELS, GATING AND MODALS — LIVES IN THE
+  // SHARED `AppListingActionsMenu`, NOT HERE. It used to be written out inline in
+  // this file; the store CARD now renders the same menu, and a second copy is
+  // exactly how these two surfaces drifted over the CTA glyph mapping (which had
+  // to be pulled out into `appListingActionGlyph.ts` after the fact). Everything
+  // the old block explained — why the modals are siblings of the `Menu` rather
+  // than of a `Menu.Item`, why the report affordance's two prop bags must both be
+  // spread, why the mod set is an intersection rather than a hand-rolled list —
+  // moved with the code and is documented there.
   //
-  // 🔴 The report affordance's STATE comes from `useReportListingAffordance` rather
-  // than a bare `useDisclosure` here, and that is the fix for a shipped defect: the
-  // server allows one open report per reporter, so once a report lands the trigger
-  // has to go spent ("Reported", disabled) or the next click returns a CONFLICT the
-  // user reads as a failure. That rule used to live in a standalone `ReportListingButton`
-  // nothing rendered, while this — the live path — mounted the modal with no
-  // `onReported` and kept its menu item live. Spread BOTH bags; do not hand-roll
-  // either half.
-  // `detail.kind` is threaded in so the affordance obeys the SAME store-scope kind
-  // rule the write gate applies — an external-only viewer is not offered a review
-  // control on an onsite listing the server would NOT_FOUND.
-  const canReview = useCanReviewListing({
-    ownerUserId: detail.creator?.id ?? null,
-    listingKind: detail.kind,
-  });
-  const canReport = useCanReportListing();
-  const report = useReportListingAffordance();
-  const [reviewOpened, reviewModal] = useDisclosure(false);
-
-  // MODERATOR section of the same menu. The action SET is derived, never hand-rolled:
-  // `appListingDetailModActions` intersects the shared lifecycle state machine
-  // (`listingModActions`, which the /apps/review mgmt table also depends on) with the
-  // subset this surface implements, and answers empty for a non-moderator and in
-  // preview. See that module for why `relist` can never appear here.
-  //
-  // 🔴 The gate is `isAppReviewer` — the existing named predicate the /apps/review page
-  // and `IframeHost` already use — NOT an inlined `isModerator`. It is COSMETIC: every
-  // proc behind these items is `moderatorProcedure` plus an inner `isModerator` recheck,
-  // which is the actual boundary.
-  const isModerator = isAppReviewer(currentUser);
-  const modActions = appListingDetailModActions({
-    isModerator,
-    preview,
-    kind: detail.kind,
-  });
-
-  // 🔴 Both mod modals are owned HERE for the same structural reason the review/report
-  // pair above is: a Mantine `Menu.Dropdown` UNMOUNTS when the menu closes, so a modal
-  // rendered as a sibling of its `Menu.Item` is destroyed by the click that opens it.
-  // Each holds the LISTING (nullable) rather than a boolean, matching the contract
-  // `MessageAppOwnerModal` already defines for its one other call site.
-  //
-  // 🔴 The TAKEDOWN pair shares ONE piece of state holding WHICH action is open, rather
-  // than a boolean each. Two booleans can both be true; this cannot, so "the hide confirm
-  // and the unpublish confirm are open at once" is unrepresentable instead of merely
-  // unlikely — and the two confirms differ only in which mutation they fire, so a viewer
-  // seeing both would have no way to tell which one they were about to submit.
-  const modListing = { appListingId: detail.id, slug: detail.slug, kind: detail.kind };
-  const [messageOpened, messageModal] = useDisclosure(false);
-  const [takedown, setTakedown] = useState<DetailTakedownAction | null>(null);
+  // What stays here is only what is TRUE OF THIS SURFACE: the trigger's geometry
+  // (Mantine's default size + a 20px glyph, `variant="light"`), and `preview`.
 
   // Hero click-to-launch — the banner is an affordance for the SAME destination
   // as the primary CTA, derived FROM that CTA (`getDetailPrimaryAction`) rather
@@ -973,11 +891,6 @@ export function AppListingDetailBody({
     !preview && primaryAction.mode === 'open' && !primaryAction.external && primaryAction.href
       ? primaryAction.href
       : null;
-
-  // `modActions` is already empty in preview, so the leading `!preview` is not what
-  // suppresses the mod section — it is the pre-existing clause that suppresses the whole
-  // menu, kept verbatim.
-  const showMenu = !preview && (showEdit || canReview || canReport || modActions.length > 0);
 
   return (
     <Stack gap="lg">
@@ -1070,138 +983,21 @@ export function AppListingDetailBody({
 
           {/* Overflow menu — the secondary actions, collapsed. Replaces the stacked
               full-width button column; the PRIMARY action stays a real button in the
-              right-rail action card, never buried in here. */}
-          {showMenu && (
-            <Box style={{ flexShrink: 0 }}>
-              <Menu
-                position="bottom-end"
-                transitionProps={{ transition: 'pop-top-right' }}
-                withinPortal
-              >
-                <Menu.Target>
-                  <LegacyActionIcon
-                    variant="light"
-                    aria-label="App options"
-                    data-testid="apps-listing-actions-menu"
-                  >
-                    <IconDotsVertical size={20} />
-                  </LegacyActionIcon>
-                </Menu.Target>
-                <Menu.Dropdown>
-                  {/* Owner-only "Edit" deep-link, gated by owner + editable status
-                      (mod-removed listings hide it). Routes by kind (manifest editor
-                      for on-site, submit editor for off-site). */}
-                  {showEdit && editHref && (
-                    <Menu.Item
-                      component={Link}
-                      href={editHref}
-                      leftSection={<IconPencil size={14} stroke={1.5} />}
-                      data-testid="apps-listing-owner-edit"
-                    >
-                      Edit
-                    </Menu.Item>
-                  )}
-                  {/* Review affordance (thumbs/recommend) — hidden for the owner, signed-out
-                      viewers, AND viewers whose resolved store scope does not admit this
-                      listing's kind, all by `useCanReviewListing`. The write proc is
-                      protected + STORE-SCOPE-gated (not flag-gated — that spelling was the
-                      defect) + self-review-blocked server-side. */}
-                  {canReview && (
-                    <Menu.Item
-                      leftSection={<IconThumbUp size={14} stroke={1.5} />}
-                      onClick={reviewModal.open}
-                      data-testid="apps-listing-review-action"
-                    >
-                      Leave a review
-                    </Menu.Item>
-                  )}
-                  {/* Report affordance — dark behind the mod-only store surface; the
-                      proc is protected + rate-limited + reporter-bound server-side.
-                      🔴 `triggerProps` carries BOTH the click and the spent `disabled`
-                      state; the modal below carries its `onReported` counterpart. The
-                      pair is what stops a second report from returning the server's
-                      one-open-report-per-reporter CONFLICT as an error toast. */}
-                  {canReport && (
-                    <Menu.Item
-                      color="red"
-                      leftSection={<IconFlag size={14} stroke={1.5} />}
-                      {...report.triggerProps}
-                      data-testid="apps-listing-report-action"
-                    >
-                      {report.label}
-                    </Menu.Item>
-                  )}
-                  {/* MODERATOR section — divided and labelled so a mod action is never
-                      one slot away from a reader's "Leave a review". The set comes from
-                      `appListingDetailModActions`; the ORDER is that function's
-                      (Contact before the lifecycle action), and the review-queue link
-                      is last because it navigates away rather than acting. */}
-                  {modActions.length > 0 && (
-                    <>
-                      <Menu.Divider />
-                      <Menu.Label>Moderator</Menu.Label>
-                      {modActions.includes('message-owner') && (
-                        <Menu.Item
-                          leftSection={<IconMail size={14} stroke={1.5} />}
-                          onClick={messageModal.open}
-                          data-testid="apps-listing-mod-message-owner"
-                        >
-                          {detailModActionLabel('message-owner')}
-                        </Menu.Item>
-                      )}
-                      {/* The TAKEDOWN pair, rendered by mapping the canonical order
-                          rather than as two hand-written branches: the two items differ
-                          only in which action they carry, so writing them out twice is
-                          how one of them ends up wired to the other's label or testid.
-                          Each still renders only if `modActions` admits it. */}
-                      {DETAIL_TAKEDOWN_ACTIONS.filter((a) => modActions.includes(a)).map(
-                        (action) => (
-                          <Menu.Item
-                            key={action}
-                            color="red"
-                            leftSection={
-                              action === 'hide' ? (
-                                <IconEyeOff size={14} stroke={1.5} />
-                              ) : (
-                                <IconRefresh size={14} stroke={1.5} />
-                              )
-                            }
-                            onClick={() => setTakedown(action)}
-                            data-testid={`${TAKEDOWN_TESTID_STEM[action]}-menu-item`}
-                          >
-                            {detailModActionLabel(action)}
-                          </Menu.Item>
-                        )
-                      )}
-                      {/* 🔴 THE INVERSE AFFORDANCE, AND IT IS A LINK RATHER THAN A
-                          BUTTON ON PURPOSE. There is no relist/republish control here
-                          because there cannot be one: `relistListing` acts on a
-                          `removed` listing, this page's read is approved-only, and a
-                          removed listing 404s before the body mounts. So the honest way
-                          back is the surface that CAN see a removed listing — the
-                          /apps/review mgmt table, which already carries Relist (and
-                          Claim/Purge) for exactly that state. See
-                          `appListingDetailModActions.detailListingStatus`.
+              right-rail action card, never buried in here.
 
-                          🔴 THE `?tab=manage` IS LOAD-BEARING — a bare `/apps/review`
-                          resolves to the PENDING tab, and Relist is on the manage tab.
-                          The href is a named constant so the destination this menu
-                          promises is pinned in the blocking tier rather than typed
-                          inline. */}
-                      <Menu.Item
-                        component={Link}
-                        href={REVIEW_QUEUE_MANAGE_HREF}
-                        leftSection={<IconShieldCheck size={14} stroke={1.5} />}
-                        data-testid="apps-listing-mod-manage"
-                      >
-                        Manage in review queue
-                      </Menu.Item>
-                    </>
-                  )}
-                </Menu.Dropdown>
-              </Menu>
-            </Box>
-          )}
+              🔴 SHARED WITH THE STORE CARD. This renders `AppListingActionsMenu`; the
+              item set, order, labels, eligibility gates and modal ownership all live
+              there. Only the trigger's geometry is this surface's own. */}
+          <AppListingActionsMenu
+            listing={{
+              id: detail.id,
+              slug: detail.slug,
+              kind: detail.kind,
+              kindData: detail.kindData,
+              creatorUserId: detail.creator?.id ?? null,
+            }}
+            preview={preview}
+          />
         </Group>
 
         {/* META LINE — `Updated: <date>` │ category, exactly as the model page renders
@@ -1421,54 +1217,6 @@ export function AppListingDetailBody({
           preview (a shadow listing has no thread; loading it would 404/N+1). */}
       {!preview && (
         <AppListingComments serialId={detail.serialId} ownerUserId={detail.creator?.id ?? null} />
-      )}
-
-      {/* The two action modals, mounted OUTSIDE the menu — see the note where their
-          state is declared. Each is gated by the same predicate as its menu item, so
-          an ineligible viewer mounts neither the trigger nor the form.
-          🔴 THE `!preview` CLAUSE ON THESE TWO IS DEFENCE-IN-DEPTH, AND IS THE ONLY
-          `preview` GUARD IN THIS FILE THAT NO TEST CAN KILL — measured, not assumed:
-          deleting it leaves the mutation battery fully green, because a Mantine `Modal`
-          with `opened={false}` renders NO DOM at all and its `getMyReview` query is
-          `enabled: false`, so a mounted-but-closed modal is unobservable from the
-          rendered output and issues no request. Removing the clause would therefore be
-          inert TODAY. It stays because "mount no live-action component against an
-          unapproved shadow listing" is the posture, and the day either modal grows a
-          mount effect the clause is what stops it firing. Do not delete it on the
-          grounds that nothing goes red. */}
-      {!preview && canReview && (
-        <ReviewListingModal
-          appListingId={detail.id}
-          opened={reviewOpened}
-          onClose={reviewModal.close}
-        />
-      )}
-      {!preview && canReport && (
-        <ReportListingModal appListingId={detail.id} {...report.modalProps} />
-      )}
-      {/* The two MODERATOR modals, mounted outside the menu for the same reason. Gated
-          on the same derived set as their menu items — `modActions` is empty for a
-          non-moderator and in preview, so neither form is mounted for a viewer who
-          cannot act. `MessageAppOwnerModal` is REUSED, not forked: it names no
-          recipient by design (the owner is resolved server-side, and for an on-site
-          listing that resolution can disagree with the listing's own `userId` column),
-          and its call-site ledger in `__tests__/appModeratorMessageForm.callSites.test.ts`
-          now enumerates this file. */}
-      {modActions.includes('message-owner') && (
-        <MessageAppOwnerModal
-          listing={messageOpened ? modListing : null}
-          onClose={messageModal.close}
-        />
-      )}
-      {/* ONE takedown confirm, for whichever of the pair is open. It is mounted only when
-          `modActions` still admits that action, so the state alone cannot open a confirm
-          for something this viewer or this listing state does not offer. */}
-      {takedown && modActions.includes(takedown) && (
-        <ListingTakedownModal
-          action={takedown}
-          listing={modListing}
-          onClose={() => setTakedown(null)}
-        />
       )}
     </Stack>
   );

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -987,7 +987,13 @@ export function AppListingDetailBody({
 
               🔴 SHARED WITH THE STORE CARD. This renders `AppListingActionsMenu`; the
               item set, order, labels, eligibility gates and modal ownership all live
-              there. Only the trigger's geometry is this surface's own. */}
+              there. This surface's own are the trigger's geometry and `surface`.
+
+              🔴 `surface="detail"` IS WHAT KEEPS "Leave a review" AND "Report" HERE.
+              They are offered to any eligible signed-in viewer on this page and to
+              nobody on the store card — see `appListingMenuSurface.ts`. Changing this
+              string silently removes both items from the one surface whose job is to
+              offer them. */}
           <AppListingActionsMenu
             listing={{
               id: detail.id,
@@ -996,6 +1002,7 @@ export function AppListingDetailBody({
               kindData: detail.kindData,
               creatorUserId: detail.creator?.id ?? null,
             }}
+            surface="detail"
             preview={preview}
           />
         </Group>

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -30,7 +30,12 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
     reviewCount: 0,
     kindData:
       kind === 'onsite'
-        ? { kind: 'onsite', appBlockId: `blk-${id}`, hasPage: false, liveUrl: `https://slug-${id}.civit.ai` }
+        ? {
+            kind: 'onsite',
+            appBlockId: `blk-${id}`,
+            hasPage: false,
+            liveUrl: `https://slug-${id}.civit.ai`,
+          }
         : { kind: 'offsite', externalUrl: 'https://x.app' },
   };
 }
@@ -92,8 +97,23 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
   },
 }));
 
+// 🔴 THE WHOLESALE FACTORY MUST NAME **BOTH** FLAG HOOKS.
+// It replaces the module outright, so a named import in the file's module graph that
+// the factory omits makes the whole file fail to IMPORT — reported as
+// `Tests no tests`, i.e. as nothing to see rather than as a failure. That is exactly
+// what happened when the store card began rendering the shared `⋮` menu, whose
+// `useCanReviewListing` reads `useOptionalFeatureFlags`.
+// 🔴 AN `importOriginal` SPREAD IS THE WRONG CURE HERE, and it was tried: the real
+// flags module imports `setTrpcBatchingEnabled` from `~/utils/trpc`, which this
+// file's own wholesale trpc factory does not provide, so spreading moves the same
+// import failure one module over. See
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`, which
+// gates exactly this rule for its own directory.
+// Both hooks must return the SAME flags: a component may call either, and which one
+// it calls is not something a test file can see.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
 }));
 
 // The filters now live in the shared `AdaptiveFiltersDropdown`, which pulls in two

--- a/src/components/Apps/AppListingsMarketplaceBody.hydration.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.hydration.browser.test.tsx
@@ -79,8 +79,23 @@ const mocks = vi.hoisted(() => ({
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => mocks.isClient }));
 vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+// 🔴 THE WHOLESALE FACTORY MUST NAME **BOTH** FLAG HOOKS.
+// It replaces the module outright, so a named import in the file's module graph that
+// the factory omits makes the whole file fail to IMPORT — reported as
+// `Tests no tests`, i.e. as nothing to see rather than as a failure. That is exactly
+// what happened when the store card began rendering the shared `⋮` menu, whose
+// `useCanReviewListing` reads `useOptionalFeatureFlags`.
+// 🔴 AN `importOriginal` SPREAD IS THE WRONG CURE HERE, and it was tried: the real
+// flags module imports `setTrpcBatchingEnabled` from `~/utils/trpc`, which this
+// file's own wholesale trpc factory does not provide, so spreading moves the same
+// import failure one module over. See
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`, which
+// gates exactly this rule for its own directory.
+// Both hooks must return the SAME flags: a component may call either, and which one
+// it calls is not something a test file can see.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
 }));
 
 vi.mock('~/utils/trpc', async (importOriginal) => ({

--- a/src/components/Apps/AppListingsMarketplaceBody.recentsReconcile.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.recentsReconcile.browser.test.tsx
@@ -106,8 +106,23 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 // returns `/apps/run/<blockId>` when it is on, so with the flag dark EVERY tile
 // resolves to the detail page and this file's central assertion would pass on the
 // broken build for the wrong reason.
+// 🔴 THE WHOLESALE FACTORY MUST NAME **BOTH** FLAG HOOKS.
+// It replaces the module outright, so a named import in the file's module graph that
+// the factory omits makes the whole file fail to IMPORT — reported as
+// `Tests no tests`, i.e. as nothing to see rather than as a failure. That is exactly
+// what happened when the store card began rendering the shared `⋮` menu, whose
+// `useCanReviewListing` reads `useOptionalFeatureFlags`.
+// 🔴 AN `importOriginal` SPREAD IS THE WRONG CURE HERE, and it was tried: the real
+// flags module imports `setTrpcBatchingEnabled` from `~/utils/trpc`, which this
+// file's own wholesale trpc factory does not provide, so spreading moves the same
+// import failure one module over. See
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`, which
+// gates exactly this rule for its own directory.
+// Both hooks must return the SAME flags: a component may call either, and which one
+// it calls is not something a test file can see.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: true }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: true }),
 }));
 
 // Both throw rather than defaulting when their provider is absent, taking the

--- a/src/components/Apps/AppListingsMarketplaceBody.storeGate.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.storeGate.browser.test.tsx
@@ -61,7 +61,24 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
-vi.mock('~/providers/FeatureFlagsProvider', () => ({ useFeatureFlags: () => mocks.flags }));
+// 🔴 THE WHOLESALE FACTORY MUST NAME **BOTH** FLAG HOOKS.
+// It replaces the module outright, so a named import in the file's module graph that
+// the factory omits makes the whole file fail to IMPORT — reported as
+// `Tests no tests`, i.e. as nothing to see rather than as a failure. That is exactly
+// what happened when the store card began rendering the shared `⋮` menu, whose
+// `useCanReviewListing` reads `useOptionalFeatureFlags`.
+// 🔴 AN `importOriginal` SPREAD IS THE WRONG CURE HERE, and it was tried: the real
+// flags module imports `setTrpcBatchingEnabled` from `~/utils/trpc`, which this
+// file's own wholesale trpc factory does not provide, so spreading moves the same
+// import failure one module over. See
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`, which
+// gates exactly this rule for its own directory.
+// Both hooks must return the SAME flags: a component may call either, and which one
+// it calls is not something a test file can see.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.flags,
+  useOptionalFeatureFlags: () => mocks.flags,
+}));
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
 vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
 

--- a/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.urlState.browser.test.tsx
@@ -70,8 +70,23 @@ const mocks = vi.hoisted(() => ({
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
 vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+// 🔴 THE WHOLESALE FACTORY MUST NAME **BOTH** FLAG HOOKS.
+// It replaces the module outright, so a named import in the file's module graph that
+// the factory omits makes the whole file fail to IMPORT — reported as
+// `Tests no tests`, i.e. as nothing to see rather than as a failure. That is exactly
+// what happened when the store card began rendering the shared `⋮` menu, whose
+// `useCanReviewListing` reads `useOptionalFeatureFlags`.
+// 🔴 AN `importOriginal` SPREAD IS THE WRONG CURE HERE, and it was tried: the real
+// flags module imports `setTrpcBatchingEnabled` from `~/utils/trpc`, which this
+// file's own wholesale trpc factory does not provide, so spreading moves the same
+// import failure one module over. See
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`, which
+// gates exactly this rule for its own directory.
+// Both hooks must return the SAME flags: a component may call either, and which one
+// it calls is not something a test file can see.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
 }));
 vi.mock('~/utils/trpc', async (importOriginal) => ({
   ...(await importOriginal<typeof TrpcMod>()),

--- a/src/components/Apps/MarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/MarketplaceBody.browser.test.tsx
@@ -33,7 +33,12 @@ function makeBlock(id: string, name: string): AvailableBlock {
     blockId: `block-${id}`,
     appId: id,
     appName: name,
-    manifest: { name, description: 'desc', targets: [{ slotId: 'model.sidebar_top' }], hasPage: false },
+    manifest: {
+      name,
+      description: 'desc',
+      targets: [{ slotId: 'model.sidebar_top' }],
+      hasPage: false,
+    },
     installCount: 0,
     category: null,
     externalUrl: null,
@@ -84,7 +89,9 @@ vi.mock('~/utils/trpc', () => {
           useInfiniteQuery: (input: Record<string, unknown>) => {
             mocks.lastListArgs = input;
             return {
-              data: { pages: [{ items: mocks.listAvailableItems.map(block), nextCursor: undefined }] },
+              data: {
+                pages: [{ items: mocks.listAvailableItems.map(block), nextCursor: undefined }],
+              },
               isLoading: false,
               isFetchingNextPage: false,
               fetchNextPage: vi.fn(),
@@ -109,8 +116,23 @@ vi.mock('~/utils/trpc', () => {
   };
 });
 
+// 🔴 THE WHOLESALE FACTORY MUST NAME **BOTH** FLAG HOOKS.
+// It replaces the module outright, so a named import in the file's module graph that
+// the factory omits makes the whole file fail to IMPORT — reported as
+// `Tests no tests`, i.e. as nothing to see rather than as a failure. That is exactly
+// what happened when the store card began rendering the shared `⋮` menu, whose
+// `useCanReviewListing` reads `useOptionalFeatureFlags`.
+// 🔴 AN `importOriginal` SPREAD IS THE WRONG CURE HERE, and it was tried: the real
+// flags module imports `setTrpcBatchingEnabled` from `~/utils/trpc`, which this
+// file's own wholesale trpc factory does not provide, so spreading moves the same
+// import failure one module over. See
+// `src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts`, which
+// gates exactly this rule for its own directory.
+// Both hooks must return the SAME flags: a component may call either, and which one
+// it calls is not something a test file can see.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: mocks.appBlocksPages }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: mocks.appBlocksPages }),
 }));
 
 /**
@@ -189,14 +211,14 @@ describe('/apps marketplace body (explore-all CTA clears filters)', () => {
     await expect.element(page.getByRole('button', { name: 'Generation' })).toBeInTheDocument();
     // Pick a category → filter active → the query receives it.
     await userEvent.click(page.getByRole('button', { name: 'Generation' }).element());
-    await expect.element(page.getByRole('button', { name: 'Explore all apps' })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: 'Explore all apps' }))
+      .toBeInTheDocument();
     expect(mocks.lastListArgs?.category).toBe('generation');
 
     // Click "Explore all apps" → filters cleared → query no longer filtered.
     await userEvent.click(page.getByRole('button', { name: 'Explore all apps' }).element());
-    await expect
-      .element(page.getByRole('button', { name: 'All categories' }))
-      .toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'All categories' })).toBeInTheDocument();
     expect(mocks.lastListArgs?.category).toBeUndefined();
     // The explore-all CTA hides once there are no active filters.
     expect(page.getByRole('button', { name: 'Explore all apps' }).elements()).toHaveLength(0);
@@ -209,7 +231,9 @@ describe('/apps marketplace body (explore-all CTA clears filters)', () => {
     await userEvent.fill(search.element() as HTMLInputElement, 'alpha');
     // A non-empty search activates the filters → the CTA appears (debounced, so
     // wait for it rather than asserting synchronously).
-    await expect.element(page.getByRole('button', { name: 'Explore all apps' })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: 'Explore all apps' }))
+      .toBeInTheDocument();
     await userEvent.click(page.getByRole('button', { name: 'Explore all apps' }).element());
     // The search input is emptied (clearFilters reset searchInput state).
     await expect.element(page.getByRole('textbox', { name: 'Search' })).toHaveValue('');
@@ -247,7 +271,9 @@ describe('/apps marketplace body (opening an app records it to recents)', () => 
     expect(window.localStorage.getItem(RECENTLY_OPENED_APPS_KEY)).toBeTruthy();
 
     // The "Recently opened" section now renders (resolved against the listing).
-    await expect.element(page.getByRole('heading', { name: 'Recently opened' })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('heading', { name: 'Recently opened' }))
+      .toBeInTheDocument();
   });
 });
 
@@ -287,7 +313,9 @@ describe('/apps marketplace body — PAGE app open records to recents (M1)', () 
     expect(recents.map((r) => r.id)).toContain('p');
     expect(window.localStorage.getItem(RECENTLY_OPENED_APPS_KEY)).toBeTruthy();
     // The "Recently opened" section renders for the page app.
-    await expect.element(page.getByRole('heading', { name: 'Recently opened' })).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('heading', { name: 'Recently opened' }))
+      .toBeInTheDocument();
   });
 
   test('clicking the title link on a PAGE app also records it to recents (flag off)', async () => {
@@ -318,9 +346,9 @@ describe('/apps marketplace body — sort default + fallback (M3)', () => {
     // the test is the AGREEMENT between the two — a label showing one sort while
     // the query asks for another is the bug this pins.
     await expect.element(page.getByRole('textbox', { name: 'Sort' })).toBeInTheDocument();
-    expect(
-      (page.getByRole('textbox', { name: 'Sort' }).element() as HTMLInputElement).value
-    ).toBe('Most popular');
+    expect((page.getByRole('textbox', { name: 'Sort' }).element() as HTMLInputElement).value).toBe(
+      'Most popular'
+    );
     expect(mocks.lastListArgs?.sort).toBe('popular');
     // Negative control: the removed 5-star sort must not come back through here.
     expect(mocks.lastListArgs?.sort).not.toBe('rating');

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -1011,8 +1011,13 @@ function ListingPreviewSection({ request }: { request: OffsitePendingRow }) {
       <Text size="xs" c="dimmed">
         Listing preview — how it will appear in the store once approved.
       </Text>
+      {/* 🔴 `preview` — the SAME posture the detail body below it takes. Without it
+          this card offers a moderator (which every viewer of this queue is) the `⋮`
+          menu's live takedown actions against a listing that is NOT approved and
+          whose `id` may be the publish REQUEST's rather than an `AppListing`'s. See
+          `appListingDetailModActions.detailListingStatus`. */}
       <div style={{ maxWidth: 340 }} data-testid="apps-listing-preview-card">
-        <AppListingCard card={card} />
+        <AppListingCard card={card} preview />
       </div>
       <Card withBorder p="md" data-testid="apps-listing-preview-detail">
         <AppListingDetailBody detail={detail} preview />
@@ -1225,7 +1230,8 @@ function RevisionDriftSection({ request }: { request: OffsitePendingRow }) {
 
       {parentPreviewQuery.data && (
         <div style={{ maxWidth: 340 }} data-testid="apps-listing-revision-drift-live-card">
-          <AppListingCard card={parentPreviewQuery.data.card} />
+          {/* `preview` — read-only drift comparison; no live action belongs on it. */}
+          <AppListingCard card={parentPreviewQuery.data.card} preview />
         </div>
       )}
     </Stack>

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -1,5 +1,11 @@
+import fs from 'fs';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import {
+  LISTING_ACTIONS_WIDEST_PX,
+  LISTING_ACTION_ROW_GAP_PX,
+  LISTING_ROLLUP_HIDE_BELOW_PX,
+  LISTING_ROLLUP_MIN_WIDTH_PX,
   canOwnerEditListing,
   getListingBadge,
   getListingCta,
@@ -7,6 +13,7 @@ import {
   getOwnerEditHref,
   getRecommendLabel,
   isEditableListingStatus,
+  listingRollupHideThreshold,
   safeExternalHref,
 } from '~/components/Apps/appListingCardView';
 import type {
@@ -28,7 +35,9 @@ const roll = (
   recommendPct: number | null
 ): ListingRecommendRollup => ({ recommendedCount, notRecommendedCount, recommendPct });
 
-function onsiteCard(over: Partial<ListingCard> & { hasPage: boolean; appBlockId?: string | null }): ListingCard {
+function onsiteCard(
+  over: Partial<ListingCard> & { hasPage: boolean; appBlockId?: string | null }
+): ListingCard {
   const { hasPage, appBlockId = 'blk-1', ...rest } = over;
   return {
     id: 'l1',
@@ -78,7 +87,10 @@ describe('getListingBadge', () => {
   // The word a human reads, typed out. (Was `'App'` before the kind rename: not a
   // retired wording, just a word that was not the kind's name at all.)
   it('on-site → "Embedded"', () => {
-    expect(getListingBadge(onsiteCard({ hasPage: true }))).toEqual({ label: 'Embedded', kind: 'onsite' });
+    expect(getListingBadge(onsiteCard({ hasPage: true }))).toEqual({
+      label: 'Embedded',
+      kind: 'onsite',
+    });
   });
   /**
    * 🔴 NEW BEHAVIOUR (not regression coverage): off-site used to badge as
@@ -147,7 +159,9 @@ describe('getListingDetailHref', () => {
 
 describe('getListingCta — on-site (P2c: View details → unified detail)', () => {
   it('hasPage + canOpenPage → Open → /apps/run/<slug> (direct primary)', () => {
-    expect(getListingCta(onsiteCard({ hasPage: true, slug: 'gen-matrix' }), { canOpenPage: true })).toEqual({
+    expect(
+      getListingCta(onsiteCard({ hasPage: true, slug: 'gen-matrix' }), { canOpenPage: true })
+    ).toEqual({
       label: 'Open',
       action: 'open',
       href: '/apps/run/gen-matrix',
@@ -155,7 +169,9 @@ describe('getListingCta — on-site (P2c: View details → unified detail)', () 
     });
   });
   it('hasPage but NOT canOpenPage → View details → unified detail (no dead run link)', () => {
-    expect(getListingCta(onsiteCard({ hasPage: true, slug: 'my-app' }), { canOpenPage: false })).toEqual({
+    expect(
+      getListingCta(onsiteCard({ hasPage: true, slug: 'my-app' }), { canOpenPage: false })
+    ).toEqual({
       label: 'View details',
       action: 'detail',
       href: '/apps/store-preview/my-app',
@@ -163,7 +179,9 @@ describe('getListingCta — on-site (P2c: View details → unified detail)', () 
     });
   });
   it('!hasPage → View details → unified detail', () => {
-    expect(getListingCta(onsiteCard({ hasPage: false, slug: 'my-app' }), { canOpenPage: true })).toEqual({
+    expect(
+      getListingCta(onsiteCard({ hasPage: false, slug: 'my-app' }), { canOpenPage: true })
+    ).toEqual({
       label: 'View details',
       action: 'detail',
       href: '/apps/store-preview/my-app',
@@ -171,7 +189,11 @@ describe('getListingCta — on-site (P2c: View details → unified detail)', () 
     });
   });
   it('!hasPage + no appBlockId → still reaches the unified detail (never actionless)', () => {
-    expect(getListingCta(onsiteCard({ hasPage: false, appBlockId: null, slug: 'my-app' }), { canOpenPage: true })).toEqual({
+    expect(
+      getListingCta(onsiteCard({ hasPage: false, appBlockId: null, slug: 'my-app' }), {
+        canOpenPage: true,
+      })
+    ).toEqual({
       label: 'View details',
       action: 'detail',
       href: '/apps/store-preview/my-app',
@@ -227,7 +249,9 @@ describe('getListingCta — off-site (P2c: View details → unified detail)', ()
 
 describe('getOwnerEditHref (owner Edit deep-link)', () => {
   it('on-site → the UNIFIED /edit editor keyed on appBlockId (Item 2)', () => {
-    expect(getOwnerEditHref({ kind: 'onsite', appBlockId: 'blk-1' }, 'l1')).toBe('/apps/blk-1/edit');
+    expect(getOwnerEditHref({ kind: 'onsite', appBlockId: 'blk-1' }, 'l1')).toBe(
+      '/apps/blk-1/edit'
+    );
   });
   it('on-site with no backing appBlockId → null (no editable target → hide)', () => {
     expect(getOwnerEditHref({ kind: 'onsite', appBlockId: null }, 'l1')).toBeNull();
@@ -236,9 +260,9 @@ describe('getOwnerEditHref (owner Edit deep-link)', () => {
     expect(getOwnerEditHref({ kind: 'offsite' }, 'l2')).toBe('/apps/submit?edit=l2');
   });
   it('accepts the full card kindData (extra fields are ignored)', () => {
-    expect(getOwnerEditHref(onsiteCard({ hasPage: true, appBlockId: 'blk-9' }).kindData, 'l1')).toBe(
-      '/apps/blk-9/edit'
-    );
+    expect(
+      getOwnerEditHref(onsiteCard({ hasPage: true, appBlockId: 'blk-9' }).kindData, 'l1')
+    ).toBe('/apps/blk-9/edit');
     expect(getOwnerEditHref(offsiteCard('connect', null).kindData, 'l2')).toBe(
       '/apps/submit?edit=l2'
     );
@@ -278,5 +302,126 @@ describe('isEditableListingStatus / canOwnerEditListing (owner Edit gating)', ()
   it('owner but mod-removed / rejected → hide', () => {
     expect(canOwnerEditListing({ isOwner: true, status: 'removed' })).toBe(false);
     expect(canOwnerEditListing({ isOwner: true, status: 'rejected' })).toBe(false);
+  });
+});
+
+/**
+ * ── ACTION-ROW GEOMETRY ─────────────────────────────────────────────────────
+ *
+ * 🔴 WHY THIS IS IN THE BLOCKING TIER AT ALL. The two numbers behind the action
+ * row used to be magic values inside `AppListingCard.tsx`: one derived in a
+ * comment, one read off a table, neither checkable. The component suite that
+ * MEASURES them is the browser project, which is report-only in CI — so in CI
+ * nothing at all held them. What CAN be gated here is the arithmetic and the
+ * spelling, and both are where the drift actually happens.
+ *
+ * 🔴 WHAT THIS CANNOT SEE, stated rather than implied: it does not measure
+ * anything. `LISTING_ACTIONS_WIDEST_PX` is a MEASUREMENT, and if the action
+ * cluster's real width changes (a different trigger size, a longer CTA label)
+ * this file stays green while the threshold silently stops matching reality.
+ * That claim is made by `AppListingCard.browser.test.tsx`'s "AT the threshold"
+ * test, which asserts all three terms against a real render.
+ */
+describe('the recommend-rollup floor and the container-query threshold', () => {
+  const CARD_MODULE = path.resolve(__dirname, '../AppListingCard.tsx');
+  const cardSource = () => fs.readFileSync(CARD_MODULE, 'utf8');
+  /**
+   * 🔴 EVERY ASSERTION BELOW IS A CLAIM ABOUT CODE, AND PROSE IS NOT CODE. This
+   * file's comments deliberately quote the constants they explain — the note
+   * recording that `@[360px]` was deleted contains the literal `@[360px]` — so a
+   * raw `not.toContain` reads a correct file as an offence. Measured: that exact
+   * false positive is why this stripper exists.
+   */
+  const cardCode = () =>
+    cardSource()
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, ' ')
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  /** The single JSX opening tag that carries `substr`, as source text. */
+  function enclosingTag(code: string, substr: string): string {
+    const at = code.indexOf(substr);
+    expect(at, `"${substr}" not found in AppListingCard.tsx`).toBeGreaterThan(-1);
+    const open = code.lastIndexOf('<', at);
+    const close = code.indexOf('>', at);
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    return code.slice(open, close + 1);
+  }
+
+  it('the threshold is the floor plus the gap plus the action cluster, rounded up to even', () => {
+    expect(LISTING_ROLLUP_HIDE_BELOW_PX).toBe(
+      LISTING_ACTIONS_WIDEST_PX + LISTING_ACTION_ROW_GAP_PX + LISTING_ROLLUP_MIN_WIDTH_PX
+    );
+    expect(LISTING_ROLLUP_HIDE_BELOW_PX).toBe(264);
+  });
+
+  it('rounding is UP and to an even number — never down', () => {
+    // Rounding down would place the threshold BELOW the width at which the floor
+    // first fits, i.e. it would render a row that overflows. Two odd sums and an
+    // already-even one, so the branch is exercised rather than asserted about.
+    expect(listingRollupHideThreshold(183, 10, 70)).toBe(264);
+    expect(listingRollupHideThreshold(184, 11, 70)).toBe(266);
+    expect(listingRollupHideThreshold(184, 10, 70)).toBe(264);
+    for (const [a, g, f] of [
+      [183, 10, 70],
+      [184, 11, 70],
+      [100, 7, 33],
+    ] as const) {
+      expect(listingRollupHideThreshold(a, g, f)).toBeGreaterThanOrEqual(a + g + f);
+      expect(listingRollupHideThreshold(a, g, f) % 2).toBe(0);
+    }
+  });
+
+  /**
+   * 🔴 THE SPELLING GUARD. A Tailwind arbitrary variant cannot read a JS constant,
+   * so `@[264px]` in the component and `LISTING_ROLLUP_HIDE_BELOW_PX` here are an
+   * unavoidable duplication. What is avoidable is one moving without the other,
+   * which is exactly the drift this asserts.
+   */
+  it("the component's container query spells the derived threshold", () => {
+    const code = cardSource();
+    const queries = [...code.matchAll(/@\[(\d+)px\]:/g)].map((m) => Number(m[1]));
+    // Positive control: the pattern really does match something, so an equal-to
+    // result is a match and not an empty sweep.
+    expect(queries.length).toBeGreaterThan(0);
+    expect([...new Set(queries)]).toEqual([LISTING_ROLLUP_HIDE_BELOW_PX]);
+  });
+
+  /**
+   * 🔴 THE `@[360px]` BREAKPOINT IS GONE AND MUST STAY GONE. It existed only to
+   * choose between a text Edit button and an icon-only one; both are now a single
+   * `Menu.Item` behind a fixed-width `⋮` trigger, so it had nothing left to decide.
+   * The assertion above already forbids it by enumerating the whole set — this one
+   * names it, so a reader of a future failure knows which constant died and why.
+   */
+  it('the retired dual-Edit breakpoint is not reintroduced', () => {
+    // Positive control on the stripper: the comment that NAMES the retired
+    // breakpoint is still in the file, so a green result here is about code and not
+    // about an empty read.
+    expect(cardSource()).toContain('@[360px]');
+    expect(cardCode()).not.toContain('@[360px]');
+    // …and the stripper did not simply eat the file.
+    expect(cardCode()).toContain('@[264px]:flex');
+  });
+
+  /**
+   * 🔴 THE FLOOR IS ENFORCED, NOT MERELY DOCUMENTED. The rollup used to carry
+   * `minWidth: 0`; the whole point of this change is that the number is now a
+   * layout constraint. A revert to 0 is the mutation that makes the growing CTA
+   * starve the rollup at every width, and it would leave every arithmetic
+   * assertion above perfectly green.
+   */
+  it('the component applies the floor as the rollup min-width', () => {
+    // 🔴 SCOPED TO THE ROLLUP'S OWN TAG, not to the file. Four other elements on
+    // this card legitimately carry `minWidth: 0` (the creator chip, the title
+    // stack, the action cluster) — a file-wide `not.toContain` fails against
+    // correct code, which it did on the first run of this assertion.
+    const tag = enclosingTag(cardCode(), "'hidden @[264px]:flex'");
+    expect(tag).toContain('minWidth: LISTING_ROLLUP_MIN_WIDTH_PX');
+    expect(tag).not.toMatch(/minWidth:\s*0\b/);
+    // The tag really is the rollup's Group, not some enclosing element the index
+    // walk happened to land on.
+    expect(tag.startsWith('<Group')).toBe(true);
   });
 });

--- a/src/components/Apps/__tests__/appListingDetailModalPlacement.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailModalPlacement.test.ts
@@ -40,12 +40,18 @@ import { describe, expect, it } from 'vitest';
  */
 
 const SRC = path.resolve(__dirname, '../../..');
-const BODY_MODULE = 'components/Apps/AppListingDetailBody.tsx';
+/**
+ * 🔴 RE-POINTED FROM `AppListingDetailBody.tsx` TO THE SHARED MENU. The `⋮` menu was
+ * extracted so the store CARD renders the same one; the rule, the dropdown and all four
+ * modals moved with it. Re-pointing rather than widening to "either file" is deliberate:
+ * there is exactly ONE dropdown in the codebase now, which is what the extractor below
+ * asserts, and a second one appearing anywhere is the regression this whole file guards.
+ */
+const BODY_MODULE = 'components/Apps/AppListingActionsMenu.tsx';
 
 /**
- * Every modal the detail body's overflow menu opens. All four, not just the two this
- * change adds: the rule is the same for all of them, and the two pre-existing ones were
- * the mutants measured above as uncaught.
+ * Every modal the overflow menu opens. All four: the rule is the same for all of them,
+ * and two of them were the mutants measured above as uncaught.
  */
 const MENU_MODALS = [
   'ReviewListingModal',

--- a/src/components/Apps/__tests__/appListingMenuSurface.test.ts
+++ b/src/components/Apps/__tests__/appListingMenuSurface.test.ts
@@ -1,0 +1,145 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  APP_LISTING_MENU_SURFACES,
+  surfaceOffersViewerActions,
+} from '~/components/Apps/appListingMenuSurface';
+
+/**
+ * App Store Listings — the `⋮` menu's SURFACE policy (node `unit` project → the
+ * BLOCKING correctness gate).
+ *
+ * 🔴 WHY THIS FILE EXISTS AT ALL, WHEN THE BEHAVIOUR IS ALREADY ASSERTED IN TWO
+ * BROWSER SUITES. Because those suites are REPORT-ONLY. `*.browser.test.tsx` runs in
+ * the `component` project, which CI reaches only through the PR-preview pipeline's
+ * `preview / component-tests` task — non-blocking, gated on the `preview` label, and
+ * not reported at all when the preview build fails. `.github/workflows/lint.yml`'s
+ * `Unit tests` job runs `--project 'unit*'`, whose include is `src/**\/*.test.ts`:
+ * `.tsx` is not in it. So the real rendered assertions — a signed-in shopper gets no
+ * card menu, the same shopper still gets Review/Report on the detail page — can go
+ * red without blocking anything. This file re-states the parts of that claim a node
+ * test CAN hold, in the tier that blocks.
+ *
+ * 🔴 WHAT IT THEREFORE CANNOT SEE, stated rather than implied: it renders nothing. It
+ * cannot tell you that the card's action row is 138px wide, that the menu trigger is
+ * absent from the DOM, or that `useAppListingMenuGates` actually consults this module
+ * — only that the policy says what it should and that both call sites spell a
+ * surface. The rendered claims are made in `AppListingCard.browser.test.tsx` and
+ * `AppListingDetailBody.browser.test.tsx`.
+ */
+describe('the listing menu surface policy', () => {
+  it('the card does NOT offer the viewer actions and the detail page DOES', () => {
+    // Both directions, because a policy that answered `false` for everything would
+    // satisfy the card half alone — and it would silently strip Review and Report
+    // from the one surface whose job is to offer them.
+    expect(surfaceOffersViewerActions('card')).toBe(false);
+    expect(surfaceOffersViewerActions('detail')).toBe(true);
+  });
+
+  it('every declared surface has an answer, and the set is exactly the two call sites', () => {
+    expect([...APP_LISTING_MENU_SURFACES]).toEqual(['card', 'detail']);
+    // A surface added to the union without a decision here would otherwise inherit
+    // whatever the lookup happens to do — see the fails-closed assertion below.
+    for (const surface of APP_LISTING_MENU_SURFACES) {
+      expect(typeof surfaceOffersViewerActions(surface)).toBe('boolean');
+    }
+  });
+
+  /**
+   * 🔴 THE FAILURE DIRECTION, ASSERTED RATHER THAN TRUSTED TO THE TYPE. `surface` is
+   * a prop, and a prop is not type-checked at runtime — a JS caller, a stale build,
+   * or a value round-tripped through JSON can hand this function anything. A
+   * `Record<Surface, boolean>` lookup would resolve `'toString'` to a FUNCTION, i.e.
+   * truthy, and grant the viewer actions to a surface nobody decided about; the
+   * implementation uses a `Set`, which answers false for every key it was not given.
+   *
+   * Prototype keys specifically, because that is the shape this repo has been bitten
+   * by before (civitai#3495) and the one a plain "unknown string" case does not
+   * exercise: `'nope'` is absent from an object literal too, so it would pass against
+   * the broken implementation and prove nothing.
+   */
+  it('an unknown surface fails CLOSED, prototype keys included', () => {
+    for (const key of ['toString', 'constructor', 'hasOwnProperty', '__proto__', 'nope', '']) {
+      expect(surfaceOffersViewerActions(key as never), `surface ${JSON.stringify(key)}`).toBe(
+        false
+      );
+    }
+  });
+
+  /**
+   * 🔴 THE CALL SITES, READ FROM SOURCE. The policy above is only worth anything if
+   * the two surfaces actually pass the string this module expects — and the wrong
+   * one is not a type error, because both are members of the same union. A card that
+   * said `surface="detail"` would type-check perfectly and re-introduce the exact
+   * regression this change removes.
+   */
+  describe('the call sites name their own surface', () => {
+    const read = (rel: string) => fs.readFileSync(path.resolve(__dirname, rel), 'utf8');
+    /**
+     * Comments are not code. Both modules discuss the OTHER surface by name in prose
+     * — the card's action-row note explains why the detail page keeps these items —
+     * so a raw `toContain` on the source text would pass against a file whose actual
+     * JSX says nothing at all. Same stripper as `appListingCardView.test.ts`.
+     */
+    const code = (rel: string) =>
+      read(rel)
+        .replace(/\{\/\*[\s\S]*?\*\/\}/g, ' ')
+        .replace(/\/\*[\s\S]*?\*\//g, ' ')
+        .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+    it('AppListingCard renders the menu with surface="card", and reads the same for layout', () => {
+      const card = code('../AppListingCard.tsx');
+      expect(card).toContain('surface="card"');
+      expect(card).not.toContain('surface="detail"');
+      // 🔴 THE HOOK CALL TOO, NOT ONLY THE COMPONENT. The card asks
+      // `useAppListingActionsMenuVisible` whether the trigger takes up row space, and
+      // that answer must come from the SAME surface — a card that rendered
+      // `surface="card"` while laying out for `'detail'` reserves 36px for a control
+      // it does not render, which is a silent 46px-row geometry bug.
+      expect(card).toMatch(/useAppListingActionsMenuVisible\(\s*menuTarget,\s*'card'/);
+      // Positive control on the stripper: it did not simply eat the file.
+      expect(card).toContain('AppListingActionsMenu');
+    });
+
+    it('AppListingDetailBody renders the menu with surface="detail"', () => {
+      const detail = code('../AppListingDetailBody.tsx');
+      expect(detail).toContain('surface="detail"');
+      expect(detail).not.toContain('surface="card"');
+      expect(detail).toContain('AppListingActionsMenu');
+    });
+
+    /**
+     * 🔴 A LEDGER, NOT A SPOT CHECK. The two assertions above are claims about two
+     * files; this one is a claim about the SET. A third surface — a recents rail
+     * tile, a modal header — that renders this menu without appearing here is the
+     * case those two cannot see, and it is the case where the wrong default would do
+     * damage. The prop is required precisely so `tsc` stops such a call site, and
+     * this fails when the set GROWS or SHRINKS so the decision is re-made rather
+     * than inherited.
+     */
+    it('exactly two modules render AppListingActionsMenu', () => {
+      // 🔴 THE WHOLE OF `src`, NOT THIS DIRECTORY. A ledger scoped to the folder the
+      // component lives in cannot see the case it exists for — a renderer added
+      // somewhere else, which is where a surface nobody thought about would appear.
+      const SRC = path.resolve(__dirname, '../../..');
+      const found: string[] = [];
+      const walk = (dir: string) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) {
+            if (/<AppListingActionsMenu\b/.test(fs.readFileSync(full, 'utf8'))) {
+              found.push(path.relative(SRC, full));
+            }
+          }
+        }
+      };
+      walk(SRC);
+      expect(found.sort()).toEqual([
+        'components/Apps/AppListingCard.tsx',
+        'components/Apps/AppListingDetailBody.tsx',
+      ]);
+    });
+  });
+});

--- a/src/components/Apps/__tests__/appListingReportCallSites.test.ts
+++ b/src/components/Apps/__tests__/appListingReportCallSites.test.ts
@@ -52,11 +52,17 @@ const SRC = path.resolve(__dirname, '../../..');
 const MODAL_MODULE = 'components/Apps/ReportListingModal.tsx';
 
 /**
- * Every PRODUCTION site that mounts `ReportListingModal`. One today: the listing
- * detail body, which is the live store surface. Adding a second report surface means
- * adding it here — that is the point, not an inconvenience.
+ * Every PRODUCTION site that mounts `ReportListingModal`. One today: the SHARED `⋮`
+ * overflow menu, which both live store surfaces (the card and the listing detail body)
+ * render. Adding a second report surface means adding it here — that is the point, not
+ * an inconvenience.
+ *
+ * 🔴 IT USED TO BE `AppListingDetailBody.tsx`. The menu was extracted so the card could
+ * render it too, and the modal moved with it. That the ledger had to be edited at all is
+ * the ledger working: an extraction that silently dropped the wiring would have shown up
+ * here as a SHRINK.
  */
-const MODAL_MOUNT_SITES = ['components/Apps/AppListingDetailBody.tsx'] as const;
+const MODAL_MOUNT_SITES = ['components/Apps/AppListingActionsMenu.tsx'] as const;
 
 /**
  * Every PRODUCTION site that renders the report TRIGGER, identified by the stable
@@ -64,7 +70,7 @@ const MODAL_MOUNT_SITES = ['components/Apps/AppListingDetailBody.tsx'] as const;
  * a rename shows up here as a SHRINK, not as a silent hole.
  */
 const TRIGGER_TEST_ID = 'apps-listing-report-action';
-const TRIGGER_SITES = ['components/Apps/AppListingDetailBody.tsx'] as const;
+const TRIGGER_SITES = ['components/Apps/AppListingActionsMenu.tsx'] as const;
 
 type MountSite = { file: string; onReportedWired: boolean };
 type TriggerSite = { file: string; disabledFromState: boolean; labelFromState: boolean };

--- a/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
+++ b/src/components/Apps/__tests__/appModeratorMessageForm.callSites.test.ts
@@ -93,13 +93,21 @@ const FIELD_MODULE = 'components/Apps/ReasonGatedActionModal.tsx';
 const TABLE_MODULE = 'components/Apps/AppListingsModerationTable.tsx';
 
 /**
- * The unified store listing DETAIL body — the second mount. It reaches the composer from
- * the `⋮` overflow menu's moderator section on `/apps/store-preview/<slug>`, where the
- * listing is `approved` by construction (the read is approved-only). It has no
- * `openAction` dispatch of its own: the menu item calls the modal's disclosure directly,
- * so the routing assertions below do not apply to it and are not asserted of it.
+ * The SHARED `⋮` overflow menu — the second mount, and now the ONLY one outside the mod
+ * table. It reaches the composer from the menu's moderator section, which both the store
+ * CARD and the listing DETAIL body render; on both the listing is `approved` by
+ * construction (each read is approved-only). It has no `openAction` dispatch of its own:
+ * the menu item calls the modal's disclosure directly, so the routing assertions below do
+ * not apply to it and are not asserted of it.
+ *
+ * 🔴 THIS USED TO BE `AppListingDetailBody.tsx`, AND THE MOVE IS THE POINT OF THE LEDGER
+ * WORKING. When the menu was extracted so the card could render it too, the composer's
+ * mount moved with it — a ledger keyed on the old file would have failed LOUDLY (mount
+ * set shrank AND grew), which is exactly the signal it exists to give. It is re-pointed
+ * here rather than widened to "either file": there is one menu now, and a second copy of
+ * it is the thing the extraction removed.
  */
-const DETAIL_MODULE = 'components/Apps/AppListingDetailBody.tsx';
+const MENU_MODULE = 'components/Apps/AppListingActionsMenu.tsx';
 
 /**
  * Every PRODUCTION site that mounts `MessageAppOwnerModal`. Adding a third surface means
@@ -107,7 +115,7 @@ const DETAIL_MODULE = 'components/Apps/AppListingDetailBody.tsx';
  * SHRINKS (the surface goes dark again, which is what happened once already) and when it
  * GROWS (a surface appears that nobody wired to the same rules).
  */
-const MOUNT_SITES = [TABLE_MODULE, DETAIL_MODULE] as const;
+const MOUNT_SITES = [TABLE_MODULE, MENU_MODULE] as const;
 
 const SCHEMA_IMPORT = '~/server/schema/blocks/app-moderator-message.schema';
 
@@ -551,20 +559,25 @@ describe('the composer takes no owner from its caller', () => {
     }
     // Positive control: the mount sites DO still build the props they are supposed to.
     expect(codeOf(TABLE_MODULE)).toMatch(/appListingId:\s*messageRow\.id/);
-    expect(codeOf(DETAIL_MODULE)).toMatch(/appListingId:\s*detail\.id/);
+    expect(codeOf(MENU_MODULE)).toMatch(/appListingId:\s*listing\.id/);
   });
 
   /**
-   * 🔴 THE DETAIL BODY FEEDS THE LISTING ID, NEVER THE SLUG — the same transposition the
-   * table's assertion guards, in a file where it is MORE reachable: `detail.id` and
-   * `detail.slug` are adjacent in the one object literal the menu hands the composer, and
-   * the neighbouring `slug` there is a legitimate prop. A slug would come back NOT_FOUND
-   * from `messageAppOwner`, which keys on `apl_<ULID>`.
+   * 🔴 THE MENU FEEDS THE LISTING ID, NEVER THE SLUG — the same transposition the
+   * table's assertion guards, in a file where it is MORE reachable: `listing.id` and
+   * `listing.slug` are adjacent in the one object literal the menu hands the composer,
+   * and the neighbouring `slug` there is a legitimate prop. A slug would come back
+   * NOT_FOUND from `messageAppOwner`, which keys on `apl_<ULID>`.
+   *
+   * 🔴 IT NOW GUARDS BOTH SURFACES AT ONCE, which is a strengthening rather than a
+   * relocation: the card and the detail body render this one menu, so a transposition
+   * here would have been two separate defects under the old duplicated arrangement and
+   * needed two separate assertions to catch.
    */
-  it('the detail body feeds the composer the listing ID, never the slug', () => {
-    const body = codeOf(DETAIL_MODULE);
-    expect(body).toMatch(/appListingId:\s*detail\.id/);
-    expect(body).not.toMatch(/appListingId:\s*detail\.slug/);
+  it('the shared menu feeds the composer the listing ID, never the slug', () => {
+    const menu = codeOf(MENU_MODULE);
+    expect(menu).toMatch(/appListingId:\s*listing\.id/);
+    expect(menu).not.toMatch(/appListingId:\s*listing\.slug/);
   });
 
   /**

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -219,3 +219,89 @@ export function getOwnerEditHref(
   }
   return `/apps/submit?edit=${encodeURIComponent(listingId)}`;
 }
+
+// ── Action-row geometry (S7) ────────────────────────────────────────────────
+//
+// 🔴 THESE ARE DERIVED NUMBERS, AND THEY LIVE HERE SO THE DERIVATION IS MACHINE-
+// CHECKED. They used to be two magic values inside `AppListingCard.tsx` — one
+// stated as arithmetic in a comment, one read off a table — with nothing pinning
+// either to the measurements it came from. `__tests__/appListingCardView.test.ts`
+// (blocking) now re-runs the arithmetic and asserts the component's Tailwind
+// container-query class spells the same number.
+
+/**
+ * The recommend rollup's FLOOR, in px — the width below which it stops saying
+ * anything and becomes debris.
+ *
+ * 13px thumb glyph + 4px `Group gap={4}` + ~53px of 12px text ≈ 9 characters,
+ * which is enough for "No reviews…" / "91% recom…" to read as a phrase. Below it
+ * the surviving glyphs carry no information while still occupying the slot, which
+ * reads as a rendering bug.
+ *
+ * 🔴 THIS IS NOW AN ENFORCED `min-width` ON THE ROLLUP, NOT AN IMPLICIT ONE. The
+ * rollup used to carry `minWidth: 0`, i.e. "shrink to nothing", and the floor
+ * existed only as the arithmetic behind the container-query threshold — so at any
+ * width the query did not cover, the rollup could still be crushed. Making the CTA
+ * grow into the free space is exactly the change that would have made that worse
+ * (a `flex-grow` with no counterweight starves the rollup at EVERY width), so the
+ * floor is stated as a constraint the layout engine enforces rather than as a
+ * number a comment claims.
+ */
+export const LISTING_ROLLUP_MIN_WIDTH_PX = 70;
+
+/**
+ * The gap between the two sides of the action row, in px — Mantine `gap="xs"`
+ * (`0.625rem` at the 16px root this app ships).
+ */
+export const LISTING_ACTION_ROW_GAP_PX = 10;
+
+/**
+ * The action cluster's NATURAL width at its WIDEST, in px, MEASURED (not modelled)
+ * in the component suite at the store's real geometry: a fixed 36px `⋮` trigger +
+ * the row's 10px `gap="xs"` + the widest CTA ("View details", 137.9px with its
+ * glyph) = 183.9, i.e. 184.
+ *
+ * 🔴 NATURAL, not rendered. The CTA now grows into the row's free space, so the
+ * cluster's RENDERED width is larger than this wherever there is slack (measured:
+ * 356.3 at a 462px container). The threshold below is about the DEFICIT case,
+ * where there is no growth and the two coincide — so this is the number the
+ * arithmetic needs.
+ *
+ * 🔴 RE-MEASURED after the overflow-menu change (this PR). The previous value was
+ * also 184 — for a different reason that happens to coincide: the control the
+ * menu replaced was an icon-only Edit `ActionIcon` at the same `size={36}`. The
+ * coincidence is worth naming, because "the number did not move" is also the
+ * shape of a measurement nobody took.
+ */
+export const LISTING_ACTIONS_WIDEST_PX = 184;
+
+/**
+ * The container width below which the rollup is HIDDEN rather than clamped at its
+ * floor, in px.
+ *
+ * Rounded UP to an even number so the Tailwind arbitrary variant reads cleanly;
+ * rounding up is the safe direction (hide slightly earlier, never render an
+ * overflowing row).
+ */
+export function listingRollupHideThreshold(
+  actionsWidthPx: number,
+  gapPx: number,
+  rollupFloorPx: number
+): number {
+  const exact = actionsWidthPx + gapPx + rollupFloorPx;
+  return Math.ceil(exact / 2) * 2;
+}
+
+/**
+ * The live threshold: 184 + 10 + 70 = 264.
+ *
+ * 🔴 MUST EQUAL the number in `AppListingCard.tsx`'s `@[264px]:flex` class. A
+ * Tailwind arbitrary variant cannot read a JS constant, so the duplication is
+ * unavoidable; what is avoidable is it going unnoticed, which is why the blocking
+ * suite reads the component source and compares the two.
+ */
+export const LISTING_ROLLUP_HIDE_BELOW_PX = listingRollupHideThreshold(
+  LISTING_ACTIONS_WIDEST_PX,
+  LISTING_ACTION_ROW_GAP_PX,
+  LISTING_ROLLUP_MIN_WIDTH_PX
+);

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -272,6 +272,15 @@ export const LISTING_ACTION_ROW_GAP_PX = 10;
  * menu replaced was an icon-only Edit `ActionIcon` at the same `size={36}`. The
  * coincidence is worth naming, because "the number did not move" is also the
  * shape of a measurement nobody took.
+ *
+ * 🔴 THE NUMBER IS ABOUT A CARD THAT HAS A `⋮`; WHICH VIEWERS THOSE ARE IS A
+ * SEPARATE FACT, AND IT MOVED WITHOUT THE NUMBER MOVING. The card does not offer
+ * "Leave a review" or "Report" (`appListingMenuSurface.ts`), so the viewers whose
+ * cluster is 184 rather than 137.9 are exactly the OWNER and a MODERATOR — not,
+ * as this constant's arithmetic briefly implied on the way here, every signed-in
+ * shopper. Nothing derived below changes; the population does, and a stale
+ * population is the half of a derived number that gets quoted instead of
+ * re-measured.
  */
 export const LISTING_ACTIONS_WIDEST_PX = 184;
 

--- a/src/components/Apps/appListingMenuSurface.ts
+++ b/src/components/Apps/appListingMenuSurface.ts
@@ -1,0 +1,56 @@
+/**
+ * App Store Listings — WHICH SURFACE the shared `⋮` menu is being rendered on, and
+ * the one thing that answer is allowed to change.
+ *
+ * Pure + React-free so the correctness gate lives in the blocking node `unit` project
+ * (the `.browser.test.tsx` component suites are report-only), mirroring its siblings
+ * `appListingDetailModActions` / `appListingCardView`.
+ *
+ * 🔴 WHY THIS EXISTS AT ALL, GIVEN THAT `AppListingActionsMenu` WAS WRITTEN TO MAKE
+ * THE TWO SURFACES IDENTICAL. Because one difference between them is real and the
+ * rest are not. The listing DETAIL page is a page the viewer chose to open about one
+ * app: offering them "Leave a review" and "Report" there is the point of the page.
+ * The store CARD is one of ~24 tiles in a grid the viewer is scanning, and the same
+ * two items on it are an invitation to review an app they have not opened. So the
+ * card offers only the items that are about ACTING ON YOUR OWN THING — the owner's
+ * Edit and the moderator section — and the viewer actions stay on the detail page.
+ *
+ * 🔴 THE POLICY LIVES HERE RATHER THAN AT THE CALL SITES, WHICH IS THE WHOLE POINT
+ * OF THE SHAPE. A boolean prop (`viewerActions={false}`) would put the POLICY in
+ * each call site, so a third surface would spell its own answer and the two could
+ * disagree — a predicate duplicated across call sites, which is precisely the drift
+ * `AppListingActionsMenu` was extracted to end. A `surface` name puts the call site
+ * in charge of saying WHERE it is and this module in charge of saying WHAT THAT
+ * MEANS, so the difference between the surfaces is auditable in one place.
+ */
+
+/** The surfaces that render `AppListingActionsMenu`. Closed on purpose. */
+export const APP_LISTING_MENU_SURFACES = ['card', 'detail'] as const;
+export type AppListingMenuSurface = (typeof APP_LISTING_MENU_SURFACES)[number];
+
+/**
+ * The surfaces that offer the VIEWER actions — "Leave a review" and "Report".
+ *
+ * 🔴 A `Set` OF THE ADMITTING SURFACES, NOT A `Record<Surface, boolean>` LOOKUP, AND
+ * THE DIFFERENCE IS THE FAILURE DIRECTION. A record indexed by a key that did not
+ * come from the union — `surface` is a prop, and a JS caller is not type-checked —
+ * resolves inherited members: `table['toString']` is a function, i.e. TRUTHY, so an
+ * unknown surface would be granted the viewer actions. `Set.has` answers false for
+ * every key it was not given, so an unknown surface gets the NARROWER menu. That is
+ * the same fails-open shape this repo has been bitten by before (civitai#3495).
+ */
+const VIEWER_ACTION_SURFACES: ReadonlySet<AppListingMenuSurface> = new Set(['detail']);
+
+/**
+ * May this surface offer "Leave a review" / "Report" to an ordinary signed-in viewer?
+ *
+ * 🔴 THIS IS A SURFACE GATE, NOT AN ELIGIBILITY GATE, and it is the NARROWER of the
+ * two by construction: it is `&&`-ed with `useCanReviewListing` / `useCanReportListing`
+ * rather than replacing either, so it can only ever REMOVE an item that those
+ * predicates already admitted. Nothing here can hand an action to a viewer the
+ * affordance's own rule refuses, and neither can it reach the server gate, which is
+ * the real boundary in both cases.
+ */
+export function surfaceOffersViewerActions(surface: AppListingMenuSurface): boolean {
+  return VIEWER_ACTION_SURFACES.has(surface);
+}


### PR DESCRIPTION
Two UI changes to the App Store listing card's action row, plus the consolidation the second one forced.

## 1. The primary CTA fills the row

The ask was a bigger primary action. The next Mantine size up is 42px tall and this row's height is load-bearing — it sits in an `h-full` grid row, so a taller control grows every card in that row across the store — so the only free axis is horizontal.

**The obvious implementation is wrong.** A bare `flex-grow` on the CTA eats all the free space at *every* width, starving the recommend rollup that the `@[264px]` query exists to protect. So the rollup's 70px floor — until now only the arithmetic *behind* that query — becomes an enforced `min-width`, and the CTA takes the remainder. Measured at a 462px container: rollup 95.7 (its natural width), CTA 310.3.

## 2. Edit moves into a `⋮` overflow menu

The card carried **two** Edit controls — a text `Button` and an icon-only `ActionIcon` — swapped by an `@[360px]` container query. Both are gone, and so is that breakpoint: a `⋮` trigger is a fixed 36px at every width, so the query had nothing left to decide. It is **deleted** rather than kept as a constant nothing needs.

## 3. The menu is shared, not copied

`AppListingDetailBody` already shipped this menu. A second copy is exactly how the card and the detail page drifted over the CTA glyph mapping, which had to be extracted into `appListingActionGlyph.ts` after the fact. So the whole thing — item set, order, labels, four eligibility predicates and four modals whose mount site is load-bearing — moves into `AppListingActionsMenu`, and the detail body now renders it. Only the trigger's geometry is parameterised.

## Geometry — re-derived from measurement, not re-recorded

```
threshold = actions(184) + row gap(10) + rollup floor(70) = 264
```

`actions = 184` is **measured**: a 36px `⋮` + the row's 10px `gap="xs"` + the widest CTA at its natural 137.9px. It happens to equal the pre-change value, because the control the menu replaced was an icon-only Edit `ActionIcon` at the same `size={36}` — named in the code, because "the number did not move" is also what an unmeasured number looks like.

Measured on this branch (card with a menu, widest CTA, no reviews — the shortest label the rollup can carry):

| card | container | actions nat/rendered | rollup | row h | rollup    |
|-----:|----------:|---------------------|-------:|------:|-----------|
|  280 |       248 | 184 / 248 (grown)   |    0   |    46 | HIDDEN    |
|  296 |       264 | 184 / 184           |   70.1 |    46 | at FLOOR  |
|  314 |       282 | 184 / 184           |   88.1 |    46 | clamped   |
|  494 |       462 | 184 / 356.3 (grown) |   95.7 |    46 | natural   |

and with **no** menu (anonymous shopper), which is what the byte-unchanged claim rests on:

| card | container | actions nat/rendered | rollup (reviewed) | row h |
|-----:|----------:|---------------------|------------------:|------:|
|  280 |       248 | 137.9 / 137.9       |             100.1 |    46 |
|  314 |       282 | 137.9 / 137.9       |             134.1 |    46 |
|  494 |       462 | 137.9 / 312.9       |             139.1 |    46 |

The 264 row is the model and the measurement agreeing to 0.1px. **Row height is 46 in every cell.**

The three constants and the arithmetic now live in `appListingCardView.ts` and are gated in the **blocking** node project: the sum, the rounding direction, and a source read asserting the component's `@[264px]` class spells the same number. A Tailwind arbitrary variant cannot read a JS constant, so the duplication is unavoidable — the drift is what gets gated.

## Gating, and a consequence worth reading before approving

The menu renders when it would hold **at least one item** — the detail page's own predicate, now written once in `useAppListingMenuGates`. A **signed-out** viewer gets no menu, so their card is byte-unchanged (pinned: actions 138, rollup ≥ 130).

🔴 **But `useCanReportListing` is `!!useCurrentUser()`, so an ordinary SIGNED-IN shopper does get a menu**, and their action cluster goes 137.9 → 184 exactly like an owner's. That is a real change on the most common path in the store. It is measured and pinned in a test rather than left to a screenshot. Narrowing it — dropping review/report from the *card's* copy of the menu and leaving them on the detail page — is a one-line change to `useAppListingMenuGates`, and that test is where the decision would show up. **Flagging it because the brief this was built from expected "an ordinary non-owner sees no menu at all", which is true only for signed-out viewers.**

A moderator viewing someone else's card also gets a menu and does change geometry. Accepted, and stated in a comment.

`AppListingCard` gains a `preview` prop, passed at `OffsiteReviewQueue`'s two card call sites. Without it the moderator reviewing an **unapproved shadow listing** — who is by definition a moderator — would be offered live takedown actions against a listing whose status and whose `id` are both unguaranteed. Same posture `AppListingDetailBody` already takes.

## Two things measured rather than reasoned

- **`Menu.Target > Tooltip > ActionIcon` silently breaks the menu.** Both clone their child and `Tooltip` overrides the ref, so the trigger stops opening the dropdown. A 2×2 probe (tooltip × stopPropagation) failed both tooltip-inside arms and passed all four with `Tooltip` wrapping `Menu.Target`. ⚠️ Several other files in this repo use the broken order (`ComicExportButton`, `GeneratedImageActions`, `DrawingToolbar`, the comics page's moderator menus) — **out of scope here and not fixed**, but worth someone's attention.
- **The modals mount lazily**, on first open. The grid renders ~24 cards; four modals each would be ~96 modal subtrees and ~24 `matchMedia` listeners for a viewer who will open at most one. Every one of them is reachable only from inside this menu, so nothing is lost.

## Ledgers re-pointed (each had to be edited, which is the ledger working)

`appModeratorMessageForm.callSites`, `appListingReportCallSites` and `appListingDetailModalPlacement` all read `AppListingDetailBody.tsx` as the mount site. The mount moved with the menu, so they now read `AppListingActionsMenu.tsx`. An extraction that had silently dropped the wiring would have shown up in them as a SHRINK.

Six browser suites mock `FeatureFlagsProvider` wholesale naming only `useFeatureFlags`; the card's graph now reaches `useOptionalFeatureFlags`, which took the whole component run down with an unattributable mocking error. Fixed by naming **both** hooks — **not** by an `importOriginal` spread. That was tried and moves the same failure one module over, exactly as `AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts` documents.

## Verification

**Watched-fail matrix** — every changed/new assertion, red at the base commit `e6fe40b0f2`, green at HEAD.

Browser tier (`AppListingCard.browser.test.tsx`), base card component restored: **13 failed / 46 passed**, → **59 passed** at HEAD. The 13:

- owner sees the Edit deep-link → on-site manifest editor
- owner of an off-site listing → Edit routes to the submit editor
- a non-owner gets a menu WITHOUT an Edit item
- a MODERATOR viewing someone else's card gets the moderator section
- EXACTLY ONE Edit affordance in the accessibility tree
- the `⋮` trigger has a real accessible name and does not navigate the card
- the `⋮` trigger is 36px — the row-height contract
- the action row does NOT wrap (changed: rollup `minWidth` 0 → 70, actions gained `flexGrow`)
- the recommend rollup is the side that absorbs the extra width (same change)
- the floor CLAMPS a menu-less rollup that would otherwise be a stub
- a SIGNED-IN shopper gets the menu, and the wider action cluster with it
- the primary CTA GROWS into the row × {anonymous, owner}

Blocking tier, base sources restored + the new module deleted: **14 failed / 53 passed** across the four guard files, → all green at HEAD. Includes all three new geometry guards, all four modal-placement checks plus their positive control, and all three call-site ledgers plus their positive controls.

🔴 **Labelled honestly as INVARIANT guards, not regression coverage** (measured: they pass on pre-change code too): "AT the threshold the rollup sits on its floor", the width sweep's floor half, "a signed-out viewer gets NO menu", "`preview` suppresses the whole menu". At any container width the store produces, `minWidth: 70` changes nothing — a deficit deep enough to push the rollup under 70 arrives at exactly the width where the query hides it, so on a card *with* a menu the clamp and the query bite at the same point by construction. The clamp is observable only on a **menu-less** card below a 218px container, which is what the discriminating test above uses (pre-change ≈ 20px stub, post-change exactly 70 with the row overflowing). That overflow is the accepted cost, asserted rather than hidden; no store surface goes below 248.

**Suites**

- `node scripts/typecheck.mjs` → **0 type errors** (negative control: an injected `const x: number = "s"` produced `1 type error(s)`, so the check can go red).
- Blocking unit project (`scripts/test-unit-run.mjs`) → **1566 files / 24859 passed, 3 files + 33 tests skipped, 0 failed**.
- Full browser component project (`scripts/test-component-run.mjs`, no filter) → **210 files / 2345 passed, 0 failed**, ledger `0 failed suites, 0 failed tests`, floor 1240 satisfied.

**Which tier each guard runs in.** `lint.yml` does not run `*.browser.test.tsx`, so every geometry/menu assertion in `AppListingCard.browser.test.tsx` is **report-only** in CI. The gating coverage is in the node `unit` project: the threshold arithmetic, the rounding direction, the `@[264px]` class spelling, the `@[360px]` deletion, the rollup's `min-width` being the constant, all four modal-placement checks and the three call-site ledgers.

**Prettier**: measured on the ten files this PR touches — all clean, with the same command reporting 2 dirty files before I formatted them (so the check is not vacuous). The added file `AppListingActionsMenu.tsx` — the only one where prettier blocks — is clean.

**Not verified**: nothing was exercised in a real browser against a live store page; every geometry number here comes from the component suite's real-stylesheet render, not from a screenshot of `/apps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBUj8SH7D2H8NTgHW1hDHm
