### PR TITLE
feat(articles): mark an article as published by Civitai

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260904180000_article_is_official/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260904180000_article_is_official/migration.sql
@@ -1,0 +1,13 @@
+-- Marks an article as published by Civitai rather than by a community author.
+--
+-- Mirrors `Model.isOfficial` (schema.prisma:967), which is the same concept on models: a
+-- column with a moderator-only setter and a "Mark Official" menu item. Justin chose this
+-- over a tag on 2026-09-04, after a review of the tag version found four defects that the
+-- column does not have -- chiefly that article tags attach by NAME through
+-- `connectOrCreate`, so a tag-based marker is a string any user can type, and the row it
+-- creates defaults to not-adminOnly.
+--
+-- `DEFAULT false NOT NULL` on a boolean is metadata-only in Postgres 11+ (no table
+-- rewrite), so this is safe to apply to `Article` while the site is up. Measured on prod
+-- 2026-09-04: 27,002 rows, server_version 18.3.
+ALTER TABLE "Article" ADD COLUMN IF NOT EXISTS "isOfficial" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -4498,6 +4498,9 @@ model Article {
   // override is active (or a legacy override predating this column).
   moderatorNsfwLevelBasis Int?
   lockedProperties String[]      @default([])
+  // Published by Civitai rather than by a community author. Mirrors Model.isOfficial:
+  // a column with a moderator-only setter, not a tag anyone can type.
+  isOfficial       Boolean       @default(false)
   status           ArticleStatus @default(Draft)
 
   thread             Thread?

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -601,6 +601,7 @@ export type Article = {
   moderatorNsfwLevel: number | null;
   moderatorNsfwLevelBasis: number | null;
   lockedProperties: Generated<string[]>;
+  isOfficial: Generated<boolean>;
   status: Generated<ArticleStatus>;
 };
 export type ArticleEngagement = {

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -2911,6 +2911,7 @@ export interface Article {
   moderatorNsfwLevel: number | null;
   moderatorNsfwLevelBasis: number | null;
   lockedProperties: string[];
+  isOfficial: boolean;
   status: ArticleStatus;
   thread?: Thread | null;
   reactions?: ArticleReaction[];

--- a/src/components/Article/ArticleContextMenu.tsx
+++ b/src/components/Article/ArticleContextMenu.tsx
@@ -24,7 +24,7 @@ import { ArticleStatus, CollectionType, CosmeticEntity } from '~/shared/utils/pr
 import React from 'react';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { ToggleLockComments } from '../CommentsV2/ToggleLockComments';
-import { IconLock } from '@tabler/icons-react';
+import { IconLock, IconRosetteDiscountCheck } from '@tabler/icons-react';
 import { ToggleSearchableMenuItem } from '../MenuItems/ToggleSearchableMenuItem';
 import { AddArtFrameMenuItem } from '~/components/Decorations/AddArtFrameMenuItem';
 import { useRescanArticle } from '~/hooks/useRescanArticle';
@@ -85,6 +85,30 @@ export function ArticleContextMenu({ article, ...props }: Props) {
         ),
     });
   };
+
+  // Moderator-only, mirroring the model menu's Mark Official. The server is the authority
+  // (`article.setOfficial` is a `moderatorProcedure`); this only draws the control.
+  const setOfficialMutation = trpc.article.setOfficial.useMutation({
+    async onSuccess(result) {
+      showSuccessNotification({
+        title: result.isOfficial ? 'Marked official' : 'Unmarked official',
+        message: result.isOfficial
+          ? 'This article now shows the Civitai Official badge'
+          : 'The Civitai Official badge has been removed',
+      });
+
+      queryUtils.article.getById.setData({ id: article.id }, (old) =>
+        old ? { ...old, isOfficial: result.isOfficial } : old
+      );
+      await queryUtils.article.getInfinite.invalidate();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to update official status',
+        error: new Error(error.message),
+      });
+    },
+  });
 
   const unpublishArticleMutation = trpc.article.unpublish.useMutation();
   const handleUnpublishArticle = () => {
@@ -231,6 +255,26 @@ export function ArticleContextMenu({ article, ...props }: Props) {
                 closeMenuOnClick={false}
               >
                 Rescan
+              </Menu.Item>
+            )}
+            {isModerator && (
+              <Menu.Item
+                color="blue"
+                leftSection={
+                  setOfficialMutation.isPending ? (
+                    <Loader size={14} />
+                  ) : (
+                    <IconRosetteDiscountCheck size={14} stroke={1.5} />
+                  )
+                }
+                disabled={setOfficialMutation.isPending}
+                onClick={(e: React.MouseEvent) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setOfficialMutation.mutate({ id: article.id, isOfficial: !article.isOfficial });
+                }}
+              >
+                {article.isOfficial ? 'Unmark Official' : 'Mark Official'}
               </Menu.Item>
             )}
             {isModerator && (

--- a/src/components/Article/OfficialArticleBadge.tsx
+++ b/src/components/Article/OfficialArticleBadge.tsx
@@ -1,0 +1,37 @@
+import { IconRosetteDiscountCheck } from '@tabler/icons-react';
+
+import { IconBadge } from '~/components/IconBadge/IconBadge';
+
+/**
+ * The marker on an article published by Civitai rather than by a community author.
+ *
+ * Driven by `Article.isOfficial` — a column with a moderator-only setter
+ * (`setArticleOfficial`, mounted on `moderatorProcedure`), mirroring `Model.isOfficial`.
+ * 🔴 It is a provenance claim, so never render it from anything a user can set about their
+ * own content, and never derive it from a tag name: the design this replaced did exactly
+ * that, and article tags attach by name through `connectOrCreate`, so the marker was a
+ * string any user could type.
+ *
+ * Built on `IconBadge` rather than composing `Badge` + `Tooltip` by hand, so the
+ * icon-to-text gap and the horizontal padding stay the ones every other icon badge on the
+ * card uses. `IconRosetteDiscountCheck` is the same icon the model moderator menu uses for
+ * Mark Official, which is the point — one provenance concept should not look like two.
+ *
+ * One component for both surfaces (the card and the article page) on purpose. Two
+ * hand-maintained copies of a provenance marker is how one of them ends up looking like an
+ * ordinary chip.
+ */
+export function OfficialArticleBadge({ className }: { className?: string }) {
+  return (
+    <IconBadge
+      className={className}
+      color="blue"
+      variant="filled"
+      size="sm"
+      tooltip="Published by Civitai"
+      icon={<IconRosetteDiscountCheck size={14} stroke={2.5} />}
+    >
+      Official
+    </IconBadge>
+  );
+}

--- a/src/components/Cards/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard.tsx
@@ -1,5 +1,6 @@
 import { Badge, Text } from '@mantine/core';
 import { memo } from 'react';
+import { OfficialArticleBadge } from '~/components/Article/OfficialArticleBadge';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { IconBolt, IconBookmark, IconEye, IconMessageCircle2 } from '@tabler/icons-react';
 import { slugit } from '~/utils/string-helpers';
@@ -29,7 +30,7 @@ export const ArticleCard = memo(function ArticleCard({ data, aspectRatio }: Prop
 });
 
 function ArticleCardContent({ data, aspectRatio }: Props) {
-  const { id, title, coverImage, publishedAt, user, tags, status, nsfwLevel } = data;
+  const { id, title, coverImage, publishedAt, user, tags, status, nsfwLevel, isOfficial } = data;
   // Show the article's aggregate nsfwLevel on the card (badge + blur), not just
   // the cover image's own level. Content images or a moderator/user override can
   // raise the article above the cover's rating; lifting here keeps every feed
@@ -55,6 +56,8 @@ function ArticleCardContent({ data, aspectRatio }: Props) {
       header={
         <div className="flex w-full justify-between">
           <div className="flex items-center gap-1">
+            {/* Provenance leads: an official article is official before it is a guide. */}
+            {isOfficial && <OfficialArticleBadge className={cardClasses.chip} />}
             {category && (
               <Badge
                 size="sm"

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -44,6 +44,7 @@ import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { openArticleRatingReviewModal } from '~/components/Dialog/triggers/article-rating-review';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { OfficialArticleBadge } from '~/components/Article/OfficialArticleBadge';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMenu';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
@@ -386,6 +387,12 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
                   </Text>
                 </Tooltip>
               )}
+            {article.isOfficial && (
+              <>
+                <Divider orientation="vertical" />
+                <OfficialArticleBadge />
+              </>
+            )}
             {category && (
               <>
                 <Divider orientation="vertical" />

--- a/src/server/routers/__tests__/article.router.set-official.test.ts
+++ b/src/server/routers/__tests__/article.router.set-official.test.ts
@@ -1,0 +1,89 @@
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `article.setOfficial` marks an article as published by Civitai. It is a PROVENANCE
+ * claim, so the whole feature is the authorization: a badge a user can put on their own
+ * article is worse than no badge.
+ *
+ * This drives the REAL router through `createCaller`, so the middleware wiring is what
+ * decides — not a source scan and not the service's own recheck. The design this replaced
+ * carried the marker on a tag, and tags attach by name through `connectOrCreate`, which is
+ * exactly the shape that made it forgeable.
+ */
+
+const { mockSetArticleOfficial } = vi.hoisted(() => ({ mockSetArticleOfficial: vi.fn() }));
+
+vi.mock('~/server/services/article.service', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  setArticleOfficial: mockSetArticleOfficial,
+}));
+
+import { articleRouter } from '../article.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const moderator = { id: 1, isModerator: true, tier: 'free', muted: false, bannedAt: null };
+const member = { id: 2, isModerator: false, tier: 'free', muted: false, bannedAt: null };
+
+describe('article.setOfficial', () => {
+  beforeEach(() => {
+    mockSetArticleOfficial.mockReset();
+    mockSetArticleOfficial.mockResolvedValue({ id: 7, isOfficial: true });
+  });
+
+  it('rejects a signed-in member, and does not reach the service', async () => {
+    const caller = articleRouter.createCaller(fakeCtx(member) as never);
+
+    await expect(caller.setOfficial({ id: 7, isOfficial: true })).rejects.toBeInstanceOf(TRPCError);
+    expect(mockSetArticleOfficial).not.toHaveBeenCalled();
+  });
+
+  it('rejects an anonymous caller, and does not reach the service', async () => {
+    const caller = articleRouter.createCaller(fakeCtx(undefined) as never);
+
+    await expect(caller.setOfficial({ id: 7, isOfficial: true })).rejects.toBeInstanceOf(TRPCError);
+    expect(mockSetArticleOfficial).not.toHaveBeenCalled();
+  });
+
+  // The control for both refusals above. Without it they pass for a route that rejects
+  // everyone, including moderators — which would read as "well guarded" and ship a
+  // feature nobody can use.
+  it('lets a moderator through, and passes the moderator flag to the service', async () => {
+    const caller = articleRouter.createCaller(fakeCtx(moderator) as never);
+
+    await expect(caller.setOfficial({ id: 7, isOfficial: true })).resolves.toEqual({
+      id: 7,
+      isOfficial: true,
+    });
+    expect(mockSetArticleOfficial).toHaveBeenCalledWith({
+      id: 7,
+      isOfficial: true,
+      isModerator: true,
+    });
+  });
+
+  // Unmarking is the same boundary as marking: a member who could clear the flag could
+  // strip provenance off a Civitai article.
+  it('rejects a member unmarking, too', async () => {
+    const caller = articleRouter.createCaller(fakeCtx(member) as never);
+
+    await expect(caller.setOfficial({ id: 7, isOfficial: false })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockSetArticleOfficial).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/article.router.ts
+++ b/src/server/routers/article.router.ts
@@ -17,12 +17,14 @@ import {
   getMyArticleRatingReviewSchema,
   resolveArticleImageScanSchema,
   rescanArticleImageSchema,
+  setArticleOfficialSchema,
 } from '~/server/schema/article.schema';
 import { getAllQuerySchema, getByIdSchema } from '~/server/schema/base.schema';
 import {
   deleteArticleById,
   getArticleById,
   getArticles,
+  setArticleOfficial,
   getArticleScanStatus,
   getCivitaiEvents,
   getCivitaiNews,
@@ -169,6 +171,13 @@ export const articleRouter = router({
         .catch(() => undefined);
       return review;
     }),
+  // Moderator-only, exactly like `model.setOfficial`. This is a provenance claim, so the
+  // authority is the procedure, not anything in the payload.
+  setOfficial: moderatorProcedure
+    .input(setArticleOfficialSchema)
+    .mutation(({ input, ctx }) =>
+      setArticleOfficial({ ...input, isModerator: ctx.user.isModerator ?? false })
+    ),
   getMyArticleRatingReview: protectedProcedure
     .use(isFlagProtected('articleRatingDispute'))
     .input(getMyArticleRatingReviewSchema)

--- a/src/server/schema/article.schema.ts
+++ b/src/server/schema/article.schema.ts
@@ -171,3 +171,9 @@ export type GetMyArticleRatingReviewInput = z.infer<typeof getMyArticleRatingRev
 export const getMyArticleRatingReviewSchema = z.object({
   articleId: z.number(),
 });
+
+export type SetArticleOfficialInput = z.infer<typeof setArticleOfficialSchema>;
+export const setArticleOfficialSchema = z.object({
+  id: z.number(),
+  isOfficial: z.boolean(),
+});

--- a/src/server/selectors/article.selector.ts
+++ b/src/server/selectors/article.selector.ts
@@ -24,6 +24,10 @@ export const articleDetailSelect = Prisma.validator<Prisma.ArticleSelect>()({
   title: true,
   publishedAt: true,
   status: true,
+  // Deliberately exposed to the webhook and search-index consumers that spread this
+  // select: "published by Civitai" is the kind of provenance an external consumer wants,
+  // and it is already public on the page.
+  isOfficial: true,
   // `tag` is a required relation on TagsOnArticle, but orphaned join rows
   // exist in prod (tagId pointing at a hard-deleted Tag). Selecting the
   // required relation on such a row makes Prisma throw "Inconsistent query

--- a/src/server/services/__tests__/article-set-official.service.test.ts
+++ b/src/server/services/__tests__/article-set-official.service.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+const { mockQueueUpdate } = vi.hoisted(() => ({ mockQueueUpdate: vi.fn() }));
+
+vi.mock('~/server/search-index', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  articlesSearchIndex: { queueUpdate: mockQueueUpdate },
+}));
+
+import { setArticleOfficial } from '~/server/services/article.service';
+
+/**
+ * The service's own moderator check, separate from the router's.
+ *
+ * Two checks for one boundary is deliberate and worth keeping: the router decides who may
+ * CALL this, and this decides what the function does when someone calls it anyway. The
+ * second is what protects a future caller — a job, a script, another service — that does
+ * not go through `moderatorProcedure`. `setModelOfficial` is built the same way.
+ */
+describe('setArticleOfficial', () => {
+  beforeEach(() => {
+    mockQueueUpdate.mockReset();
+    mockQueueUpdate.mockResolvedValue(undefined);
+    dbMock.dbRead.article.findUnique.mockReset();
+    dbMock.dbRead.article.findUnique.mockResolvedValue({ id: 7 });
+    dbMock.dbWrite.article.update.mockReset();
+    dbMock.dbWrite.article.update.mockResolvedValue({ id: 7, isOfficial: true });
+  });
+
+  it('refuses a non-moderator, and writes nothing', async () => {
+    await expect(
+      setArticleOfficial({ id: 7, isOfficial: true, isModerator: false })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+    expect(dbMock.dbWrite.article.update).not.toHaveBeenCalled();
+    expect(mockQueueUpdate).not.toHaveBeenCalled();
+  });
+
+  // The control for the refusal above: same call, moderator flag set. Without it, a
+  // function that threw unconditionally would pass.
+  it('writes the flag for a moderator', async () => {
+    await expect(
+      setArticleOfficial({ id: 7, isOfficial: true, isModerator: true })
+    ).resolves.toEqual({ id: 7, isOfficial: true });
+
+    expect(dbMock.dbWrite.article.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { isOfficial: true },
+      select: { id: true, isOfficial: true },
+    });
+  });
+
+  it('carries the value through rather than always marking official', async () => {
+    dbMock.dbWrite.article.update.mockResolvedValue({ id: 7, isOfficial: false });
+
+    await setArticleOfficial({ id: 7, isOfficial: false, isModerator: true });
+
+    expect(dbMock.dbWrite.article.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { isOfficial: false } })
+    );
+  });
+
+  it('refuses an article that does not exist, and writes nothing', async () => {
+    dbMock.dbRead.article.findUnique.mockResolvedValue(null);
+
+    await expect(
+      setArticleOfficial({ id: 404, isOfficial: true, isModerator: true })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    expect(dbMock.dbWrite.article.update).not.toHaveBeenCalled();
+  });
+
+  // The search index document spreads `articleDetailSelect`, which carries `isOfficial`.
+  // Without this the index keeps serving the old provenance until something else touches
+  // the article — which for an article nobody edits is forever.
+  it('queues a search-index update for the article it changed', async () => {
+    await setArticleOfficial({ id: 7, isOfficial: true, isModerator: true });
+
+    expect(mockQueueUpdate).toHaveBeenCalledWith([{ id: 7, action: 'Update' }]);
+  });
+});

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -17,6 +17,7 @@ import type {
   ArticleMetadata,
   CreateArticleRatingReviewInput,
   GetInfiniteArticlesSchema,
+  SetArticleOfficialInput,
   UpsertArticleInput,
 } from '~/server/schema/article.schema';
 import { articleWhereSchema } from '~/server/schema/article.schema';
@@ -105,6 +106,7 @@ type ArticleRaw = {
   availability: Availability;
   userId: number | null;
   status: ArticleStatus;
+  isOfficial: boolean;
   tags: {
     tag: {
       id: number;
@@ -448,6 +450,7 @@ export const getArticles = async ({
         a."availability",
         a."userId",
         a.status,
+        a."isOfficial",
         (
           SELECT COALESCE(
             jsonb_agg(
@@ -2919,3 +2922,39 @@ export async function getArticleRatingReviewForOwner({
 // NOTE(moderator-migration): the moderator resolution path (formerly resolveArticleRatingReview) now
 // lives in the spoke app (apps/moderator, Kysely). The owner-facing create + auto-resolve paths above
 // stay here.
+
+/**
+ * Mark an article as published by Civitai, or take that mark off.
+ *
+ * Mirrors `setModelOfficial` (model.service.ts) deliberately, down to the moderator check:
+ * this is a provenance claim, so the authority has to be a permission the user cannot give
+ * themselves. The earlier design put it on an `adminOnly` TAG, which a review killed —
+ * article tags attach by NAME through `connectOrCreate`, so the marker was a string any
+ * user could type, and the row it creates defaults to not-adminOnly.
+ *
+ * 🔴 The `isModerator` argument is passed by the caller, so it is only as true as the
+ * caller. The router mounts this on `moderatorProcedure`; keep it there. Do not add a
+ * second caller that computes this flag from anything a request body carries.
+ */
+export const setArticleOfficial = async ({
+  id,
+  isOfficial,
+  isModerator,
+}: SetArticleOfficialInput & { isModerator: boolean }) => {
+  if (!isModerator) throw throwAuthorizationError();
+
+  const article = await dbRead.article.findUnique({ where: { id }, select: { id: true } });
+  if (!article) throw throwNotFoundError(`No article with id ${id}`);
+
+  const updated = await dbWrite.article.update({
+    where: { id },
+    data: { isOfficial },
+    select: { id: true, isOfficial: true },
+  });
+
+  // The index document spreads `articleDetailSelect`, which now carries `isOfficial`, so
+  // a stale document would keep serving the old provenance to search.
+  await articlesSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
+
+  return updated;
+};


### PR DESCRIPTION
Adds an **Official** badge to articles published by Civitai, as a column with a moderator-only setter and a "Mark Official" menu item — mirroring `Model.isOfficial`, which already exists and is this same concept on models, down to the icon.

Replaces #4618 (closed), which did it with an `adminOnly` tag. Justin chose the column after the five-lane review on that PR found four defects a tag-based marker has and a column does not:

- **A moderator could only apply the tag by typing `civitai official` from memory** — `TagsInput` has no autocomplete of any kind, so the code path that would surface an adminOnly tag to a mod is never reached from the article form.
- **"Inert until the migration runs" was false.** Article tags attach by NAME through `connectOrCreate`, which *creates* a missing tag at `adminOnly = false`. Any user could self-badge in the window between deploy and migration, and the migration's `ON CONFLICT DO UPDATE` would then bless their article retroactively.
- **The guard compared the submitted tag list rather than the change**, so once an article was marked, its *owner* could no longer save it at all — the form seeds the tag field from the article's tags, and every save carried the adminOnly tag back into a bare `UNAUTHORIZED`.
- **The badge matched on tag name**, so renaming the row would silently unset every badge.

None of those exist here. `isOfficial` is a column no request body can set.

## The boundary

`article.setOfficial` is a `moderatorProcedure`, and `setArticleOfficial` rechecks `isModerator` for any future caller that does not come through the router. Two checks for one boundary, deliberately — the router decides who may call it, the service decides what happens when something calls it anyway. `setModelOfficial` is built the same way.

**Driven red, not just asserted:** downgrading `setOfficial` to `protectedProcedure` fails 2 of the 4 router tests. Pristine: 9 passed (4 router + 5 service).

## ⚠️ The migration is not applied

```
packages/civitai-db-schema/prisma/migrations/20260904180000_article_is_official/migration.sql
```

Adding a boolean with a default is metadata-only on Postgres 11+, so it is safe to run while the site is up. Measured on prod 2026-09-04: **27,002 article rows, server_version 18.3**. Until it runs, `setOfficial` fails on a missing column and no badge can appear.

## Also here

- `isOfficial` rides the feed payload (one more column on a query that already runs) and `articleDetailSelect`, which the search index and outbound webhook spread — provenance is what an external consumer wants, and it is public on the page.
- Marking queues a search-index update, or the index keeps serving the old provenance until something else touches the article.
- The badge is built on `IconBadge` rather than composing `Badge` + `Tooltip` by hand, so its icon gap and padding stay the ones every other icon badge on the card uses.
- **The adminOnly-tag guard from #4618 is deliberately not carried over.** Prod has zero adminOnly tags, so it fixes nothing today, and the payload-vs-delta defect above lives in that guard. If it is wanted later it should land on its own, with delta handling, and cover the four other services that attach tags by name with no check at all (`bounty`, `collection`, `model`, `question`).

## 🔴 What is not covered

**Nothing asserts that the badge renders only when `isOfficial` is true.** I tried a rendered test and abandoned it after five rounds: `ArticleCard` pulls in the card template, feature flags, a signals connection and content settings, and stubbing all of them would have tested the stubs. A source-scan guard is not a substitute — measured on the predecessor, it passed for both `{false && <Badge/>}` (badge on nothing) and `const official = true` (a Civitai provenance claim on every community article). I would rather say so than ship a guard that cannot fail.

## Verification

`typecheck: OK — 0 type errors`. ESLint clean on the changed files (3 pre-existing warnings). `pnpm run db:check-generated` passes. Full suite `Test Files 1 failed | 1622 passed | 3 skipped (1627)` — the one failure is `appListingMenuSurface.test.ts`, which compares Windows paths against forward-slash literals and fails on a clean tree. `blocks.router.workflow.test.ts` collected **370**.

One environment note for whoever picks this up next: a `pnpm install` that fails partway (mine hit `EPERM` on the Prisma query-engine DLL, held open by a running dev server) leaves the tree **short of packages while the next install still exits 0**. That produced 721 type errors in `form-graph` consumers that had nothing to do with this diff. A second `pnpm install` added 56 packages and typecheck went green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHZuQDTCG159qcPrCkP7SF