### PR TITLE
feat(apps): store card — rollup to the meta block, CTA fills the row, two reserved title lines, shared geometry module

### DIFF
--- a/src/components/Apps/AppListingActionsMenu.tsx
+++ b/src/components/Apps/AppListingActionsMenu.tsx
@@ -159,20 +159,27 @@ type AppListingMenuGates = {
 };
 
 /**
- * The menu's gates — ONE definition, used by the component AND by
- * {@link useAppListingActionsMenuVisible}.
+ * The menu's gates, resolved once for the component that renders them.
  *
- * 🔴 WRITTEN ONCE ON PURPOSE. `showMenu` is a four-term disjunction over four
- * separately-defined predicates, and the card needs the ANSWER before it can lay
- * out its action row while the component needs the TERMS to render the items. A
- * second copy of the expression at either site is a predicate duplicated across
- * call sites, which is the shape that gets fixed at one site and stays wrong at
- * the other.
+ * 🔴 THIS USED TO HAVE A SECOND CALLER AND NO LONGER DOES. `useAppListingActionsMenuVisible`
+ * exported `showMenu` on its own so the store CARD could lay out around the trigger:
+ * the card's action row hid its recommend rollup below a container width derived
+ * from how wide the action cluster was, and the trigger's 36px was what made it
+ * wide. The rollup now lives in the card's meta block, the container query is gone,
+ * and the card's layout is identical whether or not a `⋮` renders — so nothing
+ * needs the answer in advance, and the hook was deleted rather than left exported
+ * with no consumer. `appListingMenuSurface.test.ts` fails if the card starts
+ * branching its layout on menu visibility again.
  *
- * 🔴 DELIBERATELY STATE-FREE, so it is safe to call TWICE in one render (the card
- * does). Every input is a pure read of the current user, the feature flags and the
- * mod state machine; nothing here owns a `useDisclosure` or a `useState`, so a
- * second call cannot fork a second copy of anything.
+ * 🔴 STILL WRITTEN ONCE, for the reason that survives: `showMenu` is a four-term
+ * disjunction over four separately-defined predicates, and a second copy of that
+ * expression anywhere is a predicate duplicated across call sites — the shape that
+ * gets fixed at one site and stays wrong at the other.
+ *
+ * 🔴 DELIBERATELY STATE-FREE. Every input is a pure read of the current user, the
+ * feature flags and the mod state machine; nothing here owns a `useDisclosure` or a
+ * `useState`. That is what made a second call safe when there was one, and it is
+ * what keeps this hook cheap to reuse if a surface ever needs it again.
  */
 function useAppListingMenuGates(
   listing: AppListingMenuTarget,
@@ -236,22 +243,6 @@ function useAppListingMenuGates(
     // menu, on every surface.
     showMenu: !preview && (showEdit || canReview || canReport || modActions.length > 0),
   };
-}
-
-/**
- * Would {@link AppListingActionsMenu} render anything for this viewer?
- *
- * 🔴 EXISTS SO A CALLER CAN LAY OUT AROUND THE TRIGGER WITHOUT GUESSING. The store
- * card's action row hides its recommend rollup below a container width derived from
- * how wide the action cluster is, and the trigger's 36px is exactly what makes it
- * wide — so the card has to know whether the trigger is there.
- */
-export function useAppListingActionsMenuVisible(
-  listing: AppListingMenuTarget,
-  surface: AppListingMenuSurface,
-  preview = false
-): boolean {
-  return useAppListingMenuGates(listing, surface, preview).showMenu;
 }
 
 /**

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -260,12 +260,29 @@ function base(over: Partial<ListingCard>): ListingCard {
  * so `width - 34` was exact arithmetic, not fractional. The 0.877px figure comes
  * from PROD, where the scale differs — do not use it to reason about these pins.
  *
- * The two widths used below, both measured through the real
- * `AppsPageLayout` + `Grid` rather than assumed:
- *   - `280` -> a 248px content box = the TRUE 1200px-viewport geometry
- *     (container 1200 -> column 296 -> card 280 -> row 248);
- *   - `314` -> a 282px content box, i.e. roughly a 1345 viewport. "280" in the
- *     original bug report is the CARD width at 1200, not its content box.
+ * The widths used below:
+ *   - `280` -> a 248px action row. This is the CARD the store renders at FOUR
+ *     COLUMNS on a 1168px grid;
+ *   - `314` -> a 282px action row, one step wider — kept for continuity with the
+ *     pre-change table rather than because a particular rung produces it;
+ *   - `494` -> a 462px action row, the wide end, chosen so the CTA has real slack
+ *     to grow into.
+ *
+ * 🔴 STATED AGAINST THE GRID RUNG, NOT A VIEWPORT — AND THAT IS A CORRECTION, NOT
+ * A STYLE PREFERENCE. This block used to derive 280 as "the TRUE 1200px-viewport
+ * geometry (container 1200 -> column 296 -> card 280 -> row 248)". Every step of
+ * that chain except the last is the STORE's business, not the card's, and both
+ * halves have since moved: the `column 296` step names Mantine `<Grid.Col>`
+ * arithmetic the store no longer uses, and a 1200 viewport does not even yield
+ * four columns once a scrollbar is reserved. The card NUMBERS were never wrong —
+ * 280/248 is still the real four-column card — but the sentence a maintainer reads
+ * to decide whether these fixtures still represent production had gone stale, and
+ * a stale justification is how correct fixtures get "fixed".
+ *
+ * The card's contract is "AT THESE WIDTHS, THIS GEOMETRY". That survives whichever
+ * grid implementation sits above it, so these widths are exercise points anchored
+ * to the grid, and deliberately not to a viewport or to any grid's column maths.
+ * ("280" in the original bug report is the CARD width, not its content box.)
  */
 function Sized({ width, card }: { width: number; card: ListingCard }) {
   return (
@@ -1346,13 +1363,19 @@ describe('AppListingCard', () => {
      *   |       282 | 282 − 36 − 10     |           282 |    46 |
      *   |       462 | 462 − 36 − 10     |           462 |    46 |
      *
-     * 248 / 282 / 462 are the same three container widths the pre-change code
-     * measured — 248 is the TRUE 1200px-viewport geometry (container 1200 → grid
-     * column 296 → card 280 → row 248), 282 is roughly a 1345 viewport, and 462 is
-     * the wide single-column `base` case. They are kept because the row height
-     * claim is the one that must hold everywhere, and re-deriving a fresh set of
-     * widths would drop the continuity with the numbers the file already reasons
-     * about.
+     * 248 / 282 / 462 are the same three action-row widths the pre-change code
+     * measured — 248 inside the 280px card the store renders at FOUR COLUMNS on a
+     * 1168px grid, 282 one step wider, and 462 the wide end where the CTA has real
+     * slack to grow into. They are kept because the row-height claim is the one
+     * that must hold everywhere, and re-deriving a fresh set of widths would drop
+     * the continuity with the numbers the file already reasons about.
+     *
+     * 🔴 ANCHORED TO THE GRID RUNG, NOT TO A VIEWPORT — see the `Sized` docblock
+     * for why. This paragraph used to derive 248 from "container 1200 → grid
+     * column 296 → card 280" and call 462 "the wide single-column `base` case";
+     * both described a store layout rather than a card, and both have since gone
+     * stale. No number here moved: what changed is that the justification no
+     * longer claims anything about how a viewport becomes a column.
      *
      * 🔴 THE CTA WIDTHS ARE WRITTEN AS ARITHMETIC, NOT AS THE THREE RESULTING
      * NUMBERS, because the arithmetic is the claim: the CTA takes the whole row
@@ -1379,10 +1402,17 @@ describe('AppListingCard', () => {
        * 🔴 THE CTA FILLS THE ROW — asserted at TWO named container widths, because
        * one measurement is not a general claim.
        *
-       * A narrow one (248, the store's tightest real geometry) and a wide one
-       * (462, the widest). Both are above the row's ~184px natural content, so
-       * both are cases where the CTA must GROW; a single width could not
-       * distinguish "it fills" from "it happens to fit".
+       * A narrow one (248 — the action row inside the four-column card) and a wide
+       * one (462). Both are above the row's ~184px natural content, so both are
+       * cases where the CTA must GROW; a single width could not distinguish "it
+       * fills" from "it happens to fit".
+       *
+       * 🔴 NO SUPERLATIVE. These used to read "the store's tightest real geometry"
+       * and "the widest". Neither is a claim this file can keep: which rung is
+       * narrowest, and which is widest, is decided by the store's grid — not this
+       * component's, and it has changed. What the pair still buys — two widths far
+       * enough apart that "it fills" is a general claim rather than one
+       * measurement — does not need either word.
        *
        * 🔴 THE EXPECTED VALUE IS BUILT FROM THE MEASURED TRIGGER AND THE MEASURED
        * GAP, not from `LISTING_ACTION_ROW_CONTROL_PX` / `_GAP_PX`. Deriving it

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -41,7 +41,11 @@ import '~/styles/globals.css';
 import '@mantine/core/styles.layer.css';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/component-setup';
-import { LISTING_ACTION_ROW_HEIGHT_PX } from '~/components/Apps/appListingCardGeometry';
+import { Button, Text } from '@mantine/core';
+import {
+  LISTING_ACTION_ROW_HEIGHT_PX,
+  LISTING_CARD_TITLE_LINE_HEIGHT,
+} from '~/components/Apps/appListingCardGeometry';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -565,6 +569,92 @@ describe('AppListingCard', () => {
     // asserted so the change is visible rather than discovered later.
     expect(title.tagName).not.toBe('H4');
     expect(cardRoot()!.querySelector('h1,h2,h3,h4,h5,h6')).toBeNull();
+  });
+
+  /**
+   * 🔴 THE NUMBERS THE COMMENTS QUOTE AS MEASUREMENTS — pinned, so they are
+   * measurements rather than folklore.
+   *
+   * Two figures do real argumentative work in this component's comments and in
+   * `appListingCardGeometry.ts`, and until now NOTHING asserted either of them:
+   *
+   *   - **Mantine `md` is 42px tall.** This is the whole reason the CTA grows
+   *     HORIZONTALLY instead of up the size scale — the row is a load-bearing 46px
+   *     and the next size up would not fit. It is quoted three times.
+   *   - **`--mantine-line-height-xl` is 1.65, i.e. 33px at the title's 20px.** This
+   *     is why `lh` on the title is called load-bearing: without it the reserved
+   *     two lines would be 66px rather than 48, an ~18px card-height swing.
+   *
+   * A number quoted as a measurement that nothing re-derives is exactly the shape
+   * that gets cited for years after it stops being true — a Mantine upgrade
+   * retuning either token would leave every comment and both design decisions
+   * silently wrong. Both are one `getComputedStyle` away in a tier that already
+   * renders the card, so there is no excuse for leaving them unpinned.
+   *
+   * 🔴 REPORT-ONLY TIER, stated: this is the browser project, so these do not gate
+   * a merge. They are still the only place either number is checked at all.
+   */
+  describe('🔴 the Mantine tokens the geometry comments quote', () => {
+    test('the next button size up (`md`) is 42px — taller than the 46px row can afford', async () => {
+      // Rendered rather than read off a CSS variable: the claim is about a
+      // BUTTON's height, and a token lookup would not see a padding or border
+      // change that also moves it.
+      renderWithProviders(
+        <div>
+          <Button size="sm" data-testid="probe-sm">
+            Probe
+          </Button>
+          <Button size="md" data-testid="probe-md">
+            Probe
+          </Button>
+        </div>
+      );
+      await expect.element(page.getByTestId('probe-sm')).toBeInTheDocument();
+      const sm = page.getByTestId('probe-sm').element() as HTMLElement;
+      const md = page.getByTestId('probe-md').element() as HTMLElement;
+      // `sm` is the CTA's size and the row's CONTROL term — 36, the same number
+      // `LISTING_ACTION_ROW_CONTROL_PX` spells and the `⋮` trigger renders at.
+      expect(
+        Math.round(sm.getBoundingClientRect().height),
+        'Mantine `sm` is the CTA size AND the control term of the 46px row height'
+      ).toBe(36);
+      // …and `md` is 42, which is why "just bump the size" is not available: 42 + a
+      // 10px `pt` is 52, and the row must stay 46 inside an `h-full` grid row.
+      expect(
+        Math.round(md.getBoundingClientRect().height),
+        'the comments justify growing the CTA horizontally by saying `md` is 42px tall — ' +
+          'if that is no longer true, re-argue the decision instead of re-quoting the number'
+      ).toBe(42);
+    });
+
+    test("an xl Text with no `lh` inherits 1.65 — 33px, not the title's 24px", async () => {
+      renderWithProviders(
+        <div>
+          <Text size="xl" data-testid="probe-default-lh">
+            Probe
+          </Text>
+          <Text size="xl" lh={LISTING_CARD_TITLE_LINE_HEIGHT} data-testid="probe-pinned-lh">
+            Probe
+          </Text>
+        </div>
+      );
+      await expect.element(page.getByTestId('probe-default-lh')).toBeInTheDocument();
+      const bare = page.getByTestId('probe-default-lh').element() as HTMLElement;
+      const pinned = page.getByTestId('probe-pinned-lh').element() as HTMLElement;
+      // 20px x 1.65 = 33px. This is the value the title would inherit if `lh` were
+      // ever dropped, and the reason the comment calls it load-bearing.
+      expect(
+        getComputedStyle(bare).lineHeight,
+        'the comments justify `lh` on the title by saying the inherited xl line-height is ' +
+          '1.65 (33px at 20px) — pin the new value and re-derive the reserved height if this moved'
+      ).toBe('33px');
+      // …against the 24px the pinned constant produces. The gap is what the
+      // reserved two lines are worth: 48px vs 66px.
+      expect(getComputedStyle(pinned).lineHeight).toBe('24px');
+      // Stated as the arithmetic the card actually depends on, so a reader does not
+      // have to do it: 2 reserved lines at each.
+      expect(2 * 33 - 2 * 24).toBe(18);
+    });
   });
 
   /**
@@ -1357,6 +1447,28 @@ describe('AppListingCard', () => {
             expect(Math.round(row.clientWidth)).toBe(282);
             // No trigger, no gap to leave — the CTA is the entire row.
             expect(cta.getBoundingClientRect().width).toBeCloseTo(282, 0);
+            // 🔴 THE CONTROL HALF OF THE ROW-HEIGHT DERIVATION, AND IT WAS MISSING.
+            // `LISTING_ACTION_ROW_HEIGHT_PX` is `pt` (10) + a 36px CONTROL, and the
+            // suite asserted the 36 for the `⋮` trigger and for NOTHING ELSE. The
+            // CTA's own 36 was only ever asserted as the CSS variable STRING
+            // `var(--button-height-sm)` — which survives a theme override of that
+            // token, a border or padding on the button, or swapping `Button` for
+            // another element entirely.
+            //
+            // 🔴 IT MATTERS MORE ON THIS ROW THAN IT LOOKS, because `mih` MASKS it:
+            // the row is floored at 46 whatever its child renders, so a CTA that
+            // shrinks leaves the row measuring 46 and every row-height assertion
+            // green. Measured on this arm with the CTA at `size="xs"`: with `mih`
+            // the suite reported 2 reds (both size-token tests only); without `mih`
+            // it reported 4, the extra two being these arms at `expected 40 to be
+            // 46`. The floor is correct and stays — this assertion is what puts the
+            // control back under observation despite it.
+            expect(
+              Math.round(cta.getBoundingClientRect().height),
+              'the CTA must render at the same 36px as the ⋮ trigger — that 36 is the ' +
+                'CONTROL term of LISTING_ACTION_ROW_HEIGHT_PX (pt 10 + control 36 = 46), ' +
+                "and the row's `mih` floor hides a shrunken control from every height assertion"
+            ).toBe(36);
             expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
           });
         }

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -41,12 +41,7 @@ import '~/styles/globals.css';
 import '@mantine/core/styles.layer.css';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/component-setup';
-import {
-  LISTING_ACTIONS_WIDEST_PX,
-  LISTING_ACTION_ROW_GAP_PX,
-  LISTING_ROLLUP_HIDE_BELOW_PX,
-  LISTING_ROLLUP_MIN_WIDTH_PX,
-} from '~/components/Apps/appListingCardView';
+import { LISTING_ACTION_ROW_HEIGHT_PX } from '~/components/Apps/appListingCardGeometry';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -289,14 +284,56 @@ function assertLayoutIsReal(row: HTMLElement) {
   ).toBe('flex');
 }
 
-/** The action row's three parts, located from the primary CTA. */
+/**
+ * The action row, located from the primary CTA.
+ *
+ * 🔴 THE CTA IS NOW A DIRECT CHILD OF THE ROW — one level shallower than it was.
+ * It used to sit inside a nested "action cluster" `Group` that existed only to
+ * hold it and the `⋮` together as ONE flex item opposite the recommend rollup;
+ * with the rollup relocated to the meta block, the row IS that cluster and the
+ * wrapper is gone. A helper that still climbed twice would silently return the
+ * card's `Stack` — which is also a flex container, so `assertLayoutIsReal` would
+ * pass on it and every geometry assertion below would be about the wrong box.
+ * Hence the shape check: only the action row carries `--group-wrap`.
+ */
+function assertIsActionRow(row: HTMLElement) {
+  // 🔴 `mt="auto"` IS THE DISCRIMINATOR, and `--group-wrap` alone was NOT ENOUGH.
+  // The retired action cluster was ALSO a `wrap="nowrap"` Group, so a wrap check
+  // passes on it — measured: against pre-change code this helper landed on the
+  // cluster and the container-248 width assertion went GREEN, because at that one
+  // width the cluster happened to fill the row. Only the ROW is bottom-pinned.
+  expect(row.style.marginTop, 'actionRow() did not land on the action row').toBe('auto');
+  expect(row.style.getPropertyValue('--group-wrap')).toBe('nowrap');
+}
+
 function actionRow(ctaName: string) {
   const cta = page.getByRole('link', { name: ctaName, exact: true }).element() as HTMLElement;
-  const actions = cta.parentElement as HTMLElement;
-  const row = actions.parentElement as HTMLElement;
-  const rollup = row.firstElementChild as HTMLElement;
-  return { cta, actions, row, rollup };
+  const row = cta.parentElement as HTMLElement;
+  assertIsActionRow(row);
+  return { cta, row };
 }
+
+/** The recommend rollup, wherever it is. Used for BOTH presence and absence. */
+const ROLLUP_SELECTOR = '[data-testid="apps-listing-recommend-rollup"]';
+
+/**
+ * The card's META BLOCK — the `Stack` holding title / creator / rollup / badges,
+ * reached from the title's own `Anchor`. Located structurally rather than by a
+ * test id so a change that MOVES the rollup out of it cannot be papered over by
+ * moving an id with it.
+ */
+function metaBlock(titleText: string): HTMLElement {
+  const title = page.getByText(titleText, { exact: true }).element() as HTMLElement;
+  const anchor = title.closest('a') as HTMLElement;
+  expect(anchor, `no <a> around the title "${titleText}"`).not.toBeNull();
+  return anchor.parentElement as HTMLElement;
+}
+
+/** A reviewed card — the rollup then says something other than "No reviews yet". */
+const REVIEWED_ROLLUP = {
+  recommend: { recommendedCount: 91, notRecommendedCount: 9, recommendPct: 0.91 },
+  reviewCount: 100,
+};
 
 /**
  * Two elements share one flex line.
@@ -528,6 +565,131 @@ describe('AppListingCard', () => {
     // asserted so the change is visible rather than discovered later.
     expect(title.tagName).not.toBe('H4');
     expect(cardRoot()!.querySelector('h1,h2,h3,h4,h5,h6')).toBeNull();
+  });
+
+  /**
+   * 🔴 THE TITLE RESERVES TWO LINES WHETHER OR NOT IT USES THEM — asserted as an
+   * ALIGNMENT claim between two cards, not as a style read on one.
+   *
+   * The defect this fixes is only visible in a ROW: a one-line title is 24px and a
+   * wrapped one is 48px, so the creator chip — and everything under it — lands at a
+   * different y on every card. A `min-height` on a single card is a fact about that
+   * card; "the chips line up" is the property a shopper actually sees, and it is a
+   * RELATIONSHIP, so it has to be measured across two cards in one flex row rather
+   * than inferred from a computed style.
+   *
+   * 🔴 THE FIXTURES ARE PAIRWISE DISTINCT AND OFF THE BOUNDARY, deliberately. A
+   * 1-line title against a 2-line one would sit exactly ON the reservation and the
+   * mutation "remove the min-height" would be unreachable — 2 lines is 2 lines
+   * either way. The long title is chosen to overflow to THREE lines at this column
+   * width, which is asserted below rather than assumed, so the clamp is doing real
+   * work and the short card is genuinely a line short of the reservation.
+   */
+  describe('🔴 the title reserves its two lines, so creator chips align', () => {
+    /** One line at the width used below. */
+    const SHORT_TITLE = 'Ink';
+    /** Long enough to wrap past the clamp — proven, not assumed, in the test. */
+    const LONG_TITLE =
+      'Procedurally Generated Landscape Compositor With Depth Aware Relighting And Batch Export';
+
+    /** The two cards' roots, in DOM order: [short-title card, long-title card]. */
+    function cardRoots(): HTMLElement[] {
+      return Array.from(document.querySelectorAll('[class*="Card-root"]')) as HTMLElement[];
+    }
+
+    test('a 1-line title and a 3-line title put their creator chips at the SAME y', async () => {
+      renderWithProviders(
+        <div style={{ display: 'flex', width: 640, alignItems: 'flex-start' }}>
+          <div style={{ width: 320 }}>
+            <AppListingCard card={base({ name: SHORT_TITLE, slug: 'short-title' })} canOpenPage />
+          </div>
+          <div style={{ width: 320 }}>
+            <AppListingCard card={base({ name: LONG_TITLE, slug: 'long-title' })} canOpenPage />
+          </div>
+        </div>
+      );
+      // Render barrier on BOTH cards — a `.getBoundingClientRect()` on a
+      // pre-commit DOM throws, and the throw poisons every later test in the file.
+      await expect.element(page.getByText(SHORT_TITLE, { exact: true })).toBeInTheDocument();
+      await expect.element(page.getByText(LONG_TITLE, { exact: true })).toBeInTheDocument();
+
+      const [shortCard, longCard] = cardRoots();
+      expect(shortCard, 'both cards rendered').toBeTruthy();
+      expect(longCard, 'both cards rendered').toBeTruthy();
+      // Stylesheet guard: without the real cascade every measurement below is a
+      // CSS initial value and passes for the wrong reason.
+      assertLayoutIsReal(shortCard.querySelector('[class*="Group-root"]') as HTMLElement);
+
+      const shortTitle = shortCard.querySelector('a[href^="/apps/store-preview/"] span')!;
+      const longTitle = longCard.querySelector('a[href^="/apps/store-preview/"] span')!;
+
+      // 🔴 THE FIXTURE CONTROL. The long title really does overflow its two-line
+      // clamp here (vertical overflow = `scrollHeight > clientHeight`), and the
+      // short one really does not fill it. Without this pair the alignment
+      // assertion could be green because BOTH titles happened to be one line.
+      expect(
+        longTitle.scrollHeight,
+        'the long fixture must overflow the 2-line clamp at this column width'
+      ).toBeGreaterThan(longTitle.clientHeight);
+      expect(shortTitle.scrollHeight).toBeLessThanOrEqual(shortTitle.clientHeight);
+
+      // Both title boxes are the SAME height — the reservation doing its work.
+      expect(shortTitle.getBoundingClientRect().height).toBeCloseTo(
+        longTitle.getBoundingClientRect().height,
+        0
+      );
+      // 2 lines x 1.2 line-height x 20px (`size="xl"`) = 48px.
+      expect(Math.round(shortTitle.getBoundingClientRect().height)).toBe(48);
+
+      // 🔴 THE CLAIM THIS TEST IS FOR. `top`, not centre: a difference here is
+      // exactly the visible defect, and the two chips are the same height so a
+      // centre comparison would say nothing extra.
+      const shortChip = shortCard.querySelector('a[href^="/user/"]') as HTMLElement;
+      const longChip = longCard.querySelector('a[href^="/user/"]') as HTMLElement;
+      expect(shortChip).not.toBeNull();
+      expect(longChip).not.toBeNull();
+      expect(
+        shortChip.getBoundingClientRect().top,
+        'the creator chip must land at the same y whatever the title length'
+      ).toBeCloseTo(longChip.getBoundingClientRect().top, 0);
+    });
+
+    /**
+     * The clamp survived the switch from the `line-clamp-2` utility class to
+     * `TruncatedText`'s multi-line mode — a swap that is easy to get wrong,
+     * because that component's DEFAULT mode writes an INLINE `white-space: nowrap`
+     * which silently beats the utility class and yields ONE ellipsised line.
+     */
+    test('🔴 a long title still clamps at two lines rather than one', async () => {
+      renderWithProviders(
+        <Sized width={320} card={base({ name: LONG_TITLE, slug: 'long-title' })} />
+      );
+      await expect.element(page.getByText(LONG_TITLE, { exact: true })).toBeInTheDocument();
+      const title = page.getByText(LONG_TITLE, { exact: true }).element() as HTMLElement;
+      const style = getComputedStyle(title);
+      expect(style.webkitLineClamp).toBe('2');
+      expect(style.whiteSpace).not.toBe('nowrap');
+      // …and it renders as two lines, not one: 2 x 24px.
+      expect(Math.round(title.getBoundingClientRect().height)).toBe(48);
+    });
+
+    /**
+     * The other half `TruncatedText` buys: a clamped name is unreadable, so it is
+     * revealed on hover — and ONLY when it actually clips (a runtime measurement,
+     * not a guess).
+     */
+    test('a clamped title reveals its full value in a tooltip on hover', async () => {
+      renderWithProviders(
+        <Sized width={320} card={base({ name: LONG_TITLE, slug: 'long-title' })} />
+      );
+      const label = page.getByText(LONG_TITLE, { exact: true });
+      await expect.element(label).toBeInTheDocument();
+      await label.hover();
+      // The portalled tooltip is a SECOND node carrying the same text.
+      await vi.waitFor(() => {
+        expect(page.getByText(LONG_TITLE, { exact: true }).elements().length).toBeGreaterThan(1);
+      });
+    });
   });
 
   test('🔴 S5: the author line is sm/500 and STAYS dimmed (accepted contrast residual)', async () => {
@@ -917,34 +1079,47 @@ describe('AppListingCard', () => {
     expect(visit.getAttribute('rel')).toBe('noopener noreferrer');
   });
 
-  test('the action row does NOT wrap — actions stay right-aligned and never shrink', async () => {
+  test('🔴 the action row is exactly [CTA, ⋮] and does NOT wrap', async () => {
     // 🔴 Regression guard for the obvious-but-wrong fix to the taller `sm` buttons.
-    // Letting this row wrap would (a) left-align the actions, because a wrapped
-    // line with one item sits at flex-start under `justify="space-between"`, and
-    // (b) make an OWNER card (Edit + CTA) wrap at a wider column than a non-owner
-    // card, growing the height of the whole `h-full` grid row for everyone.
-    mocks.currentUser = OWNER; // → the `⋮` menu, i.e. the widest action set
+    // Letting this row wrap would put the `⋮` on its own line, so an OWNER card
+    // would be TALLER than a menu-less one — and inside an `h-full` grid row that
+    // grows every card in the row across the whole store.
+    //
+    // 🔴 THE CHILD LEDGER IS THE POINT, not an incidental structural check. The
+    // row's geometry claim ("the CTA is the row minus the trigger and the gap")
+    // is only true while these are its ONLY two children — a third one, of any
+    // kind, silently invalidates every width assertion in this file. Asserting the
+    // SET rather than a containment means the ledger fails when it grows as well
+    // as when it shrinks.
+    mocks.currentUser = OWNER; // → the `⋮`, i.e. the widest action set
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
     await expect.element(page.getByTestId('apps-listing-card-actions-menu')).toBeInTheDocument();
 
     const trigger = page.getByTestId('apps-listing-card-actions-menu').element() as HTMLElement;
-    // The group holding the primary CTA + the `⋮` trigger. The trigger sits inside a
-    // `flexShrink: 0` Box the shared menu renders, so climb one more level.
-    const actions = trigger.parentElement!.parentElement as HTMLElement;
-    expect(actions.style.getPropertyValue('--group-wrap')).toBe('nowrap');
-    // The actions are the rigid side: they never shrink…
-    expect(actions.style.flexShrink).toBe('0');
-    // …but they DO grow, which is what lets the CTA fill the row (S7).
-    expect(actions.style.flexGrow).toBe('1');
-    // …and the row itself never wraps, so the actions can't jump to the left.
-    const row = actions.parentElement as HTMLElement;
-    expect(row.style.getPropertyValue('--group-wrap')).toBe('nowrap');
-    // 🔴 The recommend rollup is the flexible side — DOWN TO A FLOOR. It used to
-    // carry `minWidth: 0` ("shrink to nothing"); that is exactly what a growing CTA
-    // would exploit, so the floor is now a constraint the layout engine enforces.
-    const rollup = row.firstElementChild as HTMLElement;
-    expect(rollup).not.toBe(actions);
-    expect(rollup.style.minWidth).toBe(`${LISTING_ROLLUP_MIN_WIDTH_PX}px`);
+    // The trigger sits inside a `flexShrink: 0` Box the shared menu renders, so the
+    // ROW is ONE level up from that Box — not two, as it was while a nested action
+    // cluster stood between them.
+    const triggerBox = trigger.parentElement as HTMLElement;
+    const row = triggerBox.parentElement as HTMLElement;
+    const cta = page.getByRole('link', { name: 'Open', exact: true }).element() as HTMLElement;
+
+    assertIsActionRow(row);
+    expect(Array.from(row.children)).toEqual([cta, triggerBox]);
+    // The CTA is the side that grows; the trigger's box never does either way.
+    expect(cta.style.flexGrow).toBe('1');
+    expect(triggerBox.style.flexShrink).toBe('0');
+    // 🔴 AND `justify="space-between"` IS GONE. It was there to push the actions
+    // away from the rollup; with one growing child it distributes nothing, and
+    // leaving it would be a declaration a later reader has to prove inert.
+    // Mantine always writes `--group-justify` (defaulting to `flex-start`), so the
+    // assertion is on the VALUE, not on the property's absence — asserting `''`
+    // fails against correct code, which it did on this test's first run.
+    expect(row.style.getPropertyValue('--group-justify')).toBe('flex-start');
+    // 🔴 …as is the `marginLeft: 'auto'` that was its second mechanism. Same
+    // reason: flexible lengths resolve BEFORE auto margins, so with the CTA
+    // filling the row there is never any free space for one to absorb.
+    expect(cta.style.marginLeft).toBe('');
+    expect(triggerBox.style.marginLeft).toBe('');
   });
 
   test('🔴 the `⋮` trigger is 36px — the row-height contract', async () => {
@@ -1015,118 +1190,79 @@ describe('AppListingCard', () => {
     });
 
     test('🔴 the action row still holds at NOWRAP with the wider buttons', async () => {
-      // The row is `wrap="nowrap"` with `flexShrink: 0` on the actions for two
-      // documented reasons (a wrapped single-item line left-aligns under
-      // space-between; an OWNER card wrapping at a different width would grow the
-      // height of a whole `h-full` grid row). Icons make the buttons ~22px wider,
-      // so this pins that the row did not quietly gain wrapping to cope.
+      // The row is `wrap="nowrap"` for a documented reason: a wrapped line would
+      // put the `⋮` under the CTA, so a card WITH a menu would be taller than one
+      // without and would grow the height of a whole `h-full` grid row. Icons make
+      // the button ~22px wider, so this pins that the row did not quietly gain
+      // wrapping to cope.
       //
       // Rendered in a NARROW column — the tight case is md/lg (3–4 columns), not
-      // the wide single-column base — and with the OWNER "Edit" button present,
-      // which is the widest configuration the row ever has.
+      // the wide single-column base — and with the OWNER `⋮` present, which is the
+      // widest configuration the row ever has.
       mocks.currentUser = { id: 5, username: 'alice' };
       renderWithProviders(<Sized width={340} card={base({})} />);
       await expect
         .element(page.getByRole('link', { name: 'Open', exact: true }))
         .toBeInTheDocument();
 
-      const { row, actions, rollup } = actionRow('Open');
+      const { row, cta } = actionRow('Open');
       assertLayoutIsReal(row);
+      const trigger = page.getByTestId('apps-listing-card-actions-menu').element() as HTMLElement;
 
       // Now that layout is real, this is a genuine assertion: with the stylesheet
       // loaded `Group` resolves `flex-wrap` from `--group-wrap`, so flipping the
       // component to `wrap="wrap"` makes this read `wrap`.
       expect(getComputedStyle(row).flexWrap).toBe('nowrap');
-      expect(getComputedStyle(actions).flexWrap).toBe('nowrap');
-      expect(getComputedStyle(actions).flexShrink).toBe('0');
 
-      // …and BEHAVIOURALLY: everything is on one line and nothing overflows the
-      // row box. This is the half a `--group-wrap` assertion cannot prove.
-      expect(sameLine(rollup, actions)).toBe(true);
+      // …and BEHAVIOURALLY: both controls are on one line and nothing overflows
+      // the row box. This is the half a `--group-wrap` assertion cannot prove.
+      expect(sameLine(cta, trigger)).toBe(true);
       expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
-      // The actions are at their natural width — not squeezed to fake a fit.
-      expect(actions.getBoundingClientRect().width).toBeCloseTo(actions.scrollWidth, 0);
     });
 
     /**
-     * 🔴 THE ACTION-ROW GEOMETRY, RE-MEASURED ON THIS BRANCH.
+     * 🔴 THE ACTION ROW AFTER THE ROLLUP MOVED OUT.
      *
-     * A 280px card is what a **1200px viewport** produces at the store's 4-column
-     * `xl` grid — the narrowest geometry the store can actually produce, and a
-     * very common laptop width.
+     * The row used to hold two competing children — the recommend rollup and an
+     * action cluster — under `justify="space-between"`, and most of this file's
+     * geometry was about arbitrating between them: a `min-width` floor on the
+     * rollup, a `@[264px]` container query hiding it below the width where even
+     * the floor did not fit, a measured 184px "widest action cluster", and a
+     * derived 264 threshold. Every one of those tests is DELETED rather than
+     * relaxed — their subject no longer exists, and a green test asserting a
+     * relationship that is gone reads as coverage while providing none.
      *
-     * Every number below was taken from a real render in this environment, with
-     * the app's real stylesheet cascade, at the widths named. It is NOT the
-     * pre-change table carried forward. Card with a `⋮` menu, widest CTA ("View
-     * details"), no reviews — the SHORTEST label the rollup can carry, so a
-     * deficit here is structural rather than an artefact of a long string:
+     * What replaces them is the smaller set of claims the row can still make:
      *
-     * 🔴 WHICH VIEWERS EACH TABLE DESCRIBES — the numbers did not move when the card
-     * stopped offering Review/Report, but the POPULATIONS did, and a table whose
-     * caption is wrong is the kind of prose that gets cited instead of re-measured.
-     * "With a menu" is now exactly {owner, moderator}; "with no menu" is EVERY other
-     * viewer, signed in or signed out. Before `surface="card"` the split was
-     * {owner, moderator, any signed-in viewer} against {signed-out} alone.
+     *   | container | CTA (menu)        | CTA (no menu) | row h |
+     *   |-----------|-------------------|---------------|-------|
+     *   |       248 | 248 − 36 − 10     |           248 |    46 |
+     *   |       282 | 282 − 36 − 10     |           282 |    46 |
+     *   |       462 | 462 − 36 − 10     |           462 |    46 |
      *
-     *   | card | container | actions nat/rendered | rollup | row h | rollup    |
-     *   |------|-----------|----------------------|--------|-------|-----------|
-     *   |  280 |       248 | 184 /  248 (grown)   |    0   |    46 | HIDDEN    |
-     *   |  296 |       264 | 184 /  184           |   70.1 |    46 | at FLOOR  |
-     *   |  314 |       282 | 184 /  184           |   88.1 |    46 | clamped   |
-     *   |  494 |       462 | 184 /  356.3 (grown) |   95.7 |    46 | natural   |
+     * 248 / 282 / 462 are the same three container widths the pre-change code
+     * measured — 248 is the TRUE 1200px-viewport geometry (container 1200 → grid
+     * column 296 → card 280 → row 248), 282 is roughly a 1345 viewport, and 462 is
+     * the wide single-column `base` case. They are kept because the row height
+     * claim is the one that must hold everywhere, and re-deriving a fresh set of
+     * widths would drop the continuity with the numbers the file already reasons
+     * about.
      *
-     * and the same widths with NO menu — a signed-OUT viewer OR an ordinary
-     * signed-IN one, which is what the byte-unchanged claim below rests on and why
-     * that claim is now asserted over both:
-     *
-     *   | card | container | actions nat/rendered | rollup (reviewed) | row h |
-     *   |------|-----------|----------------------|-------------------|-------|
-     *   |  280 |       248 | 137.9 / 137.9        |             100.1 |    46 |
-     *   |  314 |       282 | 137.9 / 137.9        |             134.1 |    46 |
-     *   |  494 |       462 | 137.9 / 312.9        |             139.1 |    46 |
-     *
-     * TWO THINGS THE TABLES SAY THAT PROSE WOULD NOT:
-     *
-     *   1. `actions` is now TWO numbers. The CTA grows into the row's free space
-     *      (S7), so the cluster's rendered width exceeds its natural width wherever
-     *      there is slack. Where the row is in DEFICIT there is no growth and the
-     *      two coincide — which is why the two middle rows of the first table, and
-     *      the first two rows of the second, are unchanged from before this branch.
-     *   2. The 264 row is the threshold doing its job: 70.1px is exactly
-     *      `LISTING_ROLLUP_MIN_WIDTH_PX`, and 264 = 184 + 10 + 70 is exactly the
-     *      arithmetic `LISTING_ROLLUP_HIDE_BELOW_PX` computes. The model and the
-     *      measurement agree to 0.1px, which is why the threshold is stated as
-     *      arithmetic rather than as a round number that happened to look right.
-     *
-     * 🔴 THE FIX IS STILL NOT TO LET THE ROW WRAP. Row height is a constant 46px in
-     * every cell above — nowrap + `flexShrink: 0` is what holds it, and the file
-     * documents why wrapping breaks alignment and grid-row heights.
+     * 🔴 THE CTA WIDTHS ARE WRITTEN AS ARITHMETIC, NOT AS THE THREE RESULTING
+     * NUMBERS, because the arithmetic is the claim: the CTA takes the whole row
+     * minus the trigger and the gap. Three literals would pass just as well
+     * against a CTA that happened to land there for some other reason.
      */
     describe("the action row at the store's real container widths", () => {
-      /**
-       * 🔴 A REVIEWED card, deliberately. The shared `base()` fixture has no
-       * reviews, so its rollup reads "No reviews yet" — only ~96px natural, which
-       * FITS at 280 even for an owner and hides the whole regression. (It did:
-       * the first run of the non-owner test below asserted a threshold taken from
-       * the reviewed measurements and failed at 95.7 against the unreviewed
-       * fixture.) "91% recommend (100)" is 139px natural, which is the content
-       * that actually gets destroyed, and is what the measured table above used.
-       */
-      const REVIEWED = {
+      // The widest CTA ("View details") — an off-site listing with no external
+      // target makes `getListingCta` fall through to the unified detail. Fully
+      // typed rather than cast: a cast here previously HID a missing `externalUrl`
+      // and a sub-kind that was not a member of its union at all, and neither
+      // `tsc` error reached vitest, which type-strips.
+      const WIDEST_CTA = {
+        kind: 'offsite' as const,
         recommend: { recommendedCount: 91, notRecommendedCount: 9, recommendPct: 0.91 },
         reviewCount: 100,
-      };
-      // The widest CTA ("View details") — the tight cell in the table above. An
-      // off-site listing with no external target makes `getListingCta` fall
-      // through to the unified detail. Fully typed (`externalUrl` included)
-      // rather than cast: the cast was HIDING a missing `externalUrl` and a
-      // `subKind: 'oauth-connect'` that was not a member of the sub-kind union
-      // at all, and neither `tsc` error reached vitest, which type-strips.
-      // (The sub-kind itself is now gone — `externalUrl` is the only off-site
-      // card input, so that particular typo has no shape left to take.)
-      const OFFSITE_CONNECT = {
-        ...REVIEWED,
-        kind: 'offsite' as const,
         kindData: {
           kind: 'offsite',
           externalUrl: null,
@@ -1134,487 +1270,220 @@ describe('AppListingCard', () => {
       };
 
       /**
-       * 🔴 THE SAME WIDEST-CTA CARD BUT WITH **NO REVIEWS** — deliberately a second
-       * fixture rather than a tweak of the one above, because `OFFSITE_CONNECT`
-       * spreads `REVIEWED` and that is easy to miss: a test that reads as "the
-       * no-reviews case" while passing `OFFSITE_CONNECT` is silently measuring
-       * "91% recommend (100)" (122px of text) instead of "No reviews yet" (79px).
-       * That mistake was made and caught here by a red baseline, not by review.
+       * 🔴 THE CTA FILLS THE ROW — asserted at TWO named container widths, because
+       * one measurement is not a general claim.
        *
-       * "No reviews yet" is the SHORT label — the least the rollup can ever say —
-       * which is exactly why it is the right fixture for the truncation floor: if
-       * even this does not fit, the deficit is structural.
+       * A narrow one (248, the store's tightest real geometry) and a wide one
+       * (462, the widest). Both are above the row's ~184px natural content, so
+       * both are cases where the CTA must GROW; a single width could not
+       * distinguish "it fills" from "it happens to fit".
+       *
+       * 🔴 THE EXPECTED VALUE IS BUILT FROM THE MEASURED TRIGGER AND THE MEASURED
+       * GAP, not from `LISTING_ACTION_ROW_CONTROL_PX` / `_GAP_PX`. Deriving it
+       * from the constants the component reads would move the expectation with any
+       * mutation of them, and the test could never fail. The constants are checked
+       * against those measurements separately, below.
        */
-      const OFFSITE_CONNECT_NO_REVIEWS = {
-        kind: 'offsite' as const,
-        recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
-        reviewCount: 0,
-        kindData: {
-          kind: 'offsite',
-          externalUrl: null,
-        } satisfies ListingCard['kindData'],
-      };
-
-      test('🔴 menu card + "View details" keeps a LEGIBLE recommend rollup', async () => {
-        mocks.currentUser = OWNER;
-        renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-
-        const { row, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(282); // 314 - 2x16 padding (no border since S4)
-
-        // 80px is grounded in the measurements above, not invented: the glyph is
-        // 13px + a 4px gap, so 80 leaves ~63px of text — enough for "91% recom…"
-        // to read as a recommendation figure. Measured here: 88.1.
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
-        // …and never below the floor while it is displayed — the property the
-        // growing CTA could otherwise take away.
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(
-          LISTING_ROLLUP_MIN_WIDTH_PX
-        );
-
-        // The thumb glyph specifically must survive — it is the affordance that
-        // says "this number is a rating" at a glance.
-        const glyph = rollup.querySelector('svg') as SVGElement;
-        expect(glyph).toBeTruthy();
-        expect(glyph.getBoundingClientRect().width).toBeGreaterThan(0);
-        expect(glyph.getBoundingClientRect().right).toBeLessThanOrEqual(
-          rollup.getBoundingClientRect().right + 1
-        );
-
-        // …and the row still holds its shape: one line, no overflow.
-        expect(sameLine(rollup, actionRow('View details').actions)).toBe(true);
-        expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
-      });
-
-      /**
-       * 🔴 THE TRUE 1200px GEOMETRY, which is TIGHTER than the case above.
-       *
-       * Measured through the real `AppsPageLayout` + `Grid` at a 1200 viewport:
-       * container 1200 -> grid column 296 -> CARD 280 -> action-row content box
-       * **248**. So "280px" in the original report is the card's OUTER width; the
-       * box the action row actually gets is 248, and a 314px wrapper (content box
-       * 282) corresponds to roughly a 1345 viewport.
-       *
-       * Below the 264px threshold the rollup is HIDDEN rather than crushed, and the
-       * actions keep the right edge. A stub is strictly worse than nothing: it holds
-       * the slot, reads as a rendering bug, and communicates nothing.
-       *
-       * Re-measured on THIS branch (menu card, widest CTA, no reviews):
-       *   container 248 -> rollup 0    (hidden by the query)
-       *   container 264 -> rollup 70.1 (AT the floor)
-       *   container 266 -> rollup 72.1
-       *   container 282 -> rollup 88.1
-       *   container 462 -> rollup 95.7 (natural; the CTA takes the other 260)
-       */
-      test('🔴 at the REAL 1200 geometry a menu card DROPS the rollup instead of crushing it', async () => {
-        mocks.currentUser = OWNER;
-        // 🔴 NO reviews — the label the live report caught, and the SHORT one (79px
-        // of text vs 122px for "91% recommend (100)"). Using the short label is
-        // what makes this structural rather than an artefact of a long string:
-        // even the least the rollup can ever say does not fit here.
-        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        await expect.element(page.getByText('No reviews yet')).toBeInTheDocument();
-        const { row, actions, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(248); // 280 - 2x16 padding (no border since S4)
-
-        // 🔴 THE GUARD. Pre-change this element measured 54.1px and computed
-        // `display: flex`. Asserted FIRST, so a mutation that re-shrinks the rollup
-        // fails HERE on this guard's own assertion rather than being killed by the
-        // alignment check below (which passes either way while the rollup exists).
-        expect(getComputedStyle(rollup).display).toBe('none');
-        expect(rollup.getBoundingClientRect().width).toBe(0);
-
-        // 🔴 A SEPARATE failure mode, deliberately in the same test because only
-        // this geometry exposes it: with the rollup out of layout the row holds ONE
-        // flex item, and `justify="space-between"` puts a lone item at flex-START.
-        // The actions group carries `marginLeft: 'auto'` for exactly that; delete
-        // the margin and the assertions above stay green while the whole CTA
-        // cluster jumps to the card's left edge.
-        expect(actions.getBoundingClientRect().right).toBeCloseTo(
-          row.getBoundingClientRect().right,
-          0
-        );
-        expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
-      });
-
-      /**
-       * ⚠️ INVARIANT GUARD, NOT regression coverage — it passes on pre-change code
-       * too (the rollup measured 88.1px here before and after). It earns its place
-       * by BOUNDING the hide above: the fix must remove the rollup only where it is
-       * debris, and this is the first real store geometry above the threshold.
-       * Without it, widening the threshold to "hide it on any narrow owner card"
-       * would pass unnoticed.
-       */
-      test('⚠️ INVARIANT: just ABOVE the 264px threshold the rollup is back and legible', async () => {
-        mocks.currentUser = OWNER;
-        renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        const { row, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(282); // 282 >= the 264 threshold
-        expect(getComputedStyle(rollup).display).toBe('flex');
-        // 80px is the literal floor from the pre-existing measured table.
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
-        const glyph = rollup.querySelector('svg') as SVGElement;
-        expect(glyph.getBoundingClientRect().width).toBeGreaterThan(0);
-        expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
-      });
-
-      /**
-       * 🔴 THE THRESHOLD IS EXACTLY WHERE THE FLOOR FIRST FITS — the assertion the
-       * arithmetic makes, checked at the arithmetic's own boundary rather than
-       * somewhere comfortably inside the band.
-       *
-       * `LISTING_ROLLUP_HIDE_BELOW_PX` = actions(184) + gap(10) + floor(70) = 264. At
-       * a 264px container the rollup must therefore be present and measure EXACTLY
-       * the floor: one pixel of slack anywhere in that sum and it would be more, one
-       * pixel of deficit and the query would have hidden it. Measured: 70.1.
-       *
-       * This is the case an off-by-a-few threshold survives everywhere else — 282 is
-       * 18px inside the band and 248 is 16px outside it, so both stay green against a
-       * threshold of, say, 250 or 276.
-       *
-       * ⚠️ INVARIANT GUARD, NOT regression coverage for THIS change: measured, it
-       * passes on pre-change code too, because at a 264px container the available
-       * space happens to equal the floor whether or not a floor is enforced. It is
-       * regression coverage for the THRESHOLD — move 264 and it goes red — and the
-       * clamp itself is pinned by the menu-less test above, which is the only width
-       * at which the two differ.
-       */
-      test('🔴 AT the threshold the rollup is present and sits exactly on its floor', async () => {
-        mocks.currentUser = OWNER;
-        // 296 outer - 2x16 padding = a 264px container, i.e. the threshold itself.
-        renderWithProviders(<Sized width={296} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        const { row, rollup, actions } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(LISTING_ROLLUP_HIDE_BELOW_PX);
-        expect(getComputedStyle(rollup).display).toBe('flex');
-        // Exactly the floor, to sub-pixel: 70.1 measured against a 70 constant.
-        expect(rollup.getBoundingClientRect().width).toBeCloseTo(LISTING_ROLLUP_MIN_WIDTH_PX, 0);
-        // …and the other two terms of the sum are what the constants say they are, so
-        // a green result here cannot be three compensating errors.
-        expect(actions.getBoundingClientRect().width).toBeCloseTo(LISTING_ACTIONS_WIDEST_PX, 0);
-        expect(getComputedStyle(row).columnGap).toBe(`${LISTING_ACTION_ROW_GAP_PX}px`);
-        expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
-      });
-
-      /**
-       * 🔴 THE ROLLUP IS NEVER SQUEEZED BELOW ITS FLOOR WHILE DISPLAYED — swept, not
-       * spot-checked, because the failure this guards is width-dependent by nature.
-       *
-       * 248 is included deliberately: there the rollup is HIDDEN, and a floor claim
-       * must not be satisfied by a zero. The sweep therefore asserts the disjunction
-       * (hidden, or >= floor) and separately asserts that at least one width in the
-       * sweep is on each side of it — a positive control against a sweep that
-       * silently tests only one arm.
-       */
-      /**
-       * 🔴 THE ONE PLACE THE FLOOR IS OBSERVABLE — and finding it is the difference
-       * between a guard and a decoration.
-       *
-       * MEASURED, and it is the uncomfortable result: at every container width the
-       * store can produce, `minWidth: 70` changes NOTHING. The rollup only shrinks
-       * under deficit, and a deficit deep enough to push it under 70 arrives at
-       * exactly the width where the container query hides it — so on a card WITH a
-       * menu the clamp and the query bite at the same point by construction. Every
-       * other floor assertion in this file therefore passes on pre-change code too;
-       * they are INVARIANT guards, and they say so.
-       *
-       * The clamp is observable on a card with NO menu, which carries no container
-       * query at all (see the action row's `hasMenu` gate). Its cluster is 137.9, so
-       * it needs 137.9 + 10 + 70 = 218px of container to hold both. Below that:
-       *   pre-change  → the rollup shrinks freely; at a 168px container it measures
-       *                 168 − 10 − 137.9 ≈ 20, a stub of two or three characters;
-       *   post-change → it stops at 70 and the ROW overflows instead (scrollWidth
-       *                 218 vs clientWidth 168).
-       *
-       * 🔴 THE OVERFLOW IS THE ACCEPTED COST, ASSERTED RATHER THAN HIDDEN. Trading a
-       * meaningless 20px stub for an overflow is only defensible because no store
-       * surface goes below 218: the 4-column `lg` grid bottoms out at 248, `base` is
-       * one wide column, and the moderator preview card is capped at 340 (308
-       * content). The width used here is a synthetic one no user reaches, chosen
-       * because it is the only width at which the constraint is visible at all.
-       */
-      test('🔴 the floor CLAMPS a menu-less rollup that would otherwise be a stub', async () => {
-        mocks.currentUser = null; // no menu → no container query → the clamp is the only guard
-        renderWithProviders(<Sized width={200} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'View details', exact: true }))
-          .toBeInTheDocument();
-        const { row, rollup } = actionRow('View details');
-        assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(168);
-        // No menu here — otherwise the query, not the clamp, would be what we measured.
-        expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
-        expect(getComputedStyle(rollup).display).toBe('flex');
-        // 🔴 THE DISCRIMINATOR. Pre-change this measures ~20; the clamp holds it at 70.
-        expect(rollup.getBoundingClientRect().width).toBeCloseTo(LISTING_ROLLUP_MIN_WIDTH_PX, 0);
-        // …and the declared consequence, so nobody discovers it from a screenshot.
-        expect(row.scrollWidth).toBeGreaterThan(row.clientWidth);
-        expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
-      });
-
-      /**
-       * 🔴 THE FLOOR SWEEP — one test PER WIDTH, deliberately, not a loop with
-       * `unmount()` between renders. This file already learned that the hard way:
-       * `.unmount()` fights the scaffold's global `afterEach(cleanup)` over the
-       * shared container and leaves EVERY subsequent test in the file rendering into
-       * an empty body. Separate tests also let each width fail independently instead
-       * of the first short-circuiting the rest.
-       *
-       * ⚠️ INVARIANT GUARD on the floor half — see the menu-less test above for why
-       * a card WITH a menu cannot distinguish "clamped at 70" from "70 is all there
-       * was". What it does pin as regression coverage is the hidden/displayed
-       * BOUNDARY and the 46px row height at every width.
-       */
-      describe('🔴 displayed ⇒ at or above the floor, swept across store widths', () => {
-        // 280 is the one width where the rollup is HIDDEN. It is in the sweep on
-        // purpose: a floor claim must not be satisfiable by a zero, so that arm
-        // asserts the zero explicitly and the others assert the floor.
-        const HIDDEN_AT = 280;
-        for (const width of [280, 296, 298, 314, 494]) {
-          test(`@${width} (container ${width - 32})`, async () => {
-            mocks.currentUser = OWNER;
-            renderWithProviders(<Sized width={width} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
-            await expect
-              .element(page.getByRole('link', { name: 'View details', exact: true }))
-              .toBeInTheDocument();
-            const { row, rollup } = actionRow('View details');
-            assertLayoutIsReal(row);
-            expect(Math.round(row.clientWidth)).toBe(width - 32);
-            if (width === HIDDEN_AT) {
-              expect(getComputedStyle(rollup).display).toBe('none');
-              expect(rollup.getBoundingClientRect().width).toBe(0);
-            } else {
-              expect(getComputedStyle(rollup).display).toBe('flex');
-              expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(
-                LISTING_ROLLUP_MIN_WIDTH_PX - 0.5
-              );
-            }
-            // Row height is the other invariant every width has to hold.
-            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
-          });
-        }
-      });
-
-      /**
-       * 🔴 THE MENU-LESS VIEWERS, MEASURED FROM ONE ASSERTION BODY — AND THAT SHAPE
-       * IS THE FIX, NOT A TIDY-UP.
-       *
-       * This used to be two tests making two different claims: a SIGNED-OUT arm
-       * asserting the full rollup survives at the store's tightest real geometry, and
-       * a SIGNED-IN arm asserting the opposite, because `useCanReportListing` is
-       * `!!useCurrentUser()` and every signed-in shopper therefore got a `⋮`. With
-       * `surface="card"` the viewer actions are gone from this surface, so the two
-       * viewers are now the SAME case — and "the same" is a claim about a
-       * RELATIONSHIP, which two independently-written tests cannot make. Two literal
-       * tables drift; one body run twice cannot.
-       *
-       * 🔴 THE POPULATION THIS COVERS IS EVERY VIEWER EXCEPT {owner, moderator}. That
-       * is the whole point of running it over both: a narrowing implemented as "hide
-       * the menu when signed out" rather than "do not offer these items on the card"
-       * passes the signed-out arm and fails the signed-in one.
-       *
-       * ⚠️ STILL AN INVARIANT GUARD ON THE SIGNED-OUT ARM — that card measured 95.7px
-       * before this whole branch and measures 95.7px after. The SIGNED-IN arm is
-       * genuine regression coverage: it is red on `5a6d111a19`.
-       */
-      describe('🔴 a menu-less viewer keeps the full rollup at the 1200 geometry', () => {
-        // One test per viewer rather than a loop with `unmount()` — same reason as
-        // the floor sweep above.
-        for (const [label, user] of [
-          ['signed-out', null],
-          ['signed-in non-owner, non-moderator', SHOPPER],
+      describe('🔴 the CTA fills the row minus the trigger and the gap', () => {
+        // One test per width rather than a loop with `unmount()` — that fights the
+        // scaffold's global `afterEach(cleanup)` over the shared container and
+        // leaves every LATER test in the file rendering into an empty body.
+        for (const [outer, container] of [
+          [280, 248],
+          [494, 462],
         ] as const) {
-          test(`${label}`, async () => {
-            mocks.currentUser = user;
-            renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+          test(`container ${container}`, async () => {
+            mocks.currentUser = OWNER; // → a `⋮`, i.e. the row's two-child case
+            renderWithProviders(<Sized width={outer} card={base(WIDEST_CTA)} />);
             await expect
               .element(page.getByRole('link', { name: 'View details', exact: true }))
               .toBeInTheDocument();
-            const { row, actions, rollup } = actionRow('View details');
+            const { row, cta } = actionRow('View details');
             assertLayoutIsReal(row);
-            expect(Math.round(row.clientWidth)).toBe(248);
-            // No trigger is what makes everything below true.
-            expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
-            expect(getComputedStyle(rollup).display).toBe('flex');
-            // Literal pin from the measured table: 95.7px, i.e. the full natural
-            // width, because a menu-less action set is 137.9px rather than 184px.
-            expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
-            const text = rollup.querySelector('[data-truncate]') as HTMLElement;
-            expect(text.scrollWidth).toBeLessThanOrEqual(text.clientWidth);
-            // 🔴 AND THE CLUSTER, BOUNDED RATHER THAN PINNED, BECAUSE THIS WIDTH IS
-            // NOT IN DEFICIT. 137.9 + 10 + 95.7 = 243.6 against a 248px row, so there
-            // are ~4px of slack for the CTA to grow into and the cluster's rendered
-            // width is legitimately a little over its 137.9 natural. What the bound
-            // excludes is the state the signed-in card was actually in before the
-            // narrowing — a cluster grown to the full 248 with the rollup gone. The
-            // exact 138 pin lives in the deficit-width test below, where growth is
-            // structurally impossible.
-            expect(actions.getBoundingClientRect().width).toBeLessThan(160);
-            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
-          });
-        }
-      });
+            expect(Math.round(row.clientWidth)).toBe(container);
 
-      test('a menu card + "Open" (the narrower CTA) also keeps the rollup legible', async () => {
-        mocks.currentUser = OWNER;
-        renderWithProviders(<Sized width={314} card={base(REVIEWED)} />);
-        await expect
-          .element(page.getByRole('link', { name: 'Open', exact: true }))
-          .toBeInTheDocument();
-        const { row, rollup } = actionRow('Open');
-        assertLayoutIsReal(row);
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
-      });
+            const trigger = page
+              .getByTestId('apps-listing-card-actions-menu')
+              .element() as HTMLElement;
+            const triggerWidth = trigger.getBoundingClientRect().width;
+            const gap = parseFloat(getComputedStyle(row).columnGap);
+            // The two terms the CTA is the row MINUS, measured rather than
+            // assumed — and each pinned to the literal it is contracted to be, so
+            // a green result cannot be two compensating errors.
+            expect(Math.round(triggerWidth)).toBe(36);
+            expect(gap).toBe(10);
 
-      /**
-       * 🔴 THE 138 PIN — AND THE REASON IT IS NOW RUN OVER TWO VIEWERS.
-       *
-       * This is the guard that was supposed to say "a shopper's action row did not
-       * move", and for one branch it did not say that at all: it ran SIGNED-OUT only,
-       * and a signed-out viewer had no menu before the change and none after, so the
-       * assertion was structurally incapable of seeing the 137.9 → 184 shift that had
-       * just landed on every SIGNED-IN shopper. It stayed green through exactly the
-       * regression it reads as covering. A guard that cannot reach its own case is
-       * worse than no guard, because it stops anyone looking.
-       *
-       * The repair is not a second copy of the numbers — that reproduces the same
-       * failure one viewer over. It is the SAME body, run over both viewers, so the
-       * claim being made is "these two measure identically" rather than two
-       * independent claims that happen to be written with the same literals.
-       *
-       * 🔴 IT SURVIVES `flex-grow` ONLY BECAUSE THIS WIDTH IS IN DEFICIT, which is
-       * worth stating rather than being quietly lucky about: at 282 the reviewed
-       * rollup's natural 139.1 + 10 + 137.9 = 287 exceeds the row, so there is no
-       * free space for the CTA to grow into and the cluster stays at its natural
-       * 137.9. That is what makes an EXACT pin honest here. The same card at 462
-       * measures 312.9 — the CTA filling the slack, which is the S7 change and NOT a
-       * regression.
-       */
-      describe('🔴 a menu-less card is byte-unchanged — no menu, actions exactly 138', () => {
-        for (const [label, user] of [
-          ['signed-out', null],
-          ['signed-in non-owner, non-moderator', SHOPPER],
-        ] as const) {
-          test(`${label}`, async () => {
-            mocks.currentUser = user;
-            renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
-            await expect
-              .element(page.getByRole('link', { name: 'View details', exact: true }))
-              .toBeInTheDocument();
-            const { row, actions, rollup } = actionRow('View details');
-            assertLayoutIsReal(row);
-            expect(page.getByTestId('apps-listing-owner-edit').elements()).toHaveLength(0);
-            expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
-            // Measured pre-change values, pinned so a menu-side change cannot leak.
-            expect(Math.round(actions.getBoundingClientRect().width)).toBe(138);
-            expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(130);
-            expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
-          });
-        }
-      });
-
-      /**
-       * 🔴 THE CTA FILLS THE ROW — the S7 change itself, asserted where there IS free
-       * space, since the byte-unchanged test above deliberately sits where there is
-       * none.
-       *
-       * Pre-change the CTA was at its natural 137.9px at every width and the row's
-       * slack was simply empty. Measured on this branch at a 462px container: the
-       * anonymous card's cluster is 312.9 and the owner's CTA is 310.3, i.e. every
-       * pixel the rollup's natural width does not need.
-       */
-      describe('🔴 the primary CTA GROWS into the row', () => {
-        // Split by viewer rather than looped for the same `unmount()` reason as the
-        // sweep above. Both arms matter: a grow implemented on the menu's cluster
-        // only would leave every anonymous card unchanged.
-        for (const [label, user] of [
-          ['anonymous', null],
-          ['owner', OWNER],
-        ] as const) {
-          test(`${label} viewer at a 462px container`, async () => {
-            mocks.currentUser = user;
-            renderWithProviders(<Sized width={494} card={base(OFFSITE_CONNECT)} />);
-            await expect
-              .element(page.getByRole('link', { name: 'View details', exact: true }))
-              .toBeInTheDocument();
-            const { row, cta, rollup, actions } = actionRow('View details');
-            assertLayoutIsReal(row);
-            expect(Math.round(row.clientWidth)).toBe(462);
-            // Natural CTA width is 137.9; anything near that means it did not grow.
-            expect(cta.getBoundingClientRect().width).toBeGreaterThan(250);
-            // …and it grew into SLACK, not into the rollup: the rollup is at its full
-            // natural width here, well above the floor.
-            expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
-            // The row is exactly filled — no overflow, no gap at the right edge.
-            expect(actions.getBoundingClientRect().right).toBeCloseTo(
-              row.getBoundingClientRect().right,
+            expect(
+              cta.getBoundingClientRect().width,
+              `the CTA must fill the action row minus the 36px trigger and the 10px gap — ` +
+                `asserted at container 248 AND container 462, this one is ${container}`
+            ).toBeCloseTo(container - triggerWidth - gap, 0);
+            // …and it fills it to the right edge, with no overflow.
+            expect(cta.getBoundingClientRect().left).toBeCloseTo(
+              row.getBoundingClientRect().left,
               0
             );
             expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
-            // The one thing growth must NOT do.
+          });
+        }
+      });
+
+      /**
+       * 🔴 THE MENU-LESS CASE — the other half of "fills the row", and the arm that
+       * a fill implemented only on the menu's side would leave untouched.
+       *
+       * Every viewer except {owner, moderator} gets no `⋮` (`surface="card"`), so
+       * for them the row holds ONE child and the CTA is the whole row. Run over
+       * both a signed-out and a signed-in non-owner from ONE assertion body: the
+       * claim is that those two measure IDENTICALLY, and two independently-written
+       * tests cannot make a claim about a relationship. (A previous version of this
+       * file ran the signed-out arm alone and was structurally blind to a 137.9 →
+       * 184 shift that had just landed on every signed-in shopper.)
+       */
+      describe('🔴 with no `⋮`, the CTA is the whole row', () => {
+        for (const [label, user] of [
+          ['signed-out', null],
+          ['signed-in non-owner, non-moderator', SHOPPER],
+        ] as const) {
+          test(`${label}`, async () => {
+            mocks.currentUser = user;
+            renderWithProviders(<Sized width={314} card={base(WIDEST_CTA)} />);
+            await expect
+              .element(page.getByRole('link', { name: 'View details', exact: true }))
+              .toBeInTheDocument();
+            const { row, cta } = actionRow('View details');
+            assertLayoutIsReal(row);
+            expect(page.getByTestId('apps-listing-card-actions-menu').elements()).toHaveLength(0);
+            expect(Math.round(row.clientWidth)).toBe(282);
+            // No trigger, no gap to leave — the CTA is the entire row.
+            expect(cta.getBoundingClientRect().width).toBeCloseTo(282, 0);
             expect(Math.round(row.getBoundingClientRect().height)).toBe(46);
+          });
+        }
+      });
+
+      /**
+       * 🔴 ROW HEIGHT IS 46px AT EVERY WIDTH — the invariant the whole store's grid
+       * rests on, since the row sits in an `h-full` grid row and a taller control
+       * here grows every card in that row.
+       *
+       * 🔴 46 IS A LITERAL HERE, DELIBERATELY. `LISTING_ACTION_ROW_HEIGHT_PX` is
+       * asserted to EQUAL it in the same test rather than substituted for it:
+       * writing `toBe(LISTING_ACTION_ROW_HEIGHT_PX)` would move the expectation in
+       * lockstep with any mutation of the constant, so a changed constant would
+       * render a 52px row and still pass. Measured at 248, 282 and 462 — the three
+       * container widths the pre-change comment named.
+       */
+      describe('🔴 the row is 46px tall', () => {
+        for (const [outer, container] of [
+          [280, 248],
+          [314, 282],
+          [494, 462],
+        ] as const) {
+          test(`container ${container}`, async () => {
+            mocks.currentUser = OWNER;
+            renderWithProviders(<Sized width={outer} card={base(WIDEST_CTA)} />);
+            await expect
+              .element(page.getByRole('link', { name: 'View details', exact: true }))
+              .toBeInTheDocument();
+            const { row } = actionRow('View details');
+            assertLayoutIsReal(row);
+            expect(Math.round(row.clientWidth)).toBe(container);
+            expect(
+              Math.round(row.getBoundingClientRect().height),
+              `the action row must stay 46px at container ${container} — it lives in an h-full grid row`
+            ).toBe(46);
+            // …and the shared constant, which the skeleton will import, says the
+            // same thing the render just did.
+            expect(LISTING_ACTION_ROW_HEIGHT_PX).toBe(46);
+            // The two terms that produce it, read off the real box.
+            expect(parseFloat(getComputedStyle(row).paddingTop)).toBe(10);
+            const trigger = page
+              .getByTestId('apps-listing-card-actions-menu')
+              .element() as HTMLElement;
+            expect(Math.round(trigger.getBoundingClientRect().height)).toBe(36);
           });
         }
       });
     });
 
-    test('the recommend rollup is the side that absorbs the extra width (it truncates)', async () => {
-      renderWithProviders(<Sized width={340} card={base({})} />);
-      await expect.element(page.getByText('No reviews yet')).toBeInTheDocument();
-      const rollup = page.getByText('No reviews yet').element() as HTMLElement;
-      // Mantine's `data-truncate` attribute AND the resolved style — with the
-      // stylesheet loaded the class-based ellipsis actually computes, so both
-      // halves are real. (Before the stylesheet import this asserted only the
-      // attribute, because `textOverflow` computed to `clip` regardless.)
-      expect(rollup.getAttribute('data-truncate')).toBe('end');
-      expect(getComputedStyle(rollup).textOverflow).toBe('ellipsis');
-      // …and its container is still the shrinkable side — but now with a FLOOR
-      // rather than `minWidth: 0`. Truncation is unaffected: the label sits inside
-      // the clamped box and ellipsises there. What changed is where the shrinking
-      // stops, and that is the property the growing CTA would otherwise erase.
-      expect((rollup.parentElement as HTMLElement).style.minWidth).toBe(
-        `${LISTING_ROLLUP_MIN_WIDTH_PX}px`
+    /**
+     * 🔴 THE RECOMMEND ROLLUP MOVED — present in the meta block, ABSENT from the
+     * action row.
+     *
+     * Both halves in one test on purpose: "it is in the meta block" is also true
+     * of a card that renders it TWICE, and "it is not in the action row" is also
+     * true of a card that does not render it at all.
+     *
+     * 🔴 THE ABSENCE IS `querySelector(...) === null` WITHIN THE ROW ELEMENT, NOT
+     * `expect.element(...).not.toBeInTheDocument()`. That matcher is INERT in this
+     * repo (civitai/civitai#4197) — it passes whether or not the element is there.
+     * The form used here is controlled BOTH ways in the same test: the identical
+     * `querySelector` call against the meta block returns the node, so a `null`
+     * from the row is a real read and not a selector that matches nothing.
+     */
+    test('🔴 the rollup renders in the meta block and NOT in the action row', async () => {
+      mocks.currentUser = OWNER; // the widest row — if it fits anywhere, it fits here
+      renderWithProviders(<Sized width={314} card={base({ ...REVIEWED_ROLLUP })} />);
+      // 🔴 THE BARRIER IS THE CTA, NOT THE ROLLUP'S OWN TEXT. `getByText` is
+      // strict-mode: a mutation that renders the rollup in BOTH places resolves to
+      // two nodes and THROWS here, so the test goes red for a locator reason
+      // before either assertion below runs. Measured — that is exactly what the
+      // "rollup back in the action row" mutation did on this test's first run, and
+      // a red for the wrong reason proves nothing about the guard.
+      await expect
+        .element(page.getByRole('link', { name: 'Open', exact: true }))
+        .toBeInTheDocument();
+
+      // 🔴 POSITIVE CONTROL FIRST, using the SAME `querySelector(ROLLUP_SELECTOR)`
+      // call shape as the absence below — so a `null` from the row is a real read
+      // and not a selector that matches nothing anywhere.
+      const meta = metaBlock('My App');
+      const inMeta = meta.querySelector(ROLLUP_SELECTOR) as HTMLElement | null;
+      expect(inMeta, 'the rollup is not in the meta block at all').not.toBeNull();
+
+      const { row } = actionRow('Open');
+      assertLayoutIsReal(row);
+
+      // 🔴 THE CLAIM THIS TEST EXISTS FOR, asserted BEFORE the count below so a
+      // mutation that renders the rollup in BOTH places fails on THIS message
+      // rather than on a duplicate-count assertion that would mask it.
+      expect(
+        row.querySelector(ROLLUP_SELECTOR),
+        'the recommend rollup is back in the action row'
+      ).toBeNull();
+      expect(row.contains(inMeta!)).toBe(false);
+      // The row is exactly the CTA + the trigger's box, nothing else.
+      expect(row.children).toHaveLength(2);
+
+      // …and exactly ONE in the whole document — not zero (which would satisfy the
+      // absence vacuously) and not two (a copy left behind in the row).
+      expect(document.querySelectorAll(ROLLUP_SELECTOR)).toHaveLength(1);
+      const rollup = inMeta!;
+
+      // It sits BELOW the creator chip (the meta block's reading order), not above
+      // the title — a position claim a containment check alone cannot make.
+      const creator = meta.querySelector('a[href^="/user/"]') as HTMLElement;
+      expect(creator).not.toBeNull();
+      expect(rollup.getBoundingClientRect().top).toBeGreaterThan(
+        creator.getBoundingClientRect().top
       );
     });
 
-    test('🔴 the clamped rollup still TRUNCATES rather than overflowing its box', async () => {
-      // The companion to the assertion above, and the half a style read cannot make:
-      // at the threshold the rollup is clamped to exactly its 70px floor, which is
-      // narrower than "No reviews yet" (79px natural) — so this is a width where the
-      // ellipsis has to be doing real work. A floor that stopped the label
-      // truncating would spill it out of the card instead.
-      mocks.currentUser = OWNER; // → a menu, → the clamp is reachable
-      renderWithProviders(
-        <Sized
-          width={296}
-          card={base({ kind: 'offsite', kindData: { kind: 'offsite', externalUrl: null } })}
-        />
-      );
-      await expect.element(page.getByText('No reviews yet')).toBeInTheDocument();
-      const text = page.getByText('No reviews yet').element() as HTMLElement;
-      const box = text.parentElement as HTMLElement;
-      assertLayoutIsReal(box);
-      expect(box.getBoundingClientRect().width).toBeCloseTo(LISTING_ROLLUP_MIN_WIDTH_PX, 0);
-      // The label is wider than the box it is in, and is clipped rather than spilling.
-      expect(text.scrollWidth).toBeGreaterThan(text.clientWidth);
-      expect(text.getBoundingClientRect().right).toBeLessThanOrEqual(
-        box.getBoundingClientRect().right + 1
-      );
+    /**
+     * The rollup line is unconditional — a card with no reviews still gets it.
+     * Dropping it would make card height depend on review state inside an `h-full`
+     * grid row, which is the same misalignment the reserved title lines fix.
+     */
+    test('🔴 a card with no reviews still renders the rollup line', async () => {
+      renderWithProviders(<Sized width={314} card={base({})} />);
+      // Same reason as above: barrier on the unique CTA, so the COUNT below is what
+      // fails when the rollup is rendered twice.
+      await expect
+        .element(page.getByRole('link', { name: 'Open', exact: true }))
+        .toBeInTheDocument();
+      expect(document.querySelectorAll(ROLLUP_SELECTOR)).toHaveLength(1);
+      expect(document.body.textContent).toContain('No reviews yet');
     });
   });
 

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -44,6 +44,7 @@ import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/comp
 import { Button, Text } from '@mantine/core';
 import {
   LISTING_ACTION_ROW_HEIGHT_PX,
+  LISTING_CARD_TITLE_LINES,
   LISTING_CARD_TITLE_LINE_HEIGHT,
 } from '~/components/Apps/appListingCardGeometry';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
@@ -651,9 +652,24 @@ describe('AppListingCard', () => {
       // …against the 24px the pinned constant produces. The gap is what the
       // reserved two lines are worth: 48px vs 66px.
       expect(getComputedStyle(pinned).lineHeight).toBe('24px');
-      // Stated as the arithmetic the card actually depends on, so a reader does not
-      // have to do it: 2 reserved lines at each.
-      expect(2 * 33 - 2 * 24).toBe(18);
+
+      // 🔴 THE "~18px SWING" THE COMMENTS QUOTE IS NOT ASSERTED SEPARATELY, AND
+      // THAT IS DELIBERATE — it is `LISTING_CARD_TITLE_LINES * (33 - 24)`, i.e.
+      // FULLY DETERMINED by the two measurements above. A third assertion over it
+      // could only fail in worlds where one of them has already failed, so it would
+      // be an UNREACHABLE guard: green for the whole life of the file, red only as
+      // a second copy of someone else's failure.
+      //
+      // 🔴 TWO WRONG VERSIONS SHIPPED BEFORE THIS COMMENT DID, both flagged by
+      // audit. First `expect(2 * 33 - 2 * 24).toBe(18)` — a tautology over two
+      // hardcoded literals, wired to neither measurement, unable to fail at all,
+      // with a comment calling it the arithmetic guard. Then a version computed
+      // from `getComputedStyle` on both probes, which is honest arithmetic but
+      // still unreachable for the reason above: measured, the mutation that retunes
+      // the pinned line-height (1.2 -> 1.4) kills the `24px` pin FIRST and the
+      // swing line never executes. Decoration that reads as a guard is the same
+      // class as the walkable spread check above, so it is stated in prose instead.
+      expect(LISTING_CARD_TITLE_LINES).toBe(2); // the multiplier in that arithmetic
     });
   });
 

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -25,6 +25,7 @@ import {
 import {
   LISTING_ACTION_ROW_CONTROL_PX,
   LISTING_ACTION_ROW_GAP_PX,
+  LISTING_ACTION_ROW_HEIGHT_PX,
   LISTING_ACTION_ROW_PT_PX,
   LISTING_CARD_COVER_ASPECT_RATIO,
   LISTING_CARD_ICON_SIZE_PX,
@@ -61,6 +62,13 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * reserve EXACTLY this geometry or the grid reflows when the query resolves, and
  * two hand-copied numbers is how that drifts. Do not re-literalise a value below
  * "for readability" — the literal is the bug.
+ *
+ * 🔴 AND "READS THEM" MEANS ALL OF THEM, WHICH IS NOW MACHINE-CHECKED AGAINST THE
+ * MODULE'S EXPORTS. This header claimed the action-row HEIGHT among them while
+ * nothing here consumed it; the row's `mih` is that consumer, and
+ * `__tests__/appListingCardView.test.ts` enumerates the module's `Object.keys`
+ * rather than a hand-maintained list, so the claim cannot quietly outgrow the code
+ * again.
  *
  * 🔴 THE RECOMMEND ROLLUP LIVES IN THE META BLOCK, NOT THE ACTION ROW. It used to
  * sit opposite the CTA under `justify="space-between"`, which cost an enforced
@@ -322,9 +330,11 @@ export function AppListingCard({
   // `container-type: inline-size` would be an unread containment declaration
   // that a later reader has to prove unused before touching. Nothing else on the
   // card is size-queried; re-add it WITH its consumer if that changes.
-  // (`useAppListingActionsMenuVisible` went with it — the card no longer needs to
-  // know whether the menu will render, only to render it. The predicate itself
-  // still lives in `AppListingActionsMenu` for the surfaces that do.)
+  // (`useAppListingActionsMenuVisible` went with it. That hook is now DELETED, not
+  // merely uncalled: it existed solely so this card could lay out around the
+  // trigger, so once the layout stopped depending on the answer it had no consumer
+  // anywhere — and an exported hook with no consumer is the same shape as an unread
+  // containment declaration, i.e. the thing that gets wired back in later.)
   // 🔴 S4 — CHROME MATCHES THE SITE'S CARD, and every property below is
   // load-bearing. Measured against a `/models` card in the same session (dark),
   // and re-measured at 394px mobile where all four values are identical:
@@ -565,7 +575,27 @@ export function AppListingCard({
             🔴 ROW HEIGHT IS A CONSTANT 46px AND MUST STAY ONE, and it is now
             DERIVED rather than asserted: `LISTING_ACTION_ROW_HEIGHT_PX` =
             `LISTING_ACTION_ROW_PT_PX` (10) + `LISTING_ACTION_ROW_CONTROL_PX`
-            (36), and this row reads both. Every control in it is that same 36:
+            (36), and this row reads all three.
+
+            🔴 `mih` IS THE HEIGHT CONSTANT'S ONLY PRODUCTION READ, AND IT IS HERE
+            BECAUSE OF WHAT ITS ABSENCE COST. The height was DERIVED in the module
+            and MEASURED in the browser suite, but nothing in production consumed
+            it — so the module's own header, this file's header and a test titled
+            "reads EVERY geometry constant" all claimed a coverage that did not
+            exist, and the test's loop quietly enumerated 8 of 9. An audit produced
+            the defect that gap admits: adding `pb={10}` beside the `pt` renders a
+            56px row while the constant still says 46, and the BLOCKING node tier
+            stays entirely green because it measures nothing. PR3's skeleton would
+            then import 46, reserve 10px too little, and reflow the grid — exactly
+            what this module exists to prevent, in the one tier CI does not gate.
+            `mih` makes the read real (and is not inert: it holds the row at 46 if a
+            control ever renders SHORTER), and the node tier now asserts this tag's
+            whole PROP LEDGER, so a `pb` — or any other prop that can move the
+            row's height — fails the blocking tier rather than only the browser one.
+            🔴 DO NOT ADD A PROP HERE WITHOUT UPDATING THAT LEDGER; that is the
+            point of it, not an obstacle to route around.
+
+            Every control in it is that same 36:
             the `sm` CTA button and the `⋮` trigger, which takes its size from the
             constant rather than a literal. The row lives in an `h-full` grid row,
             so a taller control here propagates to every card in that row across
@@ -575,6 +605,7 @@ export function AppListingCard({
         <Group
           mt="auto"
           pt={LISTING_ACTION_ROW_PT_PX}
+          mih={LISTING_ACTION_ROW_HEIGHT_PX}
           gap={LISTING_ACTION_ROW_GAP_PX}
           wrap="nowrap"
         >

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -18,15 +18,21 @@ import { type MouseEvent, useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { CATEGORY_ICONS, FALLBACK_CATEGORY_ICON } from '~/components/Apps/marketplaceCategoryIcons';
 import {
-  LISTING_ROLLUP_MIN_WIDTH_PX,
   getListingCta,
   getListingDetailHref,
   getRecommendLabel,
 } from '~/components/Apps/appListingCardView';
 import {
-  AppListingActionsMenu,
-  useAppListingActionsMenuVisible,
-} from '~/components/Apps/AppListingActionsMenu';
+  LISTING_ACTION_ROW_CONTROL_PX,
+  LISTING_ACTION_ROW_GAP_PX,
+  LISTING_ACTION_ROW_PT_PX,
+  LISTING_CARD_COVER_ASPECT_RATIO,
+  LISTING_CARD_ICON_SIZE_PX,
+  LISTING_CARD_TITLE_LINES,
+  LISTING_CARD_TITLE_LINE_HEIGHT,
+  LISTING_CARD_TITLE_MIN_HEIGHT,
+} from '~/components/Apps/appListingCardGeometry';
+import { AppListingActionsMenu } from '~/components/Apps/AppListingActionsMenu';
 import { ACTION_GLYPH_ICONS, cardActionGlyph } from '~/components/Apps/appListingActionGlyph';
 import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
@@ -47,6 +53,24 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * kind-aware CTA (Open / View details / Visit ↗). Mirrors the visual language of
  * the live `AppBlockCard` (Mantine Card + category-glyph cover placeholder) so
  * listings feel native.
+ *
+ * 🔴 THE CARD'S GEOMETRY IS NOT SPELLED HERE — it is READ from
+ * `appListingCardGeometry.ts`: cover ratio, icon size, reserved title lines and
+ * line-height, action-row height / padding / gap / control size. The reason is a
+ * relationship this file cannot enforce on its own: `AppListingCardSkeleton` must
+ * reserve EXACTLY this geometry or the grid reflows when the query resolves, and
+ * two hand-copied numbers is how that drifts. Do not re-literalise a value below
+ * "for readability" — the literal is the bug.
+ *
+ * 🔴 THE RECOMMEND ROLLUP LIVES IN THE META BLOCK, NOT THE ACTION ROW. It used to
+ * sit opposite the CTA under `justify="space-between"`, which cost an enforced
+ * `min-width` floor, a `@container` breakpoint that hid it entirely below 264px,
+ * and a derived threshold constant with its own drift guard — all of it apparatus
+ * for making two things share a row that did not need to. As a dimmed line under
+ * the creator chip it has the meta block's full width, never competes with the
+ * CTA, and the row is left holding only the CTA + the `⋮` trigger. Whether a
+ * viewer gets a `⋮` no longer has any geometry consequence beyond the trigger's
+ * own 36px, so the card no longer computes that predicate at all.
  *
  * 🔴 THERE IS NO KIND BADGE ON THIS CARD. This line used to claim "a kind badge
  * (App / Connect app / Off-site)" — doubly wrong: two of those labels no longer
@@ -137,7 +161,8 @@ function ListingCover({
           // reserved before any image bytes arrive — that's the CLS guard.
           position: 'relative',
           width: '100%',
-          aspectRatio: '16 / 9',
+          // Read, not spelled — the skeleton reserves the SAME ratio.
+          aspectRatio: LISTING_CARD_COVER_ASPECT_RATIO,
           overflow: 'hidden',
         }}
       >
@@ -279,10 +304,6 @@ export function AppListingCard({
     kindData: card.kindData,
     creatorUserId: card.creator?.id ?? null,
   };
-  // Whether the trigger occupies the action row. Read from the shared predicate
-  // rather than re-derived — see its comment.
-  const hasMenu = useAppListingActionsMenuVisible(menuTarget, 'card', preview);
-
   // OWNER-ONLY incompleteness hint. The public store DTO carries only nullable
   // iconUrl/coverUrl (no screenshot count), so this is scoped to a below-floor
   // listing (missing icon or cover). A non-owner / public shopper always sees a
@@ -294,10 +315,16 @@ export function AppListingCard({
   ].filter((v): v is string => v != null);
   const showOwnerIncomplete = isOwner && missingFloorAssets.length > 0;
 
-  // `@container` makes THIS card the query basis for the recommend-rollup floor
-  // breakpoint in the action row below (see the long note there). It is
-  // `container-type: inline-size`, i.e. inline-axis containment only, so the
-  // card's height still follows its content and `h-full` is unaffected.
+  // 🔴 `@container` IS GONE, AND SO IS THE `hasMenu` PREDICATE THAT DROVE IT.
+  // The card declared itself a query container for exactly ONE consumer: the
+  // recommend rollup's `hidden @[264px]:flex`. With the rollup relocated to the
+  // meta block there is no container query left on this card, so keeping
+  // `container-type: inline-size` would be an unread containment declaration
+  // that a later reader has to prove unused before touching. Nothing else on the
+  // card is size-queried; re-add it WITH its consumer if that changes.
+  // (`useAppListingActionsMenuVisible` went with it — the card no longer needs to
+  // know whether the menu will render, only to render it. The predicate itself
+  // still lives in `AppListingActionsMenu` for the surfaces that do.)
   // 🔴 S4 — CHROME MATCHES THE SITE'S CARD, and every property below is
   // load-bearing. Measured against a `/models` card in the same session (dark),
   // and re-measured at 394px mobile where all four values are identical:
@@ -323,7 +350,7 @@ export function AppListingCard({
   // (rgb(26,27,30)) with every ancestor transparent — the same separation `/models`
   // already relies on at `border: 0`. Measured, not assumed.
   return (
-    <Card padding="md" radius={0} className="h-full rounded-md @container">
+    <Card padding="md" radius={0} className="h-full rounded-md">
       <ListingCover
         coverUrl={card.coverUrl}
         category={card.category}
@@ -339,7 +366,7 @@ export function AppListingCard({
             src={card.iconUrl ?? undefined}
             alt=""
             radius="md"
-            size={40}
+            size={LISTING_CARD_ICON_SIZE_PX}
             style={{ flexShrink: 0 }}
             data-listing-icon-placeholder={card.iconUrl == null ? '' : undefined}
             styles={{
@@ -390,12 +417,76 @@ export function AppListingCard({
                   earlier draft of this comment claimed: `RecentlyOpenedApps`
                   ("Recently opened") and `RelatedListings` both render their own
                   `Title` on those surfaces. The broader heading-hierarchy finding
-                  (S13) stays out of scope. */}
-              <Text size="xl" fw={700} lh={1.2} c="white" className="line-clamp-2">
+                  (S13) stays out of scope.
+
+                  🔴 THE TITLE BOX RESERVES ITS FULL TWO LINES WHETHER OR NOT IT
+                  NEEDS THEM. `min-height` = lines x line-height, in `em` so it
+                  tracks the title's own font-size. Without it a one-line title is
+                  24px and a wrapped one is 48px, so the creator chip — and every
+                  row of the meta block under it — lands at a DIFFERENT y on every
+                  card in a grid row, which reads as sloppy alignment rather than
+                  as variable content. It adds NO truncation: the title already
+                  clamped at two lines, and the clamp is still two lines because
+                  both numbers are now the same constant.
+
+                  🔴 `TruncatedText` REPLACES the `line-clamp-2` utility class, and
+                  the swap is not cosmetic. (a) The class would be a SECOND copy of
+                  the line count that `min-height` derives from — exactly the drift
+                  this PR's geometry module exists to remove. (b) It buys the
+                  hover fallback the creator chip already has: a name clamped at
+                  two lines is unreadable, and `TruncatedText` reveals it in a
+                  Tooltip ONLY when it actually clips (a runtime scrollHeight
+                  measurement, not a guess). `clampLines` selects that component's
+                  multi-line mode — passing the Tailwind class instead would be
+                  silently overridden by its single-line `white-space: nowrap`. */}
+              <TruncatedText
+                size="xl"
+                fw={700}
+                lh={LISTING_CARD_TITLE_LINE_HEIGHT}
+                c="white"
+                clampLines={LISTING_CARD_TITLE_LINES}
+                tooltipLabel={card.name}
+                style={{ minHeight: LISTING_CARD_TITLE_MIN_HEIGHT }}
+              >
                 {card.name}
-              </Text>
+              </TruncatedText>
             </Anchor>
             <CreatorChip creator={card.creator} />
+            {/* ── THE RECOMMEND ROLLUP ────────────────────────────────────────
+                "N% recommend (M)", or "No reviews yet" when there are none.
+
+                🔴 IT ALWAYS RENDERS, AND THAT IS THE POINT. A card with no reviews
+                still gets the line — dropping it would make card heights depend on
+                review state inside an `h-full` grid row, which is the same class of
+                misalignment the title's reserved lines above fix.
+
+                🔴 IT MOVED HERE FROM THE ACTION ROW, and what it left behind is the
+                headline of this change. Opposite the CTA it needed an enforced
+                `min-width` floor (so a growing CTA could not starve it), a
+                `@container` query hiding it below 264px (so a narrow card did not
+                render a two-character stub), and a derived threshold constant with
+                a drift guard asserting the Tailwind class spelled the same number.
+                All three are DELETED: as a meta-block line it has the block's full
+                width, competes with nothing, and truncates against the card body
+                rather than against a button.
+
+                Dimmed + `xs`, i.e. quieter than the creator line above it: it is
+                corroboration, not identity. */}
+            <Group
+              gap={4}
+              wrap="nowrap"
+              style={{ minWidth: 0 }}
+              data-testid="apps-listing-recommend-rollup"
+            >
+              <IconThumbUp
+                size={13}
+                style={{ flexShrink: 0 }}
+                className={card.recommend.recommendPct == null ? 'text-gray-500' : 'text-green-500'}
+              />
+              <Text size="xs" c="dimmed" truncate>
+                {recommendLabel}
+              </Text>
+            </Group>
             {/* AUTHOR-DECLARED beta label. Matches the `Incomplete` badge's shape directly
                 below, with two deliberate differences: it is PUBLIC (that one is owner-only
                 — `showOwnerIncomplete`), and it carries no tooltip, because the card DTO
@@ -448,266 +539,176 @@ export function AppListingCard({
             than a footnote. S7 then made the CTA FILL the row instead of
             stepping up the size scale again — see the CTA's own note below.
 
-            🔴 The row deliberately stays `nowrap`. Letting it wrap looks like the
-            obvious way to stop the taller buttons overflowing a narrow column, but
-            it breaks two things: (1) under `justify="space-between"` a wrapped line
-            holding a single item sits at flex-START, so the actions would jump from
-            right-aligned to LEFT-aligned; and (2) a card WITH a `⋮` menu wraps at a
-            wider column than one without, so inside a `h-full` grid row one such
-            card would grow the height of the whole row. Instead the actions never
-            shrink and the recommend rollup absorbs the pressure — down to a floor.
+            🔴 THE ROW HOLDS THE CTA AND THE `⋮` TRIGGER, AND NOTHING ELSE. The
+            recommend rollup used to sit opposite them; it is now a meta-block
+            line (see its note above). Three pieces of apparatus died with the
+            move, and none of them should come back with it:
+              - `justify="space-between"` — moot with one growing child, and it
+                was the reason a lone item could jump to flex-START;
+              - `marginLeft: 'auto'` on the action cluster — it existed as a
+                SECOND mechanism keeping the actions right-aligned when the
+                rollup was hidden. There is no "hidden rollup" state any more and
+                the CTA reaches both edges by growing, so an auto margin now has
+                exactly zero free space to absorb at every width. Kept, it would
+                be a guard for a hazard that no longer has a shape — dead code
+                that reads as load-bearing. DELETED;
+              - the nested action-cluster `Group` — it existed to keep the CTA and
+                the trigger together as one flex item opposite the rollup. With
+                the rollup gone the row IS that cluster, so the wrapper is one
+                level of nesting with nothing left to group.
 
-            🔴 ROW HEIGHT IS A CONSTANT 46px AND MUST STAY ONE. `pt="xs"` (10px) +
-            a 36px control. Every control in the row is 36px: the `sm` CTA button
-            and the `size={36}` menu trigger. The row lives in an `h-full` grid
-            row, so a taller control here propagates to every card in that row
-            across the whole store — which is why the CTA grows HORIZONTALLY
-            rather than up the size scale. Re-measured after this change at
-            container 248 / 282 / 462: 46px in every cell. */}
-        <Group justify="space-between" mt="auto" pt="xs" gap="xs" wrap="nowrap">
-          {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". This is the
-              flexible side: it may truncate so the actions never do.
+            🔴 The row still stays `nowrap`. With one growing CTA a wrapped line
+            would put the `⋮` on its own row, and a card WITH a menu would then be
+            taller than one without — inside an `h-full` grid row that grows every
+            card in the row across the store.
 
-              🔴 …but ONLY DOWN TO A FLOOR, AND THE FLOOR IS NOW ENFORCED. It used
-              to be `minWidth: 0` — "shrink to nothing" — with the floor existing
-              only as the arithmetic behind the container query below. That was
-              survivable while nothing competed for the free space. It is not
-              survivable now that the CTA GROWS into it: a `flex-grow` on the CTA
-              with a zero-floor rollup starves the rollup at EVERY width, not just
-              the narrow ones the query was built for — i.e. the obvious
-              implementation of "make the CTA fill the row" destroys the exact
-              thing the query exists to protect. So the floor is stated as a
-              constraint the layout engine enforces (`minWidth:
-              LISTING_ROLLUP_MIN_WIDTH_PX`), and the CTA takes only the remainder.
+            🔴 ROW HEIGHT IS A CONSTANT 46px AND MUST STAY ONE, and it is now
+            DERIVED rather than asserted: `LISTING_ACTION_ROW_HEIGHT_PX` =
+            `LISTING_ACTION_ROW_PT_PX` (10) + `LISTING_ACTION_ROW_CONTROL_PX`
+            (36), and this row reads both. Every control in it is that same 36:
+            the `sm` CTA button and the `⋮` trigger, which takes its size from the
+            constant rather than a literal. The row lives in an `h-full` grid row,
+            so a taller control here propagates to every card in that row across
+            the whole store — which is why the CTA grows HORIZONTALLY rather than
+            up the size scale. Pinned at container 248 / 282 / 462 in
+            `AppListingCard.browser.test.tsx`. */}
+        <Group
+          mt="auto"
+          pt={LISTING_ACTION_ROW_PT_PX}
+          gap={LISTING_ACTION_ROW_GAP_PX}
+          wrap="nowrap"
+        >
+          {/* Kind-aware CTA — always has a working target (a direct Open / Visit,
+              or the unified detail). External Visit → new-tab anchor; everything
+              else → an internal Link.
 
-              🔴 THE TABLE BELOW WAS RE-MEASURED ON THIS BRANCH — it is not the
-              pre-change one carried forward. A card WITH a menu, the widest CTA
-              ("View details"), no reviews (the SHORTEST label the rollup can
-              carry, so a deficit here is structural rather than an artefact of a
-              long string). Widths are `getBoundingClientRect`:
+              🔴 IT FILLS THE ROW RATHER THAN STEPPING UP THE SIZE SCALE. The ask
+              was a bigger primary action; the next Mantine size (`md`) is 42px
+              tall, and this row's height is load-bearing (see the row note
+              above), so the only free axis is horizontal. `flexGrow: 1` on the
+              button — now a DIRECT child of the row — takes every pixel the `⋮`
+              trigger and the row gap do not need, i.e.
+              `cta = row − LISTING_ACTION_ROW_CONTROL_PX − LISTING_ACTION_ROW_GAP_PX`
+              when a menu renders and the whole row when one does not. Asserted at
+              two container widths, because one measurement is not a general
+              claim.
 
-                | card | container | actions nat/rendered | rollup | row h | rollup    |
-                |------|-----------|----------------------|--------|-------|-----------|
-                |  280 |       248 | 184 /  248 (grown)   |    0   |    46 | HIDDEN    |
-                |  296 |       264 | 184 /  184           |   70.1 |    46 | at FLOOR  |
-                |  314 |       282 | 184 /  184           |   88.1 |    46 | clamped   |
-                |  494 |       462 | 184 /  356.3 (grown) |   95.7 |    46 | natural   |
+              🔴 SHRINK IS LEFT AT ITS DEFAULT, deliberately, and that is a CHANGE.
+              The old cluster carried `flexShrink: 0` so the rollup would absorb
+              every deficit; the documented cost was that below ~218px of container
+              the row OVERFLOWED the card instead. With the rollup gone the CTA is
+              the only thing that can give, so letting it shrink (with `minWidth: 0`
+              so the label clips rather than propping the box open) keeps the `⋮`
+              inside the card at widths no store surface produces anyway — the
+              narrowest real one is 248, comfortably above the ~184 natural.
 
-              Two columns for the actions because they are now two different
-              numbers: 184 is the cluster's NATURAL width (36px `⋮` + 10px gap +
-              137.9px CTA), which is what the threshold arithmetic below is built
-              from; the RENDERED width is larger wherever the row has free space
-              for the CTA to grow into. In the two middle rows the row is in
-              DEFICIT, so there is no growth and the two coincide.
+              ICONS (product-feedback pass). Each action carries its own glyph so
+              the three CTAs are distinguishable at a glance in a dense grid
+              rather than three same-shaped buttons differing only in wording.
+              🔴 The mapping itself is NOT restated here — it lives in
+              `appListingActionGlyph.ts` and is read above via `CtaGlyph`. A copy
+              of it in this comment is exactly how the card and the detail page
+              drifted apart in the first place. The rail tile's icon button used
+              to carry a third copy (`RECENT_ACTION_ICONS` in
+              `RecentlyOpenedApps.tsx`); it now resolves through the same module
+              via `recentRailActionGlyph`, so all three surfaces are single-
+              sourced and the consolidation is complete.
 
-              The 264 row is the one that matters: 70.1px is
-              `LISTING_ROLLUP_MIN_WIDTH_PX` doing work, not a coincidence of the
-              content. The same card at 462 leaves the rollup at its natural 95.7
-              and gives the CTA the other 260 — which is the whole point of the
-              change: the CTA grows into the slack, it does not eat the floor.
+              🔴 The icon is DECORATIVE — the label text stays the accessible
+              name. Tabler icons render `<svg>` with no `<title>`, so they
+              contribute nothing to the name; the button's name is still
+              exactly "Open" / "Visit" / "View details". Asserted in
+              `AppListingCard.browser.test.tsx`. */}
+          {cta.external ? (
+            <Button
+              component="a"
+              href={cta.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="sm"
+              variant="light"
+              style={{ flexGrow: 1, minWidth: 0 }}
+              rightSection={<CtaGlyph size={16} />}
+              // "Opened" = actually opened. An OFF-SITE app is opened the
+              // moment this Visit CTA is followed — there is no on-platform
+              // route afterwards that could record it (the on-site path is
+              // recorded by `/apps/run/<slug>` itself). Recording on a detail
+              // VIEW would be wrong: browsing is not opening.
+              // 🔴 Stamped with the viewer's account id (#4048) — recents are
+              // per-account, not per browser profile.
+              onClick={() =>
+                recordRecentlyOpenedApp(toRecentAppFromListing(card), currentUser?.id ?? null)
+              }
+            >
+              {cta.label}
+            </Button>
+          ) : (
+            <Button
+              component={Link}
+              href={cta.href}
+              size="sm"
+              variant={cta.action === 'open' ? 'filled' : 'light'}
+              style={{ flexGrow: 1, minWidth: 0 }}
+              leftSection={<CtaGlyph size={16} />}
+            >
+              {cta.label}
+            </Button>
+          )}
 
-              ⚠️ A CORNER THIS CREATES, on the record: an enforced floor means a
-              row can OVERFLOW instead of crushing the rollup. A card with no menu
-              needs 137.9 + 10 + 70 = 218px of container to hold both; measured at
-              a synthetic 168px container the row's `scrollWidth` is 218 against a
-              `clientWidth` of 168. No store surface produces that — the 4-column
-              `lg` grid bottoms out at 248, the `base` grid is one wide column, and
-              the moderator preview card is capped at 340 (308 content) — and a
-              card WITH a menu already overflowed at that width before this change
-              (its 184px cluster alone exceeds 168). Pinned at 248, the narrowest
-              width the store can actually produce, rather than left to prose.
+          {/* The `⋮` overflow menu — owner Edit, review, report, moderator
+              actions. SHARED with the listing detail body; see
+              `AppListingActionsMenu`.
 
-              🔴 THRESHOLD 264px, DERIVED NOT GUESSED, AND NOW MACHINE-CHECKED.
-              `LISTING_ROLLUP_HIDE_BELOW_PX` in `appListingCardView.ts` computes
-              it as actions(184) + row gap(10) + floor(70) = 264, and
-              `__tests__/appListingCardView.test.ts` asserts this file's
-              `@[264px]` class spells the same number — a Tailwind arbitrary
-              variant cannot read a JS constant, so the duplication is
-              unavoidable and the drift is what gets gated instead.
+              🔴 IT REPLACED A DUAL EDIT APPARATUS AND A WHOLE BREAKPOINT. The
+              card used to carry BOTH a text `Button` ("Edit") and an icon-only
+              `ActionIcon`, with an `@[360px]` container query choosing between
+              them — a query that existed for no other reason. A `⋮` trigger is a
+              fixed 36px at every width, so that query had nothing left to decide
+              and is DELETED rather than kept as a constant nothing needs.
 
-              The 184 is MEASURED, not modelled: a 36px `⋮` trigger + the row's
-              10px `gap="xs"` + the widest CTA at its natural 138px. It happens to
-              equal the pre-change value, because the control the menu replaced was
-              an icon-only Edit `ActionIcon` at the same `size={36}` — worth naming,
-              because "the number did not move" is also what a measurement nobody
-              took looks like.
+              🔴 `triggerSize` IS THE ROW-HEIGHT CONTRACT, not a style choice —
+              it is `LISTING_ACTION_ROW_CONTROL_PX`, the SAME 36 the derived row
+              height is built from and the same height the `sm` CTA button
+              renders at. Passing a literal here is how the row and its own
+              height constant would come apart. `variant="default"` matches the
+              control it replaced.
 
-              🔴 A CONTAINER query, not a media query: card width is NOT monotonic
-              in viewport width (at `base` the grid is ONE column, so a 390px phone
-              gives a ~356px card — wider than the 280px a 1200px laptop gets at
-              four columns). A `max-width` media query would hide the rollup on
-              exactly the viewports with the most room.
+              🔴 `stopPropagation` covers the trigger AND the dropdown. Every
+              other action on this card stops propagation because the card is a
+              click target; a portalled dropdown still propagates along the REACT
+              tree, so opening the menu would otherwise navigate the card.
 
-              🔴 GATED ON `hasMenu`, NOT ON OWNERSHIP. It used to be `showEdit`,
-              because the Edit button was the only thing that widened the row.
-              The `⋮` trigger is now that thing, and it appears for anyone the menu
-              has an item for. A card with NO menu keeps its 138px action cluster
-              and its rollup never approaches the floor at any width the store
-              produces — byte-unchanged, and pinned as such.
+              🔴 THE CARD DOES NOT OFFER THE VIEWER ACTIONS — `surface="card"`,
+              and `appListingMenuSurface.ts` owns that decision. Review and
+              Report stay on the listing DETAIL page, where the viewer has
+              chosen to look at one app; on a grid of ~24 tiles they are an
+              invitation to review something nobody opened. The narrowing is
+              declared by NAMING the surface, not by re-deriving a predicate
+              here — re-deriving one is precisely the drift the shared module
+              exists to prevent.
 
-              ⚠️ ACCEPTED COLLATERAL, on the record rather than discovered later:
-              the query cannot see WHICH CTA rendered, so a card whose CTA is the
-              narrow "Open" loses a rollup that would have fit, across container
-              248–264. Encoding a second per-CTA threshold buys a second magic
-              number and a CTA-width classification in the render path; one rule
-              that is occasionally conservative is the better trade. */}
-          <Group
-            gap={4}
-            wrap="nowrap"
-            style={{ minWidth: LISTING_ROLLUP_MIN_WIDTH_PX }}
-            className={hasMenu ? 'hidden @[264px]:flex' : undefined}
-          >
-            <IconThumbUp
-              size={13}
-              style={{ flexShrink: 0 }}
-              className={card.recommend.recommendPct == null ? 'text-gray-500' : 'text-green-500'}
-            />
-            <Text size="xs" c="dimmed" truncate>
-              {recommendLabel}
-            </Text>
-          </Group>
-
-          {/* 🔴 `flexGrow: 1` IS WHAT MAKES THE CTA FILL THE ROW, and it is on the
-              CLUSTER rather than on the button alone because the button is not a
-              direct child of the row — the `⋮` trigger shares the cluster with it.
-              The cluster grows, the fixed-width trigger does not, so the whole
-              remainder lands on the CTA (which carries its own `flexGrow: 1`).
-
-              🔴 `flexShrink: 0` STAYS. Growth and shrink are independent here and
-              only growth is wanted: the actions are the rigid side, and the rollup
-              — clamped at its floor — is the side that gives. Below the container
-              query's threshold the rollup leaves layout entirely rather than the
-              actions being squeezed.
-
-              🔴 `marginLeft: 'auto'` is RETAINED THOUGH NOW REDUNDANT, deliberately.
-              With `flexGrow: 1` the cluster already reaches the row's right edge, so
-              the auto margin currently absorbs zero free space (flexible lengths are
-              resolved BEFORE auto margins). It stays because it is the thing that
-              keeps the actions right-aligned if the grow is ever removed: under
-              `justify="space-between"` a SINGLE remaining flex item sits at
-              flex-START, so with the rollup hidden and no grow and no auto margin,
-              the whole CTA cluster jumps to the card's left edge. Two independent
-              mechanisms for one invariant, both cheap. */}
-          <Group
-            gap="xs"
-            wrap="nowrap"
-            style={{ flexShrink: 0, flexGrow: 1, minWidth: 0, marginLeft: 'auto' }}
-          >
-            {/* Kind-aware CTA — always has a working target (a direct Open / Visit,
-                or the unified detail). External Visit → new-tab anchor; everything
-                else → an internal Link.
-
-                🔴 IT FILLS THE ROW RATHER THAN STEPPING UP THE SIZE SCALE. The ask
-                was a bigger primary action; the next Mantine size (`md`) is 42px
-                tall, and this row's height is load-bearing (see the row note
-                above), so the only free axis is horizontal. `flexGrow: 1` inside a
-                cluster that itself grows gives the CTA every pixel the rollup's
-                floor and the `⋮` trigger do not need.
-
-                ICONS (product-feedback pass). Each action carries its own glyph so
-                the three CTAs are distinguishable at a glance in a dense grid
-                rather than three same-shaped buttons differing only in wording.
-                🔴 The mapping itself is NOT restated here — it lives in
-                `appListingActionGlyph.ts` and is read above via `CtaGlyph`. A copy
-                of it in this comment is exactly how the card and the detail page
-                drifted apart in the first place. The rail tile's icon button used
-                to carry a third copy (`RECENT_ACTION_ICONS` in
-                `RecentlyOpenedApps.tsx`); it now resolves through the same module
-                via `recentRailActionGlyph`, so all three surfaces are single-
-                sourced and the consolidation is complete.
-
-                🔴 The icon is DECORATIVE — the label text stays the accessible
-                name. Tabler icons render `<svg>` with no `<title>`, so they
-                contribute nothing to the name; the button's name is still
-                exactly "Open" / "Visit" / "View details". Asserted in
-                `AppListingCard.browser.test.tsx`. */}
-            {cta.external ? (
-              <Button
-                component="a"
-                href={cta.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                size="sm"
-                variant="light"
-                style={{ flexGrow: 1 }}
-                rightSection={<CtaGlyph size={16} />}
-                // "Opened" = actually opened. An OFF-SITE app is opened the
-                // moment this Visit CTA is followed — there is no on-platform
-                // route afterwards that could record it (the on-site path is
-                // recorded by `/apps/run/<slug>` itself). Recording on a detail
-                // VIEW would be wrong: browsing is not opening.
-                // 🔴 Stamped with the viewer's account id (#4048) — recents are
-                // per-account, not per browser profile.
-                onClick={() =>
-                  recordRecentlyOpenedApp(toRecentAppFromListing(card), currentUser?.id ?? null)
-                }
-              >
-                {cta.label}
-              </Button>
-            ) : (
-              <Button
-                component={Link}
-                href={cta.href}
-                size="sm"
-                variant={cta.action === 'open' ? 'filled' : 'light'}
-                style={{ flexGrow: 1 }}
-                leftSection={<CtaGlyph size={16} />}
-              >
-                {cta.label}
-              </Button>
-            )}
-
-            {/* The `⋮` overflow menu — owner Edit, review, report, moderator
-                actions. SHARED with the listing detail body; see
-                `AppListingActionsMenu`.
-
-                🔴 IT REPLACED A DUAL EDIT APPARATUS AND A WHOLE BREAKPOINT. The
-                card used to carry BOTH a text `Button` ("Edit") and an icon-only
-                `ActionIcon`, with an `@[360px]` container query choosing between
-                them — a query that existed for no other reason. A `⋮` trigger is a
-                fixed 36px at every width, so that query had nothing left to decide
-                and is DELETED rather than kept as a constant nothing needs.
-
-                🔴 `size={36}` IS THE ROW-HEIGHT CONTRACT, not a style choice — it
-                matches the `sm` CTA button exactly, which is what keeps the row at
-                46px (see the row note above). `variant="default"` matches the
-                control it replaced.
-
-                🔴 `stopPropagation` covers the trigger AND the dropdown. Every
-                other action on this card stops propagation because the card is a
-                click target; a portalled dropdown still propagates along the REACT
-                tree, so opening the menu would otherwise navigate the card.
-
-                🔴 THE CARD DOES NOT OFFER THE VIEWER ACTIONS — `surface="card"`,
-                and `appListingMenuSurface.ts` owns that decision. Review and
-                Report stay on the listing DETAIL page, where the viewer has
-                chosen to look at one app; on a grid of ~24 tiles they are an
-                invitation to review something nobody opened. The narrowing is
-                declared by NAMING the surface, not by re-deriving a predicate
-                here — re-deriving one is precisely the drift the shared module
-                exists to prevent.
-
-                🔴 GEOMETRY CONSEQUENCE, ACCEPTED AND STATED: the menu's predicate
-                is still "would it hold at least one item", not "is the viewer the
-                owner". With the viewer actions gone from this surface, the items
-                that remain are the owner's Edit and the moderator section — so
-                the population that gets a `⋮`, and therefore the wider action
-                row, is exactly {owner, moderator}. Every other viewer, signed in
-                or signed out, gets the identical menu-less row. That equality is
-                pinned in `AppListingCard.browser.test.tsx` by running one
-                assertion body over both viewers. */}
-            <AppListingActionsMenu
-              listing={menuTarget}
-              surface="card"
-              preview={preview}
-              triggerSize={36}
-              triggerVariant="default"
-              triggerIconSize={16}
-              triggerTestId="apps-listing-card-actions-menu"
-              triggerTooltip
-              stopPropagation
-            />
-          </Group>
+              🔴 GEOMETRY CONSEQUENCE, RESTATED BECAUSE IT SHRANK. The menu's
+              predicate is still "would it hold at least one item", not "is the
+              viewer the owner", so the population that gets a `⋮` is exactly
+              {owner, moderator}. What that costs has changed: it used to widen
+              the action cluster from 137.9 to 184 and thereby decide whether the
+              recommend rollup fit at all. With the rollup out of this row the
+              trigger's only consequence is that the CTA is 46px narrower
+              (`LISTING_ACTION_ROW_CONTROL_PX` + `LISTING_ACTION_ROW_GAP_PX`);
+              the row height and every other card's geometry are untouched. That
+              equality is still pinned in `AppListingCard.browser.test.tsx` by
+              running one assertion body over both viewers. */}
+          <AppListingActionsMenu
+            listing={menuTarget}
+            surface="card"
+            preview={preview}
+            triggerSize={LISTING_ACTION_ROW_CONTROL_PX}
+            triggerVariant="default"
+            triggerIconSize={16}
+            triggerTestId="apps-listing-card-actions-menu"
+            triggerTooltip
+            stopPropagation
+          />
         </Group>
       </Stack>
     </Card>

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -587,11 +587,16 @@ export function AppListingCard({
             56px row while the constant still says 46, and the BLOCKING node tier
             stays entirely green because it measures nothing. PR3's skeleton would
             then import 46, reserve 10px too little, and reflow the grid — exactly
-            what this module exists to prevent, in the one tier CI does not gate.
+            what this module exists to prevent. (This sentence used to end "in the
+            one tier CI does not gate", which is a FOURTH instance of the same wrong
+            severity story: on a pull request NEITHER tier gates. See the canonical
+            note in `appListingCardGeometry.ts`.)
             `mih` makes the read real (and is not inert: it holds the row at 46 if a
             control ever renders SHORTER), and the node tier now asserts this tag's
             whole PROP LEDGER, so a `pb` — or any other prop that can move the
-            row's height — fails the blocking tier rather than only the browser one.
+            row's height — fails the node tier too, not only the browser one. (That
+            is a `main`-push red, not a merge gate: on a PR both tiers are
+            `continue-on-error`. Canonical note in `appListingCardGeometry.ts`.)
             🔴 DO NOT ADD A PROP HERE WITHOUT UPDATING THAT LEDGER; that is the
             point of it, not an obstacle to route around.
 

--- a/src/components/Apps/AppListingTruncate.tsx
+++ b/src/components/Apps/AppListingTruncate.tsx
@@ -45,17 +45,58 @@ export function useIsOverflowing<T extends HTMLElement = HTMLElement>() {
 }
 
 /**
- * A `Text` that clips (via `lineClamp`/`truncate` passed through) and reveals its
- * full value in a Tooltip ONLY when it actually clips. Rendered inline (`span`)
- * so it composes inside the creator chip's Group.
+ * A `Text` that clips and reveals its full value in a Tooltip ONLY when it
+ * actually clips. Rendered inline (`span`) so it composes inside the creator
+ * chip's Group.
+ *
+ * TWO CLIPPING MODES, and which one you get is decided by `clampLines`:
+ *   - omitted (the default, and every pre-existing call site) → SINGLE-LINE
+ *     ellipsis, exactly as before;
+ *   - a number → a multi-line `-webkit-line-clamp` box of that many lines.
+ *
+ * 🔴 THE MODES ARE MUTUALLY EXCLUSIVE AT THE CSS LEVEL, WHICH IS WHY THIS IS A
+ * PROP AND NOT A CLASSNAME THE CALLER PASSES IN. The single-line mode's
+ * `white-space: nowrap` + `display: inline-block` are written INLINE and
+ * therefore beat a `line-clamp-N` utility class: hand this component the
+ * Tailwind class and you silently get one ellipsised line, not N clamped ones.
+ * The overflow hook already measures BOTH axes (`scrollWidth > clientWidth ||
+ * scrollHeight > clientHeight`), so the tooltip gating works unchanged in the
+ * multi-line mode — it is the clipping CSS that has to differ.
  */
 export function TruncatedText({
   children,
   tooltipLabel,
+  clampLines,
   style,
   ...textProps
-}: { children: string; tooltipLabel?: string } & TextProps) {
+}: { children: string; tooltipLabel?: string; clampLines?: number } & TextProps) {
   const { ref, overflowing } = useIsOverflowing<HTMLSpanElement>();
+  const clipping =
+    clampLines == null
+      ? // Single line. `component="span"` (inline-VALID inside the chip's <a>) +
+        // an explicit `inline-block` so the element HAS a client box. Mantine's
+        // `span` boolean prop forces `display: inline`, whose
+        // clientWidth/scrollWidth are always 0 — the overflow measurement then
+        // never trips and the Tooltip is dead. Clipping on a single line makes
+        // `scrollWidth > clientWidth` a true overflow signal.
+        ({
+          display: 'inline-block',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'bottom',
+        } as const)
+      : // N lines. `-webkit-box` is what `line-clamp-N` compiles to; written
+        // inline here so it cannot be overridden by the single-line rules above,
+        // and so the line count comes from the caller's constant rather than
+        // from a class name that spells a second copy of it. Overflow is then
+        // VERTICAL, which `useIsOverflowing`'s `scrollHeight` arm sees.
+        ({
+          display: '-webkit-box',
+          WebkitBoxOrient: 'vertical' as const,
+          WebkitLineClamp: clampLines,
+          overflow: 'hidden',
+        } as const);
   return (
     <Tooltip
       label={tooltipLabel ?? children}
@@ -65,26 +106,11 @@ export function TruncatedText({
       maw={320}
       withArrow
     >
-      {/* `component="span"` (inline-VALID inside the chip's <a>) + an explicit
-          `inline-block` so the element HAS a client box. Mantine's `span` boolean
-          prop forces `display: inline`, whose clientWidth/scrollWidth are always 0
-          — the overflow measurement then never trips and the Tooltip is dead (and
-          the passed `lineClamp` never clips either). Clipping on a single line
-          below makes `scrollWidth > clientWidth` a true overflow signal; the inline
-          `display` overrides any `-webkit-box` a forwarded `lineClamp` would set. */}
       <Text
         ref={ref}
         component="span"
         {...textProps}
-        style={{
-          ...style,
-          display: 'inline-block',
-          maxWidth: '100%',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          verticalAlign: 'bottom',
-        }}
+        style={{ ...style, maxWidth: '100%', ...clipping }}
       >
         {children}
       </Text>

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -409,10 +409,16 @@ describe('the card geometry module', () => {
    * than the body, which is the shape that reads as coverage while providing none.
    * Deriving the list from `Object.keys` makes the omission impossible to repeat AND
    * makes the guard cover constants nobody has written yet: add one to the module
-   * without reading it in the card and this fails, naming it.
+   * without reading it in the card and this fails, NAMING it.
    *
-   * 🔴 SO THE FAILURE MESSAGE NAMES THE CONSTANT, not "the import list changed" —
-   * a set comparison would say only that two arrays differ.
+   * 🔴 "NAMING IT" IS TRUE ONLY BECAUSE THE COUNT CHECK RUNS LAST, and it did not
+   * at first. `expect(exported).toHaveLength(9)` sat ABOVE the loop, so the first
+   * failure a reader saw was `expected [ …(10) ] to have a length of 9 but got 10`
+   * — the guard fired, but the constant was not named until someone bumped 9 to 10
+   * and re-ran. That is the description-wider-than-its-body class this very file
+   * exists to close, reintroduced inside the commit that closed it. The loop now
+   * runs FIRST, so an unread export is named on the first failure and the count is
+   * the backstop for the case where someone adds an export AND reads it.
    */
   it('AppListingCard reads every geometry constant the module exports', () => {
     const code = cardCode();
@@ -421,10 +427,11 @@ describe('the card geometry module', () => {
     expect(code).toContain("from '~/components/Apps/appListingCardGeometry'");
 
     const exported = Object.keys(geometry);
-    // Positive control on the enumeration itself: a module that exported nothing
-    // would make the loop below vacuous, and `toHaveLength(0)` is not something a
-    // reader would notice. 9 is typed out so ADDING an export is a deliberate act.
-    expect(exported).toHaveLength(9);
+    // Positive control on the enumeration BEFORE the loop, so a module that
+    // exported nothing cannot make the loop vacuously green. Deliberately a
+    // non-zero LOWER BOUND rather than the exact count — the exact count is the
+    // backstop below, and putting it here is what buried the named failure.
+    expect(exported.length, 'appListingCardGeometry exports nothing').toBeGreaterThan(0);
     expect(exported).toContain('LISTING_ACTION_ROW_HEIGHT_PX');
 
     for (const name of exported) {
@@ -438,6 +445,17 @@ describe('the card geometry module', () => {
           `(found ${uses} occurrence(s); an import with no use site counts as 1)`
       ).toBeGreaterThanOrEqual(2);
     }
+
+    // 🔴 THE BACKSTOP, RUN LAST ON PURPOSE. It catches the one case the loop
+    // cannot — an export ADDED and dutifully read, which should still be a
+    // deliberate act — and it is here rather than above so that the common failure
+    // (an export nobody reads) is reported by NAME first. 9 is typed out.
+    expect(
+      exported,
+      'appListingCardGeometry gained or lost an export. If you added one, the loop ' +
+        'above already proved the card reads it — bump this count deliberately, and ' +
+        'make sure AppListingCardSkeleton reads it too.'
+    ).toHaveLength(9);
   });
 
   /**
@@ -459,10 +477,25 @@ describe('the card geometry module', () => {
    * be present cannot see it. This asserts the EXACT SET, so it fails when the set
    * grows as well as when it shrinks — and it fails loudly enough to name the prop.
    *
-   * 🔴 WHAT IT STILL CANNOT SEE, stated rather than implied: it reads the row's own
-   * opening tag. Height moved by a CHILD — a taller CTA size, a bigger
-   * `triggerSize` — is invisible here and is caught by the constants' own literal
-   * pins plus the browser measurements. This closes the row's own tag, not the row.
+   * 🔴 WHAT IT STILL CANNOT SEE, stated rather than implied, and the two halves are
+   * NOT equally covered. It reads the row's own opening tag, so height moved by a
+   * CHILD is invisible to it — and only ONE of the two children is picked up
+   * elsewhere in this blocking tier:
+   *
+   *   - `triggerSize` IS covered: it reads `LISTING_ACTION_ROW_CONTROL_PX`, so the
+   *     "reads every constant" test above and that constant's literal pin both see
+   *     a change to it.
+   *   - **the CTA is NOT.** Its 36px comes from Mantine's `size="sm"` token, which
+   *     no constant in the geometry module touches. Measured: flipping the CTA to
+   *     `size="md"` leaves this whole node file green at 45/45, and only the
+   *     REPORT-ONLY browser tier reds. An earlier draft of this note said a child
+   *     change was "caught by the constants' own literal pins plus the browser
+   *     measurements", which credits the blocking tier with coverage it does not
+   *     have for half the row.
+   *
+   * `AppListingCard.browser.test.tsx` now asserts the CTA's RENDERED height as well
+   * as the trigger's, which is the real guard on that term — but it lives in the
+   * non-gating tier. Do not read this ledger as covering a CTA size bump.
    */
   it("🔴 the action row's prop set is exactly the geometry it declares", () => {
     const code = cardCode();
@@ -480,9 +513,31 @@ describe('the card geometry module', () => {
     // happened to land on.
     expect(tag.startsWith('<Group')).toBe(true);
 
+    // 🔴 NO SPREAD, ASSERTED FIRST AND SEPARATELY. A spread carries props the name
+    // scan below CANNOT see — it has no `name=` to match — so `{...{ pb: 10 }}`,
+    // or the realistic `{...(compact ? { pt: 4, pb: 0 } : {})}` for a dense
+    // variant, changes the rendered row height while leaving the set unchanged.
+    // Measured green at 45/45 against the previous version of this test. A ledger
+    // that can be walked past by writing the same prop a different way is a
+    // SPELLED guard, and this one's own comment claimed it was not.
+    expect(
+      tag,
+      `the action row's opening tag contains a spread. A spread can carry padding or ` +
+        `height props that the prop-name ledger below cannot see, so the row's 46px ` +
+        `height would change with every node assertion green. Write the props literally.`
+    ).not.toContain('{...');
+
     // The prop NAMES, in source order. `pb`, `p`, `py`, `h`, `mah`, `style` — or
     // anything else that can move a flex row's height — makes this set grow.
-    const props = [...tag.matchAll(/\n\s+([a-zA-Z-]+)=/g)].map((m) => m[1]);
+    //
+    // 🔴 SPLIT ON ANY WHITESPACE, NOT ON A LINE START. This was `/\n\s+([a-zA-Z-]+)=/`,
+    // which required a prop to BEGIN A LINE — so `mt="auto" pb={10}` on one line
+    // slipped a second prop past it, also measured green at 45/45. Prettier would
+    // reformat that onto its own line and the ledger would then red, but nothing
+    // BLOCKING runs prettier here: `.github/workflows/lint.yml`'s
+    // `Prettier (modified files, report-only)` job is `continue-on-error: true`,
+    // and only ADDED files are gating. `AppListingCard.tsx` is a modified file.
+    const props = [...tag.matchAll(/\s([a-zA-Z-]+)=/g)].map((m) => m[1]);
     expect(
       props,
       `the action row's props changed — every one of them can move the 46px row height, ` +

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -318,8 +318,9 @@ describe('isEditableListingStatus / canOwnerEditListing (owner Edit gating)', ()
  *
  * 🔴 WHAT THIS TIER CAN AND CANNOT CLAIM. It cannot measure anything — that a
  * 36px control plus 10px of padding really renders a 46px row is a claim about a
- * browser and a stylesheet, and it lives in `AppListingCard.browser.test.tsx`
- * (which is REPORT-ONLY in CI). What it CAN gate, and what actually drifts, is
+ * browser and a stylesheet, and it lives in `AppListingCard.browser.test.tsx`,
+ * which never blocks anything. What this file CAN catch — on the next `main` push,
+ * NOT on the PR; see the canonical tier note in `appListingCardGeometry.ts` — is
  * (a) the arithmetic between the constants and (b) whether the component still
  * READS them instead of re-spelling the numbers. Both are checked below.
  *
@@ -459,18 +460,27 @@ describe('the card geometry module', () => {
   });
 
   /**
-   * 🔴 THE ACTION ROW'S PROP LEDGER — the assertion that makes the BLOCKING tier
-   * able to see a row-height regression at all.
+   * 🔴 THE ACTION ROW'S PROP LEDGER — the assertion that makes the NODE tier able
+   * to see a row-height regression at all.
+   *
+   * ⚠️ "NODE", NOT "BLOCKING". An earlier draft of this docblock called it the
+   * blocking tier and priced the guard as a merge gate. It is not one on a PR —
+   * `lint.yml` makes both `unit` and `geometry` `continue-on-error` for
+   * `pull_request` events. What this buys is catching the regression on the next
+   * push to `main` instead of never. Canonical statement:
+   * `appListingCardGeometry.ts`'s header.
    *
    * 🔴 THIS EXISTS BECAUSE THE OBVIOUS GUARD IS BLIND. Row height is 46px, derived
    * as `PT + CONTROL`, and MEASURED at three container widths — in the browser
-   * project, which is REPORT-ONLY in CI. So the only tier that gates merges cannot
+   * project, which never blocks. So the only tier that ever blocks anything cannot
    * measure the row, and until this test existed a change that moved the row's
-   * height passed it completely. The worked case, produced by an audit rather than
+   * height reached `main` unremarked. The worked case, produced by an audit rather than
    * imagined: adding `pb={10}` beside the `pt` renders a 56px row while
    * `LISTING_ACTION_ROW_HEIGHT_PX` still says 46; every node assertion stayed green,
    * and PR3's skeleton would have imported 46, reserved 10px too little, and
-   * reflowed the grid on every query resolve.
+   * reflowed the grid on every query resolve. Nothing would have stopped that PR
+   * merging either way — what this adds is that `main` goes red immediately after,
+   * rather than the defect living until someone measures a card by hand.
    *
    * 🔴 IT IS A LEDGER, NOT A CONTAINMENT CHECK, and that is the whole design. The
    * hazard is a prop being ADDED, so a test that merely requires `pt` and `mih` to
@@ -480,7 +490,7 @@ describe('the card geometry module', () => {
    * 🔴 WHAT IT STILL CANNOT SEE, stated rather than implied, and the two halves are
    * NOT equally covered. It reads the row's own opening tag, so height moved by a
    * CHILD is invisible to it — and only ONE of the two children is picked up
-   * elsewhere in this blocking tier:
+   * elsewhere in this node tier:
    *
    *   - `triggerSize` IS covered: it reads `LISTING_ACTION_ROW_CONTROL_PX`, so the
    *     "reads every constant" test above and that constant's literal pin both see
@@ -488,14 +498,18 @@ describe('the card geometry module', () => {
    *   - **the CTA is NOT.** Its 36px comes from Mantine's `size="sm"` token, which
    *     no constant in the geometry module touches. Measured: flipping the CTA to
    *     `size="md"` leaves this whole node file green at 45/45, and only the
-   *     REPORT-ONLY browser tier reds. An earlier draft of this note said a child
-   *     change was "caught by the constants' own literal pins plus the browser
-   *     measurements", which credits the blocking tier with coverage it does not
-   *     have for half the row.
+   *     browser tier reds. An earlier draft of this note said a child change was
+   *     "caught by the constants' own literal pins plus the browser measurements",
+   *     which credits this file with coverage it does not have for half the row.
    *
    * `AppListingCard.browser.test.tsx` now asserts the CTA's RENDERED height as well
-   * as the trigger's, which is the real guard on that term — but it lives in the
-   * non-gating tier. Do not read this ledger as covering a CTA size bump.
+   * as the trigger's, which is the real guard on that term — but that tier never
+   * blocks, so a CTA size bump is caught by NOTHING that can stop a merge and by
+   * nothing that reddens `main` either. Do not read this ledger as covering it.
+   * Closing it properly is a ~5-line change (promote the size token into
+   * `appListingCardGeometry.ts` so the `Object.keys` loop above covers it
+   * automatically); it is deliberately deferred to a follow-up rather than done
+   * here, because it is production payload.
    */
   it("🔴 the action row's prop set is exactly the geometry it declares", () => {
     const code = cardCode();
@@ -517,15 +531,31 @@ describe('the card geometry module', () => {
     // scan below CANNOT see — it has no `name=` to match — so `{...{ pb: 10 }}`,
     // or the realistic `{...(compact ? { pt: 4, pb: 0 } : {})}` for a dense
     // variant, changes the rendered row height while leaving the set unchanged.
-    // Measured green at 45/45 against the previous version of this test. A ledger
-    // that can be walked past by writing the same prop a different way is a
-    // SPELLED guard, and this one's own comment claimed it was not.
+    // Measured green at 45/45 against the version of this test before the spread
+    // check existed. A ledger that can be walked past by writing the same prop a
+    // different way is a SPELLED guard, and this one's own comment claimed it was not.
+    //
+    // 🔴 A REGEX, NOT `toContain('{...')` — AND THE FIRST VERSION *WAS* THAT
+    // `toContain`, i.e. this guard shipped as an instance of the exact class it
+    // exists to close. JSX permits whitespace inside a spread attribute, so
+    // `{ ...{ pb: 10 } }` is valid, parses identically, and contains no literal
+    // `{...`. Measured: the spaced form left this file 45/45 GREEN while the
+    // browser tier reported 5 reds at `expected 56 to be 46` — the row really did
+    // render 10px taller and the source-reading tier saw nothing. The argument six
+    // lines below (prettier normalises the spacing, but nothing that gates a merge
+    // runs prettier) applies here word for word and was simply not applied.
+    //
+    // 🔴 `\s\{` RATHER THAN `\{`, so an OBJECT spread in a prop VALUE is not
+    // flagged: a JSX spread attribute is preceded by whitespace, while
+    // `style={{ ...base, pt: 10 }}` has its brace preceded by `=`/`{`. That form is
+    // a different hazard — it is a `style` prop, so the NAME ledger below catches
+    // it — and flagging it here would be a false positive on correct code.
     expect(
       tag,
-      `the action row's opening tag contains a spread. A spread can carry padding or ` +
+      `the action row's opening tag contains a JSX spread. A spread can carry padding or ` +
         `height props that the prop-name ledger below cannot see, so the row's 46px ` +
         `height would change with every node assertion green. Write the props literally.`
-    ).not.toContain('{...');
+    ).not.toMatch(/\s\{\s*\.\.\./);
 
     // The prop NAMES, in source order. `pb`, `p`, `py`, `h`, `mah`, `style` — or
     // anything else that can move a flex row's height — makes this set grow.
@@ -534,14 +564,16 @@ describe('the card geometry module', () => {
     // which required a prop to BEGIN A LINE — so `mt="auto" pb={10}` on one line
     // slipped a second prop past it, also measured green at 45/45. Prettier would
     // reformat that onto its own line and the ledger would then red, but nothing
-    // BLOCKING runs prettier here: `.github/workflows/lint.yml`'s
-    // `Prettier (modified files, report-only)` job is `continue-on-error: true`,
-    // and only ADDED files are gating. `AppListingCard.tsx` is a modified file.
+    // that runs before a merge runs prettier over this file:
+    // `.github/workflows/lint.yml`'s `Prettier (modified files, report-only)` job
+    // is `continue-on-error: true` and only ADDED files are checked at all —
+    // `AppListingCard.tsx` is a modified file. So the unformatted spelling can
+    // reach `main`, and the guard has to read it as written.
     const props = [...tag.matchAll(/\s([a-zA-Z-]+)=/g)].map((m) => m[1]);
     expect(
       props,
       `the action row's props changed — every one of them can move the 46px row height, ` +
-        `which the BLOCKING tier cannot measure. Update this ledger deliberately, ` +
+        `which the node tier cannot measure. Update this ledger deliberately, ` +
         `and re-measure the row in AppListingCard.browser.test.tsx.`
     ).toEqual(['mt', 'pt', 'mih', 'gap', 'wrap']);
 

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -12,6 +12,7 @@ import {
   isEditableListingStatus,
   safeExternalHref,
 } from '~/components/Apps/appListingCardView';
+import * as geometry from '~/components/Apps/appListingCardGeometry';
 import {
   LISTING_ACTION_ROW_CONTROL_PX,
   LISTING_ACTION_ROW_GAP_PX,
@@ -401,33 +402,105 @@ describe('the card geometry module', () => {
    * 🔴 THE COMPONENT READS THE MODULE — the assertion the card⇄skeleton
    * relationship actually rests on, and the one a values-only test cannot make.
    *
-   * Named constants, one per geometry fact, so a failure says WHICH one stopped
-   * being read rather than "the import list changed".
+   * 🔴 THE LIST IS THE MODULE'S OWN EXPORTS, NOT A LIST SOMEONE MAINTAINS. It used
+   * to be nine names typed out here, and it contained eight — the title said "every
+   * geometry constant" while `LISTING_ACTION_ROW_HEIGHT_PX` was silently omitted,
+   * and that constant had NO production consumer at all. The description was wider
+   * than the body, which is the shape that reads as coverage while providing none.
+   * Deriving the list from `Object.keys` makes the omission impossible to repeat AND
+   * makes the guard cover constants nobody has written yet: add one to the module
+   * without reading it in the card and this fails, naming it.
+   *
+   * 🔴 SO THE FAILURE MESSAGE NAMES THE CONSTANT, not "the import list changed" —
+   * a set comparison would say only that two arrays differ.
    */
-  it('AppListingCard reads every geometry constant from the shared module', () => {
+  it('AppListingCard reads every geometry constant the module exports', () => {
     const code = cardCode();
     // Positive control on the stripper: it did not simply eat the file.
     expect(code).toContain('export function AppListingCard');
     expect(code).toContain("from '~/components/Apps/appListingCardGeometry'");
-    for (const name of [
-      'LISTING_CARD_COVER_ASPECT_RATIO',
-      'LISTING_CARD_ICON_SIZE_PX',
-      'LISTING_CARD_TITLE_LINES',
-      'LISTING_CARD_TITLE_LINE_HEIGHT',
-      'LISTING_CARD_TITLE_MIN_HEIGHT',
-      'LISTING_ACTION_ROW_PT_PX',
-      'LISTING_ACTION_ROW_GAP_PX',
-      'LISTING_ACTION_ROW_CONTROL_PX',
-    ]) {
+
+    const exported = Object.keys(geometry);
+    // Positive control on the enumeration itself: a module that exported nothing
+    // would make the loop below vacuous, and `toHaveLength(0)` is not something a
+    // reader would notice. 9 is typed out so ADDING an export is a deliberate act.
+    expect(exported).toHaveLength(9);
+    expect(exported).toContain('LISTING_ACTION_ROW_HEIGHT_PX');
+
+    for (const name of exported) {
       // Twice: once in the import list, once at the use site. A constant that is
       // imported and never read is exactly the state a re-literalised value
       // leaves behind, and it is invisible to a bare `toContain`.
       const uses = [...code.matchAll(new RegExp(name, 'g'))].length;
       expect(
         uses,
-        `${name} is imported but never read in AppListingCard.tsx`
+        `${name} is exported by appListingCardGeometry but never read in AppListingCard.tsx ` +
+          `(found ${uses} occurrence(s); an import with no use site counts as 1)`
       ).toBeGreaterThanOrEqual(2);
     }
+  });
+
+  /**
+   * 🔴 THE ACTION ROW'S PROP LEDGER — the assertion that makes the BLOCKING tier
+   * able to see a row-height regression at all.
+   *
+   * 🔴 THIS EXISTS BECAUSE THE OBVIOUS GUARD IS BLIND. Row height is 46px, derived
+   * as `PT + CONTROL`, and MEASURED at three container widths — in the browser
+   * project, which is REPORT-ONLY in CI. So the only tier that gates merges cannot
+   * measure the row, and until this test existed a change that moved the row's
+   * height passed it completely. The worked case, produced by an audit rather than
+   * imagined: adding `pb={10}` beside the `pt` renders a 56px row while
+   * `LISTING_ACTION_ROW_HEIGHT_PX` still says 46; every node assertion stayed green,
+   * and PR3's skeleton would have imported 46, reserved 10px too little, and
+   * reflowed the grid on every query resolve.
+   *
+   * 🔴 IT IS A LEDGER, NOT A CONTAINMENT CHECK, and that is the whole design. The
+   * hazard is a prop being ADDED, so a test that merely requires `pt` and `mih` to
+   * be present cannot see it. This asserts the EXACT SET, so it fails when the set
+   * grows as well as when it shrinks — and it fails loudly enough to name the prop.
+   *
+   * 🔴 WHAT IT STILL CANNOT SEE, stated rather than implied: it reads the row's own
+   * opening tag. Height moved by a CHILD — a taller CTA size, a bigger
+   * `triggerSize` — is invisible here and is caught by the constants' own literal
+   * pins plus the browser measurements. This closes the row's own tag, not the row.
+   */
+  it("🔴 the action row's prop set is exactly the geometry it declares", () => {
+    const code = cardCode();
+    // Locate the row by `mt="auto"` — the only bottom-pinned element on the card,
+    // and the same discriminator the browser suite's `actionRow()` uses after
+    // `--group-wrap` alone proved insufficient there.
+    const at = code.indexOf('mt="auto"');
+    expect(at, 'no bottom-pinned action row found in AppListingCard.tsx').toBeGreaterThan(-1);
+    const open = code.lastIndexOf('<', at);
+    const close = code.indexOf('>', at);
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(at);
+    const tag = code.slice(open, close + 1);
+    // It really is the row's Group, not some enclosing element the index walk
+    // happened to land on.
+    expect(tag.startsWith('<Group')).toBe(true);
+
+    // The prop NAMES, in source order. `pb`, `p`, `py`, `h`, `mah`, `style` — or
+    // anything else that can move a flex row's height — makes this set grow.
+    const props = [...tag.matchAll(/\n\s+([a-zA-Z-]+)=/g)].map((m) => m[1]);
+    expect(
+      props,
+      `the action row's props changed — every one of them can move the 46px row height, ` +
+        `which the BLOCKING tier cannot measure. Update this ledger deliberately, ` +
+        `and re-measure the row in AppListingCard.browser.test.tsx.`
+    ).toEqual(['mt', 'pt', 'mih', 'gap', 'wrap']);
+
+    // …and each geometry prop reads its constant rather than a literal. `mih` is
+    // the height constant's ONLY production consumer; without it the module's
+    // "the card READS every value" claim, this file's "reads every geometry
+    // constant" test title, and the loop above were all wider than the code.
+    expect(tag).toContain('pt={LISTING_ACTION_ROW_PT_PX}');
+    expect(tag).toContain('mih={LISTING_ACTION_ROW_HEIGHT_PX}');
+    expect(tag).toContain('gap={LISTING_ACTION_ROW_GAP_PX}');
+    // Positive control on the tag slice: `mt="auto"` is a literal on purpose (it is
+    // not geometry, it is "bottom-pinned"), so a green result above is about the
+    // three constants and not about a slice that matched nothing.
+    expect(tag).toContain('mt="auto"');
   });
 
   /**
@@ -479,8 +552,8 @@ describe('the card geometry module', () => {
  * is asserted instead — the exports must be GONE, not merely unused, because a
  * surviving constant with no consumer is the shape that gets wired back in later.
  */
-describe('the retired rollup-floor constants', () => {
-  it('are no longer exported by the card view-model', () => {
+describe('the retired rollup-floor constants (four deleted, one moved)', () => {
+  it('the four DELETED ones are gone from the card view-model', () => {
     // Runtime keys, not a source grep: the module's tombstone comment names all
     // four, so a text search would report them present in a correct file.
     const exported = Object.keys(cardView);
@@ -492,11 +565,34 @@ describe('the retired rollup-floor constants', () => {
       'LISTING_ROLLUP_MIN_WIDTH_PX',
       'LISTING_ROLLUP_HIDE_BELOW_PX',
       'LISTING_ACTIONS_WIDEST_PX',
-      'LISTING_ACTION_ROW_GAP_PX',
       'listingRollupHideThreshold',
     ]) {
       expect(exported, `${gone} came back to appListingCardView`).not.toContain(gone);
     }
+  });
+
+  /**
+   * 🔴 THE FIFTH ONE MOVED, AND SAYING "DELETED" ABOUT IT WAS AN ERROR WITH A
+   * FAILURE MODE. `LISTING_ACTION_ROW_GAP_PX` still exists, under the same name, in
+   * `appListingCardGeometry`; the card reads it as the action row's `gap`. A
+   * tombstone claiming all five were deleted sends the next person who needs a row
+   * gap off to mint a SECOND copy — the two-copies drift this whole PR removes.
+   *
+   * So this asserts the MOVE as a relationship — absent from the old home AND
+   * present in the new one — rather than just the absence. An absence alone is
+   * equally true of a genuinely deleted constant, which is the reading that was
+   * wrong.
+   */
+  it('the fifth MOVED to the geometry module, and is live in both senses', () => {
+    expect(Object.keys(cardView)).not.toContain('LISTING_ACTION_ROW_GAP_PX');
+    expect(
+      Object.keys(geometry),
+      'LISTING_ACTION_ROW_GAP_PX moved to appListingCardGeometry — if it is gone from ' +
+        'there too then it was deleted after all, and the tombstone in ' +
+        'appListingCardView.ts is now wrong in the other direction'
+    ).toContain('LISTING_ACTION_ROW_GAP_PX');
+    // Same value it had at the old home — a move, not a redefinition.
+    expect(geometry.LISTING_ACTION_ROW_GAP_PX).toBe(10);
   });
 
   it('and the container query they placed is gone from the component', () => {

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -1,11 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import * as cardView from '~/components/Apps/appListingCardView';
 import {
-  LISTING_ACTIONS_WIDEST_PX,
-  LISTING_ACTION_ROW_GAP_PX,
-  LISTING_ROLLUP_HIDE_BELOW_PX,
-  LISTING_ROLLUP_MIN_WIDTH_PX,
   canOwnerEditListing,
   getListingBadge,
   getListingCta,
@@ -13,9 +10,19 @@ import {
   getOwnerEditHref,
   getRecommendLabel,
   isEditableListingStatus,
-  listingRollupHideThreshold,
   safeExternalHref,
 } from '~/components/Apps/appListingCardView';
+import {
+  LISTING_ACTION_ROW_CONTROL_PX,
+  LISTING_ACTION_ROW_GAP_PX,
+  LISTING_ACTION_ROW_HEIGHT_PX,
+  LISTING_ACTION_ROW_PT_PX,
+  LISTING_CARD_COVER_ASPECT_RATIO,
+  LISTING_CARD_ICON_SIZE_PX,
+  LISTING_CARD_TITLE_LINES,
+  LISTING_CARD_TITLE_LINE_HEIGHT,
+  LISTING_CARD_TITLE_MIN_HEIGHT,
+} from '~/components/Apps/appListingCardGeometry';
 import type {
   ListingCard,
   ListingRecommendRollup,
@@ -306,31 +313,32 @@ describe('isEditableListingStatus / canOwnerEditListing (owner Edit gating)', ()
 });
 
 /**
- * ── ACTION-ROW GEOMETRY ─────────────────────────────────────────────────────
+ * ── CARD GEOMETRY: ONE MODULE, READ NOT COPIED ──────────────────────────────
  *
- * 🔴 WHY THIS IS IN THE BLOCKING TIER AT ALL. The two numbers behind the action
- * row used to be magic values inside `AppListingCard.tsx`: one derived in a
- * comment, one read off a table, neither checkable. The component suite that
- * MEASURES them is the browser project, which is report-only in CI — so in CI
- * nothing at all held them. What CAN be gated here is the arithmetic and the
- * spelling, and both are where the drift actually happens.
+ * 🔴 WHAT THIS TIER CAN AND CANNOT CLAIM. It cannot measure anything — that a
+ * 36px control plus 10px of padding really renders a 46px row is a claim about a
+ * browser and a stylesheet, and it lives in `AppListingCard.browser.test.tsx`
+ * (which is REPORT-ONLY in CI). What it CAN gate, and what actually drifts, is
+ * (a) the arithmetic between the constants and (b) whether the component still
+ * READS them instead of re-spelling the numbers. Both are checked below.
  *
- * 🔴 WHAT THIS CANNOT SEE, stated rather than implied: it does not measure
- * anything. `LISTING_ACTIONS_WIDEST_PX` is a MEASUREMENT, and if the action
- * cluster's real width changes (a different trigger size, a longer CTA label)
- * this file stays green while the threshold silently stops matching reality.
- * That claim is made by `AppListingCard.browser.test.tsx`'s "AT the threshold"
- * test, which asserts all three terms against a real render.
+ * 🔴 THE RELATIONSHIP BEING PROTECTED IS CARD ⇄ SKELETON. `AppListingCardSkeleton`
+ * (a later PR) must reserve exactly the geometry the real card occupies or the
+ * grid reflows when the query resolves. A skeleton importing this module is
+ * enough — provided the CARD imports it too. The moment a literal creeps back
+ * into the component, the skeleton is pinned to a number the card no longer uses
+ * and nothing here or there goes red. That is what the source assertions are for.
  */
-describe('the recommend-rollup floor and the container-query threshold', () => {
+describe('the card geometry module', () => {
   const CARD_MODULE = path.resolve(__dirname, '../AppListingCard.tsx');
   const cardSource = () => fs.readFileSync(CARD_MODULE, 'utf8');
   /**
    * 🔴 EVERY ASSERTION BELOW IS A CLAIM ABOUT CODE, AND PROSE IS NOT CODE. This
-   * file's comments deliberately quote the constants they explain — the note
-   * recording that `@[360px]` was deleted contains the literal `@[360px]` — so a
-   * raw `not.toContain` reads a correct file as an offence. Measured: that exact
-   * false positive is why this stripper exists.
+   * component's comments deliberately quote the constructs they explain — the
+   * note recording that `@[264px]` was deleted contains the literal `@[264px]` —
+   * so a raw `not.toContain` reads a correct file as an offence. Measured: that
+   * exact false positive is why this stripper exists (it long predates this
+   * change, and every retirement below re-earns it).
    */
   const cardCode = () =>
     cardSource()
@@ -338,90 +346,180 @@ describe('the recommend-rollup floor and the container-query threshold', () => {
       .replace(/\/\*[\s\S]*?\*\//g, ' ')
       .replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-  /** The single JSX opening tag that carries `substr`, as source text. */
-  function enclosingTag(code: string, substr: string): string {
-    const at = code.indexOf(substr);
-    expect(at, `"${substr}" not found in AppListingCard.tsx`).toBeGreaterThan(-1);
-    const open = code.lastIndexOf('<', at);
-    const close = code.indexOf('>', at);
-    expect(open).toBeGreaterThan(-1);
-    expect(close).toBeGreaterThan(open);
-    return code.slice(open, close + 1);
-  }
-
-  it('the threshold is the floor plus the gap plus the action cluster, rounded up to even', () => {
-    expect(LISTING_ROLLUP_HIDE_BELOW_PX).toBe(
-      LISTING_ACTIONS_WIDEST_PX + LISTING_ACTION_ROW_GAP_PX + LISTING_ROLLUP_MIN_WIDTH_PX
-    );
-    expect(LISTING_ROLLUP_HIDE_BELOW_PX).toBe(264);
+  /**
+   * 🔴 THE HUMAN-FACING NUMBERS, PINNED AS LITERALS — deliberately NOT derived
+   * from the constants they describe.
+   *
+   * A test that reads the value out of the module and asserts it equals itself
+   * cannot fail, and this file has a standing rule against exactly that (see the
+   * badge-label note above). These are the figures a designer, a skeleton and the
+   * browser suite all quote, so a change to any of them has to be typed twice —
+   * which is the whole friction budget this test is spending.
+   */
+  it('pins the geometry a skeleton has to reproduce', () => {
+    expect(LISTING_CARD_COVER_ASPECT_RATIO).toBe('16 / 9');
+    expect(LISTING_CARD_ICON_SIZE_PX).toBe(40);
+    expect(LISTING_CARD_TITLE_LINES).toBe(2);
+    expect(LISTING_CARD_TITLE_LINE_HEIGHT).toBe(1.2);
+    expect(LISTING_ACTION_ROW_PT_PX).toBe(10);
+    expect(LISTING_ACTION_ROW_GAP_PX).toBe(10);
+    expect(LISTING_ACTION_ROW_CONTROL_PX).toBe(36);
+    expect(LISTING_ACTION_ROW_HEIGHT_PX).toBe(46);
   });
 
-  it('rounding is UP and to an even number — never down', () => {
-    // Rounding down would place the threshold BELOW the width at which the floor
-    // first fits, i.e. it would render a row that overflows. Two odd sums and an
-    // already-even one, so the branch is exercised rather than asserted about.
-    expect(listingRollupHideThreshold(183, 10, 70)).toBe(264);
-    expect(listingRollupHideThreshold(184, 11, 70)).toBe(266);
-    expect(listingRollupHideThreshold(184, 10, 70)).toBe(264);
-    for (const [a, g, f] of [
-      [183, 10, 70],
-      [184, 11, 70],
-      [100, 7, 33],
-    ] as const) {
-      expect(listingRollupHideThreshold(a, g, f)).toBeGreaterThanOrEqual(a + g + f);
-      expect(listingRollupHideThreshold(a, g, f) % 2).toBe(0);
+  /**
+   * The one derivation in the module: the row height is its padding plus its
+   * control, never a third number someone measured once. Asserted as arithmetic
+   * AND against the literal above, so neither a wrong sum nor a right sum of
+   * wrong terms survives.
+   */
+  it('derives the action-row height from its padding and its control', () => {
+    expect(LISTING_ACTION_ROW_HEIGHT_PX).toBe(
+      LISTING_ACTION_ROW_PT_PX + LISTING_ACTION_ROW_CONTROL_PX
+    );
+  });
+
+  /**
+   * 🔴 PARSED, NOT RE-CONSTRUCTED. Writing
+   * ``expect(MIN_HEIGHT).toBe(`calc(${LINES} * ${LH}em)`)`` restates the
+   * implementation and passes for every possible value of both terms. Pulling the
+   * two numbers back OUT of the rendered string is an independent read: it fails
+   * if the template ever stops carrying the constants, or carries them in the
+   * wrong slots.
+   */
+  it('the reserved title height carries BOTH constants, in em', () => {
+    const m = /^calc\((\d+(?:\.\d+)?) \* (\d+(?:\.\d+)?)em\)$/.exec(LISTING_CARD_TITLE_MIN_HEIGHT);
+    expect(m, `unparseable min-height: ${LISTING_CARD_TITLE_MIN_HEIGHT}`).not.toBeNull();
+    expect(Number(m![1])).toBe(LISTING_CARD_TITLE_LINES);
+    expect(Number(m![2])).toBe(LISTING_CARD_TITLE_LINE_HEIGHT);
+    // `em`, not `px`: it must resolve against the title's OWN font-size, so the
+    // reservation stays correct if the title's `size` ever moves.
+    expect(LISTING_CARD_TITLE_MIN_HEIGHT.endsWith('em)')).toBe(true);
+  });
+
+  /**
+   * 🔴 THE COMPONENT READS THE MODULE — the assertion the card⇄skeleton
+   * relationship actually rests on, and the one a values-only test cannot make.
+   *
+   * Named constants, one per geometry fact, so a failure says WHICH one stopped
+   * being read rather than "the import list changed".
+   */
+  it('AppListingCard reads every geometry constant from the shared module', () => {
+    const code = cardCode();
+    // Positive control on the stripper: it did not simply eat the file.
+    expect(code).toContain('export function AppListingCard');
+    expect(code).toContain("from '~/components/Apps/appListingCardGeometry'");
+    for (const name of [
+      'LISTING_CARD_COVER_ASPECT_RATIO',
+      'LISTING_CARD_ICON_SIZE_PX',
+      'LISTING_CARD_TITLE_LINES',
+      'LISTING_CARD_TITLE_LINE_HEIGHT',
+      'LISTING_CARD_TITLE_MIN_HEIGHT',
+      'LISTING_ACTION_ROW_PT_PX',
+      'LISTING_ACTION_ROW_GAP_PX',
+      'LISTING_ACTION_ROW_CONTROL_PX',
+    ]) {
+      // Twice: once in the import list, once at the use site. A constant that is
+      // imported and never read is exactly the state a re-literalised value
+      // leaves behind, and it is invisible to a bare `toContain`.
+      const uses = [...code.matchAll(new RegExp(name, 'g'))].length;
+      expect(
+        uses,
+        `${name} is imported but never read in AppListingCard.tsx`
+      ).toBeGreaterThanOrEqual(2);
     }
   });
 
   /**
-   * 🔴 THE SPELLING GUARD. A Tailwind arbitrary variant cannot read a JS constant,
-   * so `@[264px]` in the component and `LISTING_ROLLUP_HIDE_BELOW_PX` here are an
-   * unavoidable duplication. What is avoidable is one moving without the other,
-   * which is exactly the drift this asserts.
+   * 🔴 THE MIRROR IMAGE, AND THE HALF THAT ACTUALLY CATCHES A REGRESSION. "It
+   * imports the module" stays true when someone adds a literal BESIDE the
+   * constant — which is how a card and a skeleton drift while every import
+   * assertion is green. These are the exact literals the constants replaced.
    */
-  it("the component's container query spells the derived threshold", () => {
-    const code = cardSource();
-    const queries = [...code.matchAll(/@\[(\d+)px\]:/g)].map((m) => Number(m[1]));
-    // Positive control: the pattern really does match something, so an equal-to
-    // result is a match and not an empty sweep.
-    expect(queries.length).toBeGreaterThan(0);
-    expect([...new Set(queries)]).toEqual([LISTING_ROLLUP_HIDE_BELOW_PX]);
+  it('AppListingCard spells none of those numbers itself', () => {
+    const code = cardCode();
+    for (const [literal, why] of [
+      ["aspectRatio: '16 / 9'", 'cover ratio'],
+      ['size={40}', 'app-icon avatar'],
+      ['triggerSize={36}', 'menu trigger / row-height contract'],
+      ['pt="xs"', 'action-row padding'],
+      ['line-clamp-2', 'reserved title lines'],
+      ['lh={1.2}', 'title line-height'],
+    ] as const) {
+      expect(code, `${why}: re-literalised as \`${literal}\``).not.toContain(literal);
+    }
+    // Positive control: the stripper leaves OTHER literals alone, so the six
+    // absences above are about these constructs and not about an empty read.
+    expect(code).toContain('line-clamp-3'); // the tagline's clamp, deliberately not geometry
+  });
+});
+
+/**
+ * ── THE RETIRED ACTION-ROW GEOMETRY ─────────────────────────────────────────
+ *
+ * 🔴 WHAT USED TO BE HERE, AND WHY ITS GUARD IS GONE RATHER THAN RELAXED.
+ *
+ * `appListingCardView` exported `LISTING_ROLLUP_MIN_WIDTH_PX` (70),
+ * `LISTING_ACTIONS_WIDEST_PX` (184), `listingRollupHideThreshold()` and
+ * `LISTING_ROLLUP_HIDE_BELOW_PX` (264 = 184 + 10 + 70), and this file asserted
+ * that `AppListingCard.tsx`'s `@[264px]:flex` Tailwind class spelled the same
+ * number — a Tailwind arbitrary variant cannot read a JS constant, so the
+ * duplication was unavoidable and the DRIFT was what got gated.
+ *
+ * All of it existed for ONE reason: the recommend rollup shared the action row
+ * with the CTA, so it needed an enforced floor, a breakpoint below which it was
+ * hidden rather than crushed, and a derived threshold to place that breakpoint.
+ * The rollup now lives in the card's meta block. There is no shared row, no
+ * floor, no container query and no threshold — so the drift guard is not
+ * weakened, it has no subject.
+ *
+ * 🔴 LEAVING IT ASSERTING THE OLD COUPLING WOULD HAVE BEEN THE WORST OUTCOME: a
+ * green test claiming a relationship that no longer exists reads as coverage and
+ * stops anyone looking. Deleting it silently is the second worst. So the deletion
+ * is asserted instead — the exports must be GONE, not merely unused, because a
+ * surviving constant with no consumer is the shape that gets wired back in later.
+ */
+describe('the retired rollup-floor constants', () => {
+  it('are no longer exported by the card view-model', () => {
+    // Runtime keys, not a source grep: the module's tombstone comment names all
+    // four, so a text search would report them present in a correct file.
+    const exported = Object.keys(cardView);
+    // Positive control — the module still exports the things it is FOR, so an
+    // empty `exported` cannot satisfy the absences below.
+    expect(exported).toContain('getRecommendLabel');
+    expect(exported).toContain('getListingCta');
+    for (const gone of [
+      'LISTING_ROLLUP_MIN_WIDTH_PX',
+      'LISTING_ROLLUP_HIDE_BELOW_PX',
+      'LISTING_ACTIONS_WIDEST_PX',
+      'LISTING_ACTION_ROW_GAP_PX',
+      'listingRollupHideThreshold',
+    ]) {
+      expect(exported, `${gone} came back to appListingCardView`).not.toContain(gone);
+    }
   });
 
-  /**
-   * 🔴 THE `@[360px]` BREAKPOINT IS GONE AND MUST STAY GONE. It existed only to
-   * choose between a text Edit button and an icon-only one; both are now a single
-   * `Menu.Item` behind a fixed-width `⋮` trigger, so it had nothing left to decide.
-   * The assertion above already forbids it by enumerating the whole set — this one
-   * names it, so a reader of a future failure knows which constant died and why.
-   */
-  it('the retired dual-Edit breakpoint is not reintroduced', () => {
-    // Positive control on the stripper: the comment that NAMES the retired
-    // breakpoint is still in the file, so a green result here is about code and not
-    // about an empty read.
-    expect(cardSource()).toContain('@[360px]');
-    expect(cardCode()).not.toContain('@[360px]');
-    // …and the stripper did not simply eat the file.
-    expect(cardCode()).toContain('@[264px]:flex');
-  });
-
-  /**
-   * 🔴 THE FLOOR IS ENFORCED, NOT MERELY DOCUMENTED. The rollup used to carry
-   * `minWidth: 0`; the whole point of this change is that the number is now a
-   * layout constraint. A revert to 0 is the mutation that makes the growing CTA
-   * starve the rollup at every width, and it would leave every arithmetic
-   * assertion above perfectly green.
-   */
-  it('the component applies the floor as the rollup min-width', () => {
-    // 🔴 SCOPED TO THE ROLLUP'S OWN TAG, not to the file. Four other elements on
-    // this card legitimately carry `minWidth: 0` (the creator chip, the title
-    // stack, the action cluster) — a file-wide `not.toContain` fails against
-    // correct code, which it did on the first run of this assertion.
-    const tag = enclosingTag(cardCode(), "'hidden @[264px]:flex'");
-    expect(tag).toContain('minWidth: LISTING_ROLLUP_MIN_WIDTH_PX');
-    expect(tag).not.toMatch(/minWidth:\s*0\b/);
-    // The tag really is the rollup's Group, not some enclosing element the index
-    // walk happened to land on.
-    expect(tag.startsWith('<Group')).toBe(true);
+  it('and the container query they placed is gone from the component', () => {
+    const CARD_MODULE = path.resolve(__dirname, '../AppListingCard.tsx');
+    const source = fs.readFileSync(CARD_MODULE, 'utf8');
+    const code = source
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, ' ')
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    // Positive control on the stripper: the comments that NAME the retired
+    // breakpoints are still in the file, so a green result here is about code.
+    expect(source).toContain('@[264px]');
+    expect(source).toContain('@[360px]');
+    // 🔴 NO arbitrary container variant survives — enumerated rather than named,
+    // so a NEW one cannot slip in under a check that only forbids the old two.
+    expect([...code.matchAll(/@\[(\d+)px\]:/g)].map((m) => m[1])).toEqual([]);
+    // …and the card no longer declares itself a query container at all, because
+    // nothing on it is size-queried any more.
+    expect(code).not.toContain('@container');
+    // Positive control: the OTHER classes on that same element are untouched, so
+    // the two absences are about the container query and not about a card whose
+    // className was emptied.
+    expect(code).toContain('rounded-md');
+    expect(code).toContain('h-full');
   });
 });

--- a/src/components/Apps/__tests__/appListingMenuSurface.test.ts
+++ b/src/components/Apps/__tests__/appListingMenuSurface.test.ts
@@ -88,18 +88,35 @@ describe('the listing menu surface policy', () => {
         .replace(/\/\*[\s\S]*?\*\//g, ' ')
         .replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-    it('AppListingCard renders the menu with surface="card", and reads the same for layout', () => {
+    it('AppListingCard renders the menu with surface="card", and lays out the same either way', () => {
       const card = code('../AppListingCard.tsx');
       expect(card).toContain('surface="card"');
       expect(card).not.toContain('surface="detail"');
-      // 🔴 THE HOOK CALL TOO, NOT ONLY THE COMPONENT. The card asks
-      // `useAppListingActionsMenuVisible` whether the trigger takes up row space, and
-      // that answer must come from the SAME surface — a card that rendered
-      // `surface="card"` while laying out for `'detail'` reserves 36px for a control
-      // it does not render, which is a silent 46px-row geometry bug.
-      expect(card).toMatch(/useAppListingActionsMenuVisible\(\s*menuTarget,\s*'card'/);
-      // Positive control on the stripper: it did not simply eat the file.
+      // 🔴 THIS USED TO ALSO REQUIRE A `useAppListingActionsMenuVisible(menuTarget,
+      // 'card')` CALL, AND THAT REQUIREMENT IS RETIRED RATHER THAN RELAXED. The card
+      // asked the hook whether the trigger would take up row space, because the answer
+      // decided a container query on the recommend rollup: a card laying out for the
+      // wrong surface reserved 36px for a control it did not render. The rollup has
+      // moved to the meta block, the query is gone, and the card's layout is now
+      // IDENTICAL whether or not a `⋮` renders — so the coupling the old assertion
+      // protected has no shape left to take.
+      //
+      // 🔴 SO THE ABSENCE IS ASSERTED INSTEAD, because "the card does not branch its
+      // layout on menu visibility" is the property that replaced it. Re-introducing
+      // that predicate is how the deleted apparatus comes back — and it would come
+      // back silently, since nothing else reads it.
+      expect(
+        card,
+        'AppListingCard branches its layout on menu visibility again — the rollup lives in the meta block now, so it should not need to'
+      ).not.toContain('useAppListingActionsMenuVisible');
+      // Positive control on the stripper: it did not simply eat the file, AND the
+      // surface prop above is still reaching a real render.
       expect(card).toContain('AppListingActionsMenu');
+      // …and the hook itself is still exported for the surfaces that DO need it, so
+      // the absence above is a fact about this card, not about a deleted module.
+      expect(code('../AppListingActionsMenu.tsx')).toContain(
+        'export function useAppListingActionsMenuVisible'
+      );
     });
 
     it('AppListingDetailBody renders the menu with surface="detail"', () => {

--- a/src/components/Apps/__tests__/appListingMenuSurface.test.ts
+++ b/src/components/Apps/__tests__/appListingMenuSurface.test.ts
@@ -112,10 +112,20 @@ describe('the listing menu surface policy', () => {
       // Positive control on the stripper: it did not simply eat the file, AND the
       // surface prop above is still reaching a real render.
       expect(card).toContain('AppListingActionsMenu');
-      // …and the hook itself is still exported for the surfaces that DO need it, so
-      // the absence above is a fact about this card, not about a deleted module.
+      // 🔴 AND THE HOOK IS GONE ENTIRELY — asserted so the absence above cannot be
+      // satisfied by a card that merely stopped calling something still sitting
+      // there exported. It had exactly one consumer, this card, for exactly one
+      // reason (laying out around the trigger), and that reason died with the
+      // rollup's container query. An earlier draft of this test asserted the
+      // OPPOSITE — "still exported for the surfaces that DO need it" — which was
+      // false when written: there are none. That framing would also have turned a
+      // future cleanup of dead code into a red BLOCKING test for no correctness
+      // reason, which is the failure mode this assertion is inverted to avoid.
+      expect(code('../AppListingActionsMenu.tsx')).not.toContain('useAppListingActionsMenuVisible');
+      // Positive control on that read: the module is still the one that owns the
+      // menu, so the absence is about the hook and not about an unreadable file.
       expect(code('../AppListingActionsMenu.tsx')).toContain(
-        'export function useAppListingActionsMenuVisible'
+        'export function AppListingActionsMenu'
       );
     });
 

--- a/src/components/Apps/__tests__/appListingMenuSurface.test.ts
+++ b/src/components/Apps/__tests__/appListingMenuSurface.test.ts
@@ -121,7 +121,14 @@ describe('the listing menu surface policy', () => {
       // false when written: there are none. That framing would also have turned a
       // future cleanup of dead code into a red BLOCKING test for no correctness
       // reason, which is the failure mode this assertion is inverted to avoid.
-      expect(code('../AppListingActionsMenu.tsx')).not.toContain('useAppListingActionsMenuVisible');
+      expect(
+        code('../AppListingActionsMenu.tsx'),
+        'useAppListingActionsMenuVisible is back in AppListingActionsMenu.tsx. It was deleted ' +
+          'because it had exactly one consumer (this card, to lay out around the trigger) and ' +
+          "that reason died with the rollup's container query. If a NEW surface genuinely " +
+          'needs it, re-add it AND change this assertion to name that surface — do not leave ' +
+          'an exported hook with no consumer, which is how the deleted apparatus comes back.'
+      ).not.toContain('useAppListingActionsMenuVisible');
       // Positive control on that read: the module is still the one that owns the
       // menu, so the absence is about the hook and not about an unreadable file.
       expect(code('../AppListingActionsMenu.tsx')).toContain(

--- a/src/components/Apps/appListingCardGeometry.ts
+++ b/src/components/Apps/appListingCardGeometry.ts
@@ -16,7 +16,10 @@
  * the card's own header and a test titled "reads every geometry constant" all said
  * otherwise (the test's list enumerated 8 of these 9). `appListingCardView.test.ts`
  * now derives that list from THIS module's `Object.keys`, so an export added below
- * and not read by the card fails the BLOCKING tier, naming it.
+ * and not read by the card fails the BLOCKING tier, naming it. (Its exact-count
+ * backstop runs AFTER that loop, deliberately — ordered first, as it was at
+ * first, the failure a reader saw was a length mismatch and the constant went
+ * unnamed.)
  *
  * 🔴 REACT-FREE AND PURE, deliberately: the node `unit` project is the BLOCKING
  * tier here (the browser component suites are report-only), so a module with no

--- a/src/components/Apps/appListingCardGeometry.ts
+++ b/src/components/Apps/appListingCardGeometry.ts
@@ -16,14 +16,32 @@
  * the card's own header and a test titled "reads every geometry constant" all said
  * otherwise (the test's list enumerated 8 of these 9). `appListingCardView.test.ts`
  * now derives that list from THIS module's `Object.keys`, so an export added below
- * and not read by the card fails the BLOCKING tier, naming it. (Its exact-count
+ * and not read by the card fails the node tier, naming it. (Its exact-count
  * backstop runs AFTER that loop, deliberately — ordered first, as it was at
  * first, the failure a reader saw was a length mismatch and the constant went
  * unnamed.)
  *
- * 🔴 REACT-FREE AND PURE, deliberately: the node `unit` project is the BLOCKING
- * tier here (the browser component suites are report-only), so a module with no
- * DOM dependency is one the blocking tier can assert about. The values that can
+ * 🔴 WHAT "THE NODE TIER" ACTUALLY BUYS — READ THIS BEFORE QUOTING A SEVERITY.
+ * THE CANONICAL STATEMENT FOR THIS COMPONENT; every other comment that mentions a
+ * tier defers to it. The node `unit` project **blocks pushes to `main` and is
+ * REPORT-ONLY on a pull request**: `.github/workflows/lint.yml` puts
+ * `continue-on-error: ${{ github.event_name == 'pull_request' }}` at JOB level on
+ * `unit` (line 405) and on `geometry` (line 830). The browser `component` project
+ * never blocks anything.
+ *
+ * So on a PR the two tiers are **equally non-gating**, and the difference is WHEN
+ * a regression is caught: node catches it on the next `main` push — after the
+ * merge — while browser never does. Three comments in this arc, and a severity
+ * call in the PR body, were written on the premise that node gates a PR and
+ * browser does not. It does not. The guards built on that premise are still worth
+ * having (catching a defect one push later beats never), but do not price them as
+ * merge gates. `lint.yml:377` warns about the same trap from the other side: with
+ * `continue-on-error` the JOB conclusion is `success` while the step underneath is
+ * `failure`, so a branch-protection rule naming "Unit tests (N)" would be inert.
+ *
+ * 🔴 REACT-FREE AND PURE, deliberately: the node `unit` project is the one that can
+ * run without a DOM (and, per the note above, the one that at least blocks `main`),
+ * so a module with no DOM dependency is one it can assert about. The values that can
  * only be MEASURED — that a 36px control plus 10px of padding really renders a
  * 46px row in the app's own stylesheet cascade — are pinned in
  * `AppListingCard.browser.test.tsx`, which renders the card for real.

--- a/src/components/Apps/appListingCardGeometry.ts
+++ b/src/components/Apps/appListingCardGeometry.ts
@@ -10,6 +10,14 @@
  * skeleton importing the same module is enough to make the two agree by
  * construction instead of by review.
  *
+ * 🔴 "READS EVERY VALUE" IS A CHECKED CLAIM, NOT A PROMISE — and it was FALSE when
+ * first written. `LISTING_ACTION_ROW_HEIGHT_PX` was derived here and measured in
+ * the browser suite but consumed by nothing in production, while this paragraph,
+ * the card's own header and a test titled "reads every geometry constant" all said
+ * otherwise (the test's list enumerated 8 of these 9). `appListingCardView.test.ts`
+ * now derives that list from THIS module's `Object.keys`, so an export added below
+ * and not read by the card fails the BLOCKING tier, naming it.
+ *
  * 🔴 REACT-FREE AND PURE, deliberately: the node `unit` project is the BLOCKING
  * tier here (the browser component suites are report-only), so a module with no
  * DOM dependency is one the blocking tier can assert about. The values that can

--- a/src/components/Apps/appListingCardGeometry.ts
+++ b/src/components/Apps/appListingCardGeometry.ts
@@ -1,0 +1,111 @@
+/**
+ * App Store Listings (W13) — the store CARD's GEOMETRY, in one place.
+ *
+ * 🔴 WHY THIS MODULE EXISTS: A SKELETON AND ITS CARD MUST NOT BE ABLE TO DRIFT.
+ * `AppListingCardSkeleton` (a later PR) has to reserve exactly the geometry the
+ * real card occupies — cover ratio, icon size, reserved title lines, action-row
+ * height — or the grid visibly reflows the moment the query resolves. Two
+ * hand-copied numbers is the failure mode; one imported constant is the fix.
+ * `AppListingCard.tsx` READS every value below rather than spelling it, so the
+ * skeleton importing the same module is enough to make the two agree by
+ * construction instead of by review.
+ *
+ * 🔴 REACT-FREE AND PURE, deliberately: the node `unit` project is the BLOCKING
+ * tier here (the browser component suites are report-only), so a module with no
+ * DOM dependency is one the blocking tier can assert about. The values that can
+ * only be MEASURED — that a 36px control plus 10px of padding really renders a
+ * 46px row in the app's own stylesheet cascade — are pinned in
+ * `AppListingCard.browser.test.tsx`, which renders the card for real.
+ *
+ * These are geometry ONLY. Kind/CTA/label logic stays in `appListingCardView.ts`.
+ */
+
+// ── Cover ────────────────────────────────────────────────────────────────────
+
+/**
+ * The cover's aspect ratio, as a CSS `aspect-ratio` value.
+ *
+ * A RATIO rather than a fixed height: it scales with the grid column (so widening
+ * the grid actually makes the art bigger) while still deriving the box height from
+ * the already-known column width BEFORE any image bytes arrive — which is what
+ * keeps the card CLS-free. A skeleton reserving a fixed pixel height instead would
+ * be correct at exactly one column width.
+ */
+export const LISTING_CARD_COVER_ASPECT_RATIO = '16 / 9';
+
+// ── The meta block (icon + title + creator + rollup) ─────────────────────────
+
+/** The publisher app-icon avatar's edge length, in px (square). */
+export const LISTING_CARD_ICON_SIZE_PX = 40;
+
+/**
+ * How many lines of the title are RESERVED — and, being the same number, how many
+ * the title clamps to.
+ *
+ * 🔴 THE TWO ARE ONE NUMBER ON PURPOSE. Reserving fewer lines than the clamp
+ * allows lets a long title push the creator line down; reserving more leaves dead
+ * space under every short one. Because the reservation is a `min-height` and the
+ * clamp is a `-webkit-line-clamp`, the rendered title box is exactly this many
+ * lines tall for EVERY listing — which is what puts the creator chip at the same
+ * y on every card in a row. Splitting these into two literals is precisely the
+ * drift this module exists to prevent.
+ */
+export const LISTING_CARD_TITLE_LINES = 2;
+
+/**
+ * The title's `line-height`, unitless.
+ *
+ * 🔴 LOAD-BEARING, and easy to delete by accident: without it the title inherits
+ * `--mantine-line-height-xl` (1.65), which at the title's 20px is 33px per line
+ * rather than 24px — a ~18px card-height swing across the reserved two lines.
+ */
+export const LISTING_CARD_TITLE_LINE_HEIGHT = 1.2;
+
+/**
+ * The title box's reserved height, as a CSS length.
+ *
+ * `em`, not `px`: it resolves against the title's OWN font-size, so this stays
+ * correct if the title's `size` ever moves without anyone remembering to re-derive
+ * a pixel figure here.
+ */
+export const LISTING_CARD_TITLE_MIN_HEIGHT = `calc(${LISTING_CARD_TITLE_LINES} * ${LISTING_CARD_TITLE_LINE_HEIGHT}em)`;
+
+// ── The action row ───────────────────────────────────────────────────────────
+
+/**
+ * Every control in the action row is this tall AND this wide — the `sm` CTA button
+ * and the square `⋮` menu trigger alike.
+ *
+ * 🔴 IT IS THE ROW-HEIGHT CONTRACT, not a style choice. Handing the menu a
+ * different `triggerSize` changes the row height, and the row lives in an `h-full`
+ * grid row, so that propagates to every card in that row across the whole store.
+ */
+export const LISTING_ACTION_ROW_CONTROL_PX = 36;
+
+/**
+ * The action row's top padding, in px. Equal to Mantine `xs` spacing
+ * (`0.625rem` at the 16px root this app ships), passed as a number so the row
+ * READS this constant instead of spelling `pt="xs"` and leaving the arithmetic
+ * below unverifiable.
+ */
+export const LISTING_ACTION_ROW_PT_PX = 10;
+
+/**
+ * The gap between the CTA and the `⋮` trigger, in px — Mantine `gap="xs"`.
+ *
+ * This is what the CTA's width is the row MINUS: with the recommend rollup moved
+ * up into the meta block the row holds only those two children, so
+ * `cta = row − trigger − gap`.
+ */
+export const LISTING_ACTION_ROW_GAP_PX = 10;
+
+/**
+ * The action row's total height, in px — DERIVED, not measured-and-retyped.
+ *
+ * 🔴 46px AND IT MUST STAY 46px. `pt` (10) + a 36px control. The row sits in an
+ * `h-full` grid row, so a taller control here grows every card in that row across
+ * the store — which is why the CTA grows HORIZONTALLY rather than up Mantine's
+ * size scale (the next step, `md`, is 42px tall).
+ */
+export const LISTING_ACTION_ROW_HEIGHT_PX =
+  LISTING_ACTION_ROW_PT_PX + LISTING_ACTION_ROW_CONTROL_PX;

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -220,97 +220,27 @@ export function getOwnerEditHref(
   return `/apps/submit?edit=${encodeURIComponent(listingId)}`;
 }
 
-// ── Action-row geometry (S7) ────────────────────────────────────────────────
+// ── Action-row geometry (S7) — RETIRED, and this note is the tombstone ──────
 //
-// 🔴 THESE ARE DERIVED NUMBERS, AND THEY LIVE HERE SO THE DERIVATION IS MACHINE-
-// CHECKED. They used to be two magic values inside `AppListingCard.tsx` — one
-// stated as arithmetic in a comment, one read off a table — with nothing pinning
-// either to the measurements it came from. `__tests__/appListingCardView.test.ts`
-// (blocking) now re-runs the arithmetic and asserts the component's Tailwind
-// container-query class spells the same number.
-
-/**
- * The recommend rollup's FLOOR, in px — the width below which it stops saying
- * anything and becomes debris.
- *
- * 13px thumb glyph + 4px `Group gap={4}` + ~53px of 12px text ≈ 9 characters,
- * which is enough for "No reviews…" / "91% recom…" to read as a phrase. Below it
- * the surviving glyphs carry no information while still occupying the slot, which
- * reads as a rendering bug.
- *
- * 🔴 THIS IS NOW AN ENFORCED `min-width` ON THE ROLLUP, NOT AN IMPLICIT ONE. The
- * rollup used to carry `minWidth: 0`, i.e. "shrink to nothing", and the floor
- * existed only as the arithmetic behind the container-query threshold — so at any
- * width the query did not cover, the rollup could still be crushed. Making the CTA
- * grow into the free space is exactly the change that would have made that worse
- * (a `flex-grow` with no counterweight starves the rollup at EVERY width), so the
- * floor is stated as a constraint the layout engine enforces rather than as a
- * number a comment claims.
- */
-export const LISTING_ROLLUP_MIN_WIDTH_PX = 70;
-
-/**
- * The gap between the two sides of the action row, in px — Mantine `gap="xs"`
- * (`0.625rem` at the 16px root this app ships).
- */
-export const LISTING_ACTION_ROW_GAP_PX = 10;
-
-/**
- * The action cluster's NATURAL width at its WIDEST, in px, MEASURED (not modelled)
- * in the component suite at the store's real geometry: a fixed 36px `⋮` trigger +
- * the row's 10px `gap="xs"` + the widest CTA ("View details", 137.9px with its
- * glyph) = 183.9, i.e. 184.
- *
- * 🔴 NATURAL, not rendered. The CTA now grows into the row's free space, so the
- * cluster's RENDERED width is larger than this wherever there is slack (measured:
- * 356.3 at a 462px container). The threshold below is about the DEFICIT case,
- * where there is no growth and the two coincide — so this is the number the
- * arithmetic needs.
- *
- * 🔴 RE-MEASURED after the overflow-menu change (this PR). The previous value was
- * also 184 — for a different reason that happens to coincide: the control the
- * menu replaced was an icon-only Edit `ActionIcon` at the same `size={36}`. The
- * coincidence is worth naming, because "the number did not move" is also the
- * shape of a measurement nobody took.
- *
- * 🔴 THE NUMBER IS ABOUT A CARD THAT HAS A `⋮`; WHICH VIEWERS THOSE ARE IS A
- * SEPARATE FACT, AND IT MOVED WITHOUT THE NUMBER MOVING. The card does not offer
- * "Leave a review" or "Report" (`appListingMenuSurface.ts`), so the viewers whose
- * cluster is 184 rather than 137.9 are exactly the OWNER and a MODERATOR — not,
- * as this constant's arithmetic briefly implied on the way here, every signed-in
- * shopper. Nothing derived below changes; the population does, and a stale
- * population is the half of a derived number that gets quoted instead of
- * re-measured.
- */
-export const LISTING_ACTIONS_WIDEST_PX = 184;
-
-/**
- * The container width below which the rollup is HIDDEN rather than clamped at its
- * floor, in px.
- *
- * Rounded UP to an even number so the Tailwind arbitrary variant reads cleanly;
- * rounding up is the safe direction (hide slightly earlier, never render an
- * overflowing row).
- */
-export function listingRollupHideThreshold(
-  actionsWidthPx: number,
-  gapPx: number,
-  rollupFloorPx: number
-): number {
-  const exact = actionsWidthPx + gapPx + rollupFloorPx;
-  return Math.ceil(exact / 2) * 2;
-}
-
-/**
- * The live threshold: 184 + 10 + 70 = 264.
- *
- * 🔴 MUST EQUAL the number in `AppListingCard.tsx`'s `@[264px]:flex` class. A
- * Tailwind arbitrary variant cannot read a JS constant, so the duplication is
- * unavoidable; what is avoidable is it going unnoticed, which is why the blocking
- * suite reads the component source and compares the two.
- */
-export const LISTING_ROLLUP_HIDE_BELOW_PX = listingRollupHideThreshold(
-  LISTING_ACTIONS_WIDEST_PX,
-  LISTING_ACTION_ROW_GAP_PX,
-  LISTING_ROLLUP_MIN_WIDTH_PX
-);
+// 🔴 FIVE EXPORTS LIVED HERE AND ALL FIVE ARE DELETED, not moved:
+// `LISTING_ROLLUP_MIN_WIDTH_PX` (70), `LISTING_ROLLUP_HIDE_BELOW_PX` (264),
+// `LISTING_ACTIONS_WIDEST_PX` (184), `listingRollupHideThreshold()` and the
+// spelling guard in `__tests__/appListingCardView.test.ts` that asserted the
+// component's `@[264px]` Tailwind class agreed with the JS constant.
+//
+// Every one of them existed to let the recommend rollup and the CTA share the
+// action row: a floor so a growing CTA could not starve the rollup, a container
+// query hiding the rollup where even the floor did not fit, a measured
+// action-cluster width to derive that threshold from, and a drift guard because a
+// Tailwind arbitrary variant cannot read a JS constant. Moving the rollup up into
+// the card's meta block removed the competition, and with it the entire
+// apparatus. Deleting a derived number and its guard TOGETHER is the point — a
+// surviving constant with no consumer is the shape that gets "fixed" back into
+// use later.
+//
+// The geometry this card DOES still have — cover ratio, icon size, reserved title
+// lines, action-row height / padding / gap / control size — lives in
+// `~/components/Apps/appListingCardGeometry.ts`, which exists so the (later)
+// `AppListingCardSkeleton` reserves the same numbers by import rather than by
+// copy. This module is back to being the pure kind/CTA/label view-model its
+// header describes.

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -222,11 +222,27 @@ export function getOwnerEditHref(
 
 // ── Action-row geometry (S7) — RETIRED, and this note is the tombstone ──────
 //
-// 🔴 FIVE EXPORTS LIVED HERE AND ALL FIVE ARE DELETED, not moved:
-// `LISTING_ROLLUP_MIN_WIDTH_PX` (70), `LISTING_ROLLUP_HIDE_BELOW_PX` (264),
-// `LISTING_ACTIONS_WIDEST_PX` (184), `listingRollupHideThreshold()` and the
-// spelling guard in `__tests__/appListingCardView.test.ts` that asserted the
-// component's `@[264px]` Tailwind class agreed with the JS constant.
+// 🔴 FIVE EXPORTS LIVED HERE. FOUR ARE DELETED; ONE MOVED. The distinction is the
+// whole point of writing this down, and an earlier draft of this note got it wrong
+// — it said "all five are deleted" and then listed four names plus a TEST, which is
+// not an export at all.
+//
+//   DELETED, no replacement anywhere:
+//     `LISTING_ROLLUP_MIN_WIDTH_PX` (70) — the rollup's enforced min-width floor
+//     `LISTING_ACTIONS_WIDEST_PX`   (184) — the measured widest action cluster
+//     `LISTING_ROLLUP_HIDE_BELOW_PX`(264) — the derived container-query threshold
+//     `listingRollupHideThreshold()`      — the function that derived it
+//
+//   MOVED, same name, new home:
+//     `LISTING_ACTION_ROW_GAP_PX`   (10) → `~/components/Apps/appListingCardGeometry.ts`,
+//     where the card reads it as the action row's `gap`. It is still live geometry;
+//     it just is not rollup-threshold arithmetic any more. 🔴 IF YOU CAME HERE
+//     LOOKING FOR THE ROW GAP, IMPORT IT FROM THERE — do NOT mint a second copy,
+//     which is exactly the two-copies drift the geometry module exists to remove.
+//
+// Also deleted, though it was never an export: the spelling guard in
+// `__tests__/appListingCardView.test.ts` that asserted the component's `@[264px]`
+// Tailwind class agreed with the JS constant.
 //
 // Every one of them existed to let the recommend rollup and the CTA share the
 // action row: a floor so a growing CTA could not starve the rollup, a container


### PR DESCRIPTION
## What changed

The App Listing store card's action row held two competing children — the recommend rollup and the CTA cluster — under `justify="space-between"`. Most of the card's geometry existed to arbitrate between them. Moving the rollup up into the meta block removes the competition, and the whole apparatus with it.

**1. The recommend rollup moved into the meta block.** It is now a dimmed `xs` line beneath the `CreatorChip`, inside the title `Stack`. It still renders unconditionally ("No reviews yet" when there are none), so card height does not depend on review state inside an `h-full` grid row.

**2. The CTA fills the action row.** The row now holds only the CTA and the 36px `⋮` trigger, so `flexGrow: 1` on the button gives it `row − 36 − 10`. Row height stays exactly **46px**. The CTA grows horizontally rather than up Mantine's size scale (the next step, `md`, is 42px tall, and a taller control propagates to every card in that `h-full` grid row store-wide).

**3. The title reserves two lines.** `min-height: calc(2 * 1.2em)` alongside a two-line clamp, so the creator chip lands at the same `y` on every card in a row regardless of title length. The title now routes through `TruncatedText`, which gained an opt-in multi-line clamp mode — that also buys the hover fallback the creator chip already had.

**4. New `src/components/Apps/appListingCardGeometry.ts`** is the single source for cover ratio (`16 / 9`), icon size (40), reserved title lines (2) + line-height (1.2), and action-row height (46) / `pt` (10) / gap (10) / control size (36). `AppListingCard.tsx` reads all nine — the row's `mih` is the height constant's consumer — and the blocking tier enumerates that list from the module's own `Object.keys` rather than a hand-typed one. The later `AppListingCardSkeleton` must import the same module.

> ⚠️ **In `f4dc965a97` this sentence said "reads every one" and it was FALSE**: `LISTING_ACTION_ROW_HEIGHT_PX` had zero production consumers, and the test asserting the claim enumerated 8 of 9. Round-1 audit finding 🟡1; fixed in `d4b2bbe69b`. See "Round-1 audit fixes" below.

### Deleted, not relaxed

**Four deleted** from `appListingCardView`: `LISTING_ROLLUP_MIN_WIDTH_PX`, `LISTING_ACTIONS_WIDEST_PX`, `LISTING_ROLLUP_HIDE_BELOW_PX` and `listingRollupHideThreshold()`. **One moved**: `LISTING_ACTION_ROW_GAP_PX` (10) now lives in `appListingCardGeometry` under the same name and is read as the action row's `gap` — it is still live geometry, just not threshold arithmetic. *(An earlier draft of this list, the tombstone comment and the test all said "all five deleted", which would have sent the next person needing a row gap off to mint a second copy — the exact drift this PR removes. Round-1 audit finding 🟡2, fixed in `d4b2bbe69b`.)* Also deleted: the `hidden @[264px]:flex` class; the card's now-unread `@container` declaration and the `hasMenu` predicate that was its only consumer; the nested action-cluster `Group`; `justify="space-between"`; the `marginLeft: 'auto'` that was its second mechanism; and the node-tier drift guard asserting the Tailwind class spelled the same number as the JS constant.

Their subject no longer exists — a green test asserting a relationship that is gone reads as coverage while providing none. The node tier now asserts the **deletion** instead (runtime `Object.keys` on the module, plus a "no arbitrary container variant survives" enumeration on the component source).

### Comments updated because they stopped being true

| Where | Was asserting | Now |
|---|---|---|
| `AppListingCard.tsx` header | the rollup is part of the action row | states the rollup lives in the meta block and lists the three pieces of apparatus that died with the move; adds "geometry is READ from `appListingCardGeometry`, do not re-literalise" |
| `AppListingCard.tsx` — the `@container` note | "`@container` makes THIS card the query basis for the recommend-rollup floor breakpoint" | records that `@container` and `hasMenu` are both gone, and why (one consumer, now relocated) |
| `AppListingCard.tsx` — the action-row block | a measured 4-row rollup/threshold table, the "nowrap protects space-between alignment" reasoning, `pt="xs"` + `size={36}` as literals | the row is `[CTA, ⋮]`; the three deletions with a reason each; row height DERIVED from `PT + CONTROL` rather than asserted |
| `AppListingCard.tsx` — the rollup's own note | "this is the flexible side… only down to a floor, and the floor is now enforced" | replaced by a meta-block note: unconditional, full block width, nothing to compete with |
| `AppListingCard.tsx` — the CTA note | "`flexGrow: 1` on the CLUSTER rather than the button, because the button is not a direct child" | the button IS the direct child; adds that `flexShrink` is deliberately left at default now (a CHANGE — the old `flexShrink: 0` made the row overflow the card below ~218px container) |
| `AppListingCard.tsx` — the `⋮` note | "`size={36}` IS THE ROW-HEIGHT CONTRACT"; "GEOMETRY CONSEQUENCE: [owner, moderator] get the wider action row" | `triggerSize` reads the constant; the trigger's only remaining consequence is a CTA 46px narrower — it no longer decides whether the rollup fits |
| `appListingCardView.ts` — "Action-row geometry (S7)" | five exported constants + their derivations | a tombstone naming all five, why each existed, and where the surviving geometry went |
| `__tests__/appListingCardView.test.ts` | "the threshold is the floor plus the gap plus the action cluster"; "the component's container query spells the derived threshold" | two new describes: the geometry module's contract, and the retired constants' absence |
| `AppListingCard.browser.test.tsx` | two measured tables of rollup widths at 248/264/282/462, the "184 natural cluster" reasoning, the `actionRow()` three-part walk | one table of CTA/row-height at 248/282/462, written as arithmetic; `actionRow()` walks one level and guards that it landed on the row |

## Round-1 audit fixes (`d4b2bbe69b`)

Round-1 returned no 🔴 and three 🟡. All three were the same shape — **a description claiming wider coverage than its body delivered** — and all three are fixed in this PR.

### 🟡1 — `LISTING_ACTION_ROW_HEIGHT_PX` had zero production consumers

Four places said otherwise: the geometry module header, the card header, this PR body §4, and a test literally titled *"AppListingCard reads **every** geometry constant"* whose loop enumerated **8 of the 9**.

The auditor produced the defect that gap admits: adding `pb={10}` beside the row's `pt` renders a **56px** row while the constant still says 46, and **the blocking node tier stayed entirely green** because it measures nothing. PR3's skeleton would import 46, reserve 10px too little, and reflow the grid — in the one tier CI does not gate on.

Three changes:
- The row carries `mih={LISTING_ACTION_ROW_HEIGHT_PX}`. Not test-driven decoration: it holds the row at 46 if a control ever renders *shorter*, and it costs nothing today (the row is already exactly 46, `box-sizing: border-box`).
- The "reads every constant" loop is **derived from the module's own `Object.keys`**, not a hand-typed list. The omission cannot repeat, and an export added later without a consumer fails the blocking tier **naming the constant**.
- A new blocking test asserts the action row tag's **whole prop ledger** — the exact set `['mt','pt','mih','gap','wrap']`, so it fails when the set **grows**, which is the direction a padding prop moves it.

**Acceptance condition, measured:** `pb={10}` now reds the **BLOCKING** tier — see mutation **M5** below.

### 🟡2 — the tombstone was factually wrong, and the test repeated it

`appListingCardView.ts` said *"FIVE EXPORTS LIVED HERE AND ALL FIVE ARE DELETED, not moved"*, then listed four names plus **a test**, which is not an export. The real fifth was `LISTING_ACTION_ROW_GAP_PX`, and it **moved** — same name, now in `appListingCardGeometry`, read by the card as the row `gap`. The test's describe, its loop message (*"came back to appListingCardView"*) and this PR body all repeated the error.

Fixed in all four places. The move is now asserted as a **relationship** — absent from the old home **and** present in the new one **at the same value (10)** — rather than as an absence, which is equally true of a genuinely deleted constant. That is the reading that was wrong.

### 🟡3 — `useAppListingActionsMenuVisible` was dead; **branch taken: DELETE**

I took the delete branch. Before doing so I checked for the consumers the escape hatch names — a barrel re-export, a dynamic import, a consumer outside `src` — by grepping every `.ts/.tsx/.mjs/.js/.json/.md` in the worktree outside `node_modules` and `.git`. **Three files matched, all known**: the hook's own module, `AppListingCard.tsx` (a comment), and `appListingMenuSurface.test.ts`. No barrel, no dynamic import, nothing outside `src`.

So the hook is deleted, together with:
- `AppListingActionsMenu.tsx:243-248` — its JSDoc describing the container-query mechanism this PR removed;
- `AppListingActionsMenu.tsx:165-175` — *"the card needs the ANSWER before it can lay out its action row"* and *"safe to call TWICE in one render (the card does)"*. The surviving reasons for `useAppListingMenuGates` being written once (a four-term disjunction should not be duplicated; it is state-free) are kept, and the retirement is recorded there rather than dropped;
- `AppListingCard.tsx:327` — *"still lives in `AppListingActionsMenu` for the surfaces that do"*.

The test's assertion is **inverted**: it now requires the hook to be **absent**, with a positive control that the module still exports `AppListingActionsMenu`. Two reasons — a card that merely stopped *calling* something still sitting there exported should not satisfy "the layout no longer branches on menu visibility", and the old framing would have turned a future dead-code cleanup into a red **blocking** test for no correctness reason.

### Also from round 1

- **Under-reported mutant, corrected.** I reported M3 (`PT_PX` 10→14) as 3 browser reds; the auditor measured 5. Re-measured here: **5**. The two I missed are the `with no ⋮, the CTA is the whole row` arms, which also assert the 46px height. Every mutation row below now states the tier-by-tier count I actually observed.
- **The `flexShrink` change** was measured by the auditor at containers 248/184/168/152/136/118 with no overflow at any width — strictly better than the old `flexShrink: 0`, which overflowed the card below ~218. My "not verified" note on it is retired.
- **Left alone deliberately** (flagged by the auditor as not-findings): the browser test comment calling 462 "the wide single-column `base` case" when it is the 4-column `xl` case — no reader decision turns on it, and it was not worth a round.
- **Known second-order cost, not addressed here:** the title now mounts a `Tooltip` + `ResizeObserver` per card (~24 extra on a 24-tile grid). Unmeasured; deliberately not optimised in this PR.

### Environment note for the next runner

`direnv exec <dir>` loads the env but **does not chdir**. Run the browser tier as `direnv exec "$WT" env -C "$WT" npx vitest ...` — otherwise Tailwind's `content: ['./src/**/*.{ts,tsx}']` resolves against whatever tree you are standing in, `rounded-md` is never emitted, and the S4 chrome test fails with `expected '0px' to be '6px'`. That cost the auditor a false finding. (My round-1 runs used `(cd "$WT" && direnv exec ...)`, which chdir'd via the subshell, so they were not affected; every run in this round used the `env -C` form.)


## Findings I hit and fixed during the work (round 0)

**A finding from the battery, fixed rather than reported as a pass.** The rollup mutation's *first* run turned that test red for the **wrong reason**: the test's render barrier was `page.getByText('91% recommend (100)')`, which is strict-mode, so a rollup rendered in two places resolved to two nodes and **threw at the barrier** before either assertion ran. Both rollup tests now barrier on the unique CTA link, and the mutation was re-run to confirm the intended `toBeNull()` message fires.

**A second finding — from CI, not from me.** The first push failed `Unit tests (2)`: `appListingMenuSurface.test.ts` required `AppListingCard.tsx` to call `useAppListingActionsMenuVisible(menuTarget, 'card')`, on the premise that the card had to *lay out* for the same surface it *rendered* — that answer drove the rollup's container query, so laying out for the wrong surface reserved 36px for a control that did not render. That premise died with the query. I had only run the one node file I edited; the guard lives in a different file. Fixed in `76445943df`: the requirement is retired and its **absence** asserted in its place (a re-introduced layout predicate is how the deleted apparatus comes back, silently), with a positive control that the hook is still exported for the surfaces that do need it. I then ran all 8 node test files that read any of the changed sources — 167 passed.

**A third finding, from the base comparison.** `actionRow()` originally identified the row by `--group-wrap: nowrap`. The *retired* action cluster was also a `wrap="nowrap"` `Group`, so against base code the helper landed on the cluster — and at container 248 the cluster happens to fill the row, so the CTA-fills assertion went **green against pre-change code**. `actionRow()` now also asserts `marginTop === 'auto'`, which only the real (bottom-pinned) row carries. That took the base-red count from 10 to 13.


## Round-2 audit fixes (`17c7ed3421`)

Round 2 confirmed all three round-1 findings genuinely closed, and returned two 🟡 + two 🟢. **Zero behaviour change in this commit** — all four production files are byte-identical to `d4b2bbe69b`; the only non-test edit is a four-line comment correction.

### 🟡 F2 — a coverage regression my own round-1 fix introduced

The auditor's round-1 instruction offered "assert it against the rendered row **or** set the row's `mih`". I chose `mih`. It satisfies the letter — it is a genuine read — but it **floors the row at 46 regardless of what its child renders**, so it masked the case it was supposed to expose.

The hole underneath: `AppListingCard.browser.test.tsx` asserted the **trigger**'s rendered 36px and **nothing asserted the CTA's**. The two CTA-size tests pin the CSS *variable string* `var(--button-height-sm)`, which survives a theme override of that token, a border or padding on the button, or swapping `Button` for another element entirely. So the **control** half of `LISTING_ACTION_ROW_HEIGHT_PX` = `pt` (10) + a 36px **control** had no rendered evidence at all.

`mih` **stays** — it is a real read and a correct floor. The `with no ⋮` arms now also assert the CTA's own rendered height, with a message that names why.

| tree | CTA `size="sm"` → `"xs"` | reds |
|---|---|---|
| round-1 head (`mih`, no CTA assertion) | auditor measured | **2** — the two size-token tests only |
| round-1 head **minus** `mih` | auditor measured | **4** — plus both `with no ⋮` arms, `expected 40 to be 46` |
| **this head** (`mih` **and** the CTA assertion) | **M9, measured here** | **4** — the two size-token tests plus both arms on the new assertion's own message |

Acceptance condition met: back to 4, without giving up the floor. **M11** is the control — the same mutation with `mih` removed gives the *same* 4 browser reds, i.e. the new assertion does not depend on the mask being absent (it also reds the node tier twice, because removing `mih` breaks both the read-check and the ledger).

### 🟡 F1 — the prop ledger was a SPELLED guard, and its own comment said it was not

The regex was `/\n\s+([a-zA-Z-]+)=/g` — a prop had to **begin a line** *and* be `name=`. Two shapes that change the rendered row height walked straight past it, **both measured green at 45/45**:

- **Spread** — `{...{ pb: 10 }}` on its own line. No `=`, so the set never grows. Realistic shape: `{...(compact ? { pt: 4, pb: 0 } : {})}` for a dense variant.
- **Same line** — `mt="auto" pb={10}`. The `pb=` is not preceded by `\n\s+`.

Prettier reformats the second, after which the ledger reds — but **nothing blocking runs prettier**: `.github/workflows/lint.yml`'s `Prettier (modified files, report-only)` job carries `continue-on-error: true`, and only *added* files gate. `AppListingCard.tsx` is a modified file.

The comment claimed `pb`, `p`, `py`, `h`, `mah`, `style` "or anything else that can move a flex row's height" grows the set. `style` does; a spread does not. Fixed by splitting on **any whitespace** and asserting the tag contains **no `{...`** — as a *separate* assertion with its own message, so the two holes fail distinguishably (**M7** and **M8** below).

### 🟢 F3 — "fails, naming it" was false for the failure a reader actually sees

`expect(exported).toHaveLength(9)` ran **before** the loop, so adding an export reported `expected [ …(10) ] to have a length of 9 but got 10`. The guard fired and the 8-of-9 omission genuinely could not recur — but the constant was not named until someone bumped 9 to 10 and re-ran, while two comments promised naming on the first failure.

That is the description-wider-than-its-body class the *predecessor commit existed to close*, reintroduced inside it. The loop now runs first and the exact count is the backstop, last, with its own message; a non-zero **lower bound** stays above the loop so it cannot go vacuous.

### 🟢 F4 — the ledger's stated limitation over-credited the literal pins

It said a child-driven height change "is caught by the constants' own literal pins plus the browser measurements". Half true, and the halves are not symmetric:

- **`triggerSize` IS covered** by the blocking tier — it reads `LISTING_ACTION_ROW_CONTROL_PX`.
- **the CTA is NOT.** Its 36px comes from Mantine's `size="sm"` token, which no constant in the module touches. **Measured (M10): CTA `size="md"` leaves the node file green at 45/45**; only the report-only tier reds (7).

Reworded to state both halves separately, so nobody reads the ledger as covering a CTA size bump. F2's new assertion narrows this but does not close it — the blocking tier still cannot see a CTA size change.

### Cheap items

- **Two numbers quoted as measurements that nothing asserted, now pinned** (browser tier, +2 tests, both pass — so both figures are real):
  - **Mantine `md` is 42px.** Quoted three times, and the load-bearing reason the CTA grows *horizontally* rather than up the size scale (42 + a 10px `pt` is 52; the row must stay 46). Asserted by rendering `sm` and `md` buttons and measuring — not by reading the token, which would miss a padding or border change.
  - **`--mantine-line-height-xl` is 1.65 — 33px at the title's 20px.** The reason `lh` on the title is called load-bearing; the two reserved lines would be 66px rather than 48, the "~18px swing" the comment quotes. Both the bare and pinned cases are measured, and the 18 is asserted as arithmetic.
- **PR body M5 row corrected** — it said "browser: three ×" while its own count column said 5. Re-measured: **5** — three carrying the named message, two bare `expected 56 to be 46` in the `with no ⋮` arms. Identical to the under-report I corrected for M3 one line above it, which is the part worth noticing.
- **`appListingMenuSurface.test.ts`** absence assertion had no message argument, unlike its sibling. It now explains what was deleted, why, and what to do if a new surface genuinely needs the hook.

### Not touched, as instructed

`appsPageWidths.ts`, `appListingGrid.ts`, `AppListingsMarketplaceBody*` — owned by the concurrent PR.


## Round-3 audit fixes (`15acc30140`) — final round

Round 3 returned **safe to merge** + two 🟡, both one-line/prose. **Zero executable payload**, verified rather than asserted: with comments stripped and whitespace normalised, `AppListingCard.tsx` and `appListingCardGeometry.ts` are **identical** to `17c7ed3421`.

### 🟡 F-A — the no-spread guard was walkable by ONE SPACE

`.not.toContain('{...')`. JSX permits whitespace inside a spread attribute, so `{ ...{ pb: 10 } }` is valid, parses identically, and contains no literal `{...`. **The guard shipped as an instance of the exact class it exists to close** — and the argument that justified widening the prop regex six lines below (*prettier normalises the spacing, but nothing that runs before a merge runs prettier over a modified file*) applies here word for word and simply was not applied.

Now `/\s\{\s*\.\.\./`. The `\s` prefix also fixes a false positive the auditor spotted: `style={{ ...base, pt: 10 }}` is an **object** spread inside a prop value, not a **JSX** spread attribute, and it is properly the NAME ledger's business (it introduces a `style` prop).

| mutation | node | browser |
|---|---|---|
| **M12** `{ ...{ pb: 10 } }` — spaced spread | **1 red**, this guard's own message: *"the action row's opening tag contains a JSX spread…"* | 5 red, `expected 56 to be 46` |
| *(same, against the pre-fix guard — auditor measured)* | **0 red / 45 green** | 5 red |
| **M13** `style={{ ...{}, minWidth: 0 }}` — false-positive control | **1 red on the NAME LEDGER**, not the spread guard | 56 green (it does not change height) |

### 🟡 F-B — "the BLOCKING tier" does not block a pull request

I verified this in `.github/workflows/lint.yml` myself before editing: `continue-on-error: ${{ github.event_name == 'pull_request' }}` sits at **job** level on `unit` (line **405**) and on `geometry` (line **830**).

So **on a PR the node tier is exactly as non-gating as the browser tier.** The difference is *when*: node reddens `main` on the next push — after the merge — and browser never blocks at all. Four places in this arc were written on the premise that node gates a PR and browser does not, plus a 🔴 severity call in this body.

Fixed as prose. The **canonical statement now lives once**, in `appListingCardGeometry.ts`'s header, and every other site defers to it rather than restating a contrast. The guards built on the wrong premise are still worth having — catching a defect one push later beats never — they are just not merge gates.

`lint.yml:377` warns about the same trap from the other side: with `continue-on-error` the **job** conclusion is `success` while the step underneath is `failure`, so a branch-protection rule naming "Unit tests (N)" would be **inert**.

### The tautology at line 656 — and why "wire it up" was the wrong fix

`expect(2 * 33 - 2 * 24).toBe(18)` was a tautology over two hardcoded literals, presented by its comment as the arithmetic guard.

I first rewired it to the two rendered line-heights. That is honest arithmetic and **still wrong**: if the two measurements above it pass, the swing is *arithmetically determined*, so the assertion can only fail in worlds where an earlier one already has. **M14** (title line-height 1.2 → 1.4) proved it — the `24px` pin dies first and the swing line never executes. That is an **unreachable guard**: green for the life of the file, red only as a second copy of someone else's failure.

Taken the delete option instead: the ~18px figure is stated in prose as fully determined by the two measurements, with both wrong versions recorded, and replaced by a reachable pin on the multiplier. **M14 now kills 4 browser tests** including both line-height pins.

### Deferred, deliberately, not done here

**Close the CTA-size residual by promoting the size token into the geometry module** — `LISTING_ACTION_ROW_CONTROL_SIZE = 'sm'`, read by the card, after which the existing `Object.keys` loop covers it automatically. ~5 lines, genuinely structural rather than a spelled guard.

Not done because **it is production payload and payload restarts the audit ladder**, and because F-B lowers what it buys: today a CTA size bump is caught by the browser tier only, which never blocks; promoting the token would move it into the node tier, which blocks `main` pushes but not PRs. The coordinator is filing it. Costed here so the follow-up carries its own justification.


## Mutation table — full re-run at `15acc30140`, both tiers

Each mutation applied to production code, **both** tiers run, restored from a `cp` snapshot before *and* after; checksums verified against that snapshot at the end. Clean controls (node 45/45, browser 56/56) ran before and after the battery. **Observed, not expected.**

| # | Mutation | node | browser | the intended guard's own message |
|---|---|---|---|---|
| M1 | remove the title `min-height` | **1** / 44 | **1** / 55 | node: *"LISTING_CARD_TITLE_MIN_HEIGHT is exported by appListingCardGeometry but never read…"* · browser: `expected 24 to be close to 48` |
| M2 | drop `flexGrow` on the CTA | 0 / 45 | **5** / 51 | *"the CTA must fill the action row minus the 36px trigger and the 10px gap — asserted at container 248 AND container 462…"* |
| M3 | row-height constant (`PT_PX` 10 → 14) | **1** / 44 | **5** / 51 | node `expected 14 to be 10`; browser 3 × *"must stay 46px at container N: expected 50 to be 46"* + the 2 `with no ⋮` arms |
| M4 | rollup back in the action row | 0 / 45 | **9** / 47 | *"the recommend rollup is back in the action row: expected \<div\> to be null"* |
| M5 | `pb={10}` beside the row's `pt` | **1** / 44 | **5** / 51 | the prop ledger's set message |
| M6 | re-introduce the layout predicate | **1** / 44 | 54 / 2 (crash) | *"AppListingCard branches its layout on menu visibility again…"* |
| M7 | `{...{ pb: 10 }}` — spread, no space | **1** / 44 | **5** / 51 | the spread guard's own message |
| M8 | `mt="auto" pb={10}` — same line | **1** / 44 | **5** / 51 | the prop ledger's set message |
| M9 | CTA `size="sm"` → `"xs"` | 0 / 45 | **4** / 52 | 2 × size-token + 2 × *"the CTA must render at the same 36px as the ⋮ trigger…"* |
| M10 | CTA `size="sm"` → `"md"` | **0 / 45 — green** | **7** / 49 | the node tier cannot see a CTA size bump (this is F4's measurement) |
| M11 | M9 with `mih` removed | **2** / 43 | **4** / 52 | node: read-check + ledger; browser: the **same 4** as M9 |
| **M12** | **`{ ...{ pb: 10 } }` — SPACED spread (F-A)** | **1** / 44 | **5** / 51 | *"the action row's opening tag contains a JSX spread. A spread can carry padding or height props that the prop-name ledger below cannot see…"* |
| **M13** | **`style={{ ...{}, minWidth: 0 }}` — false-positive control** | **1** / 44 — on the **NAME LEDGER**, not the spread guard | **56 green** | the narrowing works: an object spread in a prop value is the ledger's business, and this mutation does not change height |
| **M14** | **title line-height 1.2 → 1.4** | **1** / 44 (`expected 1.4 to be 1.2`) | **4** / 52 | `expected '28px' to be '24px'`, `'line-height: 1.2'` missing, 2 × `expected 56 to be 48` |

**M13 is a false-positive control, not a height mutation** — its browser column is *green by design*. It exists to show the spread guard does not fire on an object spread in a prop value, and that the NAME ledger catches that case instead.

**M6's browser column is a crash, not an assertion.** Incidental positive control: exactly **2** tests still pass under it, and they are the two quoted-number probes, which render `Button`/`Text` rather than the card — so the crash is confined to the card and the harness is provably alive.

## Regression matrix — re-measured at `15acc30140`

Base `ec49115e55d7c85722ec6223ec342c36df59c9d4` (`origin/main`) · HEAD `15acc30140790aa6e9731bd63885f5beb8fdcc81`

| Tier | red at `ec49115e55` | green at `15acc30140` |
|---|---|---|
| node `unit` | **7 failed** / 38 passed | **45 passed** |
| browser `component` | **13 failed** / 43 passed | **56 passed** |

Both red sets identical to the previous round, re-measured rather than carried forward.

## Verification at `15acc30140`

| Check | Result |
|---|---|
| node — the two changed suites | **45 passed** |
| node — all 8 files reading any changed source | **169 passed** |
| browser — `AppListingCard.browser.test.tsx` | **56 passed** |
| browser — 3 sibling suites | **143 passed** (one file needed a re-run after an import-fetch flake; 118 + 25) |
| `node scripts/typecheck.mjs` | **0 errors, rc 0** |
| `eslint` / `prettier --check` | clean |

## Payload vs scaffolding, round 4

`git diff --numstat 17c7ed3421..15acc30140 -- src`:

| | lines | files |
|---|---|---|
| payload | 35 | `AppListingCard.tsx` (7), `appListingCardGeometry.ts` (28) |
| scaffolding | 100 | the browser spec (22), `appListingCardView.test.ts` (78) |

**All 35 payload lines are comment prose, and that is verified rather than eyeballed**: stripping `{/* */}`, `/* */` and `//` comments and normalising whitespace, both production files are byte-identical to `17c7ed3421`. So the executable payload of this round is **zero**.

Trend: round 2 **120 / 146** → round 3 **5 / 202** (payload = one comment) → round 4 **35 / 100** (payload = all comment). **Two consecutive rounds of zero executable payload.**


## Integration with #4615

**Measured on merged tree `449b599e30`** = `origin/main` `ec49115e55` + #4615 `a261c8287d` + #4616 **`15acc30140`**.

> 🔴 **The stamped SHA is `15acc30140`, not this PR's current head.** #4616 has moved once since the test-merge, to `6c27a99a2e` — the comment-only fix described below, whose own diff is provably outside any executable line. So the integration result is a claim about `15acc30140`, and it carries to head only because the delta is comment prose. Saying "integration verified" under a SHA that was never in the merged tree is the same over-claim this PR has spent four rounds removing from its own guards, so the constituents are written out rather than implied.

The merged tree was verified by the coordinator (not by me — I did not run it) and is **green**: `unit` 25,246 passed / 33 skipped; `component` 2,380 passed across 214 files, **twice consecutively**; `geometry` 19 passed over two warm runs; typecheck 0 errors under `src/`; eslint and prettier clean. The two PRs share **zero files** — the merge was exit-0 with an empty intersection, so the entire risk surface was semantic rather than textual.

The seam was measured, not assumed. #4615's `AppListingsMarketplaceBody.stretch.geometry.test.tsx` renders this rewritten card inside the real grid **for the first time** and passes at 1376 (4 columns) and 2450 (5 columns) — and the verifier mutated `.grid` to `align-items: start` on the merged tree, watched that guard go **red against this card** with a ~73px unpinning, then restored and verified the tree byte-clean. So the green is live, not vacuous: a guard nobody has watched fail proves nothing, and this one was watched failing on the exact seam. The `container-type` and `@[264px]` query this PR deletes leave nothing resolving against the wrong container — swept across all non-test sources with a positive control.

### One finding, and it is the class neither adversarial audit could reach

Each audit ran against **one branch**, so neither could see a claim that is **true here and false on the merged tree**. This file justified its fixture widths twice by deriving them from a viewport:

> "248 is the TRUE 1200px-viewport geometry (container 1200 → grid column 296 → card 280 → row 248)"

Both halves die on merge. `column 296` names Mantine `<Grid.Col>` arithmetic that #4615 deletes outright, and a 1200 viewport does not yield four columns at all once a scrollbar is reserved — #4615's own geometry test asserts **three**.

**No number is wrong and nothing fails.** 280/248 is still the real four-column card at the 1168px grid rung, and 494/462 still brackets the merged store's widest card. What was wrong is the sentence a maintainer reads to decide whether these fixtures still represent production — and a stale justification is how correct fixtures get "fixed".

The subtlety: rewording it to be true *after* the merge would make it false *here*, where `Grid.Col` still exists and a 1200 viewport really does give four columns. So the widths are now stated in terms that hold in **both** worlds — anchored to the **grid rung** rather than to a viewport or to any grid implementation's column maths. The viewport→grid step is the store's business; the card's contract is *"at these widths, this geometry"*, and that survives whichever grid sits above it.

Two superlatives went with it — *"the store's tightest real geometry"* and *"the widest"* — with the reason recorded rather than silently deleted: which rung is narrowest or widest is decided by the store's grid, not by this component, and it has changed.

**Comment-only, verified not asserted:** with comments stripped and whitespace normalised the spec is identical to `15acc30140`, and no diff line falls outside a comment. No assertion, fixture value or test logic moved. Browser 56/56, node 45/45, lint + prettier clean.

## What I did NOT verify

- 🟡 **Nothing exercises `limit: 48` against the rewritten card.** #4615 doubles the store's page size 24 → 48, so twice as many of these cards mount per page — and every spec on **both** PRs uses small fixtures (this one renders at most two cards at once). This is not a defect anyone found; it is an **untested combination the merge creates**, and it should be visible to whoever merges rather than discovered later. The per-card cost this PR adds is known and small but non-zero: one `Tooltip` + one `ResizeObserver` per title (see the second-order note below), which at 48 cards is 48 of each rather than 24.

- **No visual check.** I never rendered the card in a browser a human looked at. Every geometry claim is a `getBoundingClientRect` / `getComputedStyle` measurement inside vitest browser mode with the app's real stylesheet cascade — which is what the pre-existing suite does, and it is not the same as looking at it. In particular: whether the rollup **reads well** as a dimmed line under the creator chip, and whether the wider CTA looks right in a real grid, are aesthetic judgements no assertion here makes.
- **The browser tier is REPORT-ONLY in CI.** Everything in the mutation table and most of the regression matrix lives there. The blocking node tier can only see the arithmetic and whether the component still reads the constants.
- **Tekton is the typecheck authority, not my local run.** My local `typecheck.mjs` was clean, but only after `git submodule update --init event-engine-common`— worktrees do not populate submodules, and without it 10 pre-existing errors appear in `image.service.ts` that have nothing to do with this change.
- **`ThemeProvider`'s CSS-variable overrides are not loaded in the component project**, so no colour/contrast claim is made — `--mantine-color-white` resolves to `rgb(255,255,255)` there and `#fefefe` in the app. Geometry (px) is trustworthy; brand colours are not.
- **No skeleton exists yet.** The card↔skeleton drift this module prevents is asserted only on the card's half. Nothing today proves the later `AppListingCardSkeleton` will import it — that guard belongs in the PR that adds it.
- ~~**`flexShrink` on the CTA is a behaviour change I could not observe at a real store width.**~~ **RETIRED** — the round-1 auditor measured it at containers 248 / 184 / 168 / 152 / 136 / 118 and found **no overflow at any width**, i.e. strictly better than the old `flexShrink: 0`, which overflowed the card below ~218. Still no synthetic-narrow test of my own.
- **The `@container` removal.** `container-type: inline-size` also applies inline-axis size containment; I removed it because its only consumer (`@[264px]`) is gone and asserted that no arbitrary container variant survives, but I did not measure whether dropping the containment changes anything else on the card. Nothing in 278 passing tests moved.
- **I never ran the full `unit` or `component` project locally.** CI did, and is green — but the one real defect in this PR was found by a CI shard after I had already reported a green local run, so treat the local numbers as scoped to the files named above, not as a suite claim.
- **Not run locally:** the full `component` project (130 files), the full `unit` project (5,631 tests), or Playwright e2e.
- **The `mih` on the action row is inert at today's geometry** — it equals the row's natural height. Round 2 showed it is worse than inert: it MASKS a shrunken control from every row-height assertion. It stays (it is a correct floor and the height constant's production consumer), and the CTA's rendered height is now asserted directly so the mask no longer costs coverage. Measured in mutation **M9/M11**.
- 🟡 **A CTA size change is caught by NOTHING that blocks, and by nothing that reddens `main` either.** Measured (**M10**): CTA `size="sm"`→`"md"` leaves the node file green at **45/45**; only the browser tier reds. `triggerSize` IS covered by the node tier (it reads a constant); the CTA's 36px is a Mantine size token no constant touches, and the prop ledger reads the row's own opening tag so no child-driven height change is visible to it. **Do not read the ledger as covering the CTA.**
  > **Severity downgraded from 🔴, and the reason is the correction itself.** This was 🔴 because "the node tier gates and the browser tier does not". That is false on a PR — `lint.yml` makes `unit` (line 405) and `geometry` (line 830) `continue-on-error` for `pull_request` events. What is actually true: **neither tier gates a PR**; the node tier reddens `main` on the next push; the browser tier never blocks. So the gap is real but it is one *report-only* tier away from a *push-only* tier, not a hole in a merge gate. Closing it is the ~5-line follow-up costed in the round-3 section above.
- **The two newly-pinned Mantine numbers are in the browser tier, which never blocks.** `md` = 42px and `xl` line-height 1.65 are now asserted, but a Mantine upgrade retuning either would not block a merge and would not redden `main` either.
- **`expect(2 * 33 - 2 * 24).toBe(18)` shipped as a tautology, and its first repair shipped as an unreachable guard.** Both are recorded in the file rather than quietly deleted. The ~18px figure is now stated in prose as determined by the two measurements above it; nothing asserts it independently, because nothing could without being unreachable.
- **The `Tooltip` + `ResizeObserver` the title now mounts per card** (~24 extra on a 24-tile grid) is unmeasured. Raised as a 🟢 in round 1 and deliberately not optimised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG1JXGbsBJsWyFzG56APs8

