### PR TITLE
feat(observability): dark probe for whether caching moderation verdicts would pay

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1815,7 +1815,8 @@ export const REDIS_SYS_KEYS = {
      * exact string sent to the external prompt classifier, so we can count how often that string
      * REPEATS inside a window. Nothing reads the value back to skip work; the classifier is called
      * every time either way. Written only while EXTERNAL_MODERATION_CACHE_PROBE names a namespace
-     * (it is a deployment LABEL, not an on/off flag — empty, or any on/off word, means disabled),
+     * (it is a deployment LABEL, not an on/off flag, and the accepted labels are a CLOSED
+     * ALLOWLIST — empty, or anything outside it, means disabled),
      * and the value becomes the segment after this prefix so two armed deployments sharing one
      * sysRedis cannot collide. Every key carries an EX, so the keyspace evaporates on its own once
      * the probe is disarmed.

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1810,6 +1810,15 @@ export const REDIS_SYS_KEYS = {
     BLOCKED_PROMPTS: 'generation:blocked-prompts',
     REMIX_AUDIT_CHECKED: 'generation:remix-audit-checked',
     CLIENT: 'generation:client',
+    /**
+     * MEASUREMENT ONLY — a dark probe, not a cache. Holds `1` against a truncated SHA-256 of the
+     * exact string sent to the external prompt classifier, so we can count how often that string
+     * REPEATS inside a window. Nothing reads the value back to skip work; the classifier is called
+     * every time either way. Written only while EXTERNAL_MODERATION_CACHE_PROBE is on, and every
+     * key carries an EX, so the whole keyspace evaporates on its own when the flag goes off.
+     * See src/server/integrations/moderation-cache-probe.ts.
+     */
+    MODERATION_CACHE_PROBE: 'generation:moderation-cache-probe',
   },
   TRAINING: {
     STATUS: 'training:status',

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1814,8 +1814,11 @@ export const REDIS_SYS_KEYS = {
      * MEASUREMENT ONLY — a dark probe, not a cache. Holds `1` against a truncated SHA-256 of the
      * exact string sent to the external prompt classifier, so we can count how often that string
      * REPEATS inside a window. Nothing reads the value back to skip work; the classifier is called
-     * every time either way. Written only while EXTERNAL_MODERATION_CACHE_PROBE is on, and every
-     * key carries an EX, so the whole keyspace evaporates on its own when the flag goes off.
+     * every time either way. Written only while EXTERNAL_MODERATION_CACHE_PROBE names a namespace
+     * (it is a deployment LABEL, not an on/off flag — empty, or any on/off word, means disabled),
+     * and the value becomes the segment after this prefix so two armed deployments sharing one
+     * sysRedis cannot collide. Every key carries an EX, so the keyspace evaporates on its own once
+     * the probe is disarmed.
      * See src/server/integrations/moderation-cache-probe.ts.
      */
     MODERATION_CACHE_PROBE: 'generation:moderation-cache-probe',

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -614,8 +614,9 @@ export const serverSchema = z
     // and never adds latency to the request (the Redis round trip is fire-and-forget).
     //
     // 🔴 IT IS A NAMESPACE, NOT A BOOLEAN, AND THAT IS THE WHOLE POINT. Set it to a short label for
-    // the deployment being measured — the accepted set is the allowlist named below, currently
-    // `prod`, `next`, `next-stage`; the value becomes a segment of the
+    // the deployment being measured. The accepted set is the allowlist in
+    // moderation-cache-probe.ts and is deliberately NOT restated here — restating it is exactly how
+    // this sentence went stale once already. The value becomes a segment of the
     // probe's Redis key. Several civitai-web deployments SHARE ONE sysRedis, and unlike cache keys
     // — which get an environment prefix via CACHE_KEY_NAMESPACE — sys keys carry no environment
     // segment at all (see cache-key-prefix.ts: "This is CACHE-ONLY"). So two armed deployments

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -607,6 +607,13 @@ export const serverSchema = z
     // ~116-day timeout) re-introduces the unbounded-park failure the deadline exists
     // to prevent. Any out-of-range value falls back to 5000.
     EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).catch(5000),
+    // Dark measurement probe for "would a moderation-result cache pay?". OFF by default and
+    // deliberately so: it ships inert, gets flipped on in config, and the metric's ARMING DATE is
+    // then visible as the instant its series appear — which is the only thing that distinguishes
+    // "no repeats" from "probe never ran". It never changes the verdict, never skips the
+    // classifier, and never adds latency to the request (the Redis round trip is fire-and-forget).
+    // See src/server/integrations/moderation-cache-probe.ts.
+    EXTERNAL_MODERATION_CACHE_PROBE: zc.booleanString.optional().default(false),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -636,12 +636,14 @@ export const serverSchema = z
     // `''` — routing the probe through it would put production and stage in one shared probe
     // keyspace, which is precisely the collision this namespace exists to prevent.
     //
-    // Values are restricted to /^[a-z0-9][a-z0-9-]{0,31}$/ AND rejected if they are an on/off word
-    // (`true`/`false`/`on`/`off`/`yes`/`no`/`0`/`1`/`enabled`/`disabled`) — the charset alone would
-    // happily accept `false` as a namespace, so the most likely way to spell "turn this off" would
-    // ARM the probe. Anything rejected is treated as OFF and logged once, rather than sanitised, so
-    // a typo produces NO SERIES (already documented as "not armed") plus a line saying why, instead
-    // of a second silent keyspace. See src/server/integrations/moderation-cache-probe.ts.
+    // The accepted values are a CLOSED ALLOWLIST of deployment labels, defined in
+    // moderation-cache-probe.ts and deliberately not restated here (one rule, one place). Anything
+    // else — including every on/off spelling — is treated as OFF and logged once, so a typo yields
+    // NO SERIES (already documented as "not armed") plus a line saying why, rather than a second
+    // silent keyspace. An allowlist rather than a charset plus a denylist because a denylist is a
+    // guard SPELLED rather than STRUCTURAL: the charset alone accepts `false`, `n` and `disabled`
+    // as perfectly good namespaces, so the likeliest spelling of "turn this off" would ARM the
+    // probe. See src/server/integrations/moderation-cache-probe.ts.
     EXTERNAL_MODERATION_CACHE_PROBE: z.string().trim().optional().default(''),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -614,7 +614,8 @@ export const serverSchema = z
     // and never adds latency to the request (the Redis round trip is fire-and-forget).
     //
     // 🔴 IT IS A NAMESPACE, NOT A BOOLEAN, AND THAT IS THE WHOLE POINT. Set it to a short label for
-    // the deployment being measured (`prod`, `next`, `stage`); the value becomes a segment of the
+    // the deployment being measured — the accepted set is the allowlist named below, currently
+    // `prod`, `next`, `next-stage`; the value becomes a segment of the
     // probe's Redis key. Several civitai-web deployments SHARE ONE sysRedis, and unlike cache keys
     // — which get an environment prefix via CACHE_KEY_NAMESPACE — sys keys carry no environment
     // segment at all (see cache-key-prefix.ts: "This is CACHE-ONLY"). So two armed deployments

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -622,15 +622,26 @@ export const serverSchema = z
     // the result toward "caching pays" — the direction that gets a cache built that does not pay.
     //
     // Making the namespace the ARMING SWITCH is what stops that being a thing to remember: there is
-    // no way to turn the probe on without naming a keyspace for it. A separate namespace variable
-    // could be left unset while the probe ran, which is exactly how CACHE_KEY_NAMESPACE behaves in
-    // practice — measured 2026-09-03, it is ABSENT on all of civitai-dp-prod, civitai-next and
-    // civitai-next-stage, including the deployment its own doc says should set it. A fix routed
-    // through it would have been inert while looking like a fix.
+    // no way to turn the probe on without naming a keyspace for it.
     //
-    // Values are restricted to /^[a-z0-9][a-z0-9-]{0,31}$/; anything else is treated as OFF rather
-    // than sanitised, so a typo produces NO SERIES (loud, and already documented as "not armed")
-    // instead of a second silent keyspace. See src/server/integrations/moderation-cache-probe.ts.
+    // ⚠️ WHY NOT REUSE CACHE_KEY_NAMESPACE — corrected 2026-09-03, because the first version of this
+    // comment asserted a measurement that was FALSE. It claimed that variable is "ABSENT on all of
+    // civitai-dp-prod, civitai-next and civitai-next-stage". It is not: `CACHE_KEY_NAMESPACE=next`
+    // is set on civitai-next (in the deployment env, which the original check never read — it
+    // looked only at ConfigMaps and generalised one source into a claim about all of them).
+    //
+    // The real reason it cannot serve here is the opposite of "nobody sets it": it is set EXACTLY
+    // as designed, and its design is wrong for this purpose. cache-key-prefix.ts requires
+    // production to be the EMPTY prefix, so civitai-dp-prod and civitai-next-stage BOTH resolve to
+    // `''` — routing the probe through it would put production and stage in one shared probe
+    // keyspace, which is precisely the collision this namespace exists to prevent.
+    //
+    // Values are restricted to /^[a-z0-9][a-z0-9-]{0,31}$/ AND rejected if they are an on/off word
+    // (`true`/`false`/`on`/`off`/`yes`/`no`/`0`/`1`/`enabled`/`disabled`) — the charset alone would
+    // happily accept `false` as a namespace, so the most likely way to spell "turn this off" would
+    // ARM the probe. Anything rejected is treated as OFF and logged once, rather than sanitised, so
+    // a typo produces NO SERIES (already documented as "not armed") plus a line saying why, instead
+    // of a second silent keyspace. See src/server/integrations/moderation-cache-probe.ts.
     EXTERNAL_MODERATION_CACHE_PROBE: z.string().trim().optional().default(''),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -607,13 +607,31 @@ export const serverSchema = z
     // ~116-day timeout) re-introduces the unbounded-park failure the deadline exists
     // to prevent. Any out-of-range value falls back to 5000.
     EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).catch(5000),
-    // Dark measurement probe for "would a moderation-result cache pay?". OFF by default and
-    // deliberately so: it ships inert, gets flipped on in config, and the metric's ARMING DATE is
-    // then visible as the instant its series appear — which is the only thing that distinguishes
-    // "no repeats" from "probe never ran". It never changes the verdict, never skips the
-    // classifier, and never adds latency to the request (the Redis round trip is fire-and-forget).
-    // See src/server/integrations/moderation-cache-probe.ts.
-    EXTERNAL_MODERATION_CACHE_PROBE: zc.booleanString.optional().default(false),
+    // Dark measurement probe for "would a moderation-result cache pay?". Empty/unset = OFF, and
+    // deliberately so: it ships inert, gets armed in config, and the metric's ARMING DATE is then
+    // visible as the instant its series appear — which is the only thing that distinguishes "no
+    // repeats" from "probe never ran". It never changes the verdict, never skips the classifier,
+    // and never adds latency to the request (the Redis round trip is fire-and-forget).
+    //
+    // 🔴 IT IS A NAMESPACE, NOT A BOOLEAN, AND THAT IS THE WHOLE POINT. Set it to a short label for
+    // the deployment being measured (`prod`, `next`, `stage`); the value becomes a segment of the
+    // probe's Redis key. Several civitai-web deployments SHARE ONE sysRedis, and unlike cache keys
+    // — which get an environment prefix via CACHE_KEY_NAMESPACE — sys keys carry no environment
+    // segment at all (see cache-key-prefix.ts: "This is CACHE-ONLY"). So two armed deployments
+    // would write the same probe keyspace and each would score HITS on the other's prompts, biasing
+    // the result toward "caching pays" — the direction that gets a cache built that does not pay.
+    //
+    // Making the namespace the ARMING SWITCH is what stops that being a thing to remember: there is
+    // no way to turn the probe on without naming a keyspace for it. A separate namespace variable
+    // could be left unset while the probe ran, which is exactly how CACHE_KEY_NAMESPACE behaves in
+    // practice — measured 2026-09-03, it is ABSENT on all of civitai-dp-prod, civitai-next and
+    // civitai-next-stage, including the deployment its own doc says should set it. A fix routed
+    // through it would have been inert while looking like a fix.
+    //
+    // Values are restricted to /^[a-z0-9][a-z0-9-]{0,31}$/; anything else is treated as OFF rather
+    // than sanitised, so a typo produces NO SERIES (loud, and already documented as "not armed")
+    // instead of a second silent keyspace. See src/server/integrations/moderation-cache-probe.ts.
+    EXTERNAL_MODERATION_CACHE_PROBE: z.string().trim().optional().default(''),
     BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
     MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -130,6 +130,7 @@ describe('cache probe — the flag is the arming switch', () => {
     // DO land in this window, so the flag-off leg finding none is evidence.
     installRedisFake();
     stubFetchOk();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
@@ -142,6 +143,14 @@ describe('cache probe — the flag is the arming switch', () => {
 
     expect(await probeTotal()).toBe(2);
     expect(redisMock.sysRedis.set.mock.calls.length).toBe(redisCallsWhileOn);
+    // 🔴 SHIPPING INERT MUST ALSO MEAN SHIPPING SILENT, and without this assertion the empty-string
+    // early return is untested: delete it and the probe is STILL off (the charset pattern rejects
+    // '' anyway), so every other case here stays green — a mutant removing it SURVIVED. What it
+    // actually buys is that a DELIBERATELY unarmed deployment — which today is every deployment —
+    // does not log a misconfiguration error on every single generation.
+    expect(
+      errorSpy.mock.calls.filter((c) => String(c[0]).includes('moderation-cache-probe'))
+    ).toHaveLength(0);
   });
 
   it('POSITIVE CONTROL: the identical call with the flag ON does record', async () => {
@@ -388,6 +397,59 @@ describe('cache probe — the namespace IS the arming switch', () => {
 
     expect(await probeCount('generate', '5m', 'miss')).toBe(2);
     expect(await probeCount('generate', '5m', 'hit')).toBe(0);
+  });
+
+  it('an ON/OFF WORD never arms the probe, however the operator spells it', async () => {
+    // 🔴 THE HIGHEST-RISK VALUE, and the charset alone accepts every one of these as a perfectly
+    // good namespace. This variable was a boolean one commit ago, so `=false` is the PREVIOUS
+    // contract's spelling for "off" and the likeliest thing an operator writes. Without this guard
+    // it would ARM the probe under a namespace literally called `false` — and two deployments
+    // "disabled" that way would share the keyspace `…:false:…` and score hits on each other's
+    // prompts, which is the exact collision the namespace exists to prevent.
+    installRedisFake();
+    stubFetchOk();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilProbeTotal(2);
+
+    for (const word of [
+      'true',
+      'false',
+      'on',
+      'off',
+      'yes',
+      'no',
+      '0',
+      '1',
+      'enabled',
+      'disabled',
+    ]) {
+      env.EXTERNAL_MODERATION_CACHE_PROBE = word;
+      await extModeration.moderatePrompt(`prompt for ${word}`, 'generate');
+    }
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await probeTotal()).toBe(2);
+  });
+
+  it('logs once per distinct bad value, so a misconfiguration is findable but not a per-call flood', async () => {
+    // The previous boolean spelling failed boot loudly on garbage; a rejected namespace is
+    // otherwise completely silent, which would leave an operator staring at an absent metric with
+    // no way to tell "armed, no repeats" from "my value was rejected".
+    installRedisFake();
+    stubFetchOk();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'NOT-VALID';
+    await extModeration.moderatePrompt('one', 'generate');
+    await extModeration.moderatePrompt('two', 'generate');
+    await extModeration.moderatePrompt('three', 'generate');
+
+    const forThisValue = spy.mock.calls.filter((c) => String(c[0]).includes('NOT-VALID'));
+    expect(forThisValue).toHaveLength(1);
+    expect(String(forThisValue[0][0])).toContain('is DISABLED');
   });
 
   it('an out-of-charset namespace is treated as OFF, not sanitised', async () => {

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -29,14 +29,17 @@ const env = vi.hoisted(() => ({
   EXTERNAL_MODERATION_THRESHOLD: 0.5,
   EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
   EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
-  EXTERNAL_MODERATION_CACHE_PROBE: 'next' as string,
+  EXTERNAL_MODERATION_CACHE_PROBE: 'prod' as string,
 }));
 vi.mock('~/env/server', () => ({ env }));
 
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
-import { probeModerationCacheRepeat } from '~/server/integrations/moderation-cache-probe';
+import {
+  PROBE_NAMESPACES,
+  probeModerationCacheRepeat,
+} from '~/server/integrations/moderation-cache-probe';
 
 const PROBE = 'civitai_app_external_moderation_cache_probe_total';
 const HIST = 'civitai_app_external_moderation_duration_seconds';
@@ -105,7 +108,7 @@ async function untilProbeTotal(n: number) {
 beforeEach(() => {
   promClient.register.getSingleMetric(PROBE)?.reset();
   promClient.register.getSingleMetric(HIST)?.reset();
-  env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
+  env.EXTERNAL_MODERATION_CACHE_PROBE = 'prod';
   // 🔴 `resetSharedMocks()` in src/__tests__/setup.ts runs once PER FILE, not per test, so
   // `sysRedis.set`'s call history accumulates across every case here. Without this, the
   // `not.toHaveBeenCalled()` assertion in the flag-off case passes only because it happens to run
@@ -132,7 +135,7 @@ describe('cache probe — the flag is the arming switch', () => {
     stubFetchOk();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'prod';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
     const redisCallsWhileOn = redisMock.sysRedis.set.mock.calls.length;
@@ -367,39 +370,80 @@ describe('cache probe — label bounds', () => {
 });
 
 describe('cache probe — the namespace IS the arming switch', () => {
-  it('writes the configured namespace into the key, so two armed deployments cannot collide', async () => {
-    // 🔴 WHY THIS MATTERS: several civitai-web deployments share ONE sysRedis, and sys keys carry
-    // no environment segment (cache-key-prefix.ts: "This is CACHE-ONLY"). Two armed deployments on
-    // one keyspace would each score HITS on the other's prompts, biasing the answer toward
-    // "caching pays" — the direction that gets a cache built that does not pay.
+  it('gives the namespace its own key SEGMENT, so a second member could never share a keyspace', async () => {
+    // 🔴 WHY A NAMESPACE SEGMENT EXISTS AT ALL: several civitai-web deployments share ONE sysRedis,
+    // and sys keys carry no environment segment (cache-key-prefix.ts: "This is CACHE-ONLY"). Two
+    // armed deployments on one keyspace would each score HITS on the other's prompts, biasing the
+    // answer toward "caching pays" — the direction that gets a cache built that does not pay.
+    //
+    // ⚠️ THIS USED TO BE A TWO-NAMESPACE BEHAVIOURAL TEST and cannot be any more: audit round 5
+    // reduced the allowlist to a single member, so "the same prompt under a different namespace"
+    // is a scenario config can no longer reach. That is a STRONGER guarantee than the test it
+    // replaces, not a weaker one — but the segment stays in the key as defence-in-depth for a
+    // future second member, so what is still assertable is its SHAPE.
+    //
+    // Asserting the segment COUNT and POSITION rather than just `startsWith` is what keeps this
+    // from passing when the namespace is appended somewhere that does not separate keyspaces —
+    // the mutant that drops `${namespace}:` from the template yields one segment fewer and dies.
     installRedisFake();
     stubFetchOk();
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
 
     await extModeration.moderatePrompt('a serene landscape', 'generate');
     await untilProbeTotal(2);
 
     const keys = (redisMock.sysRedis.set.mock.calls as [string][]).map(([k]) => k);
     expect(keys).toHaveLength(2);
-    expect(keys.every((k) => k.startsWith('generation:moderation-cache-probe:next:'))).toBe(true);
+    for (const key of keys) {
+      // generation:moderation-cache-probe : <namespace> : <window> : <digest>
+      const [prefix, namespace, window, digest, ...rest] = key.split(':').slice(1);
+      expect(`generation:${prefix}`).toBe('generation:moderation-cache-probe');
+      expect(namespace).toBe('prod');
+      expect(['5m', '1h']).toContain(window);
+      expect(digest).toMatch(/^[0-9a-f]{32}$/);
+      expect(rest).toEqual([]);
+    }
+    expect(new Set(keys).size).toBe(2);
   });
 
-  it('the SAME prompt under a DIFFERENT namespace is a miss, not a hit', async () => {
-    // The behavioural half of the case above: a structural `startsWith` assertion would still pass
-    // if the namespace were appended somewhere that does not separate the keyspaces.
+  it('pins the allowlist MEMBERSHIP as a ledger — asserted whole, so growth fails too', async () => {
+    // 🔴 ASSERT THE SET ITSELF, NOT A LOOP OVER CANDIDATES I THOUGHT OF. The first version of this
+    // case probed four hardcoded candidates and claimed to fail "whether the set GROWS or SHRINKS".
+    // Half true, and audit round 5 measured it: adding `'staging'` to the allowlist SURVIVED 21/21,
+    // because a loop can only see growth by a member already in its own list. Comparing the whole
+    // normalised set to a literal is what closes the growth direction for any member at all.
+    expect([...PROBE_NAMESPACES].sort()).toEqual(['prod']);
+  });
+
+  it('every allowlist member arms, and the three removed ones do not', async () => {
+    // 🔴 THE BEHAVIOURAL HALF. The structural assertion above type-checks past a set whose members
+    // do not actually arm anything, so this drives each candidate through the real path.
+    //
+    // `preview`, `next` and `next-stage` are asserted ABSENT rather than merely omitted — each was
+    // a member at some point and each was removed for a measured reason (a shared preview keyspace,
+    // a ConfigMap the preview pipeline clones wholesale, and a deployment nothing scrapes). Someone
+    // will eventually try to add one back as an obvious convenience; this is what stops it being
+    // quiet.
     installRedisFake();
     stubFetchOk();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'prod';
-    await extModeration.moderatePrompt('a serene landscape', 'generate');
-    await untilProbeTotal(2);
+    const armed: string[] = [];
+    for (const candidate of ['prod', 'next', 'next-stage', 'preview']) {
+      promClient.register.getSingleMetric(PROBE)?.reset();
+      env.EXTERNAL_MODERATION_CACHE_PROBE = candidate;
+      await extModeration.moderatePrompt(`a prompt for ${candidate}`, 'generate');
+      await new Promise((r) => setTimeout(r, 150));
+      if ((await probeTotal()) > 0) armed.push(candidate);
+    }
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
-    await extModeration.moderatePrompt('a serene landscape', 'generate');
-    await untilProbeTotal(4);
-
-    expect(await probeCount('generate', '5m', 'miss')).toBe(2);
-    expect(await probeCount('generate', '5m', 'hit')).toBe(0);
+    expect(armed).toEqual(['prod']);
+    // The removed ones must be rejected LOUDLY, i.e. through the same path as any other unknown
+    // value — not silently, which is reserved for the deliberately-empty case.
+    for (const removed of ['next', 'next-stage', 'preview']) {
+      expect(errorSpy.mock.calls.filter((c) => String(c[0]).includes(`"${removed}"`))).toHaveLength(
+        1
+      );
+    }
   });
 
   it('no off-ish spelling arms the probe, including the ones a denylist would miss', async () => {
@@ -418,7 +462,7 @@ describe('cache probe — the namespace IS the arming switch', () => {
     stubFetchOk();
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'prod';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
 
@@ -474,39 +518,6 @@ describe('cache probe — the namespace IS the arming switch', () => {
     expect(String(forThisValue[0][0])).toContain('is DISABLED');
   });
 
-  it('pins the allowlist MEMBERSHIP — every member arms, and `preview` deliberately does not', async () => {
-    // 🔴 AN ASSERTED LEDGER, FAILING WHETHER THE SET GROWS OR SHRINKS. The allowlist is now the
-    // entire arming contract, and before this case only 2 of its members were exercised anywhere —
-    // audit round 4 measured that deleting `next-stage` left all 20 cases GREEN. A rebase, a
-    // "one rule one place" tidy, or a non-ASCII hyphen in `next‑stage` would then silently stop
-    // that deployment from ever arming, and the failure surfaces only as an absent series, which
-    // the help text tells the reader means "not armed".
-    //
-    // 🔴 `preview` is asserted ABSENT, not merely omitted. It was a member until round 4, and it
-    // defeats the invariant the allowlist exists to enforce: ~10 concurrent PR-preview namespaces
-    // take their config from one shared template and share one sysRedis, so arming that word arms
-    // all of them into a single keyspace and they score mutual hits across unrelated PRs. Someone
-    // will eventually try to add it back as an obvious convenience; this is what stops it being
-    // quiet.
-    installRedisFake();
-    stubFetchOk();
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-
-    const armed: string[] = [];
-    for (const candidate of ['prod', 'next', 'next-stage', 'preview']) {
-      promClient.register.getSingleMetric(PROBE)?.reset();
-      env.EXTERNAL_MODERATION_CACHE_PROBE = candidate;
-      await extModeration.moderatePrompt(`a prompt for ${candidate}`, 'generate');
-      await new Promise((r) => setTimeout(r, 150));
-      if ((await probeTotal()) > 0) armed.push(candidate);
-    }
-
-    expect(armed).toEqual(['prod', 'next', 'next-stage']);
-    // `preview` must be rejected LOUDLY, i.e. through the same path as any other unknown value —
-    // not silently, which is reserved for the deliberately-empty case.
-    expect(errorSpy.mock.calls.filter((c) => String(c[0]).includes('"preview"'))).toHaveLength(1);
-  });
-
   it('an unknown namespace is treated as OFF, not sanitised', async () => {
     // A typo must produce NO SERIES — which the help text already tells the reader means "not
     // armed" — rather than quietly opening a second keyspace that looks armed and measures a
@@ -516,7 +527,7 @@ describe('cache probe — the namespace IS the arming switch', () => {
 
     // Warm the lazy import with a valid namespace first, so the absence below is evidence and not
     // an insufficient wait (same reasoning as the flag-off case).
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'prod';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
 

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -37,6 +37,7 @@ import { redisMock } from '~/__tests__/mocks/redis.mock';
 import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
 import {
+  buildProbeKey,
   PROBE_NAMESPACES,
   probeModerationCacheRepeat,
 } from '~/server/integrations/moderation-cache-probe';
@@ -376,11 +377,17 @@ describe('cache probe — the namespace IS the arming switch', () => {
     // armed deployments on one keyspace would each score HITS on the other's prompts, biasing the
     // answer toward "caching pays" — the direction that gets a cache built that does not pay.
     //
-    // ⚠️ THIS USED TO BE A TWO-NAMESPACE BEHAVIOURAL TEST and cannot be any more: audit round 5
-    // reduced the allowlist to a single member, so "the same prompt under a different namespace"
-    // is a scenario config can no longer reach. That is a STRONGER guarantee than the test it
-    // replaces, not a weaker one — but the segment stays in the key as defence-in-depth for a
-    // future second member, so what is still assertable is its SHAPE.
+    // ⚠️ THIS USED TO BE A TWO-NAMESPACE BEHAVIOURAL TEST and cannot be driven through config any
+    // more: audit round 5 reduced the allowlist to a single member, so "the same prompt under a
+    // different namespace" is a scenario config cannot reach.
+    //
+    // 🔴 AN EARLIER REVISION CALLED THAT "A STRONGER GUARANTEE … NOT A WEAKER ONE". That was FALSE,
+    // and audit round 6 measured it: with one member, `namespace` is always `'prod'`, so a mutant
+    // replacing `${namespace}` with the literal `prod` is indistinguishable from the real thing and
+    // SURVIVED this shape assertion — the same mutant two cases killed one commit earlier. Coverage
+    // for the segment that keeps two deployments apart had silently gone to zero.
+    // The kill is restored by the separate `buildProbeKey` case below, which takes the namespace as
+    // an argument. This case still pins the shape, which is worth having on its own.
     //
     // Asserting the segment COUNT and POSITION rather than just `startsWith` is what keeps this
     // from passing when the namespace is appended somewhere that does not separate keyspaces —
@@ -405,6 +412,23 @@ describe('cache probe — the namespace IS the arming switch', () => {
     expect(new Set(keys).size).toBe(2);
   });
 
+  it('DERIVES the namespace segment from its argument — the kill the shape assertion cannot make', async () => {
+    // 🔴 THE ONLY CASE IN THIS FILE THAT CAN SEE A HARDCODED NAMESPACE. Everything else runs through
+    // config, where the allowlist admits exactly one value, so `namespace` is always `'prod'` and a
+    // literal `prod` in the key template looks identical to the real derivation. Passing two
+    // different namespaces to the pure builder is what makes the difference observable.
+    expect(buildProbeKey('p', 'alpha', '5m', 'deadbeef')).toBe('p:alpha:5m:deadbeef');
+    expect(buildProbeKey('p', 'beta', '5m', 'deadbeef')).toBe('p:beta:5m:deadbeef');
+    // The property that actually matters, stated as a property rather than as two literals: two
+    // namespaces must never produce the same key for the same prompt and window.
+    expect(buildProbeKey('p', 'alpha', '5m', 'd')).not.toBe(buildProbeKey('p', 'beta', '5m', 'd'));
+    // …and the other three segments must each be derived too, or a mutant could hardcode one of
+    // them and still pass the pair above.
+    expect(buildProbeKey('q', 'a', '5m', 'd')).not.toBe(buildProbeKey('p', 'a', '5m', 'd'));
+    expect(buildProbeKey('p', 'a', '1h', 'd')).not.toBe(buildProbeKey('p', 'a', '5m', 'd'));
+    expect(buildProbeKey('p', 'a', '5m', 'e')).not.toBe(buildProbeKey('p', 'a', '5m', 'd'));
+  });
+
   it('pins the allowlist MEMBERSHIP as a ledger — asserted whole, so growth fails too', async () => {
     // 🔴 ASSERT THE SET ITSELF, NOT A LOOP OVER CANDIDATES I THOUGHT OF. The first version of this
     // case probed four hardcoded candidates and claimed to fail "whether the set GROWS or SHRINKS".
@@ -412,6 +436,9 @@ describe('cache probe — the namespace IS the arming switch', () => {
     // because a loop can only see growth by a member already in its own list. Comparing the whole
     // normalised set to a literal is what closes the growth direction for any member at all.
     expect([...PROBE_NAMESPACES].sort()).toEqual(['prod']);
+    // Frozen at runtime, not merely `ReadonlySet`-typed — that type is erased and an importer
+    // could otherwise `.add()` an arbitrary namespace into the object `probeNamespace` reads.
+    expect(Object.isFrozen(PROBE_NAMESPACES)).toBe(true);
   });
 
   it('every allowlist member arms, and the three removed ones do not', async () => {
@@ -447,15 +474,15 @@ describe('cache probe — the namespace IS the arming switch', () => {
   });
 
   it('no off-ish spelling arms the probe, including the ones a denylist would miss', async () => {
-    // 🔴 THE HIGHEST-RISK VALUES. This variable was a boolean two commits ago, so `=false` is the
+    // 🔴 THE HIGHEST-RISK VALUES. This variable was a boolean until audit round 1, so `=false` is the
     // PREVIOUS contract's spelling for "off" and the likeliest thing an operator writes. Under a
     // charset-plus-denylist guard it would ARM the probe under a namespace literally called
     // `false`, and two deployments "disabled" that way would share `…:false:…` and score hits on
     // each other's prompts — the exact collision the namespace exists to prevent.
     //
     // 🔴 THE SECOND HALF OF THIS LIST IS THE POINT. `y`, `n`, `none`, `null`, `undefined`, `nil`,
-    // `disable`, `enable` and `2` all passed the charset AND the ten-word denylist that shipped one
-    // commit ago — audit round 3 enumerated them. `y`/`n` are not exotic: zod's own `stringbool`
+    // `disable`, `enable` and `2` all passed the charset AND the ten-word denylist that audit
+    // round 2 introduced — audit round 3 enumerated them. `y`/`n` are not exotic: zod's own `stringbool`
     // treats them as boolean spellings. That is why the guard is now a closed ALLOWLIST rather than
     // a denylist: a list of forbidden members can only ever forbid the members someone thought of.
     installRedisFake();

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -454,9 +454,12 @@ describe('cache probe — the namespace IS the arming switch', () => {
   });
 
   it('logs once per distinct bad value, so a misconfiguration is findable but not a per-call flood', async () => {
-    // The previous boolean spelling failed boot loudly on garbage; a rejected namespace is
-    // otherwise completely silent, which would leave an operator staring at an absent metric with
-    // no way to tell "armed, no repeats" from "my value was rejected".
+    // A rejected namespace is otherwise completely silent, which would leave an operator staring
+    // at an absent metric with no way to tell "armed, no repeats" from "my value was rejected".
+    //
+    // ⚠️ NOT because the previous boolean spelling "failed boot loudly on garbage" — that sentence
+    // was here for two commits and it is false. `zc.booleanString` preprocesses every input to a
+    // boolean, so it never threw on anything; the old contract swallowed garbage silently too.
     installRedisFake();
     stubFetchOk();
     const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -469,6 +472,39 @@ describe('cache probe — the namespace IS the arming switch', () => {
     const forThisValue = spy.mock.calls.filter((c) => String(c[0]).includes('NOT-VALID'));
     expect(forThisValue).toHaveLength(1);
     expect(String(forThisValue[0][0])).toContain('is DISABLED');
+  });
+
+  it('pins the allowlist MEMBERSHIP — every member arms, and `preview` deliberately does not', async () => {
+    // 🔴 AN ASSERTED LEDGER, FAILING WHETHER THE SET GROWS OR SHRINKS. The allowlist is now the
+    // entire arming contract, and before this case only 2 of its members were exercised anywhere —
+    // audit round 4 measured that deleting `next-stage` left all 20 cases GREEN. A rebase, a
+    // "one rule one place" tidy, or a non-ASCII hyphen in `next‑stage` would then silently stop
+    // that deployment from ever arming, and the failure surfaces only as an absent series, which
+    // the help text tells the reader means "not armed".
+    //
+    // 🔴 `preview` is asserted ABSENT, not merely omitted. It was a member until round 4, and it
+    // defeats the invariant the allowlist exists to enforce: ~10 concurrent PR-preview namespaces
+    // take their config from one shared template and share one sysRedis, so arming that word arms
+    // all of them into a single keyspace and they score mutual hits across unrelated PRs. Someone
+    // will eventually try to add it back as an obvious convenience; this is what stops it being
+    // quiet.
+    installRedisFake();
+    stubFetchOk();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const armed: string[] = [];
+    for (const candidate of ['prod', 'next', 'next-stage', 'preview']) {
+      promClient.register.getSingleMetric(PROBE)?.reset();
+      env.EXTERNAL_MODERATION_CACHE_PROBE = candidate;
+      await extModeration.moderatePrompt(`a prompt for ${candidate}`, 'generate');
+      await new Promise((r) => setTimeout(r, 150));
+      if ((await probeTotal()) > 0) armed.push(candidate);
+    }
+
+    expect(armed).toEqual(['prod', 'next', 'next-stage']);
+    // `preview` must be rejected LOUDLY, i.e. through the same path as any other unknown value —
+    // not silently, which is reserved for the deliberately-empty case.
+    expect(errorSpy.mock.calls.filter((c) => String(c[0]).includes('"preview"'))).toHaveLength(1);
   });
 
   it('an unknown namespace is treated as OFF, not sanitised', async () => {

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -29,13 +29,14 @@ const env = vi.hoisted(() => ({
   EXTERNAL_MODERATION_THRESHOLD: 0.5,
   EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
   EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
-  EXTERNAL_MODERATION_CACHE_PROBE: true,
+  EXTERNAL_MODERATION_CACHE_PROBE: 'testns' as string,
 }));
 vi.mock('~/env/server', () => ({ env }));
 
 import { redisMock } from '~/__tests__/mocks/redis.mock';
 import { serverSchema } from '~/env/server-schema';
 import { extModeration } from '~/server/integrations/moderation';
+import { probeModerationCacheRepeat } from '~/server/integrations/moderation-cache-probe';
 
 const PROBE = 'civitai_app_external_moderation_cache_probe_total';
 const HIST = 'civitai_app_external_moderation_duration_seconds';
@@ -104,7 +105,7 @@ async function untilProbeTotal(n: number) {
 beforeEach(() => {
   promClient.register.getSingleMetric(PROBE)?.reset();
   promClient.register.getSingleMetric(HIST)?.reset();
-  env.EXTERNAL_MODERATION_CACHE_PROBE = true;
+  env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
   // 🔴 `resetSharedMocks()` in src/__tests__/setup.ts runs once PER FILE, not per test, so
   // `sysRedis.set`'s call history accumulates across every case here. Without this, the
   // `not.toHaveBeenCalled()` assertion in the flag-off case passes only because it happens to run
@@ -130,12 +131,12 @@ describe('cache probe — the flag is the arming switch', () => {
     installRedisFake();
     stubFetchOk();
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = true;
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
     const redisCallsWhileOn = redisMock.sysRedis.set.mock.calls.length;
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = false;
+    env.EXTERNAL_MODERATION_CACHE_PROBE = '';
     await extModeration.moderatePrompt('an entirely different prompt', 'generate');
     await new Promise((r) => setTimeout(r, 200));
 
@@ -301,6 +302,23 @@ describe('cache probe — label bounds', () => {
     expect(await probeCount('not-a-real-source', '5m', 'miss')).toBe(0);
   });
 
+  it('clamps when called DIRECTLY, not only through moderatePrompt', async () => {
+    // 🔴 THE CASE ABOVE DOES NOT TEST THE PROBE'S OWN CLAMP. `moderatePrompt` clamps first and
+    // passes the clamped value, so the probe's `clampExternalModerationSource` never sees a bad
+    // string on that path — an audit mutant that DELETED the probe's clamp survived a green 14-case
+    // suite. `probeModerationCacheRepeat` is exported, so a future direct caller (or a helper in
+    // the test tree, which tsconfig.json excludes) can reach it with a widened `string`, and an
+    // unbounded value on a hot-path prom label is a cardinality incident with no error anywhere.
+    // This drives the exported function directly, which is the only way to exercise that guard.
+    installRedisFake();
+
+    probeModerationCacheRepeat('not-a-real-source' as never, 'a serene landscape');
+
+    await untilProbeTotal(2);
+    expect(await probeCount('other', '5m', 'miss')).toBe(1);
+    expect(await probeCount('not-a-real-source', '5m', 'miss')).toBe(0);
+  });
+
   it('emits exactly two observations per call — one per window, never more', async () => {
     installRedisFake();
     stubFetchOk();
@@ -336,13 +354,72 @@ describe('cache probe — label bounds', () => {
   });
 });
 
+describe('cache probe — the namespace IS the arming switch', () => {
+  it('writes the configured namespace into the key, so two armed deployments cannot collide', async () => {
+    // 🔴 WHY THIS MATTERS: several civitai-web deployments share ONE sysRedis, and sys keys carry
+    // no environment segment (cache-key-prefix.ts: "This is CACHE-ONLY"). Two armed deployments on
+    // one keyspace would each score HITS on the other's prompts, biasing the answer toward
+    // "caching pays" — the direction that gets a cache built that does not pay.
+    installRedisFake();
+    stubFetchOk();
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(2);
+
+    const keys = (redisMock.sysRedis.set.mock.calls as [string][]).map(([k]) => k);
+    expect(keys).toHaveLength(2);
+    expect(keys.every((k) => k.startsWith('generation:moderation-cache-probe:next:'))).toBe(true);
+  });
+
+  it('the SAME prompt under a DIFFERENT namespace is a miss, not a hit', async () => {
+    // The behavioural half of the case above: a structural `startsWith` assertion would still pass
+    // if the namespace were appended somewhere that does not separate the keyspaces.
+    installRedisFake();
+    stubFetchOk();
+
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'prod';
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(2);
+
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(4);
+
+    expect(await probeCount('generate', '5m', 'miss')).toBe(2);
+    expect(await probeCount('generate', '5m', 'hit')).toBe(0);
+  });
+
+  it('an out-of-charset namespace is treated as OFF, not sanitised', async () => {
+    // A typo must produce NO SERIES — which the help text already tells the reader means "not
+    // armed" — rather than quietly opening a second keyspace that looks armed and measures a
+    // fiction. Sanitising would silently map two distinct typos onto one namespace.
+    installRedisFake();
+    stubFetchOk();
+
+    // Warm the lazy import with a valid namespace first, so the absence below is evidence and not
+    // an insufficient wait (same reasoning as the flag-off case).
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilProbeTotal(2);
+
+    for (const bad of ['Prod', 'has space', 'has:colon', '-leading', 'x'.repeat(33)]) {
+      env.EXTERNAL_MODERATION_CACHE_PROBE = bad;
+      await extModeration.moderatePrompt(`prompt for ${bad}`, 'generate');
+    }
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await probeTotal()).toBe(2);
+  });
+});
+
 describe('cache probe — env schema', () => {
-  it('defaults to OFF, so the code ships inert and the arming instant is readable', () => {
+  it('defaults to EMPTY, so the code ships inert and the arming instant is readable', () => {
     const parsed = serverSchema.safeParse({});
     // The schema has many required keys; only this field's default is under test.
     const value = parsed.success
       ? parsed.data.EXTERNAL_MODERATION_CACHE_PROBE
       : serverSchema.shape.EXTERNAL_MODERATION_CACHE_PROBE.parse(undefined);
-    expect(value).toBe(false);
+    expect(value).toBe('');
   });
 });

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -417,6 +417,11 @@ describe('cache probe — the namespace IS the arming switch', () => {
     // config, where the allowlist admits exactly one value, so `namespace` is always `'prod'` and a
     // literal `prod` in the key template looks identical to the real derivation. Passing two
     // different namespaces to the pure builder is what makes the difference observable.
+    //
+    // ⚠️ AND IT COVERS THE FUNCTION, NOT THE CALL SITE. Audit round 7 measured that hardcoding the
+    // third ARGUMENT in `runProbe` still leaves this suite green — the same defect one level up,
+    // unreachable by any test driven through config while the allowlist has one member. Recorded
+    // rather than papered over; see the note on `buildProbeKey`.
     expect(buildProbeKey('p', 'alpha', '5m', 'deadbeef')).toBe('p:alpha:5m:deadbeef');
     expect(buildProbeKey('p', 'beta', '5m', 'deadbeef')).toBe('p:beta:5m:deadbeef');
     // The property that actually matters, stated as a property rather than as two literals: two
@@ -441,7 +446,7 @@ describe('cache probe — the namespace IS the arming switch', () => {
     expect(Object.isFrozen(PROBE_NAMESPACES)).toBe(true);
   });
 
-  it('every allowlist member arms, and the three removed ones do not', async () => {
+  it('exactly the declared members arm — every realistic non-member is rejected', async () => {
     // 🔴 THE BEHAVIOURAL HALF. The structural assertion above type-checks past a set whose members
     // do not actually arm anything, so this drives each candidate through the real path.
     //
@@ -454,8 +459,25 @@ describe('cache probe — the namespace IS the arming switch', () => {
     stubFetchOk();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
+    // 🔴 CANDIDATES = THE DECLARED MEMBERS PLUS REALISTIC NON-MEMBERS, and the expectation is
+    // DERIVED from the export rather than written out. That is what makes this catch a predicate
+    // that consults something OTHER than the declared list: audit round 7 found that when the
+    // allowlist was stored twice, growing only the consulted copy armed a new namespace while the
+    // ledger kept asserting the old one. The two objects are one again, but a predicate can still
+    // diverge from its declaration by other means, and a hardcoded expectation here could not see
+    // it. `staging`/`dev`/`test`/`stage` are the values someone would most plausibly add.
     const armed: string[] = [];
-    for (const candidate of ['prod', 'next', 'next-stage', 'preview']) {
+    const candidates = [
+      ...PROBE_NAMESPACES,
+      'next',
+      'next-stage',
+      'preview',
+      'staging',
+      'dev',
+      'test',
+      'stage',
+    ];
+    for (const candidate of candidates) {
       promClient.register.getSingleMetric(PROBE)?.reset();
       env.EXTERNAL_MODERATION_CACHE_PROBE = candidate;
       await extModeration.moderatePrompt(`a prompt for ${candidate}`, 'generate');
@@ -463,7 +485,7 @@ describe('cache probe — the namespace IS the arming switch', () => {
       if ((await probeTotal()) > 0) armed.push(candidate);
     }
 
-    expect(armed).toEqual(['prod']);
+    expect(armed).toEqual([...PROBE_NAMESPACES]);
     // The removed ones must be rejected LOUDLY, i.e. through the same path as any other unknown
     // value — not silently, which is reserved for the deliberately-empty case.
     for (const removed of ['next', 'next-stage', 'preview']) {
@@ -543,6 +565,13 @@ describe('cache probe — the namespace IS the arming switch', () => {
     const forThisValue = spy.mock.calls.filter((c) => String(c[0]).includes('NOT-VALID'));
     expect(forThisValue).toHaveLength(1);
     expect(String(forThisValue[0][0])).toContain('is DISABLED');
+    // The message names the accepted values by rendering the allowlist. Nothing asserted that, so a
+    // mutant emptying or mis-joining it would leave the operator a message that says "set it to one
+    // of those" and then lists nothing.
+    for (const member of PROBE_NAMESPACES) {
+      expect(String(forThisValue[0][0])).toContain(member);
+    }
+    expect(String(forThisValue[0][0])).toContain(PROBE_NAMESPACES.join(', '));
   });
 
   it('an unknown namespace is treated as OFF, not sanitised', async () => {

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -29,7 +29,7 @@ const env = vi.hoisted(() => ({
   EXTERNAL_MODERATION_THRESHOLD: 0.5,
   EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
   EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
-  EXTERNAL_MODERATION_CACHE_PROBE: 'testns' as string,
+  EXTERNAL_MODERATION_CACHE_PROBE: 'next' as string,
 }));
 vi.mock('~/env/server', () => ({ env }));
 
@@ -105,7 +105,7 @@ async function untilProbeTotal(n: number) {
 beforeEach(() => {
   promClient.register.getSingleMetric(PROBE)?.reset();
   promClient.register.getSingleMetric(HIST)?.reset();
-  env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
+  env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
   // 🔴 `resetSharedMocks()` in src/__tests__/setup.ts runs once PER FILE, not per test, so
   // `sysRedis.set`'s call history accumulates across every case here. Without this, the
   // `not.toHaveBeenCalled()` assertion in the flag-off case passes only because it happens to run
@@ -132,7 +132,7 @@ describe('cache probe — the flag is the arming switch', () => {
     stubFetchOk();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
     const redisCallsWhileOn = redisMock.sysRedis.set.mock.calls.length;
@@ -144,10 +144,13 @@ describe('cache probe — the flag is the arming switch', () => {
     expect(await probeTotal()).toBe(2);
     expect(redisMock.sysRedis.set.mock.calls.length).toBe(redisCallsWhileOn);
     // 🔴 SHIPPING INERT MUST ALSO MEAN SHIPPING SILENT, and without this assertion the empty-string
-    // early return is untested: delete it and the probe is STILL off (the charset pattern rejects
-    // '' anyway), so every other case here stays green — a mutant removing it SURVIVED. What it
-    // actually buys is that a DELIBERATELY unarmed deployment — which today is every deployment —
-    // does not log a misconfiguration error on every single generation.
+    // early return is untested: delete it and the probe is STILL off ('' is not in the allowlist
+    // either), so every other case here stays green — a mutant removing it SURVIVED. What it buys
+    // is that a DELIBERATELY unarmed deployment — which today is every deployment — logs no
+    // misconfiguration error at all. ⚠️ Measured cost of the mutant: ONE line per process per
+    // distinct value, not one per generation, because `warnedNamespace` dedupes. An earlier
+    // revision of this comment and of the PR body said "on every generation", which overstated it
+    // by orders of magnitude.
     expect(
       errorSpy.mock.calls.filter((c) => String(c[0]).includes('moderation-cache-probe'))
     ).toHaveLength(0);
@@ -399,22 +402,28 @@ describe('cache probe — the namespace IS the arming switch', () => {
     expect(await probeCount('generate', '5m', 'hit')).toBe(0);
   });
 
-  it('an ON/OFF WORD never arms the probe, however the operator spells it', async () => {
-    // 🔴 THE HIGHEST-RISK VALUE, and the charset alone accepts every one of these as a perfectly
-    // good namespace. This variable was a boolean one commit ago, so `=false` is the PREVIOUS
-    // contract's spelling for "off" and the likeliest thing an operator writes. Without this guard
-    // it would ARM the probe under a namespace literally called `false` — and two deployments
-    // "disabled" that way would share the keyspace `…:false:…` and score hits on each other's
-    // prompts, which is the exact collision the namespace exists to prevent.
+  it('no off-ish spelling arms the probe, including the ones a denylist would miss', async () => {
+    // 🔴 THE HIGHEST-RISK VALUES. This variable was a boolean two commits ago, so `=false` is the
+    // PREVIOUS contract's spelling for "off" and the likeliest thing an operator writes. Under a
+    // charset-plus-denylist guard it would ARM the probe under a namespace literally called
+    // `false`, and two deployments "disabled" that way would share `…:false:…` and score hits on
+    // each other's prompts — the exact collision the namespace exists to prevent.
+    //
+    // 🔴 THE SECOND HALF OF THIS LIST IS THE POINT. `y`, `n`, `none`, `null`, `undefined`, `nil`,
+    // `disable`, `enable` and `2` all passed the charset AND the ten-word denylist that shipped one
+    // commit ago — audit round 3 enumerated them. `y`/`n` are not exotic: zod's own `stringbool`
+    // treats them as boolean spellings. That is why the guard is now a closed ALLOWLIST rather than
+    // a denylist: a list of forbidden members can only ever forbid the members someone thought of.
     installRedisFake();
     stubFetchOk();
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
 
     for (const word of [
+      // the original denylist
       'true',
       'false',
       'on',
@@ -425,6 +434,16 @@ describe('cache probe — the namespace IS the arming switch', () => {
       '1',
       'enabled',
       'disabled',
+      // the ones that walked straight through it
+      'y',
+      'n',
+      'none',
+      'null',
+      'undefined',
+      'nil',
+      'disable',
+      'enable',
+      '2',
     ]) {
       env.EXTERNAL_MODERATION_CACHE_PROBE = word;
       await extModeration.moderatePrompt(`prompt for ${word}`, 'generate');
@@ -452,7 +471,7 @@ describe('cache probe — the namespace IS the arming switch', () => {
     expect(String(forThisValue[0][0])).toContain('is DISABLED');
   });
 
-  it('an out-of-charset namespace is treated as OFF, not sanitised', async () => {
+  it('an unknown namespace is treated as OFF, not sanitised', async () => {
     // A typo must produce NO SERIES — which the help text already tells the reader means "not
     // armed" — rather than quietly opening a second keyspace that looks armed and measures a
     // fiction. Sanitising would silently map two distinct typos onto one namespace.
@@ -461,7 +480,7 @@ describe('cache probe — the namespace IS the arming switch', () => {
 
     // Warm the lazy import with a valid namespace first, so the absence below is evidence and not
     // an insufficient wait (same reasoning as the flag-off case).
-    env.EXTERNAL_MODERATION_CACHE_PROBE = 'testns';
+    env.EXTERNAL_MODERATION_CACHE_PROBE = 'next';
     await extModeration.moderatePrompt('a warmup prompt', 'generate');
     await untilProbeTotal(2);
 

--- a/src/server/integrations/__tests__/moderation-cache-probe.test.ts
+++ b/src/server/integrations/__tests__/moderation-cache-probe.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Contract for the external-moderation CACHE PROBE.
+ *
+ * WHAT IT IS. A dark instrument that answers one question — "if we cached moderation verdicts,
+ * how often would we skip the classifier?" — without caching anything. It runs on the generation
+ * submission path, so its whole design is negative constraints: it must not change the verdict,
+ * must not add latency, must not be able to fail a generation, and must not exist at all until it
+ * is switched on.
+ *
+ * 🔴 WHY THE TESTS LOOK LIKE THIS. A probe that quietly reports zero is indistinguishable from a
+ * probe that was never wired up, and both read as "prompts do not repeat" — the reassuring
+ * conclusion, which is the one that gets acted on. So every case here is written to fail if the
+ * probe is inert, and the fidelity case below (`hashes the PREPARED prompt`) is the one that would
+ * survive a green suite if it were dropped: the probe would still record hits and misses, just of
+ * the wrong string, and the number it produced would be a plausible underestimate with nothing
+ * anywhere to contradict it.
+ *
+ * These read back the REAL prom-client registry rather than asserting we called our own wrapper —
+ * `@civitai/telemetry/client` is not stubbed by src/__tests__/setup.ts.
+ */
+import promClient from 'prom-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable env mock, overriding the global stub in src/__tests__/setup.ts, so each case can flip the
+// probe flag. `vi.hoisted` so it exists before the hoisted `vi.mock` factory references it.
+const env = vi.hoisted(() => ({
+  EXTERNAL_MODERATION_ENDPOINT: 'https://moderation.example/v1/moderations' as string,
+  EXTERNAL_MODERATION_TOKEN: 'tok' as string,
+  EXTERNAL_MODERATION_THRESHOLD: 0.5,
+  EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
+  EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
+  EXTERNAL_MODERATION_CACHE_PROBE: true,
+}));
+vi.mock('~/env/server', () => ({ env }));
+
+import { redisMock } from '~/__tests__/mocks/redis.mock';
+import { serverSchema } from '~/env/server-schema';
+import { extModeration } from '~/server/integrations/moderation';
+
+const PROBE = 'civitai_app_external_moderation_cache_probe_total';
+const HIST = 'civitai_app_external_moderation_duration_seconds';
+
+type Sample = { metricName?: string; labels: Record<string, string | number>; value: number };
+
+async function samples(name: string): Promise<Sample[]> {
+  const metric = promClient.register.getSingleMetric(name);
+  if (!metric) throw new Error(`metric ${name} is not registered`);
+  return (await metric.get()).values as Sample[];
+}
+
+async function probeCount(source: string, window: string, result: string) {
+  const vals = await samples(PROBE);
+  return (
+    vals.find(
+      (v) => v.labels.source === source && v.labels.window === window && v.labels.result === result
+    )?.value ?? 0
+  );
+}
+
+/** Every probe series summed — the double-count guard, mirroring the histogram tests. */
+async function probeTotal() {
+  const vals = await samples(PROBE);
+  return vals.reduce((acc, v) => acc + v.value, 0);
+}
+
+/**
+ * An in-memory stand-in for `SET key value NX EX`, faithful on the ONE property the measurement
+ * rests on: the first write for a key wins and returns a reply, every later write returns null.
+ * The default mock (`set: ok`) always returns 'OK', i.e. always a MISS — which would let a probe
+ * that never reads Redis at all pass a hit/miss test vacuously.
+ */
+function installRedisFake() {
+  const store = new Set<string>();
+  redisMock.sysRedis.set.mockImplementation(
+    async (key: string, _value: unknown, opts?: { NX?: boolean; EX?: number }) => {
+      if (opts?.NX && store.has(key)) return null;
+      store.add(key);
+      return 'OK';
+    }
+  );
+  return store;
+}
+
+const okResponse = () => ({
+  ok: true,
+  json: async () => ({ results: [{ flagged: false, category_scores: {}, categories: {} }] }),
+});
+
+function stubFetchOk() {
+  const spy = vi.fn(async () => okResponse());
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+/**
+ * The probe is fire-and-forget, so nothing in `moderatePrompt`'s own promise chain waits for it.
+ * Poll the registry rather than sleeping a fixed amount — a fixed sleep is the classic flake, and
+ * it also silently passes if the probe is slower than the sleep.
+ */
+async function untilProbeTotal(n: number) {
+  await vi.waitFor(async () => expect(await probeTotal()).toBe(n));
+}
+
+beforeEach(() => {
+  promClient.register.getSingleMetric(PROBE)?.reset();
+  promClient.register.getSingleMetric(HIST)?.reset();
+  env.EXTERNAL_MODERATION_CACHE_PROBE = true;
+  // 🔴 `resetSharedMocks()` in src/__tests__/setup.ts runs once PER FILE, not per test, so
+  // `sysRedis.set`'s call history accumulates across every case here. Without this, the
+  // `not.toHaveBeenCalled()` assertion in the flag-off case passes only because it happens to run
+  // first, and the key/EX assertions below see every earlier case's calls. Found by the key/EX
+  // case failing with 30 calls instead of 2.
+  redisMock.sysRedis.set.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('cache probe — the flag is the arming switch', () => {
+  it('records NOTHING and touches Redis not at all when the flag is off', async () => {
+    // 🔴 STRUCTURED AS A DIFFERENTIAL, NOT AS A BARE ABSENCE, and that is not stylistic. The first
+    // version of this test set the flag off, called once, slept 20 ms and asserted zero — and a
+    // mutation run with the flag guard DELETED still passed it. The probe's first invocation has to
+    // resolve a lazy `import()`, which takes longer than 20 ms, so the sleep was proving that the
+    // probe is slow rather than that it is off. Warming the import inside the test and reusing the
+    // same budget makes the absence load-bearing: the flag-on leg demonstrates that observations
+    // DO land in this window, so the flag-off leg finding none is evidence.
+    installRedisFake();
+    stubFetchOk();
+
+    env.EXTERNAL_MODERATION_CACHE_PROBE = true;
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilProbeTotal(2);
+    const redisCallsWhileOn = redisMock.sysRedis.set.mock.calls.length;
+
+    env.EXTERNAL_MODERATION_CACHE_PROBE = false;
+    await extModeration.moderatePrompt('an entirely different prompt', 'generate');
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await probeTotal()).toBe(2);
+    expect(redisMock.sysRedis.set.mock.calls.length).toBe(redisCallsWhileOn);
+  });
+
+  it('POSITIVE CONTROL: the identical call with the flag ON does record', async () => {
+    // Without this pair, the assertion above proves only that the metric name is spelled wrong.
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+
+    await untilProbeTotal(2);
+    expect(redisMock.sysRedis.set).toHaveBeenCalled();
+  });
+});
+
+describe('cache probe — hit/miss', () => {
+  it('a first-sighting prompt is a MISS in both windows', async () => {
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+
+    await untilProbeTotal(2);
+    expect(await probeCount('generate', '5m', 'miss')).toBe(1);
+    expect(await probeCount('generate', '1h', 'miss')).toBe(1);
+    expect(await probeCount('generate', '5m', 'hit')).toBe(0);
+  });
+
+  it('the SAME prompt again is a HIT in both windows — and the classifier is still called', async () => {
+    installRedisFake();
+    const fetchSpy = stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(2);
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(4);
+
+    expect(await probeCount('generate', '5m', 'hit')).toBe(1);
+    expect(await probeCount('generate', '1h', 'hit')).toBe(1);
+    // 🔴 THE LOAD-BEARING HALF. A hit must not skip the call — this is a probe, not a cache. If
+    // this ever reads 1, the probe has silently become a moderation bypass.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('a DIFFERENT prompt is a miss, not a hit', async () => {
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(2);
+    await extModeration.moderatePrompt('a completely different subject', 'generate');
+    await untilProbeTotal(4);
+
+    expect(await probeCount('generate', '5m', 'miss')).toBe(2);
+    expect(await probeCount('generate', '5m', 'hit')).toBe(0);
+  });
+});
+
+describe('cache probe — fidelity to what the classifier actually receives', () => {
+  it('hashes the PREPARED prompt, so two raw prompts that normalise to one call are a HIT', async () => {
+    // 🔴 THIS IS THE CASE THAT PINS THE CALL SITE. `removeFalsePositiveTriggers` rewrites
+    // /\d*girl/ -> 'woman', so these two RAW strings differ but produce a byte-identical request
+    // body. A real cache keyed on the request would hit; a probe hashing the raw prompt would
+    // record two misses and understate the repeat rate — with every other test here still green.
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('1girl in a field', 'generate');
+    await untilProbeTotal(2);
+    await extModeration.moderatePrompt('girl in a field', 'generate');
+    await untilProbeTotal(4);
+
+    expect(await probeCount('generate', '5m', 'hit')).toBe(1);
+    expect(await probeCount('generate', '1h', 'hit')).toBe(1);
+  });
+
+  it('CONTROL for the case above: the transform is what collapses them, not the digest being constant', async () => {
+    // If `digestPrompt` ignored its argument entirely, the case above would also pass. Two prompts
+    // the transform does NOT collapse must stay distinct.
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('1girl in a field', 'generate');
+    await untilProbeTotal(2);
+    await extModeration.moderatePrompt('1boy in a field', 'generate');
+    await untilProbeTotal(4);
+
+    expect(await probeCount('generate', '5m', 'hit')).toBe(0);
+    expect(await probeCount('generate', '5m', 'miss')).toBe(2);
+  });
+});
+
+describe('cache probe — it cannot hurt the generation path', () => {
+  it('a Redis failure records outcome=error and the moderation call still succeeds', async () => {
+    redisMock.sysRedis.set.mockRejectedValue(new Error('redis is down'));
+    stubFetchOk();
+
+    const result = await extModeration.moderatePrompt('a serene landscape', 'generate');
+
+    expect(result).toEqual({ flagged: false, categories: [] });
+    await untilProbeTotal(2);
+    expect(await probeCount('generate', '5m', 'error')).toBe(1);
+    expect(await probeCount('generate', '1h', 'error')).toBe(1);
+    // The error must be its OWN series, never folded into miss — a Redis outage counted as misses
+    // would read as "prompts stopped repeating".
+    expect(await probeCount('generate', '5m', 'miss')).toBe(0);
+  });
+
+  it('a Redis call that NEVER settles does not park the moderation call', async () => {
+    // The probe is not awaited, so a hung Redis must be invisible to the caller. If someone later
+    // adds an `await`, this is the test that catches it — by timing out rather than by asserting a
+    // number, which is why it carries its own tight deadline.
+    redisMock.sysRedis.set.mockImplementation(() => new Promise(() => undefined));
+    stubFetchOk();
+
+    const result = await Promise.race([
+      extModeration.moderatePrompt('a serene landscape', 'generate'),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('probe blocked the call')), 500)
+      ),
+    ]);
+
+    expect(result).toEqual({ flagged: false, categories: [] });
+  });
+
+  it('records nothing when the integration is not configured — no request, no probe', async () => {
+    // The skip path returns before `preparedPrompt` exists. A probe there would count calls that
+    // never happened and inflate the denominator of the hit rate.
+    //
+    // Same differential shape as the flag-off case above, for the same reason: warm the lazy import
+    // with a configured call first, so "nothing arrived" cannot be an artefact of not waiting.
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a warmup prompt', 'generate');
+    await untilProbeTotal(2);
+
+    const endpoint = env.EXTERNAL_MODERATION_ENDPOINT;
+    env.EXTERNAL_MODERATION_ENDPOINT = '';
+    try {
+      await extModeration.moderatePrompt('a serene landscape', 'generate');
+      await new Promise((r) => setTimeout(r, 200));
+      expect(await probeTotal()).toBe(2);
+    } finally {
+      env.EXTERNAL_MODERATION_ENDPOINT = endpoint;
+    }
+  });
+});
+
+describe('cache probe — label bounds', () => {
+  it('clamps an out-of-set source to `other`, so no caller can mint a label value', async () => {
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'not-a-real-source' as never);
+
+    await untilProbeTotal(2);
+    expect(await probeCount('other', '5m', 'miss')).toBe(1);
+    expect(await probeCount('not-a-real-source', '5m', 'miss')).toBe(0);
+  });
+
+  it('emits exactly two observations per call — one per window, never more', async () => {
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(2);
+
+    const windows = new Set((await samples(PROBE)).map((v) => String(v.labels.window)));
+    expect([...windows].sort()).toEqual(['1h', '5m']);
+  });
+
+  it('writes each window under its own key with NX and the matching EX', async () => {
+    installRedisFake();
+    stubFetchOk();
+
+    await extModeration.moderatePrompt('a serene landscape', 'generate');
+    await untilProbeTotal(2);
+
+    const calls = redisMock.sysRedis.set.mock.calls as [
+      string,
+      unknown,
+      { NX: boolean; EX: number }
+    ][];
+    expect(calls).toHaveLength(2);
+    // NX is what makes the measurement atomic: GET-then-SET would race two concurrent submissions
+    // of one prompt into two misses and undercount exactly the population being measured.
+    expect(calls.every(([, , opts]) => opts.NX === true)).toBe(true);
+    expect(calls.map(([, , opts]) => opts.EX).sort((a, b) => a - b)).toEqual([300, 3600]);
+    // Distinct keys, or the two windows would contend on one slot and the 5m series would be a
+    // copy of the 1h one.
+    expect(new Set(calls.map(([key]) => key)).size).toBe(2);
+    expect(calls.every(([key]) => key.startsWith('generation:moderation-cache-probe:'))).toBe(true);
+  });
+});
+
+describe('cache probe — env schema', () => {
+  it('defaults to OFF, so the code ships inert and the arming instant is readable', () => {
+    const parsed = serverSchema.safeParse({});
+    // The schema has many required keys; only this field's default is under test.
+    const value = parsed.success
+      ? parsed.data.EXTERNAL_MODERATION_CACHE_PROBE
+      : serverSchema.shape.EXTERNAL_MODERATION_CACHE_PROBE.parse(undefined);
+    expect(value).toBe(false);
+  });
+});

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -54,6 +54,27 @@ const PROBE_WINDOWS = [
 type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
 
 /**
+ * The deployment namespace the probe writes under, or `null` when it is not armed.
+ *
+ * 🔴 ARMING AND NAMESPACING ARE ONE ACTION. `EXTERNAL_MODERATION_CACHE_PROBE` is a LABEL, not a
+ * boolean: several civitai-web deployments share one sysRedis, and sys keys — unlike cache keys —
+ * carry no environment segment (`cache-key-prefix.ts`: "This is CACHE-ONLY"). Two armed
+ * deployments writing one probe keyspace would each score HITS on the other's prompts, biasing the
+ * result toward "caching pays". Requiring a namespace to arm at all is what makes that unforgettable
+ * rather than a note in a doc.
+ *
+ * An out-of-charset or over-long value returns `null` (i.e. OFF) rather than being sanitised: a
+ * typo then yields NO SERIES, which the metric's help text already tells the reader means "not
+ * armed", instead of quietly opening a second keyspace that looks armed and measures a fiction.
+ */
+const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
+
+function probeNamespace(): string | null {
+  const raw = env.EXTERNAL_MODERATION_CACHE_PROBE?.trim() ?? '';
+  return NAMESPACE_PATTERN.test(raw) ? raw : null;
+}
+
+/**
  * `miss` = this exact prepared prompt had not been seen inside the window (a real cache would have
  * called the classifier). `hit` = it had (a real cache would have skipped the call). `error` = the
  * probe itself failed — Redis unreachable, a command deadline, anything.
@@ -72,12 +93,17 @@ const probeCounter = registerCounterWithLabels({
     'moderation verdicts would pay. Labeled by source (same population split as ' +
     'external_moderation_duration_seconds), window (5m|1h) and result (hit|miss|error). A hit means ' +
     'a real cache with that TTL WOULD have skipped the call — the classifier was still called. ' +
-    'COMPUTE THE HIT RATE AS hit/(hit+miss), never over the total: error is Redis failing, and ' +
-    'folding it in makes an outage look like "prompts stopped repeating". 🔴 IGNORE THE FIRST FULL ' +
-    'WINDOW AFTER ARMING — the probe keyspace starts empty, so every observation is necessarily a ' +
-    'miss until it has been running longer than the window it is measuring, and a hit rate read too ' +
-    'early is biased toward zero by construction. Gated by EXTERNAL_MODERATION_CACHE_PROBE; with the ' +
-    'flag off there are no series at all, which is what makes the arming instant readable.',
+    'COMPUTE THE HIT RATE AS sum by (window) (rate(...{result="hit"}[..])) / sum by (window) ' +
+    '(rate(...{result=~"hit|miss"}[..])). BOTH halves matter: dividing over the TOTAL folds in ' +
+    'error, so a Redis outage reads as "prompts stopped repeating"; and omitting `by (window)` ' +
+    'averages the 5m and 1h series into one number, which is exactly the shape the two windows ' +
+    'exist to reveal. 🔴 IGNORE THE FIRST FULL WINDOW AFTER ARMING — the probe keyspace starts ' +
+    'empty, so every observation is necessarily a miss until it has been running longer than the ' +
+    'window it is measuring, and a hit rate read too early is biased toward zero by construction. ' +
+    '🔴 THE RESULT IS AN UPPER BOUND, NOT A FLOOR: it simulates a cache that COALESCES concurrent ' +
+    'duplicates (see the SET NX note in the source), which a plain read-through cache does not do. ' +
+    'Armed per deployment via EXTERNAL_MODERATION_CACHE_PROBE, whose value is the key namespace; ' +
+    'unarmed there are no series at all, which is what makes the arming instant readable.',
   labelNames: ['source', 'window', 'result'] as const,
 });
 
@@ -125,16 +151,26 @@ export function probeModerationCacheRepeat(
   source: ExternalModerationSource,
   preparedPrompt: string
 ): void {
-  if (!env.EXTERNAL_MODERATION_CACHE_PROBE) return;
-  // `void` + a terminal catch: an unhandled rejection here would be a process-level event raised by
-  // an instrument that is explicitly not allowed to affect anything.
-  void runProbe(clampExternalModerationSource(source), preparedPrompt).catch(() => {
+  const namespace = probeNamespace();
+  if (namespace === null) return;
+  // 🔴 CLAMP HERE, NOT ONLY AT THE CALLER. `moderatePrompt` already clamps and passes the clamped
+  // value, so this looks redundant and an audit mutant that removed it SURVIVED a green 14-case
+  // suite. It is not redundant: this function is EXPORTED, so its `source` is reachable from a
+  // future direct caller and from the test tree, which `tsconfig.json` excludes — and an unbounded
+  // string on a hot-path prom label is a cardinality incident that arrives with no error anywhere.
+  // The clamp is now exercised directly by a test that calls this function rather than
+  // `moderatePrompt`; without that test the guard reads as covered while being untested.
+  void runProbe(clampExternalModerationSource(source), preparedPrompt, namespace).catch(() => {
     // `runProbe` already records `error` per window; this only guards a throw before that point
     // (e.g. the dynamic import itself failing), which has no window to attribute.
   });
 }
 
-async function runProbe(source: ExternalModerationSource, preparedPrompt: string): Promise<void> {
+async function runProbe(
+  source: ExternalModerationSource,
+  preparedPrompt: string,
+  namespace: string
+): Promise<void> {
   const digest = digestPrompt(preparedPrompt);
   const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');
 
@@ -143,14 +179,25 @@ async function runProbe(source: ExternalModerationSource, preparedPrompt: string
       try {
         // SET NX EX is the whole measurement, in one atomic round trip: it returns a truthy reply
         // when the key did NOT exist (a miss, and the key is now claimed for `seconds`) and null
-        // when it did (a hit). Doing this as GET-then-SET would race two concurrent submissions of
-        // the same prompt into two misses and undercount exactly the population being measured.
+        // when it did (a hit). One round trip rather than GET-then-SET keeps the two windows cheap
+        // and the observation self-consistent — but do NOT read that atomicity as accuracy:
         //
-        // 🔴 The TTL is FIXED FROM FIRST WRITE, not sliding — NX means a hit does not extend it. So
-        // this simulates the CONSERVATIVE cache design; one that refreshed its TTL on every hit
-        // would score at least as high. Read the result as a floor on the achievable hit rate.
+        // 🔴 BUT NX ALSO MAKES THIS AN UPPER BOUND, NOT A FLOOR — do not read the atomicity as pure
+        // fidelity. `SET NX` claims the slot the moment the request STARTS, whereas a plain
+        // read-through cache cannot store a verdict until the classifier ANSWERS ~200 ms later. So
+        // for two identical prompts submitted 50 ms apart (a re-roll double-click, or a trending
+        // prompt) this scores miss+hit while a non-coalescing cache would score miss+miss. What it
+        // faithfully simulates is a cache with request COALESCING (singleflight); against one
+        // without, the number here is optimistic.
+        //
+        // The TTL is separately FIXED FROM FIRST WRITE, not sliding — NX means a hit does not
+        // extend it — which pushes the other way. The two do not cancel to anything knowable, so
+        // the honest summary is the one in the help text: upper bound.
+        //
+        // The namespace segment keeps two armed deployments off each other's keyspace; see
+        // `probeNamespace`.
         const key =
-          `${REDIS_SYS_KEYS.GENERATION.MODERATION_CACHE_PROBE}:${label}:${digest}` as const;
+          `${REDIS_SYS_KEYS.GENERATION.MODERATION_CACHE_PROBE}:${namespace}:${label}:${digest}` as const;
         const claimed = await sysRedis.set(key, '1', { NX: true, EX: seconds });
         record(source, label, claimed ? 'miss' : 'hit');
       } catch {

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -1,0 +1,161 @@
+// DARK PROBE: would caching external prompt-moderation verdicts actually pay?
+//
+// WHY this exists. `extModeration.moderatePrompt` is an outbound HTTPS call that runs inline and
+// serially on the generation submission path, and it is expensive in WALL TIME: measured in
+// production it is ~200 ms per call at p50 ~188 ms, and it accounts for roughly 78-88% of the
+// app-side (non-orchestrator-submit) time of `orchestrator.generateFromGraph`.
+//
+// Three ways to make that cheaper were tested against production measurements and ALL THREE ARE
+// DEAD, which is what makes this probe the remaining question rather than one option among many:
+//   1. Tune the tail / the abort deadline — the distribution is a FLOOR, not a tail. Zero calls
+//      land under 50 ms and 0.46% under 100 ms, so clamping the slow 1.18% is worth single-digit
+//      milliseconds of the mean.
+//   2. Reuse the connection — the call does pay a fresh TCP+TLS handshake on most invocations
+//      (call spacing per process far exceeds undici's 4 s default keep-alive, and nothing in this
+//      app configures a dispatcher), but the classifier answers from a nearby edge, so the whole
+//      handshake measures ~7-24 ms. Not the lever it looks like.
+//   3. Overlap it with the workflow submit — impossible by construction. The audit is a
+//      FAIL-CLOSED gate: a flagged prompt throws and must never reach `submitWorkflow`.
+// What is left is the classifier's own inference time, and the only way to avoid paying it is to
+// NOT MAKE THE CALL. That is worth building only if prompts actually repeat — and nobody knows
+// whether they do. This module measures exactly that, and nothing else.
+//
+// 🔴 IT IS A MEASUREMENT, NOT A CACHE, AND IT MUST NEVER BECOME ONE BY ACCIDENT. No caller reads a
+// verdict back from here; `moderatePrompt` issues its request every single time regardless of what
+// this reports. Changing that is a moderation-policy decision (a stale verdict is a trust-and-safety
+// question, not a performance one) and must be its own change with its own review.
+import { createHash } from 'node:crypto';
+
+import { registerCounterWithLabels } from '@civitai/telemetry/client';
+import { env } from '~/env/server';
+import {
+  clampExternalModerationSource,
+  type ExternalModerationSource,
+} from '~/server/prom/external-moderation.metrics';
+
+/**
+ * The windows the probe simulates, as (label, seconds) pairs.
+ *
+ * 🔴 TWO WINDOWS, NOT ONE, AND THAT IS THE POINT. A single hit rate is one number with no shape:
+ * it cannot distinguish "users re-roll the same prompt within minutes" (a tiny TTL captures nearly
+ * all of the value, and a small cache is enough) from "the same prompts recur all day across
+ * different users" (the value keeps climbing with TTL, and the cache has to be big). Those imply
+ * completely different builds. Measuring at a boundary AND a middle is what makes the answer a
+ * curve instead of an anecdote.
+ *
+ * `5m` and `1h` are 12x apart deliberately — close enough that both are cheap, far enough that a
+ * flat reading between them is real evidence of saturation rather than measurement noise.
+ */
+const PROBE_WINDOWS = [
+  { label: '5m', seconds: 300 },
+  { label: '1h', seconds: 3600 },
+] as const;
+
+type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
+
+/**
+ * `miss` = this exact prepared prompt had not been seen inside the window (a real cache would have
+ * called the classifier). `hit` = it had (a real cache would have skipped the call). `error` = the
+ * probe itself failed — Redis unreachable, a command deadline, anything.
+ *
+ * 🔴 `error` IS A SEPARATE RESULT SO THE HIT RATE CANNOT SILENTLY DEFLATE. Divide by `hit + miss`,
+ * NEVER by the total across all three: a Redis outage would otherwise read as "prompts stopped
+ * repeating", which is the reassuring direction and therefore the dangerous one.
+ */
+type ProbeResult = 'hit' | 'miss' | 'error';
+
+const probeCounter = registerCounterWithLabels({
+  name: 'external_moderation_cache_probe_total',
+  help:
+    'DARK PROBE (measurement only, changes no behaviour): counts whether the exact string sent to ' +
+    'the external prompt classifier had already been seen inside a window, to size whether caching ' +
+    'moderation verdicts would pay. Labeled by source (same population split as ' +
+    'external_moderation_duration_seconds), window (5m|1h) and result (hit|miss|error). A hit means ' +
+    'a real cache with that TTL WOULD have skipped the call — the classifier was still called. ' +
+    'COMPUTE THE HIT RATE AS hit/(hit+miss), never over the total: error is Redis failing, and ' +
+    'folding it in makes an outage look like "prompts stopped repeating". 🔴 IGNORE THE FIRST FULL ' +
+    'WINDOW AFTER ARMING — the probe keyspace starts empty, so every observation is necessarily a ' +
+    'miss until it has been running longer than the window it is measuring, and a hit rate read too ' +
+    'early is biased toward zero by construction. Gated by EXTERNAL_MODERATION_CACHE_PROBE; with the ' +
+    'flag off there are no series at all, which is what makes the arming instant readable.',
+  labelNames: ['source', 'window', 'result'] as const,
+});
+
+function record(
+  source: ExternalModerationSource,
+  window: ProbeWindowLabel,
+  result: ProbeResult
+): void {
+  try {
+    probeCounter.inc({ source, window, result });
+  } catch {
+    // Observability must never break the moderation path. Swallow any prom-client error.
+  }
+}
+
+/**
+ * Hash of the exact string handed to the classifier.
+ *
+ * Truncated to 32 hex chars (128 bits) because the only operation performed on it is equality
+ * inside one bounded window — collisions at 128 bits are not a practical concern at these volumes,
+ * and the shorter key keeps the probe keyspace small.
+ *
+ * 🔴 THE PROMPT ITSELF IS NEVER STORED, LOGGED OR LABELLED. Only this digest reaches Redis, and
+ * nothing user-controlled reaches a metric label — a prompt on a label would be an unbounded
+ * cardinality incident on a hot path, on top of being user content in an observability system.
+ */
+function digestPrompt(preparedPrompt: string): string {
+  return createHash('sha256').update(preparedPrompt).digest('hex').slice(0, 32);
+}
+
+/**
+ * Fire-and-forget. Records, for each window, whether `preparedPrompt` had been seen before.
+ *
+ * 🔴 DELIBERATELY NOT AWAITED BY THE CALLER, AND THAT IS LOAD-BEARING TWICE OVER. First, this runs
+ * on the generation submission path: awaiting a Redis round trip here would add latency to the very
+ * request whose latency is under investigation, so the instrument would perturb its own subject.
+ * Second, it makes the probe unable to fail the generation — there is no path from a Redis problem
+ * to a user-visible error, because nothing downstream is waiting on this promise.
+ *
+ * The Redis client is imported LAZILY, inside the async body. `moderation.ts` is imported by a cron
+ * job and keeps a deliberately light import graph; a static import here would pull the whole Redis
+ * client into it for a feature that is off by default.
+ */
+export function probeModerationCacheRepeat(
+  source: ExternalModerationSource,
+  preparedPrompt: string
+): void {
+  if (!env.EXTERNAL_MODERATION_CACHE_PROBE) return;
+  // `void` + a terminal catch: an unhandled rejection here would be a process-level event raised by
+  // an instrument that is explicitly not allowed to affect anything.
+  void runProbe(clampExternalModerationSource(source), preparedPrompt).catch(() => {
+    // `runProbe` already records `error` per window; this only guards a throw before that point
+    // (e.g. the dynamic import itself failing), which has no window to attribute.
+  });
+}
+
+async function runProbe(source: ExternalModerationSource, preparedPrompt: string): Promise<void> {
+  const digest = digestPrompt(preparedPrompt);
+  const { sysRedis, REDIS_SYS_KEYS } = await import('~/server/redis/client');
+
+  await Promise.all(
+    PROBE_WINDOWS.map(async ({ label, seconds }) => {
+      try {
+        // SET NX EX is the whole measurement, in one atomic round trip: it returns a truthy reply
+        // when the key did NOT exist (a miss, and the key is now claimed for `seconds`) and null
+        // when it did (a hit). Doing this as GET-then-SET would race two concurrent submissions of
+        // the same prompt into two misses and undercount exactly the population being measured.
+        //
+        // 🔴 The TTL is FIXED FROM FIRST WRITE, not sliding — NX means a hit does not extend it. So
+        // this simulates the CONSERVATIVE cache design; one that refreshed its TTL on every hit
+        // would score at least as high. Read the result as a floor on the achievable hit rate.
+        const key =
+          `${REDIS_SYS_KEYS.GENERATION.MODERATION_CACHE_PROBE}:${label}:${digest}` as const;
+        const claimed = await sysRedis.set(key, '1', { NX: true, EX: seconds });
+        record(source, label, claimed ? 'miss' : 'hit');
+      } catch {
+        record(source, label, 'error');
+      }
+    })
+  );
+}

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -84,17 +84,34 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  * measurement instrument whose deployment set is known, small, and expected to shrink to zero when
  * the probe is removed.
  *
- * 🔴 THERE IS NO `preview` MEMBER, AND ITS ABSENCE IS THE POINT. It was in the first version of
- * this list and audit round 4 removed it: `preview` is not a deployment, it is a CLASS. Measured
- * live, ~10 concurrent `civitai-pr-*` namespaces each run this code, each take their config from
- * one shared template (so they would all arm together, with the same value) and they share one
- * `civitai-pr-sysredis`. Arming them would put every PR preview in the keyspace
- * `…:preview:<window>:<digest>` at once — mutual hits across unrelated PRs, the exact collision
- * the paragraph above says an allowlist prevents. A member that defeats the invariant the guard
- * enforces is worse than no guard, because the guard is what stops anyone looking. If preview
- * traffic is ever worth measuring it needs a PER-PR segment, not a shared word.
+ * 🔴 THE ONLY MEMBER IS `prod`, AND BOTH OMISSIONS ARE LOAD-BEARING. The list held four members
+ * two rounds ago; audit rounds 4 and 5 removed three of them, each for a measured reason:
+ *
+ *   · `preview` is not a deployment, it is a CLASS — ~10 concurrent `civitai-pr-*` namespaces run
+ *     this code and share one `civitai-pr-sysredis`, so arming that one word arms all of them into
+ *     a single keyspace and they score mutual hits across unrelated PRs.
+ *   · `next` LOOKS like a single deployment and is not, for the same reason one level up: the
+ *     PR-preview Tekton task copies civitai-next's `civitai-cfg` ConfigMap WHOLESALE into every
+ *     `civitai-pr-<N>` namespace, overriding only an explicit key list this variable is not on.
+ *     So arming `next` silently arms every open PR's preview too, onto that same shared sysRedis.
+ *     Removing `preview` alone did not close the hazard; it moved it.
+ *   · `next-stage` is a genuine single deployment, and arming it would still be useless: it has
+ *     NO ServiceMonitor or PodMonitor, so nothing scrapes it. Measured — `civitai-next` and
+ *     `civitai-next-stage` have zero monitors between them, and the probe's population twin
+ *     `civitai_app_external_moderation_duration_seconds_count` exists in exactly one namespace,
+ *     `civitai-dp-prod`. An operator arming a non-scraped deployment sees no series at all, which
+ *     this metric's own help text defines as "not armed" — the two states the whole arming design
+ *     exists to keep apart.
+ *
+ * 🔴 SO BEFORE ADDING A MEMBER, CHECK BOTH: that it names ONE running population rather than a
+ * template other namespaces inherit, and that something actually scrapes it. A member that fails
+ * either test makes this guard assert an invariant it does not enforce, which is worse than no
+ * guard because the guard is what stops anyone looking.
+ *
+ * Exported so a test can assert the membership as a LEDGER — failing when the set grows OR shrinks,
+ * not merely when a known member disappears.
  */
-const PROBE_NAMESPACES: ReadonlySet<string> = new Set(['prod', 'next', 'next-stage']);
+export const PROBE_NAMESPACES: ReadonlySet<string> = new Set(['prod']);
 
 let warnedNamespace: string | null = null;
 

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -66,12 +66,59 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  * An out-of-charset or over-long value returns `null` (i.e. OFF) rather than being sanitised: a
  * typo then yields NO SERIES, which the metric's help text already tells the reader means "not
  * armed", instead of quietly opening a second keyspace that looks armed and measures a fiction.
+ * Unlike the previous boolean spelling, which failed boot loudly on garbage, a rejected value here
+ * is otherwise silent — so it is logged once, on the same reasoning (and in the same shape) as
+ * `cache-key-prefix.ts`'s misconfiguration guard: loud enough to find, never able to fail boot.
+ *
+ * 🔴 A BOOLEAN-SHAPED VALUE IS REJECTED, AND THAT IS NOT PEDANTRY. The charset alone accepts
+ * `false`, `off`, `no`, `0` and `disabled` as perfectly good namespaces — so the single most likely
+ * way an operator spells "turn this off" would instead ARM the probe under a namespace called
+ * `false`. Worse, it reintroduces the very collision this namespace exists to prevent: two
+ * deployments each "disabled" that way share the keyspace `…:false:…` and score hits on each
+ * other's prompts. This variable was a `zc.booleanString` one commit ago, so `=false` is not a
+ * hypothetical spelling — it is the previous contract, and `civitai-dp-prod` sets other env flags
+ * to the literal string `false` today.
  */
 const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
 
+/**
+ * Values whose PLAIN MEANING is on/off rather than a place. Rejected even though the charset admits
+ * them, because a namespace is not what the operator typing one of these intends.
+ */
+const BOOLEANISH = new Set([
+  'true',
+  'false',
+  'on',
+  'off',
+  'yes',
+  'no',
+  '0',
+  '1',
+  'enabled',
+  'disabled',
+]);
+
+let warnedNamespace: string | null = null;
+
 function probeNamespace(): string | null {
   const raw = env.EXTERNAL_MODERATION_CACHE_PROBE?.trim() ?? '';
-  return NAMESPACE_PATTERN.test(raw) ? raw : null;
+  if (raw === '') return null;
+  if (NAMESPACE_PATTERN.test(raw) && !BOOLEANISH.has(raw)) return raw;
+
+  // Warn ONCE per distinct bad value: this runs on the generation hot path, and a per-call log on a
+  // misconfigured deployment would be its own incident. `console.error` rather than a throw for the
+  // reason cache-key-prefix.ts gives for the same choice — a namespace mistake must not be able to
+  // take a deployment down.
+  if (warnedNamespace !== raw) {
+    warnedNamespace = raw;
+    console.error(
+      `[moderation-cache-probe] EXTERNAL_MODERATION_CACHE_PROBE=${JSON.stringify(raw)} is not a ` +
+        `valid namespace (expected /^[a-z0-9][a-z0-9-]{0,31}$/ and not an on/off word). The probe ` +
+        `is DISABLED. Set it to a deployment label such as "prod" or "next" to arm it, or leave it ` +
+        `empty to disable it deliberately.`
+    );
+  }
+  return null;
 }
 
 /**
@@ -100,8 +147,10 @@ const probeCounter = registerCounterWithLabels({
     'exist to reveal. 🔴 IGNORE THE FIRST FULL WINDOW AFTER ARMING — the probe keyspace starts ' +
     'empty, so every observation is necessarily a miss until it has been running longer than the ' +
     'window it is measuring, and a hit rate read too early is biased toward zero by construction. ' +
-    '🔴 THE RESULT IS AN UPPER BOUND, NOT A FLOOR: it simulates a cache that COALESCES concurrent ' +
-    'duplicates (see the SET NX note in the source), which a plain read-through cache does not do. ' +
+    '🔴 THE RESULT IS SCOPED, NOT ABSOLUTE: against a fixed-TTL, NON-COALESCING read-through cache ' +
+    'it is an UPPER bound (it simulates coalescing, which that design does not do); against a ' +
+    'SLIDING-TTL cache it is a LOWER bound, because this TTL never extends on a hit. Quote the ' +
+    'comparison you mean rather than netting the two — see the SET NX note in the source. ' +
     'Armed per deployment via EXTERNAL_MODERATION_CACHE_PROBE, whose value is the key namespace; ' +
     'unarmed there are no series at all, which is what makes the arming instant readable.',
   labelNames: ['source', 'window', 'result'] as const,
@@ -191,8 +240,18 @@ async function runProbe(
         // without, the number here is optimistic.
         //
         // The TTL is separately FIXED FROM FIRST WRITE, not sliding — NX means a hit does not
-        // extend it — which pushes the other way. The two do not cancel to anything knowable, so
-        // the honest summary is the one in the help text: upper bound.
+        // extend it — and that pushes the OTHER way, understating what a sliding-TTL cache would
+        // achieve.
+        //
+        // 🔴 SO "UPPER BOUND" IS A CLAIM ABOUT ONE COMPARISON, NOT ABOUT REALITY IN GENERAL, and an
+        // earlier revision of this comment got that wrong: it named both biases, said they "do not
+        // cancel to anything knowable", and then concluded "upper bound" anyway — a conclusion its
+        // own premise withdraws. State the scope instead:
+        //   · vs a fixed-TTL, NON-COALESCING read-through cache — this OVERSTATES (upper bound).
+        //   · vs a SLIDING-TTL cache — this UNDERSTATES; that design can only score higher.
+        // The two biases also differ in reach: coalescing only touches duplicates arriving inside
+        // the ~200 ms in-flight window, while fixed-vs-sliding touches every duplicate recurring
+        // near the window edge. Do not net them; quote the comparison you mean.
         //
         // The namespace segment keeps two armed deployments off each other's keyspace; see
         // `probeNamespace`.

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -63,59 +63,61 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  * result toward "caching pays". Requiring a namespace to arm at all is what makes that unforgettable
  * rather than a note in a doc.
  *
- * An out-of-charset or over-long value returns `null` (i.e. OFF) rather than being sanitised: a
- * typo then yields NO SERIES, which the metric's help text already tells the reader means "not
- * armed", instead of quietly opening a second keyspace that looks armed and measures a fiction.
- * Unlike the previous boolean spelling, which failed boot loudly on garbage, a rejected value here
- * is otherwise silent — so it is logged once, on the same reasoning (and in the same shape) as
- * `cache-key-prefix.ts`'s misconfiguration guard: loud enough to find, never able to fail boot.
+ * A value that is not a known deployment label returns `null` (i.e. OFF) rather than being
+ * sanitised or accepted: a typo then yields NO SERIES, which the metric's help text already tells
+ * the reader means "not armed", instead of quietly opening a second keyspace that looks armed and
+ * measures a fiction. It is logged once so the operator can tell the two apart.
  *
- * 🔴 A BOOLEAN-SHAPED VALUE IS REJECTED, AND THAT IS NOT PEDANTRY. The charset alone accepts
- * `false`, `off`, `no`, `0` and `disabled` as perfectly good namespaces — so the single most likely
- * way an operator spells "turn this off" would instead ARM the probe under a namespace called
- * `false`. Worse, it reintroduces the very collision this namespace exists to prevent: two
- * deployments each "disabled" that way share the keyspace `…:false:…` and score hits on each
- * other's prompts. This variable was a `zc.booleanString` one commit ago, so `=false` is not a
- * hypothetical spelling — it is the previous contract, and `civitai-dp-prod` sets other env flags
- * to the literal string `false` today.
+ * 🔴 A CLOSED ALLOWLIST, NOT A CHARSET PLUS A DENYLIST — and the denylist it replaces is why.
+ * The first version of this guard accepted any `/^[a-z0-9][a-z0-9-]{0,31}$/` and rejected ten
+ * on/off words. That is a guard SPELLED rather than STRUCTURAL: it defends a class by listing its
+ * members, so every spelling nobody thought of walks straight through. Audit round 3 enumerated
+ * the survivors — `y`, `n`, `none`, `null`, `undefined`, `nil`, `disable`, `enable`, `2` — and
+ * `y`/`n` are not exotic: zod's own `stringbool` treats them as boolean spellings, so an operator
+ * carrying that habit writes `=n`, the probe ARMS under a namespace called `n`, and two
+ * deployments "disabled" that way share `…:n:…` and score hits on each other's prompts. That is
+ * the exact collision this namespace exists to prevent, arriving at the moment the operator
+ * believes the probe is off.
+ *
+ * An allowlist cannot be walked by a spelling nobody thought of. The cost is that arming a NEW
+ * deployment needs a one-line code change — acceptable, and arguably correct, for a temporary
+ * measurement instrument whose deployment set is known, small, and expected to shrink to zero when
+ * the probe is removed.
  */
-const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
-
-/**
- * Values whose PLAIN MEANING is on/off rather than a place. Rejected even though the charset admits
- * them, because a namespace is not what the operator typing one of these intends.
- */
-const BOOLEANISH = new Set([
-  'true',
-  'false',
-  'on',
-  'off',
-  'yes',
-  'no',
-  '0',
-  '1',
-  'enabled',
-  'disabled',
-]);
+const PROBE_NAMESPACES: ReadonlySet<string> = new Set(['prod', 'next', 'next-stage', 'preview']);
 
 let warnedNamespace: string | null = null;
 
 function probeNamespace(): string | null {
   const raw = env.EXTERNAL_MODERATION_CACHE_PROBE?.trim() ?? '';
+  // Empty is the DELIBERATELY-unarmed case — every deployment today — so it returns before the
+  // diagnostic below. Shipping inert has to mean shipping silent: without this line the probe is
+  // still off (an empty string is not in the allowlist either), but every unarmed pod logs a
+  // misconfiguration error it has done nothing to deserve.
   if (raw === '') return null;
-  if (NAMESPACE_PATTERN.test(raw) && !BOOLEANISH.has(raw)) return raw;
+  if (PROBE_NAMESPACES.has(raw)) return raw;
 
   // Warn ONCE per distinct bad value: this runs on the generation hot path, and a per-call log on a
   // misconfigured deployment would be its own incident. `console.error` rather than a throw for the
   // reason cache-key-prefix.ts gives for the same choice — a namespace mistake must not be able to
   // take a deployment down.
+  //
+  // ⚠️ NOT because the previous spelling "failed boot loudly on garbage" — that claim was in this
+  // comment for one commit and it was FALSE. `zc.booleanString` is
+  // `z.preprocess((v) => v === true || v === 'true', z.boolean())`, and that preprocess maps EVERY
+  // input to a boolean, so the inner schema can never fail: executed against the installed zod,
+  // `'off'`, `'garbage'`, `'$$$'` and `''` all parse successfully to `false`. The old contract
+  // swallowed garbage silently too. The log is worth having on its own merits — it is the only way
+  // to tell "armed, no repeats" from "my value was rejected" — not because it restores a guard
+  // that never existed.
   if (warnedNamespace !== raw) {
     warnedNamespace = raw;
     console.error(
       `[moderation-cache-probe] EXTERNAL_MODERATION_CACHE_PROBE=${JSON.stringify(raw)} is not a ` +
-        `valid namespace (expected /^[a-z0-9][a-z0-9-]{0,31}$/ and not an on/off word). The probe ` +
-        `is DISABLED. Set it to a deployment label such as "prod" or "next" to arm it, or leave it ` +
-        `empty to disable it deliberately.`
+        `known deployment namespace (${[...PROBE_NAMESPACES].join(
+          ', '
+        )}). The probe is DISABLED. ` +
+        `Set it to one of those to arm it, or leave it empty to disable it deliberately.`
     );
   }
   return null;
@@ -147,10 +149,13 @@ const probeCounter = registerCounterWithLabels({
     'exist to reveal. 🔴 IGNORE THE FIRST FULL WINDOW AFTER ARMING — the probe keyspace starts ' +
     'empty, so every observation is necessarily a miss until it has been running longer than the ' +
     'window it is measuring, and a hit rate read too early is biased toward zero by construction. ' +
-    '🔴 THE RESULT IS SCOPED, NOT ABSOLUTE: against a fixed-TTL, NON-COALESCING read-through cache ' +
-    'it is an UPPER bound (it simulates coalescing, which that design does not do); against a ' +
-    'SLIDING-TTL cache it is a LOWER bound, because this TTL never extends on a hit. Quote the ' +
-    'comparison you mean rather than netting the two — see the SET NX note in the source. ' +
+    '🔴 THE RESULT IS SCOPED, NOT ABSOLUTE — it differs from a real cache on TWO independent axes ' +
+    '(it coalesces concurrent duplicates; its TTL never extends on a hit), so the bound depends on ' +
+    'BOTH. vs a fixed-TTL NON-COALESCING cache: an UPPER bound. vs a sliding-TTL COALESCING cache: ' +
+    'a LOWER bound. vs a sliding-TTL NON-COALESCING cache — the ordinary design, since singleflight ' +
+    'is a feature you must build — the two effects OPPOSE and NO bound is established; treat the ' +
+    'number as an estimate. Name both axes of the design you are comparing against before quoting ' +
+    'a direction — see the SET NX note in the source. ' +
     'Armed per deployment via EXTERNAL_MODERATION_CACHE_PROBE, whose value is the key namespace; ' +
     'unarmed there are no series at all, which is what makes the arming instant readable.',
   labelNames: ['source', 'window', 'result'] as const,
@@ -247,11 +252,15 @@ async function runProbe(
         // earlier revision of this comment got that wrong: it named both biases, said they "do not
         // cancel to anything knowable", and then concluded "upper bound" anyway — a conclusion its
         // own premise withdraws. State the scope instead:
-        //   · vs a fixed-TTL, NON-COALESCING read-through cache — this OVERSTATES (upper bound).
-        //   · vs a SLIDING-TTL cache — this UNDERSTATES; that design can only score higher.
-        // The two biases also differ in reach: coalescing only touches duplicates arriving inside
-        // the ~200 ms in-flight window, while fixed-vs-sliding touches every duplicate recurring
-        // near the window edge. Do not net them; quote the comparison you mean.
+        //   · vs a fixed-TTL, NON-COALESCING cache — this OVERSTATES (upper bound).
+        //   · vs a sliding-TTL, COALESCING cache — this UNDERSTATES (lower bound).
+        //   · vs a sliding-TTL, NON-COALESCING cache — INDETERMINATE. The two effects oppose and
+        //     neither dominates, so no bound holds in either direction.
+        // ⚠️ That third line is the one an earlier revision got wrong: it said "vs a SLIDING-TTL
+        // cache — that design can only score higher", pinning only the TTL axis. A sliding-TTL
+        // cache that is not ALSO coalescing still never repays this probe's coalescing bonus, and
+        // singleflight is an extra feature you must build, so the ordinary sliding-TTL design is
+        // exactly the indeterminate case. Name BOTH axes before quoting a direction.
         //
         // The namespace segment keeps two armed deployments off each other's keyspace; see
         // `probeNamespace`.

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -85,7 +85,7 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  * the probe is removed.
  *
  * 🔴 THE ONLY MEMBER IS `prod`, AND BOTH OMISSIONS ARE LOAD-BEARING. The list held four members
- * two rounds ago; audit rounds 4 and 5 removed three of them, each for a measured reason:
+ * at audit round 4; rounds 4 and 5 removed three of them, each for a measured reason:
  *
  *   · `preview` is not a deployment, it is a CLASS — ~10 concurrent `civitai-pr-*` namespaces run
  *     this code and share one `civitai-pr-sysredis`, so arming that one word arms all of them into
@@ -110,8 +110,17 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  *
  * Exported so a test can assert the membership as a LEDGER — failing when the set grows OR shrinks,
  * not merely when a known member disappears.
+ *
+ * 🔴 A FROZEN ARRAY, NOT A `ReadonlySet`. `ReadonlySet<string>` is a COMPILE-TIME type and is erased
+ * at runtime, so `(PROBE_NAMESPACES as Set<string>).add('preview')` from any importer would arm an
+ * arbitrary namespace against the same object `probeNamespace` reads. `Object.freeze` on an array is
+ * enforced by the runtime. The Set below is private and built from it, so lookup stays O(1) without
+ * exposing a mutable handle.
  */
-export const PROBE_NAMESPACES: ReadonlySet<string> = new Set(['prod']);
+export const PROBE_NAMESPACES: readonly string[] = Object.freeze(['prod']);
+
+/** Lookup form. Private, so nothing outside can add to it — see the note on the export above. */
+const PROBE_NAMESPACE_SET = new Set(PROBE_NAMESPACES);
 
 let warnedNamespace: string | null = null;
 
@@ -122,7 +131,7 @@ function probeNamespace(): string | null {
   // still off (an empty string is not in the allowlist either), but every unarmed pod logs a
   // misconfiguration error it has done nothing to deserve.
   if (raw === '') return null;
-  if (PROBE_NAMESPACES.has(raw)) return raw;
+  if (PROBE_NAMESPACE_SET.has(raw)) return raw;
 
   // Warn ONCE per distinct bad value: this runs on the generation hot path, and a per-call log on a
   // misconfigured deployment would be its own incident. `console.error` rather than a throw for the
@@ -141,9 +150,7 @@ function probeNamespace(): string | null {
     warnedNamespace = raw;
     console.error(
       `[moderation-cache-probe] EXTERNAL_MODERATION_CACHE_PROBE=${JSON.stringify(raw)} is not a ` +
-        `known deployment namespace (${[...PROBE_NAMESPACES].join(
-          ', '
-        )}). The probe is DISABLED. ` +
+        `known deployment namespace (${PROBE_NAMESPACES.join(', ')}). The probe is DISABLED. ` +
         `Set it to one of those to arm it, or leave it empty to disable it deliberately.`
     );
   }
@@ -247,6 +254,38 @@ export function probeModerationCacheRepeat(
   });
 }
 
+/**
+ * The probe's Redis key: `<prefix>:<namespace>:<window>:<digest>`.
+ *
+ * 🔴 THIS EXISTS AS A SEPARATE, EXPORTED FUNCTION FOR ONE REASON: to make the namespace derivation
+ * TESTABLE. It is not an abstraction anyone asked for, and inlining it would read better.
+ *
+ * Audit round 6 measured the problem it solves. Once the allowlist narrowed to a single member,
+ * `namespace` is always `'prod'` at runtime, so a mutant replacing `${namespace}` with the literal
+ * `prod` became INDISTINGUISHABLE from the real thing and SURVIVED a green 21-case suite — the
+ * same mutant that was killed by two cases one commit earlier. The key-shape test cannot see it,
+ * because with one member the shape is identical either way. So the coverage for the segment that
+ * exists to keep two deployments apart quietly went to zero at exactly the moment two rounds of
+ * work had gone into strengthening it.
+ *
+ * A pure function takes the namespace as an ARGUMENT, so a test can pass two different values
+ * without config being able to produce them. That restores the kill.
+ */
+export function buildProbeKey<P extends string>(
+  prefix: P,
+  namespace: string,
+  window: string,
+  digest: string
+): `${P}:${string}` {
+  // 🔴 GENERIC IN THE PREFIX, and not for elegance. `sysRedis.set` takes a key from a closed
+  // template-literal union derived from REDIS_SYS_KEYS, so a return type of `${string}:${string}`
+  // widens the key out of that union and the call stops compiling. Threading `P` through keeps the
+  // prefix literal, so the result is still `generation:moderation-cache-probe:${string}` and the
+  // typed-key guarantee survives the extraction. (Caught by `pnpm typecheck` the moment this
+  // function was introduced — the first version returned the widened type.)
+  return `${prefix}:${namespace}:${window}:${digest}`;
+}
+
 async function runProbe(
   source: ExternalModerationSource,
   preparedPrompt: string,
@@ -290,9 +329,14 @@ async function runProbe(
         // exactly the indeterminate case. Name BOTH axes before quoting a direction.
         //
         // The namespace segment keeps two armed deployments off each other's keyspace; see
-        // `probeNamespace`.
-        const key =
-          `${REDIS_SYS_KEYS.GENERATION.MODERATION_CACHE_PROBE}:${namespace}:${label}:${digest}` as const;
+        // `probeNamespace`. Built through `buildProbeKey` rather than inline SOLELY so a test can
+        // drive it with two different namespaces — see that function's note.
+        const key = buildProbeKey(
+          REDIS_SYS_KEYS.GENERATION.MODERATION_CACHE_PROBE,
+          namespace,
+          label,
+          digest
+        );
         const claimed = await sysRedis.set(key, '1', { NX: true, EX: seconds });
         record(source, label, claimed ? 'miss' : 'hit');
       } catch {

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -83,8 +83,18 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  * deployment needs a one-line code change — acceptable, and arguably correct, for a temporary
  * measurement instrument whose deployment set is known, small, and expected to shrink to zero when
  * the probe is removed.
+ *
+ * 🔴 THERE IS NO `preview` MEMBER, AND ITS ABSENCE IS THE POINT. It was in the first version of
+ * this list and audit round 4 removed it: `preview` is not a deployment, it is a CLASS. Measured
+ * live, ~10 concurrent `civitai-pr-*` namespaces each run this code, each take their config from
+ * one shared template (so they would all arm together, with the same value) and they share one
+ * `civitai-pr-sysredis`. Arming them would put every PR preview in the keyspace
+ * `…:preview:<window>:<digest>` at once — mutual hits across unrelated PRs, the exact collision
+ * the paragraph above says an allowlist prevents. A member that defeats the invariant the guard
+ * enforces is worse than no guard, because the guard is what stops anyone looking. If preview
+ * traffic is ever worth measuring it needs a PER-PR segment, not a shared word.
  */
-const PROBE_NAMESPACES: ReadonlySet<string> = new Set(['prod', 'next', 'next-stage', 'preview']);
+const PROBE_NAMESPACES: ReadonlySet<string> = new Set(['prod', 'next', 'next-stage']);
 
 let warnedNamespace: string | null = null;
 

--- a/src/server/integrations/moderation-cache-probe.ts
+++ b/src/server/integrations/moderation-cache-probe.ts
@@ -114,13 +114,16 @@ type ProbeWindowLabel = (typeof PROBE_WINDOWS)[number]['label'];
  * 🔴 A FROZEN ARRAY, NOT A `ReadonlySet`. `ReadonlySet<string>` is a COMPILE-TIME type and is erased
  * at runtime, so `(PROBE_NAMESPACES as Set<string>).add('preview')` from any importer would arm an
  * arbitrary namespace against the same object `probeNamespace` reads. `Object.freeze` on an array is
- * enforced by the runtime. The Set below is private and built from it, so lookup stays O(1) without
- * exposing a mutable handle.
+ * enforced by the runtime.
+ *
+ * 🔴 AND IT IS ONE OBJECT, DELIBERATELY — the ASSERTED object and the CONSULTED object must be the
+ * same one. A previous revision kept a private `Set` beside this array for O(1) lookup, and audit
+ * round 7 measured what that cost: growing the SET alone, leaving the array untouched, armed a new
+ * namespace while the ledger test kept happily asserting `['prod']` — green 22/22. The ledger's
+ * whole claim is that growth fails, and a second copy is exactly how that claim goes false. With a
+ * membership this small `.includes` is not measurably slower than `.has`, and it cannot drift.
  */
 export const PROBE_NAMESPACES: readonly string[] = Object.freeze(['prod']);
-
-/** Lookup form. Private, so nothing outside can add to it — see the note on the export above. */
-const PROBE_NAMESPACE_SET = new Set(PROBE_NAMESPACES);
 
 let warnedNamespace: string | null = null;
 
@@ -131,7 +134,7 @@ function probeNamespace(): string | null {
   // still off (an empty string is not in the allowlist either), but every unarmed pod logs a
   // misconfiguration error it has done nothing to deserve.
   if (raw === '') return null;
-  if (PROBE_NAMESPACE_SET.has(raw)) return raw;
+  if (PROBE_NAMESPACES.includes(raw)) return raw;
 
   // Warn ONCE per distinct bad value: this runs on the generation hot path, and a per-call log on a
   // misconfigured deployment would be its own incident. `console.error` rather than a throw for the
@@ -270,6 +273,15 @@ export function probeModerationCacheRepeat(
  *
  * A pure function takes the namespace as an ARGUMENT, so a test can pass two different values
  * without config being able to produce them. That restores the kill.
+ *
+ * ⚠️ AT THE FUNCTION ONLY — THE CALL SITE REMAINS UNCOVERED, AND THIS IS THE HONEST LIMIT. Audit
+ * round 7 measured it: hardcoding the third argument at the call site in `runProbe` (rather than
+ * inside this function) still leaves the suite green. With one allowlist member, `namespace` is
+ * always `'prod'` on every path config can reach, so no test driven through the public surface can
+ * distinguish a hardcoded argument from the derived one. Closing it would need a test-only
+ * injectable namespace resolver — more machinery than a temporary probe warrants — so it is
+ * recorded here instead of being left to read as closed. If a second member is ever added, that
+ * ALSO re-opens this: add a two-namespace behavioural case at the same time.
  */
 export function buildProbeKey<P extends string>(
   prefix: P,

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -74,7 +74,9 @@ async function moderatePrompt(
   // It also runs BEFORE the outcome is known, so it claims a window slot even for a call that then
   // fails. A real cache would store only successful verdicts, so this overstates the hit rate by
   // exactly the non-`ok` share — measured at ~0.01% in production, i.e. immaterial, but stated
-  // rather than assumed.
+  // rather than assumed. That is the SAME DIRECTION as the coalescing effect documented on the
+  // `SET NX` in the probe module: both make the reported hit rate optimistic, which is why the
+  // help text calls the result an upper bound and not a floor.
   probeModerationCacheRepeat(metricSource, preparedPrompt);
 
   // Wall-clock timing of the whole classifier call — the interval the generation submission actually

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -75,8 +75,13 @@ async function moderatePrompt(
   // fails. A real cache would store only successful verdicts, so this overstates the hit rate by
   // exactly the non-`ok` share — measured at ~0.01% in production, i.e. immaterial, but stated
   // rather than assumed. That is the SAME DIRECTION as the coalescing effect documented on the
-  // `SET NX` in the probe module: both make the reported hit rate optimistic, which is why the
-  // help text calls the result an upper bound and not a floor.
+  // `SET NX` in the probe module: both make the reported hit rate optimistic.
+  //
+  // ⚠️ That does NOT make the result "an upper bound", which is what this comment said for two
+  // commits. The probe also differs from a real cache on a SECOND axis — its TTL never extends on
+  // a hit — which points the other way, so the direction depends on which design you are comparing
+  // against. The three cases are enumerated on the `SET NX` note in the probe module; read them
+  // there rather than carrying a direction away from here.
   probeModerationCacheRepeat(metricSource, preparedPrompt);
 
   // Wall-clock timing of the whole classifier call — the interval the generation submission actually

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -1,4 +1,5 @@
 import { env } from '~/env/server';
+import { probeModerationCacheRepeat } from '~/server/integrations/moderation-cache-probe';
 import {
   clampExternalModerationSource,
   isAbortDeadlineError,
@@ -62,6 +63,19 @@ async function moderatePrompt(
   }
 
   const preparedPrompt = removeFalsePositiveTriggers(prompt);
+
+  // Dark measurement: would a verdict cache have avoided this call? Off by default, fire-and-forget,
+  // reads nothing back — the request below is issued either way. Placed HERE, on `preparedPrompt`
+  // rather than on `prompt`, because that is the exact string the classifier receives, so the digest
+  // matches what a real cache would key on. `removeFalsePositiveTriggers` is many-to-one, so probing
+  // the raw prompt instead would count two requests that produce an identical classifier call as
+  // distinct and UNDERSTATE the repeat rate.
+  //
+  // It also runs BEFORE the outcome is known, so it claims a window slot even for a call that then
+  // fails. A real cache would store only successful verdicts, so this overstates the hit rate by
+  // exactly the non-`ok` share — measured at ~0.01% in production, i.e. immaterial, but stated
+  // rather than assumed.
+  probeModerationCacheRepeat(metricSource, preparedPrompt);
 
   // Wall-clock timing of the whole classifier call — the interval the generation submission actually
   // parks on. Started before the span so the observation cannot be biased by span setup, and read


### PR DESCRIPTION
## What

A dark measurement probe that answers one question — **if we cached external moderation verdicts, how often would we skip the classifier?** — without caching anything. Off by default.

## Why this and not something cheaper

`extModeration.moderatePrompt` is an outbound HTTPS call that runs inline and serially on the generation submission path. Measured in production it is **~200 ms per call, p50 ~188 ms**, and it accounts for roughly **78–88 % of the app-side (non-submit) time of `orchestrator.generateFromGraph`**.

Three cheaper ways to attack that were tested against production measurements first, and **all three are dead**:

| lever | verdict | worth |
|---|---|---|
| Tune the tail / abort deadline | it's a **floor, not a tail** — 0 calls under 50 ms, 0.46 % under 100 ms | 6–24 ms |
| Reuse the connection | calls *do* pay a fresh TCP+TLS handshake (spacing per process far exceeds undici's 4 s default keep-alive, and nothing configures a dispatcher) — but the classifier answers from a nearby edge, so the whole handshake is ~7–24 ms | ~10 ms |
| Overlap it with the submit | impossible by construction — the audit is a **fail-closed gate**, so a flagged prompt must never reach `submitWorkflow` | ~10 ms |

What's left is the classifier's own inference time, and the only way to avoid paying it is to **not make the call**. That's worth building only if prompts actually repeat — and nobody knows whether they do. This measures exactly that, and nothing else.

## 🔴 It is a probe, not a cache

No verdict is ever read back. The classifier is called every single time, whatever the probe reports. Turning this into a real cache is a **trust-and-safety decision about verdict staleness**, not a performance one, and belongs in its own change with its own review. There's a test that fails if a hit ever skips the call.

## Design notes

- **Off by default, and armed with a NAMESPACE rather than a boolean** — `EXTERNAL_MODERATION_CACHE_PROBE=prod`, and `prod` is the **only** accepted value. The set is a closed allowlist rather than a charset plus a denylist (a denylist defends a class by listing members; `y`, `n`, `none`, `null`, `nil`, `disable`, `2` all walked through the one that shipped for a commit), and the three values that were once members are asserted **absent**: `preview` and `next` are *classes* rather than deployments, and `next-stage` isn't scraped. See the rollout note. It ships inert so the **arming instant is visible** as the moment the series appear — that's the only thing that distinguishes "no repeats" from "the probe never ran". The value becomes a key segment, so the probe cannot be armed without naming a keyspace: several civitai-web deployments share one sysRedis and sys keys carry no environment prefix, so two armed deployments would otherwise score hits on each other's prompts.
- **Two windows (5m, 1h), not one.** A single hit rate has no shape: it can't separate "users re-roll the same prompt within minutes" (a tiny TTL captures the value) from "the same prompts recur all day" (the cache has to be big). Those imply different builds.
- **Read the hit rate as `hit/(hit+miss)`, always `by (window)`.** Dividing over the *total* folds in `error`, so a Redis outage reads as "prompts stopped repeating" — the reassuring direction, and therefore the dangerous one. Omitting `by (window)` averages the 5m and 1h series into one number and collapses the very shape the two windows exist to reveal.
- **Ignore the first full window after arming.** The keyspace starts empty, so everything is necessarily a miss until the probe has run longer than the window it measures.
- **Fire-and-forget**, so it can't add latency to the very request whose latency is under investigation, and can't fail a generation. The Redis client is imported lazily to keep `moderation.ts`'s import graph light for its cron caller.
- **Hashes the *prepared* prompt** (post `removeFalsePositiveTriggers`) — the exact string the classifier receives, so the digest matches what a real cache would key on. Only the digest reaches Redis; **no prompt text is stored, logged, or put on a label.**
- **`SET NX EX`** in one atomic round trip, which keeps both windows cheap and the observation self-consistent — but see the bound below: that atomicity is not the same thing as fidelity.
- 🔴 **The bound is SCOPED, not absolute.** The probe differs from a real cache on **two** independent axes — it coalesces concurrent duplicates (`SET NX` claims the slot at request *start*, ~200 ms before a read-through cache could store an answer), and its TTL never extends on a hit. So: vs a **fixed-TTL non-coalescing** cache it is an **upper** bound; vs a **sliding-TTL coalescing** cache a **lower** one; vs a **sliding-TTL non-coalescing** cache — the ordinary design, since singleflight is a feature you must build — the two effects oppose and **no bound holds**. Name both axes before quoting a direction. *(Two corrections deep: round 1 said "floor", round 2 said "upper bound" unqualified, round 3 caught the sliding-TTL half pinning only one axis.)*

## Testing

22 cases, plus a **mutation battery that was run rather than trusted** — 15 isolated mutants plus targeted membership ones. Every defect the battery or an audit round caught is listed below; **count the bullets rather than trusting a total**, because a total kept beside the thing it counts has now gone stale three rounds running:

- 🔴 **The flag-off case was vacuous** (round 1, self-caught). Deleting the flag guard left the suite green, because a 20 ms sleep is shorter than the probe's first lazy `import()` — it proved the probe is *slow*, not *off*. Restructured as a differential.
- 🔴 **The probe's own `source` clamp was untested** (audit round 1). The existing case drove `moderatePrompt`, which clamps first and passes the clamped value, so the probe's clamp never saw a bad string — a mutant deleting it survived a green 14-case suite. Now exercised by a case that calls the export directly.
- 🔴 **Every boolean-shaped "off" token ARMED the probe** (audit round 2). Once the flag became a namespace, the charset accepted `false`/`off`/`no`/`0`/`disabled` — so the likeliest spelling of "disable this" armed it under a namespace called `false`, and two deployments "disabled" that way would share `…:false:…`.
- 🔴 **And the denylist that fixed it was itself walkable** (audit round 3). `y`, `n`, `none`, `null`, `undefined`, `nil`, `disable`, `enable`, `2` all passed both the charset and the ten-word denylist; zod's own `stringbool` treats `y`/`n` as boolean spellings. Replaced with a closed allowlist — a guard that is structural rather than spelled.
- 🔴 **Shipping inert did not mean shipping silent** (own battery, found by *isolating* the mutants properly). Removing the empty-string early return leaves the probe off — so all 20 cases stayed green — while making an unarmed deployment log a misconfiguration error it has done nothing to deserve. Nothing asserted the silence. Now pinned. *(Measured cost of that mutant: one line per process per distinct value — the dedupe caps it. An earlier revision of this body said "on every generation", overstating it by orders of magnitude.)*

- 🔴 **`preview` was in the allowlist and defeated the allowlist's own invariant** (audit round 4). `preview` is not a deployment, it is a *class*: ~10 concurrent `civitai-pr-*` namespaces run this code, take config from one shared template, and share one sysRedis — so arming that word arms all of them into one keyspace and they score mutual hits across unrelated PRs. Dropped, and asserted absent.
- 🔴 **The allowlist was the whole arming contract with half of it unexercised** (audit round 4). Deleting `next-stage` left all 20 cases green. Now an asserted ledger that fails whether the set **grows or shrinks** — verified in both directions.

- 🔴 **Dropping `preview` moved the class hazard instead of closing it** (audit round 5). The PR-preview Tekton task copies `civitai-next`'s `civitai-cfg` **wholesale** into every `civitai-pr-<N>` namespace and repoints them at one shared sysRedis — so arming `next` would silently arm every open PR's preview into a single keyspace. Verified against the GitOps repo.
- 🔴 **Two of the three members were unreadable even when armed** (audit round 5). `civitai-next` and `civitai-next-stage` have **zero** ServiceMonitors/PodMonitors between them, and the probe's population twin exists in exactly one namespace. Arming them shows no series — which the help text defines as "not armed". Allowlist reduced to `prod`.
- 🔴 **The membership ledger was false in the growth direction** (audit round 5). Adding `'staging'` survived 21/21, because a loop over candidates can only see growth by a member already in its own list. The set is now exported and asserted **whole** against a literal.
- 🔴 **The battery caught me deleting two tests.** Splicing a rewrite on text anchors silently removed everything between them; the suite stayed green at 19/19 and it surfaced only as a mutant surviving. Both restored. A green suite cannot tell you a test is missing.

- 🔴 **Narrowing to one allowlist member silently took the namespace-segment coverage to ZERO** (audit round 6). A mutant hardcoding the namespace was killed by two cases one commit earlier and **survived a green 21-case suite** after the narrowing — with one member, the shape test cannot tell a literal from the real derivation. Restored with an exported `buildProbeKey` seam a test can drive with two namespaces. The comment claiming the replacement was "stronger, not weaker" was false and is corrected.
- 🔴 **A fix can be un-fixed by a restore.** The round-5 relative-counter fix landed, then I restored two deleted tests *from `HEAD`* — which predated it — silently reverting it, while the commit message asserted it had landed. Re-applied and verified by grepping after, not by trusting the edit.

Every mutant below is **isolated** to the narrowest expression that can be wrong. That matters: two earlier rows were not, and each scored a kill for the wrong reason. Counts are measured, not estimated; the unmutated control runs green before and after.

| mutant |
|---|
| hash the raw prompt instead of the prepared one |
| the probe's own clamp removed |
| allowlist guard removed |
| allowlist widened back to the previous charset guard |
| allowlist grown by a member |
| allowlist not frozen |
| empty string no longer means off |
| namespace **hardcoded** in the key |
| namespace dropped from the key |
| `error` folded into `miss` |
| hit/miss inverted |
| `NX` dropped |
| diagnostic log removed |
| diagnostic logs on every call |
| probe moved above the not-configured skip check |

⚠️ **Per-mutant kill counts are deliberately not listed.** They were, and they drifted for three consecutive rounds — a count kept beside the thing it counts goes stale every time the suite changes, and a stale count in a table headed "measured, not estimated" is worse than no table. The claim that matters is the one the reader can re-derive: **every mutant above is killed, and the unmutated control is green before and after.**

`pnpm typecheck` clean (0 errors), eslint + prettier clean, and **732 passed / 7 skipped** over a named population: `src/server/integrations/__tests__`, `src/server/prom/__tests__`, `src/server/services/orchestrator/__tests__`, `src/env/__tests__`, `src/server/redis/__tests__`.

⚠️ **Corrections to earlier revisions of this body**, kept rather than silently edited away: it described the result as a **floor** (wrong, optimistically), then as an unqualified **upper bound** (pinning only one of two axes); it reported the skip-check mutant as killed by 2 cases (**1**, once isolated); it said a mutant cost a log line **per generation** (one per process per distinct value); and it stated a mutant count and kill table that had gone stale. The source comments carry the same retractions, including one where I asserted the previous env spelling "failed boot loudly on garbage" — it never failed on anything, which I confirmed by executing it.

## Rollout

Merging changes nothing — the flag defaults to empty, which is OFF. Arming it means setting `EXTERNAL_MODERATION_CACHE_PROBE=prod` on `civitai-dp-prod`, which is the **only** deployment the allowlist accepts and the only one that is scraped. Give it more than an hour before reading the 1h window.

🔴 **Before ever adding a member, check both**: that the value names ONE running population rather than a config template other namespaces inherit, and that something actually scrapes it. Both of those failed silently on values that looked obviously fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rtwdS8j8PA3TWMZemcY27
