### PR TITLE
feat(collections): allow creators to archive collections

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260831000000_collection_archived_at/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260831000000_collection_archived_at/migration.sql
@@ -1,0 +1,15 @@
+-- Adds a nullable "archivedAt" timestamp to "Collection". A creator archives an old
+-- collection so it drops out of the "Save to collection" picker and stops accepting new
+-- entries, while it still loads at its public URL. NULL = active; a timestamp = archived.
+-- Reversible from the UI by clearing it back to NULL.
+--
+-- Additive and nullable, so existing rows default to NULL (active) and nothing is backfilled.
+--
+-- ⚠️ MANUAL-APPLY. The main civitai DB does NOT run `prisma migrate deploy` — this file is
+-- committed for history and applied BY HAND (psql) per environment by a human. Nothing in CI
+-- or the deploy pipeline runs it.
+--
+-- ORDERING: safe to apply before or after the code ships. The new client SELECTs the column,
+-- so apply it no later than the deploy; applying it early is inert because no code reads or
+-- writes the column until the deploy lands. `IF NOT EXISTS` makes a re-run a no-op.
+ALTER TABLE "Collection" ADD COLUMN IF NOT EXISTS "archivedAt" TIMESTAMP(3);

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -4632,6 +4632,7 @@ model Collection {
   availability Availability                 @default(Public)
   nsfwLevel    Int                          @default(0)
   collaborationDisabledAt DateTime?
+  archivedAt   DateTime?
 
   items        CollectionItem[]
   contributors CollectionContributor[]

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -1828,6 +1828,7 @@ export type Collection = {
   availability: Generated<Availability>;
   nsfwLevel: Generated<number>;
   collaborationDisabledAt: Timestamp | null;
+  archivedAt: Timestamp | null;
 };
 export type CollectionContributor = {
   createdAt: Generated<Timestamp | null>;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -3008,6 +3008,7 @@ export interface Collection {
   availability: Availability;
   nsfwLevel: number;
   collaborationDisabledAt: Date | null;
+  archivedAt: Date | null;
   items?: CollectionItem[];
   contributors?: CollectionContributor[];
   invites?: CollectionInvite[];

--- a/src/components/Collections/AddToCollectionModal.tsx
+++ b/src/components/Collections/AddToCollectionModal.tsx
@@ -248,11 +248,14 @@ function CollectionListForm({
       // Active contests only surface for models the user owns, so the server can gate the branch
       // on ownership. Only meaningful when includeActiveContests is true (Model saves).
       contestModelId: props.modelId,
+      // Archived collections accept no new entries, so keep them out of the picker entirely.
+      excludeArchived: true,
     });
 
   const { data: collectionItems = [], isLoading: loadingStatus } =
     trpc.collection.getUserCollectionItemsByItem.useQuery({
       ...target,
+      excludeArchived: true,
     });
 
   // Ensures we don't present the user with a list of collections

--- a/src/components/Collections/Collection.tsx
+++ b/src/components/Collections/Collection.tsx
@@ -2,6 +2,7 @@ import type { ContainerProps } from '@mantine/core';
 import {
   ActionIcon,
   AspectRatio,
+  Badge,
   Box,
   Button,
   Center,
@@ -721,6 +722,11 @@ export function Collection({
                         <Title order={1} lineClamp={1} className={classes.title}>
                           {collection?.name ?? 'Loading...'}
                         </Title>
+                        {collection?.archivedAt && (
+                          <Badge color="gray" variant="light" radius="sm">
+                            Archived
+                          </Badge>
+                        )}
                         {submissionPeriod}
                       </Group>
                       {collection?.description && (

--- a/src/components/Collections/components/CollectionContextMenu.tsx
+++ b/src/components/Collections/components/CollectionContextMenu.tsx
@@ -2,6 +2,8 @@ import type { MenuProps } from '@mantine/core';
 import { Menu } from '@mantine/core';
 import { useQueryClient } from '@tanstack/react-query';
 import {
+  IconArchive,
+  IconArchiveOff,
   IconEdit,
   IconRobot,
   IconHome,
@@ -86,6 +88,26 @@ export function CollectionContextMenu({
     },
     onSettled: async () => {
       await queryUtils.collection.getAllUser.invalidate();
+    },
+  });
+
+  const isArchived = permissions?.archived ?? false;
+  const setArchivedMutation = trpc.collection.setArchived.useMutation({
+    async onSuccess(_res, { archived }) {
+      showSuccessNotification({
+        title: archived ? 'Collection archived' : 'Collection unarchived',
+        message: archived
+          ? "This collection is now hidden from the 'Save to collection' list and won't accept new entries until you unarchive it."
+          : 'This collection can receive new entries again.',
+      });
+      await queryUtils.collection.getById.invalidate({ id: collectionId });
+      await queryUtils.collection.getAllUser.invalidate();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to update collection',
+        error: new Error(error.message),
+      });
     },
   });
 
@@ -296,6 +318,25 @@ export function CollectionContextMenu({
               </Menu.Item>
             )}
           </>
+        )}
+        {!isBookmarkCollection && (isOwner || isMod) && (
+          <Menu.Item
+            leftSection={
+              isArchived ? (
+                <IconArchiveOff size={14} stroke={1.5} />
+              ) : (
+                <IconArchive size={14} stroke={1.5} />
+              )
+            }
+            disabled={setArchivedMutation.isPending}
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setArchivedMutation.mutate({ id: collectionId, archived: !isArchived });
+            }}
+          >
+            {isArchived ? 'Unarchive collection' : 'Archive collection'}
+          </Menu.Item>
         )}
         {currentUser && permissions?.read && (
           <Menu.Item

--- a/src/server/controllers/collection.controller.ts
+++ b/src/server/controllers/collection.controller.ts
@@ -17,6 +17,7 @@ import type {
   GetCollectionPermissionDetails,
   GetUserCollectionItemsByItemSchema,
   RemoveCollectionItemInput,
+  SetCollectionArchivedInput,
   SetCollectionItemNsfwLevelInput,
   SetItemScoreInput,
   UpdateCollectionCoverImageInput,
@@ -46,6 +47,7 @@ import {
   removeCollectionItem,
   removeContributorFromCollection,
   saveItemInCollections,
+  setCollectionArchived,
   setCollectionItemNsfwLevel,
   setItemScore,
   updateCollectionCoverImage,
@@ -443,6 +445,26 @@ export const deleteUserCollectionHandler = async ({
   try {
     const { user } = ctx;
     await deleteCollectionById({ id: input.id, userId: user.id, isModerator: user.isModerator });
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    else throw throwDbError(error);
+  }
+};
+
+export const setCollectionArchivedHandler = async ({
+  input,
+  ctx,
+}: {
+  input: SetCollectionArchivedInput;
+  ctx: ProtectedContext;
+}) => {
+  try {
+    const { user } = ctx;
+    return await setCollectionArchived({
+      ...input,
+      userId: user.id,
+      isModerator: user.isModerator,
+    });
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/routers/collection.router.ts
+++ b/src/server/routers/collection.router.ts
@@ -13,6 +13,7 @@ import {
   joinCollectionAsManagerHandler,
   removeCollectionItemHandler,
   saveItemHandler,
+  setCollectionArchivedHandler,
   setCollectionItemNsfwLevelHandler,
   setItemScoreHandler,
   unfollowHandler,
@@ -35,6 +36,7 @@ import {
   getUserCollectionItemsByItemSchema,
   removeCollectionItemInput,
   saveCollectionItemInputSchema,
+  setCollectionArchivedInput,
   setCollectionItemNsfwLevelInput,
   setItemScoreInput,
   updateCollectionCoverImageInput,
@@ -178,6 +180,12 @@ export const collectionRouter = router({
     .use(isFlagProtected('collections'))
     .use(isOwnerOrModerator)
     .mutation(deleteUserCollectionHandler),
+  setArchived: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
+    .input(setCollectionArchivedInput)
+    .use(isFlagProtected('collections'))
+    .use(isOwnerOrModerator)
+    .mutation(setCollectionArchivedHandler),
   bulkSaveItems: protectedProcedure
     .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(bulkSaveCollectionItemsInput)

--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -105,6 +105,9 @@ export const getAllUserCollectionsInputSchema = z
     // The model the picker is targeting. Active contests only surface when the user owns it —
     // you can only submit your own models — so this gates the includeActiveContests branch.
     contestModelId: z.number(),
+    // The "Save to collection" picker sets this to drop archived collections; management
+    // surfaces leave it off so the owner can still see and unarchive them.
+    excludeArchived: z.boolean(),
   })
   .partial();
 
@@ -231,6 +234,12 @@ export const upsertCollectionInput = z
     tags: z.array(tagSchema).nullish(),
   })
   .merge(collectionItemSchema);
+
+export type SetCollectionArchivedInput = z.infer<typeof setCollectionArchivedInput>;
+export const setCollectionArchivedInput = z.object({
+  id: z.number(),
+  archived: z.boolean(),
+});
 
 export type UpdateCollectionCoverImageInput = z.infer<typeof updateCollectionCoverImageInput>;
 export const updateCollectionCoverImageInput = z.object({

--- a/src/server/selectors/collection.selector.ts
+++ b/src/server/selectors/collection.selector.ts
@@ -17,6 +17,7 @@ export const collectionWithoutImageSelect = Prisma.validator<Prisma.CollectionSe
   mode: true,
   metadata: true,
   availability: true,
+  archivedAt: true,
   userId: true,
   tags: {
     select: {

--- a/src/server/services/__tests__/collection-collaborator-permissions.test.ts
+++ b/src/server/services/__tests__/collection-collaborator-permissions.test.ts
@@ -16,6 +16,7 @@ function arrange({
   write = 'Private',
   contributorPermissions = null,
   collaborationDisabledAt = null,
+  archivedAt = null,
   hasAcceptedSeat = false,
   ownerId = OWNER_ID,
   mode = null,
@@ -24,6 +25,7 @@ function arrange({
   write?: 'Public' | 'Review' | 'Private';
   contributorPermissions?: string[] | null;
   collaborationDisabledAt?: Date | null;
+  archivedAt?: Date | null;
   hasAcceptedSeat?: boolean;
   ownerId?: number;
   mode?: string | null;
@@ -39,6 +41,7 @@ function arrange({
       mode,
       contributorPermissions,
       collaborationDisabledAt,
+      archivedAt,
       hasAcceptedSeat,
     },
   ]);
@@ -189,6 +192,58 @@ describe('collection collaborator permissions', () => {
     });
     expect(permissions.isCollaborator).toBe(false);
     expect(permissions.writeReview).toBe(false);
+  });
+
+  // Archive differs from collaboration-disable: it blocks the OWNER too, so no new entries land
+  // from anyone until it's unarchived.
+  it('blocks the owner from adding to an archived collection but keeps manage and read', async () => {
+    arrange({ write: 'Public', archivedAt: new Date('2026-08-31') });
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: OWNER_ID,
+    });
+    expect(permissions.archived).toBe(true);
+    expect(permissions.write).toBe(false);
+    expect(permissions.writeReview).toBe(false);
+    expect(permissions.manage).toBe(true);
+    expect(permissions.read).toBe(true);
+  });
+
+  it('blocks a moderator from adding to an archived collection', async () => {
+    arrange({ write: 'Public', archivedAt: new Date('2026-08-31') });
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: OTHER_ID,
+      isModerator: true,
+    });
+    expect(permissions.write).toBe(false);
+    expect(permissions.writeReview).toBe(false);
+  });
+
+  it('blocks a collaborator from adding to an archived collection', async () => {
+    arrange({
+      write: 'Review',
+      contributorPermissions: ['VIEW', 'ADD', 'MANAGE'],
+      archivedAt: new Date('2026-08-31'),
+    });
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: OTHER_ID,
+    });
+    expect(permissions.write).toBe(false);
+    expect(permissions.writeReview).toBe(false);
+    // Manage is untouched, so an invited manager could still unarchive it.
+    expect(permissions.manage).toBe(true);
+  });
+
+  it('leaves write intact once a collection is unarchived', async () => {
+    arrange({ write: 'Public', archivedAt: null });
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: OWNER_ID,
+    });
+    expect(permissions.archived).toBe(false);
+    expect(permissions.write).toBe(true);
   });
 });
 

--- a/src/server/services/__tests__/collection-picker-archive.test.ts
+++ b/src/server/services/__tests__/collection-picker-archive.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const mockDbRead = dbMock.dbRead;
+
+const { getUserCollectionsWithPermissions } = await import('~/server/services/collection.service');
+
+// The picker's owned/contributor/public branches are assembled as a single UNIONed Prisma.Sql.
+// Find whichever argument carries the reconstructed text.
+function capturedSql(): string {
+  const call = mockDbRead.$queryRaw.mock.calls.at(-1) ?? [];
+  for (const arg of call) {
+    const sql = (arg as { sql?: unknown } | null)?.sql;
+    if (typeof sql === 'string') return sql;
+  }
+  return '';
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbRead.$queryRaw.mockResolvedValue([]);
+  mockDbRead.tagsOnCollection.findMany.mockResolvedValue([]);
+});
+
+describe('getUserCollectionsWithPermissions archive filtering', () => {
+  it('excludes archived collections when excludeArchived is set (the Save-to-collection picker)', async () => {
+    await getUserCollectionsWithPermissions({ input: { userId: 1, excludeArchived: true } });
+    expect(capturedSql()).toContain('"archivedAt" IS NULL');
+  });
+
+  it('leaves archived collections in for management surfaces when the flag is off', async () => {
+    await getUserCollectionsWithPermissions({ input: { userId: 1 } });
+    // The column is always projected; only the IS NULL filter is conditional.
+    expect(capturedSql()).not.toContain('"archivedAt" IS NULL');
+  });
+});

--- a/src/server/services/__tests__/collection-set-archived.service.test.ts
+++ b/src/server/services/__tests__/collection-set-archived.service.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+// setCollectionArchived requeues the search index and marks the row fresh — neither is under
+// test here, so stub them so the module loads without reaching real infra.
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+  getKyselyWithoutLag: vi.fn(),
+  preventReplicationLag: vi.fn(),
+}));
+
+const mockDbRead = dbMock.dbRead;
+const mockDbWrite = dbMock.dbWrite;
+
+const { setCollectionArchived } = await import('~/server/services/collection.service');
+
+const COLLECTION_ID = 10;
+const OWNER_ID = 999;
+const OTHER_ID = 777;
+
+function arrange({
+  userId = OWNER_ID,
+  mode = null,
+}: {
+  userId?: number;
+  mode?: string | null;
+} = {}) {
+  mockDbRead.collection.findUnique.mockResolvedValue({ id: COLLECTION_ID, userId, mode });
+  mockDbWrite.collection.update.mockResolvedValue({ id: COLLECTION_ID });
+}
+
+describe('setCollectionArchived', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('archives the owner’s own collection with a timestamp', async () => {
+    arrange();
+    await setCollectionArchived({ id: COLLECTION_ID, archived: true, userId: OWNER_ID });
+    const call = mockDbWrite.collection.update.mock.calls[0][0];
+    expect(call.data.archivedAt).toBeInstanceOf(Date);
+  });
+
+  it('unarchives by clearing the timestamp', async () => {
+    arrange();
+    await setCollectionArchived({ id: COLLECTION_ID, archived: false, userId: OWNER_ID });
+    const call = mockDbWrite.collection.update.mock.calls[0][0];
+    expect(call.data.archivedAt).toBeNull();
+  });
+
+  it('refuses to archive a collection the caller does not own', async () => {
+    arrange({ userId: OWNER_ID });
+    await expect(
+      setCollectionArchived({ id: COLLECTION_ID, archived: true, userId: OTHER_ID })
+    ).rejects.toThrow();
+    expect(mockDbWrite.collection.update).not.toHaveBeenCalled();
+  });
+
+  it('lets a moderator archive a collection they do not own', async () => {
+    arrange({ userId: OWNER_ID });
+    await setCollectionArchived({
+      id: COLLECTION_ID,
+      archived: true,
+      userId: OTHER_ID,
+      isModerator: true,
+    });
+    expect(mockDbWrite.collection.update).toHaveBeenCalled();
+  });
+
+  it('refuses to archive a Bookmark collection (no UI path back)', async () => {
+    arrange({ mode: 'Bookmark' });
+    await expect(
+      setCollectionArchived({ id: COLLECTION_ID, archived: true, userId: OWNER_ID })
+    ).rejects.toThrow();
+    expect(mockDbWrite.collection.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -42,6 +42,7 @@ import type {
   UpdateCollectionItemsStatusInput,
   UpsertCollectionInput,
   SetCollectionAiReviewInput,
+  SetCollectionArchivedInput,
 } from '~/server/schema/collection.schema';
 import { collectionAiReviewSchema } from '~/server/schema/collection.schema';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
@@ -118,6 +119,9 @@ export type CollectionContributorPermissionFlags = {
   isContributor: boolean;
   isCollaborator: boolean;
   collaborationDisabled: boolean;
+  // Archived collections stay readable but accept no new entries — write/writeReview are
+  // forced false for everyone, the owner and moderators included.
+  archived: boolean;
   isOwner: boolean;
   followPermissions: CollectionContributorPermission[];
   publicCollection: boolean;
@@ -216,6 +220,7 @@ export async function getUserCollectionPermissionsByIds({
     mode: CollectionMode | null;
     contributorPermissions: CollectionContributorPermission[] | null;
     collaborationDisabledAt: Date | null;
+    archivedAt: Date | null;
     hasAcceptedSeat: boolean;
   };
 
@@ -228,6 +233,7 @@ export async function getUserCollectionPermissionsByIds({
       c.type::"CollectionType" as "type",
       c.mode::"CollectionMode" as "mode",
       c."collaborationDisabledAt",
+      c."archivedAt",
       ${
         userId
           ? Prisma.sql`cc.permissions as "contributorPermissions", ci.id IS NOT NULL as "hasAcceptedSeat"`
@@ -265,6 +271,7 @@ export async function getUserCollectionPermissionsByIds({
       isContributor: false,
       isCollaborator: false,
       collaborationDisabled: !!collection.collaborationDisabledAt,
+      archived: !!collection.archivedAt,
       isOwner: false,
       publicCollection: false,
       followPermissions: [],
@@ -370,6 +377,17 @@ export async function getUserCollectionPermissionsByIds({
     return permissions;
   });
 
+  // Archive is an absolute write block, applied after every per-user grant above so it also
+  // closes the owner and moderator branches — an archived collection accepts no new entries
+  // from anyone until it's unarchived. Read/manage are untouched, so the owner can still view
+  // it and unarchive it.
+  for (const permission of results) {
+    if (permission.archived) {
+      permission.write = false;
+      permission.writeReview = false;
+    }
+  }
+
   return results;
 }
 
@@ -438,6 +456,7 @@ function createEmptyPermissions(collectionId: number): CollectionContributorPerm
     isContributor: false,
     isCollaborator: false,
     collaborationDisabled: false,
+    archived: false,
     isOwner: false,
     publicCollection: false,
     followPermissions: [],
@@ -456,6 +475,7 @@ type CollectionForPermission = {
   imageId?: number;
   type?: CollectionType;
   mode?: CollectionMode | null;
+  archivedAt?: Date | null;
 };
 
 export const getUserCollectionsWithPermissions = async <
@@ -470,14 +490,21 @@ export const getUserCollectionsWithPermissions = async <
     permission,
     contributingOnly = true,
     includeActiveContests = false,
+    excludeArchived = false,
     contestModelId,
   } = input;
   let { permissions = [] } = input;
   // By default, owned collections will be always returned
   const AND: Prisma.Sql[] = [];
   const SELECT: Prisma.Sql = Prisma.raw(
-    `SELECT c."id", c."name", c."description", c."read", c."userId", c."write", c."imageId", c."type", c."mode", c."createdAt", c."updatedAt"`
+    `SELECT c."id", c."name", c."description", c."read", c."userId", c."write", c."imageId", c."type", c."mode", c."archivedAt", c."createdAt", c."updatedAt"`
   );
+
+  // The "Save to collection" picker passes this to drop archived collections from every branch;
+  // management surfaces (MyCollections) leave it off so the owner can still see and unarchive them.
+  const excludeArchivedFilter = excludeArchived
+    ? Prisma.sql`AND c."archivedAt" IS NULL`
+    : Prisma.empty;
 
   if (input.type) {
     AND.push(Prisma.sql`(c."type" = ${input.type}::"CollectionType" OR c."type" IS NULL)`);
@@ -498,6 +525,7 @@ export const getUserCollectionsWithPermissions = async <
       FROM "Collection" c
       WHERE "userId" = ${userId}
         ${AND.length > 0 ? Prisma.sql`AND ${Prisma.join(AND, ',')}` : Prisma.sql``}
+        ${excludeArchivedFilter}
 
     )`,
   ];
@@ -512,6 +540,7 @@ export const getUserCollectionsWithPermissions = async <
       FROM "Collection" c
       WHERE "write" = ${CollectionWriteConfiguration.Public}::"CollectionWriteConfiguration"
           ${AND.length > 0 ? Prisma.sql`AND ${Prisma.join(AND, ',')}` : Prisma.sql``}
+          ${excludeArchivedFilter}
     `);
   }
 
@@ -529,6 +558,7 @@ export const getUserCollectionsWithPermissions = async <
       WHERE "read" = ${CollectionReadConfiguration.Public}::"CollectionReadConfiguration"
         ${AND.length > 0 ? Prisma.sql`AND ${Prisma.join(AND, ',')}` : Prisma.sql``}
         ${excludeContests}
+        ${excludeArchivedFilter}
 
     `);
   }
@@ -547,6 +577,7 @@ export const getUserCollectionsWithPermissions = async <
           AND cc."collectionId" IS NOT NULL
           ${AND.length > 0 ? Prisma.sql`AND ${Prisma.join(AND, ',')}` : Prisma.sql``}
           ${excludeContests}
+          ${excludeArchivedFilter}
     )`);
   }
 
@@ -576,6 +607,7 @@ export const getUserCollectionsWithPermissions = async <
             WHERE m."id" = ${contestModelId} AND m."userId" = ${userId}
           )
           ${AND.length > 0 ? Prisma.sql`AND ${Prisma.join(AND, ',')}` : Prisma.sql``}
+          ${excludeArchivedFilter}
         LIMIT 100
     )`);
   }
@@ -678,6 +710,38 @@ export const getPendingReviewCount = (collectionId: number) =>
   dbRead.collectionItem.count({
     where: { collectionId, status: CollectionItemStatus.REVIEW },
   });
+
+// Archiving keeps the collection readable but drops it out of the "Save to collection" picker
+// and blocks new entries; unarchiving clears the timestamp. Scoped to the owner (moderators
+// exempt) so a direct call can't archive someone else's collection even though the router
+// already gates on ownership. Bookmark collections (a user's Liked/Favorites) are refused: the
+// UI offers no archive toggle for them, so archiving one via a direct call would strand it with
+// no in-product way back.
+export const setCollectionArchived = async ({
+  id,
+  archived,
+  userId,
+  isModerator,
+}: SetCollectionArchivedInput & { userId: number; isModerator?: boolean }) => {
+  const collection = await dbRead.collection.findUnique({
+    where: { id },
+    select: { id: true, userId: true, mode: true },
+  });
+  if (!collection || (!isModerator && collection.userId !== userId))
+    throw throwNotFoundError(`No collection with id ${id}`);
+  if (collection.mode === CollectionMode.Bookmark)
+    throw throwBadRequestError('Bookmark collections cannot be archived.');
+
+  await dbWrite.collection.update({
+    where: { id },
+    data: { archivedAt: archived ? new Date() : null },
+  });
+
+  await collectionsSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
+  await preventReplicationLag('collection', id);
+
+  return { id, archived };
+};
 
 const inputToCollectionType = {
   modelId: CollectionType.Model,
@@ -2035,7 +2099,7 @@ export const getUserCollectionItemsByItem = async ({
 }: {
   input: GetUserCollectionItemsByItemSchema & { userId: number; isModerator?: boolean };
 }) => {
-  const { userId, isModerator, modelId, imageId, articleId, postId } = input;
+  const { userId, isModerator, modelId, imageId, articleId, postId, excludeArchived } = input;
 
   const userCollections = await getUserCollectionsWithPermissions({
     input: {
@@ -2045,6 +2109,7 @@ export const getUserCollectionItemsByItem = async ({
         CollectionContributorPermission.MANAGE,
       ],
       userId,
+      excludeArchived,
     },
   });
 


### PR DESCRIPTION
Add archiving capability for collections so creators can remove old
collections from the "Save to collection" picker without deleting them.

Archived collections:
- No longer appear in the save picker when excludeArchived is set
- Reject new entries until unarchived
- Remain publicly accessible and readable
- Can be unarchived via UI toggle

Changes:
- Add nullable archivedAt timestamp to Collection model
- Extend getUserCollectionsWithPermissions with excludeArchived filter
- Add setCollectionArchived service to toggle archive state
- Update permission flags to block write/writeReview for archived collections
- Add archive badge display on archived collection pages
- Add Archive/Unarchive menu item for collection owners and moderators

Migration adds the column as nullable with no backfill, so existing
collections default to active state (NULL).

Refs: 868kyuehu