### PR TITLE
feat(hubs): negative sources, and tags as a hub source

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260904190000_user_hub_source_exclude/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260904190000_user_hub_source_exclude/migration.sql
@@ -1,0 +1,7 @@
+-- Negative hub sources: a creator, model or version whose content is kept OUT of
+-- the hub. Applied manually — see CLAUDE.md.
+--
+-- Additive and defaulted, so the currently deployed client (which does not select
+-- the column) keeps working: apply this BEFORE the deploy that reads it, never after.
+
+ALTER TABLE "UserHubSource" ADD COLUMN "exclude" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/civitai-db-schema/prisma/migrations/20260904190100_user_hub_source_tag/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260904190100_user_hub_source_tag/migration.sql
@@ -1,0 +1,10 @@
+-- Tags as a hub source. Applied manually — see CLAUDE.md.
+--
+-- Safe to apply BEFORE the deploy that ships the regenerated client, because no
+-- currently deployed code can write the new label: the only writers are the hub
+-- mutations in the same release. The hazard the expand/contract rule guards against
+-- is a row carrying a label the running client cannot deserialize, and nothing here
+-- creates one. Applying it AFTER the deploy is also safe — the writes just fail
+-- until it lands.
+
+ALTER TYPE "UserHubSourceType" ADD VALUE 'Tag';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -8166,6 +8166,7 @@ enum UserHubSourceType {
   Model
   ModelVersion
   Collection
+  Tag
 }
 
 /// A user-composed image feed: a named set of creators, models, versions and
@@ -8219,6 +8220,10 @@ model UserHubSource {
   targetId Int
   alias    String?
   enabled  Boolean           @default(true)
+  // A NEGATIVE source: content matching it is kept OUT of the hub, instead of
+  // pulled in. The unique below is what makes the two mutually exclusive — one
+  // target is either something the hub collects or something it refuses.
+  exclude  Boolean           @default(false)
   index    Int               @default(0)
 
   @@unique([hubId, type, targetId])

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -1240,6 +1240,7 @@ export const UserHubSourceType = {
   Model: 'Model',
   ModelVersion: 'ModelVersion',
   Collection: 'Collection',
+  Tag: 'Tag',
 } as const;
 
 export type UserHubSourceType = (typeof UserHubSourceType)[keyof typeof UserHubSourceType];

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -987,5 +987,6 @@ export const UserHubSourceType = {
   Model: 'Model',
   ModelVersion: 'ModelVersion',
   Collection: 'Collection',
+  Tag: 'Tag',
 } as const;
 export type UserHubSourceType = (typeof UserHubSourceType)[keyof typeof UserHubSourceType];

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -4059,6 +4059,7 @@ export type UserHubSource = {
   targetId: number;
   alias: string | null;
   enabled: Generated<boolean>;
+  exclude: Generated<boolean>;
   index: Generated<number>;
 };
 export type UserLink = {

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -252,7 +252,7 @@ export type ShopifyMerchOrderStatus = "Pending" | "Granted";
 
 export type OutboxEntity = "Article" | "Image" | "Model" | "Post" | "ModelVersion";
 
-export type UserHubSourceType = "User" | "Model" | "ModelVersion" | "Collection";
+export type UserHubSourceType = "User" | "Model" | "ModelVersion" | "Collection" | "Tag";
 
 export interface Account {
   id: number;
@@ -5428,6 +5428,7 @@ export interface UserHubSource {
   targetId: number;
   alias: string | null;
   enabled: boolean;
+  exclude: boolean;
   index: number;
 }
 

--- a/src/components/Hubs/AddToHubModal.tsx
+++ b/src/components/Hubs/AddToHubModal.tsx
@@ -21,7 +21,10 @@ import { trpc } from '~/utils/trpc';
 export default function AddToHubModal({
   source,
 }: {
-  source: Omit<AddUserHubSourceInput, 'hubId'>;
+  // `exclude` is omitted, not defaulted: every entry point into this modal is a
+  // "put this in a hub" affordance on a creator or model page. Keeping the field out
+  // of the prop means a caller cannot quietly turn one of them into an exclusion.
+  source: Omit<AddUserHubSourceInput, 'hubId' | 'exclude'>;
 }) {
   const dialog = useDialogContext();
   const invalidateHub = useInvalidateHub();
@@ -71,9 +74,16 @@ export default function AddToHubModal({
                 // owner switched off in the rail reads as unticked: the hub is not
                 // showing it, and ticking is what turns it back on.
                 const checked = hub.sources.some(
-                  (s) => s.type === source.type && s.targetId === source.targetId && s.enabled
+                  (s) =>
+                    s.type === source.type &&
+                    s.targetId === source.targetId &&
+                    s.enabled &&
+                    !s.exclude
                 );
-                const full = hub.sources.length >= hubLimits.sourcesPerHub;
+                // Exclusions have their own cap, so counting them here would report a
+                // hub as full while it still had room for what this box adds.
+                const held = hub.sources.filter((s) => !s.exclude).length;
+                const full = held >= hubLimits.sourcesPerHub;
                 return (
                   <Checkbox
                     key={hub.id}
@@ -83,9 +93,7 @@ export default function AddToHubModal({
                       <Group gap={6} wrap="nowrap">
                         <Text size="sm">{hub.name}</Text>
                         <Text size="xs" c="dimmed">
-                          {full && !checked
-                            ? 'Full'
-                            : `${hub.sources.length}/${hubLimits.sourcesPerHub}`}
+                          {full && !checked ? 'Full' : `${held}/${hubLimits.sourcesPerHub}`}
                         </Text>
                       </Group>
                     }

--- a/src/components/Hubs/AddToHubModal.tsx
+++ b/src/components/Hubs/AddToHubModal.tsx
@@ -73,13 +73,17 @@ export default function AddToHubModal({
                 // Membership here means "this hub shows me that source", so a row the
                 // owner switched off in the rail reads as unticked: the hub is not
                 // showing it, and ticking is what turns it back on.
-                const checked = hub.sources.some(
-                  (s) =>
-                    s.type === source.type &&
-                    s.targetId === source.targetId &&
-                    s.enabled &&
-                    !s.exclude
+                const row = hub.sources.find(
+                  (s) => s.type === source.type && s.targetId === source.targetId
                 );
+                const checked = !!row?.enabled && !row.exclude;
+                // 🔴 A hub that EXCLUDES this target must not render as an empty box.
+                // The server flips a row rather than refusing the pair, so ticking it
+                // would delete the owner's keep-out — from a modal that never showed
+                // the exclusion existed, in one click, with no warning. Locked instead;
+                // removing an exclusion is an edit you make in the hub, where you can
+                // see it.
+                const excluded = !!row?.exclude;
                 // Exclusions have their own cap, so counting them here would report a
                 // hub as full while it still had room for what this box adds.
                 const held = hub.sources.filter((s) => !s.exclude).length;
@@ -88,12 +92,16 @@ export default function AddToHubModal({
                   <Checkbox
                     key={hub.id}
                     checked={checked}
-                    disabled={pending || (full && !checked)}
+                    disabled={pending || excluded || (full && !checked)}
                     label={
                       <Group gap={6} wrap="nowrap">
                         <Text size="sm">{hub.name}</Text>
                         <Text size="xs" c="dimmed">
-                          {full && !checked ? 'Full' : `${held}/${hubLimits.sourcesPerHub}`}
+                          {excluded
+                            ? 'Kept out of this hub'
+                            : full && !checked
+                            ? 'Full'
+                            : `${held}/${hubLimits.sourcesPerHub}`}
                         </Text>
                       </Group>
                     }

--- a/src/components/Hubs/HubSourceCard.tsx
+++ b/src/components/Hubs/HubSourceCard.tsx
@@ -1,5 +1,12 @@
 import { ActionIcon, Group, Paper, Stack, Switch, Text, Tooltip } from '@mantine/core';
-import { IconBox, IconFolder, IconStack2, IconTrash, IconUserCircle } from '@tabler/icons-react';
+import {
+  IconBox,
+  IconFolder,
+  IconStack2,
+  IconTag,
+  IconTrash,
+  IconUserCircle,
+} from '@tabler/icons-react';
 import clsx from 'clsx';
 import { UserHubSourceType } from '~/shared/utils/prisma/enums';
 
@@ -9,6 +16,7 @@ export type HubSourceCardProps = {
     targetId: number;
     alias?: string | null;
     enabled: boolean;
+    exclude?: boolean;
     index: number;
   };
   disabled?: boolean;
@@ -26,6 +34,7 @@ const sourceMeta: Record<
   [UserHubSourceType.Model]: { label: 'Model', color: 'violet', Icon: IconBox },
   [UserHubSourceType.ModelVersion]: { label: 'Version', color: 'teal', Icon: IconStack2 },
   [UserHubSourceType.Collection]: { label: 'Collection', color: 'orange', Icon: IconFolder },
+  [UserHubSourceType.Tag]: { label: 'Tag', color: 'grape', Icon: IconTag },
 };
 
 export function HubSourceCard({
@@ -35,9 +44,13 @@ export function HubSourceCard({
   onToggle,
   onRemove,
 }: HubSourceCardProps) {
-  const { label, color, Icon } = sourceMeta[source.type];
+  const { label, color: includeColor, Icon } = sourceMeta[source.type];
   const name = source.alias ?? `#${source.targetId}`;
   const on = source.enabled;
+  // One red for every excluded kind, rather than the type's own colour: what the
+  // row DOES is the thing to read at a glance, and a red creator chip beside a blue
+  // one says it faster than the word does.
+  const color = source.exclude ? 'red' : includeColor;
 
   return (
     <Paper
@@ -73,7 +86,7 @@ export function HubSourceCard({
             c={on ? color : 'dimmed'}
             className="tracking-wide"
           >
-            {label}
+            {source.exclude ? `${label} · kept out` : label}
           </Text>
           <Text size="sm" fw={500} lh={1.3} lineClamp={1} c={on ? undefined : 'dimmed'}>
             {name}
@@ -82,7 +95,17 @@ export function HubSourceCard({
       </Group>
 
       <Group gap={4} wrap="nowrap" className="shrink-0 self-center">
-        <Tooltip label={on ? 'Showing in this hub' : 'Hidden from this hub'}>
+        <Tooltip
+          label={
+            source.exclude
+              ? on
+                ? 'Kept out of this hub'
+                : 'Exclusion switched off'
+              : on
+              ? 'Showing in this hub'
+              : 'Hidden from this hub'
+          }
+        >
           <Switch
             size="xs"
             checked={on}

--- a/src/components/Hubs/HubSourceEditor.tsx
+++ b/src/components/Hubs/HubSourceEditor.tsx
@@ -18,7 +18,7 @@ export type HubSourceValue = {
   index: number;
 };
 
-type AddMode = 'collect' | 'exclude';
+type AddMode = 'include' | 'exclude';
 
 export function HubSourceEditor({
   value,
@@ -45,7 +45,7 @@ export function HubSourceEditor({
   emptyMessage?: string;
 }) {
   const [adding, setAdding] = useState(false);
-  const [addMode, setAddMode] = useState<AddMode>('collect');
+  const [addMode, setAddMode] = useState<AddMode>('include');
   const exclude = addMode === 'exclude';
 
   const collected = value.filter((source) => !source.exclude);
@@ -132,7 +132,7 @@ export function HubSourceEditor({
                     value={addMode}
                     onChange={(next) => setAddMode(next as AddMode)}
                     data={[
-                      { value: 'collect', label: 'Collect' },
+                      { value: 'include', label: 'Include' },
                       { value: 'exclude', label: 'Exclude' },
                     ]}
                   />

--- a/src/components/Hubs/HubSourceEditor.tsx
+++ b/src/components/Hubs/HubSourceEditor.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Collapse, Stack, Text } from '@mantine/core';
+import { Button, Card, Collapse, SegmentedControl, Stack, Text } from '@mantine/core';
 import { IconPlus, IconX } from '@tabler/icons-react';
 import { useState } from 'react';
 import { HubSourceCard } from '~/components/Hubs/HubSourceCard';
@@ -13,13 +13,18 @@ export type HubSourceValue = {
   targetId: number;
   alias?: string | null;
   enabled: boolean;
+  /** A negative source: kept OUT of the hub rather than collected into it. */
+  exclude: boolean;
   index: number;
 };
+
+type AddMode = 'collect' | 'exclude';
 
 export function HubSourceEditor({
   value,
   onChange,
   maxSources = hubLimits.sourcesPerHub,
+  maxExclusions = hubLimits.exclusionsPerHub,
   disabled,
   hideAdd,
   readOnly,
@@ -28,6 +33,7 @@ export function HubSourceEditor({
   value: HubSourceValue[];
   onChange: (next: HubSourceValue[]) => void;
   maxSources?: number;
+  maxExclusions?: number;
   disabled?: boolean;
   /** Drop the add affordance, for surfaces too small to hold it open. */
   hideAdd?: boolean;
@@ -39,20 +45,53 @@ export function HubSourceEditor({
   emptyMessage?: string;
 }) {
   const [adding, setAdding] = useState(false);
+  const [addMode, setAddMode] = useState<AddMode>('collect');
+  const exclude = addMode === 'exclude';
+
+  const collected = value.filter((source) => !source.exclude);
+  const excluded = value.filter((source) => source.exclude);
+
   const addSource = (type: UserHubSourceType, targetId: number, rawAlias: string) => {
     // Match what the server stores, so the optimistic row is not a different
     // string from the one that comes back.
     const alias = rawAlias.trim().slice(0, hubLimits.aliasLength);
+    // Across BOTH lists, matching the row's unique key: a target the hub already
+    // collects cannot also be excluded, and the server would refuse the pair.
     if (value.some((s) => s.type === type && s.targetId === targetId)) return;
-    if (value.length >= maxSources) {
+    const held = exclude ? excluded.length : collected.length;
+    const cap = exclude ? maxExclusions : maxSources;
+    if (held >= cap) {
       showErrorNotification({
-        title: 'Hub is full',
-        error: new Error(`A hub can hold at most ${maxSources} sources.`),
+        title: exclude ? 'Exclusion list is full' : 'Hub is full',
+        error: new Error(
+          exclude
+            ? `A hub can exclude at most ${cap} sources.`
+            : `A hub can hold at most ${cap} sources.`
+        ),
       });
       return;
     }
-    onChange([...value, { type, targetId, alias, enabled: true, index: value.length }]);
+    onChange([...value, { type, targetId, alias, enabled: true, exclude, index: value.length }]);
   };
+
+  const renderCard = (source: HubSourceValue) => (
+    <HubSourceCard
+      key={`${source.type}-${source.targetId}`}
+      source={source}
+      disabled={disabled}
+      onToggle={(enabled) =>
+        onChange(
+          value.map((s) =>
+            s.type === source.type && s.targetId === source.targetId ? { ...s, enabled } : s
+          )
+        )
+      }
+      hideRemove={readOnly}
+      onRemove={() =>
+        onChange(value.filter((s) => !(s.type === source.type && s.targetId === source.targetId)))
+      }
+    />
+  );
 
   return (
     <Stack gap="sm">
@@ -72,6 +111,21 @@ export function HubSourceEditor({
             {adding && (
               <Card withBorder p="xs">
                 <Stack gap="xs">
+                  <SegmentedControl
+                    size="xs"
+                    fullWidth
+                    value={addMode}
+                    onChange={(next) => setAddMode(next as AddMode)}
+                    data={[
+                      { value: 'collect', label: 'Collect' },
+                      { value: 'exclude', label: 'Exclude' },
+                    ]}
+                  />
+                  <Text size="xs" c="dimmed">
+                    {exclude
+                      ? 'Content from what you pick is kept out of this hub.'
+                      : 'Content from what you pick fills this hub.'}
+                  </Text>
                   <HubSourceSearch
                     disabled={disabled}
                     isAdded={(item) =>
@@ -90,32 +144,20 @@ export function HubSourceEditor({
         </>
       )}
 
-      {value.length === 0 ? (
+      {collected.length === 0 ? (
         <Text size="sm" c="dimmed">
           {emptyMessage}
         </Text>
       ) : (
+        <Stack gap={6}>{collected.map(renderCard)}</Stack>
+      )}
+
+      {excluded.length > 0 && (
         <Stack gap={6}>
-          {value.map((source) => (
-            <HubSourceCard
-              key={`${source.type}-${source.targetId}`}
-              source={source}
-              disabled={disabled}
-              onToggle={(enabled) =>
-                onChange(
-                  value.map((s) =>
-                    s.type === source.type && s.targetId === source.targetId ? { ...s, enabled } : s
-                  )
-                )
-              }
-              hideRemove={readOnly}
-              onRemove={() =>
-                onChange(
-                  value.filter((s) => !(s.type === source.type && s.targetId === source.targetId))
-                )
-              }
-            />
-          ))}
+          <Text size="xs" fw={700} tt="uppercase" c="dimmed" className="tracking-wide">
+            Kept out
+          </Text>
+          {excluded.map(renderCard)}
         </Stack>
       )}
     </Stack>

--- a/src/components/Hubs/HubSourceEditor.tsx
+++ b/src/components/Hubs/HubSourceEditor.tsx
@@ -48,7 +48,7 @@ export function HubSourceEditor({
   const [addMode, setAddMode] = useState<AddMode>('include');
   const exclude = addMode === 'exclude';
 
-  const collected = value.filter((source) => !source.exclude);
+  const included = value.filter((source) => !source.exclude);
   const excluded = value.filter((source) => source.exclude);
 
   const addSource = (type: UserHubSourceType, targetId: number, rawAlias: string) => {
@@ -73,7 +73,7 @@ export function HubSourceEditor({
       });
       return;
     }
-    const held = exclude ? excluded.length : collected.length;
+    const held = exclude ? excluded.length : included.length;
     const cap = exclude ? maxExclusions : maxSources;
     if (held >= cap) {
       showErrorNotification({
@@ -159,12 +159,12 @@ export function HubSourceEditor({
         </>
       )}
 
-      {collected.length === 0 ? (
+      {included.length === 0 ? (
         <Text size="sm" c="dimmed">
           {emptyMessage}
         </Text>
       ) : (
-        <Stack gap={6}>{collected.map(renderCard)}</Stack>
+        <Stack gap={6}>{included.map(renderCard)}</Stack>
       )}
 
       {excluded.length > 0 && (

--- a/src/components/Hubs/HubSourceEditor.tsx
+++ b/src/components/Hubs/HubSourceEditor.tsx
@@ -56,8 +56,23 @@ export function HubSourceEditor({
     // string from the one that comes back.
     const alias = rawAlias.trim().slice(0, hubLimits.aliasLength);
     // Across BOTH lists, matching the row's unique key: a target the hub already
-    // collects cannot also be excluded, and the server would refuse the pair.
-    if (value.some((s) => s.type === type && s.targetId === targetId)) return;
+    // collects cannot also be excluded. Told, not silently dropped — the same click
+    // did nothing whether the target was already collected or currently kept out, and
+    // either list can be long enough that neither is on screen.
+    const clash = value.find((s) => s.type === type && s.targetId === targetId);
+    if (clash) {
+      showErrorNotification({
+        title: 'Already in this hub',
+        error: new Error(
+          clash.exclude
+            ? `"${
+                clash.alias ?? targetId
+              }" is currently kept out of this hub. Remove it from the kept-out list first.`
+            : `"${clash.alias ?? targetId}" is already one of this hub's sources.`
+        ),
+      });
+      return;
+    }
     const held = exclude ? excluded.length : collected.length;
     const cap = exclude ? maxExclusions : maxSources;
     if (held >= cap) {

--- a/src/components/Hubs/HubSourcePanel.tsx
+++ b/src/components/Hubs/HubSourcePanel.tsx
@@ -122,7 +122,11 @@ export function HubSourcePanel({
 
   // Only what the owner has switched on: a source they switched off contributes
   // nothing, so listing it would offer a toggle that cannot change the feed.
-  const ownerEnabled = hub.sources.filter((source) => source.enabled);
+  //
+  // The owner's EXCLUSIONS are left out as well, and not because they are secret —
+  // `resolveHubSources` deliberately ignores session toggles on negative sources, so
+  // listing one here would render a switch that cannot move the feed.
+  const ownerEnabled = hub.sources.filter((source) => source.enabled && !source.exclude);
   const excludedKeys = new Set(excluded.map(hubSourceKey));
   const view = ownerEnabled.map((source) => ({
     ...source,

--- a/src/components/Hubs/HubSourcePanel.tsx
+++ b/src/components/Hubs/HubSourcePanel.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, ScrollArea, Stack } from '@mantine/core';
+import { Button, Divider, ScrollArea, Stack, Text } from '@mantine/core';
 import { IconCopy } from '@tabler/icons-react';
 import { useState } from 'react';
 import { BrowsingLevelsInput } from '~/components/BrowsingLevel/BrowsingLevelInput';
@@ -32,6 +32,8 @@ export type HubPanelHub = {
   availability: Availability;
   isOwner: boolean;
   sources: HubSourceValue[];
+  /** How many things this hub keeps out. A count only — see `toHubDetail`. */
+  excludedCount: number;
 };
 
 function MaybeScrollArea({
@@ -178,6 +180,13 @@ export function HubSourcePanel({
             setSessionLevel(hub.id, Flags.intersection(level, viewerAllowedLevel))
           }
         />
+      )}
+
+      {hub.excludedCount > 0 && (
+        <Text size="xs" c="dimmed">
+          {hub.excludedCount === 1 ? '1 thing is' : `${hub.excludedCount} things are`} kept out of
+          this hub. Duplicating it does not copy them.
+        </Text>
       )}
 
       <MaybeScrollArea maxHeight={listMaxHeight}>

--- a/src/components/Hubs/HubSourcePanel.tsx
+++ b/src/components/Hubs/HubSourcePanel.tsx
@@ -110,7 +110,7 @@ export function HubSourcePanel({
           value={current}
           hideAdd={hideAdd}
           disabled={upsert.isPending}
-          emptyMessage="Nothing here yet. Add a creator, a model or a public collection."
+          emptyMessage="Nothing here yet. Add a creator, a model or a tag to start filling it."
           onChange={(next) => {
             setPending(next);
             upsert.mutate({ id: hub.id, sources: next.map((s, index) => ({ ...s, index })) });

--- a/src/components/Hubs/HubSourceSearch.tsx
+++ b/src/components/Hubs/HubSourceSearch.tsx
@@ -13,7 +13,7 @@ import { IconSearch } from '@tabler/icons-react';
 import { useState } from 'react';
 import type { HubSuggestionType } from '~/server/schema/user-hub.schema';
 import { HUB_COLLECTION_SOURCES_ENABLED } from '~/server/schema/user-hub.schema';
-import { UserHubSourceType } from '~/shared/utils/prisma/enums';
+import { TagTarget, TagType, UserHubSourceType } from '~/shared/utils/prisma/enums';
 import { trpc } from '~/utils/trpc';
 
 type Suggestion = { type: UserHubSourceType; targetId: number; alias: string };
@@ -30,7 +30,12 @@ const tabs = [
     scope: 'collections you follow',
     disabled: !HUB_COLLECTION_SOURCES_ENABLED,
   },
+  // The one tab that is not a relationship: everyone shares the same tag
+  // vocabulary, so it searches the site's tags rather than the viewer's library.
+  { value: UserHubSourceType.Tag, label: 'Tags', scope: 'image tags' },
 ];
+
+const TAG_SUGGESTION_LIMIT = 25;
 
 /**
  * One type at a time, over a bounded window of the viewer's own relationships. The
@@ -46,14 +51,40 @@ export function HubSourceSearch({
   isAdded: (suggestion: Suggestion) => boolean;
   disabled?: boolean;
 }) {
-  const [type, setType] = useState<HubSuggestionType>(UserHubSourceType.User);
+  const [type, setType] = useState<UserHubSourceType>(UserHubSourceType.User);
   const [query, setQuery] = useState('');
   const [debounced] = useDebouncedValue(query, 300);
+  const isTag = type === UserHubSourceType.Tag;
 
-  const { data: suggestions = [], isFetching } = trpc.userHub.sourceSuggestions.useQuery({
-    type,
-    query: debounced || undefined,
-  });
+  const { data: related = [], isFetching: fetchingRelated } =
+    trpc.userHub.sourceSuggestions.useQuery(
+      { type: type as HubSuggestionType, query: debounced || undefined },
+      { enabled: !isTag }
+    );
+
+  // The site's own tag list, not a hub endpoint: `tag.getAll` is what every other
+  // tag picker on the site already uses, and it carries the filters this needs —
+  // image tags, listed, and not the moderation or system vocabularies. Adding a
+  // fourth arm to `sourceSuggestions` would have been a second implementation of
+  // it, scoped to relationships tags do not have.
+  const { data: tagData, isFetching: fetchingTags } = trpc.tag.getAll.useQuery(
+    {
+      entityType: [TagTarget.Image],
+      types: [TagType.UserGenerated, TagType.Label],
+      query: debounced || undefined,
+      limit: TAG_SUGGESTION_LIMIT,
+    },
+    { enabled: isTag }
+  );
+
+  const isFetching = isTag ? fetchingTags : fetchingRelated;
+  const suggestions: Suggestion[] = isTag
+    ? (tagData?.items ?? []).map((tag) => ({
+        type: UserHubSourceType.Tag,
+        targetId: tag.id,
+        alias: tag.name,
+      }))
+    : related;
 
   const active = tabs.find((tab) => tab.value === type);
 
@@ -69,7 +100,7 @@ export function HubSourceSearch({
           label,
           disabled: itemDisabled,
         }))}
-        onChange={(value) => setType(value as HubSuggestionType)}
+        onChange={(value) => setType(value as UserHubSourceType)}
       />
 
       <TextInput

--- a/src/components/Hubs/HubSourceSearch.tsx
+++ b/src/components/Hubs/HubSourceSearch.tsx
@@ -12,7 +12,8 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
 import { useState } from 'react';
 import type { HubSuggestionType } from '~/server/schema/user-hub.schema';
-import { TagTarget, TagType, UserHubSourceType } from '~/shared/utils/prisma/enums';
+import { HUB_TAG_SOURCE_FILTER } from '~/server/schema/user-hub.schema';
+import { UserHubSourceType } from '~/shared/utils/prisma/enums';
 import { trpc } from '~/utils/trpc';
 
 type Suggestion = { type: UserHubSourceType; targetId: number; alias: string };
@@ -63,8 +64,13 @@ export function HubSourceSearch({
   // it, scoped to relationships tags do not have.
   const { data: tagData, isFetching: fetchingTags } = trpc.tag.getAll.useQuery(
     {
-      entityType: [TagTarget.Image],
-      types: [TagType.UserGenerated, TagType.Label],
+      // Spread, not retyped. The same two fields were written out here verbatim,
+      // which made this a third copy of a rule the server states once — and the
+      // divergence would be silent and one-directional: widen the constant and the
+      // server accepts the new tags while the picker keeps offering the old set, so
+      // a tag you could add by pasting a link could not be found by searching.
+      entityType: [...HUB_TAG_SOURCE_FILTER.entityType],
+      types: [...HUB_TAG_SOURCE_FILTER.types],
       query: debounced || undefined,
       limit: TAG_SUGGESTION_LIMIT,
     },

--- a/src/components/Hubs/HubSourceSearch.tsx
+++ b/src/components/Hubs/HubSourceSearch.tsx
@@ -12,24 +12,18 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
 import { useState } from 'react';
 import type { HubSuggestionType } from '~/server/schema/user-hub.schema';
-import { HUB_COLLECTION_SOURCES_ENABLED } from '~/server/schema/user-hub.schema';
 import { TagTarget, TagType, UserHubSourceType } from '~/shared/utils/prisma/enums';
 import { trpc } from '~/utils/trpc';
 
 type Suggestion = { type: UserHubSourceType; targetId: number; alias: string };
 
-// Collections are listed but not selectable until the index attribute they are
-// served by is live — `HUB_COLLECTION_SOURCES_ENABLED` gates the write path too,
-// so an enabled tab would offer sources the server refuses.
+// Collections are absent rather than disabled. They cannot work until the index
+// attribute serving them is live, and a greyed-out tab advertises a source the
+// server would refuse — `resolveHubSourceFromUrl` still resolves a pasted
+// collection link, gated the same way, so nothing is lost by not listing it.
 const tabs = [
   { value: UserHubSourceType.User, label: 'Creators', scope: 'creators you follow' },
   { value: UserHubSourceType.Model, label: 'Models', scope: 'models you own or bookmarked' },
-  {
-    value: UserHubSourceType.Collection,
-    label: 'Collections',
-    scope: 'collections you follow',
-    disabled: !HUB_COLLECTION_SOURCES_ENABLED,
-  },
   // The one tab that is not a relationship: everyone shares the same tag
   // vocabulary, so it searches the site's tags rather than the viewer's library.
   { value: UserHubSourceType.Tag, label: 'Tags', scope: 'image tags' },
@@ -95,11 +89,7 @@ export function HubSourceSearch({
         size="xs"
         value={type}
         disabled={disabled}
-        data={tabs.map(({ value, label, disabled: itemDisabled }) => ({
-          value,
-          label,
-          disabled: itemDisabled,
-        }))}
+        data={tabs.map(({ value, label }) => ({ value, label }))}
         onChange={(value) => setType(value as UserHubSourceType)}
       />
 

--- a/src/components/Hubs/HubSourceUrlInput.tsx
+++ b/src/components/Hubs/HubSourceUrlInput.tsx
@@ -66,7 +66,8 @@ export function HubSourceUrlInput({
         <Group gap={4} wrap="nowrap" c="dimmed">
           <IconAlertTriangle size={14} className="shrink-0" />
           <Text size="xs">
-            Not a link we recognise. Try a creator, model, version or collection page.
+            Not a link we recognise. Try a creator, model, version or tag page — a feed link works
+            too, as long as it carries a single tag.
           </Text>
         </Group>
       )}

--- a/src/components/Hubs/HubSourceUrlInput.tsx
+++ b/src/components/Hubs/HubSourceUrlInput.tsx
@@ -10,6 +10,7 @@ const sourceLabels: Record<UserHubSourceType, string> = {
   [UserHubSourceType.Model]: 'Model',
   [UserHubSourceType.ModelVersion]: 'Version',
   [UserHubSourceType.Collection]: 'Collection',
+  [UserHubSourceType.Tag]: 'Tag',
 };
 
 /**

--- a/src/components/Hubs/__tests__/hub-share.test.ts
+++ b/src/components/Hubs/__tests__/hub-share.test.ts
@@ -71,12 +71,13 @@ describe('buildDuplicateHubInput', () => {
   // spreading the whole source instead of picking fields stays green — and in
   // production that spreads the ORIGINAL hub's source-row ids into the copy.
   let nextId = 100;
-  const source = (targetId: number, enabled = true) => ({
+  const source = (targetId: number, enabled = true, exclude = false) => ({
     id: nextId++,
     type: UserHubSourceType.User,
     targetId,
     alias: `creator-${targetId}`,
     enabled,
+    exclude,
     index: 0,
   });
 
@@ -132,5 +133,48 @@ describe('buildDuplicateHubInput', () => {
 
   it('defaults the level to uncapped when the original had none', () => {
     expect(buildDuplicateHubInput(hub()).forcedBrowsingLevel).toBe(0);
+  });
+  it('carries the exclusions across, not only the sources', () => {
+    // A copy that drops them serves content the original refuses, under the same
+    // name, with nothing saying so. `exclude` is asserted on the OUTPUT rather than
+    // just counted: hardcoding `exclude: false` in the map produces the right number
+    // of rows and the wrong hub.
+    const result = buildDuplicateHubInput(hub({ sources: [source(1), source(2, true, true)] }));
+
+    expect(result.sources).toEqual([
+      {
+        type: UserHubSourceType.User,
+        targetId: 1,
+        alias: 'creator-1',
+        enabled: true,
+        exclude: false,
+        index: 0,
+      },
+      {
+        type: UserHubSourceType.User,
+        targetId: 2,
+        alias: 'creator-2',
+        enabled: true,
+        exclude: true,
+        index: 1,
+      },
+    ]);
+  });
+
+  it('slices the two kinds against their OWN caps', () => {
+    // One `slice` over the combined list lets a full source list swallow every
+    // exclusion — the half that keeps content out. Sized past both caps so a single
+    // combined slice cannot produce this shape by coincidence.
+    const sources = [
+      ...Array.from({ length: hubLimits.sourcesPerHub + 5 }, (_, i) => source(i + 1)),
+      ...Array.from({ length: hubLimits.exclusionsPerHub + 5 }, (_, i) =>
+        source(i + 500, true, true)
+      ),
+    ];
+
+    const result = buildDuplicateHubInput(hub({ sources }));
+
+    expect(result.sources.filter((s) => !s.exclude)).toHaveLength(hubLimits.sourcesPerHub);
+    expect(result.sources.filter((s) => s.exclude)).toHaveLength(hubLimits.exclusionsPerHub);
   });
 });

--- a/src/components/Hubs/hub.utils.ts
+++ b/src/components/Hubs/hub.utils.ts
@@ -88,6 +88,7 @@ export function buildDuplicateHubInput(hub: {
     targetId: number;
     alias?: string | null;
     enabled: boolean;
+    exclude?: boolean;
   }[];
 }) {
   return {
@@ -99,16 +100,24 @@ export function buildDuplicateHubInput(hub: {
     forcedBrowsingLevel: hub.forcedBrowsingLevel ?? 0,
     // Fields picked one by one rather than spread: `getById` rows carry a row `id`,
     // and passing one through would address the ORIGINAL's source rows.
-    sources: hub.sources
-      .filter((source) => source.enabled)
-      .slice(0, hubLimits.sourcesPerHub)
-      .map((source, index) => ({
-        type: source.type,
-        targetId: source.targetId,
-        alias: source.alias ?? null,
-        enabled: true,
-        index,
-      })),
+    // Sliced per kind, because the two caps are separate: one `slice` over the
+    // combined list would let a long source list swallow the copier's exclusions,
+    // which is the half that keeps content OUT.
+    sources: [
+      ...hub.sources
+        .filter((source) => source.enabled && !source.exclude)
+        .slice(0, hubLimits.sourcesPerHub),
+      ...hub.sources
+        .filter((source) => source.enabled && source.exclude)
+        .slice(0, hubLimits.exclusionsPerHub),
+    ].map((source, index) => ({
+      type: source.type,
+      targetId: source.targetId,
+      alias: source.alias ?? null,
+      enabled: true,
+      exclude: !!source.exclude,
+      index,
+    })),
   };
 }
 
@@ -126,6 +135,7 @@ export function toPanelHub(hub: {
     targetId: number;
     alias: string | null;
     enabled: boolean;
+    exclude: boolean;
     index: number;
   }[];
 }): HubPanelHub {

--- a/src/components/Hubs/hub.utils.ts
+++ b/src/components/Hubs/hub.utils.ts
@@ -138,6 +138,7 @@ export function toPanelHub(hub: {
     exclude: boolean;
     index: number;
   }[];
+  excludedCount: number;
 }): HubPanelHub {
   return {
     id: hub.id,
@@ -146,5 +147,6 @@ export function toPanelHub(hub: {
     availability: hub.availability,
     isOwner: hub.isOwner,
     sources: hub.sources.map(({ id: _id, ...source }) => source),
+    excludedCount: hub.excludedCount,
   };
 }

--- a/src/server/flipt/__tests__/flipt-eval-context.test.ts
+++ b/src/server/flipt/__tests__/flipt-eval-context.test.ts
@@ -157,9 +157,9 @@ const ENTITY_WITHOUT_CONTEXT_LEDGER: Record<string, string> = {
   // flag `feed-image-existence`: enabled=true, 0 rules, 0 rollouts. Three sites.
   'server/services/image.service.ts:3142':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:3865':
+  'server/services/image.service.ts:3911':
     'feed-image-existence has no segment rollouts; hot feed path',
-  'server/services/image.service.ts:4670':
+  'server/services/image.service.ts:4721':
     'feed-image-existence has no segment rollouts; hot feed path',
   // flags `model-text-moderation-xguard` / `-apply`: both enabled=true, 0 rules,
   // 0 rollouts (checked against flipt-state and against the evaluation API on

--- a/src/server/schema/user-hub.schema.ts
+++ b/src/server/schema/user-hub.schema.ts
@@ -73,6 +73,13 @@ export const HUB_COLLECTION_SOURCES_ENABLED = false;
  * is the control that already enforces it; a second, weaker spelling would leave a
  * user believing they had set something stronger than they had.
  */
+/**
+ * ⚠️ `entityType` holding exactly ONE value is load-bearing. The picker reaches
+ * `getTags`, which matches it with array OVERLAP (`target && ARRAY[...]`, i.e. ANY);
+ * the server's `hubTagWhere` uses `hasEvery` (ALL). Identical at one element, and
+ * they part company at two — in the dangerous direction, with the picker offering
+ * tags the server then refuses. Add a second target only with that reconciled.
+ */
 export const HUB_TAG_SOURCE_FILTER = {
   entityType: [TagTarget.Image],
   types: [TagType.UserGenerated, TagType.Label],

--- a/src/server/schema/user-hub.schema.ts
+++ b/src/server/schema/user-hub.schema.ts
@@ -14,6 +14,15 @@ export const hubLimits = {
   // whole list, and the follow button decides its own state from it.
   followedHubs: 50,
   sourcesPerHub: 50,
+  // Counted separately from `sourcesPerHub`, not out of it: a hub that refuses 20
+  // creators has not spent any of the budget it collects with, and sharing one cap
+  // would let the exclusion list starve the thing the hub is for.
+  //
+  // 20 also bounds the excluded-version expansion, which — unlike the positive one —
+  // deliberately does NOT truncate. Measured on the prod replica: 942,241 models,
+  // p99 of 5 versions each, 180 at the worst model, and 58 models past 50 versions.
+  // So the ceiling is 20 x 180 = 3,600 ids and the realistic case is ~100.
+  exclusionsPerHub: 20,
   nameLength: 60,
   aliasLength: 60,
   descriptionLength: 300,
@@ -70,6 +79,10 @@ export const userHubSourceSchema = z.object({
     .transform((value) => value.slice(0, hubLimits.aliasLength))
     .nullish(),
   enabled: z.boolean().default(true),
+  // A negative source. Defaulted rather than optional because this list REPLACES the
+  // stored one: an undefined here would write `false` through Prisma's own default
+  // anyway, and spelling it makes the round trip visible.
+  exclude: z.boolean().default(false),
   index: z.number().int().min(0).default(0),
 });
 
@@ -127,7 +140,13 @@ export const upsertUserHubSchema = z.object({
   // Every caller sending its own cached copy of the full list turned a sort change
   // into a full replacement, so a save issued before another one's invalidate
   // settled reverted it.
-  sources: z.array(userHubSourceSchema).max(hubLimits.sourcesPerHub).optional(),
+  // The two kinds share one array and are capped SEPARATELY in the service — this
+  // bound is only the outer one, so a list of 50 sources plus 20 exclusions is not
+  // rejected before the service can tell the caller which half it overran.
+  sources: z
+    .array(userHubSourceSchema)
+    .max(hubLimits.sourcesPerHub + hubLimits.exclusionsPerHub)
+    .optional(),
   // Same "omitted means leave alone" rule as `sources`; stored on
   // `metadata.filters`, like `description`.
   filters: hubFeedFiltersSchema.optional(),
@@ -215,6 +234,7 @@ export const userHubSourceRefSchema = z.object({
 
 export const addUserHubSourceSchema = userHubSourceRefSchema.extend({
   alias: userHubSourceSchema.shape.alias,
+  exclude: z.boolean().default(false),
 });
 
 export type UserHubSourceRefInput = z.infer<typeof userHubSourceRefSchema>;

--- a/src/server/schema/user-hub.schema.ts
+++ b/src/server/schema/user-hub.schema.ts
@@ -4,6 +4,8 @@ import {
   Availability,
   MediaType,
   MetricTimeframe,
+  TagTarget,
+  TagType,
   UserHubSourceType,
 } from '~/shared/utils/prisma/enums';
 import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
@@ -18,11 +20,21 @@ export const hubLimits = {
   // creators has not spent any of the budget it collects with, and sharing one cap
   // would let the exclusion list starve the thing the hub is for.
   //
-  // 20 also bounds the excluded-version expansion, which — unlike the positive one —
-  // deliberately does NOT truncate. Measured on the prod replica: 942,241 models,
-  // p99 of 5 versions each, 180 at the worst model, and 58 models past 50 versions.
-  // So the ceiling is 20 x 180 = 3,600 ids and the realistic case is ~100.
   exclusionsPerHub: 20,
+  // What the excluded Model sources of one hub may expand to, checked when a source
+  // is ADDED rather than when the feed is read. The exclusion expansion deliberately
+  // does not truncate — a trimmed exclusion serves back content the owner said to
+  // keep out — so the bound has to sit somewhere a user can be told about it.
+  //
+  // 🔴 `exclusionsPerHub` alone does NOT bound it. It caps sources; the expansion
+  // factor is whatever `ModelVersion` happens to hold, which drifts with the data and
+  // reports nothing. Measured on the prod replica 2026-09-04: 942,348 models /
+  // 1,219,642 versions, p99 of 5, max 180, and the 20 DISTINCT largest models sum to
+  // 2,064 — which, across the three attribution arms the filter needs, is 6,192 ids
+  // and ~45KB, against 2,250 / ~18KB on the positive side. That shape measured 5.7s
+  // cold, past the 5s deadline. Matched to `resolvedVersionIds` so neither side can
+  // put more into the filter than the other.
+  excludedVersionIds: 750,
   nameLength: 60,
   aliasLength: 60,
   descriptionLength: 300,
@@ -50,6 +62,21 @@ export const hubLimits = {
 // So collection sources stay dark until the index has actually been rebuilt.
 // Flip this to true in the same change that confirms the attribute is live.
 export const HUB_COLLECTION_SOURCES_ENABLED = false;
+
+/**
+ * The tag vocabulary a hub may be keyed on. One constant because the picker QUERIES
+ * with it and the server ASSERTS with it, and a picker offering something the server
+ * 404s is the shape this is here to stop.
+ *
+ * Moderation and System tags are out in BOTH directions — Justin's call, 2026-09-04.
+ * Excluding a moderation label is a reasonable thing to want, but the browsing level
+ * is the control that already enforces it; a second, weaker spelling would leave a
+ * user believing they had set something stronger than they had.
+ */
+export const HUB_TAG_SOURCE_FILTER = {
+  entityType: [TagTarget.Image],
+  types: [TagType.UserGenerated, TagType.Label],
+} as const;
 
 // The hub's public identifier, as it appears in the URL. A string, because the route
 // carries the ENCODED id — an int here would be the pre-encoding format and would put

--- a/src/server/services/__tests__/hub-feed-filter.test.ts
+++ b/src/server/services/__tests__/hub-feed-filter.test.ts
@@ -34,8 +34,10 @@ const hubSources = (over: Partial<ResolvedHubSources> = {}): ResolvedHubSources 
   userIds: [],
   modelVersionIds: [],
   collectionIds: [],
+  tagIds: [],
   truncated: false,
   forcedBrowsingLevel: 0,
+  excluded: { userIds: [], modelVersionIds: [], tagIds: [] },
   ...over,
 });
 
@@ -181,6 +183,115 @@ describe('hub filter reaches the search backend', () => {
     expect(fetchDocumentsMock).toHaveBeenCalled();
     expect(emittedFilter()).not.toContain('postedToId IN');
     expect(resolveHubSourcesMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('a tag source joins the OR group', () => {
+  it('emits the tag arm beside the others', async () => {
+    resolveHubSourcesMock.mockResolvedValue(hubSources({ userIds: [10], tagIds: [77, 78] }));
+
+    await getImagesFromSearchPreFilter(input(1));
+
+    // One string, for the reason the first test in this file gives: per-arm
+    // `toContain` survives ' OR ' becoming ' AND ', which is an empty hub.
+    expect(emittedFilter()).toContain('(userId IN [10] OR tagIds IN [77,78])');
+  });
+});
+
+/**
+ * The keep-out group. Two mutations this has to catch, and the first is the one a
+ * per-arm assertion misses:
+ *
+ *   `AND NOT (…)` -> `OR NOT (…)`   — the exclusion stops narrowing anything, and
+ *                                     the hub serves the excluded content back.
+ *   `NOT (a OR b)` -> `NOT (a AND b)` — only content matching BOTH is removed, so
+ *                                     almost nothing is.
+ *
+ * Both are one-token edits inside a string nothing else reads, so the assertions
+ * below quote the operators rather than the arms.
+ */
+describe('a hub keeps its excluded sources out', () => {
+  // A NOT group opening on one of the hub's own fields. `String.raw` because a
+  // template literal turns `` into a backspace, which matches nothing and makes
+  // the control pass forever.
+  const hubExclusionGroup = new RegExp(String.raw`NOT \((userId|tagIds|postedToId)`);
+
+  const withExclusions = hubSources({
+    userIds: [10],
+    excluded: { userIds: [11], modelVersionIds: [20], tagIds: [77] },
+  });
+
+  it('ANDs a NOT group onto the source filter', async () => {
+    resolveHubSourcesMock.mockResolvedValue(withExclusions);
+
+    await getImagesFromSearchPreFilter(input(1));
+
+    expect(emittedFilter()).toContain(
+      '(userId IN [10]) AND NOT (userId IN [11] OR tagIds IN [77] OR postedToId IN [20] OR modelVersionIds IN [20] OR modelVersionIdsManual IN [20])'
+    );
+  });
+
+  it('excludes a model under every resource attribution, not only the gated ones', async () => {
+    // hideAutoResources/hideManualResources gate the INCLUSION arms. Letting them
+    // reach the exclusion would serve a refused model back to anyone who happened to
+    // have one of those filters on.
+    resolveHubSourcesMock.mockResolvedValue(withExclusions);
+
+    await getImagesFromSearchPreFilter({
+      ...input(1),
+      hideAutoResources: true,
+      hideManualResources: true,
+    });
+
+    expect(emittedFilter()).toContain(
+      'NOT (userId IN [11] OR tagIds IN [77] OR postedToId IN [20] OR modelVersionIds IN [20] OR modelVersionIdsManual IN [20])'
+    );
+  });
+
+  it('emits no NOT group at all when the hub excludes nothing', async () => {
+    // The negative control. Without it every assertion above passes for a builder
+    // that hard-codes a NOT group, and an unconditional `NOT ()` is either a syntax
+    // error Meili rejects or a filter that removes content nobody excluded.
+    //
+    // Matched on the ARM, not on a bare `NOT (`: the licence-restriction filter emits
+    // its own NOT group on every request, so `not.toContain('NOT (')` fails whether or
+    // not this code is correct.
+    resolveHubSourcesMock.mockResolvedValue(hubSources({ userIds: [10] }));
+
+    await getImagesFromSearchPreFilter(input(1));
+
+    expect(fetchDocumentsMock).toHaveBeenCalled();
+    expect(emittedFilter()).not.toMatch(hubExclusionGroup);
+  });
+
+  it('still serves the page — an exclusion narrows the feed, it does not empty it', async () => {
+    resolveHubSourcesMock.mockResolvedValue(withExclusions);
+
+    const result = await getImagesFromSearchPreFilter(input(1));
+
+    expect(fetchDocumentsMock).toHaveBeenCalled();
+    expect(result.data).toEqual([]);
+  });
+
+  it('the post-filter builder emits the same NOT group', async () => {
+    // Per builder, not once: a per-user flag decides which one a request takes, and
+    // the one nobody tested is the one the exclusion goes missing from.
+    resolveHubSourcesMock.mockResolvedValue(withExclusions);
+
+    await getImagesFromSearchPostFilter(input(1));
+
+    expect(emittedFilter()).toContain(
+      '(userId IN [10]) AND NOT (userId IN [11] OR tagIds IN [77] OR postedToId IN [20] OR modelVersionIds IN [20] OR modelVersionIdsManual IN [20])'
+    );
+  });
+
+  it('the post-filter builder emits no NOT group without exclusions', async () => {
+    resolveHubSourcesMock.mockResolvedValue(hubSources({ userIds: [10] }));
+
+    await getImagesFromSearchPostFilter(input(1));
+
+    expect(fetchDocumentsMock).toHaveBeenCalled();
+    expect(emittedFilter()).not.toMatch(hubExclusionGroup);
   });
 });
 

--- a/src/server/services/__tests__/hub-feed-filter.test.ts
+++ b/src/server/services/__tests__/hub-feed-filter.test.ts
@@ -196,6 +196,17 @@ describe('a tag source joins the OR group', () => {
     // `toContain` survives ' OR ' becoming ' AND ', which is an empty hub.
     expect(emittedFilter()).toContain('(userId IN [10] OR tagIds IN [77,78])');
   });
+
+  it('serves a hub whose ONLY source is a tag', async () => {
+    // The empty-hub branch reads the arm list, not the source list. A tag-only hub
+    // that produced no arm would return an empty page while its rail showed a source.
+    resolveHubSourcesMock.mockResolvedValue(hubSources({ tagIds: [77] }));
+
+    await getImagesFromSearchPreFilter(input(1));
+
+    expect(fetchDocumentsMock).toHaveBeenCalled();
+    expect(emittedFilter()).toContain('(tagIds IN [77])');
+  });
 });
 
 /**
@@ -214,7 +225,16 @@ describe('a hub keeps its excluded sources out', () => {
   // A NOT group opening on one of the hub's own fields. `String.raw` because a
   // template literal turns `` into a backspace, which matches nothing and makes
   // the control pass forever.
-  const hubExclusionGroup = new RegExp(String.raw`NOT \((userId|tagIds|postedToId)`);
+  // `\)` is in the alternation because the OTHER revert of the guard — deleting
+  // `if (!arms.length) return null` — emits the literal `NOT ()`, which no arm name
+  // matches. That one is not a quiet permissive bug: Meilisearch rejects the filter
+  // (verified against the prod index, HTTP 400, where the same query without the
+  // group returns 200), so every hub feed that excludes NOTHING fails. `modelVersionIds`
+  // is here so the control does not depend on which arm the builder happens to emit
+  // first.
+  const hubExclusionGroup = new RegExp(
+    String.raw`NOT \((\)|userId|tagIds|postedToId|modelVersionIds)`
+  );
 
   const withExclusions = hubSources({
     userIds: [10],

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -525,12 +525,6 @@ describe('tag sources are restricted to the browsable vocabulary', () => {
     expect(dbMock.dbWrite.userHub.create).not.toHaveBeenCalled();
   });
 
-  it('refuses a tag id that matches no row', async () => {
-    findTags.mockResolvedValue([]);
-
-    await expect(upsertUserHub(withTag())).rejects.toThrow(/not found/i);
-  });
-
   it('checks EVERY tag, not just the first one', async () => {
     // The guard matches rows to ids with `find`. Positional matching — `tags[0]` —
     // passes every single-tag case in this block, and in production lets a moderation
@@ -566,10 +560,16 @@ describe('tag sources are restricted to the browsable vocabulary', () => {
     findTags.mockResolvedValue([]);
 
     await expect(upsertUserHub(withTag(true))).rejects.toThrow(/not found/i);
-    // And the same query, so the exclude side cannot drift onto a looser rule.
-    expect(findTags.mock.calls[0][0].where).toEqual(
-      expect.objectContaining({ type: { in: [TagType.UserGenerated, TagType.Label] } })
-    );
+    // All four clauses, not just `type`. Pinning one caught a drift on the vocabulary
+    // I happened to name and missed a drift that dropped `unlisted`, `adminOnly` or
+    // `target` — the three that hide moderation labels.
+    expect(findTags.mock.calls[0][0].where).toEqual({
+      id: { in: [77] },
+      unlisted: false,
+      adminOnly: false,
+      target: { hasEvery: [TagTarget.Image] },
+      type: { in: [TagType.UserGenerated, TagType.Label] },
+    });
   });
 });
 
@@ -930,9 +930,17 @@ describe('resolving a pasted link', () => {
       // `equals`, NOT `mode: 'insensitive'`. Tag.name is citext, so a plain equals is
       // already case-insensitive and index-served; the ILIKE the other spelling emits
       // is served by no btree. The same argument the username lookup makes above.
-      expect(findTag.mock.calls[0][0].where).toEqual(
-        expect.objectContaining({ name: { equals: 'dragon' } })
-      );
+      // Whole object rather than `objectContaining`: the name clause is known here, so
+      // nothing is lost by pinning all of it — and only the strict form catches a
+      // clause being ADDED beside the rule, which is how a loosening escape hatch
+      // would arrive.
+      expect(findTag.mock.calls[0][0].where).toEqual({
+        name: { equals: 'dragon' },
+        unlisted: false,
+        adminOnly: false,
+        target: { hasEvery: [TagTarget.Image] },
+        type: { in: [TagType.UserGenerated, TagType.Label] },
+      });
     });
 
     it('resolves a single-tag feed link by id', async () => {
@@ -944,7 +952,18 @@ describe('resolving a pasted link', () => {
       });
 
       expect(source).toEqual({ type: UserHubSourceType.Tag, targetId: 5499, alias: 'dragon' });
-      expect(findTag.mock.calls[0][0].where).toEqual(expect.objectContaining({ id: 5499 }));
+      // 🔴 The WHOLE where, vocabulary included. The rule is spread into two arms of a
+      // ternary, and pinning only `id` left this one — the feed-chip link, the paste
+      // most likely to carry a moderation-label id — free to drop it and return that
+      // label's NAME to the caller. Asserting `objectContaining({ id })` went green
+      // over exactly that.
+      expect(findTag.mock.calls[0][0].where).toEqual({
+        id: 5499,
+        unlisted: false,
+        adminOnly: false,
+        target: { hasEvery: [TagTarget.Image] },
+        type: { in: [TagType.UserGenerated, TagType.Label] },
+      });
     });
 
     it('applies the SAME vocabulary rule the add path applies', async () => {

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -42,6 +42,8 @@ import {
   CollectionReadConfiguration,
   MetricTimeframe,
   ModelStatus,
+  TagTarget,
+  TagType,
   UserHubSourceType,
 } from '~/shared/utils/prisma/enums';
 import { ImageSort } from '~/server/common/enums';
@@ -177,6 +179,114 @@ describe('resolveHubSources', () => {
     });
 
     expect(result?.userIds).toEqual([10]);
+  });
+
+  /**
+   * Negative sources. The properties here are the ones no assertion on the emitted
+   * FILTER can see, because they decide what reaches the builder in the first place.
+   */
+  describe('negative sources', () => {
+    const excludedVersions = dbMock.dbRead.modelVersion.findMany;
+
+    it('keeps an excluded source out of the positive sets and in the excluded ones', async () => {
+      findFirstHub.mockResolvedValue({
+        forcedBrowsingLevel: 0,
+        sources: [
+          { type: UserHubSourceType.User, targetId: 10, exclude: false },
+          { type: UserHubSourceType.User, targetId: 11, exclude: true },
+          { type: UserHubSourceType.Tag, targetId: 77, exclude: false },
+          { type: UserHubSourceType.Tag, targetId: 78, exclude: true },
+        ],
+      });
+
+      const result = await resolveHubSources({ hubId: 1, userId: 5 });
+
+      // Both directions asserted. Half of this — the positive sets — stays green if
+      // every source is read as an exclusion, which is a hub that shows nothing.
+      expect(result?.userIds).toEqual([10]);
+      expect(result?.tagIds).toEqual([77]);
+      expect(result?.excluded.userIds).toEqual([11]);
+      expect(result?.excluded.tagIds).toEqual([78]);
+    });
+
+    it('IGNORES a session toggle aimed at a negative source', async () => {
+      // 🔴 The one direction a viewer-supplied list must never move the feed. A
+      // session toggle removes content from the person who forged it; letting it
+      // reach an exclusion would ADD content the owner refused, to anyone who can
+      // post a hub feed query. Do not "fix" this by subtracting before the split.
+      findFirstHub.mockResolvedValue({
+        forcedBrowsingLevel: 0,
+        sources: [
+          { type: UserHubSourceType.User, targetId: 10, exclude: false },
+          { type: UserHubSourceType.User, targetId: 11, exclude: true },
+        ],
+      });
+
+      const result = await resolveHubSources({
+        hubId: 1,
+        userId: 5,
+        excludedSources: [{ type: UserHubSourceType.User, targetId: 11 }],
+      });
+
+      expect(result?.excluded.userIds).toEqual([11]);
+    });
+
+    it('still lets a session toggle drop a POSITIVE source', async () => {
+      // The control for the test above: without it, that assertion also passes for a
+      // resolver that ignores the session list entirely, which breaks every viewer's
+      // source toggles.
+      findFirstHub.mockResolvedValue({
+        forcedBrowsingLevel: 0,
+        sources: [
+          { type: UserHubSourceType.User, targetId: 10, exclude: false },
+          { type: UserHubSourceType.User, targetId: 11, exclude: true },
+        ],
+      });
+
+      const result = await resolveHubSources({
+        hubId: 1,
+        userId: 5,
+        excludedSources: [{ type: UserHubSourceType.User, targetId: 10 }],
+      });
+
+      expect(result?.userIds).toEqual([]);
+      expect(result?.excluded.userIds).toEqual([11]);
+    });
+
+    it('expands an excluded model into ALL of its versions, untrimmed', async () => {
+      // Deliberately not the budgeted, per-model-ranked expansion the positive path
+      // uses: a trimmed exclusion serves back content the owner said to keep out.
+      findFirstHub.mockResolvedValue({
+        forcedBrowsingLevel: 0,
+        sources: [
+          { type: UserHubSourceType.Model, targetId: 20, exclude: true },
+          { type: UserHubSourceType.ModelVersion, targetId: 99, exclude: true },
+        ],
+      });
+      excludedVersions.mockResolvedValue([{ id: 30 }, { id: 31 }, { id: 32 }]);
+
+      const result = await resolveHubSources({ hubId: 1, userId: 5 });
+
+      expect(result?.excluded.modelVersionIds).toEqual([99, 30, 31, 32]);
+      // Every version of the model, with no rank limit anywhere in the query.
+      expect(excludedVersions).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { modelId: { in: [20] } } })
+      );
+      expect(result?.modelVersionIds).toEqual([]);
+    });
+
+    it('does not query versions when nothing is excluded', async () => {
+      // The control: the assertion above passes for a resolver that expands models
+      // unconditionally, which would make every hub pay for a query it does not use.
+      findFirstHub.mockResolvedValue({
+        forcedBrowsingLevel: 0,
+        sources: [{ type: UserHubSourceType.User, targetId: 10, exclude: false }],
+      });
+
+      await resolveHubSources({ hubId: 1, userId: 5 });
+
+      expect(excludedVersions).not.toHaveBeenCalled();
+    });
   });
 
   it('carries the hub stored level out to the filter builders', async () => {
@@ -322,6 +432,72 @@ describe('resolveHubSources source expansion', () => {
         }),
       })
     );
+  });
+});
+
+/**
+ * Which tags a hub may name. The tag table carries the moderation labels the
+ * scanners write and the system tags the site runs on beside the subject tags, and
+ * a hub source is an id — so without this a hub can be keyed on any of them.
+ */
+describe('tag sources are restricted to the browsable vocabulary', () => {
+  const findTags = dbMock.dbRead.tag.findMany;
+  const imageTag = (over: Record<string, unknown> = {}) => ({
+    id: 77,
+    name: 'dragon',
+    type: TagType.UserGenerated,
+    target: [TagTarget.Image],
+    unlisted: false,
+    adminOnly: false,
+    ...over,
+  });
+  const withTag = (exclude = false) => ({
+    name: 'tagged',
+    sources: [{ type: UserHubSourceType.Tag, targetId: 77, enabled: true, exclude, index: 0 }],
+    userId: 5,
+  });
+
+  beforeEach(() => {
+    dbMock.dbRead.userHub.count.mockResolvedValue(0);
+    dbMock.dbWrite.userHub.create.mockResolvedValue({ id: 7, metadata: {}, sources: [] });
+  });
+
+  it('accepts a listed image tag', async () => {
+    // The negative control for every refusal below. Without it a guard that throws
+    // on every tag passes this whole block while shipping no tag sources at all.
+    findTags.mockResolvedValue([imageTag()]);
+
+    await upsertUserHub(withTag());
+
+    expect(dbMock.dbWrite.userHub.create).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['a moderation label', imageTag({ type: TagType.Moderation })],
+    ['a system tag', imageTag({ type: TagType.System })],
+    ['an unlisted tag', imageTag({ unlisted: true })],
+    ['an admin-only tag', imageTag({ adminOnly: true })],
+    ['a tag that does not apply to images', imageTag({ target: [TagTarget.Model] })],
+  ])('refuses %s', async (_label, tag) => {
+    findTags.mockResolvedValue([tag]);
+
+    await expect(upsertUserHub(withTag())).rejects.toThrow(/not found/i);
+    expect(dbMock.dbWrite.userHub.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses a tag id that matches no row', async () => {
+    findTags.mockResolvedValue([]);
+
+    await expect(upsertUserHub(withTag())).rejects.toThrow(/not found/i);
+  });
+
+  it('applies the same rule to an EXCLUDED tag', async () => {
+    // The direction that reads as harmless — keeping something out cannot show
+    // anything. It still names a moderation label by id, and the error text would
+    // confirm which ids are moderation labels to anyone counting.
+    findTags.mockResolvedValue([imageTag({ type: TagType.Moderation })]);
+
+    await expect(upsertUserHub(withTag(true))).rejects.toThrow(/not found/i);
   });
 });
 

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -1378,6 +1378,28 @@ describe('getUserHubById', () => {
     await expect(getUserHubById({ id: 1, userId: 999 })).rejects.toThrow(/not found/i);
   });
 
+  it('withholds the owner EXCLUSIONS from everyone but the owner', async () => {
+    // 🔴 Named for the decision, so the next reader knows it is deliberate. A public
+    // hub is openable by anyone with the link; a negative source names a creator its
+    // owner refuses. Publishing that turns every public hub into a list of who its
+    // owner blocks — a stronger rule than the `enabled` filter beside it, not the
+    // same one. A moderator is covered too: their grant is view-only over the hub,
+    // not a licence to read one user's refusals about another.
+    const sources = [
+      { type: UserHubSourceType.User, targetId: 10, enabled: true, exclude: false },
+      { type: UserHubSourceType.User, targetId: 11, enabled: true, exclude: true },
+    ];
+    findFirstHub.mockResolvedValue({ id: 1, userId: 5, metadata: {}, sources });
+
+    const stranger = await getUserHubById({ id: 1, userId: 999, isModerator: true });
+    expect(stranger.sources.map((source) => source.targetId)).toEqual([10]);
+
+    // The control. Without it this passes for a service that drops every source, or
+    // that hands the owner a list they cannot edit.
+    const owner = await getUserHubById({ id: 1, userId: 5 });
+    expect(owner.sources.map((source) => source.targetId)).toEqual([10, 11]);
+  });
+
   it('reports a moderator as NOT the owner, so the client renders it read-only', async () => {
     // "View only" is the whole scope of moderator access. `isOwner` is what every
     // write affordance branches on, so a moderator reading as owner would hand them

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as SystemCache from '~/server/services/system-cache';
 
 // These cover the two ways a hub can fail QUIETLY rather than loudly:
 //   - resolveHubSources returning something for a hub the viewer does not own,
@@ -8,10 +9,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 //     without its content-rating cap (forcedBrowsingLevel).
 // Neither shows up as an error at any layer, so only a test pins them.
 
-const { permissionsMock } = vi.hoisted(() => ({ permissionsMock: vi.fn() }));
+const { permissionsMock, replacedTagIdsMock } = vi.hoisted(() => ({
+  permissionsMock: vi.fn(),
+  replacedTagIdsMock: vi.fn(),
+}));
 
 vi.mock('~/server/services/collection.service', () => ({
   getUserCollectionPermissionsByIds: permissionsMock,
+}));
+
+// Spread rather than listed: `system-cache` exports a dozen caches this file does not
+// name, and a hand-listed factory would break the moment the service reaches one of
+// them — far from anything this test is about.
+vi.mock('~/server/services/system-cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof SystemCache>()),
+  getReplacedTagIds: replacedTagIdsMock,
 }));
 
 import {
@@ -74,6 +86,10 @@ function stubVersions(versionsByModel: Record<number, number[]>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `clearAllMocks` clears calls but keeps implementations, so a resolved value set by
+  // one test leaks into every later one. Re-declared here so each test starts from
+  // "nothing is replaced" rather than from whatever ran before it.
+  replacedTagIdsMock.mockResolvedValue([]);
   stubVersions({});
   // The service maps whatever the write returns before handing it back, so the
   // fakes have to return a row rather than undefined.
@@ -268,10 +284,15 @@ describe('resolveHubSources', () => {
       const result = await resolveHubSources({ hubId: 1, userId: 5 });
 
       expect(result?.excluded.modelVersionIds).toEqual([99, 30, 31, 32]);
-      // Every version of the model, with no rank limit anywhere in the query.
-      expect(excludedVersions).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { modelId: { in: [20] } } })
-      );
+      // The WHOLE argument, not `objectContaining`: the fake ignores what it is
+      // handed, so a `take` or an `orderBy` added to this query cannot change the rows
+      // it returns — and `objectContaining` deep-checks `where` while ignoring exactly
+      // those siblings. Trimming here is the permissive failure the whole design note
+      // is about, and this is the only assertion that can see it.
+      expect(excludedVersions.mock.calls[0][0]).toEqual({
+        where: { modelId: { in: [20] } },
+        select: { id: true },
+      });
       expect(result?.modelVersionIds).toEqual([]);
     });
 
@@ -491,6 +512,34 @@ describe('tag sources are restricted to the browsable vocabulary', () => {
     await expect(upsertUserHub(withTag())).rejects.toThrow(/not found/i);
   });
 
+  it('checks EVERY tag, not just the first one', async () => {
+    // The guard matches rows to ids with `find`. Positional matching — `tags[0]` —
+    // passes every single-tag case in this block, and in production lets a moderation
+    // label through behind one valid tag.
+    findTags.mockResolvedValue([imageTag()]);
+
+    await expect(
+      upsertUserHub({
+        name: 'tagged',
+        sources: [
+          { type: UserHubSourceType.Tag, targetId: 77, enabled: true, exclude: false, index: 0 },
+          { type: UserHubSourceType.Tag, targetId: 78, enabled: true, exclude: false, index: 1 },
+        ],
+        userId: 5,
+      })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('refuses a REPLACED tag, which the index would never match', async () => {
+    // A replaced tag is listed, image-targeted and the right type — it passes every
+    // other clause. The index carries its replacement's id, so as a source it matches
+    // nothing and as an exclusion it keeps nothing out.
+    findTags.mockResolvedValue([imageTag()]);
+    replacedTagIdsMock.mockResolvedValue([77]);
+
+    await expect(upsertUserHub(withTag())).rejects.toThrow(/not found/i);
+  });
+
   it('applies the same rule to an EXCLUDED tag', async () => {
     // The direction that reads as harmless — keeping something out cannot show
     // anything. It still names a moderation label by id, and the error text would
@@ -498,6 +547,62 @@ describe('tag sources are restricted to the browsable vocabulary', () => {
     findTags.mockResolvedValue([imageTag({ type: TagType.Moderation })]);
 
     await expect(upsertUserHub(withTag(true))).rejects.toThrow(/not found/i);
+  });
+});
+
+describe('upsertUserHub source caps', () => {
+  // `upsertUserHubSchema` widened its array max to sourcesPerHub + exclusionsPerHub,
+  // so the zod bound no longer enforces either side on its own. `assertSourceCounts`
+  // is the whole of what does. Delete the call and a 70-source hub saves clean.
+  const many = (count: number, exclude: boolean, from = 1) =>
+    Array.from({ length: count }, (_, i) => ({
+      type: UserHubSourceType.User,
+      targetId: from + i,
+      enabled: true,
+      exclude,
+      index: i,
+    }));
+
+  beforeEach(() => {
+    dbMock.dbRead.userHub.count.mockResolvedValue(0);
+    dbMock.dbWrite.userHub.create.mockResolvedValue({ id: 7, metadata: {}, sources: [] });
+  });
+
+  it('refuses more sources than the source cap', async () => {
+    await expect(
+      upsertUserHub({
+        name: 'too many',
+        sources: many(hubLimits.sourcesPerHub + 1, false),
+        userId: 5,
+      })
+    ).rejects.toThrow(/at most/i);
+    expect(dbMock.dbWrite.userHub.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses more exclusions than the exclusion cap', async () => {
+    await expect(
+      upsertUserHub({
+        name: 'too many',
+        sources: many(hubLimits.exclusionsPerHub + 1, true),
+        userId: 5,
+      })
+    ).rejects.toThrow(/exclude at most/i);
+    expect(dbMock.dbWrite.userHub.create).not.toHaveBeenCalled();
+  });
+
+  it('accepts a hub that fills BOTH caps at once', async () => {
+    // The control, and the reason the two are counted apart: a full source list plus
+    // a full exclusion list is 70 rows, which one shared cap would refuse.
+    await upsertUserHub({
+      name: 'full both ways',
+      sources: [
+        ...many(hubLimits.sourcesPerHub, false),
+        ...many(hubLimits.exclusionsPerHub, true, 1000),
+      ],
+      userId: 5,
+    });
+
+    expect(dbMock.dbWrite.userHub.create).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1298,6 +1403,236 @@ describe('addUserHubSource', () => {
     await expect(addUserHubSource({ userId: 5, hubId: 1, ...source })).rejects.toThrow();
     expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
   });
+
+  /**
+   * The exclude side of this mutation. Every test above leaves `exclude` undefined, so
+   * none of them can see the field at all: `toHaveBeenCalledWith` ignores a key whose
+   * value is undefined on both sides.
+   */
+  describe('exclusions', () => {
+    const rows = (count: number, exclude: boolean, from = 100) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: from + i,
+        type: UserHubSourceType.Model,
+        targetId: from + i,
+        enabled: true,
+        exclude,
+        index: i,
+      }));
+
+    const excludedUser = { ...source, exclude: true };
+
+    it('writes the exclude flag when creating a negative source', async () => {
+      // Drop `exclude: source.exclude` from the create and exclusions are never
+      // created at all, the row landing as an ordinary source instead. No other test
+      // in this file can see that field.
+      writerHub.mockResolvedValue({ id: 1, sources: [] });
+
+      await addUserHubSource({ userId: 5, hubId: 1, ...excludedUser });
+
+      expect(dbMock.dbWrite.userHubSource.create).toHaveBeenCalledWith({
+        data: {
+          hubId: 1,
+          type: UserHubSourceType.User,
+          targetId: 42,
+          alias: 'someone',
+          exclude: true,
+          index: 0,
+        },
+      });
+    });
+
+    it('flips a collected source to an excluded one rather than reporting a no-op', async () => {
+      writerHub.mockResolvedValue({
+        id: 1,
+        sources: [
+          {
+            id: 9,
+            type: UserHubSourceType.User,
+            targetId: 42,
+            enabled: true,
+            exclude: false,
+            index: 0,
+          },
+        ],
+      });
+
+      const result = await addUserHubSource({ userId: 5, hubId: 1, ...excludedUser });
+
+      expect(result).toEqual({ hubId: 1, added: true });
+      expect(dbMock.dbWrite.userHubSource.updateMany).toHaveBeenCalledWith({
+        where: { id: 9, hub: { userId: 5 } },
+        data: { enabled: true, exclude: true },
+      });
+    });
+
+    it('still reports a no-op when the row is already on the side asked for', async () => {
+      // The control for the flip above: without it a service that flips
+      // unconditionally passes, and re-adding a source the hub already holds writes.
+      writerHub.mockResolvedValue({
+        id: 1,
+        sources: [
+          {
+            id: 9,
+            type: UserHubSourceType.User,
+            targetId: 42,
+            enabled: true,
+            exclude: false,
+            index: 0,
+          },
+        ],
+      });
+
+      const result = await addUserHubSource({ userId: 5, hubId: 1, ...source, exclude: false });
+
+      expect(result).toEqual({ hubId: 1, added: false });
+      expect(dbMock.dbWrite.userHubSource.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('refuses a FLIP that would go past the exclusion cap', async () => {
+      // The bypass this branch had: the flip returned before the cap block, so fifty
+      // sources flipped one at a time put fifty exclusions on a hub whose limit is
+      // twenty, and flipping also empties the positive side, so the cycle repeated
+      // without bound. The exclusion expansion never truncates, which is what made
+      // that unbounded rather than merely untidy.
+      writerHub.mockResolvedValue({
+        id: 1,
+        sources: [
+          ...rows(hubLimits.exclusionsPerHub, true),
+          {
+            id: 9,
+            type: UserHubSourceType.User,
+            targetId: 42,
+            enabled: true,
+            exclude: false,
+            index: 0,
+          },
+        ],
+      });
+
+      await expect(addUserHubSource({ userId: 5, hubId: 1, ...excludedUser })).rejects.toThrow(
+        /exclude at most/i
+      );
+      expect(dbMock.dbWrite.userHubSource.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('lets a flip through when the destination has room', async () => {
+      // The control. Without it the assertion above passes for a branch that refuses
+      // every flip, which is the shipped feature not working.
+      writerHub.mockResolvedValue({
+        id: 1,
+        sources: [
+          ...rows(hubLimits.exclusionsPerHub - 1, true),
+          {
+            id: 9,
+            type: UserHubSourceType.User,
+            targetId: 42,
+            enabled: true,
+            exclude: false,
+            index: 0,
+          },
+        ],
+      });
+
+      await addUserHubSource({ userId: 5, hubId: 1, ...excludedUser });
+
+      expect(dbMock.dbWrite.userHubSource.updateMany).toHaveBeenCalled();
+    });
+
+    it('does not charge the hub twice for the row it is flipping', async () => {
+      // The row is LEAVING the other side, so counting it against the destination
+      // would refuse a flip that fits on a hub sitting exactly at the cap.
+      writerHub.mockResolvedValue({
+        id: 1,
+        sources: [
+          ...rows(hubLimits.sourcesPerHub - 1, false),
+          {
+            id: 9,
+            type: UserHubSourceType.User,
+            targetId: 42,
+            enabled: true,
+            exclude: true,
+            index: 0,
+          },
+        ],
+      });
+
+      await addUserHubSource({ userId: 5, hubId: 1, ...source, exclude: false });
+
+      expect(dbMock.dbWrite.userHubSource.updateMany).toHaveBeenCalled();
+    });
+
+    it('counts the two caps separately', async () => {
+      // A hub full of sources still has room to exclude something, and the reverse.
+      writerHub.mockResolvedValue({ id: 1, sources: rows(hubLimits.sourcesPerHub, false) });
+
+      await addUserHubSource({ userId: 5, hubId: 1, ...excludedUser });
+
+      expect(dbMock.dbWrite.userHubSource.create).toHaveBeenCalled();
+    });
+
+    it('refuses an excluded model whose versions would not fit the filter', async () => {
+      // Refused at the WRITE, because the read cannot fix it: trimming the expansion
+      // serves back content the owner said to keep out, with nothing reporting it. The
+      // cap on source COUNT does not bound this, because the expansion factor is a
+      // property of the data rather than of the code.
+      writerHub.mockResolvedValue({ id: 1, sources: [] });
+      dbMock.dbRead.modelVersion.findMany.mockResolvedValue(
+        Array.from({ length: hubLimits.excludedVersionIds + 1 }, () => ({ modelId: 20 }))
+      );
+      dbMock.dbRead.model.findFirst.mockResolvedValue({ name: 'A Very Forked Model' });
+
+      await expect(
+        addUserHubSource({
+          userId: 5,
+          hubId: 1,
+          type: UserHubSourceType.Model,
+          targetId: 20,
+          alias: null,
+          exclude: true,
+        })
+      ).rejects.toThrow(/A Very Forked Model/);
+      expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+    });
+
+    it('allows an excluded model that fits', async () => {
+      // The control for the budget: without it a check that refuses every excluded
+      // model passes, and model exclusions never work at all.
+      writerHub.mockResolvedValue({ id: 1, sources: [] });
+      dbMock.dbRead.modelVersion.findMany.mockResolvedValue(
+        Array.from({ length: hubLimits.excludedVersionIds }, () => ({ modelId: 20 }))
+      );
+
+      await addUserHubSource({
+        userId: 5,
+        hubId: 1,
+        type: UserHubSourceType.Model,
+        targetId: 20,
+        alias: null,
+        exclude: true,
+      });
+
+      expect(dbMock.dbWrite.userHubSource.create).toHaveBeenCalled();
+    });
+
+    it('refuses to EXCLUDE a collection, which would store and filter nothing', async () => {
+      // `resolveExcludedSources` has no collection arm. Refused rather than ignored,
+      // so the gap is loud on the day the collection flag is turned on.
+      writerHub.mockResolvedValue({ id: 1, sources: [] });
+
+      await expect(
+        addUserHubSource({
+          userId: 5,
+          hubId: 1,
+          type: UserHubSourceType.Collection,
+          targetId: 7,
+          alias: null,
+          exclude: true,
+        })
+      ).rejects.toThrow(/cannot be excluded/i);
+      expect(dbMock.dbWrite.userHubSource.create).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('removeUserHubSource', () => {
@@ -1349,7 +1684,9 @@ describe('getUserHubs', () => {
   });
 
   it('marks the caller as the owner of their own hubs', async () => {
-    dbMock.dbRead.userHub.findMany.mockResolvedValue([{ id: 1, userId: 5, metadata: {} }]);
+    dbMock.dbRead.userHub.findMany.mockResolvedValue([
+      { id: 1, userId: 5, metadata: {}, sources: [] },
+    ]);
 
     const [hub] = await getUserHubs({ userId: 5 });
 
@@ -1385,19 +1722,27 @@ describe('getUserHubById', () => {
     // owner blocks — a stronger rule than the `enabled` filter beside it, not the
     // same one. A moderator is covered too: their grant is view-only over the hub,
     // not a licence to read one user's refusals about another.
+    // A DISABLED positive source is in the fixture too, because the filter this
+    // tightened is a conjunction: with only `enabled: true` rows present, dropping the
+    // `source.enabled &&` half reddens nothing and a viewer starts seeing sources the
+    // owner switched off. Both conjuncts are pinned by the same expectation.
     const sources = [
       { type: UserHubSourceType.User, targetId: 10, enabled: true, exclude: false },
       { type: UserHubSourceType.User, targetId: 11, enabled: true, exclude: true },
+      { type: UserHubSourceType.User, targetId: 12, enabled: false, exclude: false },
     ];
     findFirstHub.mockResolvedValue({ id: 1, userId: 5, metadata: {}, sources });
 
     const stranger = await getUserHubById({ id: 1, userId: 999, isModerator: true });
     expect(stranger.sources.map((source) => source.targetId)).toEqual([10]);
+    // The number is published where the identities are not, so it is asserted here
+    // rather than left to whatever the payload happens to carry.
+    expect(stranger.excludedCount).toBe(1);
 
     // The control. Without it this passes for a service that drops every source, or
     // that hands the owner a list they cannot edit.
     const owner = await getUserHubById({ id: 1, userId: 5 });
-    expect(owner.sources.map((source) => source.targetId)).toEqual([10, 11]);
+    expect(owner.sources.map((source) => source.targetId)).toEqual([10, 11, 12]);
   });
 
   it('reports a moderator as NOT the owner, so the client renders it read-only', async () => {
@@ -1667,8 +2012,12 @@ describe('getHubCardData', () => {
       name: true,
       metadata: true,
       user: { select: { username: true } },
-      // Enabled only — the count a visitor can see, not the owner's full list.
-      _count: { select: { sources: { where: { enabled: true } }, followers: true } },
+      // Enabled and POSITIVE only — the count a visitor can see. This card answers
+      // unauthenticated at /api/og, and counting the exclusions would publish by
+      // subtraction the one number the keep-out list is withheld to keep private.
+      _count: {
+        select: { sources: { where: { enabled: true, exclude: false } }, followers: true },
+      },
     });
   });
 

--- a/src/server/services/__tests__/user-hub.service.test.ts
+++ b/src/server/services/__tests__/user-hub.service.test.ts
@@ -493,14 +493,33 @@ describe('tag sources are restricted to the browsable vocabulary', () => {
     expect(dbMock.dbWrite.userHub.create).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    ['a moderation label', imageTag({ type: TagType.Moderation })],
-    ['a system tag', imageTag({ type: TagType.System })],
-    ['an unlisted tag', imageTag({ unlisted: true })],
-    ['an admin-only tag', imageTag({ adminOnly: true })],
-    ['a tag that does not apply to images', imageTag({ target: [TagTarget.Model] })],
-  ])('refuses %s', async (_label, tag) => {
-    findTags.mockResolvedValue([tag]);
+  it('asks the database for the vocabulary rather than filtering rows it got back', () => {
+    // 🔴 Asserted on the QUERY, and it has to be. The rule moved into the `where` so
+    // that this path and `resolveHubSourceFromUrl` cannot disagree about it — and a
+    // mocked Prisma IGNORES `where`, returning whatever the fake holds. So feeding it
+    // a moderation label and expecting a throw would test the fake, not the code:
+    // every one of those cases passed for a service with no rule at all.
+    //
+    // Deleting any clause below is a hub keyed on a moderation label in production,
+    // and this expectation is the only thing that reddens for it.
+    findTags.mockResolvedValue([imageTag()]);
+
+    return upsertUserHub(withTag()).then(() => {
+      expect(findTags.mock.calls[0][0].where).toEqual({
+        id: { in: [77] },
+        unlisted: false,
+        adminOnly: false,
+        target: { hasEvery: [TagTarget.Image] },
+        type: { in: [TagType.UserGenerated, TagType.Label] },
+      });
+    });
+  });
+
+  it('refuses a tag the query did not return, whatever the reason', async () => {
+    // The behavioural half: whether a row was withheld for being unlisted, admin-only,
+    // the wrong type or the wrong target, the service sees the same thing — an id it
+    // asked about and did not get back — and must refuse it.
+    findTags.mockResolvedValue([]);
 
     await expect(upsertUserHub(withTag())).rejects.toThrow(/not found/i);
     expect(dbMock.dbWrite.userHub.create).not.toHaveBeenCalled();
@@ -544,9 +563,13 @@ describe('tag sources are restricted to the browsable vocabulary', () => {
     // The direction that reads as harmless — keeping something out cannot show
     // anything. It still names a moderation label by id, and the error text would
     // confirm which ids are moderation labels to anyone counting.
-    findTags.mockResolvedValue([imageTag({ type: TagType.Moderation })]);
+    findTags.mockResolvedValue([]);
 
     await expect(upsertUserHub(withTag(true))).rejects.toThrow(/not found/i);
+    // And the same query, so the exclude side cannot drift onto a looser rule.
+    expect(findTags.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({ type: { in: [TagType.UserGenerated, TagType.Label] } })
+    );
   });
 });
 
@@ -890,6 +913,94 @@ describe('resolving a pasted link', () => {
 
     expect(source).toBeNull();
     expect(dbMock.dbRead.model.findFirst).not.toHaveBeenCalled();
+  });
+
+  describe('tag links', () => {
+    const findTag = dbMock.dbRead.tag.findFirst;
+
+    it('resolves a tag page by NAME, matched the citext way', async () => {
+      findTag.mockResolvedValue({ id: 5499, name: 'dragon' });
+
+      const source = await resolveHubSourceFromUrl({
+        url: 'https://civitai.com/tag/dragon',
+        userId: 5,
+      });
+
+      expect(source).toEqual({ type: UserHubSourceType.Tag, targetId: 5499, alias: 'dragon' });
+      // `equals`, NOT `mode: 'insensitive'`. Tag.name is citext, so a plain equals is
+      // already case-insensitive and index-served; the ILIKE the other spelling emits
+      // is served by no btree. The same argument the username lookup makes above.
+      expect(findTag.mock.calls[0][0].where).toEqual(
+        expect.objectContaining({ name: { equals: 'dragon' } })
+      );
+    });
+
+    it('resolves a single-tag feed link by id', async () => {
+      findTag.mockResolvedValue({ id: 5499, name: 'dragon' });
+
+      const source = await resolveHubSourceFromUrl({
+        url: 'https://civitai.com/images?tags=5499',
+        userId: 5,
+      });
+
+      expect(source).toEqual({ type: UserHubSourceType.Tag, targetId: 5499, alias: 'dragon' });
+      expect(findTag.mock.calls[0][0].where).toEqual(expect.objectContaining({ id: 5499 }));
+    });
+
+    it('applies the SAME vocabulary rule the add path applies', async () => {
+      // 🔴 The whole point of the shared `where` fragment. If this endpoint looked a
+      // tag up without it, a moderation label would resolve here — showing its name —
+      // and only be refused later at the add. Refusing after showing the name is not
+      // refusing. Asserted on the query, because the fake returns whatever it is told
+      // and cannot enforce a filter itself.
+      findTag.mockResolvedValue({ id: 5499, name: 'dragon' });
+
+      await resolveHubSourceFromUrl({ url: 'https://civitai.com/tag/dragon', userId: 5 });
+
+      expect(findTag.mock.calls[0][0].where).toEqual(
+        expect.objectContaining({
+          unlisted: false,
+          adminOnly: false,
+          target: { hasEvery: [TagTarget.Image] },
+          type: { in: [TagType.UserGenerated, TagType.Label] },
+        })
+      );
+    });
+
+    it('returns null for a REPLACED tag, which the index would never match', async () => {
+      findTag.mockResolvedValue({ id: 5499, name: 'dragon' });
+      replacedTagIdsMock.mockResolvedValue([5499]);
+
+      const source = await resolveHubSourceFromUrl({
+        url: 'https://civitai.com/tag/dragon',
+        userId: 5,
+      });
+
+      expect(source).toBeNull();
+    });
+
+    it('returns null when the tag does not exist', async () => {
+      findTag.mockResolvedValue(null);
+
+      const source = await resolveHubSourceFromUrl({
+        url: 'https://civitai.com/tag/nope',
+        userId: 5,
+      });
+
+      expect(source).toBeNull();
+    });
+
+    it('does not reach the database for a multi-tag feed link', async () => {
+      // The parser refuses it; this pins that the service does not paper over that
+      // by looking up an arbitrary one of them.
+      const source = await resolveHubSourceFromUrl({
+        url: 'https://civitai.com/images?tags=5499&tags=5133',
+        userId: 5,
+      });
+
+      expect(source).toBeNull();
+      expect(findTag).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3384,12 +3384,53 @@ function hubFilterArms(
     if (!hideManualResources)
       arms.push({ field: 'modelVersionIdsManual', ids: sources.modelVersionIds });
   }
+  // No guard, unlike `collectionIds` below: `tagIds` has been a live filterable
+  // attribute on the metrics index since 2024, and the ids are denormalised onto the
+  // documents at index time. Verified against the prod index rather than assumed —
+  // a tag filter returns hits where `collectionIds IN [...]` is rejected outright.
+  if (sources.tagIds.length) arms.push({ field: 'tagIds', ids: sources.tagIds });
   // Guarded, not merely unused: filtering on an attribute the index has not been
   // rebuilt with makes Meilisearch reject the entire query, which surfaces as a 503.
   if (HUB_COLLECTION_SOURCES_ENABLED && sources.collectionIds.length)
     arms.push({ field: 'collectionIds', ids: sources.collectionIds });
 
   return arms.length ? arms : null;
+}
+
+/**
+ * The hub's keep-out group: a creator, model or version whose content the owner
+ * said must not appear. ANDed as a `NOT` against everything else rather than ORed
+ * into the source group — an exclusion that joins the OR is not an exclusion, it is
+ * a fifth way to be included.
+ *
+ * Returns null for "this hub excludes nothing", which is the only safe reading of
+ * an empty set: unlike `hubFilterArms`, a null here must NOT empty the page.
+ *
+ * The three resource arms are emitted unconditionally, where the positive builder
+ * gates two of them on hideAutoResources / hideManualResources. Those gates say
+ * which attributions the viewer wants to be COLLECTED by; they do not say the
+ * viewer is willing to see a model the owner refused, arriving under a different
+ * attribution.
+ */
+function buildHubExclusionFilter(sources: ResolvedHubSources): string | null {
+  const { userIds, modelVersionIds, tagIds } = sources.excluded;
+  const arms: HubFilterArm[] = [];
+  if (userIds.length) arms.push({ field: 'userId', ids: userIds });
+  if (tagIds.length) arms.push({ field: 'tagIds', ids: tagIds });
+  if (modelVersionIds.length) {
+    arms.push({ field: 'postedToId', ids: modelVersionIds });
+    arms.push({ field: 'modelVersionIds', ids: modelVersionIds });
+    arms.push({ field: 'modelVersionIdsManual', ids: modelVersionIds });
+  }
+  if (!arms.length) return null;
+
+  // Verified against the prod metrics index rather than assumed: a document whose
+  // `tagIds` is empty survives `NOT tagIds IN [x]`, and `NOT field IN [unused-id]`
+  // returns the whole set. So a NOT arm removes matches only — it does not also
+  // drop documents that lack the field.
+  return `NOT (${arms
+    .map((arm) => makeMeiliImageSearchFilter(arm.field, `IN [${arm.ids.join(',')}]`))
+    .join(' OR ')})`;
 }
 
 function buildHubFilter(
@@ -3554,6 +3595,11 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     const hubFilter = sources && buildHubFilter(sources, input);
     if (!hubFilter) return { data: [], nextCursor: undefined };
     filters.push(hubFilter);
+
+    // Pushed as its own AND term, and only when there is something to exclude: an
+    // empty keep-out set must leave the feed alone, not empty it.
+    const hubExclusionFilter = buildHubExclusionFilter(sources);
+    if (hubExclusionFilter) filters.push(hubExclusionFilter);
 
     // The hub's own content cap, applied before the browsing-level block below
     // reads `browsingLevel`. An empty intersection is served as an empty page, not
@@ -4188,6 +4234,11 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     const hubFilter = sources && buildHubFilter(sources, input);
     if (!hubFilter) return { data: [], nextCursor: undefined };
     filters.push(hubFilter);
+
+    // Pushed as its own AND term, and only when there is something to exclude: an
+    // empty keep-out set must leave the feed alone, not empty it.
+    const hubExclusionFilter = buildHubExclusionFilter(sources);
+    if (hubExclusionFilter) filters.push(hubExclusionFilter);
 
     // The hub's own content cap, applied before the browsing-level block below
     // reads `browsingLevel`. An empty intersection is served as an empty page, not

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -1071,9 +1071,17 @@ export async function resolveHubSourceFromUrl({
   }
 
   if (ref.type === 'tag' || ref.type === 'tagId') {
-    // Name lookup is a plain equals because `Tag.name` is citext — case-insensitive
-    // AND index-served, the same reason `User.username` is matched this way above
-    // rather than with `mode: 'insensitive'`.
+    // Plain equals, never `mode: 'insensitive'`: measured on the prod replica, this
+    // is an Index Scan on `Tag_name_cover_idx` at 0.04ms over 567,616 rows, and the
+    // vocabulary clauses ride as a filter over the single row the unique index
+    // returns. 🔴 What carries that is the BIND being citext, not the column — force
+    // the same predicate to `text` and the plan collapses to a parallel seq scan at
+    // 77ms. Prisma leaves the parameter type to the server, which infers citext.
+    //
+    // Note /tag/<name> is the MODEL tag page, and this rule requires an Image-targeted
+    // tag — so a model-only tag resolves to null here, which is correct (it would
+    // match nothing in an image feed) but means the by-name arm succeeds only for
+    // dual-targeted tags.
     const [tag, replacedTagIds] = await Promise.all([
       dbRead.tag.findFirst({
         where:

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -86,7 +86,7 @@ type HubRow = {
   id: number;
   metadata: Prisma.JsonValue;
   userId: number;
-  sources: { enabled: boolean }[];
+  sources: { enabled: boolean; exclude: boolean }[];
 };
 
 export type HubViewer = { userId?: number; isModerator?: boolean };
@@ -174,7 +174,15 @@ function toHubDetail<T extends HubRow>({ metadata, ...hub }: T, viewerId?: numbe
     // A source the owner switched off contributes nothing to the feed and is not
     // shown, so shipping it to a viewer publishes part of their curation for no
     // reason. The owner still gets the whole list, which is the one they edit.
-    sources: isOwner ? hub.sources : hub.sources.filter((source) => source.enabled),
+    //
+    // 🔴 Exclusions are withheld from everyone but the owner, and that is a stronger
+    // rule than the one above rather than the same one. A positive source says "I
+    // like this creator"; a negative one says "keep this creator away from me", about
+    // a named person, on a hub anyone with the link can open. Publishing it would
+    // make every public hub a list of who its owner refuses.
+    sources: isOwner
+      ? hub.sources
+      : hub.sources.filter((source) => source.enabled && !source.exclude),
     description: readDescription(metadata),
     // Re-validated on the way out: what is on the row was written by an older
     // shape of this schema, and the feed refuses some combinations outright.

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -947,6 +947,18 @@ async function assertExcludedModelsFit(modelIds: number[]) {
  * of the same intent exist would leave a user believing they had set something they
  * had not.
  */
+/**
+ * The vocabulary rule as a `where` fragment, so the add path and the paste-a-link
+ * path cannot disagree about what a hub may be keyed on. `HUB_TAG_SOURCE_FILTER` is
+ * the values; this is the query that applies them.
+ */
+const hubTagWhere = {
+  unlisted: false,
+  adminOnly: false,
+  target: { hasEvery: [...HUB_TAG_SOURCE_FILTER.entityType] },
+  type: { in: [...HUB_TAG_SOURCE_FILTER.types] },
+};
+
 async function assertHubTagsUsable(sources: UserHubSourceInput[]) {
   const tagIds = sources
     .filter((source) => source.type === UserHubSourceType.Tag)
@@ -954,9 +966,13 @@ async function assertHubTagsUsable(sources: UserHubSourceInput[]) {
   if (!tagIds.length) return;
 
   const [tags, replacedTagIds] = await Promise.all([
+    // Filtered in the QUERY, by the same fragment `resolveHubSourceFromUrl` uses to
+    // look one up by name. Re-deriving the rule from selected columns here would be
+    // a second spelling of it, and the two would drift the first time the vocabulary
+    // moved.
     dbRead.tag.findMany({
-      where: { id: { in: tagIds } },
-      select: { id: true, name: true, type: true, target: true, unlisted: true, adminOnly: true },
+      where: { id: { in: tagIds }, ...hubTagWhere },
+      select: { id: true },
     }),
     // A replaced tag still exists and still reads as browsable, but the index carries
     // its REPLACEMENT's id — so as a source it matches nothing, and as an exclusion it
@@ -965,21 +981,14 @@ async function assertHubTagsUsable(sources: UserHubSourceInput[]) {
     getReplacedTagIds(),
   ]);
   const replaced = new Set(replacedTagIds);
+  const usable = new Set(tags.map((tag) => tag.id));
 
   for (const id of tagIds) {
-    const tag = replaced.has(id) ? undefined : tags.find((t) => t.id === id);
     // A tag that fails the rule is a not-found rather than a refusal naming it: this
     // is an id-addressed lookup over a dense id space, so an error that distinguishes
     // "no such tag" from "that one is a moderation label" enumerates the moderation
     // vocabulary for anyone willing to count.
-    if (
-      !tag ||
-      tag.unlisted ||
-      tag.adminOnly ||
-      !HUB_TAG_SOURCE_FILTER.entityType.every((target) => tag.target.includes(target)) ||
-      !HUB_TAG_SOURCE_FILTER.types.some((type) => tag.type === type)
-    )
-      throw throwNotFoundError(`Tag ${id} not found`);
+    if (!usable.has(id) || replaced.has(id)) throw throwNotFoundError(`Tag ${id} not found`);
   }
 }
 
@@ -1059,6 +1068,28 @@ export async function resolveHubSourceFromUrl({
       targetId: version.id,
       alias: `${version.model.name} - ${version.name}`,
     };
+  }
+
+  if (ref.type === 'tag' || ref.type === 'tagId') {
+    // Name lookup is a plain equals because `Tag.name` is citext — case-insensitive
+    // AND index-served, the same reason `User.username` is matched this way above
+    // rather than with `mode: 'insensitive'`.
+    const [tag, replacedTagIds] = await Promise.all([
+      dbRead.tag.findFirst({
+        where:
+          ref.type === 'tag'
+            ? { name: { equals: ref.tagname }, ...hubTagWhere }
+            : { id: ref.tagId, ...hubTagWhere },
+        select: { id: true, name: true },
+      }),
+      getReplacedTagIds(),
+    ]);
+    // Null for a moderation label exactly as for a tag that does not exist. This
+    // endpoint answers before anything is saved, so a distinguishable refusal here
+    // would be a name oracle over the vocabulary the add path hides.
+    if (!tag || replacedTagIds.includes(tag.id)) return null;
+
+    return { type: UserHubSourceType.Tag, targetId: tag.id, alias: tag.name };
   }
 
   // Same gate the write path enforces, and in the same order: refusing after

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -32,6 +32,8 @@ import {
   MetricTimeframe,
   ModelEngagementType,
   ModelStatus,
+  TagTarget,
+  TagType,
   UserEngagementType,
   UserHubSourceType,
 } from '~/shared/utils/prisma/enums';
@@ -58,7 +60,15 @@ const hubListSelect = {
   metadata: true,
 
   sources: {
-    select: { id: true, type: true, targetId: true, alias: true, enabled: true, index: true },
+    select: {
+      id: true,
+      type: true,
+      targetId: true,
+      alias: true,
+      enabled: true,
+      exclude: true,
+      index: true,
+    },
     orderBy: { index: 'asc' },
   },
 } as const;
@@ -287,6 +297,7 @@ export async function upsertUserHub({
       duplicate.add(key);
     }
 
+    assertSourceCounts(sources);
     await assertHubSourcesUsable({ sources, userId });
   }
 
@@ -379,6 +390,16 @@ export async function upsertUserHub({
   return toHubDetail(updated, userId);
 }
 
+// Each kind against its own cap. Counted here rather than on the zod array, which
+// sees one list and cannot say which half overran it.
+function assertSourceCounts(sources: UserHubSourceInput[]) {
+  const excluded = sources.filter((source) => source.exclude).length;
+  if (sources.length - excluded > hubLimits.sourcesPerHub)
+    throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
+  if (excluded > hubLimits.exclusionsPerHub)
+    throw throwBadRequestError(`A hub can exclude at most ${hubLimits.exclusionsPerHub} sources`);
+}
+
 export async function addUserHubSource({
   userId,
   hubId,
@@ -393,7 +414,9 @@ export async function addUserHubSource({
     where: { id: hubId, userId },
     select: {
       id: true,
-      sources: { select: { id: true, type: true, targetId: true, enabled: true, index: true } },
+      sources: {
+        select: { id: true, type: true, targetId: true, enabled: true, exclude: true, index: true },
+      },
     },
   });
   if (!hub) throw throwNotFoundError('Hub not found');
@@ -404,23 +427,32 @@ export async function addUserHubSource({
   if (existing) {
     // A source the owner switched off is invisible to the feed — `resolveHubSources`
     // selects enabled rows only — so reporting "already there" and leaving it off is a
-    // success message for nothing happening.
-    if (existing.enabled) return { hubId, added: false };
+    // success message for nothing happening. Adding the SAME target on the other side
+    // is the same story: the unique key holds one row per target, so asking to exclude
+    // something the hub collects flips it rather than failing.
+    if (existing.enabled && existing.exclude === source.exclude) return { hubId, added: false };
 
     // Owner-scoped on the write as well as in the read above, per the argument this
     // file makes for `removeUserHubSource`: id-addressing is safe only while a source
     // row cannot change hubs, and that is not a property anything enforces.
     await dbWrite.userHubSource.updateMany({
       where: { id: existing.id, hub: { userId } },
-      data: { enabled: true },
+      data: { enabled: true, exclude: source.exclude },
     });
     return { hubId, added: true };
   }
 
-  if (hub.sources.length >= hubLimits.sourcesPerHub)
+  const held = hub.sources.filter((s) => s.exclude === source.exclude).length;
+  if (source.exclude) {
+    if (held >= hubLimits.exclusionsPerHub)
+      throw throwBadRequestError(`A hub can exclude at most ${hubLimits.exclusionsPerHub} sources`);
+  } else if (held >= hubLimits.sourcesPerHub)
     throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
 
-  await assertHubSourcesUsable({ sources: [{ ...source, enabled: true, index: 0 }], userId });
+  await assertHubSourcesUsable({
+    sources: [{ ...source, enabled: true, index: 0 }],
+    userId,
+  });
 
   try {
     await dbWrite.userHubSource.create({
@@ -429,6 +461,7 @@ export async function addUserHubSource({
         type: source.type,
         targetId: source.targetId,
         alias: source.alias ?? null,
+        exclude: source.exclude,
         index: hub.sources.reduce((max, s) => Math.max(max, s.index + 1), 0),
       },
     });
@@ -570,10 +603,22 @@ export type ResolvedHubSources = {
   userIds: number[];
   modelVersionIds: number[];
   collectionIds: number[];
+  /**
+   * Image tags. Unlike a Model source these need no expansion and no budget: the
+   * ids ARE what the index is filtered on.
+   */
+  tagIds: number[];
   /** True when a Model source expanded past the id cap and was trimmed. */
   truncated: boolean;
   /** The hub's stored browsing-level cap. 0 means the hub imposes none. */
   forcedBrowsingLevel: number;
+  /**
+   * What the hub refuses. Never truncated, unlike the positive sets above: a
+   * trimmed inclusion shows less than the owner asked for, where a trimmed
+   * exclusion shows content they said to keep out. `exclusionsPerHub` is what
+   * bounds this instead.
+   */
+  excluded: { userIds: number[]; modelVersionIds: number[]; tagIds: number[] };
 };
 
 // Resolves a hub to the id sets its feed filter is built from. Returns null when
@@ -593,7 +638,10 @@ export async function resolveHubSources({
     where: { id: hubId, ...hubViewerWhere({ userId, isModerator }) },
     select: {
       forcedBrowsingLevel: true,
-      sources: { where: { enabled: true }, select: { type: true, targetId: true } },
+      sources: {
+        where: { enabled: true },
+        select: { type: true, targetId: true, exclude: true },
+      },
     },
   });
   if (!hub) return null;
@@ -603,13 +651,20 @@ export async function resolveHubSources({
   // than in the filter builders because this is the one place the id sets exist,
   // and because subtracting can only ever NARROW the feed: a forged exclusion
   // removes content from the forger, and can add none.
-  const excluded = new Set((excludedSources ?? []).map(hubSourceKey));
-  const sources = excluded.size
-    ? hub.sources.filter((s) => !excluded.has(hubSourceKey(s)))
-    : hub.sources;
+  //
+  // 🔴 Applied to the POSITIVE sources only. A session toggle reaching the negative
+  // ones would let a viewer switch off somebody else's exclusion, which is the one
+  // direction this list must never be able to move the feed: forging it would ADD
+  // content the owner refused, where forging a positive toggle only removes their
+  // own.
+  const sessionExcluded = new Set((excludedSources ?? []).map(hubSourceKey));
+  const negativeSources = hub.sources.filter((s) => s.exclude);
+  const positiveSources = hub.sources
+    .filter((s) => !s.exclude)
+    .filter((s) => !sessionExcluded.size || !sessionExcluded.has(hubSourceKey(s)));
 
   const byType = (type: UserHubSourceType) =>
-    sources.filter((s) => s.type === type).map((s) => s.targetId);
+    positiveSources.filter((s) => s.type === type).map((s) => s.targetId);
 
   const modelIds = byType(UserHubSourceType.Model);
   const explicitVersionIds = byType(UserHubSourceType.ModelVersion);
@@ -657,7 +712,44 @@ export async function resolveHubSources({
     modelVersionIds,
     truncated,
     collectionIds: byType(UserHubSourceType.Collection),
+    tagIds: byType(UserHubSourceType.Tag),
     forcedBrowsingLevel: hub.forcedBrowsingLevel,
+    excluded: await resolveExcludedSources(negativeSources),
+  };
+}
+
+/**
+ * The id sets a hub's negative sources become. An excluded Model expands to ALL of
+ * its versions — no per-model budget and no trimming, unlike the positive path,
+ * because a trimmed exclusion is a permissive failure: the content the owner said
+ * to keep out comes back, and nothing anywhere reports it.
+ *
+ * What makes that affordable is `hubLimits.exclusionsPerHub` plus the shape of the
+ * data: measured on the prod replica, 942,241 models at a p99 of 5 versions and 180
+ * at the very worst one, so 20 exclusions is ~100 ids in practice and 3,600 at a
+ * ceiling no real hub reaches.
+ */
+async function resolveExcludedSources(
+  sources: { type: UserHubSourceType; targetId: number }[]
+): Promise<ResolvedHubSources['excluded']> {
+  const byType = (type: UserHubSourceType) =>
+    sources.filter((s) => s.type === type).map((s) => s.targetId);
+
+  const modelIds = byType(UserHubSourceType.Model);
+  const versionIds = byType(UserHubSourceType.ModelVersion);
+
+  if (modelIds.length) {
+    const rows = await dbRead.modelVersion.findMany({
+      where: { modelId: { in: modelIds } },
+      select: { id: true },
+    });
+    versionIds.push(...rows.map((row) => row.id));
+  }
+
+  return {
+    userIds: byType(UserHubSourceType.User),
+    modelVersionIds: [...new Set(versionIds)],
+    tagIds: byType(UserHubSourceType.Tag),
   };
 }
 
@@ -680,7 +772,10 @@ export function hubBrowsingLevel(browsingLevel: number | undefined, sources: Res
 
 export function hubSourcesAreEmpty(sources: ResolvedHubSources) {
   return (
-    !sources.userIds.length && !sources.modelVersionIds.length && !sources.collectionIds.length
+    !sources.userIds.length &&
+    !sources.modelVersionIds.length &&
+    !sources.collectionIds.length &&
+    !sources.tagIds.length
   );
 }
 
@@ -695,6 +790,8 @@ async function assertHubSourcesUsable({
   sources: UserHubSourceInput[];
   userId: number;
 }) {
+  await assertHubTagsUsable(sources);
+
   const collectionIds = sources
     .filter((s) => s.type === UserHubSourceType.Collection)
     .map((s) => s.targetId);
@@ -737,6 +834,46 @@ async function assertHubSourcesUsable({
       throw throwBadRequestError(
         `"${collection.name}" limits the content ratings it shows, which a hub cannot honour. It cannot be used as a hub source.`
       );
+  }
+}
+
+/**
+ * Which tags a hub may be keyed on, in either direction. The tag table is not a
+ * vocabulary of subjects — it also carries the moderation labels the scanners write
+ * and the system tags the site runs on, and a hub addressed by id would otherwise
+ * reach every one of them.
+ *
+ * Applied to exclusions as well as sources. Excluding a moderation label is a
+ * reasonable thing to WANT, but the browsing level is the control that already does
+ * it and the one the server actually enforces; letting a second, unenforced spelling
+ * of the same intent exist would leave a user believing they had set something they
+ * had not.
+ */
+async function assertHubTagsUsable(sources: UserHubSourceInput[]) {
+  const tagIds = sources
+    .filter((source) => source.type === UserHubSourceType.Tag)
+    .map((source) => source.targetId);
+  if (!tagIds.length) return;
+
+  const tags = await dbRead.tag.findMany({
+    where: { id: { in: tagIds } },
+    select: { id: true, name: true, type: true, target: true, unlisted: true, adminOnly: true },
+  });
+
+  for (const id of tagIds) {
+    const tag = tags.find((t) => t.id === id);
+    // A tag that fails the rule is a not-found rather than a refusal naming it: this
+    // is an id-addressed lookup over a dense id space, so an error that distinguishes
+    // "no such tag" from "that one is a moderation label" enumerates the moderation
+    // vocabulary for anyone willing to count.
+    if (
+      !tag ||
+      tag.unlisted ||
+      tag.adminOnly ||
+      !tag.target.includes(TagTarget.Image) ||
+      (tag.type !== TagType.UserGenerated && tag.type !== TagType.Label)
+    )
+      throw throwNotFoundError(`Tag ${id} not found`);
   }
 }
 

--- a/src/server/services/user-hub.service.ts
+++ b/src/server/services/user-hub.service.ts
@@ -14,6 +14,7 @@ import type {
 } from '~/server/schema/user-hub.schema';
 import {
   HUB_COLLECTION_SOURCES_ENABLED,
+  HUB_TAG_SOURCE_FILTER,
   hubFeedFiltersSchema,
   hubLimits,
   hubSourceKey,
@@ -39,6 +40,7 @@ import {
 } from '~/shared/utils/prisma/enums';
 import { ImageSort, NsfwLevel } from '~/server/common/enums';
 import { getUserCollectionPermissionsByIds } from '~/server/services/collection.service';
+import { getReplacedTagIds } from '~/server/services/system-cache';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import type { CollectionMetadataSchema } from '~/server/schema/collection.schema';
 import { getAllServerHosts } from '~/server/utils/server-domain';
@@ -183,6 +185,11 @@ function toHubDetail<T extends HubRow>({ metadata, ...hub }: T, viewerId?: numbe
     sources: isOwner
       ? hub.sources
       : hub.sources.filter((source) => source.enabled && !source.exclude),
+    // The count without the identities. A viewer who is shown nothing cannot tell a
+    // hub that filters from one that does not — and "Duplicate this hub" copies only
+    // what the payload carries, so a copy silently serves content the original
+    // refuses. A bare number says the feed is narrowed without naming anyone.
+    excludedCount: hub.sources.filter((source) => source.enabled && source.exclude).length,
     description: readDescription(metadata),
     // Re-validated on the way out: what is on the row was written by an older
     // shape of this schema, and the feed refuses some combinations outright.
@@ -265,10 +272,15 @@ export async function getHubCardData(id: number) {
       name: true,
       metadata: true,
       user: { select: { username: true } },
-      // Enabled only, because that is the number a visitor can see: `toHubDetail`
-      // strips disabled sources for everyone but the owner, so counting all of them
-      // advertises a hub as larger than the page it opens.
-      _count: { select: { sources: { where: { enabled: true } }, followers: true } },
+      // Enabled and POSITIVE only, because that is the number a visitor can see:
+      // `toHubDetail` strips disabled sources — and every exclusion — for everyone but
+      // the owner. Counting all of them advertises a hub as larger than the page it
+      // opens, and counting the exclusions publishes by subtraction the one number the
+      // owner's keep-out list is withheld to keep private. This card answers
+      // unauthenticated, at /api/og?type=hub.
+      _count: {
+        select: { sources: { where: { enabled: true, exclude: false } }, followers: true },
+      },
     },
   });
   if (!hub) return null;
@@ -307,6 +319,7 @@ export async function upsertUserHub({
 
     assertSourceCounts(sources);
     await assertHubSourcesUsable({ sources, userId });
+    await assertExcludedModelsFit(excludedModelIds(sources));
   }
 
   if (!id) {
@@ -398,6 +411,10 @@ export async function upsertUserHub({
   return toHubDetail(updated, userId);
 }
 
+const excludedModelIds = (
+  sources: { type: UserHubSourceType; targetId: number; exclude?: boolean }[]
+) => sources.filter((s) => s.exclude && s.type === UserHubSourceType.Model).map((s) => s.targetId);
+
 // Each kind against its own cap. Counted here rather than on the zod array, which
 // sees one list and cannot say which half overran it.
 function assertSourceCounts(sources: UserHubSourceInput[]) {
@@ -406,6 +423,42 @@ function assertSourceCounts(sources: UserHubSourceInput[]) {
     throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
   if (excluded > hubLimits.exclusionsPerHub)
     throw throwBadRequestError(`A hub can exclude at most ${hubLimits.exclusionsPerHub} sources`);
+}
+
+/**
+ * Everything one added-or-flipped source has to satisfy: the cap on the side it lands
+ * on, the rules for what may be a source at all, and the excluded-model expansion
+ * budget over the set the hub would hold afterwards.
+ *
+ * `ignoreId` is the row being flipped — it is leaving the other side, so counting it
+ * against the destination would charge the hub twice for one target.
+ */
+async function assertHubSourceFits({
+  hub,
+  source,
+  userId,
+  ignoreId,
+}: {
+  hub: { sources: { id: number; type: UserHubSourceType; targetId: number; exclude: boolean }[] };
+  source: { type: UserHubSourceType; targetId: number; exclude: boolean; alias?: string | null };
+  userId: number;
+  ignoreId?: number;
+}) {
+  const held = hub.sources.filter((s) => s.exclude === source.exclude && s.id !== ignoreId).length;
+  if (source.exclude) {
+    if (held >= hubLimits.exclusionsPerHub)
+      throw throwBadRequestError(`A hub can exclude at most ${hubLimits.exclusionsPerHub} sources`);
+  } else if (held >= hubLimits.sourcesPerHub)
+    throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
+
+  await assertHubSourcesUsable({
+    sources: [{ ...source, enabled: true, index: 0 }],
+    userId,
+  });
+
+  await assertExcludedModelsFit(
+    excludedModelIds([...hub.sources.filter((s) => s.id !== ignoreId), source])
+  );
 }
 
 export async function addUserHubSource({
@@ -440,6 +493,14 @@ export async function addUserHubSource({
     // something the hub collects flips it rather than failing.
     if (existing.enabled && existing.exclude === source.exclude) return { hubId, added: false };
 
+    // 🔴 A flip crosses between the two lists, so it faces the DESTINATION's checks —
+    // its cap, and the same usability rules a create gets. Returning here without them
+    // made this branch a door around both: fifty sources flipped one at a time put
+    // fifty exclusions on a hub whose stated limit is twenty, and since flipping also
+    // empties the positive side, the cycle repeated without bound. That matters beyond
+    // the number, because the exclusion expansion deliberately never truncates.
+    await assertHubSourceFits({ hub, source, userId, ignoreId: existing.id });
+
     // Owner-scoped on the write as well as in the read above, per the argument this
     // file makes for `removeUserHubSource`: id-addressing is safe only while a source
     // row cannot change hubs, and that is not a property anything enforces.
@@ -450,17 +511,7 @@ export async function addUserHubSource({
     return { hubId, added: true };
   }
 
-  const held = hub.sources.filter((s) => s.exclude === source.exclude).length;
-  if (source.exclude) {
-    if (held >= hubLimits.exclusionsPerHub)
-      throw throwBadRequestError(`A hub can exclude at most ${hubLimits.exclusionsPerHub} sources`);
-  } else if (held >= hubLimits.sourcesPerHub)
-    throw throwBadRequestError(`A hub can hold at most ${hubLimits.sourcesPerHub} sources`);
-
-  await assertHubSourcesUsable({
-    sources: [{ ...source, enabled: true, index: 0 }],
-    userId,
-  });
+  await assertHubSourceFits({ hub, source, userId });
 
   try {
     await dbWrite.userHubSource.create({
@@ -687,6 +738,11 @@ export async function resolveHubSources({
   // reads enabled in the rail.
   const perModel = modelIds.length ? Math.max(1, Math.floor(budget / modelIds.length)) : 0;
 
+  // Started before the positive expansion below rather than awaited after it: both
+  // are independent reads on the same hot path, and a hub carrying a Model source on
+  // each side would otherwise pay for them end to end before the first Meili call.
+  const excludedPromise = resolveExcludedSources(negativeSources);
+
   let truncated = false;
   const versionIdsOfModels: number[] = [];
   if (modelIds.length && perModel > 0) {
@@ -711,6 +767,7 @@ export async function resolveHubSources({
     truncated = true;
   }
 
+  const excluded = await excludedPromise;
   const allVersionIds = [...new Set([...explicitVersionIds, ...versionIdsOfModels])];
   const modelVersionIds = allVersionIds.slice(0, hubLimits.resolvedVersionIds);
   if (allVersionIds.length > modelVersionIds.length) truncated = true;
@@ -722,7 +779,7 @@ export async function resolveHubSources({
     collectionIds: byType(UserHubSourceType.Collection),
     tagIds: byType(UserHubSourceType.Tag),
     forcedBrowsingLevel: hub.forcedBrowsingLevel,
-    excluded: await resolveExcludedSources(negativeSources),
+    excluded,
   };
 }
 
@@ -732,10 +789,10 @@ export async function resolveHubSources({
  * because a trimmed exclusion is a permissive failure: the content the owner said
  * to keep out comes back, and nothing anywhere reports it.
  *
- * What makes that affordable is `hubLimits.exclusionsPerHub` plus the shape of the
- * data: measured on the prod replica, 942,241 models at a p99 of 5 versions and 180
- * at the very worst one, so 20 exclusions is ~100 ids in practice and 3,600 at a
- * ceiling no real hub reaches.
+ * What keeps it affordable is `assertExcludedModelsFit`, which refuses the ADD when
+ * a hub's excluded models would expand past `hubLimits.excludedVersionIds`. The cap
+ * on source COUNT does not bound this on its own — the expansion factor is a
+ * property of the data, not of the code.
  */
 async function resolveExcludedSources(
   sources: { type: UserHubSourceType; targetId: number }[]
@@ -778,15 +835,6 @@ export function hubBrowsingLevel(browsingLevel: number | undefined, sources: Res
   return (browsingLevel || NsfwLevel.PG) & sources.forcedBrowsingLevel;
 }
 
-export function hubSourcesAreEmpty(sources: ResolvedHubSources) {
-  return (
-    !sources.userIds.length &&
-    !sources.modelVersionIds.length &&
-    !sources.collectionIds.length &&
-    !sources.tagIds.length
-  );
-}
-
 // Collection sources are served by the indexed `collectionIds` field, which only
 // carries ACCEPTED membership of non-private collections. A collection the index
 // cannot represent must be refused at add time rather than silently contributing
@@ -799,6 +847,14 @@ async function assertHubSourcesUsable({
   userId: number;
 }) {
   await assertHubTagsUsable(sources);
+
+  // A Collection cannot be a NEGATIVE source: `resolveExcludedSources` has no
+  // collection arm, so the row would store, read as an exclusion in the editor, and
+  // filter nothing. Refused rather than quietly ignored, and refused ahead of the
+  // feature flag below so that flipping the flag on does not turn this into the
+  // silent case — whoever flips it will be exercising the positive path.
+  if (sources.some((s) => s.type === UserHubSourceType.Collection && s.exclude))
+    throw throwBadRequestError('A collection cannot be excluded from a hub.');
 
   const collectionIds = sources
     .filter((s) => s.type === UserHubSourceType.Collection)
@@ -846,6 +902,40 @@ async function assertHubSourcesUsable({
 }
 
 /**
+ * Whether a hub's excluded models still fit the filter the feed has to build.
+ *
+ * Checked HERE, at the write, because the read cannot fix it: trimming the expansion
+ * is the permissive failure this whole path is shaped to avoid, so the only honest
+ * options are refusing the add or serving a filter that grows without bound. The
+ * caller passes the ids the hub would hold AFTER the write, so it also covers a
+ * source flipped from collected to excluded.
+ */
+async function assertExcludedModelsFit(modelIds: number[]) {
+  if (!modelIds.length) return;
+
+  const versions = await dbRead.modelVersion.findMany({
+    where: { modelId: { in: modelIds } },
+    select: { modelId: true },
+  });
+  if (versions.length <= hubLimits.excludedVersionIds) return;
+
+  // Names the model that costs the most, because "you have excluded too much" is not
+  // something a user can act on without knowing which one to drop.
+  const perModel = new Map<number, number>();
+  for (const { modelId } of versions) perModel.set(modelId, (perModel.get(modelId) ?? 0) + 1);
+  const [worst] = [...perModel.entries()].sort((a, b) => b[1] - a[1]);
+  const model = await dbRead.model.findFirst({
+    where: { id: worst[0] },
+    select: { name: true },
+  });
+
+  throw throwBadRequestError(
+    `Excluding these models covers ${versions.length} versions, more than a hub can filter on (${hubLimits.excludedVersionIds}). ` +
+      `"${model?.name ?? worst[0]}" alone accounts for ${worst[1]}.`
+  );
+}
+
+/**
  * Which tags a hub may be keyed on, in either direction. The tag table is not a
  * vocabulary of subjects — it also carries the moderation labels the scanners write
  * and the system tags the site runs on, and a hub addressed by id would otherwise
@@ -863,13 +953,21 @@ async function assertHubTagsUsable(sources: UserHubSourceInput[]) {
     .map((source) => source.targetId);
   if (!tagIds.length) return;
 
-  const tags = await dbRead.tag.findMany({
-    where: { id: { in: tagIds } },
-    select: { id: true, name: true, type: true, target: true, unlisted: true, adminOnly: true },
-  });
+  const [tags, replacedTagIds] = await Promise.all([
+    dbRead.tag.findMany({
+      where: { id: { in: tagIds } },
+      select: { id: true, name: true, type: true, target: true, unlisted: true, adminOnly: true },
+    }),
+    // A replaced tag still exists and still reads as browsable, but the index carries
+    // its REPLACEMENT's id — so as a source it matches nothing, and as an exclusion it
+    // keeps nothing out, which is the permissive direction. `getTags` drops these, so
+    // the picker never offers one; the URL input and the raw API reach here without it.
+    getReplacedTagIds(),
+  ]);
+  const replaced = new Set(replacedTagIds);
 
   for (const id of tagIds) {
-    const tag = tags.find((t) => t.id === id);
+    const tag = replaced.has(id) ? undefined : tags.find((t) => t.id === id);
     // A tag that fails the rule is a not-found rather than a refusal naming it: this
     // is an id-addressed lookup over a dense id space, so an error that distinguishes
     // "no such tag" from "that one is a moderation label" enumerates the moderation
@@ -878,8 +976,8 @@ async function assertHubTagsUsable(sources: UserHubSourceInput[]) {
       !tag ||
       tag.unlisted ||
       tag.adminOnly ||
-      !tag.target.includes(TagTarget.Image) ||
-      (tag.type !== TagType.UserGenerated && tag.type !== TagType.Label)
+      !HUB_TAG_SOURCE_FILTER.entityType.every((target) => tag.target.includes(target)) ||
+      !HUB_TAG_SOURCE_FILTER.types.some((type) => tag.type === type)
     )
       throw throwNotFoundError(`Tag ${id} not found`);
   }

--- a/src/utils/civitai-url.test.ts
+++ b/src/utils/civitai-url.test.ts
@@ -163,11 +163,41 @@ describe('parseCivitaiUrlSafe', () => {
     });
   });
 
+  it('reads the SAME tag param on every feed that emits it', () => {
+    // The tag chip row is mounted on /images and /videos and writes the param on
+    // whichever route the user is on, so a link the site produced for one feed
+    // must not be refused because it came from the other. /posts is the same shape.
+    for (const feed of ['images', 'videos', 'posts']) {
+      expect(parseCivitaiUrlSafe(`https://civitai.com/${feed}?tags=5499`)).toEqual({
+        type: 'tagId',
+        tagId: 5499,
+      });
+    }
+  });
+
+  it('does not read a tag off an image DETAIL link', () => {
+    // /images/<id> is one image, not a feed. Without the segment check, a detail
+    // link that happened to carry the feed's query would add a tag source the
+    // sender never picked. Nothing pushes that URL with a query today, which is
+    // exactly why the check has to be here rather than relied upon there.
+    expect(parseCivitaiUrlSafe('https://civitai.com/images/12345?tags=5499')).toBeNull();
+  });
+
   it('refuses a feed link carrying more than one tag', () => {
     // 🔴 The dangerous direction: a hub source is ONE tag, so picking the first of
     // several would silently discard what the sender meant and add a source they
     // did not choose. Unrecognised is the honest answer.
     expect(parseCivitaiUrlSafe('https://civitai.com/images?tags=5499&tags=5133')).toBeNull();
+  });
+
+  it('refuses every OTHER encoding of more than one tag', () => {
+    // The repeated-param form above is what `qs` emits today, but the app's own
+    // reader also accepts a JSON array, so both are URLs a user can hold. These
+    // are refused only as a side effect of the strict integer test — relax that to
+    // `parseInt` and `?tags=5499,5133` silently becomes tag 5499, which is the
+    // take-the-first hazard back through the encoding nothing covered.
+    expect(parseCivitaiUrlSafe('https://civitai.com/images?tags=5499,5133')).toBeNull();
+    expect(parseCivitaiUrlSafe('https://civitai.com/images?tags=[5499,5133]')).toBeNull();
   });
 
   it('refuses a feed link with no tag at all', () => {

--- a/src/utils/civitai-url.test.ts
+++ b/src/utils/civitai-url.test.ts
@@ -140,6 +140,43 @@ describe('parseCivitaiUrlSafe', () => {
     expect(parseCivitaiUrlSafe('https://image.civitai.com/models/123')).toBeNull();
   });
 
+  it('reads a tag page as a NAME, not an id', () => {
+    // /tag/<name> is what the address bar holds. The name is what identifies it;
+    // there is no id in this URL to fall back on.
+    expect(parseCivitaiUrlSafe('https://civitai.com/tag/dragon')).toEqual({
+      type: 'tag',
+      tagname: 'dragon',
+    });
+    // Percent-escapes are decoded with the rest of the path, so a multi-word tag
+    // arrives as the name the database holds rather than as 'blue%20hair'.
+    expect(parseCivitaiUrlSafe('https://civitai.com/tag/blue%20hair')).toEqual({
+      type: 'tag',
+      tagname: 'blue hair',
+    });
+  });
+
+  it('reads a single-tag feed link as an ID', () => {
+    // What a tag chip in the feed links to.
+    expect(parseCivitaiUrlSafe('https://civitai.com/images?tags=5499')).toEqual({
+      type: 'tagId',
+      tagId: 5499,
+    });
+  });
+
+  it('refuses a feed link carrying more than one tag', () => {
+    // 🔴 The dangerous direction: a hub source is ONE tag, so picking the first of
+    // several would silently discard what the sender meant and add a source they
+    // did not choose. Unrecognised is the honest answer.
+    expect(parseCivitaiUrlSafe('https://civitai.com/images?tags=5499&tags=5133')).toBeNull();
+  });
+
+  it('refuses a feed link with no tag at all', () => {
+    // The control for the two above: without it, a parser that returned a tag ref
+    // for any /images link would pass them both.
+    expect(parseCivitaiUrlSafe('https://civitai.com/images')).toBeNull();
+    expect(parseCivitaiUrlSafe('https://civitai.com/images?tags=notanid')).toBeNull();
+  });
+
   it('returns null for a bare id so the caller decides what it means', () => {
     expect(parseCivitaiUrlSafe('123')).toBeNull();
     expect(parseCivitaiUrlSafe('')).toBeNull();

--- a/src/utils/civitai-url.ts
+++ b/src/utils/civitai-url.ts
@@ -2,7 +2,13 @@ export type CivitaiEntityRef =
   | { type: 'user'; username: string }
   | { type: 'model'; modelId: number; modelVersionId?: number }
   | { type: 'modelVersion'; modelVersionId: number }
-  | { type: 'collection'; collectionId: number };
+  | { type: 'collection'; collectionId: number }
+  // Two members rather than one with both fields optional, because the two links
+  // carry genuinely different things: /tag/<name> is what the address bar holds,
+  // and ?tags=<id> is what a tag chip in a feed links to. A consumer has to look
+  // one up by name and the other by id, so the type says which it got.
+  | { type: 'tag'; tagname: string }
+  | { type: 'tagId'; tagId: number };
 
 // Hosts we recognise without being told. The domain env vars are optional, so a
 // bare dev environment supplies no runtime host list and this backstop is what
@@ -95,6 +101,21 @@ export function parseCivitaiUrlSafe(
   if (head === 'collections') {
     const collectionId = toInt(second);
     return collectionId ? { type: 'collection', collectionId } : null;
+  }
+
+  if (head === 'tag') {
+    const tagname = second?.trim();
+    return tagname ? { type: 'tag', tagname } : null;
+  }
+
+  // A feed link carrying exactly ONE tag. Two or more is a filter, not an
+  // identity, and picking the first would silently drop what the sender meant —
+  // so it stays unrecognised rather than becoming an arbitrary one of them.
+  if (head === 'images') {
+    const tags = url.searchParams.getAll('tags');
+    if (tags.length !== 1) return null;
+    const tagId = toInt(tags[0]);
+    return tagId ? { type: 'tagId', tagId } : null;
   }
 
   if (head === 'user') {

--- a/src/utils/civitai-url.ts
+++ b/src/utils/civitai-url.ts
@@ -111,7 +111,17 @@ export function parseCivitaiUrlSafe(
   // A feed link carrying exactly ONE tag. Two or more is a filter, not an
   // identity, and picking the first would silently drop what the sender meant —
   // so it stays unrecognised rather than becoming an arbitrary one of them.
-  if (head === 'images') {
+  //
+  // All three feeds, because `ImageFeedTagBar` is mounted on /images AND /videos and
+  // writes the same param on whichever route the user is on — a tag chip clicked on
+  // /videos produced a link this refused while the identical id worked from /images.
+  // /posts carries the same param shape.
+  //
+  // `!second` matters: /images/<imageId> is the image detail route, and without the
+  // check a detail link that happened to carry the feed's query would resolve to a
+  // TAG the sender never picked. Nothing pushes that URL with a query today, which
+  // is the kind of thing that changes without anyone thinking about this file.
+  if (!second && (head === 'images' || head === 'videos' || head === 'posts')) {
     const tags = url.searchParams.getAll('tags');
     if (tags.length !== 1) return null;
     const tagId = toInt(tags[0]);


### PR DESCRIPTION
Two halves of ClickUp [868m150gf](https://app.clickup.com/t/868m150gf) — hubs get **negative sources** (keep content out) and **tags** as a fourth source type.

## The near-miss, first — worth more than the diff

An exclusion mechanism looks like it already exists. `hubSourceExclusionSchema`, `hubExcludedSources`, `hub-session.store.ts` and `UserHubSource.enabled` all grep as "hubs can exclude things". None of them is this:

- `hubExcludedSources` / `hub-session.store` is a **viewer's per-session toggle of somebody else's positive sources**. It is deliberately not persisted, and it can only narrow the feed in front of the person who sent it.
- `enabled` is the **owner switching a positive source off**. Also not a negative source.

A grep-and-stop audit closes this ticket as already shipped, and nothing downstream catches it. Both of those subtract from what a hub *collects*; neither can express "collect from these creators, but never show me this tag."

## Half A — tags as a source

`tagIds` has been a live filterable attribute on the metrics-images index since 2024, and the ids are denormalised onto the image documents at index time. Verified against the prod index rather than read off the code:

| probe | result |
| --- | --- |
| `tagIds IN [111757]` | 2,987 hits |
| `tagIds IN [99999999]` | 0 hits (negative control — the probe can return zero) |
| `collectionIds IN [1]` | Meili **rejects the whole query**: "Attribute `collectionIds` is not filterable" |

So a tag source is one more arm in the OR group the hub filter already builds — no expansion, no budget, no extra round trip. It is the *simplest* of the source types; a Model source, by contrast, pays a ranked ModelVersion query under a 750-id budget.

That third row is also why **collections remain out of scope** and are not touched here: they are blocked on an index reset plus the Postgres/Meili merge decision in #868kv1rxd. Tags share none of that. All five collection gates are still shut.

Tag sources are restricted at add time to **listed, non-replaced, non-admin-only, Image-targeted, UserGenerated/Label** tags. The tag table also carries the moderation labels the scanners write and the system tags the site runs on, and a hub source is an id — without the guard a hub can be keyed on any of them. Every failure is a not-found rather than a specific refusal, so the error cannot be used to enumerate which ids are moderation labels.

Moderation labels stay out **in both directions** — Justin's call. Excluding one is a reasonable thing to want, but the browsing level is the control that already enforces it, and a second weaker spelling would leave a user believing they had set something stronger than they had.

The picker and the server share one `HUB_TAG_SOURCE_FILTER` constant, so a picker offering what the server 404s is not reachable.

## Half B — negative sources

`UserHubSource.exclude` splits the existing rows into a collect list and a keep-out list. One target is either collected or refused — the existing `@@unique([hubId, type, targetId])` is what makes them mutually exclusive, and adding a source on the other side flips it rather than failing.

In the feed, the keep-out group is ANDed on as a `NOT (...)` against everything else, in **both** Meili builders:

```
(<source OR-group>) AND NOT (<keep-out OR-group>)
```

Four decisions worth reading:

- **The session toggle never reaches a negative source.** `hubExcludedSources` is viewer-supplied. Applied to positive sources it can only remove content from the person who sent it. Applied to a negative source it would *add* content the owner refused, to anyone who can post a feed query.
- **Exclusions are never truncated at read time.** An excluded Model expands to *all* its versions with no per-model budget — unlike the positive path, which trims. A trimmed inclusion shows less than the owner asked for; a trimmed exclusion serves back content they said to keep out, silently. The bound sits at the **write** instead: `assertExcludedModelsFit` refuses the add and names the model responsible.
- **The three resource arms are emitted unconditionally**, where the positive builder gates two of them on `hideAutoResources` / `hideManualResources`. Those gates say which attributions the viewer wants to be collected by; they do not say the viewer will accept a refused model arriving under a different attribution.
- **A hub's exclusions are withheld from everyone but its owner.** A positive source says "I like this creator"; a negative one names a creator its owner refuses, on a URL anyone can open. Viewers get an anonymous count instead — enough to know the feed is filtered, and to be told that duplicating the hub will not carry them.

Exclusions have their own cap (20), counted separately from the 50 sources.

## Migrations — hand-applied, both APPLIED to dev and prod

```sql
ALTER TABLE "UserHubSource" ADD COLUMN "exclude" BOOLEAN NOT NULL DEFAULT false;
ALTER TYPE "UserHubSourceType" ADD VALUE 'Tag';
```

**Both were applied by hand on 2026-09-04, on Justin's instruction — dev first, then prod.** Verified against a before-picture in each: prod went from 4 enum labels to 5 with `Tag` appended, and `pg_attribute` for `exclude` from 0 to 1 (that read rather than `information_schema`, which hides columns you lack privileges on and so cannot prove absence). Target confirmed from the connection itself — 1,185 `UserHub` rows on prod against 653 on dev.

That ordering was the safe one and is now closed: **the column had to exist before the client that selects it ships**, or every read of that model throws. The enum value was inert either way, since nothing deployed can write `'Tag'`. Applying them while this PR was still open was therefore the right window rather than a risk — and applying them is **not** authorisation to merge.

## What the review found

Five lanes ran over this (reuse, correctness, perf, tests, intent). They found eleven things, all fixed in `ad29ef3b`. The three worth naming:

**The cap was bypassable without bound.** `addUserHubSource`'s existing-row branch flipped `exclude` and returned *before* the cap block. Fifty sources flipped one at a time put fifty exclusions on a hub whose limit is twenty — and flipping empties the positive side, so the cycle repeated indefinitely. That defeated the premise the never-truncated expansion rests on.

**The filter it fed was over the deadline.** Measured cold on the prod index by the perf lane: the exclusion path could carry 6,192 filter ids across three arms (45.6KB) against the positive cap's 2,250 (18KB), for a combined 63,670-byte filter — larger than the 53KB shape that previously produced a 502 — at **5,690ms wall, past the 5s deadline**. Two corrections to what I had written: `NOT` is *not* more expensive than `IN` at equal cardinality (1,481ms vs 1,349ms cold), so negation was never the mechanism; and my stated ceiling of 3,600 was wrong twice — the real maximum is 2,064 (twenty *distinct* worst models), and nothing in code bounded it at all.

**One click deleted an exclusion.** `AddToHubModal` rendered an excluded target as an *unticked* box, and ticking it flipped the row back to a positive source — from a modal that never showed the exclusion existed. Found independently by two lanes.

Also fixed: the unauthenticated OG card counted exclusions in `sourceCount`; an excluded Collection stored and filtered nothing; a replaced tag passed every clause while matching nothing in the index; the two expansions ran end to end rather than in parallel; and adding a target the hub already held on the other side did nothing silently.

## Verification

- `pnpm run typecheck` — clean. `pnpm run db:check-generated` — exit 0.
- `pnpm run lint` — the diff adds nothing. `image.service.ts` reports 16 problems / 3 errors both with my changes and with the pristine `origin/main` copy of the file, run side by side; the other changed files are clean.
- `pnpm run test:unit:run --max-workers=4` — `Test Files 1 failed | 1621 passed | 3 skipped (1625)`, `Tests 1 failed | 37902 passed | 35 skipped (37938)`. Both lines sum to their collected totals and there were no worker errors, which matters today: an earlier run on this box dropped six files to dead worker forks and reported 1619 of 1625, so it was re-queued rather than read. The single failure is `appListingMenuSurface.test.ts`, pre-existing on Windows (`components\Apps\…` vs `components/Apps/…`), reproduced on clean `main` at 885e3a621f before attributing it. `blocks.router.workflow.test.ts` collected 370 tests, so the submodule-dependent suite really ran.
- **Ten mutants driven red**, each naming the test that caught it — including four the tests could *not* catch before review: an empty `NOT ()` group (prod Meili answers that with a 400, so every hub feed excluding nothing would have failed), a `take` on the untruncated expansion, a dropped `enabled` conjunct, and a duplicate that loses exclusions.

## Round two: tag links, and what a second review found

Justin tested the branch on a dev server and asked for three things — drop the Collections tab, say Include rather than Collect, and support pasting a tag link. All five lanes then ran again over that range alone.

**Pasting a tag link** works in two shapes: `/tag/<name>` resolves by name, `/images?tags=<id>` by id (and `/videos`, `/posts` — the tag chip row is mounted on more than one feed and writes the same param, so a link the site itself produced was being refused for coming from the wrong one). A feed link carrying more than one tag stays unrecognised: a hub source is one tag, and taking the first would add a source the sender did not choose.

The tag vocabulary rule now lives in **one** `where` fragment. It was written twice, the paste path would have made three, and the picker was quietly a fourth — hand-typed literals identical to the constant whose own doc claimed the picker used it. That matters in one direction in particular: without the shared rule, a moderation label **resolves on paste and shows you its name** before the add refuses it, and refusing after showing the name is not refusing.

**The most valuable finding was against my own verification.** I had run a mutant dropping that rule from the resolver and recorded it as caught. The rule is spread into two arms of a ternary, and I had only exercised one: dropping it from the **id** arm turned nothing red — the feed-chip path, the paste most likely to carry a moderation-label id. Both arms now pin the whole `where`, which also catches a clause being *added* beside the rule rather than removed.

Also fixed from that round: `/images/<id>?tags=` would have read a tag off an image **detail** link (unreachable today only because nothing pushes that URL with a query); two user-facing strings still advertised collections, one of them the failure text of the paste feature itself, which also never mentioned tags; and the citext comment claimed more than it should — the plan depends on the **bind** being citext, not the column, and forced to `text` the same predicate is a 77ms parallel seq scan rather than a 0.04ms index scan.

Perf measured the new work and found nothing: the name lookup is an index scan at 0.04ms over 567,616 rows, the add-path query is plan- and I/O-identical to before, and `getReplacedTagIds` is a 55-row cached blob.

Ten further mutants driven red across the two rounds of this range, each naming the test that caught it.

## Known, not fixed here

The new Tags tab reaches `trpc.tag.getAll` with a query, which bypasses that endpoint's cache and plans a parallel seq scan over 567,521 `Tag` rows (~90ms, 72MB buffers, per keystroke). Pre-existing plan, new caller — every existing tag picker passing a query gets the same one. Worth a ticket against `getTags`, not a blocker here.

## One process note, recorded because it will outlive the channel it happened in

The CI watcher I first wrote to gate this merge had **no sleep in it**. It burned forty poll iterations in a few seconds and reported that it had given up — while CI had barely started. That reads exactly like a stalled pipeline.

The worse half: it only knew how to exit on **success**. A failed run would have looked identical to a still-running one right up until the timeout, because the only thing it could recognise was the happy path.

Both halves are the same mistake as the one this PR's review caught in my mutation testing, where a mutant recorded as caught had only exercised one of the two arms the rule lives in. **A check that can only recognise the outcome you are hoping for cannot fail, and a check that cannot fail is not evidence.** The replacement poller exits on `failure`, `timed_out` and `cancelled` as well as on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5UtUkMEi4s32MQZG36ajS
