### PR TITLE
fix(app-blocks): full-bleed opt-out ledger was inert in production (data-testid is stripped)

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -429,20 +429,33 @@ removed here without that being a deliberate, reviewed change.
 **What actually guards the snippet above.** The CSS block on this page is read by
 `src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts`,
 which parses the strip list out of `next.config.mjs` and fails if the selector
-shown here depends on an attribute production removes. That test runs in the node
-`unit` project, which is a **blocking** CI check — so the specific way this recipe
-went wrong before (the `data-testid` spelling) cannot come back silently.
+shown here depends on an attribute production removes — and parses
+`PageBlockHost.tsx` and fails if the attributes the selector chains are not
+stamped **together on one element**, the other way a compound selector silently
+matches nothing. Both are real checks and both catch the specific ways this
+recipe has gone wrong (the `data-testid` spelling; a half of the selector moved
+onto another box).
+
+🔴 **What that does NOT mean is that the mistake is impossible.** The guard runs
+in the node `unit` project, which on a pull request is **report-only** — the job
+carries `continue-on-error` there, so the check annotates and the run still
+concludes green — and renders a real verdict only on pushes to `main`, after the
+merge. And **no status check is required on `main` in this repo at all**: branch
+protection declares none, so nothing a test does stops a merge. A red guard here
+is a signal a reviewer has to read, not a gate that holds the door.
 
 Two things it does **not** promise. It compares the doc against the compiler
-config; it does not render anything, so it cannot tell you the rule still has the
-visual effect described. And the rule's measured behaviour —
-`src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx` injects a rule
-of this shape at a 2560px viewport and asserts the host goes back to full width —
-runs in the browser `component` project, which reports as the **non-blocking**
-`preview / component-tests` status. Useful evidence, not a gate: it can go red
-without stopping a merge. And the guard covers the CSS **selector** on this page,
-nothing else: that test is the only thing in the repo that reads this file, so
-every other claim here is unverified prose and should be read as such.
+config and against the host's JSX; it does not render anything, so it cannot tell
+you the rule still has the visual effect described. And the rule's measured
+behaviour — `src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx`
+injects a rule of this shape at a 2560px viewport and asserts the host goes back
+to full width — runs in the browser `component` project, which reports as the
+`preview / component-tests` status. Useful evidence, not a gate — and, as above,
+neither tier is one: both can go red without stopping a merge. What this tier
+alone can do is see a rendered width at all. And the guard covers the CSS
+**selector** on this page, nothing else: that test is the only thing in the repo
+that reads this file, so every other claim here is unverified prose and should be
+read as such.
 
 ### Manifest re-publish behavior
 

--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -395,10 +395,21 @@ would be untyped where the host reads it). Instead it is one CSS rule on the
 civitai side, keyed on the `data-block-id` the host stamps:
 
 ```css
-[data-testid='app-page-frame'][data-block-id='your-app-slug'] {
+[data-app-page-frame][data-block-id='your-app-slug'] {
   --app-page-max-width: none;
 }
 ```
+
+🔴 **Never key this rule on `data-testid` — that attribute does not exist in
+production.** `next.config.mjs` sets `compiler.reactRemoveProperties` under
+`NODE_ENV === 'production'`, so every testid is compiled out of the live DOM. A
+rule keyed on one works in every preview and local build and matches **zero
+elements on civitai.com** — the app stays letterboxed and nothing looks broken.
+That is not hypothetical: this ledger shipped that spelling and
+`playable-collections` rendered capped in production while every test tier passed.
+`data-app-page-frame` is the presence marker the host stamps for exactly this
+purpose, on the same element as `data-block-id`; both halves of the selector must
+be on that one element.
 
 Those rules live in the **full-bleed opt-out ledger** in
 `src/styles/globals.css`, next to the `--app-page-max-width` declaration; the
@@ -415,10 +426,23 @@ is unaffected either way. Every entry is expected to carry a reason like this
 one; the ledger's membership is asserted in a test, so a rule cannot be added or
 removed here without that being a deliberate, reviewed change.
 
-The mechanism is measured, not just documented:
+**What actually guards the snippet above.** The CSS block on this page is read by
+`src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts`,
+which parses the strip list out of `next.config.mjs` and fails if the selector
+shown here depends on an attribute production removes. That test runs in the node
+`unit` project, which is a **blocking** CI check — so the specific way this recipe
+went wrong before (the `data-testid` spelling) cannot come back silently.
+
+Two things it does **not** promise. It compares the doc against the compiler
+config; it does not render anything, so it cannot tell you the rule still has the
+visual effect described. And the rule's measured behaviour —
 `src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx` injects a rule
-of exactly this shape at a 2560px viewport and asserts the host goes back to full
-width, so the instructions above cannot rot into something that no longer works.
+of this shape at a 2560px viewport and asserts the host goes back to full width —
+runs in the browser `component` project, which reports as the **non-blocking**
+`preview / component-tests` status. Useful evidence, not a gate: it can go red
+without stopping a merge. And the guard covers the CSS **selector** on this page,
+nothing else: that test is the only thing in the repo that reads this file, so
+every other claim here is unverified prose and should be read as such.
 
 ### Manifest re-publish behavior
 

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -3868,8 +3868,8 @@ export function PageBlockHost({
         // the `data-block-id` opt-out ledger — the custom property is still declared
         // once in globals.css and still overridden per-app on THIS element, from
         // which it INHERITS to the content wrapper. So a ledger entry keyed on
-        // `[data-testid='app-page-frame'][data-block-id='…']` keeps working exactly
-        // as documented, with no change to its selector.
+        // `[data-app-page-frame][data-block-id='…']` keeps working exactly as
+        // documented, with no change to its selector.
         width: '100%',
         // See the `fit` prop for why these are the two modes and why the
         // viewport arithmetic can never agree with its own scroll viewport.
@@ -3892,6 +3892,28 @@ export function PageBlockHost({
             }),
       }}
       data-testid="app-page-frame"
+      // 🔴 THE OPT-OUT LEDGER'S OTHER HALF, AND IT EXISTS BECAUSE `data-testid`
+      // DOES NOT SHIP. `next.config.mjs` sets
+      // `compiler.reactRemoveProperties: { properties: ['^data-testid$'] }` under
+      // `NODE_ENV === 'production'`, so EVERY `data-testid` is compiled out of the
+      // production DOM. The ledger in globals.css used to be keyed on
+      // `[data-testid='app-page-frame'][data-block-id='…']`, which therefore
+      // matched nothing on the live site while passing in every test tier (they
+      // all run with `NODE_ENV !== 'production'`, where the testid is present) —
+      // measured on civitai.com/apps/run/playable-collections: the rule shipped
+      // verbatim in the CSS, 0 elements matched the compound selector, 1 matched
+      // `[data-block-id='playable-collections']`, and the app was letterboxed at
+      // the 1600px cap. This attribute is the production-surviving spelling of
+      // "this is the page host", the same way `data-app-footer` and
+      // `data-adhesive-ad` mark their elements for `globals.css` elsewhere.
+      //
+      // It carries no value on purpose: it is a presence marker, not data. Never
+      // re-key the ledger onto `data-testid` (stripped) and never delete this —
+      // both make every ledger rule inert with nothing visibly wrong. Guarded by
+      // `__tests__/ledgerSelectorSurvivesProdStrip.test.ts`, which reads the strip
+      // list out of `next.config.mjs` and the ledger selectors out of globals.css
+      // and compares them, rather than restating either.
+      data-app-page-frame=""
       // Observable sizing mode, so a regression test (and DevTools) can assert
       // WHICH branch a surface took rather than re-deriving it from computed
       // styles that jsdom does not resolve.
@@ -3963,7 +3985,7 @@ export function PageBlockHost({
           same element, which is precisely the rule shape the opt-out ledger uses — so
           writing the value inline would silently make the opt-out inert while looking
           tidier. The property is set on the ROOT and inherits down to here, so the
-          ledger's existing `[data-testid='app-page-frame'][data-block-id='…']` selector
+          ledger's existing `[data-app-page-frame][data-block-id='…']` selector
           is unchanged by the move.
 
           🔴 IT REPRODUCES THE VERTICAL CHAIN IT WAS INSERTED INTO, which is the only

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -443,7 +443,8 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
 
   /**
    * THE DOCUMENTED FULL-BLEED OPT-OUT, end to end: the ledger in `globals.css`
-   * keys on `data-block-id`, which the host stamps.
+   * keys on `data-app-page-frame` + `data-block-id`, both of which the host
+   * stamps on its root.
    *
    * Both halves are in ONE test on purpose. The second assertion alone is GREEN
    * on the base revision (an uncapped host is full width for reasons that have
@@ -451,6 +452,18 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
    * than coverage. Pairing it with the capped measurement makes the test assert
    * a DELTA — the rule changed something — which is only true once both the cap
    * and the `data-block-id` anchor exist.
+   *
+   * ⚠️ THIS TIER IS STRUCTURALLY BLIND TO THE ONE DEFECT THAT ACTUALLY SHIPPED,
+   * AND SAYING SO IS THE POINT. The selector below used to read
+   * `[data-testid='app-page-frame'][data-block-id='…']`, which is what
+   * `globals.css` shipped — and `next.config.mjs` strips every `data-testid` from
+   * the DOM under `NODE_ENV === 'production'`, so on the live site it matched
+   * nothing and `playable-collections` was letterboxed at the cap. This test
+   * passed throughout, because vitest never runs with `NODE_ENV=production`; no
+   * assertion added here can change that. The check that CAN see it compares the
+   * two configurations instead of rendering:
+   * `__tests__/ledgerSelectorSurvivesProdStrip.test.ts`. Do not "strengthen" this
+   * test to cover it — widen that one.
    */
   test('an app can opt out of the cap with a CSS rule keyed on `data-block-id`', async () => {
     const { measure, hostWidth, parentWidth } = await mountAt(2560, 1080);
@@ -458,15 +471,14 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
       parentWidth
     );
 
-    injectCss(
-      `[data-testid='app-page-frame'][data-block-id='${BLOCK_ID}'] { --app-page-max-width: none; }`
-    );
+    injectCss(`[data-app-page-frame][data-block-id='${BLOCK_ID}'] { --app-page-max-width: none; }`);
     const optedOut = measure();
     expect(
       optedOut.hostWidth,
       'the ledger rule shape documented on `--app-page-max-width` in globals.css did not ' +
-        'restore full-bleed at 2560x1080 — either `data-block-id` is no longer stamped or the ' +
-        'cap is no longer overridable, and every opt-out in that ledger is inert'
+        'restore full-bleed at 2560x1080 — either `data-app-page-frame`/`data-block-id` are no ' +
+        'longer stamped on the host root or the cap is no longer overridable, and every opt-out ' +
+        'in that ledger is inert'
     ).toBe(optedOut.parentWidth);
   });
 

--- a/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
+++ b/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
@@ -35,19 +35,24 @@ import { describe, expect, it } from 'vitest';
  * which is what this file does — it restates neither side.
  *
  * WHAT IS PINNED HERE:
- *   · the strip list is parseable out of `next.config.mjs`, non-empty, and
+ *   · the strip list is parseable out of `next.config.mjs`, non-empty, ENTIRELY
+ *     readable (every array element a plain literal — a mixed array would let
+ *     this guard grade a SHORTER list than production applies), and
  *     production-gated — asserted on the `compiler:` property's OWN conditional,
  *     not on "the words appear earlier in the file" (the reason the other tiers
  *     cannot see this defect)
  *   · at least one ledger rule is parseable out of `globals.css`
  *   · NO attribute any ledger selector depends on is removed by that strip list
- *     — checked over the shipped rules, over the ledger's own "HOW TO ADD ONE"
- *     template, AND over the publisher-facing HOW-TO in
- *     `docs/features/app-blocks.md`, because an example teaching the broken
- *     spelling re-creates the bug on the next entry
  *   · every ledger selector's attributes are stamped TOGETHER ON ONE ELEMENT by
  *     `PageBlockHost.tsx` — surviving the strip is worthless if nothing renders
  *     them, and a compound selector is satisfied by neither half alone
+ *
+ *   Those last two are applied to all THREE surfaces that carry a selector: the
+ *   shipped rules, the ledger's own "HOW TO ADD ONE" template, and the
+ *   publisher-facing HOW-TO in `docs/features/app-blocks.md` — because an example
+ *   re-creates the bug on the next entry, and it can do so through EITHER
+ *   mechanism (a stripped attribute, or a misspelled/renamed one that nothing
+ *   stamps). A guard on only one of the two would be narrower than this sentence.
  *
  * FAILS CLOSED. An unparseable config, an empty strip list, or zero parsed ledger
  * rules is a FAILURE, not a quiet pass: a reassuring zero here is indistinguishable
@@ -169,11 +174,36 @@ function stripPatterns(): string[] {
       'strip list would let every ledger selector pass unchecked.'
   ).toBe(true);
 
-  const patterns = (list!.initializer as ts.ArrayLiteralExpression).elements
+  const elements = (list!.initializer as ts.ArrayLiteralExpression).elements;
+  const patterns = elements
     .filter((e): e is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral =>
       ts.isStringLiteralLike(e)
     )
     .map((e) => e.text);
+
+  // 🔴 EVERY ELEMENT MUST BE READABLE, NOT JUST SOME OF THEM. Filtering to the
+  // string literals and grading what survives FAILS OPEN on a mixed array: a
+  // spread, an identifier, a template with a substitution or a conditional is
+  // silently dropped, and this guard then certifies the ledger against a strip
+  // list SHORTER than the one production applies. Measured, before this check
+  // existed: with `properties: ['^data-testid$', ...EXTRA_STRIPS]` where
+  // `EXTRA_STRIPS = ['^data-app-page-frame$']`, this file reported 7 passed / 7
+  // while production was stripping the very attribute the ledger had just been
+  // re-keyed onto — i.e. it re-certified the shipped defect as fixed. Same
+  // fail-closed direction as the two assertions above it.
+  expect(
+    patterns.length,
+    `next.config.mjs lists ${elements.length} entries in \`reactRemoveProperties.properties\` ` +
+      `but only ${patterns.length} of them are plain string literals this parse can read ` +
+      `(unreadable: ${elements
+        .filter((e) => !ts.isStringLiteralLike(e))
+        .map((e) => norm(e.getText()))
+        .join(', ')}). A spread, a variable or an interpolated template hides part of the strip ` +
+      'list, and everything below would then compare the ledger against a SHORTER list than ' +
+      'production applies — passing while an attribute the ledger depends on is being removed. ' +
+      'Inline the entries, or extend this parse to follow them; do not let it grade a subset.'
+  ).toBe(elements.length);
+
   expect(
     patterns,
     'next.config.mjs declares `reactRemoveProperties` with an EMPTY property list. Either the ' +
@@ -184,8 +214,14 @@ function stripPatterns(): string[] {
   return patterns;
 }
 
-/** The `compiler:` value's own conditional — the strip's actual gate. */
-function compilerGate(): { condition: string; whenTrue: string; whenFalse: string } {
+/**
+ * The `compiler:` value's own conditional — the strip's actual gate.
+ *
+ * `whenFalse` is deliberately NOT returned: the assertion that used to read it
+ * was unreachable (see the note in the gate test), and a field nobody reads
+ * invites the next person to re-add an assertion that can never fire.
+ */
+function compilerGate(): { condition: string; whenTrue: string } {
   const hits = propertyAssignments(nextConfigAst(), 'compiler');
   expect(
     hits.length,
@@ -211,7 +247,6 @@ function compilerGate(): { condition: string; whenTrue: string; whenFalse: strin
   return {
     condition: norm(c.condition.getText()),
     whenTrue: norm(c.whenTrue.getText()),
-    whenFalse: norm(c.whenFalse.getText()),
   };
 }
 
@@ -261,15 +296,19 @@ function strippedAttrsIn(selector: LedgerSelector, patterns: string[]): string[]
  * Measured: moving `data-app-page-frame=""` off the host root onto the
  * `app-page-content` wrapper re-creates the shipped production defect exactly —
  * `[data-app-page-frame][data-block-id='…']` matches zero elements, because the
- * two halves are now on different boxes — and the whole gating node tier stayed
- * BYTE-IDENTICALLY green. Only the report-only browser tier caught it, and that
- * tier cannot block a merge. Relocation is the mutation this shape exists to
- * catch, and it survived the guard written against it.
+ * two halves are now on different boxes — and the whole node tier stayed
+ * BYTE-IDENTICALLY green. Only the report-only browser tier caught it. (Neither
+ * tier blocks a merge — `main` requires no status check in this repo — so what a
+ * node-tier guard buys is an honest verdict on a push to `main` and an annotation
+ * a reviewer has to read, not a door that stays shut.) Relocation is the mutation
+ * this shape exists to catch, and it survived the guard written against it.
  *
- * 🔴 A SPREAD IS NOT COUNTED, DELIBERATELY. `{...props}` could carry anything, so
- * crediting a spread-bearing element with an attribute would be a guess in the
- * PASSING direction. Not counting it means such an element cannot satisfy a
- * selector, which fails closed — the right way round for a guard.
+ * 🔴 A SPREAD'S CONTENTS ARE NOT COUNTED, DELIBERATELY. `{...props}` could carry
+ * anything, so crediting a spread-bearing element with an attribute it might be
+ * passing would be a guess in the PASSING direction. Its EXPLICITLY WRITTEN
+ * attributes still count, so such an element can satisfy a selector on those; what
+ * cannot satisfy one is an attribute arriving only via the spread. Fail-closed on
+ * the unknown half — the right way round for a guard.
  */
 function stampedAttributeSets(): string[][] {
   const sf = ts.createSourceFile(HOST, read(HOST), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
@@ -303,12 +342,25 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
     // unconditional, the browser suite would start failing on its own and this
     // guard's framing would need rewriting.
     //
-    // 🔴 THREE ASSERTIONS, ON THE `compiler:` PROPERTY'S OWN CONDITIONAL. The
-    // condition must BE the production test; the strip must live in the branch
-    // that condition selects; and it must NOT also live in the other branch. A
-    // substring search over the file's prefix could make none of these claims —
-    // `const isProd = process.env.NODE_ENV === 'production'` on line 9 satisfied
-    // the old spelling by itself, so an unconditional strip passed 5/5.
+    // 🔴 TWO ASSERTIONS, ON THE `compiler:` PROPERTY'S OWN CONDITIONAL: the
+    // condition must BE the production test, and the strip must live in the branch
+    // that condition selects. A substring search over the file's prefix could make
+    // neither claim — `const isProd = process.env.NODE_ENV === 'production'` on
+    // line 9 satisfied the old spelling by itself, so an unconditional strip
+    // passed 5/5.
+    //
+    // 🔴 THERE USED TO BE A THIRD, `whenFalse` NOT CONTAINING THE STRIP, AND IT WAS
+    // UNREACHABLE. Both shapes it named are consumed earlier, so its message could
+    // never print. Measured: the strip in BOTH branches dies in `stripPatterns()`
+    // — which this test calls at its very first line, before any of this — with
+    // "declares `reactRemoveProperties` 2 times, not once" (5 failed / 2 passed);
+    // the strip in the non-production branch ONLY dies on the `whenTrue` assertion
+    // below (1 failed / 6 passed). With exactly one `reactRemoveProperties`, the
+    // only inputs that could still have reached the deleted assertion were text
+    // coincidences in `getText()` — false positives of the spelled-not-structural
+    // kind this file exists to remove. A coverage sentence wider than what is
+    // actually asserted reads as protection while providing none, so both the
+    // assertion and its share of this comment are gone rather than left standing.
     const gate = compilerGate();
     expect(
       gate.condition,
@@ -326,13 +378,6 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
         'SELECTS. Either it moved to the non-production branch (then every tier now runs with ' +
         'the stripped DOM and this guard is inverted), or it left the conditional entirely.'
     ).toContain('reactRemoveProperties');
-    expect(
-      gate.whenFalse,
-      'the `reactRemoveProperties` strip also appears in the NON-production branch of ' +
-        '`compiler:`, so it is effectively unconditional. That contradicts the premise this ' +
-        'whole file rests on — that the stripped DOM exists only in production, which is why no ' +
-        'rendered test tier can see a ledger selector keyed on a stripped attribute.'
-    ).not.toContain('reactRemoveProperties');
   });
 
   /**
@@ -447,9 +492,12 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
   /**
    * The ledger's own worked example is the thing the next person copies. If it
    * teaches the stripped spelling, the next entry re-creates the production-only
-   * defect — so the template is held to the same rule as the rules.
+   * defect — so the template is held to the same rules as the rules: it must
+   * survive the strip AND name attributes something actually stamps together.
+   * The shipped-rule guards below run over `stripComments()`d CSS and therefore
+   * cannot see this template at all.
    */
-  it('🔴 the ledger’s HOW-TO-ADD-ONE template teaches a spelling that survives production', () => {
+  it('🔴 the ledger’s HOW-TO-ADD-ONE template teaches a selector that survives production AND matches something', () => {
     const patterns = stripPatterns();
     const raw = read(GLOBALS_CSS);
     const documented = ledgerSelectors(raw);
@@ -470,6 +518,22 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
         'example is what the next entry is copied from, so it reproduces the defect one commit ' +
         'later. Update the "HOW TO ADD ONE" template as well as the rules.'
     ).toEqual([]);
+
+    const elements = stampedAttributeSets();
+    expect(
+      elements.length,
+      'no JSX elements were parsed out of PageBlockHost.tsx at all, so the check below would be ' +
+        'vacuous in the PASSING direction.'
+    ).toBeGreaterThan(0);
+
+    expect(
+      documented.filter((s) => !stampedTogether(s, elements)).map((s) => s.text),
+      'the "HOW TO ADD ONE" template in src/styles/globals.css chains attributes that NO SINGLE ' +
+        'element in PageBlockHost.tsx stamps together, so an entry copied from it matches ' +
+        'nothing. A misspelling reaches this assertion and not the strip one above (nothing ' +
+        'strips a misspelling); so does a rename that updated the shipped rules and the host but ' +
+        'not the comment they are copied from.'
+    ).toEqual([]);
   });
 
   /**
@@ -481,8 +545,20 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
    * the live site, which is precisely the defect this file was created for,
    * re-entering through the door marked documentation. This assertion is what
    * lets that doc claim it is checked.
+   *
+   * 🔴 BOTH MECHANISMS, NOT JUST THE STRIP. A documented selector can match zero
+   * elements two ways, and this file's own header names both: an attribute the
+   * compiler removes, or attributes nothing stamps TOGETHER. Checking only the
+   * first is a guard narrower than the sentence describing it. Measured, before
+   * the second check existed: changing the recipe to
+   * `[data-app-page-fram][data-block-id='your-app-slug']` — one dropped `e` — left
+   * this file 7 passed / 7, because a typo'd attribute is stripped by nothing. An
+   * author copying it gets a rule matching zero elements and a letterboxed app:
+   * the same user-visible outcome as the shipped bug, through the other door. The
+   * realistic trigger is a RENAME, where `globals.css` and `PageBlockHost.tsx` are
+   * both pinned and the doc is pinned by nothing.
    */
-  it('🔴 the publisher HOW-TO in docs/features/app-blocks.md teaches a production-surviving spelling', () => {
+  it('🔴 the publisher HOW-TO in docs/features/app-blocks.md teaches a selector that survives production AND matches something', () => {
     const patterns = stripPatterns();
     const documented = ledgerSelectors(read(PUBLISHER_DOC));
     expect(
@@ -505,6 +581,24 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
         'This is the copy app authors read, so it teaches a rule that works in every preview and ' +
         'matches nothing on civitai.com. Key it on a marker the compiler keeps, such as ' +
         '`data-app-page-frame`.'
+    ).toEqual([]);
+
+    const elements = stampedAttributeSets();
+    expect(
+      elements.length,
+      'no JSX elements were parsed out of PageBlockHost.tsx at all, so the check below would be ' +
+        'vacuous in the PASSING direction — the reassuring-zero shape this file refuses.'
+    ).toBeGreaterThan(0);
+
+    expect(
+      documented.filter((s) => !stampedTogether(s, elements)).map((s) => s.text),
+      'the full-bleed recipe in docs/features/app-blocks.md chains attributes that NO SINGLE ' +
+        'element in PageBlockHost.tsx stamps together, so a rule copied from it matches nothing — ' +
+        'surviving the production strip is worthless if nothing renders the attributes. A typo in ' +
+        'the documented attribute name reaches this assertion and not the strip one (nothing ' +
+        'strips a misspelling), and a rename of the real marker reaches it too, because this doc ' +
+        'is the one copy of the recipe that no other guard pins. Spell the attributes exactly as ' +
+        'PageBlockHost stamps them, on the element that stamps them both.'
     ).toEqual([]);
   });
 
@@ -543,7 +637,7 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
         'silent outcome as keying it on a stripped attribute, arrived at from the other side. ' +
         'Both halves existing somewhere in the file is NOT enough: splitting them across the ' +
         'host root and the `app-page-content` wrapper is exactly the relocation that re-creates ' +
-        'the shipped production defect, and the whole gating tier stayed green under it until ' +
+        'the shipped production defect, and the whole node tier stayed green under it until ' +
         'this assertion was written per-element. Either stamp every attribute the selector ' +
         'chains on the SAME element, or re-key the ledger onto attributes that are.'
     ).toEqual([]);

--- a/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
+++ b/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
@@ -83,6 +83,28 @@ function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 }
 
+/**
+ * ONLY the comment text of `src` — the exact complement of `stripComments`.
+ *
+ * 🔴 THIS EXISTS SO THE TEMPLATE ASSERTION INSPECTS THE TEMPLATE. It used to run
+ * over the WHOLE un-stripped file, which is the shipped rules AND the HOW-TO
+ * template, under a message naming only the template. Measured under the
+ * relocation mutant (`data-app-page-frame=""` moved off the host root): the
+ * assertion printed two selectors and blamed "the 'HOW TO ADD ONE' template" for
+ * both, when one of them is the shipped `playable-collections` rule — pointing a
+ * developer at a correct template to fix a defect that is not in it. The shipped
+ * rules keep their own coverage: the strip mechanism in "no shipped ledger rule
+ * depends on an attribute production strips", the stamped-together mechanism in
+ * "each ledger selector's attributes are stamped TOGETHER on ONE PageBlockHost
+ * element". Both of those read `stripComments()`d CSS, so the two scopes now
+ * partition the file instead of overlapping.
+ */
+function commentsOnly(src: string): string {
+  return [...src.matchAll(/\/\*[\s\S]*?\*\//g), ...src.matchAll(/^\s*\/\/.*$/gm)]
+    .map((m) => m[0])
+    .join('\n');
+}
+
 /** Collapse whitespace so an assertion pins the EXPRESSION, not its formatting. */
 function norm(src: string): string {
   return src.replace(/\s+/g, ' ').trim();
@@ -299,9 +321,10 @@ function strippedAttrsIn(selector: LedgerSelector, patterns: string[]): string[]
  * two halves are now on different boxes — and the whole node tier stayed
  * BYTE-IDENTICALLY green. Only the report-only browser tier caught it. (Neither
  * tier blocks a merge — `main` requires no status check in this repo — so what a
- * node-tier guard buys is an honest verdict on a push to `main` and an annotation
- * a reviewer has to read, not a door that stays shut.) Relocation is the mutation
- * this shape exists to catch, and it survived the guard written against it.
+ * node-tier guard buys is an honest verdict on a push to `main` or a
+ * `workflow_dispatch`, and an annotation a reviewer has to read, not a door that
+ * stays shut.) Relocation is the mutation this shape exists to catch, and it
+ * survived the guard written against it.
  *
  * 🔴 A SPREAD'S CONTENTS ARE NOT COUNTED, DELIBERATELY. `{...props}` could carry
  * anything, so crediting a spread-bearing element with an attribute it might be
@@ -496,16 +519,43 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
    * survive the strip AND name attributes something actually stamps together.
    * The shipped-rule guards below run over `stripComments()`d CSS and therefore
    * cannot see this template at all.
+   *
+   * 🔴 SCOPED TO `commentsOnly()`, WHICH IS THE COMPLEMENT OF WHAT THOSE GUARDS
+   * READ. Everything asserted here is therefore genuinely about the template, so
+   * the failure messages can name it — see `commentsOnly` for the measured case
+   * where they named it wrongly.
    */
   it('🔴 the ledger’s HOW-TO-ADD-ONE template teaches a selector that survives production AND matches something', () => {
     const patterns = stripPatterns();
     const raw = read(GLOBALS_CSS);
-    const documented = ledgerSelectors(raw);
+    const documented = ledgerSelectors(commentsOnly(raw));
     expect(
       documented.length,
-      'no ledger-shaped selector was found in src/styles/globals.css at all, comments included ' +
-        '— the template and the rules both went missing, or this parse is broken.'
+      'no ledger-shaped selector was found in the COMMENTS of src/styles/globals.css — the ' +
+        '"HOW TO ADD ONE" template went missing, or this parse is broken. (A shipped rule ' +
+        'cannot satisfy this: the scope here is comments only.)'
     ).toBeGreaterThanOrEqual(1);
+
+    // 🔴 CONTROL ON THE SCOPING ITSELF, DERIVED RATHER THAN LITERAL. If
+    // `commentsOnly()` ever degrades toward the identity function, every message
+    // below silently goes back to blaming the template for shipped-rule
+    // violations — the exact defect this scoping fixed. Comparing against the
+    // rules the shipped-rule guards actually read keeps this true whatever the
+    // ledger's membership becomes.
+    const shippedTexts = ledgerSelectors(stripComments(raw)).map((s) => s.text);
+    expect(
+      shippedTexts.length,
+      'no shipped ledger rule was parsed out of src/styles/globals.css, so the disjointness ' +
+        'control below could not fail even if `commentsOnly()` were the identity function.'
+    ).toBeGreaterThan(0);
+    expect(
+      documented.map((s) => s.text).filter((t) => shippedTexts.includes(t)),
+      'a SHIPPED ledger rule appeared in the comment-only scope, so `commentsOnly()` is no ' +
+        'longer isolating the "HOW TO ADD ONE" template and the messages below would ' +
+        'misattribute a shipped-rule violation to it. (If a template was deliberately written ' +
+        "with a live app's slug, give the example a placeholder slug instead — a template that " +
+        'is byte-identical to a shipped rule is a copyable example of a real entry.)'
+    ).toEqual([]);
 
     const bad = documented
       .map((s) => ({ selector: s.text, stripped: strippedAttrsIn(s, patterns) }))

--- a/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
+++ b/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
@@ -1,0 +1,284 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 🔴 THE FULL-BLEED LEDGER MUST SURVIVE THE PRODUCTION COMPILER'S ATTRIBUTE STRIP.
+ *
+ * This is a SEAM guard. Two files were each correct on their own and broken
+ * together, and every existing test was scoped to one side of the seam:
+ *
+ *   · `next.config.mjs` strips `data-testid` from the DOM in production builds
+ *     (`compiler.reactRemoveProperties`, gated on `NODE_ENV === 'production'`).
+ *   · `src/styles/globals.css` keyed the opt-out ledger on
+ *     `[data-testid='app-page-frame'][data-block-id='…']`.
+ *
+ * So on the live site the compound selector matched ZERO elements, and
+ * `playable-collections` — an app whose every open-collection view mode is
+ * uncapped by the app itself — rendered letterboxed at the 1600px cap, the exact
+ * outcome the rule's own comment says it exists to prevent. Measured on
+ * civitai.com/apps/run/playable-collections (image `20260902233645-bbbe837`):
+ * the rule was present in the deployed CSS verbatim; 0 elements matched the
+ * compound selector; 1 matched `[data-block-id='playable-collections']`; the
+ * whole page carried 0 `data-testid` attributes across 615 elements while 209
+ * elements carried other `data-*` attributes; the computed
+ * `--app-page-max-width` on the capped box was `1600px`.
+ *
+ * 🔴 WHY NO TEST COULD SEE IT, AND WHY THIS ONE CAN. Every tier runs with
+ * `NODE_ENV !== 'production'`, so the testid is present and the selector matches
+ * — including `PageBlockHostMaxWidth.browser.test.tsx`, which INJECTS a rule of
+ * that exact shape and measures full-bleed at 2560x1080. That suite is not
+ * wrong; it is structurally blind, because its environment fixes the one
+ * dimension the defect lives on. A rendered test can never see this. The only
+ * thing that can is a check that reads the two CONFIGURATIONS and compares them,
+ * which is what this file does — it restates neither side.
+ *
+ * WHAT IS PINNED HERE:
+ *   · the strip list is parseable out of `next.config.mjs`, non-empty, and
+ *     production-gated (the reason the other tiers cannot see it)
+ *   · at least one ledger rule is parseable out of `globals.css`
+ *   · NO attribute any ledger selector depends on is removed by that strip list
+ *     — checked over the shipped rules AND over the ledger's own "HOW TO ADD ONE"
+ *     template, because a doc example teaching the broken spelling re-creates the
+ *     bug on the next entry
+ *   · every attribute a ledger selector depends on is actually STAMPED by
+ *     `PageBlockHost.tsx` — surviving the strip is worthless if nothing renders it
+ *
+ * FAILS CLOSED. An unparseable config, an empty strip list, or zero parsed ledger
+ * rules is a FAILURE, not a quiet pass: a reassuring zero here is indistinguishable
+ * from a guard wired to nothing. If `reactRemoveProperties` is ever removed
+ * deliberately, delete or re-point this file in the same commit rather than
+ * letting it fail — but do that knowingly.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const NEXT_CONFIG = path.join(REPO_ROOT, 'next.config.mjs');
+const GLOBALS_CSS = path.join(REPO_ROOT, 'src/styles/globals.css');
+const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/PageBlockHost.tsx');
+
+const repoPath = (file: string) => path.relative(REPO_ROOT, file).split(path.sep).join('/');
+
+function read(file: string): string {
+  // Prove the path before trusting anything derived from it — a comparison
+  // against an absent operand reports SAME, not MISSING, so a renamed file would
+  // turn every assertion below into a vacuous pass on an empty string.
+  expect(fs.existsSync(file), `${repoPath(file)} does not exist`).toBe(true);
+  return fs.readFileSync(file, 'utf8');
+}
+
+/** Strip `/* *\/` block comments and `//` line comments. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * The property-name patterns `reactRemoveProperties` deletes in a production
+ * build, read out of `next.config.mjs`.
+ *
+ * Deliberately a narrow regex over the source rather than importing the config:
+ * `next.config.mjs` pulls in the whole Next build pipeline as a side effect, and
+ * the value we need is a literal array two tokens from a fixed key.
+ */
+function stripPatterns(): string[] {
+  const cfg = read(NEXT_CONFIG);
+  const m = /reactRemoveProperties\s*:\s*\{\s*properties\s*:\s*\[([^\]]*)\]/.exec(cfg);
+  expect(
+    m,
+    'could not parse `compiler.reactRemoveProperties.properties` out of next.config.mjs. This ' +
+      'guard exists to compare that strip list against the full-bleed opt-out ledger in ' +
+      'globals.css; with the list unreadable it can prove nothing, so it fails rather than ' +
+      'passing silently. If `reactRemoveProperties` was removed on purpose, delete or re-point ' +
+      'this file in the same commit.'
+  ).not.toBeNull();
+
+  const patterns = [...(m as RegExpExecArray)[1].matchAll(/['"`]([^'"`]+)['"`]/g)].map((p) => p[1]);
+  expect(
+    patterns,
+    'next.config.mjs declares `reactRemoveProperties` with an EMPTY property list. Either the ' +
+      'literals moved behind a variable this parse cannot follow (then fix the parse), or the ' +
+      'strip was disabled (then this guard is obsolete). An empty list would let every ledger ' +
+      'selector pass unchecked, which is the reassuring-zero failure this file is about.'
+  ).not.toHaveLength(0);
+  return patterns;
+}
+
+/** A run of consecutive attribute selectors that includes `[data-block-id=…]`. */
+type LedgerSelector = { text: string; attrs: string[] };
+
+/**
+ * Every ledger-shaped attribute-selector run in `css`, with the attribute names
+ * it depends on.
+ *
+ * A "run" is one or more adjacent `[…]` selectors — the compound shape the ledger
+ * uses. Runs that do not name `data-block-id` are not ledger rules and are
+ * skipped, which is what keeps unrelated rules like `#__next:has([data-adhesive-ad])`
+ * out of this guard's scope.
+ */
+function ledgerSelectors(css: string): LedgerSelector[] {
+  const RUN = /(?:\[\s*[A-Za-z_][\w-]*(?:\s*[~|^$*]?=\s*(?:'[^']*'|"[^"]*"|[^\]\s]+))?\s*\]\s*)+/g;
+  const out: LedgerSelector[] = [];
+  for (const m of css.matchAll(RUN)) {
+    const text = m[0].trim();
+    if (!/\[\s*data-block-id\s*[~|^$*]?=/.test(text)) continue;
+    out.push({
+      text,
+      attrs: [...text.matchAll(/\[\s*([A-Za-z_][\w-]*)/g)].map((a) => a[1]),
+    });
+  }
+  return out;
+}
+
+/**
+ * Which attributes of `selector` production removes, given `patterns`.
+ * The unit under test — exercised against a synthetic known-bad input below so
+ * this file is never a check that has only ever been watched to pass.
+ */
+function strippedAttrsIn(selector: LedgerSelector, patterns: string[]): string[] {
+  return selector.attrs.filter((attr) => patterns.some((p) => new RegExp(p).test(attr)));
+}
+
+describe('the full-bleed opt-out ledger survives the production attribute strip', () => {
+  it('the strip list is parseable, non-empty, and gated on a production build', () => {
+    const patterns = stripPatterns();
+    expect(patterns.length).toBeGreaterThan(0);
+
+    // The production gate is WHY every other tier is blind to this, so it is
+    // part of the claim rather than background. If the strip ever became
+    // unconditional, the browser suite would start failing on its own and this
+    // guard's framing would need rewriting.
+    const cfg = read(NEXT_CONFIG);
+    const gate = cfg.slice(0, cfg.indexOf('reactRemoveProperties'));
+    expect(
+      gate,
+      'the `reactRemoveProperties` strip in next.config.mjs is no longer preceded by a ' +
+        "`NODE_ENV === 'production'` gate. This guard's whole premise is that the strip happens " +
+        'ONLY in production, which is why no rendered test tier can observe it. Re-read the ' +
+        'config before trusting anything else in this file.'
+    ).toContain("process.env.NODE_ENV === 'production'");
+  });
+
+  /**
+   * 🔴 NEGATIVE CONTROL — can this check go red at all?
+   *
+   * The known-bad attribute is DERIVED from the parsed patterns (anchors stripped
+   * off a literal pattern), not restated as `data-testid`, so the control moves
+   * with the config instead of pinning today's value. A check that has only ever
+   * been watched to pass is a claim about the check.
+   */
+  it('CONTROL — a ledger selector using a stripped attribute is reported as a violation', () => {
+    const patterns = stripPatterns();
+    // Pair the derived name with the pattern it came from — filtering first and
+    // indexing back into `patterns` would misalign the moment one is dropped.
+    const samples = patterns
+      .map((p) => ({ pattern: p, name: p.replace(/^\^/, '').replace(/\$$/, '') }))
+      .filter(
+        ({ pattern, name }) => /^[A-Za-z_][\w-]*$/.test(name) && new RegExp(pattern).test(name)
+      )
+      .map(({ name }) => name);
+    expect(
+      samples,
+      'no literal attribute name could be derived from the parsed strip patterns, so this ' +
+        'control cannot build a known-bad input and the checks below have no negative control. ' +
+        'Add a derivation for the new pattern shape rather than deleting this test.'
+    ).not.toHaveLength(0);
+
+    const bad = ledgerSelectors(`[${samples[0]}='app-page-frame'][data-block-id='x'] { }`);
+    expect(
+      bad,
+      'the ledger-selector extraction did not even match a synthetic ledger rule'
+    ).toHaveLength(1);
+    expect(
+      strippedAttrsIn(bad[0], patterns),
+      'the strip check did NOT flag a selector built from an attribute the production compiler ' +
+        'is configured to remove. The check is inert — fix it before reading any verdict below.'
+    ).toEqual([samples[0]]);
+
+    // …and green on the shape the ledger is supposed to use.
+    const good = ledgerSelectors(`[data-app-page-frame][data-block-id='x'] { }`);
+    expect(good).toHaveLength(1);
+    expect(strippedAttrsIn(good[0], patterns)).toEqual([]);
+  });
+
+  it('🔴 no shipped ledger rule depends on an attribute production strips', () => {
+    const patterns = stripPatterns();
+    const shipped = ledgerSelectors(stripComments(read(GLOBALS_CSS)));
+
+    // Minimum parsed-rule count. Zero would make every assertion below vacuous,
+    // and a broken regex reads exactly like "nothing to check".
+    expect(
+      shipped.length,
+      'zero `[data-block-id=…]` ledger rules were parsed out of src/styles/globals.css. Either ' +
+        'the full-bleed ledger was emptied (then this guard and the membership expectation in ' +
+        '__tests__/pageBlockHostMaxWidth.test.ts should be retired together, deliberately), or ' +
+        'this parse no longer reaches the rules. Failing rather than passing on zero is the point.'
+    ).toBeGreaterThanOrEqual(1);
+
+    const violations = shipped
+      .map((s) => ({ selector: s.text, stripped: strippedAttrsIn(s, patterns) }))
+      .filter((v) => v.stripped.length > 0);
+
+    expect(
+      violations,
+      'a full-bleed ledger rule in src/styles/globals.css is keyed on an attribute that ' +
+        '`next.config.mjs` REMOVES from the production DOM ' +
+        `(${patterns.join(', ')}). The rule ships in the stylesheet and matches nothing on the ` +
+        'live site, so the app it excuses from the ultrawide cap is letterboxed in production ' +
+        'while every test tier passes — they all run with NODE_ENV != production, where the ' +
+        'attribute still exists. Key the rule on a marker the compiler keeps, such as ' +
+        '`data-app-page-frame`, which PageBlockHost stamps beside `data-block-id`.'
+    ).toEqual([]);
+  });
+
+  /**
+   * The ledger's own worked example is the thing the next person copies. If it
+   * teaches the stripped spelling, the next entry re-creates the production-only
+   * defect — so the template is held to the same rule as the rules.
+   */
+  it('🔴 the ledger’s HOW-TO-ADD-ONE template teaches a spelling that survives production', () => {
+    const patterns = stripPatterns();
+    const raw = read(GLOBALS_CSS);
+    const documented = ledgerSelectors(raw);
+    expect(
+      documented.length,
+      'no ledger-shaped selector was found in src/styles/globals.css at all, comments included ' +
+        '— the template and the rules both went missing, or this parse is broken.'
+    ).toBeGreaterThanOrEqual(1);
+
+    const bad = documented
+      .map((s) => ({ selector: s.text, stripped: strippedAttrsIn(s, patterns) }))
+      .filter((v) => v.stripped.length > 0);
+
+    expect(
+      bad,
+      'the full-bleed ledger documentation in src/styles/globals.css shows a selector keyed on ' +
+        'an attribute production strips. Even if no shipped rule uses that shape today, the ' +
+        'example is what the next entry is copied from, so it reproduces the defect one commit ' +
+        'later. Update the "HOW TO ADD ONE" template as well as the rules.'
+    ).toEqual([]);
+  });
+
+  /**
+   * Surviving the strip is only half of it: a ledger keyed on an attribute nobody
+   * renders matches nothing for a different reason, and looks just as fine.
+   */
+  it('🔴 every attribute the ledger depends on is actually stamped by PageBlockHost', () => {
+    const host = stripComments(read(HOST));
+    const shipped = ledgerSelectors(stripComments(read(GLOBALS_CSS)));
+    expect(
+      shipped.length,
+      'zero ledger rules parsed — see the strip test above'
+    ).toBeGreaterThanOrEqual(1);
+
+    const attrs = [...new Set(shipped.flatMap((s) => s.attrs))].sort();
+    const unstamped = attrs.filter((a) => !host.includes(`${a}=`));
+
+    expect(
+      unstamped,
+      'a full-bleed ledger rule in src/styles/globals.css selects on an attribute that ' +
+        'PageBlockHost.tsx does not stamp on its root, so the rule matches nothing — the same ' +
+        'silent outcome as keying it on a stripped attribute, arrived at from the other side. ' +
+        'Either restore the attribute on the host root or re-key the ledger onto one that is ' +
+        'really rendered.'
+    ).toEqual([]);
+  });
+});

--- a/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
+++ b/src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -35,14 +36,18 @@ import { describe, expect, it } from 'vitest';
  *
  * WHAT IS PINNED HERE:
  *   · the strip list is parseable out of `next.config.mjs`, non-empty, and
- *     production-gated (the reason the other tiers cannot see it)
+ *     production-gated — asserted on the `compiler:` property's OWN conditional,
+ *     not on "the words appear earlier in the file" (the reason the other tiers
+ *     cannot see this defect)
  *   · at least one ledger rule is parseable out of `globals.css`
  *   · NO attribute any ledger selector depends on is removed by that strip list
- *     — checked over the shipped rules AND over the ledger's own "HOW TO ADD ONE"
- *     template, because a doc example teaching the broken spelling re-creates the
- *     bug on the next entry
- *   · every attribute a ledger selector depends on is actually STAMPED by
- *     `PageBlockHost.tsx` — surviving the strip is worthless if nothing renders it
+ *     — checked over the shipped rules, over the ledger's own "HOW TO ADD ONE"
+ *     template, AND over the publisher-facing HOW-TO in
+ *     `docs/features/app-blocks.md`, because an example teaching the broken
+ *     spelling re-creates the bug on the next entry
+ *   · every ledger selector's attributes are stamped TOGETHER ON ONE ELEMENT by
+ *     `PageBlockHost.tsx` — surviving the strip is worthless if nothing renders
+ *     them, and a compound selector is satisfied by neither half alone
  *
  * FAILS CLOSED. An unparseable config, an empty strip list, or zero parsed ledger
  * rules is a FAILURE, not a quiet pass: a reassuring zero here is indistinguishable
@@ -55,6 +60,8 @@ const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const NEXT_CONFIG = path.join(REPO_ROOT, 'next.config.mjs');
 const GLOBALS_CSS = path.join(REPO_ROOT, 'src/styles/globals.css');
 const HOST = path.join(REPO_ROOT, 'src/components/AppBlocks/PageBlockHost.tsx');
+/** The publisher-facing HOW-TO. The copy app authors actually read. */
+const PUBLISHER_DOC = path.join(REPO_ROOT, 'docs/features/app-blocks.md');
 
 const repoPath = (file: string) => path.relative(REPO_ROOT, file).split(path.sep).join('/');
 
@@ -71,27 +78,102 @@ function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 }
 
+/** Collapse whitespace so an assertion pins the EXPRESSION, not its formatting. */
+function norm(src: string): string {
+  return src.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * `next.config.mjs`, PARSED — not searched.
+ *
+ * 🔴 A REAL PARSE, BECAUSE THE TEXT VERSION WAS SATISFIABLE BY AN UNRELATED LINE.
+ * The gate assertion used to slice the file at the first `reactRemoveProperties`
+ * and ask whether `process.env.NODE_ENV === 'production'` appeared anywhere in
+ * the prefix. `next.config.mjs:9` is `const isProd = process.env.NODE_ENV ===
+ * 'production';` — 174 lines earlier and unrelated to the compiler block — which
+ * satisfied it on its own. Measured: rewriting `compiler:` so the strip applies
+ * UNCONDITIONALLY (ternary and NODE_ENV test both deleted) left the guard 5/5
+ * green. A parse can ask about the strip's OWN gate; a substring search cannot.
+ *
+ * Parsing also makes the whole file comment-proof for free, which is the other
+ * half: a commented-out `reactRemoveProperties` earlier in the file is invisible
+ * to the parser but would be the FIRST hit for any text search.
+ *
+ * Still not an import: `next.config.mjs` pulls in the whole Next build pipeline
+ * as a side effect. `ScriptKind.JS` reads it as the plain ESM module it is.
+ */
+function nextConfigAst(): ts.SourceFile {
+  return ts.createSourceFile(
+    NEXT_CONFIG,
+    read(NEXT_CONFIG),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  );
+}
+
+/** The static name of an object-literal member, or `null` for a computed one. */
+function memberName(p: ts.ObjectLiteralElementLike): string | null {
+  if (!p.name) return null;
+  if (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) return p.name.text;
+  return null;
+}
+
+/**
+ * Every `key: value` assignment named `name`, at any depth.
+ *
+ * Returns ALL of them rather than the first: callers assert the count, so a
+ * second `compiler:` or `reactRemoveProperties:` (a second config branch, a
+ * conditional spread) fails loudly instead of being graded arbitrarily.
+ */
+function propertyAssignments(sf: ts.SourceFile, name: string): ts.PropertyAssignment[] {
+  const out: ts.PropertyAssignment[] = [];
+  const visit = (n: ts.Node) => {
+    if (ts.isPropertyAssignment(n) && memberName(n) === name) out.push(n);
+    ts.forEachChild(n, visit);
+  };
+  visit(sf);
+  return out;
+}
+
 /**
  * The property-name patterns `reactRemoveProperties` deletes in a production
  * build, read out of `next.config.mjs`.
- *
- * Deliberately a narrow regex over the source rather than importing the config:
- * `next.config.mjs` pulls in the whole Next build pipeline as a side effect, and
- * the value we need is a literal array two tokens from a fixed key.
  */
 function stripPatterns(): string[] {
-  const cfg = read(NEXT_CONFIG);
-  const m = /reactRemoveProperties\s*:\s*\{\s*properties\s*:\s*\[([^\]]*)\]/.exec(cfg);
+  const hits = propertyAssignments(nextConfigAst(), 'reactRemoveProperties');
   expect(
-    m,
-    'could not parse `compiler.reactRemoveProperties.properties` out of next.config.mjs. This ' +
+    hits.length,
+    `next.config.mjs declares \`reactRemoveProperties\` ${hits.length} times, not once. This ` +
       'guard exists to compare that strip list against the full-bleed opt-out ledger in ' +
-      'globals.css; with the list unreadable it can prove nothing, so it fails rather than ' +
-      'passing silently. If `reactRemoveProperties` was removed on purpose, delete or re-point ' +
+      'globals.css; with zero it can prove nothing, and with several it would be grading an ' +
+      'arbitrary one. If `reactRemoveProperties` was removed on purpose, delete or re-point ' +
       'this file in the same commit.'
-  ).not.toBeNull();
+  ).toBe(1);
 
-  const patterns = [...(m as RegExpExecArray)[1].matchAll(/['"`]([^'"`]+)['"`]/g)].map((p) => p[1]);
+  const init = hits[0].initializer;
+  expect(
+    ts.isObjectLiteralExpression(init),
+    '`reactRemoveProperties` is no longer an inline object literal, so its property list lives ' +
+      'somewhere this guard is not looking. Re-point the parse rather than letting the check ' +
+      'pass on a value it cannot read.'
+  ).toBe(true);
+
+  const list = (init as ts.ObjectLiteralExpression).properties.find(
+    (p): p is ts.PropertyAssignment => ts.isPropertyAssignment(p) && memberName(p) === 'properties'
+  );
+  expect(
+    list?.initializer !== undefined && ts.isArrayLiteralExpression(list.initializer),
+    '`reactRemoveProperties.properties` is not an inline array literal in next.config.mjs. The ' +
+      'literals moved behind a variable this parse cannot follow — fix the parse; an unreadable ' +
+      'strip list would let every ledger selector pass unchecked.'
+  ).toBe(true);
+
+  const patterns = (list!.initializer as ts.ArrayLiteralExpression).elements
+    .filter((e): e is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral =>
+      ts.isStringLiteralLike(e)
+    )
+    .map((e) => e.text);
   expect(
     patterns,
     'next.config.mjs declares `reactRemoveProperties` with an EMPTY property list. Either the ' +
@@ -100,6 +182,37 @@ function stripPatterns(): string[] {
       'selector pass unchecked, which is the reassuring-zero failure this file is about.'
   ).not.toHaveLength(0);
   return patterns;
+}
+
+/** The `compiler:` value's own conditional — the strip's actual gate. */
+function compilerGate(): { condition: string; whenTrue: string; whenFalse: string } {
+  const hits = propertyAssignments(nextConfigAst(), 'compiler');
+  expect(
+    hits.length,
+    `next.config.mjs declares \`compiler:\` ${hits.length} times, not once. This guard reads that ` +
+      "one property's own gate; with zero there is nothing to read, and with several it would be " +
+      'grading an arbitrary branch while another one ships.'
+  ).toBe(1);
+
+  const init = hits[0].initializer;
+  expect(
+    ts.isConditionalExpression(init),
+    "the `compiler:` value in next.config.mjs is no longer a `NODE_ENV === 'production' ? … : …` " +
+      'conditional, so the `reactRemoveProperties` attribute strip is NOT gated on a production ' +
+      "build by its own expression. This guard's whole premise — and the reason no rendered test " +
+      'tier can observe a ledger selector keyed on a stripped attribute — is that the strip ' +
+      'happens ONLY in production. If the strip is now unconditional, every tier will start ' +
+      'seeing the stripped DOM and this file needs rewriting rather than relaxing. NOTE: this ' +
+      "assertion is about the `compiler:` property ITSELF; an unrelated `NODE_ENV === 'production'` " +
+      'elsewhere in the file must not be able to satisfy it.'
+  ).toBe(true);
+
+  const c = init as ts.ConditionalExpression;
+  return {
+    condition: norm(c.condition.getText()),
+    whenTrue: norm(c.whenTrue.getText()),
+    whenFalse: norm(c.whenFalse.getText()),
+  };
 }
 
 /** A run of consecutive attribute selectors that includes `[data-block-id=…]`. */
@@ -137,6 +250,49 @@ function strippedAttrsIn(selector: LedgerSelector, patterns: string[]): string[]
   return selector.attrs.filter((attr) => patterns.some((p) => new RegExp(p).test(attr)));
 }
 
+/**
+ * The attribute names each JSX element in `PageBlockHost.tsx` stamps, one entry
+ * per element.
+ *
+ * 🔴 PER-ELEMENT, BECAUSE A COMPOUND SELECTOR IS A RELATIONSHIP AND A WHOLE-FILE
+ * SEARCH CANNOT SEE ONE. This used to be `host.includes(`${attr}=`)` over the
+ * file's text, under a message claiming the attribute was "stamped on its root".
+ * The implementation only asked whether the characters occurred ANYWHERE.
+ * Measured: moving `data-app-page-frame=""` off the host root onto the
+ * `app-page-content` wrapper re-creates the shipped production defect exactly —
+ * `[data-app-page-frame][data-block-id='…']` matches zero elements, because the
+ * two halves are now on different boxes — and the whole gating node tier stayed
+ * BYTE-IDENTICALLY green. Only the report-only browser tier caught it, and that
+ * tier cannot block a merge. Relocation is the mutation this shape exists to
+ * catch, and it survived the guard written against it.
+ *
+ * 🔴 A SPREAD IS NOT COUNTED, DELIBERATELY. `{...props}` could carry anything, so
+ * crediting a spread-bearing element with an attribute would be a guess in the
+ * PASSING direction. Not counting it means such an element cannot satisfy a
+ * selector, which fails closed — the right way round for a guard.
+ */
+function stampedAttributeSets(): string[][] {
+  const sf = ts.createSourceFile(HOST, read(HOST), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const out: string[][] = [];
+  const visit = (n: ts.Node) => {
+    if (ts.isJsxOpeningElement(n) || ts.isJsxSelfClosingElement(n)) {
+      out.push(n.attributes.properties.filter(ts.isJsxAttribute).map((a) => a.name.getText()));
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+/**
+ * Does SOME ONE element stamp every attribute `selector` chains together?
+ * The unit under test for the relationship claim — exercised against both a
+ * satisfying and a split-across-two-elements input in the control below.
+ */
+function stampedTogether(selector: LedgerSelector, elements: string[][]): boolean {
+  return elements.some((el) => selector.attrs.every((a) => el.includes(a)));
+}
+
 describe('the full-bleed opt-out ledger survives the production attribute strip', () => {
   it('the strip list is parseable, non-empty, and gated on a production build', () => {
     const patterns = stripPatterns();
@@ -146,15 +302,37 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
     // part of the claim rather than background. If the strip ever became
     // unconditional, the browser suite would start failing on its own and this
     // guard's framing would need rewriting.
-    const cfg = read(NEXT_CONFIG);
-    const gate = cfg.slice(0, cfg.indexOf('reactRemoveProperties'));
+    //
+    // 🔴 THREE ASSERTIONS, ON THE `compiler:` PROPERTY'S OWN CONDITIONAL. The
+    // condition must BE the production test; the strip must live in the branch
+    // that condition selects; and it must NOT also live in the other branch. A
+    // substring search over the file's prefix could make none of these claims —
+    // `const isProd = process.env.NODE_ENV === 'production'` on line 9 satisfied
+    // the old spelling by itself, so an unconditional strip passed 5/5.
+    const gate = compilerGate();
     expect(
-      gate,
-      'the `reactRemoveProperties` strip in next.config.mjs is no longer preceded by a ' +
-        "`NODE_ENV === 'production'` gate. This guard's whole premise is that the strip happens " +
-        'ONLY in production, which is why no rendered test tier can observe it. Re-read the ' +
-        'config before trusting anything else in this file.'
-    ).toContain("process.env.NODE_ENV === 'production'");
+      gate.condition,
+      'the `compiler:` block in next.config.mjs is gated on something other than ' +
+        "`process.env.NODE_ENV === 'production'`. The attribute strip's blindness to every test " +
+        'tier follows from that exact condition; a different one means this file is reasoning ' +
+        'about a build mode that no longer matches reality. If you merely hoisted the test into ' +
+        'a named constant (`isProd`), re-point this assertion at that constant in the same ' +
+        'commit rather than relaxing it into a substring search — that is the spelling an ' +
+        'unrelated line 174 lines earlier was already able to satisfy on its own.'
+    ).toBe("process.env.NODE_ENV === 'production'");
+    expect(
+      gate.whenTrue,
+      'the `reactRemoveProperties` strip is no longer in the branch the production condition ' +
+        'SELECTS. Either it moved to the non-production branch (then every tier now runs with ' +
+        'the stripped DOM and this guard is inverted), or it left the conditional entirely.'
+    ).toContain('reactRemoveProperties');
+    expect(
+      gate.whenFalse,
+      'the `reactRemoveProperties` strip also appears in the NON-production branch of ' +
+        '`compiler:`, so it is effectively unconditional. That contradicts the premise this ' +
+        'whole file rests on — that the stripped DOM exists only in production, which is why no ' +
+        'rendered test tier can see a ledger selector keyed on a stripped attribute.'
+    ).not.toContain('reactRemoveProperties');
   });
 
   /**
@@ -197,6 +375,43 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
     const good = ledgerSelectors(`[data-app-page-frame][data-block-id='x'] { }`);
     expect(good).toHaveLength(1);
     expect(strippedAttrsIn(good[0], patterns)).toEqual([]);
+  });
+
+  /**
+   * 🔴 SECOND NEGATIVE CONTROL — for the RELATIONSHIP check specifically.
+   *
+   * `stampedTogether` is the half that the old whole-file substring search got
+   * wrong, so it gets its own known-bad input rather than riding on the strip
+   * control above. The known-bad here is the exact defect shape: both attributes
+   * present, on DIFFERENT elements.
+   */
+  it('CONTROL — attributes split across two elements do NOT satisfy a compound selector', () => {
+    const [selector] = ledgerSelectors(`[data-app-page-frame][data-block-id='x'] { }`);
+    expect(selector, 'the ledger-selector extraction did not match a synthetic rule').toBeDefined();
+
+    expect(
+      stampedTogether(selector, [
+        ['data-testid', 'data-app-page-frame', 'data-block-id', 'data-fit'],
+      ]),
+      'the relationship check did not accept an element that really does stamp both halves — it ' +
+        'is over-strict and would fail on a correct host. Fix it before reading any verdict.'
+    ).toBe(true);
+
+    expect(
+      stampedTogether(selector, [
+        ['data-testid', 'data-block-id'],
+        ['data-testid', 'data-app-page-frame'],
+      ]),
+      'the relationship check ACCEPTED a host that stamps the two halves of a compound selector ' +
+        'on two DIFFERENT elements — the relocation defect. The check is inert; it has ' +
+        'regressed to asking whether each token appears somewhere. Fix it before reading any ' +
+        'verdict below.'
+    ).toBe(false);
+
+    expect(
+      stampedTogether(selector, [['data-testid', 'data-block-id']]),
+      'the relationship check accepted a host missing one half of the selector entirely.'
+    ).toBe(false);
   });
 
   it('🔴 no shipped ledger rule depends on an attribute production strips', () => {
@@ -258,27 +473,79 @@ describe('the full-bleed opt-out ledger survives the production attribute strip'
   });
 
   /**
-   * Surviving the strip is only half of it: a ledger keyed on an attribute nobody
-   * renders matches nothing for a different reason, and looks just as fine.
+   * 🔴 AND THE PUBLISHER-FACING COPY, WHICH IS THE ONE APP AUTHORS ACTUALLY READ.
+   *
+   * `docs/features/app-blocks.md` carries the same "asking for full bleed"
+   * recipe. It shipped the production-inert `data-testid` spelling and nothing
+   * guarded it — a maintainer following it writes a rule that matches nothing on
+   * the live site, which is precisely the defect this file was created for,
+   * re-entering through the door marked documentation. This assertion is what
+   * lets that doc claim it is checked.
    */
-  it('🔴 every attribute the ledger depends on is actually stamped by PageBlockHost', () => {
-    const host = stripComments(read(HOST));
+  it('🔴 the publisher HOW-TO in docs/features/app-blocks.md teaches a production-surviving spelling', () => {
+    const patterns = stripPatterns();
+    const documented = ledgerSelectors(read(PUBLISHER_DOC));
+    expect(
+      documented.length,
+      'no `[data-block-id=…]` selector was found in docs/features/app-blocks.md. The full-bleed ' +
+        'opt-out recipe is the only documented way out of the ultrawide cap; if it was removed, ' +
+        'retire this assertion deliberately rather than letting it pass on an empty parse.'
+    ).toBeGreaterThanOrEqual(1);
+
+    const bad = documented
+      .map((s) => ({ selector: s.text, stripped: strippedAttrsIn(s, patterns) }))
+      .filter((v) => v.stripped.length > 0);
+
+    expect(
+      bad,
+      'the full-bleed recipe in docs/features/app-blocks.md shows a selector keyed on an ' +
+        `attribute that next.config.mjs REMOVES from the production DOM (${patterns.join(
+          ', '
+        )}). ` +
+        'This is the copy app authors read, so it teaches a rule that works in every preview and ' +
+        'matches nothing on civitai.com. Key it on a marker the compiler keeps, such as ' +
+        '`data-app-page-frame`.'
+    ).toEqual([]);
+  });
+
+  /**
+   * Surviving the strip is only half of it: a ledger keyed on attributes nobody
+   * renders TOGETHER matches nothing for a different reason, and looks just as fine.
+   *
+   * 🔴 THE CLAIM IS THE RELATIONSHIP — BOTH ATTRIBUTES ON ONE ELEMENT — NOT THE
+   * PRESENCE OF EACH TOKEN SOMEWHERE. `[data-app-page-frame][data-block-id='…']`
+   * is a compound selector: an element carrying only one half matches it exactly
+   * as poorly as an element carrying neither. The sibling guard
+   * `pageBlockHostMaxWidth.test.ts` states the same thing from the other side, on
+   * the parsed frame element.
+   */
+  it('🔴 each ledger selector’s attributes are stamped TOGETHER on ONE PageBlockHost element', () => {
     const shipped = ledgerSelectors(stripComments(read(GLOBALS_CSS)));
     expect(
       shipped.length,
       'zero ledger rules parsed — see the strip test above'
     ).toBeGreaterThanOrEqual(1);
 
-    const attrs = [...new Set(shipped.flatMap((s) => s.attrs))].sort();
-    const unstamped = attrs.filter((a) => !host.includes(`${a}=`));
+    const elements = stampedAttributeSets();
+    expect(
+      elements.length,
+      'no JSX elements were parsed out of PageBlockHost.tsx at all. Zero would make the check ' +
+        'below vacuous in the passing direction for every selector, which is the reassuring-zero ' +
+        'shape this file exists to refuse.'
+    ).toBeGreaterThan(0);
+
+    const unmatched = shipped.filter((s) => !stampedTogether(s, elements)).map((s) => s.text);
 
     expect(
-      unstamped,
-      'a full-bleed ledger rule in src/styles/globals.css selects on an attribute that ' +
-        'PageBlockHost.tsx does not stamp on its root, so the rule matches nothing — the same ' +
+      unmatched,
+      'a full-bleed ledger rule in src/styles/globals.css chains attributes that NO SINGLE ' +
+        'element in PageBlockHost.tsx stamps together, so the rule matches nothing — the same ' +
         'silent outcome as keying it on a stripped attribute, arrived at from the other side. ' +
-        'Either restore the attribute on the host root or re-key the ledger onto one that is ' +
-        'really rendered.'
+        'Both halves existing somewhere in the file is NOT enough: splitting them across the ' +
+        'host root and the `app-page-content` wrapper is exactly the relocation that re-creates ' +
+        'the shipped production defect, and the whole gating tier stayed green under it until ' +
+        'this assertion was written per-element. Either stamp every attribute the selector ' +
+        'chains on the SAME element, or re-key the ledger onto attributes that are.'
     ).toEqual([]);
   });
 });

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -38,9 +38,10 @@ import { describe, expect, it } from 'vitest';
  *     relationship the ledger's inheritance depends on, which no older pin covers
  *   · the content wrapper's whole box model, because a dropped `flex: 1` collapses
  *     the app to a sliver with every test in BOTH tiers green (measured)
- *   · `data-block-id` is stamped on the host root — the opt-out ledger's selector
- *     chains it with `data-app-page-frame`, so a rename makes every ledger rule
- *     match nothing without changing anything visible
+ *   · BOTH `data-app-page-frame` and `data-block-id` are stamped on the host root
+ *     ELEMENT — the opt-out ledger's selector chains them, so a rename OR a move
+ *     of either half onto another element makes every ledger rule match nothing
+ *     without changing anything visible
  *
  *   · the value is read through `var()` and never written inline
  *
@@ -584,26 +585,49 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * nothing — and nothing about the page looks wrong, so no one finds out until
    * an app that opted out is reported as still capped.
    *
-   * The testid is only this guard's ANCHOR for finding the root region; the
-   * ledger no longer selects on it (production strips it). That both ledger
-   * attributes are really stamped is asserted in
-   * `ledgerSelectorSurvivesProdStrip.test.ts`, from the ledger's side.
+   * The testid is only this guard's ANCHOR for finding the root element; the
+   * ledger no longer selects on it (production strips it).
+   *
+   * 🔴 BOTH HALVES, ON THE PARSED FRAME ELEMENT — NOT A TEXT SEARCH OVER THE FILE.
+   * `data-app-page-frame` was added by the fix that re-keyed the ledger, and it
+   * was originally pinned only by a whole-file substring search in
+   * `ledgerSelectorSurvivesProdStrip.test.ts`. Measured: moving that attribute off
+   * the host root onto the `app-page-content` wrapper — which re-creates the
+   * shipped production defect exactly, since the compound selector then matches
+   * zero elements — left the ENTIRE gating node tier byte-identically green
+   * (`7 failed | 741 passed`, the same pre-existing failures, both ways). Only the
+   * report-only browser tier caught it. Asking `hostElements()` for the frame and
+   * reading ITS attribute list is what makes "on the root" a checkable claim.
    */
-  it('stamps `data-block-id` on the host root — the opt-out ledger keys on it', () => {
-    const src = code(read(HOST));
-    const root = region(
-      src,
-      /data-testid="app-page-frame"[\s\S]*?data-needs-consent=/,
-      'host root attributes'
-    );
+  it('stamps BOTH ledger attributes on the host root — the opt-out selector chains them', () => {
+    const { frame } = hostElements();
+    const attrs = frame.attributes.properties.filter(ts.isJsxAttribute);
+    const names = attrs.map((a) => a.name.getText());
+
     expect(
-      root,
-      'the host root no longer stamps `data-block-id={blockId}` between its testid and ' +
-        '`data-needs-consent`. The full-bleed ledger in src/styles/globals.css selects on ' +
-        "`[data-app-page-frame][data-block-id='…']`, so every entry in it is now inert. " +
-        '`blockId` (the app slug) is the required value — `blockInstanceId` is per-install ' +
-        'and is NOT what an app author knows their app by.'
-    ).toContain('data-block-id={blockId}');
+      names,
+      'the host ROOT no longer stamps `data-app-page-frame`. The full-bleed ledger in ' +
+        "src/styles/globals.css selects on `[data-app-page-frame][data-block-id='…']` — a " +
+        'compound selector, so BOTH halves must be on the SAME element. `data-testid` cannot ' +
+        'stand in for it: `next.config.mjs` strips every testid from the production DOM, which ' +
+        'is the defect that made this attribute necessary. Moving it to the content wrapper ' +
+        'reads as a tidy-up and makes every ledger entry match nothing, with nothing visibly wrong.'
+    ).toContain('data-app-page-frame');
+
+    expect(
+      names,
+      'the host root no longer stamps `data-block-id`. The full-bleed ledger selects on ' +
+        "`[data-app-page-frame][data-block-id='…']`, so every entry in it is now inert."
+    ).toContain('data-block-id');
+
+    const blockIdAttr = attrs.find((a) => a.name.getText() === 'data-block-id');
+    expect(
+      norm(blockIdAttr!.getText()),
+      'the host root stamps `data-block-id` from something other than `blockId`. `blockId` (the ' +
+        'app slug, what builds `<slug>.civit.ai`) is the required value — `blockInstanceId` is ' +
+        'per-install and is NOT what an app author knows their app by, so a ledger entry written ' +
+        'against the slug would match nothing.'
+    ).toBe('data-block-id={blockId}');
   });
 
   /**

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -22,11 +22,15 @@ import { describe, expect, it } from 'vitest';
  * 🔴 WHY A SOURCE GUARD AS WELL AS A RENDERED ONE. The measurement lives in
  * `PageBlockHostMaxWidth.browser.test.tsx`, which is the only tier that can see a
  * width at all — but the browser `component` project runs in CI as the
- * REPORT-ONLY `preview / component-tests` status, so nothing there can block a
- * merge. This file is in the node `unit` project, which can. The same split, and
- * the same reasoning, as `pageRunScrollContract.test.ts` (whose own header
- * records the measured case where a fully-reverted floor left the gating tier
- * 9/9 green and only the non-blocking tier red).
+ * REPORT-ONLY `preview / component-tests` status. This file is in the node
+ * `unit` project, which is report-only on a pull request too (`continue-on-error`)
+ * and renders a real verdict only on a push to `main`. 🔴 NEITHER TIER BLOCKS A
+ * MERGE — `main` requires no status check at all in this repo — so what a source
+ * guard buys is a verdict that is honest on `main` and an annotation a reviewer
+ * can read, NOT a door that stays shut. The same split, and the same reasoning,
+ * as `pageRunScrollContract.test.ts` (whose own header records the measured case
+ * where a fully-reverted floor left this node tier 9/9 green and only the browser
+ * tier red).
  *
  * WHAT IS PINNED HERE — each is a thing whose absence is SILENT. Deliberately an
  * unnumbered list: it has grown twice, and a count stated beside the thing it counts
@@ -480,8 +484,10 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    *
    * Measured by mutation, in a copy: reverting the whole change (cap back on the
    * frame, chrome capped again) left the FULL node suite — 1569 files, 24,879 tests
-   * — byte-identically green. Only the report-only browser tier caught it, and
-   * that tier cannot block a merge. This test is the gating-tier half.
+   * — byte-identically green. Only the browser tier caught it, and that tier is
+   * report-only everywhere. This test is the node-tier half — the one that renders
+   * an honest verdict on a push to `main` (neither tier blocks a merge; see the
+   * header).
    */
   it('the cap sits on `app-page-content`, and that box is a real DESCENDANT of the frame', () => {
     const { frame, content } = hostElements();
@@ -594,7 +600,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * `ledgerSelectorSurvivesProdStrip.test.ts`. Measured: moving that attribute off
    * the host root onto the `app-page-content` wrapper — which re-creates the
    * shipped production defect exactly, since the compound selector then matches
-   * zero elements — left the ENTIRE gating node tier byte-identically green
+   * zero elements — left the ENTIRE node tier byte-identically green
    * (`7 failed | 741 passed`, the same pre-existing failures, both ways). Only the
    * report-only browser tier caught it. Asking `hostElements()` for the frame and
    * reading ITS attribute list is what makes "on the root" a checkable claim.

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -4,7 +4,8 @@ import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
- * THE ULTRAWIDE CAP — the GATING half.
+ * THE ULTRAWIDE CAP — the SOURCE half. (`PageBlockHostMaxWidth.browser.test.tsx`
+ * is the MEASURED half. Neither half is a merge gate — see below.)
  *
  * A full-page App Block had no width bound anywhere in its chain (page wrapper,
  * host root and iframe are each `width: 100%`), so on a 2560px display an app
@@ -24,13 +25,13 @@ import { describe, expect, it } from 'vitest';
  * width at all — but the browser `component` project runs in CI as the
  * REPORT-ONLY `preview / component-tests` status. This file is in the node
  * `unit` project, which is report-only on a pull request too (`continue-on-error`)
- * and renders a real verdict only on a push to `main`. 🔴 NEITHER TIER BLOCKS A
- * MERGE — `main` requires no status check at all in this repo — so what a source
- * guard buys is a verdict that is honest on `main` and an annotation a reviewer
- * can read, NOT a door that stays shut. The same split, and the same reasoning,
- * as `pageRunScrollContract.test.ts` (whose own header records the measured case
- * where a fully-reverted floor left this node tier 9/9 green and only the browser
- * tier red).
+ * and renders a real verdict on a push to `main` or a `workflow_dispatch`.
+ * 🔴 NEITHER TIER BLOCKS A MERGE — `main` requires no status check at all in this
+ * repo — so what a source guard buys is a verdict that is honest on `main` and an
+ * annotation a reviewer can read, NOT a door that stays shut. The same split, and
+ * the same reasoning, as `pageRunScrollContract.test.ts` (whose own header records
+ * the measured case where a fully-reverted floor left this node tier 9/9 green and
+ * only the browser tier red).
  *
  * WHAT IS PINNED HERE — each is a thing whose absence is SILENT. Deliberately an
  * unnumbered list: it has grown twice, and a count stated beside the thing it counts
@@ -214,7 +215,7 @@ function isDescendant(
  * an empty string satisfies trivially. Measured: lifting the frame's inline style into
  * a `const` in a sibling module and putting the cap back in it, with the exact pinned
  * spelling, left this file 9/9 GREEN while the app chrome was capped again — the one
- * regression this file exists to block, through an entirely ordinary refactor. A
+ * regression this file exists to catch, through an entirely ordinary refactor. A
  * spread `{...{ style: … }}` did the same.
  *
  * So the two cases are now distinguishable and the callers must assert on it: a style
@@ -275,8 +276,11 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
     expect(
       declared,
       'APP_PAGE_MAX_WIDTH_PX declaration not found in PageBlockHost.tsx — if it was renamed or ' +
-        'derived, re-point this guard rather than deleting it: it is the only BLOCKING check on ' +
-        'the ultrawide cap.'
+        'derived, re-point this guard rather than deleting it: it is the ONLY assertion anywhere ' +
+        'that reads this declaration. The browser tier deliberately imports nothing from the ' +
+        'host (it measures a rendered width instead), so deleting this leaves the constant and ' +
+        'its band unchecked. It is not a merge gate — no status check is required on `main` — ' +
+        'but it is the only thing that would say so.'
     ).toBeDefined();
 
     const cap = Number(declared);
@@ -471,7 +475,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
 
   /**
    * 🔴 THE CAP AND THE CHROME ARE ON DIFFERENT ELEMENTS NOW, AND UNTIL THIS GUARD
-   * EXISTED THE GATING TIER COULD NOT SEE THAT AT ALL.
+   * EXISTED THE NODE TIER COULD NOT SEE THAT AT ALL.
    *
    * The cap used to sit on the host root, so the two guards above — "the cap pair
    * appears verbatim somewhere" and "`data-block-id` is on the frame" — described
@@ -486,8 +490,8 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * frame, chrome capped again) left the FULL node suite — 1569 files, 24,879 tests
    * — byte-identically green. Only the browser tier caught it, and that tier is
    * report-only everywhere. This test is the node-tier half — the one that renders
-   * an honest verdict on a push to `main` (neither tier blocks a merge; see the
-   * header).
+   * an honest verdict on a push to `main` or a `workflow_dispatch` (neither tier
+   * blocks a merge; see the header).
    */
   it('the cap sits on `app-page-content`, and that box is a real DESCENDANT of the frame', () => {
     const { frame, content } = hostElements();
@@ -498,7 +502,7 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
     // sibling, cousin and unrelated later element also satisfies. Measured on that
     // version: closing the frame before the content box, so the two are genuine SIBLINGS
     // and the ledger's inheritance is dead, left this file 9/9 green AND the whole
-    // gating suite (1569 files / 24,879 tests) byte-identically green, while the
+    // node suite (1569 files / 24,879 tests) byte-identically green, while the
     // report-only browser tier correctly failed BOTH ledger tests. A guard whose message
     // says "no longer renders inside" must actually mean inside.
     expect(
@@ -507,7 +511,9 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
         'opt-out ledger sets `--app-page-max-width` ON THE FRAME and relies on CSS ' +
         'INHERITANCE to reach the capped box, so lifting that box out from under the ' +
         'frame — even into a sibling that still renders — makes every ledger entry ' +
-        'silently inert. Nothing rendered in the gating tier can see this.'
+        'silently inert. This node tier renders nothing, so this source-level ' +
+        'containment check is its only view of the relationship; the only tier that ' +
+        'can observe it at runtime is the report-only browser tier.'
     ).toBe(true);
 
     // The cap must live in the CONTENT element's style prop, not the FRAME's.

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -38,10 +38,19 @@ import { describe, expect, it } from 'vitest';
  *     relationship the ledger's inheritance depends on, which no older pin covers
  *   · the content wrapper's whole box model, because a dropped `flex: 1` collapses
  *     the app to a sliver with every test in BOTH tiers green (measured)
- *   · `data-block-id` is stamped on the SAME element as the host testid — the
- *     opt-out ledger's selector chains the two, so a rename makes every ledger
- *     rule match nothing without changing anything visible
+ *   · `data-block-id` is stamped on the host root — the opt-out ledger's selector
+ *     chains it with `data-app-page-frame`, so a rename makes every ledger rule
+ *     match nothing without changing anything visible
+ *
  *   · the value is read through `var()` and never written inline
+ *
+ * 🔴 WHAT IS **NOT** PINNED HERE, AND WHY. That the ledger's selector survives the
+ * PRODUCTION compiler is a different claim, and this file cannot make it: it reads
+ * source, not the build config. `next.config.mjs` strips `data-testid` from the DOM
+ * under `NODE_ENV === 'production'`, so a ledger keyed on the testid ships in the
+ * stylesheet and matches nothing live — which is exactly what happened, with this
+ * file and the browser suite both green. That seam is owned by
+ * `ledgerSelectorSurvivesProdStrip.test.ts`.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
@@ -151,9 +160,11 @@ function hostElements(): {
   return {
     frame: one(
       'app-page-frame',
-      'no element in PageBlockHost.tsx carries `data-testid="app-page-frame"`. The opt-out ' +
-        'ledger selects on it, so every ledger rule is inert. Re-point this guard only if the ' +
-        'element was deliberately renamed.'
+      'no element in PageBlockHost.tsx carries `data-testid="app-page-frame"`. This guard uses ' +
+        'it to locate the host ROOT and prove the capped content wrapper is inside it — the ' +
+        "relationship the ledger's inheritance depends on. (The ledger itself selects on " +
+        '`data-app-page-frame`, not on the testid, which production strips.) Re-point this ' +
+        'guard only if the element was deliberately renamed.'
     ),
     content: one(
       'app-page-content',
@@ -567,13 +578,18 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * in the file.
    *
    * The ledger in globals.css is written as
-   * `[data-testid='app-page-frame'][data-block-id='…']`. If `data-block-id` moves
-   * to a different element, or is renamed, or is fed the per-install
+   * `[data-app-page-frame][data-block-id='…']`. If `data-block-id` moves to a
+   * different element, or is renamed, or is fed the per-install
    * `blockInstanceId` instead of the app's slug, every ledger rule matches
    * nothing — and nothing about the page looks wrong, so no one finds out until
    * an app that opted out is reported as still capped.
+   *
+   * The testid is only this guard's ANCHOR for finding the root region; the
+   * ledger no longer selects on it (production strips it). That both ledger
+   * attributes are really stamped is asserted in
+   * `ledgerSelectorSurvivesProdStrip.test.ts`, from the ledger's side.
    */
-  it('stamps `data-block-id` on the same element as the host testid — the opt-out ledger keys on both', () => {
+  it('stamps `data-block-id` on the host root — the opt-out ledger keys on it', () => {
     const src = code(read(HOST));
     const root = region(
       src,
@@ -584,8 +600,8 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
       root,
       'the host root no longer stamps `data-block-id={blockId}` between its testid and ' +
         '`data-needs-consent`. The full-bleed ledger in src/styles/globals.css selects on ' +
-        "`[data-testid='app-page-frame'][data-block-id='…']`, so every entry in it is now " +
-        'inert. `blockId` (the app slug) is the required value — `blockInstanceId` is per-install ' +
+        "`[data-app-page-frame][data-block-id='…']`, so every entry in it is now inert. " +
+        '`blockId` (the app slug) is the required value — `blockInstanceId` is per-install ' +
         'and is NOT what an app author knows their app by.'
     ).toContain('data-block-id={blockId}');
   });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -118,13 +118,14 @@
      🔴 THE ELEMENT THAT READS IT IS NOT THE ELEMENT THE LEDGER SELECTS, AND THAT
      IS DELIBERATE — checking the wrong one in DevTools is the likeliest way to
      conclude this mechanism is broken when it is not. The host root
-     (`[data-testid='app-page-frame']`) is FULL-BLEED: it carries the app chrome,
-     which spans the page like every other site-level bar. The cap is read one
-     level down, on `[data-testid='app-page-content']`, which holds the app and
-     its failure card. The ledger below still keys on the FRAME because a custom
-     property INHERITS — set it there and the content wrapper picks it up — so
-     ledger rules are written against the frame and take effect on the content.
-     Inspect `app-page-content` for the resolved `max-width`.
+     (`[data-app-page-frame]`, and `data-testid='app-page-frame'` in a dev build
+     only — see the ledger's strip note below) is FULL-BLEED: it carries the app
+     chrome, which spans the page like every other site-level bar. The cap is read
+     one level down, on the content wrapper, which holds the app and its failure
+     card. The ledger below still keys on the FRAME because a custom property
+     INHERITS — set it there and the content wrapper picks it up — so ledger rules
+     are written against the frame and take effect on the content. Inspect
+     `app-page-content` for the resolved `max-width`.
 
      🔴 IT IS DECLARED HERE, AND ONLY HERE, SO THAT AN APP CAN OPT OUT — see the
      ledger below. The host reads it through `var()` rather than writing it as
@@ -153,10 +154,30 @@
    is one line, needs no schema motion, and cannot be forged: the guest is
    cross-origin and can never reach this cascade.
 
-   HOW TO ADD ONE. `PageBlockHost` stamps `data-block-id` (the app's slug — the
-   same value that builds `<slug>.civit.ai`) on its root, so:
+   🔴 NEVER KEY A RULE HERE ON `data-testid` — IT DOES NOT EXIST IN PRODUCTION,
+   AND THAT IS EXACTLY HOW THIS LEDGER SHIPPED BROKEN. `next.config.mjs` sets
+   `compiler.reactRemoveProperties: { properties: ['^data-testid$'] }` whenever
+   `NODE_ENV === 'production'`, so every `data-testid` is compiled out of the
+   live DOM. The `playable-collections` rule below used to chain the app-page-frame
+   TESTID with its block id, and therefore matched ZERO elements on civitai.com
+   while matching fine in every test tier, all of which run with
+   `NODE_ENV !== 'production'` — a rule that was present in the deployed
+   stylesheet, verified verbatim, and still did nothing. The frame's
+   production-surviving marker is `data-app-page-frame`, stamped beside
+   `data-block-id` on the same element in `PageBlockHost.tsx`. This is checked
+   mechanically: `src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts`
+   parses the strip list out of `next.config.mjs` and the selectors out of this
+   file — INCLUDING the ones in these comments, since the template below is what
+   the next entry gets copied from — and fails if any of them depends on an
+   attribute production removes. That is also why the broken selector is described
+   above in words rather than spelled out: a literal example of the wrong shape,
+   even a historical one, is a copyable example.
 
-     [data-testid='app-page-frame'][data-block-id='my-canvas-app'] {
+   HOW TO ADD ONE. `PageBlockHost` stamps `data-block-id` (the app's slug — the
+   same value that builds `<slug>.civit.ai`) alongside `data-app-page-frame` on
+   its root, so:
+
+     [data-app-page-frame][data-block-id='my-canvas-app'] {
        --app-page-max-width: none;
      }
 
@@ -199,7 +220,7 @@
    pair in `PageBlockHostMaxWidth.browser.test.tsx` — that suite parses THIS file
    and injects the rule below verbatim, so deleting or mistyping it fails a test
    rather than silently letterboxing the app again. */
-[data-testid='app-page-frame'][data-block-id='playable-collections'] {
+[data-app-page-frame][data-block-id='playable-collections'] {
   --app-page-max-width: none;
 }
 


### PR DESCRIPTION
## The defect: production-only, and no test tier can see it

`src/styles/globals.css` carries the full-bleed opt-out ledger — the only way an App Block escapes the 1600px ultrawide cap. Its one member was written as:

```css
[data-testid='app-page-frame'][data-block-id='playable-collections'] {
  --app-page-max-width: none;
}
```

`next.config.mjs` sets:

```js
compiler: process.env.NODE_ENV === 'production'
  ? { reactRemoveProperties: { properties: ['^data-testid$'] } }
  : {},
```

So **every `data-testid` is compiled out of the production DOM**, the compound selector matches nothing on the live site, and `playable-collections` — a collection player whose every open-collection view mode is uncapped by the app itself — renders letterboxed at the cap. That is the exact outcome the rule's own comment says it exists to prevent.

## Measured evidence

On the live site, `civitai.com/apps/run/playable-collections`, image `20260902233645-bbbe837`:

| Observation | Value |
|---|---|
| the ledger rule present in the deployed CSS, verbatim | yes (2136 rules scanned, 0 sheets blocked) |
| `querySelectorAll("[data-testid='app-page-frame'][data-block-id='playable-collections']").length` | **0** |
| `querySelectorAll("[data-block-id='playable-collections']").length` | **1** |
| `data-testid` attributes on the page | **0** across 615 elements |
| elements carrying some other `data-*` attribute | **209** (so the zero above is a measurement, not a broken search) |
| computed `--app-page-max-width` on the capped box | `1600px` — the opt-out did not apply |
| at viewport 1920 | app column x=160 w=1600, i.e. capped |

## Why the existing tests could not see it

Every tier runs with `NODE_ENV != production`, where `data-testid` is present and the selector matches. `PageBlockHostMaxWidth.browser.test.tsx` (~line 455) *injects that very selector* and asserts full-bleed at 2560x1080 — and passes, correctly, on the broken tree. It is not a bad test; it is structurally blind, because its environment fixes the one dimension the defect lives on. The gating node guard `__tests__/pageBlockHostMaxWidth.test.ts` reads source, not the build config, so it could not see it either. This is a config-blind suite plus an unowned seam: two files each correct alone, broken together.

No rendered test can close this. Only a check that reads the two *configurations* and compares them can.

## The fix

`PageBlockHost` now stamps a presence marker on the same element it already puts `data-block-id` on:

```jsx
data-app-page-frame=""
data-fit={fit}
data-block-id={blockId}
```

and the ledger is re-keyed onto `[data-app-page-frame][data-block-id='…']`.

Naming follows the repo idiom for exactly this job — `AdhesiveAd` stamps `data-adhesive-ad=""` and `AppFooter` stamps `data-app-footer=""` precisely so `globals.css` can key off something the compiler keeps.

The frame half is **kept rather than dropped**. `[data-block-id='…']` alone would work today, but `PageBlockHostMaxWidth.browser.test.tsx` (~line 527) deliberately asserts the ledger is keyed on something app-specific "and not on something every host carries" — the frame attribute is what says *this is the page host*, not some other surface that happens to carry a block id. Preserving that keeps the original design intent intact while surviving the production strip.

## New guard — reads one side, compares it to the other

`src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts`, in the **gating** node `unit` project (the browser tier is report-only in CI). It:

- parses `compiler.reactRemoveProperties.properties` out of `next.config.mjs`
- parses the ledger selectors out of `src/styles/globals.css`
- fails if any ledger selector depends on an attribute production strips
- applies the same rule to the ledger's own **HOW-TO-ADD-ONE template**, because the next entry is copied from it (that is how this bug reproduces one commit later)
- checks every attribute the ledger depends on is actually **stamped** by `PageBlockHost.tsx` — surviving the strip is worthless if nothing renders it

It restates neither side, so it keeps working if either changes.

**Fails closed.** An unparseable config, an empty strip list, or zero parsed ledger rules is a failure, not a quiet pass — a reassuring zero here is indistinguishable from a guard wired to nothing. It asserts a minimum parsed-rule count (>= 1) for the same reason, and it carries a **negative control** that builds a known-bad selector from the *parsed* patterns (anchors stripped off a literal) and asserts the check reports it, so the check has been watched to go red.

### Red -> green matrix

Run with the identical guard file in both trees:

| Tree | Result |
|---|---|
| `origin/main` (`bbbe837d13`) | **RED** — `Tests 2 failed \| 3 passed (5)` |
| this branch (HEAD) | **GREEN** — `Tests 14 passed (14)` (guard + the existing node ledger guard) |

The two failures at base are the shipped-rule check and the template check, each with its own message naming the stripped attribute (`^data-testid$`). The 3 that pass at base are the config parse, the negative control, and the stamping check — correctly, since both attributes *are* stamped at base.

## Mutation results

Each mutation was applied to the fixed tree, run, and reverted (files restored byte-identical, verified with `cmp`).

| Mutation | Result |
|---|---|
| revert the ledger selector in `globals.css` to the `data-testid` form | 2 failed / 3 passed. `AssertionError: a full-bleed ledger rule in src/styles/globals.css is keyed on an attribute that next.config.mjs REMOVES from the production DOM (^data-testid$)…` — the guard's own message, plus the template check |
| delete `data-app-page-frame=""` from `PageBlockHost.tsx` | **exactly one** test failed, the stamping check: `AssertionError: a full-bleed ledger rule … selects on an attribute that PageBlockHost.tsx does not stamp on its root … expected [ 'data-app-page-frame' ] to deeply equal []`. No neighbouring assertion fired |
| empty the strip list in `next.config.mjs` (`properties: []`) | 4 failed / 1 passed, all with the fail-closed message: `next.config.mjs declares reactRemoveProperties with an EMPTY property list… An empty list would let every ledger selector pass unchecked` |

Each died for its **own** specific message, not a neighbour's.

## Tests run (counts, from run logs — not exit codes)

| Suite | Result |
|---|---|
| new guard + `__tests__/pageBlockHostMaxWidth.test.ts` (node `unit`) | `Tests 14 passed (14)` |
| full AppBlocks node `unit` tier (`src/components/AppBlocks/`) | `Test Files 1 failed \| 46 passed (47)`, `Tests 7 failed \| 741 passed (748)` — the 7 are `__tests__/hiddenBlocks.test.ts`, **pre-existing**: `7 failed (7)` at `origin/main` too, same `TypeError: Cannot read properties of undefined (reading 'clear')`. Untouched by this PR |
| full AppBlocks `component` (browser) tier | `Test Files 40 passed (40)`, `Tests 484 passed (484)` |
| `PageBlockHostMaxWidth.browser.test.tsx` alone | `Tests 11 passed (11)` (11/11 at base too — the tier is blind to this defect by construction) |
| `src/components/Apps/ReviewPreviewFit.browser.test.tsx` (other `app-page-frame` consumer) | `Tests 3 passed (3)` |
| `src/components/Meta/__tests__/viewport-fit-cover.test.ts` (other `globals.css` guard) | `Tests 40 passed (40)` |

## Lint / format

Scoped to the changed paths only — this repo is pre-existing red repo-wide, so no repo-wide claim is made.

- `prettier --check` on all 5 changed files: `All matched files use Prettier code style!`
- `eslint` on the 4 changed TS/TSX files: exit 0, no output

## Files changed

- `src/components/AppBlocks/PageBlockHost.tsx` — stamp `data-app-page-frame=""`; comments updated
- `src/styles/globals.css` — ledger rule re-keyed; HOW-TO-ADD-ONE template re-keyed; a 🔴 note on why `data-testid` must never be used here
- `src/components/AppBlocks/__tests__/ledgerSelectorSurvivesProdStrip.test.ts` — **new** seam guard
- `src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx` — injected selector updated; a note recording that this tier is structurally blind to the production strip and pointing at the guard that is not
- `src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts` — prose/messages updated to the new selector shape. The membership assertion still fails on **growth and shrink** (it reads ids out of `[data-block-id='…']`, which is unchanged), and the `data-block-id={blockId}` stamping pin is unchanged

## Not verified

The fix has not been observed on the live site — that needs a deploy. The claim proven here is that the shipped selector no longer depends on an attribute the production compiler removes, and that the marker it depends on instead is really rendered.
