### PR TITLE
fix(leaderboard): let mature boards earn a badge and be showcased

### DIFF
--- a/src/components/Modals/UserProfileEditModal.tsx
+++ b/src/components/Modals/UserProfileEditModal.tsx
@@ -47,7 +47,7 @@ import {
   creatorCardStats,
   creatorCardStatsDefaults,
 } from '~/server/common/constants';
-import { CosmeticType, DomainColor, LinkType } from '~/shared/utils/prisma/enums';
+import { CosmeticType, LinkType } from '~/shared/utils/prisma/enums';
 import * as z from 'zod';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
@@ -267,24 +267,18 @@ export default function UserProfileEditModal() {
     [user]
   );
 
-  // Mirrors the exclusion in `updateLeaderboardRank`: a RED-exclusive board's title
-  // would render sitewide, so it never earns a badge. Offering it here let people
-  // pick an option that could never take effect. A board already stored as this user's
-  // showcase stays listed regardless, so the Select doesn't render blank while still
-  // holding that value. That only reaches boards `getLeaderboards` returned at all —
-  // on a domain where the stored board isn't visible it was already blank before this.
-  const leaderboardOptions = useMemo(() => {
-    const current = user?.leaderboardShowcase;
-    return leaderboards
-      .filter((board) => board.public)
-      .filter(
-        (board) => board.id === current || board.domain.some((color) => color !== DomainColor.red)
-      )
-      .map(({ title, id }) => ({
-        label: titleCase(title),
-        value: id,
-      }));
-  }, [leaderboards, user?.leaderboardShowcase]);
+  // `getLeaderboards` is already domain-scoped, so this list is whatever is visible
+  // on the current host — no second filter on `domain` belongs here.
+  const leaderboardOptions = useMemo(
+    () =>
+      leaderboards
+        .filter((board) => board.public)
+        .map(({ title, id }) => ({
+          label: titleCase(title),
+          value: id,
+        })),
+    [leaderboards]
+  );
 
   const form = useForm({ schema, shouldUnregister: false });
 

--- a/src/server/services/__tests__/leaderboard-domain-visibility.test.ts
+++ b/src/server/services/__tests__/leaderboard-domain-visibility.test.ts
@@ -48,3 +48,43 @@ describe('domainVisibilityFilter', () => {
     }
   });
 });
+
+// The cases above exercise the pure function. These pin that `getLeaderboards` actually
+// CALLS it — the wiring, which nothing else covered. That matters more than it looks:
+// UserProfileEditModal's showcase picker deliberately carries no domain filter of its
+// own and relies entirely on this query being scoped, so if the `domain` key stops
+// reaching the `where`, .com starts listing mature boards in the picker and no other
+// test notices.
+describe('getLeaderboards applies the filter to the query', () => {
+  const whereOfLastCall = () => {
+    const calls = dbMock.dbRead.leaderboard.findMany.mock.calls;
+    if (!calls.length) throw new Error('getLeaderboards issued no findMany');
+    return (calls.at(-1)?.[0] as { where: Record<string, unknown> }).where;
+  };
+
+  it.each([
+    ['red host', DomainColor.red],
+    ['green host', DomainColor.green],
+    ['unresolved host', undefined],
+  ])('scopes the board list on a %s', async (_label, domain) => {
+    const { getLeaderboards, domainVisibilityFilter } = await import('../leaderboard.service');
+    dbMock.dbRead.leaderboard.findMany.mockResolvedValue([]);
+
+    await getLeaderboards({ domain, isModerator: false });
+
+    // Compared against the helper's own output rather than a literal, so the two
+    // cannot drift apart silently.
+    expect(whereOfLastCall().domain).toEqual(domainVisibilityFilter(domain));
+  });
+
+  it('still restricts non-moderators to public, active boards', async () => {
+    const { getLeaderboards } = await import('../leaderboard.service');
+    dbMock.dbRead.leaderboard.findMany.mockResolvedValue([]);
+
+    await getLeaderboards({ domain: DomainColor.red, isModerator: false });
+
+    const where = whereOfLastCall();
+    expect(where.public).toBe(true);
+    expect(where.active).toBe(true);
+  });
+});

--- a/src/server/services/__tests__/leaderboard-rank-showcase.test.ts
+++ b/src/server/services/__tests__/leaderboard-rank-showcase.test.ts
@@ -66,6 +66,62 @@ describe('leaderboard rank — showcase is a preference, not a filter', () => {
   });
 });
 
+describe('mature boards earn a badge on every domain', () => {
+  /**
+   * If you are here because you are about to re-add a domain filter: this was removed
+   * deliberately (Justin, 2026-09-04, ClickUp 868m1b61y), and the reasoning is not
+   * recoverable from the diff.
+   *
+   * The old `AND NOT (l.domain <@ ARRAY['red']::"DomainColor"[])` existed so a
+   * red-exclusive board's title could not render on civitai.com. Measured on prod the
+   * day it was removed: it withheld a badge from 174 users, 120 of whom had no badge at
+   * all, to suppress a title containing the word "mature" for 86 of them. 88 of the 174
+   * were on `new_creators-red` / `images-new-red`, whose titles are character-identical
+   * to their SFW twins, so they leaked nothing and were excluded anyway. The cosmetic
+   * art is a chili-pepper motif, not explicit. Justin's call was that the string is
+   * acceptable sitewide and the mechanism was not worth its cost.
+   *
+   * Restoring per-domain badges is a bigger change than restoring this line: `UserRank`
+   * is one global row per user and feeds a single users search index, so it would need a
+   * domain dimension in both. Re-adding the filter alone just reintroduces the 120.
+   *
+   * Asserted on the whole statement rather than the exact old line, so a re-spelling
+   * that names the column (`&&`, `=`, `@>`, a join to "Leaderboard".domain) fails too.
+   * The board-LISTING surface stayed domain-scoped on purpose — see
+   * `leaderboard-domain-visibility.test.ts`. Only the badge path opted out.
+   */
+  it.each([
+    ['full rebuild', () => updateLeaderboardRank()],
+    ['per-user rebuild', () => updateLeaderboardRankForUsers({ userIds: 42 })],
+  ])('%s does not filter candidate boards by domain', async (_label, run) => {
+    await run();
+    expect(insertStatement().sql).not.toMatch(/domain/i);
+  });
+
+  // The statement text elides interpolated values as placeholders, so an exclusion
+  // smuggled in as one — `AND lr."leaderboardId" NOT IN (${Prisma.join(RED_IDS)})` —
+  // never contains the word "domain" and passes the case above. The full rebuild binds
+  // nothing today, so any parameter at all is that shape arriving.
+  it('binds no parameters on the full rebuild, so no board list can hide in them', async () => {
+    await updateLeaderboardRank();
+    expect(insertStatement().values).toEqual([]);
+  });
+
+  // The domain filter went; the visibility one did not. Dropping `l.public` would put
+  // unlisted boards on profiles, which no part of the above licenses.
+  //
+  // Matched as a conjunction rather than a substring: `toContain('l.public')` stays
+  // green through `AND NOT l.public`, `AND l.public = false` and `OR l.public` — the
+  // exact inversions it claims to catch — while breaking on a harmless `l."public"`.
+  it('still restricts candidates to public boards', async () => {
+    await updateLeaderboardRank();
+    const sql = insertStatement().sql.replace(/\s+/g, ' ');
+
+    expect(sql).toMatch(/JOIN "Leaderboard" l ON l\.id = lr\."leaderboardId" AND l\."?public"?/);
+    expect(sql).not.toMatch(/NOT\s+l\."?public|l\."?public"?\s*=\s*false/i);
+  });
+});
+
 describe('updateLeaderboardRankForUsers', () => {
   it('scopes the rebuild to the given users and never truncates', async () => {
     await updateLeaderboardRankForUsers({ userIds: 42 });

--- a/src/server/services/leaderboard.service.ts
+++ b/src/server/services/leaderboard.service.ts
@@ -72,7 +72,10 @@ export async function getLeaderboards(input: GetLeaderboardsInput) {
       title: true,
       description: true,
       scoringDescription: true,
-      domain: true,
+      // `domain` is deliberately NOT selected. The `where` above is the only place
+      // domain scoping belongs; shipping the column invites a client to re-derive it,
+      // which is the bug this replaced.
+      //
       // Unconditional: the `where` above already limits non-moderators to public
       // boards, and UserProfileEditModal filters its showcase options on this
       // field — selecting it only for moderators would blank that list for

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1594,12 +1594,6 @@ const leaderboardRankInsert = ({
     JOIN "Leaderboard" l ON l.id = lr."leaderboardId" AND l.public
     WHERE lr.date = current_date
       AND lr.position <= 100
-      -- UserRank is a single global table but the badge (title + cosmetic) renders
-      -- on every domain, so a RED-EXCLUSIVE board would leak its name sitewide —
-      -- e.g. "Creators (mature)" on civitai.com. Exclude only those; a board that
-      -- is visible on any SFW domain still earns a badge (requiring 'all' would
-      -- strip the badge from everyone on the green/blue-scoped boards).
-      AND NOT (l.domain <@ ARRAY['red']::"DomainColor"[])
       ${leaderboardFilter}
       ${userFilter}
   ),


### PR DESCRIPTION
Closes the "Master Generators (mature)" showcase bug (ClickUp 868m1b61y, reported by Ellie on civitai.red).

## The bug

The board was never broken. `images-nsfw` is public, active, `domain: {red}`, and **visible on civitai.red right now** — verified against the live site rather than the code:

| URL | HTTP | "Master Generators (mature)" | "Master Generators" |
|---|---|---|---|
| civitai.red/leaderboard/images-overall | 200 | **1** | 2 |
| civitai.red/leaderboard/images-nsfw | 200 | **2** | 2 |
| civitai.com/leaderboard/images-nsfw | 200 | **0** | 1 |
| civitai.com/leaderboard/images-overall | 200 | **0** | 2 |

The plain `{all}` title appears on all four, so the probe demonstrably works; the `(mature)` one appears only on red.

The bug was a **client-side** filter in `UserProfileEditModal.tsx` (added 2026-08-14, `b5c3093a15`). It is host-blind, so it hid red-exclusive boards on *every* domain — including the one where they're visible and earnable.

## Why this deletes a mechanism instead of adding one

That filter mirrored `AND NOT (l.domain <@ ARRAY['red'])` in `leaderboardRankInsert`, which stops red-exclusive boards earning a `UserRank` badge — `UserRank` is one global row per user and the title renders sitewide. Since `leaderboardShowcase` has exactly **one** consumer (that insert), un-hiding the picker alone would have restored an option that still did nothing.

So the mechanism was measured on prod before proposing its removal:

- It withheld a badge from **174** users, **120 of whom had no badge at all**
- to suppress a title containing "mature" for **86** of them
- while **88** were on `new_creators-red` / `images-new-red`, whose titles are *character-identical* to their SFW twins — excluded for no benefit whatsoever
- **6,640** users already had a red-exclusive board stored as their showcase, inert (6,010 excluding deleted accounts)
- the mature cosmetic art is a chili-pepper motif, not explicit

Given that, the maintainer chose to delete the mechanism and accept the title appearing on `.com`, rather than make `UserRank` domain-aware (which would need a domain dimension on the table *and* the users search index).

## Changes

- `user.service.ts` — remove the domain predicate from `leaderboardRankInsert`. `l.public`, `position <= 100`, `lr.date` and the showcase ordering are untouched.
- `UserProfileEditModal.tsx` — remove the red-exclusion filter. No domain filter belongs here: `getLeaderboards` is already scoped by request host, so `.com` never lists these boards.
- `leaderboard.service.ts` — stop selecting `domain`. It had no consumer left, and shipping the column invites a client to re-derive scoping, which is the bug this replaces.
- Guards in both test files (below).

## Consequences, measured

Because the showcase outranks position, a user showcasing a mature board now takes their rank from it:

| | users |
|---|---|
| Newly get a badge | 120 |
| Rank gets better | 52 |
| Rank gets **worse** | **2** |
| Lose Top 10 Discord role | **0** |
| Lose Top 100 Discord role | **0** (impossible by construction) |

Those zeros are controlled, not assumed: **238** users are currently Top 10, so a loss was observable and did not occur; and losing Top 100 requires losing the row entirely, which adding candidates cannot cause.

No backfill needed — the nightly rebuild and the per-user recompute on profile save cover existing users.

## Guards

Both new guards were **proven able to fail**, by mutation:

| Mutant | Result |
|---|---|
| Re-add the deleted domain predicate | red |
| `AND NOT l.public` | red |
| `OR l.public` | red |
| Exclusion smuggled in as bound values (`NOT IN (?,?)`) | red |
| Delete `getLeaderboards`' domain filter | red (3 cases) |
| Benign `l."public"` requote | **green** |

Two of these exist because the first versions I wrote were defeatable: `toContain('l.public')` stayed green through `AND NOT l.public`, and `/domain/i` missed an exclusion carried as interpolated values. The public join is now matched as a conjunction, the full rebuild asserts it binds no parameters, and the benign-reformat case is pinned green so the guard won't cry wolf.

`getLeaderboards`' domain scoping is now tested at the query rather than only as a pure function — the picker depends on it alone.

## Verification

- `typecheck` — 0 errors
- `lint` — 0 errors across all 5 changed files (repo-wide 358 are pre-existing)
- Full unit suite — **1 failed / 1621 passed / 3 skipped (1625)**, 37,862 tests
- Submodule canary `blocks.router.workflow` collected **370**, so the run was real

The single failure is `appListingMenuSurface.test.ts`, a Windows path-separator guard. I reverted all changed files to `origin/main` in place, re-ran it, saw it fail identically, and restored by md5 — so "pre-existing" here is a control result, not an assumption.

Five adversarial review lanes ran at this SHA (reuse, correctness, perf, tests, intent). Perf: candidate set +12.5%, plan shape identical, delta inside noise.

## Worth recording

**Three of my own checks produced false clean results while doing this work — an `awk` syntax error, a `grep -c` that returned 0 against a file containing the line, and a scanner that reported 0 errors for a file with 2. All three were caught by controls before I acted on them.** Three in one session, all silent, all green. That is the argument for positive controls as data rather than principle.

## Known, accepted, not fixed here

- A mature badge on `.com` links to `/leaderboard/<red-id>`, which renders empty there (200, no 404). Leak-safe — the board's contents stay filtered. Disclosed before the decision.
- `leaderboardCosmetic` is an image URL with no domain, `public`, or browsing-level predicate, denormalized into the single users search index. Today's art is safe; nothing in code would catch a future red-board cosmetic that isn't.
- Pre-existing: `Cosmetic` has no index on `leaderboardId`, making a correlated subquery ~91% of the nightly rebuild (measured). The size of the fix is estimated, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuAuU5hKEmPE46y1ZDMRoQ
