### PR TITLE
feat(apps): record a TRUSTED play event for on-site app launches (1/4)

### DIFF
--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -14,6 +14,7 @@ import { dbRead } from '~/server/db/client';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import { readListingBetaBySlugForRender } from '~/server/services/blocks/app-listing-beta.service';
 import { readListingIconBySlugForRender } from '~/server/services/blocks/app-listing-icon.service';
+import { recordAppListingOpen } from '~/server/services/blocks/app-listing-open.service';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { ratingAllowedOnHost } from '~/server/utils/server-domain';
 import { Page } from '~/components/AppLayout/Page';
@@ -81,7 +82,7 @@ interface PageProps {
 
 export const getServerSideProps = createServerSideProps<PageProps>({
   useSession: true,
-  resolver: async ({ features, ctx }) => {
+  resolver: async ({ features, ctx, session }) => {
     // GATE FIRST, fail-closed. Both flags required. A viewer without them gets
     // a 404 — the page is invisible/un-enumerable until W10 launch widens the
     // `app-blocks-pages-enabled` segment.
@@ -140,6 +141,24 @@ export const getServerSideProps = createServerSideProps<PageProps>({
     if (!ratingAllowedOnHost(page.contentRating, host)) {
       return { notFound: true };
     }
+
+    // ── RECORD THE PLAY ────────────────────────────────────────────────────────
+    // 🔴 AFTER EVERY FAIL-CLOSED GATE, DELIBERATELY. A launch that 404s — flags off,
+    // no such approved page app, or a mature app on a non-red host — is not a play,
+    // and recording before these returns would make the count include requests that
+    // never rendered an app. This is the first line that can only be reached by a
+    // launch that actually succeeds.
+    //
+    // 🔴 NOT AWAITED, and the `void` is load-bearing rather than stylistic: this is the
+    // app-launch critical path that the whole `Promise.all` above exists to keep short,
+    // so a ClickHouse insert must never sit in front of the page. `recordAppListingOpen`
+    // swallows its own errors for the same reason — see its docstring.
+    // `?? null` is an assertion, not a shrug: this route is `useSession: true`, so
+    // `createServerSideProps` has already resolved the session before calling this
+    // resolver — the `undefined` is only in the type. Passing an explicit `null` tells the
+    // Tracker "known anonymous" so it skips a second JWE decrypt, which is precisely the
+    // anonymous case its constructor note calls out.
+    void recordAppListingOpen({ appBlockId: page.appBlockId, session: session ?? null, ctx });
 
     return {
       props: {

--- a/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
@@ -60,10 +60,16 @@ describe('actions.type enum drift', () => {
   const actionsBlocks = enumBlocks.filter((b) => b.table === 'default.actions');
   const actionsBlock = actionsBlocks[actionsBlocks.length - 1];
 
-  // The prod indices this guard was written against (SHOW CREATE TABLE actions,
-  // 2026-08-21). These predate the migrations directory, so no file here introduces them
-  // — but any migration that RESTATES the column must reproduce them exactly, because a
+  // The indices every migration that RESTATES this column must reproduce exactly, because a
   // MODIFY COLUMN is a replacement.
+  //
+  // ⚠️ 1-21 are the prod indices this guard was originally written against (SHOW CREATE
+  // TABLE actions, 2026-08-21) and predate the migrations directory, so no file there
+  // introduces them. 🔴 THAT IS NO LONGER TRUE OF THE WHOLE MAP: 22-25 were added on
+  // 2026-09-05 and ARE introduced by files in that directory (see the block below). The
+  // original sentence said it of every entry, which the four new ones falsify — it is split
+  // rather than deleted because the 1-21 half is still the reason those indices cannot be
+  // re-derived from any file here.
   //
   // 🔴 Do not add a name here to silence a failing case. That is the one-line bypass of
   // this whole guard, and it produces exactly the "looks instrumented, writes no rows"

--- a/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
+++ b/src/server/clickhouse/__tests__/action-type-enum-drift.test.ts
@@ -90,13 +90,38 @@ describe('actions.type enum drift', () => {
     ['Image_Remix_Click', 19],
     ['Generator_Submit', 20],
     ['Generator_JobLinked', 21],
+    // 🔴 22-25 ADDED 2026-09-05, AND THIS IS A WIDENING OF THE GUARD, NOT AN EXEMPTION —
+    // read the warning above before assuming otherwise. Every name below is already
+    // carried by an APPLIED migration at exactly this index (`Feed_TagBar_Click` by
+    // 2026-08-21-feed-tag-bar-action.sql, the three announcement values by
+    // 2026-09-04-announcement-click-action.sql). Listing them here makes the
+    // "restates every pre-existing value at the index it already has" case cover them;
+    // it does NOT exempt anything from needing a migration, because the `it.each` below
+    // is driven by `ActionType` and skips only names present in this map — and each of
+    // these four is in a migration already.
+    //
+    // WHY IT MATTERED: before this, values past 21 were checked for NAME PRESENCE only.
+    // Measured — editing a migration to `'Announcement_Unmute' = 30` passed 10/10, i.e.
+    // the one destructive class the migrations' own headers forbid ("Do NOT renumber…
+    // that WOULD rewrite the whole table") was unguarded, and every value added after
+    // the baseline enlarged the blind set. Positive control from the same measurement:
+    // dropping `'ProfanitySearch' = 16` correctly reds, so the mechanism itself works.
+    ['Feed_TagBar_Click', 22],
+    ['Announcement_Click', 23],
+    ['Announcement_Mute', 24],
+    ['Announcement_Unmute', 25],
   ]);
 
   it('freezes the pre-existing baseline', () => {
     // Growing this map is how a new type gets exempted without a migration, so the size
     // is pinned. If prod legitimately gains a value outside these migrations, update it
     // deliberately and say why.
-    expect(PRE_EXISTING.size).toBe(21);
+    //
+    // 21 -> 25 on 2026-09-05: the four values above were moved from "name checked, index
+    // unchecked" into the index-pinned set. The number is a tripwire on THIS list, so it
+    // moves with it; what must never happen is a name being added here INSTEAD of to a
+    // migration.
+    expect(PRE_EXISTING.size).toBe(25);
   });
 
   it('found an ALTER on default.actions to scan', () => {

--- a/src/server/clickhouse/migrations/2026-09-05-app-open-action.sql
+++ b/src/server/clickhouse/migrations/2026-09-05-app-open-action.sql
@@ -1,0 +1,73 @@
+-- App store play count — ClickHouse DDL (on-site app launches).
+--
+-- Apply this MANUALLY, BEFORE the app code that emits `App_Open` is deployed. We do not
+-- auto-run DDL (same policy as the Postgres migrations).
+--
+-- 🔴 ORDER IS LOAD-BEARING AND THE FAILURE IS SILENT. `actions.type` is an Enum16. The app
+-- POSTs to the tracker service, which inserts; a value the column does not carry is rejected
+-- THERE, so the caller sees a successful send, the app logs nothing, and the row simply never
+-- exists. The store card's play count would then read a permanent zero that is
+-- indistinguishable from "nobody opened this app" — and unlike a chart nobody reads, that
+-- zero is printed on a public marketplace card next to the review count.
+--
+-- 25 is the last index in use ('Announcement_Unmute'), so this appends at 26. Appending at an
+-- unused index is a metadata-only ALTER: no data is rewritten and no mutation is scheduled. Do
+-- NOT renumber or rename any existing value; that WOULD rewrite the whole table.
+--
+-- `actions` still has no dependent materialized view (asserted by the same reasoning as
+-- 2026-09-04-announcement-click-action.sql, which re-verified it against `system.tables`;
+-- 🔴 RE-VERIFY BEFORE APPLYING rather than trusting this line — an MV added since would put a
+-- MODIFY QUERY obligation on this widening). This change deliberately does not add one: the
+-- rollup that consumes these rows is the `AppListing` metric processor, which queries
+-- `actions` directly on the same batched schedule as every other ClickHouse-derived counter.
+--
+-- WHY `actions` RATHER THAN A NEW TABLE: a play is a low-volume, id-only interaction, and
+-- `actions` already carries the actor columns (userId/ip/userAgent) plus no TTL — so the rows
+-- outlive the rollup that reads them, which is what makes `open_count` RECOMPUTABLE rather
+-- than a ±1 counter that can drift with nothing to repair it from. That property is the
+-- reason this arc uses an event stream at all; see the ownership contract in
+-- src/server/metrics/appListing.metrics.ts.
+--
+-- The emitted `details` carries `{ appBlockId }` — a pure id, never author text — and the
+-- rollup joins it to `app_listings.app_block_id` (which is `@unique`).
+
+ALTER TABLE default.actions
+  MODIFY COLUMN `type` Enum16(
+    'AddToBounty_Click' = 1,
+    'AddToBounty_Confirm' = 2,
+    'AwardBounty_Click' = 3,
+    'AwardBounty_Confirm' = 4,
+    'Tip_Click' = 5,
+    'Tip_Confirm' = 6,
+    'TipInteractive_Click' = 7,
+    'TipInteractive_Cancel' = 8,
+    'NotEnoughFunds' = 9,
+    'PurchaseFunds_Cancel' = 10,
+    'PurchaseFunds_Confirm' = 11,
+    'LoginRedirect' = 12,
+    'Membership_Cancel' = 13,
+    'CSAM_Help_Triggered' = 14,
+    'Membership_Downgrade' = 15,
+    'ProfanitySearch' = 16,
+    'BuzzLimit_Set' = 17,
+    'Model_Create_Click' = 18,
+    'Image_Remix_Click' = 19,
+    'Generator_Submit' = 20,
+    'Generator_JobLinked' = 21,
+    'Feed_TagBar_Click' = 22,
+    'Announcement_Click' = 23,
+    'Announcement_Mute' = 24,
+    'Announcement_Unmute' = 25,
+    'App_Open' = 26
+  );
+
+-- Verification, AFTER applying (the widening is metadata-only, so this returns immediately):
+--
+--   SHOW CREATE TABLE default.actions;
+--     -- must show 'App_Open' = 26, and every value 1..25 unchanged.
+--
+-- Positive control once the app is deployed — open an on-site app at /apps/run/<slug>, then:
+--
+--   SELECT count() FROM default.actions WHERE type = 'App_Open' AND time > now() - INTERVAL 1 HOUR;
+--     -- must be non-zero. A zero here after a real launch means the emitter is not wired,
+--     -- NOT that the enum is missing: this file is what rules the enum out.

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -177,6 +177,18 @@ export const ActionType = [
   'Announcement_Click',
   'Announcement_Mute',
   'Announcement_Unmute',
+  // App store "plays" — one row per on-site app LAUNCH, emitted from the
+  // `/apps/run/<slug>` SSR resolver. Same Enum16 hazard as the two blocks above: the
+  // widening migration (src/server/clickhouse/migrations/2026-09-05-app-open-action.sql)
+  // must be applied to prod BEFORE this deploys, or the store's play count reads a
+  // permanent zero that looks exactly like "nobody opened it".
+  //
+  // 🔴 SERVER-ONLY, AND THAT IS THE WHOLE POINT OF THE TYPE. It is deliberately absent
+  // from `trackActionSchema` (see the note there), following `BuzzLimit_Set` and the
+  // announcement mute pair: that schema is what `/api/track/batch` accepts from a
+  // browser, so a client arm would let anyone inflate any app's play count by POSTing.
+  // A number printed on a public store card has to be one a script cannot manufacture.
+  'App_Open',
 ] as const;
 export type ActionType = (typeof ActionType)[number];
 

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -50,15 +50,17 @@ const BATCH_SIZE = 200;
 // `/apps/run/<slug>` SSR resolver started emitting a trusted `App_Open` action per
 // on-site launch (`app-listing-open.service.ts`). The rows are an EVENT STREAM in
 // ClickHouse `actions`, deliberately, so this counter stays recomputable rather than
-// becoming a second no-recompute denormalization like the thumbs pair below.
+// becoming a second no-recompute denormalization like the thumbs pair described in the
+// OWNERSHIP CONTRACT paragraph above.
 // Two obligations for whoever writes that rollup:
 //   1. 🔴 DEDUPE AT READ TIME. The emit is triggered by an unauthenticated GET on an
 //      optional catch-all route with no rate limit, so the raw row count is inflatable
 //      by a refresh loop, a crawler or a link unfurler. Collapse per `userId` (falling
 //      back to `ip`) over a window; the actor columns are kept for exactly this.
-//   2. Add `open_count` to the ON CONFLICT list below when — and only when — you do,
-//      keeping `thumbs_*` out of it. The ownership contract in
-//      `app-listing-review.service.ts` cuts both ways.
+//   2. Add `open_count` to the ON CONFLICT list when — and only when — you do, keeping
+//      `thumbs_*` out of it. That list is NOT in this file: it is
+//      `APP_LISTING_METRIC_UPSERT_SQL` in `appListing.metrics.sql.ts`. The ownership
+//      contract in `app-listing-review.service.ts` cuts both ways.
 // OFF-SITE listings have no trustworthy source at all (their CTA is a third-party
 // anchor), so their count is structurally absent, not zero — do not render it as 0.
 // ---------------------------------------------------------------------------

--- a/src/server/metrics/appListing.metrics.ts
+++ b/src/server/metrics/appListing.metrics.ts
@@ -41,10 +41,26 @@ const BATCH_SIZE = 200;
 // to a feature that isn't live): `connect_count` (off-site OAuth-connect grants —
 // OAuth-connect submission is a locked-deferred product decision, so there are no
 // connect listings yet and nothing reads the count), `open_count`, `visit_count`,
-// `tipped_count`, `tipped_amount_count` (open/visit are never recorded
-// server-side; AppListing is not a BuzzTip entity — BuzzTip.entityId is Int,
-// AppListing.id is a string ULID). Populate each with the PR that ships its
-// consumer, not speculatively.
+// `tipped_count`, `tipped_amount_count` (AppListing is not a BuzzTip entity —
+// BuzzTip.entityId is Int, AppListing.id is a string ULID). Populate each with the
+// PR that ships its consumer, not speculatively.
+//
+// 🔴 `open_count` IS THE NEXT ONE, AND ITS SOURCE ROWS NOW EXIST. This paragraph used
+// to say "open/visit are never recorded server-side"; that stopped being true when the
+// `/apps/run/<slug>` SSR resolver started emitting a trusted `App_Open` action per
+// on-site launch (`app-listing-open.service.ts`). The rows are an EVENT STREAM in
+// ClickHouse `actions`, deliberately, so this counter stays recomputable rather than
+// becoming a second no-recompute denormalization like the thumbs pair below.
+// Two obligations for whoever writes that rollup:
+//   1. 🔴 DEDUPE AT READ TIME. The emit is triggered by an unauthenticated GET on an
+//      optional catch-all route with no rate limit, so the raw row count is inflatable
+//      by a refresh loop, a crawler or a link unfurler. Collapse per `userId` (falling
+//      back to `ip`) over a window; the actor columns are kept for exactly this.
+//   2. Add `open_count` to the ON CONFLICT list below when — and only when — you do,
+//      keeping `thumbs_*` out of it. The ownership contract in
+//      `app-listing-review.service.ts` cuts both ways.
+// OFF-SITE listings have no trustworthy source at all (their CTA is a third-party
+// anchor), so their count is structurally absent, not zero — do not render it as 0.
 // ---------------------------------------------------------------------------
 
 export const appListingMetrics = createMetricProcessor({

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -678,7 +678,10 @@ const announcementClickSchema = z.object({
 //
 // Emitted SERVER-SIDE from the tRPC mutation, not from the browser: unlike the impression
 // beacon this number cannot be inflated by a script posting to /api/track/batch.
-// App store play count — the `App_Open` half.
+
+// App store play count — the `App_Open` half. (Blank line above is load-bearing: without
+// it this block reads as a continuation of the mute pair's rationale directly overhead,
+// and the play-count reasoning attaches to the wrong schemas.)
 //
 // 🔴 DELIBERATELY ABSENT FROM `trackActionSchema`, for the same reason as the mute pair
 // above and `BuzzLimit_Set` before it: this schema is what `/api/track/batch` accepts from

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -678,6 +678,19 @@ const announcementClickSchema = z.object({
 //
 // Emitted SERVER-SIDE from the tRPC mutation, not from the browser: unlike the impression
 // beacon this number cannot be inflated by a script posting to /api/track/batch.
+// App store play count — the `App_Open` half.
+//
+// 🔴 DELIBERATELY ABSENT FROM `trackActionSchema`, for the same reason as the mute pair
+// above and `BuzzLimit_Set` before it: this schema is what `/api/track/batch` accepts from
+// a browser, so an arm here would let anyone inflate ANY app's play count by POSTing —
+// and unlike a chart in an admin page, that number is printed on a public marketplace card
+// next to the review count. It is emitted SERVER-SIDE only, from the `/apps/run/<slug>`
+// SSR resolver (`recordAppListingOpen`), i.e. from a request this server actually served
+// after the flag gate, the approved-app resolution and the host rating check all passed.
+//
+// The containment direction in `action-type-enum-drift.test.ts` is what keeps this true in
+// one direction (every arm here must be an `ActionType`); the reverse is deliberately not
+// asserted, which is exactly what lets a server-only type exist.
 export const TRACK_BATCH_MAX = 100;
 
 export type TrackActionInput = z.infer<typeof trackActionSchema>;

--- a/src/server/services/blocks/__tests__/app-listing-open.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-open.service.test.ts
@@ -17,12 +17,27 @@ import { trackActionSchema } from '~/server/schema/track.schema';
  * bottom, against the real schema rather than against this module.
  */
 
-const { mockAction } = vi.hoisted(() => ({
+const { mockAction, mockCtor } = vi.hoisted(() => ({
   mockAction: vi.fn<(...a: any[]) => Promise<boolean>>(),
+  // 🔴 A SEPARATE CONSTRUCTOR SPY, AND IT IS NOT DECORATION. With `class { action = … }`
+  // the constructor is empty and can never throw, so the "constructing the tracker throws"
+  // case below was asserted by nothing — its throw came from `action`, the same call site
+  // the async-rejection case already used. Measured: hoisting `new Tracker(…)` out of the
+  // `try` (a plausible tidy-up) left all 13 tests green while a real constructor throw
+  // would escape an un-awaited call, which on Node's default `--unhandled-rejections=throw`
+  // exits the process on the app-launch path.
+  //
+  // It also records its ARGUMENTS, which nothing pinned either: deleting the third
+  // (`session`) argument passed 42/42, silently reinstating the second `getServerAuthSession`
+  // round trip on the critical path that the resolver's comment claims to avoid.
+  mockCtor: vi.fn<(...a: any[]) => void>(),
 }));
 
 vi.mock('~/server/clickhouse/client', () => ({
   Tracker: class {
+    constructor(...args: any[]) {
+      mockCtor(...args);
+    }
     action = mockAction;
   },
 }));
@@ -36,6 +51,7 @@ describe('recordAppListingOpen', () => {
   beforeEach(() => {
     mockAction.mockReset();
     mockAction.mockResolvedValue(true);
+    mockCtor.mockReset();
   });
 
   it('emits one App_Open carrying the block id', async () => {
@@ -72,10 +88,10 @@ describe('recordAppListingOpen', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('RESOLVES when constructing the tracker throws', async () => {
-    // The other half of the same property: the throw can come from the constructor (a
-    // malformed req) rather than from the send, and a try/catch wrapped around only the
-    // await would miss it.
+  it('RESOLVES when the tracker throws SYNCHRONOUSLY from action()', async () => {
+    // A sync throw takes a different path out of an `async` function than a rejected
+    // promise, so both arms are needed: a `.catch()` chained onto the send would handle the
+    // rejection and miss this one.
     mockAction.mockImplementation(() => {
       throw new Error('sync boom');
     });
@@ -83,6 +99,32 @@ describe('recordAppListingOpen', () => {
     await expect(
       recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX })
     ).resolves.toBeUndefined();
+  });
+
+  it('RESOLVES when the tracker CONSTRUCTOR throws', async () => {
+    // 🔴 THE CASE THAT USED TO BE VACUOUS. The construction must be INSIDE the try — moving
+    // `new Tracker(…)` above it is a plausible refactor that reds nothing without this, and
+    // it would let a constructor throw escape an un-awaited call, which Node's default
+    // `--unhandled-rejections=throw` turns into a process exit on the app-launch path.
+    mockCtor.mockImplementation(() => {
+      throw new Error('ctor boom');
+    });
+
+    await expect(
+      recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX })
+    ).resolves.toBeUndefined();
+    expect(mockAction).not.toHaveBeenCalled();
+  });
+
+  it('hands the Tracker the request, response AND the resolved session', async () => {
+    // 🔴 THE THIRD ARGUMENT IS THE POINT. Omitting `session` leaves `sessionResolved` false,
+    // so `Tracker.send` re-runs `getServerAuthSession` — a full JWE decrypt — on every
+    // launch, which is exactly the cost the resolver's comment claims to avoid. Nothing
+    // pinned it before: deleting the argument passed the whole suite.
+    await recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX });
+
+    expect(mockCtor).toHaveBeenCalledTimes(1);
+    expect(mockCtor).toHaveBeenCalledWith(CTX.req, CTX.res, null);
   });
 
   it('App_Open is a real ActionType but has NO trackActionSchema arm', async () => {

--- a/src/server/services/blocks/__tests__/app-listing-open.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-open.service.test.ts
@@ -127,6 +127,24 @@ describe('recordAppListingOpen', () => {
     expect(mockCtor).toHaveBeenCalledWith(CTX.req, CTX.res, null);
   });
 
+  it('FORWARDS a non-null session rather than a hardcoded null', async () => {
+    // 🔴 THE ANONYMOUS CASE ABOVE CANNOT SEE A SUBSTITUTION, ONLY AN OMISSION. Its fixture
+    // passes `null` and its assertion names the literal `null`, so a call site rewritten to
+    // `new Tracker(req, res, null)` produces exactly the value the assertion expects —
+    // measured surviving 21/21 before this test existed. The control is mechanical: feed a
+    // value the constant CANNOT equal and watch the argument move.
+    //
+    // What the substitution would cost is not cosmetic: `Tracker`'s constructor sets
+    // `sessionResolved = true` for a `null` too, so it never learns the user — every
+    // App_Open row for a logged-in launch is written anonymous, and the read-time dedup the
+    // service docstring is built on ("collapse per userId, falling back to ip") silently
+    // degrades to IP-only, merging everyone behind one office egress into a single play.
+    const session = { user: { id: 7 } } as any;
+    await recordAppListingOpen({ appBlockId: 'ab_42', session, ctx: CTX });
+
+    expect(mockCtor).toHaveBeenCalledWith(CTX.req, CTX.res, session);
+  });
+
   it('App_Open is a real ActionType but has NO trackActionSchema arm', async () => {
     // 🔴 THE TRUSTED PROPERTY, and the one most likely to be undone by a well-meaning
     // "you forgot to add the schema arm" PR. `trackActionSchema` is what

--- a/src/server/services/blocks/__tests__/app-listing-open.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-open.service.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ActionType } from '~/server/clickhouse/tracker';
+import { trackActionSchema } from '~/server/schema/track.schema';
+
+/**
+ * `recordAppListingOpen` — the ONLY writer of the store's play count.
+ *
+ * Two properties are pinned here, and they fail in opposite directions:
+ *
+ *   1. it emits the right row (`App_Open`, carrying the block id and nothing else);
+ *   2. it NEVER throws — a tracker outage must cost a slightly low number, not an app
+ *      launch. The route calls it un-awaited, so a rejection here would surface as an
+ *      unhandled rejection on the launch path rather than as anything a user could act on.
+ *
+ * The third property — that a browser cannot forge one of these rows — is asserted at the
+ * bottom, against the real schema rather than against this module.
+ */
+
+const { mockAction } = vi.hoisted(() => ({
+  mockAction: vi.fn<(...a: any[]) => Promise<boolean>>(),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  Tracker: class {
+    action = mockAction;
+  },
+}));
+
+// Imported AFTER the mock is declared (vi.mock is hoisted, so this is the mocked Tracker).
+const { recordAppListingOpen } = await import('~/server/services/blocks/app-listing-open.service');
+
+const CTX = { req: { headers: {} }, res: {} } as any;
+
+describe('recordAppListingOpen', () => {
+  beforeEach(() => {
+    mockAction.mockReset();
+    mockAction.mockResolvedValue(true);
+  });
+
+  it('emits one App_Open carrying the block id', async () => {
+    await recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX });
+
+    expect(mockAction).toHaveBeenCalledTimes(1);
+    expect(mockAction).toHaveBeenCalledWith({ type: 'App_Open', details: { appBlockId: 'ab_42' } });
+  });
+
+  it('puts NOTHING but ids in details — the column never carries author text', async () => {
+    // `details` is a String column on a table with no TTL, so anything author-supplied that
+    // reaches it outlives the listing it came from. The block id is a generated id; there is
+    // no name, slug, tagline or URL in this payload, and this asserts the whole shape rather
+    // than the presence of one key.
+    await recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX });
+
+    const details = mockAction.mock.calls[0][0].details;
+    expect(Object.keys(details)).toEqual(['appBlockId']);
+  });
+
+  it('does not use skipActorMeta — a play is an interaction, not a private judgement', async () => {
+    // Dropping ip/userAgent here would also drop the only signal the rollup can use to
+    // collapse a refresh loop into one play, so the absence of that option is deliberate.
+    await recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX });
+
+    expect(mockAction.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it('RESOLVES when the tracker rejects — a dead ClickHouse is not a failed launch', async () => {
+    mockAction.mockRejectedValue(new Error('clickhouse unreachable'));
+
+    await expect(
+      recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX })
+    ).resolves.toBeUndefined();
+  });
+
+  it('RESOLVES when constructing the tracker throws', async () => {
+    // The other half of the same property: the throw can come from the constructor (a
+    // malformed req) rather than from the send, and a try/catch wrapped around only the
+    // await would miss it.
+    mockAction.mockImplementation(() => {
+      throw new Error('sync boom');
+    });
+
+    await expect(
+      recordAppListingOpen({ appBlockId: 'ab_42', session: null, ctx: CTX })
+    ).resolves.toBeUndefined();
+  });
+
+  it('App_Open is a real ActionType but has NO trackActionSchema arm', async () => {
+    // 🔴 THE TRUSTED PROPERTY, and the one most likely to be undone by a well-meaning
+    // "you forgot to add the schema arm" PR. `trackActionSchema` is what
+    // `/api/track/batch` accepts from a browser; an arm here would let anyone POST plays
+    // for any app, and this number is printed on a public store card.
+    expect(ActionType).toContain('App_Open');
+
+    const schemaTypes = trackActionSchema.options.map(
+      (option: any) => option.shape.type.value as string
+    );
+    expect(schemaTypes).not.toContain('App_Open');
+  });
+});

--- a/src/server/services/blocks/app-listing-open.service.ts
+++ b/src/server/services/blocks/app-listing-open.service.ts
@@ -7,13 +7,38 @@ import type { Session } from '~/types/session';
 /**
  * App store PLAY recording — one `App_Open` row per on-site app launch.
  *
- * 🔴 WHY THIS IS A SERVER-SIDE EMIT AND NOT A BEACON, WHICH IS THE WHOLE POINT OF THE
- * NUMBER. The count it feeds is printed on a PUBLIC store card next to the review count,
- * so it has to be one a script cannot manufacture. `App_Open` is therefore deliberately
- * absent from `trackActionSchema` — the schema `/api/track/batch` accepts from a browser —
- * following `BuzzLimit_Set` and the announcement mute pair. The only writer is this
- * function, called from the `/apps/run/<slug>` SSR resolver, i.e. from a request the
- * server itself served after the flag gate and the approved-app resolution both passed.
+ * 🔴 WHY THIS IS A SERVER-SIDE EMIT AND NOT A BEACON. The count it feeds is printed on a
+ * PUBLIC store card next to the review count, so it has to be one a script cannot cheaply
+ * manufacture. `App_Open` is therefore deliberately absent from `trackActionSchema` — the
+ * schema `/api/track/batch` accepts from a browser — following `BuzzLimit_Set` and the
+ * announcement mute pair. The only writer is this function, called from the
+ * `/apps/run/<slug>` SSR resolver, i.e. from a request the server itself served after the
+ * flag gate and the approved-app resolution both passed.
+ *
+ * 🔴 THAT CLOSES THE POST CHANNEL, NOT THE WHOLE PROBLEM — AND THE DIFFERENCE IS STAGE 2'S
+ * TO CLOSE, NOT THIS FILE'S. The write is still triggered by a plain, unauthenticated
+ * `GET /apps/run/<slug>`, and:
+ *   - the route is an optional catch-all, so `/apps/run/<slug>/1`, `/2`, … are distinct
+ *     URLs that each record a play for the same app — no CDN cache, no URL-level dedup;
+ *   - there is no per-route rate limit, and `robots.txt` does not disallow `/apps/run/*`,
+ *     so a crawler or a chat-client link unfurler records a play per fetch (the page's
+ *     `deIndex` only takes effect AFTER the fetch that reads it);
+ *   - nothing dedups at write time.
+ * Today this is contained because both `appBlocks` and `appBlocksPages` are moderator-only,
+ * so the reachable population is tiny. It stops being contained the moment those flags
+ * widen — which is the plan.
+ * 🔴 **SO STAGE 2 MUST DEDUPE AT READ TIME; the counter is not honest without it.** Actor
+ * metadata is kept below precisely so it can (collapse per `userId`, falling back to `ip`,
+ * over a window). If you are writing the rollup and this paragraph is still here, that
+ * obligation is still open.
+ *
+ * 🔴 RECOMPUTABILITY HAS ONE HOLE, NAMED RATHER THAN LEFT TO BE DISCOVERED. These rows are
+ * an event stream so `open_count` can always be recomputed — that is why this arc does not
+ * use a `+1` counter. But the recompute joins `details.appBlockId` to
+ * `AppListing.appBlockId`, and that relation is `onDelete: SetNull`: deleting an `AppBlock`
+ * nulls the listing's `app_block_id` and every historical row for it becomes permanently
+ * unjoinable. Rarer trigger, same unrepairable-drift outcome the `+1` counter was rejected
+ * for. If that becomes a real case, carry the listing id in `details` as well.
  *
  * 🔴 WHAT THIS DOES **NOT** COVER, stated here because the gap is invisible from the
  * store card: OFF-SITE listings. Their CTA is a plain `target="_blank"` anchor to a third

--- a/src/server/services/blocks/app-listing-open.service.ts
+++ b/src/server/services/blocks/app-listing-open.service.ts
@@ -1,0 +1,71 @@
+import type { GetServerSidePropsContext } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { Tracker } from '~/server/clickhouse/client';
+import type { Session } from '~/types/session';
+
+/**
+ * App store PLAY recording — one `App_Open` row per on-site app launch.
+ *
+ * 🔴 WHY THIS IS A SERVER-SIDE EMIT AND NOT A BEACON, WHICH IS THE WHOLE POINT OF THE
+ * NUMBER. The count it feeds is printed on a PUBLIC store card next to the review count,
+ * so it has to be one a script cannot manufacture. `App_Open` is therefore deliberately
+ * absent from `trackActionSchema` — the schema `/api/track/batch` accepts from a browser —
+ * following `BuzzLimit_Set` and the announcement mute pair. The only writer is this
+ * function, called from the `/apps/run/<slug>` SSR resolver, i.e. from a request the
+ * server itself served after the flag gate and the approved-app resolution both passed.
+ *
+ * 🔴 WHAT THIS DOES **NOT** COVER, stated here because the gap is invisible from the
+ * store card: OFF-SITE listings. Their CTA is a plain `target="_blank"` anchor to a third
+ * party, so no on-platform request follows the click and there is nothing trustworthy to
+ * record. An off-site listing's play count is therefore structurally 0, not "0 so far" —
+ * do not read the two as the same number, and do not "fix" it with a client beacon, which
+ * would put a spoofable count beside a trusted one under one label.
+ *
+ * 🔴 FIRE-AND-FORGET, AND IT MUST STAY THAT WAY. This sits on the app-LAUNCH critical
+ * path, which the run route's own resolver comment already protects (its two listing
+ * reads run concurrently rather than serially for exactly this reason). Awaiting a
+ * ClickHouse insert here would put the tracker's latency — and its failures — in front of
+ * every app launch. So: never awaited by the caller, and every error is swallowed.
+ */
+
+/** The subset of the SSR context this needs. Narrow on purpose — it is called from one place. */
+export type AppOpenRequestContext = Pick<GetServerSidePropsContext, 'req' | 'res'>;
+
+/**
+ * Record one play of an on-site app.
+ *
+ * `appBlockId` rather than the listing id: the run route already has it in scope, so this
+ * adds NO query to the launch path, and `AppListing.appBlockId` is `@unique` so the rollup
+ * can join it back to exactly one listing. It is also a pure id — `details` never carries
+ * author-supplied text.
+ *
+ * Returns a promise so tests can await it; production callers must not.
+ */
+export async function recordAppListingOpen({
+  appBlockId,
+  session,
+  ctx,
+}: {
+  appBlockId: string;
+  session: Session | null;
+  ctx: AppOpenRequestContext;
+}): Promise<void> {
+  try {
+    // Passing the already-resolved session skips the Tracker's own
+    // `getServerAuthSession` round trip — the resolver has it in hand, and an ANONYMOUS
+    // launch would otherwise re-run a full JWE decrypt (see the Tracker constructor note).
+    const tracker = new Tracker(
+      ctx.req as unknown as NextApiRequest,
+      ctx.res as unknown as NextApiResponse,
+      session
+    );
+    // Actor metadata is KEPT (no `skipActorMeta`): a launch is an interaction, not a
+    // private judgement, and `userId`/`ip` are what let the rollup collapse a refresh loop
+    // into one play at read time instead of trusting the raw row count.
+    await tracker.action({ type: 'App_Open', details: { appBlockId } });
+  } catch {
+    // Swallowed deliberately — see the fire-and-forget note above. A play that goes
+    // unrecorded is a slightly low number; a throw here is a failed app launch.
+  }
+}

--- a/src/tests/pages/apps/run/run-page-play-count.test.ts
+++ b/src/tests/pages/apps/run/run-page-play-count.test.ts
@@ -17,7 +17,10 @@ import '~/pages/apps/run/[slug]/[[...path]]';
  * The other property here is that the recording is NOT AWAITED. It is asserted
  * behaviourally rather than by reading the source for a `void`: the recorder is made to
  * return a promise that never settles, and the resolver is required to produce its props
- * anyway. An `await` added in front of the call hangs that test instead of passing it.
+ * anyway. An `await` added in front of the call reds that one test — by ASSERTION at the
+ * 2 s sentinel, not by hanging the suite; the guard is bounded on purpose. (This sentence
+ * previously claimed a hang. It was corrected in the test body and NOT here, which is how a
+ * retraction ends up half-applied — see that test for the measured failure text.)
  */
 
 const { capturedResolver } = vi.hoisted(() => ({

--- a/src/tests/pages/apps/run/run-page-play-count.test.ts
+++ b/src/tests/pages/apps/run/run-page-play-count.test.ts
@@ -167,11 +167,22 @@ describe('run-page SSR — play recording', () => {
   });
 
   it('does not wait for the recording — a hung tracker still serves the app', async () => {
-    // 🔴 THE FIRE-AND-FORGET GUARD, asserted behaviourally. `await`ing the call would make
-    // this resolver never settle, so this test fails by TIMEOUT rather than by assertion —
-    // which is the honest failure for the defect it describes (a ClickHouse stall becoming
-    // an app-launch stall).
+    // 🔴 THE FIRE-AND-FORGET GUARD, asserted behaviourally: the recorder is made to return a
+    // promise that never settles, and the resolver must produce its props anyway. An `await`
+    // in front of the call reds this test and nothing else — measured.
+    //
+    // ⚠️ It fails by ASSERTION, not by timeout. An earlier draft of this comment (and the
+    // PR body) claimed "by TIMEOUT, the honest failure for that defect"; the `Promise.race`
+    // below resolves to the sentinel at 2 s and the expectation rejects it, so the observed
+    // failure is `expected 'TIMED_OUT' not to be 'TIMED_OUT'` in ~2005 ms. That is the
+    // better behaviour — a bounded, named failure rather than a suite-wide hang — but the
+    // description was wrong, so it is corrected rather than made true.
     mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    // A promise that never settles IS the fixture; an empty executor is the only way to
+    // express it. (The disable must sit on the line DIRECTLY above the code — a two-line
+    // comment puts the second line in that slot and the rule fires anyway, which is how
+    // this shipped red the first time.)
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     mockRecordOpen.mockReturnValue(new Promise<void>(() => {}));
 
     const resolver = await loadResolver();

--- a/src/tests/pages/apps/run/run-page-play-count.test.ts
+++ b/src/tests/pages/apps/run/run-page-play-count.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Module scope, not a test body: from a body this transform is charged to one test's 60s
+// budget. See vitest.config.mts (and the sibling run-page-maturity test, which this
+// harness is cloned from).
+import '~/pages/apps/run/[slug]/[[...path]]';
+
+/**
+ * App store PLAY COUNT — the recording seam on the run-page SSR resolver.
+ *
+ * 🔴 WHAT THIS FILE EXISTS TO PIN IS AN ORDERING, NOT A CALL. That
+ * `recordAppListingOpen` is invoked somewhere in the resolver is worth almost nothing on
+ * its own — a call placed at the TOP of the resolver would satisfy it and would count
+ * every 404 as a play, inflating a public number with requests that never rendered an app.
+ * So every fail-closed exit is asserted to record NOTHING, and only the successful launch
+ * is asserted to record exactly one.
+ *
+ * The other property here is that the recording is NOT AWAITED. It is asserted
+ * behaviourally rather than by reading the source for a `void`: the recorder is made to
+ * return a promise that never settles, and the resolver is required to produce its props
+ * anyway. An `await` added in front of the call hangs that test instead of passing it.
+ */
+
+const { capturedResolver } = vi.hoisted(() => ({
+  capturedResolver: { fn: null as null | ((c: any) => Promise<any>) },
+}));
+
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: (opts: { resolver: (c: any) => Promise<any> }) => {
+    capturedResolver.fn = opts.resolver;
+    return async () => ({ props: {} });
+  },
+}));
+
+const { mockResolvePageBlockBySlug, mockRecordOpen } = vi.hoisted(() => ({
+  mockResolvePageBlockBySlug: vi.fn<(...a: any[]) => Promise<any>>(),
+  mockRecordOpen: vi.fn<(...a: any[]) => Promise<void>>(),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: { resolvePageBlockBySlug: mockResolvePageBlockBySlug },
+}));
+vi.mock('~/server/services/blocks/app-listing-open.service', () => ({
+  recordAppListingOpen: mockRecordOpen,
+}));
+
+// Real-ish host gate: mature (r/x) requires civitai.red. Same stub as the maturity test,
+// because the maturity 404 is one of the exits this file asserts records nothing.
+vi.mock('~/server/utils/server-domain', () => ({
+  ratingAllowedOnHost: (rating: unknown, host: string) => {
+    const mature = typeof rating === 'string' && ['r', 'x'].includes(rating.toLowerCase());
+    if (!mature) return true;
+    return host === 'civitai.red' || host === 'www.civitai.red';
+  },
+}));
+
+vi.mock('@mantine/core', () => ({ Box: () => null, useComputedColorScheme: () => 'dark' }));
+vi.mock('~/components/AppBlocks/PageBlockHost', () => ({ PageBlockHost: () => null }));
+vi.mock('~/components/AppBlocks/useBlockToken', () => ({ useBlockToken: () => ({}) }));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+const PAGE = {
+  appBlockId: 'ab_1',
+  blockId: 'cool-app',
+  appId: 'app_1',
+  iframeSrc: 'https://cool-app.civit.ai',
+  sandbox: 'allow-scripts',
+  trustTier: 'unverified' as const,
+  name: 'Cool App',
+  pageTitle: 'Cool',
+  scopes: [],
+  contentRating: 'g',
+};
+
+function makeCtx(host: string, opts: { slug?: string; features?: any; session?: any } = {}) {
+  const { slug = 'cool-app', features = { appBlocks: true, appBlocksPages: true } } = opts;
+  // 🔴 `'session' in opts`, NOT a default parameter. A default fires on an explicit
+  // `undefined`, so `{ session: undefined }` would silently get the authed default back —
+  // which is exactly the value the anonymous case exists to rule out, and it made that
+  // test fail against a correct implementation the first time it ran.
+  const session = 'session' in opts ? opts.session : ({ user: { id: 7 } } as any);
+  return {
+    features,
+    session,
+    ctx: { params: { slug }, req: { headers: { host } }, res: {} },
+  };
+}
+
+async function loadResolver() {
+  if (!capturedResolver.fn) throw new Error('resolver not captured');
+  return capturedResolver.fn;
+}
+
+describe('run-page SSR — play recording', () => {
+  beforeEach(() => {
+    // NOT capturedResolver — the page module is imported once (ESM cache), so nulling it
+    // would lose the resolver for every later test. Same note as the maturity test.
+    mockResolvePageBlockBySlug.mockReset();
+    mockRecordOpen.mockReset();
+    mockRecordOpen.mockResolvedValue(undefined);
+  });
+
+  it('records exactly one play for a launch that actually renders', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.com'));
+
+    expect(result).toHaveProperty('props');
+    expect(mockRecordOpen).toHaveBeenCalledTimes(1);
+    // The id is the RESOLVED block's, not the request's slug — the two differ whenever a
+    // slug is re-pointed, and the rollup joins on `app_listings.app_block_id`.
+    expect(mockRecordOpen.mock.calls[0][0]).toMatchObject({ appBlockId: 'ab_1' });
+  });
+
+  it('passes the resolved session through, so an authed play is attributable', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    const resolver = await loadResolver();
+    await resolver(makeCtx('civitai.com'));
+
+    expect(mockRecordOpen.mock.calls[0][0].session).toEqual({ user: { id: 7 } });
+  });
+
+  it('records an ANONYMOUS play as an explicit null session, never undefined', async () => {
+    // The Tracker distinguishes the two: `undefined` means "resolve it yourself" (a second
+    // JWE decrypt on the launch path), `null` means "known anonymous". This route has
+    // already resolved the session, so it must assert the latter.
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    const resolver = await loadResolver();
+    await resolver(makeCtx('civitai.com', { session: undefined }));
+
+    expect(mockRecordOpen).toHaveBeenCalledTimes(1);
+    const arg = mockRecordOpen.mock.calls[0][0];
+    expect(arg.session).toBeNull();
+    expect('session' in arg).toBe(true);
+  });
+
+  // ── The three fail-closed exits. Each one is a 404 that must NOT be a play. ──────────
+
+  it('records NOTHING when the feature gate 404s the launch', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(
+      makeCtx('civitai.com', { features: { appBlocks: false, appBlocksPages: true } })
+    );
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockRecordOpen).not.toHaveBeenCalled();
+  });
+
+  it('records NOTHING when there is no such approved page app', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue(null);
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.com'));
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockRecordOpen).not.toHaveBeenCalled();
+  });
+
+  it('records NOTHING when the maturity gate 404s a mature app off .red', async () => {
+    // 🔴 THE ORDERING ASSERTION. This exit is the LAST one in the resolver, so it is the
+    // one a "record it at the top" mistake would sail past while every other test here
+    // still passed.
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'x' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.com'));
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockRecordOpen).not.toHaveBeenCalled();
+  });
+
+  it('does not wait for the recording — a hung tracker still serves the app', async () => {
+    // 🔴 THE FIRE-AND-FORGET GUARD, asserted behaviourally. `await`ing the call would make
+    // this resolver never settle, so this test fails by TIMEOUT rather than by assertion —
+    // which is the honest failure for the defect it describes (a ClickHouse stall becoming
+    // an app-launch stall).
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    mockRecordOpen.mockReturnValue(new Promise<void>(() => {}));
+
+    const resolver = await loadResolver();
+    const result = await Promise.race([
+      resolver(makeCtx('civitai.com')),
+      new Promise((resolve) => setTimeout(() => resolve('TIMED_OUT'), 2000)),
+    ]);
+
+    expect(result).not.toBe('TIMED_OUT');
+    expect(result).toHaveProperty('props');
+  });
+});


### PR DESCRIPTION
Stage 1 of 4 toward showing a **play count** on the app store card. This ships the event only — **nothing reads it yet and no user-visible surface changes.**

## 🔴 Before this deploys

Apply `src/server/clickhouse/migrations/2026-09-05-app-open-action.sql` manually first.

`actions.type` is an `Enum16`. A value the column does not carry is rejected at the tracker service, so the app logs nothing and the row simply never exists — the eventual count would read a permanent zero that is indistinguishable from *"nobody opened it"*. The migration appends at the first unused index (26), restates 1–25 unchanged (a `MODIFY COLUMN` **replaces** the definition, so a name left out is dropped from a live column), and carries its own verification + positive-control queries.

## Why an event rather than a counter

`app_listing_metrics.open_count` already exists and has never been written, so the obvious move is a `+1` on launch. The metrics job's own ownership contract argues against it:

> *"'No recompute' is a TWO-SIDED contract… A third writer is only safe if it brings a full recompute with it."*

A `+1` counter for plays would have **no source rows at all**, so any drift would be unrepairable forever. Recording to the `actions` stream instead makes `open_count` recomputable by construction — the same way `article`, `model3d` and `model` metrics already derive their counters from ClickHouse.

## Why it is *trusted*

`App_Open` is **deliberately absent from `trackActionSchema`** — the schema `/api/track/batch` accepts from a browser — following `BuzzLimit_Set` and the announcement mute pair. The only writer is the `/apps/run/<slug>` SSR resolver, i.e. a request the server actually served, after the flag gate, the approved-app resolution and the host rating check have all passed. A number printed on a public store card next to the review count has to be one a script cannot manufacture.

## What this deliberately does *not* cover

**Off-site listings.** Their CTA is a plain `target="_blank"` anchor to a third party, so no on-platform request follows the click and there is nothing trustworthy to record. An off-site play count is therefore structurally **0, not "0 so far"**.

Resolving that is a product decision — count on-site only, or route off-site visits through a counting endpoint — and is **not taken in this PR**. Please don't "fix" it with a client beacon: that would put a spoofable count beside a trusted one under one label.

## Placement and cost

The call sits after **every** fail-closed exit, so a 404 is never a play. It is emitted **un-awaited** and swallows its own errors — this is the app-launch critical path that the resolver's existing `Promise.all` exists to keep short, so a ClickHouse stall must never become an app-launch stall. It adds **no query**: `appBlockId` is already in scope, and `AppListing.appBlockId` is `@unique`, so the rollup can join it back to exactly one listing.

## Verification

Every guard was watched fail for its **own** reason rather than assumed:

| mutation | result |
|---|---|
| hoist the call above the maturity gate | only the maturity **ordering** test reds |
| `await` the call | only the fire-and-forget test reds — **by assertion at a 2 s sentinel** (~2005 ms), not by hanging the suite. ⚠️ This row said "by timeout" until round 2; the guard is bounded on purpose, and the original wording invited a maintainer to "fix the hang" by removing the very `Promise.race` that bounds it |
| remove the `try/catch` | both resolve-guards red — async rejection **and** sync throw, so a catch around only the `await` is not enough |
| delete the ClickHouse migration | the pre-existing enum-drift guard reds naming `App_Open` specifically |

- `vitest --project unit` over `app-listing-open.service.test.ts` + `src/tests/pages/apps/run/` + `action-type-enum-drift.test.ts`: **51 passed** at `2e4431e2b3`.
  ⚠️ This line said **52** until round 3, which was true only of the first commit. Round 1 folded four values into `PRE_EXISTING`, deleting four `it.each` cases (−4) while adding guards, and round 2 added one test (+1). Re-measured rather than adjusted on paper. The suite set is now named by path, because "every affected suite" is not a command anyone can re-run.
- `pnpm typecheck`: clean.
- `prettier --check` over the changed files: clean (it flagged one file first — that was the positive control that it was checking them).

**Not verified live.** The event has not been observed landing in ClickHouse, because that needs the migration applied and a real launch. The first post-deploy check is the positive-control query in the migration file.

## What comes next

2. `open_count` into the metrics rollup (derived from these rows)
3. `openCount` onto the store card DTO
4. the card change this arc is for — drop the author chip, move reviews + plays below the CTA


