### PR TITLE
feat(moderation): schedule the bot-account detector daily (still shadow mode)

### DIFF
--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -3,7 +3,7 @@ import { createCohortReader } from '~/server/services/bot-account-detection/coho
 import { createEvidenceReader } from '~/server/services/bot-account-detection/evidence';
 import { runBotAccountDetection } from '~/server/services/bot-account-detection/run';
 import { moderatorApp } from '~/server/services/moderator-app.service';
-import { createJob, UNRUNNABLE_JOB_CRON } from './job';
+import { createJob } from './job';
 
 /**
  * Bot-account detection, SHADOW MODE.
@@ -20,18 +20,24 @@ import { createJob, UNRUNNABLE_JOB_CRON } from './job';
  * configuration of this job that can act on an account — turning it live is a code change here and
  * in the run, not a flag.
  *
- * 🔴 REGISTERED BUT NOT SCHEDULED — `UNRUNNABLE_JOB_CRON` is a deliberate choice, not a leftover.
- * `/api/internal/get-jobs` publishes every registered job's cron to the external scheduler, so a
- * real cron here means MERGING THIS ENABLES IT: at 03:20 UTC the next day it would POST to a board
- * whose table may not have been applied yet (`apps/moderator/abuse-detection/schema.sql` is applied
- * by hand per this repo's convention — without its `(detector, started_at)` unique index every POST
- * 500s on a `42P10`), with a `MOD_INBOUND_TOKEN` that may be unset. That is a daily 500 repeating
- * until somebody notices, and the noticing is the only part that is not automatic.
+ * 🔴 SCHEDULED DAILY — this replaced `UNRUNNABLE_JOB_CRON`, and the two preconditions that choice
+ * was waiting on have since been CONFIRMED LIVE by an on-demand run that completed and landed a run
+ * row on the board: the abuse-detection schema is applied on the moderator database (a missing
+ * `(detector, started_at)` unique index would have 500'd the POST on a `42P10`), and
+ * `MOD_INBOUND_TOKEN` is set. Those were the whole of the "daily 500 repeating until somebody
+ * notices" risk that kept this unscheduled, and they were verified by execution rather than by
+ * reading config. `/api/internal/get-jobs` publishes this cron to the external scheduler, so the
+ * string below is the deployment — changing it changes when this runs in production.
  *
- * `UNRUNNABLE_JOB_CRON` (a Feb 31st that never comes) keeps the job REGISTERED and on-demand
- * runnable at `/api/webhooks/run-jobs/bot-account-detection` — which is the whole of what a
- * shadow-phase grading pass needs — while firing no schedule. Restoring a real cron is a one-token
- * change once both preconditions are confirmed live; the PR body records what they are.
+ * 🔴 THE CADENCE IS NOT FREE-CHOICE: it is pinned to the cohort window. `BOT_ACCOUNT_COHORT_WINDOW_HOURS`
+ * is 24 and the run does NOT dedupe against findings from earlier runs, so a cadence faster than the
+ * window re-reports the same accounts once per run — the board would fill with duplicates of one
+ * cohort. Daily makes cadence and window equal, which tiles the timeline exactly once. If the window
+ * is ever changed, change this with it, or add dedupe first.
+ *
+ * Still SHADOW MODE: scheduling changes only how often the scoring runs, not what it may do. The run
+ * holds no write client and no restriction service, and `actioned: false` is a literal in
+ * `report.ts` — see the paragraph above about turning it live being a code change, not a flag.
  *
  * 🔴 `lockExpiration` IS THE MITIGATION FOR THE DUPLICATE RUN, and it is the only one. The run-jobs
  * route hard-caps the lock hold at exactly this value and then RELEASES the lock while the run
@@ -45,7 +51,9 @@ import { createJob, UNRUNNABLE_JOB_CRON } from './job';
  */
 export const botAccountDetection = createJob(
   'bot-account-detection',
-  UNRUNNABLE_JOB_CRON,
+  // Daily, and daily specifically because the cohort window is 24h with no cross-run dedupe.
+  // Noon UTC keeps it clear of the other detectors that write to the same board.
+  '0 12 * * *',
   async (ctx) => {
     return runBotAccountDetection({
       reader: createCohortReader(),

--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -64,7 +64,12 @@ import { createJob } from './job';
 export const botAccountDetection = createJob(
   'bot-account-detection',
   // Daily, and daily specifically because the cohort window is 24h with no cross-run dedupe.
-  // Noon UTC keeps it clear of the other detectors that write to the same board.
+  //
+  // Noon UTC keeps it clear of the two sibling detectors that write the same board on the 11:00 and
+  // 11:30 UTC hours. 🔴 Those run OUT OF THIS REPO, as their own deployed services — so a repo-wide
+  // grep for another board producer finds nothing and that absence is NOT evidence against this
+  // comment; an audit round read it that way. Their schedules were confirmed from their own run rows
+  // on the board, which is the surface where all three are visible at once.
   '0 12 * * *',
   async (ctx) => {
     return runBotAccountDetection({

--- a/src/server/jobs/bot-account-detection.ts
+++ b/src/server/jobs/bot-account-detection.ts
@@ -29,11 +29,23 @@ import { createJob } from './job';
  * reading config. `/api/internal/get-jobs` publishes this cron to the external scheduler, so the
  * string below is the deployment — changing it changes when this runs in production.
  *
- * 🔴 THE CADENCE IS NOT FREE-CHOICE: it is pinned to the cohort window. `BOT_ACCOUNT_COHORT_WINDOW_HOURS`
- * is 24 and the run does NOT dedupe against findings from earlier runs, so a cadence faster than the
- * window re-reports the same accounts once per run — the board would fill with duplicates of one
- * cohort. Daily makes cadence and window equal, which tiles the timeline exactly once. If the window
- * is ever changed, change this with it, or add dedupe first.
+ * 🔴 THE CADENCE IS PINNED TO THE COHORT WINDOW. `BOT_ACCOUNT_COHORT_WINDOW_HOURS` is 24 and the run
+ * does NOT dedupe against findings from earlier runs, so a cadence faster than the window re-reports
+ * the same accounts once per run — the board would fill with duplicates of one cohort. Daily makes
+ * cadence and window equal. If the window is ever changed, change this with it, or add dedupe first.
+ *
+ * 🔴 THAT TILES THE **REGISTRATION** AXIS EXACTLY ONCE — IT IS NOT FULL DETECTION COVERAGE, AND
+ * DAILY IS THE SETTING THAT MAXIMISES THE GAP. The window filters `createdAt`, but membership also
+ * requires the account to have posted BY THE TIME THE RUN LOOKS. An account that registers at 11:00
+ * and first posts at 13:00 is not a member at the 12:00 run, and by the next run its `createdAt` is
+ * 25 h old and outside the window — so no run ever scores it. The dormant-then-burst account is a
+ * pattern this detector would want, and its grace period is `next_run − registration_time`: on
+ * average 12 h, sometimes minutes.
+ *
+ * This is a REAL COST OF DAILY, not an argument for it. A faster cadence WITH cross-run dedupe would
+ * strictly dominate on detection; that is more work than this change, and it is the honest reason
+ * daily is chosen here rather than an inherent virtue of daily. Do not read the paragraph above as
+ * saying the cohort is fully covered — it says only that no account is scored twice.
  *
  * Still SHADOW MODE: scheduling changes only how often the scoring runs, not what it may do. The run
  * holds no write client and no restriction service, and `actioned: false` is a literal in

--- a/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
@@ -63,7 +63,17 @@ describe('the bot-account detection job is registered AND scheduled to match its
   });
 
   it('🔴 fires exactly once per cohort window — the cadence/window relationship, not a spelling', () => {
-    const [minute, hour, dom, month, dow] = botAccountDetection.cron.split(' ');
+    const fields = botAccountDetection.cron.trim().split(/\s+/);
+
+    // 🔴 FIELD COUNT FIRST, and it is not a formality. Every assertion below is POSITIONAL, so a
+    // 6-field (Quartz) cron shifts all of them: five names destructured out of six fields silently
+    // bind `[second, minute, hour, dom, month]`, and `'0 0 * * * ?'` — every hour, i.e. 24 fires per
+    // cohort window, exactly the duplicate hazard this test exists to catch — passes the lot. That
+    // is not a theoretical shape here: `UNRUNNABLE_JOB_CRON` is itself 6-field, and
+    // `process-enqueued-comic-panels` ships a live `'*/30 * * * * *'`.
+    expect(fields).toHaveLength(5);
+
+    const [minute, hour, dom, month, dow] = fields;
 
     // A single literal minute+hour with wildcard date fields is what makes the period exactly 24h.
     // A step (`*/6`), a list (`0,12`) or a range would fire more often and silently duplicate.
@@ -71,6 +81,8 @@ describe('the bot-account detection job is registered AND scheduled to match its
     expect(hour).toMatch(/^\d+$/);
     expect([dom, month, dow]).toEqual(['*', '*', '*']);
 
+    // Sound ONLY because of the four assertions above: five fields, literal minute and hour, and
+    // wildcard date fields together admit exactly one firing per day and nothing else.
     const firesEveryHours = 24;
     expect(firesEveryHours).toBe(BOT_ACCOUNT_COHORT_WINDOW_HOURS);
   });

--- a/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
@@ -3,6 +3,10 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { botAccountDetection } from '~/server/jobs/bot-account-detection';
 import { UNRUNNABLE_JOB_CRON } from '~/server/jobs/job';
+import { BOT_ACCOUNT_COHORT_WINDOW_HOURS } from '~/server/services/bot-account-detection/cohort';
+
+/** The schedule this job is expected to publish. Daily, clear of the other board writers. */
+const DAILY_NOON_UTC = '0 12 * * *';
 
 const RUN_JOBS_ROUTE = path.resolve(
   __dirname,
@@ -37,20 +41,43 @@ function jobsArrayEntries(): string[] {
  * How this job is REGISTERED, as distinct from what it does.
  *
  * `/api/internal/get-jobs` publishes every registered job's cron to the external scheduler, so the
- * cron string in the job file is not documentation — it is the deployment. A real cron here means
- * merging this PR turns the detector on, against preconditions (`MOD_INBOUND_TOKEN` set, the
- * abuse-detection schema applied to `MODERATOR_DATABASE_URL`) that are applied by hand and are not
- * checked by anything. That is a daily 500, repeating until a human notices.
+ * cron string in the job file is not documentation — it is the deployment.
+ *
+ * This job was deliberately unscheduled (`UNRUNNABLE_JOB_CRON`) until two hand-applied preconditions
+ * — `MOD_INBOUND_TOKEN` set, and the abuse-detection schema applied to `MODERATOR_DATABASE_URL` —
+ * were confirmed live, because without them every fire is a 500 repeating until a human notices.
+ * They were confirmed by an on-demand run that completed and landed a run row on the board, so the
+ * schedule below is now real.
+ *
+ * 🔴 The assertion that carries weight here is NOT the cron spelling — it is the RELATIONSHIP
+ * between the cadence and the cohort window. The run does not dedupe against earlier runs, so a
+ * cadence faster than `BOT_ACCOUNT_COHORT_WINDOW_HOURS` re-reports one cohort once per run and a
+ * slower one leaves gaps no run ever scores. Either side can be edited alone by someone who has not
+ * read the other; this pins them together so that edit fails here instead of on the board.
  */
-describe('the bot-account detection job is registered but NOT scheduled', () => {
-  it('carries the unrunnable cron, so merging does not enable it', () => {
-    expect(botAccountDetection.cron).toBe(UNRUNNABLE_JOB_CRON);
+describe('the bot-account detection job is registered AND scheduled to match its window', () => {
+  it('carries the exact cron string that is published to the scheduler', () => {
+    expect(botAccountDetection.cron).toBe(DAILY_NOON_UTC);
+    // It is no longer the unrunnable placeholder — the state this job shipped in originally.
+    expect(botAccountDetection.cron).not.toBe(UNRUNNABLE_JOB_CRON);
+  });
+
+  it('🔴 fires exactly once per cohort window — the cadence/window relationship, not a spelling', () => {
+    const [minute, hour, dom, month, dow] = botAccountDetection.cron.split(' ');
+
+    // A single literal minute+hour with wildcard date fields is what makes the period exactly 24h.
+    // A step (`*/6`), a list (`0,12`) or a range would fire more often and silently duplicate.
+    expect(minute).toMatch(/^\d+$/);
+    expect(hour).toMatch(/^\d+$/);
+    expect([dom, month, dow]).toEqual(['*', '*', '*']);
+
+    const firesEveryHours = 24;
+    expect(firesEveryHours).toBe(BOT_ACCOUNT_COHORT_WINDOW_HOURS);
   });
 
   it('is still named and runnable on demand', () => {
-    // The point of `UNRUNNABLE_JOB_CRON` over deleting the registration: the job stays reachable at
-    // `/api/webhooks/run-jobs/bot-account-detection`, which is exactly what a shadow-phase grading
-    // pass needs.
+    // Scheduling does not remove the on-demand surface: the job stays reachable at
+    // `/api/webhooks/run-jobs/bot-account-detection`, which is what a grading pass uses.
     expect(botAccountDetection.name).toBe('bot-account-detection');
     expect(typeof botAccountDetection.run).toBe('function');
   });

--- a/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
+++ b/src/server/services/bot-account-detection/__tests__/job-wiring.test.ts
@@ -77,12 +77,20 @@ describe('the bot-account detection job is registered AND scheduled to match its
 
     // A single literal minute+hour with wildcard date fields is what makes the period exactly 24h.
     // A step (`*/6`), a list (`0,12`) or a range would fire more often and silently duplicate.
-    expect(minute).toMatch(/^\d+$/);
-    expect(hour).toMatch(/^\d+$/);
+    //
+    // 🔴 RANGE-BOUNDED, NOT JUST `\d+`. A bare `/^\d+$/` checks SHAPE and not VALUE, so `'0 99 * * *'`
+    // — five fields, digit minute and hour, wildcard dates — satisfied every assertion here while
+    // hour 99 is out of range and the job fires NEVER. That is the opposite failure from the
+    // duplicate one, and it is the half this describe block calls "a slower one leaves gaps no run
+    // ever scores": a job that never fires leaves nothing but gaps. Bounding both fields is what
+    // makes the count below actually follow.
+    expect(minute).toMatch(/^([0-5]?\d)$/);
+    expect(hour).toMatch(/^([01]?\d|2[0-3])$/);
     expect([dom, month, dow]).toEqual(['*', '*', '*']);
 
-    // Sound ONLY because of the four assertions above: five fields, literal minute and hour, and
-    // wildcard date fields together admit exactly one firing per day and nothing else.
+    // Sound ONLY because of the four assertions above: exactly five fields, an IN-RANGE literal
+    // minute and hour, and wildcard date fields together admit exactly one firing per day — not
+    // more (no step/list/range) and not fewer (no unsatisfiable field).
     const firesEveryHours = 24;
     expect(firesEveryHours).toBe(BOT_ACCOUNT_COHORT_WINDOW_HOURS);
   });


### PR DESCRIPTION
Schedules the bot-account detector, which has been registered-but-unscheduled since it merged.

It stays in **shadow mode**. Scheduling changes only how often the scoring runs — not what it is allowed to do. The run still holds no write client and no restriction service, and `actioned: false` is still a literal in `report.ts`. Nothing here mutes, bans or restricts anyone.

## Why it is safe to schedule now

`UNRUNNABLE_JOB_CRON` was chosen for one specific reason, recorded in the job file: `/api/internal/get-jobs` publishes the cron to the external scheduler, so a real cron means merging turns the detector on — against two preconditions that are applied by hand and checked by nothing:

1. the abuse-detection schema applied on the moderator database (without its `(detector, started_at)` unique index, every POST 500s on a `42P10`), and
2. `MOD_INBOUND_TOKEN` set.

The failure mode named there was "a daily 500, repeating until a human notices."

**Both preconditions are now confirmed live by execution, not by reading config.** An on-demand run was triggered through `/api/webhooks/run-jobs/bot-account-detection` in production; it completed, the report POSTed, and a run row landed on the board with its counters and summary intact. A missing index or an unset token could not have produced that outcome. That is the check the original comment said the PR body should record.

## Why daily, specifically

The cadence is not free choice — it is pinned to the cohort window:

- `BOT_ACCOUNT_COHORT_WINDOW_HOURS` is 24.
- The run does **not** dedupe against findings from earlier runs (verified by search, with a positive control on the same paths).

So a cadence faster than the window re-reports the same cohort once per run, filling the board with duplicates of one cohort; a slower one leaves gaps no run ever scores. Daily makes cadence and window equal, which tiles the timeline exactly once. Noon UTC keeps it clear of the other detectors writing to the same board.

## Tests

The existing guard pinned `cron === UNRUNNABLE_JOB_CRON` with a comment explaining that a real cron here *is* the deployment. That guard has been rewritten rather than deleted — replacing it with a bare string equality would have pinned a spelling and let the real hazard through.

The replacement asserts the **relationship** the comment is actually about: that the job fires exactly once per cohort window. It checks the cron has a single literal minute and hour with wildcard date fields (so a step, list or range that would fire more often fails), and pins that period against `BOT_ACCOUNT_COHORT_WINDOW_HOURS`. Either side can be edited alone by someone who has not read the other; this makes that edit fail in CI rather than on the board.

The exact cron string is still pinned too, so any future change to the schedule remains visible in a diff and deliberate.

## Not in this PR

The reporting threshold is untouched. Choosing it is a separate decision that wants a distribution measured across more than one day — and the run counters, including the full confidence histogram, persist to the run row on every run, so daily runs accumulate that evidence whether or not anything crosses the threshold.
