### PR TITLE
fix(nowpayments): process failed deposit events from webhook

### DIFF
--- a/src/pages/api/webhooks/nowpayments.ts
+++ b/src/pages/api/webhooks/nowpayments.ts
@@ -68,8 +68,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).send({ error: 'Missing payment_status or payment_id' });
     }
 
-    // Process actionable statuses (partially_paid treated like finished for buzz grant)
-    if (['confirming', 'finished', 'partially_paid'].includes(paymentStatus)) {
+    // Process actionable statuses (partially_paid treated like finished for buzz grant).
+    // `failed` advances an in-flight row to the terminal status; isDepositComplete gates
+    // the buzz grant, so a failed event records the status without crediting buzz.
+    if (['confirming', 'finished', 'partially_paid', 'failed'].includes(paymentStatus)) {
       await processDeposit(event.payment_id, paymentStatus, event);
     }
   } catch (error: any) {

--- a/src/server/__tests__/nowpayments-webhook-endpoint.test.ts
+++ b/src/server/__tests__/nowpayments-webhook-endpoint.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The handler pulls these in at module scope; install canonical mocks first.
+import '~/__tests__/mocks/logging.mock';
+
+const { env, processDeposit, validateWebhookEvent } = vi.hoisted(() => ({
+  env: { NOW_PAYMENTS_IPN_KEY: 'ipn-secret' } as { NOW_PAYMENTS_IPN_KEY?: string },
+  processDeposit: vi.fn(async () => ({ userId: 42, buzzAmount: 0, transactionId: undefined })),
+  // Signature validation is not what this suite tests; hold it valid and vary the body.
+  validateWebhookEvent: vi.fn((_sig: string, body: unknown) => ({ isValid: true, ...(body as object) })),
+}));
+
+vi.mock('~/env/server', () => ({ env }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ trackWebhookEvent: vi.fn(() => Promise.resolve()) }));
+vi.mock('~/server/http/nowpayments/nowpayments.caller', () => ({
+  default: { validateWebhookEvent },
+}));
+vi.mock('~/server/services/nowpayments.service', () => ({ processDeposit }));
+
+const handler = (await import('~/pages/api/webhooks/nowpayments')).default;
+
+function createMocks(body: unknown) {
+  const req = { method: 'POST', headers: { 'x-nowpayments-sig': 'sig' }, body } as Record<
+    string,
+    unknown
+  >;
+
+  let statusCode = 0;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json: () => res,
+    send: () => res,
+    setHeader: () => res,
+    end: () => res,
+    once: () => res,
+    _status: () => statusCode,
+  };
+  return { req, res };
+}
+
+const run = (payment_status: string) => {
+  const { req, res } = createMocks({ payment_id: 12345, payment_status, order_id: 'user:42' });
+  return handler(req as never, res as never).then(() => res);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  env.NOW_PAYMENTS_IPN_KEY = 'ipn-secret';
+});
+
+describe('nowpayments webhook endpoint', () => {
+  it('routes a failed event to processDeposit', async () => {
+    await run('failed');
+
+    expect(processDeposit).toHaveBeenCalledTimes(1);
+    expect(processDeposit).toHaveBeenCalledWith(12345, 'failed', expect.any(Object));
+  });
+
+  it.each(['confirming', 'finished', 'partially_paid'])(
+    'routes a %s event to processDeposit',
+    async (status) => {
+      await run(status);
+      expect(processDeposit).toHaveBeenCalledWith(12345, status, expect.any(Object));
+    }
+  );
+
+  it('does not process a non-actionable status', async () => {
+    const res = await run('waiting');
+
+    expect(processDeposit).not.toHaveBeenCalled();
+    expect(res._status()).toBe(200);
+  });
+});

--- a/src/server/services/__tests__/nowpayments.service.test.ts
+++ b/src/server/services/__tests__/nowpayments.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { dbMock } from '~/__tests__/mocks/db.mock';
+import { loggingMock } from '~/__tests__/mocks/logging.mock';
 import type { NOWPayments } from '~/server/http/nowpayments/nowpayments.schema';
 
 // Use vi.hoisted so mocks are available inside vi.mock factories
@@ -170,6 +171,77 @@ describe('processDeposit', () => {
 
     expect(result).toEqual({ userId: 42, buzzAmount: 0, transactionId: undefined });
     expect(mockGrantBuzzPurchase).not.toHaveBeenCalled();
+  });
+
+  it('records failed status and grants zero buzz', async () => {
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'confirming',
+      buzzCredited: null,
+    });
+
+    const event = makeWebhookEvent({ payment_status: 'failed', outcome_amount: 5.0 });
+    const result = await processDeposit(12345, 'failed', event);
+
+    expect(result).toEqual({ userId: 42, buzzAmount: 0, transactionId: undefined });
+    expect(mockGrantBuzzPurchase).not.toHaveBeenCalled();
+
+    const upsertCall = mockDbWrite.cryptoDeposit.upsert.mock.calls[0]?.[0];
+    expect(upsertCall?.create).toMatchObject({ status: 'failed' });
+    expect(upsertCall?.update).toHaveProperty('status', 'failed');
+
+    expect(loggingMock.logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'NowPayments reported deposit failed', userId: 42 })
+    );
+  });
+
+  it('does not overwrite buzz_failed status with failed (keeps it in the retry sweep)', async () => {
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'buzz_failed',
+      buzzCredited: null,
+    });
+
+    const event = makeWebhookEvent({ payment_status: 'failed', outcome_amount: 5.0 });
+    await processDeposit(12345, 'failed', event);
+
+    expect(mockDbWrite.cryptoDeposit.upsert).toHaveBeenCalledTimes(1);
+    const upsertCall = mockDbWrite.cryptoDeposit.upsert.mock.calls[0][0];
+    // No `status` in the update means the row keeps its buzz_failed status.
+    expect(upsertCall.update).not.toHaveProperty('status');
+  });
+
+  it('preserves recorded amounts when a failed event with null amounts lands on a finished row', async () => {
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'finished',
+      payAmount: 10,
+      outcomeAmount: 9.5,
+      buzzCredited: 9500,
+    });
+
+    const event = makeWebhookEvent({
+      payment_status: 'failed',
+      actually_paid: null,
+      outcome_amount: null,
+    });
+    await processDeposit(12345, 'failed', event);
+
+    const upsertCall = mockDbWrite.cryptoDeposit.upsert.mock.calls[0][0];
+    // Status stays finished (immutable) and the amounts are not nulled out.
+    expect(upsertCall.update).not.toHaveProperty('status');
+    expect(upsertCall.update).toMatchObject({ payAmount: 10, outcomeAmount: 9.5 });
+  });
+
+  it('advances failed to finished when a completed webhook arrives afterward', async () => {
+    mockDbRead.cryptoDeposit.findUnique.mockResolvedValueOnce({
+      status: 'failed',
+      buzzCredited: null,
+    });
+
+    const event = makeWebhookEvent({ outcome_amount: 5.0 });
+    await processDeposit(12345, 'finished', event);
+
+    expect(mockGrantBuzzPurchase).toHaveBeenCalled();
+    const upsertCall = mockDbWrite.cryptoDeposit.upsert.mock.calls[0]?.[0];
+    expect(upsertCall?.update).toHaveProperty('status', 'finished');
   });
 
   it('calculates buzz correctly: floors fractional amounts', async () => {

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -265,20 +265,36 @@ export const processDeposit = async (
     depositStatus = webhookStatus;
   }
 
+  // Surface a rejected payment as its own Axiom alert — otherwise a `failed` event is
+  // indistinguishable from routine status traffic in the logs, and this is the signal
+  // support needs to see a stuck deposit resolve.
+  if (webhookStatus === 'failed') {
+    await log({
+      type: 'warning',
+      message: 'NowPayments reported deposit failed',
+      paymentId,
+      userId,
+      status: depositStatus,
+    });
+  }
+
   // Upsert the CryptoDeposit record on every webhook status
   if (event.payment_id) {
     try {
       // Fetch existing record for status ordering and data preservation
       const existing = await dbRead.cryptoDeposit.findUnique({
         where: { paymentId: BigInt(event.payment_id) },
-        select: { status: true, buzzCredited: true, bonusBuzz: true, multiplier: true,
-                  depositFee: true, serviceFee: true, feeCurrency: true, paidFiat: true },
+        select: { status: true, payAmount: true, outcomeAmount: true, buzzCredited: true,
+                  bonusBuzz: true, multiplier: true, depositFee: true, serviceFee: true,
+                  feeCurrency: true, paidFiat: true },
       });
 
       const depositData = {
         payCurrency: event.pay_currency ?? 'unknown',
-        payAmount: event.actually_paid ?? null,
-        outcomeAmount: event.outcome_amount ?? null,
+        // A `failed` IPN typically carries null amounts; preserve the recorded values
+        // instead of nulling them out (matches the sibling fields below).
+        payAmount: event.actually_paid ?? (existing?.payAmount ?? null),
+        outcomeAmount: event.outcome_amount ?? (existing?.outcomeAmount ?? null),
         buzzCredited: buzzAmount > 0 && !buzzGrantFailed ? buzzAmount : (existing?.buzzCredited ?? null),
         bonusBuzz: !buzzGrantFailed ? bonusBuzz : (existing?.bonusBuzz ?? null),
         multiplier: !buzzGrantFailed ? multiplierInt : (existing?.multiplier ?? null),
@@ -289,13 +305,17 @@ export const processDeposit = async (
         chain,
       };
 
+      // `failed` outranks the in-flight statuses so a rejection advances a stuck row, but
+      // sits below buzz_failed and finished: a late `failed` must not pull an owed
+      // (buzz_failed, still swept by retryFailedDeposits) or credited (finished) deposit
+      // into a terminal state, and a `finished` arriving after `failed` must still win.
       const statusRank: Record<string, number> = {
         waiting: 0, confirming: 1, sending: 1, partially_paid: 1,
-        buzz_failed: 2, finished: 3, failed: 4,
+        failed: 2, buzz_failed: 3, finished: 4,
       };
       const existingRank = existing ? (statusRank[existing.status] ?? 0) : -1;
       const nextRank = statusRank[depositStatus] ?? 0;
-      // Only advance status forward; finished is immutable except via failed (manual)
+      // Only advance status forward; finished is immutable.
       const shouldUpdateStatus = !existing || (existing.status !== 'finished' && nextRank > existingRank)
         || (existing.status === 'buzz_failed' && depositStatus === 'finished');
 


### PR DESCRIPTION
The NowPayments webhook handler silently dropped failed payment events because 'failed' was not in the processDeposit allowlist. Rejected deposits remained stuck in 'confirming' status indefinitely, delivering a misleading customer experience and driving support queue volume.

Added 'failed' to the webhook's status allowlist (nowpayments.ts:72). The existing statusRank map already ranked failed correctly; it was simply unreachable from the webhook path. Adjusted rank ordering so failed advances in-flight deposits without granting buzz, but cannot regress already-finished or already-buzz_failed rows (failed: 2, buzz_failed: 3, finished: 4).

A failed event triggers no buzz grant and is idempotent on settled rows. Preserves recorded amounts when null amounts arrive in a failed event. Added comprehensive test coverage for routing, status advancement, preservation logic, and ordering invariants.

Refs: 868kyct02