### PR TITLE
fix(dev): repair createbuckets — mc config/policy commands were removed upstream

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -92,7 +92,7 @@ services:
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c "/usr/bin/mc config host add minio http://minio:9000 minioadmin minioadmin && /usr/bin/mc mb minio/modelshare && /usr/bin/mc policy set public minio/modelshare && /usr/bin/mc mb minio/images && /usr/bin/mc policy set public minio/images && exit 0"
+      /bin/sh -c "/usr/bin/mc alias set minio http://minio:9000 minioadmin minioadmin && /usr/bin/mc mb --ignore-existing minio/modelshare && /usr/bin/mc anonymous set public minio/modelshare && /usr/bin/mc mb --ignore-existing minio/images && /usr/bin/mc anonymous set public minio/images && exit 0"
 
   maildev:
     image: maildev/maildev


### PR DESCRIPTION
## The problem

`createbuckets` in `docker-compose.base.yml` fails on every local `docker compose up`, so the `modelshare` and `images` buckets are never created. It calls two `mc` subcommands that have since been removed upstream:

| in the compose file | current `mc` |
|---|---|
| `mc config host add` | `mc alias set` |
| `mc policy set public` | `mc anonymous set public` |

The image is unpinned (`minio/mc`), so this broke silently whenever upstream dropped them. On `mc RELEASE.2025-08-13T08-35-41Z`:

```
mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.
```

The entrypoint is one `&&` chain, so the first failure aborts everything after it and **neither bucket is created**. Nothing else in the stack complains, so it stays invisible until something reaches for object storage.

## Why `--ignore-existing` is also needed

Fixing only the two command names would work exactly once. `mc mb` against an existing bucket exits **1**:

```
$ mc mb m/modelshare
mc: <ERROR> Unable to make bucket `m/modelshare`. Your previous request to create
the named bucket succeeded and you already own it.
rc=1

$ mc mb --ignore-existing m/modelshare
rc=0
```

That non-zero aborts the same `&&` chain, so the service would go straight back to failing on the second and every later `docker compose up`. The flag is what makes it idempotent, not cosmetic.

## Verification

Run against a live local MinIO from this branch's compose file:

- **before** — container exits `1`, `mc ls` shows no buckets
- **after** — exits `0`; both buckets created and set public
- **re-run** — exits `0` again (idempotent)
- **control** — `mc mb` on an existing bucket: `rc=1` without the flag, `rc=0` with it

```
createbuckets-1  | Added `minio` successfully.
createbuckets-1  | Bucket created successfully `minio/modelshare`.
createbuckets-1  | Access permission for `minio/modelshare` is set to `public`
createbuckets-1  | Bucket created successfully `minio/images`.
createbuckets-1  | Access permission for `minio/images` is set to `public`
createbuckets-1 exited with code 0
```

Buckets confirmed present afterwards via `mc ls`.

## Scope

One line in `docker-compose.base.yml`. Local dev only — nothing in the application or in any deployed path is touched.

## Note

`minio/mc` is unpinned, which is what let this rot silently. Pinning it would prevent a repeat, but that is a separate judgement call about update cadence and is deliberately not part of this change.
