### PR TITLE
perf(redis): brotli-compress imageMetaCache values at rest (#4588)

### DIFF
--- a/packages/civitai-redis/src/__tests__/cached-array-compress.test.ts
+++ b/packages/civitai-redis/src/__tests__/cached-array-compress.test.ts
@@ -83,7 +83,7 @@ vi.mock('redis', () => {
 
 import { createCacheBuilders, type CachedLookupOptions } from '../cached-array';
 import { createCacheRedis } from '../client';
-import { PACKED_BROTLI_SENTINEL, compressPacked } from '../packed-compression';
+import { PACKED_BROTLI_SENTINEL, compressPacked, decompressPacked } from '../packed-compression';
 import type { RedisKeyTemplateCache } from '../client';
 
 const redis = createCacheRedis();
@@ -388,5 +388,78 @@ describe('the symmetry hazard this flag exists to prevent', () => {
     store.set(key, await compressPacked(Buffer.from(pack({ id: 99, blob: bigBlob }))));
     const [viaCompress] = await redis.packed.mGet<Row>([key], { compress: true });
     expect(viaCompress).toEqual({ id: 99, blob: bigBlob });
+  });
+});
+
+describe('packed.mGet index alignment — the OTHER half of the seam', () => {
+  /**
+   * `mGet`'s contract is POSITIONAL: result[i] belongs to keys[i], and a decode failure at i must
+   * evict keys[i] — nobody else. Both halves are unguarded by everything above, because
+   * `createCachedArray` re-keys the batch by `idKey` immediately after the read and so cannot
+   * observe either defect. The next caller would.
+   *
+   * The eviction half is not hypothetical for this PR: during a mixed-fleet rollout a pod WILL
+   * meet entries it cannot decode (see the compress-symmetry test above), so a mis-indexed
+   * `unlink` would repeatedly evict a healthy NEIGHBOUR while leaving the bad entry in place —
+   * a self-sustaining eviction of good data that looks like ordinary cache churn.
+   *
+   * Shape of the fixture, which is what makes both defects visible:
+   *  - THREE keys, failure in the MIDDLE, so an off-by-one and a first-element collapse land on
+   *    different keys and neither can be satisfied by luck;
+   *  - the two good values are PAIRWISE DISTINCT, so a reversed array is detectable (a reversal
+   *    keeps `null` in the middle — only distinct outer values expose it);
+   *  - eviction is asserted as an exact SET over the store, so it fails whether the wrong key is
+   *    evicted, an extra key is evicted, or nothing is evicted at all.
+   */
+  const K = (n: number) => `${KEY}:align-${n}` as RedisKeyTemplateCache;
+  const first = { id: 101, blob: 'first-value' };
+  const last = { id: 103, blob: 'last-value' };
+  // Sentinel-tagged but NOT a valid brotli stream: reaches the compress-aware decode and throws
+  // inside brotliDecompress, which is the realistic corruption on this path.
+  const CORRUPT_COMPRESSED = Buffer.from([PACKED_BROTLI_SENTINEL, 0xff, 0xff, 0xff, 0xff]);
+  // A truncated msgpack map16 header — no sentinel byte, so it is a corrupt LEGACY value and
+  // fails inside `unpack` on the general path.
+  const CORRUPT_PLAIN = Buffer.from([0xde, 0x00, 0x05]);
+
+  it('COMPRESS branch: positional order is preserved and ONLY the failing key is evicted', async () => {
+    store.set(K(1), await compressPacked(Buffer.from(pack(first))));
+    store.set(K(2), CORRUPT_COMPRESSED);
+    store.set(K(3), await compressPacked(Buffer.from(pack(last))));
+
+    const got = await redis.packed.mGet<Row>([K(1), K(2), K(3)], { compress: true });
+
+    // ORDER: index 0 is the FIRST key's value, index 2 is the LAST key's. Reversing the array
+    // keeps the null in the middle, so only these two distinct outer values can catch it.
+    expect(got).toEqual([first, null, last]);
+
+    // EVICTION: exactly the offending key, and nothing else. An exact set rather than three
+    // independent `has` calls, so a wrong/extra/absent eviction all fail the same assertion.
+    const survivors = [K(1), K(2), K(3)].filter((k) => store.has(k));
+    expect(survivors, 'only the undecodable key may be evicted').toEqual([K(1), K(3)]);
+  });
+
+  it('NON-COMPRESS branch: same contract, same fixture shape', async () => {
+    // The general path is PRE-EXISTING code this PR did not touch, but it carries the identical
+    // `keys[i]` shape one line below the branch that was added — so a future edit to one half is
+    // overwhelmingly likely to be made to both. Guarded here to close the class rather than the
+    // instance; this is test-only and expands no production diff.
+    store.set(K(4), Buffer.from(pack(first)));
+    store.set(K(5), CORRUPT_PLAIN);
+    store.set(K(6), Buffer.from(pack(last)));
+
+    const got = await redis.packed.mGet<Row>([K(4), K(5), K(6)]);
+
+    expect(got).toEqual([first, null, last]);
+    const survivors = [K(4), K(5), K(6)].filter((k) => store.has(k));
+    expect(survivors, 'only the undecodable key may be evicted').toEqual([K(4), K(6)]);
+  });
+
+  it('POSITIVE CONTROL: the corrupt fixtures really are undecodable on their own path', () => {
+    // Without this, a fixture that silently DECODED would make both tests above pass while
+    // proving nothing — the null would never be produced and no eviction would ever be attempted.
+    expect(CORRUPT_COMPRESSED[0]).toBe(PACKED_BROTLI_SENTINEL);
+    expect(CORRUPT_PLAIN[0]).not.toBe(PACKED_BROTLI_SENTINEL);
+    expect(() => unpack(CORRUPT_PLAIN)).toThrow();
+    return expect(decompressPacked(CORRUPT_COMPRESSED)).rejects.toThrow();
   });
 });

--- a/packages/civitai-redis/src/__tests__/cached-array-compress.test.ts
+++ b/packages/civitai-redis/src/__tests__/cached-array-compress.test.ts
@@ -1,0 +1,392 @@
+import { readFileSync } from 'fs';
+import { pack, unpack } from 'msgpackr';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * End-to-end coverage for `compress` on createCachedArray / createCachedObject (issue #4588,
+ * shipped for `imageMetaCache`).
+ *
+ * WHY THIS FILE DRIVES THE REAL CLIENT: the hazard here is a SEAM, not a component. The flag has
+ * to be symmetric across TWO modules — `cached-array.ts` must pass `{ compress }` to every one of
+ * its nine `redis.packed` reads and writes, AND `client.ts`'s `packed.mGet` must actually honour
+ * it (before #4588 it could not — only `packed.get` took the option, and `createCachedArray` reads
+ * exclusively through `mGet`). A test that mocks `redis.packed` proves neither half: it would pass
+ * against a client whose mGet ignores the flag entirely, which is the exact production defect —
+ * a compressed value decoded on the general msgpack path throws, the entry is EVICTED, and the
+ * read reports a MISS. Permanent miss+evict loop, no error anywhere.
+ *
+ * So the only thing faked here is the TRANSPORT: `redis`'s client factory is replaced by an
+ * in-memory server holding raw Buffers. Everything above the socket — `createCacheRedis`,
+ * `client.packed.set/mGet/get`, the msgpack + brotli codec, `createCacheBuilders` — is the real
+ * module. That also lets these tests assert the ON-DISK BYTES (the 0x01 brotli sentinel), which is
+ * the only way to tell "compression is on" from "the round-trip happens to work anyway".
+ */
+
+// process.env must be populated BEFORE ../client is imported: loadRedisEnv() validates it.
+vi.hoisted(() => {
+  process.env.REDIS_URL ??= 'redis://localhost:6379';
+  process.env.REDIS_SYS_URL ??= 'redis://localhost:6379';
+  process.env.REDIS_CLUSTER = 'false';
+});
+
+/** The in-memory "server": key -> raw stored bytes, exactly as a real Redis would hold them. */
+const { store } = vi.hoisted(() => ({ store: new Map<string, Buffer>() }));
+
+vi.mock('redis', () => {
+  const toBuffer = (v: unknown): Buffer =>
+    Buffer.isBuffer(v) ? v : Buffer.from(v as string, 'binary');
+
+  // A single fake node client. `withTypeMapping` returns a Buffer-mode VIEW over the same store
+  // (mirroring node-redis: same connection, different reply decoding).
+  const makeClient = (bufferMode = false): Record<string, unknown> => {
+    const self: Record<string, any> = {
+      connect: () => Promise.resolve(self),
+      on: () => self,
+      withTypeMapping: () => makeClient(true),
+      get: async (key: string) => {
+        const v = store.get(key);
+        if (v === undefined) return null;
+        return bufferMode ? v : v.toString('binary');
+      },
+      set: async (key: string, value: unknown, options?: { NX?: boolean; XX?: boolean }) => {
+        const exists = store.has(key);
+        if (options?.NX && exists) return null;
+        if (options?.XX && !exists) return null;
+        store.set(key, toBuffer(value));
+        return 'OK';
+      },
+      del: async (key: string) => (store.delete(key) ? 1 : 0),
+      unlink: async (key: string) => (store.delete(key) ? 1 : 0),
+      // Backs client.setNxKeepTtlWithEx's EVAL (SET NX KEEPTTL + EXPIRE). TTLs are irrelevant to
+      // the codec contract under test, so the lock is modelled as plain set-if-absent.
+      eval: async (_script: string, opts: { keys: string[] }) => {
+        const key = opts.keys[0];
+        if (store.has(key)) return 0;
+        store.set(key, Buffer.from('1'));
+        return 1;
+      },
+      scanIterator: async function* () {
+        /* unused */
+      },
+    };
+    return self;
+  };
+
+  return {
+    createClient: () => makeClient(false),
+    createCluster: () => makeClient(false),
+    createSentinel: () => makeClient(false),
+    RESP_TYPES: { BLOB_STRING: 36 },
+  };
+});
+
+import { createCacheBuilders, type CachedLookupOptions } from '../cached-array';
+import { createCacheRedis } from '../client';
+import { PACKED_BROTLI_SENTINEL, compressPacked } from '../packed-compression';
+import type { RedisKeyTemplateCache } from '../client';
+
+const redis = createCacheRedis();
+
+type Row = { id: number; blob: string };
+
+// A value with real redundancy, so a compressed payload is unambiguously SMALLER than the packed
+// one. A short random string would compress LARGER than its input and make the size assertion
+// below a coin flip.
+const bigBlob = 'prompt, masterpiece, highly detailed, '.repeat(120);
+
+const KEY = 'packed:caches:test-compress' as RedisKeyTemplateCache;
+
+function buildCache(
+  overrides: Partial<CachedLookupOptions<Row>> = {},
+  lookupFn = vi.fn(
+    async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, blob: bigBlob }])) as Record<string, Row>
+  )
+) {
+  const noopMetrics = {
+    hit: () => undefined,
+    miss: () => undefined,
+    revalidate: () => undefined,
+    failOpenDegraded: () => undefined,
+    failOpenOriginFetch: () => undefined,
+  };
+  const { createCachedObject } = createCacheBuilders({
+    redis,
+    defaultTtl: 300,
+    metrics: noopMetrics,
+    logFailOpen: () => undefined,
+    logRefreshError: () => undefined,
+    log: () => undefined,
+    clearByPattern: async () => undefined,
+  });
+  const cache = createCachedObject<Row>({
+    key: KEY,
+    idKey: 'id',
+    lookupFn,
+    ttl: 3600,
+    ...overrides,
+  });
+  return { cache, lookupFn };
+}
+
+/** Raw bytes as they sit "in redis" for one cached id. */
+const stored = (id: number) => store.get(`${KEY}:${id}`);
+
+beforeEach(() => {
+  store.clear();
+});
+
+describe('createCachedObject { compress: true } — write path', () => {
+  // INVARIANT GUARD (green at origin/main too): with `compress` ignored, reads and writes are
+  // still symmetric — just uncompressed — so this cannot go red on the pre-change tree. It pins
+  // that enabling compression does not BREAK the basic read-through contract; the regression
+  // coverage for compression actually happening is the sentinel test below.
+  it('round-trips a value through a compressed cache (2nd fetch is served from redis)', async () => {
+    const { cache, lookupFn } = buildCache({ compress: true });
+
+    const first = await cache.fetch([1, 2]);
+    expect(first['1']).toEqual({ id: 1, blob: bigBlob });
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+
+    const second = await cache.fetch([1, 2]);
+    expect(second['1']).toEqual({ id: 1, blob: bigBlob });
+    expect(second['2']).toEqual({ id: 2, blob: bigBlob });
+    // Served from the compressed redis entry — the origin was NOT re-consulted. This is what
+    // fails when mGet ignores `compress`: the decode throws, the entry is evicted, and lookupFn
+    // is called a second time.
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('actually writes a SENTINEL-TAGGED, smaller payload (compression is not a silent no-op)', async () => {
+    const { cache } = buildCache({ compress: true });
+    await cache.fetch([1]);
+
+    const raw = stored(1)!;
+    expect(raw).toBeInstanceOf(Buffer);
+    expect(raw[0]).toBe(PACKED_BROTLI_SENTINEL);
+    // Positive control on the codec itself: the stored payload must be materially smaller than
+    // the uncompressed msgpack of the same record. A round-trip assertion alone passes even if
+    // `compress` never reached the write.
+    const uncompressedSize = pack({ id: 1, blob: bigBlob, cachedAt: new Date() }).length;
+    expect(raw.length).toBeLessThan(uncompressedSize / 2);
+  });
+
+  it('compresses the notFound sentinel write too, and does not re-consult the origin', async () => {
+    // lookupFn returns nothing for id 7 -> negative marker { id, notFound, cachedAt }.
+    const lookupFn = vi.fn(async () => ({} as Record<string, Row>));
+    const { cache } = buildCache({ compress: true }, lookupFn);
+
+    const first = await cache.fetch([7]);
+    expect(first['7']).toBeUndefined();
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+
+    const raw = stored(7)!;
+    expect(raw[0]).toBe(PACKED_BROTLI_SENTINEL);
+
+    // The negative cache must be READABLE through the compressed path, or every miss re-queries.
+    const second = await cache.fetch([7]);
+    expect(second['7']).toBeUndefined();
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createCachedObject { compress: true } — symmetry across bust / refresh / update', () => {
+  it('refresh() rewrites a sentinel-tagged entry that later reads decode', async () => {
+    const lookupFn = vi.fn(
+      async (ids: number[]) =>
+        Object.fromEntries(ids.map((id) => [id, { id, blob: bigBlob }])) as Record<string, Row>
+    );
+    // staleWhileRevalidate:false so `bust` is the debounce-marker variant and refresh's EX path
+    // is the plain one; the SWR variant is covered by the invalidate test below.
+    const { cache } = buildCache({ compress: true, staleWhileRevalidate: false }, lookupFn);
+
+    await cache.refresh([3]);
+    expect(stored(3)![0]).toBe(PACKED_BROTLI_SENTINEL);
+
+    lookupFn.mockClear();
+    const got = await cache.fetch([3]);
+    expect(got['3']).toEqual({ id: 3, blob: bigBlob });
+    expect(lookupFn).not.toHaveBeenCalled();
+  });
+
+  it('bust() writes a compressed debounce marker that the read path understands', async () => {
+    const { cache, lookupFn } = buildCache({ compress: true, staleWhileRevalidate: false });
+    await cache.fetch([4]);
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+
+    await cache.bust(4);
+    const raw = stored(4)!;
+    expect(raw[0]).toBe(PACKED_BROTLI_SENTINEL);
+    // The marker must DECODE, or the debounce is invisible and the entry reads as absent for a
+    // different reason. Decoding it proves the compressed bust write is symmetric with the read.
+    const marker = unpack(
+      await import('zlib').then(
+        (z) =>
+          new Promise<Buffer>((res, rej) =>
+            z.brotliDecompress(raw.subarray(1), (e, b) => (e ? rej(e) : res(b)))
+          )
+      )
+    ) as { id: number; debounce: boolean };
+    expect(marker).toMatchObject({ id: 4, debounce: true });
+
+    lookupFn.mockClear();
+    const after = await cache.fetch([4]);
+    expect(after['4']).toEqual({ id: 4, blob: bigBlob });
+    expect(lookupFn).toHaveBeenCalledTimes(1); // the bust forced a re-fetch
+  });
+
+  it('bust() on an SWR cache (invalidate) reads AND rewrites through the compressed path', async () => {
+    // invalidate() mGets the existing entry and rewrites it with a backdated cachedAt. Both halves
+    // must be compress-aware: an mGet that ignores the flag sees nothing to rewrite and the
+    // invalidate silently NO-OPS — the value keeps being served fresh.
+    const { cache } = buildCache({ compress: true, staleWhileRevalidate: true });
+    await cache.fetch([5]);
+    const before = stored(5)!;
+
+    await cache.bust(5);
+    const after = stored(5);
+    // Asserted before indexing: if invalidate's mGet decoded on the wrong path the entry is
+    // EVICTED, and this says so instead of throwing a bare TypeError on `after[0]`.
+    expect(after, 'entry was evicted — invalidate read it on the non-compress path').toBeDefined();
+    expect(after![0]).toBe(PACKED_BROTLI_SENTINEL);
+    expect(after!.equals(before)).toBe(false); // it really rewrote the entry
+  });
+
+  it('update() reads and rewrites a compressed entry', async () => {
+    const { cache } = buildCache({ compress: true, staleWhileRevalidate: false });
+    await cache.fetch([6]);
+
+    // `false` here means update() found nothing to correct — which, on a compressed cache, is
+    // what an asymmetric mGet produces: the read throws, the entry is evicted, and the
+    // write-through silently degrades to a no-op the caller is expected to fall back from.
+    const ok = await cache.update(6, (current) => ({ ...current, blob: 'updated' }));
+    expect(ok, 'update() found no entry — the compressed read decoded on the wrong path').toBe(
+      true
+    );
+    expect(stored(6)![0]).toBe(PACKED_BROTLI_SENTINEL);
+
+    const got = await cache.fetch([6]);
+    expect(got['6']).toEqual({ id: 6, blob: 'updated' });
+  });
+});
+
+describe('back-compat: legacy UNCOMPRESSED entries stay readable', () => {
+  it('serves a MIXED population — a legacy raw entry and a freshly compressed one — in one fetch', async () => {
+    // This is the state of the cache for the whole TTL after the flag is flipped, and the reason
+    // no key-bust or migration is needed. Both entries must decode in the SAME mGet.
+    const { cache, lookupFn } = buildCache({ compress: true });
+
+    // Exactly what the cache wrote before compression was enabled: raw msgpack, no sentinel.
+    const legacy = pack({ id: 9, blob: bigBlob, cachedAt: new Date() });
+    expect(legacy[0]).not.toBe(PACKED_BROTLI_SENTINEL);
+    store.set(`${KEY}:9`, Buffer.from(legacy));
+
+    // id 10 is absent, so this pass writes it through the NEW compressed path.
+    const got = await cache.fetch([9, 10]);
+    expect(got['9']).toEqual({ id: 9, blob: bigBlob });
+    expect(got['10']).toEqual({ id: 10, blob: bigBlob });
+    // Only the missing id reached the origin — the legacy entry was a hit, not a decode failure.
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(lookupFn.mock.calls[0][0]).toEqual([10]);
+
+    // The two entries are now stored in DIFFERENT formats…
+    expect(stored(9)![0]).not.toBe(PACKED_BROTLI_SENTINEL);
+    expect(stored(10)![0]).toBe(PACKED_BROTLI_SENTINEL);
+    // …and the legacy one survived (a failed decode would have UNLINKed it).
+    expect(store.has(`${KEY}:9`)).toBe(true);
+
+    // A second fetch reads both formats back with no origin call at all.
+    lookupFn.mockClear();
+    const again = await cache.fetch([9, 10]);
+    expect(again['9']).toEqual({ id: 9, blob: bigBlob });
+    expect(again['10']).toEqual({ id: 10, blob: bigBlob });
+    expect(lookupFn).not.toHaveBeenCalled();
+  });
+});
+
+// INVARIANT GUARDS (green at origin/main too, by construction — that is the point). These pin
+// that the DEFAULT is unchanged, i.e. that ~30 other packed caches keep writing plain msgpack.
+// They go red only if someone flips the default on, which is the regression they exist for.
+describe('default / compress:false is byte-for-byte unchanged', () => {
+  it('writes NO sentinel and stores plain msgpack when compress is omitted', async () => {
+    const { cache } = buildCache({});
+    await cache.fetch([1]);
+
+    const raw = stored(1)!;
+    expect(raw[0]).not.toBe(PACKED_BROTLI_SENTINEL);
+    // Plain msgpack map marker, and it unpacks with no decompression step.
+    const decoded = unpack(raw) as Row;
+    expect(decoded).toMatchObject({ id: 1, blob: bigBlob });
+  });
+
+  it('compress:false explicitly is identical to the default', async () => {
+    const { cache } = buildCache({ compress: false });
+    await cache.fetch([2]);
+    expect(stored(2)![0]).not.toBe(PACKED_BROTLI_SENTINEL);
+  });
+});
+
+describe('SEAM LEDGER: every redis.packed call site in cached-array.ts is compress-aware', () => {
+  // The behavioural tests above cover all NINE call sites as they exist today. This ledger is
+  // what catches the TENTH: a new redis.packed read or write added later without `packedOptions`
+  // would be silently asymmetric on a compressed cache, and no existing test would exercise it.
+  // Asserted as an exact COUNT in both directions — a shrinking set means the detector went
+  // blind, which passes an additions-only check while reporting a clean file.
+  const src = readFileSync(path.join(__dirname, '..', 'cached-array.ts'), 'utf8');
+  // Paren-matched rather than regex-captured: the call sites here span 1–6 lines and a
+  // "up to the closing paren" regex silently misses the single-line ones (it did, at first —
+  // it found 8 of 9, which is exactly the shape of a detector that reports a clean file).
+  const calls: { op: string; args: string }[] = [];
+  for (const m of src.matchAll(/redis\.packed\.(mGet|set)\b/g)) {
+    let i = m.index! + m[0].length;
+    if (src[i] === '<') i = src.indexOf('>', i) + 1; // skip an explicit type argument
+    if (src[i] !== '(') continue;
+    let depth = 0;
+    let end = i;
+    for (; end < src.length; end++) {
+      if (src[end] === '(') depth++;
+      else if (src[end] === ')' && --depth === 0) break;
+    }
+    calls.push({ op: m[1], args: src.slice(i + 1, end) });
+  }
+
+  // INVARIANT GUARD (green at origin/main too): the nine call sites exist there as well. Its job
+  // is to keep the ledger below honest — a detector that goes blind fails HERE rather than
+  // reporting zero violations over zero call sites.
+  it('finds exactly the 9 known redis.packed call sites', () => {
+    // POSITIVE CONTROL on the detector: if the matcher stops matching, the count drops and the
+    // whole ledger fails loudly rather than reporting zero violations over zero call sites.
+    expect(calls.length).toBe(9);
+    expect(calls.filter((c) => c.op === 'mGet').length).toBe(3);
+    expect(calls.filter((c) => c.op === 'set').length).toBe(6);
+  });
+
+  it('every one of them passes packedOptions', () => {
+    const missing = calls.filter((c) => !c.args.includes('packedOptions')).map((c) => c.args);
+    expect(missing).toEqual([]);
+  });
+
+  it('packedOptions is derived from the option, not hardcoded', () => {
+    expect(src).toMatch(/const packedOptions = \{ compress \} as const;/);
+  });
+});
+
+describe('the symmetry hazard this flag exists to prevent', () => {
+  it('a compressed entry read through the NON-compress path is a miss AND is evicted', async () => {
+    // This is the production failure mode if any one call site drops the flag: not an error, a
+    // silent permanent miss+evict loop. Asserted directly against the real client so the guard
+    // pins the mechanism rather than a mocked stand-in.
+    const key = `${KEY}:99` as RedisKeyTemplateCache;
+    store.set(key, await compressPacked(Buffer.from(pack({ id: 99, blob: bigBlob }))));
+
+    const [viaGeneral] = await redis.packed.mGet<Row>([key]);
+    expect(viaGeneral).toBeNull();
+    expect(store.has(key)).toBe(false); // evicted by safeUnpack's unlink
+
+    // …and the same bytes read WITH the flag decode fine.
+    store.set(key, await compressPacked(Buffer.from(pack({ id: 99, blob: bigBlob }))));
+    const [viaCompress] = await redis.packed.mGet<Row>([key], { compress: true });
+    expect(viaCompress).toEqual({ id: 99, blob: bigBlob });
+  });
+});

--- a/packages/civitai-redis/src/__tests__/packed-decode-paths.test.ts
+++ b/packages/civitai-redis/src/__tests__/packed-decode-paths.test.ts
@@ -1,27 +1,27 @@
 import { pack, unpack } from 'msgpackr';
 import { describe, expect, it } from 'vitest';
-import {
-  PACKED_BROTLI_SENTINEL,
-  compressPacked,
-  decompressPacked,
-} from '../packed-compression';
+import { PACKED_BROTLI_SENTINEL, compressPacked, decompressPacked } from '../packed-compression';
 
 /**
  * Regression guard for the hardened decode design (PR #2649 review Fix 1).
  *
  * `redis.packed` has TWO decode paths in src/server/redis/client.ts:
  *
- *   GENERAL  (safeUnpack, used by get/mGet/sMembers/sPop/hGet/hGetAll/hmGet across ~30
- *            cache writers): plain `unpack(value)` — NEVER decompresses.
- *   COMPRESS-AWARE (safeUnpackCompressed, used ONLY by get(key, { compress: true }), i.e.
- *            fetchThroughCache's compressed callers): sentinel-detect → brotli-decompress
- *            → unpack, back-compat with legacy uncompressed wrappers.
+ *   GENERAL  (safeUnpack — the DEFAULT for get/mGet, and the only path for
+ *            sMembers/sPop/hGet/hGetAll/hmGet, across ~30 cache writers): plain
+ *            `unpack(value)` — NEVER decompresses.
+ *   COMPRESS-AWARE (safeUnpackCompressed, used ONLY by get/mGet when passed
+ *            `{ compress: true }`: fetchThroughCache's compressed callers, and
+ *            createCachedArray/createCachedObject caches built with `compress: true`
+ *            — #4588 added the mGet half): sentinel-detect → brotli-decompress →
+ *            unpack, back-compat with legacy uncompressed values.
  *
  * The brotli sentinel (0x01) collides with `pack(1)` (=== <01>). Routing decompression
  * through the SHARED general path would mis-read a bare `1` (a count/flag/scalar tRPC
  * result) as a compressed payload → throw → evict → permanent cache miss. Confining
  * decompression to the compress-aware path makes the collision harmless: that path only
- * ever sees the `{ data, cachedAt }` wrapper (first byte = MAP marker, never 0x01).
+ * ever sees OBJECTS — the `{ data, cachedAt }` wrapper, or a cached-array record/marker —
+ * whose first byte is always a MAP marker, never 0x01.
  *
  * These tests model BOTH paths at the exact decode boundary the wrappers use (the same
  * `unpack` / `decompressPacked` calls as client.ts), without booting the full client
@@ -97,7 +97,10 @@ describe('packed decode paths (Fix 1 — confined decompression)', () => {
     });
 
     it('a corrupt/garbage value is treated as a cache miss (null), preserving fail-open', async () => {
-      const garbage = Buffer.concat([Buffer.from([PACKED_BROTLI_SENTINEL]), Buffer.from('not-brotli')]);
+      const garbage = Buffer.concat([
+        Buffer.from([PACKED_BROTLI_SENTINEL]),
+        Buffer.from('not-brotli'),
+      ]);
       expect(await safeUnpackCompressed(garbage)).toBeNull();
     });
   });

--- a/packages/civitai-redis/src/cached-array.ts
+++ b/packages/civitai-redis/src/cached-array.ts
@@ -50,16 +50,39 @@ export type CachedLookupOptions<T extends object> = {
   // total L1 footprint is bounded regardless of per-value size spikes. A single value larger than the
   // budget is simply not stored (falls through to Redis) — never an error.
   localMaxBytes?: number;
+  // Opt-in brotli compression of the packed value at rest (sentinel-tagged). Enable only for caches
+  // whose values are LARGE and repetitive enough to pay the codec — most per-id values are tiny.
+  //
+  // 🔴 SYMMETRY IS THE WHOLE CONTRACT: this flag is threaded to EVERY redis.packed read AND write
+  // this builder performs (fetch's mGet, the value/notFound writes, bust's debounce marker,
+  // invalidate's mGet + rewrite, refresh's rewrite, update's mGet + rewrite). A key written
+  // compressed but read via the general msgpack path throws → the entry is EVICTED and the read
+  // reports a miss, i.e. a permanent miss+evict loop rather than a visible error. If you add a new
+  // redis.packed call site to this module you MUST pass `{ compress }` to it.
+  //
+  // Back-compat is free in BOTH directions: the compress-aware read is sentinel-discriminated, so
+  // legacy uncompressed entries written before the flag was flipped still decode. No key-bust or
+  // migration is needed to turn this on. (Turning it OFF again is NOT symmetric — see the note on
+  // the general decode path in ./packed-compression — so flip it off only with a key-bust.)
+  //
+  // SENTINEL SAFETY: every value this module writes is an object (`{ ...result, cachedAt }`, the
+  // notFound marker, the debounce marker) and `T extends object`, so the 0x01 sentinel can never
+  // collide with a bare-scalar msgpack payload. See ./packed-compression.
+  compress?: boolean;
 };
 
 /** The slice of the redis client this module needs. */
 type PackedClient = {
   packed: {
-    mGet<T>(keys: RedisKeyTemplateCache[]): Promise<(T | null)[]>;
+    mGet<T>(
+      keys: RedisKeyTemplateCache[],
+      packedOptions?: { compress?: boolean }
+    ): Promise<(T | null)[]>;
     set<T>(
       key: RedisKeyTemplateCache,
       value: T,
-      options?: { EX?: number; NX?: boolean; XX?: boolean }
+      options?: { EX?: number; NX?: boolean; XX?: boolean },
+      packedOptions?: { compress?: boolean }
     ): Promise<unknown>;
   };
   del(key: RedisKeyTemplateCache | RedisKeyTemplateCache[]): Promise<unknown>;
@@ -143,7 +166,12 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
     localTtl,
     localMax = 10000,
     localMaxBytes,
+    compress = false,
   }: CachedLookupOptions<T>) {
+    // Resolved ONCE and passed to every redis.packed read/write below. Keeping a single object
+    // (rather than re-spelling `{ compress }` per call site) makes the symmetry contract in
+    // CachedLookupOptions.compress mechanically obvious: one binding, nine consumers.
+    const packedOptions = { compress } as const;
     // Holds the FINAL resolved per-id value — post-appendFn, cachedAt stripped — so an L1 hit is
     // byte-identical to what the Redis path returns and needs no further decoration.
     // Driven with get/set rather than its wrapping .fetch — the access pattern here is a batch mGet,
@@ -271,7 +299,8 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
       try {
         for (const batch of chunk(distinctIds, 200)) {
           const batchResults = await redis.packed.mGet<T>(
-            batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache)
+            batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache),
+            packedOptions
           );
           cacheResults.push(...batchResults.filter(isDefined));
         }
@@ -399,7 +428,12 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
           if (Object.keys(toCache).length > 0)
             await Promise.all(
               Object.entries(toCache).map(([id, value]) =>
-                redis.packed.set(`${key}:${id}` as RedisKeyTemplateCache, value, { EX })
+                redis.packed.set(
+                  `${key}:${id}` as RedisKeyTemplateCache,
+                  value,
+                  { EX },
+                  packedOptions
+                )
               )
             );
 
@@ -409,10 +443,12 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
             const notFoundEX = notFoundTtl ?? EX;
             await Promise.all(
               Object.entries(toCacheNotFound).map(([id, value]) =>
-                redis.packed.set(`${key}:${id}` as RedisKeyTemplateCache, value, {
-                  EX: notFoundEX,
-                  NX: true,
-                })
+                redis.packed.set(
+                  `${key}:${id}` as RedisKeyTemplateCache,
+                  value,
+                  { EX: notFoundEX, NX: true },
+                  packedOptions
+                )
               )
             );
           }
@@ -464,7 +500,8 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
           redis.packed.set(
             `${key}:${id}` as RedisKeyTemplateCache,
             { [idKey]: id, debounce: true },
-            { EX: options.debounceTime ?? debounceTime }
+            { EX: options.debounceTime ?? debounceTime },
+            packedOptions
           )
         )
       );
@@ -479,7 +516,8 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
       const cacheResults: T[] = [];
       for (const batch of chunk(ids, 200)) {
         const batchResults = await redis.packed.mGet<T>(
-          batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache)
+          batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache),
+          packedOptions
         );
         cacheResults.push(...batchResults.filter(isDefined));
       }
@@ -500,7 +538,7 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
       if (Object.keys(toCache).length > 0)
         await Promise.all(
           Object.entries(toCache).map(([id, value]) =>
-            redis.packed.set(`${key}:${id}` as RedisKeyTemplateCache, value, { EX })
+            redis.packed.set(`${key}:${id}` as RedisKeyTemplateCache, value, { EX }, packedOptions)
           )
         );
 
@@ -523,7 +561,12 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
         const cacheable = Object.entries(results).filter(([, x]) => x && !dontCacheFn?.(x));
         await Promise.all(
           cacheable.map(([rid, x]) =>
-            redis.packed.set(`${key}:${rid}` as RedisKeyTemplateCache, { ...x, cachedAt }, { EX })
+            redis.packed.set(
+              `${key}:${rid}` as RedisKeyTemplateCache,
+              { ...x, cachedAt },
+              { EX },
+              packedOptions
+            )
           )
         );
 
@@ -598,7 +641,7 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
       }
 
       try {
-        const [current] = await redis.packed.mGet<T>([entryKey]);
+        const [current] = await redis.packed.mGet<T>([entryKey], packedOptions);
         const marker = current as AnyRecord | null;
         if (!current || marker?.notFound || marker?.debounce || !marker?.cachedAt) return false;
 
@@ -620,7 +663,8 @@ export function createCacheBuilders(deps: CacheBuilderDeps) {
         const written = await redis.packed.set(
           entryKey,
           { ...next, cachedAt: marker.cachedAt },
-          { EX, XX: true }
+          { EX, XX: true },
+          packedOptions
         );
         if (written === null) return false;
         // After the write, not before: a concurrent fetch between the two would

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -115,8 +115,12 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
     // (sentinel-detect + brotli-decompress), SYMMETRIC with set's compress. Only enable
     // for keys written with compress — see the SENTINEL SCOPE note in packed-compression.
     get<T>(key: K, packedOptions?: { compress?: boolean }): Promise<T | null>;
-    // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all
-    mGet<T>(keys: K[]): Promise<(T | null)[]>;
+    // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all.
+    // `packedOptions.compress` opts the READ into the compress-aware decode path, exactly as
+    // `get` does — REQUIRED for any caller whose writes compress, since mGet is the batched
+    // read counterpart of set. Without it a compressed value decodes via the general msgpack
+    // path, throws, and is EVICTED — a permanent miss+evict loop, not a soft failure.
+    mGet<T>(keys: K[], packedOptions?: { compress?: boolean }): Promise<(T | null)[]>;
     // `packedOptions.compress` opts the value into brotli compression at rest (sentinel-
     // tagged; reads decode both compressed and legacy-uncompressed values transparently).
     // Only safe for callers that store wrapper objects, never bare scalars — see the
@@ -1280,9 +1284,9 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   // it deliberately does NOT brotli-decompress, so the 0x01 brotli sentinel is NOT a
   // global invariant on all packed values (a bare msgpack `1` packs to <01> and must
   // decode as the integer 1, not be mistaken for a compressed payload). Brotli
-  // decompression is confined to the opt-in compress-aware read path below
-  // (`get(key, { compress: true })`) — see ./packed-compression for why the
-  // sentinel is provably collision-free THERE (wrapper objects only).
+  // decompression is confined to the opt-in compress-aware read paths below
+  // (`get`/`mGet` with `{ compress: true }`) — see ./packed-compression for why the
+  // sentinel is provably collision-free THERE (objects only, never bare scalars).
   const safeUnpack = <T>(value: Buffer, evict: () => Promise<unknown>): T | null => {
     try {
       return unpack(value) as T;
@@ -1297,15 +1301,17 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   };
 
   // Compress-aware decode — the SYMMETRIC counterpart of `set(..., { compress: true })`,
-  // used ONLY by the opt-in `get(key, { compress: true })` read path (currently just
-  // fetchThroughCache's compressed callers, e.g. tensor-metadata full). It awaits the
-  // async brotli codec and discriminates on the sentinel byte so a legacy uncompressed
-  // value (written before compression was enabled) still decodes: first byte === sentinel
-  // → strip + brotli-decompress + unpack; else → unpack as legacy raw. Provably safe HERE
-  // (and only here) because every value on this path is the `{ data, cachedAt }` wrapper
-  // object whose msgpack first byte is always a MAP marker (0x80–0x8f / 0xde / 0xdf),
-  // never 0x01. Preserves safeUnpack's evict-on-failure / fail-open semantics: a
-  // decompress/unpack throw is treated as a cache miss (null) and evicts the bad entry.
+  // used ONLY by the opt-in `get`/`mGet` with `{ compress: true }` read paths
+  // (fetchThroughCache's compressed callers, e.g. tensor-metadata full; and
+  // createCachedArray/createCachedObject caches built with `compress: true`, e.g.
+  // imageMetaCache). It awaits the async brotli codec and discriminates on the sentinel
+  // byte so a legacy uncompressed value (written before compression was enabled) still
+  // decodes: first byte === sentinel → strip + brotli-decompress + unpack; else → unpack
+  // as legacy raw. Provably safe HERE (and only here) because every value on these paths
+  // is an OBJECT (the `{ data, cachedAt }` wrapper, or a cached-array record/marker) whose
+  // msgpack first byte is always a MAP marker (0x80–0x8f / 0xde / 0xdf), never 0x01.
+  // Preserves safeUnpack's evict-on-failure / fail-open semantics: a decompress/unpack
+  // throw is treated as a cache miss (null) and evicts the bad entry.
   const safeUnpackCompressed = async <T>(
     value: Buffer,
     evict: () => Promise<unknown>
@@ -1336,8 +1342,18 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
     },
 
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all
-    async mGet<T>(keys: K[]): Promise<(T | null)[]> {
+    async mGet<T>(keys: K[], packedOptions?: { compress?: boolean }): Promise<(T | null)[]> {
       const results = await Promise.all(keys.map((key) => bufferClient.get<Buffer>(key)));
+      // SYMMETRIC with `set(..., { compress: true })`, same as the single-key `get` above.
+      // The batched read is the one a per-id cache (createCachedArray) actually uses, so a
+      // compressed writer that could not opt its mGet in would corrupt every read.
+      if (packedOptions?.compress) {
+        return Promise.all(
+          results.map((result, i) =>
+            result ? safeUnpackCompressed<T>(result, () => client.unlink(keys[i])) : null
+          )
+        );
+      }
       return results.map((result, i) =>
         result ? safeUnpack<T>(result, () => client.unlink(keys[i])) : null
       );

--- a/packages/civitai-redis/src/packed-compression.ts
+++ b/packages/civitai-redis/src/packed-compression.ts
@@ -18,13 +18,22 @@ import { promisify } from 'util';
  * On-disk format for a compressed value is a single SENTINEL prefix byte (0x01 = brotli)
  * followed by the brotli stream of the msgpack-packed Buffer.
  *
- * SENTINEL SCOPE: decompression is CONFINED to the compress-aware read path
- * (`redis.packed.get(key, { compress: true })`, used only by `fetchThroughCache` when
- * `compress: true`). The general decode path (`safeUnpack`, used by every other packed
- * read) NEVER touches this code, so the 0x01 sentinel is NOT a global invariant on all
- * packed values — it only applies on the one confined path, where every value is the
- * `{ data, cachedAt }` WRAPPER OBJECT (msgpack first byte is always a MAP marker
- * 0x80–0x8f / 0xde / 0xdf — never 0x01), making the sentinel provably collision-free.
+ * SENTINEL SCOPE: decompression is CONFINED to the compress-aware read paths
+ * (`redis.packed.get(key, { compress: true })` and `redis.packed.mGet(keys,
+ * { compress: true })`). The general decode path (`safeUnpack`, used by every other
+ * packed read) NEVER touches this code, so the 0x01 sentinel is NOT a global invariant
+ * on all packed values — it only applies on those confined paths.
+ *
+ * Two callers opt in today, and BOTH store an object, never a bare scalar, so the
+ * sentinel is provably collision-free on the path (a msgpack map's first byte is always
+ * a MAP marker 0x80–0x8f / 0xde / 0xdf — never 0x01):
+ *   - `fetchThroughCache` — always the `{ data, cachedAt }` WRAPPER OBJECT.
+ *   - `createCachedArray` / `createCachedObject` (`compress: true`) — every value it
+ *     writes is a record: `{ ...result, cachedAt }`, the negative marker
+ *     `{ [idKey]: id, notFound: true, cachedAt }`, and the debounce marker
+ *     `{ [idKey]: id, debounce: true }`. `lookupFn` is typed `T extends object`, so a
+ *     scalar cannot reach the write path.
+ *
  * Do NOT enable `compress` for a caller that stores a bare scalar (a positive-fixint
  * 0x01 would be ambiguous with the sentinel).
  */

--- a/src/server/redis/__tests__/image-meta-cache-compress.test.ts
+++ b/src/server/redis/__tests__/image-meta-cache-compress.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `imageMetaCache` must stay configured with `compress: true` (issue #4588).
+ *
+ * WHY A SOURCE-LEVEL GUARD. `caches.ts` builds 20+ module-scope cache singletons during module
+ * evaluation and pulls in the env / clickhouse / orchestrator import graph, so importing it from
+ * a unit test is not viable (that is why every other cache test in this directory rebuilds the
+ * cache from a copied lookupFn instead). The cache objects it exports are opaque closures — they
+ * do not expose the options they were built with — so there is nothing to assert on at runtime
+ * either. The declaration site IS the configuration, so that is what this pins.
+ *
+ * The MECHANISM is covered behaviourally, end-to-end against the real redis client, in
+ * `packages/civitai-redis/src/__tests__/cached-array-compress.test.ts`. This file only guards
+ * that this particular cache is still opted in — the deployment half of #4588.
+ *
+ * SCOPE: the extractor brace-matches the `imageMetaCache` options object specifically, so a
+ * `compress: true` elsewhere in the 3,000-line file cannot satisfy it. The positive control
+ * below proves that scoping is real by running the same extractor over a NEIGHBOURING cache
+ * that must NOT be compressed — if the extractor ever degrades into "scan the whole file", that
+ * control turns red rather than this guard silently passing on the wrong evidence.
+ */
+
+const CACHES_PATH = path.join(process.cwd(), 'src/server/redis/caches.ts');
+const source = readFileSync(CACHES_PATH, 'utf8');
+
+/**
+ * Return the text of the options object literal passed to the `createCached*` call that
+ * initialises `export const <name>`. Throws if the declaration is absent, so a rename fails
+ * loudly instead of returning an empty string that vacuously satisfies a `not.toContain`.
+ */
+function cacheOptionsBlock(name: string): string {
+  const decl = new RegExp(`export const ${name} = createCached(?:Object|Array)<[^>]*>\\(`);
+  const m = decl.exec(source);
+  if (!m) throw new Error(`Could not locate "export const ${name} = createCached…(" in caches.ts`);
+  const open = source.indexOf('{', m.index + m[0].length - 1);
+  if (open === -1) throw new Error(`No options object literal found for ${name}`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  throw new Error(`Unbalanced braces while extracting ${name}'s options`);
+}
+
+describe('imageMetaCache compression (#4588)', () => {
+  const block = cacheOptionsBlock('imageMetaCache');
+
+  it('is the IMAGE_META cache (the extractor is pointed at the right declaration)', () => {
+    expect(block).toContain('key: REDIS_KEYS.CACHES.IMAGE_META');
+  });
+
+  it('is configured with compress: true', () => {
+    expect(block).toMatch(/(^|\n)\s*compress:\s*true\s*,/);
+  });
+
+  it('still has NO per-pod L1 (the hideMeta privacy control — do not "fix" decode cost with one)', () => {
+    // `meta` is gated on hideMeta and a cross-pod refresh() cannot be observed by an L1, so an
+    // L1 here would keep serving a prompt the owner just hid. Compression changes the decode
+    // cost, which is exactly the argument someone will reach for an L1 with — pinned so that
+    // reasoning has to come back through review.
+    expect(block).not.toMatch(/(^|\n)\s*localTtl:/);
+  });
+
+  it('keeps the 4h logical TTL and the trimmed 1h stale tail', () => {
+    // Compression is the lever that replaced the (already-spent) TTL lever; a future change that
+    // shortens the logical TTL would convert the hot working set into misses and stampede dbRead.
+    expect(block).toContain('ttl: CacheTTL.hour * 4');
+    expect(block).toContain('staleWhileRevalidateTtl: CacheTTL.hour');
+  });
+
+  it('POSITIVE CONTROL: the extractor is block-scoped, not a whole-file scan', () => {
+    // imageMetadataCache sits directly after imageMetaCache in the file and is NOT compressed.
+    // If the extractor degraded to scanning the whole source, this would find imageMetaCache's
+    // `compress: true` and fail — which is precisely the failure this control exists to catch.
+    const neighbour = cacheOptionsBlock('imageMetadataCache');
+    expect(neighbour).toContain('key: REDIS_KEYS.CACHES.IMAGE_METADATA');
+    expect(neighbour).not.toMatch(/(^|\n)\s*compress:\s*true\s*,/);
+  });
+
+  it('POSITIVE CONTROL: a missing declaration throws rather than passing vacuously', () => {
+    expect(() => cacheOptionsBlock('noSuchCacheDoesNotExist')).toThrow(/Could not locate/);
+  });
+});

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1370,6 +1370,23 @@ export const imageMetaCache = createCachedObject<ImageWithMeta>({
   // working set into misses and stampede dbRead.
   ttl: CacheTTL.hour * 4,
   staleWhileRevalidateTtl: CacheTTL.hour,
+  // Brotli-compress every value at rest (see #4588). image-meta is the ELASTIC component of the
+  // cache — its resident set swings ~5x under load and is what drives the cluster to its memory
+  // cap — and its values are prompt/generation-parameter text, i.e. highly repetitive. Measured on
+  // 336 real values sampled AT A PEAK: 3.09x, 67.6% of bytes saved, at under 2% of app CPU as a
+  // deliberately pessimistic upper bound (that bound attributes ALL cache traffic to this one
+  // prefix). The codec is async (libuv threadpool), so it never blocks the event loop.
+  //
+  // ALL values, not a size threshold: measured, `> 4 KiB` saves only 47.5% of the prefix's bytes
+  // against 67.6% for everything — the ~20pp difference is the difference between clearing the cap
+  // at peak and not — and it trades away the scarce resource (memory) to protect one that is not
+  // scarce (CPU). `> 1 KiB` is within 1pp of "all"; the primitive has no threshold support anyway,
+  // so "all" is also the least code.
+  //
+  // Back-compat: entries are sentinel-tagged and the read path decodes legacy uncompressed values
+  // transparently, so this needed no key-bust. Turning it back OFF is NOT symmetric — a compressed
+  // key read through the general path throws and is evicted — so that would need one.
+  compress: true,
   // NO per-pod L1 here (deliberate): `meta` is gated on `hideMeta`, and when an owner
   // flips hideMeta false→true the write path calls imageMetaCache.refresh() (meta→NULL).
   // A per-pod L1 can't observe that cross-pod refresh, so other viewers' pods would keep

--- a/src/server/utils/__tests__/cache-helpers-update.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-update.test.ts
@@ -77,9 +77,14 @@ describe('createCachedArray.update — the write-through path', () => {
     // The entry's OWN key on both the read and the write. Reading `id + 1` while
     // writing `id` would apply one user's delta to another user's cached set, and
     // asserting only the write would not see it.
-    expect(mGetMock).toHaveBeenCalledWith([ENTRY_KEY]);
-    const [key, value, options] = setMock.mock.calls[0];
+    // The 2nd arg is the packed codec options threaded from the cache's `compress` option
+    // (#4588). This cache does not opt in, so it must be `false` here — asserted rather than
+    // loosened to `expect.anything()`, since a read that silently flipped to compress:true
+    // against uncompressed writes is exactly the asymmetry that flag has to avoid.
+    expect(mGetMock).toHaveBeenCalledWith([ENTRY_KEY], { compress: false });
+    const [key, value, options, packedOptions] = setMock.mock.calls[0];
     expect(key).toBe(ENTRY_KEY);
+    expect(packedOptions).toEqual({ compress: false });
     // `cachedAt` carried over, not reset: the entry stays as fresh as it was and no
     // fresher, so its revalidation clock is unchanged.
     expect(value).toEqual({ id: 1, members: [7, 9], cachedAt });


### PR DESCRIPTION
Closes #4588.

`packed:caches:image-meta` was stored uncompressed. It is the **elastic** component of the packed cache — its resident set swings ~5× under load and is what drives the cache to its memory cap — and its values are prompt / generation-parameter text, i.e. highly repetitive. Measured on 336 real values sampled **at a peak** (issue #4588, [benchmark comment](https://github.com/civitai/civitai/issues/4588#issuecomment-5549843539)): brotli q=6 gives **3.09×, 67.6 % of bytes saved**, at **under 2 % of app CPU** as a deliberately pessimistic upper bound (that bound attributes *all* cache read+write traffic to this one prefix; the true figure is a fraction of it). The codec is already `promisify(zlib.brotli*)`, so it runs on the libuv threadpool and never blocks the event loop.

## What changed

### 1. `packed.mGet` gains a `compress` option — this was a hard blocker, not a nicety

The issue describes the work as "thread `compress` through `createCachedObject`". That is necessary but **not sufficient**: `redis.packed.mGet` had no `compress` option at all — only `packed.get` did — and `createCachedArray` reads **exclusively** through `mGet`. Enabling compression without this would have written sentinel-tagged values that the batched read decodes on the general msgpack path: `unpack()` throws, `safeUnpack` **UNLINKs the entry**, and the read reports a miss. A permanent miss+evict loop, with no error surfaced anywhere and a *higher* DB load than before the change.

`mGet` now routes through `safeUnpackCompressed` when opted in, exactly as `get` does.

### 2. `createCachedArray` / `createCachedObject` gain `compress`, threaded to **all nine** packed call sites

Symmetry is the entire contract — one missed site is silent cache corruption on exactly the path that was missed. The full ledger, all in `packages/civitai-redis/src/cached-array.ts`:

| # | site | op | how it is covered |
|---|---|---|---|
| 1 | `fetch` batch read | `mGet` | behavioural (round-trip + mixed-population) |
| 2 | `fetch` value write | `set` | sentinel-byte assertion |
| 3 | `fetch` `notFound` marker write | `set` (NX) | sentinel-byte + no-re-query assertion |
| 4 | `bust` debounce-marker write | `set` | sentinel byte + marker decodes to `{ debounce: true }` |
| 5 | `invalidate` read | `mGet` | behavioural (SWR `bust` rewrites the entry) |
| 6 | `invalidate` rewrite | `set` | sentinel byte |
| 7 | `refresh` rewrite | `set` | sentinel byte + subsequent read hits |
| 8 | `update` read | `mGet` | behavioural (`update` returns `true`) |
| 9 | `update` rewrite | `set` | sentinel byte + value round-trips |

`redis.del` / `setNxKeepTtlWithEx` carry no codec and are untouched. A **seam-ledger test** asserts the count is exactly 9 in both directions and that every one passes the options object, so a tenth call site added later cannot be silently asymmetric.

**Sentinel safety re-verified for this new caller.** The 0x01 brotli sentinel is only collision-free because every value on the compress-aware path is an object (a msgpack map marker is `0x80–0x8f`/`0xde`/`0xdf`, never `0x01`). Everything `createCachedArray` writes is a record — `{ ...result, cachedAt }`, `{ [idKey]: id, notFound: true, cachedAt }`, `{ [idKey]: id, debounce: true }` — and `T extends object`, so a bare scalar cannot reach the write path. The doc comments in `packed-compression.ts` and `client.ts` are updated to name both callers rather than just `fetchThroughCache`.

### 3. `imageMetaCache` opts in — **all values, not a threshold**

The issue body suggests `> 4 KiB` as "the best CPU-per-byte-saved point". Measured, it is not a good trade:

| threshold | keys touched | bytes saved (whole prefix) |
|---|---|---|
| **all values** | 100 % | **67.6 %** |
| `> 1 KiB` | 78.6 % | 66.6 % |
| `> 2 KiB` | 31.8 % | 57.5 % |
| `> 4 KiB` | 6.0 % | **47.5 %** |

`> 4 KiB` gives up **~20 percentage points** — the difference between clearing the cap at peak and not — to buy back a fraction of a percent of app CPU. That trades away the resource that is scarce for one that is not. `> 1 KiB` is within 1 pp of "all", and since the primitive has no threshold support, "all" is also the least code. (Codec and quality are unchanged: the primitive hardcodes q=6, which measures an identical ratio to q=5.)

**Back-compat needs no key-bust or migration.** Entries are sentinel-tagged and the compress-aware read discriminates on the first byte, so legacy uncompressed entries written before the flag still decode. Covered by a test that serves a **mixed population** — one legacy raw entry and one freshly compressed entry — in a single `fetch`, which is the state of the cache for the whole TTL after the flag flips. Note the asymmetry: turning the flag back **off** is *not* free (a compressed key read on the general path throws and is evicted), so that direction would need a bust. Called out in the option's doc comment.

**The deliberate absence of a per-pod L1 on this cache is preserved and now guarded.** `meta` is gated on `hideMeta`, and a cross-pod `refresh()` cannot be observed by an L1, so one would keep serving a hidden prompt. Compression changes decode cost, which is exactly the argument someone would reach for an L1 with — a test now pins its absence so that reasoning has to come back through review.

## Tests

`packages/civitai-redis/src/__tests__/cached-array-compress.test.ts` drives the **real** `createCacheRedis()` client against an in-memory transport (only `redis`'s client factory is faked). Everything above the socket — the packed wrappers, msgpack, brotli, the cache builders — is the real module. That is deliberate: a suite that mocks `redis.packed` would pass against a client whose `mGet` ignores the flag entirely, i.e. against the exact production defect. Driving the real client also lets the tests assert the **on-disk bytes**, which is the only way to tell "compression is on" from "the round-trip happens to work anyway".

Plus `src/server/redis/__tests__/image-meta-cache-compress.test.ts`, a config guard on the declaration site (`caches.ts` builds 20+ module-scope singletons behind the env/clickhouse import graph, so importing it from a unit test is not viable, and the cache objects do not expose the options they were built with). It carries two positive controls: the extractor is brace-scoped to `imageMetaCache` and proven so against an uncompressed neighbour, and a missing declaration throws rather than passing vacuously.

One existing assertion, `cache-helpers-update.test.ts`, was updated for the new packed-options argument.

### Red/green matrix

Base ref `d197ecbea2` (`origin/main`), HEAD `44f5a6ee74` (matrix measured at `d84df61ec6`; the follow-up commit is test-only and adds no new red/green rows — its evidence is the mutation table below it). Both suites run at the base with the test files copied in.

| suite | at `d197ecbea2` | at HEAD |
|---|---|---|
| `cached-array-compress.test.ts` | **10 failed** / 4 passed (14) | 14 passed |
| `image-meta-cache-compress.test.ts` | **1 failed** / 5 passed (6) | 6 passed |

The 5 that are green at base are **invariant guards**, labelled as such in the file and not counted as regression coverage:

- *round-trips a value through a compressed cache* — with `compress` ignored, reads and writes are still symmetric, just uncompressed. It pins that enabling compression does not break the read-through contract; the regression coverage is the sentinel assertion.
- *finds exactly the 9 known redis.packed call sites* — the nine sites exist at base too. Its job is to keep the ledger honest: a detector that goes blind fails here rather than reporting zero violations over zero call sites.
- the two *compress:false / default is unchanged* tests — green at base by construction, which is the point. They go red only if someone flips the default on.
- *a missing declaration throws* (the config guard's own positive control).

### Mutation results — 13 mutants, **0 survivors**

Each mutant applied alone to a clean tree, both suites run, tree restored. An unmutated control run (14/14 and 6/6 green) was recorded first, so "killed" is attributable.

| # | mutation | killed by | failure |
|---|---|---|---|
| M1 | drop the flag from the `fetch` value **write** | sentinel + mixed-population + ledger | `expected 222 to be 1` (0xde map marker, not the sentinel) |
| M2 | drop it from `fetch`'s **mGet** | 5 behavioural + ledger | `lookupFn called 2 times` — the miss+evict loop |
| M3 | drop it from the `notFound` write | notFound test + ledger | `expected 222 to be 1` |
| M4 | drop it from `bust`'s debounce write | bust test + ledger | `expected 222 to be 1` |
| M5 | drop it from `invalidate`'s mGet | SWR-bust test + ledger | `entry was evicted — invalidate read it on the non-compress path` |
| M6 | drop it from `invalidate`'s write | SWR-bust test + ledger | `expected 222 to be 1` |
| M7 | drop it from `refresh`'s write | refresh test + ledger | `expected 222 to be 1` |
| M8 | drop it from `update`'s mGet | update test + ledger | `update() found no entry — the compressed read decoded on the wrong path` |
| M9 | drop it from `update`'s write | update test + ledger | `expected 222 to be 1` |
| M10 | accept the option but hardcode `{ compress: false }` | 8 tests | 7× sentinel + the "derived, not hardcoded" guard |
| M11 | **the seam** — `client.ts` `mGet` ignores the flag (the pre-#4588 state) | 7 tests | `lookupFn called 2 times`; `expected null to deeply equal {…}` |
| M12 | `decompressPacked` skips the sentinel branch | 7 tests | same set as M11 (same mechanism, one layer lower) |
| M13 | remove `compress: true` from `imageMetaCache` | config guard | `expected '{\n  key: REDIS_KEYS.CACHES.IMAGE_MET…' to match /compress:\s*true/` |

Two things worth stating plainly rather than leaving implicit:

- **M11 and M12 produce identical failure sets.** They are the same mechanism at two layers, so neither is independent evidence about the other.
- **A dropped flag on a WRITE site (M1, M3, M4, M6, M7, M9) is behaviourally invisible** — the value is written uncompressed and the compress-aware read decodes it fine as "legacy". Those mutants are killed *only* by the on-disk sentinel assertions and the ledger. This is exactly why the tests assert bytes rather than round-trips: a suite built on round-trips alone would have scored six survivors while reporting full coverage.

### Commands run

| command | result |
|---|---|
| `pnpm typecheck` | `OK — 0 type errors in 68s` |
| `npx vitest run --project '@civitai/redis'` | 18 files, **170 passed** |
| `pnpm test:packages:run` | 87 files, 1178 passed / **8 failed** — all in `@civitai/db-queries` `*.explain.test.ts`, which need a live Postgres; unrelated |
| `pnpm test:unit:run` | 1646 files, **38 212 passed** / 4 files failed — `apps/moderator`'s `.svelte-kit/tsconfig.json` is not generated in a fresh checkout; the identical 4 fail at `d197ecbea2` |
| `npx prettier --check` (changed files) | clean |
| `npx eslint` (changed files) | 6 pre-existing `no-explicit-any` in `caches.ts` (lines 305–649, untouched by this PR); byte-identical at `d197ecbea2` |

### Round-1 audit follow-up — `packed.mGet`'s index contract (commit `44f5a6ee74`)

An adversarial audit reproduced the 13-mutant table and the red/green matrix above exactly, and found **no blocking issue** — but it wrote six mutants of its own, and two of them survived the full package project against code *this PR adds*: the `if (packedOptions?.compress)` branch in `mGet` had no index-alignment guard.

| mutation | why it matters |
|---|---|
| `client.unlink(keys[i])` → `keys[0]` | a decode failure evicts the **first** key of the batch, not the offending one — so one undecodable entry repeatedly evicts a healthy neighbour and never evicts itself. Reachable in production: the mixed-fleet rollout described below is precisely when this path meets values it cannot decode. |
| reverse the returned array | `mGet`'s contract is positional. `createCachedArray` re-keys the batch by `idKey` immediately after the read, so it cannot observe the break — the next caller would. |

Fixed test-only, one test per branch: a **3-key batch whose MIDDLE key holds an undecodable value**, asserting the results are `[value, null, value]` *in that order* and that **exactly** the offending key was evicted. Failure in the middle means an off-by-one and a first-element collapse land on different keys; the two good values are pairwise distinct so a reversal is detectable (a reversal keeps the `null` in the middle, so only distinct outer values expose it); eviction is asserted as an exact set, so a wrong, extra, or absent eviction all fail alike. A positive control pins that the corrupt fixtures really are undecodable on their own path — a fixture that silently decoded would make both tests pass while proving nothing.

**The general (non-compress) branch is guarded too.** It is pre-existing code this PR does not modify, and the guard adds no production diff — but it carries the identical `keys[i]` shape one line below the branch that was added, so an edit to one is overwhelmingly likely to be made to both. Closing the class rather than the instance.

Each mutant was run against the **full package project**, both with and without the new guard, so the kills are attributable:

| mutant | without the guard | with the guard |
|---|---|---|
| compress, `unlink keys[0]` | **SURVIVED** 170/170 | KILLED — `only the undecodable key may be evicted` |
| compress, reversed array | **SURVIVED** 170/170 | KILLED — the order assertion |
| general, `unlink keys[0]` | **SURVIVED** 170/170 | KILLED — `only the undecodable key may be evicted` |
| general, reversed array | **SURVIVED** 170/170 | KILLED — the order assertion |

Each fails **exactly one** test, the one owning that branch, with no collateral from another assertion. Package project: 170 → **173 passing**.

### A pre-existing gap this PR does NOT close

`packed.get`'s compress branch has no client-level test, so deleting `if (packedOptions?.compress)` from **`get`** (as opposed to `mGet`) survives the suite. That is #2649's code, not this PR's, and closing it would expand the diff into unrelated territory — recorded here so it is visible rather than silently inherited.

## Not done, deliberately

- **No size threshold** — see the table above.
- **No codec or quality change.** q=6 vs q=5 measured an identical 3.09× at ~20 % more CPU on a negligible base.
- **No switch to zstd.** It would win on a clean slate (97 % of the saving for roughly a third of the CPU), but the brotli path is already sentinel-tagged and back-compat safe, and CPU is not the binding constraint. Recorded so it is not re-litigated.
- **No per-pod L1** on this cache — see above.

## One second-order effect worth naming

During the rollout window, a pod running the OLD image that reads an `image-meta` key a NEW pod already wrote compressed will fail to decode it, **evict it, and refetch from origin**. That is the documented and intended behaviour of the sentinel design (see the mixed-fleet note at the bottom of `packed-decode-paths.test.ts`) — fail-open, no corruption, no 5xx — but it does mean a transient bump in `image-meta` misses against the DB while the fleet converges, on top of the normal deploy churn. It is bounded by the deploy duration, not by the 4 h TTL.

Verifying the issue's close condition is a peak-to-peak re-measurement, which is a runtime observation and not something this PR can assert.

