### PR TITLE
fix(announcements): count followed-creator announcements in the badge

### DIFF
--- a/src/components/Announcements/AnnouncementsPanel.tsx
+++ b/src/components/Announcements/AnnouncementsPanel.tsx
@@ -4,8 +4,9 @@ import { Announcement } from '~/components/Announcements/Announcement';
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import { CreatorAnnouncement } from '~/components/Announcements/CreatorAnnouncement';
 import {
-  dismissCreatorAnnouncement,
+  dismissCreatorAnnouncements,
   pruneDismissedCreatorAnnouncements,
+  selectUndismissedAnnouncements,
   useDismissedCreatorAnnouncements,
 } from '~/components/Announcements/creator-announcement-dismissals';
 import { DeleteCreatorAnnouncementButton } from '~/components/Announcements/CreatorAnnouncementsCarousel';
@@ -51,7 +52,7 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
     pruneDismissedCreatorAnnouncements(creatorItems.map((x) => x.id));
   }, [creatorItems]);
 
-  const visibleCreatorItems = creatorItems.filter((x) => !dismissedCreatorIds.includes(x.id));
+  const visibleCreatorItems = selectUndismissedAnnouncements(creatorItems, dismissedCreatorIds);
 
   if (isLoading)
     return (
@@ -112,7 +113,7 @@ export function AnnouncementsPanel({ sources }: { sources: AnnouncementSource[] 
                 color="gray"
                 radius="xl"
                 className="text-dark-9 dark:text-white"
-                onClick={() => dismissCreatorAnnouncement(announcement.id)}
+                onClick={() => dismissCreatorAnnouncements(announcement.id)}
                 aria-label="Dismiss creator announcement"
               >
                 <IconX size={16} />

--- a/src/components/Announcements/creator-announcement-dismissals.ts
+++ b/src/components/Announcements/creator-announcement-dismissals.ts
@@ -25,8 +25,20 @@ const store = createDismissalStore<number, typeof BUCKET>({
 
 export const useDismissedCreatorAnnouncements = () => store.useDismissed();
 
-export function dismissCreatorAnnouncement(id: number) {
-  store.dismiss(id);
+export function dismissCreatorAnnouncements(ids: number | number[]) {
+  store.dismiss(ids);
+}
+
+/**
+ * The badge counts these and the panel renders them, from the same query and the same
+ * dismissal set — so the predicate has one owner. Two copies that drift are the reported
+ * bug in mirror image: a number that no longer matches the list under it.
+ */
+export function selectUndismissedAnnouncements<T extends { id: number }>(
+  announcements: T[],
+  dismissedIds: number[]
+) {
+  return announcements.filter((x) => !dismissedIds.includes(x.id));
 }
 
 export function pruneDismissedCreatorAnnouncements(live: Iterable<number>) {

--- a/src/components/Notifications/NotificationsComposed.tsx
+++ b/src/components/Notifications/NotificationsComposed.tsx
@@ -17,15 +17,22 @@ import React, { forwardRef, useMemo, useState } from 'react';
 import { dismissAnnouncements } from '~/components/Announcements/announcements.utils';
 import type { AnnouncementSource } from '~/components/Announcements/AnnouncementsPanel';
 import { AnnouncementsPanel } from '~/components/Announcements/AnnouncementsPanel';
-import { useCreatorAnnouncementsFeature } from '~/components/Announcements/creator-announcements.utils';
+import { dismissCreatorAnnouncements } from '~/components/Announcements/creator-announcement-dismissals';
+import {
+  useCreatorAnnouncementsFeature,
+  useQueryFollowedAnnouncements,
+} from '~/components/Announcements/creator-announcements.utils';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { NextLink } from '~/components/NextLink/NextLink';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 import { NotificationList } from '~/components/Notifications/NotificationList';
 import {
+  clearAnnouncements,
   getCategoryDisplayName,
   useGetAnnouncementsAsNotifications,
+  resolveMarkAsRead,
   useMarkReadNotification,
   useQueryNotifications,
 } from '~/components/Notifications/notifications.utils';
@@ -45,6 +52,7 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
       key: 'notifications-announcement-sources',
       defaultValue: ['civitai', 'creators'],
     });
+    const currentUser = useCurrentUser();
     const creatorAnnouncementsEnabled = useCreatorAnnouncementsFeature();
     const selectedCategory = Object.values(NotificationCategory).find(
       (category) => category === selectedTab
@@ -66,6 +74,11 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
     );
 
     const announcements = useGetAnnouncementsAsNotifications({ hideRead });
+    // Gated on the session, as the badge's own call is: /user/notifications has no auth guard,
+    // and `getFollowedAnnouncements` is a protected procedure — without this an anonymous
+    // visitor fires it on mount and takes an UNAUTHORIZED.
+    const { announcements: followedAnnouncements, isLoading: loadingFollowed } =
+      useQueryFollowedAnnouncements(!!currentUser);
     const notifications = useMemo(() => {
       return !selectedTab
         ? data.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -76,8 +89,20 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
     const categoryName = !selectedTab ? 'all' : getCategoryDisplayName(selectedTab);
 
     function handleMarkAsRead() {
-      if (selectedTab === 'announcements') dismissAnnouncements(announcements.map((x) => x.id));
-      if (selectedTab !== 'announcements')
+      const { clearsAnnouncements, marksNotificationsRead } = resolveMarkAsRead(selectedTab);
+      if (clearsAnnouncements) {
+        // Neither half is filtered by the source chips: the chips filter the view, while this
+        // button clears the tab's count, and leaving the half the reader happens to have
+        // hidden would leave a badge nothing in the UI can clear.
+        clearAnnouncements(
+          {
+            platformIds: announcements.map((x) => x.id),
+            creatorIds: followedAnnouncements.map((x) => x.id),
+          },
+          { platform: dismissAnnouncements, creator: dismissCreatorAnnouncements }
+        );
+      }
+      if (marksNotificationsRead)
         readNotificationMutation.mutate({
           all: true,
           category: selectedCategory,
@@ -99,7 +124,10 @@ export const NotificationsComposed = forwardRef<HTMLDivElement, { onClose?: () =
                 onChange={(e) => setHideRead(e.currentTarget.checked)}
               />
               <Tooltip label={`Mark ${categoryName} as read`} position="bottom">
-                <LegacyActionIcon size="lg" onClick={handleMarkAsRead}>
+                {/* Disabled until the followed set has landed: an empty list dismisses
+                    nothing, so an early click would clear the platform half and leave a
+                    badge the second click cannot clear either. */}
+                <LegacyActionIcon size="lg" onClick={handleMarkAsRead} disabled={loadingFollowed}>
                   <IconListCheck />
                 </LegacyActionIcon>
               </Tooltip>

--- a/src/components/Notifications/__tests__/announcement-counts.test.ts
+++ b/src/components/Notifications/__tests__/announcement-counts.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clearAnnouncements,
+  resolveMarkAsRead,
+  withAnnouncementCounts,
+} from '~/components/Notifications/notifications.utils';
+
+/**
+ * The Announcements tab renders two sets — Civitai's own announcements and the ones from
+ * creators you follow — but its badge counted only the first, so a followed creator's post
+ * sat in the tab, uncounted, with nothing to tell the reader it was there. Reported by a
+ * tester whose badge read 2 with a creator announcement visible below it (FD #72072).
+ *
+ * These take the followed list and the dismissal set rather than a count, because the bug
+ * was the creator half never reaching the counter — an assertion on a sum cannot tell a
+ * real count from a zero, so a function that accepts one cannot catch the revert.
+ */
+describe('withAnnouncementCounts', () => {
+  const base = Object.freeze({ all: 5, comment: 3, pendingPlacements: 2 });
+  const followed = [{ id: 10 }, { id: 11 }, { id: 12 }];
+
+  it('counts undismissed followed announcements alongside the platform ones', () => {
+    const counts = withAnnouncementCounts(base, { platform: 2, followed, dismissedIds: [] });
+
+    expect(counts.announcements).toBe(5);
+    expect(counts.all).toBe(10);
+  });
+
+  it('counts the creator set when there are no platform announcements', () => {
+    // The reported shape once the two official cards expired: drop the creator half and
+    // this reads 0, which is the bug rather than an empty tab.
+    const counts = withAnnouncementCounts(base, { platform: 0, followed, dismissedIds: [] });
+
+    expect(counts.announcements).toBe(3);
+    expect(counts.all).toBe(8);
+  });
+
+  it('excludes dismissed followed announcements', () => {
+    const counts = withAnnouncementCounts(base, { platform: 0, followed, dismissedIds: [11] });
+
+    expect(counts.announcements).toBe(2);
+    expect(counts.all).toBe(7);
+  });
+
+  it('reaches zero once every followed announcement is dismissed', () => {
+    // The other direction of the same bug: dismiss them all and the badge must clear, or
+    // "mark as read" leaves a number behind with nothing left to click.
+    const counts = withAnnouncementCounts(base, {
+      platform: 0,
+      followed,
+      dismissedIds: [10, 11, 12],
+    });
+
+    expect(counts.announcements).toBe(0);
+    expect(counts.all).toBe(5);
+  });
+
+  it('leaves the other counts alone', () => {
+    const counts = withAnnouncementCounts(base, { platform: 1, followed, dismissedIds: [] });
+
+    expect(counts.comment).toBe(3);
+    expect(counts.pendingPlacements).toBe(2);
+  });
+});
+
+/**
+ * The bell renders `all`, which now includes announcements — so a "Mark all as read" that
+ * skipped them would drop the bell to a number the tab it was clicked on cannot clear.
+ */
+describe('resolveMarkAsRead', () => {
+  it('clears announcements and the notification feed from the All tab', () => {
+    expect(resolveMarkAsRead(null)).toEqual({
+      clearsAnnouncements: true,
+      marksNotificationsRead: true,
+    });
+  });
+
+  it('clears only announcements on the Announcements tab', () => {
+    expect(resolveMarkAsRead('announcements')).toEqual({
+      clearsAnnouncements: true,
+      marksNotificationsRead: false,
+    });
+  });
+
+  it('leaves announcements alone on a category tab', () => {
+    // A category tab's button is scoped to that category, and its count never included
+    // announcements — clearing them there would dismiss cards the reader never saw.
+    expect(resolveMarkAsRead('Comment')).toEqual({
+      clearsAnnouncements: false,
+      marksNotificationsRead: true,
+    });
+  });
+});
+
+describe('clearAnnouncements', () => {
+  const spies = () => ({ platform: vi.fn(), creator: vi.fn() });
+
+  it('dismisses both sets', () => {
+    // Dropping either call is the "badge goes up and will not come down" bug, and both
+    // dismissers write to browser storage and return nothing — so the call is the only
+    // observable there is.
+    const dismiss = spies();
+
+    clearAnnouncements({ platformIds: [1, 2], creatorIds: [10, 11] }, dismiss);
+
+    expect(dismiss.platform).toHaveBeenCalledTimes(1);
+    expect(dismiss.platform).toHaveBeenCalledWith([1, 2]);
+    expect(dismiss.creator).toHaveBeenCalledTimes(1);
+    expect(dismiss.creator).toHaveBeenCalledWith([10, 11]);
+  });
+
+  it('does not cross the two sets over', () => {
+    // Both dismissers take number[], so a swap typechecks and would dismiss each half
+    // against the other's store — silently, since ids that match nothing are a no-op.
+    const dismiss = spies();
+
+    clearAnnouncements({ platformIds: [1], creatorIds: [10] }, dismiss);
+
+    expect(dismiss.platform).not.toHaveBeenCalledWith([10]);
+    expect(dismiss.creator).not.toHaveBeenCalledWith([1]);
+  });
+});

--- a/src/components/Notifications/__tests__/useQueryNotificationsCount.test.ts
+++ b/src/components/Notifications/__tests__/useQueryNotificationsCount.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as TrpcModule from '~/utils/trpc';
+import type * as DismissalsModule from '~/components/Announcements/creator-announcement-dismissals';
+
+/**
+ * The reported bug was WIRING, not arithmetic: the creator half never reached the counter
+ * (FD #72072). `withAnnouncementCounts` is unit-tested next door, but a test of it cannot
+ * see the hook decline to pass the followed set — so this file drives the hook itself.
+ *
+ * `selectUndismissedAnnouncements` is left REAL via importOriginal. Mocking it would leave
+ * the dismissal filter — the half of this that decides whether the badge can ever clear —
+ * untested with the suite green.
+ */
+const state = vi.hoisted(() => ({
+  currentUser: { id: 1 } as { id: number } | null,
+  counts: undefined as Record<string, number> | undefined,
+  countsLoading: false,
+  platform: [] as { id: number; dismissed: boolean }[],
+  platformLoading: false,
+  followed: [] as { id: number }[],
+  dismissedCreatorIds: [] as number[],
+  followedEnabled: undefined as boolean | undefined,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => state.currentUser,
+}));
+vi.mock('~/components/Announcements/announcements.utils', () => ({
+  useGetAnnouncements: () => ({ data: state.platform, isLoading: state.platformLoading }),
+}));
+vi.mock('~/components/Announcements/creator-announcements.utils', () => ({
+  useQueryFollowedAnnouncements: (enabled?: boolean) => {
+    state.followedEnabled = enabled;
+    return { announcements: state.followed, isLoading: false };
+  },
+}));
+vi.mock('~/components/Announcements/creator-announcement-dismissals', async (importOriginal) => ({
+  ...(await importOriginal<typeof DismissalsModule>()),
+  useDismissedCreatorAnnouncements: () => state.dismissedCreatorIds,
+}));
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    user: {
+      checkNotifications: {
+        useQuery: () => ({ data: state.counts, isLoading: state.countsLoading }),
+      },
+    },
+  },
+}));
+
+import { useQueryNotificationsCount } from '~/components/Notifications/notifications.utils';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+function renderHook<T>(useHook: () => T) {
+  const result = { current: undefined as T };
+  const root = createRoot(document.createElement('div'));
+  function Probe() {
+    result.current = useHook();
+    return null;
+  }
+  act(() => {
+    root.render(createElement(Probe));
+  });
+  return result;
+}
+
+const counts = () => renderHook(() => useQueryNotificationsCount()).current;
+
+beforeEach(() => {
+  state.currentUser = { id: 1 };
+  state.counts = { all: 4, comment: 4 };
+  state.countsLoading = false;
+  state.platform = [];
+  state.platformLoading = false;
+  state.followed = [];
+  state.dismissedCreatorIds = [];
+  state.followedEnabled = undefined;
+});
+
+describe('useQueryNotificationsCount', () => {
+  it('passes the followed announcements through to the count', () => {
+    // The regression itself: before the fix these three were fetched, rendered in the tab,
+    // and never counted. A hook that stops passing them reads 0 here.
+    state.followed = [{ id: 10 }, { id: 11 }, { id: 12 }];
+
+    expect(counts().announcements).toBe(3);
+    expect(counts().all).toBe(7);
+  });
+
+  it('counts both halves together', () => {
+    state.platform = [{ id: 1, dismissed: false }];
+    state.followed = [{ id: 10 }, { id: 11 }];
+
+    expect(counts().announcements).toBe(3);
+  });
+
+  it('drops a dismissed creator announcement from the count', () => {
+    state.followed = [{ id: 10 }, { id: 11 }];
+    state.dismissedCreatorIds = [10];
+
+    expect(counts().announcements).toBe(1);
+  });
+
+  it('clears once every creator announcement is dismissed', () => {
+    state.followed = [{ id: 10 }, { id: 11 }];
+    state.dismissedCreatorIds = [10, 11];
+
+    expect(counts().announcements).toBe(0);
+    expect(counts().all).toBe(4);
+  });
+
+  it('still excludes dismissed platform announcements', () => {
+    state.platform = [
+      { id: 1, dismissed: true },
+      { id: 2, dismissed: false },
+    ];
+
+    expect(counts().announcements).toBe(1);
+  });
+
+  it('gates the followed query on there being a signed-in user', () => {
+    // `getFollowedAnnouncements` is a protected procedure; an ungated call is an
+    // UNAUTHORIZED per anonymous page view.
+    state.currentUser = null;
+
+    counts();
+
+    expect(state.followedEnabled).toBe(false);
+  });
+
+  it('reports zero while the platform counts are still loading', () => {
+    state.countsLoading = true;
+    state.followed = [{ id: 10 }];
+
+    expect(counts().all).toBe(0);
+    expect(counts().announcements).toBe(0);
+  });
+});

--- a/src/components/Notifications/notifications.utils.ts
+++ b/src/components/Notifications/notifications.utils.ts
@@ -5,6 +5,11 @@ import { getQueryKey } from '@trpc/react-query';
 import produce from 'immer';
 import { useCallback, useMemo } from 'react';
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
+import {
+  selectUndismissedAnnouncements,
+  useDismissedCreatorAnnouncements,
+} from '~/components/Announcements/creator-announcement-dismissals';
+import { useQueryFollowedAnnouncements } from '~/components/Announcements/creator-announcements.utils';
 import { useSignalConnection } from '~/components/Signals/SignalsProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { NotificationCategory, SignalMessages } from '~/server/common/enums';
@@ -76,6 +81,59 @@ export function useGetAnnouncementsAsNotifications({
   );
 }
 
+/**
+ * The Announcements tab holds two independently-fetched, independently-dismissed sets —
+ * Civitai's own and the ones from creators you follow — and its badge is the count of what
+ * is undismissed across both.
+ *
+ * It takes the followed announcements and the dismissal set rather than a number, so the
+ * call site has nothing left to get wrong: the bug this fixes was the creator half never
+ * reaching the counter, and a function that accepts a count cannot tell a real one from a
+ * zero. Everything that decides the number is inside here, where a test can reach it.
+ */
+export function withAnnouncementCounts<T extends { all: number }>(
+  counts: T,
+  {
+    platform,
+    followed,
+    dismissedIds,
+  }: { platform: number; followed: { id: number }[]; dismissedIds: number[] }
+): T & { announcements: number } {
+  const announcements = platform + selectUndismissedAnnouncements(followed, dismissedIds).length;
+  return { ...counts, all: counts.all + announcements, announcements };
+}
+
+/**
+ * Which halves the "mark as read" button clears, per tab.
+ *
+ * The announcements half is cleared from the All tab too, not just the Announcements tab:
+ * the bell renders `all`, which now includes announcements, so a button labelled "Mark all
+ * as read" that skipped them would drop the bell to a number the tab it was clicked on has
+ * no way to clear.
+ */
+export function resolveMarkAsRead(selectedTab: string | null) {
+  const isAnnouncementsTab = selectedTab === 'announcements';
+  return {
+    clearsAnnouncements: isAnnouncementsTab || !selectedTab,
+    marksNotificationsRead: !isAnnouncementsTab,
+  };
+}
+
+/**
+ * Clearing the announcements half of the tab: both sets, or the badge goes up on a creator
+ * post and then refuses to come down — a worse bug than the uncounted one this fixes.
+ *
+ * Takes its two dismissers so the pair can be asserted. Dropping either call is otherwise
+ * invisible: they write to browser storage and return nothing.
+ */
+export function clearAnnouncements(
+  { platformIds, creatorIds }: { platformIds: number[]; creatorIds: number[] },
+  dismiss: { platform: (ids: number[]) => void; creator: (ids: number[]) => void }
+) {
+  dismiss.platform(platformIds);
+  dismiss.creator(creatorIds);
+}
+
 export const useQueryNotificationsCount = () => {
   const currentUser = useCurrentUser();
   const { data, isLoading } = trpc.user.checkNotifications.useQuery(undefined, {
@@ -87,6 +145,17 @@ export const useQueryNotificationsCount = () => {
   const { data: allAnnouncements, isLoading: announcementsLoading } = useGetAnnouncements();
   const announcements = allAnnouncements.filter((x) => !x.dismissed);
 
+  // Followed-creator announcements are the SAME tab and the same dismiss affordance as the
+  // rows above, so they belong in the same number — but they are a different query with a
+  // different dismissal store, so the count has to be assembled here rather than server-side.
+  // Same input as the panel's own call, so the two share one cache entry instead of fetching
+  // twice.
+  const { announcements: followedAnnouncements } = useQueryFollowedAnnouncements(!!currentUser);
+  const dismissedCreatorIds = useDismissedCreatorAnnouncements();
+
+  // Deliberately NOT gated on the followed query's loading state: this hook drives the header
+  // bell on every page, and adding a third gate would blank the whole badge until a query the
+  // rest of it does not need has landed.
   return isLoading || announcementsLoading || !data || !announcements
     ? {
         all: 0,
@@ -105,7 +174,11 @@ export const useQueryNotificationsCount = () => {
         pendingStickerPlacements: 0,
         pendingRemixSubmissions: 0,
       }
-    : { ...data, all: data.all + announcements.length, announcements: announcements.length };
+    : withAnnouncementCounts(data, {
+        platform: announcements.length,
+        followed: followedAnnouncements,
+        dismissedIds: dismissedCreatorIds,
+      });
 };
 
 /**


### PR DESCRIPTION
@
Closes the reported half of [CU 868m0fbnu](https://app.clickup.com/t/868m0fbnu) (FD #72072, reported by tester RisingV).

## The bug

The notification menu Announcements tab renders two sets: Civitai own announcements and the ones from creators you follow. The badge counted only the first. A followed creator post sat in the tab, uncounted, with nothing to tell the reader it was there. RisingV saw a count of 2 with a creator announcement visible below it, and only noticed because two official cards expired and the number dropped from 4 to 2.

Measured on the prod replica while auditing:

- **67** creator announcements live right now (positive control in the same query: 317 platform rows)
- **107,082** distinct users currently have at least one live, uncounted announcement from someone they follow
- flag went **public 2026-09-02**, so this is everyone, not testers

## Option A, deliberately, and why not B

The ticket named two directions and Justin picked A: count them in the badge, no fan-out. Recorded here because option B would reverse a decision made ten days ago, not because it was unaffordable.

The follower fan-out was removed in #4408 (`7a9b8a28c1`), and the stated reason is **UX, not cost**: it "duplicated the Announcements tab, which already resolves followers at read time via getFollowedAnnouncements, and buried the surface that owns the feature", on three creator reports. Restoring it would cost about 24,800 notification rows/day, 0.44% of the ~5.6M/day already written, so it was affordable. The tab unread signal is what this builds instead.

`creator-announcement.notifications.ts` and the test pinning its absent `prepareQuery` are untouched.

## What changed

- **The badge** counts undismissed followed-creator announcements alongside the platform ones, in both `announcements` and `all`.
- **Mark-all-read** clears both halves. Without this the new number would go up on a creator post and then refuse to come down, which is a worse bug than the one being fixed. It also clears from the **All** tab, since the bell renders `all`.
- **Both call sites are gated on the session.** `getFollowedAnnouncements` is a `protectedProcedure` and `/user/notifications` has no auth guard, so the ungated call was an UNAUTHORIZED per anonymous page view.
- **The visibility predicate has one owner**, consumed by the badge and the panel. Two copies drifting is the reported bug in mirror image.

Counted client-side rather than folded into `checkNotifications` because the two halves dismiss into different stores: platform into a server-readable cookie, creator into localStorage.

## Performance

The badge runs for every signed-in user on every page, so this was measured rather than assumed, on the prod replica.

- Cost is **bounded by the number of live creator announcements, not by follower count** - the planner drives off `Announcement_userId_startsAt_idx` and does a point lookup per candidate. 55 loops for the heaviest follower on the site (120,028 follows) and 55 for a 5-follow user.
- Actual data work is **1.35 ms**. Heavy accounts can total 27-45 ms, ~95% of it JIT emission from a row mis-estimate. **Plausible, not confirmed** for the app: the EXPLAIN inlined literals and Prisma binds parameters, so real traffic may get a generic plan that never trips JIT. Worth a `pg_stat_statements` check after ramp.
- **One fetch, one cache entry.** All three call sites pass `{ limit: 20 }` and `domain` is stamped server-side, so the badge and the panel share it.
- `withAuthorIdentity` is cached per **author**, and there are only 76 distinct authors site-wide, so the set is shared across every viewer.

Two things to know rather than fix here:

- Until `trpcBatching` ramps, this is a **second un-batched HTTP request** per signed-in page bootstrap. That is the largest real cost today and it collapses to near-free when that flag lands.
- The driving scan reads every creator announcement ever created (105 so far, all in 30 days, ~10/day) and `LIMIT 21` cannot terminate it early. A partial index on the ORDER BY fixes it well before "thousands".

## Behaviour worth a second opinion

With the **Creators** chip unchecked the badge still counts those items, so the number can exceed what the tab renders. Kept deliberately: the alternative makes a hidden source uncountable *and* unclearable. Mark-all-read does clear it.

The creator half of the badge saturates at 20. Not a defect - the panel renders the same top 20 from the same cache entry, so the number always matches the list.

## Verification

- `pnpm run typecheck` 0 errors; eslint 0 errors on the changed files; prettier clean
- **Full unit suite: `1634 passed | 3 skipped (1637)`, `38070 passed | 35 skipped (38105)`** - both dimensions reconcile, no dropped workers, zero failures
- `blocks.router.workflow.test.ts` collected **370** tests, run directly rather than inferred from the log
- `pnpm run test:lint-rules` 476 passed, including `no-untruthy-query-gate` which covers the session coercion added here

**Mutation-tested at the call site, which is where the bug actually was.** An earlier revision of this PR shipped a test that asserted a sum; setting the creator term to zero at the call site left it fully green. The function now takes the followed list and the dismissal set, so:

- call site `followed: followedAnnouncements` -> `[]` gives **3 failures** (`expected +0 to be 3`)
- deleting `dismiss.creator(creatorIds)` gives **1 failure** (`expected "vi.fn()" to be called 1 times, but got 0 times`)

Both were green before the rework. `useQueryNotificationsCount.test.ts` drives the real hook and leaves `selectUndismissedAnnouncements` real via `importOriginal`, so the dismissal filter is covered rather than mocked away.

Reviewed by the five main-app lanes (reuse, correctness, perf, tests, intent); every finding is either fixed above or recorded as a deliberate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf5FaDU3gjwAU8xkdFjL1D
@