### PR TITLE
feat(app-blocks): allow the init-fragment fast path for app-requests

### DIFF
--- a/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
+++ b/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
@@ -181,13 +181,68 @@ describe('blockInitFragmentEnabledWith — opt-in only', () => {
   });
 });
 
-describe('blockInitFragmentEnabled — the PRODUCTION binding is OFF', () => {
-  it('🔴 ships with an EMPTY allowlist, so the fast path is inert everywhere', () => {
-    // A live-block enumeration on 2026-08-05 found that NO deployed block can
-    // decode the fragment (`civitai-block=v1` x0 across 20 bundles) because the
-    // SDK half is merged but unpublished. Shipping it enabled would be pure
-    // risk for zero benefit.
-    expect(BLOCK_INIT_FRAGMENT_ALLOWLIST.size).toBe(0);
+describe('blockInitFragmentEnabled — the PRODUCTION allowlist', () => {
+  it('🔴 contains EXACTLY the blocks opted in — pinned as a whole set', () => {
+    // Bind against the REAL exported constant, not the injectable `TEST_ALLOW`.
+    // Every assertion above drives `blockInitFragmentEnabledWith` with a
+    // synthetic allowlist, which BY CONSTRUCTION cannot observe a change to the
+    // production one — so without this test the shipped allowlist is unpinned
+    // and could be widened silently.
+    //
+    // Pinned as a sorted array rather than `.has(...)` + `.size`: an exact
+    // whole-set comparison fails on an ADDITION as well as a removal, and names
+    // the offending entry in its own diff.
+    expect([...BLOCK_INIT_FRAGMENT_ALLOWLIST].sort()).toEqual(['app-requests']);
+  });
+
+  it('🔴 enables the fast path for app-requests on page-run', () => {
+    // `app-requests` declares `"blockId": "app-requests"` and a `page` with no
+    // slots, and on page-run `slug === blockId` — so the single allowlist string
+    // matches whichever key the host passes. Assert BOTH keys and each alone,
+    // because a regression that dropped one lookup branch would still pass if
+    // only the combined shape were tested.
+    expect(
+      blockInitFragmentEnabled({
+        surface: 'page-run',
+        slug: 'app-requests',
+        blockId: 'app-requests',
+      })
+    ).toBe(true);
+    expect(blockInitFragmentEnabled({ surface: 'page-run', slug: 'app-requests' })).toBe(true);
+    expect(blockInitFragmentEnabled({ surface: 'page-run', blockId: 'app-requests' })).toBe(true);
+  });
+
+  it('🔴 does NOT leak onto dev-tunnel or review-preview for that same block', () => {
+    // THE POINT OF THIS TEST. Allowlisting a PUBLISHED app must not enable the
+    // fragment on a moderator's preview of that same app's next UNREVIEWED
+    // submission, nor on the author's dev tunnel — both mount unreviewed code
+    // under an identity the allowlist cannot distinguish from the reviewed one.
+    //
+    // 🔴 This assertion was VACUOUS before `app-requests` was allowlisted: with
+    // an empty allowlist every surface returned false anyway, so it could not
+    // distinguish "the surface was refused first" from "nothing was listed".
+    // The sibling page-run assertion is what gives it teeth — the SAME id on an
+    // eligible surface returns TRUE, so the only thing producing `false` here
+    // is the surface check.
+    for (const surface of ['dev-tunnel', 'review-preview'] as const) {
+      expect(
+        blockInitFragmentEnabled({
+          surface,
+          slug: 'app-requests',
+          blockId: 'app-requests',
+        })
+      ).toBe(false);
+    }
+    expect(
+      blockInitFragmentEnabled({
+        surface: 'page-run',
+        slug: 'app-requests',
+        blockId: 'app-requests',
+      })
+    ).toBe(true);
+  });
+
+  it('refuses a block that is on neither list, on every surface', () => {
     for (const surface of ALL_SURFACES) {
       expect(blockInitFragmentEnabled({ surface, blockId: 'anything', slug: 'anything' })).toBe(
         false
@@ -205,17 +260,32 @@ describe('blockInitFragmentEnabled — the PRODUCTION binding is OFF', () => {
     // started returning TRUE. The one block named as must-never-receive would
     // have received it.
     //
-    // Neither `ALLOWLIST.size === 0` nor `DENYLIST.has(...)` nor a lookup of an
-    // unknown id can see that swap: with the lists exchanged, the (empty)
-    // allowlist becomes the denylist and the denylist becomes the allowlist, so
-    // a denylisted slug is "allowed". Only asserting a DENYLISTED id through the
-    // production binding distinguishes the two wirings.
+    // Neither a set-contents pin nor `DENYLIST.has(...)` nor a lookup of an
+    // unknown id can see that swap: with the lists exchanged, the real
+    // allowlist is consulted as the denylist and vice versa, so a DENYLISTED
+    // slug is "allowed". Only asserting a denylisted id through the production
+    // binding distinguishes the two wirings.
     expect(blockInitFragmentEnabled({ surface: 'page-run', slug: 'playable-collections' })).toBe(
       false
     );
     expect(
       blockInitFragmentEnabled({ surface: 'model-slot', blockId: 'playable-collections' })
     ).toBe(false);
+  });
+
+  it('🔴 keeps playable-collections false on EVERY surface — denylist beats the allowlist', () => {
+    // Now that the real allowlist is non-empty, the denylist is doing load-
+    // bearing work through the production binding rather than being masked by
+    // an allowlist that refused everything anyway.
+    for (const surface of ALL_SURFACES) {
+      expect(
+        blockInitFragmentEnabled({
+          surface,
+          slug: 'playable-collections',
+          blockId: 'playable-collections',
+        })
+      ).toBe(false);
+    }
   });
 
   it('pins playable-collections in the real denylist', () => {

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -27,8 +27,9 @@
 //      🔴 THIS DOES NOT REOPEN THE FRAGMENT FAST PATH. The two counts are
 //      independent: `BLOCK_HELLO` is a runtime postMessage the SDK sends, while
 //      `civitai-block=v1` is a URL-fragment payload a block must DECODE, and
-//      nothing here re-measured the fragment half. The gate stays an empty
-//      opt-in allowlist until someone measures THAT.
+//      nothing there re-measured the fragment half. The gate stays a per-block
+//      opt-in, and an entry is earned only by measuring THAT half for THAT
+//      block — which is what was done for the one entry now in the ALLOWLIST.
 //
 //      🔴 AND IT IS A DATED MEASUREMENT, NOT A FACT. Blocks are rebuilt and
 //      re-approved continuously, so both numbers move on their own. The reason
@@ -50,10 +51,12 @@
 //
 // 🔴 THIS IS AN OPT-IN ALLOWLIST, NOT A RUNTIME KILL SWITCH. Enabling or
 // disabling a block is a deploy. That is an honest limitation and it is stated
-// here rather than in a commit message: with `ALLOWLIST` empty the feature is
-// inert, so there is nothing to revoke in a hurry, but if a runtime switch is
-// wanted the right home is a feature flag in the flags service — outside this
-// module and deliberately not added here.
+// here rather than in a commit message. 🔴 IT NOW HAS TEETH: the allowlist is
+// no longer empty, so "there is nothing to revoke in a hurry" — true while the
+// set was empty — NO LONGER HOLDS. Backing a block out is a code change and a
+// deploy, at deploy latency. If a faster revocation path is wanted the right
+// home is a feature flag in the flags service — outside this module and
+// deliberately not added here.
 
 /**
  * The surfaces that can mount an iframe block host. Passed explicitly by each
@@ -85,14 +88,31 @@ export type BlockHostSurface =
  * NOTHING on the model slot. When enabling a block, add its `blockId` — or add
  * both — and verify on the surface you actually care about.
  *
- * 🔴 EMPTY MEANS THE FEATURE IS OFF EVERYWHERE. That is the intended state
- * until blocks rebuild against an SDK that decodes the fragment. Adding an
- * entry is a deliberate, per-block decision that should be made only once THAT
- * block is known to ship a decoding SDK — the fragment is inert to a block that
- * does not read it, but a block that reads `location.hash` for its OWN purposes
- * can be perturbed by it (see DENYLIST).
+ * 🔴 NO LONGER EMPTY — but the bar for an entry is unchanged. Adding one is a
+ * deliberate, per-block decision that should be made only once THAT block is
+ * known to ship a decoding SDK: the fragment is inert to a block that does not
+ * read it, but a block that reads `location.hash` for its OWN purposes can be
+ * perturbed by it (see DENYLIST).
  */
-export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([]);
+export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  // 🔴 ONE STRING COVERS BOTH LOOKUPS **ONLY BECAUSE THIS BLOCK IS PAGE-MOUNTED**
+  // — do not copy this shape to a slot-mounted block without re-reading the
+  // KEYING ASYMMETRY note above. `app-requests` declares `"blockId":
+  // "app-requests"` and a `page` with NO slots, and on the page-run surface
+  // `slug === blockId`, so the single entry below matches whichever key the
+  // host happens to pass. A block that mounts in a MODEL SLOT is the dangerous
+  // case: that surface knows only a `blockId`, so an entry written as a slug
+  // there is silently inert.
+  //
+  // Both halves of the bar are met: it ships the decoding reader (an inline
+  // pre-paint fragment reader in its `index.html`, which records the resolved
+  // theme on `data-civitai-boot-theme` for React to read back), and it reads
+  // `location.hash` nowhere at runtime — the only textual mentions in its
+  // source are doc comments warning against exactly that, since the SDK's
+  // transport strips the fragment during init. That hash-reading hazard is
+  // what put `playable-collections` on the DENYLIST; this block is clear of it.
+  'app-requests',
+]);
 
 /**
  * Blocks that must NEVER receive the fragment, whatever the allowlist says.


### PR DESCRIPTION
Turns on the App Blocks init-fragment fast path for a single block: **App Requests**.

`BLOCK_INIT_FRAGMENT_ALLOWLIST` has shipped empty since it was introduced, so the fast path has been inert everywhere. This adds its first entry. The behavioural change is one string; everything else is a comment or a test.

With it, the block receives its host theme in the iframe URL fragment and can paint in the correct theme **before first paint**, instead of painting the wrong one and repainting when the init message arrives.

## Why this block, and why only this one

The gate's own doc comment sets the bar: add an entry "only once THAT block is known to ship a decoding SDK — the fragment is inert to a block that does not read it, but a block that reads `location.hash` for its OWN purposes can be perturbed by it." App Requests clears both halves:

- **It ships the reader.** Its `index.html` resolves the host theme in an inline pre-paint script and records the result on a boot-theme attribute that React reads back on its first commit. Verified against the current tip of the block's source.
- **It reads `location.hash` nowhere at runtime.** The only two textual mentions in its source are doc comments warning *against* reading it — the SDK's transport strips the fragment during init, so a runtime read would race the strip. Perturbing a block's own hash routing is exactly the hazard that put `playable-collections` on the denylist, and this block is clear of it.

No other block is added. The denylist, the predicate and the surface enum are untouched.

## Keying

The gate documents a keying asymmetry: the page host knows both a `blockId` and a `slug`, but the model slot knows only a `blockId`, so an entry written as a slug is silently inert there.

For this block that is benign — it declares `"blockId": "app-requests"` and a `page` with no slots, and on the page-run surface `slug === blockId`, so the single string is correct for both lookups. There is now a comment beside the entry saying so, and warning the next person not to copy the shape to a slot-mounted block, where a slug-only entry would do nothing.

## Tests

The existing suite drove only the injectable `blockInitFragmentEnabledWith` with a synthetic allowlist — which **by construction cannot observe a change to the shipped constant** — and its one production-binding assertion pinned the allowlist as *empty*. That gap is precisely what this PR alters, so the suite is extended to bind against the real export:

- The real `BLOCK_INIT_FRAGMENT_ALLOWLIST` is pinned as an **exact whole set**, so an unintended *addition* fails just as loudly as a removal.
- The fast path is `true` for this block on `page-run` — asserted with both keys and with each key alone.
- 🔴 It stays `false` on `dev-tunnel` and `review-preview` for that same block. This is the assertion that proves allowlisting a *published* app did not leak the fragment onto a moderator's preview of that app's next *unreviewed* submission. It was vacuous while the allowlist was empty (everything returned false anyway) and is genuinely reachable here for the first time.
- `playable-collections` stays `false` on every surface through the production binding — the denylist is now doing load-bearing work rather than being masked by an allowlist that refused everything.
- The existing positive control and ordering tests are kept.

Two header comments asserting the allowlist was empty are corrected rather than left to rot — including the "nothing to revoke in a hurry" note, which no longer holds now that the set has an entry. Backing a block out is a code change and a deploy; that limitation is stated honestly in the file.

### Verification

- **Red at `origin/main`, green at HEAD.** The three new production-binding tests fail against the unmodified gate — `AssertionError: expected [] to deeply equal [ 'app-requests' ]`, and two `expected false to be true` — and pass after the change.
- **Mutation-tested.** Removing `'app-requests'` from the allowlist kills the whole-set pin and the page-run assertion. Deleting the `dev-tunnel`/`review-preview` early return turns the leak test red at its *own* assertion (`expected true to be false`), not at a sibling.
- Test file: 12 → 16 tests. All 38 AppBlocks unit files green (496 tests). `pnpm typecheck`: 0 errors. Prettier clean.

## Rollout note

This changes host behaviour for a live app, so it is deliberately scoped to one block and left for the operator to merge.
