### PR TITLE
feat(moderation): bot-account detection — three heuristics and a reporting threshold

### DIFF
--- a/apps/moderator/src/lib/server/clickhouse-filters.ts
+++ b/apps/moderator/src/lib/server/clickhouse-filters.ts
@@ -3,7 +3,11 @@
 // Declared once because a divergence here fails silently in the worst direction: a copy that misses an
 // updated internal range starts counting our own infrastructure as user signal, so a vote-ring panel
 // reports clusters made of Civitai traffic and nothing anywhere errors.
-export const INTERNAL_IP_RANGE = '10.124.0.0/16';
+//
+// 🔴 THE RANGE LIST NOW LIVES IN `@civitai/shared/clickhouse-ip-filters`, because the main Next app
+// reads the same table and cannot import anything from `apps/moderator`. It is re-exported here so
+// this app's existing importers are unchanged; adding a range in the shared module reaches both.
+export { INTERNAL_IP_RANGE } from '@civitai/shared/clickhouse-ip-filters';
 
 /** Interpolated into ClickHouse queries, which do NO escaping — every IP must match this first. */
 export const IP_PATTERN = /^[0-9a-fA-F.:]{3,45}$/;

--- a/apps/moderator/src/lib/server/reactor-lookup.service.ts
+++ b/apps/moderator/src/lib/server/reactor-lookup.service.ts
@@ -1,7 +1,8 @@
 import { sql } from '@civitai/db/kysely';
 import { dbRead } from './db';
 import { getClickhouse } from './clickhouse';
-import { INTERNAL_IP_RANGE, IP_PATTERN } from './clickhouse-filters';
+import { publicIpOnlySql } from '@civitai/shared/clickhouse-ip-filters';
+import { IP_PATTERN } from './clickhouse-filters';
 import { isInt4Id, usersByIds } from './users.service';
 import { strikeCountsByUserIds } from './moderation-memory.service';
 
@@ -59,26 +60,16 @@ const DELETE_TYPES = [
 const CREATES_ONLY = `type NOT IN (${DELETE_TYPES.map((t) => `'${t}'`).join(',')})`;
 
 /**
- * Private and carrier-internal space, which correlates everyone and therefore no one. `10.124.0.0/16`
- * is ours and already inside `10/8`; it stays named so the shared constant governs the rest.
+ * Private and carrier-internal space, which correlates everyone and therefore no one.
  *
- * 🔴 `ip != ''` is a guard, not a tidy-up. `isIPAddressInRange` RAISES on an empty string, and
- * `userActivities` holds a handful (3 in the last 30 days) — so whether this filter throws depends on
- * whether one lands in the range scanned. Order matters too: the guard has to be evaluated first.
+ * 🔴 THE LIST AND THE COMPOSITION MOVED TO `@civitai/shared/clickhouse-ip-filters` and this is now
+ * one call into it. The main Next app's bot-account detector reads the same `userActivities` rows
+ * for the same reason and cannot import from `apps/moderator`, so the alternative was a second
+ * hand-written copy — which is precisely the divergence `clickhouse-filters.ts` says fails silently.
+ * The emitted string is unchanged, including that `ip != ''` comes first: `isIPAddressInRange` RAISES
+ * on an empty string, and `userActivities` holds a handful.
  */
-const PUBLIC_IP_ONLY = [
-  `ip != ''`,
-  ...[
-    INTERNAL_IP_RANGE,
-    '10.0.0.0/8',
-    '172.16.0.0/12',
-    '192.168.0.0/16',
-    '127.0.0.0/8',
-    '169.254.0.0/16',
-    'fc00::/7',
-    '::1/128',
-  ].map((range) => `NOT isIPAddressInRange(ip, '${range}')`),
-].join(' AND ');
+const PUBLIC_IP_ONLY = publicIpOnlySql();
 
 const windowFilter = (days: number) => `time >= now() - INTERVAL ${Math.trunc(days)} DAY`;
 

--- a/packages/civitai-shared/package.json
+++ b/packages/civitai-shared/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./basemodel.constants": "./src/basemodel.constants.ts",
+    "./clickhouse-ip-filters": "./src/clickhouse-ip-filters.ts",
     "./lazy": "./src/lazy.ts",
     "./type-guards": "./src/type-guards.ts",
     "./moderator-paths": "./src/moderator-paths.ts"

--- a/packages/civitai-shared/src/clickhouse-ip-filters.ts
+++ b/packages/civitai-shared/src/clickhouse-ip-filters.ts
@@ -33,6 +33,16 @@ export const NON_PUBLIC_IP_RANGES: readonly string[] = [
 ];
 
 /**
+ * A bare ClickHouse column identifier — the only thing `publicIpOnlySql` will interpolate.
+ *
+ * Deliberately narrower than ClickHouse's own identifier grammar: no backtick-quoted forms, no dots,
+ * no digits in the leading position. Every caller today passes a plain column name, so the narrow
+ * form costs nothing, and widening it later is a decision someone makes on purpose rather than a
+ * gap someone finds.
+ */
+const SQL_COLUMN_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
  * `ip != '' AND NOT isIPAddressInRange(ip, '…') AND …` — the WHERE fragment.
  *
  * 🔴 `ip != ''` IS A GUARD, NOT A TIDY-UP, AND ITS POSITION IS PART OF IT. `isIPAddressInRange`
@@ -41,10 +51,22 @@ export const NON_PUBLIC_IP_RANGES: readonly string[] = [
  * breaks later, once, for one reader. It is emitted first for that reason, and a caller must not
  * reorder the conjunction.
  *
- * The column is a parameter only so a reader whose column is not called `ip` can use it; it is
- * interpolated, so it must be an identifier the caller controls and never user input.
+ * The column is a parameter only so a reader whose column is not called `ip` can use it.
+ *
+ * 🔴 IT IS INTERPOLATED, AND A COMMENT IS NOT A PRECONDITION. This module's own sibling —
+ * `apps/moderator/src/lib/server/clickhouse-filters.ts`'s `IP_PATTERN` — exists because ClickHouse
+ * queries here are built by string concatenation and the client does NO escaping, so a regex at the
+ * seam is this codebase's convention at exactly this point. Both call sites pass the default today,
+ * which makes this unreachable and makes NOW the cheap time to close it: the guard is being added
+ * before the parameter spreads, not after a caller has already reached it with something it built.
+ * Throwing is the only safe direction — a shadow-mode detector that silently issues a mangled
+ * statement produces a zero that reads as "no ring found".
  */
 export function publicIpOnlySql(column = 'ip'): string {
+  if (!SQL_COLUMN_IDENTIFIER.test(column))
+    throw new Error(
+      `publicIpOnlySql: column must be a bare SQL identifier, got ${JSON.stringify(column)}`
+    );
   return [
     `${column} != ''`,
     ...NON_PUBLIC_IP_RANGES.map((range) => `NOT isIPAddressInRange(${column}, '${range}')`),

--- a/packages/civitai-shared/src/clickhouse-ip-filters.ts
+++ b/packages/civitai-shared/src/clickhouse-ip-filters.ts
@@ -1,0 +1,52 @@
+// The address space that carries no per-account signal, and the predicate that excludes it from any
+// ClickHouse read of a request-level event table (`userActivities` and friends).
+//
+// 🔴 DECLARED ONCE BECAUSE A DIVERGENCE HERE FAILS SILENTLY IN THE WORST DIRECTION. Private and
+// carrier-internal space correlates everyone and therefore no one: a query that omits this filter
+// does not error, it returns a large, confident cluster made of our own infrastructure or of one
+// mobile carrier's NAT, and every consumer reads that as evidence. `apps/moderator`'s reactor-lookup
+// panel carried the only copy of this predicate; a second copy written by hand for a second reader is
+// how one of them silently stops matching the other.
+//
+// Client-safe: string constants and string building only, no client, no env, no IO.
+
+/** Our own infrastructure range. Already inside `10/8`; kept named because several moderator
+ *  queries exclude it on its own without the rest of the list. */
+export const INTERNAL_IP_RANGE = '10.124.0.0/16';
+
+/**
+ * Every range whose members must not be treated as a user-identifying address.
+ *
+ * `INTERNAL_IP_RANGE` first, then RFC1918, loopback, link-local and the IPv6 equivalents. The list is
+ * over-inclusive on purpose — an address wrongly excluded costs one account's IP signal, an address
+ * wrongly INCLUDED manufactures a ring out of everyone behind it.
+ */
+export const NON_PUBLIC_IP_RANGES: readonly string[] = [
+  INTERNAL_IP_RANGE,
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '127.0.0.0/8',
+  '169.254.0.0/16',
+  'fc00::/7',
+  '::1/128',
+];
+
+/**
+ * `ip != '' AND NOT isIPAddressInRange(ip, '…') AND …` — the WHERE fragment.
+ *
+ * 🔴 `ip != ''` IS A GUARD, NOT A TIDY-UP, AND ITS POSITION IS PART OF IT. `isIPAddressInRange`
+ * RAISES on an empty string and `userActivities` holds a handful of them, so whether the query
+ * throws depends on whether a blank row lands in the range being scanned — it passes in testing and
+ * breaks later, once, for one reader. It is emitted first for that reason, and a caller must not
+ * reorder the conjunction.
+ *
+ * The column is a parameter only so a reader whose column is not called `ip` can use it; it is
+ * interpolated, so it must be an identifier the caller controls and never user input.
+ */
+export function publicIpOnlySql(column = 'ip'): string {
+  return [
+    `${column} != ''`,
+    ...NON_PUBLIC_IP_RANGES.map((range) => `NOT isIPAddressInRange(${column}, '${range}')`),
+  ].join(' AND ');
+}

--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -1,5 +1,6 @@
 import { logToAxiom } from '~/server/logging/client';
 import { createCohortReader } from '~/server/services/bot-account-detection/cohort';
+import { createEvidenceReader } from '~/server/services/bot-account-detection/evidence';
 import { runBotAccountDetection } from '~/server/services/bot-account-detection/run';
 import { moderatorApp } from '~/server/services/moderator-app.service';
 import { createJob, UNRUNNABLE_JOB_CRON } from './job';
@@ -48,6 +49,11 @@ export const botAccountDetection = createJob(
   async (ctx) => {
     return runBotAccountDetection({
       reader: createCohortReader(),
+      // The cohort-level sources. Its ClickHouse half is `undefined` on any deployment without
+      // `CLICKHOUSE_HOST`, which is a supported state and NOT an error: the run reports
+      // `evidence_registration_ips: 0` and says so in the summary rather than reporting that no
+      // accounts shared an IP.
+      evidence: createEvidenceReader(),
       sendReport: (report) => moderatorApp.abuseReport(report),
       now: () => new Date(),
       // The scheduler cancels by closing the response; without this the walk keeps paging and

--- a/src/server/services/bot-account-detection/__tests__/cohort.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/cohort.test.ts
@@ -14,6 +14,7 @@ import {
   mergePostCounts,
   modelCountArgs,
   newAccountPageArgs,
+  normalizeEmailDomain,
   selectCohortMembers,
   type CohortDb,
   type CohortReader,
@@ -29,6 +30,10 @@ const account = (id: number, createdAt = NOW): NewAccountRow => ({
   id,
   username: `user${id}`,
   createdAt,
+  // Per-account domain by default, so a fixture never accidentally builds a cluster the test did
+  // not ask for — the clustering heuristic counts members sharing a domain, and a shared fixture
+  // domain would silently make every paging test a ring.
+  email: `user${id}@user${id}.test`,
 });
 
 const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
@@ -158,8 +163,12 @@ describe('newAccountPageArgs', () => {
     expect(seed.orderBy).toEqual({ id: 'desc' });
   });
 
-  it('selects only the columns the report cites', () => {
-    expect(args.select).toEqual({ id: true, username: true, createdAt: true });
+  it('selects only the columns the report cites, plus the email the clustering heuristic needs', () => {
+    // 🔴 `email` is here so the registration-cluster heuristic gets a domain WITHOUT a second
+    // query — widening a `select` adds no database operation, which is what keeps the asserted
+    // operation ledger in `no-write-surface.test.ts` at five reads. The address itself does not
+    // survive `selectCohortMembers`; see the `emailDomain` cases below.
+    expect(args.select).toEqual({ id: true, username: true, createdAt: true, email: true });
   });
 });
 
@@ -517,9 +526,12 @@ describe('selectCohortMembers', () => {
   it('carries the account identity and its activity through', () => {
     const created = at('2026-09-03T09:30:00.000Z');
     const members = selectCohortMembers(
-      [{ id: 5, username: 'spam5', createdAt: created }],
+      [{ id: 5, username: 'spam5', createdAt: created, email: 'spam5@Ring.Example' }],
       counts([[5, { comments: 2, models: 1, images: 3 }]])
     );
+    // 🔴 A WHOLE-OBJECT EQUALITY, not a `toMatchObject`. That is what makes the next assertion
+    // meaningful: `toEqual` fails if the member grows a field, so the email address CANNOT
+    // reappear on this object without a failing test.
     expect(members[0]).toEqual({
       userId: 5,
       username: 'spam5',
@@ -529,7 +541,56 @@ describe('selectCohortMembers', () => {
         visible: { comments: 2, models: 1, images: 3, total: 6 },
         excluded: { comments: 0, models: 0, images: 0, total: 0 },
       },
+      // Lowercased, and the local part is gone.
+      emailDomain: 'ring.example',
     });
+  });
+
+  it('🔴 reduces the email to its domain and keeps the address nowhere', () => {
+    // The reduction happens in the pure selector rather than inside the heuristic that consumes it,
+    // so nothing downstream — no score, counter, note or reason string — can hold an address. This
+    // asserts the boundary rather than the heuristic's use of it.
+    const [only] = selectCohortMembers(
+      [
+        {
+          id: 7,
+          username: 'u7',
+          createdAt: at('2026-09-03T09:30:00.000Z'),
+          email: 'someone@a.test',
+        },
+      ],
+      counts([[7, { comments: 1 }]])
+    );
+    expect(only.emailDomain).toBe('a.test');
+    expect(JSON.stringify(only)).not.toContain('someone');
+  });
+});
+
+describe('normalizeEmailDomain', () => {
+  it('lowercases and trims a real domain', () => {
+    expect(normalizeEmailDomain('User@Example.COM')).toBe('example.com');
+    expect(normalizeEmailDomain('u@ example.com ')).toBe('example.com');
+  });
+
+  it('splits on the LAST @, because a local part may legally contain one', () => {
+    // A domain cannot contain `@`; a quoted local part can. Splitting on the first would yield a
+    // cluster key with an `@` in it, and two differently-quoted addresses at the same real domain
+    // would then fail to cluster.
+    expect(normalizeEmailDomain('"odd@name"@real.example')).toBe('real.example');
+  });
+
+  it('🔴 returns null rather than a key for anything that is not a domain', () => {
+    // The return value becomes a CLUSTER KEY, and two accounts are called related when their keys
+    // are equal — so a permissive parse maps several malformed addresses onto one key and
+    // MANUFACTURES a ring out of bad data. Every rejection here is a ring that cannot be invented.
+    expect(normalizeEmailDomain(null)).toBeNull();
+    expect(normalizeEmailDomain('')).toBeNull();
+    expect(normalizeEmailDomain('no-at-sign')).toBeNull();
+    expect(normalizeEmailDomain('trailing@')).toBeNull();
+    // No dot: not a domain a registration can have come from.
+    expect(normalizeEmailDomain('u@localhost')).toBeNull();
+    // Internal whitespace: not a domain at all.
+    expect(normalizeEmailDomain('u@bad domain.com')).toBeNull();
   });
 });
 

--- a/src/server/services/bot-account-detection/__tests__/evidence.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/evidence.test.ts
@@ -1,4 +1,4 @@
-import { NON_PUBLIC_IP_RANGES } from '@civitai/shared/clickhouse-ip-filters';
+import { NON_PUBLIC_IP_RANGES, publicIpOnlySql } from '@civitai/shared/clickhouse-ip-filters';
 import { describe, expect, it, vi } from 'vitest';
 import type { BotAccountCohortMember, SurfaceCounts } from '../cohort';
 import {
@@ -308,6 +308,28 @@ describe('registrationIpSql', () => {
 
     // Optional: a caller with no window still gets a correct, merely unpruned, answer.
     expect(registrationIpSql([1])).not.toContain('time >=');
+  });
+});
+
+describe('publicIpOnlySql', () => {
+  it('🔴 THROWS on a column that is not a bare identifier, rather than interpolating it', () => {
+    // 🔴 THE PRECONDITION WAS A COMMENT ONLY, ON A NEW SHARED EXPORT. The value is concatenated into
+    // a ClickHouse statement and the client does no escaping — the sibling `IP_PATTERN` in
+    // `apps/moderator/src/lib/server/clickhouse-filters.ts` exists for exactly that reason. Both
+    // call sites pass the default today, so this is closed BEFORE the parameter spreads.
+    //
+    // Watching the throw is the point: a guard nobody has seen go red is a claim about the regex.
+    expect(() => publicIpOnlySql("ip' OR 1=1 --")).toThrow(/bare SQL identifier/);
+    expect(() => publicIpOnlySql('ip)')).toThrow(/bare SQL identifier/);
+    expect(() => publicIpOnlySql('remote.ip')).toThrow(/bare SQL identifier/);
+    expect(() => publicIpOnlySql('')).toThrow(/bare SQL identifier/);
+    expect(() => publicIpOnlySql('1ip')).toThrow(/bare SQL identifier/);
+
+    // The negative control on the guard itself: a legitimate column must still get through, or the
+    // regex could be `/^$/` and every case above would pass for the wrong reason.
+    expect(publicIpOnlySql()).toContain(`ip != ''`);
+    expect(publicIpOnlySql('clientIp')).toContain(`clientIp != ''`);
+    expect(publicIpOnlySql('_ip2')).toContain(`_ip2 != ''`);
   });
 });
 

--- a/src/server/services/bot-account-detection/__tests__/evidence.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/evidence.test.ts
@@ -1,10 +1,16 @@
+import { NON_PUBLIC_IP_RANGES } from '@civitai/shared/clickhouse-ip-filters';
 import { describe, expect, it, vi } from 'vitest';
 import type { BotAccountCohortMember, SurfaceCounts } from '../cohort';
 import {
+  MAX_CONTENT_CHARS,
+  MAX_CONTENT_SAMPLES,
+  MAX_IPS_PER_ACCOUNT,
+  EVIDENCE_CHUNK_SIZE,
   MIN_FINGERPRINT_CHARS,
   MIN_FINGERPRINT_TOKENS,
   buildCohortSignals,
   chunk,
+  clickhouseDateTime,
   collectCohortSignals,
   contentFingerprint,
   contentSampleArgs,
@@ -127,6 +133,81 @@ describe('contentFingerprint', () => {
     expect(a).not.toBe(other);
     expect(other).not.toBeNull();
   });
+
+  it('🔴 KNOWN FALSE POSITIVE, PINNED: a generation-parameter paste collides with itself', () => {
+    // 🔴 THIS IS NOT A GUARD, IT IS A RECORD. Pasting settings under a model is one of the most
+    // ordinary comments on this site, and the digit masking that makes a swapped payout match ALSO
+    // makes two unrelated parameter pastes match: every number in them is a `nummask`. Six such
+    // accounts in one day's cohort read as a ring of six and are reported.
+    //
+    // It is asserted so the collision cannot quietly stop being true — a normaliser change that
+    // fixed it should have to delete this case deliberately, and one that made it WORSE (a longer
+    // paste form colliding too) is a diff a reader can see. `similarity.ts` records why the two
+    // candidate fixes were rejected on the arithmetic below.
+    const a = contentFingerprint(
+      'Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 1234567890, Size: 512x768'
+    );
+    const b = contentFingerprint(
+      'Steps: 35, Sampler: Euler a, CFG scale: 4, Seed: 9987654321, Size: 768x1024'
+    );
+    expect(a).toBe(b);
+    expect(a).not.toBeNull();
+
+    // 🔴 THE MEASUREMENT THAT KILLED THE "DISCARD MASK-HEAVY FINGERPRINTS" FIX. Run over the
+    // SHIPPED normaliser, not argued: the two classes do not merely sit close, they INTERLEAVE in
+    // both directions, so no threshold exists in either.
+    const maskRatio = (fp: string) => {
+      const tokens = fp.split(' ').filter(Boolean);
+      return tokens.filter((t) => t === 'nummask' || t === 'linkmask').length / tokens.length;
+    };
+    const fp = (s: string) => contentFingerprint(s) as string;
+    // The commonest real form — the whole metadata block including the prompt — and an ordinary
+    // shill template are EXACTLY equal at 2/7. A cut cannot go between two identical values.
+    const pasteWithPrompt = fp(
+      'masterpiece, best quality, 1girl, detailed eyes, Steps: 20, Sampler: Euler a, ' +
+        'CFG scale: 7, Seed: 1234567890, Size: 512x768'
+    );
+    const shillLink = fp('check out https://mysite.example/a for 500 free buzz');
+    expect(maskRatio(pasteWithPrompt)).toBeCloseTo(6 / 21, 12);
+    expect(maskRatio(shillLink)).toBeCloseTo(2 / 7, 12);
+    expect(maskRatio(pasteWithPrompt)).toBeCloseTo(maskRatio(shillLink), 12);
+
+    // And the ordering INVERTS at the other end: the shortest shill template is mask-heavier than
+    // the longest parameter paste, so a cut high enough to spare shill text discards nothing and a
+    // cut low enough to catch pastes discards shill text first.
+    const shillMinimal = fp('free buzz https://x.example 999');
+    const pasteLong = fp(
+      'Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 1234567890, Size: 512x768, ' +
+        'Model hash: a1b2c3d4, Model: dreamShaper_8, Denoising strength: 0.45, Clip skip: 2'
+    );
+    expect(maskRatio(shillMinimal)).toBeGreaterThan(maskRatio(pasteLong));
+    // A positive control on the measure itself: a zero everywhere would make every comparison above
+    // vacuously agree.
+    expect(maskRatio(fp('This checkpoint handles hands surprisingly well overall'))).toBe(0);
+    expect(maskRatio(a as string)).toBeGreaterThan(0);
+  });
+});
+
+describe('the module constants', () => {
+  it('🔴 pins every bound a run is sized by, so moving one is a deliberate edit', () => {
+    // 🔴 FOUR OF THESE WERE UNTESTED. A constant nothing asserts can be changed by a mutant — or by
+    // a maintainer — with the entire suite green, and each of these decides how much of a wave a
+    // run actually sees: the budget is the ceiling on content read at all, the chunk size is the
+    // width of every `IN (…)` list, and the truncation is what bounds both the memory a run holds
+    // and what counts as "the same text".
+    expect(MAX_CONTENT_SAMPLES).toBe(5_000);
+    expect(EVIDENCE_CHUNK_SIZE).toBe(500);
+    expect(MAX_CONTENT_CHARS).toBe(512);
+    expect(MIN_FINGERPRINT_CHARS).toBe(24);
+    expect(MIN_FINGERPRINT_TOKENS).toBe(4);
+    expect(MAX_IPS_PER_ACCOUNT).toBe(4);
+  });
+
+  it('renders a ClickHouse DateTime literal, not an ISO string', () => {
+    // The `Z`-suffixed ISO form is not accepted by ClickHouse, and a rejected statement is a whole
+    // heuristic dark for a day with nothing but a caught error to say so.
+    expect(clickhouseDateTime(new Date('2026-09-03T03:20:00.000Z'))).toBe('2026-09-03 03:20:00');
+  });
 });
 
 // ---------------------------------------------------------------------------------------------
@@ -166,8 +247,67 @@ describe('registrationIpSql', () => {
     expect(registrationIpSql([Number.NaN] as number[])).toBe('');
   });
 
-  it('bounds the result so one account cannot flood a chunk', () => {
-    expect(registrationIpSql([1, 2])).toMatch(/LIMIT 8\b/);
+  it('🔴 pins the SELECT PROJECTION, not only the WHERE clause', () => {
+    // 🔴 THE MUTANT THIS EXISTS FOR: `SELECT targetUserId, ip` → `SELECT userId, ip`, leaving the
+    // WHERE alone. Every other case in this describe passed. Rows then come back keyed `userId`,
+    // `Number(row.targetUserId)` is `Number(undefined)` = `NaN`, the `Number.isFinite` filter drops
+    // every row, and `sources.registrationIps` stays TRUE — a zero that says the source answered.
+    // The projection is what decides the KEY the reader destructures, so it is behaviour, not
+    // formatting.
+    const sql = registrationIpSql([7, 8]);
+    expect(sql).toContain('SELECT targetUserId, ip');
+    // The `GROUP BY` names it too, and the two must not drift apart: grouping on one column while
+    // projecting another is the same silent zero arrived at from the other side.
+    expect(sql).toContain('GROUP BY targetUserId, ip');
+  });
+
+  it('🔴 excludes private and carrier-internal space — the shared predicate, not a copy', () => {
+    // 🔴 WITHOUT THIS THE HEURISTIC IS WORSE THAN ABSENT. Private space correlates everyone and
+    // therefore no one: six cohort members behind one `10.124/16` address or one proxy reach a
+    // reported score, and ten of them top the run's whole distribution from an infrastructure
+    // address — a confident finding produced by omission.
+    const sql = registrationIpSql([1]);
+    for (const range of NON_PUBLIC_IP_RANGES)
+      expect(sql).toContain(`NOT isIPAddressInRange(ip, '${range}')`);
+    // A positive control on the list itself: an empty `NON_PUBLIC_IP_RANGES` would make the loop
+    // above vacuous, and it is imported from another package.
+    expect(NON_PUBLIC_IP_RANGES.length).toBeGreaterThanOrEqual(6);
+    expect(NON_PUBLIC_IP_RANGES).toContain('10.0.0.0/8');
+
+    // 🔴 `isIPAddressInRange` RAISES on an empty string and `userActivities` holds a handful, so
+    // whether this query throws depends on whether a blank row lands in the scanned range — it
+    // passes in testing and breaks later, once. The guard has to come FIRST.
+    expect(sql).toContain(`ip != ''`);
+    expect(sql.indexOf(`ip != ''`)).toBeLessThan(sql.indexOf('isIPAddressInRange'));
+  });
+
+  it('bounds the addresses PER ACCOUNT, not per result', () => {
+    // 🔴 `LIMIT ids.length * 4` was a cap on the RESULT with no `ORDER BY` under it: one account
+    // with many distinct registration addresses could consume the whole allowance and evict every
+    // other account in its chunk, silently, understating every ring that straddled it. The comment
+    // claimed a per-account cap; only `LIMIT n BY` delivers one.
+    const sql = registrationIpSql([1, 2]);
+    expect(sql).toContain(`LIMIT ${MAX_IPS_PER_ACCOUNT} BY targetUserId`);
+    // `ORDER BY` is what makes which addresses survive the per-account cap deterministic rather
+    // than whatever the merge happened to emit first.
+    expect(sql).toContain('ORDER BY targetUserId, ip');
+    // The total is still bounded — the property the old `LIMIT` was there for is not lost.
+    expect(MAX_IPS_PER_ACCOUNT).toBe(4);
+  });
+
+  it('bounds the scan on `time` when it is given a window, and omits it when it is not', () => {
+    // `time` is this table's pruning column. Every cohort account was created after the window
+    // opened, so its registration event cannot predate it: the predicate removes no row the query
+    // wants and is the difference between fifty unpruned chunk scans and fifty pruned ones.
+    const windowed = registrationIpSql([1], new Date('2026-09-03T03:20:00.000Z'));
+    // ClickHouse's `DateTime` literal form. The `Z`-suffixed ISO string is NOT accepted, and a
+    // rejected statement here is a whole heuristic dark for a day.
+    expect(windowed).toContain(`AND time >= '2026-09-03 03:20:00'`);
+    expect(windowed).not.toContain('T03:20:00');
+    expect(windowed).not.toContain(`03:20:00.000Z'`);
+
+    // Optional: a caller with no window still gets a correct, merely unpruned, answer.
+    expect(registrationIpSql([1])).not.toContain('time >=');
   });
 });
 
@@ -191,6 +331,7 @@ describe('contentSampleArgs', () => {
 describe('buildCohortSignals', () => {
   const sources = {
     registrationIps: true,
+    contentSamples: true,
     contentBudgetExhausted: false,
     membersSampledForContent: 3,
   };
@@ -289,12 +430,14 @@ describe('buildCohortSignals', () => {
       contentSamples: [],
       sources: {
         registrationIps: false,
+        contentSamples: true,
         contentBudgetExhausted: true,
         membersSampledForContent: 7,
       },
     });
     expect(s.sources).toEqual({
       registrationIps: false,
+      contentSamples: true,
       contentBudgetExhausted: true,
       membersSampledForContent: 7,
     });
@@ -303,9 +446,12 @@ describe('buildCohortSignals', () => {
 
 describe('emptyCohortSignals', () => {
   it('🔴 defaults every source to "did not run", which is the safe reading', () => {
-    // A run with no evidence reader must not look like a run that found no rings.
+    // A run with no evidence reader must not look like a run that found no rings. Both source
+    // flags default to false for that reason — including `contentSamples`, whose false means "no
+    // content was read", never "the cohort posted nothing that matched".
     expect(emptyCohortSignals().sources).toEqual({
       registrationIps: false,
+      contentSamples: false,
       contentBudgetExhausted: false,
       membersSampledForContent: 0,
     });
@@ -332,20 +478,29 @@ function fakeReader(opts: {
   content?: ContentSampleRow[];
   hasIps?: boolean;
   ipError?: Error;
-}): EvidenceReader & { ipCalls: number[][]; contentCalls: Array<{ ids: number[]; take: number }> } {
+  contentError?: Error;
+}): EvidenceReader & {
+  ipCalls: number[][];
+  ipWindows: Array<Date | undefined>;
+  contentCalls: Array<{ ids: number[]; take: number }>;
+} {
   const ipCalls: number[][] = [];
+  const ipWindows: Array<Date | undefined> = [];
   const contentCalls: Array<{ ids: number[]; take: number }> = [];
   return {
     ipCalls,
+    ipWindows,
     contentCalls,
     hasRegistrationIps: opts.hasIps ?? true,
-    listRegistrationIps: async (ids) => {
+    listRegistrationIps: async (ids, createdAfter) => {
       ipCalls.push(ids);
+      ipWindows.push(createdAfter);
       if (opts.ipError) throw opts.ipError;
       return (opts.ips ?? []).filter((r) => ids.includes(r.userId));
     },
     listContentSamples: async (ids, take) => {
       contentCalls.push({ ids, take });
+      if (opts.contentError) throw opts.contentError;
       return (opts.content ?? []).filter((r) => ids.includes(r.userId)).slice(0, take);
     },
   };
@@ -414,6 +569,69 @@ describe('collectCohortSignals', () => {
     const s = await collectCohortSignals(reader, members, { chunkSize: 2 });
     expect(s.sources.registrationIps).toBe(false);
     expect(s.membersPerFingerprint.get(contentFingerprint(text) as string)).toBe(3);
+  });
+
+  it('🔴 a failing CONTENT read degrades the run instead of killing it', async () => {
+    // 🔴 THE FAILURE THIS EXISTS TO PREVENT. `listContentSamples` had no guard at all, so a timeout
+    // on a busy replica propagated out of `runBotAccountDetection` and NO REPORT WAS FILED — losing
+    // the velocity heuristic's day with it, and looking exactly like a producer that stopped
+    // running. The IP loop already had this shape; this is the same contract on the other read.
+    const reader = fakeReader({ contentError: new Error('replica timeout') });
+    const log = vi.fn();
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2, log });
+
+    // It does not throw, the rest of the index is intact, and the flag says which half is missing.
+    expect(s.sources.contentSamples).toBe(false);
+    expect(s.membersPerFingerprint.size).toBe(0);
+    // The domain half of the clustering heuristic costs no read and is unaffected.
+    expect(s.membersPerDomain.get('ring.test')).toBe(5);
+    // It stops rather than hammering a dead source once per chunk.
+    expect(reader.contentCalls).toHaveLength(1);
+    expect(log.mock.calls.map(([name]) => name)).toContain(
+      'bot-account-detection:content-samples-failed'
+    );
+    // 🔴 A FAILED READ IS NOT AN EXHAUSTED BUDGET. Reporting it as one would send a grading pass
+    // looking for a cohort too large rather than for a broken replica, and `membersSampled` must
+    // not claim members whose samples were discarded.
+    expect(s.sources.contentBudgetExhausted).toBe(false);
+    expect(s.sources.membersSampledForContent).toBe(0);
+  });
+
+  it('discards the PARTIAL content already read when a later chunk fails', async () => {
+    // Same argument as the IP loop's: a fingerprint count built from some of the chunks understates
+    // every ring that straddles the missing ones, and understating produces the confident zero.
+    const text = 'Grab your 100 free credits at https://spam.example now';
+    let calls = 0;
+    const reader: EvidenceReader = {
+      hasRegistrationIps: false,
+      listRegistrationIps: async () => [],
+      listContentSamples: async (ids) => {
+        calls += 1;
+        if (calls > 1) throw new Error('replica timeout');
+        return ids.map((userId) => ({ userId, content: text }));
+      },
+    };
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2 });
+    expect(calls).toBe(2);
+    expect(s.sources.contentSamples).toBe(false);
+    // The two rows the FIRST chunk returned are gone, not scored as a two-account cluster.
+    expect(s.membersPerFingerprint.size).toBe(0);
+    expect(s.fingerprintsByUser.size).toBe(0);
+  });
+
+  it('reports the content source as present on an ordinary run', async () => {
+    // Emitted true, not merely absent-when-false: the flag has to distinguish "read fine, nobody
+    // matched" from "read did not happen", and only asserting the false side leaves the true side
+    // free to be wrong.
+    const s = await collectCohortSignals(fakeReader({ content: [] }), members, { chunkSize: 2 });
+    expect(s.sources.contentSamples).toBe(true);
+  });
+
+  it('hands the run window down to the registration-IP read', async () => {
+    const reader = fakeReader({});
+    const createdAfter = new Date('2026-09-02T03:20:00.000Z');
+    await collectCohortSignals(reader, members, { chunkSize: 5, createdAfter });
+    expect(reader.ipWindows).toEqual([createdAfter]);
   });
 
   it('🔴 stops reading content once the BUDGET is spent, and records that it did', async () => {

--- a/src/server/services/bot-account-detection/__tests__/evidence.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/evidence.test.ts
@@ -1,0 +1,519 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BotAccountCohortMember, SurfaceCounts } from '../cohort';
+import {
+  MIN_FINGERPRINT_CHARS,
+  MIN_FINGERPRINT_TOKENS,
+  buildCohortSignals,
+  chunk,
+  collectCohortSignals,
+  contentFingerprint,
+  contentSampleArgs,
+  createEvidenceReader,
+  emptyCohortSignals,
+  normalizeContent,
+  registrationIpSql,
+  type ContentSampleRow,
+  type EvidenceClickhouse,
+  type EvidenceReader,
+  type RegistrationIpRow,
+} from '../evidence';
+
+const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
+  const row = { comments: 0, models: 0, images: 0, ...partial };
+  return { ...row, total: row.comments + row.models + row.images };
+};
+
+const member = (userId: number, emailDomain: string | null = null): BotAccountCohortMember => ({
+  userId,
+  username: `u${userId}`,
+  createdAt: new Date('2026-09-03T09:00:00.000Z'),
+  posts: { all: surface({ comments: 1 }), visible: surface({ comments: 1 }), excluded: surface() },
+  emailDomain,
+});
+
+// ---------------------------------------------------------------------------------------------
+// Text normalisation and fingerprinting
+// ---------------------------------------------------------------------------------------------
+
+describe('normalizeContent', () => {
+  it('🔴 masks links, which is what turns copy-paste detection into TEMPLATE detection', () => {
+    // The link is exactly the part a ring varies. Without this the two below are different strings
+    // and the heuristic finds nothing.
+    expect(normalizeContent('Check out https://a.example/x')).toBe('check out linkmask');
+    expect(normalizeContent('Check out https://b.example/y')).toBe('check out linkmask');
+    expect(normalizeContent('visit www.spam.example/ref')).toBe('visit linkmask');
+  });
+
+  it('🔴 masks digit runs, so a swapped payout or referral code still matches', () => {
+    expect(normalizeContent('I earned 50 credits')).toBe('i earned nummask credits');
+    expect(normalizeContent('I earned 9000 credits')).toBe('i earned nummask credits');
+  });
+
+  it('drops punctuation, emoji and decoration, so a template survives being dressed up', () => {
+    // Spam text is routinely padded to defeat exact matching.
+    expect(normalizeContent('B.U.Y!!! now 🎉🎉')).toBe('b u y now');
+    expect(normalizeContent('buy   \n\t now')).toBe('buy now');
+  });
+
+  it('lowercases, so case-flipping does not split a ring', () => {
+    expect(normalizeContent('BUY NOW')).toBe(normalizeContent('buy now'));
+  });
+
+  it('truncates before normalising, and says so by colliding long texts', () => {
+    // Documented consequence, asserted rather than left as a claim: two texts differing only past
+    // the character cap fingerprint identically.
+    const head = 'z'.repeat(600);
+    expect(normalizeContent(`${head}AAA`)).toBe(normalizeContent(`${head}BBB`));
+  });
+
+  it('the placeholders survive the punctuation strip — they are bare words for that reason', () => {
+    // A bracketed marker like `<url>` would be destroyed by the step that removes punctuation,
+    // silently merging every link into nothing at all.
+    expect(normalizeContent('see https://a.example')).toContain('linkmask');
+    expect(normalizeContent('see 42')).toContain('nummask');
+  });
+});
+
+describe('contentFingerprint', () => {
+  it('🔴 refuses a short text rather than returning a key that clusters rarely', () => {
+    // "thanks", "nice work", "great model" are written independently by unrelated people every
+    // hour. A key that merely matches rarely still CLUSTERS whenever it matches, and the whole
+    // requirement is that these must never cluster at all — so the encoding is `null`, not a key.
+    expect(contentFingerprint('thanks')).toBeNull();
+    expect(contentFingerprint('nice work!')).toBeNull();
+    expect(contentFingerprint('')).toBeNull();
+  });
+
+  it('🔴 pins the two floors, so moving either is a deliberate edit', () => {
+    // Separated from the behavioural cases: a case written in terms of the constant it tests is
+    // vacuous about that constant's VALUE. Measured — lowering `MIN_FINGERPRINT_CHARS` from 24 to 3
+    // was killed only by the token floor, never by a case about the character floor itself.
+    expect(MIN_FINGERPRINT_CHARS).toBe(24);
+    expect(MIN_FINGERPRINT_TOKENS).toBe(4);
+  });
+
+  it('🔴 enforces the two floors INDEPENDENTLY, each isolated from the other', () => {
+    // Either alone is walkable: one long word clears the character floor, four one-letter words
+    // clear the token floor. So each case must clear the OTHER floor outright — otherwise the
+    // surviving floor kills the mutant and the floor under test is never exercised.
+    //
+    // Clears the CHARACTER floor (30 chars), fails the TOKEN floor (1 token):
+    const oneLongWord = 'a'.repeat(30);
+    expect(oneLongWord.length).toBeGreaterThan(MIN_FINGERPRINT_CHARS);
+    expect(contentFingerprint(oneLongWord)).toBeNull();
+
+    // Clears the TOKEN floor (5 tokens), fails the CHARACTER floor (9 chars). This is the case that
+    // isolates the character floor — without it, lowering that constant changes nothing observable.
+    const shortButManyWords = 'a b c d e';
+    expect(shortButManyWords.split(' ').length).toBeGreaterThanOrEqual(MIN_FINGERPRINT_TOKENS);
+    expect(shortButManyWords.length).toBeLessThan(MIN_FINGERPRINT_CHARS);
+    expect(contentFingerprint(shortButManyWords)).toBeNull();
+
+    // And a text clearing BOTH is accepted — the positive control that stops the two cases above
+    // from passing because the function simply always returns null.
+    expect(contentFingerprint('grab your free credits from this page now')).not.toBeNull();
+  });
+
+  it('returns the normalised text for something substantial', () => {
+    const fp = contentFingerprint('Check out my page at https://spam.example for 500 free credits');
+    expect(fp).toBe('check out my page at linkmask for nummask free credits');
+  });
+
+  it('two templated variants share one fingerprint; unrelated text does not', () => {
+    const a = contentFingerprint('Grab your 100 free credits here: https://a.example/ref1');
+    const b = contentFingerprint('Grab your 250 free credits here: https://b.example/ref9');
+    const other = contentFingerprint('This checkpoint handles hands surprisingly well overall');
+    expect(a).toBe(b);
+    expect(a).not.toBe(other);
+    expect(other).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Query shapes
+// ---------------------------------------------------------------------------------------------
+
+describe('registrationIpSql', () => {
+  it('🔴 filters on targetUserId, not userId', () => {
+    // `Tracker.userActivity` writes the account an event is ABOUT into `targetUserId`; a
+    // Registration has no signed-in actor, so `userId` is not the new account. `bulk-ban.service.ts`
+    // reads `targetUserId` for this reason. Using `userId` here returns nothing, silently.
+    const sql = registrationIpSql([7, 8]);
+    expect(sql).toContain('targetUserId IN (7,8)');
+    expect(sql).not.toMatch(/\buserId IN\b/);
+  });
+
+  it('reads registrations only, never logins', () => {
+    // A shared LOGIN ip is weak evidence — carriers and offices put thousands of unrelated people
+    // behind one address. Widening this to logins would flood the board.
+    expect(registrationIpSql([1])).toContain("type = 'Registration'");
+    expect(registrationIpSql([1])).not.toContain('Login');
+  });
+
+  it('is a bare SELECT and nothing else', () => {
+    expect(registrationIpSql([1]).trim()).toMatch(/^SELECT\b/);
+  });
+
+  it('🔴 drops anything that is not a positive integer before interpolating', () => {
+    // This is string-interpolated SQL: the client takes no bound parameters, so this filter is the
+    // only thing between a value and the statement.
+    const sql = registrationIpSql([5, Number.NaN, -3, 1.5, 0, 9] as number[]);
+    expect(sql).toContain('IN (5,9)');
+  });
+
+  it('returns an empty string for an empty list, so no statement is issued', () => {
+    expect(registrationIpSql([])).toBe('');
+    expect(registrationIpSql([Number.NaN] as number[])).toBe('');
+  });
+
+  it('bounds the result so one account cannot flood a chunk', () => {
+    expect(registrationIpSql([1, 2])).toMatch(/LIMIT 8\b/);
+  });
+});
+
+describe('contentSampleArgs', () => {
+  it('reads the newest comments of exactly these accounts, bounded, two columns', () => {
+    // 🔴 `orderBy: id desc` is load-bearing: `take` bounds the read, so the ORDER decides which
+    // comments a bounded read keeps — and a wave is made of the newest ones.
+    expect(contentSampleArgs([3, 4], 25)).toEqual({
+      where: { userId: { in: [3, 4] } },
+      select: { userId: true, content: true },
+      orderBy: { id: 'desc' },
+      take: 25,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Index building
+// ---------------------------------------------------------------------------------------------
+
+describe('buildCohortSignals', () => {
+  const sources = {
+    registrationIps: true,
+    contentBudgetExhausted: false,
+    membersSampledForContent: 3,
+  };
+
+  it('🔴 counts DISTINCT accounts per IP, not rows', () => {
+    // One account with several registration rows on one address must contribute ONE member. Rows
+    // would let a single account manufacture a ring out of itself.
+    const s = buildCohortSignals({
+      members: [member(1), member(2)],
+      registrationIps: [
+        { userId: 1, ip: 'x' },
+        { userId: 1, ip: 'x' },
+        { userId: 1, ip: 'x' },
+        { userId: 2, ip: 'x' },
+      ],
+      contentSamples: [],
+      sources,
+    });
+    expect(s.membersPerIp.get('x')).toBe(2);
+    // And the account's own IP list is deduplicated too.
+    expect(s.ipsByUser.get(1)).toEqual(['x']);
+  });
+
+  it('🔴 counts DISTINCT accounts per fingerprint, not repetitions', () => {
+    // The same defect in the text axis: one account pasting its shill line ninety times is ONE
+    // member of that group, not ninety. Otherwise a lone spammer scores as a ten-account ring.
+    const text = 'Grab your 100 free credits at https://spam.example now';
+    const s = buildCohortSignals({
+      members: [member(1), member(2)],
+      registrationIps: [],
+      contentSamples: Array.from({ length: 9 }, () => ({ userId: 1, content: text })).concat([
+        { userId: 2, content: text },
+      ]),
+      sources,
+    });
+    const fp = contentFingerprint(text) as string;
+    expect(s.membersPerFingerprint.get(fp)).toBe(2);
+    expect(s.fingerprintsByUser.get(1)).toEqual([fp]);
+  });
+
+  it('🔴 ignores rows for accounts outside the cohort', () => {
+    // A registration row for a banned account ClickHouse still remembers would otherwise inflate an
+    // IP's tally with something that is never scored — a ring counted larger than the population it
+    // is drawn from.
+    const s = buildCohortSignals({
+      members: [member(1)],
+      registrationIps: [
+        { userId: 1, ip: 'x' },
+        { userId: 99, ip: 'x' },
+      ],
+      contentSamples: [{ userId: 99, content: 'Grab your 100 free credits at https://s.example' }],
+      sources,
+    });
+    expect(s.membersPerIp.get('x')).toBe(1);
+    expect(s.membersPerFingerprint.size).toBe(0);
+  });
+
+  it('tallies email domains from the members, with no query at all', () => {
+    // One of the clustering heuristic's two signals is free — it rode in on the cohort read.
+    const s = buildCohortSignals({
+      members: [
+        member(1, 'ring.test'),
+        member(2, 'ring.test'),
+        member(3, 'other.test'),
+        member(4, null),
+      ],
+      registrationIps: [],
+      contentSamples: [],
+      sources,
+    });
+    expect(s.membersPerDomain.get('ring.test')).toBe(2);
+    expect(s.membersPerDomain.get('other.test')).toBe(1);
+    // A null domain is not a cluster key — see `normalizeEmailDomain`.
+    expect(s.membersPerDomain.size).toBe(2);
+  });
+
+  it('drops content too slight to be a key', () => {
+    const s = buildCohortSignals({
+      members: [member(1), member(2), member(3)],
+      registrationIps: [],
+      contentSamples: [
+        { userId: 1, content: 'thanks' },
+        { userId: 2, content: 'thanks' },
+        { userId: 3, content: 'thanks' },
+      ],
+      sources,
+    });
+    // Three accounts, one identical text — and deliberately NOT a ring.
+    expect(s.membersPerFingerprint.size).toBe(0);
+  });
+
+  it('carries the source flags through unchanged', () => {
+    const s = buildCohortSignals({
+      members: [],
+      registrationIps: [],
+      contentSamples: [],
+      sources: {
+        registrationIps: false,
+        contentBudgetExhausted: true,
+        membersSampledForContent: 7,
+      },
+    });
+    expect(s.sources).toEqual({
+      registrationIps: false,
+      contentBudgetExhausted: true,
+      membersSampledForContent: 7,
+    });
+  });
+});
+
+describe('emptyCohortSignals', () => {
+  it('🔴 defaults every source to "did not run", which is the safe reading', () => {
+    // A run with no evidence reader must not look like a run that found no rings.
+    expect(emptyCohortSignals().sources).toEqual({
+      registrationIps: false,
+      contentBudgetExhausted: false,
+      membersSampledForContent: 0,
+    });
+  });
+});
+
+describe('chunk', () => {
+  it('slices in order and keeps a short tail', () => {
+    expect(chunk([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([[1, 2, 3], [4, 5, 6], [7]]);
+    expect(chunk([], 3)).toEqual([]);
+  });
+  it('refuses a nonsense size rather than looping forever', () => {
+    expect(() => chunk([1], 0)).toThrow(/chunk size/);
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Collection: budgets and degradation
+// ---------------------------------------------------------------------------------------------
+
+/** A reader that records what it was asked for and answers from fixtures. */
+function fakeReader(opts: {
+  ips?: RegistrationIpRow[];
+  content?: ContentSampleRow[];
+  hasIps?: boolean;
+  ipError?: Error;
+}): EvidenceReader & { ipCalls: number[][]; contentCalls: Array<{ ids: number[]; take: number }> } {
+  const ipCalls: number[][] = [];
+  const contentCalls: Array<{ ids: number[]; take: number }> = [];
+  return {
+    ipCalls,
+    contentCalls,
+    hasRegistrationIps: opts.hasIps ?? true,
+    listRegistrationIps: async (ids) => {
+      ipCalls.push(ids);
+      if (opts.ipError) throw opts.ipError;
+      return (opts.ips ?? []).filter((r) => ids.includes(r.userId));
+    },
+    listContentSamples: async (ids, take) => {
+      contentCalls.push({ ids, take });
+      return (opts.content ?? []).filter((r) => ids.includes(r.userId)).slice(0, take);
+    },
+  };
+}
+
+describe('collectCohortSignals', () => {
+  const members = Array.from({ length: 5 }, (_, i) => member(i + 1, 'ring.test'));
+
+  it('does nothing at all for an empty cohort', async () => {
+    const reader = fakeReader({});
+    const s = await collectCohortSignals(reader, []);
+    expect(reader.ipCalls).toEqual([]);
+    expect(reader.contentCalls).toEqual([]);
+    expect(s).toEqual(emptyCohortSignals());
+  });
+
+  it('chunks the cohort and indexes what comes back', async () => {
+    const reader = fakeReader({
+      ips: [
+        { userId: 1, ip: 'x' },
+        { userId: 4, ip: 'x' },
+      ],
+    });
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2 });
+    expect(reader.ipCalls).toEqual([[1, 2], [3, 4], [5]]);
+    expect(s.membersPerIp.get('x')).toBe(2);
+    expect(s.sources.registrationIps).toBe(true);
+  });
+
+  it('🔴 does not call ClickHouse at all when the client is absent, and SAYS so', () => {
+    // A zero from a missing source is indistinguishable from a zero meaning "these accounts share
+    // nothing", and the two call for opposite conclusions.
+    return collectCohortSignals(fakeReader({ hasIps: false }), members).then((s) => {
+      expect(s.sources.registrationIps).toBe(false);
+      expect(s.membersPerIp.size).toBe(0);
+    });
+  });
+
+  it('🔴 discards PARTIAL IP data when a chunk fails, rather than scoring it', async () => {
+    // A cluster count built from a partial read UNDERSTATES every ring that straddles the missing
+    // chunk — and understating is the direction that produces a confident zero. So the whole
+    // signal is dropped and the flag records it.
+    const reader = fakeReader({ ipError: new Error('clickhouse down') });
+    const log = vi.fn();
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2, log });
+    expect(s.sources.registrationIps).toBe(false);
+    expect(s.membersPerIp.size).toBe(0);
+    // It stops rather than hammering a dead source once per chunk.
+    expect(reader.ipCalls).toHaveLength(1);
+    expect(log.mock.calls.map(([name]) => name)).toContain(
+      'bot-account-detection:registration-ips-failed'
+    );
+  });
+
+  it('a failing IP read does not stop the content read', async () => {
+    // The heuristics are independent; one dead source must not cost the others.
+    const text = 'Grab your 100 free credits at https://spam.example now';
+    const reader = fakeReader({
+      ipError: new Error('down'),
+      content: [
+        { userId: 1, content: text },
+        { userId: 2, content: text },
+        { userId: 3, content: text },
+      ],
+    });
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2 });
+    expect(s.sources.registrationIps).toBe(false);
+    expect(s.membersPerFingerprint.get(contentFingerprint(text) as string)).toBe(3);
+  });
+
+  it('🔴 stops reading content once the BUDGET is spent, and records that it did', async () => {
+    // A per-query cap multiplied by a page count is not a bound on anything: the cohort can be tens
+    // of thousands of accounts. The budget is what makes the worst case fixed.
+    const content = members.flatMap((m) =>
+      Array.from({ length: 4 }, () => ({
+        userId: m.userId,
+        content: `Grab your 100 free credits at https://spam.example now ${m.userId}`,
+      }))
+    );
+    const reader = fakeReader({ content });
+    const s = await collectCohortSignals(reader, members, { chunkSize: 2, maxContentSamples: 3 });
+    // The first chunk consumes the budget; the walk stops rather than reading the remaining two.
+    expect(reader.contentCalls).toHaveLength(1);
+    expect(s.sources.contentBudgetExhausted).toBe(true);
+    expect(s.sources.membersSampledForContent).toBe(2);
+  });
+
+  it('does not claim exhaustion when the whole cohort fit inside the budget', async () => {
+    // The flag must mean "accounts were left unsampled", not "the budget happened to reach zero" —
+    // the same distinction `cohort.capped` draws for the account walk.
+    const reader = fakeReader({ content: [{ userId: 1, content: 'x' }] });
+    const s = await collectCohortSignals(reader, members, { chunkSize: 5, maxContentSamples: 50 });
+    expect(s.sources.contentBudgetExhausted).toBe(false);
+    expect(s.sources.membersSampledForContent).toBe(5);
+  });
+
+  it('never asks for more rows than the budget has left', async () => {
+    const reader = fakeReader({ content: [] });
+    await collectCohortSignals(reader, members, { chunkSize: 2, maxContentSamples: 3 });
+    for (const call of reader.contentCalls) expect(call.take).toBeLessThanOrEqual(3);
+  });
+
+  it('checks cancellation while it walks', async () => {
+    // The scheduler cancels by closing the response; a walk that never looks keeps reading after
+    // nobody is listening.
+    const reader = fakeReader({});
+    let checks = 0;
+    await expect(
+      collectCohortSignals(reader, members, {
+        chunkSize: 2,
+        checkCanceled: () => {
+          checks += 1;
+          if (checks > 1) throw new Error('Job was canceled');
+        },
+      })
+    ).rejects.toThrow('Job was canceled');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// The real reader's wiring
+// ---------------------------------------------------------------------------------------------
+
+describe('createEvidenceReader', () => {
+  const db = {
+    comment: { findMany: vi.fn(async () => [{ userId: 1, content: 'a' }]) },
+    commentV2: { findMany: vi.fn(async () => [{ userId: 2, content: 'b' }]) },
+  };
+
+  it('🔴 reports the IP source as unavailable when there is no ClickHouse client', async () => {
+    const reader = createEvidenceReader({ db, ch: null });
+    expect(reader.hasRegistrationIps).toBe(false);
+    // And asking anyway returns nothing rather than throwing — the caller's flag is the record.
+    expect(await reader.listRegistrationIps([1, 2])).toEqual([]);
+  });
+
+  it('reads both comment surfaces and merges them', async () => {
+    // An account that only used the newer comment system would otherwise read as having posted no
+    // text at all — a false negative in the one direction a detector must not have.
+    const reader = createEvidenceReader({ db, ch: null });
+    expect(await reader.listContentSamples([1, 2], 10)).toEqual([
+      { userId: 1, content: 'a' },
+      { userId: 2, content: 'b' },
+    ]);
+  });
+
+  it('issues no statement for an empty id list or a zero take', async () => {
+    const reader = createEvidenceReader({ db, ch: null });
+    db.comment.findMany.mockClear();
+    expect(await reader.listContentSamples([], 10)).toEqual([]);
+    expect(await reader.listContentSamples([1], 0)).toEqual([]);
+    expect(db.comment.findMany).not.toHaveBeenCalled();
+  });
+
+  it('coerces ClickHouse’s string integers and drops rows with no ip', async () => {
+    // ClickHouse returns integers as strings over HTTP JSON; a `userId` left as a string would
+    // never match a cohort member and the whole IP signal would silently be empty.
+    // The port's `$query` is generic (`<T extends object>`) to mirror the real client's signature —
+    // a fake with a concrete return type is NOT assignable to it, so the cast is on the FUNCTION
+    // rather than on the object. Casting the object would hide a genuine shape mismatch; this way
+    // only the unused type parameter is bypassed.
+    const ch: EvidenceClickhouse = {
+      $query: (async () => [
+        { targetUserId: '7', ip: '203.0.113.9' },
+        { targetUserId: '8', ip: '' },
+      ]) as EvidenceClickhouse['$query'],
+    };
+    const reader = createEvidenceReader({ db, ch });
+    expect(await reader.listRegistrationIps([7, 8])).toEqual([{ userId: 7, ip: '203.0.113.9' }]);
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, it } from 'vitest';
+import type { BotAccountCohortMember, SurfaceCounts } from '../cohort';
+import { emptyCohortSignals, type CohortSignals } from '../evidence';
+import { BOT_ACCOUNT_HEURISTICS } from '../heuristics';
+import {
+  COMMON_EMAIL_DOMAINS,
+  DOMAIN_ONE_AT,
+  DOMAIN_ZERO_AT,
+  IP_ONE_AT,
+  IP_ZERO_AT,
+  domainClusterSize,
+  isCommonEmailDomain,
+  largestIpCluster,
+  registrationClusterHeuristic,
+} from '../heuristics/clustering';
+import { rampScore } from '../heuristics/ramp';
+import {
+  CLUSTER_ONE_AT,
+  CLUSTER_ZERO_AT,
+  contentTemplatingHeuristic,
+  largestContentCluster,
+} from '../heuristics/similarity';
+import {
+  MIN_AGE_HOURS,
+  MIN_ITEMS,
+  ONE_AT_PER_HOUR,
+  ZERO_AT_PER_HOUR,
+  effectiveAgeHours,
+  itemsPerHour,
+  postingVelocityHeuristic,
+} from '../heuristics/velocity';
+import { scoreAccount, type BotAccountEvidence } from '../scoring';
+
+const at = (iso: string) => new Date(iso);
+const NOW = at('2026-09-03T12:00:00.000Z');
+
+const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
+  const row = { comments: 0, models: 0, images: 0, ...partial };
+  return { ...row, total: row.comments + row.models + row.images };
+};
+
+/**
+ * `visible` defaults to everything posted. Where a case needs them to DIFFER it says so — the
+ * velocity heuristic reading the wrong one is a specific regression with its own case below.
+ */
+const member = (
+  overrides: Partial<BotAccountCohortMember> & { all?: Partial<SurfaceCounts> } = {}
+): BotAccountCohortMember => {
+  const { all, ...rest } = overrides;
+  const allCounts = surface(all ?? { images: 3 });
+  return {
+    userId: 42,
+    username: 'candidate',
+    createdAt: at('2026-09-03T09:00:00.000Z'),
+    posts: { all: allCounts, visible: allCounts, excluded: surface() },
+    emailDomain: 'unusual.test',
+    ...rest,
+  };
+};
+
+const evidence = (
+  m: BotAccountCohortMember,
+  signals: CohortSignals = emptyCohortSignals(),
+  now = NOW
+): BotAccountEvidence => ({ member: m, now, signals });
+
+/** A signals index built from plain declarations, so a case reads as the world it describes. */
+function signalsWith(spec: {
+  ips?: Record<number, string[]>;
+  membersPerIp?: Record<string, number>;
+  membersPerDomain?: Record<string, number>;
+  fingerprints?: Record<number, string[]>;
+  membersPerFingerprint?: Record<string, number>;
+  sources?: Partial<CohortSignals['sources']>;
+}): CohortSignals {
+  const s = emptyCohortSignals();
+  for (const [userId, ips] of Object.entries(spec.ips ?? {})) s.ipsByUser.set(Number(userId), ips);
+  for (const [ip, n] of Object.entries(spec.membersPerIp ?? {})) s.membersPerIp.set(ip, n);
+  for (const [d, n] of Object.entries(spec.membersPerDomain ?? {})) s.membersPerDomain.set(d, n);
+  for (const [userId, fps] of Object.entries(spec.fingerprints ?? {}))
+    s.fingerprintsByUser.set(Number(userId), fps);
+  for (const [fp, n] of Object.entries(spec.membersPerFingerprint ?? {}))
+    s.membersPerFingerprint.set(fp, n);
+  s.sources = { ...s.sources, ...spec.sources };
+  return s;
+}
+
+// ---------------------------------------------------------------------------------------------
+// The shared ramp
+// ---------------------------------------------------------------------------------------------
+
+describe('rampScore', () => {
+  it('scores exactly 0 AT the zero boundary, not just below it', () => {
+    // 🔴 THE OFF-BY-ONE THIS NAMING EXISTS TO PREVENT. `zeroAt` is the largest value still worth
+    // nothing, so with `zeroAt: 2` a cluster of TWO scores nothing and a cluster of three is the
+    // smallest that scores. Reading it as "the smallest value that fires" moves every threshold in
+    // this directory one step earlier — which surfaces as noise on a board, not as an error.
+    expect(rampScore(2, 2, 10)).toBe(0);
+    expect(rampScore(1, 2, 10)).toBe(0);
+    expect(rampScore(-5, 2, 10)).toBe(0);
+  });
+
+  it('scores exactly 1 AT the one boundary, and stays there above it', () => {
+    expect(rampScore(10, 2, 10)).toBe(1);
+    expect(rampScore(400, 2, 10)).toBe(1);
+  });
+
+  it('interpolates linearly between them', () => {
+    // 5 of the way from 2 to 10 is 3/8 — deliberately not a half, a third or a round tenth, so a
+    // mutant that averages the bounds, divides by `oneAt`, or drops the `- zeroAt` cannot land on
+    // it. (Those give 0.5, 0.5 and 0.625 respectively.)
+    expect(rampScore(5, 2, 10)).toBeCloseTo(0.375, 12);
+    expect(rampScore(7, 2, 10)).toBeCloseTo(0.625, 12);
+  });
+
+  it('scores a non-finite value 0 rather than 1', () => {
+    // Same asymmetry `clampScore` states: a non-finite input is a DEFECT in whatever produced it —
+    // a divide by zero — not a maximal opinion about the account.
+    expect(rampScore(Number.NaN, 2, 10)).toBe(0);
+    expect(rampScore(Number.POSITIVE_INFINITY, 2, 10)).toBe(0);
+  });
+
+  it('🔴 throws on inverted or coincident boundaries rather than scoring', () => {
+    // A heuristic with these constants would look calibrated while emitting only 0 and 1. Failing
+    // at the call is how that is found in a test rather than in a moderator's queue.
+    expect(() => rampScore(5, 10, 2)).toThrow(/oneAt > zeroAt/);
+    expect(() => rampScore(5, 4, 4)).toThrow(/oneAt > zeroAt/);
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Heuristic 1 — posting velocity
+// ---------------------------------------------------------------------------------------------
+
+describe('posting-velocity', () => {
+  const score = (m: BotAccountCohortMember, now = NOW) =>
+    postingVelocityHeuristic.score(evidence(m, emptyCohortSignals(), now));
+
+  it('🔴 pins its constants, separately from the behavioural cases', () => {
+    // Same reasoning as the two ring heuristics: every behavioural case below uses LITERAL item
+    // counts and timestamps, so none of them says anything about these values. This does.
+    expect(MIN_ITEMS).toBe(5);
+    expect(MIN_AGE_HOURS).toBe(0.25);
+    expect(ZERO_AT_PER_HOUR).toBe(4);
+    expect(ONE_AT_PER_HOUR).toBe(40);
+  });
+
+  it('floors the age divisor, so a minutes-old account is not scored on scheduler jitter', () => {
+    // Without the floor the rate is unbounded and how extreme it looks depends on the gap between
+    // the signup and the cron tick, which is nothing to do with the account.
+    const oneMinuteOld = at('2026-09-03T11:59:00.000Z');
+    expect(effectiveAgeHours(oneMinuteOld, NOW)).toBe(MIN_AGE_HOURS);
+    // A clock that ran backwards is skew between the app and the database, not a negative age.
+    expect(effectiveAgeHours(at('2026-09-03T13:00:00.000Z'), NOW)).toBe(MIN_AGE_HOURS);
+  });
+
+  it('computes items per hour against the floored age', () => {
+    // 9 items over 3 hours — distinct from both operands and not a round rate.
+    expect(itemsPerHour(9, at('2026-09-03T09:00:00.000Z'), NOW)).toBeCloseTo(3, 12);
+  });
+
+  it('🔴 scores 0 below the volume gate however fast the rate looks', () => {
+    // The divisor floor makes a tiny numerator look fast: 4 items from a 6-minute-old account is
+    // 16/hour, well past `ZERO_AT_PER_HOUR`. Four items is not a wave under any reading, and a
+    // detector that says it is says it about a large share of every day's genuine signups.
+    const tiny = member({
+      all: { images: MIN_ITEMS - 1 },
+      createdAt: at('2026-09-03T11:54:00.000Z'),
+    });
+    expect(itemsPerHour(MIN_ITEMS - 1, tiny.createdAt, NOW)).toBeGreaterThan(ZERO_AT_PER_HOUR);
+    expect(score(tiny)).toBe(0);
+  });
+
+  it('scores a genuine wave at the top of the ramp', () => {
+    // 40 uploads from an account 20 minutes old: 40 / 0.333h = 120/hour, three times
+    // `ONE_AT_PER_HOUR`. Deliberately overshoots rather than landing on the boundary.
+    const wave = member({ all: { images: 40 }, createdAt: at('2026-09-03T11:40:00.000Z') });
+    expect(score(wave)).toBe(1);
+  });
+
+  it('scores an ordinary new account 0', () => {
+    // 6 items over 11 hours is 0.55/hour — an enthusiastic newcomer, comfortably under the floor.
+    const ordinary = member({
+      all: { images: 4, comments: 2 },
+      createdAt: at('2026-09-03T01:00:00.000Z'),
+    });
+    expect(score(ordinary)).toBe(0);
+  });
+
+  it('lands between the boundaries for a middling rate', () => {
+    // 13 items in 1 hour = 13/hour. (13 - 4) / (40 - 4) = 0.25. Chosen so the numerator and the
+    // span share no factor with the item count, and so no mutant reading `total` as the rate, or
+    // dropping the `- ZERO_AT_PER_HOUR`, produces 0.25.
+    const middling = member({ all: { images: 13 }, createdAt: at('2026-09-03T11:00:00.000Z') });
+    expect(score(middling)).toBeCloseTo(0.25, 12);
+  });
+
+  it('🔴 counts everything posted, NOT what is still on the site', () => {
+    // The canonical bot wave: 40 uploads, every one blocked by the scanner. Reading `visible` here
+    // would score this account 0 — silently zeroing precisely the accounts the detector exists to
+    // find, and by the same mistake membership was once decided on.
+    const allBlocked = member({
+      createdAt: at('2026-09-03T11:40:00.000Z'),
+      posts: {
+        all: surface({ images: 40 }),
+        visible: surface(),
+        excluded: surface({ images: 40 }),
+      },
+    });
+    expect(score(allBlocked)).toBe(1);
+  });
+
+  it('explains itself with the numbers it used, and says nothing at zero', () => {
+    const wave = member({ all: { images: 40 }, createdAt: at('2026-09-03T11:40:00.000Z') });
+    const note = postingVelocityHeuristic.explain(evidence(wave), 1);
+    expect(note).toContain('40 item(s)');
+    expect(note).toContain('/hour');
+    // A reason reciting every heuristic that did NOT fire buries the one that did.
+    expect(postingVelocityHeuristic.explain(evidence(member()), 0)).toBeNull();
+  });
+
+  it('needs no cohort-level evidence at all', () => {
+    // The cheapest of the three and the only one that cannot degrade: both numbers rode in on the
+    // cohort read. Scoring against a wholly empty index must be unaffected.
+    const wave = member({ all: { images: 40 }, createdAt: at('2026-09-03T11:40:00.000Z') });
+    expect(score(wave)).toBe(postingVelocityHeuristic.score(evidence(wave, emptyCohortSignals())));
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Heuristic 2 — registration clustering
+// ---------------------------------------------------------------------------------------------
+
+describe('registration-cluster', () => {
+  const score = (m: BotAccountCohortMember, s: CohortSignals) =>
+    registrationClusterHeuristic.score(evidence(m, s));
+
+  it('picks the LARGEST cluster among an account’s registration IPs', () => {
+    // 🔴 THE LARGEST IS FIRST IN THE LIST, DELIBERATELY. With it last, "take the max" and "take the
+    // last" agree, so a `>` → `>=` mutant — or a loop that simply keeps overwriting — survives a
+    // green test. Ordering the fixture so the answer is NOT the last element is what makes this a
+    // test of the comparison rather than of the iteration.
+    const s = signalsWith({
+      ips: { 42: ['big', 'small'] },
+      membersPerIp: { big: 7, small: 3 },
+    });
+    expect(largestIpCluster(42, s)).toEqual({ size: 7, ip: 'big' });
+  });
+
+  it('reports nothing for an account with no recorded IP', () => {
+    expect(largestIpCluster(42, signalsWith({}))).toEqual({ size: 0, ip: null });
+  });
+
+  it('🔴 pins the boundary CONSTANTS, so moving one is a deliberate edit', () => {
+    // 🔴 SEPARATED FROM THE BEHAVIOURAL CASES ON PURPOSE. Those use literals; this pins the values.
+    // Writing a boundary case as `membersPerIp: { x: IP_ZERO_AT }` reads as thorough and is
+    // VACUOUS — the expectation is computed from the very constant under test, so shifting the
+    // constant shifts the test with it and the case passes at any value. Measured: a mutant moving
+    // `IP_ZERO_AT` from 2 to 1 survived its own boundary test for exactly that reason.
+    expect(IP_ZERO_AT).toBe(2);
+    expect(IP_ONE_AT).toBe(10);
+    expect(DOMAIN_ZERO_AT).toBe(3);
+    expect(DOMAIN_ONE_AT).toBe(15);
+  });
+
+  it('scores 0 at an IP cluster of two, and fires from three', () => {
+    // Two accounts on one address is a household or a phone. LITERAL sizes, so this case is a
+    // statement about behaviour at 2 and 3 rather than about whatever the constant happens to say.
+    const two = signalsWith({ ips: { 42: ['x'] }, membersPerIp: { x: 2 } });
+    expect(score(member(), two)).toBe(0);
+    const three = signalsWith({ ips: { 42: ['x'] }, membersPerIp: { x: 3 } });
+    expect(score(member(), three)).toBeCloseTo(0.125, 12);
+  });
+
+  it('saturates at a large IP ring', () => {
+    // Overshoots the boundary rather than landing on it.
+    const big = signalsWith({ ips: { 42: ['x'] }, membersPerIp: { x: 15 } });
+    expect(score(member(), big)).toBe(1);
+  });
+
+  it('breaks a tie on the FIRST IP, deterministically', () => {
+    // Two IPs of equal size: which one is named must not depend on iteration luck. Pinned because
+    // `>` and `>=` in the max loop differ ONLY on a tie, so without this case the comparison is
+    // untested — a survived mutant, measured.
+    const tied = signalsWith({
+      ips: { 42: ['first', 'second'] },
+      membersPerIp: { first: 5, second: 5 },
+    });
+    expect(largestIpCluster(42, tied)).toEqual({ size: 5, ip: 'first' });
+  });
+
+  it('🔴 scores a common mail provider 0 at ANY cluster size', () => {
+    // Without the suppression this heuristic is anti-correlated: `gmail.com` is the largest cluster
+    // in every cohort every day, so cluster size would hand the board the day's most ordinary
+    // accounts at maximum confidence while a real disposable-domain ring scored lower.
+    const huge = signalsWith({ membersPerDomain: { 'gmail.com': 900 } });
+    expect(score(member({ emailDomain: 'gmail.com' }), huge)).toBe(0);
+    expect(domainClusterSize('gmail.com', huge.membersPerDomain)).toBe(0);
+    // Case-insensitively, because the domain arrives lowercased but the set must not depend on it.
+    expect(isCommonEmailDomain('GMAIL.COM')).toBe(true);
+  });
+
+  it('scores an uncommon domain ring, and 0 at the boundary', () => {
+    // Literal sizes, for the reason given on the constants case above.
+    const atBoundary = signalsWith({ membersPerDomain: { 'ring.test': 3 } });
+    expect(score(member({ emailDomain: 'ring.test' }), atBoundary)).toBe(0);
+    const justOver = signalsWith({ membersPerDomain: { 'ring.test': 5 } });
+    expect(score(member({ emailDomain: 'ring.test' }), justOver)).toBeCloseTo(1 / 6, 12);
+    const past = signalsWith({ membersPerDomain: { 'ring.test': 19 } });
+    expect(score(member({ emailDomain: 'ring.test' }), past)).toBe(1);
+  });
+
+  it('scores an account with no email domain 0 rather than throwing', () => {
+    expect(score(member({ emailDomain: null }), signalsWith({}))).toBe(0);
+    expect(domainClusterSize(null, new Map())).toBe(0);
+  });
+
+  it('🔴 combines the two halves with max, so the sub-score stays a ring size', () => {
+    // 7 accounts on an IP is (7-2)/8 = 0.625; 8 on a domain is (8-3)/12 = 0.4167. A sum would be
+    // 1.04 — clamped to 1, i.e. indistinguishable from total certainty — and the number in the
+    // reason string would stop meaning "the size of the ring this account is in".
+    const both = signalsWith({
+      ips: { 42: ['x'] },
+      membersPerIp: { x: 7 },
+      membersPerDomain: { 'unusual.test': 8 },
+    });
+    expect(score(member(), both)).toBeCloseTo(0.625, 12);
+  });
+
+  it('🔴 still scores on the domain half when the IP source was unavailable', () => {
+    // The half that costs no query keeps working, which is the point of splitting them.
+    const domainOnly = signalsWith({
+      membersPerDomain: { 'unusual.test': DOMAIN_ONE_AT + 2 },
+      sources: { registrationIps: false },
+    });
+    expect(score(member(), domainOnly)).toBe(1);
+    // And the note SAYS the IP half did not run, so a reader does not take the score as a
+    // statement about IPs.
+    expect(registrationClusterHeuristic.explain(evidence(member(), domainOnly), 1)).toContain(
+      'UNAVAILABLE'
+    );
+  });
+
+  it('🔴 never quotes the IP address itself into the reason', () => {
+    // The abuse board is a wider audience than the IP-lookup tool. A moderator who needs the
+    // address has `getAccountsOnIps`, which carries the paging and already-banned marking this
+    // sentence cannot.
+    const s = signalsWith({ ips: { 42: ['203.0.113.7'] }, membersPerIp: { '203.0.113.7': 9 } });
+    const note = registrationClusterHeuristic.explain(evidence(member(), s), 0.9);
+    expect(note).toContain('9 new posting accounts share its registration IP');
+    expect(note).not.toContain('203.0.113.7');
+  });
+
+  it('the common-domain list is lowercase and non-trivial', () => {
+    expect(COMMON_EMAIL_DOMAINS.size).toBeGreaterThan(10);
+    for (const d of COMMON_EMAIL_DOMAINS) expect(d).toBe(d.toLowerCase());
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// Heuristic 3 — content templating
+// ---------------------------------------------------------------------------------------------
+
+describe('content-templating', () => {
+  const score = (m: BotAccountCohortMember, s: CohortSignals) =>
+    contentTemplatingHeuristic.score(evidence(m, s));
+
+  it('picks the largest group any of the account’s texts belongs to', () => {
+    // Largest FIRST, for the reason spelled out on the IP twin: with it last, "max" and "last"
+    // agree and the comparison goes untested.
+    const s = signalsWith({
+      fingerprints: { 42: ['bigger', 'smaller'] },
+      membersPerFingerprint: { bigger: 6, smaller: 2 },
+    });
+    expect(largestContentCluster(42, s)).toEqual({ size: 6, fingerprint: 'bigger' });
+  });
+
+  it('🔴 pins the boundary CONSTANTS separately from the behaviour', () => {
+    // Same reasoning as the clustering twin: a boundary case written in terms of the constant is
+    // vacuous about its value. Measured — a mutant moving `CLUSTER_ZERO_AT` from 2 to 1 survived.
+    expect(CLUSTER_ZERO_AT).toBe(2);
+    expect(CLUSTER_ONE_AT).toBe(10);
+  });
+
+  it('scores 0 for a pair and fires from three accounts', () => {
+    // A pair of strangers writing the same masked sentence is common enough — a quoted
+    // announcement, a stock phrase with a number in it — that scoring it is noise. LITERAL sizes.
+    const pair = signalsWith({ fingerprints: { 42: ['t'] }, membersPerFingerprint: { t: 2 } });
+    expect(score(member(), pair)).toBe(0);
+    const trio = signalsWith({ fingerprints: { 42: ['t'] }, membersPerFingerprint: { t: 3 } });
+    expect(score(member(), trio)).toBeCloseTo(0.125, 12);
+  });
+
+  it('saturates on a large ring', () => {
+    const ring = signalsWith({ fingerprints: { 42: ['t'] }, membersPerFingerprint: { t: 17 } });
+    expect(score(member(), ring)).toBe(1);
+  });
+
+  it('breaks a tie on the FIRST fingerprint, deterministically', () => {
+    const tied = signalsWith({
+      fingerprints: { 42: ['one', 'two'] },
+      membersPerFingerprint: { one: 4, two: 4 },
+    });
+    expect(largestContentCluster(42, tied)).toEqual({ size: 4, fingerprint: 'one' });
+  });
+
+  it('scores an account whose content was never sampled 0, without throwing', () => {
+    expect(score(member(), signalsWith({}))).toBe(0);
+  });
+
+  it('🔴 quotes the shared text so a moderator can confirm or dismiss it', () => {
+    // The whole reason this is exact-match-after-masking rather than a distance measure: the
+    // finding has to be checkable at a glance. The QUOTED form is the normalised one — what was
+    // actually compared — so a reader is not shown a different string from the one that scored.
+    const s = signalsWith({
+      fingerprints: { 42: ['check out my page at linkmask for nummask free credits'] },
+      membersPerFingerprint: { 'check out my page at linkmask for nummask free credits': 6 },
+    });
+    const note = contentTemplatingHeuristic.explain(evidence(member(), s), 0.5);
+    expect(note).toContain('6 new accounts posted the same text');
+    expect(note).toContain('check out my page at linkmask');
+  });
+
+  it('bounds the quote, so one long text cannot truncate the whole finding', () => {
+    // `reason` is capped at 2,000 characters by the wire contract and an over-long quote here would
+    // cost the post counts and the other two notes, not just itself.
+    const long = 'a'.repeat(400);
+    const s = signalsWith({ fingerprints: { 42: [long] }, membersPerFingerprint: { [long]: 5 } });
+    const note = contentTemplatingHeuristic.explain(evidence(member(), s), 0.5) ?? '';
+    expect(note.length).toBeLessThan(200);
+    expect(note).toContain('…');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// The registry, blended
+// ---------------------------------------------------------------------------------------------
+
+describe('the three heuristics together', () => {
+  it('score independently — one firing does not move the others', () => {
+    // The operator chose shadow mode to grade each signal ON ITS OWN, so this is the property that
+    // matters most: a wave-shaped account with no ring evidence must show velocity alone.
+    const wave = member({ all: { images: 40 }, createdAt: at('2026-09-03T11:40:00.000Z') });
+    const result = scoreAccount(BOT_ACCOUNT_HEURISTICS, evidence(wave));
+    expect(result.subScores.map((s) => [s.id, s.score])).toEqual([
+      ['posting-velocity', 1],
+      ['registration-cluster', 0],
+      ['content-templating', 0],
+    ]);
+    // One of three equally weighted heuristics fully convinced blends to a third — which is above
+    // the reporting threshold, and is the arithmetic that threshold was chosen against.
+    expect(result.confidence).toBeCloseTo(1 / 3, 12);
+  });
+
+  it('an ordinary new account scores 0 on all three', () => {
+    // The population this detector must NOT report: a real newcomer, a common mail provider, no
+    // shared IP, no templated text.
+    const ordinary = member({
+      all: { images: 2, comments: 1 },
+      createdAt: at('2026-09-03T01:00:00.000Z'),
+      emailDomain: 'gmail.com',
+    });
+    const result = scoreAccount(BOT_ACCOUNT_HEURISTICS, evidence(ordinary));
+    expect(result.subScores.every((s) => s.score === 0)).toBe(true);
+    expect(result.confidence).toBe(0);
+  });
+
+  it('a coordinated ring member scores on the two ring heuristics without any velocity', () => {
+    // 🔴 THE CASE PER-ACCOUNT SCORING MISSES ENTIRELY. Three posts over eleven hours is nothing;
+    // this account is only visible because of who it registered and posted ALONGSIDE.
+    const quiet = member({
+      all: { comments: 3 },
+      createdAt: at('2026-09-03T01:00:00.000Z'),
+      emailDomain: 'ring.test',
+    });
+    const s = signalsWith({
+      ips: { 42: ['x'] },
+      membersPerIp: { x: IP_ONE_AT + 3 },
+      membersPerDomain: { 'ring.test': DOMAIN_ONE_AT + 3 },
+      fingerprints: { 42: ['buy nummask credits at linkmask right now'] },
+      membersPerFingerprint: { 'buy nummask credits at linkmask right now': CLUSTER_ONE_AT + 2 },
+      sources: { registrationIps: true },
+    });
+    const result = scoreAccount(BOT_ACCOUNT_HEURISTICS, evidence(quiet, s));
+    expect(result.subScores.map((x) => [x.id, x.score])).toEqual([
+      ['posting-velocity', 0],
+      ['registration-cluster', 1],
+      ['content-templating', 1],
+    ]);
+    expect(result.confidence).toBeCloseTo(2 / 3, 12);
+  });
+});

--- a/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/heuristics.test.ts
@@ -355,6 +355,79 @@ describe('registration-cluster', () => {
     expect(COMMON_EMAIL_DOMAINS.size).toBeGreaterThan(10);
     for (const d of COMMON_EMAIL_DOMAINS) expect(d).toBe(d.toLowerCase());
   });
+
+  it('🔴 suppresses the NON-ANGLOPHONE providers too, where the false positives actually land', () => {
+    // 🔴 THE ORIGINAL LIST WAS ANGLOPHONE, AND ITS OMISSIONS WERE NOT RANDOM. `hotmail.com` and
+    // `hotmail.co.uk` were listed; `hotmail.fr/de/es/it` were not — so nine new posting accounts a
+    // day on one country's ordinary free provider scored like a ring, and the standing false
+    // positive fell systematically on people who do not write in English. Each of these is one
+    // country's commonest webmail or ISP address, not an exotic case.
+    for (const domain of [
+      'hotmail.fr',
+      'hotmail.de',
+      'hotmail.es',
+      'hotmail.it',
+      'web.de',
+      't-online.de',
+      'free.fr',
+      'orange.fr',
+      'laposte.net',
+      'libero.it',
+      'virgilio.it',
+      'uol.com.br',
+      'terra.com.br',
+      'seznam.cz',
+      'wp.pl',
+      'yandex.com',
+      'ya.ru',
+      'foxmail.com',
+      'daum.net',
+      'naver.com',
+      'nate.com',
+      'rediffmail.com',
+      'comcast.net',
+      'btinternet.com',
+      'bigpond.com',
+    ])
+      expect(isCommonEmailDomain(domain), `${domain} is not suppressed`).toBe(true);
+  });
+
+  it('🔴 suppresses `pm.me` — Proton’s own alias domain, the sharpest omission', () => {
+    // `proton.me` and `protonmail.com` were both listed and `pm.me` was not, although Proton offers
+    // it to every paid account and it is exactly as ordinary as the other two. Asserted on its own
+    // because the whole family has to be suppressed or none of it is: a ring on the missing member
+    // of a listed family is the case the list is least likely to be re-read for.
+    for (const domain of ['proton.me', 'protonmail.com', 'protonmail.ch', 'pm.me'])
+      expect(isCommonEmailDomain(domain)).toBe(true);
+    // Scored, not merely classified — the classification only matters through this.
+    const huge = signalsWith({ membersPerDomain: { 'pm.me': 40 } });
+    expect(score(member({ emailDomain: 'pm.me' }), huge)).toBe(0);
+  });
+
+  it('🔴 a NEGATIVE control: the list does not swallow every domain', () => {
+    // The three cases above are all `true`, and a predicate wired to `() => true` passes all of
+    // them while destroying the heuristic. An uncommon domain must still cluster.
+    for (const domain of ['ring.test', 'freshdomain.xyz', 'mail.proton.me', 'notgmail.com'])
+      expect(isCommonEmailDomain(domain), `${domain} was wrongly suppressed`).toBe(false);
+    const ring = signalsWith({ membersPerDomain: { 'ring.test': 15 } });
+    expect(score(member({ emailDomain: 'ring.test' }), ring)).toBe(1);
+  });
+
+  it('🔴 the list stays a WORD LIST, and the evasion it cannot close is one keystroke', () => {
+    // Not a guard on the code — a statement of what extending the list bought and what it did not.
+    // A domain on the list scores 0 by construction, so the list is also a map of where a ring
+    // should register. The IP half is what carries this heuristic against anyone who reads it, and
+    // the principled fix is a base rate rather than a longer list.
+    const ringOnGmail = signalsWith({ membersPerDomain: { 'gmail.com': 40 } });
+    expect(score(member({ emailDomain: 'gmail.com' }), ringOnGmail)).toBe(0);
+    // …and the IP half of the SAME account still scores it, which is the part that survives.
+    const ringOnGmailSharingAnIp = signalsWith({
+      ips: { 42: ['203.0.113.9'] },
+      membersPerIp: { '203.0.113.9': IP_ONE_AT },
+      membersPerDomain: { 'gmail.com': 40 },
+    });
+    expect(score(member({ emailDomain: 'gmail.com' }), ringOnGmailSharingAnIp)).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------------------------

--- a/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
@@ -9,6 +9,10 @@ const RUN_JOBS_ROUTE = path.resolve(
   '../../../../pages/api/webhooks/run-jobs/[[...run]].ts'
 );
 
+/** The job file itself — the ONLY wiring, so what it passes to the run is what a production run
+ *  actually gets. */
+const JOB_FILE = path.resolve(__dirname, '../../../jobs/bot-account-detection.ts');
+
 /**
  * The `jobs` array the route dispatches on, as source.
  *
@@ -69,6 +73,30 @@ describe('the bot-account detection job is registered but NOT scheduled', () => 
     // separate lines, and the array alone would not compile without it.
     const source = readFileSync(RUN_JOBS_ROUTE, 'utf8');
     expect(source).toContain("from '~/server/jobs/bot-account-detection'");
+  });
+
+  it('🔴 SUPPLIES THE EVIDENCE READER — without it two of three heuristics are inert', () => {
+    // 🔴 THE OTHER HALF OF THE SEAM. `run.test.ts` proves the cohort-level signals reach scoring
+    // WHEN a reader is passed; nothing proved the production job passes one. Deleting the
+    // `evidence:` line from the wiring below left the whole suite green — `evidence?` is optional
+    // on `BotAccountDetectionDeps`, deliberately, so its absence is a supported state and not a
+    // type error — and the run would then score `registration-cluster` and `content-templating` 0
+    // for every account, on every real run, for ever.
+    //
+    // Asserted on the job's SOURCE. The alternative is calling `botAccountDetection.run`, which
+    // constructs a real Prisma reader, a real ClickHouse client and a real moderator client; this
+    // is one line of wiring and a line is something a file can be asked about directly — the same
+    // argument the `jobs` array assertion above is built on.
+    const source = readFileSync(JOB_FILE, 'utf8');
+    // A positive control on the read before anything is concluded from a `toContain`.
+    expect(source.length).toBeGreaterThan(500);
+    expect(source).toContain('runBotAccountDetection(');
+
+    expect(source).toContain('evidence: createEvidenceReader()');
+    // The import that makes the identifier resolve. Membership and import are separate lines, and
+    // a wiring that named an undefined binding would not compile — but a wiring that dropped both
+    // compiles fine, which is the case this pair covers.
+    expect(source).toContain("from '~/server/services/bot-account-detection/evidence'");
   });
 
   it('holds its lock for longer than a capped run can take', () => {

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -281,8 +281,14 @@ export function resolveDbAliases(source: string): string {
  * 🔴 `dbRead['user']['update'](…)` reaches the same method with no dot in it, and prettier wraps a
  * long chain as `dbRead.user\n  .update(` — a newline where the old pattern required none. Both
  * left the operation ledger unmoved.
+ *
+ * 🔴 OPTIONAL CHAINING IS THE THIRD SPELLING, and it is not exotic here — it is IDIOMATIC. Several
+ * handles in this tree are typed `| undefined` (`clickhouse` most of all), so `?.` is what anyone
+ * reaching for one actually writes, and `dbWrite?.user.update(…)` left BOTH ledgers unmoved: the
+ * `?` sat between the handle and the `.` where the pattern required adjacency. Both the dot form
+ * (`a?.b`) and the computed form (`a?.['b']`) are covered.
  */
-const SEGMENT = String.raw`(?:\s*\.\s*([A-Za-z_$][\w$]*)|\s*\[\s*['"]([^'"\n\]]+)['"]\s*\])`;
+const SEGMENT = String.raw`(?:\s*\??\s*\.\s*([A-Za-z_$][\w$]*)|\s*(?:\?\s*\.)?\s*\[\s*['"]([^'"\n\]]+)['"]\s*\])`;
 
 /**
  * `db.model.method(` / `dbRead.$rawMethod(` / `dbWrite['model']['method'](` — every shape a Prisma
@@ -371,13 +377,29 @@ function importSpecifiers(sources: ReturnType<typeof detectorSources>): string[]
  * control asserts the benign shape IS seen rather than only that the hostile one is.
  *
  * The type-argument body excludes parentheses so the match cannot run past the call it belongs to.
+ *
+ * 🔴 OPTIONAL CHAINING AND THE BRACKET FORM ARE BOTH MATCHED, and the first of those is the one that
+ * mattered: `~/server/clickhouse/client` exports `clickhouse: CustomClickHouseClient | undefined`,
+ * so `clickhouse?.$exec(…)` is not an evasion, it is the SPELLING THE TYPE PUSHES YOU TOWARDS —
+ * `evidence.ts` only avoids it by binding a narrowed local first. Against the adjacency-requiring
+ * pattern it recorded nothing at all, and `$exec` runs arbitrary DDL/DML and returns `void`, so a
+ * mutation through it produces no value anyone would notice was missing. `ch['$exec'](…)` is the
+ * same hole with a different keystroke.
+ *
+ * 🔴 WHAT REMAINS OPEN, stated rather than implied by the widening: this matches the two handle
+ * NAMES it knows and a `$`-prefixed method spelled as a literal. It does not follow a client through
+ * an assignment to a differently-named variable, a destructure (`const { $exec } = clickhouse`), an
+ * object field, a function return, or a computed key built at runtime (`ch[m]`). Those are dataflow,
+ * not pattern-matching, and this file does not attempt them — the import ledger is what bounds the
+ * blast radius there, by refusing a new specifier without a maintainer looking at it.
  */
-const CLICKHOUSE_CALL = /\b(?:clickhouse|ch)\s*\.\s*(\$[A-Za-z_$][\w$]*)\s*(?:<[^()]*>)?\s*\(/g;
+const CLICKHOUSE_CALL =
+  /\b(?:clickhouse|ch)\s*(?:\??\s*\.\s*(\$[A-Za-z_$][\w$]*)|(?:\s*\?\s*\.)?\s*\[\s*['"](\$[A-Za-z_$][\w$]*)['"]\s*\])\s*(?:<[^()]*>)?\s*\(/g;
 
 export function clickhouseMethods(sources: ReturnType<typeof detectorSources>): string[] {
   const found = new Set<string>();
   for (const { source } of sources)
-    for (const match of source.matchAll(CLICKHOUSE_CALL)) found.add(match[1]);
+    for (const match of source.matchAll(CLICKHOUSE_CALL)) found.add(match[1] ?? match[2]);
   return [...found].sort();
 }
 
@@ -761,6 +783,11 @@ describe('the detector has no write surface', () => {
       './similarity',
       './velocity',
       '@civitai/moderation',
+      // Pure string constants and one string builder — no client, no env, no IO. It is the SAME
+      // predicate `apps/moderator/src/lib/server/reactor-lookup.service.ts` reads `userActivities`
+      // with, shared rather than copied; a second hand-written copy is how two readers of one table
+      // silently stop agreeing about what an address means.
+      '@civitai/shared/clickhouse-ip-filters',
       '~/server/clickhouse/client',
       '~/server/db/client',
       '~/server/logging/client',
@@ -789,6 +816,57 @@ describe('the detector has no write surface', () => {
     const benign = asSources({ 'b.ts': "await ch.$query<{ip: string}>('SELECT ip FROM t');\n" });
     expect(clickhouseMethods(benign)).toEqual(['$query']);
     expect(nonSelectClickhouseStatements(benign)).toEqual([]);
+  });
+
+  it('🔴 sees a ClickHouse call spelled with OPTIONAL CHAINING or a bracket key', () => {
+    // 🔴 Red before the widening, and this is not an exotic spelling: `clickhouse` is typed
+    // `| undefined`, so `clickhouse?.$exec(…)` is what the type pushes anyone towards. Against the
+    // adjacency-requiring pattern it recorded NOTHING — the ledger read `['$query']`, exactly as it
+    // does on a clean tree, so the reassuring answer and the escaped answer were the same string.
+    //
+    // Each widening gets its OWN control rather than one case asserting both, so a regression names
+    // which spelling came back.
+    const optional = asSources({
+      'a.ts': `await clickhouse?.$exec(\`ALTER TABLE default.userActivities DELETE WHERE ip = ''\`);\n`,
+    });
+    expect(clickhouseMethods(optional)).toEqual(['$exec']);
+
+    const bracket = asSources({
+      'b.ts': `await ch['$exec'](\`ALTER TABLE default.userActivities DELETE WHERE ip = ''\`);\n`,
+    });
+    expect(clickhouseMethods(bracket)).toEqual(['$exec']);
+
+    const optionalBracket = asSources({ 'c.ts': `await ch?.['$exec']('DROP TABLE t');\n` });
+    expect(clickhouseMethods(optionalBracket)).toEqual(['$exec']);
+
+    // And the widening did not swallow the benign shape it has to keep seeing.
+    expect(
+      clickhouseMethods(
+        asSources({ 'd.ts': "await ch.$query<{ip: string}>('SELECT ip FROM t');\n" })
+      )
+    ).toEqual(['$query']);
+    // Nor does it now match an ordinary array method on a variable called `ch` — the `$` prefix is
+    // still what keeps `.map(`/`.filter(` out, and a widened pattern is the moment to re-check it.
+    expect(clickhouseMethods(asSources({ 'e.ts': 'const x = ch?.map((r) => r.ip);\n' }))).toEqual(
+      []
+    );
+  });
+
+  it('🔴 sees a Prisma write spelled with OPTIONAL CHAINING', () => {
+    // Same class, other ledger: `dbWrite?.user.update(…)` put the `?` exactly where `SEGMENT`
+    // required a bare `.`, so it contributed no operation and the ledger stayed at seven members.
+    // Its own control, separate from the ClickHouse one above.
+    const optional = asSources({ 'a.ts': 'await dbWrite?.user.update({ where: { id } });\n' });
+    expect(databaseOperations(optional)).toEqual(['user.update']);
+
+    const optionalBracket = asSources({ 'b.ts': "await dbRead?.['user']?.['update']({ id });\n" });
+    expect(databaseOperations(optionalBracket)).toEqual(['user.update']);
+
+    // The benign shapes the ledger already saw still read the same, so the widening added members
+    // rather than moving them.
+    expect(
+      databaseOperations(asSources({ 'c.ts': 'await dbRead.comment.findMany(args);\n' }))
+    ).toEqual(['comment.findMany']);
   });
 
   it('calls exactly one ClickHouse method, and it is the read one', () => {

--- a/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/no-write-surface.test.ts
@@ -348,6 +348,72 @@ function importSpecifiers(sources: ReturnType<typeof detectorSources>): string[]
 }
 
 /**
+ * A method called on a ClickHouse handle — `clickhouse.$query(`, `ch.$exec(`.
+ *
+ * 🔴 A SECOND LEDGER, BECAUSE THE FIRST ONE IS BLIND HERE BY CONSTRUCTION. `DB_CALL` above anchors
+ * on `db`/`dbRead`/`dbWrite`; the ClickHouse client is none of those, so a call on it moves the
+ * operation ledger not at all. That matters because the client's surface is not read-only: `$exec`
+ * takes the same kind of string, runs arbitrary DDL/DML, and returns `void` — so a mutation through
+ * it produces no value anyone would notice was missing.
+ *
+ * The handle names are matched rather than tracked by dataflow, for the same reason
+ * `resolveDbAliases` is a regex: following a client through property assignment is an analysis this
+ * file does not attempt. `ch` is included because that is what `createEvidenceReader` binds it to.
+ * The `$`-prefixed method requirement is what keeps ordinary `.map(`/`.filter(` on a variable named
+ * `ch` out of the set.
+ *
+ * 🔴 THE TYPE-ARGUMENT LIST IS PART OF THE PATTERN, and leaving it out made the ledger return an
+ * empty set for a module that calls `$query` on every run. `ch.$query<{ ip: string }>(sql)` puts a
+ * generic argument between the method name and the `(`, so a pattern requiring them adjacent matches
+ * nothing — while `$exec(` , which nobody writes with type arguments, matched fine. The result was
+ * the worst possible shape: the guard's negative control passed, its assertion read a reassuring
+ * `[]`, and it was blind to the exact call the real code makes. Caught only because the positive
+ * control asserts the benign shape IS seen rather than only that the hostile one is.
+ *
+ * The type-argument body excludes parentheses so the match cannot run past the call it belongs to.
+ */
+const CLICKHOUSE_CALL = /\b(?:clickhouse|ch)\s*\.\s*(\$[A-Za-z_$][\w$]*)\s*(?:<[^()]*>)?\s*\(/g;
+
+export function clickhouseMethods(sources: ReturnType<typeof detectorSources>): string[] {
+  const found = new Set<string>();
+  for (const { source } of sources)
+    for (const match of source.matchAll(CLICKHOUSE_CALL)) found.add(match[1]);
+  return [...found].sort();
+}
+
+/**
+ * Every SQL-looking string literal in the module.
+ *
+ * Deliberately over-inclusive: it collects any template or quoted string whose first word is a SQL
+ * verb, whether or not it is passed to ClickHouse. Over-inclusion is the safe direction — it can
+ * only add candidates for the "is it a SELECT" test below, never hide one — and it means a statement
+ * built into a variable before being passed is still seen, which is exactly how `registrationIpSql`
+ * is written.
+ */
+const SQL_VERB = /^\s*(select|insert|alter|drop|delete|update|create|truncate|optimize|rename)\b/i;
+
+export function clickhouseStatements(sources: ReturnType<typeof detectorSources>): string[] {
+  const out: string[] = [];
+  for (const { source } of sources) {
+    // Template literals and quoted strings alike. The comment stripper has already run, so nothing
+    // collected here is prose.
+    for (const match of source.matchAll(/`([^`]*)`|'([^'\n]*)'|"([^"\n]*)"/g)) {
+      const text = match[1] ?? match[2] ?? match[3] ?? '';
+      if (SQL_VERB.test(text)) out.push(text);
+    }
+  }
+  return out;
+}
+
+/** The statements that are NOT reads. The assertion this exists for expects an empty list, so the
+ *  control that proves it can be non-empty is a test of its own. */
+export function nonSelectClickhouseStatements(
+  sources: ReturnType<typeof detectorSources>
+): string[] {
+  return clickhouseStatements(sources).filter((sql) => !/^\s*select\b/i.test(sql));
+}
+
+/**
  * 🔴 Temp trees are REMOVED. Every case below that plants an escape builds one, and they used to be
  * left behind on the runner — one per case per run, forever, under `os.tmpdir()`.
  */
@@ -642,12 +708,25 @@ describe('the detector has no write surface', () => {
     expect(importSpecifiers(planted)).toEqual(['~/server/services/user-restriction.service']);
   });
 
-  it('performs exactly five database operations, all of them reads', () => {
-    // 🔴 THE LEDGER. A write added anywhere in these files is a sixth member and fails here; a read
-    // removed is a missing member and fails here too (dropping `commentV2` would silently turn
+  it('performs exactly seven database operations, all of them reads', () => {
+    // 🔴 THE LEDGER. A write added anywhere in these files is an eighth member and fails here; a
+    // read removed is a missing member and fails here too (dropping `commentV2` would silently turn
     // every newer-comment-only account into a false negative).
+    //
+    // 🔴 IT WENT FROM FIVE TO SEVEN WITH THE HEURISTICS, AND THE TWO NEW MEMBERS ARE THE WHOLE
+    // DATABASE COST OF THIS CHANGE. `comment.findMany`/`commentV2.findMany` are the content samples
+    // the templating heuristic compares. Note what is NOT here: the velocity heuristic added
+    // nothing (it reads counts the cohort already carried) and the clustering heuristic's email
+    // half added nothing (a wider `select` on the existing `user.findMany` is not a new operation).
+    //
+    // 🔴 THIS LEDGER CANNOT SEE THE CLICKHOUSE READ — `DB_CALL` anchors on a `db` handle and the
+    // ClickHouse client is not one. That is not a gap being tolerated; it is why the separate
+    // ClickHouse ledger below exists. Adding a source that is not Prisma leaves this assertion
+    // completely unmoved, which is the exact shape of hole this file is built to refuse.
     expect(databaseOperations(detectorSources())).toEqual([
+      'comment.findMany',
       'comment.groupBy',
+      'commentV2.findMany',
       'commentV2.groupBy',
       'image.groupBy',
       'model.groupBy',
@@ -661,19 +740,74 @@ describe('the detector has no write surface', () => {
     // ledger above completely unmoved. Adding a module to this list is the moment to ask whether
     // the shadow guarantee still holds — and, per the file header, WHICH BINDING is taken from it,
     // which this list cannot see.
+    //
+    // 🔴 THE ONE ENTRY THAT CHANGES THE THREAT MODEL IS `~/server/clickhouse/client`. Every other
+    // new member is a local module inside this tree. That one is a NEW EXTERNAL DATA SYSTEM, and
+    // the question this list exists to force is what else its module exports: it exports a client
+    // whose surface includes `$exec`, which runs arbitrary statements and returns nothing. Nothing
+    // in THIS assertion can tell `clickhouse` apart from `$exec` being taken off the same
+    // specifier — that is the "which BINDING" gap named in the file header — so the ClickHouse
+    // ledger below asserts the method set and the statement text separately.
     expect(importSpecifiers(detectorSources())).toEqual([
+      '../scoring',
+      './clustering',
       './cohort',
+      './evidence',
+      './heuristics',
       './job',
+      './ramp',
       './report',
       './scoring',
+      './similarity',
+      './velocity',
       '@civitai/moderation',
+      '~/server/clickhouse/client',
       '~/server/db/client',
       '~/server/logging/client',
       '~/server/services/bot-account-detection/cohort',
+      '~/server/services/bot-account-detection/evidence',
       '~/server/services/bot-account-detection/run',
       '~/server/services/moderator-app.service',
       '~/shared/utils/prisma/enums',
     ]);
+  });
+
+  it('the ClickHouse scanner can see a call and a statement — controls, both halves', () => {
+    // 🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT. The two assertions after this one are
+    // both ZEROES ("no method other than $query", "no non-SELECT statement"), and a reassuring zero
+    // is indistinguishable from a scanner wired to nothing. Both controls are built from the exact
+    // text a real regression would carry.
+    const planted = asSources({
+      'a.ts': `await clickhouse.$exec(\`ALTER TABLE default.userActivities DELETE WHERE ip = ''\`);\n`,
+    });
+    // Positive control: the method scanner CAN produce a non-empty result.
+    expect(clickhouseMethods(planted)).toEqual(['$exec']);
+    // Positive control: the statement scanner CAN find a non-SELECT.
+    expect(nonSelectClickhouseStatements(planted)).toHaveLength(1);
+
+    // And it does not fire on the shape the module actually uses.
+    const benign = asSources({ 'b.ts': "await ch.$query<{ip: string}>('SELECT ip FROM t');\n" });
+    expect(clickhouseMethods(benign)).toEqual(['$query']);
+    expect(nonSelectClickhouseStatements(benign)).toEqual([]);
+  });
+
+  it('calls exactly one ClickHouse method, and it is the read one', () => {
+    // 🔴 THE LEDGER THE PRISMA ONE STRUCTURALLY CANNOT PROVIDE. `DB_CALL` anchors on a `db` handle,
+    // so a ClickHouse call contributes nothing to it — the operation ledger above stays at seven
+    // members whatever this module does to ClickHouse. `$exec` is on the same client and the same
+    // import, takes the same kind of string, and runs arbitrary DDL/DML while returning nothing.
+    // An asserted set, so it fails if a second method appears as well as if this one goes.
+    expect(clickhouseMethods(detectorSources())).toEqual(['$query']);
+  });
+
+  it('every ClickHouse statement it holds is a bare SELECT', () => {
+    // The method ledger says which call is made; this says what is handed to it. They are different
+    // claims — `$query` is a read method, but the scanner cannot know that the string it is given
+    // is a read, and ClickHouse will happily accept a mutation through a query path.
+    expect(nonSelectClickhouseStatements(detectorSources())).toEqual([]);
+    // 🔴 POSITIVE CONTROL ON THE REAL TREE, not just on a fixture: an empty list above is only
+    // meaningful if the walk found statements to look at in the first place.
+    expect(clickhouseStatements(detectorSources()).length).toBeGreaterThanOrEqual(1);
   });
 
   it('names no write client, and no raw-SQL escape hatch on EITHER handle', () => {

--- a/src/server/services/bot-account-detection/__tests__/report.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/report.test.ts
@@ -44,6 +44,7 @@ const member = (overrides: Partial<BotAccountCohortMember> = {}): BotAccountCoho
   username: 'newcomer',
   createdAt: at('2026-09-03T00:20:00.000Z'),
   posts: posts({ comments: 2, models: 1, images: 3 }),
+  emailDomain: 'newcomer.test',
   ...overrides,
 });
 
@@ -80,6 +81,43 @@ describe('buildFinding', () => {
 
   it('passes the blended confidence through unaltered', () => {
     expect(buildFinding(member(), score({ confidence: 0.75 }), STARTED).confidence).toBe(0.75);
+  });
+
+  it('🔴 carries each heuristic’s NOTE, not only its number', () => {
+    // 🔴 THE GAP THIS CLOSES. `HeuristicScore.note` was collected on every score and rendered
+    // nowhere: the reason carried `Per-heuristic: a=0.60` and no statement of what the heuristic
+    // SAW, which is the half a moderator needs to decide anything. It was invisible while the only
+    // registered heuristic was a placeholder whose note was always null.
+    const finding = buildFinding(
+      member(),
+      score({
+        confidence: 0.42,
+        subScores: [
+          {
+            id: 'registration-cluster',
+            score: 0.6,
+            weight: 1,
+            note: '9 new posting accounts share its registration IP',
+            clamped: false,
+          },
+          { id: 'content-templating', score: 0, weight: 1, note: null, clamped: false },
+        ],
+      }),
+      STARTED
+    );
+    expect(finding.reason).toContain(
+      'Signals — registration-cluster: 9 new posting accounts share its registration IP.'
+    );
+    // The heuristic that said nothing contributes no clause — a reason reciting every signal that
+    // did not fire buries the one that did.
+    expect(finding.reason).not.toContain('content-templating:');
+    // The numbers still follow, for both.
+    expect(finding.reason).toContain('registration-cluster=0.60, content-templating=0.00');
+  });
+
+  it('omits the signals clause entirely when nothing fired', () => {
+    // Rather than rendering `Signals — .`, which reads as a truncation.
+    expect(buildFinding(member(), score(), STARTED).reason).not.toContain('Signals —');
   });
 
   it('cites the evidence a moderator needs to judge it', () => {

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -225,6 +225,113 @@ describe('the reporting threshold, end to end', () => {
   });
 });
 
+/**
+ * The reason string's `Per-heuristic: a=0.60, b=0.00` clause, parsed back into a map.
+ *
+ * Read off the EMITTED FINDING rather than off an intermediate, because the finding is the only
+ * thing that leaves this process — an assertion on a score object one layer up cannot tell whether
+ * that score ever reached the board.
+ */
+function subScoresOf(finding: { reason: string }): Record<string, number> {
+  // Anchored on the clause that FOLLOWS it, because the scores themselves contain full stops —
+  // `[^.]*` reads `posting-velocity=0` and stops, which is a parse that looks like a value.
+  const clause = /Per-heuristic: (.*?)\. Blended confidence/.exec(finding.reason);
+  if (!clause) throw new Error(`no per-heuristic clause in reason: ${finding.reason}`);
+  return Object.fromEntries(
+    clause[1].split(', ').map((pair) => {
+      const [id, value] = pair.split('=');
+      return [id, Number(value)];
+    })
+  );
+}
+
+describe('🔴 the seam between the evidence and the scoring', () => {
+  /**
+   * A cohort of six accounts that share ONE registration IP and ONE templated comment, run end to
+   * end through the PRODUCTION heuristic registry with a real `EvidenceReader` behind it.
+   *
+   * Six, not three: at the shipped boundaries six members on one address is where the IP ramp
+   * reaches 0.5, and it overshoots `IP_ZERO_AT`/`CLUSTER_ZERO_AT` rather than sitting on them.
+   */
+  const RING_TEXT = 'Grab your 100 free credits here: https://spam.example/ref1';
+  const ringRun = (evidence: Parameters<typeof runBotAccountDetection>[0]['evidence']) => {
+    const accounts = Array.from({ length: 6 }, (_, i) => account(i + 1));
+    const { reader } = recordingReader(accounts);
+    const out = sink();
+    return {
+      ...out,
+      result: runBotAccountDetection(
+        { reader, evidence, sendReport: out.sendReport, now: clock() }, // production registry
+        { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+      ),
+    };
+  };
+
+  const ringEvidence = {
+    hasRegistrationIps: true,
+    listRegistrationIps: async (ids: number[]) =>
+      ids.map((userId) => ({ userId, ip: '203.0.113.9' })),
+    listContentSamples: async (ids: number[]) =>
+      ids.map((userId) => ({ userId, content: RING_TEXT })),
+  };
+
+  it('🔴 the cohort-level evidence REACHES the scoring, and the finding proves it', async () => {
+    // 🔴 THE MUTANT THIS EXISTS FOR, AND IT IS THE MOST EXPENSIVE ONE IN THIS TREE. Replacing the
+    // `signals` handed to `scoreAccount` with `emptyCohortSignals()` left the entire suite green:
+    // `evidence.test.ts` covers the index, `heuristics.test.ts` covers the pure scorers over
+    // hand-built signals, `run.test.ts` covered the threshold — and NO test ever built the combined
+    // state. Two of the three heuristics would have scored 0 for every account on every production
+    // run while `evidence_registration_ips`, `evidence_distinct_registration_ips` and
+    // `evidence_distinct_content_fingerprints` all reported healthy values, because those read
+    // `signals` rather than what scoring saw. Two-thirds of the detector inert, every counter
+    // saying it was fine.
+    //
+    // The assertion is on the EMITTED FINDING's own sub-scores. A score object, or a counter, is a
+    // claim about an intermediate; the finding is what reaches the board.
+    const scenario = ringRun(ringEvidence);
+    await scenario.result;
+
+    const finding = scenario.reports[0].findings.find((f) => f.userId === 1);
+    expect(finding).toBeDefined();
+    const sub = subScoresOf(finding as { reason: string });
+
+    // A positive control on the parse before either number is believed: all three registered
+    // heuristics are present, so a regex that matched a fragment cannot read as a pass.
+    expect(Object.keys(sub).sort()).toEqual([
+      'content-templating',
+      'posting-velocity',
+      'registration-cluster',
+    ]);
+
+    // 🔴 THE TWO THAT GO INERT. Both read `signals` and nothing else; under the mutant both are 0.
+    expect(sub['registration-cluster']).toBeGreaterThan(0);
+    expect(sub['content-templating']).toBeGreaterThan(0);
+    // Six on one address and six on one fingerprint, at the shipped boundaries.
+    expect(sub['registration-cluster']).toBeCloseTo(0.5, 6);
+    expect(sub['content-templating']).toBeCloseTo(0.5, 6);
+    // And the blend a moderator sorts on moved with them, rather than the sub-scores being
+    // decoration on a number computed elsewhere.
+    expect(finding?.confidence).toBeCloseTo(1 / 3, 6);
+
+    // The reason a moderator reads names WHAT was seen, not only that something was.
+    expect(finding?.reason).toContain('6 new posting accounts share its registration IP');
+    expect(finding?.reason).toContain('6 new accounts posted the same text');
+  });
+
+  it('the same cohort with NO evidence reader scores both ring heuristics 0 — the control', async () => {
+    // The other arm. Without it the case above cannot attribute anything: a finding whose ring
+    // sub-scores are non-zero proves the seam only if they are zero when the evidence is absent,
+    // and that is exactly the state the mutant manufactures.
+    const scenario = ringRun(undefined);
+    await scenario.result;
+    const sub = subScoresOf(
+      scenario.reports[0].findings.find((f) => f.userId === 1) as { reason: string }
+    );
+    expect(sub['registration-cluster']).toBe(0);
+    expect(sub['content-templating']).toBe(0);
+  });
+});
+
 describe('the evidence sources are reported, not assumed', () => {
   it('🔴 a run with NO evidence reader says the ring sources did not run', async () => {
     // Two of the three heuristics score 0 when their source is missing, which is byte-identical to
@@ -268,6 +375,264 @@ describe('the evidence sources are reported, not assumed', () => {
     const scenario = run([account(1)]);
     await scenario.result;
     expect(scenario.reports[0].summary).toContain('REGISTRATION-IP DATA WAS UNAVAILABLE');
+  });
+
+  it('🔴 says so when the IP read RAN and matched nothing — the wrong-query signature', async () => {
+    // 🔴 THE CASE THE AVAILABILITY FLAG CANNOT EXPRESS. `evidence_registration_ips: 1` with
+    // `evidence_distinct_registration_ips: 0` over a non-empty cohort is what a changed column, a
+    // moved table or an over-tight filter looks like — and it is also what a quiet day looks like.
+    // The counters carried both numbers; the summary, which is what a human reads first, said
+    // nothing at all, so the two states were indistinguishable to the only reader who would
+    // recognise the difference.
+    const { reader } = recordingReader([account(1), account(2)]);
+    const out = sink();
+    await runBotAccountDetection(
+      {
+        reader,
+        evidence: {
+          hasRegistrationIps: true,
+          listRegistrationIps: async () => [],
+          listContentSamples: async () => [],
+        },
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [],
+      },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+    const summary = out.reports[0].summary ?? '';
+    expect(summary).toContain('THE REGISTRATION-IP READ RAN AND MATCHED NOTHING for any of the 2');
+    expect(summary).toContain('wrong column, a moved table or an over-tight filter');
+    // And it does NOT also claim the source was unavailable — the two clauses are mutually
+    // exclusive, and emitting both would make each meaningless.
+    expect(summary).not.toContain('REGISTRATION-IP DATA WAS UNAVAILABLE');
+    expect(out.reports[0].counters?.evidence_registration_ips).toBe(1);
+    expect(out.reports[0].counters?.evidence_distinct_registration_ips).toBe(0);
+  });
+
+  it('stays quiet when the IP read ran and DID match — the negative control', async () => {
+    // The clause above must not fire on an ordinary run, or it is noise that trains a reader to
+    // skip the summary.
+    const { reader } = recordingReader([account(1), account(2)]);
+    const out = sink();
+    await runBotAccountDetection(
+      {
+        reader,
+        evidence: {
+          hasRegistrationIps: true,
+          listRegistrationIps: async () => [{ userId: 1, ip: '203.0.113.4' }],
+          listContentSamples: async () => [],
+        },
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [],
+      },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+    expect(out.reports[0].summary).not.toContain('MATCHED NOTHING');
+  });
+
+  it('🔴 a failing CONTENT read degrades the run: a report is still filed, and it SAYS so', async () => {
+    // 🔴 THE FAILURE THIS EXISTS TO PREVENT, END TO END. `listContentSamples` had no guard, so a
+    // replica timeout propagated out of the run and NO REPORT WAS FILED AT ALL — the velocity
+    // heuristic's day lost with it, and the whole thing indistinguishable from a producer that
+    // stopped running. Under the pre-fix code this case does not fail an assertion, it REJECTS.
+    const { reader } = recordingReader([account(1), account(2)]);
+    const out = sink();
+    const result = await runBotAccountDetection(
+      {
+        reader,
+        evidence: {
+          hasRegistrationIps: false,
+          listRegistrationIps: async () => [],
+          listContentSamples: async () => {
+            throw new Error('replica timeout');
+          },
+        },
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [],
+      },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+
+    expect(result.reportsSent).toBe(1);
+    expect(result.cohortSize).toBe(2);
+    expect(out.reports[0].counters?.evidence_content_samples).toBe(0);
+    expect(out.reports[0].summary).toContain('CONTENT SAMPLE DATA WAS UNAVAILABLE');
+    // Not reported as an exhausted budget: that would send a grading pass looking for a cohort too
+    // large rather than for a broken replica.
+    expect(out.reports[0].counters?.evidence_content_budget_exhausted).toBe(0);
+    expect(out.reports[0].counters?.evidence_members_sampled_for_content).toBe(0);
+  });
+
+  it('publishes evidence_content_samples as a 1 when the read worked', async () => {
+    // Emitted on both sides, so the counter is a state rather than a flag that only ever appears in
+    // the bad case.
+    const { reader } = recordingReader([account(1)]);
+    const out = sink();
+    await runBotAccountDetection(
+      {
+        reader,
+        evidence: {
+          hasRegistrationIps: false,
+          listRegistrationIps: async () => [],
+          listContentSamples: async () => [],
+        },
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [],
+      },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+    expect(out.reports[0].counters?.evidence_content_samples).toBe(1);
+    expect(out.reports[0].summary).not.toContain('CONTENT SAMPLE DATA WAS UNAVAILABLE');
+  });
+
+  it('🔴 says the budget ran out, in the summary as well as the counters', async () => {
+    // 🔴 The whole budget-exhausted sentence was unasserted: mutating `(signals.sources
+    // .contentBudgetExhausted` to `(false` left the suite green, so half of what the PR body claims
+    // the summary warns about was never checked. The sentence is pinned in full, not by keyword —
+    // it names WHICH END went unsampled, and a reword that inverted that would pass a keyword test.
+    const { reader } = recordingReader([account(1), account(2), account(3), account(4)]);
+    const out = sink();
+    await runBotAccountDetection(
+      {
+        reader,
+        evidence: {
+          hasRegistrationIps: false,
+          listRegistrationIps: async () => [],
+          // Two rows per chunk against a budget of 2: the first chunk spends it and the walk stops.
+          listContentSamples: async (ids) =>
+            ids.map((userId) => ({ userId, content: 'x'.repeat(30) })),
+        },
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [],
+      },
+      { pageSize: 2, maxAccounts: 10, minConfidence: 0, maxContentSamples: 2 }
+    );
+
+    expect(out.reports[0].counters?.evidence_content_budget_exhausted).toBe(1);
+    expect(out.reports[0].counters?.evidence_content_budget).toBe(2);
+    expect(out.reports[0].summary).toContain(
+      '🔴 THE CONTENT SAMPLE BUDGET (2 rows) WAS EXHAUSTED after 2 of 4 members. Members are ' +
+        'sampled newest-first, so the unsampled remainder is the OLDEST end of the window and ' +
+        'scored 0 on content templating for want of data.'
+    );
+  });
+});
+
+describe('the counters that make the heuristics’ own blind spots measurable', () => {
+  it('🔴 counts the members whose email domain was SUPPRESSED as a common provider', async () => {
+    // 🔴 `clustering.ts` asserted `domains_suppressed_common` "is what makes the first measurable"
+    // while the identifier existed nowhere in `src/`, `packages/` or `apps/` — a comment claiming
+    // coverage that did not exist, which is worse than no comment because it stops anyone looking.
+    // It is the SIZE of the domain half's blind spot: a real ring that registered on a listed
+    // provider scores 0 there by construction and nothing else can see it.
+    const common = [1, 2, 3].map((id) => ({
+      ...account(id),
+      email: `u${id}@gmail.com`,
+    }));
+    const uncommon = [4, 5].map((id) => ({ ...account(id), email: `u${id}@ring.test` }));
+    const { reader } = recordingReader([...common, ...uncommon]);
+    const out = sink();
+    const result = await runBotAccountDetection(
+      { reader, sendReport: out.sendReport, now: clock(), heuristics: [] },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+
+    expect(result.counters.domains_suppressed_common).toBe(3);
+    expect(result.counters.cohort_size).toBe(5);
+    // Emitted at zero too, on a cohort where nothing was suppressed — a counter that appears only
+    // in the interesting case cannot be charted or alerted on.
+    const clean = recordingReader(uncommon);
+    const out2 = sink();
+    const result2 = await runBotAccountDetection(
+      { reader: clean.reader, sendReport: out2.sendReport, now: clock(), heuristics: [] },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+    expect(result2.counters.domains_suppressed_common).toBe(0);
+    expect(Object.keys(out2.reports[0].counters ?? {})).toContain('domains_suppressed_common');
+  });
+
+  it('🔴 counts the findings that rest on ONE heuristic and nothing else', async () => {
+    // The counter the content-templating false positive shows up in. A generation-parameter paste
+    // fires that heuristic and no other, so a run inflated by collisions moves
+    // `heuristic:content-templating:sole_signal` and leaves `fired` looking ordinary. Over the
+    // REPORTED members only: a sole signal below the threshold produced no finding and cost nobody
+    // anything.
+    const { reader } = recordingReader([account(1), account(2)]);
+    const out = sink();
+    const result = await runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [
+          constantHeuristic('alone', 0.9),
+          constantHeuristic('quiet', 0),
+          constantHeuristic('silent', 0),
+        ],
+      },
+      { pageSize: 10, maxAccounts: 10 }
+    );
+
+    expect(result.counters['heuristic:alone:sole_signal']).toBe(2);
+    // Emitted as zeros for the heuristics that never fired alone, not omitted.
+    expect(result.counters['heuristic:quiet:sole_signal']).toBe(0);
+    expect(result.counters['heuristic:silent:sole_signal']).toBe(0);
+  });
+
+  it('does not count a finding TWO heuristics agreed on', async () => {
+    // The negative control: `sole_signal` must mean "carried by one signal", not "fired". Without
+    // this a counter wired to the same predicate as `fired` passes the case above.
+    const { reader } = recordingReader([account(1)]);
+    const out = sink();
+    const result = await runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [constantHeuristic('a', 0.9), constantHeuristic('b', 0.9)],
+      },
+      { pageSize: 10, maxAccounts: 10 }
+    );
+    expect(result.counters['heuristic:a:evaluated']).toBe(1);
+    expect(result.counters['heuristic:a:fired']).toBe(1);
+    expect(result.counters['heuristic:a:sole_signal']).toBe(0);
+    expect(result.counters['heuristic:b:sole_signal']).toBe(0);
+  });
+
+  it('counts only the REPORTED members, not every scored one', async () => {
+    // A sole signal under the threshold produced no finding. Counting it would bury the number that
+    // matters in the cohort's own size, which is the shape of every reassuring figure this detector
+    // was built to avoid producing.
+    const accounts = [account(1), account(2)];
+    const { reader } = recordingReader(accounts);
+    const out = sink();
+    const result = await runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [
+          {
+            id: 'weak',
+            description: 'test',
+            weight: 1,
+            // #2 blends to 0.9 and is reported; #1 blends to 0.01 and is not.
+            score: ({ member }) => (member.userId === 2 ? 0.9 : 0.01),
+            explain: () => null,
+          },
+        ],
+      },
+      { pageSize: 10, maxAccounts: 10 }
+    );
+    expect(result.findingsReported).toBe(1);
+    expect(result.findingsSuppressed).toBe(1);
+    expect(result.counters['heuristic:weak:fired']).toBe(2);
+    expect(result.counters['heuristic:weak:sole_signal']).toBe(1);
   });
 });
 

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -5,10 +5,20 @@ import {
 } from '@civitai/moderation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock, mockNode } from '~/__tests__/mocks';
-import type { CohortReader, NewAccountRow } from '../cohort';
+import type { BotAccountCohortMember, CohortReader, NewAccountRow } from '../cohort';
+import { emptyCohortSignals } from '../evidence';
 import { BOT_ACCOUNT_DETECTOR } from '../report';
-import { BOT_ACCOUNT_HEURISTICS } from '../heuristics';
-import { MIN_REPORTED_CONFIDENCE, type BotAccountHeuristic } from '../scoring';
+import {
+  BOT_ACCOUNT_HEURISTICS,
+  contentTemplatingHeuristic,
+  postingVelocityHeuristic,
+  registrationClusterHeuristic,
+} from '../heuristics';
+import {
+  MIN_REPORTED_CONFIDENCE,
+  SOLE_SIGNAL_DOMINANCE,
+  type BotAccountHeuristic,
+} from '../scoring';
 import { BotAccountReportError, runBotAccountDetection } from '../run';
 
 const STARTED = new Date('2026-09-03T03:20:00.000Z');
@@ -602,6 +612,119 @@ describe('the counters that make the heuristics’ own blind spots measurable', 
     expect(result.counters['heuristic:a:fired']).toBe(1);
     expect(result.counters['heuristic:a:sole_signal']).toBe(0);
     expect(result.counters['heuristic:b:sole_signal']).toBe(0);
+  });
+
+  it('🔴 counts a finding a TRACE from another heuristic used to EXCLUDE', async () => {
+    // 🔴 THE COLLISION'S ROUTINE SHAPE, AND THE OLD PREDICATE COULD NOT SEE IT. `sole_signal` was
+    // `exactly one heuristic scored above zero`, which measured a strictly smaller population than
+    // the sentence it was documented with. A member 40 minutes old with 6 parameter-paste comments
+    // in a fingerprint cluster of 6 scores a TRACE on posting-velocity as well — and that trace
+    // excluded the whole finding from the count. An operator reading
+    // `content-templating:sole_signal = 0` concluded the known collision produced no reports, on
+    // the one number the decision about that collision was deferred to.
+    //
+    // The two scores below are EXECUTED against the shipped heuristics, not stipulated: if
+    // `ZERO_AT_PER_HOUR` or `CLUSTER_ZERO_AT` moves, this case moves with it rather than pinning a
+    // number the detector no longer produces.
+    const colliding: BotAccountCohortMember = {
+      userId: 1,
+      username: 'u1',
+      createdAt: new Date(STARTED.getTime() - 40 * 60_000),
+      posts: {
+        all: { comments: 6, models: 0, images: 0, total: 6 },
+        visible: { comments: 6, models: 0, images: 0, total: 6 },
+        excluded: { comments: 0, models: 0, images: 0, total: 0 },
+      },
+      emailDomain: null,
+    };
+    const signals = emptyCohortSignals();
+    signals.fingerprintsByUser.set(1, ['paste']);
+    signals.membersPerFingerprint.set('paste', 6);
+
+    const velocity = postingVelocityHeuristic.score({ member: colliding, now: STARTED, signals });
+    const templating = contentTemplatingHeuristic.score({
+      member: colliding,
+      now: STARTED,
+      signals,
+    });
+    // 6 items in 0.67h is 9/hour, just over the 4/hour floor — a trace, not a finding.
+    expect(velocity).toBeCloseTo(0.1389, 4);
+    expect(templating).toBeCloseTo(0.5, 4);
+    // The property that makes this the collision population rather than a corroborated finding.
+    expect(templating).toBeGreaterThanOrEqual(SOLE_SIGNAL_DOMINANCE * velocity);
+
+    const { reader } = recordingReader([account(1)]);
+    const out = sink();
+    const result = await runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [
+          constantHeuristic(postingVelocityHeuristic.id, velocity),
+          constantHeuristic(registrationClusterHeuristic.id, 0),
+          constantHeuristic(contentTemplatingHeuristic.id, templating),
+        ],
+      },
+      { pageSize: 10, maxAccounts: 10 }
+    );
+
+    // It cleared the threshold, so it is a report a moderator received — the count is over the
+    // REPORTED members and this case has to be inside that population to mean anything.
+    expect(result.findingsReported).toBe(1);
+    // `fired` is what looks ordinary while the collision inflates the board: two heuristics fired.
+    expect(result.counters[`heuristic:${postingVelocityHeuristic.id}:fired`]).toBe(1);
+    expect(result.counters[`heuristic:${contentTemplatingHeuristic.id}:fired`]).toBe(1);
+
+    expect(result.counters[`heuristic:${contentTemplatingHeuristic.id}:sole_signal`]).toBe(1);
+    // The trace itself carried nothing, and must not be counted as though it had.
+    expect(result.counters[`heuristic:${postingVelocityHeuristic.id}:sole_signal`]).toBe(0);
+    expect(result.counters[`heuristic:${registrationClusterHeuristic.id}:sole_signal`]).toBe(0);
+  });
+
+  it('🔴 is blind to REGISTRY ORDER, and counts nobody on a member nothing fired on', async () => {
+    // Two mutants the case above cannot see, both of which inflate the counter in the reassuring
+    // direction — the one direction this number must not fail in, since it is what a decision about
+    // the content-templating collision is deferred to.
+    //
+    // 🔴 ORDER. `subScores` follows the registry order, and the registry is
+    // [velocity, clustering, templating] — so the leading heuristic is routinely the LAST one seen,
+    // and the account's real runner-up is a score that already held the lead. Failing to carry a
+    // displaced leader into the runner-up leaves it at 0, and then EVERY finding looks sole.
+    const { reader } = recordingReader([account(1)]);
+    const out = sink();
+    const ordered = await runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        // Ascending, so the winner arrives last and 0.4 is only ever seen as a displaced leader.
+        // 0.5 is not 3× 0.4, so neither heuristic carried this finding.
+        heuristics: [constantHeuristic('low', 0.4), constantHeuristic('high', 0.5)],
+      },
+      { pageSize: 10, maxAccounts: 10 }
+    );
+    expect(ordered.findingsReported).toBe(1);
+    expect(ordered.counters['heuristic:high:sole_signal']).toBe(0);
+    expect(ordered.counters['heuristic:low:sole_signal']).toBe(0);
+
+    // 🔴 NOTHING FIRED. `minConfidence: 0` reports a member every heuristic scored 0 on, and a
+    // dominance test taken on its own is satisfied by 0 ≥ 3 × 0 — so without the score-above-zero
+    // guard the first heuristic is credited with carrying a finding no heuristic saw anything for.
+    const quiet = recordingReader([account(2)]);
+    const out2 = sink();
+    const silent = await runBotAccountDetection(
+      {
+        reader: quiet.reader,
+        sendReport: out2.sendReport,
+        now: clock(),
+        heuristics: [constantHeuristic('a', 0), constantHeuristic('b', 0)],
+      },
+      { pageSize: 10, maxAccounts: 10, minConfidence: 0 }
+    );
+    expect(silent.findingsReported).toBe(1);
+    expect(silent.counters['heuristic:a:sole_signal']).toBe(0);
+    expect(silent.counters['heuristic:b:sole_signal']).toBe(0);
   });
 
   it('counts only the REPORTED members, not every scored one', async () => {

--- a/src/server/services/bot-account-detection/__tests__/run.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/run.test.ts
@@ -7,7 +7,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbMock, mockNode } from '~/__tests__/mocks';
 import type { CohortReader, NewAccountRow } from '../cohort';
 import { BOT_ACCOUNT_DETECTOR } from '../report';
-import { BOT_ACCOUNT_HEURISTICS, type BotAccountHeuristic } from '../scoring';
+import { BOT_ACCOUNT_HEURISTICS } from '../heuristics';
+import { MIN_REPORTED_CONFIDENCE, type BotAccountHeuristic } from '../scoring';
 import { BotAccountReportError, runBotAccountDetection } from '../run';
 
 const STARTED = new Date('2026-09-03T03:20:00.000Z');
@@ -17,6 +18,9 @@ const account = (id: number): NewAccountRow => ({
   id,
   username: `u${id}`,
   createdAt: new Date('2026-09-03T01:00:00.000Z'),
+  // A distinct domain per account: a shared one would make every fixture a domain cluster and
+  // silently change what the clustering heuristic scores in tests that are about something else.
+  email: `u${id}@u${id}.test`,
 });
 
 /**
@@ -109,6 +113,163 @@ const run = (
     ),
   };
 };
+
+/** A run whose heuristics score each account a value chosen by id, so a case can build an exact
+ *  confidence distribution and then assert what the threshold did to it. */
+const runScoring = (
+  byId: Record<number, number>,
+  overrides: Parameters<typeof runBotAccountDetection>[1] = {}
+) => {
+  const accounts = Object.keys(byId).map((id) => account(Number(id)));
+  const { reader } = recordingReader(accounts);
+  const out = sink();
+  return {
+    ...out,
+    result: runBotAccountDetection(
+      {
+        reader,
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [
+          {
+            id: 'tunable',
+            description: 'test',
+            weight: 1,
+            score: ({ member }) => byId[member.userId] ?? 0,
+            explain: () => null,
+          },
+        ],
+      },
+      { pageSize: 100, maxAccounts: 1_000, ...overrides }
+    ),
+  };
+};
+
+describe('the reporting threshold, end to end', () => {
+  it('🔴 reports only the members above the cut, and COUNTS the rest', async () => {
+    // 🔴 THE FAILURE THIS EXISTS TO PREVENT. `run.ts` turned every cohort member into a finding
+    // with no confidence filter anywhere. With three real heuristics that puts a whole day's
+    // posting cohort on a live moderator board as confidence-0 rows — a board that is mostly noise
+    // on its first day is a board nobody reads on its second.
+    //
+    // Five members, one above the default 0.15 cut. Values overshoot the boundary in both
+    // directions rather than sitting on it.
+    const scenario = runScoring({ 1: 0.02, 2: 0.9, 3: 0, 4: 0.04, 5: 0.31 });
+    const result = await scenario.result;
+
+    expect(result.cohortSize).toBe(5);
+    expect(result.findingsReported).toBe(2);
+    expect(result.findingsSuppressed).toBe(3);
+    expect(result.minConfidence).toBe(MIN_REPORTED_CONFIDENCE);
+    expect(scenario.reports[0].findings.map((f) => f.userId).sort()).toEqual([2, 5]);
+  });
+
+  it('🔴 the suppressed members are still in the distribution counters', async () => {
+    // The counterweight that makes the threshold safe. A member nobody can see is a member nobody
+    // can grade, and grading is the entire purpose of the shadow phase. "2 findings" over a cohort
+    // of 5 is only readable next to the three that scored under the cut.
+    const scenario = runScoring({ 1: 0.02, 2: 0.9, 3: 0, 4: 0.04, 5: 0.31 });
+    await scenario.result;
+    const counters = scenario.reports[0].counters ?? {};
+
+    expect(counters.findings_reported).toBe(2);
+    expect(counters.findings_suppressed).toBe(3);
+    expect(counters.report_min_confidence).toBe(MIN_REPORTED_CONFIDENCE);
+    // Three members under 0.1, one in 0.3-0.4, one in 0.9-1.0.
+    expect(counters['confidence_bucket_0_10']).toBe(3);
+    expect(counters['confidence_bucket_30_40']).toBe(1);
+    expect(counters['confidence_bucket_90_100']).toBe(1);
+    // 🔴 The buckets sum back to the COHORT, not to the findings. That equality is the whole claim:
+    // nothing was dropped between scoring and reporting without being counted.
+    const bucketTotal = Object.entries(counters)
+      .filter(([k]) => k.startsWith('confidence_bucket_'))
+      .reduce((sum, [, v]) => sum + (v as number), 0);
+    expect(bucketTotal).toBe(counters.cohort_size);
+    expect(bucketTotal).toBe(counters.findings_reported + counters.findings_suppressed);
+  });
+
+  it('publishes every bucket on a run where nothing scored, zeros included', async () => {
+    // A counter that appears only in the interesting case cannot be alerted on.
+    const scenario = runScoring({ 1: 0, 2: 0 });
+    await scenario.result;
+    const counters = scenario.reports[0].counters ?? {};
+    const buckets = Object.keys(counters).filter((k) => k.startsWith('confidence_bucket_'));
+    expect(buckets).toHaveLength(10);
+    expect(counters['confidence_bucket_90_100']).toBe(0);
+  });
+
+  it('says what it suppressed in the summary a human reads first', async () => {
+    const scenario = runScoring({ 1: 0.02, 2: 0.9, 3: 0 });
+    await scenario.result;
+    const summary = scenario.reports[0].summary ?? '';
+    expect(summary).toContain('1 scored at or above the 0.15 reporting threshold');
+    expect(summary).toContain('2 scored under it');
+    expect(summary).toContain('NOT reported as findings');
+  });
+
+  it('a threshold of 0 restores the full-cohort run', async () => {
+    const scenario = runScoring({ 1: 0, 2: 0, 3: 0 }, { minConfidence: 0 });
+    const result = await scenario.result;
+    expect(result.findingsReported).toBe(3);
+    expect(result.findingsSuppressed).toBe(0);
+  });
+
+  it('still files an empty report when everything was suppressed', async () => {
+    // "No report today" and "a report with zero findings" look the same to a reader otherwise, and
+    // the first is what a broken producer looks like.
+    const scenario = runScoring({ 1: 0, 2: 0 });
+    const result = await scenario.result;
+    expect(result.reportsSent).toBe(1);
+    expect(scenario.reports[0].findings).toEqual([]);
+    expect(scenario.reports[0].counters?.findings_suppressed).toBe(2);
+  });
+});
+
+describe('the evidence sources are reported, not assumed', () => {
+  it('🔴 a run with NO evidence reader says the ring sources did not run', async () => {
+    // Two of the three heuristics score 0 when their source is missing, which is byte-identical to
+    // scoring 0 because nothing was found. These counters are the only things that tell the two
+    // apart — without them a grading pass averages blind runs in as evidence of no rings.
+    const scenario = run([account(1)]);
+    await scenario.result;
+    const counters = scenario.reports[0].counters ?? {};
+    expect(counters.evidence_registration_ips).toBe(0);
+    expect(counters.evidence_content_budget_exhausted).toBe(0);
+    expect(counters.evidence_members_sampled_for_content).toBe(0);
+  });
+
+  it('reports the sources as present when the reader answered', async () => {
+    const { reader } = recordingReader([account(1), account(2)]);
+    const out = sink();
+    await runBotAccountDetection(
+      {
+        reader,
+        evidence: {
+          hasRegistrationIps: true,
+          listRegistrationIps: async () => [
+            { userId: 1, ip: 'x' },
+            { userId: 2, ip: 'x' },
+          ],
+          listContentSamples: async () => [],
+        },
+        sendReport: out.sendReport,
+        now: clock(),
+        heuristics: [],
+      },
+      { pageSize: 100, maxAccounts: 100, minConfidence: 0 }
+    );
+    const counters = out.reports[0].counters ?? {};
+    expect(counters.evidence_registration_ips).toBe(1);
+    expect(counters.evidence_distinct_registration_ips).toBe(1);
+    expect(counters.evidence_members_sampled_for_content).toBe(2);
+  });
+
+  it('warns in the summary when the IP source was unavailable', async () => {
+    const scenario = run([account(1)]);
+    await scenario.result;
+    expect(scenario.reports[0].summary).toContain('REGISTRATION-IP DATA WAS UNAVAILABLE');
+  });
+});
 
 describe('runBotAccountDetection', () => {
   it('files the cohort as one report when it fits', async () => {
@@ -329,7 +490,16 @@ describe('runBotAccountDetection', () => {
     await expect(
       runBotAccountDetection(
         { reader, sendReport, now: clock(), heuristics: [] },
-        { pageSize: 10, maxAccounts: 10, maxFindingsPerReport: 2 }
+        {
+          pageSize: 10,
+          maxAccounts: 10,
+          maxFindingsPerReport: 2,
+          // 🔴 `heuristics: []` scores every member 0, which the DEFAULT threshold suppresses —
+          // so without this the run produces one empty report and this case silently stops
+          // exercising batching at all. `minConfidence: 0` is the documented full-cohort mode,
+          // and it is what keeps this test about the thing it names rather than about the cut.
+          minConfidence: 0,
+        }
       )
       // A bare rethrow would say "the run failed" and hide that a third of it is already on the
       // board — which is what a reader has to know before retrying, since a retry re-sends under a
@@ -359,7 +529,16 @@ describe('runBotAccountDetection', () => {
             if (checks > 2) throw new Error('Job was canceled');
           },
         },
-        { pageSize: 10, maxAccounts: 10, maxFindingsPerReport: 2 }
+        {
+          pageSize: 10,
+          maxAccounts: 10,
+          maxFindingsPerReport: 2,
+          // 🔴 `heuristics: []` scores every member 0, which the DEFAULT threshold suppresses —
+          // so without this the run produces one empty report and this case silently stops
+          // exercising batching at all. `minConfidence: 0` is the documented full-cohort mode,
+          // and it is what keeps this test about the thing it names rather than about the cut.
+          minConfidence: 0,
+        }
       )
     ).rejects.toThrow('Job was canceled');
     expect(out.sendReport).toHaveBeenCalledTimes(1);
@@ -371,7 +550,16 @@ describe('runBotAccountDetection', () => {
     const log = vi.fn();
     await runBotAccountDetection(
       { reader, sendReport: out.sendReport, now: clock(), heuristics: [], log },
-      { pageSize: 10, maxAccounts: 10, maxFindingsPerReport: 2 }
+      {
+        pageSize: 10,
+        maxAccounts: 10,
+        maxFindingsPerReport: 2,
+        // 🔴 `heuristics: []` scores every member 0, which the DEFAULT threshold suppresses —
+        // so without this the run produces one empty report and this case silently stops
+        // exercising batching at all. `minConfidence: 0` is the documented full-cohort mode,
+        // and it is what keeps this test about the thing it names rather than about the cut.
+        minConfidence: 0,
+      }
     );
     const sent = log.mock.calls.filter(([name]) => name === 'bot-account-detection:report-sent');
     expect(sent.map(([, data]) => data.batch)).toEqual([1, 2, 3]);

--- a/src/server/services/bot-account-detection/__tests__/scoring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/scoring.test.ts
@@ -1,24 +1,52 @@
 import { describe, expect, it } from 'vitest';
-import type { BotAccountCohortMember } from '../cohort';
+import type { BotAccountCohortMember, SurfaceCounts } from '../cohort';
+import { emptyCohortSignals } from '../evidence';
+import { BOT_ACCOUNT_HEURISTICS } from '../heuristics';
 import {
-  BOT_ACCOUNT_HEURISTICS,
+  CONFIDENCE_BUCKETS,
+  MIN_REPORTED_CONFIDENCE,
+  confidenceBucket,
+  confidenceBucketCounters,
+  confidenceBucketKey,
   heuristicCounters,
+  partitionByConfidence,
   placeholderHeuristic,
+  renderNotes,
   renderSubScores,
   scoreAccount,
   type BotAccountEvidence,
   type BotAccountHeuristic,
+  type BotAccountScore,
 } from '../scoring';
 
 const NOW = new Date('2026-09-03T12:00:00.000Z');
 
+const surface = (partial: Partial<SurfaceCounts> = {}): SurfaceCounts => {
+  const row = { comments: 0, models: 0, images: 0, ...partial };
+  return { ...row, total: row.comments + row.models + row.images };
+};
+
+/**
+ * 🔴 THIS FIXTURE WAS THE WRONG SHAPE and nothing caught it. It read
+ * `posts: { comments: 1, models: 0, images: 2, total: 3 }` — the FLAT `SurfaceCounts` that
+ * `PostCounts` stopped being when membership moved onto unfiltered counts. `src/**\/__tests__/**` is
+ * excluded from `tsconfig.json`, so no typecheck ever looked at it, and every assertion in this file
+ * happened to be about blending rather than about `posts`, so nothing read the bad field either. A
+ * fixture that cannot occur in production is a test asserting against a world that does not exist;
+ * corrected here because this change gives `posts` a consumer (`heuristics/velocity.ts`).
+ */
 const member: BotAccountCohortMember = {
   userId: 12,
   username: 'candidate',
   createdAt: new Date('2026-09-03T09:00:00.000Z'),
-  posts: { comments: 1, models: 0, images: 2, total: 3 },
+  posts: {
+    all: surface({ comments: 1, images: 2 }),
+    visible: surface({ comments: 1, images: 2 }),
+    excluded: surface(),
+  },
+  emailDomain: 'example.test',
 };
-const evidence: BotAccountEvidence = { member, now: NOW };
+const evidence: BotAccountEvidence = { member, now: NOW, signals: emptyCohortSignals() };
 
 const heuristic = (
   id: string,
@@ -34,15 +62,40 @@ const heuristic = (
 });
 
 describe('the shipped registry', () => {
-  it('carries only the labelled placeholder — no detection ships in this change', () => {
-    expect(BOT_ACCOUNT_HEURISTICS.map((h) => h.id)).toEqual(['placeholder-no-op']);
-    expect(placeholderHeuristic.description).toMatch(/[Pp]laceholder/);
+  it('🔴 carries the three real heuristics and NOT the placeholder', () => {
+    // The placeholder shipped as the sole registered heuristic and was labelled "delete it in the
+    // change that adds the first real heuristic". This asserts the deletion happened — an asserted
+    // ledger of ids, so it fails if the registry grows (the LLM read is a separate change and must
+    // not arrive unnoticed) as well as if it shrinks.
+    expect(BOT_ACCOUNT_HEURISTICS.map((h) => h.id)).toEqual([
+      'posting-velocity',
+      'registration-cluster',
+      'content-templating',
+    ]);
+    expect(BOT_ACCOUNT_HEURISTICS.map((h) => h.id)).not.toContain('placeholder-no-op');
   });
 
-  it('scores every account 0, so nothing here is a calibration', () => {
+  it('weights them equally, so the blend is a plain mean of three opinions', () => {
+    // Load-bearing for the threshold's reasoning: `MIN_REPORTED_CONFIDENCE` is derived from
+    // "one of three equally-weighted heuristics at 0.45". A re-weighting that left the threshold
+    // alone would silently change what the threshold admits, and this is what makes that a
+    // deliberate edit with a failing test attached.
+    expect([...new Set(BOT_ACCOUNT_HEURISTICS.map((h) => h.weight))]).toEqual([1]);
+  });
+
+  it('every registered heuristic describes itself for the humans reading a report', () => {
+    for (const h of BOT_ACCOUNT_HEURISTICS) {
+      expect(h.description.length, `${h.id} has no description`).toBeGreaterThan(40);
+      // The id is a metric key and a counters namespace — a colon in it would read ambiguously
+      // against the `heuristic:<id>:fired` keys it becomes.
+      expect(h.id, `${h.id} is not an identifier`).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it('the placeholder is still inert, and is kept only for these tests', () => {
     expect(placeholderHeuristic.score(evidence)).toBe(0);
     expect(placeholderHeuristic.explain(evidence, 0)).toBeNull();
-    expect(scoreAccount(BOT_ACCOUNT_HEURISTICS, evidence).confidence).toBe(0);
+    expect(scoreAccount([placeholderHeuristic], evidence).confidence).toBe(0);
   });
 });
 
@@ -135,6 +188,151 @@ describe('heuristicCounters', () => {
 
   it('is empty for a run with no accounts', () => {
     expect(heuristicCounters([])).toEqual({});
+  });
+});
+
+describe('renderNotes', () => {
+  it('names the heuristic beside its own clause', () => {
+    // 🔴 The notes were collected into `HeuristicScore.note` and then never rendered — the reason
+    // string carried `id=0.00` and no statement of what anything SAW. Invisible while the only
+    // heuristic was a placeholder whose note was always null.
+    expect(
+      renderNotes([
+        { id: 'a', score: 0.5, weight: 1, note: 'saw three things', clamped: false },
+        { id: 'b', score: 0.2, weight: 1, note: 'saw a fourth', clamped: false },
+      ])
+    ).toBe('a: saw three things | b: saw a fourth');
+  });
+
+  it('omits a heuristic that said nothing, rather than rendering an empty clause', () => {
+    expect(
+      renderNotes([
+        { id: 'a', score: 0.5, weight: 1, note: 'saw three things', clamped: false },
+        { id: 'quiet', score: 0, weight: 1, note: null, clamped: false },
+      ])
+    ).toBe('a: saw three things');
+  });
+
+  it('returns null when nothing fired, so the caller can drop the clause entirely', () => {
+    expect(renderNotes([{ id: 'a', score: 0, weight: 1, note: null, clamped: false }])).toBeNull();
+    expect(renderNotes([])).toBeNull();
+  });
+});
+
+const scored = (userId: number, confidence: number): BotAccountScore => ({
+  userId,
+  confidence,
+  subScores: [],
+});
+
+describe('the reporting threshold', () => {
+  it('🔴 defaults to a value derived from the blend arithmetic, not an intuition', () => {
+    // With three equal weights the blend is their mean, so 0.15 admits ONE heuristic at ~0.45 and
+    // rejects an account where every signal is weak. Pinned because the number is the whole
+    // difference between a usable board and a board nobody reads on its second day.
+    expect(MIN_REPORTED_CONFIDENCE).toBe(0.15);
+    // One heuristic fully convinced blends to 1/3 — comfortably reported.
+    expect(1 / BOT_ACCOUNT_HEURISTICS.length).toBeGreaterThan(MIN_REPORTED_CONFIDENCE);
+    // One heuristic at 0.4 blends to 0.133 — below the cut. So the threshold genuinely bites
+    // somewhere a single moderate signal lives, rather than being decorative.
+    expect(0.4 / BOT_ACCOUNT_HEURISTICS.length).toBeLessThan(MIN_REPORTED_CONFIDENCE);
+  });
+
+  it('reports a score EXACTLY at the threshold', () => {
+    // `>=`, or the constant's own name is a lie — a "minimum reported confidence" that is not
+    // itself reported. The off-by-one would be invisible in the counters.
+    const { reported, suppressed } = partitionByConfidence([scored(1, 0.15)], 0.15);
+    expect(reported.map((s) => s.userId)).toEqual([1]);
+    expect(suppressed).toEqual([]);
+  });
+
+  it('suppresses below and reports above, and returns BOTH halves', () => {
+    // Values deliberately overshoot the boundary in both directions rather than sitting on it —
+    // 0.02 and 0.9 against a 0.15 cut — so a mutant flipping the comparison, or moving the cut by
+    // a step, cannot land on this expectation.
+    const { reported, suppressed } = partitionByConfidence(
+      [scored(1, 0.02), scored(2, 0.9), scored(3, 0.14), scored(4, 0.31)],
+      0.15
+    );
+    expect(reported.map((s) => s.userId)).toEqual([2, 4]);
+    // 🔴 The suppressed half comes back rather than being dropped: the caller needs to COUNT it.
+    // A member nobody can see is a member nobody can grade.
+    expect(suppressed.map((s) => s.userId)).toEqual([1, 3]);
+  });
+
+  it('a threshold of 0 reports everything — the deliberate full-cohort grading run', () => {
+    const { reported, suppressed } = partitionByConfidence([scored(1, 0), scored(2, 0.5)], 0);
+    expect(reported).toHaveLength(2);
+    expect(suppressed).toHaveLength(0);
+  });
+});
+
+describe('the confidence distribution', () => {
+  it('buckets by tenths, half-open', () => {
+    expect(confidenceBucket(0)).toBe(0);
+    expect(confidenceBucket(0.099)).toBe(0);
+    expect(confidenceBucket(0.1)).toBe(1);
+    expect(confidenceBucket(0.55)).toBe(5);
+    expect(confidenceBucket(0.9)).toBe(9);
+  });
+
+  it('🔴 puts 1.0 in the TOP bucket rather than inventing an eleventh', () => {
+    // A naive `floor(c * 10)` gives 10 for a perfect score — a bucket with no key, so the most
+    // interesting accounts in the run vanish from the distribution and the buckets stop summing to
+    // the number scored. That is a silent loss of exactly the rows a grading pass wants.
+    expect(confidenceBucket(1)).toBe(CONFIDENCE_BUCKETS - 1);
+    expect(confidenceBucketKey(confidenceBucket(1))).toBe('confidence_bucket_90_100');
+  });
+
+  it('names each bucket in percent, so the key is an identifier', () => {
+    expect(confidenceBucketKey(0)).toBe('confidence_bucket_0_10');
+    expect(confidenceBucketKey(9)).toBe('confidence_bucket_90_100');
+    // The wire contract caps a counter key at 64 characters.
+    for (let i = 0; i < CONFIDENCE_BUCKETS; i += 1)
+      expect(confidenceBucketKey(i).length).toBeLessThanOrEqual(64);
+  });
+
+  it('🔴 counts EVERY scored member, suppressed ones included', () => {
+    // The whole point of the distribution: it is the counterweight that makes the threshold safe.
+    // Four of these five are below the default cut and would appear nowhere else in the report.
+    const counters = confidenceBucketCounters([
+      scored(1, 0),
+      scored(2, 0.02),
+      scored(3, 0.05),
+      scored(4, 0.07),
+      scored(5, 0.94),
+    ]);
+    expect(counters['confidence_bucket_0_10']).toBe(4);
+    expect(counters['confidence_bucket_90_100']).toBe(1);
+    // Every bucket sums back to the population — nothing was dropped on the way in.
+    const total = Object.values(counters).reduce((a, b) => a + b, 0);
+    expect(total).toBe(5);
+  });
+
+  it('publishes every bucket including the empty ones, on a run with no accounts', () => {
+    // A counter that appears only when non-zero cannot be charted or alerted on: its absence is
+    // indistinguishable from the producer not having run.
+    const counters = confidenceBucketCounters([]);
+    expect(Object.keys(counters)).toHaveLength(CONFIDENCE_BUCKETS);
+    expect(Object.values(counters).every((v) => v === 0)).toBe(true);
+  });
+
+  it('does not lose a non-finite score out of the distribution', () => {
+    // `scoreAccount` clamps, so these should be unreachable — which is exactly why they are pinned:
+    // an unreachable value that silently vanishes is how a bucket total stops matching the cohort.
+    //
+    // 🔴 `Infinity` GOES TO THE BOTTOM BUCKET, NOT THE TOP, and that is the same rule `clampScore`
+    // states one layer up: a non-finite score is a DEFECT in a heuristic — a divide by zero, an
+    // empty denominator — not a maximal opinion about the account. Bucketing it high would put a
+    // top-confidence-looking row in the distribution on the strength of a bug, in the one direction
+    // a shadow-mode detector must not fail in. Written the other way round first; the code was
+    // right and the expectation was wrong.
+    expect(confidenceBucket(Number.NaN)).toBe(0);
+    expect(confidenceBucket(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(confidenceBucket(-1)).toBe(0);
+    // A finite over-1 value still clamps UP, because that is an in-range opinion expressed badly
+    // rather than a defect — the same asymmetry `clampScore` draws.
+    expect(confidenceBucket(4.2)).toBe(CONFIDENCE_BUCKETS - 1);
   });
 });
 

--- a/src/server/services/bot-account-detection/cohort.ts
+++ b/src/server/services/bot-account-detection/cohort.ts
@@ -73,6 +73,13 @@ export type NewAccountRow = {
   id: number;
   username: string | null;
   createdAt: Date;
+  /**
+   * 🔴 THE ONLY PLACE A FULL EMAIL ADDRESS EXISTS IN THIS DETECTOR, and it does not survive
+   * `selectCohortMembers`. The registration-cluster heuristic needs the DOMAIN and nothing else, so
+   * the local part is dropped at the first pure step rather than carried through scoring into a
+   * reason string that a moderator board stores. See `normalizeEmailDomain`.
+   */
+  email: string | null;
 };
 
 /** Per-user counts from one content table. */
@@ -131,6 +138,11 @@ export type BotAccountCohortMember = {
   username: string | null;
   createdAt: Date;
   posts: PostCounts;
+  /**
+   * The lowercased domain of the registration email, or `null` when the account has no email or the
+   * address has no parseable domain. NOT the address — see `NewAccountRow.email`.
+   */
+  emailDomain: string | null;
 };
 
 /**
@@ -203,10 +215,46 @@ export function newAccountPageArgs(args: {
       bannedAt: null,
       deletedAt: null,
     },
-    select: { id: true, username: true, createdAt: true },
+    // 🔴 `email` is selected for the registration-cluster heuristic and for nothing else. It is
+    // reduced to its domain in `selectCohortMembers`, which is the last point at which the address
+    // exists — no scored object, counter, note or reason string can carry it. Selecting it here
+    // rather than in a second query is what keeps the operation ledger at the same five reads:
+    // widening a `select` adds no database operation.
+    select: { id: true, username: true, createdAt: true, email: true },
     orderBy: { id: 'desc' },
     take: args.take,
   } as const;
+}
+
+/**
+ * The domain half of an email address, lowercased — or `null` when there is not one.
+ *
+ * 🔴 THE RETURN VALUE IS THE WHOLE PRIVACY BOUNDARY. Everything downstream of this function sees a
+ * domain; nothing downstream can reconstruct the address. That is why the reduction happens in the
+ * pure selector rather than inside the heuristic that consumes it — a heuristic is the wrong place
+ * for a rule about what the rest of the system is allowed to hold.
+ *
+ * Deliberately strict about what counts as a domain, because the value becomes a CLUSTER KEY: two
+ * accounts are called related when their keys are equal, so a permissive parse that maps several
+ * malformed addresses onto one key manufactures a ring out of bad data. An address with no `@`,
+ * nothing after the last `@`, no dot in the domain, or whitespace in it yields `null` — which the
+ * heuristic reads as "no signal", never as a cluster.
+ *
+ * The LAST `@` is the split point: local parts may legally contain `@` inside quotes, domains may
+ * not contain one at all.
+ */
+export function normalizeEmailDomain(email: string | null): string | null {
+  if (!email) return null;
+  const at = email.lastIndexOf('@');
+  if (at < 0) return null;
+  const domain = email
+    .slice(at + 1)
+    .trim()
+    .toLowerCase();
+  // A domain with no dot is not a domain a registration can have come from, and a domain with
+  // internal whitespace is not one at all.
+  if (!domain || !domain.includes('.') || /\s/.test(domain)) return null;
+  return domain;
 }
 
 /**
@@ -511,6 +559,8 @@ export function selectCohortMembers(
       username: account.username,
       createdAt: account.createdAt,
       posts,
+      // The address is reduced here and never stored. See `normalizeEmailDomain`.
+      emailDomain: normalizeEmailDomain(account.email),
     });
   }
   return members;

--- a/src/server/services/bot-account-detection/evidence.ts
+++ b/src/server/services/bot-account-detection/evidence.ts
@@ -1,0 +1,483 @@
+import { clickhouse } from '~/server/clickhouse/client';
+import { dbRead } from '~/server/db/client';
+import type { BotAccountCohortMember } from './cohort';
+
+/**
+ * The COHORT-LEVEL evidence: the things that are only visible by looking at the whole day's signups
+ * at once, rather than at one account.
+ *
+ * 🔴 WHY THIS FILE EXISTS AT ALL. Two of the three heuristics are ring detectors — "how many OTHER
+ * new accounts registered on this IP", "how many OTHER new accounts posted this text" — and a
+ * per-account scoring function cannot answer either. Scoring one account at a time is exactly what
+ * misses a coordinated wave, which is the case the operator named as the reason for the clustering
+ * heuristic. So the cohort is indexed ONCE per run, and each heuristic reads its member's entry out
+ * of a precomputed index rather than issuing a query of its own.
+ *
+ * That split is also what keeps the heuristics testable: every scoring function in `heuristics/` is
+ * pure over `CohortSignals`, and the only IO lives here.
+ *
+ * 🔴 THIS MODULE READS, AND THAT IS ALL IT CAN DO. Its Postgres surface is the two-method structural
+ * port `EvidenceDb` below — two `findMany` calls, no write method — and its ClickHouse surface is a
+ * single `$query`. Both are asserted as ledgers in `__tests__/no-write-surface.test.ts`, which also
+ * pins that every ClickHouse statement in this module is a bare `SELECT`. The operation ledger there
+ * anchors on a `db` handle and therefore CANNOT see a ClickHouse call at all — that is precisely why
+ * the ClickHouse ledger is a separate assertion rather than an assumed extension of the first.
+ */
+
+/**
+ * The most content rows one run will read, across every account and both comment surfaces.
+ *
+ * 🔴 A BUDGET, NOT A PER-QUERY LIMIT, and the distinction is the whole point. The cohort is bounded
+ * only by `MAX_COHORT_ACCOUNTS`, and a wave day is exactly when it approaches that; a per-query cap
+ * multiplied by a page count is not a bound on anything. This is decremented as chunks are read and
+ * the walk stops when it is gone, so the worst case is fixed no matter how large the cohort gets.
+ *
+ * The cohort arrives NEWEST FIRST (see `cohort.ts`), so a budget that runs out spends itself on the
+ * most recent signups and abandons the oldest — the same direction the account walk truncates in,
+ * for the same reason. `content_budget_exhausted` says when that happened; without it a partially
+ * sampled run is indistinguishable from a cohort that simply posted less.
+ */
+export const MAX_CONTENT_SAMPLES = 5_000;
+
+/** How many accounts' ids go into one `IN (…)` list. Matches the cohort's own page size so the two
+ *  walks put the same width of list in front of the planner. */
+export const EVIDENCE_CHUNK_SIZE = 500;
+
+/**
+ * How much of one comment is kept.
+ *
+ * Templated shill text is identical from its first words; the tail is padding. Truncating on receipt
+ * bounds the memory a run holds to `MAX_CONTENT_SAMPLES × this` regardless of how long a single
+ * comment is, and it bounds the fingerprint keys the index is built out of.
+ *
+ * 🔴 IT IS APPLIED BEFORE NORMALISATION, so two texts that differ only past this point fingerprint
+ * IDENTICALLY. That is a deliberate widening of what counts as "the same text" and it is stated
+ * because it can produce a false cluster: a long shared quotation with different endings collides.
+ * The alternative — truncating after normalisation — has the same property one step later.
+ */
+export const MAX_CONTENT_CHARS = 512;
+
+/** One account's registration, as ClickHouse recorded it. */
+export type RegistrationIpRow = { userId: number; ip: string };
+
+/** One piece of text an account posted. */
+export type ContentSampleRow = { userId: number; content: string };
+
+/**
+ * The Postgres slice this module is allowed to use: two reads, no write method, nothing to widen.
+ *
+ * Written structurally rather than as `typeof dbRead` for the reason `cohort.ts` gives at length —
+ * naming the read handle buys convention, not reachability, because `dbRead` and `dbWrite` are the
+ * same object wherever the replica URL equals the primary's. A type with no write method on it is
+ * what actually holds the property.
+ */
+export type EvidenceDb = {
+  comment: {
+    findMany: (args: ReturnType<typeof contentSampleArgs>) => Promise<ContentSampleRow[]>;
+  };
+  commentV2: {
+    findMany: (args: ReturnType<typeof contentSampleArgs>) => Promise<ContentSampleRow[]>;
+  };
+};
+
+/**
+ * The ClickHouse slice: one method, which takes SQL and returns rows.
+ *
+ * 🔴 IT IS OPTIONAL BECAUSE THE REAL CLIENT IS. `~/server/clickhouse/client` exports
+ * `clickhouse: CustomClickHouseClient | undefined` — it is `undefined` whenever `CLICKHOUSE_HOST` or
+ * `CLICKHOUSE_USERNAME` is unset, and during a Next build. A detector that assumed it existed would
+ * throw on those deployments; one that caught the error and moved on would report a clean run with a
+ * silently dead heuristic, which is worse. So absence is a FIRST-CLASS STATE carried on
+ * `CohortSignals.sources` and reported as a counter — see `collectCohortSignals`.
+ */
+/**
+ * 🔴 THE `T extends object` CONSTRAINT MIRRORS THE REAL CLIENT AND IS NOT DECORATION. The shipped
+ * `$query` is `<T extends object>(query: TemplateStringsArray | string, …values) => Promise<T[]>`;
+ * a port declaring plain `<T>` is a DIFFERENT generic signature, so the real client is not assignable
+ * to it and the union of the two is not callable at all. Narrowing the parameter to `string` is safe
+ * in the other direction — a function accepting more shapes is assignable to one accepting fewer —
+ * and it removes the tagged-template form this module deliberately does not use.
+ */
+export type EvidenceClickhouse = { $query: <T extends object>(sql: string) => Promise<T[]> };
+
+export type EvidenceReader = {
+  /** Registration IPs for exactly these accounts. Empty when ClickHouse is unavailable. */
+  listRegistrationIps(userIds: number[]): Promise<RegistrationIpRow[]>;
+  /** Up to `take` recent comments across both comment surfaces, for exactly these accounts. */
+  listContentSamples(userIds: number[], take: number): Promise<ContentSampleRow[]>;
+  /** Whether a registration-IP read can happen at all. `false` means the source is missing, NOT
+   *  that the accounts share no IP. */
+  hasRegistrationIps: boolean;
+};
+
+/**
+ * The `findMany` arguments for one chunk of accounts' comments.
+ *
+ * Exported and built apart from the call for the reason `newAccountPageArgs` is: this is the part
+ * with behaviour, and asserting it is how "reads the right columns, newest first, bounded" becomes
+ * testable without a database.
+ *
+ * 🔴 `orderBy: { id: 'desc' }` is load-bearing, not decoration. The `take` bounds a chunk, so the
+ * order decides WHICH comments a bounded read keeps — and the newest are the ones a wave is made of.
+ * Ascending would spend the budget on whatever the chunk's accounts happened to post first.
+ *
+ * Only `userId` and `content` are selected. Nothing else is needed to fingerprint text, and a
+ * comment's `id`, thread and timestamps would only widen what this module holds in memory.
+ */
+export function contentSampleArgs(userIds: number[], take: number) {
+  return {
+    where: { userId: { in: userIds } },
+    select: { userId: true, content: true },
+    orderBy: { id: 'desc' },
+    take,
+  } as const;
+}
+
+/**
+ * The registration-IP query.
+ *
+ * Built as a separate exported function so the SQL is a value a test can assert on, rather than a
+ * string buried in a call — the ClickHouse ledger in `__tests__/no-write-surface.test.ts` reads it
+ * and pins that it is a bare `SELECT`.
+ *
+ * 🔴 `targetUserId`, NOT `userId`, AND THE TWO ARE NOT INTERCHANGEABLE. `Tracker.userActivity` writes
+ * the account the event is ABOUT into `targetUserId`; a `Registration` event has no signed-in actor,
+ * so the `userId` provenance column is not the new account. `apps/moderator/src/lib/server/bulk-ban.service.ts`
+ * — the ban-evasion queries this heuristic is adapted from — reads `targetUserId` for exactly this
+ * reason. (`csam.service.ts` filters the same table on `userId`; that is a different question about
+ * a signed-in user's own activity, and copying its predicate here would silently return nothing.)
+ *
+ * 🔴 IDS ARE RE-VALIDATED AS INTEGERS AT THE JOIN, not trusted for having come from the database.
+ * This is string-interpolated SQL — the ClickHouse client takes no bound parameters here — so the
+ * only thing standing between a value and the statement is this filter. It is cheap and it is the
+ * kind of guard that is correct until someone routes a different id source into it.
+ *
+ * `GROUP BY` rather than a plain select: an account can have several registration rows, and the
+ * heuristic wants distinct (account, ip) pairs, not a row count. `LIMIT` bounds a pathological
+ * chunk — an account with thousands of recorded registration events cannot flood the result.
+ */
+export function registrationIpSql(userIds: number[]): string {
+  const ids = userIds.filter((n) => Number.isInteger(n) && n > 0);
+  if (!ids.length) return '';
+  return `
+    SELECT targetUserId, ip
+    FROM default.userActivities
+    WHERE targetUserId IN (${ids.join(',')})
+      AND type = 'Registration'
+    GROUP BY targetUserId, ip
+    LIMIT ${ids.length * 4}
+  `;
+}
+
+/** The real reader: Postgres over the replica, ClickHouse where it exists. */
+export function createEvidenceReader(
+  deps: { db?: EvidenceDb; ch?: EvidenceClickhouse | null } = {}
+): EvidenceReader {
+  const db = deps.db ?? dbRead;
+  // `deps.ch` may be explicitly `null` to model an unavailable client in a test; `undefined` falls
+  // back to the real one, which is itself possibly `undefined`.
+  // Annotated rather than inferred: without it the ternary widens to a UNION of the port and the
+  // real client's own type, and a union of two generic call signatures is not callable — the error
+  // lands on the `$query` call below and names it "not callable", which reads as a defect in the
+  // client rather than in this line.
+  const ch: EvidenceClickhouse | null = deps.ch === undefined ? clickhouse ?? null : deps.ch;
+
+  return {
+    hasRegistrationIps: ch !== null,
+    listRegistrationIps: async (userIds) => {
+      const sql = registrationIpSql(userIds);
+      if (!ch || !sql) return [];
+      const rows = await ch.$query<{ targetUserId: string | number; ip: string }>(sql);
+      // ClickHouse returns integers as strings over HTTP JSON; `Number` on an already-numeric value
+      // is a no-op, so this covers both without asking which one arrived.
+      return rows
+        .map((r) => ({ userId: Number(r.targetUserId), ip: r.ip }))
+        .filter((r) => Number.isFinite(r.userId) && !!r.ip);
+    },
+    listContentSamples: async (userIds, take) => {
+      if (!userIds.length || take <= 0) return [];
+      const [comments, commentsV2] = await Promise.all([
+        db.comment.findMany(contentSampleArgs(userIds, take)),
+        db.commentV2.findMany(contentSampleArgs(userIds, take)),
+      ]);
+      return [...comments, ...commentsV2];
+    },
+  };
+}
+
+/**
+ * Text reduced to the shape a templating check compares.
+ *
+ * 🔴 THE MASKING IS THE DETECTION. An exact-match check over raw text finds only literal copy-paste,
+ * and a shill ring's whole method is one template with the payload swapped — the link, the referral
+ * code, the amount. Replacing links and digit runs with placeholders BEFORE comparing is what turns
+ * "check out mysite.example/a" and "check out mysite.example/b" into one fingerprint, and it is the
+ * only part of this heuristic that is not simply string equality.
+ *
+ * 🔴 IT IS ALSO WHERE THE FALSE POSITIVES COME FROM, and pretending otherwise would be the
+ * comfortable lie. Masking numbers means "I got 5 buzz" and "I got 900 buzz" collide, which is
+ * correct for a payout ring and wrong for two people saying an ordinary thing. `MIN_FINGERPRINT_CHARS`
+ * and `MIN_FINGERPRINT_TOKENS` below are the whole defence against that, they are set by judgement
+ * rather than by measurement, and the shadow phase exists to replace that judgement with a number.
+ *
+ * Order matters: links are masked first, because a URL contains the punctuation and digits the later
+ * steps would otherwise chew through and turn into an unrecognisable token. The placeholders are
+ * bare words rather than bracketed markers so the punctuation strip cannot destroy them.
+ */
+export function normalizeContent(raw: string): string {
+  return (
+    raw
+      .slice(0, MAX_CONTENT_CHARS)
+      .toLowerCase()
+      .replace(/https?:\/\/\S+|www\.\S+/g, ' linkmask ')
+      .replace(/\d+/g, ' nummask ')
+      // Everything that is not a letter, a digit or a space. Emoji, punctuation and the zero-width
+      // characters spam text is padded with all go, so a template survives being decorated.
+      .replace(/[^a-z0-9\s]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+/**
+ * The shortest normalised text that may act as a cluster key.
+ *
+ * 🔴 A SHORT STRING IS NOT EVIDENCE OF ANYTHING. "thanks", "nice work", "great model" are written
+ * independently by unrelated people every hour, and without a floor they would cluster a day's
+ * politest new accounts into a fake ring — the single most likely way this heuristic fires on the
+ * innocent. Both a character floor and a token floor, because either alone is walkable: one long
+ * word clears the character floor, and four one-letter words clear the token floor.
+ */
+export const MIN_FINGERPRINT_CHARS = 24;
+export const MIN_FINGERPRINT_TOKENS = 4;
+
+/**
+ * The cluster key for one piece of text, or `null` when the text is too slight to be one.
+ *
+ * Returning `null` rather than a key is the honest encoding: the alternative — a key that simply
+ * matches rarely — still clusters whenever it does match, and the whole point is that these texts
+ * must never cluster at all.
+ */
+export function contentFingerprint(raw: string): string | null {
+  const normalized = normalizeContent(raw);
+  if (normalized.length < MIN_FINGERPRINT_CHARS) return null;
+  if (normalized.split(' ').filter(Boolean).length < MIN_FINGERPRINT_TOKENS) return null;
+  return normalized;
+}
+
+/**
+ * Everything the cohort-level heuristics read, indexed once per run.
+ *
+ * 🔴 EVERY COUNT HERE IS A COUNT OF DISTINCT ACCOUNTS, never of rows. One account pasting the same
+ * text ninety times is one member of that fingerprint's set, not ninety — otherwise a single
+ * prolific spammer manufactures a ring out of itself and every other heuristic's independence is
+ * lost. The same holds for IPs and domains. The sets are built with `Set`s for that reason and the
+ * public shape exposes sizes rather than lists.
+ */
+export type CohortSignals = {
+  /** userId → the registration IPs recorded for it. Absent means no row, or no ClickHouse. */
+  ipsByUser: Map<number, string[]>;
+  /** ip → how many DISTINCT cohort members registered on it. */
+  membersPerIp: Map<string, number>;
+  /** emailDomain → how many DISTINCT cohort members carry it. */
+  membersPerDomain: Map<string, number>;
+  /** userId → the content fingerprints it produced. */
+  fingerprintsByUser: Map<number, string[]>;
+  /** fingerprint → how many DISTINCT cohort members produced it. */
+  membersPerFingerprint: Map<string, number>;
+  /**
+   * 🔴 WHICH SOURCES ACTUALLY ANSWERED. A heuristic reading an empty index cannot tell "these
+   * accounts share nothing" from "nobody asked" — and the two call for opposite conclusions. Every
+   * consumer of this type is expected to branch on these before reading a zero as a signal.
+   */
+  sources: {
+    /** ClickHouse was reachable and the registration-IP read ran. */
+    registrationIps: boolean;
+    /** The content budget was spent before the whole cohort was sampled. */
+    contentBudgetExhausted: boolean;
+    /** How many members had content sampled at all. The denominator for the similarity heuristic. */
+    membersSampledForContent: number;
+  };
+};
+
+/** An index over nothing: the shape every map has before a run, and what a zero-member cohort
+ *  yields. Sources default to "did not run", which is the safe reading. */
+export function emptyCohortSignals(): CohortSignals {
+  return {
+    ipsByUser: new Map(),
+    membersPerIp: new Map(),
+    membersPerDomain: new Map(),
+    fingerprintsByUser: new Map(),
+    membersPerFingerprint: new Map(),
+    sources: {
+      registrationIps: false,
+      contentBudgetExhausted: false,
+      membersSampledForContent: 0,
+    },
+  };
+}
+
+/** Fixed-size slices of an id list, in order. */
+export function chunk<T>(items: T[], size: number): T[][] {
+  if (size < 1) throw new Error(`chunk size must be >= 1, got ${size}`);
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Fold the raw reads into the indexes, PURELY.
+ *
+ * Separated from the IO above because this is the half with the arithmetic in it — the distinct-account
+ * counting, the fingerprinting, the domain tally — and it is the half worth testing exhaustively.
+ * `collectCohortSignals` is then a loop that fetches and calls this.
+ *
+ * 🔴 THE DOMAIN TALLY IS BUILT FROM THE MEMBERS, NOT FROM A QUERY. `emailDomain` already rode in on
+ * every cohort member, so the domain half of the clustering heuristic costs ZERO additional reads.
+ * That is worth saying plainly: of the two signals in that heuristic, one is free and one needs
+ * ClickHouse, so the heuristic keeps working — at reduced power, and it says so — when ClickHouse
+ * does not.
+ */
+export function buildCohortSignals(args: {
+  members: BotAccountCohortMember[];
+  registrationIps: RegistrationIpRow[];
+  contentSamples: ContentSampleRow[];
+  sources: CohortSignals['sources'];
+}): CohortSignals {
+  const signals = emptyCohortSignals();
+  signals.sources = args.sources;
+
+  // Only accounts that are actually IN the cohort may contribute to a cluster count. A registration
+  // row for an id outside it — a banned account ClickHouse still remembers, a stale row — would
+  // otherwise inflate an IP's tally without ever being scored.
+  const inCohort = new Set(args.members.map((m) => m.userId));
+
+  const ipMembers = new Map<string, Set<number>>();
+  for (const row of args.registrationIps) {
+    if (!inCohort.has(row.userId)) continue;
+    const ips = signals.ipsByUser.get(row.userId);
+    if (ips) {
+      if (!ips.includes(row.ip)) ips.push(row.ip);
+    } else signals.ipsByUser.set(row.userId, [row.ip]);
+    let members = ipMembers.get(row.ip);
+    if (!members) ipMembers.set(row.ip, (members = new Set()));
+    members.add(row.userId);
+  }
+  for (const [ip, members] of ipMembers) signals.membersPerIp.set(ip, members.size);
+
+  const domainMembers = new Map<string, Set<number>>();
+  for (const member of args.members) {
+    if (!member.emailDomain) continue;
+    let members = domainMembers.get(member.emailDomain);
+    if (!members) domainMembers.set(member.emailDomain, (members = new Set()));
+    members.add(member.userId);
+  }
+  for (const [domain, members] of domainMembers) signals.membersPerDomain.set(domain, members.size);
+
+  const fingerprintMembers = new Map<string, Set<number>>();
+  for (const sample of args.contentSamples) {
+    if (!inCohort.has(sample.userId)) continue;
+    const fingerprint = contentFingerprint(sample.content);
+    if (!fingerprint) continue;
+    const owned = signals.fingerprintsByUser.get(sample.userId);
+    if (owned) {
+      if (!owned.includes(fingerprint)) owned.push(fingerprint);
+    } else signals.fingerprintsByUser.set(sample.userId, [fingerprint]);
+    let members = fingerprintMembers.get(fingerprint);
+    if (!members) fingerprintMembers.set(fingerprint, (members = new Set()));
+    members.add(sample.userId);
+  }
+  for (const [fingerprint, members] of fingerprintMembers)
+    signals.membersPerFingerprint.set(fingerprint, members.size);
+
+  return signals;
+}
+
+/**
+ * Read every cohort-level source and index the result.
+ *
+ * 🔴 A FAILING SOURCE DEGRADES THE RUN, IT DOES NOT FAIL IT — and it is recorded, which is the half
+ * that matters. A ClickHouse outage must not lose a day of the cheap heuristics; it must also never
+ * look like a day on which no accounts shared an IP. So the read is guarded, the flag on
+ * `sources.registrationIps` carries the outcome, and `run.ts` turns it into a counter that a grading
+ * pass can filter on. A run whose IP data was missing is not comparable with one whose was there,
+ * and this flag is the only thing that says which kind you are looking at.
+ *
+ * The content walk is a BUDGET, not a per-chunk cap — see `MAX_CONTENT_SAMPLES`.
+ */
+export async function collectCohortSignals(
+  reader: EvidenceReader,
+  members: BotAccountCohortMember[],
+  opts: {
+    chunkSize?: number;
+    maxContentSamples?: number;
+    checkCanceled?: () => void;
+    log?: (name: string, data: Record<string, unknown>) => void;
+  } = {}
+): Promise<CohortSignals> {
+  const chunkSize = opts.chunkSize ?? EVIDENCE_CHUNK_SIZE;
+  const budgetTotal = opts.maxContentSamples ?? MAX_CONTENT_SAMPLES;
+  const checkCanceled = opts.checkCanceled ?? (() => undefined);
+  const log = opts.log ?? (() => undefined);
+
+  if (!members.length) return emptyCohortSignals();
+
+  const chunks = chunk(
+    members.map((m) => m.userId),
+    chunkSize
+  );
+
+  const registrationIps: RegistrationIpRow[] = [];
+  let ipsRead = reader.hasRegistrationIps;
+  if (ipsRead) {
+    for (const ids of chunks) {
+      checkCanceled();
+      try {
+        registrationIps.push(...(await reader.listRegistrationIps(ids)));
+      } catch (e) {
+        // One failed chunk invalidates the IP signal for the WHOLE run, not just for its own
+        // accounts: a cluster count built from a partial read UNDERSTATES every ring that straddles
+        // the missing chunk, and understating is the direction that produces a confident zero. So
+        // the partial data is discarded rather than scored.
+        log('bot-account-detection:registration-ips-failed', {
+          chunkIds: ids.length,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        registrationIps.length = 0;
+        ipsRead = false;
+        break;
+      }
+    }
+  }
+
+  const contentSamples: ContentSampleRow[] = [];
+  let budget = budgetTotal;
+  let budgetExhausted = false;
+  let membersSampled = 0;
+  for (const ids of chunks) {
+    checkCanceled();
+    if (budget <= 0) {
+      budgetExhausted = true;
+      break;
+    }
+    // The per-surface `take` is the remaining budget, so one chunk can never consume more than what
+    // is left; `listContentSamples` reads two surfaces, so the actual return can be up to twice it.
+    // Bounding the SPEND rather than the take is what keeps the total fixed.
+    const rows = await reader.listContentSamples(ids, Math.min(budget, chunkSize * 2));
+    membersSampled += ids.length;
+    budget -= rows.length;
+    contentSamples.push(...rows);
+  }
+  if (budget <= 0 && membersSampled < members.length) budgetExhausted = true;
+
+  return buildCohortSignals({
+    members,
+    registrationIps,
+    contentSamples,
+    sources: {
+      registrationIps: ipsRead,
+      contentBudgetExhausted: budgetExhausted,
+      membersSampledForContent: Math.min(membersSampled, members.length),
+    },
+  });
+}

--- a/src/server/services/bot-account-detection/evidence.ts
+++ b/src/server/services/bot-account-detection/evidence.ts
@@ -1,3 +1,4 @@
+import { publicIpOnlySql } from '@civitai/shared/clickhouse-ip-filters';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead } from '~/server/db/client';
 import type { BotAccountCohortMember } from './cohort';
@@ -101,8 +102,13 @@ export type EvidenceDb = {
 export type EvidenceClickhouse = { $query: <T extends object>(sql: string) => Promise<T[]> };
 
 export type EvidenceReader = {
-  /** Registration IPs for exactly these accounts. Empty when ClickHouse is unavailable. */
-  listRegistrationIps(userIds: number[]): Promise<RegistrationIpRow[]>;
+  /**
+   * Registration IPs for exactly these accounts. Empty when ClickHouse is unavailable.
+   *
+   * `createdAfter` is the run's own window opening — see `registrationIpSql`. Optional so a caller
+   * that has no window still gets an (unpruned) answer rather than an empty one.
+   */
+  listRegistrationIps(userIds: number[], createdAfter?: Date): Promise<RegistrationIpRow[]>;
   /** Up to `take` recent comments across both comment surfaces, for exactly these accounts. */
   listContentSamples(userIds: number[], take: number): Promise<ContentSampleRow[]>;
   /** Whether a registration-IP read can happen at all. `false` means the source is missing, NOT
@@ -152,20 +158,57 @@ export function contentSampleArgs(userIds: number[], take: number) {
  * only thing standing between a value and the statement is this filter. It is cheap and it is the
  * kind of guard that is correct until someone routes a different id source into it.
  *
+ * 🔴 PRIVATE AND CARRIER-INTERNAL SPACE IS EXCLUDED, and this is the one filter without which the
+ * heuristic is worse than absent. `publicIpOnlySql` comes from `@civitai/shared/clickhouse-ip-filters`
+ * — the SAME predicate `apps/moderator/src/lib/server/reactor-lookup.service.ts` reads this table
+ * with, moved to a shared module rather than copied, because a second hand-written copy is how the
+ * two silently stop matching. That file names this heuristic's failure mode exactly: private space
+ * "correlates everyone and therefore no one". Without it, six cohort members behind one `10.124/16`
+ * address or one proxy reach a reported score, and ten of them top the run's whole distribution from
+ * an infrastructure address — a confident finding about nothing, produced by omission rather than by
+ * error. The predicate's own `ip != ''` guard is emitted FIRST because `isIPAddressInRange` raises on
+ * an empty string; do not reorder the conjunction.
+ *
+ * 🔴 `time` IS THE PRUNING COLUMN AND THE WINDOW IS SEMANTICALLY FREE. Every cohort account was
+ * created inside `createdAfter`, so its registration event cannot predate it; the predicate removes
+ * no row this query wants and is the difference between a walk of up to fifty chunks scanning the
+ * whole table and one scanning a day. Sibling readers of this table all bound on `time` for the same
+ * reason. It is optional so a caller with no window gets a correct — merely unpruned — answer.
+ *
  * `GROUP BY` rather than a plain select: an account can have several registration rows, and the
- * heuristic wants distinct (account, ip) pairs, not a row count. `LIMIT` bounds a pathological
- * chunk — an account with thousands of recorded registration events cannot flood the result.
+ * heuristic wants distinct (account, ip) pairs, not a row count.
+ *
+ * 🔴 THE CAP IS PER ACCOUNT, AND `LIMIT n` COULD NOT SAY THAT. `LIMIT ids.length * 4` was a cap on
+ * the RESULT with no `ORDER BY` under it, so one account with many distinct registration addresses
+ * could consume the whole allowance and EVICT every other account in its chunk — silently, and in
+ * the direction that understates every ring. `LIMIT n BY targetUserId` is the per-group form
+ * (precedent: `~/server/redis/caches.ts`'s `LIMIT 2000 BY userId`), so the comment and the code now
+ * say the same thing: at most `MAX_IPS_PER_ACCOUNT` addresses per account, whatever any other
+ * account in the chunk did. The total is still bounded, at `ids.length * MAX_IPS_PER_ACCOUNT`.
+ * `ORDER BY` makes which addresses survive that per-account cap deterministic rather than whatever
+ * the merge happened to emit.
  */
-export function registrationIpSql(userIds: number[]): string {
+export const MAX_IPS_PER_ACCOUNT = 4;
+
+/** ClickHouse's `DateTime` literal form — `YYYY-MM-DD hh:mm:ss`, UTC, no zone suffix. The `Z`-suffixed
+ *  ISO string is not accepted, and the spelling below is the one every other ClickHouse writer in
+ *  this repo uses. */
+export const clickhouseDateTime = (d: Date): string =>
+  d.toISOString().slice(0, 19).replace('T', ' ');
+
+export function registrationIpSql(userIds: number[], createdAfter?: Date): string {
   const ids = userIds.filter((n) => Number.isInteger(n) && n > 0);
   if (!ids.length) return '';
+  const window = createdAfter ? `\n      AND time >= '${clickhouseDateTime(createdAfter)}'` : '';
   return `
     SELECT targetUserId, ip
     FROM default.userActivities
     WHERE targetUserId IN (${ids.join(',')})
-      AND type = 'Registration'
+      AND type = 'Registration'${window}
+      AND ${publicIpOnlySql()}
     GROUP BY targetUserId, ip
-    LIMIT ${ids.length * 4}
+    ORDER BY targetUserId, ip
+    LIMIT ${MAX_IPS_PER_ACCOUNT} BY targetUserId
   `;
 }
 
@@ -184,8 +227,8 @@ export function createEvidenceReader(
 
   return {
     hasRegistrationIps: ch !== null,
-    listRegistrationIps: async (userIds) => {
-      const sql = registrationIpSql(userIds);
+    listRegistrationIps: async (userIds, createdAfter) => {
+      const sql = registrationIpSql(userIds, createdAfter);
       if (!ch || !sql) return [];
       const rows = await ch.$query<{ targetUserId: string | number; ip: string }>(sql);
       // ClickHouse returns integers as strings over HTTP JSON; `Number` on an already-numeric value
@@ -293,6 +336,16 @@ export type CohortSignals = {
   sources: {
     /** ClickHouse was reachable and the registration-IP read ran. */
     registrationIps: boolean;
+    /**
+     * The content read ran to completion. `false` means it never ran, or a chunk THREW and the
+     * partial data was discarded — NOT that the cohort posted nothing.
+     *
+     * 🔴 IT IS A SOURCE FLAG FOR THE SAME REASON `registrationIps` IS. Before it, a content-read
+     * failure propagated out of the run and no report was filed at all — losing the velocity
+     * heuristic's day too, and looking exactly like a dead producer. Degrading and saying so is what
+     * this module's header claims it does; this is the flag that makes the claim true of both reads.
+     */
+    contentSamples: boolean;
     /** The content budget was spent before the whole cohort was sampled. */
     contentBudgetExhausted: boolean;
     /** How many members had content sampled at all. The denominator for the similarity heuristic. */
@@ -311,6 +364,7 @@ export function emptyCohortSignals(): CohortSignals {
     membersPerFingerprint: new Map(),
     sources: {
       registrationIps: false,
+      contentSamples: false,
       contentBudgetExhausted: false,
       membersSampledForContent: 0,
     },
@@ -403,6 +457,12 @@ export function buildCohortSignals(args: {
  * pass can filter on. A run whose IP data was missing is not comparable with one whose was there,
  * and this flag is the only thing that says which kind you are looking at.
  *
+ * 🔴 BOTH READS, NOT ONE. That paragraph described only the IP read for a while, and the content
+ * read — the Postgres one, on a replica that is exactly the thing that times out — had no guard at
+ * all, so a failure there propagated out and lost the whole run including the heuristic that needs
+ * no source. `sources.contentSamples` is the second flag, and it exists so this docstring is a
+ * description rather than an aspiration.
+ *
  * The content walk is a BUDGET, not a per-chunk cap — see `MAX_CONTENT_SAMPLES`.
  */
 export async function collectCohortSignals(
@@ -411,6 +471,8 @@ export async function collectCohortSignals(
   opts: {
     chunkSize?: number;
     maxContentSamples?: number;
+    /** The run's window opening, passed through to the ClickHouse read as its `time` bound. */
+    createdAfter?: Date;
     checkCanceled?: () => void;
     log?: (name: string, data: Record<string, unknown>) => void;
   } = {}
@@ -433,7 +495,7 @@ export async function collectCohortSignals(
     for (const ids of chunks) {
       checkCanceled();
       try {
-        registrationIps.push(...(await reader.listRegistrationIps(ids)));
+        registrationIps.push(...(await reader.listRegistrationIps(ids, opts.createdAfter)));
       } catch (e) {
         // One failed chunk invalidates the IP signal for the WHOLE run, not just for its own
         // accounts: a cluster count built from a partial read UNDERSTATES every ring that straddles
@@ -454,6 +516,17 @@ export async function collectCohortSignals(
   let budget = budgetTotal;
   let budgetExhausted = false;
   let membersSampled = 0;
+  // 🔴 THE CONTENT READ DEGRADES THE RUN INSTEAD OF KILLING IT, for exactly the reason the IP read
+  // above does. Without this a timeout on a busy replica propagated out of `runBotAccountDetection`
+  // and NO REPORT WAS FILED AT ALL — the velocity heuristic's day lost with it, and the whole thing
+  // indistinguishable from a producer that stopped running. The partial data is DISCARDED rather
+  // than scored, again for the IP loop's reason: a fingerprint count built from some of the chunks
+  // understates every ring that straddles the missing ones, and understating is the direction that
+  // produces a confident zero.
+  //
+  // `checkCanceled()` stays OUTSIDE the try. It throws on purpose, and swallowing that would turn
+  // cancellation into a degraded run that keeps going.
+  let contentRead = true;
   for (const ids of chunks) {
     checkCanceled();
     if (budget <= 0) {
@@ -463,12 +536,27 @@ export async function collectCohortSignals(
     // The per-surface `take` is the remaining budget, so one chunk can never consume more than what
     // is left; `listContentSamples` reads two surfaces, so the actual return can be up to twice it.
     // Bounding the SPEND rather than the take is what keeps the total fixed.
-    const rows = await reader.listContentSamples(ids, Math.min(budget, chunkSize * 2));
+    let rows: ContentSampleRow[];
+    try {
+      rows = await reader.listContentSamples(ids, Math.min(budget, chunkSize * 2));
+    } catch (e) {
+      log('bot-account-detection:content-samples-failed', {
+        chunkIds: ids.length,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      contentSamples.length = 0;
+      contentRead = false;
+      // A failed read is not an exhausted budget, and reporting it as one would send a grading pass
+      // looking for a cohort too large rather than for a broken replica.
+      budgetExhausted = false;
+      membersSampled = 0;
+      break;
+    }
     membersSampled += ids.length;
     budget -= rows.length;
     contentSamples.push(...rows);
   }
-  if (budget <= 0 && membersSampled < members.length) budgetExhausted = true;
+  if (contentRead && budget <= 0 && membersSampled < members.length) budgetExhausted = true;
 
   return buildCohortSignals({
     members,
@@ -476,6 +564,7 @@ export async function collectCohortSignals(
     contentSamples,
     sources: {
       registrationIps: ipsRead,
+      contentSamples: contentRead,
       contentBudgetExhausted: budgetExhausted,
       membersSampledForContent: Math.min(membersSampled, members.length),
     },

--- a/src/server/services/bot-account-detection/heuristics/clustering.ts
+++ b/src/server/services/bot-account-detection/heuristics/clustering.ts
@@ -1,0 +1,169 @@
+import type { BotAccountHeuristic } from '../scoring';
+import { rampScore } from './ramp';
+
+/**
+ * HEURISTIC 2 — do these accounts look like ONE actor.
+ *
+ * Adapted from `apps/moderator/src/lib/server/bulk-ban.service.ts`, which is the moderator-facing
+ * version of this question: `getRegistrationIps` groups a set of accounts by the IP they registered
+ * from, `getEmailDomains` groups them by email domain, and `getAccountsOnIps` grows a ring from one
+ * account outwards. What carries over, and what changes:
+ *
+ *  - CARRIED OVER, and it is the load-bearing choice: REGISTRATION IPs ONLY. That service says why —
+ *    a shared LOGIN ip is weak evidence, because mobile carriers and offices put thousands of
+ *    unrelated people behind one address, while a shared REGISTRATION ip across many accounts is the
+ *    ban-evasion signal. Widening this to logins would flood the board.
+ *  - CARRIED OVER: a disposable-domain ring shows up as one domain with a high count.
+ *  - INVERTED: that service is INVESTIGATIVE — a moderator supplies the accounts and it counts them.
+ *    Nothing supplies accounts here, so the population is the cohort itself, and "how many accounts
+ *    share this" means "how many of the day's new posting accounts share this". That is a much
+ *    narrower denominator than the whole user table, which is what makes an unbounded count usable
+ *    as a score without a base rate to divide by.
+ *
+ * 🔴 THIS IS THE ONLY HEURISTIC OF THE THREE THAT CAN SEE A COORDINATED RING, and it is also the
+ * only one that can go dark. Its IP half needs ClickHouse, which is `undefined` on any deployment
+ * without `CLICKHOUSE_HOST`. When that happens the heuristic does NOT silently score 0 — a zero from
+ * a missing source is indistinguishable from a zero meaning "these accounts share nothing", and the
+ * two call for opposite conclusions. `CohortSignals.sources.registrationIps` carries the state, the
+ * note below says which halves actually ran, and `run.ts` publishes it as a counter so a grading
+ * pass can throw the affected runs out rather than average them in.
+ *
+ * 🔴 THE TWO HALVES ARE COMBINED WITH `max`, NOT A SUM. An account caught by both is not twice as
+ * suspicious as one caught by either; more importantly, summing would make the heuristic's own
+ * sub-score uninterpretable — the number in the reason string could no longer be read as "the size
+ * of the ring this account is in". Keeping it a max means the sub-score always means one thing, and
+ * the note names which half produced it.
+ */
+
+export const REGISTRATION_CLUSTER_ID = 'registration-cluster';
+
+/**
+ * The largest cluster still worth nothing, and the size at which the heuristic is convinced.
+ *
+ * Separate boundaries for IPs and domains because the two have different innocent explanations at
+ * the same size. Two accounts on one IP is a household or a phone; two on one domain is a coincidence
+ * among however many domains a day's signups use. But a domain is a far weaker signal than an IP at
+ * every size — one is "these were created from the same machine", the other is "these use the same
+ * mail provider" — so the domain boundaries sit higher and its ramp is longer.
+ *
+ * 🔴 NAT IS THE KNOWN FALSE-POSITIVE, and no threshold removes it. `bulk-ban.service.ts` warns that
+ * a carrier-NAT address can carry thousands of unrelated registrations, and nothing here can tell
+ * that apart from a ring. Two things hold it down and neither is a fix: the population is only the
+ * day's new accounts THAT POSTED, which is a small fraction of registrations behind any NAT, and the
+ * ramp does not reach 1 until ten of them. It is a real limitation and the shadow phase is where its
+ * rate gets measured.
+ */
+export const IP_ZERO_AT = 2;
+export const IP_ONE_AT = 10;
+export const DOMAIN_ZERO_AT = 3;
+export const DOMAIN_ONE_AT = 15;
+
+/**
+ * Mail providers whose domain carries no signal at any cluster size.
+ *
+ * 🔴 WITHOUT THIS LIST THE DOMAIN HALF IS WORSE THAN USELESS — IT IS ANTI-CORRELATED. Most of any
+ * day's genuine signups use a handful of free providers, so `gmail.com` is the largest cluster in
+ * every cohort by a wide margin, every day, and a heuristic that scores cluster size would hand the
+ * board the day's most ordinary accounts with maximum confidence while a ten-account disposable-domain
+ * ring scored lower. This is the exact "fires on 90% of accounts" failure the scoring seam was built
+ * to expose, and here it is foreseeable rather than something to discover in shadow.
+ *
+ * 🔴 IT IS A HARDCODED LIST AND THEREFORE BRITTLE, WHICH IS THE HONEST COST. The principled version
+ * is a base rate — how over-represented is this domain against its ordinary share of signups — and
+ * that needs a historical query this change does not make. A list has two failure modes worth
+ * stating: a provider missing from it produces a standing false positive that looks exactly like a
+ * ring, and a provider ON it hides a real ring that happened to use it. `domains_suppressed_common`
+ * in the run counters is what makes the first measurable; nothing measures the second.
+ *
+ * Deliberately SHORT. Every entry is a domain that hides real rings, so the list earns its length
+ * only where the provider is common enough that its cluster would dominate anyway.
+ */
+export const COMMON_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  'gmail.com',
+  'googlemail.com',
+  'yahoo.com',
+  'yahoo.co.uk',
+  'hotmail.com',
+  'hotmail.co.uk',
+  'outlook.com',
+  'live.com',
+  'msn.com',
+  'icloud.com',
+  'me.com',
+  'aol.com',
+  'proton.me',
+  'protonmail.com',
+  'gmx.com',
+  'gmx.de',
+  'mail.com',
+  'mail.ru',
+  'yandex.ru',
+  'qq.com',
+  '163.com',
+  '126.com',
+  'naver.com',
+]);
+
+/** Whether a domain is one whose cluster size means nothing. */
+export const isCommonEmailDomain = (domain: string): boolean =>
+  COMMON_EMAIL_DOMAINS.has(domain.toLowerCase());
+
+/** The largest number of cohort members sharing any one of this account's registration IPs,
+ *  including the account itself. `0` when nothing is known. */
+export function largestIpCluster(
+  userId: number,
+  signals: { ipsByUser: Map<number, string[]>; membersPerIp: Map<string, number> }
+): { size: number; ip: string | null } {
+  let best = { size: 0, ip: null as string | null };
+  for (const ip of signals.ipsByUser.get(userId) ?? []) {
+    const size = signals.membersPerIp.get(ip) ?? 0;
+    if (size > best.size) best = { size, ip };
+  }
+  return best;
+}
+
+/** The number of cohort members sharing this account's email domain — `0` for a common provider,
+ *  which is the encoding that keeps a suppressed domain from ever scoring. */
+export function domainClusterSize(
+  emailDomain: string | null,
+  membersPerDomain: Map<string, number>
+): number {
+  if (!emailDomain || isCommonEmailDomain(emailDomain)) return 0;
+  return membersPerDomain.get(emailDomain) ?? 0;
+}
+
+export const registrationClusterHeuristic: BotAccountHeuristic = {
+  id: REGISTRATION_CLUSTER_ID,
+  description:
+    'How many OTHER new posting accounts share this account’s registration IP or its (uncommon) ' +
+    'email domain. The only heuristic here that can see a coordinated ring; needs ClickHouse for ' +
+    'its IP half and says so when that is missing.',
+  weight: 1,
+  score: ({ member, signals }) => {
+    const ip = largestIpCluster(member.userId, signals);
+    const domain = domainClusterSize(member.emailDomain, signals.membersPerDomain);
+    return Math.max(
+      rampScore(ip.size, IP_ZERO_AT, IP_ONE_AT),
+      rampScore(domain, DOMAIN_ZERO_AT, DOMAIN_ONE_AT)
+    );
+  },
+  explain: ({ member, signals }, score) => {
+    if (score <= 0) return null;
+    const ip = largestIpCluster(member.userId, signals);
+    const domain = domainClusterSize(member.emailDomain, signals.membersPerDomain);
+    const clauses: string[] = [];
+    // The IP itself is NOT quoted into the reason. A moderator who needs it has
+    // `getAccountsOnIps` — the tool built for exactly that lookup, with the paging and the
+    // already-banned marking this sentence cannot carry — and the abuse board is a wider audience
+    // than that tool.
+    if (ip.size > IP_ZERO_AT)
+      clauses.push(`${ip.size} new posting accounts share its registration IP`);
+    if (domain > DOMAIN_ZERO_AT)
+      clauses.push(
+        `${domain} share its email domain ${member.emailDomain ?? ''} (not a common provider)`
+      );
+    if (!signals.sources.registrationIps)
+      clauses.push('registration-IP data was UNAVAILABLE this run — domain half only');
+    return clauses.length ? clauses.join('; ') : null;
+  },
+};

--- a/src/server/services/bot-account-detection/heuristics/clustering.ts
+++ b/src/server/services/bot-account-detection/heuristics/clustering.ts
@@ -68,40 +68,190 @@ export const DOMAIN_ONE_AT = 15;
  * ring scored lower. This is the exact "fires on 90% of accounts" failure the scoring seam was built
  * to expose, and here it is foreseeable rather than something to discover in shadow.
  *
- * 🔴 IT IS A HARDCODED LIST AND THEREFORE BRITTLE, WHICH IS THE HONEST COST. The principled version
- * is a base rate — how over-represented is this domain against its ordinary share of signups — and
- * that needs a historical query this change does not make. A list has two failure modes worth
- * stating: a provider missing from it produces a standing false positive that looks exactly like a
- * ring, and a provider ON it hides a real ring that happened to use it. `domains_suppressed_common`
- * in the run counters is what makes the first measurable; nothing measures the second.
+ * 🔴 WHAT A WORD LIST STRUCTURALLY CANNOT DO, stated here because the length below invites the
+ * opposite reading. Extending it is a PATCH, not a fix, and no amount of extending changes any of
+ * these three:
  *
- * Deliberately SHORT. Every entry is a domain that hides real rings, so the list earns its length
- * only where the provider is common enough that its cluster would dominate anyway.
+ *   1. IT IS WALKABLE IN ONE KEYSTROKE, and the evasion is to register the ring on `gmail.com`.
+ *      A domain on this list scores 0 by construction, so the list is a map of where a ring should
+ *      go. The domain half is therefore a signal against the CARELESS only, and the IP half is what
+ *      carries the heuristic against anyone who has read this file.
+ *   2. EVERY OMISSION IS A STANDING FALSE POSITIVE, and they do not fall evenly. The omissions are
+ *      whatever the author did not think of, and an English-speaking author does not think of
+ *      `hotmail.fr`, `libero.it`, `uol.com.br`, `daum.net` or `foxmail.com` — so the false positives
+ *      land systematically on people who do not write in English. Nine new posting accounts a day on
+ *      one country's ordinary free provider is not a ring; before this list was widened it scored
+ *      like one. The list can only ever be as complete as the last person to look at it.
+ *   3. A DOMAIN ON IT HIDES A REAL RING THAT USED IT, and nothing measures that.
+ *      `domains_suppressed_common` in the run counters (see `run.ts`) is how many members had their
+ *      domain suppressed this way — it makes the SIZE of that blind spot visible, which is the most
+ *      the shadow phase can do; it cannot say how many of those members were a ring.
+ *
+ * The principled version is a BASE RATE — how over-represented is this domain against its ordinary
+ * share of signups — which needs a historical query this change does not make and which removes
+ * failure modes 1 and 2 outright. That is the fix; this is the patch, and it is labelled as one.
+ *
+ * Grouped by provider family rather than alphabetically, because the way an entry goes missing is
+ * that someone adds `hotmail.fr` and does not think about `hotmail.be`.
  */
 export const COMMON_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  // Google
   'gmail.com',
   'googlemail.com',
-  'yahoo.com',
-  'yahoo.co.uk',
+  // Microsoft — the country variants are the single largest omission class, because the .com is
+  // obvious and the rest are only obvious to whoever uses them.
   'hotmail.com',
   'hotmail.co.uk',
+  'hotmail.fr',
+  'hotmail.de',
+  'hotmail.es',
+  'hotmail.it',
+  'hotmail.be',
+  'hotmail.nl',
+  'hotmail.com.br',
+  'hotmail.com.ar',
+  'hotmail.gr',
+  'hotmail.se',
   'outlook.com',
+  'outlook.fr',
+  'outlook.de',
+  'outlook.es',
+  'outlook.it',
+  'outlook.com.br',
   'live.com',
+  'live.co.uk',
+  'live.fr',
+  'live.de',
+  'live.it',
+  'live.nl',
+  'live.se',
+  'live.ca',
+  'live.com.au',
   'msn.com',
+  // Yahoo and its acquisitions
+  'yahoo.com',
+  'yahoo.co.uk',
+  'yahoo.fr',
+  'yahoo.de',
+  'yahoo.es',
+  'yahoo.it',
+  'yahoo.ca',
+  'yahoo.co.jp',
+  'yahoo.co.in',
+  'yahoo.com.br',
+  'yahoo.com.mx',
+  'yahoo.com.ar',
+  'yahoo.com.au',
+  'ymail.com',
+  'rocketmail.com',
+  'aol.com',
+  'aol.co.uk',
+  // Apple
   'icloud.com',
   'me.com',
-  'aol.com',
+  'mac.com',
+  // Proton. 🔴 `pm.me` is Proton's own short alias domain, offered to every paid account — it is as
+  // ordinary as `proton.me` and was the sharpest omission on the original list.
   'proton.me',
   'protonmail.com',
+  'protonmail.ch',
+  'pm.me',
+  // Germany / Austria / Switzerland
   'gmx.com',
   'gmx.de',
-  'mail.com',
+  'gmx.net',
+  'gmx.at',
+  'gmx.ch',
+  'web.de',
+  't-online.de',
+  'freenet.de',
+  'bluewin.ch',
+  // France
+  'free.fr',
+  'orange.fr',
+  'wanadoo.fr',
+  'laposte.net',
+  'sfr.fr',
+  'bbox.fr',
+  // Italy
+  'libero.it',
+  'virgilio.it',
+  'alice.it',
+  'tiscali.it',
+  // Iberia and Latin America
+  'terra.com.br',
+  'uol.com.br',
+  'bol.com.br',
+  'globo.com',
+  'prodigy.net.mx',
+  // Russia, Ukraine and the CIS
   'mail.ru',
+  'inbox.ru',
+  'list.ru',
+  'bk.ru',
+  'internet.ru',
   'yandex.ru',
+  'yandex.com',
+  'yandex.by',
+  'yandex.kz',
+  'ya.ru',
+  'rambler.ru',
+  'ukr.net',
+  // Central and eastern Europe
+  'seznam.cz',
+  'wp.pl',
+  'o2.pl',
+  'onet.pl',
+  'interia.pl',
+  'abv.bg',
+  'mynet.com',
+  // China
   'qq.com',
+  'foxmail.com',
   '163.com',
   '126.com',
+  'sina.com',
+  'sina.cn',
+  'sohu.com',
+  '139.com',
+  '189.cn',
+  // Korea and Japan
   'naver.com',
+  'daum.net',
+  'hanmail.net',
+  'nate.com',
+  'docomo.ne.jp',
+  'ezweb.ne.jp',
+  // India
+  'rediffmail.com',
+  // Generic and privacy-first providers
+  'mail.com',
+  'email.com',
+  'usa.com',
+  'zoho.com',
+  'fastmail.com',
+  'tutanota.com',
+  'tuta.io',
+  'hushmail.com',
+  'gmx.us',
+  // Consumer ISPs — an ISP address is as ordinary as a webmail one and clusters the same way
+  'comcast.net',
+  'verizon.net',
+  'att.net',
+  'sbcglobal.net',
+  'cox.net',
+  'charter.net',
+  'bellsouth.net',
+  'btinternet.com',
+  'sky.com',
+  'virginmedia.com',
+  'talktalk.net',
+  'bigpond.com',
+  'optusnet.com.au',
+  'shaw.ca',
+  'rogers.com',
+  'telus.net',
+  'sympatico.ca',
 ]);
 
 /** Whether a domain is one whose cluster size means nothing. */

--- a/src/server/services/bot-account-detection/heuristics/index.ts
+++ b/src/server/services/bot-account-detection/heuristics/index.ts
@@ -1,0 +1,39 @@
+import type { BotAccountHeuristic } from '../scoring';
+import { registrationClusterHeuristic } from './clustering';
+import { contentTemplatingHeuristic } from './similarity';
+import { postingVelocityHeuristic } from './velocity';
+
+/**
+ * The heuristics a production run uses.
+ *
+ * 🔴 THE PLACEHOLDER IS GONE. `placeholderHeuristic` was labelled "delete it in the change that adds
+ * the first real heuristic; it is not a baseline, a prior, or a floor" — this is that change. It is
+ * still exported from `scoring.ts` because the registry-mechanics tests need SOMETHING inert to
+ * exercise the seam with, but it is not registered and no run scores against it.
+ *
+ * 🔴 EQUAL WEIGHTS, AND THAT IS A DECISION NOT TO GUESS. Nothing yet distinguishes these three by
+ * precision — no run has produced a single graded finding — so any other split would be a number
+ * invented to look considered. Equal weights make the blend mean exactly "the average of three
+ * independent opinions", which is the only claim the evidence supports today. Re-weighting is what
+ * the shadow phase's per-heuristic counters are FOR, and doing it before those counters exist would
+ * bake a guess into the thing built to test guesses.
+ *
+ * 🔴 WHAT THE BLEND STRUCTURALLY CANNOT SAY, stated because a weighted mean invites the opposite
+ * reading: with three equal weights, ONE heuristic at full confidence blends to 0.33. So a blend of
+ * 0.33 is not "mildly suspicious" — it can be one signal that is completely certain, and the
+ * reporting threshold in `scoring.ts` is set against that arithmetic rather than against an
+ * intuition about what 0.33 feels like. Read the sub-scores, not the blend; the reason string
+ * carries both for that reason.
+ *
+ * Order is the order a moderator reads them in, cheapest and most self-evident first.
+ */
+export const BOT_ACCOUNT_HEURISTICS: readonly BotAccountHeuristic[] = [
+  postingVelocityHeuristic,
+  registrationClusterHeuristic,
+  contentTemplatingHeuristic,
+];
+
+export { postingVelocityHeuristic } from './velocity';
+export { registrationClusterHeuristic } from './clustering';
+export { contentTemplatingHeuristic } from './similarity';
+export { rampScore } from './ramp';

--- a/src/server/services/bot-account-detection/heuristics/index.ts
+++ b/src/server/services/bot-account-detection/heuristics/index.ts
@@ -34,6 +34,10 @@ export const BOT_ACCOUNT_HEURISTICS: readonly BotAccountHeuristic[] = [
 ];
 
 export { postingVelocityHeuristic } from './velocity';
-export { registrationClusterHeuristic } from './clustering';
+export {
+  registrationClusterHeuristic,
+  isCommonEmailDomain,
+  COMMON_EMAIL_DOMAINS,
+} from './clustering';
 export { contentTemplatingHeuristic } from './similarity';
 export { rampScore } from './ramp';

--- a/src/server/services/bot-account-detection/heuristics/ramp.ts
+++ b/src/server/services/bot-account-detection/heuristics/ramp.ts
@@ -1,0 +1,43 @@
+/**
+ * The one shape every heuristic in this directory turns a measurement into a score with.
+ *
+ * 🔴 ONE RAMP, NOT THREE. Each heuristic measures something with a different unit — items per hour,
+ * accounts per IP, accounts per fingerprint — but all three answer the same question: "how far past
+ * boring is this". Writing that arithmetic once means the three heuristics differ ONLY in what they
+ * measure and where their two boundaries sit, which is what makes the sub-scores comparable enough
+ * to sit beside each other in one reason string. It is also one place for the off-by-one to live
+ * rather than three, and the boundary is the part every mutation check aims at.
+ *
+ * The two boundaries are named for what they DO, not for what they bound:
+ *  - `zeroAt` — the largest value that is still worth nothing. A value equal to it scores exactly 0.
+ *  - `oneAt`  — the smallest value that is worth everything. A value equal to it scores exactly 1.
+ *
+ * 🔴 THAT NAMING IS DELIBERATE AND IT IS THE OPPOSITE OF THE OBVIOUS ONE. Calling them `min`/`max`
+ * invites reading `min` as "the smallest value that fires", which is off by one step in the
+ * direction that makes a threshold fire earlier than its author intended — a detector's most
+ * expensive kind of mistake, because it shows up as noise rather than as an error. With `zeroAt: 2`,
+ * a cluster of THREE is the smallest that scores anything.
+ */
+
+/**
+ * Linear interpolation between two boundaries, clamped at both ends.
+ *
+ * Returns 0 at or below `zeroAt`, 1 at or above `oneAt`, and the straight line between them
+ * otherwise. A non-finite input scores 0 — it is a defect in whatever produced it, not a maximal
+ * opinion, and the same reasoning `scoring.ts` gives for clamping `Infinity` down rather than up
+ * applies here one layer earlier.
+ *
+ * `oneAt <= zeroAt` throws rather than returning something. It is not a value a caller could have
+ * meant: the two boundaries would be inverted or coincident, every input would land on a degenerate
+ * step, and the resulting heuristic would look calibrated while scoring 0 or 1 and nothing between.
+ * A constant this wrong is a bug at module load, and it is better found there than averaged into a
+ * moderator's queue.
+ */
+export function rampScore(value: number, zeroAt: number, oneAt: number): number {
+  if (!(oneAt > zeroAt))
+    throw new Error(`rampScore needs oneAt > zeroAt, got zeroAt=${zeroAt}, oneAt=${oneAt}`);
+  if (!Number.isFinite(value)) return 0;
+  if (value <= zeroAt) return 0;
+  if (value >= oneAt) return 1;
+  return (value - zeroAt) / (oneAt - zeroAt);
+}

--- a/src/server/services/bot-account-detection/heuristics/similarity.ts
+++ b/src/server/services/bot-account-detection/heuristics/similarity.ts
@@ -39,6 +39,36 @@ import { rampScore } from './ramp';
  * wave day the oldest end of the cohort may not be sampled at all. An unsampled account scores 0
  * here for want of data, which — again — is not the same as scoring 0 for want of a signal. The
  * budget state rides out on `sources.contentBudgetExhausted` and as a run counter.
+ *
+ * 🔴 THE KNOWN FALSE POSITIVE, NAMED, MEASURED AND DELIBERATELY NOT PATCHED: A GENERATION-PARAMETER
+ * PASTE. `Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 1234567890, Size: 512x768` and the same
+ * line with entirely different numbers produce an IDENTICAL fingerprint, because every number is a
+ * `nummask` — verified by executing the shipped normaliser, and pinned as a regression case in
+ * `__tests__/evidence.test.ts` so it cannot quietly stop being true. Pasting settings under a model
+ * is one of the most ordinary comments on this site, so six such accounts in one day's cohort read
+ * as a ring of six and are reported. `MIN_FINGERPRINT_CHARS`/`MIN_FINGERPRINT_TOKENS` defend against
+ * SHORT text only and cannot reach this by construction.
+ *
+ * TWO FIXES WERE CONSIDERED AND BOTH REJECTED ON THE ARITHMETIC, not on taste:
+ *  - DISCARD FINGERPRINTS THAT ARE MOSTLY MASK TOKENS. Measured on the shipped normaliser, the two
+ *    classes do not sit close — they INTERLEAVE, in both directions, so no threshold exists in
+ *    either. A paste that includes the prompt (the commonest real form) is 6/21 masks and
+ *    `check out linkmask for nummask free buzz` is 2/7 — the SAME value, 0.286. And the ordering
+ *    inverts at the other end: `free buzz linkmask nummask` is 0.500, above the longest parameter
+ *    paste's 0.389. A cut low enough to catch pastes discards shill text first; a cut high enough
+ *    to spare shill text catches nothing. The arithmetic is asserted in `__tests__/evidence.test.ts`
+ *    rather than left as a claim here.
+ *  - RAISE `CLUSTER_ZERO_AT`. It does not remove the class, it only demands a larger innocent
+ *    cluster — and the innocent cluster here is "people who commented their settings under a
+ *    popular model today", which is not bounded by anything. A floor high enough to exclude it
+ *    would also exclude most real rings.
+ * So the honest disposition is the shadow phase's own: the collision is REPORTED rather than
+ * silently tuned away, the reason string QUOTES the normalised text that clustered — so a
+ * generation-parameter paste identifies itself to a moderator in one glance, which is a property of
+ * the design rather than a hope — and `heuristic:content-templating:sole_signal` counts the
+ * findings that rest on this heuristic ALONE, which is exactly the population a collision inflates.
+ * That counter is what should set the fix, and inventing a third judgement constant before it exists
+ * is the thing `evidence.ts` argues against at `MIN_FINGERPRINT_CHARS`.
  */
 
 export const CONTENT_TEMPLATING_ID = 'content-templating';

--- a/src/server/services/bot-account-detection/heuristics/similarity.ts
+++ b/src/server/services/bot-account-detection/heuristics/similarity.ts
@@ -1,0 +1,98 @@
+import type { BotAccountHeuristic } from '../scoring';
+import { rampScore } from './ramp';
+
+/**
+ * HEURISTIC 3 — the same text, posted by accounts that are supposed to be strangers.
+ *
+ * 🔴 NO EXISTING IMPLEMENTATION TO ADAPT, so the approach is stated here in full rather than by
+ * reference. The requirement is "the same shill text pasted N times across new accounts", and the
+ * constraint that shaped every decision below is that a moderator must be able to READ the reason
+ * and see why — which rules out anything whose output is a distance nobody can picture.
+ *
+ * WHAT IT DOES: reduce each comment to a normalised fingerprint (`evidence.ts#contentFingerprint` —
+ * lowercased, links and digit runs masked, punctuation dropped, whitespace collapsed), then count how
+ * many DISTINCT cohort members produced each fingerprint. An account's score is the size of the
+ * largest group its own text belongs to.
+ *
+ * 🔴 WHY NOT A REAL SIMILARITY MEASURE. Cosine over TF-IDF, edit distance, MinHash and friends all
+ * answer a better question, and all three fail the constraint above in the same way: the finding
+ * would read "similarity 0.83 to a cluster of 6", which no moderator can check and nobody can
+ * calibrate without a corpus. Exact-match-after-masking is crude, but the reason string can quote
+ * the shared text, and a human can confirm or dismiss it in one glance. It is also O(rows) with a
+ * hash map, against O(rows²) for pairwise distance — and the cohort is bounded only by
+ * `MAX_COHORT_ACCOUNTS`, so the quadratic option was never actually on the table at this budget.
+ *
+ * 🔴 WHAT THE MASKING BUYS AND WHAT IT COSTS. Masking links and numbers is what upgrades this from
+ * "literal copy-paste" to "one template with the payload swapped", which is the actual method — the
+ * link, the referral code and the amount are exactly the parts a ring varies. It also means two
+ * genuinely independent people who wrote the same ordinary sentence with different numbers in it now
+ * collide. `MIN_FINGERPRINT_CHARS`/`MIN_FINGERPRINT_TOKENS` are the only defence, they are set by
+ * judgement, and measuring their false-positive rate is precisely what the shadow phase is for.
+ *
+ * 🔴 IT SEES COMMENTS ONLY. Model names, model descriptions and image prompts are all text a ring
+ * could template, and none of them is read: comments are the surface shill text actually lands on,
+ * they are the two tables with a `userId` index that makes the read cheap, and adding a third source
+ * is a widening of `evidence.ts` rather than a change here. An account that templated only its model
+ * descriptions scores 0 from this heuristic and is a KNOWN false negative, not an accident.
+ *
+ * 🔴 IT SEES A SAMPLE, NOT A CENSUS. The content read is budgeted (`MAX_CONTENT_SAMPLES`), so on a
+ * wave day the oldest end of the cohort may not be sampled at all. An unsampled account scores 0
+ * here for want of data, which — again — is not the same as scoring 0 for want of a signal. The
+ * budget state rides out on `sources.contentBudgetExhausted` and as a run counter.
+ */
+
+export const CONTENT_TEMPLATING_ID = 'content-templating';
+
+/**
+ * The largest number of accounts sharing one text that is still worth nothing, and the number at
+ * which the heuristic is convinced.
+ *
+ * `zeroAt: 2` means THREE accounts sharing one templated text is the smallest group that scores.
+ * Two is a pair, and a pair of strangers writing the same masked sentence is common enough — a
+ * quoted announcement, a meme, a stock phrase with a number in it — that scoring it would put the
+ * heuristic straight into the noise it exists to rise above.
+ */
+export const CLUSTER_ZERO_AT = 2;
+export const CLUSTER_ONE_AT = 10;
+
+/** How much of the shared text the reason string quotes. Bounded because the contract caps `reason`
+ *  at 2,000 characters and this clause competes with the post counts and the other two notes for
+ *  that budget — an over-long quote here truncates the whole finding, not just itself. */
+export const QUOTE_CHARS = 60;
+
+/** The largest group of cohort members this account's text belongs to, with the text itself. */
+export function largestContentCluster(
+  userId: number,
+  signals: { fingerprintsByUser: Map<number, string[]>; membersPerFingerprint: Map<string, number> }
+): { size: number; fingerprint: string | null } {
+  let best = { size: 0, fingerprint: null as string | null };
+  for (const fingerprint of signals.fingerprintsByUser.get(userId) ?? []) {
+    const size = signals.membersPerFingerprint.get(fingerprint) ?? 0;
+    if (size > best.size) best = { size, fingerprint };
+  }
+  return best;
+}
+
+export const contentTemplatingHeuristic: BotAccountHeuristic = {
+  id: CONTENT_TEMPLATING_ID,
+  description:
+    'How many OTHER new accounts posted the same comment text, compared after masking links and ' +
+    'numbers so one template with a swapped payload still matches. Comments only, and over a ' +
+    'budgeted sample of them.',
+  weight: 1,
+  score: ({ member, signals }) =>
+    rampScore(largestContentCluster(member.userId, signals).size, CLUSTER_ZERO_AT, CLUSTER_ONE_AT),
+  explain: ({ member, signals }, score) => {
+    if (score <= 0) return null;
+    const { size, fingerprint } = largestContentCluster(member.userId, signals);
+    // The QUOTED text is the normalised form, not the raw comment: it is what was actually compared,
+    // so quoting anything else would show a moderator a different string from the one the score was
+    // computed on. The masks (`linkmask`, `nummask`) are visible on purpose — they are the reason
+    // two superficially different comments matched.
+    const quote = (fingerprint ?? '').slice(0, QUOTE_CHARS);
+    return (
+      `${size} new accounts posted the same text after masking links/numbers — ` +
+      `“${quote}${(fingerprint ?? '').length > QUOTE_CHARS ? '…' : ''}”`
+    );
+  },
+};

--- a/src/server/services/bot-account-detection/heuristics/velocity.ts
+++ b/src/server/services/bot-account-detection/heuristics/velocity.ts
@@ -1,0 +1,98 @@
+import type { BotAccountHeuristic } from '../scoring';
+import { rampScore } from './ramp';
+
+/**
+ * HEURISTIC 1 — how fast the account posted, against how long it has existed.
+ *
+ * Adapted from `apps/moderator/src/lib/server/comment-spam.service.ts`, which finds a comment burst
+ * by counting an account's comments inside one hour and then throwing away every burst from an
+ * account older than a few days. Two things carry over and one deliberately does not:
+ *
+ *  - CARRIED OVER: the rate is measured AGAINST ACCOUNT AGE rather than in absolute terms. Forty
+ *    uploads is unremarkable from a year-old creator and is the whole signal from an account that
+ *    registered twenty minutes ago. That service expresses it as an age cut-off on a burst; here the
+ *    cohort is already age-bounded to a day, so age becomes the DIVISOR instead of a filter, which
+ *    is the same idea with more resolution — it separates the twenty-minute account from the
+ *    twenty-three-hour one, where a cut-off would keep both.
+ *  - CARRIED OVER: the floor at zero for a clock that ran backwards. That service floors
+ *    `ageAtBurstHours` because a burst timestamped before its own signup is skew between two
+ *    systems, not a negative age.
+ *  - NOT CARRIED OVER: its ClickHouse read. Everything this heuristic needs — the counts and the
+ *    registration time — already rode in on the cohort member, so this heuristic costs NO query at
+ *    all. It is the cheapest of the three by a wide margin and the only one that cannot degrade.
+ *
+ * 🔴 IT COUNTS `posts.all`, NOT `posts.visible`, and that is the same decision membership turns on.
+ * An account whose forty uploads were all blocked by the scanner posted forty things at some rate;
+ * the scanner's verdict is evidence ABOUT the account, not a reason to score it as idle. Reading
+ * `visible` here would zero the score of precisely the accounts this detector exists to find, and it
+ * would do it silently.
+ */
+
+/** The id is a metric key and a board-facing sub-score name — an identifier, not a sentence. */
+export const POSTING_VELOCITY_ID = 'posting-velocity';
+
+/**
+ * The youngest age the divisor will use, in hours.
+ *
+ * 🔴 WITHOUT IT THE RATE IS UNBOUNDED AND THE SCORE IS AN ARTEFACT OF SCHEDULING. An account created
+ * ninety seconds before the run posts three items at 120/hour — a top score for something entirely
+ * ordinary — and how extreme it looks depends on the gap between the signup and the cron tick, which
+ * is nothing to do with the account. Fifteen minutes is long enough that the divisor stops being
+ * dominated by that gap and short enough to still separate a twenty-minute wave from a six-hour one.
+ *
+ * This is a judgement, not a measurement, and it is the constant most likely to be wrong. It is also
+ * why `MIN_ITEMS` below exists: the two guard the same corner from different sides.
+ */
+export const MIN_AGE_HOURS = 0.25;
+
+/**
+ * How many items an account must have posted before a rate is computed at all.
+ *
+ * 🔴 THE RATE ALONE IS NOT ENOUGH, because the divisor floor makes a tiny numerator look fast: two
+ * items from a ten-minute-old account is 8/hour, which clears `ZERO_AT` on its own. Two items is not
+ * a wave under any reading, and a detector that says it is will say it about a large share of every
+ * day's genuine signups — the "fires on 90% of accounts" uselessness the scoring seam was built to
+ * make visible. So volume and rate must BOTH be present.
+ */
+export const MIN_ITEMS = 5;
+
+/** The fastest posting rate still worth nothing, in items per hour. */
+export const ZERO_AT_PER_HOUR = 4;
+/** The rate at which the heuristic is fully convinced, in items per hour. */
+export const ONE_AT_PER_HOUR = 40;
+
+/** Hours between registration and the scan instant, floored at the divisor's minimum.
+ *
+ *  Exported because the flooring is behaviour worth asserting on its own: a negative age is clock
+ *  skew between the app and the database, and a rate computed from one is a negative rate. */
+export function effectiveAgeHours(createdAt: Date, now: Date): number {
+  const raw = (now.getTime() - createdAt.getTime()) / 3_600_000;
+  return Math.max(MIN_AGE_HOURS, raw);
+}
+
+/** Items posted per hour of (floored) account age. */
+export function itemsPerHour(total: number, createdAt: Date, now: Date): number {
+  return total / effectiveAgeHours(createdAt, now);
+}
+
+export const postingVelocityHeuristic: BotAccountHeuristic = {
+  id: POSTING_VELOCITY_ID,
+  description:
+    'Items posted per hour of account age, over everything the account posted rather than only ' +
+    'what is still on the site. Costs no query — the cohort read already carries both numbers.',
+  weight: 1,
+  score: ({ member, now }) => {
+    const total = member.posts.all.total;
+    if (total < MIN_ITEMS) return 0;
+    return rampScore(itemsPerHour(total, member.createdAt, now), ZERO_AT_PER_HOUR, ONE_AT_PER_HOUR);
+  },
+  explain: ({ member, now }, score) => {
+    if (score <= 0) return null;
+    const rate = itemsPerHour(member.posts.all.total, member.createdAt, now);
+    const age = effectiveAgeHours(member.createdAt, now);
+    return (
+      `posted ${member.posts.all.total} item(s) in ${age.toFixed(1)}h — ` +
+      `${rate.toFixed(1)}/hour (scores above ${ZERO_AT_PER_HOUR}/hour)`
+    );
+  },
+};

--- a/src/server/services/bot-account-detection/report.ts
+++ b/src/server/services/bot-account-detection/report.ts
@@ -1,6 +1,6 @@
 import { MAX_FINDINGS_PER_REPORT, type AbuseReportInput } from '@civitai/moderation';
 import type { BotAccountCohortMember, SurfaceCounts } from './cohort';
-import { renderSubScores, type BotAccountScore } from './scoring';
+import { renderNotes, renderSubScores, type BotAccountScore } from './scoring';
 
 /**
  * Turning a scored cohort into abuse-board reports.
@@ -104,11 +104,18 @@ export function buildFinding(
   // Floored at zero: an account timestamped after the scan instant is clock skew between the app and
   // the database, not a negative age, and a negative figure in the reason reads as corrupt data.
   const ageHours = Math.max(0, (observedAt.getTime() - member.createdAt.getTime()) / 3_600_000);
+  // 🔴 THE NOTES ARE THE ONLY PART A MODERATOR CAN ACT ON. `Per-heuristic: a=0.60, b=0.00` says
+  // which signal fired and nothing about WHAT IT SAW — so the clause below carries the cluster
+  // sizes, the posting rate and the shared text, and it is placed BEFORE the numbers because it is
+  // the part that gets read. It is omitted entirely when nothing fired rather than rendered as an
+  // empty clause; that is the case where the numbers alone are the whole story.
+  const notes = renderNotes(score.subScores);
   const reason = truncateReason(
     `Shadow-mode observation — NOT actioned. Account ${member.userId}` +
       `${member.username ? ` (${member.username})` : ''} registered ` +
       `${member.createdAt.toISOString()}, ${ageHours.toFixed(1)}h old at scan. ` +
       `${renderPostCounts(member.posts)} ` +
+      `${notes ? `Signals — ${notes}. ` : ''}` +
       `Per-heuristic: ${renderSubScores(score.subScores)}. ` +
       `Blended confidence ${score.confidence.toFixed(2)}.`
   );

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -7,10 +7,19 @@ import {
   collectCohort,
   type CohortReader,
 } from './cohort';
+import {
+  MAX_CONTENT_SAMPLES,
+  collectCohortSignals,
+  emptyCohortSignals,
+  type EvidenceReader,
+} from './evidence';
+import { BOT_ACCOUNT_HEURISTICS } from './heuristics';
 import { BOT_ACCOUNT_DETECTOR, buildFinding, buildReports } from './report';
 import {
-  BOT_ACCOUNT_HEURISTICS,
+  MIN_REPORTED_CONFIDENCE,
+  confidenceBucketCounters,
   heuristicCounters,
+  partitionByConfidence,
   scoreAccount,
   type BotAccountHeuristic,
 } from './scoring';
@@ -34,6 +43,15 @@ export type BotAccountReportSink = (report: AbuseReportInput) => Promise<unknown
 
 export type BotAccountDetectionDeps = {
   reader: CohortReader;
+  /**
+   * The cohort-level sources — registration IPs and content samples.
+   *
+   * Optional, and its absence is a REAL state rather than a test affordance: a run without it scores
+   * the velocity heuristic normally and the two ring heuristics against an empty index. That is why
+   * `emptyCohortSignals()` sets both source flags to "did not run" — so the counters say the ring
+   * heuristics had no data, instead of the run reporting that nobody shared anything.
+   */
+  evidence?: EvidenceReader;
   sendReport: BotAccountReportSink;
   /** The producer's clock. Injected, because the report's `startedAt`/`finishedAt` are the producer's
    *  own times and the board's "how current is this" reading depends on them being real. */
@@ -65,14 +83,40 @@ export type BotAccountDetectionOptions = {
   pageSize?: number;
   maxAccounts?: number;
   maxFindingsPerReport?: number;
+  /**
+   * The confidence at or above which a scored member becomes a finding. Defaults to
+   * `MIN_REPORTED_CONFIDENCE`.
+   *
+   * 🔴 IT FILTERS REPORTING, NEVER SCORING. Every cohort member is scored and lands in the
+   * distribution counters whatever this is set to; the only thing it decides is whether a moderator
+   * sees a row. Setting it to 0 restores the previous behaviour — every member reported — and is
+   * how a deliberate full-cohort grading run is requested, rather than something that happens by
+   * default on a live board.
+   */
+  minConfidence?: number;
+  /** Ceiling on content rows read for the templating heuristic. Defaults to `MAX_CONTENT_SAMPLES`. */
+  maxContentSamples?: number;
 };
 
 export type BotAccountDetectionResult = {
   detector: string;
   /** Accounts read from the window, before the has-posted filter. */
   scanned: number;
-  /** Accounts that made the cohort, i.e. findings. */
+  /**
+   * Accounts that made the cohort and were SCORED.
+   *
+   * 🔴 NO LONGER THE NUMBER OF FINDINGS. It was, while every member became one; the threshold broke
+   * that identity and the two names are kept apart deliberately so a caller cannot read a cohort
+   * size as a finding count.
+   */
   cohortSize: number;
+  /** Members at or above the threshold — the rows a moderator actually receives. */
+  findingsReported: number;
+  /** Members scored BELOW the threshold. Never zero-by-omission: this is the number that makes a
+   *  small finding count readable. */
+  findingsSuppressed: number;
+  /** The threshold this run applied. */
+  minConfidence: number;
   /** The window held more accounts than the cap allowed the run to read. */
   capped: boolean;
   reports: number;
@@ -93,6 +137,15 @@ export class BotAccountReportError extends Error {
   }
 }
 
+/** A map lookup that cannot fail silently. The alternative — `map.get(k)!` — turns a broken
+ *  invariant into `undefined` flowing into a reason string as "Account undefined". */
+function mustGet<K, V>(map: Map<K, V>, key: K): V {
+  const value = map.get(key);
+  if (value === undefined)
+    throw new Error(`bot-account-detection: no cohort member for scored id ${String(key)}`);
+  return value;
+}
+
 export async function runBotAccountDetection(
   deps: BotAccountDetectionDeps,
   options: BotAccountDetectionOptions = {}
@@ -102,6 +155,8 @@ export async function runBotAccountDetection(
   const pageSize = options.pageSize ?? COHORT_PAGE_SIZE;
   const maxAccounts = options.maxAccounts ?? MAX_COHORT_ACCOUNTS;
   const maxFindingsPerReport = options.maxFindingsPerReport ?? MAX_FINDINGS_PER_REPORT;
+  const minConfidence = options.minConfidence ?? MIN_REPORTED_CONFIDENCE;
+  const maxContentSamples = options.maxContentSamples ?? MAX_CONTENT_SAMPLES;
   const log = deps.log ?? (() => undefined);
   const checkCanceled = deps.checkCanceled ?? (() => undefined);
 
@@ -122,10 +177,42 @@ export async function runBotAccountDetection(
     createdAfter: createdAfter.toISOString(),
   });
 
+  // The cohort-level indexes, read once for the whole run. Without an evidence reader the ring
+  // heuristics score against an empty index whose source flags say "did not run" — which the
+  // counters below publish, so a run with no evidence source is never mistaken for a run that found
+  // no rings.
+  const signals = deps.evidence
+    ? await collectCohortSignals(deps.evidence, cohort.members, {
+        chunkSize: pageSize,
+        maxContentSamples,
+        checkCanceled,
+        log,
+      })
+    : emptyCohortSignals();
+  log('bot-account-detection:signals', {
+    registrationIps: signals.sources.registrationIps,
+    contentBudgetExhausted: signals.sources.contentBudgetExhausted,
+    membersSampledForContent: signals.sources.membersSampledForContent,
+    distinctIps: signals.membersPerIp.size,
+    distinctDomains: signals.membersPerDomain.size,
+    distinctFingerprints: signals.membersPerFingerprint.size,
+  });
+
+  const memberById = new Map(cohort.members.map((m) => [m.userId, m]));
   const scores = cohort.members.map((member) =>
-    scoreAccount(heuristics, { member, now: startedAt })
+    scoreAccount(heuristics, { member, now: startedAt, signals })
   );
-  const findings = cohort.members.map((member, i) => buildFinding(member, scores[i], startedAt));
+
+  // 🔴 THE THRESHOLD, APPLIED HERE AND NOWHERE ELSE. Every member above was scored; only the
+  // reported half becomes a finding. The suppressed half is still counted, bucketed and summarised
+  // below — a member nobody can see is a member nobody can grade, and grading is the entire purpose
+  // of the shadow phase.
+  const { reported, suppressed } = partitionByConfidence(scores, minConfidence);
+  const findings = reported.map((score) =>
+    // Every score was built from a member, so the lookup cannot miss; the non-null assertion would
+    // be the only place in this module where a missing key is silent, so it throws instead.
+    buildFinding(mustGet(memberById, score.userId), score, startedAt)
+  );
 
   const finishedAt = deps.now();
 
@@ -155,7 +242,34 @@ export async function runBotAccountDetection(
     // on, because its absence is indistinguishable from the producer not running.
     cohort_capped: cohort.capped ? 1 : 0,
     heuristics_registered: heuristics.length,
+
+    // 🔴 THE SUPPRESSION LEDGER. `findings_reported` on its own is the reassuring number this
+    // project keeps being burned by — "12 findings" reads as a quiet day whether the cohort was
+    // twelve accounts or the whole day's signups. The pair, plus the threshold that produced it,
+    // plus the full distribution below, is what makes a small number readable. All emitted every
+    // run, zeros included.
+    findings_reported: reported.length,
+    findings_suppressed: suppressed.length,
+    // A float, which the contract's `z.record(z.string(), z.number())` accepts. Recorded because a
+    // distribution is uninterpretable without the cut that was applied to it, and the cut is
+    // configurable.
+    report_min_confidence: minConfidence,
+
+    // 🔴 EVIDENCE AVAILABILITY, AS 0/1 ON EVERY RUN. Two of the three heuristics score 0 when their
+    // source is missing, which is byte-identical to scoring 0 because nothing was found. These are
+    // the only things that tell the two apart, so a grading pass can exclude the runs whose ring
+    // heuristics were blind rather than averaging them in as evidence of no rings.
+    evidence_registration_ips: signals.sources.registrationIps ? 1 : 0,
+    evidence_content_budget_exhausted: signals.sources.contentBudgetExhausted ? 1 : 0,
+    evidence_members_sampled_for_content: signals.sources.membersSampledForContent,
+    evidence_content_budget: maxContentSamples,
+    evidence_distinct_registration_ips: signals.membersPerIp.size,
+    evidence_distinct_email_domains: signals.membersPerDomain.size,
+    evidence_distinct_content_fingerprints: signals.membersPerFingerprint.size,
+
     ...heuristicCounters(scores),
+    // Over EVERY scored member, not only the reported ones — see `confidenceBucketCounters`.
+    ...confidenceBucketCounters(scores),
   };
 
   // 🔴 The truncation sentence names WHICH END was dropped. "TRUNCATED at the N-account cap" alone
@@ -170,6 +284,26 @@ export async function runBotAccountDetection(
     `the site; ${nothingOnSite} of the ${cohort.members.length} have nothing left on the site at ` +
     `all. Membership counts everything an account posted, so an account whose uploads were all ` +
     `blocked or removed is included rather than dropped.` +
+    // 🔴 THE SUPPRESSION SENTENCE. The counters carry this too, but the summary is what a human
+    // reads first, and a finding count with no denominator beside it is the shape of every
+    // reassuring zero this detector was built to avoid producing.
+    ` ${reported.length} scored at or above the ${minConfidence.toFixed(
+      2
+    )} reporting threshold and ` +
+    `appear below; ${suppressed.length} scored under it and are counted in the ` +
+    `confidence_bucket_* counters but NOT reported as findings.` +
+    // Two of three heuristics are ring detectors and both can go dark. Saying so in the summary
+    // stops a reader treating a low-confidence run as evidence that no ring existed.
+    (signals.sources.registrationIps
+      ? ''
+      : ` 🔴 REGISTRATION-IP DATA WAS UNAVAILABLE this run, so the clustering heuristic scored on ` +
+        `email domain alone — a low score from it is not evidence that accounts share no IP.`) +
+    (signals.sources.contentBudgetExhausted
+      ? ` 🔴 THE CONTENT SAMPLE BUDGET (${maxContentSamples} rows) WAS EXHAUSTED after ` +
+        `${signals.sources.membersSampledForContent} of ${cohort.members.length} members. Members ` +
+        `are sampled newest-first, so the unsampled remainder is the OLDEST end of the window and ` +
+        `scored 0 on content templating for want of data.`
+      : '') +
     (cohort.capped
       ? ` 🔴 TRUNCATED at the ${maxAccounts}-account cap. Accounts are read NEWEST FIRST, so the ` +
         `${cohort.scanned} read are the most recent of the window and the unread remainder is its ` +
@@ -207,6 +341,9 @@ export async function runBotAccountDetection(
     detector: BOT_ACCOUNT_DETECTOR,
     scanned: cohort.scanned,
     cohortSize: cohort.members.length,
+    findingsReported: reported.length,
+    findingsSuppressed: suppressed.length,
+    minConfidence,
     capped: cohort.capped,
     reports: reports.length,
     reportsSent: sent,

--- a/src/server/services/bot-account-detection/run.ts
+++ b/src/server/services/bot-account-detection/run.ts
@@ -13,7 +13,7 @@ import {
   emptyCohortSignals,
   type EvidenceReader,
 } from './evidence';
-import { BOT_ACCOUNT_HEURISTICS } from './heuristics';
+import { BOT_ACCOUNT_HEURISTICS, isCommonEmailDomain } from './heuristics';
 import { BOT_ACCOUNT_DETECTOR, buildFinding, buildReports } from './report';
 import {
   MIN_REPORTED_CONFIDENCE,
@@ -21,6 +21,7 @@ import {
   heuristicCounters,
   partitionByConfidence,
   scoreAccount,
+  soleSignalCounters,
   type BotAccountHeuristic,
 } from './scoring';
 
@@ -185,12 +186,17 @@ export async function runBotAccountDetection(
     ? await collectCohortSignals(deps.evidence, cohort.members, {
         chunkSize: pageSize,
         maxContentSamples,
+        // The window this run already computed, handed to the ClickHouse read as its `time` bound.
+        // Every cohort account was created after it, so it prunes the scan without removing a row
+        // the query wants.
+        createdAfter,
         checkCanceled,
         log,
       })
     : emptyCohortSignals();
   log('bot-account-detection:signals', {
     registrationIps: signals.sources.registrationIps,
+    contentSamples: signals.sources.contentSamples,
     contentBudgetExhausted: signals.sources.contentBudgetExhausted,
     membersSampledForContent: signals.sources.membersSampledForContent,
     distinctIps: signals.membersPerIp.size,
@@ -228,6 +234,16 @@ export async function runBotAccountDetection(
   const postedAll = cohort.members.reduce((sum, m) => sum + m.posts.all.total, 0);
   const postedExcluded = cohort.members.reduce((sum, m) => sum + m.posts.excluded.total, 0);
 
+  // 🔴 THE DOMAIN LIST'S OWN BLIND SPOT, AS A NUMBER. `COMMON_EMAIL_DOMAINS` scores a member's
+  // domain half at 0 by construction, so a real ring that registered on a listed provider is
+  // invisible to the clustering heuristic and to every counter that reads its score. This is how
+  // many members that applied to — the SIZE of the blind spot, which is the most the shadow phase
+  // can measure; it cannot say how many of them were a ring. It was asserted in a code comment
+  // before it existed anywhere, which is the failure mode the comment was warning about.
+  const domainsSuppressed = cohort.members.filter(
+    (m) => m.emailDomain !== null && isCommonEmailDomain(m.emailDomain)
+  ).length;
+
   const counters: Record<string, number> = {
     window_hours: windowHours,
     cohort_scanned: cohort.scanned,
@@ -260,16 +276,24 @@ export async function runBotAccountDetection(
     // the only things that tell the two apart, so a grading pass can exclude the runs whose ring
     // heuristics were blind rather than averaging them in as evidence of no rings.
     evidence_registration_ips: signals.sources.registrationIps ? 1 : 0,
+    // The content read's own availability, on the same 0/1 terms and for the same reason: a
+    // templating score of 0 across the cohort means "nobody templated" only when this is 1.
+    evidence_content_samples: signals.sources.contentSamples ? 1 : 0,
     evidence_content_budget_exhausted: signals.sources.contentBudgetExhausted ? 1 : 0,
     evidence_members_sampled_for_content: signals.sources.membersSampledForContent,
     evidence_content_budget: maxContentSamples,
     evidence_distinct_registration_ips: signals.membersPerIp.size,
     evidence_distinct_email_domains: signals.membersPerDomain.size,
     evidence_distinct_content_fingerprints: signals.membersPerFingerprint.size,
+    domains_suppressed_common: domainsSuppressed,
 
     ...heuristicCounters(scores),
     // Over EVERY scored member, not only the reported ones — see `confidenceBucketCounters`.
     ...confidenceBucketCounters(scores),
+    // Over the REPORTED members only: which findings rest on ONE heuristic and nothing else. See
+    // `soleSignalCounters` — this is what a known collision (a generation-parameter paste matching
+    // itself under `content-templating`) shows up as, and it is not visible in `fired`.
+    ...soleSignalCounters(reported, heuristics),
   };
 
   // 🔴 The truncation sentence names WHICH END was dropped. "TRUNCATED at the N-account cap" alone
@@ -298,6 +322,24 @@ export async function runBotAccountDetection(
       ? ''
       : ` 🔴 REGISTRATION-IP DATA WAS UNAVAILABLE this run, so the clustering heuristic scored on ` +
         `email domain alone — a low score from it is not evidence that accounts share no IP.`) +
+    // 🔴 THE READ RAN AND MATCHED NOTHING — the case the availability flag alone cannot express.
+    // `evidence_registration_ips: 1` with `evidence_distinct_registration_ips: 0` over a non-empty
+    // cohort is the signature of a query that is wrong rather than of a day with no shared
+    // addresses: a changed column name, a moved table, an over-tight filter. The counters already
+    // carry both numbers; a human reading the summary had nothing, and this is the reader who would
+    // recognise it.
+    (signals.sources.registrationIps && signals.membersPerIp.size === 0 && cohort.members.length > 0
+      ? ` 🔴 THE REGISTRATION-IP READ RAN AND MATCHED NOTHING for any of the ` +
+        `${cohort.members.length} member(s). That is possible on a quiet day, and it is also what a ` +
+        `wrong column, a moved table or an over-tight filter looks like — the two are not ` +
+        `distinguishable from this run alone.`
+      : '') +
+    (signals.sources.contentSamples
+      ? ''
+      : ` 🔴 CONTENT SAMPLE DATA WAS UNAVAILABLE this run — the read either did not run or failed ` +
+        `and its partial result was discarded — so the content-templating heuristic scored 0 for ` +
+        `every member for want of data. That is not evidence that no accounts posted the same text. ` +
+        `The rest of the run was scored normally.`) +
     (signals.sources.contentBudgetExhausted
       ? ` 🔴 THE CONTENT SAMPLE BUDGET (${maxContentSamples} rows) WAS EXHAUSTED after ` +
         `${signals.sources.membersSampledForContent} of ${cohort.members.length} members. Members ` +

--- a/src/server/services/bot-account-detection/scoring.ts
+++ b/src/server/services/bot-account-detection/scoring.ts
@@ -167,6 +167,40 @@ export function heuristicCounters(scores: BotAccountScore[]): Record<string, num
   return counters;
 }
 
+/**
+ * How many of these scores each heuristic was the ONLY firing signal on.
+ *
+ * 🔴 THIS IS THE COUNTER THE FALSE-POSITIVE QUESTION IS ANSWERED WITH, and `fired` cannot answer it.
+ * A heuristic that fires alongside the other two on the same account is corroborated; one that fires
+ * BY ITSELF is carrying a finding on its own, and that is the population where a known collision
+ * turns into a report nobody should have received. The worked example is `content-templating`: a
+ * generation-parameter paste — `Steps: …, Sampler: …, CFG scale: …, Seed: …` — fingerprints
+ * identically to the same line with different numbers, because the digit masking is doing the
+ * matching, so six accounts pasting their settings under one model look like one ring. Nothing about
+ * such an account fires the other two heuristics, so it lands here and nowhere else.
+ *
+ * Run over the REPORTED members rather than all scored ones: a sole signal below the threshold
+ * produced no finding and cost nobody anything, and mixing the two would bury the number that
+ * matters in the cohort's own size.
+ *
+ * A member on whom NOTHING fired contributes to no key, which is why these are emitted for every
+ * registered heuristic including the zeros — a key that appears only when non-zero cannot be charted.
+ */
+export function soleSignalCounters(
+  scores: BotAccountScore[],
+  heuristics: readonly BotAccountHeuristic[]
+): Record<string, number> {
+  const counters: Record<string, number> = {};
+  for (const heuristic of heuristics) counters[`heuristic:${heuristic.id}:sole_signal`] = 0;
+  for (const account of scores) {
+    const fired = account.subScores.filter((s) => s.score > 0);
+    if (fired.length !== 1) continue;
+    const key = `heuristic:${fired[0].id}:sole_signal`;
+    counters[key] = (counters[key] ?? 0) + 1;
+  }
+  return counters;
+}
+
 /** The compact `id=0.00` rendering the finding's reason carries, so a moderator sees each
  *  heuristic's own number rather than only the blend. */
 export function renderSubScores(subScores: HeuristicScore[]): string {

--- a/src/server/services/bot-account-detection/scoring.ts
+++ b/src/server/services/bot-account-detection/scoring.ts
@@ -168,16 +168,47 @@ export function heuristicCounters(scores: BotAccountScore[]): Record<string, num
 }
 
 /**
- * How many of these scores each heuristic was the ONLY firing signal on.
+ * How much larger than every other score a heuristic's own must be before the finding counts as
+ * carried by it alone.
+ *
+ * 🔴 DERIVED FROM THE REGISTRY'S SIZE, NOT PICKED. With `n` equally weighted heuristics and a top
+ * score `s`, every other is at most `s / k`, so the rest together contribute at most `(n - 1) · s / k`
+ * — which is less than `s` exactly when `k > n - 1`. At `n = 3` that makes 3 the smallest integer
+ * multiple at which the leading heuristic outweighs everything else combined, which is the plain
+ * reading of "this finding rests on one signal".
+ *
+ * 🔴 SO IT IS TIED TO `n = 3`. A fourth registered heuristic makes `k > 3` the condition and this
+ * value no longer satisfies it — re-derive here when `heuristics/index.ts` grows, rather than
+ * leaving a counter that quietly starts calling a two-signal finding sole.
+ */
+export const SOLE_SIGNAL_DOMINANCE = 3;
+
+/**
+ * How many of these scores each heuristic CARRIED ON ITS OWN.
  *
  * 🔴 THIS IS THE COUNTER THE FALSE-POSITIVE QUESTION IS ANSWERED WITH, and `fired` cannot answer it.
- * A heuristic that fires alongside the other two on the same account is corroborated; one that fires
- * BY ITSELF is carrying a finding on its own, and that is the population where a known collision
- * turns into a report nobody should have received. The worked example is `content-templating`: a
- * generation-parameter paste — `Steps: …, Sampler: …, CFG scale: …, Seed: …` — fingerprints
- * identically to the same line with different numbers, because the digit masking is doing the
- * matching, so six accounts pasting their settings under one model look like one ring. Nothing about
- * such an account fires the other two heuristics, so it lands here and nowhere else.
+ * A heuristic that fires alongside the other two on the same account is corroborated; one that
+ * carries a finding by itself is the population where a known collision turns into a report nobody
+ * should have received. The worked example is `content-templating`: a generation-parameter paste —
+ * `Steps: …, Sampler: …, CFG scale: …, Seed: …` — fingerprints identically to the same line with
+ * different numbers, because the digit masking is doing the matching, so six accounts pasting their
+ * settings under one model look like one ring.
+ *
+ * 🔴 "CARRIED IT" IS A DOMINANCE TEST, NOT AN EXCLUSIVITY TEST, AND THE DIFFERENCE IS THE WHOLE
+ * POINT OF THE COUNTER. The predicate used to be `exactly one heuristic scored above zero`, and that
+ * measured a strictly smaller population than the sentence above describes: the collision's own
+ * routine shape is a member who ALSO scores a trace somewhere else, and a trace excluded it. A
+ * member 40 minutes old with 6 parameter-paste comments and a fingerprint cluster of 6 scores
+ * `posting-velocity` 0.1389 — six items in 0.67h is 9/hour, just over the 4/hour floor — and
+ * `content-templating` 0.5. It blends to 0.2130, clears `MIN_REPORTED_CONFIDENCE`, is REPORTED, and
+ * under the old predicate incremented nothing. An operator reading
+ * `content-templating:sole_signal = 0` concluded the collision produced no reports, on the one
+ * number the decision about that collision was deferred to, and the error ran in the reassuring
+ * direction. The dominance form counts it: 0.5 ≥ 3 × 0.1389.
+ *
+ * Two signals that genuinely agree still count for neither. At any multiple above 1 a tie fails the
+ * test — `0.9 ≥ 3 × 0.9` is false — so corroboration is excluded by the arithmetic rather than by a
+ * special case.
  *
  * Run over the REPORTED members rather than all scored ones: a sole signal below the threshold
  * produced no finding and cost nobody anything, and mixing the two would bury the number that
@@ -185,6 +216,12 @@ export function heuristicCounters(scores: BotAccountScore[]): Record<string, num
  *
  * A member on whom NOTHING fired contributes to no key, which is why these are emitted for every
  * registered heuristic including the zeros — a key that appears only when non-zero cannot be charted.
+ *
+ * The key keeps the name `sole_signal` even though the predicate moved. It is a metric name, and
+ * the question it answers — which heuristic carried this finding — is the same one; the change is
+ * that it now measures the population that question names instead of a subset of it. Nothing has
+ * consumed the key yet, so no series breaks either way, and renaming costs every reader of the
+ * design notes a lookup for no gain in what the number means.
  */
 export function soleSignalCounters(
   scores: BotAccountScore[],
@@ -193,9 +230,22 @@ export function soleSignalCounters(
   const counters: Record<string, number> = {};
   for (const heuristic of heuristics) counters[`heuristic:${heuristic.id}:sole_signal`] = 0;
   for (const account of scores) {
-    const fired = account.subScores.filter((s) => s.score > 0);
-    if (fired.length !== 1) continue;
-    const key = `heuristic:${fired[0].id}:sole_signal`;
+    // The leading score, and the largest of everything else. A registry of one leaves the runner-up
+    // at 0, which is what makes a single-heuristic run count — there is nothing for it to share the
+    // finding with.
+    let leader: HeuristicScore | null = null;
+    let runnerUp = 0;
+    for (const sub of account.subScores) {
+      if (leader === null || sub.score > leader.score) {
+        if (leader !== null) runnerUp = Math.max(runnerUp, leader.score);
+        leader = sub;
+      } else {
+        runnerUp = Math.max(runnerUp, sub.score);
+      }
+    }
+    if (leader === null || leader.score <= 0) continue;
+    if (leader.score < SOLE_SIGNAL_DOMINANCE * runnerUp) continue;
+    const key = `heuristic:${leader.id}:sole_signal`;
     counters[key] = (counters[key] ?? 0) + 1;
   }
   return counters;

--- a/src/server/services/bot-account-detection/scoring.ts
+++ b/src/server/services/bot-account-detection/scoring.ts
@@ -1,9 +1,8 @@
 import type { BotAccountCohortMember } from './cohort';
+import type { CohortSignals } from './evidence';
 
 /**
- * The scoring seam. NO DETECTION LIVES HERE YET, and that is the deliverable rather than an omission
- * — the heuristics are a separate change, and inventing some to fill the shape out would be
- * inventing exactly the thing the shadow phase exists to measure.
+ * The scoring seam.
  *
  * Why a registry of independent sub-scores rather than one `score(member)` function: shadow mode is
  * not a dry run of the blend, it is a grading harness for each heuristic ON ITS OWN. A signal that
@@ -11,15 +10,31 @@ import type { BotAccountCohortMember } from './cohort';
  * visible if every heuristic's own number reaches the board. So each contributes a separately
  * reportable value, the blend is derived from those rather than the other way round, and the
  * per-heuristic counters go out with every report.
+ *
+ * The registry itself lives in `heuristics/index.ts`, not here — this file owns the MECHANICS
+ * (clamping, blending, counting, the reporting threshold) and knows nothing about what any
+ * particular heuristic measures.
  */
 
-/** Everything a heuristic is allowed to look at. A parameter object rather than a bare member so a
- *  heuristic that needs a second source (ClickHouse events, registration IPs) is added by widening
- *  this type once, not by changing every signature. */
+/**
+ * Everything a heuristic is allowed to look at.
+ *
+ * A parameter object rather than a bare member precisely so a heuristic needing a second source is
+ * added by widening this type ONCE. That is what happened: `signals` is that widening, and every
+ * heuristic signature was untouched by it.
+ */
 export type BotAccountEvidence = {
   member: BotAccountCohortMember;
   /** The run's clock, so a heuristic never reaches for `new Date()` and becomes untestable. */
   now: Date;
+  /**
+   * The cohort-level indexes — who else registered on this IP, who else posted this text.
+   *
+   * 🔴 IT CARRIES ITS OWN AVAILABILITY (`signals.sources`), and a heuristic reading a count out of
+   * it is expected to consult that before treating a zero as a finding. An empty index means "no
+   * cluster" OR "the source was down", and those two are not the same claim.
+   */
+  signals: CohortSignals;
 };
 
 export type BotAccountHeuristic = {
@@ -64,25 +79,23 @@ export type BotAccountScore = {
 };
 
 /**
- * 🔴 THE PLACEHOLDER. It detects nothing, by construction: it returns 0 for every account and
- * explains nothing.
+ * 🔴 THE PLACEHOLDER, NO LONGER REGISTERED. It returns 0 for every account and explains nothing.
  *
- * It exists so the registry is exercised on a real run — an empty array makes every loop, every
- * counter and every blend vacuous, and a seam that has never had anything in it is not a seam that
- * has been shown to work. Delete it in the change that adds the first real heuristic; it is not a
- * baseline, a prior, or a floor, and no calibration should ever be derived from it.
+ * It shipped as the sole member of the registry so that the seam was exercised on a real run before
+ * any heuristic existed. It is NOT in `BOT_ACCOUNT_HEURISTICS` any more — `heuristics/index.ts` now
+ * holds the three real ones — and it is kept only because the registry-mechanics tests need an inert
+ * heuristic to exercise blending and counting with, independently of what any real one measures.
+ *
+ * It is not a baseline, a prior, or a floor, and no calibration may be derived from it.
  */
 export const placeholderHeuristic: BotAccountHeuristic = {
   id: 'placeholder-no-op',
   description:
-    'Placeholder. Scores every account 0 and detects nothing. Remove with the first real heuristic.',
+    'Placeholder. Scores every account 0 and detects nothing. Not registered; kept for tests only.',
   weight: 1,
   score: () => 0,
   explain: () => null,
 };
-
-/** The heuristics a production run uses. */
-export const BOT_ACCOUNT_HEURISTICS: readonly BotAccountHeuristic[] = [placeholderHeuristic];
 
 /**
  * Force one heuristic's return value into the contract.
@@ -159,4 +172,120 @@ export function heuristicCounters(scores: BotAccountScore[]): Record<string, num
 export function renderSubScores(subScores: HeuristicScore[]): string {
   if (!subScores.length) return 'no heuristics registered';
   return subScores.map((s) => `${s.id}=${s.score.toFixed(2)}`).join(', ');
+}
+
+/**
+ * The evidence-citing clauses, in one string a moderator can act on.
+ *
+ * 🔴 THE NOTES WERE COLLECTED AND THEN DROPPED. `HeuristicScore.note` has always existed and every
+ * heuristic has always been asked to produce one, but the finding's reason rendered only
+ * `renderSubScores` — the bare `id=0.00` list. So the board carried three numbers and no statement
+ * of what any of them SAW, which is the half a moderator needs to decide anything. With a
+ * do-nothing placeholder as the only heuristic that gap was invisible, because the only note was
+ * always `null`.
+ *
+ * Heuristics that scored 0 return `null` and contribute nothing here, deliberately: a reason that
+ * recites every signal that did not fire buries the one that did.
+ */
+export function renderNotes(subScores: HeuristicScore[]): string | null {
+  const notes = subScores.flatMap((s) => (s.note ? [`${s.id}: ${s.note}`] : []));
+  return notes.length ? notes.join(' | ') : null;
+}
+
+/**
+ * 🔴 THE REPORTING THRESHOLD. WITHOUT IT THE DETECTOR CANNOT HAVE A REAL RUN.
+ *
+ * `run.ts` turned every cohort member into a finding with no confidence filter anywhere. With a
+ * do-nothing placeholder that was harmless — every finding was confidence 0 and the run was never
+ * meant to be looked at. With three real heuristics it is not: a day's posting cohort would land on
+ * a live moderator board in front of the whole abuse team, batched across up to ten reports, almost
+ * entirely as confidence-0 rows. A board that is mostly noise on its first day is a board nobody
+ * reads on its second, and that failure is not recoverable by tuning later.
+ *
+ * WHAT THE DEFAULT IS SET AGAINST — the blend's own arithmetic, not an intuition. With three equally
+ * weighted heuristics the blend is their mean, so:
+ *   - one heuristic alone at 0.45 → 0.15   (the threshold)
+ *   - one heuristic alone at 1.00 → 0.33
+ *   - two at 0.23 each            → 0.15
+ * So 0.15 admits an account on the strength of ONE signal that is about half convinced, and rejects
+ * one where every signal is weak. That is the loosest cut that still means something, chosen because
+ * the shadow phase's job is to see marginal cases — a tight threshold would report only the accounts
+ * nobody needed a detector to find, and would teach us nothing about where the real line sits.
+ *
+ * 🔴 IT IS A STARTING POINT, NOT A CALIBRATION, and nothing here pretends otherwise. No run has
+ * produced a graded finding, so this number is derived from the weighting rather than from data.
+ * The `confidence_bucket_*` counters below exist precisely to replace it: after a few runs the
+ * distribution says where the mass actually sits, and the threshold moves to a measured value.
+ * Until then the honest statement is that it is an argument, and the counters are what will settle it.
+ */
+export const MIN_REPORTED_CONFIDENCE = 0.15;
+
+/**
+ * How many buckets the confidence distribution is reported in.
+ *
+ * Ten, i.e. tenths. Coarse on purpose: the counters are a shape, not a histogram to do statistics
+ * on, and a wide bucket cannot be reversed into any individual account's score — which matters
+ * because these ride out on every report whether or not the account produced a finding.
+ */
+export const CONFIDENCE_BUCKETS = 10;
+
+/** The counter key for one bucket — `confidence_bucket_20_30` is `0.2 <= c < 0.3`, in percent so
+ *  the key is an identifier with no decimal point in it. */
+export const confidenceBucketKey = (index: number): string =>
+  `confidence_bucket_${index * 10}_${(index + 1) * 10}`;
+
+/**
+ * Which bucket a confidence falls in.
+ *
+ * 🔴 THE TOP BUCKET IS CLOSED AT BOTH ENDS. Every other bucket is half-open, but `1.0` is a real and
+ * meaningful score — it is what a fully convinced heuristic produces — and a naive `floor(c * 10)`
+ * puts it in an eleventh bucket that no key exists for, silently dropping the most interesting
+ * accounts in the run out of the distribution entirely. Clamping is what keeps the buckets summing
+ * to the number scored.
+ */
+export function confidenceBucket(confidence: number): number {
+  if (!Number.isFinite(confidence)) return 0;
+  const clamped = Math.min(Math.max(confidence, 0), 1);
+  return Math.min(CONFIDENCE_BUCKETS - 1, Math.floor(clamped * CONFIDENCE_BUCKETS));
+}
+
+/**
+ * 🔴 THE DISTRIBUTION OF EVERY MEMBER SCORED, REPORTED OR NOT.
+ *
+ * This is the counterweight to the threshold and the reason the threshold is safe to add. A member
+ * dropped below the cut produces no finding, so nothing on the board mentions it — and the whole
+ * point of shadow mode is grading the heuristics, which cannot be done over a population that was
+ * silently discarded. A run reporting "12 findings" while the whole rest of the cohort scored 0 is a
+ * reassuring number that hides the only fact worth knowing about that run.
+ *
+ * So: every bucket is emitted on every run, INCLUDING the empty ones. A counter that appears only
+ * when non-zero cannot be charted or alerted on, because its absence is indistinguishable from the
+ * producer not having run — the same reasoning `cohort_capped` is emitted as 0/1 for.
+ */
+export function confidenceBucketCounters(scores: BotAccountScore[]): Record<string, number> {
+  const counters: Record<string, number> = {};
+  for (let i = 0; i < CONFIDENCE_BUCKETS; i += 1) counters[confidenceBucketKey(i)] = 0;
+  for (const score of scores)
+    counters[confidenceBucketKey(confidenceBucket(score.confidence))] += 1;
+  return counters;
+}
+
+/**
+ * Split the scored cohort at the threshold.
+ *
+ * `>=`, so a score exactly equal to the threshold IS reported. The alternative reading makes the
+ * constant's name a lie — a "minimum reported confidence" that is itself not reported — and the
+ * off-by-one would be invisible in the counters, which is the worst place for one to hide.
+ *
+ * Both halves come back. The caller needs the suppressed side to count it, not merely to discard it.
+ */
+export function partitionByConfidence(
+  scores: BotAccountScore[],
+  minConfidence: number
+): { reported: BotAccountScore[]; suppressed: BotAccountScore[] } {
+  const reported: BotAccountScore[] = [];
+  const suppressed: BotAccountScore[] = [];
+  for (const score of scores)
+    (score.confidence >= minConfidence ? reported : suppressed).push(score);
+  return { reported, suppressed };
 }


### PR DESCRIPTION
Replaces the labelled always-zero placeholder with the first three real heuristics, and adds the reporting threshold the detector needed before it could have a real run.

**Still shadow mode.** Mutes nobody, bans nobody, writes no `UserRestriction` row. That property was re-verified, not assumed: the asserted operation ledger, the import ledger and the real `dbWrite` spy all still hold, and a **third ledger** was added because the first two are structurally blind to the new data source.

The LLM read is deliberately not here. Nothing was scaffolded for it beyond the existing registry shape.

---

## The threshold, and why it was not optional

`run.ts` did `cohort.members.map(...)` — **every cohort member became a finding**, with no confidence filter anywhere. With a do-nothing placeholder that was harmless. With three real heuristics it would put a whole day's posting cohort on a live moderator board as confidence-0 rows, batched across up to ten reports. A board that is mostly noise on its first day is a board nobody reads on its second, and that is not recoverable by tuning later.

- **`MIN_REPORTED_CONFIDENCE = 0.15`**, configurable per run via `minConfidence`.
- **Set against the blend's own arithmetic, not an intuition.** With three equal weights the blend is their mean:
  - one heuristic alone at 0.45 → **0.15** (the cut)
  - one heuristic alone at 1.00 → 0.33
  - two at 0.23 each → 0.15

  So it admits an account on the strength of **one** signal that is about half convinced, and rejects one where every signal is weak. That is the loosest cut that still means something — a tight threshold would report only the accounts nobody needed a detector to find, and would teach us nothing about where the real line sits.
- **It filters reporting, never scoring.** Every member is scored and bucketed whatever it is set to. `minConfidence: 0` restores the previous full-cohort behaviour and is how a deliberate grading run is requested.
- **It is a starting point, not a calibration**, and the code says so. No run has produced a graded finding, so the number comes from the weighting rather than from data. The bucket counters below exist to replace it.

### The suppressed members are counted, not dropped

A member nobody can see is a member nobody can grade, and grading is the entire purpose of the shadow phase. Every run emits, zeros included:

| counter | meaning |
|---|---|
| `findings_reported` | members at or above the cut |
| `findings_suppressed` | members below it |
| `report_min_confidence` | the cut actually applied |
| `confidence_bucket_0_10` … `confidence_bucket_90_100` | the distribution over **every scored member** |

The buckets sum back to `cohort_size`, and that equality is asserted — nothing goes from scoring to reporting without being counted. The summary sentence states the split too, because the summary is what a human reads first.

---

## The three heuristics

Each contributes an independent, separately-reportable sub-score. Equal weights, deliberately: nothing yet distinguishes them by precision, so any other split would be a number invented to look considered.

### 1. `posting-velocity` — items posted per hour of account age
Adapted from `apps/moderator/src/lib/server/comment-spam.service.ts`. What carried over: the rate is measured **against account age**, and the floor at zero for a clock that ran backwards. What changed: that service expresses age as a cut-off on a burst; the cohort here is already age-bounded to a day, so age becomes the **divisor** — same idea with more resolution, since it separates the twenty-minute account from the twenty-three-hour one where a cut-off keeps both.

Counts `posts.all`, **not** `posts.visible`. The canonical wave is forty uploads the scanner blocked; reading `visible` would score exactly the accounts this detector exists to find as idle, and silently.

**Cost: no query at all.** Both numbers already rode in on the cohort read. The only one of the three that cannot degrade.

### 2. `registration-cluster` — how many other new posting accounts share this one's registration IP or uncommon email domain
Adapted from `apps/moderator/src/lib/server/bulk-ban.service.ts`. Keeps its load-bearing choice: **registration IPs only, never logins** — a shared login IP is weak evidence because carriers and offices put thousands of unrelated people behind one address. Inverts its framing: that service is investigative (a moderator supplies the accounts), here the population is the cohort itself, which is a much narrower denominator and is what makes an unbounded count usable without a base rate.

The two halves combine with **`max`, not a sum**, so the sub-score always reads as "the size of the ring this account is in".

**The only heuristic here that can see a coordinated ring**, and the only one whose email half is free (a wider `select` on the existing `user.findMany` — no new operation). Its IP half is one ClickHouse read per chunk.

### 3. `content-templating` — the same text, posted by accounts that are supposed to be strangers
No existing implementation. Each comment is reduced to a fingerprint — lowercased, **links and digit runs masked**, punctuation dropped — then scored on how many **distinct** cohort members produced the same fingerprint.

The masking is the detection: an exact-match check finds only literal copy-paste, while a ring's whole method is one template with the payload swapped (the link, the referral code, the amount).

Chose exact-match-after-masking over cosine/TF-IDF, edit distance or MinHash because a moderator has to read the reason and see why. Those produce "similarity 0.83 to a cluster of 6", which nobody can check and nobody can calibrate without a corpus; this lets the finding **quote the shared text**. It is also O(rows) with a hash map against O(rows²) for pairwise distance, which the cohort bound rules out anyway.

**Cost: two `comment.findMany` reads per chunk, under a fixed run-wide row budget.**

### Structure
Cross-account signals are indexed **once per run** in `evidence.ts`; each heuristic is a pure function over that index. Per-account scoring cannot answer "how many others", which is exactly what misses a wave.

Every count is of **distinct accounts, never rows** — otherwise one account pasting its shill line ninety times manufactures a ring out of itself.

---

## A missing source is a state, not a zero

Two of the three can go dark. `clickhouse` is `undefined` on any deployment without `CLICKHOUSE_HOST`, and the content read is budgeted. A zero from a dead source is byte-identical to a zero meaning "these accounts share nothing", and the two call for opposite conclusions.

- `evidence_registration_ips`, `evidence_content_budget_exhausted`, `evidence_members_sampled_for_content` are published on **every** run.
- The summary warns explicitly when the IP source was unavailable or the budget ran out.
- A **partial** IP read is discarded rather than scored: a cluster count built from a partial read understates every ring that straddles the missing chunk, and understating is the direction that produces a confident zero.
- The content budget spends itself newest-first, matching the cohort walk's own truncation direction.

---

## Also fixed here

- **The heuristic notes were collected and then dropped.** `HeuristicScore.note` has always existed and every heuristic has always been asked to produce one, but the reason rendered only `id=0.00` — three numbers and no statement of what any of them *saw*. Invisible while the only registered heuristic was a placeholder whose note was always `null`.
- **`scoring.test.ts`'s member fixture was the wrong shape** — the pre-split flat `PostCounts`. `src/**/__tests__/**` is excluded from the root tsconfig so nothing typechecked it, and no assertion happened to read the bad field. A fixture that cannot occur in production tests a world that does not exist; corrected because this change gives `posts` a consumer.
- **The email address is reduced to its domain in the pure selector and stored nowhere else.** A whole-object `toEqual` on the member is what keeps it from reappearing.

---

## The third ledger

The operation ledger anchors on a `db` handle, so it **cannot see a ClickHouse call** — it stays at seven members whatever this module does to ClickHouse. `$exec` is on the same client and the same import, takes the same kind of string, runs arbitrary DDL/DML, and returns `void`.

That is not a tolerated gap. A new ledger asserts the ClickHouse method set is exactly `{$query}` and that every SQL statement in the module is a bare `SELECT`, each with a positive and a negative control.

**Its own positive control caught a defect in the scanner.** The pattern required the method name and its paren to be adjacent, so `ch.$query<{ ip: string }>(sql)` matched nothing — while `$exec(`, which nobody writes with type arguments, matched fine. The guard's negative control passed, its assertion read a reassuring `[]`, and it was blind to the only call the code actually makes. Caught only because the control asserts the *benign* shape is seen, not merely that the hostile one is.

---

## Test matrix

**131 → 243 tests, 8 files (2 new).** Every base-failure reason below was observed, not predicted.

### Red at `8d7faf6138`, behaviourally

Measured by running the new tests against the base source in a clean worktree:

| test | base failure |
|---|---|
| `newAccountPageArgs > selects only the columns … plus the email` | `expected { id, username, createdAt } to deeply equal { …, email }` |
| `selectCohortMembers > carries the account identity` | member object missing `emailDomain` |
| `selectCohortMembers > reduces the email to its domain` | `expected undefined to be 'a.test'` |
| `buildFinding > carries each heuristic's NOTE` | reason did not contain `Signals — registration-cluster: …` |

### Red at base only as an import error — **not behavioural coverage**

`normalizeEmailDomain` (×3 cases) fails at base with `normalizeEmailDomain is not a function`. `evidence.ts` and `heuristics/` do not exist at base at all, so every test in `evidence.test.ts` and `heuristics.test.ts`, and the threshold cases in `run.test.ts`, can only fail there by failing to import. **Stating that plainly: those are attributed by mutation instead**, per the table below.

### One invariant guard, labelled as such

`omits the signals clause entirely when nothing fired` **passes at base** — base also omits it, because base never renders notes at all. It pins an invariant the bug never violated. It is not regression coverage and is not counted as such.

### Mutation results — 35 mutants, 35 killed, 0 survived

Includes a positive control (an obviously-broken ramp) which was killed, proving the harness can go red. Each mutant was checked to fail in **its own** test, not merely to fail something.

Covered: both ramp boundaries and its interpolation; the velocity volume gate, age floor, `all`-vs-`visible` read and its rate boundary; the clustering `max`-vs-sum, the common-domain suppression and both cluster boundaries; the templating boundary and quote bound; the distinct-account counting on both axes, the cohort filter, both fingerprint floors, both text masks, the content budget, the `targetUserId` column and the integer filter; the threshold comparison and its value, the top-bucket clamp and the zero fill; and at run level, the buckets covering all scored members, the suppressed counter, the cut itself and the evidence flag.

**The battery found five real weaknesses, now fixed:**

1. `IP_ZERO_AT`, `CLUSTER_ZERO_AT` and `MIN_FINGERPRINT_CHARS` boundary cases were written as `membersPerIp: { x: IP_ZERO_AT }` — **the expectation was derived from the very constant under test**, so shifting the constant shifted the test with it and the case passed at any value. Rewritten with literals, with the constants pinned separately.
2. Both `largest*Cluster` fixtures put the answer **last**, so "take the max" and "take the last" agreed and `>` vs `>=` survived. Fixtures reordered, plus explicit tie-break cases.
3. The character floor on fingerprints was only ever killed by the **token** floor. An isolated case (≥4 tokens, <24 chars) now exercises it, with a positive control so the pair cannot pass by the function always returning `null`.

### Gates

- **Typecheck: 758 errors, byte-identical to base, 0 of them in this tree.** The 758 are pre-existing in this checkout (unresolvable `form-graph` / `kysely`), present identically in the primary clone.
- **Tests-typecheck gate:** base 1143 errors / 222 files, this branch **1137 / 220**. The 11 "got WORSE" files it lists are identical at base and none is touched here — measured in a clean base worktree rather than argued from the diff.
- Prettier clean over all 19 files (file count read, not just the exit code). ESLint: 0 errors.

---

## Round-1 adversarial audit — what changed

Verdict was *"safe to merge as it stands; not safe to schedule"*, with **F1, F2 and F3 named as blocking a real cron**. All three are fixed, plus the rest of the list. The full comment is above; this is what the code now does differently.

**F2 — nothing held the seam between the evidence and the scoring.** Replacing the `signals` handed to `scoreAccount` with `emptyCohortSignals()` left 243/243 green: two of three heuristics would have scored 0 on **every production run** while `evidence_registration_ips`, `evidence_distinct_registration_ips` and `evidence_distinct_content_fingerprints` all reported healthy values, because those read `signals` rather than what scoring saw. Three suites each hermetic, none building the combined state. `run.test.ts` now drives a six-account ring through the **production** registry with a real `EvidenceReader` and asserts the **emitted finding's** own sub-scores — with a no-evidence control arm, since a non-zero score attributes nothing without the zero beside it. Deleting `evidence: createEvidenceReader()` from the job was equally green (`evidence?` is deliberately optional), so that half is asserted on the job source.

**F1 — no private/carrier-internal IP filter**, unlike both sibling readers of the same table. The predicate is now **shared, not copied**: `PUBLIC_IP_ONLY` moved out of `reactor-lookup.service.ts` into `@civitai/shared/clickhouse-ip-filters` — a dependency of both the main app and `apps/moderator` — with `INTERNAL_IP_RANGE` re-exported from the moderator's `clickhouse-filters.ts` so its other importers are untouched. The SQL that file emits is byte-unchanged and its existing assertions still pass. `ip != ''` still comes first, because `isIPAddressInRange` raises on an empty string.

**F3 — the SELECT projection was unguarded.** Pinned, along with the `GROUP BY`, since the two drifting apart is the same silent zero from the other side.

**F8** — `listContentSamples` had no `try`/`catch`, so a replica timeout propagated out and **no report was filed at all**, losing the velocity heuristic's day too. It now degrades exactly as the IP read does: partial data discarded, `sources.contentSamples` false, a log line, an `evidence_content_samples` counter and its own summary sentence. It is **not** reported as an exhausted budget.

**F4** — the summary now names the read-ran-and-matched-nothing case; the PR body's overstatement of the `targetUserId` risk is corrected under *NOT verified*.

**F7** — `domains_suppressed_common` is a real counter rather than a claim in a comment.

**F9** — `AND time >= '<createdAfter>'`, in ClickHouse's `DateTime` literal form.

**F12** — `LIMIT ids.length * 4` was a cap on the **result** with no `ORDER BY`: one account with many addresses could evict every other account in its chunk. Now `LIMIT 4 BY targetUserId` plus an `ORDER BY`, so the comment and the code say the same thing.

**F13** — the six bounds a run is sized by are pinned, and the whole budget-exhausted summary sentence is asserted in full.

**F10** — both ledger patterns see optional chaining; the ClickHouse one also sees a bracket key. Each widening has its own control, plus controls that the benign shapes still read the same. What remains open is stated in the pattern's docstring.

**F6** — `COMMON_EMAIL_DOMAINS` extended to ~120 entries grouped by provider family, `pm.me` included. The code now states plainly what a word list structurally cannot do.

**F5** — measured, pinned, and deliberately not patched. See *NOT verified*.

**F11 is out of scope** (a query-side note about `batch_index = 1`, not code).

### Mutation, this round

21 mutants planted one at a time, each with a fresh `node_modules/.vite`; **21 killed, 0 survived**, each on the assertion written for it. The two the audit used are in that set: `signals` → `emptyCohortSignals()` and `SELECT targetUserId, ip` → `SELECT userId, ip`, plus deleting the job's `evidence:` line. Two positive controls (`MIN_REPORTED_CONFIDENCE` 0.15 → 0.5, killing 11; `rampScore` → 0, killing 7) confirm the harness can go red. One candidate control was **discarded as equivalent** rather than reported as a survivor: `BOT_ACCOUNT_DETECTOR` is asserted against the same imported constant, so mutating it moves both sides.

271 tests / 8 files, up from 243. Typecheck clean (0 errors). `svelte-check` on `apps/moderator`: 0 errors, 0 warnings. Prettier clean.

---

## NOT verified

- **No heuristic has been run against real data.** Every threshold and boundary in this PR is a judgement, not a measurement. The per-heuristic counters and the confidence distribution exist to replace them, and that has not happened yet.
- **The ClickHouse read has never executed.** `registrationIpSql` is asserted as a string and the reader is exercised against a fake; `default.userActivities` was never queried from this code. That much is unchanged.

  🔴 **CORRECTED — this bullet overstated the `targetUserId` risk in two ways, and the round-1 audit was right about both.**

  1. **The choice is not merely argued, it is settled in-repo with a measurement.** `apps/moderator/src/lib/server/user-signals.service.ts:33-34` records it: *"Use `targetUserId`, NOT `userId`: for Login and Registration rows `userId` is empty ~95% of the time (30M of 31.5M logins), so filtering on it silently finds nothing."* That is the same table, the same event type, and a counted result — not an inference from the writer.
  2. **A discriminator for the failure DOES exist, and this PR already emits it.** `evidence_registration_ips: 1` (the read ran) together with `evidence_distinct_registration_ips: 0` over a non-empty `cohort_size` is the wrong-column signature. The original sentence said the counter "cannot detect" it; what the *availability* counter alone cannot detect is a different thing, and the pair does detect it. The PR under-claimed its own coverage.

  What genuinely remained was the human-facing half: the summary said nothing when the read ran and matched nothing, so a moderator reading it could not tell a quiet day from a broken query. That is now a summary clause of its own, with a control that it stays quiet on an ordinary run.
- **No live run.** The job is still `UNRUNNABLE_JOB_CRON`; nothing has posted to the board.
- **False-positive rates are unmeasured for all three.** Named risks: NAT addresses on the clustering heuristic (no threshold removes this); ordinary phrases colliding after number-masking on the templating heuristic; the `COMMON_EMAIL_DOMAINS` list, which stays a hardcoded word list and is brittle in both directions — a missing provider is a standing false positive, and a listed one hides a real ring that used it.

  `domains_suppressed_common` **is now implemented** (it was asserted by a code comment while existing nowhere), so the first direction is measurable. Nothing measures the second.

  🔴 **One collision is no longer merely "named" — it is measured and pinned.** A generation-parameter paste (`Steps: …, Sampler: …, CFG scale: …, Seed: …`) fingerprints identically to the same line with different numbers, because every number is a `nummask`. That is one of the commonest comments on this site, so six such accounts in a day read as a ring of six and are reported. Both candidate fixes were rejected on arithmetic run over the shipped normaliser, not on taste: mask-token ratio **interleaves** the two classes in both directions (a paste including the prompt is 6/21 = 0.286, `check out linkmask for nummask free buzz` is 2/7 = 0.286, and `free buzz linkmask nummask` is 0.500 — above the longest paste's 0.389), and raising `CLUSTER_ZERO_AT` does not bound the innocent cluster, which is "people who commented their settings under a popular model today". So it is recorded as a regression case, stated in `similarity.ts`, and the `heuristic:<id>:sole_signal` counter — the findings a heuristic **carried on its own**, over the reported members — is what should set the fix. 🔴 **That counter's predicate changed in round 2** (`dfe494e4ba`): it used to be *exactly one heuristic scored above zero*, which excluded the collision's own routine shape — a member who also scores a TRACE somewhere else — and therefore under-reported the very population it was built for, in the reassuring direction. It is now a dominance test (`SOLE_SIGNAL_DOMINANCE`, see below).
- **`MIN_REPORTED_CONFIDENCE = 0.15` has never been applied to a real distribution.** It could be badly wrong in either direction.
- **The templating heuristic sees comments only** — model names, descriptions and image prompts are all templatable and none is read. A known false negative, not an oversight.
- **It sees a sample, not a census.** On a wave day the budget can run out and the oldest end of the cohort scores 0 for want of data.
- The no-write ledgers' stated blind spots are **narrowed but still open**: which *binding* is taken from a permitted specifier, what a permitted module does on its side, destructured handles, handles in object fields, computed method names, and the network. Optional chaining and a bracketed ClickHouse method key are no longer among them — `clickhouse` is typed `| undefined`, so `clickhouse?.$exec(…)` is the *idiomatic* spelling and both ledgers recorded nothing for it. That class is **not** closed: the patterns still match two handle names and a literal method, and they do not follow a client through an assignment, a destructure, an object field, a return value or a computed key. Those are dataflow, not pattern-matching.

---

Do not merge without a second read of the threshold default and the `COMMON_EMAIL_DOMAINS` list — those are the two judgement calls with the widest blast radius on a live board.




---

## Round-2 addenda

### `sole_signal` now measures what its name claims (`dfe494e4ba`)

The docstring said *"Nothing about such an account fires the other two heuristics, so it lands here and nowhere else"*, and the predicate was `exactly one heuristic scored above zero`. Those are different populations. A member 40 minutes old with 6 parameter-paste comments in a fingerprint cluster of 6 scores `posting-velocity` **0.1389** (6 items in 0.67h = 9/hour, just over the 4/hour floor) and `content-templating` **0.5**, blends to **0.2130**, clears `MIN_REPORTED_CONFIDENCE`, is **reported** — and incremented nothing. Reading `content-templating:sole_signal = 0` as "the collision produced no reports" was therefore wrong on the one number that decision was deferred to.

The predicate is now: the leading heuristic must score at least `SOLE_SIGNAL_DOMINANCE` (**3**) times every other. The multiple is derived, not picked — with `n` equally weighted heuristics the rest together contribute at most `(n-1)·s/k`, which is below `s` exactly when `k > n-1`, so at `n = 3` the smallest integer that works is 3. **It is tied to `n = 3`**: a fourth registered heuristic makes `k > 3` the condition, and the constant's docstring says so.

**No existing test had to change.** All three sole_signal pins survive, including the negative control at two heuristics agreeing at 0.9 — a tie fails the dominance test at any multiple above 1, so corroboration is excluded by arithmetic rather than by a special case. Two new cases were added: the 0.1389 + 0.5 collision (both scores **executed against the shipped heuristics**, not stipulated, so the case moves if `ZERO_AT_PER_HOUR` or `CLUSTER_ZERO_AT` moves), and a case pinning registry-**order** independence plus the nothing-fired guard.

Mutation results on the new predicate — 6 of 7 killed; the survivor (`>` → `>=` in the argmax tie-break) is **equivalent**, because on a tie the displaced member lands in `runnerUp` at the same value and dominance fails whichever tied member is named leader.

### `publicIpOnlySql` rejects a column that is not a bare identifier (`6fd1f13637`)

The precondition was a comment only, on a new shared export whose return value is concatenated into a ClickHouse statement by a client that does no escaping. Its own sibling `IP_PATTERN` in `apps/moderator/src/lib/server/clickhouse-filters.ts` exists for exactly this seam, so a regex here is the convention rather than a new idea. Both call sites pass the default `'ip'` today — it is unreachable, and that is why now is the cheap time. The test watches the throw and carries a negative control on accepted columns; all four regex mutants died.

### 🔴 Pre-cron check, owned by whoever schedules the job: the `time >=` literal's timezone

`registrationIpSql` compares a `DateTime` column to `'YYYY-MM-DD HH:MM:SS'` built from a UTC instant with no timezone qualifier. **This PR does not introduce the spelling** — `src/server/services/blocks/app-views.service.ts:129,226` already compares a `time DateTime` column to that identical literal format in production, and there are ≥5 in-repo precedents. It is a pruning predicate over accounts that cannot predate the window, so a skew removes rows the query would want rather than adding wrong ones; it is not a correctness hazard for the findings.

It was **not settled here** because it needs one query against an external vendor endpoint that was deliberately not used in this work. Run these two before the cron is enabled:

```sql
SELECT name, type FROM system.columns WHERE table = 'userActivities' AND name = 'time';
SELECT timezone();
```

**Closing condition:** the column's declared type carries no non-UTC timezone **and** `timezone()` is UTC — or, if either is false, the literal gains an explicit `toDateTime(…, 'UTC')`. Checked by whoever enables `UNRUNNABLE_JOB_CRON` for this job, before the first scheduled run.

### Report-summary headroom is smaller than it looks

Worst case — a 25,000-account cohort at the `MAX_COHORT_ACCOUNTS` cap with **every** degradation clause present at once (registration IPs unavailable, the read ran and matched nothing, content samples unavailable, the 5,000-row content budget exhausted, and the cohort truncated) — the summary measures **1,753 characters** against the schema's `z.string().max(2_000)` cap. That is **247 characters of headroom**, not the ~400 quoted earlier from a narrower assumption; measured by reproducing the concatenation in `run.ts` with those values. A third clause of the size of the ones added recently would push it over and **400 the whole report**, losing every finding in the batch rather than truncating the sentence. `reason` is truncated by `truncateReason`; `summary` is not.
