### PR TITLE
chore(articles): backfill several authors, and skip named ids

### DIFF
--- a/scripts/backfill-official-articles.mjs
+++ b/scripts/backfill-official-articles.mjs
@@ -15,8 +15,9 @@
  * Usage:
  *   node scripts/backfill-official-articles.mjs                 # dry run against DATABASE_URL
  *   node scripts/backfill-official-articles.mjs --apply
- *   node scripts/backfill-official-articles.mjs --user-id 123   # a different author
+ *   node scripts/backfill-official-articles.mjs --user-ids 1,3,43555   # several authors
  *   node scripts/backfill-official-articles.mjs --unmark        # clear instead of set
+ *   node scripts/backfill-official-articles.mjs --exclude-ids 6222,6339  # skip these
  *
  * The connection comes from DATABASE_URL, so it follows whatever `.env` the tree points
  * at. Check the host it prints before passing --apply.
@@ -30,16 +31,38 @@ config();
 const args = process.argv.slice(2);
 const apply = args.includes('--apply');
 const unmark = args.includes('--unmark');
-const userIdArg = args.indexOf('--user-id');
+const userIdArg = args.findIndex((a) => a === '--user-id' || a === '--user-ids');
 // 12042163 — `constants.system.officialUserId`, the "Public CivitaiOfficial content
 // account". Not imported: this is a plain node script and `~/server/common/constants`
 // pulls the whole server graph. If that id ever changes, it changes in two places.
-const OFFICIAL_USER_ID = userIdArg === -1 ? 12042163 : Number(args[userIdArg + 1]);
+//
+// Several ids are accepted because the account is not the whole story: Civitai's
+// announcements were written from staff accounts for years before that account existed,
+// so a backfill keyed on it alone leaves most of the back catalogue unmarked.
+const USER_IDS =
+  userIdArg === -1
+    ? [12042163]
+    : String(args[userIdArg + 1] ?? '')
+        .split(',')
+        .map((id) => Number(id.trim()))
+        .filter((id) => id !== 0);
 
-if (!Number.isInteger(OFFICIAL_USER_ID) || OFFICIAL_USER_ID <= 0) {
-  console.error(`Error: --user-id must be a positive integer, got ${args[userIdArg + 1]}`);
+if (!USER_IDS.length || USER_IDS.some((id) => !Number.isInteger(id) || id <= 0)) {
+  console.error(`Error: --user-ids takes a comma-separated list of positive integers`);
   process.exit(1);
 }
+
+// Reviewed exclusions. An author rule is right for the bulk and wrong for individual
+// rows, and the only way to know which is to read the titles — so the exceptions live
+// here as ids rather than as a cleverer predicate that would be wrong in a new way later.
+const excludeArg = args.indexOf('--exclude-ids');
+const EXCLUDE_IDS =
+  excludeArg === -1
+    ? []
+    : String(args[excludeArg + 1] ?? '')
+        .split(',')
+        .map((id) => Number(id.trim()))
+        .filter((id) => Number.isInteger(id) && id > 0);
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
@@ -59,16 +82,18 @@ const [{ host, db }] = (
 console.log(`Database: ${db} @ ${host ?? 'local'}  (from DATABASE_URL)`);
 
 const { rows: pending } = await client.query(
-  `select a.id, a.title, a.status, a."publishedAt"
+  `select a.id, a.title, a.status, a."publishedAt", u.username
      from "Article" a
-    where a."userId" = $1 and a."isOfficial" = $2
+     join "User" u on u.id = a."userId"
+    where a."userId" = ANY($1) and a."isOfficial" = $2
+      and not (a.id = ANY($3))
     order by a."publishedAt" desc nulls last`,
-  [OFFICIAL_USER_ID, !target]
+  [USER_IDS, !target, EXCLUDE_IDS]
 );
 
 const { rows: alreadyRows } = await client.query(
-  `select count(*)::int as n from "Article" where "userId" = $1 and "isOfficial" = $2`,
-  [OFFICIAL_USER_ID, target]
+  `select count(*)::int as n from "Article" where "userId" = ANY($1) and "isOfficial" = $2`,
+  [USER_IDS, target]
 );
 const already = alreadyRows[0].n;
 
@@ -76,18 +101,23 @@ const already = alreadyRows[0].n;
 // mark that this rule would NOT have set. A backfill that silently disagrees with the
 // moderators who marked things by hand is worth seeing before it runs, not after.
 const { rows: outsideRows } = await client.query(
-  `select count(*)::int as n from "Article" where "userId" <> $1 and "isOfficial" = true`,
-  [OFFICIAL_USER_ID]
+  `select count(*)::int as n from "Article" where NOT ("userId" = ANY($1)) and "isOfficial" = true`,
+  [USER_IDS]
 );
 
 console.log(
-  `Author ${OFFICIAL_USER_ID}: ${pending.length} to ${unmark ? 'unmark' : 'mark'}, ` +
+  `Authors ${USER_IDS.join(', ')}: ${pending.length} to ${unmark ? 'unmark' : 'mark'}, ` +
     `${already} already ${unmark ? 'unmarked' : 'marked'}.`
 );
 console.log(`Marked by someone else (left alone): ${outsideRows[0].n}`);
+if (EXCLUDE_IDS.length) console.log(`Excluded by id: ${EXCLUDE_IDS.join(', ')}`);
 
 for (const row of pending.slice(0, 20)) {
-  console.log(`  ${row.id}  ${row.status.padEnd(9)}  ${row.title.slice(0, 70)}`);
+  console.log(
+    `  ${String(row.id).padStart(6)}  ${String(row.username).padEnd(16)} ${row.status.padEnd(
+      9
+    )}  ${row.title.slice(0, 60)}`
+  );
 }
 if (pending.length > 20) console.log(`  … and ${pending.length - 20} more`);
 
@@ -104,20 +134,21 @@ if (!apply) {
 }
 
 const { rowCount } = await client.query(
-  `update "Article" set "isOfficial" = $2 where "userId" = $1 and "isOfficial" = $3`,
-  [OFFICIAL_USER_ID, target, !target]
+  `update "Article" set "isOfficial" = $2
+     where "userId" = ANY($1) and "isOfficial" = $3 and not (id = ANY($4))`,
+  [USER_IDS, target, !target, EXCLUDE_IDS]
 );
 
 // Read it back rather than trusting rowCount: they should agree, and if they do not, the
 // difference is somebody writing the same rows at the same time.
 const { rows: afterRows } = await client.query(
-  `select count(*)::int as n from "Article" where "userId" = $1 and "isOfficial" = $2`,
-  [OFFICIAL_USER_ID, target]
+  `select count(*)::int as n from "Article" where "userId" = ANY($1) and "isOfficial" = $2`,
+  [USER_IDS, target]
 );
 
 console.log(`Updated ${rowCount} article(s).`);
 console.log(
-  `Now ${afterRows[0].n} article(s) by ${OFFICIAL_USER_ID} are ${unmark ? 'unmarked' : 'marked'}.`
+  `Now ${afterRows[0].n} article(s) by those authors are ${unmark ? 'unmarked' : 'marked'}.`
 );
 if (afterRows[0].n !== already + rowCount) {
   console.error('⚠ Read-back disagrees with the update count — something else wrote these rows.');


### PR DESCRIPTION
Updates the backfill script from #4630 to what actually ran, and records the run.

## Why it needed changing

The first version keyed on `constants.system.officialUserId` alone. That account did not exist for most of Civitai's history, so it would have left the whole back catalogue unmarked — `--user-ids` now takes a list.

`--exclude-ids` is the other half, and it exists because of what reading the list taught me. I first tried narrowing by **category** — `announcement` / `news` / `tool guide` — which excluded these:

```
33296  JustMaier  (none)   Open Your Own Creator Shop
33294  JustMaier  (none)   The 2026 Creator Program: The Full Picture
32087  JustMaier  (none)   Creator Economy Update 2026: You Set the Price Now
33749  JustMaier  musing   Proposal: Fixing Creator Compensation and Leveling Up Licensing
```

All Civitai speaking, none carrying a category, because the announcements written before that account existed were filed under whatever fit. **An author rule is right for the bulk and wrong for individual rows**, and the only way to know which rows is to read the titles. So the exceptions are ids in the command rather than a cleverer predicate that would be wrong in some new way later.

## What ran on prod

2026-09-04, on Justin's approval of the reviewed list:

```bash
node scripts/backfill-official-articles.mjs   --user-ids 12042163,1,3,43555,5418   --exclude-ids 6222,6339,6454,6338,5344,28893   --apply
```

**214 marked** — Maxfield 65, JustMaier 58, CivitaiOfficial 51, Faeia 38, theally 2.

Read back afterwards rather than trusting the update count: 214 total on prod, **0 marked outside those five accounts**, and all six excluded ids confirmed still `false`.

## The exclusions

Five abandoned drafts titled `test` / `rtert`, and `28893` theally *"Farewell, Civitans!"* — a departing staff member's goodbye, which is about leaving Civitai rather than Civitai speaking.

CivBot's 438 automated posts were deliberately left out; 438 machine-generated posts wearing a provenance badge is the opposite of what the badge is for.

Reversible: the same ids with `--unmark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHZuQDTCG159qcPrCkP7SF