### PR TITLE
feat(apps): store card skeletons that reserve the card box, and keep the previous page across a filter change

### DIFF
--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -1,0 +1,351 @@
+/**
+ * `/apps` store — THE SKELETON ⇄ CARD BOX PARITY.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT IS BEING GUARDED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The store's loading state used to be `<Center py="xl"><Loader /></Center>` — a
+ * spinner in a box with no relationship to the grid that replaced it, so every
+ * cell in the store moved when the query resolved. It is now a grid of
+ * `AppListingCardSkeleton`s rendered into the SAME `.gridContainer` / `.grid`
+ * markup.
+ *
+ * "The same markup" is a claim about CSS classes; what a viewer experiences is a
+ * claim about BOXES. So this file renders the real `AppListingsMarketplaceBody`
+ * TWICE at the same grid width — once with the query loading, once resolved — and
+ * compares each cell's `top` / `left` / `width` / `height`. Anything less (a
+ * `getComputedStyle` check, an assertion that both render `.grid`) type-checks
+ * straight past a skeleton that is 20px short.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 WHY THE `geometry` PROJECT AND NOT `component`
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The card's box depends on `h-full` (a Tailwind utility) resolving against
+ * Mantine's `Card` rules and this repo's CSS module — a three-way cascade fight —
+ * and on the grid STRETCHING its items. `test/component-setup.tsx` injects only
+ * `globals.css`'s unconditional `:root` custom properties into a throwaway sheet,
+ * so Tailwind utilities are inert in that tier by default: `className="flex"`
+ * computes `display: block`. Three specs opt in with a side-effect
+ * `import '~/styles/globals.css'`, and even those lack `test/cascade-layer-order.css`
+ * and the six `@mantine/<pkg>/styles.layer.css` sheets, so they render under a cascade
+ * matching neither the tier default nor production.
+ *
+ * That is not theory here. The sibling `AppListingsMarketplaceBody.stretch.geometry.test.tsx`
+ * records its first draft living in the `component` tier and reporting heights of
+ * `[458.23, 312.75, 434.23, 312.75]` on a CORRECT grid, because `h-full` did
+ * nothing there — a test that cannot distinguish the fix from the defect. This file
+ * therefore asserts `cascadeEvidence()` before it asserts anything about boxes.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 THE FIXTURE IS PART OF THE CLAIM — READ THIS BEFORE QUOTING A RESULT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The skeleton reserves the card's INVARIANT parts: the 16:9 cover, the icon, the
+ * two RESERVED title lines, the creator line and the always-rendered recommend
+ * rollup line, plus the 46px action row. A card can also render a `line-clamp-3`
+ * tagline, a Beta badge and an owner-only "Incomplete" badge — none of which a
+ * loading state can predict.
+ *
+ * So the fixture below is a listing of exactly that invariant shape: a creator, no
+ * tagline, not beta, viewed signed-out. What this file proves is "the invariant box
+ * matches EXACTLY", NOT "no card ever moves". A listing carrying a tagline is
+ * taller than its skeleton and the grid still resizes — stated in the component's
+ * header and in the PR body rather than papered over here.
+ */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup } from 'vitest-browser-react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { box, cascadeEvidence, nextLayout, renderAtViewport } from '../../../test/geometry-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * A listing of the shape the skeleton reserves.
+ *
+ * 🔴 THE VALUES ARE PAIRWISE DISTINCT AND SHARE NOTHING WITH ANY CONSTANT THE
+ * ASSERTIONS NAME. Names are of different lengths so the fixture is not
+ * accidentally uniform in a way that could hide a width bug, and no field spells
+ * 2, 10, 36, 40, 46, 16 or 9 — a fixture that can only ever produce a constant's
+ * own value cannot see a mutant that hardcodes the literal.
+ */
+function makeCard(id: string, name: string, creator: string): ListingCard {
+  return {
+    id,
+    slug: `slug-${id}`,
+    kind: 'onsite',
+    name,
+    // 🔴 `null`, not `''`. The card renders the tagline conditionally and the
+    // skeleton reserves nothing for it — see the fixture note in the header.
+    tagline: null,
+    category: null,
+    contentRating: null,
+    isBeta: false,
+    iconUrl: null,
+    coverUrl: null,
+    creator: { id: 7331, username: creator, image: null },
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: {
+      kind: 'onsite',
+      appBlockId: `blk-${id}`,
+      hasPage: false,
+      liveUrl: `https://slug-${id}.civit.ai`,
+    },
+  };
+}
+
+/** Enough distinct listings to fill two rows at the widest count measured here. */
+const POOL: ListingCard[] = [
+  makeCard('u1', 'Prompt Vault', 'ashling'),
+  makeCard('u2', 'Gen Matrix Studio', 'bertrand'),
+  makeCard('u3', 'Palette', 'cyd'),
+  makeCard('u4', 'Frame Weaver Pro', 'delphine'),
+  makeCard('u5', 'Nudge', 'esben'),
+  makeCard('u6', 'Contour Lab', 'fitzgerald'),
+  makeCard('u7', 'Stipple', 'greta'),
+  makeCard('u8', 'Rehearsal Room', 'hollis'),
+  makeCard('u9', 'Kerf', 'imogen'),
+  makeCard('u10', 'Sable Notebook', 'jarrah'),
+  makeCard('u11', 'Tessellate', 'kestrel'),
+  makeCard('u12', 'Overtone Bench', 'linnea'),
+];
+
+const mocks = vi.hoisted(() => ({ items: [] as ListingCard[], isLoading: false }));
+
+// The same mock set, and the same reasons, as
+// `AppListingsMarketplaceBody.stretch.geometry.test.tsx` — see the long notes in
+// `AppListingsMarketplaceBody.browser.test.tsx`. In short: the card reads
+// `useCurrentUser`, the filters dropdown reads `useIsClient` + `useIsMobile` and both
+// THROW without a provider, and the flags factory must name BOTH flag hooks or the
+// whole file fails to IMPORT and reports `no tests` rather than a failure.
+// `next/router` is already mocked by `test/geometry-setup.tsx`.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useFeatureFlagsReady: () => true,
+}));
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-module-mock).
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: {
+        useInfiniteQuery: () => ({
+          // 🔴 `data` IS UNDEFINED WHILE LOADING, as it is in production before the
+          // first page arrives. Handing back items AND `isLoading: true` would let
+          // a body that renders the grid regardless still look correct.
+          data: mocks.isLoading
+            ? undefined
+            : { pages: [{ items: mocks.items, nextCursor: undefined }] },
+          isLoading: mocks.isLoading,
+          isError: false,
+          isPlaceholderData: false,
+          isFetchingNextPage: false,
+          refetch: vi.fn(),
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+        }),
+      },
+    },
+    blocks: { getNavSummary: { useQuery: () => ({ data: undefined }) } },
+  },
+}));
+
+// Import AFTER the mocks (vi.mock is hoisted; static imports are not).
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+const { APP_LISTING_SKELETON_ROWS } = await import('./AppListingCardSkeleton');
+const { listingGridColumnsAt } = await import('./appListingGrid');
+
+/**
+ * A viewport wide enough that neither grid width below is clamped by it. The grid
+ * width is set on a wrapper, so the viewport is deliberately NOT the variable
+ * under test.
+ */
+const VIEWPORT = { width: 2880, height: 900 } as const;
+
+/**
+ * TWO column counts, both NAMED in every assertion, because one measurement is
+ * not a general claim.
+ *
+ * 1376 is mid-band in the four-column rung (the `xl` low end); 2450 is mid-band in
+ * the five-column rung. 🔴 2364 — the five-column threshold itself — is
+ * deliberately avoided: a fixture sitting on its own boundary cannot detect an
+ * off-by-one, and the ladder's rungs are asserted against below so this cannot rot
+ * into a coincidence.
+ */
+const WIDTHS = [
+  { gridWidth: 1376, columns: 4 },
+  { gridWidth: 2450, columns: 5 },
+] as const;
+
+/** The ladder's rungs, so a fixture can be checked against them. */
+const RUNGS = [736, 960, 1168, 2364, 2840];
+
+/**
+ * Render the store body at an explicit grid width and hand back the cells of
+ * whichever grid it decided to render.
+ *
+ * 🔴 CLEAN FIRST, ALWAYS. `vitest-browser-react` APPENDS each render rather than
+ * replacing it, and the setup file's `afterEach` runs only BETWEEN tests — so a
+ * test that renders twice leaves two grids in the document and
+ * `document.querySelectorAll` keeps returning the FIRST one's cells. This file
+ * renders twice in EVERY test, so without this every parity assertion would be
+ * comparing a tree to itself and would pass unconditionally. The same defect was
+ * found and fixed in two sibling suites; `the harness really replaces the tree`
+ * below is the control that proves the cure works here.
+ */
+async function renderStore(gridWidth: number, opts: { loading: boolean; items?: ListingCard[] }) {
+  await cleanup();
+  mocks.isLoading = opts.loading;
+  mocks.items = opts.items ?? [];
+  const { observed } = await renderAtViewport(
+    <div style={{ width: gridWidth, maxWidth: 'none' }} data-testid="width-harness">
+      <AppListingsMarketplaceBody />
+    </div>,
+    VIEWPORT
+  );
+  await nextLayout();
+  const selector = opts.loading ? 'apps-listing-skeleton-col' : 'apps-listing-grid-col';
+  const gridId = opts.loading ? 'apps-listing-skeleton-grid' : 'apps-listing-grid';
+  const grid = document.querySelector(`[data-testid="${gridId}"]`) as HTMLElement | null;
+  const cells = Array.from(
+    document.querySelectorAll(`[data-testid="${selector}"]`)
+  ) as HTMLElement[];
+  if (!grid) throw new Error(`${gridId} did not render (loading=${opts.loading})`);
+  return {
+    observed,
+    grid,
+    cells,
+    boxes: cells.map((c) => box(c)),
+    gridWidth: Math.round(grid.getBoundingClientRect().width),
+  };
+}
+
+beforeEach(() => {
+  mocks.items = [];
+  mocks.isLoading = false;
+});
+
+describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () => {
+  test('the harness loaded the REAL cascade (positive control — Tailwind must resolve)', async () => {
+    // 🔴 THE CONTROL THIS FILE EXISTS BECAUSE OF. Without Tailwind's utilities
+    // `h-full` is inert, both grids' heights follow their content, and the
+    // comparison below would be between two DIFFERENT wrong layouts that might
+    // still happen to agree. `tailwindFlexUtilityResolves` is `false` under the
+    // `component` tier's default setup and `true` here, so it is evidence rather
+    // than a reassurance.
+    await renderStore(2450, { loading: true });
+    const evidence = cascadeEvidence();
+    expect(
+      evidence.tailwindFlexUtilityResolves,
+      'Tailwind utilities did not resolve — the real cascade did not load'
+    ).toBe(true);
+    expect(evidence.probeBoxSizing, 'Preflight did not load').toBe('border-box');
+    expect(evidence.ruleCount, 'the cascade is far too small to be the real one').toBeGreaterThan(
+      1000
+    );
+  });
+
+  test.each(WIDTHS)(
+    'at $gridWidth px of grid ($columns columns) every skeleton box equals its card box',
+    async ({ gridWidth, columns }) => {
+      // ── ARM 1: LOADING ────────────────────────────────────────────────────
+      const loading = await renderStore(gridWidth, { loading: true });
+      expect(loading.observed).toEqual({ width: VIEWPORT.width, height: VIEWPORT.height });
+      expect(loading.gridWidth, 'the harness did not size the grid as asked').toBe(gridWidth);
+
+      // The count is the thing the skeleton grid decides for itself, so assert it
+      // against the ladder rather than against a number typed here twice.
+      expect(
+        loading.cells.length,
+        `at ${gridWidth}px the skeleton grid rendered ${loading.cells.length} cells; ` +
+          `${APP_LISTING_SKELETON_ROWS} rows at ${columns} columns is ` +
+          `${columns * APP_LISTING_SKELETON_ROWS}`
+      ).toBe(columns * APP_LISTING_SKELETON_ROWS);
+      expect(listingGridColumnsAt(gridWidth)).toBe(columns);
+
+      // ── ARM 2: RESOLVED, with EXACTLY as many listings as there were cells ──
+      // Same count, so any difference in a box is a difference in the CELL, never
+      // a difference in how many rows the grid has.
+      const items = POOL.slice(0, loading.cells.length);
+      expect(items, 'the fixture pool is too small for this column count').toHaveLength(
+        loading.cells.length
+      );
+      const resolved = await renderStore(gridWidth, { loading: false, items });
+      expect(resolved.gridWidth).toBe(gridWidth);
+      expect(resolved.cells).toHaveLength(loading.cells.length);
+
+      // 🔴 NON-VACUITY: the boxes must be real boxes. A pair of collapsed
+      // zero-height trees would compare equal and prove nothing.
+      for (const b of [...loading.boxes, ...resolved.boxes]) {
+        expect(b.width, 'a cell has no width — the grid did not lay out').toBeGreaterThan(100);
+        expect(b.height, 'a cell has no height — the grid did not lay out').toBeGreaterThan(100);
+      }
+
+      // ── THE ASSERTION ─────────────────────────────────────────────────────
+      expect(
+        loading.boxes,
+        `at ${gridWidth}px of grid (${columns} columns) a skeleton cell does not occupy the ` +
+          'box its card will. Every cell in the store therefore MOVES when the query ' +
+          'resolves — which is the entire defect the skeleton exists to remove. Compare ' +
+          `skeleton ${JSON.stringify(loading.boxes[0])} with card ` +
+          `${JSON.stringify(resolved.boxes[0])}.`
+      ).toEqual(resolved.boxes);
+    }
+  );
+
+  /**
+   * Guard-the-guard #1: the two widths really are different column counts, and
+   * neither sits on a rung. A pair resolving to the SAME count would test one
+   * shape twice and nothing above would notice.
+   */
+  test('the two widths really are different column counts, and neither sits on a rung', async () => {
+    const a = await renderStore(WIDTHS[0].gridWidth, { loading: true });
+    const b = await renderStore(WIDTHS[1].gridWidth, { loading: true });
+    expect(a.cells.length).toBe(WIDTHS[0].columns * APP_LISTING_SKELETON_ROWS);
+    expect(b.cells.length).toBe(WIDTHS[1].columns * APP_LISTING_SKELETON_ROWS);
+    expect(a.cells.length).not.toBe(b.cells.length);
+    for (const { gridWidth } of WIDTHS) {
+      for (const rung of RUNGS) {
+        expect(gridWidth, `fixture ${gridWidth} sits exactly on the ${rung} rung`).not.toBe(rung);
+      }
+    }
+  });
+
+  /**
+   * 🔴 Guard-the-guard #2: THE HARNESS REALLY REPLACES THE TREE.
+   *
+   * `vitest-browser-react` appends. If `renderStore`'s `cleanup()` were dropped,
+   * the second render's `querySelectorAll` would return the FIRST render's cells
+   * and every parity assertion above would be comparing a tree to itself — green,
+   * unconditionally, forever. This proves two renders give two answers, which is
+   * the property the whole file rests on.
+   */
+  test('🔴 two renders give two answers — the parity comparison is not a tree against itself', async () => {
+    const narrow = await renderStore(WIDTHS[0].gridWidth, { loading: true });
+    const wide = await renderStore(WIDTHS[1].gridWidth, { loading: true });
+    expect(narrow.boxes[0].width).not.toBe(wide.boxes[0].width);
+    // …and only ONE grid is in the document at a time, which is the mechanism.
+    expect(document.querySelectorAll('[data-testid="apps-listing-skeleton-grid"]')).toHaveLength(1);
+  });
+
+  /**
+   * The reason the cells can be compared positionally at all: the store renders
+   * the SAME control row above both grids, so cell 0's `top` is not being compared
+   * across two different page layouts.
+   */
+  test('both states render the same chrome above the grid, so `top` is comparable', async () => {
+    const loading = await renderStore(2450, { loading: true });
+    const loadingRow = box(
+      document.querySelector('[data-testid="apps-store-control-row"]') as HTMLElement
+    );
+    const resolved = await renderStore(2450, { loading: false, items: POOL.slice(0, 10) });
+    const resolvedRow = box(
+      document.querySelector('[data-testid="apps-store-control-row"]') as HTMLElement
+    );
+    expect(loadingRow).toEqual(resolvedRow);
+    expect(loading.boxes[0].top).toBe(resolved.boxes[0].top);
+  });
+});

--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -54,7 +54,13 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { cleanup } from 'vitest-browser-react';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
-import { box, cascadeEvidence, nextLayout, renderAtViewport } from '../../../test/geometry-setup';
+import {
+  box,
+  cascadeEvidence,
+  LOADABLE_IMAGE_DATA_URI,
+  nextLayout,
+  renderAtViewport,
+} from '../../../test/geometry-setup';
 import type * as TrpcMod from '~/utils/trpc';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
@@ -109,7 +115,12 @@ const POOL: ListingCard[] = [
   makeCard('u12', 'Overtone Bench', 'linnea'),
 ];
 
-const mocks = vi.hoisted(() => ({ items: [] as ListingCard[], isLoading: false }));
+const mocks = vi.hoisted(() => ({
+  items: [] as ListingCard[],
+  isLoading: false,
+  /** The signed-in viewer, or `null`. Drives whether a card renders the `⋮` trigger. */
+  currentUser: null as { id: number; username: string } | null,
+}));
 
 // The same mock set, and the same reasons, as
 // `AppListingsMarketplaceBody.stretch.geometry.test.tsx` — see the long notes in
@@ -118,7 +129,7 @@ const mocks = vi.hoisted(() => ({ items: [] as ListingCard[], isLoading: false }
 // THROW without a provider, and the flags factory must name BOTH flag hooks or the
 // whole file fails to IMPORT and reports `no tests` rather than a failure.
 // `next/router` is already mocked by `test/geometry-setup.tsx`.
-vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => mocks.currentUser }));
 vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
 vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
@@ -157,6 +168,9 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
 const { APP_LISTING_SKELETON_ROWS } = await import('./AppListingCardSkeleton');
 const { listingGridColumnsAt } = await import('./appListingGrid');
+const { LISTING_ACTION_ROW_CONTROL_PX, LISTING_ACTION_ROW_GAP_PX } = await import(
+  './appListingCardGeometry'
+);
 
 /**
  * A viewport wide enough that neither grid width below is clamped by it. The grid
@@ -196,10 +210,19 @@ const RUNGS = [736, 960, 1168, 2364, 2840];
  * found and fixed in two sibling suites; `the harness really replaces the tree`
  * below is the control that proves the cure works here.
  */
-async function renderStore(gridWidth: number, opts: { loading: boolean; items?: ListingCard[] }) {
+async function renderStore(
+  gridWidth: number,
+  opts: {
+    loading: boolean;
+    items?: ListingCard[];
+    /** Signed-out unless given. An owner gets the `⋮` trigger on every card. */
+    viewer?: { id: number; username: string } | null;
+  }
+) {
   await cleanup();
   mocks.isLoading = opts.loading;
   mocks.items = opts.items ?? [];
+  mocks.currentUser = opts.viewer ?? null;
   const { observed } = await renderAtViewport(
     <div style={{ width: gridWidth, maxWidth: 'none' }} data-testid="width-harness">
       <AppListingsMarketplaceBody />
@@ -223,9 +246,35 @@ async function renderStore(gridWidth: number, opts: { loading: boolean; items?: 
   };
 }
 
+/**
+ * The rendered width of each card's CTA button — the action row's first child.
+ *
+ * Resolved structurally because `AppListingCard` puts no testid on the CTA, and
+ * VALIDATED rather than trusted: a silently mis-resolved element would make the
+ * comparison below compare the wrong boxes and pass.
+ */
+function ctaWidths(): number[] {
+  const cells = Array.from(
+    document.querySelectorAll('[data-testid="apps-listing-grid-col"]')
+  ) as HTMLElement[];
+  return cells.map((cell) => {
+    const card = cell.firstElementChild as HTMLElement | null;
+    const stack = card?.lastElementChild as HTMLElement | null;
+    const actionRow = stack?.lastElementChild as HTMLElement | null;
+    const cta = actionRow?.firstElementChild as HTMLElement | null;
+    if (!cta || !(cta.tagName === 'BUTTON' || cta.tagName === 'A')) {
+      throw new Error(
+        `the walk did not land on the CTA control: ${cta?.outerHTML.slice(0, 200) ?? 'null'}`
+      );
+    }
+    return Math.round(cta.getBoundingClientRect().width * 100) / 100;
+  });
+}
+
 beforeEach(() => {
   mocks.items = [];
   mocks.isLoading = false;
+  mocks.currentUser = null;
 });
 
 describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () => {
@@ -329,6 +378,84 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
     expect(narrow.boxes[0].width).not.toBe(wide.boxes[0].width);
     // …and only ONE grid is in the document at a time, which is the mechanism.
     expect(document.querySelectorAll('[data-testid="apps-listing-skeleton-grid"]')).toHaveLength(1);
+  });
+
+  /**
+   * 🔴 THE `LISTING_ACTION_ROW_GAP_PX` EXCLUSION, MEASURED RATHER THAN ASSERTED IN
+   * PROSE.
+   *
+   * `AppListingCardSkeleton` deliberately does not read that constant: it is the gap
+   * between the CTA and the `⋮` overflow trigger, a card renders that trigger only
+   * for an owner or a moderator, and a loading state cannot know which viewer it is
+   * about to serve. `__tests__/appListingCardSkeleton.test.ts` carries the exclusion
+   * as a named carve-out, and a carve-out justified by "it costs no geometry" has to
+   * have that COST measured, or it is a promise.
+   *
+   * So: the same listings, the same width, rendered for a signed-out viewer and for
+   * their OWNER. The trigger appears, the CTA gives up exactly
+   * `LISTING_ACTION_ROW_CONTROL_PX + LISTING_ACTION_ROW_GAP_PX` of width to it — and
+   * the CARD's box does not move. That is the whole claim.
+   *
+   * The fixture carries an icon and a cover here, unlike the parity fixture above:
+   * an owner looking at a listing missing either gets the "Incomplete" badge, which
+   * would make the owner arm genuinely taller for a reason that has nothing to do
+   * with the trigger and would turn this measurement into a different test.
+   */
+  test('🔴 the ⋮ trigger takes width from the CTA and NOTHING from the card box', async () => {
+    const OWNER = { id: 7331, username: 'ashling' };
+    const COMPLETE = POOL.slice(0, 8).map((c) => ({
+      ...c,
+      iconUrl: LOADABLE_IMAGE_DATA_URI,
+      coverUrl: LOADABLE_IMAGE_DATA_URI,
+    }));
+    const GRID_WIDTH = 1376;
+
+    const anon = await renderStore(GRID_WIDTH, { loading: false, items: COMPLETE });
+    const anonMenus = document.querySelectorAll(
+      '[data-testid="apps-listing-card-actions-menu"]'
+    ).length;
+    const anonCtas = ctaWidths();
+
+    const owner = await renderStore(GRID_WIDTH, {
+      loading: false,
+      items: COMPLETE,
+      viewer: OWNER,
+    });
+    const ownerMenus = document.querySelectorAll(
+      '[data-testid="apps-listing-card-actions-menu"]'
+    ).length;
+    const ownerCtas = ctaWidths();
+
+    // POSITIVE CONTROL, FIRST — the two arms must genuinely differ, or "the boxes
+    // are equal" is a fact about rendering the same thing twice.
+    expect(anonMenus, 'the signed-out arm rendered a ⋮ trigger it should not have').toBe(0);
+    expect(ownerMenus, 'the owner arm rendered no ⋮ trigger — the arms are identical').toBe(
+      owner.cells.length
+    );
+    // …and no "Incomplete" badge crept in, which would make the owner arm taller for
+    // an unrelated reason.
+    expect(document.querySelectorAll('[data-testid="apps-listing-owner-incomplete"]')).toHaveLength(
+      0
+    );
+
+    // THE CTA PAYS FOR THE TRIGGER — exactly the trigger plus the row gap.
+    expect(anonCtas.length).toBe(ownerCtas.length);
+    for (let i = 0; i < anonCtas.length; i++) {
+      expect(
+        Math.round(anonCtas[i] - ownerCtas[i]),
+        `CTA ${i} did not give up exactly the trigger + gap when the ⋮ appeared ` +
+          `(${anonCtas[i]} -> ${ownerCtas[i]})`
+      ).toBe(LISTING_ACTION_ROW_CONTROL_PX + LISTING_ACTION_ROW_GAP_PX);
+    }
+
+    // …AND THE CARD DOES NOT MOVE. This is what licenses the skeleton to ignore the
+    // gap constant.
+    expect(
+      anon.boxes,
+      'a card changes box when its viewer gains the ⋮ trigger — the skeleton cannot ' +
+        'then reserve one box for both viewers, and the gap exclusion in ' +
+        '__tests__/appListingCardSkeleton.test.ts is wrong'
+    ).toEqual(owner.boxes);
   });
 
   /**

--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -51,7 +51,7 @@
  * taller than its skeleton and the grid still resizes — stated in the component's
  * header and in the PR body rather than papered over here.
  */
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { cleanup } from 'vitest-browser-react';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import {
@@ -246,6 +246,17 @@ async function renderStore(
   };
 }
 
+/** How many cells share the FIRST visual row — i.e. the column count CSS produced. */
+function firstRowCount(cells: HTMLElement[]): number {
+  if (cells.length === 0) return 0;
+  const tops = cells.map((c) => Math.round(c.getBoundingClientRect().top));
+  const first = Math.min(...tops);
+  return tops.filter((t) => t === first).length;
+}
+
+/** 2dp, so sub-pixel layout is visible but float noise is not. */
+const q = (n: number) => Math.round(n * 100) / 100;
+
 /**
  * The rendered width of each card's CTA button — the action row's first child.
  *
@@ -271,10 +282,48 @@ function ctaWidths(): number[] {
   });
 }
 
+/**
+ * 🔴 REACT'S OWN DOM-VALIDITY CHANNEL, WIRED TO THE RUN'S VERDICT.
+ *
+ * `validateDOMNesting` is a `console.error`, not a thrown error, so it scrolls past in
+ * a run that reports green. That is not hypothetical here: this very file emitted
+ * `<div> cannot appear as a descendant of <p>` at `MetaLineSkeleton` on EVERY run of
+ * round 1 and still reported 7 passed — the offending element is `position: absolute`,
+ * so no box comparison can see it. A geometry suite is structurally blind to invalid
+ * nesting; this makes it not blind.
+ *
+ * Kept as a SECOND, independent signal beside
+ * `AppListingCardSkeleton.ssr.browser.test.tsx`'s string scan of the server markup:
+ * the two fail differently, so a change to React's warning text cannot disarm both.
+ */
+const domNestingErrors: string[] = [];
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
+
 beforeEach(() => {
   mocks.items = [];
   mocks.isLoading = false;
   mocks.currentUser = null;
+  domNestingErrors.length = 0;
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    const text = args.map((a) => String(a)).join(' ');
+    if (text.includes('validateDOMNesting') || text.includes('cannot appear as a descendant')) {
+      domNestingErrors.push(text);
+    }
+  });
+});
+
+afterEach(() => {
+  consoleErrorSpy?.mockRestore();
+  consoleErrorSpy = null;
+  // 🔴 ASSERTED IN THE HOOK, so it covers EVERY test in this file rather than the one
+  // someone remembered to add it to — including the ones whose whole point is to
+  // render the card and the skeleton side by side.
+  expect(
+    domNestingErrors,
+    'React reported invalid DOM nesting while rendering. A parser auto-closes the ' +
+      "offending parent, so the parsed DOM and React's tree disagree — that is a " +
+      'hydration mismatch on /apps, not a lint nit.'
+  ).toEqual([]);
 });
 
 describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () => {
@@ -344,6 +393,114 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
       ).toEqual(resolved.boxes);
     }
   );
+
+  /**
+   * 🔴 THE CELL COUNT IS TWO ROWS OF THE GRID **AS CSS ACTUALLY LAID IT OUT** — not
+   * two rows of what the ladder says CSS should have done.
+   *
+   * The skeleton grid computes its count in JS (`listingGridColumnsAt` over a measured
+   * width) while the tracks are produced by an `@container (min-width: …)` query. Two
+   * mechanisms, one number, and they can silently disagree: a query container's size is
+   * its CONTENT box while `getBoundingClientRect()` is the BORDER box, so a `padding`
+   * or `border` added to `.gridContainer` — a plausible styling change — desynchronises
+   * them. The component subtracts padding and border for exactly that reason, but a
+   * check that re-derived the expected count from the ladder would be testing the JS
+   * against itself and would not notice.
+   *
+   * So this compares the count against the RENDERED first row: whatever CSS decided the
+   * column count is, the grid must hold exactly `APP_LISTING_SKELETON_ROWS` of them.
+   * That is a RELATIONSHIP, and it catches the desync above and any other cause of one.
+   */
+  test.each(WIDTHS)(
+    'at $gridWidth px the cell count is exactly two rows of the grid CSS actually laid out',
+    async ({ gridWidth, columns }) => {
+      const m = await renderStore(gridWidth, { loading: true });
+      const rendered = firstRowCount(m.cells);
+      expect(
+        m.cells.length,
+        `the grid rendered ${rendered} columns but the skeleton emitted ${m.cells.length} ` +
+          `cells, which is not ${APP_LISTING_SKELETON_ROWS} rows of it. The JS column ` +
+          'count and the @container ladder have desynchronised — check whether ' +
+          '`.gridContainer` gained padding or a border (the query reads the CONTENT box, ' +
+          '`getBoundingClientRect()` the BORDER box).'
+      ).toBe(rendered * APP_LISTING_SKELETON_ROWS);
+      // …and the rendered count really is the one the ladder predicts, so a failure
+      // above is attributable rather than merely a mismatch between two unknowns.
+      expect(rendered).toBe(columns);
+    }
+  );
+
+  /**
+   * 🔴 THE FOURTH CONTENT-VARIANCE AXIS, AND THE ONLY ONE THAT RUNS **DOWNWARD**.
+   *
+   * `ListingCard.creator` is nullable and `AppListingCard`'s `CreatorChip` returns
+   * `null` for a listing without one, while this skeleton reserves that line
+   * unconditionally. So such a card is SHORTER than its skeleton — the opposite
+   * direction from the tagline and the two badges, and it went undocumented for a
+   * round while the header and the PR body both said only "taller". It is not
+   * hypothetical: this PR's own `keepPreviousData` fixture uses `creator: null`.
+   *
+   * 🔴 THE DELTA IS DERIVED FROM THE RENDER, NOT RESTATED. Asserting "−22.29px" would
+   * pin a number nobody could check; asserting that the shortfall equals the skeleton's
+   * own creator line plus the meta stack's gap — both measured off the live tree — says
+   * WHY it is what it is, and stays true if the type scale moves.
+   */
+  test('🔴 a card with NO CREATOR is SHORTER than its skeleton, by exactly the reserved line', async () => {
+    const GRID_WIDTH = 1376;
+
+    // The skeleton, and the two meta lines it reserves.
+    const skel = await renderStore(GRID_WIDTH, { loading: true });
+    const creatorLine = box(
+      document.querySelector('[data-testid="apps-listing-skeleton-creator"]') as HTMLElement
+    );
+    const rollupLine = box(
+      document.querySelector('[data-testid="apps-listing-skeleton-rollup"]') as HTMLElement
+    );
+    // The meta `Stack`'s gap, measured rather than spelled: the card writes `gap={2}`
+    // and so does the skeleton, and neither number is in the geometry module.
+    const metaGap = q(rollupLine.top - creatorLine.bottom);
+    const skeletonHeight = skel.boxes[0].height;
+
+    // Arm A — WITH a creator. This is the parity fixture, and the parity test above
+    // already pins it equal to the skeleton; re-read here so the subtraction below is
+    // between two numbers this test measured itself.
+    const withCreator = await renderStore(GRID_WIDTH, {
+      loading: false,
+      items: POOL.slice(0, skel.cells.length),
+    });
+    expect(withCreator.boxes[0].height).toBe(skeletonHeight);
+
+    // Arm B — the SAME listings with the creator removed. Nothing else differs.
+    const withoutCreator = await renderStore(GRID_WIDTH, {
+      loading: false,
+      items: POOL.slice(0, skel.cells.length).map((c) => ({ ...c, creator: null })),
+    });
+
+    // NON-VACUITY: the chip really is gone, so the height change has a named cause.
+    expect(
+      document.querySelectorAll('[data-testid="apps-listing-grid-col"] a[href^="/user/"]'),
+      'the creator chip still rendered — the fixture did not actually drop it'
+    ).toHaveLength(0);
+
+    const shortfall = q(withCreator.boxes[0].height - withoutCreator.boxes[0].height);
+    const reserved = q(creatorLine.height + metaGap);
+    // 🔴 A SUB-PIXEL TOLERANCE, AND WHY IT DOES NOT WEAKEN THE CLAIM. Both sides are
+    // fractional layouts rounded independently (measured: 22.29 vs 20.3 + 2 = 22.30),
+    // so exact equality pins float noise rather than the reservation. 0.1px is far
+    // below the smallest thing that could be wrongly reserved here — the meta lines are
+    // 16.8 and 20.3 tall and the title box is 48 — so no incorrect reservation fits
+    // inside it.
+    expect(
+      Math.abs(shortfall - reserved),
+      `a creator-less card is ${shortfall}px shorter than its skeleton, which should be ` +
+        `the reserved creator line (${creatorLine.height}) plus the meta stack gap ` +
+        `(${metaGap}) = ${reserved}. If these disagree by more than sub-pixel rounding, ` +
+        'the skeleton is reserving something else too.'
+    ).toBeLessThan(0.1);
+
+    // …and state the DIRECTION explicitly, because that is the half the docs got wrong.
+    expect(withoutCreator.boxes[0].height).toBeLessThan(skeletonHeight);
+  });
 
   /**
    * Guard-the-guard #1: the two widths really are different column counts, and

--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -166,7 +166,7 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
 
 // Import AFTER the mocks (vi.mock is hoisted; static imports are not).
 const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
-const { APP_LISTING_SKELETON_ROWS } = await import('./AppListingCardSkeleton');
+const { APP_LISTING_SKELETON_ROWS, gridQueryInlineSize } = await import('./AppListingCardSkeleton');
 const { listingGridColumnsAt } = await import('./appListingGrid');
 const { LISTING_ACTION_ROW_CONTROL_PX, LISTING_ACTION_ROW_GAP_PX } = await import(
   './appListingCardGeometry'
@@ -295,6 +295,16 @@ function ctaWidths(): number[] {
  * Kept as a SECOND, independent signal beside
  * `AppListingCardSkeleton.ssr.browser.test.tsx`'s string scan of the server markup:
  * the two fail differently, so a change to React's warning text cannot disarm both.
+ *
+ * ⚠️ IT IS ONE CHECK, NOT TEN — AND AN EARLIER VERSION OF THIS NOTE SAID OTHERWISE.
+ * It claimed the hook "covers EVERY test in this file rather than the one someone
+ * remembered to add it to". React DEDUPES `validateDOMNesting` per warn-key per module
+ * instance, so with the defect reintroduced the whole file reports **1 failed / 9
+ * passed** even though 9 of the 10 tests render the offending markup; run the late
+ * "NO CREATOR" test alone and it reds by itself. The hook does RUN on every test, and
+ * the guard is not inert — it goes red — but what it buys is "this file will fail if
+ * the pairing is ever rendered", not ten independent assertions. Do not price it as
+ * per-test coverage.
  */
 const domNestingErrors: string[] = [];
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
@@ -304,11 +314,17 @@ beforeEach(() => {
   mocks.isLoading = false;
   mocks.currentUser = null;
   domNestingErrors.length = 0;
+  // 🔴 CALL THROUGH. `mockImplementation` REPLACES the console method, so a spy that
+  // only collects would silently swallow every unrelated React/Mantine warning in this
+  // file — in the file whose own docstring says such a warning "scrolls past in a run
+  // that reports green". Collect AND forward.
+  const originalError = console.error.bind(console) as (...args: unknown[]) => void;
   consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
     const text = args.map((a) => String(a)).join(' ');
     if (text.includes('validateDOMNesting') || text.includes('cannot appear as a descendant')) {
       domNestingErrors.push(text);
     }
+    originalError(...args);
   });
 });
 
@@ -395,21 +411,27 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
   );
 
   /**
-   * 🔴 THE CELL COUNT IS TWO ROWS OF THE GRID **AS CSS ACTUALLY LAID IT OUT** — not
-   * two rows of what the ladder says CSS should have done.
+   * The cell count is two rows of the grid AS CSS ACTUALLY LAID IT OUT — not two rows
+   * of what the ladder says CSS should have done. The count is computed in JS while
+   * the tracks come from an `@container` query, so comparing the count against the
+   * RENDERED first row is a relationship between the two mechanisms rather than a
+   * re-derivation of one from the other.
    *
-   * The skeleton grid computes its count in JS (`listingGridColumnsAt` over a measured
-   * width) while the tracks are produced by an `@container (min-width: …)` query. Two
-   * mechanisms, one number, and they can silently disagree: a query container's size is
-   * its CONTENT box while `getBoundingClientRect()` is the BORDER box, so a `padding`
-   * or `border` added to `.gridContainer` — a plausible styling change — desynchronises
-   * them. The component subtracts padding and border for exactly that reason, but a
-   * check that re-derived the expected count from the ladder would be testing the JS
-   * against itself and would not notice.
+   * ⚠️ THIS IS **NOT** THE BOX-MODEL DESYNC GUARD, AND AN EARLIER VERSION OF THIS
+   * DOCBLOCK CLAIMED IT WAS ("it catches the desync above and any other cause"). An
+   * audit measured it PASSING with `padding: 8px` on `.gridContainer` and the
+   * component's subtraction removed — i.e. firing identically on its own control,
+   * which attributes nothing. The cause is structural, not a bad assertion: both
+   * fixtures sit deliberately MID-BAND (1376 is 208px above the 1168 rung, 2450 is
+   * 86px above 2364) so an off-by-one cannot reach them, and that same margin means no
+   * plausible padding can move the column count either. The property that makes them
+   * good PARITY fixtures is what blinds them here. It IS reachable — at `padding: 50px`
+   * it reds with its own message — but only at a padding nobody would write.
    *
-   * So this compares the count against the RENDERED first row: whatever CSS decided the
-   * column count is, the grid must hold exactly `APP_LISTING_SKELETON_ROWS` of them.
-   * That is a RELATIONSHIP, and it catches the desync above and any other cause of one.
+   * The desync is therefore guarded separately and without any fixture, against the
+   * container's own content box: see "the query inline size IS the container's content
+   * box" below. What THIS test still buys is the count↔track relationship at two real
+   * column counts, which is worth having and is all it should be read as.
    */
   test.each(WIDTHS)(
     'at $gridWidth px the cell count is exactly two rows of the grid CSS actually laid out',
@@ -429,6 +451,87 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
       expect(rendered).toBe(columns);
     }
   );
+
+  /**
+   * 🔴 THE BOX-MODEL DESYNC, GUARDED WITHOUT A FIXTURE.
+   *
+   * The component picks its column count from `gridQueryInlineSize(container)`, which
+   * must equal what an `@container` query sees: the container's CONTENT box.
+   * `getBoundingClientRect()` gives the BORDER box, so dropping the padding/border
+   * subtraction desynchronises the cell count from the rendered tracks — silently,
+   * because today `.gridContainer` has neither.
+   *
+   * This asserts that equality DIRECTLY, against a second and independent read of the
+   * same quantity (`getComputedStyle().width` is the used content-box width whatever
+   * `box-sizing` says), and it applies the padding ITSELF rather than waiting for a
+   * fixture width at which the count happens to flip. That is what makes it
+   * independent of where `WIDTHS` sit — the failure mode the count↔row test above was
+   * measured to have.
+   */
+  test("🔴 the query inline size IS the container's content box, padded or not", async () => {
+    await renderStore(WIDTHS[0].gridWidth, { loading: true });
+    const container = document.querySelector(
+      '[data-testid="apps-listing-skeleton-grid-container"]'
+    ) as HTMLElement;
+    const grid = document.querySelector(
+      '[data-testid="apps-listing-skeleton-grid"]'
+    ) as HTMLElement;
+    expect(container, 'the skeleton grid container did not render').not.toBeNull();
+    expect(grid, 'the skeleton grid did not render').not.toBeNull();
+
+    /**
+     * 🔴 THE REFERENCE READ: THE GRID'S OWN WIDTH.
+     *
+     * `.grid` is a block-level child with no margin, so its border box fills the
+     * container's CONTENT box exactly — a layout-derived, fractional, independent
+     * measurement of the very quantity the `@container` query sizes.
+     *
+     * ⚠️ `getComputedStyle(container).width` WAS THE FIRST CHOICE AND IS WRONG, and
+     * only the positive control below caught it: under `box-sizing: border-box` —
+     * which Preflight sets on everything — Chrome resolves `width` to the BORDER box.
+     * Measured with 8px padding + 2px borders on a 1376px container: computed `width`
+     * `1376px`, `clientWidth` 1372, true content box 1356. A reference that tracks the
+     * value under test is not a reference.
+     */
+    const contentBox = () => grid.getBoundingClientRect().width;
+
+    // ── ARM 1: as shipped — no padding, no border. The two agree trivially, which is
+    // exactly why this arm cannot be the whole guard. It is not useless either: it is
+    // what fires if `.gridContainer` ever GAINS padding in the stylesheet while the
+    // component still measures the border box.
+    expect(
+      Math.abs(gridQueryInlineSize(container) - contentBox()),
+      "the container query inline size and the grid's own width disagree with no " +
+        'padding or border in play — either `.gridContainer` gained one in the ' +
+        'stylesheet, or `gridQueryInlineSize` stopped measuring the content box'
+    ).toBeLessThan(0.01);
+    expect(container.getBoundingClientRect().width).toBeCloseTo(contentBox(), 1);
+
+    // ── ARM 2: the plausible styling change, applied here rather than hoped for.
+    container.style.padding = '8px';
+    container.style.borderLeft = '2px solid transparent';
+    container.style.borderRight = '2px solid transparent';
+    await nextLayout();
+
+    // POSITIVE CONTROL — the box model really moved, so a pass below is about the
+    // subtraction and not about a style that silently did nothing.
+    expect(
+      container.getBoundingClientRect().width - contentBox(),
+      'the padding/border did not change the box model — this arm is testing nothing'
+    ).toBeCloseTo(20, 1);
+
+    expect(
+      Math.abs(gridQueryInlineSize(container) - contentBox()),
+      'the measured inline size is the BORDER box, not the CONTENT box. An @container ' +
+        'query reads the content box, so the skeleton computes its cell count from a ' +
+        'different width than CSS uses for its tracks — restore the padding/border ' +
+        'subtraction in `gridQueryInlineSize`.'
+    ).toBeLessThan(0.01);
+
+    container.style.padding = '';
+    container.style.borderLeft = '';
+    container.style.borderRight = '';
+  });
 
   /**
    * 🔴 THE FOURTH CONTENT-VARIANCE AXIS, AND THE ONLY ONE THAT RUNS **DOWNWARD**.

--- a/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.geometry.test.tsx
@@ -331,9 +331,13 @@ beforeEach(() => {
 afterEach(() => {
   consoleErrorSpy?.mockRestore();
   consoleErrorSpy = null;
-  // 🔴 ASSERTED IN THE HOOK, so it covers EVERY test in this file rather than the one
-  // someone remembered to add it to — including the ones whose whole point is to
-  // render the card and the skeleton side by side.
+  // 🔴 ASSERTED IN THE HOOK so no test can forget it — but it is ONE check for the
+  // file, not one per test: React dedupes `validateDOMNesting` per warn-key, so with
+  // the defect present the file reports 1 failed / 9 passed even though 9 of the 10
+  // tests render the offending markup. See the declaration above for the measurement.
+  // (An earlier version of this comment claimed it "covers EVERY test in this file",
+  // and the correction was ADDED beside the declaration while this sentence — the one
+  // a reader debugging a failure actually meets — was left saying the opposite.)
   expect(
     domNestingErrors,
     'React reported invalid DOM nesting while rendering. A parser auto-closes the ' +
@@ -441,10 +445,12 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
       expect(
         m.cells.length,
         `the grid rendered ${rendered} columns but the skeleton emitted ${m.cells.length} ` +
-          `cells, which is not ${APP_LISTING_SKELETON_ROWS} rows of it. The JS column ` +
-          'count and the @container ladder have desynchronised — check whether ' +
-          '`.gridContainer` gained padding or a border (the query reads the CONTENT box, ' +
-          '`getBoundingClientRect()` the BORDER box).'
+          `cells, which is not ${APP_LISTING_SKELETON_ROWS} rows of it — so the cell ` +
+          'count and the rendered track count disagree. Look at ' +
+          '`APP_LISTING_SKELETON_ROWS` and at what the layout effect sets `columns` to. ' +
+          '🔴 NOT a box-model lead: this test is measurably blind to that (see its ' +
+          'docblock), and "the query inline size IS the container\'s content box" is the ' +
+          'guard that owns it — if THAT one is green, padding is not your cause.'
       ).toBe(rendered * APP_LISTING_SKELETON_ROWS);
       // …and the rendered count really is the one the ladder predicts, so a failure
       // above is attributable rather than merely a mismatch between two unknowns.
@@ -508,17 +514,27 @@ describe('🔴 a skeleton cell occupies EXACTLY the box the card cell will', () 
     expect(container.getBoundingClientRect().width).toBeCloseTo(contentBox(), 1);
 
     // ── ARM 2: the plausible styling change, applied here rather than hoped for.
-    container.style.padding = '8px';
+    //
+    // 🔴 ASYMMETRIC, AND EVERY EDGE DISTINCT. An earlier version used `padding: 8px`
+    // with equal 2px borders, which cannot tell left from right: the copy-paste mutant
+    // `rect.width - px(cs.paddingLeft) - px(cs.paddingLeft)` survived it at 11/11. In
+    // production that mis-subtracts by `paddingRight − paddingLeft` on any asymmetric
+    // padding, and `padding: 8px 16px` is at least as plausible as `padding: 8px`.
+    // Four distinct paddings and two distinct borders make every term observable.
+    container.style.padding = '4px 16px 12px 32px'; // T R B L
     container.style.borderLeft = '2px solid transparent';
-    container.style.borderRight = '2px solid transparent';
+    container.style.borderRight = '6px solid transparent';
     await nextLayout();
+
+    /** left + right padding + left + right border — what the subtraction must remove. */
+    const INLINE_INSETS = 32 + 16 + 2 + 6;
 
     // POSITIVE CONTROL — the box model really moved, so a pass below is about the
     // subtraction and not about a style that silently did nothing.
     expect(
       container.getBoundingClientRect().width - contentBox(),
       'the padding/border did not change the box model — this arm is testing nothing'
-    ).toBeCloseTo(20, 1);
+    ).toBeCloseTo(INLINE_INSETS, 1);
 
     expect(
       Math.abs(gridQueryInlineSize(container) - contentBox()),

--- a/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
@@ -1,0 +1,151 @@
+import { MantineProvider } from '@mantine/core';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+import {
+  AppListingCardSkeletonGrid,
+  APP_LISTING_SKELETON_ROWS,
+  APP_LISTING_SKELETON_SSR_COLUMNS,
+} from '~/components/Apps/AppListingCardSkeleton';
+
+/**
+ * `/apps` store — WHAT THE SERVER ACTUALLY EMITS FOR THE LOADING STATE.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 THIS FILE EXISTS BECAUSE ITS ABSENCE SHIPPED TWO DEFECTS IN ONE COMMIT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The first round of this change replaced `<Center py="xl"><Loader /></Center>` with
+ * a skeleton grid whose cell count came from `useState(0)` corrected in a layout
+ * effect. `useIsomorphicLayoutEffect` is `useLayoutEffect` only when `window` exists
+ * and a plain `useEffect` otherwise — so it does not run during SSR at all — and tRPC
+ * runs `ssr: false`, so the server always renders the `isLoading` branch. Net effect:
+ * the server emitted an EMPTY grid. A spinner was replaced with nothing, on a page
+ * whose own Lighthouse bot reports a 6.4s LCP, and two rows of skeletons popped in at
+ * hydration.
+ *
+ * The component's own docstring asserted the opposite ("the count is set BEFORE the
+ * browser paints and the viewer never sees the zero-cell first render") one sentence
+ * after correctly naming SSR. Neither the parity suite nor the node guard could see
+ * it: one measures a browser render where the effect HAS run, the other reads source
+ * text. An adversarial audit found it. This file is the check that should have.
+ *
+ * The second defect is in the same blind spot for the same reason: Mantine's `Text`
+ * renders `<p>` and Mantine's `Skeleton` renders `<div>`, and `<div>` may not descend
+ * from `<p>`. A parser auto-closes the `<p>`, so the parsed DOM and React's tree
+ * disagree — a hydration mismatch, 16–20 times per store load. The parity suite
+ * emitted `validateDOMNesting` warnings on every run and still reported 7 passed,
+ * because the offending element is `position: absolute` and contributes no geometry.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY `renderToString` IS THE RIGHT INSTRUMENT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * It runs NO effects — not `useEffect`, not `useLayoutEffect` — so it reproduces the
+ * server's output faithfully even though this suite runs in a browser where `window`
+ * exists. That is what makes the assertion below a claim about production SSR rather
+ * than about this harness. (`AppsSubNav.ssrHydration.browser.test.tsx` uses the same
+ * instrument for the same reason.)
+ */
+
+/** The server's markup for the loading grid, under the provider the app uses. */
+function serverHtml(): string {
+  return renderToString(
+    <MantineProvider>
+      <AppListingCardSkeletonGrid />
+    </MantineProvider>
+  );
+}
+
+/** How many grid cells that markup contains. */
+function cellCount(html: string): number {
+  return [...html.matchAll(/data-testid="apps-listing-skeleton-col"/g)].length;
+}
+
+/**
+ * Every `<div …>` that appears between a `<p …>` and its `</p>`.
+ *
+ * 🔴 A DELIBERATELY DUMB SCAN, AND IT HAS A POSITIVE CONTROL BELOW. Parsing the
+ * string with the browser's own parser would be useless here: the parser is the thing
+ * that AUTO-CLOSES the `<p>`, so by the time it hands back a tree the invalid nesting
+ * has been silently repaired and the offence is gone. The defect lives in the STRING.
+ */
+function divsInsideParagraphs(html: string): number {
+  let count = 0;
+  const openP = /<p\b[^>]*>/g;
+  let m: RegExpExecArray | null;
+  while ((m = openP.exec(html)) !== null) {
+    const from = m.index + m[0].length;
+    const close = html.indexOf('</p>', from);
+    const segment = close === -1 ? html.slice(from) : html.slice(from, close);
+    count += [...segment.matchAll(/<div\b/g)].length;
+  }
+  return count;
+}
+
+describe('🔴 the server emits a real skeleton grid, not an empty one', () => {
+  test('POSITIVE CONTROLS — the instrument produces markup and the scanners can see it', () => {
+    const html = serverHtml();
+    // The render happened at all.
+    expect(html.length, 'renderToString produced nothing').toBeGreaterThan(200);
+    expect(html).toContain('apps-listing-skeleton-grid');
+
+    // 🔴 THE SCANNERS THEMSELVES, FED A CASE THEY MUST FLAG. A reassuring zero from
+    // `divsInsideParagraphs` is indistinguishable from a regex wired to nothing, so
+    // watch it return a non-zero count before believing the zero it returns below.
+    expect(divsInsideParagraphs('<p class="x"><div>bar</div></p>')).toBe(1);
+    expect(divsInsideParagraphs('<p>a</p><div>b</div>')).toBe(0);
+    expect(cellCount('<i data-testid="apps-listing-skeleton-col"></i>')).toBe(1);
+    expect(cellCount('<i></i>')).toBe(0);
+  });
+
+  /**
+   * 🔴 THE ASSERTION THE DEFECT WOULD HAVE FAILED. It is deliberately an EXACT count
+   * rather than `> 0`: "some cells" would pass on a seed of 1, which would make every
+   * desktop first paint render two full-width cards that become eight quarter-width
+   * ones at hydration — a PER-CELL shift, i.e. the thing this whole PR removes.
+   */
+  test('the server renders exactly two rows at the seeded column count', () => {
+    const html = serverHtml();
+    const cells = cellCount(html);
+    expect(
+      cells,
+      `the server emitted ${cells} skeleton cells. Zero means the loading state is ` +
+        'EMPTY server-side — a spinner replaced with nothing, popping in at hydration. ' +
+        'Check that `columns` is seeded from APP_LISTING_SKELETON_SSR_COLUMNS rather ' +
+        'than 0: the layout effect that corrects it does NOT run during SSR.'
+    ).toBe(APP_LISTING_SKELETON_SSR_COLUMNS * APP_LISTING_SKELETON_ROWS);
+    // …and the seed is the derived desktop rung, not something hand-picked. 4 is typed
+    // out here and derived there, so a test that reads the value and asserts it equals
+    // itself is not what this is.
+    expect(APP_LISTING_SKELETON_SSR_COLUMNS).toBe(4);
+    expect(cells).toBe(8);
+  });
+
+  test('🔴 the server markup contains no <div> inside a <p> — no hydration mismatch', () => {
+    const html = serverHtml();
+    expect(
+      divsInsideParagraphs(html),
+      'a <div> is nested inside a <p> in the server markup. An HTML parser auto-closes ' +
+        "the <p> at the <div>, so the parsed DOM is `<p></p><div></div>` while React's " +
+        'tree is `<p><div/></p>` — a hydration mismatch on every /apps load. Mantine ' +
+        '`Text` is a <p> and Mantine `Skeleton` is a <div>: pass `component="span"` to ' +
+        'the Skeleton (NOT `component="div"` to the Text — that moves the element the ' +
+        'meta line is measured on).'
+    ).toBe(0);
+    // The offending elements are still THERE — this is not passing by rendering less.
+    expect(html).toContain('apps-listing-skeleton-creator');
+    expect(html).toContain('apps-listing-skeleton-rollup');
+    expect(html).toContain('<p');
+  });
+
+  /**
+   * The grid announces itself once. Cheap, and it is the only thing on the loading
+   * path that carries announcement semantics at all — `aria-busy` on the results
+   * container does not (it defers processing WITHIN a live region; that container is
+   * not one).
+   */
+  test('the loading grid is announced, once', () => {
+    const html = serverHtml();
+    expect([...html.matchAll(/role="status"/g)]).toHaveLength(1);
+    expect(html).toContain('aria-label="Loading apps"');
+  });
+});

--- a/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
@@ -138,14 +138,34 @@ describe('🔴 the server emits a real skeleton grid, not an empty one', () => {
   });
 
   /**
-   * The grid announces itself once. Cheap, and it is the only thing on the loading
-   * path that carries announcement semantics at all — `aria-busy` on the results
-   * container does not (it defers processing WITHIN a live region; that container is
-   * not one).
+   * 🔴 THE LIVE REGION HAS SOMETHING TO ANNOUNCE, AND IS NOT MARKED BUSY.
+   *
+   * ⚠️ THIS TEST USED TO BE `expect(html).toContain('aria-label="Loading apps"')` AND
+   * IT WAS TITLED "announced, once" — a name wider than its body, over markup that
+   * most likely announced NOTHING. The region carried `role="status" aria-busy="true"`
+   * with every descendant `aria-hidden`: `aria-busy="true"` on a live region is the
+   * standard instruction to withhold announcements (and it was a hardcoded literal
+   * that never cleared — the grid unmounts instead), a fully `aria-hidden` subtree has
+   * no announceable content, and a live region announces its CONTENT rather than its
+   * label. An audit found it in the paragraph rewritten to stop overstating exactly
+   * this.
+   *
+   * So the three things asserted are the three the markup has to satisfy: one live
+   * region, NOT busy, with real text inside it.
+   *
+   * ⚠️ WHAT IS STILL NOT CLAIMED: that any particular screen reader announces it.
+   * Nobody has run one — not this PR, not the audit. This is a markup assertion.
    */
-  test('the loading grid is announced, once', () => {
+  test('the loading grid is a live region with announceable text, and is not marked busy', () => {
     const html = serverHtml();
     expect([...html.matchAll(/role="status"/g)]).toHaveLength(1);
-    expect(html).toContain('aria-label="Loading apps"');
+    expect(html).toContain('Loading apps');
+    expect(
+      html,
+      'the live region is marked `aria-busy`, which tells assistive tech to withhold ' +
+        'announcements — and nothing ever clears it, because the grid unmounts instead'
+    ).not.toContain('aria-busy');
+    // …and the text is not itself hidden, which is the other way to announce nothing.
+    expect(html).toMatch(/class="[^"]*sr-only[^"]*"[^>]*>Loading apps/);
   });
 });

--- a/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.ssr.browser.test.tsx
@@ -140,32 +140,81 @@ describe('🔴 the server emits a real skeleton grid, not an empty one', () => {
   /**
    * 🔴 THE LIVE REGION HAS SOMETHING TO ANNOUNCE, AND IS NOT MARKED BUSY.
    *
-   * ⚠️ THIS TEST USED TO BE `expect(html).toContain('aria-label="Loading apps"')` AND
-   * IT WAS TITLED "announced, once" — a name wider than its body, over markup that
-   * most likely announced NOTHING. The region carried `role="status" aria-busy="true"`
-   * with every descendant `aria-hidden`: `aria-busy="true"` on a live region is the
-   * standard instruction to withhold announcements (and it was a hardcoded literal
-   * that never cleared — the grid unmounts instead), a fully `aria-hidden` subtree has
-   * no announceable content, and a live region announces its CONTENT rather than its
-   * label. An audit found it in the paragraph rewritten to stop overstating exactly
-   * this.
+   * ⚠️ THIS GUARD HAS NOW BEEN WRONG THREE TIMES IN THE SAME WAY, WHICH IS WHY IT IS
+   * BUILT DIFFERENTLY RATHER THAN BUILT BETTER. v1 asserted `aria-label="Loading apps"`
+   * — a label, which a live region does not announce. v2 asserted three strings over
+   * `serverHtml()`. v3 (this) asserts CONTAINMENT, because the two things the docblock
+   * kept promising — "with real text INSIDE it", "the text is not itself hidden" — are
+   * facts about a TREE, and a flat string scan cannot express either. Both mutants
+   * below were measured passing v2 at 4/4:
+   *   · move the `sr-only` span OUT of the region, rendered as a sibling before it —
+   *     `role="status"` still occurs once, `Loading apps` is still in the string, no
+   *     `aria-busy`, and the class regex still matches;
+   *   · put `aria-hidden` on the span — the old `[^>]*` admitted any other attribute.
+   * Each restores exactly the defect the file's own headline names.
    *
-   * So the three things asserted are the three the markup has to satisfy: one live
-   * region, NOT busy, with real text inside it.
+   * 🔴 WHY THIS ONE PARSES AND THE `<div>`-IN-`<p>` ONE MUST NOT. They ask opposite
+   * questions of the same string. The nesting check is about what the SERIALISED markup
+   * says, and an HTML parser silently REPAIRS that particular offence (auto-closing the
+   * `<p>`), so parsing would destroy the evidence — it stays a string scan. This check
+   * is about ancestry, which only exists in a tree. Same input, two instruments, on
+   * purpose.
    *
-   * ⚠️ WHAT IS STILL NOT CLAIMED: that any particular screen reader announces it.
-   * Nobody has run one — not this PR, not the audit. This is a markup assertion.
+   * ⚠️ WHAT IS STILL NOT CLAIMED: that any particular screen reader announces this.
+   * Nobody has run one — not this PR, not either audit. These are markup properties.
    */
-  test('the loading grid is a live region with announceable text, and is not marked busy', () => {
+  test('the announceable text is INSIDE the live region, unhidden, and the region is not busy', () => {
     const html = serverHtml();
-    expect([...html.matchAll(/role="status"/g)]).toHaveLength(1);
-    expect(html).toContain('Loading apps');
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+
+    // POSITIVE CONTROL on the parse itself — a DOMParser handed junk returns a
+    // perfectly valid empty document, which would make every query below a confident
+    // `null` and every `.toHaveLength(0)` a pass.
     expect(
-      html,
+      doc.querySelectorAll('[data-testid="apps-listing-skeleton-col"]').length,
+      'the parsed document holds no skeleton cells — the parse, not the markup, is what failed'
+    ).toBe(APP_LISTING_SKELETON_SSR_COLUMNS * APP_LISTING_SKELETON_ROWS);
+
+    const regions = doc.querySelectorAll('[role="status"]');
+    expect(regions, 'expected exactly one live region on the loading path').toHaveLength(1);
+    const region = regions[0] as HTMLElement;
+
+    // ── NOT BUSY. `aria-busy="true"` instructs assistive tech to withhold
+    // announcements, and nothing here ever clears it (the grid unmounts instead).
+    expect(
+      region.getAttribute('aria-busy'),
       'the live region is marked `aria-busy`, which tells assistive tech to withhold ' +
         'announcements — and nothing ever clears it, because the grid unmounts instead'
-    ).not.toContain('aria-busy');
-    // …and the text is not itself hidden, which is the other way to announce nothing.
-    expect(html).toMatch(/class="[^"]*sr-only[^"]*"[^>]*>Loading apps/);
+    ).toBeNull();
+
+    // ── THE TEXT IS **INSIDE** THE REGION. `region.querySelector` is the containment
+    // assertion: a span rendered as a SIBLING of the region satisfies every string
+    // check in the document and fails this one.
+    const text = region.querySelector('.sr-only');
+    expect(
+      text,
+      'the live region contains no `sr-only` text. A region announces its CONTENT, not ' +
+        'its label — text rendered as a SIBLING of the region announces nothing, and ' +
+        'that is exactly what an earlier version of this guard could not tell apart.'
+    ).not.toBeNull();
+    expect(text?.textContent?.trim()).toBe('Loading apps');
+
+    // ── AND NOTHING BETWEEN THE TEXT AND THE REGION HIDES IT. Walked rather than
+    // regexed: `aria-hidden` on the span, or on any ancestor up to and including the
+    // region, removes it from the accessibility tree just as effectively.
+    for (let el: Element | null = text; el; el = el.parentElement) {
+      expect(
+        el.getAttribute('aria-hidden'),
+        `\`aria-hidden\` on <${el.tagName.toLowerCase()}> removes the announceable text ` +
+          'from the accessibility tree — a fully hidden subtree has nothing to announce'
+      ).toBeNull();
+      if (el === region) break;
+    }
+
+    // …and the cards themselves ARE still hidden, which is the state this guard is
+    // distinguishing from — so a pass is not "nothing is hidden anywhere".
+    expect(
+      doc.querySelector('[data-testid="apps-listing-card-skeleton"]')?.getAttribute('aria-hidden')
+    ).toBe('true');
   });
 });

--- a/src/components/Apps/AppListingCardSkeleton.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.tsx
@@ -148,8 +148,12 @@ function MetaLineSkeleton({
 /**
  * One store card's worth of reserved space.
  *
- * `aria-hidden` — it carries no information a screen reader wants; the grid it
- * sits in announces "Loading apps" once (see {@link AppListingCardSkeletonGrid}).
+ * `aria-hidden` — it carries no information a screen reader wants. The announceable
+ * text lives in the live region on the grid's CONTAINER (see
+ * {@link AppListingCardSkeletonGrid}), not on the grid: this comment used to name the
+ * grid, and the commit that moved `role="status"` onto the container left the sentence
+ * describing a tree it had just changed. Whether any assistive tech actually announces
+ * it is untested — see the hedge at the render site.
  */
 export function AppListingCardSkeleton() {
   return (

--- a/src/components/Apps/AppListingCardSkeleton.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.tsx
@@ -1,0 +1,295 @@
+import { Box, Card, Group, Skeleton, Stack, Text } from '@mantine/core';
+import { useRef, useState } from 'react';
+import gridClasses from '~/components/Apps/AppListingsMarketplaceBody.module.scss';
+import {
+  LISTING_ACTION_ROW_CONTROL_PX,
+  LISTING_ACTION_ROW_HEIGHT_PX,
+  LISTING_ACTION_ROW_PT_PX,
+  LISTING_CARD_COVER_ASPECT_RATIO,
+  LISTING_CARD_ICON_SIZE_PX,
+  LISTING_CARD_TITLE_LINES,
+  LISTING_CARD_TITLE_LINE_HEIGHT,
+  LISTING_CARD_TITLE_MIN_HEIGHT,
+} from '~/components/Apps/appListingCardGeometry';
+import { listingGridColumnsAt } from '~/components/Apps/appListingGrid';
+import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
+
+/**
+ * App Store Listings (W13) — the `/apps` store's LOADING state.
+ *
+ * 🔴 WHAT THIS BUYS, STATED NARROWLY. It removes the PER-CARD layout shift: the
+ * store used to render `<Center py="xl"><Loader /></Center>` while the first page
+ * loaded, so the grid appeared from nothing and every cell moved. A skeleton
+ * occupying the card's exact box means each cell's top/left/width/height is
+ * already final when the query resolves.
+ *
+ * 🔴 WHAT IT DOES **NOT** BUY, AND MUST NOT BE SOLD AS. Two shifts survive, both
+ * by construction:
+ *   · THE COUNT AXIS. This renders two rows at the current column count; the
+ *     query returns up to 48. When the two differ the GRID still resizes on
+ *     resolve — fewer/more rows — so page height moves even though no cell does.
+ *   · THE RECENTS RAIL. It is seeded empty for SSR parity and hydrates from
+ *     localStorage one frame late, inserting ~90px above the grid. That is the
+ *     status quo (and is why the rail is rendered BELOW the search/sort controls
+ *     — see `AppListingsMarketplaceBody`), and nothing here touches it.
+ * "Zero layout shift" is therefore the wrong claim. "Zero per-card shift" is the
+ * right one.
+ *
+ * 🔴 AND A THIRD, SMALLER ONE: the skeleton reserves the card's INVARIANT parts
+ * only — cover, icon, the two RESERVED title lines, the creator line, the always-
+ * rendered recommend rollup line, and the 46px action row. A card also renders a
+ * conditional tagline (`line-clamp-3`), a Beta badge, and an owner-only
+ * "Incomplete" badge, none of which the loading state can predict. A listing
+ * carrying one is taller than its skeleton. See the parity test's fixture note.
+ *
+ * ── EVERY GEOMETRY NUMBER IS READ, NEVER SPELLED ────────────────────────────
+ * 🔴 THIS FILE IMPORTS `appListingCardGeometry.ts` AND SO DOES `AppListingCard`.
+ * That module exists for exactly this relationship: a skeleton that hand-copied
+ * "16 / 9", 40, 2, 1.2, 10, 36 and 46 would drift from the card the first time
+ * one of them moved, silently, with both files individually correct-looking.
+ * `__tests__/appListingCardSkeleton.test.ts` enumerates the module's own
+ * `Object.keys` and fails if this file stops reading any of them — the same guard
+ * `appListingCardView.test.ts` already runs over the card.
+ *
+ * What is NOT single-sourced is the MARKUP the two files mirror (`gap={2}` on the
+ * meta stack, `size="sm"`/`size="xs"` on the meta lines, `padding="md"` on the
+ * Card). Those are not in the geometry module — the card spells them too — so the
+ * thing that pins them is the MEASURED parity test
+ * (`AppListingCardSkeleton.geometry.test.tsx`), which renders both grids and
+ * compares boxes. Stated so nobody reads the import list above as covering more
+ * than it does.
+ */
+
+/**
+ * A skeleton bar shaped like ONE line of real text.
+ *
+ * 🔴 THE `<Text>` IS NOT DECORATION — IT IS THE MEASUREMENT. Its content is a
+ * non-breaking space, so the element's line box is exactly the line box the real
+ * card's `<Text>` of the same `size`/`fw` produces, whatever Mantine's font-size
+ * and line-height tokens happen to be. The visible bar is an ABSOLUTELY
+ * positioned `Skeleton` over it, i.e. out of flow, so it contributes no height of
+ * its own and cannot change the answer. A bar with a hand-picked pixel height
+ * would be a second copy of Mantine's type scale, and would go wrong the day the
+ * theme moved.
+ */
+function MetaLineSkeleton({
+  size,
+  fw,
+  widthPct,
+  'data-testid': testId,
+}: {
+  size: 'sm' | 'xs';
+  fw?: number;
+  widthPct: number;
+  'data-testid'?: string;
+}) {
+  return (
+    <Text size={size} fw={fw} c="dimmed" style={{ position: 'relative' }} data-testid={testId}>
+      {/* 🔴 A NON-BREAKING SPACE, NOT A PLAIN ONE. Whitespace-only text collapses under
+          `white-space: normal`, which can leave the element with NO line box and therefore
+          zero height — the reservation would then silently be nothing. `\u00A0` never
+          collapses, and is written as an escape so it is visible in a diff. */}
+      {'\u00A0'}
+      <Skeleton
+        style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: `${widthPct}%` }}
+      />
+    </Text>
+  );
+}
+
+/**
+ * One store card's worth of reserved space.
+ *
+ * `aria-hidden` — it carries no information a screen reader wants; the grid it
+ * sits in announces "Loading apps" once (see {@link AppListingCardSkeletonGrid}).
+ */
+export function AppListingCardSkeleton() {
+  return (
+    <Card
+      padding="md"
+      radius={0}
+      className="h-full rounded-md"
+      aria-hidden
+      data-testid="apps-listing-card-skeleton"
+    >
+      {/* THE COVER. Same `Card.Section` + same ratio box as `ListingCover`, so the
+          cover's height is derived from the column width before anything loads —
+          in the skeleton for the same reason it is in the card. */}
+      <Card.Section>
+        <Box
+          data-testid="apps-listing-skeleton-cover"
+          style={{
+            position: 'relative',
+            width: '100%',
+            aspectRatio: LISTING_CARD_COVER_ASPECT_RATIO,
+            overflow: 'hidden',
+          }}
+        >
+          <Skeleton radius={0} style={{ position: 'absolute', inset: 0 }} />
+        </Box>
+      </Card.Section>
+
+      <Stack gap="sm" h="100%" pt="sm">
+        <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
+          {/* The publisher icon — a square of exactly the avatar's edge length. */}
+          <Skeleton
+            width={LISTING_CARD_ICON_SIZE_PX}
+            height={LISTING_CARD_ICON_SIZE_PX}
+            radius="md"
+            style={{ flexShrink: 0 }}
+            data-testid="apps-listing-skeleton-icon"
+          />
+          <Stack gap={2} style={{ minWidth: 0, flexGrow: 1 }}>
+            {/* THE RESERVED TITLE BOX — the card's `min-height` reservation, in the
+                same `em`, over the same font-size token.
+
+                🔴 THE BARS ARE ABSOLUTE, AND THE BOX'S HEIGHT COMES FROM
+                `LISTING_CARD_TITLE_MIN_HEIGHT` ALONE. That is what makes this box
+                the same 2 lines tall as the card's title whether the real title
+                wraps or not — the card reserves the full clamp height for every
+                listing precisely so the rows below it land at the same y on every
+                card. Laying the bars out in flow instead would make the height a
+                function of the bars, i.e. of a number this file chose. */}
+            <Box
+              data-testid="apps-listing-skeleton-title"
+              style={{
+                position: 'relative',
+                fontSize: 'var(--mantine-font-size-xl)',
+                lineHeight: LISTING_CARD_TITLE_LINE_HEIGHT,
+                minHeight: LISTING_CARD_TITLE_MIN_HEIGHT,
+              }}
+            >
+              {Array.from({ length: LISTING_CARD_TITLE_LINES }, (_, i) => (
+                <Skeleton
+                  key={i}
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    top: `calc(${i} * ${LISTING_CARD_TITLE_LINE_HEIGHT}em)`,
+                    height: `${LISTING_CARD_TITLE_LINE_HEIGHT}em`,
+                    // Cosmetic only: a ragged last line reads as text rather than
+                    // as a block. No geometry depends on it.
+                    width: i === LISTING_CARD_TITLE_LINES - 1 ? '58%' : '100%',
+                  }}
+                />
+              ))}
+            </Box>
+            {/* The creator chip's line. `size="sm"` / `fw={500}` mirror
+                `CreatorChip`'s `TruncatedText`; the chip's 20px avatar is shorter
+                than that line box, so the text is what sets the row height and the
+                skeleton does not need to reproduce the avatar to match it. */}
+            <MetaLineSkeleton
+              size="sm"
+              fw={500}
+              widthPct={44}
+              data-testid="apps-listing-skeleton-creator"
+            />
+            {/* The recommend rollup's line. It ALWAYS renders on a card — including
+                for a listing with no reviews — which is what makes it safe to
+                reserve unconditionally here. `size="xs"`, and the 13px thumb icon
+                is again shorter than the line box. */}
+            <MetaLineSkeleton size="xs" widthPct={62} data-testid="apps-listing-skeleton-rollup" />
+          </Stack>
+        </Group>
+
+        {/* THE ACTION ROW — the card's own `mt="auto"` bottom pin, its padding and
+            its minimum height, read from the same constants the card reads. The bar
+            is the CTA: it grows into the row exactly as the button does
+            (`flexGrow: 1` + `minWidth: 0`).
+
+            🔴 `LISTING_ACTION_ROW_GAP_PX` IS THE ONE GEOMETRY CONSTANT THIS FILE
+            DELIBERATELY DOES NOT READ, and that is a decision, not an omission. It
+            is the gap BETWEEN the CTA and the `⋮` overflow trigger — and whether a
+            card gets a trigger depends on the viewer being the owner or a
+            moderator, which a loading state cannot know. So this row holds exactly
+            one child and a gap has nothing to apply to. Passing it anyway would be
+            an unread declaration that reads as load-bearing, which is the shape
+            this component family has spent several rounds deleting (see the
+            `@container` note in `AppListingCard.tsx`). It costs nothing in
+            geometry: the trigger changes how wide the CTA is, never how tall the
+            row or the card is — the parity test measures cards, and it is green for
+            an owner and a signed-out viewer alike.
+            `__tests__/appListingCardSkeleton.test.ts` names this exclusion
+            explicitly, so it cannot become a silent hole. */}
+        <Group
+          mt="auto"
+          pt={LISTING_ACTION_ROW_PT_PX}
+          mih={LISTING_ACTION_ROW_HEIGHT_PX}
+          wrap="nowrap"
+          data-testid="apps-listing-skeleton-actions"
+        >
+          <Skeleton
+            height={LISTING_ACTION_ROW_CONTROL_PX}
+            style={{ flexGrow: 1, minWidth: 0 }}
+            radius="sm"
+          />
+        </Group>
+      </Stack>
+    </Card>
+  );
+}
+
+/**
+ * How many ROWS of skeletons the store reserves while its first page loads.
+ *
+ * Two, deliberately: enough that the grid reads as a grid at every column count
+ * (one row of five cards reads as a strip), and few enough that a small result
+ * set does not shrink the page dramatically on resolve. It is NOT an estimate of
+ * the result count — the query asks for 48 — so the count axis still moves. See
+ * the header.
+ */
+export const APP_LISTING_SKELETON_ROWS = 2;
+
+/**
+ * The store's loading grid — the SAME markup and the SAME CSS module classes the
+ * results grid uses, so a skeleton cell and a card cell get byte-identical track
+ * geometry from the container query.
+ *
+ * 🔴 THE COLUMN COUNT IS MEASURED, NOT RESTATED. The ladder lives in
+ * `appListingGrid.ts` (and, as CSS, in the stylesheet the unit test pins against
+ * it); this reads the container's own width through the exported
+ * `listingGridColumnsAt`, which is the single source. A second hardcoded ladder
+ * here — or a set of `@container` rules hiding surplus cells — would be exactly
+ * the drift `appListingGrid.ts` exists to prevent.
+ *
+ * 🔴 MEASURED IN A LAYOUT EFFECT, so the count is set BEFORE the browser paints
+ * and the viewer never sees the zero-cell first render. `useIsomorphicLayoutEffect`
+ * because this component renders during SSR too (the query has no server data, so
+ * `isLoading` is true there) and `useLayoutEffect` warns on the server.
+ */
+export function AppListingCardSkeletonGrid() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [columns, setColumns] = useState(0);
+
+  useIsomorphicLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => setColumns(listingGridColumnsAt(el.getBoundingClientRect().width));
+    measure();
+    // Keep it right across a resize / a sub-nav reflow. Guarded because the
+    // constructor is absent in some non-browser environments; the one-shot
+    // `measure()` above still runs there.
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div className={gridClasses.gridContainer} ref={containerRef}>
+      <div
+        className={gridClasses.grid}
+        data-testid="apps-listing-skeleton-grid"
+        role="status"
+        aria-busy="true"
+        aria-label="Loading apps"
+      >
+        {Array.from({ length: columns * APP_LISTING_SKELETON_ROWS }, (_, i) => (
+          <div key={i} data-testid="apps-listing-skeleton-col">
+            <AppListingCardSkeleton />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Apps/AppListingCardSkeleton.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.tsx
@@ -98,7 +98,11 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * IS VALID HTML. Mantine's `Text` renders a `<p>` and Mantine's `Skeleton` renders a
  * `<div>`, and `<div>` may not descend from `<p>`. An HTML parser auto-closes the
  * `<p>` at the `<div>`, so the parsed DOM is `<p></p><div></div>` while React's tree
- * is `<p><div/></p>` — a HYDRATION MISMATCH on every `/apps` load, 16–20 times over.
+ * is `<p><div/></p>` — a HYDRATION MISMATCH on every `/apps` load, EXACTLY 16 times:
+ * 8 cells (`APP_LISTING_SKELETON_SSR_COLUMNS` x `APP_LISTING_SKELETON_ROWS`) x the two
+ * meta lines each. An earlier draft said "16–20"; 20 would need 10 cells, which no
+ * server render produces, and the mutation reproducing this observed `expected 16 to
+ * be +0`.
  * It shipped in the first round of this PR and was invisible to the parity suite,
  * because the bar is `position: absolute` and therefore contributes no geometry for
  * a box comparison to see; the only signal was a `validateDOMNesting` warning on a
@@ -328,6 +332,50 @@ export const APP_LISTING_SKELETON_SSR_COLUMNS = listingGridColumnsAt(
 );
 
 /**
+ * The inline size an `@container` query would see for `el` — i.e. its CONTENT box.
+ *
+ * 🔴 CONTENT BOX, NOT BORDER BOX. The ladder that actually lays this grid out is an
+ * `@container (min-width: …)` query, and a query container's size is its content box.
+ * `getBoundingClientRect()` returns the BORDER box. Today `.gridContainer` declares
+ * neither padding nor a border, so the two numbers are identical and either would
+ * work — which is precisely the hazard: a later `padding: 8px` on that class would
+ * silently desynchronise the cell COUNT computed here from the track count CSS
+ * renders. Subtracting makes the two definitions agree by construction rather than by
+ * coincidence.
+ *
+ * `getBoundingClientRect()` rather than `clientWidth`: the latter is rounded to an
+ * integer, so a container at 1167.6px would report 1168 and pick the four-column rung
+ * while the (fractional) container query stays on three.
+ *
+ * 🔴 EXPORTED SO IT CAN BE GUARDED DIRECTLY, AND THAT EXPORT IS THE POINT. The first
+ * attempt guarded this relationship end-to-end — "the cell count is two rows of the
+ * grid CSS actually laid out" — and an audit measured that guard PASSING with and
+ * without the desync it was written for. The reason is structural rather than a
+ * mistake in the assertion: the parity fixtures sit deliberately MID-BAND (1376 is
+ * 208px above the 1168 rung, 2450 is 86px above 2364) so that they cannot be tripped
+ * by an off-by-one, and that same margin means no plausible padding can move the
+ * column count. The property that makes them good parity fixtures is what blinded the
+ * desync guard. Two guards wanted opposite fixtures and were sharing one list.
+ *
+ * So the desync is now guarded HERE, against the element's own content box, with no
+ * fixture involved at all — see "the query inline size IS the container's content
+ * box" in `AppListingCardSkeleton.geometry.test.tsx`. The end-to-end count↔row test
+ * is kept, with its claim narrowed to what it actually checks.
+ */
+export function gridQueryInlineSize(el: HTMLElement): number {
+  const rect = el.getBoundingClientRect();
+  const cs = getComputedStyle(el);
+  const px = (v: string) => parseFloat(v) || 0;
+  return (
+    rect.width -
+    px(cs.paddingLeft) -
+    px(cs.paddingRight) -
+    px(cs.borderLeftWidth) -
+    px(cs.borderRightWidth)
+  );
+}
+
+/**
  * The store's loading grid — the SAME markup and the SAME CSS module classes the
  * results grid uses, so a skeleton cell and a card cell get byte-identical track
  * geometry from the container query.
@@ -349,40 +397,7 @@ export function AppListingCardSkeletonGrid() {
   useIsomorphicLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    /**
-     * 🔴 THE CONTENT BOX, NOT THE BORDER BOX — and the difference is currently ZERO,
-     * which is exactly why it is worth writing down.
-     *
-     * The ladder that actually lays this grid out is an `@container (min-width: …)`
-     * query, and a query container's size is its CONTENT box. `getBoundingClientRect()`
-     * returns the BORDER box. Today `.gridContainer` declares neither padding nor a
-     * border, so the two numbers are identical and either would work — meaning a later
-     * `padding: 8px` on that class would silently desynchronise the cell COUNT this
-     * computes from the track count CSS renders, with nothing anywhere going red.
-     * Subtracting them makes the two definitions agree by construction instead of by
-     * coincidence.
-     *
-     * `getBoundingClientRect()` rather than `clientWidth`: the latter is rounded to an
-     * integer, so a container at 1167.6px would report 1168 and pick the four-column
-     * rung while the (fractional) container query stays on three.
-     *
-     * The relationship is guarded end-to-end in
-     * `AppListingCardSkeleton.geometry.test.tsx` — "the cell count is two rows of the
-     * grid CSS ACTUALLY laid out" — which compares this count against the rendered
-     * first row rather than against the ladder, so it catches this and any other cause.
-     */
-    const measure = () => {
-      const rect = el.getBoundingClientRect();
-      const cs = getComputedStyle(el);
-      const px = (v: string) => parseFloat(v) || 0;
-      const inlineSize =
-        rect.width -
-        px(cs.paddingLeft) -
-        px(cs.paddingRight) -
-        px(cs.borderLeftWidth) -
-        px(cs.borderRightWidth);
-      setColumns(listingGridColumnsAt(inlineSize));
-    };
+    const measure = () => setColumns(listingGridColumnsAt(gridQueryInlineSize(el)));
     measure();
     // Keep it right across a resize / a sub-nav reflow. Guarded because the
     // constructor is absent in some non-browser environments; the one-shot
@@ -394,14 +409,34 @@ export function AppListingCardSkeletonGrid() {
   }, []);
 
   return (
-    <div className={gridClasses.gridContainer} ref={containerRef}>
-      <div
-        className={gridClasses.grid}
-        data-testid="apps-listing-skeleton-grid"
-        role="status"
-        aria-busy="true"
-        aria-label="Loading apps"
-      >
+    <div
+      className={gridClasses.gridContainer}
+      ref={containerRef}
+      data-testid="apps-listing-skeleton-grid-container"
+      role="status"
+    >
+      {/* 🔴 NO `aria-busy` HERE, AND THAT IS A CORRECTION, NOT AN OMISSION.
+          This region carried `role="status" aria-busy="true"` with `aria-label="Loading
+          apps"` and EVERY descendant `aria-hidden`. `aria-busy="true"` on a live region
+          is the standard instruction to WITHHOLD announcements until it clears, and it
+          was a hardcoded literal that never flipped to false (the grid unmounts
+          instead); a region whose whole subtree is `aria-hidden` has no content to
+          announce either way; and a live region announces its CONTENT, not its label.
+          So the loading state most likely announced nothing — in markup whose own
+          comment claimed it was the one thing on the page that did.
+          The fix is real text in the live region and no busy flag.
+
+          ⚠️ NOT VERIFIED WITH A SCREEN READER, by me or by the audit that found it.
+          What is claimed is only that the markup can now announce — a live region, not
+          marked busy, with non-hidden text content — not that a particular AT does. */}
+      {/* 🔴 THE LIVE REGION IS THE CONTAINER, NOT THE GRID, so this text can sit
+          INSIDE it without becoming a grid item. On `.grid` it would be a cell —
+          an extra track's worth of layout, in the component whose entire job is
+          reserving exact boxes. (Tailwind's `sr-only` is `position: absolute`, so
+          it would in fact be out of flow either way; relying on that would be a
+          load-bearing detail of a utility class nobody would think to check.) */}
+      <span className="sr-only">Loading apps</span>
+      <div className={gridClasses.grid} data-testid="apps-listing-skeleton-grid">
         {Array.from({ length: columns * APP_LISTING_SKELETON_ROWS }, (_, i) => (
           <div key={i} data-testid="apps-listing-skeleton-col">
             <AppListingCardSkeleton />

--- a/src/components/Apps/AppListingCardSkeleton.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.tsx
@@ -11,7 +11,8 @@ import {
   LISTING_CARD_TITLE_LINE_HEIGHT,
   LISTING_CARD_TITLE_MIN_HEIGHT,
 } from '~/components/Apps/appListingCardGeometry';
-import { listingGridColumnsAt } from '~/components/Apps/appListingGrid';
+import { listingGridColumnsAt, MANTINE_BREAKPOINT_PX } from '~/components/Apps/appListingGrid';
+import { APPS_CONTAINER_GUTTER } from '~/components/Apps/appsPageWidths';
 import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
 
 /**
@@ -35,12 +36,27 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * "Zero layout shift" is therefore the wrong claim. "Zero per-card shift" is the
  * right one.
  *
- * 🔴 AND A THIRD, SMALLER ONE: the skeleton reserves the card's INVARIANT parts
- * only — cover, icon, the two RESERVED title lines, the creator line, the always-
- * rendered recommend rollup line, and the 46px action row. A card also renders a
- * conditional tagline (`line-clamp-3`), a Beta badge, and an owner-only
- * "Incomplete" badge, none of which the loading state can predict. A listing
- * carrying one is taller than its skeleton. See the parity test's fixture note.
+ * 🔴 AND A THIRD: CONTENT VARIANCE, WHICH RUNS IN **BOTH** DIRECTIONS. The skeleton
+ * reserves cover, icon, the two RESERVED title lines, a creator line, the always-
+ * rendered recommend rollup line, and the 46px action row. Four axes move a real
+ * card off that:
+ *   · a conditional tagline (`line-clamp-3`)      → card TALLER
+ *   · an author-declared `Beta` badge             → card TALLER
+ *   · an owner-only "Incomplete" badge            → card TALLER
+ *   · NO CREATOR — `ListingCard.creator` is nullable and `CreatorChip` returns
+ *     `null` for it — → card SHORTER, by the creator line plus the meta stack's gap.
+ * ⚠️ THAT LAST ONE WAS MISSING FROM THIS LIST AND FROM THE PR BODY FOR A ROUND, both
+ * of which said only "a listing carrying one is TALLER than its skeleton". It is not
+ * hypothetical: measured at −22.29px (1376px grid / 4 columns) and −22.30px
+ * (2450px / 5), and this PR's own `keepPreviousData` fixture uses `creator: null`.
+ * It is pinned rather than merely described — see "a card with NO CREATOR is SHORTER"
+ * in `AppListingCardSkeleton.geometry.test.tsx`, which derives the delta from the
+ * rendered creator line rather than restating the number above.
+ *
+ * 🔴 SO "THE INVARIANT SHAPE" INCLUDES HAVING A CREATOR. The parity fixture is a
+ * listing WITH a creator and WITHOUT a tagline or badges; that is the shape the
+ * skeleton is exact for, and it is a choice (most listings have a creator, so
+ * reserving the line is right more often than not), not a discovered invariant.
  *
  * ── EVERY GEOMETRY NUMBER IS READ, NEVER SPELLED ────────────────────────────
  * 🔴 THIS FILE IMPORTS `appListingCardGeometry.ts` AND SO DOES `AppListingCard`.
@@ -53,7 +69,13 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  *
  * What is NOT single-sourced is the MARKUP the two files mirror (`gap={2}` on the
  * meta stack, `size="sm"`/`size="xs"` on the meta lines, `padding="md"` on the
- * Card). Those are not in the geometry module — the card spells them too — so the
+ * Card) — plus one deliberate DIVERGENCE: this file adds `flexGrow: 1` to the meta
+ * `Stack`, which the card does not have. The card's stack is sized by its real text;
+ * this one's content is absolutely-positioned bars over a non-breaking space, so
+ * without it the stack shrink-to-fits to almost nothing and the bars (sized in `%`)
+ * render as slivers. It changes no height — the title box is `min-height`-pinned and
+ * both meta lines are single-line — which is why the parity test stays exact.
+ * Those are not in the geometry module — the card spells them too — so the
  * thing that pins them is the MEASURED parity test
  * (`AppListingCardSkeleton.geometry.test.tsx`), which renders both grids and
  * compares boxes. Stated so nobody reads the import list above as covering more
@@ -71,6 +93,27 @@ import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
  * its own and cannot change the answer. A bar with a hand-picked pixel height
  * would be a second copy of Mantine's type scale, and would go wrong the day the
  * theme moved.
+ *
+ * 🔴 `component="span"` ON THE SKELETON IS NOT COSMETIC — IT IS THE ONLY REASON THIS
+ * IS VALID HTML. Mantine's `Text` renders a `<p>` and Mantine's `Skeleton` renders a
+ * `<div>`, and `<div>` may not descend from `<p>`. An HTML parser auto-closes the
+ * `<p>` at the `<div>`, so the parsed DOM is `<p></p><div></div>` while React's tree
+ * is `<p><div/></p>` — a HYDRATION MISMATCH on every `/apps` load, 16–20 times over.
+ * It shipped in the first round of this PR and was invisible to the parity suite,
+ * because the bar is `position: absolute` and therefore contributes no geometry for
+ * a box comparison to see; the only signal was a `validateDOMNesting` warning on a
+ * run that reported 7 passed. Both halves are now guarded —
+ * `AppListingCardSkeleton.ssr.browser.test.tsx` scans the SERVER HTML for a `<div>`
+ * inside a `<p>`, and the geometry suite fails the run on a `validateDOMNesting`
+ * console error.
+ *
+ * 🔴 AND THE FIX IS ON THE SKELETON, NOT ON THE TEXT, DELIBERATELY. `<Text
+ * component="div">` would also be valid HTML, and it would change the element this
+ * line is measured on. The whole point of the `<Text>` is that its line box equals
+ * the line box `AppListingCard`'s own `<Text size="xs">` (a `<p>`) produces, so
+ * moving the tag moves the measurement — the thing this component exists to
+ * reproduce. `position: absolute` blockifies the span, so nothing about the bar
+ * changes either.
  */
 function MetaLineSkeleton({
   size,
@@ -91,6 +134,7 @@ function MetaLineSkeleton({
           collapses, and is written as an escape so it is visible in a diff. */}
       {'\u00A0'}
       <Skeleton
+        component="span"
         style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: `${widthPct}%` }}
       />
     </Text>
@@ -242,6 +286,48 @@ export function AppListingCardSkeleton() {
 export const APP_LISTING_SKELETON_ROWS = 2;
 
 /**
+ * 🔴 THE COLUMN COUNT USED BEFORE ANYTHING HAS BEEN MEASURED — i.e. on the SERVER,
+ * and on the client's first render before the layout effect runs.
+ *
+ * ⚠️ THIS CONSTANT EXISTS BECAUSE ITS ABSENCE SHIPPED A REGRESSION, AND THE COMMENT
+ * THAT USED TO SIT BELOW ASSERTED THE OPPOSITE OF WHAT THE CODE DID. It read "the
+ * count is set BEFORE the browser paints and the viewer never sees the zero-cell
+ * first render", one sentence after correctly noting that this component renders
+ * during SSR. `useIsomorphicLayoutEffect` is `useLayoutEffect` only when `window`
+ * exists and a plain `useEffect` otherwise, so **it does not run during SSR at
+ * all** — and with the seed at 0 the server emitted an EMPTY `.grid`. tRPC runs
+ * `ssr: false`, so the server always renders the `isLoading` branch: this component
+ * replaced a spinner with literally nothing on first paint, then popped two rows of
+ * skeletons in at hydration. Found by an adversarial audit, not by a test; the
+ * `renderToString` guard in `AppListingCardSkeleton.ssr.browser.test.tsx` is the
+ * test that did not exist.
+ *
+ * 🔴 WHY A SEED IS SAFE AT ALL — AND IT IS THE WHOLE JUSTIFICATION, SO CHECK IT
+ * BEFORE CHANGING THE VALUE. This number decides HOW MANY cells are rendered. It
+ * does NOT decide how WIDE they are: the columns come from the `@container` ladder
+ * in `AppListingsMarketplaceBody.module.scss`, which is CSS and is correct on the
+ * very first paint at every viewport. So a wrong seed can only ever move the COUNT
+ * axis — the shift this component's header already declares as unresolved — and can
+ * never produce a wrongly-sized cell.
+ *
+ * That is what makes 4 the right default rather than 1. It is DERIVED, not chosen:
+ * `listingGridColumnsAt` at the `xl` breakpoint's grid width, i.e. the widest rung
+ * the legacy Mantine half of the ladder reaches, which is what a desktop first paint
+ * lands on. The two ways it is wrong, both count-only:
+ *   · a PHONE (1 column) paints 8 stacked cells and settles to 2. The grid is the
+ *     last element on the page, so shrinking it moves nothing above it, and the
+ *     surplus is below the fold;
+ *   · a 2364px+ grid (5 columns) paints 8 and settles to 10 — it under-reserves by
+ *     two cells rather than by the whole grid.
+ * Seeding 1 instead would be correct on a phone and would make every desktop first
+ * paint render two full-width cards that then become eight quarter-width ones —
+ * a PER-CELL shift, which is the thing this PR exists to remove.
+ */
+export const APP_LISTING_SKELETON_SSR_COLUMNS = listingGridColumnsAt(
+  MANTINE_BREAKPOINT_PX.xl - APPS_CONTAINER_GUTTER
+);
+
+/**
  * The store's loading grid — the SAME markup and the SAME CSS module classes the
  * results grid uses, so a skeleton cell and a card cell get byte-identical track
  * geometry from the container query.
@@ -253,19 +339,50 @@ export const APP_LISTING_SKELETON_ROWS = 2;
  * here — or a set of `@container` rules hiding surplus cells — would be exactly
  * the drift `appListingGrid.ts` exists to prevent.
  *
- * 🔴 MEASURED IN A LAYOUT EFFECT, so the count is set BEFORE the browser paints
- * and the viewer never sees the zero-cell first render. `useIsomorphicLayoutEffect`
- * because this component renders during SSR too (the query has no server data, so
- * `isLoading` is true there) and `useLayoutEffect` warns on the server.
+ * The seed above covers the server and the pre-effect render; the effect below
+ * corrects it on the client, before paint.
  */
 export function AppListingCardSkeletonGrid() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [columns, setColumns] = useState(0);
+  const [columns, setColumns] = useState(APP_LISTING_SKELETON_SSR_COLUMNS);
 
   useIsomorphicLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    const measure = () => setColumns(listingGridColumnsAt(el.getBoundingClientRect().width));
+    /**
+     * 🔴 THE CONTENT BOX, NOT THE BORDER BOX — and the difference is currently ZERO,
+     * which is exactly why it is worth writing down.
+     *
+     * The ladder that actually lays this grid out is an `@container (min-width: …)`
+     * query, and a query container's size is its CONTENT box. `getBoundingClientRect()`
+     * returns the BORDER box. Today `.gridContainer` declares neither padding nor a
+     * border, so the two numbers are identical and either would work — meaning a later
+     * `padding: 8px` on that class would silently desynchronise the cell COUNT this
+     * computes from the track count CSS renders, with nothing anywhere going red.
+     * Subtracting them makes the two definitions agree by construction instead of by
+     * coincidence.
+     *
+     * `getBoundingClientRect()` rather than `clientWidth`: the latter is rounded to an
+     * integer, so a container at 1167.6px would report 1168 and pick the four-column
+     * rung while the (fractional) container query stays on three.
+     *
+     * The relationship is guarded end-to-end in
+     * `AppListingCardSkeleton.geometry.test.tsx` — "the cell count is two rows of the
+     * grid CSS ACTUALLY laid out" — which compares this count against the rendered
+     * first row rather than against the ladder, so it catches this and any other cause.
+     */
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      const px = (v: string) => parseFloat(v) || 0;
+      const inlineSize =
+        rect.width -
+        px(cs.paddingLeft) -
+        px(cs.paddingRight) -
+        px(cs.borderLeftWidth) -
+        px(cs.borderRightWidth);
+      setColumns(listingGridColumnsAt(inlineSize));
+    };
     measure();
     // Keep it right across a resize / a sub-nav reflow. Guarded because the
     // constructor is absent in some non-browser environments; the one-shot

--- a/src/components/Apps/AppListingCardSkeleton.tsx
+++ b/src/components/Apps/AppListingCardSkeleton.tsx
@@ -206,9 +206,10 @@ export function AppListingCardSkeleton() {
             an unread declaration that reads as load-bearing, which is the shape
             this component family has spent several rounds deleting (see the
             `@container` note in `AppListingCard.tsx`). It costs nothing in
-            geometry: the trigger changes how wide the CTA is, never how tall the
-            row or the card is — the parity test measures cards, and it is green for
-            an owner and a signed-out viewer alike.
+            geometry, MEASURED not assumed: `AppListingCardSkeleton.geometry.test.tsx`
+            renders the same listings for a signed-out viewer and for their owner and
+            pins that the CTA gives up exactly the trigger + the row gap of WIDTH
+            while the card's box is identical across the two arms.
             `__tests__/appListingCardSkeleton.test.ts` names this exclusion
             explicitly, so it cannot become a silent hole. */}
         <Group

--- a/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
@@ -240,6 +240,67 @@ describe('🔴 a sort change re-orders the store without emptying it', () => {
   });
 
   /**
+   * 🔴 THE PATH `keepPreviousData` QUIETLY TOOK A LOADING AFFORDANCE AWAY FROM.
+   *
+   * When the previous page is EMPTY there is no grid to dim. `isLoading` is false
+   * (that is what `keepPreviousData` buys), `filteredItems` is `[]`, so the empty
+   * state wins and "No apps match" sits there — undimmed, unannounced, no skeleton —
+   * for the whole round trip. Measured at `isPlaceholderData: true` over a previous
+   * page of `items: []`: `{pendingEls: 0, ariaBusyEls: 0, skeletonCells: 0,
+   * showsNoAppsYet: true}`.
+   *
+   * 🔴 AND IT IS A REGRESSION AGAINST PRE-PR BEHAVIOUR, NOT JUST A GAP: before this
+   * change a new query key gave `data: undefined` → `isLoading: true` → the spinner.
+   * So without the fix this PR is a net LOSS on that path, which is the shape a
+   * feature-flagged improvement is most likely to ship unnoticed.
+   *
+   * Found by an adversarial audit. The scenario is ordinary: filter to a category
+   * with nothing in it, then change the sort.
+   */
+  test('🔴 a stale EMPTY previous page still shows a loading affordance', async () => {
+    mocks.sort = 'top-rated';
+    mocks.pending = [];
+
+    renderWithProviders(<AppListingsMarketplaceBody />);
+
+    // First load resolves to NOTHING — the viewer has filtered into an empty corner.
+    await expect.poll(() => mocks.pending.length).toBe(1);
+    resolveNext([]);
+    await expect.poll(() => document.body.textContent).toContain('No apps');
+    expect(cardCells()).toBe(0);
+    expect(skeletonCells()).toBe(0);
+
+    // They change the sort. The placeholder is that same empty page.
+    setSort('newest');
+
+    // POSITIVE CONTROL FIRST — a second query really is in flight for the new sort.
+    // Without this, "a skeleton appeared" could just mean nothing happened at all.
+    await expect.poll(() => mocks.pending.length).toBe(1);
+    expect(mocks.pending[0].sort).toBe('newest');
+
+    await expect
+      .poll(() => skeletonCells(), {
+        message:
+          'the store showed NO loading affordance while re-sorting an empty result ' +
+          'set: no skeleton, and no grid to dim either. Before keepPreviousData this ' +
+          'path rendered a spinner, so this is a regression, not a gap. Check that ' +
+          '`showingStaleEmpty` still short-circuits ahead of `showingEmpty`.',
+      })
+      .toBeGreaterThan(0);
+
+    // …and the empty state is NOT also on screen — the two must not stack.
+    // 🔴 'No apps', not 'No apps match'. With no filters active the empty state reads
+    // "No apps YET", so asserting the absence of the *filtered* wording would pass
+    // whether or not the empty state rendered — a check that cannot fail.
+    expect(document.body.textContent).not.toContain('No apps');
+
+    // The new page lands and the store settles back to its ordinary empty state.
+    resolveNext([]);
+    await expect.poll(() => skeletonCells()).toBe(0);
+    await expect.poll(() => document.body.textContent).toContain('No apps');
+  });
+
+  /**
    * 🔴 GUARD-THE-GUARD, BY IDENTITY. The test above would measure the HARNESS rather
    * than the component if this file supplied `placeholderData` itself — it would then
    * stay green with the option deleted from the source, which is the exact shape of a

--- a/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * `/apps` store — THE GRID DOES NOT EMPTY ACROSS A FILTER CHANGE.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT IS BEING GUARDED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `appListings.listAvailable` is keyed on `{kind, category, sort, limit}`, so every
+ * sort/filter change is a NEW query key. Without `placeholderData: keepPreviousData`
+ * react-query hands back `data: undefined` for the duration of the round trip:
+ * `items` empties, the grid collapses to zero rows, the page jumps, and everything
+ * comes back a moment later. That is a full-height layout shift on a control the
+ * viewer touched expecting a re-ORDER.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 WHY THIS TEST DELEGATES TO A REAL `useInfiniteQuery`
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Every sibling spec mocks `trpc.appListings.listAvailable.useInfiniteQuery` with a
+ * function that returns a literal object. Against such a mock this behaviour is
+ * UNTESTABLE: the mock decides what `data` is, so the component's option is inert
+ * and the test would pass with `placeholderData` deleted — the classic guard that
+ * reads as coverage while providing none.
+ *
+ * So the mock here is a THIN ADAPTER: it forwards the component's own `input` and
+ * its own `options` object into react-query's real `useInfiniteQuery`. The query key
+ * is built from that input, so a sort change really does change the key, and
+ * `placeholderData` really is the thing deciding what `data` holds while the new key
+ * loads. Delete the option from the component and this file goes red — verified, see
+ * the mutation table in the PR body.
+ *
+ * ⚠️ WHAT IT DOES NOT COVER, STATED SO IT IS NOT COUNTED TWICE. The URL plumbing.
+ * `useAppsStoreQueryParams` is mocked to a controllable store, because driving the
+ * sort through the real hook needs a router that actually re-renders on `replace` —
+ * a different surface, already covered by
+ * `AppListingsMarketplaceBody.urlState.browser.test.tsx`. What this file owns is
+ * what the QUERY does once the filters have moved.
+ *
+ * ⚠️ AND: the `component` tier never gates anything (`preview / component-tests` is
+ * report-only), so this catches a regression when someone runs it, not at merge. The
+ * canonical tier note is in `appListingCardGeometry.ts`.
+ */
+import { describe, expect, test, vi } from 'vitest';
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+function makeCard(id: string, name: string): ListingCard {
+  return {
+    id,
+    slug: `slug-${id}`,
+    kind: 'onsite',
+    name,
+    tagline: null,
+    category: null,
+    contentRating: null,
+    isBeta: false,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: {
+      kind: 'onsite',
+      appBlockId: `blk-${id}`,
+      hasPage: false,
+      liveUrl: `https://slug-${id}.civit.ai`,
+    },
+  };
+}
+
+/**
+ * The controllable half of the harness.
+ *
+ * `pending` is a queue of the queries the component has STARTED and not yet been
+ * given an answer to. Holding them open is what makes "while the new page loads" an
+ * observable state rather than a race — nothing here waits on a timer.
+ */
+const mocks = vi.hoisted(() => ({
+  sort: 'top-rated' as string,
+  listeners: new Set<() => void>(),
+  pending: [] as { sort: string; resolve: (items: unknown[]) => void }[],
+  /** The options object the COMPONENT handed the query, captured by the adapter. */
+  lastOptions: null as Record<string, unknown> | null,
+}));
+
+function setSort(next: string) {
+  mocks.sort = next;
+  for (const l of mocks.listeners) l();
+}
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+// Both flag hooks — a factory that names only one makes the whole FILE fail to
+// import and reports `Tests no tests` rather than a failure. See the long note in
+// `AppListingsMarketplaceBody.browser.test.tsx`.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useOptionalFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+  useFeatureFlagsReady: () => true,
+}));
+
+/**
+ * The filters, as an external store the test can move.
+ *
+ * `useSyncExternalStore` rather than component state so `setSort` can be called from
+ * the test body and still produce a real React re-render of the subject.
+ */
+vi.mock('~/components/Apps/useAppsStoreQueryParams', async () => {
+  const React = await import('react');
+  const subscribe = (cb: () => void) => {
+    mocks.listeners.add(cb);
+    return () => mocks.listeners.delete(cb);
+  };
+  const snapshot = () => mocks.sort;
+  return {
+    useAppsStoreQueryParams: () => {
+      const sort = React.useSyncExternalStore(subscribe, snapshot, snapshot);
+      return {
+        filters: { kind: 'all' as const, category: null, sort, query: '' },
+        setFilters: vi.fn(),
+        hasPendingWrite: () => false,
+      };
+    },
+  };
+});
+
+/**
+ * 🔴 THE ADAPTER. It passes the component's OWN options object straight through, so
+ * `placeholderData`, `getNextPageParam` and `enabled` are the component's decisions,
+ * not this file's. `queryKey` is built from the component's own input, so the key
+ * changes exactly when the component's input does.
+ */
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const { useInfiniteQuery } = await import('@tanstack/react-query');
+  return {
+    ...(await importOriginal<typeof TrpcMod>()),
+    trpc: {
+      appListings: {
+        listAvailable: {
+          useInfiniteQuery: (input: Record<string, unknown>, options: Record<string, unknown>) => {
+            mocks.lastOptions = options;
+            // 🔴 CAST, BECAUSE THE OPTIONS ARRIVE AT RUNTIME. `getNextPageParam` is
+            // required by `useInfiniteQuery`'s type and is supplied by the COMPONENT,
+            // which is the whole point of this adapter — TypeScript cannot see that it
+            // is present in the spread, so the object is asserted rather than the
+            // option duplicated here (duplicating it is what would make the test
+            // measure the harness).
+            return useInfiniteQuery({
+              queryKey: ['appListings.listAvailable', input],
+              queryFn: () =>
+                new Promise((resolve) => {
+                  mocks.pending.push({
+                    sort: String(input.sort),
+                    resolve: (items) => resolve({ items, nextCursor: undefined }),
+                  });
+                }),
+              initialPageParam: undefined,
+              ...options,
+            } as unknown as Parameters<typeof useInfiniteQuery>[0]);
+          },
+        },
+      },
+      blocks: { getNavSummary: { useQuery: () => ({ data: undefined }) } },
+    },
+  };
+});
+
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+
+const cardCells = () => document.querySelectorAll('[data-testid="apps-listing-grid-col"]').length;
+const skeletonCells = () =>
+  document.querySelectorAll('[data-testid="apps-listing-skeleton-col"]').length;
+const pendingGrids = () => document.querySelectorAll('[data-pending]').length;
+
+/** Answer the oldest outstanding query. Throws rather than no-op if there is none. */
+function resolveNext(items: ListingCard[]) {
+  const next = mocks.pending.shift();
+  if (!next) throw new Error('no query is outstanding — the component never started one');
+  next.resolve(items);
+  return next;
+}
+
+describe('🔴 a sort change re-orders the store without emptying it', () => {
+  test('the previous page stays on screen, dimmed, while the new one loads', async () => {
+    mocks.sort = 'top-rated';
+    mocks.pending = [];
+    const FIRST = [makeCard('a1', 'Prompt Vault'), makeCard('a2', 'Kerf'), makeCard('a3', 'Nudge')];
+    const SECOND = [makeCard('b1', 'Stipple'), makeCard('b2', 'Tessellate')];
+
+    renderWithProviders(<AppListingsMarketplaceBody />);
+
+    // ── FIRST LOAD ────────────────────────────────────────────────────────────
+    // Nothing cached, so this is the genuine `isLoading` branch: skeletons, and NO
+    // card cells. (Asserted positively — `not.toBeInTheDocument()` is inert in this
+    // repo, issue #4197 — so every absence below is a COUNT of zero.)
+    await expect.poll(() => skeletonCells()).toBeGreaterThan(0);
+    expect(cardCells()).toBe(0);
+
+    await expect.poll(() => mocks.pending.length).toBe(1);
+    resolveNext(FIRST);
+    await expect.poll(() => cardCells()).toBe(FIRST.length);
+    expect(skeletonCells()).toBe(0);
+    expect(pendingGrids()).toBe(0);
+
+    // ── THE FILTER CHANGE ─────────────────────────────────────────────────────
+    setSort('newest');
+
+    // 🔴 POSITIVE CONTROL, FIRST. "The grid did not empty" is also what you observe
+    // when NOTHING HAPPENED — a mocked filter store that failed to re-render, a
+    // query key that did not actually change. So prove a second query really is in
+    // flight, for the new sort, before reading anything into the grid's contents.
+    await expect.poll(() => mocks.pending.length).toBe(1);
+    expect(mocks.pending[0].sort).toBe('newest');
+
+    // ── THE ASSERTION ─────────────────────────────────────────────────────────
+    expect(
+      cardCells(),
+      'the store emptied while the re-sorted page loaded — every card unmounted and the ' +
+        'grid collapsed to zero rows. That is the layout shift `placeholderData: ' +
+        'keepPreviousData` exists to remove; check it is still passed to the query.'
+    ).toBe(FIRST.length);
+    // …and it is not the SKELETON standing in for them either: that would be the
+    // same collapse wearing a different costume, since two rows of skeletons is not
+    // three cards.
+    expect(skeletonCells()).toBe(0);
+    // The stale marker is up, so the viewer is told the result is being replaced.
+    expect(
+      pendingGrids(),
+      'the grid is showing a stale result set with no pending affordance — a sort ' +
+        'change then looks like it did nothing for a whole round trip'
+    ).toBe(1);
+
+    // ── AND THE NEW PAGE LANDS ────────────────────────────────────────────────
+    resolveNext(SECOND);
+    await expect.poll(() => cardCells()).toBe(SECOND.length);
+    // The counts differ, which is what makes the assertion above a claim about
+    // IDENTITY rather than about a number that happens to be stable.
+    expect(SECOND.length).not.toBe(FIRST.length);
+    await expect.poll(() => pendingGrids()).toBe(0);
+  });
+
+  /**
+   * 🔴 GUARD-THE-GUARD, BY IDENTITY. The test above would measure the HARNESS rather
+   * than the component if this file supplied `placeholderData` itself — it would then
+   * stay green with the option deleted from the source, which is the exact shape of a
+   * guard that reads as coverage while providing none.
+   *
+   * So the adapter captures the options object the COMPONENT passed, and this asserts
+   * that its `placeholderData` is react-query's own `keepPreviousData` FUNCTION — the
+   * same module object, not a string, not a value spelled twice.
+   */
+  test('the component — not this harness — supplies placeholderData: keepPreviousData', async () => {
+    const { keepPreviousData } = await import('@tanstack/react-query');
+    mocks.sort = 'top-rated';
+    mocks.pending = [];
+    // Typed on the way in: a bare `= null` narrows the property to `null` for the
+    // rest of this function, which makes every read below `never`.
+    mocks.lastOptions = null as Record<string, unknown> | null;
+    renderWithProviders(<AppListingsMarketplaceBody />);
+    await expect.poll(() => mocks.lastOptions !== null).toBe(true);
+    // Read through a local: assigning `null` above narrows the property's type to
+    // `null` for the rest of this function, which would make the reads below `never`.
+    const captured: Record<string, unknown> | null = mocks.lastOptions;
+    expect(captured, 'the adapter never saw an options object').not.toBeNull();
+    expect(
+      captured?.placeholderData,
+      'the store query no longer asks react-query to keep the previous page. The grid ' +
+        'will empty on every sort/filter change.'
+    ).toBe(keepPreviousData);
+    // Positive control on the capture itself: an adapter wired to nothing would also
+    // report an options object with no `placeholderData`, so prove it carried the
+    // component's OTHER options too.
+    expect(typeof captured?.getNextPageParam).toBe('function');
+  });
+});

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -54,9 +54,21 @@
    card; it only stops one of the two ways of doing so, which is worse than either
    choice made consistently. And the cards are stale, not wrong: each still points
    at a listing that exists, so following one is a valid navigation rather than a
-   trap. Dim to say "being replaced"; leave it usable. */
+   trap. Dim to say "being replaced"; leave it usable.
+
+   🔴 0.7, NOT THE 0.55 THIS STARTED AT, AND THE REASON IS CONTRAST. Opacity composites
+   text toward its background, so it reduces contrast on everything under it — and one
+   thing under it is the card's author line, which `AppListingCard.tsx` records as an
+   ACCEPTED RESIDUAL at contrast 4.73, i.e. AA by 0.23. A heavy dim pushes that under AA
+   for however long the fetch takes, which on a slow connection is not a frame.
+   ⚠️ 0.7 IS A JUDGEMENT, NOT A MEASURED CONTRAST FIGURE — no ratio was computed for the
+   composited result, and this comment deliberately does not quote one. What is claimed
+   is only the direction (less dim, less contrast loss) and that 0.7 is still plainly
+   visible as a state change. If someone needs a guarantee here, the honest fix is to
+   measure the composite and pick a value from it, or to move the signal off opacity
+   entirely. */
 .gridPending {
-  opacity: 0.55;
+  opacity: 0.7;
   transition: opacity 120ms ease-out;
 }
 

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -39,6 +39,21 @@
   container-type: inline-size;
 }
 
+/* The STALE-RESULTS affordance, applied alongside `.gridContainer` while the store
+   is showing `keepPreviousData`'s previous page.
+
+   🔴 OPACITY ONLY, ON PURPOSE. The whole point of keeping the previous result is
+   that nothing MOVES while the new one loads, so the pending signal must be a
+   repaint: no height, no margin, no inserted spinner, nothing that participates in
+   layout. `pointer-events: none` because a stale row is not a thing to click —
+   following a card that is about to be replaced is how a viewer lands on a listing
+   the filter they just chose excludes. */
+.gridPending {
+  opacity: 0.55;
+  pointer-events: none;
+  transition: opacity 120ms ease-out;
+}
+
 /* 🔴 DO NOT ADD `align-items` HERE. ITS ABSENCE IS LOAD-BEARING, NOT AN OMISSION.
    `AppListingCard` bottom-pins its action row with `mt="auto"` inside a `Stack h="100%"`
    inside a `Card className="h-full"`, and `h-full` only resolves because this grid

--- a/src/components/Apps/AppListingsMarketplaceBody.module.scss
+++ b/src/components/Apps/AppListingsMarketplaceBody.module.scss
@@ -42,15 +42,21 @@
 /* The STALE-RESULTS affordance, applied alongside `.gridContainer` while the store
    is showing `keepPreviousData`'s previous page.
 
-   🔴 OPACITY ONLY, ON PURPOSE. The whole point of keeping the previous result is
-   that nothing MOVES while the new one loads, so the pending signal must be a
-   repaint: no height, no margin, no inserted spinner, nothing that participates in
-   layout. `pointer-events: none` because a stale row is not a thing to click —
-   following a card that is about to be replaced is how a viewer lands on a listing
-   the filter they just chose excludes. */
+   🔴 OPACITY ONLY, ON PURPOSE — no height, no margin, no inserted spinner, nothing
+   that participates in layout. The whole point of keeping the previous result is
+   that nothing MOVES while the new one loads, so the pending signal has to be a
+   repaint; a shimmer or a spinner here would re-introduce the shift this change
+   removes.
+
+   🔴 AND DELIBERATELY **NOT** `pointer-events: none`, which an earlier draft had.
+   It blocks the MOUSE and not the KEYBOARD — focus still lands on every card and
+   Enter still follows it — so it does not actually stop a viewer reaching a stale
+   card; it only stops one of the two ways of doing so, which is worse than either
+   choice made consistently. And the cards are stale, not wrong: each still points
+   at a listing that exists, so following one is a valid navigation rather than a
+   trap. Dim to say "being replaced"; leave it usable. */
 .gridPending {
   opacity: 0.55;
-  pointer-events: none;
   transition: opacity 120ms ease-out;
 }
 

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -1,8 +1,10 @@
-import { Button, Center, Group, Loader, Select, Stack, Text, TextInput } from '@mantine/core';
+import { Button, Center, Group, Select, Stack, Text, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
+import { keepPreviousData } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppListingCard } from '~/components/Apps/AppListingCard';
+import { AppListingCardSkeletonGrid } from '~/components/Apps/AppListingCardSkeleton';
 import gridClasses from '~/components/Apps/AppListingsMarketplaceBody.module.scss';
 import { AppsStoreFiltersDropdown } from '~/components/Apps/AppsStoreFiltersDropdown';
 import { hasActiveAppsStoreFilters } from '~/components/Apps/appsStoreQueryParams';
@@ -219,35 +221,66 @@ export function AppListingsMarketplaceBody() {
     );
   }
 
-  const { data, isLoading, isError, refetch, isFetchingNextPage, fetchNextPage, hasNextPage } =
-    trpc.appListings.listAvailable.useInfiniteQuery(
-      {
-        kind,
-        category: category ?? undefined,
-        sort,
-        // 🔴 48, NOT 24, AND IT IS THE COLUMN LADDER THAT MOVED IT. 24 was six rows at
-        // the old four-column maximum; at the FIVE columns the grid now reaches on a
-        // 2560 monitor it is under five, so a viewer on the widest screen the container
-        // supports would meet the "Load more" button after the least content. 48 gives
-        // nine rows at five columns and twelve at four — and stays ≥ 8 rows even if a
-        // future cap raise engages the declared-but-unreachable sixth column.
-        // 🔴 THE SERVER CAPS THIS AT 50, so 48 is deliberately just inside it.
-        // `listAppListingsSchema` in
-        // `src/server/schema/blocks/app-listing-read.schema.ts` declares
-        // `limit: z.number().int().min(1).max(50).default(20)` — a larger value is a
-        // request-time zod error, not a bigger page.
-        limit: 48,
-      },
-      {
-        // W13 (PR-W1a/D8): store-visibility gate = the SHARED `hasAppsStoreAccess`
-        // predicate (dedicated `appListings` OR-falling-back to `appBlocks`).
-        // Mirrors the server read gate (`enforceAppListingsReadFlag` →
-        // `isAppListingsEnabled`), which is why this query — unlike
-        // `blocks.getNavSummary` — DOES widen with the store.
-        enabled: hasAppsStoreAccess(features),
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
-      }
-    );
+  const {
+    data,
+    isLoading,
+    isError,
+    isPlaceholderData,
+    refetch,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = trpc.appListings.listAvailable.useInfiniteQuery(
+    {
+      kind,
+      category: category ?? undefined,
+      sort,
+      // 🔴 48, NOT 24, AND IT IS THE COLUMN LADDER THAT MOVED IT. 24 was six rows at
+      // the old four-column maximum; at the FIVE columns the grid now reaches on a
+      // 2560 monitor it is under five, so a viewer on the widest screen the container
+      // supports would meet the "Load more" button after the least content. 48 gives
+      // nine rows at five columns and twelve at four — and stays ≥ 8 rows even if a
+      // future cap raise engages the declared-but-unreachable sixth column.
+      // 🔴 THE SERVER CAPS THIS AT 50, so 48 is deliberately just inside it.
+      // `listAppListingsSchema` in
+      // `src/server/schema/blocks/app-listing-read.schema.ts` declares
+      // `limit: z.number().int().min(1).max(50).default(20)` — a larger value is a
+      // request-time zod error, not a bigger page.
+      limit: 48,
+    },
+    {
+      // W13 (PR-W1a/D8): store-visibility gate = the SHARED `hasAppsStoreAccess`
+      // predicate (dedicated `appListings` OR-falling-back to `appBlocks`).
+      // Mirrors the server read gate (`enforceAppListingsReadFlag` →
+      // `isAppListingsEnabled`), which is why this query — unlike
+      // `blocks.getNavSummary` — DOES widen with the store.
+      enabled: hasAppsStoreAccess(features),
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      /**
+       * 🔴 KEEP THE PREVIOUS RESULT WHILE A NEW ONE LOADS. The query key is
+       * `{kind, category, sort, limit}`, so every sort/filter change is a NEW
+       * key — and without this `data` goes `undefined` for the duration of the
+       * round trip. `items` empties, the grid collapses to zero rows, the page
+       * jumps, and then everything comes back: a full-height layout shift on a
+       * control the viewer touched expecting a re-ORDER.
+       *
+       * With `keepPreviousData` the old cards stay mounted and in place, and
+       * `isPlaceholderData` marks them as stale so the grid can dim (see its
+       * render site). The swap is then a repaint rather than a reflow — unless
+       * the two result sets differ in COUNT, which still moves the grid's
+       * height. That residue is real and is stated in the PR body rather than
+       * papered over.
+       *
+       * 🔴 IT DOES **NOT** REPLACE THE RECENTS MEMO. `reconcileRecentApps`'s
+       * third argument exists because `items` can be empty when the rail
+       * reconciles against it; this narrows that window (a first load, an error,
+       * a cache eviction still produce it) but does not close it. Do not read
+       * this option as licence to drop that argument — `__tests__/recentAppsRail.test.ts`
+       * fails if the call goes back to two, and that guard is correct.
+       */
+      placeholderData: keepPreviousData,
+    }
+  );
 
   const items = useMemo(() => (data?.pages ?? []).flatMap((p) => p.items as ListingCard[]), [data]);
 
@@ -435,10 +468,17 @@ export function AppListingsMarketplaceBody() {
         onOpenRecent={handleOpenRecent}
       />
 
+      {/* THE FIRST-LOAD STATE. This used to be `<Center py="xl"><Loader /></Center>`
+          — a spinner in a box whose height had nothing to do with the grid that
+          replaced it, so every cell in the store moved when the query resolved.
+          The skeleton grid renders the SAME `.gridContainer` / `.grid` markup with
+          the same per-cell wrapper, so the cells that appear are already the right
+          size and in the right place.
+          🔴 IT IS NOT "ZERO LAYOUT SHIFT". Two rows of skeletons against up to 48
+          results still changes the grid's HEIGHT on resolve, and the recents rail
+          still hydrates a frame late above it. See `AppListingCardSkeleton.tsx`. */}
       {isLoading ? (
-        <Center py="xl">
-          <Loader />
-        </Center>
+        <AppListingCardSkeletonGrid />
       ) : isError ? (
         <Center py="xl">
           <Stack align="center" gap={8}>
@@ -504,7 +544,24 @@ export function AppListingsMarketplaceBody() {
               parses the stylesheet and fails unless the `@container` rules equal
               `LISTING_GRID_COLUMN_STEPS`. The rendered column counts are measured in
               `AppListingsMarketplaceBody.columns.browser.test.tsx`. */}
-          <div className={gridClasses.gridContainer}>
+          {/* 🔴 THE PENDING AFFORDANCE, AND WHY IT IS ON THE CONTAINER. With
+              `keepPreviousData` the grid keeps showing the OLD result set while the
+              new one loads, so without a signal a sort change looks like it did
+              nothing for a round trip. Dimming says "this is stale" without moving
+              anything — an opacity change is a repaint, never a reflow, which is
+              the whole point of choosing it over a spinner or a shimmer that would
+              re-introduce the shift this PR is removing.
+              `data-pending` is the machine-readable half; `aria-busy` is the
+              assistive-tech half. */}
+          <div
+            className={
+              isPlaceholderData
+                ? `${gridClasses.gridContainer} ${gridClasses.gridPending}`
+                : gridClasses.gridContainer
+            }
+            data-pending={isPlaceholderData ? '' : undefined}
+            aria-busy={isPlaceholderData ? true : undefined}
+          >
             <div className={gridClasses.grid} data-testid="apps-listing-grid">
               {filteredItems.map((card) => (
                 <div key={card.id} data-testid="apps-listing-grid-col">

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -398,6 +398,30 @@ export function AppListingsMarketplaceBody() {
 
   const showingEmpty = !isLoading && filteredItems.length === 0;
 
+  /**
+   * 🔴 A STALE **EMPTY** PREVIOUS PAGE IS STILL LOADING, AND WITHOUT THIS THE STORE
+   * SHOWS NO LOADING AFFORDANCE AT ALL.
+   *
+   * `keepPreviousData` removed `isLoading` from the filter-change path — that is the
+   * point of it — and the dim/`aria-busy` that replaced it lives on the GRID branch.
+   * When the previous page is EMPTY there is no grid branch to dim: `isLoading` is
+   * false, `filteredItems` is `[]`, so `showingEmpty` wins and "No apps match" sits
+   * there, undimmed and unannounced, for the whole round trip. Measured at
+   * `isPlaceholderData: true` over a previous page of `items: []` →
+   * `{pendingEls: 0, ariaBusyEls: 0, skeletonCells: 0, showsNoAppsYet: true}`.
+   *
+   * 🔴 IT IS A REGRESSION AGAINST THE PRE-PR BEHAVIOUR, NOT MERELY A GAP. Before
+   * `keepPreviousData` a new query key gave `data: undefined` → `isLoading: true` →
+   * the spinner. So this branch is what keeps the change from being a net loss on
+   * that path.
+   *
+   * The skeleton grid rather than a dimmed empty state, deliberately: dimming "No
+   * apps match" says "this answer is stale" about an answer the viewer has not been
+   * given yet — the honest signal is the loading one, and it is the same component
+   * the first load already uses.
+   */
+  const showingStaleEmpty = isPlaceholderData && filteredItems.length === 0;
+
   return (
     <Stack gap="md">
       {/*
@@ -476,8 +500,11 @@ export function AppListingsMarketplaceBody() {
           size and in the right place.
           🔴 IT IS NOT "ZERO LAYOUT SHIFT". Two rows of skeletons against up to 48
           results still changes the grid's HEIGHT on resolve, and the recents rail
-          still hydrates a frame late above it. See `AppListingCardSkeleton.tsx`. */}
-      {isLoading ? (
+          still hydrates a frame late above it. See `AppListingCardSkeleton.tsx`.
+          🔴 `showingStaleEmpty` IS THE SECOND ENTRY INTO THIS BRANCH, and it must
+          stay ORDERED BEFORE `showingEmpty` below — that ordering is the whole fix.
+          See its declaration for what renders without it. */}
+      {isLoading || showingStaleEmpty ? (
         <AppListingCardSkeletonGrid />
       ) : isError ? (
         <Center py="xl">
@@ -551,8 +578,16 @@ export function AppListingsMarketplaceBody() {
               anything — an opacity change is a repaint, never a reflow, which is
               the whole point of choosing it over a spinner or a shimmer that would
               re-introduce the shift this PR is removing.
-              `data-pending` is the machine-readable half; `aria-busy` is the
-              assistive-tech half. */}
+
+              🔴 `aria-busy` IS NOT AN ANNOUNCEMENT, AND CALLING IT "THE ASSISTIVE-TECH
+              HALF" (as an earlier draft did) OVERSTATES IT. On a non-live-region
+              element it tells assistive tech to defer processing of changes WITHIN a
+              live region; this container is not one, so it announces nothing. It is
+              still the correct attribute for "this region is being updated" and is
+              kept as such — but the affordance a viewer actually gets here is the
+              VISUAL dim, and the only thing on this page that announces is the
+              skeleton grid's own `role="status"` (which is what the stale-EMPTY path
+              now falls back to). `data-pending` is the machine-readable half. */}
           <div
             className={
               isPlaceholderData

--- a/src/components/Apps/__tests__/appListingCardSkeleton.test.ts
+++ b/src/components/Apps/__tests__/appListingCardSkeleton.test.ts
@@ -237,12 +237,49 @@ describe('the store body renders the skeleton grid and keeps the previous page',
 
   it('🔴 the first-load state is the skeleton grid, and the bare Loader is gone', () => {
     const code = bodyCode();
-    expect(code).toMatch(/isLoading \?\s*\(?\s*<AppListingCardSkeletonGrid\s*\/>/);
+    expect(code).toMatch(/isLoading \|\| showingStaleEmpty \?\s*\(?\s*<AppListingCardSkeletonGrid/);
     // The retired spinner. Left in place beside the skeleton it would be dead
     // markup that reads as the live loading state to the next person here.
     expect(code, 'the store still renders a bare <Loader /> somewhere').not.toMatch(
       /<Loader[\s/>]/
     );
+  });
+
+  /**
+   * 🔴 THE SECOND ENTRY INTO THE SKELETON BRANCH, AND THE ORDERING THAT MAKES IT
+   * WORK.
+   *
+   * `keepPreviousData` removed `isLoading` from the filter-change path, and the
+   * dim that replaced it lives on the GRID branch — so when the previous page is
+   * EMPTY there is nothing to dim and the empty state renders, undimmed and
+   * unannounced, for the whole round trip. That is a REGRESSION against the
+   * pre-PR spinner, not merely a gap.
+   *
+   * ⚠️ THIS IS THE STRUCTURAL HALF ONLY. That the store genuinely shows an
+   * affordance on that path is behavioural and lives in
+   * `AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx` ("a stale
+   * EMPTY previous page still shows a loading affordance"), which drives a real
+   * query through a real key change. What this adds is the ORDERING — the
+   * skeleton branch must be evaluated BEFORE `showingEmpty`, and a ternary chain
+   * makes that a source fact rather than a runtime one.
+   */
+  it('🔴 a stale EMPTY page falls back to the skeleton, and does so BEFORE showingEmpty', () => {
+    const code = bodyCode();
+    expect(code).toMatch(
+      /const showingStaleEmpty =\s*isPlaceholderData && filteredItems\.length === 0/
+    );
+    const stale = code.indexOf('isLoading || showingStaleEmpty ?');
+    const empty = code.indexOf('showingEmpty ?');
+    expect(stale, 'the stale-empty fallback is not wired into the render').toBeGreaterThan(-1);
+    expect(
+      empty,
+      'the empty state branch has moved — re-derive this ordering check'
+    ).toBeGreaterThan(-1);
+    expect(
+      stale,
+      'the empty state is evaluated before the stale-empty fallback, so "No apps match" ' +
+        'wins for the whole round trip and the fallback is dead code'
+    ).toBeLessThan(empty);
   });
 
   it('🔴 passes keepPreviousData to the listing query, imported from react-query', () => {

--- a/src/components/Apps/__tests__/appListingCardSkeleton.test.ts
+++ b/src/components/Apps/__tests__/appListingCardSkeleton.test.ts
@@ -1,0 +1,267 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import * as geometry from '~/components/Apps/appListingCardGeometry';
+// 🔴 THE SKELETON COMPONENT ITSELF IS DELIBERATELY **NOT** IMPORTED. It pulls in
+// `@mantine/core` and a `.module.scss`, neither of which the node `unit` project is
+// set up for — an import failure there reports as `Tests no tests`, i.e. as nothing
+// to see rather than as a failure. Every claim below is therefore made against the
+// SOURCE, and `appListingCardGeometry` (React-free and pure, by its own design note)
+// is the only module actually imported.
+
+/**
+ * ── THE SKELETON ⇄ CARD SINGLE SOURCE ───────────────────────────────────────
+ *
+ * 🔴 WHAT THIS TIER CAN CLAIM. Nothing about pixels: that the skeleton and the
+ * card occupy the SAME BOX is a measurement, and it lives in
+ * `AppListingCardSkeleton.geometry.test.tsx`, which renders both grids against the
+ * real cascade. What this file checks is the mechanism that makes that
+ * measurement stay true: the skeleton READS `appListingCardGeometry.ts` rather
+ * than copying it.
+ *
+ * 🔴 WHY THAT IS WORTH A TEST AT ALL. The card already has this guard
+ * (`appListingCardView.test.ts` → "AppListingCard reads every geometry constant
+ * the module exports"), and it is only half the relationship. A skeleton that
+ * spells `40` where the card reads `LISTING_CARD_ICON_SIZE_PX` is correct on the
+ * day it is written and silently wrong the day the constant moves — both files
+ * individually reasonable, the grid reflowing on every store load, and no test
+ * anywhere red. That is the exact failure the geometry module was extracted to
+ * make impossible, and it is impossible only while BOTH ends are pinned.
+ *
+ * 🔴 "NODE", NOT "BLOCKING". `.github/workflows/lint.yml` carries
+ * `continue-on-error: ${{ github.event_name == 'pull_request' }}` at JOB level on
+ * `unit` (line 405) and on `geometry` (line 830), so on a PR neither tier gates a
+ * merge; they block a `main` push. The canonical statement of this is in
+ * `appListingCardGeometry.ts` — do not restate a different severity here.
+ */
+
+const SKELETON = path.resolve(__dirname, '../AppListingCardSkeleton.tsx');
+const BODY = path.resolve(__dirname, '../AppListingsMarketplaceBody.tsx');
+const GEOMETRY_MODULE = '~/components/Apps/appListingCardGeometry';
+
+/**
+ * 🔴 THE ONE CONSTANT THE SKELETON IS NOT REQUIRED TO READ — NAMED, SO IT CANNOT
+ * BECOME A SILENT HOLE.
+ *
+ * `LISTING_ACTION_ROW_GAP_PX` is the gap between the CTA and the `⋮` overflow
+ * trigger. A card renders that trigger only for an owner or a moderator, which a
+ * loading state cannot know, so the skeleton's action row holds exactly ONE child
+ * and the gap has nothing to apply to. Importing it to satisfy a set-equality
+ * check would be an unread declaration that the next reader has to prove unused —
+ * the same shape this component family deleted a `@container` rule and a hook for.
+ *
+ * It costs no geometry: the trigger decides how WIDE the CTA is, never how tall
+ * the row or the card is. The measured parity test is green for an owner (menu
+ * present) and a signed-out viewer (menu absent) alike, which is what makes this
+ * exclusion a fact rather than an assumption.
+ *
+ * The test below still asserts this name IS an export, so the exclusion cannot rot
+ * into a reference to a constant that no longer exists.
+ */
+const NOT_REQUIRED_IN_SKELETON = ['LISTING_ACTION_ROW_GAP_PX'] as const;
+
+const read = (p: string) => fs.readFileSync(p, 'utf8');
+
+/**
+ * 🔴 COMMENTS STRIPPED, AND THE STRIP IS ITSELF CONTROLLED BELOW. Every file in
+ * this component family quotes its own symbols in prose — this one names
+ * `LISTING_CARD_ICON_SIZE_PX` and `keepPreviousData` in docblocks — so an
+ * unstripped scan reads the documentation and stays green with the code deleted.
+ */
+const strip = (src: string) =>
+  src
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/**
+ * The named bindings the file imports from `moduleSpecifier`, parsed rather than
+ * regexed.
+ *
+ * 🔴 PARSED BECAUSE THE CLAIM IS ABOUT THE IMPORT GRAPH, NOT ABOUT TEXT. A regex
+ * over the import statement cannot tell an import from a mention of one inside a
+ * string or a comment, and — the case that matters — cannot distinguish
+ * `import { X } from 'geometry'` from `import { X } from 'somewhere-else'`. The
+ * whole assertion is "these identifiers resolve to THAT module".
+ */
+function namedImportsFrom(file: string, moduleSpecifier: string): string[] {
+  const sf = ts.createSourceFile(file, read(file), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const names: string[] = [];
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    if (stmt.moduleSpecifier.text !== moduleSpecifier) continue;
+    const bindings = stmt.importClause?.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const el of bindings.elements) names.push(el.name.text);
+    }
+  }
+  return names;
+}
+
+describe('AppListingCardSkeleton reads the card geometry rather than copying it', () => {
+  it('POSITIVE CONTROL — the file was found and the comment strip did not eat the code', () => {
+    const code = strip(read(SKELETON));
+    expect(code).toContain('export function AppListingCardSkeleton');
+    expect(code).toContain('export function AppListingCardSkeletonGrid');
+    // …and the strip really removed prose. This sentence exists ONLY in a
+    // docblock in that file, so it is a witness that cannot become code.
+    expect(read(SKELETON)).toContain('IT IS THE MEASUREMENT');
+    expect(code).not.toContain('IT IS THE MEASUREMENT');
+  });
+
+  /**
+   * 🔴 THE ASSERTION THE WHOLE ARRANGEMENT RESTS ON, AND IT IS AN IMPORT-IDENTITY
+   * ONE. Not "the file mentions the constant" and not "the values are equal" — a
+   * value comparison between two copies of the same literal passes for every
+   * possible value of both, which is why `appListingCardView.test.ts` has a
+   * standing rule against it. The set of names imported FROM the geometry module
+   * must equal the set of names the geometry module EXPORTS.
+   *
+   * It fails in both directions on purpose: a constant dropped from the import
+   * list (because someone inlined its value) and a constant ADDED to the module
+   * that the skeleton does not reserve.
+   */
+  it('🔴 imports EXACTLY the geometry module’s exports — no more, no fewer', () => {
+    const allExports = Object.keys(geometry);
+    // The exclusion must still name a real export, or it is silently excusing
+    // nothing while reading as a deliberate carve-out.
+    for (const name of NOT_REQUIRED_IN_SKELETON) {
+      expect(
+        allExports,
+        `${name} is on the skeleton's exclusion list but appListingCardGeometry no longer ` +
+          'exports it — the carve-out has rotted; delete it or repoint it.'
+      ).toContain(name);
+    }
+    const exported = allExports
+      .filter((n) => !(NOT_REQUIRED_IN_SKELETON as readonly string[]).includes(n))
+      .sort();
+    const imported = namedImportsFrom(SKELETON, GEOMETRY_MODULE).sort();
+
+    // Positive control on the parse BEFORE the comparison: a resolver that found
+    // no import at all would otherwise report a plain set difference and read as
+    // "the skeleton is missing everything" rather than "the scan is broken".
+    expect(
+      imported.length,
+      `no named imports parsed from '${GEOMETRY_MODULE}' in AppListingCardSkeleton.tsx — ` +
+        'either the import moved, the specifier changed, or this parser is broken'
+    ).toBeGreaterThan(0);
+    expect(exported.length, 'appListingCardGeometry exports nothing').toBeGreaterThan(0);
+
+    expect(
+      imported,
+      'AppListingCardSkeleton and appListingCardGeometry disagree about the geometry set. ' +
+        'A constant missing here is a number the skeleton is now spelling itself, which is ' +
+        'exactly the drift that module exists to prevent; a constant missing THERE is one ' +
+        'the skeleton reserves for a card that no longer has it.'
+    ).toEqual(exported);
+  });
+
+  /**
+   * 🔴 AN IMPORT IS NOT A READ. The mutation this catches is the realistic one:
+   * keep the import line intact (so nothing looks wrong) and replace the use site
+   * with a literal. The name then occurs exactly ONCE in the file, and the set
+   * equality above still holds.
+   *
+   * Two occurrences is the floor — once in the import clause, once at a use site.
+   * `LISTING_CARD_TITLE_LINE_HEIGHT` is read three times; the floor is what is
+   * assertable for every constant.
+   */
+  it('🔴 …and READS each of them — an imported-but-unused constant is a re-literalised one', () => {
+    const code = strip(read(SKELETON));
+    for (const name of Object.keys(geometry)) {
+      if ((NOT_REQUIRED_IN_SKELETON as readonly string[]).includes(name)) continue;
+      const uses = [...code.matchAll(new RegExp(name, 'g'))].length;
+      expect(
+        uses,
+        `${name} is imported by AppListingCardSkeleton.tsx but never read ` +
+          `(found ${uses} occurrence(s); an import with no use site counts as 1). ` +
+          'Its value is presumably spelled inline somewhere below — put the constant back.'
+      ).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  /**
+   * The column ladder is the OTHER single source this file must not copy. The
+   * skeleton renders two rows at the CURRENT column count, and that count is the
+   * grid's own — `listingGridColumnsAt` in `appListingGrid.ts`, whose thresholds
+   * the stylesheet is already pinned against. A second ladder here (a hardcoded
+   * count, or `@container` rules hiding surplus cells) would be a third copy.
+   */
+  it('reads the column ladder from appListingGrid, not from a second copy', () => {
+    expect(namedImportsFrom(SKELETON, '~/components/Apps/appListingGrid')).toContain(
+      'listingGridColumnsAt'
+    );
+    const code = strip(read(SKELETON));
+    expect(code).toContain('listingGridColumnsAt(');
+    // No stylesheet ladder of its own: the skeleton uses the STORE grid's classes,
+    // so a skeleton cell and a card cell get the same track from the same rules.
+    expect(code).toContain('AppListingsMarketplaceBody.module.scss');
+    const container = code.indexOf('gridClasses.gridContainer');
+    const grid = code.indexOf('gridClasses.grid}');
+    expect(container, 'the skeleton grid does not render the query container').toBeGreaterThan(-1);
+    expect(grid, 'the skeleton grid does not render the grid class').toBeGreaterThan(-1);
+    expect(container, 'the container must WRAP the grid, not sit inside it').toBeLessThan(grid);
+  });
+
+  it('reserves TWO rows, and multiplies the measured column count by that constant', () => {
+    const code = strip(read(SKELETON));
+    // 2 is typed out here and declared there — a test that read the value out of
+    // the module and asserted it equals itself could not fail. That the count the
+    // grid RENDERS really is `2 × columns` is measured in the geometry tier.
+    expect(code).toMatch(/APP_LISTING_SKELETON_ROWS = 2\b/);
+    expect(code).toMatch(/columns \* APP_LISTING_SKELETON_ROWS/);
+  });
+});
+
+/**
+ * ── THE STORE BODY'S HALF OF IT ─────────────────────────────────────────────
+ *
+ * 🔴 STRUCTURAL ONLY, AND SAY SO. These assert that the wiring EXISTS; whether it
+ * WORKS — that the grid genuinely does not empty across a filter change — is a
+ * behavioural claim and lives in
+ * `AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx`, which drives a
+ * real `useInfiniteQuery` through a real key change. A source check alone would be
+ * satisfied by an option passed to a query that ignores it.
+ */
+describe('the store body renders the skeleton grid and keeps the previous page', () => {
+  const bodyCode = () => strip(read(BODY));
+
+  it('POSITIVE CONTROL — the body was found and stripped without losing its code', () => {
+    expect(bodyCode()).toContain('export function AppListingsMarketplaceBody');
+  });
+
+  it('🔴 the first-load state is the skeleton grid, and the bare Loader is gone', () => {
+    const code = bodyCode();
+    expect(code).toMatch(/isLoading \?\s*\(?\s*<AppListingCardSkeletonGrid\s*\/>/);
+    // The retired spinner. Left in place beside the skeleton it would be dead
+    // markup that reads as the live loading state to the next person here.
+    expect(code, 'the store still renders a bare <Loader /> somewhere').not.toMatch(
+      /<Loader[\s/>]/
+    );
+  });
+
+  it('🔴 passes keepPreviousData to the listing query, imported from react-query', () => {
+    expect(namedImportsFrom(BODY, '@tanstack/react-query')).toContain('keepPreviousData');
+    expect(bodyCode()).toMatch(/placeholderData:\s*keepPreviousData/);
+  });
+
+  it('marks the stale grid while the replacement loads', () => {
+    const code = bodyCode();
+    expect(code).toContain('isPlaceholderData');
+    expect(code).toContain('gridClasses.gridPending');
+  });
+
+  /**
+   * 🔴 THE ONE THIS CHANGE COULD PLAUSIBLY HAVE BROKEN. `keepPreviousData` REDUCES
+   * the window in which `items` is empty — it does not remove it (first load,
+   * error, cache eviction) — so the rail's monotonic memo is still load-bearing.
+   * `recentAppsRail.test.ts` owns that guard; this is a local reminder that the
+   * option and the memo are not alternatives, placed where someone deleting the
+   * memo "because keepPreviousData handles it" would meet it.
+   */
+  it('did NOT drop the recents monotonic memo on the strength of keepPreviousData', () => {
+    expect(bodyCode()).toMatch(/reconcileRecentApps\(\s*recents,\s*items,\s*[A-Za-z0-9_.]+\s*\)/);
+  });
+});

--- a/src/components/Apps/__tests__/appListingCardSkeleton.test.ts
+++ b/src/components/Apps/__tests__/appListingCardSkeleton.test.ts
@@ -51,10 +51,13 @@ const GEOMETRY_MODULE = '~/components/Apps/appListingCardGeometry';
  * check would be an unread declaration that the next reader has to prove unused —
  * the same shape this component family deleted a `@container` rule and a hook for.
  *
- * It costs no geometry: the trigger decides how WIDE the CTA is, never how tall
- * the row or the card is. The measured parity test is green for an owner (menu
- * present) and a signed-out viewer (menu absent) alike, which is what makes this
- * exclusion a fact rather than an assumption.
+ * It costs no geometry, and that is MEASURED rather than promised — a carve-out
+ * justified by "it costs nothing" has to have the cost measured or it is a
+ * promise. `AppListingCardSkeleton.geometry.test.tsx` renders the same listings at
+ * the same width for a signed-out viewer and for their OWNER, and pins that the
+ * CTA gives up exactly `LISTING_ACTION_ROW_CONTROL_PX + LISTING_ACTION_ROW_GAP_PX`
+ * of WIDTH to the trigger while the card's box is byte-identical across the two
+ * arms ("the ⋮ trigger takes width from the CTA and NOTHING from the card box").
  *
  * The test below still asserts this name IS an export, so the exclusion cannot rot
  * into a reference to a constant that no longer exists.


### PR DESCRIPTION
## What

The `/apps` store's first-load state is now a grid of card **skeletons** rendered into the same grid markup the results use, and the listing query keeps its previous page across a sort/filter change.

Three pieces:

1. **`AppListingCardSkeleton`** (+ `AppListingCardSkeletonGrid`) — reserves the store card's box. It **imports `appListingCardGeometry.ts`** and reads every constant it needs; it spells none of them. That module was extracted in #4616 for exactly this relationship, and a node guard now pins *both* ends of it.
2. **The loading state** — `<Center py="xl"><Loader /></Center>` is replaced by the skeleton grid, inside the same `.gridContainer` / `.grid` classes and the same per-cell wrapper, so a skeleton cell and a card cell get byte-identical track geometry from the container query (#4615). Count = **two rows at the current column count**, where the count comes from `listingGridColumnsAt` (the ladder's single source) measured off the container, not from a second hardcoded ladder.
3. **`placeholderData: keepPreviousData`** on `appListings.listAvailable`, plus a dimmed/`aria-busy` pending affordance while the replacement loads.

The pending affordance is **opacity only** — no height, no margin, no inserted spinner, nothing that participates in layout, because the point of keeping the previous result is that nothing moves. It is also deliberately **not** `pointer-events: none` (a third commit removes that from an earlier draft): it blocks the mouse and not the keyboard, so it does not stop a viewer reaching a stale card, only one of the two ways of doing so — and the cards are stale, not wrong, so following one is a valid navigation.

## 🔴 What this fixes, and what it does NOT — read this before quoting a number

**Eliminated**

- **Per-card layout shift, for the card's invariant box.** Measured, not inferred: at two named column counts the skeleton cell's `top` / `left` / `width` / `height` are *identical* to the card cell's — `{top: 52, left: 0, width: 332, height: 361.84}` at 1376px of grid (4 columns) and `{top: 52, left: 0, width: 477.19, height: 443.52}` at 2450px (5 columns).
- **The grid emptying on a sort/filter change.** The query key is `{kind, category, sort, limit}`, so every filter change was a new key and `data` went `undefined` for a round trip: `items` emptied, the grid collapsed to zero rows, the page jumped. It no longer does.

**NOT eliminated — all three are real and remain after this PR**

- **The count axis.** The skeleton reserves two rows; the query asks for up to 48 listings. When the two differ the grid still resizes on resolve — the page height moves even though no individual cell does. This PR does not claim, and must not be read as claiming, "zero layout shift".
- **The recents rail's late insertion.** It is seeded empty for SSR parity and hydrates from `localStorage` one frame late, inserting ~90px above the grid. That is the status quo — its placement *below* the search/sort controls already contains it, so it moves the grid rather than the primary controls — and this PR deliberately does not touch it. (The per-account recents-count cookie that would have reserved that height server-side was withdrawn; `recentlyOpenedAppsStore.ts`, `getServerSideProps` and `__tests__/recentsCallSites.test.ts` are all untouched.)
- **Content-variance per card, in BOTH directions.** The skeleton reserves the parts a loading state can predict: the 16:9 cover, the icon, the two *reserved* title lines, a creator line and the always-rendered recommend rollup. Four axes move a real card off that — a conditional `line-clamp-3` tagline, a Beta badge and an owner-only "Incomplete" badge all make it **taller**; a listing with **no creator** (`ListingCard.creator` is nullable and `CreatorChip` returns `null`) makes it **shorter**, measured at −22.29px at 1376/4 cols and −22.30px at 2450/5.
  ⚠️ An earlier revision of this body listed only three axes and said "a listing carrying one is **taller** than its skeleton" — wrong in both the count and the direction, and not hypothetical: this PR's own `keepPreviousData` fixture uses `creator: null`. The downward axis is now pinned by a test that derives the delta from the rendered creator line rather than restating the number. "The invariant shape" the parity fixture describes therefore *includes having a creator* — a choice (most listings have one), not a discovered invariant.

## 🔴 The recents monotonic memo is untouched, on purpose

`reconcileRecentApps(recents, items, healedRecentsRef.current)` still passes its third argument. `keepPreviousData` *narrows* the window in which `items` is empty; it does not close it (first load, an error, a cache eviction). `__tests__/recentAppsRail.test.ts` scans the store body and fails if that call drops to two arguments — that guard is correct and was not widened or weakened.

## 🔴 One geometry constant is deliberately NOT read, and it is named

`LISTING_ACTION_ROW_GAP_PX` is the gap between the CTA and the `⋮` overflow trigger. A card renders that trigger only for an owner or a moderator, which a loading state cannot know, so the skeleton's action row holds exactly one child and a gap has nothing to apply to. Passing it anyway would be an unread declaration reading as load-bearing — the shape this component family has already deleted a `@container` rule and a hook for. It costs no geometry (the trigger decides how *wide* the CTA is, never how *tall* the row or the card is). The node guard carries the exclusion as a named constant and asserts the name is still a real export, so it cannot rot into a silent hole.

🔴 **"It costs no geometry" is MEASURED, not promised** — a second commit exists because the first one only asserted it in prose while every arm of the parity suite rendered a signed-out viewer, i.e. the menu never existed in any measurement the claim cited. `AppListingCardSkeleton.geometry.test.tsx` now renders the same listings at the same width for a signed-out viewer **and for their owner**, and pins that the CTA gives up exactly `LISTING_ACTION_ROW_CONTROL_PX + LISTING_ACTION_ROW_GAP_PX` (46px) of *width* per card while the card's box is identical across the two arms. Positive controls run first (0 triggers in the anon arm, one per cell in the owner arm, no "Incomplete" badge), because "the boxes are equal" is also what you observe when the two arms are the same render.

## Round-2 changes (adversarial audit, no 🔴 — three 🟡 and a doc correction)

**F2 — the skeleton grid emitted ZERO cells server-side.** `useIsomorphicLayoutEffect` is `useLayoutEffect` only when `window` exists and a plain `useEffect` otherwise, so it does not run during SSR at all; with `columns` at `useState(0)` and tRPC on `ssr: false` (the server always renders the `isLoading` branch) this PR replaced a spinner with **nothing** on first paint, then popped ~740px (4 cols) / ~903px (5 cols) of skeleton in at hydration. The component's own docstring asserted the opposite one sentence after correctly naming SSR. `columns` is now seeded from `APP_LISTING_SKELETON_SSR_COLUMNS`, **derived** as `listingGridColumnsAt(MANTINE_BREAKPOINT_PX.xl − APPS_CONTAINER_GUTTER)` = 4.
Why a seed is safe: it decides how MANY cells render, never how WIDE they are — the columns come from the `@container` ladder, which is right on the first paint at every viewport. A wrong seed therefore moves only the COUNT axis (already declared unresolved) and can never produce a wrongly-sized cell. 4 rather than 1 because seeding 1 would make every desktop first paint render two full-width cards that become eight quarter-width ones — a *per-cell* shift, i.e. the thing this PR removes. On a phone it over-reserves (8 → 2) below the fold, on a 5-column grid it under-reserves (8 → 10); both count-only.

**F1 — `<div>` inside `<p>`, 16 per store load.** Mantine `Text` is a `<p>`, Mantine `Skeleton` is a `<div>`. A parser auto-closes the `<p>`, so the parsed DOM and React's tree disagree — a hydration mismatch on `/apps`. It was dormant only because F2 emitted nothing server-side, so **fixing F2 arms it**; both land together. Fixed with `component="span"` on the *Skeleton*, deliberately not `component="div"` on the *Text*: the `<Text>` is the measurement (its line box is the one the card's own `<Text>` produces), so moving that tag moves what this component exists to reproduce. `position: absolute` blockifies the span, so the bar is unchanged.

**F3 — an empty previous page removed the loading affordance entirely.** The dim lives on the grid branch; with an empty previous page there is no grid, `isLoading` is false and `showingEmpty` wins, so "No apps match" sat undimmed and unannounced for the whole round trip. That is a **regression against pre-PR behaviour** (a new key used to give `data: undefined` → `isLoading: true` → the spinner), not merely a gap. `showingStaleEmpty` now falls back to the skeleton grid, ordered ahead of `showingEmpty` — the skeleton rather than a dimmed empty state, because dimming "No apps match" says "this answer is stale" about an answer the viewer has not been given yet.

**F4 — see the content-variance bullet above.** Corrected and pinned.

**🟢 also addressed.** `aria-busy` is no longer described as "the assistive-tech half" — on a non-live-region element it defers processing *within* a live region and announces nothing. The pending dim moved 0.55 → **0.7**, because opacity composites text toward its background and the card's author line is an accepted AA-by-0.23 residual — flagged in the stylesheet as a **judgement, not a measured contrast figure**. And the border-box/content-box hazard is fixed (the measurement subtracts padding and border) — see round 3 for how the *guard* on it had to be rebuilt.

### Guards added, because F2 and F1 both shipped through a green suite

| guard | tier | what it can see that the others could not |
|---|---|---|
| `AppListingCardSkeleton.ssr.browser.test.tsx` | `component` | `renderToString` runs **no** effects, so it reproduces the server faithfully: an exact cell count, a **string** scan for `<div>` inside `<p>` (a parser would repair it), and a **tree** containment check that the announceable text is inside the live region and unhidden. Every scanner carries a positive control on itself. |
| `validateDOMNesting` spy asserted in the geometry suite's `afterEach` | `geometry` | React reports invalid nesting as a `console.error`; the round-1 suite emitted it on **every** run and still reported 7 passed, because the offending element is `position: absolute` and contributes no geometry. Asserted in the hook so it covers every test in the file. |
| "the cell count is two rows of the grid CSS **actually** laid out" | `geometry` | The count↔track relationship at two real column counts. ⚠️ Round 3 measured that it does **not** catch the box-model desync — see below — and its docblock now says so. |
| "the query inline size IS the container's content box" | `geometry` | The box-model desync, with **no fixture**: asserts `gridQueryInlineSize` against the grid's own width, applying the padding itself. |

## Round-3 changes (delta audit: safe to merge, two 🟡 + two 🟢 — all accuracy defects in round-2's *claims*)

The round-2 payload was confirmed correct and mutation-proven; what was wrong was what round 2 *said* about two of its guards.

**🟡 1 — the relationship guard could not see the desync it was written for.** With `padding: 8px` on `.gridContainer` and the subtraction removed, "the cell count is two rows of the grid CSS actually laid out" passed in **both** arms. The cause is structural, not a bad assertion: the parity fixtures sit deliberately **mid-band** (1376 is 208px above the 1168 rung, 2450 is 86px above 2364) so an off-by-one cannot reach them — and that same margin means no plausible padding can move the column count either. **The property that makes them good parity fixtures is what blinded the desync guard**; two guards with opposite fixture requirements were sharing one list.
Fixed by removing the fixture dependency rather than adding a second fixture: the measurement is now an exported `gridQueryInlineSize`, asserted **directly** against the container's content box with the padding applied by the test itself. The count↔row test is kept with its claim narrowed, and the component comment claiming it "catches this and any other cause" is corrected.

🔴 **The reference read was wrong first time, and only the positive control caught it.** `getComputedStyle(el).width` looked like an independent read of the content box; under `box-sizing: border-box` — which Preflight sets on everything — Chrome resolves it to the **border** box. Measured on a 1376px container with 8px padding + 2px borders: computed `width` `1376px`, `clientWidth` 1372, true content box 1356. A reference that tracks the value under test is not a reference. The guard now measures the **grid's own width**, which as a marginless block child *is* the container's content box.

**🟡 2 — the live region most likely announced nothing.** It carried `role="status" aria-busy="true"` with `aria-label="Loading apps"` and every descendant `aria-hidden`. `aria-busy="true"` on a live region instructs AT to **withhold** announcements and was a hardcoded literal that never cleared (the grid unmounts instead); a fully `aria-hidden` subtree has no announceable content; and a live region announces its **content**, not its label. This sat in the paragraph rewritten in round 2 to stop overstating exactly this. `role="status"` moved to the container (so the text is not a grid cell), `aria-busy` is gone, and the region holds real `sr-only` text.
⚠️ **Not verified with a screen reader**, by me or by the audit. The claim is that the markup *can* announce, not that a given AT does — the SSR test asserts the three markup properties and is named accordingly.
📏 **Known cost of choosing the skeleton fallback over dimming the empty state**, measured by the auditor: at 1376px of grid the store body is **791.69px** in the skeleton state vs **173.09px** in the empty state — a **618.6px** grow-then-shrink each time that branch is entered and left, plus "Clear filters" vanishing for the round trip. Mitigating: the grid is the last child of the `Stack`, so nothing above it moves and CLS impact is likely ~0 — the cost is the content swap, not a shift.

**🟢 3** — "asserted in the hook, so it covers EVERY test in this file" was a claim about **one** test. React dedupes `validateDOMNesting` per warn-key, so with the defect reintroduced the whole file reports 1 failed / 9 passed even though 9 of the 10 tests render the offending markup. Not inert, but reworded to what it buys.
**🟢 4** — the `console.error` spy **replaced** rather than wrapped, silently discarding every unrelated warning in the file whose own docstring says such warnings scroll past. It now forwards to the original.
**Nits** — the nesting defect fired **exactly 16** times per load (8 cells × 2 meta lines), not "16–20"; 20 would need 10 cells, which no server render produces. And the F2 fix takes the loading grid's server HTML from **1,035 → 28,123 bytes** uncompressed: intended (that is the skeleton markup existing at all), highly compressible, and worth naming on a page whose LCP this body cites as 6.4s.

## Round-4 changes (delta audit on round 3 — guard/description accuracy only; last round)

**🟡 F1 — the a11y guard asserted neither structural property its docblock claimed, for the third time.** Its body was a flat string scan while the docblock promised "with real text INSIDE it" and "the text is not itself hidden" — both facts about a **tree**. Two mutants measured passing it at 4/4: the `sr-only` span rendered as a **sibling** of the region (`role="status"` still once, `Loading apps` still in the string, no `aria-busy`, class regex still matches), and `aria-hidden` on the span (the old `[^>]*` admitted any attribute). Both restore the exact round-2 defect.
Rebuilt as a **containment** check over a parsed document: one region, `aria-busy` null, `region.querySelector('.sr-only')` non-null with the right text, and an `aria-hidden` walk from the text up to and including the region. A positive control asserts the parse produced the expected cell count first, since `DOMParser` returns a valid empty document for junk.
🔴 **The two instruments are deliberately different on purpose, and the file says so:** the `<div>`-in-`<p>` check must stay a **string** scan because an HTML parser *repairs* that offence, while this one must be a **tree** check because a string cannot express ancestry. Same input, opposite requirements.

**🟡 F2 — the sentence my round-3 commit said it corrected survived verbatim.** The correction was *added* beside the `domNestingErrors` declaration; the original ("covers EVERY test in this file") sat 35 lines below, immediately above the assertion — where a reader debugging a failure actually looks. Two contradictory claims shipped and the wrong one was better-placed. The original is now rewritten, not annotated.

**🟢 F3** — `AppListingCardSkeleton.tsx` still said the `aria-hidden` subtree was fine because "the **grid** it sits in announces 'Loading apps' once". The same commit had moved `role="status"` onto the **container**, and "announces … once" was the unhedged version I had correctly hedged at two other sites. Three sites carried it; I had fixed two.
**🟢 F4** — the rebuilt guard's fixture used `padding: 8px` with equal 2px borders, so it could not tell left from right: the copy-paste mutant `px(cs.paddingLeft) - px(cs.paddingLeft)` survived at 11/11. Now `4px 16px 12px 32px` with 2px/6px borders, every term observable; both left/left mutants die.
**🟢 F6** — the count↔row test's failure message still sent engineers to "check whether `.gridContainer` gained padding or a border", the investigation its own docblock declares it blind to. It now names the real leads and says explicitly that a green box-model guard rules padding out.

## Tests

| file | tier | what it owns |
|---|---|---|
| `AppListingCardSkeleton.geometry.test.tsx` | `geometry` | measured box parity at 4 and 5 columns; the owner-vs-anon trigger arm; the cell-count↔rendered-row relationship; the creator-less delta; cascade / cleanup / rung / DOM-nesting controls |
| `AppListingCardSkeleton.ssr.browser.test.tsx` | `component` | what the SERVER emits: exact cell count, no `<div>` in a `<p>`, announced once |
| `__tests__/appListingCardSkeleton.test.ts` | `unit` (node) | import-**identity** against `appListingCardGeometry`'s own `Object.keys`, and that each name is actually *read* |
| `AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx` | `component` | the grid does not empty across a filter change, driven through a **real** `useInfiniteQuery`; and a stale EMPTY previous page still shows an affordance |

**The parity test is in `geometry`, not `component`, and that is load-bearing.** `test/component-setup.tsx` injects only `globals.css`'s unconditional `:root` custom properties into a throwaway sheet, so Tailwind utilities are inert in that tier by default — and the card's box depends on `h-full` and on the grid stretching its items. The sibling `AppListingsMarketplaceBody.stretch.geometry.test.tsx` records its own first draft, written in `component`, reporting the *defect's* numbers on correct code. This file asserts `cascadeEvidence()` (Tailwind resolves, Preflight loaded, >1000 rules) before it asserts any box.

**The keepPreviousData spec delegates to react-query rather than mocking the result.** Every sibling spec mocks `useInfiniteQuery` with a function returning a literal object; against such a mock this behaviour is untestable, because the mock decides what `data` is and the test would pass with the option deleted. The mock here is a thin adapter forwarding the component's own input and its own options object into the real `useInfiniteQuery`, and it captures that options object so a second test can assert `placeholderData` **is** react-query's `keepPreviousData` by identity.

### Mutation table (mutate → run → observe → revert)

| # | mutation | expectation | observed |
|---|---|---|---|
| A | skeleton's cover ratio box → a fixed `height: 100` | parity red | **RED**, both widths, with its own message: skeleton `height 275.09` vs card `361.84` at 1376; `327.09` vs `413.84` bottoms |
| B | skeleton re-literalises `LISTING_CARD_ICON_SIZE_PX` as `40` (**same value**, import kept) | node guard red | **RED**: `LISTING_CARD_ICON_SIZE_PX is imported by AppListingCardSkeleton.tsx but never read (found 1 occurrence(s)…)` |
| C | skeleton's title reservation halved (2 lines → 1) | parity red | **RED**, both widths: skeleton `337.84` vs card `361.84` at 1376; `419.52` vs `443.52` at 2450 |
| D | `LISTING_CARD_TITLE_LINES` `2 → 3` **in the shared module** | *(see below)* | parity **GREEN**; node `pins the geometry a skeleton has to reproduce` **RED** |
| E | remove `placeholderData: keepPreviousData` from the query | keepPreviousData spec red | **RED**, both tests: `the store emptied while the re-sorted page loaded… expected +0 to be 3`, and `expected undefined to be [Function keepPreviousData]` |
| F | seed back to `useState(0)` (the round-1 code) | SSR spec red | **RED**: `the server emitted 0 skeleton cells… the layout effect that corrects it does NOT run during SSR` |
| G | drop `component="span"` from the Skeleton (the round-1 code) | SSR spec red | **RED**: `expected 16 to be +0` — 8 cells × 2 meta lines, matching the audit's "16–20 per store load" |
| G2 | same mutation, geometry tier | geometry suite red | **RED**: `React reported invalid DOM nesting while rendering` — the blind spot round 1 shipped through |
| H | desync the JS column count from the CSS ladder (`inlineSize + 1000`) | relationship guard red | **RED**, both widths: `the grid rendered 4 columns but the skeleton emitted 10 cells, which is not 2 rows of it` |
| I | remove the `showingStaleEmpty` fallback | stale-empty test red | **RED**: `the store showed NO loading affordance while re-sorting an empty result set` |
| J | `padding: 8px` on `.gridContainer` **and** drop the subtraction (the audit's mutation) | desync guard red | **RED**: `expected 16 to be less than 0.01` — the round-2 guard passed in both arms here |
| J2 | drop the subtraction **only** (no stylesheet change) — the isolated control | desync guard red | **RED**, and the *only* failure (1 of 11): `the measured inline size is the BORDER box, not the CONTENT box… expected 20 to be less than 0.01` |
| K | put `aria-busy="true"` back on the live region | SSR a11y test red | **RED**: `the live region is marked aria-busy, which tells assistive tech to withhold announcements` |
| K2 | render the `sr-only` text as a **sibling** of the live region | a11y guard red | **RED** (was 4/4 green pre-rebuild): `the live region contains no sr-only text… text rendered as a SIBLING of the region announces nothing` |
| K4 | `aria-hidden` on the announceable text | a11y guard red | **RED** (was 4/4 green pre-rebuild): `aria-hidden on <span> removes the announceable text from the accessibility tree` |
| L | `px(cs.paddingLeft) - px(cs.paddingLeft)` (copy-paste left/left) | desync guard red | **RED** (survived at 11/11 under the symmetric fixture): `expected 16 to be less than 0.01` |
| L2 | `px(cs.borderLeftWidth)` twice | desync guard red | **RED**, 1 of 11 |

🔴 **Mutation D is reported as it happened, not as it was predicted.** The brief expected "change a geometry constant the skeleton reads → parity reds". It does **not**, and that is the single source working rather than a gap: both the card and the skeleton read the same constant, so moving it moves both ends together and their boxes stay equal — which is the entire property this arrangement exists to buy. What catches D is the node tier's hand-typed literal pin in `appListingCardView.test.ts` ("pins the geometry a skeleton has to reproduce"), by design. The mutation that *does* red parity is the skeleton **diverging** from the constant — A and C above.

Also worth stating plainly: mutation **E leaves the stale-empty test PASSING** (1 of 3) — without `keepPreviousData` that path falls back to `isLoading` and shows a skeleton anyway. The stale-empty test discriminates on **I**, not on E; the two are not redundant. And mutation B changes no pixels, so **parity stays green under it**. Re-literalising a constant at its current value is the drift *precursor*, invisible to any measurement; the node guard is the only thing that sees it. That division of labour is why both tests exist.

## Regression matrix

Every new spec was run against pre-change source and watched to FAIL, then against HEAD.

**Round 1 — against `7fe47a6558`** (the tip this branch was cut from). Method: restore `AppListingsMarketplaceBody.tsx` and `.module.scss` to base content with the new tests and the new component present, so each spec LOADS and fails on pre-change *behaviour*.

| spec | red at base | green at HEAD |
|---|---|---|
| `AppListingCardSkeleton.geometry.test.tsx` | **6 failed / 6** — `apps-listing-skeleton-grid did not render (loading=true)` | ✅ **10 passed** |
| `__tests__/appListingCardSkeleton.test.ts` | **3 failed / 10** — the three body assertions | ✅ **11 passed** |
| `AppListingsMarketplaceBody.keepPreviousData.browser.test.tsx` | **2 failed / 2** | ✅ **3 passed** |

**Round 2 — against `cadad49a71`**, the round-1 tip that actually shipped the audited defects. This is the meaningful control for the new guards: I checked out that commit's `AppListingCardSkeleton.tsx`, `AppListingsMarketplaceBody.tsx` and `.module.scss` and ran the round-2 specs over them.

| guard | at `cadad49a71` | at HEAD |
|---|---|---|
| geometry `validateDOMNesting` (F1) | **RED** — `1 failed / 10`, `React reported invalid DOM nesting while rendering` | ✅ green |
| stale-empty affordance (F3) | **RED** — `1 failed / 3`, with its own message | ✅ green |
| SSR cell count (F2) | ⚠️ **cannot load** — `does not provide an export named 'APP_LISTING_SKELETON_SSR_COLUMNS'` → `Tests no tests`. An absence, **not** a red. | ✅ green |

🔴 **That last row is stated as a limitation, not glossed.** A spec that fails to import reports "no tests", which is the reassuring-zero shape this repo has been bitten by. The isolated control for it is **mutation F**: round-1's `useState(0)` with the new export present so the module loads — that goes RED with the naming message, which is the evidence the row above cannot supply. Likewise mutation G reproduces round-1's Skeleton markup exactly at the defect site.

**Suites re-run whole at HEAD (round 2):**

| project | result |
|---|---|
| `unit`, `src/components/Apps` | 71 files / **1524** tests passed |
| `geometry` (whole project) | 4 files / **30** tests passed |
| `component`, `src/components/Apps` | 80 files / **1183** tests passed |
| `test:lint-rules` | 32 files / 476 tests passed |
| `pnpm typecheck` | 0 errors |
| eslint + prettier on all seven changed files | clean |

⚠️ **On COLD browser runs.** The first one or two after a module-graph change produce a different, meaningless failure set each time (`Vitest failed to find the runner`, `error when mocking a module`, `Failed to connect to the browser session`). Wall time is the discriminator — a cold `component` run over `src/components/Apps` aborts in 1–3s or dies at 56s; the warm ones above take ~45–60s and are the readings quoted. Every red here was re-run warm before being believed.

⚠️ **A `Tests no tests` I misattributed, corrected here because the wrong diagnosis is worse than none.** I hit `Tests no tests` on one mutation run and blamed `src/components/Apps/__screenshots__/<spec>.geometry.test.tsx/` — a **directory** created by a failing browser test whose name matches the `geometry` glob — and started `rm -rf`-ing it between runs.

**That mechanism is refuted.** With such a directory deliberately present and no cleanup, a whole-project `geometry` run gives `4 passed / 30 passed` and the single spec `11 passed` — it neither hangs nor reports `Tests no tests`. The reproducible cause is a **cold `optimizeDeps` reload**: `Vite unexpectedly reloaded a test` → `Cannot read properties of undefined (reading 'config')` → `Tests no tests`, with the identical command warm giving `4 passed`. So the `rm -rf` mitigation does not address it, and re-running **warm** does.

Recording the retraction rather than quietly deleting the claim: an empty result cannot distinguish two mechanisms, and the next `Tests no tests` must not be dismissed by a rule that does not apply to it. (I did separately observe a whole-project `geometry` hang while such a directory existed; that observation is unexplained and is **not** evidence for the mechanism I attached to it.)

## Out of scope (explicitly)

No recents-count cookie, no `getServerSideProps` change, `recentlyOpenedAppsStore.ts` untouched, `appsPageWidths.ts` / `src/pages/apps/*.tsx` / `submissionsTable.ts` untouched (a concurrent PR owns those).
