### PR TITLE
fix(monetization): put every monetization gate on the creator score, at 10k

### DIFF
--- a/apps/creator-studio/src/lib/monetization/paid-access.ts
+++ b/apps/creator-studio/src/lib/monetization/paid-access.ts
@@ -9,11 +9,11 @@ export const MIN_GENERATION_PRICE = 50;
 export const DEFAULT_GENERATION_TRIAL_LIMIT = 10;
 export const MAX_GENERATION_TRIAL_LIMIT = 1000;
 
-// Max early-access days unlock by the creator's *models* score — mirrors the main app's
+// Max early-access days unlock by the creator score (`scores.total`) — mirrors the main app's
 // EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock (enforced by /api/v1/model-versions/early-access).
 // The 30-day feature-flag tier is intentionally omitted here.
 export const EARLY_ACCESS_SCORE_UNLOCK: ReadonlyArray<readonly [number, number]> = [
-  [40000, 3],
+  [10000, 3],
   [65000, 5],
   [90000, 7],
   [125000, 9],
@@ -21,11 +21,11 @@ export const EARLY_ACCESS_SCORE_UNLOCK: ReadonlyArray<readonly [number, number]>
   [250000, 15],
 ];
 
-// Highest early-access duration (days) the given models score unlocks. 0 = early access unavailable.
-export function earlyAccessDaysForScore(modelsScore: number): number {
+// Highest early-access duration (days) the given creator score unlocks. 0 = early access unavailable.
+export function earlyAccessDaysForScore(creatorScore: number): number {
   let days = 0;
   for (const [score, unlocked] of EARLY_ACCESS_SCORE_UNLOCK) {
-    if (modelsScore >= score) days = unlocked;
+    if (creatorScore >= score) days = unlocked;
   }
   return days;
 }
@@ -33,7 +33,7 @@ export function earlyAccessDaysForScore(modelsScore: number): number {
 // How many versions can be in early access *at the same time* — mirrors EARLY_ACCESS_CONFIG.scoreQuantityUnlock.
 // Separate from the duration unlock above: score gates both how long and how many. 30-day flag tier omitted.
 export const EARLY_ACCESS_QUANTITY_UNLOCK: ReadonlyArray<readonly [number, number]> = [
-  [40000, 1],
+  [10000, 1],
   [65000, 2],
   [90000, 4],
   [125000, 6],
@@ -41,11 +41,11 @@ export const EARLY_ACCESS_QUANTITY_UNLOCK: ReadonlyArray<readonly [number, numbe
   [250000, 20],
 ];
 
-// Concurrent early-access slots the given models score unlocks. 0 = early access unavailable.
-export function earlyAccessQuantityForScore(modelsScore: number): number {
+// Concurrent early-access slots the given creator score unlocks. 0 = early access unavailable.
+export function earlyAccessQuantityForScore(creatorScore: number): number {
   let quantity = 0;
   for (const [score, unlocked] of EARLY_ACCESS_QUANTITY_UNLOCK) {
-    if (modelsScore >= score) quantity = unlocked;
+    if (creatorScore >= score) quantity = unlocked;
   }
   return quantity;
 }

--- a/apps/creator-studio/src/lib/server/__tests__/licensing-fee-poi-guard.test.ts
+++ b/apps/creator-studio/src/lib/server/__tests__/licensing-fee-poi-guard.test.ts
@@ -12,7 +12,7 @@ const state = vi.hoisted(() => ({
   released: [] as number[][],
   releaseFilters: [] as string[],
   slotsUsed: 0,
-  modelsScore: 50_000,
+  creatorScore: 50_000,
   // modelVersionId -> the last licenseFee charge ClickHouse reports for it.
   charges: {} as Record<number, string>,
   chargeQueries: [] as string[],
@@ -64,7 +64,12 @@ vi.mock('$lib/server/db', () => {
       });
     if (table === 'User')
       return chain({
-        executeTakeFirst: async () => ({ meta: { scores: { models: state.modelsScore } } }),
+        executeTakeFirst: async () => ({
+          // `models` is deliberately high and unequal: with a single-key fixture the spoke's
+          // getTotalScore and its aggregate getCreatorScore return the same number, and swapping
+          // the gate between them stays green. This is what makes that swap visible.
+          meta: { scores: { total: state.creatorScore, models: 50_000 } },
+        }),
       });
     if (table === 'PricingSlot')
       return chain({ executeTakeFirst: async () => ({ count: String(state.slotsUsed) }) });
@@ -146,7 +151,7 @@ beforeEach(() => {
   state.chargeQueries = [];
   state.clickhouseDown = false;
   state.slotsUsed = 0;
-  state.modelsScore = 50_000;
+  state.creatorScore = 50_000;
 });
 
 // Clearing a price hands the slot back, but only when nothing has transacted against the version — the
@@ -444,7 +449,7 @@ describe('licensing fee POI guard', () => {
 describe('eligibility floor and monthly allowance', () => {
   it('refuses a first fee from a creator below the score floor, and writes nothing', async () => {
     state.rows = [version()];
-    state.modelsScore = 9_999;
+    state.creatorScore = 9_999;
 
     const result = await setLicensingFee(7, GOLD, 1, 1, true);
 
@@ -453,9 +458,34 @@ describe('eligibility floor and monthly allowance', () => {
     expect(state.slots).toEqual([]);
   });
 
+  // User.meta is JSON, so a string-typed score is possible. getTotalScore reads it strictly for this
+  // reason: coercing it here would allow a row the main app refuses, at the same money gate on the
+  // same account. Nothing else in the spoke exercises that strictness.
+  it('refuses a string score rather than coercing it, matching the main app', async () => {
+    state.rows = [version()];
+    state.creatorScore = '999999' as unknown as number;
+
+    const result = await setLicensingFee(7, GOLD, 1, 1, true);
+
+    expect(result).toMatchObject({ ok: false, status: 403 });
+    expect(state.written).toEqual([]);
+  });
+
+  // The other direction the fixture could not previously see: `total` absent entirely must not fall
+  // back to another key.
+  it('refuses when the total score is missing altogether', async () => {
+    state.rows = [version()];
+    state.creatorScore = undefined as unknown as number;
+
+    const result = await setLicensingFee(7, GOLD, 1, 1, true);
+
+    expect(result).toMatchObject({ ok: false, status: 403 });
+    expect(state.written).toEqual([]);
+  });
+
   it('lets a below-floor creator change a fee they already charge', async () => {
     state.rows = [version({ currentFee: 2 })];
-    state.modelsScore = 0;
+    state.creatorScore = 0;
 
     const result = await setLicensingFee(7, GOLD, 1, 5, true);
 
@@ -467,7 +497,7 @@ describe('eligibility floor and monthly allowance', () => {
   // Already sells through a permanent gate, so it is exempt from both rules.
   it('treats a version with a permanent gate and no fee as already priced', async () => {
     state.rows = [version({ gated: 1 })];
-    state.modelsScore = 0;
+    state.creatorScore = 0;
     state.slotsUsed = 3;
 
     const result = await setLicensingFee(7, GOLD, 1, 1, true);

--- a/apps/creator-studio/src/lib/server/creator-score.ts
+++ b/apps/creator-studio/src/lib/server/creator-score.ts
@@ -49,7 +49,7 @@ export async function getTotalScore(userId: number): Promise<number> {
 
 // Moderator-only testing override (this app only), mirroring TEST_MEMBERSHIP_COOKIE. The early-access
 // ladder keys off the creator score, which membership doesn't touch — so simulating a tier alone can't
-// reach these flows, and the ladder's first rung is 40k. Set from the sidebar simulator.
+// reach these flows, and the ladder's first rung is 10k. Set from the sidebar simulator.
 // Cookie name predates the switch off the models score; renaming it would only drop live simulator state.
 export const TEST_MODELS_SCORE_COOKIE = 'cs-test-models-score';
 

--- a/apps/creator-studio/src/lib/server/creator-score.ts
+++ b/apps/creator-studio/src/lib/server/creator-score.ts
@@ -35,18 +35,25 @@ export async function getCreatorScore(userId: number): Promise<number> {
   return Math.max(sum, num(scores.total));
 }
 
-// The per-type *models* score — what the early-access day ladder keys off (distinct from the
-// aggregate creator score above).
-export async function getModelsScore(userId: number): Promise<number> {
-  return num((await readScores(userId)).models);
+// The stored total, which is the number `/user/account` puts under the words "Creator Score" — so it
+// is what every gate that says "creator score" to the creator must compare against. Distinct from the
+// aggregate above only when the nightly job has left `total` stale below the sum of its parts; the
+// creator sees the stale figure too, so a gate reading it stays consistent with what they are told.
+export async function getTotalScore(userId: number): Promise<number> {
+  // Strict rather than `num`, which coerces: a string-typed score in this JSON column would read
+  // 50000 here and 0 in the main app's creatorScoreFromMeta, so the same row would be refused
+  // permission to price in one app and allowed in the other, at the same money gate.
+  const total = (await readScores(userId)).total;
+  return typeof total === 'number' && Number.isFinite(total) ? total : 0;
 }
 
 // Moderator-only testing override (this app only), mirroring TEST_MEMBERSHIP_COOKIE. The early-access
-// ladder keys off the *models* score, which membership doesn't touch — so simulating a tier alone can't
+// ladder keys off the creator score, which membership doesn't touch — so simulating a tier alone can't
 // reach these flows, and the ladder's first rung is 40k. Set from the sidebar simulator.
+// Cookie name predates the switch off the models score; renaming it would only drop live simulator state.
 export const TEST_MODELS_SCORE_COOKIE = 'cs-test-models-score';
 
-export async function resolveModelsScore(
+export async function resolveTotalScore(
   userId: number,
   isModerator: boolean,
   testCookie?: string
@@ -55,7 +62,7 @@ export async function resolveModelsScore(
     const n = Number(testCookie);
     if (Number.isFinite(n) && n >= 0) return n;
   }
-  return getModelsScore(userId);
+  return getTotalScore(userId);
 }
 
 // Moderator-only testing override (this app only), mirroring TEST_MODELS_SCORE_COOKIE. Scheduled sales

--- a/apps/creator-studio/src/lib/server/monetization/pricing-slot.ts
+++ b/apps/creator-studio/src/lib/server/monetization/pricing-slot.ts
@@ -12,7 +12,7 @@ import {
 import { getClickhouse } from '$lib/server/clickhouse';
 import { withTimeoutFallback } from '$lib/server/timeout';
 import { dbRead, dbWrite } from '$lib/server/db';
-import { getModelsScore } from '$lib/server/creator-score';
+import { getTotalScore } from '$lib/server/creator-score';
 import { cappedTier, type Membership } from '$lib/server/membership';
 
 // This spoke's direct-SQL writes never reach the main app's service layer, so both pricing rules are
@@ -242,9 +242,9 @@ export async function assertPricingAllowed(
 ): Promise<PricingGateResult> {
   if (newlyPricedCount <= 0) return { ok: true };
 
-  // The REAL score, not resolveModelsScore: the moderator score simulator moves what this page shows,
+  // The REAL score, not resolveTotalScore: the moderator score simulator moves what this page shows,
   // never what it enforces. Simulating past a money gate would make the simulator a bypass.
-  const score = await getModelsScore(userId);
+  const score = await getTotalScore(userId);
   if (score < MONETIZATION_MIN_CREATOR_SCORE)
     return { ok: false, status: 403, error: pricingFloorMessage() };
 

--- a/apps/creator-studio/src/routes/(app)/+layout.svelte
+++ b/apps/creator-studio/src/routes/(app)/+layout.svelte
@@ -61,7 +61,7 @@
   // a tier can't reach those flows on an account below the first rung (10k).
   const scoreOptions = [
     { value: '', label: 'Real score' },
-    ...[40000, 90000, 250000].map((score) => {
+    ...[9_999, 10_000, 90_000, 250_000].map((score) => {
       const days = earlyAccessDaysForScore(score);
       const slots = earlyAccessQuantityForScore(score);
       return {

--- a/apps/creator-studio/src/routes/(app)/+layout.svelte
+++ b/apps/creator-studio/src/routes/(app)/+layout.svelte
@@ -57,8 +57,8 @@
     invalidateAll();
   }
 
-  // The early-access ladder keys off the models score, not membership, so simulating a tier can't reach
-  // those flows on an account below the first rung (40k).
+  // The early-access ladder keys off the creator score (`scores.total`), not membership, so simulating
+  // a tier can't reach those flows on an account below the first rung (40k).
   const scoreOptions = [
     { value: '', label: 'Real score' },
     ...[40000, 90000, 250000].map((score) => {

--- a/apps/creator-studio/src/routes/(app)/+layout.svelte
+++ b/apps/creator-studio/src/routes/(app)/+layout.svelte
@@ -58,7 +58,7 @@
   }
 
   // The early-access ladder keys off the creator score (`scores.total`), not membership, so simulating
-  // a tier can't reach those flows on an account below the first rung (40k).
+  // a tier can't reach those flows on an account below the first rung (10k).
   const scoreOptions = [
     { value: '', label: 'Real score' },
     ...[40000, 90000, 250000].map((score) => {

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -31,7 +31,7 @@ import {
 import { checkbox } from '$lib/server/form-fields';
 import {
   resolveCreatorScore,
-  resolveModelsScore,
+  resolveTotalScore,
   TEST_CREATOR_SCORE_COOKIE,
   TEST_MODELS_SCORE_COOKIE,
 } from '$lib/server/creator-score';
@@ -73,7 +73,7 @@ export const load: PageServerLoad = async ({ locals, parent, url, cookies }) => 
   const [view, modelsScore, pricingUsed, earlyAccessUsed, creatorScore, pricingSlots] =
     await Promise.all([
       getModelsView(locals.user, url, cookies),
-      resolveModelsScore(
+      resolveTotalScore(
         locals.user.id,
         !!locals.user.isModerator,
         cookies.get(TEST_MODELS_SCORE_COOKIE)
@@ -209,7 +209,10 @@ export const actions: Actions = {
     if (!permanent && !locals.user.isModerator) {
       // A timed window is bounded by creator score, not membership — and it has no price ceiling at all,
       // so the permanent price/count caps below don't apply to it.
-      const score = await resolveModelsScore(
+      // Load-bearing: the enclosing `!locals.user.isModerator` is what makes passing the simulator
+      // cookie into an enforced decision safe here — it is always discarded at this call. Dropping
+      // that half of the condition would make the simulator move a money gate.
+      const score = await resolveTotalScore(
         locals.user.id,
         !!locals.user.isModerator,
         cookies.get(TEST_MODELS_SCORE_COOKIE)

--- a/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/sales/+page.server.ts
@@ -14,7 +14,7 @@ import {
   shortenSale,
   summarizeSaleSelection,
 } from '$lib/server/monetization/sales';
-import { resolveCreatorScore, TEST_CREATOR_SCORE_COOKIE } from '$lib/server/creator-score';
+import { resolveTotalScore, TEST_CREATOR_SCORE_COOKIE } from '$lib/server/creator-score';
 import { minCreatorScoreForSale } from '@civitai/buzz';
 import { salePreviewPayload } from '$lib/monetization/sales';
 import type { SessionUser } from '@civitai/auth';
@@ -87,7 +87,7 @@ export const load: PageServerLoad = async ({ locals, parent, cookies }) => {
         getCreatorSales(locals.user.id),
         getManageableSales(locals.user.id),
         getSaleLimitOverrides(),
-        resolveCreatorScore(
+        resolveTotalScore(
           locals.user.id,
           !!locals.user.isModerator,
           cookies.get(TEST_CREATOR_SCORE_COOKIE)
@@ -141,7 +141,7 @@ export const actions: Actions = {
     if (!parsed.success) return fail(400, { error: firstError(parsed.error) });
 
     // The score floor is a server rule, not a form hint — the form only renders the progress bar.
-    const creatorScore = await resolveCreatorScore(
+    const creatorScore = await resolveTotalScore(
       locals.user.id,
       !!locals.user.isModerator,
       cookies.get(TEST_CREATOR_SCORE_COOKIE)

--- a/docs/features/monetization-rules.md
+++ b/docs/features/monetization-rules.md
@@ -129,10 +129,10 @@ it lapsed in, which would fix the involuntary case (a failed card is the most co
 Gold is **unlimited**, so "held it at any point this month" would mean unlimited pricing for that month
 off one payment. Left as-is deliberately; revisit with that cost in view.
 
-**Membership tier does not unlock early access.** The ladder reads the creator score (`scores.total`)
-and starts at 10,000 — the same floor as pricing, so early access and monetization open at one
-number — so simulating a tier will never reach it — the studio has a separate moderator-only score simulator
-for this reason. The one non-score unlock is the **granted `thirtyDayEarlyAccess` feature flag**, which by
+**Membership tier does not unlock early access.** The ladder reads the creator score
+(`scores.total`), so simulating a tier will never reach it — the studio has a separate
+moderator-only score simulator for this reason. Its entry rung is 10,000, matching the pricing
+floor. The one non-score unlock is the **granted `thirtyDayEarlyAccess` feature flag**, which by
 itself confers the top rung (30 days, 30 concurrent) at any score.
 
 The fee ceiling blocks **raises only** (`raisesOverCap`): a stored price above it stays chargeable, so a

--- a/docs/features/monetization-rules.md
+++ b/docs/features/monetization-rules.md
@@ -93,12 +93,20 @@ publish-restricted.
 
 | Limit                     | Source                              | Applies to                    |
 | ------------------------- | ----------------------------------- | ----------------------------- |
-| Eligibility (score ≥ 10k)  | **Creator score** (`models` score)  | A new fee or a new gate       |
+| Eligibility (score ≥ 10k)  | **Creator score** (`scores.total`)  | A new fee or a new gate       |
 | New prices per month      | **Membership tier**                 | A new fee or a permanent gate |
 | Licensing fee ceiling     | Flat 100/generation × media type    | Fees                          |
 | Paid access price ceiling | — none                              | —                             |
 | Window length (days)      | **Creator score**                   | Timed                         |
 | Concurrent windows        | **Creator score**                   | Timed                         |
+
+**Every "creator score" in this table is `User.meta.scores.total`** — the figure `/user/account`
+displays under that name. Monetization and the early-access ladder both compared against the
+per-category `scores.models` until 2026-09-04; 45,216 accounts were above the displayed floor and
+below the enforced one, and had no way to see why. **Any gate that says "creator score" to the user**
+reads it through `creatorScoreFromMeta` (`src/shared/utils/creator-score.ts`) rather than reaching
+into `meta.scores` directly. (The rate-limit checks in `src/server/schema/{comment,reaction,post}.schema.ts`
+still inline `scores.total`; they gate posting frequency, not money, and are not covered by this rule.)
 
 Every creator gets the same fee ceiling — `maxLicensingFeeCeiling`, 100 per generation and 500 on a
 video model. Paid access has no ceiling at all. What a tier buys is **allowance**:
@@ -121,8 +129,8 @@ it lapsed in, which would fix the involuntary case (a failed card is the most co
 Gold is **unlimited**, so "held it at any point this month" would mean unlimited pricing for that month
 off one payment. Left as-is deliberately; revisit with that cost in view.
 
-**Membership tier does not unlock early access.** The ladder reads `User.meta.scores.models` and starts at
-40,000, so simulating a tier will never reach it — the studio has a separate moderator-only score simulator
+**Membership tier does not unlock early access.** The ladder reads the creator score (`scores.total`)
+and starts at 40,000, so simulating a tier will never reach it — the studio has a separate moderator-only score simulator
 for this reason. The one non-score unlock is the **granted `thirtyDayEarlyAccess` feature flag**, which by
 itself confers the top rung (30 days, 30 concurrent) at any score.
 

--- a/docs/features/monetization-rules.md
+++ b/docs/features/monetization-rules.md
@@ -130,7 +130,8 @@ Gold is **unlimited**, so "held it at any point this month" would mean unlimited
 off one payment. Left as-is deliberately; revisit with that cost in view.
 
 **Membership tier does not unlock early access.** The ladder reads the creator score (`scores.total`)
-and starts at 40,000, so simulating a tier will never reach it — the studio has a separate moderator-only score simulator
+and starts at 10,000 — the same floor as pricing, so early access and monetization open at one
+number — so simulating a tier will never reach it — the studio has a separate moderator-only score simulator
 for this reason. The one non-score unlock is the **granted `thirtyDayEarlyAccess` feature flag**, which by
 itself confers the top rung (30 days, 30 concurrent) at any score.
 

--- a/docs/licensing-fee-revamp-checklist.md
+++ b/docs/licensing-fee-revamp-checklist.md
@@ -51,7 +51,7 @@ Nothing from that branch is being carried forward except two notes worth keeping
 Added by Justin 2026-08-20, not in the article. Gates **any** monetization, so it sits in front of
 everything below: no licensing fee, no paid access, without the score.
 
-- [x] Read `User.meta.scores.models`, the same score the early-access ladder uses
+- [x] Read `User.meta.scores.total`, the same score the early-access ladder uses
       (`EARLY_ACCESS_CONFIG` in [common/constants.ts](../src/server/common/constants.ts)). Note EA
       already gates 4× higher — its first rung is 40,000 — so this floor binds on fees and paid
       access, not on EA.

--- a/docs/testing/reading-ci-results.md
+++ b/docs/testing/reading-ci-results.md
@@ -1,0 +1,60 @@
+# Reading a CI result on a PR
+
+Two traps, both measured on 2026-09-04, both of which produced a **real, correct, still-visible
+green attached to the wrong commit**. Neither is a silent negative — there is nothing absent to
+notice, which is what makes them worse than the failure modes we already write down.
+
+## 1. `gh pr checks` answers a question you did not ask
+
+On PR #4640 it reported `no checks reported on the branch`. That reads as "CI has not started yet".
+What was actually true: **four workflow runs existed and had passed**, against a commit three
+pushes behind the branch tip.
+
+`gh pr checks` and the PR's own checks tab are scoped in a way that can leave you with a green you
+did not earn. Ask about the SHA instead:
+
+```bash
+sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+gh api repos/<owner>/<repo>/commits/$sha/status     -q '.state'
+gh api repos/<owner>/<repo>/commits/$sha/check-runs -q '.total_count'
+gh run list --branch <branch> --json headSha,name,conclusion
+```
+
+**A healthy internal PR here has 13 check-runs at head and a `success` combined status** carrying
+`tekton / typecheck` and `tekton / fixture-bootstrap` (measured across PRs #4641–#4643). A count of
+0 is obvious; a count of 4 would not have been, which is why the number is worth knowing.
+
+The two systems are separate and you need both. For an internal PR targeting `main`,
+`tekton / typecheck` is the **authoritative** typecheck — the GitHub Actions typecheck job
+deliberately skips that case (see the header of `.github/workflows/lint.yml`). So a check set that
+contains Actions results but no Tekton status does not cover the thing that gates.
+
+## 2. `gh pr view --json headRefOid` can hand you the previous SHA
+
+Immediately after a force-push it returned the **old** commit. On that single read the push looks
+like it failed. Confirm from three sources that agree — local `HEAD`, `origin/<branch>`, and the
+PR's `headRefOid` — before reporting either way.
+
+## Unconfirmed: force-push may not re-trigger either CI system
+
+**Hypothesis, not established.** On PR #4640 the only push that ever produced runs was the branch's
+**first, non-force** push. Three subsequent `--force-with-lease` pushes and one close/reopen produced
+nothing from GitHub Actions *or* Tekton, while three other PRs open at the same time each had a full
+13 runs at head. All four workflows are `on: pull_request: branches: [main, release]` with no
+`types:`, so the default already includes `synchronize` and `reopened` — the configuration says this
+should have fired.
+
+Confirming it needs a second force-pushed PR to compare against, which we did not have.
+
+**If it is true, the consequence is the one worth caring about:** a force-pushed PR can sit
+indefinitely at a green belonging to an older commit, while `gh pr checks` reports nothing wrong.
+Reviewers see a PR that looks tested and is not.
+
+**Until someone confirms or refutes it: after any force-push, check by SHA that runs exist for the
+new commit.** If none appear, push a real commit rather than re-forcing — that is the only shape of
+push observed to produce runs here, and this repo squash-merges, so the extra commit never reaches
+`main`'s history.
+
+> The workflow file already warns about the general form of this, about a different question:
+> *"Both were reasoning from the workflow's CONFIGURATION, which says nothing about whether the job
+> RUNS."* Everything above is the same lesson, arrived at from the other direction.

--- a/docs/testing/reading-ci-results.md
+++ b/docs/testing/reading-ci-results.md
@@ -35,22 +35,26 @@ Immediately after a force-push it returned the **old** commit. On that single re
 like it failed. Confirm from three sources that agree — local `HEAD`, `origin/<branch>`, and the
 PR's `headRefOid` — before reporting either way.
 
-## Measured: force-push does not re-trigger Tekton, and Actions can stop firing entirely
+## Two systems post here, they fail independently, and one of them stopped
 
-Two separate systems post to a PR here and they fail differently. **They are not interchangeable and
-neither substitutes for the other.**
-
-| System | Surfaces as | On PR #4640 |
+| System | Surfaces as | Latency |
 | --- | --- | --- |
-| Tekton (in-cluster) | **commit statuses** — `tekton / typecheck`, `tekton / fixture-bootstrap` | skipped 3 force-pushes; fired on the next **normal** push, ~3.5 min |
-| GitHub Actions | **check-runs** — Lint, Schema drift gate, Submodule Pin Guard, Windows dev-env | fired once on the branch's first push, then never again — including on the normal push |
+| Tekton (in-cluster) | **commit statuses** — `tekton / typecheck`, `tekton / fixture-bootstrap` | ~3.5 min |
+| GitHub Actions | **check-runs** — Lint, Schema drift gate, Submodule Pin Guard, Windows dev-env | ~immediate |
 
-Sequence measured 2026-09-04/05: branch created and pushed → 4 Actions runs + 2 Tekton statuses.
-Three `--force-with-lease` pushes → nothing from either. One close/reopen → nothing. One **normal**
-fast-forward push → **Tekton posted both statuses; Actions produced zero check-runs.**
+Observed on PR #4640 over an evening, in order: branch created and pushed → 4 Actions runs + 2 Tekton
+statuses. Three amend + `--force-with-lease` pushes → **nothing from either**. One close/reopen →
+nothing. Two normal pushes → **Tekton only**. One rebase + `--force-with-lease` → **Tekton only**.
 
-So the force-push hypothesis holds for Tekton and does **not** explain Actions, which stopped firing
-on this PR for a reason this evidence does not identify.
+**What is established:** GitHub Actions fired once, on the branch's first push, and never again —
+through six subsequent pushes of three different shapes. That is a real and unexplained failure, and
+it is why `gh pr checks` on this PR can report a pass over jobs that never ran.
+
+**What is NOT established, and what an earlier revision of this file wrongly claimed:** that
+force-push is the discriminator. It looked that way after three amend-pushes produced nothing and a
+normal push produced Tekton — but a later rebase-and-force-push produced Tekton too. So the shape of
+the push does not explain it, and whatever does is still unidentified. **Do not plan around a rule
+here; measure the SHA you actually have.**
 
 ### The part that will fool you
 

--- a/docs/testing/reading-ci-results.md
+++ b/docs/testing/reading-ci-results.md
@@ -35,25 +35,56 @@ Immediately after a force-push it returned the **old** commit. On that single re
 like it failed. Confirm from three sources that agree — local `HEAD`, `origin/<branch>`, and the
 PR's `headRefOid` — before reporting either way.
 
-## Unconfirmed: force-push may not re-trigger either CI system
+## Measured: force-push does not re-trigger Tekton, and Actions can stop firing entirely
 
-**Hypothesis, not established.** On PR #4640 the only push that ever produced runs was the branch's
-**first, non-force** push. Three subsequent `--force-with-lease` pushes and one close/reopen produced
-nothing from GitHub Actions *or* Tekton, while three other PRs open at the same time each had a full
-13 runs at head. All four workflows are `on: pull_request: branches: [main, release]` with no
-`types:`, so the default already includes `synchronize` and `reopened` — the configuration says this
-should have fired.
+Two separate systems post to a PR here and they fail differently. **They are not interchangeable and
+neither substitutes for the other.**
 
-Confirming it needs a second force-pushed PR to compare against, which we did not have.
+| System | Surfaces as | On PR #4640 |
+| --- | --- | --- |
+| Tekton (in-cluster) | **commit statuses** — `tekton / typecheck`, `tekton / fixture-bootstrap` | skipped 3 force-pushes; fired on the next **normal** push, ~3.5 min |
+| GitHub Actions | **check-runs** — Lint, Schema drift gate, Submodule Pin Guard, Windows dev-env | fired once on the branch's first push, then never again — including on the normal push |
 
-**If it is true, the consequence is the one worth caring about:** a force-pushed PR can sit
-indefinitely at a green belonging to an older commit, while `gh pr checks` reports nothing wrong.
-Reviewers see a PR that looks tested and is not.
+Sequence measured 2026-09-04/05: branch created and pushed → 4 Actions runs + 2 Tekton statuses.
+Three `--force-with-lease` pushes → nothing from either. One close/reopen → nothing. One **normal**
+fast-forward push → **Tekton posted both statuses; Actions produced zero check-runs.**
 
-**Until someone confirms or refutes it: after any force-push, check by SHA that runs exist for the
-new commit.** If none appear, push a real commit rather than re-forcing — that is the only shape of
-push observed to produce runs here, and this repo squash-merges, so the extra commit never reaches
-`main`'s history.
+So the force-push hypothesis holds for Tekton and does **not** explain Actions, which stopped firing
+on this PR for a reason this evidence does not identify.
+
+### The part that will fool you
+
+After that normal push, `gh pr checks` reported:
+
+```
+CI Checks Summary:
+  [ok] Passed: 2
+  [FAIL] Failed: 0
+```
+
+**Two passed, zero failed, and 13 checks that never ran.** Nothing in that output is false and
+nothing in it is missing-looking. Earlier the same command on the same PR said `no checks reported`
+while four passing runs existed against an older commit. It answers about what it found, never about
+what should have been there.
+
+### What to do
+
+- **Count, don't skim.** A healthy internal PR here carries **13 check-runs plus 2 Tekton statuses**
+  at head (measured across #4641–#4643). `Passed: 2` is not a pass.
+- **Check both mechanisms by SHA**, because one can be present while the other is absent:
+
+```bash
+sha=$(gh pr view <pr> --json headRefOid -q .headRefOid)
+gh api repos/<owner>/<repo>/commits/$sha/status     -q '.state + " " + ([.statuses[]?.context]|join(","))'
+gh api repos/<owner>/<repo>/commits/$sha/check-runs -q '.total_count'
+```
+
+- **After a force-push, expect no Tekton status.** Push a real commit instead; this repo
+  squash-merges, so it never reaches `main`'s history.
+- For an internal PR targeting `main`, `tekton / typecheck` is the **authoritative** typecheck — the
+  Actions typecheck job deliberately skips that case (see the header of `.github/workflows/lint.yml`).
+  So Tekton present + Actions absent still leaves Lint, the schema drift gate, the submodule pin
+  guard and the Windows dev-env smoke unrun.
 
 > The workflow file already warns about the general form of this, about a different question:
 > *"Both were reasoning from the workflow's CONFIGURATION, which says nothing about whether the job

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -286,9 +286,19 @@ export const SALE_DAYS_BY_TIER: Record<string, number> = {
 };
 
 /**
- * Creator score (`User.meta.scores.models`) required to charge for anything — a new price, or a sale.
+ * The floor required to charge for anything — a new price, or a sale.
+ *
+ * The two gates do not read the same number, and this constant cannot make them. The PRICING gate
+ * compares `User.meta.scores.total`, the figure `/user/account` shows. The SALE gate compares the
+ * spoke's aggregate, `GREATEST(sum of the six categories, total)`, which is >= it — so a small
+ * cohort sits below this floor for pricing and at or above it for sales (46 accounts when measured
+ * 2026-09-04). Reconciling them is a
+ * separate decision; until it is made, do not read this comment as one definition.
  *
  * Deliberately NOT waived for moderators: it states who may sell here, not a permission level.
+ * The two paths do not resolve their input identically — see the private operations note before
+ * treating this constant as a description of the sale gate's behaviour.
+ *
  * The sale gate reads it via `minCreatorScoreForSale`, which a KeyValue override can move without a
  * deploy; the pricing gate has no override.
  */

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1849,9 +1849,10 @@ export const EARLY_ACCESS_CONFIG: {
   buzzChargedPerDay: 100,
   timeframeValues: [3, 5, 7, 9, 12, 15, 30],
   scoreTimeFrameUnlock: [
-    // The maximum amount of days that can be set based off of score. The entry rung matches the
-    // monetization floor (MONETIZATION_MIN_CREATOR_SCORE) on purpose: early access and pricing open
-    // at the same creator score, so there is one number to explain rather than two.
+    // The maximum amount of days that can be set based off of score. The entry rung is set to the
+    // same figure as MONETIZATION_MIN_CREATOR_SCORE, deliberately — but the two are separate
+    // constants that nothing keeps in step, and clearing this rung is not the same permission as
+    // clearing the pricing floor. Do not read the shared number as a shared rule.
     [10000, 3],
     [65000, 5],
     [90000, 7],

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1849,8 +1849,10 @@ export const EARLY_ACCESS_CONFIG: {
   buzzChargedPerDay: 100,
   timeframeValues: [3, 5, 7, 9, 12, 15, 30],
   scoreTimeFrameUnlock: [
-    // The maximum amount of days that can be set based off of score.
-    [40000, 3],
+    // The maximum amount of days that can be set based off of score. The entry rung matches the
+    // monetization floor (MONETIZATION_MIN_CREATOR_SCORE) on purpose: early access and pricing open
+    // at the same creator score, so there is one number to explain rather than two.
+    [10000, 3],
     [65000, 5],
     [90000, 7],
     [125000, 9],
@@ -1859,8 +1861,9 @@ export const EARLY_ACCESS_CONFIG: {
     [({ features }: { features?: FeatureAccess }) => features?.thirtyDayEarlyAccess ?? false, 30],
   ],
   scoreQuantityUnlock: [
-    // How many items can be marked EA at the same time based off of score.
-    [40000, 1],
+    // How many items can be marked EA at the same time based off of score. Entry rung matches
+    // scoreTimeFrameUnlock's — see the note there.
+    [10000, 1],
     [65000, 2],
     [90000, 4],
     [125000, 6],

--- a/src/server/services/__tests__/challenge-eligibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-eligibility.service.test.ts
@@ -97,6 +97,17 @@ describe('assertUserInGoodStanding (create gate — standing AND score, unchange
     );
   });
 
+  // Until 2026-09-04 this read `meta.scores?.total ?? 0`, which failed OPEN on a malformed score:
+  // JS coerces the string, `999999 < 5000` is false, and the gate lets the account through. Every
+  // other fixture in this file supplies a numeric total, so nothing caught it.
+  it('refuses a non-numeric score rather than coercing it through the gate', async () => {
+    mockUser({ meta: { scores: { total: '999999' } } });
+
+    await expect(assertUserInGoodStanding(1)).rejects.toThrow(
+      'You need a creator score of at least 5,000 to create challenges.'
+    );
+  });
+
   it('resolves when standing is good and scoreTotal meets the creator threshold', async () => {
     mockUser({ meta: { scores: { total: 5000 } } });
 

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -300,7 +300,7 @@ describe('getViewerMonetization — an unset gate/fee is never invented', () => 
 // only case either rule applies to — the "editing is always free" direction is at the end, and is the
 // property that grandfathers everything priced before these rules existed.
 describe('assertMonetizationWrite', () => {
-  const ELIGIBLE = { scores: { models: 50000 } };
+  const ELIGIBLE = { scores: { total: 50000 } };
 
   beforeEach(() => {
     mockCacheFetch.mockImplementation(async () => ({}));
@@ -351,7 +351,9 @@ describe('assertMonetizationWrite', () => {
         ownerId: 1,
         paidAccess: { permanent: true, terms: {} } as never,
         tier: 'gold',
-        userMeta: { scores: { models: 9999 } },
+        // Both keys, unequal: with `total` alone a "take the best of both during migration" edit at
+        // the call site would be a no-op here and re-open the gate in production.
+        userMeta: { scores: { total: 9999, models: 50_000 } },
       })
     ).rejects.toThrow(/creator score of 10,000/);
   });
@@ -390,7 +392,7 @@ describe('assertMonetizationWrite', () => {
         isModerator: true,
         paidAccess: { permanent: true, terms: {} } as never,
         tier: 'free',
-        userMeta: { scores: { models: 100 } },
+        userMeta: { scores: { total: 100 } },
       })
     ).rejects.toThrow(/creator score/);
   });
@@ -429,7 +431,7 @@ describe('assertMonetizationWrite', () => {
           licensingFee: 5,
           storedLicensingFee: 0,
           tier: 'free',
-          userMeta: { scores: { models: 0 } },
+          userMeta: { scores: { total: 0 } },
         })
       ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
     });
@@ -449,7 +451,7 @@ describe('assertMonetizationWrite', () => {
             terms: { download: { price: 99999 } },
           } as never,
           tier: 'free',
-          userMeta: { scores: { models: 0 } },
+          userMeta: { scores: { total: 0 } },
         })
       ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
     });
@@ -467,7 +469,7 @@ describe('assertMonetizationWrite', () => {
           licensingFee: 5,
           storedLicensingFee: 0,
           tier: 'free',
-          userMeta: { scores: { models: 50000 } },
+          userMeta: { scores: { total: 50000 } },
         })
       ).resolves.toEqual({ spendsSlot: true, releasesSlot: false });
     });
@@ -484,7 +486,7 @@ describe('assertMonetizationWrite', () => {
           licensingFee: 5,
           storedLicensingFee: 0,
           tier: 'free',
-          userMeta: { scores: { models: 0 } },
+          userMeta: { scores: { total: 0 } },
         })
       ).rejects.toThrow(/creator score/);
     });
@@ -501,7 +503,7 @@ describe('assertMonetizationWrite', () => {
           licensingFee: 0,
           storedLicensingFee: 5,
           tier: 'free',
-          userMeta: { scores: { models: 0 } },
+          userMeta: { scores: { total: 0 } },
         })
       ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
     });
@@ -517,7 +519,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: 500,
         storedLicensingFee: 500,
         tier: 'gold',
-        userMeta: { scores: { models: 50000 } },
+        userMeta: { scores: { total: 50000 } },
         baseModel: 'SDXL 1.0',
         storedBaseModel: 'Hunyuan Video',
       })
@@ -534,7 +536,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: undefined,
         storedLicensingFee: 500,
         tier: 'gold',
-        userMeta: { scores: { models: 50000 } },
+        userMeta: { scores: { total: 50000 } },
         baseModel: 'SDXL 1.0',
         storedBaseModel: 'Hunyuan Video',
       })
@@ -549,7 +551,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: 500,
         storedLicensingFee: 500,
         tier: 'gold',
-        userMeta: { scores: { models: 50000 } },
+        userMeta: { scores: { total: 50000 } },
         baseModel: 'Hunyuan Video',
         storedBaseModel: 'Hunyuan Video',
       })
@@ -565,7 +567,7 @@ describe('assertMonetizationWrite', () => {
         isModerator: true,
         paidAccess: { permanent: true, terms: {} } as never,
         tier: 'free',
-        userMeta: { scores: { models: 50000 } },
+        userMeta: { scores: { total: 50000 } },
       })
     ).rejects.toThrow(/3 of 3/);
   });
@@ -581,7 +583,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: 5,
         storedLicensingFee: 2,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
   });
@@ -593,7 +595,7 @@ describe('assertMonetizationWrite', () => {
         paidAccess: null,
         storedLicensingFee: 2,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
   });
@@ -606,7 +608,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: 0,
         storedLicensingFee: 0,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
   });
@@ -621,7 +623,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: 0,
         storedLicensingFee: 5,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: true });
   });
@@ -639,7 +641,7 @@ describe('assertMonetizationWrite', () => {
         licensingFee: 0,
         storedLicensingFee: 5,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
   });
@@ -656,7 +658,7 @@ describe('assertMonetizationWrite', () => {
         paidAccess: null,
         storedLicensingFee: 0,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: true });
   });
@@ -668,7 +670,7 @@ describe('assertMonetizationWrite', () => {
         ownerId: 1,
         paidAccess: { permanent: false, timeframeDays: 7, terms: {} } as never,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
   });

--- a/src/server/services/__tests__/pricing-slot.service.test.ts
+++ b/src/server/services/__tests__/pricing-slot.service.test.ts
@@ -12,7 +12,6 @@ import { MONETIZATION_MIN_CREATOR_SCORE } from '@civitai/buzz';
 import {
   assertPricingAllowed,
   countPricingSlotsThisMonth,
-  creatorScoreFromMeta,
   listPricingSlots,
   recordPricingSlot,
   releasePricingSlot,
@@ -284,21 +283,6 @@ describe('releasePricingSlot', () => {
   });
 });
 
-describe('creatorScoreFromMeta', () => {
-  it('reads the models score', () => {
-    expect(creatorScoreFromMeta({ scores: { models: 12345 } })).toBe(12345);
-  });
-
-  it('treats missing, null, or non-numeric meta as a score of 0', () => {
-    expect(creatorScoreFromMeta(undefined)).toBe(0);
-    expect(creatorScoreFromMeta(null)).toBe(0);
-    expect(creatorScoreFromMeta({})).toBe(0);
-    expect(creatorScoreFromMeta({ scores: {} })).toBe(0);
-    expect(creatorScoreFromMeta({ scores: { models: 'lots' } })).toBe(0);
-    expect(creatorScoreFromMeta({ scores: { models: Infinity } })).toBe(0);
-  });
-});
-
 describe('countPricingSlotsThisMonth', () => {
   // afterEach, not a trailing call: a failed assertion would otherwise leak frozen time into every
   // later test in the file and turn one legible failure into a cascade.
@@ -338,7 +322,7 @@ describe('recordPricingSlot', () => {
 });
 
 describe('assertPricingAllowed', () => {
-  const eligible = { scores: { models: MONETIZATION_MIN_CREATOR_SCORE } };
+  const eligible = { scores: { total: MONETIZATION_MIN_CREATOR_SCORE } };
 
   it('spends a slot for a newly priced version', async () => {
     await expect(
@@ -359,7 +343,7 @@ describe('assertPricingAllowed', () => {
         wasPriced: true,
         willBePriced: true,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
     expect(mockCount).not.toHaveBeenCalled();
@@ -372,7 +356,7 @@ describe('assertPricingAllowed', () => {
         wasPriced: false,
         willBePriced: false,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: false });
   });
@@ -386,7 +370,7 @@ describe('assertPricingAllowed', () => {
         wasPriced: true,
         willBePriced: false,
         tier: 'free',
-        userMeta: { scores: { models: 0 } },
+        userMeta: { scores: { total: 0 } },
       })
     ).resolves.toEqual({ spendsSlot: false, releasesSlot: true });
     // Neither rule is consulted: a creator below the floor may always stop charging.
@@ -407,7 +391,7 @@ describe('assertPricingAllowed', () => {
         wasPriced: false,
         willBePriced: true,
         tier: async () => 'gold',
-        userMeta: { scores: { models: 50000 } },
+        userMeta: { scores: { total: 50000 } },
       })
     ).resolves.toEqual({ spendsSlot: true, releasesSlot: false });
   });
@@ -421,7 +405,7 @@ describe('assertPricingAllowed', () => {
         wasPriced: false,
         willBePriced: true,
         tier: async () => null,
-        userMeta: { scores: { models: 50000 } },
+        userMeta: { scores: { total: 50000 } },
       })
     ).rejects.toThrow(/3 of 3/);
   });
@@ -436,7 +420,7 @@ describe('assertPricingAllowed', () => {
       wasPriced: true,
       willBePriced: true,
       tier,
-      userMeta: { scores: { models: 50000 } },
+      userMeta: { scores: { total: 50000 } },
     });
 
     expect(tier).not.toHaveBeenCalled();
@@ -449,7 +433,8 @@ describe('assertPricingAllowed', () => {
         wasPriced: false,
         willBePriced: true,
         tier: 'gold',
-        userMeta: { scores: { models: MONETIZATION_MIN_CREATOR_SCORE - 1 } },
+        // Both keys, unequal — see the note on the same fixture in paid-access.service.test.ts.
+        userMeta: { scores: { total: MONETIZATION_MIN_CREATOR_SCORE - 1, models: 50_000 } },
       })
     ).rejects.toThrow(/creator score/);
 
@@ -502,7 +487,7 @@ describe('assertPricingAllowed', () => {
   });
 
   it('falls back to reading the score when the caller has no user meta', async () => {
-    mockFindUnique.mockResolvedValue({ meta: { scores: { models: 50000 } } } as never);
+    mockFindUnique.mockResolvedValue({ meta: { scores: { total: 50000 } } } as never);
 
     await expect(
       assertPricingAllowed({ userId: 1, wasPriced: false, willBePriced: true, tier: 'free' })

--- a/src/server/services/challenge-eligibility.service.ts
+++ b/src/server/services/challenge-eligibility.service.ts
@@ -8,6 +8,7 @@ import {
 } from '~/shared/constants/challenge.constants';
 import { ChallengeSource, ChallengeStatus, StrikeStatus } from '~/shared/utils/prisma/enums';
 import { MUTE_POINTS } from '~/shared/constants/strike.constants';
+import { creatorScoreFromMeta } from '~/shared/utils/creator-score';
 
 function forbidden(message: string) {
   return new TRPCError({ code: 'FORBIDDEN', message });
@@ -39,7 +40,6 @@ export async function getUserChallengeStanding(userId: number): Promise<UserChal
   });
   if (!user) throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
 
-  const meta = (user.meta ?? {}) as { scores?: { total?: number } };
   // POINTS, not the strike count — severity is what the ladder measures everywhere else. Gating on the
   // count locked an account out for a strike's full lifetime over one 1-point strike that mutes nobody.
   const { _sum } = await dbRead.userStrike.aggregate({
@@ -48,7 +48,7 @@ export async function getUserChallengeStanding(userId: number): Promise<UserChal
   });
 
   return {
-    scoreTotal: meta.scores?.total ?? 0,
+    scoreTotal: creatorScoreFromMeta(user.meta),
     bannedAt: user.bannedAt,
     muted: user.muted,
     deletedAt: user.deletedAt,

--- a/src/server/services/pricing-slot.service.ts
+++ b/src/server/services/pricing-slot.service.ts
@@ -17,6 +17,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { withTimeoutFallback } from '~/server/utils/timeout-helpers';
+import { creatorScoreFromMeta } from '~/shared/utils/creator-score';
 
 // The queries and the ordering behind the two pricing rules; the rules themselves are in
 // @civitai/buzz, shared with the creator-studio spoke, which enforces them against the same database
@@ -24,14 +25,6 @@ import { withTimeoutFallback } from '~/server/utils/timeout-helpers';
 
 /** The entity kinds that can carry a price. Mirrors PaidAccessEntityType. */
 export type PricingSlotEntityType = 'ModelVersion' | 'ComicChapter';
-
-type UserMetaScores = { scores?: { models?: number } };
-
-/** Absent or malformed meta reads as 0 — this decides who may start charging, so it fails closed. */
-export function creatorScoreFromMeta(meta: unknown): number {
-  const score = (meta as UserMetaScores | null | undefined)?.scores?.models;
-  return typeof score === 'number' && Number.isFinite(score) ? score : 0;
-}
 
 export async function getCreatorScore(userId: number): Promise<number> {
   const user = await dbRead.user.findUnique({ where: { id: userId }, select: { meta: true } });

--- a/src/server/utils/__tests__/early-access-ladder.test.ts
+++ b/src/server/utils/__tests__/early-access-ladder.test.ts
@@ -7,7 +7,8 @@ import {
 
 // The ladder had no assertions at all until 2026-09-04, so the score it reads could be swapped
 // without a single test printing anything. These pin the field, not the rungs: the rung values come
-// from EARLY_ACCESS_CONFIG so a deliberate re-tiering doesn't redden them.
+// from EARLY_ACCESS_CONFIG so a deliberate re-tiering doesn't redden them — which is what let the
+// entry rung move 40,000 -> 10,000 without touching a line here.
 
 const [firstDayScore, firstDays] = EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock[0] as [number, number];
 const [secondDayScore, secondDays] = EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock[1] as [

--- a/src/server/utils/__tests__/early-access-ladder.test.ts
+++ b/src/server/utils/__tests__/early-access-ladder.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { EARLY_ACCESS_CONFIG } from '~/server/common/constants';
+import {
+  getMaxEarlyAccessDays,
+  getMaxEarlyAccessModels,
+} from '~/server/utils/early-access-helpers';
+
+// The ladder had no assertions at all until 2026-09-04, so the score it reads could be swapped
+// without a single test printing anything. These pin the field, not the rungs: the rung values come
+// from EARLY_ACCESS_CONFIG so a deliberate re-tiering doesn't redden them.
+
+const [firstDayScore, firstDays] = EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock[0] as [number, number];
+const [secondDayScore, secondDays] = EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock[1] as [
+  number,
+  number
+];
+const [firstQtyScore, firstQty] = EARLY_ACCESS_CONFIG.scoreQuantityUnlock[0] as [number, number];
+
+describe('getMaxEarlyAccessDays', () => {
+  it('reads the creator score even when the models score is 0', () => {
+    expect(
+      getMaxEarlyAccessDays({ userMeta: { scores: { total: secondDayScore, models: 0 } } })
+    ).toBe(secondDays);
+  });
+
+  // Its own test on purpose: paired with the one above it would be masked by that assertion
+  // failing first, and this is the direction that actually pins the field.
+  it('ignores a models score that would clear every rung', () => {
+    expect(getMaxEarlyAccessDays({ userMeta: { scores: { total: 0, models: 250_000 } } })).toBe(0);
+  });
+
+  it('gives nothing below the first rung', () => {
+    expect(getMaxEarlyAccessDays({ userMeta: { scores: { total: firstDayScore - 1 } } })).toBe(0);
+    expect(getMaxEarlyAccessDays({ userMeta: { scores: { total: firstDayScore } } })).toBe(
+      firstDays
+    );
+  });
+
+  // `total` is the sum of six categories and reportsAgainst is negative, so unlike the old models
+  // score this can arrive below zero. A penalised account must not reach a rung.
+  it('gives nothing to a negative score', () => {
+    expect(getMaxEarlyAccessDays({ userMeta: { scores: { total: -1_500 } } })).toBe(0);
+  });
+
+  it('treats absent meta as no access', () => {
+    expect(getMaxEarlyAccessDays({})).toBe(0);
+    expect(getMaxEarlyAccessDays({ userMeta: {} })).toBe(0);
+  });
+
+  // The flag entry is last in the config and `[length - 1]` wins, so it outranks every score rung.
+  // Pinned because a future reordering of the config would silently take it away.
+  it('lets the thirtyDayEarlyAccess flag beat every score rung', () => {
+    const features = { thirtyDayEarlyAccess: true } as never;
+    const [, flagDays] = EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock.at(-1) as [unknown, number];
+    const [topScore, topDays] = EARLY_ACCESS_CONFIG.scoreTimeFrameUnlock.at(-2) as [number, number];
+    // The score must clear the TOP rung, or there is nothing for the flag to beat and this passes
+    // just as well when the flag is the only thing granting anything.
+    const withFlag = getMaxEarlyAccessDays({ userMeta: { scores: { total: topScore } }, features });
+    expect(withFlag).toBe(flagDays);
+    expect(withFlag).not.toBe(topDays);
+  });
+});
+
+describe('getMaxEarlyAccessModels', () => {
+  it('reads the creator score even when the models score is 0', () => {
+    expect(
+      getMaxEarlyAccessModels({ userMeta: { scores: { total: firstQtyScore, models: 0 } } })
+    ).toBe(firstQty);
+  });
+
+  it('ignores a models score that would clear every rung', () => {
+    expect(getMaxEarlyAccessModels({ userMeta: { scores: { total: 0, models: 250_000 } } })).toBe(
+      0
+    );
+  });
+
+  it('gives nothing to a negative score', () => {
+    expect(getMaxEarlyAccessModels({ userMeta: { scores: { total: -1_500 } } })).toBe(0);
+  });
+
+  // Every other test here lands on rung 0 or on nothing, so without this the `[length - 1]` pick is
+  // never exercised and swapping it for `[0]` would drop a top creator to the entry allowance.
+  it('takes the highest rung the score clears, not the first', () => {
+    // -2, not -1: the last entry is the feature-flag rung, whose "score" is a predicate.
+    const [score, qty] = EARLY_ACCESS_CONFIG.scoreQuantityUnlock.at(-2) as [number, number];
+    expect(getMaxEarlyAccessModels({ userMeta: { scores: { total: score } } })).toBe(qty);
+    expect(qty).not.toBe(firstQty);
+  });
+
+  it('lets the thirtyDayEarlyAccess flag beat every score rung', () => {
+    const features = { thirtyDayEarlyAccess: true } as never;
+    const flagEntry = EARLY_ACCESS_CONFIG.scoreQuantityUnlock.find(
+      ([score]) => typeof score === 'function'
+    ) as [unknown, number] | undefined;
+    // Asserted rather than skipped: the days ladder has a flag rung and this one is expected to
+    // match it. If the entry is ever removed, this should be a decision, not a silent pass.
+    expect(flagEntry).toBeDefined();
+    expect(getMaxEarlyAccessModels({ userMeta: { scores: { total: 0 } }, features })).toBe(
+      (flagEntry as [unknown, number])[1]
+    );
+  });
+});

--- a/src/server/utils/early-access-helpers.ts
+++ b/src/server/utils/early-access-helpers.ts
@@ -5,6 +5,7 @@ import type { UserMeta } from '~/server/schema/user.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { increaseDate, maxDate } from '~/utils/date-helpers';
 import { isDefined } from '~/utils/type-guards';
+import { creatorScoreFromMeta } from '~/shared/utils/creator-score';
 
 // DEPRECATED: Use the `earlyAccessEndsAt` field on the model version instead
 export function getEarlyAccessDeadline({
@@ -54,7 +55,7 @@ export function getMaxEarlyAccessDays({
         return score({ features }) ? (days as number) : null;
       }
 
-      return (userMeta?.scores?.models ?? 0) >= score ? (days as number) : null;
+      return creatorScoreFromMeta(userMeta) >= score ? (days as number) : null;
     })
     .filter(isDefined);
 
@@ -76,7 +77,7 @@ export function getMaxEarlyAccessModels({
         return score({ features }) ? (days as number) : null;
       }
 
-      return (userMeta?.scores?.models ?? 0) >= score ? (days as number) : null;
+      return creatorScoreFromMeta(userMeta) >= score ? (days as number) : null;
     })
     .filter(isDefined);
 

--- a/src/shared/utils/__tests__/creator-score.test.ts
+++ b/src/shared/utils/__tests__/creator-score.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { creatorScoreFromMeta } from '~/shared/utils/creator-score';
+
+describe('creatorScoreFromMeta', () => {
+  it('reads the total score — the figure /user/account labels "Creator Score"', () => {
+    expect(creatorScoreFromMeta({ scores: { total: 12345 } })).toBe(12345);
+  });
+
+  // The one test that pins the switch. Named for the decision, because a later reader has no way to
+  // tell a deliberate change of field from a typo. Both keys populated and unequal, so it also
+  // reddens under `total ?? models`, under summing the categories, and under max(total, models).
+  it('ignores the per-category models score', () => {
+    expect(creatorScoreFromMeta({ scores: { total: 53_143, models: 4_883 } })).toBe(53_143);
+    expect(creatorScoreFromMeta({ scores: { models: 4_883 } })).toBe(0);
+  });
+
+  // Unlike the models score this replaced, `total` is legitimately negative: reportsAgainst is
+  // -1000 per actioned violation and is one of the six summed categories. Pins the contract, not a
+  // gate — every threshold in the codebase is >= 10,000, so clamping at 0 would be invisible there.
+  it('passes a negative score through rather than clamping it', () => {
+    expect(creatorScoreFromMeta({ scores: { total: -1_500 } })).toBe(-1_500);
+  });
+
+  // User.meta is JSON, so a string-typed score is possible. Refusing it keeps this in step with the
+  // Creator Studio spoke, which enforces the same money gate against the same row.
+  it('refuses a string score rather than coercing it', () => {
+    expect(creatorScoreFromMeta({ scores: { total: '50000' } })).toBe(0);
+  });
+
+  it('treats missing, null, or non-numeric meta as a score of 0', () => {
+    expect(creatorScoreFromMeta(undefined)).toBe(0);
+    expect(creatorScoreFromMeta(null)).toBe(0);
+    expect(creatorScoreFromMeta({})).toBe(0);
+    expect(creatorScoreFromMeta({ scores: {} })).toBe(0);
+    expect(creatorScoreFromMeta({ scores: { total: 'lots' } })).toBe(0);
+    expect(creatorScoreFromMeta({ scores: { total: Infinity } })).toBe(0);
+  });
+});

--- a/src/shared/utils/creator-score.ts
+++ b/src/shared/utils/creator-score.ts
@@ -1,0 +1,17 @@
+type UserMetaScores = { scores?: { total?: number } };
+
+/**
+ * The Creator Score, as `/user/account` displays it — `User.meta.scores.total`, the sum of the six
+ * per-category scores the nightly job writes.
+ *
+ * Read it through here rather than reaching for a per-category score. Every gate that says "creator
+ * score" to the user has to mean the number the user can see, or the gate refuses people the account
+ * page told were eligible: monetization and early access both keyed off `scores.models` until
+ * 2026-09-04, and 45,216 accounts sat above the displayed floor and below the enforced one.
+ *
+ * Absent or malformed reads as 0, so every caller fails closed.
+ */
+export function creatorScoreFromMeta(meta: unknown): number {
+  const score = (meta as UserMetaScores | null | undefined)?.scores?.total;
+  return typeof score === 'number' && Number.isFinite(score) ? score : 0;
+}


### PR DESCRIPTION
## What

Monetization and the early-access ladder gated on `User.meta.scores.models` — the per-category
models sub-score — while `/user/account` puts `scores.total` under the words **"Creator Score"**,
and [article 34394](https://civitai.com/articles/34394) tells creators to read the floor there:

> "You need a creator score of at least 10,000 (**you can see this at the bottom of the account
> settings**)"

Both numbers are called "creator score" in user-facing copy, including in the gate's own refusal
message. So a creator could read **53,143** on their account page and be told by the gate that
theirs is **4,883**.

This points every gate that says "creator score" at the number the creator can actually see, and
then puts every monetization gate on the same number: **10,000**.

Two commits, separately revertible:

| | |
| --- | --- |
| `28a0d4eda4` | read the number we display — `scores.models` → `scores.total` |
| `f2fb7ddad6` | and use the same number everywhere — early access and sales open at 10,000 too |

## Why now

Three creators reported it in the comments on 34394 within eight days, and a fourth report was
answered with "that's an odd one" and turns out to be the same bug. Confirmed against the prod
replica:

| User | What they saw | `scores.total` | `scores.models` |
| --- | --- | --- | --- |
| SencneS | 53,900 profile / 4,834 gate | 53,143 | 4,883 |
| firemanbrakeneck | 15.2k profile / 3,827 gate | 15,316 | 3,868 |
| nickiskids93677 | "80,000 is More than 10,000. How is That Not Good?" | 88,147 | 217 |
| CatusRex | "really high creator score, but no EA access" | 678,565 | 40,124 — **124 points** over the rung |

CatusRex is the clearest case: the gate was behaving correctly and nobody, including the person
answering him, could see that he was 124 points short, because the number on screen was 678,565.

**Population, prod replica, 2026-09-04:**

| Gate | Eligible before | Eligible after | Lose access |
| --- | --- | --- | --- |
| Monetization | 15,379 | 60,171 | **424** |
| Early access | 7,953 | **60,171** | **88** |
| Schedule a sale | — | — | **46** |

**Every monetization gate now opens at 10,000 on `scores.total`.** The gate table afterwards:

| Gate | Threshold | Reads |
| --- | --- | --- |
| Monetize / paid access | 10,000 | `scores.total` |
| Schedule a sale | 10,000 | `scores.total` *(was the aggregate)* |
| Early access — entry | 10,000 | `scores.total` *(was 40,000 on `scores.models`)* |
| Early access — upper rungs | 65k / 90k / 125k / 200k / 250k | `scores.total` |
| Create a challenge | 5,000 | `scores.total` — unchanged |
| Creator Program | 40,000 | aggregate — unchanged |

The EA upper rungs are deliberately untouched: score still buys a longer window and more concurrent
versions, it just no longer decides whether you get early access at all. The Creator Program is the
only remaining reader of the aggregate, and it is the one gate that is not monetization.

## The decision behind this, made deliberately

**This changes who may take money on the platform, in both directions.** 44,792 accounts gain the
ability to monetize; **424 lose it**. Those are two views of one number, not a fix plus a regret.

**Why anyone loses, since it is not obvious.** `total` is not always larger than `models` —
`reportsAgainst` is **−1000 per actioned violation** and it sits *inside* the total:

```
total = models + articles + images + users + reportsActioned + reportsAgainst
```

Of the 424: **422 carry a violation penalty**, **323 have a negative total**, mean penalty
**−267,915**, worst **−9,355,000**. The largest is `models` 440,019 against `total` −645,951.

So this lowers the bar for ~45,000 creators *and*, for the first time, applies a violation penalty
to gates that never had one. **That second half was put to Justin with these numbers and approved:
let it ride.** It is an intended policy change, not a side effect — if you are reading this later
because 424 accounts lost monetization, that was a decision, taken with the count in front of him.

`max(total, models)`, which would have lowered the bar for all 44,792 and taken it from nobody, was
offered and declined.

The same trade applies to the 88 who lose early access and the 46 who lose sale scheduling: same
mechanism, same approved decision. (An earlier revision of this PR said 138 would lose early access
— that was the halfway state where EA sat at 40,000 on `total`. At 10,000 the group is 88.)

## Changes

- **New `src/shared/utils/creator-score.ts`** — one `creatorScoreFromMeta`, reading `scores.total`.
  Fail-closed on absent or malformed meta, as before.
- **Main app** — the pricing gate (`pricing-slot.service.ts`) and both early-access ladders
  (`early-access-helpers.ts`) read it.
- **Creator Studio** — `getModelsScore`/`resolveModelsScore` → `getTotalScore`/`resolveTotalScore`,
  so the spoke's pricing gate and its early-access display move with the main app. The moderator
  simulator cookie keeps its name so live simulator state survives a deploy. The spoke's separate
  aggregate `getCreatorScore` (sales, Creator Program) is **untouched**.
- **Comic chapters move too**, for free — `comics.router.ts` early access goes through the same
  helpers. Named here because it is a real behavioural consequence that the file list does not show.
- **`docs/features/monetization-rules.md`** corrected, with a note on which field every "creator
  score" in that table means, plus two stale `scores.models` claims elsewhere in the docs.

**Deliberately out of scope:** challenge creation (5,000) and the Creator Program (40,000) already
gate on the aggregate, so they were never wrong. Creator Studio's `getCreatorScore` uses
`GREATEST(sum of parts, stored total)` rather than plain `total`; those differ for 6,860 accounts
with a stale total, and reconciling them is a separate call. **Concretely:** since
`GREATEST(sum, total) >= total`, a creator with a stale total can be allowed to schedule a *sale* on
a version they are refused permission to *price*. That is this same bug class — two numbers, one
name, one floor — surviving on a money path, and it should be closed rather than left.

## Verification

Everything below was run in a worktree on this branch, with a stashed baseline for anything that
was already red.

| Check | Result |
| --- | --- |
| `pnpm run typecheck` | 775 errors — **identical count** on a stashed clean tree, none in touched files |
| `pnpm run test:lint-rules` | 476 pass |
| `pnpm run test:packages:run` | 1 pre-existing failure (`@civitai/redis` cache-key-prefix), **same on baseline** |
| `pnpm run test:apps:run` | 1303 pass / 0 fail, **identical to baseline** |
| creator-studio `svelte-check` | 0 errors — **positive control**: a deliberate `: string` annotation produced 2 |
| `eslint` on touched files | 2 warnings on `early-access-helpers.ts`, **same 2 on baseline** |

**Revert control — and an honest count.** Flipping the helper back to `scores.models` reddens 9
tests, but **only one of them is evidence**: seven have single-key fixtures and assert "the gate
refuses a score of 0", which was equally true before this change. The one that pins the switch is
`creator-score.test.ts`'s `ignores the per-category models score`, which populates both keys with
unequal values and also reddens under `total ?? models`, under summing the categories, and under
`max(total, models)`. Both new tests are named for the decision rather than the behaviour, so a
later reader can tell a deliberate switch from a typo.

**The early-access ladder had zero coverage before this PR** — reverting the change there printed
*nothing*, no failure and no timeout, because the only suite touching that path `vi.mock`s the
functions away. `early-access-ladder.test.ts` is new; reverting now fails 5, including
`expected 15 to be 0`.

My first draft of that control paired the load-bearing assertion with another in the same `it()`, so
the first failure masked it and the control showed 3 reds where 5 were owed. **A test that only
fails for the reason you already knew about is not the test you think you wrote.** Split them.

**The Creator Studio suite could not see the bug this PR fixes.** With a single-key fixture the
spoke's `getTotalScore` and its aggregate `getCreatorScore` return the same number, so pointing the
money gate at the wrong one stayed 29/29 green. An unequal `models: 50_000` in the fixture makes
that swap redden. A fixture that behaves identically under both implementations tests nothing.

**Full unit suite on `d898bb934f`: 1631 files passed / 3 skipped (1634), 38035 tests passed / 35
skipped (38070), zero failures.** Both dimensions reconcile against the collected totals. The
`event-engine-common` submodule canary `blocks.router.workflow.test.ts` was run explicitly and
collected **370** tests, so the suite is not silently missing it.

## 🔴 CI has not run on this branch's tip, and `gh pr checks` will not tell you

**Do not read this PR as tested until a status exists on the SHA being merged.** As of writing:

```
f2fb7ddad6  (tip)      combined status "pending", 0 statuses, 0 check-runs
d898bb934f  (3 back)   "success": tekton / typecheck, tekton / fixture-bootstrap
```

Every workflow run on this branch is against `d898bb934f`. `gh pr checks` reports
`no checks reported on the branch` — which reads as "CI hasn't started", not as "four passing runs
exist against a commit you are no longer shipping". **The green is real, correctly obtained, still
visible, and attached to a diff that no longer exists.** Nothing about it looks stale.

**Unconfirmed hypothesis, logged because it may not be specific to this PR:** *force-push may not
re-trigger either CI system on this repo.* The only push to this branch that ever produced runs was
its **first, non-force** push. Three subsequent `--force-with-lease` pushes and one close/reopen
produced nothing from GitHub Actions *or* Tekton, while PRs #4641, #4642 and #4643 each carried a
full **13 check-runs** at head over the same window. All four workflows are
`on: pull_request: branches: [main, release]` with no `types:`, so the default already includes
`synchronize` and `reopened` — the configuration says this should have fired.

Confirming it needs a second force-pushed PR to compare against, which we did not have. **If it is
true, the consequence is the one that matters: a force-pushed PR here can sit indefinitely at a
green belonging to an older commit while `gh pr checks` reports nothing wrong** — reviewers see a PR
that looks tested and is not.

**Until someone confirms or refutes it:** after any force-push, check by SHA —
`gh api repos/<owner>/<repo>/commits/<sha>/status` and `/check-runs`, never `gh pr checks`. A
healthy internal PR here has **13** check-runs at head; 0 is obvious, 4 would not have been. If none
appear, push a real commit rather than re-forcing — this repo squash-merges, so that commit never
reaches `main`'s history.

## Open policy question, held privately

An unresolved question about what the early-access floor permits — distinct from the score it reads —
is with Justin. It is not written up here, deliberately. **This PR should not merge until it is
answered**, independently of CI.

**A note on verifying the push, because the obvious check lied.** `gh pr view --json headRefOid`
returned the **previous** SHA on the first read after a force-push — API lag. On that single read
this branch would have been reported as "push did not take". It is a shape worth knowing because it
is not a silent negative and not a pipeline exit code: it is a *stale but authoritative-looking*
answer. Confirmed instead from three sources agreeing — local `HEAD`, `origin/<branch>`, and the
PR's `headRefOid`.

**On the worker cap:** the certifying run used `--max-workers=4`, which is circulating as a cure for
dropped files under load. No files dropped on this run either capped or uncapped, so **this run is
not evidence the cap helps** — only that it did no harm. Recorded that way rather than as a result.

**CI:** 15 checks on the earlier SHA — 14 pass, 1 correctly skipped (`Typecheck (main pushes / fork
PRs / non-main base)`).

### The full suite earned its keep, and it is worth saying how

An earlier run of this same work came back **exit code 0 with seven failures in it.** On this box
the exit code is evidence in neither direction — runs today have exited 0 while reporting failures
and silently dropping files, and exited 1 over suites that were fine.

Three checks caught it, as a conjunction, and no two of them are redundant:

1. **The counts reconciled on both dimensions** (files and tests, each summing to its collected
   total), which is what made the run trustworthy rather than truncated. A dead worker fork drops a
   file silently and the arithmetic is the only thing that sees it.
2. **The failing files were read by name from the log.** One was the known Windows path failure —
   and **six were mine**, in `paid-access.service.test.ts`, from nineteen `scores: { models: ... }`
   fixtures in a shape my grep had not matched. Inferring "1 failed means the known one" would have
   shipped a broken suite under a money gate.
3. **The submodule canary collected nonzero**, which the arithmetic cannot tell you: a file that
   collects zero tests and reports nothing reconciles perfectly at 0.

## Review

All five lanes ran as registered `civitai-*-review` subagent types, not general-purpose agents
reading the `.md`. **Which SHA each one actually saw**, since "reviewed" without one means nothing:

| Lane | SHA reviewed | Current? |
| --- | --- | --- |
| correctness | `d898bb934f`, re-run at `a8a85766c5` | ⚠️ behind |
| tests | `d898bb934f`, re-run at `e7280d37dc` | ⚠️ behind |
| intent | `d898bb934f` | ⚠️ behind |
| reuse | `d898bb934f` | ⚠️ behind |
| perf | `d898bb934f` | ⚠️ behind |

🔴 **No lane has reviewed `f2fb7ddad6` at all.** The threshold commit arrived after every review. It
is a small diff — two constants, their Creator Studio mirror, one import swap and prose — and its
suites are green, but "small and green" is not "reviewed" and I am not going to write it as one.

The four amendments since `d898bb934f` carry these lanes' own fixes, so the staleness is **content,
not just age** — those greens do not cover the code as it now stands. The two changes after
`a8a85766c5` are comment-only, which is what keeps the correctness re-review meaningful.

Between them the lanes found: two coverage gaps (an untested money gate, and a spoke suite blind to
the swap this PR makes), doc drift I had introduced, a string-coercion divergence between the two
apps at the same money gate, a sibling gate failing open on a non-numeric score, and two comments I
had edited into making false claims.

### The tests I wrote to close those findings had holes of their own

The tests lane was re-run specifically because nobody had adversarially read the tests written in
response to it. It found **six surviving mutations**. The one worth quoting, at the main app's money
gate:

```ts
// a "take the best of both during migration" softening
Math.max(creatorScoreFromMeta(userMeta), userMeta?.scores?.models ?? 0)
```

Every main-app gate fixture was single-key, so the `max` was a no-op in the tests and re-opened the
gate in production: **green suite, open gate.**

This is the argument for why these six tests exist, so do not delete one as redundant without it:
**the decision recorded above is what makes that edit attractive.** "Take the best of both during
migration" is the first thing anyone will propose *because* 424 accounts lose monetization — so the
most likely future regression on this gate is precisely the one the suite could not see, and it
would arrive wearing the costume of a kindness.

All six are closed, each with a control that fires:

| Mutation | Now |
| --- | --- |
| `max(total, models)` at the main-app gate | 2 fail |
| spoke `getTotalScore` back to coercing `num()` | 1 fail |
| challenge gate back to `?? 0` (fail-open on a string score) | 1 fail |
| models ladder picks `[0]` instead of the highest rung | 1 fail |

Plus one where the *name* overclaimed: `lets the thirtyDayEarlyAccess flag beat every score rung`
set the score to 0, so there was no rung for the flag to beat and it passed equally well if the flag
were the only thing granting anything. It now sets the top rung and asserts the result is not that
value.

**One of those new tests immediately caught an error in itself** — `.at(-1)` on the quantity ladder
is the feature-flag entry, not a score rung, so it expected 30 and got 0.

**Still untested, and flagged rather than fixed:** the comment added at
`models/+page.server.ts` declares its enclosing `!isModerator` condition load-bearing, and no test
in the spoke covers it. Hoisting that call out of the branch would stay green. Pre-existing
behaviour — but this diff is what asserts in prose that it is guarded.

**Found and deliberately not fixed here** — both pre-existing, both carried to the follow-up:

- The **sale** gate reads `GREATEST(sum, total)` while pricing now reads `total`; 46 accounts sit
  below the floor for one and above it for the other. Same two-numbers-one-name bug, still live —
  and more visible now, since violations bite one gate and not the other.
- One elevated-role path resolves the sale floor's input differently from the pricing gate's.
  Details are in the private note rather than here; a comment in this diff that described it too
  precisely has been trimmed for the same reason. Behaviour unchanged in this PR.
- `countActiveEarlyAccessVersions` drives from **every active EA gate site-wide** and filters by
  owner afterwards, on every Creator Studio `/models` page load: measured 4.4 ms / 3,053 buffers at
  today's 289 gates, 15.9 ms / 16,112 at 1,693. This PR grows that population 3.7x and the
  follow-up grows it further, so it wants an index there before that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BrgCPUR9TacrvsYNRv9c3
