### PR TITLE
fix(apps): /apps/mine painted the Updated date under the Status badges

### DIFF
--- a/src/components/Apps/AppsWideLayout.geometry.test.tsx
+++ b/src/components/Apps/AppsWideLayout.geometry.test.tsx
@@ -574,6 +574,235 @@ describe('/apps/mine — the author table spends the width on its App column', (
   });
 });
 
+// ── /apps/mine, the REGRESSION this ledger shipped ───────────────────────────
+
+/**
+ * 🔴 THE LEDGER ABOVE PAINTED THE `Updated` DATE ON TOP OF THE `Status` BADGES.
+ *
+ * Both `APPS_MINE_COLUMNS` and `MyAppsBody`'s `<AppsTableColgroup>` were introduced by
+ * `2f3c556c7b` (#4619); `git show 2f3c556c7b^:src/components/Apps/MyAppsBody.tsx` has
+ * neither, i.e. before that commit the browser auto-sized these columns to their content
+ * and an overlap was not expressible. Measured against `origin/main` on the real page,
+ * last status badge's right edge minus the date's left edge:
+ *
+ *      vw      1280   1366   1440   1600   1920   2560
+ *      overlap  +22    +13     +6    −10    −43   −107
+ *      date     2 lines everywhere except 2560
+ *
+ * (Positive = the badge is painted over the date. Read against the ADVISORY GLYPH — the
+ * right-most thing in the cell — rather than the last badge, the overlap runs to +55 at
+ * 1280 and is still +23 at 1600.)
+ *
+ * 🔴 WHY AUTOMATIC TABLE LAYOUT DID NOT SAVE IT, because that is the part a reader will
+ * not guess. A column with a specified width is still floored at its cell's MIN-CONTENT
+ * width — normally the thing that expands a column whose content does not fit. Here the
+ * floor was a lie: Mantine's `Badge` sets `overflow: hidden`, so as a flex item its
+ * automatic minimum size collapses, and the cell reported a min-content of 78px while a
+ * `wrap="nowrap"` row of `flex-shrink: 0` badges actually painted 185.17px. 10% of the
+ * 1406px table is 140.59px, the floor was "satisfied", and `<td>`'s `overflow: visible`
+ * meant the 60px that did not fit was drawn over the next cell rather than clipped.
+ *
+ * 🔴 WHAT THIS GUARD ASSERTS, AND WHY IT IS NOT A CONSTANT PIN. A test reading
+ * `expect(APPS_MINE_COLUMNS[2]).toBe(18)` is walkable by editing the constant, and says
+ * nothing about the two mechanisms that have to agree (the share AND the row being
+ * allowed to wrap). So the assertions are RELATIONSHIPS between painted boxes:
+ * everything in the Status cell ends to the LEFT of where the date begins, the cell does
+ * not overflow itself, and the date occupies one line.
+ *
+ * 🔴 THE WIDTHS ARE THE ONES THAT FAILED, AND BOTH ARE MEASURED. 1366 and 1440 are the
+ * two most common laptop widths and were +13 and +6 at `origin/main`. Neither is the
+ * file's `NARROW`/`WIDE` pair, because those two are about the SURPLUS and this defect
+ * lives at the squeezed end.
+ *
+ * ⚠️ RED→GREEN MATRIX, MEASURED ONE HALF AT A TIME RATHER THAN ASSERTED. This block is
+ * nine tests over the whole `geometry` project's 64; the counts are that project's:
+ *
+ *   both halves reverted (= `origin/main`)      6 failed | 58 passed
+ *   ledger only, `wrap="nowrap"` restored       1 failed | 63 passed  ← the 768 arm
+ *   wrap only, ledger back to [null, 5, 10, 5]  2 failed | 62 passed  ← the ONE-line arms
+ *   both halves in place                        0 failed | 64 passed
+ *
+ * 🔴 READ THE MIDDLE TWO ROWS BEFORE ADDING TO THIS BLOCK. They say that the 1366/1440
+ * overlap arms are satisfied by the SHARE alone — 18% of those tables is wider than the
+ * two-badge row needs, so they cannot see the wrap being taken away. What pins the wrap
+ * is the 768 arm, and what pins the share is the ONE-line pair. Each half has exactly one
+ * arm that fails for its own reason; neither is redundant and neither covers the other.
+ */
+describe('🔴 /apps/mine — the Status badges never paint over the Updated date', () => {
+  /**
+   * 🔴 THE ADVISORY GLYPH IS PART OF THE FIXTURE, and leaving it out would have measured a
+   * narrower cell than production ever renders. `StatusBadges` always renders
+   * `ListingProblemsIndicator`, which returns `null` for an empty `problems` array — and
+   * `MINE_ROW` above omits the field. Every row on the live page carries at least one
+   * advisory, and the glyph is the RIGHT-MOST thing in the cell, i.e. exactly the box this
+   * block is about.
+   */
+  const OVERLAP_ROW: MyAppRow = {
+    ...MINE_ROW,
+    problems: [
+      { code: 'no-screenshots', label: 'Add at least one screenshot', severity: 'advisory' },
+    ],
+  } as MyAppRow;
+
+  const body = () => <MyAppsBodyView rows={[OVERLAP_ROW]} />;
+
+  /** The two laptop widths the defect was measured at. */
+  const OVERLAP_WIDTHS = [
+    { width: 1366, height: 900 },
+    { width: 1440, height: 900 },
+  ] as const;
+
+  /** The Status `<td>` and the Updated `<td>` of the first body row. */
+  function statusAndDateCells(): { status: HTMLTableCellElement; date: HTMLTableCellElement } {
+    const row = document.querySelector('table tbody tr');
+    if (!row) throw new Error('the author table rendered no body row');
+    const cells = Array.from(row.querySelectorAll('td'));
+    if (cells.length !== 4) {
+      throw new Error(`expected the four-column author row, got ${cells.length} cells`);
+    }
+    return {
+      status: cells[2] as HTMLTableCellElement,
+      date: cells[3] as HTMLTableCellElement,
+    };
+  }
+
+  /** Every painted leaf inside an element — the boxes a reader actually sees. */
+  function paintedLeaves(root: Element): Element[] {
+    return Array.from(root.querySelectorAll('*')).filter(
+      (el) => el.children.length === 0 && (el.textContent ?? '').trim().length + el.clientWidth > 0
+    );
+  }
+
+  test('the fixture really renders the two badges AND the advisory (guards a vacuous pass)', async () => {
+    // POSITIVE CONTROL, and the one that matters most here: an empty Status cell trivially
+    // satisfies "nothing in it overlaps the date". Both badges carry a testid, and the
+    // advisory glyph is the third box — if any of them stops rendering, this fails BEFORE
+    // the geometry assertions get a chance to pass for the wrong reason.
+    await renderRoute(body(), OVERLAP_WIDTHS[1]);
+    const { status } = statusAndDateCells();
+    expect(
+      status.querySelector(`[data-testid="apps-mine-role-${OVERLAP_ROW.appListingId}"]`)
+    ).not.toBeNull();
+    expect(
+      status.querySelector(`[data-testid="apps-mine-status-${OVERLAP_ROW.appListingId}"]`)
+    ).not.toBeNull();
+    expect(
+      status.querySelector('[data-testid="apps-submission-problems"]'),
+      'the completeness advisory is the right-most box in the cell; without it this block ' +
+        'measures a narrower cell than the page ever renders'
+    ).not.toBeNull();
+    await cleanup();
+  });
+
+  test.each(OVERLAP_WIDTHS)(
+    'at $width the Status cell ends before the Updated date begins',
+    async (viewport) => {
+      const observed = await renderRoute(body(), viewport);
+      expect(observed).toEqual({ width: viewport.width, height: viewport.height });
+
+      const { status, date } = statusAndDateCells();
+      const leaves = paintedLeaves(status);
+      expect(leaves.length, 'the Status cell painted nothing to measure').toBeGreaterThan(0);
+
+      const rightmost = Math.max(...leaves.map((el) => el.getBoundingClientRect().right));
+      const dateText = paintedLeaves(date)[0];
+      expect(dateText, 'the Updated cell painted no date').toBeTruthy();
+      const dateLeft = dateText.getBoundingClientRect().left;
+
+      expect(
+        px(rightmost - dateLeft),
+        `the right-most box in the Status cell reaches ${px(rightmost)} while the date ` +
+          `starts at ${px(dateLeft)} — a positive number here is the badge painted ON TOP ` +
+          `of the date (measured +55 at 1280 and +23 at 1600 on origin/main)`
+      ).toBeLessThan(0);
+
+      await cleanup();
+    }
+  );
+
+  test.each(OVERLAP_WIDTHS)(
+    'at $width the Status cell does not overflow ITSELF',
+    async (viewport) => {
+      // The same defect stated without reference to the neighbour, so a future layout that
+      // moves the date somewhere else cannot make the overlap check vacuous while the cell
+      // is still painting outside its own box.
+      await renderRoute(body(), viewport);
+      const { status } = statusAndDateCells();
+      expect(
+        status.scrollWidth,
+        `the Status cell paints ${status.scrollWidth}px of content into ` +
+          `${status.clientWidth}px of cell; \`<td>\` is \`overflow: visible\`, so the ` +
+          'difference is drawn over whatever sits to its right'
+      ).toBeLessThanOrEqual(status.clientWidth);
+      await cleanup();
+    }
+  );
+
+  test('🔴 …and at 768, where NO share can hold the row, it still does not overflow', async () => {
+    // 🔴 THIS IS THE ARM THAT PINS THE *WRAP*, AND THE TWO ABOVE DO NOT. Measured by
+    // reverting one half at a time: with the ledger alone (Status back to `wrap="nowrap"`,
+    // share 18%) every assertion at 1366/1440 stays GREEN, because 18% of those tables is
+    // wider than the two-badge row needs. The share cannot be the answer at every width —
+    // 18% of the 736px container here is 132px against the 217px this row paints, and the
+    // widest real row ("Collaborator" + "removed by a moderator" + the advisory) is ~307px
+    // and fits under no percentage that is also sane at 2560.
+    //
+    // What makes the cell safe at ANY width is that the row may wrap: its min-content then
+    // becomes its widest single badge instead of a number no layout can produce, so the
+    // content reflows onto a second line rather than being painted over the neighbour. The
+    // date legitimately wraps at this width too, which is why only the two overflow
+    // relationships are read here — a squeezed column is allowed to get taller, it is not
+    // allowed to paint outside itself.
+    const viewport = { width: TABLET.width, height: TABLET.height };
+    await renderRoute(body(), viewport);
+    const { status, date } = statusAndDateCells();
+    expect(
+      status.scrollWidth,
+      `at 768 the Status cell paints ${status.scrollWidth}px into ${status.clientWidth}px`
+    ).toBeLessThanOrEqual(status.clientWidth);
+    const rightmost = Math.max(
+      ...paintedLeaves(status).map((el) => el.getBoundingClientRect().right)
+    );
+    expect(px(rightmost - date.getBoundingClientRect().left)).toBeLessThanOrEqual(0);
+    await cleanup();
+  });
+
+  test.each(OVERLAP_WIDTHS)('at $width the Updated date stays on ONE line', async (viewport) => {
+    // The second half of the same squeeze: 5% resolved to 88px at 1440 against the 96.73px
+    // ("Sep 4, 2026" max-content 64.73 + 32px cell padding) one line needs, so the date
+    // wrapped at every width below 2560.
+    await renderRoute(body(), viewport);
+    const { date } = statusAndDateCells();
+    const text = paintedLeaves(date)[0];
+    expect(lineCount(text), `the date "${text.textContent}" wrapped`).toBe(1);
+    await cleanup();
+  });
+
+  test('…and the App column still takes MOST of the surplus (the #4619 behaviour is intact)', async () => {
+    // 🔴 THE FIX MUST NOT BE A REVERT. Widening two fixed columns takes the surplus from
+    // the primary one, and past some share the table stops "spending the width" and goes
+    // back to padding it — which is the defect #4619 exists to remove. Same shape as that
+    // PR's own assertion, re-read here so this block owns the trade it made.
+    const { narrow, wide } = await atBothWidths(body, headerWidths);
+    const appDelta = wide[0] - narrow[0];
+    const otherDelta = wide.reduce((s, w, i) => (i === 0 ? s : s + (w - narrow[i])), 0);
+    expect(
+      appDelta,
+      `the App column took ${px(appDelta)} of the container's ${CONTAINER_DELTA}px and the ` +
+        `other three took ${px(otherDelta)}`
+    ).toBeGreaterThan(otherDelta);
+    // …and the table still SPANS the container at both widths rather than capping itself.
+    for (const vp of [NARROW, WIDE]) {
+      await renderRoute(body(), vp);
+      const table = document.querySelector('table')!.getBoundingClientRect().width;
+      expect(px(table), `the table did not span the ${vp.width} container`).toBeGreaterThan(
+        vp.content - 4
+      );
+      await cleanup();
+    }
+  });
+});
+
 // ── table route 3: /apps/review's ACTIVE PREVIEWS — the payload of round 1 ───
 
 describe('/apps/review — the active-previews panel keeps its buttons near its rows', () => {

--- a/src/components/Apps/MyAppsBody.tsx
+++ b/src/components/Apps/MyAppsBody.tsx
@@ -317,7 +317,31 @@ function ListingName({ row }: { row: MyAppRow }) {
  */
 function StatusBadges({ row }: { row: MyAppRow }) {
   return (
-    <Group gap={6} wrap="nowrap">
+    /*
+     * 🔴 THIS ROW MAY WRAP, AND THAT IS THE STRUCTURAL HALF OF A LAYOUT FIX — NOT A
+     * COSMETIC PREFERENCE. It was `wrap="nowrap"`, and in the table layout that made the
+     * badges paint ON TOP of the Updated column at every viewport ≤ 1440 (measured, last
+     * badge's right minus the date's left: +22px at 1280, +13 at 1366, +6 at 1440).
+     *
+     * The mechanism, because "make it wrap" is not self-evidently the cure. Under
+     * automatic table layout a column with a specified width is still floored at its
+     * cell's MIN-CONTENT width, which is what normally expands a column whose content
+     * does not fit. Here that floor lied: Mantine's `Badge` sets `overflow: hidden`, so
+     * as a flex item its automatic minimum size collapses, and this cell reported a
+     * min-content of 78px while a `flex-shrink: 0` badge row actually painted 185.17px.
+     * `<td>` is `overflow: visible`, so the 60px that did not fit was not clipped — it was
+     * drawn over the next cell.
+     *
+     * Allowing the row to wrap makes the min-content honest (the widest single badge
+     * rather than a number no layout can produce), so the cell can never paint outside
+     * itself again REGARDLESS of the ledger. The ledger's Status share (18%, see
+     * `APPS_MINE_COLUMNS`) is the other half and does a different job: it keeps the
+     * ordinary two-badge row on ONE line from 1280 up. The long case — "Collaborator" plus
+     * "removed by a moderator" plus the advisory — is ~307px and no percentage that is
+     * also sane at 2560 can hold it on one line; with wrapping it reflows instead of
+     * overlapping, which is the point of keeping both halves.
+     */
+    <Group gap={6}>
       {/* 🔴 The role badge is not decoration: an editor cannot invite, remove or transfer,
           so saying which one they are is what makes the missing controls legible rather
           than looking broken. */}

--- a/src/components/Apps/appsWideLayout.tsx
+++ b/src/components/Apps/appsWideLayout.tsx
@@ -166,11 +166,47 @@ export const APPS_REVIEW_QUEUE_COLUMNS = {
  * The `/apps/mine` table (`MyAppsBody`) — **App** · Cover · Status · Updated.
  *
  * App is primary for the same reason as above, and here it also carries the icon and
- * the slug, so it is the cell that most wants the room. Cover is a fixed 96px image, so
- * its 12% is a floor rather than an aspiration; Status holds up to three badges plus
- * the completeness advisory, which is why it is the widest fixed share.
+ * the slug, so it is the cell that most wants the room.
+ *
+ * 🔴 THE COMMENT THAT USED TO SIT HERE WAS WRONG IN BOTH HALVES, AND THE SECOND HALF
+ * DESCRIBED THE DEFECT AS THOUGH IT WERE THE DESIGN. It read: "Cover is a fixed 96px
+ * image, so its 12% is a floor rather than an aspiration; Status holds up to three
+ * badges plus the completeness advisory, which is why it is the widest fixed share."
+ *
+ *   · COVER. The declared value was never 12 — it is 5, and it has never had any effect
+ *     at any width this container reaches. Measured at 1440 (table 1406): the Cover
+ *     column resolves to 128px while 5% is 70.3px, because the cell's min-content is the
+ *     96px image plus the table's 2×16px horizontal padding = 128. At the container's
+ *     2560 cap (table 2526) 5% is 126.3px — still under 128. So the share is INERT over
+ *     the whole supported range and the column is sized by its own min-content floor.
+ *     5 is kept rather than raised to 12 precisely because it is inert: 12% of 1406 is
+ *     168.7px, i.e. raising it to match the sentence would take 40px off the primary
+ *     column to pad a fixed-size image. The number is right; the sentence was not.
+ *
+ *   · STATUS. It does not hold "up to three badges" — `StatusBadges` renders exactly two
+ *     (role, then status-or-owner-chip) plus the completeness advisory glyph. And 10 was
+ *     not "the widest fixed share" in any useful sense: measured at 1440, that row's
+ *     max-content is 185.17px + 32px padding = 217.17px against the 140.59px the 10%
+ *     share resolved to, so the badges painted 60px OUTSIDE their own cell and on top of
+ *     the Updated column at every width ≤ 1440 (+22px of overlap at 1280, +13 at 1366,
+ *     +6 at 1440). Auto table layout could not defend the column because a `nowrap`
+ *     `Group` of `flex-shrink: 0` badges reports a min-content of 78px — far below the
+ *     185.17px it actually paints — so the min-content floor that normally expands a
+ *     squeezed column was satisfied by a number the row never honours. The structural
+ *     half of that fix is in `MyAppsBody`'s `StatusBadges` (the row may now wrap, which
+ *     makes its min-content honest and overflow impossible); the share here is what
+ *     keeps the ordinary row on ONE line: 18% of the 1246px table at 1280 is 224px,
+ *     above the 217.17px the two badges plus the advisory need.
+ *
+ *   · UPDATED. 5% resolved to 88px at 1440 — under the 96.73px ("Sep 4, 2026" max-content
+ *     64.73 + 32 padding) a single line needs — so the date wrapped to two lines at every
+ *     width below 2560. 9% is 112px at 1280, which also covers the widest formatted date.
+ *
+ * The primary column still takes the surplus and still takes most of it: 100 − 32 = 68%
+ * against a widest fixed share of 18%, which is what `appsTableColumnProblems` and the
+ * geometry tier check.
  */
-export const APPS_MINE_COLUMNS: AppsTableColumns = [null, 5, 10, 5];
+export const APPS_MINE_COLUMNS: AppsTableColumns = [null, 5, 18, 9];
 
 /**
  * The `/apps/review` MANAGE-LISTINGS table (`AppListingsModerationTable`) —


### PR DESCRIPTION
On `/apps/mine`, the **Updated** date is painted underneath the **Status** badges at every viewport ≤ 1440 — including 1366 and 1440, the two most common laptop widths — and the date wraps to two lines at every width below 2560.

## Attribution — a regression, not pre-existing

`git log -S 'APPS_MINE_COLUMNS'` and `git log -S 'AppsTableColgroup'` both put the constant **and** `MyAppsBody`'s `<AppsTableColgroup>` in **`2f3c556c7b` (#4619)**. `git show 2f3c556c7b^:src/components/Apps/MyAppsBody.tsx` has no `<colgroup>` and no column widths at all — before that commit the browser auto-sized these columns to their content, so an overlap was not expressible. #4619 introduced it.

## Mechanism

Under CSS **automatic** table layout a column with a specified width is still floored at its cell's **min-content** width — that floor is what normally expands a column whose content does not fit, and it is why a percentage ledger is safe on the other five `/apps/*` tables.

Here the floor was a lie. Measured at 1440 (table 1406px):

| what | px |
|---|---|
| `Status` column at `width: 10%` | 140.59 |
| what the badge row actually paints | 185.17 (+ 32 cell padding = **217.17**) |
| what the cell reports as its **min-content** | **78** |
| `<td>` `scrollWidth` / `clientWidth` | 201 / 141 |

Mantine's `Badge` sets `overflow: hidden`, so as a flex item its automatic minimum size collapses and the `wrap="nowrap"` `Group` reports a min-content far below anything it can actually render; the badges themselves are `flex-shrink: 0`, so they never compress into it. The 10% share therefore "satisfied" the floor, and `<td>` is `overflow: visible` — so the 60px that did not fit was **drawn over the next cell** rather than clipped.

The `Updated` column had the milder half of the same squeeze: 5% resolved to 88px against the 96.73px a single line needs (`"Sep 4, 2026"` max-content 64.73 + 32 padding), so the date wrapped.

## The fix — two halves, doing different jobs

* **`StatusBadges`' `Group` may now wrap** (`src/components/Apps/MyAppsBody.tsx`). This makes the cell's min-content honest — its widest single badge — so the cell can never paint outside itself *at any width*. It has to be structural rather than a bigger share: the worst real row is `Collaborator` + `removed by a moderator` + the advisory glyph at ~307px, which fits under no percentage that is also sane at 2560.
* **`APPS_MINE_COLUMNS: [null, 5, 10, 5]` → `[null, 5, 18, 9]`** (`src/components/Apps/appsWideLayout.tsx`). 18% of the 1246px table at 1280 is 224px against the 217.17px the ordinary two-badge row needs, so it stays on **one** line; 9% is 112px against the 96.73px a single-line date needs, which is what stops the date wrapping. The primary column keeps 68% against a widest fixed share of 18%.

## Before / after — measured in Chromium against a seeded local stack

Last status badge's right edge minus the date's left edge. **Positive = the badge is painted on top of the date.**

| vw | 1280 | 1366 | 1440 | 1600 | 1920 | 2560 |
|---|---|---|---|---|---|---|
| **before** | **+22** | **+13** | **+6** | −10 | −43 | −107 |
| **after** | −78 | −93 | −106 | −136 | −193 | −309 |
| before, date lines | 2 | 2 | 2 | 2 | 2 | 1 |
| after, date lines | **1** | **1** | **1** | **1** | **1** | **1** |

Read against the **completeness-advisory glyph** — the right-most box in the cell, which the headline metric above misses — the defect is wider than it looks and reaches 1600:

| vw | 1280 | 1366 | 1440 | 1600 | 1920 | 2560 |
|---|---|---|---|---|---|---|
| **before** | **+55** | **+47** | **+39** | **+23** | −9 | −73 |
| **after** | −44 | −60 | −73 | −102 | −159 | −275 |

Status cell `scrollWidth` vs `clientWidth`, i.e. the cell overflowing itself: **before** 201/125, 201/133, 201/141, 201/157, 201/189, 253/253 — **after** they are equal at every width.

### The #4619 behaviour is intact — the table still SPENDS the width

Table width is byte-identical before and after at all six viewports: **1246 / 1332 / 1406 / 1566 / 1886 / 2526**. It still spans ~1406 at 1440 and ~2526 at 2560; it has not reverted to padding, and the geometry tier's existing "the App column takes MOST of the surplus" assertions still pass (a new arm in this PR re-reads that claim against the new ledger).

## Doc/reality mismatch, fixed here

The comment above `APPS_MINE_COLUMNS` read *"Cover is a fixed 96px image, so its **12%** is a floor rather than an aspiration; Status holds up to **three badges** plus the completeness advisory, which is why it is the widest fixed share."* Both halves were wrong:

* **Cover.** The declared value is **5**, not 12 — and it is **inert at every width up to the 2560 container cap**. Measured: the column resolves to **128px** (the 96px image plus 2×16px cell padding = its own min-content floor) while 5% is 70.3px at 1440 and 126.3px at 2526. **The code is right and the comment was wrong**, so the value stays at 5: raising it to 12 would make 168.7px at 1440, i.e. take ~40px off the primary column to pad a fixed-size image — the exact "surplus becomes padding" failure this module exists to remove.
* **Status.** `StatusBadges` renders exactly **two** badges (role, then status-or-owner-chip) plus the advisory glyph, never three. And 10 was not "the widest fixed share" in any useful sense — it was the number that produced the overlap.

The comment is now the measured description of both, with the numbers it is derived from.

## The guard, and its red→green evidence

Nine tests in `src/components/Apps/AppsWideLayout.geometry.test.tsx`, in the **`geometry`** project — the tier that loads the real cascade (`cascade-layer-order.css`, `globals.css` through PostCSS, the six `@mantine/*/styles.layer.css`). The `component` tier injects only 24 `:root` custom-property rules, so Tailwind utilities and Mantine rules are inert there and a layout assertion written in it reports meaningless numbers on correct code.

They assert **relationships between painted boxes**, not constants — a test reading `expect(APPS_MINE_COLUMNS[2]).toBe(18)` is walkable by editing the constant and says nothing about the two mechanisms having to agree:

* at 1366 and 1440 (the widths that failed), the right-most painted box in the Status cell ends **left of** where the date begins;
* at 1366 and 1440 the Status cell's `scrollWidth ≤ clientWidth` — the same defect stated without reference to its neighbour;
* at 1366 and 1440 the date occupies **one** line;
* at **768**, where no share can hold the row, both overflow relationships still hold — this is the arm that pins the *wrap*;
* the App column still takes most of the surplus and the table still spans the container at 1440 and 2560;
* a positive control asserting the fixture really renders both badges **and** the advisory glyph, because an empty Status cell would satisfy "nothing in it overlaps the date" vacuously.

**Red → green, measured one half at a time.** Counts are the whole `geometry` project's:

| tree | result |
|---|---|
| both halves reverted (= `origin/main`) | **6 failed** \| 58 passed |
| ledger only, `wrap="nowrap"` restored | **1 failed** \| 63 passed ← the 768 arm |
| wrap only, ledger back to `[null, 5, 10, 5]` | **2 failed** \| 62 passed ← the one-line arms |
| both halves in place | **0 failed** \| 64 passed |

Each half has exactly one arm that fails for its own reason; neither is redundant and neither covers the other. The pre-fix failures reproduce the browser numbers independently — `+12.98` at 1366 and `+5.58` at 1440, against `+13` and `+6` measured on the page.

Every run's collected file/test count was read rather than the `Tests` summary line alone (the `geometry` project can silently collect a partial set on a cold `node_modules/.vite`; all runs quoted here collected **5 files / 64 tests**).

## Other checks

`pnpm typecheck` — 0 errors. `eslint` on the three changed files — clean. `prettier --check` — clean. `src/components/Apps/__tests__/appsWideLayout.test.ts` (the ledger's unit tier, incl. the `primary share > widest fixed share` invariant) — 33 passed. `src/components/Apps/MyAppsBody.browser.test.tsx` — 65 passed.

## Files changed

* `src/components/Apps/appsWideLayout.tsx` — the ledger + the corrected doc comment
* `src/components/Apps/MyAppsBody.tsx` — `StatusBadges` may wrap
* `src/components/Apps/AppsWideLayout.geometry.test.tsx` — the guard
