### PR TITLE
fix(dev-server): run the daemon from the primary checkout, never the calling worktree

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -33,8 +33,8 @@ node .claude/skills/dev-server/cli.mjs stop <session-id>
 
 ## Which node the daemon runs on — and why it is sticky
 
-The daemon is spawned with `process.execPath` (`cli.mjs:71`, `console.mjs:90`), i.e. **whatever node ran
-the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
+The daemon is spawned with `process.execPath` (`startDaemon` in `cli.mjs` and `console.mjs`), i.e.
+**whatever node ran the CLI verb that first started it**. It then passes its own environment down to every `next dev` it
 supervises. So the node you happened to have on `PATH` the first time you typed any command above is the
 node the whole tree runs on, until someone shuts the daemon down — and nothing records which one that was.
 
@@ -191,6 +191,7 @@ node .claude/skills/dev-server/scripts/branch-watch.selftest.mjs       # HEAD wa
 node .claude/skills/dev-server/scripts/probe.selftest.mjs              # the classifier, pure
 node .claude/skills/dev-server/scripts/probe.integration.selftest.mjs  # the real probe() end to end
 node .claude/skills/dev-server/scripts/worktree.selftest.mjs           # what `wt stale` / `wt rm` say about a PR and a prune
+node .claude/skills/dev-server/scripts/daemon-home.selftest.mjs        # the daemon runs from the primary, never the calling worktree
 node .claude/hooks/check-writable.selftest.mjs                         # the hook, both directions
 ```
 
@@ -252,9 +253,11 @@ gitignored — a fresh copy of `env-modes.example` defines none, so `--prod all`
 fill it in. Adding a service is an edit to that file, not to the code.
 
 ⚠️ **`env-modes.local` does not fall through** the way `.env` now does. It is read from the skill
-directory of the daemon that is running (`env-modes.mjs`), so a daemon started from a worktree's own
-copy of the CLI finds none and applies no overlay at all. Start the daemon from the primary checkout,
-or the groups simply will not exist.
+directory of the daemon that is running (`env-modes.mjs`), and that file is gitignored, so it exists
+only in the primary checkout. The CLI and the console now always spawn the daemon from the primary
+(`resolveDaemonHome` in `scripts/paths.mjs`), so this is handled — but a daemon started **by hand**
+from inside a worktree, `node scripts/daemon.mjs`, still reads that worktree's skill directory, finds
+no `env-modes.local`, and applies no overlay at all.
 
 Several services have **no dev counterpart to move to at all** — `env-modes.mjs` lists orchestrator,
 payments, s3, clickhouse, notifications, feeds and opensearch in `PROD_ONLY_GROUPS`, and `auth-hub`
@@ -653,6 +656,12 @@ What's already handled:
   take the primary from the first entry of `git worktree list`, which git guarantees is the main
   worktree; before that, running them through a worktree's own CLI copy inverted every check and
   offered the real main checkout as removable.
+
+  **The daemon PROCESS also runs from there**, whichever worktree's CLI started it — script, pid file
+  and cwd all come from the primary (`resolveDaemonHome`). One daemon serves every tree, and a daemon
+  living inside one of them holds that directory open for its whole life, so `wt rm` on it failed
+  EBUSY for whoever finished their PR first. `wt rm` now asks the daemon where it runs from and names
+  it when it is the holder, instead of blaming a stray shell.
 - **Auth on secondary ports.** `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, and `NEXT_PUBLIC_BASE_URL` are rewritten to `http://localhost:<port>`, so logins work on non-3000 sessions instead of bouncing to the primary.
 - **Independent branch watching + prewarming** per session.
 - **Port allocation sees listeners the daemon does not own.** The picker connects to both loopback

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -62,8 +62,10 @@ subcommands — the wrapper only decides which node runs them, so nothing here d
 Either way, **check what you have got** before trusting a session:
 
 ```bash
-# the daemon's real interpreter, not the one you assume
-readlink -f /proc/$(cat .claude/skills/dev-server/daemon.pid)/exe
+# the daemon's real interpreter, not the one you assume.
+# the pid file belongs to the skill dir the daemon RUNS FROM, which is the primary checkout — a
+# relative path here reads the wrong tree's file, or none, when you are standing in a worktree.
+readlink -f /proc/$(cat <primary-checkout>/.claude/skills/dev-server/daemon.pid)/exe
 ```
 
 Changing node means restarting the daemon — `cli.mjs shutdown`, then start it again from the right shell.
@@ -254,10 +256,11 @@ fill it in. Adding a service is an edit to that file, not to the code.
 
 ⚠️ **`env-modes.local` does not fall through** the way `.env` now does. It is read from the skill
 directory of the daemon that is running (`env-modes.mjs`), and that file is gitignored, so it exists
-only in the primary checkout. The CLI and the console now always spawn the daemon from the primary
-(`resolveDaemonHome` in `scripts/paths.mjs`), so this is handled — but a daemon started **by hand**
-from inside a worktree, `node scripts/daemon.mjs`, still reads that worktree's skill directory, finds
-no `env-modes.local`, and applies no overlay at all.
+only in the primary checkout. A CLI or console **carrying the `resolveDaemonHome` change** spawns the
+daemon from the primary, which handles it — but the skill directory is committed, so each worktree
+runs its own copy: a tree cut before that change still spawns the daemon into itself, and so does a
+daemon started **by hand** with `node scripts/daemon.mjs`. Either way it reads that worktree's skill
+directory, finds no `env-modes.local`, and applies no overlay at all.
 
 Several services have **no dev counterpart to move to at all** — `env-modes.mjs` lists orchestrator,
 payments, s3, clickhouse, notifications, feeds and opensearch in `PROD_ONLY_GROUPS`, and `auth-hub`
@@ -657,11 +660,17 @@ What's already handled:
   worktree; before that, running them through a worktree's own CLI copy inverted every check and
   offered the real main checkout as removable.
 
-  **The daemon PROCESS also runs from there**, whichever worktree's CLI started it — script, pid file
-  and cwd all come from the primary (`resolveDaemonHome`). One daemon serves every tree, and a daemon
-  living inside one of them holds that directory open for its whole life, so `wt rm` on it failed
-  EBUSY for whoever finished their PR first. `wt rm` now asks the daemon where it runs from and names
-  it when it is the holder, instead of blaming a stray shell.
+  **The daemon PROCESS also runs from there** — script, pid file and cwd all resolved through
+  `resolveDaemonHome`. One daemon serves every tree, and a daemon living inside one of them holds
+  that directory open for its whole life, so `wt rm` on it fails EBUSY for whoever finishes their PR
+  first. `wt rm` asks the daemon for its script path and its cwd, and names it when either is inside
+  the target instead of blaming a stray shell.
+
+  🔴 **This only binds a CLI that has the change.** The skill directory is committed, so every
+  worktree runs its own `cli.mjs`, and a tree cut before it re-pins itself the next time the daemon
+  dies and that tree is first to start it. So the daemon moving to the primary requires both a
+  shutdown and an updated spawner — it is not retroactive, and a daemon already running is unaffected
+  until it restarts.
 - **Auth on secondary ports.** `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, and `NEXT_PUBLIC_BASE_URL` are rewritten to `http://localhost:<port>`, so logins work on non-3000 sessions instead of bouncing to the primary.
 - **Independent branch watching + prewarming** per session.
 - **Port allocation sees listeners the daemon does not own.** The picker connects to both loopback

--- a/.claude/skills/dev-server/cli.mjs
+++ b/.claude/skills/dev-server/cli.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { exitCodeFor, isTerminal as isTerminalStatus } from './scripts/test-queue.mjs';
 import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
+import { resolveDaemonHome } from './scripts/paths.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -26,8 +27,20 @@ function findProjectRoot(startDir) {
 }
 
 const projectRoot = findProjectRoot(__dirname);
-const pidFile = resolve(__dirname, 'daemon.pid');
-const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
+
+// ONE daemon serves every worktree, so it must not live inside one. The skill directory is
+// committed, so `__dirname` names whichever tree the agent happened to run the CLI from — and a
+// daemon spawned there holds that directory open for its whole life, so `wt rm` on it fails EBUSY
+// for whoever finishes their PR first. It also survives the tree: the daemon's own copy of
+// daemon.mjs would be deleted out from under it.
+//
+// So the daemon's script, its pid file and its cwd all come from the checkout that owns the .git
+// directory. Falls back to the caller's own tree when git cannot answer — a wrong-tree daemon is
+// worse than a right-tree one, but no daemon at all is worse than either.
+const daemonHome = resolveDaemonHome(__dirname, projectRoot);
+
+const pidFile = resolve(daemonHome.skillDir, 'daemon.pid');
+const serverScript = resolve(daemonHome.skillDir, 'scripts/daemon.mjs');
 
 // Overridable via DEV_DAEMON_PORT, so a second daemon can be exercised without touching the
 // shared one. The whole decision — port included — is made in scripts/daemon-port.mjs, which is
@@ -59,7 +72,9 @@ async function startDaemon() {
   const spawnOptions = {
     detached: true,
     stdio: 'ignore',
-    cwd: projectRoot,
+    // The primary checkout, not the caller's. A cwd inside a worktree is itself a handle on that
+    // directory, so pointing only the script at the primary would still pin the tree.
+    cwd: daemonHome.home,
     windowsHide: true,
   };
 

--- a/.claude/skills/dev-server/console.mjs
+++ b/.claude/skills/dev-server/console.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import readline from 'readline';
 import { resolveDaemonUrl } from './scripts/daemon-port.mjs';
+import { resolveDaemonHome } from './scripts/paths.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -26,8 +27,13 @@ function findProjectRoot(startDir) {
 }
 
 const projectRoot = findProjectRoot(__dirname);
-const pidFile = resolve(__dirname, 'daemon.pid');
-const serverScript = resolve(__dirname, 'scripts/daemon.mjs');
+
+// The daemon runs from the primary checkout, never from the worktree this console was launched in
+// — see resolveDaemonHome. The console spawns it too, so it has to agree with cli.mjs about where
+// the daemon lives, or the two put different daemons' pids in different pid files.
+const daemonHome = resolveDaemonHome(__dirname, projectRoot);
+const pidFile = resolve(daemonHome.skillDir, 'daemon.pid');
+const serverScript = resolve(daemonHome.skillDir, 'scripts/daemon.mjs');
 
 // The whole decision — port included — is made in scripts/daemon-port.mjs, the same module the
 // daemon reads, so this file does no arithmetic on a port and cannot drift from it.
@@ -88,7 +94,7 @@ async function isDaemonRunning() {
 async function startDaemon() {
   // No shell — see cli.mjs startDaemon.
   const child = spawn(process.execPath, [serverScript], {
-    detached: true, stdio: 'ignore', cwd: projectRoot, windowsHide: true,
+    detached: true, stdio: 'ignore', cwd: daemonHome.home, windowsHide: true,
   });
   child.unref();
   writeFileSync(pidFile, String(child.pid));

--- a/.claude/skills/dev-server/scripts/daemon-home.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/daemon-home.selftest.mjs
@@ -55,18 +55,31 @@ check('it is the checkout that owns .git', primary.path, resolve(gitCommonDir, '
 // --- the whole point: run from a worktree, get the primary ---
 
 const home = resolveDaemonHome(skillDir, projectRoot);
-check('the daemon home is the primary checkout', home.home, primary.path);
-check('the daemon script comes from the primary', home.skillDir, resolve(primary.path, '.claude/skills/dev-server'));
-check('and it says so', home.fromPrimary, true);
 
-// The assertion that actually fails on a revert to `__dirname`, stated as the property rather than
-// as a path: run this selftest from a worktree and the home must not be that worktree. In the
-// primary checkout the two are legitimately equal, so this can only fail where it can fire.
+// 🔴 EVERY LIVE ASSERTION HERE IS VACUOUS IN THE PRIMARY CHECKOUT, so all of them sit behind one
+// guard rather than only the last. Run from the primary, `callerProjectRoot` and `primary.path` are
+// the same directory — so a `resolveDaemonHome` reverted to plain `__dirname` returns exactly the
+// values these expect and the file prints `all passed` over the bug it exists to catch. Guarding
+// only the isInside check (the first version of this file) left the two above it reporting PASS.
+//
+// The banner at the top of this file is addressed to whoever reverts this function; the primary
+// checkout is where they will run it, and it is the one place these cannot fire. So say so loudly
+// instead of printing a quiet SKIP among PASSes.
 if (resolve(projectRoot).toLowerCase() !== resolve(primary.path).toLowerCase()) {
+  check('the daemon home is the primary checkout', home.home, primary.path);
+  check('the daemon script comes from the primary', home.skillDir, resolve(primary.path, '.claude/skills/dev-server'));
   check('running from a worktree does NOT pin that worktree', isInside(home.skillDir, projectRoot), false);
 } else {
-  console.log('SKIP  running from a worktree does NOT pin that worktree (this IS the primary)');
+  console.log(
+    '\n⚠️  VACUOUS HERE — this run is in the PRIMARY checkout, where a reverted resolveDaemonHome\n' +
+      '    returns the same values as a correct one. 3 checks skipped. Re-run from a worktree to\n' +
+      '    exercise them; a green run here is not evidence about the fix.\n'
+  );
 }
+
+// Non-vacuous everywhere, including the primary: `fromPrimary` requires `derived && existsSync`, so
+// a revert to `__dirname` cannot satisfy it wherever it is run.
+check('and it says so', home.fromPrimary, true);
 
 // --- the fallback, which must never leave the caller without a daemon ---
 
@@ -102,13 +115,29 @@ if (process.platform === 'win32') {
 const reply = (data) => async () => (data === null ? { ok: false } : { ok: true, data });
 const tree = resolve('C:' + sep + 'Dev', 'Repos', 'work', 'worktrees', 'foo');
 
-const held = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: resolve(tree, '.claude/skills/dev-server') }));
-check('a daemon inside the tree is named', held.holder?.pid, 42);
+const outsideDir = resolve(tree, '../bar/.claude');
+
+const held = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: resolve(tree, '.claude/skills/dev-server'), cwd: outsideDir }));
+check('a daemon whose SCRIPT is in the tree is named', held.holder?.pid, 42);
+check('and the message says which handle', held.holder?.reason.startsWith('its running script'), true);
 check('and the answer is conclusive', held.checked, true);
 
-const elsewhere = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: resolve(tree, '../bar/.claude') }));
-check('a daemon outside the tree is not blamed', elsewhere.holder, null);
+// 🔴 THE CASE THE FIRST VERSION OF THIS GOT WRONG. A daemon started by hand from inside a worktree
+// runs the PRIMARY's script while holding the worktree open through its working directory alone.
+// Testing skillDir only answered "not the holder" here — the same confidently-wrong message this
+// whole change exists to remove, reintroduced in a narrower case.
+const byCwd = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: outsideDir, cwd: resolve(tree, 'src') }));
+check('a daemon holding the tree only by CWD is still named', byCwd.holder?.pid, 42);
+check('and the message says it was the cwd', byCwd.holder?.reason.startsWith('its working directory'), true);
+
+const elsewhere = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: outsideDir, cwd: outsideDir }));
+check('a daemon outside the tree on BOTH handles is not blamed', elsewhere.holder, null);
 check('and THAT answer is conclusive too', elsewhere.checked, true);
+
+// An old daemon reports skillDir but no cwd. It must not throw, and must not be blamed on a missing
+// field — `undefined` is not inside anything.
+const noCwd = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: outsideDir }));
+check('a daemon that reports no cwd is not blamed for it', noCwd.holder, null);
 
 for (const [name, res] of [
   ['a daemon that is down', reply(null)],

--- a/.claude/skills/dev-server/scripts/daemon-home.selftest.mjs
+++ b/.claude/skills/dev-server/scripts/daemon-home.selftest.mjs
@@ -1,0 +1,124 @@
+/**
+ * `node .claude/skills/dev-server/scripts/daemon-home.selftest.mjs`
+ *
+ * ONE daemon serves every worktree, so it must not live inside one.
+ *
+ * 🔴 TO WHOEVER IS ABOUT TO SIMPLIFY `resolveDaemonHome` BACK TO `__dirname`: that is where it
+ * started, and it is why `wt rm` failed EBUSY on whichever tree happened to start the daemon first.
+ * The skill directory is committed, so every worktree has a copy of it, and a daemon spawned from
+ * one holds that directory open — cwd and running script both — for its entire life. The agent who
+ * finishes their PR first is the one who cannot clean up. Observed 2026-09-04: pid 46332 running
+ * `daemon.mjs` out of `worktrees/profile-remix-flyout`, pinning a tree whose PR had merged.
+ *
+ * The failures below name the wrong PATH, not a count, so a revert reads as a path in a worktree
+ * where the primary checkout was wanted.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
+import { isInside, resolveDaemonHome, resolvePrimaryCheckout } from './paths.mjs';
+import { daemonRunningFrom } from './worktree.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skillDir = resolve(__dirname, '..');
+const projectRoot = resolve(skillDir, '../../..');
+
+let failures = 0;
+function check(name, actual, expected) {
+  const pass = actual === expected;
+  if (!pass) failures++;
+  console.log(
+    `${pass ? 'PASS' : 'FAIL'}  ${name}\n        got=${JSON.stringify(actual)}\n       want=${JSON.stringify(expected)}`
+  );
+}
+
+// --- the primary, resolved from wherever this copy of the skill happens to live ---
+
+const primary = resolvePrimaryCheckout(projectRoot);
+// First, because it changes what every check below MEANS: outside a git repo the resolution falls
+// back to the caller's own root and the assertions would then be comparing a tree to itself.
+check('the primary was derived from git, not fallen back', primary.derived, true);
+if (!primary.derived) {
+  console.error(`  (fell back to ${primary.path}: ${primary.error})`);
+}
+
+const gitCommonDir = execFileSync(
+  'git',
+  ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+  { cwd: projectRoot, encoding: 'utf8', windowsHide: true }
+).trim();
+check('it is the checkout that owns .git', primary.path, resolve(gitCommonDir, '..'));
+
+// --- the whole point: run from a worktree, get the primary ---
+
+const home = resolveDaemonHome(skillDir, projectRoot);
+check('the daemon home is the primary checkout', home.home, primary.path);
+check('the daemon script comes from the primary', home.skillDir, resolve(primary.path, '.claude/skills/dev-server'));
+check('and it says so', home.fromPrimary, true);
+
+// The assertion that actually fails on a revert to `__dirname`, stated as the property rather than
+// as a path: run this selftest from a worktree and the home must not be that worktree. In the
+// primary checkout the two are legitimately equal, so this can only fail where it can fire.
+if (resolve(projectRoot).toLowerCase() !== resolve(primary.path).toLowerCase()) {
+  check('running from a worktree does NOT pin that worktree', isInside(home.skillDir, projectRoot), false);
+} else {
+  console.log('SKIP  running from a worktree does NOT pin that worktree (this IS the primary)');
+}
+
+// --- the fallback, which must never leave the caller without a daemon ---
+
+const outside = mkdtempSync(resolve(tmpdir(), 'daemon-home-'));
+try {
+  const stray = resolveDaemonHome(resolve(outside, '.claude/skills/dev-server'), outside);
+  // Outside a repository git answers nothing. A daemon in the caller's own tree is wrong; NO daemon
+  // is worse, so the fallback is the caller's tree and `fromPrimary` is what says it is a fallback.
+  check('outside a repo it falls back to the caller', stray.home, resolve(outside));
+  check('and does not claim the primary', stray.fromPrimary, false);
+} finally {
+  rmSync(outside, { recursive: true, force: true });
+}
+
+// --- isInside, which decides whether `wt rm` blames the daemon ---
+
+const base = resolve('C:' + sep + 'Dev', 'Repos', 'work', 'worktrees', 'foo');
+check('a directory is inside itself', isInside(base, base), true);
+check('a child is inside', isInside(resolve(base, '.claude/skills'), base), true);
+// startsWith would call this a child, and `wt rm foo` would then blame a daemon in `foo-old`.
+check('a name-prefixed SIBLING is not', isInside(base + '-old', base), false);
+check('a parent is not inside its child', isInside(base, resolve(base, '.claude')), false);
+if (process.platform === 'win32') {
+  check('drive letter casing does not matter', isInside(base.toLowerCase(), base.toUpperCase()), true);
+}
+
+// --- what `wt rm` is allowed to CLAIM about the daemon ---
+//
+// Three outcomes, not two. "no holder" and "could not tell" print different failure text, because
+// the message this replaced asserted a stray shell was to blame in a case where nothing had been
+// checked at all. A live paired control covers the first two (a worktree-resident daemon is named;
+// a daemon elsewhere is not), but only a fake can produce the third on demand.
+const reply = (data) => async () => (data === null ? { ok: false } : { ok: true, data });
+const tree = resolve('C:' + sep + 'Dev', 'Repos', 'work', 'worktrees', 'foo');
+
+const held = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: resolve(tree, '.claude/skills/dev-server') }));
+check('a daemon inside the tree is named', held.holder?.pid, 42);
+check('and the answer is conclusive', held.checked, true);
+
+const elsewhere = await daemonRunningFrom(tree, reply({ pid: 42, skillDir: resolve(tree, '../bar/.claude') }));
+check('a daemon outside the tree is not blamed', elsewhere.holder, null);
+check('and THAT answer is conclusive too', elsewhere.checked, true);
+
+for (const [name, res] of [
+  ['a daemon that is down', reply(null)],
+  ['a daemon too old to report skillDir', reply({ pid: 42 })],
+]) {
+  const unknown = await daemonRunningFrom(tree, res);
+  check(`${name} yields no holder`, unknown.holder, null);
+  // The one that matters: unknown must not read as innocent.
+  check(`${name} does NOT count as checked`, unknown.checked, false);
+}
+
+console.log(failures ? `\n${failures} FAILED` : '\nall passed');
+process.exit(failures ? 1 : 0);

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { access } from 'fs/promises';
 import { isPortFree } from './port-probe.mjs';
-import { samePath, canonicalPath } from './paths.mjs';
+import { samePath, canonicalPath, resolvePrimaryCheckout } from './paths.mjs';
 import { parsePort, resolveDaemonPort } from './daemon-port.mjs';
 import { TestQueue } from './test-queue.mjs';
 import {
@@ -40,34 +40,10 @@ const skillDir = resolve(__dirname, '..');
 const projectRoot = resolve(skillDir, '../../..');
 const pidFile = resolve(skillDir, 'daemon.pid');
 
-// The checkout that owns the .git directory — the base of every env chain. This is NOT projectRoot:
-// the skill directory is committed, so a daemon launched from a worktree derives projectRoot as that
-// worktree, and the "fall back to the primary" half of every chain then points at a file the
-// worktree does not have. `git rev-parse --git-common-dir` resolves to the primary's `.git` from
-// inside any worktree, which is the only spelling of this that does not depend on where the process
-// was started. Falls back to projectRoot when git cannot answer, which is the pre-worktree behaviour.
-function resolvePrimaryCheckout() {
-  try {
-    const gitCommonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
-      cwd: projectRoot,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      // The daemon has no console of its own, so every console child it starts without this
-      // allocates one — which Windows 11 hands to the default terminal app, popping a Windows
-      // Terminal window that takes focus. Piping stdio does not prevent the allocation.
-      windowsHide: true,
-      // This runs at module load, before the listener exists, so a wedged git would hang the daemon
-      // where `ensureDaemon` reports a bare "Failed to start daemon" with nothing naming git.
-      timeout: 5000,
-    }).trim();
-    if (gitCommonDir) return { path: resolve(gitCommonDir, '..'), derived: true, error: null };
-  } catch (e) {
-    return { path: projectRoot, derived: false, error: e.message };
-  }
-  return { path: projectRoot, derived: false, error: 'git named no common dir' };
-}
-
-const primaryResolution = resolvePrimaryCheckout();
+// The checkout that owns the .git directory — the base of every env chain, and since cli.mjs now
+// spawns this process from there, normally projectRoot as well. Still resolved rather than assumed:
+// a daemon started by hand from a worktree must not take that worktree as the base of every chain.
+const primaryResolution = resolvePrimaryCheckout(projectRoot);
 const primaryCheckout = primaryResolution.path;
 
 // Configuration
@@ -2274,6 +2250,11 @@ async function main() {
           status: 'running',
           pid: process.pid,
           uptime: process.uptime(),
+          // Where this process is running FROM, which the caller cannot derive: a daemon started
+          // before cli.mjs learned to spawn from the primary is still running out of a worktree and
+          // holds that directory open. `wt rm` reads this to name itself as the holder rather than
+          // blaming a stray shell.
+          skillDir,
           sessions: await listSessions(),
         }));
         return;

--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -2250,11 +2250,15 @@ async function main() {
           status: 'running',
           pid: process.pid,
           uptime: process.uptime(),
-          // Where this process is running FROM, which the caller cannot derive: a daemon started
-          // before cli.mjs learned to spawn from the primary is still running out of a worktree and
-          // holds that directory open. `wt rm` reads this to name itself as the holder rather than
-          // blaming a stray shell.
+          // Both handles this process holds on a directory, which the caller cannot derive. `wt rm`
+          // reads them to name itself as the holder rather than blaming a stray shell.
+          //
+          // cwd as well as skillDir, because they can differ: a daemon started BY HAND from inside a
+          // worktree (`node <primary>/.claude/.../daemon.mjs`) runs the primary's script while
+          // holding the worktree open through its working directory alone. Reporting only skillDir
+          // would answer "not the holder" there — confidently, and wrongly.
           skillDir,
+          cwd: process.cwd(),
           sessions: await listSessions(),
         }));
         return;

--- a/.claude/skills/dev-server/scripts/paths.mjs
+++ b/.claude/skills/dev-server/scripts/paths.mjs
@@ -1,13 +1,15 @@
 // Path identity, in one place.
 //
-// A leaf module rather than a corner of daemon.mjs, because worktree.mjs and the selftests would
-// otherwise import a module that runs `execSync` and constructs AuthHub and RgbProxy at load, just
-// to reach six lines of string comparison.
+// A leaf module rather than a corner of daemon.mjs, because worktree.mjs, cli.mjs and the selftests
+// would otherwise import a module that constructs AuthHub and RgbProxy at load just to reach a
+// string comparison and a `git rev-parse`. Nothing in here runs at import.
 //
 // One definition, because the next person to improve it (trailing separators, UNC paths, `\\?\`
 // prefixes) has to improve every caller at once: a daemon and a `wt rm` that disagree about whether
 // two paths are the same tree is how `wt rm` deletes one the daemon is serving.
-import { resolve } from 'path';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { relative, resolve, sep } from 'path';
 
 /**
  * True when two paths name the same location.
@@ -20,6 +22,85 @@ export function samePath(a, b) {
   const x = resolve(a);
   const y = resolve(b);
   return process.platform === 'win32' ? x.toLowerCase() === y.toLowerCase() : x === y;
+}
+
+/**
+ * The checkout that owns the `.git` directory, resolved from anywhere inside it.
+ *
+ * The skill directory is committed, so every worktree has its own copy of it and `__dirname` names
+ * whichever tree the caller happened to be standing in. Two things must not be derived that way:
+ * the base of the daemon's env chain (a worktree's copy of a file the worktree does not have), and
+ * the daemon's own script path — a daemon running out of a worktree holds that directory open, and
+ * `wt rm` on it fails EBUSY for as long as the daemon lives.
+ *
+ * `git rev-parse --git-common-dir` answers with the primary's `.git` from inside any worktree,
+ * which is the only spelling of this that does not depend on where the process was started. Falls
+ * back to `from` when git cannot answer, which is the pre-worktree behaviour; callers that need to
+ * know the difference read `derived`.
+ *
+ * @param {string} from — a directory inside the repository
+ * @returns {{ path: string, derived: boolean, error: string | null }}
+ */
+export function resolvePrimaryCheckout(from) {
+  try {
+    const gitCommonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+      cwd: from,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      // The daemon has no console of its own, so every console child it starts without this
+      // allocates one — which Windows 11 hands to the default terminal app, popping a Windows
+      // Terminal window that takes focus. Piping stdio does not prevent the allocation.
+      windowsHide: true,
+      // This runs at module load in the daemon, before the listener exists, so a wedged git would
+      // hang it where `ensureDaemon` reports a bare "Failed to start daemon" with nothing naming git.
+      timeout: 5000,
+    }).trim();
+    if (gitCommonDir) return { path: resolve(gitCommonDir, '..'), derived: true, error: null };
+  } catch (e) {
+    return { path: from, derived: false, error: e.message };
+  }
+  return { path: from, derived: false, error: 'git named no common dir' };
+}
+
+/**
+ * True when `child` is `parent` or sits underneath it.
+ *
+ * Compared segment-wise rather than with `startsWith`, which calls `.../worktrees/foo-old` a child
+ * of `.../worktrees/foo` and would have `wt rm` blame a daemon in a sibling tree.
+ */
+export function isInside(child, parent) {
+  if (samePath(child, parent)) return true;
+  const p = canonicalPath(parent);
+  // `resolve` has already dropped any trailing separator except on a drive/filesystem root, where
+  // it must stay: `c:\` + sep would be `c:\\` and match nothing.
+  return canonicalPath(child).startsWith(p.endsWith(sep) ? p : p + sep);
+}
+
+/**
+ * Where a daemon this process spawns should live: its script, its pid file, its cwd.
+ *
+ * One function because cli.mjs and console.mjs both spawn the daemon, and a version of this that
+ * lived at both call sites is the shape daemon-port.mjs already documents going wrong — open-coded
+ * at five sites, disagreeing at three. Two spawners that disagree about the daemon's home would put
+ * a second daemon's pid in the first one's pid file.
+ *
+ * @param {string} callerSkillDir — the calling module's own skill directory (`__dirname`)
+ * @param {string} callerProjectRoot — the checkout that directory is in
+ */
+export function resolveDaemonHome(callerSkillDir, callerProjectRoot) {
+  const skillRelative = relative(callerProjectRoot, callerSkillDir);
+  const primary = resolvePrimaryCheckout(callerProjectRoot);
+  const primarySkillDir = resolve(primary.path, skillRelative);
+  // Both halves checked, not just `derived`: a checkout whose skill directory has been moved or
+  // removed on the primary's branch would otherwise send us to spawn a file that is not there, and
+  // `ensureDaemon` reports that as a bare "Failed to start daemon".
+  const fromPrimary = primary.derived && existsSync(resolve(primarySkillDir, 'scripts/daemon.mjs'));
+  return {
+    fromPrimary,
+    primary,
+    home: fromPrimary ? primary.path : callerProjectRoot,
+    skillDir: fromPrimary ? primarySkillDir : callerSkillDir,
+  };
 }
 
 /** The canonical spelling of a path, for use as a Map key where samePath cannot be called. */

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -12,7 +12,7 @@
 
 import { execFileSync } from 'child_process';
 import { readdirSync, lstatSync, rmdirSync, rmSync, unlinkSync, existsSync } from 'fs';
-import { samePath } from './paths.mjs';
+import { isInside, samePath } from './paths.mjs';
 import { resolve, sep } from 'path';
 
 function git(args, cwd) {
@@ -189,6 +189,23 @@ async function fetchRunning(daemonRequest) {
   };
 }
 
+// The daemon reports where its own code lives; a daemon running out of this tree holds the
+// directory open and no delete can succeed while it lives.
+//
+// `checked` is separate from `holder` on purpose. A daemon that is down, unreachable, or older than
+// the `skillDir` field yields no holder AND no knowledge — and the failure path below must not then
+// tell the reader the daemon has been ruled out, which is the confidently-wrong message this
+// replaces.
+export async function daemonRunningFrom(target, daemonRequest) {
+  const res = await daemonRequest('/');
+  const skillDir = res.ok ? res.data?.skillDir : null;
+  if (!skillDir) return { holder: null, checked: false };
+  return {
+    holder: isInside(skillDir, target) ? { pid: res.data.pid, skillDir } : null,
+    checked: true,
+  };
+}
+
 // Main-app sessions AND app sessions, because both hold a port and a live process in this tree.
 // While apps were global singletons they were invisible here, so `wt rm` would delete a worktree
 // out from under a running moderator and report a clean removal.
@@ -300,6 +317,20 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
     console.log(`stopped ${s.id}`);
   }
 
+  // Before the delete, not after it: the delete unlinks thousands of reparse points first, and a
+  // tree left half-dismantled by a failure nothing could have prevented is worse than a refusal.
+  const daemonCheck = await daemonRunningFrom(target, daemonRequest);
+  if (daemonCheck.holder) {
+    fail(
+      `the dev-server daemon (pid ${daemonCheck.holder.pid}) is running from this worktree\n` +
+        `  ${daemonCheck.holder.skillDir}\n` +
+        `its cwd and its own script are inside the directory, so no delete can succeed while it lives.\n` +
+        `a daemon started by a current cli.mjs runs from the primary checkout and never blocks this;\n` +
+        `this one predates that. it is SHARED — other agents' dev servers and queued test runs are on it —\n` +
+        `so check "cli.mjs test list" reports zero running and zero queued, and ask before restarting it.`
+    );
+  }
+
   const dirty = dirtyCount(target);
   if (dirty && !opts.force) {
     fail(`${dirty} uncommitted change(s) in ${target}\ninspect them, or re-run with --force`);
@@ -333,7 +364,12 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
       rmSync(target, { recursive: true, force: true });
     } catch (err) {
       fail(
-        `could not delete ${target}: ${err.message}\nsomething is holding it open (a shell cwd'd inside it?)`
+        `could not delete ${target}: ${err.message}\n` +
+          (daemonCheck.checked
+            ? `the dev-server daemon was asked and is running from elsewhere, so it is not the holder.\n` +
+              `look for a shell cwd'd inside, an editor, an unmanaged dev server, or a virus scan.`
+            : `the dev-server daemon could not be asked where it runs from (down, unreachable, or too\n` +
+              `old to report it), so it has NOT been ruled out — check it before hunting a stray shell.`)
       );
     }
     if (existsSync(target)) fail(`directory still present after delete: ${target}`);

--- a/.claude/skills/dev-server/scripts/worktree.mjs
+++ b/.claude/skills/dev-server/scripts/worktree.mjs
@@ -200,8 +200,14 @@ export async function daemonRunningFrom(target, daemonRequest) {
   const res = await daemonRequest('/');
   const skillDir = res.ok ? res.data?.skillDir : null;
   if (!skillDir) return { holder: null, checked: false };
+  // Its script AND its working directory: either one alone keeps the directory open. A daemon
+  // started by hand from a worktree runs the primary's script and still pins the tree by cwd.
+  const held = [
+    ['its running script', skillDir],
+    ['its working directory', res.data.cwd],
+  ].find(([, p]) => p && isInside(p, target));
   return {
-    holder: isInside(skillDir, target) ? { pid: res.data.pid, skillDir } : null,
+    holder: held ? { pid: res.data.pid, reason: `${held[0]}: ${held[1]}` } : null,
     checked: true,
   };
 }
@@ -301,6 +307,22 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
   const entry = trees.find((t) => samePath(t.path, target));
   if (!entry) fail(`not a registered worktree: ${target}\nrun: git worktree list`);
 
+  // Ahead of the session stops, not merely ahead of the delete. `--stop-server` stops OTHER agents'
+  // dev servers in this tree, which is irreversible and cannot be undone by the refusal that would
+  // otherwise follow it.
+  const daemonCheck = await daemonRunningFrom(target, daemonRequest);
+  if (daemonCheck.holder) {
+    fail(
+      `the dev-server daemon (pid ${daemonCheck.holder.pid}) is running from this worktree\n` +
+        `  ${daemonCheck.holder.reason}\n` +
+        `no delete can succeed while it lives — that path is inside the directory.\n` +
+        `a daemon started by a cli.mjs carrying this fix runs from the primary checkout and never\n` +
+        `blocks this; this one does not. it is SHARED — other agents' dev servers and queued test\n` +
+        `runs are on it — so check "cli.mjs test list" reports zero running and zero queued, and ask\n` +
+        `before restarting it.`
+    );
+  }
+
   const sessions = sessionsIn(target, await fetchRunning(daemonRequest));
   const live = sessions.filter((s) => s.status === 'running');
   if (live.length && !opts.stopServer) {
@@ -315,20 +337,6 @@ export async function cmdRemove(primary, targetArg, opts, daemonRequest) {
     // Both release the port — the difference is only which endpoint owns the reservation.
     await daemonRequest(s.stopPath, { method: s.id.startsWith('app:') ? 'POST' : 'DELETE' });
     console.log(`stopped ${s.id}`);
-  }
-
-  // Before the delete, not after it: the delete unlinks thousands of reparse points first, and a
-  // tree left half-dismantled by a failure nothing could have prevented is worse than a refusal.
-  const daemonCheck = await daemonRunningFrom(target, daemonRequest);
-  if (daemonCheck.holder) {
-    fail(
-      `the dev-server daemon (pid ${daemonCheck.holder.pid}) is running from this worktree\n` +
-        `  ${daemonCheck.holder.skillDir}\n` +
-        `its cwd and its own script are inside the directory, so no delete can succeed while it lives.\n` +
-        `a daemon started by a current cli.mjs runs from the primary checkout and never blocks this;\n` +
-        `this one predates that. it is SHARED — other agents' dev servers and queued test runs are on it —\n` +
-        `so check "cli.mjs test list" reports zero running and zero queued, and ask before restarting it.`
-    );
   }
 
   const dirty = dirtyCount(target);


### PR DESCRIPTION
One dev-server daemon serves every worktree, but it was spawned from whichever tree started it — `serverScript`, `pidFile` and the spawn `cwd` all derived from `__dirname`, and the skill directory is committed, so every worktree has its own copy. The daemon then holds that directory open for its whole life: `wt rm` fails EBUSY, and the agent who finishes their PR first is the one who cannot clean up.

Live example while writing this: pid `46332` running `daemon.mjs` out of `worktrees/profile-remix-flyout` — a tree whose PR had already merged.

## What changed

- `cli.mjs` and `console.mjs` resolve the checkout that owns `.git` and spawn the daemon from there — script, pid file and cwd. The `cwd` matters as much as the script: a working directory inside a worktree is itself a handle on it.
- The resolution lives once in `scripts/paths.mjs` (`resolveDaemonHome`). Two spawners open-coding it is the shape `daemon-port.mjs` already documents going wrong — five sites, disagreeing at three.
- `daemon.mjs` drops its private copy of `resolvePrimaryCheckout` and imports the shared one. Behaviour unchanged; it is now one definition instead of two.
- Fallback: when git cannot answer, or the primary has no copy of the skill, it uses the caller's own tree. A wrong-tree daemon is worse than a right-tree one, but no daemon at all is worse than either.
- **`wt rm` stops guessing.** The daemon reports the directory it runs from; `wt rm` refuses up front and names it when it is the holder. Previously it failed *after* unlinking several thousand reparse points and said "something is holding it open (a shell cwd'd inside it?)", which is confidently wrong and sends the reader hunting a stray shell. Where the daemon cannot be asked — down, or older than the new field — the message now says it has **not** been ruled out, rather than implying it has.

## Verified on this box

**Paired live control, both directions, on a private port** (`DEV_DAEMON_PORT=9455`), so the shared daemon and its queue were never touched. Started from *inside the worktree* each time, then read the spawned process's actual command line:

| | spawned `daemon.mjs` from |
|---|---|
| pre-fix behaviour (mutant) | `C:\Dev\Repos\work\worktrees\daemon-root-pin\...` |
| with the fix | `C:\Dev\Repos\work\model-share\...` |

**Existing-daemon detection intact.** From the worktree, against the shared daemon on 9444: reports `"pid": 46332`, does not print `Starting daemon...`, starts no second process. Process list before and after shows the same two daemons (ours, and the unrelated `ai-notifications` one).

**`wt rm` holder message, both directions.** With a worktree-resident daemon (pid 44132) it refuses before touching anything — `the dev-server daemon (pid 44132) is running from this worktree` — and the tree is intact. With the daemon elsewhere it gets past that check to the pre-existing dirty-tree guard (`7 uncommitted change(s)`), so the refusal is not unconditional.

**Selftest** `scripts/daemon-home.selftest.mjs`, new, 20 checks, all passing. Its mutation control — forcing the pre-fix `__dirname` behaviour — fails 4 checks naming the worktree path where the primary was wanted:

```
FAIL  the daemon home is the primary checkout
        got="C:\Dev\Repos\work\worktrees\daemon-root-pin"
       want="C:\Dev\Repos\work\model-share"
```

It also covers the three `wt rm` outcomes against a fake daemon — named / not blamed / could-not-tell — because only a fake can produce the third on demand.

All 8 other dev-server selftests pass (`worktree`, `cli-verbs`, `app-registry`, `env-chain`, `branch-watch`, `db-host`, `probe`, plus the new one). `probe.integration.selftest.mjs` was not run — it starts real servers.

`pnpm run typecheck` → `OK — 0 type errors in 241s`. `pnpm run lint` exits 1 repo-wide with 358 pre-existing errors, byte-identical output to the same command on the base, and zero lines naming this skill (eslint does not cover `.claude/`). `pnpm run prettier:write` → `no uncommitted .ts/.tsx files`; the root Prettier globs `.ts`/`.tsx` only, so it does not format `.mjs` and this diff is outside its scope.

**The full unit suite is not the coverage here** — this is skill tooling, not `src/`. `scripts/__tests__/dev-server-daemon-port.test.ts`, the one repo test that reads this skill, passes: `Tests 21 passed (21)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGLvuRNShS6UoMWGoDmuHh