### PR TITLE
fix(notifications): stop the reaction milestone counting suppressed accounts

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2135,6 +2135,7 @@ const REDIS_KEYS_UNPREFIXED = {
   },
   CACHES: {
     ECOSYSTEM_SEO: 'packed:caches:ecosystem-seo',
+    METRIC_EXCLUDED_USERS: 'packed:caches:metric-excluded-users',
     FILES_FOR_MODEL_VERSION: 'packed:caches:files-for-model-version-2',
     MULTIPLIERS_FOR_USER: 'packed:caches:multipliers-for-user',
     TAG_IDS_FOR_IMAGES: 'packed:caches:tag-ids-for-images',

--- a/src/server/controllers/__tests__/reaction-noop-tracking.test.ts
+++ b/src/server/controllers/__tests__/reaction-noop-tracking.test.ts
@@ -1,14 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProtectedContext } from '~/server/createContext';
 
-const { mockToggleReaction, mockUpdateEntityMetric, mockDbRead } = vi.hoisted(() => ({
+const {
+  mockToggleReaction,
+  mockUpdateEntityMetric,
+  mockDbRead,
+  mockNotificationExists,
+  mockCreateNotification,
+  mockExcludedUserIds,
+} = vi.hoisted(() => ({
   mockToggleReaction: vi.fn(),
   mockUpdateEntityMetric: vi.fn(async () => undefined),
+  mockNotificationExists: vi.fn(async () => true),
+  mockCreateNotification: vi.fn(async () => undefined),
+  mockExcludedUserIds: vi.fn(async () => [] as number[]),
   mockDbRead: {
     image: {
-      findFirst: vi.fn(async () => ({ nsfwLevel: 1, userId: 99 })),
+      findFirst: vi.fn(async () => ({
+        nsfwLevel: 1,
+        userId: 99,
+        id: 1,
+        postId: 42,
+        resourceHelper: [],
+      })),
       findUniqueOrThrow: vi.fn(async () => ({ postId: 42 })),
     },
+    imageReaction: { count: vi.fn(async () => 5) },
   },
 }));
 
@@ -26,10 +43,13 @@ vi.mock('~/server/rewards', () => ({
   goodContentReward: { apply: vi.fn(async () => undefined) },
 }));
 vi.mock('~/server/notifications/client', () => ({
-  notifications: { notificationExists: vi.fn(async () => true) },
+  notifications: { notificationExists: mockNotificationExists },
 }));
 vi.mock('~/server/services/notification.service', () => ({
-  createNotification: vi.fn(async () => undefined),
+  createNotification: mockCreateNotification,
+}));
+vi.mock('~/server/services/metric-excluded-users.service', () => ({
+  getMetricExcludedUserIds: mockExcludedUserIds,
 }));
 
 import { toggleReactionHandler } from '~/server/controllers/reaction.controller';
@@ -46,6 +66,8 @@ function makeCtx() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockNotificationExists.mockResolvedValue(true);
+  mockExcludedUserIds.mockResolvedValue([]);
 });
 
 describe('toggleReactionHandler — a delete that removed nothing', () => {
@@ -73,5 +95,26 @@ describe('toggleReactionHandler — a delete that removed nothing', () => {
     expect(mockUpdateEntityMetric).toHaveBeenCalledWith(
       expect.objectContaining({ metricType: 'ReactionLike', amount: -1 })
     );
+  });
+});
+
+// The milestone hangs off one fire-and-forget line in toggleReactionHandler, and
+// nothing observed it: deleting `createReactionNotification(input).catch(...)` left
+// this suite and the milestone's own tests green. This is the only place that drives
+// the real handler, so it is the only place that can see the call happen at all.
+describe('toggleReactionHandler — the milestone is actually reached', () => {
+  it('creates the milestone notification for a newly created reaction', async () => {
+    mockToggleReaction.mockResolvedValue('created');
+    mockNotificationExists.mockResolvedValue(false);
+    const ctx = makeCtx();
+
+    await toggleReactionHandler({ ctx, input });
+    // The call is fire-and-forget, so let its microtasks drain before asserting.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification.mock.calls[0][0]).toMatchObject({
+      key: 'image-reaction-milestone:1:5',
+    });
   });
 });

--- a/src/server/controllers/reaction.controller.ts
+++ b/src/server/controllers/reaction.controller.ts
@@ -8,6 +8,7 @@ import { imageReactionMilestones } from '~/server/notifications/reaction.notific
 import { encouragementReward, goodContentReward } from '~/server/rewards';
 import type { ToggleReactionInput } from '~/server/schema/reaction.schema';
 import { getContestsFromEntity } from '~/server/services/collection.service';
+import { getMetricExcludedUserIds } from '~/server/services/metric-excluded-users.service';
 import { createNotification } from '~/server/services/notification.service';
 import { handleLogError, throwBadRequestError, throwDbError } from '~/server/utils/errorHandling';
 import { updateEntityMetric } from '~/server/utils/metric-helpers';
@@ -289,10 +290,23 @@ export const toggleReactionHandler = async ({
   }
 };
 
-const createReactionNotification = async ({ entityType, entityId }: ToggleReactionInput) => {
+// Exported for tests: the property that matters is that an unavailable exclusion
+// list still produces a notification, and that is only observable here.
+export const createReactionNotification = async ({
+  entityType,
+  entityId,
+}: ToggleReactionInput) => {
   if (entityType === 'image') {
+    // Every displayed count filters reaction-farm accounts; a raw Postgres count did
+    // not, so the milestone fired on numbers no display agreed with. An empty list
+    // here means the lookup was unavailable and the count is unfiltered — the
+    // pre-change behaviour, and never a skipped notification.
+    const excludedUserIds = await getMetricExcludedUserIds();
     const cnt = await dbRead.imageReaction.count({
-      where: { imageId: entityId },
+      where: {
+        imageId: entityId,
+        ...(excludedUserIds.length ? { userId: { notIn: excludedUserIds } } : {}),
+      },
     });
 
     // const { reactionCount: cnt = 0 } =
@@ -310,6 +324,14 @@ const createReactionNotification = async ({ entityType, entityId }: ToggleReacti
     const key = `${type}:${entityId}:${match}`;
 
     if (await notifications.notificationExists({ key })) return;
+
+    // KNOWN, and deliberately not guarded here: filtering can lower `cnt`, so `match`
+    // can move DOWN, and where a burst crossed several thresholds at once only the top
+    // key was written — so a lower milestone can arrive after a higher one. Guarding it
+    // means asking `notificationExists` for each higher threshold, and that is an HTTP
+    // call per key to the notifications service, re-run on every reaction to exactly the
+    // images this suppression targets. A cosmetic ordering quirk is not worth a standing
+    // cross-service N+1; it needs a batched existence check first.
 
     const resource = await dbRead.image.findFirst({
       where: { id: entityId },

--- a/src/server/services/__tests__/reaction-milestone-excluded-users.test.ts
+++ b/src/server/services/__tests__/reaction-milestone-excluded-users.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as CacheHelpers from '~/server/utils/cache-helpers';
+import { CacheTTL } from '~/server/common/constants';
+import { REDIS_KEYS } from '~/server/redis/client';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+// The reaction milestone counted every `ImageReaction` row, while every displayed
+// count filters the reaction-farm suppression list — 24 against a displayed 4 on
+// image 141298569, two milestones apart at thresholds of 5/10/20/50/100.
+//
+// Nothing here mocks `getMetricExcludedUserIds`. The tests drive the real service
+// through a faked `fetchThroughCache`, so the fail-open path they assert is the one
+// that runs in production rather than a stand-in for it.
+
+const h = vi.hoisted(() => ({
+  fetchThroughCache: vi.fn(),
+  chQuery: vi.fn(),
+  notificationExists: vi.fn(),
+  createNotification: vi.fn(),
+}));
+
+// Spread the real module rather than listing exports: the controller's import graph
+// pulls other cache helpers in, and a hand-listed mock breaks the moment it grows.
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof CacheHelpers>()),
+  fetchThroughCache: h.fetchThroughCache,
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { $query: h.chQuery },
+}));
+
+vi.mock('~/server/notifications/client', () => ({
+  notifications: { notificationExists: h.notificationExists },
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: h.createNotification,
+}));
+
+const count = dbMock.dbRead.imageReaction.count;
+const findFirst = dbMock.dbRead.image.findFirst;
+
+const { getMetricExcludedUserIds } = await import(
+  '~/server/services/metric-excluded-users.service'
+);
+// Hoisted rather than imported inside a test: the controller's import graph took
+// ~12s, and charging that to one test's budget turns a slow box into a timeout with
+// no assertion to read.
+const { createReactionNotification } = await import('~/server/controllers/reaction.controller');
+
+/** Runs the real fetch function, so the row mapping and filtering are exercised. */
+const cachePassthrough = () =>
+  h.fetchThroughCache.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => fn());
+
+const cacheRejects = (message = 'clickhouse unreachable') =>
+  h.fetchThroughCache.mockRejectedValue(new Error(message));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.fetchThroughCache.mockReset();
+  h.chQuery.mockReset();
+  h.notificationExists.mockResolvedValue(false);
+  count.mockReset();
+  findFirst.mockReset();
+  findFirst.mockResolvedValue({ userId: 42, id: 141298569, postId: 7, resourceHelper: [] });
+  h.createNotification.mockResolvedValue(undefined);
+});
+
+describe('getMetricExcludedUserIds', () => {
+  it('returns the suppressed ids', async () => {
+    cachePassthrough();
+    h.chQuery.mockResolvedValue([{ userId: 6680940 }, { userId: 7472843 }]);
+
+    await expect(getMetricExcludedUserIds()).resolves.toEqual([6680940, 7472843]);
+  });
+
+  // `Number(null)` is 0, not NaN, so a null column would enter the list as user 0
+  // and suppress whatever writes that id.
+  it('drops ids that are not positive numbers', async () => {
+    cachePassthrough();
+    h.chQuery.mockResolvedValue([{ userId: 0 }, { userId: null }, { userId: 6680940 }]);
+
+    await expect(getMetricExcludedUserIds()).resolves.toEqual([6680940]);
+  });
+
+  // Without these the statement was unasserted: deleting `WHERE active = 1` subtracts
+  // every user ever flagged, including ones since un-flagged, so milestones silently
+  // stop firing for people who should get them — and every test stayed green.
+  it('reads only rows still active, through FINAL', async () => {
+    cachePassthrough();
+    h.chQuery.mockResolvedValue([]);
+
+    await getMetricExcludedUserIds();
+
+    const sql = (h.chQuery.mock.calls[0][0] as string[]).join('');
+    expect(sql).toContain('FINAL');
+    expect(sql).toContain('active = 1');
+    expect(sql).toContain('metricExcludedUsers');
+  });
+
+  // The key is new in this diff, so nothing else protects it: pointing it at a
+  // sibling constant would write a number[] over another cache's namespace and read
+  // that cache's payload back as user ids, with every test still passing.
+  it('reads and writes its own cache key, at its own TTL', async () => {
+    cachePassthrough();
+    h.chQuery.mockResolvedValue([]);
+
+    await getMetricExcludedUserIds();
+
+    expect(h.fetchThroughCache).toHaveBeenCalledWith(
+      REDIS_KEYS.CACHES.METRIC_EXCLUDED_USERS,
+      expect.any(Function),
+      { ttl: CacheTTL.sm }
+    );
+  });
+
+  // `fetchThroughCache` returns any present `data` unvalidated, so a cached `null`
+  // would reach the caller's `.length` OUTSIDE this function's catch — a TypeError
+  // that `.catch(handleLogError)` turns into the silent skip this design avoids.
+  it('treats a cached value that is not an array as unavailable', async () => {
+    h.fetchThroughCache.mockResolvedValue(null);
+
+    await expect(getMetricExcludedUserIds()).resolves.toEqual([]);
+  });
+
+  // `fetchThroughCache` REJECTS when the origin fails with nothing cached, and the
+  // only caller runs as `.catch(handleLogError)` — so propagating would silently
+  // skip the notification. Returning [] degrades to the unfiltered count instead.
+  it('returns an empty list instead of rejecting when the lookup fails', async () => {
+    cacheRejects();
+
+    await expect(getMetricExcludedUserIds()).resolves.toEqual([]);
+  });
+});
+
+describe('createReactionNotification', () => {
+  async function run() {
+    await createReactionNotification({ entityType: 'image', entityId: 141298569 } as never);
+  }
+
+  // The `count` fake honours the where clause on purpose. With a flat stub the 4 comes
+  // from the stub rather than from the filter, so the assertion would hold even with
+  // the filter removed — it would prove the mock works, not the code.
+  const countHonouringWhere = () =>
+    count.mockImplementation(async (args: { where: { userId?: unknown } }) =>
+      args.where.userId ? 4 : 24
+    );
+
+  it('excludes suppressed users, changing which milestone fires', async () => {
+    cachePassthrough();
+    h.chQuery.mockResolvedValue([{ userId: 6680940 }]);
+    countHonouringWhere();
+
+    await run();
+
+    expect(count).toHaveBeenCalledWith({
+      where: { imageId: 141298569, userId: { notIn: [6680940] } },
+    });
+    // Filtered this image is 4, below the lowest threshold (5). Unfiltered it is 24,
+    // which fires the 20 — that difference is the whole change.
+    expect(h.createNotification).not.toHaveBeenCalled();
+  });
+
+  // The property that decided this approach over reading ClickHouse. If the list is
+  // unavailable the milestone must still fire on the unfiltered count; the failure
+  // mode is the old bug, never a skipped notification.
+  it('still fires on the unfiltered count when the exclusion lookup fails', async () => {
+    cacheRejects();
+    count.mockResolvedValue(24);
+
+    await run();
+
+    expect(count).toHaveBeenCalledWith({ where: { imageId: 141298569 } });
+    expect(h.createNotification).toHaveBeenCalledTimes(1);
+    expect(h.createNotification.mock.calls[0][0]).toMatchObject({
+      key: 'image-reaction-milestone:141298569:20',
+      userId: 42,
+    });
+  });
+
+  // An empty list must not become `notIn: []`, which is a different query.
+  it('omits the filter clause entirely when nothing is suppressed', async () => {
+    cachePassthrough();
+    h.chQuery.mockResolvedValue([]);
+    count.mockResolvedValue(10);
+
+    await run();
+
+    expect(count).toHaveBeenCalledWith({ where: { imageId: 141298569 } });
+    expect(h.createNotification).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/metric-excluded-users.service.ts
+++ b/src/server/services/metric-excluded-users.service.ts
@@ -1,0 +1,80 @@
+import { clickhouse } from '~/server/clickhouse/client';
+import { CacheTTL } from '~/server/common/constants';
+import { REDIS_KEYS } from '~/server/redis/client';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * Users suppressed from metrics by the reaction-abuse detector
+ * (`/api/admin/reaction-abuse`). Every ClickHouse path that produces a metric total
+ * filters them, and as of #4584 so does the event-engine's Redis cache — but a
+ * Postgres `count()` over `ImageReaction` does not, which is why the reaction
+ * milestone fires on numbers no displayed count agrees with.
+ *
+ * These accounts are NOT banned, deleted or muted: the list suppresses metrics only.
+ */
+const CACHE_TTL = CacheTTL.sm;
+
+/**
+ * Returns [] rather than throwing, and that is the point rather than caution.
+ *
+ * `fetchThroughCache` rejects when the origin fails with nothing cached, and the one
+ * caller runs as `createReactionNotification(input).catch(handleLogError)` — so a
+ * propagated rejection would silently skip the notification. Skipping is the failure
+ * mode this approach was chosen to avoid: an empty list means the count is computed
+ * unfiltered, which is exactly how the milestone behaved before this change. Degrade
+ * to the old bug, never to silence.
+ */
+export async function getMetricExcludedUserIds(): Promise<number[]> {
+  if (!clickhouse) return [];
+
+  try {
+    const cached = await fetchThroughCache(
+      REDIS_KEYS.CACHES.METRIC_EXCLUDED_USERS,
+      async () => {
+        const rows = await clickhouse!.$query<{ userId: number }>`
+          SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
+        `;
+        // > 0 because `Number(null)` is 0, not NaN: a null column would otherwise
+        // enter the list as user 0 and silently suppress whatever writes that id.
+        // `isFinite` is belt-and-braces here, kept for parity with the identical
+        // guard in metric-reaction-repair.service.ts and the event-engine copy.
+        return rows.map((r) => Number(r.userId)).filter((id) => Number.isFinite(id) && id > 0);
+      },
+      // Passed explicitly, not because it differs from fetchThroughCache's default —
+      // it does not — but so a change to that default cannot silently widen this past
+      // the "within ~5 min" the admin endpoint promises.
+      { ttl: CACHE_TTL }
+    );
+
+    // The cache read is the one failure this function's own try does NOT cover:
+    // `fetchThroughCache` returns any present `data` unvalidated, and a `null` would
+    // reach the caller's `.length` outside this catch — a thrown TypeError, which the
+    // caller's `.catch(handleLogError)` turns into the silent skip this whole design
+    // exists to avoid. Validate the shape rather than trust the type.
+    if (!Array.isArray(cached)) throw new Error('cached exclusion list was not an array');
+    unavailable = false;
+    return cached;
+  } catch (error) {
+    reportUnavailable(error);
+    return [];
+  }
+}
+
+/**
+ * Logged once per outage — on the first failure, and again only after a success has
+ * reset the flag. This runs on every created reaction, so once an outage outlives the
+ * cache entry every reaction would otherwise emit its own Axiom ingest, turning the
+ * busiest write path into a log amplifier exactly when infrastructure is degraded.
+ */
+let unavailable = false;
+function reportUnavailable(error: unknown) {
+  if (unavailable) return;
+  unavailable = true;
+  logToAxiom({
+    type: 'warning',
+    name: 'metric-excluded-users-unavailable',
+    message: 'Falling back to an unfiltered count',
+    details: { error: (error as Error)?.message },
+  }).catch(() => undefined);
+}


### PR DESCRIPTION
Second half of ClickUp `868m0a19b`. [#4584](https://github.com/civitai/civitai/pull/4584) fixed the Redis metric cache; this fixes the reaction milestone. Unblocks `868kuyu5t`.

## The bug

`createReactionNotification` judged the milestone on a raw `dbRead.imageReaction.count()`, which counts every row. Every number a user is *shown* filters `metricExcludedUsers` — a reaction-farm suppression list of 461 accounts. Every ClickHouse aggregate does, and since #4584 so does the Redis metric cache. The milestone did not.

Thresholds are **5/10/20/50/100**, which is exactly the low-count band where suppression dominates. Image 141298569: raw 24 (fires the 20), filtered 4 (fires nothing). Proved in Postgres alone, with the 461 ids inlined and no ClickHouse in the computation:

| imageId | pg_all | excluded | pg_kept | aggregate |
|---|---|---|---|---|
| 141295926 | 25 | 20 | **5** | 5 |
| 141298569 | 24 | 20 | **4** | 4 |
| 141488072 | 16 | 8 | **8** | 8 |
| 140989291 | 12 | 8 | **4** | 4 |

Across 120 images sampled by the ticket's own method, filtering takes the worst error from **12 to 1** and the total error from **89 to 5**.

## Why not read the ClickHouse aggregate

It fails two ways this does not.

- `getImageMetricsObject` soft-fails to `{}`, so `cnt` is undefined, `if (!cnt) return` fires, and the notification is **silently skipped**. That is the failure mode this whole ticket exists to keep visible — the milestone is the only place the two numbers appear side by side, which is why a user could report it.
- It inherits forward-only staleness. `entityMetricTotal_v3` recomputes only for entities in `entityMetricDirty_v3`, so a milestone could fire on a total the aggregate itself would not support once refreshed.

**Forward-only staleness only bites if the milestone reads ClickHouse.** Subtracting the list from a live Postgres count has no equivalent.

## The safety property, and how it is pinned

`getMetricExcludedUserIds` never propagates a failure:

- `fetchThroughCache` **rejects** when the origin fails with nothing cached, and the caller runs as `.catch(handleLogError)` — propagating would reintroduce the silent skip.
- It also validates the cached value is an array. `fetchThroughCache` returns any present `data` unvalidated, so a cached `null` would reach the caller's `.length` **outside** the catch and throw into the same silent skip.

Both return `[]`, which yields an unfiltered count — the behaviour before this change. **Degrade to the old bug, never to silence.** Two tests force each failure; reverting either catch reddens them by name.

## Known, and deliberately not addressed

- **A lower milestone can arrive after a higher one.** Filtering can lower `cnt`, so `match` can move down; where a burst crossed several thresholds at once only the top key was written. Guarding it costs one `notificationExists` **HTTP call per higher threshold** (the notifications spoke has no batched existence API), re-run on every reaction to exactly the images suppression targets — a standing cross-service N+1 for a cosmetic ordering quirk. I wrote that guard, measured it, and removed it.
- **A reverted exclusion does not restore a withheld milestone.** Evaluation runs only when a reaction is created, so if no further reaction lands the owner never receives it.
- **No reaction-type filter.** The milestone counts `Dislike`, the display does not — but `availableReactions` is a flat map that *includes* `Dislike`, and the four-reaction set exists only as a hand-written literal in five places, so closing it here means a sixth copy. Inert today: 0 Dislikes in the last 200,000 reaction rows.
- **Nothing is repaired.** Milestones already delivered stand. Neither this nor #4584 fixes historical counts — `exclude` performs no `metrics:*` purge, so the four images above do not read correctly after both ship. That needs a purge or backfill nobody has scoped.

⚠️ **This depends on #4584 being deployed to be coherent.** `apps/event-engine` releases separately, so until an event-engine release ships, the cache still counts farm reactions and this makes the milestone and the displayed count disagree in the *opposite* direction.

## Performance — measured on the prod replica, read-only

Same index (`ImageReaction_imageId_userId_reaction_key`, Index Only Scan), **identical buffer counts**, exclusion applied as a node Filter with hashed ScalarArrayOpExpr. Execution does not scale with list size at any size up to 20,000. **The entire cost is query planning**, linear at ~2.4 µs/element, and it is re-paid on every execution because Prisma's N-scalar `notIn` never reaches a generic plan (verified with `PREPARE` + 6 executions).

🔴 **These ratios are measured against the p50 image — 1 reaction, `shared hit=6`, ~0.12 ms baseline.** Against a hot image the same clause looks like nothing: identical buffers, execution unchanged. Cited without that denominator, someone re-measuring on a hot image will find no effect and read the finding as wrong.

| variant (p50 image) | planning | execution | total |
|---|---|---|---|
| no filter | 0.06–0.09 ms | 0.04–0.06 ms | **~0.12 ms** |
| `NOT IN` 461 (today) | 0.99–1.23 ms | 0.05 ms | **~1.05 ms** |
| `NOT IN` 5000 | 11.9–17.9 ms | 0.18–0.25 ms | **~12–18 ms** |

At 928,124 image reactions/day: **~1.1% of one replica core today**, ~12.6% at 5000 ids. Organic growth (~200/month) reaches 5000 in ~23 months — but the admin endpoint accepts 5000 ids in **one call**, so a single batch gets there in one request. The fix when it matters is a single `int[]` bind parameter (measured: 0.28 ms planning at 5000 once the generic plan kicks in, vs 9.8 ms), with the caveat that a pgbouncer transaction-pooling hop would erase the win. Filed with a mechanical closing condition rather than done here.

Redis and the stampede lock are fine, with a number: `fetchThroughCache` writes with `EX: ttl * 2`, so between 180 s and 360 s the key still exists and losers stale-serve — **one ClickHouse query per 180 s fleet-wide**, not per reaction. The fail-open origin is a 467-row / 22.6 KiB table, so the Redis-outage bypass cannot hurt ClickHouse.

⚠️ **Re-running those EXPLAINs from the worktree silently hits the dev clone behind a banner reading PROD** — the worktree has no `.claude/skills/postgres-query/.env`. Run from the primary checkout and confirm the banner says `civitai-app-readonly@localhost:25061`.

## Verification — commit `c7e30eb22c`, based on `main` at `b4bad5d28f`

| check | result | what it covered |
|---|---|---|
| `pnpm run typecheck` | exit 0, 0 errors | src/ |
| `pnpm exec eslint` (5 changed files) | exit 0 | 0 errors; 1 warning, an unused `Prisma` import `git show origin/main` confirms predates this |
| `pnpm run test:unit:run` | exit 0 | `Test Files 1570 passed \| 3 skipped (1573)`, `Tests 24891 passed \| 35 skipped (24926)` |
| `pnpm run test:packages:run` | exit 0 | `83 passed \| 3 skipped (86)`, `1158 passed \| 8 skipped (1166)` — the Redis key constant lives here |
| `pnpm run test:lint-rules` | exit 0 | `28 passed (28)`, `448 passed (448)` |
| `prettier --check` (new files) | clean | added files are CI-blocking |

**One failure, reported rather than filtered.** The first full-suite run was `Test Files 1 failed | 1569 passed | 3 skipped (1573)` — `eventloop-watchdog.worker.test.ts`, `civitai_app_watchdog_wedged` was 1 where 0 was expected. That test measures event-loop wedging, was authored in #3752/#3755 and is untouched here; this diff has no import path to it; it passes 8/8 alone; and the run's own timings show heavy contention (`import 5792s` across workers). A second full run was green with identical file and test totals, so nothing vanished — the one failure flipped. Load-sensitive, mechanism named.

`no-direct-shared-module-mock` caught the first version of these tests hand-mocking `~/server/db/client` when a canonical `dbMock` exists. Fixed rather than exempted — note the repo's own codemod emits the wiring **above** the `vi.hoisted` const it references, which is a temporal dead zone, so its output needs reading before it is trusted.

### Every test fails on revert, by name

Ten mutants, each restored with an md5 match (`git status` does not prove a restore — a same-length substitution passes it):

| mutant | caught by |
|---|---|
| filter clause removed | `excludes suppressed users, changing which milestone fires` |
| empty-list guard removed | `still fires on the unfiltered count…` + `omits the filter clause entirely…` |
| **fail-open catch removed** | `returns an empty list instead of rejecting…` + `still fires on the unfiltered count…` |
| **`Array.isArray` guard removed** | `treats a cached value that is not an array as unavailable` |
| **`WHERE active = 1` deleted** | `reads only rows still active, through FINAL` |
| **`FINAL` deleted** | `reads only rows still active, through FINAL` |
| **cache key pointed at a sibling** | `reads and writes its own cache key, at its own TTL` |
| **TTL dropped** | `reads and writes its own cache key, at its own TTL` |
| positive-id filter removed | `drops ids that are not positive numbers` |
| **call site deleted** | `creates the milestone notification for a newly created reaction` |

The six in bold were **surviving mutants** in the first version of this branch — the review found them, not the suite. The SQL, the cache key and the TTL were entirely unasserted, and deleting the call site left every test in the repo green.

The headline test also changed shape: `count` was a flat stub returning 4, so the assertion held from the stub rather than the filter. It is now a fake that honours the `where` clause — 24 unfiltered, 4 filtered — which makes the diff's central claim executable rather than assumed.

## Review

`civitai-correctness-review`, `civitai-reuse-review`, `civitai-perf-review`, `civitai-test-review`, `civitai-intent-review`, all against `adeeb8dbce`. Findings acted on: the `Array.isArray` gap, the four unasserted mutants, the per-reaction Axiom amplification during an outage (now logged once per outage, reset on recovery), and the N+1 guard removal above.

Corrections to my own claims, made on their evidence: the commit no longer says "one named home" — the query now exists in **three** places in `src/`, and the other two (`metric-reaction-repair.service.ts`, `contest-score.queries.ts`) are deliberately not converted **because they must throw** rather than silently see an empty list. One writes compensation rows at scale; the other feeds contest disqualification. The failure modes differ on purpose. And the TTL is stated as the library default passed explicitly, not as a bespoke choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Pcj1JeRGSkvVo7f3Ek6q2
