### PR TITLE
fix(tests): normalise path separators in the AppListingActionsMenu ledger

### DIFF
--- a/src/components/Apps/__tests__/appListingMenuSurface.test.ts
+++ b/src/components/Apps/__tests__/appListingMenuSurface.test.ts
@@ -164,7 +164,10 @@ describe('the listing menu surface policy', () => {
           if (entry.isDirectory()) walk(full);
           else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) {
             if (/<AppListingActionsMenu\b/.test(fs.readFileSync(full, 'utf8'))) {
-              found.push(path.relative(SRC, full));
+              // Separators normalised because the ledger below is spelled with `/`:
+              // `path.relative` returns `\` on Windows, so the raw value is green on CI
+              // and red on every local run.
+              found.push(path.relative(SRC, full).split(path.sep).join('/'));
             }
           }
         }


### PR DESCRIPTION
`src/components/Apps/__tests__/appListingMenuSurface.test.ts` fails on `origin/main` on every Windows machine, and has reddened every local full-suite run on the box today.

The ledger test walks `src` and pushes `path.relative(SRC, full)`, which returns platform separators — `components\Apps\AppListingCard.tsx` on Windows — then compares it against forward-slash literals. Green on Linux CI, red locally.

Normalised at the push. The walk still covers the whole of `src`, and the assertion is still an exact `toEqual` on the set — nothing is narrowed, relaxed or skipped.

## Verified on this Windows box

**Before** (`origin/main` content, exit 1, `Tests 1 failed | 5 passed (6)`) — one failing assertion, no second platform problem in the file:

```
-   "components/Apps/AppListingCard.tsx",
+   "components\Apps\AppListingCard.tsx",
```

**After**: `Test Files 1 passed (1)` / `Tests 6 passed (6)`, exit 0.

**The guard still guards** — both directions mutated:

- *Set grows*: added a third `<AppListingActionsMenu` renderer at `src/components/Account/MutantProbe.tsx` (deliberately outside `components/Apps`, to prove the whole-`src` walk still sees it) — exit 1, `expected [ …(3) ] to deeply equal [ …(2) ]`, naming `components/Account/MutantProbe.tsx`.
- *Set shrinks*: removed one expected entry — exit 1, `expected [ …(2) ] to deeply equal [ Array(1) ]`.

Both mutants reverted; `git status` clean apart from this file.

`pnpm run typecheck` → `OK — 0 type errors`. `pnpm run lint` exits 1 repo-wide (358 pre-existing errors) with **zero** entries for this file.

**Full unit suite not run, deliberately.** The queue is saturated at ~20-25 min per slot and this PR is what makes those runs worth reading; queueing one to verify a one-line test-file change would add to the very wait it fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGLvuRNShS6UoMWGoDmuHh