### PR TITLE
feat(announcements): attribute creator announcements in the notifications panel

### DIFF
--- a/src/components/Announcements/Announcement.tsx
+++ b/src/components/Announcements/Announcement.tsx
@@ -48,9 +48,9 @@ export function Announcement({
           <LegacyActionIcon
             variant="subtle"
             radius="xl"
-            color="red"
+            color="gray"
             onClick={handleDismiss}
-            className="absolute right-2 top-2"
+            className="absolute right-2 top-2 text-dark-9 dark:text-white"
             aria-label="Dismiss announcement"
           >
             <IconX size={20} />

--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -125,7 +125,12 @@ export function AnnouncementCard({
       )}
 
       <div
-        className={clsx('flex flex-1 flex-col justify-center gap-2 p-3', cover && 'border-l')}
+        className={clsx(
+          'flex flex-1 flex-col justify-center gap-2 p-3',
+          // Gated on the same container query that hides the cover: keyed on the DATA alone
+          // this is a second border 1px inside the card's own on a narrow card.
+          cover && 'border-l @max-xs:border-l-0'
+        )}
         style={cover ? { borderColor } : undefined}
       >
         {(!!title || !!controls) && (

--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -1,5 +1,5 @@
 import type { ButtonVariant } from '@mantine/core';
-import { Button, Title, useMantineTheme } from '@mantine/core';
+import { alpha, Button, Title, useMantineTheme } from '@mantine/core';
 import clsx from 'clsx';
 import React from 'react';
 import { ANNOUNCEMENT_IMAGE_WIDTH } from '~/components/Announcements/announcement-image';
@@ -54,6 +54,7 @@ export function AnnouncementCard({
   color,
   cover,
   actions = [],
+  topBar,
   controls,
   overlay,
   footer,
@@ -66,6 +67,12 @@ export function AnnouncementCard({
   color: string;
   cover?: AnnouncementCardCover | null;
   actions?: AnnouncementCardAction[];
+  /**
+   * A full-width bar across the top of the card, outside the cover/content row. Attribution
+   * for a card Civitai did not write goes here rather than beside the title: the frame is
+   * what a reader takes in before any of the card's own content.
+   */
+  topBar?: React.ReactNode;
   /** Rendered beside the title — moderator or author controls. */
   controls?: React.ReactNode;
   /** Absolutely positioned over the card, e.g. the dismiss button. */
@@ -75,15 +82,8 @@ export function AnnouncementCard({
   const theme = useMantineTheme();
   const borderColor = theme.colors[color]?.[4] ?? theme.colors.blue[4];
 
-  return (
-    <TwCard
-      className={clsx('items-stretch border', className)}
-      direction="row"
-      style={{ borderColor, ...style }}
-      {...props}
-    >
-      {overlay}
-
+  const body = (
+    <>
       {cover && (
         // Both halves of `size-40` are load-bearing. The height is what makes this square:
         // it is a definite cross size, so the row's `items-stretch` no longer applies, and
@@ -124,7 +124,10 @@ export function AnnouncementCard({
         </div>
       )}
 
-      <div className="flex flex-1 flex-col justify-center gap-2 p-3">
+      <div
+        className={clsx('flex flex-1 flex-col justify-center gap-2 p-3', cover && 'border-l')}
+        style={cover ? { borderColor } : undefined}
+      >
         {(!!title || !!controls) && (
           <div className="flex justify-between gap-2">
             {!!title && <Title order={4}>{title}</Title>}
@@ -151,6 +154,39 @@ export function AnnouncementCard({
         )}
         {footer}
       </div>
+    </>
+  );
+
+  if (!topBar)
+    return (
+      <TwCard
+        className={clsx('items-stretch border', className)}
+        direction="row"
+        style={{ borderColor, ...style }}
+        {...props}
+      >
+        {overlay}
+        {body}
+      </TwCard>
+    );
+
+  return (
+    <TwCard
+      className={clsx('border', className)}
+      direction="col"
+      style={{ borderColor, ...style }}
+      {...props}
+    >
+      {overlay}
+      {/* A wash of the border colour rather than the colour itself: the bar has to read as
+          part of the frame without competing with the announcement's own content. */}
+      <div
+        className="w-full border-b px-3 py-2"
+        style={{ backgroundColor: alpha(borderColor, 0.15), borderColor }}
+      >
+        {topBar}
+      </div>
+      <div className="flex flex-1 items-stretch">{body}</div>
     </TwCard>
   );
 }

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -89,7 +89,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     ...actual,
     trpc: new Proxy(stubbed, {
       get(target, prop: string) {
-        if (prop in target) return target[prop];
+        if (Object.hasOwn(target, prop)) return target[prop];
         throw new Error(`Unmocked tRPC router in a component test: trpc.${String(prop)}`);
       },
     }),

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -11,8 +11,8 @@ import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvid
 import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import type * as Trpc from '~/utils/trpc';
 import {
+  clearDismissedCreatorAnnouncements,
   CREATOR_ANNOUNCEMENTS_DISMISSED_KEY,
-  pruneDismissedCreatorAnnouncements,
 } from '~/components/Announcements/creator-announcement-dismissals';
 
 /**
@@ -145,10 +145,10 @@ describe('AnnouncementsPanel', () => {
     // The dismissal store is module-scope and reads localStorage ONCE, at import. In browser
     // mode the module is not re-evaluated between tests — `vi.resetModules()` does not do it,
     // measured: moving the dismissal test to run first made four later tests fail on a leaked
-    // dismissal. Pruning against an empty live set clears the set through the store's own
-    // API, which is the only thing that actually resets it. The localStorage key goes too, so
-    // a fresh import in some later run does not read a stale set back.
-    pruneDismissedCreatorAnnouncements([]);
+    // dismissal. Reset through the store's state rather than by pruning against an empty live
+    // set: that is the behaviour the panel deliberately guards against, so a reset built on it
+    // would no-op the day anyone moves that guard down into the store.
+    clearDismissedCreatorAnnouncements();
     window.localStorage.removeItem(CREATOR_ANNOUNCEMENTS_DISMISSED_KEY);
   });
 
@@ -235,8 +235,9 @@ describe('AnnouncementsPanel', () => {
 
   // The prune's whole contract is the early return on an empty live set: `pruneDismissals`
   // cannot tell "nothing is live" from "nothing has loaded", so pruning against an empty
-  // load would drop every dismissal the user has made. Deleting that guard, or the effect,
-  // makes this test fail — the card comes back.
+  // load would drop every dismissal the user has made. Deleting THAT GUARD makes this test
+  // fail — the card comes back. Deleting the effect does not; the test below is the one that
+  // covers the effect, and the two are separate arms on purpose.
   test('a load with no creator announcements does not resurrect a dismissal', async () => {
     await renderPanel(['civitai', 'creators']);
     await page.getByRole('button', { name: 'Dismiss creator announcement' }).click();
@@ -252,5 +253,24 @@ describe('AnnouncementsPanel', () => {
     await renderPanel(['civitai', 'creators']);
     await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
     expect(page.getByText('Creator says hello').elements()).toHaveLength(0);
+  });
+
+  // The other arm: the effect has to actually run, or dismissals accumulate forever in a
+  // store that is never swept. A load that no longer carries a dismissed id must drop it,
+  // so the id coming back later is visible again rather than dismissed by a stale entry.
+  test('an id that leaves the feed is pruned, so it is visible again if it returns', async () => {
+    await renderPanel(['civitai', 'creators']);
+    await page.getByRole('button', { name: 'Dismiss creator announcement' }).click();
+    await expect.element(page.getByText('Creator says hello')).not.toBeInTheDocument();
+
+    cleanup();
+    mocks.creators = [{ ...creatorAnnouncement, id: 7, title: 'Someone else' }];
+    await renderPanel(['civitai', 'creators']);
+    await expect.element(page.getByText('Someone else')).toBeInTheDocument();
+
+    cleanup();
+    mocks.creators = [creatorAnnouncement];
+    await renderPanel(['civitai', 'creators']);
+    await expect.element(page.getByText('Creator says hello')).toBeInTheDocument();
   });
 });

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -5,6 +5,11 @@ import type * as AnnouncementsUtils from '~/components/Announcements/announcemen
 import type * as CreatorUtils from '~/components/Announcements/creator-announcements.utils';
 import type * as CurrentUser from '~/hooks/useCurrentUser';
 import type * as IsClientProvider from '~/providers/IsClientProvider';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
+import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvider';
+import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import type * as Trpc from '~/utils/trpc';
+import { CREATOR_ANNOUNCEMENTS_DISMISSED_KEY } from '~/components/Announcements/creator-announcement-dismissals';
 
 /**
  * The chips decide which SOURCE renders, and both are on by default. The failure this
@@ -47,6 +52,40 @@ vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
   useIsClient: () => true,
 }));
 
+// The byline's avatar reads three more providers this scaffold does not mount.
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
+  useFeatureFlags: () => ({ canViewNsfw: false, creatorAnnouncements: true }),
+}));
+
+vi.mock('~/providers/BrowserSettingsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowserSettingsProvider>()),
+  useBrowsingSettings: () => false,
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowsingLevelProvider>()),
+  useViewerBrowsingLevelDebounced: () => 1,
+}));
+
+// `UserAvatar` calls `trpc.user.getById.useQuery` even when it is handed a user (the query
+// is disabled, the hook still runs), and this scaffold mounts no tRPC provider. Only that
+// one procedure is replaced; the rest of the module is the real one.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  return {
+    ...actual,
+    trpc: {
+      ...actual.trpc,
+      user: {
+        ...(actual.trpc as any).user,
+        getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+      },
+    },
+  };
+});
+
+
 const civitaiAnnouncement = {
   id: 1,
   title: 'Civitai says hello',
@@ -73,7 +112,14 @@ const creatorAnnouncement = {
   userId: 99,
   nsfwLevel: 1,
   cover: null,
-  user: { id: 99, username: 'someone' },
+  user: {
+    id: 99,
+    username: 'someone',
+    image: null,
+    deletedAt: null,
+    cosmetics: [],
+    profilePicture: null,
+  },
 };
 
 async function renderPanel(sources: Array<'civitai' | 'creators'>) {
@@ -86,6 +132,11 @@ describe('AnnouncementsPanel', () => {
     mocks.civitai = [civitaiAnnouncement];
     mocks.creators = [creatorAnnouncement];
     mocks.featureEnabled = true;
+    // The dismissal store is module-scope and reads localStorage once, at import. Clearing
+    // the key alone would leave the previous test's in-memory set standing, so the modules
+    // are reset too and `renderPanel`'s dynamic import rebuilds the store from empty.
+    window.localStorage.removeItem(CREATOR_ANNOUNCEMENTS_DISMISSED_KEY);
+    vi.resetModules();
   });
 
   test('both chips on renders both sources', async () => {
@@ -123,5 +174,37 @@ describe('AnnouncementsPanel', () => {
     await renderPanel(['civitai', 'creators']);
 
     await expect.element(page.getByText('All caught up! Nothing to see here')).toBeInTheDocument();
+  });
+
+  test('a creator announcement in the panel names its author and is marked as a creator post', async () => {
+    await renderPanel(['civitai', 'creators']);
+
+    await expect.element(page.getByText('someone')).toBeInTheDocument();
+
+    // The href exactly, not a role-name match: a name matches as a SUBSTRING, so that
+    // assertion passes against a link pointing anywhere.
+    const hrefs = page
+      .getByRole('link')
+      .elements()
+      .map((el) => el.getAttribute('href'));
+    expect(hrefs).toContain('/user/someone');
+  });
+
+  test('a civitai announcement carries no creator byline', async () => {
+    await renderPanel(['civitai']);
+
+    await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
+    expect(page.getByText('someone').elements()).toHaveLength(0);
+  });
+
+  test('dismissing a creator announcement removes it and leaves the civitai one', async () => {
+    await renderPanel(['civitai', 'creators']);
+    await expect.element(page.getByText('Creator says hello')).toBeInTheDocument();
+
+    await page.getByRole('button', { name: 'Dismiss creator announcement' }).click();
+
+    await expect.element(page.getByText('Creator says hello')).not.toBeInTheDocument();
+    // The control: dismissal is targeted, not a panel-wide clear.
+    await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
   });
 });

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
+import { cleanup } from 'vitest-browser-react';
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as AnnouncementsUtils from '~/components/Announcements/announcements.utils';
 import type * as CreatorUtils from '~/components/Announcements/creator-announcements.utils';
@@ -9,7 +10,10 @@ import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
 import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvider';
 import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import type * as Trpc from '~/utils/trpc';
-import { CREATOR_ANNOUNCEMENTS_DISMISSED_KEY } from '~/components/Announcements/creator-announcement-dismissals';
+import {
+  CREATOR_ANNOUNCEMENTS_DISMISSED_KEY,
+  pruneDismissedCreatorAnnouncements,
+} from '~/components/Announcements/creator-announcement-dismissals';
 
 /**
  * The chips decide which SOURCE renders, and both are on by default. The failure this
@@ -68,23 +72,29 @@ vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOrigina
   useViewerBrowsingLevelDebounced: () => 1,
 }));
 
-// `UserAvatar` calls `trpc.user.getById.useQuery` even when it is handed a user (the query
-// is disabled, the hook still runs), and this scaffold mounts no tRPC provider. Only that
-// one procedure is replaced; the rest of the module is the real one.
+// A STUB tRPC client, not a narrowed real one. `trpc` is a tRPC flat Proxy, and spreading a
+// Proxy reads ownKeys — which is empty — so `{...actual.trpc}` yields `{}`. Anything not
+// named here is absent by construction; the Proxy below turns that into a named error
+// instead of `Cannot read properties of undefined` inside a render, which empties the tree
+// and makes every assertion in the file time out with nothing pointing at tRPC.
+//
+// `UserAvatar` calls `trpc.user.getById.useQuery` even when handed a complete user (the
+// query is disabled, the hook still runs), and this scaffold mounts no tRPC provider.
 vi.mock('~/utils/trpc', async (importOriginal) => {
   const actual = await importOriginal<typeof Trpc>();
+  const stubbed: Record<string, unknown> = {
+    user: { getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) } },
+  };
   return {
     ...actual,
-    trpc: {
-      ...actual.trpc,
-      user: {
-        ...(actual.trpc as any).user,
-        getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    trpc: new Proxy(stubbed, {
+      get(target, prop: string) {
+        if (prop in target) return target[prop];
+        throw new Error(`Unmocked tRPC router in a component test: trpc.${String(prop)}`);
       },
-    },
+    }),
   };
 });
-
 
 const civitaiAnnouncement = {
   id: 1,
@@ -132,11 +142,14 @@ describe('AnnouncementsPanel', () => {
     mocks.civitai = [civitaiAnnouncement];
     mocks.creators = [creatorAnnouncement];
     mocks.featureEnabled = true;
-    // The dismissal store is module-scope and reads localStorage once, at import. Clearing
-    // the key alone would leave the previous test's in-memory set standing, so the modules
-    // are reset too and `renderPanel`'s dynamic import rebuilds the store from empty.
+    // The dismissal store is module-scope and reads localStorage ONCE, at import. In browser
+    // mode the module is not re-evaluated between tests — `vi.resetModules()` does not do it,
+    // measured: moving the dismissal test to run first made four later tests fail on a leaked
+    // dismissal. Pruning against an empty live set clears the set through the store's own
+    // API, which is the only thing that actually resets it. The localStorage key goes too, so
+    // a fresh import in some later run does not read a stale set back.
+    pruneDismissedCreatorAnnouncements([]);
     window.localStorage.removeItem(CREATOR_ANNOUNCEMENTS_DISMISSED_KEY);
-    vi.resetModules();
   });
 
   test('both chips on renders both sources', async () => {
@@ -190,11 +203,23 @@ describe('AnnouncementsPanel', () => {
     expect(hrefs).toContain('/user/someone');
   });
 
-  test('a civitai announcement carries no creator byline', async () => {
-    await renderPanel(['civitai']);
-
+  // BOTH sources render, and the assertion is scoped to the Civitai card's own subtree.
+  // Rendering only `['civitai']` would pass with the whole feature deleted — the creator
+  // card simply would not be on screen — which is a different fact than the one under test.
+  test('a civitai announcement carries no creator byline while a creator one does', async () => {
+    await renderPanel(['civitai', 'creators']);
     await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
-    expect(page.getByText('someone').elements()).toHaveLength(0);
+
+    const civitaiCard = page.getByText('Civitai says hello').element().closest('.rounded-md');
+    const creatorCard = page.getByText('Creator says hello').element().closest('.rounded-md');
+    if (!civitaiCard || !creatorCard) throw new Error('both cards should have rendered');
+
+    expect(civitaiCard.querySelector('a[href="/user/someone"]')).toBeNull();
+    expect(civitaiCard.classList.contains('flex-col')).toBe(false);
+    // The positive half, in the same list: whatever distinguishes them has to be present on
+    // one card and absent on the other, or "absent here" means nothing.
+    expect(creatorCard.querySelector('a[href="/user/someone"]')).not.toBeNull();
+    expect(creatorCard.classList.contains('flex-col')).toBe(true);
   });
 
   test('dismissing a creator announcement removes it and leaves the civitai one', async () => {
@@ -206,5 +231,26 @@ describe('AnnouncementsPanel', () => {
     await expect.element(page.getByText('Creator says hello')).not.toBeInTheDocument();
     // The control: dismissal is targeted, not a panel-wide clear.
     await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
+  });
+
+  // The prune's whole contract is the early return on an empty live set: `pruneDismissals`
+  // cannot tell "nothing is live" from "nothing has loaded", so pruning against an empty
+  // load would drop every dismissal the user has made. Deleting that guard, or the effect,
+  // makes this test fail — the card comes back.
+  test('a load with no creator announcements does not resurrect a dismissal', async () => {
+    await renderPanel(['civitai', 'creators']);
+    await page.getByRole('button', { name: 'Dismiss creator announcement' }).click();
+    await expect.element(page.getByText('Creator says hello')).not.toBeInTheDocument();
+
+    cleanup();
+    mocks.creators = [];
+    await renderPanel(['civitai', 'creators']);
+    await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
+
+    cleanup();
+    mocks.creators = [creatorAnnouncement];
+    await renderPanel(['civitai', 'creators']);
+    await expect.element(page.getByText('Civitai says hello')).toBeInTheDocument();
+    expect(page.getByText('Creator says hello').elements()).toHaveLength(0);
   });
 });

--- a/src/components/Announcements/AnnouncementsPanel.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.tsx
@@ -3,7 +3,12 @@ import React from 'react';
 import { Announcement } from '~/components/Announcements/Announcement';
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import { CreatorAnnouncement } from '~/components/Announcements/CreatorAnnouncement';
-import { DeleteCreatorAnnouncementButton } from '~/components/Announcements/CreatorAnnouncementsCarousel';
+import {
+  dismissCreatorAnnouncement,
+  pruneDismissedCreatorAnnouncements,
+  useDismissedCreatorAnnouncements,
+} from '~/components/Announcements/creator-announcement-dismissals';
+import { DeleteCreatorAnnouncementMenuItem } from '~/components/Announcements/CreatorAnnouncementsCarousel';
 import { AnnouncementMuteMenuItem } from '~/components/Announcements/AnnouncementMuteToggle';
 import {
   useCreatorAnnouncementsFeature,
@@ -11,10 +16,13 @@ import {
   useQueryFollowedAnnouncements,
 } from '~/components/Announcements/creator-announcements.utils';
 import { Menu } from '@mantine/core';
-import { IconDotsVertical } from '@tabler/icons-react';
+import { IconDotsVertical, IconX } from '@tabler/icons-react';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
 export type AnnouncementSource = 'civitai' | 'creators';
+
+// Stable reference so the memo below does not churn when creators are switched off.
+const EMPTY_CREATOR_ITEMS: never[] = [];
 
 export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] }) {
   const creatorAnnouncementsEnabled = useCreatorAnnouncementsFeature();
@@ -25,10 +33,25 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
   const { announcements: creators, isLoading: loadingCreators } =
     useQueryFollowedAnnouncements(showCreators);
   const mutedCreatorIds = useMutedCreators();
+  const dismissedCreatorIds = useDismissedCreatorAnnouncements();
 
   const isLoading = (showCivitai && loadingCivitai) || (showCreators && loadingCreators);
   const civitaiItems = showCivitai ? civitai : [];
-  const creatorItems = showCreators ? creators : [];
+  // Memoised because the prune effect below depends on it: a fresh array each render would
+  // re-run the effect every render.
+  const creatorItems = React.useMemo(
+    () => (showCreators ? creators : EMPTY_CREATOR_ITEMS),
+    [showCreators, creators]
+  );
+
+  // Same contract as the sitewide prune: only once the live set has resolved, or an empty
+  // load would drop every dismissal.
+  React.useEffect(() => {
+    if (!creatorItems.length) return;
+    pruneDismissedCreatorAnnouncements(creatorItems.map((x) => x.id));
+  }, [creatorItems]);
+
+  const visibleCreatorItems = creatorItems.filter((x) => !dismissedCreatorIds.includes(x.id));
 
   if (isLoading)
     return (
@@ -37,7 +60,7 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
       </Center>
     );
 
-  if (!civitaiItems.length && !creatorItems.length)
+  if (!civitaiItems.length && !visibleCreatorItems.length)
     return (
       <Center p="sm">
         <Text>All caught up! Nothing to see here</Text>
@@ -53,13 +76,13 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
           style={announcement.dismissed ? { background: 'transparent' } : undefined}
         />
       ))}
-      {creatorItems.map((announcement) => (
+      {visibleCreatorItems.map((announcement) => (
         <CreatorAnnouncement
           key={announcement.id}
           announcement={announcement}
+          withAuthor
           actions={
             <div className="flex items-center gap-1">
-              <DeleteCreatorAnnouncementButton announcement={announcement} />
               {!!announcement.user && (
                 <Menu withinPortal position="bottom-end">
                   <Menu.Target>
@@ -78,9 +101,20 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
                       creatorName={announcement.user.username}
                       muted={mutedCreatorIds.includes(announcement.user.id)}
                     />
+                    <DeleteCreatorAnnouncementMenuItem announcement={announcement} />
                   </Menu.Dropdown>
                 </Menu>
               )}
+              <LegacyActionIcon
+                variant="subtle"
+                color="gray"
+                radius="xl"
+                className="text-dark-9 dark:text-white"
+                onClick={() => dismissCreatorAnnouncement(announcement.id)}
+                aria-label="Dismiss creator announcement"
+              >
+                <IconX size={16} />
+              </LegacyActionIcon>
             </div>
           }
         />

--- a/src/components/Announcements/AnnouncementsPanel.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.tsx
@@ -8,7 +8,7 @@ import {
   pruneDismissedCreatorAnnouncements,
   useDismissedCreatorAnnouncements,
 } from '~/components/Announcements/creator-announcement-dismissals';
-import { DeleteCreatorAnnouncementMenuItem } from '~/components/Announcements/CreatorAnnouncementsCarousel';
+import { DeleteCreatorAnnouncementButton } from '~/components/Announcements/CreatorAnnouncementsCarousel';
 import { AnnouncementMuteMenuItem } from '~/components/Announcements/AnnouncementMuteToggle';
 import {
   useCreatorAnnouncementsFeature,
@@ -83,28 +83,30 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
           withAuthor
           actions={
             <div className="flex items-center gap-1">
-              {!!announcement.user && (
-                <Menu withinPortal position="bottom-end">
-                  <Menu.Target>
-                    <LegacyActionIcon
-                      variant="subtle"
-                      color="gray"
-                      radius="xl"
-                      aria-label="Announcement options"
-                    >
-                      <IconDotsVertical size={16} />
-                    </LegacyActionIcon>
-                  </Menu.Target>
-                  <Menu.Dropdown>
+              <Menu withinPortal position="bottom-end">
+                <Menu.Target>
+                  <LegacyActionIcon
+                    variant="subtle"
+                    color="gray"
+                    radius="xl"
+                    aria-label="Announcement options"
+                  >
+                    <IconDotsVertical size={16} />
+                  </LegacyActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  {/* Muting needs an author to mute; deleting does not, and a moderator
+                      should not lose the control on the row most likely to need it. */}
+                  {!!announcement.user && (
                     <AnnouncementMuteMenuItem
                       creatorId={announcement.user.id}
                       creatorName={announcement.user.username}
                       muted={mutedCreatorIds.includes(announcement.user.id)}
                     />
-                    <DeleteCreatorAnnouncementMenuItem announcement={announcement} />
-                  </Menu.Dropdown>
-                </Menu>
-              )}
+                  )}
+                  <DeleteCreatorAnnouncementButton announcement={announcement} as="menu-item" />
+                </Menu.Dropdown>
+              </Menu>
               <LegacyActionIcon
                 variant="subtle"
                 color="gray"

--- a/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
@@ -90,9 +90,11 @@ const announcement = {
   },
 } as any;
 
-async function renderCard(withAuthor: boolean) {
+async function renderCard(withAuthor: boolean, overrides: Record<string, unknown> = {}) {
   const { CreatorAnnouncement } = await import('~/components/Announcements/CreatorAnnouncement');
-  renderWithProviders(<CreatorAnnouncement announcement={announcement} withAuthor={withAuthor} />);
+  renderWithProviders(
+    <CreatorAnnouncement announcement={{ ...announcement, ...overrides }} withAuthor={withAuthor} />
+  );
 }
 
 /**
@@ -141,5 +143,17 @@ describe('CreatorAnnouncement attribution', () => {
 
     await expect.element(page.getByText('Creator says hello')).toBeInTheDocument();
     expect(page.getByText('someone').elements()).toHaveLength(0);
+  });
+
+  // FAILS CLOSED. An author-less row cannot reach the panel today — both queries pin
+  // `userId: { not: null }` — but nothing pins that coupling, and the direction of failure
+  // matters more than its likelihood here: dropping the bar would render a creator
+  // announcement in the exact shape of an official Civitai one, which is the confusion this
+  // whole feature exists to prevent. Gate the bar on `withAuthor`, never on the author.
+  test('an author-less row still gets a top bar rather than the sitewide card shape', async () => {
+    await renderCard(true, { user: null });
+
+    expect((await cardRoot()).classList.contains('flex-col')).toBe(true);
+    await expect.element(page.getByText('Creator announcement')).toBeInTheDocument();
   });
 });

--- a/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
@@ -60,7 +60,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
     ...actual,
     trpc: new Proxy(stubbed, {
       get(target, prop: string) {
-        if (prop in target) return target[prop];
+        if (Object.hasOwn(target, prop)) return target[prop];
         throw new Error(`Unmocked tRPC router in a component test: trpc.${String(prop)}`);
       },
     }),
@@ -90,7 +90,7 @@ const announcement = {
   },
 } as any;
 
-async function renderCard(withAuthor: boolean, overrides: Record<string, unknown> = {}) {
+async function renderCard(withAuthor: boolean, overrides: Partial<typeof announcement> = {}) {
   const { CreatorAnnouncement } = await import('~/components/Announcements/CreatorAnnouncement');
   renderWithProviders(
     <CreatorAnnouncement announcement={{ ...announcement, ...overrides }} withAuthor={withAuthor} />
@@ -121,6 +121,10 @@ describe('CreatorAnnouncement attribution', () => {
     const links = page.getByRole('link').elements();
     const hrefs = links.map((el) => el.getAttribute('href'));
     expect(hrefs).toContain('/user/someone');
+
+    // The author-less fallback label is the OTHER branch of the same ternary; without this,
+    // rendering both the avatar and the label would pass every test in the file.
+    expect(page.getByText('Creator announcement').elements()).toHaveLength(0);
   });
 
   // The sitewide Civitai card renders through the same `AnnouncementCard` with no top bar.

--- a/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
@@ -43,23 +43,29 @@ vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOrigina
   useViewerBrowsingLevelDebounced: () => 1,
 }));
 
-// `UserAvatar` calls `trpc.user.getById.useQuery` even when it is handed a user (the query
-// is disabled, the hook still runs), and this scaffold mounts no tRPC provider. Only that
-// one procedure is replaced; the rest of the module is the real one.
+// A STUB tRPC client, not a narrowed real one. `trpc` is a tRPC flat Proxy, and spreading a
+// Proxy reads ownKeys — which is empty — so `{...actual.trpc}` yields `{}`. Anything not
+// named here is absent by construction; the Proxy below turns that into a named error
+// instead of `Cannot read properties of undefined` inside a render, which empties the tree
+// and makes every assertion in the file time out with nothing pointing at tRPC.
+//
+// `UserAvatar` calls `trpc.user.getById.useQuery` even when handed a complete user (the
+// query is disabled, the hook still runs), and this scaffold mounts no tRPC provider.
 vi.mock('~/utils/trpc', async (importOriginal) => {
   const actual = await importOriginal<typeof Trpc>();
+  const stubbed: Record<string, unknown> = {
+    user: { getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) } },
+  };
   return {
     ...actual,
-    trpc: {
-      ...actual.trpc,
-      user: {
-        ...(actual.trpc as any).user,
-        getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+    trpc: new Proxy(stubbed, {
+      get(target, prop: string) {
+        if (prop in target) return target[prop];
+        throw new Error(`Unmocked tRPC router in a component test: trpc.${String(prop)}`);
       },
-    },
+    }),
   };
 });
-
 
 const announcement = {
   id: 2,

--- a/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as CurrentUser from '~/hooks/useCurrentUser';
+import type * as IsClientProvider from '~/providers/IsClientProvider';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
+import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvider';
+import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import type * as Trpc from '~/utils/trpc';
+
+/**
+ * The byline is OFF by default and the surface turns it on.
+ *
+ * 🔴 Do not "simplify" this by making the byline unconditional. It is deliberately absent
+ * on the author's own profile, where every card on the page is already theirs, and present
+ * in the notifications panel, where creator and Civitai cards are interleaved in one list
+ * and a reader has no other way to tell an announcement is not from Civitai. That second
+ * case is an impersonation surface, not a missing nicety.
+ */
+
+vi.mock('~/hooks/useCurrentUser', async (importOriginal) => ({
+  ...(await importOriginal<typeof CurrentUser>()),
+  useCurrentUser: () => ({ id: 1, isModerator: false }),
+}));
+
+vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof IsClientProvider>()),
+  useIsClient: () => true,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
+  useFeatureFlags: () => ({ canViewNsfw: false }),
+}));
+
+vi.mock('~/providers/BrowserSettingsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowserSettingsProvider>()),
+  useBrowsingSettings: () => false,
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowsingLevelProvider>()),
+  useViewerBrowsingLevelDebounced: () => 1,
+}));
+
+// `UserAvatar` calls `trpc.user.getById.useQuery` even when it is handed a user (the query
+// is disabled, the hook still runs), and this scaffold mounts no tRPC provider. Only that
+// one procedure is replaced; the rest of the module is the real one.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  return {
+    ...actual,
+    trpc: {
+      ...actual.trpc,
+      user: {
+        ...(actual.trpc as any).user,
+        getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) },
+      },
+    },
+  };
+});
+
+
+const announcement = {
+  id: 2,
+  title: 'Creator says hello',
+  content: 'new lora dropping',
+  color: 'blue',
+  emoji: null,
+  metadata: {},
+  startsAt: new Date(),
+  endsAt: null,
+  createdAt: new Date(),
+  userId: 99,
+  nsfwLevel: 1,
+  cover: null,
+  user: {
+    id: 99,
+    username: 'someone',
+    image: null,
+    deletedAt: null,
+    cosmetics: [],
+    profilePicture: null,
+  },
+} as any;
+
+async function renderCard(withAuthor: boolean) {
+  const { CreatorAnnouncement } = await import('~/components/Announcements/CreatorAnnouncement');
+  renderWithProviders(<CreatorAnnouncement announcement={announcement} withAuthor={withAuthor} />);
+}
+
+/**
+ * The card root, found from content the card definitely rendered. Awaits that content
+ * first: the render is committed asynchronously, so reading the DOM straight after
+ * `renderCard` sees an empty body and fails for a reason that has nothing to do with the
+ * layout under test.
+ */
+async function cardRoot() {
+  await expect.element(page.getByText('new lora dropping')).toBeInTheDocument();
+  const el = page.getByText('new lora dropping').element().closest('.rounded-md');
+  if (!el) throw new Error('no card root found — the card did not render');
+  return el;
+}
+
+describe('CreatorAnnouncement attribution', () => {
+  test('withAuthor renders the creator name and a profile link in the top bar', async () => {
+    await renderCard(true);
+
+    await expect.element(page.getByText('someone')).toBeInTheDocument();
+
+    // The href exactly, not a name match: `getByRole('link', { name })` matches as a
+    // SUBSTRING, so it would pass against a link pointing anywhere.
+    const links = page.getByRole('link').elements();
+    const hrefs = links.map((el) => el.getAttribute('href'));
+    expect(hrefs).toContain('/user/someone');
+  });
+
+  // The sitewide Civitai card renders through the same `AnnouncementCard` with no top bar.
+  // `flex-col` is what the top-bar path adds to the card root, so its absence is the
+  // structural proof that path is not taken — no stylesheet needed to read it.
+  test('the no-top-bar path leaves the card a row, as the sitewide card has always been', async () => {
+    await renderCard(false);
+
+    expect((await cardRoot()).classList.contains('flex-col')).toBe(false);
+  });
+
+  test('withAuthor stacks the card so the top bar spans it', async () => {
+    await renderCard(true);
+
+    expect((await cardRoot()).classList.contains('flex-col')).toBe(true);
+  });
+
+  test('without withAuthor there is no byline — the profile surface renders this shape', async () => {
+    await renderCard(false);
+
+    await expect.element(page.getByText('Creator says hello')).toBeInTheDocument();
+    expect(page.getByText('someone').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Announcements/CreatorAnnouncement.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.tsx
@@ -6,6 +6,7 @@ import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 
 export const DEFAULT_ANNOUNCEMENT_TITLE = 'Creator Announcement';
+export const CREATOR_ANNOUNCEMENT_LABEL = 'Creator announcement';
 
 /**
  * A creator-authored announcement. Layout lives in `AnnouncementCard`, shared with the
@@ -29,7 +30,6 @@ export function CreatorAnnouncement({
   withAuthor?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>) {
   const { cover, user } = announcement;
-  const showAuthor = withAuthor && !!user;
   const postedAt = announcement.startsAt ?? announcement.createdAt;
 
   // The backfill stores this title on migrated banners, so this fallback is for the case
@@ -59,12 +59,27 @@ export function CreatorAnnouncement({
       actions={announcement.metadata?.actions ?? []}
       // With a top bar the controls belong up there beside the author, not indented into
       // the content; without one there is nowhere else for them to go.
-      controls={showAuthor ? undefined : actions}
+      controls={withAuthor ? undefined : actions}
       topBar={
-        showAuthor ? (
+        withAuthor ? (
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2">
-              <UserAvatar user={user} size="sm" withUsername linkToProfile withHoverCard={false} />
+              {user ? (
+                <UserAvatar
+                  user={user}
+                  size="sm"
+                  withUsername
+                  linkToProfile
+                  withHoverCard={false}
+                />
+              ) : (
+                // Fails CLOSED. An author-less row cannot reach this today, but if one ever
+                // does, dropping the bar would render a creator announcement in the exact
+                // shape of an official Civitai one — the confusion this exists to prevent.
+                <Text size="sm" fw={500}>
+                  {CREATOR_ANNOUNCEMENT_LABEL}
+                </Text>
+              )}
               <Text c="dimmed" size="xs" className="whitespace-nowrap">
                 <DaysFromNow date={postedAt} />
               </Text>
@@ -74,7 +89,7 @@ export function CreatorAnnouncement({
         ) : null
       }
       footer={
-        showAuthor ? null : (
+        withAuthor ? null : (
           <Text c="dimmed" size="xs">
             <DaysFromNow date={postedAt} />
           </Text>

--- a/src/components/Announcements/CreatorAnnouncement.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { AnnouncementCard } from '~/components/Announcements/AnnouncementCard';
 import type { CreatorAnnouncement as CreatorAnnouncementModel } from '~/components/Announcements/creator-announcement.types';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 
 export const DEFAULT_ANNOUNCEMENT_TITLE = 'Creator Announcement';
 
@@ -10,16 +11,26 @@ export const DEFAULT_ANNOUNCEMENT_TITLE = 'Creator Announcement';
  * A creator-authored announcement. Layout lives in `AnnouncementCard`, shared with the
  * sitewide variant; what is specific here is the cover coming from a real `Image` row, the
  * fallback title, and the posted-at line.
+ *
+ * `withAuthor` is off by default because the surface decides, not the row: on the author's
+ * own profile the byline is noise, while in the notifications panel creator and Civitai
+ * cards are interleaved in one list and a reader has to be able to tell them apart. The
+ * author sits in the card's top bar rather than beside the title so that identity is part
+ * of the frame, not of the content the author wrote.
  */
 export function CreatorAnnouncement({
   announcement,
   actions,
+  withAuthor = false,
   ...props
 }: {
   announcement: CreatorAnnouncementModel;
   actions?: React.ReactNode;
+  withAuthor?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>) {
-  const { cover } = announcement;
+  const { cover, user } = announcement;
+  const showAuthor = withAuthor && !!user;
+  const postedAt = announcement.startsAt ?? announcement.createdAt;
 
   // The backfill stores this title on migrated banners, so this fallback is for the case
   // it does not cover: a creator writing a body-only announcement. Same wording, so the two
@@ -46,11 +57,28 @@ export function CreatorAnnouncement({
           : null
       }
       actions={announcement.metadata?.actions ?? []}
-      controls={actions}
+      // With a top bar the controls belong up there beside the author, not indented into
+      // the content; without one there is nowhere else for them to go.
+      controls={showAuthor ? undefined : actions}
+      topBar={
+        showAuthor ? (
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <UserAvatar user={user} size="sm" withUsername linkToProfile withHoverCard={false} />
+              <Text c="dimmed" size="xs" className="whitespace-nowrap">
+                <DaysFromNow date={postedAt} />
+              </Text>
+            </div>
+            {actions}
+          </div>
+        ) : null
+      }
       footer={
-        <Text c="dimmed" size="xs">
-          <DaysFromNow date={announcement.startsAt ?? announcement.createdAt} />
-        </Text>
+        showAuthor ? null : (
+          <Text c="dimmed" size="xs">
+            <DaysFromNow date={postedAt} />
+          </Text>
+        )
       }
       {...props}
     />

--- a/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
@@ -13,17 +13,28 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 /**
- * Who may delete, and the confirm step. Shared so the profile's icon button and the panel's
- * menu item cannot drift apart on either — the permission is the load-bearing half.
+ * Delete an announcement, as an icon button or as a menu entry. One component with `as`
+ * rather than two, following `HideUserButton` and its siblings: the permission, the confirm
+ * step and the in-flight state cannot then differ between the two chromes.
+ *
+ * In the panel this lives in the options menu — a destructive control does not belong loose
+ * in the card's top bar, which is chrome the reader scans.
  */
-function useDeleteCreatorAnnouncementAction(announcement: CreatorAnnouncementModel) {
+export function DeleteCreatorAnnouncementButton({
+  announcement,
+  as = 'button',
+}: {
+  announcement: CreatorAnnouncementModel;
+  as?: 'menu-item' | 'button';
+}) {
   const currentUser = useCurrentUser();
   const { deleteAnnouncement, isLoading } = useDeleteCreatorAnnouncement();
 
   const canDelete =
     !!currentUser && (currentUser.isModerator || currentUser.id === announcement.userId);
+  if (!canDelete) return null;
 
-  const confirmDelete = () =>
+  const handleDelete = () =>
     openConfirmModal({
       title: 'Delete announcement',
       children: 'Are you sure you want to delete this announcement? This cannot be undone.',
@@ -32,45 +43,24 @@ function useDeleteCreatorAnnouncementAction(announcement: CreatorAnnouncementMod
       onConfirm: () => deleteAnnouncement(announcement.id),
     });
 
-  return { canDelete, isLoading, confirmDelete };
-}
-
-export function DeleteCreatorAnnouncementButton({
-  announcement,
-}: {
-  announcement: CreatorAnnouncementModel;
-}) {
-  const { canDelete, isLoading, confirmDelete } = useDeleteCreatorAnnouncementAction(announcement);
-  if (!canDelete) return null;
-
-  return (
+  return as === 'button' ? (
     <LegacyActionIcon
       variant="subtle"
       color="red"
       radius="xl"
       loading={isLoading}
-      onClick={confirmDelete}
+      onClick={handleDelete}
       aria-label="Delete announcement"
     >
       <IconTrash size={18} />
     </LegacyActionIcon>
-  );
-}
-
-/**
- * The same action as a menu entry. In the panel the card's top bar is chrome the reader
- * scans, so a destructive control does not belong loose in it.
- */
-export function DeleteCreatorAnnouncementMenuItem({
-  announcement,
-}: {
-  announcement: CreatorAnnouncementModel;
-}) {
-  const { canDelete, confirmDelete } = useDeleteCreatorAnnouncementAction(announcement);
-  if (!canDelete) return null;
-
-  return (
-    <Menu.Item color="red" leftSection={<IconTrash size={16} />} onClick={confirmDelete}>
+  ) : (
+    <Menu.Item
+      color="red"
+      disabled={isLoading}
+      leftSection={<IconTrash size={16} />}
+      onClick={handleDelete}
+    >
       Delete announcement
     </Menu.Item>
   );

--- a/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
+++ b/src/components/Announcements/CreatorAnnouncementsCarousel.tsx
@@ -1,3 +1,4 @@
+import { Menu } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconTrash } from '@tabler/icons-react';
 import React from 'react';
@@ -11,19 +12,18 @@ import {
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 
-export function DeleteCreatorAnnouncementButton({
-  announcement,
-}: {
-  announcement: CreatorAnnouncementModel;
-}) {
+/**
+ * Who may delete, and the confirm step. Shared so the profile's icon button and the panel's
+ * menu item cannot drift apart on either — the permission is the load-bearing half.
+ */
+function useDeleteCreatorAnnouncementAction(announcement: CreatorAnnouncementModel) {
   const currentUser = useCurrentUser();
   const { deleteAnnouncement, isLoading } = useDeleteCreatorAnnouncement();
 
   const canDelete =
     !!currentUser && (currentUser.isModerator || currentUser.id === announcement.userId);
-  if (!canDelete) return null;
 
-  const handleDelete = () =>
+  const confirmDelete = () =>
     openConfirmModal({
       title: 'Delete announcement',
       children: 'Are you sure you want to delete this announcement? This cannot be undone.',
@@ -32,17 +32,47 @@ export function DeleteCreatorAnnouncementButton({
       onConfirm: () => deleteAnnouncement(announcement.id),
     });
 
+  return { canDelete, isLoading, confirmDelete };
+}
+
+export function DeleteCreatorAnnouncementButton({
+  announcement,
+}: {
+  announcement: CreatorAnnouncementModel;
+}) {
+  const { canDelete, isLoading, confirmDelete } = useDeleteCreatorAnnouncementAction(announcement);
+  if (!canDelete) return null;
+
   return (
     <LegacyActionIcon
       variant="subtle"
       color="red"
       radius="xl"
       loading={isLoading}
-      onClick={handleDelete}
+      onClick={confirmDelete}
       aria-label="Delete announcement"
     >
       <IconTrash size={18} />
     </LegacyActionIcon>
+  );
+}
+
+/**
+ * The same action as a menu entry. In the panel the card's top bar is chrome the reader
+ * scans, so a destructive control does not belong loose in it.
+ */
+export function DeleteCreatorAnnouncementMenuItem({
+  announcement,
+}: {
+  announcement: CreatorAnnouncementModel;
+}) {
+  const { canDelete, confirmDelete } = useDeleteCreatorAnnouncementAction(announcement);
+  if (!canDelete) return null;
+
+  return (
+    <Menu.Item color="red" leftSection={<IconTrash size={16} />} onClick={confirmDelete}>
+      Delete announcement
+    </Menu.Item>
   );
 }
 

--- a/src/components/Announcements/DeleteCreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/DeleteCreatorAnnouncement.browser.test.tsx
@@ -36,7 +36,18 @@ async function renderDelete() {
   const { DeleteCreatorAnnouncementButton } = await import(
     '~/components/Announcements/CreatorAnnouncementsCarousel'
   );
-  renderWithProviders(<DeleteCreatorAnnouncementButton announcement={announcement} />);
+  // The marker is load-bearing. A negative read straight after render sees an empty body —
+  // the commit is asynchronous — so `elements()` would return 0 for every case, including
+  // the ones where the control SHOULD be there. Awaiting a sibling that always renders
+  // proves the tree is committed before the absence is read. Measured: without it, widening
+  // the gate to `!!currentUser` left all four tests green.
+  renderWithProviders(
+    <>
+      <span>delete gate rendered</span>
+      <DeleteCreatorAnnouncementButton announcement={announcement} />
+    </>
+  );
+  await expect.element(page.getByText('delete gate rendered')).toBeInTheDocument();
 }
 
 function deleteControls() {

--- a/src/components/Announcements/DeleteCreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/DeleteCreatorAnnouncement.browser.test.tsx
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as CreatorUtils from '~/components/Announcements/creator-announcements.utils';
+import type * as CurrentUser from '~/hooks/useCurrentUser';
+
+/**
+ * Who gets offered the delete control, in both chromes.
+ *
+ * The server is the real gate — `deleteCreatorAnnouncement` is a `guardedProcedure` and
+ * `assertOwnedAnnouncement` scopes by owner — so this is about the affordance, not about
+ * authorization. It is here because the two chromes were separate components until they were
+ * collapsed behind `as`, and a destructive control's gate should not be rewritten with
+ * nothing on either side of it: mutating `canDelete` to `!!currentUser` reddened nothing in
+ * the repo before this file existed.
+ */
+
+const mocks = vi.hoisted(() => ({
+  currentUser: null as { id: number; isModerator: boolean } | null,
+}));
+
+vi.mock('~/hooks/useCurrentUser', async (importOriginal) => ({
+  ...(await importOriginal<typeof CurrentUser>()),
+  useCurrentUser: () => mocks.currentUser,
+}));
+
+vi.mock('~/components/Announcements/creator-announcements.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof CreatorUtils>()),
+  useDeleteCreatorAnnouncement: () => ({ deleteAnnouncement: vi.fn(), isLoading: false }),
+}));
+
+const AUTHOR = 99;
+const announcement = { id: 1, userId: AUTHOR } as any;
+
+async function renderDelete() {
+  const { DeleteCreatorAnnouncementButton } = await import(
+    '~/components/Announcements/CreatorAnnouncementsCarousel'
+  );
+  renderWithProviders(<DeleteCreatorAnnouncementButton announcement={announcement} />);
+}
+
+function deleteControls() {
+  return page.getByRole('button', { name: 'Delete announcement' }).elements();
+}
+
+describe('who is offered the delete control', () => {
+  beforeEach(() => {
+    mocks.currentUser = null;
+  });
+
+  test('the author sees it', async () => {
+    mocks.currentUser = { id: AUTHOR, isModerator: false };
+    await renderDelete();
+
+    await expect
+      .element(page.getByRole('button', { name: 'Delete announcement' }))
+      .toBeInTheDocument();
+  });
+
+  test('a moderator sees it on someone else’s announcement', async () => {
+    mocks.currentUser = { id: AUTHOR + 1, isModerator: true };
+    await renderDelete();
+
+    await expect
+      .element(page.getByRole('button', { name: 'Delete announcement' }))
+      .toBeInTheDocument();
+  });
+
+  // The two negatives are what the mutation `canDelete = !!currentUser` breaks, and they are
+  // paired with the positives above so "absent" means the gate refused rather than that the
+  // component rendered nothing at all.
+  test('another signed-in user does not', async () => {
+    mocks.currentUser = { id: AUTHOR + 1, isModerator: false };
+    await renderDelete();
+
+    expect(deleteControls()).toHaveLength(0);
+  });
+
+  test('a signed-out visitor does not', async () => {
+    mocks.currentUser = null;
+    await renderDelete();
+
+    expect(deleteControls()).toHaveLength(0);
+  });
+});

--- a/src/components/Announcements/__tests__/creator-announcement-mutations.test.ts
+++ b/src/components/Announcements/__tests__/creator-announcement-mutations.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as Trpc from '~/utils/trpc';
 
 /**
  * Which caches a creator-announcement mutation busts.
@@ -23,7 +24,8 @@ const invalidate = vi.hoisted(() => ({
 
 const captured = vi.hoisted(() => ({ options: {} as Record<string, any> }));
 
-vi.mock('~/utils/trpc', () => {
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
   const mutationHook = (name: string) => ({
     useMutation: (options: Record<string, unknown>) => {
       captured.options[name] = options;
@@ -31,6 +33,7 @@ vi.mock('~/utils/trpc', () => {
     },
   });
   return {
+    ...actual,
     trpc: {
       useUtils: () => ({
         announcement: {

--- a/src/components/Announcements/__tests__/creator-announcement-mutations.test.ts
+++ b/src/components/Announcements/__tests__/creator-announcement-mutations.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Which caches a creator-announcement mutation busts.
+ *
+ * The panel and the profile carousel read DIFFERENT queries — `getFollowedAnnouncements`
+ * and `getCreatorAnnouncements` — and tRPC is configured with `staleTime: Infinity` and
+ * `refetchOnWindowFocus: false`, so a query nobody invalidates does not refetch for the rest
+ * of the session. A mutation that busts only one of them therefore reports success and
+ * leaves the mutated row on screen wherever the other query is the source.
+ *
+ * These live here rather than in the panel's browser test because that test stubs
+ * `useDeleteCreatorAnnouncement` out entirely, which makes the invalidation set
+ * unobservable by construction.
+ */
+
+const invalidate = vi.hoisted(() => ({
+  getCreatorAnnouncements: vi.fn(),
+  getFollowedAnnouncements: vi.fn(),
+  getMutedCreators: vi.fn(),
+  isCreatorMuted: vi.fn(),
+}));
+
+const captured = vi.hoisted(() => ({ options: {} as Record<string, any> }));
+
+vi.mock('~/utils/trpc', () => {
+  const mutationHook = (name: string) => ({
+    useMutation: (options: Record<string, unknown>) => {
+      captured.options[name] = options;
+      return { mutate: vi.fn(), isPending: false };
+    },
+  });
+  return {
+    trpc: {
+      useUtils: () => ({
+        announcement: {
+          getCreatorAnnouncements: { invalidate: invalidate.getCreatorAnnouncements },
+          getFollowedAnnouncements: { invalidate: invalidate.getFollowedAnnouncements },
+          getMutedCreators: { invalidate: invalidate.getMutedCreators },
+          isCreatorMuted: { invalidate: invalidate.isCreatorMuted },
+        },
+      }),
+      announcement: {
+        deleteCreatorAnnouncement: mutationHook('delete'),
+        toggleAnnouncementMute: mutationHook('mute'),
+      },
+    },
+  };
+});
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ creatorAnnouncements: true }),
+}));
+
+import {
+  useDeleteCreatorAnnouncement,
+  useToggleAnnouncementMute,
+} from '~/components/Announcements/creator-announcements.utils';
+
+describe('creator announcement mutations invalidate both feeds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.options = {};
+  });
+
+  it('a delete busts the followed feed as well as the profile one', async () => {
+    useDeleteCreatorAnnouncement();
+    await captured.options.delete.onSuccess();
+
+    // BOTH, named individually: asserting only the profile one passes against the bug this
+    // covers, where a delete from the notifications panel left the card on screen.
+    expect(invalidate.getCreatorAnnouncements).toHaveBeenCalled();
+    expect(invalidate.getFollowedAnnouncements).toHaveBeenCalled();
+  });
+
+  it('a mute toggle busts the followed feed', async () => {
+    useToggleAnnouncementMute(99);
+    await captured.options.mute.onSuccess({ muted: true });
+
+    expect(invalidate.getFollowedAnnouncements).toHaveBeenCalled();
+    expect(invalidate.getMutedCreators).toHaveBeenCalled();
+  });
+});

--- a/src/components/Announcements/creator-announcement-dismissals.ts
+++ b/src/components/Announcements/creator-announcement-dismissals.ts
@@ -1,0 +1,34 @@
+import { createDismissalStore, localStorageDismissalStorage } from '~/store/dismissal-store';
+
+/**
+ * Dismissed creator announcements, in localStorage rather than the announcements cookie.
+ *
+ * The cookie exists so the SERVER can render the sitewide carousel at its true height from
+ * frame 0, and its bucket map is `Record<AnnouncementType, number[]>` — deliberately a
+ * closed literal, so a creator bucket cannot be added without widening `AnnouncementType`,
+ * which is what the sitewide queries filter on. Creator announcements render only in the
+ * notifications panel, which is client-only and never SSRs, so none of the cookie's
+ * property is needed here and paying for it would mean reaching into sitewide filtering.
+ */
+export const CREATOR_ANNOUNCEMENTS_DISMISSED_KEY = 'creator-announcements-dismissed';
+
+const BUCKET = 'creators';
+
+const store = createDismissalStore<number, typeof BUCKET>({
+  storage: localStorageDismissalStorage({
+    key: CREATOR_ANNOUNCEMENTS_DISMISSED_KEY,
+    buckets: [BUCKET],
+    isId: (value): value is number => typeof value === 'number',
+  }),
+  defaultBucket: BUCKET,
+});
+
+export const useDismissedCreatorAnnouncements = () => store.useDismissed();
+
+export function dismissCreatorAnnouncement(id: number) {
+  store.dismiss(id);
+}
+
+export function pruneDismissedCreatorAnnouncements(live: Iterable<number>) {
+  store.prune(live);
+}

--- a/src/components/Announcements/creator-announcement-dismissals.ts
+++ b/src/components/Announcements/creator-announcement-dismissals.ts
@@ -32,3 +32,13 @@ export function dismissCreatorAnnouncement(id: number) {
 export function pruneDismissedCreatorAnnouncements(live: Iterable<number>) {
   store.prune(live);
 }
+
+/**
+ * Drop every dismissal. Exists for tests: resetting by pruning against an empty live set
+ * would depend on the very behaviour `AnnouncementsPanel` guards against, so the day anyone
+ * hardens `pruneDismissals` to refuse an empty set, the reset would silently no-op and the
+ * leak would surface as a timeout on an unrelated control.
+ */
+export function clearDismissedCreatorAnnouncements() {
+  store.useStore.setState({ dismissed: { [BUCKET]: [] } });
+}

--- a/src/components/Announcements/creator-announcements.utils.ts
+++ b/src/components/Announcements/creator-announcements.utils.ts
@@ -82,7 +82,14 @@ export function useDeleteCreatorAnnouncement() {
   const mutation = trpc.announcement.deleteCreatorAnnouncement.useMutation({
     onSuccess: async () => {
       showSuccessNotification({ message: 'Announcement deleted' });
-      await queryUtils.announcement.getCreatorAnnouncements.invalidate();
+      // Both feeds, as the mute mutation above already does. The panel reads the followed
+      // feed, and trpc sets `staleTime: Infinity` with `refetchOnWindowFocus: false` — so
+      // without this a delete from the panel reports success and leaves the card on screen
+      // for the rest of the session, where a second click reports failure.
+      await Promise.all([
+        queryUtils.announcement.getCreatorAnnouncements.invalidate(),
+        queryUtils.announcement.getFollowedAnnouncements.invalidate(),
+      ]);
     },
     onError: (error) => {
       showErrorNotification({

--- a/src/server/services/__tests__/creator-announcement-boundary.test.ts
+++ b/src/server/services/__tests__/creator-announcement-boundary.test.ts
@@ -347,11 +347,20 @@ describe('the followed feed', () => {
   // The author's picture and cosmetics are not columns on `User`, so no `select` can reach
   // them; they come from the caches instead. A byline that is only a username is what a
   // reader has to tell apart from an official Civitai announcement, which is the point.
-  it('attaches the author identity the select cannot reach', async () => {
+  //
+  // TWO authors, and the caches hold an entry for only ONE of them. One author would let
+  // three separate bugs through: dropping the id dedupe, keying every row off the first
+  // author's identity, and dropping the null-author filter. The undecorated author is also
+  // this test's own negative control — an author the caches know nothing about must render
+  // as a plain name, never a half-built bar or a crash.
+  it('attaches each author their own identity, and degrades for one the caches do not know', async () => {
+    const OTHER = AUTHOR + 1;
     vi.mocked(getProfilePicturesForUsers).mockResolvedValue({ [AUTHOR]: { id: 7 } } as never);
     vi.mocked(getCosmeticsForUsers).mockResolvedValue({ [AUTHOR]: [{ cosmeticId: 3 }] } as never);
     dbMock.dbRead.announcement.findMany.mockResolvedValue([
       { id: 1, metadata: {}, cover: null, user: { id: AUTHOR, username: 'author' } },
+      { id: 2, metadata: {}, cover: null, user: { id: OTHER, username: 'other' } },
+      { id: 3, metadata: {}, cover: null, user: { id: AUTHOR, username: 'author' } },
     ] as never);
 
     const page = await getFollowedAnnouncements({ userId: 999 });
@@ -361,25 +370,27 @@ describe('the followed feed', () => {
       profilePicture: { id: 7 },
       cosmetics: [{ cosmeticId: 3 }],
     });
-    expect(vi.mocked(getProfilePicturesForUsers).mock.calls[0][0]).toEqual([AUTHOR]);
+    expect(page.items[1].user).toMatchObject({
+      username: 'other',
+      profilePicture: null,
+      cosmetics: [],
+    });
+    expect(page.items[2].user).toMatchObject({ username: 'author', profilePicture: { id: 7 } });
+
+    // Deduped: the repeated author is asked for once, and the order is the first-seen order.
+    expect(vi.mocked(getProfilePicturesForUsers).mock.calls[0][0]).toEqual([AUTHOR, OTHER]);
   });
 
-  // An author the caches know nothing about still renders — as a plain name, never a
-  // half-built bar or a crash.
-  it('degrades to a plain author when the caches hold nothing for them', async () => {
-    vi.mocked(getProfilePicturesForUsers).mockResolvedValue({} as never);
-    vi.mocked(getCosmeticsForUsers).mockResolvedValue({} as never);
+  it('asks the caches nothing when no row has an author', async () => {
     dbMock.dbRead.announcement.findMany.mockResolvedValue([
-      { id: 1, metadata: {}, cover: null, user: { id: AUTHOR, username: 'author' } },
+      { id: 1, metadata: {}, cover: null, user: null },
     ] as never);
 
     const page = await getFollowedAnnouncements({ userId: 999 });
 
-    expect(page.items[0].user).toMatchObject({
-      username: 'author',
-      profilePicture: null,
-      cosmetics: [],
-    });
+    expect(page.items[0].user).toBeNull();
+    expect(getProfilePicturesForUsers).not.toHaveBeenCalled();
+    expect(getCosmeticsForUsers).not.toHaveBeenCalled();
   });
 
   it('skips the cursor row itself so a page never repeats its predecessor', async () => {
@@ -540,6 +551,26 @@ describe('an omitted field means leave it alone', () => {
     const data = (tx.announcement.create.mock.calls[0][0] as { data: Record<string, unknown> })
       .data;
     expect(data.disabled).toBe(false);
+  });
+});
+
+describe('the profile query deliberately does NOT fetch author identity', () => {
+  // The profile carousel renders no byline (`CreatorAnnouncement`'s `withAuthor` defaults
+  // off), so hydrating there is two cache fan-outs and several KB per row for fields nothing
+  // reads — and every row on that surface shares one author, so it is duplicated too.
+  //
+  // 🔴 If you are here because you added a byline to the profile, the fix is to flip
+  // `hydrate` to true in `getCreatorAnnouncements`, NOT to delete this test.
+  it('returns the identity fields empty without asking the caches', async () => {
+    dbMock.dbRead.announcement.findMany.mockResolvedValue([
+      { id: 1, metadata: {}, cover: null, user: { id: AUTHOR, username: 'author' } },
+    ] as never);
+
+    const rows = await getCreatorAnnouncements({ userId: AUTHOR });
+
+    expect(rows[0].user).toMatchObject({ profilePicture: null, cosmetics: [] });
+    expect(getProfilePicturesForUsers).not.toHaveBeenCalled();
+    expect(getCosmeticsForUsers).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/__tests__/creator-announcement-boundary.test.ts
+++ b/src/server/services/__tests__/creator-announcement-boundary.test.ts
@@ -12,7 +12,11 @@ vi.mock('~/server/services/cover-image.service', () => ({
   resolveCoverImageId: vi.fn(async () => 555),
 }));
 vi.mock('~/server/services/util.service', () => ({ isImageOwner: vi.fn(async () => true) }));
-vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser: vi.fn(async () => false) }));
+vi.mock('~/server/services/user.service', () => ({
+  amIBlockedByUser: vi.fn(async () => false),
+  getProfilePicturesForUsers: vi.fn(async () => ({})),
+  getCosmeticsForUsers: vi.fn(async () => ({})),
+}));
 // The real host list comes from SERVER_DOMAIN_* env, which the test env does not set — an
 // empty list would make every link "not ours" and the assertions below vacuous.
 vi.mock('~/server/utils/server-domain', () => ({
@@ -41,7 +45,11 @@ import {
   MIN_ANNOUNCEMENT_DURATION_MS,
 } from '../creator-announcement.service';
 import { getAnnouncementAllowance } from '~/server/services/announcement-allowance.service';
-import { amIBlockedByUser } from '~/server/services/user.service';
+import {
+  amIBlockedByUser,
+  getCosmeticsForUsers,
+  getProfilePicturesForUsers,
+} from '~/server/services/user.service';
 
 const AUTHOR = 101;
 
@@ -334,6 +342,44 @@ describe('the followed feed', () => {
     const last = await getFollowedAnnouncements({ userId: AUTHOR, limit: 2 });
     expect(last.items).toHaveLength(2);
     expect(last.nextCursor).toBeUndefined();
+  });
+
+  // The author's picture and cosmetics are not columns on `User`, so no `select` can reach
+  // them; they come from the caches instead. A byline that is only a username is what a
+  // reader has to tell apart from an official Civitai announcement, which is the point.
+  it('attaches the author identity the select cannot reach', async () => {
+    vi.mocked(getProfilePicturesForUsers).mockResolvedValue({ [AUTHOR]: { id: 7 } } as never);
+    vi.mocked(getCosmeticsForUsers).mockResolvedValue({ [AUTHOR]: [{ cosmeticId: 3 }] } as never);
+    dbMock.dbRead.announcement.findMany.mockResolvedValue([
+      { id: 1, metadata: {}, cover: null, user: { id: AUTHOR, username: 'author' } },
+    ] as never);
+
+    const page = await getFollowedAnnouncements({ userId: 999 });
+
+    expect(page.items[0].user).toMatchObject({
+      username: 'author',
+      profilePicture: { id: 7 },
+      cosmetics: [{ cosmeticId: 3 }],
+    });
+    expect(vi.mocked(getProfilePicturesForUsers).mock.calls[0][0]).toEqual([AUTHOR]);
+  });
+
+  // An author the caches know nothing about still renders — as a plain name, never a
+  // half-built bar or a crash.
+  it('degrades to a plain author when the caches hold nothing for them', async () => {
+    vi.mocked(getProfilePicturesForUsers).mockResolvedValue({} as never);
+    vi.mocked(getCosmeticsForUsers).mockResolvedValue({} as never);
+    dbMock.dbRead.announcement.findMany.mockResolvedValue([
+      { id: 1, metadata: {}, cover: null, user: { id: AUTHOR, username: 'author' } },
+    ] as never);
+
+    const page = await getFollowedAnnouncements({ userId: 999 });
+
+    expect(page.items[0].user).toMatchObject({
+      username: 'author',
+      profilePicture: null,
+      cosmetics: [],
+    });
   });
 
   it('skips the cursor row itself so a page never repeats its predecessor', async () => {

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -9,8 +9,13 @@ import { CREATOR_ANNOUNCEMENT_CONTENT_MAX } from '~/server/schema/announcement.s
 import { getAnnouncementAllowance } from '~/server/services/announcement-allowance.service';
 import { resolveCoverImageId } from '~/server/services/cover-image.service';
 import { isImageOwner } from '~/server/services/util.service';
-import { amIBlockedByUser } from '~/server/services/user.service';
+import {
+  amIBlockedByUser,
+  getCosmeticsForUsers,
+  getProfilePicturesForUsers,
+} from '~/server/services/user.service';
 import { getAllServerHosts } from '~/server/utils/server-domain';
+import { isDefined } from '~/utils/type-guards';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 import { DomainColor, UserEngagementType } from '~/shared/utils/prisma/enums';
 
@@ -48,7 +53,7 @@ const creatorAnnouncementSelect = {
       hash: true,
     },
   },
-  user: { select: { id: true, username: true, image: true } },
+  user: { select: { id: true, username: true, image: true, deletedAt: true } },
   // `satisfies`, not `as const`: a standalone object literal gets no excess-property
   // check when it is passed to Prisma later, so a column that does not exist typechecks
   // clean and 500s at runtime on every read and write. This is the check that catches it.
@@ -72,6 +77,31 @@ function toCreatorAnnouncementDTO<T extends RawCreatorAnnouncement>(announcement
     metadata: (announcement.metadata ?? {}) as AnnouncementMetaSchema,
     nsfwLevel: announcement.cover?.nsfwLevel ?? 0,
   };
+}
+
+/**
+ * Cosmetics and the profile-picture row are not columns on `User`, so the select cannot
+ * reach them; both already live in caches every other card-shaped surface reads, and the
+ * author set on one page of announcements is a handful of ids. Attached to the author here
+ * so a creator announcement renders with the same identity the rest of the site gives them
+ * — a byline that is only a name is what the reader has to tell apart from Civitai's own.
+ */
+async function withAuthorIdentity<T extends { user: { id: number } | null }>(announcements: T[]) {
+  const userIds = [...new Set(announcements.map((x) => x.user?.id).filter(isDefined))];
+  const [profilePictures, cosmetics] = userIds.length
+    ? await Promise.all([getProfilePicturesForUsers(userIds), getCosmeticsForUsers(userIds)])
+    : [{}, {}];
+
+  return announcements.map((announcement) => ({
+    ...announcement,
+    user: announcement.user
+      ? {
+          ...announcement.user,
+          profilePicture: profilePictures[announcement.user.id] ?? null,
+          cosmetics: cosmetics[announcement.user.id] ?? [],
+        }
+      : null,
+  }));
 }
 
 /**
@@ -124,7 +154,7 @@ export async function getCreatorAnnouncements({
     take: limit,
   });
 
-  return announcements.map(toCreatorAnnouncementDTO);
+  return withAuthorIdentity(announcements.map(toCreatorAnnouncementDTO));
 }
 
 /**
@@ -189,7 +219,9 @@ export async function getFollowedAnnouncements({
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
   });
 
-  const items = announcements.slice(0, limit).map(toCreatorAnnouncementDTO);
+  const items = await withAuthorIdentity(
+    announcements.slice(0, limit).map(toCreatorAnnouncementDTO)
+  );
 
   return {
     items,

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -86,8 +86,13 @@ function toCreatorAnnouncementDTO<T extends RawCreatorAnnouncement>(announcement
  * so a creator announcement renders with the same identity the rest of the site gives them
  * — a byline that is only a name is what the reader has to tell apart from Civitai's own.
  */
-async function withAuthorIdentity<T extends { user: { id: number } | null }>(announcements: T[]) {
-  const userIds = [...new Set(announcements.map((x) => x.user?.id).filter(isDefined))];
+async function withAuthorIdentity<T extends { user: { id: number } | null }>(
+  announcements: T[],
+  { hydrate }: { hydrate: boolean }
+) {
+  const userIds = hydrate
+    ? [...new Set(announcements.map((x) => x.user?.id).filter(isDefined))]
+    : [];
   const [profilePictures, cosmetics] = userIds.length
     ? await Promise.all([getProfilePicturesForUsers(userIds), getCosmeticsForUsers(userIds)])
     : [{}, {}];
@@ -154,7 +159,12 @@ export async function getCreatorAnnouncements({
     take: limit,
   });
 
-  return withAuthorIdentity(announcements.map(toCreatorAnnouncementDTO));
+  // `hydrate: false` — the profile carousel renders no byline (see `CreatorAnnouncement`'s
+  // `withAuthor`), so fetching the author's picture and cosmetics here would be two cache
+  // fan-outs and several KB per row, duplicated across rows that all share one author, for
+  // fields nothing reads. The FIELDS are still present so both queries have one DTO shape.
+  // If a byline is ever added to the profile, flip this — do not remove the argument.
+  return withAuthorIdentity(announcements.map(toCreatorAnnouncementDTO), { hydrate: false });
 }
 
 /**
@@ -220,7 +230,8 @@ export async function getFollowedAnnouncements({
   });
 
   const items = await withAuthorIdentity(
-    announcements.slice(0, limit).map(toCreatorAnnouncementDTO)
+    announcements.slice(0, limit).map(toCreatorAnnouncementDTO),
+    { hydrate: true }
   );
 
   return {


### PR DESCRIPTION
Closes ClickUp [868m06qzv](https://app.clickup.com/t/868m06qzv).

## Why this matters, which is not what the ticket says

The ticket says a creator announcement shows no byline. The reason it is worth fixing is narrower than that, and it is Luis's, from the 2026-09-02 standup:

> "I would prefer users not confusing that as with our announcements… it would put us in a bad place if someone, like, if there's a bad actor."

**This is an impersonation surface, not a missing byline.** In the notifications panel, creator-authored and Civitai-authored announcements are rendered interleaved in one list by the same component. A creator card carried title, body and cover and nothing identifying its author, so it was visually indistinguishable from an official Civitai announcement. Ellie (2026-09-01) added that there was often no link back to the creator at all.

The bar this is held to: **a reader can tell a creator announcement from an official one at a glance, and knows who wrote it.**

## What changed

The author sits in a bar across the top of the card **frame**, not inside the content the author wrote:

- avatar, linked username and posted-at on the left
- the options menu and a dismiss button on the right
- a wash of the card's border colour behind it, so it reads as part of the frame

Also:

- **Creator announcements are dismissible for the first time**, matching what Civitai announcements have always allowed.
- **Delete moved out of the card and into the options menu.** It was a loose destructive icon in chrome the reader scans. The permission is unchanged — author or moderator — and now lives in one shared hook so the profile's icon button and the panel's menu item cannot drift apart on who may click it.
- Both dismiss buttons (creator *and* Civitai) went from red to white-on-dark.
- The cover gets a divider that runs the full height of the card, so a long announcement reads as content beside the image rather than dead space. It sits on the content side, not the cover: the cover is a fixed 160px square, so a border on it stops where the image does.

**Deliberately not on the profile page.** On a creator's own profile every card is already theirs, so a byline there is noise — and the profile is not where the impersonation risk lives. `withAuthor` defaults to off and the panel opts in; the profile carousel renders exactly as it does today.

## The audit answer, and where it was wrong

Nothing had shipped: at `origin/main` the only occurrence of `user.username` anywhere under `src/components/Announcements/` was as a prop of the mute menu item, inside a dropdown.

"No server work needed" was true of the author **reference** — `creatorAnnouncementSelect` already carried `{ id, username, image }` — and false of the author **identity**. Profile picture, cosmetics, nameplate and decoration are not columns on `User`, so no `select` could ever have reached them, and a byline that is only a username does not read as a person. That only became visible on the dev server, which is why the design changed after seeing it rather than before.

So the service gained:

- `deletedAt` on the author select, so a deleted author does not get a live profile link.
- One helper, `withAuthorIdentity`, on the panel query. It collects the **distinct** author ids of a page and calls `getProfilePicturesForUsers` and `getCosmeticsForUsers` — the same cache-backed helpers `model.service.getAll` and `post.service` already use, in the same shape. No new query, no new cache, and no new import edge (the file already imported from `user.service`).

  **It is not N+1 against Postgres**, and the perf lane measured that rather than taking my word: the cache builder batches misses into one lookup per chunk, so a 20-author page is at most **3 Postgres queries** — 1.377 ms and 0.884 ms for the two real ones on prod. My original claim of "exactly two calls" was wrong at the Redis layer, and I am correcting it rather than leaving it: `packed.mGet` is `Promise.all(keys.map(get))` (deliberately, to dodge CROSSSLOT), and `getCosmeticsForUsers` awaits its two caches in sequence, so the same page is ~60–100 Redis commands in two latency waves. Bounded, on a drawer-open surface, and the lever if the panel's limit ever grows is collapsing those two waves.

No `where` clause moved.

## Why dismissal is localStorage and not the announcements cookie

The dismissed-announcements cookie exists so the **server** can render the sitewide carousel at its true height from frame 0. Its bucket map is `Record<AnnouncementType, number[]>` — a closed literal, deliberately, so a creator bucket cannot be added without widening `AnnouncementType`, which is what the sitewide queries filter on.

The notifications panel is client-only and never SSRs, so it needs none of the cookie's property. A separate store, built from the existing `createDismissalStore` factory with the existing `localStorageDismissalStorage` adapter, buys the same set semantics without reaching into sitewide filtering.

## Verification

Every test below was proved capable of failing, by mutating the code it covers and naming the test that went red:

| Mutant | Result |
|---|---|
| `direction="col"` → `"row"` on the top-bar card | 1 failed — *withAuthor stacks the card so the top bar spans it*, `expected false to be true` |
| `showAuthor` forced false | 3 failed across both browser files |
| dismissed filter removed from the panel | 1 failed — *dismissing a creator announcement removes it and leaves the civitai one* |
| `withAuthorIdentity` dropped from the feed path | 2 failed in 9ms and 2ms |
| the id dedupe (`new Set`) dropped | 1 failed — *attaches each author their own identity…* |
| every row keyed off the FIRST author's cosmetics | 2 failed |
| the prune's empty-load guard deleted | 1 failed in 208ms — *a load with no creator announcements does not resurrect a dismissal* |

Each file's hash was compared before and after mutation and again after restore.

The first of those is not hypothetical: `direction="column"` (the card takes `'col' | 'row'`) shipped to the dev server and rendered the bar as a left-hand column. That is now pinned.

**The service tests are new because the suite was blind here.** Every existing feed fixture in `creator-announcement-boundary.test.ts` omits `user`, so `withAuthorIdentity` only ever took its empty branch — the suite passed without exercising a line of the cache path.

## What the five review lanes changed

Correctness came back with no findings. The other four found real problems, and the fixes are in this branch rather than filed:

- **Reuse:** the delete action had been split into two components; the repo's seam for "one action, two chromes" is a single component with `as: 'button' | 'menu-item'` (`HideUserButton` and four siblings). The split had *already* drifted on its first commit — the icon showed a spinner, the menu item did not. Collapsed to one component.
- **Perf:** the profile query was hydrating author identity the profile carousel never renders. Every row there shares one author, so a ~3.5–5 KB identity blob was duplicated onto each row of a per-page-view surface. It now passes `hydrate: false`; the FIELDS remain so both queries keep one DTO shape, and a test named for the decision pins it.
- **Intent:** the byline failed **open** — an author-less row would have rendered a creator announcement in the exact shape of an official Civitai one, which is the confusion this PR exists to prevent. It fails closed now. The cover divider was gated on the cover's data while the cover is hidden by a container query, leaving a stray double border on narrow cards. And the options menu disappeared with the author, taking a moderator's delete with it.

### Two of my own tests could not have failed

- `a civitai announcement carries no creator byline` rendered only the `civitai` source, so the creator card was absent rather than byline-free. It passed with the whole feature reverted. It now renders both sources and asserts per card subtree, with the positive half in the same assertion.
- The `vi.mock('~/utils/trpc')` used `importOriginal` spreads over a tRPC flat Proxy. Spreading a Proxy reads `ownKeys`, which is empty, so both spreads yielded `{}` — the mock was wholesale while its comment said it was narrow. Replaced with an explicit stub behind a Proxy that throws a named error, so a future unmocked router is a message rather than a 15-second timeout with nothing pointing at tRPC.
- The dismissal test's isolation was a claim in a comment. `vi.resetModules()` does not re-evaluate a module-scope store in browser mode. **Measured:** moving the dismissal test to run first made four later tests fail on a leaked dismissal; after resetting through the store's own API, the same reordering passes 8/8.

Also added, because a mutation survived each: a two-author identity fixture where the caches know only one of them (kills the id-dedupe, cross-author-keying and null-author mutants at once, and carries its own negative control), and a test for the prune guard — the empty-load early return that exists so a load with nothing in it cannot wipe every dismissal.

## Deliberate, so a reviewer does not have to guess

- **The cover divider applies to sitewide Civitai cards too**, since they share `AnnouncementCard`. Raised at the time and not objected to.
- **"White X" ships as `text-dark-9 dark:text-white`**, not literal white, which would vanish on a light-mode card.
- **Dismissing a creator card removes it; dismissing a Civitai one dims it in place** (existing behaviour). Raised as an open question rather than silently unified.
- **No CI job runs the `component` project**, so the browser tests here gate nothing on a PR. They were still run, and each was mutation-checked.
- Not touched: the "currently live" predicate over `Announcement` exists in three hand-written copies (`announcement.service.ts` plus two in `creator-announcement.service.ts`). Equivalent today, predates this branch, and folding them is wider than this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vAEASSgSXDKe2gZ9f7FU9
