### PR TITLE
revert(models): call Checkpoint "Checkpoint" again, not "Fine-tune"

### DIFF
--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -66,7 +66,7 @@ export interface AppSettingsModalProps {
 }
 
 const MODEL_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: ModelType.Checkpoint, label: 'Fine-tune' },
+  { value: ModelType.Checkpoint, label: 'Checkpoint' },
   { value: ModelType.LORA, label: 'LoRA' },
   { value: ModelType.LoCon, label: 'LoCon' },
   { value: ModelType.TextualInversion, label: 'Embedding' },

--- a/src/components/Auction/AuctionInfo.tsx
+++ b/src/components/Auction/AuctionInfo.tsx
@@ -256,7 +256,7 @@ export const AuctionTopSection = ({
                   <Badge color="green" mr="xs">
                     Generation
                   </Badge>
-                  Fine-tunes will be enabled for use in generation.
+                  Checkpoints will be enabled for use in generation.
                 </Text>
               </Stack>
             </Stack>

--- a/src/components/Tours/tours/auction.tour.tsx
+++ b/src/components/Tours/tours/auction.tour.tsx
@@ -27,7 +27,7 @@ export const auctionTour: StepWithData[] = [
           You can bid ⚡ Buzz to feature models on the homepage and resource selection areas of the
           site. Higher bids = better spots!
         </Text>
-        <Text>Fine-tunes will also be enabled for generation until the auction cycle ends.</Text>
+        <Text>Checkpoints will also be enabled for generation until the auction cycle ends.</Text>
       </Stack>
     ),
     disableBeacon: true,

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -7,8 +7,9 @@ import {
   modelTypeGroups,
   resolveModelTypeDefaults,
   retiredModelTypes,
+  leadingUngroupedModelTypes,
   selectableModelTypes,
-  ungroupedModelTypes,
+  trailingUngroupedModelTypes,
 } from '~/shared/constants/model-type.constants';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
@@ -115,9 +116,10 @@ describe('model type picker data', () => {
       expect(item.label.length).toBeGreaterThan(0);
     }
 
-    // Only the trailing ungrouped types have no heading; a group of one would repeat its own name.
+    // Only the ungrouped types have no heading; a group of one would repeat its own name.
     expect(data.filter(({ group }) => !group).map(({ value }) => value)).toStrictEqual([
-      ...ungroupedModelTypes,
+      ...leadingUngroupedModelTypes,
+      ...trailingUngroupedModelTypes,
     ]);
   });
 
@@ -198,7 +200,22 @@ describe('model type picker data', () => {
     expect(source).not.toContain('resolveModelTypeDefaults(model)');
   });
 
-  it('labels Checkpoint as Fine-tune', () => {
-    expect(getDisplayName(ModelType.Checkpoint)).toBe('Fine-tune');
+  // Reverted from "Fine-tune" (#4521) after tester complaints that it replaced a term people
+  // already knew. If you are here to rename it again, that is a product call, not a cleanup.
+  it('labels Checkpoint as Checkpoint, not Fine-tune', () => {
+    expect(getDisplayName(ModelType.Checkpoint)).toBe('Checkpoint');
+  });
+
+  // Same revert: Checkpoint is offered with no heading rather than under a "Fine-tunes" group of
+  // one. Restoring a heading here reintroduces the word the revert removed.
+  it('offers Checkpoint ungrouped and first, under no heading', () => {
+    const data = getModelTypeSelectData(null);
+
+    expect(data[0]).toStrictEqual({ value: ModelType.Checkpoint, label: 'Checkpoint' });
+    expect(modelTypeGroups.map(({ group }) => group)).toStrictEqual([
+      'Adapters',
+      'Component replacements',
+      'Workflow additives',
+    ]);
   });
 });

--- a/src/shared/constants/__tests__/model-type.constants.test.ts
+++ b/src/shared/constants/__tests__/model-type.constants.test.ts
@@ -206,6 +206,20 @@ describe('model type picker data', () => {
     expect(getDisplayName(ModelType.Checkpoint)).toBe('Checkpoint');
   });
 
+  // App settings keeps its own hand-written label map instead of calling getDisplayName, so the
+  // test above does not reach it: #4521 renamed Checkpoint in both files and so did the revert,
+  // both times found by grep. Derived rather than hardcoded, so it reddens whichever side moves.
+  it('keeps the App settings label in step with getDisplayName for Checkpoint', () => {
+    const source = readFileSync(
+      path.resolve(__dirname, '../../../components/Apps/AppSettingsModal.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain(
+      `{ value: ModelType.Checkpoint, label: '${getDisplayName(ModelType.Checkpoint)}' }`
+    );
+  });
+
   // Same revert: Checkpoint is offered with no heading rather than under a "Fine-tunes" group of
   // one. Restoring a heading here reintroduces the word the revert removed.
   it('offers Checkpoint ungrouped and first, under no heading', () => {

--- a/src/shared/constants/model-type.constants.ts
+++ b/src/shared/constants/model-type.constants.ts
@@ -2,7 +2,6 @@ import { ModelType } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
 
 export const modelTypeGroups = [
-  { group: 'Fine-tunes', types: [ModelType.Checkpoint] },
   { group: 'Adapters', types: [ModelType.LORA, ModelType.LoCon, ModelType.DoRA] },
   {
     group: 'Component replacements',
@@ -14,12 +13,21 @@ export const modelTypeGroups = [
   },
 ] as const satisfies readonly { group: string; types: readonly ModelType[] }[];
 
-/** Offered after the groups, under no heading — a group of one repeats its own name as a header. */
-export const ungroupedModelTypes = [ModelType.Other] as const satisfies readonly ModelType[];
+/**
+ * Offered under no heading — a group of one repeats its own name as a header. Two lists because
+ * Checkpoint leads the picker and Other trails it, either side of the groups.
+ */
+export const leadingUngroupedModelTypes = [
+  ModelType.Checkpoint,
+] as const satisfies readonly ModelType[];
+export const trailingUngroupedModelTypes = [
+  ModelType.Other,
+] as const satisfies readonly ModelType[];
 
 export const selectableModelTypes = [
+  ...leadingUngroupedModelTypes,
   ...modelTypeGroups.flatMap(({ types }) => types),
-  ...ungroupedModelTypes,
+  ...trailingUngroupedModelTypes,
 ] as ModelType[];
 
 /**
@@ -41,8 +49,9 @@ export const retiredModelTypes = [
 ] as const satisfies readonly ModelType[];
 
 type SelectableModelType =
+  | (typeof leadingUngroupedModelTypes)[number]
   | (typeof modelTypeGroups)[number]['types'][number]
-  | (typeof ungroupedModelTypes)[number];
+  | (typeof trailingUngroupedModelTypes)[number];
 type UncategorisedModelType = Exclude<
   ModelType,
   SelectableModelType | (typeof retiredModelTypes)[number]
@@ -57,7 +66,7 @@ type UncategorisedModelType = Exclude<
 const _everyModelTypeIsCategorised: [UncategorisedModelType] extends [never]
   ? true
   : {
-      error: 'Add it to modelTypeGroups, ungroupedModelTypes or retiredModelTypes';
+      error: 'Add it to modelTypeGroups, one of the ungrouped lists, or retiredModelTypes';
       missing: UncategorisedModelType;
     } = true;
 void _everyModelTypeIsCategorised;
@@ -86,8 +95,9 @@ export function getModelTypeSelectData(
   currentType?: ModelType | string | null
 ): ModelTypeSelectItem[] {
   const offered = [
+    ...leadingUngroupedModelTypes.map((type) => toItem(type)),
     ...modelTypeGroups.flatMap(({ group, types }) => types.map((type) => toItem(type, group))),
-    ...ungroupedModelTypes.map((type) => toItem(type)),
+    ...trailingUngroupedModelTypes.map((type) => toItem(type)),
   ];
 
   if (!currentType || selectableModelTypeSet.has(currentType)) return offered;

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -42,7 +42,6 @@ export function getStripeCurrencyDisplay(unitAmount: number, currency: string) {
 }
 
 const nameOverrides: Record<string, string> = {
-  Checkpoint: 'Fine-tune',
   LoCon: 'LyCORIS',
   LORA: 'LoRA',
   DoRA: 'DoRA',


### PR DESCRIPTION
Closes the label half of ClickUp [868m15nnm](https://app.clickup.com/t/868m15nnm).

## What testers reported

PR #4521 renamed the `Checkpoint` model type to **"Fine-tune"** in user-facing strings. In `#civitai-testers` on 2026-09-02, Demian: *"So, apparently 'Checkpoint' filter is no longer a thing, but 'Fine-tune' is? Pointless change that will lead to confusion"* — corroborated by freckledvixon (*"ya i already saw few complaints"*) and by Ellie on the ticket.

## What this does

Puts every user-facing string back to "Checkpoint". Five places, all introduced by #4521:

| File | Was | Now |
|---|---|---|
| `src/utils/string-helpers.ts` | `nameOverrides.Checkpoint = 'Fine-tune'` | override removed; falls through to `splitUppercase` → `Checkpoint` |
| `src/components/Apps/AppSettingsModal.tsx` | option label `Fine-tune` | `Checkpoint` |
| `src/components/Auction/AuctionInfo.tsx` | "Fine-tunes will be enabled…" | "Checkpoints will be enabled…" |
| `src/components/Tours/tours/auction.tour.tsx` | "Fine-tunes will also be enabled…" | "Checkpoints will also be enabled…" |
| `src/shared/constants/model-type.constants.ts` | `{ group: 'Fine-tunes', types: [Checkpoint] }` | group dropped; Checkpoint offered ungrouped |

The `string-helpers.ts` line is the one that matters most — `getDisplayName` is what the `/models` browse filter chip reads, so that single deletion is what fixes the reported filter.

The enum value was never touched by #4521 and is not touched here. This is display text only; no data changes, no migration.

### On the fifth row

#4521 also added a **"Fine-tunes" group heading over a group of one** in the model-upload type picker. Renaming it to "Checkpoints" would have produced `Checkpoints > Checkpoint` — a group repeating its own name, which is the exact thing that file's own comment says was avoided for `Other`. Justin chose to drop the group instead and offer Checkpoint ungrouped, the way `Other` already was.

That needs two ungrouped lists rather than one, because Checkpoint leads the picker and `Other` trails it, either side of the groups. **`selectableModelTypes` comes out in the identical order** — `Checkpoint, LORA, LoCon, DoRA, VAE, TextEncoder, UNet, Upscaler, Workflows, Wildcards, Controlnet, Other` — so the existing order test needed no edit.

## What this deliberately does NOT do

**The mis-scoping half of the ticket is not fixed here, and it is not a regression from the rename.**

Cheshire's report — *"fine tune and merge act as the checkpoint filters but also apply to the other filters … surprised me to see that we have a few fine tuned loras"* — is this clause in `getModelsRaw` (`src/server/services/model.service.ts:746`):

```
if (checkpointType && (!types?.length || types?.includes('Checkpoint'))) {
  ...
  } else TypeOr.push(Prisma.sql`m."type" != 'Checkpoint'`);
```

With a checkpoint type picked and no model types selected, the SQL is `(m."checkpointType" = $x OR m."type" != 'Checkpoint')` — every non-checkpoint passes through unfiltered, which is why LoRAs still come back.

That clause dates to **49d060c9ab (2023-02-06)**, and #4521 (`e41df85be0`) never touched `model.service.ts`. The intent review corroborated this by a second route: the *client* mirrors the same predicate character-for-character at `ModelFiltersDropdown.tsx:151`, and that is untouched by #4521 too. So the two complaints share a ticket but not a cause — the rename made three-year-old behaviour *more visible* by putting a familiar word on an unfamiliar control, it did not create it.

**Justin has since decided this half: leave it as is.** "Checkpoint type" narrows checkpoints only, by design. Asked and answered, so it is a closed decision rather than an open follow-up, and there is nothing left to file.

One correction to the ticket's wording while we are here: the Checkpoint-type chips render **"Trained" and "Merge"**, not "Fine tune" and "Merge" — `CheckpointType` has exactly those two members (`packages/civitai-db-schema/src/kysely/enums.ts:177`) and no override remaps them. The reporter was paraphrasing "Trained" as fine-tuning.

Also left alone deliberately: prose that uses "fine-tune" as an ML concept rather than as the name of the type — the `/train` landing page, ecosystem SEO copy, the "Fine-tuned from" licensing-lineage field, and onboarding's "Fine-tune preferences". None of those came from #4521.

## Tests

Both halves have a **positive control**, run and measured, not assumed:

- Re-adding `Checkpoint: 'Fine-tune'` to `nameOverrides` → `AssertionError: expected 'Fine-tune' to be 'Checkpoint'`, exit 1, `Tests 2 failed | 12 passed (14)`.
- Restoring the `{ group: 'Fine-tunes', … }` entry → exit 1, `Tests 1 failed | 13 passed (14)`, with the diff naming the offender: `+ "group": "Fine-tunes"`.

Both tests are named for the decision (`labels Checkpoint as Checkpoint, not Fine-tune`, `offers Checkpoint ungrouped and first, under no heading`) and carry a line saying a further rename is a product call, not a cleanup — otherwise the next competent reviewer correctly recommends undoing this and nobody in the loop knows why not.

## Verification

- `pnpm run typecheck` — **0 type errors**
- `pnpm run lint` — exits 1 repo-wide (358 pre-existing errors). None are in the six changed files: the three that appear at all carry only pre-existing warnings on lines this diff never touched.
- `pnpm exec prettier --write` on the six files — clean
- `pnpm run test:unit:run` — `Test Files 1 failed | 1621 passed | 3 skipped (1625)`, `Tests 1 failed | 37856 passed | 35 skipped (37892)`, exit 1

The one failure is **pre-existing on this base and unrelated**: `appListingMenuSurface.test.ts` compares hardcoded POSIX paths against Windows separators (`components/Apps/AppListingCard.tsx` vs `components\Apps\AppListingCard.tsx`). Confirmed by stashing this diff and re-running that file on a clean tree — same failure, `Tests 1 failed | 5 passed (6)`.

`blocks.router.workflow.test.ts` collected **370 tests** (not zero), so the submodule was initialised and the run is meaningful.

## Review

Five adversarial lanes over this diff, each prompted to refute and to default to broken-until-proven.

- **Correctness** — clean. Confirmed no `getDisplayName` call site treats the label as load-bearing (the four server-side ones are notification prose, a PDF, a helper Checkpoint early-returns out of, and one keyed on flag names); confirmed the constants restructure leaves `selectableModelTypes`, `resolveModelTypeDefaults` and the exhaustiveness check behaviour-identical; and read Mantine 7.17.8's own dropdown source to confirm a leading ungrouped item stays first rather than assuming it.
- **Perf** — clean, with numbers: the removed override moves `getDisplayName('Checkpoint')` from a 7 ns map hit to a 744 ns regex path, which on the heaviest consumer (one call per model card) is ~74 µs per 100-card page, client-side only. `getDisplayName` has zero server call sites on a request path, and nothing keys a cache, Meili filter or query param on the display name, so there is no reindex and no invalidation.
- **Tests** — confirmed both controls reproduce exactly as measured, and made one useful correction: a literal `git revert` of the first commit would fail at *import* rather than with the assertion diff quoted above, because it renames the export back. Still red, still legible, just not that message.
- **Intent** — scored as delivering, with no widening (the two-list split is the minimum shape that keeps Checkpoint first; the untouched strict-order test is the evidence), no narrowing, and no leakage from the separate proposal.
- **Reuse** — one finding, below.

**The one finding, found independently by two lanes and fixed in `d6ef523c3f`:** App settings keeps its *own* hand-written `ModelType`→label map rather than calling `getDisplayName`, so neither new test reached it — a third rename of Checkpoint would have gone green with that file still saying the old word. It is now pinned, with the expected label **derived from `getDisplayName`** so it reddens whichever side moves. Control: setting that label back to `'Fine-tune'` gives exit 1, `Tests 1 failed | 14 passed (15)`.

Both lanes noted the deeper fix is to derive that whole map from `getDisplayName` — the two already disagree, rendering `LoCon` where `getDisplayName` says `LyCORIS`. That is a real duplicate worth collapsing, but doing it here would rename a user-visible chip as a side effect of a revert, so it is left as Justin's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNACBJtghXG1o3i9DZLF53
