### PR TITLE
fix(license): stop Attachment B duplicating on every license page load

### DIFF
--- a/src/server/controllers/__tests__/model-version.controller.license-cache.test.ts
+++ b/src/server/controllers/__tests__/model-version.controller.license-cache.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as ModelVersionService from '~/server/services/model-version.service';
+
+/**
+ * `getStaticContent` caches parsed static content in-memory for 5 minutes and returns the cached
+ * object BY REFERENCE. The license handler used to assign the Attachment B addendum onto that
+ * object's `.content`, so every later request re-appended onto an already-appended string and the
+ * page grew a new "Additional Restrictions" block per refresh until the TTL expired.
+ *
+ * The real cache and the real addendum builder are both exercised here — a mock of either would
+ * describe the bug instead of reproducing it.
+ */
+
+const { mockGetVersionById } = vi.hoisted(() => ({ mockGetVersionById: vi.fn() }));
+
+// The controller reaches the orchestrator caller through training.service, which throws on a
+// missing token at import. Nothing on this path calls it.
+vi.mock('~/server/services/training.service', () => ({}));
+vi.mock('~/server/services/model-version.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof ModelVersionService>()),
+  getVersionById: mockGetVersionById,
+}));
+
+import { getVersionLicenseHandler } from '~/server/controllers/model-version.controller';
+import { getStaticContent } from '~/server/services/content.service';
+
+const LICENSE_SLUG = 'CreativeML Open RAIL++-M';
+const ADDENDUM_MARKER = /This Attachment B supplements the license/g;
+
+const countAddenda = (content: string) => (content.match(ADDENDUM_MARKER) ?? []).length;
+
+const version = {
+  id: 4242,
+  name: 'v1.0',
+  baseModel: 'SDXL 1.0',
+  status: 'Published',
+  model: {
+    id: 909,
+    name: 'Test Model',
+    status: 'Published',
+    allowCommercialUse: ['Image'],
+    allowDerivatives: false,
+    allowNoCredit: false,
+    allowDifferentLicense: true,
+    user: { username: 'tester' },
+  },
+};
+
+const callHandler = () =>
+  getVersionLicenseHandler({ input: { id: version.id } } as never) as Promise<{
+    license: { content: string };
+  }>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetVersionById.mockResolvedValue(version);
+});
+
+describe('getVersionLicenseHandler — Attachment B against the static-content cache', () => {
+  it('returns exactly one addendum on every request', async () => {
+    const first = await callHandler();
+    expect(countAddenda(first.license.content)).toBe(1);
+
+    for (let i = 0; i < 4; i++) {
+      const next = await callHandler();
+      expect(countAddenda(next.license.content)).toBe(1);
+    }
+  });
+
+  it('leaves the cached static content free of the addendum', async () => {
+    await callHandler();
+
+    const cached = await getStaticContent({ slug: ['licenses', LICENSE_SLUG] });
+    expect(countAddenda(cached.content)).toBe(0);
+  });
+
+  it('gives concurrent requests identical content', async () => {
+    const results = await Promise.all([callHandler(), callHandler(), callHandler()]);
+    const contents = new Set(results.map((r) => r.license.content));
+
+    expect(contents.size).toBe(1);
+    expect(countAddenda(results[0].license.content)).toBe(1);
+  });
+});

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -1158,18 +1158,22 @@ export async function getVersionLicenseHandler({ input }: { input: GetByIdInput 
     if (!hasAdditionalPermissions) throw throwBadRequestError('No additional permissions');
 
     const licenseSlug = baseModelLicenses[version.baseModel as BaseModel]?.name ?? '';
-    const license = await getStaticContent({ slug: ['licenses', licenseSlug] });
-
-    license.content = addAdditionalLicensePermissions(license.content, {
-      modelId: version.model.id,
-      modelName: version.model.name,
-      versionId: version.id,
-      username: version.model.user.username,
-      allowCommercialUse: version.model.allowCommercialUse,
-      allowNoCredit: version.model.allowNoCredit,
-      allowDerivatives: version.model.allowDerivatives,
-      allowDifferentLicense: version.model.allowDifferentLicense,
-    });
+    // `getStaticContent` returns its cached object by reference — assigning to `.content`
+    // here would append Attachment B onto what the next request reads.
+    const staticLicense = await getStaticContent({ slug: ['licenses', licenseSlug] });
+    const license = {
+      ...staticLicense,
+      content: addAdditionalLicensePermissions(staticLicense.content, {
+        modelId: version.model.id,
+        modelName: version.model.name,
+        versionId: version.id,
+        username: version.model.user.username,
+        allowCommercialUse: version.model.allowCommercialUse,
+        allowNoCredit: version.model.allowNoCredit,
+        allowDerivatives: version.model.allowDerivatives,
+        allowDifferentLicense: version.model.allowDifferentLicense,
+      }),
+    };
 
     return { ...version, license };
   } catch (error) {


### PR DESCRIPTION
Fixes the license page rendering a different number of "Additional Restrictions" blocks on every refresh.

ClickUp: [868m18qaa](https://app.clickup.com/t/868m18qaa) — Freshdesk #70539

## The bug

`getStaticContent` caches parsed static content in-memory for 5 minutes and returns **the cached object by reference** (`content.service.ts:47`). `getVersionLicenseHandler` assigned the Attachment B addendum onto that object's `.content`, so each request re-appended onto the string the previous request had already appended to:

```
refresh 1 → base + AttB
refresh 2 → base + AttB + AttB
refresh 3 → base + AttB + AttB + AttB
```

…until the TTL expired. Concurrent requests landing at different accumulation states is what made the page look different on every reload.

## Confirmed live in production

The license page SSR-prefetches the query, so the served HTML carries the content. Counting the addendum marker per page load, across four unrelated versions:

| version | model | blocks over consecutive refreshes |
|---|---|---|
| 2840768 | CyberRealistic XL v10.0 | 2 1 2 1 1 2 1 3 1 3 2 2 1 2 1 2 3 1 1 1 |
| 3296176 | Stoned Pygmalion | 3 3 4 1 3 2 |
| 3295656 | Moe (SD 1.5) | 4 1 2 5 2 1 |
| 3294903 | OC_Tanned_RedHair | 3 2 3 1 2 2 |

Up to five stacked copies. The base license files contain zero occurrences of "Attachment B", so every occurrence is appended. Not model-specific — it hits every SD 1.5 / SDXL 1.0 page with additional permissions.

## The fix

Build a new object instead of writing through to the cache:

```ts
const staticLicense = await getStaticContent({ slug: ['licenses', licenseSlug] });
const license = {
  ...staticLicense,
  content: addAdditionalLicensePermissions(staticLicense.content, { ... }),
};
```

I checked every other `getStaticContent` caller — `user.controller.ts:383,395`, `strike.service.ts:545` and `content.router.ts:23` all read the result without writing to it, so this was the only mutation site.

## Tests

`src/server/controllers/__tests__/model-version.controller.license-cache.test.ts` drives the real handler against the **real** cache and the **real** addendum builder, mocking only `getVersionById`. Mocking either of the first two would describe the bug rather than reproduce it.

Verified against a revert of the fix — all three fail, quickly and legibly:

```
1. returns exactly one addendum on every request
   AssertionError: expected 2 to be 1
2. leaves the cached static content free of the addendum
   AssertionError: expected 3 to be +0
3. gives concurrent requests identical content
   AssertionError: expected 6 to be 1
```

Locally: `pnpm typecheck` clean (0 errors), eslint clean on both files (the 4 remaining warnings in `model-version.controller.ts` are identical on `main`). The full unit suite is left to CI.

## Impact

Display-only — the terms that actually apply were always "base license + permissions once". But license text is a legal-clarity surface, and creators and licensees could not tell which set of restrictions was real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ9xz7HicULyW7kvBDcUbq
