### PR TITLE
F5b (split): give iframe.minHeight its own, tighter ceiling (800)

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -157,9 +157,9 @@
         },
         "minHeight": {
           "type": "integer",
-          "description": "Minimum iframe height in px.",
+          "description": "Minimum iframe height in px. Capped well below maxHeight's ceiling on purpose: minHeight is a floor the host must honour, so a large value overrides the host's viewport clamp and can push the block off a phone screen.",
           "minimum": 40,
-          "maximum": 4000
+          "maximum": 800
         },
         "maxHeight": {
           "description": "Maximum iframe height in px, or null for unbounded.",

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -65,9 +65,11 @@ describe('BlockManifestValidator', () => {
 
     it('accepts a 40-char blockId (boundary) and a 3-char one', () => {
       const max = 'a' + 'b'.repeat(38) + 'c'; // 40 chars
-      expect(BlockManifestValidator.validate({ ...VALID_MANIFEST, blockId: max }, APP_CTX)).toEqual({
-        valid: true,
-      });
+      expect(BlockManifestValidator.validate({ ...VALID_MANIFEST, blockId: max }, APP_CTX)).toEqual(
+        {
+          valid: true,
+        }
+      );
       expect(
         BlockManifestValidator.validate({ ...VALID_MANIFEST, blockId: 'abc' }, APP_CTX)
       ).toEqual({ valid: true });
@@ -130,9 +132,7 @@ describe('BlockManifestValidator', () => {
     expect(result.valid).toBe(false);
     if (!result.valid) {
       expect(
-        result.errors.some(
-          (e) => e.includes('allow-top-navigation') || e.includes('not allowed')
-        )
+        result.errors.some((e) => e.includes('allow-top-navigation') || e.includes('not allowed'))
       ).toBe(true);
     }
   });
@@ -157,9 +157,7 @@ describe('BlockManifestValidator', () => {
       ...VALID_MANIFEST,
       iframe: { ...VALID_MANIFEST.iframe, sandbox: 'allow-scripts allow-modals' },
     };
-    expect(
-      BlockManifestValidator.validate(unverified, APP_CTX).valid
-    ).toBe(false);
+    expect(BlockManifestValidator.validate(unverified, APP_CTX).valid).toBe(false);
 
     const verified = { ...unverified, trustTier: 'verified' };
     expect(BlockManifestValidator.validate(verified, APP_CTX).valid).toBe(true);
@@ -178,9 +176,7 @@ describe('BlockManifestValidator', () => {
     expect(result.valid).toBe(false);
     if (!result.valid) {
       expect(
-        result.errors.some(
-          (e) => e.includes('allow-popups') || e.includes('not allowed')
-        )
+        result.errors.some((e) => e.includes('allow-popups') || e.includes('not allowed'))
       ).toBe(true);
     }
   });
@@ -201,7 +197,9 @@ describe('BlockManifestValidator', () => {
     ).toBe(true);
   });
 
-  it('rejects iframe heights outside the [40, 4000] envelope', () => {
+  // The envelope is no longer one range: `minHeight` is [40, 800] and `maxHeight`
+  // is [40, 4000]. The asymmetry has its own describe block below.
+  it('rejects iframe heights outside their envelopes', () => {
     const tiny = {
       ...VALID_MANIFEST,
       iframe: { ...VALID_MANIFEST.iframe, minHeight: 10 },
@@ -223,6 +221,68 @@ describe('BlockManifestValidator', () => {
     if (!result.valid) {
       expect(result.errors.some((e) => e.includes('iframe.maxHeight must be ≥'))).toBe(true);
     }
+  });
+
+  /**
+   * `minHeight` gets a TIGHTER ceiling than `maxHeight`, and the asymmetry is the
+   * whole guard — a test that only checked "some big number is rejected" would
+   * pass just as happily with both ceilings moved, which is the change that
+   * would break every live block.
+   *
+   * WHY THE CAP EXISTS. `maxHeight` is a ceiling the publisher volunteers, and
+   * the host binds below it anyway. `minHeight` is a FLOOR the host must honour —
+   * the host's viewport clamp (#4589) computes `Math.max(min, viewportBudget)` —
+   * so a large enough `minHeight` overrides the viewport clamp outright. At the
+   * old shared ceiling of 4000 a single schema-legal field reproduced exactly the
+   * defect that clamp exists to prevent: a 4000px slot on a 640px screen.
+   *
+   * WHY 800. Measured against the complete approved population (11 of 11 blocks,
+   * not a sample): the largest declared `minHeight` is 700. 800 rejects nothing
+   * that exists and leaves headroom above it.
+   */
+  describe('iframe.minHeight has its own, tighter ceiling', () => {
+    const withIframe = (over: Record<string, unknown>) => ({
+      ...VALID_MANIFEST,
+      iframe: { ...VALID_MANIFEST.iframe, ...over },
+    });
+
+    it('accepts 800 — the boundary is inclusive, and 800 is above every live block (max 700)', () => {
+      expect(
+        BlockManifestValidator.validate(withIframe({ minHeight: 800 }), APP_CTX),
+        'a minHeight of exactly 800 must be accepted: the largest live declaration is 700, so an ' +
+          'exclusive boundary here would be a needless contract break'
+      ).toEqual({ valid: true });
+      expect(
+        BlockManifestValidator.validate(withIframe({ minHeight: 700 }), APP_CTX),
+        'the largest minHeight in the live approved population (700) must still validate — this ' +
+          'cap is supposed to reject nothing that exists today'
+      ).toEqual({ valid: true });
+    });
+
+    it('rejects 801 and 4000, naming the tighter bound', () => {
+      for (const minHeight of [801, 4000]) {
+        const result = BlockManifestValidator.validate(withIframe({ minHeight }), APP_CTX);
+        expect(result.valid, `minHeight ${minHeight} should be rejected`).toBe(false);
+        if (!result.valid) {
+          expect(
+            result.errors.some((e) => e.includes('iframe.minHeight must be a number in [40, 800]')),
+            `minHeight ${minHeight} was rejected, but not by the minHeight envelope — errors were ` +
+              `${JSON.stringify(result.errors)}. A pass on the wrong error is not coverage.`
+          ).toBe(true);
+        }
+      }
+    });
+
+    it('does NOT tighten maxHeight — 4000 must still validate', () => {
+      // 🔴 THE REGRESSION THIS PAIR EXISTS FOR. Both bounds used to share one
+      // constant. Lowering that shared constant to 800 would reject EVERY block
+      // in the live population at once: all 11 declare `maxHeight: 4000`.
+      expect(
+        BlockManifestValidator.validate(withIframe({ minHeight: 600, maxHeight: 4000 }), APP_CTX),
+        'maxHeight 4000 must still be accepted — all 11 live approved blocks declare exactly ' +
+          'that, so tightening it would reject the entire population'
+      ).toEqual({ valid: true });
+    });
   });
 
   it('rejects scopes the OAuth client does not allow', () => {
@@ -260,9 +320,7 @@ describe('BlockManifestValidator', () => {
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(
-          result.errors.some(
-            (e) => e.includes('not a known block scope') && e.includes(removed)
-          )
+          result.errors.some((e) => e.includes('not a known block scope') && e.includes(removed))
         ).toBe(true);
       }
     }
@@ -738,9 +796,9 @@ describe('BlockManifestValidator', () => {
       const result = BlockManifestValidator.validate(manifest, APP_CTX);
       expect(result.valid).toBe(false);
       if (!result.valid) {
-        expect(
-          result.errors.some((e) => e === 'tagline must not be blank (omit it instead)')
-        ).toBe(true);
+        expect(result.errors.some((e) => e === 'tagline must not be blank (omit it instead)')).toBe(
+          true
+        );
       }
     });
 
@@ -766,7 +824,9 @@ describe('BlockManifestValidator', () => {
     it('accepts a justification keyed by a declared scope', () => {
       const manifest = {
         ...VALID_MANIFEST,
-        scopeJustifications: { 'models:read:self': 'We render the page model in a comparison widget.' },
+        scopeJustifications: {
+          'models:read:self': 'We render the page model in a comparison widget.',
+        },
       };
       expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
     });
@@ -794,7 +854,9 @@ describe('BlockManifestValidator', () => {
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(
-          result.errors.some((e) => e.includes('user:read:self') && e.includes('not in the manifest'))
+          result.errors.some(
+            (e) => e.includes('user:read:self') && e.includes('not in the manifest')
+          )
         ).toBe(true);
       }
     });
@@ -864,7 +926,9 @@ describe('BlockManifestValidator', () => {
       if (!result.valid) {
         expect(
           result.errors.some(
-            (e) => e.includes('sensitive scopes require a justification') && e.includes('ai:write:budgeted')
+            (e) =>
+              e.includes('sensitive scopes require a justification') &&
+              e.includes('ai:write:budgeted')
           )
         ).toBe(true);
       }
@@ -945,7 +1009,9 @@ describe('BlockManifestValidator', () => {
       const manifest = {
         ...VALID_MANIFEST,
         scopes: ['collections:read:private', 'apps:storage:shared:write'],
-        scopeJustifications: { 'collections:read:private': 'We read the viewer’s private collections.' },
+        scopeJustifications: {
+          'collections:read:private': 'We read the viewer’s private collections.',
+        },
       };
       const result = BlockManifestValidator.validate(manifest, APP_CTX);
       expect(result.valid).toBe(false);
@@ -973,7 +1039,9 @@ describe('BlockManifestValidator', () => {
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(
-          result.errors.some((e) => e.includes('user:read:self') && e.includes('not in the manifest'))
+          result.errors.some(
+            (e) => e.includes('user:read:self') && e.includes('not in the manifest')
+          )
         ).toBe(true);
       }
     });

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -214,11 +214,7 @@ export const MANIFEST_TAGLINE_MAX_LENGTH = 140;
  * Re-exported so `ManifestEditForm.tsx` can import the bound + the host list from the
  * validator it already imports, rather than reaching into the schema module directly.
  */
-export {
-  MAX_REPOSITORY_URL_LENGTH,
-  REPOSITORY_HOST_ALLOWLIST,
-  validateRepositoryUrl,
-};
+export { MAX_REPOSITORY_URL_LENGTH, REPOSITORY_HOST_ALLOWLIST, validateRepositoryUrl };
 
 // Config-as-code `buildCommand` shape allowlist (defense-in-depth — see the
 // field comment in RawManifest). The build sandbox is already isolated; this
@@ -234,8 +230,7 @@ export {
 // is rejected. The separate SHELL_METACHAR_RE below is a redundant second gate
 // so the rejection reason is explicit when a metachar is what tripped it.
 export const BUILD_COMMAND_MAX_LENGTH = 128;
-export const BUILD_COMMAND_RE =
-  /^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$/;
+export const BUILD_COMMAND_RE = /^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$/;
 // Shell metacharacters that must never appear in a buildCommand. Checked first
 // so the error is specific ("contains shell metacharacters") rather than the
 // generic allowlist-miss message.
@@ -253,6 +248,37 @@ export { SCOPE_JUSTIFICATION_MAX_LENGTH };
 // registration time is cheaper than fighting them at runtime.
 const HEIGHT_MIN_FLOOR = 40;
 const HEIGHT_MAX_CEILING = 4000;
+
+// 🔴 A TIGHTER CEILING FOR `minHeight` ALONE, and the asymmetry is the point.
+//
+// `maxHeight` is a CEILING the publisher volunteers — a big one costs nothing,
+// because the host's own layers (HARD_HEIGHT_CEILING and the viewport clamp in
+// IframeHost's viewport clamp, added in #4589) bind below it. `minHeight` is a FLOOR the
+// host is obliged to honour: `Math.max(min, viewportBudget)` means a large
+// enough `minHeight` wins over the viewport outright, so at 4000 a single
+// schema-legal field reproduced exactly the defect the viewport clamp exists to
+// prevent — a 4000px slot on a 640px screen — with the clamp fully present.
+//
+// 800 rather than something tighter: measured against the complete approved
+// population (11 of 11 blocks, not a sample) the largest declared `minHeight` is
+// 700, so this rejects NOTHING that exists today and leaves headroom above it.
+// It bounds only what a FUTURE manifest can declare.
+//
+// 🔴 It does NOT make the viewport clamp a total bound, and must not be read as
+// doing so: 600/640/700 are all still legal and all still exceed the budget a
+// 640px viewport leaves after the host chrome. Closing that residue is a
+// per-publisher change or a precedence change, not a constant.
+//
+// Mirrored (as `maximum` on `iframe.minHeight`) in public/schemas/app-block/v1.json,
+// which the Go CLI re-vendors from the LIVE published copy on a 6-hourly cron —
+// see `.github/workflows/revendor-canonical-schema.yml` in civitai/cli. That
+// mirror is byte-compared against the URL, so it goes red only after a
+// `main` → `release` cut publishes these bytes, and its own automation opens the
+// resync PR. The CLI ALSO carries a hand-maintained Go copy of this envelope
+// (`internal/validate/semantic.go`, `heightMaxCeiling`) that the re-vendor does
+// NOT touch — until that is updated the CLI accepts a `minHeight` this validator
+// rejects, which fails CLOSED at the real gate but gives a late error.
+const MIN_HEIGHT_MAX_CEILING = 800;
 
 // SSRF gate for iframe.src and assetBundleUrl. `isPublicHttpsUrl` (and the
 // `PRIVATE_HOSTNAME_PATTERNS` it uses) live in `~/server/utils/ssrf-hostname` (a
@@ -375,9 +401,7 @@ export class BlockManifestValidator {
     opts?: ManifestValidationOptions
   ): ValidationResult {
     const ctx: AppContext =
-      typeof app === 'number'
-        ? { allowedScopes: app, allowedOrigins: [] }
-        : app;
+      typeof app === 'number' ? { allowedScopes: app, allowedOrigins: [] } : app;
     const errors: string[] = [];
     const oauthClientAllowedScopes = ctx.allowedScopes;
 
@@ -495,16 +519,16 @@ export class BlockManifestValidator {
           errors.push(`scope "${scope}" is not a known block scope`);
         }
       }
-      const blockScopes = (m.scopes as unknown[]).filter(
-        (s): s is string => typeof s === 'string'
-      );
+      const blockScopes = (m.scopes as unknown[]).filter((s): s is string => typeof s === 'string');
       const scopeCheck = validateBlockScopesAgainstOauthClient(
         blockScopes,
         oauthClientAllowedScopes
       );
       if (!scopeCheck.valid) {
         errors.push(
-          `requested scopes exceed OAuth client allowedScopes: ${scopeCheck.rejectedScopes.join(', ')}`
+          `requested scopes exceed OAuth client allowedScopes: ${scopeCheck.rejectedScopes.join(
+            ', '
+          )}`
         );
       }
     }
@@ -521,7 +545,9 @@ export class BlockManifestValidator {
         typeof m.scopeJustifications !== 'object' ||
         Array.isArray(m.scopeJustifications)
       ) {
-        errors.push('scopeJustifications must be an object mapping scope-id to a justification string');
+        errors.push(
+          'scopeJustifications must be an object mapping scope-id to a justification string'
+        );
       } else {
         const declaredScopes = new Set(
           Array.isArray(m.scopes)
@@ -593,9 +619,7 @@ export class BlockManifestValidator {
         return;
       }
       if (!allowedOriginSet.has(origin)) {
-        errors.push(
-          `${field} rejected: origin ${origin} not in OauthClient.allowedOrigins`
-        );
+        errors.push(`${field} rejected: origin ${origin} not in OauthClient.allowedOrigins`);
       }
     }
 
@@ -647,10 +671,10 @@ export class BlockManifestValidator {
       if (
         typeof iframe.minHeight !== 'number' ||
         iframe.minHeight < HEIGHT_MIN_FLOOR ||
-        iframe.minHeight > HEIGHT_MAX_CEILING
+        iframe.minHeight > MIN_HEIGHT_MAX_CEILING
       ) {
         errors.push(
-          `iframe.minHeight must be a number in [${HEIGHT_MIN_FLOOR}, ${HEIGHT_MAX_CEILING}]`
+          `iframe.minHeight must be a number in [${HEIGHT_MIN_FLOOR}, ${MIN_HEIGHT_MAX_CEILING}]`
         );
       }
       if (
@@ -673,9 +697,10 @@ export class BlockManifestValidator {
       if (typeof iframe.resizable !== 'boolean') {
         errors.push('iframe.resizable must be a boolean');
       }
-      const tierForSandbox = (ALLOWED_TRUST_TIERS.has(trustTier)
-        ? trustTier
-        : 'unverified') as 'unverified' | 'verified' | 'internal';
+      const tierForSandbox = (ALLOWED_TRUST_TIERS.has(trustTier) ? trustTier : 'unverified') as
+        | 'unverified'
+        | 'verified'
+        | 'internal';
       if (typeof iframe.sandbox !== 'string' || iframe.sandbox.length === 0) {
         errors.push('iframe.sandbox must be a non-empty string');
       } else {
@@ -713,7 +738,9 @@ export class BlockManifestValidator {
           // slot — the page surface is declared via the `page` field, not a
           // `targets` entry.
           if (isPageSlot(slotId)) {
-            errors.push(`target slotId "${slotId}" is the page slot — declare a full page via the "page" field, not targets`);
+            errors.push(
+              `target slotId "${slotId}" is the page slot — declare a full page via the "page" field, not targets`
+            );
           }
         }
       }

--- a/src/server/services/blocks/__tests__/manifest-iframe-height.schema-drift.test.ts
+++ b/src/server/services/blocks/__tests__/manifest-iframe-height.schema-drift.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { BlockManifestValidator } from '~/server/services/block-manifest-validator.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * Drift guard — the manifest `iframe` height envelope.
+ *
+ * TWO places declare these bounds and they must never diverge:
+ *   1. the canonical published schema `public/schemas/app-block/v1.json` — what
+ *      the Go CLI byte-mirrors (re-vendored from the LIVE published copy by
+ *      `.github/workflows/revendor-canonical-schema.yml` in `civitai/cli`) and
+ *      what editors validate against;
+ *   2. the IMPERATIVE validator in
+ *      `src/server/services/block-manifest-validator.service.ts`, which is the
+ *      authoritative gate at submit/approve — the JSON schema is a shape hint.
+ *
+ * 🔴 THE ASYMMETRY IS THE THING UNDER GUARD, not the numbers on their own.
+ * `minHeight` is capped at 800 and `maxHeight` at 4000, and they used to share
+ * one constant. Each direction of collapsing them back is a distinct, severe
+ * failure:
+ *
+ *   - raising `minHeight` back to 4000 re-opens the defect the host's viewport
+ *     clamp exists to prevent. The host clamp (`clampBlockHeight`, added by #4589) computes
+ *     `Math.max(min, viewportBudget)`, so a large `minHeight` overrides the
+ *     clamp outright — measured at 390x640 with `{minHeight: 4000}`, the applied
+ *     height was 4000 WITH the clamp present;
+ *   - lowering `maxHeight` to 800 rejects the ENTIRE live population: all 11
+ *     approved blocks declare `maxHeight: 4000`.
+ *
+ * So the bounds are asserted INDEPENDENTLY, and each assertion says which
+ * failure it is standing in front of. A single "both are in range" check would
+ * be satisfied by either collapse.
+ *
+ * 🔴 STRUCTURAL + BEHAVIOURAL, deliberately. Reading the schema's numbers proves
+ * only what one JSON file says; the validator is what actually rejects a
+ * manifest, and the two are separate code paths. Each case therefore checks the
+ * declared number AND drives the validator across the boundary.
+ */
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'public/schemas/app-block/v1.json');
+
+/** The largest `minHeight` in the live approved population (11 of 11 measured). */
+const LARGEST_LIVE_MIN_HEIGHT = 700;
+/** The `maxHeight` every live approved block declares (11 of 11). */
+const LIVE_MAX_HEIGHT = 4000;
+
+const MIN_HEIGHT_CEILING = 800;
+const MAX_HEIGHT_CEILING = 4000;
+const HEIGHT_FLOOR = 40;
+
+// Mirrors the APP_CTX in block-manifest-validator.service.test.ts: `iframe.src`
+// is gated against the app's registered allowedOrigins, so a bare scope value
+// defaults allowedOrigins to [] and every manifest here would be rejected for a
+// reason that has nothing to do with heights.
+const APP_CTX = {
+  allowedScopes: TokenScope.ModelsRead,
+  allowedOrigins: ['https://blocks.civitai.com'],
+};
+
+const BASE = {
+  blockId: 'test-block',
+  version: '1.0.0',
+  name: 'Test Block',
+  contentRating: 'g',
+  renderMode: 'iframe',
+  trustTier: 'unverified',
+  scopes: ['models:read:self'],
+  iframe: {
+    src: 'https://blocks.civitai.com/test',
+    minHeight: 200,
+    maxHeight: null as number | null,
+    resizable: true,
+    sandbox: 'allow-scripts',
+  },
+};
+
+const validateWith = (over: Record<string, unknown>) =>
+  BlockManifestValidator.validate(
+    { ...BASE, iframe: { ...BASE.iframe, ...over } },
+    APP_CTX as never
+  );
+
+describe('app-block v1 schema ⇄ iframe height envelope drift guard', () => {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
+    properties?: {
+      iframe?: {
+        properties?: {
+          minHeight?: { minimum?: unknown; maximum?: unknown };
+          maxHeight?: { minimum?: unknown; maximum?: unknown };
+        };
+      };
+    };
+  };
+  const heights = () => schema.properties?.iframe?.properties;
+
+  it('the schema caps minHeight at 800 — the bound that keeps a publisher floor from overriding the viewport clamp', () => {
+    expect(
+      heights()?.minHeight?.maximum,
+      'the canonical schema no longer caps `iframe.minHeight` at 800. At 4000 a single ' +
+        'schema-legal field reproduces the exact defect the host viewport clamp exists to ' +
+        'prevent, because the host clamp (#4589) honours `Math.max(min, viewportBudget)`.'
+    ).toBe(MIN_HEIGHT_CEILING);
+    expect(heights()?.minHeight?.minimum).toBe(HEIGHT_FLOOR);
+  });
+
+  it('the schema leaves maxHeight at 4000 — tightening it would reject every live block', () => {
+    expect(
+      heights()?.maxHeight?.maximum,
+      'the canonical schema changed `iframe.maxHeight`. All 11 live approved blocks declare ' +
+        'exactly 4000, so any ceiling below that rejects the entire population at once.'
+    ).toBe(MAX_HEIGHT_CEILING);
+    expect(heights()?.maxHeight?.minimum).toBe(HEIGHT_FLOOR);
+  });
+
+  it('the VALIDATOR agrees with the schema at the minHeight boundary', () => {
+    // The schema numbers above are a claim about one JSON file. This is the gate.
+    expect(
+      validateWith({ minHeight: MIN_HEIGHT_CEILING }).valid,
+      `minHeight ${MIN_HEIGHT_CEILING} sits exactly on the declared ceiling and must be accepted`
+    ).toBe(true);
+    expect(
+      validateWith({ minHeight: MIN_HEIGHT_CEILING + 1 }).valid,
+      `minHeight ${MIN_HEIGHT_CEILING + 1} is over the declared ceiling and must be rejected — ` +
+        'the schema and the imperative validator have drifted'
+    ).toBe(false);
+  });
+
+  it('the VALIDATOR still accepts the live population, both bounds at once', () => {
+    // The regression that a numbers-only guard cannot see: both live values in
+    // one manifest, through the real gate.
+    expect(
+      validateWith({ minHeight: LARGEST_LIVE_MIN_HEIGHT, maxHeight: LIVE_MAX_HEIGHT }).valid,
+      `the tallest live declaration (minHeight ${LARGEST_LIVE_MIN_HEIGHT}, maxHeight ` +
+        `${LIVE_MAX_HEIGHT}) no longer validates — this change was supposed to reject nothing ` +
+        'that exists today'
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
> **Draft, and split out of #4589 deliberately.** #4589 is the host-side viewport clamp and has zero cross-repo cost; this is the manifest-**contract** half and has some. They are decoupled, not stacked — this branch is based directly on `main`.

## The hole

`HEIGHT_MAX_CEILING = 4000` was shared by **both** `iframe.minHeight` and `iframe.maxHeight`. They are not the same kind of bound:

- **`maxHeight` is a ceiling the publisher volunteers.** A big one costs nothing — the host's own layers (`HARD_HEIGHT_CEILING`, and the viewport clamp in #4589) bind below it.
- **`minHeight` is a floor the host is obliged to honour.** The host clamp computes `Math.max(min, viewportBudget)`, so a large enough `minHeight` wins over the viewport outright.

Measured at 390×640 with `{minHeight: 4000}` and the block reporting 100: **appliedHeight = 4000** — a 4000px slot on a 640px screen, reachable through one schema-legal field, *with* #4589's clamp fully present.

## The change

`minHeight` gets its own `MIN_HEIGHT_MAX_CEILING = 800`, mirrored as `maximum` on `iframe.minHeight` in `public/schemas/app-block/v1.json`. **`maxHeight` stays at 4000.**

800 rejects **nothing that exists**: measured over the complete approved population (11 of 11 blocks, not a sample) the largest declared floor is **700**.

🔴 **The asymmetry is the thing under guard**, and collapsing it is severe in a named direction either way:

| collapse | consequence |
|---|---|
| raise the `minHeight` ceiling back to 4000 | the 4000px-slot defect above returns |
| lower `maxHeight` to 800 | **every live block is rejected at once** — all 11 declare `maxHeight: 4000` |

So `src/server/services/blocks/__tests__/manifest-iframe-height.schema-drift.test.ts` asserts each bound **independently** — a single "both in range" check is satisfied by either collapse — and additionally drives the imperative validator across the `minHeight` boundary. The schema numbers are a claim about one JSON file; the validator is what actually rejects a manifest, and they are separate code paths.

## 🔴 This does NOT close the residue

Do not merge it believing otherwise. Live floors are `400 ×1 / 600 ×5 / 640 ×3 / 700 ×2`, and at a 640px viewport the budget after the host overhead (chrome 31 + 1px on each frame border = **33**) is **607** — so the 640-tier (×3) and the 700-tier (×2) are bound by their own, entirely modest floor and still overflow by **33px and 93px**: **5 of 11**. The 400- and 600-tiers fit. A cap at 800 changes none of those.

> ⚠️ **Corrected.** An earlier revision of this body said *"budget 542 … 10 of 11 … 58–158px"*, computed from a chrome figure of 98 that #4589's suite measured **without `@mantine/core/styles.css` loaded** — an empty cascade, in which the frame's `1px` borders also compute to 0. The real overhead is 33, re-measured with the stylesheet in place. The correction matters here: it means the 600-tier, **five of the eleven live blocks**, actually fits. The commit message on this branch still carries the old figure and cannot be amended after pushing.

Shrinking that residue is a per-publisher change (lower those blocks' declared `minHeight`) or a change to which of floor/viewport wins — not a constant, and not attempted here.

## Measured mirror cost — why this is a draft

**civitai CI is unaffected.** Nothing in this repo guarded `iframe.*` at all until this commit; `manifest-schema-endpoint.test.ts` deep-equals the endpoint against the file it already imports, so it follows.

**Downstream fires on the `main` → `release` cut, not on merge** — the mirrors byte-compare against the *live published* schema URL, which only changes on a release deploy.

`civitai/cli`'s schema mirror **self-heals**: `revendor-canonical-schema.yml` runs 6-hourly, re-vendors, validates in-job and opens a PR. Its fixtures use `minHeight` 400/600, so that PR opens cleanly.

Two hand edits are needed in repos this one does not control, and **both should land before that cut**:

1. 🔴 **`civitai-app-starters` → `packages/civitai-app-sdk/test/blocks/schema-parity.test.ts:230`** hardcodes `expect(minHeightSchema?.maximum).toBe(4000)`. Its weekly re-vendor bot runs that suite **before** opening a PR, so it **fails closed and opens nothing** — that repo's CI stays red until a human changes 4000 → 800. Line 249's `maxHeight` assertion stays correct as-is; the test **name** at :219 ("canonical bounds 40-4000") also goes stale.
   *Closing condition: :230 reads 800, :219 renamed, that repo's `schema-drift` job green.*
2. **`civitai/cli` → `internal/validate/semantic.go:38`** — `heightMaxCeiling = 4000` is a hand-maintained Go re-derivation the re-vendor does **not** touch, and it is used for **both** bounds (lines 240-243). That is the *same collapsed-constant defect* this PR fixes in civitai, and it needs the same split; until then the CLI accepts a `minHeight` the server rejects (fails closed at the real gate, but gives a late error).
   *Closing condition: `semantic.go` carries a separate `minHeightMaxCeiling = 800` and `go test ./...` passes.*

## Verification

| | result |
|---|---|
| red at `origin/main` @ `e92cf5fe4a` (validator + schema reverted) | `Tests 3 failed \| 173 passed (176)` |
| green at HEAD | `Tests 178 passed (178)` |

Three isolated mutants, all killed by this suite's own assertion messages:

| mutant | change | killed by |
|---|---|---|
| V1 | `MIN_HEIGHT_MAX_CEILING` back to 4000 | *"minHeight 801 should be rejected"* + *"the schema and the imperative validator have drifted"* |
| V2 | tighten `HEIGHT_MAX_CEILING` to 800 as well | *"maxHeight 4000 must still be accepted — all 11 live approved blocks declare exactly that…"* + *"the tallest live declaration (minHeight 700, maxHeight 4000) no longer validates"* |
| V3 | schema back to 4000, validator left at 800 | *"the canonical schema no longer caps `iframe.minHeight` at 800…"* |

The schema JSON is edited as a **2-line diff**; it is not run through Prettier (it is already non-Prettier-formatted on `main`, and `scripts/prettier-changed.mjs` only targets `.ts`/`.tsx`), so the downstream byte-mirror diff stays minimal.

