### PR TITLE
fix(tests): make the ModelVersionUpsertForm trpc mock a Proxy, not a hand-list

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.browser.test.tsx
@@ -21,9 +21,118 @@ const allowance = vi.hoisted(() => ({
   data: { used: 0, limit: 3 } as Record<string, unknown>,
 }));
 
-vi.mock('~/utils/trpc', async (importOriginal) => ({
-  ...(await importOriginal<typeof TrpcModule>()),
-  trpc: {
+/**
+ * The `trpc` mock is in two layers, and the split between them is the whole point.
+ *
+ * MODELLED — every proc whose *behaviour* a test reads. Those keep exactly the shape they had, and
+ * a proc a test depends on has to stay here.
+ *
+ * FALLBACK — a Proxy over the router surface for everything else, so a component may call any proc
+ * it likes and get an inert react-query result back instead of `TypeError: Cannot read properties
+ * of undefined (reading 'useQuery')`. The hand-listed object this replaces went red twice for that
+ * reason: once when the allowance counter landed, and again when `PricingSlotHistory` started
+ * reading `modelVersion.getPricingSlots` (2cbacbc4d5). The comment that recorded the first
+ * occurrence did not stop the second — a note describing a trap is not a guard against it.
+ *
+ * 🔴 The fallback is deliberately the EMPTY result, not a satisfying one. `data: undefined` is what
+ * react-query hands a query that has not resolved: every consumer already guards on it, so the
+ * component renders, and there is nothing for an assertion to land on, so an unlisted proc can never
+ * make a test pass that should fail. The Proxy stops the crash; it is not a stand-in for a fixture.
+ */
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  /** react-query's shape for a query with no data — the same state an `enabled: false` query sits in. */
+  const noData = () => ({
+    data: undefined,
+    error: null,
+    status: 'pending',
+    isPending: true,
+    // v5 defines `isLoading` as `isPending && isFetching`. A query that is not running is pending but
+    // NOT loading, so a consumer's spinner branch stays shut and its empty branch is what renders.
+    isLoading: false,
+    isFetching: false,
+    isRefetching: false,
+    isError: false,
+    isSuccess: false,
+    refetch: vi.fn(async () => ({ data: undefined })),
+  });
+  const inertHook: Record<string, () => unknown> = {
+    useQuery: noData,
+    useSuspenseQuery: noData,
+    useInfiniteQuery: () => ({
+      ...noData(),
+      fetchNextPage: vi.fn(async () => undefined),
+      fetchPreviousPage: vi.fn(async () => undefined),
+      hasNextPage: false,
+      hasPreviousPage: false,
+      isFetchingNextPage: false,
+    }),
+    useMutation: () => ({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(async () => undefined),
+      reset: vi.fn(),
+      data: undefined,
+      error: null,
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+    }),
+  };
+
+  // A proc. A modelled hook wins outright — it is NOT merged with the inert defaults, because merging
+  // would quietly widen a mock a test reads (`getLicensingRoots` returns `{ data }` and nothing else,
+  // on purpose). Anything that is not a hook name — `_def`, `then`, a symbol React or the runtime
+  // probes for — stays `undefined`, so the proxy is never mistaken for a promise or a real procedure.
+  const proc = (modelled: Record<string, unknown> = {}) =>
+    new Proxy(modelled, {
+      get: (target, key) => (typeof key === 'string' ? target[key] ?? inertHook[key] : undefined),
+    });
+
+  const router = (modelled: Record<string, unknown> = {}) =>
+    new Proxy(modelled, {
+      get: (target, key) =>
+        typeof key === 'string'
+          ? proc(target[key] as Record<string, unknown> | undefined)
+          : undefined,
+    });
+
+  // `useUtils` is the same hazard one surface over: the form invalidates by path after a save, so a
+  // newly-added `utils.<router>.<proc>.invalidate()` would throw exactly the way a new query did.
+  // Same split, and the verb list is closed rather than "anything is callable" — an unknown member of
+  // a utils proc is still `undefined`.
+  const utilsVerbs = new Set([
+    'invalidate',
+    'refetch',
+    'cancel',
+    'reset',
+    'setData',
+    'getData',
+    'setInfiniteData',
+    'getInfiniteData',
+    'prefetch',
+    'fetch',
+    'ensureData',
+  ]);
+  const utilsProc = (modelled: Record<string, unknown> = {}) =>
+    new Proxy(modelled, {
+      get: (target, key) => {
+        if (typeof key !== 'string') return undefined;
+        return target[key] ?? (utilsVerbs.has(key) ? vi.fn(async () => undefined) : undefined);
+      },
+    });
+  const utils = (modelled: Record<string, Record<string, unknown>>) =>
+    new Proxy(modelled, {
+      get: (target, key) =>
+        typeof key === 'string'
+          ? new Proxy(target[key] ?? {}, {
+              get: (routerTarget, procKey) =>
+                typeof procKey === 'string'
+                  ? utilsProc(routerTarget[procKey] as Record<string, unknown> | undefined)
+                  : undefined,
+            })
+          : undefined,
+    });
+
+  const modelled: Record<string, unknown> = {
     modelVersion: {
       getLicensingRoots: {
         // Modelled on react-query's own contract, because that contract is what the fix turns on: a
@@ -34,20 +143,35 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
         }),
       },
       getUserEarlyAccessVersions: { useQuery: () => ({ data: [] }) },
-      // Hand-listed, so every router entry the component reads has to appear here or it throws on
-      // render — the whole suite went red on this one when the allowance counter was added.
       getPricingAllowance: { useQuery: () => ({ data: allowance.data }) },
       upsert: { useMutation: () => ({ mutateAsync, isPending: false }) },
     },
-    useUtils: () => ({
-      modelVersion: {
-        getById: { invalidate: vi.fn() },
-        getByIdForEdit: { invalidate: vi.fn() },
+    // Rebuilt per call, so each render gets its own spies — the shape the hand-listed version had.
+    useUtils: () =>
+      utils({
+        modelVersion: {
+          getById: { invalidate: vi.fn() },
+          getByIdForEdit: { invalidate: vi.fn() },
+        },
+        model: { getById: { invalidate: vi.fn() } },
+      }),
+  };
+  // tRPC's deprecated alias for the same thing; a component still on it must not fall into `router()`.
+  modelled.useContext = modelled.useUtils;
+
+  return {
+    ...(await importOriginal<typeof TrpcModule>()),
+    trpc: new Proxy(modelled, {
+      get: (target, key) => {
+        if (typeof key !== 'string') return undefined;
+        const own = target[key];
+        // Members of the client itself (`useUtils`, `useContext`) are functions, not routers.
+        if (typeof own === 'function') return own;
+        return router(own as Record<string, unknown> | undefined);
       },
-      model: { getById: { invalidate: vi.fn() } },
     }),
-  },
-}));
+  };
+});
 /** Anima's default licensing root: a Checkpoint charging 5 Buzz per image, settled to its own owner. */
 const ANIMA_CHECKPOINT_ROOT = {
   id: 2945208,


### PR DESCRIPTION
## The regression

`preview / component-tests` fails on any PR whose base includes **`2cbacbc4d5`** ("feat(monetization): say what the pricing cap counts, and what spent it").

Attribution chain:

| step | where |
|---|---|
| commit | `2cbacbc4d5` added `src/components/Buzz/PricingSlotHistory.tsx` and wired it into `ModelVersionUpsertForm` |
| component | `PricingSlotHistory.tsx:48` — `trpc.modelVersion.getPricingSlots.useQuery(undefined, { enabled: opened })` |
| mount site | `ModelVersionUpsertForm.tsx:1369` renders `<PricingSlotHistory />` (inside the allowance counter, so it mounts on essentially every render of the monetization section) |
| spec | `ModelVersionUpsertForm.browser.test.tsx` mocked `~/utils/trpc` with a hand-listed router object that has no `getPricingSlots` |
| error | `TypeError: Cannot read properties of undefined (reading 'useQuery')` at `PricingSlotHistory.tsx:48` — the form renders as an empty div, 30 unhandled rejections, **31 failed / 5 passed (36)** |

Note the query is `enabled: opened` and `opened` starts `false` — it never runs. The crash is purely the *property read* on a router entry the mock does not have.

## This is the second occurrence in this file, and the first one is written on the thing that broke

The mock's own comment, at the line above `getPricingAllowance`:

> *Hand-listed, so every router entry the component reads has to appear here or it throws on render — the whole suite went red on this one when the allowance counter was added.*

So the trap was known, documented, and sitting three lines from the defect. A comment describing a trap is not a guard against it. Adding `getPricingSlots` would have fixed today's instance and guaranteed the next one, so this PR removes the hand-list instead.

## The fix

The router surface is a Proxy with two layers:

- **MODELLED** — every proc whose *behaviour* a test reads. `getLicensingRoots` (still models react-query's `enabled: false` contract, because the behaviour under test turns on it), `getUserEarlyAccessVersions`, `getPricingAllowance`, `upsert`. A modelled hook wins **outright** and is deliberately **not merged** with the inert defaults, so a mock that returns `{ data }` and nothing else keeps returning exactly that.
- **FALLBACK** — everything else resolves to the *empty* react-query result.

The inert defaults, and why they are these:

| hook | fallback | rationale |
|---|---|---|
| `useQuery` / `useSuspenseQuery` | `{ data: undefined, status: 'pending', isPending: true, isLoading: false, isFetching: false, isError: false, isSuccess: false, error: null, refetch }` | the state react-query puts a query in when it has not resolved — which is also exactly the `enabled: false` state. Consumers already guard on `data`, so the component renders. `isLoading: false` (v5 defines it as `isPending && isFetching`) keeps a consumer's spinner branch shut so the empty branch is what renders. |
| `useInfiniteQuery` | the same, plus `fetchNextPage` / `fetchPreviousPage` / `hasNextPage: false` / `isFetchingNextPage: false` | same shape one level out |
| `useMutation` | `{ mutate, mutateAsync → undefined, reset, data: undefined, isPending: false, isError: false, isSuccess: false, error: null }` | callable, records nothing anyone holds a reference to |
| anything that is not a hook name (`_def`, `then`, symbols) | `undefined` | so the proxy is never mistaken for a promise or a real tRPC procedure |

**`data: undefined` is the whole safety argument.** A fallback that returned `[]`, `{}` or a fixture would let an unlisted proc satisfy an assertion about rendered content. `undefined` renders and asserts nothing, so a proc a test depends on still has to be modelled explicitly — the Proxy stops the crash, it does not stand in for a fixture.

`useUtils` (and its deprecated alias `useContext`) gets the same split, because it is the identical hazard one surface over: the form invalidates by path after a save, so a newly-added `utils.<router>.<proc>.invalidate()` would throw exactly the way a new query did. Its fallback is bounded to a **closed verb list** (`invalidate`, `refetch`, `cancel`, `reset`, `setData`, `getData`, `setInfiniteData`, `getInfiniteData`, `prefetch`, `fetch`, `ensureData`) rather than "anything is callable" — an unknown member of a utils proc is still `undefined`.

## Verification

All runs: `vitest run --project component`, warm (every run below had **zero** `new dependencies optimized … reloading` lines; runs that had one are excluded as void).

### 1. Red at base, converged twice

Base = `fe67de4633` (`origin/main` at branch time), spec unmodified:

```
Test Files  1 failed (1)
     Tests  31 failed | 5 passed (36)
  Duration  468.11s          # run 3
  Duration  467.14s          # run 4
```

The two runs' failing-test sets are **byte-identical** (31 names), and each carries **30** occurrences of `PricingSlotHistory src/components/Buzz/PricingSlotHistory.tsx:48` in the rejection traces. Every failure is a ~15 s locator timeout against a form that never rendered — which is where the 468 s wall time comes from, and is itself the discriminator against a load flake (the green runs below take ~6 s).

### 2. Green at HEAD, converged twice

```
Test Files  1 passed (1)
     Tests  36 passed (36)
  Duration  6.72s / 5.96s
```

Whole `component` tier over `src/components/Resource` (3 spec files, `--maxWorkers=1`):

```
Test Files  3 passed (3)
     Tests  42 passed (42)
  Duration  ~11s
```

**Honest caveat:** 1 of 6 directory runs died with the known host-local `[vitest] There was an error when mocking a module` unhandled rejection and printed no summary. The other 5 were 42/42. I did not root-cause that one; it is the documented flake for the `component` project on this box, and it is not specific to this change (the same run configuration passed immediately before and four times after, unmodified).

### 3. The Proxy did not swallow the explicit entries

Mutation: `getLicensingRoots.useQuery` returns data **unconditionally** — the narrowest possible edit, only the ternary:

```diff
-          data: opts?.enabled === false ? undefined : licensingRoots.respond(input),
+          data: licensingRoots.respond(input),
```

Result — exactly one test dies, and for its own assertion, not a neighbour's:

```
× stamps nothing while the model type is still unknown 162ms
AssertionError: expected 2945208 to be null

Test Files  1 failed (1)
     Tests  1 failed | 35 passed (36)
```

That is the test whose comment says it pins `enabled: !!baseModel && !!model?.type`. Reverted after the run; the spec is byte-identical to the committed version.

### 4. The class is closed — with a positive control

Temporarily added to `ModelVersionUpsertForm.tsx`, on every render, four router entries **no test models** — one per hook kind plus an invalidate path:

```tsx
const probeQuery    = trpc.someRouterNobodyMocked.aProcNobodyMocked.useQuery({ x: 1 });
const probeInfinite = trpc.modelVersion.anInfiniteProcNobodyMocked.useInfiniteQuery({});
const probeMutation = trpc.model.aMutationNobodyMocked.useMutation();
const probeUtils    = trpc.useUtils().modelVersion.aProcNobodyMocked;
```

| mock | result |
|---|---|
| **this PR's Proxy** | `Tests 36 passed (36)` — 6.46 s |
| **the old hand-list** (spec reverted, same probe) | `Tests 36 failed (36)` — 540.96 s, `Uncaught TypeError: Cannot read properties of undefined (reading 'aProcNobodyMocked')` |

The control matters: without it, "the probe passed" would be a claim about the probe, not about the fix. It kills the whole file under the old mock and passes under the new one. Probe reverted; `git status` shows only the spec changed.

### 5. Matrix

| | base `fe67de4633` | HEAD `2dff61777b` |
|---|---|---|
| `ModelVersionUpsertForm.browser.test.tsx` | **31 failed / 5 passed (36)** ×2 | **36 passed (36)** ×2 |
| `component` over `src/components/Resource` | not run green-able (the file above is in it) | **42 passed (42)**, 5 of 6 runs |

### Static checks

- `eslint` on the changed file: **clean**. Instrument validated in both directions — a planted `const x: any` produced `@typescript-eslint/no-explicit-any`, and deleting the `...(await importOriginal())` spread produced `local-rules/no-wholesale-module-mock`, so that rule genuinely runs on this file and the new factory satisfies it.
- `prettier --check`: `All matched files use Prettier code style!`
- `scripts/typecheck.mjs`: **763 errors at base and 763 at HEAD, byte-identical error sets** — the change adds none. I could not get a clean typecheck: in my worktree `form-graph` and several `@civitai/buzz` exports do not resolve, which cascades into all 763. That is an artifact of my local checkout, not something I fixed or verified away, so treat the typecheck signal here as *"no delta"*, not *"green"*.

### What I could not verify

- The `preview / component-tests` job itself. I reproduced and fixed the failure locally against a host Chromium build (the repo pins revision 1200; this box only has 1228), so CI is the first place the fix runs on the pinned browser.
- Whether the 1-in-6 `error when mocking a module` flake can also hit CI. It produced no summary and rc=1, so if it fires there it will read as a red build with nothing to look at.

## Related, reported not fixed

`vi.mock('~/utils/trpc', …)` appears in **158** files under `src/` + `test/`; **149** of them contain a hand-listed `trpc: { … }` router literal, i.e. the same shape that broke here. Five already use a Proxy, and three of those (`AnnouncementsPanel`, `CreatorAnnouncement`, `announcement-tracking`) take the **opposite** design — a Proxy that *throws* `Unmocked tRPC router in a component test: trpc.<x>` on any unlisted entry, deliberately failing loud rather than inert.

So there is a real fork here and I have not tried to settle it repo-wide: fail-loud is the right default for a spec that wants to know its mock has drifted; inert-fallback is right for this one, where the drift is caused by *an unrelated component* and the cost is 36 tests and a red CI leg for everyone. Converting the other 149 is a separate decision, not one to take in a regression fix.

Worth noting alongside it: the existing `local-rules/no-wholesale-module-mock` rule (the #3579 lineage — its own message cites "this disabled ~36 tests via `trpcVanilla`") already guards the *module export shape* of exactly these mocks, and it passed here throughout. It cannot see this defect, because the breakage is one level in: inside the `trpc` object the factory hands back, which no rule inspects. If anyone wants a deterministic gate for this class, that rule is where it would live.

**Do not merge on my say-so** — CI has not run at the time of writing.
