### PR TITLE
feat(announcements): reach, link clicks and mutes for creators

### DIFF
--- a/apps/creator-studio/src/lib/components/ImpressionsNotice.svelte
+++ b/apps/creator-studio/src/lib/components/ImpressionsNotice.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import { IconLayoutGrid } from '@tabler/icons-svelte';
+  import Notice from '$lib/components/Notice.svelte';
   import { IMPRESSIONS_SINCE_LABEL, IMPRESSIONS_FULL_LABEL } from '$lib/impressions';
 </script>
 
-<div
-  class="mb-4 flex items-start gap-2 rounded-lg border border-dark-4 bg-dark-7 px-3 py-2 text-xs text-dark-2"
->
-  <IconLayoutGrid size={15} class="mt-px shrink-0 text-white" />
-  <p>
+<div class="mb-4">
+  <Notice icon={IconLayoutGrid}>
     <strong class="font-medium text-white">Feed impressions are new.</strong> We started counting on
     {IMPRESSIONS_SINCE_LABEL} and reached every visitor on {IMPRESSIONS_FULL_LABEL}, so there is
     nothing before those dates and totals will look low until a full month has been counted.
-  </p>
+  </Notice>
 </div>

--- a/apps/creator-studio/src/lib/components/Notice.svelte
+++ b/apps/creator-studio/src/lib/components/Notice.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { Icon as TablerIcon } from '@tabler/icons-svelte';
+
+  let { icon: Icon, children }: { icon: TablerIcon; children: Snippet } = $props();
+</script>
+
+<div
+  class="flex items-start gap-2 rounded-lg border border-dark-4 bg-dark-7 px-3 py-2 text-xs text-dark-2"
+>
+  <Icon size={15} class="mt-px shrink-0 text-white" />
+  <p>{@render children()}</p>
+</div>

--- a/apps/creator-studio/src/lib/impressions.ts
+++ b/apps/creator-studio/src/lib/impressions.ts
@@ -5,6 +5,12 @@
 export const IMPRESSIONS_SINCE = '2026-08-17';
 export const IMPRESSIONS_FULL = '2026-08-18';
 
+// Announcement reach, clicks and mute events start here — the day that instrumentation shipped,
+// which is later than the feed dates above and unrelated to them. It is also the floor every
+// `actions` read uses, so moving it earlier makes those queries scan more of a 92.8M-row table
+// for rows that cannot exist.
+export const ANNOUNCEMENT_METRICS_SINCE = '2026-09-04';
+
 const monthDay = new Intl.DateTimeFormat('en-US', {
   month: 'long',
   day: 'numeric',
@@ -24,3 +30,5 @@ export const IMPRESSIONS_FULL_LABEL = long(IMPRESSIONS_FULL);
 // whole calendar months, so testing `from` suppresses August 2026 — the ramp month, which holds ~14 days of a
 // month and three of those hours at 1% traffic, and would otherwise render +100-300% on every row.
 export const impressionsComparable = (compareFrom: string) => compareFrom >= IMPRESSIONS_FULL;
+
+export const ANNOUNCEMENT_METRICS_SINCE_LABEL = long(ANNOUNCEMENT_METRICS_SINCE);

--- a/apps/creator-studio/src/lib/server/analytics-sql.ts
+++ b/apps/creator-studio/src/lib/server/analytics-sql.ts
@@ -32,3 +32,23 @@ export function ownerViewsDailySql(uid: number, from: string, to: string): strin
   const sealed = `assumeNotNull((SELECT max(createdDate) FROM image_views_daily_by_owner))`;
   return `SELECT createdDate AS date, sum(views) AS value FROM image_views_daily_by_owner WHERE ownerId = ${uid} AND createdDate >= toDate('${from}') AND createdDate <= toDate('${to}') GROUP BY date ORDER BY date WITH FILL FROM toDate('${from}') TO least(toDate('${to}'), ${sealed}) + 1 STEP 1`;
 }
+
+// All-time impressions for a bounded list of entity ids, one row per id. `daily_impressions` is
+// keyed `(entityType, entityId, createdDate)`, so a literal id list is a prefix seek (measured:
+// 13 marks) — this is the read for a creator who holds a handful of entities, where the
+// owner-keyed rollup above has no arm and would not help anyway.
+//
+// `ids` is a pre-joined list of numbers from the caller's own rows. Nothing here quotes it.
+//
+// The date range is optional because the two callers ask different questions: the analytics tabs
+// compare periods, the announcements page shows a lifetime total.
+export function entityImpressionTotalsSql(
+  entityType: string,
+  ids: string,
+  range?: { from: string; to: string }
+): string {
+  const window = range
+    ? ` AND createdDate >= toDate('${range.from}') AND createdDate <= toDate('${range.to}')`
+    : '';
+  return `SELECT entityId AS id, sum(impressions) AS impressions FROM daily_impressions WHERE entityType = '${entityType}' AND entityId IN (${ids})${window} GROUP BY id`;
+}

--- a/apps/creator-studio/src/lib/server/analytics.ts
+++ b/apps/creator-studio/src/lib/server/analytics.ts
@@ -1,11 +1,12 @@
 import { sql } from '@civitai/db/kysely';
 import { getClickhouse } from '$lib/server/clickhouse';
+import { entityImpressionTotalsSql } from '$lib/server/analytics-sql';
 import { dbRead } from '$lib/server/db';
 import { createCache } from '$lib/server/cache';
 import { rangeTtlSeconds } from '$lib/date-range';
 import { bucketReactors, type ReactionAudienceSplit } from '$lib/analytics/reaction-audience';
 import { viewTrackingSql, ownerViewsDailySql } from '$lib/server/analytics-sql';
-import { VIEW_ENTITY, IMPRESSION_ENTITY } from '$lib/server/view-entities';
+import { VIEW_ENTITY, IMPRESSION_ENTITY, OWNER_IMPRESSION_ARMS } from '$lib/server/view-entities';
 import type { ViewEntity, ImpressionEntity } from '$lib/server/view-entities';
 
 export type { AudienceBucket, ReactionAudienceSplit } from '$lib/analytics/reaction-audience';
@@ -453,10 +454,7 @@ function impressionsDailySql(uid: number, from: string, to: string): string {
   return `SELECT createdDate AS date, sum(impressions) AS value FROM impressions_daily_by_owner WHERE ownerId = ${uid} AND entityType IN (${impressionArms()}) AND createdDate >= toDate('${from}') AND createdDate <= toDate('${to}') GROUP BY date ORDER BY date WITH FILL FROM toDate('${from}') TO toDate('${to}') + 1 STEP 1`;
 }
 
-const impressionArms = () =>
-  Object.values(IMPRESSION_ENTITY)
-    .map((e) => `'${e}'`)
-    .join(', ');
+const impressionArms = () => OWNER_IMPRESSION_ARMS.map((e) => `'${e}'`).join(', ');
 
 function netReactionsDailySql(uid: number, from: string, to: string): string {
   return `SELECT toDate(time) AS date, ${netReactions} AS value FROM reactions WHERE ownerId = ${uid} AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY date`;
@@ -616,9 +614,7 @@ async function fetchImpressionsByEntity(
 ): Promise<Map<number, number>> {
   if (!ids.length) return new Map();
   const rows = await getClickhouse().$query<{ id: number | string; impressions: number | string }>(
-    `SELECT entityId AS id, sum(impressions) AS impressions FROM daily_impressions WHERE entityType = '${entityType}' AND entityId IN (${ids.join(
-      ','
-    )}) AND createdDate >= toDate('${from}') AND createdDate <= toDate('${to}') GROUP BY id`
+    entityImpressionTotalsSql(entityType, ids.join(','), { from, to })
   );
   return new Map(rows.map((r) => [Number(r.id), Number(r.impressions)]));
 }

--- a/apps/creator-studio/src/lib/server/announcement-analytics.ts
+++ b/apps/creator-studio/src/lib/server/announcement-analytics.ts
@@ -1,0 +1,111 @@
+import { dbRead } from '$lib/server/db';
+import { getClickhouse } from '$lib/server/clickhouse';
+import { createCache } from '$lib/server/cache';
+import { IMPRESSION_ENTITY } from '$lib/server/view-entities';
+import { entityImpressionTotalsSql } from '$lib/server/analytics-sql';
+import { ANNOUNCEMENT_METRICS_SINCE } from '$lib/impressions';
+
+export type MutePoint = { date: string; muted: number; unmuted: number };
+
+export type AnnouncementMetrics = {
+  /** Per announcement id. A missing id means no rows, which is a real zero — both reads are all-time. */
+  impressions: Record<number, number>;
+  clicks: Record<number, number>;
+  /** How many people mute this creator's announcements right now. Postgres, so retroactive and exact. */
+  mutedNow: number;
+  /** Mute and unmute events per day. Empty before the first event, never backfilled. */
+  muteSeries: MutePoint[];
+};
+
+// Ten minutes: these are read on every load of a page the creator also composes on, so a save
+// or a delete re-runs the load. `mutedNow` stays outside the cache — it is the one figure a
+// creator can change by asking someone, and it is a single indexed count.
+const announcementClickhouse = createCache({
+  name: 'announcement-metrics',
+  ttlSeconds: 600,
+  fetch: ({ userId, ids }: { userId: number; ids: string }) => readClickhouse(userId, ids),
+});
+
+/**
+ * Reach, click-through and mutes for a creator's own announcements.
+ *
+ * Reads what the platform already writes: `daily_impressions` for reach, `actions` for the
+ * link click and the mute events. Nothing announcement-specific is stored.
+ *
+ * The two halves are not equally trustworthy and the difference matters if this is ever used
+ * for more than showing a creator their own numbers: impressions arrive from the browser on
+ * an unauthenticated beacon, while mute events are written server-side from the mutation that
+ * performs the mute.
+ */
+export async function getAnnouncementMetrics(
+  userId: number,
+  announcementIds: number[]
+): Promise<AnnouncementMetrics> {
+  const [mutedNow, clickhouse] = await Promise.all([
+    countMutes(userId),
+    announcementClickhouse.get({ userId, ids: announcementIds.join(',') }),
+  ]);
+
+  return { ...clickhouse, mutedNow };
+}
+
+async function countMutes(userId: number): Promise<number> {
+  const row = await dbRead
+    .selectFrom('UserAnnouncementMute')
+    .where('creatorId', '=', userId)
+    .select(({ fn }) => fn.countAll<string>().as('count'))
+    .executeTakeFirst();
+
+  return Number(row?.count ?? 0);
+}
+
+async function readClickhouse(
+  userId: number,
+  idList: string
+): Promise<Omit<AnnouncementMetrics, 'mutedNow'>> {
+  const ch = getClickhouse();
+
+  const [impressionRows, clickRows, muteRows] = await Promise.all([
+    idList
+      ? ch.$query<{ id: number | string; impressions: number | string }>(
+          entityImpressionTotalsSql(IMPRESSION_ENTITY.announcement, idList)
+        )
+      : [],
+    idList
+      ? ch.$query<{ id: number | string; clicks: number | string }>(
+          // 🔴 `time >= …` is the only predicate that prunes. `actions` is ORDER BY (time, type),
+          // so a `type` filter alone reads every one of its 92.8M rows (measured: 11,157 of 11,157
+          // marks, ~900ms) and gets worse by ~215M rows a year. The floor is the day the feature
+          // shipped, and no row of these types can predate it.
+          `SELECT JSONExtractUInt(details, 'announcementId') AS id, count() AS clicks FROM actions
+           WHERE time >= toDate('${ANNOUNCEMENT_METRICS_SINCE}')
+             AND type = 'Announcement_Click'
+             AND JSONExtractUInt(details, 'creatorId') = ${userId}
+             AND id IN (${idList})
+           GROUP BY id`
+        )
+      : [],
+    ch.$query<{ date: string; muted: number | string; unmuted: number | string }>(
+      `SELECT toDate(time) AS date,
+              countIf(type = 'Announcement_Mute') AS muted,
+              countIf(type = 'Announcement_Unmute') AS unmuted
+       FROM actions
+       WHERE time >= toDate('${ANNOUNCEMENT_METRICS_SINCE}')
+         AND type IN ('Announcement_Mute', 'Announcement_Unmute')
+         AND JSONExtractUInt(details, 'creatorId') = ${userId}
+       GROUP BY date ORDER BY date`
+    ),
+  ]);
+
+  return {
+    impressions: Object.fromEntries(
+      impressionRows.map((r) => [Number(r.id), Number(r.impressions)])
+    ),
+    clicks: Object.fromEntries(clickRows.map((r) => [Number(r.id), Number(r.clicks)])),
+    muteSeries: muteRows.map((r) => ({
+      date: String(r.date),
+      muted: Number(r.muted),
+      unmuted: Number(r.unmuted),
+    })),
+  };
+}

--- a/apps/creator-studio/src/lib/server/view-entities.ts
+++ b/apps/creator-studio/src/lib/server/view-entities.ts
@@ -18,7 +18,15 @@ export const VIEW_ENTITY = {
 export const IMPRESSION_ENTITY = {
   image: 'Image',
   model: 'Model',
+  announcement: 'Announcement',
 } as const;
+
+// The arms of `impressions_daily_by_owner`. NOT every impression entity: that table is populated by an MV
+// with one arm per ownership source in ClickHouse, and only Image and Model have one. Announcement
+// impressions exist per-entity in `daily_impressions` and are read by id from the announcements page —
+// summing them here would add a column the MV never writes, so a creator-wide total would silently
+// under-report by however much it claimed to include.
+export const OWNER_IMPRESSION_ARMS = [IMPRESSION_ENTITY.image, IMPRESSION_ENTITY.model] as const;
 
 export type ViewEntity = (typeof VIEW_ENTITY)[keyof typeof VIEW_ENTITY];
 export type ImpressionEntity = (typeof IMPRESSION_ENTITY)[keyof typeof IMPRESSION_ENTITY];

--- a/apps/creator-studio/src/routes/(app)/announcements/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/announcements/+page.server.ts
@@ -8,6 +8,7 @@ import {
   saveAnnouncement,
 } from '$lib/server/announcements';
 import { announcementFormSchema, deleteAnnouncementSchema } from '$lib/server/announcements-schema';
+import { getAnnouncementMetrics } from '$lib/server/announcement-analytics';
 
 async function assertEnabled(locals: App.Locals) {
   if (!(await announcementsEnabled(locals.user))) error(404, 'Not found');
@@ -21,8 +22,17 @@ export const load: PageServerLoad = async ({ locals, request }) => {
     getMyAnnouncements(locals.user.id),
   ]);
 
+  // Runs after the list because the ids to ask ClickHouse about are the rows Postgres just
+  // returned. `null` on failure rather than a throw: these numbers decorate a page whose real
+  // job is composing and deleting announcements, and a ClickHouse outage must not take that away.
+  const metrics = await getAnnouncementMetrics(
+    locals.user.id,
+    announcements.map((a) => a.id)
+  ).catch(() => null);
+
   return {
     announcements,
+    metrics,
     allowance: allowance.ok ? allowance.data : null,
     allowanceError: allowance.ok ? null : allowance.error,
   };

--- a/apps/creator-studio/src/routes/(app)/announcements/+page.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/+page.svelte
@@ -3,6 +3,8 @@
   import AllowanceNotice from './AllowanceNotice.svelte';
   import AnnouncementComposer from './AnnouncementComposer.svelte';
   import AnnouncementList from './AnnouncementList.svelte';
+  import AnnouncementMetricsNotice from './AnnouncementMetricsNotice.svelte';
+  import MutesPanel from './MutesPanel.svelte';
   import type { AnnouncementRow } from '$lib/server/announcements';
   import type { ActionData, PageData } from './$types';
 
@@ -50,6 +52,8 @@
 
   <AllowanceNotice allowance={data.allowance} error={data.allowanceError} />
 
+  <AnnouncementMetricsNotice unavailable={data.metrics === null} />
+
   {#if open}
     {#key editingId ?? 'new'}
       <AnnouncementComposer
@@ -61,8 +65,13 @@
     {/key}
   {/if}
 
+  {#if data.metrics}
+    <MutesPanel mutedNow={data.metrics.mutedNow} series={data.metrics.muteSeries} />
+  {/if}
+
   <AnnouncementList
     announcements={data.announcements}
+    metrics={data.metrics}
     deleteError={form?.scope === 'delete'
       ? { id: form.subject ?? null, message: form.error ?? '' }
       : null}

--- a/apps/creator-studio/src/routes/(app)/announcements/AnnouncementList.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/AnnouncementList.svelte
@@ -6,13 +6,17 @@
   import EdgeImage from '$lib/components/EdgeImage.svelte';
   import { DOMAIN_LABELS, type AnnouncementDomain } from '$lib/announcements';
   import type { AnnouncementRow } from '$lib/server/announcements';
+  import type { AnnouncementMetrics } from '$lib/server/announcement-analytics';
 
   let {
     announcements,
+    metrics,
     deleteError = null,
     onEdit,
   }: {
     announcements: AnnouncementRow[];
+    /** Null when the metrics read failed — rows then say so rather than showing a zero. */
+    metrics: AnnouncementMetrics | null;
     /** Carries the row it belongs to, so a failure renders beside that row and nowhere else. */
     deleteError?: { id: number | null; message: string } | null;
     onEdit: (announcement: AnnouncementRow) => void;
@@ -20,6 +24,11 @@
 
   let confirmingId = $state<number | null>(null);
   let deletingId = $state<number | null>(null);
+
+  const seen = (id: number) => metrics?.impressions[id] ?? 0;
+  const clicked = (id: number) => metrics?.clicks[id] ?? 0;
+
+  const num = (value: number) => value.toLocaleString();
 
   const formatDate = (value: Date | string) =>
     new Date(value).toLocaleDateString(undefined, {
@@ -95,6 +104,22 @@
             Posted {formatDate(announcement.createdAt)}
             {#if announcement.endsAt}· ends {formatDate(announcement.endsAt)}{/if}
           </p>
+          {#if metrics}
+            {@const impressions = seen(announcement.id)}
+            {@const clicks = clicked(announcement.id)}
+            <p class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-dark-2">
+              <span><span class="font-medium text-white">{num(impressions)}</span> seen</span>
+              {#if announcement.link}
+                <!-- Clicks are raw presses and "seen" is deduplicated people, so the two are
+                     deliberately not divided into a rate: the units differ and one person
+                     clicking twice would read as 200%. -->
+                <span
+                  ><span class="font-medium text-white">{num(clicks)}</span>
+                  link {clicks === 1 ? 'click' : 'clicks'}</span
+                >
+              {/if}
+            </p>
+          {/if}
         </div>
         <div class="flex shrink-0 flex-col items-end gap-2">
           <Button variant="outline" size="sm" onclick={() => onEdit(announcement)}>Edit</Button>

--- a/apps/creator-studio/src/routes/(app)/announcements/AnnouncementMetricsNotice.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/AnnouncementMetricsNotice.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { IconAlertTriangle, IconLayoutGrid } from '@tabler/icons-svelte';
+  import Notice from '$lib/components/Notice.svelte';
+  import { ANNOUNCEMENT_METRICS_SINCE_LABEL } from '$lib/impressions';
+
+  let { unavailable = false }: { unavailable?: boolean } = $props();
+</script>
+
+<div class="flex flex-col gap-2">
+  {#if unavailable}
+    <Notice icon={IconAlertTriangle}>
+      <strong class="font-medium text-white">Your numbers could not be loaded.</strong> Everything else
+      on this page still works. Reload in a minute — this is not a report that nobody saw your announcements.
+    </Notice>
+  {:else}
+    <Notice icon={IconLayoutGrid}>
+      <strong class="font-medium text-white">Seen counts people, not opens.</strong> An announcement
+      is counted once per person per visit, once it has been at least half on screen for a full
+      second. Counting started on {ANNOUNCEMENT_METRICS_SINCE_LABEL}, so anything you posted before
+      that has nothing recorded.
+    </Notice>
+  {/if}
+</div>

--- a/apps/creator-studio/src/routes/(app)/announcements/MutesPanel.svelte
+++ b/apps/creator-studio/src/routes/(app)/announcements/MutesPanel.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { Chart, chartColor } from '@civitai/ui/components/ui/chart/index.js';
+  import { ANNOUNCEMENT_METRICS_SINCE_LABEL } from '$lib/impressions';
+  import type { MutePoint } from '$lib/server/announcement-analytics';
+
+  let { mutedNow, series }: { mutedNow: number; series: MutePoint[] } = $props();
+
+  const num = (n: number) => n.toLocaleString();
+  const mmdd = (d: string) => (d.length >= 10 ? d.slice(5, 10) : d);
+
+  // Muting is per creator, not per announcement — a reader muting you stops seeing all of them —
+  // so this is one panel about the whole feed rather than a column on a row.
+  const chart = $derived({
+    labels: series.map((p) => mmdd(p.date)),
+    datasets: [
+      {
+        label: 'Muted',
+        data: series.map((p) => p.muted),
+        borderColor: chartColor(0),
+        backgroundColor: chartColor(0),
+      },
+      {
+        label: 'Unmuted',
+        data: series.map((p) => p.unmuted),
+        borderColor: chartColor(1),
+        backgroundColor: chartColor(1),
+      },
+    ],
+  });
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: { legend: { display: true } },
+    interaction: { mode: 'index' as const, intersect: false },
+    scales: {
+      x: { ticks: { maxTicksLimit: 8, autoSkip: true, maxRotation: 0, align: 'inner' as const } },
+      y: { beginAtZero: true, ticks: { precision: 0 } },
+    },
+  };
+</script>
+
+<div class="cs-panel p-4">
+  <div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+    <p class="text-sm font-medium text-white">
+      {num(mutedNow)}
+      {mutedNow === 1 ? 'person has' : 'people have'} muted your announcements
+    </p>
+    <p class="text-xs text-dark-2">They still see your profile, just not these.</p>
+  </div>
+
+  {#if series.length > 0}
+    <div class="h-48">
+      <!-- Bars, not a line: mutes are daily counts, and a line through a single day renders as an
+           invisible point — which is the state every creator is in for the first day. -->
+      <Chart type="bar" data={chart} {options} class="h-full" />
+    </div>
+  {:else}
+    <!-- An empty series and a quiet week look identical on a chart, and this one is empty for
+         everyone until the first mute lands after the ship date. Say which it is. -->
+    <p class="text-xs text-dark-2">
+      Nothing to chart yet — mutes and unmutes have been recorded since {ANNOUNCEMENT_METRICS_SINCE_LABEL},
+      and none have happened since.
+    </p>
+  {/if}
+</div>

--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -9,6 +9,8 @@ import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { TwCard } from '~/components/TwCard/TwCard';
+import { useTrackImpression } from '~/components/TrackView/useTrackImpression';
+import type { ImpressionTarget } from '~/components/TrackView/useTrackImpression';
 
 export type AnnouncementCardAction = {
   link: string;
@@ -39,6 +41,39 @@ export type AnnouncementCardCover =
       height?: number | null;
     };
 
+type AnnouncementCardProps = {
+  title?: string;
+  content: string;
+  color: string;
+  cover?: AnnouncementCardCover | null;
+  actions?: AnnouncementCardAction[];
+  /**
+   * Notified when one of `actions` is pressed, before the navigation. Analytics only, and
+   * deliberately a callback rather than tracking done here: this component renders sitewide
+   * and creator announcements alike, and only the creator ones are instrumented. Passing the
+   * decision to the call site is what keeps that boolean out of a component whose contract is
+   * layout.
+   */
+  onActionClick?: (action: AnnouncementCardAction, index: number) => void;
+  /**
+   * Entities this card should record an impression for once it has been half visible for a
+   * continuous second. Omitted by the sitewide surface, which is not instrumented — the hook
+   * disables itself on an empty list, so "creator only" is a property of who passes this.
+   */
+  impressions?: ImpressionTarget[];
+  /**
+   * A full-width bar across the top of the card, outside the cover/content row. Attribution
+   * for a card Civitai did not write goes here rather than beside the title: the frame is
+   * what a reader takes in before any of the card's own content.
+   */
+  topBar?: React.ReactNode;
+  /** Rendered beside the title — moderator or author controls. */
+  controls?: React.ReactNode;
+  /** Absolutely positioned over the card, e.g. the dismiss button. */
+  overlay?: React.ReactNode;
+  footer?: React.ReactNode;
+} & React.HTMLAttributes<HTMLDivElement>;
+
 /**
  * The one announcement card. Sitewide and creator announcements render through this so they
  * cannot drift apart visually — they had already drifted twice, on the cover breakpoint and
@@ -54,6 +89,8 @@ export function AnnouncementCard({
   color,
   cover,
   actions = [],
+  onActionClick,
+  impressions,
   topBar,
   controls,
   overlay,
@@ -61,24 +98,8 @@ export function AnnouncementCard({
   className,
   style,
   ...props
-}: {
-  title?: string;
-  content: string;
-  color: string;
-  cover?: AnnouncementCardCover | null;
-  actions?: AnnouncementCardAction[];
-  /**
-   * A full-width bar across the top of the card, outside the cover/content row. Attribution
-   * for a card Civitai did not write goes here rather than beside the title: the frame is
-   * what a reader takes in before any of the card's own content.
-   */
-  topBar?: React.ReactNode;
-  /** Rendered beside the title — moderator or author controls. */
-  controls?: React.ReactNode;
-  /** Absolutely positioned over the card, e.g. the dismiss button. */
-  overlay?: React.ReactNode;
-  footer?: React.ReactNode;
-} & React.HTMLAttributes<HTMLDivElement>) {
+}: AnnouncementCardProps) {
+  const impressionRef = useTrackImpression<HTMLElement>(impressions);
   const theme = useMantineTheme();
   const borderColor = theme.colors[color]?.[4] ?? theme.colors.blue[4];
 
@@ -149,6 +170,7 @@ export function AnnouncementCard({
                 key={index}
                 component={Link}
                 href={action.link}
+                onClick={() => onActionClick?.(action, index)}
                 variant={action.variant ? (action.variant as ButtonVariant) : 'outline'}
                 color={action.color ?? color}
               >
@@ -165,6 +187,7 @@ export function AnnouncementCard({
   if (!topBar)
     return (
       <TwCard
+        ref={impressionRef}
         className={clsx('items-stretch border', className)}
         direction="row"
         style={{ borderColor, ...style }}
@@ -177,6 +200,7 @@ export function AnnouncementCard({
 
   return (
     <TwCard
+      ref={impressionRef}
       className={clsx('border', className)}
       direction="col"
       style={{ borderColor, ...style }}

--- a/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.browser.test.tsx
@@ -84,6 +84,10 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
   const actual = await importOriginal<typeof Trpc>();
   const stubbed: Record<string, unknown> = {
     user: { getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) } },
+    // `CreatorAnnouncement` records analytics through `useTrackEvent`, which mounts the
+    // trackShare mutation whether or not a share ever happens. Absent here the Proxy below
+    // throws during render and every assertion in the file reads an empty body.
+    track: { trackShare: { useMutation: () => ({ mutateAsync: async () => undefined }) } },
   };
   return {
     ...actual,

--- a/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.browser.test.tsx
@@ -55,6 +55,10 @@ vi.mock('~/utils/trpc', async (importOriginal) => {
   const actual = await importOriginal<typeof Trpc>();
   const stubbed: Record<string, unknown> = {
     user: { getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) } },
+    // `CreatorAnnouncement` records analytics through `useTrackEvent`, which mounts the
+    // trackShare mutation whether or not a share ever happens. Absent here the Proxy below
+    // throws during render and every assertion in the file reads an empty body.
+    track: { trackShare: { useMutation: () => ({ mutateAsync: async () => undefined }) } },
   };
   return {
     ...actual,

--- a/src/components/Announcements/CreatorAnnouncement.tsx
+++ b/src/components/Announcements/CreatorAnnouncement.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@mantine/core';
 import React from 'react';
 import { AnnouncementCard } from '~/components/Announcements/AnnouncementCard';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import type { CreatorAnnouncement as CreatorAnnouncementModel } from '~/components/Announcements/creator-announcement.types';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
@@ -31,6 +32,16 @@ export function CreatorAnnouncement({
 } & React.HTMLAttributes<HTMLDivElement>) {
   const { cover, user } = announcement;
   const postedAt = announcement.startsAt ?? announcement.createdAt;
+  const { trackAction } = useTrackEvent();
+
+  // Only creator announcements are instrumented, and that is structural rather than a check:
+  // the sitewide surface renders `AnnouncementCard` directly and passes neither of these
+  // props, so there is no condition here for anyone to get wrong later.
+  //
+  // Null only for a platform row, which cannot reach this component; narrowed rather than
+  // asserted so a future caller that does pass one records nothing rather than a row keyed
+  // to nobody.
+  const creatorId = announcement.userId;
 
   // The backfill stores this title on migrated banners, so this fallback is for the case
   // it does not cover: a creator writing a body-only announcement. Same wording, so the two
@@ -57,6 +68,18 @@ export function CreatorAnnouncement({
           : null
       }
       actions={announcement.metadata?.actions ?? []}
+      impressions={[{ entityType: 'Announcement', entityId: announcement.id }]}
+      // `creatorId` rides along because the Creator Studio read is a ClickHouse query with
+      // no announcement table to join against.
+      onActionClick={
+        creatorId
+          ? () =>
+              trackAction({
+                type: 'Announcement_Click',
+                details: { announcementId: announcement.id, creatorId },
+              }).catch(() => undefined)
+          : undefined
+      }
       // With a top bar the controls belong up there beside the author, not indented into
       // the content; without one there is nowhere else for them to go.
       controls={withAuthor ? undefined : actions}

--- a/src/components/Announcements/announcement-tracking.browser.test.tsx
+++ b/src/components/Announcements/announcement-tracking.browser.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as CurrentUser from '~/hooks/useCurrentUser';
+import type * as IsClientProvider from '~/providers/IsClientProvider';
+import type * as FeatureFlagsProvider from '~/providers/FeatureFlagsProvider';
+import type * as BrowserSettingsProvider from '~/providers/BrowserSettingsProvider';
+import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import type * as Trpc from '~/utils/trpc';
+import type * as TrackUtils from '~/components/TrackView/track.utils';
+import type * as UseTrackImpression from '~/components/TrackView/useTrackImpression';
+
+/**
+ * Announcement analytics is CREATOR-ONLY, and the sitewide rows render through the same
+ * `AnnouncementCard`. So the assertion that carries this feature is the NEGATIVE one: a
+ * platform announcement must record nothing. A test that only checks the creator card emits
+ * passes just as happily on an unconditional hook that instruments all 317 platform rows.
+ */
+
+const trackAction = vi.fn(() => Promise.resolve());
+const trackImpression = vi.fn();
+// The ref the fake hands back, kept so a test can assert it reached a DOM node. Asserting the
+// hook's ARGUMENT alone would stay green if the card stopped attaching the ref, which records
+// nothing forever — the real hook only ever observes `ref.current`.
+let impressionRef: { current: HTMLElement | null } = { current: null };
+
+vi.mock('~/components/TrackView/track.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrackUtils>()),
+  useTrackEvent: () => ({ trackAction, trackSearch: vi.fn(), trackShare: vi.fn() }),
+}));
+
+// Spied rather than left real: the real hook needs an IntersectionObserver to fire and a
+// second of dwell, so asserting on it would be asserting on the observer's timing. What is
+// under test here is WHICH entities each surface registers, which is this argument.
+vi.mock('~/components/TrackView/useTrackImpression', async (importOriginal) => ({
+  ...(await importOriginal<typeof UseTrackImpression>()),
+  useTrackImpression: (targets: unknown) => {
+    trackImpression(targets);
+    return impressionRef;
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', async (importOriginal) => ({
+  ...(await importOriginal<typeof CurrentUser>()),
+  useCurrentUser: () => ({ id: 1, isModerator: false }),
+}));
+
+vi.mock('~/providers/IsClientProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof IsClientProvider>()),
+  useIsClient: () => true,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlagsProvider>()),
+  useFeatureFlags: () => ({ canViewNsfw: false, feedImpressions: true }),
+}));
+
+vi.mock('~/providers/BrowserSettingsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowserSettingsProvider>()),
+  useBrowsingSettings: () => false,
+}));
+
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof BrowsingLevelProvider>()),
+  useViewerBrowsingLevelDebounced: () => 1,
+}));
+
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof Trpc>();
+  const stubbed: Record<string, unknown> = {
+    user: { getById: { useQuery: () => ({ data: undefined, isInitialLoading: false }) } },
+  };
+  return {
+    ...actual,
+    trpc: new Proxy(stubbed, {
+      get(target, prop: string) {
+        if (Object.hasOwn(target, prop)) return target[prop];
+        throw new Error(`Unmocked tRPC router in a component test: trpc.${String(prop)}`);
+      },
+    }),
+  };
+});
+
+// A hash link, not a real path. Clicking a path navigates the test iframe, which kills the
+// run — and vitest reports that as `success: true` with the remaining tests "pending", so a
+// green summary would be hiding the two assertions this file exists for. A hash click still
+// dispatches the same event through the same handler without a reload.
+const action = { link: '#offer', linkText: 'Go look' };
+
+const creatorAnnouncement = {
+  id: 2,
+  title: 'Creator says hello',
+  content: 'new lora dropping',
+  color: 'blue',
+  emoji: null,
+  metadata: { actions: [action] },
+  startsAt: new Date(),
+  endsAt: null,
+  createdAt: new Date(),
+  userId: 99,
+  nsfwLevel: 1,
+  cover: null,
+  user: {
+    id: 99,
+    username: 'someone',
+    image: null,
+    deletedAt: null,
+    cosmetics: [],
+    profilePicture: null,
+  },
+} as any;
+
+const platformAnnouncement = {
+  id: 7,
+  title: 'Civitai says hello',
+  content: 'new lora dropping',
+  color: 'blue',
+  metadata: { actions: [action], type: 'site' },
+} as any;
+
+function resetSpies() {
+  trackImpression.mockClear();
+  trackAction.mockClear();
+  impressionRef = { current: null };
+}
+
+async function renderCreator(withAuthor = true) {
+  const { CreatorAnnouncement } = await import('~/components/Announcements/CreatorAnnouncement');
+  renderWithProviders(
+    <CreatorAnnouncement announcement={creatorAnnouncement} withAuthor={withAuthor} />
+  );
+  await expect.element(page.getByText('new lora dropping')).toBeInTheDocument();
+}
+
+async function renderPlatform() {
+  const { Announcement } = await import('~/components/Announcements/Announcement');
+  renderWithProviders(<Announcement announcement={platformAnnouncement} />);
+  await expect.element(page.getByText('new lora dropping')).toBeInTheDocument();
+}
+
+describe('announcement analytics is creator-only', () => {
+  test('a creator announcement registers itself for an impression, on a real element', async () => {
+    resetSpies();
+    await renderCreator();
+
+    expect(trackImpression).toHaveBeenCalledWith([{ entityType: 'Announcement', entityId: 2 }]);
+    // The ref has to LAND. Without this, deleting the card's `ref=` leaves every assertion
+    // above green while production records nothing at all.
+    expect(impressionRef.current).toBeInstanceOf(HTMLElement);
+  });
+
+  test('a creator announcement records a click on its link, once, naming both ids', async () => {
+    resetSpies();
+    await renderCreator();
+
+    await page.getByRole('link', { name: 'Go look' }).click();
+
+    expect(trackAction).toHaveBeenCalledWith({
+      type: 'Announcement_Click',
+      details: { announcementId: 2, creatorId: 99 },
+    });
+    // Count as well as shape: two handlers firing one event doubles a number a creator reads.
+    expect(trackAction).toHaveBeenCalledTimes(1);
+  });
+
+  // The card has TWO roots — `withAuthor` picks the stacked one, the profile carousel renders
+  // the other — and each attaches the ref itself. Asserting only the byline shape left the
+  // carousel's root free to lose its ref and record nothing, with every test still green.
+  test('the profile-carousel shape attaches the ref too', async () => {
+    resetSpies();
+    await renderCreator(false);
+
+    expect(trackImpression).toHaveBeenCalledWith([{ entityType: 'Announcement', entityId: 2 }]);
+    expect(impressionRef.current).toBeInstanceOf(HTMLElement);
+  });
+
+  // 🔴 The whole point. Remove the branch and this is the test that goes red.
+  test('a sitewide announcement records nothing — no impression, no click', async () => {
+    resetSpies();
+    await renderPlatform();
+
+    await page.getByRole('link', { name: 'Go look' }).click();
+
+    // The hook IS called by the shared card — with nothing to record, which is what disables
+    // it. So the assertion is on the entities, not on the call: a platform card must never
+    // register an entity.
+    expect(trackImpression.mock.calls.flatMap(([targets]) => targets ?? [])).toEqual([]);
+    expect(trackAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
@@ -52,7 +52,13 @@ describe('actions.type enum drift', () => {
     ),
   }));
 
-  const actionsBlock = enumBlocks.find((b) => b.table === 'default.actions');
+  // 🔴 The LAST block, not the first. `MODIFY COLUMN` replaces the definition, so once a
+  // second migration restates the column the newest file is the live one — reading the
+  // oldest checks a definition prod no longer has, and every value added after it reads as
+  // missing. Files are read in name order and these migrations are date-prefixed, so last
+  // is newest.
+  const actionsBlocks = enumBlocks.filter((b) => b.table === 'default.actions');
+  const actionsBlock = actionsBlocks[actionsBlocks.length - 1];
 
   // The prod indices this guard was written against (SHOW CREATE TABLE actions,
   // 2026-08-21). These predate the migrations directory, so no file here introduces them
@@ -101,13 +107,13 @@ describe('actions.type enum drift', () => {
       actionsBlock,
       'no MODIFY COLUMN on default.actions found in any migration'
     ).toBeDefined();
-    expect(actionsBlock!.arms.size).toBeGreaterThan(0);
+    expect(actionsBlock.arms.size).toBeGreaterThan(0);
   });
 
   it.each([...ActionType].filter((t) => !PRE_EXISTING.has(t)))(
     '%s is widened into the actions enum by a migration',
     (type) => {
-      expect([...actionsBlock!.arms.keys()]).toContain(type);
+      expect([...actionsBlock.arms.keys()]).toContain(type);
     }
   );
 
@@ -116,12 +122,12 @@ describe('actions.type enum drift', () => {
     // column, and a name given a different index silently remaps existing rows. The
     // migration's own header forbids both; this is what makes that enforceable.
     for (const [name, index] of PRE_EXISTING) {
-      expect(actionsBlock!.arms.get(name), `${name} missing from the restated enum`).toBe(index);
+      expect(actionsBlock.arms.get(name), `${name} missing from the restated enum`).toBe(index);
     }
   });
 
   it('assigns every value a distinct index', () => {
-    const indices = [...actionsBlock!.arms.values()];
+    const indices = [...actionsBlock.arms.values()];
     expect(new Set(indices).size).toBe(indices.length);
   });
 

--- a/src/server/clickhouse/migrations/2026-09-04-announcement-click-action.sql
+++ b/src/server/clickhouse/migrations/2026-09-04-announcement-click-action.sql
@@ -1,0 +1,66 @@
+-- Creator announcement analytics — ClickHouse DDL (link clicks + mute/unmute).
+--
+-- Apply this MANUALLY, BEFORE the app code that emits `Announcement_Click` is deployed. We do
+-- not auto-run DDL (same policy as the Postgres migrations).
+--
+-- 🔴 ORDER IS LOAD-BEARING AND THE FAILURE IS SILENT. `actions.type` is an Enum16. The app
+-- POSTs to the tracker service, which inserts; a value the column does not carry is rejected
+-- THERE, so the browser sees a successful beacon, the app logs nothing, and the row simply
+-- never exists. The click half of the creator's analytics page would then read a permanent
+-- zero that is indistinguishable from "nobody clicked".
+--
+-- 22 is the last index in use ('Feed_TagBar_Click'), so these append at 23-25. Appending at an
+-- unused index is a metadata-only ALTER: no data is rewritten and no mutation is scheduled. Do
+-- NOT renumber or rename any existing value; that WOULD rewrite the whole table.
+--
+-- `actions` still has no dependent materialized view (re-verified 2026-09-04 against
+-- `system.tables`), and this change deliberately does not add one: an MV over `actions` would
+-- put a MODIFY QUERY obligation on every future widening of this column, and the read this
+-- feeds does not need it. `actions` is 92.8M rows all-time / 590,896 in the last day, ordered
+-- (time, type), and the per-creator read filters on `type` over ~100 announcements site-wide.
+
+ALTER TABLE default.actions
+  MODIFY COLUMN `type` Enum16(
+    'AddToBounty_Click' = 1,
+    'AddToBounty_Confirm' = 2,
+    'AwardBounty_Click' = 3,
+    'AwardBounty_Confirm' = 4,
+    'Tip_Click' = 5,
+    'Tip_Confirm' = 6,
+    'TipInteractive_Click' = 7,
+    'TipInteractive_Cancel' = 8,
+    'NotEnoughFunds' = 9,
+    'PurchaseFunds_Cancel' = 10,
+    'PurchaseFunds_Confirm' = 11,
+    'LoginRedirect' = 12,
+    'Membership_Cancel' = 13,
+    'CSAM_Help_Triggered' = 14,
+    'Membership_Downgrade' = 15,
+    'ProfanitySearch' = 16,
+    'BuzzLimit_Set' = 17,
+    'Model_Create_Click' = 18,
+    'Image_Remix_Click' = 19,
+    'Generator_Submit' = 20,
+    'Generator_JobLinked' = 21,
+    'Feed_TagBar_Click' = 22,
+    'Announcement_Click' = 23,
+    'Announcement_Mute' = 24,
+    'Announcement_Unmute' = 25
+  );
+
+-- Verify the value landed before deploying. This must return 1 row:
+--
+--   SELECT 1 FROM system.columns
+--   WHERE database = 'default' AND table = 'actions' AND name = 'type'
+--     AND position(type, 'Announcement_Click') > 0
+--     AND position(type, 'Announcement_Mute') > 0
+--     AND position(type, 'Announcement_Unmute') > 0;
+--
+-- 🔴 And after the deploy, check that rows arrive with a CONTROL that can fail. A bare count of
+-- the new type returns 0 both when the ALTER never ran and when nobody has clicked yet — the
+-- same observation, two different causes. Pair it with a type that is known to be flowing, over
+-- the same window, so a zero on BOTH means "the window is empty" rather than "this is broken":
+--
+--   SELECT countIf(type = 'Announcement_Click') AS announcement,
+--          countIf(type = 'Generator_Submit')   AS control
+--   FROM actions WHERE time > now() - INTERVAL 1 HOUR;

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -170,6 +170,13 @@ export const ActionType = [
   // (src/server/clickhouse/migrations/2026-08-21-feed-tag-bar-action.sql) must be
   // applied to prod BEFORE this deploys, or the bar ships blind.
   'Feed_TagBar_Click',
+  // Creator announcement analytics. Same Enum16 hazard as the line above: the widening
+  // migration (src/server/clickhouse/migrations/2026-09-04-announcement-click-action.sql)
+  // must be applied to prod BEFORE this deploys, or the Creator Studio page reads a
+  // permanent zero that looks exactly like "nobody clicked".
+  'Announcement_Click',
+  'Announcement_Mute',
+  'Announcement_Unmute',
 ] as const;
 export type ActionType = (typeof ActionType)[number];
 
@@ -591,13 +598,21 @@ export class Tracker {
     });
   }
 
-  public action(values: { type: ActionType; details?: any }) {
+  // `skipActorMeta` drops `ip` and `userAgent`, keeping only `userId`. Reach for it when the
+  // event records a private judgement rather than an interaction: `actions` has no TTL, so a
+  // row outlives the state that produced it and an IP-stamped record of who disliked whom is
+  // not what a reversible, private product control should leave behind.
+  public action(values: { type: ActionType; details?: any }, options?: { skipActorMeta: boolean }) {
     const { details, ...rest } = values;
-    return this.track('actions', {
-      ...rest,
-      details:
-        details != null ? (typeof details === 'string' ? details : JSON.stringify(details)) : '',
-    });
+    return this.track(
+      'actions',
+      {
+        ...rest,
+        details:
+          details != null ? (typeof details === 'string' ? details : JSON.stringify(details)) : '',
+      },
+      options
+    );
   }
 
   public activity(activity: string) {

--- a/src/server/routers/__tests__/announcement.router.mute-tracking.test.ts
+++ b/src/server/routers/__tests__/announcement.router.mute-tracking.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The gate that decides whether a mute is RECORDED, which is a different layer from the
+ * service flag it reads. `toggleAnnouncementMute` returning `changed` correctly is tested
+ * beside the service; nothing tested the consumer, so deleting `if (result.changed)` — or
+ * swapping the two event types — printed nothing anywhere.
+ *
+ * These events are the only record of a mute over time (an unmute deletes the Postgres row),
+ * so both mistakes corrupt a creator's chart rather than merely losing a sample.
+ */
+
+import type * as MiddlewareTrpc from '~/server/middleware.trpc';
+import type * as FeatureFlags from '~/server/services/feature-flags.service';
+
+const { mockToggle } = vi.hoisted(() => ({ mockToggle: vi.fn() }));
+
+vi.mock('~/server/services/creator-announcement.service', () => ({
+  toggleAnnouncementMute: (...args: unknown[]) => mockToggle(...args),
+}));
+// The router imports the whole announcement surface; the rest of it is not under test and
+// pulls in Prisma, Redis and the image services on import.
+vi.mock('~/server/services/announcement.service', () => ({}));
+// Only `rateLimit` is stubbed, and only because it reaches Redis. The flag gate is left REAL
+// and satisfied through `ctx.features` below, so this exercises the procedure a browser gets.
+// Spread rather than hand-listed: naming exports couples the file to the router's whole
+// import graph, and a missing one fails at LOAD — which reports as zero tests collected.
+// The flag gate reads `getFeatureFlags(ctx)`, not `ctx.features`, and that resolves through
+// Flipt. Turned on here so the test exercises the enabled procedure rather than the refusal.
+vi.mock('~/server/services/feature-flags.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof FeatureFlags>()),
+  getFeatureFlags: () => ({ creatorAnnouncements: true }),
+}));
+vi.mock('~/server/middleware.trpc', async (importOriginal) => {
+  const { middleware } = await import('~/server/trpc');
+  return {
+    ...(await importOriginal<typeof MiddlewareTrpc>()),
+    rateLimit: () => middleware(async ({ next }) => next()),
+  };
+});
+
+import { announcementRouter } from '../announcement.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+// Returns a promise because the router attaches `.catch` — a bare `vi.fn()` makes every case
+// fail on the tracker call rather than on the assertion.
+const action = vi.fn(() => Promise.resolve(true));
+
+function callerFor(userId: number) {
+  return announcementRouter.createCaller({
+    user: { id: userId, isModerator: false, tier: 'free', username: 'muter' },
+    // `publicProcedure` refuses a caller without this and points at the public API instead,
+    // so every case below would fail UNAUTHORIZED before reaching the mutation.
+    acceptableOrigin: true,
+    // A browser session, which is what performs a mute: full scope, no api key.
+    tokenScope: TokenScope.Full,
+    apiKeyId: null,
+    req: { headers: {} },
+    res: { setHeader: () => undefined },
+    cache: { edgeTTL: 0 },
+    features: { creatorAnnouncements: true },
+    track: { action },
+  } as never);
+}
+
+beforeEach(() => {
+  action.mockClear();
+  mockToggle.mockReset();
+});
+
+describe('announcement.toggleAnnouncementMute — what reaches ClickHouse', () => {
+  it('records a mute that actually changed the row, once', async () => {
+    mockToggle.mockResolvedValue({ muted: true, changed: true });
+
+    await callerFor(7).toggleAnnouncementMute({ creatorId: 99, muted: true });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledWith(
+      { type: 'Announcement_Mute', details: { creatorId: 99 } },
+      // Without this the row keeps the muter's ip and userAgent forever, in a table with no
+      // TTL, for an action the product presents as reversible and private.
+      { skipActorMeta: true }
+    );
+  });
+
+  it('records an unmute as an unmute — not the type of the state it left', async () => {
+    mockToggle.mockResolvedValue({ muted: false, changed: true });
+
+    await callerFor(7).toggleAnnouncementMute({ creatorId: 99, muted: false });
+
+    expect(action).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'Announcement_Unmute' }),
+      expect.anything()
+    );
+  });
+
+  it('records NOTHING when the toggle changed nothing', async () => {
+    mockToggle.mockResolvedValue({ muted: true, changed: false });
+
+    await callerFor(7).toggleAnnouncementMute({ creatorId: 99, muted: true });
+
+    expect(action).toHaveBeenCalledTimes(0);
+  });
+
+  it('still returns the service result to the caller', async () => {
+    mockToggle.mockResolvedValue({ muted: true, changed: false });
+
+    await expect(
+      callerFor(7).toggleAnnouncementMute({ creatorId: 99, muted: true })
+    ).resolves.toEqual({ muted: true, changed: false });
+  });
+});

--- a/src/server/routers/announcement.router.ts
+++ b/src/server/routers/announcement.router.ts
@@ -110,5 +110,25 @@ export const announcementRouter = router({
   toggleAnnouncementMute: protectedProcedure
     .use(isFlagProtected('creatorAnnouncements'))
     .input(z.object({ creatorId: z.number(), muted: z.boolean() }))
-    .mutation(({ ctx, input }) => toggleAnnouncementMute({ ...input, userId: ctx.user.id })),
+    .mutation(async ({ ctx, input }) => {
+      const result = await toggleAnnouncementMute({ ...input, userId: ctx.user.id });
+      // Recorded here rather than in the service because the tracker lives on the request
+      // context. Server-side on purpose: unlike the impression beacon, which authenticates
+      // nothing, this count cannot be inflated by anything but a real signed-in mutation.
+      if (result.changed)
+        ctx.track
+          .action(
+            {
+              type: result.muted ? 'Announcement_Mute' : 'Announcement_Unmute',
+              details: { creatorId: input.creatorId },
+            },
+            // No `ip`/`userAgent`. Unmuting removes the Postgres row, but `actions` has no
+            // TTL, so without this a reversible, private control leaves a permanent
+            // IP-stamped record of who muted whom. The chart needs a count per day; it does
+            // not need an actor.
+            { skipActorMeta: true }
+          )
+          .catch(() => undefined);
+      return result;
+    }),
 });

--- a/src/server/schema/__tests__/announcement-tracking.test.ts
+++ b/src/server/schema/__tests__/announcement-tracking.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IMPRESSION_ENTITY_TYPES,
+  trackActionSchema,
+  trackImpressionSchema,
+} from '~/server/schema/track.schema';
+import { ActionType } from '~/server/clickhouse/tracker';
+
+describe('announcement analytics wiring', () => {
+  it('accepts an Announcement impression', () => {
+    expect(IMPRESSION_ENTITY_TYPES).toContain('Announcement');
+    const parsed = trackImpressionSchema.safeParse({
+      sessionKey: 'abc',
+      surface: 'user',
+      entities: [{ entityType: 'Announcement', entityId: 1 }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a click naming both ids', () => {
+    expect(
+      trackActionSchema.safeParse({
+        type: 'Announcement_Click',
+        details: { announcementId: 1, creatorId: 2 },
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a click that names no announcement', () => {
+    expect(
+      trackActionSchema.safeParse({ type: 'Announcement_Click', details: { creatorId: 2 } }).success
+    ).toBe(false);
+  });
+
+  // 🔴 The mute counts are the half of this feature that cannot be forged, and this is what
+  // makes that true: `trackActionSchema` is what `/api/track/batch` accepts from a browser,
+  // so an arm for these types would let anyone post mute events for any creator. They are
+  // still `ActionType`s — the tracker writes them — they are just not client-postable.
+  // `BuzzLimit_Set` is the existing server-only precedent.
+  it.each(['Announcement_Mute', 'Announcement_Unmute'] as const)(
+    '%s is writable by the server but NOT postable by a client',
+    (type) => {
+      expect(ActionType).toContain(type);
+      expect(trackActionSchema.safeParse({ type, details: { creatorId: 2 } }).success).toBe(false);
+    }
+  );
+});

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -646,6 +646,38 @@ const feedTagBarClickSchema = z.object({
   }),
 });
 
+// Creator announcement analytics — the click half. The impression half rides the feed
+// impression pipeline (`entityType: 'Announcement'`) and writes no `actions` row.
+//
+// `creatorId` is carried even though it is derivable from `announcementId` in Postgres:
+// the Creator Studio read is a ClickHouse query and would otherwise need a join it has no
+// table for. Both are ids, so neither can carry user text into the `details` column.
+const announcementClickSchema = z.object({
+  type: z.literal('Announcement_Click'),
+  details: z.object({
+    announcementId: z.number().int().positive(),
+    creatorId: z.number().int().positive(),
+  }),
+});
+
+// Mute and unmute of a creator's announcements. Two types rather than one carrying a
+// boolean: the chart is `countIf(type = ...)` per day with no JSON parsing of `details`,
+// and a net line is the difference of the two.
+//
+// 🔴 DELIBERATELY ABSENT FROM `trackActionSchema`. That schema is what `/api/track/batch`
+// accepts from a browser, so an arm here would let anyone post mute events for any creator
+// — which is the opposite of the property these two types exist to have. They are emitted
+// only from the tRPC mutation that performs the mute. `BuzzLimit_Set` is the existing
+// precedent for a server-only action type with no client arm.
+//
+// 🔴 THESE ARE THE ONLY RECORD OF A MUTE OVER TIME. `UserAnnouncementMute` is the live
+// truth for "how many people have me muted right now", but an unmute DELETES the row, so
+// a chart built from its `createdAt` shows only mutes that are still in force — a past
+// day's bar shrinks as people unmute, and a mute-then-unmute never happened at all. These
+// events are what make the series honest, so they must be emitted on BOTH edges.
+//
+// Emitted SERVER-SIDE from the tRPC mutation, not from the browser: unlike the impression
+// beacon this number cannot be inflated by a script posting to /api/track/batch.
 export const TRACK_BATCH_MAX = 100;
 
 export type TrackActionInput = z.infer<typeof trackActionSchema>;
@@ -670,6 +702,7 @@ export const trackActionSchema = z.discriminatedUnion('type', [
   imageRemixClickSchema,
   generatorSubmitSchema,
   feedTagBarClickSchema,
+  announcementClickSchema,
 ]);
 
 // Feed impression event — an entity was actually SEEN in a feed, as opposed to
@@ -696,6 +729,10 @@ export const IMPRESSION_ENTITY_TYPES = [
   'Bounty',
   'BountyEntry',
   'User',
+  // Creator announcements only. The sitewide rows render through the same card but are
+  // not instrumented — nobody reads a reach number for those, and they would sit in the
+  // same rollup a creator's page sums.
+  'Announcement',
 ] as const;
 export type ImpressionEntityType = (typeof IMPRESSION_ENTITY_TYPES)[number];
 

--- a/src/server/services/__tests__/announcement-mute-change.test.ts
+++ b/src/server/services/__tests__/announcement-mute-change.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { dbMock } from '~/__tests__/mocks/db.mock';
+import { toggleAnnouncementMute } from '../creator-announcement.service';
+
+const MUTER = 7;
+const CREATOR = 99;
+
+/**
+ * `changed` is what gates the analytics event, so it has to mean "this call moved the row"
+ * and not "this call ran". A client re-sending the state it is already in — a double tap, a
+ * retry, a stale toggle — must record nothing, or one muter becomes several mutes on the
+ * creator's chart.
+ */
+describe('toggleAnnouncementMute reports whether it changed anything', () => {
+  beforeEach(() => {
+    // History as well as behaviour: the self-mute case asserts the write was NOT reached, and
+    // calls from the tests above would satisfy that assertion on their own.
+    dbMock.dbWrite.userAnnouncementMute.createMany.mockClear();
+    dbMock.dbWrite.userAnnouncementMute.deleteMany.mockClear();
+    dbMock.dbWrite.userAnnouncementMute.createMany.mockResolvedValue({ count: 0 });
+    dbMock.dbWrite.userAnnouncementMute.deleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('a first mute writes a row and reports the change', async () => {
+    dbMock.dbWrite.userAnnouncementMute.createMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      toggleAnnouncementMute({ userId: MUTER, creatorId: CREATOR, muted: true })
+    ).resolves.toEqual({ muted: true, changed: true });
+
+    // The write is `skipDuplicates`, not a read-then-create: two concurrent mutes must not
+    // both come back believing they were first.
+    expect(dbMock.dbWrite.userAnnouncementMute.createMany).toHaveBeenCalledWith({
+      data: { userId: MUTER, creatorId: CREATOR },
+      skipDuplicates: true,
+    });
+  });
+
+  it('muting again writes nothing and reports no change', async () => {
+    dbMock.dbWrite.userAnnouncementMute.createMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      toggleAnnouncementMute({ userId: MUTER, creatorId: CREATOR, muted: true })
+    ).resolves.toEqual({ muted: true, changed: false });
+  });
+
+  it('an unmute that removed a row reports the change', async () => {
+    dbMock.dbWrite.userAnnouncementMute.deleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      toggleAnnouncementMute({ userId: MUTER, creatorId: CREATOR, muted: false })
+    ).resolves.toEqual({ muted: false, changed: true });
+    expect(dbMock.dbWrite.userAnnouncementMute.deleteMany).toHaveBeenCalledWith({
+      where: { userId: MUTER, creatorId: CREATOR },
+    });
+  });
+
+  it('unmuting when nothing was muted reports no change', async () => {
+    await expect(
+      toggleAnnouncementMute({ userId: MUTER, creatorId: CREATOR, muted: false })
+    ).resolves.toEqual({ muted: false, changed: false });
+  });
+
+  it('refuses to let someone mute themselves, before any write', async () => {
+    await expect(
+      toggleAnnouncementMute({ userId: CREATOR, creatorId: CREATOR, muted: true })
+    ).rejects.toThrow(/mute yourself/i);
+    expect(dbMock.dbWrite.userAnnouncementMute.createMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/creator-announcement.service.ts
+++ b/src/server/services/creator-announcement.service.ts
@@ -523,17 +523,28 @@ export async function toggleAnnouncementMute({
 }) {
   if (userId === creatorId) throw throwBadRequestError('You cannot mute yourself');
 
+  // `changed` says whether this call moved the row, and the caller records an analytics
+  // event only when it did. Without it a client that re-sends the state it is already in
+  // — a double-tap, a retry, a stale toggle — writes a second mute event for one muter,
+  // and the creator's chart counts people who never changed their mind.
+  //
+  // `createMany` with `skipDuplicates` rather than a read-then-create: it reports whether
+  // a row appeared, and two concurrent mutes cannot both believe they were first.
+  let changed: boolean;
   if (muted) {
-    await dbWrite.userAnnouncementMute.upsert({
-      where: { userId_creatorId: { userId, creatorId } },
-      create: { userId, creatorId },
-      update: {},
+    const { count } = await dbWrite.userAnnouncementMute.createMany({
+      data: { userId, creatorId },
+      skipDuplicates: true,
     });
+    changed = count > 0;
   } else {
-    await dbWrite.userAnnouncementMute.deleteMany({ where: { userId, creatorId } });
+    const { count } = await dbWrite.userAnnouncementMute.deleteMany({
+      where: { userId, creatorId },
+    });
+    changed = count > 0;
   }
 
-  return { muted };
+  return { muted, changed };
 }
 
 export async function isAnnouncementCreatorMuted({


### PR DESCRIPTION
Closes the ask in ClickUp `868m1qatq`, which came from SubtleShader in Justin's DMs: *"a statistics page that shows how many people saw each announcement and how many clicked the link."* Justin added mutes.

## What a creator sees

On the Creator Studio announcements page they already have: **seen** and **link clicks** per announcement, and a panel for **how many people mute their announcements**, with a daily mute/unmute chart.

## 🔴 The ClickHouse migration must be applied BEFORE this deploys

`src/server/clickhouse/migrations/2026-09-04-announcement-click-action.sql` widens the `actions.type` Enum16 with three values at unused indices 23/24/25 (metadata-only). **Already applied to prod** (2026-09-04, approved on a card).

That covers the deployed environments: dev and preview write to the **same** cloud ClickHouse instance as production. What is not covered is a **local docker ClickHouse** a developer runs — per machine, not a deploy step.

Order is load-bearing and the failure is silent: the app POSTs to the tracker service, which rejects a value the column does not carry, so the browser sees a successful beacon, nothing logs, and the row never exists — the page then reads a permanent zero indistinguishable from "nobody clicked".

The landed-check in that file pairs the count with a control query for exactly that reason. **Before the deploy, zero rows of these types is the correct answer**, not a symptom.

## What this reuses rather than builds

The audit came first, and most of the work was deciding *not* to build things:

- **Impressions ride the existing feed pipeline** — `useTrackImpression` (50% visible, 1s continuous dwell, once per browser tab) into `/api/track/batch`, `impressions`, `daily_impressions`. `impressions.entityType` is `LowCardinality(String)` rather than an Enum precisely so a new entity type is a code change, so **adding `Announcement` needed no ClickHouse DDL at all**.
- **Clicks and mutes go into `actions`**, the existing action table. No new table, and deliberately **no materialized view over `actions`** — an MV there would put a `MODIFY QUERY` obligation on every future widening of that column, and the read does not need it.
- **The read side** uses the Studio's existing per-entity impressions query, now shared as `entityImpressionTotalsSql` in `analytics-sql.ts` instead of a second copy.
- **The historical list already existed** (`getMyAnnouncements`). The ticket said it did not; this PR only hangs numbers off it. Note its `.limit(50)` silently bounds "historically".

## Creator-only is structural, not a condition

Sitewide and creator announcements render through the same `AnnouncementCard`. Rather than adding a boolean there, the instrumentation lives in `CreatorAnnouncement`, which only creator rows reach, and the card takes the repo's existing `impressions?: ImpressionTarget[]` prop (as `FeedCard` and `AspectRatioCard` do). There is no flag for a future edit to get wrong — and the browser test still asserts the negative case, with a mutant that moves the hook into the shared card to prove it discriminates.

## Mutes: a live count plus an event stream, and why not just a COUNT

`UserAnnouncementMute` is the live truth and is free to read. But **an unmute hard-deletes the row**, so a chart built from `createdAt` shows only mutes still in force: a past day's bar shrinks as people unmute, and mute-then-unmute never happened. The count is therefore Postgres; the *history* is `Announcement_Mute` / `Announcement_Unmute` events, emitted on both edges.

The chart was added on the intent review's finding — it scored the count alone as NOT meeting Justin's ask, and correctly pointed out that the original rationale (unmute deletes the row) argues against charting Postgres while this same PR builds the thing that makes charting honest. It is labelled as counting from the ship date, because a series that starts empty only reads honestly if you can tell that from "nobody muted me".

Mutes are **per creator, not per announcement**, so they are one panel rather than a column.

## Not all of these numbers are equally trustworthy

`/api/track/batch` authenticates nothing beyond an origin check, so **impressions can be fabricated by a script**, including against another creator's announcement id (`daily_impressions` has no owner column to key the read on, unlike the click read, which checks `creatorId`). That is acceptable for a reach statistic shown to its own creator. **It must not become an input to payouts, ranking, or anything competitive** without a rate-limited, authenticated path first.

The **mute counts do not share that weakness** — they are written server-side from the tRPC mutation that performs the mute.

## Privacy: mute events carry no actor metadata

`ctx.track.action` gained a `skipActorMeta` option and the mute events use it. Without it each row would carry `userId`, `ip` and `userAgent` into a table with **no TTL** — so unmuting would delete the Postgres row while leaving a permanent, per-user, IP-stamped record of who muted whom, for a control the product presents as reversible and private. The chart needs a count per day, not an actor.

## No click-through rate, deliberately

An earlier revision showed one. It was removed: impressions are deduplicated per person per visit while clicks are raw presses, so one person clicking twice reads as 200% — and impressions are gated on the `feed-impressions` cohort flag while clicks are not, so at a partial cohort the rate inflates by the inverse of the cohort. The units were never divisible.

## A fix to an existing guard

`action-type-enum-drift.test.ts` used `.find()` to pick the `default.actions` ALTER block and so read the **first** migration that restates the column. This is the second such migration, so it never saw these three values — but the deeper problem is that a `MODIFY COLUMN` *replaces* the definition, so its "restates every pre-existing value" and "distinct index" assertions were also checking the older file. From this commit on, the newest migration would have been unguarded against a dropped or renumbered value. It now takes the last block.

## Flag

Announcement impressions inherit the **`feed-impressions`** kill switch (currently `enabled:false` plus a 100% rollout, i.e. fully on). No new flag, per Justin. Consequence to know: a `feed-impressions` rollback also blanks the "seen" column on this creator-facing page. That was a deliberate choice, not an oversight.

## Verification

**Review SHA:** the eight review lanes ran against `b20f1ad5c3`. The branch was later rebased onto `main` to pick up the Windows path fix, so head is now `50e09250cc`. A rebase does not change the diff's content and the findings still apply — but they were not produced against the SHA that is open, and should not be described as "reviewed green at head".

- `pnpm run typecheck` (main app) and `pnpm typecheck` (creator-studio, 9006 files) both clean.
- Announcement browser suite: 41 passing. New node tests cover the schema/action wiring, the mute-change flag, and the router gate.
- **Mutants run, each restored in place:** the router gate `if (result.changed)` forced true (red); the impression hook moved into the shared card (red); the card's `ref` dropped, one branch at a time (each reddens exactly one test — the first run of this found a real gap, because the test only rendered one of the card's two roots).
- **Full unit suite**, counts reconciling on both dimensions: files `1 + 1624 + 3 = 1628` of 1628, tests `1 + 37873 + 35 = 37909` of 37909, no dead worker forks. The single failure was `appListingMenuSurface.test.ts`, a pre-existing Windows path-separator bug — since fixed on `main` in `450fa8e2`, and green here after the rebase. `blocks.router.workflow.test.ts` collected 370 tests, so the submodule was present and the run means something.

## Demo data to clean up

A hidden test announcement and obviously-fake metrics were created to demo the page (approved on a card). The announcement is inert twice over — `disabled = true` and an `endsAt` already in the past. **Delete when done:**

```sql
-- Postgres (prod)
DELETE FROM "Announcement" WHERE id = 909;
```

```sql
-- ClickHouse (prod). Raw impressions also expire on their own under the 30-day TTL.
ALTER TABLE default.impressions DELETE WHERE entityType = 'Announcement' AND entityId = 909;
ALTER TABLE default.actions DELETE WHERE reason = 'demo909';
```

The 412 fake impressions also land in `daily_impressions` for entity 909. That table is keyed by entity, so nobody else's numbers move.

A note on why the demo row lives in prod rather than dev: ClickHouse is shared and singular, so a dev-space announcement id could collide with a real prod announcement id and land fake impressions on a real creator's numbers, in the very table Creator Studio reads.

## One thing for the next person in this app

`pnpm format` in `apps/creator-studio` reformats the whole app and touches two files carrying committed formatting drift (`BulkActionDialog.svelte`, `monetization/sales.ts`). They are reverted here — that drift is pre-existing, not something you caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4Z81o8c1FwLA5RcwBzLSx
