### PR TITLE
fix(event-engine): make the metric cache and live signals respect metricExcludedUsers

### DIFF
--- a/apps/event-engine/.env.example
+++ b/apps/event-engine/.env.example
@@ -32,6 +32,9 @@ BATCH_INSERT_INTERVAL=30
 INDEX_UPDATE_INTERVAL=300
 INDEX_UPDATE_ENABLED=false
 REDIS_CACHE_UPDATES_ENABLED=true
+# How often the reaction-farm exclusion list (ClickHouse metricExcludedUsers) is
+# re-read into the cache-increment path. Default 5 min.
+METRIC_EXCLUSION_REFRESH_MS=300000
 WORKER_POOL_SIZE=10
 HEALTH_CHECK_PORT=3000
 

--- a/apps/event-engine/CLAUDE.md
+++ b/apps/event-engine/CLAUDE.md
@@ -30,6 +30,7 @@ metric-event-watcher/
 │   │   ├── worker-pool.ts         # Parallel task processing
 │   │   ├── debezium-manager.ts    # CDC connector management
 │   │   ├── redis-cache.ts         # Redis cache updates
+│   │   ├── metric-excluded-users.ts # Reaction-farm exclusion list, mirrored from ClickHouse
 │   │   ├── metric-event-batcher.ts # ClickHouse batch inserts
 │   │   ├── index-update-queue.ts  # Meilisearch updates
 │   │   └── health-check.ts        # Health monitoring
@@ -78,6 +79,7 @@ metric-event-watcher/
 - **MetricEventBatcher**: ClickHouse batch inserts
 - **IndexUpdateQueue**: Meilisearch index updates
 - **RedisCache**: Real-time metric cache updates
+- **MetricExcludedUsers**: Mirrors the ClickHouse `metricExcludedUsers` reaction-farm list into memory (refreshed every `METRIC_EXCLUSION_REFRESH_MS`). `RedisCache` and the live signal path skip events from users in it, matching what the ClickHouse metric aggregates already filter
 
 ### Handlers (`src/handlers/`)
 - handlers for different entity types (User, Model, Post, Image, etc.)

--- a/apps/event-engine/README.md
+++ b/apps/event-engine/README.md
@@ -216,6 +216,22 @@ The service exposes comprehensive Prometheus metrics at `/metrics`. All metrics 
   - Labels: `operation` (increment, etc.)
 - `mew_redis_cache_errors_total{operation}` - Total Redis cache errors (counter)
 
+#### Metric Exclusion Metrics
+
+The reaction-farm suppression list (`metricExcludedUsers` in ClickHouse) is mirrored into each pod and
+gates both the Redis cache increment and the live metric signal, matching what the ClickHouse metric
+aggregates already filter.
+
+- `mew_metric_excluded_users` - Users in this pod's exclusion list (gauge)
+  - Per-pod state, so the fleet value is a MINIMUM rather than a single number: alert on
+    `min(mew_metric_excluded_users) == 0`, since one pod counting farm reactions drifts the shared cache.
+    A pod whose first load failed recovers on the next refresh, so a sustained 0 means the refresh itself
+    is failing.
+- `mew_metric_excluded_skipped_total{operation}` - Cache increments and live signals suppressed (counter)
+  - Labels: `operation` (`increment`, `increment_once`, `signal`)
+- `mew_metric_excluded_refresh_errors_total{cause}` - Failed refreshes of the exclusion list (counter)
+  - Labels: `cause` (`query` = the ClickHouse read, `unexpected` = a throw the refresh path does not expect)
+
 #### Default Node.js Metrics
 
 The service also exposes default Node.js metrics:
@@ -270,6 +286,7 @@ WORKER_POOL_SIZE=10  # Defaults to 10
 BATCH_INSERT_INTERVAL=30  # ClickHouse batch interval (seconds)
 INDEX_UPDATE_INTERVAL=300  # Meilisearch update interval (seconds)
 HEALTH_CHECK_PORT=3000  # Health check server port
+METRIC_EXCLUSION_REFRESH_MS=300000  # Re-read interval for the reaction-farm exclusion list; floored at 1000
 
 # Meilisearch (if using search index updates)
 MEILISEARCH_IMAGE_INDEX_URL=http://localhost:7700

--- a/apps/event-engine/src/__tests__/metric-excluded-users.test.ts
+++ b/apps/event-engine/src/__tests__/metric-excluded-users.test.ts
@@ -1,0 +1,290 @@
+// Deliberately outside `src/common`, for the reason given at the top of
+// signals.test.ts: `src/common` is a hand-vendored copy of event-engine-common and a
+// re-vendor would clobber a test living there.
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { MetricExcludedUsers } from '@/services/metric-excluded-users';
+import { RedisCache } from '@/services/redis-cache';
+import { EventProcessor } from '@/services/event-processor';
+import { metricSignals } from '@/services/metric-signals';
+import type { CacheUpdate, MetricEvent } from '@/types/events';
+
+type Row = { userId: number | string };
+
+/** Minimal stand-in for the ClickHouse client SimpleClickhouse wraps. */
+function chReturning(...responses: (Row[] | Error | undefined)[]) {
+  let call = 0;
+  return {
+    query: async () => {
+      const next = responses[Math.min(call++, responses.length - 1)];
+      if (next instanceof Error) throw next;
+      return { json: async () => next, text: async () => '', stream: () => undefined };
+    },
+  } as never;
+}
+
+type IncrCall = { key: string; field: string; value: number };
+
+function cacheWithFakeRedis(excluded: MetricExcludedUsers) {
+  const incr: IncrCall[] = [];
+  const incrOnce: IncrCall[] = [];
+  const client = {
+    run: async (commands: unknown[]) => commands,
+    hIncrIfExists: (key: string, field: string, value: number) => {
+      incr.push({ key, field, value });
+      return Promise.resolve(1);
+    },
+    hIncrIfExistsOnce: (key: string, _dedupeKey: string, field: string, value: number) => {
+      incrOnce.push({ key, field, value });
+      return Promise.resolve(true);
+    },
+  };
+  const cache = new RedisCache('redis://unused', excluded);
+  // Bypass connect(): it would dial a real host.
+  (cache as unknown as { client: unknown }).client = client;
+  (cache as unknown as { isConnected: boolean }).isConnected = true;
+  return { cache, incr, incrOnce };
+}
+
+function update(userId: number | string, metricType = 'Like'): CacheUpdate {
+  return {
+    entityId: 141298569,
+    entityType: 'Image',
+    metricType,
+    metricValue: 1,
+    userId: userId as number,
+  };
+}
+
+function event(userId: number | string, metricType = 'Like'): MetricEvent {
+  return {
+    ...update(userId, metricType),
+    timestamp: new Date('2026-09-02T17:39:23Z'),
+  };
+}
+
+async function loaded(...userIds: (number | string)[]) {
+  const list = new MetricExcludedUsers(chReturning(userIds.map((userId) => ({ userId }))), 60_000);
+  await list.refresh();
+  return list;
+}
+
+describe('MetricExcludedUsers', () => {
+  test('has() matches loaded ids and nothing else, and never matches a missing userId', async () => {
+    const list = await loaded(6680940, 7472843);
+
+    expect(list.has(6680940)).toBe(true);
+    expect(list.has(7472843)).toBe(true);
+    expect(list.has(9999999)).toBe(false);
+    // A CacheUpdate may carry userId null/undefined; those must not be treated as
+    // excluded or every anonymous-ish update would stop counting. '' matters
+    // separately because Number('') is 0, not NaN.
+    expect(list.has(null)).toBe(false);
+    expect(list.has(undefined)).toBe(false);
+    expect(list.has('')).toBe(false);
+    expect(list.size).toBe(2);
+  });
+
+  // clickhouse-js returns 64-bit integer columns as JS STRINGS, and
+  // handlers/manual/update-compensation.ts casts raw ClickHouse rows straight to
+  // CacheUpdate. Without coercion `Set<number>.has('6680940')` is false, the farm
+  // user is counted, and typecheck/lint/every other test still pass.
+  test('has() matches a userId that arrives as a string', async () => {
+    const list = await loaded(6680940);
+
+    expect(list.has('6680940')).toBe(true);
+    expect(list.has('not-a-number')).toBe(false);
+  });
+
+  // `Number(null)` and `Number('')` coerce to 0, so junk rows would otherwise enter
+  // the set as 0 — the id update-compensation writes on its model-earnings rows.
+  test('userId 0 is never admitted to the set', async () => {
+    const list = await loaded(0, 6680940);
+
+    expect(list.has(0)).toBe(false);
+    expect(list.size).toBe(1);
+  });
+
+  test('a failed refresh keeps the previous set rather than counting farm users again', async () => {
+    const list = new MetricExcludedUsers(
+      chReturning([{ userId: 6680940 }], new Error('clickhouse unreachable')),
+      60_000
+    );
+
+    await list.refresh();
+    expect(list.has(6680940)).toBe(true);
+
+    await list.refresh(); // throws internally
+    expect(list.has(6680940)).toBe(true);
+    expect(list.size).toBe(1);
+  });
+
+  // SimpleClickhouse casts `await response?.json()` to T[] through an optional
+  // chain, so a nullish response is TYPED as an array and is not one. Iterating it
+  // would throw out of a `void`ed interval callback and take the pod down, which
+  // is not what a method documented as "does not throw" should do.
+  test('a non-array response is handled, not thrown out of refresh', async () => {
+    const list = new MetricExcludedUsers(chReturning([{ userId: 6680940 }], undefined), 60_000);
+
+    await list.refresh();
+    await expect(list.refresh()).resolves.toBeUndefined();
+    expect(list.has(6680940)).toBe(true);
+  });
+
+  // Do not re-add the empty-result guard — see metric-excluded-users.ts refresh().
+  test('an empty successful refresh clears the list and does not strand suppressions', async () => {
+    const list = new MetricExcludedUsers(chReturning([{ userId: 6680940 }], []), 60_000);
+
+    await list.refresh();
+    expect(list.size).toBe(1);
+
+    await list.refresh();
+    expect(list.size).toBe(0);
+    expect(list.has(6680940)).toBe(false);
+  });
+
+  // An unparseable METRIC_EXCLUSION_REFRESH_MS reaches this constructor as NaN,
+  // and setInterval clamps a NaN delay to 1ms — a ClickHouse query loop from every
+  // pod, invisible because refresh() swallows its own errors.
+  test('a NaN or tiny refresh interval is floored, not passed to setInterval', async () => {
+    const spy = vi.spyOn(globalThis, 'setInterval');
+    const list = new MetricExcludedUsers(chReturning([]), Number.NaN);
+    await list.start();
+    list.stop();
+
+    expect(spy.mock.calls[0]?.[1]).toBeGreaterThanOrEqual(1000);
+
+    const tiny = new MetricExcludedUsers(chReturning([]), 5);
+    await tiny.start();
+    tiny.stop();
+
+    expect(spy.mock.calls[1]?.[1]).toBeGreaterThanOrEqual(1000);
+  });
+});
+
+describe('RedisCache respects the exclusion list', () => {
+  test('increment() drops excluded users and still applies the rest', async () => {
+    const excluded = await loaded(6680940, 7472843);
+    const { cache, incr } = cacheWithFakeRedis(excluded);
+
+    await cache.increment([update(6680940), update(111, 'Heart'), update(7472843)]);
+
+    expect(incr).toEqual([{ key: 'metrics:Image:141298569', field: 'Heart', value: 1 }]);
+  });
+
+  test('increment() issues no Redis command at all when every update is excluded', async () => {
+    const excluded = await loaded(6680940);
+    const { cache, incr } = cacheWithFakeRedis(excluded);
+
+    await cache.increment(update(6680940));
+
+    expect(incr).toEqual([]);
+  });
+
+  // The filter runs BEFORE connect(), so a fully-excluded batch never dials Redis.
+  // Asserted by making connect() fail loudly: move dropExcluded below the connect
+  // block and this throws instead of returning.
+  test('a fully-excluded batch returns without connecting', async () => {
+    const excluded = await loaded(6680940);
+    const cache = new RedisCache('redis://unused', excluded);
+    (cache as unknown as { connect: () => Promise<void> }).connect = async () => {
+      throw new Error('connect() must not be reached for a fully-excluded batch');
+    };
+
+    await expect(cache.increment(update(6680940))).resolves.toBeUndefined();
+  });
+
+  test('incrementOnce() skips an excluded user and applies a kept one', async () => {
+    const excluded = await loaded(6680940);
+    const { cache, incrOnce } = cacheWithFakeRedis(excluded);
+
+    await cache.incrementOnce(event(6680940));
+    await cache.incrementOnce(event(111, 'Heart'));
+
+    expect(incrOnce).toEqual([{ key: 'metrics:Image:141298569', field: 'Heart', value: 1 }]);
+  });
+});
+
+// Asserted at the CALL SITES in createActions, not on the predicate: a `has()` test
+// passes while the delta goes out unfiltered. Both sites are covered on purpose — an
+// earlier revision covered only addMetricEvent, and the ungated-incMetricCache mutant
+// passed the whole suite.
+describe('live metric signals respect the exclusion list', () => {
+  let restoreSignals: (() => void) | null = null;
+
+  afterEach(() => {
+    restoreSignals?.();
+    restoreSignals = null;
+  });
+
+  function actionsWith(excluded: MetricExcludedUsers) {
+    const sent: (number | string)[] = [];
+    const batched: (number | string)[] = [];
+    const original = metricSignals.sendDelta;
+    // Patched before anything that can throw, and released in afterEach: a throw
+    // between here and the assertions would otherwise leave the singleton patched
+    // for the rest of the file and poison the next test's `original`.
+    metricSignals.sendDelta = (async (upd: CacheUpdate) => {
+      sent.push(upd.userId as number);
+    }) as typeof metricSignals.sendDelta;
+    restoreSignals = () => {
+      metricSignals.sendDelta = original;
+    };
+
+    const proc = Object.create(EventProcessor.prototype) as EventProcessor;
+    Object.assign(proc, {
+      excludedUsers: excluded,
+      redisCache: { increment: async () => undefined, incrementOnce: async () => undefined },
+      metricBatcher: {
+        add: (ev: MetricEvent) => {
+          batched.push(ev.userId as number);
+        },
+      },
+    });
+
+    const actions = (
+      proc as unknown as {
+        createActions(
+          meta: unknown,
+          ts: Date
+        ): {
+          addMetricEvent(e: MetricEvent): void;
+          incMetricCache(u: CacheUpdate | CacheUpdate[]): Promise<void>;
+        };
+      }
+    ).createActions({ topic: 't', partition: 0, offset: '0' }, new Date());
+
+    return { actions, sent, batched };
+  }
+
+  test('addMetricEvent broadcasts a kept user and not an excluded one', async () => {
+    const excluded = await loaded(6680940);
+    const { actions, sent } = actionsWith(excluded);
+
+    actions.addMetricEvent(event(6680940));
+    actions.addMetricEvent(event(111, 'Heart'));
+
+    expect(sent).toEqual([111]);
+  });
+
+  test('incMetricCache broadcasts a kept user and not an excluded one', async () => {
+    const excluded = await loaded(6680940);
+    const { actions, sent } = actionsWith(excluded);
+
+    await actions.incMetricCache(update(6680940));
+    await actions.incMetricCache(update(111, 'Heart'));
+
+    expect(sent).toEqual([111]);
+  });
+
+  // Suppression is a read-side concern. The raw ClickHouse event table is what the
+  // aggregate filters FROM and what metric-reaction-repair reconciles against, so
+  // dropping these rows would break the thing that makes the count correct.
+  test('an excluded user still reaches the ClickHouse batch', async () => {
+    const excluded = await loaded(6680940);
+    const { actions, batched } = actionsWith(excluded);
+
+    actions.addMetricEvent(event(6680940));
+
+    expect(batched).toEqual([6680940]);
+  });
+});

--- a/apps/event-engine/src/config/index.ts
+++ b/apps/event-engine/src/config/index.ts
@@ -19,6 +19,13 @@ export const config = {
     // makes the increment a no-op on replay. Redelivery from a rebalance lands
     // within seconds, so this only needs to cover the realistic replay gap.
     cacheDedupeTtlSeconds: parseInt(process.env.CACHE_DEDUPE_TTL_SECONDS ?? '3600'),
+    // How often the reaction-farm exclusion list is re-read from ClickHouse. The
+    // admin endpoint that writes it documents the effect as landing "within ~5
+    // min", so matching that keeps the increment path no staler than the promise
+    // already made about the aggregate. MetricExcludedUsers floors this at 1s —
+    // it drives a setInterval, so an unparseable value would otherwise become a
+    // 1ms query loop against ClickHouse from every pod.
+    metricExclusionRefreshMs: parseInt(process.env.METRIC_EXCLUSION_REFRESH_MS ?? '300000', 10),
   },
   kafka: {
     brokers: (process.env.KAFKA_BROKERS ?? 'localhost:9092').split(','),

--- a/apps/event-engine/src/metrics.ts
+++ b/apps/event-engine/src/metrics.ts
@@ -195,6 +195,29 @@ export const redisCacheMetrics = {
   }),
 };
 
+// Per-pod in-memory state, so `size` is a fleet-wide MINIMUM: alert on
+// min(mew_metric_excluded_users) == 0, since one pod counting farm reactions
+// drifts the shared cache.
+export const excludedUsersMetrics = {
+  size: new Gauge({
+    name: 'mew_metric_excluded_users',
+    help: 'Number of users in this pod\'s in-memory reaction-farm exclusion list',
+    registers: [register],
+  }),
+  skipped: new Counter({
+    name: 'mew_metric_excluded_skipped_total',
+    help: 'Total cache increments and live signals suppressed because the originating user is metric-excluded',
+    labelNames: ['operation'],
+    registers: [register],
+  }),
+  refreshErrors: new Counter({
+    name: 'mew_metric_excluded_refresh_errors_total',
+    help: 'Failed refreshes of the exclusion list, by cause',
+    labelNames: ['cause'],
+    registers: [register],
+  }),
+};
+
 // Cache Drift Monitor Metrics
 // Periodically compares the Redis metric cache against the deduped ClickHouse
 // ground truth for a sample of hot entities. This is the leading indicator for

--- a/apps/event-engine/src/services/event-processor.ts
+++ b/apps/event-engine/src/services/event-processor.ts
@@ -16,10 +16,11 @@ import { OutboxPoller } from '@/services/outbox-poller'
 import { spineService } from '@/services/spine'
 import { HandlerContext, EventHandler, HandlerActions, FeedUpdateType } from '@/types/handlers'
 import { createEventHandlerMapper } from '@/utils/handler-mapper'
-import { eventProcessorMetrics, queryCacheMetrics } from '@/metrics'
+import { eventProcessorMetrics, excludedUsersMetrics, queryCacheMetrics } from '@/metrics'
 import { MetricService } from '@/common/services/metrics'
 import { CacheService } from '@/common/services/cache'
 import { CacheDriftMonitor } from '@/services/cache-drift-monitor'
+import { MetricExcludedUsers } from '@/services/metric-excluded-users'
 
 interface HandlerEntry {
   name: string
@@ -42,6 +43,7 @@ export class EventProcessor {
   private metricService!: MetricService
   private cacheService!: CacheService
   private cacheDriftMonitor: CacheDriftMonitor | null = null
+  private excludedUsers: MetricExcludedUsers
   private outboxService: OutboxService
   private outboxPoller: OutboxPoller | null = null
   private isRunning: boolean = false
@@ -64,7 +66,8 @@ export class EventProcessor {
       host: config.clickhouse.url
     })
 
-    this.redisCache = new RedisCache(config.redis.url)
+    this.excludedUsers = new MetricExcludedUsers(this.chClient, config.redis.metricExclusionRefreshMs)
+    this.redisCache = new RedisCache(config.redis.url, this.excludedUsers)
     this.metricBatcher = new MetricEventBatcher(this.chClient)
     this.outboxService = new OutboxService(this.pgPool)
 
@@ -87,6 +90,9 @@ export class EventProcessor {
     if (this.isRunning) return
 
     this.isRunning = true
+
+    // Before the first event, so a reaction in the opening seconds is not counted.
+    await this.excludedUsers.start()
 
     await this.redisCache.connect()
 
@@ -164,6 +170,7 @@ export class EventProcessor {
 
     this.outboxPoller?.stop()
     this.cacheDriftMonitor?.stop()
+    this.excludedUsers.stop()
 
     if (this.queryCacheManager) {
       await this.queryCacheManager.stop()
@@ -370,9 +377,18 @@ export class EventProcessor {
 
   private createActions(kafkaMeta: KafkaOffsetMeta, eventTimestamp: Date): HandlerActions {
     const actions: HandlerActions = {
+      // A live delta is broadcast to every viewer of the entity, so it is a third
+      // writer of the same displayed number and has to agree with the other two.
+      // Filtering the cache but not the signal would push a +1 that no store
+      // holds, and the count would tick up and then revert on the next fetch.
       incMetricCache: async (update: CacheUpdate | CacheUpdate[]) => {
         await this.redisCache.increment(update)
-        if (!Array.isArray(update)) await metricSignals.sendDelta(update)
+        if (Array.isArray(update)) return
+        if (this.excludedUsers.has(update.userId)) {
+          excludedUsersMetrics.skipped.inc({ operation: 'signal' })
+          return
+        }
+        await metricSignals.sendDelta(update)
       },
       addMetricEvent: (event: MetricEvent) => {
         if (event.entityId == null || !event.userId) {
@@ -386,6 +402,8 @@ export class EventProcessor {
           _kafka: kafkaMeta,
         }
 
+        // Excluded users' events still go to ClickHouse: the raw table is what the
+        // aggregate filters FROM and what the repair path reconciles against.
         this.metricBatcher.add(enriched)
         // Apply the cache increment inline. incrementOnce is idempotent per
         // (entity, metric, source message), so a rebalance/restart replay
@@ -395,7 +413,11 @@ export class EventProcessor {
         // untracked entities are simply skipped until a reader populates them).
         void this.redisCache.incrementOnce(enriched)
         // Signals are ephemeral live hints, emitted immediately for snappy UI.
-        void metricSignals.sendDelta(enriched as CacheUpdate)
+        if (this.excludedUsers.has(enriched.userId)) {
+          excludedUsersMetrics.skipped.inc({ operation: 'signal' })
+        } else {
+          void metricSignals.sendDelta(enriched as CacheUpdate)
+        }
       },
       feedUpdate: (entityType: FeedUpdate['entityType'], entityId: FeedUpdate['entityId'], type: FeedUpdateType = 'update') => {
         if (entityId == null) return

--- a/apps/event-engine/src/services/metric-excluded-users.ts
+++ b/apps/event-engine/src/services/metric-excluded-users.ts
@@ -1,0 +1,122 @@
+import { SimpleClickhouse } from '@/common/utils/query-utils';
+import { logger } from '@/utils/logger';
+import { excludedUsersMetrics } from '@/metrics';
+
+/**
+ * The reaction-farm suppression list, cached in memory.
+ *
+ * `metricExcludedUsers` is written by `/api/admin/reaction-abuse` and filtered by
+ * the ClickHouse aggregate the metric cache repopulates from (those view
+ * definitions live in ClickHouse, not in this repo). The Redis increment path did
+ * not filter it, so `metrics:<type>:<id>` counted suppressed reactions until its
+ * 12h TTL lapsed, and the value a user saw depended on cache age.
+ *
+ * Excluded accounts are NOT banned, deleted or muted: this list suppresses
+ * metrics only, so nothing else in the pipeline drops their rows.
+ */
+export interface ExcludedUserLookup {
+  has(userId?: number | string | null): boolean;
+}
+
+const REFRESH_QUERY = `SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1`;
+const MIN_REFRESH_MS = 1000;
+
+export class MetricExcludedUsers implements ExcludedUserLookup {
+  private ch: SimpleClickhouse;
+  private ids: Set<number> = new Set();
+  private loaded = false;
+  private timer: NodeJS.Timeout | null = null;
+  private readonly intervalMs: number;
+
+  constructor(chClient: ConstructorParameters<typeof SimpleClickhouse>[0], intervalMs: number) {
+    this.ch = new SimpleClickhouse(chClient);
+    // parseInt('5m') is 5 and parseInt('abc') is NaN, which setInterval clamps to 1ms —
+    // a ClickHouse query loop from every pod, silent because refresh() swallows its errors.
+    this.intervalMs = Number.isFinite(intervalMs)
+      ? Math.max(MIN_REFRESH_MS, intervalMs)
+      : MIN_REFRESH_MS;
+  }
+
+  /**
+   * Loads once, then on an interval. Never throws: a ClickHouse failure at boot leaves
+   * the set empty — the pre-fix behaviour of counting everything. Failing closed would
+   * drop every increment and freeze every displayed count.
+   */
+  async start(): Promise<void> {
+    if (this.timer) return;
+    await this.refresh();
+    this.timer = setInterval(() => {
+      this.refresh().catch((err) => {
+        excludedUsersMetrics.refreshErrors.inc({ cause: 'unexpected' });
+        logger.error({ err }, 'Metric exclusion refresh threw unexpectedly');
+      });
+    }, this.intervalMs);
+    this.timer.unref?.();
+    logger.info(
+      `Metric exclusion list started (${this.ids.size} users, refresh ${Math.round(
+        this.intervalMs / 1000
+      )}s)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async refresh(): Promise<void> {
+    try {
+      // Iterating INSIDE the try is load-bearing: SimpleClickhouse casts `response?.json()`
+      // to T[] through an optional chain, so a nullish response is typed as an array and is
+      // not one — iterating outside would throw out of the void'ed interval callback.
+      const rows = await this.ch.query<{ userId: number | string }>(REFRESH_QUERY);
+
+      const next = new Set<number>();
+      for (const row of rows) {
+        const id = Number(row.userId);
+        // `Number(null)` and `Number('')` are 0, not NaN, so isFinite alone admits junk
+        // rows as 0 — the same id update-compensation writes on its model-earnings rows.
+        if (Number.isFinite(id) && id > 0) next.add(id);
+      }
+
+      // Do NOT re-add a guard that keeps the previous set on an empty result. `unexclude`
+      // takes up to 5000 ids in one call, so an empty list is a real state; keeping the old
+      // set would suppress those users with no TTL until a pod restart.
+      if (next.size === 0 && this.ids.size > 0) {
+        logger.warn(
+          { previousSize: this.ids.size },
+          'Metric exclusion list is now empty; nothing will be suppressed'
+        );
+      }
+
+      this.ids = next;
+      this.loaded = true;
+      excludedUsersMetrics.size.set(next.size);
+    } catch (err) {
+      excludedUsersMetrics.refreshErrors.inc({ cause: 'query' });
+      logger.error({ err }, 'Failed to refresh metric exclusion list; keeping previous set');
+    }
+  }
+
+  /**
+   * Coerces: callers' `userId` is typed by assertion, not validation — handlers read it
+   * off an untyped Debezium record, and update-compensation casts raw ClickHouse rows to
+   * CacheUpdate, where 64-bit columns arrive as strings. `Set<number>.has('6680940')` is
+   * false, so without this a farm user is counted and every test still passes.
+   */
+  has(userId?: number | string | null): boolean {
+    if (userId == null || userId === '') return false;
+    const id = Number(userId);
+    return Number.isFinite(id) && this.ids.has(id);
+  }
+
+  get size(): number {
+    return this.ids.size;
+  }
+
+  get isLoaded(): boolean {
+    return this.loaded;
+  }
+}

--- a/apps/event-engine/src/services/redis-cache.ts
+++ b/apps/event-engine/src/services/redis-cache.ts
@@ -5,8 +5,9 @@ import { cacheKeys } from '@/common/utils/cache-keys'
 import { EntityType } from '@/common/types/metric-types'
 import { RedisWithHelpers, withRedisHelpers } from '@/common/utils/query-utils'
 import { chunk } from '@/common/utils/basic'
-import { redisCacheMetrics } from '@/metrics'
+import { excludedUsersMetrics, redisCacheMetrics } from '@/metrics'
 import { config } from '@/config'
+import type { ExcludedUserLookup } from '@/services/metric-excluded-users'
 
 /**
  * Manages Redis cache updates for real-time metrics
@@ -15,7 +16,7 @@ export class RedisCache {
   private client: RedisWithHelpers<RedisClusterType> | null = null
   private isConnected: boolean = false
 
-  constructor(private redisUrl: string) {}
+  constructor(private redisUrl: string, private excludedUsers: ExcludedUserLookup) {}
 
   /**
    * Connect to Redis
@@ -76,14 +77,16 @@ export class RedisCache {
   async increment(update: CacheUpdate | CacheUpdate[]): Promise<void> {
     if (!config.redis.cacheUpdatesEnabled) return
 
+    const requested = Array.isArray(update) ? update : [update]
+    const counted = this.dropExcluded(requested, 'increment')
+    if (counted.length === 0) return
+
     if (!this.client || !this.isConnected) {
       await this.connect()
     }
 
-    update = Array.isArray(update) ? update : [update]
-
     // Use a pipeline for batch updates
-    const batches = chunk(update, 1000); // Process in batches of 1000
+    const batches = chunk(counted, 1000);
     for (const batch of batches) {
       // Using concurrent commands (node redis pipelines)
       try {
@@ -115,6 +118,10 @@ export class RedisCache {
   ): Promise<void> {
     if (!config.redis.cacheUpdatesEnabled) return
     if (event.entityId == null) return
+    if (this.excludedUsers.has(event.userId)) {
+      excludedUsersMetrics.skipped.inc({ operation: 'increment_once' })
+      return
+    }
 
     if (!this.client || !this.isConnected) {
       await this.connect()
@@ -263,6 +270,13 @@ export class RedisCache {
       logger.error({ err, entityType, entityId }, 'Failed to check cache existence')
       return false
     }
+  }
+
+  private dropExcluded(updates: CacheUpdate[], operation: string): CacheUpdate[] {
+    const kept = updates.filter((upd) => !this.excludedUsers.has(upd.userId))
+    const skipped = updates.length - kept.length
+    if (skipped > 0) excludedUsersMetrics.skipped.inc({ operation }, skipped)
+    return kept
   }
 
   /**

--- a/src/pages/api/admin/reaction-abuse.ts
+++ b/src/pages/api/admin/reaction-abuse.ts
@@ -4,10 +4,12 @@
  *
  * Hidden route. Guarded by WEBHOOK_TOKEN via `?token=` (see WebhookEndpoint).
  * No public UI. Designed so an out-of-loop agent can PULL suspect reactor data,
- * apply judgment, and COMMIT excluded users — the same `metricExcludedUsers`
- * ClickHouse table the `entityMetricDaily_mv` materialized view filters on, so
- * excluded users stop counting toward reaction metrics/ranking (forward-only,
- * within ~5 min on the current day).
+ * apply judgment, and COMMIT excluded users to the `metricExcludedUsers` ClickHouse
+ * table. Two things filter it: the ClickHouse metric aggregates, and apps/event-engine,
+ * which mirrors the list into memory so the Redis metric cache and the live metric
+ * signals stop counting excluded users too. Forward-only, within ~5 min on the current
+ * day — and that number is load-bearing in a second place: event-engine's
+ * METRIC_EXCLUSION_REFRESH_MS default was chosen to match it.
  *
  * NOTE: lives under /api/admin (NOT /api/testing) on purpose — it is called by a
  * scheduled agent in PRODUCTION, and `route-guards.middleware.ts` hard-blocks


### PR DESCRIPTION
## The bug is not what the ticket said

ClickUp `868m0a19b` was filed as "the image metric aggregate is lossy" — `entityMetricDailyAgg_v2` returning 4 where Postgres and the raw `entityMetricEvents` both returned 24. **The aggregate is not lossy. It is strict.** It filters `metricExcludedUsers`, a reaction-farm suppression list of 461 active accounts written by `/api/admin/reaction-abuse`. Postgres does not.

Proved in Postgres alone — the 461 ids pulled from ClickHouse and inlined, each image's `ImageReaction` rows split into kept vs excluded, no ClickHouse in the computation:

| imageId | pg_all | excluded | pg_kept | aggregate | residual |
|---|---|---|---|---|---|
| 141295926 | 25 | 20 | **5** | 5 | **0** |
| 141298569 | 24 | 20 | **4** | 4 | **0** |
| 141488072 | 16 | 8 | **8** | 8 | **0** |
| 140989291 | 12 | 8 | **4** | 4 | **0** |

Re-running the ticket's own sampling method over 120 images: the aggregate matches the raw Postgres count on 104, and matches Postgres-minus-the-list on **115**. Max error **12 → 1**, total error **89 → 5**, and zero images off by more than 1. One image, 140719304, has all 12 of its reactions from farm accounts and correctly reads 0.

## What this PR fixes

`metrics:<entityType>:<id>` has **two writers with different definitions of the same number**:

1. `MetricService` repopulates it on a cache miss from `entityMetricDailyAgg_v2` — farm-filtered, 12h TTL.
2. `RedisCache.increment` / `incrementOnce` HINCRBY it per Kafka event — **no filter**.

So a farm reaction lands in the cache immediately and is stripped only when the entry expires. Image 141298569 read **24 from Redis and 4 from ClickHouse**: the number a user saw depended on cache age. On 150 images touched by an excluded user in the last 10 days, 88 had a cached hash; Redis exceeded the aggregate on **43** of them, 11 at a ratio of 1.5 or more — `redis 13 / view 2` among them. (62 were not cached: that absence is the control proving the probe can return empty.)

This makes the increment path respect the same list, mirrored into memory and refreshed every 5 minutes to match what the admin endpoint already documents.

**The live signal is gated too.** `metricSignals.sendDelta` broadcasts to a topic keyed by the same string as the cache key, so every viewer of the entity receives the delta — a third writer of the same number. Filtering the cache alone would push a `+1` that no store holds, and the count would tick up live and revert on the next fetch.

**Excluded users' events still reach ClickHouse.** The raw event table is what the aggregate filters *from* and what `metric-reaction-repair` reconciles against. Suppression belongs to the read side, not to the record.

## Four things a reader will otherwise get wrong

- **The 461 are not banned, not deleted, not muted.** All 10 excluded reactors on image 141298569 checked against Postgres `User`: `bannedAt` null, `deletedAt` null, `muted` false. This list suppresses metrics only. Anyone meeting it later will assume moderation and be wrong.
- **Exclusion is forward-only, by design**, in ClickHouse as well as here. `entityMetricTotal_v3` recomputes only for entities in `entityMetricDirty_v3`, so an image whose farm reactors were excluded after its last reaction stays inflated indefinitely. In a 400-image June-2025 sample, 9 of the 26 affected images were still stale-high.
- **This repairs nothing.** It stops new inflation. Counts already inflated stay inflated until their key is evicted and repopulated from the aggregate — `exclude` performs no `metrics:*` purge. If the intent is that 141298569 shows 4 today, this change alone does not do that.
- 🔴 **Merging this changes nothing in production until an `@civitai/event-engine` release is cut and deployed.** The app releases separately from the main app, with its own Dockerfile, `k8s/` and version. Merged is not deployed.

## `mew_cache_drift_ratio` is a green check that could not have gone red

`cache-drift-monitor.ts` exports exactly this signal and reads clean. I ran its own sampling query, ground-truth query, ratio and 1.1 threshold against prod: `max 1.0081, p95 1.0051, drifted 0`.

The control that makes that a finding rather than reassurance: **49 of the 50 images it samples carry suppressed reactions right now**, up to 45 on one image. It samples the *hottest* images of the last hour, where a farm ring's 30-45 reactions sit on a base of ~4,000 — a ceiling of ~1.012 against a 1.1 threshold. The population where the defect bites measures **6.5**. Sampling by heat cannot see a defect that lives on low-count images. Not fixed here; filed separately.

Axiom could not answer whether it ever warned: the event-engine logger targets the `civitai-event-watcher` dataset, and `dataset-info` returns `"fields": []` — the dataset is empty, so its logs do not land there. That is real absence, not a bad query.

## Verification

Run against `b948031797`, rebased on `ef7698fdf5`:

| check | result | what it covered |
|---|---|---|
| `pnpm run typecheck` (root) | exit 0 | src/ — needed because this touches `reaction-abuse.ts` |
| `pnpm --filter @civitai/event-engine typecheck` | exit 0 | **the app — the root typecheck does not cover `apps/`** |
| `pnpm --filter @civitai/event-engine lint` | exit 0 | CI lints this app explicitly (`LINTABLE='^(src\|packages\|apps/event-engine)/'`) |
| `pnpm run test:apps:run` | exit 0 | `Test Files 113 passed (113)`, `Tests 1225 passed \| 36 skipped (1261)` |
| `pnpm run test:unit:run` | exit 0 | `Test Files 1569 passed \| 3 skipped (1572)`, `Tests 24881 passed \| 35 skipped (24916)` — **runs zero files in this diff** |
| `prettier --check` (2 new files) | clean | added files are CI-blocking; scoped to mine so neighbours are not reformatted |

`blocks.router.workflow.test.ts` collected **370** tests, not zero — the submodule is initialised, so the unit run means something.

Root typecheck was **red with 5 errors** in `orchestration-new.service.ts` and `training.orch.ts` before a reinstall, on identical code. `@civitai/client` resolved to `0.2.0-beta.95` against a `0.2.0-beta.97` pin: a stale dependency after a rebase, not this diff. It is green on the same commit after `pnpm install`.

### Every test fails on revert, by name

Nine mutants, each restored with an md5 match:

| mutant | caught by |
|---|---|
| `increment` filter removed | `increment() drops excluded users…` + 2 others |
| `incrementOnce` guard removed | `incrementOnce() skips an excluded user…` |
| `addMetricEvent` signal gate removed | `addMetricEvent broadcasts a kept user and not an excluded one` |
| `incMetricCache` signal gate removed | `incMetricCache broadcasts a kept user and not an excluded one` |
| ClickHouse batch drops excluded | `an excluded user still reaches the ClickHouse batch` |
| `has()` coercion removed | `has() matches a userId that arrives as a string` |
| userId 0 admitted to the set | `userId 0 is never admitted to the set` |
| interval clamp removed | `a NaN or tiny refresh interval is floored…` |
| row loop moved outside the `try` | `a non-array response is handled, not thrown out of refresh` |

Two of those exist because a mutant **survived** first: the `incMetricCache` signal gate had no coverage at all and passed the whole suite ungated, and an `Array.isArray` guard I had added turned out unfalsifiable — the enclosing `try` already caught it — so it was deleted rather than kept as decoration.

## Review

Adversarial review prompted to refute, plus `comment-review` and `docs-drift-review`. The main-app five (`civitai-correctness-review` and friends) do not apply — no Mantine, no tRPC, no Prisma, no `src/`.

Findings acted on: unvalidated `METRIC_EXCLUSION_REFRESH_MS` (a typo became a 1ms ClickHouse query loop per pod — now floored at 1s); a type-coercion hole where `update-compensation` casts raw ClickHouse rows to `CacheUpdate` and clickhouse-js returns 64-bit columns as strings, making `Set<number>.has('6680940')` false; the row loop sitting outside its `try` in a method documented not to throw.

I also **reversed one of my own decisions**. An earlier revision kept the previous list when a refresh returned zero rows, on a comment asserting that un-excluding happens one user at a time. `reaction-abuse.ts` validates `userIds: z.array(...).max(5000)` — that comment was false, and the guard would have stranded up to 5000 suppressions with no TTL until a pod restart, drifting counts the opposite way from this bug. Removed, and pinned with a test named for the decision.

Refs ClickUp `868m0a19b`. Blocks `868kuyu5t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Pcj1JeRGSkvVo7f3Ek6q2
