### PR TITLE
fix(models): bump Model."updatedAt" when restoreModelById un-deletes a model

### DIFF
--- a/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
+++ b/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
@@ -53,10 +53,27 @@ const LEDGER = [
  *    breaks the line after the table name, which is how `restoreModelById`
  *    writes it. The closing quote is what excludes `UPDATE "ModelVersion"`;
  *    the space was never doing that job.
- *  - `model.service.ts` holds THREE raw `UPDATE "Model"` statements and only
+ *  - `model.service.ts` holds SEVEN raw `UPDATE "Model"` statements and only
  *    one of them drafts. Taking the first match would have anchored this guard
  *    on `captureMinorFlagSnapshot`'s meta write — a different statement, in a
  *    different function, with nothing to do with the reaper.
+ *
+ * 🔴 The two defects COMPOSE, which is why neither was visible on its own. The
+ * drafting statement is the FIRST of the seven, so a first-match rule alone
+ * would have found it; it is the space anchor that skips it, and only then does
+ * first-match land on the meta write. Fixing either half in isolation would have
+ * produced a guard that happened to be right for the wrong reason.
+ *
+ * 🔴 And the reason no review round could have caught this: both files this
+ * extractor was originally written against hold EXACTLY ONE raw `UPDATE "Model"`
+ * each, and both spell it `UPDATE "Model" m` — with a space, because of the
+ * alias. Both assumptions were therefore true of the entire corpus the guard
+ * could see. A guard's doc comment states a RULE ("a raw-SQL write that drafts a
+ * Model"); its implementation covered two files that happened to satisfy two
+ * unstated assumptions. Nothing short of pointing it at a file it was not
+ * written for can tell those apart — which is exactly what adding the third site
+ * did. When extending a ledger like this, re-derive the extractor against the
+ * NEW file before trusting the green it reports.
  *
  * Each statement is read to the end of its tagged template (the next backtick).
  * That over-reads on a template carrying an interpolated expression, which is

--- a/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
+++ b/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
@@ -69,9 +69,26 @@ const LEDGER: { file: string; draftingStatements: number }[] = [
  * this file: that statement extracted 156 characters and ended mid-ternary.
  *
  * So the scan tracks `${...}` interpolations by brace depth, recursing through
- * nested templates and skipping quoted strings inside the JS. Known limits, both
- * absent from this corpus: a brace or backtick inside a regex literal or a `//`
- * comment within an interpolation would confuse the depth count.
+ * nested templates and skipping quoted strings inside the JS.
+ *
+ * KNOWN LIMITS, none present in this corpus. 🔴 They are listed WITH THE
+ * DIRECTION THEY FAIL, because a limits list that mixes the two is more
+ * dangerous than no list — a reader assumes the whole list is as harmless as
+ * whichever entry they check first:
+ *
+ *  - FAILS CLOSED — a brace or backtick inside a regex literal or a `//` comment
+ *    within an interpolation confuses the depth count. The scan then runs long
+ *    or never terminates, which surfaces as the unterminated-template error or a
+ *    wrong count. Loud, and it cannot un-watch a statement.
+ *  - 🔴 FAILS OPEN — an `UPDATE "Model"` written INSIDE an interpolation of
+ *    another `UPDATE "Model"` template. Because the scan now correctly reads to
+ *    the OUTER close, the inner statement is absorbed into the outer one rather
+ *    than enumerated separately. Measured: outer bumped, inner drafting and
+ *    unbumped gives `drafting=1, bumped=1` and an exact count of 1 — all green
+ *    over an unbumped drafting statement. Deliberately NOT engineered around:
+ *    nobody nests an `UPDATE "Model"` inside another one, and a parser change to
+ *    catch it would cost more risk than the shape is worth. Recorded so the next
+ *    person weighing that trade has the measurement rather than a guess.
  */
 function templateEnd(source: string, start: number): number {
   let i = start;
@@ -226,12 +243,22 @@ describe('a raw SQL write that drafts a Model bumps its "updatedAt"', () => {
   // The exact number fails in BOTH directions: a statement that disappears from
   // the extractor's view, and one that ARRIVES unwatched. Bumping the number is
   // how you record a deliberate decision about a new site.
+  //
+  // 🔴 But an INCREASE has two causes and only one of them is a new site. The
+  // extractor anchors on the raw text `UPDATE "Model"`, so a `//` comment or a
+  // string that merely QUOTES the statement counts as one. That is not
+  // hypothetical here: the comment block on `restoreModelById` already contains
+  // `'Draft'` and `"updatedAt" = now()`, so it is one `UPDATE "Model"` mention
+  // away from tripping this — and prose about this very guard is exactly the
+  // kind of text that would do it. The failure message therefore has to name
+  // that cause, because a maintainer who follows a bare "bump the count" would
+  // permanently install a phantom statement in the ledger.
   it.each(LEDGER)(
     '$file holds exactly the drafting statements this ledger claims',
     ({ file, draftingStatements: expected }: (typeof LEDGER)[number]) => {
       expect(
         draftingStatements(file).length,
-        `${file}: expected ${expected} raw UPDATE "Model" statement(s) writing Draft. Fewer means one dropped out of the extractor's view and is no longer checked; more means a new drafting site arrived — bump the count here once you have confirmed it carries the bump.`
+        `${file}: expected ${expected} raw UPDATE "Model" statement(s) writing Draft. FEWER means one dropped out of the extractor's view and is no longer checked. MORE means one of two things: either a real new drafting site arrived, in which case confirm it carries the bump and then raise the count here — or a comment or string literal now quotes the statement text, which this text-anchored extractor cannot tell from real SQL. If it is prose, REWORD THE PROSE; do not raise the count, or you install a phantom statement in this ledger permanently.`
       ).toBe(expected);
     }
   );

--- a/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
+++ b/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
@@ -15,63 +15,95 @@ import { describe, expect, it } from 'vitest';
  * irreversibly. A model drafted by raw SQL without the bump therefore enters the
  * reapable state with its entire 30-day grace period already spent.
  *
- * These two sites are checked as SOURCE TEXT rather than by executing them,
- * because one is an admin `temp/` endpoint whose handler stack would have to be
- * stood up to reach the statement. The job's statement is additionally covered
- * behaviourally-ish in `src/server/jobs/__tests__/reset-to-draft-without-requirements.test.ts`;
- * this guard exists so the endpoint is not the untested half of one fix.
+ * These sites are checked as SOURCE TEXT rather than by executing them, because
+ * one is an admin `temp/` endpoint whose handler stack would have to be stood up
+ * to reach the statement. Two of the three are additionally covered
+ * behaviourally: the job's statement in
+ * `src/server/jobs/__tests__/reset-to-draft-without-requirements.test.ts`, and
+ * `restoreModelById`'s in
+ * `src/server/services/__tests__/restore-model-updated-at.service.test.ts`. This
+ * guard exists so the endpoint is not the untested half of one fix, and so all
+ * three sites are held to one rule in one place.
  *
- * ⚠ SCOPE, stated so this is not read as wider than it is: this is a LEDGER of two
- * named files, not a repo-wide scan. It cannot see a third site that starts
- * drafting models by raw SQL tomorrow. `restoreModelById`
- * (`src/server/services/model.service.ts`) is a KNOWN sibling with the same
- * defect — it raw-SQL-sets `status = CASE WHEN "publishedAt" IS NULL THEN 'Draft'`
- * with no bump, so an un-deleted model lands in Draft with a clock older than its
- * deletion. It is deliberately NOT in this ledger: it is pre-existing, needs its
- * own change and its own review, and adding it here would make this guard
- * permanently red, which is how a guard stops being read.
+ * ⚠ SCOPE, stated so this is not read as wider than it is: this is a LEDGER of
+ * named files, not a repo-wide scan. It cannot see a fourth site that starts
+ * drafting models by raw SQL tomorrow. As of this writing the ledger is
+ * complete — an enumeration of every raw `UPDATE "Model"` in the tree found
+ * exactly these three writing `Draft`; `republish-orphaned-drafts.ts` and
+ * `process-scheduled-publishing.ts` write `Published` and are out of scope.
+ * Adding a site here is part of adding one to the tree.
  */
 const repoRoot = path.resolve(__dirname, '../../../..');
 
-/** Files whose raw `UPDATE "Model"` statement moves a model into Draft. */
+/** Files with a raw `UPDATE "Model"` statement that moves a model into Draft. */
 const LEDGER = [
   'src/server/jobs/reset-to-draft-without-requirements.ts',
   'src/pages/api/admin/temp/backfill-swept-trained-models.ts',
+  'src/server/services/model.service.ts',
 ];
 
 /**
- * The `UPDATE "Model"` statement's text, `--` comments stripped.
+ * EVERY raw `UPDATE "Model"` statement in a file, `--` comments stripped.
  *
- * Anchored on `UPDATE "Model" ` WITH the trailing space so it cannot match
- * `UPDATE "ModelVersion"`, and read to the end of the tagged template (the next
- * backtick). Comment stripping is load-bearing: both statements carry `--`
- * comments, and a `-- "updatedAt" = now()` would otherwise satisfy this guard
- * over SQL that does not do it.
+ * 🔴 All of them, not the first one — and the anchor includes the CLOSING quote
+ * rather than a trailing space. Both details are load-bearing and both were
+ * wrong here before `restoreModelById` joined the ledger:
+ *
+ *  - a trailing-space anchor (`UPDATE "Model" `) cannot see a statement that
+ *    breaks the line after the table name, which is how `restoreModelById`
+ *    writes it. The closing quote is what excludes `UPDATE "ModelVersion"`;
+ *    the space was never doing that job.
+ *  - `model.service.ts` holds THREE raw `UPDATE "Model"` statements and only
+ *    one of them drafts. Taking the first match would have anchored this guard
+ *    on `captureMinorFlagSnapshot`'s meta write — a different statement, in a
+ *    different function, with nothing to do with the reaper.
+ *
+ * Each statement is read to the end of its tagged template (the next backtick).
+ * That over-reads on a template carrying an interpolated expression, which is
+ * deliberate: it can only pull MORE text into scope, so it fails closed.
+ * Comment stripping is load-bearing too — these statements carry `--` comments,
+ * and a `-- "updatedAt" = now()` would otherwise satisfy this guard over SQL
+ * that does not do it.
  */
-function modelUpdateStatement(relPath: string) {
+function modelUpdateStatements(relPath: string): string[] {
   const source = readFileSync(path.join(repoRoot, relPath), 'utf8');
-  const start = source.indexOf('UPDATE "Model" ');
-  expect(start, `${relPath} no longer contains a raw UPDATE "Model" statement`).toBeGreaterThan(0);
-  const end = source.indexOf('`', start);
-  expect(end, `${relPath}: could not find the end of the tagged template`).toBeGreaterThan(start);
-  return source.slice(start, end).replace(/--[^\n]*/g, ' ');
+  const statements: string[] = [];
+  for (let start = source.indexOf('UPDATE "Model"'); start >= 0; ) {
+    const end = source.indexOf('`', start);
+    expect(end, `${relPath}: could not find the end of the tagged template`).toBeGreaterThan(start);
+    statements.push(source.slice(start, end).replace(/--[^\n]*/g, ' '));
+    start = source.indexOf('UPDATE "Model"', end);
+  }
+  expect(
+    statements.length,
+    `${relPath} no longer contains a raw UPDATE "Model" statement`
+  ).toBeGreaterThan(0);
+  return statements;
+}
+
+/** Of those, the ones that write `Draft` status — the only ones this rule binds. */
+function draftingStatements(relPath: string): string[] {
+  return modelUpdateStatements(relPath).filter((sql) => sql.includes(`'Draft'`));
 }
 
 describe('a raw SQL write that drafts a Model bumps its "updatedAt"', () => {
-  it.each(LEDGER)('%s sets "updatedAt" = now()', (relPath) => {
-    expect(
-      modelUpdateStatement(relPath),
-      `${relPath}: without the bump this model is immediately reapable by remove-old-drafts, which cascade-deletes it`
-    ).toContain('"updatedAt" = now()');
+  it.each(LEDGER)('%s sets "updatedAt" = now() on every drafting statement', (relPath) => {
+    for (const statement of draftingStatements(relPath)) {
+      expect(
+        statement,
+        `${relPath}: without the bump this model is immediately reapable by remove-old-drafts, which cascade-deletes it`
+      ).toContain('"updatedAt" = now()');
+    }
   });
 
-  // POSITIVE CONTROL. Without it, a renamed or deleted file would make the
-  // assertion above vacuous rather than red — and a ledger that silently checks
+  // POSITIVE CONTROL. Without it, a renamed file, a moved statement or a
+  // reworded `Draft` literal would make the assertion above vacuous rather than
+  // red — it iterates an empty list and passes. A ledger that silently checks
   // nothing is the failure mode this whole class of guard is prone to.
   it.each(LEDGER)('%s actually drafts a model, so the guard above is not vacuous', (relPath) => {
     expect(
-      modelUpdateStatement(relPath),
-      `${relPath} no longer writes Draft status; if that is intended, remove it from the ledger`
-    ).toContain(`'Draft'`);
+      draftingStatements(relPath).length,
+      `${relPath} no longer writes Draft status in a raw UPDATE "Model"; if that is intended, remove it from the ledger`
+    ).toBeGreaterThan(0);
   });
 });

--- a/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
+++ b/src/server/services/__tests__/no-unbumped-draft-status-write.test.ts
@@ -35,12 +35,100 @@ import { describe, expect, it } from 'vitest';
  */
 const repoRoot = path.resolve(__dirname, '../../../..');
 
-/** Files with a raw `UPDATE "Model"` statement that moves a model into Draft. */
-const LEDGER = [
-  'src/server/jobs/reset-to-draft-without-requirements.ts',
-  'src/pages/api/admin/temp/backfill-swept-trained-models.ts',
-  'src/server/services/model.service.ts',
+/**
+ * Files with a raw `UPDATE "Model"` statement that moves a model into Draft, and
+ * HOW MANY such statements each one holds.
+ *
+ * 🔴 The count is not decoration — it is the control that makes a dropped
+ * statement impossible to hide. The per-file rule below iterates the drafting
+ * statements, so anything that removes one from the list (a broken extractor, a
+ * reworded literal, a moved statement) makes the rule iterate a shorter list and
+ * pass. "At least one" was the previous control, and it is only sufficient while
+ * every ledger file holds exactly one: with two, the guard can silently stop
+ * watching one of them and still be green. Pinning the exact number closes that,
+ * and it also forces a deliberate decision when a file GAINS a drafting
+ * statement, rather than letting it arrive unwatched.
+ */
+const LEDGER: { file: string; draftingStatements: number }[] = [
+  { file: 'src/server/jobs/reset-to-draft-without-requirements.ts', draftingStatements: 1 },
+  { file: 'src/pages/api/admin/temp/backfill-swept-trained-models.ts', draftingStatements: 1 },
+  { file: 'src/server/services/model.service.ts', draftingStatements: 1 },
 ];
+
+/**
+ * Index of the backtick that CLOSES the tagged template `start` sits inside, or
+ * `-1` if it never closes.
+ *
+ * 🔴 "The next backtick" is WRONG, and the failure mode is TRUNCATION, not
+ * over-reading. A template carrying an interpolated expression that is itself a
+ * tagged template — `${cond ? Prisma.empty : Prisma.sql`...`}`, which is exactly
+ * the shape of the description write in `model.service.ts` — closes on the
+ * NESTED opening backtick. The extracted text then stops mid-expression, and
+ * because truncation REMOVES text it can drop the `'Draft'` literal and quietly
+ * take a statement out of scope entirely. Measured on the previous revision of
+ * this file: that statement extracted 156 characters and ended mid-ternary.
+ *
+ * So the scan tracks `${...}` interpolations by brace depth, recursing through
+ * nested templates and skipping quoted strings inside the JS. Known limits, both
+ * absent from this corpus: a brace or backtick inside a regex literal or a `//`
+ * comment within an interpolation would confuse the depth count.
+ */
+function templateEnd(source: string, start: number): number {
+  let i = start;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '`') return i;
+    if (ch === '$' && source[i + 1] === '{') {
+      i = skipInterpolation(source, i + 2);
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/** Index just past the `}` closing an interpolation opened before `i`. */
+function skipInterpolation(source: string, i: number): number {
+  let depth = 1;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '`') {
+      const nested = templateEnd(source, i + 1);
+      if (nested < 0) return source.length;
+      i = nested + 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      i = skipQuoted(source, i + 1, ch);
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+    i++;
+  }
+  return i;
+}
+
+/** Index just past the closing `quote`. */
+function skipQuoted(source: string, i: number, quote: string): number {
+  while (i < source.length) {
+    if (source[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (source[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
 
 /**
  * EVERY raw `UPDATE "Model"` statement in a file, `--` comments stripped.
@@ -75,9 +163,9 @@ const LEDGER = [
  * did. When extending a ledger like this, re-derive the extractor against the
  * NEW file before trusting the green it reports.
  *
- * Each statement is read to the end of its tagged template (the next backtick).
- * That over-reads on a template carrying an interpolated expression, which is
- * deliberate: it can only pull MORE text into scope, so it fails closed.
+ * Each statement is read to the end of its tagged template via `templateEnd`,
+ * which is nesting-aware — see the 🔴 note on that function for why "the next
+ * backtick" silently TRUNCATED a statement rather than over-reading it.
  * Comment stripping is load-bearing too — these statements carry `--` comments,
  * and a `-- "updatedAt" = now()` would otherwise satisfy this guard over SQL
  * that does not do it.
@@ -86,8 +174,14 @@ function modelUpdateStatements(relPath: string): string[] {
   const source = readFileSync(path.join(repoRoot, relPath), 'utf8');
   const statements: string[] = [];
   for (let start = source.indexOf('UPDATE "Model"'); start >= 0; ) {
-    const end = source.indexOf('`', start);
-    expect(end, `${relPath}: could not find the end of the tagged template`).toBeGreaterThan(start);
+    const end = templateEnd(source, start);
+    // An unterminated template means the scan is wrong about this file, so every
+    // statement after it is suspect. Fail rather than skip: a skipped statement
+    // leaves the rule silently unbound, which is the whole hazard here.
+    expect(
+      end,
+      `${relPath}: tagged template starting at offset ${start} never closes — the extractor cannot be trusted on this file`
+    ).toBeGreaterThan(start);
     statements.push(source.slice(start, end).replace(/--[^\n]*/g, ' '));
     start = source.indexOf('UPDATE "Model"', end);
   }
@@ -104,23 +198,41 @@ function draftingStatements(relPath: string): string[] {
 }
 
 describe('a raw SQL write that drafts a Model bumps its "updatedAt"', () => {
-  it.each(LEDGER)('%s sets "updatedAt" = now() on every drafting statement', (relPath) => {
-    for (const statement of draftingStatements(relPath)) {
-      expect(
-        statement,
-        `${relPath}: without the bump this model is immediately reapable by remove-old-drafts, which cascade-deletes it`
-      ).toContain('"updatedAt" = now()');
+  it.each(LEDGER)(
+    '$file sets "updatedAt" = now() on every drafting statement',
+    ({ file }: (typeof LEDGER)[number]) => {
+      // Indexed, so a failure names WHICH of a file's drafting statements is
+      // unbumped rather than just the file.
+      draftingStatements(file).forEach((statement, i) => {
+        expect(
+          statement,
+          `${file}: drafting statement #${
+            i + 1
+          } does not bump "updatedAt" — a model it drafts carries a spent clock into remove-old-drafts, which cascade-deletes it`
+        ).toContain('"updatedAt" = now()');
+      });
     }
-  });
+  );
 
-  // POSITIVE CONTROL. Without it, a renamed file, a moved statement or a
-  // reworded `Draft` literal would make the assertion above vacuous rather than
-  // red — it iterates an empty list and passes. A ledger that silently checks
-  // nothing is the failure mode this whole class of guard is prone to.
-  it.each(LEDGER)('%s actually drafts a model, so the guard above is not vacuous', (relPath) => {
-    expect(
-      draftingStatements(relPath).length,
-      `${relPath} no longer writes Draft status in a raw UPDATE "Model"; if that is intended, remove it from the ledger`
-    ).toBeGreaterThan(0);
-  });
+  // 🔴 POSITIVE CONTROL, and an EXACT count rather than "at least one".
+  //
+  // The rule above iterates a list, so anything that shortens the list weakens it
+  // silently: a broken extractor, a reworded `Draft` literal, a moved statement.
+  // "At least one" only catches that while a file holds exactly one drafting
+  // statement — true of every ledger file today, which is a property of this
+  // corpus and not of the guard. With two, one can drop out and the file still
+  // reports a non-empty list.
+  //
+  // The exact number fails in BOTH directions: a statement that disappears from
+  // the extractor's view, and one that ARRIVES unwatched. Bumping the number is
+  // how you record a deliberate decision about a new site.
+  it.each(LEDGER)(
+    '$file holds exactly the drafting statements this ledger claims',
+    ({ file, draftingStatements: expected }: (typeof LEDGER)[number]) => {
+      expect(
+        draftingStatements(file).length,
+        `${file}: expected ${expected} raw UPDATE "Model" statement(s) writing Draft. Fewer means one dropped out of the extractor's view and is no longer checked; more means a new drafting site arrived — bump the count here once you have confirmed it carries the bump.`
+      ).toBe(expected);
+    }
+  );
 });

--- a/src/server/services/__tests__/restore-model-updated-at.service.test.ts
+++ b/src/server/services/__tests__/restore-model-updated-at.service.test.ts
@@ -4,14 +4,16 @@ import type * as ModelVersionService from '~/server/services/model-version.servi
 
 /**
  * `restoreModelById` un-deletes a model with raw SQL, so Prisma's `@updatedAt`
- * does not fire and the restored row keeps the timestamp it carried BEFORE it
- * was deleted — by construction older than its own deletion.
- * `src/server/jobs/remove-old-drafts.ts` reaps
+ * does not fire and the restored row keeps the timestamp it carried while it was
+ * deleted — the DELETION instant, since `deleteModelById` writes through the
+ * Prisma client. `src/server/jobs/remove-old-drafts.ts` reaps
  * `status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'`
  * and cascade-deletes the model together with its versions, files and training
- * data, irreversibly. Without a bump, a model restored today is eligible for
- * that cascade tonight, with only `downloadCount < 10` and the job's activity
- * fences between it and destruction.
+ * data, irreversibly. So without a bump, a model that sat deleted for longer
+ * than 30 days is past that threshold the instant it is restored and is eligible
+ * for the cascade the same night, with only `downloadCount < 10` between it and
+ * destruction — the job's activity fences read ModelVersion timestamps, which
+ * the same delete froze at the same instant.
  *
  * Same defect class as the two sweep sites fixed in #4595, and the same fix.
  * `no-unbumped-draft-status-write.test.ts` holds all three sites to the rule as
@@ -215,9 +217,9 @@ describe('restoreModelById', () => {
 
   describe('the UPDATE "Model" statement', () => {
     // 🔴 THE FIX. See the file header: this statement is raw SQL, so
-    // `@updatedAt` does not fire and a restored model lands in Draft carrying a
-    // clock older than its own deletion — inside remove-old-drafts' 30-day
-    // window from the instant it is restored.
+    // `@updatedAt` does not fire and a restored model lands in Draft carrying
+    // the clock it had when it was deleted — already outside remove-old-drafts'
+    // 30-day window for anything that sat deleted longer than that.
     it('bumps "updatedAt" so a restored model gets a real grace period before the reaper', async () => {
       await restoreModelById({ id: MODEL_ID });
 

--- a/src/server/services/__tests__/restore-model-updated-at.service.test.ts
+++ b/src/server/services/__tests__/restore-model-updated-at.service.test.ts
@@ -17,9 +17,11 @@ import type * as ModelVersionService from '~/server/services/model-version.servi
  * missing bump does not make a model reapable that was not already. It costs two
  * other things: a restored model keeps only the REMAINDER of its 30 days rather
  * than a fresh window (deleted day 0, restored day 29 -> reaped the night of day
- * 30/31), and — the stronger one — it is cascade-deleted UNWARNED, because the
- * `old-draft` notification warns on `Draft` only and evaluates its band once at
- * `U + OLD_DRAFT_NOTICE_DAYS`, which a carried-over `U` has already passed.
+ * 30/31), and — the stronger one — a model restored after its band has gone by
+ * is cascade-deleted UNWARNED, because the `old-draft` notification warns on
+ * `Draft` only and evaluates its band once at `U + OLD_DRAFT_NOTICE_DAYS` (23
+ * days), never revisiting it. Restored EARLIER than that and the band still
+ * matches, so it is warned and the bump is not what saves it.
  *
  * Same defect class as the two sweep sites fixed in #4595, and the same fix.
  * `no-unbumped-draft-status-write.test.ts` holds all three sites to the rule as
@@ -230,7 +232,7 @@ describe('restoreModelById', () => {
 
       expect(
         modelUpdateSql(),
-        'without the bump a restored model keeps only the remainder of its 30 days before remove-old-drafts cascade-deletes it, and is deleted unwarned because the old-draft notification band for that carried-over timestamp has already passed'
+        'without the bump a restored model keeps only the remainder of its 30 days before remove-old-drafts cascade-deletes it, and if the restore lands after the old-draft notification band at U + 23 days it is deleted unwarned, because that band is evaluated once and never revisited'
       ).toContain('"updatedAt" = now()');
     });
 

--- a/src/server/services/__tests__/restore-model-updated-at.service.test.ts
+++ b/src/server/services/__tests__/restore-model-updated-at.service.test.ts
@@ -6,14 +6,20 @@ import type * as ModelVersionService from '~/server/services/model-version.servi
  * `restoreModelById` un-deletes a model with raw SQL, so Prisma's `@updatedAt`
  * does not fire and the restored row keeps the timestamp it carried while it was
  * deleted — the DELETION instant, since `deleteModelById` writes through the
- * Prisma client. `src/server/jobs/remove-old-drafts.ts` reaps
- * `status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'`
- * and cascade-deletes the model together with its versions, files and training
- * data, irreversibly. So without a bump, a model that sat deleted for longer
- * than 30 days is past that threshold the instant it is restored and is eligible
- * for the cascade the same night, with only `downloadCount < 10` between it and
- * destruction — the job's activity fences read ModelVersion timestamps, which
- * the same delete froze at the same instant.
+ * Prisma client.
+ *
+ * 🔴 What that does and does NOT cause — the full reasoning, against the actual
+ * predicate, is on `restoreModelById` itself; the short version, because three
+ * earlier framings of it were wrong: `'Deleted'` is already in
+ * `remove-old-drafts`' `status IN ('Draft','Deleted')` set, so the clock runs
+ * while the model sits deleted, and restoring changes only `status`. The
+ * post-restore candidate set is a strict SUBSET of the pre-restore one, so the
+ * missing bump does not make a model reapable that was not already. It costs two
+ * other things: a restored model keeps only the REMAINDER of its 30 days rather
+ * than a fresh window (deleted day 0, restored day 29 -> reaped the night of day
+ * 30/31), and — the stronger one — it is cascade-deleted UNWARNED, because the
+ * `old-draft` notification warns on `Draft` only and evaluates its band once at
+ * `U + OLD_DRAFT_NOTICE_DAYS`, which a carried-over `U` has already passed.
  *
  * Same defect class as the two sweep sites fixed in #4595, and the same fix.
  * `no-unbumped-draft-status-write.test.ts` holds all three sites to the rule as
@@ -217,15 +223,14 @@ describe('restoreModelById', () => {
 
   describe('the UPDATE "Model" statement', () => {
     // 🔴 THE FIX. See the file header: this statement is raw SQL, so
-    // `@updatedAt` does not fire and a restored model lands in Draft carrying
-    // the clock it had when it was deleted — already outside remove-old-drafts'
-    // 30-day window for anything that sat deleted longer than that.
+    // `@updatedAt` does not fire and a restored model lands in Draft still
+    // carrying the clock it had when it was deleted.
     it('bumps "updatedAt" so a restored model gets a real grace period before the reaper', async () => {
       await restoreModelById({ id: MODEL_ID });
 
       expect(
         modelUpdateSql(),
-        'a model restored with a stale "updatedAt" is immediately reapable by remove-old-drafts, which cascade-deletes it'
+        'without the bump a restored model keeps only the remainder of its 30 days before remove-old-drafts cascade-deletes it, and is deleted unwarned because the old-draft notification band for that carried-over timestamp has already passed'
       ).toContain('"updatedAt" = now()');
     });
 

--- a/src/server/services/__tests__/restore-model-updated-at.service.test.ts
+++ b/src/server/services/__tests__/restore-model-updated-at.service.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as ModelVersionService from '~/server/services/model-version.service';
+
+/**
+ * `restoreModelById` un-deletes a model with raw SQL, so Prisma's `@updatedAt`
+ * does not fire and the restored row keeps the timestamp it carried BEFORE it
+ * was deleted — by construction older than its own deletion.
+ * `src/server/jobs/remove-old-drafts.ts` reaps
+ * `status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'`
+ * and cascade-deletes the model together with its versions, files and training
+ * data, irreversibly. Without a bump, a model restored today is eligible for
+ * that cascade tonight, with only `downloadCount < 10` and the job's activity
+ * fences between it and destruction.
+ *
+ * Same defect class as the two sweep sites fixed in #4595, and the same fix.
+ * `no-unbumped-draft-status-write.test.ts` holds all three sites to the rule as
+ * source text; this file is the behavioural half for this one — it drives the
+ * real `restoreModelById` and reads the statement it actually issues.
+ *
+ * Same import-the-real-model.service scaffold as
+ * `model.service.transfer-paid-access-owner.test.ts`; only the I/O surfaces are
+ * stubbed, and `~/server/db/client` uses the canonical `dbMock`.
+ */
+
+const MODEL_ID = 4711;
+// Deliberately distinct from MODEL_ID and from every literal asserted below, so
+// a mutant cannot pass by landing on a constant one of them happens to equal.
+const OWNER_USER_ID = 8302;
+
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: { cancellableQuery: vi.fn() },
+  pgDbWrite: {},
+  pgDbReadLong: {},
+}));
+vi.mock('~/server/services/model-file.service', () => ({
+  getFilesForModelVersionCache: vi.fn(),
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: vi.fn().mockResolvedValue({}),
+  queueImageSearchIndexUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+vi.mock('~/server/services/paid-access.service', () => ({
+  getPaidAccess: vi.fn(),
+  getPublicPaidAccessForModelVersions: vi.fn().mockResolvedValue({}),
+  bustPaidAccessCache: vi.fn(),
+}));
+vi.mock('~/server/services/model-version.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelVersionService>()),
+  bustMvCache: vi.fn(),
+}));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn().mockResolvedValue(new Map()),
+  getUserMetricPrivacyDefaultsMap: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn().mockResolvedValue({}),
+  getProfilePicturesForUsers: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { fetch: vi.fn() },
+  modelVersionPublicDonationGoalsCache: { fetch: vi.fn(), bust: vi.fn() },
+  modelTagCache: { fetch: vi.fn(), bust: vi.fn() },
+  modelVotableTagsCache: { fetch: vi.fn(), bust: vi.fn() },
+  userBasicCache: { fetch: vi.fn().mockResolvedValue({}), bust: vi.fn() },
+  userModelCountCache: { fetch: vi.fn(), bust: vi.fn(), refresh: vi.fn() },
+}));
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {},
+  Tracker: class {
+    modelEvent = vi.fn();
+  },
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+import { restoreModelById } from '~/server/services/model.service';
+
+const mockDbWrite = dbMock.dbWrite;
+
+/**
+ * Every raw statement the call issued, `--` comments stripped and whitespace
+ * collapsed.
+ *
+ * 🔴 Stripping comments is not cosmetic. These are SPELLED guards over SQL
+ * source, and a `--` comment is not a clause: a future
+ * `-- also sets "updatedAt" = now()` beside the statement would satisfy the fix
+ * guard below over SQL that does not do it.
+ *
+ * `$queryRaw` and `$executeRaw` are read together because the two statements in
+ * this transaction use different methods (the Model one RETURNs, the
+ * ModelVersion one does not) and every helper here selects by table name.
+ *
+ * ⚠ An approximation of what Postgres executes, not a SQL parser. A `--` inside
+ * a quoted string literal is stripped here but is not a comment to the database.
+ * Nothing in this function is near that shape.
+ */
+function issuedStatements(): string[] {
+  return [...mockDbWrite.$queryRaw.mock.calls, ...mockDbWrite.$executeRaw.mock.calls].map(
+    ([strings]) =>
+      (strings as string[])
+        .join(' ?? ')
+        .replace(/--[^\n]*/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+  );
+}
+
+/**
+ * The single `UPDATE "Model"` statement.
+ *
+ * Asserting there is exactly one is the positive control for every guard built
+ * on it: without it, a function that stopped issuing the statement — or a mock
+ * wired to nothing — would satisfy them all by returning `undefined`.
+ */
+function modelUpdateSql(): string {
+  const matches = issuedStatements().filter((sql) => sql.startsWith('UPDATE "Model" '));
+  expect(matches, 'expected exactly one UPDATE "Model" statement to have been issued').toHaveLength(
+    1
+  );
+  return matches[0];
+}
+
+/** The single `UPDATE "ModelVersion"` statement. */
+function versionUpdateSql(): string {
+  const matches = issuedStatements().filter((sql) => sql.startsWith('UPDATE "ModelVersion" '));
+  expect(
+    matches,
+    'expected exactly one UPDATE "ModelVersion" statement to have been issued'
+  ).toHaveLength(1);
+  return matches[0];
+}
+
+/**
+ * The `UPDATE "Model"` statement's SET clause as ordered `[target, value]` pairs.
+ *
+ * 🔴 Reading the assignments as a LIST is the point. A `toContain` guard can
+ * only see a clause that was REMOVED; it is blind to one that was ADDED.
+ * Injecting `"publishedAt" = now(),` here would pass every `toContain` in this
+ * file — and `publishedAt` is exactly the column this function's own comment
+ * says must not move, because a spurious bump would let the next publish reset
+ * it under the legacy gate.
+ *
+ * Split on commas at paren depth 0 so a comma inside a function call cannot
+ * fragment an assignment. The status CASE carries no parenthesised group today;
+ * the depth tracking is what keeps that from becoming load-bearing.
+ */
+function modelSetAssignments(): [string, string][] {
+  const sql = modelUpdateSql();
+  // Anchored on the column the top-level WHERE opens on, not on the first
+  // ` WHERE `, so a future subquery in the SET clause cannot silently truncate
+  // this and make every assertion below read a fragment.
+  const whereAt = sql.indexOf(' WHERE id = ');
+  expect(
+    whereAt,
+    'could not locate the top-level WHERE; every SET-clause guard would be vacuous'
+  ).toBeGreaterThan(0);
+  const setAt = sql.indexOf(' SET ');
+  expect(setAt, 'could not locate the SET clause').toBeGreaterThan(0);
+  const setClause = sql.slice(setAt + ' SET '.length, whereAt);
+
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of setClause) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  parts.push(current);
+
+  return parts.map((part) => {
+    const eq = part.indexOf(' = ');
+    expect(eq, `SET fragment is not an assignment: ${part.trim()}`).toBeGreaterThan(0);
+    return [part.slice(0, eq).trim(), part.slice(eq + 3).trim()] as [string, string];
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // A row must come back or `restoreModelById` returns null before the caches
+  // are touched — and, more importantly, a run that restored nothing would be
+  // the same green as a harness wired to nothing.
+  mockDbWrite.$queryRaw.mockResolvedValue([{ userId: OWNER_USER_ID }]);
+  mockDbWrite.$executeRaw.mockResolvedValue(1);
+});
+
+describe('restoreModelById', () => {
+  it('restores the model and reports its owner', async () => {
+    // POSITIVE CONTROL for the whole file: the function has to reach its
+    // statements and return a restored model, or every guard below is a claim
+    // about a code path that never ran.
+    await expect(restoreModelById({ id: MODEL_ID })).resolves.toEqual({
+      id: MODEL_ID,
+      userId: OWNER_USER_ID,
+    });
+  });
+
+  describe('the UPDATE "Model" statement', () => {
+    // 🔴 THE FIX. See the file header: this statement is raw SQL, so
+    // `@updatedAt` does not fire and a restored model lands in Draft carrying a
+    // clock older than its own deletion — inside remove-old-drafts' 30-day
+    // window from the instant it is restored.
+    it('bumps "updatedAt" so a restored model gets a real grace period before the reaper', async () => {
+      await restoreModelById({ id: MODEL_ID });
+
+      expect(
+        modelUpdateSql(),
+        'a model restored with a stale "updatedAt" is immediately reapable by remove-old-drafts, which cascade-deletes it'
+      ).toContain('"updatedAt" = now()');
+    });
+
+    // The fix must be ADDITIVE. These pin the behaviour it sits next to, so a
+    // change that satisfies the guard above by REPLACING the SET list rather
+    // than extending it cannot pass.
+    it('still clears the deletion columns', async () => {
+      await restoreModelById({ id: MODEL_ID });
+
+      const sql = modelUpdateSql();
+      expect(sql, 'un-deleting is the point of this function').toContain('"deletedAt" = NULL');
+      expect(sql).toContain('"deletedBy" = NULL');
+    });
+
+    it('still derives the restored status from publishedAt', async () => {
+      await restoreModelById({ id: MODEL_ID });
+
+      const sql = modelUpdateSql();
+      expect(sql, 'the status CASE must survive the "updatedAt" bump').toContain('"status" = CASE');
+      expect(sql).toContain(`WHEN "publishedAt" IS NULL THEN 'Draft'::"ModelStatus"`);
+      expect(sql).toContain(`WHEN "publishedAt" > NOW() THEN 'Scheduled'::"ModelStatus"`);
+      expect(sql).toContain(`ELSE 'Unpublished'::"ModelStatus"`);
+    });
+
+    it('still only touches a row that is actually Deleted', async () => {
+      await restoreModelById({ id: MODEL_ID });
+
+      // Without this predicate the bump alone would move `updatedAt` on a live
+      // model — a write to every row the id matches, restored or not.
+      expect(modelUpdateSql()).toContain(`AND "status" = 'Deleted'::"ModelStatus"`);
+    });
+
+    // 🔴 The ledger. Fails when the SET list GROWS as well as when it shrinks.
+    it('writes exactly "deletedAt", "deletedBy", "status" and "updatedAt" — no other column', async () => {
+      await restoreModelById({ id: MODEL_ID });
+
+      expect(
+        modelSetAssignments().map(([target]) => target),
+        'this statement must not acquire another column write without a deliberate decision — "publishedAt" in particular is what this function\'s status CASE reads, and moving it would change the restored status'
+      ).toEqual(['"deletedAt"', '"deletedBy"', '"status"', '"updatedAt"']);
+    });
+
+    // Pinning the VALUE, not just the presence of the target. This is what
+    // catches a `CASE ... THEN now() ELSE "updatedAt" END` mutant — which would
+    // leave exactly the Draft rows the reaper eats still carrying a stale clock
+    // — and equally a `now() - INTERVAL '31 days'` one, which is the defect
+    // spelled as a fix.
+    it('assigns "updatedAt" exactly now(), unconditionally', async () => {
+      await restoreModelById({ id: MODEL_ID });
+
+      const updatedAt = modelSetAssignments().find(([target]) => target === '"updatedAt"');
+      expect(
+        updatedAt?.[1],
+        'a conditional or offset bump leaves the restored row inside the reaper window'
+      ).toBe('now()');
+    });
+  });
+
+  // 🔴 A SCOPE GUARD, not a prohibition — read this before "fixing" it.
+  //
+  // Bumping ModelVersion."updatedAt" on a system write is not forbidden in this
+  // codebase: `unpublishModelById` in this same service does it deliberately,
+  // because the column is on the public v1 payload via
+  // src/server/selectors/modelVersion.selector.ts and a taken-down version would
+  // otherwise serve a pre-take-down timestamp.
+  //
+  // What this pins is that THIS change did not quietly do that too. The reaper
+  // reads `Model."updatedAt"`, so the Model bump is the whole fix; the restored
+  // versions' effect on the public payload is a separate decision with its own
+  // consequences and wants its own change and its own review. If you are making
+  // that decision on purpose, delete this test — do not work around it.
+  it('keeps this change scoped to Model."updatedAt" and leaves ModelVersion alone', async () => {
+    await restoreModelById({ id: MODEL_ID });
+
+    // versionUpdateSql() asserts the statement was issued at all, so this is not
+    // a reassuring zero from a branch that never ran.
+    expect(versionUpdateSql()).not.toContain('"updatedAt"');
+  });
+});

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1907,6 +1907,18 @@ export const restoreModelById = async ({ id }: GetByIdInput) => {
   //   publishedAt IS NULL    -> Draft
   //   publishedAt >  NOW()   -> Scheduled (future publish was queued)
   //   publishedAt <= NOW()   -> Unpublished
+  //
+  // 🔴 `"updatedAt" = now()` is load-bearing, not cosmetic. This is `$queryRaw`,
+  // so Prisma's `@updatedAt` does NOT fire and the row keeps the timestamp it
+  // carried before it was deleted — by construction older than its own deletion.
+  // `remove-old-drafts` reaps
+  // `status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'`
+  // and cascade-deletes the model with its versions, files and training data,
+  // irreversibly. Without the bump a model restored today can be destroyed
+  // tonight, its entire 30-day grace period already spent. Restoring a model is
+  // a write to the row, so the bump is also what the column is supposed to mean.
+  // Pinned by `no-unbumped-draft-status-write.test.ts` and exercised through
+  // this function by `restore-model-updated-at.service.test.ts`.
   const result = await dbWrite.$transaction(async (tx) => {
     const rows = await tx.$queryRaw<{ userId: number }[]>`
       UPDATE "Model"
@@ -1916,7 +1928,8 @@ export const restoreModelById = async ({ id }: GetByIdInput) => {
             WHEN "publishedAt" IS NULL      THEN 'Draft'::"ModelStatus"
             WHEN "publishedAt" >  NOW()     THEN 'Scheduled'::"ModelStatus"
             ELSE 'Unpublished'::"ModelStatus"
-          END
+          END,
+          "updatedAt" = now()
       WHERE id = ${id}
         AND "status" = 'Deleted'::"ModelStatus"
       RETURNING "userId"

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1944,12 +1944,21 @@ export const restoreModelById = async ({ id }: GetByIdInput) => {
   //     REAP_AGE_DAYS, which is what a restored model is entitled to.
   //  2. THE `old-draft` WARNING, and this is the stronger one. That notification
   //     warns on `Draft` ONLY — a `Deleted` model is deliberately never warned —
-  //     and its band is evaluated ONCE, at `U + OLD_DRAFT_NOTICE_DAYS`, never
-  //     re-evaluated for that `U` (`model.notifications.ts`). A model restored
-  //     with its pre-restore `U` is now `Draft`, so it is warnable for the first
-  //     time, but its band is already in the past — so it is cascade-deleted
-  //     UNWARNED. The bump re-arms the band, which is the only way the user ever
-  //     hears about it.
+  //     and its band is evaluated ONCE, at `U + OLD_DRAFT_NOTICE_DAYS` (23 days),
+  //     never re-evaluated for that `U` (`model.notifications.ts`). A model
+  //     restored while carrying its pre-restore `U` is now `Draft`, so it is
+  //     warnable for the first time — but only if its band has not already gone
+  //     by.
+  //       - restored BEFORE `U + 23d`: the band still matches, and it IS warned.
+  //         Deleted day 0, restored day 10 -> `Draft` at day 23 with `U` = day 0
+  //         -> warned. The bump is not what saves this one.
+  //       - restored AFTER `U + 23d` (the day-29 case above, or a path where
+  //         `downloadCount` drops below 10 late): the band is in the past and is
+  //         never revisited, so the model is cascade-deleted UNWARNED.
+  //     So the bump re-arms the band, and that is the only way the user hears
+  //     about it in the second case. Stated at that width deliberately: this
+  //     comment tells the next editor not to justify the line from a story, so
+  //     it has to meet its own bar.
   //
   // And independently of the reaper: restoring a model is a write to the row, so
   // the bump is what the column is supposed to mean.

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1908,20 +1908,57 @@ export const restoreModelById = async ({ id }: GetByIdInput) => {
   //   publishedAt >  NOW()   -> Scheduled (future publish was queued)
   //   publishedAt <= NOW()   -> Unpublished
   //
-  // 🔴 `"updatedAt" = now()` is load-bearing, not cosmetic. This is `$queryRaw`,
-  // so Prisma's `@updatedAt` does NOT fire and the row keeps the timestamp it
-  // carried while it was deleted. `deleteModelById` writes through the Prisma
-  // client, so that timestamp is the DELETION instant — measured, not assumed:
-  // the restore statement below is the only raw SQL in `src/` that touches a
-  // Model's `'Deleted'` status, every other path is a client write.
-  // `remove-old-drafts` reaps
-  // `status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'`
-  // and cascade-deletes the model with its versions, files and training data,
-  // irreversibly. So without the bump, a model that sat deleted for longer than
-  // 30 days is PAST the reaper's threshold the instant it is restored, and the
-  // job's activity fences do not save it: they read ModelVersion timestamps,
-  // which the same delete froze at the same instant. Restoring a model is a
-  // write to the row, so the bump is also what the column is supposed to mean.
+  // 🔴 `"updatedAt" = now()` is load-bearing. This is `$queryRaw`, so Prisma's
+  // `@updatedAt` does NOT fire and the row keeps the timestamp it carried while
+  // deleted — the deletion instant, since `deleteModelById` writes through the
+  // client.
+  //
+  // 🔴 READ THE REAPER'S PREDICATE BEFORE EDITING THIS COMMENT. Three successive
+  // versions of it justified the bump with a story about what restoring does,
+  // and all three were false. `remove-old-drafts` selects on:
+  //
+  //     status IN ('Draft','Deleted')
+  //     AND m."updatedAt" < now() - INTERVAL '30 days'   -- REAP_AGE_DAYS
+  //     AND mm."downloadCount" < 10
+  //     AND m."availability" != 'Private'
+  //     AND NOT EXISTS (recent ModelVersion) AND NOT EXISTS (recent ModelFile)
+  //
+  // `'Deleted'` is IN that set, so the clock is already running while the model
+  // sits deleted: a low-download model is destroyed the night after
+  // deletion + 30 days, still `Deleted`, having never been restored. Restoring
+  // changes exactly one term — status goes `Deleted` -> `Draft` (still in the
+  // set) or `Unpublished`/`Scheduled` (out of it). Nothing else the predicate
+  // reads moves: the `ModelVersion` statement below is raw SQL and does not bump
+  // `mv."updatedAt"` either, and downloadCount / availability / the ModelMetric
+  // join are untouched. **The post-restore candidate set is therefore a strict
+  // subset of the pre-restore one — without this bump, restoring can never make
+  // a model reapable that was not already.** Do not re-justify this line with a
+  // "restore it and it dies that night" scenario; no such model exists.
+  //
+  // What the bump actually buys, both real:
+  //
+  //  1. A PARTLY-SPENT CLOCK. Deleted day 0, restored day 29: without the bump
+  //     the model is reaped the night of day 30/31 — one day after restore, with
+  //     the version fence (where the delete set one at all) expiring at the same
+  //     instant. The bump turns whatever remains of the window into a full
+  //     REAP_AGE_DAYS, which is what a restored model is entitled to.
+  //  2. THE `old-draft` WARNING, and this is the stronger one. That notification
+  //     warns on `Draft` ONLY — a `Deleted` model is deliberately never warned —
+  //     and its band is evaluated ONCE, at `U + OLD_DRAFT_NOTICE_DAYS`, never
+  //     re-evaluated for that `U` (`model.notifications.ts`). A model restored
+  //     with its pre-restore `U` is now `Draft`, so it is warnable for the first
+  //     time, but its band is already in the past — so it is cascade-deleted
+  //     UNWARNED. The bump re-arms the band, which is the only way the user ever
+  //     hears about it.
+  //
+  // And independently of the reaper: restoring a model is a write to the row, so
+  // the bump is what the column is supposed to mean.
+  //
+  // (Nuance, so the fences are not over-credited: `deleteModelById`'s nested
+  // `modelVersions.updateMany` is scoped to `status IN (Published, Scheduled)`,
+  // so a Draft-only model has NO ModelVersion row bumped at delete time. Those
+  // timestamps are older still, making the fences less protective, not more.)
+  //
   // Pinned by `no-unbumped-draft-status-write.test.ts` and exercised through
   // this function by `restore-model-updated-at.service.test.ts`.
   const result = await dbWrite.$transaction(async (tx) => {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1910,13 +1910,18 @@ export const restoreModelById = async ({ id }: GetByIdInput) => {
   //
   // 🔴 `"updatedAt" = now()` is load-bearing, not cosmetic. This is `$queryRaw`,
   // so Prisma's `@updatedAt` does NOT fire and the row keeps the timestamp it
-  // carried before it was deleted — by construction older than its own deletion.
+  // carried while it was deleted. `deleteModelById` writes through the Prisma
+  // client, so that timestamp is the DELETION instant — measured, not assumed:
+  // the restore statement below is the only raw SQL in `src/` that touches a
+  // Model's `'Deleted'` status, every other path is a client write.
   // `remove-old-drafts` reaps
   // `status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'`
   // and cascade-deletes the model with its versions, files and training data,
-  // irreversibly. Without the bump a model restored today can be destroyed
-  // tonight, its entire 30-day grace period already spent. Restoring a model is
-  // a write to the row, so the bump is also what the column is supposed to mean.
+  // irreversibly. So without the bump, a model that sat deleted for longer than
+  // 30 days is PAST the reaper's threshold the instant it is restored, and the
+  // job's activity fences do not save it: they read ModelVersion timestamps,
+  // which the same delete froze at the same instant. Restoring a model is a
+  // write to the row, so the bump is also what the column is supposed to mean.
   // Pinned by `no-unbumped-draft-status-write.test.ts` and exercised through
   // this function by `restore-model-updated-at.service.test.ts`.
   const result = await dbWrite.$transaction(async (tx) => {


### PR DESCRIPTION
## The defect

`restoreModelById` un-deletes a model with raw SQL:

```sql
UPDATE "Model"
SET "deletedAt" = NULL, "deletedBy" = NULL,
    "status" = CASE WHEN "publishedAt" IS NULL THEN 'Draft'::"ModelStatus" ... END
WHERE id = $1 AND "status" = 'Deleted'::"ModelStatus"
```

It is `$queryRaw`, so Prisma's `@updatedAt` never fires. The restored row keeps the timestamp it carried **while it was deleted** — which is the deletion instant itself, because `deleteModelById` writes through the Prisma client (`tx.model.update` with a nested `modelVersions.updateMany`) and so *does* bump it. Measured rather than assumed: an enumeration of every raw `UPDATE "Model"` in `src/` finds this restore statement is the only one that touches a Model's `'Deleted'` status; every other delete path is a client write.

`remove-old-drafts` reaps

```sql
status IN ('Draft','Deleted') AND m."updatedAt" < now() - INTERVAL '30 days'
```

and cascade-deletes the model together with its versions, files and training data. That delete is irreversible.

So the naive reading — "restoring exposes the model" — is **wrong**, and it is worth saying why explicitly, because two earlier revisions of this PR said it.

### What restoring does and does not cause

`'Deleted'` is *already* in the reaper's `status IN ('Draft','Deleted')` set. The clock therefore runs while the model sits deleted: a low-download model is destroyed the night after deletion + 30 days, **still `Deleted`, never restored**. Restoring changes exactly one term — `status` goes `Deleted` → `Draft` (still in the set) or `Unpublished`/`Scheduled` (out of it). Nothing else the predicate reads moves: the `ModelVersion` statement is raw SQL and does not bump `mv."updatedAt"` either, and `downloadCount` / `availability` / the `ModelMetric` join are untouched.

**So the post-restore candidate set is a strict subset of the pre-restore one. Without the bump, restoring can never make a model reapable that was not already.** A "restored after eight months, gone that night" scenario cannot occur — surviving months of nightly reaping requires a sparing condition (`downloadCount >= 10`, `availability = 'Private'`, no `ModelMetric` row, live version/file activity), and every one of those still holds after the restore.

### What the bump actually buys — both real

1. **A partly-spent clock.** Deleted day 0, restored day 29 → without the bump the model is reaped the night of day 30/31, one day after restore. The bump turns whatever remains into a full `REAP_AGE_DAYS`, which is what a restored model is entitled to.
2. **The `old-draft` warning — arguably the stronger reason, and absent from every earlier revision of this PR.** That notification warns on `Draft` **only** (a `Deleted` model is deliberately never warned), and its band evaluates **once**, at `U + OLD_DRAFT_NOTICE_DAYS` (23 days), never re-evaluated for that `U`. A model restored carrying its pre-restore `U` is now `Draft` — warnable for the first time — but its band is already in the past, so it is cascade-deleted **unwarned**. The bump re-arms the band, which is the only way the user ever hears about it.

Every claim above was re-derived from source: the predicate in `remove-old-drafts.ts`, the constants in `draft-reaping.ts` (`REAP_AGE_DAYS` 30, `OLD_DRAFT_LEAD_DAYS` 7, `OLD_DRAFT_NOTICE_DAYS` 23), the `Draft`-only status term and once-evaluated band in `model.notifications.ts`, and the `updateMany` scope in `deleteModelById`.

One precision note, since an earlier revision got it backwards: `deleteModelById`'s nested `modelVersions.updateMany` is scoped to `status IN (Published, Scheduled)`, so a **Draft-only model has no `ModelVersion` row bumped at delete time**. Those timestamps are *older*, making the activity fences less protective, not more.

**Why getting this right matters:** a maintainer who tests the old stated scenario finds no such model, concludes the justification is fiction, and deletes a line that is genuinely load-bearing for both cases above.

## The change

Add `"updatedAt" = now()` to that statement. Restoring a model *is* a write to the row, so the bump is what the column is supposed to mean as well as the thing that stops the reaper eating it.

This is the same defect class and the same one-token fix as #4595, which closed the two sweep sites and named this one in its body as a known unfixed sibling. **This is the third and last raw-SQL-into-`Draft` site in the tree** — an enumeration of every raw `UPDATE "Model"` found exactly three writing `Draft`; `republish-orphaned-drafts.ts` and `process-scheduled-publishing.ts` write `Published` and are out of scope.

## The guard ledger

`no-unbumped-draft-status-write.test.ts` (introduced by #4595) explicitly excluded `restoreModelById`, on the stated grounds that including it would make the guard permanently red. This PR removes that reason, so the file is added to the ledger and the exclusion note is deleted. The guard now covers all three sites.

### 🔴 The extractor was narrower than its own description — read this part

This is the most transferable thing in the PR, so it is stated plainly rather than left as a diff.

The guard's doc comment states a **rule**: *"a raw-SQL write that moves a `Model` into `Draft` must also set `"updatedAt" = now()"`."* Its implementation did not enforce that rule. It carried two unstated assumptions:

1. it anchored on `UPDATE "Model" ` **with a trailing space**, so it could not see a statement that breaks the line after the table name — exactly how `restoreModelById` writes it (the closing quote is what excludes `UPDATE "ModelVersion"`; the space was never doing that job);
2. it took only the **first** match per file.

`model.service.ts` holds **seven** raw `UPDATE "Model"` statements, one of which drafts. Measured on `origin/main`: the space anchor skips the drafting statement, and first-match then lands on `captureMinorFlagSnapshot`'s `meta` write — a different statement, in a different function, unrelated to the reaper.

**The two defects compose, which is why neither is visible alone.** The drafting statement is the *first* of the seven, so a first-match rule on its own would have found it. Fixing either half in isolation yields a guard that is right for the wrong reason.

**Why no review round could have caught it.** Both files the extractor was written against hold **exactly one** raw `UPDATE "Model"` each, and both spell it `UPDATE "Model" m` — with a space, because of the alias. Both assumptions were true of the entire corpus the guard could see. A doc comment claiming a general rule, over an implementation covering two files that happen to satisfy two unstated assumptions, cannot be told apart from a correct guard by reading it, by running it, or by auditing it — only by pointing it at a file it was not written for. That is what adding the third site did, and it is the argument for re-deriving a ledger extractor against each new member rather than trusting the green it reports.

It now reads *every* raw `UPDATE "Model"` statement in a ledger file and binds the rule to the ones writing `Draft`.

### A third extractor defect, found while fixing the first two

The terminator was "the next backtick". On a template whose interpolation is itself a tagged template — `${cond ? Prisma.empty : Prisma.sql`...`}`, the shape of the description write in `model.service.ts` — that backtick is the **nested** one, so the extraction **truncates**. Measured: that statement extracted 156 characters and stopped mid-ternary; it now extracts 207.

Truncation *removes* text, so it can drop the `'Draft'` literal and silently take a statement out of scope entirely. My previous comment claimed the terminator "can only pull MORE text into scope, so it fails closed" — that described the opposite of the real failure mode.

`templateEnd` now tracks `${...}` by brace depth, recursing through nested templates and skipping quoted strings in the JS; an unterminated template is an error rather than a skip.

**And the control was upgraded from "at least one drafting statement" to an exact per-file count.** "At least one" is sufficient only while every ledger file holds exactly one — a property of this corpus, not of the guard. With two, one can drop out of the extractor's view and the file still reports a non-empty list. The exact count fails both when a statement disappears *and* when one arrives unwatched.

**Proof, since this is the case the single-statement coincidence hides.** A second drafting statement planted in `model.service.ts`:

| planted statement | ledger count | result |
|---|---|---|
| plain spelling, **unbumped** | 2 | KILLED — *"drafting statement #2 does not bump"* |
| plain spelling, bumped | left at 1 | KILLED by the count control |
| **nested-template spelling, unbumped** | 2 | KILLED — *"drafting statement #2 does not bump"* |

The third is the one that matters. Under the old terminator it extracted as `UPDATE "Model" SET ${Prisma.sql`, carried no `'Draft'`, dropped out of the drafting set entirely — and the old "at least one" control **passed, silently green over an unbumped drafting statement.**

No `no-*` guard file was added or removed, so `no-lint-rules-script-drift` needs no change — verified green, along with the rest of `test:lint-rules` (30 files, 461 tests).

## Test coverage

Behavioural, not only source-scanning. `src/server/services/__tests__/restore-model-updated-at.service.test.ts` drives the real `restoreModelById` through the canonical `dbMock` (no direct mock of `~/server/db/client`) and reads the statement it actually issues:

- the bump is present, assigned **exactly `now()`**, and **unconditional**;
- the SET clause is pinned as an ordered **ledger**, so an added column write is caught as well as a removed one — `publishedAt` in particular, which this function's own status `CASE` reads;
- the deletion-column clears, the status `CASE` and the `status = 'Deleted'` predicate are pinned, so the fix has to be *additive*;
- a scope guard holds the change to `Model."updatedAt"` and leaves `ModelVersion` alone (with a positive control asserting that statement was issued at all);
- a positive control asserts the function actually restored a model and returned its owner, so no guard is a claim about a path that never ran.

### Red → green

Both new guards were watched fail on the pre-fix source (`origin/main` at `34510fb587`, service file reverted, test files in place):

```
Test Files  2 failed (2)
     Tests  4 failed | 10 passed (14)

FAIL  no-unbumped-draft-status-write > model.service.ts sets "updatedAt" = now() on every drafting statement
  AssertionError: src/server/services/model.service.ts: without the bump this model is immediately
  reapable by remove-old-drafts, which cascade-deletes it: expected 'UPDATE "Model"\n SET "deletedAt"…'
  to contain '"updatedAt" = now()'

FAIL  restoreModelById > bumps "updatedAt" so a restored model gets a real grace period before the reaper
  AssertionError: a model restored with a stale "updatedAt" is immediately reapable by
  remove-old-drafts, which cascade-deletes it

FAIL  restoreModelById > writes exactly "deletedAt", "deletedBy", "status" and "updatedAt" — no other column
FAIL  restoreModelById > assigns "updatedAt" exactly now(), unconditionally
  AssertionError: expected undefined to be 'now()'
```

At the first commit, green: **10 files, 215 tests passed** (the two new/changed files plus `no-lint-rules-script-drift`, `no-direct-shared-module-mock`, `no-wholesale-module-mock`, `no-io-in-transaction`, `reset-to-draft-without-requirements`, `remove-old-drafts`, and the two existing `model.service` suites).

### Mutation results

Each mutant edits the narrowest expression that can be wrong, and each was confirmed to die with **the specific guard's own assertion message**, not collaterally. `M0` is the unmutated control.

| # | Mutant | Result | Killed by |
|---|---|---|---|
| M0 | *(none — control)* | 14 passed | — |
| M1 | bump deleted | KILLED (4 failed) | ledger guard + 3 behavioural |
| M2 | `now() - INTERVAL '31 days'` | KILLED (1 failed) | **behavioural only** — ledger guard passes |
| M3 | bump made conditional on `publishedAt IS NULL` | KILLED (3 failed) | ledger guard + 2 behavioural |
| M4 | extra `"publishedAt" = now()` write added | KILLED (1 failed) | **behavioural only** — SET-clause ledger |
| M5 | bump demoted to a `--` SQL comment | KILLED (4 failed) | ledger guard + 3 behavioural (comment stripping works) |
| M6 | `"updatedAt" = now()` added to the `ModelVersion` statement | KILLED (1 failed) | scope guard |
| M7 | `'Draft'` literal changed to `'Unpublished'` | KILLED (2 failed) | ledger exact-count control |
| N2 | second drafting statement, unbumped (count 2) | KILLED | *"drafting statement #2 does not bump"* |
| N3 | second drafting statement, bumped (count left 1) | KILLED | exact-count control |
| N4 | second drafting statement behind a nested template, unbumped | KILLED | **invisible to the old terminator** |

Re-run in full against the **final** head rather than carried forward from the first commit, since the extractor is a mechanism change: **11 mutants across both batteries, all killed, 2 controls green.**

### Two known limits of the extractor, listed by the direction they fail

The extractor is text-anchored on `UPDATE "Model"`, and the guard's own doc comment now records both limits *with which way each one breaks*, because a limits list that mixes fail-closed and fail-open reads as uniformly harmless:

- **Fails closed** — a comment or string that merely *quotes* the statement is counted as one. The exact-count control catches it, and the failure message now says to **reword the prose, not raise the count**, since a maintainer who raised it would install a phantom statement in the ledger permanently. (`model.service.ts`'s comment block already contains `'Draft'` and `"updatedAt" = now()`, so it is one mention away from this.) Watched it render: planting that comment turns the guard red with the new text.
- **Fails open** — an `UPDATE "Model"` written *inside another one's interpolation* is absorbed into the outer statement rather than enumerated, since `templateEnd` now correctly reads to the outer close. Measured: outer bumped, inner drafting and unbumped ⇒ `drafting=1, bumped=1`, count 1, all green. Deliberately **not** engineered around — nobody writes that shape and a parser change costs more risk than it buys — but recorded with the measurement so the next person weighing that trade is not guessing.

M2 and M4 are the ones that matter for the choice of test: both are **invisible to the source-text ledger** — M2 contains the literal the ledger greps for, and M4 is an addition no `toContain` can see. Only the behavioural test catches them. M2 in particular is the defect spelled as a fix.

## Verification scope, stated honestly

- **Typecheck**: `pnpm typecheck` is clean (0 errors), re-run against the final head. The instrument was validated — a planted `const x: number = 'nope'` in `model.service.ts` was reported (`TS2322` at the planted line). It does **not** cover the added test file: `tsconfig.json` excludes `src/**/__tests__/**` by design, and a planted error there was correctly not reported. Stating that rather than implying wider coverage.
- **ESLint**: run the way `lint.yml` does — added-file tier is blocking, so the added file was linted with `--rule '{"@typescript-eslint/no-inferrable-types":"error"}'` forced explicitly, resolving `@typescript-eslint` 5.62.0 (the lockfile version). Clean. The invocation's negative control was watched go red on a planted inferrable type. `model.service.ts` carries 9 pre-existing findings in the report-only modified tier — **identical count at the base commit**, so this change introduces none.
- **Prettier**: clean on both added and modified files.
- **Not verified**: no run against a real database. The statement's SQL is unchanged apart from one additional assignment of a nullary function to a `timestamp` column, so this is a low-risk gap, but it is a gap.

At the final head, green at **124 tests / 8 files**: `services/__tests__/{no-unbumped-draft-status-write, restore-model-updated-at.service, no-lint-rules-script-drift, no-direct-shared-module-mock, no-io-in-transaction}.test.ts`, `jobs/__tests__/{reset-to-draft-without-requirements, remove-old-drafts}.test.ts`, `notifications/__tests__/old-draft-reaper-parity.test.ts`. Counts are quoted with the file set they were measured over, so they can be reproduced.
