### PR TITLE
fix(postgres-query): --notifications could not connect at all

### DIFF
--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -210,8 +210,19 @@ if (!connectionString) {
   process.exit(1);
 }
 
+// `sslmode=require` in a connection string makes pg verify the certificate chain, and
+// it WINS over the `ssl` option below - so `--notifications` failed outright with
+// `self-signed certificate in certificate chain` against the bastion, while every other
+// target worked because their URLs say `sslmode=no-verify`, which already agrees with
+// the policy this script sets explicitly two lines down. Drop just that one value so the
+// client's own `rejectUnauthorized: false` applies uniformly. `no-verify` is left alone:
+// it already means what we want, and rewriting it would be a change with no effect.
+const effectiveConnectionString = connectionString
+  .replace(/([?&])sslmode=require(?=&|$)/i, '$1')
+  .replace(/[?&]$/, '');
+
 const client = new Client({
-  connectionString,
+  connectionString: effectiveConnectionString,
   ssl: { rejectUnauthorized: false },
   statement_timeout: timeoutSeconds * 1000,
   query_timeout: timeoutSeconds * 1000,


### PR DESCRIPTION
## The bug

`node .claude/skills/postgres-query/query.mjs --notifications ...` failed **every time**:

```
Query error: self-signed certificate in certificate chain
```

Not intermittent, not environmental — the target was unusable for every seat on the box.

## Cause

The script sets `ssl: { rejectUnauthorized: false }` on the client, but `NOTIFICATION_DB_REPLICA_URL` carries `sslmode=require`, and **pg honours the connection string over the client option**. So the bastion's self-signed certificate got verified and rejected, despite the script explicitly asking not to verify it.

Every other target already works, and the reason is the discriminator here: their URLs say `sslmode=no-verify`, which already agrees with the policy the script sets two lines down. Only the notifications URL says `require`.

| env var | sslmode | worked |
|---|---|---|
| `DATABASE_URL`, `DATABASE_REPLICA_URL` | `no-verify` | yes |
| `DEV_DATABASE_URL` | `no-verify` | yes |
| `DATABASE_DATA_PACKET_URL` | none | yes |
| `NOTIFICATION_DB_REPLICA_URL` | **`require`** | **no** |

## The fix

Drop `sslmode=require` only. `no-verify` is deliberately left alone — it already means what the script wants, and rewriting it would be a change with no effect for a later reader to reason about.

## Verified

Run in a tree with `node_modules`, after the change:

| command | result |
|---|---|
| `--notifications SELECT COUNT(*) FROM "Notification" WHERE type = 'new-image-comment'` | **776221 rows**, 16.7s (previously: hard failure) |
| `--prod SELECT 1` | `ok`, 97ms — unchanged, no regression |

The 776,221 figure cross-checks exactly against a standalone script that stripped the same param independently, so the patched path is reaching the same database rather than merely not erroring.

## Note on how this was nearly missed

My first attempt looked correct and silently did nothing: a heredoc turned the `\b` in the regex into a literal backspace byte, so `sslmode=require<BS>` never matched anything. `grep` showed the line as expected — the control character is invisible — and the target still failed with the identical error, which reads exactly like "the diagnosis was wrong" rather than "the patch didn't apply". Instrumenting the effective connection string, rather than re-reasoning about the cause, is what separated the two.

Found while verifying a notification-details question for #4599. The workaround there was a local throwaway script, which would have died with that session and left the next seat hitting the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtYZrp2py6qZLag9LcgGBs
