### PR TITLE
refactor(form-graph): collapse the cutover to the single formGraphGenerator flag

### DIFF
--- a/.claude/skills/form-graph-port/SKILL.md
+++ b/.claude/skills/form-graph-port/SKILL.md
@@ -69,17 +69,21 @@ pick ONLY the fields worth carrying, build one address→raw-value record with
 schemas validate on first resolve, so stale garbage degrades to defaults. Never delete
 the old records while anything still reads them.
 
-## 6. Cutover: three flags, staged
+## 6. Cutover: ONE feature flag, always-on comparison
 
-1. `<form>-shadow-parse` (Flipt) — server parses BOTH, compares, counts
-   (`registerCounterWithLabels`) and logs divergence with **diff keys only — never field
-   values** (user content must not reach logs; pin that with a test).
-2. `<form>-parse` — serve the port's result; keep the old parse running for whatever
-   metrics still tap it.
-3. Client feature flag (`availability: ['mod']` first) swapping the form component.
+One feature flag (`availability: ['mod']` first, widened via its Flipt key) gates the
+whole cutover per user: it swaps the form component on the client AND serves the
+port's parse on the server (read from the ctx the feature-flag system already
+threads — coerce it, a sparse record reads `undefined`). Every server parse runs BOTH
+engines regardless and records the comparison — outcomes counted
+(`registerCounterWithLabels`), divergence logged with **diff keys only — never field
+values** (user content must not reach logs; pin that with a test, one sentinel per
+emit path). Comparison noise is fine: it dies with the old engine.
 
-Flags off must be byte-identical. Deleting the old engine is a separate change after the
-flags have fully flipped.
+Flag off must be byte-identical. The generation port briefly used three flags
+(separate shadow/serve Flipt switches) and collapsed them once the parity battery
+made independent server/client rollback unnecessary — start with one. Deleting the
+old engine is a separate change after the flag is fully widened.
 
 ## Keeping parity during the dual-graph window
 

--- a/docs/form-graph-port-plan.md
+++ b/docs/form-graph-port-plan.md
@@ -303,14 +303,17 @@ records are only read, never deleted. Store-path gotcha this surfaced: STORE
 state holds raw inputs (a bare-number model), so mode picks and scopes read ids
 via `modelIdOf` rather than `.id`.
 
-### Phase 4 — server swap (small, high-stakes) — BUILT, staged behind Flipt flags (2026-09-02)
+### Phase 4 — server swap (small, high-stakes) — BUILT, gated on the ONE cutover flag (2026-09-04)
 
-No adapter needed. `validateInput` in `orchestration-new.service.ts` is staged behind
-two Flipt flags (both default off; see
-`src/server/services/orchestrator/form-graph/shadow-parse.ts`):
-`form-graph-shadow-parse` runs the hub parse alongside v1 and compares — outcomes
-counted in `form_graph_shadow_parse_total`, divergence logged with diff KEYS only —
-and `form-graph-parse` serves the hub result. The v1 parse always runs (substitution
+No adapter needed. `validateInput` in `orchestration-new.service.ts` runs BOTH engines
+on every parse and records the comparison — outcomes counted in
+`form_graph_shadow_parse_total`, divergence logged with diff KEYS only (see
+`src/server/services/orchestrator/form-graph/shadow-parse.ts`) — and serves the hub
+result for users whose `formGraphGenerator` feature flag is on (read from
+`externalCtx.flags`; the App Blocks bridge passes no flags, so it stays on v1
+throughout). Originally staged behind two extra Flipt flags; collapsed to the single
+feature flag 2026-09-04 — comparison logging stays on and noisy until Phase 6 removes
+it wholesale. The v1 parse always runs (substitution
 metrics + reverse compare); dropping it belongs to Phase 6. `computedKeys` on the
 serve path comes from the parse result's own `computedKeys` (wire-named computeds —
 the v1 node-partition equivalent), and the substitution metrics need no mapping
@@ -318,7 +321,7 @@ because the port's `checkpoint.ts` records into `ext.modelSubstitutions` directl
 `legacy-metadata-mapper.ts`'s `getGenerationDisplayKeys` deliberately stays on the v1
 graph: its input/computed partition differs in the hub (workflow/ecosystem are
 fields, not computeds), so it moves in Phase 6 with a behavior decision, not
-mechanically. Flip criterion: a sustained zero on diverged/error outcomes.
+mechanically. Widen criterion: a sustained zero on diverged/error outcomes.
 
 ### Phase 5 — client swap (large, UI) — BUILT, staged behind `formGraphGenerator` (mod-only); awaiting Briant's hands-on pass
 
@@ -340,8 +343,9 @@ needs Briant's hands-on testing before it is called done.
 
 Delete `src/libs/data-graph/`, `src/shared/data-graph/generation/` (the old graphs),
 move `form-graph/generation/` to its final home (`src/shared/generation-form/` or Briant's choice),
-delete the differential suites (they die with their oracle), and run `docs-drift-review`
-+ `comment-review` over the branch.
+delete the differential suites (they die with their oracle), delete the cutover
+machinery — the `formGraphGenerator` flag, `shadow-parse.ts`, its counter and Axiom
+logging — and run `docs-drift-review` + `comment-review` over the branch.
 
 **Closing condition:** no import of `~/libs/data-graph` or the old graph paths remains
 (`grep -rn "libs/data-graph\|shared/data-graph/generation" src` is empty besides the new

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -43,10 +43,6 @@ export enum FLIPT_FEATURE_FLAGS {
   GENERATION_EXPERIMENTAL = 'generation-experimental',
   AI_TOOLKIT_DEFAULT_SD = 'ai-toolkit-default-sd',
   WAN22_MULTI_STEP = 'wan22-multi-step',
-  // form-graph cutover, staged: shadow-compare first, then serve. See
-  // src/server/services/orchestrator/form-graph/shadow-parse.ts.
-  FORM_GRAPH_SHADOW_PARSE = 'form-graph-shadow-parse',
-  FORM_GRAPH_PARSE = 'form-graph-parse',
   ENHANCED_COMPATIBILITY_SDCPP = 'enhanced-compatibility-sdcpp',
   IMAGE_INDEX_FEED = 'image-index-feed',
   // Routes ImageResourceNew reads to the writer (primary) instead of the read

--- a/src/server/prom/form-graph.metrics.ts
+++ b/src/server/prom/form-graph.metrics.ts
@@ -1,11 +1,10 @@
 import { registerCounterWithLabels } from '@civitai/telemetry/client';
 
 /**
- * Shadow-parse comparison outcomes for the form-graph cutover: while the
- * `form-graph-shadow-parse` flag is on, every server-side generation parse
- * runs through BOTH graphs and the results are compared. `match` should be
- * the only outcome; a sustained zero on the others is the flip criterion for
- * `form-graph-parse`.
+ * Shadow-parse comparison outcomes for the form-graph cutover: every
+ * server-side generation parse runs through BOTH graphs and the results are
+ * compared. `match` should be the only outcome; a sustained zero on the
+ * others is the criterion for widening the `formGraphGenerator` flag.
  *
  * outcome: match | diverged (results differ) | error (the hub parse threw)
  */

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -493,9 +493,10 @@ const featureFlags = createFeatureFlags({
   // kill lever. Off ⇒ v2.0 is dropped from the picker and a submitted v2.0
   // version id falls back to the ecosystem default (see grok-graph.ts).
   grokImagine2: { availability: ['mod'], fliptKey: 'grok-imagine-2' },
-  // form-graph cutover: swaps GenerationTabs' form for the form-graph lane
-  // (FormGraphGenerator). Server parsing is staged separately via the
-  // form-graph-shadow-parse / form-graph-parse Flipt flags.
+  // THE form-graph cutover flag: swaps GenerationTabs' form for the form-graph
+  // lane AND serves the hub parse for the user's submits/whatIfs (validateInput
+  // reads it from the generation ctx). Every parse shadow-compares regardless.
+  // Widen via the fliptKey; flag and comparison both go away with data-graph.
   formGraphGenerator: { availability: ['mod'], fliptKey: 'form-graph-generator' },
   // Retool privileged endpoints — `granted` means the moderator must carry the
   // matching permission key in user.permissions. Endpoints lookup the key

--- a/src/server/services/orchestrator/__tests__/orchestration-new.shadow-tap.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.shadow-tap.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type * as ShadowParse from '~/server/services/orchestrator/form-graph/shadow-parse';
 
 /**
- * The cutover's flip criterion depends on `validateInput` actually invoking the
- * shadow comparison once per parse — the shadow-parse suite tests the functions,
- * not this caller. Mock preamble mirrors `orchestration-new.collector-attach.test.ts`:
- * it only keeps the heavy DB/redis module graph inert so the module imports.
+ * The cutover rides on `validateInput` doing three things: running the shadow
+ * comparison exactly once per parse, serving the hub result for a user whose
+ * `formGraphGenerator` flag is on, and serving v1 for everyone else. The
+ * shadow-parse suite tests the functions, not this caller. Mock preamble
+ * mirrors `orchestration-new.collector-attach.test.ts`: it only keeps the
+ * heavy DB/redis module graph inert so the module imports.
  */
 
 vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {}, pgDbRead: {}, pgDbWrite: {} }));
@@ -34,14 +36,16 @@ vi.mock('~/server/services/image.service', () => ({
 }));
 
 const shadow = vi.hoisted(() => ({
-  flags: { serve: false, shadow: false },
   record: vi.fn(),
+  hubResult: undefined as unknown,
 }));
 vi.mock('~/server/services/orchestrator/form-graph/shadow-parse', async (importOriginal) => {
   const mod = await importOriginal<typeof ShadowParse>();
   return {
     ...mod,
-    shadowFlags: vi.fn(() => shadow.flags),
+    runHubParse: vi.fn((...args: Parameters<typeof mod.runHubParse>) =>
+      shadow.hubResult === undefined ? mod.runHubParse(...args) : shadow.hubResult
+    ),
     recordShadowComparison: shadow.record,
   };
 });
@@ -52,38 +56,64 @@ import { dbMock } from '~/__tests__/mocks/db.mock';
 
 void dbMock;
 
-const EXT: GenerationCtx = {
+const ext = (flags: GenerationCtx['flags']): GenerationCtx => ({
   limits: { maxQuantity: 4, maxResources: 9, vidQuantity: 4 },
   user: { isMember: true, tier: 'gold' },
-  flags: {},
+  flags,
   gateRules: [],
-};
+});
 
 const INPUT = { workflow: 'txt2img', ecosystem: 'SDXL', prompt: 'a cat' };
 
 // Step-building may fail on the inert mocks downstream of validateInput; the
-// tap fires (or not) before that, which is all this suite asserts.
-const run = () =>
-  createWorkflowStepsFromGraphInput({ input: { ...INPUT }, externalCtx: EXT }).catch(
-    () => undefined
-  );
+// behaviour under test happens (or not) before that.
+const run = (externalCtx: GenerationCtx) =>
+  createWorkflowStepsFromGraphInput({ input: { ...INPUT }, externalCtx });
 
-describe('validateInput shadow tap', () => {
-  beforeEach(() => shadow.record.mockClear());
+describe('validateInput cutover gate', () => {
+  beforeEach(() => {
+    shadow.record.mockClear();
+    shadow.hubResult = undefined;
+  });
 
-  it('with the shadow flag on, one parse records exactly one comparison', async () => {
-    shadow.flags = { serve: false, shadow: true };
-    await run();
+  it('one parse records exactly one comparison, flag or no flag', async () => {
+    await run(ext({})).catch(() => undefined);
     expect(shadow.record).toHaveBeenCalledTimes(1);
     const [v1, hub, workflow] = shadow.record.mock.calls[0];
     expect(v1).toHaveProperty('success');
     expect(hub).toHaveProperty('ok');
     expect(workflow).toBe('txt2img');
+
+    await run(ext({ formGraphGenerator: true })).catch(() => undefined);
+    expect(shadow.record).toHaveBeenCalledTimes(2);
   });
 
-  it('with both flags off, the hub parse never runs', async () => {
-    shadow.flags = { serve: false, shadow: false };
-    await run();
-    expect(shadow.record).not.toHaveBeenCalled();
+  it('the hub result is SERVED only for a user with the flag on', async () => {
+    // a hub-only refusal: if the hub is being served, the submit rejects with
+    // its message; if v1 is served, the parse succeeds and continues past it
+    shadow.hubResult = {
+      ok: false,
+      errors: { prompt: { message: 'HUB_SERVED_ERROR' } },
+    };
+
+    await expect(run(ext({ formGraphGenerator: true }))).rejects.toThrow(/HUB_SERVED_ERROR/);
+
+    const offLane = await run(ext({})).then(
+      () => 'v1-served',
+      (e) => (String(e).includes('HUB_SERVED_ERROR') ? 'hub-served' : 'v1-served')
+    );
+    expect(offLane).toBe('v1-served');
+  });
+
+  it('a missing flag record serves v1 (the coercion the untruthy-gate guard exists for)', async () => {
+    shadow.hubResult = {
+      ok: false,
+      errors: { prompt: { message: 'HUB_SERVED_ERROR' } },
+    };
+    const lane = await run(ext(undefined)).then(
+      () => 'v1-served',
+      (e) => (String(e).includes('HUB_SERVED_ERROR') ? 'hub-served' : 'v1-served')
+    );
+    expect(lane).toBe('v1-served');
   });
 });

--- a/src/server/services/orchestrator/form-graph/__tests__/shadow-parse.test.ts
+++ b/src/server/services/orchestrator/form-graph/__tests__/shadow-parse.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import type * as PromMetrics from '~/server/prom/form-graph.metrics';
-import type * as FliptClient from '~/server/flipt/client';
 import { loggingMock } from '~/__tests__/mocks/logging.mock';
 
 const { inc } = vi.hoisted(() => ({ inc: vi.fn() }));
@@ -9,20 +8,7 @@ vi.mock('~/server/prom/form-graph.metrics', async (importOriginal) => ({
   formGraphShadowParseCounter: { inc },
 }));
 
-const flags = vi.hoisted(() => ({ serve: false, shadow: false }));
-vi.mock('~/server/flipt/client', async (importOriginal) => {
-  const mod = await importOriginal<typeof FliptClient>();
-  return {
-    ...mod,
-    isFliptSync: vi.fn((flag: string) => {
-      if (flag === mod.FLIPT_FEATURE_FLAGS.FORM_GRAPH_PARSE) return flags.serve;
-      if (flag === mod.FLIPT_FEATURE_FLAGS.FORM_GRAPH_SHADOW_PARSE) return flags.shadow;
-      return false;
-    }),
-  };
-});
-
-import { recordShadowComparison, runHubParse, shadowFlags } from '../shadow-parse';
+import { recordShadowComparison, runHubParse } from '../shadow-parse';
 import type { GenerationCtx } from '~/shared/data-graph/generation/context';
 
 const logToAxiom = loggingMock.logToAxiom;
@@ -129,25 +115,5 @@ describe('shadow-parse comparison', () => {
     );
     expect(inc).toHaveBeenCalledWith({ outcome: 'diverged', workflow: 'unknown' });
     expectNoSentinelLogged();
-  });
-});
-
-describe('shadowFlags', () => {
-  it('serve implies shadow — the reverse comparison must keep running during cutover', () => {
-    flags.serve = true;
-    flags.shadow = false;
-    expect(shadowFlags()).toEqual({ serve: true, shadow: true });
-  });
-
-  it('both flags off is the zero-cost fast path', () => {
-    flags.serve = false;
-    flags.shadow = false;
-    expect(shadowFlags()).toEqual({ serve: false, shadow: false });
-  });
-
-  it('shadow alone compares without serving', () => {
-    flags.serve = false;
-    flags.shadow = true;
-    expect(shadowFlags()).toEqual({ serve: false, shadow: true });
   });
 });

--- a/src/server/services/orchestrator/form-graph/shadow-parse.ts
+++ b/src/server/services/orchestrator/form-graph/shadow-parse.ts
@@ -1,5 +1,4 @@
 import { isEqual } from 'lodash-es';
-import { FLIPT_FEATURE_FLAGS, isFliptSync } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
 import { formGraphShadowParseCounter } from '~/server/prom/form-graph.metrics';
 import { workflowConfigByKey } from '~/shared/data-graph/generation/config/workflows';
@@ -8,19 +7,15 @@ import { generationHub } from '~/shared/form-graph/generation/hub.graph';
 import { reconcileSelectors } from '~/shared/form-graph/generation/reconcile';
 
 /**
- * The form-graph cutover's server side, staged behind two Flipt flags:
- *
- * 1. `form-graph-shadow-parse` — every generation parse ALSO runs through
- *    `generationHub`; results are compared and divergence is counted
- *    (`form_graph_shadow_parse_total`) and logged with diff KEYS only — no
- *    field values, so no prompts or user content reach the log.
- * 2. `form-graph-parse` — the hub result is SERVED. The v1 parse still runs
- *    (it feeds the substitution metrics and the reverse shadow-compare);
- *    dropping it entirely belongs to the delete-data-graph change, which
- *    ports the metrics tap onto the hub's correction notes.
- *
- * Both flags default off; with neither set this module costs one sync flag
- * check per parse.
+ * The form-graph cutover's server side, gated by the ONE cutover flag —
+ * the `formGraphGenerator` feature flag, read per-user from the generation
+ * context. Every parse runs BOTH engines and records the comparison
+ * (`form_graph_shadow_parse_total`, divergences logged with diff KEYS only —
+ * no field values, so no prompts or user content reach the log); the hub
+ * result is SERVED for users whose flag is on. The v1 parse always runs
+ * (it feeds the substitution metrics and the reverse comparison). Both the
+ * flag and this whole module go away in the delete-data-graph change, which
+ * ports the metrics tap onto the hub's correction notes.
  */
 
 export type HubParse =
@@ -31,12 +26,6 @@ export type HubParse =
       computedKeys: readonly string[];
     }
   | { ok: false; errors: Record<string, { message: string }> };
-
-export function shadowFlags() {
-  const serve = isFliptSync(FLIPT_FEATURE_FLAGS.FORM_GRAPH_PARSE) === true;
-  const shadow = serve || isFliptSync(FLIPT_FEATURE_FLAGS.FORM_GRAPH_SHADOW_PARSE) === true;
-  return { serve, shadow };
-}
 
 /** The hub parse, never throwing — a throw is a divergence class of its own. */
 export function runHubParse(

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -104,7 +104,7 @@ import { parsePromptSnippetReferences } from '~/utils/prompt-helpers';
 
 // Ecosystem handlers - unified router
 import { createEcosystemStepInput } from './ecosystems';
-import { recordShadowComparison, runHubParse, shadowFlags } from './form-graph/shadow-parse';
+import { recordShadowComparison, runHubParse } from './form-graph/shadow-parse';
 import { createComfyInput, resourcesToImageMetadataResources } from './ecosystems/comfy-input';
 import { extractStepErrors, sanitizeProviderError } from './provider-errors';
 import { resolveSourceImageIds, signProvenance, unionSourceImageIds } from './remix-provenance';
@@ -595,14 +595,14 @@ function validateInput(input: Record<string, unknown>, externalCtx: GenerationCt
   const normalized = normalizeInput(input);
   const result = generationGraph.safeParse(normalized, externalCtx);
 
-  // form-graph cutover: shadow-compare (and optionally serve) the hub parse.
-  // The v1 parse above always runs — it feeds the substitution metrics and,
-  // while serving the hub, the reverse comparison.
-  const cutover = shadowFlags();
-  const hubResult = cutover.shadow ? runHubParse(normalized, externalCtx) : undefined;
-  if (hubResult) {
-    recordShadowComparison(result, hubResult, String(normalized.workflow ?? 'unknown'));
-  }
+  // form-graph cutover: every parse runs both engines and records the
+  // comparison; the hub result is served for users with the cutover flag on.
+  // The v1 parse above always runs — it feeds the substitution metrics and
+  // the reverse comparison. Flag, comparison, and the whole shadow-parse
+  // module go away in the delete-data-graph change.
+  const serveHub = externalCtx.flags?.formGraphGenerator === true;
+  const hubResult = runHubParse(normalized, externalCtx);
+  recordShadowComparison(result, hubResult, String(normalized.workflow ?? 'unknown'));
 
   // Issue #3520 — count silent checkpoint substitutions. This is the single
   // choke point every SERVER-side graph validation passes through (submit,
@@ -616,7 +616,7 @@ function validateInput(input: Record<string, unknown>, externalCtx: GenerationCt
   // awaited: this function is synchronous and on the submit path.
   void emitModelSubstitutions(externalCtx.modelSubstitutions);
 
-  if (cutover.serve && hubResult && hubResult.ok !== null) {
+  if (serveHub && hubResult.ok !== null) {
     if (!hubResult.ok) {
       const errorMessages = Object.entries(hubResult.errors)
         .map(([key, error]) => `${key}: ${error.message}`)


### PR DESCRIPTION
One flag now gates the whole cutover per user: formGraphGenerator swaps the client form AND serves the hub parse for that user's submits and whatIfs (validateInput reads it from the generation ctx, coerced — a sparse flag record serves v1). Every server parse runs both engines and records the comparison unconditionally; the logging stays on and noisy by design until Phase 6 deletes flag, comparison, and the v1 engine together.

- shadow-parse.ts: shadowFlags() and the Flipt reads deleted; comparison machinery (clamped label, keys-only logging, errorName-only throws) unchanged
- the form-graph-shadow-parse / form-graph-parse Flipt constants deleted; no Flipt flags need creating — widening the form-graph-generator key is the entire rollout lever
- App Blocks bridge passes no flags, so it stays on v1 throughout; preset generation threads its caller's flags and follows the user
- shadow-tap test re-pinned: one comparison per parse flag or no flag, hub served only with the flag on (distinguishable hub refusal), missing flag record serves v1
- plan doc + port skill updated to the single-flag design, with the three-flag history recorded; Phase 6 scope now names the cutover machinery explicitly