### PR TITLE
feat(articles): official toggle in the editor, and an official filter on the feed

### DIFF
--- a/scripts/backfill-official-articles.mjs
+++ b/scripts/backfill-official-articles.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Backfill `Article."isOfficial"` for articles published by the Civitai account.
+ *
+ * `isOfficial` (civitai#4624) starts false for every existing article, so the badge is
+ * invisible until something marks the back catalogue. The rule this script applies is the
+ * one the codebase already uses to mean "ours":
+ * `constants.system.officialUserId` — the same id `resource-select.service.ts` uses to
+ * define its "official" tab.
+ *
+ * 🔴 DRY RUN BY DEFAULT. It prints what it would change and writes nothing until you pass
+ * `--apply`. That is deliberate: the column is a public provenance claim, and a backfill
+ * that marks the wrong author is a false claim on somebody else's writing.
+ *
+ * Usage:
+ *   node scripts/backfill-official-articles.mjs                 # dry run against DATABASE_URL
+ *   node scripts/backfill-official-articles.mjs --apply
+ *   node scripts/backfill-official-articles.mjs --user-id 123   # a different author
+ *   node scripts/backfill-official-articles.mjs --unmark        # clear instead of set
+ *
+ * The connection comes from DATABASE_URL, so it follows whatever `.env` the tree points
+ * at. Check the host it prints before passing --apply.
+ */
+
+import { config } from 'dotenv';
+import pg from 'pg';
+
+config();
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const unmark = args.includes('--unmark');
+const userIdArg = args.indexOf('--user-id');
+// 12042163 — `constants.system.officialUserId`, the "Public CivitaiOfficial content
+// account". Not imported: this is a plain node script and `~/server/common/constants`
+// pulls the whole server graph. If that id ever changes, it changes in two places.
+const OFFICIAL_USER_ID = userIdArg === -1 ? 12042163 : Number(args[userIdArg + 1]);
+
+if (!Number.isInteger(OFFICIAL_USER_ID) || OFFICIAL_USER_ID <= 0) {
+  console.error(`Error: --user-id must be a positive integer, got ${args[userIdArg + 1]}`);
+  process.exit(1);
+}
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  console.error('Error: DATABASE_URL is not set');
+  process.exit(1);
+}
+
+const target = !unmark;
+const client = new pg.Client({ connectionString, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+// Say which database, every run. A backfill pointed at the wrong one is the failure this
+// line exists to prevent, and `.env` here has been swapped between dev and prod before.
+const [{ host, db }] = (
+  await client.query(`select inet_server_addr()::text as host, current_database() as db`)
+).rows;
+console.log(`Database: ${db} @ ${host ?? 'local'}  (from DATABASE_URL)`);
+
+const { rows: pending } = await client.query(
+  `select a.id, a.title, a.status, a."publishedAt"
+     from "Article" a
+    where a."userId" = $1 and a."isOfficial" = $2
+    order by a."publishedAt" desc nulls last`,
+  [OFFICIAL_USER_ID, !target]
+);
+
+const { rows: alreadyRows } = await client.query(
+  `select count(*)::int as n from "Article" where "userId" = $1 and "isOfficial" = $2`,
+  [OFFICIAL_USER_ID, target]
+);
+const already = alreadyRows[0].n;
+
+// The count nobody asks for and everybody wants after the fact: articles carrying the
+// mark that this rule would NOT have set. A backfill that silently disagrees with the
+// moderators who marked things by hand is worth seeing before it runs, not after.
+const { rows: outsideRows } = await client.query(
+  `select count(*)::int as n from "Article" where "userId" <> $1 and "isOfficial" = true`,
+  [OFFICIAL_USER_ID]
+);
+
+console.log(
+  `Author ${OFFICIAL_USER_ID}: ${pending.length} to ${unmark ? 'unmark' : 'mark'}, ` +
+    `${already} already ${unmark ? 'unmarked' : 'marked'}.`
+);
+console.log(`Marked by someone else (left alone): ${outsideRows[0].n}`);
+
+for (const row of pending.slice(0, 20)) {
+  console.log(`  ${row.id}  ${row.status.padEnd(9)}  ${row.title.slice(0, 70)}`);
+}
+if (pending.length > 20) console.log(`  … and ${pending.length - 20} more`);
+
+if (!pending.length) {
+  console.log('Nothing to do.');
+  await client.end();
+  process.exit(0);
+}
+
+if (!apply) {
+  console.log('\nDRY RUN — nothing written. Re-run with --apply to make these changes.');
+  await client.end();
+  process.exit(0);
+}
+
+const { rowCount } = await client.query(
+  `update "Article" set "isOfficial" = $2 where "userId" = $1 and "isOfficial" = $3`,
+  [OFFICIAL_USER_ID, target, !target]
+);
+
+// Read it back rather than trusting rowCount: they should agree, and if they do not, the
+// difference is somebody writing the same rows at the same time.
+const { rows: afterRows } = await client.query(
+  `select count(*)::int as n from "Article" where "userId" = $1 and "isOfficial" = $2`,
+  [OFFICIAL_USER_ID, target]
+);
+
+console.log(`Updated ${rowCount} article(s).`);
+console.log(
+  `Now ${afterRows[0].n} article(s) by ${OFFICIAL_USER_ID} are ${unmark ? 'unmarked' : 'marked'}.`
+);
+if (afterRows[0].n !== already + rowCount) {
+  console.error('⚠ Read-back disagrees with the update count — something else wrote these rows.');
+  process.exitCode = 1;
+}
+
+await client.end();

--- a/src/components/Article/ArticleUpsertForm.tsx
+++ b/src/components/Article/ArticleUpsertForm.tsx
@@ -35,6 +35,7 @@ import {
   InputMultiFileUpload,
   InputMultiSelect,
   InputRTE,
+  InputSwitch,
   InputSelect,
   InputSimpleImageUpload,
   InputTags,
@@ -123,6 +124,7 @@ export function ArticleUpsertForm({ article }: Props) {
       tags: article?.tags.filter((tag) => !tag.isCategory) ?? [],
       coverImage: article?.coverImage ?? null,
       lockedProperties: article?.lockedProperties ?? [],
+      isOfficial: article?.isOfficial ?? false,
     } as any,
   });
   const clearStorage = useFormStorage({
@@ -178,6 +180,7 @@ export function ArticleUpsertForm({ article }: Props) {
     userNsfwLevel,
     moderatorNsfwLevel,
     lockedProperties,
+    isOfficial,
     content,
     ...rest
   }: z.infer<typeof schema>) => {
@@ -213,6 +216,11 @@ export function ArticleUpsertForm({ article }: Props) {
           status: args?.status ? args.status : publishing ? ArticleStatus.Published : undefined,
           coverImage,
           lockedProperties: lockedPropertiesRef.current,
+          // Same shape as moderatorNsfwLevel above, and for a stronger reason: the server
+          // DROPS this field for a non-moderator rather than refusing the save, so a
+          // non-mod payload carrying it would be silently ignored. Not sending the key at
+          // all keeps the client honest about what it is asking for.
+          isOfficial: currentUser?.isModerator ? isOfficial : undefined,
         },
         {
           async onSuccess(result) {
@@ -564,11 +572,18 @@ export function ArticleUpsertForm({ article }: Props) {
             <UploadNotice className="-mt-2" />
             {currentUser?.isModerator && (
               <Paper radius="md" p="xl" withBorder>
-                <InputMultiSelect
-                  name="lockedProperties"
-                  label="Locked properties"
-                  data={lockableProperties}
-                />
+                <Stack gap="md">
+                  <InputSwitch
+                    name="isOfficial"
+                    label="Official Civitai article"
+                    description="Shows the Official badge on the card and the article page. Moderators only."
+                  />
+                  <InputMultiSelect
+                    name="lockedProperties"
+                    label="Locked properties"
+                    data={lockableProperties}
+                  />
+                </Stack>
               </Paper>
             )}
             <ActionButtons

--- a/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
+++ b/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
@@ -1,5 +1,5 @@
 import type { ButtonProps } from '@mantine/core';
-import { Divider, Drawer, Indicator, Popover, Stack, useMantineTheme } from '@mantine/core';
+import { Chip, Divider, Drawer, Indicator, Popover, Stack, useMantineTheme } from '@mantine/core';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { IconFilter } from '@tabler/icons-react';
 import { useCallback, useMemo } from 'react';
@@ -32,20 +32,32 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
   );
 
   const handleClear = useCallback(() => {
+    // `isOfficial` is deliberately absent rather than `false`: the schema treats only
+    // `true` as a filter, so clearing means dropping the key.
     const reset = { period: MetricTimeframe.AllTime };
     if (onChange) onChange(reset);
     else setFilters(reset);
   }, [onChange, setFilters]);
 
-  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
-    useStagedFilters({
-      committed: committedFilters,
-      onApply: handleApply,
-      onClear: handleClear,
-    });
+  const {
+    opened,
+    toggle,
+    close,
+    mergedFilters,
+    isDirty,
+    patchPending,
+    apply,
+    reset,
+    clearAndClose,
+  } = useStagedFilters({
+    committed: committedFilters,
+    onApply: handleApply,
+    onClear: handleClear,
+  });
 
   const filterLength =
-    mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0;
+    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
+    (mergedFilters.isOfficial ? 1 : 0);
 
   const target = (
     <Indicator
@@ -81,6 +93,26 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
           value={mergedFilters.period ?? MetricTimeframe.AllTime}
           onChange={(period) => patchPending({ period })}
         />
+      </Stack>
+      <Stack gap="md">
+        <Divider
+          label="Source"
+          styles={{
+            label: {
+              fontSize: theme.fontSizes.sm,
+              fontWeight: 700,
+            },
+          }}
+        />
+        {/* Off sends `undefined`, not `false` — see the schema. There is no "community
+            only" filter here because nobody browses for that, and a `false` that filtered
+            would let a stale url hide every official article. */}
+        <Chip
+          checked={!!mergedFilters.isOfficial}
+          onChange={(checked) => patchPending({ isOfficial: checked ? true : undefined })}
+        >
+          Civitai Official
+        </Chip>
       </Stack>
     </Stack>
   );

--- a/src/components/Article/article.utils.ts
+++ b/src/components/Article/article.utils.ts
@@ -26,6 +26,8 @@ const articleQueryParamSchema = z
     period: z.enum(MetricTimeframe),
     sort: z.enum(ArticleSort),
     section: z.enum(['published', 'draft']),
+    // `?isOfficial=true` makes "everything Civitai published" a link you can send.
+    isOfficial: booleanString(),
     favorites: booleanString(),
     hidden: booleanString(),
     username: z.string(),

--- a/src/providers/FiltersProvider.tsx
+++ b/src/providers/FiltersProvider.tsx
@@ -125,6 +125,9 @@ const articleFilterSchema = z.object({
   periodMode: periodModeSchema,
   sort: z.enum(ArticleSort).default(ArticleSort.MostBookmarks),
   followed: z.boolean().optional(),
+  // Optional with no default, so an unfiltered store carries no key at all — the server
+  // reads only `true` as a filter.
+  isOfficial: z.boolean().optional(),
 });
 
 type CollectionFilterSchema = z.infer<typeof collectionFilterSchema>;

--- a/src/server/controllers/__tests__/article.controller.is-official.test.ts
+++ b/src/server/controllers/__tests__/article.controller.is-official.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import type * as ArticleService from '~/server/services/article.service';
+
+const { mockUpsertArticle } = vi.hoisted(() => ({ mockUpsertArticle: vi.fn() }));
+
+vi.mock('~/server/services/article.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ArticleService>()),
+  upsertArticle: mockUpsertArticle,
+}));
+
+// The handler still runs the pre-existing adminOnly-CATEGORY check, which reads the
+// system cache. Unrelated to this field, and it throws without redis.
+vi.mock('~/server/services/system-cache', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getCategoryTags: async () => [],
+}));
+
+import { upsertArticleHandler } from '../article.controller';
+
+function ctx(isModerator: boolean) {
+  return {
+    user: { id: 7, isModerator },
+    features: { articleImageScanning: false },
+    req: undefined,
+    track: { article: vi.fn(async () => undefined) },
+  } as never;
+}
+
+const input = (isOfficial?: boolean) =>
+  ({
+    id: 5,
+    title: 't',
+    content: '<p>c</p>',
+    ...(isOfficial === undefined ? {} : { isOfficial }),
+  } as never);
+
+const lastUpsertArg = () => mockUpsertArticle.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+
+/**
+ * `isOfficial` is a provenance claim reachable from a user-facing mutation, so the
+ * question is not only "can a member set it" but "what happens to a member who sends it".
+ */
+describe('upsertArticleHandler — isOfficial', () => {
+  beforeEach(() => {
+    mockUpsertArticle.mockReset();
+    mockUpsertArticle.mockResolvedValue({ id: 5, publishedAt: null });
+    dbMock.dbRead.article.findUnique.mockResolvedValue({ publishedAt: null });
+    dbMock.dbRead.tag.findMany.mockResolvedValue([]);
+  });
+
+  it('does not let a member mark their own article official', async () => {
+    await upsertArticleHandler({ input: input(true), ctx: ctx(false) });
+
+    expect(lastUpsertArg().isOfficial).toBeUndefined();
+  });
+
+  // 🔴 The other half, and the one that is easy to get wrong. The member's SAVE must
+  // still succeed. Refusing is what killed the tag version of this feature: the edit form
+  // seeds itself from the article, so an owner editing an article a moderator had marked
+  // would send the flag back and be locked out of their own article with a bare
+  // UNAUTHORIZED and nothing explaining it.
+  it('still saves the member’s article, rather than refusing it', async () => {
+    await expect(
+      upsertArticleHandler({ input: input(true), ctx: ctx(false) })
+    ).resolves.toBeDefined();
+
+    expect(mockUpsertArticle).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg().title).toBe('t');
+  });
+
+  // `undefined` is what tells `upsertArticle` to leave the column alone, so this is also
+  // the assertion that a member's edit cannot CLEAR a mark a moderator set.
+  it('does not let a member clear an official mark either', async () => {
+    await upsertArticleHandler({ input: input(false), ctx: ctx(false) });
+
+    expect(lastUpsertArg().isOfficial).toBeUndefined();
+  });
+
+  // The control for all three: same field, moderator context. Without it they pass for a
+  // handler that drops `isOfficial` from everyone, which would make the editor toggle a
+  // decoration.
+  it('passes a moderator’s value through', async () => {
+    await upsertArticleHandler({ input: input(true), ctx: ctx(true) });
+    expect(lastUpsertArg().isOfficial).toBe(true);
+
+    await upsertArticleHandler({ input: input(false), ctx: ctx(true) });
+    expect(lastUpsertArg().isOfficial).toBe(false);
+  });
+
+  // An ordinary save from anyone must not carry the key at all — `upsertArticle` reads
+  // `undefined` as "leave the column alone", and an accidental `false` here would unmark
+  // every official article the moment its author edited it.
+  it('sends no isOfficial key when nobody asked for one', async () => {
+    await upsertArticleHandler({ input: input(), ctx: ctx(true) });
+
+    expect(lastUpsertArg()).toHaveProperty('isOfficial', undefined);
+  });
+});

--- a/src/server/controllers/article.controller.ts
+++ b/src/server/controllers/article.controller.ts
@@ -30,6 +30,15 @@ export const upsertArticleHandler = async ({
     );
     // Only users with adminTags featureFlag can add adminOnly tags
     if (includesAdminOnlyTag && !ctx.features.adminTags) throw throwAuthorizationError();
+    // 🔴 `isOfficial` is a provenance claim, so a non-moderator's value is DROPPED rather
+    // than refused. Refusing is the shape that killed the tag version of this feature: the
+    // edit form seeds itself from the article, so an owner editing an article a moderator
+    // had marked would send the flag back and be locked out of their own article with a
+    // bare UNAUTHORIZED. Dropping it means their save succeeds and changes nothing about
+    // the mark — `upsertArticle` leaves the column alone when the field is undefined.
+    const { isOfficial, ...articleInput } = input;
+    const official = ctx.user.isModerator ? isOfficial : undefined;
+
     const scanContent = ctx.features.articleImageScanning ?? false;
 
     // Capture the prior published state so we can tell a publish transition apart
@@ -45,7 +54,8 @@ export const upsertArticleHandler = async ({
       : false;
 
     const result = await upsertArticle({
-      ...input,
+      ...articleInput,
+      isOfficial: official,
       userId: ctx.user.id,
       isModerator: ctx.user.isModerator,
       scanContent,

--- a/src/server/schema/article.schema.ts
+++ b/src/server/schema/article.schema.ts
@@ -63,6 +63,10 @@ export type ArticleQueryInput = z.input<typeof articleWhereSchema>;
 export const articleWhereSchema = baseQuerySchema.extend({
   query: z.string().optional(),
   tags: z.array(z.number()).optional(),
+  // `true` narrows to Civitai-published articles. `false` is NOT the inverse — it is
+  // absent, the same as not filtering — so a stale `?isOfficial=false` in a url cannot
+  // silently hide every official article from a feed.
+  isOfficial: z.boolean().optional(),
   favorites: z.boolean().optional(),
   hidden: z.boolean().optional(),
   username: z.string().optional(),
@@ -109,6 +113,9 @@ export const upsertArticleInput = z.object({
   attachments: z.array(baseFileSchema).optional(),
   lockedProperties: z.string().array().optional(),
   status: z.enum(ArticleStatus).optional(),
+  // Moderator-only. `upsertArticleHandler` DROPS this field for everyone else rather
+  // than refusing the save — see the comment there for why refusing is the wrong shape.
+  isOfficial: z.boolean().optional(),
 });
 
 export type ResolveArticleImageScanInput = z.infer<typeof resolveArticleImageScanSchema>;

--- a/src/server/services/__tests__/article-official-filter.service.test.ts
+++ b/src/server/services/__tests__/article-official-filter.service.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dbMock } from '~/__tests__/mocks/db.mock';
+
+vi.mock('~/server/services/system-cache', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getCategoryTags: async () => [],
+}));
+
+import { ArticleSort } from '~/server/common/enums';
+import { getArticles } from '~/server/services/article.service';
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+
+// The fields `getArticles` reads unconditionally. Only `isOfficial` varies below.
+const base = { limit: 10, sort: ArticleSort.Newest, period: MetricTimeframe.AllTime };
+
+/**
+ * The `?isOfficial=true` feed filter, asserted on the SQL the service emits.
+ *
+ * Reading the emitted statement rather than the arguments is deliberate: the filter is a
+ * WHERE clause, and a test that only checked the service was CALLED with `isOfficial`
+ * would pass for a service that accepted the flag and ignored it — which is exactly what
+ * "filter does nothing" looks like to a user.
+ */
+function emittedSql() {
+  const calls = dbMock.dbRead.$queryRaw.mock.calls as unknown[][];
+
+  // Two things had to be learned here, and both are why this helper is not a one-liner.
+  //
+  // 1. `$queryRaw` is called as a TAGGED TEMPLATE, so the first argument is the
+  //    TemplateStringsArray, not a `Prisma.Sql`.
+  // 2. The WHERE clause is INTERPOLATED — `Prisma.join(AND)` arrives as a value, not as
+  //    template text — so the filter this file is about does not appear in the strings at
+  //    all. Reading only the strings returned SQL that could never contain the clause,
+  //    and the negative assertions below passed against it happily.
+  const render = (value: unknown): string => {
+    if (value == null) return '';
+    if (Array.isArray(value)) return value.map(render).join(' ');
+    if (typeof value === 'object') {
+      const sql = value as { strings?: unknown; sql?: string; values?: unknown };
+      return [render(sql.strings), sql.sql ?? '', render(sql.values)].join(' ');
+    }
+    return String(value);
+  };
+
+  return calls.map((args) => render(args)).join('\n');
+}
+
+describe('getArticles — isOfficial filter', () => {
+  beforeEach(() => {
+    dbMock.dbRead.$queryRaw.mockReset();
+    dbMock.dbRead.$queryRaw.mockResolvedValue([]);
+  });
+
+  it('narrows to official articles when asked', async () => {
+    await getArticles({ ...base, isOfficial: true } as never);
+
+    expect(emittedSql()).toContain('"isOfficial" = true');
+  });
+
+  // The control. Without it the assertion above passes for a service that hardcodes the
+  // clause into every article feed on the site — which would hide all community content.
+  it('does not narrow when the filter is absent', async () => {
+    await getArticles({ ...base } as never);
+
+    // The SQL really was captured — without this, the negative above passes when the
+    // helper returns nothing, which is how it was written the first time.
+    expect(emittedSql()).toContain('FROM "Article" a');
+    expect(emittedSql()).not.toContain('"isOfficial" = true');
+  });
+
+  // 🔴 `false` is NOT the inverse, deliberately. Nobody browses FOR community articles,
+  // and treating `false` as a filter would let a stale `?isOfficial=false` in somebody's
+  // url quietly hide every official article from their feed. The schema comment says the
+  // same thing; this is what enforces it.
+  it('treats an explicit false as no filter, not as “community only”', async () => {
+    await getArticles({ ...base, isOfficial: false } as never);
+
+    expect(emittedSql()).toContain('FROM "Article" a');
+    expect(emittedSql()).not.toContain('"isOfficial" = false');
+    expect(emittedSql()).not.toContain('"isOfficial" = true');
+  });
+});

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -161,6 +161,7 @@ export const getArticles = async ({
   cursor,
   query,
   tags,
+  isOfficial,
   period,
   periodMode,
   sort,
@@ -213,6 +214,11 @@ export const getArticles = async ({
     if (query) {
       AND.push(Prisma.sql`a."title" ILIKE ${'%' + query + '%'}`);
     }
+    // Only `true` narrows. An explicit `false` is treated as no filter, matching the
+    // schema comment: nobody browses FOR community articles, and a `false` that filtered
+    // would let a stale url hide every official article from a feed.
+    if (isOfficial) AND.push(Prisma.sql`a."isOfficial" = true`);
+
     if (!!tags?.length) {
       AND.push(
         Prisma.sql`EXISTS (


### PR DESCRIPTION
Follows #4624 (the column, the moderator-only mutation, the badge). Three things Justin asked for after it merged: the mark reachable from the **article editor** rather than only the ⋯ menu, the **agent CLI** able to set it, and a way to **browse official articles**.

The CLI half is `civitai/civitai-user-skill@5f3cfa4` — `article.mjs --official / --no-official`. This PR is the app.

## 🔴 A non-moderator's `isOfficial` is dropped, not refused

That distinction is the design, not defensive coding. The edit form seeds itself from the article, so an owner editing an article a moderator had marked sends the flag straight back. **Refusing there locks the author out of their own article** with a bare `UNAUTHORIZED` and nothing explaining it — the exact defect the five-lane review found in the tag version (#4618, closed).

Dropping it means their save succeeds and changes nothing about the mark, because `upsertArticle` leaves the column alone when the field is `undefined`. Both halves are tested; the *"still saves"* half is the one a future tidy-up will break.

The editor toggle sits in the moderator-only panel beside Locked properties, and the form omits the key entirely for everyone else rather than sending a value the server would discard.

## The feed filter

A `Civitai Official` chip in the filters dropdown, plus `?isOfficial=true` so an official feed is a link you can send.

**Only `true` filters.** An explicit `false` is treated as absent, deliberately: nobody browses *for* community articles, and a `false` that filtered would let a stale url quietly hide every official article from someone's feed. Asserted on the **emitted SQL**, not on the arguments — a test that only checked the service was *called* with the flag would pass for a service that ignored it, which is what "the filter does nothing" looks like to a user.

## Controls — every mutation red, pristine 8 passed (5 + 3)

| Mutation | Result |
|---|---|
| non-mod value passed through instead of dropped | 2 failed |
| refuse instead of drop | 3 failed |
| drop becomes `false` instead of `undefined` | 2 failed |
| `WHERE` clause removed | 1 failed |
| `WHERE` clause applied unconditionally | 2 failed |
| `false` filters too | 1 failed |

## ⚠️ One of those tests was wrong first, and now carries the warning

The SQL helper read only the template strings — but `getArticles` interpolates its `WHERE` clause as a **value**, so it captured SQL that could never contain the filter, and **both negative assertions passed against it**. Every assertion in that file now carries a `FROM "Article" a` control, so an empty capture fails loudly instead of quietly. Same class as the two dead guards on #4618; that is three in two days, all of them mine, all of them negatives without a positive control.

## Verification

`typecheck: OK — 0 type errors`. ESLint clean on the changed files (3 pre-existing warnings). Full suite `Test Files 1 failed | 1625 passed | 3 skipped (1629)` — the one failure is `appListingMenuSurface.test.ts`, which compares Windows paths against forward-slash literals and fails on a clean tree.

**Note on CI:** `Unit tests (3)` and `(4)` are red on `main` itself (run 33912148012 at `26d17e46f4`), reporting 14,730 passed / 0 failed and then exiting 1. Not from this branch.

## Not done

The editor toggle has no rendered test, for the same reason #4624's badge doesn't: the form pulls in providers that would have to be stubbed until the test was testing the stubs. The server side of it — which is the part that matters — is covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHZuQDTCG159qcPrCkP7SF