### PR TITLE
feat(articles): mark Civitai-published articles, and make adminOnly tags actually admin-only

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260904160000_civitai_official_article_tag/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260904160000_civitai_official_article_tag/migration.sql
@@ -1,0 +1,33 @@
+-- Creates the tag that marks an article as published by Civitai rather than by a community
+-- author. Justin, 2026-09-04, after choosing option A on the design question.
+--
+-- A TAG and not a category, deliberately: an article carries exactly one category
+-- (ArticleUpsertForm makes the author pick one) and official articles span several of them --
+-- an official announcement and an official guide are both official.
+--
+-- 🔴 `adminOnly` is the whole permission model. `upsertArticleHandler` refuses any article
+-- carrying an adminOnly tag from a caller without the `adminTags` feature (mod, or granted).
+-- Clearing this column does not disable a badge; it makes the badge FORGEABLE by any user,
+-- because article tags attach by NAME through `connectOrCreate` and anyone can type a name.
+--
+-- 🔴 Renaming this row silently unsets every badge. The client matches on the name, from
+-- `src/shared/constants/official-article.constants.ts`. Rename in one place only and the badge
+-- disappears with no error anywhere.
+--
+-- Measured on prod 2026-09-04 before writing this:
+--   * `SELECT count(*) FROM "Tag" WHERE "adminOnly"` -> 0. Nothing has ever used this column,
+--     so this row is the first thing the guard above will ever refuse.
+--   * A tag named `official` already exists (id 123833), targets Post, is NOT adminOnly, and is
+--     on 8 posts. It is deliberately NOT reused: flipping it would retroactively mark 8 existing
+--     posts as official, and users have already applied it themselves.
+--   * No tag named `civitai official` exists.
+--
+-- Idempotent. `Tag.name` is unique, so a second run updates the existing row to the intended
+-- state rather than failing or duplicating -- which also repairs a row whose `adminOnly` was
+-- cleared by hand.
+INSERT INTO "Tag" ("name", "target", "adminOnly", "unlisted", "createdAt", "updatedAt")
+VALUES ('civitai official', ARRAY['Article']::"TagTarget"[], true, false, NOW(), NOW())
+ON CONFLICT ("name") DO UPDATE
+  SET "target" = ARRAY['Article']::"TagTarget"[],
+      "adminOnly" = true,
+      "updatedAt" = NOW();

--- a/src/components/Article/OfficialArticleBadge.tsx
+++ b/src/components/Article/OfficialArticleBadge.tsx
@@ -1,0 +1,34 @@
+import { Badge, Tooltip } from '@mantine/core';
+import { IconRosetteDiscountCheck } from '@tabler/icons-react';
+import clsx from 'clsx';
+
+import { OFFICIAL_ARTICLE_LABEL } from '~/shared/constants/official-article.constants';
+
+/**
+ * The marker on an article published by Civitai rather than by a community author.
+ *
+ * One component for both surfaces — the card and the article page — because this badge is
+ * a claim about provenance, and two hand-maintained copies of a provenance marker is how
+ * one of them ends up looking like an ordinary chip. `className` is the only thing a
+ * caller varies; the card passes its own chip class so the badge sits in the card's
+ * header rhythm.
+ *
+ * 🔴 Rendering this is NOT what makes an article official. The tag behind it is
+ * `adminOnly`, and `upsertArticleHandler` is what refuses it from a non-moderator. Do not
+ * reuse this badge for anything a user can set about themselves.
+ */
+export function OfficialArticleBadge({ className }: { className?: string }) {
+  return (
+    <Tooltip label="Published by Civitai" withArrow>
+      <Badge
+        size="sm"
+        variant="filled"
+        color="blue"
+        className={clsx('uppercase', className)}
+        leftSection={<IconRosetteDiscountCheck size={14} stroke={2.5} />}
+      >
+        {OFFICIAL_ARTICLE_LABEL}
+      </Badge>
+    </Tooltip>
+  );
+}

--- a/src/components/Cards/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard.tsx
@@ -1,5 +1,7 @@
 import { Badge, Text } from '@mantine/core';
 import { memo } from 'react';
+import { OfficialArticleBadge } from '~/components/Article/OfficialArticleBadge';
+import { hasOfficialArticleTag } from '~/shared/constants/official-article.constants';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { IconBolt, IconBookmark, IconEye, IconMessageCircle2 } from '@tabler/icons-react';
 import { slugit } from '~/utils/string-helpers';
@@ -38,6 +40,8 @@ function ArticleCardContent({ data, aspectRatio }: Props) {
     ? { ...coverImage, nsfwLevel: Math.max(nsfwLevel ?? 0, coverImage.nsfwLevel ?? 0) }
     : undefined;
   const category = tags?.find((tag) => tag.isCategory);
+  // Provenance, so it leads: an official article is official before it is a guide.
+  const official = hasOfficialArticleTag(tags);
   const currentUser = useCurrentUser();
   const canSeeStatus = !!currentUser && (currentUser.id === user.id || currentUser.isModerator);
   const statusBadge = canSeeStatus && status ? articleStatusBadge[status] : null;
@@ -55,6 +59,7 @@ function ArticleCardContent({ data, aspectRatio }: Props) {
       header={
         <div className="flex w-full justify-between">
           <div className="flex items-center gap-1">
+            {official && <OfficialArticleBadge className={cardClasses.chip} />}
             {category && (
               <Badge
                 size="sm"

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -44,7 +44,12 @@ import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { openArticleRatingReviewModal } from '~/components/Dialog/triggers/article-rating-review';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { OfficialArticleBadge } from '~/components/Article/OfficialArticleBadge';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
+import {
+  hasOfficialArticleTag,
+  isOfficialArticleTag,
+} from '~/shared/constants/official-article.constants';
 import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMenu';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
 import { ArticleCoverStickers } from '~/components/Article/ArticleCoverStickers';
@@ -250,7 +255,12 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
   if (!article || isBlocked || disableArticles) return <NotFound />;
 
   const category = article.tags.find((tag) => tag.isCategory);
-  const tags = article.tags.filter((tag) => !tag.isCategory);
+  const official = hasOfficialArticleTag(article.tags);
+  // The official tag is drawn as its own badge below, so it is filtered out of the
+  // ordinary tag row as well as the category — otherwise the same fact appears twice on
+  // one line, once as a provenance marker and once as a grey chip a reader can mistake
+  // for a topic.
+  const tags = article.tags.filter((tag) => !tag.isCategory && !isOfficialArticleTag(tag));
 
   const actionButtons = (
     <Group gap={4} align="center" wrap="nowrap">
@@ -386,6 +396,12 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
                   </Text>
                 </Tooltip>
               )}
+            {official && (
+              <>
+                <Divider orientation="vertical" />
+                <OfficialArticleBadge />
+              </>
+            )}
             {category && (
               <>
                 <Divider orientation="vertical" />

--- a/src/server/controllers/__tests__/article.controller.admin-only-tags.test.ts
+++ b/src/server/controllers/__tests__/article.controller.admin-only-tags.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as ArticleService from '~/server/services/article.service';
+
+const { mockUpsertArticle } = vi.hoisted(() => ({ mockUpsertArticle: vi.fn() }));
+
+vi.mock('~/server/services/article.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ArticleService>()),
+  upsertArticle: mockUpsertArticle,
+}));
+
+import { upsertArticleHandler } from '../article.controller';
+
+const OFFICIAL = { id: 900001, name: 'civitai official' };
+
+function ctx({ adminTags }: { adminTags?: boolean }) {
+  return {
+    user: { id: 7, isModerator: false },
+    features: { adminTags, articleImageScanning: false },
+    req: undefined,
+    // The handler tracks provenance after a successful save. Stubbed so the
+    // ALLOWED assertions do not fail for an unrelated reason.
+    track: { article: vi.fn(async () => undefined) },
+  } as never;
+}
+
+const input = (tags: { id?: number; name?: string }[]) =>
+  ({ title: 't', content: '<p>c</p>', tags } as never);
+
+describe('upsertArticleHandler — adminOnly tags', () => {
+  beforeEach(() => {
+    mockUpsertArticle.mockReset();
+    mockUpsertArticle.mockResolvedValue({ id: 1, publishedAt: null });
+    // Call history, not just the return value: the shared db mock keeps its calls across
+    // tests in a file, so `not.toHaveBeenCalled()` below would be reading the PREVIOUS
+    // test's guard query and failing for the wrong reason.
+    dbMock.dbRead.tag.findMany.mockClear();
+    dbMock.dbRead.tag.findMany.mockResolvedValue([]);
+    dbMock.dbRead.article.findUnique.mockResolvedValue(null);
+  });
+
+  // 🔴 The defect this file exists for. The guard used to resolve the incoming tags
+  // through `getCategoryTags('article')`, so it only saw adminOnly tags that were ALSO
+  // article categories. An adminOnly tag that is not a category — which is what a
+  // mod-only marker has to be, since one article already carries exactly one category —
+  // went through unchecked, and tags attach by NAME via `connectOrCreate`, so a normal
+  // user could put it on their own article by typing it.
+  it('refuses an adminOnly tag that is not a category', async () => {
+    dbMock.dbRead.tag.findMany.mockResolvedValue([OFFICIAL]);
+
+    await expect(
+      upsertArticleHandler({ input: input([{ name: OFFICIAL.name }]), ctx: ctx({}) })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+    expect(mockUpsertArticle).not.toHaveBeenCalled();
+  });
+
+  // The control for the test above: same call, same user, a tag the table does not report
+  // as adminOnly. Without this, a handler that refused EVERY article would pass.
+  it('allows an ordinary tag from the same user', async () => {
+    await expect(
+      upsertArticleHandler({ input: input([{ name: 'workflows' }]), ctx: ctx({}) })
+    ).resolves.toBeDefined();
+
+    expect(mockUpsertArticle).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows an adminOnly tag when the user holds the adminTags feature', async () => {
+    dbMock.dbRead.tag.findMany.mockResolvedValue([OFFICIAL]);
+
+    await expect(
+      upsertArticleHandler({
+        input: input([{ name: OFFICIAL.name }]),
+        ctx: ctx({ adminTags: true }),
+      })
+    ).resolves.toBeDefined();
+
+    expect(mockUpsertArticle).toHaveBeenCalledTimes(1);
+  });
+
+  // A mod pays no query for the check. Stated as a test because the obvious refactor —
+  // resolve first, then decide — is a database read on every article save by a moderator,
+  // and nothing else would notice.
+  it('does not query the tag table at all for an adminTags holder', async () => {
+    await upsertArticleHandler({
+      input: input([{ name: OFFICIAL.name }]),
+      ctx: ctx({ adminTags: true }),
+    });
+
+    expect(dbMock.dbRead.tag.findMany).not.toHaveBeenCalled();
+  });
+
+  // `adminTags` is a sparse FeatureAccess: an off flag is absent, so it reads `undefined`
+  // rather than `false`. A guard written as `=== false` would let every non-mod through.
+  it('treats an absent adminTags flag as off, not as unknown', async () => {
+    dbMock.dbRead.tag.findMany.mockResolvedValue([OFFICIAL]);
+
+    await expect(
+      upsertArticleHandler({ input: input([{ name: OFFICIAL.name }]), ctx: ctx({}) })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('asks the tag table for both the ids and the lowercased names it was sent', async () => {
+    await upsertArticleHandler({
+      input: input([{ id: 12, name: 'Announcement' }, { name: '  Civitai Official  ' }]),
+      ctx: ctx({}),
+    });
+
+    const [args] = dbMock.dbRead.tag.findMany.mock.calls[0] as [
+      { where: { adminOnly: boolean; OR: ({ id?: unknown } | { name?: unknown })[] } }
+    ];
+    expect(args.where.adminOnly).toBe(true);
+    // Normalised the way `article.service` normalises on the attach path. A guard
+    // comparing the raw string misses `Civitai Official` for the tag named
+    // `civitai official`, which is a one-keystroke bypass.
+    expect(args.where.OR).toEqual([
+      { id: { in: [12] } },
+      { name: { in: ['announcement', 'civitai official'] } },
+    ]);
+  });
+});

--- a/src/server/controllers/article.controller.ts
+++ b/src/server/controllers/article.controller.ts
@@ -7,7 +7,7 @@ import type {
   ArticleMetadata,
 } from '~/server/schema/article.schema';
 import { unpublishArticleById, upsertArticle } from '~/server/services/article.service';
-import { getCategoryTags } from '~/server/services/system-cache';
+import { findAdminOnlyTags } from '~/server/services/tag.service';
 import {
   throwAuthorizationError,
   throwDbError,
@@ -23,13 +23,19 @@ export const upsertArticleHandler = async ({
   ctx: ProtectedContext;
 }) => {
   try {
-    const categories = await getCategoryTags('article');
-    const adminOnlyCategories = categories.filter((category) => category.adminOnly);
-    const includesAdminOnlyTag = input.tags?.some(
-      (tag) => adminOnlyCategories.findIndex((category) => category.name === tag.name) !== -1
-    );
-    // Only users with adminTags featureFlag can add adminOnly tags
-    if (includesAdminOnlyTag && !ctx.features.adminTags) throw throwAuthorizationError();
+    // Only users with the adminTags feature can attach an `adminOnly` tag.
+    //
+    // 🔴 This used to resolve the tags through `getCategoryTags('article')`, so it only
+    // ever saw adminOnly tags that were also article CATEGORIES — an adminOnly tag that
+    // is not a category was not checked at all, and tags attach by NAME through
+    // `connectOrCreate`, so anyone could put one on their own article. That is the whole
+    // point of a mod-only marker, so the guard now asks the tag table directly and covers
+    // every adminOnly tag. The old behaviour is a strict subset of this one: an adminOnly
+    // category is still an adminOnly tag.
+    if (input.tags?.length && !ctx.features.adminTags) {
+      const adminOnlyTags = await findAdminOnlyTags(input.tags);
+      if (adminOnlyTags.length) throw throwAuthorizationError();
+    }
     const scanContent = ctx.features.articleImageScanning ?? false;
 
     // Capture the prior published state so we can tell a publish transition apart

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -46,6 +46,7 @@ import { getPagination, getPagingData } from '~/server/utils/pagination-helpers'
 import { Flags } from '~/shared/utils/flags';
 import { TagSource, TagTarget, TagType } from '~/shared/utils/prisma/enums';
 import { bustCacheTag, fetchThroughCache, queryCache } from '~/server/utils/cache-helpers';
+import { isDefined } from '~/utils/type-guards';
 import { removeEmpty } from '~/utils/object-helpers';
 
 const alwaysIncludeTags = [...styleTags, ...subjectTags];
@@ -993,4 +994,40 @@ export const getTypeCategories = async ({
   if (limit) categories = categories.slice(start, start + limit);
 
   return categories;
+};
+
+/**
+ * The `adminOnly` tags among `tags`, resolved the same two ways a caller can name a tag:
+ * by id, and by lowercased name.
+ *
+ * 🔴 The NAME arm is the load-bearing one, and it is why this exists. Entity upserts
+ * attach tags with `connectOrCreate` keyed on `name` (article.service.ts, and the same
+ * shape in post.service and model.service), so a caller never has to know a tag's id to
+ * attach it. A guard that only checked ids would be trivially bypassed by sending the
+ * name — which is how every tag the web client sends arrives.
+ *
+ * Deliberately NOT cached. The other global tag blobs (`getSystemTags`, `getCategoryTags`)
+ * sit behind a 4h redis TTL, which is fine for a listing and wrong for a permission
+ * check: the window between flagging a tag `adminOnly` and the guard honouring it would
+ * be a window where anyone can apply it. Entity upserts are low volume and this reads at
+ * most a handful of rows on an indexed unique column.
+ */
+export const findAdminOnlyTags = async (tags: { id?: number; name?: string }[]) => {
+  const ids = uniq(tags.map((tag) => tag.id).filter(isDefined));
+  // Matching `article.service`'s own normalisation on the attach path — a tag arrives as
+  // free text and is lowercased and trimmed before `connectOrCreate` sees it, so a guard
+  // comparing the raw string would miss `Official` for the tag named `official`.
+  const names = uniq(
+    tags.map((tag) => tag.name?.toLowerCase().trim()).filter((name): name is string => !!name)
+  );
+  if (!ids.length && !names.length) return [];
+
+  const OR: Prisma.TagWhereInput[] = [];
+  if (ids.length) OR.push({ id: { in: ids } });
+  if (names.length) OR.push({ name: { in: names } });
+
+  return dbRead.tag.findMany({
+    where: { adminOnly: true, OR },
+    select: { id: true, name: true },
+  });
 };

--- a/src/shared/constants/__tests__/official-article.constants.test.ts
+++ b/src/shared/constants/__tests__/official-article.constants.test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  OFFICIAL_ARTICLE_TAG,
+  hasOfficialArticleTag,
+  isOfficialArticleTag,
+} from '~/shared/constants/official-article.constants';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const read = (relative: string) =>
+  fs.readFileSync(path.join(repoRoot, ...relative.split('/')), 'utf-8');
+
+describe('isOfficialArticleTag', () => {
+  it('matches the tag the migration creates', () => {
+    expect(isOfficialArticleTag({ name: 'civitai official' })).toBe(true);
+  });
+
+  // `Tag.name` is `citext` and `article.service` lowercases on the attach path, but a
+  // payload is only as clean as the query that built it.
+  it.each(['Civitai Official', 'CIVITAI OFFICIAL', '  civitai official  '])(
+    'matches %j',
+    (name) => {
+      expect(isOfficialArticleTag({ name })).toBe(true);
+    }
+  );
+
+  // 🔴 The negative that matters, and it is not hypothetical. A tag named `official`
+  // already exists on prod (id 123833, targets Post, NOT adminOnly) and is on 8 posts,
+  // applied by ordinary users. A looser match — `includes('official')`, or matching the
+  // bare word — would paint a Civitai provenance badge on whatever those users tagged.
+  it.each(['official', 'unofficial', 'civitai', 'civitai officials', 'official civitai'])(
+    'does not match %j',
+    (name) => {
+      expect(isOfficialArticleTag({ name })).toBe(false);
+    }
+  );
+
+  it.each([{ name: null }, { name: undefined }, {}])('does not match %j', (tag) => {
+    expect(isOfficialArticleTag(tag)).toBe(false);
+  });
+
+  it('finds the tag among an article’s other tags, and reports absence', () => {
+    const others = [{ name: 'announcement' }, { name: 'news' }];
+    expect(hasOfficialArticleTag(others)).toBe(false);
+    expect(hasOfficialArticleTag([...others, { name: OFFICIAL_ARTICLE_TAG }])).toBe(true);
+    expect(hasOfficialArticleTag([])).toBe(false);
+    expect(hasOfficialArticleTag(undefined)).toBe(false);
+  });
+});
+
+/**
+ * The name is one string in two systems: this constant, and the `Tag` row the migration
+ * creates. Nothing at runtime reconciles them — a rename in either place leaves a badge
+ * that silently never renders, with no error anywhere and a passing suite.
+ */
+describe('the constant and the migration agree on the name', () => {
+  const migration = read(
+    'packages/civitai-db-schema/prisma/migrations/20260904160000_civitai_official_article_tag/migration.sql'
+  );
+
+  it('the migration inserts exactly the tag this constant names', () => {
+    expect(migration).toContain(`VALUES ('${OFFICIAL_ARTICLE_TAG}'`);
+  });
+
+  // The permission model, pinned in the only place it is written down. Without
+  // `adminOnly` the badge is forgeable: article tags attach by NAME through
+  // `connectOrCreate`, so anyone who can type the name can claim it.
+  it('the migration creates it adminOnly, and repairs it if cleared', () => {
+    expect(migration).toMatch(/"adminOnly"\s*=\s*true/);
+    expect(migration).toMatch(/ON CONFLICT \("name"\) DO UPDATE/);
+  });
+});
+
+/**
+ * Rendering the badge component directly would leave every test above green with the
+ * badge on no page at all — the failure mode #4141 shipped and 868kuq3jk had to clean up.
+ * These are the only assertions that anything in the app draws it.
+ */
+describe('the article surfaces render the badge', () => {
+  it.each([['src/components/Cards/ArticleCard.tsx'], ['src/pages/articles/[id]/[[...slug]].tsx']])(
+    '%s renders <OfficialArticleBadge />',
+    (relative) => {
+      const source = read(relative);
+      // Comments stripped first: commenting the mount out is likelier than deleting it and
+      // leaves the string in place. The character class after the name is deliberate — a
+      // bare `includes('<OfficialArticleBadge')` is a PREFIX match, satisfied by
+      // `<OfficialArticleBadgeSkeleton />` with the real badge mounted nowhere.
+      const code = source.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+      const mounted = code
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => /<OfficialArticleBadge[\s/>]/.test(line) && !line.startsWith('//'));
+
+      expect(mounted).toHaveLength(1);
+    }
+  );
+
+  // The detail page draws every non-category tag as a grey chip. Without this filter the
+  // official tag appears twice on one line — once as provenance, once as a topic.
+  it('the detail page keeps the official tag out of the ordinary tag row', () => {
+    // Whitespace collapsed first: this line is close enough to printWidth that one more
+    // condition makes Prettier wrap it, and a guard that reddens on a re-wrap is a guard
+    // people delete.
+    const source = read('src/pages/articles/[id]/[[...slug]].tsx').replace(/\s+/g, ' ');
+    expect(source).toMatch(/const tags = article\.tags\.filter\(.*isOfficialArticleTag/);
+  });
+});

--- a/src/shared/constants/official-article.constants.ts
+++ b/src/shared/constants/official-article.constants.ts
@@ -1,0 +1,40 @@
+/**
+ * The tag that marks an article as published by Civitai rather than by a community
+ * author, and the one place its name is written down.
+ *
+ * It is a TAG and not a category on purpose: an article carries exactly one category
+ * (`ArticleUpsertForm` makes the author pick one), and official articles span several of
+ * them — an official announcement and an official guide are both official. A category
+ * could not say both things at once.
+ *
+ * 🔴 The authority behind this badge is `Tag.adminOnly` plus the guard in
+ * `upsertArticleHandler`, NOT this constant. Article tags attach by NAME through
+ * `connectOrCreate`, so anything that can send a tag name can ask for this one; what stops
+ * it is the server refusing an `adminOnly` tag from a caller without the `adminTags`
+ * feature. If you are adding a second surface that reads this badge, you are relying on
+ * that guard — do not add a path that trusts the name alone on the way IN.
+ *
+ * 🔴 And the tag row itself is the other half: renaming the tag in the database, or
+ * clearing its `adminOnly`, silently changes what this badge means without touching a
+ * line of code. The row is created by
+ * `prisma/sql-migrations/2026-09-04-civitai-official-tag.sql`.
+ */
+export const OFFICIAL_ARTICLE_TAG = 'civitai official';
+
+/** What the badge reads. The tag name carries the brand for moderators picking it out of
+ * a tag list; the badge sits next to Civitai's own logo, where repeating it is noise. */
+export const OFFICIAL_ARTICLE_LABEL = 'Official';
+
+type MaybeTag = { name?: string | null };
+
+/**
+ * Case- and whitespace-insensitive, matching how `article.service` normalises a tag name
+ * before `connectOrCreate` — the stored row is lowercase, but a payload is only as clean
+ * as the query that built it, and a future caller selecting the raw column should not
+ * silently lose the badge.
+ */
+export const isOfficialArticleTag = (tag: MaybeTag) =>
+  tag.name?.toLowerCase().trim() === OFFICIAL_ARTICLE_TAG;
+
+export const hasOfficialArticleTag = (tags?: MaybeTag[] | null) =>
+  !!tags?.some(isOfficialArticleTag);


### PR DESCRIPTION
Adds an **Official** marker to articles published by Civitai, and fixes the permission hole that would have made it forgeable.

Justin, 2026-09-04: a tag rather than a category, because an article carries exactly one category (`ArticleUpsertForm` makes the author pick one) and official articles span several of them — an official announcement and an official guide are both official.

## 🔴 The permission half is a bug fix, and it cannot land after the tag

`upsertArticleHandler` resolved the incoming tags through `getCategoryTags('article')`, so its `adminOnly` check only ever saw adminOnly tags that were **also article categories**. An adminOnly tag that is not a category — exactly what this marker is — was not checked at all. Article tags attach by **name** through `connectOrCreate` (`article.service.ts`), so any user could have typed `civitai official` onto their own article.

The guard now asks the tag table directly and covers every adminOnly tag. The old behaviour is a strict subset: an adminOnly category is still an adminOnly tag.

`findAdminOnlyTags` resolves by id **and** by lowercased name. The name arm is the load-bearing one — nothing obliges a caller to send an id, and the web client never does. It is deliberately **uncached**, unlike `getSystemTags`/`getCategoryTags`: a 4h TTL on a listing is fine, a 4h TTL on a permission check is a window where anyone can apply the tag. A moderator pays no query at all, because it runs only when the caller lacks the feature.

**Measured on prod before writing any of this:** `SELECT count(*) FROM "Tag" WHERE "adminOnly"` → **0**. The column has never been used, so this tag is the first thing that guard will ever refuse.

## Why not the `official` tag that already exists

It exists (id 123833), targets `Post`, is **not** adminOnly, and **8 posts already carry it**, applied by ordinary users. Flipping it to adminOnly would retroactively mark those. Hence `civitai official` — and hence a deliberately exact match: `includes('official')` would paint a Civitai provenance badge on all 8, which is pinned as a test.

## ⚠️ The migration is not applied

It needs running by hand against prod:

```
packages/civitai-db-schema/prisma/migrations/20260904160000_civitai_official_article_tag/migration.sql
```

Until then **the code is inert** — no tag, no badge, and the guard has nothing to refuse. It is idempotent, and a second run repairs a row whose `adminOnly` was cleared by hand.

## Two facts that live only in a comment and a test

Both would unset every badge with no error and a green suite:
- **Renaming the tag row.** The client matches on the name.
- **Clearing its `adminOnly`.** That does not hide the badge — it makes it forgeable.

## Testing

24 tests across two files. Every mutation driven red on purpose; both suites pristine at 6 and 18.

| Mutation | Result |
|---|---|
| guard narrowed back to categories only | 2 failed |
| ids only, name arm dropped | 1 failed |
| names no longer lowercased | 1 failed |
| query moved before the feature check | 1 failed |
| `adminTags === false` instead of `!adminTags` | 3 failed |
| card mount removed | 1 failed |
| detail mount removed | 1 failed |
| detail tag-row filter reverted | 1 failed |
| match loosened to `includes('official')` | 4 failed |
| migration renames the tag | 1 failed |
| migration drops `adminOnly` | 1 failed |

One control I discarded rather than counted: my first "narrow it back" mutant killed all 6 tests, which is a broken mutant, not a demonstration — it failed on an unmocked `getCategoryTags` reaching redis. The faithful version kills exactly the two that should die.

`typecheck: OK — 0 type errors`. ESLint clean on the changed files (2 pre-existing unused-import warnings in `tag.service.ts`). Full suite `Test Files 1 failed | 1597 passed | 3 skipped (1601)` — the one failure is `appListingMenuSurface.test.ts`, which compares Windows paths against forward-slash literals and fails on a clean tree. `blocks.router.workflow.test.ts` collected **370**.

## Open question I did not decide

`ctx.features.adminTags` is `['mod', 'granted']` — moderators **and** anyone individually granted the feature. You asked for mods only; those coincide today unless someone holds a grant. Say the word and I will make it a moderator check instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHZuQDTCG159qcPrCkP7SF