### PR TITLE
docs(AppBlocks): stop calling the node `unit` tier a merge gate — it is not one

### DIFF
--- a/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeMobileShell.browser.test.tsx
@@ -688,7 +688,7 @@ describe('AppBlockChrome mobile shell', () => {
   /**
    * 🔴 CONSTRAINT 1, AND NOT REGRESSION COVERAGE — both cases pass at `origin/main`
    * and are supposed to. `CHROME_BAR_PX` in `slotReservation.ts` pins the bar's
-   * resting height as the model slot's CLS reservation and is asserted in a GATING
+   * resting height as the model slot's CLS reservation and is asserted in a
    * node-tier test, so the mobile shell must not move it. This checks that at a
    * rendered-pixel level, at both viewports, rather than by reading a constant back.
    *

--- a/src/components/AppBlocks/AppBlockChromeRecentsClamp.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeRecentsClamp.browser.test.tsx
@@ -7,12 +7,12 @@
  * it silently did not: `ChromeSurfaceItem` wraps children in
  * `<Text size="sm" lineClamp={1}>` in its SHEET branch and rendered them raw in its
  * MENU branch, so the publisher-controlled app name lost the clamp the pre-primitive
- * chrome gave it. Nothing caught it — the full gating tier and all seven touched
+ * chrome gave it. Nothing caught it — the full node `unit` tier and all seven touched
  * browser suites were green with the defect present — because every existing test
  * either uses a short fixture name or asserts attributes rather than geometry.
  *
  * So the guard is a MEASUREMENT, not a source-text pin.
- * `__tests__/chromeItemClamp.test.ts` carries the structural half in the gating node
+ * `__tests__/chromeItemClamp.test.ts` carries the structural half in the node `unit`
  * tier; this is the half that would still fail if `clamp` were threaded correctly and
  * rendered something that does not actually clamp.
  *

--- a/src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChromeResponsive.browser.test.tsx
@@ -29,10 +29,15 @@
  * the assertions still pass. Vitest browser mode runs each test file in its own
  * iframe, so the import does not leak into the sibling suites.
  *
- * 🔴 THIS PROJECT IS NOT A GATE. The Vitest browser-mode `component` project is
- * report-only in CI. The gating half of this change is the node-tier
- * `__tests__/chromeGeometry.test.ts` (which is unit coverage of a new module,
- * not regression coverage — see its own header).
+ * 🔴 NOTHING HERE IS A GATE — AND NEITHER IS THE OTHER TIER. The Vitest
+ * browser-mode `component` project runs in CI as the REPORT-ONLY
+ * `preview / component-tests` status. Its node-tier counterpart for this change
+ * is `__tests__/chromeGeometry.test.ts` (which is unit coverage of a new module,
+ * not regression coverage — see its own header); that tier is report-only on a
+ * pull request too (`continue-on-error`) and renders a real verdict on a push to
+ * `main` or a `workflow_dispatch`. NEITHER TIER BLOCKS A MERGE: `main` requires
+ * no status check at all in this repo, so a red run here is a signal a reviewer
+ * must read, not a door that stays shut.
  */
 import '@mantine/core/styles.css';
 import { describe, expect, test, vi } from 'vitest';

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -249,10 +249,12 @@ const WILDCARD_REVIEW_NACK_CODE: WildcardPackErrorCode = 'forbidden';
  * unreachable content), so the number's only job is to make the band as small as
  * it can be while still catching the degenerate case. Raising it widens the
  * population that sees two scrollbars, so the value is bounded on BOTH sides —
- * in `__tests__/pageRunScrollContract.test.ts` (the GATING node suite; that is
- * the copy that can block a merge) and again in
- * `PageBlockHostScrollFit.browser.test.tsx` (report-only, which is why it is not
- * the only one). The NUMBERS deliberately live in those tests, not here: a band
+ * in `__tests__/pageRunScrollContract.test.ts` (the node `unit` suite, which
+ * renders a real verdict on a push to `main`) and again in
+ * `PageBlockHostScrollFit.browser.test.tsx` (the report-only browser tier, which
+ * is why it is not the only one). NEITHER TIER BLOCKS A MERGE: `main` requires
+ * no status check at all in this repo, so both are signals a reviewer must read,
+ * not doors that stay shut. The NUMBERS deliberately live in those tests, not here: a band
  * declared beside the value it bounds can be moved in the same edit. What lives
  * here is the ARITHMETIC that justifies them.
  *
@@ -3999,8 +4001,10 @@ export function PageBlockHost({
           `AppBlocks` browser suite green while the app column collapses to ~150px at a
           900px content height — a running App Block reduced to a sliver, with every tier
           green. `__tests__/pageBlockHostMaxWidth.test.ts` therefore pins this style block
-          verbatim in the GATING tier; that source pin is the only thing standing between
-          that mutation and production.
+          verbatim in the node `unit` tier; that source pin is the only thing that CATCHES
+          that mutation at all. It does not BLOCK it: `main` requires no status check in
+          this repo, so what the pin buys is a red run a reviewer has to read (and an
+          honest verdict on a push to `main`), not a door that stays shut.
 
           ⚠️ `minHeight: 0` IS DEFENCE, NOT A LOAD-BEARING PROPERTY — SAY SO RATHER THAN
           NAMING A TEST THAT DOES NOT COVER IT. Measured: removing it leaves the scroll-fit

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -44,10 +44,13 @@ import type * as TrpcMod from '~/utils/trpc';
  *
  * NOTE ON REACH: the browser `component` project runs in CI as the
  * `preview / component-tests` status — REPORT-ONLY, so a break here is visible
- * but does not block a merge. This file is the EMPIRICAL half; the gating half
- * is the source guard in `__tests__/pageBlockHostMaxWidth.test.ts`, which is in
- * the node `unit` project. Neither can replace the other: only a real layout can
- * see a width, and only the gating tier can stop a merge.
+ * but does not block a merge. This file is the EMPIRICAL half; the source-guard
+ * half is `__tests__/pageBlockHostMaxWidth.test.ts`, which is in the node `unit`
+ * project — report-only on a pull request too (`continue-on-error`), and an
+ * honest verdict on a push to `main` or a `workflow_dispatch`. NEITHER TIER
+ * BLOCKS A MERGE: `main` requires no status check at all in this repo. Neither
+ * can replace the other either: only a real layout can see a width, and only the
+ * node tier stays honest on `main`.
  */
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));

--- a/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostScrollFit.browser.test.tsx
@@ -44,9 +44,12 @@ import type * as TrpcMod from '~/utils/trpc';
  *
  * NOTE ON REACH: this suite DOES run in CI — `pnpm run test:component`, surfaced
  * as the `preview / component-tests` commit status — but REPORT-ONLY, so a break
- * here is visible without blocking a merge. The gating half of this contract is
- * the source-scan guard in `__tests__/pageRunScrollContract.test.ts`. This file
- * is the empirical half, and it is the one that can see layout at all.
+ * here is visible without blocking a merge. The source-scan half of this contract
+ * is `__tests__/pageRunScrollContract.test.ts`, in the node `unit` project —
+ * report-only on a pull request too (`continue-on-error`), and an honest verdict
+ * on a push to `main` or a `workflow_dispatch`. NEITHER TIER BLOCKS A MERGE:
+ * `main` requires no status check at all in this repo. This file is the empirical
+ * half, and it is the one that can see layout at all.
  */
 
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));

--- a/src/components/AppBlocks/__tests__/chromeCrumbLinkStyle.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeCrumbLinkStyle.test.ts
@@ -21,10 +21,13 @@ import { describe, expect, it } from 'vitest';
  *
  * Together those are the claim. Neither half alone is.
  *
- * 🔴 AND IT IS IN THE GATING TIER, WHICH THE RENDERED ONE WOULD NOT HAVE BEEN. The
- * browser project runs in CI as the REPORT-ONLY `preview / component-tests` status, so
- * nothing there can block a merge; the node `unit` project can. Same split, and the same
- * reasoning, as `pageBlockHostMaxWidth.test.ts`.
+ * 🔴 AND IT IS IN THE TIER THAT EXECUTES, WHICH THE RENDERED ONE WOULD NOT HAVE BEEN.
+ * The browser project runs in CI as the REPORT-ONLY `preview / component-tests` status;
+ * the node `unit` project actually runs the assertion, report-only on a pull request
+ * (`continue-on-error`) and an honest verdict on a push to `main` or a
+ * `workflow_dispatch`. NEITHER TIER BLOCKS A MERGE: `main` requires no status check at
+ * all in this repo, so this is a signal a reviewer must read, not a door that stays
+ * shut. Same split, and the same reasoning, as `pageBlockHostMaxWidth.test.ts`.
  *
  * HISTORY THIS PROTECTS. The crumb used to carry `c="blue.6" td="underline"` — a
  * hand-rolled colour and decoration. The `blue.6` was not arbitrary: an audit found

--- a/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeGeometry.test.ts
@@ -16,8 +16,13 @@
  * (monotonic, and `base` == the pre-change constants) that no single rendered
  * viewport can express.
  *
- * It lives in the node `unit` project on purpose: that tier is GATING in CI,
- * while the browser `component` project is report-only.
+ * It lives in the node `unit` project on purpose: that tier EXECUTES the
+ * assertion, while the browser `component` project runs in CI as the REPORT-ONLY
+ * `preview / component-tests` status. The node tier is report-only on a pull
+ * request too (`continue-on-error`) and renders a real verdict on a push to
+ * `main` or a `workflow_dispatch`. NEITHER TIER BLOCKS A MERGE: `main` requires
+ * no status check at all in this repo, so this is a signal a reviewer must read,
+ * not a door that stays shut.
  */
 import { describe, expect, it } from 'vitest';
 import {

--- a/src/components/AppBlocks/__tests__/chromeItemClamp.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeItemClamp.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * A PUBLISHER-CONTROLLED LABEL IN THE APP-BLOCK CHROME MUST BE HELD TO ONE LINE.
- * Node `unit` project — the GATING tier. The rendered proof lives in
- * `AppBlockChromeRecentsClamp.browser.test.tsx`; this is the copy that can block a
- * merge.
+ * Node `unit` project — the tier that EXECUTES this assertion (report-only on a
+ * pull request, an honest verdict on a push to `main`). The rendered proof lives in
+ * `AppBlockChromeRecentsClamp.browser.test.tsx`, in the REPORT-ONLY browser tier.
+ * NEITHER TIER BLOCKS A MERGE: `main` requires no status check at all in this repo,
+ * so this is a signal a reviewer must read, not a door that stays shut.
  *
  * WHAT BROKE. F3 consolidated the chrome's two dropdowns and its bottom sheets onto
  * one primitive (`ChromeSurface`). Its sheet row wraps children in
@@ -16,7 +18,7 @@ import { describe, expect, it } from 'vitest';
  * which the pre-primitive chrome wrapped in exactly that `Text`, with the comment
  * "`lineClamp={1}` keeps a pathologically long name from blowing out the dropdown at
  * ANY of its widths". The consolidation dropped it on the desktop path only, and
- * nothing noticed: the whole gating tier and all seven touched browser suites stayed
+ * nothing noticed: the whole node `unit` tier and all seven touched browser suites stayed
  * green. Measured at 1440×900 with a 63-char name (`APP_CHROME_NAME_MAX` is 64), the
  * row went 35px → 78px — three lines — ×`RECENTLY_RUN_LIMIT` = 5. (The audit reported
  * 33.6 → 56.7 for the same defect with a shorter fixture; the gap is the name length,

--- a/src/components/AppBlocks/__tests__/chromeListingQueryIsSingleSourced.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeListingQueryIsSingleSourced.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * The app-block host chrome reads `appListings.getAppDetail` from exactly ONE place.
- * Node `unit` project — the GATING tier (the Vitest browser-mode `component` project
- * is report-only in CI, so `ChromeReviewEntry.browser.test.tsx`, which proves the
- * same property behaviourally against real React Query, cannot block a merge).
+ * Node `unit` project — the tier that EXECUTES this assertion (report-only on a pull
+ * request, an honest verdict on a push to `main`). `ChromeReviewEntry.browser.test.tsx`
+ * proves the same property behaviourally against real React Query, in the REPORT-ONLY
+ * browser tier. NEITHER TIER BLOCKS A MERGE: `main` requires no status check at all in
+ * this repo, so this is a signal a reviewer must read, not a door that stays shut.
  *
  * WHY IT EXISTS. F2 gave the chrome one consumer of that listing row (the app-name
  * crumb's store popover). F4 added a second (the ⋮ menu's review item, which needs

--- a/src/components/AppBlocks/__tests__/chromeNavAlignsWithSubNav.test.ts
+++ b/src/components/AppBlocks/__tests__/chromeNavAlignsWithSubNav.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * The app-block host chrome's platform-nav dropdown must draw the store's
- * destinations the way the STORE draws them. Node `unit` project — the GATING
- * tier (the Vitest browser-mode `component` project is report-only in CI, so the
- * behavioural companion in `AppBlockChromePlatformNav.browser.test.tsx` cannot
- * block a merge).
+ * destinations the way the STORE draws them. Node `unit` project — the tier that
+ * EXECUTES this assertion (report-only on a pull request, an honest verdict on a
+ * push to `main`). The behavioural companion in
+ * `AppBlockChromePlatformNav.browser.test.tsx` is in the REPORT-ONLY browser tier.
+ * NEITHER TIER BLOCKS A MERGE: `main` requires no status check at all in this
+ * repo, so this is a signal a reviewer must read, not a door that stays shut.
  *
  * WHAT BROKE. `AppBlockChrome`'s dropdown and `AppsSubNav`'s tab bar are two
  * renderings of ONE platform navigation — a user who opens an app from the store

--- a/src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts
+++ b/src/components/AppBlocks/__tests__/featureFlagsMockCompleteness.test.ts
@@ -4,8 +4,13 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * A WHOLESALE `vi.mock('~/providers/FeatureFlagsProvider', …)` factory must name
- * BOTH flag hooks. Node `unit` project — the GATING tier, which matters here
- * because the failure this prevents is invisible in the report-only browser tier.
+ * BOTH flag hooks. Node `unit` project — the tier that EXECUTES this assertion,
+ * which matters here because the failure this prevents is invisible in the browser
+ * tier. Both tiers are report-only on a pull request (the node one via
+ * `continue-on-error`, the browser one always, as `preview / component-tests`);
+ * the node tier renders an honest verdict on a push to `main`. NEITHER TIER BLOCKS
+ * A MERGE: `main` requires no status check at all in this repo, so this is a signal
+ * a reviewer must read, not a door that stays shut.
  *
  * WHAT BROKE (F2). `IframeHost.tsx` began importing a component that reads
  * `useOptionalFeatureFlags` — the non-throwing variant, correct for a chrome that

--- a/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeAwareMenu.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * EVERY `<Menu>` in the app-block host chrome must be iframe-aware. Node `unit`
- * project — the GATING tier. The behavioural proof lives in
+ * project — the tier that EXECUTES this assertion (report-only on a pull request,
+ * an honest verdict on a push to `main`). The behavioural proof lives in
  * `AppBlockChrome.browser.test.tsx`, which runs in CI as the REPORT-ONLY
- * `preview / component-tests` status; this is the copy that can block a merge.
+ * `preview / component-tests` status. NEITHER TIER BLOCKS A MERGE: `main` requires
+ * no status check at all in this repo, so this is a signal a reviewer must read,
+ * not a door that stays shut.
  *
  * WHAT BROKE. `AppBlockChrome` renders two Mantine menus a hundred lines apart.
  * The platform-nav one was made CONTROLLED with a window-`blur` close, because

--- a/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
+++ b/src/components/AppBlocks/__tests__/pageRunScrollContract.test.ts
@@ -4,11 +4,14 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * `/apps/run/<slug>` must declare a NON-SCROLLING layout, and its host must
- * claim no height of its own. Node `unit` project — the GATING suite. The
- * `.browser.test.tsx` component suites DO run in CI, as the report-only
- * `preview / component-tests` status (`pnpm run test:component`), so a break
- * there is visible but does not block a merge. The coupling is pinned here for
- * that reason, and only MEASURED in `PageBlockHostScrollFit.browser.test.tsx`.
+ * claim no height of its own. Node `unit` project — the suite that EXECUTES this
+ * assertion (report-only on a pull request via `continue-on-error`, an honest
+ * verdict on a push to `main` or a `workflow_dispatch`). The `.browser.test.tsx`
+ * component suites DO run in CI, as the report-only `preview / component-tests`
+ * status (`pnpm run test:component`), so a break there is visible but is only ever
+ * an annotation. NEITHER TIER BLOCKS A MERGE: `main` requires no status check at
+ * all in this repo. The coupling is pinned here so that it is at least visible on
+ * `main`, and only MEASURED in `PageBlockHostScrollFit.browser.test.tsx`.
  *
  * WHAT BROKE. The route shipped a bare `export default function AppPage`, so it
  * inherited `AppLayout`'s default `scrollable: true` — a `ScrollArea` with
@@ -474,7 +477,7 @@ describe('the run page and its host agree on who owns the height', () => {
   });
 
   /**
-   * 🔴 THE FLOOR'S VALUE BELONGS IN THE GATING TIER, NOT ONLY THE BROWSER ONE.
+   * 🔴 THE FLOOR'S VALUE BELONGS IN THE NODE TIER, NOT ONLY THE BROWSER ONE.
    *
    * `FILL_MIN_HEIGHT_PX` is the whole WCAG fix: too low and a short viewport
    * strands content behind `overflow-hidden`; too high and the page grows a
@@ -483,23 +486,26 @@ describe('the run page and its host agree on who owns the height', () => {
    * `PageBlockHostScrollFit.browser.test.tsx` — and that suite is REPORT-ONLY
    * (`preview / component-tests`) and historically ~16% flaky, i.e. exactly the
    * combination that trains people to click through. Measured: with the floor set
-   * to 0, this gating file was 9/9 GREEN and only the non-blocking tier went red.
+   * to 0, this node-tier file was 9/9 GREEN and only the browser tier went red.
    *
    * So the band is asserted HERE too, by reading the declaration out of the
    * source the same way the `HEADER_HEIGHT` tripwire above does. The browser
    * suite still measures the CONSEQUENCE (a real host, laid out, at two viewport
-   * sizes); this pins the DECISION so a merge cannot quietly change it.
+   * sizes); this pins the DECISION so that changing it cannot be silent. It is
+   * still only a signal — NEITHER TIER BLOCKS A MERGE (`main` requires no status
+   * check at all in this repo); what this buys is a red run on a push to `main`
+   * and an annotation a reviewer has to read.
    *
    * 🔴 THE BOUNDS ARE DELIBERATELY LITERALS HERE, NOT READ FROM THE SOURCE. A
    * band imported from (or regexed out of) `PageBlockHost.tsx` would be graded
    * against the same file it bounds, so a single edit could move the value and
    * its own limits together — the self-referential trap this whole guard exists
    * because of. The ARITHMETIC that justifies them lives on the constant's doc
-   * comment; the NUMBERS live here (gating) and in
-   * `PageBlockHostScrollFit.browser.test.tsx` (report-only). Both must admit a
+   * comment; the NUMBERS live here (node tier) and in
+   * `PageBlockHostScrollFit.browser.test.tsx` (browser tier). Both must admit a
    * value, so the tighter pair wins and drift is fail-safe.
    */
-  it('`FILL_MIN_HEIGHT_PX` stays inside its documented band — in the BLOCKING tier', () => {
+  it('`FILL_MIN_HEIGHT_PX` stays inside its documented band — in the node tier', () => {
     const declared = /export const FILL_MIN_HEIGHT_PX = (\d+);/.exec(code(read(HOST)))?.[1];
     expect(
       declared,

--- a/src/components/AppBlocks/chromeGeometry.ts
+++ b/src/components/AppBlocks/chromeGeometry.ts
@@ -6,9 +6,13 @@
  * renders on two surfaces with wildly different widths — the narrow
  * `model.sidebar_top` slot and the full-page `/apps/run/<slug>` frame — and it
  * used to carry hard-coded pixel caps for both. Putting the decision in a pure
- * function keeps it testable in the node `unit` project, which is the GATING
- * tier here (the Vitest browser-mode `component` project is report-only in CI),
- * exactly as `slotReservation.ts` and `selectChromeRecentApps` already do.
+ * function keeps it testable in the node `unit` project, which is the tier that
+ * EXECUTES such an assertion (the Vitest browser-mode `component` project runs in
+ * CI as the REPORT-ONLY `preview / component-tests` status; the node tier is
+ * report-only on a pull request too and renders a real verdict on a push to
+ * `main` — neither blocks a merge, since `main` requires no status check at all
+ * in this repo), exactly as `slotReservation.ts` and `selectChromeRecentApps`
+ * already do.
  *
  * 🔴 ONE BREAKPOINT SCALE, AND IT IS THE PX SCALE. This repo has two scales that
  * agree on exactly one key:


### PR DESCRIPTION
Comment-only. No behaviour change, no test logic touched, no assertion moved. 15 files, +102/-55, all prose.

## What was false

~13 comments across `src/components/AppBlocks/` asserted that the node `unit` test tier is a merge gate — "the GATING tier", "the copy that can block a merge", "only the gating tier can stop a merge" — plus one test title reading "in the BLOCKING tier". None of that is true.

## Measured ground truth

- `.github/workflows/lint.yml:405` sets `continue-on-error: ${{ github.event_name == 'pull_request' }}` on the `unit` job. That workflow's `on:` also includes `push: branches: [main]` and `workflow_dispatch`. Line 377 of the same file already records the consequence: *"`conclusion` is USELESS here: `continue-on-error` makes it `success` while the suite underneath is broken."*
- `gh api repos/civitai/civitai/branches/main/protection --jq 'has("required_status_checks")'` returns **`false`**, and the `required_status_checks` endpoint returns **404 "Required status checks not enabled"**. The only ruleset on `main` is a `deletion` rule.

**So no status check is required on `main`, by either mechanism.** On a pull request the node `unit` tier is report-only. It renders an honest verdict only on a push to `main` or a `workflow_dispatch`. A red run is a signal a human must read — never a merge blocker.

## What was deliberately NOT over-corrected

The distinction the old wording was reaching for is real and is preserved everywhere: the node `unit` project **executes** the assertion, whereas the Vitest browser-mode `component` project is the always-report-only `preview / component-tests` status. What is false is calling *either* one a merge gate. The guards themselves are unchanged and still catch exactly what their headers claim.

Two files in this directory — `__tests__/pageBlockHostMaxWidth.test.ts` and `__tests__/ledgerSelectorSurvivesProdStrip.test.ts` — already carried the corrected wording. This PR converges the rest onto their phrasing rather than inventing 13 new sentences.

## Before / after

Same instrument both times: `git grep -niE 'gating|block(s|ing)? a merge' -- 'src/components/AppBlocks/'`

**Before: 45 hits. After: 32.**

Every one of the 32 survivors is accounted for:

| Survivors | Why they are fine |
|---|---|
| 13 lines matching `NEITHER TIER BLOCKS A MERGE` / `does not block a merge` / `neither blocks a merge` | These are the **corrections** — the true negation of the claim being removed. |
| `AppPermissionsActivityDrawer.tsx:54`, `PageBlockHost.tsx:488`, `:671`, `:1785`, `PageBlockHostLaunchReveal.browser.test.tsx:448`, `PageBlockHostSharedStorage.browser.test.tsx:963`, `IframeHostStatusGates.browser.test.tsx:57`, `shouldStartInit.test.ts:16`, `:32` | "gating" in the **program-logic** sense — conditional mount, a NACK gate, a token-settled branch, message pre-conditions, init preconditions. A different word, not a CI claim. |
| `blockIframeUrl.ts:32`, `:34`, `:72`, `hostHandlerParity.ts:140`, `PageBlockHostTokenTerminal.browser.test.tsx:489` | Substring false positives — "navi**gating**", "propa**gating**". |
| `ledgerSelectorSurvivesProdStrip.test.ts:323`, `pageBlockHostMaxWidth.test.ts:29`, `:494` | Already-correct pre-existing wording, untouched. |

Adversarial confirmation that no claim of this class survives, with a positive control on the same pattern:

```
$ git grep -niE 'GATING (tier|suite|node|half|file|project)|BLOCKING tier|can block a merge|can stop a merge' -- 'src/components/AppBlocks/'
(none)

$ git grep -niE '<same pattern>' origin/main -- 'src/components/AppBlocks/' | wc -l
21
```

## Verification

- **Node `unit`, scoped to `src/components/AppBlocks/`** — `7 failed | 747 passed (754)` at `origin/main`, and `7 failed | 747 passed (754)` at this commit. The failing set is byte-identical (`diff` of the sorted FAIL lines is empty): the 7 pre-existing `__tests__/hiddenBlocks.test.ts` failures, `TypeError: Cannot read properties of undefined (reading 'clear')`. Both runs used the same warm `.vite` cache.
- **`node scripts/typecheck.mjs`** — `typecheck: OK — 0 type errors in 94s`. Instrument validated: with a deliberately broken scratch file in this same directory it returned rc=2 and named it.
- **prettier + eslint on the 15 changed paths** — both clean. Both instruments validated with a positive control on the identical invocation: a 16th, deliberately bad file was flagged by each while the 15 real ones stayed clean, so the zero is a real zero and not an empty file list.

## Out of scope, noted

The same false "BLOCKING tier" phrasing also appears in `src/components/Apps/` — `__tests__/appListingDetailModActions.test.ts:24` and `__tests__/appModeratorMessageForm.callSites.test.ts:593`. Left untouched: this PR was scoped to `src/components/AppBlocks/`. Worth the same treatment in a follow-up if someone is already in that directory.
