### PR TITLE
fix(rewards): steer bonus events away from a mid-UTC-day start

### DIFF
--- a/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
+++ b/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
@@ -10,12 +10,13 @@ import {
   type UpsertRewardsBonusEventSchema,
 } from '~/server/schema/rewards-bonus-event.schema';
 import {
-  defaultStartsAtValue,
+  initialStartsAtValue,
   lateEnableWarning,
+  resolveDisplayEnd,
   resolveDisplayStart,
+  toDisplayDate,
 } from '~/components/RewardsBonusEvent/rewards-bonus-event.utils';
 import dayjs from '~/shared/utils/dayjs';
-import { fromDisplayUTC, toDisplayUTC } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -80,20 +81,24 @@ export function RewardsBonusEventEditModal({
       articleUrl: event?.articleId ? `/articles/${event.articleId}` : '',
       bannerLabel: event?.bannerLabel ?? '',
       enabled: event?.enabled ?? false,
-      startsAt: event?.startsAt
-        ? toDisplayUTC(event.startsAt)
-        : event?.id
-        ? undefined
-        : defaultStartsAtValue(new Date()),
-      endsAt: event?.endsAt ? toDisplayUTC(event.endsAt) : undefined,
+      startsAt: initialStartsAtValue({ event, now: new Date() }),
+      endsAt: event?.endsAt ? toDisplayDate(event.endsAt) : undefined,
     },
   });
 
+  const watchedStartsAt = form.watch('startsAt');
+  const watchedEndsAt = form.watch('endsAt');
   const warning = lateEnableWarning({
-    // The schema defaults this to false, but the form's INPUT type still admits
-    // undefined before defaults apply.
-    enabled: !!form.watch('enabled'),
-    startsAt: form.watch('startsAt'),
+    next: {
+      // The schema defaults this to false, but the form's INPUT type still admits
+      // undefined before defaults apply.
+      enabled: !!form.watch('enabled'),
+      startsAt: watchedStartsAt ? resolveDisplayStart(watchedStartsAt) : null,
+      endsAt: watchedEndsAt ? resolveDisplayEnd(watchedEndsAt) : null,
+    },
+    previous: event?.id
+      ? { enabled: !!event.enabled, startsAt: event.startsAt, endsAt: event.endsAt }
+      : undefined,
     now: new Date(),
   });
 
@@ -116,9 +121,7 @@ export function RewardsBonusEventEditModal({
 
   function handleSubmit(data: z.infer<typeof schema>) {
     const startsAt = data.startsAt ? resolveDisplayStart(data.startsAt) : null;
-    const endsAt = data.endsAt
-      ? dayjs.utc(fromDisplayUTC(data.endsAt)).endOf('day').toDate()
-      : null;
+    const endsAt = data.endsAt ? resolveDisplayEnd(data.endsAt) : null;
 
     const payload: UpsertRewardsBonusEventSchema = {
       id: event?.id,
@@ -211,7 +214,7 @@ export function RewardsBonusEventEditModal({
           label="Enabled (must also be within the start/end window to be active)"
         />
         {warning && (
-          <Alert color="yellow" title="This will start the event mid-day">
+          <Alert color="yellow" title="This will start the event mid-day (UTC)">
             {warning}
           </Alert>
         )}

--- a/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
+++ b/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, Stack } from '@mantine/core';
+import { Alert, Button, Modal, Stack } from '@mantine/core';
 import { DatePickerInput } from '@mantine/dates';
 import { useMemo } from 'react';
 import { Controller } from 'react-hook-form';
@@ -9,6 +9,11 @@ import {
   REWARDS_BONUS_MULTIPLIER_OPTIONS,
   type UpsertRewardsBonusEventSchema,
 } from '~/server/schema/rewards-bonus-event.schema';
+import {
+  defaultStartsAtValue,
+  lateEnableWarning,
+  resolveDisplayStart,
+} from '~/components/RewardsBonusEvent/rewards-bonus-event.utils';
 import dayjs from '~/shared/utils/dayjs';
 import { fromDisplayUTC, toDisplayUTC } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -75,9 +80,21 @@ export function RewardsBonusEventEditModal({
       articleUrl: event?.articleId ? `/articles/${event.articleId}` : '',
       bannerLabel: event?.bannerLabel ?? '',
       enabled: event?.enabled ?? false,
-      startsAt: event?.startsAt ? toDisplayUTC(event.startsAt) : undefined,
+      startsAt: event?.startsAt
+        ? toDisplayUTC(event.startsAt)
+        : event?.id
+        ? undefined
+        : defaultStartsAtValue(new Date()),
       endsAt: event?.endsAt ? toDisplayUTC(event.endsAt) : undefined,
     },
+  });
+
+  const warning = lateEnableWarning({
+    // The schema defaults this to false, but the form's INPUT type still admits
+    // undefined before defaults apply.
+    enabled: !!form.watch('enabled'),
+    startsAt: form.watch('startsAt'),
+    now: new Date(),
   });
 
   const title = useMemo(
@@ -98,9 +115,7 @@ export function RewardsBonusEventEditModal({
   });
 
   function handleSubmit(data: z.infer<typeof schema>) {
-    const startsAt = data.startsAt
-      ? dayjs.utc(fromDisplayUTC(data.startsAt)).startOf('day').toDate()
-      : null;
+    const startsAt = data.startsAt ? resolveDisplayStart(data.startsAt) : null;
     const endsAt = data.endsAt
       ? dayjs.utc(fromDisplayUTC(data.endsAt)).endOf('day').toDate()
       : null;
@@ -160,7 +175,8 @@ export function RewardsBonusEventEditModal({
             name="startsAt"
             render={({ field }) => (
               <DatePickerInput
-                label="Starts at"
+                label="Starts at (UTC)"
+                description="The event goes live at 00:00 UTC on this date, and only if it is already enabled."
                 placeholder="No start date"
                 value={field.value ?? null}
                 onChange={(v) => field.onChange(v ?? null)}
@@ -178,7 +194,8 @@ export function RewardsBonusEventEditModal({
                 startsAtValue && startsAtValue.getTime() > today.getTime() ? startsAtValue : today;
               return (
                 <DatePickerInput
-                  label="Ends at"
+                  label="Ends at (UTC)"
+                  description="Runs through 23:59 UTC on this date."
                   placeholder="No end date"
                   value={field.value ?? null}
                   onChange={(v) => field.onChange(v ?? null)}
@@ -193,6 +210,11 @@ export function RewardsBonusEventEditModal({
           name="enabled"
           label="Enabled (must also be within the start/end window to be active)"
         />
+        {warning && (
+          <Alert color="yellow" title="This will start the event mid-day">
+            {warning}
+          </Alert>
+        )}
         <Stack gap="xs" pt="sm">
           <Button type="submit" loading={isLoading}>
             Save

--- a/src/components/RewardsBonusEvent/__tests__/rewards-bonus-event.utils.test.ts
+++ b/src/components/RewardsBonusEvent/__tests__/rewards-bonus-event.utils.test.ts
@@ -1,20 +1,24 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  defaultStartsAtValue,
+  initialStartsAtValue,
   lateEnableWarning,
   nextUtcMidnight,
+  resolveDisplayEnd,
   resolveDisplayStart,
+  toDisplayDate,
 } from '~/components/RewardsBonusEvent/rewards-bonus-event.utils';
 
 // 2026-08-19T21:18:52.600Z is the minute the "Creator Collab Update" event was
-// switched on, 21 hours after the 00:00 UTC start it already carried. Using the
-// real instant keeps the tests anchored to the thing they exist to prevent.
+// switched on, 21 hours after the 00:00 UTC start it already carried.
 const ACTIVATION = new Date('2026-08-19T21:18:52.600Z');
 
+// 🔴 Deliberately NOT the instant passed as `now`. Every function here takes the
+// clock as a parameter, so a mutation reading the ambient clock instead would be
+// invisible if the two agreed. Six years apart, it is not.
 beforeEach(() => {
   vi.useFakeTimers();
-  vi.setSystemTime(ACTIVATION);
+  vi.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
 });
 
 afterEach(() => {
@@ -33,62 +37,165 @@ describe('nextUtcMidnight', () => {
   });
 });
 
-describe('defaultStartsAtValue', () => {
-  // 🔴 Pin a non-zero UTC offset rather than trusting the runner's. The whole
-  // display-space shift is a no-op at UTC, so on a UTC box (which is what CI is)
-  // these assertions hold for any implementation and prove nothing. UTC-5.
-  const OFFSET_MINUTES = 300;
+describe('the display round trip', () => {
+  // Asserted as a relation between calendar fields rather than against a literal,
+  // so it means the same thing in every timezone the runner might use.
+  it('shows the operator the UTC calendar day, whatever the local offset is', () => {
+    const instant = nextUtcMidnight(ACTIVATION);
+    const display = toDisplayDate(instant);
 
-  beforeEach(() => {
-    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(OFFSET_MINUTES);
+    expect([display.getFullYear(), display.getMonth(), display.getDate()]).toEqual([
+      instant.getUTCFullYear(),
+      instant.getUTCMonth(),
+      instant.getUTCDate(),
+    ]);
   });
 
-  // The control for the pin above: if the offset were not being applied, the
-  // display value would equal the instant and the round-trip below would pass
-  // without exercising the shift at all.
-  it('is shifted away from the instant it represents', () => {
-    expect(defaultStartsAtValue(ACTIVATION).getTime()).toBe(
-      new Date('2026-08-20T00:00:00.000Z').getTime() + OFFSET_MINUTES * 60_000
-    );
-  });
-
-  // The picker value is shifted into display space and `handleSubmit` shifts it
-  // back. If the two disagree the default silently saves the wrong day, which is
-  // invisible in the UI because the picker renders the shifted value.
-  it('round-trips through the submit path to the next UTC midnight', () => {
-    expect(resolveDisplayStart(defaultStartsAtValue(ACTIVATION)).toISOString()).toBe(
+  it('resolves back to the instant it was built from', () => {
+    expect(resolveDisplayStart(toDisplayDate(nextUtcMidnight(ACTIVATION))).toISOString()).toBe(
       '2026-08-20T00:00:00.000Z'
     );
+  });
+
+  it('resolves the end field to the far end of the same UTC day', () => {
+    expect(
+      resolveDisplayEnd(toDisplayDate(new Date('2026-09-02T00:00:00.000Z'))).toISOString()
+    ).toBe('2026-09-02T23:59:59.999Z');
+  });
+
+  // 🔴 The control that has to run in a REAL timezone. An offset-arithmetic
+  // implementation (`toDisplayUTC`/`fromDisplayUTC`) is a correct-looking identity
+  // at any FIXED offset — including UTC, which is what CI runs — and only slips
+  // where the offset differs between the instant and the shifted value. Mocking
+  // `getTimezoneOffset` to a constant cannot reach it; nor can a west-of-UTC
+  // offset, because `startOf('day')` absorbs the shift inside the same UTC day.
+  //
+  // Sydney's 2026-10-04 is the date the old implementation turned into 2026-10-03.
+  describe('across a DST start that lands on UTC midnight', () => {
+    const original = process.env.TZ;
+
+    beforeEach(() => {
+      process.env.TZ = 'Australia/Sydney';
+    });
+
+    // 🔴 `delete`, not assignment. TZ is UNSET on some machines, and
+    // `process.env.TZ = undefined` stores the STRING "undefined", which Node reads
+    // as an invalid zone and silently resolves to UTC — leaving every later test
+    // file in this worker on a different clock than it asked for.
+    afterAll(() => {
+      if (original === undefined) delete process.env.TZ;
+      else process.env.TZ = original;
+    });
+
+    it('does not slip a day when the offset changes mid-trip', () => {
+      // Sunday 2026-10-04 02:00 AEST -> 03:00 AEDT, i.e. the transition sits on
+      // the 2026-10-04T00:00Z boundary this default is aiming at.
+      const eve = new Date('2026-10-03T12:00:00.000Z');
+      const target = nextUtcMidnight(eve);
+
+      expect(target.toISOString()).toBe('2026-10-04T00:00:00.000Z');
+      expect(resolveDisplayStart(toDisplayDate(target)).toISOString()).toBe(
+        '2026-10-04T00:00:00.000Z'
+      );
+    });
+
+    it('has a local offset that actually moves across that boundary', () => {
+      // The positive control for the block above: without a real DST shift here,
+      // the assertion would hold for a broken implementation too.
+      expect(new Date('2026-10-03T12:00:00.000Z').getTimezoneOffset()).not.toBe(
+        new Date('2026-10-04T12:00:00.000Z').getTimezoneOffset()
+      );
+    });
+  });
+});
+
+describe('initialStartsAtValue', () => {
+  it('opens a new event on the next UTC midnight', () => {
+    const value = initialStartsAtValue({ event: undefined, now: ACTIVATION });
+
+    expect(resolveDisplayStart(value!).toISOString()).toBe('2026-08-20T00:00:00.000Z');
+  });
+
+  it('keeps the start an existing event already has', () => {
+    const value = initialStartsAtValue({
+      event: { id: 2, startsAt: new Date('2026-08-19T00:00:00.000Z') },
+      now: ACTIVATION,
+    });
+
+    expect(resolveDisplayStart(value!).toISOString()).toBe('2026-08-19T00:00:00.000Z');
+  });
+
+  // 🔴 Event id 1 is enabled with a null start. Collapsing the three arms to two
+  // would hand it a start date the moment a moderator opened it, rescheduling a
+  // live event with nobody having typed anything.
+  it('leaves an existing event with no start date alone', () => {
+    expect(
+      initialStartsAtValue({ event: { id: 1, startsAt: null }, now: ACTIVATION })
+    ).toBeUndefined();
   });
 });
 
 describe('lateEnableWarning', () => {
-  const future = defaultStartsAtValue(ACTIVATION);
+  const past = new Date('2026-08-19T00:00:00.000Z');
+  const future = new Date('2026-08-20T00:00:00.000Z');
 
   it('says nothing when the event is not being enabled', () => {
-    expect(lateEnableWarning({ enabled: false, startsAt: null, now: ACTIVATION })).toBeNull();
+    expect(
+      lateEnableWarning({ next: { enabled: false, startsAt: null }, now: ACTIVATION })
+    ).toBeNull();
   });
 
   it('says nothing when enabling against a start date still to come', () => {
-    expect(lateEnableWarning({ enabled: true, startsAt: future, now: ACTIVATION })).toBeNull();
+    expect(
+      lateEnableWarning({ next: { enabled: true, startsAt: future }, now: ACTIVATION })
+    ).toBeNull();
   });
 
   it('warns when enabling with no start date at all', () => {
-    // The shape of RewardsBonusEvent id 1, which is `enabled` with a null start.
-    expect(lateEnableWarning({ enabled: true, startsAt: null, now: ACTIVATION })).toMatch(
+    expect(lateEnableWarning({ next: { enabled: true, startsAt: null }, now: ACTIVATION })).toMatch(
       /no start date/
     );
   });
 
-  // 🔴 The case this whole file exists for: id 2 carried 2026-08-19T00:00:00.000Z
-  // and was enabled at 21:18 the same day. Do not weaken this to a null check —
-  // the start date was present and correct, and the event still went live mid-day.
+  // The incident: id 2 carried 2026-08-19T00:00:00.000Z and was enabled at 21:18
+  // the same day. Do not weaken this to a null check — the start date was present
+  // and correct, and the event still went live mid-day.
   it('warns when enabling against a start date earlier the same UTC day', () => {
-    const startOfToday = defaultStartsAtValue(new Date('2026-08-18T12:00:00.000Z'));
-
-    expect(resolveDisplayStart(startOfToday).toISOString()).toBe('2026-08-19T00:00:00.000Z');
-    expect(lateEnableWarning({ enabled: true, startsAt: startOfToday, now: ACTIVATION })).toMatch(
+    expect(lateEnableWarning({ next: { enabled: true, startsAt: past }, now: ACTIVATION })).toMatch(
       /already passed/
     );
+  });
+
+  // 🔴 Scoped to the transition. Warning on the resting state fires on every edit
+  // of every running event, which is how the warning stops being read.
+  it('says nothing when editing an event that was already live', () => {
+    expect(
+      lateEnableWarning({
+        next: { enabled: true, startsAt: past },
+        previous: { enabled: true, startsAt: past },
+        now: ACTIVATION,
+      })
+    ).toBeNull();
+  });
+
+  it('warns when re-enabling an event that had been switched off', () => {
+    expect(
+      lateEnableWarning({
+        next: { enabled: true, startsAt: past },
+        previous: { enabled: false, startsAt: past },
+        now: ACTIVATION,
+      })
+    ).toMatch(/already passed/);
+  });
+
+  // Enabled, but the window is behind us — `getActiveRewardsBonusEvent` picks up
+  // nothing, so there is nothing to warn about.
+  it('says nothing when the end date has already gone by', () => {
+    expect(
+      lateEnableWarning({
+        next: { enabled: true, startsAt: past, endsAt: new Date('2026-08-19T12:00:00.000Z') },
+        now: ACTIVATION,
+      })
+    ).toBeNull();
   });
 });

--- a/src/components/RewardsBonusEvent/__tests__/rewards-bonus-event.utils.test.ts
+++ b/src/components/RewardsBonusEvent/__tests__/rewards-bonus-event.utils.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   initialStartsAtValue,
@@ -12,6 +12,35 @@ import {
 // 2026-08-19T21:18:52.600Z is the minute the "Creator Collab Update" event was
 // switched on, 21 hours after the 00:00 UTC start it already carried.
 const ACTIVATION = new Date('2026-08-19T21:18:52.600Z');
+
+const ORIGINAL_TZ = process.env.TZ;
+
+/**
+ * Run a block in a named zone, and prove the pin took.
+ *
+ * 🔴 Every display-space assertion here is an IDENTITY at UTC, which is what CI
+ * runs. Replacing `toDisplayDate` with `new Date(instant.getTime())` passes 17/17
+ * under `TZ=UTC` and fails 5 under `America/Denver`. A display test that inherits
+ * the runner's zone is not a weak test, it is no test.
+ *
+ * `delete` rather than assignment on restore: TZ is unset on some machines, and
+ * `process.env.TZ = undefined` stores the STRING "undefined", which Node reads as
+ * an invalid zone and resolves to UTC.
+ */
+function useTimezone(tz: string) {
+  beforeAll(() => {
+    process.env.TZ = tz;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_TZ === undefined) delete process.env.TZ;
+    else process.env.TZ = ORIGINAL_TZ;
+  });
+
+  it(`is running in ${tz}`, () => {
+    expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe(tz);
+  });
+}
 
 // 🔴 Deliberately NOT the instant passed as `now`. Every function here takes the
 // clock as a parameter, so a mutation reading the ambient clock instead would be
@@ -37,10 +66,14 @@ describe('nextUtcMidnight', () => {
   });
 });
 
-describe('the display round trip', () => {
-  // Asserted as a relation between calendar fields rather than against a literal,
-  // so it means the same thing in every timezone the runner might use.
-  it('shows the operator the UTC calendar day, whatever the local offset is', () => {
+// West of UTC is where the SHIFT is observable: 00:00 UTC falls on the previous
+// local day, so a conversion that forgets to shift renders and saves the day
+// before. East of UTC these same targets land on the same local day and every
+// assertion below passes without exercising anything.
+describe('the display round trip, west of UTC', () => {
+  useTimezone('America/Denver');
+
+  it('shows the operator the UTC calendar day, not the local one', () => {
     const instant = nextUtcMidnight(ACTIVATION);
     const display = toDisplayDate(instant);
 
@@ -49,6 +82,9 @@ describe('the display round trip', () => {
       instant.getUTCMonth(),
       instant.getUTCDate(),
     ]);
+    // The control for the zone: at UTC these are the same instant and the
+    // assertion above holds for any implementation, identity included.
+    expect(display.getTime()).not.toBe(instant.getTime());
   });
 
   it('resolves back to the instant it was built from', () => {
@@ -63,75 +99,54 @@ describe('the display round trip', () => {
     ).toBe('2026-09-02T23:59:59.999Z');
   });
 
-  // 🔴 The control that has to run in a REAL timezone. An offset-arithmetic
-  // implementation (`toDisplayUTC`/`fromDisplayUTC`) is a correct-looking identity
-  // at any FIXED offset — including UTC, which is what CI runs — and only slips
-  // where the offset differs between the instant and the shifted value. Mocking
-  // `getTimezoneOffset` to a constant cannot reach it; nor can a west-of-UTC
-  // offset, because `startOf('day')` absorbs the shift inside the same UTC day.
-  //
-  // Sydney's 2026-10-04 is the date the old implementation turned into 2026-10-03.
-  describe('across a DST start that lands on UTC midnight', () => {
-    const original = process.env.TZ;
+  describe('initialStartsAtValue', () => {
+    it('opens a new event on the next UTC midnight', () => {
+      const value = initialStartsAtValue({ event: undefined, now: ACTIVATION });
 
-    beforeEach(() => {
-      process.env.TZ = 'Australia/Sydney';
+      expect(resolveDisplayStart(value!).toISOString()).toBe('2026-08-20T00:00:00.000Z');
     });
 
-    // 🔴 `delete`, not assignment. TZ is UNSET on some machines, and
-    // `process.env.TZ = undefined` stores the STRING "undefined", which Node reads
-    // as an invalid zone and silently resolves to UTC — leaving every later test
-    // file in this worker on a different clock than it asked for.
-    afterAll(() => {
-      if (original === undefined) delete process.env.TZ;
-      else process.env.TZ = original;
+    it('keeps the start an existing event already has', () => {
+      const value = initialStartsAtValue({
+        event: { id: 2, startsAt: new Date('2026-08-19T00:00:00.000Z') },
+        now: ACTIVATION,
+      });
+
+      expect(resolveDisplayStart(value!).toISOString()).toBe('2026-08-19T00:00:00.000Z');
     });
 
-    it('does not slip a day when the offset changes mid-trip', () => {
-      // Sunday 2026-10-04 02:00 AEST -> 03:00 AEDT, i.e. the transition sits on
-      // the 2026-10-04T00:00Z boundary this default is aiming at.
-      const eve = new Date('2026-10-03T12:00:00.000Z');
-      const target = nextUtcMidnight(eve);
-
-      expect(target.toISOString()).toBe('2026-10-04T00:00:00.000Z');
-      expect(resolveDisplayStart(toDisplayDate(target)).toISOString()).toBe(
-        '2026-10-04T00:00:00.000Z'
-      );
-    });
-
-    it('has a local offset that actually moves across that boundary', () => {
-      // The positive control for the block above: without a real DST shift here,
-      // the assertion would hold for a broken implementation too.
-      expect(new Date('2026-10-03T12:00:00.000Z').getTimezoneOffset()).not.toBe(
-        new Date('2026-10-04T12:00:00.000Z').getTimezoneOffset()
-      );
+    // 🔴 Event id 1 is enabled with a null start. Collapsing the three arms to two
+    // would hand it a start date the moment a moderator opened it, rescheduling a
+    // live event with nobody having typed anything.
+    it('leaves an existing event with no start date alone', () => {
+      expect(
+        initialStartsAtValue({ event: { id: 1, startsAt: null }, now: ACTIVATION })
+      ).toBeUndefined();
     });
   });
 });
 
-describe('initialStartsAtValue', () => {
-  it('opens a new event on the next UTC midnight', () => {
-    const value = initialStartsAtValue({ event: undefined, now: ACTIVATION });
+// A different axis from the block above: this one catches the offset CHANGING
+// mid-trip, which is what the old toDisplayUTC/fromDisplayUTC pair did across a
+// DST boundary. Sydney's 2026-10-04 is the date it turned into 2026-10-03.
+describe('the display round trip, across a DST start on UTC midnight', () => {
+  useTimezone('Australia/Sydney');
 
-    expect(resolveDisplayStart(value!).toISOString()).toBe('2026-08-20T00:00:00.000Z');
+  it('does not slip a day when the offset changes mid-trip', () => {
+    // Sunday 2026-10-04 02:00 AEST -> 03:00 AEDT, i.e. the transition sits on the
+    // 2026-10-04T00:00Z boundary this default aims at.
+    const target = nextUtcMidnight(new Date('2026-10-03T12:00:00.000Z'));
+
+    expect(target.toISOString()).toBe('2026-10-04T00:00:00.000Z');
+    expect(resolveDisplayStart(toDisplayDate(target)).toISOString()).toBe(
+      '2026-10-04T00:00:00.000Z'
+    );
   });
 
-  it('keeps the start an existing event already has', () => {
-    const value = initialStartsAtValue({
-      event: { id: 2, startsAt: new Date('2026-08-19T00:00:00.000Z') },
-      now: ACTIVATION,
-    });
-
-    expect(resolveDisplayStart(value!).toISOString()).toBe('2026-08-19T00:00:00.000Z');
-  });
-
-  // 🔴 Event id 1 is enabled with a null start. Collapsing the three arms to two
-  // would hand it a start date the moment a moderator opened it, rescheduling a
-  // live event with nobody having typed anything.
-  it('leaves an existing event with no start date alone', () => {
-    expect(
-      initialStartsAtValue({ event: { id: 1, startsAt: null }, now: ACTIVATION })
-    ).toBeUndefined();
+  it('has a local offset that actually moves across that boundary', () => {
+    expect(new Date('2026-10-03T12:00:00.000Z').getTimezoneOffset()).not.toBe(
+      new Date('2026-10-04T12:00:00.000Z').getTimezoneOffset()
+    );
   });
 });
 
@@ -188,8 +203,8 @@ describe('lateEnableWarning', () => {
     ).toMatch(/already passed/);
   });
 
-  // Enabled, but the window is behind us — `getActiveRewardsBonusEvent` picks up
-  // nothing, so there is nothing to warn about.
+  // Enabled, but the window is behind us, so getActiveRewardsBonusEvent picks up
+  // nothing and there is nothing to warn about.
   it('says nothing when the end date has already gone by', () => {
     expect(
       lateEnableWarning({

--- a/src/components/RewardsBonusEvent/__tests__/rewards-bonus-event.utils.test.ts
+++ b/src/components/RewardsBonusEvent/__tests__/rewards-bonus-event.utils.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  defaultStartsAtValue,
+  lateEnableWarning,
+  nextUtcMidnight,
+  resolveDisplayStart,
+} from '~/components/RewardsBonusEvent/rewards-bonus-event.utils';
+
+// 2026-08-19T21:18:52.600Z is the minute the "Creator Collab Update" event was
+// switched on, 21 hours after the 00:00 UTC start it already carried. Using the
+// real instant keeps the tests anchored to the thing they exist to prevent.
+const ACTIVATION = new Date('2026-08-19T21:18:52.600Z');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(ACTIVATION);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('nextUtcMidnight', () => {
+  it('lands on the next UTC day, not the current one', () => {
+    expect(nextUtcMidnight(ACTIVATION).toISOString()).toBe('2026-08-20T00:00:00.000Z');
+  });
+
+  it('still moves forward a whole day when called exactly at midnight', () => {
+    expect(nextUtcMidnight(new Date('2026-08-19T00:00:00.000Z')).toISOString()).toBe(
+      '2026-08-20T00:00:00.000Z'
+    );
+  });
+});
+
+describe('defaultStartsAtValue', () => {
+  // 🔴 Pin a non-zero UTC offset rather than trusting the runner's. The whole
+  // display-space shift is a no-op at UTC, so on a UTC box (which is what CI is)
+  // these assertions hold for any implementation and prove nothing. UTC-5.
+  const OFFSET_MINUTES = 300;
+
+  beforeEach(() => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(OFFSET_MINUTES);
+  });
+
+  // The control for the pin above: if the offset were not being applied, the
+  // display value would equal the instant and the round-trip below would pass
+  // without exercising the shift at all.
+  it('is shifted away from the instant it represents', () => {
+    expect(defaultStartsAtValue(ACTIVATION).getTime()).toBe(
+      new Date('2026-08-20T00:00:00.000Z').getTime() + OFFSET_MINUTES * 60_000
+    );
+  });
+
+  // The picker value is shifted into display space and `handleSubmit` shifts it
+  // back. If the two disagree the default silently saves the wrong day, which is
+  // invisible in the UI because the picker renders the shifted value.
+  it('round-trips through the submit path to the next UTC midnight', () => {
+    expect(resolveDisplayStart(defaultStartsAtValue(ACTIVATION)).toISOString()).toBe(
+      '2026-08-20T00:00:00.000Z'
+    );
+  });
+});
+
+describe('lateEnableWarning', () => {
+  const future = defaultStartsAtValue(ACTIVATION);
+
+  it('says nothing when the event is not being enabled', () => {
+    expect(lateEnableWarning({ enabled: false, startsAt: null, now: ACTIVATION })).toBeNull();
+  });
+
+  it('says nothing when enabling against a start date still to come', () => {
+    expect(lateEnableWarning({ enabled: true, startsAt: future, now: ACTIVATION })).toBeNull();
+  });
+
+  it('warns when enabling with no start date at all', () => {
+    // The shape of RewardsBonusEvent id 1, which is `enabled` with a null start.
+    expect(lateEnableWarning({ enabled: true, startsAt: null, now: ACTIVATION })).toMatch(
+      /no start date/
+    );
+  });
+
+  // 🔴 The case this whole file exists for: id 2 carried 2026-08-19T00:00:00.000Z
+  // and was enabled at 21:18 the same day. Do not weaken this to a null check —
+  // the start date was present and correct, and the event still went live mid-day.
+  it('warns when enabling against a start date earlier the same UTC day', () => {
+    const startOfToday = defaultStartsAtValue(new Date('2026-08-18T12:00:00.000Z'));
+
+    expect(resolveDisplayStart(startOfToday).toISOString()).toBe('2026-08-19T00:00:00.000Z');
+    expect(lateEnableWarning({ enabled: true, startsAt: startOfToday, now: ACTIVATION })).toMatch(
+      /already passed/
+    );
+  });
+});

--- a/src/components/RewardsBonusEvent/rewards-bonus-event.utils.ts
+++ b/src/components/RewardsBonusEvent/rewards-bonus-event.utils.ts
@@ -1,5 +1,4 @@
-import dayjs from '~/shared/utils/dayjs';
-import { fromDisplayUTC, toDisplayUTC } from '~/utils/date-helpers';
+import { endOfDay, startOfDay } from '~/utils/date-helpers';
 
 /**
  * `startsAt` is a gate, not a trigger. `getActiveRewardsBonusEvent` requires
@@ -12,44 +11,106 @@ import { fromDisplayUTC, toDisplayUTC } from '~/utils/date-helpers';
  * who already claimed a once-per-day reward under the lower cap cannot claim the
  * difference, so activating part-way through a UTC day strands everyone who
  * claimed earlier in it. On 2026-08-19 that was 17,843 daily-boost claimers.
+ *
+ * These helpers only steer the operator toward an aligned start. The reward-side
+ * defect — ClickUp 868m16pdp, a once-per-day reward cannot claim the top-up to a
+ * cap that rose mid-day — is still open, and nothing here fixes it.
  */
 
 /** The first 00:00 UTC strictly after `now`. */
 export function nextUtcMidnight(now: Date) {
-  return dayjs.utc(now).add(1, 'day').startOf('day').toDate();
+  const tomorrow = new Date(now.getTime());
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  return startOfDay(tomorrow, { utc: true });
 }
 
 /**
- * The picker edits dates in "display UTC" space — shifted so the date the
- * operator sees is the UTC one — and `handleSubmit` reverses it. A default has to
- * live in the same space or it round-trips to the wrong day.
+ * The date pickers hold a LOCAL date whose calendar day is read as the UTC one.
+ *
+ * 🔴 Convert by calendar fields, never by `toDisplayUTC`/`fromDisplayUTC`. Those
+ * shift by `getTimezoneOffset()` taken at two different instants, so they are not
+ * inverses across a DST boundary — and against a 00:00 UTC target an hour of slip
+ * is a whole day. Measured with real `Intl` offsets: Australia/Sydney turns
+ * 2026-10-04 into 2026-10-03, Pacific/Auckland 2026-09-27 into 2026-09-26,
+ * America/Santiago 2026-04-05 into 2026-04-04, Asia/Beirut 2026-03-29 into
+ * 2026-03-28. Zones transitioning at 02:00 local (the US ones) never show it,
+ * which is why it survives a US-only reading. Reading the fields cannot slip:
+ * a skipped local midnight still reports the day the operator picked.
  */
-export function defaultStartsAtValue(now: Date) {
-  return toDisplayUTC(nextUtcMidnight(now));
+export function toDisplayDate(instant: Date) {
+  return new Date(instant.getUTCFullYear(), instant.getUTCMonth(), instant.getUTCDate());
 }
 
 /** The instant a display-space picker value resolves to once submitted. */
 export function resolveDisplayStart(value: Date) {
-  return dayjs.utc(fromDisplayUTC(value)).startOf('day').toDate();
+  return new Date(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()));
+}
+
+/** As `resolveDisplayStart`, but the far end of the same UTC day. */
+export function resolveDisplayEnd(value: Date) {
+  return endOfDay(resolveDisplayStart(value), { utc: true });
 }
 
 /**
- * Warns when saving would switch the event on mid-UTC-day. Returns the reason, or
- * null when the save is safe.
+ * What the start picker opens on. A create gets the next UTC midnight so that
+ * ticking Enabled straight away is already safe; an existing event keeps whatever
+ * it has, INCLUDING nothing.
+ *
+ * 🔴 The three arms are not two. Collapsing the middle one injects a start date
+ * into an event saved without one — event id 1 is enabled with a null start — and
+ * a moderator opening it to fix a typo would reschedule a live event having typed
+ * nothing.
  */
-export function lateEnableWarning({
-  enabled,
-  startsAt,
+export function initialStartsAtValue({
+  event,
   now,
 }: {
-  enabled: boolean;
-  startsAt?: Date | null;
+  event?: { id?: number; startsAt?: Date | null };
   now: Date;
 }) {
-  if (!enabled) return null;
-  if (!startsAt)
-    return 'This event has no start date, so saving turns it on immediately. Rewards already claimed today keep the lower cap until 00:00 UTC.';
-  if (resolveDisplayStart(startsAt).getTime() <= now.getTime())
-    return 'This start date has already passed, so saving turns the event on immediately. Rewards already claimed today keep the lower cap until 00:00 UTC.';
-  return null;
+  if (event?.startsAt) return toDisplayDate(event.startsAt);
+  if (event?.id) return undefined;
+  return toDisplayDate(nextUtcMidnight(now));
+}
+
+type ActivationState = {
+  enabled: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+};
+
+/** Whether `getActiveRewardsBonusEvent` would pick this state up right now. */
+function isLive(state: ActivationState, now: Date) {
+  if (!state.enabled) return false;
+  if (state.startsAt && state.startsAt.getTime() > now.getTime()) return false;
+  if (state.endsAt && state.endsAt.getTime() < now.getTime()) return false;
+  return true;
+}
+
+/**
+ * Warns when saving would switch the event on part-way through a UTC day.
+ *
+ * 🔴 Scoped to the TRANSITION, not to the resting state. Warning whenever a live
+ * event merely looks live fires on every edit of every running event — a banner
+ * label typo included — and the operators who see that are the same handful the
+ * warning exists to reach. An advisory control that cries wolf on the common path
+ * has already stopped working on the rare one.
+ *
+ * Both states are INSTANTS. Resolve display-space picker values before calling.
+ */
+export function lateEnableWarning({
+  next,
+  previous,
+  now,
+}: {
+  next: ActivationState;
+  previous?: ActivationState;
+  now: Date;
+}) {
+  if (!isLive(next, now)) return null;
+  if (previous && isLive(previous, now)) return null;
+
+  return next.startsAt
+    ? 'This start date has already passed, so saving turns the event on now. Rewards already claimed today keep the lower cap until 00:00 UTC.'
+    : 'This event has no start date, so saving turns it on now. Rewards already claimed today keep the lower cap until 00:00 UTC.';
 }

--- a/src/components/RewardsBonusEvent/rewards-bonus-event.utils.ts
+++ b/src/components/RewardsBonusEvent/rewards-bonus-event.utils.ts
@@ -1,0 +1,55 @@
+import dayjs from '~/shared/utils/dayjs';
+import { fromDisplayUTC, toDisplayUTC } from '~/utils/date-helpers';
+
+/**
+ * `startsAt` is a gate, not a trigger. `getActiveRewardsBonusEvent` requires
+ * `enabled` AND the window, and `enabled` is a checkbox with no schedule — so an
+ * event enabled by hand goes live at the moment of the click regardless of the
+ * start date it carries.
+ *
+ * That matters because every reward's daily cap multiplies by the event, while
+ * the Redis hash the caps are enforced against only resets at 00:00 UTC. A user
+ * who already claimed a once-per-day reward under the lower cap cannot claim the
+ * difference, so activating part-way through a UTC day strands everyone who
+ * claimed earlier in it. On 2026-08-19 that was 17,843 daily-boost claimers.
+ */
+
+/** The first 00:00 UTC strictly after `now`. */
+export function nextUtcMidnight(now: Date) {
+  return dayjs.utc(now).add(1, 'day').startOf('day').toDate();
+}
+
+/**
+ * The picker edits dates in "display UTC" space — shifted so the date the
+ * operator sees is the UTC one — and `handleSubmit` reverses it. A default has to
+ * live in the same space or it round-trips to the wrong day.
+ */
+export function defaultStartsAtValue(now: Date) {
+  return toDisplayUTC(nextUtcMidnight(now));
+}
+
+/** The instant a display-space picker value resolves to once submitted. */
+export function resolveDisplayStart(value: Date) {
+  return dayjs.utc(fromDisplayUTC(value)).startOf('day').toDate();
+}
+
+/**
+ * Warns when saving would switch the event on mid-UTC-day. Returns the reason, or
+ * null when the save is safe.
+ */
+export function lateEnableWarning({
+  enabled,
+  startsAt,
+  now,
+}: {
+  enabled: boolean;
+  startsAt?: Date | null;
+  now: Date;
+}) {
+  if (!enabled) return null;
+  if (!startsAt)
+    return 'This event has no start date, so saving turns it on immediately. Rewards already claimed today keep the lower cap until 00:00 UTC.';
+  if (resolveDisplayStart(startsAt).getTime() <= now.getTime())
+    return 'This start date has already passed, so saving turns the event on immediately. Rewards already claimed today keep the lower cap until 00:00 UTC.';
+  return null;
+}


### PR DESCRIPTION
## What this is

Operator-side guard for the shape behind ClickUp `868m16pdp`. **It does not fix the reward-side defect in that ticket, which stays open** — see the last section.

A rewards bonus event multiplies every reward's daily cap, but the Redis hash those caps are enforced against only resets at 00:00 UTC. A user who already claimed a once-per-day reward under the lower cap cannot claim the difference, so switching an event on part-way through a UTC day strands everyone who claimed earlier in it.

## Why `startsAt` didn't already prevent that

`startsAt` is a gate, not a trigger. `getActiveRewardsBonusEvent` requires `enabled` **and** the window, and `enabled` is a checkbox with no schedule.

`RewardsBonusEvent` id 2 carried `startsAt = 2026-08-19T00:00:00.000Z` — correctly at midnight — with `updatedAt = 2026-08-19T21:18:52.600Z`. The `buzzEvents` rows for `dailyBoost` show it paid at 1x through hour 20:00, split 241/428 in hour 21:00, and flat 2x after. 08-18 is flat 1x for all 24 hours and 08-20 flat 2x for all 24, so the transition is a single edit, twenty-one hours after the event's own start time.

**17,843 users** claimed that day before activation and could not take the top-up.

(What changed at 21:18 is not recorded — there is no audit trail on that table. The multiplier transition is observed; the cause is inferred from `updatedAt` lining up with it.)

## The change

Make the aligned choice the default rather than a thing to remember:

- Default `startsAt` to the **next** 00:00 UTC on create, so ticking Enabled straight away is already safe.
- Label both date fields UTC and say what the boundaries are.
- Warn on save when the event is being **switched on** part-way through a UTC day.

Advisory, not blocking — a deliberate mid-day start is sometimes legitimate, and a hard block on a moderator tool invites editing the row directly instead.

Moderator-only. Nothing under `src/server`, no schema, no query, no cache.

## Two things review caught that would otherwise have shipped

**The date conversion was broken across DST.** `toDisplayUTC`/`fromDisplayUTC` shift by `getTimezoneOffset()` read at two different instants, so they are not inverses across a transition — and against a 00:00 UTC target an hour of slip is a whole day. Enumerated across all 418 IANA zones over 2018-2035: **34 zones** drift on the old arithmetic, **0** on the new. Sydney turned 2026-10-04 into 2026-10-03. Zones transitioning at 02:00 local (the US ones) never show it, which is why it survives a US-only reading. So the default would have landed a day early in exactly the zones it exists to protect. Now converted by calendar fields, which cannot slip.

**The warning fired on a state, not a transition.** It read only the form's current values, so every edit of an already-running event — a banner label typo included — claimed the save would start it mid-day. The operators who see that are the same few the warning exists to reach, and an advisory control that cries wolf on the common path has already stopped working on the rare one. Now scoped to not-live → live, judged by the same enabled-and-within-window rule the service uses.

## Tests

Pure functions extracted so the logic is testable without the component; 19 tests. Every behaviour has a mutant recorded against it, including:

- `toDisplayDate` → identity: **17 passed under `TZ=UTC`** before the zone fix, **5 failed** after — `expected [ 2026, 7, 19 ] to deeply equal [ 2026, 7, 20 ]`
- revert to offset arithmetic: `expected '2026-10-03T00:00:00.000Z' to be '2026-10-04T00:00:00.000Z'`
- collapse `initialStartsAtValue`'s three arms to two: `expected 2026-08-20T00:00:00.000Z to be undefined`
- drop `{ utc: true }` from `endOfDay`: `expected '2026-09-02T05:59:59.999Z' to be '2026-09-02T23:59:59.999Z'`

The zone blocks are pinned with `process.env.TZ` and each asserts its own pin, because every display assertion here is an identity at UTC and CI runs UTC — a display test that inherits the runner's zone is not a weak test, it is no test.

Known and left unpinned: `setUTCDate` → `setDate` in `nextUtcMidnight` survives in every zone tried, because the `startOfDay` that follows absorbs it.

## Verification

`pnpm run typecheck` 0 errors. ESLint clean on all three files. Prettier clean. Full unit suite at `7e76e09bdc`: `1 failed | 1622 passed | 3 skipped (1626)` with both file and test counts reconciling, the single failure being the pre-existing Windows path assertion in `appListingMenuSurface.test.ts` that reproduces on `main` at `885e3a621f`. The only commit after that run touches one test file, run directly.

## Still open

`868m16pdp` itself. `dailyBoost` is the only registered on-demand reward keyed on the day rather than on a thing that happened, so its Redis dedup entry still blocks a second claim and a cap raised mid-day is still unclaimable. This PR makes that situation rarer; it does not fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mj2Cjt4YXSztqcAKvK3Yp6