### PR TITLE
feat(moderation): bot-account detection skeleton, shadow mode only

### DIFF
--- a/packages/civitai-moderation/src/client.ts
+++ b/packages/civitai-moderation/src/client.ts
@@ -1,6 +1,8 @@
 import {
   MOD_ACTION,
+  abuseReportInput,
   imageModerateInput,
+  type AbuseReportInput,
   type ImageModerateInput,
   type ModActionName,
 } from './schema';
@@ -83,6 +85,20 @@ export function createModeratorClient(config: ModeratorClientConfig = {}) {
     /** Block or unblock one or more images. Validates the payload locally before the network call. */
     imageModerate: (input: ImageModerateInput): Promise<unknown> =>
       call(MOD_ACTION.imageModerate, imageModerateInput.parse(input)),
+    /**
+     * File one run of an automated abuse detector on the moderation board.
+     *
+     * `.parse` rather than a hand-rolled body, and that is the point of having a method here at all:
+     * the receiving table carries CHECK constraints whose violation aborts the transaction and loses
+     * the WHOLE run, so a malformed finding must be refused on the producer's side of the wire — a
+     * thrown ZodError names the offending field, where a 400 from the spoke names only the request.
+     * A producer that reaches for `call(MOD_ACTION.abuseReport, …)` directly skips that.
+     *
+     * Write-only, like the endpoint behind it: this stores what a detector found and grants nothing.
+     * It cannot mute, exclude or ban, and adding a method here can never make it able to.
+     */
+    abuseReport: (input: AbuseReportInput): Promise<unknown> =>
+      call(MOD_ACTION.abuseReport, abuseReportInput.parse(input)),
   };
 }
 

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -5,6 +5,7 @@ import { addOnDemandRunStrategiesJob } from '~/server/jobs/add-on-demand-run-str
 import { announcementMediaCheckJob } from '~/server/jobs/announcement-media-check';
 import { auditRemixSourcesJob } from '~/server/jobs/audit-remix-sources';
 import { blurbFanoutJob } from '~/server/jobs/blurb-fanout';
+import { botAccountDetection } from '~/server/jobs/bot-account-detection';
 import { dedupeOfficialUploadsJob } from '~/server/jobs/dedupe-official-uploads';
 import { applyContestTags } from '~/server/jobs/apply-contest-tags';
 import { applyDiscordRoles } from '~/server/jobs/apply-discord-roles';
@@ -192,6 +193,7 @@ export const jobs: Job[] = [
   imagesCreatedEvents,
   updateCreatorResourceCompensation,
   confirmMutes,
+  botAccountDetection,
   confirmPendingBlockAttributions,
   bulkPayoutBlockAttributions,
   reapDevTunnelsJob,

--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -2,7 +2,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { createCohortReader } from '~/server/services/bot-account-detection/cohort';
 import { runBotAccountDetection } from '~/server/services/bot-account-detection/run';
 import { moderatorApp } from '~/server/services/moderator-app.service';
-import { createJob } from './job';
+import { createJob, UNRUNNABLE_JOB_CRON } from './job';
 
 /**
  * Bot-account detection, SHADOW MODE.
@@ -19,18 +19,40 @@ import { createJob } from './job';
  * configuration of this job that can act on an account — turning it live is a code change here and
  * in the run, not a flag.
  *
- * Scheduled off the hour so a daily full-window read does not land on top of the top-of-hour jobs.
- * The window is 24h and the schedule is daily, so a missed run
- * leaves a gap rather than double-counting; it is also runnable on demand at
- * `/api/webhooks/run-jobs/bot-account-detection`, which is how a shadow-phase grading pass gets a
- * fresh report without waiting for the schedule.
+ * 🔴 REGISTERED BUT NOT SCHEDULED — `UNRUNNABLE_JOB_CRON` is a deliberate choice, not a leftover.
+ * `/api/internal/get-jobs` publishes every registered job's cron to the external scheduler, so a
+ * real cron here means MERGING THIS ENABLES IT: at 03:20 UTC the next day it would POST to a board
+ * whose table may not have been applied yet (`apps/moderator/abuse-detection/schema.sql` is applied
+ * by hand per this repo's convention — without its `(detector, started_at)` unique index every POST
+ * 500s on a `42P10`), with a `MOD_INBOUND_TOKEN` that may be unset. That is a daily 500 repeating
+ * until somebody notices, and the noticing is the only part that is not automatic.
+ *
+ * `UNRUNNABLE_JOB_CRON` (a Feb 31st that never comes) keeps the job REGISTERED and on-demand
+ * runnable at `/api/webhooks/run-jobs/bot-account-detection` — which is the whole of what a
+ * shadow-phase grading pass needs — while firing no schedule. Restoring a real cron is a one-token
+ * change once both preconditions are confirmed live; the PR body records what they are.
+ *
+ * `lockExpiration` is widened from the 5-minute default because the run-jobs route hard-caps the
+ * lock hold at exactly that value and then RELEASES the lock while the run continues — so a run
+ * longer than the expiration leaves the door open for a second, concurrent full run whose different
+ * `startedAt` the board cannot merge with the first. A capped walk is up to
+ * `MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE` account pages plus four `groupBy` reads each; 30 minutes
+ * is comfortably above that and is a ceiling, not a reservation.
  */
-export const botAccountDetection = createJob('bot-account-detection', '20 3 * * *', async () => {
-  return runBotAccountDetection({
-    reader: createCohortReader(),
-    sendReport: (report) => moderatorApp.abuseReport(report),
-    now: () => new Date(),
-    log: (name, data) =>
-      void logToAxiom({ type: 'info', name, ...data }, 'moderation').catch(() => undefined),
-  });
-});
+export const botAccountDetection = createJob(
+  'bot-account-detection',
+  UNRUNNABLE_JOB_CRON,
+  async (ctx) => {
+    return runBotAccountDetection({
+      reader: createCohortReader(),
+      sendReport: (report) => moderatorApp.abuseReport(report),
+      now: () => new Date(),
+      // The scheduler cancels by closing the response; without this the walk keeps paging and
+      // keeps POSTing after nobody is listening.
+      checkCanceled: () => ctx.checkIfCanceled(),
+      log: (name, data) =>
+        void logToAxiom({ type: 'info', name, ...data }, 'moderation').catch(() => undefined),
+    });
+  },
+  { lockExpiration: 30 * 60 }
+);

--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -32,12 +32,15 @@ import { createJob, UNRUNNABLE_JOB_CRON } from './job';
  * shadow-phase grading pass needs — while firing no schedule. Restoring a real cron is a one-token
  * change once both preconditions are confirmed live; the PR body records what they are.
  *
- * `lockExpiration` is widened from the 5-minute default because the run-jobs route hard-caps the
- * lock hold at exactly that value and then RELEASES the lock while the run continues — so a run
- * longer than the expiration leaves the door open for a second, concurrent full run whose different
- * `startedAt` the board cannot merge with the first. A capped walk is up to
- * `MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE` account pages plus four `groupBy` reads each; 30 minutes
- * is comfortably above that and is a ceiling, not a reservation.
+ * 🔴 `lockExpiration` IS THE MITIGATION FOR THE DUPLICATE RUN, and it is the only one. The run-jobs
+ * route hard-caps the lock hold at exactly this value and then RELEASES the lock while the run
+ * continues, so past that point a retry can start a second, concurrent full run whose different
+ * `startedAt` the board's `(detector, started_at)` key cannot merge with the first — two complete
+ * duplicate finding sets. Widening the window until a run fits inside it is what prevents that; the
+ * `checkCanceled` wiring below does NOT, because `release()` clears the redis key and its refresh
+ * interval and never touches the job context (see `acquireLock` in the route). A capped walk is up
+ * to `MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE` account pages plus eight `groupBy` reads each;
+ * 30 minutes is comfortably above that and is a ceiling, not a reservation.
  */
 export const botAccountDetection = createJob(
   'bot-account-detection',

--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -1,0 +1,36 @@
+import { logToAxiom } from '~/server/logging/client';
+import { createCohortReader } from '~/server/services/bot-account-detection/cohort';
+import { runBotAccountDetection } from '~/server/services/bot-account-detection/run';
+import { moderatorApp } from '~/server/services/moderator-app.service';
+import { createJob } from './job';
+
+/**
+ * Bot-account detection, SHADOW MODE.
+ *
+ * Reads the accounts registered in the last day that have already posted, scores each one, and files
+ * the result on the moderator app's abuse-detection board with `actioned: false` on every finding.
+ * It mutes nobody. See `~/server/services/bot-account-detection/report.ts` for why the board rather
+ * than a `UserRestriction` row — briefly: `applyPendingReviewMute` has no file-without-mute path, so
+ * filing a Pending row without muting would manufacture the one state that service says a Pending
+ * row must never be left in.
+ *
+ * This file is the ONLY wiring: it supplies a read-replica reader, the moderator client, and a
+ * clock. The run itself holds no write client and no restriction service, so there is no
+ * configuration of this job that can act on an account — turning it live is a code change here and
+ * in the run, not a flag.
+ *
+ * Scheduled off the hour so a daily full-window read does not land on top of the top-of-hour jobs.
+ * The window is 24h and the schedule is daily, so a missed run
+ * leaves a gap rather than double-counting; it is also runnable on demand at
+ * `/api/webhooks/run-jobs/bot-account-detection`, which is how a shadow-phase grading pass gets a
+ * fresh report without waiting for the schedule.
+ */
+export const botAccountDetection = createJob('bot-account-detection', '20 3 * * *', async () => {
+  return runBotAccountDetection({
+    reader: createCohortReader(),
+    sendReport: (report) => moderatorApp.abuseReport(report),
+    now: () => new Date(),
+    log: (name, data) =>
+      void logToAxiom({ type: 'info', name, ...data }, 'moderation').catch(() => undefined),
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/cohort.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/cohort.test.ts
@@ -3,11 +3,13 @@ import {
   BOT_ACCOUNT_COHORT_WINDOW_HOURS,
   COHORT_PAGE_SIZE,
   MAX_COHORT_ACCOUNTS,
+  allContentCountArgs,
   cohortCutoff,
   collectCohort,
   commentCountArgs,
   commentV2CountArgs,
   createCohortReader,
+  emptyRawPostCounts,
   imageCountArgs,
   mergePostCounts,
   modelCountArgs,
@@ -17,7 +19,7 @@ import {
   type CohortReader,
   type NewAccountRow,
   type PostCounts,
-  type RawPostCounts,
+  type SurfaceCounts,
 } from '../cohort';
 
 const at = (iso: string) => new Date(iso);
@@ -29,15 +31,65 @@ const account = (id: number, createdAt = NOW): NewAccountRow => ({
   createdAt,
 });
 
-const counts = (entries: Array<[number, Partial<PostCounts>]>): Map<number, PostCounts> =>
+const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
+  const row = { comments: 0, models: 0, images: 0, ...partial };
+  return { ...row, total: row.comments + row.models + row.images };
+};
+
+/**
+ * A `PostCounts` from a per-surface spec.
+ *
+ * The bare form gives what the account POSTED, with `visible` equal to it — the ordinary case where
+ * nothing has been taken down. Pass `visible` to describe an account some of whose content is gone;
+ * `excluded` is always the difference, exactly as `mergePostCounts` computes it.
+ */
+const counts = (
+  entries: Array<[number, Partial<SurfaceCounts> & { visible?: Partial<SurfaceCounts> }]>
+): Map<number, PostCounts> =>
   new Map(
-    entries.map(([userId, partial]) => {
-      const row = { comments: 0, models: 0, images: 0, ...partial };
-      return [userId, { ...row, total: row.comments + row.models + row.images }];
+    entries.map(([userId, spec]) => {
+      const { visible: visibleSpec, ...allSpec } = spec;
+      const all = surface(allSpec);
+      const visible = visibleSpec === undefined ? all : surface(visibleSpec);
+      return [
+        userId,
+        {
+          all,
+          visible,
+          excluded: {
+            comments: Math.max(0, all.comments - visible.comments),
+            models: Math.max(0, all.models - visible.models),
+            images: Math.max(0, all.images - visible.images),
+            total: Math.max(0, all.total - visible.total),
+          },
+        },
+      ];
     })
   );
 
-const emptyRaw = (): RawPostCounts => ({ comments: [], commentsV2: [], models: [], images: [] });
+// The module's own empty, not a local copy: a surface added to `RawPostCounts` and forgotten here
+// would otherwise leave every fixture below silently short of a field.
+const emptyRaw = emptyRawPostCounts;
+
+/** Content counts for a set of ids: `visible` on each surface, and `posted` in total. */
+const rawFor = (
+  ids: number[],
+  per: { images?: number; comments?: number; models?: number },
+  visiblePer: { images?: number; comments?: number; models?: number } = per
+) => {
+  const rows = (n: number | undefined) =>
+    n === undefined || n === 0 ? [] : ids.map((userId) => ({ userId, count: n }));
+  return {
+    comments: rows(visiblePer.comments),
+    commentsV2: [],
+    models: rows(visiblePer.models),
+    images: rows(visiblePer.images),
+    allComments: rows(per.comments),
+    allCommentsV2: [],
+    allModels: rows(per.models),
+    allImages: rows(per.images),
+  };
+};
 
 describe('cohortCutoff', () => {
   // Two points, not one: a single window cannot tell an implementation that subtracts the argument
@@ -65,7 +117,7 @@ describe('the cohort cap is set against the measured signup baseline', () => {
     // looks proven, and trips for the first time on exactly the day a wave lands. Expressed in
     // PAGES so the bound holds without naming the baseline.
     expect(MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE).toBeGreaterThanOrEqual(40);
-    // Still a bound: the walk is at most this many pages, four content reads each.
+    // Still a bound: the walk is at most this many pages, eight content reads each.
     expect(MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE).toBeLessThanOrEqual(100);
   });
 });
@@ -154,6 +206,21 @@ describe('content-count arguments count only content a moderator can open', () =
       ingestion: { notIn: ['Blocked', 'NotFound'] },
     });
   });
+
+  it('🔴 the MEMBERSHIP read carries no visibility predicate at all', () => {
+    // 🔴 The read membership is decided on. Every predicate in the four builders above is a
+    // moderation outcome, and any one of them appearing here would put the scanner or a moderator
+    // back in charge of who the detector is allowed to look at — the exact defect this pair splits
+    // apart. An exact object, not a `toMatchObject`: a stray extra clause has to fail.
+    expect(allContentCountArgs([7]).where).toEqual({ userId: { in: [7] } });
+    expect(allContentCountArgs([7]).by).toEqual(['userId']);
+    expect(allContentCountArgs([7])._count).toEqual({ _all: true });
+
+    // And it is genuinely a different argument from each visible read, so a refactor collapsing the
+    // pair back into one builder fails here rather than silently restoring the old behaviour.
+    for (const build of [commentCountArgs, commentV2CountArgs, modelCountArgs, imageCountArgs])
+      expect(build([7]).where).not.toEqual(allContentCountArgs([7]).where);
+  });
 });
 
 describe('createCohortReader', () => {
@@ -161,6 +228,17 @@ describe('createCohortReader', () => {
   // changes nothing, and that is invisible to a test of the builder alone.
   const makeDb = () => {
     const calls: string[] = [];
+    // Each surface is asked TWICE — once with its visibility filter and once without — and answers
+    // differently, so a mutant that hands the same argument to both, or reads the wrong reply into
+    // the wrong field, cannot produce the expected numbers by coincidence. The two are told apart
+    // by the only thing that distinguishes them: the unfiltered read's `where` has exactly one key.
+    const groupBy = (label: string, visible: number, all: number) => ({
+      groupBy: vi.fn(async (args: { where: Record<string, unknown> }) => {
+        const filtered = Object.keys(args.where).length > 1;
+        calls.push(`${label}.groupBy:${filtered ? 'visible' : 'all'}`);
+        return [{ userId: 1, _count: { _all: filtered ? visible : all } }];
+      }),
+    });
     const db = {
       user: {
         findMany: vi.fn(async (args: unknown) => {
@@ -169,30 +247,11 @@ describe('createCohortReader', () => {
           return [account(1)];
         }),
       },
-      comment: {
-        groupBy: vi.fn(async () => {
-          calls.push('comment.groupBy');
-          return [{ userId: 1, _count: { _all: 2 } }];
-        }),
-      },
-      commentV2: {
-        groupBy: vi.fn(async () => {
-          calls.push('commentV2.groupBy');
-          return [{ userId: 1, _count: { _all: 3 } }];
-        }),
-      },
-      model: {
-        groupBy: vi.fn(async () => {
-          calls.push('model.groupBy');
-          return [{ userId: 1, _count: { _all: 4 } }];
-        }),
-      },
-      image: {
-        groupBy: vi.fn(async () => {
-          calls.push('image.groupBy');
-          return [{ userId: 1, _count: { _all: 5 } }];
-        }),
-      },
+      // Pairwise-distinct across all eight values, and distinct from every total they add up to.
+      comment: groupBy('comment', 2, 20),
+      commentV2: groupBy('commentV2', 3, 30),
+      model: groupBy('model', 4, 40),
+      image: groupBy('image', 5, 50),
     } satisfies CohortDb;
     return { db, calls };
   };
@@ -219,23 +278,46 @@ describe('createCohortReader', () => {
     expect(modelCountArgs([1]).where).not.toEqual(imageCountArgs([1]).where);
   });
 
-  it('reads both comment systems, models and images — and nothing else', async () => {
+  it('🔴 also asks each surface for its UNFILTERED count — the membership read', async () => {
+    // 🔴 The half membership now depends on. A correct `allContentCountArgs` that is never handed
+    // to the client changes nothing, and a builder test cannot see that: the whole F-2 fix is the
+    // pair of reads reaching the database, per surface.
+    const { db } = makeDb();
+    await createCohortReader(db).countPosts([1]);
+    for (const model of [db.comment, db.commentV2, db.model, db.image]) {
+      expect(model.groupBy).toHaveBeenCalledWith(allContentCountArgs([1]));
+      expect(model.groupBy).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it('reads both comment systems, models and images — filtered AND unfiltered, nothing else', async () => {
     const { db, calls } = makeDb();
     const raw = await createCohortReader(db).countPosts([1]);
     // An asserted LEDGER, sorted so it is order-independent but not membership-independent: it
     // fails if an operation is added AND if one is removed. Dropping `commentV2` is the realistic
     // regression — it reads as a tidy-up and turns every newer-comment-only account into a
-    // false negative.
+    // false negative. Dropping an `:all` member is the F-2 regression: membership silently goes
+    // back to being decided on visible content.
     expect([...calls].sort()).toEqual([
-      'comment.groupBy',
-      'commentV2.groupBy',
-      'image.groupBy',
-      'model.groupBy',
+      'comment.groupBy:all',
+      'comment.groupBy:visible',
+      'commentV2.groupBy:all',
+      'commentV2.groupBy:visible',
+      'image.groupBy:all',
+      'image.groupBy:visible',
+      'model.groupBy:all',
+      'model.groupBy:visible',
     ]);
+    // Eight distinct values landing in eight distinct fields: a mutant that wires a reply to the
+    // wrong field cannot land on the right number.
     expect(raw.comments).toEqual([{ userId: 1, count: 2 }]);
     expect(raw.commentsV2).toEqual([{ userId: 1, count: 3 }]);
     expect(raw.models).toEqual([{ userId: 1, count: 4 }]);
     expect(raw.images).toEqual([{ userId: 1, count: 5 }]);
+    expect(raw.allComments).toEqual([{ userId: 1, count: 20 }]);
+    expect(raw.allCommentsV2).toEqual([{ userId: 1, count: 30 }]);
+    expect(raw.allModels).toEqual([{ userId: 1, count: 40 }]);
+    expect(raw.allImages).toEqual([{ userId: 1, count: 50 }]);
   });
 
   it('asks the database nothing when there are no ids', async () => {
@@ -243,6 +325,18 @@ describe('createCohortReader', () => {
     const raw = await createCohortReader(db).countPosts([]);
     expect(calls).toEqual([]);
     expect(raw).toEqual(emptyRaw());
+    // The empty answer covers every surface. A field added to `RawPostCounts` and left out of the
+    // empty case would arrive as `undefined` and be silently skipped by `mergePostCounts`.
+    expect(Object.keys(raw).sort()).toEqual([
+      'allComments',
+      'allCommentsV2',
+      'allImages',
+      'allModels',
+      'comments',
+      'commentsV2',
+      'images',
+      'models',
+    ]);
   });
 });
 
@@ -253,21 +347,72 @@ describe('mergePostCounts', () => {
       commentsV2: [{ userId: 1, count: 3 }],
       models: [{ userId: 1, count: 4 }],
       images: [{ userId: 1, count: 5 }],
+      allComments: [{ userId: 1, count: 2 }],
+      allCommentsV2: [{ userId: 1, count: 3 }],
+      allModels: [{ userId: 1, count: 4 }],
+      allImages: [{ userId: 1, count: 5 }],
     });
     // Distinct values per surface, and distinct from the total, so a mutant that reads the wrong
     // field or drops one of the four cannot produce the same number by accident.
-    expect(merged.get(1)).toEqual({ comments: 5, models: 4, images: 5, total: 14 });
+    expect(merged.get(1)?.visible).toEqual({ comments: 5, models: 4, images: 5, total: 14 });
+    expect(merged.get(1)?.all).toEqual({ comments: 5, models: 4, images: 5, total: 14 });
+    expect(merged.get(1)?.excluded).toEqual({ comments: 0, models: 0, images: 0, total: 0 });
+  });
+
+  it('keeps the two sides apart, per surface', () => {
+    // 🔴 The split itself. Every one of the eight inputs is a different number and no two of the
+    // twelve outputs coincide, so a mutant that reads an `all*` row into the visible side (or the
+    // reverse), or that folds `commentsV2` into the wrong half, lands on a value this cannot
+    // produce.
+    const merged = mergePostCounts({
+      comments: [{ userId: 1, count: 1 }],
+      commentsV2: [{ userId: 1, count: 2 }],
+      models: [{ userId: 1, count: 4 }],
+      images: [{ userId: 1, count: 8 }],
+      allComments: [{ userId: 1, count: 16 }],
+      allCommentsV2: [{ userId: 1, count: 32 }],
+      allModels: [{ userId: 1, count: 64 }],
+      allImages: [{ userId: 1, count: 128 }],
+    });
+    expect(merged.get(1)?.visible).toEqual({ comments: 3, models: 4, images: 8, total: 15 });
+    expect(merged.get(1)?.all).toEqual({ comments: 48, models: 64, images: 128, total: 240 });
+    expect(merged.get(1)?.excluded).toEqual({
+      comments: 45,
+      models: 60,
+      images: 120,
+      total: 225,
+    });
+  });
+
+  it('floors `excluded` at zero when the two reads disagree', () => {
+    // The filtered and unfiltered counts of one surface are separate statements against a replica,
+    // so a row created between them can leave `visible` above `all`. A negative in the one sentence
+    // a moderator acts on reads as corrupt data; zero reads as "nothing was taken down", which is
+    // the truth as near as this run can tell.
+    const merged = mergePostCounts({
+      ...emptyRaw(),
+      images: [{ userId: 1, count: 9 }],
+      allImages: [{ userId: 1, count: 4 }],
+    });
+    expect(merged.get(1)?.excluded).toEqual({ comments: 0, models: 0, images: 0, total: 0 });
+    expect(merged.get(1)?.all.total).toBe(4);
+    expect(merged.get(1)?.visible.total).toBe(9);
   });
 
   it('keeps users apart', () => {
     const merged = mergePostCounts({
+      ...emptyRaw(),
       comments: [{ userId: 1, count: 1 }],
-      commentsV2: [],
-      models: [{ userId: 2, count: 7 }],
-      images: [],
+      allComments: [{ userId: 1, count: 1 }],
+      allModels: [{ userId: 2, count: 7 }],
     });
-    expect(merged.get(1)?.total).toBe(1);
-    expect(merged.get(2)?.total).toBe(7);
+    expect(merged.get(1)?.all.total).toBe(1);
+    expect(merged.get(2)?.all.total).toBe(7);
+    // User 2's models were all taken down; user 1's comment is still up. Neither leaks into the
+    // other.
+    expect(merged.get(2)?.visible.total).toBe(0);
+    expect(merged.get(2)?.excluded.models).toBe(7);
+    expect(merged.get(1)?.excluded.total).toBe(0);
   });
 });
 
@@ -300,6 +445,46 @@ describe('selectCohortMembers', () => {
     expect(members[0].userId).toBe(4);
   });
 
+  it('🔴 INCLUDES an account whose every upload was blocked — the canonical bot wave', () => {
+    // 🔴 THE REGRESSION THIS SPLIT EXISTS FOR. An account two hours old uploads 40 images and the
+    // scanner marks every one of them `Blocked`. Under a visible-total membership rule it counted
+    // zero, so it was not a member, not scored and not reported — while `scanned` still counted it,
+    // making the run summary read "0 had posted". Nothing anywhere reported an error.
+    const members = selectCohortMembers([account(6)], counts([[6, { images: 40, visible: {} }]]));
+    expect(members).toHaveLength(1);
+    expect(members[0].userId).toBe(6);
+    expect(members[0].posts.all.total).toBe(40);
+    expect(members[0].posts.visible.total).toBe(0);
+    expect(members[0].posts.excluded.images).toBe(40);
+  });
+
+  it.each([
+    ['every comment hidden or TOS-flagged', { comments: 12 }],
+    ['every model unpublished or deleted', { models: 9 }],
+    ['every image blocked', { images: 40 }],
+  ])('🔴 a moderator action on %s does not drop the account', (_label, posted) => {
+    // One moderator action, or one scanner verdict, could remove a whole account from the cohort —
+    // on any of the three surfaces, since each spells "removed" in its own columns. Three cases so
+    // a fix that covers only the surface the bug was found on fails here.
+    const members = selectCohortMembers([account(7)], counts([[7, { ...posted, visible: {} }]]));
+    expect(members).toHaveLength(1);
+    expect(members[0].posts.visible.total).toBe(0);
+    expect(members[0].posts.all.total).toBeGreaterThan(0);
+  });
+
+  it('🔴 the partial case: 39 of 40 blocked still ranks by what was POSTED', () => {
+    // Worse than the total case, because it is invisible. The account is in the cohort either way,
+    // but under the old rule its finding said "1 image" — so a moderator sorting a queue by volume
+    // put the account that uploaded 40 and had 39 blocked at the very bottom.
+    const members = selectCohortMembers(
+      [account(8)],
+      counts([[8, { images: 40, visible: { images: 1 } }]])
+    );
+    expect(members[0].posts.all.images).toBe(40);
+    expect(members[0].posts.visible.images).toBe(1);
+    expect(members[0].posts.excluded.images).toBe(39);
+  });
+
   it('carries the account identity and its activity through', () => {
     const created = at('2026-09-03T09:30:00.000Z');
     const members = selectCohortMembers(
@@ -310,7 +495,11 @@ describe('selectCohortMembers', () => {
       userId: 5,
       username: 'spam5',
       createdAt: created,
-      posts: { comments: 2, models: 1, images: 3, total: 6 },
+      posts: {
+        all: { comments: 2, models: 1, images: 3, total: 6 },
+        visible: { comments: 2, models: 1, images: 3, total: 6 },
+        excluded: { comments: 0, models: 0, images: 0, total: 0 },
+      },
     });
   });
 });
@@ -328,12 +517,7 @@ function fakeReader(accounts: NewAccountRow[]): CohortReader & { pageRequests: n
         .filter((a) => before === undefined || a.id < before)
         .slice(0, take);
     },
-    countPosts: async (ids) => ({
-      comments: [],
-      commentsV2: [],
-      models: [],
-      images: ids.map((userId) => ({ userId, count: 1 })),
-    }),
+    countPosts: async (ids) => rawFor(ids, { images: 1 }),
   };
 }
 
@@ -458,15 +642,42 @@ describe('collectCohort', () => {
     const reader: CohortReader = {
       ...base,
       // Only odd ids posted.
-      countPosts: async (ids) => ({
-        ...emptyRaw(),
-        images: ids.filter((id) => id % 2 === 1).map((userId) => ({ userId, count: 1 })),
-      }),
+      countPosts: async (ids) =>
+        rawFor(
+          ids.filter((id) => id % 2 === 1),
+          { images: 1 }
+        ),
     };
     const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
     expect(result.members.map((m) => m.userId)).toEqual([7, 5, 3, 1]);
     // `scanned` is the denominator the counters publish. If the filter were applied to it too, a
     // report could never say "3 of 700", which is the number that says whether the rule is tight.
     expect(result.scanned).toBe(7);
+  });
+
+  it('🔴 a whole page of already-blocked accounts is a COHORT, not a reassuring zero', async () => {
+    // 🔴 END TO END, through the walk rather than the pure selector, because that is where the
+    // reassuring zero was produced. The reader reports what a real bot wave looks like at the
+    // moment this detector runs: 40 uploads each, every one of them blocked, so every visible
+    // count is empty and only the unfiltered reads return rows.
+    //
+    // Before the split this walk produced `members: []` against `scanned: 7`, and the run summary
+    // said "Scanned 7 account(s); 0 had posted". Nothing errored, nothing was logged, and the whole
+    // shadow phase's output for that wave was the word zero.
+    const base = fakeReader(seven);
+    const reader: CohortReader = {
+      ...base,
+      countPosts: async (ids) => rawFor(ids, { images: 40 }, {}),
+    };
+    const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
+
+    expect(result.members).toHaveLength(7);
+    expect(result.members.map((m) => m.userId)).toEqual([7, 6, 5, 4, 3, 2, 1]);
+    expect(result.scanned).toBe(7);
+    for (const member of result.members) {
+      expect(member.posts.all.images).toBe(40);
+      expect(member.posts.visible.total).toBe(0);
+      expect(member.posts.excluded.images).toBe(40);
+    }
   });
 });

--- a/src/server/services/bot-account-detection/__tests__/cohort.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/cohort.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   BOT_ACCOUNT_COHORT_WINDOW_HOURS,
+  COHORT_PAGE_SIZE,
+  MAX_COHORT_ACCOUNTS,
   cohortCutoff,
   collectCohort,
+  commentCountArgs,
+  commentV2CountArgs,
   createCohortReader,
+  imageCountArgs,
   mergePostCounts,
+  modelCountArgs,
   newAccountPageArgs,
-  postCountArgs,
   selectCohortMembers,
   type CohortDb,
   type CohortReader,
@@ -48,9 +53,26 @@ describe('cohortCutoff', () => {
   });
 });
 
+describe('the cohort cap is set against the measured signup baseline', () => {
+  /** Signups in the 24h window, counted read-only on a replica while auditing this change. Not a
+   *  live figure and it will drift — it is the number the constant was CHOSEN against, recorded so
+   *  the choice is checkable rather than a remembered anecdote. */
+  const MEASURED_DAILY_SIGNUPS = 8_863;
+
+  it('leaves room for a registration wave, not 13% headroom', () => {
+    // 🔴 An invariant guard, deliberately labelled as one: it pins the reasoning, it is not
+    // regression coverage for a bug. The previous 10,000 sat ~13% above the baseline, which is the
+    // worst place for a cap — never trips on an ordinary day, so it looks proven, and trips for the
+    // first time on exactly the day a wave lands.
+    expect(MAX_COHORT_ACCOUNTS).toBeGreaterThanOrEqual(MEASURED_DAILY_SIGNUPS * 2);
+    // Still a bound: the walk is at most this many pages, four content reads each.
+    expect(MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE).toBeLessThanOrEqual(100);
+  });
+});
+
 describe('newAccountPageArgs', () => {
   const cutoff = at('2026-09-02T12:00:00.000Z');
-  const args = newAccountPageArgs({ createdAfter: cutoff, after: 41, take: 7 });
+  const args = newAccountPageArgs({ createdAfter: cutoff, before: 41, take: 7 });
 
   it('bounds the window at the cutoff, inclusive and forward-only', () => {
     // `gte` and nothing else: an upper bound would exclude accounts created while the run walks,
@@ -64,11 +86,22 @@ describe('newAccountPageArgs', () => {
     expect(args.where.deletedAt).toBeNull();
   });
 
-  it('pages by keyset on id, ascending, not by offset', () => {
-    expect(args.where.id).toEqual({ gt: 41 });
-    expect(args.orderBy).toEqual({ id: 'asc' });
+  it('pages by keyset on id, DESCENDING, not by offset', () => {
+    // 🔴 The direction is the behaviour, not a style choice. Ascending, a capped run's unread
+    // remainder is the HIGHEST ids — the newest signups, i.e. the registration wave this detector
+    // exists to notice. Descending, the remainder is the oldest end of the window.
+    expect(args.where.id).toEqual({ lt: 41 });
+    expect(args.orderBy).toEqual({ id: 'desc' });
     expect(args.take).toBe(7);
     expect(args).not.toHaveProperty('skip');
+  });
+
+  it('seeds the walk with no id bound at all', () => {
+    // `undefined` rather than a sentinel: Prisma drops an undefined field from the WHERE clause,
+    // where any real integer would have to be inside `int4` and would eventually be reachable.
+    const seed = newAccountPageArgs({ createdAfter: cutoff, before: undefined, take: 3 });
+    expect(seed.where.id).toBeUndefined();
+    expect(seed.orderBy).toEqual({ id: 'desc' });
   });
 
   it('selects only the columns the report cites', () => {
@@ -76,12 +109,50 @@ describe('newAccountPageArgs', () => {
   });
 });
 
-describe('postCountArgs', () => {
-  it('counts per user, restricted to the ids handed in', () => {
-    const args = postCountArgs([3, 4]);
-    expect(args.by).toEqual(['userId']);
-    expect(args.where).toEqual({ userId: { in: [3, 4] } });
-    expect(args._count).toEqual({ _all: true });
+describe('content-count arguments count only content a moderator can open', () => {
+  // 🔴 Filtering the content side on `userId` alone counted drafts, unattached uploads, blocked
+  // uploads, hidden comments and already-removed models as "posted" — and the finding's reason
+  // string then told a moderator to go and look at them.
+  it('shapes every read as a per-user count over exactly the ids handed in', () => {
+    for (const build of [commentCountArgs, commentV2CountArgs, modelCountArgs, imageCountArgs]) {
+      const args = build([3, 4]);
+      expect(args.by).toEqual(['userId']);
+      expect(args._count).toEqual({ _all: true });
+      expect(args.where).toMatchObject({ userId: { in: [3, 4] } });
+    }
+  });
+
+  it('excludes hidden and TOS-flagged comments, in both comment systems', () => {
+    // `hidden` is a NULLABLE boolean, so `{ not: true }` and not `false`: `hidden: false` would
+    // drop every comment that has never been hidden, which is nearly all of them.
+    for (const build of [commentCountArgs, commentV2CountArgs]) {
+      expect(build([7]).where).toEqual({
+        userId: { in: [7] },
+        hidden: { not: true },
+        tosViolation: false,
+      });
+    }
+  });
+
+  it('counts only published, undeleted, un-flagged models', () => {
+    expect(modelCountArgs([7]).where).toEqual({
+      userId: { in: [7] },
+      status: 'Published',
+      deletedAt: null,
+      tosViolation: false,
+    });
+  });
+
+  it('counts only images attached to a post, and not blocked or missing ones', () => {
+    // 🔴 `Pending` is deliberately still counted: a fresh upload is Pending for minutes, so a bot
+    // wave's images are Pending at the instant this detector looks at them. Blocked and NotFound
+    // are decisions to remove; Pending is a scan that has not finished.
+    expect(imageCountArgs([7]).where).toEqual({
+      userId: { in: [7] },
+      postId: { not: null },
+      tosViolation: false,
+      ingestion: { notIn: ['Blocked', 'NotFound'] },
+    });
   });
 });
 
@@ -128,9 +199,24 @@ describe('createCohortReader', () => {
 
   it('hands `newAccountPageArgs` to the client verbatim', async () => {
     const { db } = makeDb();
-    const request = { createdAfter: at('2026-09-02T12:00:00.000Z'), after: 9, take: 3 };
+    const request = { createdAfter: at('2026-09-02T12:00:00.000Z'), before: 9, take: 3 };
     await createCohortReader(db).listNewAccounts(request);
     expect(db.user.findMany).toHaveBeenCalledWith(newAccountPageArgs(request));
+  });
+
+  it('hands each content read its OWN visibility filter, not one shared argument', async () => {
+    // The seam again, in the axis that changed: four reads that used to take one identical
+    // argument now take four different ones, and a refactor that reverts them to a shared
+    // `postCountArgs` would be invisible to a test of the builders alone.
+    const { db } = makeDb();
+    await createCohortReader(db).countPosts([1]);
+    expect(db.comment.groupBy).toHaveBeenCalledWith(commentCountArgs([1]));
+    expect(db.commentV2.groupBy).toHaveBeenCalledWith(commentV2CountArgs([1]));
+    expect(db.model.groupBy).toHaveBeenCalledWith(modelCountArgs([1]));
+    expect(db.image.groupBy).toHaveBeenCalledWith(imageCountArgs([1]));
+    // And they are genuinely different objects — a shared one would satisfy all four above only if
+    // the four builders had collapsed into one, which this catches directly.
+    expect(modelCountArgs([1]).where).not.toEqual(imageCountArgs([1]).where);
   });
 
   it('reads both comment systems, models and images — and nothing else', async () => {
@@ -229,15 +315,18 @@ describe('selectCohortMembers', () => {
   });
 });
 
-/** A reader over a fixed account list: pages it by keyset, and reports every account as having
- *  posted exactly one image so membership never masks a paging bug. */
+/** A reader over a fixed account list: pages it by DESCENDING keyset, and reports every account as
+ *  having posted exactly one image so membership never masks a paging bug. */
 function fakeReader(accounts: NewAccountRow[]): CohortReader & { pageRequests: number[] } {
   const pageRequests: number[] = [];
   return {
     pageRequests,
-    listNewAccounts: async ({ after, take }) => {
+    listNewAccounts: async ({ before, take }) => {
       pageRequests.push(take);
-      return accounts.filter((a) => a.id > after).slice(0, take);
+      return [...accounts]
+        .sort((a, b) => b.id - a.id)
+        .filter((a) => before === undefined || a.id < before)
+        .slice(0, take);
     },
     countPosts: async (ids) => ({
       comments: [],
@@ -255,10 +344,10 @@ describe('collectCohort', () => {
   // leave this one unexercised.
   const seven = Array.from({ length: 7 }, (_, i) => account(i + 1));
 
-  it('walks every page of the window', async () => {
+  it('walks every page of the window, newest account first', async () => {
     const reader = fakeReader(seven);
     const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
-    expect(result.members.map((m) => m.userId)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(result.members.map((m) => m.userId)).toEqual([7, 6, 5, 4, 3, 2, 1]);
     expect(result.scanned).toBe(7);
     expect(result.pages).toBe(3);
     expect(result.capped).toBe(false);
@@ -268,11 +357,49 @@ describe('collectCohort', () => {
     const reader = fakeReader(seven);
     const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 5 });
     expect(result.scanned).toBe(5);
-    expect(result.members.map((m) => m.userId)).toEqual([1, 2, 3, 4, 5]);
     expect(result.capped).toBe(true);
     // The final page is clamped to the remaining budget, not the page size — otherwise the cap is
     // only ever approximate and a run reads more than it claims.
     expect(reader.pageRequests).toEqual([3, 2, 1]);
+  });
+
+  it('🔴 TRUNCATES THE OLDEST END: a capped run keeps the NEWEST accounts', async () => {
+    // The finding this test exists for. 11 accounts against a cap of 7, page size 3 — the fixture
+    // OVERSHOOTS the cap (11 > 7), the cap is not a multiple of the page size, and neither is a
+    // power-of-two multiple of it, so the budget-clamped final page runs and the surviving set is
+    // not producible by landing exactly on a boundary.
+    //
+    // Ascending, this returns ids 1..7 — the oldest seven — and discards 8..11, the four most
+    // recent signups, which is precisely the population a registration wave lives in.
+    const eleven = Array.from({ length: 11 }, (_, i) => account(i + 1));
+    const reader = fakeReader(eleven);
+    const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 7 });
+
+    expect(result.scanned).toBe(7);
+    expect(result.capped).toBe(true);
+    // WHICH accounts survived, not just how many.
+    expect(result.members.map((m) => m.userId)).toEqual([11, 10, 9, 8, 7, 6, 5]);
+    // Said the other way round, so a mutant that reverses the direction fails on the identity of
+    // the dropped set rather than only on the order of the kept one.
+    const kept = new Set(result.members.map((m) => m.userId));
+    for (const newest of [11, 10, 9, 8]) expect(kept.has(newest)).toBe(true);
+    for (const oldest of [1, 2, 3, 4]) expect(kept.has(oldest)).toBe(false);
+  });
+
+  it('walks strictly downwards, page by page', async () => {
+    // The keyset itself, independent of the cap: each page asks for ids strictly below the lowest
+    // id of the page before it, and the seed page asks with no bound.
+    const bounds: Array<number | undefined> = [];
+    const base = fakeReader(seven);
+    const reader: CohortReader = {
+      ...base,
+      listNewAccounts: async (args) => {
+        bounds.push(args.before);
+        return base.listNewAccounts(args);
+      },
+    };
+    await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
+    expect(bounds).toEqual([undefined, 5, 2]);
   });
 
   it('does not call a complete cohort truncated when its size equals the cap', async () => {
@@ -283,6 +410,26 @@ describe('collectCohort', () => {
     const result = await collectCohort(reader, { createdAfter, pageSize: 5, maxAccounts: 5 });
     expect(result.scanned).toBe(5);
     expect(result.capped).toBe(false);
+  });
+
+  it('checks for cancellation once per page, and stops when it throws', async () => {
+    // The scheduler cancels by closing the response. A walk that never asks keeps paging — and on
+    // this job that overrun is what produces a second, unmergeable run.
+    const reader = fakeReader(seven);
+    let checks = 0;
+    await expect(
+      collectCohort(reader, {
+        createdAfter,
+        pageSize: 3,
+        maxAccounts: 100,
+        checkCanceled: () => {
+          checks += 1;
+          if (checks === 2) throw new Error('Job was canceled');
+        },
+      })
+    ).rejects.toThrow('Job was canceled');
+    // One page read before the cancellation was seen, and none after.
+    expect(reader.pageRequests).toEqual([3]);
   });
 
   it('reports an empty window without paging', async () => {
@@ -317,7 +464,7 @@ describe('collectCohort', () => {
       }),
     };
     const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
-    expect(result.members.map((m) => m.userId)).toEqual([1, 3, 5, 7]);
+    expect(result.members.map((m) => m.userId)).toEqual([7, 5, 3, 1]);
     // `scanned` is the denominator the counters publish. If the filter were applied to it too, a
     // report could never say "3 of 700", which is the number that says whether the rule is tight.
     expect(result.scanned).toBe(7);

--- a/src/server/services/bot-account-detection/__tests__/cohort.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/cohort.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BOT_ACCOUNT_COHORT_WINDOW_HOURS,
+  cohortCutoff,
+  collectCohort,
+  createCohortReader,
+  mergePostCounts,
+  newAccountPageArgs,
+  postCountArgs,
+  selectCohortMembers,
+  type CohortDb,
+  type CohortReader,
+  type NewAccountRow,
+  type PostCounts,
+  type RawPostCounts,
+} from '../cohort';
+
+const at = (iso: string) => new Date(iso);
+const NOW = at('2026-09-03T12:00:00.000Z');
+
+const account = (id: number, createdAt = NOW): NewAccountRow => ({
+  id,
+  username: `user${id}`,
+  createdAt,
+});
+
+const counts = (entries: Array<[number, Partial<PostCounts>]>): Map<number, PostCounts> =>
+  new Map(
+    entries.map(([userId, partial]) => {
+      const row = { comments: 0, models: 0, images: 0, ...partial };
+      return [userId, { ...row, total: row.comments + row.models + row.images }];
+    })
+  );
+
+const emptyRaw = (): RawPostCounts => ({ comments: [], commentsV2: [], models: [], images: [] });
+
+describe('cohortCutoff', () => {
+  // Two points, not one: a single window cannot tell an implementation that subtracts the argument
+  // from an implementation that ignores it and hardcodes a day.
+  it('opens the window `hours` before the run clock', () => {
+    expect(cohortCutoff(NOW, 24).toISOString()).toBe('2026-09-02T12:00:00.000Z');
+    expect(cohortCutoff(NOW, 6).toISOString()).toBe('2026-09-03T06:00:00.000Z');
+  });
+
+  it('defaults to the brief’s 24h window', () => {
+    expect(BOT_ACCOUNT_COHORT_WINDOW_HOURS).toBe(24);
+    expect(cohortCutoff(NOW).getTime()).toBe(cohortCutoff(NOW, 24).getTime());
+  });
+});
+
+describe('newAccountPageArgs', () => {
+  const cutoff = at('2026-09-02T12:00:00.000Z');
+  const args = newAccountPageArgs({ createdAfter: cutoff, after: 41, take: 7 });
+
+  it('bounds the window at the cutoff, inclusive and forward-only', () => {
+    // `gte` and nothing else: an upper bound would exclude accounts created while the run walks,
+    // and `gt` would drop an account created exactly on the boundary.
+    expect(args.where.createdAt).toEqual({ gte: cutoff });
+    expect(Object.keys(args.where.createdAt)).toEqual(['gte']);
+  });
+
+  it('excludes accounts a moderator has already dealt with', () => {
+    expect(args.where.bannedAt).toBeNull();
+    expect(args.where.deletedAt).toBeNull();
+  });
+
+  it('pages by keyset on id, ascending, not by offset', () => {
+    expect(args.where.id).toEqual({ gt: 41 });
+    expect(args.orderBy).toEqual({ id: 'asc' });
+    expect(args.take).toBe(7);
+    expect(args).not.toHaveProperty('skip');
+  });
+
+  it('selects only the columns the report cites', () => {
+    expect(args.select).toEqual({ id: true, username: true, createdAt: true });
+  });
+});
+
+describe('postCountArgs', () => {
+  it('counts per user, restricted to the ids handed in', () => {
+    const args = postCountArgs([3, 4]);
+    expect(args.by).toEqual(['userId']);
+    expect(args.where).toEqual({ userId: { in: [3, 4] } });
+    expect(args._count).toEqual({ _all: true });
+  });
+});
+
+describe('createCohortReader', () => {
+  // The seam, not the builders: a correct argument object that is never handed to the client
+  // changes nothing, and that is invisible to a test of the builder alone.
+  const makeDb = () => {
+    const calls: string[] = [];
+    const db = {
+      user: {
+        findMany: vi.fn(async (args: unknown) => {
+          calls.push('user.findMany');
+          void args;
+          return [account(1)];
+        }),
+      },
+      comment: {
+        groupBy: vi.fn(async () => {
+          calls.push('comment.groupBy');
+          return [{ userId: 1, _count: { _all: 2 } }];
+        }),
+      },
+      commentV2: {
+        groupBy: vi.fn(async () => {
+          calls.push('commentV2.groupBy');
+          return [{ userId: 1, _count: { _all: 3 } }];
+        }),
+      },
+      model: {
+        groupBy: vi.fn(async () => {
+          calls.push('model.groupBy');
+          return [{ userId: 1, _count: { _all: 4 } }];
+        }),
+      },
+      image: {
+        groupBy: vi.fn(async () => {
+          calls.push('image.groupBy');
+          return [{ userId: 1, _count: { _all: 5 } }];
+        }),
+      },
+    } satisfies CohortDb;
+    return { db, calls };
+  };
+
+  it('hands `newAccountPageArgs` to the client verbatim', async () => {
+    const { db } = makeDb();
+    const request = { createdAfter: at('2026-09-02T12:00:00.000Z'), after: 9, take: 3 };
+    await createCohortReader(db).listNewAccounts(request);
+    expect(db.user.findMany).toHaveBeenCalledWith(newAccountPageArgs(request));
+  });
+
+  it('reads both comment systems, models and images — and nothing else', async () => {
+    const { db, calls } = makeDb();
+    const raw = await createCohortReader(db).countPosts([1]);
+    // An asserted LEDGER, sorted so it is order-independent but not membership-independent: it
+    // fails if an operation is added AND if one is removed. Dropping `commentV2` is the realistic
+    // regression — it reads as a tidy-up and turns every newer-comment-only account into a
+    // false negative.
+    expect([...calls].sort()).toEqual([
+      'comment.groupBy',
+      'commentV2.groupBy',
+      'image.groupBy',
+      'model.groupBy',
+    ]);
+    expect(raw.comments).toEqual([{ userId: 1, count: 2 }]);
+    expect(raw.commentsV2).toEqual([{ userId: 1, count: 3 }]);
+    expect(raw.models).toEqual([{ userId: 1, count: 4 }]);
+    expect(raw.images).toEqual([{ userId: 1, count: 5 }]);
+  });
+
+  it('asks the database nothing when there are no ids', async () => {
+    const { db, calls } = makeDb();
+    const raw = await createCohortReader(db).countPosts([]);
+    expect(calls).toEqual([]);
+    expect(raw).toEqual(emptyRaw());
+  });
+});
+
+describe('mergePostCounts', () => {
+  it('adds both comment systems together and totals the three surfaces', () => {
+    const merged = mergePostCounts({
+      comments: [{ userId: 1, count: 2 }],
+      commentsV2: [{ userId: 1, count: 3 }],
+      models: [{ userId: 1, count: 4 }],
+      images: [{ userId: 1, count: 5 }],
+    });
+    // Distinct values per surface, and distinct from the total, so a mutant that reads the wrong
+    // field or drops one of the four cannot produce the same number by accident.
+    expect(merged.get(1)).toEqual({ comments: 5, models: 4, images: 5, total: 14 });
+  });
+
+  it('keeps users apart', () => {
+    const merged = mergePostCounts({
+      comments: [{ userId: 1, count: 1 }],
+      commentsV2: [],
+      models: [{ userId: 2, count: 7 }],
+      images: [],
+    });
+    expect(merged.get(1)?.total).toBe(1);
+    expect(merged.get(2)?.total).toBe(7);
+  });
+});
+
+describe('selectCohortMembers', () => {
+  it('excludes an account that has not posted', () => {
+    const members = selectCohortMembers(
+      [account(1), account(2)],
+      counts([
+        [1, { comments: 1 }],
+        [2, { comments: 0, models: 0, images: 0 }],
+      ])
+    );
+    expect(members.map((m) => m.userId)).toEqual([1]);
+  });
+
+  it('excludes an account the content read returned nothing at all for', () => {
+    // Distinct from the zero-total case above: no map entry, not an entry of zeroes. Prisma's
+    // groupBy omits a user with no rows entirely, so this is the shape production actually
+    // produces and the one a `counts.get(id)!.total === 0` implementation would crash on.
+    expect(selectCohortMembers([account(3)], counts([]))).toEqual([]);
+  });
+
+  it.each([
+    ['comments only', { comments: 1 }],
+    ['models only', { models: 1 }],
+    ['images only', { images: 1 }],
+  ])('includes an account that posted %s', (_label, posted) => {
+    const members = selectCohortMembers([account(4)], counts([[4, posted]]));
+    expect(members).toHaveLength(1);
+    expect(members[0].userId).toBe(4);
+  });
+
+  it('carries the account identity and its activity through', () => {
+    const created = at('2026-09-03T09:30:00.000Z');
+    const members = selectCohortMembers(
+      [{ id: 5, username: 'spam5', createdAt: created }],
+      counts([[5, { comments: 2, models: 1, images: 3 }]])
+    );
+    expect(members[0]).toEqual({
+      userId: 5,
+      username: 'spam5',
+      createdAt: created,
+      posts: { comments: 2, models: 1, images: 3, total: 6 },
+    });
+  });
+});
+
+/** A reader over a fixed account list: pages it by keyset, and reports every account as having
+ *  posted exactly one image so membership never masks a paging bug. */
+function fakeReader(accounts: NewAccountRow[]): CohortReader & { pageRequests: number[] } {
+  const pageRequests: number[] = [];
+  return {
+    pageRequests,
+    listNewAccounts: async ({ after, take }) => {
+      pageRequests.push(take);
+      return accounts.filter((a) => a.id > after).slice(0, take);
+    },
+    countPosts: async (ids) => ({
+      comments: [],
+      commentsV2: [],
+      models: [],
+      images: ids.map((userId) => ({ userId, count: 1 })),
+    }),
+  };
+}
+
+describe('collectCohort', () => {
+  const createdAfter = at('2026-09-02T12:00:00.000Z');
+  // 7 accounts at a page size of 3: the last page is SHORT (1), so the walk's terminate-on-short-page
+  // branch runs. A multiple of the page size would exit through the empty-page branch instead and
+  // leave this one unexercised.
+  const seven = Array.from({ length: 7 }, (_, i) => account(i + 1));
+
+  it('walks every page of the window', async () => {
+    const reader = fakeReader(seven);
+    const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
+    expect(result.members.map((m) => m.userId)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(result.scanned).toBe(7);
+    expect(result.pages).toBe(3);
+    expect(result.capped).toBe(false);
+  });
+
+  it('stops at the cap and says so', async () => {
+    const reader = fakeReader(seven);
+    const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 5 });
+    expect(result.scanned).toBe(5);
+    expect(result.members.map((m) => m.userId)).toEqual([1, 2, 3, 4, 5]);
+    expect(result.capped).toBe(true);
+    // The final page is clamped to the remaining budget, not the page size — otherwise the cap is
+    // only ever approximate and a run reads more than it claims.
+    expect(reader.pageRequests).toEqual([3, 2, 1]);
+  });
+
+  it('does not call a complete cohort truncated when its size equals the cap', async () => {
+    // 🔴 The case `scanned === maxAccounts` cannot distinguish. Reporting it as truncated sends a
+    // moderator looking for accounts that do not exist, which is why the walk probes instead of
+    // inferring.
+    const reader = fakeReader(seven.slice(0, 5));
+    const result = await collectCohort(reader, { createdAfter, pageSize: 5, maxAccounts: 5 });
+    expect(result.scanned).toBe(5);
+    expect(result.capped).toBe(false);
+  });
+
+  it('reports an empty window without paging', async () => {
+    const reader = fakeReader([]);
+    const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
+    expect(result).toMatchObject({ members: [], scanned: 0, pages: 1, capped: false });
+  });
+
+  it('passes the window cutoff to every page', async () => {
+    const seen: Date[] = [];
+    const base = fakeReader(seven);
+    const reader: CohortReader = {
+      ...base,
+      listNewAccounts: async (args) => {
+        seen.push(args.createdAfter);
+        return base.listNewAccounts(args);
+      },
+    };
+    await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
+    expect(seen).toHaveLength(3);
+    expect(seen.every((d) => d.getTime() === createdAfter.getTime())).toBe(true);
+  });
+
+  it('drops accounts that have not posted from the members but not from `scanned`', async () => {
+    const base = fakeReader(seven);
+    const reader: CohortReader = {
+      ...base,
+      // Only odd ids posted.
+      countPosts: async (ids) => ({
+        ...emptyRaw(),
+        images: ids.filter((id) => id % 2 === 1).map((userId) => ({ userId, count: 1 })),
+      }),
+    };
+    const result = await collectCohort(reader, { createdAfter, pageSize: 3, maxAccounts: 100 });
+    expect(result.members.map((m) => m.userId)).toEqual([1, 3, 5, 7]);
+    // `scanned` is the denominator the counters publish. If the filter were applied to it too, a
+    // report could never say "3 of 700", which is the number that says whether the rule is tight.
+    expect(result.scanned).toBe(7);
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/cohort.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/cohort.test.ts
@@ -41,7 +41,9 @@ const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
  *
  * The bare form gives what the account POSTED, with `visible` equal to it — the ordinary case where
  * nothing has been taken down. Pass `visible` to describe an account some of whose content is gone;
- * `excluded` is always the difference, exactly as `mergePostCounts` computes it.
+ * `excluded` is the difference. NOT a re-implementation of `mergePostCounts` — no caller passes a
+ * `visible` above its `all`, so the clamp that function applies to a torn read has nothing to do
+ * here, and the tests that exercise the clamp call `mergePostCounts` itself.
  */
 const counts = (
   entries: Array<[number, Partial<SurfaceCounts> & { visible?: Partial<SurfaceCounts> }]>
@@ -384,11 +386,13 @@ describe('mergePostCounts', () => {
     });
   });
 
-  it('floors `excluded` at zero when the two reads disagree', () => {
+  it('🔴 clamps `visible` to `all` when the two reads disagree', () => {
     // The filtered and unfiltered counts of one surface are separate statements against a replica,
     // so a row created between them can leave `visible` above `all`. A negative in the one sentence
     // a moderator acts on reads as corrupt data; zero reads as "nothing was taken down", which is
-    // the truth as near as this run can tell.
+    // the truth as near as this run can tell. Flooring the DIFFERENCE achieved that much but left
+    // `visible` reporting 9 items on the site for an account that posted 4 — clamping the surplus
+    // row away instead is what keeps the sentence internally consistent.
     const merged = mergePostCounts({
       ...emptyRaw(),
       images: [{ userId: 1, count: 9 }],
@@ -396,7 +400,32 @@ describe('mergePostCounts', () => {
     });
     expect(merged.get(1)?.excluded).toEqual({ comments: 0, models: 0, images: 0, total: 0 });
     expect(merged.get(1)?.all.total).toBe(4);
-    expect(merged.get(1)?.visible.total).toBe(9);
+    expect(merged.get(1)?.visible.total).toBe(4);
+  });
+
+  it('🔴 a two-direction torn read still adds up', () => {
+    // 🔴 F2. The eight reads are separate statements in ONE `Promise.all`, so two surfaces can tear
+    // in OPPOSITE directions within one run. `excluded.total` used to be
+    // `max(0, all.total - visible.total)` — derived from the totals, independently of the three
+    // floored surfaces — so this fixture produced a NOT-on-site total of 2 over a breakdown summing
+    // to 3, and a finding saying the account posted 5 comments while 6 were still on the site.
+    const merged = mergePostCounts({
+      ...emptyRaw(),
+      comments: [{ userId: 1, count: 6 }], // torn HIGH: the filtered read caught a newer row
+      allComments: [{ userId: 1, count: 5 }],
+      allModels: [{ userId: 1, count: 3 }], // torn the ordinary way: three models taken down
+    });
+    const row = merged.get(1)!;
+    // The relationship, not the constants: the breakdown a moderator reads must sum to the total
+    // stated beside it.
+    expect(row.excluded.total).toBe(
+      row.excluded.comments + row.excluded.models + row.excluded.images
+    );
+    expect(row.excluded).toEqual({ comments: 0, models: 3, images: 0, total: 3 });
+    // …and both halves add back to the figure the sentence leads with.
+    expect(row.visible.total + row.excluded.total).toBe(row.all.total);
+    expect(row.all.total).toBe(8);
+    expect(row.visible.total).toBe(5);
   });
 
   it('keeps users apart', () => {

--- a/src/server/services/bot-account-detection/__tests__/cohort.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/cohort.test.ts
@@ -54,17 +54,17 @@ describe('cohortCutoff', () => {
 });
 
 describe('the cohort cap is set against the measured signup baseline', () => {
-  /** Signups in the 24h window, counted read-only on a replica while auditing this change. Not a
-   *  live figure and it will drift — it is the number the constant was CHOSEN against, recorded so
-   *  the choice is checkable rather than a remembered anecdote. */
-  const MEASURED_DAILY_SIGNUPS = 8_863;
-
-  it('leaves room for a registration wave, not 13% headroom', () => {
+  /** 🔴 The baseline figure itself is NOT in this repository — it is production business data and
+   *  this repo is public. It is recorded privately; what is pinned here is the RELATIONSHIP the cap
+   *  was chosen for, which is what a maintainer has to preserve. Re-measure before changing the
+   *  constant: the number drifts, the reasoning does not. */
+  it('leaves room for a registration wave rather than sitting just above an ordinary day', () => {
     // 🔴 An invariant guard, deliberately labelled as one: it pins the reasoning, it is not
-    // regression coverage for a bug. The previous 10,000 sat ~13% above the baseline, which is the
-    // worst place for a cap — never trips on an ordinary day, so it looks proven, and trips for the
-    // first time on exactly the day a wave lands.
-    expect(MAX_COHORT_ACCOUNTS).toBeGreaterThanOrEqual(MEASURED_DAILY_SIGNUPS * 2);
+    // regression coverage for a bug. The previous ceiling sat only marginally above an ordinary
+    // day's volume, which is the worst place for a cap — never trips on an ordinary day, so it
+    // looks proven, and trips for the first time on exactly the day a wave lands. Expressed in
+    // PAGES so the bound holds without naming the baseline.
+    expect(MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE).toBeGreaterThanOrEqual(40);
     // Still a bound: the walk is at most this many pages, four content reads each.
     expect(MAX_COHORT_ACCOUNTS / COHORT_PAGE_SIZE).toBeLessThanOrEqual(100);
   });

--- a/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
@@ -1,6 +1,33 @@
+import { readFileSync } from 'fs';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { botAccountDetection } from '~/server/jobs/bot-account-detection';
 import { UNRUNNABLE_JOB_CRON } from '~/server/jobs/job';
+
+const RUN_JOBS_ROUTE = path.resolve(
+  __dirname,
+  '../../../../pages/api/webhooks/run-jobs/[[...run]].ts'
+);
+
+/**
+ * The `jobs` array the route dispatches on, as source.
+ *
+ * Read rather than imported: importing that route pulls in every job in the application, which is
+ * most of the server. The claim is about one line of a list, and a list is something a file can be
+ * asked about directly.
+ */
+function jobsArrayEntries(): string[] {
+  const source = readFileSync(RUN_JOBS_ROUTE, 'utf8');
+  const start = source.indexOf('export const jobs: Job[] = [');
+  if (start === -1) throw new Error(`no \`jobs\` array in ${RUN_JOBS_ROUTE}`);
+  const end = source.indexOf('\n];', start);
+  if (end === -1) throw new Error(`unterminated \`jobs\` array in ${RUN_JOBS_ROUTE}`);
+  return source
+    .slice(start, end)
+    .split('\n')
+    .map((line) => line.trim().replace(/,$/, ''))
+    .filter((line) => line.length > 0 && !line.startsWith('//'));
+}
 
 /**
  * How this job is REGISTERED, as distinct from what it does.
@@ -24,13 +51,51 @@ describe('the bot-account detection job is registered but NOT scheduled', () => 
     expect(typeof botAccountDetection.run).toBe('function');
   });
 
+  it('🔴 IS IN THE `jobs` ARRAY THE ROUTE DISPATCHES ON — what actually makes it reachable', () => {
+    // 🔴 `.name` and `typeof .run` assert neither half of on-demand runnability. They are
+    // properties of an object this file imported directly; the route never sees that import. What
+    // decides whether `/api/webhooks/run-jobs/bot-account-detection` answers is one line — the
+    // job's membership in `export const jobs: Job[]`, which the handler does a `.find()` over
+    // before returning 404. Deleting that line leaves every other assertion in this file green and
+    // the endpoint 404ing, which is precisely the state `UNRUNNABLE_JOB_CRON` is chosen to avoid:
+    // a job registered for on-demand grading that cannot be run on demand.
+    const entries = jobsArrayEntries();
+    // A positive control on the extraction. A parse that silently returned nothing, or one line,
+    // would make the membership assertion below vacuous — and this route's array is long.
+    expect(entries.length).toBeGreaterThan(50);
+    expect(entries).toContain('botAccountDetection');
+
+    // The import that makes the identifier resolve. Membership in the array and the import are two
+    // separate lines, and the array alone would not compile without it.
+    const source = readFileSync(RUN_JOBS_ROUTE, 'utf8');
+    expect(source).toContain("from '~/server/jobs/bot-account-detection'");
+  });
+
   it('holds its lock for longer than a capped run can take', () => {
-    // 🔴 The run-jobs route hard-caps the lock hold at `lockExpiration` and then RELEASES the lock
-    // WHILE the run continues (`acquireLock`'s refresh interval, `src/pages/api/webhooks/
-    // run-jobs/[[...run]].ts`). Past that point a retry can start a second full run whose
-    // different `startedAt` the board's `(detector, started_at)` key cannot merge with the first,
-    // and the board shows two complete duplicate finding sets. The default 5 minutes is not enough
-    // headroom for a walk of up to `MAX_COHORT_ACCOUNTS` accounts.
+    // 🔴 THE LOCK WINDOW IS THE DUPLICATE-RUN MITIGATION, AND IT IS THE ONLY ONE. The route hard-
+    // caps the lock hold at `lockExpiration` and then RELEASES the lock WHILE the run continues
+    // (`acquireLock`'s refresh interval, `src/pages/api/webhooks/run-jobs/[[...run]].ts`). Past
+    // that point a retry can start a second full run whose different `startedAt` the board's
+    // `(detector, started_at)` key cannot merge with the first, and the board shows two complete
+    // duplicate finding sets.
+    //
+    // 🔴 `checkIfCanceled` DOES NOT COVER THIS, and reading it as a second line of defence is how
+    // the hazard gets treated as handled. `release()` clears the redis key and its refresh
+    // interval; it never touches the job context, so a lapsed lock makes nothing throw. The only
+    // thing that cancels the run is `res.on('close')` — the caller hanging up. So the headroom
+    // below is load-bearing on its own: the default 5 minutes is not enough for a walk of up to
+    // `MAX_COHORT_ACCOUNTS` accounts at eight `groupBy` reads a page.
     expect(botAccountDetection.options.lockExpiration).toBeGreaterThanOrEqual(30 * 60);
+  });
+
+  it('the route cancels on a closed response, and its lock release does not', () => {
+    // The claim above is about another file, so it is checked against that file rather than
+    // restated. If the route ever grows a cancel on lock expiry this goes red and the comments
+    // that depend on it get revisited — which is the point, because today they would be wrong in
+    // the reassuring direction.
+    const source = readFileSync(RUN_JOBS_ROUTE, 'utf8');
+    expect(source).toContain("res.on('close', cancelHandler)");
+    const release = source.slice(source.indexOf('const release = async () => {'));
+    expect(release.slice(0, release.indexOf('};'))).not.toContain('cancel');
   });
 });

--- a/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { botAccountDetection } from '~/server/jobs/bot-account-detection';
+import { UNRUNNABLE_JOB_CRON } from '~/server/jobs/job';
+
+/**
+ * How this job is REGISTERED, as distinct from what it does.
+ *
+ * `/api/internal/get-jobs` publishes every registered job's cron to the external scheduler, so the
+ * cron string in the job file is not documentation — it is the deployment. A real cron here means
+ * merging this PR turns the detector on, against preconditions (`MOD_INBOUND_TOKEN` set, the
+ * abuse-detection schema applied to `MODERATOR_DATABASE_URL`) that are applied by hand and are not
+ * checked by anything. That is a daily 500, repeating until a human notices.
+ */
+describe('the bot-account detection job is registered but NOT scheduled', () => {
+  it('carries the unrunnable cron, so merging does not enable it', () => {
+    expect(botAccountDetection.cron).toBe(UNRUNNABLE_JOB_CRON);
+  });
+
+  it('is still named and runnable on demand', () => {
+    // The point of `UNRUNNABLE_JOB_CRON` over deleting the registration: the job stays reachable at
+    // `/api/webhooks/run-jobs/bot-account-detection`, which is exactly what a shadow-phase grading
+    // pass needs.
+    expect(botAccountDetection.name).toBe('bot-account-detection');
+    expect(typeof botAccountDetection.run).toBe('function');
+  });
+
+  it('holds its lock for longer than a capped run can take', () => {
+    // 🔴 The run-jobs route hard-caps the lock hold at `lockExpiration` and then RELEASES the lock
+    // WHILE the run continues (`acquireLock`'s refresh interval, `src/pages/api/webhooks/
+    // run-jobs/[[...run]].ts`). Past that point a retry can start a second full run whose
+    // different `startedAt` the board's `(detector, started_at)` key cannot merge with the first,
+    // and the board shows two complete duplicate finding sets. The default 5 minutes is not enough
+    // headroom for a walk of up to `MAX_COHORT_ACCOUNTS` accounts.
+    expect(botAccountDetection.options.lockExpiration).toBeGreaterThanOrEqual(30 * 60);
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 /**
  * The structural half of the shadow-mode guarantee.
@@ -16,29 +16,156 @@ import { describe, expect, it } from 'vitest';
  * 🔴 EVERY assertion here is an asserted LEDGER — an exact set, failing when it grows AND when it
  * shrinks — rather than a search for a forbidden word. A word list is walkable by spelling the same
  * hazard differently; a ledger is not, because the new spelling is still a new member of the set.
+ *
+ * 🔴 WHAT THE LEDGERS STRUCTURALLY CANNOT POLICE. Stating it, because a guard whose comment claims
+ * more than it delivers is worse than no guard — it stops the next person looking.
+ *  - **Which BINDING is taken from an already-permitted specifier.** The import ledger records
+ *    module specifiers, not names. `~/server/db/client` is on the list because `cohort.ts` needs
+ *    `dbRead` from it; nothing here can tell that specifier apart from one that also yields
+ *    `dbWrite`, and `import { dbWrite } from '~/server/db/client'` moves the import ledger not at
+ *    all. What catches that case is the operation ledger (a write method is a new member) and the
+ *    name check at the end — NOT this list. The same holds for every permitted specifier: adding a
+ *    module to the import ledger is the moment to ask what else that module exports.
+ *  - **What a permitted module does on ITS side.** `moderator-app.service` is a network client
+ *    today. If it grew a database write, no assertion in this file would move.
+ *  - **Destructured handles.** `resolveDbAliases` follows `const c = dbRead`, and does not follow
+ *    `const { user } = dbRead`. That shape reaches `user.update(` with no `db` token in front of
+ *    it, and the operation ledger would miss it. The name check does not cover it either.
+ * None of these is hypothetical-only; each is a live gap, listed so it is chosen rather than
+ * assumed away.
  */
 
 const MODULE_DIR = path.resolve(__dirname, '..');
 const JOB_FILE = path.resolve(__dirname, '../../../jobs/bot-account-detection.ts');
 
 /**
+ * 🔴 EVERY EXTENSION A BUNDLER WOULD LOAD, not just `.ts`.
+ *
+ * The two enumerations below are deliberately different mechanisms so they cannot share a bug — but
+ * they shared this filter, so "different mechanism" bought nothing in the extension axis: a
+ * `heuristics/ip-cluster.tsx` carrying a write and a restriction import left the whole guard green,
+ * and the byte-identical file named `.ts` went red. A `.tsx` under `services/` is unusual, which is
+ * exactly the property that makes it a hole nobody would look in.
+ */
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+
+const isSourceFile = (name: string) => SOURCE_EXTENSIONS.some((ext) => name.endsWith(ext));
+
+/** Same width, so the columns of everything on either side are undisturbed. */
+const blankOut = (text: string) => text.replace(/[^\n]/g, ' ');
+
+/**
+ * Where a `/` may open a regex literal: only where a VALUE is expected.
+ *
+ * After an identifier, a closing bracket or a string, a `/` is division. Everywhere else it may be
+ * a regex, and this errs deliberately towards "may be": treating a division as a regex only makes
+ * the scanner copy MORE text through unchanged, while treating a regex as division is what lets a
+ * `//` inside it truncate the line.
+ */
+const regexCanStartAfter = (prev: string) => prev === '' || !/[\w$)\]'"`]/.test(prev);
+
+/** Index just past the string/template literal starting at `start`. Bails at an unterminated one. */
+function endOfQuoted(source: string, start: number): number {
+  const quote = source[start];
+  let i = start + 1;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') i += 2;
+    else if (c === quote) return i + 1;
+    // A plain string cannot span lines; stopping at the newline keeps a stray quote from swallowing
+    // the rest of the file.
+    else if (quote !== '`' && c === '\n') return i;
+    else i += 1;
+  }
+  return source.length;
+}
+
+/** Index just past the regex literal starting at `start`, or `start + 1` if it is not one after
+ *  all. Backing off is the safe direction: the `/` is then re-read as ordinary code. */
+function endOfRegex(source: string, start: number): number {
+  let i = start + 1;
+  let inClass = false;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') i += 2;
+    else if (c === '\n') return start + 1;
+    else if (c === '[') (inClass = true), (i += 1);
+    else if (c === ']') (inClass = false), (i += 1);
+    else if (c === '/' && !inClass) return i + 1;
+    else i += 1;
+  }
+  return start + 1;
+}
+
+/**
  * Comments removed, because the claims below are about CODE.
  *
  * These files explain at length why they hold no write client, and an explanation that names the
  * thing it forbids would otherwise fail the very guard it documents — training the next maintainer
- * to delete the comment rather than keep the property. Blank lines are substituted for a stripped
- * block so nothing on either side of it is joined into a token that was never written.
+ * to delete the comment rather than keep the property. Blanks are substituted for a stripped span so
+ * nothing on either side of it is joined into a token that was never written.
+ *
+ * 🔴 A SCANNER, NOT TWO REGEXES, AND THE DIRECTION OF ERROR IS THE WHOLE POINT. This was a
+ * `.replace()` of a `(^|[^:])` + `//` + rest-of-line pattern, which deletes the rest of any line
+ * holding `//` — including one inside a string or a regex. Written out, the pattern cannot appear
+ * in this comment: its trailing `[^\n]` star closes the block comment it sits in, which is its own
+ * small lesson. `const p = 'a//b'; await dbWrite.user.update({ id });` stripped
+ * to `const p = 'a`, and BOTH ledgers then passed: the operation had been deleted before either
+ * scanner ran, and so had the name. The old control only ever tested the `://` spelling, which is
+ * the one case the `[^:]` hack happened to cover.
+ *
+ * Stripping too MUCH hides a real write and reports green; stripping too LITTLE only surfaces a
+ * comment as a false failure. So every ambiguous case here resolves towards copying text through.
  */
 export function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
-    .replace(/(^|[^:])\/\/[^\n]*/g, (_m, lead: string) => lead);
+  let out = '';
+  let i = 0;
+  /** Last non-whitespace character emitted as code. Decides regex-vs-division. */
+  let prev = '';
+
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (c === '/' && next === '*') {
+      const end = source.indexOf('*/', i + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      out += blankOut(source.slice(i, stop));
+      i = stop;
+      continue;
+    }
+    if (c === '/' && next === '/') {
+      let stop = source.indexOf('\n', i);
+      if (stop === -1) stop = source.length;
+      out += blankOut(source.slice(i, stop));
+      i = stop;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      const stop = endOfQuoted(source, i);
+      out += source.slice(i, stop);
+      i = stop;
+      prev = c;
+      continue;
+    }
+    if (c === '/' && regexCanStartAfter(prev)) {
+      const stop = endOfRegex(source, i);
+      out += source.slice(i, stop);
+      i = stop;
+      prev = '/';
+      continue;
+    }
+    out += c;
+    if (!/\s/.test(c)) prev = c;
+    i += 1;
+  }
+  return out;
 }
 
 const EXCLUDED_DIRS = new Set(['__tests__']);
 
 /**
- * Every `.ts` file under a directory, RECURSIVELY.
+ * Every source file under a directory, RECURSIVELY.
  *
  * 🔴 A flat `readdirSync` was a hole with a name on it: heuristics are the announced next change,
  * they will land in `heuristics/`, and a flat walk stops scanning the moment a subdirectory exists.
@@ -55,7 +182,7 @@ export function listSourceFiles(root: string): string[] {
     if (entry.isDirectory()) {
       if (EXCLUDED_DIRS.has(entry.name)) continue;
       out.push(...listSourceFiles(full));
-    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+    } else if (entry.isFile() && isSourceFile(entry.name)) {
       out.push(full);
     }
   }
@@ -74,21 +201,86 @@ function detectorSources(): Array<{ file: string; source: string }> {
   }));
 }
 
-/** `db.model.method(` / `dbRead.model.method(` / `dbWrite.model.method(` — the shape every Prisma
- *  call in this codebase takes. */
-const DB_CALL = /\bdb(?:Read|Write)?\.([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(/g;
+const escapeRegExp = (literal: string) => literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Rewrite local aliases of a database handle back to the handle.
+ *
+ * 🔴 `const c = dbRead; await c.user.update(…)` is one line longer than the direct call and was
+ * completely invisible: no `db` token stands in front of the operation, so the operation ledger
+ * never saw it. Substituting the handle back in is enough to put it on the ledger, and the
+ * substitution is applied to a COPY used only for counting operations — never to the text the
+ * import ledger reads, where rewriting an identifier that also occurs inside a specifier string
+ * would corrupt the very set it is asserting.
+ *
+ * Iterated to a fixed point (bounded) so `const c = dbRead; const d = c;` resolves too. Widening
+ * an identifier to `dbRead` can only ADD ledger members, so a wrong guess fails closed.
+ *
+ * It does NOT follow destructuring — see the file header; that gap is stated, not papered over.
+ */
+export function resolveDbAliases(source: string): string {
+  const declaration =
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(db(?:Read|Write)?)\s*(?=[;\n,)])/g;
+  let out = source;
+  for (let pass = 0; pass < 5; pass += 1) {
+    let changed = false;
+    for (const match of [...out.matchAll(declaration)]) {
+      const [, alias, handle] = match;
+      if (alias === handle) continue;
+      const next = out.replace(new RegExp(`\\b${escapeRegExp(alias)}\\b`, 'g'), handle);
+      if (next !== out) {
+        out = next;
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return out;
+}
+
+/**
+ * One member access, by dot or by computed string key, tolerating the whitespace a formatter
+ * inserts.
+ *
+ * 🔴 `dbRead['user']['update'](…)` reaches the same method with no dot in it, and prettier wraps a
+ * long chain as `dbRead.user\n  .update(` — a newline where the old pattern required none. Both
+ * left the operation ledger unmoved.
+ */
+const SEGMENT = String.raw`(?:\s*\.\s*([A-Za-z_$][\w$]*)|\s*\[\s*['"]([^'"\n\]]+)['"]\s*\])`;
+
+/**
+ * `db.model.method(` / `dbRead.$rawMethod(` / `dbWrite['model']['method'](` — every shape a Prisma
+ * call takes on a handle in this codebase.
+ *
+ * 🔴 THE SECOND SEGMENT IS OPTIONAL, and requiring it was the hole that mattered most. Prisma's
+ * raw-SQL escape hatches hang off the CLIENT, not off a model — `dbRead.$executeRawUnsafe(…)` is
+ * two segments, so a three-segment pattern never matched it. One such line at the top of
+ * `collectCohort`'s loop — the hot path every run takes — issued an arbitrary `UPDATE` and left the
+ * whole suite green. It also escaped the name check, because the handle it is spelled on is
+ * `dbRead`; and wherever `DATABASE_REPLICA_URL` equals `DATABASE_URL` those two names are the same
+ * object, so that statement runs against the primary.
+ */
+const DB_CALL = new RegExp(
+  String.raw`\bdb(?:Read|Write)?` + SEGMENT + `(?:${SEGMENT})?` + String.raw`\s*\(`,
+  'g'
+);
 
 function databaseOperations(sources: ReturnType<typeof detectorSources>): string[] {
   const found = new Set<string>();
-  for (const { source } of sources)
-    for (const match of source.matchAll(DB_CALL)) found.add(`${match[1]}.${match[2]}`);
+  for (const { source } of sources) {
+    for (const match of resolveDbAliases(source).matchAll(DB_CALL)) {
+      const first = match[1] ?? match[2];
+      const second = match[3] ?? match[4];
+      found.add(second ? `${first}.${second}` : first);
+    }
+  }
   return [...found].sort();
 }
 
 /**
  * Every module specifier this code can pull in, however it is spelled.
  *
- * 🔴 Three spellings, because a ledger that only knows one of them is a word list wearing a
+ * 🔴 Four spellings, because a ledger that only knows one of them is a word list wearing a
  * ledger's clothes. Each of these was a demonstrated escape from the single-quoted `from '…'`
  * pattern this used to be, and each left the whole suite green:
  *  - `from "…"` — double quotes. A one-character difference.
@@ -98,16 +290,48 @@ function databaseOperations(sources: ReturnType<typeof detectorSources>): string
  *    natural way to reach a heavy service from a job.
  *  - `require('…')` — included for completeness; it is a module reference like any other and
  *    leaving it out would just move the hole.
- * The alternation is written once so a fourth spelling is added in one place.
+ *  - ``import(`…`)`` / ``require(`…`)`` — a TEMPLATE literal. Constant ones read like any other
+ *    specifier; an interpolated one (`` `~/server/services/${name}` ``) is recorded verbatim,
+ *    which is a member no expected list will ever hold, so a computed specifier fails CLOSED
+ *    rather than slipping through as unrecorded.
+ * The alternation is written once so a fifth spelling is added in one place.
+ *
+ * 🔴 THE LEADING LOOKBEHIND IS LOad-BEARING. Without it the pattern matched any `.from('literal')`,
+ * so `Buffer.from('base64')` contributed an import specifier `base64`. It failed CLOSED — a bogus
+ * member fails the ledger — but the natural repair is to add `base64` to the expected list, which
+ * puts a permanent lie in the one assertion whose whole value is being exactly right.
  */
-const MODULE_REF = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*(?:'([^'\n]+)'|"([^"\n]+)")/g;
+const MODULE_REF =
+  /(?<![.\w$])(?:from|import|require)\s*\(?\s*(?:'([^'\n]+)'|"([^"\n]+)"|`([^`\n]*)`)/g;
 
 function importSpecifiers(sources: ReturnType<typeof detectorSources>): string[] {
   const found = new Set<string>();
   for (const { source } of sources)
-    for (const match of source.matchAll(MODULE_REF)) found.add(match[1] ?? match[2]);
+    for (const match of source.matchAll(MODULE_REF)) found.add(match[1] ?? match[2] ?? match[3]);
   return [...found].sort();
 }
+
+/**
+ * 🔴 Temp trees are REMOVED. Every case below that plants an escape builds one, and they used to be
+ * left behind on the runner — one per case per run, forever, under `os.tmpdir()`.
+ */
+const tempRoots: string[] = [];
+function tempTree(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'bot-account-tree-'));
+  tempRoots.push(root);
+  return root;
+}
+afterEach(() => {
+  while (tempRoots.length) rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+});
+
+/** The exact text a real regression would carry, on whichever handle is named. */
+const plantedWrite = (handle: string) =>
+  `import { applyPendingReviewMute } from '~/server/services/user-restriction.service';\n` +
+  `await ${handle}.user.update({ where: { id }, data: { muted: true } });\n`;
+
+const asSources = (files: Record<string, string>) =>
+  Object.entries(files).map(([file, source]) => ({ file, source: stripComments(source) }));
 
 describe('the detector has no write surface', () => {
   it('reads its own source — positive control', () => {
@@ -129,9 +353,11 @@ describe('the detector has no write surface', () => {
     //
     // The enumeration this is checked against is deliberately a DIFFERENT MECHANISM from the walk
     // it grades — Node's own `readdirSync(..., { recursive: true })` rather than the hand-rolled
-    // recursion in `listSourceFiles` — so the two cannot share a bug and agree on it.
+    // recursion in `listSourceFiles` — so the two cannot share a bug and agree on it. They do
+    // share `SOURCE_EXTENSIONS` and `EXCLUDED_DIRS`, which is why those are asserted directly
+    // rather than left to this comparison.
     const expected = readdirSync(MODULE_DIR, { recursive: true, encoding: 'utf8' })
-      .filter((rel) => rel.endsWith('.ts'))
+      .filter((rel) => isSourceFile(rel))
       .filter((rel) => !rel.split(path.sep).some((seg) => EXCLUDED_DIRS.has(seg)))
       .map((rel) => path.join(MODULE_DIR, rel))
       .sort();
@@ -145,18 +371,14 @@ describe('the detector has no write surface', () => {
 
   it('a module in a SUBDIRECTORY is scanned — the escape heuristics will walk into', () => {
     // Red before the recursive walk landed: a flat `readdirSync` returns the directory entry and
-    // filters it out for not ending in `.ts`, so the nested file is never opened and everything
+    // filters it out for not being a source file, so the nested file is never opened and everything
     // inside it is unledgered. Built on a temp tree rather than the real one so the control is a
     // control and not a commit.
-    const root = mkdtempSync(path.join(os.tmpdir(), 'bot-account-tree-'));
+    const root = tempTree();
     mkdirSync(path.join(root, 'heuristics'));
     mkdirSync(path.join(root, '__tests__'));
     writeFileSync(path.join(root, 'top.ts'), 'export const a = 1;\n');
-    writeFileSync(
-      path.join(root, 'heuristics', 'ip-cluster.ts'),
-      "import { applyPendingReviewMute } from '~/server/services/user-restriction.service';\n" +
-        'await dbWrite.user.update({ where: { id }, data: { muted: true } });\n'
-    );
+    writeFileSync(path.join(root, 'heuristics', 'ip-cluster.ts'), plantedWrite('dbWrite'));
     writeFileSync(path.join(root, '__tests__', 'ignored.ts'), 'export const b = 2;\n');
     writeFileSync(path.join(root, 'notes.md'), 'dbWrite.user.update(x)\n');
 
@@ -172,41 +394,156 @@ describe('the detector has no write surface', () => {
     expect(importSpecifiers(sources)).toEqual(['~/server/services/user-restriction.service']);
   });
 
-  it('sees an import however it is spelled — the two quote/dynamic escapes', () => {
+  it('scans every extension a bundler would load, not only `.ts`', () => {
+    // 🔴 Red before `SOURCE_EXTENSIONS`: `heuristics/ip-cluster.tsx` carrying a write and a
+    // restriction import left the guard 9/9 green, while the byte-identical file named `.ts` went
+    // red. The two enumerations are different mechanisms but shared this one filter, so the
+    // redundancy bought nothing here.
+    const root = tempTree();
+    mkdirSync(path.join(root, 'heuristics'));
+    for (const [i, ext] of SOURCE_EXTENSIONS.entries())
+      writeFileSync(path.join(root, 'heuristics', `h${i}${ext}`), plantedWrite('dbWrite'));
+
+    const found = listSourceFiles(root).map((f) => path.extname(f));
+    expect(found.sort()).toEqual([...SOURCE_EXTENSIONS].sort());
+
+    const sources = listSourceFiles(root).map((file) => ({
+      file,
+      source: stripComments(readFileSync(file, 'utf8')),
+    }));
+    // Every one of them is on the ledger — not just the `.ts` member of the set.
+    expect(sources).toHaveLength(SOURCE_EXTENSIONS.length);
+    expect(databaseOperations(sources)).toEqual(['user.update']);
+  });
+
+  it('the exhaustiveness walk uses the same extension set as the tree walk', () => {
+    // The two enumerations agree only because they read one constant. Pinning it here is what makes
+    // the previous case a statement about the guard rather than about one temp directory: widening
+    // `SOURCE_EXTENSIONS` for one walk and not the other is the regression that reopens F-4.
+    expect(SOURCE_EXTENSIONS).toContain('.ts');
+    expect(SOURCE_EXTENSIONS).toContain('.tsx');
+    expect(isSourceFile('ip-cluster.tsx')).toBe(true);
+    expect(isSourceFile('notes.md')).toBe(false);
+    expect(isSourceFile('heuristics')).toBe(false);
+  });
+
+  it('sees an import however it is spelled — quotes, dynamic, require, template', () => {
     // Each of these was planted alone in the real tree and left the full suite green, because the
     // scanner matched only `from '…'`. They are asserted here on synthetic sources so the control
     // is repeatable and does not require editing a shipped file.
-    const doubleQuoted = [
-      { file: 'a.ts', source: 'import { x } from "~/server/services/user-restriction.service";\n' },
-    ];
-    expect(importSpecifiers(doubleQuoted)).toEqual(['~/server/services/user-restriction.service']);
+    const restriction = '~/server/services/user-restriction.service';
 
-    const dynamic = [
-      {
-        file: 'b.ts',
-        source:
-          "const m = await import('~/server/services/user-restriction.service');\nm.applyPendingReviewMute(id);\n",
-      },
-    ];
+    expect(
+      importSpecifiers(asSources({ 'a.ts': `import { x } from "${restriction}";\n` }))
+    ).toEqual([restriction]);
+
     // 🔴 The case that defeats BOTH halves of the guard: no `dbWrite` token, no new database
     // operation, and — until this — no `from` clause either.
-    expect(importSpecifiers(dynamic)).toEqual(['~/server/services/user-restriction.service']);
+    const dynamic = asSources({
+      'b.ts': `const m = await import('${restriction}');\nm.applyPendingReviewMute(id);\n`,
+    });
+    expect(importSpecifiers(dynamic)).toEqual([restriction]);
     expect(databaseOperations(dynamic)).toEqual([]);
 
-    const dynamicDoubleQuoted = [
-      { file: 'c.ts', source: 'await import("~/server/services/user-restriction.service");\n' },
-    ];
-    expect(importSpecifiers(dynamicDoubleQuoted)).toEqual([
-      '~/server/services/user-restriction.service',
+    expect(importSpecifiers(asSources({ 'c.ts': `await import("${restriction}");\n` }))).toEqual([
+      restriction,
     ]);
+    expect(
+      importSpecifiers(asSources({ 'd.ts': `const m = require('${restriction}');\n` }))
+    ).toEqual([restriction]);
+  });
 
-    const required = [
-      {
-        file: 'd.ts',
-        source: "const m = require('~/server/services/user-restriction.service');\n",
-      },
-    ];
-    expect(importSpecifiers(required)).toEqual(['~/server/services/user-restriction.service']);
+  it('sees a TEMPLATE-LITERAL module specifier, constant or interpolated', () => {
+    // 🔴 Red before the backtick alternative: ``await import(`…`)`` matched nothing, so a dynamic
+    // import written with backticks — the spelling anyone reaching for interpolation uses — was
+    // completely unledgered while looking exactly like the two spellings that were covered.
+    const restriction = '~/server/services/user-restriction.service';
+    expect(
+      importSpecifiers(asSources({ 'a.ts': 'await import(`' + restriction + '`);\n' }))
+    ).toEqual([restriction]);
+
+    // An interpolated specifier cannot be resolved to a module name, so it is recorded verbatim.
+    // No expected list will ever contain it, which is the point: it fails CLOSED instead of
+    // resolving to nothing and slipping past.
+    const computed = importSpecifiers(
+      asSources({ 'b.ts': 'await import(`~/server/services/${name}.service`);\n' })
+    );
+    expect(computed).toEqual(['~/server/services/${name}.service']);
+    expect(computed).not.toEqual([]);
+  });
+
+  it('does not invent an import from a `.from(` method call', () => {
+    // 🔴 `MODULE_REF` used to match any `.from('literal')`, so `Buffer.from('base64')` produced an
+    // import specifier `base64`. It failed closed — but the obvious repair is to add `base64` to
+    // the expected list, and a ledger carrying a member that is not an import is a ledger nobody
+    // can reason about afterwards.
+    const sources = asSources({
+      'a.ts':
+        "const buf = Buffer.from('base64');\n" +
+        "const rows = qb.from('User');\n" +
+        "import { x } from '~/server/db/client';\n",
+    });
+    expect(importSpecifiers(sources)).toEqual(['~/server/db/client']);
+  });
+
+  it('sees a raw-SQL call on ANY handle, including the read client — two segments, not three', () => {
+    // 🔴 THE DEMONSTRATED ESCAPE. One line at the top of `collectCohort`'s loop left the suite
+    // 102/102 green and the guard 9/9: `$executeRawUnsafe` hangs off the client, so it is two
+    // segments where the old pattern required three, and it is spelled on `dbRead`, so the name
+    // check did not fire either.
+    const planted = asSources({
+      'a.ts': `await dbRead.$executeRawUnsafe('UPDATE "User" SET "muted" = true WHERE id > 0');\n`,
+    });
+    expect(databaseOperations(planted)).toEqual(['$executeRawUnsafe']);
+
+    // The same shape on every handle and every raw method, so the fix is not one spelling deep.
+    for (const handle of ['db', 'dbRead', 'dbWrite'])
+      for (const method of ['$executeRaw', '$executeRawUnsafe', '$queryRaw', '$transaction'])
+        expect(
+          databaseOperations(asSources({ 'a.ts': `await ${handle}.${method}(x);\n` })),
+          `${handle}.${method} is invisible to the operation ledger`
+        ).toEqual([method]);
+  });
+
+  it('sees a computed member access — `db["model"]["method"]`', () => {
+    // Red before `SEGMENT` learned the bracket form: `dbRead['user']['update'](…)` reaches exactly
+    // the method the dotted spelling does and contained no `.` for the pattern to anchor on.
+    expect(
+      databaseOperations(asSources({ 'a.ts': "await dbRead['user']['update']({ id });\n" }))
+    ).toEqual(['user.update']);
+    expect(
+      databaseOperations(asSources({ 'a.ts': 'await dbWrite["user"].update({ id });\n' }))
+    ).toEqual(['user.update']);
+    expect(
+      databaseOperations(asSources({ 'a.ts': "await dbRead['$executeRawUnsafe']('x');\n" }))
+    ).toEqual(['$executeRawUnsafe']);
+  });
+
+  it('sees a call a formatter wrapped across lines', () => {
+    // Red before `SEGMENT` allowed leading whitespace: prettier breaks a long chain after the
+    // receiver, and the resulting `dbRead.user\n  .update(` matched nothing at all.
+    expect(
+      databaseOperations(
+        asSources({ 'a.ts': 'await dbWrite.user\n  .update({ where: { id }, data: {} });\n' })
+      )
+    ).toEqual(['user.update']);
+    expect(
+      databaseOperations(asSources({ 'a.ts': 'await dbRead\n  .user\n  .update({ id });\n' }))
+    ).toEqual(['user.update']);
+  });
+
+  it('follows a local alias of a database handle', () => {
+    // Red before `resolveDbAliases`: `const c = dbRead;` puts an ordinary identifier in front of
+    // the operation, and nothing anchored on `db` could see it.
+    expect(
+      databaseOperations(asSources({ 'a.ts': 'const c = dbRead;\nawait c.user.update({ id });\n' }))
+    ).toEqual(['user.update']);
+    // Through two hops, and on the write client too.
+    expect(
+      databaseOperations(
+        asSources({ 'a.ts': 'const c = dbWrite;\nconst d = c;\nawait d.$executeRawUnsafe(sql);\n' })
+      )
+    ).toEqual(['$executeRawUnsafe']);
   });
 
   it('the comment stripper removes prose and keeps code — controls, both directions', () => {
@@ -227,17 +564,44 @@ describe('the detector has no write surface', () => {
     );
   });
 
+  it('the stripper keeps a `//` that lives inside a string or a regex', () => {
+    // 🔴 THE DEMONSTRATED ESCAPE, and it beat both ledgers at once. The old stripper deleted the
+    // rest of any line containing `//` unless it was preceded by a colon, so
+    // `const p = 'a//b'; await dbWrite.user.update({ id });` became `const p = 'a` — the operation
+    // was gone before `databaseOperations` ran, and so was the `dbWrite` the name check looks for.
+    // The old control tested only the `://` spelling, which is precisely the case the `[^:]` hack
+    // covered.
+    const inString = "const p = 'a//b'; await dbWrite.user.update({ id });";
+    expect(stripComments(inString)).toContain('dbWrite.user.update');
+    expect(databaseOperations(asSources({ 'a.ts': inString }))).toEqual(['user.update']);
+
+    const inDoubleQuotes = 'const p = "a//b"; await dbRead.$executeRawUnsafe(sql);';
+    expect(databaseOperations(asSources({ 'a.ts': inDoubleQuotes }))).toEqual([
+      '$executeRawUnsafe',
+    ]);
+
+    const inTemplate = 'const p = `a//b`; await dbWrite.user.update({ id });';
+    expect(databaseOperations(asSources({ 'a.ts': inTemplate }))).toEqual(['user.update']);
+
+    const inRegex = 'const re = /a[//]b/; await dbWrite.user.update({ id });';
+    expect(databaseOperations(asSources({ 'a.ts': inRegex }))).toEqual(['user.update']);
+  });
+
+  it('the stripper still treats a division as a division, not a regex', () => {
+    // The safe direction has a cost: mistaking division for a regex would swallow code. Pinned so
+    // the regex branch cannot quietly widen — `)` and an identifier are the two receivers a `/`
+    // most often follows in this module.
+    const divided =
+      'const h = (a.getTime() - b.getTime()) / 3600000; await dbWrite.user.update(x);';
+    expect(databaseOperations(asSources({ 'a.ts': divided }))).toEqual(['user.update']);
+    const byIdent = 'const r = weighted / totalWeight; await dbWrite.user.update(x);';
+    expect(databaseOperations(asSources({ 'a.ts': byIdent }))).toEqual(['user.update']);
+  });
+
   it('the scanners can see a write — negative control', () => {
     // Proves the instrument can go red before its zero is believed. Built from the exact text a
     // real regression would carry, not a textbook fixture.
-    const planted = [
-      {
-        file: 'planted.ts',
-        source:
-          "import { applyPendingReviewMute } from '~/server/services/user-restriction.service';\n" +
-          'await dbWrite.user.update({ where: { id }, data: { muted: true } });\n',
-      },
-    ];
+    const planted = asSources({ 'planted.ts': plantedWrite('dbWrite') });
     expect(databaseOperations(planted)).toEqual(['user.update']);
     expect(importSpecifiers(planted)).toEqual(['~/server/services/user-restriction.service']);
   });
@@ -259,7 +623,8 @@ describe('the detector has no write surface', () => {
     // The other half of the ledger: a write does not have to be spelled here to happen here. Calling
     // `applyPendingReviewMute` is one import and one line, and it would leave the database-operation
     // ledger above completely unmoved. Adding a module to this list is the moment to ask whether
-    // the shadow guarantee still holds.
+    // the shadow guarantee still holds — and, per the file header, WHICH BINDING is taken from it,
+    // which this list cannot see.
     expect(importSpecifiers(detectorSources())).toEqual([
       './cohort',
       './job',
@@ -275,11 +640,23 @@ describe('the detector has no write surface', () => {
     ]);
   });
 
-  it('names the write client nowhere', () => {
+  it('names no write client, and no raw-SQL escape hatch on EITHER handle', () => {
     // Redundant with the ledgers by construction, and kept anyway: it is the assertion whose failure
     // message names the hazard directly, so a maintainer who trips it is told what they did rather
     // than shown a set diff.
-    for (const { file, source } of detectorSources())
+    //
+    // 🔴 IT NO LONGER CHECKS ONLY `dbWrite`. That spelling was the entire test, and the escape that
+    // beat it was spelled on the READ handle — `dbRead.$executeRawUnsafe(…)`, which mutates the
+    // primary wherever the replica URL equals the primary's. The raw methods are handle-agnostic
+    // here for that reason. This remains a word list, and it is not what holds the property; the
+    // operation ledger above is.
+    for (const { file, source } of detectorSources()) {
       expect(source.includes('dbWrite'), `${file} names the write client`).toBe(false);
+      for (const raw of ['$executeRaw', '$queryRaw', '$transaction'])
+        expect(
+          source.includes(raw),
+          `${file} names ${raw} — raw SQL can issue a write through ANY handle, dbRead included`
+        ).toBe(false);
+    }
   });
 });

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The structural half of the shadow-mode guarantee.
+ *
+ * `run.test.ts` proves that a run over ITS fixtures issues no write. That is a claim about the paths
+ * those fixtures reach. This is the complementary claim: the detector's source contains no write
+ * SURFACE at all, so there is no input, flag or unlucky branch that could reach one. Neither guard
+ * subsumes the other — a write behind a condition no fixture satisfies is invisible to the first,
+ * and a write issued by an imported module is invisible to the second, which is why the two are
+ * asserted against different things (behaviour, and the import ledger below).
+ *
+ * 🔴 EVERY assertion here is an asserted LEDGER — an exact set, failing when it grows AND when it
+ * shrinks — rather than a search for a forbidden word. A word list is walkable by spelling the same
+ * hazard differently; a ledger is not, because the new spelling is still a new member of the set.
+ */
+
+const MODULE_DIR = path.resolve(__dirname, '..');
+const JOB_FILE = path.resolve(__dirname, '../../../jobs/bot-account-detection.ts');
+
+/**
+ * Comments removed, because the claims below are about CODE.
+ *
+ * These files explain at length why they hold no write client, and an explanation that names the
+ * thing it forbids would otherwise fail the very guard it documents — training the next maintainer
+ * to delete the comment rather than keep the property. Blank lines are substituted for a stripped
+ * block so nothing on either side of it is joined into a token that was never written.
+ */
+export function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (_m, lead: string) => lead);
+}
+
+/** Every source file the detector is made of. Tests excluded: they legitimately name write paths in
+ *  order to assert they are unused. */
+function detectorSources(): Array<{ file: string; source: string }> {
+  const files = readdirSync(MODULE_DIR)
+    .filter((f) => f.endsWith('.ts'))
+    .map((f) => path.join(MODULE_DIR, f));
+  return [...files, JOB_FILE].map((file) => ({
+    file: path.relative(path.resolve(__dirname, '../../../../..'), file),
+    source: stripComments(readFileSync(file, 'utf8')),
+  }));
+}
+
+/** `db.model.method(` / `dbRead.model.method(` / `dbWrite.model.method(` — the shape every Prisma
+ *  call in this codebase takes. */
+const DB_CALL = /\bdb(?:Read|Write)?\.([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(/g;
+
+function databaseOperations(sources: ReturnType<typeof detectorSources>): string[] {
+  const found = new Set<string>();
+  for (const { source } of sources)
+    for (const match of source.matchAll(DB_CALL)) found.add(`${match[1]}.${match[2]}`);
+  return [...found].sort();
+}
+
+function importSpecifiers(sources: ReturnType<typeof detectorSources>): string[] {
+  const found = new Set<string>();
+  for (const { source } of sources)
+    for (const match of source.matchAll(/\bfrom\s+'([^']+)'/g)) found.add(match[1]);
+  return [...found].sort();
+}
+
+describe('the detector has no write surface', () => {
+  it('reads its own source — positive control', () => {
+    // Everything below is a claim about a set of files. If the walk returns nothing, or files with
+    // no content, every one of those claims is vacuously true and this suite reports success while
+    // checking nothing.
+    const sources = detectorSources();
+    expect(sources.length).toBeGreaterThanOrEqual(5);
+    expect(sources.every((s) => s.source.length > 200)).toBe(true);
+    expect(sources.map((s) => path.basename(s.file)).sort()).toEqual([
+      'bot-account-detection.ts',
+      'cohort.ts',
+      'report.ts',
+      'run.ts',
+      'scoring.ts',
+    ]);
+  });
+
+  it('the comment stripper removes prose and keeps code — controls, both directions', () => {
+    // The stripper is an instrument the ledgers below read through. A stripper that removed too
+    // much would delete a real write and report a clean ledger; one that removed nothing would fail
+    // on the files' own explanations. Both directions, so neither is assumed.
+    expect(stripComments('// dbWrite.user.update(x)\nconst a = 1;')).not.toContain('dbWrite');
+    expect(stripComments('/* a\n dbWrite.user.update(x)\n */ const a = 1;')).not.toContain(
+      'dbWrite'
+    );
+    expect(stripComments('await dbWrite.user.update(x); // fine')).toContain(
+      'dbWrite.user.update(x)'
+    );
+    // A `://` inside a URL is not a line comment, and treating it as one would silently truncate
+    // the rest of that line — including a write sitting after it.
+    expect(stripComments("fetch('https://x/y'); dbWrite.user.update(z);")).toContain(
+      'dbWrite.user.update'
+    );
+  });
+
+  it('the scanners can see a write — negative control', () => {
+    // Proves the instrument can go red before its zero is believed. Built from the exact text a
+    // real regression would carry, not a textbook fixture.
+    const planted = [
+      {
+        file: 'planted.ts',
+        source:
+          "import { applyPendingReviewMute } from '~/server/services/user-restriction.service';\n" +
+          'await dbWrite.user.update({ where: { id }, data: { muted: true } });\n',
+      },
+    ];
+    expect(databaseOperations(planted)).toEqual(['user.update']);
+    expect(importSpecifiers(planted)).toEqual(['~/server/services/user-restriction.service']);
+  });
+
+  it('performs exactly five database operations, all of them reads', () => {
+    // 🔴 THE LEDGER. A write added anywhere in these files is a sixth member and fails here; a read
+    // removed is a missing member and fails here too (dropping `commentV2` would silently turn
+    // every newer-comment-only account into a false negative).
+    expect(databaseOperations(detectorSources())).toEqual([
+      'comment.groupBy',
+      'commentV2.groupBy',
+      'image.groupBy',
+      'model.groupBy',
+      'user.findMany',
+    ]);
+  });
+
+  it('imports exactly the modules it needs, and none that can act on an account', () => {
+    // The other half of the ledger: a write does not have to be spelled here to happen here. Calling
+    // `applyPendingReviewMute` is one import and one line, and it would leave the database-operation
+    // ledger above completely unmoved. Adding a module to this list is the moment to ask whether
+    // the shadow guarantee still holds.
+    expect(importSpecifiers(detectorSources())).toEqual([
+      './cohort',
+      './job',
+      './report',
+      './scoring',
+      '@civitai/moderation',
+      '~/server/db/client',
+      '~/server/logging/client',
+      '~/server/services/bot-account-detection/cohort',
+      '~/server/services/bot-account-detection/run',
+      '~/server/services/moderator-app.service',
+    ]);
+  });
+
+  it('names the write client nowhere', () => {
+    // Redundant with the ledgers by construction, and kept anyway: it is the assertion whose failure
+    // message names the hazard directly, so a maintainer who trips it is told what they did rather
+    // than shown a set diff.
+    for (const { file, source } of detectorSources())
+      expect(source.includes('dbWrite'), `${file} names the write client`).toBe(false);
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -19,6 +19,13 @@ import { afterEach, describe, expect, it } from 'vitest';
  *
  * 🔴 WHAT THE LEDGERS STRUCTURALLY CANNOT POLICE. Stating it, because a guard whose comment claims
  * more than it delivers is worse than no guard — it stops the next person looking.
+ *
+ * 🔴 THIS LIST IS NOT AN ENUMERATION. It names the escapes that have been DEMONSTRATED against this
+ * file — each was written, run, and left the suite green — and it is not, and cannot be, the set of
+ * every shape that escapes. A shape absent from it has not been ruled out; it has not been tried.
+ * An earlier revision closed this paragraph with "each is a live gap, listed so it is chosen rather
+ * than assumed away", which reads as completeness and is exactly the sentence this guard must not
+ * make. Two whole axes below (object fields, and the network) were missing from it at the time.
  *  - **Which BINDING is taken from an already-permitted specifier.** The import ledger records
  *    module specifiers, not names. `~/server/db/client` is on the list because `cohort.ts` needs
  *    `dbRead` from it; nothing here can tell that specifier apart from one that also yields
@@ -31,8 +38,25 @@ import { afterEach, describe, expect, it } from 'vitest';
  *  - **Destructured handles.** `resolveDbAliases` follows `const c = dbRead`, and does not follow
  *    `const { user } = dbRead`. That shape reaches `user.update(` with no `db` token in front of
  *    it, and the operation ledger would miss it. The name check does not cover it either.
- * None of these is hypothetical-only; each is a live gap, listed so it is chosen rather than
- * assumed away.
+ *  - **A handle held in an OBJECT FIELD, not a binding.** `const holder = { h: dbRead };
+ *    holder.h.user.update(…)` — `resolveDbAliases` rewrites declarations whose initialiser IS the
+ *    handle, and an object literal is not one. Left open deliberately: following a handle through
+ *    property assignment is a dataflow analysis, not a regex, and this file is not the place for one.
+ *  - **A method name COMPUTED rather than written.** `const k = 'up' + 'date';
+ *    (dbRead as any).user[k](…)` — `SEGMENT` requires a quoted literal inside `[…]`, so a
+ *    concatenation, a template with a hole, or a variable contributes no ledger member. Same reason:
+ *    resolving it is constant folding, which a scanner does not do.
+ *  - **🔴 THE NETWORK, WHICH IS A WHOLE AXIS NEITHER LEDGER LOOKS AT.**
+ *    `await fetch('http://…/api/mod/mute', { method: 'POST' })` mutes an account with no import — the
+ *    global needs none — and no database handle, so the import ledger and the operation ledger are
+ *    BOTH unmoved. Every other gap here is a way of hiding a `db` token; this one never has one. It
+ *    is not closed by widening any pattern below, and the only thing standing against it today is
+ *    `run.test.ts`'s behavioural claim over its own fixtures plus review.
+ *
+ * WHAT `resolveDbAliases` WAS WIDENED FOR, and what it still is not: it now follows a type
+ * annotation (`const c: typeof dbRead = dbRead`), a non-null assertion (`const c = dbRead!`) and a
+ * trailing `??`/`||`/`&&` operand (`const c = maybeDb ?? dbRead`). It does not follow destructuring,
+ * object fields, or a handle returned from a function. See its own docstring.
  */
 
 const MODULE_DIR = path.resolve(__dirname, '..');
@@ -216,11 +240,23 @@ const escapeRegExp = (literal: string) => literal.replace(/[.*+?^${}()|[\]\\]/g,
  * Iterated to a fixed point (bounded) so `const c = dbRead; const d = c;` resolves too. Widening
  * an identifier to `dbRead` can only ADD ledger members, so a wrong guess fails closed.
  *
- * It does NOT follow destructuring — see the file header; that gap is stated, not papered over.
+ * 🔴 THREE FORMS THE FIRST VERSION MISSED, all of them ordinary TypeScript rather than evasion:
+ *  - `const c: typeof dbRead = dbRead;` — a TYPE ANNOTATION sits between the identifier and the `=`,
+ *    so the pattern's `identifier` `=` adjacency never matched. This is the one most likely to be
+ *    written by accident, which is why it is worth the widening.
+ *  - `const c = dbRead!;` — a non-null assertion between the handle and the terminator.
+ *  - `const c = maybeDb ?? dbRead;` — the handle is the LAST operand, not the whole initialiser.
+ * All three left the guard 19/19 green. The optional initialiser prefix is deliberately anchored on
+ * `??`/`||`/`&&`: a bare `[^=;\n]*` would alias on any initialiser merely CONTAINING the handle
+ * (`wrap(dbRead)`), and while over-aliasing fails closed, doing it on every call expression makes
+ * the operation ledger noise rather than a ledger.
+ *
+ * It does NOT follow destructuring, an object field, or a handle returned from a call — see the file
+ * header; those gaps are stated, not papered over.
  */
 export function resolveDbAliases(source: string): string {
   const declaration =
-    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(db(?:Read|Write)?)\s*(?=[;\n,)])/g;
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=;\n]*)?=\s*(?:[^=;\n]*?(?:\?\?|\|\||&&)\s*)?(db(?:Read|Write)?)\s*!?\s*(?=[;\n,)])/g;
   let out = source;
   for (let pass = 0; pass < 5; pass += 1) {
     let changed = false;

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync, readdirSync } from 'fs';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
@@ -34,13 +35,40 @@ export function stripComments(source: string): string {
     .replace(/(^|[^:])\/\/[^\n]*/g, (_m, lead: string) => lead);
 }
 
-/** Every source file the detector is made of. Tests excluded: they legitimately name write paths in
- *  order to assert they are unused. */
+const EXCLUDED_DIRS = new Set(['__tests__']);
+
+/**
+ * Every `.ts` file under a directory, RECURSIVELY.
+ *
+ * 🔴 A flat `readdirSync` was a hole with a name on it: heuristics are the announced next change,
+ * they will land in `heuristics/`, and a flat walk stops scanning the moment a subdirectory exists.
+ * Nothing goes red when that happens — the ledgers below simply stop covering the new code and keep
+ * passing, which is the failure mode this whole file exists to prevent.
+ *
+ * Test directories are excluded: they legitimately name write paths in order to assert they are
+ * unused.
+ */
+export function listSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      out.push(...listSourceFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+/** Every source file the detector is made of. */
+function detectorFiles(): string[] {
+  return [...listSourceFiles(MODULE_DIR), JOB_FILE];
+}
+
 function detectorSources(): Array<{ file: string; source: string }> {
-  const files = readdirSync(MODULE_DIR)
-    .filter((f) => f.endsWith('.ts'))
-    .map((f) => path.join(MODULE_DIR, f));
-  return [...files, JOB_FILE].map((file) => ({
+  return detectorFiles().map((file) => ({
     file: path.relative(path.resolve(__dirname, '../../../../..'), file),
     source: stripComments(readFileSync(file, 'utf8')),
   }));
@@ -57,10 +85,27 @@ function databaseOperations(sources: ReturnType<typeof detectorSources>): string
   return [...found].sort();
 }
 
+/**
+ * Every module specifier this code can pull in, however it is spelled.
+ *
+ * 🔴 Three spellings, because a ledger that only knows one of them is a word list wearing a
+ * ledger's clothes. Each of these was a demonstrated escape from the single-quoted `from '…'`
+ * pattern this used to be, and each left the whole suite green:
+ *  - `from "…"` — double quotes. A one-character difference.
+ *  - `await import('…')` / `import("…")` — a DYNAMIC import, which defeats BOTH halves of the guard
+ *    at once: it adds no `dbWrite` token and no new database operation, so the operation ledger is
+ *    unmoved, and it is not a `from` clause, so the import ledger was unmoved too. It is also the
+ *    natural way to reach a heavy service from a job.
+ *  - `require('…')` — included for completeness; it is a module reference like any other and
+ *    leaving it out would just move the hole.
+ * The alternation is written once so a fourth spelling is added in one place.
+ */
+const MODULE_REF = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*(?:'([^'\n]+)'|"([^"\n]+)")/g;
+
 function importSpecifiers(sources: ReturnType<typeof detectorSources>): string[] {
   const found = new Set<string>();
   for (const { source } of sources)
-    for (const match of source.matchAll(/\bfrom\s+'([^']+)'/g)) found.add(match[1]);
+    for (const match of source.matchAll(MODULE_REF)) found.add(match[1] ?? match[2]);
   return [...found].sort();
 }
 
@@ -72,13 +117,96 @@ describe('the detector has no write surface', () => {
     const sources = detectorSources();
     expect(sources.length).toBeGreaterThanOrEqual(5);
     expect(sources.every((s) => s.source.length > 200)).toBe(true);
-    expect(sources.map((s) => path.basename(s.file)).sort()).toEqual([
-      'bot-account-detection.ts',
-      'cohort.ts',
-      'report.ts',
-      'run.ts',
-      'scoring.ts',
+    expect(sources.map((s) => path.basename(s.file))).toContain('cohort.ts');
+    expect(sources.map((s) => path.basename(s.file))).toContain('bot-account-detection.ts');
+  });
+
+  it('scans EVERY file in the module tree, at any depth — exhaustiveness', () => {
+    // 🔴 This replaces a hand-maintained list of five basenames. That list was the wrong shape of
+    // assertion: it pinned which files exist, not that every file that exists is SCANNED, so a
+    // sixth file added under `heuristics/` failed the list once (a maintainer deletes the stale
+    // name) and was then invisible forever after.
+    //
+    // The enumeration this is checked against is deliberately a DIFFERENT MECHANISM from the walk
+    // it grades — Node's own `readdirSync(..., { recursive: true })` rather than the hand-rolled
+    // recursion in `listSourceFiles` — so the two cannot share a bug and agree on it.
+    const expected = readdirSync(MODULE_DIR, { recursive: true, encoding: 'utf8' })
+      .filter((rel) => rel.endsWith('.ts'))
+      .filter((rel) => !rel.split(path.sep).some((seg) => EXCLUDED_DIRS.has(seg)))
+      .map((rel) => path.join(MODULE_DIR, rel))
+      .sort();
+
+    const scanned = detectorFiles().sort();
+    expect(expected.length).toBeGreaterThanOrEqual(4);
+    // Every file in the tree is scanned. Set equality, not containment: a scanned file that is not
+    // in the tree means the walk is reading something it should not be.
+    expect(scanned).toEqual([...expected, JOB_FILE].sort());
+  });
+
+  it('a module in a SUBDIRECTORY is scanned — the escape heuristics will walk into', () => {
+    // Red before the recursive walk landed: a flat `readdirSync` returns the directory entry and
+    // filters it out for not ending in `.ts`, so the nested file is never opened and everything
+    // inside it is unledgered. Built on a temp tree rather than the real one so the control is a
+    // control and not a commit.
+    const root = mkdtempSync(path.join(os.tmpdir(), 'bot-account-tree-'));
+    mkdirSync(path.join(root, 'heuristics'));
+    mkdirSync(path.join(root, '__tests__'));
+    writeFileSync(path.join(root, 'top.ts'), 'export const a = 1;\n');
+    writeFileSync(
+      path.join(root, 'heuristics', 'ip-cluster.ts'),
+      "import { applyPendingReviewMute } from '~/server/services/user-restriction.service';\n" +
+        'await dbWrite.user.update({ where: { id }, data: { muted: true } });\n'
+    );
+    writeFileSync(path.join(root, '__tests__', 'ignored.ts'), 'export const b = 2;\n');
+    writeFileSync(path.join(root, 'notes.md'), 'dbWrite.user.update(x)\n');
+
+    const files = listSourceFiles(root).map((f) => path.relative(root, f));
+    expect(files).toEqual([path.join('heuristics', 'ip-cluster.ts'), 'top.ts']);
+
+    // And the scanners see through to it: the planted write is a ledger member, not invisible.
+    const sources = listSourceFiles(root).map((file) => ({
+      file,
+      source: stripComments(readFileSync(file, 'utf8')),
+    }));
+    expect(databaseOperations(sources)).toEqual(['user.update']);
+    expect(importSpecifiers(sources)).toEqual(['~/server/services/user-restriction.service']);
+  });
+
+  it('sees an import however it is spelled — the two quote/dynamic escapes', () => {
+    // Each of these was planted alone in the real tree and left the full suite green, because the
+    // scanner matched only `from '…'`. They are asserted here on synthetic sources so the control
+    // is repeatable and does not require editing a shipped file.
+    const doubleQuoted = [
+      { file: 'a.ts', source: 'import { x } from "~/server/services/user-restriction.service";\n' },
+    ];
+    expect(importSpecifiers(doubleQuoted)).toEqual(['~/server/services/user-restriction.service']);
+
+    const dynamic = [
+      {
+        file: 'b.ts',
+        source:
+          "const m = await import('~/server/services/user-restriction.service');\nm.applyPendingReviewMute(id);\n",
+      },
+    ];
+    // 🔴 The case that defeats BOTH halves of the guard: no `dbWrite` token, no new database
+    // operation, and — until this — no `from` clause either.
+    expect(importSpecifiers(dynamic)).toEqual(['~/server/services/user-restriction.service']);
+    expect(databaseOperations(dynamic)).toEqual([]);
+
+    const dynamicDoubleQuoted = [
+      { file: 'c.ts', source: 'await import("~/server/services/user-restriction.service");\n' },
+    ];
+    expect(importSpecifiers(dynamicDoubleQuoted)).toEqual([
+      '~/server/services/user-restriction.service',
     ]);
+
+    const required = [
+      {
+        file: 'd.ts',
+        source: "const m = require('~/server/services/user-restriction.service');\n",
+      },
+    ];
+    expect(importSpecifiers(required)).toEqual(['~/server/services/user-restriction.service']);
   });
 
   it('the comment stripper removes prose and keeps code — controls, both directions', () => {
@@ -143,6 +271,7 @@ describe('the detector has no write surface', () => {
       '~/server/services/bot-account-detection/cohort',
       '~/server/services/bot-account-detection/run',
       '~/server/services/moderator-app.service',
+      '~/shared/utils/prisma/enums',
     ]);
   });
 

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -1,0 +1,220 @@
+import { MAX_FINDINGS_PER_REPORT, abuseReportInput } from '@civitai/moderation';
+import { describe, expect, it } from 'vitest';
+import type { BotAccountCohortMember } from '../cohort';
+import {
+  BOT_ACCOUNT_DETECTOR,
+  buildFinding,
+  buildReports,
+  chunkFindings,
+  truncateReason,
+} from '../report';
+import type { BotAccountScore } from '../scoring';
+
+const at = (iso: string) => new Date(iso);
+const STARTED = at('2026-09-03T03:20:00.000Z');
+const FINISHED = at('2026-09-03T03:20:41.000Z');
+
+const member = (overrides: Partial<BotAccountCohortMember> = {}): BotAccountCohortMember => ({
+  userId: 91,
+  username: 'newcomer',
+  createdAt: at('2026-09-03T00:20:00.000Z'),
+  posts: { comments: 2, models: 1, images: 3, total: 6 },
+  ...overrides,
+});
+
+const score = (overrides: Partial<BotAccountScore> = {}): BotAccountScore => ({
+  userId: 91,
+  confidence: 0.25,
+  subScores: [{ id: 'placeholder-no-op', score: 0, weight: 1, note: null, clamped: false }],
+  ...overrides,
+});
+
+const findings = (n: number) =>
+  Array.from({ length: n }, (_, i) =>
+    buildFinding(member({ userId: i + 1 }), score({ userId: i + 1 }), STARTED)
+  );
+
+const build = (n: number, maxFindingsPerReport?: number) =>
+  buildReports({
+    findings: findings(n),
+    startedAt: STARTED,
+    finishedAt: FINISHED,
+    counters: { cohort_size: n },
+    summary: 'Scanned things.',
+    maxFindingsPerReport,
+  });
+
+describe('buildFinding', () => {
+  it('is never actioned, and carries no action name', () => {
+    const finding = buildFinding(member(), score(), STARTED);
+    expect(finding.actioned).toBe(false);
+    // `action` ABSENT, not null: the contract refuses an action name beside `actioned: false`, and
+    // omitting the key makes the wrong pair unrepresentable rather than merely unset today.
+    expect(finding).not.toHaveProperty('action');
+  });
+
+  it('passes the blended confidence through unaltered', () => {
+    expect(buildFinding(member(), score({ confidence: 0.75 }), STARTED).confidence).toBe(0.75);
+  });
+
+  it('cites the evidence a moderator needs to judge it', () => {
+    const finding = buildFinding(member(), score(), STARTED);
+    // Distinct counts per surface so a mutant reading the wrong field cannot produce this string.
+    expect(finding.reason).toContain('2 comment(s)');
+    expect(finding.reason).toContain('1 model(s)');
+    expect(finding.reason).toContain('3 image(s)');
+    expect(finding.reason).toContain('3.0h old');
+    expect(finding.reason).toContain('placeholder-no-op=0.00');
+    expect(finding.reason).toContain('NOT actioned');
+  });
+
+  it('floors the account age at zero when the clocks disagree', () => {
+    const future = member({ createdAt: at('2026-09-03T05:00:00.000Z') });
+    expect(buildFinding(future, score(), STARTED).reason).toContain('0.0h old');
+  });
+
+  it('survives an account with no username', () => {
+    const finding = buildFinding(member({ username: null }), score(), STARTED);
+    expect(finding.reason).toContain('Account 91 registered');
+    expect(finding.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe('truncateReason', () => {
+  it('leaves a reason inside the limit alone', () => {
+    expect(truncateReason('short', 10)).toBe('short');
+  });
+
+  it('cuts an over-long reason to the limit and marks the cut', () => {
+    const cut = truncateReason('x'.repeat(50), 10);
+    expect(cut).toHaveLength(10);
+    expect(cut.endsWith('…')).toBe(true);
+  });
+
+  it('keeps a generated reason within the contract’s own bound', () => {
+    const finding = buildFinding(
+      member({ username: 'n'.repeat(4_000) }),
+      score({
+        subScores: Array.from({ length: 200 }, (_, i) => ({
+          id: `heuristic-${i}`,
+          score: 0.5,
+          weight: 1,
+          note: null,
+          clamped: false,
+        })),
+      }),
+      STARTED
+    );
+    expect(finding.reason.length).toBeLessThanOrEqual(2_000);
+    expect(() =>
+      abuseReportInput.parse({
+        detector: BOT_ACCOUNT_DETECTOR,
+        startedAt: STARTED.toISOString(),
+        finishedAt: FINISHED.toISOString(),
+        findings: [finding],
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('chunkFindings', () => {
+  it('returns one empty batch for an empty run', () => {
+    // A run that found nothing must still reach the board: "no report today" and "a report with
+    // zero findings" look identical to a reader otherwise, and the first is what a broken
+    // producer looks like.
+    expect(chunkFindings([], 10)).toEqual([[]]);
+  });
+
+  it('splits at the size boundary with a short final batch', () => {
+    // 7 into 3 — deliberately not a multiple, and not a power-of-two multiple of the size, so the
+    // remainder branch actually runs.
+    expect(chunkFindings([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([[1, 2, 3], [4, 5, 6], [7]]);
+  });
+
+  it('refuses a size that could never terminate', () => {
+    expect(() => chunkFindings([1], 0)).toThrow(/chunk size/);
+  });
+});
+
+describe('buildReports', () => {
+  it('files one report for a run under the cap', () => {
+    const reports = build(3, 10);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].detector).toBe(BOT_ACCOUNT_DETECTOR);
+    expect(reports[0].findings).toHaveLength(3);
+  });
+
+  it('batches at the real MAX_FINDINGS_PER_REPORT', () => {
+    // 2,501 OVERSHOOTS the 1,000 cap by an amount that is neither a multiple of it nor a power of
+    // two times it, so the full-batch branch, the remainder branch and the multi-batch numbering all
+    // execute. A fixture of exactly 1,000 or 2,000 exercises none of them.
+    const reports = build(2_501);
+    expect(MAX_FINDINGS_PER_REPORT).toBe(1_000);
+    expect(reports.map((r) => r.findings.length)).toEqual([1_000, 1_000, 501]);
+    expect(reports.every((r) => r.findings.length <= MAX_FINDINGS_PER_REPORT)).toBe(true);
+  });
+
+  it('gives every batch a DISTINCT startedAt', () => {
+    // 🔴 `(detector, started_at)` is the receiving table's idempotency key: re-reporting the pair
+    // REPLACES the run and deletes its previous findings. Two batches sharing a startedAt would
+    // therefore show the last 501 findings of a 2,501-finding run with nothing to indicate the
+    // other 2,000 ever arrived.
+    const reports = build(2_501);
+    const startedAt = reports.map((r) => r.startedAt);
+    expect(new Set(startedAt).size).toBe(reports.length);
+    // Ascending, so a board sorting by started_at renders the batches in order.
+    expect([...startedAt].sort()).toEqual(startedAt);
+  });
+
+  it('keeps finishedAt at or after each batch’s own startedAt', () => {
+    // A run fast enough to finish inside `batchCount` milliseconds would otherwise emit
+    // `finishedAt < startedAt` on a later batch, which the contract refuses outright — losing a
+    // whole report to the run having been quick.
+    const reports = buildReports({
+      findings: findings(2_501),
+      startedAt: STARTED,
+      finishedAt: STARTED,
+      counters: {},
+      summary: 'Instant run.',
+    });
+    for (const report of reports)
+      expect(Date.parse(report.finishedAt)).toBeGreaterThanOrEqual(Date.parse(report.startedAt));
+  });
+
+  it('makes the batching observable in counters and summary', () => {
+    const reports = build(2_501);
+    expect(reports.map((r) => r.counters?.batch_index)).toEqual([1, 2, 3]);
+    expect(reports.every((r) => r.counters?.batch_count === 3)).toBe(true);
+    expect(reports.map((r) => r.counters?.batch_findings)).toEqual([1_000, 1_000, 501]);
+    expect(reports.every((r) => r.counters?.run_findings === 2_501)).toBe(true);
+    expect(reports[1].summary).toContain('Batch 2 of 3');
+  });
+
+  it('carries the run counters into every batch', () => {
+    const reports = build(2_501);
+    expect(reports.every((r) => r.counters?.cohort_size === 2_501)).toBe(true);
+  });
+
+  it('says in every summary that nothing was acted on', () => {
+    for (const report of build(2_501)) expect(report.summary).toContain('SHADOW MODE');
+  });
+
+  it('marks every finding of every batch un-actioned', () => {
+    for (const report of build(2_501))
+      for (const finding of report.findings) expect(finding.actioned).toBe(false);
+  });
+
+  it('produces payloads the real wire contract accepts', () => {
+    // The REAL schema, imported rather than a fixture shape that can drift from it. This is what
+    // stops the producer discovering a CHECK violation on the receiving side, where it aborts the
+    // transaction and loses the whole run.
+    for (const report of build(2_501)) expect(() => abuseReportInput.parse(report)).not.toThrow();
+  });
+
+  it('still files a report when the run found nothing', () => {
+    const reports = build(0);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].findings).toEqual([]);
+    expect(() => abuseReportInput.parse(reports[0])).not.toThrow();
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -91,13 +91,18 @@ describe('buildFinding', () => {
     expect(finding.reason).toContain('NOT actioned');
   });
 
-  it('🔴 pins the WHOLE clause when nothing was taken down', () => {
+  it('🔴 pins the WHOLE clause when nothing was taken down — carve-out included', () => {
     // 🔴 THE WIRE CONTRACT CALLS THIS STRING "the whole value of the row to a moderator", so it is
     // pinned as a whole normalised string rather than by keyword. A guard on words is walkable by
     // rewording; this one makes a cosmetic reword a deliberate edit with a failing test attached.
+    //
+    // 🔴 The Pending carve-out is part of the pin, in THIS branch too. It was absent here while the
+    // excluded branch carried it, and this is the branch a young account with three unscanned
+    // uploads takes — see `renderPostCounts`.
     expect(renderPostCounts(posts({ comments: 2, models: 1, images: 3 }))).toBe(
       'Posted 6 item(s) — 2 comment(s), 1 model(s), 3 image(s). All 6 still on the site ' +
-        '(nothing hidden, blocked, unpublished or removed).'
+        '(nothing hidden, blocked, unpublished or removed). ' +
+        'Images still awaiting a scan result are counted as on the site.'
     );
   });
 
@@ -138,9 +143,13 @@ describe('buildFinding', () => {
     const shown = renderPostCounts(posts({ images: 40 }, { images: 1 }));
     expect(shown).not.toContain('visible');
     expect(shown).toContain('Images still awaiting a scan result are counted as on the site.');
-    // The no-exclusions branch has no room for the caveat and must not silently imply viewability
-    // either.
-    expect(renderPostCounts(posts({ images: 3 }))).not.toContain('visible');
+    // 🔴 AND THE NO-EXCLUSIONS BRANCH, which is where this actually bites. Three uploads, all
+    // attached, all `ingestion: Pending` — `excluded.total` is 0, so nothing has been taken down and
+    // there is nothing for a moderator to look at either. Dropping the word "visible" was never
+    // enough on its own here: "All 3 still on the site" makes the same claim in other words.
+    const allPending = renderPostCounts(posts({ images: 3 }));
+    expect(allPending).not.toContain('visible');
+    expect(allPending).toContain('Images still awaiting a scan result are counted as on the site.');
   });
 
   it('floors the account age at zero when the clocks disagree', () => {

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -1,11 +1,12 @@
 import { MAX_FINDINGS_PER_REPORT, abuseReportInput } from '@civitai/moderation';
 import { describe, expect, it } from 'vitest';
-import type { BotAccountCohortMember } from '../cohort';
+import type { BotAccountCohortMember, PostCounts, SurfaceCounts } from '../cohort';
 import {
   BOT_ACCOUNT_DETECTOR,
   buildFinding,
   buildReports,
   chunkFindings,
+  renderPostCounts,
   truncateReason,
 } from '../report';
 import type { BotAccountScore } from '../scoring';
@@ -14,11 +15,35 @@ const at = (iso: string) => new Date(iso);
 const STARTED = at('2026-09-03T03:20:00.000Z');
 const FINISHED = at('2026-09-03T03:20:41.000Z');
 
+const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
+  const row = { comments: 0, models: 0, images: 0, ...partial };
+  return { ...row, total: row.comments + row.models + row.images };
+};
+
+/** `visible` defaults to everything posted — nothing taken down, the ordinary case. */
+const posts = (
+  all: Partial<SurfaceCounts>,
+  visiblePartial: Partial<SurfaceCounts> = all
+): PostCounts => {
+  const a = surface(all);
+  const v = surface(visiblePartial);
+  return {
+    all: a,
+    visible: v,
+    excluded: {
+      comments: Math.max(0, a.comments - v.comments),
+      models: Math.max(0, a.models - v.models),
+      images: Math.max(0, a.images - v.images),
+      total: Math.max(0, a.total - v.total),
+    },
+  };
+};
+
 const member = (overrides: Partial<BotAccountCohortMember> = {}): BotAccountCohortMember => ({
   userId: 91,
   username: 'newcomer',
   createdAt: at('2026-09-03T00:20:00.000Z'),
-  posts: { comments: 2, models: 1, images: 3, total: 6 },
+  posts: posts({ comments: 2, models: 1, images: 3 }),
   ...overrides,
 });
 
@@ -60,26 +85,62 @@ describe('buildFinding', () => {
   it('cites the evidence a moderator needs to judge it', () => {
     const finding = buildFinding(member(), score(), STARTED);
     // Distinct counts per surface so a mutant reading the wrong field cannot produce this string.
-    expect(finding.reason).toContain('2 visible comment(s)');
-    expect(finding.reason).toContain('1 published model(s)');
-    expect(finding.reason).toContain('3 visible image(s)');
+    expect(finding.reason).toContain('Posted 6 item(s) — 2 comment(s), 1 model(s), 3 image(s).');
     expect(finding.reason).toContain('3.0h old');
     expect(finding.reason).toContain('placeholder-no-op=0.00');
     expect(finding.reason).toContain('NOT actioned');
   });
 
-  it('says what the counts EXCLUDE, because the moderator’s next move is to go and look', () => {
-    // 🔴 The counts are of visible content only (see `cohort.ts`). An unqualified "Posted 3
-    // image(s)" was a promise the cohort query did not keep — it counted drafts, unattached and
-    // blocked uploads, hidden comments and removed models — and the wire contract calls this
-    // string "the whole value of the row". The whole normalised clause is pinned, not a keyword,
-    // so a reword that quietly drops the qualifier has to be a deliberate edit.
-    const finding = buildFinding(member(), score(), STARTED);
-    expect(finding.reason).toContain(
-      'Posted 2 visible comment(s), 1 published model(s), 3 visible image(s) — counts exclude ' +
-        'drafts, unattached uploads, blocked uploads, hidden or TOS-flagged content and anything ' +
-        'already removed.'
+  it('🔴 pins the WHOLE clause when nothing was taken down', () => {
+    // 🔴 THE WIRE CONTRACT CALLS THIS STRING "the whole value of the row to a moderator", so it is
+    // pinned as a whole normalised string rather than by keyword. A guard on words is walkable by
+    // rewording; this one makes a cosmetic reword a deliberate edit with a failing test attached.
+    expect(renderPostCounts(posts({ comments: 2, models: 1, images: 3 }))).toBe(
+      'Posted 6 item(s) — 2 comment(s), 1 model(s), 3 image(s). All 6 still on the site ' +
+        '(nothing hidden, blocked, unpublished or removed).'
     );
+  });
+
+  it('🔴 leads with what was POSTED and states the split, when content was taken down', () => {
+    // 🔴 THE F-2 REGRESSION, in the sentence a moderator reads. Forty uploads, thirty-nine blocked:
+    // the finding used to say "1 visible image(s)", so a queue sorted by volume put the worst
+    // account last. The total leads; the split follows and says plainly what is gone and why.
+    //
+    // Pairwise-distinct numbers across all three lines — 40/1/39, and comments 5/2/3 — so no
+    // mutant that reads `visible` for `all`, or recomputes `excluded` the other way round, can
+    // land on this string.
+    expect(
+      renderPostCounts(posts({ comments: 5, models: 0, images: 40 }, { comments: 2, images: 1 }))
+    ).toBe(
+      'Posted 45 item(s) — 5 comment(s), 0 model(s), 40 image(s). ' +
+        'Still on the site: 3 (2 comment(s), 0 model(s), 1 image(s)). ' +
+        'NOT on the site: 42 (3 comment(s), 0 model(s), 39 image(s)) — drafts, unpublished or ' +
+        'scheduled models, unattached uploads, uploads the scanner blocked or could not find, and ' +
+        'hidden, TOS-flagged or already-removed content. Images still awaiting a scan result are ' +
+        'counted as on the site.'
+    );
+  });
+
+  it('🔴 an account with NOTHING left on the site still leads with what it posted', () => {
+    // The canonical bot wave: 40 images, every one blocked. Under the old rule this account was not
+    // in the cohort at all, so there was no finding for this sentence to be wrong in.
+    const finding = buildFinding(member({ posts: posts({ images: 40 }, {}) }), score(), STARTED);
+    expect(finding.reason).toContain('Posted 40 item(s) — 0 comment(s), 0 model(s), 40 image(s).');
+    expect(finding.reason).toContain('Still on the site: 0 (0 comment(s), 0 model(s), 0 image(s))');
+    expect(finding.reason).toContain('NOT on the site: 40 (0 comment(s), 0 model(s), 40 image(s))');
+  });
+
+  it('🔴 never calls the reported number "visible" — the Pending carve-out', () => {
+    // 🔴 `cohort.ts` deliberately counts an image whose scan has not finished as on-site, and that
+    // is exactly the case a moderator cannot view. "N visible image(s)" claimed something the query
+    // does not deliver. The replacement states the carve-out in the same sentence, so this checks
+    // BOTH halves: the over-claiming word is gone, and the caveat that replaced it is present.
+    const shown = renderPostCounts(posts({ images: 40 }, { images: 1 }));
+    expect(shown).not.toContain('visible');
+    expect(shown).toContain('Images still awaiting a scan result are counted as on the site.');
+    // The no-exclusions branch has no room for the caveat and must not silently imply viewability
+    // either.
+    expect(renderPostCounts(posts({ images: 3 }))).not.toContain('visible');
   });
 
   it('floors the account age at zero when the clocks disagree', () => {

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -60,12 +60,26 @@ describe('buildFinding', () => {
   it('cites the evidence a moderator needs to judge it', () => {
     const finding = buildFinding(member(), score(), STARTED);
     // Distinct counts per surface so a mutant reading the wrong field cannot produce this string.
-    expect(finding.reason).toContain('2 comment(s)');
-    expect(finding.reason).toContain('1 model(s)');
-    expect(finding.reason).toContain('3 image(s)');
+    expect(finding.reason).toContain('2 visible comment(s)');
+    expect(finding.reason).toContain('1 published model(s)');
+    expect(finding.reason).toContain('3 visible image(s)');
     expect(finding.reason).toContain('3.0h old');
     expect(finding.reason).toContain('placeholder-no-op=0.00');
     expect(finding.reason).toContain('NOT actioned');
+  });
+
+  it('says what the counts EXCLUDE, because the moderator’s next move is to go and look', () => {
+    // 🔴 The counts are of visible content only (see `cohort.ts`). An unqualified "Posted 3
+    // image(s)" was a promise the cohort query did not keep — it counted drafts, unattached and
+    // blocked uploads, hidden comments and removed models — and the wire contract calls this
+    // string "the whole value of the row". The whole normalised clause is pinned, not a keyword,
+    // so a reword that quietly drops the qualifier has to be a deliberate edit.
+    const finding = buildFinding(member(), score(), STARTED);
+    expect(finding.reason).toContain(
+      'Posted 2 visible comment(s), 1 published model(s), 3 visible image(s) — counts exclude ' +
+        'drafts, unattached uploads, blocked uploads, hidden or TOS-flagged content and anything ' +
+        'already removed.'
+    );
   });
 
   it('floors the account age at zero when the clocks disagree', () => {

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -1,0 +1,313 @@
+import {
+  MAX_FINDINGS_PER_REPORT,
+  abuseReportInput,
+  type AbuseReportInput,
+} from '@civitai/moderation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMock, mockNode } from '~/__tests__/mocks';
+import type { CohortReader, NewAccountRow } from '../cohort';
+import { BOT_ACCOUNT_DETECTOR } from '../report';
+import type { BotAccountHeuristic } from '../scoring';
+import { BotAccountReportError, runBotAccountDetection } from '../run';
+
+const STARTED = new Date('2026-09-03T03:20:00.000Z');
+const FINISHED = new Date('2026-09-03T03:20:12.000Z');
+
+const account = (id: number): NewAccountRow => ({
+  id,
+  username: `u${id}`,
+  createdAt: new Date('2026-09-03T01:00:00.000Z'),
+});
+
+/**
+ * A reader over a fixed account list that RECORDS every operation it is asked for.
+ *
+ * The recording is the point. This port is the run's ENTIRE database surface, so the recorded set
+ * is a ledger of what the run did to the database — and a ledger fails when the set grows, which a
+ * check for a named forbidden call cannot.
+ */
+function recordingReader(accounts: NewAccountRow[], postedIds?: Set<number>) {
+  const operations: string[] = [];
+  const reader: CohortReader = {
+    listNewAccounts: async ({ after, take }) => {
+      operations.push('listNewAccounts');
+      return accounts.filter((a) => a.id > after).slice(0, take);
+    },
+    countPosts: async (ids) => {
+      operations.push('countPosts');
+      return {
+        comments: [],
+        commentsV2: [],
+        models: [],
+        images: ids
+          .filter((id) => !postedIds || postedIds.has(id))
+          .map((userId) => ({ userId, count: 1 })),
+      };
+    },
+  };
+  return { reader, operations };
+}
+
+function sink() {
+  const reports: AbuseReportInput[] = [];
+  return {
+    reports,
+    sendReport: vi.fn(async (report: AbuseReportInput) => {
+      reports.push(report);
+      return { runId: reports.length };
+    }),
+  };
+}
+
+/** A clock that returns STARTED first and FINISHED after — two distinct instants, so a report that
+ *  stamps one field from the other is visible. */
+function clock() {
+  let call = 0;
+  return () => (call++ === 0 ? STARTED : FINISHED);
+}
+
+const constantHeuristic = (id: string, value: number): BotAccountHeuristic => ({
+  id,
+  description: `test ${id}`,
+  weight: 1,
+  score: () => value,
+  explain: () => null,
+});
+
+const run = (
+  accounts: NewAccountRow[],
+  overrides: Parameters<typeof runBotAccountDetection>[1] = {},
+  postedIds?: Set<number>
+) => {
+  const { reader, operations } = recordingReader(accounts, postedIds);
+  const out = sink();
+  return {
+    operations,
+    ...out,
+    result: runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [constantHeuristic('h', 0.4)],
+      },
+      { pageSize: 100, maxAccounts: 1_000, ...overrides }
+    ),
+  };
+};
+
+describe('runBotAccountDetection', () => {
+  it('files the cohort as one report when it fits', async () => {
+    const scenario = run([account(1), account(2)]);
+    const result = await scenario.result;
+    expect(result).toMatchObject({
+      detector: BOT_ACCOUNT_DETECTOR,
+      scanned: 2,
+      cohortSize: 2,
+      capped: false,
+      reports: 1,
+      reportsSent: 1,
+    });
+    expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([1, 2]);
+  });
+
+  it('marks every finding of every batch un-actioned', async () => {
+    const scenario = run(
+      Array.from({ length: 7 }, (_, i) => account(i + 1)),
+      {
+        maxFindingsPerReport: 3,
+      }
+    );
+    await scenario.result;
+    const findings = scenario.reports.flatMap((r) => r.findings);
+    expect(findings).toHaveLength(7);
+    expect(findings.every((f) => f.actioned === false)).toBe(true);
+    expect(findings.some((f) => 'action' in f)).toBe(false);
+  });
+
+  it('uses the producer’s own clock for both timestamps', async () => {
+    const scenario = run([account(1)]);
+    await scenario.result;
+    // startedAt is the FIRST read and finishedAt the SECOND — a report that stamps both from one
+    // read, or that lets the receiver default them, is what makes the board's "how current is this"
+    // reading quietly wrong.
+    expect(scenario.reports[0].startedAt).toBe(STARTED.toISOString());
+    expect(scenario.reports[0].finishedAt).toBe(FINISHED.toISOString());
+  });
+
+  it('sends payloads the real wire contract accepts', async () => {
+    const scenario = run([account(1), account(2)]);
+    await scenario.result;
+    for (const report of scenario.reports)
+      expect(() => abuseReportInput.parse(report)).not.toThrow();
+  });
+
+  it('excludes accounts that have not posted, and still counts them as scanned', async () => {
+    const scenario = run(
+      [account(1), account(2), account(3)],
+      {},
+      new Set([2]) // only #2 posted
+    );
+    const result = await scenario.result;
+    expect(result.cohortSize).toBe(1);
+    expect(result.scanned).toBe(3);
+    expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([2]);
+  });
+
+  it('batches across reports at the real cap, with distinct startedAt per batch', async () => {
+    // 2,501 overshoots the 1,000 cap by a non-multiple, so the remainder batch runs.
+    const scenario = run(
+      Array.from({ length: 2_501 }, (_, i) => account(i + 1)),
+      {
+        pageSize: 1_000,
+        maxAccounts: 5_000,
+      }
+    );
+    const result = await scenario.result;
+    expect(MAX_FINDINGS_PER_REPORT).toBe(1_000);
+    expect(result.reports).toBe(3);
+    expect(result.reportsSent).toBe(3);
+    expect(scenario.reports.map((r) => r.findings.length)).toEqual([1_000, 1_000, 501]);
+    // 🔴 Sharing a startedAt would make the receiving upsert REPLACE the previous batch instead of
+    // adding to it — the run would land as its last 501 findings with nothing to say so.
+    expect(new Set(scenario.reports.map((r) => r.startedAt)).size).toBe(3);
+  });
+
+  it('reports the cap in the counters and the summary when it truncates', async () => {
+    const scenario = run(
+      Array.from({ length: 12 }, (_, i) => account(i + 1)),
+      {
+        pageSize: 4,
+        maxAccounts: 8,
+      }
+    );
+    const result = await scenario.result;
+    expect(result.capped).toBe(true);
+    expect(result.scanned).toBe(8);
+    expect(scenario.reports[0].counters?.cohort_capped).toBe(1);
+    expect(scenario.reports[0].counters?.cohort_cap).toBe(8);
+    expect(scenario.reports[0].summary).toContain('TRUNCATED');
+  });
+
+  it('publishes cohort_capped as a zero on an untruncated run', async () => {
+    const scenario = run([account(1)]);
+    await scenario.result;
+    // Not omitted. A counter that only appears in the bad case cannot be alerted on, because its
+    // absence is indistinguishable from the producer not running.
+    expect(scenario.reports[0].counters?.cohort_capped).toBe(0);
+    expect(scenario.reports[0].summary).not.toContain('TRUNCATED');
+  });
+
+  it('publishes a per-heuristic count for every registered heuristic', async () => {
+    const { reader } = recordingReader([account(1), account(2)]);
+    const out = sink();
+    await runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [constantHeuristic('loud', 0.9), constantHeuristic('quiet', 0)],
+      },
+      { pageSize: 10, maxAccounts: 10 }
+    );
+    expect(out.reports[0].counters).toMatchObject({
+      heuristics_registered: 2,
+      'heuristic:loud:evaluated': 2,
+      'heuristic:loud:fired': 2,
+      'heuristic:quiet:evaluated': 2,
+      'heuristic:quiet:fired': 0,
+    });
+  });
+
+  it('still files a report for an empty window', async () => {
+    const scenario = run([]);
+    const result = await scenario.result;
+    expect(result.cohortSize).toBe(0);
+    expect(result.reportsSent).toBe(1);
+    expect(scenario.reports[0].findings).toEqual([]);
+  });
+
+  it('surfaces a failed batch with how much of the run already landed', async () => {
+    const { reader } = recordingReader(Array.from({ length: 5 }, (_, i) => account(i + 1)));
+    const sendReport = vi
+      .fn<(_report: AbuseReportInput) => Promise<unknown>>()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('502 from the spoke'));
+    await expect(
+      runBotAccountDetection(
+        { reader, sendReport, now: clock(), heuristics: [] },
+        { pageSize: 10, maxAccounts: 10, maxFindingsPerReport: 2 }
+      )
+      // A bare rethrow would say "the run failed" and hide that a third of it is already on the
+      // board — which is what a reader has to know before retrying, since a retry re-sends under a
+      // NEW startedAt and duplicates rather than upserting.
+    ).rejects.toThrow(BotAccountReportError);
+    expect(sendReport).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs each batch as it lands', async () => {
+    const { reader } = recordingReader(Array.from({ length: 5 }, (_, i) => account(i + 1)));
+    const out = sink();
+    const log = vi.fn();
+    await runBotAccountDetection(
+      { reader, sendReport: out.sendReport, now: clock(), heuristics: [], log },
+      { pageSize: 10, maxAccounts: 10, maxFindingsPerReport: 2 }
+    );
+    const sent = log.mock.calls.filter(([name]) => name === 'bot-account-detection:report-sent');
+    expect(sent.map(([, data]) => data.batch)).toEqual([1, 2, 3]);
+    expect(sent.every(([, data]) => data.of === 3)).toBe(true);
+  });
+});
+
+describe('the shadow-mode invariant: nothing is muted, banned or restricted', () => {
+  beforeEach(() => {
+    // The canonical `~/server/db/client` mock is reset per file by the global setup; these paths
+    // are named so the assertions below read against a spy that definitely exists.
+    void dbMock.dbWrite;
+  });
+
+  it('performs exactly two kinds of database operation, both reads', async () => {
+    const scenario = run(
+      Array.from({ length: 5 }, (_, i) => account(i + 1)),
+      { pageSize: 2 }
+    );
+    await scenario.result;
+    // 🔴 AN ASSERTED LEDGER, not a check for a forbidden name. It fails if the set GROWS — which is
+    // what adding a write looks like — and if it SHRINKS. The reader port is the run's entire
+    // database surface, so this is the whole of what the run did to the database.
+    expect([...new Set(scenario.operations)].sort()).toEqual(['countPosts', 'listNewAccounts']);
+  });
+
+  it('never touches the write client', async () => {
+    const scenario = run(Array.from({ length: 3 }, (_, i) => account(i + 1)));
+    await scenario.result;
+    // The behavioural half of the guard, against the REAL global `dbWrite` spy rather than a local
+    // fake: it sees a write issued from anywhere in the run's import graph, including one this
+    // module's own fakes know nothing about. The structural half — which sees a write that this
+    // fixture's data happens not to reach — is `no-write-surface.test.ts`.
+    for (const path of [
+      'dbWrite.user.update',
+      'dbWrite.user.updateMany',
+      'dbWrite.userRestriction.create',
+      'dbWrite.userRestriction.update',
+      'dbWrite.$transaction',
+      'dbWrite.$executeRaw',
+      'dbWrite.$executeRawUnsafe',
+      'dbWrite.$queryRaw',
+    ])
+      expect(mockNode(path), `${path} was called by a shadow-mode run`).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing that claims an action was taken', async () => {
+    const scenario = run(
+      Array.from({ length: 7 }, (_, i) => account(i + 1)),
+      {
+        maxFindingsPerReport: 3,
+      }
+    );
+    await scenario.result;
+    const payload = JSON.stringify(scenario.reports);
+    expect(payload).not.toContain('"actioned":true');
+    expect(payload).not.toContain('"action"');
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -26,7 +26,12 @@ const account = (id: number): NewAccountRow => ({
  * is a ledger of what the run did to the database — and a ledger fails when the set grows, which a
  * check for a named forbidden call cannot.
  */
-function recordingReader(accounts: NewAccountRow[], postedIds?: Set<number>) {
+function recordingReader(
+  accounts: NewAccountRow[],
+  postedIds?: Set<number>,
+  /** Ids whose content is all gone — posted, but nothing left on the site. The bot-wave shape. */
+  blockedIds?: Set<number>
+) {
   const operations: string[] = [];
   const reader: CohortReader = {
     // Descending keyset, matching the real reader: ids strictly BELOW `before`, newest first.
@@ -39,13 +44,17 @@ function recordingReader(accounts: NewAccountRow[], postedIds?: Set<number>) {
     },
     countPosts: async (ids) => {
       operations.push('countPosts');
+      const posted = ids.filter((id) => !postedIds || postedIds.has(id));
       return {
         comments: [],
         commentsV2: [],
         models: [],
-        images: ids
-          .filter((id) => !postedIds || postedIds.has(id))
-          .map((userId) => ({ userId, count: 1 })),
+        // Still on the site: everything the account posted, unless it is one of the blocked ones.
+        images: posted.filter((id) => !blockedIds?.has(id)).map((userId) => ({ userId, count: 1 })),
+        allComments: [],
+        allCommentsV2: [],
+        allModels: [],
+        allImages: posted.map((userId) => ({ userId, count: blockedIds?.has(userId) ? 40 : 1 })),
       };
     },
   };
@@ -81,9 +90,10 @@ const constantHeuristic = (id: string, value: number): BotAccountHeuristic => ({
 const run = (
   accounts: NewAccountRow[],
   overrides: Parameters<typeof runBotAccountDetection>[1] = {},
-  postedIds?: Set<number>
+  postedIds?: Set<number>,
+  blockedIds?: Set<number>
 ) => {
-  const { reader, operations } = recordingReader(accounts, postedIds);
+  const { reader, operations } = recordingReader(accounts, postedIds, blockedIds);
   const out = sink();
   return {
     operations,
@@ -156,6 +166,59 @@ describe('runBotAccountDetection', () => {
     expect(result.cohortSize).toBe(1);
     expect(result.scanned).toBe(3);
     expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([2]);
+  });
+
+  it('🔴 reports accounts whose content is ALL gone, and counts how many there are', async () => {
+    // 🔴 END TO END for F-2. Three accounts posted; two of them had every upload blocked. Before the
+    // split those two were not in the cohort at all, so `cohortSize` was 1 and no counter, finding
+    // or summary sentence in the whole run mentioned them.
+    const scenario = run(
+      [account(1), account(2), account(3)],
+      {},
+      undefined,
+      new Set([2, 3]) // 40 uploads each, every one blocked
+    );
+    const result = await scenario.result;
+
+    expect(result.cohortSize).toBe(3);
+    expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([3, 2, 1]);
+    // The blind-spot counter: how many of the cohort have nothing left on the site. Structurally
+    // unobservable before, because those accounts were not members.
+    expect(result.counters.cohort_members_nothing_on_site).toBe(2);
+    // 40 + 40 + 1 posted, of which 40 + 40 are gone. Distinct from every other counter in the run.
+    expect(result.counters.cohort_items_posted).toBe(81);
+    expect(result.counters.cohort_items_not_on_site).toBe(80);
+  });
+
+  it('emits the blind-spot counters on a run where nothing was taken down', async () => {
+    // Emitted at zero, not omitted. A counter that appears only in the bad case cannot be alerted
+    // on, because its absence is indistinguishable from the producer not running at all.
+    const scenario = run([account(1), account(2)]);
+    const result = await scenario.result;
+    expect(result.counters.cohort_members_nothing_on_site).toBe(0);
+    expect(result.counters.cohort_items_not_on_site).toBe(0);
+    expect(result.counters.cohort_items_posted).toBe(2);
+    for (const key of [
+      'cohort_members_nothing_on_site',
+      'cohort_items_posted',
+      'cohort_items_not_on_site',
+    ])
+      expect(Object.keys(scenario.reports[0].counters ?? {})).toContain(key);
+  });
+
+  it('says in the summary that membership counts everything an account posted', async () => {
+    // The summary is what a grading pass reads first. "N had posted" against a visible-only
+    // membership rule was a true sentence about a number that had quietly excluded the accounts
+    // most worth looking at, so the rule is stated where the number is.
+    const scenario = run([account(1), account(2)], {}, undefined, new Set([2]));
+    await scenario.result;
+    const summary = scenario.reports[0].summary ?? '';
+    expect(summary).toContain('They posted 41 item(s), of which 40 are no longer on the site');
+    expect(summary).toContain('1 of the 2 have nothing left on the site at all');
+    expect(summary).toContain(
+      'Membership counts everything an account posted, so an account whose uploads were all ' +
+        'blocked or removed is included rather than dropped.'
+    );
   });
 
   it('batches across reports at the real cap, with distinct startedAt per batch', async () => {
@@ -335,24 +398,38 @@ describe('the shadow-mode invariant: nothing is muted, banned or restricted', ()
     expect([...new Set(scenario.operations)].sort()).toEqual(['countPosts', 'listNewAccounts']);
   });
 
-  it('never touches the write client', async () => {
+  it('never touches a write path on EITHER client', async () => {
     const scenario = run(Array.from({ length: 3 }, (_, i) => account(i + 1)));
     await scenario.result;
     // The behavioural half of the guard, against the REAL global `dbWrite` spy rather than a local
     // fake: it sees a write issued from anywhere in the run's import graph, including one this
     // module's own fakes know nothing about. The structural half — which sees a write that this
     // fixture's data happens not to reach — is `no-write-surface.test.ts`.
-    for (const path of [
-      'dbWrite.user.update',
-      'dbWrite.user.updateMany',
-      'dbWrite.userRestriction.create',
-      'dbWrite.userRestriction.update',
-      'dbWrite.$transaction',
-      'dbWrite.$executeRaw',
-      'dbWrite.$executeRawUnsafe',
-      'dbWrite.$queryRaw',
-    ])
-      expect(mockNode(path), `${path} was called by a shadow-mode run`).not.toHaveBeenCalled();
+    //
+    // 🔴 THE `dbRead` HALF IS NOT DECORATION. `packages/civitai-db/src/client.ts` builds `dbRead` as
+    // `singleClient ? dbWrite : new PrismaClient(replica)`, so wherever `DATABASE_REPLICA_URL`
+    // equals `DATABASE_URL` the two names are the SAME OBJECT and every raw statement below runs
+    // against the primary. A list that named only `dbWrite.*` watched half the surface: the
+    // demonstrated escape was `dbRead.$executeRawUnsafe('UPDATE "User" SET "muted" = true …')` in
+    // `collectCohort`'s loop, which left this file entirely green.
+    for (const client of ['dbWrite', 'dbRead'])
+      for (const method of [
+        'user.update',
+        'user.updateMany',
+        'user.create',
+        'user.delete',
+        'userRestriction.create',
+        'userRestriction.update',
+        '$transaction',
+        '$executeRaw',
+        '$executeRawUnsafe',
+        '$queryRaw',
+        '$queryRawUnsafe',
+      ])
+        expect(
+          mockNode(`${client}.${method}`),
+          `${client}.${method} was called by a shadow-mode run`
+        ).not.toHaveBeenCalled();
   });
 
   it('holds with the PRODUCTION heuristic registry, not only injected fakes', async () => {

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock, mockNode } from '~/__tests__/mocks';
 import type { CohortReader, NewAccountRow } from '../cohort';
 import { BOT_ACCOUNT_DETECTOR } from '../report';
-import type { BotAccountHeuristic } from '../scoring';
+import { BOT_ACCOUNT_HEURISTICS, type BotAccountHeuristic } from '../scoring';
 import { BotAccountReportError, runBotAccountDetection } from '../run';
 
 const STARTED = new Date('2026-09-03T03:20:00.000Z');
@@ -29,9 +29,13 @@ const account = (id: number): NewAccountRow => ({
 function recordingReader(accounts: NewAccountRow[], postedIds?: Set<number>) {
   const operations: string[] = [];
   const reader: CohortReader = {
-    listNewAccounts: async ({ after, take }) => {
+    // Descending keyset, matching the real reader: ids strictly BELOW `before`, newest first.
+    listNewAccounts: async ({ before, take }) => {
       operations.push('listNewAccounts');
-      return accounts.filter((a) => a.id > after).slice(0, take);
+      return [...accounts]
+        .sort((a, b) => b.id - a.id)
+        .filter((a) => before === undefined || a.id < before)
+        .slice(0, take);
     },
     countPosts: async (ids) => {
       operations.push('countPosts');
@@ -108,7 +112,7 @@ describe('runBotAccountDetection', () => {
       reports: 1,
       reportsSent: 1,
     });
-    expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([1, 2]);
+    expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([2, 1]);
   });
 
   it('marks every finding of every batch un-actioned', async () => {
@@ -174,8 +178,10 @@ describe('runBotAccountDetection', () => {
   });
 
   it('reports the cap in the counters and the summary when it truncates', async () => {
+    // 13 against a cap of 8 at page size 4: overshoots the cap, and the cap is neither a multiple
+    // nor a power-of-two multiple of the page size, so the budget-clamped page runs.
     const scenario = run(
-      Array.from({ length: 12 }, (_, i) => account(i + 1)),
+      Array.from({ length: 13 }, (_, i) => account(i + 1)),
       {
         pageSize: 4,
         maxAccounts: 8,
@@ -187,6 +193,30 @@ describe('runBotAccountDetection', () => {
     expect(scenario.reports[0].counters?.cohort_capped).toBe(1);
     expect(scenario.reports[0].counters?.cohort_cap).toBe(8);
     expect(scenario.reports[0].summary).toContain('TRUNCATED');
+    // 🔴 The findings that survived a cap are the NEWEST accounts, end to end through the run —
+    // not only inside `collectCohort`.
+    expect(scenario.reports[0].findings.map((f) => f.userId)).toEqual([13, 12, 11, 10, 9, 8, 7, 6]);
+  });
+
+  it('says WHICH END the cap dropped, in the summary a moderator reads', async () => {
+    // "TRUNCATED at the N-account cap" alone is read as "we saw the first N", and in a signup
+    // window "first" means oldest — the exact opposite of what the walk does. A moderator who
+    // reads it that way concludes the newest signups went unexamined and goes looking for them.
+    const scenario = run(
+      Array.from({ length: 13 }, (_, i) => account(i + 1)),
+      { pageSize: 4, maxAccounts: 8 }
+    );
+    await scenario.result;
+    const summary = scenario.reports[0].summary ?? '';
+    expect(summary).toContain('NEWEST FIRST');
+    expect(summary).toContain('OLDEST end');
+    // The whole normalised sentence, so a cosmetic reword has to be a deliberate edit rather than
+    // something that slips past a keyword check while inverting the meaning.
+    expect(summary).toContain(
+      '🔴 TRUNCATED at the 8-account cap. Accounts are read NEWEST FIRST, so the 8 read are the ' +
+        'most recent of the window and the unread remainder is its OLDEST end — the earliest ' +
+        'signups of the window were not scored.'
+    );
   });
 
   it('publishes cohort_capped as a zero on an untruncated run', async () => {
@@ -245,6 +275,33 @@ describe('runBotAccountDetection', () => {
     expect(sendReport).toHaveBeenCalledTimes(2);
   });
 
+  it('stops at the next report when the job is canceled', async () => {
+    // Past `lockExpiration` the run-jobs route RELEASES the lock while the run continues, so an
+    // overrunning run is how a retry starts a second one whose different `startedAt` the board
+    // cannot merge. Cancellation is checked before each send, not only per page, because sending
+    // is where a canceled run does damage the board can see.
+    const { reader } = recordingReader(Array.from({ length: 5 }, (_, i) => account(i + 1)));
+    const out = sink();
+    let checks = 0;
+    await expect(
+      runBotAccountDetection(
+        {
+          reader,
+          sendReport: out.sendReport,
+          now: clock(),
+          heuristics: [],
+          checkCanceled: () => {
+            checks += 1;
+            // Pages first, then one send, then canceled.
+            if (checks > 2) throw new Error('Job was canceled');
+          },
+        },
+        { pageSize: 10, maxAccounts: 10, maxFindingsPerReport: 2 }
+      )
+    ).rejects.toThrow('Job was canceled');
+    expect(out.sendReport).toHaveBeenCalledTimes(1);
+  });
+
   it('logs each batch as it lands', async () => {
     const { reader } = recordingReader(Array.from({ length: 5 }, (_, i) => account(i + 1)));
     const out = sink();
@@ -296,6 +353,38 @@ describe('the shadow-mode invariant: nothing is muted, banned or restricted', ()
       'dbWrite.$queryRaw',
     ])
       expect(mockNode(path), `${path} was called by a shadow-mode run`).not.toHaveBeenCalled();
+  });
+
+  it('holds with the PRODUCTION heuristic registry, not only injected fakes', async () => {
+    // 🔴 Every other case here injects `heuristics`, so `BOT_ACCOUNT_HEURISTICS` — the registry a
+    // real run actually uses, and the one the first real heuristic will be added to — was never
+    // exercised against the real `dbWrite` spy. A heuristic that reached for a write client would
+    // have been invisible to this whole file.
+    const { reader, operations } = recordingReader(
+      Array.from({ length: 3 }, (_, i) => account(i + 1))
+    );
+    const out = sink();
+    const result = await runBotAccountDetection(
+      { reader, sendReport: out.sendReport, now: clock() }, // no `heuristics` override
+      { pageSize: 10, maxAccounts: 10 }
+    );
+
+    expect(result.counters.heuristics_registered).toBe(BOT_ACCOUNT_HEURISTICS.length);
+    expect(BOT_ACCOUNT_HEURISTICS.length).toBeGreaterThan(0);
+    // Every registered heuristic reports its own counters, so a registry member that silently
+    // fails to run is visible rather than absorbed into the blend.
+    for (const heuristic of BOT_ACCOUNT_HEURISTICS)
+      expect(out.reports[0].counters?.[`heuristic:${heuristic.id}:evaluated`]).toBe(3);
+
+    expect([...new Set(operations)].sort()).toEqual(['countPosts', 'listNewAccounts']);
+    for (const path of [
+      'dbWrite.user.update',
+      'dbWrite.userRestriction.create',
+      'dbWrite.$transaction',
+      'dbWrite.$executeRawUnsafe',
+    ])
+      expect(mockNode(path), `${path} was called by a real-registry run`).not.toHaveBeenCalled();
+    expect(JSON.stringify(out.reports)).not.toContain('"actioned":true');
   });
 
   it('sends nothing that claims an action was taken', async () => {

--- a/src/server/services/bot-account-detection/__tests__/scoring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/scoring.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import type { BotAccountCohortMember } from '../cohort';
+import {
+  BOT_ACCOUNT_HEURISTICS,
+  heuristicCounters,
+  placeholderHeuristic,
+  renderSubScores,
+  scoreAccount,
+  type BotAccountEvidence,
+  type BotAccountHeuristic,
+} from '../scoring';
+
+const NOW = new Date('2026-09-03T12:00:00.000Z');
+
+const member: BotAccountCohortMember = {
+  userId: 12,
+  username: 'candidate',
+  createdAt: new Date('2026-09-03T09:00:00.000Z'),
+  posts: { comments: 1, models: 0, images: 2, total: 3 },
+};
+const evidence: BotAccountEvidence = { member, now: NOW };
+
+const heuristic = (
+  id: string,
+  value: number,
+  weight = 1,
+  note: string | null = null
+): BotAccountHeuristic => ({
+  id,
+  description: `test heuristic ${id}`,
+  weight,
+  score: () => value,
+  explain: () => note,
+});
+
+describe('the shipped registry', () => {
+  it('carries only the labelled placeholder — no detection ships in this change', () => {
+    expect(BOT_ACCOUNT_HEURISTICS.map((h) => h.id)).toEqual(['placeholder-no-op']);
+    expect(placeholderHeuristic.description).toMatch(/[Pp]laceholder/);
+  });
+
+  it('scores every account 0, so nothing here is a calibration', () => {
+    expect(placeholderHeuristic.score(evidence)).toBe(0);
+    expect(placeholderHeuristic.explain(evidence, 0)).toBeNull();
+    expect(scoreAccount(BOT_ACCOUNT_HEURISTICS, evidence).confidence).toBe(0);
+  });
+});
+
+describe('scoreAccount', () => {
+  it('reports each heuristic separately, not only the blend', () => {
+    // The whole reason the seam exists: a signal that fires on everything is useless whatever the
+    // blend does with it, and that is only visible if its own number survives to the report.
+    const result = scoreAccount([heuristic('a', 0.2), heuristic('b', 0.9)], evidence);
+    expect(result.subScores.map((s) => ({ id: s.id, score: s.score }))).toEqual([
+      { id: 'a', score: 0.2 },
+      { id: 'b', score: 0.9 },
+    ]);
+  });
+
+  it('blends by weight, not by count', () => {
+    // 0.2*1 + 0.6*4 = 2.6 over a total weight of 5 → 0.52. Deliberately not the unweighted mean
+    // (0.4) and not either input, so a mutant that ignores the weights, sums instead of averaging,
+    // or returns one member's score cannot land on it.
+    const result = scoreAccount([heuristic('a', 0.2, 1), heuristic('b', 0.6, 4)], evidence);
+    expect(result.confidence).toBeCloseTo(0.52, 10);
+  });
+
+  it('returns 0 rather than NaN for an empty registry', () => {
+    const result = scoreAccount([], evidence);
+    expect(result.confidence).toBe(0);
+    expect(result.subScores).toEqual([]);
+  });
+
+  it.each([
+    ['above 1', 4.2, 1],
+    ['below 0', -3, 0],
+    // 🔴 Both non-finite values go to 0, not to the nearest bound. `Infinity` is a DEFECT in the
+    // heuristic, not a maximal opinion about the account, and clamping it to 1 would put a
+    // top-confidence finding in front of a moderator on the strength of a divide-by-zero.
+    ['NaN', Number.NaN, 0],
+    ['Infinity', Number.POSITIVE_INFINITY, 0],
+  ])('clamps a %s sub-score and records that it did', (_label, raw, expected) => {
+    // 🔴 An unclamped value 400s the whole REPORT against `confidence: z.number().max(1)`, losing
+    // every finding in the batch rather than the offending one. Clamping is the only safe
+    // direction; `clamped` is what stops it being silent.
+    const result = scoreAccount([heuristic('rogue', raw)], evidence);
+    expect(result.subScores[0].score).toBe(expected);
+    expect(result.subScores[0].clamped).toBe(true);
+    expect(result.confidence).toBe(expected);
+  });
+
+  it('does not flag an in-range score as clamped', () => {
+    expect(scoreAccount([heuristic('ok', 0.3)], evidence).subScores[0].clamped).toBe(false);
+  });
+
+  it('hands the heuristic the run clock rather than letting it read one', () => {
+    let seen: BotAccountEvidence | undefined;
+    scoreAccount([{ ...heuristic('spy', 0), score: (e) => ((seen = e), 0) }], evidence);
+    expect(seen?.now).toBe(NOW);
+    expect(seen?.member).toBe(member);
+  });
+
+  it('keeps a heuristic’s note beside its own score', () => {
+    const result = scoreAccount([heuristic('a', 0.5, 1, 'because reasons')], evidence);
+    expect(result.subScores[0].note).toBe('because reasons');
+  });
+});
+
+describe('heuristicCounters', () => {
+  it('counts evaluations, firings and clamps per heuristic', () => {
+    // Three distinct numbers, because "how often does this fire, and how hard" cannot be answered
+    // by a single count: a signal that never triggers and one that triggers weakly on everything
+    // are the two failures shadow mode exists to tell apart.
+    const scores = [
+      scoreAccount([heuristic('a', 0.4), heuristic('b', 0)], evidence),
+      scoreAccount([heuristic('a', 0), heuristic('b', 0)], evidence),
+      scoreAccount([heuristic('a', 9), heuristic('b', 0)], evidence),
+    ];
+    expect(heuristicCounters(scores)).toEqual({
+      'heuristic:a:evaluated': 3,
+      'heuristic:a:fired': 2,
+      'heuristic:a:clamped': 1,
+      'heuristic:b:evaluated': 3,
+      'heuristic:b:fired': 0,
+      'heuristic:b:clamped': 0,
+    });
+  });
+
+  it('publishes a zero rather than omitting a heuristic that never fired', () => {
+    // A counter that appears only in the interesting case cannot be alerted on: its absence is
+    // indistinguishable from the producer not having run.
+    const counters = heuristicCounters([scoreAccount([heuristic('quiet', 0)], evidence)]);
+    expect(counters['heuristic:quiet:fired']).toBe(0);
+  });
+
+  it('is empty for a run with no accounts', () => {
+    expect(heuristicCounters([])).toEqual({});
+  });
+});
+
+describe('renderSubScores', () => {
+  it('names every heuristic and its own number', () => {
+    expect(
+      renderSubScores([
+        { id: 'a', score: 0.125, weight: 1, note: null, clamped: false },
+        { id: 'b', score: 1, weight: 1, note: null, clamped: false },
+      ])
+    ).toBe('a=0.13, b=1.00');
+  });
+
+  it('says so when nothing is registered, rather than rendering an empty clause', () => {
+    expect(renderSubScores([])).toBe('no heuristics registered');
+  });
+});

--- a/src/server/services/bot-account-detection/cohort.ts
+++ b/src/server/services/bot-account-detection/cohort.ts
@@ -1,17 +1,27 @@
 import { dbRead } from '~/server/db/client';
+import { ImageIngestionStatus, ModelStatus } from '~/shared/utils/prisma/enums';
 
 /**
  * The cohort a bot-account run looks at: accounts created in the last day that have already posted
- * something.
+ * something visible.
  *
  * Shaped after `apps/moderator/src/lib/server/comment-spam.service.ts` — a read that fetches raw rows
  * and a PURE function that decides which of them belong in the queue. Everything the rule rejects, it
  * rejects in the pure half, which is the half worth testing.
  *
- * 🔴 READ REPLICA ONLY. This module names `dbRead` and nothing else. That is not a performance
- * preference here, it is the property the shadow phase rests on: a detector that cannot reach a write
- * client cannot mute, ban, or file a restriction however wrong its scoring turns out to be. The
- * asserted ledger in `__tests__/no-write-surface.test.ts` fails if this file's database surface grows.
+ * 🔴 WHAT ACTUALLY HOLDS THE NO-WRITE PROPERTY, precisely — because the obvious reading is wrong.
+ * `dbRead` is NOT a structurally read-only client: `packages/civitai-db/src/client.ts` builds it as
+ * `singleClient ? dbWrite : new PrismaClient(replica)`, so wherever `DATABASE_REPLICA_URL` equals
+ * `DATABASE_URL` the two are THE SAME OBJECT, `.user.update()` included. Naming `dbRead` therefore
+ * buys convention, not reachability, and "a detector that cannot reach a write client" would be a
+ * comment stronger than the code.
+ *
+ * The property is held by two things that ARE checkable:
+ *  1. the compile-time `CohortDb` type below — a structural port with five read methods and no write
+ *     method, so this module cannot call one on the handle it is given however that handle was built;
+ *  2. the asserted source ledger in `__tests__/no-write-surface.test.ts`, which fails if this
+ *     module's database-operation set or its import set grows by so much as one member.
+ * Both are mechanical. Neither depends on `dbRead` being a different connection from `dbWrite`.
  */
 
 /** The window the detector is defined over. A day, because the operator's brief is "created in the
@@ -37,8 +47,24 @@ export const COHORT_PAGE_SIZE = 500;
  * (`cohort_capped` / `cohort_cap` counters, and a sentence in the report summary). A silent cap is
  * indistinguishable from a quiet day, which is the reassuring-zero the abuse board was built to
  * remove.
+ *
+ * 🔴 THE VALUE IS SET AGAINST A MEASUREMENT, and the previous one was set against nothing. A
+ * read-only count on a replica put the 24h signup baseline at **8,863 accounts**. Against the
+ * former ceiling of 10,000 that is ~13% headroom, which is the worst possible place for a cap to
+ * sit: it never trips on an ordinary day, so it looks proven, and it trips for the FIRST time on
+ * exactly the day a registration wave lands. 25,000 is ~2.8x the baseline, so an ordinary day plus
+ * a wave of nearly twice the site's normal daily signups still fits, and the cap goes back to being
+ * a ceiling on work rather than a daily filter.
+ *
+ * It is still a bound and it is still cheap: at `COHORT_PAGE_SIZE` this is at most 50 account pages
+ * and 200 `groupBy` reads, all on the replica, all keyset-paged.
+ *
+ * 🔴 The value is the SECOND line of defence, not the first. The walk below pages DESCENDING, so
+ * whatever the cap is set to, the accounts it discards are the OLDEST of the window rather than the
+ * newest — see `newAccountPageArgs`. Raising the number reduces how often truncation happens;
+ * paging downwards is what makes truncation safe when it does.
  */
-export const MAX_COHORT_ACCOUNTS = 10_000;
+export const MAX_COHORT_ACCOUNTS = 25_000;
 
 /** One row of the account read — who the account is, not what it did. */
 export type NewAccountRow = {
@@ -82,10 +108,13 @@ export type BotAccountCohortMember = {
  * fails if a write ever appears among them. Two read methods, no write method, nothing to widen.
  */
 export type CohortReader = {
-  /** One keyset page of new accounts, ordered by id ascending, ids strictly greater than `after`. */
+  /**
+   * One keyset page of new accounts, ordered by id DESCENDING — newest first — with ids strictly
+   * less than `before`. `before: undefined` seeds the walk at the newest account in the window.
+   */
   listNewAccounts(args: {
     createdAfter: Date;
-    after: number;
+    before: number | undefined;
     take: number;
   }): Promise<NewAccountRow[]>;
   /** Per-user content counts for exactly these ids. */
@@ -106,41 +135,124 @@ export function cohortCutoff(now: Date, windowHours = BOT_ACCOUNT_COHORT_WINDOW_
  *
  * `bannedAt`/`deletedAt` are excluded in SQL rather than in the pure selector: unlike "has posted",
  * they are not a judgement, and filtering them here keeps them out of the `IN` lists the content
- * reads build. Keyset on `id` rather than an OFFSET because the cohort's newest end grows while the
- * run walks it, and an OFFSET page would skip rows as it did.
+ * reads build.
+ *
+ * 🔴 KEYSET, AND IT PAGES DOWNWARDS. Keyset rather than OFFSET because the window's newest end grows
+ * while the run walks it and an OFFSET page skips rows as it does. DESCENDING because the walk is
+ * capped, and the direction decides WHICH accounts a capped run throws away:
+ *
+ *  - ascending, the unread remainder is the HIGHEST ids — the most recent signups. That is the
+ *    registration wave this detector exists to notice, discarded, while `capped: true` reads as
+ *    "we saw the first N". Measured baseline is ~8,863 signups/24h, so the cap does not trip on an
+ *    ordinary day and trips first on exactly the day it must not.
+ *  - descending, the unread remainder is the LOWEST ids — the oldest accounts of the window, which
+ *    have had a full day to be seen by every other surface and are the harmless end to drop.
+ *
+ * `id` is the primary key, so the order is TOTAL and the keyset is stable: no two rows tie, and
+ * `id < before` cannot re-emit or skip a row. Descending is also the stabler walk under concurrent
+ * inserts — new signups land ABOVE the seed page and are simply outside this run's window rather
+ * than a moving target the walk chases.
+ *
+ * `before: undefined` means "no lower-than bound yet", i.e. start at the newest. It is spelled as
+ * `undefined` rather than a sentinel id because Prisma drops an `undefined` field from the WHERE
+ * clause entirely, where a sentinel would have to be a real integer and `User.id` is an `int4` whose
+ * maximum a future migration could reach.
  */
-export function newAccountPageArgs(args: { createdAfter: Date; after: number; take: number }) {
+export function newAccountPageArgs(args: {
+  createdAfter: Date;
+  before: number | undefined;
+  take: number;
+}) {
   return {
     where: {
       createdAt: { gte: args.createdAfter },
-      id: { gt: args.after },
+      id: args.before === undefined ? undefined : ({ lt: args.before } as const),
       bannedAt: null,
       deletedAt: null,
     },
     select: { id: true, username: true, createdAt: true },
-    orderBy: { id: 'asc' },
+    orderBy: { id: 'desc' },
     take: args.take,
   } as const;
 }
 
 /**
- * The `groupBy` arguments each content read uses.
+ * 🔴 WHAT "HAS POSTED" MEANS: content a moderator can open right now.
+ *
+ * The reason string on every finding says "Posted N comment(s), N model(s), N image(s)" to a human
+ * whose next action is to go and look. So the counts have to be counts of things that are THERE.
+ * Filtering on `userId` alone counted an account's drafts, its never-attached image uploads, its
+ * blocked uploads, its hidden comments and its already-removed models — content that is either not
+ * published yet or has already been taken down — and sent a moderator after all of it.
+ *
+ * The rule, per surface, and what each clause excludes:
+ *  - `Comment` / `CommentV2`: `hidden` is not true, `tosViolation` is false. Both are moderation
+ *    outcomes: the comment is already gone from the page. `hidden` is a NULLABLE boolean, so
+ *    `{ not: true }` and not `false` — the repo's own idiom (`jobs/entity-moderation.ts`), and the
+ *    one that keeps the never-hidden rows whose column is NULL.
+ *  - `Model`: `status` is `Published`, not soft-deleted, not TOS-flagged. `Draft` and `Training` are
+ *    not posted yet; `Unpublished`/`UnpublishedViolation`/`Deleted` are posted and then withdrawn;
+ *    `Scheduled` is a promise to publish and has no page to open.
+ *  - `Image`: attached to a post (`postId` is not null — a detached image is a leftover with nowhere
+ *    to be viewed), not TOS-flagged, and its ingestion is not `Blocked`/`NotFound`.
+ *
+ * 🔴 `ingestion: Pending` is DELIBERATELY KEPT, and it is the one judgement call here. A fresh
+ * upload sits Pending for minutes; a bot wave's images are Pending *by definition* at the moment
+ * this detector looks at them. Excluding Pending would be excluding the signal, and unlike Blocked
+ * it is a scan that has not finished rather than a decision to remove. Blocked and NotFound are
+ * decisions, so they go.
  *
  * No time predicate, deliberately: every account in the list is younger than the window, so its
  * content is too, and a redundant `createdAt` filter would only cost the planner an extra condition
  * on a column these tables are not being seeked by.
  */
-export function postCountArgs(userIds: number[]) {
-  // NOT a blanket `as const`, and not a plain literal either — Prisma's generated `groupBy` argument
-  // type wants both at once. `by` must be a MUTABLE array of the model's scalar-field enum (a
-  // readonly tuple is rejected), while `_count._all` must be the literal `true` (a widened `boolean`
-  // is rejected). Getting either wrong produces the same error four times over, once per model,
-  // which reads as four unrelated faults.
-  return {
-    by: ['userId'] as ['userId'],
-    where: { userId: { in: userIds } },
-    _count: { _all: true as const },
-  };
+// NOT a blanket `as const`, and not a plain literal either — Prisma's generated `groupBy` argument
+// type wants both at once. `by` must be a MUTABLE array of the model's scalar-field enum (a
+// readonly tuple is rejected), while `_count._all` must be the literal `true` (a widened `boolean`
+// is rejected). Getting either wrong produces the same error four times over, once per model,
+// which reads as four unrelated faults.
+const groupByUser = <W>(where: W) => ({
+  by: ['userId'] as ['userId'],
+  where,
+  _count: { _all: true as const },
+});
+
+/** Comments still on the page: not hidden by moderation, not TOS-flagged. */
+export function commentCountArgs(userIds: number[]) {
+  return groupByUser({
+    userId: { in: userIds },
+    hidden: { not: true },
+    tosViolation: false,
+  });
+}
+
+/** The newer comment system, same rule. */
+export function commentV2CountArgs(userIds: number[]) {
+  return groupByUser({
+    userId: { in: userIds },
+    hidden: { not: true },
+    tosViolation: false,
+  });
+}
+
+/** Models with a live page: published, not soft-deleted, not TOS-flagged. */
+export function modelCountArgs(userIds: number[]) {
+  return groupByUser({
+    userId: { in: userIds },
+    status: ModelStatus.Published,
+    deletedAt: null,
+    tosViolation: false,
+  });
+}
+
+/** Images a moderator can open: attached to a post, not TOS-flagged, not blocked or missing. */
+export function imageCountArgs(userIds: number[]) {
+  return groupByUser({
+    userId: { in: userIds },
+    postId: { not: null },
+    tosViolation: false,
+    ingestion: { notIn: [ImageIngestionStatus.Blocked, ImageIngestionStatus.NotFound] },
+  });
 }
 
 type GroupByRow = { userId: number; _count: { _all: number } };
@@ -169,14 +281,14 @@ const toCountRows = (rows: GroupByRow[]): CountRow[] =>
  * (`toCountRows`), where the shape is asserted once. `findMany` has no such problem and keeps its
  * real row type, which is what pins the `select` in `newAccountPageArgs` to the fields used here.
  */
-type GroupByFn = (args: ReturnType<typeof postCountArgs>) => Promise<unknown>;
+type GroupByFn<A> = (args: A) => Promise<unknown>;
 
 export type CohortDb = {
   user: { findMany: (args: ReturnType<typeof newAccountPageArgs>) => Promise<NewAccountRow[]> };
-  comment: { groupBy: GroupByFn };
-  commentV2: { groupBy: GroupByFn };
-  model: { groupBy: GroupByFn };
-  image: { groupBy: GroupByFn };
+  comment: { groupBy: GroupByFn<ReturnType<typeof commentCountArgs>> };
+  commentV2: { groupBy: GroupByFn<ReturnType<typeof commentV2CountArgs>> };
+  model: { groupBy: GroupByFn<ReturnType<typeof modelCountArgs>> };
+  image: { groupBy: GroupByFn<ReturnType<typeof imageCountArgs>> };
 };
 
 /**
@@ -191,12 +303,11 @@ export function createCohortReader(db: CohortDb = dbRead): CohortReader {
     listNewAccounts: (args) => db.user.findMany(newAccountPageArgs(args)),
     countPosts: async (userIds) => {
       if (!userIds.length) return { comments: [], commentsV2: [], models: [], images: [] };
-      const args = postCountArgs(userIds);
       const [comments, commentsV2, models, images] = await Promise.all([
-        db.comment.groupBy(args),
-        db.commentV2.groupBy(args),
-        db.model.groupBy(args),
-        db.image.groupBy(args),
+        db.comment.groupBy(commentCountArgs(userIds)),
+        db.commentV2.groupBy(commentV2CountArgs(userIds)),
+        db.model.groupBy(modelCountArgs(userIds)),
+        db.image.groupBy(imageCountArgs(userIds)),
       ]);
       return {
         comments: toCountRows(comments as GroupByRow[]),
@@ -252,10 +363,11 @@ export function selectCohortMembers(
 }
 
 export type CohortResult = {
+  /** Newest account first — the walk's own order, see `newAccountPageArgs`. */
   members: BotAccountCohortMember[];
   /** Accounts read, before the has-posted filter. The denominator the counters report. */
   scanned: number;
-  /** Accounts were left unread because the cap was reached. */
+  /** Accounts were left unread because the cap was reached. They are the OLDEST of the window. */
   capped: boolean;
   /** Reads the walk performed, including the probe below. Reported so a run that did no paging is
    *  distinguishable from one that paged and found nothing. */
@@ -263,7 +375,7 @@ export type CohortResult = {
 };
 
 /**
- * Walk the window, page by page, up to the cap.
+ * Walk the window, page by page, up to the cap — newest account first.
  *
  * 🔴 `capped` means accounts were LEFT UNREAD, and it is measured rather than inferred from
  * `scanned === maxAccounts`. The two differ on the case a moderator would act on: a cohort whose
@@ -271,6 +383,15 @@ export type CohortResult = {
  * accounts that do not exist. So when the budget runs out the walk spends one extra 1-row read to
  * ask whether anything follows. Those rows are not scanned and not scored — the probe answers one
  * question and its result is discarded.
+ *
+ * 🔴 WHEN IT IS CAPPED, THE UNREAD REMAINDER IS THE OLDEST END. The walk descends by `id`, so the
+ * cursor moves from the newest signup in the window towards the oldest and truncation lands on
+ * accounts that have already had a full day of exposure. That is stated in the report summary in
+ * those words, because "TRUNCATED at the N-account cap" on its own reads as "we saw the first N"
+ * and the natural reading of "first" is the opposite of what happens.
+ *
+ * `checkCanceled` is called once per page rather than once per run: the scheduler cancels by closing
+ * the response, and a walk that never looks keeps reading pages after nobody is listening.
  */
 export async function collectCohort(
   reader: CohortReader,
@@ -278,23 +399,28 @@ export async function collectCohort(
     createdAfter: Date;
     pageSize?: number;
     maxAccounts?: number;
+    /** Throws if the job has been canceled. Optional so the core has no job-context dependency. */
+    checkCanceled?: () => void;
   }
 ): Promise<CohortResult> {
   const pageSize = opts.pageSize ?? COHORT_PAGE_SIZE;
   const maxAccounts = opts.maxAccounts ?? MAX_COHORT_ACCOUNTS;
+  const checkCanceled = opts.checkCanceled ?? (() => undefined);
 
   const members: BotAccountCohortMember[] = [];
-  let after = 0;
+  // No lower-than bound yet: the first page starts at the newest account in the window.
+  let before: number | undefined = undefined;
   let scanned = 0;
   let pages = 0;
   let capped = false;
 
   for (;;) {
+    checkCanceled();
     const remaining = maxAccounts - scanned;
     if (remaining <= 0) {
       const probe = await reader.listNewAccounts({
         createdAfter: opts.createdAfter,
-        after,
+        before,
         take: 1,
       });
       pages += 1;
@@ -304,14 +430,16 @@ export async function collectCohort(
     const take = Math.min(pageSize, remaining);
     const accounts = await reader.listNewAccounts({
       createdAfter: opts.createdAfter,
-      after,
+      before,
       take,
     });
     pages += 1;
     if (!accounts.length) break;
 
     scanned += accounts.length;
-    after = accounts[accounts.length - 1].id;
+    // Descending, so the LAST row of the page is the lowest id seen and the next page is strictly
+    // below it.
+    before = accounts[accounts.length - 1].id;
 
     const counts = mergePostCounts(await reader.countPosts(accounts.map((a) => a.id)));
     members.push(...selectCohortMembers(accounts, counts));

--- a/src/server/services/bot-account-detection/cohort.ts
+++ b/src/server/services/bot-account-detection/cohort.ts
@@ -427,10 +427,22 @@ const zeroSurface = (): SurfaceCounts => ({ comments: 0, models: 0, images: 0, t
  *
  * 🔴 `excluded` is SUBTRACTED, not read. There is no eighth query for "how much was taken down":
  * it is `all` minus `visible` on the same rows at the same instant, which is the only definition
- * under which the three numbers in a finding are guaranteed to add up. It is floored at zero so a
- * torn read — the unfiltered and filtered counts of one surface are separate statements against a
- * replica, and a row can be created between them — reports 0 excluded rather than a negative, which
- * would read as corrupt data in the one sentence a moderator acts on.
+ * under which the three numbers in a finding are guaranteed to add up.
+ *
+ * 🔴 THE TORN READ IS CLAMPED ON THE `visible` SIDE, BEFORE ANY SUBTRACTION OR ANY TOTAL. The eight
+ * reads are separate statements in one `Promise.all` against a replica, so a surface's filtered count
+ * can exceed its unfiltered one and DIFFERENT surfaces can tear in opposite directions. Flooring each
+ * difference at zero independently — which is what this used to do, including for `total` — made the
+ * docstring above false: with `allComments=5, comments=6` and `allModels=3, models=0`, the per-surface
+ * floors give an excluded breakdown of `0 + 3 + 0 = 3` while `all.total - visible.total` floors to 2,
+ * so the finding stated a NOT-on-site total of 2 over a breakdown summing to 3, and said the account
+ * posted 5 comments while 6 were still on the site.
+ *
+ * Clamping `visible` to `all` per surface first fixes both halves at once and needs no floors after
+ * it: every difference is non-negative by construction, `visible.total + excluded.total === all.total`
+ * exactly, and each side's total is the sum of its own three surfaces. The clamp costs a torn read the
+ * one impossible surplus row it invented; nothing else moves, and `all` — what membership is decided
+ * on — is never touched.
  */
 export function mergePostCounts(raw: RawPostCounts): Map<number, PostCounts> {
   const merged = new Map<number, PostCounts>();
@@ -452,13 +464,19 @@ export function mergePostCounts(raw: RawPostCounts): Map<number, PostCounts> {
   for (const r of raw.allModels) get(r.userId).all.models += r.count;
   for (const r of raw.allImages) get(r.userId).all.images += r.count;
   for (const row of merged.values()) {
+    // Clamp first — see the docstring. After this every subtraction below is non-negative and the
+    // three surfaces and the total cannot disagree, so no `Math.max` floor is needed or wanted: one
+    // would only hide a future arithmetic error behind a plausible zero.
+    row.visible.comments = Math.min(row.visible.comments, row.all.comments);
+    row.visible.models = Math.min(row.visible.models, row.all.models);
+    row.visible.images = Math.min(row.visible.images, row.all.images);
     for (const side of [row.all, row.visible])
       side.total = side.comments + side.models + side.images;
     row.excluded = {
-      comments: Math.max(0, row.all.comments - row.visible.comments),
-      models: Math.max(0, row.all.models - row.visible.models),
-      images: Math.max(0, row.all.images - row.visible.images),
-      total: Math.max(0, row.all.total - row.visible.total),
+      comments: row.all.comments - row.visible.comments,
+      models: row.all.models - row.visible.models,
+      images: row.all.images - row.visible.images,
+      total: row.all.total - row.visible.total,
     };
   }
   return merged;

--- a/src/server/services/bot-account-detection/cohort.ts
+++ b/src/server/services/bot-account-detection/cohort.ts
@@ -58,7 +58,8 @@ export const COHORT_PAGE_SIZE = 500;
  * a ceiling on work rather than a daily filter.
  *
  * It is still a bound and it is still cheap: at `COHORT_PAGE_SIZE` this is at most 50 account pages
- * and 200 `groupBy` reads, all on the replica, all keyset-paged.
+ * and 400 `groupBy` reads — eight per page, see `createCohortReader` — all on the replica, all
+ * keyset-paged.
  *
  * 🔴 The value is the SECOND line of defence, not the first. The walk below pages DESCENDING, so
  * whatever the cap is set to, the accounts it discards are the OLDEST of the window rather than the
@@ -77,20 +78,51 @@ export type NewAccountRow = {
 /** Per-user counts from one content table. */
 export type CountRow = { userId: number; count: number };
 
-/** The four content reads, unmerged. Kept apart so the merge stays a pure, testable step. */
+/**
+ * The eight content reads, unmerged. Kept apart so the merge stays a pure, testable step.
+ *
+ * Two counts per surface, not one:
+ *  - `comments`/`commentsV2`/`models`/`images` — the subset still on the site, i.e. what the
+ *    visibility filters keep. Reported to the moderator.
+ *  - `all*` — every row the account owns on that surface, moderation outcome or not. This is what
+ *    decides MEMBERSHIP; see `selectCohortMembers`.
+ */
 export type RawPostCounts = {
   comments: CountRow[];
   commentsV2: CountRow[];
   models: CountRow[];
   images: CountRow[];
+  allComments: CountRow[];
+  allCommentsV2: CountRow[];
+  allModels: CountRow[];
+  allImages: CountRow[];
 };
 
-/** What an account posted, per surface. `total` is what decides membership. */
-export type PostCounts = {
+/** Three surface counts and their sum. The unit both halves of `PostCounts` are expressed in. */
+export type SurfaceCounts = {
   comments: number;
   models: number;
   images: number;
   total: number;
+};
+
+/**
+ * What an account posted.
+ *
+ * 🔴 `all.total` DECIDES MEMBERSHIP; `visible` is reported and never gates anything. The two were
+ * one number until this split, and that number was the visible one — which made a moderator's own
+ * action, or the scanner's, able to remove an account from the cohort entirely. See
+ * `selectCohortMembers`.
+ */
+export type PostCounts = {
+  /** Every row the account owns, whatever state it is in. Membership is decided on this. */
+  all: SurfaceCounts;
+  /** The subset a moderator can still open. Reported, never used for membership. */
+  visible: SurfaceCounts;
+  /** `all` minus `visible`, per surface. Derived here so the reason string cannot recompute it
+   *  differently, and non-negative by construction — every visibility filter is a restriction of
+   *  the unfiltered read over the same rows. */
+  excluded: SurfaceCounts;
 };
 
 /** An account that is in the cohort, with the activity that put it there. */
@@ -178,13 +210,26 @@ export function newAccountPageArgs(args: {
 }
 
 /**
- * 🔴 WHAT "HAS POSTED" MEANS: content a moderator can open right now.
+ * 🔴 WHAT "STILL ON THE SITE" MEANS — AND WHY IT IS NOT THE MEMBERSHIP RULE.
  *
- * The reason string on every finding says "Posted N comment(s), N model(s), N image(s)" to a human
- * whose next action is to go and look. So the counts have to be counts of things that are THERE.
- * Filtering on `userId` alone counted an account's drafts, its never-attached image uploads, its
- * blocked uploads, its hidden comments and its already-removed models — content that is either not
- * published yet or has already been taken down — and sent a moderator after all of it.
+ * These filters answer one question: of what this account posted, how much can a moderator open
+ * right now. That is worth reporting, because the reason string on every finding is read by a human
+ * whose next action is to go and look, and "4 images" meaning "four things you can open" is a
+ * different sentence from "four rows, some of which we already removed".
+ *
+ * 🔴 IT IS NOT WHAT DECIDES WHO IS IN THE COHORT, and using it that way was a hole with a name on
+ * it. An account registered two hours ago that uploads forty images the scanner then marks
+ * `Blocked` is the canonical bot wave — and under a visible-only membership rule it counted zero,
+ * produced no `groupBy` row, and was therefore not a member, not scored and not reported, while
+ * `scanned` still counted it. The run summary then read "Scanned N account(s); 0 had posted": a
+ * reassuring zero produced by the detector working exactly as written. The partial case is worse —
+ * 39 of 40 blocked leaves "1 image", so a moderator sorting by volume puts the worst account last.
+ * `tosViolation` and `hidden` behave identically, so one moderator action could drop a whole
+ * account out of the cohort.
+ *
+ * So membership is decided on the UNFILTERED counts (`allContentCountArgs`) and these filtered
+ * counts are reported alongside them, with the difference stated in the finding. See
+ * `selectCohortMembers` and `buildFinding`.
  *
  * The rule, per surface, and what each clause excludes:
  *  - `Comment` / `CommentV2`: `hidden` is not true, `tosViolation` is false. Both are moderation
@@ -202,6 +247,12 @@ export function newAccountPageArgs(args: {
  * this detector looks at them. Excluding Pending would be excluding the signal, and unlike Blocked
  * it is a scan that has not finished rather than a decision to remove. Blocked and NotFound are
  * decisions, so they go.
+ *
+ * 🔴 THAT CLAUSE IS WHY THE REPORTED NUMBER IS NOT CALLED "VISIBLE". A Pending image is counted
+ * here and is precisely the case a moderator cannot view yet, so "N visible image(s)" over-claimed
+ * against this set's own definition. The set is "not removed, withheld or unpublished" — the
+ * finding says "still on the site" and states the Pending carve-out in the same sentence rather
+ * than leaving a reader to infer it.
  *
  * No time predicate, deliberately: every account in the list is younger than the window, so its
  * content is too, and a redundant `createdAt` filter would only cost the planner an extra condition
@@ -256,6 +307,22 @@ export function imageCountArgs(userIds: number[]) {
   });
 }
 
+/**
+ * Everything the account posted on one surface, with no visibility judgement at all.
+ *
+ * 🔴 ONE BUILDER FOR ALL FOUR SURFACES, deliberately, where the visible reads have four. There is
+ * nothing per-surface to express: the question is "does this row belong to this account", and the
+ * four filtered builders differ only because each surface spells "removed" in its own columns. A
+ * second builder per surface here would be four copies of the same clause and four places for a
+ * stray predicate to reappear — which is the exact defect this pair exists to undo.
+ *
+ * Soft-deleted, blocked, hidden and TOS-flagged rows are all counted. That is the point: a
+ * moderation outcome is evidence about the account, not a reason to stop looking at it.
+ */
+export function allContentCountArgs(userIds: number[]) {
+  return groupByUser({ userId: { in: userIds } });
+}
+
 type GroupByRow = { userId: number; _count: { _all: number } };
 
 const toCountRows = (rows: GroupByRow[]): CountRow[] =>
@@ -284,12 +351,16 @@ const toCountRows = (rows: GroupByRow[]): CountRow[] =>
  */
 type GroupByFn<A> = (args: A) => Promise<unknown>;
 
+/** Every `groupBy` argument shape one surface is asked for: its own visibility filter, and the
+ *  unfiltered count that decides membership. */
+type Grouped<A> = { groupBy: GroupByFn<A | ReturnType<typeof allContentCountArgs>> };
+
 export type CohortDb = {
   user: { findMany: (args: ReturnType<typeof newAccountPageArgs>) => Promise<NewAccountRow[]> };
-  comment: { groupBy: GroupByFn<ReturnType<typeof commentCountArgs>> };
-  commentV2: { groupBy: GroupByFn<ReturnType<typeof commentV2CountArgs>> };
-  model: { groupBy: GroupByFn<ReturnType<typeof modelCountArgs>> };
-  image: { groupBy: GroupByFn<ReturnType<typeof imageCountArgs>> };
+  comment: Grouped<ReturnType<typeof commentCountArgs>>;
+  commentV2: Grouped<ReturnType<typeof commentV2CountArgs>>;
+  model: Grouped<ReturnType<typeof modelCountArgs>>;
+  image: Grouped<ReturnType<typeof imageCountArgs>>;
 };
 
 /**
@@ -303,38 +374,93 @@ export function createCohortReader(db: CohortDb = dbRead): CohortReader {
   return {
     listNewAccounts: (args) => db.user.findMany(newAccountPageArgs(args)),
     countPosts: async (userIds) => {
-      if (!userIds.length) return { comments: [], commentsV2: [], models: [], images: [] };
-      const [comments, commentsV2, models, images] = await Promise.all([
+      if (!userIds.length) return emptyRawPostCounts();
+      // 🔴 EIGHT READS PER PAGE, NOT FOUR — the visible count and the unfiltered count of each
+      // surface. That is the price of deciding membership on everything an account posted while
+      // still telling a moderator how much of it is still up, and it is paid on purpose. All eight
+      // are per-user counts over the same `userId IN (…)` list on the replica, issued together.
+      const [comments, commentsV2, models, images, allC, allC2, allM, allI] = await Promise.all([
         db.comment.groupBy(commentCountArgs(userIds)),
         db.commentV2.groupBy(commentV2CountArgs(userIds)),
         db.model.groupBy(modelCountArgs(userIds)),
         db.image.groupBy(imageCountArgs(userIds)),
+        db.comment.groupBy(allContentCountArgs(userIds)),
+        db.commentV2.groupBy(allContentCountArgs(userIds)),
+        db.model.groupBy(allContentCountArgs(userIds)),
+        db.image.groupBy(allContentCountArgs(userIds)),
       ]);
       return {
         comments: toCountRows(comments as GroupByRow[]),
         commentsV2: toCountRows(commentsV2 as GroupByRow[]),
         models: toCountRows(models as GroupByRow[]),
         images: toCountRows(images as GroupByRow[]),
+        allComments: toCountRows(allC as GroupByRow[]),
+        allCommentsV2: toCountRows(allC2 as GroupByRow[]),
+        allModels: toCountRows(allM as GroupByRow[]),
+        allImages: toCountRows(allI as GroupByRow[]),
       };
     },
   };
 }
 
-/** The four reads folded into one per-user record. Comments from both systems add together — they
- *  are the same act to a moderator, and splitting them in the report would invite reading a
- *  migration artefact as a signal. */
+/** An empty result for every surface — the shape `countPosts` returns when asked about nobody. */
+export function emptyRawPostCounts(): RawPostCounts {
+  return {
+    comments: [],
+    commentsV2: [],
+    models: [],
+    images: [],
+    allComments: [],
+    allCommentsV2: [],
+    allModels: [],
+    allImages: [],
+  };
+}
+
+const zeroSurface = (): SurfaceCounts => ({ comments: 0, models: 0, images: 0, total: 0 });
+
+/**
+ * The eight reads folded into one per-user record.
+ *
+ * Comments from both systems add together — they are the same act to a moderator, and splitting
+ * them in the report would invite reading a migration artefact as a signal.
+ *
+ * 🔴 `excluded` is SUBTRACTED, not read. There is no eighth query for "how much was taken down":
+ * it is `all` minus `visible` on the same rows at the same instant, which is the only definition
+ * under which the three numbers in a finding are guaranteed to add up. It is floored at zero so a
+ * torn read — the unfiltered and filtered counts of one surface are separate statements against a
+ * replica, and a row can be created between them — reports 0 excluded rather than a negative, which
+ * would read as corrupt data in the one sentence a moderator acts on.
+ */
 export function mergePostCounts(raw: RawPostCounts): Map<number, PostCounts> {
   const merged = new Map<number, PostCounts>();
   const get = (userId: number) => {
     let row = merged.get(userId);
-    if (!row) merged.set(userId, (row = { comments: 0, models: 0, images: 0, total: 0 }));
+    if (!row)
+      merged.set(
+        userId,
+        (row = { all: zeroSurface(), visible: zeroSurface(), excluded: zeroSurface() })
+      );
     return row;
   };
-  for (const r of raw.comments) get(r.userId).comments += r.count;
-  for (const r of raw.commentsV2) get(r.userId).comments += r.count;
-  for (const r of raw.models) get(r.userId).models += r.count;
-  for (const r of raw.images) get(r.userId).images += r.count;
-  for (const row of merged.values()) row.total = row.comments + row.models + row.images;
+  for (const r of raw.comments) get(r.userId).visible.comments += r.count;
+  for (const r of raw.commentsV2) get(r.userId).visible.comments += r.count;
+  for (const r of raw.models) get(r.userId).visible.models += r.count;
+  for (const r of raw.images) get(r.userId).visible.images += r.count;
+  for (const r of raw.allComments) get(r.userId).all.comments += r.count;
+  for (const r of raw.allCommentsV2) get(r.userId).all.comments += r.count;
+  for (const r of raw.allModels) get(r.userId).all.models += r.count;
+  for (const r of raw.allImages) get(r.userId).all.images += r.count;
+  for (const row of merged.values()) {
+    for (const side of [row.all, row.visible])
+      side.total = side.comments + side.models + side.images;
+    row.excluded = {
+      comments: Math.max(0, row.all.comments - row.visible.comments),
+      models: Math.max(0, row.all.models - row.visible.models),
+      images: Math.max(0, row.all.images - row.visible.images),
+      total: Math.max(0, row.all.total - row.visible.total),
+    };
+  }
   return merged;
 }
 
@@ -344,6 +470,15 @@ export function mergePostCounts(raw: RawPostCounts): Map<number, PostCounts> {
  * Pure, and the only place membership is decided. An account with no content is not a bot-account
  * candidate under this brief — a signup that has done nothing is a signup, and including it would
  * put most of a day's registrations in front of a moderator.
+ *
+ * 🔴 `all.total`, NOT `visible.total`. The test is "did this account post anything at all", so a
+ * moderation outcome — the scanner blocking every upload, a moderator hiding a comment, a
+ * TOS flag — cannot take the account out of the cohort. It goes into the finding instead, where a
+ * human can see it. Reading `visible.total` here restores the hole this split exists to close, and
+ * does so silently: the run reports a smaller cohort and nothing anywhere reports an error.
+ *
+ * Membership is the only thing that changed. `visible` is still what the finding leads with,
+ * because it is still what a moderator can go and look at.
  */
 export function selectCohortMembers(
   accounts: NewAccountRow[],
@@ -352,7 +487,7 @@ export function selectCohortMembers(
   const members: BotAccountCohortMember[] = [];
   for (const account of accounts) {
     const posts = counts.get(account.id);
-    if (!posts || posts.total === 0) continue;
+    if (!posts || posts.all.total === 0) continue;
     members.push({
       userId: account.id,
       username: account.username,

--- a/src/server/services/bot-account-detection/cohort.ts
+++ b/src/server/services/bot-account-detection/cohort.ts
@@ -49,11 +49,12 @@ export const COHORT_PAGE_SIZE = 500;
  * remove.
  *
  * 🔴 THE VALUE IS SET AGAINST A MEASUREMENT, and the previous one was set against nothing. A
- * read-only count on a replica put the 24h signup baseline at **8,863 accounts**. Against the
- * former ceiling of 10,000 that is ~13% headroom, which is the worst possible place for a cap to
- * sit: it never trips on an ordinary day, so it looks proven, and it trips for the FIRST time on
- * exactly the day a registration wave lands. 25,000 is ~2.8x the baseline, so an ordinary day plus
- * a wave of nearly twice the site's normal daily signups still fits, and the cap goes back to being
+ * read-only count on a replica established the current 24h signup baseline; the figure itself is
+ * recorded outside this repository. Against the former ceiling of 10,000 that was only ~13%
+ * headroom, which is the worst possible place for a cap to sit: it never trips on an ordinary day,
+ * so it looks proven, and it trips for the FIRST time on exactly the day a registration wave lands.
+ * This ceiling is ~2.8x that baseline, so an ordinary day plus a wave of nearly twice the site's
+ * normal daily signups still fits, and the cap goes back to being
  * a ceiling on work rather than a daily filter.
  *
  * It is still a bound and it is still cheap: at `COHORT_PAGE_SIZE` this is at most 50 account pages
@@ -143,8 +144,8 @@ export function cohortCutoff(now: Date, windowHours = BOT_ACCOUNT_COHORT_WINDOW_
  *
  *  - ascending, the unread remainder is the HIGHEST ids — the most recent signups. That is the
  *    registration wave this detector exists to notice, discarded, while `capped: true` reads as
- *    "we saw the first N". Measured baseline is ~8,863 signups/24h, so the cap does not trip on an
- *    ordinary day and trips first on exactly the day it must not.
+ *    "we saw the first N". At the measured baseline the old cap did not trip on an ordinary day and
+ *    would have tripped first on exactly the day it must not.
  *  - descending, the unread remainder is the LOWEST ids — the oldest accounts of the window, which
  *    have had a full day to be seen by every other surface and are the harmless end to drop.
  *

--- a/src/server/services/bot-account-detection/cohort.ts
+++ b/src/server/services/bot-account-detection/cohort.ts
@@ -1,0 +1,324 @@
+import { dbRead } from '~/server/db/client';
+
+/**
+ * The cohort a bot-account run looks at: accounts created in the last day that have already posted
+ * something.
+ *
+ * Shaped after `apps/moderator/src/lib/server/comment-spam.service.ts` — a read that fetches raw rows
+ * and a PURE function that decides which of them belong in the queue. Everything the rule rejects, it
+ * rejects in the pure half, which is the half worth testing.
+ *
+ * 🔴 READ REPLICA ONLY. This module names `dbRead` and nothing else. That is not a performance
+ * preference here, it is the property the shadow phase rests on: a detector that cannot reach a write
+ * client cannot mute, ban, or file a restriction however wrong its scoring turns out to be. The
+ * asserted ledger in `__tests__/no-write-surface.test.ts` fails if this file's database surface grows.
+ */
+
+/** The window the detector is defined over. A day, because the operator's brief is "created in the
+ *  last 24 hours"; a parameter rather than a literal so a backfill can widen it without editing a
+ *  query, and so the tests can name a window without also naming a wall-clock. */
+export const BOT_ACCOUNT_COHORT_WINDOW_HOURS = 24;
+
+/**
+ * How many accounts one page pulls.
+ *
+ * Deliberately well under the `userId IN (…)` lists this feeds: each page becomes four `IN` lists
+ * against the content tables, so the page size is the width of those lists, not just a round-trip
+ * count.
+ */
+export const COHORT_PAGE_SIZE = 500;
+
+/**
+ * The most accounts one run will look at, ever.
+ *
+ * 🔴 A 24h signup cohort on this site is not a small number and it is not a stable one — a
+ * registration wave is exactly the condition this detector exists to notice, and exactly the
+ * condition under which an unbounded read is worst. So the run stops here and SAYS it stopped
+ * (`cohort_capped` / `cohort_cap` counters, and a sentence in the report summary). A silent cap is
+ * indistinguishable from a quiet day, which is the reassuring-zero the abuse board was built to
+ * remove.
+ */
+export const MAX_COHORT_ACCOUNTS = 10_000;
+
+/** One row of the account read — who the account is, not what it did. */
+export type NewAccountRow = {
+  id: number;
+  username: string | null;
+  createdAt: Date;
+};
+
+/** Per-user counts from one content table. */
+export type CountRow = { userId: number; count: number };
+
+/** The four content reads, unmerged. Kept apart so the merge stays a pure, testable step. */
+export type RawPostCounts = {
+  comments: CountRow[];
+  commentsV2: CountRow[];
+  models: CountRow[];
+  images: CountRow[];
+};
+
+/** What an account posted, per surface. `total` is what decides membership. */
+export type PostCounts = {
+  comments: number;
+  models: number;
+  images: number;
+  total: number;
+};
+
+/** An account that is in the cohort, with the activity that put it there. */
+export type BotAccountCohortMember = {
+  userId: number;
+  username: string | null;
+  createdAt: Date;
+  posts: PostCounts;
+};
+
+/**
+ * The narrow slice of the database this detector is allowed to use.
+ *
+ * A port rather than a direct `dbRead` call so the run can be exercised end to end against a fake —
+ * and so the fake can be a LEDGER: a test asserts the exact set of operations a run performs, which
+ * fails if a write ever appears among them. Two read methods, no write method, nothing to widen.
+ */
+export type CohortReader = {
+  /** One keyset page of new accounts, ordered by id ascending, ids strictly greater than `after`. */
+  listNewAccounts(args: {
+    createdAfter: Date;
+    after: number;
+    take: number;
+  }): Promise<NewAccountRow[]>;
+  /** Per-user content counts for exactly these ids. */
+  countPosts(userIds: number[]): Promise<RawPostCounts>;
+};
+
+/** The instant the window opens, given the run's own clock. */
+export function cohortCutoff(now: Date, windowHours = BOT_ACCOUNT_COHORT_WINDOW_HOURS): Date {
+  return new Date(now.getTime() - windowHours * 3_600_000);
+}
+
+/**
+ * The `User.findMany` arguments for one page.
+ *
+ * Exported and built separately from the call that uses it because this — the window, the
+ * exclusions, the keyset — is the part with behaviour. Asserting it is how "selects the right
+ * window" is testable without a database.
+ *
+ * `bannedAt`/`deletedAt` are excluded in SQL rather than in the pure selector: unlike "has posted",
+ * they are not a judgement, and filtering them here keeps them out of the `IN` lists the content
+ * reads build. Keyset on `id` rather than an OFFSET because the cohort's newest end grows while the
+ * run walks it, and an OFFSET page would skip rows as it did.
+ */
+export function newAccountPageArgs(args: { createdAfter: Date; after: number; take: number }) {
+  return {
+    where: {
+      createdAt: { gte: args.createdAfter },
+      id: { gt: args.after },
+      bannedAt: null,
+      deletedAt: null,
+    },
+    select: { id: true, username: true, createdAt: true },
+    orderBy: { id: 'asc' },
+    take: args.take,
+  } as const;
+}
+
+/**
+ * The `groupBy` arguments each content read uses.
+ *
+ * No time predicate, deliberately: every account in the list is younger than the window, so its
+ * content is too, and a redundant `createdAt` filter would only cost the planner an extra condition
+ * on a column these tables are not being seeked by.
+ */
+export function postCountArgs(userIds: number[]) {
+  // NOT a blanket `as const`, and not a plain literal either — Prisma's generated `groupBy` argument
+  // type wants both at once. `by` must be a MUTABLE array of the model's scalar-field enum (a
+  // readonly tuple is rejected), while `_count._all` must be the literal `true` (a widened `boolean`
+  // is rejected). Getting either wrong produces the same error four times over, once per model,
+  // which reads as four unrelated faults.
+  return {
+    by: ['userId'] as ['userId'],
+    where: { userId: { in: userIds } },
+    _count: { _all: true as const },
+  };
+}
+
+type GroupByRow = { userId: number; _count: { _all: number } };
+
+const toCountRows = (rows: GroupByRow[]): CountRow[] =>
+  rows.map((r) => ({ userId: r.userId, count: r._count._all }));
+
+/**
+ * The five database operations this detector performs, and the only ones it can.
+ *
+ * 🔴 A READ-ONLY SURFACE BY CONSTRUCTION. Five methods, all reads, no `dbWrite` anywhere in the
+ * type — so the adapter below cannot mute, ban or file a restriction even if someone asked it to,
+ * and a test can hand it a recorder and assert the exact set of operations a run performed. The
+ * asserted ledger in `__tests__/no-write-surface.test.ts` fails if this type grows a method.
+ *
+ * Written as a structural type rather than `typeof dbRead` so a fake satisfies it, which is what
+ * makes the seam between "the arguments we build" and "the call we make" testable at all. A builder
+ * that is correct and never passed to the client is the shape of a fix that changes nothing.
+ */
+/**
+ * 🔴 `groupBy`'s RESULT is `unknown`, and that is forced rather than lazy. Prisma's generated
+ * `groupBy` is a generic whose argument type depends on the expected RETURN type, so naming a
+ * concrete row type here makes the real client fail to satisfy this interface — TS folds the
+ * expected result into the parameter constraint and reports the args object as "missing length,
+ * pop, push and 35 more" from an array type. Narrowing happens at the call site instead
+ * (`toCountRows`), where the shape is asserted once. `findMany` has no such problem and keeps its
+ * real row type, which is what pins the `select` in `newAccountPageArgs` to the fields used here.
+ */
+type GroupByFn = (args: ReturnType<typeof postCountArgs>) => Promise<unknown>;
+
+export type CohortDb = {
+  user: { findMany: (args: ReturnType<typeof newAccountPageArgs>) => Promise<NewAccountRow[]> };
+  comment: { groupBy: GroupByFn };
+  commentV2: { groupBy: GroupByFn };
+  model: { groupBy: GroupByFn };
+  image: { groupBy: GroupByFn };
+};
+
+/**
+ * The real reader, over the read replica.
+ *
+ * `commentsV2` is read alongside `comments` because the two comment systems both still carry
+ * traffic and an account that only used the newer one would otherwise read as having posted nothing
+ * — a false negative in the one direction a detector must not have.
+ */
+export function createCohortReader(db: CohortDb = dbRead): CohortReader {
+  return {
+    listNewAccounts: (args) => db.user.findMany(newAccountPageArgs(args)),
+    countPosts: async (userIds) => {
+      if (!userIds.length) return { comments: [], commentsV2: [], models: [], images: [] };
+      const args = postCountArgs(userIds);
+      const [comments, commentsV2, models, images] = await Promise.all([
+        db.comment.groupBy(args),
+        db.commentV2.groupBy(args),
+        db.model.groupBy(args),
+        db.image.groupBy(args),
+      ]);
+      return {
+        comments: toCountRows(comments as GroupByRow[]),
+        commentsV2: toCountRows(commentsV2 as GroupByRow[]),
+        models: toCountRows(models as GroupByRow[]),
+        images: toCountRows(images as GroupByRow[]),
+      };
+    },
+  };
+}
+
+/** The four reads folded into one per-user record. Comments from both systems add together — they
+ *  are the same act to a moderator, and splitting them in the report would invite reading a
+ *  migration artefact as a signal. */
+export function mergePostCounts(raw: RawPostCounts): Map<number, PostCounts> {
+  const merged = new Map<number, PostCounts>();
+  const get = (userId: number) => {
+    let row = merged.get(userId);
+    if (!row) merged.set(userId, (row = { comments: 0, models: 0, images: 0, total: 0 }));
+    return row;
+  };
+  for (const r of raw.comments) get(r.userId).comments += r.count;
+  for (const r of raw.commentsV2) get(r.userId).comments += r.count;
+  for (const r of raw.models) get(r.userId).models += r.count;
+  for (const r of raw.images) get(r.userId).images += r.count;
+  for (const row of merged.values()) row.total = row.comments + row.models + row.images;
+  return merged;
+}
+
+/**
+ * Which of a page's accounts are in the cohort.
+ *
+ * Pure, and the only place membership is decided. An account with no content is not a bot-account
+ * candidate under this brief — a signup that has done nothing is a signup, and including it would
+ * put most of a day's registrations in front of a moderator.
+ */
+export function selectCohortMembers(
+  accounts: NewAccountRow[],
+  counts: Map<number, PostCounts>
+): BotAccountCohortMember[] {
+  const members: BotAccountCohortMember[] = [];
+  for (const account of accounts) {
+    const posts = counts.get(account.id);
+    if (!posts || posts.total === 0) continue;
+    members.push({
+      userId: account.id,
+      username: account.username,
+      createdAt: account.createdAt,
+      posts,
+    });
+  }
+  return members;
+}
+
+export type CohortResult = {
+  members: BotAccountCohortMember[];
+  /** Accounts read, before the has-posted filter. The denominator the counters report. */
+  scanned: number;
+  /** Accounts were left unread because the cap was reached. */
+  capped: boolean;
+  /** Reads the walk performed, including the probe below. Reported so a run that did no paging is
+   *  distinguishable from one that paged and found nothing. */
+  pages: number;
+};
+
+/**
+ * Walk the window, page by page, up to the cap.
+ *
+ * 🔴 `capped` means accounts were LEFT UNREAD, and it is measured rather than inferred from
+ * `scanned === maxAccounts`. The two differ on the case a moderator would act on: a cohort whose
+ * size is exactly the cap is complete, and reporting that as truncated sends someone looking for
+ * accounts that do not exist. So when the budget runs out the walk spends one extra 1-row read to
+ * ask whether anything follows. Those rows are not scanned and not scored — the probe answers one
+ * question and its result is discarded.
+ */
+export async function collectCohort(
+  reader: CohortReader,
+  opts: {
+    createdAfter: Date;
+    pageSize?: number;
+    maxAccounts?: number;
+  }
+): Promise<CohortResult> {
+  const pageSize = opts.pageSize ?? COHORT_PAGE_SIZE;
+  const maxAccounts = opts.maxAccounts ?? MAX_COHORT_ACCOUNTS;
+
+  const members: BotAccountCohortMember[] = [];
+  let after = 0;
+  let scanned = 0;
+  let pages = 0;
+  let capped = false;
+
+  for (;;) {
+    const remaining = maxAccounts - scanned;
+    if (remaining <= 0) {
+      const probe = await reader.listNewAccounts({
+        createdAfter: opts.createdAfter,
+        after,
+        take: 1,
+      });
+      pages += 1;
+      capped = probe.length > 0;
+      break;
+    }
+    const take = Math.min(pageSize, remaining);
+    const accounts = await reader.listNewAccounts({
+      createdAfter: opts.createdAfter,
+      after,
+      take,
+    });
+    pages += 1;
+    if (!accounts.length) break;
+
+    scanned += accounts.length;
+    after = accounts[accounts.length - 1].id;
+
+    const counts = mergePostCounts(await reader.countPosts(accounts.map((a) => a.id)));
+    members.push(...selectCohortMembers(accounts, counts));
+
+    // A short page is the end of the window: the reader was asked for `take` and had fewer.
+    if (accounts.length < take) break;
+  }
+
+  return { members, scanned, capped, pages };
+}

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -63,8 +63,14 @@ export function buildFinding(
     `Shadow-mode observation — NOT actioned. Account ${member.userId}` +
       `${member.username ? ` (${member.username})` : ''} registered ` +
       `${member.createdAt.toISOString()}, ${ageHours.toFixed(1)}h old at scan. ` +
-      `Posted ${member.posts.comments} comment(s), ${member.posts.models} model(s), ` +
-      `${member.posts.images} image(s). ` +
+      // 🔴 The qualifier is not decoration. This sentence is what a moderator acts on — they go and
+      // look — so it has to say what was counted. These counts are VISIBLE content only: published
+      // models, images attached to a post, comments not hidden or TOS-flagged, nothing soft-deleted
+      // or blocked (see `cohort.ts`). Naming that here is the difference between "4 images" meaning
+      // "four things you can open" and meaning "four rows, some of which are drafts we removed".
+      `Posted ${member.posts.comments} visible comment(s), ${member.posts.models} published ` +
+      `model(s), ${member.posts.images} visible image(s) — counts exclude drafts, unattached ` +
+      `uploads, blocked uploads, hidden or TOS-flagged content and anything already removed. ` +
       `Per-heuristic: ${renderSubScores(score.subScores)}. ` +
       `Blended confidence ${score.confidence.toFixed(2)}.`
   );

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -1,0 +1,154 @@
+import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
+import type { BotAccountCohortMember } from './cohort';
+import { renderSubScores, type BotAccountScore } from './scoring';
+
+/**
+ * Turning a scored cohort into abuse-board reports.
+ *
+ * 🔴 WHY THE BOARD AND NOT `UserRestriction`. The integration target for the LIVE phase is a
+ * `UserRestriction` row of type `bot-account`, and that seam already exists (civitai#4609). It is
+ * deliberately not used here, because in the shadow phase it cannot be: `applyPendingReviewMute` has
+ * no file-without-mute path — its create branch is one `$transaction([user.update({muted:true}),
+ * userRestriction.create(…)])` — and the service's own comment calls an unmuted Pending row "the one
+ * state a Pending row must never be left in", since an uphold then sets `mutedAt` and `confirm-mutes`
+ * acts on the account. So "file a Pending row, mute nobody" would manufacture that forbidden state on
+ * every single finding.
+ *
+ * The abuse board is the surface built for precisely this: `actioned: false` on the wire contract is
+ * documented as "a detection the system chose not to act on, which is exactly what no existing
+ * surface can represent". Write-only, and it grants nothing.
+ */
+
+/** The producer key. Opaque — it groups runs on the board and is a counters namespace, so it is not
+ *  a display string and renaming it orphans this detector's history. */
+export const BOT_ACCOUNT_DETECTOR = 'bot-account-detection';
+
+type AbuseFinding = AbuseReportInput['findings'][number];
+
+/** The wire contract's own cap on `reason`. Restated as a constant because the truncation below has
+ *  to be arithmetic on it, and a literal in two places drifts. */
+const MAX_REASON_LENGTH = 2_000;
+
+/**
+ * 🔴 A reason over the contract's limit does not lose the finding, it 400s the REPORT and loses
+ * every finding in the batch. So it is truncated here rather than left to fail, and the ellipsis is
+ * the record that something was cut. Reason text is generated from bounded facts plus a username and
+ * a per-heuristic list, both of which can grow.
+ */
+export function truncateReason(reason: string, max = MAX_REASON_LENGTH): string {
+  if (reason.length <= max) return reason;
+  return `${reason.slice(0, max - 1)}…`;
+}
+
+/**
+ * One finding.
+ *
+ * 🔴 `actioned: false` is a LITERAL, not a parameter and not a default. It is the shadow-mode
+ * invariant made unreachable rather than merely unset: a caller cannot pass `true`, so there is no
+ * argument, config value or flag anywhere upstream that can turn this run into an acting one. When
+ * the operator approves auto-mute, that is a deliberate edit here and in `run.ts`, not a flag flip.
+ *
+ * `action` is OMITTED rather than set to null — both are accepted by the contract, and omitting it
+ * makes the pair unrepresentable in the wrong combination rather than merely correct today.
+ */
+export function buildFinding(
+  member: BotAccountCohortMember,
+  score: BotAccountScore,
+  observedAt: Date
+): AbuseFinding {
+  // Floored at zero: an account timestamped after the scan instant is clock skew between the app and
+  // the database, not a negative age, and a negative figure in the reason reads as corrupt data.
+  const ageHours = Math.max(0, (observedAt.getTime() - member.createdAt.getTime()) / 3_600_000);
+  const reason = truncateReason(
+    `Shadow-mode observation — NOT actioned. Account ${member.userId}` +
+      `${member.username ? ` (${member.username})` : ''} registered ` +
+      `${member.createdAt.toISOString()}, ${ageHours.toFixed(1)}h old at scan. ` +
+      `Posted ${member.posts.comments} comment(s), ${member.posts.models} model(s), ` +
+      `${member.posts.images} image(s). ` +
+      `Per-heuristic: ${renderSubScores(score.subScores)}. ` +
+      `Blended confidence ${score.confidence.toFixed(2)}.`
+  );
+  return {
+    userId: member.userId,
+    confidence: score.confidence,
+    reason,
+    actioned: false,
+  };
+}
+
+/** Fixed-size slices, in order. A separate function because the boundary is the interesting part and
+ *  a loop inlined into the report builder cannot be exercised on its own. */
+export function chunkFindings<T>(findings: T[], size: number): T[][] {
+  if (size < 1) throw new Error(`chunk size must be >= 1, got ${size}`);
+  // One batch, empty, rather than none: a run that found nothing must still reach the board. "No
+  // report today" and "a report with zero findings" are the same picture to a reader otherwise, and
+  // the first is what a broken producer looks like.
+  if (!findings.length) return [[]];
+  const out: T[][] = [];
+  for (let i = 0; i < findings.length; i += size) out.push(findings.slice(i, i + size));
+  return out;
+}
+
+export type BuildReportsArgs = {
+  findings: AbuseFinding[];
+  /** The producer's clock at the start of the run. */
+  startedAt: Date;
+  /** The producer's clock when scoring finished. */
+  finishedAt: Date;
+  /** Run-level counters. Merged under the per-heuristic ones, which are namespaced. */
+  counters: Record<string, number>;
+  /** Sentence prefix describing the cohort — batch wording is appended per report. */
+  summary: string;
+  detector?: string;
+  maxFindingsPerReport?: number;
+};
+
+/**
+ * Split a run into the reports the endpoint will accept.
+ *
+ * 🔴 THE BATCH TIMESTAMPS ARE OFFSET ON PURPOSE, AND SKIPPING THAT LOSES DATA SILENTLY.
+ * `(detector, started_at)` is the receiving table's IDEMPOTENCY KEY: re-reporting the same pair does
+ * not append, it REPLACES the run and DELETES its previous findings (see
+ * `apps/moderator/src/lib/server/abuse-detection.service.ts`, and the unique index in
+ * `apps/moderator/abuse-detection/schema.sql`). That behaviour is correct and load-bearing — it is
+ * what makes a retried POST safe — but it means two batches of ONE run sharing a `startedAt` would
+ * see the second overwrite the first, and the board would show the last 1,000 findings of a 2,500
+ * finding run with nothing to indicate the other 1,500 ever arrived.
+ *
+ * So batch `k` is stamped `startedAt + k ms`. The offset is synthetic and it is bounded by the batch
+ * count in milliseconds; it is not a measurement, and it is the smallest change that makes the key
+ * unique while keeping the batches contiguous and correctly ordered on a board that sorts by
+ * `started_at`.
+ *
+ * 🔴 `finishedAt` is floored at each batch's own `startedAt`. Without it a run fast enough to finish
+ * inside `batchCount` milliseconds emits `finishedAt < startedAt` on a later batch, which the wire
+ * contract refuses outright ("finishedAt is before startedAt") — losing a whole report to the run
+ * having been quick.
+ */
+export function buildReports(args: BuildReportsArgs): AbuseReportInput[] {
+  const detector = args.detector ?? BOT_ACCOUNT_DETECTOR;
+  const size = args.maxFindingsPerReport ?? MAX_FINDINGS_PER_REPORT;
+  const batches = chunkFindings(args.findings, size);
+
+  return batches.map((batch, index) => {
+    const startedAt = new Date(args.startedAt.getTime() + index);
+    const finishedAt = new Date(Math.max(args.finishedAt.getTime(), startedAt.getTime()));
+    return {
+      detector,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      summary:
+        `${args.summary} Batch ${index + 1} of ${batches.length}; ` +
+        `${batch.length} finding(s) in this report, ${args.findings.length} in the run. ` +
+        `SHADOW MODE: nothing was muted, banned or restricted.`,
+      counters: {
+        ...args.counters,
+        batch_index: index + 1,
+        batch_count: batches.length,
+        batch_findings: batch.length,
+        run_findings: args.findings.length,
+      },
+      findings: batch,
+    };
+  });
+}

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -1,5 +1,5 @@
 import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
-import type { BotAccountCohortMember } from './cohort';
+import type { BotAccountCohortMember, SurfaceCounts } from './cohort';
 import { renderSubScores, type BotAccountScore } from './scoring';
 
 /**
@@ -40,6 +40,40 @@ export function truncateReason(reason: string, max = MAX_REASON_LENGTH): string 
   return `${reason.slice(0, max - 1)}…`;
 }
 
+/** `3 comment(s), 0 model(s), 40 image(s)` — the per-surface breakdown, spelled one way. */
+const renderSurface = (s: SurfaceCounts) =>
+  `${s.comments} comment(s), ${s.models} model(s), ${s.images} image(s)`;
+
+/**
+ * 🔴 WHAT THE ACCOUNT POSTED, AND HOW MUCH OF IT IS STILL UP — both, always, in that order.
+ *
+ * The leading number is the total, because that is what membership was decided on and a moderator
+ * ranking a queue by volume must see the same figure the detector did. An account with 40 blocked
+ * uploads leads with 40, not with 0.
+ *
+ * The split follows, because "40 images" and "40 images, 39 of which we already removed" call for
+ * different actions and the second is the interesting one. When nothing was excluded the split
+ * collapses to one clause — the sentence still states it, so a reader never has to infer the
+ * absence of a missing clause.
+ *
+ * 🔴 "STILL ON THE SITE", NOT "VISIBLE". `cohort.ts` deliberately counts an image whose scan has
+ * not finished (`ingestion: Pending`) as on-site, which is exactly the case a moderator cannot view
+ * yet — so calling that number "visible" claimed something the query does not deliver. The carve-out
+ * is stated in the same sentence rather than left to a reader who would have no way to know.
+ */
+export function renderPostCounts(posts: BotAccountCohortMember['posts']): string {
+  const head = `Posted ${posts.all.total} item(s) — ${renderSurface(posts.all)}.`;
+  if (posts.excluded.total === 0)
+    return `${head} All ${posts.all.total} still on the site (nothing hidden, blocked, unpublished or removed).`;
+  return (
+    `${head} Still on the site: ${posts.visible.total} (${renderSurface(posts.visible)}). ` +
+    `NOT on the site: ${posts.excluded.total} (${renderSurface(posts.excluded)}) — drafts, ` +
+    `unpublished or scheduled models, unattached uploads, uploads the scanner blocked or could not ` +
+    `find, and hidden, TOS-flagged or already-removed content. Images still awaiting a scan result ` +
+    `are counted as on the site.`
+  );
+}
+
 /**
  * One finding.
  *
@@ -63,14 +97,7 @@ export function buildFinding(
     `Shadow-mode observation — NOT actioned. Account ${member.userId}` +
       `${member.username ? ` (${member.username})` : ''} registered ` +
       `${member.createdAt.toISOString()}, ${ageHours.toFixed(1)}h old at scan. ` +
-      // 🔴 The qualifier is not decoration. This sentence is what a moderator acts on — they go and
-      // look — so it has to say what was counted. These counts are VISIBLE content only: published
-      // models, images attached to a post, comments not hidden or TOS-flagged, nothing soft-deleted
-      // or blocked (see `cohort.ts`). Naming that here is the difference between "4 images" meaning
-      // "four things you can open" and meaning "four rows, some of which are drafts we removed".
-      `Posted ${member.posts.comments} visible comment(s), ${member.posts.models} published ` +
-      `model(s), ${member.posts.images} visible image(s) — counts exclude drafts, unattached ` +
-      `uploads, blocked uploads, hidden or TOS-flagged content and anything already removed. ` +
+      `${renderPostCounts(member.posts)} ` +
       `Per-heuristic: ${renderSubScores(score.subScores)}. ` +
       `Blended confidence ${score.confidence.toFixed(2)}.`
   );

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -59,18 +59,29 @@ const renderSurface = (s: SurfaceCounts) =>
  * 🔴 "STILL ON THE SITE", NOT "VISIBLE". `cohort.ts` deliberately counts an image whose scan has
  * not finished (`ingestion: Pending`) as on-site, which is exactly the case a moderator cannot view
  * yet — so calling that number "visible" claimed something the query does not deliver. The carve-out
- * is stated in the same sentence rather than left to a reader who would have no way to know.
+ * is stated in BOTH branches, rather than left to a reader who would have no way to know.
+ *
+ * 🔴 THE NOTHING-EXCLUDED BRANCH NEEDS THE CARVE-OUT MOST, and used to be the one branch without it.
+ * `imageCountArgs` keeps `ingestion: Pending`, so a twenty-minute-old account whose three uploads are
+ * all attached and all awaiting a scan has `excluded.total === 0` and takes this branch — and this is
+ * the modal shape of the population this detector exists to find, precisely because nothing has been
+ * actioned yet. "All 3 still on the site" then sent a moderator to look at three items none of which
+ * they can view. Same over-claim the word "visible" was removed for, surviving in the commoner half.
  */
+const PENDING_CARVE_OUT = 'Images still awaiting a scan result are counted as on the site.';
+
 export function renderPostCounts(posts: BotAccountCohortMember['posts']): string {
   const head = `Posted ${posts.all.total} item(s) — ${renderSurface(posts.all)}.`;
   if (posts.excluded.total === 0)
-    return `${head} All ${posts.all.total} still on the site (nothing hidden, blocked, unpublished or removed).`;
+    return (
+      `${head} All ${posts.all.total} still on the site (nothing hidden, blocked, unpublished or ` +
+      `removed). ${PENDING_CARVE_OUT}`
+    );
   return (
     `${head} Still on the site: ${posts.visible.total} (${renderSurface(posts.visible)}). ` +
     `NOT on the site: ${posts.excluded.total} (${renderSurface(posts.excluded)}) — drafts, ` +
     `unpublished or scheduled models, unattached uploads, uploads the scanner blocked or could not ` +
-    `find, and hidden, TOS-flagged or already-removed content. Images still awaiting a scan result ` +
-    `are counted as on the site.`
+    `find, and hidden, TOS-flagged or already-removed content. ${PENDING_CARVE_OUT}`
   );
 }
 

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -41,6 +41,17 @@ export type BotAccountDetectionDeps = {
   heuristics?: readonly BotAccountHeuristic[];
   /** Structured progress, one call per notable step. Optional so the core has no logger dependency. */
   log?: (name: string, data: Record<string, unknown>) => void;
+  /**
+   * Throws if the job has been canceled. In production this is `JobContext.checkIfCanceled`.
+   *
+   * 🔴 A run that never asks keeps going after the scheduler has hung up, and this one is on a
+   * lock the webhook route releases at `lockExpiration` WHILE the run continues — so an uncanceled
+   * overrun is how the same window gets walked twice under two different `startedAt`s, which
+   * `(detector, started_at)` cannot merge and the board shows as two complete duplicate sets.
+   * Checked once per cohort page and once before each report send: the two places this run can be
+   * doing work nobody is waiting for.
+   */
+  checkCanceled?: () => void;
 };
 
 export type BotAccountDetectionOptions = {
@@ -86,11 +97,17 @@ export async function runBotAccountDetection(
   const maxAccounts = options.maxAccounts ?? MAX_COHORT_ACCOUNTS;
   const maxFindingsPerReport = options.maxFindingsPerReport ?? MAX_FINDINGS_PER_REPORT;
   const log = deps.log ?? (() => undefined);
+  const checkCanceled = deps.checkCanceled ?? (() => undefined);
 
   const startedAt = deps.now();
   const createdAfter = cohortCutoff(startedAt, windowHours);
 
-  const cohort = await collectCohort(deps.reader, { createdAfter, pageSize, maxAccounts });
+  const cohort = await collectCohort(deps.reader, {
+    createdAfter,
+    pageSize,
+    maxAccounts,
+    checkCanceled,
+  });
   log('bot-account-detection:cohort', {
     scanned: cohort.scanned,
     members: cohort.members.length,
@@ -120,11 +137,18 @@ export async function runBotAccountDetection(
     ...heuristicCounters(scores),
   };
 
+  // 🔴 The truncation sentence names WHICH END was dropped. "TRUNCATED at the N-account cap" alone
+  // is read as "we saw the first N", and "first" in a signup window means oldest — the opposite of
+  // what the walk does. The walk pages newest-first, so what a capped run did NOT read is the
+  // oldest tail of the window; saying so is what stops a moderator drawing the backwards
+  // conclusion that the newest signups went unexamined.
   const summary =
     `Scanned ${cohort.scanned} account(s) created since ${createdAfter.toISOString()}; ` +
     `${cohort.members.length} had posted and were scored by ${heuristics.length} heuristic(s).` +
     (cohort.capped
-      ? ` 🔴 TRUNCATED at the ${maxAccounts}-account cap — more accounts matched the window than this run read.`
+      ? ` 🔴 TRUNCATED at the ${maxAccounts}-account cap. Accounts are read NEWEST FIRST, so the ` +
+        `${cohort.scanned} read are the most recent of the window and the unread remainder is its ` +
+        `OLDEST end — the earliest signups of the window were not scored.`
       : '');
 
   const reports = buildReports({
@@ -138,6 +162,7 @@ export async function runBotAccountDetection(
 
   let sent = 0;
   for (const report of reports) {
+    checkCanceled();
     try {
       await deps.sendReport(report);
     } catch (e) {

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -1,0 +1,165 @@
+import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
+import {
+  BOT_ACCOUNT_COHORT_WINDOW_HOURS,
+  COHORT_PAGE_SIZE,
+  MAX_COHORT_ACCOUNTS,
+  cohortCutoff,
+  collectCohort,
+  type CohortReader,
+} from './cohort';
+import { BOT_ACCOUNT_DETECTOR, buildFinding, buildReports } from './report';
+import {
+  BOT_ACCOUNT_HEURISTICS,
+  heuristicCounters,
+  scoreAccount,
+  type BotAccountHeuristic,
+} from './scoring';
+
+/**
+ * The bot-account detector, shadow phase.
+ *
+ * 🔴 THIS RUN HAS EXACTLY ONE EFFECT: it POSTs reports. It does not mute, ban, exclude, or write a
+ * `UserRestriction` row, and it holds no handle that could — its whole database surface is the
+ * two-method read port in `cohort.ts`, and its whole outbound surface is `sendReport`. That is the
+ * shadow guarantee expressed as reachability rather than as a flag, so there is no configuration
+ * under which this run acts.
+ *
+ * Everything it touches arrives as a dependency, which is also what makes it testable end to end
+ * without a database, a network, or a clock.
+ */
+
+/** Where a finished report goes. In production this is `moderatorApp.abuseReport`, which validates
+ *  against the shared contract before the network call and cannot do anything else. */
+export type BotAccountReportSink = (report: AbuseReportInput) => Promise<unknown>;
+
+export type BotAccountDetectionDeps = {
+  reader: CohortReader;
+  sendReport: BotAccountReportSink;
+  /** The producer's clock. Injected, because the report's `startedAt`/`finishedAt` are the producer's
+   *  own times and the board's "how current is this" reading depends on them being real. */
+  now: () => Date;
+  heuristics?: readonly BotAccountHeuristic[];
+  /** Structured progress, one call per notable step. Optional so the core has no logger dependency. */
+  log?: (name: string, data: Record<string, unknown>) => void;
+};
+
+export type BotAccountDetectionOptions = {
+  windowHours?: number;
+  pageSize?: number;
+  maxAccounts?: number;
+  maxFindingsPerReport?: number;
+};
+
+export type BotAccountDetectionResult = {
+  detector: string;
+  /** Accounts read from the window, before the has-posted filter. */
+  scanned: number;
+  /** Accounts that made the cohort, i.e. findings. */
+  cohortSize: number;
+  /** The window held more accounts than the cap allowed the run to read. */
+  capped: boolean;
+  reports: number;
+  reportsSent: number;
+  counters: Record<string, number>;
+};
+
+/** Thrown when a batch fails to land, carrying how much of the run already did. */
+export class BotAccountReportError extends Error {
+  constructor(readonly sent: number, readonly total: number, cause: unknown) {
+    super(
+      `bot-account-detection: report ${sent + 1} of ${total} failed; ${sent} already landed. ` +
+        `A retry re-sends the whole run under a NEW startedAt, so the landed batches will ` +
+        `duplicate rather than upsert.`,
+      { cause }
+    );
+    this.name = 'BotAccountReportError';
+  }
+}
+
+export async function runBotAccountDetection(
+  deps: BotAccountDetectionDeps,
+  options: BotAccountDetectionOptions = {}
+): Promise<BotAccountDetectionResult> {
+  const heuristics = deps.heuristics ?? BOT_ACCOUNT_HEURISTICS;
+  const windowHours = options.windowHours ?? BOT_ACCOUNT_COHORT_WINDOW_HOURS;
+  const pageSize = options.pageSize ?? COHORT_PAGE_SIZE;
+  const maxAccounts = options.maxAccounts ?? MAX_COHORT_ACCOUNTS;
+  const maxFindingsPerReport = options.maxFindingsPerReport ?? MAX_FINDINGS_PER_REPORT;
+  const log = deps.log ?? (() => undefined);
+
+  const startedAt = deps.now();
+  const createdAfter = cohortCutoff(startedAt, windowHours);
+
+  const cohort = await collectCohort(deps.reader, { createdAfter, pageSize, maxAccounts });
+  log('bot-account-detection:cohort', {
+    scanned: cohort.scanned,
+    members: cohort.members.length,
+    pages: cohort.pages,
+    capped: cohort.capped,
+    createdAfter: createdAfter.toISOString(),
+  });
+
+  const scores = cohort.members.map((member) =>
+    scoreAccount(heuristics, { member, now: startedAt })
+  );
+  const findings = cohort.members.map((member, i) => buildFinding(member, scores[i], startedAt));
+
+  const finishedAt = deps.now();
+
+  const counters: Record<string, number> = {
+    window_hours: windowHours,
+    cohort_scanned: cohort.scanned,
+    cohort_size: cohort.members.length,
+    cohort_pages: cohort.pages,
+    cohort_cap: maxAccounts,
+    // A boolean as 0/1 because the contract's counters are `Record<string, number>`. Emitted on
+    // every run, not only when true: a counter that appears only in the bad case cannot be alerted
+    // on, because its absence is indistinguishable from the producer not running.
+    cohort_capped: cohort.capped ? 1 : 0,
+    heuristics_registered: heuristics.length,
+    ...heuristicCounters(scores),
+  };
+
+  const summary =
+    `Scanned ${cohort.scanned} account(s) created since ${createdAfter.toISOString()}; ` +
+    `${cohort.members.length} had posted and were scored by ${heuristics.length} heuristic(s).` +
+    (cohort.capped
+      ? ` 🔴 TRUNCATED at the ${maxAccounts}-account cap — more accounts matched the window than this run read.`
+      : '');
+
+  const reports = buildReports({
+    findings,
+    startedAt,
+    finishedAt,
+    counters,
+    summary,
+    maxFindingsPerReport,
+  });
+
+  let sent = 0;
+  for (const report of reports) {
+    try {
+      await deps.sendReport(report);
+    } catch (e) {
+      log('bot-account-detection:report-failed', { sent, total: reports.length });
+      throw new BotAccountReportError(sent, reports.length, e);
+    }
+    sent += 1;
+    log('bot-account-detection:report-sent', {
+      batch: sent,
+      of: reports.length,
+      findings: report.findings.length,
+      startedAt: report.startedAt,
+    });
+  }
+
+  return {
+    detector: BOT_ACCOUNT_DETECTOR,
+    scanned: cohort.scanned,
+    cohortSize: cohort.members.length,
+    capped: cohort.capped,
+    reports: reports.length,
+    reportsSent: sent,
+    counters,
+  };
+}

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -44,12 +44,18 @@ export type BotAccountDetectionDeps = {
   /**
    * Throws if the job has been canceled. In production this is `JobContext.checkIfCanceled`.
    *
-   * 🔴 A run that never asks keeps going after the scheduler has hung up, and this one is on a
-   * lock the webhook route releases at `lockExpiration` WHILE the run continues — so an uncanceled
-   * overrun is how the same window gets walked twice under two different `startedAt`s, which
-   * `(detector, started_at)` cannot merge and the board shows as two complete duplicate sets.
-   * Checked once per cohort page and once before each report send: the two places this run can be
-   * doing work nobody is waiting for.
+   * 🔴 WHAT THIS PROTECTS AGAINST IS THE CALLER HANGING UP, and only that. The run-jobs route
+   * cancels in exactly one place — `res.on('close')`, which calls `jobRunner.cancel()` — so what
+   * this stops is a walk that keeps paging and keeps POSTing after nobody is listening. Checked
+   * once per cohort page and once before each report send: the two places this run can be doing
+   * work for a closed response.
+   *
+   * 🔴 IT DOES NOT PROTECT AGAINST LOCK EXPIRY, and reading it that way is how the duplicate-run
+   * hazard gets treated as handled. The route's `release()` clears the redis key and the refresh
+   * interval; it never touches the job context, so nothing about a lapsed lock makes this throw and
+   * the run continues unaware. The mitigation for a second concurrent run under a different
+   * `startedAt` is the widened `lockExpiration` on the job — see
+   * `~/server/jobs/bot-account-detection.ts` — not this callback.
    */
   checkCanceled?: () => void;
 };
@@ -123,10 +129,25 @@ export async function runBotAccountDetection(
 
   const finishedAt = deps.now();
 
+  // 🔴 THE COHORT'S OWN BLIND-SPOT COUNTER. Membership is decided on everything an account posted,
+  // so an account whose every item was blocked, hidden or removed is now a member — and this is how
+  // many of them there were. It is the number that was structurally unobservable while membership
+  // ran off the visible count: those accounts were not in the cohort at all, so no counter, no
+  // finding and no summary sentence could mention them. Emitted on every run, zero included, so its
+  // absence means the producer did not run rather than that the case did not occur.
+  const nothingOnSite = cohort.members.filter((m) => m.posts.visible.total === 0).length;
+  // Everything the cohort posted, and how much of it has already been taken down. A run-level ratio
+  // a grading pass can read without opening a single finding.
+  const postedAll = cohort.members.reduce((sum, m) => sum + m.posts.all.total, 0);
+  const postedExcluded = cohort.members.reduce((sum, m) => sum + m.posts.excluded.total, 0);
+
   const counters: Record<string, number> = {
     window_hours: windowHours,
     cohort_scanned: cohort.scanned,
     cohort_size: cohort.members.length,
+    cohort_members_nothing_on_site: nothingOnSite,
+    cohort_items_posted: postedAll,
+    cohort_items_not_on_site: postedExcluded,
     cohort_pages: cohort.pages,
     cohort_cap: maxAccounts,
     // A boolean as 0/1 because the contract's counters are `Record<string, number>`. Emitted on
@@ -144,7 +165,11 @@ export async function runBotAccountDetection(
   // conclusion that the newest signups went unexamined.
   const summary =
     `Scanned ${cohort.scanned} account(s) created since ${createdAfter.toISOString()}; ` +
-    `${cohort.members.length} had posted and were scored by ${heuristics.length} heuristic(s).` +
+    `${cohort.members.length} had posted something and were scored by ${heuristics.length} ` +
+    `heuristic(s). They posted ${postedAll} item(s), of which ${postedExcluded} are no longer on ` +
+    `the site; ${nothingOnSite} of the ${cohort.members.length} have nothing left on the site at ` +
+    `all. Membership counts everything an account posted, so an account whose uploads were all ` +
+    `blocked or removed is included rather than dropped.` +
     (cohort.capped
       ? ` 🔴 TRUNCATED at the ${maxAccounts}-account cap. Accounts are read NEWEST FIRST, so the ` +
         `${cohort.scanned} read are the most recent of the window and the unread remainder is its ` +

--- a/src/server/services/bot-account-detection/scoring.ts
+++ b/src/server/services/bot-account-detection/scoring.ts
@@ -1,0 +1,162 @@
+import type { BotAccountCohortMember } from './cohort';
+
+/**
+ * The scoring seam. NO DETECTION LIVES HERE YET, and that is the deliverable rather than an omission
+ * — the heuristics are a separate change, and inventing some to fill the shape out would be
+ * inventing exactly the thing the shadow phase exists to measure.
+ *
+ * Why a registry of independent sub-scores rather than one `score(member)` function: shadow mode is
+ * not a dry run of the blend, it is a grading harness for each heuristic ON ITS OWN. A signal that
+ * fires on 90% of a day's new accounts is useless whatever the blend does with it, and that is only
+ * visible if every heuristic's own number reaches the board. So each contributes a separately
+ * reportable value, the blend is derived from those rather than the other way round, and the
+ * per-heuristic counters go out with every report.
+ */
+
+/** Everything a heuristic is allowed to look at. A parameter object rather than a bare member so a
+ *  heuristic that needs a second source (ClickHouse events, registration IPs) is added by widening
+ *  this type once, not by changing every signature. */
+export type BotAccountEvidence = {
+  member: BotAccountCohortMember;
+  /** The run's clock, so a heuristic never reaches for `new Date()` and becomes untestable. */
+  now: Date;
+};
+
+export type BotAccountHeuristic = {
+  /**
+   * Stable opaque key. It is a counters key and a board-facing sub-score name, so it is an
+   * identifier and not a sentence — renaming one renames a metric.
+   */
+  id: string;
+  /** What it claims to detect, for the humans reading a report. Never parsed. */
+  description: string;
+  /**
+   * Share of the blend. Relative, not absolute: the blend divides by the total weight of the
+   * heuristics that ran, so adding one does not silently dilute the others' meaning.
+   */
+  weight: number;
+  /** 0..1. Out-of-range and non-finite values are clamped and COUNTED — see `scoreAccount`. */
+  score: (evidence: BotAccountEvidence) => number;
+  /**
+   * The evidence-citing clause for the score just produced, or `null` to say nothing. Returning
+   * `null` at zero is the normal case: a report whose reason recites every heuristic that did not
+   * fire is unreadable, and the sub-scores carry that information already.
+   */
+  explain: (evidence: BotAccountEvidence, score: number) => string | null;
+};
+
+/** One heuristic's verdict on one account. */
+export type HeuristicScore = {
+  id: string;
+  score: number;
+  weight: number;
+  note: string | null;
+  /** The heuristic returned something outside 0..1 or non-finite, and it was clamped. */
+  clamped: boolean;
+};
+
+export type BotAccountScore = {
+  userId: number;
+  /** The weighted blend, 0..1. The producer's own confidence — not comparable with another
+   *  detector's, which is why the wire contract says so too. */
+  confidence: number;
+  subScores: HeuristicScore[];
+};
+
+/**
+ * 🔴 THE PLACEHOLDER. It detects nothing, by construction: it returns 0 for every account and
+ * explains nothing.
+ *
+ * It exists so the registry is exercised on a real run — an empty array makes every loop, every
+ * counter and every blend vacuous, and a seam that has never had anything in it is not a seam that
+ * has been shown to work. Delete it in the change that adds the first real heuristic; it is not a
+ * baseline, a prior, or a floor, and no calibration should ever be derived from it.
+ */
+export const placeholderHeuristic: BotAccountHeuristic = {
+  id: 'placeholder-no-op',
+  description:
+    'Placeholder. Scores every account 0 and detects nothing. Remove with the first real heuristic.',
+  weight: 1,
+  score: () => 0,
+  explain: () => null,
+};
+
+/** The heuristics a production run uses. */
+export const BOT_ACCOUNT_HEURISTICS: readonly BotAccountHeuristic[] = [placeholderHeuristic];
+
+/**
+ * Force one heuristic's return value into the contract.
+ *
+ * A heuristic is ordinary code and can return `NaN`, `Infinity` or 1.4 — and the wire schema
+ * `.max(1)`s confidence, so an unclamped value 400s the whole report and loses every finding in the
+ * batch, not just the offending one. Clamping is therefore the only safe direction; the `clamped`
+ * flag is what stops it being silent.
+ */
+function clampScore(raw: number): { score: number; clamped: boolean } {
+  // 🔴 Non-finite goes to 0, NOT to the nearest bound. `Infinity` is a defect in the heuristic — a
+  // divide by zero, an empty denominator — and not a maximal opinion about the account. Clamping it
+  // to 1 would put a top-confidence finding in front of a moderator on the strength of a bug, which
+  // is the one direction a shadow-mode detector must not fail in.
+  if (!Number.isFinite(raw)) return { score: 0, clamped: true };
+  if (raw < 0) return { score: 0, clamped: true };
+  if (raw > 1) return { score: 1, clamped: true };
+  return { score: raw, clamped: false };
+}
+
+/**
+ * Run every heuristic over one account.
+ *
+ * The blend is a weighted mean over the heuristics that RAN, so a registry of one always-zero
+ * placeholder yields 0 and a registry of none yields 0 — neither of which is a claim about the
+ * account.
+ */
+export function scoreAccount(
+  heuristics: readonly BotAccountHeuristic[],
+  evidence: BotAccountEvidence
+): BotAccountScore {
+  const subScores: HeuristicScore[] = heuristics.map((h) => {
+    const { score, clamped } = clampScore(h.score(evidence));
+    return { id: h.id, score, weight: h.weight, note: h.explain(evidence, score), clamped };
+  });
+
+  const totalWeight = subScores.reduce((sum, s) => sum + (s.weight > 0 ? s.weight : 0), 0);
+  const weighted = subScores.reduce((sum, s) => sum + (s.weight > 0 ? s.weight * s.score : 0), 0);
+  // A zero total weight is not an error: it is what a registry of zero heuristics, or of
+  // deliberately disabled ones, looks like. Dividing would be NaN, and NaN reaches the wire schema
+  // as a rejected report.
+  const confidence = totalWeight > 0 ? clampScore(weighted / totalWeight).score : 0;
+
+  return { userId: evidence.member.userId, confidence, subScores };
+}
+
+/**
+ * The per-heuristic counters that ride out with every report.
+ *
+ * Three numbers per heuristic, not one, because the question shadow mode asks is "how often does
+ * this fire, and how hard" — `fired` alone cannot distinguish a signal that never triggers from one
+ * that triggers weakly on everything.
+ *
+ * The `heuristic:` prefix keeps them from colliding with the run-level counters in the same flat
+ * record; a heuristic id containing a colon would read ambiguously, which is why ids are identifiers.
+ */
+export function heuristicCounters(scores: BotAccountScore[]): Record<string, number> {
+  const counters: Record<string, number> = {};
+  for (const account of scores) {
+    for (const sub of account.subScores) {
+      const evaluated = `heuristic:${sub.id}:evaluated`;
+      const fired = `heuristic:${sub.id}:fired`;
+      const clamped = `heuristic:${sub.id}:clamped`;
+      counters[evaluated] = (counters[evaluated] ?? 0) + 1;
+      counters[fired] = (counters[fired] ?? 0) + (sub.score > 0 ? 1 : 0);
+      counters[clamped] = (counters[clamped] ?? 0) + (sub.clamped ? 1 : 0);
+    }
+  }
+  return counters;
+}
+
+/** The compact `id=0.00` rendering the finding's reason carries, so a moderator sees each
+ *  heuristic's own number rather than only the blend. */
+export function renderSubScores(subScores: HeuristicScore[]): string {
+  if (!subScores.length) return 'no heuristics registered';
+  return subScores.map((s) => `${s.id}=${s.score.toFixed(2)}`).join(', ');
+}


### PR DESCRIPTION
## What this is

The **skeleton** of a bot-account detector over accounts registered in the last 24 hours that have already posted: cohort query, scoring seam, reporting, and wiring. **No detection heuristics** — those are a separate change.

It runs in **shadow mode**: it scores, it files, it mutes nobody.

- `src/server/services/bot-account-detection/cohort.ts` — keyset-paged, capped read over the read replica. Accounts created since the cutoff, not banned, not deleted; then per-user content counts from `Comment`, `CommentV2`, `Model` and `Image`; then a pure selector that drops anyone who has posted nothing. Shaped after `apps/moderator/src/lib/server/comment-spam.service.ts` (raw read + pure selector) and `bulk-ban.service.ts` (`userId IN (…)` against the content tables).
- `src/server/services/bot-account-detection/scoring.ts` — the seam. A registry of heuristics, each contributing an **independent, separately reportable sub-score**, with a weighted blend derived from those. Ships with exactly one heuristic, `placeholder-no-op`, which returns 0 for every account and is labelled in its own doc comment as something to delete with the first real heuristic.
- `src/server/services/bot-account-detection/report.ts` — findings and batching.
- `src/server/services/bot-account-detection/run.ts` — orchestration. Its only effect is the POST.
- `src/server/jobs/bot-account-detection.ts` — the job, registered in `run-jobs`. Daily, and runnable on demand at `/api/webhooks/run-jobs/bot-account-detection`.
- `packages/civitai-moderation/src/client.ts` — adds `abuseReport()`, so a producer validates against the real `abuseReportInput` before the network call rather than discovering a `CHECK` violation on the receiving side, where it aborts the transaction and loses the whole run.

## The shadow-vs-live split, and why the abuse board rather than `UserRestriction`

The eventual live target is a `UserRestriction` row of `type: 'bot-account'`, and **that seam already exists and is merged (#4609)**. This PR does not touch it.

It cannot be the shadow-phase target, and this is a property of the code rather than a preference:

- `applyPendingReviewMute` (`src/server/services/user-restriction.service.ts`) has **no file-without-mute path**. Its create branch is a single `dbWrite.$transaction([user.update({ muted: true }), userRestriction.create(…)])`.
- The service's own repair branch calls an unmuted Pending row *"the one state a Pending row must never be left in"*, because an uphold then sets `mutedAt` without `muted` and `confirm-mutes` acts on the account while the user keeps generating.

So "file a Pending row, mute nobody" would manufacture that forbidden state on **every** finding.

The abuse-detection board is the surface built for exactly this. `abuseReportInput`'s `actioned` field is documented in `packages/civitai-moderation/src/schema.ts` as: *"False is the common case and the interesting one: it is a detection the system chose not to act on, which is exactly what no existing surface can represent and what a human review queue needs."* The endpoint is write-only from the producer's side and grants nothing.

**Turning this live is a code change here, not a flag.** `actioned: false` is a literal in `buildFinding` with no parameter behind it, and the run holds no write client and no restriction service — its entire database surface is a two-method read port, and its entire outbound surface is one report sink.

## Two things about the receiving side that shape the design

**Batching must not share a timestamp.** `(detector, started_at)` is the receiving table's **idempotency key** (`apps/moderator/abuse-detection/schema.sql`; the upsert in `abuse-detection.service.ts` deletes and re-inserts a run's findings). That is correct and load-bearing — it is what makes a retried POST safe — but it means two batches of one run sharing a `startedAt` would see the second **replace** the first. A 2,501-finding run would land on the board as its last 501 findings, with nothing to indicate the other 2,000 ever arrived. So batch *k* is stamped `startedAt + k ms`; the offset is synthetic, bounded by the batch count in milliseconds, and is the smallest thing that makes the key unique while keeping the batches contiguous and correctly ordered.

**`finishedAt` is floored at each batch's own `startedAt`.** Without it, a run fast enough to finish inside `batchCount` milliseconds emits `finishedAt < startedAt` on a later batch, which the contract refuses outright — losing a whole report to the run having been quick.

## Boundedness, and it is not silent

- `COHORT_PAGE_SIZE = 500`, `MAX_COHORT_ACCOUNTS = 10_000`.
- When the cap is reached the walk spends **one extra 1-row probe** rather than inferring truncation from `scanned === cap`. Those differ on the case a moderator would act on: a cohort whose size is exactly the cap is complete, and reporting that as truncated sends someone looking for accounts that do not exist.
- Truncation is reported three ways: `cohort_capped` in the counters, `cohort_cap` beside it, and a `🔴 TRUNCATED` sentence in the report summary. `cohort_capped` is published as `0` on a normal run rather than omitted — a counter that only appears in the bad case cannot be alerted on, because its absence is indistinguishable from the producer not running.
- Per-heuristic counters (`heuristic:<id>:evaluated` / `:fired` / `:clamped`) ride out with every report, because "how often does this fire, and how hard" cannot be answered by a single count.

## Test matrix

**102 tests across 6 files** (83 across 5 before the fix round). `pnpm typecheck` clean; the whole `unit*` project green (25,298 passed / 33 skipped). CI on this PR is **18 pass / 1 skipping** on head `791073a392`, measured after the fix round settled. An earlier revision of this body said 14 (stale); the round-1 audit counted 20 pass on head `0583ecda67` — the rollup's size varies with which `preview / *` jobs register, so quote the count with the head it was read at.

**Base-failure reason — stated plainly.** Every one of these files fails at `origin/main` as an **import error**, not behaviourally: `git cat-file -e origin/main:<path>` confirms `cohort.ts`, `scoring.ts`, `report.ts`, `run.ts` and the job file are all absent there, and `abuseReport` appears zero times in the client at base. A red-at-base run therefore proves only that the symbols are new. **Coverage is attributed by mutation instead**, below.

| Test | Pins | Base-failure reason |
|---|---|---|
| `cohort.test.ts` — window (2 points: 24h, 6h) | `cohortCutoff` arithmetic uses its argument | import error only |
| `cohort.test.ts` — `newAccountPageArgs` | `createdAt: { gte: cutoff }` and nothing else; `bannedAt`/`deletedAt` null; keyset `id.gt`, no `skip` | import error only |
| `cohort.test.ts` — `createCohortReader` seam | the built args are actually handed to the client; the four content reads and no others | import error only |
| `cohort.test.ts` — `selectCohortMembers` | an account with zero posts, and one absent from the counts map entirely, are both excluded | import error only |
| `cohort.test.ts` — `collectCohort` | paging, cap, the exactly-at-cap case, cutoff on every page, `scanned` counts pre-filter | import error only |
| `scoring.test.ts` | registry holds only the placeholder; weighted blend; clamping incl. `NaN`/`Infinity`; per-heuristic counters | import error only |
| `report.test.ts` | `actioned: false` and no `action` key; reason truncation; batching at the real 1,000 cap; distinct `startedAt`; `finishedAt` floor; every payload `abuseReportInput.parse`s | import error only |
| `run.test.ts` | end-to-end with fakes: every finding un-actioned, batching, capped reporting, producer clock on both fields, partial-send error | import error only |
| `run.test.ts` — no-mute | ledger of the run's database operations; the **real global `dbWrite` spy** never called; no `"actioned":true` in any payload | import error only |
| `no-write-surface.test.ts` | source-level ledgers: the exact 5 database operations, the exact import set, no `dbWrite` token | import error only |

Fixture sizes **overshoot** the cap: 2,501 findings against `MAX_FINDINGS_PER_REPORT = 1,000` (neither a multiple nor a power-of-two multiple, so the full-batch, remainder and multi-batch-numbering branches all run), and 7 accounts at page size 3 so the short-final-page branch runs rather than the empty-page one.

`no-write-surface.test.ts` carries its own controls: a positive control that it actually read ≥5 non-trivial files, a negative control that both scanners detect a planted `dbWrite.user.update` and a planted `user-restriction.service` import, and two-directional controls on the comment stripper it reads through (a commented-out write must be invisible; a real write beside a comment, and one after a `https://` URL, must not be).

## Mutation results

Ten mutations, each applied alone and reverted. Every one was killed **by a test's own assertion**, not by a neighbouring failure.

| # | Mutation | Killed by | Assertion |
|---|---|---|---|
| M1 | `dbWrite.user.update({ muted: true })` added to `run.ts` | 3 tests | `expected [5 ops] to deeply equal [4 ops]` · `run.ts names the write client` · `dbWrite.user.update … been called 2543 times` |
| M1b | `applyPendingReviewMute(…)` called from `run.ts` (no `dbWrite` token, no new db op) | import ledger | `expected [9 imports] to deeply equal [8 imports]` |
| M2 | `actioned: false` → `actioned: true, action: 'muted'` (deliberately contract-**valid**, so the schema test cannot be what fires) | 4 tests | `expected true to be false` · `not to contain '"actioned":true'` |
| M3 | per-report cap ignored | 6 tests | `expected [2501] to deeply equal [1000, 1000, 501]` |
| M4 | batches share one `startedAt` | 2 tests | `expected 1 to be 3` (distinct-timestamp count) |
| M5 | 24h window predicate dropped | window test | `expected undefined to deeply equal { gte: … }` |
| M5b | window predicate `gte` → `lte` | window test | `expected { lte: … } to deeply equal { gte: … }` |
| M6 | has-posted filter never excludes | selector test | `expected [1, 2] to deeply equal [1]` |
| M7 | cap becomes silent (`capped` always false) | 2 tests | `expected false to be true` |
| M8 | final page not clamped to remaining budget | cap test | `expected 6 to be 5` |
| M9 | `commentV2` dropped from the content reads | 2 ledger tests | `expected [3 ops] to deeply equal [4 ops]` |

M1b is worth reading closely: the import ledger killed it with its own assertion, while the **behavioural** tests in the same file died for the *wrong* reason (`Error: No user with id 1`, from the mocked client). That is the case the structural ledger exists for, and the reason both halves are kept.

The unmutated tree was re-run green (83/83) after the battery, from `cp -a` restores.

## Deployment — the job ships REGISTERED BUT NOT SCHEDULED

`src/server/jobs/bot-account-detection.ts` uses **`UNRUNNABLE_JOB_CRON`**. `/api/internal/get-jobs` publishes every registered job's cron to the external scheduler, so a real cron here would mean **merging this PR turns the detector on** — which is exactly what the preconditions below say must not happen yet. As shipped it fires no schedule, and it is still on-demand runnable at `/api/webhooks/run-jobs/bot-account-detection`, which is the whole of what a shadow-phase grading pass needs.

**Restoring a real cron is a one-token change. What must be true first:**

1. **`MOD_INBOUND_TOKEN` present** wherever the jobs workload runs. `moderator-app.service.ts` falls back to `WEBHOOK_TOKEN`, which the moderator app **no longer accepts** — a guaranteed 401. ⚠️ **Corrected:** this was previously described here as a "success-shaped failure that does not throw", and that is **false on this path**. `packages/civitai-moderation/src/client.ts` logs via `onFailure` **and `throw err`**; `run.ts` rethrows as `BotAccountReportError`; `job.ts` rethrows; the webhook 500s. The failure is loud. The "does not throw" reading belongs to the image-moderation path and was transplanted.
2. **The abuse-detection schema applied** to `MODERATOR_DATABASE_URL` as the application role — `apps/moderator/abuse-detection/schema.sql`, applied by hand per this repo's convention. Without the `(detector, started_at)` unique index every POST 500s with a `42P10`.
3. **A decision on where the job runs.** It is registered in `run-jobs` like every other cron; no dedicated queue or `dedicated: true` is set, which is only correct if a single scheduler fires it. Worth confirming before it is scheduled rather than after.
4. ✅ **Index review — ANSWERED, and it is not a blocker.** A read-only `pg_indexes` check on a replica found `User_createdAt_idx` (btree on `createdAt`, **partial**, `WHERE deletedAt IS NULL`) and `Model_userId` both present. The cohort query filters `deletedAt: null`, so it matches the partial index's predicate: the 24h window is **not** an unindexed walk of the `User` table.

`lockExpiration` on this job is widened to **30 minutes**. The run-jobs route hard-caps the lock hold at `lockExpiration` and then **releases the lock while the run continues**, so a run longer than the expiration is how a retry starts a second full run whose different `startedAt` the board's `(detector, started_at)` key cannot merge. See the cancellation note below.

---

# Round-1 audit fix pass

Findings from the [round-1 adversarial audit](https://github.com/civitai/civitai/pull/4613#issuecomment-5535303647). **The shadow property is unchanged and re-verified: this mutes nobody, bans nobody, and writes no `UserRestriction` row.**

### 🔴 F2 — the cap truncated the NEWEST end, i.e. the registration wave

`cohort.ts` paged keyset-**ascending** on `User.id`, so at `MAX_COHORT_ACCOUNTS` the unread remainder was the *highest* ids — the most recent signups. Measured against production, that is worse than the audit could establish: **8,863 signups/24h against a 10,000 cap is ~13% headroom**, so the cap never trips on an ordinary day and trips for the first time on exactly the day a registration wave lands, discarding the accounts the detector exists to find while `capped: true` reads as *"we saw the first 10,000"*.

- **Keyset reversed to descending.** `orderBy: { id: 'desc' }`, `id: { lt: before }`, seeded with `before: undefined` — Prisma drops an undefined field from the `WHERE` clause, where a sentinel would have to be a real integer inside `int4`. `id` is the primary key, so the order stays **total** and the keyset stays stable. Descending is also the stabler walk under concurrent inserts: new signups land *above* the seed page rather than being a moving target.
- **The truncation sentence now names which end.** "TRUNCATED at the N-account cap" alone is read as "we saw the first N", and in a signup window "first" means oldest — the opposite of what the walk does.
- **`MAX_COHORT_ACCOUNTS` 10,000 → 25,000.** Secondary, and said as such: **the direction fix is what makes the cap safe at any value.** 25,000 is ~2.8× the measured baseline, so an ordinary day plus a wave of nearly twice normal daily signups still fits and the cap goes back to being a ceiling on work rather than a daily filter. Still bounded: at most 50 account pages and 200 `groupBy` reads.

### 🟡 F1 — the job shipped scheduled, so merging enabled it

Now `UNRUNNABLE_JOB_CRON`. See **Deployment** above for what must be true before a real cron is restored, and for the `pg_indexes` answer that resolves the scan-cost half of this concern.

### 🟡 F3 — the no-write guard had three demonstrated escapes

Each of a **subdirectory** module, a **dynamic** `await import(...)` and a **double-quoted** specifier left the base guard **6/6 green** — reproduced here against the base files before fixing. All three closed:

- the module walk **recurses** (the subdirectory hole is the one that would actually be walked, because heuristics are the announced next change and they land in `heuristics/`);
- one alternation matches `from`, `import(...)` and `require(...)` in **both quote styles**, written once so a fourth spelling is added in one place;
- the hand-maintained five-basename list is replaced by an **exhaustiveness check** — every `.ts` file in the tree must be scanned, graded against a *different* enumeration mechanism (`readdirSync(..., { recursive: true })`) so the two cannot share a bug and agree on it.

Also closed while here: every `run.test.ts` case injected `heuristics`, so the production registry `BOT_ACCOUNT_HEURISTICS` was never exercised by the real-`dbWrite`-spy test. It now is.

### 🟡 F4 — "has posted" counted content that is not there

The user side was filtered on `bannedAt`/`deletedAt`; the content side on **nothing but `userId`**. So unattached images, `Pending`/blocked ingestion, draft and soft-deleted models, and hidden or TOS-flagged comments all counted as "posted" — and the finding's reason string then told a moderator to go and look at them.

**The definition chosen: content a moderator can open right now.**

| Surface | Counted | Why |
|---|---|---|
| `Comment` / `CommentV2` | `hidden` not true, `tosViolation: false` | both are moderation outcomes — it is already off the page. `hidden` is a nullable boolean, so `{ not: true }` and not `false`, matching `jobs/entity-moderation.ts` |
| `Model` | `status: Published`, `deletedAt: null`, `tosViolation: false` | `Draft`/`Training` are not posted yet; `Unpublished`/`UnpublishedViolation`/`Deleted` were posted and withdrawn; `Scheduled` has no page to open |
| `Image` | `postId` not null, `tosViolation: false`, ingestion not `Blocked`/`NotFound` | a detached image is a leftover with nowhere to be viewed |

🔴 **`ingestion: Pending` is deliberately KEPT, and it is the one judgement call.** A fresh upload sits Pending for minutes, so a bot wave's images are Pending *by definition* at the instant this detector looks at them — excluding Pending would be excluding the signal. Unlike `Blocked`, it is a scan that has not finished rather than a decision to remove.

The reason string now reads *"Posted N visible comment(s), N published model(s), N visible image(s) — counts exclude drafts, unattached uploads, blocked uploads, hidden or TOS-flagged content and anything already removed."*

### 🟢 F5 — the comment claimed a property the code does not have

`cohort.ts` said a detector *"cannot reach a write client"*. False: `packages/civitai-db/src/client.ts` builds `dbRead` as `singleClient ? dbWrite : new PrismaClient(replica)`, so wherever the replica URL equals the database URL the two are the **same object**, `.user.update()` included. The comment now says what actually holds the property — the compile-time `CohortDb` structural port and the asserted source ledger — and says explicitly that neither depends on `dbRead` being a different connection.

### 🟢 F6 — the body's "success-shaped failures" claim was false

Corrected in **Deployment** above: the missing-token path throws, and the webhook 500s.

### 🟢 F7 — cancellation, and the lock that frees mid-run

**Wired:** `checkCanceled` is consulted **once per cohort page** and **once before each report send** — the two places this run can be doing work nobody is waiting for — supplied in production from `JobContext.checkIfCanceled`.

**Scoped, not half-fixed:** the second half of the finding — that past `lockExpiration` the refresher `release()`s while the run continues, so a retry can start a second full run whose different `now()` makes `(detector, started_at)` unmergeable — is **a property of the shared run-jobs route** (`acquireLock`'s `ttl -= LOCK_REFRESH_INTERVAL; if (ttl <= 0) release()`), not of this detector. Fixing it properly means changing a mechanism every job in the repo is on, which does not belong in this PR. What is done here instead:

1. cancellation, so a cancelled run stops promptly rather than continuing to POST; and
2. `lockExpiration: 30 * 60` on this job, so a full capped walk finishes **inside** the hold and the overrun window is not reached in the first place.

If a run ever does exceed 30 minutes, the duplicate-set failure mode returns — it is a mitigation, not a proof. The general fix (refreshing the lock for as long as the run holds it, or cancelling the run when the hold lapses) is a separate change against the route.

## Fix-round verification

**Red at base.** Running the fixed tests against the base sources: **24 tests fail**, with named reasons — e.g. `expected { gt: undefined } to deeply equal { lt: 41 }` (keyset), `expected [11, 10, 9, 11, 10, 9, 11] to deeply equal [11, 10, 9, 8, 7, 6, 5]` (truncation direction), `expected '20 3 * * *' to be '0 0 5 31 2 ?'` (cron), `expected 300 to be greater than or equal to 1800` (lock), `expected 10000 to be greater than or equal to 17726` (cap). Five of the 24 are red only because the symbol does not exist at base (`TypeError: modelCountArgs is not a function`); those are attributed by mutation instead, below.

**Base-guard reproduction.** The three F3 escapes were planted into the base tree one at a time: `no-write-surface.test.ts` reported **6/6 green** in every case, reproducing the audit exactly. Post-fix, each is caught, and each of the guard's own closures is pinned by its own control test.

**Mutation battery — 22 mutants, each applied alone, tree restored from a `cp -a` backup between each, controls green before *and* after (102/102).** Every mutant died, and each is named by the assertion that killed it:

| # | Mutation | Killed by |
|---|---|---|
| M1 | `orderBy: 'desc'` → `'asc'` | `pages by keyset on id, DESCENDING` — `expected { gt: … }` |
| M2 | `id: { lt }` → `{ gt }` | same test, on `where.id` |
| M3 | seed gains a bogus `{ lt: 0 }` bound | `seeds the walk with no id bound at all` |
| M4 | cursor advances from the page **head** | 8 tests, incl. `TRUNCATES THE OLDEST END` and `walks strictly downwards` |
| M5 | cap back to 10,000 | `leaves room for a registration wave, not 13% headroom` |
| M6 | truncation sentence stops naming the end | `says WHICH END the cap dropped` |
| M7 | `Image.postId` filter dropped | `counts only images attached to a post` |
| M8 | `Image.ingestion` filter dropped | same test |
| M9 | `Model.status` dropped | `counts only published, undeleted, un-flagged models` |
| M10 | `Model.deletedAt` dropped | same test |
| M11 | `hidden: { not: true }` → `hidden: false` | `excludes hidden and TOS-flagged comments` |
| M12 | reason string loses its qualifier | 2 tests, incl. `says what the counts EXCLUDE` |
| M13 | cron back to `'20 3 * * *'` | `carries the unrunnable cron` |
| M14 | `lockExpiration` back to the default | `holds its lock for longer than a capped run can take` |
| M15 | `checkCanceled()` removed from the walk | 2 cancellation tests |
| M16 | `checkCanceled()` removed before send | `stops at the next report when the job is canceled` |
| M17 | `BOT_ACCOUNT_HEURISTICS` emptied | `holds with the PRODUCTION heuristic registry` + the registry test |
| M18 | guard walk goes flat again | `a module in a SUBDIRECTORY is scanned` |
| M19 | guard matches only single-quoted `from` | `sees an import however it is spelled` |
| E1 | a write + a restriction import planted in `heuristics/ip-cluster.ts` | 3 ledger tests (db-ops, imports, `dbWrite` name) |
| E2 | a dynamic `import('…user-restriction.service')` planted in `run.ts` | the import ledger |
| E3 | a double-quoted import of the same, planted in `run.ts` | the import ledger |

## What the fix round did NOT verify

- **Still nothing has run against a real database.** The cohort SQL — now with four different per-surface `WHERE` clauses — has never executed. It typechecks against the real generated Prisma client, which is what pins `hidden: { not: true }`, `status`, `postId` and `ingestion` as valid filters on those models; it is not evidence about the plan or the row counts.
- **The truncation-direction fixture is a test of the composition, not of the SQL.** `collectCohort` is direction-agnostic on its own — it passes a cursor to a reader. The direction lives in `newAccountPageArgs` (asserted directly), in the cursor advancing from the page's tail (asserted directly), and in `createCohortReader` handing the built args to the client verbatim (asserted directly). The "which accounts survive" test states the property end to end **given a reader that honours the contract**; it does not prove Postgres orders the rows.
- **The 8,863 figure is one measurement on one day**, not a distribution, and it is recorded in a test constant as the number the cap was chosen against — not as a live value.
- **`ingestion: Pending` being the right call is a judgement, not a measurement.** How much of a new account's image content is Pending at scan time has not been measured; the first shadow runs are what would say.
- **Cancellation is proved against an injected `checkCanceled`, not against a real closed response.** The production wiring (`ctx.checkIfCanceled`) is one line and is typechecked, not exercised end to end.

## NOT verified (original PR)

- **Nothing has been run against a real database.** Every test uses fakes or the canonical mocked client. The cohort SQL has never executed.
- ~~**Index coverage is unverified**~~ — **RESOLVED.** `pg_indexes` was checked read-only on a replica: `User_createdAt_idx` (partial, `WHERE deletedAt IS NULL`) and `Model_userId` both exist. The Prisma schema declares neither, and the migrations carry zero `CREATE INDEX` statements across all 770 files, so the declarations were never evidence either way — the live catalog is. The content-side filters added in the fix round (`Model.status`, `Image.postId`/`ingestion`, `Comment.hidden`) are **not** index-backed on their own; they are additional predicates on a `userId IN (…)` seek of at most `COHORT_PAGE_SIZE` ids, not a new access path.
- **No live report has ever reached the board.** The endpoint, its auth, and `recordAbuseRun` are exercised only by their own existing tests, not by this producer.
- **`createCohortReader`'s real Prisma calls are typechecked, not executed.** The seam test proves the built arguments are passed through, against a fake.
- **Cohort size in production is now measured, once.** The 24h signup baseline is **8,863 accounts**, counted read-only on a replica. `MAX_COHORT_ACCOUNTS` is **25,000** against that (~2.8x). It is one measurement on one day, not a distribution — the first shadow runs' `cohort_scanned` / `cohort_capped` are still what will say whether the number holds.
- **The batch-timestamp offset assumes millisecond resolution end to end.** `timestamptz` holds microseconds and `Date` holds milliseconds, so this holds — but it has not been observed round-tripping through the real table.
- **The `bot-account` `UserRestriction` seam is untouched and unexercised by this PR.** Its own tests still cover it.
- **`abuseReport()` on the shared client is not covered by a network-level test.** It is `call()` plus a `.parse`, and the parse is covered indirectly by every report payload in `report.test.ts` and `run.test.ts` being run through the same schema.

