### PR TITLE
fix(buzz): floor purchasesMultiplier at 1 to prevent zero buzz credit

### DIFF
--- a/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
+++ b/src/server/services/__tests__/buzz.service.multiplier-floor.test.ts
@@ -117,21 +117,21 @@ describe('getMultipliersForUser floors the value it pays with', () => {
   // 🔴 THE DECISION THIS PINS. If you are here because you are adding a `clampRewardMultiplier` to
   // `purchasesMultiplier` for symmetry: don't. It feeds `getBuzzBulkMultiplier`, which is called
   // UNCONDITIONALLY unlike every UI consumer, and there `mainBuzzAdded = floor(amount * m - amount)`
-  // — so a 0 makes `totalCustomBuzz` 0 and a completed Stripe/Paddle/NowPayments purchase credits
-  // NOTHING. `completeStripeBuzzPurchase` then writes the `transactionId` its own early return uses
-  // as an idempotency marker, so a retry can never repair it. A 0 means "earns nothing" on the
-  // rewards side and nothing at all on the purchases side. That path needs its own floor, decided
-  // on its own terms. Without this test the reverted regression comes back green.
+  // — so a 0 makes `totalCustomBuzz` 0 and a completed Stripe/Paddle purchase credits NOTHING.
+  // `completeStripeBuzzPurchase` then writes the `transactionId` its own early return uses as an
+  // idempotency marker, so a retry can never repair it. A 0 means "earns nothing" on the rewards
+  // side and nothing at all on the purchases side.
   //
-  // Closing condition, so this does not become a wall: the decision is "0 is the WRONG repair", not
-  // "no repair". When the purchases path gets its own floor — likely at 1, which delivers what was
-  // paid for — this test is UPDATED to assert that, not deleted.
+  // The purchases repair landed where the arithmetic is, NOT here: `getBuzzBulkMultiplier` floors at
+  // 1 (finite `Math.max(m, 1)`, no ceiling) — ClickUp 868m0axkg. So `getMultipliersForUser` still
+  // must NOT floor: a second floor here would be redundant and would change what the award
+  // computation and Redis Lua cap (other consumers of this value) see. This test keeps pinning that
+  // absence; without it the reverted regression comes back green.
   //
   // Read the assertions knowing this: `clampRewardMultiplier` only alters negatives and non-finites,
-  // so every value able to witness "not floored" is a value that must never reach the payment path.
-  // `-3` credits a NEGATIVE grant and `NaN` an unpayable one — both already broken today, and both
-  // worse than the 0 this argues against. The test pins the absence of a repair, not the health of
-  // the path.
+  // so every value able to witness "not floored" is a value the downstream floor now neutralises on
+  // the payment path. `-3` and `NaN` reach `getMultipliersForUser` unchanged and are clamped to 1 at
+  // `getBuzzBulkMultiplier`. The test pins where the repair lives, not the health of this function.
   it('does NOT floor purchasesMultiplier — that is a different money path', async () => {
     h.fetch.mockResolvedValue({
       [USER]: {

--- a/src/server/utils/__tests__/buzz-helpers.test.ts
+++ b/src/server/utils/__tests__/buzz-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   domainSpendType,
   getAllowedAccountTypes,
   getBlockAllowedAccountTypes,
+  getBuzzBulkMultiplier,
   isPayoutEligibleBuzz,
   orderBlockCurrencyTypes,
   PAYOUT_ELIGIBLE_BUZZ_TYPES,
@@ -159,5 +160,42 @@ describe('orderBlockCurrencyTypes — preferred-first + domain clamp', () => {
     const mature = orderBlockCurrencyTypes(false, 'green');
     expect(mature.disallowed).toBe(true);
     expect(mature.ordered).toEqual(['blue', 'yellow']); // never widened to include green
+  });
+});
+
+describe('getBuzzBulkMultiplier — a bad multiplier never zero-credits a paid purchase', () => {
+  // The paid-purchase path (Stripe/Paddle) feeds the result straight into a buzz transaction, then
+  // writes an idempotency marker — so a zero credit is unrepairable by retry. A non-finite or sub-1
+  // multiplier must floor to 1 (base Buzz granted, no bonus), never to 0. ClickUp 868m0axkg.
+  const cases: [string, number][] = [
+    ['NaN (Math.max fold of a bad row against membership)', NaN],
+    ['negative', -3],
+    ['zero', 0],
+    ['Infinity', Infinity],
+    ['below 1', 0.5],
+  ];
+
+  it.each(cases)('grants the full purchase and no bonus at %s', (_label, multiplier) => {
+    const result = getBuzzBulkMultiplier({ buzzAmount: 1000, purchasesMultiplier: multiplier });
+    // On revert (raw multiplier) totalCustomBuzz goes to 0 / negative / NaN / Infinity — never 1000.
+    expect(result.totalCustomBuzz).toBe(1000);
+    expect(result.mainBuzzAdded).toBe(0);
+    expect(result.purchasesMultiplier).toBe(1);
+  });
+
+  it('still applies a real membership multiplier', () => {
+    const result = getBuzzBulkMultiplier({ buzzAmount: 1000, purchasesMultiplier: 1.2 });
+    expect(result.mainBuzzAdded).toBe(200);
+    expect(result.totalCustomBuzz).toBe(1200);
+  });
+
+  it('coerces a numeric-string multiplier rather than dropping the bonus', () => {
+    // Matches the defensive `Number()` on buzzAmount: a DB-typed value can arrive as a string.
+    const result = getBuzzBulkMultiplier({
+      buzzAmount: 1000,
+      purchasesMultiplier: '1.2' as unknown as number,
+    });
+    expect(result.mainBuzzAdded).toBe(200);
+    expect(result.totalCustomBuzz).toBe(1200);
   });
 });

--- a/src/server/utils/buzz-helpers.ts
+++ b/src/server/utils/buzz-helpers.ts
@@ -4,12 +4,19 @@ import type { FeatureAccess } from '~/server/services/feature-flags.service';
 
 export const getBuzzBulkMultiplier = ({
   buzzAmount: _buzzAmount,
-  purchasesMultiplier,
+  purchasesMultiplier: _purchasesMultiplier,
 }: {
   buzzAmount: number;
   purchasesMultiplier: number;
 }) => {
   const buzzAmount = Number(_buzzAmount);
+  // Floor at 1 (no bonus), never 0: on the paid-purchase path a non-finite or sub-1 multiplier makes
+  // `buzzAmount * m - buzzAmount` zero/negative, and the caller's `metadata.transactionId`
+  // idempotency marker makes that zero-credit unrepairable by retry. See ClickUp 868m0axkg.
+  const parsedMultiplier = Number(_purchasesMultiplier);
+  const purchasesMultiplier = Number.isFinite(parsedMultiplier)
+    ? Math.max(parsedMultiplier, 1)
+    : 1;
   const bulkBuzzMultiplier = buzzBulkBonusMultipliers.reduce((acc, [amount, multiplier]) => {
     if (buzzAmount >= amount) {
       return multiplier;


### PR DESCRIPTION
Non-finite, negative, or zero purchasesMultiplier causes getBuzzBulkMultiplier
to return zero buzz despite real payment. The paid-purchase paths (Stripe,
Paddle, NowPayments) then write an idempotency marker, making the zero-credit
unrepairable by retry.

Floor purchasesMultiplier at 1 in getBuzzBulkMultiplier (the unconditional
call site) to ensure customers always receive at least their purchased buzz.
Add tests verifying NaN, negative, zero, and sub-1 multipliers are clamped to
1, yielding totalCustomBuzz = buzzAmount (no bonus).

Keep the floor here, not in getMultipliersForUser, to avoid double-flooring
downstream consumers (award computation, Redis Lua cap) that rely on raw
multiplier values.

Refs: 868m0axkg