### PR TITLE
feat(app-blocks): allowlist three more blocks for the init-fragment fast path

### DIFF
--- a/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
+++ b/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
@@ -248,22 +248,25 @@ describe('blockInitFragmentEnabled — the PRODUCTION allowlist', () => {
     expect(BLOCK_INIT_FRAGMENT_ALLOWLIST.has('playable-collections')).toBe(false);
 
     const allowedAnyway = new Set([...BLOCK_INIT_FRAGMENT_ALLOWLIST, 'playable-collections']);
-    // Positive control: with the denylist EMPTY the same call returns true, so a
-    // false below is the denylist and not the surface or a missing entry.
-    expect(
-      blockInitFragmentEnabledWith(
-        { surface: 'page-run', slug: 'playable-collections', blockId: 'playable-collections' },
-        allowedAnyway,
-        new Set<string>()
-      )
-    ).toBe(true);
-    expect(
-      blockInitFragmentEnabledWith(
-        { surface: 'page-run', slug: 'playable-collections', blockId: 'playable-collections' },
-        allowedAnyway,
-        BLOCK_INIT_FRAGMENT_DENYLIST
-      )
-    ).toBe(false);
+
+    // 🔴 EACH KEY ALONE, not just the combined shape — the same rule the `it.each`
+    // above states, which the first version of THIS test broke by passing `slug`
+    // and `blockId` together. Measured: with both keys supplied, deleting EITHER
+    // denylist branch on its own left this test green, because the surviving branch
+    // still matched. Driving each key alone is what makes a single deleted branch
+    // fail here rather than only in the pre-existing per-key tests.
+    for (const args of [
+      { surface: 'page-run', slug: 'playable-collections' },
+      { surface: 'page-run', blockId: 'playable-collections' },
+      { surface: 'page-run', slug: 'playable-collections', blockId: 'playable-collections' },
+    ] as const) {
+      // Positive control: with the denylist EMPTY the same call returns true, so a
+      // false below is the denylist winning and not the surface or a missing entry.
+      expect(blockInitFragmentEnabledWith(args, allowedAnyway, new Set<string>())).toBe(true);
+      expect(
+        blockInitFragmentEnabledWith(args, allowedAnyway, BLOCK_INIT_FRAGMENT_DENYLIST)
+      ).toBe(false);
+    }
   });
 
   it('🔴 enables the fast path for app-requests on page-run', () => {

--- a/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
+++ b/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
@@ -192,7 +192,78 @@ describe('blockInitFragmentEnabled — the PRODUCTION allowlist', () => {
     // Pinned as a sorted array rather than `.has(...)` + `.size`: an exact
     // whole-set comparison fails on an ADDITION as well as a removal, and names
     // the offending entry in its own diff.
-    expect([...BLOCK_INIT_FRAGMENT_ALLOWLIST].sort()).toEqual(['app-requests']);
+    expect([...BLOCK_INIT_FRAGMENT_ALLOWLIST].sort()).toEqual([
+      'app-requests',
+      'custom-generators',
+      'model-benchmarking',
+      'sensei',
+    ]);
+  });
+
+  // 🔴 EACH NEW BLOCK IS ASSERTED ON ITS OWN, not covered by the `app-requests`
+  // case below. Three entries went in together, and one shared assertion would
+  // pass with any single member present — which is how a batch addition loses a
+  // member silently. Both keys and each key alone, for the same reason the
+  // `app-requests` case gives: a regression dropping one lookup branch still
+  // passes if only the combined shape is tested.
+  it.each(['custom-generators', 'model-benchmarking', 'sensei'])(
+    '🔴 enables the fast path for %s on page-run, by either key',
+    (id) => {
+      expect(blockInitFragmentEnabled({ surface: 'page-run', slug: id, blockId: id })).toBe(true);
+      expect(blockInitFragmentEnabled({ surface: 'page-run', slug: id })).toBe(true);
+      expect(blockInitFragmentEnabled({ surface: 'page-run', blockId: id })).toBe(true);
+    }
+  );
+
+  // The surface check must hold for the new entries too: allowlisting a PUBLISHED
+  // app must never reach a moderator's preview of its next UNREVIEWED submission,
+  // nor the author's dev tunnel. Paired with the page-run assertion above, which is
+  // what stops this being vacuous — the SAME id returns true on an eligible
+  // surface, so only the surface check can be producing false here.
+  it.each(['custom-generators', 'model-benchmarking', 'sensei'])(
+    '🔴 does NOT leak onto dev-tunnel or review-preview for %s',
+    (id) => {
+      for (const surface of ['dev-tunnel', 'review-preview'] as const) {
+        expect(blockInitFragmentEnabled({ surface, slug: id, blockId: id })).toBe(false);
+      }
+    }
+  );
+
+  // 🔴 The DENYLIST must still beat the widened allowlist. `playable-collections`
+  // shipped the same boot skeleton as the three above, in the same batch, and is
+  // the one block of that set which reads `location.hash` for its own routing — so
+  // it is deliberately NOT allowlisted.
+  //
+  // 🔴 THIS TEST WAS VACUOUS AS FIRST WRITTEN and the rewrite is the point. It
+  // asserted `blockInitFragmentEnabled({slug:'playable-collections'}) === false`,
+  // which passes for the WRONG REASON: that block is refused because it is not in
+  // the allowlist, not because the denylist works. Rewiring the production wrapper
+  // to pass an EMPTY denylist left it green — a guard reading as protection while
+  // providing none.
+  //
+  // What it pins now is precedence against the REAL denylist: feed a synthetic
+  // allowlist that DOES contain the block, alongside the real denylist, so the only
+  // thing that can produce `false` is the denylist check winning.
+  it('🔴 the REAL denylist beats an allowlist that contains the same block', () => {
+    expect(BLOCK_INIT_FRAGMENT_ALLOWLIST.has('playable-collections')).toBe(false);
+
+    const allowedAnyway = new Set([...BLOCK_INIT_FRAGMENT_ALLOWLIST, 'playable-collections']);
+    // Positive control: with the denylist EMPTY the same call returns true, so a
+    // false below is the denylist and not the surface or a missing entry.
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'page-run', slug: 'playable-collections', blockId: 'playable-collections' },
+        allowedAnyway,
+        new Set<string>()
+      )
+    ).toBe(true);
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'page-run', slug: 'playable-collections', blockId: 'playable-collections' },
+        allowedAnyway,
+        BLOCK_INIT_FRAGMENT_DENYLIST
+      )
+    ).toBe(false);
   });
 
   it('🔴 enables the fast path for app-requests on page-run', () => {

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -125,14 +125,37 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   //
   // (b) READS `location.hash` NOWHERE AT RUNTIME. Measured per block over its
   //     shipped `src/`: the only occurrences are inside each block's own
-  //     `bootFragment.test.tsx`, which SETS the hash to drive its reader. No app
-  //     code reads or rewrites it, so the SDK transport's strip-after-init cannot
-  //     race a competing consumer. This is the check `playable-collections` fails.
+  //     `bootFragment.test.tsx`, which SETS the hash to drive its reader. This is
+  //     the check `playable-collections` fails — it reads AND writes the hash for
+  //     its own routing.
   //
-  // KEYING: all three are page-mounted — `page` declared, `slots` empty, and each
-  // `blockId` equals its store slug — so, exactly as for `app-requests` above, one
-  // string covers whichever key the surface passes. None of them mounts in a model
-  // slot; if one ever does, re-read the KEYING ASYMMETRY note before trusting this.
+  //     🔴 BUT `grep location.hash` IS NOT THE CRITERION, and reading it as one is
+  //     how the next block gets admitted wrongly. `custom-generators` rewrites the
+  //     URL through `location.href` + `history.replaceState` (its `App.tsx`, via
+  //     `stripDeeplinkParam`, which strips only `?g=` and PRESERVES the fragment) —
+  //     invisible to a hash-shaped grep. It is safe here only because the SDK's
+  //     `seedFromFragment` strips synchronously at transport start, and that call
+  //     reads `location.href` LIVE, so it cannot re-instate an already-stripped
+  //     fragment. A block that round-tripped a CAPTURED href — one commit away from
+  //     this shape — would pass the same grep and re-instate it. The criterion is
+  //     "nothing re-instates the fragment after the transport strips it", so check
+  //     `location.href`/`replaceState`/`pushState` too, not just `location.hash`.
+  //
+  // KEYING: all three are page-mounted — `page` declared, no `slots` key at all,
+  // and each `blockId` equals its store slug — so, exactly as for `app-requests`
+  // above, one string covers whichever key the surface passes.
+  //
+  // 🔴 AN ENTRY IS PER-BLOCK, NOT PER-SURFACE, so it PRE-AUTHORISES the model slot.
+  // The KEYING ASYMMETRY note above warns about the inert direction (a slug-only
+  // entry doing nothing on a slot); this is the opposite one and it is the one that
+  // widens. `IframeHost` calls the gate with `surface: 'model-slot'` and the
+  // `blockId` alone, and these entries ARE blockIds — so if any of these three
+  // later adds a `slots` entry in ITS OWN repo and clears App-Block moderation, the
+  // fragment starts being appended on model pages with no change here, no civitai
+  // reviewer involved and no test going red. Low impact (the fragment carries only
+  // theme/renderMode/blockInstanceId, all of which BLOCK_INIT already delivers) but
+  // the decision widens without anyone taking it. If a block here goes slot-mounted,
+  // re-evaluate the entry for that surface rather than inheriting this one.
   'custom-generators',
   'model-benchmarking',
   'sensei',

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -129,17 +129,35 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   //     the check `playable-collections` fails — it reads AND writes the hash for
   //     its own routing.
   //
-  //     🔴 BUT `grep location.hash` IS NOT THE CRITERION, and reading it as one is
-  //     how the next block gets admitted wrongly. `custom-generators` rewrites the
-  //     URL through `location.href` + `history.replaceState` (its `App.tsx`, via
-  //     `stripDeeplinkParam`, which strips only `?g=` and PRESERVES the fragment) —
-  //     invisible to a hash-shaped grep. It is safe here only because the SDK's
-  //     `seedFromFragment` strips synchronously at transport start, and that call
-  //     reads `location.href` LIVE, so it cannot re-instate an already-stripped
-  //     fragment. A block that round-tripped a CAPTURED href — one commit away from
-  //     this shape — would pass the same grep and re-instate it. The criterion is
-  //     "nothing re-instates the fragment after the transport strips it", so check
-  //     `location.href`/`replaceState`/`pushState` too, not just `location.hash`.
+  //     🔴 BUT `grep location.hash` IS NOT ENOUGH ON ITS OWN, and reading it as the
+  //     whole test is how the next block gets admitted wrongly. `custom-generators`
+  //     rewrites the URL through `location.href` + `history.replaceState` (its
+  //     `App.tsx`, via `stripDeeplinkParam`, which strips only `?g=` and PRESERVES
+  //     the fragment) — invisible to a hash-shaped grep. So apply a SECOND check
+  //     ALONGSIDE the read one, never instead of it: nothing may RE-INSTATE the
+  //     fragment. Grep `location.href` / `replaceState` / `pushState` as well.
+  //     (`playable-collections` fails the READ half, which is why the read half
+  //     stays — a block can re-instate nothing and still be disqualified.)
+  //
+  //     🔴 AND DO NOT REST THAT ON THE SDK'S STRIP — IT DOES NOT RUN FOR ANY BLOCK
+  //     LISTED HERE. An earlier revision of this comment said `custom-generators` is
+  //     safe "only because `seedFromFragment` strips synchronously at transport
+  //     start". Measured, that premise is false in production: every block above is
+  //     `trust_tier: 'unverified'` with `sandbox: "allow-scripts allow-forms"`, and
+  //     `sandbox.ts` adds `allow-same-origin` only for `TRUSTED_TIERS`
+  //     (`internal`/`verified`). The frame therefore runs at an OPAQUE ORIGIN, the
+  //     `history.replaceState` inside `seedFromFragment` throws, and that throw is
+  //     swallowed by a `catch` documented as "nothing depends on this" — so the
+  //     fragment is NOT stripped and persists in `location.hash` for the session.
+  //     These three are safe because of (b) itself — nothing in them reads or
+  //     re-instates it — not because of a strip that never executes.
+  //
+  //     Why that distinction is worth the words: the strip DOES start working if a
+  //     block is later promoted to `verified`/`internal`. A maintainer who admitted
+  //     a block on "the transport already stripped it, so a captured href is clean"
+  //     would have been right at `unverified` only by accident (that block's own
+  //     write throws too), and wrong the moment the tier changes — reaching the
+  //     exact hazard along a path this comment would have declared closed.
   //
   // KEYING: all three are page-mounted — `page` declared, no `slots` key at all,
   // and each `blockId` equals its store slug — so, exactly as for `app-requests`
@@ -151,8 +169,8 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   // widens. `IframeHost` calls the gate with `surface: 'model-slot'` and the
   // `blockId` alone, and these entries ARE blockIds — so if any of these three
   // later adds a `slots` entry in ITS OWN repo and clears App-Block moderation, the
-  // fragment starts being appended on model pages with no change here, no civitai
-  // reviewer involved and no test going red. Low impact (the fragment carries only
+  // fragment starts being appended on model pages with no change here, no reviewer
+  // ON THIS REPO involved and no test going red. Low impact (the fragment carries only
   // theme/renderMode/blockInstanceId, all of which BLOCK_INIT already delivers) but
   // the decision widens without anyone taking it. If a block here goes slot-mounted,
   // re-evaluate the entry for that surface rather than inheriting this one.

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -166,9 +166,19 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   //     swallowed by a `catch` documented as "nothing depends on this" — so the
   //     fragment is NOT stripped and persists in `location.hash` for the session.
   //     These three are safe on their own terms, not because of a strip that never
-  //     executes: none of them READS the fragment, and the one URL write among them
-  //     (`custom-generators`, above) is built from a LIVE href read, so it cannot
-  //     re-instate anything.
+  //     executes: none of them CONSUMES the fragment — none branches on it, routes
+  //     on it, or stores it — and the one URL write among them (`custom-generators`,
+  //     above) is built from a LIVE href read, so it cannot re-instate anything.
+  //
+  //     🔴 "Consumes", not "reads", and the difference is not pedantry:
+  //     `location.href` CONTAINS the fragment, so `custom-generators` does read it,
+  //     incidentally, every time `getHref()` runs. An earlier draft of this line
+  //     said "none of them READS the fragment", which is false for exactly that
+  //     block and would have sent the next maintainer looking for a contradiction
+  //     that is really just imprecision. Criterion (b) is about a block that reads
+  //     the fragment TO USE IT; an href round-trip that passes it through untouched
+  //     is not that, and a grep for `location.hash` alone will not tell you which
+  //     kind you are looking at.
   //
   //     Why that distinction is worth the words: the strip DOES start working if a
   //     block is later promoted to `verified`/`internal`. A maintainer who admitted

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -136,8 +136,24 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   //     the fragment) — invisible to a hash-shaped grep. So apply a SECOND check
   //     ALONGSIDE the read one, never instead of it: nothing may RE-INSTATE the
   //     fragment. Grep `location.href` / `replaceState` / `pushState` as well.
-  //     (`playable-collections` fails the READ half, which is why the read half
-  //     stays — a block can re-instate nothing and still be disqualified.)
+  //
+  //     🔴 A HIT ON THAT SECOND CHECK IS NOT AUTOMATICALLY A DISQUALIFICATION, and
+  //     `custom-generators` IS such a hit — so read this before concluding the entry
+  //     below is wrong. What separates safe from unsafe is LIVE versus CAPTURED:
+  //     its `getHref: () => window.location.href` is read at call time, so whatever
+  //     it writes back carries the CURRENT fragment and the write is a no-op with
+  //     respect to it. The unsafe shape is a block that CAPTURES an href early
+  //     (at mount, in a ref, in state) and writes that stale copy back later — that
+  //     one really can re-instate a fragment the transport had removed, and it
+  //     passes a `location.hash` grep exactly as this one does. So the second check
+  //     is a prompt to go LOOK at each hit, not a filter that rejects on sight.
+  //
+  //     The read half stays because the two checks catch different things: a block
+  //     can re-instate nothing and still be disqualified for reading the fragment
+  //     for its own routing. `playable-collections` is not a clean illustration of
+  //     that — it happens to fail BOTH halves (it reads the hash AND calls
+  //     `replaceState`), so it is evidence for neither half being independently
+  //     necessary. Keep the read half on the principle, not on that example.
   //
   //     🔴 AND DO NOT REST THAT ON THE SDK'S STRIP — IT DOES NOT RUN FOR ANY BLOCK
   //     LISTED HERE. An earlier revision of this comment said `custom-generators` is
@@ -149,8 +165,10 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   //     `history.replaceState` inside `seedFromFragment` throws, and that throw is
   //     swallowed by a `catch` documented as "nothing depends on this" — so the
   //     fragment is NOT stripped and persists in `location.hash` for the session.
-  //     These three are safe because of (b) itself — nothing in them reads or
-  //     re-instates it — not because of a strip that never executes.
+  //     These three are safe on their own terms, not because of a strip that never
+  //     executes: none of them READS the fragment, and the one URL write among them
+  //     (`custom-generators`, above) is built from a LIVE href read, so it cannot
+  //     re-instate anything.
   //
   //     Why that distinction is worth the words: the strip DOES start working if a
   //     block is later promoted to `verified`/`internal`. A maintainer who admitted

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -112,6 +112,30 @@ export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string
   // transport strips the fragment during init. That hash-reading hazard is
   // what put `playable-collections` on the DENYLIST; this block is clear of it.
   'app-requests',
+
+  // The three below were added together and each was checked against BOTH halves
+  // of the bar above, per block — not inherited from `app-requests` because they
+  // shipped in the same batch.
+  //
+  // (a) SHIPS A DECODING READER. Each now serves an inline pre-paint fragment
+  //     reader in its own `index.html` that records the resolved theme on
+  //     `data-civitai-boot-theme`, and each declares `bootSkeleton: true`, so the
+  //     host stands its veil down and the block's own boot paint is what a viewer
+  //     actually sees. Verified against the SERVED artifact, not the repo.
+  //
+  // (b) READS `location.hash` NOWHERE AT RUNTIME. Measured per block over its
+  //     shipped `src/`: the only occurrences are inside each block's own
+  //     `bootFragment.test.tsx`, which SETS the hash to drive its reader. No app
+  //     code reads or rewrites it, so the SDK transport's strip-after-init cannot
+  //     race a competing consumer. This is the check `playable-collections` fails.
+  //
+  // KEYING: all three are page-mounted — `page` declared, `slots` empty, and each
+  // `blockId` equals its store slug — so, exactly as for `app-requests` above, one
+  // string covers whichever key the surface passes. None of them mounts in a model
+  // slot; if one ever does, re-read the KEYING ASYMMETRY note before trusting this.
+  'custom-generators',
+  'model-benchmarking',
+  'sensei',
 ]);
 
 /**


### PR DESCRIPTION
Adds `custom-generators`, `model-benchmarking` and `sensei` to `BLOCK_INIT_FRAGMENT_ALLOWLIST`.

## Why

All three now ship an inline pre-paint fragment reader and declare `bootSkeleton: true`, so the full-page run host stands its loading treatment down and the block's own boot paint is what a viewer actually sees. Without an allowlist entry that paint has to **guess** the theme from `prefers-color-scheme`; with one it is the host's real answer. The difference is between "usually right" and "cannot disagree" — and a wrong guess repaints at `BLOCK_INIT`, which is exactly the flash the boot skeleton exists to remove.

The readers are already deployed and inert. This is the switch that makes them do anything.

## Both halves of the bar, checked per block

These three shipped in one batch, so nothing here is inherited from `app-requests`:

- **(a) Ships a decoding reader** — each serves an inline reader recording the resolved theme on `data-civitai-boot-theme`. Verified against the **served artifact** in each running container, not against the repo.
- **(b) Reads `location.hash` nowhere at runtime** — measured over each block's shipped `src/`: the only occurrences are inside its own `bootFragment` test, which *sets* the hash to drive the reader. No app code reads or rewrites it, so the transport's strip-after-init cannot race a competing consumer. This is precisely the check `playable-collections` fails, and it remains denylisted.

**Keying:** all three are page-mounted, `blockId` equals the store slug, `slots` empty — so one string matches whichever key the surface passes, the same shape as `app-requests`. Not safe to copy to a slot-mounted block, which knows only a `blockId`.

## Tests

The whole-set ledger is updated deliberately — it is designed to fail on an addition, which is what makes widening a decision rather than a drift.

Added **per-block** enablement and surface-leak assertions rather than one shared case: three entries landing together means a single assertion would pass with any one member present, which is how a batch addition loses a member silently.

## 🔴 One added test was vacuous, and the rewrite is the point

The denylist test as first written asserted that `playable-collections` is refused. That passes for the **wrong reason** — the block is refused for *not being allowlisted*, not because the denylist works. I proved it by rewiring the production wrapper to pass an **empty denylist**: the test stayed green. A guard reading as protection while providing none.

It now feeds a synthetic allowlist that **does** contain the block alongside the **real** denylist, with a positive control showing the same call returns `true` when the denylist is empty — so a `false` can only be the denylist check winning.

## 🔴 A gap I found and did not close

**No test — pre-existing or added — catches the production wrapper being handed the wrong lists.** The rewrite above calls the injectable `blockInitFragmentEnabledWith` and therefore bypasses `blockInitFragmentEnabled`. Closing it behaviourally needs a block present on **both** lists, and none exists. The wrapper is a three-line delegation, so the exposure is small — but it is recorded here rather than papered over, and it is worth knowing before someone assumes the denylist is covered end to end.

Also worth stating plainly: five of the six mutants I ran against this gate were killed by **pre-existing** tests, not the ones added here. That file already covers the lookup branches, denylist precedence and the surface gate through its injectable-list tests. The added tests earn their place by naming each new block, not by covering new mechanism.

## Verification

Gate suite green (23 tests). `pnpm typecheck` clean — **0 type errors**, read from the runner's own summary rather than an exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5cBVVja4n7qzYU1FCBqZ8
