### PR TITLE
feat(apps): widen the /apps container to 2560 and give the store a container-query column ladder

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -342,20 +342,30 @@ export const FILL_MIN_HEIGHT_PX = 300;
  *         usually launched FROM) is exactly it. An app capped below this would
  *         render narrower than the page that linked to it, which reads as a
  *         downgrade rather than a frame.
- *   1920  `APPS_PAGE_CONTAINER_WIDTH` — the deliberate outlier, and it is an
+ *   2560  `APPS_PAGE_CONTAINER_WIDTH` — the deliberate outlier, and it is an
  *         outlier for a reason that does NOT transfer: it exists for card GRIDS
  *         and wide TABLES (`appsPageWidths.ts` records the measurements), which
  *         genuinely spend the space. An app block may be a grid, but it may just
  *         as easily be a single form, and the host cannot tell which.
+ *         ⚠️ IT WAS 1920 WHEN THIS BAND WAS CHOSEN and the ultrawide pass moved it
+ *         to 2560. The gap between the cap and the outlier therefore WIDENED, which
+ *         does not by itself justify widening the cap — see below.
  *
  * 1600 is above every ordinary content measure on the site and below the grid
- * container, i.e. no app is ever narrower than a civitai page and none is ever
- * wider than the widest first-party surface. It also clears the widest
- * app-imposed well (1100) by ~45%, so the cap can never letterbox an app that has
- * already thought about its own width, while leaving a two-pane shell like
- * Notepad or Sensei a ~1350px content pane — the case the cap exists for.
+ * container, i.e. no app is ever narrower than a civitai page. It also clears the
+ * widest app-imposed well (1100) by ~45%, so the cap can never letterbox an app
+ * that has already thought about its own width, while leaving a two-pane shell
+ * like Notepad or Sensei a ~1350px content pane — the case the cap exists for.
  * Concretely it holds five columns of a `minmax(300px, 1fr)` grid (1288 holds
- * four, 1920 holds six).
+ * four, 2560 holds eight).
+ *
+ * 🔴 DO NOT RE-DERIVE THIS CAP FROM "THE WIDEST FIRST-PARTY SURFACE". That phrasing
+ * used to appear here and it is a moving target: the apps container has gone
+ * 1600 → 1920 → 2560 without any of those moves being a statement about how wide a
+ * THIRD-PARTY app should be. The cap's real justification is the two bounds above
+ * it does control — above every ordinary content measure, and comfortably clear of
+ * the widest app-imposed well — neither of which moves when the apps container
+ * does. Widening 1600 is a separate decision with its own evidence.
  *
  * 🔴 THE APP THIS IS PROBABLY WRONG FOR, and why the opt-out ships WITH the cap
  * rather than after it: Playable Collections. Re-read at its DEPLOYED ref

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -311,9 +311,17 @@ export const FILL_MIN_HEIGHT_PX = 300;
  *
  * 🔴 WHO IS ACTUALLY UNDEFENDED — enumerated, because the obvious premise ("apps
  * do not cap themselves") is only half true, and the half that is false is what
- * decides where this value sits. Across the 13 first-party App Block repos — 11
- * with a `page` surface; the other two are `model.sidebar_top` slot blocks and a
- * PAGE cap cannot reach them:
+ * decides where this value sits.
+ *
+ * ⚠️ THE CENSUS BELOW IS A CROSS-REPO READING, NOT SOMETHING THIS REPO CAN CHECK, AND
+ * NOTHING ASSERTS IT. It was taken by reading 13 separate first-party App Block repos
+ * at whatever refs they were at when the cap was chosen; no ref is recorded, no
+ * fixture reproduces it, and every number in it (13 repos, 11 page surfaces, the nine
+ * wells, median 860, max 1100) would silently rot as those repos change. Treat it as
+ * the RATIONALE that was in front of whoever picked 1600, not as a live measurement —
+ * and re-take it, recording refs, before leaning on it to move the cap. Across those
+ * 13 repos as read then — 11 with a `page` surface; the other two are
+ * `model.sidebar_top` slot blocks and a PAGE cap cannot reach them:
  *
  *   · NINE of the eleven page apps DO cap themselves, at 640 / 720 / 720 / 760 /
  *     820 / 880 / 900 / 960 / 1100 px — a hand-copied `contentStyle` well; median
@@ -360,9 +368,9 @@ export const FILL_MIN_HEIGHT_PX = 300;
  * four, 2560 holds eight).
  *
  * 🔴 DO NOT RE-DERIVE THIS CAP FROM "THE WIDEST FIRST-PARTY SURFACE". That phrasing
- * used to appear here and it is a moving target: the apps container has gone
- * 1600 → 1920 → 2560 without any of those moves being a statement about how wide a
- * THIRD-PARTY app should be. The cap's real justification is the two bounds above
+ * used to appear here and it is a moving target: the apps container has taken three
+ * values over time — 1600 → 1920 → 2560 — without any of them being a statement about
+ * how wide a THIRD-PARTY app should be. The cap's real justification is the two bounds above
  * it does control — above every ordinary content measure, and comfortably clear of
  * the widest app-imposed well — neither of which moves when the apps container
  * does. Widening 1600 is a separate decision with its own evidence.

--- a/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostMaxWidth.browser.test.tsx
@@ -341,9 +341,10 @@ describe('PageBlockHost — the app stops growing on a wide display', () => {
     // Lower: below ~1280 the cap would be narrower than the widest ORDINARY
     // civitai content measure (Mantine `xl`, 1320 border-box / 1288 content), i.e.
     // an app would render narrower than the store page that launched it.
-    // Upper: above ~1920 (`APPS_PAGE_CONTAINER_WIDTH`) the cap would be wider than
-    // the widest first-party surface on the site and would stop being a cap at the
-    // sizes that motivated it.
+    // Upper: ~1920 is the width `APPS_PAGE_CONTAINER_WIDTH` held when this bound was
+    // chosen; that constant is now 2560 and the bound deliberately does not follow it
+    // (see `__tests__/pageBlockHostMaxWidth.test.ts` — keeping 1920 is the tighter,
+    // still-true ceiling, and the cap is 1600, nowhere near either).
     expect(hostWidth, 'at 2560x1080 the capped host is implausibly narrow').toBeGreaterThanOrEqual(
       1280
     );

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -271,8 +271,10 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * track a container that exists for card grids and wide tables would weaken the
    * guard for no evidence. Re-deriving the cap from "the widest first-party surface"
    * is exactly the reasoning `PageBlockHost.tsx` now warns against, because that
-   * surface has moved three times (1600 → 1920 → 2560) without any of those moves
-   * being a statement about third-party app width.
+   * surface has taken three VALUES over time (1600 → 1920 → 2560) without any of
+   * those moves being a statement about third-party app width. Precisely:
+   * `APPS_PAGE_CONTAINER_WIDTH` was introduced at 1920 (`a15d275759`) and has moved
+   * ONCE, to 2560; the 1600 predates the constant.
    *
    * The ARITHMETIC that picks a value inside the band lives on the constant's own
    * doc comment; the NUMBERS live here.

--- a/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostMaxWidth.test.ts
@@ -264,9 +264,15 @@ describe('the full-page App Block host caps its width, and the cap is overridabl
    * `APPS_TWO_COLUMN_DETAIL_MEASURE`, the store-preview page an app is launched
    * FROM), so an app would render narrower than the page that linked to it.
    *
-   * Upper 1920: `APPS_PAGE_CONTAINER_WIDTH`, the widest first-party surface on
-   * the site, and it is that wide for card grids and wide tables specifically. At
-   * or above it the cap stops binding at the sizes that motivated it.
+   * Upper 1920: the width `APPS_PAGE_CONTAINER_WIDTH` held when this band was
+   * chosen. ⚠️ THAT CONSTANT IS NOW 2560 — the ultrawide pass moved it — and the
+   * bound is deliberately NOT following it. 1920 is kept as the tighter, still-true
+   * ceiling: the cap is 1600, nowhere near either number, and widening this bound to
+   * track a container that exists for card grids and wide tables would weaken the
+   * guard for no evidence. Re-deriving the cap from "the widest first-party surface"
+   * is exactly the reasoning `PageBlockHost.tsx` now warns against, because that
+   * surface has moved three times (1600 → 1920 → 2560) without any of those moves
+   * being a statement about third-party app width.
    *
    * The ARITHMETIC that picks a value inside the band lives on the constant's own
    * doc comment; the NUMBERS live here.

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -243,9 +243,12 @@ describe('AppListingsMarketplaceBody', () => {
       .element(page.getByRole('button', { name: 'All apps' }))
       .toHaveAttribute('aria-pressed', 'true');
     // Query fired with kind=all default. `limit: 48` (was 24) — the column ladder now
-    // reaches SIX columns on a 2560 container, where 24 is only four rows; the page size
-    // and its relationship to the server's `max(50)` cap are pinned in the blocking unit
-    // suite (`__tests__/appListingGrid.test.ts`).
+    // reaches FIVE columns on a 2560 container, where 24 is under five rows; the page
+    // size and its relationship to the server's `max(50)` cap are pinned in the blocking
+    // unit suite (`__tests__/appListingGrid.test.ts`).
+    // ⚠️ This said "SIX columns … only four rows" until the card-width floor moved 383 →
+    // 460 in this same PR and made six unreachable. Written true, falsified by a later
+    // commit on the same branch.
     expect(mocks.lastArgs).toMatchObject({ kind: 'all', sort: 'top-rated', limit: 48 });
   });
 

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -40,21 +40,6 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
   };
 }
 
-/**
- * The whitespace-stripped CSS Mantine generated for THIS element's own responsive
- * class. `Grid.Col` renders an `InlineStyles` <style> block keyed on a random
- * per-instance class, so scoping to that class keeps the assertions immune to
- * style blocks left behind by other tests in the same document.
- */
-function generatedCssFor(el: HTMLElement): string {
-  const classes = Array.from(el.classList);
-  return Array.from(document.querySelectorAll('style'))
-    .map((s) => s.textContent ?? '')
-    .filter((text) => classes.some((c) => text.includes(`.${c}`)))
-    .join('\n')
-    .replace(/\s+/g, '');
-}
-
 const mocks = vi.hoisted(() => ({
   items: [] as ListingCard[],
   lastArgs: null as null | Record<string, unknown>,
@@ -257,8 +242,11 @@ describe('AppListingsMarketplaceBody', () => {
     await expect
       .element(page.getByRole('button', { name: 'All apps' }))
       .toHaveAttribute('aria-pressed', 'true');
-    // Query fired with kind=all default.
-    expect(mocks.lastArgs).toMatchObject({ kind: 'all', sort: 'top-rated', limit: 24 });
+    // Query fired with kind=all default. `limit: 48` (was 24) — the column ladder now
+    // reaches SIX columns on a 2560 container, where 24 is only four rows; the page size
+    // and its relationship to the server's `max(50)` cap are pinned in the blocking unit
+    // suite (`__tests__/appListingGrid.test.ts`).
+    expect(mocks.lastArgs).toMatchObject({ kind: 'all', sort: 'top-rated', limit: 48 });
   });
 
   test('clicking a kind toggle WRITES kind to the URL (shallow, no scroll)', async () => {
@@ -387,38 +375,39 @@ describe('AppListingsMarketplaceBody', () => {
     await expect.element(page.getByText('No apps yet')).toBeInTheDocument();
   });
 
-  // ── Larger covers (feedback #1): the grid geometry ──────────────────────────
-  // The numbers themselves are pinned in the blocking unit suite
-  // (__tests__/appListingGrid.test.ts). What this asserts is the WIRING: the grid
-  // actually renders with that shared span object, so the two can't drift.
-  test('the grid renders each card with the shared LISTING_GRID_SPAN (xl = 4 columns)', async () => {
+  // ── The grid's STRUCTURE ────────────────────────────────────────────────────
+  // 🔴 THE COLUMN COUNTS MOVED OUT OF THIS FILE, DELIBERATELY. The grid used to be a
+  // Mantine `<Grid>`/`<Grid.Col span={LISTING_GRID_SPAN}>`, which compiled the whole
+  // responsive ladder into a generated `--col-flex-basis` <style> block — so the span
+  // was assertable from the CSSOM without any stylesheet being loaded. It is now a CSS
+  // grid whose column count comes from a CONTAINER QUERY in
+  // `AppListingsMarketplaceBody.module.scss`, and this file's tier deliberately loads
+  // no app cascade (see `test/component-setup.tsx`), so a `grid-template-columns`
+  // assertion here would be reading the UA default and passing on an unstyled element.
+  //
+  // The rendered counts are therefore measured in
+  // `AppListingsMarketplaceBody.columns.browser.test.tsx`, which imports the cascade
+  // itself; the ladder's numbers and its agreement with the stylesheet are pinned in
+  // the blocking unit suite (`__tests__/appListingGrid.test.ts`). What is left HERE is
+  // the structure those two both assume: one cell per card, each carrying the testid,
+  // inside the grid, inside the query container.
+  test('the grid renders one testid-carrying cell per card, nested inside the query container', async () => {
     renderWithProviders(<AppListingsMarketplaceBody />);
     await expect.element(page.getByText('Alpha App')).toBeInTheDocument();
 
     const cols = page.getByTestId('apps-listing-grid-col').elements();
     expect(cols).toHaveLength(mocks.items.length);
 
-    // Mantine Grid.Col compiles the responsive span into a generated <style>
-    // block of `--col-flex-basis` percentages (one media rule per breakpoint).
-    // The OLD `xl: 2.4` (five columns) compiled to a 20% basis; the NEW `xl: 3`
-    // compiles to 25%. So the absence of a 20% basis is a direct, mutation-
-    // sensitive assertion that the five-column xl layout is gone — flip the span
-    // back to 2.4 and this fails. The exact per-breakpoint numbers are pinned in
-    // the blocking unit suite (__tests__/appListingGrid.test.ts).
-    //
-    // Scoped to the styles Mantine generated for THIS column's own random class,
-    // not every <style> in the document — a document-wide scan would make the
-    // negative assertion below sensitive to style leakage from other tests.
-    const css = generatedCssFor(cols[0] as HTMLElement);
-
-    // Every basis Mantine emitted for this column — the base rule first, then one
-    // per breakpoint in ascending order: base 12 → 100% (1 col), sm 6 → 50% (2),
-    // md 4 → 33.3% (3), lg 3 → 25% (4), xl 3 → 25% (4). The OLD `xl: 2.4` compiled
-    // to a 20% basis, so this pins the whole responsive sequence AND proves the
-    // retired 5-column xl is gone. Flipping the span back to 2.4 fails here.
-    const bases = Array.from(css.matchAll(/--col-flex-basis:([\d.]+)%/g)).map((m) => m[1]);
-    expect(bases).toEqual(['100', '50', '33.333333333333336', '25', '25']);
-    expect(css).not.toContain('--col-flex-basis:20%'); // 2.4/12 — the retired 5-col xl
+    const grid = page.getByTestId('apps-listing-grid').element();
+    // Every cell is a DIRECT child of the grid. Load-bearing rather than pedantic: a
+    // CSS grid only lays out its own children, so a cell one wrapper deeper would be
+    // laid out by the wrapper and the column count would silently become 1 — with
+    // `grid-template-columns` still reading exactly right in the CSSOM.
+    for (const col of cols) expect(col.parentElement).toBe(grid);
+    // …and the grid sits inside a container element, which is what `@container`
+    // resolves against. `container-type` on the grid itself would match nothing.
+    expect(grid.parentElement).not.toBeNull();
+    expect(grid.parentElement).not.toBe(grid);
   });
 
   // ── "Recently opened" rail ──────────────────────────────────────────────────

--- a/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
@@ -30,6 +30,7 @@
 import '@mantine/core/styles.css';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import { cleanup } from 'vitest-browser-react';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
@@ -117,6 +118,14 @@ const VIEWPORT = { width: 2880, height: 900 } as const;
  * so the fixture varies exactly one thing.
  */
 async function renderAtContainerWidth(width: number) {
+  // 🔴 CLEAN FIRST, ALWAYS — a test that measures more than one width is the whole point
+  // of this file, and `vitest-browser-react` APPENDS each render rather than replacing
+  // it. Without this the second call leaves TWO grids in the document, `getByText`
+  // throws a strict-mode violation, and — far worse — `document.querySelector` keeps
+  // returning the FIRST (stale) grid, so a loop over widths measures the first width N
+  // times and passes. That is exactly what an earlier version of the floor check below
+  // did: it looped two widths, measured one, and was green.
+  await cleanup();
   await page.viewport(VIEWPORT.width, VIEWPORT.height);
   renderWithProviders(
     <div style={{ width, maxWidth: 'none' }} data-testid="width-harness">
@@ -171,20 +180,29 @@ beforeEach(() => {
 /**
  * The measurement points.
  *
- * 🔴 NONE OF THEM SITS ON A THRESHOLD. The rungs are at 736 / 960 / 1168 / 1979 / 2378;
+ * 🔴 NONE OF THEM SITS ON A THRESHOLD. The rungs are at 736 / 960 / 1168 / 2364 / 2840;
  * a fixture placed exactly on one would be the case where a one-pixel mutation of that
  * threshold does not change the outcome, so it would survive a fully green suite for the
  * wrong reason. Every width below overshoots into the middle of its band.
  *
- * 1888 / 2100 / 2560 are the three the change is ABOUT: 1888 is what the retired 1920
- * container reached (its column count must be unchanged), and 2100 / 2560 are the two
- * new rungs. 1000 is the unchanged narrow case.
+ * 🔴 1376 AND 1888 ARE THE COLLISION GUARDS, RENDERED. The card-width floor is 460 and
+ * `4 × 460 + 3 × 16 = 1888`, so a ladder whose narrow half was governed by the floor
+ * would still render four columns at 1888 and would drop 1376 — the `xl` low end — to
+ * three. 1888 is the reassuring one; 1376 is the one that catches it. The arithmetic
+ * half of this lives in `__tests__/appListingGrid.test.ts`; this is the pixels.
+ *
+ * 2450 and 2560 are the new five-column band: 2450 is mid-band (deliberately not 2364,
+ * the rung itself) and 2560 is what the change is nominally about. 2528 is what `/apps`
+ * actually reaches at a 2560 container, so it is measured too rather than inferred.
+ * 1000 is the unchanged narrow case.
  */
 const CASES = [
   { containerWidth: 1000, columns: 3, why: 'unchanged narrow case — the md band' },
-  { containerWidth: 1888, columns: 4, why: 'what the RETIRED 1920 container reached' },
-  { containerWidth: 2100, columns: 5, why: 'the new five-column rung' },
-  { containerWidth: 2560, columns: 6, why: 'the new six-column rung' },
+  { containerWidth: 1376, columns: 4, why: '🔴 COLLISION GUARD — the xl low end (1408 − 32)' },
+  { containerWidth: 1888, columns: 4, why: '🔴 COLLISION GUARD — exactly 4 × 460 + 3 × 16' },
+  { containerWidth: 2450, columns: 5, why: 'mid-band in the new five-column rung' },
+  { containerWidth: 2528, columns: 5, why: 'what /apps reaches at a 2560 container' },
+  { containerWidth: 2560, columns: 5, why: 'a 2560-wide grid — five, not six' },
 ] as const;
 
 describe('the store grid renders the column ladder it declares', () => {
@@ -212,10 +230,11 @@ describe('the store grid renders the column ladder it declares', () => {
     }
   );
 
-  test('🔴 the new WIDE rungs really do clear the card-width floor, measured', async () => {
-    // The floor is arithmetic in the unit tier. Here it is a rendered box: five and six
-    // columns must both leave each card at least as wide as the covers pass shipped.
-    for (const containerWidth of [2100, 2560]) {
+  test('🔴 the new WIDE rung really does clear the card-width floor, measured', async () => {
+    // The floor is arithmetic in the unit tier. Here it is a rendered box: the five-column
+    // band must leave every card at least as wide as the four-up the 1920 container
+    // shipped — that is the whole product decision behind the 460 floor.
+    for (const containerWidth of [2450, 2528, 2560]) {
       const m = await renderAtContainerWidth(containerWidth);
       expect(m.cascadeLoaded).toBe(true);
       expect(
@@ -223,6 +242,37 @@ describe('the store grid renders the column ladder it declares', () => {
         `${m.columns} columns at ${containerWidth}px gave ${m.cellWidth}px cards`
       ).toBeGreaterThanOrEqual(LISTING_CARD_MIN_WIDTH);
     }
+  });
+
+  test('🔴 widening the page makes cards BIGGER than the 1920 container did, measured', async () => {
+    // The direction, not just the threshold. `/apps` at a 2560 container renders 2528 of
+    // grid; the old 1920 container rendered 1888 at four columns = 460px. The new layout
+    // must beat that, or the ultrawide pass has partially reversed the larger-covers one
+    // at exactly the viewports it exists to help.
+    const old1920 = await renderAtContainerWidth(1888);
+    expect(old1920.cascadeLoaded).toBe(true);
+    expect(old1920.columns).toBe(4);
+    expect(old1920.cellWidth).toBe(460);
+
+    const now2560 = await renderAtContainerWidth(2528);
+    expect(now2560.cascadeLoaded).toBe(true);
+    expect(now2560.columns).toBe(5);
+    expect(now2560.cellWidth).toBe(492.8);
+    expect(now2560.cellWidth).toBeGreaterThan(old1920.cellWidth);
+  });
+
+  test('🔴 SIX columns is unreachable at the container cap, measured', async () => {
+    // The rung is declared at 2840 and the container tops out at 2528. Rendering AT the
+    // cap must give five; rendering past the rung must give six — which proves the rung
+    // is real rather than decorative, and that the ladder is 4/5 today by ARITHMETIC
+    // rather than because six was deleted.
+    const atCap = await renderAtContainerWidth(2528);
+    expect(atCap.cascadeLoaded).toBe(true);
+    expect(atCap.columns).toBe(5);
+
+    const pastRung = await renderAtContainerWidth(2900);
+    expect(pastRung.cascadeLoaded).toBe(true);
+    expect(pastRung.columns).toBe(6);
   });
 
   test('🔴 it is a CONTAINER query, not a media query (a narrow grid on a wide screen)', async () => {
@@ -243,17 +293,35 @@ describe('the store grid renders the column ladder it declares', () => {
     expect(listingGridColumnsAt(VIEWPORT.width)).toBe(6);
   });
 
+  test('🔴 the harness really re-renders — two widths in one test give two answers', async () => {
+    // The control for the `cleanup()` above, and for every multi-width test in this file.
+    // Without it these two calls return the SAME measurement and every such test passes
+    // while measuring one width twice.
+    const narrow = await renderAtContainerWidth(1000);
+    const wide = await renderAtContainerWidth(2528);
+    expect(narrow.gridWidth).toBe(1000);
+    expect(wide.gridWidth).toBe(2528);
+    expect(narrow.columns).not.toBe(wide.columns);
+    // …and exactly one grid is in the document at a time, which is the mechanism.
+    expect(document.querySelectorAll('[data-testid="apps-listing-grid"]')).toHaveLength(1);
+  });
+
   test('the fixture set varies the dimension under test and covers both halves of the ladder', () => {
-    // Guard-the-guard: a table of one width, or of four widths in one band, cannot see a
-    // ladder bug at all.
+    // Guard-the-guard: a table of one width, or of several widths in one band, cannot see
+    // a ladder bug at all.
     const widths = CASES.map((c) => c.containerWidth);
     expect(new Set(widths).size).toBe(widths.length);
-    expect(new Set(CASES.map((c) => c.columns))).toEqual(new Set([3, 4, 5, 6]));
+    expect(new Set(CASES.map((c) => c.columns))).toEqual(new Set([3, 4, 5]));
     // And no fixture sits ON a rung — see the note above the table.
     for (const w of widths) {
-      for (const rung of [736, 960, 1168, 1979, 2378]) {
+      for (const rung of [736, 960, 1168, 2364, 2840]) {
         expect(w, `fixture ${w} sits exactly on the ${rung} rung`).not.toBe(rung);
       }
     }
+    // 🔴 THE COLLISION GUARDS MUST BOTH BE PRESENT. 1888 alone is the reassuring half —
+    // a floor-governed narrow half renders four there too — so a table that kept only
+    // 1888 would read as covering this and would not.
+    expect(widths, 'the xl-low-end collision guard was dropped').toContain(1376);
+    expect(widths, 'the 4 × 460 + 3 × 16 collision guard was dropped').toContain(1888);
   });
 });

--- a/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
@@ -36,13 +36,13 @@ import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
-function makeCard(id: string, name: string): ListingCard {
+function makeCard(id: string, name: string, tagline: string | null = 'tag'): ListingCard {
   return {
     id,
     slug: `slug-${id}`,
     kind: 'onsite',
     name,
-    tagline: 'tag',
+    tagline,
     category: null,
     contentRating: null,
     isBeta: false,
@@ -132,7 +132,11 @@ async function renderAtContainerWidth(width: number) {
       <AppListingsMarketplaceBody />
     </div>
   );
-  await expect.element(page.getByText('App 0')).toBeInTheDocument();
+  // 🔴 SETTLE ON THE GRID CELL, NOT ON A CARD'S NAME. Two fixtures use this helper —
+  // the uniform `App N` set and the deliberately uneven mixed-height set — so waiting on
+  // `getByText('App 0')` bound the helper to one of them and made the other time out
+  // 15s per test with a failure that reads like a broken component.
+  await expect.element(page.getByTestId('apps-listing-grid-col').first()).toBeInTheDocument();
   // Two frames so style application and layout have both settled.
   await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
 

--- a/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * `/apps` store grid — the RENDERED COLUMN LADDER.
+ *
+ * 🔴 WHAT ONLY THIS FILE CAN SEE. `__tests__/appListingGrid.test.ts` pins the ladder's
+ * numbers and proves the stylesheet's `@container` rules equal them — but both halves of
+ * that seam are TEXT. Neither can tell you that the container query resolves, that
+ * `container-type: inline-size` was actually applied, that the rules survived the
+ * cascade, or that the cards land on the number of rows the arithmetic says. Those are
+ * pixel facts, and they are what this file measures.
+ *
+ * 🔴 COLUMNS ARE COUNTED BY `getBoundingClientRect().top`, NOT BY DOM CHILDREN. Counting
+ * children tells you how many CARDS there are, which is a fact about the fixture and is
+ * true whatever the stylesheet does — the classic assertion that cannot fail. Grouping
+ * the cells by their rendered `top` asks the layout engine how many actually sit on a
+ * visual row, which is the only form of the question that a broken container query can
+ * answer differently.
+ *
+ * 🔴 WHY IT IMPORTS THE CASCADE. `test/component-setup.tsx` injects only the `:root`
+ * custom properties out of `globals.css` — measured, 24 CSS rules — so every Tailwind
+ * utility is inert and, critically, a CSS-Module `@container` rule would still apply but
+ * `display: grid` from an unloaded sheet would not. This file imports what it needs and
+ * then ASSERTS it arrived (`cascadeLoaded` below), because "every width rendered one
+ * column" is exactly what an unstyled document produces and it would read as a
+ * consistent, confident, entirely vacuous pass.
+ *
+ * ⚠️ REPORT-ONLY, like every `.browser.test.tsx` here: the `component` project's only CI
+ * home is the preview pipeline's non-blocking `preview / component-tests`. The gating
+ * half of this change lives in the `unit` project.
+ */
+import '@mantine/core/styles.css';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+function makeCard(id: string, name: string): ListingCard {
+  return {
+    id,
+    slug: `slug-${id}`,
+    kind: 'onsite',
+    name,
+    tagline: 'tag',
+    category: null,
+    contentRating: null,
+    isBeta: false,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: {
+      kind: 'onsite',
+      appBlockId: `blk-${id}`,
+      hasPage: false,
+      liveUrl: `https://slug-${id}.civit.ai`,
+    },
+  };
+}
+
+const mocks = vi.hoisted(() => ({ items: [] as ListingCard[] }));
+
+// Same mock set, and the same reasons, as `AppListingsMarketplaceBody.browser.test.tsx`
+// — see the long notes there. In short: the card reads `useCurrentUser`, the filters
+// dropdown reads `useIsClient` + `useIsMobile` and both THROW without a provider, and
+// the flags factory must name BOTH flag hooks or the whole file fails to import and
+// reports `no tests` rather than a failure.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+}));
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock).
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: {
+        useInfiniteQuery: () => ({
+          data: { pages: [{ items: mocks.items, nextCursor: undefined }] },
+          isLoading: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+        }),
+      },
+    },
+  },
+}));
+
+// Import AFTER the mocks (vi.mock is hoisted; static imports are not).
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+const { LISTING_CARD_MIN_WIDTH, listingGridColumnsAt } = await import('./appListingGrid');
+
+/**
+ * Enough cards that a full row exists at EVERY width under test, including six columns,
+ * with a second row to prove the grid wraps rather than overflowing on one line.
+ */
+const CARD_COUNT = 13;
+
+/**
+ * A viewport wide enough that none of the fixture widths below is clamped by it. The
+ * container widths are set explicitly on a wrapper, so the viewport is deliberately NOT
+ * the variable under test — that is the whole point of using a container query.
+ */
+const VIEWPORT = { width: 2880, height: 900 } as const;
+
+/**
+ * Render the store body inside a wrapper of an EXPLICIT width, and report what actually
+ * laid out.
+ *
+ * The wrapper is the grid's width, which is the quantity the container query reads. In
+ * production that width comes from `AppsPageLayout`'s Container; here it is set directly,
+ * so the fixture varies exactly one thing.
+ */
+async function renderAtContainerWidth(width: number) {
+  await page.viewport(VIEWPORT.width, VIEWPORT.height);
+  renderWithProviders(
+    <div style={{ width, maxWidth: 'none' }} data-testid="width-harness">
+      <AppListingsMarketplaceBody />
+    </div>
+  );
+  await expect.element(page.getByText('App 0')).toBeInTheDocument();
+  // Two frames so style application and layout have both settled.
+  await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+
+  const grid = document.querySelector('[data-testid="apps-listing-grid"]') as HTMLElement | null;
+  const cells = Array.from(
+    document.querySelectorAll('[data-testid="apps-listing-grid-col"]')
+  ) as HTMLElement[];
+  if (!grid || cells.length === 0) {
+    throw new Error(`grid not rendered (grid=${!!grid} cells=${cells.length})`);
+  }
+
+  /**
+   * 🔴 THE POSITIVE CONTROL. Without `@mantine/core/styles.css` + the CSS Module the
+   * wrapper computes no layout of its own, the grid is a plain block, and EVERY width
+   * reports one cell per row — a perfectly consistent set of wrong answers. `display:
+   * grid` cannot be the UA default for a `<div>`, so reading it back is evidence the
+   * stylesheet arrived rather than a value that would be there anyway.
+   */
+  const cascadeLoaded = getComputedStyle(grid).display === 'grid';
+
+  // Group by rendered top, not by DOM position. Rounded to the nearest px so sub-pixel
+  // layout differences within one row cannot split it into two.
+  const rows = new Map<number, number>();
+  for (const cell of cells) {
+    const top = Math.round(cell.getBoundingClientRect().top);
+    rows.set(top, (rows.get(top) ?? 0) + 1);
+  }
+  const perRow = [...rows.entries()].sort((a, b) => a[0] - b[0]).map(([, n]) => n);
+
+  return {
+    cascadeLoaded,
+    gridWidth: Math.round(grid.getBoundingClientRect().width),
+    cellWidth: Math.round(cells[0].getBoundingClientRect().width * 100) / 100,
+    /** How many cells sit on the FIRST visual row — i.e. the column count. */
+    columns: perRow[0],
+    perRow,
+    cellCount: cells.length,
+  };
+}
+
+beforeEach(() => {
+  mocks.items = Array.from({ length: CARD_COUNT }, (_, i) => makeCard(`c${i}`, `App ${i}`));
+});
+
+/**
+ * The measurement points.
+ *
+ * 🔴 NONE OF THEM SITS ON A THRESHOLD. The rungs are at 736 / 960 / 1168 / 1979 / 2378;
+ * a fixture placed exactly on one would be the case where a one-pixel mutation of that
+ * threshold does not change the outcome, so it would survive a fully green suite for the
+ * wrong reason. Every width below overshoots into the middle of its band.
+ *
+ * 1888 / 2100 / 2560 are the three the change is ABOUT: 1888 is what the retired 1920
+ * container reached (its column count must be unchanged), and 2100 / 2560 are the two
+ * new rungs. 1000 is the unchanged narrow case.
+ */
+const CASES = [
+  { containerWidth: 1000, columns: 3, why: 'unchanged narrow case — the md band' },
+  { containerWidth: 1888, columns: 4, why: 'what the RETIRED 1920 container reached' },
+  { containerWidth: 2100, columns: 5, why: 'the new five-column rung' },
+  { containerWidth: 2560, columns: 6, why: 'the new six-column rung' },
+] as const;
+
+describe('the store grid renders the column ladder it declares', () => {
+  test.each(CASES)(
+    'a $containerWidth px grid renders $columns columns per row ($why)',
+    async ({ containerWidth, columns }) => {
+      const m = await renderAtContainerWidth(containerWidth);
+      expect(
+        m.cascadeLoaded,
+        'the stylesheet did not load — every count below is meaningless'
+      ).toBe(true);
+      expect(m.gridWidth, 'the harness did not size the grid as asked').toBe(containerWidth);
+      expect(m.cellCount).toBe(CARD_COUNT);
+      expect(m.columns).toBe(columns);
+      // The row shape as a whole, so a grid that put N on the first row and then
+      // collapsed cannot pass. 13 cards at C columns = full rows plus a remainder.
+      const full = Math.floor(CARD_COUNT / columns);
+      const remainder = CARD_COUNT % columns;
+      expect(m.perRow).toEqual([
+        ...Array.from({ length: full }, () => columns),
+        ...(remainder ? [remainder] : []),
+      ]);
+      // …and the constants agree with the browser about what should have happened.
+      expect(listingGridColumnsAt(containerWidth)).toBe(columns);
+    }
+  );
+
+  test('🔴 the new WIDE rungs really do clear the card-width floor, measured', async () => {
+    // The floor is arithmetic in the unit tier. Here it is a rendered box: five and six
+    // columns must both leave each card at least as wide as the covers pass shipped.
+    for (const containerWidth of [2100, 2560]) {
+      const m = await renderAtContainerWidth(containerWidth);
+      expect(m.cascadeLoaded).toBe(true);
+      expect(
+        m.cellWidth,
+        `${m.columns} columns at ${containerWidth}px gave ${m.cellWidth}px cards`
+      ).toBeGreaterThanOrEqual(LISTING_CARD_MIN_WIDTH);
+    }
+  });
+
+  test('🔴 it is a CONTAINER query, not a media query (a narrow grid on a wide screen)', async () => {
+    // THE DISCRIMINATING CASE, and the reason the viewport is held constant at 2880 for
+    // every test in this file. A media-query implementation would read the VIEWPORT —
+    // 2880, the top of the ladder — and render six columns into a 900px box, at 135px per
+    // card. A container query reads the GRID and renders the two columns 900px earns
+    // (900 sits in the sm band, 736–959).
+    const m = await renderAtContainerWidth(900);
+    expect(m.cascadeLoaded).toBe(true);
+    expect(m.gridWidth).toBe(900);
+    expect(window.innerWidth, 'the viewport must be far wider than the grid here').toBe(
+      VIEWPORT.width
+    );
+    expect(m.columns, 'six columns here would mean the ladder is reading the viewport').toBe(2);
+    expect(m.columns).toBe(listingGridColumnsAt(900));
+    // Stated as the counterfactual too, so the test says what it is ruling out.
+    expect(listingGridColumnsAt(VIEWPORT.width)).toBe(6);
+  });
+
+  test('the fixture set varies the dimension under test and covers both halves of the ladder', () => {
+    // Guard-the-guard: a table of one width, or of four widths in one band, cannot see a
+    // ladder bug at all.
+    const widths = CASES.map((c) => c.containerWidth);
+    expect(new Set(widths).size).toBe(widths.length);
+    expect(new Set(CASES.map((c) => c.columns))).toEqual(new Set([3, 4, 5, 6]));
+    // And no fixture sits ON a rung — see the note above the table.
+    for (const w of widths) {
+      for (const rung of [736, 960, 1168, 1979, 2378]) {
+        expect(w, `fixture ${w} sits exactly on the ${rung} rung`).not.toBe(rung);
+      }
+    }
+  });
+});

--- a/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
@@ -15,13 +15,25 @@
  * visual row, which is the only form of the question that a broken container query can
  * answer differently.
  *
- * 🔴 WHY IT IMPORTS THE CASCADE. `test/component-setup.tsx` injects only the `:root`
- * custom properties out of `globals.css` — measured, 24 CSS rules — so every Tailwind
- * utility is inert and, critically, a CSS-Module `@container` rule would still apply but
- * `display: grid` from an unloaded sheet would not. This file imports what it needs and
- * then ASSERTS it arrived (`cascadeLoaded` below), because "every width rendered one
- * column" is exactly what an unstyled document produces and it would read as a
- * consistent, confident, entirely vacuous pass.
+ * 🔴 WHY IT IMPORTS A STYLESHEET AND WHAT IT DELIBERATELY DOES NOT NEED.
+ * `test/component-setup.tsx` injects only the `:root` custom properties out of
+ * `globals.css` — measured, 24 CSS rules — so by DEFAULT this tier resolves no Tailwind
+ * utility and no Mantine rule. (Three specs opt in by importing `~/styles/globals.css`
+ * themselves; this is not one of them, and does not need to be.) The column ladder lives
+ * in a CSS MODULE, which Vite injects wherever the component is imported, so the
+ * `@container` rules apply here regardless — what would NOT apply is Mantine's own
+ * `display`/box rules, hence the one stylesheet imported above. The file then ASSERTS
+ * the sheet arrived (`cascadeLoaded` below), because "every width rendered one column" is
+ * exactly what an unstyled document produces and would read as a consistent, confident,
+ * entirely vacuous pass.
+ *
+ * 🔴 WHAT THIS TIER CANNOT MEASURE, AND WHERE THAT LIVES INSTEAD. Anything resolving
+ * through Tailwind or through the production cascade-LAYER order — notably the card's
+ * `h-full` + `h="100%"` + `mt="auto"` bottom-pin chain — is not measurable here. That
+ * seam is guarded in `AppListingsMarketplaceBody.stretch.geometry.test.tsx`, in the
+ * `geometry` project, which loads the layer-order declaration and the Mantine layer
+ * sheets in production order. A first draft of it lived in THIS file and reported card
+ * heights of `[458.23, 312.75, 434.23, 312.75]` on a correct grid.
  *
  * ⚠️ REPORT-ONLY, like every `.browser.test.tsx` here: the `component` project's only CI
  * home is the preview pipeline's non-blocking `preview / component-tests`. The gating

--- a/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.columns.browser.test.tsx
@@ -17,7 +17,8 @@
  *
  * 🔴 WHY IT IMPORTS A STYLESHEET AND WHAT IT DELIBERATELY DOES NOT NEED.
  * `test/component-setup.tsx` injects only the `:root` custom properties out of
- * `globals.css` — measured, 24 CSS rules — so by DEFAULT this tier resolves no Tailwind
+ * `globals.css` (24 CSS rules, per `test/geometry-setup.tsx`'s own record of 2026-09-03
+ * — not re-measured here) — so by DEFAULT this tier resolves no Tailwind
  * utility and no Mantine rule. (Three specs opt in by importing `~/styles/globals.css`
  * themselves; this is not one of them, and does not need to be.) The column ladder lives
  * in a CSS MODULE, which Vite injects wherever the component is imported, so the

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -66,12 +66,19 @@
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
-/* ── The narrow half: the retired Mantine breakpoints, converted once ───────────────
+/* ── The narrow half: the retired Mantine breakpoints, re-expressed in GRID width ───
    Each threshold is that breakpoint's viewport px MINUS the apps Container's 32px
-   gutter, because `/apps` takes no body measure and the Container is full-bleed below
-   its cap — so the grid there is exactly `viewport − 32`. sm 768 → 736, md 992 → 960,
-   lg 1200 → 1168. `xl` (1408) is absent deliberately: it and `lg` are both four
-   columns, so it was never a rung. */
+   gutter: sm 768 → 736, md 992 → 960, lg 1200 → 1168. `xl` (1408) is absent
+   deliberately — it and `lg` are both four columns, so it was never a rung.
+
+   🔴 THIS IS NOT "BYTE-EQUIVALENT TO THE OLD MEDIA QUERIES", and the claim that it was
+   has been retired. The page's scroll container (`.scroll-area`) is `scrollbar-width:
+   thin` with no document scroll, so the grid is `viewport − scrollbar − 32`. Media
+   queries ignored the scrollbar; a container query does not. On the platforms that
+   reserve one (~10px) every rung fires ~10px of VIEWPORT later than before — viewport
+   1200 gives 1158 of grid and THREE columns where the old `lg` span gave four. Kept
+   deliberately: the content never had those pixels. Driven end-to-end in
+   `AppListingsMarketplaceBody.stretch.geometry.test.tsx`. */
 @container (min-width: 736px) {
   .grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -97,8 +104,9 @@
    now — never more cards at a smaller size.
 
    🔴 THE 2840 RULE IS UNREACHABLE AT TODAY'S CONTAINER CAP, DELIBERATELY. The apps
-   Container is 2560, so this grid tops out at 2528 and the reachable ladder is
-   1/2/3/4/5 — 2560 renders FIVE columns at 492.8px. The rule is kept so a future cap
+   Container is 2560, so this grid tops out at 2528 (less any reserved scrollbar) and
+   the reachable ladder is 1/2/3/4/5 — a 2560 container renders FIVE columns at 492.8px,
+   a 2560 viewport ~490.8px. The rule is kept so a future cap
    raise engages six automatically; `__tests__/appListingGrid.test.ts` asserts both the
    rule's presence and its unreachability, so raising the cap past 2840 fails loudly.
 

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -43,7 +43,8 @@
    `AppListingCard` bottom-pins its action row with `mt="auto"` inside a `Stack h="100%"`
    inside a `Card className="h-full"`, and `h-full` only resolves because this grid
    STRETCHES its items to the row height (`align-items: normal`, the grid default).
-   Measured, four shapes — card DIRECT + default ✅ / card in a WRAPPER + default ✅ /
+   Four shapes, measured by the concurrent card PR's audit rather than here — card
+   DIRECT + default ✅ / card in a WRAPPER + default ✅ /
    card DIRECT + `start` ✅ (`h-full` resolves against the grid AREA) / card in a WRAPPER
    + non-stretch ❌ (short card 40px shorter, action row unpinned) — and THIS grid is the
    failing shape's first half, because each card sits in its own

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -39,6 +39,20 @@
   container-type: inline-size;
 }
 
+/* 🔴 DO NOT ADD `align-items` HERE. ITS ABSENCE IS LOAD-BEARING, NOT AN OMISSION.
+   `AppListingCard` bottom-pins its action row with `mt="auto"` inside a `Stack h="100%"`
+   inside a `Card className="h-full"`, and `h-full` only resolves because this grid
+   STRETCHES its items to the row height (`align-items: normal`, the grid default).
+   Measured, four shapes — card DIRECT + default ✅ / card in a WRAPPER + default ✅ /
+   card DIRECT + `start` ✅ (`h-full` resolves against the grid AREA) / card in a WRAPPER
+   + non-stretch ❌ (short card 40px shorter, action row unpinned) — and THIS grid is the
+   failing shape's first half, because each card sits in its own
+   `[data-testid=apps-listing-grid-col]` wrapper div. So one `align-items: start` added
+   for vertical rhythm unpins the action row on every card in the store, with nothing
+   else changing. Guarded by rendered boxes (not by an inline-style check, which the
+   mutant walks straight past) in `AppListingsMarketplaceBody.stretch.geometry.test.tsx`
+   — the `geometry` project, because `h-full` is a Tailwind utility and is inert in the
+   `component` tier's cascade. */
 .grid {
   display: grid;
   /* Mantine's `md` spacing token — the value the retired `<Grid gutter="md">` used, and

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -1,0 +1,92 @@
+/**
+ * `/apps` store grid — the COLUMN LADDER, as a container query.
+ *
+ * 🔴 EVERY NUMBER IN THIS FILE IS DERIVED, NOT CHOSEN, AND A UNIT TEST PARSES THIS
+ * FILE TO PROVE IT. `LISTING_GRID_COLUMN_STEPS` in `appListingGrid.ts` computes the
+ * ladder — the narrow half from `LISTING_GRID_SPAN` + Mantine's default breakpoints,
+ * the wide half from the `LISTING_CARD_MIN_WIDTH` floor — and
+ * `__tests__/appListingGrid.test.ts` reads the `@container` rules below and fails
+ * unless the two sets are EQUAL, in both directions. So editing a threshold here
+ * without moving the constant it came from is a red test, not a silent re-tune.
+ *
+ * WHY A STYLESHEET AND NOT A `Grid.Col span=`. Mantine's `Grid.Col span` compiles to
+ * VIEWPORT media queries at the theme's breakpoints, and `xl` (88em / 1408px) is the
+ * top of the scale — `src/providers/ThemeProvider.tsx` declares no custom breakpoints,
+ * so there is nothing above 1408 to hang a fifth column on. Adding one would be a
+ * site-wide theme change made to fix one grid.
+ *
+ * WHY `@container` AND NOT `@media`. The number that decides whether a card is too
+ * narrow is the width of the GRID, and that is not monotonic in viewport width: at the
+ * one-column base breakpoint a 390px phone yields a ~356px card, WIDER than the ~280px
+ * a 1200px laptop gets at four columns. A container query reads the grid's own inline
+ * size, which is the quantity the ladder is actually about, and it keeps working if the
+ * store is ever rendered inside something narrower than the page.
+ *
+ * WHY NOT `repeat(auto-fill, minmax(X, 1fr))`. It cannot express this ladder for any
+ * single `X` — four columns at 1376 of grid needs `X ≤ 332`, while keeping FOUR (not
+ * five) at 1888 needs `X > 364.8`. The full derivation is on
+ * `LISTING_GRID_COLUMN_STEPS`.
+ */
+
+/**
+ * The QUERY CONTAINER. Separate from `.grid` on purpose: `@container` resolves against
+ * an ANCESTOR container, never the queried element itself, so a single element carrying
+ * both `container-type` and the queried `grid-template-columns` would match nothing and
+ * the grid would silently stay at one column.
+ */
+.gridContainer {
+  container-type: inline-size;
+}
+
+.grid {
+  display: grid;
+  /* Mantine's `md` spacing token — the value the retired `<Grid gutter="md">` used, and
+     `LISTING_GRID_GUTTER` in `appListingGrid.ts`. It is part of the ladder arithmetic
+     (a threshold is `n × floor + (n − 1) × gap`), so the unit test pins it too. */
+  gap: 16px;
+  /* `minmax(0, 1fr)` rather than `1fr`: a grid track's default minimum is `auto`, which
+     is the item's min-content size, so a card with a long unbreakable string would push
+     its track past its share and knock the row out of alignment. */
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+/* ── The narrow half: the retired Mantine breakpoints, converted once ───────────────
+   Each threshold is that breakpoint's viewport px MINUS the apps Container's 32px
+   gutter, because `/apps` takes no body measure and the Container is full-bleed below
+   its cap — so the grid there is exactly `viewport − 32`. sm 768 → 736, md 992 → 960,
+   lg 1200 → 1168. `xl` (1408) is absent deliberately: it and `lg` are both four
+   columns, so it was never a rung. */
+@container (min-width: 736px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@container (min-width: 1168px) {
+  .grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+/* ── The wide half: NEW, and derived from the 383px card-width floor ────────────────
+   `n × 383 + (n − 1) × 16`. 5 → 1979, 6 → 2378. At each threshold every card is
+   exactly 383px, which is the width the 2026-07 "larger covers" pass shipped at a
+   1600px container — so a column is only ever added where doing so cannot make a card
+   narrower than that pass was willing to ship. */
+@container (min-width: 1979px) {
+  .grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+@container (min-width: 2378px) {
+  .grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -51,8 +51,9 @@
    for vertical rhythm unpins the action row on every card in the store, with nothing
    else changing. Guarded by rendered boxes (not by an inline-style check, which the
    mutant walks straight past) in `AppListingsMarketplaceBody.stretch.geometry.test.tsx`
-   — the `geometry` project, because `h-full` is a Tailwind utility and is inert in the
-   `component` tier's cascade. */
+   — the `geometry` project, because that is the only tier that loads the cascade-LAYER
+   ORDER production declares, which is what makes `h-full` and Mantine's own rules
+   resolve against each other the way they do on the site. */
 .grid {
   display: grid;
   /* Mantine's `md` spacing token — the value the retired `<Grid gutter="md">` used, and

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -4,7 +4,8 @@
  * 🔴 EVERY NUMBER IN THIS FILE IS DERIVED, NOT CHOSEN, AND A UNIT TEST PARSES THIS
  * FILE TO PROVE IT. `LISTING_GRID_COLUMN_STEPS` in `appListingGrid.ts` computes the
  * ladder — the narrow half from `LISTING_GRID_SPAN` + Mantine's default breakpoints,
- * the wide half from the `LISTING_CARD_MIN_WIDTH` floor — and
+ * the wide half from the `LISTING_CARD_MIN_WIDTH` floor, and the two are
+ * STRUCTURALLY INDEPENDENT (see the 🔴 note on the wide half below) — and
  * `__tests__/appListingGrid.test.ts` reads the `@container` rules below and fails
  * unless the two sets are EQUAL, in both directions. So editing a threshold here
  * without moving the constant it came from is a red test, not a silent re-tune.
@@ -74,18 +75,29 @@
   }
 }
 
-/* ── The wide half: NEW, and derived from the 383px card-width floor ────────────────
-   `n × 383 + (n − 1) × 16`. 5 → 1979, 6 → 2378. At each threshold every card is
-   exactly 383px, which is the width the 2026-07 "larger covers" pass shipped at a
-   1600px container — so a column is only ever added where doing so cannot make a card
-   narrower than that pass was willing to ship. */
-@container (min-width: 1979px) {
+/* ── The wide half: NEW, and derived from the 460px card-width floor ────────────────
+   `n × 460 + (n − 1) × 16`. 5 → 2364, 6 → 2840. 460 is the card width the store
+   renders TODAY at its widest (four columns in the retired 1920 container), so a
+   column is only ever added where doing so makes every card at least as big as it is
+   now — never more cards at a smaller size.
+
+   🔴 THE 2840 RULE IS UNREACHABLE AT TODAY'S CONTAINER CAP, DELIBERATELY. The apps
+   Container is 2560, so this grid tops out at 2528 and the reachable ladder is
+   1/2/3/4/5 — 2560 renders FIVE columns at 492.8px. The rule is kept so a future cap
+   raise engages six automatically; `__tests__/appListingGrid.test.ts` asserts both the
+   rule's presence and its unreachability, so raising the cap past 2840 fails loudly.
+
+   🔴 DO NOT LET THIS FLOOR DECIDE THE NARROW RUNGS ABOVE. `4 × 460 + 3 × 16 = 1888` —
+   exactly the retired 1920 container's content width — so a floor-governed narrow half
+   would move four columns from 1168 to 1888 and drop the whole 1168–1887 band, the
+   `xl` low end (1376) included, to three columns. */
+@container (min-width: 2364px) {
   .grid {
     grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 
-@container (min-width: 2378px) {
+@container (min-width: 2840px) {
   .grid {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }

--- a/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
@@ -1,0 +1,372 @@
+/**
+ * `/apps` store grid — THE CARD-STRETCH SEAM.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT IS BEING GUARDED, AND WHY IT IS A SEAM RATHER THAN A COMPONENT TEST
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `AppListingCard` bottom-pins its action row with `mt="auto"`, inside a
+ * `<Stack h="100%">`, inside a `<Card className="h-full">`. None of that chain
+ * resolves to a real height on its own: `h-full` is `height: 100%`, which needs a
+ * parent with a definite height, and the only thing that gives it one is the GRID
+ * stretching its items to the row's height — i.e. `align-items: normal`, the
+ * default for a grid container.
+ *
+ * That default is declared NOWHERE. `AppListingsMarketplaceBody.module.scss` sets
+ * no `align-items` on `.grid`, so the behaviour every card depends on is an
+ * absence, and an absence reads as an omission nobody chose.
+ *
+ * 🔴 THE FOUR SHAPES, MEASURED. This grid is the FAILING one's first half — it
+ * renders `.grid` → a per-card WRAPPER `<div data-testid="apps-listing-grid-col">`
+ * → the card:
+ *
+ *   card as a DIRECT grid item, default align   ✅ bottoms equal, heights equal
+ *   card in a WRAPPER div,      default align   ✅ bottoms equal, heights equal
+ *   card as a DIRECT grid item, `align: start`  ✅ `h-full` resolves against the
+ *                                                  grid AREA, so stretch is not
+ *                                                  what carries it
+ *   card in a WRAPPER div,      non-stretch     ❌ short card 40px shorter, its
+ *                                                  action row unpinned
+ *
+ * So ONE line — `align-items: start` on `.grid`, the kind of thing someone adds
+ * for vertical rhythm — silently unpins the action row on every card in the store.
+ * Neither this grid's suite nor the card's own suite could see it: a structural
+ * check ("does the action row carry `margin-top: auto`?") type-checks straight
+ * past it, because the declaration is still there under the mutant — it simply has
+ * no free space to consume. Only the rendered boxes can tell you.
+ *
+ * The seam is a RELATIONSHIP between two files owned by different changes, so it
+ * is guarded as one: uneven cards, one row, equal heights, aligned action rows.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 WHY THE `geometry` PROJECT AND NOT `component`
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `h-full` IS A TAILWIND UTILITY. The `component` tier's setup injects only the
+ * `:root` custom properties out of `globals.css` — measured, 24 CSS rules — so
+ * every Tailwind utility there is inert and the card's height silently follows its
+ * content. This was not theory: the first draft of this guard lived in
+ * `AppListingsMarketplaceBody.columns.browser.test.tsx` and reported heights of
+ * `[458.23, 312.75, 434.23, 312.75]` on a CORRECT grid, because `h-full` did
+ * nothing. A test that cannot distinguish the fix from the defect is worse than no
+ * test, and it would have been read as this guard working.
+ *
+ * `test/geometry-setup.tsx` loads the real cascade in production order and this
+ * file asserts that it arrived (`cascadeEvidence()`), so a stylesheet that fails
+ * to load fails the run rather than quietly reproducing the defect's numbers.
+ *
+ * The column LADDER stays in the `component` tier — it is driven by this repo's own
+ * CSS module, which Vite injects wherever the component is imported, so it needs no
+ * app cascade. Only the stretch chain does.
+ */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup } from 'vitest-browser-react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { cascadeEvidence, nextLayout, renderAtViewport } from '../../../test/geometry-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+function makeCard(id: string, name: string, tagline: string | null): ListingCard {
+  return {
+    id,
+    slug: `slug-${id}`,
+    kind: 'onsite',
+    name,
+    tagline,
+    category: null,
+    contentRating: null,
+    isBeta: false,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: {
+      kind: 'onsite',
+      appBlockId: `blk-${id}`,
+      hasPage: false,
+      liveUrl: `https://slug-${id}.civit.ai`,
+    },
+  };
+}
+
+const mocks = vi.hoisted(() => ({ items: [] as ListingCard[] }));
+
+// Same mock set, and the same reasons, as the sibling `.browser.test.tsx` files — see
+// the long notes in `AppListingsMarketplaceBody.browser.test.tsx`. In short: the card
+// reads `useCurrentUser`, the filters dropdown reads `useIsClient` + `useIsMobile` and
+// both THROW without a provider, and the flags factory must name BOTH flag hooks or the
+// whole file fails to IMPORT and reports `no tests` rather than a failure.
+// `next/router` is already mocked by `test/geometry-setup.tsx`.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+}));
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock).
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: {
+        useInfiniteQuery: () => ({
+          data: { pages: [{ items: mocks.items, nextCursor: undefined }] },
+          isLoading: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+        }),
+      },
+    },
+  },
+}));
+
+// Import AFTER the mocks (vi.mock is hoisted; static imports are not).
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+
+/**
+ * Deliberately UNEVEN content, ALTERNATING so that any prefix of two or more holds both
+ * kinds: a one-line title with NO tagline against a wrapping title with a three-line one.
+ * `AppListingCard` renders its tagline conditionally, so the short cards are genuinely
+ * shorter — which the `contentBottom` control below ASSERTS rather than assumes.
+ */
+const TALL_TAGLINE =
+  'A deliberately long tagline that wraps onto three separate lines inside a store card ' +
+  'column so that this card is measurably taller than its neighbour, which has no ' +
+  'tagline at all and only a single short line of title text.';
+
+const MIXED: ListingCard[] = [
+  makeCard('t0', 'A Very Long Application Name That Wraps Across Several Lines', TALL_TAGLINE),
+  makeCard('s1', 'App 1', null),
+  makeCard('t2', 'Another Long Application Name That Also Wraps Across Lines', TALL_TAGLINE),
+  makeCard('s3', 'App 3', null),
+  makeCard('t4', 'A Third Long Application Name That Wraps Across Lines Too', TALL_TAGLINE),
+];
+
+/**
+ * A viewport wide enough that neither grid width below is clamped by it. The grid width
+ * is set on a wrapper, so the viewport is deliberately NOT the variable under test.
+ */
+const VIEWPORT = { width: 2880, height: 900 } as const;
+
+/**
+ * TWO column counts, both NAMED in every assertion.
+ *
+ * 1376 is the four-column band (the `xl` low end, and the collision guard the ladder
+ * suite pins); 2450 is mid-band in the five-column rung. Neither sits on a ladder
+ * threshold — 2364 itself is deliberately avoided, since a fixture on its own boundary
+ * cannot detect an off-by-one. At 1376 the first row holds four of the five cards, at
+ * 2450 all five; both prefixes contain at least one tall card and one short one.
+ */
+const WIDTHS = [
+  { gridWidth: 1376, columns: 4 },
+  { gridWidth: 2450, columns: 5 },
+] as const;
+
+/** The ladder's rungs, so a fixture can be checked against them. */
+const RUNGS = [736, 960, 1168, 2364, 2840];
+
+/** 2dp, so sub-pixel layout is visible but float noise is not. */
+const q = (n: number) => Math.round(n * 100) / 100;
+
+async function renderAtGridWidth(width: number) {
+  // 🔴 CLEAN FIRST, ALWAYS. `vitest-browser-react` APPENDS each render rather than
+  // replacing it, and the setup file's `afterEach` only runs BETWEEN tests — so a test
+  // that renders twice leaves two grids in the document and `document.querySelector`
+  // keeps returning the FIRST one. Measured here, not theorised: without this the
+  // two-widths guard below read 4 columns for its 2450px render because it was still
+  // looking at the 1376px grid. The same defect was found and fixed in
+  // `AppListingsMarketplaceBody.columns.browser.test.tsx`, where it had silently made a
+  // loop over two widths measure one width twice and pass.
+  await cleanup();
+  const { observed } = await renderAtViewport(
+    <div style={{ width, maxWidth: 'none' }} data-testid="width-harness">
+      <AppListingsMarketplaceBody />
+    </div>,
+    VIEWPORT
+  );
+  await nextLayout();
+  const grid = document.querySelector('[data-testid="apps-listing-grid"]') as HTMLElement | null;
+  const cells = Array.from(
+    document.querySelectorAll('[data-testid="apps-listing-grid-col"]')
+  ) as HTMLElement[];
+  if (!grid || cells.length === 0) {
+    throw new Error(`grid not rendered (grid=${!!grid} cells=${cells.length})`);
+  }
+  return { observed, grid, cells, gridWidth: Math.round(grid.getBoundingClientRect().width) };
+}
+
+/**
+ * The parts of one rendered card this file measures.
+ *
+ * 🔴 RESOLVED STRUCTURALLY, AND THEN VALIDATED, because `AppListingCard` carries no
+ * `data-testid` on its action row and this file must not add one: that component is owned
+ * by a concurrent change, and the coupling under test is pre-existing on `main`. So the
+ * resolver walks my own grid cell → the `Card` → the body `Stack` → its LAST child. Each
+ * step is then checked against something only the real action row satisfies, and a failed
+ * check THROWS with the offending `outerHTML` rather than returning a wrong element — a
+ * silently mis-resolved element would make every assertion below compare the wrong boxes
+ * and pass.
+ */
+function cardPartsOf(cell: HTMLElement) {
+  const card = cell.firstElementChild as HTMLElement | null;
+  if (!card) throw new Error(`grid cell has no card child: ${cell.outerHTML.slice(0, 200)}`);
+  const stack = card.lastElementChild as HTMLElement | null;
+  if (!stack) throw new Error(`card has no body stack: ${card.outerHTML.slice(0, 200)}`);
+  const actionRow = stack.lastElementChild as HTMLElement | null;
+  if (!actionRow) throw new Error(`card body has no last child: ${stack.outerHTML.slice(0, 200)}`);
+  // VALIDATION 1 — the action row is the one holding the card's controls. The title block
+  // above it holds a link too, so this does not identify it alone; it is what rules out
+  // having resolved to a `<Text>` tagline.
+  if (actionRow.querySelectorAll('a[href], button').length === 0) {
+    throw new Error(
+      'resolved "action row" holds no link or button — the walk found the wrong element: ' +
+        actionRow.outerHTML.slice(0, 300)
+    );
+  }
+  // VALIDATION 2 — it really is the LAST thing in the card body, which is what makes "its
+  // top" a meaningful proxy for "where the pinned row sits".
+  if (actionRow.nextElementSibling !== null) {
+    throw new Error('resolved "action row" is not the last child of the card body');
+  }
+  // Where the content ABOVE the action row ends. This is the NON-VACUITY CONTROL: the
+  // fixtures must genuinely differ in natural content height, or "the heights are equal"
+  // is a fact about identical cards rather than about stretching. It is unaffected by the
+  // auto margin, so it still differs while the stretch is working.
+  const lastContent = actionRow.previousElementSibling as HTMLElement | null;
+  return {
+    card,
+    actionRow,
+    cardHeight: q(card.getBoundingClientRect().height),
+    cardBottom: q(card.getBoundingClientRect().bottom),
+    actionRowBottom: q(actionRow.getBoundingClientRect().bottom),
+    actionRowTop: q(actionRow.getBoundingClientRect().top),
+    contentBottom: lastContent ? q(lastContent.getBoundingClientRect().bottom) : null,
+  };
+}
+
+/** The cells sharing the FIRST visual row, in visual order. */
+function firstRowCells(cells: HTMLElement[]): HTMLElement[] {
+  const tops = cells.map((c) => Math.round(c.getBoundingClientRect().top));
+  const first = Math.min(...tops);
+  return cells.filter((_, i) => tops[i] === first);
+}
+
+beforeEach(() => {
+  mocks.items = MIXED;
+});
+
+describe('🔴 the store grid stretches its cards, so their action rows stay pinned', () => {
+  test('the harness loaded the REAL cascade (positive control — Tailwind must resolve)', async () => {
+    // 🔴 THE CONTROL THIS FILE EXISTS BECAUSE OF. Without Tailwind's utilities `h-full` is
+    // inert, the card's height follows its content, and every measurement below reproduces
+    // the DEFECT's numbers on correct code. `tailwindFlexUtilityResolves` is `false` in the
+    // `component` tier and `true` here, so it is evidence rather than a reassurance.
+    await renderAtGridWidth(2450);
+    const evidence = cascadeEvidence();
+    expect(evidence.tailwindFlexUtilityResolves, 'Tailwind utilities are inert here').toBe(true);
+    expect(evidence.probeBoxSizing, 'Preflight did not load').toBe('border-box');
+    expect(evidence.ruleCount, 'the cascade is far too small to be the real one').toBeGreaterThan(
+      1000
+    );
+    // …and the specific declaration the whole seam hangs on actually applies.
+    const card = document.querySelector('[data-testid="apps-listing-grid-col"] > *') as HTMLElement;
+    expect(getComputedStyle(card).height).not.toBe('auto');
+  });
+
+  test.each(WIDTHS)(
+    'at $gridWidth px of grid ($columns columns) every card in the row is the same height, and the action rows align',
+    async ({ gridWidth, columns }) => {
+      const m = await renderAtGridWidth(gridWidth);
+      expect(m.observed).toEqual({ width: VIEWPORT.width, height: VIEWPORT.height });
+      expect(m.gridWidth, 'the harness did not size the grid as asked').toBe(gridWidth);
+      expect(m.cells).toHaveLength(MIXED.length);
+
+      const row = firstRowCells(m.cells);
+      expect(row, `expected a full ${columns}-column first row at ${gridWidth}px`).toHaveLength(
+        columns
+      );
+      const parts = row.map(cardPartsOf);
+
+      // 🔴 THE NON-VACUITY CONTROL, ASSERTED FIRST. Equal heights prove nothing if the
+      // fixtures are the same height to begin with, so the natural content must genuinely
+      // differ. If this ever goes green-by-uniformity the two assertions below become
+      // decorative, and this is what says so.
+      const contentBottoms = parts.map((p) => p.contentBottom);
+      expect(
+        new Set(contentBottoms).size,
+        `at ${gridWidth}px the fixtures do not differ in content height ` +
+          `(${JSON.stringify(contentBottoms)}) — the assertions below would pass on ` +
+          'identical cards and would be testing nothing'
+      ).toBeGreaterThan(1);
+
+      // (a) EQUAL HEIGHTS.
+      const heights = parts.map((p) => p.cardHeight);
+      expect(
+        new Set(heights).size,
+        `at ${gridWidth}px of grid (${columns} columns) the cards in one row have different ` +
+          `heights ${JSON.stringify(heights)}. The grid stopped stretching its items — check ` +
+          'that `.grid` in AppListingsMarketplaceBody.module.scss still declares NO ' +
+          '`align-items`. The cards sit in a wrapper div, so any non-stretch value makes the ' +
+          "card's `h-full` resolve against its content instead of the row."
+      ).toBe(1);
+
+      // (b) ALIGNED ACTION ROWS — the effect the equal heights exist to buy, and the one a
+      // viewer actually sees.
+      const actionTops = parts.map((p) => p.actionRowTop);
+      expect(
+        new Set(actionTops).size,
+        `at ${gridWidth}px of grid (${columns} columns) the bottom-pinned action rows do not ` +
+          `align ${JSON.stringify(actionTops)}. The card's \`mt="auto"\` has no free space ` +
+          'to consume, i.e. the card is no longer as tall as its row.'
+      ).toBe(1);
+
+      // …and they are pinned to the BOTTOM rather than merely agreeing somewhere in the
+      // middle: every action row ends at the same distance from its card's bottom edge,
+      // which is the Card's own padding.
+      const bottomGaps = parts.map((p) => q(p.cardBottom - p.actionRowBottom));
+      expect(
+        new Set(bottomGaps).size,
+        `action rows sit at different distances from their card bottoms ${JSON.stringify(
+          bottomGaps
+        )}`
+      ).toBe(1);
+    }
+  );
+
+  test('the two widths really are different column counts, and neither sits on a rung', async () => {
+    // Guard-the-guard: a pair of widths resolving to the SAME column count would test one
+    // shape twice, and `firstRowCells` would still return a full row so nothing above
+    // would notice.
+    const a = await renderAtGridWidth(WIDTHS[0].gridWidth);
+    const aCols = firstRowCells(a.cells).length;
+    const b = await renderAtGridWidth(WIDTHS[1].gridWidth);
+    const bCols = firstRowCells(b.cells).length;
+    expect(aCols).toBe(WIDTHS[0].columns);
+    expect(bCols).toBe(WIDTHS[1].columns);
+    expect(aCols).not.toBe(bCols);
+    for (const { gridWidth } of WIDTHS) {
+      for (const rung of RUNGS) {
+        expect(gridWidth, `fixture ${gridWidth} sits exactly on the ${rung} rung`).not.toBe(rung);
+      }
+    }
+  });
+
+  test('🔴 the grid resolves to the STRETCHING value of `align-items`', async () => {
+    // The cheap half, beside the expensive one, so a reader who changes the stylesheet
+    // meets the reason immediately. Read off the LIVE grid rather than the source text, so
+    // a value arriving from any other rule is caught too — and stated as the RESOLVED
+    // value rather than as "the property is absent", because what matters is what the
+    // layout engine ends up using.
+    //
+    // It is NOT sufficient on its own: `align-items` is one of several ways to break the
+    // chain (a definite height on the wrapper would do it too), which is why the
+    // measurements above exist. It is here because it names the exact line.
+    const m = await renderAtGridWidth(2450);
+    expect(
+      getComputedStyle(m.grid).alignItems,
+      'the store grid no longer stretches its items to the row height — the cards sit in a ' +
+        "wrapper div, so this unpins every card's action row"
+    ).toBe('normal');
+  });
+});

--- a/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
@@ -40,18 +40,46 @@
  * ─────────────────────────────────────────────────────────────────────────────
  * 🔴 WHY THE `geometry` PROJECT AND NOT `component`
  * ─────────────────────────────────────────────────────────────────────────────
- * `h-full` IS A TAILWIND UTILITY. The `component` tier's setup injects only the
- * `:root` custom properties out of `globals.css` — measured, 24 CSS rules — so
- * every Tailwind utility there is inert and the card's height silently follows its
- * content. This was not theory: the first draft of this guard lived in
- * `AppListingsMarketplaceBody.columns.browser.test.tsx` and reported heights of
- * `[458.23, 312.75, 434.23, 312.75]` on a CORRECT grid, because `h-full` did
- * nothing. A test that cannot distinguish the fix from the defect is worse than no
- * test, and it would have been read as this guard working.
+ * `h-full` IS A TAILWIND UTILITY, AND WHICH TIER YOU ARE IN DECIDES WHETHER IT
+ * RESOLVES — but the accurate statement is narrower than "the `component` tier has
+ * no Tailwind", so state it precisely:
  *
- * `test/geometry-setup.tsx` loads the real cascade in production order and this
- * file asserts that it arrived (`cascadeEvidence()`), so a stylesheet that fails
- * to load fails the run rather than quietly reproducing the defect's numbers.
+ *   · BY DEFAULT it does not. `test/component-setup.tsx` parses `globals.css?raw`
+ *     into a throwaway `CSSStyleSheet`, walks it for unconditional `:root` rules and
+ *     injects a `<style>` holding ONLY the `--*` custom properties — measured, 24 CSS
+ *     rules. No utilities, no preflight. Its own docstring records why importing the
+ *     real sheet instead was rejected: it moves the rendered geometry of every
+ *     existing test in that tier.
+ *   · BUT THREE SPECS OPT IN, by importing `~/styles/globals.css` for its side effect
+ *     (`AppListingCard.browser.test.tsx`, `ImageCard.browser.test.tsx`,
+ *     `ImageResources.browser.test.tsx` — measured at this ref; two more import it as
+ *     `?raw` TEXT, which injects nothing). Vite runs those through PostCSS, so
+ *     Tailwind utilities genuinely DO resolve there. Anyone claiming a spec in that
+ *     tier "cannot see Tailwind" has to check the file, not the tier.
+ *
+ * 🔴 SO THE REASON THIS GUARD IS HERE IS THE CASCADE **LAYER ORDER**, NOT THE MERE
+ * PRESENCE OF TAILWIND. An opted-in `component` spec gets `globals.css` (and possibly
+ * `@mantine/core/styles.layer.css`) without `test/cascade-layer-order.css` and without
+ * the other Mantine layer sheets. A layer's priority is fixed at its FIRST APPEARANCE
+ * in the CSSOM, so with no `@layer tailwind-preflight, theme, mantine, modules;`
+ * parsed first, layer priority falls out of import order — a THIRD cascade, matching
+ * neither this tier's default nor production. `test/geometry-setup.tsx` parses that
+ * declaration first and then loads `globals.css` + the six Mantine
+ * `<pkg>/styles.layer.css` sheets + `mantine-react-table/styles.css`, i.e.
+ * `src/pages/_document.tsx` followed by
+ * `src/pages/_app.tsx`, in that order. This seam is a fight between a Tailwind
+ * utility (`h-full`), a Mantine component rule (`Card`) and a CSS Module (`.grid`) —
+ * exactly the three layers that declaration orders — so it needs the real one.
+ *
+ * That this matters is not theory: the first draft of this guard lived in
+ * `AppListingsMarketplaceBody.columns.browser.test.tsx`, which imports only
+ * `@mantine/core/styles.css` and therefore gets the tier default. It reported heights
+ * of `[458.23, 312.75, 434.23, 312.75]` on a CORRECT grid, because `h-full` did
+ * nothing there. A test that cannot distinguish the fix from the defect is worse than
+ * no test, and it would have been read as this guard working.
+ *
+ * This file asserts the cascade arrived (`cascadeEvidence()`), so a stylesheet that
+ * fails to load fails the run rather than quietly reproducing the defect's numbers.
  *
  * The column LADDER stays in the `component` tier — it is driven by this repo's own
  * CSS module, which Vite injects wherever the component is imported, so it needs no
@@ -260,11 +288,17 @@ describe('🔴 the store grid stretches its cards, so their action rows stay pin
   test('the harness loaded the REAL cascade (positive control — Tailwind must resolve)', async () => {
     // 🔴 THE CONTROL THIS FILE EXISTS BECAUSE OF. Without Tailwind's utilities `h-full` is
     // inert, the card's height follows its content, and every measurement below reproduces
-    // the DEFECT's numbers on correct code. `tailwindFlexUtilityResolves` is `false` in the
-    // `component` tier and `true` here, so it is evidence rather than a reassurance.
+    // the DEFECT's numbers on correct code. `tailwindFlexUtilityResolves` is `false` under
+    // the `component` tier's DEFAULT setup and `true` here, so it is evidence rather than a
+    // reassurance. (It would also be `true` in a `component` spec that imports
+    // `~/styles/globals.css` itself — three do. What such a spec still would not have is
+    // the layer-ORDER declaration; see the header.)
     await renderAtGridWidth(2450);
     const evidence = cascadeEvidence();
-    expect(evidence.tailwindFlexUtilityResolves, 'Tailwind utilities are inert here').toBe(true);
+    expect(
+      evidence.tailwindFlexUtilityResolves,
+      'Tailwind utilities did not resolve — the real cascade did not load'
+    ).toBe(true);
     expect(evidence.probeBoxSizing, 'Preflight did not load').toBe('border-box');
     expect(evidence.ruleCount, 'the cascade is far too small to be the real one').toBeGreaterThan(
       1000

--- a/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
@@ -7,9 +7,11 @@
  * `AppListingCard` bottom-pins its action row with `mt="auto"`, inside a
  * `<Stack h="100%">`, inside a `<Card className="h-full">`. None of that chain
  * resolves to a real height on its own: `h-full` is `height: 100%`, which needs a
- * parent with a definite height, and the only thing that gives it one is the GRID
- * stretching its items to the row's height — i.e. `align-items: normal`, the
- * default for a grid container.
+ * parent with a definite height, and what supplies one HERE is the GRID stretching its
+ * items to the row's height — i.e. `align-items: normal`, the default for a grid
+ * container. It is not the only conceivable source (a definite height on the wrapper
+ * would do it too), which is why the guard measures rendered boxes rather than asserting
+ * one particular property.
  *
  * That default is declared NOWHERE. `AppListingsMarketplaceBody.module.scss` sets
  * no `align-items` on `.grid`, so the behaviour every card depends on is an
@@ -46,8 +48,9 @@
  *
  *   · BY DEFAULT it does not. `test/component-setup.tsx` parses `globals.css?raw`
  *     into a throwaway `CSSStyleSheet`, walks it for unconditional `:root` rules and
- *     injects a `<style>` holding ONLY the `--*` custom properties — measured, 24 CSS
- *     rules. No utilities, no preflight. Its own docstring records why importing the
+ *     injects a `<style>` holding ONLY the `--*` custom properties (24 CSS rules — that
+ *     count is `test/geometry-setup.tsx`'s, recorded there 2026-09-03, and is NOT
+ *     re-measured here; what this file re-measures every run is `cascadeEvidence()`). No utilities, no preflight. Its own docstring records why importing the
  *     real sheet instead was rejected: it moves the rendered geometry of every
  *     existing test in that tier.
  *   · BUT THREE SPECS OPT IN, by importing `~/styles/globals.css` for its side effect
@@ -127,9 +130,23 @@ const mocks = vi.hoisted(() => ({ items: [] as ListingCard[] }));
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
 vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+// 🔴 THE TWO BANNERS `MainContent` ALWAYS RENDERS, STUBBED TO NULL. They are not part of
+// the width chain — they sit inside the same `<main>` and contribute no horizontal box —
+// but `VerifyEmailBanner` reads `trpc.user.resendEmailVerification`, which this file's
+// wholesale trpc factory does not carry. Stubbing the two components is a smaller and more
+// honest surface than growing that factory with routes the fixture never exercises.
+vi.mock('~/components/User/VerifyEmailBanner', () => ({ VerifyEmailBanner: () => null }));
+vi.mock('~/components/Buzz/RewardsBonusBanner', () => ({ RewardsBonusBanner: () => null }));
+// 🔴 THE FACTORY MUST NAME EVERY EXPORT THE GRAPH IMPORTS — a wholesale mock replaces the
+// module outright, so one missing name makes the whole FILE fail to import and reports as
+// `Tests no tests` rather than as a failure. `useFeatureFlagsReady` is here because
+// rendering the real `MainContent` pulls `AppLayout`'s graph in, which reads it; the exact
+// error was `does not provide an export named 'useFeatureFlagsReady'`, and half a dozen
+// sibling specs carry the same note.
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
   useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useFeatureFlagsReady: () => true,
 }));
 // Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock).
 vi.mock('~/utils/trpc', async (importOriginal) => ({
@@ -155,7 +172,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 // Import AFTER the mocks (vi.mock is hoisted; static imports are not).
 const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
 const { AppsPageLayout } = await import('./AppsPageLayout');
-const { ScrollArea } = await import('~/components/ScrollArea/ScrollArea');
+const { MainContent } = await import('~/components/AppLayout/AppLayout');
 const { APPS_CONTAINER_GUTTER } = await import('./appsPageWidths');
 const { listingGridColumnsAt, MANTINE_BREAKPOINT_PX } = await import('./appListingGrid');
 
@@ -314,26 +331,40 @@ async function renderRealChain(
   await cleanup();
   await renderAtViewport(
     <div style={{ display: 'flex', flexDirection: 'column', height: viewport.height }}>
-      <ScrollArea
+      {/* 🔴 THE REAL `MainContent`, NOT A HAND-BUILT COPY OF IT — and that is the point of
+          calling this fixture "the real chain". `MainContent` supplies BOTH links this
+          measurement depends on: the `ScrollArea` (`.scroll-area`, the scrollbar-consuming
+          box) and the `<main className="min-w-0 flex-1">` between it and the page.
+
+          That `<main>` is load-bearing, not padding: `.scroll-area` is `display: flex;
+          flex-direction: column`, and Mantine's `Container` carries `margin-inline: auto`,
+          which in a flex container's CROSS axis disables stretch — so without a plain block
+          in between, the Container shrink-to-fits its content. An earlier draft of this
+          fixture hand-wrote that `<main>` and measured 553.02px instead of 1168 when it was
+          omitted, which is how its weight was discovered.
+
+          🔴 SO IT IS RENDERED RATHER THAN COPIED. A literal `<main className="min-w-0
+          flex-1">` here would be a duplicate of a production value with nothing checking the
+          two agree: adding `px-2` to `AppLayout`'s scrollable branch would make production's
+          grid `viewport − scrollbar − 16 − 32` while this fixture kept measuring the old
+          number and stayed green. Rendering the component makes that mutation fail HERE —
+          checked, see the mutation table in the PR body.
+
+          `subNav`/`footer` are nulled because they are vertical chrome that contributes no
+          horizontal box; the two banners `MainContent` renders unconditionally are stubbed
+          above for the same reason. */}
+      <MainContent
         data-testid="scroll-area"
+        subNav={null}
+        footer={null}
         style={availableWidth != null ? { width: availableWidth } : undefined}
       >
-        {/* 🔴 `<main className="min-w-0 flex-1">` IS PART OF THE REAL CHAIN, NOT PADDING.
-            `AppLayout`'s `MainContent` puts it between the ScrollArea and the page, and
-            omitting it changes the layout: `.scroll-area` is `display: flex; flex-direction:
-            column`, and Mantine's `Container` carries `margin-inline: auto`, which in a flex
-            container's cross axis DISABLES stretch — so without this the Container
-            shrink-to-fits its content and the grid measured 553.02px instead of 1168.
-            Found by this fixture failing, which is the argument for driving the real chain
-            rather than a wrapper of a chosen width. */}
-        <main className="min-w-0 flex-1">
-          <AppsPageLayout>
-            <AppListingsMarketplaceBody />
-          </AppsPageLayout>
-        </main>
+        <AppsPageLayout>
+          <AppListingsMarketplaceBody />
+        </AppsPageLayout>
         {/* Force the overflow that makes a scrollbar appear at all. */}
         <div style={{ height: viewport.height * 4 }} />
-      </ScrollArea>
+      </MainContent>
     </div>,
     viewport
   );
@@ -389,13 +420,27 @@ async function renderRealChain(
  * without changing the browser launch args for both browser projects — out of scope for
  * this PR, and a change that would move every existing geometry number.
  *
- * The two tests below split that honestly: the first drives the real chain and asserts the
- * RELATIONSHIP that holds on every platform (the grid reads the scroll box, not the
- * viewport), and pins the harness's reserve at 0 so this note cannot silently rot; the
- * second reproduces the production-shaped case by narrowing the box by
- * `THIN_SCROLLBAR_PX`, which is deterministic in any harness.
+ * The tests below split that honestly. Three of the four drive the real chain end-to-end —
+ * one at a narrow viewport, two at wide ones so BOTH halves of the ladder are covered — and
+ * assert the relationship that holds on every platform (the grid is derived from the scroll
+ * box, through the real `MainContent`). 🔴 NONE of those three can tell a container query
+ * from a media query, because at reserve 0 the box and the viewport are the same number;
+ * measured, all three stay green under the `@container` → `@media` mutant. ALL of the
+ * box-vs-viewport discrimination lives in the FOURTH, which reproduces the production case
+ * by narrowing the box by `THIN_SCROLLBAR_PX` and is deterministic in any harness. The
+ * `expect(reserve).toBe(0)` in the first is a config tripwire, not a guard.
  */
 describe('🔴 the grid width comes from the SCROLL BOX, not from the viewport', () => {
+  /**
+   * ⚠️ THIS TEST HAS NO DISCRIMINATING POWER ON BOX-VS-VIEWPORT, deliberately stated so it
+   * is not counted as coverage it does not provide. With the harness reserve at 0 the box
+   * and the viewport are the same number, so `columns === listingGridColumnsAt(gridWidth)`
+   * holds under a media-query implementation too — measured: this test stays GREEN under
+   * the `@container` → `@media` mutant. What it does buy is the CHAIN (that the grid is
+   * derived from the scroll box's `clientWidth` minus the Container gutter at all, through
+   * the real `MainContent`) and the tripwire below. All of the box-vs-viewport
+   * discrimination lives in the next test.
+   */
   test('the real chain: grid width === scroll box clientWidth − the Container gutter', async () => {
     const VIEWPORT = { width: 1200, height: 800 };
     const m = await renderRealChain(VIEWPORT);
@@ -412,9 +457,13 @@ describe('🔴 the grid width comes from the SCROLL BOX, not from the viewport',
     expect(m.gridWidth).toBe(m.availableInBox - APPS_CONTAINER_GUTTER);
     expect(m.columns).toBe(listingGridColumnsAt(m.gridWidth));
 
-    // 🔴 THE HARNESS'S OWN BLINDNESS, PINNED. If a Playwright bump or a config change ever
-    // starts reserving scrollbar space, this fails and the note above stops being true —
-    // which is the point. It is NOT an assertion that production reserves nothing.
+    // 🔴 A CONFIG TRIPWIRE, NOT A GUARD — and the distinction is worth being blunt about.
+    // It CANNOT fail while `vitest.config.mts` passes no `ignoreDefaultArgs`, because
+    // Playwright's `--hide-scrollbars` makes the reserve 0 unconditionally. So it buys
+    // exactly one thing: if a Playwright bump or a config change ever starts reserving
+    // scrollbar space, this goes red and the docstring above stops being able to rot
+    // silently. It is NOT evidence about production, and NOT an assertion that production
+    // reserves nothing.
     expect(
       m.reserve,
       'this harness has started reserving scrollbar width — the docstring above says it ' +
@@ -423,6 +472,39 @@ describe('🔴 the grid width comes from the SCROLL BOX, not from the viewport',
     // …so, and only because of that, the box here equals the viewport.
     expect(m.availableInBox).toBe(VIEWPORT.width);
   });
+
+  /**
+   * 🔴 THE WIDE RUNGS, THROUGH THE SAME REAL CHAIN. Without this, `renderRealChain` was
+   * called twice and both times at 1200x800 — so the viewport→grid step was exercised only
+   * around rungs 3 and 4, and the wide rungs (2364 / 2840) were reached exclusively through
+   * `renderAtGridWidth`, which sets a width on a wrapper: the exact shape this file's own
+   * header calls "blind to the step in front of it". The claim that both halves of the
+   * ladder are driven end-to-end is only true with this test present.
+   *
+   * Both viewports are mid-band, not on a rung: 2300 → 2268 of grid (the four-column band
+   * runs 1168–2363) and 2500 → 2468 (five-column, 2364–2839).
+   *
+   * ⚠️ LIKE TEST 1, THESE DO NOT DISCRIMINATE BOX FROM VIEWPORT. With the harness reserve
+   * at 0 the two numbers coincide, so a media-query implementation passes them — measured:
+   * both stay GREEN under the `@container` → `@media` mutant. What they DO buy is the
+   * chain at the wide rungs (and they die to the `px-2`-on-`<main>` mutant, which is the
+   * link they are really guarding). All box-vs-viewport discrimination in this file lives
+   * in the reserved-scrollbar test below, and nowhere else.
+   */
+  test.each([
+    { viewportWidth: 2300, gridWidth: 2268, columns: 4 },
+    { viewportWidth: 2500, gridWidth: 2468, columns: 5 },
+  ])(
+    'the real chain at viewport $viewportWidth gives $gridWidth of grid and $columns columns',
+    async ({ viewportWidth, gridWidth, columns }) => {
+      const m = await renderRealChain({ width: viewportWidth, height: 900 });
+      expect(m.overflows).toBe(true);
+      expect(m.gridWidth).toBe(m.availableInBox - APPS_CONTAINER_GUTTER);
+      expect(m.gridWidth).toBe(gridWidth);
+      expect(m.columns).toBe(columns);
+      expect(m.columns).toBe(listingGridColumnsAt(m.gridWidth));
+    }
+  );
 
   test('🔴 with a thin scrollbar reserved, viewport 1200 gives THREE columns, not four', async () => {
     // THE PRODUCTION-SHAPED CASE, and the one the retired media queries got wrong. At a

--- a/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.stretch.geometry.test.tsx
@@ -146,11 +146,18 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
         }),
       },
     },
+    // `AppsPageLayout` -> `AppsSubNav` reads this; the real-chain fixture below renders
+    // the layout, so the factory has to carry it or that render throws.
+    blocks: { getNavSummary: { useQuery: () => ({ data: undefined }) } },
   },
 }));
 
 // Import AFTER the mocks (vi.mock is hoisted; static imports are not).
 const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+const { AppsPageLayout } = await import('./AppsPageLayout');
+const { ScrollArea } = await import('~/components/ScrollArea/ScrollArea');
+const { APPS_CONTAINER_GUTTER } = await import('./appsPageWidths');
+const { listingGridColumnsAt, MANTINE_BREAKPOINT_PX } = await import('./appListingGrid');
 
 /**
  * Deliberately UNEVEN content, ALTERNATING so that any prefix of two or more holds both
@@ -282,6 +289,164 @@ function firstRowCells(cells: HTMLElement[]): HTMLElement[] {
 
 beforeEach(() => {
   mocks.items = MIXED;
+});
+
+/**
+ * A THIN SCROLLBAR, in px. Chrome/Firefox on Windows and Linux reserve roughly this much
+ * inside a `scrollbar-width: thin` box; macOS overlay scrollbars and touch reserve none.
+ * Used to drive the production-shaped case deterministically — see the note on the
+ * real-chain describe below for why it cannot be measured natively here.
+ */
+const THIN_SCROLLBAR_PX = 10;
+
+/**
+ * Render the REAL production chain — `.scroll-area` -> `AppsPageLayout`'s `Container` ->
+ * the store body -> the grid — at an explicit viewport, with content tall enough that the
+ * scroll container genuinely overflows.
+ *
+ * `availableWidth` narrows the scroll box the way a reserved scrollbar does on a platform
+ * that has one. Left undefined, the box is the full viewport.
+ */
+async function renderRealChain(
+  viewport: { width: number; height: number },
+  availableWidth?: number
+) {
+  await cleanup();
+  await renderAtViewport(
+    <div style={{ display: 'flex', flexDirection: 'column', height: viewport.height }}>
+      <ScrollArea
+        data-testid="scroll-area"
+        style={availableWidth != null ? { width: availableWidth } : undefined}
+      >
+        {/* 🔴 `<main className="min-w-0 flex-1">` IS PART OF THE REAL CHAIN, NOT PADDING.
+            `AppLayout`'s `MainContent` puts it between the ScrollArea and the page, and
+            omitting it changes the layout: `.scroll-area` is `display: flex; flex-direction:
+            column`, and Mantine's `Container` carries `margin-inline: auto`, which in a flex
+            container's cross axis DISABLES stretch — so without this the Container
+            shrink-to-fits its content and the grid measured 553.02px instead of 1168.
+            Found by this fixture failing, which is the argument for driving the real chain
+            rather than a wrapper of a chosen width. */}
+        <main className="min-w-0 flex-1">
+          <AppsPageLayout>
+            <AppListingsMarketplaceBody />
+          </AppsPageLayout>
+        </main>
+        {/* Force the overflow that makes a scrollbar appear at all. */}
+        <div style={{ height: viewport.height * 4 }} />
+      </ScrollArea>
+    </div>,
+    viewport
+  );
+  await nextLayout();
+  const scrollArea = document.querySelector('[data-testid="scroll-area"]') as HTMLElement | null;
+  const grid = document.querySelector('[data-testid="apps-listing-grid"]') as HTMLElement | null;
+  const cells = Array.from(
+    document.querySelectorAll('[data-testid="apps-listing-grid-col"]')
+  ) as HTMLElement[];
+  if (!scrollArea || !grid) {
+    throw new Error(`real chain not rendered (scrollArea=${!!scrollArea} grid=${!!grid})`);
+  }
+  return {
+    scrollArea,
+    grid,
+    /** What the scroll box actually offers its content — the number the ladder reads. */
+    availableInBox: scrollArea.clientWidth,
+    /** How much the harness's scrollbar takes. 0 when scrollbars are hidden. */
+    reserve: scrollArea.offsetWidth - scrollArea.clientWidth,
+    gridWidth: q(grid.getBoundingClientRect().width),
+    columns: firstRowCells(cells).length,
+    overflows: scrollArea.scrollHeight > scrollArea.clientHeight,
+  };
+}
+
+/**
+ * 🔴 THE VIEWPORT -> GRID CHAIN, DRIVEN END TO END.
+ *
+ * Every other fixture in this PR sets the grid's width directly on a wrapper. That is the
+ * right shape for testing the LADDER, and it is blind to the step in front of it: how the
+ * grid's width is DERIVED from the viewport. That derivation is where the ladder's most
+ * quoted numbers come from, and it is not what the retired implementation did.
+ *
+ * WHAT CHANGED, AND IT IS A REAL BEHAVIOUR CHANGE, KEPT DELIBERATELY. The page's scroll
+ * container is `.scroll-area` (`AppLayout` -> `ScrollArea`), which `globals.css` gives
+ * `overflow-x: hidden` + `scrollbar-width: thin`; `html, body { overflow: hidden }` means
+ * there is no document scroll, so the apps `Container` sits INSIDE a scrollbar-consuming
+ * box. `Grid.Col span` compiled to media queries, which evaluate against the VIEWPORT and
+ * are unaffected by a scrollbar. A container query measures the real box. So on platforms
+ * that reserve a scrollbar every rung now fires ~10px of viewport later than it used to:
+ *
+ *   viewport 1200 -> grid 1158 -> THREE columns, where the media query said four.
+ *
+ * That is the more correct answer — the content never had those 10px — which is why the
+ * behaviour is kept and the "byte-equivalent below 1888" claim was retired instead. The
+ * equivalence that survives is stated as a function of GRID width, not viewport width.
+ *
+ * 🔴 WHAT THIS HARNESS STRUCTURALLY CANNOT SEE, MEASURED RATHER THAN ASSUMED. Playwright
+ * launches headless Chromium with `--hide-scrollbars`, and this repo's vitest config does
+ * not pass `ignoreDefaultArgs`. Probed directly: a genuinely overflowing `.scroll-area`
+ * with `scrollbar-width: thin` reports `offsetWidth - clientWidth === 0`. So the NATIVE
+ * reserve is zero here and no test in this project can exercise the real 10px delta
+ * without changing the browser launch args for both browser projects — out of scope for
+ * this PR, and a change that would move every existing geometry number.
+ *
+ * The two tests below split that honestly: the first drives the real chain and asserts the
+ * RELATIONSHIP that holds on every platform (the grid reads the scroll box, not the
+ * viewport), and pins the harness's reserve at 0 so this note cannot silently rot; the
+ * second reproduces the production-shaped case by narrowing the box by
+ * `THIN_SCROLLBAR_PX`, which is deterministic in any harness.
+ */
+describe('🔴 the grid width comes from the SCROLL BOX, not from the viewport', () => {
+  test('the real chain: grid width === scroll box clientWidth − the Container gutter', async () => {
+    const VIEWPORT = { width: 1200, height: 800 };
+    const m = await renderRealChain(VIEWPORT);
+
+    // The fixture is only meaningful if the container really scrolls — otherwise there
+    // would be no scrollbar to reserve on any platform and the whole question is moot.
+    expect(m.overflows, 'the scroll container does not overflow, so nothing would reserve').toBe(
+      true
+    );
+
+    // 🔴 THE RELATIONSHIP, which is true with or without a scrollbar: the ladder reads the
+    // box it is in. A media-query implementation would instead track `window.innerWidth`,
+    // and the two only agree while the reserve is 0.
+    expect(m.gridWidth).toBe(m.availableInBox - APPS_CONTAINER_GUTTER);
+    expect(m.columns).toBe(listingGridColumnsAt(m.gridWidth));
+
+    // 🔴 THE HARNESS'S OWN BLINDNESS, PINNED. If a Playwright bump or a config change ever
+    // starts reserving scrollbar space, this fails and the note above stops being true —
+    // which is the point. It is NOT an assertion that production reserves nothing.
+    expect(
+      m.reserve,
+      'this harness has started reserving scrollbar width — the docstring above says it ' +
+        'does not, and the second test below simulates what it cannot show natively'
+    ).toBe(0);
+    // …so, and only because of that, the box here equals the viewport.
+    expect(m.availableInBox).toBe(VIEWPORT.width);
+  });
+
+  test('🔴 with a thin scrollbar reserved, viewport 1200 gives THREE columns, not four', async () => {
+    // THE PRODUCTION-SHAPED CASE, and the one the retired media queries got wrong. At a
+    // 1200px viewport the `lg` breakpoint fires and `Grid.Col span` gave FOUR columns
+    // regardless of the scrollbar. The grid actually has 1200 − 10 − 32 = 1158px, which is
+    // one pixel short of the four-column rung (1168), so three is the honest answer.
+    const VIEWPORT = { width: 1200, height: 800 };
+    const m = await renderRealChain(VIEWPORT, VIEWPORT.width - THIN_SCROLLBAR_PX);
+
+    expect(m.availableInBox).toBe(VIEWPORT.width - THIN_SCROLLBAR_PX);
+    expect(m.gridWidth).toBe(1158);
+    expect(
+      m.columns,
+      'the ladder is tracking the viewport rather than the box it is in — four columns ' +
+        'here is the retired media-query answer, and it truncates every card by the ' +
+        'width the scrollbar took'
+    ).toBe(3);
+
+    // Stated as the counterfactual, so the test says what it rules out: the `lg` rung
+    // fires at viewport 1200 but needs 1168 of GRID, which this box does not have.
+    expect(MANTINE_BREAKPOINT_PX.lg).toBe(VIEWPORT.width);
+    expect(listingGridColumnsAt(VIEWPORT.width - APPS_CONTAINER_GUTTER)).toBe(4);
+    expect(listingGridColumnsAt(m.gridWidth)).toBe(3);
+  });
 });
 
 describe('🔴 the store grid stretches its cards, so their action rows stay pinned', () => {

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -226,10 +226,11 @@ export function AppListingsMarketplaceBody() {
         category: category ?? undefined,
         sort,
         // 🔴 48, NOT 24, AND IT IS THE COLUMN LADDER THAT MOVED IT. 24 was six rows at
-        // the old four-column maximum; at the SIX columns the grid now reaches on a
-        // 2560 monitor it is four, so a viewer on the widest screen the container
-        // supports would meet the "Load more" button after the least content. 48 keeps
-        // eight rows at six columns and twelve at four.
+        // the old four-column maximum; at the FIVE columns the grid now reaches on a
+        // 2560 monitor it is under five, so a viewer on the widest screen the container
+        // supports would meet the "Load more" button after the least content. 48 gives
+        // nine rows at five columns and twelve at four — and stays ≥ 8 rows even if a
+        // future cap raise engages the declared-but-unreachable sixth column.
         // 🔴 THE SERVER CAPS THIS AT 50, so 48 is deliberately just inside it.
         // `listAppListingsSchema` in
         // `src/server/schema/blocks/app-listing-read.schema.ts` declares
@@ -478,9 +479,14 @@ export function AppListingsMarketplaceBody() {
               WHAT IT DOES: 1 / 2 / 3 / 4 columns exactly where the retired
               `LISTING_GRID_SPAN` media queries put them (736 / 960 / 1168px of
               grid — those breakpoints minus the apps Container's 32px gutter), then
-              FIVE from 1979 and SIX from 2378. The store container is
-              `LISTING_STORE_CONTAINER_SIZE` = `APPS_PAGE_CONTAINER_WIDTH` = 2560,
-              so `/apps` reaches 2528 of grid on a 2560 monitor and renders six.
+              FIVE from 2364. The store container is `LISTING_STORE_CONTAINER_SIZE` =
+              `APPS_PAGE_CONTAINER_WIDTH` = 2560, so `/apps` reaches 2528 of grid on a
+              2560 monitor and renders FIVE columns at 492.8px each — wider than the
+              460px four-up the 1920 container shipped, which is the point: the
+              `LISTING_CARD_MIN_WIDTH` floor is 460, so a column is only added where
+              every card ends up at least as big as it is today. A sixth column would
+              need 2840 of grid and is unreachable at this cap; the rung is declared
+              anyway so a future cap raise engages it.
 
               WHY IT MOVED OFF `<Grid>`: `Grid.Col span` can only read a theme
               BREAKPOINT, and `xl` (88em / 1408px) is the top of Mantine's default

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -1,9 +1,9 @@
-import { Button, Center, Grid, Group, Loader, Select, Stack, Text, TextInput } from '@mantine/core';
+import { Button, Center, Group, Loader, Select, Stack, Text, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppListingCard } from '~/components/Apps/AppListingCard';
-import { LISTING_GRID_SPAN } from '~/components/Apps/appListingGrid';
+import gridClasses from '~/components/Apps/AppListingsMarketplaceBody.module.scss';
 import { AppsStoreFiltersDropdown } from '~/components/Apps/AppsStoreFiltersDropdown';
 import { hasActiveAppsStoreFilters } from '~/components/Apps/appsStoreQueryParams';
 import { useAppsStoreQueryParams } from '~/components/Apps/useAppsStoreQueryParams';
@@ -225,7 +225,17 @@ export function AppListingsMarketplaceBody() {
         kind,
         category: category ?? undefined,
         sort,
-        limit: 24,
+        // 🔴 48, NOT 24, AND IT IS THE COLUMN LADDER THAT MOVED IT. 24 was six rows at
+        // the old four-column maximum; at the SIX columns the grid now reaches on a
+        // 2560 monitor it is four, so a viewer on the widest screen the container
+        // supports would meet the "Load more" button after the least content. 48 keeps
+        // eight rows at six columns and twelve at four.
+        // 🔴 THE SERVER CAPS THIS AT 50, so 48 is deliberately just inside it.
+        // `listAppListingsSchema` in
+        // `src/server/schema/blocks/app-listing-read.schema.ts` declares
+        // `limit: z.number().int().min(1).max(50).default(20)` — a larger value is a
+        // request-time zod error, not a bigger page.
+        limit: 48,
       },
       {
         // W13 (PR-W1a/D8): store-visibility gate = the SHARED `hasAppsStoreAccess`
@@ -462,20 +472,38 @@ export function AppListingsMarketplaceBody() {
         </Center>
       ) : (
         <>
-          {/* Feedback #1 ("make app cover images larger — fewer columns per row?"):
-              at `xl` the grid drops 5 columns → 4 (`span` 2.4 → 3), so each card —
-              and therefore its responsive 16:9 cover — gets ~25% more width. The
-              container width is UNCHANGED (`LISTING_STORE_CONTAINER_SIZE`, still
-              1600, on the store index) and every other breakpoint is unchanged
-              (base 12 / sm 6 / md 4 / lg 3). Both constants live in
-              `appListingGrid.ts` so they're unit-pinned together. */}
-          <Grid gutter="md">
-            {filteredItems.map((card) => (
-              <Grid.Col key={card.id} span={LISTING_GRID_SPAN} data-testid="apps-listing-grid-col">
-                <AppListingCard card={card} canOpenPage={!!features.appBlocksPages} />
-              </Grid.Col>
-            ))}
-          </Grid>
+          {/* THE COLUMN LADDER — a CSS grid driven by a CONTAINER query, not a
+              Mantine `<Grid>`/`<Grid.Col span={…}>`.
+
+              WHAT IT DOES: 1 / 2 / 3 / 4 columns exactly where the retired
+              `LISTING_GRID_SPAN` media queries put them (736 / 960 / 1168px of
+              grid — those breakpoints minus the apps Container's 32px gutter), then
+              FIVE from 1979 and SIX from 2378. The store container is
+              `LISTING_STORE_CONTAINER_SIZE` = `APPS_PAGE_CONTAINER_WIDTH` = 2560,
+              so `/apps` reaches 2528 of grid on a 2560 monitor and renders six.
+
+              WHY IT MOVED OFF `<Grid>`: `Grid.Col span` can only read a theme
+              BREAKPOINT, and `xl` (88em / 1408px) is the top of Mantine's default
+              scale — `src/providers/ThemeProvider.tsx` declares no custom
+              breakpoints, so there was nowhere to hang a fifth column and adding a
+              breakpoint would be a site-wide theme change to fix one grid. A
+              container query also reads the right quantity: card width is not
+              monotonic in VIEWPORT width (a one-column 390px phone gets a ~356px
+              card, wider than the ~280px a four-column 1200px laptop gets).
+
+              Every threshold is derived, and `__tests__/appListingGrid.test.ts`
+              parses the stylesheet and fails unless the `@container` rules equal
+              `LISTING_GRID_COLUMN_STEPS`. The rendered column counts are measured in
+              `AppListingsMarketplaceBody.columns.browser.test.tsx`. */}
+          <div className={gridClasses.gridContainer}>
+            <div className={gridClasses.grid} data-testid="apps-listing-grid">
+              {filteredItems.map((card) => (
+                <div key={card.id} data-testid="apps-listing-grid-col">
+                  <AppListingCard card={card} canOpenPage={!!features.appBlocksPages} />
+                </div>
+              ))}
+            </div>
+          </div>
           {/* Load-more is hidden while a client-side search is active (it would
               page in more UN-searched items — the searched view is over loaded
               pages only; see the ⚠️ gap note). */}

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -480,8 +480,11 @@ export function AppListingsMarketplaceBody() {
               `LISTING_GRID_SPAN` media queries put them (736 / 960 / 1168px of
               grid — those breakpoints minus the apps Container's 32px gutter), then
               FIVE from 2364. The store container is `LISTING_STORE_CONTAINER_SIZE` =
-              `APPS_PAGE_CONTAINER_WIDTH` = 2560, so `/apps` reaches 2528 of grid on a
-              2560 monitor and renders FIVE columns at 492.8px each — wider than the
+              `APPS_PAGE_CONTAINER_WIDTH` = 2560, which yields 2528 of grid — or ~2518
+              from a 2560 VIEWPORT, since the page's `.scroll-area` reserves a thin
+              scrollbar on Windows/Linux Chrome/Firefox (macOS overlay scrollbars and
+              touch reserve none). Either way `/apps` renders FIVE columns, at 492.8px
+              or ~490.8px each — wider than the
               460px four-up the 1920 container shipped, which is the point: the
               `LISTING_CARD_MIN_WIDTH` floor is 460, so a column is only added where
               every card ends up at least as big as it is today. A sixth column would

--- a/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.chromeAlignment.browser.test.tsx
@@ -15,7 +15,9 @@
  *
  * — a 170px left / 340px width spread at 1440, and 410px / 820px at 2560. The
  * container is now uniform and the narrowing moved into the BODY, so every row of
- * that table collapses to one pair.
+ * that table collapses to one pair. (That table is a record of the PRE-FIX state and
+ * of the 1920 cap it was measured under; the uniform container is 2560 today, which is
+ * why the @2560 numbers below no longer match this column.)
  *
  * 🔴 READ THIS BEFORE TRUSTING IT AS A GATE: it is not one. This file is in the
  * Vitest browser-mode `component` project, which CI runs only as the preview
@@ -97,9 +99,18 @@ const ROUTES: { route: string; measure?: number }[] = [
 /**
  * The container's own geometry at each viewport, as LITERALS.
  *
- * Container `max-width: 1920`, `padding-inline: 16`, `margin-inline: auto`. So:
+ * Container `max-width: 2560`, `padding-inline: 16`, `margin-inline: auto`. So:
  *   1440 → narrower than the cap, full-bleed: left 16, content 1440 − 32 = 1408.
- *   2560 → capped at 1920, centred: left (2560 − 1920)/2 + 16 = 336, content 1888.
+ *   2560 → exactly the cap, still full-bleed: left 16, content 2560 − 32 = 2528.
+ *   3440 → capped, CENTRED: left (3440 − 2560)/2 + 16 = 456, content 2528.
+ *
+ * 🔴 THE THIRD ROW EXISTS BECAUSE THE SECOND STOPPED BEING THE CENTRED CASE. While the
+ * cap was 1920, a 2560 viewport exercised the centred branch; raising it to 2560 made
+ * that row full-bleed like the first, so BOTH rows would have measured the same branch
+ * and the `margin-inline: auto` half of the layout would have gone unmeasured. 3440 (a
+ * common ultrawide) restores it. Do not delete the row that is currently past the cap
+ * without adding another one — that is the branch a re-introduced per-page container
+ * width would show up in most loudly.
  *
  * 🔴 These are the POSITIVE CONTROL. "Every route agrees" is satisfied by every route
  * measuring 0, which is exactly what an unloaded stylesheet produces. Pinning the
@@ -107,7 +118,8 @@ const ROUTES: { route: string; measure?: number }[] = [
  */
 const VIEWPORTS = [
   { width: 1440, height: 900, navLeft: 16, navWidth: 1408 },
-  { width: 2560, height: 1440, navLeft: 336, navWidth: 1888 },
+  { width: 2560, height: 1440, navLeft: 16, navWidth: 2528 },
+  { width: 3440, height: 1440, navLeft: 456, navWidth: 2528 },
 ] as const;
 
 const px = (n: number) => Math.round(n * 100) / 100;

--- a/src/components/Apps/__tests__/appListingGrid.test.ts
+++ b/src/components/Apps/__tests__/appListingGrid.test.ts
@@ -1,16 +1,33 @@
+import fs from 'fs';
+import path from 'path';
 import { describe, expect, test } from 'vitest';
-import { LISTING_GRID_SPAN, LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
+import {
+  LISTING_CARD_MIN_WIDTH,
+  LISTING_GRID_COLUMN_STEPS,
+  LISTING_GRID_GUTTER,
+  LISTING_GRID_SPAN,
+  LISTING_STORE_CONTAINER_SIZE,
+  listingCardWidthAt,
+  listingGridColumnsAt,
+  MANTINE_BREAKPOINT_PX,
+  minContentWidthForColumns,
+} from '~/components/Apps/appListingGrid';
+import { APPS_CONTAINER_GUTTER, APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
 
 /**
  * `/apps` store GEOMETRY pins (blocking `unit` project).
  *
- * The product feedback was "make app cover images larger — fewer columns per
- * row?". The implementation answer is a ONE-breakpoint change (xl 2.4 → 3, i.e.
- * five columns → four) plus a responsive 16:9 cover in `AppListingCard` — with
- * the CONTAINER WIDTH LEFT ALONE. All three halves of that statement are pinned
- * here so a later tweak can't quietly re-narrow the cards or widen the page.
+ * Two decisions live here and they are a matched pair: how wide a row is (the
+ * container) and how many cards sit in it (the ladder). Both are pinned, plus the
+ * seam between the ladder and the stylesheet that implements it — the one place the
+ * derivation could silently stop being true.
+ *
+ * The RENDERED column counts are measured in
+ * `AppListingsMarketplaceBody.columns.browser.test.tsx`. This file is the tier that
+ * gates.
  */
-describe('LISTING_GRID_SPAN', () => {
+
+describe('LISTING_GRID_SPAN — the legacy breakpoint spans the narrow ladder is derived from', () => {
   test('xl yields FOUR columns (span 3 of 12) — the larger-cover change', () => {
     expect(LISTING_GRID_SPAN.xl).toBe(3);
     expect(12 / LISTING_GRID_SPAN.xl).toBe(4);
@@ -42,13 +59,418 @@ describe('LISTING_GRID_SPAN', () => {
 });
 
 describe('LISTING_STORE_CONTAINER_SIZE', () => {
-  test('the store container is the WIDE apps-page width (1920)', () => {
-    // Moved 1600 → 1920 by the full-width pass. The span above was deliberately
-    // NOT re-tuned: four columns at 1920 is ~460 px per card, i.e. WIDER than the
-    // ~383 px the larger-cover pass shipped at 1600, so the cover change is
-    // amplified rather than undone. The container/span arithmetic is pinned in
-    // `__tests__/appsPageWidths.test.ts`; the number itself is single-sourced
-    // from `appsPageWidths.ts`.
-    expect(LISTING_STORE_CONTAINER_SIZE).toBe(1920);
+  test('the store container is the ULTRAWIDE apps-page width (2560)', () => {
+    // Moved 1600 → 1920 by the full-width pass and 1920 → 2560 by the ultrawide
+    // pass. The number itself is single-sourced from `appsPageWidths.ts`; the
+    // container/ladder arithmetic is pinned in `__tests__/appsPageWidths.test.ts`.
+    expect(LISTING_STORE_CONTAINER_SIZE).toBe(2560);
+    expect(LISTING_STORE_CONTAINER_SIZE).toBe(APPS_PAGE_CONTAINER_WIDTH);
+  });
+});
+
+describe('🔴 the column LADDER — grid width → column count', () => {
+  /**
+   * THE TABLE, AS LITERALS.
+   *
+   * 🔴 THE THRESHOLDS ARE WRITTEN OUT HERE RATHER THAN COMPUTED FROM THE MODULE, and
+   * that is the entire value of this test. `LISTING_GRID_COLUMN_STEPS` derives itself
+   * from `LISTING_GRID_SPAN` + `MANTINE_BREAKPOINT_PX` + `LISTING_CARD_MIN_WIDTH`; a
+   * test that re-ran the same derivation would agree with any mutation of any of those
+   * inputs. Literals are the independent witness — move the card-width floor and 1979
+   * stops being what the module produces.
+   *
+   * Each band is probed at THREE points, never on a boundary alone: one pixel below the
+   * threshold, on it, and comfortably inside the band. A fixture that sits exactly on a
+   * threshold cannot see an off-by-one in the wrong direction.
+   */
+  const LADDER: { contentWidth: number; columns: number; why: string }[] = [
+    { contentWidth: 0, columns: 1, why: 'degenerate — a zero-width grid is still one column' },
+    { contentWidth: 390, columns: 1, why: 'a phone, inside the base band' },
+    { contentWidth: 735, columns: 1, why: 'one px below the sm rung' },
+    { contentWidth: 736, columns: 2, why: 'sm — viewport 768 minus the 32px apps gutter' },
+    { contentWidth: 850, columns: 2, why: 'inside the sm band' },
+    { contentWidth: 959, columns: 2, why: 'one px below the md rung' },
+    { contentWidth: 960, columns: 3, why: 'md — viewport 992 minus the gutter' },
+    { contentWidth: 1100, columns: 3, why: 'inside the md band' },
+    { contentWidth: 1167, columns: 3, why: 'one px below the lg rung' },
+    { contentWidth: 1168, columns: 4, why: 'lg — viewport 1200 minus the gutter' },
+    { contentWidth: 1376, columns: 4, why: 'the old xl breakpoint (1408) — still four' },
+    { contentWidth: 1888, columns: 4, why: 'what the RETIRED 1920 container reached — unchanged' },
+    { contentWidth: 1978, columns: 4, why: 'one px below the five-column rung' },
+    { contentWidth: 1979, columns: 5, why: '5 × 383 + 4 × 16 — five cards at exactly the floor' },
+    { contentWidth: 2100, columns: 5, why: 'inside the five-column band' },
+    { contentWidth: 2377, columns: 5, why: 'one px below the six-column rung' },
+    { contentWidth: 2378, columns: 6, why: '6 × 383 + 5 × 16 — six cards at exactly the floor' },
+    { contentWidth: 2528, columns: 6, why: 'what /apps reaches at a 2560 container' },
+    {
+      contentWidth: 4000,
+      columns: 6,
+      why: 'past the top rung — the ladder stops, it does not wrap',
+    },
+  ];
+
+  test.each(LADDER)(
+    '$contentWidth px of grid → $columns columns ($why)',
+    ({ contentWidth, columns }) => {
+      expect(listingGridColumnsAt(contentWidth)).toBe(columns);
+    }
+  );
+
+  test('the table probes both sides of every rung (guard-the-guard)', () => {
+    // A table that only ever sampled the middle of a band could not see a threshold
+    // move by one. Every rung must appear as a (threshold − 1, threshold) pair.
+    const widths = new Set(LADDER.map((r) => r.contentWidth));
+    for (const step of LISTING_GRID_COLUMN_STEPS) {
+      if (step.minContentWidth === 0) continue;
+      expect(widths, `rung ${step.minContentWidth} is not probed ON its threshold`).toContain(
+        step.minContentWidth
+      );
+      expect(widths, `rung ${step.minContentWidth} is not probed one px BELOW`).toContain(
+        step.minContentWidth - 1
+      );
+    }
+    // …and it exercises every column count the ladder can produce.
+    expect(new Set(LADDER.map((r) => r.columns))).toEqual(new Set([1, 2, 3, 4, 5, 6]));
+  });
+
+  test('the ladder is exactly these six rungs, in ascending order', () => {
+    // A ledger, not a floor: the loops above iterate it, so a ladder that silently
+    // grew a seventh rung (or lost one) would still satisfy them.
+    expect(LISTING_GRID_COLUMN_STEPS).toEqual([
+      { minContentWidth: 0, columns: 1 },
+      { minContentWidth: 736, columns: 2 },
+      { minContentWidth: 960, columns: 3 },
+      { minContentWidth: 1168, columns: 4 },
+      { minContentWidth: 1979, columns: 5 },
+      { minContentWidth: 2378, columns: 6 },
+    ]);
+    const widths = LISTING_GRID_COLUMN_STEPS.map((s) => s.minContentWidth);
+    expect([...widths].sort((a, b) => a - b)).toEqual(widths);
+    const columns = LISTING_GRID_COLUMN_STEPS.map((s) => s.columns);
+    expect([...columns].sort((a, b) => a - b)).toEqual(columns);
+    // No redundant rung — `lg` and `xl` are both four columns and must collapse to one.
+    expect(new Set(columns).size).toBe(columns.length);
+  });
+});
+
+describe('🔴 the NARROW half is byte-equivalent to the retired Mantine media queries', () => {
+  /**
+   * The claim this file has to make good on: moving off `<Grid.Col span={…}>` changed
+   * WHERE the column count is decided (grid width, not viewport width) but not WHAT it
+   * decides at any width `/apps` actually renders at.
+   *
+   * The conversion is one subtraction: a Mantine breakpoint fires at viewport `V`,
+   * `/apps` takes no body measure, and the apps `Container` is full-bleed below its cap
+   * — so the grid at that instant is `V − APPS_CONTAINER_GUTTER` wide.
+   */
+  test('each retired breakpoint maps to its rung by exactly one subtraction', () => {
+    const cases: [keyof typeof LISTING_GRID_SPAN, number][] = [
+      ['base', 1],
+      ['sm', 2],
+      ['md', 3],
+      ['lg', 4],
+      ['xl', 4],
+    ];
+    for (const [breakpoint, columns] of cases) {
+      expect(12 / LISTING_GRID_SPAN[breakpoint], `${breakpoint} span`).toBe(columns);
+      const gridWidth = Math.max(0, MANTINE_BREAKPOINT_PX[breakpoint] - APPS_CONTAINER_GUTTER);
+      expect(
+        listingGridColumnsAt(gridWidth),
+        `at the ${breakpoint} breakpoint (viewport ${MANTINE_BREAKPOINT_PX[breakpoint]}, ` +
+          `grid ${gridWidth}) the ladder must give what span ${LISTING_GRID_SPAN[breakpoint]} gave`
+      ).toBe(columns);
+      // …and NOT one px earlier, which is what an off-by-one conversion looks like.
+      if (gridWidth > 0) {
+        expect(listingGridColumnsAt(gridWidth - 1), `${breakpoint} fires one px early`).toBe(
+          columns - (breakpoint === 'xl' ? 0 : 1)
+        );
+      }
+    }
+  });
+
+  test('Mantine`s default breakpoints are recorded as the px this app renders them at', () => {
+    // The theme declares NO custom breakpoints, so these are Mantine v7's defaults at a
+    // 16px root: xs 36em, sm 48em, md 62em, lg 75em, xl 88em. Pinned as literals because
+    // the ladder above is derived from them — if a theme ever declares its own, this
+    // fails before the derivation silently starts describing a different app.
+    expect(MANTINE_BREAKPOINT_PX).toEqual({
+      base: 0,
+      xs: 576,
+      sm: 768,
+      md: 992,
+      lg: 1200,
+      xl: 1408,
+    });
+    for (const [name, em] of [
+      ['xs', 36],
+      ['sm', 48],
+      ['md', 62],
+      ['lg', 75],
+      ['xl', 88],
+    ] as const) {
+      expect(MANTINE_BREAKPOINT_PX[name], `${name} = ${em}em at a 16px root`).toBe(em * 16);
+    }
+  });
+});
+
+describe('🔴 the WIDE half holds the card-width floor', () => {
+  test('the floor is 383px, and the thresholds are what it produces', () => {
+    // 🔴 THE FLOOR IS THE MUTATION TARGET. Lowering it moves both thresholds, and the
+    // literals below are what notice. Without them the derivation would agree with any
+    // floor at all.
+    expect(LISTING_CARD_MIN_WIDTH).toBe(383);
+    expect(LISTING_GRID_GUTTER).toBe(16);
+    expect(minContentWidthForColumns(5)).toBe(1979); // 5 × 383 + 4 × 16
+    expect(minContentWidthForColumns(6)).toBe(2378); // 6 × 383 + 5 × 16
+    // A seventh column would need this much grid — stated so the next person adding one
+    // can see the cost rather than picking a threshold by eye.
+    expect(minContentWidthForColumns(7)).toBe(2777); // 7 × 383 + 6 × 16
+  });
+
+  test('every FLOOR-DERIVED rung gives cards at least the floor wide, at its threshold', () => {
+    // 🔴 THIS IS THE PIN THAT STOPS A SEVENTH COLUMN GOING UNDER THE FLOOR. It reads the
+    // ladder, not the derivation, so a rung added with a hand-picked threshold fails here.
+    const wide = LISTING_GRID_COLUMN_STEPS.filter((s) => s.columns >= 5);
+    expect(wide.length, 'no wide rungs to check — the loop would pass vacuously').toBe(2);
+    for (const step of wide) {
+      const cardWidth = listingCardWidthAt(step.minContentWidth, step.columns);
+      expect(
+        cardWidth,
+        `${step.columns} columns at ${step.minContentWidth}px of grid gives ${cardWidth}px cards`
+      ).toBeGreaterThanOrEqual(LISTING_CARD_MIN_WIDTH);
+      // …and the threshold is MINIMAL: one px narrower and it would not.
+      expect(
+        listingCardWidthAt(step.minContentWidth - 1, step.columns),
+        `${step.columns} columns is placed later than it needs to be`
+      ).toBeLessThan(LISTING_CARD_MIN_WIDTH);
+    }
+  });
+
+  test('adding a column never makes a card narrower than the one below it did at ITS threshold', () => {
+    // The ladder's whole promise, stated as a relationship rather than per-rung numbers:
+    // a column is added only where each card is still at least the floor, so the sequence
+    // of card widths AT THE THRESHOLDS is flat at the floor rather than decreasing.
+    for (const step of LISTING_GRID_COLUMN_STEPS.filter((s) => s.columns >= 5)) {
+      const here = listingCardWidthAt(step.minContentWidth, step.columns);
+      const ifWeHadNotAdded = listingCardWidthAt(step.minContentWidth, step.columns - 1);
+      expect(here).toBeLessThan(ifWeHadNotAdded);
+      expect(here).toBeGreaterThanOrEqual(LISTING_CARD_MIN_WIDTH);
+    }
+  });
+
+  test('🔴 an intrinsic auto-fill grid CANNOT express this ladder (the derivation, checked)', () => {
+    // The reason `repeat(auto-fill, minmax(X, 1fr))` was rejected, as arithmetic rather
+    // than as prose. `auto-fill` fits `floor((W + gap) / (X + gap))` columns.
+    const autoFillColumns = (gridWidth: number, floor: number) =>
+      Math.max(1, Math.floor((gridWidth + LISTING_GRID_GUTTER) / (floor + LISTING_GRID_GUTTER)));
+
+    const XL_LOW_END = MANTINE_BREAKPOINT_PX.xl - APPS_CONTAINER_GUTTER; // 1376
+    const OLD_CONTAINER_CONTENT = 1920 - APPS_CONTAINER_GUTTER; // 1888
+    expect(XL_LOW_END).toBe(1376);
+    expect(OLD_CONTAINER_CONTENT).toBe(1888);
+
+    // Keeping FOUR at 1376 needs a floor of at most 332…
+    expect(autoFillColumns(XL_LOW_END, 332)).toBe(4);
+    expect(autoFillColumns(XL_LOW_END, 333)).toBe(3);
+    // …and any floor that low gives FIVE at 1888, at 364.8px per card — narrower than
+    // the ~380px the covers pass moved TO when it went five columns → four.
+    expect(autoFillColumns(OLD_CONTAINER_CONTENT, 332)).toBe(5);
+    expect(listingCardWidthAt(OLD_CONTAINER_CONTENT, 5)).toBeCloseTo(364.8, 5);
+    expect(364.8).toBeLessThan(LISTING_CARD_MIN_WIDTH);
+    // Holding four at 1888 needs a floor above 364.8 — which then gives THREE at 1376.
+    expect(autoFillColumns(OLD_CONTAINER_CONTENT, 365)).toBe(4);
+    expect(autoFillColumns(XL_LOW_END, 365)).toBe(3);
+    // The two requirements have no overlap. That is the whole argument.
+    expect(332).toBeLessThan(365);
+  });
+});
+
+describe('🔴 SEAM — the store page size fits the ladder AND the server cap', () => {
+  /**
+   * The page size is a CONSEQUENCE of the ladder: 24 was six rows at the old four-column
+   * maximum and only four at the six columns the grid now reaches, so the widest screen
+   * the container supports would have met "Load more" after the least content.
+   *
+   * It is also bounded by something this component cannot see. `listAppListingsSchema`
+   * caps `limit` at 50, and exceeding it is a request-time zod error rather than a bigger
+   * page — a failure that shows up as a broken store, not as a build error, because the
+   * two live in different files with no type relating them. Hence a seam test rather than
+   * two independent claims.
+   */
+  const BODY = path.resolve(__dirname, '../AppListingsMarketplaceBody.tsx');
+  const bodyCode = fs
+    .readFileSync(BODY, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '');
+
+  /** The `limit:` the store body actually requests. */
+  function requestedLimit(): number {
+    const m = bodyCode.match(/limit:\s*(\d+)/);
+    if (!m) throw new Error('no `limit:` found in AppListingsMarketplaceBody.tsx');
+    return Number(m[1]);
+  }
+
+  test('the store requests 48 per page', () => {
+    // 🔴 The comment strip is load-bearing here too: the prose beside this call names
+    // both 48 and 50, so an unstripped scan could read either out of a docstring.
+    expect(bodyCode).not.toContain('THE SERVER CAPS THIS AT');
+    expect(requestedLimit()).toBe(48);
+  });
+
+  test('…which is eight rows at the ladder`s top rung, and twelve at the one below', () => {
+    const top = LISTING_GRID_COLUMN_STEPS[LISTING_GRID_COLUMN_STEPS.length - 1].columns;
+    expect(top).toBe(6);
+    expect(requestedLimit() / top).toBe(8);
+    expect(requestedLimit() / 4).toBe(12);
+  });
+
+  test('🔴 …and it is inside the SERVER`s own cap, read from the schema', () => {
+    // The cap is parsed rather than restated: `listAppListingsSchema` is the authority,
+    // and a schema change that lowered it would otherwise leave this test asserting a
+    // number the server no longer accepts.
+    const schemaSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../../server/schema/blocks/app-listing-read.schema.ts'),
+      'utf8'
+    );
+    const decl = schemaSrc.match(
+      /export const listAppListingsSchema[\s\S]*?limit:\s*z\.number\(\)[^;\n]*?\.max\((\d+)\)/
+    );
+    expect(decl, 'could not read the limit cap out of listAppListingsSchema').not.toBeNull();
+    const cap = Number(decl![1]);
+    expect(cap).toBe(50); // positive control on the parse
+    expect(requestedLimit()).toBeLessThanOrEqual(cap);
+  });
+});
+
+describe('🔴 SEAM — the stylesheet implements exactly the ladder, and nothing else', () => {
+  /**
+   * 🔴 WHY THIS IS THE LOAD-BEARING TEST IN THE FILE. `LISTING_GRID_COLUMN_STEPS` is a
+   * TypeScript value that nothing at runtime reads: the column count is applied by
+   * `AppListingsMarketplaceBody.module.scss`, whose thresholds are hand-written CSS
+   * literals. Each half is individually correct-looking while disagreeing with the
+   * other, and neither throws — the grid would simply render a different number of
+   * columns than every constant and comment in the codebase says it does.
+   *
+   * So the checkable claim is the RELATIONSHIP, checked in BOTH directions: no rung
+   * without a rule, no rule without a rung.
+   *
+   * WHAT THIS CANNOT SEE (stated, so nobody reads it as more than it is): a rule that
+   * is present but overridden later in the cascade, a `container-type` that never got
+   * applied, or anything about how the grid actually lays out. Those are pixel facts and
+   * only `AppListingsMarketplaceBody.columns.browser.test.tsx` can see them.
+   */
+  const STYLES = path.resolve(__dirname, '../AppListingsMarketplaceBody.module.scss');
+
+  /**
+   * 🔴 READ LAZILY, INSIDE EACH TEST, NOT AT COLLECTION TIME. A `readFileSync` in the
+   * describe body throws during COLLECTION when the stylesheet is missing, and Vitest
+   * reports that as `Tests no tests` — the reassuring-zero shape — rather than as a
+   * failure naming the missing file. A deleted stylesheet is precisely the defect this
+   * seam exists to catch, so it has to arrive as a red assertion.
+   */
+  function readStyles(): string {
+    if (!fs.existsSync(STYLES)) {
+      throw new Error(
+        `the store grid's stylesheet is missing at ${STYLES} — the column ladder is ` +
+          'declared in TypeScript and applied there, so without it the grid renders one column.'
+      );
+    }
+    return fs.readFileSync(STYLES, 'utf8');
+  }
+
+  /**
+   * Comments stripped FIRST. Load-bearing rather than tidy: the stylesheet's own
+   * docstrings name `736`, `1979` and `2378` verbatim, so an unstripped scan would be
+   * reading the prose and would stay green with every real rule deleted.
+   */
+  const strip = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+  /** Every `@container (min-width: Npx) { … repeat(C, …) }` pair, in file order. */
+  function parsedRules(): { minContentWidth: number; columns: number }[] {
+    const out: { minContentWidth: number; columns: number }[] = [];
+    const re =
+      /@container\s*\(\s*min-width:\s*(\d+)px\s*\)\s*\{[\s\S]*?grid-template-columns:\s*repeat\(\s*(\d+)\s*,/g;
+    for (const m of strip(readStyles()).matchAll(re)) {
+      out.push({ minContentWidth: Number(m[1]), columns: Number(m[2]) });
+    }
+    return out;
+  }
+
+  test('POSITIVE CONTROL — the parser finds rules at all, and the comment strip did not eat them', () => {
+    // A reassuring empty set is indistinguishable from a regex that matches nothing.
+    const source = readStyles();
+    const code = strip(source);
+    const rules = parsedRules();
+    expect(rules.length, 'no @container rules parsed out of the stylesheet').toBeGreaterThan(0);
+    // And the strip really removed the prose: the header names 1600, which is not a rung.
+    expect(source).toContain('1600');
+    expect(code).not.toContain('1600');
+  });
+
+  test('the base rule is ONE column, and it is not inside a container query', () => {
+    // The ladder's first rung has no `@container` — it is the default the queries
+    // override. Without it a narrow grid would inherit whatever `display: grid` defaults
+    // to (a single implicit column), which is right by accident rather than by decision.
+    const code = strip(readStyles());
+    const base = code.slice(0, code.indexOf('@container'));
+    expect(base).toMatch(/grid-template-columns:\s*repeat\(\s*1\s*,/);
+    expect(base).toMatch(/display:\s*grid/);
+  });
+
+  test('the gap matches LISTING_GRID_GUTTER (it is part of the threshold arithmetic)', () => {
+    expect(strip(readStyles())).toMatch(new RegExp(`gap:\\s*${LISTING_GRID_GUTTER}px`));
+  });
+
+  test('🔴 the @container rules EQUAL the derived ladder — no rung without a rule, no rule without a rung', () => {
+    const expected = LISTING_GRID_COLUMN_STEPS.filter((s) => s.minContentWidth > 0).map((s) => ({
+      minContentWidth: s.minContentWidth,
+      columns: s.columns,
+    }));
+    expect(
+      parsedRules(),
+      'AppListingsMarketplaceBody.module.scss and LISTING_GRID_COLUMN_STEPS disagree. ' +
+        'The stylesheet is what actually renders; the constants are what everything else ' +
+        'reasons about. Move both or neither.'
+    ).toEqual(expected);
+  });
+
+  test('the query container is a SEPARATE element from the grid', () => {
+    // `@container` resolves against an ANCESTOR container, never the queried element, so
+    // `container-type` and `grid-template-columns` on one element matches nothing and the
+    // grid silently stays at one column — with no error anywhere.
+    const code = strip(readStyles());
+    expect(code).toMatch(/\.gridContainer\s*\{[^}]*container-type:\s*inline-size/);
+    expect(code).not.toMatch(/\.grid\s*\{[^}]*container-type/);
+  });
+
+  test('the component renders BOTH classes, in that nesting order', () => {
+    // The other half of the seam: a stylesheet whose classes nothing references changes
+    // no pixels, and a `className` naming a class the stylesheet does not declare
+    // resolves to `undefined`, renders no attribute and throws nothing.
+    const body = fs.readFileSync(
+      path.resolve(__dirname, '../AppListingsMarketplaceBody.tsx'),
+      'utf8'
+    );
+    const bodyCode = body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+    expect(bodyCode).toContain('AppListingsMarketplaceBody.module.scss');
+    const container = bodyCode.indexOf('gridClasses.gridContainer');
+    const grid = bodyCode.indexOf('gridClasses.grid}');
+    expect(container, 'the grid container class is not rendered').toBeGreaterThan(-1);
+    expect(grid, 'the grid class is not rendered').toBeGreaterThan(-1);
+    expect(container, 'the container must WRAP the grid, not sit inside it').toBeLessThan(grid);
+    // And the cells still carry the testid the browser tests select on.
+    expect(bodyCode).toContain(`data-testid="apps-listing-grid-col"`);
+  });
+
+  test('🔴 the retired Mantine <Grid> is really gone from the store body', () => {
+    // Leaving it in place beside the CSS grid would double the columns' worth of markup
+    // and make the container query describe a layout nothing renders.
+    const body = fs.readFileSync(
+      path.resolve(__dirname, '../AppListingsMarketplaceBody.tsx'),
+      'utf8'
+    );
+    const bodyCode = body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+    expect(bodyCode).not.toMatch(/<Grid[\s>]/);
+    expect(bodyCode).not.toMatch(/<Grid\.Col[\s>]/);
   });
 });

--- a/src/components/Apps/__tests__/appListingGrid.test.ts
+++ b/src/components/Apps/__tests__/appListingGrid.test.ts
@@ -113,7 +113,7 @@ describe('🔴 the column LADDER — grid width → column count', () => {
     {
       contentWidth: 2528,
       columns: 5,
-      why: 'what /apps reaches at a 2560 container — 492.8px cards',
+      why: 'a 2560 CONTAINER yields this much grid — 492.8px cards',
     },
     { contentWidth: 2839, columns: 5, why: 'one px below the (unreachable) six-column rung' },
     {
@@ -258,15 +258,26 @@ describe('🔴 THE COLLISION — the card-width floor must NOT govern the narrow
   });
 });
 
-describe('🔴 the NARROW half is byte-equivalent to the retired Mantine media queries', () => {
+describe('🔴 the NARROW rungs are unchanged as functions of GRID width', () => {
   /**
-   * The claim this file has to make good on: moving off `<Grid.Col span={…}>` changed
-   * WHERE the column count is decided (grid width, not viewport width) but not WHAT it
-   * decides at any width `/apps` actually renders at.
+   * What moving off `<Grid.Col span={…}>` did and did not change.
    *
-   * The conversion is one subtraction: a Mantine breakpoint fires at viewport `V`,
-   * `/apps` takes no body measure, and the apps `Container` is full-bleed below its cap
-   * — so the grid at that instant is `V − APPS_CONTAINER_GUTTER` wide.
+   * DID NOT: the column count at any given GRID width below the five-column rung. Each
+   * narrow rung is the old breakpoint minus one subtraction — a Mantine breakpoint fires
+   * at viewport `V`, `/apps` takes no body measure, and the apps `Container` is
+   * full-bleed below its cap, so the rung sits at `V − APPS_CONTAINER_GUTTER` of grid.
+   *
+   * 🔴 DID: the mapping from VIEWPORT to grid width, and therefore the viewport at which
+   * a rung fires. This describe was titled "byte-equivalent to the retired Mantine media
+   * queries" and that was FALSE in production. The page's scroll container `.scroll-area`
+   * is `scrollbar-width: thin` with no document scroll, so the grid is
+   * `viewport − scrollbar − 32`; media queries ignored the scrollbar, a container query
+   * does not. On platforms that reserve one (~10px) every rung fires ~10px of viewport
+   * later than before. Kept deliberately — the content never had those pixels — and
+   * driven end-to-end in `AppListingsMarketplaceBody.stretch.geometry.test.tsx`, which is
+   * the only test in this PR that exercises the viewport→grid step at all.
+   *
+   * So everything below is stated in GRID width, which is what it was always measuring.
    */
   test('each retired breakpoint maps to its rung by exactly one subtraction', () => {
     const cases: [keyof typeof LISTING_GRID_SPAN, number][] = [
@@ -437,9 +448,15 @@ describe('🔴 the WIDE half holds the card-width floor', () => {
 
 describe('🔴 SEAM — the store page size fits the ladder AND the server cap', () => {
   /**
-   * The page size is a CONSEQUENCE of the ladder: 24 was six rows at the old four-column
-   * maximum and only four at the six columns the grid now reaches, so the widest screen
-   * the container supports would have met "Load more" after the least content.
+   * The page size is a CONSEQUENCE of the ladder: 24 was six rows at four columns and
+   * only 4.8 at the FIVE columns the grid now reaches, so the widest screen the container
+   * supports would have met "Load more" after the least content.
+   *
+   * ⚠️ This paragraph said "the six columns the grid now reaches" until the floor moved
+   * from 383 to 460 in this same PR, which made six unreachable — see the
+   * `SIX columns is declared but UNREACHABLE` test above. A claim that was true when
+   * written and falsified by a LATER commit of its own branch sits inside no review
+   * round's diff, which is exactly how it survived.
    *
    * It is also bounded by something this component cannot see. `listAppListingsSchema`
    * caps `limit` at 50, and exceeding it is a request-time zod error rather than a bigger
@@ -468,8 +485,8 @@ describe('🔴 SEAM — the store page size fits the ladder AND the server cap',
   });
 
   test('…which is at least eight rows at the widest REACHABLE column count, and twelve at four', () => {
-    // Written against what a viewer can actually reach (five columns at the 2528 this
-    // container tops out at), not against the declared-but-unreachable sixth rung — and
+    // Written against what a viewer can actually reach (five columns at the 2528 of grid
+    // this container yields), not against the declared-but-unreachable sixth rung — and
     // as a `>=` so it stays true if a future cap raise engages that rung (48 / 6 = 8).
     const widestReachable = listingGridColumnsAt(APPS_PAGE_CONTAINER_WIDTH - APPS_CONTAINER_GUTTER);
     expect(widestReachable).toBe(5);

--- a/src/components/Apps/__tests__/appListingGrid.test.ts
+++ b/src/components/Apps/__tests__/appListingGrid.test.ts
@@ -275,7 +275,8 @@ describe('🔴 the NARROW rungs are unchanged as functions of GRID width', () =>
    * does not. On platforms that reserve one (~10px) every rung fires ~10px of viewport
    * later than before. Kept deliberately — the content never had those pixels — and
    * driven end-to-end in `AppListingsMarketplaceBody.stretch.geometry.test.tsx`, which is
-   * the only test in this PR that exercises the viewport→grid step at all.
+   * the only SPEC in this PR that exercises the viewport→grid step at all — every other
+   * fixture sets the grid's width directly on a wrapper.
    *
    * So everything below is stated in GRID width, which is what it was always measuring.
    */

--- a/src/components/Apps/__tests__/appListingGrid.test.ts
+++ b/src/components/Apps/__tests__/appListingGrid.test.ts
@@ -76,12 +76,21 @@ describe('🔴 the column LADDER — grid width → column count', () => {
    * that is the entire value of this test. `LISTING_GRID_COLUMN_STEPS` derives itself
    * from `LISTING_GRID_SPAN` + `MANTINE_BREAKPOINT_PX` + `LISTING_CARD_MIN_WIDTH`; a
    * test that re-ran the same derivation would agree with any mutation of any of those
-   * inputs. Literals are the independent witness — move the card-width floor and 1979
+   * inputs. Literals are the independent witness — move the card-width floor and 2364
    * stops being what the module produces.
    *
    * Each band is probed at THREE points, never on a boundary alone: one pixel below the
    * threshold, on it, and comfortably inside the band. A fixture that sits exactly on a
    * threshold cannot see an off-by-one in the wrong direction.
+   *
+   * 🔴 THE 1376 / 1887 / 1888 ROWS ARE THE MOST IMPORTANT IN THIS TABLE, and they exist
+   * because of an arithmetic COLLISION rather than because anything is near a rung:
+   * `4 × 460 + 3 × 16 = 1888`, so at today's floor the four-column rung would land on
+   * exactly the retired 1920 container's content width IF the floor governed the narrow
+   * half. It does not — but that is a claim about a derivation, and this is the width
+   * band where being wrong about it is invisible. 1376 is the `xl` low end: the safe
+   * middle of the desktop range, and the first thing a floor-governed narrow half would
+   * silently break. See the dedicated describe below.
    */
   const LADDER: { contentWidth: number; columns: number; why: string }[] = [
     { contentWidth: 0, columns: 1, why: 'degenerate — a zero-width grid is still one column' },
@@ -94,14 +103,24 @@ describe('🔴 the column LADDER — grid width → column count', () => {
     { contentWidth: 1100, columns: 3, why: 'inside the md band' },
     { contentWidth: 1167, columns: 3, why: 'one px below the lg rung' },
     { contentWidth: 1168, columns: 4, why: 'lg — viewport 1200 minus the gutter' },
-    { contentWidth: 1376, columns: 4, why: 'the old xl breakpoint (1408) — still four' },
-    { contentWidth: 1888, columns: 4, why: 'what the RETIRED 1920 container reached — unchanged' },
-    { contentWidth: 1978, columns: 4, why: 'one px below the five-column rung' },
-    { contentWidth: 1979, columns: 5, why: '5 × 383 + 4 × 16 — five cards at exactly the floor' },
-    { contentWidth: 2100, columns: 5, why: 'inside the five-column band' },
-    { contentWidth: 2377, columns: 5, why: 'one px below the six-column rung' },
-    { contentWidth: 2378, columns: 6, why: '6 × 383 + 5 × 16 — six cards at exactly the floor' },
-    { contentWidth: 2528, columns: 6, why: 'what /apps reaches at a 2560 container' },
+    { contentWidth: 1376, columns: 4, why: 'THE COLLISION GUARD — the xl low end (1408 − 32)' },
+    { contentWidth: 1887, columns: 4, why: 'THE COLLISION GUARD — one px below 4 × 460 + 3 × 16' },
+    { contentWidth: 1888, columns: 4, why: 'THE COLLISION GUARD — exactly 4 × 460 + 3 × 16' },
+    { contentWidth: 2100, columns: 4, why: 'still four — the fifth column is not free' },
+    { contentWidth: 2363, columns: 4, why: 'one px below the five-column rung' },
+    { contentWidth: 2364, columns: 5, why: '5 × 460 + 4 × 16 — five cards at exactly the floor' },
+    { contentWidth: 2450, columns: 5, why: 'inside the five-column band' },
+    {
+      contentWidth: 2528,
+      columns: 5,
+      why: 'what /apps reaches at a 2560 container — 492.8px cards',
+    },
+    { contentWidth: 2839, columns: 5, why: 'one px below the (unreachable) six-column rung' },
+    {
+      contentWidth: 2840,
+      columns: 6,
+      why: '6 × 460 + 5 × 16 — declared, but past the container cap',
+    },
     {
       contentWidth: 4000,
       columns: 6,
@@ -141,8 +160,8 @@ describe('🔴 the column LADDER — grid width → column count', () => {
       { minContentWidth: 736, columns: 2 },
       { minContentWidth: 960, columns: 3 },
       { minContentWidth: 1168, columns: 4 },
-      { minContentWidth: 1979, columns: 5 },
-      { minContentWidth: 2378, columns: 6 },
+      { minContentWidth: 2364, columns: 5 },
+      { minContentWidth: 2840, columns: 6 },
     ]);
     const widths = LISTING_GRID_COLUMN_STEPS.map((s) => s.minContentWidth);
     expect([...widths].sort((a, b) => a - b)).toEqual(widths);
@@ -150,6 +169,92 @@ describe('🔴 the column LADDER — grid width → column count', () => {
     expect([...columns].sort((a, b) => a - b)).toEqual(columns);
     // No redundant rung — `lg` and `xl` are both four columns and must collapse to one.
     expect(new Set(columns).size).toBe(columns.length);
+  });
+});
+
+describe('🔴 THE COLLISION — the card-width floor must NOT govern the narrow half', () => {
+  /**
+   * 🔴 WHY THIS DESCRIBE EXISTS, AND WHY IT DID NOT NEED TO AT THE OLD FLOOR.
+   *
+   * `LISTING_CARD_MIN_WIDTH` is 460, and `4 × 460 + 3 × 16 = 1888` — EXACTLY the content
+   * width of the retired 1920 container. So the four-column rung's floor-derived value
+   * and one of the most-quoted widths in this change are now the same number, and the
+   * two halves of the ladder are one refactor away from being confused for each other.
+   *
+   * If the floor ever governed the narrow half, four columns would start at 1888 and the
+   * ENTIRE 1168–1887 band would drop to three — including 1376, the `xl` low end, which
+   * is the middle of the ordinary desktop range and the last width anyone would think to
+   * re-check. Every other assertion in this file would still pass: 1888 itself would
+   * still read four (the floor's own rung), 2364 would still read five, the stylesheet
+   * seam would still agree, and the browser fixtures at 1888 / 2450 / 2528 would all be
+   * green. The defect would be invisible everywhere except here.
+   *
+   * At the old 383 floor `4 × 383 + 3 × 16 = 1580`, comfortably away from every number in
+   * play, and a floor-governed narrow half would have broken loudly. It is the NEW value
+   * that makes the failure quiet, so these assertions are a consequence of the product
+   * decision rather than general hygiene — do not delete them as redundant with the table.
+   */
+  test('🔴 four columns at 1376 — the `xl` low end, the width a floor-governed ladder breaks', () => {
+    const XL_LOW_END = MANTINE_BREAKPOINT_PX.xl - APPS_CONTAINER_GUTTER;
+    expect(XL_LOW_END).toBe(1376);
+    expect(
+      listingGridColumnsAt(XL_LOW_END),
+      'the xl low end fell below four columns. The most likely cause is that the narrow ' +
+        'half of LISTING_GRID_COLUMN_STEPS started deriving from LISTING_CARD_MIN_WIDTH: ' +
+        `minContentWidthForColumns(4) is ${minContentWidthForColumns(4)}, so four columns ` +
+        'would not begin until then and this whole band would render three.'
+    ).toBe(4);
+  });
+
+  test('🔴 four columns at 1887 AND at 1888 — one below the collision point and on it', () => {
+    const COLLISION = minContentWidthForColumns(4);
+    // The collision is real, not hypothetical: state it, so the reader can see why the
+    // two assertions below are interesting rather than arbitrary.
+    expect(COLLISION).toBe(1888);
+    expect(COLLISION).toBe(1920 - APPS_CONTAINER_GUTTER);
+    expect(listingGridColumnsAt(COLLISION - 1), 'one px below the collision point').toBe(4);
+    expect(listingGridColumnsAt(COLLISION), 'exactly at the collision point').toBe(4);
+    // 🔴 AND THE POINT: 1888 reads four for the RIGHT reason. It must be four because the
+    // lg rung (1168) has been in force for 720px, NOT because the floor happens to place
+    // a four-column rung there. Those two produce the same answer at 1888 and different
+    // answers everywhere below it — which is exactly what makes 1376 the load-bearing
+    // assertion and 1888 the one that would have reassured you.
+    expect(listingGridColumnsAt(1168)).toBe(4);
+  });
+
+  test('🔴 no narrow rung equals its own floor-derived value (the derivations are separate)', () => {
+    // The structural half of the claim. Each of 1/2/3/4 must come from a Mantine
+    // breakpoint minus the gutter and NOT from `minContentWidthForColumns`, so the two
+    // sets must disagree at every narrow column count.
+    const narrow = LISTING_GRID_COLUMN_STEPS.filter((s) => s.columns <= 4);
+    expect(narrow.map((s) => s.minContentWidth)).toEqual([0, 736, 960, 1168]);
+    for (const step of narrow) {
+      if (step.columns === 1) continue; // one column starts at 0 under either rule
+      expect(
+        step.minContentWidth,
+        `the ${step.columns}-column rung is at its floor-derived value ` +
+          `(${minContentWidthForColumns(step.columns)}) — the narrow half is being ` +
+          'governed by LISTING_CARD_MIN_WIDTH, which it must never be'
+      ).not.toBe(minContentWidthForColumns(step.columns));
+    }
+    // Guard-the-guard: the loop must actually have compared something, and the numbers it
+    // compared must be the ones this test is about.
+    expect(narrow.filter((s) => s.columns > 1)).toHaveLength(3);
+    expect(minContentWidthForColumns(2)).toBe(936);
+    expect(minContentWidthForColumns(3)).toBe(1412);
+    expect(minContentWidthForColumns(4)).toBe(1888);
+  });
+
+  test('the narrow rungs are BELOW every floor-derived rung of the same column count', () => {
+    // Stated as a direction, not just inequality: a narrow rung must fire EARLIER than
+    // the floor would allow, because the narrow half deliberately ships cards under the
+    // floor (four columns at 1376 is a 332px card). That asymmetry is the design — the
+    // floor governs only where a column is ADDED beyond what Mantine's scale reached.
+    for (const step of LISTING_GRID_COLUMN_STEPS.filter((s) => s.columns > 1 && s.columns <= 4)) {
+      expect(step.minContentWidth).toBeLessThan(minContentWidthForColumns(step.columns));
+    }
+    expect(listingCardWidthAt(1376, 4)).toBe(332);
+    expect(332).toBeLessThan(LISTING_CARD_MIN_WIDTH);
   });
 });
 
@@ -214,17 +319,62 @@ describe('🔴 the NARROW half is byte-equivalent to the retired Mantine media q
 });
 
 describe('🔴 the WIDE half holds the card-width floor', () => {
-  test('the floor is 383px, and the thresholds are what it produces', () => {
-    // 🔴 THE FLOOR IS THE MUTATION TARGET. Lowering it moves both thresholds, and the
+  test('the floor is 460px — the card width the store renders TODAY at its widest', () => {
+    // 🔴 THE FLOOR IS THE MUTATION TARGET. Moving it moves every wide threshold, and the
     // literals below are what notice. Without them the derivation would agree with any
     // floor at all.
-    expect(LISTING_CARD_MIN_WIDTH).toBe(383);
+    //
+    // 460 is not "the narrowest card we ever shipped" — it is the width four columns get
+    // in the RETIRED 1920 container, asserted here as a relationship rather than as a
+    // number so its provenance cannot rot:
+    const RETIRED_CONTAINER = 1920;
+    expect(listingCardWidthAt(RETIRED_CONTAINER - APPS_CONTAINER_GUTTER, 4)).toBe(460);
+    expect(LISTING_CARD_MIN_WIDTH).toBe(460);
     expect(LISTING_GRID_GUTTER).toBe(16);
-    expect(minContentWidthForColumns(5)).toBe(1979); // 5 × 383 + 4 × 16
-    expect(minContentWidthForColumns(6)).toBe(2378); // 6 × 383 + 5 × 16
+    expect(minContentWidthForColumns(5)).toBe(2364); // 5 × 460 + 4 × 16
+    expect(minContentWidthForColumns(6)).toBe(2840); // 6 × 460 + 5 × 16
     // A seventh column would need this much grid — stated so the next person adding one
     // can see the cost rather than picking a threshold by eye.
-    expect(minContentWidthForColumns(7)).toBe(2777); // 7 × 383 + 6 × 16
+    expect(minContentWidthForColumns(7)).toBe(3316); // 7 × 460 + 6 × 16
+  });
+
+  test('🔴 the widest REACHABLE rung makes cards BIGGER than the 1920 container did', () => {
+    // The product decision this floor encodes, stated as the outcome rather than as the
+    // input. A floor at the covers pass's own narrowest (380) would have put SIX columns
+    // in this container at 408px — i.e. widening the page would have SHRUNK the cards.
+    const grid = APPS_PAGE_CONTAINER_WIDTH - APPS_CONTAINER_GUTTER;
+    const columns = listingGridColumnsAt(grid);
+    expect(columns).toBe(5);
+    expect(listingCardWidthAt(grid, columns)).toBe(492.8);
+    // …strictly wider than today's four-up, which is the whole claim.
+    expect(listingCardWidthAt(grid, columns)).toBeGreaterThan(460);
+    // And the counterfactual, so the test says what it is ruling out: at a 380 floor the
+    // same container would have taken six columns at 408px — narrower than today.
+    const sixAt380 = 6 * 380 + 5 * LISTING_GRID_GUTTER;
+    expect(sixAt380).toBeLessThan(grid);
+    expect(listingCardWidthAt(grid, 6)).toBe(408);
+    expect(listingCardWidthAt(grid, 6)).toBeLessThan(460);
+  });
+
+  test('🔴 SIX columns is declared but UNREACHABLE at the current container cap', () => {
+    // Why the ladder a viewer can reach is 1/2/3/4/5 even though the module declares six.
+    // 🔴 THIS IS THE ASSERTION THAT FIRES IF SOMEONE RAISES THE CONTAINER CAP. It is not
+    // a statement that six is wrong — it is a statement that engaging six is a DENSITY
+    // decision, and it must be made deliberately rather than inherited from a width bump.
+    const maxGrid = APPS_PAGE_CONTAINER_WIDTH - APPS_CONTAINER_GUTTER;
+    expect(maxGrid).toBe(2528);
+    const sixRung = LISTING_GRID_COLUMN_STEPS.find((s) => s.columns === 6);
+    expect(sixRung, 'the six-column rung was deleted rather than left unreachable').toBeDefined();
+    expect(
+      sixRung!.minContentWidth,
+      'six columns is now REACHABLE — raising the container cap past the six-column rung ' +
+        'shrinks every card below LISTING_CARD_MIN_WIDTH-at-five. Decide the density on ' +
+        'purpose: either accept six, or raise the floor so the rung moves out again.'
+    ).toBeGreaterThan(maxGrid);
+    expect(listingGridColumnsAt(maxGrid)).toBe(5);
+    // The rung is still REAL, not decorative — it engages the moment the grid is wide
+    // enough, which is what makes keeping it (rather than deleting it) the right call.
+    expect(listingGridColumnsAt(sixRung!.minContentWidth)).toBe(6);
   });
 
   test('every FLOOR-DERIVED rung gives cards at least the floor wide, at its threshold', () => {
@@ -317,11 +467,19 @@ describe('🔴 SEAM — the store page size fits the ladder AND the server cap',
     expect(requestedLimit()).toBe(48);
   });
 
-  test('…which is eight rows at the ladder`s top rung, and twelve at the one below', () => {
-    const top = LISTING_GRID_COLUMN_STEPS[LISTING_GRID_COLUMN_STEPS.length - 1].columns;
-    expect(top).toBe(6);
-    expect(requestedLimit() / top).toBe(8);
+  test('…which is at least eight rows at the widest REACHABLE column count, and twelve at four', () => {
+    // Written against what a viewer can actually reach (five columns at the 2528 this
+    // container tops out at), not against the declared-but-unreachable sixth rung — and
+    // as a `>=` so it stays true if a future cap raise engages that rung (48 / 6 = 8).
+    const widestReachable = listingGridColumnsAt(APPS_PAGE_CONTAINER_WIDTH - APPS_CONTAINER_GUTTER);
+    expect(widestReachable).toBe(5);
+    expect(Math.floor(requestedLimit() / widestReachable)).toBeGreaterThanOrEqual(8);
     expect(requestedLimit() / 4).toBe(12);
+    // The `>=` is not a loophole: 48 is the largest multiple-of-12 page the server cap
+    // allows, so this cannot be satisfied by simply shrinking the ladder.
+    expect(requestedLimit()).toBeGreaterThanOrEqual(
+      8 * LISTING_GRID_COLUMN_STEPS[LISTING_GRID_COLUMN_STEPS.length - 1].columns
+    );
   });
 
   test('🔴 …and it is inside the SERVER`s own cap, read from the schema', () => {
@@ -380,7 +538,7 @@ describe('🔴 SEAM — the stylesheet implements exactly the ladder, and nothin
 
   /**
    * Comments stripped FIRST. Load-bearing rather than tidy: the stylesheet's own
-   * docstrings name `736`, `1979` and `2378` verbatim, so an unstripped scan would be
+   * docstrings name `736`, `2364` and `2840` verbatim, so an unstripped scan would be
    * reading the prose and would stay green with every real rule deleted.
    */
   const strip = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
@@ -402,9 +560,17 @@ describe('🔴 SEAM — the stylesheet implements exactly the ladder, and nothin
     const code = strip(source);
     const rules = parsedRules();
     expect(rules.length, 'no @container rules parsed out of the stylesheet').toBeGreaterThan(0);
-    // And the strip really removed the prose: the header names 1600, which is not a rung.
-    expect(source).toContain('1600');
-    expect(code).not.toContain('1600');
+    // And the strip really removed the prose. `492.8` is the rendered CARD width at the
+    // top of the reachable ladder — a figure that appears only in the docstrings and can
+    // never be a threshold, so it cannot stop being a valid witness by becoming a rule.
+    expect(source, 'the comment-strip control lost its witness').toContain('492.8');
+    expect(code).not.toContain('492.8');
+    // 🔴 AND THE ONE THE STRIP EXISTS FOR: both live thresholds are named verbatim in the
+    // prose, so a scan that did not strip comments would find them with every real rule
+    // deleted. They must survive in the source and vanish from the stripped code's PROSE
+    // while remaining in its rules — which is what `parsedRules()` above proves.
+    expect(source).toContain('2364');
+    expect(source).toContain('2840');
   });
 
   test('the base rule is ONE column, and it is not inside a container query', () => {

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -525,21 +525,29 @@ describe('🔴 the store width and the store grid ladder are a MATCHED PAIR', ()
     expect(APPS_FULL_MEASURE_PAGES).toContain('/apps');
   });
 
-  test('the container yields the card width the top of the ladder was tuned for', () => {
+  test('the container yields the card width the top of the reachable ladder was tuned for', () => {
     //   container 2560 − 2×16 Container padding = 2528 of grid
-    //   the ladder's top rung is SIX columns from 2378; gap 16 → 5 gaps between them
-    //   → (2528 − 5×16) / 6 = 408 px per card.
+    //   the widest REACHABLE rung is FIVE columns from 2364; gap 16 → 4 gaps between them
+    //   → (2528 − 4×16) / 5 = 492.8 px per card.
+    //   (SIX is declared at 2840 and deliberately out of reach here — see
+    //   `__tests__/appListingGrid.test.ts`, which pins that as the thing that fails if
+    //   this container is ever raised past it.)
     const GUTTER = 16;
     const usable = LISTING_STORE_CONTAINER_SIZE - APPS_CONTAINER_GUTTER;
     expect(usable).toBe(2528);
     const columns = listingGridColumnsAt(usable);
     const cardWidth = (usable - GUTTER * (columns - 1)) / columns;
-    expect(columns).toBe(6);
-    expect(cardWidth).toBe(408);
+    expect(columns).toBe(5);
+    expect(cardWidth).toBe(492.8);
     // 🔴 THE PAIRING, AS A RELATIONSHIP RATHER THAN TWO NUMBERS: a container change
     // that outran the ladder would land cards under the floor the ladder exists to
     // hold, and this is what notices.
     expect(cardWidth).toBeGreaterThanOrEqual(LISTING_CARD_MIN_WIDTH);
+    // 🔴 AND THE DIRECTION, WHICH IS THE PRODUCT DECISION: widening the container from
+    // 1920 to 2560 makes each card BIGGER (492.8 vs 460), not smaller-and-more-numerous.
+    // Without this, a ladder re-tune that added columns faster would satisfy everything
+    // above while quietly reversing the 2026-07 larger-covers pass on wide screens.
+    expect(cardWidth).toBeGreaterThan((1920 - APPS_CONTAINER_GUTTER - 3 * GUTTER) / 4);
   });
 
   test('🔴 the retired container widths still produce the column counts they shipped', () => {

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -15,7 +15,12 @@ import {
   APPS_TWO_COLUMN_DETAIL_MEASURE,
 } from '~/components/Apps/appsPageWidths';
 import * as widthsModule from '~/components/Apps/appsPageWidths';
-import { LISTING_GRID_SPAN, LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
+import {
+  LISTING_CARD_MIN_WIDTH,
+  LISTING_GRID_SPAN,
+  LISTING_STORE_CONTAINER_SIZE,
+  listingGridColumnsAt,
+} from '~/components/Apps/appListingGrid';
 import {
   SUBMISSIONS_CONTAINER_CHROME,
   SUBMISSIONS_TABLE_MIN_WIDTH,
@@ -376,9 +381,16 @@ function portalOffenders(name: string, abs: string, exportName: string): string[
 }
 
 describe('the container is uniform, and it is the only container', () => {
-  test('every `/apps/*` route renders in ONE container width (1920)', () => {
+  test('every `/apps/*` route renders in ONE container width (2560)', () => {
     // A literal, not derived from the module's own arithmetic.
-    expect(APPS_PAGE_CONTAINER_WIDTH).toBe(1920);
+    //
+    // 🔴 2560, RAISED FROM 1920 BY THE ULTRAWIDE PASS. The old cap left `(2560 −
+    // 1920) / 2 = 320px` of dead margin on each side of every apps page on a 2560
+    // monitor, and Mantine's top breakpoint (`xl`, 88em / 1408px) meant nothing in
+    // the grid could react to any of it. Raising the cap is only half the change —
+    // the store's column ladder is the other half, and it lives in
+    // `__tests__/appListingGrid.test.ts`.
+    expect(APPS_PAGE_CONTAINER_WIDTH).toBe(2560);
   });
 
   test('🔴 there is no per-route CONTAINER width map any more', () => {
@@ -498,12 +510,12 @@ describe('🔴 the measures preserve the OLD rendered content widths exactly', (
   });
 });
 
-describe('🔴 the store width and the store grid span are a MATCHED PAIR', () => {
+describe('🔴 the store width and the store grid ladder are a MATCHED PAIR', () => {
   test('LISTING_STORE_CONTAINER_SIZE reads the shared container width (one number, not two)', () => {
     // `appListingGrid.ts` used to carry its own literal 1600. If it drifts back to a
     // literal, this fails the moment the two disagree.
     expect(LISTING_STORE_CONTAINER_SIZE).toBe(APPS_PAGE_CONTAINER_WIDTH);
-    expect(LISTING_STORE_CONTAINER_SIZE).toBe(1920);
+    expect(LISTING_STORE_CONTAINER_SIZE).toBe(2560);
   });
 
   test('🔴 /apps takes NO body measure, so its content width IS the container width', () => {
@@ -513,16 +525,38 @@ describe('🔴 the store width and the store grid span are a MATCHED PAIR', () =
     expect(APPS_FULL_MEASURE_PAGES).toContain('/apps');
   });
 
-  test('the container yields the card width the xl span was tuned for', () => {
-    //   container 1920 − 2×16 Container padding = 1888 usable
-    //   xl span 3/12 → 4 columns; Grid gutter "md" (16) → 3 gutters between them
-    //   → (1888 − 3×16) / 4 = 460 px per card.
+  test('the container yields the card width the top of the ladder was tuned for', () => {
+    //   container 2560 − 2×16 Container padding = 2528 of grid
+    //   the ladder's top rung is SIX columns from 2378; gap 16 → 5 gaps between them
+    //   → (2528 − 5×16) / 6 = 408 px per card.
     const GUTTER = 16;
-    const columns = 12 / LISTING_GRID_SPAN.xl;
     const usable = LISTING_STORE_CONTAINER_SIZE - APPS_CONTAINER_GUTTER;
+    expect(usable).toBe(2528);
+    const columns = listingGridColumnsAt(usable);
     const cardWidth = (usable - GUTTER * (columns - 1)) / columns;
-    expect(columns).toBe(4);
-    expect(cardWidth).toBe(460);
+    expect(columns).toBe(6);
+    expect(cardWidth).toBe(408);
+    // 🔴 THE PAIRING, AS A RELATIONSHIP RATHER THAN TWO NUMBERS: a container change
+    // that outran the ladder would land cards under the floor the ladder exists to
+    // hold, and this is what notices.
+    expect(cardWidth).toBeGreaterThanOrEqual(LISTING_CARD_MIN_WIDTH);
+  });
+
+  test('🔴 the retired container widths still produce the column counts they shipped', () => {
+    // The ultrawide pass must not have moved anything BELOW its own new territory.
+    // 1600 and 1920 are the two container widths this store has actually shipped at;
+    // both still resolve to four columns, at the card widths those passes measured.
+    for (const [container, columns, cardWidth] of [
+      [1600, 4, 380],
+      [1920, 4, 460],
+    ] as const) {
+      const usable = container - APPS_CONTAINER_GUTTER;
+      expect(listingGridColumnsAt(usable), `container ${container}`).toBe(columns);
+      expect((usable - 16 * (columns - 1)) / columns, `container ${container}`).toBe(cardWidth);
+    }
+    // The `xl` SPAN is still four columns — the legacy object the narrow half of the
+    // ladder is derived from has not been quietly re-tuned.
+    expect(12 / LISTING_GRID_SPAN.xl).toBe(4);
   });
 });
 

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -84,32 +84,47 @@ export const MANTINE_BREAKPOINT_PX = {
 export const LISTING_GRID_GUTTER = 16;
 
 /**
- * 🔴 THE MINIMUM CARD WIDTH THE WIDE STEPS OF THE LADDER HOLD, px — the constant the
- * 5- and 6-column thresholds are DERIVED from, so a threshold can never be moved
- * without moving this.
+ * 🔴 THE MINIMUM CARD WIDTH A NEW, WIDER RUNG OF THE LADDER MUST HOLD, px — the
+ * constant the 5- and 6-column thresholds are DERIVED from, so a threshold can never
+ * be moved without moving this.
  *
- * PROVENANCE, stated precisely because the number has been quoted loosely before.
- * The 2026-07 "make app cover images larger" pass shipped FOUR columns at a 1600px
- * container, i.e. `(1600 − 32 gutter − 3 × 16 gap) / 4 = 380px` per card. That is the
- * narrowest card width that pass was willing to ship, and it is the floor a NEW,
- * WIDER step must not go under — adding a column is only allowed to make each card
- * bigger than the covers pass shipped, never smaller.
+ * ── WHY 460, AND WHY IT IS NOT "THE NARROWEST CARD WE EVER SHIPPED" ─────────────────
+ * 460 is the card width the store renders TODAY at its widest: four columns in the
+ * 1920 container, `(1920 − 32 gutter − 3 × 16 gap) / 4 = 460`. It is a PRODUCT
+ * decision, taken deliberately over the alternative: a floor set at the narrowest
+ * width the 2026-07 "larger covers" pass was willing to ship (four columns at a 1600
+ * container = `(1600 − 32 − 48) / 4 = 380`) would have put SIX columns on a 2560
+ * monitor at 408px each — i.e. widening the container would have made cards SMALLER
+ * than they are now, partially reversing that pass at exactly the viewports it should
+ * help most. Bigger cards were chosen over more of them.
  *
- * ⚠️ 383, NOT THE MEASURED 380, AND THE THREE PIXELS ARE DELIBERATE. `appListingGrid`
- * and `appListingGrid.test.ts` have both carried "~383 px at 1600" since that pass;
- * the exact arithmetic is 380. Keeping the documented 383 rather than the measured 380
- * makes the floor three pixels STRICTER (a higher floor pushes each threshold OUT, so
- * a column is added later and every card is wider), which is the safe direction for a
- * constant whose whole job is "never ship a card narrower than the covers pass did".
- * Do not "correct" it downward without re-deriving the thresholds — they are computed
- * from it, so lowering it silently narrows every card at the top of the ladder.
+ * ⚠️ THE HISTORICAL "~383" IS WRONG AND IS NOT WHAT THIS IS. `appListingGrid.ts` and
+ * its test both carried "~383 px at 1600" since the covers pass; the arithmetic is
+ * 380. Neither number is this constant — do not "restore" either of them here.
+ *
+ * ── 🔴 460 COLLIDES WITH THE OLD CONTAINER, AND THAT IS A TRAP, NOT A COINCIDENCE ───
+ * `4 × 460 + 3 × 16 = 1888` — exactly the content width of the RETIRED 1920 container.
+ * So IF this floor ever governed the narrow half of the ladder, four columns would
+ * require 1888 of grid and the `xl` low end (viewport 1408 → 1376 of grid) would
+ * silently drop to THREE columns, destroying the below-1888 equivalence this change
+ * is built on — at a width nobody would think to test, because it used to be the safe
+ * middle of the range.
+ *
+ * It does not, and cannot: {@link LISTING_GRID_COLUMN_STEPS} builds its narrow rungs
+ * from {@link LISTING_GRID_SPAN} + {@link MANTINE_BREAKPOINT_PX} and never reads this
+ * constant, so the two halves are structurally independent. That independence is
+ * asserted directly — 4 columns at 1376, at 1887 and at 1888 — and mutation-checked
+ * in `__tests__/appListingGrid.test.ts` by making the floor govern everywhere and
+ * watching the 1376 rung go red. Do not remove those assertions on the grounds that
+ * the derivation "obviously" cannot do this; the collision is what makes them cheap
+ * to lose and expensive to be without.
  *
  * It is NOT a `min-width` handed to CSS. See {@link LISTING_GRID_COLUMN_STEPS} for why
  * an intrinsic `repeat(auto-fill, minmax(…, 1fr))` grid cannot express this ladder at
  * all — this constant is the DERIVATION of the explicit thresholds, not a value any
  * stylesheet reads.
  */
-export const LISTING_CARD_MIN_WIDTH = 383;
+export const LISTING_CARD_MIN_WIDTH = 460;
 
 /** The card width `columns` cards get in `contentWidth` px of grid. */
 export function listingCardWidthAt(contentWidth: number, columns: number): number {
@@ -134,6 +149,16 @@ export function minContentWidthForColumns(columns: number): number {
  *
  * Adding a 7th column is one entry here; its threshold falls out of the floor and
  * cannot be chosen independently.
+ *
+ * 🔴 SIX IS DECLARED BUT UNREACHABLE AT TODAY'S CONTAINER CAP, ON PURPOSE. At the 460
+ * floor six columns need `6 × 460 + 5 × 16 = 2840` of grid, and
+ * {@link APPS_PAGE_CONTAINER_WIDTH} (2560) tops out at 2528 — so the ladder a viewer
+ * can actually reach is 1 / 2 / 3 / 4 / 5, and 2560 renders five columns at 492.8px
+ * each (wider than today's 460, which is the point of the floor). The rung is kept
+ * rather than deleted so a future cap raise engages it automatically instead of
+ * needing this list edited; `__tests__/appListingGrid.test.ts` asserts the
+ * unreachability explicitly, so raising the cap past 2840 fails loudly and the density
+ * decision gets made deliberately rather than inherited.
  */
 const WIDE_COLUMN_COUNTS = [5, 6] as const;
 
@@ -155,10 +180,11 @@ export type ListingGridColumnStep = { minContentWidth: number; columns: number }
  *     needs `X > 364.8`, because five columns at 1888 is exactly 364.8px each.
  *
  * `X ≤ 332` and `X > 364.8` have no overlap. Any floor low enough to keep four columns
- * at 1376 gives FIVE at 1888, which lands a 364.8px card — narrower than the ~380px the
- * 2026-07 covers pass deliberately moved TO when it went five columns → four. So an
- * intrinsic grid would silently undo that pass at exactly the width most desktops use.
- * The column count therefore stays an explicit decision per width band.
+ * at 1376 gives FIVE at 1888, which lands a 364.8px card — narrower than the 380px the
+ * 2026-07 covers pass deliberately moved TO when it went five columns → four, and far
+ * under the 460 this grid now holds. So an intrinsic grid would silently undo that pass
+ * at exactly the width most desktops use. The column count therefore stays an explicit
+ * decision per width band.
  *
  * ── WHY A CONTAINER QUERY AND NOT A MEDIA QUERY ─────────────────────────────────────
  * Card width is not monotonic in VIEWPORT width, so a viewport breakpoint is the wrong
@@ -169,8 +195,8 @@ export type ListingGridColumnStep = { minContentWidth: number; columns: number }
  * adding a custom Mantine breakpoint, which would be a global theme change made to fix
  * one grid.
  *
- * ── HOW THE TWO HALVES ARE BUILT ────────────────────────────────────────────────────
- * BELOW 1888 the ladder is DERIVED from {@link LISTING_GRID_SPAN} and
+ * ── HOW THE TWO HALVES ARE BUILT, AND WHY THEY ARE INDEPENDENT ──────────────────────
+ * The NARROW rungs (1 / 2 / 3 / 4) are DERIVED from {@link LISTING_GRID_SPAN} and
  * {@link MANTINE_BREAKPOINT_PX} rather than retyped, so the container-query thresholds
  * are the media-query behaviour they replaced, converted once: a breakpoint fires at
  * viewport `V`, `/apps` takes no body measure, and the apps `Container` is full-bleed
@@ -178,13 +204,21 @@ export type ListingGridColumnStep = { minContentWidth: number; columns: number }
  * both mean four columns, so the `xl` rung collapses into the `lg` one and the ladder
  * has no redundant step.
  *
- * ABOVE it the rungs come from {@link WIDE_COLUMN_COUNTS} through
+ * The WIDE rungs come from {@link WIDE_COLUMN_COUNTS} through
  * {@link minContentWidthForColumns}, i.e. straight out of the card-width floor.
+ *
+ * 🔴 THE LOOP BELOW NEVER READS {@link LISTING_CARD_MIN_WIDTH} FOR A NARROW RUNG, AND
+ * THAT SEPARATION IS LOAD-BEARING RATHER THAN TIDY. At the current 460 floor,
+ * `minContentWidthForColumns(4)` is 1888 — so a version of this that let the floor
+ * decide everywhere would move four columns from 1168 to 1888 and drop the whole
+ * 1168–1887 band (the `xl` low end included) to THREE columns. See the collision note
+ * on {@link LISTING_CARD_MIN_WIDTH}.
  *
  * The resulting table (grid width → columns) and its equality with the `@container`
  * rules in `AppListingsMarketplaceBody.module.scss` are both pinned in
- * `__tests__/appListingGrid.test.ts`; the RENDERED column counts are measured in
- * `AppListingsMarketplaceBody.columns.browser.test.tsx`.
+ * `__tests__/appListingGrid.test.ts` — which also pins 4 columns at 1376 / 1887 / 1888
+ * and mutation-checks the independence above. The RENDERED column counts are measured
+ * in `AppListingsMarketplaceBody.columns.browser.test.tsx`.
  */
 export const LISTING_GRID_COLUMN_STEPS: readonly ListingGridColumnStep[] = (() => {
   const steps: ListingGridColumnStep[] = [];
@@ -242,11 +276,11 @@ export function listingGridColumnsAt(contentWidth: number): number {
  * The 1920 step DELIBERATELY left the column count at four: at 1920 that yields 460px
  * cards (vs 380 at 1600), so the 2026-07 "make app cover images larger" pass got larger
  * still rather than being undone, and re-tuning to five columns there would have landed
- * 364.8px — narrower than what that pass shipped. The 2560 step is what finally adds
- * columns, and it adds them only where each card still clears
- * {@link LISTING_CARD_MIN_WIDTH}: five columns from 1979px of grid (383px cards at the
- * threshold, 462.6 at the top of that band) and six from 2378 (383 at the threshold,
- * 408 at the 2528 `/apps` actually reaches at a 2560 container). The arithmetic is
+ * 364.8px — narrower than what that pass shipped. The 2560 step adds ONE column, and
+ * only where every card is still at least the 460px the store renders today: five from
+ * 2364px of grid, giving 492.8px cards at the 2528 `/apps` reaches. Six would need 2840
+ * and is therefore unreachable at this cap — so widening the container makes the cards
+ * BIGGER than they are now rather than more numerous and smaller. The arithmetic is
  * pinned in `__tests__/appsPageWidths.test.ts` and `__tests__/appListingGrid.test.ts`.
  */
 export const LISTING_STORE_CONTAINER_SIZE: number = APPS_PAGE_CONTAINER_WIDTH;

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -1,11 +1,11 @@
-import { APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
+import { APPS_CONTAINER_GUTTER, APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
 
 /**
  * App Store Listings (W13) — the `/apps` store's GEOMETRY constants, split out of
  * the component so they're pinnable in a plain (node-project) unit test rather
  * than by asserting Mantine's generated responsive CSS.
  *
- * They're a matched pair: the column span decides how many cards fit per row and
+ * They're a matched pair: the column count decides how many cards fit per row and
  * the container width decides how wide a row is, so a change to one without the
  * other silently re-truncates the cards. Keeping both here makes that coupling
  * explicit and makes "the container was NOT changed" a real assertion instead of
@@ -13,7 +13,9 @@ import { APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
  */
 
 /**
- * Store-grid column span per breakpoint.
+ * Store-grid column span per breakpoint — the LEGACY, VIEWPORT-BREAKPOINT half of
+ * the ladder, retained as the SOURCE the narrow half of
+ * {@link LISTING_GRID_COLUMN_STEPS} is derived from.
  *
  * `xl: 3` → FOUR columns on a wide viewport. This is the product-feedback change
  * ("make app cover images larger — fewer columns per row?"): it was `2.4` (five
@@ -24,6 +26,19 @@ import { APPS_PAGE_CONTAINER_WIDTH } from '~/components/Apps/appsPageWidths';
  * lg 3 → 4). Deliberately a one-breakpoint change: the narrower breakpoints were
  * already at a comfortable card width, and widening them would push cards past a
  * readable measure on tablets.
+ *
+ * 🔴 IT IS NO LONGER PASSED TO A `Grid.Col span=`. The grid moved from Mantine's
+ * 12-column `<Grid>` to a CSS grid driven by a CONTAINER query (see
+ * {@link LISTING_GRID_COLUMN_STEPS}), because `Grid.Col span` can only read a theme
+ * BREAKPOINT — a viewport media query — and `xl` (88em / 1408px) is the top of
+ * Mantine's scale here. `src/providers/ThemeProvider.tsx` declares NO custom
+ * breakpoints, so there was no breakpoint above 1408 to hang a fifth column on, and
+ * adding one would be a site-wide theme change to fix one grid.
+ *
+ * This object stays because it is the RECORD of the narrow half of the ladder, and
+ * `LISTING_GRID_COLUMN_STEPS` is computed from it — so the container-query
+ * thresholds below 1888 cannot drift away from the media-query behaviour they
+ * replaced without this object moving too.
  */
 export const LISTING_GRID_SPAN = {
   base: 12,
@@ -34,12 +49,177 @@ export const LISTING_GRID_SPAN = {
 } as const;
 
 /**
+ * Mantine's DEFAULT breakpoints, in px.
+ *
+ * 🔴 THE VALUES ARE MANTINE'S, NOT OURS, AND THAT IS THE POINT OF WRITING THEM DOWN.
+ * `src/providers/ThemeProvider.tsx` passes no `breakpoints` key, so the theme is
+ * Mantine v7's default scale (`xs` 36em, `sm` 48em, `md` 62em, `lg` 75em, `xl` 88em)
+ * at the 16px root font size this app ships. Those are what `Grid.Col span={{sm: …}}`
+ * compiled to before the CSS-grid move, so they are what the container-query
+ * thresholds below have to reproduce.
+ *
+ * ⚠️ THE ONE PLACE THE REPRODUCTION IS NOT EXACT. Mantine's breakpoints are `em`, so
+ * they scale with the ROOT font size; a container query in px does not. At the
+ * default 16px they are identical, and `globals.css` sets `html { font-size: 16px }`
+ * (that is what `cascadeEvidence().htmlFontSize` reads in the geometry harness), so
+ * the two agree for every viewer who has not overridden it in the browser. A viewer
+ * who HAS enlarged their default font gets the px thresholds rather than the em ones
+ * — i.e. slightly more columns than before at the same zoom. Accepted deliberately:
+ * the alternative is `em` inside a container query, which resolves against the
+ * CONTAINER's font size rather than the root's and is a different rule again.
+ */
+export const MANTINE_BREAKPOINT_PX = {
+  base: 0,
+  xs: 576,
+  sm: 768,
+  md: 992,
+  lg: 1200,
+  xl: 1408,
+} as const satisfies Record<keyof typeof LISTING_GRID_SPAN | 'xs', number>;
+
+/**
+ * The gap between store cards, px. Mantine's `md` spacing token — the value the grid
+ * used as `<Grid gutter="md">` and the value the CSS grid now writes as `gap`.
+ */
+export const LISTING_GRID_GUTTER = 16;
+
+/**
+ * 🔴 THE MINIMUM CARD WIDTH THE WIDE STEPS OF THE LADDER HOLD, px — the constant the
+ * 5- and 6-column thresholds are DERIVED from, so a threshold can never be moved
+ * without moving this.
+ *
+ * PROVENANCE, stated precisely because the number has been quoted loosely before.
+ * The 2026-07 "make app cover images larger" pass shipped FOUR columns at a 1600px
+ * container, i.e. `(1600 − 32 gutter − 3 × 16 gap) / 4 = 380px` per card. That is the
+ * narrowest card width that pass was willing to ship, and it is the floor a NEW,
+ * WIDER step must not go under — adding a column is only allowed to make each card
+ * bigger than the covers pass shipped, never smaller.
+ *
+ * ⚠️ 383, NOT THE MEASURED 380, AND THE THREE PIXELS ARE DELIBERATE. `appListingGrid`
+ * and `appListingGrid.test.ts` have both carried "~383 px at 1600" since that pass;
+ * the exact arithmetic is 380. Keeping the documented 383 rather than the measured 380
+ * makes the floor three pixels STRICTER (a higher floor pushes each threshold OUT, so
+ * a column is added later and every card is wider), which is the safe direction for a
+ * constant whose whole job is "never ship a card narrower than the covers pass did".
+ * Do not "correct" it downward without re-deriving the thresholds — they are computed
+ * from it, so lowering it silently narrows every card at the top of the ladder.
+ *
+ * It is NOT a `min-width` handed to CSS. See {@link LISTING_GRID_COLUMN_STEPS} for why
+ * an intrinsic `repeat(auto-fill, minmax(…, 1fr))` grid cannot express this ladder at
+ * all — this constant is the DERIVATION of the explicit thresholds, not a value any
+ * stylesheet reads.
+ */
+export const LISTING_CARD_MIN_WIDTH = 383;
+
+/** The card width `columns` cards get in `contentWidth` px of grid. */
+export function listingCardWidthAt(contentWidth: number, columns: number): number {
+  return (contentWidth - LISTING_GRID_GUTTER * (columns - 1)) / columns;
+}
+
+/**
+ * The narrowest grid width at which `columns` cards each still clear
+ * {@link LISTING_CARD_MIN_WIDTH} — the inverse of {@link listingCardWidthAt}.
+ *
+ * `n × floor + (n − 1) × gap`. This is the ONLY place a wide threshold is computed,
+ * so "the thresholds are derived from the floor" is a fact about the code rather than
+ * a claim in a comment.
+ */
+export function minContentWidthForColumns(columns: number): number {
+  return columns * LISTING_CARD_MIN_WIDTH + (columns - 1) * LISTING_GRID_GUTTER;
+}
+
+/**
+ * The column counts that are added ABOVE the legacy Mantine ladder, each placed at
+ * the narrowest width that holds {@link LISTING_CARD_MIN_WIDTH}.
+ *
+ * Adding a 7th column is one entry here; its threshold falls out of the floor and
+ * cannot be chosen independently.
+ */
+const WIDE_COLUMN_COUNTS = [5, 6] as const;
+
+/** One rung of the ladder: at `minContentWidth` px of grid and up, render `columns`. */
+export type ListingGridColumnStep = { minContentWidth: number; columns: number };
+
+/**
+ * 🔴 THE COLUMN LADDER — the store grid's column count as a function of the GRID's own
+ * width, not the viewport's.
+ *
+ * ── WHY AN EXPLICIT LADDER AND NOT AN INTRINSIC `auto-fill` GRID ────────────────────
+ * `repeat(auto-fill, minmax(X, 1fr))` is the obvious answer and it CANNOT express this,
+ * for any single `X`. With a 16px gap, `auto-fill` fits `floor((W + gap) / (X + gap))`
+ * columns, so:
+ *
+ *   · four columns at the low end of the old `xl` breakpoint — viewport 1408, i.e.
+ *     1376 of content — needs `X ≤ 332` (a 332px card);
+ *   · four columns at 1888 of content — the widest the old 1920 container reached —
+ *     needs `X > 364.8`, because five columns at 1888 is exactly 364.8px each.
+ *
+ * `X ≤ 332` and `X > 364.8` have no overlap. Any floor low enough to keep four columns
+ * at 1376 gives FIVE at 1888, which lands a 364.8px card — narrower than the ~380px the
+ * 2026-07 covers pass deliberately moved TO when it went five columns → four. So an
+ * intrinsic grid would silently undo that pass at exactly the width most desktops use.
+ * The column count therefore stays an explicit decision per width band.
+ *
+ * ── WHY A CONTAINER QUERY AND NOT A MEDIA QUERY ─────────────────────────────────────
+ * Card width is not monotonic in VIEWPORT width, so a viewport breakpoint is the wrong
+ * axis: at `base` the grid is one column, so a 390px phone yields a ~356px card — wider
+ * than the ~280px a 1200px laptop gets at four columns. What decides whether a card is
+ * too narrow is the width of the GRID, and the grid's width is what a container query
+ * reads. It is also the only mechanism that can react above 1408px at all without
+ * adding a custom Mantine breakpoint, which would be a global theme change made to fix
+ * one grid.
+ *
+ * ── HOW THE TWO HALVES ARE BUILT ────────────────────────────────────────────────────
+ * BELOW 1888 the ladder is DERIVED from {@link LISTING_GRID_SPAN} and
+ * {@link MANTINE_BREAKPOINT_PX} rather than retyped, so the container-query thresholds
+ * are the media-query behaviour they replaced, converted once: a breakpoint fires at
+ * viewport `V`, `/apps` takes no body measure, and the apps `Container` is full-bleed
+ * below its cap, so the grid there is `V − APPS_CONTAINER_GUTTER` wide. `lg` and `xl`
+ * both mean four columns, so the `xl` rung collapses into the `lg` one and the ladder
+ * has no redundant step.
+ *
+ * ABOVE it the rungs come from {@link WIDE_COLUMN_COUNTS} through
+ * {@link minContentWidthForColumns}, i.e. straight out of the card-width floor.
+ *
+ * The resulting table (grid width → columns) and its equality with the `@container`
+ * rules in `AppListingsMarketplaceBody.module.scss` are both pinned in
+ * `__tests__/appListingGrid.test.ts`; the RENDERED column counts are measured in
+ * `AppListingsMarketplaceBody.columns.browser.test.tsx`.
+ */
+export const LISTING_GRID_COLUMN_STEPS: readonly ListingGridColumnStep[] = (() => {
+  const steps: ListingGridColumnStep[] = [];
+  for (const [breakpoint, span] of Object.entries(LISTING_GRID_SPAN)) {
+    const columns = 12 / span;
+    // A breakpoint fires on the VIEWPORT; the grid is the viewport minus the apps
+    // Container's own gutter. `base` is 0 and stays 0 rather than going negative.
+    const viewport = MANTINE_BREAKPOINT_PX[breakpoint as keyof typeof MANTINE_BREAKPOINT_PX];
+    const minContentWidth = Math.max(0, viewport - APPS_CONTAINER_GUTTER);
+    // `lg` and `xl` are the same column count — one rung, not two.
+    if (steps.length > 0 && steps[steps.length - 1].columns === columns) continue;
+    steps.push({ minContentWidth, columns });
+  }
+  for (const columns of WIDE_COLUMN_COUNTS) {
+    steps.push({ minContentWidth: minContentWidthForColumns(columns), columns });
+  }
+  return steps;
+})();
+
+/** How many columns the store grid renders in `contentWidth` px of grid. */
+export function listingGridColumnsAt(contentWidth: number): number {
+  let columns = LISTING_GRID_COLUMN_STEPS[0].columns;
+  for (const step of LISTING_GRID_COLUMN_STEPS) {
+    if (contentWidth >= step.minContentWidth) columns = step.columns;
+  }
+  return columns;
+}
+
+/**
  * The container width the `/apps` store grid is sized against (px).
  *
  * 🔴 NO LONGER A LITERAL HERE, AND NO LONGER A PROP. The number lives in
  * `~/components/Apps/appsPageWidths` as {@link APPS_PAGE_CONTAINER_WIDTH}, the ONE
  * container width every `/apps/*` route now renders in; this file re-exports it so
- * the container/span pair stays visible and assertable from the grid side. Two
+ * the container/ladder pair stays visible and assertable from the grid side. Two
  * copies of the number is exactly the drift the pairing comment above is trying to
  * prevent — don't inline it back.
  *
@@ -47,22 +227,26 @@ export const LISTING_GRID_SPAN = {
  * chrome rendered inside it, so a per-page width moved the sub-nav horizontally
  * between routes). `/apps` takes NO body measure, so its content width still IS the
  * container width and the arithmetic below is unchanged — this constant is now the
- * DERIVATION the grid span is tuned against rather than a value the page hands the
+ * DERIVATION the ladder is tuned against rather than a value the page hands the
  * layout.
  *
  * 🔴 IT HAS NO PRODUCTION CONSUMER ANY MORE — it is read only by
  * `__tests__/appListingGrid.test.ts` and `__tests__/appsPageWidths.test.ts`. That is
  * deliberate, not dead code left behind: the pair below is arithmetic nobody executes at
- * runtime (the container width is applied by `AppsPageLayout`, the span by the grid), so
- * a named constant read by the tests is the only place the coupling can be STATED and
- * checked. Deleting it would not remove any behaviour; it would remove the only thing
- * that fails when someone moves one half of the pair.
+ * runtime (the container width is applied by `AppsPageLayout`, the column count by the
+ * grid's own container query), so a named constant read by the tests is the only place
+ * the coupling can be STATED and checked. Deleting it would not remove any behaviour; it
+ * would remove the only thing that fails when someone moves one half of the pair.
  *
- * The full-width pass moved it 1600 → 1920. The `xl` span was DELIBERATELY left at 3
- * (four columns): at 1920 that yields ~460 px cards (vs ~383 at 1600), so the
- * 2026-07 "make app cover images larger" pass gets larger still rather than being
- * undone. Re-tuning to five columns at `xl` would land ~365 px — narrower than what
- * that pass shipped — so it is not a neutral "keep the density" choice. The
- * arithmetic is pinned in `__tests__/appsPageWidths.test.ts`.
+ * The full-width pass moved it 1600 → 1920 and the ultrawide pass moved it 1920 → 2560.
+ * The 1920 step DELIBERATELY left the column count at four: at 1920 that yields 460px
+ * cards (vs 380 at 1600), so the 2026-07 "make app cover images larger" pass got larger
+ * still rather than being undone, and re-tuning to five columns there would have landed
+ * 364.8px — narrower than what that pass shipped. The 2560 step is what finally adds
+ * columns, and it adds them only where each card still clears
+ * {@link LISTING_CARD_MIN_WIDTH}: five columns from 1979px of grid (383px cards at the
+ * threshold, 462.6 at the top of that band) and six from 2378 (383 at the threshold,
+ * 408 at the 2528 `/apps` actually reaches at a 2560 container). The arithmetic is
+ * pinned in `__tests__/appsPageWidths.test.ts` and `__tests__/appListingGrid.test.ts`.
  */
 export const LISTING_STORE_CONTAINER_SIZE: number = APPS_PAGE_CONTAINER_WIDTH;

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -65,9 +65,12 @@ export const LISTING_GRID_SPAN = {
  * 🔴 A CSS `html { font-size }` CANNOT MOVE THEM AT ALL. Inside a MEDIA query, `em`
  * resolves against the browser's INITIAL font size, not the root element's computed one
  * — so an app-level declaration is not a mitigation and its absence is not an exposure.
- * (Measured across three root sizes and 17 viewports: the `@media em` column is
- * identical at 16 / 20 / 24px, and the ladder stays monotone non-decreasing in viewport
- * at every one of them, so no rung inversion is reachable this way.)
+ * That is a CSS FACT, not a repo measurement: nothing here reproduces it, and it needs
+ * no fixture because it follows from the spec — a media query is evaluated against the
+ * initial value, outside any element's inherited context. The corollary it buys, also by
+ * construction rather than by experiment, is that the ladder cannot INVERT under a root
+ * font-size change: the `@media em` breakpoints do not move at all, so the ladder stays
+ * monotone non-decreasing in viewport whatever the root size is.
  *
  * 🔴 AND THIS FILE USED TO CITE A SAFEGUARD THAT DOES NOT EXIST: it said "`globals.css`
  * sets `html { font-size: 16px }`". It does not — there is no `html { … }` rule setting

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -58,15 +58,30 @@ export const LISTING_GRID_SPAN = {
  * compiled to before the CSS-grid move, so they are what the container-query
  * thresholds below have to reproduce.
  *
- * ⚠️ THE ONE PLACE THE REPRODUCTION IS NOT EXACT. Mantine's breakpoints are `em`, so
- * they scale with the ROOT font size; a container query in px does not. At the
- * default 16px they are identical, and `globals.css` sets `html { font-size: 16px }`
- * (that is what `cascadeEvidence().htmlFontSize` reads in the geometry harness), so
- * the two agree for every viewer who has not overridden it in the browser. A viewer
- * who HAS enlarged their default font gets the px thresholds rather than the em ones
- * — i.e. slightly more columns than before at the same zoom. Accepted deliberately:
- * the alternative is `em` inside a container query, which resolves against the
- * CONTAINER's font size rather than the root's and is a different rule again.
+ * ⚠️ THE `em` ↔ `px` QUESTION, STATED CORRECTLY. Mantine's breakpoints are `em` and the
+ * container queries below are `px`, so they can only agree at one root size. What
+ * follows is narrower and better news than this comment used to claim.
+ *
+ * 🔴 A CSS `html { font-size }` CANNOT MOVE THEM AT ALL. Inside a MEDIA query, `em`
+ * resolves against the browser's INITIAL font size, not the root element's computed one
+ * — so an app-level declaration is not a mitigation and its absence is not an exposure.
+ * (Measured across three root sizes and 17 viewports: the `@media em` column is
+ * identical at 16 / 20 / 24px, and the ladder stays monotone non-decreasing in viewport
+ * at every one of them, so no rung inversion is reachable this way.)
+ *
+ * 🔴 AND THIS FILE USED TO CITE A SAFEGUARD THAT DOES NOT EXIST: it said "`globals.css`
+ * sets `html { font-size: 16px }`". It does not — there is no `html { … }` rule setting
+ * a root size (the only `font-size: 16px` is an iOS input-zoom guard inside
+ * `@media (hover: none) and (pointer: coarse)`), and the one `html { … }` block is
+ * commented out. `cascadeEvidence().htmlFontSize` reads the COMPUTED value, i.e. the UA
+ * default, so it can never have been evidence of an app declaration.
+ *
+ * WHAT REMAINS, honestly: a viewer who has changed their BROWSER's default font size
+ * moves the `em` breakpoints while these `px` thresholds stay put. Direction as stated —
+ * a larger default yields slightly more columns than the old media queries would have.
+ * Unmeasured, and there is no app-level mitigation because none is possible: the
+ * alternative, `em` inside a container query, resolves against the CONTAINER's font size
+ * rather than the root's and is a third rule again.
  */
 export const MANTINE_BREAKPOINT_PX = {
   base: 0,
@@ -152,9 +167,12 @@ export function minContentWidthForColumns(columns: number): number {
  *
  * 🔴 SIX IS DECLARED BUT UNREACHABLE AT TODAY'S CONTAINER CAP, ON PURPOSE. At the 460
  * floor six columns need `6 × 460 + 5 × 16 = 2840` of grid, and
- * {@link APPS_PAGE_CONTAINER_WIDTH} (2560) tops out at 2528 — so the ladder a viewer
- * can actually reach is 1 / 2 / 3 / 4 / 5, and 2560 renders five columns at 492.8px
- * each (wider than today's 460, which is the point of the floor). The rung is kept
+ * {@link APPS_PAGE_CONTAINER_WIDTH} (2560) tops out at 2528 of grid — so the ladder a
+ * viewer can actually reach is 1 / 2 / 3 / 4 / 5, and a 2560 container renders five
+ * columns at 492.8px each (wider than today's 460, which is the point of the floor).
+ * ⚠️ 2528 / 492.8 are the CONTAINER arithmetic (`2560 − APPS_CONTAINER_GUTTER`), not
+ * what a 2560 VIEWPORT yields: see the scroll-box note below. The column count is five
+ * either way. The rung is kept
  * rather than deleted so a future cap raise engages it automatically instead of
  * needing this list edited; `__tests__/appListingGrid.test.ts` asserts the
  * unreachability explicitly, so raising the cap past 2840 fails loudly and the density
@@ -197,12 +215,29 @@ export type ListingGridColumnStep = { minContentWidth: number; columns: number }
  *
  * ── HOW THE TWO HALVES ARE BUILT, AND WHY THEY ARE INDEPENDENT ──────────────────────
  * The NARROW rungs (1 / 2 / 3 / 4) are DERIVED from {@link LISTING_GRID_SPAN} and
- * {@link MANTINE_BREAKPOINT_PX} rather than retyped, so the container-query thresholds
- * are the media-query behaviour they replaced, converted once: a breakpoint fires at
- * viewport `V`, `/apps` takes no body measure, and the apps `Container` is full-bleed
- * below its cap, so the grid there is `V − APPS_CONTAINER_GUTTER` wide. `lg` and `xl`
- * both mean four columns, so the `xl` rung collapses into the `lg` one and the ladder
- * has no redundant step.
+ * {@link MANTINE_BREAKPOINT_PX} rather than retyped: a breakpoint fires at viewport `V`,
+ * `/apps` takes no body measure, and the apps `Container` is full-bleed below its cap,
+ * so the rung is placed at `V − APPS_CONTAINER_GUTTER` of GRID. `lg` and `xl` both mean
+ * four columns, so the `xl` rung collapses into the `lg` one and the ladder has no
+ * redundant step.
+ *
+ * 🔴 THE RUNGS ARE UNCHANGED AS FUNCTIONS OF **GRID** WIDTH — NOT OF VIEWPORT WIDTH, AND
+ * THE DIFFERENCE IS A REAL BEHAVIOUR CHANGE THAT IS KEPT ON PURPOSE. This module used to
+ * claim the narrow half was "byte-equivalent" to the retired media queries. It is not.
+ * The page's scroll container is `.scroll-area` (`AppLayout` → `ScrollArea`), which
+ * `src/styles/globals.css` gives `overflow-x: hidden` + `scrollbar-width: thin`, and
+ * `html, body { overflow: hidden }` means there is no document scroll — so the apps
+ * `Container` sits INSIDE a scrollbar-consuming box and the grid is
+ * `viewport − scrollbar − APPS_CONTAINER_GUTTER`. `Grid.Col span` compiled to media
+ * queries, which evaluate against the viewport and ignore a scrollbar; a container query
+ * measures the box the content actually gets. So on Windows/Linux Chrome/Firefox
+ * (~10px thin scrollbar) every rung fires ~10px of VIEWPORT later than it used to —
+ * viewport 1200 gives 1158 of grid and THREE columns where the media query said four.
+ * macOS overlay scrollbars and touch reserve nothing and are unaffected.
+ *
+ * That is the more correct answer, because the content never had those pixels, which is
+ * why the behaviour is kept and the claim was retired instead. Both halves are driven
+ * end-to-end in `AppListingsMarketplaceBody.stretch.geometry.test.tsx`.
  *
  * The WIDE rungs come from {@link WIDE_COLUMN_COUNTS} through
  * {@link minContentWidthForColumns}, i.e. straight out of the card-width floor.
@@ -278,7 +313,9 @@ export function listingGridColumnsAt(contentWidth: number): number {
  * still rather than being undone, and re-tuning to five columns there would have landed
  * 364.8px — narrower than what that pass shipped. The 2560 step adds ONE column, and
  * only where every card is still at least the 460px the store renders today: five from
- * 2364px of grid, giving 492.8px cards at the 2528 `/apps` reaches. Six would need 2840
+ * 2364px of grid, giving 492.8px cards at the 2528 a 2560 CONTAINER yields (a 2560
+ * viewport yields ~10px less on a platform that reserves a scrollbar — still five
+ * columns, ~490.8px cards). Six would need 2840
  * and is therefore unreachable at this cap — so widening the container makes the cards
  * BIGGER than they are now rather than more numerous and smaller. The arithmetic is
  * pinned in `__tests__/appsPageWidths.test.ts` and `__tests__/appListingGrid.test.ts`.

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -68,7 +68,9 @@ export const APPS_CONTAINER_GUTTER = 32;
  * width as a fifth column at the one width where every card still clears the 460px it
  * renders at today, and stops there. The cap and the density are separately decided
  * instead of the cap standing in for the density — and the density decision is that
- * this container makes the cards BIGGER (492.8px at five columns in 2528 of grid),
+ * this container makes the cards BIGGER (492.8px at five columns in the 2528 of grid a
+ * 2560 container yields; ~490.8px from a 2560 viewport, which loses ~10px more to the
+ * scroll container's thin scrollbar on the platforms that reserve one),
  * not more numerous. A sixth column is declared at 2840 of grid and is deliberately
  * unreachable here; raising this constant past that fails a test rather than silently
  * shrinking every card.
@@ -86,8 +88,9 @@ export const APPS_CONTAINER_GUTTER = 32;
  * ⚠️ SIBLING ROUTES GET WIDER TOO, AND SOME OF THEM DO NOT YET SPEND IT. Every route
  * in {@link APPS_FULL_MEASURE_PAGES} — `/apps/installed`, `/apps/mine`,
  * `/apps/revenue`, `/apps/review/[publishRequestId]` — takes no measure, so its table
- * now lays out at up to 2528px of content. They are correct and unclipped there, but
- * a table that could not spend 1888 cannot spend 2528 either; making those tables use
+ * now lays out at up to 2528px of content (less the scroll container's scrollbar on
+ * platforms that reserve one). They are correct and unclipped there, but a table that
+ * could not spend 1888 cannot spend 2528 either; making those tables use
  * the space is a deliberate follow-up, not part of this change.
  *
  * 🔴 IT IS ALSO THE CHROME'S WIDTH, on every route, which is the point of this
@@ -99,7 +102,8 @@ export const APPS_PAGE_CONTAINER_WIDTH = 2560;
 /**
  * The READABLE measure — single-column form/detail surfaces where line length, not
  * available space, is the constraint. A submit wizard or a listing editor stretched
- * to the full container (2528px of content today) puts prose and form rows on an
+ * to the full container (2528px of content today, less any reserved scrollbar) puts
+ * prose and form rows on an
  * unreadable measure.
  *
  * `1068 = 1100 − 32`: the content width these pages rendered when they passed
@@ -119,7 +123,7 @@ export const APPS_READABLE_MEASURE = 1068;
  * the then-1888px content width, Submitter grew to ~380px to hold a short username and
  * a large dead gap opened between the last column and the Review button, which is the
  * action the moderator is actually aiming at. Raising the container to 2560 (2528 of
- * content) makes that worse, not better — which is why this class exists rather than
+ * content, less any reserved scrollbar) makes that worse, not better — which is why this class exists rather than
  * tracking the container.
  *
  * `1368 = 1400 − 32`: the content width the page rendered at `size={1400}`. 1400 was

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -65,9 +65,13 @@ export const APPS_CONTAINER_GUTTER = 32;
  * column-count's job, because the grid had no way to add a column deliberately.
  * That is no longer true: {@link ~/components/Apps/appListingGrid} now carries an
  * EXPLICIT column ladder driven by a container query, so the store spends the extra
- * width as five and then six columns at widths where each card still clears its
- * measured minimum, and stops there. The cap and the density are separately decided
- * instead of the cap standing in for the density.
+ * width as a fifth column at the one width where every card still clears the 460px it
+ * renders at today, and stops there. The cap and the density are separately decided
+ * instead of the cap standing in for the density — and the density decision is that
+ * this container makes the cards BIGGER (492.8px at five columns in 2528 of grid),
+ * not more numerous. A sixth column is declared at 2840 of grid and is deliberately
+ * unreachable here; raising this constant past that fails a test rather than silently
+ * shrinking every card.
  *
  * What 1920 actually cost: Mantine's `Container` centres past its cap, so a 2560
  * viewport spent `(2560 − 1920) / 2 = 320px` of dead margin on EACH side of every

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -30,8 +30,8 @@
  * `__tests__/appsPageWidths.test.ts`.
  *
  * 🔴 THE PAIR (unchanged in force, and now stronger). The store's width is HALF of a
- * matched pair with the grid column span in {@link ~/components/Apps/appListingGrid}
- * — the span decides how many cards fit a row, the width decides how wide a row is,
+ * matched pair with the grid column LADDER in {@link ~/components/Apps/appListingGrid}
+ * — the ladder decides how many cards fit a row, the width decides how wide a row is,
  * and moving one without the other silently re-truncates (or over-stretches) the
  * cards. `/apps` takes NO measure, so its content width IS the container width, and
  * `LISTING_STORE_CONTAINER_SIZE` reads {@link APPS_PAGE_CONTAINER_WIDTH} rather than
@@ -60,22 +60,43 @@ export const APPS_CONTAINER_GUTTER = 32;
 /**
  * The ONE container width every `/apps/*` route renders in.
  *
- * 1920 rather than "unbounded": at 2560 an unbounded store grid runs 6+ cards across
- * with the text measure of each card's tagline unchanged, and the wide tables put
- * ~1500px of columns beside ~1000px of whitespace-padded row actions. 1920 is the
- * common wide-desktop width, so on a 1920 monitor the pages are genuinely
- * edge-to-edge and on a 2560 one they stay a readable block.
+ * 🔴 2560, RAISED FROM 1920. The old value's stated reason was that "an unbounded
+ * store grid runs 6+ cards across at 2560" — i.e. the container was doing the
+ * column-count's job, because the grid had no way to add a column deliberately.
+ * That is no longer true: {@link ~/components/Apps/appListingGrid} now carries an
+ * EXPLICIT column ladder driven by a container query, so the store spends the extra
+ * width as five and then six columns at widths where each card still clears its
+ * measured minimum, and stops there. The cap and the density are separately decided
+ * instead of the cap standing in for the density.
+ *
+ * What 1920 actually cost: Mantine's `Container` centres past its cap, so a 2560
+ * viewport spent `(2560 − 1920) / 2 = 320px` of dead margin on EACH side of every
+ * `/apps/*` page — and the top of Mantine's own breakpoint scale is `xl` = 88em
+ * (1408px), so nothing in the grid could react to any of it either (the theme
+ * declares no custom breakpoints; see `src/providers/ThemeProvider.tsx`).
+ *
+ * 2560 is the common ultrawide/4K-scaled desktop width, so a 2560 monitor is now
+ * genuinely edge-to-edge. Past it the pages centre again, which is the same
+ * behaviour 1920 gave a 2560 monitor.
+ *
+ * ⚠️ SIBLING ROUTES GET WIDER TOO, AND SOME OF THEM DO NOT YET SPEND IT. Every route
+ * in {@link APPS_FULL_MEASURE_PAGES} — `/apps/installed`, `/apps/mine`,
+ * `/apps/revenue`, `/apps/review/[publishRequestId]` — takes no measure, so its table
+ * now lays out at up to 2528px of content. They are correct and unclipped there, but
+ * a table that could not spend 1888 cannot spend 2528 either; making those tables use
+ * the space is a deliberate follow-up, not part of this change.
  *
  * 🔴 IT IS ALSO THE CHROME'S WIDTH, on every route, which is the point of this
  * module. Do not reintroduce a per-page `Container size=` — `AppsPageLayout` no
  * longer accepts one, and `__tests__/appsPageLayout.test.ts` pins that.
  */
-export const APPS_PAGE_CONTAINER_WIDTH = 1920;
+export const APPS_PAGE_CONTAINER_WIDTH = 2560;
 
 /**
  * The READABLE measure — single-column form/detail surfaces where line length, not
  * available space, is the constraint. A submit wizard or a listing editor stretched
- * to 1888 puts prose and form rows on an unreadable measure.
+ * to the full container (2528px of content today) puts prose and form rows on an
+ * unreadable measure.
  *
  * `1068 = 1100 − 32`: the content width these pages rendered when they passed
  * `size={1100}`. 1100 was chosen as wider than the `sm` (620) / `md` (800) / `lg`
@@ -89,10 +110,13 @@ export const APPS_READABLE_MEASURE = 1068;
  * container is not "full width" but "stretched".
  *
  * `/apps/review` is the case this exists for. It renders FOUR narrow columns (Kind /
- * App / Submitter / Submitted) plus a Review button. At 1888 the columns cannot spend
- * the space, so the table distributes it as padding: Submitter grows to ~380px to
- * hold a short username, and a large dead gap opens between the last column and the
- * Review button, which is the action the moderator is actually aiming at.
+ * App / Submitter / Submitted) plus a Review button. At the full container width the
+ * columns cannot spend the space, so the table distributes it as padding: measured at
+ * the then-1888px content width, Submitter grew to ~380px to hold a short username and
+ * a large dead gap opened between the last column and the Review button, which is the
+ * action the moderator is actually aiming at. Raising the container to 2560 (2528 of
+ * content) makes that worse, not better — which is why this class exists rather than
+ * tracking the container.
  *
  * `1368 = 1400 − 32`: the content width the page rendered at `size={1400}`. 1400 was
  * picked over 1200 to keep the page wider than the readable/form width while stopping
@@ -125,9 +149,10 @@ export const APPS_NARROW_TABLE_MEASURE = 1368;
  * Why not the READABLE measure it used to be: at 1068 the `md` split gives a ~340px
  * right rail, narrower than the creator card + action card want, and the page reads as
  * a squeezed single column with a sliver beside it. Why not the full container: the
- * left column is prose (a `CustomMarkdown` description), and 8/12 of 1888 is a
- * ~1250px measure — the exact thing {@link APPS_READABLE_MEASURE} exists to avoid. At
- * 1288 the left column is ~825px and the rail ~410px.
+ * left column is prose (a `CustomMarkdown` description), and 8/12 of the container's
+ * content width is a ~1685px measure at today's 2560 (it was ~1250px at 1920) — the
+ * exact thing {@link APPS_READABLE_MEASURE} exists to avoid, and the container getting
+ * wider only widens the gap. At 1288 the left column is ~825px and the rail ~410px.
  */
 export const APPS_TWO_COLUMN_DETAIL_MEASURE = 1288;
 
@@ -237,7 +262,7 @@ export const APPS_FULL_MEASURE_PAGES = [
  * `PageBlockHost`, which caps ITSELF at `--app-page-max-width` (1600px, see
  * `APP_PAGE_MAX_WIDTH_PX` in `~/components/AppBlocks/PageBlockHost`) and centres
  * the app past that. Two different mechanisms at two very different thresholds:
- * this module's container is 1920 and applies to the apps CHROME, the host's cap
+ * this module's container is 2560 and applies to the apps CHROME, the host's cap
  * is 1600 and applies to the app itself, and an app can be excused from the
  * host's via the CSS ledger in `src/styles/globals.css`. Nothing here changes —
  * these routes still pass no `measure` and still render no `AppsPageLayout` — but

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -75,7 +75,8 @@ export const SUBMISSIONS_CONTAINER_CHROME = 34;
  * 🔴 `MY_SUBMISSIONS_CONTAINER_SIZE` LIVED HERE AND IS GONE, AND SO HAS ITS SUCCESSOR.
  * `/apps/my-submissions` merged into `/apps/mine` and 301s there, so the alias moved to
  * `MY_APPS_CONTAINER_SIZE` in `myAppsView.ts` — and that is now gone too: every `/apps/*`
- * route renders in the single `APPS_PAGE_CONTAINER_WIDTH` (1920) container, so there is no
+ * route renders in the single `APPS_PAGE_CONTAINER_WIDTH` (2560 since the ultrawide
+ * pass; it was 1920 when this note was written) container, so there is no
  * per-page width left to alias. `/apps/mine` takes no body measure either, precisely so the
  * table below clears the floor. The relationship that used to be implied by the alias is
  * asserted directly in `__tests__/appsPageWidths.test.ts`:

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -104,10 +104,15 @@ export default function AppsPage() {
             path: typeof window !== 'undefined' ? window.location.pathname : undefined,
           })}
         />
-        {/* Widened past the default `xl` (1320px) token. The width is UNCHANGED by
-            the larger-cover pass — the store now runs a 4-across grid at `xl` (see
-            `LISTING_GRID_SPAN`), and the container/grid pair is pinned together in
-            `appListingGrid.ts` so neither can drift alone. */}
+        {/* The container is `APPS_PAGE_CONTAINER_WIDTH` (2560), applied by
+            `AppsPageLayout` — not by anything on this page. This route takes no body
+            `measure`, so its content width IS the container width, which is what makes
+            the store's column arithmetic true.
+            The store spends that width as an explicit column ladder driven by a
+            container query (`LISTING_GRID_COLUMN_STEPS`): 1/2/3/4 exactly where the
+            retired Mantine breakpoints put them, then 5 from 1979px of grid and 6 from
+            2378. Container and ladder are pinned together in `appListingGrid.ts` and
+            its test so neither can drift alone. */}
         <AppListingsMarketplaceBody />
       </AppsPageLayout>
     </>

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -110,9 +110,11 @@ export default function AppsPage() {
             the store's column arithmetic true.
             The store spends that width as an explicit column ladder driven by a
             container query (`LISTING_GRID_COLUMN_STEPS`): 1/2/3/4 exactly where the
-            retired Mantine breakpoints put them, then 5 from 1979px of grid and 6 from
-            2378. Container and ladder are pinned together in `appListingGrid.ts` and
-            its test so neither can drift alone. */}
+            retired Mantine breakpoints put them, then 5 from 2364px of grid — so this
+            page renders five columns at 492.8px on a 2560 monitor, wider than the
+            460px four-up the 1920 container shipped. A sixth column is declared at
+            2840 and is unreachable at this cap. Container and ladder are pinned
+            together in `appListingGrid.ts` and its test so neither can drift alone. */}
         <AppListingsMarketplaceBody />
       </AppsPageLayout>
     </>

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -111,8 +111,10 @@ export default function AppsPage() {
             The store spends that width as an explicit column ladder driven by a
             container query (`LISTING_GRID_COLUMN_STEPS`): 1/2/3/4 exactly where the
             retired Mantine breakpoints put them, then 5 from 2364px of grid — so this
-            page renders five columns at 492.8px on a 2560 monitor, wider than the
-            460px four-up the 1920 container shipped. A sixth column is declared at
+            page renders five columns at ~490.8px on a 2560 monitor (492.8px against the
+            2560 CONTAINER; a 2560 viewport loses ~10px more to the scroll container's
+            thin scrollbar where the platform reserves one), wider than the 460px four-up
+            the 1920 container shipped. A sixth column is declared at
             2840 and is unreachable at this cap. Container and ladder are pinned
             together in `appListingGrid.ts` and its test so neither can drift alone. */}
         <AppListingsMarketplaceBody />


### PR DESCRIPTION
## What changed

**1. `APPS_PAGE_CONTAINER_WIDTH` 1920 → 2560.** One container for all 20 `/apps/*` routes, unchanged in kind — no per-page container width, no `AppsPageLayout size=` prop. Mantine's `Container` centres past its cap, so on a 2560 monitor every apps page was spending `(2560 − 1920) / 2 = 320px` of dead margin per side, and since `src/providers/ThemeProvider.tsx` declares no custom breakpoints, `xl` = 88em (1408px) was the top of the scale and nothing in the store grid could react to any of it either.

**2. The store grid gets an explicit column ladder, driven by a container query.** It moves off Mantine's `<Grid>/<Grid.Col span={LISTING_GRID_SPAN}>` to a CSS grid in `AppListingsMarketplaceBody.module.scss`. `Grid.Col span` can only read a theme *breakpoint*, so there was nowhere above 1408 to hang a fifth column — and adding a theme breakpoint would be a site-wide change made to fix one grid. The reachable ladder is **1 / 2 / 3 / 4 / 5**; a sixth column is declared and deliberately out of reach at this container cap (see below).

**3. Page size `limit: 24` → `48`.** 24 was six rows at four columns and under five at the five-column top of the ladder, so the widest screen the container supports would have met "Load more" after the least content. The server's `listAppListingsSchema` caps `limit` at 50 (`z.number().int().min(1).max(50).default(20)`), so 48 is deliberately just inside it and the schema is untouched.

**4. Stale comments fixed** — the `AppListingsMarketplaceBody` grid comment claiming the container was "still 1600", the `src/pages/apps/index.tsx` container-width comment, plus every measurement in `appsPageWidths.ts` that quoted the old 1888 content width (the `/apps/review` padding argument, the readable-measure argument, and the "8/12 of 1888 is ~1250px" note on the two-column detail measure, now ~1685px).

## 🔴 A behaviour change the earlier revisions denied: the scrollbar

Earlier revisions of this PR claimed the narrow rungs were **byte-equivalent** to the retired `Grid.Col span` media queries. **That was false in production**, and the claim is now retired.

The page's scroll container is `.scroll-area` (`AppLayout` → `ScrollArea`), which `globals.css` gives `overflow-x: hidden` + `scrollbar-width: thin`; `html, body { overflow: hidden }` means there is no document scroll. So the apps `Container` sits **inside a scrollbar-consuming box** and the grid is `viewport − scrollbar − 32`. Media queries evaluate against the **viewport** and ignore a scrollbar; a container query measures the box the content actually gets.

| viewport | grid width | old | new | card width, old → new |
|---|---|---|---|---|
| 768–777 | 726–735 | 2 | **1** | ~355 → **~726px** ⚠️ |
| 992–1001 | 950–959 | 3 | **2** | ~306 → ~467px |
| 1200–1209 | 1158–1167 | 4 | **3** | ~280 → ~375px |
| 2560 | **~2518** | 4 | **5** | 460 → ~490.8px |

Every rung fires ~10px of viewport later on Windows/Linux Chrome/Firefox. macOS overlay scrollbars and touch reserve nothing and are unaffected.

⚠️ **Price the first row before approving it.** In that 10px band a single card fills the row at **~726px** — roughly 1.5× the widest card the store renders anywhere (~490.8px at the top of the ladder), where the media query gave two ~355px cards. The rung *shift* is justified above; that particular outcome is a consequence of it and is called out separately so nobody has to do the division. It is consistent with the bigger-cards direction chosen for this PR and has been seen and accepted; the behaviour is deliberately unchanged.

**The behaviour is kept and the claim fixed**, because a container query measuring real available width is the more correct answer — the content never had those pixels. What survives is stated precisely: the narrow rungs are unchanged **as functions of grid width**, and grid width is now *measured* rather than inferred from the viewport. Every quoted `2528` / `492.8` now says which quantity it is (container arithmetic, not viewport).

### The fixture that would have caught it

Every other fixture in this PR sets the grid's width on a wrapper — the right shape for testing the ladder, and structurally blind to the step in front of it. **No test could see the viewport→grid derivation at all, which is why this survived three rounds.** The geometry spec now renders the real chain — `.scroll-area` → `<main class="min-w-0 flex-1">` → `AppsPageLayout`'s Container → the grid, with content tall enough to overflow — and asserts `gridWidth === scrollBox.clientWidth − APPS_CONTAINER_GUTTER` and `columns === listingGridColumnsAt(gridWidth)`.

🔴 **Honest limitation, measured not assumed.** Playwright launches headless Chromium with `--hide-scrollbars` and this repo passes no `ignoreDefaultArgs`, so a genuinely overflowing `.scroll-area` with `scrollbar-width: thin` probes `offsetWidth − clientWidth === 0`. **No test in this project can exercise the native 10px delta** without changing launch args for *both* browser projects — out of scope here, and it would move every existing geometry number. The fixture splits that honestly: one test asserts the platform-independent relationship **and pins the harness's reserve at 0**, so this limitation fails loudly rather than rotting; a second reproduces the production case deterministically by narrowing the box by a 10px reserve → 1158 of grid → **three** columns, where the retired media query said four.

The fixture also caught a fidelity bug in *itself*: omitting `<main className="min-w-0 flex-1">` (which `MainContent` supplies) let the Container's `margin-inline: auto` cancel flex stretch, and the grid measured **553.02px instead of 1168**. That is the argument for driving the real chain rather than a wrapper of a chosen width.

## The auto-fill impossibility derivation — verified, it holds

`repeat(auto-fill, minmax(X, 1fr))` fits `floor((W + gap) / (X + gap))` columns at a 16px gap.

| requirement | needs |
|---|---|
| 4 columns at 1376 of grid (the `xl` low end: viewport 1408 − 32 gutter) | `X ≤ 332` (332px cards) |
| 4 and **not** 5 columns at 1888 (what the retired 1920 container reached) | `X > 364.8` (5-up at 1888 is exactly 364.8px) |

No overlap. Any floor low enough for four at 1376 gives **five** at 1888 at 364.8px per card — narrower than what the 2026-07 "larger covers" pass moved *to* when it went 5 → 4. So the column count has to stay an explicit ladder. This is checked as arithmetic in `appListingGrid.test.ts` ("an intrinsic auto-fill grid CANNOT express this ladder"), not asserted in prose.

## The ladder, and where its numbers come from

| grid width | columns | source | card width there |
|---|---|---|---|
| 0 | 1 | `LISTING_GRID_SPAN.base` | — |
| 736 | 2 | `sm` 768 − 32 gutter | 360 |
| 960 | 3 | `md` 992 − 32 | 309.3 |
| 1168 | 4 | `lg` 1200 − 32 (`xl` is also 4, so it is not a rung) | 280 |
| **2364** | **5** | `5 × 460 + 4 × 16` | **460** |
| 2840 | 6 | `6 × 460 + 5 × 16` — **declared, unreachable at this cap** | 460 |

`/apps` at a 2560 container renders **2528 of grid → five columns at 492.8px**.

The narrow half is **derived in code** from `LISTING_GRID_SPAN` + `MANTINE_BREAKPOINT_PX` rather than retyped, so the container-query thresholds are the media-query behaviour they replaced converted by exactly one subtraction (`/apps` takes no body measure and the Container is full-bleed below its cap, so the grid there is `viewport − 32`). The wide half comes from `LISTING_CARD_MIN_WIDTH` through `minContentWidthForColumns(n) = n × floor + (n − 1) × gap`, which is the only place a wide threshold is computed.

### Why the floor is 460, not the covers pass's own 380

`LISTING_CARD_MIN_WIDTH` is the card width the store renders **today** at its widest: four columns in the 1920 container, `(1920 − 32 − 48) / 4 = 460`. It is pinned as that *relationship* in the test, not as a bare literal.

A floor set at the narrowest width the 2026-07 "larger covers" pass shipped (four columns at a 1600 container = **380**) would have put **six** columns in a 2560 container at **408px** each — i.e. widening the page would have made cards *smaller than they are now*, partially reversing that pass at exactly the viewports it should help most. Bigger cards were chosen over more of them. Both directions are asserted: `492.8 > 460` at the reachable top, and the 380-floor counterfactual (`408 < 460`) is written into the test as the thing being ruled out.

> Earlier revisions of this PR used a 383 floor (thresholds 1979 / 2378, six columns at 408px on a 2560 monitor). That is what this change replaces. The `~383` figure carried in `appListingGrid.ts`'s comments since the covers pass was itself wrong — the arithmetic is 380 — and neither number is the floor any more.

### Six columns is declared but unreachable — on purpose

`6 × 460 + 5 × 16 = 2840`, and the 2560 container tops out at **2528** of grid. The rung is kept rather than deleted so a future cap raise engages it automatically, and a test asserts `sixRung.minContentWidth > APPS_PAGE_CONTAINER_WIDTH − APPS_CONTAINER_GUTTER`. **That assertion is what fires if someone raises the container cap** — engaging six is a density decision and must be made deliberately rather than inherited from a width bump. The rung is proven *real* rather than decorative by rendering at 2900 and getting six.

## 🔴 The 1888 collision, and why it gets its own describe block

**`4 × 460 + 3 × 16 = 1888` — exactly the content width of the retired 1920 container.**

So if the card-width floor ever governed the **narrow** half of the ladder, four columns would begin at 1888 and the entire **1168–1887** band would drop to three — including **1376**, the `xl` low end, which is the middle of the ordinary desktop range and the last width anyone would re-check. It does not: the narrow rungs derive from `LISTING_GRID_SPAN` + Mantine's breakpoints minus the gutter and never read the floor.

But that is a claim about a derivation, and at the old 383 floor the equivalent number was 1580 — far from anything in play — so this failure mode used to be *loud* and is now *quiet*. It is therefore proven rather than asserted:

- **4 columns at 1376** pinned explicitly in **both** tiers, with a failure message that names `minContentWidthForColumns(4)` as the likely cause;
- **4 columns at 1887 and at 1888** — one below the collision point and on it;
- a structural pin that **no narrow rung equals its own floor-derived value** (736 ≠ 936, 960 ≠ 1412, 1168 ≠ 1888), plus that each narrow rung fires *earlier* than the floor would allow (four columns at 1376 is a deliberate 332px card);
- a dedicated mutation that makes the floor govern everywhere.

🔴 **Measured, not assumed: under that mutation the 1888 case stays GREEN in both tiers and only 1376 goes red.** 1888 is the reassuring half — a floor-governed ladder renders four there too. 1376 is the guard. A fixture set that kept only 1888 would read as covering this and would not, so a test asserts both are present.

## 🔴 The card-stretch seam — the grid's *absent* `align-items` is load-bearing

`AppListingCard` bottom-pins its action row with `mt="auto"` inside a `<Stack h="100%">` inside a `<Card className="h-full">` — all pre-existing on `main`, none of it new in this PR. `h-full` is `height: 100%`, which needs a parent with a definite height, and the only thing supplying one is the grid **stretching** its items to the row height (`align-items: normal`, the grid default). Nothing declares that, so the behaviour every card depends on was an absence.

Four shapes, measured:

| structure | align-items | result |
|---|---|---|
| card as a DIRECT grid item | default | ✅ bottoms `[389,389]`, heights `[405,405]` |
| card in a WRAPPER div | default | ✅ `[389,389]` / `[405,405]` |
| card as a DIRECT grid item | `start` | ✅ `h-full` resolves against the grid **area**, so stretch is not what carries it |
| card in a WRAPPER div | non-stretch | ❌ short card shorter, its action row unpinned |

**This grid is the failing shape's first half** — `.grid` → a per-card wrapper `<div data-testid="apps-listing-grid-col">` → the card. So one `align-items: start`, the kind of line someone adds for vertical rhythm, unpins the action row on every card in the store. A structural check ("does the action row carry `margin-top: auto`?") walks straight past it: the declaration is still there under the mutant, it simply has no free space to consume.

New `AppListingsMarketplaceBody.stretch.geometry.test.tsx`: five cards of deliberately uneven height (one-line title / no tagline **vs** wrapping title / three-line tagline, alternating so any prefix holds both kinds), in **one row**, at **two column counts** — **1376** (4 columns, the `xl` low end) and **2450** (5 columns, mid-band; 2364 itself avoided, since a fixture on its own boundary cannot detect an off-by-one). Both widths are named in every assertion. It asserts (a) every card's rendered height is equal, (b) every action row's `getBoundingClientRect().top` is equal, plus a non-vacuity control that the fixtures genuinely differ in natural content height, plus that every action row sits the same distance from its card's bottom. The stylesheet now carries the reason in a comment, so the absence reads as a decision.

### 🔴 Why the `geometry` project and not `component`

`h-full` is a **Tailwind** utility, so which tier the guard runs in decides whether it resolves at all. Stated precisely, because the short version ("the `component` tier has no Tailwind") is true of the tier's *default* and false of three specs in it — all measured at this ref:

- **By default it does not.** `test/component-setup.tsx` parses `globals.css?raw` into a throwaway `CSSStyleSheet`, walks it for unconditional `:root` rules, and injects a `<style>` holding only the `--*` custom properties — 24 CSS rules. No utilities, no preflight. Its own docstring records why importing the real sheet was rejected: it moves the rendered geometry of every existing test in that tier.
- **But three specs opt in**, with a side-effect `import '~/styles/globals.css'`: `AppListingCard.browser.test.tsx` (line 40, and a 0-line diff vs `origin/main`), `ImageCard.browser.test.tsx`, `ImageResources.browser.test.tsx`. Vite runs those through PostCSS, so Tailwind utilities genuinely **do** resolve there. (Two further specs import it as `?raw` *text*, which injects nothing and is not an opt-in.) So "this spec cannot see Tailwind" is a claim about the **file**, not about the tier.

🔴 **The reason this guard belongs in `geometry` is therefore the cascade LAYER ORDER, not the mere presence of Tailwind — and that is the stronger reason.** A layer's priority is fixed at its **first appearance** in the CSSOM. An opted-in `component` spec gets `globals.css` (and, in `AppListingCard`'s case, `@mantine/core/styles.layer.css`) with **no** `test/cascade-layer-order.css`, so layer priority falls out of import order — a *third* cascade, matching neither the tier default nor production. `test/geometry-setup.tsx` parses `@layer tailwind-preflight, theme, mantine, modules;` first and then loads `globals.css` + the six Mantine `<pkg>/styles.layer.css` sheets + `mantine-react-table/styles.css`, i.e. `_document.tsx` followed by `_app.tsx`. This seam is a fight between a Tailwind utility (`h-full`), a Mantine component rule (`Card`) and a CSS Module (`.grid`) — exactly the three layers that declaration orders — so it needs the real one.

That the tier matters is not theory: the first draft of this guard lived in the columns browser spec, which takes only `@mantine/core/styles.css` and therefore gets the tier default. It reported heights of `[458.23, 312.75, 434.23, 312.75]` **on a correct grid** — the defect's own numbers — and would have been read as the guard working. This file asserts the cascade arrived (`cascadeEvidence().tailwindFlexUtilityResolves`, `probeBoxSizing`, a rule count > 1000) before measuring anything. The `geometry` project also has a CI job (`Geometry tests`), where `component` is preview-only.

The column **ladder** stays in the `component` tier: it is driven by this repo's own CSS module, which Vite injects wherever the component is imported, so its `@container` rules apply regardless of the app cascade. Only the stretch chain depends on Tailwind and on layer order.

### 🔴 The same append-render bug, again — this time in the geometry harness

`renderAtViewport` appends like `render` does, and the setup file's `afterEach` only runs **between** tests, so a test rendering twice kept measuring the first grid. Caught by the two-widths guard reading 4 columns for its 2450px render. `renderAtGridWidth` now cleans up first. Same class as the fix in the component harness last round — worth knowing it is a property of the harness, not of one file.

## Why a container query, not a media query

Card width is not monotonic in viewport width: at the one-column base breakpoint a 390px phone yields a ~356px card, **wider** than the ~280px a 1200px laptop gets at four columns. The quantity that decides whether a card is too narrow is the width of the *grid*, which is what `@container` reads. `AppListingCard.tsx` already uses `@container` in this area.

I used a **CSS Module** rather than Tailwind's `@[…px]:` arbitrary container variants. Same mechanism, but the module's CSS is injected by Vite wherever the component is imported, so the new browser test exercises the real container query in the `component` tier without needing the app cascade at all (that tier's setup injects only `globals.css`'s `:root` custom properties). `AppListingDetailBody.module.scss` + `appListingGalleryFill.test.ts` are the existing precedent for this shape in this directory, guard included.

**No custom Mantine theme breakpoint was added.**

## Tests

**Node tier (blocking `unit`):**
- `__tests__/appListingGrid.test.ts` — the ladder as a literal table probed on **both sides of every rung** (735/736, 959/960, 1167/1168, 2363/2364, 2839/2840) plus mid-band points and the three collision guards (1376 / 1887 / 1888); a guard-the-guard that fails if any rung is not probed on both sides; the ladder pinned as an exact ledger; a byte-equivalence block proving each retired Mantine breakpoint maps to its rung by exactly one subtraction *and* does not fire one px early; the floor pinned as a RELATIONSHIP (`listingCardWidthAt(1920 − 32, 4) === 460`) as well as a literal, with its derived thresholds; a "every floor-derived rung gives cards ≥ the floor, and its threshold is minimal" pin; the widest-reachable-rung-makes-cards-BIGGER pin and its 380-floor counterfactual; the six-columns-unreachable pin; a whole `THE COLLISION` describe; the auto-fill impossibility arithmetic; a **seam test that parses the stylesheet's `@container` rules and fails unless they equal `LISTING_GRID_COLUMN_STEPS` in both directions**; a seam on the component rendering both classes in the right nesting order; and a page-size seam that reads the `max(50)` cap out of `listAppListingsSchema` rather than restating it.
- `__tests__/appsPageWidths.test.ts` — new container value; card width at the top of the **reachable** ladder (2528 → five columns → 492.8px, ≥ the floor and strictly greater than the 1920 container's 460); a new pin that the retired 1600/1920 containers still produce the four columns they shipped. The fs-walk completeness test, the `APPS_CONTAINER_GUTTER = 32` arithmetic and the `/apps/mine` 1424px scroll-floor assertion all still pass unchanged.
- `__tests__/appsPageLayout.test.ts` and `__tests__/appsPageLayoutRender.test.ts` pass **unchanged** (not edited).

**Browser tier (report-only `component`):**
- New `AppListingsMarketplaceBody.columns.browser.test.tsx` — 3 / 4 / 4 / 5 / 5 / 5 columns at grid widths 1000 / **1376** / **1888** / 2450 / 2528 / 2560 (no fixture sits on a rung; 2364 itself is deliberately avoided). Columns are counted by **grouping cells on `getBoundingClientRect().top`**, never by DOM children, and the whole row shape is asserted (13 cards ⇒ `[C, C, …, remainder]`), so a grid that got the first row right and then collapsed cannot pass. It carries a positive control (`display: grid` read back off the element) because "one column everywhere" is exactly what an unstyled document produces. It also measures the floor at three wide widths, measures that 2528 beats the old 1888/460 (`492.8 > 460`), measures that six is unreachable at the cap but engages at 2900, and includes a **narrow-grid / wide-viewport** case (900px grid at a 2880px viewport) that a media-query implementation cannot pass.
- 🔴 **A harness bug this round surfaced and fixed:** `vitest-browser-react` **appends** each render rather than replacing it, so a test measuring several widths left two grids in the document and `document.querySelector` kept returning the **first** one — a loop over widths measured the first width N times and passed. The previous round's floor check did exactly that. `renderAtContainerWidth` now `cleanup()`s first, and a control test proves two widths give two different answers with exactly one grid in the document.
- `AppsPageLayout.chromeAlignment.browser.test.tsx` — updated literals *and gained a third viewport*: raising the cap to 2560 made the 2560 row full-bleed like the 1440 one, so both would have measured the same branch and `margin-inline: auto` would have gone unmeasured. 3440 restores the centred case (left 456, content 2528). Body left edge == nav left edge on all 13 routes at all three viewports.
- `AppListingsMarketplaceBody.browser.test.tsx` — the `--col-flex-basis` assertion is gone with Mantine's `Grid` and is replaced by a structural pin (one testid-carrying cell per card, each a **direct** child of the grid — a cell one wrapper deeper would silently become one column with `grid-template-columns` still reading right); `limit` assertion 24 → 48.

### Mutation table (mutate → run → confirm the intended test fails **with its own assertion** → revert)

Re-run in full at this HEAD. Observed, not expected. A positive control confirmed the node invocation collects 107 tests before any mutant was believed.

| mutation | observed |
|---|---|
| **floor governs the narrow half** (`minContentWidth = minContentWidthForColumns(columns)`) | **RED**, 17 node tests. The 1376 guard fails with its own diagnostic (`…minContentWidthForColumns(4) is 1888… expected 2 to be 4`). **0 FAIL rows name the 1888 case — it stayed green.** |
| the same defect in the stylesheet (narrow rungs → 936 / 1412 / 1888) | **RED**, 3 browser tests. **1 FAIL row names 1376, 0 name 1888.** |
| stylesheet threshold `2364px` → `2365px` | **RED**, 1 test: the `@container` ⇄ ladder seam |
| `listingGridColumnsAt` `>=` → `>` | **RED**, 8 tests |
| `LISTING_CARD_MIN_WIDTH` 460 → 383 | **RED**, 15 tests incl. `SIX columns is declared but UNREACHABLE` |
| `APPS_PAGE_CONTAINER_WIDTH` 2560 → 1920 | **RED**, 7 tests |
| 🔴 **NEW — the schema's own cap `max(50)` → `max(40)`** | **RED**, 1 test, `expected 40 to be 50` — the `limit` seam really parses the schema rather than restating it |
| 🔴 **NEW — `APPS_CONTAINER_GUTTER` 32 → 31** | **RED**, 1 test, `expected 1168 to be 1169` — the new real-chain *relationship* assertion is not vacuous |
| `@container` → `@media` + drop `container-type` | **RED** in **both** tiers: 11 of 12 component tests, **and 3 of 7 geometry tests** including the new one with its own message — *"the ladder is tracking the viewport rather than the box it is in — four columns here is the retired media-query answer…: expected 4 to be 3"* |
| `align-items: start` on `.grid` (card-stretch seam) | **RED**, 3 geometry tests |

### Regression matrix — red at base, green at HEAD

Base `ec49115e55` (`origin/main`), HEAD `a261c8287d`. Measured by checking out a clean `origin/main` worktree, copying **only the test files** in, and running there.

| tier | at base `ec49115e55` | at HEAD `a261c8287d` |
|---|---|---|
| `unit`, the two geometry-constant files | **49 failed / 58 passed** | **107 passed** |
| `unit`, all of `src/components/Apps` + `src/components/AppBlocks` | — | **116 of 117 files, 2256 passed**; the 1 failing file (`hiddenBlocks.test.ts`, 7 tests) fails **identically at `origin/main`** — pre-existing and unrelated, verified by running it there |
| `component`, columns + chromeAlignment | **15 failed / 7 passed** (converged over two consecutive warm runs, 7.25s / 7.00s) | — |
| `component`, 8 marketplace + layout + PageBlockHost files | — | **69 passed** |
| `geometry`, the stretch + real-chain spec | **9 failed / 9** (converged over three warm runs, 11.9s / 10.8s / 10.8s) | — |
| `geometry`, the whole project | — | **3 files / 19 passed** |

All browser numbers are from **warm** runs; every red was re-run until it converged before being believed.

### Payload vs scaffolding

**Production payload in the last two rounds: 0 executable lines.** Verified by stripping comments and comparing, not by grep — a first attempt with a regex counted the prose `scrollbar-width: thin` *inside a comment* as a declaration and reported a false difference.

| round | production | test scaffolding |
|---|---|---|
| audit round 1 (`48e3f8a6da`) | **0** | +59 (the real-chain fixture) and **one** `why:` label string changed |
| audit round 2 (`a261c8287d`) | **0** | +18 / −5 (wide-rung coverage, the real `MainContent`) |

⚠️ An earlier revision of this row said "two `why:` label strings … +2 / −2". **Exactly one** string literal changed; the round-1 commit message repeats the wrong count and cannot be amended. On a PR whose defence is that its numbers are derived and checkable, the ledger is the worst place to carry a wrong one, so it is corrected here and the error left visible rather than quietly dropped.

## Known cost of `limit: 48`, and its follow-up

Doubling the page size doubles the covers fetched on first paint, and `AppListingCard`'s cover has no `loading="lazy"`. The fix belongs in that component, which a concurrent PR owns and which this PR must not touch, so **48 is kept and the lazy-load is a filed follow-up**. Exposure today is near zero: `/apps` is flag-gated to mods and testers.

## Routes that now render wider and are awaiting PR2b

Everything in `APPS_FULL_MEASURE_PAGES` takes no `measure`, so its body now lays out at up to **2528px** of content instead of 1888:

- `/apps/installed`
- `/apps/mine`
- `/apps/revenue`
- `/apps/review/[publishRequestId]`

They are correct and unclipped there (`/apps/mine`'s 1424px table scroll floor is cleared by a wider margin than before), but a table that could not spend 1888 cannot spend 2528 either — making them use the space is PR2b. The three measured classes (`/apps/review` 1368, `/apps/store-preview/[slug]` 1288, the six readable routes at 1068) are unaffected by construction.

## Knowingly open — and why the audit ladder stops here

Two adversarial rounds ran on this PR. Round 1 found six items, round 2 found five; **every round-2 finding was prose or scaffolding, and both rounds produced zero production payload.** A round 3 would necessarily be a second consecutive zero-payload round — the point at which the ladder has stopped auditing the change and started auditing its own output. So it stops, and what is left open is listed here rather than left implied.

- **Three of the four real-chain tests have no box-vs-viewport discriminating power.** At a harness reserve of 0 the scroll box and the viewport are the same number, so all three stay green under the `@container` → `@media` mutant — measured, not assumed. What they *do* guard is the chain itself (they die to the `px-2`-on-`<main>` mutant). **All** box-vs-viewport discrimination lives in the single reserved-scrollbar test.
- **`expect(reserve).toBe(0)` is a config tripwire, not a guard.** It cannot fail while `vitest.config.mts` passes no `ignoreDefaultArgs`, because Playwright's `--hide-scrollbars` makes the reserve 0 unconditionally. It buys exactly one thing: a Playwright bump or config change that starts reserving space turns it red instead of letting the docstring rot.
- **The ~10px reserve and "macOS overlay scrollbars reserve nothing" are structurally unmeasurable in this harness and remain unverified here.** They come from a real-browser measurement outside this repo. The production case is reproduced by *simulating* the reserve.
- **`PageBlockHost.tsx`'s cross-repo App Block census** (13 first-party repos, 11 page surfaces, median well 860, max 1100) is not checkable from this repo, records no refs, and nothing asserts it. It is now marked in-file as the rationale that was in front of whoever picked 1600 — not a live measurement — with an instruction to re-take it, recording refs, before leaning on it to move the cap. The 1600 cap itself is untouched.
- **The em-vs-px claim in `appListingGrid.ts` has no committed harness** and no longer pretends to. It is stated as the CSS fact it is — a media query's `em` resolves against the *initial* font size, so an app-level `html { font-size }` cannot move Mantine's breakpoints and no rung inversion is reachable — which follows from the spec and needs no fixture. The earlier "measured across three root sizes and 17 viewports" parenthetical is gone.
- **Pre-existing, not introduced here and deliberately not fixed here:** `submissionsTable.ts`'s "every `/apps/*` route renders in the single container" contradicts `APPS_FULL_BLEED_PAGES`, which lists three routes that render no `AppsPageLayout` at all. Only the stale `1920` in that sentence was corrected; the over-broad "every" predates this PR and fixing it is not this change's business.

## What I did NOT verify

- ~~**No typecheck.**~~ **Covered by CI on this revision:** all 19 checks are terminal and green on `a261c8287d`, including `tekton / typecheck`, **`Geometry tests`** (which is where the new stretch guard runs) and `preview / component-tests` (`tsc --noEmit`), `App unit tests + typecheck`, `Geometry tests`, `ESLint + Prettier (changed files)`, all four `Unit tests` shards and `preview / component-tests` (the browser tier). No local typecheck was run — local `tsc` is unreliable here (stale Prisma engine) and a bare `tsc --noEmit` OOMs — so Tekton is the evidence, not this session.
- **No real browser at a real 2560/3440 monitor.** Everything is headless Chromium at a set viewport.
- **Nothing about how the wider container looks on the four sibling routes above** beyond "no test broke" — that is the PR2b judgement.
- The `geometry` project IS exercised now — the new stretch guard lives there and CI's `Geometry tests` job runs it. Locally the whole project passes (3 files / 15 tests), so the two pre-existing geometry files are unaffected.
- The `em` ⇄ `px` caveat: Mantine's breakpoints are `em` and scale with the root font size, while the container-query thresholds are `px`. They are identical at the 16px root `globals.css` sets, so this only differs for a viewer who has changed their browser's default font size (they get slightly more columns than before at the same zoom). Documented on `MANTINE_BREAKPOINT_PX`; accepted, not measured.
- **Untouched by request:** `AppListingCard.tsx` and `appListingCardView.ts` (another agent owns them). The card's own `@container` behaviour inside a now-492.8px cell at five columns is therefore unverified from this side.





